### PR TITLE
Fix maintenance mode

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -620,7 +620,7 @@ class Server extends ServerContainer implements IServerContainer {
 			return $factory->getManager();
 		});
 		$this->registerService('ThemingDefaults', function(Server $c) {
-			if($this->getConfig()->getSystemValue('installed', false) && $this->getAppManager()->isInstalled('theming')) {
+			if(class_exists('OCA\Theming\Template', false) && $this->getConfig()->getSystemValue('installed', false) && $this->getAppManager()->isInstalled('theming')) {
 				return new Template(
 					$this->getConfig(),
 					$this->getL10N('theming'),


### PR DESCRIPTION
When the server is in maintenance mode, apps are not loaded.
That means apps/theming/ is not in the allowed paths. So we
need to check without autoloading, whether the class exists.
### Steps
1. Enable theming
2. Set instance to maintenance mode
3. Reload UI
4. Expect 503, get 500
