### PR TITLE
Do not allow directory traversal using "../"

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1404,7 +1404,7 @@
 		 * @param {string} [fileId] file id
 		 */
 		_setCurrentDir: function(targetDir, changeUrl, fileId) {
-			targetDir = targetDir.replace(/\\/g, '/');
+			targetDir = targetDir.replace(/\\/g, '/').replace(/\.\.\//g, '');
 			var previousDir = this.getCurrentDirectory(),
 				baseDir = OC.basename(targetDir);
 

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1404,7 +1404,7 @@
 		 * @param {string} [fileId] file id
 		 */
 		_setCurrentDir: function(targetDir, changeUrl, fileId) {
-			targetDir = targetDir.replace(/\\/g, '/').replace(/\.\.\//g, '');
+			targetDir = targetDir.replace(/\\/g, '/').replace(/\/\.\.\//g, '/');
 			var previousDir = this.getCurrentDirectory(),
 				baseDir = OC.basename(targetDir);
 

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1552,7 +1552,7 @@
 				return false;
 			}
 
-			if (status === 404) {
+			if (status === 404 || status === 405) {
 				// go back home
 				this.changeDirectory('/');
 				return false;

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1347,6 +1347,11 @@ describe('OCA.Files.FileList tests', function() {
 			deferredList.reject(404);
 			expect(fileList.getCurrentDirectory()).toEqual('/');
 		});
+		it('switches to root dir when current directory returns 405', function() {
+			fileList.changeDirectory('/unexist');
+			deferredList.reject(405);
+			expect(fileList.getCurrentDirectory()).toEqual('/');
+		});
 		it('switches to root dir when current directory is forbidden', function() {
 			fileList.changeDirectory('/unexist');
 			deferredList.reject(403);

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1338,6 +1338,10 @@ describe('OCA.Files.FileList tests', function() {
 			fileList.changeDirectory('/another\\subdir/../foo\\../bar\\..\\file/..\\folder/../');
 			expect(fileList.getCurrentDirectory()).toEqual('/another/subdir/foo/bar/file/folder/');
 		});
+		it('does not convert folders with a ".." in the name', function() {
+			fileList.changeDirectory('/abc../def');
+			expect(fileList.getCurrentDirectory()).toEqual('/abc../def');
+		});
 		it('switches to root dir when current directory does not exist', function() {
 			fileList.changeDirectory('/unexist');
 			deferredList.reject(404);

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1334,6 +1334,10 @@ describe('OCA.Files.FileList tests', function() {
 			fileList.changeDirectory('/another\\subdir');
 			expect(fileList.getCurrentDirectory()).toEqual('/another/subdir');
 		});
+		it('converts backslashes to slashes and removes traversals when calling changeDirectory()', function() {
+			fileList.changeDirectory('/another\\subdir/../foo\\../bar\\..\\file/..\\folder/../');
+			expect(fileList.getCurrentDirectory()).toEqual('/another/subdir/foo/bar/file/folder/');
+		});
 		it('switches to root dir when current directory does not exist', function() {
 			fileList.changeDirectory('/unexist');
 			deferredList.reject(404);


### PR DESCRIPTION
We should not allow directory traversals using "../" here.

To test access the following URL once with and then without this patch:

http://localhost/server/index.php/apps/files/?dir=../../This+Should+Not+Be+Here

cc @nickvergessen @MorrisJobke 
