### PR TITLE
PasswordLoginForbidden is not a FATAL exception

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
@@ -32,6 +32,9 @@ use Sabre\HTTP\Response;
 class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
 	protected $nonFatalExceptions = array(
 		'Sabre\DAV\Exception\NotAuthenticated' => true,
+		// If tokenauth can throw this exception (which is basically as
+		// NotAuthenticated. So not fatal.
+		'OCA\DAV\Connector\Sabre\Exception\PasswordLoginForbidden' => true,
 		// the sync client uses this to find out whether files exist,
 		// so it is not always an error, log it as debug
 		'Sabre\DAV\Exception\NotFound' => true,


### PR DESCRIPTION
It is just a 'Sabre\DAV\Exception\NotAuthenticated' exception
with some special meaning.

So just log it as DEBUG and not as FATAL.

This should cleanup the log.
Also for the intergration tests!

CC: @MorrisJobke @LukasReschke 
