### PR TITLE
[stable9] Do not allow directory traversal using "../" in JS file list

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1469,7 +1469,7 @@
 				return false;
 			}
 
-			if (status === 404) {
+			if (status === 404 || status === 405) {
 				// go back home
 				this.changeDirectory('/');
 				return false;

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1333,7 +1333,7 @@
 		 * @param changeUrl true to also update the URL, false otherwise (default)
 		 */
 		_setCurrentDir: function(targetDir, changeUrl) {
-			targetDir = targetDir.replace(/\\/g, '/').replace(/\.\.\//g, '');
+			targetDir = targetDir.replace(/\\/g, '/').replace(/\/\.\.\//g, '/');
 			var previousDir = this.getCurrentDirectory(),
 				baseDir = OC.basename(targetDir);
 

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1333,7 +1333,7 @@
 		 * @param changeUrl true to also update the URL, false otherwise (default)
 		 */
 		_setCurrentDir: function(targetDir, changeUrl) {
-			targetDir = targetDir.replace(/\\/g, '/');
+			targetDir = targetDir.replace(/\\/g, '/').replace(/\.\.\//g, '');
 			var previousDir = this.getCurrentDirectory(),
 				baseDir = OC.basename(targetDir);
 

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1336,6 +1336,11 @@ describe('OCA.Files.FileList tests', function() {
 			deferredList.reject(404);
 			expect(fileList.getCurrentDirectory()).toEqual('/');
 		});
+		it('switches to root dir when current directory returns 405', function() {
+			fileList.changeDirectory('/unexist');
+			deferredList.reject(405);
+			expect(fileList.getCurrentDirectory()).toEqual('/');
+		});
 		it('switches to root dir when current directory is forbidden', function() {
 			fileList.changeDirectory('/unexist');
 			deferredList.reject(403);

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1327,6 +1327,10 @@ describe('OCA.Files.FileList tests', function() {
 			fileList.changeDirectory('/another\\subdir/../foo\\../bar\\..\\file/..\\folder/../');
 			expect(fileList.getCurrentDirectory()).toEqual('/another/subdir/foo/bar/file/folder/');
 		});
+		it('does not convert folders with a ".." in the name', function() {
+			fileList.changeDirectory('/abc../def');
+			expect(fileList.getCurrentDirectory()).toEqual('/abc../def');
+		});
 		it('switches to root dir when current directory does not exist', function() {
 			fileList.changeDirectory('/unexist');
 			deferredList.reject(404);

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1323,6 +1323,10 @@ describe('OCA.Files.FileList tests', function() {
 			fileList.changeDirectory('/another\\subdir');
 			expect(fileList.getCurrentDirectory()).toEqual('/another/subdir');
 		});
+		it('converts backslashes to slashes and removes traversals when calling changeDirectory()', function() {
+			fileList.changeDirectory('/another\\subdir/../foo\\../bar\\..\\file/..\\folder/../');
+			expect(fileList.getCurrentDirectory()).toEqual('/another/subdir/foo/bar/file/folder/');
+		});
 		it('switches to root dir when current directory does not exist', function() {
 			fileList.changeDirectory('/unexist');
 			deferredList.reject(404);


### PR DESCRIPTION
We should not allow directory traversals using "../" here.

To test access the following URL once with and then without this patch:

http://localhost/server/index.php/apps/files/?dir=../../This+Should+Not+Be+Here
