### PR TITLE
[stable9] add events to check passwords with the password policy app

### DIFF
--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -618,7 +618,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getL10N('core'),
 				$factory,
 				$c->getUserManager(),
-				$c->getRootFolder()
+				$c->getRootFolder(),
+				$c->getEventDispatcher()
 			);
 
 			return $manager;

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -24,6 +24,7 @@
 namespace OC\Share20;
 
 use OC\Files\Mount\MoveableMount;
+use OC\HintException;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\IUserManager;
@@ -42,6 +43,8 @@ use OCP\Files\Folder;
 
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\Exceptions\GenericShareException;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * This class is the communication hub for all sharing related operations.
@@ -82,6 +85,7 @@ class Manager implements IManager {
 	 * @param IProviderFactory $factory
 	 * @param IUserManager $userManager
 	 * @param IRootFolder $rootFolder
+	 * @param EventDispatcher $eventDispatcher
 	 */
 	public function __construct(
 			ILogger $logger,
@@ -93,7 +97,8 @@ class Manager implements IManager {
 			IL10N $l,
 			IProviderFactory $factory,
 			IUserManager $userManager,
-			IRootFolder $rootFolder
+			IRootFolder $rootFolder,
+			EventDispatcher $eventDispatcher
 	) {
 		$this->logger = $logger;
 		$this->config = $config;
@@ -105,6 +110,7 @@ class Manager implements IManager {
 		$this->factory = $factory;
 		$this->userManager = $userManager;
 		$this->rootFolder = $rootFolder;
+		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	/**
@@ -134,16 +140,11 @@ class Manager implements IManager {
 		}
 
 		// Let others verify the password
-		$accepted = true;
-		$message = '';
-		\OCP\Util::emitHook('\OC\Share', 'verifyPassword', [
-				'password' => $password,
-				'accepted' => &$accepted,
-				'message' => &$message
-		]);
-
-		if (!$accepted) {
-			throw new \Exception($message);
+		try {
+			$event = new GenericEvent($password);
+			$this->eventDispatcher->dispatch('OCP\PasswordPolicy::validate', $event);
+		} catch (HintException $e) {
+			throw new \Exception($e->getHint());
 		}
 	}
 

--- a/lib/private/user/database.php
+++ b/lib/private/user/database.php
@@ -49,6 +49,8 @@
  */
 
 use OC\Cache\CappedMemoryCache;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Class for user management in a SQL Database (e.g. MySQL, SQLite)
@@ -59,9 +61,12 @@ class OC_User_Database extends OC_User_Backend implements \OCP\IUserBackend {
 
 	/**
 	 * OC_User_Database constructor.
+	 *
+	 * @param EventDispatcher $eventDispatcher
 	 */
-	public function __construct() {
+	public function __construct(EventDispatcher $eventDispatcher = null) {
 		$this->cache = new CappedMemoryCache();
+		$this->eventDispatcher = $eventDispatcher ? $eventDispatcher : \OC::$server->getEventDispatcher();
 	}
 
 	/**
@@ -113,6 +118,8 @@ class OC_User_Database extends OC_User_Backend implements \OCP\IUserBackend {
 	 */
 	public function setPassword($uid, $password) {
 		if ($this->userExists($uid)) {
+			$event = new GenericEvent($password);
+			$this->eventDispatcher->dispatch('OCP\PasswordPolicy::validate', $event);
 			$query = OC_DB::prepare('UPDATE `*PREFIX*users` SET `password` = ? WHERE `uid` = ?');
 			$result = $query->execute(array(\OC::$server->getHasher()->hash($password), $uid));
 

--- a/settings/changepassword/controller.php
+++ b/settings/changepassword/controller.php
@@ -30,6 +30,8 @@
  */
 namespace OC\Settings\ChangePassword;
 
+use OC\HintException;
+
 class Controller {
 	public static function changePersonalPassword($args) {
 		// Check if we are an user
@@ -39,16 +41,21 @@ class Controller {
 		$username = \OC_User::getUser();
 		$password = isset($_POST['personal-password']) ? $_POST['personal-password'] : null;
 		$oldPassword = isset($_POST['oldpassword']) ? $_POST['oldpassword'] : '';
+		$l = new \OC_L10n('settings');
 
 		if (!\OC_User::checkPassword($username, $oldPassword)) {
-			$l = new \OC_L10n('settings');
 			\OC_JSON::error(array("data" => array("message" => $l->t("Wrong password")) ));
 			exit();
 		}
-		if (!is_null($password) && \OC_User::setPassword($username, $password)) {
-			\OC_JSON::success();
-		} else {
-			\OC_JSON::error();
+
+		try {
+			if (!is_null($password) && \OC_User::setPassword($username, $password)) {
+				\OC_JSON::success(['data' => ['message' => $l->t('Saved')]]);
+			} else {
+				\OC_JSON::error();
+			}
+		} catch (HintException $e) {
+			\OC_JSON::error(['data' => ['message' => $e->getHint()]]);
 		}
 	}
 
@@ -144,15 +151,19 @@ class Controller {
 				} elseif (!$result && !$recoveryEnabledForUser) {
 					\OC_JSON::error(array("data" => array( "message" => $l->t("Unable to change password" ) )));
 				} else {
-					\OC_JSON::success(array("data" => array( "username" => $username )));
+					\OC_JSON::success(array("data" => array("username" => $username, 'message' => $l->t('Saved'))));
 				}
 
 			}
 		} else { // if encryption is disabled, proceed
-			if (!is_null($password) && \OC_User::setPassword($username, $password)) {
-				\OC_JSON::success(array('data' => array('username' => $username)));
-			} else {
-				\OC_JSON::error(array('data' => array('message' => $l->t('Unable to change password'))));
+			try {
+				if (!is_null($password) && \OC_User::setPassword($username, $password)) {
+					\OC_JSON::success(array('data' => array('username' => $username, 'message' => $l->t('Saved'))));
+				} else {
+					\OC_JSON::error(array('data' => array('message' => $l->t('Unable to change password'))));
+				}
+			} catch (HintException $e) {
+				\OC_JSON::error(array('data' => array('message' => $e->getHint())));
 			}
 		}
 	}

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -185,6 +185,7 @@ $(document).ready(function () {
 		$('#pass2').showPassword().keyup();
 	}
 	$("#passwordbutton").click(function () {
+		OC.msg.startSaving('#password-error-msg');
 		var isIE8or9 = $('html').hasClass('lte9');
 		// FIXME - TODO - once support for IE8 and IE9 is dropped
 		// for IE8 and IE9 this will check additionally if the typed in password
@@ -201,25 +202,32 @@ $(document).ready(function () {
 				if (data.status === "success") {
 					$('#pass1').val('');
 					$('#pass2').val('').change();
-					// Hide a possible errormsg and show successmsg
-					$('#password-changed').removeClass('hidden').addClass('inlineblock');
-					$('#password-error').removeClass('inlineblock').addClass('hidden');
+					OC.msg.finishedSaving('#password-error-msg', data);
 				} else {
 					if (typeof(data.data) !== "undefined") {
-						$('#password-error').text(data.data.message);
+						OC.msg.finishedSaving('#password-error-msg', data);
 					} else {
-						$('#password-error').text(t('Unable to change password'));
+						OC.msg.finishedSaving('#password-error-msg',
+							{
+								'status' : 'error',
+								'data' : {
+									'message' : t('core', 'Unable to change password')
+								}
+							}
+						);
 					}
-					// Hide a possible successmsg and show errormsg
-					$('#password-changed').removeClass('inlineblock').addClass('hidden');
-					$('#password-error').removeClass('hidden').addClass('inlineblock');
 				}
 			});
 			return false;
 		} else {
-			// Hide a possible successmsg and show errormsg
-			$('#password-changed').removeClass('inlineblock').addClass('hidden');
-			$('#password-error').removeClass('hidden').addClass('inlineblock');
+			OC.msg.finishedSaving('#password-error-msg',
+				{
+					'status' : 'error',
+					'data' : {
+						'message' : t('core', 'Unable to change password')
+					}
+				}
+			);
 			return false;
 		}
 

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -118,8 +118,7 @@ if($_['passwordChangeSupported']) {
 ?>
 <form id="passwordform" class="section">
 	<h2 class="inlineblock"><?php p($l->t('Password'));?></h2>
-	<div class="hidden icon-checkmark" id="password-changed"></div>
-	<div class="hidden" id="password-error"><?php p($l->t('Unable to change your password'));?></div>
+	<div id="password-error-msg" class="msg success inlineblock" style="display: none;">Saved</div>
 	<br>
 	<label for="pass1" class="onlyInIE8"><?php echo $l->t('Current password');?>: </label>
 	<input type="password" id="pass1" name="oldpassword"


### PR DESCRIPTION
approved backport of https://github.com/nextcloud/server/pull/221

This backport was done manually because of the namespace changes in master. So please give it a short try, together with https://github.com/nextcloud/password_policy/tree/stable9

cc @MorrisJobke @LukasReschke 
