### PR TITLE
Allow regular users to specify global credentials password

### DIFF
--- a/apps/files_external/lib/Controller/AjaxController.php
+++ b/apps/files_external/lib/Controller/AjaxController.php
@@ -26,25 +26,48 @@ namespace OCA\Files_External\Controller;
 
 use OCA\Files_External\Lib\Auth\Password\GlobalAuth;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Response;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\AppFramework\Http\JSONResponse;
 use OCA\Files_External\Lib\Auth\PublicKey\RSA;
+use OCP\IUserSession;
 
 class AjaxController extends Controller {
 	/** @var RSA */
 	private $rsaMechanism;
 	/** @var GlobalAuth  */
 	private $globalAuth;
+	/** @var IUserSession */
+	private $userSession;
+	/** @var IGroupManager */
+	private $groupManager;
 
+	/**
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param RSA $rsaMechanism
+	 * @param GlobalAuth $globalAuth
+	 * @param IUserSession $userSession
+	 * @param IGroupManager $groupManager
+	 */
 	public function __construct($appName,
 								IRequest $request,
 								RSA $rsaMechanism,
-								GlobalAuth $globalAuth) {
+								GlobalAuth $globalAuth,
+								IUserSession $userSession,
+								IGroupManager $groupManager) {
 		parent::__construct($appName, $request);
 		$this->rsaMechanism = $rsaMechanism;
 		$this->globalAuth = $globalAuth;
+		$this->userSession = $userSession;
+		$this->groupManager = $groupManager;
 	}
 
+	/**
+	 * @return array
+	 */
 	private function generateSshKeys() {
 		$key = $this->rsaMechanism->createKey();
 		// Replace the placeholder label with a more meaningful one
@@ -70,13 +93,26 @@ class AjaxController extends Controller {
 	}
 
 	/**
+	 * @NoAdminRequired
+	 *
 	 * @param string $uid
 	 * @param string $user
 	 * @param string $password
 	 * @return bool
 	 */
 	public function saveGlobalCredentials($uid, $user, $password) {
-		$this->globalAuth->saveAuth($uid, $user, $password);
-		return true;
+		$currentUser = $this->userSession->getUser();
+
+		// Non-admins can only edit their own credentials
+		$allowedToEdit = (
+			$this->groupManager->isAdmin($currentUser->getUID()) || $currentUser->getUID() === $uid
+		) ? true : false;
+
+		if ($allowedToEdit) {
+			$this->globalAuth->saveAuth($uid, $user, $password);
+			return true;
+		} else {
+			return false;
+		}
 	}
 }

--- a/apps/files_external/tests/Controller/AjaxControllerTest.php
+++ b/apps/files_external/tests/Controller/AjaxControllerTest.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Lukas Reschke <lukas@statuscode.ch>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Files_External\Tests\Controller;
+
+use OCA\Files_External\Controller\AjaxController;
+use OCA\Files_External\Lib\Auth\Password\GlobalAuth;
+use OCA\Files_External\Lib\Auth\PublicKey\RSA;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUserSession;
+use Test\TestCase;
+
+class AjaxControllerTest extends TestCase {
+	/** @var IRequest */
+	private $request;
+	/** @var RSA */
+	private $rsa;
+	/** @var GlobalAuth */
+	private $globalAuth;
+	/** @var IUserSession */
+	private $userSession;
+	/** @var IGroupManager */
+	private $groupManager;
+	/** @var AjaxController */
+	private $ajaxController;
+
+	public function setUp() {
+		$this->request = $this->getMock('\\OCP\\IRequest');
+		$this->rsa = $this->getMockBuilder('\\OCA\\Files_External\\Lib\\Auth\\PublicKey\\RSA')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->globalAuth = $this->getMockBuilder('\\OCA\\Files_External\\Lib\\Auth\\Password\GlobalAuth')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->userSession = $this->getMock('\\OCP\\IUserSession');
+		$this->groupManager = $this->getMock('\\OCP\\IGroupManager');
+
+		$this->ajaxController = new AjaxController(
+			'files_external',
+			$this->request,
+			$this->rsa,
+			$this->globalAuth,
+			$this->userSession,
+			$this->groupManager
+		);
+
+		parent::setUp();
+	}
+
+	public function testGetSshKeys() {
+		$this->rsa
+			->expects($this->once())
+			->method('createKey')
+			->willReturn([
+				'privatekey' => 'MyPrivateKey',
+				'publickey' => 'MyPublicKey',
+			]);
+
+		$expected =  new JSONResponse(
+			[
+				'data' => [
+					'private_key' => 'MyPrivateKey',
+					'public_key' => 'MyPublicKey',
+				],
+				'status' => 'success',
+			]
+		);
+		$this->assertEquals($expected, $this->ajaxController->getSshKeys());
+	}
+
+	public function testSaveGlobalCredentialsAsAdminForAnotherUser() {
+		$user = $this->getMock('\\OCP\\IUser');
+		$user
+			->expects($this->once())
+			->method('getUID')
+			->willReturn('MyAdminUid');
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->willReturn($user);
+		$this->groupManager
+			->expects($this->once())
+			->method('isAdmin')
+			->with('MyAdminUid')
+			->willReturn(true);
+		$this->globalAuth
+			->expects($this->once())
+			->method('saveAuth')
+			->with('UidOfTestUser', 'test', 'password');
+
+		$this->assertSame(true, $this->ajaxController->saveGlobalCredentials('UidOfTestUser', 'test', 'password'));
+	}
+
+	public function testSaveGlobalCredentialsAsAdminForSelf() {
+		$user = $this->getMock('\\OCP\\IUser');
+		$user
+			->expects($this->once())
+			->method('getUID')
+			->willReturn('MyAdminUid');
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->willReturn($user);
+		$this->groupManager
+			->expects($this->once())
+			->method('isAdmin')
+			->with('MyAdminUid')
+			->willReturn(true);
+		$this->globalAuth
+			->expects($this->once())
+			->method('saveAuth')
+			->with('MyAdminUid', 'test', 'password');
+
+		$this->assertSame(true, $this->ajaxController->saveGlobalCredentials('MyAdminUid', 'test', 'password'));
+	}
+
+	public function testSaveGlobalCredentialsAsNormalUserForSelf() {
+		$user = $this->getMock('\\OCP\\IUser');
+		$user
+			->expects($this->exactly(2))
+			->method('getUID')
+			->willReturn('MyUserUid');
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->willReturn($user);
+		$this->groupManager
+			->expects($this->once())
+			->method('isAdmin')
+			->with('MyUserUid')
+			->willReturn(false);
+		$this->globalAuth
+			->expects($this->once())
+			->method('saveAuth')
+			->with('MyUserUid', 'test', 'password');
+
+		$this->assertSame(true, $this->ajaxController->saveGlobalCredentials('MyUserUid', 'test', 'password'));
+	}
+
+	public function testSaveGlobalCredentialsAsNormalUserForAnotherUser() {
+		$user = $this->getMock('\\OCP\\IUser');
+		$user
+			->expects($this->exactly(2))
+			->method('getUID')
+			->willReturn('MyUserUid');
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->willReturn($user);
+		$this->groupManager
+			->expects($this->once())
+			->method('isAdmin')
+			->with('MyUserUid')
+			->willReturn(false);
+
+		$this->assertSame(false, $this->ajaxController->saveGlobalCredentials('AnotherUserUid', 'test', 'password'));
+	}
+}


### PR DESCRIPTION
While the UI is existent the feature simply doesn't work because admin privileges are required for the controller. This adds proper permission checks and also unit tests. (actually most of the PR is unit tests…)

To test this:
1. Enable external storage
2. Login as non-admin user
3. Go to personal page and try to change global credentials
