### PR TITLE
Allow wildcard * to be used in trusted domains

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -58,6 +58,12 @@ $CONFIG = array(
  * Your list of trusted domains that users can log into. Specifying trusted
  * domains prevents host header poisoning. Do not remove this, as it performs
  * necessary security checks.
+ * You can specify:
+ * - the exact hostname of your host or virtual host, e.g. demo.example.org.
+ * - the exact hostname with permitted port, e.g. demo.example.org:443.
+ *   This disallows all other ports on this host
+ * - use * as a wildcard, e.g. ubos-raspberry-pi*.local will allow
+ *   ubos-raspberry-pi.local and ubos-raspberry-pi-2.local
  */
 'trusted_domains' =>
   array (

--- a/lib/private/Security/TrustedDomainHelper.php
+++ b/lib/private/Security/TrustedDomainHelper.php
@@ -84,7 +84,35 @@ class TrustedDomainHelper {
 			return true;
 		}
 
-		return in_array($domain, $trustedList, true);
-	}
+		if(in_array($domain, $trustedList, true)) {
+			return true;
+		}
 
+ 		// If a value contains a *, apply glob-style matching. Any second * is ignored.
+ 		foreach ($trustedList as $trusted) {
+ 			if($trusted == '*') {
+ 				return true;
+ 			}
+ 			$star = strpos($trusted, '*');
+ 			if($star === false) {
+ 				next;
+ 			}
+ 			if($star === 0) {
+ 				if(strrpos($domain, substr($trusted, 1)) !== false) {
+ 					return true;
+ 				}
+			} elseif($star === strlen($trusted)-1) {
+ 				if(strpos($domain, substr($trusted, 0, strlen($trusted)-1 )) !== false) {
+ 					return true;
+ 				}
+ 			} else {
+ 				if(strpos($domain, substr($trusted, 0, $star)) !== false
+ 				&& strrpos($domain, substr($trusted, $star+1 ), -strlen($trusted-$star-1)) !== false )
+ 				{
+ 					return true;
+ 				}
+ 			}
+ 		}
+ 		return false;
+	}
 }

--- a/lib/private/Security/TrustedDomainHelper.php
+++ b/lib/private/Security/TrustedDomainHelper.php
@@ -90,12 +90,12 @@ class TrustedDomainHelper {
 
  		// If a value contains a *, apply glob-style matching. Any second * is ignored.
  		foreach ($trustedList as $trusted) {
- 			if($trusted == '*') {
+ 			if($trusted === '*') {
  				return true;
  			}
  			$star = strpos($trusted, '*');
  			if($star === false) {
- 				next;
+ 				break;
  			}
  			if($star === 0) {
  				if(strrpos($domain, substr($trusted, 1)) !== false) {

--- a/lib/private/Security/TrustedDomainHelper.php
+++ b/lib/private/Security/TrustedDomainHelper.php
@@ -70,7 +70,7 @@ class TrustedDomainHelper {
 
 		// Read trusted domains from config
 		$trustedList = $this->config->getSystemValue('trusted_domains', []);
-		if(!is_array($trustedList)) {
+		if (!is_array($trustedList)) {
 			return false;
 		}
 
@@ -79,38 +79,14 @@ class TrustedDomainHelper {
 			return true;
 		}
 
-		// Compare with port appended
-		if(in_array($domainWithPort, $trustedList, true)) {
-			return true;
-		}
-
-		if(in_array($domain, $trustedList, true)) {
-			return true;
-		}
-
- 		// If a value contains a *, apply glob-style matching. Any second * is ignored.
- 		foreach ($trustedList as $trusted) {
- 			if($trusted === '*') {
+		// match, allowing for * wildcards
+		foreach ($trustedList as $trusted) {
+			if (gettype($trusted) !== 'string') {
+				break;
+			}
+			$regex = '/^' . join('.*', array_map(function($v) { return preg_quote($v, '/'); }, explode('*', $trusted))) . '$/';
+			if (preg_match($regex, $domain) || preg_match($regex, $domainWithPort)) {
  				return true;
- 			}
- 			$star = strpos($trusted, '*');
- 			if($star === false) {
- 				break;
- 			}
- 			if($star === 0) {
- 				if(strrpos($domain, substr($trusted, 1)) !== false) {
- 					return true;
- 				}
-			} elseif($star === strlen($trusted)-1) {
- 				if(strpos($domain, substr($trusted, 0, strlen($trusted)-1 )) !== false) {
- 					return true;
- 				}
- 			} else {
- 				if(strpos($domain, substr($trusted, 0, $star)) !== false
- 				&& strrpos($domain, substr($trusted, $star+1 ), -strlen($trusted-$star-1)) !== false )
- 				{
- 					return true;
- 				}
  			}
  		}
  		return false;

--- a/lib/private/Security/TrustedDomainHelper.php
+++ b/lib/private/Security/TrustedDomainHelper.php
@@ -78,13 +78,16 @@ class TrustedDomainHelper {
 		if (preg_match(Request::REGEX_LOCALHOST, $domain) === 1) {
 			return true;
 		}
-
-		// match, allowing for * wildcards
+		// Reject misformed domains in any case
+		if (strpos($domain,'-') === 0 || strpos($domain,'..') !== false) {
+			return false;
+		}
+		// Match, allowing for * wildcards
 		foreach ($trustedList as $trusted) {
 			if (gettype($trusted) !== 'string') {
 				break;
 			}
-			$regex = '/^' . join('.*', array_map(function($v) { return preg_quote($v, '/'); }, explode('*', $trusted))) . '$/';
+			$regex = '/^' . join('[-\.a-zA-Z0-9]*', array_map(function($v) { return preg_quote($v, '/'); }, explode('*', $trusted))) . '$/';
 			if (preg_match($regex, $domain) || preg_match($regex, $domainWithPort)) {
  				return true;
  			}

--- a/tests/lib/Security/TrustedDomainHelperTest.php
+++ b/tests/lib/Security/TrustedDomainHelperTest.php
@@ -102,6 +102,10 @@ class TrustedDomainHelperTest extends \Test\TestCase {
 			[$trustedHostTestList, 'abc.leadingwith.port:1234', false],
 			[$trustedHostTestList, 'trailingwith.port.abc:456', true],
 			[$trustedHostTestList, 'trailingwith.port.abc:123', false],
+			// bad hostname
+			[$trustedHostTestList, '-bad', false],
+			[$trustedHostTestList, '-bad.leading.host', false],
+			[$trustedHostTestList, 'bad..der.leading.host', false],
 		];
 	}
 }

--- a/tests/lib/Security/TrustedDomainHelperTest.php
+++ b/tests/lib/Security/TrustedDomainHelperTest.php
@@ -49,6 +49,11 @@ class TrustedDomainHelperTest extends \Test\TestCase {
 			'host.two.test',
 			'[1fff:0:a88:85a3::ac1f]',
 			'host.three.test:443',
+			'*.leading.host',
+			'trailing.host*',
+			'cen*ter',
+			'*.leadingwith.port:123',
+			'trailingwith.port*:456',
 		];
 		return [
 			// empty defaults to false with 8.1
@@ -76,7 +81,27 @@ class TrustedDomainHelperTest extends \Test\TestCase {
 			[$trustedHostTestList, 'localhost: evil.host', false],
 			// do not trust casting
 			[[1], '1', false],
+			// leading *
+			[$trustedHostTestList, 'abc.leading.host', true],
+			[$trustedHostTestList, 'abc.def.leading.host', true],
+			[$trustedHostTestList, 'abc.def.leading.host.another', false],
+			[$trustedHostTestList, 'abc.def.leading.host:123', true],
+			[$trustedHostTestList, 'leading.host', false],
+			// trailing *
+			[$trustedHostTestList, 'trailing.host', true],
+			[$trustedHostTestList, 'trailing.host.abc', true],
+			[$trustedHostTestList, 'trailing.host.abc.def', true],
+			[$trustedHostTestList, 'trailing.host.abc:123', true],
+			[$trustedHostTestList, 'another.trailing.host', false],
+			// center *
+			[$trustedHostTestList, 'center', true],
+			[$trustedHostTestList, 'cenxxxter', true],
+			[$trustedHostTestList, 'cen.x.y.ter', true],
+			// with port
+			[$trustedHostTestList, 'abc.leadingwith.port:123', true],
+			[$trustedHostTestList, 'abc.leadingwith.port:1234', false],
+			[$trustedHostTestList, 'trailingwith.port.abc:456', true],
+			[$trustedHostTestList, 'trailingwith.port.abc:123', false],
 		];
 	}
-
 }


### PR DESCRIPTION
This is to support setups where no reliable DNS entry is available (e.g. mDNS) or for simple-to-setup aliasing (e.g. *.example.com)

This time, I hope, tabs and formatting are all in the right places for your coding standards. We had been doing this patch just for UBOS, but now that you are doing checksums on PHP files, such as private patch leads to warnings in the management console, and I hope it can be merged into the main.

As using a \* in a trusted domain is entirely optional, this should have no security implications for the default setup.

If you'd like me to augment some existing tests, I'd appreciate a pointer to which tests.
