### PR TITLE
smb update notifications

### DIFF
--- a/apps/files_external/appinfo/register_command.php
+++ b/apps/files_external/appinfo/register_command.php
@@ -31,6 +31,7 @@ use OCA\Files_External\Command\Delete;
 use OCA\Files_External\Command\Create;
 use OCA\Files_External\Command\Backends;
 use OCA\Files_External\Command\Verify;
+use OCA\Files_External\Command\Notify;
 
 $userManager = OC::$server->getUserManager();
 $userSession = OC::$server->getUserSession();
@@ -42,6 +43,7 @@ $globalStorageService = $app->getContainer()->query('\OCA\Files_External\Service
 $userStorageService = $app->getContainer()->query('\OCA\Files_External\Service\UserStoragesService');
 $importLegacyStorageService = $app->getContainer()->query('\OCA\Files_External\Service\ImportLegacyStoragesService');
 $backendService = $app->getContainer()->query('OCA\Files_External\Service\BackendService');
+$connection = $app->getContainer()->getServer()->getDatabaseConnection();
 
 /** @var Symfony\Component\Console\Application $application */
 $application->add(new ListCommand($globalStorageService, $userStorageService, $userSession, $userManager));
@@ -54,3 +56,4 @@ $application->add(new Delete($globalStorageService, $userStorageService, $userSe
 $application->add(new Create($globalStorageService, $userStorageService, $userManager, $userSession, $backendService));
 $application->add(new Backends($backendService));
 $application->add(new Verify($globalStorageService));
+$application->add(new Notify($globalStorageService, $connection));

--- a/apps/files_external/lib/Command/Notify.php
+++ b/apps/files_external/lib/Command/Notify.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_External\Command;
+
+use OC\Core\Command\Base;
+use OCA\Files_External\Lib\InsufficientDataForMeaningfulAnswerException;
+use OCA\Files_External\Lib\StorageConfig;
+use OCA\Files_External\Service\GlobalStoragesService;
+use OCP\Files\Storage\INotifyStorage;
+use OCP\Files\StorageNotAvailableException;
+use OCP\IDBConnection;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Notify extends Base {
+	/** @var GlobalStoragesService */
+	private $globalService;
+	/** @var IDBConnection */
+	private $connection;
+	/** @var \OCP\DB\QueryBuilder\IQueryBuilder */
+	private $updateQuery;
+
+	function __construct(GlobalStoragesService $globalService, IDBConnection $connection) {
+		parent::__construct();
+		$this->globalService = $globalService;
+		$this->connection = $connection;
+		// the query builder doesn't really like subqueries with parameters
+		$this->updateQuery = $this->connection->prepare(
+			'UPDATE *PREFIX*filecache SET size = -1
+			WHERE `path` = ?
+			AND `storage` IN (SELECT storage_id FROM *PREFIX*mounts WHERE mount_id = ?)'
+		);
+	}
+
+	protected function configure() {
+		$this
+			->setName('files_external:notify')
+			->setDescription('Listen for active update notifications for a configured external mount')
+			->addArgument(
+				'mount_id',
+				InputArgument::REQUIRED,
+				'the mount id of the mount to listen to'
+			)->addOption(
+				'user',
+				'u',
+				InputOption::VALUE_REQUIRED,
+				'The username for the remote mount (required only for some mount configuration that don\'t store credentials)'
+			)->addOption(
+				'password',
+				'p',
+				InputOption::VALUE_REQUIRED,
+				'The password for the remote mount (required only for some mount configuration that don\'t store credentials)'
+			)->addOption(
+				'path',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'The directory in the storage to listen for updates in',
+				'/'
+			);
+		parent::configure();
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$mount = $this->globalService->getStorage($input->getArgument('mount_id'));
+		if (is_null($mount)) {
+			$output->writeln('<error>Mount not found</error>');
+			return 1;
+		}
+		$noAuth = false;
+		try {
+			$authBackend = $mount->getAuthMechanism();
+			$authBackend->manipulateStorageConfig($mount);
+		} catch (InsufficientDataForMeaningfulAnswerException $e) {
+			$noAuth = true;
+		} catch (StorageNotAvailableException $e) {
+			$noAuth = true;
+		}
+
+		if ($input->getOption('user')) {
+			$mount->setBackendOption('user', $input->getOption('user'));
+		}
+		if ($input->getOption('password')) {
+			$mount->setBackendOption('password', $input->getOption('password'));
+		}
+
+		try {
+			$storage = $this->createStorage($mount);
+		} catch (\Exception $e) {
+			$output->writeln('<error>Error while trying to create storage</error>');
+			if ($noAuth) {
+				$output->writeln('<error>Username and/or password required</error>');
+			}
+			return 1;
+		}
+		if (!$storage instanceof INotifyStorage) {
+			$output->writeln('<error>Mount of type "' . $mount->getBackend()->getText() . '" does not support active update notifications</error>');
+			return 1;
+		}
+
+		$verbose = $input->getOption('verbose');
+
+		$path = trim($input->getOption('path'), '/');
+		$storage->listen($path, function ($type, $path, $renameTarget) use ($mount, $verbose, $output) {
+			if ($verbose) {
+				$this->logUpdate($type, $path, $renameTarget, $output);
+			}
+			if ($type == INotifyStorage::NOTIFY_RENAMED) {
+				$this->markParentAsOutdated($mount->getId(), $renameTarget);
+			}
+			$this->markParentAsOutdated($mount->getId(), $path);
+		});
+	}
+
+	private function createStorage(StorageConfig $mount) {
+		$class = $mount->getBackend()->getStorageClass();
+		return new $class($mount->getBackendOptions());
+	}
+
+	private function markParentAsOutdated($mountId, $path) {
+		$parent = dirname($path);
+		if ($parent === '.') {
+			$parent = '';
+		}
+		$this->updateQuery->execute([$parent, $mountId]);
+	}
+
+	private function logUpdate($type, $path, $renameTarget, OutputInterface $output) {
+		switch ($type) {
+			case INotifyStorage::NOTIFY_ADDED:
+				$text = 'added';
+				break;
+			case INotifyStorage::NOTIFY_MODIFIED:
+				$text = 'modified';
+				break;
+			case INotifyStorage::NOTIFY_REMOVED:
+				$text = 'removed';
+				break;
+			case INotifyStorage::NOTIFY_RENAMED:
+				$text = 'renamed';
+				break;
+			default:
+				return;
+		}
+
+		$text .= ' ' . $path;
+		if ($type === INotifyStorage::NOTIFY_RENAMED) {
+			$text .= ' to ' . $renameTarget;
+		}
+
+		$output->writeln($text);
+	}
+}

--- a/apps/files_external/lib/Config/ConfigAdapter.php
+++ b/apps/files_external/lib/Config/ConfigAdapter.php
@@ -151,7 +151,8 @@ class ConfigAdapter implements IMountProvider {
 				'/' . $user->getUID() . '/files' . $storage->getMountPoint(),
 				null,
 				$loader,
-				$storage->getMountOptions()
+				$storage->getMountOptions(),
+				$storage->getId()
 			);
 			$mounts[$storage->getMountPoint()] = $mount;
 		}

--- a/db_structure.xml
+++ b/db_structure.xml
@@ -170,6 +170,11 @@
 				<length>4000</length>
 			</field>
 
+			<field>
+				<name>mount_id</name>
+				<type>integer</type>
+			</field>
+
 			<index>
 				<name>mounts_user_index</name>
 				<unique>false</unique>
@@ -193,6 +198,15 @@
 				<unique>false</unique>
 				<field>
 					<name>root_id</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+
+			<index>
+				<name>mounts_mount_id_index</name>
+				<unique>false</unique>
+				<field>
+					<name>mount_id</name>
 					<sorting>ascending</sorting>
 				</field>
 			</index>

--- a/lib/private/Files/Config/CachedMountInfo.php
+++ b/lib/private/Files/Config/CachedMountInfo.php
@@ -48,18 +48,25 @@ class CachedMountInfo implements ICachedMountInfo {
 	protected $mountPoint;
 
 	/**
+	 * @var int|null
+	 */
+	protected $mountId;
+
+	/**
 	 * CachedMountInfo constructor.
 	 *
 	 * @param IUser $user
 	 * @param int $storageId
 	 * @param int $rootId
 	 * @param string $mountPoint
+	 * @param int|null $mountId
 	 */
-	public function __construct(IUser $user, $storageId, $rootId, $mountPoint) {
+	public function __construct(IUser $user, $storageId, $rootId, $mountPoint, $mountId = null) {
 		$this->user = $user;
 		$this->storageId = $storageId;
 		$this->rootId = $rootId;
 		$this->mountPoint = $mountPoint;
+		$this->mountId = $mountId;
 	}
 
 	/**
@@ -103,5 +110,15 @@ class CachedMountInfo implements ICachedMountInfo {
 	 */
 	public function getMountPoint() {
 		return $this->mountPoint;
+	}
+
+	/**
+	 * Get the id of the configured mount
+	 *
+	 * @return int|null mount id or null if not applicable
+	 * @since 9.1.0
+	 */
+	public function getMountId() {
+		return $this->mountId;
 	}
 }

--- a/lib/private/Files/Config/LazyStorageMountInfo.php
+++ b/lib/private/Files/Config/LazyStorageMountInfo.php
@@ -75,4 +75,8 @@ class LazyStorageMountInfo extends CachedMountInfo {
 		}
 		return parent::getMountPoint();
 	}
+
+	public function getMountId() {
+		return $this->mount->getMountId();
+	}
 }

--- a/lib/private/Files/Mount/MountPoint.php
+++ b/lib/private/Files/Mount/MountPoint.php
@@ -68,14 +68,19 @@ class MountPoint implements IMountPoint {
 	 */
 	private $invalidStorage = false;
 
+	/** @var int|null  */
+	protected $mountId;
+
 	/**
 	 * @param string|\OC\Files\Storage\Storage $storage
 	 * @param string $mountpoint
 	 * @param array $arguments (optional) configuration for the storage backend
 	 * @param \OCP\Files\Storage\IStorageFactory $loader
 	 * @param array $mountOptions mount specific options
+	 * @param int|null $mountId
+	 * @throws \Exception
 	 */
-	public function __construct($storage, $mountpoint, $arguments = null, $loader = null, $mountOptions = null) {
+	public function __construct($storage, $mountpoint, $arguments = null, $loader = null, $mountOptions = null, $mountId = null) {
 		if (is_null($arguments)) {
 			$arguments = array();
 		}
@@ -102,6 +107,7 @@ class MountPoint implements IMountPoint {
 			$this->class = $storage;
 			$this->arguments = $arguments;
 		}
+		$this->mountId = $mountId;
 	}
 
 	/**
@@ -248,5 +254,9 @@ class MountPoint implements IMountPoint {
 	 */
 	public function getStorageRootId() {
 		return (int)$this->getStorage()->getCache()->getId('');
+	}
+
+	public function getMountId() {
+		return $this->mountId;
 	}
 }

--- a/lib/public/Files/Config/ICachedMountInfo.php
+++ b/lib/public/Files/Config/ICachedMountInfo.php
@@ -59,4 +59,12 @@ interface ICachedMountInfo {
 	 * @since 9.0.0
 	 */
 	public function getMountPoint();
+
+	/**
+	 * Get the id of the configured mount
+	 *
+	 * @return int|null mount id or null if not applicable
+	 * @since 9.1.0
+	 */
+	public function getMountId();
 }

--- a/lib/public/Files/Mount/IMountPoint.php
+++ b/lib/public/Files/Mount/IMountPoint.php
@@ -102,4 +102,12 @@ interface IMountPoint {
 	 * @since 9.1.0
 	 */
 	public function getStorageRootId();
+
+	/**
+	 * Get the id of the configured mount
+	 *
+	 * @return int|null mount id or null if not applicable
+	 * @since 9.1.0
+	 */
+	public function getMountId();
 }

--- a/lib/public/Files/Storage/INotifyStorage.php
+++ b/lib/public/Files/Storage/INotifyStorage.php
@@ -23,6 +23,8 @@ namespace OCP\Files\Storage;
 
 /**
  * Storage backend that support active notifications
+ *
+ * @since 9.1.0
  */
 interface INotifyStorage {
 	const NOTIFY_ADDED = 1;
@@ -42,6 +44,8 @@ interface INotifyStorage {
 	 *
 	 * @param string $path
 	 * @param callable $callback
+	 *
+	 * @since 9.1.0
 	 */
 	public function listen($path, callable $callback);
 }

--- a/lib/public/Files/Storage/INotifyStorage.php
+++ b/lib/public/Files/Storage/INotifyStorage.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Files\Storage;
+
+/**
+ * Storage backend that support active notifications
+ */
+interface INotifyStorage {
+	const NOTIFY_ADDED = 1;
+	const NOTIFY_REMOVED = 2;
+	const NOTIFY_MODIFIED = 3;
+	const NOTIFY_RENAMED = 4;
+
+	/**
+	 * Start listening for update notifications
+	 *
+	 * The provided callback will be called for every incoming notification with the following parameters
+	 *  - int $type the type of update, one of the INotifyStorage::NOTIFY_* constants
+	 *  - string $path the path of the update
+	 *  - string $renameTarget the target of the rename operation, only provided for rename updates
+	 *
+	 * Note that this call is blocking and will not exit on it's own, to stop listening for notifications return `false` from the callback
+	 *
+	 * @param string $path
+	 * @param callable $callback
+	 */
+	public function listen($path, callable $callback);
+}

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -163,11 +163,13 @@ class UserMountCacheTest extends TestCase {
 		$user = $this->userManager->get('u1');
 
 		$storage = $this->getStorage(10, 20);
-		$mount = new MountPoint($storage, '/foo/');
+		$mount = new MountPoint($storage, '/bar/');
 
 		$this->cache->registerMounts($user, [$mount]);
 
 		$this->clearCache();
+
+		$mount = new MountPoint($storage, '/foo/');
 
 		$this->cache->registerMounts($user, [$mount]);
 
@@ -178,6 +180,29 @@ class UserMountCacheTest extends TestCase {
 		$this->assertCount(1, $cachedMounts);
 		$cachedMount = $cachedMounts[0];
 		$this->assertEquals('/foo/', $cachedMount->getMountPoint());
+	}
+
+	public function testChangeMountId() {
+		$user = $this->userManager->get('u1');
+
+		$storage = $this->getStorage(10, 20);
+		$mount = new MountPoint($storage, '/foo/', null, null, null, null);
+
+		$this->cache->registerMounts($user, [$mount]);
+
+		$this->clearCache();
+
+		$mount = new MountPoint($storage, '/foo/', null, null, null, 1);
+
+		$this->cache->registerMounts($user, [$mount]);
+
+		$this->clearCache();
+
+		$cachedMounts = $this->cache->getMountsForUser($user);
+
+		$this->assertCount(1, $cachedMounts);
+		$cachedMount = $cachedMounts[0];
+		$this->assertEquals(1, $cachedMount->getMountId());
 	}
 
 	public function testGetMountsForUser() {

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 1, 0, 11);
+$OC_Version = array(9, 1, 0, 12);
 
 // The human readable string
 $OC_VersionString = '9.1.0 RC1';


### PR DESCRIPTION
Requires https://github.com/nextcloud/server/pull/393

Usage `occ files_external:notify <mount_id> [-user=<user>] [--password=<password>]`
(user and password are only needed if the configured auth backend doesn't provide it)

It uses the configured mount to start listening to smb notifications and marks cache entries as incomplete for incoming changes.
This "mark as incomplete" will either cause the background scanner (cron) to update the cache or automatically update the cache entries when the folder is accessed.

It uses the mount<->storage mapping (from #393) to update _all_ cache entries related to the mount, this means that it works as expected in cases where a single configured mount creates a lot storage entries (such as when using per-user auth backends such as login or user entered credentials)
