### PR TITLE
fixes global var and removes unneccesary response

### DIFF
--- a/apps/federation/js/settings-admin.js
+++ b/apps/federation/js/settings-admin.js
@@ -60,11 +60,11 @@ $(document).ready(function () {
 // remove trusted server from list
 	$( "#listOfTrustedServers" ).on('click', 'li > .icon-delete', function() {
 		var $this = $(this).parent();
-		id = $this.attr('id');
+		var id = $this.attr('id');
 		$.ajax({
 			url: OC.generateUrl('/apps/federation/trusted-servers/' + id),
 			type: 'DELETE',
-			success: function(response) {
+			success: function() {
 				$this.remove();
 			}
 		});


### PR DESCRIPTION
Small fix after b8493629aeb1804c70f70eb72ceeac3103e9f307 where id is (accidentally?) set to a global variable. Also removes unnecessary response.

@SergioBertolinSG @MorrisJobke @schiessle 
