### PR TITLE
Split CI in DB & NODB

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,44 +3,68 @@ build:
     image: nextcloudci/jsunit:1.0.6
     commands:
       - ./autotest-js.sh
+  nodb-php5.4:
+    image: nextcloudci/php5.4:1.0.7
+    commands:
+      - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
+      - git submodule update --init
+      - NOCOVERAGE=true TEST_SELECTION=NODB ./autotest.sh sqlite
+  nodb-php5.5:
+    image: nextcloudci/php5.5:1.0.7
+    commands:
+      - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
+      - git submodule update --init
+      - NOCOVERAGE=true TEST_SELECTION=NODB ./autotest.sh sqlite
+  nodb-php5.6:
+    image: nextcloudci/php5.6:1.0.6
+    commands:
+      - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
+      - git submodule update --init
+      - NOCOVERAGE=true TEST_SELECTION=NODB ./autotest.sh sqlite
+  nodb-php7.0:
+    image: nextcloudci/php7.0:1.0.9
+    commands:
+      - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
+      - git submodule update --init
+      - NOCOVERAGE=true TEST_SELECTION=NODB ./autotest.sh sqlite
   sqlite-php5.4:
     image: nextcloudci/php5.4:1.0.7
     commands:
       - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
       - git submodule update --init
-      - NOCOVERAGE=true ./autotest.sh sqlite
+      - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh sqlite
   sqlite-php5.5:
     image: nextcloudci/php5.5:1.0.7
     commands:
       - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
       - git submodule update --init
-      - NOCOVERAGE=true ./autotest.sh sqlite
+      - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh sqlite
   sqlite-php5.6:
     image: nextcloudci/php5.6:1.0.6
     commands:
       - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
       - git submodule update --init
-      - NOCOVERAGE=true ./autotest.sh sqlite
+      - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh sqlite
   sqlite-php7.0:
     image: nextcloudci/php7.0:1.0.9
     commands:
       - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
       - git submodule update --init
-      - NOCOVERAGE=true ./autotest.sh sqlite
+      - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh sqlite
   mysql-php5.6:
     image: nextcloudci/php5.6:1.0.6
     commands:
       - sleep 15 # gives the database enough time to initialize
       - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
       - git submodule update --init
-      - NOCOVERAGE=true ./autotest.sh mysql
+      - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh mysql
   postgres-php5.6:
     image: nextcloudci/php5.6:1.0.6
     commands:
       - sleep 10 # gives the database enough time to initialize
       - rm -rf data/* config/config.php # TODO: remove this - temporary fix for CI issues
       - git submodule update --init
-      - NOCOVERAGE=true ./autotest.sh pgsql
+      - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh pgsql
   integration:
     image: nextcloudci/php7.0:1.0.9
     commands:

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -129,7 +129,7 @@ class ManagerTest extends \Test\TestCase {
 		$backend->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnCallback(function ($actions) {
-				if ($actions === \OC_USER_BACKEND_CHECK_PASSWORD) {
+				if ($actions === \OC\USER\BACKEND::CHECK_PASSWORD) {
 					return true;
 				} else {
 					return false;
@@ -384,7 +384,7 @@ class ManagerTest extends \Test\TestCase {
 
 		$backend->expects($this->once())
 			->method('implementsActions')
-			->with(\OC_USER_BACKEND_COUNT_USERS)
+			->with(\OC\USER\BACKEND::COUNT_USERS)
 			->will($this->returnValue(true));
 
 		$backend->expects($this->once())
@@ -413,7 +413,7 @@ class ManagerTest extends \Test\TestCase {
 
 		$backend1->expects($this->once())
 			->method('implementsActions')
-			->with(\OC_USER_BACKEND_COUNT_USERS)
+			->with(\OC\USER\BACKEND::COUNT_USERS)
 			->will($this->returnValue(true));
 		$backend1->expects($this->once())
 			->method('getBackendName')
@@ -426,7 +426,7 @@ class ManagerTest extends \Test\TestCase {
 
 		$backend2->expects($this->once())
 			->method('implementsActions')
-			->with(\OC_USER_BACKEND_COUNT_USERS)
+			->with(\OC\USER\BACKEND::COUNT_USERS)
 			->will($this->returnValue(true));
 		$backend2->expects($this->once())
 			->method('getBackendName')

--- a/tests/lib/UserTest.php
+++ b/tests/lib/UserTest.php
@@ -41,7 +41,7 @@ class UserTest extends TestCase {
 		$this->backend->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnCallback(function ($actions) {
-				if ($actions === \OC_USER_BACKEND_CHECK_PASSWORD) {
+				if ($actions === \OC\USER\BACKEND::CHECK_PASSWORD) {
 					return true;
 				} else {
 					return false;


### PR DESCRIPTION
This splits the CI up even more (once we have parallel builds that will be more awesome!).

This means we have a DB and NODB run for all supported php versions. We also run all DB's on 5.6 still.
Once we can move more tests over to NODB we could add tests for DB of other php versions as well.

Second commit fixes undefined errors. Probabaly because we don't run some other tests that make sure they are defined :wink: 

CC: @MorrisJobke 
