### PR TITLE
Move SetupFromToken to ShareManager

### DIFF
--- a/apps/files_sharing/ajax/shareinfo.php
+++ b/apps/files_sharing/ajax/shareinfo.php
@@ -53,11 +53,12 @@ if (isset($_GET['dir'])) {
 
 $data = \OCA\Files_Sharing\Helper::setupFromToken($token, $relativePath, $password);
 
-$linkItem = $data['linkItem'];
+/** @var \OCP\Share\IShare $share */
+$share = $data['share'];
 // Load the files
 $path = $data['realPath'];
 
-$isWritable = $linkItem['permissions'] & (\OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE);
+$isWritable = $share->getPermissions() & (\OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE);
 if (!$isWritable) {
 	\OC\Files\Filesystem::addStorageWrapper('readonly', function ($mountPoint, $storage) {
 		return new \OC\Files\Storage\Wrapper\PermissionsMask(array('storage' => $storage, 'mask' => \OCP\Constants::PERMISSION_READ + \OCP\Constants::PERMISSION_SHARE));
@@ -66,10 +67,6 @@ if (!$isWritable) {
 
 $rootInfo = \OC\Files\Filesystem::getFileInfo($path);
 $rootView = new \OC\Files\View('');
-
-$shareManager = \OC::$server->getShareManager();
-$share = $shareManager->getShareByToken($token);
-$sharePermissions= (int)$share->getPermissions();
 
 if($rootInfo === false || !($share->getPermissions() & \OCP\Constants::PERMISSION_READ)) {
 	OCP\JSON::error(array('data' => 'Share is not readable.'));
@@ -98,11 +95,11 @@ function getChildInfo($dir, $view, $sharePermissions) {
 
 $result = \OCA\Files\Helper::formatFileInfo($rootInfo);
 $result['mtime'] = $result['mtime'] / 1000;
-$result['permissions'] = (int)$result['permissions'] & $sharePermissions;
+$result['permissions'] = (int)$result['permissions'] & $share->getPermissions();
 
 
 if ($rootInfo->getType() === 'dir') {
-	$result['children'] = getChildInfo($rootInfo, $rootView, $sharePermissions);
+	$result['children'] = getChildInfo($rootInfo, $rootView, $share->getPermissions());
 }
 
 OCP\JSON::success(array('data' => $result));


### PR DESCRIPTION
- Moving calls to the old \OCP\Share to the new fancy shiny sharemanager.

Lets see what CI has to say.
