### PR TITLE
[stable9] Move OC_Channel to system config

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -501,6 +501,11 @@ $CONFIG = array(
 'updater.server.url' => 'https://updates.nextcloud.org/server/',
 
 /**
+ * Release channel to use for updates
+ */
+'updater.release.channel' => 'stable',
+
+/**
  * Is Nextcloud connected to the Internet or running in a closed network?
  */
 'has_internet_connection' => true,

--- a/lib/private/repair.php
+++ b/lib/private/repair.php
@@ -37,6 +37,7 @@ use OC\Repair\Collation;
 use OC\Repair\CopyRewriteBaseToConfig;
 use OC\Repair\DropOldJobs;
 use OC\Repair\EncryptionCompatibility;
+use OC\Repair\MoveChannelToSystemConfig;
 use OC\Repair\OldGroupMembershipShares;
 use OC\Repair\RemoveGetETagEntries;
 use OC\Repair\SqliteAutoincrement;
@@ -118,6 +119,7 @@ class Repair extends BasicEmitter {
 			new UpdateOutdatedOcsIds(\OC::$server->getConfig()),
 			new RepairInvalidShares(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection()),
 			new AvatarPermissions(\OC::$server->getDatabaseConnection()),
+			new MoveChannelToSystemConfig(\OC::$server->getConfig()),
 		];
 	}
 

--- a/lib/private/repair/movechanneltosystemconfig.php
+++ b/lib/private/repair/movechanneltosystemconfig.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Lukas Reschke <lukas@statuscode.ch>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OC\Repair;
+
+use OC\Hooks\BasicEmitter;
+use OCP\IConfig;
+
+/**
+ * Class MoveChannelToSystemConfig moves the defined OC_Channel in the app config
+ * to the system config to be compatible with the Nextcloud updater.
+ *
+ * @package OC\Repair
+ */
+class MoveChannelToSystemConfig extends BasicEmitter implements \OC\RepairStep {
+	/** @var IConfig */
+	private $config;
+
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	public function getName() {
+		return 'Moves the stored release channel to the config file';
+	}
+
+	public function run() {
+		$channel = $this->config->getAppValue('core', 'OC_Channel', '');
+		if($channel !== '') {
+			$this->config->setSystemValue('updater.release.channel', $channel);
+			$this->config->deleteAppValue('core', 'OC_Channel');
+		}
+	}
+}

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -384,7 +384,8 @@ class OC_Util {
 	}
 
 	/**
-	 * @description get the update channel of the current installed of ownCloud.
+	 * Get the currently configured release channel
+	 *
 	 * @return string
 	 */
 	public static function getChannel() {
@@ -421,7 +422,7 @@ class OC_Util {
 			// Allow overriding update channel
 			
 			if (\OC::$server->getSystemConfig()->getValue('installed', false)) {
-				$channel = \OC::$server->getAppConfig()->getValue('core', 'OC_Channel');
+				$channel = \OC::$server->getConfig()->getSystemValue('updater.release.channel', null);
 			} else {
 				/** @var $OC_Channel string */
 				$channel = $OC_Channel;

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -79,8 +79,8 @@ class Util {
 	 */
 	public static function setChannel($channel) {
 		//Flush timestamp to reload version.php
+		\OC::$server->getConfig()->setSystemValue('updater.release.channel', $channel);
 		\OC::$server->getSession()->set('OC_Version_Timestamp', 0);
-		\OC::$server->getAppConfig()->setValue('core', 'OC_Channel', $channel);
 	}
 	
 	/**


### PR DESCRIPTION
The Nextcloud and ownCloud updaters allow someone to configure a custom release channel, this can then be used to publish different versions. (e.g. one channel stays on 9.x while another one already gets 10.x)

There is however one big problem with it: The value is effectively stored in the app config, which is stored in the database. So to be able to read the update channel a connection to the database is necessary. This is quite error prone and also causes some of the issues in the original ownCloud updater.

This moves the channel registration to the config.php and also includes a repair step.

@MorrisJobke Mind taking a look?
