### PR TITLE
Changing name of default logfile

### DIFF
--- a/apps/dav/tests/travis/caldav/script.sh
+++ b/apps/dav/tests/travis/caldav/script.sh
@@ -16,6 +16,6 @@ PYTHONPATH="$SCRIPTPATH/pycalendar/src" python testcaldav.py --print-details-onf
 
 RESULT=$?
 
-tail "$/../../../../../data-autotest/owncloud.log"
+tail "$/../../../../../data-autotest/nextcloud.log"
 
 exit $RESULT

--- a/apps/dav/tests/travis/carddav/script.sh
+++ b/apps/dav/tests/travis/carddav/script.sh
@@ -17,6 +17,6 @@ PYTHONPATH="$SCRIPTPATH/pycalendar/src" python testcaldav.py --print-details-onf
 
 RESULT=$?
 
-tail "$/../../../../../data-autotest/owncloud.log"
+tail "$/../../../../../data-autotest/nextcloud.log"
 
 exit $RESULT

--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -40,7 +40,7 @@ kill $PHPPID
 kill $PHPPID_FED
 
 if [ -z $HIDE_OC_LOGS ]; then
-	tail "../../data/owncloud.log"
+	tail "../../data/nextcloud.log"
 fi
 
 exit $RESULT

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -549,7 +549,7 @@ $CONFIG = array(
  */
 
 /**
- * By default the Nextcloud logs are sent to the ``owncloud.log`` file in the
+ * By default the Nextcloud logs are sent to the ``nextcloud.log`` file in the
  * default Nextcloud data directory.
  * If syslogging is desired, set this parameter to ``syslog``.
  * Setting this parameter to ``errorlog`` will use the PHP error_log function
@@ -559,9 +559,9 @@ $CONFIG = array(
 
 /**
  * Log file path for the Nextcloud logging type.
- * Defaults to ``[datadirectory]/owncloud.log``
+ * Defaults to ``[datadirectory]/nextcloud.log``
  */
-'logfile' => '/var/log/owncloud.log',
+'logfile' => '/var/log/nextcloud.log',
 
 /**
  * Loglevel to start logging at. Valid values are: 0 = Debug, 1 = Info, 2 =

--- a/core/Command/Log/OwnCloud.php
+++ b/core/Command/Log/OwnCloud.php
@@ -95,7 +95,7 @@ class OwnCloud extends Command {
 		$output->writeln('Log backend ownCloud: '.$enabledText);
 
 		$dataDir = $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT.'/data');
-		$defaultLogFile = rtrim($dataDir, '/').'/owncloud.log';
+		$defaultLogFile = rtrim($dataDir, '/').'/nextcloud.log';
 		$output->writeln('Log file: '.$this->config->getSystemValue('logfile', $defaultLogFile));
 
 		$rotateSize = $this->config->getSystemValue('log_rotate_size', 0);

--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -300,7 +300,7 @@ class Upgrade extends Command {
 			//Possible scenario: ownCloud core is updated but an app failed
 			$output->writeln('<warning>ownCloud is in maintenance mode</warning>');
 			$output->write('<comment>Maybe an upgrade is already in process. Please check the '
-				. 'logfile (data/owncloud.log). If you want to re-run the '
+				. 'logfile (data/nextcloud.log). If you want to re-run the '
 				. 'upgrade procedure, remove the "maintenance mode" from '
 				. 'config.php and call this script again.</comment>'
 				, true);

--- a/issue_template.md
+++ b/issue_template.md
@@ -94,7 +94,7 @@ Eventually replace sensitive data as the name/IP-address of your LDAP server or 
 Insert your webserver log here
 ```
 
-#### Nextcloud log (data/owncloud.log)
+#### Nextcloud log (data/nextcloud.log)
 ```
 Insert your Nextcloud log here
 ```

--- a/lib/base.php
+++ b/lib/base.php
@@ -754,8 +754,8 @@ class OC {
 		$systemConfig = \OC::$server->getSystemConfig();
 		if ($systemConfig->getValue('installed', false) && $systemConfig->getValue('log_rotate_size', false) && !self::checkUpgrade(false)) {
 			//don't try to do this before we are properly setup
-			//use custom logfile path if defined, otherwise use default of owncloud.log in data directory
-			\OCP\BackgroundJob::registerJob('OC\Log\Rotate', $systemConfig->getValue('logfile', $systemConfig->getValue('datadirectory', OC::$SERVERROOT . '/data') . '/owncloud.log'));
+			//use custom logfile path if defined, otherwise use default of nextcloud.log in data directory
+			\OCP\BackgroundJob::registerJob('OC\Log\Rotate', $systemConfig->getValue('logfile', $systemConfig->getValue('datadirectory', OC::$SERVERROOT . '/data') . '/nextcloud.log'));
 		}
 	}
 

--- a/lib/private/Log/Owncloud.php
+++ b/lib/private/Log/Owncloud.php
@@ -33,7 +33,7 @@ namespace OC\Log;
 /**
  * logging utilities
  *
- * Log is saved at data/owncloud.log (on default)
+ * Log is saved at data/nextcloud.log (on default)
  */
 
 class Owncloud {
@@ -44,7 +44,7 @@ class Owncloud {
 	 */
 	public static function init() {
 		$systemConfig = \OC::$server->getSystemConfig();
-		$defaultLogFile = $systemConfig->getValue("datadirectory", \OC::$SERVERROOT.'/data').'/owncloud.log';
+		$defaultLogFile = $systemConfig->getValue("datadirectory", \OC::$SERVERROOT.'/data').'/nextcloud.log';
 		self::$logFile = $systemConfig->getValue("logfile", $defaultLogFile);
 
 		/**

--- a/tests/Core/Command/Log/OwnCloudTest.php
+++ b/tests/Core/Command/Log/OwnCloudTest.php
@@ -101,7 +101,7 @@ class OwnCloudTest extends TestCase {
 			->will($this->returnValueMap([
 				['log_type', 'owncloud', 'log_type_value'],
 				['datadirectory', \OC::$SERVERROOT.'/data', '/data/directory/'],
-				['logfile', '/data/directory/owncloud.log', '/var/log/owncloud.log'],
+				['logfile', '/data/directory/nextcloud.log', '/var/log/nextcloud.log'],
 				['log_rotate_size', 0, 5 * 1024 * 1024],
 			]));
 
@@ -110,7 +110,7 @@ class OwnCloudTest extends TestCase {
 			->with('Log backend ownCloud: disabled');
 		$this->consoleOutput->expects($this->at(1))
 			->method('writeln')
-			->with('Log file: /var/log/owncloud.log');
+			->with('Log file: /var/log/nextcloud.log');
 		$this->consoleOutput->expects($this->at(2))
 			->method('writeln')
 			->with('Rotate at: 5 MB');

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -269,7 +269,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	 */
 	static protected function tearDownAfterClassCleanStrayDataFiles($dataDir) {
 		$knownEntries = array(
-			'owncloud.log' => true,
+			'nextcloud.log' => true,
 			'owncloud.db' => true,
 			'.ocdata' => true,
 			'..' => true,

--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -173,8 +173,8 @@ cat $BASEDIR/config/config.php
 echo "data directory:"
 ls -ll $DATADIR
 
-echo "owncloud.log:"
-[ -f "$DATADIR/owncloud.log" ] && cat $DATADIR/owncloud.log
-[ -f "$BASEDIR/data/owncloud.log" ] && cat $BASEDIR/data/owncloud.log
+echo "nextcloud.log:"
+[ -f "$DATADIR/nextcloud.log" ] && cat $DATADIR/nextcloud.log
+[ -f "$BASEDIR/data/nextcloud.log" ] && cat $BASEDIR/data/nextcloud.log
 
 cd $BASEDIR


### PR DESCRIPTION
# Change 'owncloud.log' to 'nextcloud.log'

The default name for the logfile should reflect the projects name.
Fixing #293  
