### PR TITLE
Escape special characters (#25429)

### DIFF
--- a/apps/dav/lib/Connector/Sabre/CustomPropertiesBackend.php
+++ b/apps/dav/lib/Connector/Sabre/CustomPropertiesBackend.php
@@ -327,7 +327,7 @@ class CustomPropertiesBackend implements BackendInterface {
 
 		$result = $this->connection->executeQuery(
 			$sql,
-			array($this->user, rtrim($path, '/') . '/%', $requestedProperties),
+			array($this->user, $this->connection->escapeLikeParameter(rtrim($path, '/')) . '/%', $requestedProperties),
 			array(null, null, \Doctrine\DBAL\Connection::PARAM_STR_ARRAY)
 		);
 

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -623,7 +623,7 @@ class Access extends LDAPUtility implements IUserTools {
 	 * "Developers"
 	 */
 	private function _createAltInternalOwnCloudNameForGroups($name) {
-		$usedNames = $this->groupMapper->getNamesBySearch($name.'_%');
+		$usedNames = $this->groupMapper->getNamesBySearch($name, "", '_%');
 		if(!($usedNames) || count($usedNames) === 0) {
 			$lastNo = 1; //will become name_2
 		} else {

--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -138,16 +138,18 @@ abstract class AbstractMapping {
 	/**
 	 * Searches mapped names by the giving string in the name column
 	 * @param string $search
+	 * @param string $prefixMatch
+	 * @param string $postfixMatch
 	 * @return string[]
 	 */
-	public function getNamesBySearch($search) {
+	public function getNamesBySearch($search, $prefixMatch = "", $postfixMatch = "") {
 		$query = $this->dbc->prepare('
 			SELECT `owncloud_name`
 			FROM `'. $this->getTableName() .'`
 			WHERE `owncloud_name` LIKE ?
 		');
 
-		$res = $query->execute(array($search));
+		$res = $query->execute(array($prefixMatch.$this->dbc->escapeLikeParameter($search).$postfixMatch));
 		$names = array();
 		if($res !== false) {
 			while($row = $query->fetch()) {

--- a/apps/user_ldap/tests/Mapping/AbstractMappingTest.php
+++ b/apps/user_ldap/tests/Mapping/AbstractMappingTest.php
@@ -164,7 +164,7 @@ abstract class AbstractMappingTest extends \Test\TestCase {
 	public function testSearch() {
 		list($mapper,) = $this->initTest();
 
-		$names = $mapper->getNamesBySearch('%oo%');
+		$names = $mapper->getNamesBySearch('oo', '%', '%');
 		$this->assertTrue(is_array($names));
 		$this->assertSame(2, count($names));
 		$this->assertTrue(in_array('Foobar', $names));

--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -285,7 +285,7 @@ class Database extends \OC\Group\Backend {
 		$parameters = [$gid];
 		$searchLike = '';
 		if ($search !== '') {
-			$parameters[] = '%' . $search . '%';
+			$parameters[] = '%' . $this->dbConn->escapeLikeParameter($search) . '%';
 			$searchLike = ' AND `uid` LIKE ?';
 		}
 
@@ -311,7 +311,7 @@ class Database extends \OC\Group\Backend {
 		$parameters = [$gid];
 		$searchLike = '';
 		if ($search !== '') {
-			$parameters[] = '%' . $search . '%';
+			$parameters[] = '%' . $this->dbConn->escapeLikeParameter($search) . '%';
 			$searchLike = ' AND `uid` LIKE ?';
 		}
 

--- a/lib/private/Repair/RepairLegacyStorages.php
+++ b/lib/private/Repair/RepairLegacyStorages.php
@@ -172,7 +172,7 @@ class RepairLegacyStorages implements IRepairStep{
 		$sql = 'SELECT `id`, `numeric_id` FROM `*PREFIX*storages`'
 			. ' WHERE `id` LIKE ?'
 			. ' ORDER BY `id`';
-		$result = $this->connection->executeQuery($sql, array($dataDirId . '%'));
+		$result = $this->connection->executeQuery($sql, array($this->connection->escapeLikeParameter($dataDirId) . '%'));
 
 		while ($row = $result->fetch()) {
 			$currentId = $row['id'];


### PR DESCRIPTION
- Escape LIKE parameter
- Escape LIKE parameter
- Escape LIKE parameter
- Escape LIKE parameter
- Escape LIKE parameter
- Use correct method in the AbstractMapping class
- Change the getNamesBySearch method so that input can be properly escaped while still supporting matches
- Don't escape hardcoded wildcard

---

From https://github.com/owncloud/core/pull/25429
