### PR TITLE
Ignore users personal mimetype configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /owncloud
 /config/config.php
 /config/*.config.php
+/config/mimetype*.json
 /config/mount.php
 /apps/inc.php
 /assets


### PR DESCRIPTION
I think will be correct ignore personal mimetypes settings from config.

This setting use in /lib/private/files/type/detection.php:

> **grep -n '/mimetype........json' ./lib/private/files/type/detection.php**

``` php
117:            if (file_exists($this->customConfigDir . '/mimetypealiases.json')) {
118:                    $custom = json_decode(file_get_contents($this->customConfigDir . '/mimetypealiases.json'), true);

142:            if (file_exists($this->customConfigDir . '/mimetypemapping.json')) {
143:                    $custom = json_decode(file_get_contents($this->customConfigDir . '/mimetypemapping.json'), true);
```
