### PR TITLE
[stable9] Fix data directory warning

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -197,7 +197,7 @@
 			}
 			var afterCall = function(xhr) {
 				var messages = [];
-				if (xhr.status !== 403 && xhr.status !== 307 && xhr.status !== 301 && xhr.responseText !== '') {
+				if (xhr.status !== 403 && xhr.status !== 307 && xhr.status !== 301 && xhr.responseText === 'This is used for testing whether htaccess is properly enabled to disallow access from the outside. This file can be safely removed.') {
 					messages.push({
 						msg: t('core', 'Your data directory and your files are probably accessible from the Internet. The .htaccess file is not working. We strongly suggest that you configure your web server in a way that the data directory is no longer accessible or you move the data directory outside the web server document root.'),
 						type: OC.SetupChecks.MESSAGE_TYPE_ERROR

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -103,7 +103,7 @@ describe('OC.SetupChecks tests', function() {
 		it('should return an error if data directory is not protected', function(done) {
 			var async = OC.SetupChecks.checkDataProtected();
 
-			suite.server.requests[0].respond(200, {'Content-Type': 'text/plain'}, 'file contents');
+			suite.server.requests[0].respond(200, {'Content-Type': 'text/plain'}, 'This is used for testing whether htaccess is properly enabled to disallow access from the outside. This file can be safely removed.');
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([
@@ -114,7 +114,18 @@ describe('OC.SetupChecks tests', function() {
 				done();
 			});
 		});
-		
+
+		it('should return no error if data directory is protected and returns another content', function(done) {
+			var async = OC.SetupChecks.checkDataProtected();
+
+			suite.server.requests[0].respond(200, {'Content-Type': 'text/plain'}, 'Another page');
+
+			async.done(function( data, s, x ){
+				expect(data).toEqual([]);
+				done();
+			});
+		});
+
 		it('should not return an error if data directory is protected', function(done) {
 			var async = OC.SetupChecks.checkDataProtected();
 


### PR DESCRIPTION
Otherwise always the warning is displayed that the data directory is accessible from the internet when URLs without index.php are enabled.

Fixes https://github.com/nextcloud/server/issues/91

cc @blizzz @MorrisJobke 
