### PR TITLE
[stable9] Use paramterized parameter for \OC\SystemTag\SystemTagManager

### DIFF
--- a/lib/private/systemtag/systemtagmanager.php
+++ b/lib/private/systemtag/systemtagmanager.php
@@ -124,10 +124,7 @@ class SystemTagManager implements ISystemTagManager {
 
 		if (!empty($nameSearchPattern)) {
 			$query->andWhere(
-				$query->expr()->like(
-					'name',
-					$query->expr()->literal('%' . $this->connection->escapeLikeParameter($nameSearchPattern). '%')
-				)
+				$query->expr()->like('name', $query->createNamedParameter('%' . $this->connection->escapeLikeParameter($nameSearchPattern) . '%'))
 			);
 		}
 


### PR DESCRIPTION
$nameSearchPattern was passed in and directly appended to the SQL query. Luckily the code path isn't reached anywhere in Nextcloud or the included apps.
