### PR TITLE
Add app:check-code for already compatible apps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
 
 script:
   - sh -c "if [ '$TC' = 'syntax' ]; then composer install && lib/composer/bin/parallel-lint --exclude lib/composer/jakub-onderka/ --exclude 3rdparty/symfony/polyfill-php70/Resources/stubs/ --exclude 3rdparty/patchwork/utf8/src/Patchwork/Utf8/Bootup/ --exclude 3rdparty/paragonie/random_compat/lib/ --exclude lib/composer/composer/autoload_static.php --exclude 3rdparty/composer/autoload_static.php .; fi"
+  - sh -c "if [ '$TC' = 'app:check-code' ]; then ./occ app:check-code admin_audit; ./occ app:check-code comments; ./occ app:check-code federation; fi"
   - sh -c "if [ '$TEST_DAV' != '1' ]; then echo \"Not testing DAV\"; fi"
   - sh -c "if [ '$TEST_DAV' = '1' ]; then echo \"Testing DAV\"; fi"
 
@@ -51,5 +52,7 @@ matrix:
       env: DB=sqlite;TC=syntax;TEST_DAV=0
     - php: 7.0
       env: DB=sqlite;TC=syntax;TEST_DAV=0
+    - php: 5.4
+      env: DB=sqlite;TC=app:check-code;TEST_DAV=0
 
   fast_finish: true

--- a/apps/encryption/settings/settings-admin.php
+++ b/apps/encryption/settings/settings-admin.php
@@ -22,8 +22,6 @@
  *
  */
 
-\OC_Util::checkAdminUser();
-
 $tmpl = new OCP\Template('encryption', 'settings-admin');
 
 $crypt = new \OCA\Encryption\Crypto\Crypt(

--- a/apps/federatedfilesharing/settings-admin.php
+++ b/apps/federatedfilesharing/settings-admin.php
@@ -22,8 +22,6 @@
 
 use OCA\FederatedFileSharing\AppInfo\Application;
 
-\OC_Util::checkAdminUser();
-
 $app = new Application('federatedfilesharing');
 $federatedShareProvider = $app->getFederatedShareProvider();
 

--- a/apps/federation/settings/settings-admin.php
+++ b/apps/federation/settings/settings-admin.php
@@ -19,8 +19,6 @@
  *
  */
 
-\OC_Util::checkAdminUser();
-
 $template = new OCP\Template('federation', 'settings-admin');
 
 $dbHandler = new \OCA\Federation\DbHandler(

--- a/apps/files/admin.php
+++ b/apps/files/admin.php
@@ -27,8 +27,6 @@
  *
  */
 
-OCP\User::checkAdminUser();
-
 $htaccessWorking=(getenv('htaccessWorking')=='true');
 $upload_max_filesize = OC::$server->getIniWrapper()->getBytes('upload_max_filesize');
 $post_max_size = OC::$server->getIniWrapper()->getBytes('post_max_size');

--- a/apps/files/download.php
+++ b/apps/files/download.php
@@ -26,9 +26,6 @@
  *
  */
 
-// Check if we are a user
-OCP\User::checkLoggedIn();
-
 $filename = $_GET["file"];
 
 if(!\OC\Files\Filesystem::file_exists($filename)) {

--- a/apps/files/list.php
+++ b/apps/files/list.php
@@ -20,9 +20,6 @@
  *
  */
 
-// Check if we are a user
-OCP\User::checkLoggedIn();
-
 $config = \OC::$server->getConfig();
 // TODO: move this to the generated config.js
 $publicUploadEnabled = $config->getAppValue('core', 'shareapi_allow_public_upload', 'yes');

--- a/apps/files_external/settings.php
+++ b/apps/files_external/settings.php
@@ -26,8 +26,6 @@
 
 use \OCA\Files_External\Service\BackendService;
 
-\OCP\User::checkAdminUser();
-
 // we must use the same container
 $appContainer = \OC_Mount_Config::$app->getContainer();
 $backendService = $appContainer->query('OCA\Files_External\Service\BackendService');

--- a/apps/user_ldap/settings.php
+++ b/apps/user_ldap/settings.php
@@ -27,8 +27,6 @@
  *
  */
 
-OC_Util::checkAdminUser();
-
 // fill template
 $tmpl = new OCP\Template('user_ldap', 'settings');
 


### PR DESCRIPTION
- admin_audit, comments, federation
- removed not needed call to OC_Util::checkAdminUser() (is already
  done by the request handler before)

cc @LukasReschke @schiessle 
