### PR TITLE
updated license script and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Please stay tuned while we get all the repositories up.
 
 Meanwhile check out https://nextcloud.com and follow us on https://twitter.com/nextclouders
 
-If you want to [contribute](https://nextcloud.com/contribute/), you are very welcome: 
+If you want to [contribute](https://nextcloud.com/contribute/), you are very welcome:
 
-- on our IRC channels #nextcloud & #nextcloud-dev irc://#nextcloud-dev@freenode.net (on freenode) and 
+- on our IRC channels #nextcloud & #nextcloud-dev irc://#nextcloud-dev@freenode.net (on freenode) and
 - our forum at https://help.nextcloud.com
 
 Please read the [Code of Conduct](https://nextcloud.com/community/code-of-conduct/). This document offers some guidance to ensure Nextcloud participants can cooperate effectively in a positive and inspiring atmosphere, and to explain how together we can strengthen and support each other.
@@ -30,7 +30,20 @@ if you want to join the Github organization just let us know and we’ll add you
 * ...
 
 ## Contribution Guidelines
-https://nextcloud.com/contribute/
+
+All contributions to this repository from June, 16 2016 on are considered to be
+licensed under the AGPLv3 or any later version.
+
+Nextcloud doesn't require a CLA (Contributor License Agreement).
+The copyright belongs to all the individual contributors. Therefore we recommend
+that every contributor adds following line to the header of a file, if he
+changed it substantially:
+
+```
+@copyright Copyright (c) <year>, <your name> (<your email address>)
+```
+
+More information how to contribute: https://nextcloud.com/contribute/
 
 ## Support
 Learn about the different ways you can get support for Nextcloud: https://nextcloud.com/support/


### PR DESCRIPTION
This pull request introduced following changes:
# license.php
- we keep the copyright statement and only update the authors list. Background: Not every line change is copyrighted so we can't give everyone copyright, just because git blame says that a line was changed by a specific user. This also allows us to add copyright statements to the files next to ownCloud Inc without losing it the next time we run the script
- The script checks the timestamp of each line change. If all lines of a file where changed after 6.6.2016 (the day we forked ownCloud) it will produce a output which allows us to have a look at the file and decide if we can re-license it to AGPLv3 or later.
# readme.md
- add a statement that every contributions from now on are considered to be licensed under the AGPLv3 or later.
-  as explained above, it is not a good idea to change the copyright statement automatically. Therefore we encourage contributors to add a `@copyright ...` line with their name to any file they changed in a substantial way. The script will make sure that everyone is listed as a author, but everyone can and have to decide by its own if his changes are worth a copyright notice.
