### PR TITLE
fix padding of 3-dot button on mobile

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -585,19 +585,19 @@ html.ie8 .column-mtime .selectedActions {
 #fileList a.action.action-menu {
 	padding-top: 17px;
 	padding-bottom: 17px;
-	padding-left:14px;
-	padding-right:0px;
+	padding-left: 14px;
+	padding-right: 14px;
 }
 
 #fileList .filesize {
-	padding-top:0px;
-	padding-bottom:0px;
-	padding-left:60px;
-	padding-right:15px;
+	padding-top: 0;
+	padding-bottom: 0;
+	padding-left: 60px;
+	padding-right: 15px;
 }
 
 #fileList .popovermenu {
-	margin-right: -5px;
+	margin-right: 6px;
 }
 .ie8 #fileList .popovermenu {
 	margin-top: -10px;


### PR DESCRIPTION
Currently the 3-dot menu sticks to the right side of the screen. This wasn’t like that before and isn’t supposed to be like that either:
![capture du 2016-06-15 15-51-03](https://cloud.githubusercontent.com/assets/925062/16082274/1ac2542a-3311-11e6-9b90-b580ee281f34.png)
Fixing, also giving enough tap area (44px) to the button:
![capture du 2016-06-15 15-51-32](https://cloud.githubusercontent.com/assets/925062/16082273/1a9f42aa-3311-11e6-8c93-fef2ebf73692.png)

Please review @nextcloud/designers, the only code change is the padding-right from 0 to 14px.
@ErikPel this was introduced by your commit 50655cbf7f689c2926bbfbd007887ba5cad75c2a, so probably best if you check this out and review :)

This also needs a backport to stable9 cause the original fix was backported there too.
