### PR TITLE
Fix file permissions for SMB (read-only folders will be writeable) (#…

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -383,6 +383,19 @@ class SMB extends \OC\Files\Storage\Common {
 	public function isUpdatable($path) {
 		try {
 			$info = $this->getFileInfo($path);
+			// following windows behaviour for read-only folders: they can be written into
+			// (https://support.microsoft.com/en-us/kb/326549 - "cause" section)
+			return !$info->isHidden() && (!$info->isReadOnly() || $this->is_dir($path));
+		} catch (NotFoundException $e) {
+			return false;
+		} catch (ForbiddenException $e) {
+			return false;
+		}
+	}
+
+	public function isDeletable($path) {
+		try {
+			$info = $this->getFileInfo($path);
 			return !$info->isHidden() && !$info->isReadOnly();
 		} catch (NotFoundException $e) {
 			return false;


### PR DESCRIPTION
…25301)
- Fix file permissions for SMB (read-only folders will be writeable)
- Read-only folders won't be deletable
- Added comment for the read-only behaviour for folders

---

From https://github.com/owncloud/core/pull/25301

@icewind1991 please review.
