### PR TITLE
Add large sidebar previews for text files

### DIFF
--- a/apps/files/css/detailsView.css
+++ b/apps/files/css/detailsView.css
@@ -67,11 +67,12 @@
 	background-size: contain;
 }
 
-#app-sidebar .text {
+#app-sidebar .large.text {
 	overflow-y: scroll;
 	overflow-x: hidden;
-	padding-left: 5px;
+	padding-top: 15px;
 	font-size: 80%;
+	margin-left: 0;
 }
 
 #app-sidebar .thumbnail {

--- a/apps/files/css/detailsView.css
+++ b/apps/files/css/detailsView.css
@@ -32,17 +32,17 @@
 	float: left;
 }
 
-#app-sidebar .thumbnailContainer.image {
+#app-sidebar .thumbnailContainer.large {
 	margin-left: -15px;
 	margin-right: -35px; /* 15 + 20 for the close button */
 	margin-top: -15px;
 }
 
-#app-sidebar .thumbnailContainer.image.portrait {
+#app-sidebar .thumbnailContainer.large.portrait {
 	margin: 0; /* if we don't fit the image anyway we give it back the margin */
 }
 
-#app-sidebar .image .thumbnail {
+#app-sidebar .large .thumbnail {
 	width:100%;
 	display:block;
 	background-repeat: no-repeat;
@@ -53,18 +53,25 @@
 	height: auto;
 }
 
-#app-sidebar .image .thumbnail .stretcher {
+#app-sidebar .large .thumbnail .stretcher {
 	content: '';
 	display: block;
 	padding-bottom: 56.25%; /* sets height of .thumbnail to 9/16 of the width */
 }
 
-#app-sidebar .image.portrait .thumbnail {
+#app-sidebar .large.portrait .thumbnail {
 	background-position: 50% top;
 }
 
-#app-sidebar .image.portrait .thumbnail {
+#app-sidebar .large.portrait .thumbnail {
 	background-size: contain;
+}
+
+#app-sidebar .text {
+	overflow-y: scroll;
+	overflow-x: hidden;
+	padding-left: 5px;
+	font-size: 80%;
 }
 
 #app-sidebar .thumbnail {

--- a/apps/files/js/sidebarpreviewmanager.js
+++ b/apps/files/js/sidebarpreviewmanager.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2015
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+(function () {
+	SidebarPreviewManager = function (fileList) {
+		this._fileList = fileList;
+	};
+
+	SidebarPreviewManager.prototype = {
+		loadPreview: function (model, $thumbnailDiv, $thumbnailContainer) {
+			// todo allow plugins to register custom handlers by mimetype
+			this.fallbackPreview(model, $thumbnailDiv, $thumbnailContainer);
+		},
+
+		// previews for images and mimetype icons
+		fallbackPreview: function (model, $thumbnailDiv, $thumbnailContainer) {
+			var isImage = model.isImage();
+			var maxImageWidth = $thumbnailContainer.parent().width() + 50;  // 50px for negative margins
+			var maxImageHeight = maxImageWidth / (16 / 9);
+			var smallPreviewSize = 75;
+
+			var isLandscape = function (img) {
+				return img.width > (img.height * 1.2);
+			};
+
+			var isSmall = function (img) {
+				return (img.width * 1.1) < (maxImageWidth * window.devicePixelRatio);
+			};
+
+			var getTargetHeight = function (img) {
+				if (isImage) {
+					var targetHeight = img.height / window.devicePixelRatio;
+					if (targetHeight <= smallPreviewSize) {
+						targetHeight = smallPreviewSize;
+					}
+					return targetHeight;
+				} else {
+					return smallPreviewSize;
+				}
+			};
+
+			var getTargetRatio = function (img) {
+				var ratio = img.width / img.height;
+				if (ratio > 16 / 9) {
+					return ratio;
+				} else {
+					return 16 / 9;
+				}
+			};
+
+			this._fileList.lazyLoadPreview({
+				path: model.getFullPath(),
+				mime: model.get('mimetype'),
+				etag: model.get('etag'),
+				y: isImage ? maxImageHeight : smallPreviewSize,
+				x: isImage ? maxImageWidth : smallPreviewSize,
+				a: isImage ? 1 : null,
+				mode: isImage ? 'cover' : null,
+				callback: function (previewUrl, img) {
+					$thumbnailDiv.previewImg = previewUrl;
+
+					// as long as we only have the mimetype icon, we only save it in case there is no preview
+					if (!img) {
+						return;
+					}
+					$thumbnailDiv.removeClass('icon-loading icon-32');
+					var targetHeight = getTargetHeight(img);
+					if (isImage && targetHeight > smallPreviewSize) {
+						$thumbnailContainer.addClass((isLandscape(img) && !isSmall(img)) ? 'landscape' : 'portrait');
+						$thumbnailContainer.addClass('image');
+					}
+
+					// only set background when we have an actual preview
+					// when we don't have a preview we show the mime icon in the error handler
+					$thumbnailDiv.css({
+						'background-image': 'url("' + previewUrl + '")',
+						height: (targetHeight > smallPreviewSize) ? 'auto' : targetHeight,
+						'max-height': isSmall(img) ? targetHeight : null
+					});
+
+					var targetRatio = getTargetRatio(img);
+					$thumbnailDiv.find('.stretcher').css({
+						'padding-bottom': (100 / targetRatio) + '%'
+					});
+				},
+				error: function () {
+					$thumbnailDiv.removeClass('icon-loading icon-32');
+					$thumbnailContainer.removeClass('image'); //fall back to regular view
+					$thumbnailDiv.css({
+						'background-image': 'url("' + $thumbnailDiv.previewImg + '")'
+					});
+				}
+			});
+		}
+	};
+
+	OCA.Files.SidebarPreviewManager = SidebarPreviewManager;
+})();

--- a/apps/files/js/sidebarpreviewtext.js
+++ b/apps/files/js/sidebarpreviewtext.js
@@ -29,7 +29,7 @@
 				var $textPreview = $('<pre/>').text(content);
 				$thumbnailDiv.children('.stretcher').remove();
 				$thumbnailDiv.append($textPreview);
-				$thumbnailContainer.height(previewHeight);
+				$thumbnailContainer.css("max-height", previewHeight);
 			}, function () {
 				fallback();
 			});

--- a/apps/files/js/sidebarpreviewtext.js
+++ b/apps/files/js/sidebarpreviewtext.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+(function () {
+	var SidebarPreview = function () {
+	};
+
+	SidebarPreview.prototype = {
+		attach: function (manager) {
+			manager.addPreviewHandler('text', this.handlePreview.bind(this));
+		},
+
+		handlePreview: function (model, $thumbnailDiv, $thumbnailContainer, fallback) {
+			console.log(model);
+			var previewWidth = $thumbnailContainer.parent().width() + 50;  // 50px for negative margins
+			var previewHeight = previewWidth / (16 / 9);
+
+			this.getFileContent(model.getFullPath()).then(function (content) {
+				$thumbnailDiv.removeClass('icon-loading icon-32');
+				$thumbnailContainer.addClass('large');
+				$thumbnailContainer.addClass('text');
+				var $textPreview = $('<pre/>').text(content);
+				$thumbnailDiv.children('.stretcher').remove();
+				$thumbnailDiv.append($textPreview);
+				$thumbnailContainer.height(previewHeight);
+			}, function () {
+				fallback();
+			});
+		},
+
+		getFileContent: function (path) {
+			console.log(path);
+			var url = OC.linkToRemoteBase('files' + path);
+			console.log(url);
+			return $.get(url);
+		}
+	};
+
+	OC.Plugins.register('OCA.Files.SidebarPreviewManager', new SidebarPreview());
+})();

--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -174,6 +174,7 @@ class ViewController extends Controller {
 		\OCP\Util::addScript('files', 'favoritesplugin');
 
 		\OCP\Util::addScript('files', 'detailfileinfoview');
+		\OCP\Util::addScript('files', 'sidebarpreviewmanager');
 		\OCP\Util::addScript('files', 'detailtabview');
 		\OCP\Util::addScript('files', 'mainfileinfodetailview');
 		\OCP\Util::addScript('files', 'detailsview');

--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -175,6 +175,7 @@ class ViewController extends Controller {
 
 		\OCP\Util::addScript('files', 'detailfileinfoview');
 		\OCP\Util::addScript('files', 'sidebarpreviewmanager');
+		\OCP\Util::addScript('files', 'sidebarpreviewtext');
 		\OCP\Util::addScript('files', 'detailtabview');
 		\OCP\Util::addScript('files', 'mainfileinfodetailview');
 		\OCP\Util::addScript('files', 'detailsview');


### PR DESCRIPTION
Before:

![before](https://i.imgur.com/509HWkZ.png)

After:

![after](https://i.imgur.com/nt5ASIg.png)

Instead of showing a small, unreadable image of the text, we load in the full text to make it easy to quickly tell the contents of a file.
The size of the text preview is the same as the preview of (landscape) images and long texts can be scrolled.

This also adds the ability for apps to register custom thumbnails.

cc @nextcloud/designers 
