### PR TITLE
[stable9] Cast share id to string (#25402) (#25431)

### DIFF
--- a/apps/dav/lib/connector/publicauth.php
+++ b/apps/dav/lib/connector/publicauth.php
@@ -89,7 +89,7 @@ class PublicAuth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
 					}
 					return true;
 				} else if (\OC::$server->getSession()->exists('public_link_authenticated')
-					&& \OC::$server->getSession()->get('public_link_authenticated') === $linkItem['id']) {
+					&& \OC::$server->getSession()->get('public_link_authenticated') === (string)$linkItem['id']) {
 					return true;
 				} else {
 					return false;


### PR DESCRIPTION
Downstreaming of https://github.com/owncloud/core/pull/25431
