### PR TITLE
Save the files external mount id in the mount cache table

### DIFF
--- a/apps/files_external/lib/Config/ConfigAdapter.php
+++ b/apps/files_external/lib/Config/ConfigAdapter.php
@@ -151,7 +151,8 @@ class ConfigAdapter implements IMountProvider {
 				'/' . $user->getUID() . '/files' . $storage->getMountPoint(),
 				null,
 				$loader,
-				$storage->getMountOptions()
+				$storage->getMountOptions(),
+				$storage->getId()
 			);
 			$mounts[$storage->getMountPoint()] = $mount;
 		}

--- a/db_structure.xml
+++ b/db_structure.xml
@@ -170,6 +170,11 @@
 				<length>4000</length>
 			</field>
 
+			<field>
+				<name>mount_id</name>
+				<type>integer</type>
+			</field>
+
 			<index>
 				<name>mounts_user_index</name>
 				<unique>false</unique>
@@ -193,6 +198,15 @@
 				<unique>false</unique>
 				<field>
 					<name>root_id</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+
+			<index>
+				<name>mounts_mount_id_index</name>
+				<unique>false</unique>
+				<field>
+					<name>mount_id</name>
 					<sorting>ascending</sorting>
 				</field>
 			</index>

--- a/lib/private/Files/Config/CachedMountInfo.php
+++ b/lib/private/Files/Config/CachedMountInfo.php
@@ -48,18 +48,25 @@ class CachedMountInfo implements ICachedMountInfo {
 	protected $mountPoint;
 
 	/**
+	 * @var int|null
+	 */
+	protected $mountId;
+
+	/**
 	 * CachedMountInfo constructor.
 	 *
 	 * @param IUser $user
 	 * @param int $storageId
 	 * @param int $rootId
 	 * @param string $mountPoint
+	 * @param int|null $mountId
 	 */
-	public function __construct(IUser $user, $storageId, $rootId, $mountPoint) {
+	public function __construct(IUser $user, $storageId, $rootId, $mountPoint, $mountId = null) {
 		$this->user = $user;
 		$this->storageId = $storageId;
 		$this->rootId = $rootId;
 		$this->mountPoint = $mountPoint;
+		$this->mountId = $mountId;
 	}
 
 	/**
@@ -103,5 +110,15 @@ class CachedMountInfo implements ICachedMountInfo {
 	 */
 	public function getMountPoint() {
 		return $this->mountPoint;
+	}
+
+	/**
+	 * Get the id of the configured mount
+	 *
+	 * @return int|null mount id or null if not applicable
+	 * @since 9.1.0
+	 */
+	public function getMountId() {
+		return $this->mountId;
 	}
 }

--- a/lib/private/Files/Config/LazyStorageMountInfo.php
+++ b/lib/private/Files/Config/LazyStorageMountInfo.php
@@ -75,4 +75,8 @@ class LazyStorageMountInfo extends CachedMountInfo {
 		}
 		return parent::getMountPoint();
 	}
+
+	public function getMountId() {
+		return $this->mount->getMountId();
+	}
 }

--- a/lib/private/Files/Mount/MountPoint.php
+++ b/lib/private/Files/Mount/MountPoint.php
@@ -68,14 +68,19 @@ class MountPoint implements IMountPoint {
 	 */
 	private $invalidStorage = false;
 
+	/** @var int|null  */
+	protected $mountId;
+
 	/**
 	 * @param string|\OC\Files\Storage\Storage $storage
 	 * @param string $mountpoint
 	 * @param array $arguments (optional) configuration for the storage backend
 	 * @param \OCP\Files\Storage\IStorageFactory $loader
 	 * @param array $mountOptions mount specific options
+	 * @param int|null $mountId
+	 * @throws \Exception
 	 */
-	public function __construct($storage, $mountpoint, $arguments = null, $loader = null, $mountOptions = null) {
+	public function __construct($storage, $mountpoint, $arguments = null, $loader = null, $mountOptions = null, $mountId = null) {
 		if (is_null($arguments)) {
 			$arguments = array();
 		}
@@ -102,6 +107,7 @@ class MountPoint implements IMountPoint {
 			$this->class = $storage;
 			$this->arguments = $arguments;
 		}
+		$this->mountId = $mountId;
 	}
 
 	/**
@@ -248,5 +254,9 @@ class MountPoint implements IMountPoint {
 	 */
 	public function getStorageRootId() {
 		return (int)$this->getStorage()->getCache()->getId('');
+	}
+
+	public function getMountId() {
+		return $this->mountId;
 	}
 }

--- a/lib/public/Files/Config/ICachedMountInfo.php
+++ b/lib/public/Files/Config/ICachedMountInfo.php
@@ -59,4 +59,12 @@ interface ICachedMountInfo {
 	 * @since 9.0.0
 	 */
 	public function getMountPoint();
+
+	/**
+	 * Get the id of the configured mount
+	 *
+	 * @return int|null mount id or null if not applicable
+	 * @since 9.1.0
+	 */
+	public function getMountId();
 }

--- a/lib/public/Files/Mount/IMountPoint.php
+++ b/lib/public/Files/Mount/IMountPoint.php
@@ -102,4 +102,12 @@ interface IMountPoint {
 	 * @since 9.1.0
 	 */
 	public function getStorageRootId();
+
+	/**
+	 * Get the id of the configured mount
+	 *
+	 * @return int|null mount id or null if not applicable
+	 * @since 9.1.0
+	 */
+	public function getMountId();
 }

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -163,11 +163,13 @@ class UserMountCacheTest extends TestCase {
 		$user = $this->userManager->get('u1');
 
 		$storage = $this->getStorage(10, 20);
-		$mount = new MountPoint($storage, '/foo/');
+		$mount = new MountPoint($storage, '/bar/');
 
 		$this->cache->registerMounts($user, [$mount]);
 
 		$this->clearCache();
+
+		$mount = new MountPoint($storage, '/foo/');
 
 		$this->cache->registerMounts($user, [$mount]);
 
@@ -178,6 +180,29 @@ class UserMountCacheTest extends TestCase {
 		$this->assertCount(1, $cachedMounts);
 		$cachedMount = $cachedMounts[0];
 		$this->assertEquals('/foo/', $cachedMount->getMountPoint());
+	}
+
+	public function testChangeMountId() {
+		$user = $this->userManager->get('u1');
+
+		$storage = $this->getStorage(10, 20);
+		$mount = new MountPoint($storage, '/foo/', null, null, null, null);
+
+		$this->cache->registerMounts($user, [$mount]);
+
+		$this->clearCache();
+
+		$mount = new MountPoint($storage, '/foo/', null, null, null, 1);
+
+		$this->cache->registerMounts($user, [$mount]);
+
+		$this->clearCache();
+
+		$cachedMounts = $this->cache->getMountsForUser($user);
+
+		$this->assertCount(1, $cachedMounts);
+		$cachedMount = $cachedMounts[0];
+		$this->assertEquals(1, $cachedMount->getMountId());
 	}
 
 	public function testGetMountsForUser() {

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 1, 0, 11);
+$OC_Version = array(9, 1, 0, 12);
 
 // The human readable string
 $OC_VersionString = '9.1.0 RC1';


### PR DESCRIPTION
This gives us a way to get all storages (and cache entries) belonging to a configured mount.

Needed for external storage update notifications
