### PR TITLE
[stable9] Set content-type to "application/octet-stream"

### DIFF
--- a/settings/controller/logsettingscontroller.php
+++ b/settings/controller/logsettingscontroller.php
@@ -103,7 +103,8 @@ class LogSettingsController extends Controller {
 	 */
 	public function download() {
 		$resp = new StreamResponse(\OC_Log_Owncloud::getLogFilePath());
-		$resp->addHeader('Content-Disposition', 'attachment; filename="owncloud.log"');
+		$resp->addHeader('Content-Type', 'application/octet-stream');
+		$resp->addHeader('Content-Disposition', 'attachment; filename="nextcloud.log"');
 		return $resp;
 	}
 }

--- a/tests/settings/controller/logsettingscontrollertest.php
+++ b/tests/settings/controller/logsettingscontrollertest.php
@@ -11,6 +11,7 @@ namespace Test\Settings\Controller;
 
 use \OC\Settings\Application;
 use OC\Settings\Controller\LogSettingsController;
+use OCP\AppFramework\Http\StreamResponse;
 
 /**
  * @package OC\Settings\Controller
@@ -69,6 +70,9 @@ class LogSettingsControllerTest extends \Test\TestCase {
 	public function testDownload() {
 		$response = $this->logSettingsController->download();
 
-		$this->assertInstanceOf('\OCP\AppFramework\Http\StreamResponse', $response);
+		$expected = new StreamResponse(\OC_Log_Owncloud::getLogFilePath());
+		$expected->addHeader('Content-Type', 'application/octet-stream');
+		$expected->addHeader('Content-Disposition', 'attachment; filename="nextcloud.log"');
+		$this->assertEquals($expected, $response);
 	}
 }


### PR DESCRIPTION
Some browsers such as Firefox on Microsoft Windows otherwise do offer to open the file directly which is kinda silly.

Backport of https://github.com/nextcloud/server/pull/258
