### PR TITLE
File drop highlight

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -77,6 +77,10 @@
 	background-color: rgb(179, 230, 255);
 }
 
+.dropping-to-dir .thumbnail {
+	background-image: url(/nextcloud/core/img/filetypes/folder-drag-accept.svg)!important;
+}
+
 /* icons for sidebar */
 .nav-icon-files {
 	background-image: url('../img/folder.svg');

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -68,7 +68,13 @@
 }
 
 .app-files #app-content {
+	transition: background-color 0.3s ease;
 	overflow-x: hidden;
+}
+
+.file-drag, .file-drag #filestable tbody tr, .file-drag #filestable tbody tr:hover {
+	transition: background-color 0.3s ease;
+	background-color: rgb(179, 230, 255);
 }
 
 /* icons for sidebar */
@@ -113,6 +119,7 @@
 }
 
 #filestable tbody tr {
+	transition: background-color 0.3s ease;
 	background-color: #fff;
 	height: 40px;
 }
@@ -125,6 +132,7 @@
 #filestable tbody tr.selected,
 #filestable tbody tr.searchresult,
 table tr.mouseOver td {
+	transition: background-color 0.3s ease;
 	background-color: #f8f8f8;
 }
 tbody a { color:#000; }

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -77,6 +77,14 @@
 	background-color: rgb(179, 230, 255);
 }
 
+.app-files #app-content.dir-drop, .file-drag #filestable tbody tr{
+	background-color: rgba(0, 0, 0, 0);
+}
+
+.app-files #app-content.dir-drop #filestable tbody tr.dropping-to-dir{
+	background-color: rgb(179, 230, 255);
+}
+
 .dropping-to-dir .thumbnail {
 	background-image: url(/nextcloud/core/img/filetypes/folder-drag-accept.svg)!important;
 }

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -85,10 +85,6 @@
 	background-color: rgb(179, 230, 255)!important;
 }
 
-.dropping-to-dir .thumbnail {
-	background-image: url(/nextcloud/core/img/filetypes/folder-drag-accept.svg)!important;
-}
-
 /* icons for sidebar */
 .nav-icon-files {
 	background-image: url('../img/folder.svg');

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -73,16 +73,16 @@
 }
 
 .file-drag, .file-drag #filestable tbody tr, .file-drag #filestable tbody tr:hover {
-	transition: background-color 0.3s ease;
-	background-color: rgb(179, 230, 255);
+	transition: background-color 0.3s ease!important;
+	background-color: rgb(179, 230, 255)!important;
 }
 
-.app-files #app-content.dir-drop, .file-drag #filestable tbody tr{
-	background-color: rgba(0, 0, 0, 0);
+.app-files #app-content.dir-drop, .file-drag #filestable tbody tr, .file-drag #filestable tbody tr:hover{
+	background-color: rgba(0, 0, 0, 0)!important;
 }
 
 .app-files #app-content.dir-drop #filestable tbody tr.dropping-to-dir{
-	background-color: rgb(179, 230, 255);
+	background-color: rgb(179, 230, 255)!important;
 }
 
 .dropping-to-dir .thumbnail {

--- a/apps/files/css/mobile.css
+++ b/apps/files/css/mobile.css
@@ -1,5 +1,9 @@
 @media only screen and (max-width: 768px) {
 
+.app-files #app-content.dir-drop{
+	background-color: rgba(255, 255, 255, 1)!important;
+}
+
 /* don’t require a minimum width for files table */
 #body-user #filestable {
 	min-width: initial !important;

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -494,7 +494,7 @@ OC.Upload = {
 				 * @param {object} e
 				 * @param {object} data
 				 */
-				done:function(e, data) {
+				done: function(e, data) {
 					OC.Upload.log('done', e, data);
 					// handle different responses (json or body from iframe for ie)
 					var response;
@@ -667,7 +667,12 @@ OC.Upload = {
 						OC.Upload._hideProgressBar();
 					}
 				});
-
+				fileupload.on('fileuploaddragover', function(){
+					$('#app-content').addClass('file-drag');
+				});
+				fileupload.on('fileuploaddragleave fileuploaddrop', function (){
+					$('#app-content').removeClass('file-drag');
+				});
 			} else {
 				// for all browsers that don't support the progress bar
 				// IE 8 & 9

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -674,15 +674,18 @@ OC.Upload = {
 
 					if(!filerow.hasClass('dropping-to-dir')){
 						$('.dropping-to-dir').removeClass('dropping-to-dir');
+						$('.dir-drop').removeClass('dir-drop');
 					}
 
 					if(filerow.attr('data-type') === 'dir'){
+						$('#app-content').addClass('dir-drop');
 						filerow.addClass('dropping-to-dir');
 					}
 				});
 				fileupload.on('fileuploaddragleave fileuploaddrop', function (e, data){
 					$('#app-content').removeClass('file-drag');
 					$('.dropping-to-dir').removeClass('dropping-to-dir');
+					$('.dir-drop').removeClass('dir-drop');
 				});
 			} else {
 				// for all browsers that don't support the progress bar

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -273,7 +273,7 @@ OC.Upload = {
 		var self = this;
 		if ( $('#file_upload_start').exists() ) {
 			var file_upload_param = {
-				dropZone: $('#content'), // restrict dropZone to content div
+				dropZone: $('#app-content'), // restrict dropZone to app-content div
 				pasteZone: null, 
 				autoUpload: false,
 				sequentialUploads: true,

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -667,7 +667,7 @@ OC.Upload = {
 						OC.Upload._hideProgressBar();
 					}
 				});
-				fileupload.on('fileuploaddragover', function(e, data){
+				fileupload.on('fileuploaddragover', function(e){
 					$('#app-content').addClass('file-drag');
 
 					var filerow = $(e.delegatedEvent.target).closest('tr');
@@ -675,17 +675,20 @@ OC.Upload = {
 					if(!filerow.hasClass('dropping-to-dir')){
 						$('.dropping-to-dir').removeClass('dropping-to-dir');
 						$('.dir-drop').removeClass('dir-drop');
+						$('.icon-filetype-folder-drag-accept').removeClass('icon-filetype-folder-drag-accept');
 					}
 
 					if(filerow.attr('data-type') === 'dir'){
 						$('#app-content').addClass('dir-drop');
 						filerow.addClass('dropping-to-dir');
+						filerow.find('.thumbnail').addClass('icon-filetype-folder-drag-accept');
 					}
 				});
-				fileupload.on('fileuploaddragleave fileuploaddrop', function (e, data){
+				fileupload.on('fileuploaddragleave fileuploaddrop', function (){
 					$('#app-content').removeClass('file-drag');
 					$('.dropping-to-dir').removeClass('dropping-to-dir');
 					$('.dir-drop').removeClass('dir-drop');
+					$('.icon-filetype-folder-drag-accept').removeClass('icon-filetype-folder-drag-accept');
 				});
 			} else {
 				// for all browsers that don't support the progress bar

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -667,11 +667,22 @@ OC.Upload = {
 						OC.Upload._hideProgressBar();
 					}
 				});
-				fileupload.on('fileuploaddragover', function(){
+				fileupload.on('fileuploaddragover', function(e, data){
 					$('#app-content').addClass('file-drag');
+
+					var filerow = $(e.delegatedEvent.target).closest('tr');
+
+					if(!filerow.hasClass('dropping-to-dir')){
+						$('.dropping-to-dir').removeClass('dropping-to-dir');
+					}
+
+					if(filerow.attr('data-type') === 'dir'){
+						filerow.addClass('dropping-to-dir');
+					}
 				});
-				fileupload.on('fileuploaddragleave fileuploaddrop', function (){
+				fileupload.on('fileuploaddragleave fileuploaddrop', function (e, data){
 					$('#app-content').removeClass('file-drag');
+					$('.dropping-to-dir').removeClass('dropping-to-dir');
 				});
 			} else {
 				// for all browsers that don't support the progress bar

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2514,12 +2514,13 @@
 			var self = this;
 
 			// handle upload events
-			var fileUploadStart = this.$el.find('#file_upload_start');
+			var fileUploadStart = this.$el;
+			var delegatedElement = '#file_upload_start';
 
 			// detect the progress bar resize
 			fileUploadStart.on('resized', this._onResize);
 
-			fileUploadStart.on('fileuploaddrop', function(e, data) {
+			fileUploadStart.on('fileuploaddrop', delegatedElement, function(e, data) {
 				OC.Upload.log('filelist handle fileuploaddrop', e, data);
 
 				if (self.$el.hasClass('hidden')) {
@@ -2527,7 +2528,10 @@
 					return false;
 				}
 
-				var dropTarget = $(e.originalEvent.target);
+				console.log(e);
+				var dropTarget = $(e.delegatedEvent.target);
+				console.log(dropTarget);
+
 				// check if dropped inside this container and not another one
 				if (dropTarget.length
 					&& !self.$el.is(dropTarget) // dropped on list directly

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2528,9 +2528,7 @@
 					return false;
 				}
 
-				console.log(e);
 				var dropTarget = $(e.delegatedEvent.target);
-				console.log(dropTarget);
 
 				// check if dropped inside this container and not another one
 				if (dropTarget.length

--- a/apps/files/js/jquery.fileupload.js
+++ b/apps/files/js/jquery.fileupload.js
@@ -1267,7 +1267,11 @@
                 e.preventDefault();
                 this._getDroppedFiles(dataTransfer).always(function (files) {
                     data.files = files;
-                    if (that._trigger('drop', e, data) !== false) {
+                    if (that._trigger(
+                            'drop',
+                            $.Event('drop', {delegatedEvent: e}),
+                            data
+                        ) !== false) {
                         that._onAdd(e, data);
                     }
                 });

--- a/apps/files/js/jquery.fileupload.js
+++ b/apps/files/js/jquery.fileupload.js
@@ -1267,11 +1267,7 @@
                 e.preventDefault();
                 this._getDroppedFiles(dataTransfer).always(function (files) {
                     data.files = files;
-                    if (that._trigger(
-                            'drop',
-                            $.Event('drop', {delegatedEvent: e}),
-                            data
-                        ) !== false) {
+                    if (that._trigger('drop', e, data) !== false) {
                         that._onAdd(e, data);
                     }
                 });

--- a/core/css/icons.css
+++ b/core/css/icons.css
@@ -353,6 +353,10 @@ img.icon-loading-small-dark, object.icon-loading-small-dark, video.icon-loading-
 	background-image: url('../img/filetypes/folder.svg');
 }
 
+.icon-filetype-folder-drag-accept {
+    background-image: url('../img/filetypes/folder-drag-accept.svg')!important;
+}
+
 .icon-home {
 	background-image: url('../img/places/home.svg');
 }


### PR DESCRIPTION
Hey @nextcloud/designers 

I'm creating this PR to let you know that I'm working on a visual indication for the file-upload by drag&drop and wanted your opinion on the current status. I also updated the File Upload Plugin to 9.12.5 (apps/files/js/jquery.fileupload.js) to support dragleave event.

We have, like many services, the ability to drag and drop a file directly from the filesystem of the OS to the browser to upload it to Nextcloud, though we do not currently intuitively show it in the UI. 

This fixes it.
- [x]  Improve UI further based on feedback
- [x]  Adjust CSS to make it work for all sizes
- [x]  Fix jQuery Plugin to make it uploading directly into a folders work again

![screen recording 2016-06-13 at 11 16 pm](https://cloud.githubusercontent.com/assets/868272/16023425/0f01b8ec-31bd-11e6-812f-443005469f16.gif)
