### PR TITLE
Get rid of LGTM self approvals

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,2 +1,2 @@
 pattern = "(?i):shipit:|:\\+1:|LGTM|👍"
-self_approval_off=true
+self_approval_off = true


### PR DESCRIPTION
An bug initially introduced by @tobiasKaminsky in https://github.com/nextcloud/android/pull/13 i've took over to the server in #77 and #78 😒 
- add missing spaces

_If this works, I will obviously create a backport for `stable9` and add this to our other LGTM repos_ 😉 

cc @MorrisJobke @LukasReschke 
