### PR TITLE
Show error message if config file is not readable

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -184,10 +184,10 @@ class Config {
 
 		// Include file and merge config
 		foreach ($configFiles as $file) {
-			$filePointer = file_exists($file) ? fopen($file, 'r') : false;
+			$fileExistsAndIsReadable = file_exists($file) && is_readable($file);
+			$filePointer = $fileExistsAndIsReadable ? fopen($file, 'r') : false;
 			if($file === $this->configFilePath &&
-				$filePointer === false &&
-				@!file_exists($this->configFilePath)) {
+				$filePointer === false) {
 				// Opening the main config might not be possible, e.g. if the wrong
 				// permissions are set (likely on a new installation)
 				continue;


### PR DESCRIPTION
- when the config file is not writable there is a error message shown
- same happens now if the config file is not readable
- fixes #180 

cc @adsworth @mar1u5 @williambargent @LukasReschke @schiessle  
