### PR TITLE
Add mimetype for fb2-extension

### DIFF
--- a/resources/config/mimetypealiases.dist.json
+++ b/resources/config/mimetypealiases.dist.json
@@ -61,6 +61,7 @@
 	"application/x-compressed": "package/x-generic",
 	"application/x-dcraw": "image",
 	"application/x-deb": "package/x-generic",
+	"application/x-fictionbook+xml": "text",
 	"application/x-font": "image",
 	"application/x-gimp": "image",
 	"application/x-gzip": "package/x-generic",

--- a/resources/config/mimetypemapping.dist.json
+++ b/resources/config/mimetypemapping.dist.json
@@ -52,6 +52,7 @@
 	"eps": ["application/postscript"],
 	"erf": ["image/x-dcraw"],
 	"exe": ["application/x-ms-dos-executable"],
+	"fb2": ["application/x-fictionbook+xml", "text/plain"],
 	"flac": ["audio/flac"],
 	"flv": ["video/x-flv"],
 	"gif": ["image/gif"],


### PR DESCRIPTION
FBReader dislike default mimetype "application/octet-stream" for file with fb2-extension received from OPDS catalog.
