### PR TITLE
Remove obsolete contacts_cards_properties table

### DIFF
--- a/lib/private/Repair/DropOldTables.php
+++ b/lib/private/Repair/DropOldTables.php
@@ -101,6 +101,7 @@ class DropOldTables implements IRepairStep {
 			'clndr_repeat',
 			'contacts_addressbooks',
 			'contacts_cards',
+			'contacts_cards_properties',
 			'gallery_albums',
 			'gallery_photos'
 		];


### PR DESCRIPTION
The table contacts_cards_properties was part of the contacts app until
ownCloud 8.2. It got replaced with cards_properties (part of dav).

See also: ownCloud/core#21889
