### PR TITLE
Fix warnings from building docs

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -59,6 +59,7 @@ $CONFIG = array(
  * domains prevents host header poisoning. Do not remove this, as it performs
  * necessary security checks.
  * You can specify:
+ *
  * - the exact hostname of your host or virtual host, e.g. demo.example.org.
  * - the exact hostname with permitted port, e.g. demo.example.org:443.
  *   This disallows all other ports on this host
@@ -823,7 +824,7 @@ $CONFIG = array(
  * defines the interval in minutes for the background job that checks user
  * existence and marks them as ready to be cleaned up. The number is always
  * minutes. Setting it to 0 disables the feature.
- * See command line (occ) methods ldap:show-remnants and user:delete
+ * See command line (occ) methods ``ldap:show-remnants`` and ``user:delete``
  */
 'ldapUserCleanupInterval' => 51,
 


### PR DESCRIPTION
```
/admin_manual/configuration_server/config_sample_php_parameters.rst:72: ERROR: Unexpected indentation.
/admin_manual/configuration_server/config_sample_php_parameters.rst:73: WARNING: Block quote ends without a blank line; unexpected unindent.

/admin_manual/configuration_server/config_sample_php_parameters.rst:: WARNING: unusable reference target found: ldap:show-remnants
```

@MorrisJobke @LukasReschke 
