### PR TITLE
Replace ownCloud with Nextcloud in the issue template / Fixes #12

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -1,9 +1,9 @@
 <!--
-Thanks for reporting issues back to ownCloud! This is the issue tracker of ownCloud, if you have any support question please check out https://owncloud.org/support
+Thanks for reporting issues back to Nextcloud! This is the issue tracker of Nextcloud, if you have any support question please check out https://nextcloud.com/support
 
-This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/CONTRIBUTING.md#guidelines
+This is the bug tracker for the Server component. Find other components at https://github.com/nextcloud/
 
-For reporting potential security issues please see https://owncloud.org/security/
+For reporting potential security issues please see https://nextcloud.com/security/
 
 To make it possible for us to help you please fill out below information carefully.
 --> 
@@ -27,16 +27,16 @@ Tell us what happens instead
 
 **PHP version:**
 
-**ownCloud version:** (see ownCloud admin page)
+**Nextcloud version:** (see Nextcloud admin page)
 
-**Updated from an older ownCloud or fresh install:**
+**Updated from an older Nextcloud/ownCloud or fresh install:**
 
-**Where did you install ownCloud from:**
+**Where did you install Nextcloud from:**
 
-**Signing status (ownCloud 9.0 and above):**
+**Signing status (Nextcloud 9.0 and above):**
 
 ```
-Login as admin user into your ownCloud and access 
+Login as admin user into your Nextcloud and access 
 http://example.com/index.php/settings/integrity/failed 
 paste the results here.
 ```
@@ -46,7 +46,7 @@ paste the results here.
 ```
 If you have access to your command line run e.g.:
 sudo -u www-data php occ app:list
-from within your ownCloud installation folder
+from within your Nextcloud installation folder
 ```
 
 **The content of config/config.php:**
@@ -54,7 +54,7 @@ from within your ownCloud installation folder
 ```
 If you have access to your command line run e.g.:
 sudo -u www-data php occ config:list system
-from within your ownCloud installation folder
+from within your Nextcloud installation folder
 
 or 
 
@@ -73,7 +73,7 @@ Insert your config.php content here
 ```
 With access to your command line run e.g.:
 sudo -u www-data php occ ldap:show-config
-from within your ownCloud installation folder
+from within your Nextcloud installation folder
 
 Without access to your command line download the data/owncloud.db to your local
 computer or access your SQL server remotely and run the select query:
@@ -94,9 +94,9 @@ Eventually replace sensitive data as the name/IP-address of your LDAP server or 
 Insert your webserver log here
 ```
 
-#### ownCloud log (data/owncloud.log)
+#### Nextcloud log (data/owncloud.log)
 ```
-Insert your ownCloud log here
+Insert your Nextcloud log here
 ```
 
 #### Browser log


### PR DESCRIPTION
- ownCloud ▶️ Nextcloud (fixes #12)
- Replaced "other components" link with a link to the GitHub Organization (line 4)

ToDo:
- [ ] https://nextcloud.com/security should be up after merging this 😁 @jospoortvliet 
