### PR TITLE
Use blue as approved color in app management

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -327,7 +327,7 @@ span.version {
 	padding-left: 25px;
 }
 .app-level .approved {
-	border-color: #e8c805;
+	border-color: #0082c9;
 }
 .app-level .experimental {
 	background-color: #ce3702;


### PR DESCRIPTION
- only changing the color - based on #53
- @nextcloud/designers @williambargent 

Looks like this:

<img width="384" alt="bildschirmfoto 2016-06-16 um 13 10 46" src="https://cloud.githubusercontent.com/assets/245432/16114857/d7728010-33c3-11e6-9024-5f6d19523c9e.png">
