### PR TITLE
changes emptycontent icon to drag-accept on file-drag

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -669,13 +669,14 @@ OC.Upload = {
 				});
 				fileupload.on('fileuploaddragover', function(e){
 					$('#app-content').addClass('file-drag');
+					$('#emptycontent .icon-folder').addClass('icon-filetype-folder-drag-accept');
 
 					var filerow = $(e.delegatedEvent.target).closest('tr');
 
 					if(!filerow.hasClass('dropping-to-dir')){
+						$('.dropping-to-dir .icon-filetype-folder-drag-accept').removeClass('icon-filetype-folder-drag-accept');
 						$('.dropping-to-dir').removeClass('dropping-to-dir');
 						$('.dir-drop').removeClass('dir-drop');
-						$('.icon-filetype-folder-drag-accept').removeClass('icon-filetype-folder-drag-accept');
 					}
 
 					if(filerow.attr('data-type') === 'dir'){


### PR DESCRIPTION
as per request by @jancborchardt (finally got around to do that 😄) https://github.com/nextcloud/server/pull/83#issuecomment-226115067 though we currently do not have a file-accept-drop-icon for the other types of folder (external/favorite/public), shall we just leave it at that?

please review @nextcloud/designers [demo](http://cl.ly/2g0h3f2N1b0V)
