### PR TITLE
Add getShareTypesInFolder to optimize folder listening

### DIFF
--- a/apps/dav/lib/Connector/Sabre/SharesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/SharesPlugin.php
@@ -136,6 +136,30 @@ class SharesPlugin extends \Sabre\DAV\ServerPlugin {
 		return $shareTypes;
 	}
 
+	private function getSharesTypesInFolder(\OCP\Files\Folder $node) {
+		$shares = $this->shareManager->getSharesInFolder(
+			$this->userId,
+			$node,
+			false
+		);
+
+		$children = $node->getDirectoryListing();
+
+		$values = array_map(function (\OCP\Files\Node $node) use ($shares) {
+			/** @var IShare[] $shares */
+			$shares = (isset($shares[$node->getId()])) ? $shares[$node->getId()] : [];
+			return array_map(function(IShare $share) {
+				return $share->getShareType();
+			}, $shares);
+		}, $children);
+
+		$keys = array_map(function (\OCP\Files\Node $node) {
+			return $node->getId();
+		}, $children);
+
+		return array_combine($keys, $values);
+	}
+
 	/**
 	 * Adds shares to propfind response
 	 *
@@ -156,15 +180,15 @@ class SharesPlugin extends \Sabre\DAV\ServerPlugin {
 			&& !is_null($propFind->getStatus(self::SHARETYPES_PROPERTYNAME))
 		) {
 			$folderNode = $this->userFolder->get($sabreNode->getPath());
-			$children = $folderNode->getDirectoryListing();
 
+			$childShares = $this->getSharesTypesInFolder($folderNode);
 			$this->cachedShareTypes[$folderNode->getId()] = $this->getShareTypes($folderNode);
-			foreach ($children as $childNode) {
-				$this->cachedShareTypes[$childNode->getId()] = $this->getShareTypes($childNode);
+			foreach ($childShares as $id => $shares) {
+				$this->cachedShareTypes[$id] = $shares;
 			}
 		}
 
-		$propFind->handle(self::SHARETYPES_PROPERTYNAME, function() use ($sabreNode) {
+		$propFind->handle(self::SHARETYPES_PROPERTYNAME, function () use ($sabreNode) {
 			if (isset($this->cachedShareTypes[$sabreNode->getId()])) {
 				$shareTypes = $this->cachedShareTypes[$sabreNode->getId()];
 			} else {

--- a/apps/dav/lib/Connector/Sabre/SharesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/SharesPlugin.php
@@ -148,9 +148,12 @@ class SharesPlugin extends \Sabre\DAV\ServerPlugin {
 		$values = array_map(function (\OCP\Files\Node $node) use ($shares) {
 			/** @var IShare[] $shares */
 			$shares = (isset($shares[$node->getId()])) ? $shares[$node->getId()] : [];
-			return array_map(function(IShare $share) {
+			$types = array_map(function(IShare $share) {
 				return $share->getShareType();
 			}, $shares);
+			$types = array_unique($types);
+			sort($types);
+			return $types;
 		}, $children);
 
 		$keys = array_map(function (\OCP\Files\Node $node) {

--- a/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
@@ -206,6 +206,14 @@ class SharesPluginTest extends \Test\TestCase {
 			->method('get')
 			->with('/subdir')
 			->will($this->returnValue($node));
+		
+		$dummyShares = array_map(function($type) {
+			$share = $this->getMock('\OCP\Share\IShare');
+			$share->expects($this->any())
+				->method('getShareType')
+				->will($this->returnValue($type));
+			return $share;
+		}, $shareTypes);
 
 		$this->shareManager->expects($this->any())
 			->method('getSharesBy')
@@ -222,6 +230,17 @@ class SharesPluginTest extends \Test\TestCase {
 				}
 
 				return [];
+			}));
+
+		$this->shareManager->expects($this->any())
+			->method('getSharesInFolder')
+			->with(
+				$this->equalTo('user1'),
+				$this->anything(),
+				$this->equalTo(false)
+			)
+			->will($this->returnCallback(function ($userId, $node, $flag) use ($shareTypes, $dummyShares) {
+				return [111 => $dummyShares];
 			}));
 
 		// simulate sabre recursive PROPFIND traversal

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -27,6 +27,7 @@
 namespace OCA\FederatedFileSharing;
 
 use OC\Share20\Share;
+use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\IConfig;
 use OCP\IL10N;
@@ -564,8 +565,45 @@ class FederatedShareProvider implements IShareProvider {
 	}
 
 
-	public function getSharesInFolder($userId, $node, $reshares) {
-		return [];//TODO
+	public function getSharesInFolder($userId, Folder $node, $reshares) {
+		$qb = $this->dbConnection->getQueryBuilder();
+		$qb->select('*')
+			->from('share', 's')
+			->andWhere($qb->expr()->orX(
+				$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
+				$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
+			))
+			->andWhere(
+				$qb->expr()->eq('shareType', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_REMOTE))
+			);
+
+		/**
+		 * Reshares for this user are shares where they are the owner.
+		 */
+		if ($reshares === false) {
+			$qb->andWhere($qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId)));
+		} else {
+			$qb->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->eq('uid_owner', $qb->createNamedParameter($userId)),
+					$qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId))
+				)
+			);
+		}
+
+		$qb->innerJoin('s', 'filecache' ,'f', 's.file_source = f.fileid');
+		$qb->andWhere($qb->expr()->eq('f.parent', $qb->createNamedParameter($node->getId())));
+
+		$qb->orderBy('id');
+
+		$cursor = $qb->execute();
+		$shares = [];
+		while ($data = $cursor->fetch()) {
+			$shares[$data['fileid']][] = $this->createShareObject($data);
+		}
+		$cursor->closeCursor();
+
+		return $shares;
 	}
 
 	/**

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -563,6 +563,11 @@ class FederatedShareProvider implements IShareProvider {
 		return;
 	}
 
+
+	public function getSharesInFolder($userId, $node, $reshares) {
+		return [];//TODO
+	}
+
 	/**
 	 * @inheritdoc
 	 */

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -574,7 +574,7 @@ class FederatedShareProvider implements IShareProvider {
 				$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
 			))
 			->andWhere(
-				$qb->expr()->eq('shareType', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_REMOTE))
+				$qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_REMOTE))
 			);
 
 		/**

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -454,6 +454,49 @@ class DefaultShareProvider implements IShareProvider {
 		return $share;
 	}
 
+	public function getSharesInFolder($userId, $node, $reshares) {
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->select('*')
+			->from('share', 's')
+			->andWhere($qb->expr()->orX(
+				$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
+				$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
+			));
+
+		$qb->andWhere($qb->expr()->orX(
+			$qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_USER)),
+			$qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_GROUP))
+		));
+
+		/**
+		 * Reshares for this user are shares where they are the owner.
+		 */
+		if ($reshares === false) {
+			$qb->andWhere($qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId)));
+		} else {
+			$qb->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->eq('uid_owner', $qb->createNamedParameter($userId)),
+					$qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId))
+				)
+			);
+		}
+
+		$qb->innerJoin('s', 'filecache' ,'f', 's.file_source = f.fileid');
+		$qb->andWhere($qb->expr()->eq('f.parent', $qb->createNamedParameter($node->getId())));
+
+		$qb->orderBy('id');
+
+		$cursor = $qb->execute();
+		$shares = [];
+		while ($data = $cursor->fetch()) {
+			$shares[$data['fileid']][] = $this->createShare($data);
+		}
+		$cursor->closeCursor();
+
+		return $shares;
+	}
+
 	/**
 	 * @inheritdoc
 	 */

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -466,7 +466,8 @@ class DefaultShareProvider implements IShareProvider {
 
 		$qb->andWhere($qb->expr()->orX(
 			$qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_USER)),
-			$qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_GROUP))
+			$qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_GROUP)),
+			$qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_LINK))
 		));
 
 		/**

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -24,6 +24,7 @@
 namespace OC\Share20;
 
 use OCP\Files\File;
+use OCP\Files\Folder;
 use OCP\Share\IShareProvider;
 use OC\Share20\Exception\InvalidShare;
 use OC\Share20\Exception\ProviderException;
@@ -454,7 +455,7 @@ class DefaultShareProvider implements IShareProvider {
 		return $share;
 	}
 
-	public function getSharesInFolder($userId, $node, $reshares) {
+	public function getSharesInFolder($userId, Folder $node, $reshares) {
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->select('*')
 			->from('share', 's')

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -883,7 +883,7 @@ class Manager implements IManager {
 		$provider->move($share, $recipientId);
 	}
 
-	public function getSharesInFolder($userId, Node $node, $reshares = false) {
+	public function getSharesInFolder($userId, Folder $node, $reshares = false) {
 		$providers = $this->factory->getAllProviders();
 
 		return array_reduce($providers, function($shares, IShareProvider $provider) use ($userId, $node, $reshares) {

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -887,7 +887,15 @@ class Manager implements IManager {
 		$providers = $this->factory->getAllProviders();
 
 		return array_reduce($providers, function($shares, IShareProvider $provider) use ($userId, $node, $reshares) {
-			return $shares + $provider->getSharesInFolder($userId, $node, $reshares);
+			$newShares = $provider->getSharesInFolder($userId, $node, $reshares);
+			foreach ($newShares as $fid => $data) {
+				if (!isset($shares[$fid])) {
+					$shares[$fid] = [];
+				}
+
+				$shares[$fid] = array_merge($shares[$fid], $data);
+			}
+			return $shares;
 		}, []);
 	}
 

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -34,6 +34,7 @@ use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountManager;
+use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\IConfig;
 use OCP\IGroupManager;
@@ -48,6 +49,7 @@ use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use OCP\Share\IShareProvider;
 
 /**
  * This class is the communication hub for all sharing related operations.
@@ -879,6 +881,14 @@ class Manager implements IManager {
 		$provider = $this->factory->getProvider($providerId);
 
 		$provider->move($share, $recipientId);
+	}
+
+	public function getSharesInFolder($userId, Node $node, $reshares = false) {
+		$providers = $this->factory->getAllProviders();
+
+		return array_reduce($providers, function($shares, IShareProvider $provider) use ($userId, $node, $reshares) {
+			return $shares + $provider->getSharesInFolder($userId, $node, $reshares);
+		}, []);
 	}
 
 	/**

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -163,4 +163,8 @@ class ProviderFactory implements IProviderFactory {
 
 		return $provider;
 	}
+
+	public function getAllProviders() {
+		return [$this->defaultShareProvider(), $this->federatedShareProvider()];
+	}
 }

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -22,6 +22,7 @@
 
 namespace OCP\Share;
 
+use OCP\Files\Folder;
 use OCP\Files\Node;
 
 use OCP\Share\Exceptions\ShareNotFound;
@@ -91,12 +92,12 @@ interface IManager {
 	 * Get all shares shared by (initiated) by the provided user in a folder.
 	 *
 	 * @param string $userId
-	 * @param Node|null $node
+	 * @param Folder $node
 	 * @param bool $reshares
 	 * @return IShare[]
 	 * @since 9.2.0
 	 */
-	public function getSharesInFolder($userId, Node $node, $reshares = false);
+	public function getSharesInFolder($userId, Folder $node, $reshares = false);
 
 	/**
 	 * Get shares shared by (initiated) by the provided user.

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -88,6 +88,17 @@ interface IManager {
 	public function moveShare(IShare $share, $recipientId);
 
 	/**
+	 * Get all shares shared by (initiated) by the provided user in a folder.
+	 *
+	 * @param string $userId
+	 * @param Node|null $node
+	 * @param bool $reshares
+	 * @return IShare[]
+	 * @since 9.2.0
+	 */
+	public function getSharesInFolder($userId, Node $node, $reshares = false);
+
+	/**
 	 * Get shares shared by (initiated) by the provided user.
 	 *
 	 * @param string $userId

--- a/lib/public/Share/IProviderFactory.php
+++ b/lib/public/Share/IProviderFactory.php
@@ -55,4 +55,10 @@ interface IProviderFactory {
 	 * @since 9.0.0
 	 */
 	public function getProviderForType($shareType);
+
+	/**
+	 * @return IShareProvider[]
+	 * @since 9.2.0
+	 */
+	public function getAllProviders();
 }

--- a/lib/public/Share/IShareProvider.php
+++ b/lib/public/Share/IShareProvider.php
@@ -92,6 +92,17 @@ interface IShareProvider {
 	public function move(\OCP\Share\IShare $share, $recipient);
 
 	/**
+	 * Get all shares by the given user in a folder
+	 *
+	 * @param string $userId
+	 * @param Node|null $node
+	 * @param bool $reshares Also get the shares where $user is the owner instead of just the shares where $user is the initiator
+	 * @return \OCP\Share\IShare[]
+	 * @since 9.2.0
+	 */
+	public function getSharesInFolder($userId, $node, $reshares);
+
+	/**
 	 * Get all shares by the given user
 	 *
 	 * @param string $userId

--- a/lib/public/Share/IShareProvider.php
+++ b/lib/public/Share/IShareProvider.php
@@ -22,6 +22,7 @@
 
 namespace OCP\Share;
 
+use OCP\Files\Folder;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Files\Node;
 
@@ -95,12 +96,12 @@ interface IShareProvider {
 	 * Get all shares by the given user in a folder
 	 *
 	 * @param string $userId
-	 * @param Node|null $node
+	 * @param Folder $node
 	 * @param bool $reshares Also get the shares where $user is the owner instead of just the shares where $user is the initiator
 	 * @return \OCP\Share\IShare[]
 	 * @since 9.2.0
 	 */
-	public function getSharesInFolder($userId, $node, $reshares);
+	public function getSharesInFolder($userId, Folder $node, $reshares);
 
 	/**
 	 * Get all shares by the given user

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -2564,4 +2564,13 @@ class DummyFactory implements IProviderFactory {
 	public function getProviderForType($shareType) {
 		return $this->provider;
 	}
+
+	/**
+	 * @return IShareProvider[]
+	 */
+	public function getAllProviders() {
+		return [$this->provider];
+	}
+
+
 }


### PR DESCRIPTION
When getting share info for a folder, instead of looping over the childs and querying each one individually, use a single query to get the share status of all childs.

Gives a [very significant improvement](https://blackfire.io/profiles/compare/6ee80ec7-6db6-433d-b87f-9ca8ed5c5d12/graph) when loading large folders in the webui (not sure if the sync client is affected, depends on the properties requested)

TODO
- [x] also show federated shares
- [x] tests

cc @rullzer 
