### PR TITLE
Add "goto" links for files in non-default file lists

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1387,7 +1387,7 @@
 				return;
 			}
 			this._setCurrentDir(targetDir, changeUrl, fileId);
-			this.reload().then(function(success){
+			return this.reload().then(function(success){
 				if (!success) {
 					self.changeDirectory(currentDir, true);
 				}

--- a/apps/files/js/gotoplugin.js
+++ b/apps/files/js/gotoplugin.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2016 Robin Appelman <robin@icewind.nl>
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+
+(function (OCA) {
+
+	OCA.Files = OCA.Files || {};
+
+	/**
+	 * @namespace OCA.Files.GotoPlugin
+	 *
+	 */
+	OCA.Files.GotoPlugin = {
+		name: 'Goto',
+
+		disallowedLists: [
+			'files',
+			'trashbin'
+		],
+
+		attach: function (fileList) {
+			if (this.disallowedLists.indexOf(fileList.id) !== -1) {
+				return;
+			}
+			var fileActions = fileList.fileActions;
+
+			fileActions.registerAction({
+				name: 'Goto',
+				displayName: t('files', 'View in folder'),
+				mime: 'all',
+				permissions: OC.PERMISSION_ALL,
+				iconClass: 'icon-goto nav-icon-extstoragemounts',
+				type: OCA.Files.FileActions.TYPE_DROPDOWN,
+				actionHandler: function (fileName, context) {
+					var fileModel = context.fileInfoModel;
+					OCA.Files.App.setActiveView('files', {silent: true});
+					OCA.Files.App.fileList.changeDirectory(fileModel.get('path'), true, true).then(function() {
+						OCA.Files.App.fileList.scrollTo(fileModel.get('name'));
+					});
+				},
+				render: function (actionSpec, isDefault, context) {
+					return fileActions._defaultRenderAction.call(fileActions, actionSpec, isDefault, context)
+						.removeClass('permanent');
+				}
+			});
+		}
+	};
+})(OCA);
+
+OC.Plugins.register('OCA.Files.FileList', OCA.Files.GotoPlugin);
+

--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -171,6 +171,7 @@ class ViewController extends Controller {
 
 		\OCP\Util::addScript('files', 'favoritesfilelist');
 		\OCP\Util::addScript('files', 'tagsplugin');
+		\OCP\Util::addScript('files', 'gotoplugin');
 		\OCP\Util::addScript('files', 'favoritesplugin');
 
 		\OCP\Util::addScript('files', 'detailfileinfoview');


### PR DESCRIPTION
Clicking on the "goto" link navigates you to the folder containing the file and highlights it.

![goto link](https://i.imgur.com/F1uk5ST.png)

This makes it easy to find a favorite/shared/tagged file in the context of it's folder, allowing things like moving them or finding other files in the folder.

todo:
- [ ] better icon

cc @nextcloud/designers
