### PR TITLE
allow to execute multiple tests in a directory at once

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -303,9 +303,18 @@ function execute_tests {
 	else
 		echo "No coverage"
 	fi
-	echo "${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
-	"${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
+
+	if [ -d "$2" ]; then
+	    for f in $(find "$2" -name '*.php'); do
+			echo "${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" / "$f" "$3"
+			"${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$f" "$3"
+			RESULT=$?
+	    done;
+	else
+	    echo "${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
+	    "${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
 		RESULT=$?
+	fi
 
 	if [ "$PRIMARY_STORAGE_CONFIG" == "swift" ] ; then
 		cd ..


### PR DESCRIPTION
Let you execute all tests in a given directory and it subfolders, for example `./autotest.sh sqlite apps/federation/tests` would execute all federation tests
