### PR TITLE
Add OCS Middleware

### DIFF
--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -38,6 +38,7 @@ use OC\AppFramework\Http\Dispatcher;
 use OC\AppFramework\Http\Output;
 use OC\AppFramework\Middleware\MiddlewareDispatcher;
 use OC\AppFramework\Middleware\Security\CORSMiddleware;
+use OC\AppFramework\Middleware\OCSMiddleware;
 use OC\AppFramework\Middleware\Security\SecurityMiddleware;
 use OC\AppFramework\Middleware\SessionMiddleware;
 use OC\AppFramework\Utility\SimpleContainer;
@@ -373,6 +374,12 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return new TwoFactorMiddleware($twoFactorManager, $userSession, $session, $urlGenerator, $reflector, $request);
 		});
 
+		$this->registerService('OCSMiddleware', function (SimpleContainer $c) {
+			return new OCSMiddleware(
+				$c['Request']
+			);
+		});
+
 		$middleWares = &$this->middleWares;
 		$this->registerService('MiddlewareDispatcher', function($c) use (&$middleWares) {
 			$dispatcher = new MiddlewareDispatcher();
@@ -385,6 +392,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			}
 
 			$dispatcher->registerMiddleware($c['SessionMiddleware']);
+			$dispatcher->registerMiddleware($c['OCSMiddleware']);
 			return $dispatcher;
 		});
 

--- a/lib/private/AppFramework/Middleware/OCSMiddleware.php
+++ b/lib/private/AppFramework/Middleware/OCSMiddleware.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OC\AppFramework\Middleware;
+
+use OC\AppFramework\Http;
+use OCP\AppFramework\Http\OCSResponse;
+use OCP\AppFramework\OCS\OCSException;
+use OCP\AppFramework\OCSController;
+use OCP\IRequest;
+use OCP\AppFramework\Middleware;
+
+class OCSMiddleware extends Middleware {
+
+	/** @var IRequest */
+	private $request;
+
+	/**
+	 * @param IRequest $request
+	 */
+	public function __construct(IRequest $request) {
+		$this->request = $request;
+	}
+
+	/**
+	 * @param \OCP\AppFramework\Controller $controller
+	 * @param string $methodName
+	 * @param \Exception $exception
+	 * @throws \Exception
+	 * @return OCSResponse
+	 */
+	public function afterException($controller, $methodName, \Exception $exception) {
+		if ($controller instanceof OCSController && $exception instanceof OCSException) {
+			$format = $this->getFormat($controller);
+
+			$code = $exception->getCode();
+			if ($code === 0) {
+				$code = Http::STATUS_INTERNAL_SERVER_ERROR;
+			}
+			return new OCSResponse($format, $code, $exception->getMessage());
+		}
+
+		throw $exception;
+	}
+
+	/**
+	 * @param \OCP\AppFramework\Controller $controller
+	 * @return string
+	 */
+	private function getFormat($controller) {
+		// get format from the url format or request format parameter
+		$format = $this->request->getParam('format');
+
+		// if none is given try the first Accept header
+		if($format === null) {
+			$headers = $this->request->getHeader('Accept');
+			$format = $controller->getResponderByHTTPHeader($headers);
+		}
+
+		return $format;
+	}
+}

--- a/lib/public/API.php
+++ b/lib/public/API.php
@@ -35,6 +35,7 @@ namespace OCP;
 /**
  * This class provides functions to manage apps in ownCloud
  * @since 5.0.0
+ * @deprecated 9.1.0 Use the AppFramework
  */
 class API {
 
@@ -66,6 +67,7 @@ class API {
 	 * @param array $defaults
 	 * @param array $requirements
 	 * @since 5.0.0
+	 * @deprecated 9.1.0 Use the AppFramework
 	 */
 	public static function register($method, $url, $action, $app, $authLevel = self::USER_AUTH,
 		$defaults = array(), $requirements = array()){

--- a/lib/public/AppFramework/OCS/OCSBadRequestException.php
+++ b/lib/public/AppFramework/OCS/OCSBadRequestException.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCP\AppFramework\OCS;
+
+use Exception;
+use OCP\AppFramework\Http;
+
+/**
+ * Class OCSBadRequestException
+ *
+ * @package OCP\AppFramework
+ * @since 9.1.0
+ */
+class OCSBadRequestException extends OCSException {
+	/**
+	 * OCSBadRequestException constructor.
+	 *
+	 * @param string $message
+	 * @param Exception|null $previous
+	 * @since 9.1.0
+	 */
+	public function __construct($message = '', Exception $previous = null) {
+		parent::__construct($message, Http::STATUS_BAD_REQUEST, $previous);
+	}
+
+}

--- a/lib/public/AppFramework/OCS/OCSException.php
+++ b/lib/public/AppFramework/OCS/OCSException.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCP\AppFramework\OCS;
+
+use Exception;
+
+/**
+ * Class OCSException
+ *
+ * @package OCP\AppFramework
+ * @since 9.1.0
+ */
+class OCSException extends Exception {}

--- a/lib/public/AppFramework/OCS/OCSForbiddenException.php
+++ b/lib/public/AppFramework/OCS/OCSForbiddenException.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCP\AppFramework\OCS;
+
+use Exception;
+use OCP\AppFramework\Http;
+
+/**
+ * Class OCSForbiddenException
+ *
+ * @package OCP\AppFramework
+ * @since 9.1.0
+ */
+class OCSForbiddenException extends OCSException {
+	/**
+	 * OCSForbiddenException constructor.
+	 *
+	 * @param string $message
+	 * @param Exception|null $previous
+	 * @since 9.1.0
+	 */
+	public function __construct($message = '', Exception $previous = null) {
+		parent::__construct($message, Http::STATUS_FORBIDDEN, $previous);
+	}
+}

--- a/lib/public/AppFramework/OCS/OCSNotFoundException.php
+++ b/lib/public/AppFramework/OCS/OCSNotFoundException.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCP\AppFramework\OCS;
+
+use Exception;
+use OCP\AppFramework\Http;
+
+/**
+ * Class OCSNotFoundException
+ *
+ * @package OCP\AppFramework
+ * @since 9.1.0
+ */
+class OCSNotFoundException extends OCSException {
+	/**
+	 * OCSNotFoundException constructor.
+	 *
+	 * @param string $message
+	 * @param Exception|null $previous
+	 * @since 9.1.0
+	 */
+	public function __construct($message = '', Exception $previous = null) {
+		parent::__construct($message, Http::STATUS_NOT_FOUND, $previous);
+	}
+}

--- a/tests/lib/AppFramework/Middleware/OCSMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/OCSMiddlewareTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace Test\AppFramework\Middleware;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\OCS\OCSBadRequestException;
+use OCP\AppFramework\OCS\OCSException;
+use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\AppFramework\OCS\OCSNotFoundException;
+use OC\AppFramework\Http\Request;
+use OC\AppFramework\Middleware\OCSMiddleware;
+
+
+class OCSMiddlewareTest extends \Test\TestCase {
+
+	/**
+	 * @var Request
+	 */
+	private $request;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->request = $this->getMockBuilder('OCP\IRequest')
+			->getMock();
+
+	}
+
+	public function dataAfterException() {
+		$OCSController = $this->getMockBuilder('OCP\AppFramework\OCSController')
+			->disableOriginalConstructor()
+			->getMock();
+		$controller = $this->getMockBuilder('OCP\AppFramework\Controller')
+			->disableOriginalConstructor()
+			->getMock();
+
+		return [
+			[$OCSController, new \Exception(), true],
+			[$OCSController, new OCSException(), false, '', Http::STATUS_INTERNAL_SERVER_ERROR],
+			[$OCSController, new OCSException('foo'), false, 'foo', Http::STATUS_INTERNAL_SERVER_ERROR],
+			[$OCSController, new OCSException('foo', Http::STATUS_IM_A_TEAPOT), false, 'foo', Http::STATUS_IM_A_TEAPOT],
+			[$OCSController, new OCSBadRequestException(), false, '', Http::STATUS_BAD_REQUEST],
+			[$OCSController, new OCSBadRequestException('foo'), false, 'foo', Http::STATUS_BAD_REQUEST],
+			[$OCSController, new OCSForbiddenException(), false, '', Http::STATUS_FORBIDDEN],
+			[$OCSController, new OCSForbiddenException('foo'), false, 'foo', Http::STATUS_FORBIDDEN],
+			[$OCSController, new OCSNotFoundException(), false, '', Http::STATUS_NOT_FOUND],
+			[$OCSController, new OCSNotFoundException('foo'), false, 'foo', Http::STATUS_NOT_FOUND],
+
+			[$controller, new \Exception(), true],
+			[$controller, new OCSException(), true],
+			[$controller, new OCSException('foo'), true],
+			[$controller, new OCSException('foo', Http::STATUS_IM_A_TEAPOT), true],
+			[$controller, new OCSBadRequestException(), true],
+			[$controller, new OCSBadRequestException('foo'), true],
+			[$controller, new OCSForbiddenException(), true],
+			[$controller, new OCSForbiddenException('foo'), true],
+			[$controller, new OCSNotFoundException(), true],
+			[$controller, new OCSNotFoundException('foo'), true],
+		];
+	}
+
+	/**
+	 * @dataProvider dataAfterException
+	 *
+	 * @param Controller $controller
+	 * @param \Exception $exception
+	 * @param bool $forward
+	 * @param string $message
+	 * @param int $code
+	 */
+	public function testAfterException($controller, $exception, $forward, $message = '', $code = 0) {
+		$OCSMiddleware = new OCSMiddleware($this->request);
+
+		try {
+			$result = $OCSMiddleware->afterException($controller, 'method', $exception);
+			$this->assertFalse($forward);
+
+			$this->assertInstanceOf('OCP\AppFramework\Http\OCSResponse', $result);
+
+			$this->assertSame($message, $this->invokePrivate($result, 'message'));
+			$this->assertSame($code, $this->invokePrivate($result, 'statuscode'));
+		} catch (\Exception $e) {
+			$this->assertTrue($forward);
+			$this->assertEquals($exception, $e);
+		}
+	}
+
+}


### PR DESCRIPTION
This adds OCSMiddleware so apps that use OCSController have some control about the special way OCS works.

There is the generic OCSException and for now 3 speciailized exceptions for more type safety.

Also deprecated the old \OCP\API

Of course unit tests are added.

CC: @LukasReschke @nickvergessen @MorrisJobke @BernhardPosselt 
