### PR TITLE
fix Github link in Personal and Admin settings Version note

### DIFF
--- a/settings/templates/settings.development.notice.php
+++ b/settings/templates/settings.development.notice.php
@@ -9,7 +9,7 @@
 			],
 			[
 				'<a href="https://nextcloud.com/contribute" target="_blank" rel="noreferrer">',
-				'<a href="https://github.com/owncloud" target="_blank" rel="noreferrer">',
+				'<a href="https://github.com/nextcloud" target="_blank" rel="noreferrer">',
 				'<a href="https://www.gnu.org/licenses/agpl-3.0.html" target="_blank" rel="noreferrer">',
 				'</a>',
 			],


### PR DESCRIPTION
Seems we forgot to change one Github link. ;)

Please review @karlitschek @LukasReschke @MorrisJobke
Needs backport too.
