### PR TITLE
[WIP] experiment with opening menus on hover

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -625,7 +625,7 @@ var OC={
 	registerMenu: function($toggle, $menuEl) {
 		var self = this;
 		$menuEl.addClass('menu');
-		$toggle.on('click.menu', function(event) {
+		$toggle.on('hover.menu', function(event) {
 			// prevent the link event (append anchor to URL)
 			event.preventDefault();
 


### PR DESCRIPTION
Something I wanted to try out, ref https://github.com/owncloud/core/issues/23683. Already trying out this prototype for a bit I’m not sure it’s a good idea. It feels a bit twitchy and stuff opening when you don’t want it to. What do you think @nextcloud/designers @ChristophWurst @MorrisJobke?

What would still need to be done to make it proper:
- [ ] menu needs to stay open
- [ ] should still work on click too, needs to work on mobile
- [ ] file actions menu should do that too, as should the 3-dot menus in the sidebar of apps (Mail)
