### PR TITLE
[stable9] Updater handling

### DIFF
--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -18,7 +18,11 @@
 
 	<?php if($isNewVersionAvailable === true): ?>
 		<strong><?php p($l->t('A new version is available: %s', [$newVersionString])); ?></strong>
-		<input type="button" id="oca_updatenotification_button" value="<?php p($l->t('Open updater')) ?>">
+		<?php if(\OC::$server->getConfig()->getSystemValue('updater.enable.beta.web.updater', false)): ?>
+			<input type="button" id="oca_updatenotification_button" value="<?php p($l->t('Open updater (beta)')) ?>">
+		<?php else: ?>
+			<br/><em><?php p($l->t('Updates via web are in beta. If you want to help testing them please set "updater.enable.beta.web.updater" to true in your config file and have proper backups.')) ?></em>
+		<?php endif; ?>
 	<?php else: ?>
 		<strong><?php print_unescaped($l->t('Your version is up to date.')); ?></strong>
 		<span class="icon-info svg" title="<?php p($l->t('Checked on %s', [$lastCheckedDate])) ?>"></span>

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -498,12 +498,23 @@ $CONFIG = array(
 /**
  * URL that Nextcloud should use to look for updates
  */
-'updater.server.url' => 'https://updates.nextcloud.org/server/',
+'updater.server.url' => 'https://updates.nextcloud.org/updater_server/',
 
 /**
  * Release channel to use for updates
  */
 'updater.release.channel' => 'stable',
+
+/**
+ * Whether to enable the web updater via web.
+ *
+ * The updater is in beta at the moment. While it has been tested extensively there
+ * may be some edgecases we didn't cover so before enabling make sure to have a backup
+ * of your data and your Nextcloud program code.
+ *
+ * If you encounter any issues please report it at https://github.com/nextcloud/updater/issues
+ */
+'updater.enable.beta.web.updater' => false,
 
 /**
  * Is Nextcloud connected to the Internet or running in a closed network?

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -143,7 +143,7 @@ class Updater extends BasicEmitter {
 			return json_decode($this->config->getAppValue('core', 'lastupdateResult'), true);
 		}
 
-		$updaterUrl = $this->config->getSystemValue('updater.server.url', 'https://updates.nextcloud.org/server/');
+		$updaterUrl = $this->config->getSystemValue('updater.server.url', 'https://updates.nextcloud.org/updater_server/');
 
 		$this->config->setAppValue('core', 'lastupdatedat', time());
 

--- a/tests/lib/updater.php
+++ b/tests/lib/updater.php
@@ -222,8 +222,8 @@ class UpdaterTest extends \Test\TestCase {
 		$this->config
 			->expects($this->at(1))
 			->method('getSystemValue')
-			->with('updater.server.url', 'https://updates.nextcloud.org/server/')
-			->willReturn('https://updates.nextcloud.org/server/');
+			->with('updater.server.url', 'https://updates.nextcloud.org/updater_server/')
+			->willReturn('https://updates.nextcloud.org/updater_server/');
 		$this->config
 			->expects($this->at(2))
 			->method('setAppValue')
@@ -253,7 +253,7 @@ class UpdaterTest extends \Test\TestCase {
 		$this->httpHelper
 			->expects($this->once())
 			->method('getUrlContent')
-			->with($this->buildUpdateUrl('https://updates.nextcloud.org/server/'))
+			->with($this->buildUpdateUrl('https://updates.nextcloud.org/updater_server/'))
 			->will($this->returnValue($updateXml));
 
 		$this->assertSame($expectedResult, $this->updater->check());
@@ -268,8 +268,8 @@ class UpdaterTest extends \Test\TestCase {
 		$this->config
 			->expects($this->at(1))
 			->method('getSystemValue')
-			->with('updater.server.url', 'https://updates.nextcloud.org/server/')
-			->willReturn('https://updates.nextcloud.org/server/');
+			->with('updater.server.url', 'https://updates.nextcloud.org/updater_server/')
+			->willReturn('https://updates.nextcloud.org/updater_server/');
 		$this->config
 			->expects($this->at(2))
 			->method('setAppValue')
@@ -293,7 +293,7 @@ class UpdaterTest extends \Test\TestCase {
 		$this->httpHelper
 			->expects($this->once())
 			->method('getUrlContent')
-			->with($this->buildUpdateUrl('https://updates.nextcloud.org/server/'))
+			->with($this->buildUpdateUrl('https://updates.nextcloud.org/updater_server/'))
 			->will($this->returnValue($updateXml));
 
 		$this->assertSame([], $this->updater->check());
@@ -315,8 +315,8 @@ class UpdaterTest extends \Test\TestCase {
 		$this->config
 			->expects($this->at(1))
 			->method('getSystemValue')
-			->with('updater.server.url', 'https://updates.nextcloud.org/server/')
-			->willReturn('https://updates.nextcloud.org/server/');
+			->with('updater.server.url', 'https://updates.nextcloud.org/updater_server/')
+			->willReturn('https://updates.nextcloud.org/updater_server/');
 		$this->config
 			->expects($this->at(2))
 			->method('setAppValue')
@@ -342,7 +342,7 @@ class UpdaterTest extends \Test\TestCase {
 		$this->httpHelper
 			->expects($this->once())
 			->method('getUrlContent')
-			->with($this->buildUpdateUrl('https://updates.nextcloud.org/server/'))
+			->with($this->buildUpdateUrl('https://updates.nextcloud.org/updater_server/'))
 			->will($this->returnValue($updateXml));
 
 		$this->assertSame($expectedResult, $this->updater->check());
@@ -359,8 +359,8 @@ class UpdaterTest extends \Test\TestCase {
 		$this->config
 			->expects($this->at(1))
 			->method('getSystemValue')
-			->with('updater.server.url', 'https://updates.nextcloud.org/server/')
-			->willReturn('https://updates.nextcloud.org/server/');
+			->with('updater.server.url', 'https://updates.nextcloud.org/updater_server/')
+			->willReturn('https://updates.nextcloud.org/updater_server/');
 		$this->config
 			->expects($this->at(2))
 			->method('setAppValue')
@@ -384,7 +384,7 @@ class UpdaterTest extends \Test\TestCase {
 		$this->httpHelper
 			->expects($this->once())
 			->method('getUrlContent')
-			->with($this->buildUpdateUrl('https://updates.nextcloud.org/server/'))
+			->with($this->buildUpdateUrl('https://updates.nextcloud.org/updater_server/'))
 			->will($this->returnValue($updateXml));
 
 		$this->assertSame($expectedResult, $this->updater->check());


### PR DESCRIPTION
The current updater as shipped with ownCloud and Nextcloud can easily eat your data. It also ate mine when I tested it for 9.0.3 :see_no_evil:

So we have the new fancy updater from Morris and me. It is already tested by a lot of forum users, but to get some more testing on it I'd advise:
1. Ship it with every Nextcloud release
2. Disable it by default and add a note that it can be enabled with a config switch

That way we don't have a worse situation than currently. At the moment the web updater is simply not displayed at all, with this change we ship something that we are pretty certain won't eat data. But since we want to get some more testing it is disabled by default with a note on how to use it.

While I'm pretty certain it won't eat any data I'd feel more happy if people actually spend some time testing this before and know that they are using something that not 10000 people tested before them ;-)

cc @MorrisJobke As discussed
cc @karlitschek Any objections? From my PoV it won't get worse than the current situation (current one is: Updater is not displayed at all). And this could get us some more real life testing.
