### PR TITLE
Drop obsolete tables: gallery_albums and gallery_photos

### DIFF
--- a/lib/private/Repair/DropOldTables.php
+++ b/lib/private/Repair/DropOldTables.php
@@ -100,7 +100,9 @@ class DropOldTables implements IRepairStep {
 			'clndr_share_calendar',
 			'clndr_repeat',
 			'contacts_addressbooks',
-			'contacts_cards'
+			'contacts_cards',
+			'gallery_albums',
+			'gallery_photos'
 		];
 	}
 }


### PR DESCRIPTION
Commit 34a21a63ce5730a4f45af6745b4acd6f702e6e79 renamed gallery_albums
to pictures_images_cache and removed gallery_photos entirely.
