### PR TITLE
[stable9] Show spinner for files_drop again

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -216,4 +216,5 @@ thead {
 #public-upload li span.icon-loading-small {
 	padding-left: 18px;
 	margin-right: 7px;
+	background-size: 16px;
 }


### PR DESCRIPTION
Somehow the spinner wasn't there anymore after some changes. This makes it appear again.

@jancborchardt @blizzz Mind reviewing? THX a lot.
