### PR TITLE
only show additional edit permissions for folders

### DIFF
--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -38,7 +38,9 @@
 					'<span class="shareOption">' +
 						'<input id="canEdit-{{cid}}-{{shareWith}}" type="checkbox" name="edit" class="permissions checkbox" {{#if hasEditPermission}}checked="checked"{{/if}} />' +
 						'<label for="canEdit-{{cid}}-{{shareWith}}">{{canEditLabel}}</label>' +
+						'{{#if isFolder}}' +
 						'<a href="#" class="showCruds"><img alt="{{crudsLabel}}" src="{{triangleSImage}}"/></a>' +
+						'{{/if}}' +
 					'</span>' +
 					'{{/if}}' +
 					'<div class="cruds hidden">' +
@@ -162,7 +164,8 @@
 				sharePermission: OC.PERMISSION_SHARE,
 				createPermission: OC.PERMISSION_CREATE,
 				updatePermission: OC.PERMISSION_UPDATE,
-				deletePermission: OC.PERMISSION_DELETE
+				deletePermission: OC.PERMISSION_DELETE,
+				isFolder: this.model.isFolder()
 			};
 
 			if(!this.model.hasUserShares()) {


### PR DESCRIPTION
Only show additional edit permissions for folders. For files the only edit permission is "change" so it doesn't make sense to show the additional CRUDS if it is only one permission which toggles simultaneously with the  "can edit" check box.

Old:

![share-dialog-old](https://cloud.githubusercontent.com/assets/1589737/16987937/e0580160-4e8e-11e6-8c65-35bb6cb08d94.png)

New:

![share-dialog-new](https://cloud.githubusercontent.com/assets/1589737/16987944/e529e5b4-4e8e-11e6-8721-c35393b4b8be.png)

cc @nextcloud/designers @blizzz @rullzer
