### PR TITLE
FIX NODB group

### DIFF
--- a/tests/lib/Group/GroupTest.php
+++ b/tests/lib/Group/GroupTest.php
@@ -12,15 +12,36 @@ namespace Test\Group;
 use OC\User\User;
 
 class GroupTest extends \Test\TestCase {
+
 	/**
-	 * @return \OC\User\Manager | \OC\User\Manager
+	 * @param string $uid
+	 * @param $backend
+	 * @return User
+	 */
+	private function newUser($uid, $backend) {
+		$config = $this->getMockBuilder('\OCP\IConfig')
+			->disableOriginalConstructor()
+			->getMock();
+		$urlgenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+			->disableOriginalConstructor()
+			->getMock();
+
+		return new User($uid, $backend, null, $config, $urlgenerator);
+	}
+
+	/**
+	 * @return \OC\User\Manager
 	 */
 	protected function getUserManager() {
-		$userManager = $this->getMock('\OC\User\Manager');
-		$backend = $this->getMock('\OC_User_Backend');
-		$user1 = new User('user1', $backend);
-		$user2 = new User('user2', $backend);
-		$user3 = new User('user3', $backend);
+		$userManager = $this->getMockBuilder('\OC\User\Manager')
+			->disableOriginalConstructor()
+			->getMock();
+		$backend = $this->getMockBuilder('\OC\User\Backend')
+			->disableOriginalConstructor()
+			->getMock();
+		$user1 = $this->newUser('user1', $backend);
+		$user2 = $this->newUser('user2', $backend);
+		$user3 = $this->newUser('user3', $backend);
 		$userManager->expects($this->any())
 			->method('get')
 			->will($this->returnValueMap(array(
@@ -32,7 +53,9 @@ class GroupTest extends \Test\TestCase {
 	}
 
 	public function testGetUsersSingleBackend() {
-		$backend = $this->getMock('OC\Group\Database');
+		$backend = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$userManager = $this->getUserManager();
 		$group = new \OC\Group\Group('group1', array($backend), $userManager);
 
@@ -51,8 +74,12 @@ class GroupTest extends \Test\TestCase {
 	}
 
 	public function testGetUsersMultipleBackends() {
-		$backend1 = $this->getMock('OC\Group\Database');
-		$backend2 = $this->getMock('OC\Group\Database');
+		$backend1 = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
+		$backend2 = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$userManager = $this->getUserManager();
 		$group = new \OC\Group\Group('group1', array($backend1, $backend2), $userManager);
 
@@ -78,9 +105,13 @@ class GroupTest extends \Test\TestCase {
 	}
 
 	public function testInGroupSingleBackend() {
-		$backend = $this->getMock('OC\Group\Database');
+		$backend = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$userManager = $this->getUserManager();
-		$userBackend = $this->getMock('\OC_User_Backend');
+		$userBackend = $this->getMockBuilder('\OC\User\Backend')
+			->disableOriginalConstructor()
+			->getMock();
 		$group = new \OC\Group\Group('group1', array($backend), $userManager);
 
 		$backend->expects($this->once())
@@ -88,14 +119,20 @@ class GroupTest extends \Test\TestCase {
 			->with('user1', 'group1')
 			->will($this->returnValue(true));
 
-		$this->assertTrue($group->inGroup(new User('user1', $userBackend)));
+		$this->assertTrue($group->inGroup($this->newUser('user1', $userBackend)));
 	}
 
 	public function testInGroupMultipleBackends() {
-		$backend1 = $this->getMock('OC\Group\Database');
-		$backend2 = $this->getMock('OC\Group\Database');
+		$backend1 = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
+		$backend2 = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$userManager = $this->getUserManager();
-		$userBackend = $this->getMock('\OC_User_Backend');
+		$userBackend = $this->getMockBuilder('\OC_User_Backend')
+			->disableOriginalConstructor()
+			->getMock();
 		$group = new \OC\Group\Group('group1', array($backend1, $backend2), $userManager);
 
 		$backend1->expects($this->once())
@@ -108,13 +145,17 @@ class GroupTest extends \Test\TestCase {
 			->with('user1', 'group1')
 			->will($this->returnValue(true));
 
-		$this->assertTrue($group->inGroup(new User('user1', $userBackend)));
+		$this->assertTrue($group->inGroup($this->newUser('user1', $userBackend)));
 	}
 
 	public function testAddUser() {
-		$backend = $this->getMock('OC\Group\Database');
+		$backend = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$userManager = $this->getUserManager();
-		$userBackend = $this->getMock('\OC_User_Backend');
+		$userBackend = $this->getMockBuilder('\OC\User\Backend')
+			->disableOriginalConstructor()
+			->getMock();
 		$group = new \OC\Group\Group('group1', array($backend), $userManager);
 
 		$backend->expects($this->once())
@@ -129,13 +170,17 @@ class GroupTest extends \Test\TestCase {
 			->method('addToGroup')
 			->with('user1', 'group1');
 
-		$group->addUser(new User('user1', $userBackend));
+		$group->addUser($this->newUser('user1', $userBackend));
 	}
 
 	public function testAddUserAlreadyInGroup() {
-		$backend = $this->getMock('OC\Group\Database');
+		$backend = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$userManager = $this->getUserManager();
-		$userBackend = $this->getMock('\OC_User_Backend');
+		$userBackend = $this->getMockBuilder('\OC\User\Backend')
+			->disableOriginalConstructor()
+			->getMock();
 		$group = new \OC\Group\Group('group1', array($backend), $userManager);
 
 		$backend->expects($this->once())
@@ -149,13 +194,17 @@ class GroupTest extends \Test\TestCase {
 		$backend->expects($this->never())
 			->method('addToGroup');
 
-		$group->addUser(new User('user1', $userBackend));
+		$group->addUser($this->newUser('user1', $userBackend));
 	}
 
 	public function testRemoveUser() {
-		$backend = $this->getMock('OC\Group\Database');
+		$backend = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$userManager = $this->getUserManager();
-		$userBackend = $this->getMock('\OC_User_Backend');
+		$userBackend = $this->getMockBuilder('\OC\User\Backend')
+			->disableOriginalConstructor()
+			->getMock();
 		$group = new \OC\Group\Group('group1', array($backend), $userManager);
 
 		$backend->expects($this->once())
@@ -170,13 +219,17 @@ class GroupTest extends \Test\TestCase {
 			->method('removeFromGroup')
 			->with('user1', 'group1');
 
-		$group->removeUser(new User('user1', $userBackend));
+		$group->removeUser($this->newUser('user1', $userBackend));
 	}
 
 	public function testRemoveUserNotInGroup() {
-		$backend = $this->getMock('OC\Group\Database');
+		$backend = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$userManager = $this->getUserManager();
-		$userBackend = $this->getMock('\OC_User_Backend');
+		$userBackend = $this->getMockBuilder('\OC_User_Backend')
+			->disableOriginalConstructor()
+			->getMock();
 		$group = new \OC\Group\Group('group1', array($backend), $userManager);
 
 		$backend->expects($this->once())
@@ -190,14 +243,20 @@ class GroupTest extends \Test\TestCase {
 		$backend->expects($this->never())
 			->method('removeFromGroup');
 
-		$group->removeUser(new User('user1', $userBackend));
+		$group->removeUser($this->newUser('user1', $userBackend));
 	}
 
 	public function testRemoveUserMultipleBackends() {
-		$backend1 = $this->getMock('OC\Group\Database');
-		$backend2 = $this->getMock('OC\Group\Database');
+		$backend1 = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
+		$backend2 = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$userManager = $this->getUserManager();
-		$userBackend = $this->getMock('\OC_User_Backend');
+		$userBackend = $this->getMockBuilder('\OC\User\Backend')
+			->disableOriginalConstructor()
+			->getMock();
 		$group = new \OC\Group\Group('group1', array($backend1, $backend2), $userManager);
 
 		$backend1->expects($this->once())
@@ -224,11 +283,13 @@ class GroupTest extends \Test\TestCase {
 			->method('removeFromGroup')
 			->with('user1', 'group1');
 
-		$group->removeUser(new User('user1', $userBackend));
+		$group->removeUser($this->newUser('user1', $userBackend));
 	}
 
 	public function testSearchUsers() {
-		$backend = $this->getMock('OC\Group\Database');
+		$backend = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$userManager = $this->getUserManager();
 		$group = new \OC\Group\Group('group1', array($backend), $userManager);
 
@@ -245,8 +306,12 @@ class GroupTest extends \Test\TestCase {
 	}
 
 	public function testSearchUsersMultipleBackends() {
-		$backend1 = $this->getMock('OC\Group\Database');
-		$backend2 = $this->getMock('OC\Group\Database');
+		$backend1 = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
+		$backend2 = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$userManager = $this->getUserManager();
 		$group = new \OC\Group\Group('group1', array($backend1, $backend2), $userManager);
 
@@ -267,7 +332,9 @@ class GroupTest extends \Test\TestCase {
 	}
 
 	public function testSearchUsersLimitAndOffset() {
-		$backend = $this->getMock('OC\Group\Database');
+		$backend = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$userManager = $this->getUserManager();
 		$group = new \OC\Group\Group('group1', array($backend), $userManager);
 
@@ -284,8 +351,12 @@ class GroupTest extends \Test\TestCase {
 	}
 
 	public function testSearchUsersMultipleBackendsLimitAndOffset() {
-		$backend1 = $this->getMock('OC\Group\Database');
-		$backend2 = $this->getMock('OC\Group\Database');
+		$backend1 = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
+		$backend2 = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$userManager = $this->getUserManager();
 		$group = new \OC\Group\Group('group1', array($backend1, $backend2), $userManager);
 
@@ -308,7 +379,9 @@ class GroupTest extends \Test\TestCase {
 	}
 
 	public function testCountUsers() {
-		$backend1 = $this->getMock('OC\Group\Database');
+		$backend1 = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$userManager = $this->getUserManager();
 		$group = new \OC\Group\Group('group1', array($backend1), $userManager);
 
@@ -327,8 +400,12 @@ class GroupTest extends \Test\TestCase {
 	}
 
 	public function testCountUsersMultipleBackends() {
-		$backend1 = $this->getMock('OC\Group\Database');
-		$backend2 = $this->getMock('OC\Group\Database');
+		$backend1 = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
+		$backend2 = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$userManager = $this->getUserManager();
 		$group = new \OC\Group\Group('group1', array($backend1, $backend2), $userManager);
 
@@ -354,7 +431,9 @@ class GroupTest extends \Test\TestCase {
 	}
 
 	public function testCountUsersNoMethod() {
-		$backend1 = $this->getMock('OC\Group\Database');
+		$backend1 = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$userManager = $this->getUserManager();
 		$group = new \OC\Group\Group('group1', array($backend1), $userManager);
 
@@ -370,7 +449,9 @@ class GroupTest extends \Test\TestCase {
 	}
 
 	public function testDelete() {
-		$backend = $this->getMock('OC\Group\Database');
+		$backend = $this->getMockBuilder('OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$userManager = $this->getUserManager();
 		$group = new \OC\Group\Group('group1', array($backend), $userManager);
 

--- a/tests/lib/Group/GroupTest.php
+++ b/tests/lib/Group/GroupTest.php
@@ -15,10 +15,10 @@ class GroupTest extends \Test\TestCase {
 
 	/**
 	 * @param string $uid
-	 * @param $backend
+	 * @param \OC\User\Backend $backend
 	 * @return User
 	 */
-	private function newUser($uid, $backend) {
+	private function newUser($uid, \OC\User\Backend $backend) {
 		$config = $this->getMockBuilder('\OCP\IConfig')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/lib/Group/LegacyGroupTest.php
+++ b/tests/lib/Group/LegacyGroupTest.php
@@ -27,6 +27,12 @@ namespace Test\Group;
 use OC_Group;
 use OC_User;
 
+/**
+ * Class LegacyGroupTest
+ *
+ * @package Test\Group
+ * @group DB
+ */
 class LegacyGroupTest extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();

--- a/tests/lib/Group/ManagerTest.php
+++ b/tests/lib/Group/ManagerTest.php
@@ -9,24 +9,50 @@
 
 namespace Test\Group;
 
+use OC\User\Manager;
 use OC\User\User;
 
 class ManagerTest extends \Test\TestCase {
+	/** @var Manager */
+	private $userManager;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->userManager = $this->getMockBuilder('\OC\User\Manager')
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	/**
+	 * @param string $uid
+	 * @param \OC\User\Backend $backend
+	 * @return User
+	 */
+	private function newUser($uid, $backend) {
+		$config = $this->getMockBuilder('\OCP\IConfig')
+			->disableOriginalConstructor()
+			->getMock();
+		$urlgenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+			->disableOriginalConstructor()
+			->getMock();
+
+		return new User($uid, $backend, null, $config, $urlgenerator);
+	}
+	
 	public function testGet() {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
 		 */
-		$backend = $this->getMock('\OC\Group\Database');
+		$backend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend->expects($this->any())
 			->method('groupExists')
 			->with('group1')
 			->will($this->returnValue(true));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
 		$group = $manager->get('group1');
@@ -35,11 +61,7 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	public function testGetNoBackend() {
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 
 		$this->assertNull($manager->get('group1'));
 	}
@@ -48,17 +70,15 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
 		 */
-		$backend = $this->getMock('\OC\Group\Database');
+		$backend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend->expects($this->once())
 			->method('groupExists')
 			->with('group1')
 			->will($this->returnValue(false));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
 		$this->assertNull($manager->get('group1'));
@@ -68,11 +88,7 @@ class ManagerTest extends \Test\TestCase {
 		$backend = new \Test\Util\Group\Dummy();
 		$backend->createGroup('group1');
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
 		$group = $manager->get('group1');
@@ -84,7 +100,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend1
 		 */
-		$backend1 = $this->getMock('\OC\Group\Database');
+		$backend1 = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend1->expects($this->any())
 			->method('groupExists')
 			->with('group1')
@@ -93,17 +111,15 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend2
 		 */
-		$backend2 = $this->getMock('\OC\Group\Database');
+		$backend2 = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend2->expects($this->any())
 			->method('groupExists')
 			->with('group1')
 			->will($this->returnValue(true));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend1);
 		$manager->addBackend($backend2);
 
@@ -117,7 +133,9 @@ class ManagerTest extends \Test\TestCase {
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
 		 */
 		$backendGroupCreated = false;
-		$backend = $this->getMock('\OC\Group\Database');
+		$backend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend->expects($this->any())
 			->method('groupExists')
 			->with('group1')
@@ -133,11 +151,7 @@ class ManagerTest extends \Test\TestCase {
 				$backendGroupCreated = true;
 			}));;
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
 		$group = $manager->createGroup('group1');
@@ -148,7 +162,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
 		 */
-		$backend = $this->getMock('\OC\Group\Database');
+		$backend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend->expects($this->any())
 			->method('groupExists')
 			->with('group1')
@@ -156,11 +172,7 @@ class ManagerTest extends \Test\TestCase {
 		$backend->expects($this->never())
 			->method('createGroup');
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
 		$group = $manager->createGroup('group1');
@@ -171,7 +183,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
 		 */
-		$backend = $this->getMock('\OC\Group\Database');
+		$backend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend->expects($this->once())
 			->method('getGroups')
 			->with('1')
@@ -181,11 +195,7 @@ class ManagerTest extends \Test\TestCase {
 			->with('group1')
 			->will($this->returnValue(true));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
 		$groups = $manager->search('1');
@@ -198,7 +208,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend1
 		 */
-		$backend1 = $this->getMock('\OC\Group\Database');
+		$backend1 = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend1->expects($this->once())
 			->method('getGroups')
 			->with('1')
@@ -210,7 +222,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend2
 		 */
-		$backend2 = $this->getMock('\OC\Group\Database');
+		$backend2 = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend2->expects($this->once())
 			->method('getGroups')
 			->with('1')
@@ -219,11 +233,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('groupExists')
 			->will($this->returnValue(true));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend1);
 		$manager->addBackend($backend2);
 
@@ -239,7 +249,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend1
 		 */
-		$backend1 = $this->getMock('\OC\Group\Database');
+		$backend1 = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend1->expects($this->once())
 			->method('getGroups')
 			->with('1', 2, 1)
@@ -251,7 +263,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend2
 		 */
-		$backend2 = $this->getMock('\OC\Group\Database');
+		$backend2 = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend2->expects($this->once())
 			->method('getGroups')
 			->with('1', 2, 1)
@@ -260,11 +274,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('groupExists')
 			->will($this->returnValue(true));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend1);
 		$manager->addBackend($backend2);
 
@@ -280,7 +290,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
 		 */
-		$backend = $this->getMock('\OC\Group\Database');
+		$backend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend->expects($this->once())
 			->method('getUserGroups')
 			->with('user1')
@@ -290,15 +302,13 @@ class ManagerTest extends \Test\TestCase {
 			->with('group1')
 			->will($this->returnValue(true));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$userBackend = $this->getMock('\OC_User_Backend');
-		$manager = new \OC\Group\Manager($userManager);
+		$userBackend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
-		$groups = $manager->getUserGroups(new User('user1', $userBackend));
+		$groups = $manager->getUserGroups($this->newUser('user1', $userBackend));
 		$this->assertEquals(1, count($groups));
 		$group1 = reset($groups);
 		$this->assertEquals('group1', $group1->getGID());
@@ -334,7 +344,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
 		 */
-		$backend = $this->getMock('\OC\Group\Database');
+		$backend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend->expects($this->once())
 			->method('getUserGroups')
 			->with('user1')
@@ -343,12 +355,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('groupExists')
 			->will($this->returnValue(true));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$userBackend = $this->getMock('\OC_User_Backend');
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
 		$this->assertTrue($manager->isInGroup('user1', 'group1'));
@@ -358,7 +365,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
 		 */
-		$backend = $this->getMock('\OC\Group\Database');
+		$backend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend->expects($this->once())
 			->method('getUserGroups')
 			->with('user1')
@@ -367,12 +376,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('groupExists')
 			->will($this->returnValue(true));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$userBackend = $this->getMock('\OC_User_Backend');
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
 		$this->assertTrue($manager->isAdmin('user1'));
@@ -382,7 +386,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
 		 */
-		$backend = $this->getMock('\OC\Group\Database');
+		$backend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend->expects($this->once())
 			->method('getUserGroups')
 			->with('user1')
@@ -391,12 +397,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('groupExists')
 			->will($this->returnValue(true));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$userBackend = $this->getMock('\OC_User_Backend');
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
 		$this->assertFalse($manager->isAdmin('user1'));
@@ -406,7 +407,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend1
 		 */
-		$backend1 = $this->getMock('\OC\Group\Database');
+		$backend1 = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend1->expects($this->once())
 			->method('getUserGroups')
 			->with('user1')
@@ -418,7 +421,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend2
 		 */
-		$backend2 = $this->getMock('\OC\Group\Database');
+		$backend2 = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend2->expects($this->once())
 			->method('getUserGroups')
 			->with('user1')
@@ -427,16 +432,14 @@ class ManagerTest extends \Test\TestCase {
 			->method('groupExists')
 			->will($this->returnValue(true));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$userBackend = $this->getMock('\OC_User_Backend');
-		$manager = new \OC\Group\Manager($userManager);
+		$userBackend = $this->getMockBuilder('\OC\User\Backend')
+			->disableOriginalConstructor()
+			->getMock();
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend1);
 		$manager->addBackend($backend2);
 
-		$groups = $manager->getUserGroups(new User('user1', $userBackend));
+		$groups = $manager->getUserGroups($this->newUser('user1', $userBackend));
 		$this->assertEquals(2, count($groups));
 		$group1 = reset($groups);
 		$group2 = next($groups);
@@ -448,7 +451,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend1
 		 */
-		$backend = $this->getMock('\OC\Group\Database');
+		$backend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend->expects($this->exactly(1))
 			->method('groupExists')
 			->with('testgroup')
@@ -467,37 +472,35 @@ class ManagerTest extends \Test\TestCase {
                                 }
                         }));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$userBackend = $this->getMock('\OC_User_Backend');
+		$userBackend = $this->getMockBuilder('\OC\User\Backend')
+			->disableOriginalConstructor()
+			->getMock();
 
-		$userManager->expects($this->any())
+		$this->userManager->expects($this->any())
 			->method('searchDisplayName')
 			->with('user3')
 			->will($this->returnCallback(function($search, $limit, $offset) use ($userBackend) {
                                 switch($offset) {
-                                        case 0 : return array('user3' => new User('user3', $userBackend),
-                                                        'user33' => new User('user33', $userBackend));
+                                        case 0 : return array('user3' => $this->newUser('user3', $userBackend),
+                                                        'user33' => $this->newUser('user33', $userBackend));
                                         case 2 : return array();
                                 }
                         }));
 
-		$userManager->expects($this->any())
+		$this->userManager->expects($this->any())
 			->method('get')
 			->will($this->returnCallback(function($uid) use ($userBackend) {
 				switch($uid) {
-					case 'user1' : return new User('user1', $userBackend);
-					case 'user2' : return new User('user2', $userBackend);
-					case 'user3' : return new User('user3', $userBackend);
-					case 'user33': return new User('user33', $userBackend);
+					case 'user1' : return $this->newUser('user1', $userBackend);
+					case 'user2' : return $this->newUser('user2', $userBackend);
+					case 'user3' : return $this->newUser('user3', $userBackend);
+					case 'user33': return $this->newUser('user33', $userBackend);
 					default:
 						return null;
 				}
 			}));
 
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
 		$users = $manager->displayNamesInGroup('testgroup', 'user3');
@@ -512,7 +515,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend1
 		 */
-		$backend = $this->getMock('\OC\Group\Database');
+		$backend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend->expects($this->exactly(1))
 			->method('groupExists')
 			->with('testgroup')
@@ -532,38 +537,36 @@ class ManagerTest extends \Test\TestCase {
                                 }
                         }));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$userBackend = $this->getMock('\OC_User_Backend');
+		$userBackend = $this->getMockBuilder('\OC\User\Backend')
+			->disableOriginalConstructor()
+			->getMock();
 
-		$userManager->expects($this->any())
+		$this->userManager->expects($this->any())
 			->method('searchDisplayName')
 			->with('user3')
 			->will($this->returnCallback(function($search, $limit, $offset) use ($userBackend) {
                                 switch($offset) {
-                                        case 0 : return array('user3' => new User('user3', $userBackend),
-                                                        'user33' => new User('user33', $userBackend));
-                                        case 2 : return array('user333' => new User('user333', $userBackend));
+                                        case 0 : return array('user3' => $this->newUser('user3', $userBackend),
+                                                        'user33' => $this->newUser('user33', $userBackend));
+                                        case 2 : return array('user333' => $this->newUser('user333', $userBackend));
                                 }
                         }));
 
-		$userManager->expects($this->any())
+		$this->userManager->expects($this->any())
 			->method('get')
 			->will($this->returnCallback(function($uid) use ($userBackend) {
 				switch($uid) {
-					case 'user1' : return new User('user1', $userBackend);
-					case 'user2' : return new User('user2', $userBackend);
-					case 'user3' : return new User('user3', $userBackend);
-					case 'user33': return new User('user33', $userBackend);
-					case 'user333': return new User('user333', $userBackend);
+					case 'user1' : return $this->newUser('user1', $userBackend);
+					case 'user2' : return $this->newUser('user2', $userBackend);
+					case 'user3' : return $this->newUser('user3', $userBackend);
+					case 'user33': return $this->newUser('user33', $userBackend);
+					case 'user333': return $this->newUser('user333', $userBackend);
 					default:
 						return null;
 				}
 			}));
 
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
 		$users = $manager->displayNamesInGroup('testgroup', 'user3', 1);
@@ -579,7 +582,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend1
 		 */
-		$backend = $this->getMock('\OC\Group\Database');
+		$backend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend->expects($this->exactly(1))
 			->method('groupExists')
 			->with('testgroup')
@@ -599,41 +604,39 @@ class ManagerTest extends \Test\TestCase {
                                 }
                         }));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$userBackend = $this->getMock('\OC_User_Backend');
+		$userBackend = $this->getMockBuilder('\OC\User\Backend')
+			->disableOriginalConstructor()
+			->getMock();
 
-		$userManager->expects($this->any())
+		$this->userManager->expects($this->any())
 			->method('searchDisplayName')
 			->with('user3')
 			->will($this->returnCallback(function($search, $limit, $offset) use ($userBackend) {
                                 switch($offset) {
                                         case 0 :
 											return array(
-												'user3' => new User('user3', $userBackend),
-                                                'user33' => new User('user33', $userBackend),
-												'user333' => new User('user333', $userBackend)
+												'user3' => $this->newUser('user3', $userBackend),
+                                                'user33' => $this->newUser('user33', $userBackend),
+												'user333' => $this->newUser('user333', $userBackend)
 											);
                                 }
                         }));
 
-		$userManager->expects($this->any())
+		$this->userManager->expects($this->any())
 			->method('get')
 			->will($this->returnCallback(function($uid) use ($userBackend) {
 				switch($uid) {
-					case 'user1' : return new User('user1', $userBackend);
-					case 'user2' : return new User('user2', $userBackend);
-					case 'user3' : return new User('user3', $userBackend);
-					case 'user33': return new User('user33', $userBackend);
-					case 'user333': return new User('user333', $userBackend);
+					case 'user1' : return $this->newUser('user1', $userBackend);
+					case 'user2' : return $this->newUser('user2', $userBackend);
+					case 'user3' : return $this->newUser('user3', $userBackend);
+					case 'user33': return $this->newUser('user33', $userBackend);
+					case 'user333': return $this->newUser('user333', $userBackend);
 					default:
 						return null;
 				}
 			}));
 
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
 		$users = $manager->displayNamesInGroup('testgroup', 'user3', 1, 1);
@@ -649,7 +652,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend1
 		 */
-		$backend = $this->getMock('\OC\Group\Database');
+		$backend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend->expects($this->exactly(1))
 			->method('groupExists')
 			->with('testgroup')
@@ -660,26 +665,24 @@ class ManagerTest extends \Test\TestCase {
 			->with('testgroup', '', -1, 0)
 			->will($this->returnValue(array('user2', 'user33')));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$userBackend = $this->getMock('\OC_User_Backend');
+		$userBackend = $this->getMockBuilder('\OC\User\Backend')
+			->disableOriginalConstructor()
+			->getMock();
 
-		$userManager->expects($this->any())
+		$this->userManager->expects($this->any())
 			->method('get')
 			->will($this->returnCallback(function($uid) use ($userBackend) {
 				switch($uid) {
-					case 'user1' : return new User('user1', $userBackend);
-					case 'user2' : return new User('user2', $userBackend);
-					case 'user3' : return new User('user3', $userBackend);
-					case 'user33': return new User('user33', $userBackend);
+					case 'user1' : return $this->newUser('user1', $userBackend);
+					case 'user2' : return $this->newUser('user2', $userBackend);
+					case 'user3' : return $this->newUser('user3', $userBackend);
+					case 'user33': return $this->newUser('user33', $userBackend);
 					default:
 						return null;
 				}
 			}));
 
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
 		$users = $manager->displayNamesInGroup('testgroup', '');
@@ -694,7 +697,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend1
 		 */
-		$backend = $this->getMock('\OC\Group\Database');
+		$backend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend->expects($this->exactly(1))
 			->method('groupExists')
 			->with('testgroup')
@@ -704,26 +709,25 @@ class ManagerTest extends \Test\TestCase {
 			->method('usersInGroup')
 			->with('testgroup', '', 1, 0)
 			->will($this->returnValue(array('user2')));
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$userBackend = $this->getMock('\OC_User_Backend');
 
-		$userManager->expects($this->any())
+		$userBackend = $this->getMockBuilder('\OC\User\Backend')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->userManager->expects($this->any())
 			->method('get')
 			->will($this->returnCallback(function($uid) use ($userBackend) {
 				switch($uid) {
-					case 'user1' : return new User('user1', $userBackend);
-					case 'user2' : return new User('user2', $userBackend);
-					case 'user3' : return new User('user3', $userBackend);
-					case 'user33': return new User('user33', $userBackend);
+					case 'user1' : return $this->newUser('user1', $userBackend);
+					case 'user2' : return $this->newUser('user2', $userBackend);
+					case 'user3' : return $this->newUser('user3', $userBackend);
+					case 'user33': return $this->newUser('user33', $userBackend);
 					default:
 						return null;
 				}
 			}));
 
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
 		$users = $manager->displayNamesInGroup('testgroup', '', 1);
@@ -738,7 +742,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend1
 		 */
-		$backend = $this->getMock('\OC\Group\Database');
+		$backend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend->expects($this->exactly(1))
 			->method('groupExists')
 			->with('testgroup')
@@ -749,26 +755,24 @@ class ManagerTest extends \Test\TestCase {
 			->with('testgroup', '', 1, 1)
 			->will($this->returnValue(array('user33')));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$userBackend = $this->getMock('\OC_User_Backend');
+		$userBackend = $this->getMockBuilder('\OC\User\Backend')
+			->disableOriginalConstructor()
+			->getMock();
 
-		$userManager->expects($this->any())
+		$this->userManager->expects($this->any())
 			->method('get')
 			->will($this->returnCallback(function($uid) use ($userBackend) {
 				switch($uid) {
-					case 'user1' : return new User('user1', $userBackend);
-					case 'user2' : return new User('user2', $userBackend);
-					case 'user3' : return new User('user3', $userBackend);
-					case 'user33': return new User('user33', $userBackend);
+					case 'user1' : return $this->newUser('user1', $userBackend);
+					case 'user2' : return $this->newUser('user2', $userBackend);
+					case 'user3' : return $this->newUser('user3', $userBackend);
+					case 'user33': return $this->newUser('user33', $userBackend);
 					default:
 						return null;
 				}
 			}));
 
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
 		$users = $manager->displayNamesInGroup('testgroup', '', 1, 1);
@@ -783,7 +787,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
 		 */
-		$backend = $this->getMock('\OC\Group\Database');
+		$backend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$expectedGroups = array();
 		$backend->expects($this->any())
 			->method('getUserGroups')
@@ -799,15 +805,11 @@ class ManagerTest extends \Test\TestCase {
 			->method('implementsActions')
 			->will($this->returnValue(true));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
 		// prime cache
-		$user1 = new User('user1', null);
+		$user1 = $this->newUser('user1', null);
 		$groups = $manager->getUserGroups($user1);
 		$this->assertEquals(array(), $groups);
 
@@ -827,7 +829,9 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
 		 */
-		$backend = $this->getMock('\OC\Group\Database');
+		$backend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$expectedGroups = array('group1');
 		$backend->expects($this->any())
 			->method('getUserGroups')
@@ -849,15 +853,11 @@ class ManagerTest extends \Test\TestCase {
 			->method('removeFromGroup')
 			->will($this->returnValue(true));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
 		// prime cache
-		$user1 = new User('user1', null);
+		$user1 = $this->newUser('user1', null);
 		$groups = $manager->getUserGroups($user1);
 		$this->assertEquals(1, count($groups));
 		$group1 = reset($groups);
@@ -870,24 +870,22 @@ class ManagerTest extends \Test\TestCase {
 
 		// check result
 		$groups = $manager->getUserGroups($user1);
-		$this->assertEquals(array(), $groups);
+		$this->assertEquals($expectedGroups, $groups);
 	}
 
 	public function testGetUserIdGroups() {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
 		 */
-		$backend = $this->getMock('\OC\Group\Database');
+		$backend = $this->getMockBuilder('\OC\Group\Database')
+			->disableOriginalConstructor()
+			->getMock();
 		$backend->expects($this->any())
 			->method('getUserGroups')
 			->with('user1')
 			->will($this->returnValue(null));
 
-		/**
-		 * @var \OC\User\Manager $userManager
-		 */
-		$userManager = $this->getMock('\OC\User\Manager');
-		$manager = new \OC\Group\Manager($userManager);
+		$manager = new \OC\Group\Manager($this->userManager);
 		$manager->addBackend($backend);
 
 		$groups = $manager->getUserIdGroups('user1');

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -29,6 +29,9 @@ class UtilTest extends \Test\TestCase {
 		$this->assertTrue(is_string($edition));
 	}
 
+	/**
+	 * @group DB
+	 */
 	function testFormatDate() {
 		date_default_timezone_set("UTC");
 
@@ -41,6 +44,9 @@ class UtilTest extends \Test\TestCase {
 		$this->assertEquals($expected, $result);
 	}
 
+	/**
+	 * @group DB
+	 */
 	function testFormatDateWithTZ() {
 		date_default_timezone_set("UTC");
 
@@ -69,6 +75,7 @@ class UtilTest extends \Test\TestCase {
 
 	/**
 	 * @dataProvider formatDateWithTZFromSessionData
+	 * @group DB
 	 */
 	function testFormatDateWithTZFromSession($offset, $expected, $expectedTimeZone) {
 		date_default_timezone_set("UTC");
@@ -285,6 +292,7 @@ class UtilTest extends \Test\TestCase {
 	 * Test default apps
 	 *
 	 * @dataProvider defaultAppsProvider
+	 * @group DB
 	 */
 	function testDefaultApps($defaultAppConfig, $expectedPath, $enabledApps) {
 		$oldDefaultApps = \OCP\Config::getSystemValue('defaultapp', '');


### PR DESCRIPTION
This fixes the failing tests if running the NODB group.
Note that not all could be fixed since they are basically intergration tests.

I'l create issues and PRs to move more stuff to pure unit tests.

CC: @MorrisJobke @nickvergessen @icewind1991 
