### PR TITLE
CI exclude ObjectStore tests on normal runs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,35 +9,35 @@ build:
       - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
       - git submodule update --init
       - ./occ maintenance:install --database-name oc_autotest --database-user oc_autotest --admin-user admin --admin-pass admin --database sqlite --database-pass=''
-      - NOCOVERAGE=true ./autotest.sh sqlite
+      - TESTSUITE=main NOCOVERAGE=true ./autotest.sh sqlite
   sqlite-php5.5:
     image: nextcloudci/php5.5:1.0.7
     commands:
       - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
       - git submodule update --init
       - ./occ maintenance:install --database-name oc_autotest --database-user oc_autotest --admin-user admin --admin-pass admin --database sqlite --database-pass=''
-      - NOCOVERAGE=true ./autotest.sh sqlite
+      - TESTSUITE=main NOCOVERAGE=true ./autotest.sh sqlite
   sqlite:
     image: nextcloudci/php5.6:1.0.6
     commands:
       - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
       - git submodule update --init
       - ./occ maintenance:install --database-name oc_autotest --database-user oc_autotest --admin-user admin --admin-pass admin --database sqlite --database-pass=''
-      - ./autotest.sh sqlite
+      - TESTSUITE=main ./autotest.sh sqlite
   mysql:
     image: nextcloudci/php5.6:1.0.6
     commands:
       - sleep 15 # gives the database enough time to initialize
       - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
       - git submodule update --init
-      - ./autotest.sh mysql
+      - TESTSUITE=main ./autotest.sh mysql
   postgres:
     image: nextcloudci/php5.6:1.0.6
     commands:
       - sleep 10 # gives the database enough time to initialize
       - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
       - git submodule update --init
-      - ./autotest.sh pgsql
+      - TESTSUITE=main ./autotest.sh pgsql
   integration:
     image: nextcloudci/php5.6:1.0.6
     commands:

--- a/autotest.sh
+++ b/autotest.sh
@@ -310,15 +310,23 @@ function execute_tests {
 		echo "No coverage"
 	fi
 
+	SUITE=''
+	if [ -n "$TESTSUITE" ]; then
+		echo "Running testsuite: ${TESTSUITE}"
+		SUITE="--testsuite $TESTSUITE"
+	else
+		echo "Running all testsuites"
+	fi
+
 	if [ -d "$2" ]; then
 	    for f in $(find "$2" -name '*.php'); do
-			echo "${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" / "$f" "$3"
-			"${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$f" "$3"
+			echo "${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER $SUITE --log-junit "autotest-results-$DB.xml" "$2" / "$f" "$3"
+			"${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER $SUITE --log-junit "autotest-results-$DB.xml" "$f" "$3"
 			RESULT=$?
 	    done;
 	else
-	    echo "${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
-	    "${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
+	    echo "${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER $SUITE --log-junit "autotest-results-$DB.xml" "$2" "$3"
+	    "${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER $SUITE --log-junit "autotest-results-$DB.xml" "$2" "$3"
 		RESULT=$?
 	fi
 

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -6,13 +6,22 @@
 		 timeoutForMediumTests="900"
 		 timeoutForLargeTests="900"
 >
-	<testsuite name='ownCloud'>
-		<directory suffix='.php'>lib/</directory>
-		<directory suffix='.php'>settings/</directory>
-		<directory suffix='.php'>core/</directory>
-		<directory suffix='.php'>ocs-provider/</directory>
-		<file>apps.php</file>
-	</testsuite>
+	<testsuites>
+		<testsuite name='main'>
+			<directory suffix='.php'>lib/</directory>
+			<directory suffix='.php'>settings/</directory>
+			<directory suffix='.php'>core/</directory>
+			<directory suffix='.php'>ocs-provider/</directory>
+			<file>apps.php</file>
+			<exclude>
+				<directory suffix=".php">lib/Files/ObjectStore/</directory>
+			</exclude>
+		</testsuite>
+		<testsuite name='ObjectStore'>
+			<directory suffix="Test.php">lib/Files/ObjectStore/</directory>
+		</testsuite>
+	</testsuites>
+
 	<!-- filters for code coverage -->
 	<filter>
 		<!-- whitelist processUncoveredFilesFromWhitelist="true" -->


### PR DESCRIPTION
Since we can't run them anyway we better exclude them properly

I'm still thinking if we are better of doing this with groups? Or different suites.
Same approach I want to take with testing the different memcache backends. Isolate them in suites. And just run them with the required backend available.

CC: @MorrisJobke 
