### PR TITLE
fix check if the certificate bundle needs to be updated

### DIFF
--- a/lib/private/Security/CertificateManager.php
+++ b/lib/private/Security/CertificateManager.php
@@ -238,8 +238,9 @@ class CertificateManager implements ICertificateManager {
 		if (!$this->view->file_exists($targetBundle)) {
 			return true;
 		}
+
 		if (!is_null($uid)) { // also depend on the system bundle
-			$sourceBundles[] = $this->view->filemtime($this->getCertificateBundle(null));
+			$sourceMTimes[] = $this->view->filemtime($this->getCertificateBundle(null));
 		}
 
 		$sourceMTime = array_reduce($sourceMTimes, function ($max, $mtime) {


### PR DESCRIPTION
always check the mtime of the system bundle and additionally the user specific certificate bundle if a user is given. 

I think this is how the function should look like, @icewind1991 and @LukasReschke please have a look. Thanks!
- [x] update unit test if we agree that this changes are correct (tests: https://github.com/nextcloud/server/pull/364)
