### PR TITLE
[stable9] Add exemption for ACS endpoint

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -519,6 +519,23 @@ class OC {
 			$processingScript = explode('/', $requestUri);
 			$processingScript = $processingScript[count($processingScript)-1];
 
+			// FIXME: In a SAML scenario we don't get any strict or lax cookie
+			// send for the ACS endpoint. Since we have some legacy code in Nextcloud
+			// (direct PHP files) the enforcement of lax cookies is performed here
+			// instead of the middleware.
+			//
+			// This means we cannot exclude some routes from the cookie validation,
+			// which normally is not a problem but is a little bit cumbersome for
+			// this use-case.
+			// Once the old legacy PHP endpoints have been removed we can move
+			// the verification into a middleware and also adds some exemptions.
+			//
+			// Questions about this code? Ask Lukas ;-)
+			$currentUrl = substr(explode('?',$request->getRequestUri(), 2)[0], strlen(\OC::$WEBROOT));
+			if($currentUrl === '/index.php/apps/user_saml/saml/acs') {
+				return;
+			}
+
 			// For the "index.php" endpoint only a lax cookie is required.
 			if($processingScript === 'index.php') {
 				if(!$request->passesLaxCookieCheck()) {


### PR DESCRIPTION
In a SAML scenario we don't get any strict or lax cookie send for
the ACS endpoint. Since we have some legacy code in Nextcloud
(direct PHP files) the enforcement of lax cookies is performed here
instead of the middleware.

This means we cannot exclude some routes from the cookie validation,
which normally is not a problem but is a little bit cumbersome for
this use-case.

Once the old legacy PHP endpoints have been removed we can move
the verification into a middleware and also adds some exemptions.

Not super awesome code to have but the best that I could come up
with that doesn't add another ton of technical debt.

This is for the SAML integration. 

@MorrisJobke @schiessle Reviews welcome. I know, the code is crap, so 🙈 or a better idea is welcome 😉 
