### PR TITLE
Added occ install option for database-port

### DIFF
--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -50,7 +50,7 @@ class Install extends Command {
 			->addOption('database', null, InputOption::VALUE_REQUIRED, 'Supported database type', 'sqlite')
 			->addOption('database-name', null, InputOption::VALUE_REQUIRED, 'Name of the database')
 			->addOption('database-host', null, InputOption::VALUE_REQUIRED, 'Hostname of the database', 'localhost')
-			->addOption('database-port', null, InputOption::VALUE_OPTIONAL, 'Port the database is listening on')
+			->addOption('database-port', null, InputOption::VALUE_REQUIRED, 'Port the database is listening on')
 			->addOption('database-user', null, InputOption::VALUE_REQUIRED, 'User name to connect to the database')
 			->addOption('database-pass', null, InputOption::VALUE_OPTIONAL, 'Password of the database user', null)
 			->addOption('database-table-prefix', null, InputOption::VALUE_OPTIONAL, 'Prefix for all tables (default: oc_)', null)

--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -50,6 +50,7 @@ class Install extends Command {
 			->addOption('database', null, InputOption::VALUE_REQUIRED, 'Supported database type', 'sqlite')
 			->addOption('database-name', null, InputOption::VALUE_REQUIRED, 'Name of the database')
 			->addOption('database-host', null, InputOption::VALUE_REQUIRED, 'Hostname of the database', 'localhost')
+			->addOption('database-port', null, InputOption::VALUE_OPTIONAL, 'Port the database is listening on')
 			->addOption('database-user', null, InputOption::VALUE_REQUIRED, 'User name to connect to the database')
 			->addOption('database-pass', null, InputOption::VALUE_OPTIONAL, 'Password of the database user', null)
 			->addOption('database-table-prefix', null, InputOption::VALUE_OPTIONAL, 'Prefix for all tables (default: oc_)', null)
@@ -106,6 +107,7 @@ class Install extends Command {
 		$dbUser = $input->getOption('database-user');
 		$dbPass = $input->getOption('database-pass');
 		$dbName = $input->getOption('database-name');
+		$dbPort = $input->getOption('database-port');
 		if ($db === 'oci') {
 			// an empty hostname needs to be read from the raw parameters
 			$dbHost = $input->getParameterOption('--database-host', '');
@@ -158,6 +160,7 @@ class Install extends Command {
 			'dbpass' => $dbPass,
 			'dbname' => $dbName,
 			'dbhost' => $dbHost,
+			'dbport' => $dbPort,
 			'dbtableprefix' => $dbTablePrefix,
 			'adminlogin' => $adminLogin,
 			'adminpass' => $adminPassword,

--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -42,6 +42,8 @@ abstract class AbstractDatabase {
 	/** @var string */
 	protected $dbHost;
 	/** @var string */
+	protected $dbPort;
+	/** @var string */
 	protected $tablePrefix;
 	/** @var IConfig */
 	protected $config;
@@ -78,11 +80,13 @@ abstract class AbstractDatabase {
 		$dbPass = $config['dbpass'];
 		$dbName = $config['dbname'];
 		$dbHost = !empty($config['dbhost']) ? $config['dbhost'] : 'localhost';
+		$dbPort = !empty($config['dbport']) ? $config['dbport'] : '';
 		$dbTablePrefix = isset($config['dbtableprefix']) ? $config['dbtableprefix'] : 'oc_';
 
 		$this->config->setSystemValues([
 			'dbname'		=> $dbName,
 			'dbhost'		=> $dbHost,
+			'dbport' => $dbPort,
 			'dbtableprefix'	=> $dbTablePrefix,
 		]);
 
@@ -90,6 +94,7 @@ abstract class AbstractDatabase {
 		$this->dbPassword = $dbPass;
 		$this->dbName = $dbName;
 		$this->dbHost = $dbHost;
+		$this->dbPort = $dbPort;
 		$this->tablePrefix = $dbTablePrefix;
 	}
 

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -100,8 +100,14 @@ class MySQL extends AbstractDatabase {
 				'tablePrefix' => $this->tablePrefix,
 		);
 
-		// adding port support
-		if (strpos($this->dbHost, ':')) {
+		// adding port support through installer
+		if(!empty($this->dbPort)) {
+			if (ctype_digit($this->dbPort)) {
+				$connectionParams['port'] = $this->dbPort;
+			} else {
+				$connectionParams['unix_socket'] = $this->dbPort;
+			}
+		} else if (strpos($this->dbHost, ':')) {
 			// Host variable may carry a port or socket.
 			list($host, $portOrSocket) = explode(':', $this->dbHost, 2);
 			if (ctype_digit($portOrSocket)) {

--- a/lib/private/Setup/OCI.php
+++ b/lib/private/Setup/OCI.php
@@ -63,12 +63,14 @@ class OCI extends AbstractDatabase {
 
 	public function setupDatabase($username) {
 		$e_host = addslashes($this->dbHost);
+		// adding slashes for security reasons
+		$e_port = addslashes($this->dbPort);
 		$e_dbname = addslashes($this->dbName);
 		//check if the database user has admin right
 		if ($e_host == '') {
 			$easy_connect_string = $e_dbname; // use dbname as easy connect name
 		} else {
-			$easy_connect_string = '//'.$e_host.'/'.$e_dbname;
+			$easy_connect_string = '//'.$e_host.(!empty($e_port) ? ":{$e_port}" : "").'/'.$e_dbname;
 		}
 		$this->logger->debug('connect string: ' . $easy_connect_string, ['app' => 'setup.oci']);
 		$connection = @oci_connect($this->dbUser, $this->dbPassword, $easy_connect_string);

--- a/lib/private/Setup/OCI.php
+++ b/lib/private/Setup/OCI.php
@@ -63,8 +63,8 @@ class OCI extends AbstractDatabase {
 
 	public function setupDatabase($username) {
 		$e_host = addslashes($this->dbHost);
-		// adding slashes for security reasons
-		$e_port = addslashes($this->dbPort);
+		// casting to int to avoid malicious input
+		$e_port = (int)$this->dbPort;
 		$e_dbname = addslashes($this->dbName);
 		//check if the database user has admin right
 		if ($e_host == '') {

--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -36,8 +36,8 @@ class PostgreSQL extends AbstractDatabase {
 
 		// adding port support through installer
 		if(!empty($this->dbPort)) {
-			// adding slashes for security reasons
-			$port = addslashes($this->dbPort);
+			// casting to int to avoid malicious input
+			$port = (int)$this->dbPort;
 		} else if(strpos($e_host, ':')) {
 			list($e_host, $port)=explode(':', $e_host, 2);
 		} else {

--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -34,8 +34,11 @@ class PostgreSQL extends AbstractDatabase {
 		$e_user = addslashes($this->dbUser);
 		$e_password = addslashes($this->dbPassword);
 
-		// Fix database with port connection
-		if(strpos($e_host, ':')) {
+		// adding port support through installer
+		if(!empty($this->dbPort)) {
+			// adding slashes for security reasons
+			$port = addslashes($this->dbPort);
+		} else if(strpos($e_host, ':')) {
 			list($e_host, $port)=explode(':', $e_host, 2);
 		} else {
 			$port=false;
@@ -51,8 +54,8 @@ class PostgreSQL extends AbstractDatabase {
 			$connection = @pg_connect($connection_string);
 
 			if(!$connection)
-				throw new \OC\DatabaseSetupException($this->trans->t('PostgreSQL username and/or password not valid'),
-						$this->trans->t('You need to enter either an existing account or the administrator.'));
+				throw new \OC\DatabaseSetupException($this->trans->t('PostgreSQL connection failed'),
+						$this->trans->t('Please check your connection details.'));
 		}
 		$e_user = pg_escape_string($this->dbUser);
 		//check for roles creation rights in postgresql


### PR DESCRIPTION
# Implemented non-standard database port on occ install
- Added optional input option --database-port in maintenance:install command
- Refactored the databases to store the database port as string, defaulting to an empty string
- Kept parsing hostname for port option in psql and mysql when no port was provided
- Changed the PostgreSQL connection error message
### Tested
- with MySQL TCP port
- with MySQL Unix Socket
- with PostgreSQL
### ToDo
- Testing with Oracle

Solves #271 
