### PR TITLE
smaller files drop fixes

### DIFF
--- a/apps/files/ajax/upload.php
+++ b/apps/files/ajax/upload.php
@@ -43,6 +43,7 @@ OCP\JSON::setContentTypeHeader('text/plain');
 // If no token is sent along, rely on login only
 
 $errorCode = null;
+$errorFileName = null;
 
 $l = \OC::$server->getL10N('files');
 if (empty($_POST['dirToken'])) {
@@ -225,6 +226,7 @@ if (\OC\Files\Filesystem::isValidPath($dir) === true) {
 
 				} else {
 					$error = $l->t('Upload failed. Could not find uploaded file');
+					$errorFileName = $files['name'][$i];
 				}
 			} catch(Exception $ex) {
 				$error = $ex->getMessage();
@@ -272,5 +274,9 @@ if ($error === false) {
 	}
 	OCP\JSON::encodedPrint($result);
 } else {
-	OCP\JSON::error(array(array('data' => array_merge(array('message' => $error, 'code' => $errorCode), $storageStats))));
+	OCP\JSON::error(array(array('data' => array_merge(array(
+		'message' => $error,
+		'code' => $errorCode,
+		'filename' => $errorFileName
+	), $storageStats))));
 }

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -30,13 +30,13 @@
 			'    <input type="checkbox" value="1" name="allowPublicUpload" id="sharingDialogAllowPublicUpload-{{cid}}" class="checkbox publicUploadCheckbox" {{{publicUploadChecked}}} />' +
 			'<label for="sharingDialogAllowPublicUpload-{{cid}}">{{publicUploadLabel}}</label>' +
 			'</div>' +
-			'{{#if hideFileList}}' +
+			'        {{#if hideFileList}}' +
 			'<div id="hideFileListWrapper">' +
 			'    <span class="icon-loading-small hidden"></span>' +
 			'    <input type="checkbox" value="1" name="hideFileList" id="sharingDialogHideFileList-{{cid}}" class="checkbox hideFileListCheckbox" {{{hideFileListChecked}}} />' +
 			'<label for="sharingDialogHideFileList-{{cid}}">{{hideFileListLabel}}</label>' +
 			'</div>' +
-			'{{/if}}' +
+			'        {{/if}}' +
 			'    {{/if}}' +
 			'    {{#if showPasswordCheckBox}}' +
 			'<input type="checkbox" name="showPassword" id="showPassword-{{cid}}" class="checkbox showPasswordCheckbox" {{#if isPasswordSet}}checked="checked"{{/if}} value="1" />' +


### PR DESCRIPTION
- fix infinite spinner on blacklisted files
- move HTML to template
- indentation

Fixes a minor GUI bug, where blacklisted files (e.g. .htaccess) where attempted to upload. Instead of showing an error, the spinner next to the file name would run infinitely.

@LukasReschke @schiessle @oparoz  @MorrisJobke 
