### PR TITLE
Adjust wording and layout of Sessions and App passwords personal settings

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -104,6 +104,7 @@ table.nostyle td { padding: 0.2em 0; }
 	width: 100%;
 	min-height: 150px;
 	padding-top: 5px;
+	max-width: 580px;
 }
 #sessions table th,
 #apppasswords table th {

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -38,8 +38,7 @@ input#openid, input#webdav { width:20em; }
 #displaynameform,
 #lostpassword,
 #groups,
-#passwordform,
-#language {
+#passwordform {
 	display: inline-block;
 	margin-bottom: 0;
 	padding-bottom: 0;
@@ -104,17 +103,17 @@ table.nostyle td { padding: 0.2em 0; }
 #apppasswords table {
 	width: 100%;
 	min-height: 150px;
-	padding-top: 25px;
+	padding-top: 5px;
 }
 #sessions table th,
 #apppasswords table th {
-	font-weight: 800;
+	opacity: .5;
 }
 #sessions table th,
 #sessions table td,
 #apppasswords table th,
 #apppasswords table td {
-	padding: 10px;
+	padding: 10px 10px 10px 0;
 }
 
 #sessions .token-list td,

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -167,12 +167,12 @@ if($_['passwordChangeSupported']) {
 
 <div id="sessions" class="section">
 	<h2><?php p($l->t('Sessions'));?></h2>
-	<span class="hidden-when-empty"><?php p($l->t('These are the web, desktop and mobile clients currently logged in to your account.'));?></span>
+	<span class="hidden-when-empty"><?php p($l->t('Web, desktop and mobile clients currently logged in to your account.'));?></span>
 	<table>
 		<thead class="token-list-header">
 			<tr>
-				<th><?php p($l->t('Browser'));?></th>
-				<th><?php p($l->t('Most recent activity'));?></th>
+				<th><?php p($l->t('Device'));?></th>
+				<th><?php p($l->t('Recent activity'));?></th>
 				<th></th>
 			</tr>
 		</thead>
@@ -183,19 +183,18 @@ if($_['passwordChangeSupported']) {
 
 <div id="apppasswords" class="section">
 	<h2><?php p($l->t('App passwords'));?></h2>
-	<span class="hidden-when-empty"><?php p($l->t("You've linked these apps."));?></span>
+	<p><?php p($l->t('Passcodes that give an app or device permissions to access your account.'));?></p>
 	<table>
 		<thead class="hidden-when-empty">
 			<tr>
 				<th><?php p($l->t('Name'));?></th>
-				<th><?php p($l->t('Most recent activity'));?></th>
+				<th><?php p($l->t('Recent activity'));?></th>
 				<th></th>
 			</tr>
 		</thead>
 		<tbody class="token-list icon-loading">
 		</tbody>
 	</table>
-	<p><?php p($l->t('An app password is a passcode that gives an app or device permissions to access your %s account.', [$theme->getName()]));?></p>
 	<div id="app-password-form">
 		<input id="app-password-name" type="text" placeholder="<?php p($l->t('App name')); ?>">
 		<button id="add-app-password" class="button"><?php p($l->t('Create new app password')); ?></button>


### PR DESCRIPTION
- changed headers from bold to half-transparent. The important info is the _content_, not the headers. (See Files app.)
- adjusted padding to be flush to the left with rest
- adjusted wording to be shorter so it works on mobile without a scrollbar
- shortened explanatory texts
- capped overall width to be maximally the width of the sync apps icons so it’s visually balanced and not all over the place on large screens

Please review @nextcloud/designers @ChristophWurst

Before & after:
![capture du 2016-07-19 11-43-43](https://cloud.githubusercontent.com/assets/925062/16956003/070518f6-4dd7-11e6-88ad-eb781c21ede4.png)
![capture du 2016-07-19 11-41-57](https://cloud.githubusercontent.com/assets/925062/16956004/0706c07a-4dd7-11e6-9277-a8a81c2a12c5.png)
