### PR TITLE
only load theme from the theming app if the app is really enabled

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -620,7 +620,7 @@ class Server extends ServerContainer implements IServerContainer {
 			return $factory->getManager();
 		});
 		$this->registerService('ThemingDefaults', function(Server $c) {
-			if($this->getConfig()->getSystemValue('installed', false) && $this->getAppManager()->isInstalled('theming')) {
+			if($this->getConfig()->getSystemValue('installed', false) && \OCP\App::isEnabled('theming')) {
 				return new Template(
 					$this->getConfig(),
 					$this->getL10N('theming'),


### PR DESCRIPTION
We should only load the theme from the theming app if the app is really enabled. So that users can go back to the default theme by disabling the app

cc @MorrisJobke @LukasReschke 
