### PR TITLE
Fix docker image naming issue for CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,36 +1,37 @@
 build:
-  integration:
-    image: morrisjobke/nextcloud-ci-php7:1.0.3
-    commands:
-      - git submodule update --init
-      - ./occ maintenance:install --admin-pass=admin
-      - cd build/integration
-      - ./run.sh
   jsunit:
-    image: morrisjobke/nextcloud-ci-jsunit:1.0.2
+    image: nextcloudci/jsunit:1.0.6
     commands:
       - ./autotest-js.sh
   sqlite:
-    image: morrisjobke/nextcloud-ci-php7:1.0
+    image: nextcloudci/php5.6:1.0.6
     commands:
       - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
       - git submodule update --init
       - ./occ maintenance:install --database-name oc_autotest --database-user oc_autotest --admin-user admin --admin-pass admin --database sqlite --database-pass=''
       - ./autotest.sh sqlite
   mysql:
-    image: morrisjobke/nextcloud-ci-php7:1.0.4
+    image: nextcloudci/php5.6:1.0.6
     commands:
       - sleep 15 # gives the database enough time to initialize
       - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
       - git submodule update --init
       - ./autotest.sh mysql
   postgres:
-    image: morrisjobke/nextcloud-ci-php7:1.0
+    image: nextcloudci/php5.6:1.0.6
     commands:
       - sleep 10 # gives the database enough time to initialize
       - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
       - git submodule update --init
       - ./autotest.sh pgsql
+  integration:
+    image: nextcloudci/php5.6:1.0.6
+    commands:
+      - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
+      - git submodule update --init
+      - ./occ maintenance:install --admin-pass=admin
+      - cd build/integration
+      - ./run.sh
 
 compose:
   cache:


### PR DESCRIPTION
- wrongly named PHP7 - it is PHP 5.6
- moved integration tests at the very end

cc @rullzer @LukasReschke @mar1u5 
