### PR TITLE
Added storage tests for fopen with special chars

### DIFF
--- a/apps/files_external/tests/env/start-swift-ceph.sh
+++ b/apps/files_external/tests/env/start-swift-ceph.sh
@@ -80,7 +80,7 @@ if ! "$thisFolder"/env/wait-for-connection ${host} 80 600; then
     exit 1
 fi
 echo "Waiting another 15 seconds"
-sleep 15
+sleep 15 
 
 cat > $thisFolder/config.swift.php <<DELIM
 <?php

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -105,6 +105,17 @@ abstract class Storage extends \Test\TestCase {
 		$this->assertEquals(array(), $content);
 	}
 
+	public function fileNameProvider() {
+		return [
+			['file.txt'],
+			[' file.txt'],
+			['folder .txt'],
+			['file with space.txt'],
+			['spéciäl fäile'],
+			['test single\'quote.txt'],
+		];
+	}
+
 	public function directoryProvider() {
 		return [
 			['folder'],
@@ -336,22 +347,25 @@ abstract class Storage extends \Test\TestCase {
 		$this->assertFalse($this->instance->file_exists('/lorem.txt'));
 	}
 
-	public function testFOpen() {
+	/**
+	 * @dataProvider fileNameProvider
+	 */
+	public function testFOpen($fileName) {
 		$textFile = \OC::$SERVERROOT . '/tests/data/lorem.txt';
 
-		$fh = @$this->instance->fopen('foo', 'r');
+		$fh = @$this->instance->fopen($fileName, 'r');
 		if ($fh) {
 			fclose($fh);
 		}
 		$this->assertFalse($fh);
-		$this->assertFalse($this->instance->file_exists('foo'));
+		$this->assertFalse($this->instance->file_exists($fileName));
 
-		$fh = $this->instance->fopen('foo', 'w');
+		$fh = $this->instance->fopen($fileName, 'w');
 		fwrite($fh, file_get_contents($textFile));
 		fclose($fh);
-		$this->assertTrue($this->instance->file_exists('foo'));
+		$this->assertTrue($this->instance->file_exists($fileName));
 
-		$fh = $this->instance->fopen('foo', 'r');
+		$fh = $this->instance->fopen($fileName, 'r');
 		$content = stream_get_contents($fh);
 		$this->assertEquals(file_get_contents($textFile), $content);
 	}


### PR DESCRIPTION
This makes it possible to test special chars with unit tests.
There is already a test for directories but there was none for file
names.
