### PR TITLE
Make theming work with pretty URLs

### DIFF
--- a/apps/theming/appinfo/routes.php
+++ b/apps/theming/appinfo/routes.php
@@ -40,7 +40,7 @@ namespace OCA\Theming\AppInfo;
 	],
 	[
 		'name' => 'Theming#getStylesheet',
-		'url' => '/styles.css',
+		'url' => '/styles',
 		'verb' => 'GET',
 	],
 	[

--- a/apps/theming/lib/controller/themingcontroller.php
+++ b/apps/theming/lib/controller/themingcontroller.php
@@ -234,7 +234,7 @@ class ThemingController extends Controller {
 
 		\OC_Response::setExpiresHeader(gmdate('D, d M Y H:i:s', time() + (60*60*24*45)) . ' GMT');
 		\OC_Response::enableCaching();
-		$response = new Http\DataDownloadResponse($responseCss, 'style.css', 'text/css');
+		$response = new Http\DataDownloadResponse($responseCss, 'style', 'text/css');
 		$response->cacheFor(3600);
 		return $response;
 	}

--- a/apps/theming/tests/lib/controller/ThemingControllerTest.php
+++ b/apps/theming/tests/lib/controller/ThemingControllerTest.php
@@ -323,7 +323,7 @@ class ThemingControllerTest extends TestCase {
 			->with('theming', 'backgroundMime', '')
 			->willReturn('');
 
-		$expected = new Http\DataDownloadResponse('#body-user #header,#body-settings #header,#body-public #header {background-color: #fff}', 'style.css', 'text/css');
+		$expected = new Http\DataDownloadResponse('#body-user #header,#body-settings #header,#body-public #header {background-color: #fff}', 'style', 'text/css');
 		$expected->cacheFor(3600);
 		@$this->assertEquals($expected, $this->themingController->getStylesheet());
 	}
@@ -356,7 +356,7 @@ class ThemingControllerTest extends TestCase {
 			#header .logo-icon {
 				background-image: url(\'./logo?v=0\');
 				background-size: 62px 34px;
-			}', 'style.css', 'text/css');
+			}', 'style', 'text/css');
 		$expected->cacheFor(3600);
 		@$this->assertEquals($expected, $this->themingController->getStylesheet());
 	}
@@ -385,7 +385,7 @@ class ThemingControllerTest extends TestCase {
 
 		$expected = new Http\DataDownloadResponse('#body-login {
 				background-image: url(\'./loginbackground?v=0\');
-			}', 'style.css', 'text/css');
+			}', 'style', 'text/css');
 		$expected->cacheFor(3600);
 		@$this->assertEquals($expected, $this->themingController->getStylesheet());
 	}
@@ -420,7 +420,7 @@ class ThemingControllerTest extends TestCase {
 				background-size: 62px 34px;
 			}#body-login {
 				background-image: url(\'./loginbackground?v=0\');
-			}', 'style.css', 'text/css');
+			}', 'style', 'text/css');
 		$expected->cacheFor(3600);
 		@$this->assertEquals($expected, $this->themingController->getStylesheet());
 	}


### PR DESCRIPTION
In some envs the rewrite rules for pretty URLs apply to all CSS files, so let's not end the route name which loads the theme's CSS with that extension.
Fixes #315
