### PR TITLE
add "hide file list" option

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -67,7 +67,12 @@ $server = $serverFactory->createServer($baseuri, $requestUri, $authBackend, func
 	$share = $authBackend->getShare();
 	$owner = $share->getShareOwner();
 	$isWritable = $share->getPermissions() & (\OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE);
+	$isReadable = $share->getPermissions() & \OCP\Constants::PERMISSION_READ;
 	$fileId = $share->getNodeId();
+
+	if (!$isReadable) {
+		return false;
+	}
 
 	if (!$isWritable) {
 		\OC\Files\Filesystem::addStorageWrapper('readonly', function ($mountPoint, $storage) {

--- a/apps/files/ajax/upload.php
+++ b/apps/files/ajax/upload.php
@@ -161,6 +161,15 @@ if (\OC\Files\Filesystem::isValidPath($dir) === true) {
 			$resolution = null;
 		}
 
+		if(isset($_POST['dirToken'])) {
+			// If it is a read only share the resolution will always be autorename
+			$shareManager = \OC::$server->getShareManager();
+			$share = $shareManager->getShareByToken((string)$_POST['dirToken']);
+			if (!($share->getPermissions() & \OCP\Constants::PERMISSION_READ)) {
+				$resolution = 'autorename';
+			}
+		}
+
 		// target directory for when uploading folders
 		$relativePath = '';
 		if(!empty($_POST['file_directory'])) {
@@ -247,6 +256,20 @@ if (\OC\Files\Filesystem::isValidPath($dir) === true) {
 }
 
 if ($error === false) {
+	// Do not leak file information if it is a read-only share
+	if(isset($_POST['dirToken'])) {
+		$shareManager = \OC::$server->getShareManager();
+		$share = $shareManager->getShareByToken((string)$_POST['dirToken']);
+		if (!($share->getPermissions() & \OCP\Constants::PERMISSION_READ)) {
+			$newResults = [];
+			foreach($result as $singleResult) {
+				$fileName = $singleResult['originalname'];
+				$newResults['filename'] = $fileName;
+				$newResults['mimetype'] = \OC::$server->getMimeTypeDetector()->detectPath($fileName);
+			}
+			$result = $newResults;
+		}
+	}
 	OCP\JSON::encodedPrint($result);
 } else {
 	OCP\JSON::error(array(array('data' => array_merge(array('message' => $error, 'code' => $errorCode), $storageStats))));

--- a/apps/files_sharing/ajax/publicpreview.php
+++ b/apps/files_sharing/ajax/publicpreview.php
@@ -42,6 +42,13 @@ if($token === ''){
 }
 
 $linkedItem = \OCP\Share::getShareByToken($token);
+$shareManager = \OC::$server->getShareManager();
+$share = $shareManager->getShareByToken($token);
+if(!($share->getPermissions() & \OCP\Constants::PERMISSION_READ)) {
+	OCP\JSON::error(array('data' => 'Share is not readable.'));
+	exit();
+}
+
 if($linkedItem === false || ($linkedItem['item_type'] !== 'file' && $linkedItem['item_type'] !== 'folder')) {
 	\OC_Response::setStatus(\OC_Response::STATUS_NOT_FOUND);
 	\OCP\Util::writeLog('core-preview', 'Passed token parameter is not valid', \OCP\Util::DEBUG);

--- a/apps/files_sharing/ajax/shareinfo.php
+++ b/apps/files_sharing/ajax/shareinfo.php
@@ -71,6 +71,11 @@ $shareManager = \OC::$server->getShareManager();
 $share = $shareManager->getShareByToken($token);
 $sharePermissions= (int)$share->getPermissions();
 
+if(!($share->getPermissions() & \OCP\Constants::PERMISSION_READ)) {
+	OCP\JSON::error(array('data' => 'Share is not readable.'));
+	exit();
+}
+
 /**
  * @param \OCP\Files\FileInfo $dir
  * @param \OC\Files\View $view

--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -159,36 +159,63 @@ thead {
 	cursor: pointer;
 }
 
-#body-public #emptycontent h2 {
+
+
+#public-upload .avatardiv {
+	margin: 0 auto;
+}
+
+#public-upload #emptycontent h2 {
 	margin: 10px 0 5px 0;
 }
 
-#body-public #emptycontent h2+p {
+#public-upload #emptycontent h2+p {
 	margin-bottom: 30px;
 }
 
-#body-public #emptycontent .icon-folder {
+#public-upload #emptycontent .icon-folder {
 	height: 16px;
 	width: 16px;
 	background-size: 16px;
 	display: inline-block;
 	vertical-align: text-top;
 	margin-bottom: 0;
+	margin-right: 5px;
 	opacity: 1;
 }
 
-#body-public #emptycontent .button {
-	background-size: 32px;
-	height: 32px;
-	width: 32px;
-	background-position: 16px; 
+#public-upload #emptycontent .button {
+	background-size: 16px;
+	height: 16px;
+	width: 16px;
+	background-position: 16px;
 	opacity: .7;
 	font-size: 20px;
 	margin: 20px;
 	padding: 10px 20px;
-	padding-left: 64px;
+	padding-left: 42px;
+	font-weight: normal;
 }
 
-#body-public .avatardiv {
-	margin: 0 auto;
+#public-upload #emptycontent ul {
+	width: 160px;
+	margin: 25px auto;
+	text-align: left;
+}
+
+#public-upload #emptycontent li {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	padding: 7px 0;
+}
+
+#public-upload #emptycontent li img {
+	vertical-align: text-bottom;
+	margin-right: 5px;
+}
+
+#public-upload li span.icon-loading-small {
+	padding-left: 18px;
+	margin-right: 7px;
 }

--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -158,3 +158,37 @@ thead {
 	opacity: 1;
 	cursor: pointer;
 }
+
+#body-public #emptycontent h2 {
+	margin: 10px 0 5px 0;
+}
+
+#body-public #emptycontent h2+p {
+	margin-bottom: 30px;
+}
+
+#body-public #emptycontent .icon-folder {
+	height: 16px;
+	width: 16px;
+	background-size: 16px;
+	display: inline-block;
+	vertical-align: text-top;
+	margin-bottom: 0;
+	opacity: 1;
+}
+
+#body-public #emptycontent .button {
+	background-size: 32px;
+	height: 32px;
+	width: 32px;
+	background-position: 16px; 
+	opacity: .7;
+	font-size: 20px;
+	margin: 20px;
+	padding: 10px 20px;
+	padding-left: 64px;
+}
+
+#body-public .avatardiv {
+	margin: 0 auto;
+}

--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -159,8 +159,6 @@ thead {
 	cursor: pointer;
 }
 
-
-
 #public-upload .avatardiv {
 	margin: 0 auto;
 }

--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -197,7 +197,7 @@ thead {
 
 #public-upload #emptycontent ul {
 	width: 160px;
-	margin: 25px auto;
+	margin: 5px auto;
 	text-align: left;
 }
 

--- a/apps/files_sharing/js/files_drop.js
+++ b/apps/files_sharing/js/files_drop.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016 Lukas Reschke <lukas@statuscode.ch>
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+(function ($) {
+	var Drop = {
+		initialize: function () {
+			$(document).bind('drop dragover', function (e) {
+				// Prevent the default browser drop action:
+				e.preventDefault();
+			});
+			$('#publicUploadDiv').fileupload({
+				url: OC.linkTo('files', 'ajax/upload.php'),
+				dataType: 'json',
+				//maxFileSize: fileUploadContainer.data('maxupload'),
+				messages: {
+					maxFileSize: t('files_sharing', 'File is bigger than allowed.')
+				},
+				dropZone: $('#publicUploadDiv'),
+				formData: {
+					dirToken: $('#sharingToken').val()
+				}
+			});
+
+		}
+	};
+
+	$(document).ready(function() {
+		if($('#uploadOnlyInterface').val() === "1") {
+			$('.avatardiv').avatar($('#sharingUserId').val(), 128, true);
+		}
+
+		OCA.Files_Sharing_Drop = Drop;
+		OCA.Files_Sharing_Drop.initialize();
+	});
+
+
+})(jQuery);
+

--- a/apps/files_sharing/js/files_drop.js
+++ b/apps/files_sharing/js/files_drop.js
@@ -15,24 +15,33 @@
 				// Prevent the default browser drop action:
 				e.preventDefault();
 			});
-			$('#publicUploadDiv').fileupload({
+			$('#public-upload').fileupload({
 				url: OC.linkTo('files', 'ajax/upload.php'),
 				dataType: 'json',
-				//maxFileSize: fileUploadContainer.data('maxupload'),
-				messages: {
-					maxFileSize: t('files_sharing', 'File is bigger than allowed.')
-				},
-				dropZone: $('#publicUploadDiv'),
+				dropZone: $('#public-upload'),
 				formData: {
 					dirToken: $('#sharingToken').val()
+				},
+				add: function(e, data) {
+					_.each(data['files'], function(file) {
+						$('#public-upload ul').append('<li data-name="'+escapeHTML(file.name)+'"><span class="icon-loading-small"></span> '+escapeHTML(file.name)+'</li>');
+					});
+					data.submit();
+				},
+				success: function (response) {
+					var mimeTypeUrl = OC.MimeType.getIconUrl(response['mimetype']);
+					$('#public-upload ul li[data-name="'+escapeHTML(response['filename'])+'"]').html('<img src="'+escapeHTML(mimeTypeUrl)+'"/> '+escapeHTML(response['filename']));
 				}
 			});
-
+			$('#public-upload .button.icon-upload').click(function(e) {
+				e.preventDefault();
+				$('#public-upload #emptycontent input').focus().trigger('click');
+			});
 		}
 	};
 
 	$(document).ready(function() {
-		if($('#uploadOnlyInterface').val() === "1") {
+		if($('#upload-only-interface').val() === "1") {
 			$('.avatardiv').avatar($('#sharingUserId').val(), 128, true);
 		}
 

--- a/apps/files_sharing/js/files_drop.js
+++ b/apps/files_sharing/js/files_drop.js
@@ -23,14 +23,30 @@
 					dirToken: $('#sharingToken').val()
 				},
 				add: function(e, data) {
+					var errors = [];
+					if(data.files[0]['size'] && data.files[0]['size'] > $('#maxFilesizeUpload').val()) {
+						errors.push('File is too big');
+					}
+
 					_.each(data['files'], function(file) {
-						$('#public-upload ul').append('<li data-name="'+escapeHTML(file.name)+'"><span class="icon-loading-small"></span> '+escapeHTML(file.name)+'</li>');
+						if(errors.length === 0) {
+							$('#public-upload ul').append('<li data-toggle="tooltip" title="'+escapeHTML(file.name)+'" data-name="'+escapeHTML(file.name)+'"><span class="icon-loading-small"></span> '+escapeHTML(file.name)+'</li>');
+							$('[data-toggle="tooltip"]').tooltip();
+							data.submit();
+						} else {
+							OC.Notification.showTemporary(OC.L10N.translate('files_sharing', 'Could not upload "{filename}"', {filename: file.name}));
+							$('#public-upload ul').append('<li data-toggle="tooltip" title="'+escapeHTML(file.name)+'" data-name="'+escapeHTML(file.name)+'"><img src="'+OC.imagePath('core', 'actions/error.svg')+'"/> '+escapeHTML(file.name)+'</li>');
+							$('[data-toggle="tooltip"]').tooltip();
+
+						}
 					});
-					data.submit();
 				},
 				success: function (response) {
-					var mimeTypeUrl = OC.MimeType.getIconUrl(response['mimetype']);
-					$('#public-upload ul li[data-name="'+escapeHTML(response['filename'])+'"]').html('<img src="'+escapeHTML(mimeTypeUrl)+'"/> '+escapeHTML(response['filename']));
+					if(response.status !== 'error') {
+						var mimeTypeUrl = OC.MimeType.getIconUrl(response['mimetype']);
+						$('#public-upload ul li[data-name="' + escapeHTML(response['filename']) + '"]').html('<img src="' + escapeHTML(mimeTypeUrl) + '"/> ' + escapeHTML(response['filename']));
+						$('[data-toggle="tooltip"]').tooltip();
+					}
 				}
 			});
 			$('#public-upload .button.icon-upload').click(function(e) {

--- a/apps/files_sharing/js/files_drop.js
+++ b/apps/files_sharing/js/files_drop.js
@@ -28,6 +28,8 @@
 						errors.push('File is too big');
 					}
 
+					$('#drop-upload-done-indicator').addClass('hidden');
+					$('#drop-upload-progress-indicator').removeClass('hidden');
 					_.each(data['files'], function(file) {
 						if(errors.length === 0) {
 							$('#public-upload ul').append('<li data-toggle="tooltip" title="'+escapeHTML(file.name)+'" data-name="'+escapeHTML(file.name)+'"><span class="icon-loading-small"></span> '+escapeHTML(file.name)+'</li>');
@@ -37,7 +39,6 @@
 							OC.Notification.showTemporary(OC.L10N.translate('files_sharing', 'Could not upload "{filename}"', {filename: file.name}));
 							$('#public-upload ul').append('<li data-toggle="tooltip" title="'+escapeHTML(file.name)+'" data-name="'+escapeHTML(file.name)+'"><img src="'+OC.imagePath('core', 'actions/error.svg')+'"/> '+escapeHTML(file.name)+'</li>');
 							$('[data-toggle="tooltip"]').tooltip();
-
 						}
 					});
 				},
@@ -46,6 +47,16 @@
 						var mimeTypeUrl = OC.MimeType.getIconUrl(response['mimetype']);
 						$('#public-upload ul li[data-name="' + escapeHTML(response['filename']) + '"]').html('<img src="' + escapeHTML(mimeTypeUrl) + '"/> ' + escapeHTML(response['filename']));
 						$('[data-toggle="tooltip"]').tooltip();
+					}
+				},
+				progressall: function (e, data) {
+					var progress = parseInt(data.loaded / data.total * 100, 10);
+					if(progress === 100) {
+						$('#drop-upload-done-indicator').removeClass('hidden');
+						$('#drop-upload-progress-indicator').addClass('hidden');
+					} else {
+						$('#drop-upload-done-indicator').addClass('hidden');
+						$('#drop-upload-progress-indicator').removeClass('hidden');
 					}
 				}
 			});

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -238,6 +238,11 @@ OCA.Sharing.PublicApp = {
 			$(this).select();
 		});
 
+		$(document).on('click', '.content-wrapper-upload', function (e) {
+			//e.preventDefault();
+			$('#file_upload_start').focus().trigger('click');
+		});
+
 		$('.save-form').submit(function (event) {
 			event.preventDefault();
 
@@ -302,7 +307,7 @@ OCA.Sharing.PublicApp = {
 				$('#save-button-confirm')
 				.removeClass("icon-loading-small")
 				.addClass("icon-confirm");
-				
+
 			}
 			else {
 				$('#save-button-confirm')
@@ -314,7 +319,7 @@ OCA.Sharing.PublicApp = {
 
 		toggleLoading();
 		var location = window.location.protocol + '//' + window.location.host + OC.webroot;
-		
+
 		if(remote.substr(-1) !== '/') {
 			remote += '/'
 		};

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -302,7 +302,9 @@ OCA.Sharing.PublicApp = {
 				$('#save-button-confirm')
 				.removeClass("icon-loading-small")
 				.addClass("icon-confirm");
-			} else {
+
+			}
+			else {
 				$('#save-button-confirm')
 				.removeClass("icon-confirm")
 				.addClass("icon-loading-small");
@@ -312,6 +314,7 @@ OCA.Sharing.PublicApp = {
 
 		toggleLoading();
 		var location = window.location.protocol + '//' + window.location.host + OC.webroot;
+
 		if(remote.substr(-1) !== '/') {
 			remote += '/'
 		};

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -238,11 +238,6 @@ OCA.Sharing.PublicApp = {
 			$(this).select();
 		});
 
-		$(document).on('click', '.content-wrapper-upload', function (e) {
-			//e.preventDefault();
-			$('#file_upload_start').focus().trigger('click');
-		});
-
 		$('.save-form').submit(function (event) {
 			event.preventDefault();
 
@@ -307,9 +302,7 @@ OCA.Sharing.PublicApp = {
 				$('#save-button-confirm')
 				.removeClass("icon-loading-small")
 				.addClass("icon-confirm");
-
-			}
-			else {
+			} else {
 				$('#save-button-confirm')
 				.removeClass("icon-confirm")
 				.addClass("icon-loading-small");
@@ -319,7 +312,6 @@ OCA.Sharing.PublicApp = {
 
 		toggleLoading();
 		var location = window.location.protocol + '//' + window.location.host + OC.webroot;
-
 		if(remote.substr(-1) !== '/') {
 			remote += '/'
 		};

--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -602,6 +602,7 @@ class Share20OCS {
 
 			if ($newPermissions !== null &&
 				$newPermissions !== \OCP\Constants::PERMISSION_READ &&
+				$newPermissions !== (\OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE) &&
 				$newPermissions !== (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE)) {
 				$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
 				return new \OC_OCS_Result(null, 400, $this->l->t('Can\'t change permissions for public share links'));

--- a/apps/files_sharing/lib/Controllers/ShareController.php
+++ b/apps/files_sharing/lib/Controllers/ShareController.php
@@ -252,6 +252,7 @@ class ShareController extends Controller {
 	 * @param string $path
 	 * @return TemplateResponse|RedirectResponse
 	 * @throws NotFoundException
+	 * @throws \Exception
 	 */
 	public function showShare($token, $path = '') {
 		\OC_User::setIncognitoMode(true);
@@ -373,12 +374,17 @@ class ShareController extends Controller {
 	 * @param string $files
 	 * @param string $path
 	 * @param string $downloadStartSecret
-	 * @return void|RedirectResponse
+	 * @return void|OCP\AppFramework\Http\Response
+	 * @throws NotFoundException
 	 */
 	public function downloadShare($token, $files = null, $path = '', $downloadStartSecret = '') {
 		\OC_User::setIncognitoMode(true);
 
 		$share = $this->shareManager->getShareByToken($token);
+
+		if(!($share->getPermissions() & \OCP\Constants::PERMISSION_READ)) {
+			return new OCP\AppFramework\Http\DataResponse('Share is read-only');
+		}
 
 		// Share is password protected - check whether the user is permitted to access the share
 		if ($share->getPassword() !== null && !$this->linkShareAuth($share)) {

--- a/apps/files_sharing/lib/Controllers/ShareController.php
+++ b/apps/files_sharing/lib/Controllers/ShareController.php
@@ -49,7 +49,6 @@ use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\ISession;
 use OCP\IPreview;
-use OCA\Files_Sharing\Helper;
 use OCP\Util;
 use OCA\Files_Sharing\Activity;
 use \OCP\Files\NotFoundException;
@@ -314,6 +313,7 @@ class ShareController extends Controller {
 		$shareTmpl['fileSize'] = \OCP\Util::humanFileSize($share->getNode()->getSize());
 
 		// Show file list
+		$hideFileList = false;
 		if ($share->getNode() instanceof \OCP\Files\Folder) {
 			$shareTmpl['dir'] = $rootFolder->getRelativePath($path->getPath());
 
@@ -329,12 +329,14 @@ class ShareController extends Controller {
 
 			$uploadLimit = Util::uploadLimit();
 			$maxUploadFilesize = min($freeSpace, $uploadLimit);
+			$hideFileList = $share->getPermissions() & \OCP\Constants::PERMISSION_READ ? false : true;
 
 			$folder = new Template('files', 'list', '');
 			$folder->assign('dir', $rootFolder->getRelativePath($path->getPath()));
 			$folder->assign('dirToken', $token);
 			$folder->assign('permissions', \OCP\Constants::PERMISSION_READ);
 			$folder->assign('isPublic', true);
+			$folder->assign('hideFileList', $hideFileList);
 			$folder->assign('publicUploadEnabled', 'no');
 			$folder->assign('uploadMaxFilesize', $maxUploadFilesize);
 			$folder->assign('uploadMaxHumanFilesize', OCP\Util::humanFileSize($maxUploadFilesize));
@@ -345,6 +347,8 @@ class ShareController extends Controller {
 			$shareTmpl['folder'] = $folder->fetchPage();
 		}
 
+		$shareTmpl['hideFileList'] = $hideFileList;
+		$shareTmpl['shareOwner'] = $this->userManager->get($share->getShareOwner())->getDisplayName();
 		$shareTmpl['downloadURL'] = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.downloadShare', array('token' => $token));
 		$shareTmpl['maxSizeAnimateGif'] = $this->config->getSystemValue('max_filesize_animated_gifs_public_sharing', 10);
 		$shareTmpl['previewEnabled'] = $this->config->getSystemValue('enable_previews', true);

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -66,26 +66,28 @@ OCP\Util::addscript('files', 'keyboardshortcuts');
 		<div class="header-right">
 			<span id="details">
 				<?php
-				if ($_['server2serversharing']) {
-					?>
-					<span id="save" data-protected="<?php p($_['protected']) ?>"
-						  data-owner-display-name="<?php p($_['displayName']) ?>" data-owner="<?php p($_['owner']) ?>" data-name="<?php p($_['filename']) ?>">
-					<button id="save-button"><?php p($l->t('Add to your ownCloud')) ?></button>
-					<form class="save-form hidden" action="#">
-						<input type="text" id="remote_address" placeholder="example.com/owncloud"/>
-						<button id="save-button-confirm" class="icon-confirm svg" disabled></button>
-					</form>
-				</span>
+				if (!isset($_['hideFileList']) || (isset($_['hideFileList']) && $_['hideFileList'] === false)) {
+					if ($_['server2serversharing']) {
+						?>
+						<span id="save" data-protected="<?php p($_['protected']) ?>"
+							  data-owner-display-name="<?php p($_['displayName']) ?>" data-owner="<?php p($_['owner']) ?>" data-name="<?php p($_['filename']) ?>">
+						<button id="save-button"><?php p($l->t('Add to your ownCloud')) ?></button>
+						<form class="save-form hidden" action="#">
+							<input type="text" id="remote_address" placeholder="example.com/owncloud"/>
+							<button id="save-button-confirm" class="icon-confirm svg" disabled></button>
+						</form>
+					</span>
+					<?php } ?>
+					<a href="<?php p($_['downloadURL']); ?>" id="download" class="button">
+						<img class="svg" alt="" src="<?php print_unescaped(image_path("core", "actions/download.svg")); ?>"/>
+						<span id="download-text"><?php p($l->t('Download'))?></span>
+					</a>
 				<?php } ?>
-				<a href="<?php p($_['downloadURL']); ?>" id="download" class="button">
-					<img class="svg" alt="" src="<?php print_unescaped(image_path("core", "actions/download.svg")); ?>"/>
-					<span id="download-text"><?php p($l->t('Download'))?></span>
-				</a>
 			</span>
 		</div>
-</div></header>
-<div id="content-wrapper">
-	<div id="content">
+	</div></header>
+<div id="content-wrapper" <?php if(isset($_['hideFileList']) && $_['hideFileList'] === true){ print_unescaped(" class=\"content-wrapper-upload\"");} ?>>
+		<?php if (!isset($_['hideFileList']) || (isset($_['hideFileList']) && $_['hideFileList'] === false)) { ?>
 		<div id="preview">
 			<?php if (isset($_['folder'])): ?>
 				<?php print_unescaped($_['folder']); ?>
@@ -112,7 +114,21 @@ OCP\Util::addscript('files', 'keyboardshortcuts');
 				</div>
 			<?php endif; ?>
 		</div>
+		<?php } else { ?>
+			<div id="emptycontent" class="">
+			<div class="icon-upload"></div>
+			<h2>Upload files to <?php print_unescaped($_['shareOwner']); ?></h2>
+			<a href="#" class="inlineblock button">Select</a>
+			</div>
+		<?php } ?>
+</div>
+<?php if (!isset($_['hideFileList']) || (isset($_['hideFileList']) && $_['hideFileList'] === true)): ?>
+	<input type="hidden" name="dir" id="dir" value="" />
+	<div class="hiddenuploadfield">
+	<input type="file" id="file_upload_start" class="hiddenuploadfield" name="files[]"
+		data-url="<?php print_unescaped(OCP\Util::linkTo('files', 'ajax/upload.php')); ?>" />
 	</div>
+	<?php endif; ?>
 	<footer>
 		<p class="info">
 			<?php print_unescaped($theme->getLongFooter()); ?>

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -117,7 +117,7 @@ OCP\Util::addscript('files', 'keyboardshortcuts');
 		<?php } else { ?>
 			<div id="emptycontent" class="">
 			<div class="icon-upload"></div>
-			<h2>Upload files to <?php print_unescaped($_['shareOwner']); ?></h2>
+			<h2><?php p($l->t('Upload files to %s', [$_['shareOwner']])) ?></h2>
 			<a href="#" class="inlineblock button">Select</a>
 			</div>
 		<?php } ?>

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -41,7 +41,9 @@ OCP\Util::addscript('files', 'keyboardshortcuts');
 <input type="hidden" name="mimetype" value="<?php p($_['mimetype']) ?>" id="mimetype">
 <input type="hidden" name="previewSupported" value="<?php p($_['previewSupported'] ? 'true' : 'false'); ?>" id="previewSupported">
 <input type="hidden" name="mimetypeIcon" value="<?php p(\OC::$server->getMimeTypeDetector()->mimeTypeIcon($_['mimetype'])); ?>" id="mimetypeIcon">
-<input type="hidden" name="filesize" value="<?php p($_['nonHumanFileSize']); ?>" id="filesize">
+<?php if (!isset($_['hideFileList']) || (isset($_['hideFileList']) && $_['hideFileList'] === false)): ?>
+	<input type="hidden" name="filesize" value="<?php p($_['nonHumanFileSize']); ?>" id="filesize">
+<?php endif; ?>
 <input type="hidden" name="maxSizeAnimateGif" value="<?php p($_['maxSizeAnimateGif']); ?>" id="maxSizeAnimateGif">
 
 
@@ -89,7 +91,7 @@ OCP\Util::addscript('files', 'keyboardshortcuts');
 		</div>
 	</div></header>
 <div id="content-wrapper" <?php if(isset($_['hideFileList']) && $_['hideFileList'] === true){ print_unescaped(" class=\"content-wrapper-upload\"");} ?>>
-		<?php if (!isset($_['hideFileList']) || (isset($_['hideFileList']) && $_['hideFileList'] === false)) { ?>
+	<?php if (!isset($_['hideFileList']) || (isset($_['hideFileList']) && $_['hideFileList'] === false)) { ?>
 		<div id="preview">
 			<?php if (isset($_['folder'])): ?>
 				<?php print_unescaped($_['folder']); ?>
@@ -117,13 +119,17 @@ OCP\Util::addscript('files', 'keyboardshortcuts');
 			<?php endif; ?>
 		</div>
 		<?php } else { ?>
-		<input type="hidden" id="uploadOnlyInterface" value="1"/>
-			<div id="publicUploadDiv">
+		<input type="hidden" id="upload-only-interface" value="1"/>
+			<div id="public-upload">
 				<div id="emptycontent" class="">
 					<div id="displayavatar"><div class="avatardiv"></div></div>
 					<h2><?php p($l->t('Upload files to %s', [$_['shareOwner']])) ?></h2>
 					<p><span class="icon-folder"></span> <?php p($_['filename']) ?></p>
+					<input type="file" name="files[]" class="hidden" multiple>
+
 					<a href="#" class="button icon-upload"><?php p($l->t('Select')) ?></a>
+					<ul>
+					</ul>
 				</div>
 			</div>
 		<?php } ?>

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -41,6 +41,13 @@ OCP\Util::addscript('files', 'keyboardshortcuts');
 <input type="hidden" name="mimetype" value="<?php p($_['mimetype']) ?>" id="mimetype">
 <input type="hidden" name="previewSupported" value="<?php p($_['previewSupported'] ? 'true' : 'false'); ?>" id="previewSupported">
 <input type="hidden" name="mimetypeIcon" value="<?php p(\OC::$server->getMimeTypeDetector()->mimeTypeIcon($_['mimetype'])); ?>" id="mimetypeIcon">
+<?php
+$upload_max_filesize = OC::$server->getIniWrapper()->getBytes('upload_max_filesize');
+$post_max_size = OC::$server->getIniWrapper()->getBytes('post_max_size');
+$maxUploadFilesize = min($upload_max_filesize, $post_max_size);
+?>
+<input type="hidden" name="maxFilesizeUpload" value="<?php p($maxUploadFilesize); ?>" id="maxFilesizeUpload">
+
 <?php if (!isset($_['hideFileList']) || (isset($_['hideFileList']) && $_['hideFileList'] === false)): ?>
 	<input type="hidden" name="filesize" value="<?php p($_['nonHumanFileSize']); ?>" id="filesize">
 <?php endif; ?>

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -135,7 +135,9 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 					<p><span class="icon-folder"></span> <?php p($_['filename']) ?></p>
 					<input type="file" name="files[]" class="hidden" multiple>
 
-					<a href="#" class="button icon-upload"><?php p($l->t('Select')) ?></a>
+					<a href="#" class="button icon-upload"><?php p($l->t('Select or drop files')) ?></a>
+					<div id="drop-upload-progress-indicator" style="padding-top: 25px;" class="hidden"><?php p($l->t('Uploading files…')) ?></div>
+					<div id="drop-upload-done-indicator" style="padding-top: 25px;" class="hidden"><?php p($l->t('Uploaded files:')) ?></div>
 					<ul>
 					</ul>
 				</div>

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -90,9 +90,10 @@ OCP\Util::addscript('files', 'keyboardshortcuts');
 			</span>
 		</div>
 	</div></header>
-<div id="content-wrapper" <?php if(isset($_['hideFileList']) && $_['hideFileList'] === true){ print_unescaped(" class=\"content-wrapper-upload\"");} ?>>
+<div id="content-wrapper">
 	<?php if (!isset($_['hideFileList']) || (isset($_['hideFileList']) && $_['hideFileList'] === false)) { ?>
-		<div id="preview">
+	<div id="content">
+	<div id="preview">
 			<?php if (isset($_['folder'])): ?>
 				<?php print_unescaped($_['folder']); ?>
 			<?php else: ?>

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -9,6 +9,7 @@ OCP\Util::addScript('files_sharing', 'public');
 OCP\Util::addScript('files', 'fileactions');
 OCP\Util::addScript('files', 'fileactionsmenu');
 OCP\Util::addScript('files', 'jquery.fileupload');
+OCP\Util::addScript('files_sharing', 'files_drop');
 
 // JS required for folders
 OCP\Util::addStyle('files', 'files');
@@ -30,6 +31,7 @@ OCP\Util::addscript('files', 'keyboardshortcuts');
 	<div id="notification" style="display: none;"></div>
 </div>
 
+<input type="hidden" id="sharingUserId" value="<?php p($_['owner']) ?>">
 <input type="hidden" id="filesApp" name="filesApp" value="1">
 <input type="hidden" id="isPublic" name="isPublic" value="1">
 <input type="hidden" name="dir" value="<?php p($_['dir']) ?>" id="dir">
@@ -115,14 +117,18 @@ OCP\Util::addscript('files', 'keyboardshortcuts');
 			<?php endif; ?>
 		</div>
 		<?php } else { ?>
-			<div id="emptycontent" class="">
-			<div class="icon-upload"></div>
-			<h2><?php p($l->t('Upload files to %s', [$_['shareOwner']])) ?></h2>
-			<a href="#" class="inlineblock button">Select</a>
+		<input type="hidden" id="uploadOnlyInterface" value="1"/>
+			<div id="publicUploadDiv">
+				<div id="emptycontent" class="">
+					<div id="displayavatar"><div class="avatardiv"></div></div>
+					<h2><?php p($l->t('Upload files to %s', [$_['shareOwner']])) ?></h2>
+					<p><span class="icon-folder"></span> <?php p($_['filename']) ?></p>
+					<a href="#" class="button icon-upload"><?php p($l->t('Select')) ?></a>
+				</div>
 			</div>
 		<?php } ?>
 </div>
-<?php if (!isset($_['hideFileList']) || (isset($_['hideFileList']) && $_['hideFileList'] === true)): ?>
+<?php if (!isset($_['hideFileList']) || (isset($_['hideFileList']) && $_['hideFileList'] !== true)): ?>
 	<input type="hidden" name="dir" id="dir" value="" />
 	<div class="hiddenuploadfield">
 	<input type="file" id="file_upload_start" class="hiddenuploadfield" name="files[]"

--- a/apps/files_sharing/tests/Controllers/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controllers/ShareControllerTest.php
@@ -372,6 +372,8 @@ class ShareControllerTest extends \Test\TestCase {
 			'previewEnabled' => true,
 			'previewMaxX' => 1024,
 			'previewMaxY' => 1024,
+			'hideFileList' => false,
+			'shareOwner' => 'ownerDisplay'
 		);
 
 		$csp = new \OCP\AppFramework\Http\ContentSecurityPolicy();

--- a/apps/files_sharing/tests/Controllers/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controllers/ShareControllerTest.php
@@ -32,6 +32,7 @@ namespace OCA\Files_Sharing\Tests\Controllers;
 use OC\Files\Filesystem;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\Files_Sharing\Controllers\ShareController;
+use OCP\AppFramework\Http\DataResponse;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\AppFramework\Http\NotFoundResponse;
 use OCP\AppFramework\Http\RedirectResponse;
@@ -432,10 +433,13 @@ class ShareControllerTest extends \Test\TestCase {
 		$this->shareController->showShare('token');
 	}
 
-
 	public function testDownloadShare() {
 		$share = $this->getMock('\OCP\Share\IShare');
 		$share->method('getPassword')->willReturn('password');
+		$share
+			->expects($this->once())
+			->method('getPermissions')
+			->willReturn(\OCP\Constants::PERMISSION_READ);
 
 		$this->shareManager
 			->expects($this->once())
@@ -451,6 +455,26 @@ class ShareControllerTest extends \Test\TestCase {
 		// Test with a password protected share and no authentication
 		$response = $this->shareController->downloadShare('validtoken');
 		$expectedResponse = new RedirectResponse('redirect');
+		$this->assertEquals($expectedResponse, $response);
+	}
+
+	public function testDownloadShareWithCreateOnlyShare() {
+		$share = $this->getMock('\OCP\Share\IShare');
+		$share->method('getPassword')->willReturn('password');
+		$share
+			->expects($this->once())
+			->method('getPermissions')
+			->willReturn(\OCP\Constants::PERMISSION_CREATE);
+
+		$this->shareManager
+			->expects($this->once())
+			->method('getShareByToken')
+			->with('validtoken')
+			->willReturn($share);
+
+		// Test with a password protected share and no authentication
+		$response = $this->shareController->downloadShare('validtoken');
+		$expectedResponse = new DataResponse('Share is read-only');
 		$this->assertEquals($expectedResponse, $response);
 	}
 

--- a/core/Controller/AvatarController.php
+++ b/core/Controller/AvatarController.php
@@ -85,7 +85,7 @@ class AvatarController extends Controller {
 								IL10N $l10n,
 								IUserManager $userManager,
 								IUserSession $userSession,
-								Folder $userFolder,
+								Folder $userFolder = null,
 								ILogger $logger) {
 		parent::__construct($appName, $request);
 
@@ -101,6 +101,7 @@ class AvatarController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @PublicPage
 	 *
 	 * @param string $userId
 	 * @param int $size

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -442,7 +442,6 @@ OC.Share = _.extend(OC.Share || {}, {
 });
 
 $(document).ready(function() {
-
 	if(typeof monthNames != 'undefined'){
 		// min date should always be the next day
 		var minDate = new Date();

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -30,7 +30,14 @@
 			'    <input type="checkbox" value="1" name="allowPublicUpload" id="sharingDialogAllowPublicUpload-{{cid}}" class="checkbox publicUploadCheckbox" {{{publicUploadChecked}}} />' +
 			'<label for="sharingDialogAllowPublicUpload-{{cid}}">{{publicUploadLabel}}</label>' +
 			'</div>' +
-			'    {{/if}}' +			
+			'{{#if hideFileList}}' +
+			'<div id="hideFileListWrapper">' +
+			'    <span class="icon-loading-small hidden"></span>' +
+			'    <input type="checkbox" value="1" name="hideFileList" id="sharingDialogHideFileList-{{cid}}" class="checkbox hideFileListCheckbox" {{{hideFileListChecked}}} />' +
+			'<label for="sharingDialogHideFileList-{{cid}}">{{hideFileListLabel}}</label>' +
+			'</div>' +
+			'{{/if}}' +
+			'    {{/if}}' +
 			'    {{#if showPasswordCheckBox}}' +
 			'<input type="checkbox" name="showPassword" id="showPassword-{{cid}}" class="checkbox showPasswordCheckbox" {{#if isPasswordSet}}checked="checked"{{/if}} value="1" />' +
 			'<label for="showPassword-{{cid}}">{{enablePasswordLabel}}</label>' +
@@ -74,7 +81,8 @@
 			'keyup input.linkPassText': 'onPasswordKeyUp',
 			'click .linkCheckbox': 'onLinkCheckBoxChange',
 			'click .linkText': 'onLinkTextClick',
-			'change .publicUploadCheckbox': 'onAllowPublicUploadChange',
+            'change .publicUploadCheckbox': 'onAllowPublicUploadChange',
+            'change .hideFileListCheckbox': 'onHideFileListChange',
 			'click .showPasswordCheckbox': 'onShowPasswordClick'
 		},
 
@@ -90,6 +98,10 @@
 			});
 
 			this.model.on('change:allowPublicUploadStatus', function() {
+				view.render();
+			});
+
+			this.model.on('change:hideFileListStatus', function() {
 				view.render();
 			});
 
@@ -110,6 +122,7 @@
 				'onPasswordKeyUp',
 				'onLinkTextClick',
 				'onShowPasswordClick',
+				'onHideFileListChange',
 				'onAllowPublicUploadChange'
 			);
 		},
@@ -208,7 +221,21 @@
 			this.model.saveLinkShare({
 				permissions: permissions
 			});
-		},
+        },
+
+        onHideFileListChange: function () {
+            var $checkbox = this.$('.hideFileListCheckbox');
+            $checkbox.siblings('.icon-loading-small').removeClass('hidden').addClass('inlineblock');
+
+            var permissions = OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_READ;
+            if ($checkbox.is(':checked')) {
+                permissions = OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE;
+            }
+
+            this.model.saveLinkShare({
+                permissions: permissions
+            });
+        },
 
 		render: function() {
 			var linkShareTemplate = this.template();
@@ -237,6 +264,13 @@
 				publicUploadChecked = 'checked="checked"';
 			}
 
+			var hideFileList = publicUploadChecked;
+
+			var hideFileListChecked = '';
+			if(this.model.isHideFileListSet()) {
+				hideFileListChecked = 'checked="checked"';
+			}
+
 			var isLinkShare = this.model.get('linkShare').isLinkShare;
 			var isPasswordSet = !!this.model.get('linkShare').password;
 			var showPasswordCheckBox = isLinkShare
@@ -246,6 +280,7 @@
 			this.$el.html(linkShareTemplate({
 				cid: this.cid,
 				shareAllowed: true,
+				hideFileList: hideFileList,
 				isLinkShare: isLinkShare,
 				shareLinkURL: this.model.get('linkShare').link,
 				linkShareLabel: t('core', 'Share link'),
@@ -257,7 +292,9 @@
 				showPasswordCheckBox: showPasswordCheckBox,
 				publicUpload: publicUpload && isLinkShare,
 				publicUploadChecked: publicUploadChecked,
-				publicUploadLabel: t('core', 'Allow editing'),
+				hideFileListChecked: hideFileListChecked,
+                publicUploadLabel: t('core', 'Allow editing'),
+                hideFileListLabel: t('core', 'Hide file listing'),
 				mailPublicNotificationEnabled: isLinkShare && this.configModel.isMailPublicNotificationEnabled(),
 				mailPrivatePlaceholder: t('core', 'Email link to person'),
 				mailButtonText: t('core', 'Send')

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -81,8 +81,8 @@
 			'keyup input.linkPassText': 'onPasswordKeyUp',
 			'click .linkCheckbox': 'onLinkCheckBoxChange',
 			'click .linkText': 'onLinkTextClick',
-            'change .publicUploadCheckbox': 'onAllowPublicUploadChange',
-            'change .hideFileListCheckbox': 'onHideFileListChange',
+			'change .publicUploadCheckbox': 'onAllowPublicUploadChange',
+			'change .hideFileListCheckbox': 'onHideFileListChange',
 			'click .showPasswordCheckbox': 'onShowPasswordClick'
 		},
 
@@ -221,21 +221,21 @@
 			this.model.saveLinkShare({
 				permissions: permissions
 			});
-        },
+		},
 
-        onHideFileListChange: function () {
-            var $checkbox = this.$('.hideFileListCheckbox');
-            $checkbox.siblings('.icon-loading-small').removeClass('hidden').addClass('inlineblock');
+		onHideFileListChange: function () {
+			var $checkbox = this.$('.hideFileListCheckbox');
+			$checkbox.siblings('.icon-loading-small').removeClass('hidden').addClass('inlineblock');
 
-            var permissions = OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_READ;
-            if ($checkbox.is(':checked')) {
-                permissions = OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE;
-            }
+			var permissions = OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_READ;
+			if ($checkbox.is(':checked')) {
+				permissions = OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE;
+			}
 
-            this.model.saveLinkShare({
-                permissions: permissions
-            });
-        },
+			this.model.saveLinkShare({
+				permissions: permissions
+			});
+		},
 
 		render: function() {
 			var linkShareTemplate = this.template();
@@ -293,8 +293,8 @@
 				publicUpload: publicUpload && isLinkShare,
 				publicUploadChecked: publicUploadChecked,
 				hideFileListChecked: hideFileListChecked,
-                publicUploadLabel: t('core', 'Allow editing'),
-                hideFileListLabel: t('core', 'Hide file listing'),
+				publicUploadLabel: t('core', 'Allow editing'),
+				hideFileListLabel: t('core', 'Hide file listing'),
 				mailPublicNotificationEnabled: isLinkShare && this.configModel.isMailPublicNotificationEnabled(),
 				mailPrivatePlaceholder: t('core', 'Email link to person'),
 				mailButtonText: t('core', 'Send')

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -275,6 +275,13 @@
 		/**
 		 * @returns {boolean}
 		 */
+		isHideFileListSet: function() {
+			return this.get('hideFileListStatus');
+		},
+
+		/**
+		 * @returns {boolean}
+		 */
 		isFolder: function() {
 			return this.get('itemType') === 'folder';
 		},
@@ -685,6 +692,16 @@
 				});
 			}
 
+			var hideFileListStatus = false;
+			if(!_.isUndefined(data.shares)) {
+				$.each(data.shares, function (key, value) {
+					if (value.share_type === OC.Share.SHARE_TYPE_LINK) {
+						hideFileListStatus = (value.permissions & OC.PERMISSION_READ) ? false : true;
+						return true;
+					}
+				});
+			}
+
 			/** @type {OC.Share.Types.ShareInfo[]} **/
 			var shares = _.map(data.shares, function(share) {
 				// properly parse some values because sometimes the server
@@ -757,7 +774,8 @@
 				shares: shares,
 				linkShare: linkShare,
 				permissions: permissions,
-				allowPublicUploadStatus: allowPublicUploadStatus
+				allowPublicUploadStatus: allowPublicUploadStatus,
+				hideFileListStatus: hideFileListStatus
 			};
 		},
 

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -239,8 +239,11 @@ class Manager implements IManager {
 			throw new GenericShareException($message_t, $message_t, 404);
 		}
 
+
 		// Check that read permissions are always set
-		if (($share->getPermissions() & \OCP\Constants::PERMISSION_READ) === 0) {
+		// Link shares are allowed to have no read permissions to allow upload to hidden folders
+		if ($share->getShareType() !== \OCP\Share::SHARE_TYPE_LINK &&
+			($share->getPermissions() & \OCP\Constants::PERMISSION_READ) === 0) {
 			throw new \InvalidArgumentException('Shares need at least read permissions');
 		}
 

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -670,7 +670,6 @@ class ManagerTest extends \Test\TestCase {
 
 		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_USER,  $allPermssions, $user2, $user0, $user0, 30, null, null), 'Shares need at least read permissions', true];
 		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $allPermssions, $group0, $user0, $user0, 2, null, null), 'Shares need at least read permissions', true];
-		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK,  $allPermssions, null, $user0, $user0, 16, null, null), 'Shares need at least read permissions', true];
 
 		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_USER,  $allPermssions, $user2, $user0, $user0, 31, null, null), null, false];
 		$data[] = [$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $allPermssions, $group0, $user0, $user0, 3, null, null), null, false];


### PR DESCRIPTION
Add a option for public link shares to hide the file list if "can edit" is enabled. This allows to distribute public links to allow people to upload some files without seeing the content of the folder.

fix https://github.com/nextcloud/server/issues/4
