### PR TITLE
[master] Use paramterized parameter for \OC\SystemTag\SystemTagManager

### DIFF
--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -140,10 +140,7 @@ class SystemTagManager implements ISystemTagManager {
 
 		if (!empty($nameSearchPattern)) {
 			$query->andWhere(
-				$query->expr()->like(
-					'name',
-					$query->expr()->literal('%' . $this->connection->escapeLikeParameter($nameSearchPattern). '%')
-				)
+				$query->expr()->like('name', $query->createNamedParameter('%' . $this->connection->escapeLikeParameter($nameSearchPattern) . '%'))
 			);
 		}
 


### PR DESCRIPTION
$nameSearchPattern was passed in and directly appended to the SQL query. Luckily the code path isn't reached anywhere in Nextcloud or the included apps.
