### PR TITLE
Fix Warnings Provisioning API

### DIFF
--- a/apps/provisioning_api/lib/Apps.php
+++ b/apps/provisioning_api/lib/Apps.php
@@ -26,7 +26,6 @@
 namespace OCA\Provisioning_API;
 
 use OC\OCSClient;
-use \OC_OCS_Result;
 use \OC_App;
 
 class Apps {
@@ -46,7 +45,7 @@ class Apps {
 
 	/**
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function getApps($parameters) {
 		$apps = OC_App::listAllApps(false, true, $this->ocsClient);
@@ -58,55 +57,55 @@ class Apps {
 		if($filter){
 			switch($filter){
 				case 'enabled':
-					return new OC_OCS_Result(array('apps' => \OC_App::getEnabledApps()));
+					return new \OC\OCS\Result(array('apps' => \OC_App::getEnabledApps()));
 					break;
 				case 'disabled':
 					$enabled = OC_App::getEnabledApps();
-					return new OC_OCS_Result(array('apps' => array_diff($list, $enabled)));
+					return new \OC\OCS\Result(array('apps' => array_diff($list, $enabled)));
 					break;
 				default:
 					// Invalid filter variable
-					return new OC_OCS_Result(null, 101);
+					return new \OC\OCS\Result(null, 101);
 					break;
 			}
 
 		} else {
-			return new OC_OCS_Result(array('apps' => $list));
+			return new \OC\OCS\Result(array('apps' => $list));
 		}
 	}
 
 	/**
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function getAppInfo($parameters) {
 		$app = $parameters['appid'];
 		$info = \OCP\App::getAppInfo($app);
 		if(!is_null($info)) {
-			return new OC_OCS_Result(OC_App::getAppInfo($app));
+			return new \OC\OCS\Result(OC_App::getAppInfo($app));
 		} else {
-			return new OC_OCS_Result(null, \OCP\API::RESPOND_NOT_FOUND, 'The request app was not found');
+			return new \OC\OCS\Result(null, \OCP\API::RESPOND_NOT_FOUND, 'The request app was not found');
 		}
 	}
 
 	/**
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function enable($parameters) {
 		$app = $parameters['appid'];
 		$this->appManager->enableApp($app);
-		return new OC_OCS_Result(null, 100);
+		return new \OC\OCS\Result(null, 100);
 	}
 
 	/**
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function disable($parameters) {
 		$app = $parameters['appid'];
 		$this->appManager->disableApp($app);
-		return new OC_OCS_Result(null, 100);
+		return new \OC\OCS\Result(null, 100);
 	}
 
 }

--- a/apps/provisioning_api/lib/Groups.php
+++ b/apps/provisioning_api/lib/Groups.php
@@ -25,7 +25,6 @@
 
 namespace OCA\Provisioning_API;
 
-use \OC_OCS_Result;
 use OCP\IGroup;
 use OCP\IUser;
 
@@ -57,7 +56,7 @@ class Groups{
 	 * returns a list of groups
 	 *
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function getGroups($parameters) {
 		$search = $this->request->getParam('search', '');
@@ -77,27 +76,27 @@ class Groups{
 			return $group->getGID();
 		}, $groups);
 
-		return new OC_OCS_Result(['groups' => $groups]);
+		return new \OC\OCS\Result(['groups' => $groups]);
 	}
 
 	/**
 	 * returns an array of users in the group specified
 	 *
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function getGroup($parameters) {
 		// Check if user is logged in
 		$user = $this->userSession->getUser();
 		if ($user === null) {
-			return new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED);
+			return new \OC\OCS\Result(null, \OCP\API::RESPOND_UNAUTHORISED);
 		}
 
 		$groupId = $parameters['groupid'];
 
 		// Check the group exists
 		if(!$this->groupManager->groupExists($groupId)) {
-			return new OC_OCS_Result(null, \OCP\API::RESPOND_NOT_FOUND, 'The requested group could not be found');
+			return new \OC\OCS\Result(null, \OCP\API::RESPOND_NOT_FOUND, 'The requested group could not be found');
 		}
 
 		$isSubadminOfGroup = false;
@@ -115,9 +114,9 @@ class Groups{
 				return $user->getUID();
 			}, $users);
 			$users = array_values($users);
-			return new OC_OCS_Result(['users' => $users]);
+			return new \OC\OCS\Result(['users' => $users]);
 		} else {
-			return new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED, 'User does not have access to specified group');
+			return new \OC\OCS\Result(null, \OCP\API::RESPOND_UNAUTHORISED, 'User does not have access to specified group');
 		}
 	}
 
@@ -125,49 +124,49 @@ class Groups{
 	 * creates a new group
 	 *
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function addGroup($parameters) {
 		// Validate name
 		$groupId = $this->request->getParam('groupid', '');
 		if(empty($groupId)){
 			\OCP\Util::writeLog('provisioning_api', 'Group name not supplied', \OCP\Util::ERROR);
-			return new OC_OCS_Result(null, 101, 'Invalid group name');
+			return new \OC\OCS\Result(null, 101, 'Invalid group name');
 		}
 		// Check if it exists
 		if($this->groupManager->groupExists($groupId)){
-			return new OC_OCS_Result(null, 102);
+			return new \OC\OCS\Result(null, 102);
 		}
 		$this->groupManager->createGroup($groupId);
-		return new OC_OCS_Result(null, 100);
+		return new \OC\OCS\Result(null, 100);
 	}
 
 	/**
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function deleteGroup($parameters) {
 		// Check it exists
 		if(!$this->groupManager->groupExists($parameters['groupid'])){
-			return new OC_OCS_Result(null, 101);
+			return new \OC\OCS\Result(null, 101);
 		} else if($parameters['groupid'] === 'admin' || !$this->groupManager->get($parameters['groupid'])->delete()){
 			// Cannot delete admin group
-			return new OC_OCS_Result(null, 102);
+			return new \OC\OCS\Result(null, 102);
 		} else {
-			return new OC_OCS_Result(null, 100);
+			return new \OC\OCS\Result(null, 100);
 		}
 	}
 
 	/**
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function getSubAdminsOfGroup($parameters) {
 		$group = $parameters['groupid'];
 		// Check group exists
 		$targetGroup = $this->groupManager->get($group);
 		if($targetGroup === null) {
-			return new OC_OCS_Result(null, 101, 'Group does not exist');
+			return new \OC\OCS\Result(null, 101, 'Group does not exist');
 		}
 
 		$subadmins = $this->groupManager->getSubAdmin()->getGroupsSubAdmins($targetGroup);
@@ -177,7 +176,7 @@ class Groups{
 			$uids[] = $user->getUID();
 		}
 
-		return new OC_OCS_Result($uids);
+		return new \OC\OCS\Result($uids);
 	}
 
 }

--- a/apps/provisioning_api/lib/Users.php
+++ b/apps/provisioning_api/lib/Users.php
@@ -28,7 +28,6 @@
 
 namespace OCA\Provisioning_API;
 
-use \OC_OCS_Result;
 use \OC_Helper;
 use OCP\Files\NotFoundException;
 use OCP\IConfig;
@@ -72,7 +71,7 @@ class Users {
 	/**
 	 * returns a list of users
 	 *
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function getUsers() {
 		$search = !empty($_GET['search']) ? $_GET['search'] : '';
@@ -82,7 +81,7 @@ class Users {
 		// Check if user is logged in
 		$user = $this->userSession->getUser();
 		if ($user === null) {
-			return new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED);
+			return new \OC\OCS\Result(null, \OCP\API::RESPOND_UNAUTHORISED);
 		}
 
 		// Admin? Or SubAdmin?
@@ -107,17 +106,17 @@ class Users {
 
 			$users = array_slice($users, $offset, $limit);
 		} else {
-			return new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED);
+			return new \OC\OCS\Result(null, \OCP\API::RESPOND_UNAUTHORISED);
 		}
 		$users = array_keys($users);
 
-		return new OC_OCS_Result([
+		return new \OC\OCS\Result([
 			'users' => $users
 		]);
 	}
 
 	/**
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function addUser() {
 		$userId = isset($_POST['userid']) ? $_POST['userid'] : null;
@@ -128,26 +127,26 @@ class Users {
 		$subAdminManager = $this->groupManager->getSubAdmin();
 
 		if (!$isAdmin && !$subAdminManager->isSubAdmin($user)) {
-			return new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED);
+			return new \OC\OCS\Result(null, \OCP\API::RESPOND_UNAUTHORISED);
 		}
 
 		if($this->userManager->userExists($userId)) {
 			$this->logger->error('Failed addUser attempt: User already exists.', ['app' => 'ocs_api']);
-			return new OC_OCS_Result(null, 102, 'User already exists');
+			return new \OC\OCS\Result(null, 102, 'User already exists');
 		}
 
 		if(is_array($groups)) {
 			foreach ($groups as $group) {
 				if(!$this->groupManager->groupExists($group)){
-					return new OC_OCS_Result(null, 104, 'group '.$group.' does not exist');
+					return new \OC\OCS\Result(null, 104, 'group '.$group.' does not exist');
 				}
 				if(!$isAdmin && !$subAdminManager->isSubAdminofGroup($user, $this->groupManager->get($group))) {
-					return new OC_OCS_Result(null, 105, 'insufficient privileges for group '. $group);
+					return new \OC\OCS\Result(null, 105, 'insufficient privileges for group '. $group);
 				}
 			}
 		} else {
 			if(!$isAdmin) {
-				return new OC_OCS_Result(null, 106, 'no group specified (required for subadmins)');
+				return new \OC\OCS\Result(null, 106, 'no group specified (required for subadmins)');
 			}
 		}
 		
@@ -161,10 +160,10 @@ class Users {
 					$this->logger->info('Added userid '.$userId.' to group '.$group, ['app' => 'ocs_api']);
 				}
 			}
-			return new OC_OCS_Result(null, 100);
+			return new \OC\OCS\Result(null, 100);
 		} catch (\Exception $e) {
 			$this->logger->error('Failed addUser attempt with exception: '.$e->getMessage(), ['app' => 'ocs_api']);
-			return new OC_OCS_Result(null, 101, 'Bad request');
+			return new \OC\OCS\Result(null, 101, 'Bad request');
 		}
 	}
 
@@ -172,7 +171,7 @@ class Users {
 	 * gets user info
 	 *
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function getUser($parameters) {
 		$userId = $parameters['userid'];
@@ -180,7 +179,7 @@ class Users {
 		// Check if user is logged in
 		$currentLoggedInUser = $this->userSession->getUser();
 		if ($currentLoggedInUser === null) {
-			return new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED);
+			return new \OC\OCS\Result(null, \OCP\API::RESPOND_UNAUTHORISED);
 		}
 
 		$data = [];
@@ -188,7 +187,7 @@ class Users {
 		// Check if the target user exists
 		$targetUserObject = $this->userManager->get($userId);
 		if($targetUserObject === null) {
-			return new OC_OCS_Result(null, \OCP\API::RESPOND_NOT_FOUND, 'The requested user could not be found');
+			return new \OC\OCS\Result(null, \OCP\API::RESPOND_NOT_FOUND, 'The requested user could not be found');
 		}
 
 		// Admin? Or SubAdmin?
@@ -198,7 +197,7 @@ class Users {
 		} else {
 			// Check they are looking up themselves
 			if($currentLoggedInUser->getUID() !== $userId) {
-				return new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED);
+				return new \OC\OCS\Result(null, \OCP\API::RESPOND_UNAUTHORISED);
 			}
 		}
 
@@ -207,14 +206,14 @@ class Users {
 		$data['email'] = $targetUserObject->getEMailAddress();
 		$data['displayname'] = $targetUserObject->getDisplayName();
 
-		return new OC_OCS_Result($data);
+		return new \OC\OCS\Result($data);
 	}
 
 	/** 
 	 * edit users
 	 *
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function editUser($parameters) {
 		/** @var string $targetUserId */
@@ -223,14 +222,15 @@ class Users {
 		// Check if user is logged in
 		$currentLoggedInUser = $this->userSession->getUser();
 		if ($currentLoggedInUser === null) {
-			return new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED);
+			return new \OC\OCS\Result(null, \OCP\API::RESPOND_UNAUTHORISED);
 		}
 
 		$targetUser = $this->userManager->get($targetUserId);
 		if($targetUser === null) {
-			return new OC_OCS_Result(null, 997);
+			return new \OC\OCS\Result(null, 997);
 		}
 
+		$permittedFields = [];
 		if($targetUserId === $currentLoggedInUser->getUID()) {
 			// Editing self (display, email)
 			$permittedFields[] = 'display';
@@ -252,12 +252,12 @@ class Users {
 				$permittedFields[] = 'email';
 			} else {
 				// No rights
-				return new OC_OCS_Result(null, 997);
+				return new \OC\OCS\Result(null, 997);
 			}
 		}
 		// Check if permitted to edit this field
 		if(!in_array($parameters['_put']['key'], $permittedFields)) {
-			return new OC_OCS_Result(null, 997);
+			return new \OC\OCS\Result(null, 997);
 		}
 		// Process the edit
 		switch($parameters['_put']['key']) {
@@ -273,7 +273,7 @@ class Users {
 						$quota = \OCP\Util::computerFileSize($quota);
 					}
 					if ($quota === false) {
-						return new OC_OCS_Result(null, 103, "Invalid quota value {$parameters['_put']['value']}");
+						return new \OC\OCS\Result(null, 103, "Invalid quota value {$parameters['_put']['value']}");
 					}
 					if($quota === 0) {
 						$quota = 'default';
@@ -292,50 +292,49 @@ class Users {
 				if(filter_var($parameters['_put']['value'], FILTER_VALIDATE_EMAIL)) {
 					$targetUser->setEMailAddress($parameters['_put']['value']);
 				} else {
-					return new OC_OCS_Result(null, 102);
+					return new \OC\OCS\Result(null, 102);
 				}
 				break;
 			default:
-				return new OC_OCS_Result(null, 103);
-				break;
+				return new \OC\OCS\Result(null, 103);
 		}
-		return new OC_OCS_Result(null, 100);
+		return new \OC\OCS\Result(null, 100);
 	}
 
 	/**
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function deleteUser($parameters) {
 		// Check if user is logged in
 		$currentLoggedInUser = $this->userSession->getUser();
 		if ($currentLoggedInUser === null) {
-			return new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED);
+			return new \OC\OCS\Result(null, \OCP\API::RESPOND_UNAUTHORISED);
 		}
 
 		$targetUser = $this->userManager->get($parameters['userid']);
 
 		if($targetUser === null || $targetUser->getUID() === $currentLoggedInUser->getUID()) {
-			return new OC_OCS_Result(null, 101);
+			return new \OC\OCS\Result(null, 101);
 		}
 
 		// If not permitted
 		$subAdminManager = $this->groupManager->getSubAdmin();
 		if(!$this->groupManager->isAdmin($currentLoggedInUser->getUID()) && !$subAdminManager->isUserAccessible($currentLoggedInUser, $targetUser)) {
-			return new OC_OCS_Result(null, 997);
+			return new \OC\OCS\Result(null, 997);
 		}
 
 		// Go ahead with the delete
 		if($targetUser->delete()) {
-			return new OC_OCS_Result(null, 100);
+			return new \OC\OCS\Result(null, 100);
 		} else {
-			return new OC_OCS_Result(null, 101);
+			return new \OC\OCS\Result(null, 101);
 		}
 	}
 
 	/**
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function disableUser($parameters) {
 		return $this->setEnabled($parameters, false);
@@ -343,7 +342,7 @@ class Users {
 
 	/**
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function enableUser($parameters) {
 		return $this->setEnabled($parameters, true);
@@ -352,50 +351,50 @@ class Users {
 	/**
 	 * @param array $parameters
 	 * @param bool $value
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	private function setEnabled($parameters, $value) {
 		// Check if user is logged in
 		$currentLoggedInUser = $this->userSession->getUser();
 		if ($currentLoggedInUser === null) {
-			return new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED);
+			return new \OC\OCS\Result(null, \OCP\API::RESPOND_UNAUTHORISED);
 		}
 
 		$targetUser = $this->userManager->get($parameters['userid']);
 		if($targetUser === null || $targetUser->getUID() === $currentLoggedInUser->getUID()) {
-			return new OC_OCS_Result(null, 101);
+			return new \OC\OCS\Result(null, 101);
 		}
 
 		// If not permitted
 		$subAdminManager = $this->groupManager->getSubAdmin();
 		if(!$this->groupManager->isAdmin($currentLoggedInUser->getUID()) && !$subAdminManager->isUserAccessible($currentLoggedInUser, $targetUser)) {
-			return new OC_OCS_Result(null, 997);
+			return new \OC\OCS\Result(null, 997);
 		}
 
 		// enable/disable the user now
 		$targetUser->setEnabled($value);
-		return new OC_OCS_Result(null, 100);
+		return new \OC\OCS\Result(null, 100);
 	}
 
 	/**
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function getUsersGroups($parameters) {
 		// Check if user is logged in
 		$loggedInUser = $this->userSession->getUser();
 		if ($loggedInUser === null) {
-			return new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED);
+			return new \OC\OCS\Result(null, \OCP\API::RESPOND_UNAUTHORISED);
 		}
 
 		$targetUser = $this->userManager->get($parameters['userid']);
 		if($targetUser === null) {
-			return new OC_OCS_Result(null, \OCP\API::RESPOND_NOT_FOUND);
+			return new \OC\OCS\Result(null, \OCP\API::RESPOND_NOT_FOUND);
 		}
 
 		if($targetUser->getUID() === $loggedInUser->getUID() || $this->groupManager->isAdmin($loggedInUser->getUID())) {
 			// Self lookup or admin lookup
-			return new OC_OCS_Result([
+			return new \OC\OCS\Result([
 				'groups' => $this->groupManager->getUserGroupIds($targetUser)
 			]);
 		} else {
@@ -412,10 +411,10 @@ class Users {
 					$getSubAdminsGroups,
 					$this->groupManager->getUserGroupIds($targetUser)
 				);
-				return new OC_OCS_Result(array('groups' => $groups));
+				return new \OC\OCS\Result(array('groups' => $groups));
 			} else {
 				// Not permitted
-				return new OC_OCS_Result(null, 997);
+				return new \OC\OCS\Result(null, 997);
 			}
 		}
 		
@@ -423,76 +422,76 @@ class Users {
 
 	/**
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function addToGroup($parameters) {
 		// Check if user is logged in
 		$user = $this->userSession->getUser();
 		if ($user === null) {
-			return new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED);
+			return new \OC\OCS\Result(null, \OCP\API::RESPOND_UNAUTHORISED);
 		}
 
 		// Check they're an admin
 		if(!$this->groupManager->isAdmin($user->getUID())) {
 			// This user doesn't have rights to add a user to this group
-			return new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED);
+			return new \OC\OCS\Result(null, \OCP\API::RESPOND_UNAUTHORISED);
 		}
 
 		$groupId = !empty($_POST['groupid']) ? $_POST['groupid'] : null;
 		if($groupId === null) {
-			return new OC_OCS_Result(null, 101);
+			return new \OC\OCS\Result(null, 101);
 		}
 
 		$group = $this->groupManager->get($groupId);
 		$targetUser = $this->userManager->get($parameters['userid']);
 		if($group === null) {
-			return new OC_OCS_Result(null, 102);
+			return new \OC\OCS\Result(null, 102);
 		}
 		if($targetUser === null) {
-			return new OC_OCS_Result(null, 103);
+			return new \OC\OCS\Result(null, 103);
 		}
 
 		// Add user to group
 		$group->addUser($targetUser);
-		return new OC_OCS_Result(null, 100);
+		return new \OC\OCS\Result(null, 100);
 	}
 
 	/**
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function removeFromGroup($parameters) {
 		// Check if user is logged in
 		$loggedInUser = $this->userSession->getUser();
 		if ($loggedInUser === null) {
-			return new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED);
+			return new \OC\OCS\Result(null, \OCP\API::RESPOND_UNAUTHORISED);
 		}
 
 		$group = !empty($parameters['_delete']['groupid']) ? $parameters['_delete']['groupid'] : null;
 		if($group === null) {
-			return new OC_OCS_Result(null, 101);
+			return new \OC\OCS\Result(null, 101);
 		}
 
 		$group = $this->groupManager->get($group);
 		if($group === null) {
-			return new OC_OCS_Result(null, 102);
+			return new \OC\OCS\Result(null, 102);
 		}
 
 		$targetUser = $this->userManager->get($parameters['userid']);
 		if($targetUser === null) {
-			return new OC_OCS_Result(null, 103);
+			return new \OC\OCS\Result(null, 103);
 		}
 
 		// If they're not an admin, check they are a subadmin of the group in question
 		$subAdminManager = $this->groupManager->getSubAdmin();
 		if(!$this->groupManager->isAdmin($loggedInUser->getUID()) && !$subAdminManager->isSubAdminofGroup($loggedInUser, $group)) {
-			return new OC_OCS_Result(null, 104);
+			return new \OC\OCS\Result(null, 104);
 		}
 		// Check they aren't removing themselves from 'admin' or their 'subadmin; group
 		if($parameters['userid'] === $loggedInUser->getUID()) {
 			if($this->groupManager->isAdmin($loggedInUser->getUID())) {
 				if($group->getGID() === 'admin') {
-					return new OC_OCS_Result(null, 105, 'Cannot remove yourself from the admin group');
+					return new \OC\OCS\Result(null, 105, 'Cannot remove yourself from the admin group');
 				}
 			} else {
 				// Not an admin, check they are not removing themself from their subadmin group
@@ -502,21 +501,21 @@ class Users {
 				}
 
 				if(in_array($group->getGID(), $subAdminGroups, true)) {
-					return new OC_OCS_Result(null, 105, 'Cannot remove yourself from this group as you are a SubAdmin');
+					return new \OC\OCS\Result(null, 105, 'Cannot remove yourself from this group as you are a SubAdmin');
 				}
 			}
 		}
 
 		// Remove user from group
 		$group->removeUser($targetUser);
-		return new OC_OCS_Result(null, 100);
+		return new \OC\OCS\Result(null, 100);
 	}
 
 	/**
 	 * Creates a subadmin
 	 *
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function addSubAdmin($parameters) {
 		$group = $this->groupManager->get($_POST['groupid']);
@@ -524,28 +523,28 @@ class Users {
 
 		// Check if the user exists
 		if($user === null) {
-			return new OC_OCS_Result(null, 101, 'User does not exist');
+			return new \OC\OCS\Result(null, 101, 'User does not exist');
 		}
 		// Check if group exists
 		if($group === null) {
-			return new OC_OCS_Result(null, 102, 'Group:'.$_POST['groupid'].' does not exist');
+			return new \OC\OCS\Result(null, 102, 'Group:'.$_POST['groupid'].' does not exist');
 		}
 		// Check if trying to make subadmin of admin group
 		if(strtolower($_POST['groupid']) === 'admin') {
-			return new OC_OCS_Result(null, 103, 'Cannot create subadmins for admin group');
+			return new \OC\OCS\Result(null, 103, 'Cannot create subadmins for admin group');
 		}
 
 		$subAdminManager = $this->groupManager->getSubAdmin();
 
 		// We cannot be subadmin twice
 		if ($subAdminManager->isSubAdminofGroup($user, $group)) {
-			return new OC_OCS_Result(null, 100);
+			return new \OC\OCS\Result(null, 100);
 		}
 		// Go
 		if($subAdminManager->createSubAdmin($user, $group)) {
-			return new OC_OCS_Result(null, 100);
+			return new \OC\OCS\Result(null, 100);
 		} else {
-			return new OC_OCS_Result(null, 103, 'Unknown error occurred');
+			return new \OC\OCS\Result(null, 103, 'Unknown error occurred');
 		}
 	}
 
@@ -553,7 +552,7 @@ class Users {
 	 * Removes a subadmin from a group
 	 *
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function removeSubAdmin($parameters) {
 		$group = $this->groupManager->get($parameters['_delete']['groupid']);
@@ -562,22 +561,22 @@ class Users {
 
 		// Check if the user exists
 		if($user === null) {
-			return new OC_OCS_Result(null, 101, 'User does not exist');
+			return new \OC\OCS\Result(null, 101, 'User does not exist');
 		}
 		// Check if the group exists
 		if($group === null) {
-			return new OC_OCS_Result(null, 101, 'Group does not exist');
+			return new \OC\OCS\Result(null, 101, 'Group does not exist');
 		}
 		// Check if they are a subadmin of this said group
 		if(!$subAdminManager->isSubAdminofGroup($user, $group)) {
-			return new OC_OCS_Result(null, 102, 'User is not a subadmin of this group');
+			return new \OC\OCS\Result(null, 102, 'User is not a subadmin of this group');
 		}
 
 		// Go
 		if($subAdminManager->deleteSubAdmin($user, $group)) {
-			return new OC_OCS_Result(null, 100);
+			return new \OC\OCS\Result(null, 100);
 		} else {
-			return new OC_OCS_Result(null, 103, 'Unknown error occurred');
+			return new \OC\OCS\Result(null, 103, 'Unknown error occurred');
 		}
 	}
 
@@ -585,13 +584,13 @@ class Users {
 	 * Get the groups a user is a subadmin of
 	 *
 	 * @param array $parameters
-	 * @return OC_OCS_Result
+	 * @return \OC\OCS\Result
 	 */
 	public function getUserSubAdminGroups($parameters) {
 		$user = $this->userManager->get($parameters['userid']);
 		// Check if the user exists
 		if($user === null) {
-			return new OC_OCS_Result(null, 101, 'User does not exist');
+			return new \OC\OCS\Result(null, 101, 'User does not exist');
 		}
 
 		// Get the subadmin groups
@@ -601,9 +600,9 @@ class Users {
 		}
 
 		if(!$groups) {
-			return new OC_OCS_Result(null, 102, 'Unknown error occurred');
+			return new \OC\OCS\Result(null, 102, 'Unknown error occurred');
 		} else {
-			return new OC_OCS_Result($groups);
+			return new \OC\OCS\Result($groups);
 		}
 	}
 

--- a/apps/provisioning_api/tests/AppsTest.php
+++ b/apps/provisioning_api/tests/AppsTest.php
@@ -65,13 +65,13 @@ class AppsTest extends TestCase {
 
 	public function testGetAppInfo() {
 		$result = $this->api->getAppInfo(['appid' => 'provisioning_api']);
-		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertInstanceOf('\OC\OCS\Result', $result);
 		$this->assertTrue($result->succeeded());
 	}
 
 	public function testGetAppInfoOnBadAppID() {
 		$result = $this->api->getAppInfo(['appid' => 'not_provisioning_api']);
-		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertInstanceOf('\OC\OCS\Result', $result);
 		$this->assertFalse($result->succeeded());
 		$this->assertEquals(API::RESPOND_NOT_FOUND, $result->getStatusCode());
 	}

--- a/apps/provisioning_api/tests/GroupsTest.php
+++ b/apps/provisioning_api/tests/GroupsTest.php
@@ -57,8 +57,12 @@ class GroupsTest extends \Test\TestCase {
 			->method('getSubAdmin')
 			->willReturn($this->subAdminManager);
 
-		$this->userSession = $this->getMock('OCP\IUserSession');
-		$this->request = $this->getMock('OCP\IRequest');
+		$this->userSession = $this->getMockBuilder('OCP\IUserSession')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->request = $this->getMockBuilder('OCP\IRequest')
+			->disableOriginalConstructor()
+			->getMock();
 		$this->api = new Groups(
 			$this->groupManager,
 			$this->userSession,
@@ -71,7 +75,7 @@ class GroupsTest extends \Test\TestCase {
 	 * @return \OCP\IGroup|\PHPUnit_Framework_MockObject_MockObject
 	 */
 	private function createGroup($gid) {
-		$group = $this->getMock('OCP\IGroup');
+		$group = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$group
 			->method('getGID')
 			->willReturn($gid);
@@ -83,7 +87,7 @@ class GroupsTest extends \Test\TestCase {
 	 * @return \OCP\IUser|\PHPUnit_Framework_MockObject_MockObject
 	 */
 	private function createUser($uid) {
-		$user = $this->getMock('OCP\IUser');
+		$user = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$user
 			->method('getUID')
 			->willReturn($uid);
@@ -163,7 +167,7 @@ class GroupsTest extends \Test\TestCase {
 			->willReturn($groups);
 
 		$result = $this->api->getGroups([]);
-		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertInstanceOf('\OC\OCS\Result', $result);
 		$this->assertTrue($result->succeeded());
 		$this->assertEquals(['group1', 'group2'], $result->getData()['groups']);
 	}
@@ -171,7 +175,7 @@ class GroupsTest extends \Test\TestCase {
 	public function testGetGroupAsUser() {
 		$result = $this->api->getGroup([]);
 
-		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertInstanceOf('\OC\OCS\Result', $result);
 		$this->assertFalse($result->succeeded());
 		$this->assertEquals(API::RESPOND_UNAUTHORISED, $result->getStatusCode());
 
@@ -200,7 +204,7 @@ class GroupsTest extends \Test\TestCase {
 			'groupid' => 'group',
 		]);
 
-		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertInstanceOf('\OC\OCS\Result', $result);
 		$this->assertTrue($result->succeeded());
 		$this->assertEquals(1, sizeof($result->getData()), 'Asserting the result data array only has the "users" key');
 		$this->assertArrayHasKey('users', $result->getData());
@@ -225,7 +229,7 @@ class GroupsTest extends \Test\TestCase {
 			'groupid' => 'group',
 		]);
 
-		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertInstanceOf('\OC\OCS\Result', $result);
 		$this->assertFalse($result->succeeded());
 		$this->assertEquals(API::RESPOND_UNAUTHORISED, $result->getStatusCode());
 	}
@@ -253,7 +257,7 @@ class GroupsTest extends \Test\TestCase {
 			'groupid' => 'group',
 		]);
 
-		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertInstanceOf('\OC\OCS\Result', $result);
 		$this->assertTrue($result->succeeded());
 		$this->assertEquals(1, sizeof($result->getData()), 'Asserting the result data array only has the "users" key');
 		$this->assertArrayHasKey('users', $result->getData());
@@ -267,7 +271,7 @@ class GroupsTest extends \Test\TestCase {
 			'groupid' => $this->getUniqueID()
 		]);
 
-		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertInstanceOf('\OC\OCS\Result', $result);
 		$this->assertFalse($result->succeeded());
 		$this->assertEquals(API::RESPOND_NOT_FOUND, $result->getStatusCode());
 		$this->assertEquals('The requested group could not be found', $result->getMeta()['message']);
@@ -278,7 +282,7 @@ class GroupsTest extends \Test\TestCase {
 			'groupid' => 'NonExistingGroup',
 		]);
 
-		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertInstanceOf('\OC\OCS\Result', $result);
 		$this->assertFalse($result->succeeded());
 		$this->assertEquals(101, $result->getStatusCode());
 		$this->assertEquals('Group does not exist', $result->getMeta()['message']);
@@ -304,7 +308,7 @@ class GroupsTest extends \Test\TestCase {
 			'groupid' => 'GroupWithSubAdmins',
 		]);
 
-		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertInstanceOf('\OC\OCS\Result', $result);
 		$this->assertTrue($result->succeeded());
 		$this->assertEquals(['SubAdmin1', 'SubAdmin2'], $result->getData());
 	}
@@ -327,7 +331,7 @@ class GroupsTest extends \Test\TestCase {
 			'groupid' => 'GroupWithOutSubAdmins',
 		]);
 
-		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertInstanceOf('\OC\OCS\Result', $result);
 		$this->assertTrue($result->succeeded());
 		$this->assertEquals([], $result->getData());
 	}
@@ -340,7 +344,7 @@ class GroupsTest extends \Test\TestCase {
 
 		$result = $this->api->addGroup([]);
 
-		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertInstanceOf('\OC\OCS\Result', $result);
 		$this->assertFalse($result->succeeded());
 		$this->assertEquals(101, $result->getStatusCode());
 		$this->assertEquals('Invalid group name', $result->getMeta()['message']);
@@ -359,7 +363,7 @@ class GroupsTest extends \Test\TestCase {
 
 		$result = $this->api->addGroup([]);
 
-		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertInstanceOf('\OC\OCS\Result', $result);
 		$this->assertFalse($result->succeeded());
 		$this->assertEquals(102, $result->getStatusCode());
 	}
@@ -381,7 +385,7 @@ class GroupsTest extends \Test\TestCase {
 			->with('NewGroup');
 
 		$result = $this->api->addGroup([]);
-		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertInstanceOf('\OC\OCS\Result', $result);
 		$this->assertTrue($result->succeeded());
 	}
 
@@ -402,7 +406,7 @@ class GroupsTest extends \Test\TestCase {
 			->with('Iñtërnâtiônàlizætiøn');
 
 		$result = $this->api->addGroup([]);
-		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertInstanceOf('\OC\OCS\Result', $result);
 		$this->assertTrue($result->succeeded());
 	}
 
@@ -410,7 +414,7 @@ class GroupsTest extends \Test\TestCase {
 		$result = $this->api->deleteGroup([
 			'groupid' => 'NonExistingGroup'
 		]);
-		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertInstanceOf('\OC\OCS\Result', $result);
 		$this->assertFalse($result->succeeded());
 		$this->assertEquals(101, $result->getStatusCode());
 	}
@@ -424,7 +428,7 @@ class GroupsTest extends \Test\TestCase {
 		$result = $this->api->deleteGroup([
 			'groupid' => 'admin'
 		]);
-		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertInstanceOf('\OC\OCS\Result', $result);
 		$this->assertFalse($result->succeeded());
 		$this->assertEquals(102, $result->getStatusCode());
 	}
@@ -448,7 +452,7 @@ class GroupsTest extends \Test\TestCase {
 		$result = $this->api->deleteGroup([
 			'groupid' => 'ExistingGroup',
 		]);
-		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertInstanceOf('\OC\OCS\Result', $result);
 		$this->assertTrue($result->succeeded());
 	}
 }

--- a/apps/provisioning_api/tests/UsersTest.php
+++ b/apps/provisioning_api/tests/UsersTest.php
@@ -61,13 +61,21 @@ class UsersTest extends OriginalTest {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->userManager = $this->getMock('OCP\IUserManager');
-		$this->config = $this->getMock('OCP\IConfig');
+		$this->userManager = $this->getMockBuilder('OCP\IUserManager')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->config = $this->getMockBuilder('OCP\IConfig')
+			->disableOriginalConstructor()
+			->getMock();
 		$this->groupManager = $this->getMockBuilder('OC\Group\Manager')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->userSession = $this->getMock('OCP\IUserSession');
-		$this->logger = $this->getMock('OCP\ILogger');
+		$this->userSession = $this->getMockBuilder('OCP\IUserSession')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->logger = $this->getMockBuilder('OCP\ILogger')
+			->disableOriginalConstructor()
+			->getMock();
 		$this->api = $this->getMockBuilder('OCA\Provisioning_API\Users')
 			->setConstructorArgs([
 				$this->userManager,
@@ -86,14 +94,16 @@ class UsersTest extends OriginalTest {
 			->method('getUser')
 			->will($this->returnValue(null));
 
-		$expected = new \OC_OCS_Result(null, API::RESPOND_UNAUTHORISED);
+		$expected = new \OC\OCS\Result(null, API::RESPOND_UNAUTHORISED);
 		$this->assertEquals($expected, $this->api->getUsers());
 	}
 
 	public function testGetUsersAsAdmin() {
 		$_GET['search'] = 'MyCustomSearch';
 
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
@@ -112,7 +122,7 @@ class UsersTest extends OriginalTest {
 			->with('MyCustomSearch', null, null)
 			->will($this->returnValue(['Admin' => [], 'Foo' => [], 'Bar' => []]));
 
-		$expected = new \OC_OCS_Result([
+		$expected = new \OC\OCS\Result([
 			'users' => [
 				'Admin',
 				'Foo',
@@ -125,7 +135,9 @@ class UsersTest extends OriginalTest {
 	public function testGetUsersAsSubAdmin() {
 		$_GET['search'] = 'MyCustomSearch';
 
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
@@ -138,12 +150,16 @@ class UsersTest extends OriginalTest {
 			->expects($this->once())
 			->method('isAdmin')
 			->will($this->returnValue(false));
-		$firstGroup = $this->getMock('OCP\IGroup');
+		$firstGroup = $this->getMockBuilder('OCP\IGroup')
+			->disableOriginalConstructor()
+			->getMock();
 		$firstGroup
 			->expects($this->once())
 			->method('getGID')
 			->will($this->returnValue('FirstGroup'));
-		$secondGroup = $this->getMock('OCP\IGroup');
+		$secondGroup = $this->getMockBuilder('OCP\IGroup')
+			->disableOriginalConstructor()
+			->getMock();
 		$secondGroup
 			->expects($this->once())
 			->method('getGID')
@@ -169,7 +185,7 @@ class UsersTest extends OriginalTest {
 			->method('displayNamesInGroup')
 			->will($this->onConsecutiveCalls(['AnotherUserInTheFirstGroup' => []], ['UserInTheSecondGroup' => []]));
 
-		$expected = new \OC_OCS_Result([
+		$expected = new \OC\OCS\Result([
 			'users' => [
 				'AnotherUserInTheFirstGroup',
 				'UserInTheSecondGroup',
@@ -181,7 +197,9 @@ class UsersTest extends OriginalTest {
 	public function testGetUsersAsRegularUser() {
 		$_GET['search'] = 'MyCustomSearch';
 
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
@@ -206,7 +224,7 @@ class UsersTest extends OriginalTest {
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
 
-		$expected = new \OC_OCS_Result(null, API::RESPOND_UNAUTHORISED);
+		$expected = new \OC\OCS\Result(null, API::RESPOND_UNAUTHORISED);
 		$this->assertEquals($expected, $this->api->getUsers());
 	}
 
@@ -221,7 +239,9 @@ class UsersTest extends OriginalTest {
 			->expects($this->once())
 			->method('error')
 			->with('Failed addUser attempt: User already exists.', ['app' => 'ocs_api']);
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
@@ -236,7 +256,7 @@ class UsersTest extends OriginalTest {
 			->with('adminUser')
 			->willReturn(true);
 
-		$expected = new \OC_OCS_Result(null, 102, 'User already exists');
+		$expected = new \OC\OCS\Result(null, 102, 'User already exists');
 		$this->assertEquals($expected, $this->api->addUser());
 	}
 
@@ -248,7 +268,9 @@ class UsersTest extends OriginalTest {
 			->method('userExists')
 			->with('NewUser')
 			->willReturn(false);
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
@@ -268,7 +290,7 @@ class UsersTest extends OriginalTest {
 			->with('NonExistingGroup')
 			->willReturn(false);
 
-		$expected = new \OC_OCS_Result(null, 104, 'group NonExistingGroup does not exist');
+		$expected = new \OC\OCS\Result(null, 104, 'group NonExistingGroup does not exist');
 		$this->assertEquals($expected, $this->api->addUser());
 	}
 
@@ -280,7 +302,9 @@ class UsersTest extends OriginalTest {
 			->method('userExists')
 			->with('NewUser')
 			->willReturn(false);
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
@@ -306,7 +330,7 @@ class UsersTest extends OriginalTest {
 				['NonExistingGroup', false]
 			]));
 
-		$expected = new \OC_OCS_Result(null, 104, 'group NonExistingGroup does not exist');
+		$expected = new \OC\OCS\Result(null, 104, 'group NonExistingGroup does not exist');
 		$this->assertEquals($expected, $this->api->addUser());
 	}
 
@@ -326,7 +350,9 @@ class UsersTest extends OriginalTest {
 			->expects($this->once())
 			->method('info')
 			->with('Successful addUser call with userid: NewUser', ['app' => 'ocs_api']);
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
@@ -341,7 +367,7 @@ class UsersTest extends OriginalTest {
 			->with('adminUser')
 			->willReturn(true);
 
-		$expected = new \OC_OCS_Result(null, 100);
+		$expected = new \OC\OCS\Result(null, 100);
 		$this->assertEquals($expected, $this->api->addUser());
 	}
 
@@ -354,7 +380,9 @@ class UsersTest extends OriginalTest {
 			->method('userExists')
 			->with('NewUser')
 			->willReturn(false);
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
@@ -373,13 +401,17 @@ class UsersTest extends OriginalTest {
 			->method('groupExists')
 			->with('ExistingGroup')
 			->willReturn(true);
-		$user = $this->getMock('OCP\IUser');
+		$user = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('createUser')
 			->with('NewUser', 'PasswordOfTheNewUser')
 			->willReturn($user);
-		$group = $this->getMock('OCP\IGroup');
+		$group = $this->getMockBuilder('OCP\IGroup')
+			->disableOriginalConstructor()
+			->getMock();
 		$group
 			->expects($this->once())
 			->method('addUser')
@@ -397,7 +429,7 @@ class UsersTest extends OriginalTest {
 				['Added userid NewUser to group ExistingGroup', ['app' => 'ocs_api']]
 			);
 
-		$expected = new \OC_OCS_Result(null, 100);
+		$expected = new \OC\OCS\Result(null, 100);
 		$this->assertEquals($expected, $this->api->addUser());
 	}
 
@@ -418,7 +450,9 @@ class UsersTest extends OriginalTest {
 			->expects($this->once())
 			->method('error')
 			->with('Failed addUser attempt with exception: User backend not found.', ['app' => 'ocs_api']);
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
@@ -433,14 +467,16 @@ class UsersTest extends OriginalTest {
 			->with('adminUser')
 			->willReturn(true);
 
-		$expected = new \OC_OCS_Result(null, 101, 'Bad request');
+		$expected = new \OC\OCS\Result(null, 101, 'Bad request');
 		$this->assertEquals($expected, $this->api->addUser());
 	}
 
 	public function testAddUserAsRegularUser() {
 		$_POST['userid'] = 'NewUser';
 		$_POST['password'] = 'PasswordOfTheNewUser';
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
@@ -467,14 +503,16 @@ class UsersTest extends OriginalTest {
 			->with()
 			->willReturn($subAdminManager);
 
-		$expected = new \OC_OCS_Result(null, API::RESPOND_UNAUTHORISED);
+		$expected = new \OC\OCS\Result(null, API::RESPOND_UNAUTHORISED);
 		$this->assertEquals($expected, $this->api->addUser());	
 	}
 
 	public function testAddUserAsSubAdminNoGroup() {
 		$_POST['userid'] = 'NewUser';
 		$_POST['password'] = 'PasswordOfTheNewUser';
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
@@ -501,7 +539,7 @@ class UsersTest extends OriginalTest {
 			->with()
 			->willReturn($subAdminManager);
 
-		$expected = new \OC_OCS_Result(null, 106, 'no group specified (required for subadmins)');
+		$expected = new \OC\OCS\Result(null, 106, 'no group specified (required for subadmins)');
 		$this->assertEquals($expected, $this->api->addUser());	
 	}
 
@@ -509,7 +547,9 @@ class UsersTest extends OriginalTest {
 		$_POST['userid'] = 'NewUser';
 		$_POST['password'] = 'PasswordOfTheNewUser';
 		$_POST['groups'] = ['ExistingGroup'];
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
@@ -523,7 +563,7 @@ class UsersTest extends OriginalTest {
 			->method('isAdmin')
 			->with('regularUser')
 			->willReturn(false);
-		$existingGroup = $this->getMock('OCP\IGroup');
+		$existingGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->groupManager
 			->expects($this->once())
 			->method('get')
@@ -552,7 +592,7 @@ class UsersTest extends OriginalTest {
 			->with('ExistingGroup')
 			->willReturn(true);
 
-		$expected = new \OC_OCS_Result(null, 105, 'insufficient privileges for group ExistingGroup');
+		$expected = new \OC\OCS\Result(null, 105, 'insufficient privileges for group ExistingGroup');
 		$this->assertEquals($expected, $this->api->addUser());	
 	}
 
@@ -565,7 +605,9 @@ class UsersTest extends OriginalTest {
 			->method('userExists')
 			->with('NewUser')
 			->willReturn(false);
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
@@ -587,14 +629,20 @@ class UsersTest extends OriginalTest {
 				['ExistingGroup2']
 			)
 			->willReturn(true);
-		$user = $this->getMock('OCP\IUser');
+		$user = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('createUser')
 			->with('NewUser', 'PasswordOfTheNewUser')
 			->willReturn($user);
-		$existingGroup1 = $this->getMock('OCP\IGroup');
-		$existingGroup2 = $this->getMock('OCP\IGroup');
+		$existingGroup1 = $this->getMockBuilder('OCP\IGroup')
+			->disableOriginalConstructor()
+			->getMock();
+		$existingGroup2 = $this->getMockBuilder('OCP\IGroup')
+			->disableOriginalConstructor()
+			->getMock();
 		$existingGroup1
 			->expects($this->once())
 			->method('addUser')
@@ -645,7 +693,7 @@ class UsersTest extends OriginalTest {
 			->willReturn(true);
 
 
-		$expected = new \OC_OCS_Result(null, 100);
+		$expected = new \OC\OCS\Result(null, 100);
 		$this->assertEquals($expected, $this->api->addUser());
 	}
 
@@ -656,12 +704,14 @@ class UsersTest extends OriginalTest {
 			->method('getUser')
 			->will($this->returnValue(null));
 
-		$expected = new \OC_OCS_Result(null, API::RESPOND_UNAUTHORISED);
+		$expected = new \OC\OCS\Result(null, API::RESPOND_UNAUTHORISED);
 		$this->assertEquals($expected, $this->api->getUser(['userid' => 'UserToGet']));
 	}
 
 	public function testGetUserTargetDoesNotExist() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -672,17 +722,21 @@ class UsersTest extends OriginalTest {
 			->with('UserToGet')
 			->will($this->returnValue(null));
 
-		$expected = new \OC_OCS_Result(null, API::RESPOND_NOT_FOUND, 'The requested user could not be found');
+		$expected = new \OC\OCS\Result(null, API::RESPOND_NOT_FOUND, 'The requested user could not be found');
 		$this->assertEquals($expected, $this->api->getUser(['userid' => 'UserToGet']));
 	}
 
 	public function testGetUserAsAdmin() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
 			->will($this->returnValue('admin'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$targetUser->expects($this->once())
 			->method('getEMailAddress')
 			->willReturn('demo@owncloud.org');
@@ -715,7 +769,7 @@ class UsersTest extends OriginalTest {
 			->method('getDisplayName')
 			->will($this->returnValue('Demo User'));
 
-		$expected = new \OC_OCS_Result(
+		$expected = new \OC\OCS\Result(
 			[
 				'enabled' => 'true',
 				'quota' => ['DummyValue'],
@@ -727,12 +781,16 @@ class UsersTest extends OriginalTest {
 	}
 
 	public function testGetUserAsSubAdminAndUserIsAccessible() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$targetUser
 				->expects($this->once())
 				->method('getEMailAddress')
@@ -778,7 +836,7 @@ class UsersTest extends OriginalTest {
 			->method('getDisplayName')
 			->will($this->returnValue('Demo User'));
 
-		$expected = new \OC_OCS_Result(
+		$expected = new \OC\OCS\Result(
 			[
 				'enabled' => 'true',
 				'quota' => ['DummyValue'],
@@ -790,12 +848,16 @@ class UsersTest extends OriginalTest {
 	}
 
 	public function testGetUserAsSubAdminAndUserIsNotAccessible() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->exactly(2))
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -823,17 +885,21 @@ class UsersTest extends OriginalTest {
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
 
-		$expected = new \OC_OCS_Result(null, API::RESPOND_UNAUTHORISED);
+		$expected = new \OC\OCS\Result(null, API::RESPOND_UNAUTHORISED);
 		$this->assertEquals($expected, $this->api->getUser(['userid' => 'UserToGet']));
 	}
 
 	public function testGetUserAsSubAdminSelfLookup() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->exactly(2))
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -874,7 +940,7 @@ class UsersTest extends OriginalTest {
 			->method('getEMailAddress')
 			->will($this->returnValue('subadmin@owncloud.org'));
 
-		$expected = new \OC_OCS_Result([
+		$expected = new \OC\OCS\Result([
 			'quota' => ['DummyValue'],
 			'email' => 'subadmin@owncloud.org',
 			'displayname' => 'Subadmin User',
@@ -888,17 +954,21 @@ class UsersTest extends OriginalTest {
 			->method('getUser')
 			->will($this->returnValue(null));
 
-		$expected = new \OC_OCS_Result(null, API::RESPOND_UNAUTHORISED);
+		$expected = new \OC\OCS\Result(null, API::RESPOND_UNAUTHORISED);
 		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit']));
 	}
 
 	public function testEditUserRegularUserSelfEditChangeDisplayName() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('UserToEdit'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -913,17 +983,21 @@ class UsersTest extends OriginalTest {
 			->method('setDisplayName')
 			->with('NewDisplayName');
 
-		$expected = new \OC_OCS_Result(null, 100);
+		$expected = new \OC\OCS\Result(null, 100);
 		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'display', 'value' => 'NewDisplayName']]));
 	}
 
 	public function testEditUserRegularUserSelfEditChangeEmailValid() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('UserToEdit'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -938,17 +1012,21 @@ class UsersTest extends OriginalTest {
 			->method('setEMailAddress')
 			->with('demo@owncloud.org');
 
-		$expected = new \OC_OCS_Result(null, 100);
+		$expected = new \OC\OCS\Result(null, 100);
 		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'email', 'value' => 'demo@owncloud.org']]));
 	}
 
 	public function testEditUserRegularUserSelfEditChangeEmailInvalid() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('UserToEdit'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -959,17 +1037,21 @@ class UsersTest extends OriginalTest {
 			->with('UserToEdit')
 			->will($this->returnValue($targetUser));
 
-		$expected = new \OC_OCS_Result(null, 102);
+		$expected = new \OC\OCS\Result(null, 102);
 		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'email', 'value' => 'demo.org']]));
 	}
 
 	public function testEditUserRegularUserSelfEditChangePassword() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('UserToEdit'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -984,17 +1066,21 @@ class UsersTest extends OriginalTest {
 			->method('setPassword')
 			->with('NewPassword');
 
-		$expected = new \OC_OCS_Result(null, 100);
+		$expected = new \OC\OCS\Result(null, 100);
 		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'password', 'value' => 'NewPassword']]));
 	}
 
 	public function testEditUserRegularUserSelfEditChangeQuota() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('UserToEdit'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -1005,17 +1091,17 @@ class UsersTest extends OriginalTest {
 			->with('UserToEdit')
 			->will($this->returnValue($targetUser));
 
-		$expected = new \OC_OCS_Result(null, 997);
+		$expected = new \OC\OCS\Result(null, 997);
 		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'quota', 'value' => 'NewQuota']]));
 	}
 
 	public function testEditUserAdminUserSelfEditChangeValidQuota() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();;
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('UserToEdit'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$targetUser->expects($this->once())
 			->method('setQuota')
 			->with('2.9 MB');
@@ -1034,17 +1120,17 @@ class UsersTest extends OriginalTest {
 			->with('UserToEdit')
 			->will($this->returnValue(true));
 
-		$expected = new \OC_OCS_Result(null, 100);
+		$expected = new \OC\OCS\Result(null, 100);
 		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'quota', 'value' => '3042824']]));
 	}
 
 	public function testEditUserAdminUserSelfEditChangeInvalidQuota() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('UserToEdit'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -1060,17 +1146,17 @@ class UsersTest extends OriginalTest {
 			->with('UserToEdit')
 			->will($this->returnValue(true));
 
-		$expected = new \OC_OCS_Result(null, 103, 'Invalid quota value ABC');
+		$expected = new \OC\OCS\Result(null, 103, 'Invalid quota value ABC');
 		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'quota', 'value' => 'ABC']]));
 	}
 
 	public function testEditUserAdminUserEditChangeValidQuota() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('admin'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$targetUser->expects($this->once())
 			->method('setQuota')
 			->with('2.9 MB');
@@ -1096,17 +1182,17 @@ class UsersTest extends OriginalTest {
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
 
-		$expected = new \OC_OCS_Result(null, 100);
+		$expected = new \OC\OCS\Result(null, 100);
 		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'quota', 'value' => '3042824']]));
 	}
 
 	public function testEditUserSubadminUserAccessible() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$targetUser->expects($this->once())
 			->method('setQuota')
 			->with('2.9 MB');
@@ -1132,17 +1218,17 @@ class UsersTest extends OriginalTest {
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
 
-		$expected = new \OC_OCS_Result(null, 100);
+		$expected = new \OC\OCS\Result(null, 100);
 		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'quota', 'value' => '3042824']]));
 	}
 
 	public function testEditUserSubadminUserInaccessible() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -1165,7 +1251,7 @@ class UsersTest extends OriginalTest {
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
 
-		$expected = new \OC_OCS_Result(null, 997);
+		$expected = new \OC\OCS\Result(null, 997);
 		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'quota', 'value' => '3042824']]));
 	}
 
@@ -1175,12 +1261,12 @@ class UsersTest extends OriginalTest {
 			->method('getUser')
 			->will($this->returnValue(null));
 
-		$expected = new \OC_OCS_Result(null, 997);
+		$expected = new \OC\OCS\Result(null, 997);
 		$this->assertEquals($expected, $this->api->deleteUser(['userid' => 'UserToDelete']));
 	}
 
 	public function testDeleteUserNotExistingUser() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
@@ -1195,17 +1281,17 @@ class UsersTest extends OriginalTest {
 			->with('UserToDelete')
 			->will($this->returnValue(null));
 
-		$expected = new \OC_OCS_Result(null, 101);
+		$expected = new \OC\OCS\Result(null, 101);
 		$this->assertEquals($expected, $this->api->deleteUser(['userid' => 'UserToDelete']));
 	}
 
 	public function testDeleteUserSelf() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('UserToDelete'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1220,17 +1306,17 @@ class UsersTest extends OriginalTest {
 			->with('UserToDelete')
 			->will($this->returnValue($targetUser));
 
-		$expected = new \OC_OCS_Result(null, 101);
+		$expected = new \OC\OCS\Result(null, 101);
 		$this->assertEquals($expected, $this->api->deleteUser(['userid' => 'UserToDelete']));
 	}
 
 	public function testDeleteSuccessfulUserAsAdmin() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('admin'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1254,17 +1340,17 @@ class UsersTest extends OriginalTest {
 			->method('delete')
 			->will($this->returnValue(true));
 
-		$expected = new \OC_OCS_Result(null, 100);
+		$expected = new \OC\OCS\Result(null, 100);
 		$this->assertEquals($expected, $this->api->deleteUser(['userid' => 'UserToDelete']));
 	}
 
 	public function testDeleteUnsuccessfulUserAsAdmin() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('admin'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1288,17 +1374,17 @@ class UsersTest extends OriginalTest {
 			->method('delete')
 			->will($this->returnValue(false));
 
-		$expected = new \OC_OCS_Result(null, 101);
+		$expected = new \OC\OCS\Result(null, 101);
 		$this->assertEquals($expected, $this->api->deleteUser(['userid' => 'UserToDelete']));
 	}
 
 	public function testDeleteSuccessfulUserAsSubadmin() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1333,17 +1419,17 @@ class UsersTest extends OriginalTest {
 			->method('delete')
 			->will($this->returnValue(true));
 
-		$expected = new \OC_OCS_Result(null, 100);
+		$expected = new \OC\OCS\Result(null, 100);
 		$this->assertEquals($expected, $this->api->deleteUser(['userid' => 'UserToDelete']));
 	}
 
 	public function testDeleteUnsuccessfulUserAsSubadmin() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1378,17 +1464,17 @@ class UsersTest extends OriginalTest {
 			->method('delete')
 			->will($this->returnValue(false));
 
-		$expected = new \OC_OCS_Result(null, 101);
+		$expected = new \OC\OCS\Result(null, 101);
 		$this->assertEquals($expected, $this->api->deleteUser(['userid' => 'UserToDelete']));
 	}
 
 	public function testDeleteUserAsSubAdminAndUserIsNotAccessible() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1419,7 +1505,7 @@ class UsersTest extends OriginalTest {
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
 
-		$expected = new \OC_OCS_Result(null, 997);
+		$expected = new \OC\OCS\Result(null, 997);
 		$this->assertEquals($expected, $this->api->deleteUser(['userid' => 'UserToDelete']));
 	}
 
@@ -1429,28 +1515,28 @@ class UsersTest extends OriginalTest {
 			->method('getUser')
 			->will($this->returnValue(null));
 
-		$expected = new \OC_OCS_Result(null, 997);
+		$expected = new \OC\OCS\Result(null, 997);
 		$this->assertEquals($expected, $this->api->getUsersGroups(['userid' => 'UserToLookup']));
 	}
 
 	public function testGetUsersGroupsTargetUserNotExisting() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
 			->will($this->returnValue($loggedInUser));
 
-		$expected = new \OC_OCS_Result(null, 998);
+		$expected = new \OC\OCS\Result(null, 998);
 		$this->assertEquals($expected, $this->api->getUsersGroups(['userid' => 'UserToLookup']));
 	}
 
 	public function testGetUsersGroupsSelfTargetted() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
 			->will($this->returnValue('UserToLookup'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1470,17 +1556,17 @@ class UsersTest extends OriginalTest {
 			->with($targetUser)
 			->will($this->returnValue(['DummyValue']));
 
-		$expected = new \OC_OCS_Result(['groups' => ['DummyValue']]);
+		$expected = new \OC\OCS\Result(['groups' => ['DummyValue']]);
 		$this->assertEquals($expected, $this->api->getUsersGroups(['userid' => 'UserToLookup']));
 	}
 
 	public function testGetUsersGroupsForAdminUser() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->exactly(2))
 			->method('getUID')
 			->will($this->returnValue('admin'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1505,17 +1591,17 @@ class UsersTest extends OriginalTest {
 			->with('admin')
 			->will($this->returnValue(true));
 
-		$expected = new \OC_OCS_Result(['groups' => ['DummyValue']]);
+		$expected = new \OC\OCS\Result(['groups' => ['DummyValue']]);
 		$this->assertEquals($expected, $this->api->getUsersGroups(['userid' => 'UserToLookup']));
 	}
 
 	public function testGetUsersGroupsForSubAdminUserAndUserIsAccessible() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->exactly(2))
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1545,12 +1631,12 @@ class UsersTest extends OriginalTest {
 			->expects($this->once())
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
-		$group1 = $this->getMock('OCP\IGroup');
+		$group1 = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$group1
 			->expects($this->any())
 			->method('getGID')
 			->will($this->returnValue('Group1'));
-		$group2 = $this->getMock('OCP\IGroup');
+		$group2 = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$group2
 			->expects($this->any())
 			->method('getGID')
@@ -1566,18 +1652,18 @@ class UsersTest extends OriginalTest {
 			->with($targetUser)
 			->will($this->returnValue(['Group1']));
 
-		$expected = new \OC_OCS_Result(['groups' => ['Group1']]);
+		$expected = new \OC\OCS\Result(['groups' => ['Group1']]);
 		$this->assertEquals($expected, $this->api->getUsersGroups(['userid' => 'UserToLookup']));
 	}
 
 
 	public function testGetUsersGroupsForSubAdminUserAndUserIsInaccessible() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->exactly(2))
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1613,7 +1699,7 @@ class UsersTest extends OriginalTest {
 			->with($targetUser)
 			->will($this->returnValue(['Group1']));
 
-		$expected = new \OC_OCS_Result(null, 997);
+		$expected = new \OC\OCS\Result(null, 997);
 		$this->assertEquals($expected, $this->api->getUsersGroups(['userid' => 'UserToLookup']));
 	}
 
@@ -1623,14 +1709,14 @@ class UsersTest extends OriginalTest {
 			->method('getUser')
 			->will($this->returnValue(null));
 
-		$expected = new \OC_OCS_Result(null, 997);
+		$expected = new \OC\OCS\Result(null, 997);
 		$this->assertEquals($expected, $this->api->addToGroup([]));
 	}
 
 	public function testAddToGroupWithTargetGroupNotExisting() {
 		$_POST['groupid'] = 'GroupToAddTo';
 
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
@@ -1650,12 +1736,12 @@ class UsersTest extends OriginalTest {
 			->with('admin')
 			->will($this->returnValue(true));
 
-		$expected = new \OC_OCS_Result(null, 102);
+		$expected = new \OC\OCS\Result(null, 102);
 		$this->assertEquals($expected, $this->api->addToGroup(['userid' => 'TargetUser']));
 	}
 
 	public function testAddToGroupWithNoGroupSpecified() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
@@ -1670,19 +1756,19 @@ class UsersTest extends OriginalTest {
 			->with('admin')
 			->will($this->returnValue(true));
 
-		$expected = new \OC_OCS_Result(null, 101);
+		$expected = new \OC\OCS\Result(null, 101);
 		$this->assertEquals($expected, $this->api->addToGroup(['userid' => 'TargetUser']));
 	}
 
 	public function testAddToGroupWithTargetUserNotExisting() {
 		$_POST['groupid'] = 'GroupToAddTo';
 
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
 			->will($this->returnValue('admin'));
-		$targetGroup = $this->getMock('OCP\IGroup');
+		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -1698,14 +1784,14 @@ class UsersTest extends OriginalTest {
 			->with('admin')
 			->will($this->returnValue(true));
 
-		$expected = new \OC_OCS_Result(null, 103);
+		$expected = new \OC\OCS\Result(null, 103);
 		$this->assertEquals($expected, $this->api->addToGroup(['userid' => 'TargetUser']));
 	}
 
 	public function testAddToGroupWithoutPermission() {
 		$_POST['groupid'] = 'GroupToAddTo';
 
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
@@ -1720,7 +1806,7 @@ class UsersTest extends OriginalTest {
 			->with('admin')
 			->will($this->returnValue(false));
 
-		$expected = new \OC_OCS_Result(null, 997);
+		$expected = new \OC\OCS\Result(null, 997);
 		$this->assertEquals($expected, $this->api->addToGroup(['userid' => 'TargetUser']));
 	}
 
@@ -1730,22 +1816,22 @@ class UsersTest extends OriginalTest {
 			->method('getUser')
 			->will($this->returnValue(null));
 
-		$expected = new \OC_OCS_Result(null, 997);
+		$expected = new \OC\OCS\Result(null, 997);
 		$this->assertEquals($expected, $this->api->removeFromGroup(['userid' => 'TargetUser', '_delete' => ['groupid' => 'TargetGroup']]));
 	}
 
 	public function testRemoveFromGroupWithNoTargetGroup() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
 			->will($this->returnValue($loggedInUser));
-		$expected = new \OC_OCS_Result(null, 101);
+		$expected = new \OC\OCS\Result(null, 101);
 		$this->assertEquals($expected, $this->api->removeFromGroup(['userid' => 'TargetUser', '_delete' => []]));
 	}
 
 	public function testRemoveFromGroupWithNotExistingTargetGroup() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -1756,13 +1842,13 @@ class UsersTest extends OriginalTest {
 			->with('TargetGroup')
 			->will($this->returnValue(null));
 
-		$expected = new \OC_OCS_Result(null, 102);
+		$expected = new \OC\OCS\Result(null, 102);
 		$this->assertEquals($expected, $this->api->removeFromGroup(['userid' => 'TargetUser', '_delete' => ['groupid' => 'TargetGroup']]));
 	}
 
 	public function testRemoveFromGroupWithNotExistingTargetUser() {
-		$loggedInUser = $this->getMock('OCP\IUser');
-		$targetGroup = $this->getMock('OCP\IGroup');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -1778,18 +1864,18 @@ class UsersTest extends OriginalTest {
 			->with('TargetUser')
 			->will($this->returnValue(null));
 
-		$expected = new \OC_OCS_Result(null, 103);
+		$expected = new \OC\OCS\Result(null, 103);
 		$this->assertEquals($expected, $this->api->removeFromGroup(['userid' => 'TargetUser', '_delete' => ['groupid' => 'TargetGroup']]));
 	}
 
 	public function testRemoveFromGroupWithoutPermission() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
 			->will($this->returnValue('unauthorizedUser'));
-		$targetUser = $this->getMock('OCP\IUser');
-		$targetGroup = $this->getMock('OCP\IGroup');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -1816,18 +1902,18 @@ class UsersTest extends OriginalTest {
 			->with('unauthorizedUser')
 			->will($this->returnValue(false));
 
-		$expected = new \OC_OCS_Result(null, 104);
+		$expected = new \OC\OCS\Result(null, 104);
 		$this->assertEquals($expected, $this->api->removeFromGroup(['userid' => 'TargetUser', '_delete' => ['groupid' => 'TargetGroup']]));
 	}
 
 	public function testRemoveFromGroupAsAdminFromAdmin() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('admin'));
-		$targetUser = $this->getMock('OCP\IUser');
-		$targetGroup = $this->getMock('OCP\IGroup');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$targetGroup
 			->expects($this->once())
 			->method('getGID')
@@ -1858,18 +1944,18 @@ class UsersTest extends OriginalTest {
 			->with('admin')
 			->will($this->returnValue(true));
 
-		$expected = new \OC_OCS_Result(null, 105, 'Cannot remove yourself from the admin group');
+		$expected = new \OC\OCS\Result(null, 105, 'Cannot remove yourself from the admin group');
 		$this->assertEquals($expected, $this->api->removeFromGroup(['userid' => 'admin', '_delete' => ['groupid' => 'admin']]));
 	}
 
 	public function testRemoveFromGroupAsSubAdminFromSubAdmin() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMock('OCP\IUser');
-		$targetGroup = $this->getMock('OCP\IGroup');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$targetGroup
 			->expects($this->any())
 			->method('getGID')
@@ -1910,18 +1996,18 @@ class UsersTest extends OriginalTest {
 			->with('subadmin')
 			->will($this->returnValue(false));
 
-		$expected = new \OC_OCS_Result(null, 105, 'Cannot remove yourself from this group as you are a SubAdmin');
+		$expected = new \OC\OCS\Result(null, 105, 'Cannot remove yourself from this group as you are a SubAdmin');
 		$this->assertEquals($expected, $this->api->removeFromGroup(['userid' => 'subadmin', '_delete' => ['groupid' => 'subadmin']]));
 	}
 
 	public function testRemoveFromGroupSuccessful() {
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('admin'));
-		$targetUser = $this->getMock('OCP\IUser');
-		$targetGroup = $this->getMock('OCP\IGroup');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -1952,7 +2038,7 @@ class UsersTest extends OriginalTest {
 			->method('removeUser')
 			->with($targetUser);
 
-		$expected = new \OC_OCS_Result(null, 100);
+		$expected = new \OC\OCS\Result(null, 100);
 		$this->assertEquals($expected, $this->api->removeFromGroup(['userid' => 'AnotherUser', '_delete' => ['groupid' => 'admin']]));
 	}
 
@@ -1963,14 +2049,14 @@ class UsersTest extends OriginalTest {
 			->with('NotExistingUser')
 			->will($this->returnValue(null));
 
-		$expected = new \OC_OCS_Result(null, 101, 'User does not exist');
+		$expected = new \OC\OCS\Result(null, 101, 'User does not exist');
 		$this->assertEquals($expected, $this->api->addSubAdmin(['userid' => 'NotExistingUser']));
 	}
 
 	public function testAddSubAdminWithNotExistingTargetGroup() {
 		$_POST['groupid'] = 'NotExistingGroup';
 
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -1982,15 +2068,15 @@ class UsersTest extends OriginalTest {
 			->with('NotExistingGroup')
 			->will($this->returnValue(null));
 
-		$expected = new \OC_OCS_Result(null, 102, 'Group:NotExistingGroup does not exist');
+		$expected = new \OC\OCS\Result(null, 102, 'Group:NotExistingGroup does not exist');
 		$this->assertEquals($expected, $this->api->addSubAdmin(['userid' => 'ExistingUser']));
 	}
 
 	public function testAddSubAdminToAdminGroup() {
 		$_POST['groupid'] = 'ADmiN';
 
-		$targetUser = $this->getMock('OCP\IUser');
-		$targetGroup = $this->getMock('OCP\IGroup');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -2002,15 +2088,15 @@ class UsersTest extends OriginalTest {
 			->with('ADmiN')
 			->will($this->returnValue($targetGroup));
 
-		$expected = new \OC_OCS_Result(null, 103, 'Cannot create subadmins for admin group');
+		$expected = new \OC\OCS\Result(null, 103, 'Cannot create subadmins for admin group');
 		$this->assertEquals($expected, $this->api->addSubAdmin(['userid' => 'ExistingUser']));
 	}
 
 	public function testAddSubAdminTwice() {
 		$_POST['groupid'] = 'TargetGroup';
 
-		$targetUser = $this->getMock('OCP\IUser');
-		$targetGroup = $this->getMock('OCP\IGroup');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -2033,15 +2119,15 @@ class UsersTest extends OriginalTest {
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
 
-		$expected = new \OC_OCS_Result(null, 100);
+		$expected = new \OC\OCS\Result(null, 100);
 		$this->assertEquals($expected, $this->api->addSubAdmin(['userid' => 'ExistingUser']));
 	}
 
 	public function testAddSubAdminSuccessful() {
 		$_POST['groupid'] = 'TargetGroup';
 
-		$targetUser = $this->getMock('OCP\IUser');
-		$targetGroup = $this->getMock('OCP\IGroup');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -2069,15 +2155,15 @@ class UsersTest extends OriginalTest {
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
 
-		$expected = new \OC_OCS_Result(null, 100);
+		$expected = new \OC\OCS\Result(null, 100);
 		$this->assertEquals($expected, $this->api->addSubAdmin(['userid' => 'ExistingUser']));
 	}
 
 	public function testAddSubAdminUnsuccessful() {
 		$_POST['groupid'] = 'TargetGroup';
 
-		$targetUser = $this->getMock('OCP\IUser');
-		$targetGroup = $this->getMock('OCP\IGroup');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -2105,7 +2191,7 @@ class UsersTest extends OriginalTest {
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
 
-		$expected = new \OC_OCS_Result(null, 103, 'Unknown error occurred');
+		$expected = new \OC\OCS\Result(null, 103, 'Unknown error occurred');
 		$this->assertEquals($expected, $this->api->addSubAdmin(['userid' => 'ExistingUser']));
 	}
 
@@ -2116,12 +2202,12 @@ class UsersTest extends OriginalTest {
 			->with('NotExistingUser')
 			->will($this->returnValue(null));
 
-		$expected = new \OC_OCS_Result(null, 101, 'User does not exist');
+		$expected = new \OC\OCS\Result(null, 101, 'User does not exist');
 		$this->assertEquals($expected, $this->api->removeSubAdmin(['userid' => 'NotExistingUser', '_delete' => ['groupid' => 'GroupToDeleteFrom']]));
 	}
 
 	public function testRemoveSubAdminNotExistingTargetGroup() {
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -2133,13 +2219,13 @@ class UsersTest extends OriginalTest {
 			->with('GroupToDeleteFrom')
 			->will($this->returnValue(null));
 
-		$expected = new \OC_OCS_Result(null, 101, 'Group does not exist');
+		$expected = new \OC\OCS\Result(null, 101, 'Group does not exist');
 		$this->assertEquals($expected, $this->api->removeSubAdmin(['userid' => 'ExistingUser', '_delete' => ['groupid' => 'GroupToDeleteFrom']]));
 	}
 
 	public function testRemoveSubAdminFromNotASubadmin() {
-		$targetUser = $this->getMock('OCP\IUser');
-		$targetGroup = $this->getMock('OCP\IGroup');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -2162,13 +2248,13 @@ class UsersTest extends OriginalTest {
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
 
-		$expected = new \OC_OCS_Result(null, 102, 'User is not a subadmin of this group');
+		$expected = new \OC\OCS\Result(null, 102, 'User is not a subadmin of this group');
 		$this->assertEquals($expected, $this->api->removeSubAdmin(['userid' => 'ExistingUser', '_delete' => ['groupid' => 'GroupToDeleteFrom']]));
 	}
 
 	public function testRemoveSubAdminSuccessful() {
-		$targetUser = $this->getMock('OCP\IUser');
-		$targetGroup = $this->getMock('OCP\IGroup');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -2196,13 +2282,13 @@ class UsersTest extends OriginalTest {
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
 
-		$expected = new \OC_OCS_Result(null, 100);
+		$expected = new \OC\OCS\Result(null, 100);
 		$this->assertEquals($expected, $this->api->removeSubAdmin(['userid' => 'ExistingUser', '_delete' => ['groupid' => 'GroupToDeleteFrom']]));
 	}
 
 	public function testRemoveSubAdminUnsuccessful() {
-		$targetUser = $this->getMock('OCP\IUser');
-		$targetGroup = $this->getMock('OCP\IGroup');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -2230,7 +2316,7 @@ class UsersTest extends OriginalTest {
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
 
-		$expected = new \OC_OCS_Result(null, 103, 'Unknown error occurred');
+		$expected = new \OC\OCS\Result(null, 103, 'Unknown error occurred');
 		$this->assertEquals($expected, $this->api->removeSubAdmin(['userid' => 'ExistingUser', '_delete' => ['groupid' => 'GroupToDeleteFrom']]));
 	}
 
@@ -2241,13 +2327,13 @@ class UsersTest extends OriginalTest {
 			->with('RequestedUser')
 			->will($this->returnValue(null));
 
-		$expected = new \OC_OCS_Result(null, 101, 'User does not exist');
+		$expected = new \OC\OCS\Result(null, 101, 'User does not exist');
 		$this->assertEquals($expected, $this->api->getUserSubAdminGroups(['userid' => 'RequestedUser']));
 	}
 
 	public function testGetUserSubAdminGroupsWithGroups() {
-		$targetUser = $this->getMock('OCP\IUser');
-		$targetGroup = $this->getMock('OCP\IGroup');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$targetGroup
 			->expects($this->once())
 			->method('getGID')
@@ -2269,12 +2355,12 @@ class UsersTest extends OriginalTest {
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
 
-		$expected = new \OC_OCS_Result(['TargetGroup'], 100);
+		$expected = new \OC\OCS\Result(['TargetGroup'], 100);
 		$this->assertEquals($expected, $this->api->getUserSubAdminGroups(['userid' => 'RequestedUser']));
 	}
 
 	public function testGetUserSubAdminGroupsWithoutGroups() {
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -2292,12 +2378,12 @@ class UsersTest extends OriginalTest {
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
 
-		$expected = new \OC_OCS_Result(null, 102, 'Unknown error occurred');
+		$expected = new \OC\OCS\Result(null, 102, 'Unknown error occurred');
 		$this->assertEquals($expected, $this->api->getUserSubAdminGroups(['userid' => 'RequestedUser']));
 	}
 
 	public function testEnableUser() {
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$targetUser->expects($this->once())
 			->method('setEnabled')
 			->with(true);
@@ -2306,7 +2392,7 @@ class UsersTest extends OriginalTest {
 			->method('get')
 			->with('RequestedUser')
 			->will($this->returnValue($targetUser));
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->exactly(2))
 			->method('getUID')
@@ -2320,12 +2406,12 @@ class UsersTest extends OriginalTest {
 			->method('isAdmin')
 			->will($this->returnValue(true));
 
-		$expected = new \OC_OCS_Result(null, 100);
+		$expected = new \OC\OCS\Result(null, 100);
 		$this->assertEquals($expected, $this->api->enableUser(['userid' => 'RequestedUser']));
 	}
 
 	public function testDisableUser() {
-		$targetUser = $this->getMock('OCP\IUser');
+		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$targetUser->expects($this->once())
 			->method('setEnabled')
 			->with(false);
@@ -2334,7 +2420,7 @@ class UsersTest extends OriginalTest {
 			->method('get')
 			->with('RequestedUser')
 			->will($this->returnValue($targetUser));
-		$loggedInUser = $this->getMock('OCP\IUser');
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->exactly(2))
 			->method('getUID')
@@ -2348,7 +2434,7 @@ class UsersTest extends OriginalTest {
 			->method('isAdmin')
 			->will($this->returnValue(true));
 
-		$expected = new \OC_OCS_Result(null, 100);
+		$expected = new \OC\OCS\Result(null, 100);
 		$this->assertEquals($expected, $this->api->disableUser(['userid' => 'RequestedUser']));
 	}
 }


### PR DESCRIPTION
- OC_OCS_Result is deprecated
- getMock is deprecated in phpunit 5.4

Make scrutinizer happier. And makes me happier since there are less warnings in the php7 unit test run!
