### PR TITLE
[master] Change load order of auth backends so that we can throw an exception …

### DIFF
--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -72,12 +72,15 @@ class Server {
 		$this->server->setBaseUri($this->baseUri);
 
 		$this->server->addPlugin(new BlockLegacyClientPlugin(\OC::$server->getConfig()));
-		$authPlugin = new Plugin($authBackend, 'ownCloud');
+		$authPlugin = new Plugin();
 		$this->server->addPlugin($authPlugin);
 
 		// allow setup of additional auth backends
 		$event = new SabrePluginEvent($this->server);
 		$dispatcher->dispatch('OCA\DAV\Connector\Sabre::authInit', $event);
+
+		// because we are throwing exceptions this plugin has to be the last one
+		$authPlugin->addBackend($authBackend);
 
 		// debugging
 		if(\OC::$server->getConfig()->getSystemValue('debug', false)) {


### PR DESCRIPTION
…in OCA\DAV\Connector\Sabre\Auth - fixes #25362 (#25476)

From https://github.com/owncloud/core/pull/25476
