### PR TITLE
Revert "[stable9] Don't show the updater if updater is incompatible"

### DIFF
--- a/apps/updatenotification/controller/admincontroller.php
+++ b/apps/updatenotification/controller/admincontroller.php
@@ -80,33 +80,6 @@ class AdminController extends Controller {
 	}
 
 	/**
-	 * Whether the instance is compatible with the updater
-	 *
-	 * @return bool
-	 */
-	protected function isCompatibleWithUpdater() {
-		$updaterCompatible = true;
-		if(!function_exists('proc_open') || !function_exists('shell_exec')) {
-			$updaterCompatible = false;
-		} else {
-			$whichUnzip = shell_exec('command -v unzip');
-			if(!class_exists('ZipArchive') && empty($whichUnzip)) {
-				$updaterCompatible = false;
-			}
-
-			$whichPhp = shell_exec('command -v php');
-			if(empty($whichPhp)) {
-				$updaterCompatible = false;
-			}
-		}
-		if(!function_exists('curl_exec')) {
-			$updaterCompatible = false;
-		}
-
-		return $updaterCompatible;
-	}
-
-	/**
 	 * @return TemplateResponse
 	 */
 	public function displayPanel() {
@@ -121,6 +94,7 @@ class AdminController extends Controller {
 			'production',
 		];
 		$currentChannel = \OCP\Util::getChannel();
+
 		// Remove the currently used channel from the channels list
 		if(($key = array_search($currentChannel, $channels)) !== false) {
 			unset($channels[$key]);
@@ -132,7 +106,6 @@ class AdminController extends Controller {
 			'currentChannel' => $currentChannel,
 			'channels' => $channels,
 			'newVersionString' => ($updateState === []) ? '' : $updateState['updateVersion'],
-			'updaterRequirementsFulfilled' => $this->isCompatibleWithUpdater(),
 		];
 
 		return new TemplateResponse($this->appName, 'admin', $params, '');

--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -12,19 +12,13 @@
 	$channels = $_['channels'];
 	/** @var string $currentChannel */
 	$currentChannel = $_['currentChannel'];
-	/** @var bool $updaterRequirementsFulfilled */
-	$updaterRequirementsFulfilled = $_['updaterRequirementsFulfilled'];
 ?>
 <form id="oca_updatenotification_section" class="section">
 	<h2><?php p($l->t('Updater')); ?></h2>
 
 	<?php if($isNewVersionAvailable === true): ?>
 		<strong><?php p($l->t('A new version is available: %s', [$newVersionString])); ?></strong>
-		<?php if($updaterRequirementsFulfilled === true): ?>
-			<input type="button" id="oca_updatenotification_button" value="<?php p($l->t('Open updater')) ?>">
-		<?php else: ?>
-			<br/><?php p($l->t('At the moment only manual updates are supported on your environment. This is very likely the case because functions such as shell_exec are not available.')); ?>
-		<?php endif; ?>
+		<input type="button" id="oca_updatenotification_button" value="<?php p($l->t('Open updater')) ?>">
 	<?php else: ?>
 		<strong><?php print_unescaped($l->t('Your version is up to date.')); ?></strong>
 		<span class="icon-info svg" title="<?php p($l->t('Checked on %s', [$lastCheckedDate])) ?>"></span>

--- a/apps/updatenotification/tests/controller/AdminControllerTest.php
+++ b/apps/updatenotification/tests/controller/AdminControllerTest.php
@@ -67,23 +67,17 @@ class AdminControllerTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->dateTimeFormatter = $this->getMock('\\OCP\\IDateTimeFormatter');
 
-		$this->adminController = $this->getMockBuilder('\OCA\UpdateNotification\Controller\AdminController')
-			->setConstructorArgs(
-				[
-					'updatenotification',
-					$this->request,
-					$this->jobList,
-					$this->secureRandom,
-					$this->config,
-					$this->timeFactory,
-					$this->l10n,
-					$this->updateChecker,
-					$this->dateTimeFormatter,
-				]
-			)
-			->setMethods(['isCompatibleWithUpdater'])
-			->getMock()
-		;
+		$this->adminController = new AdminController(
+			'updatenotification',
+			$this->request,
+			$this->jobList,
+			$this->secureRandom,
+			$this->config,
+			$this->timeFactory,
+			$this->l10n,
+			$this->updateChecker,
+			$this->dateTimeFormatter
+		);
 	}
 
 	public function testDisplayPanelWithUpdate() {
@@ -114,10 +108,6 @@ class AdminControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getUpdateState')
 			->willReturn(['updateVersion' => '8.1.2']);
-		$this->adminController
-			->expects($this->once())
-			->method('isCompatibleWithUpdater')
-			->willReturn(true);
 
 		$params = [
 			'isNewVersionAvailable' => true,
@@ -125,53 +115,6 @@ class AdminControllerTest extends TestCase {
 			'currentChannel' => \OCP\Util::getChannel(),
 			'channels' => $channels,
 			'newVersionString' => '8.1.2',
-			'updaterRequirementsFulfilled' => true,
-		];
-
-		$expected = new TemplateResponse('updatenotification', 'admin', $params, '');
-		$this->assertEquals($expected, $this->adminController->displayPanel());
-	}
-
-	public function testDisplayPanelWithUpdateAndIncompatibleUpdaterApp() {
-		$channels = [
-			'daily',
-			'beta',
-			'stable',
-			'production',
-		];
-		$currentChannel = \OCP\Util::getChannel();
-
-		// Remove the currently used channel from the channels list
-		if(($key = array_search($currentChannel, $channels)) !== false) {
-			unset($channels[$key]);
-		}
-
-		$this->config
-			->expects($this->once())
-			->method('getAppValue')
-			->with('core', 'lastupdatedat')
-			->willReturn('12345');
-		$this->dateTimeFormatter
-			->expects($this->once())
-			->method('formatDateTime')
-			->with('12345')
-			->willReturn('LastCheckedReturnValue');
-		$this->updateChecker
-			->expects($this->once())
-			->method('getUpdateState')
-			->willReturn(['updateVersion' => '8.1.2']);
-		$this->adminController
-			->expects($this->once())
-			->method('isCompatibleWithUpdater')
-			->willReturn(false);
-
-		$params = [
-			'isNewVersionAvailable' => true,
-			'lastChecked' => 'LastCheckedReturnValue',
-			'currentChannel' => \OCP\Util::getChannel(),
-			'channels' => $channels,
-			'newVersionString' => '8.1.2',
-			'updaterRequirementsFulfilled' => false,
 		];
 
 		$expected = new TemplateResponse('updatenotification', 'admin', $params, '');
@@ -206,10 +149,6 @@ class AdminControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getUpdateState')
 			->willReturn([]);
-		$this->adminController
-			->expects($this->once())
-			->method('isCompatibleWithUpdater')
-			->willReturn(true);
 
 		$params = [
 			'isNewVersionAvailable' => false,
@@ -217,7 +156,6 @@ class AdminControllerTest extends TestCase {
 			'currentChannel' => \OCP\Util::getChannel(),
 			'channels' => $channels,
 			'newVersionString' => '',
-			'updaterRequirementsFulfilled' => true,
 		];
 
 		$expected = new TemplateResponse('updatenotification', 'admin', $params, '');


### PR DESCRIPTION
This reverts commit 5e2bf16db1d5b2726713d04b019ade8557104fbd. The new updater can handle that.

cc @MorrisJobke 
