### PR TITLE
Remove asset pipelin

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1169,22 +1169,6 @@ $CONFIG = array(
 'part_file_in_storage' => true,
 
 /**
- * All css and js files will be served by the Web server statically in one js
- * file and one css file if this is set to ``true``. This improves performance.
- */
-'asset-pipeline.enabled' => false,
-
-/**
- * The parent of the directory where css and js assets will be stored if
- * pipelining is enabled; this defaults to the Nextcloud directory. The assets
- * will be stored in a subdirectory of this directory named 'assets'. The
- * server *must* be configured to serve that directory as $WEBROOT/assets.
- * You will only likely need to change this if the main Nextcloud directory
- * is not writeable by the Web server in your configuration.
- */
-'assetdirectory' => '/var/www/nextcloud',
-
-/**
  * Where ``mount.json`` file should be stored, defaults to ``data/mount.json``
  * in the Nextcloud directory.
  */

--- a/lib/private/Repair/AssetCache.php
+++ b/lib/private/Repair/AssetCache.php
@@ -29,14 +29,10 @@ use OCP\Migration\IRepairStep;
 class AssetCache implements IRepairStep {
 
 	public function getName() {
-		return 'Clear asset cache after upgrade';
+		return 'Remove asset cache';
 	}
 
 	public function run(IOutput $output) {
-		if (!\OC_Template::isAssetPipelineEnabled()) {
-			$output->info('Asset pipeline disabled -> nothing to do');
-			return;
-		}
 		$assetDir = \OC::$server->getConfig()->getSystemValue('assetdirectory', \OC::$SERVERROOT) . '/assets';
 		\OC_Helper::rmdirr($assetDir, false);
 		$output->info('Asset cache cleared.');

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -137,36 +137,30 @@ class TemplateLayout extends \OC_Template {
 			self::$versionHash = md5('not installed');
 		}
 
-		$useAssetPipeline = self::isAssetPipelineEnabled();
-		if ($useAssetPipeline) {
+		// Add the js files
+		$jsFiles = self::findJavascriptFiles(\OC_Util::$scripts);
+		$this->assign('jsfiles', array());
+		if ($this->config->getSystemValue('installed', false) && $renderAs != 'error') {
 			$this->append( 'jsfiles', \OC::$server->getURLGenerator()->linkToRoute('js_config', ['v' => self::$versionHash]));
-			$this->generateAssets();
-		} else {
-			// Add the js files
-			$jsFiles = self::findJavascriptFiles(\OC_Util::$scripts);
-			$this->assign('jsfiles', array());
-			if ($this->config->getSystemValue('installed', false) && $renderAs != 'error') {
-				$this->append( 'jsfiles', \OC::$server->getURLGenerator()->linkToRoute('js_config', ['v' => self::$versionHash]));
-			}
-			foreach($jsFiles as $info) {
-				$web = $info[1];
-				$file = $info[2];
-				$this->append( 'jsfiles', $web.'/'.$file . '?v=' . self::$versionHash);
-			}
+		}
+		foreach($jsFiles as $info) {
+			$web = $info[1];
+			$file = $info[2];
+			$this->append( 'jsfiles', $web.'/'.$file . '?v=' . self::$versionHash);
+		}
 
-			// Add the css files
-			$cssFiles = self::findStylesheetFiles(\OC_Util::$styles);
-			$this->assign('cssfiles', array());
-			$this->assign('printcssfiles', []);
-			foreach($cssFiles as $info) {
-				$web = $info[1];
-				$file = $info[2];
+		// Add the css files
+		$cssFiles = self::findStylesheetFiles(\OC_Util::$styles);
+		$this->assign('cssfiles', array());
+		$this->assign('printcssfiles', []);
+		foreach($cssFiles as $info) {
+			$web = $info[1];
+			$file = $info[2];
 
 			if (substr($file, -strlen('print.css')) === 'print.css') {
-					$this->append( 'printcssfiles', $web.'/'.$file . '?v=' . self::$versionHash);
-				} else {
-					$this->append( 'cssfiles', $web.'/'.$file . '?v=' . self::$versionHash);
-				}
+				$this->append( 'printcssfiles', $web.'/'.$file . '?v=' . self::$versionHash);
+			} else {
+				$this->append( 'cssfiles', $web.'/'.$file . '?v=' . self::$versionHash);
 			}
 		}
 	}
@@ -205,91 +199,6 @@ class TemplateLayout extends \OC_Template {
 		return $locator->getResources();
 	}
 
-	public function generateAssets() {
-		$assetDir = \OC::$server->getConfig()->getSystemValue('assetdirectory', \OC::$SERVERROOT);
-		$jsFiles = self::findJavascriptFiles(\OC_Util::$scripts);
-		$jsHash = self::hashFileNames($jsFiles);
-
-		if (!file_exists("$assetDir/assets/$jsHash.js")) {
-			$jsFiles = array_map(function ($item) {
-				$root = $item[0];
-				$file = $item[2];
-				// no need to minifiy minified files
-				if (substr($file, -strlen('.min.js')) === '.min.js') {
-					return new FileAsset($root . '/' . $file, array(
-						new SeparatorFilter(';')
-					), $root, $file);
-				}
-				return new FileAsset($root . '/' . $file, array(
-					new JSqueezeFilter(),
-					new SeparatorFilter(';')
-				), $root, $file);
-			}, $jsFiles);
-			$jsCollection = new AssetCollection($jsFiles);
-			$jsCollection->setTargetPath("assets/$jsHash.js");
-
-			$writer = new AssetWriter($assetDir);
-			$writer->writeAsset($jsCollection);
-		}
-
-		$cssFiles = self::findStylesheetFiles(\OC_Util::$styles);
-
-		// differentiate between screen stylesheets and printer stylesheets
-		$screenCssFiles = array_filter($cssFiles, function($cssFile) {
-			return substr_compare($cssFile[2], 'print.css', -strlen('print.css')) !== 0;
-		});
-		$screenCssAsset = $this->generateCssAsset($screenCssFiles);
-
-		$printCssFiles = array_filter($cssFiles, function($cssFile) {
-			return substr_compare($cssFile[2], 'print.css', -strlen('print.css')) === 0;
-		});
-		$printCssAsset = $this->generateCssAsset($printCssFiles);
-
-		$this->append('jsfiles', \OC::$server->getURLGenerator()->linkTo('assets', "$jsHash.js"));
-		$this->append('cssfiles', $screenCssAsset);
-		$this->append('printcssfiles', $printCssAsset);
-	}
-
-	/**
-	 * generates a single css asset file from an array of css files if at least one of them has changed
-	 * otherwise it just returns the path to the old asset file
-	 * @param $files
-	 * @return string
-	 */
-	private function generateCssAsset($files) {
-		$assetDir = \OC::$server->getConfig()->getSystemValue('assetdirectory', \OC::$SERVERROOT);
-		$hash = self::hashFileNames($files);
-
-		if (!file_exists("$assetDir/assets/$hash.css")) {
-			$files = array_map(function ($item) {
-				$root = $item[0];
-				$file = $item[2];
-				$assetPath = $root . '/' . $file;
-				$sourceRoot =  \OC::$SERVERROOT;
-				$sourcePath = substr($assetPath, strlen(\OC::$SERVERROOT));
-				return new FileAsset(
-					$assetPath,
-					array(
-						new CssRewriteFilter(),
-						new CssMinFilter(),
-						new CssImportFilter()
-					),
-					$sourceRoot,
-					$sourcePath
-				);
-			}, $files);
-
-			$cssCollection = new AssetCollection($files);
-			$cssCollection->setTargetPath("assets/$hash.css");
-
-			$writer = new AssetWriter($assetDir);
-			$writer->writeAsset($cssCollection);
-
-		}
-
-		return \OC::$server->getURLGenerator()->linkTo('assets', "$hash.css");
-	}
-
 	/**
 	 * Converts the absolute file path to a relative path from \OC::$SERVERROOT
 	 * @param string $filePath Absolute path
@@ -303,25 +212,5 @@ class TemplateLayout extends \OC_Template {
 		}
 
 		return $relativePath[1];
-	}
-
-	/**
-	 * @param array $files
-	 * @return string
-	 */
-
-	private static function hashFileNames($files) {
-		foreach($files as $i => $file) {
-			try {
-				$files[$i] = self::convertToRelativePath($file[0]).'/'.$file[2];
-			} catch (\Exception $e) {
-				$files[$i] = $file[0].'/'.$file[2];
-			}
-		}
-
-		sort($files);
-		// include the apps' versions hash to invalidate the cached assets
-		$files[] = self::$versionHash;
-		return hash('md5', implode('', $files));
 	}
 }

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -395,46 +395,4 @@ class OC_Template extends \OC\Template\Base {
 		}
 		return 'HTTP/1.1';
 	}
-
-	/**
-	 * @return bool
-	 */
-	public static function isAssetPipelineEnabled() {
-		try {
-			if (\OCP\Util::needUpgrade()) {
-				// Don't use the compiled asset when we need to do an update
-				return false;
-			}
-		} catch (\Exception $e) {
-			// Catch any exception, because this code is also called when displaying
-			// an exception error page.
-			return false;
-		}
-
-		// asset management enabled?
-		$config = \OC::$server->getConfig();
-		$useAssetPipeline = $config->getSystemValue('asset-pipeline.enabled', false);
-		if (!$useAssetPipeline) {
-			return false;
-		}
-
-		// assets folder exists?
-		$assetDir = $config->getSystemValue('assetdirectory', \OC::$SERVERROOT) . '/assets';
-		if (!is_dir($assetDir)) {
-			if (!mkdir($assetDir)) {
-				\OCP\Util::writeLog('assets',
-					"Folder <$assetDir> does not exist and/or could not be generated.", \OCP\Util::ERROR);
-				return false;
-			}
-		}
-
-		// assets folder can be accessed?
-		if (!touch($assetDir."/.oc")) {
-			\OCP\Util::writeLog('assets',
-				"Folder <$assetDir> could not be accessed.", \OCP\Util::ERROR);
-			return false;
-		}
-		return $useAssetPipeline;
-	}
-
 }


### PR DESCRIPTION
Fixes #215

The asset pipeline has shown to do more harm than good. Some apps fail
hard with it. Also it makes sure that you download a huge file on each
unvisited page.

@LukasReschke as discussed

CC: @MorrisJobke @BernhardPosselt @popov-d @nickvergessen 
