### PR TITLE
[stable9] Remove "Help" link from personal sidebar

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -381,7 +381,9 @@ class OC_App {
 
 		$settings = array();
 		// by default, settings only contain the help menu
-		if (OC_Util::getEditionString() === '' &&
+		/*
+		 * FIXME: Add help sidebar back once documentation is properly branded.
+		 * if (OC_Util::getEditionString() === '' &&
 			\OC::$server->getSystemConfig()->getValue('knowledgebaseenabled', true) == true
 		) {
 			$settings = array(
@@ -393,7 +395,7 @@ class OC_App {
 					"icon" => $urlGenerator->imagePath("settings", "help.svg")
 				)
 			);
-		}
+		}*/
 
 		// if the user is logged-in
 		if (OC_User::isLoggedIn()) {


### PR DESCRIPTION
Backport of https://github.com/nextcloud/server/pull/9
