### PR TITLE
Remove "Help" link from personal sidebar

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -421,7 +421,9 @@ class OC_App {
 
 		$settings = array();
 		// by default, settings only contain the help menu
-		if (OC_Util::getEditionString() === '' &&
+		/*
+		 * FIXME: Add help sidebar back once documentation is properly branded.
+		 if (OC_Util::getEditionString() === '' &&
 			\OC::$server->getSystemConfig()->getValue('knowledgebaseenabled', true) == true
 		) {
 			$settings = array(
@@ -433,7 +435,7 @@ class OC_App {
 					"icon" => $urlGenerator->imagePath("settings", "help.svg")
 				)
 			);
-		}
+		}*/
 
 		// if the user is logged-in
 		if (OC_User::isLoggedIn()) {


### PR DESCRIPTION
At the moment we want to hide the help link from the personal sidebar as it contains the original ownCloud documentation.

Once we have our own documentation with our proper branding and so on we can reenable this.

@jospoortvliet @karlitschek @jancborchardt @MorrisJobke As discussed 🚀 
