### PR TITLE
[stable9] Fix maintenance mode

### DIFF
--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -565,7 +565,7 @@ class Server extends ServerContainer implements IServerContainer {
 			return $factory->getManager();
 		});
 		$this->registerService('ThemingDefaults', function(Server $c) {
-			if($this->getConfig()->getSystemValue('installed', false) && $this->getAppManager()->isInstalled('theming')) {
+			if(class_exists('OCA\Theming\Template', false) && $this->getConfig()->getSystemValue('installed', false) && $this->getAppManager()->isInstalled('theming')) {
 				return new Template(
 					$this->getConfig(),
 					$this->getL10N('theming'),


### PR DESCRIPTION
When the server is in maintenance mode, apps are not loaded.
That means apps/theming/ is not in the allowed paths. So we
need to check without autoloading, whether the class exists.

Backport of #441 
