### PR TITLE
make loading spinner thicker and color lighter

### DIFF
--- a/core/css/icons.css
+++ b/core/css/icons.css
@@ -49,14 +49,14 @@
 .icon-loading-dark:after,
 .icon-loading-small:after,
 .icon-loading-small-dark:after {
-	border: 1px solid rgba(85, 85, 85, 0.5);
-	border-top-color: #555;
+	border: 2px solid rgba(150, 150, 150, .5);
+	border-top-color: rgb(100, 100, 100);
 }
 
 .icon-loading-dark:after,
 .icon-loading-small-dark:after {
-	border: 1px solid rgba(187, 187, 187, 0.5);
-	border-top-color: #BBB;
+	border: 2px solid rgba(187, 187, 187, .5);
+	border-top-color: #bbb;
 }
 
 .icon-loading-small:after,


### PR DESCRIPTION
The spinner is very difficult to see because it’s too thin (1px). Increasing to 2px makes it a tad more visible.

Before above, this pull request below:
![spinner](https://cloud.githubusercontent.com/assets/925062/16188642/d3bf58c4-36d6-11e6-986c-947637904782.png)

Please review @nextcloud/designers @skjnldsv 
(Btw @skjnldsv I invited you to join the designers team, you can accept the invitation at https://github.com/nextcloud :)
