### PR TITLE
[Stable10] AppFramework do not get default response

### DIFF
--- a/lib/private/AppFramework/Http/Dispatcher.php
+++ b/lib/private/AppFramework/Http/Dispatcher.php
@@ -167,10 +167,14 @@ class Dispatcher {
 			// if none is given try the first Accept header
 			if($format === null) {
 				$headers = $this->request->getHeader('Accept');
-				$format = $controller->getResponderByHTTPHeader($headers);
+				$format = $controller->getResponderByHTTPHeader($headers, null);
 			}
 
-			$response = $controller->buildResponse($response, $format);
+			if ($format !== null) {
+				$response = $controller->buildResponse($response, $format);
+			} else {
+				$response = $controller->buildResponse($response);
+			}
 		}
 
 		return $response;

--- a/lib/private/AppFramework/Middleware/OCSMiddleware.php
+++ b/lib/private/AppFramework/Middleware/OCSMiddleware.php
@@ -72,7 +72,7 @@ class OCSMiddleware extends Middleware {
 		// if none is given try the first Accept header
 		if($format === null) {
 			$headers = $this->request->getHeader('Accept');
-			$format = $controller->getResponderByHTTPHeader($headers);
+			$format = $controller->getResponderByHTTPHeader($headers, 'xml');
 		}
 
 		return $format;

--- a/lib/public/AppFramework/Controller.php
+++ b/lib/public/AppFramework/Controller.php
@@ -104,8 +104,9 @@ abstract class Controller {
 	 * @param string $acceptHeader
 	 * @return string the responder type
 	 * @since 7.0.0
+	 * @since 9.1.0 Added default parameter
 	 */
-	public function getResponderByHTTPHeader($acceptHeader) {
+	public function getResponderByHTTPHeader($acceptHeader, $default='json') {
 		$headers = explode(',', $acceptHeader);
 
 		// return the first matching responder
@@ -119,8 +120,8 @@ abstract class Controller {
 			}
 		}
 
-		// no matching header defaults to json
-		return 'json';
+		// no matching header return default
+		return $default;
 	}
 
 

--- a/lib/public/AppFramework/OCSController.php
+++ b/lib/public/AppFramework/OCSController.php
@@ -31,6 +31,7 @@ namespace OCP\AppFramework;
 
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\OCSResponse;
+use OCP\AppFramework\Http\Response;
 use OCP\IRequest;
 
 
@@ -69,6 +70,19 @@ abstract class OCSController extends ApiController {
 		});
 	}
 
+	/**
+	 * Since the OCS endpoints default to XML we need to find out the format
+	 * again
+	 * @param mixed $response the value that was returned from a controller and
+	 * is not a Response instance
+	 * @param string $format the format for which a formatter has been registered
+	 * @throws \DomainException if format does not match a registered formatter
+	 * @return Response
+	 * @since 9.1.0
+	 */
+	public function buildResponse($response, $format = 'xml') {
+		return parent::buildResponse($response, $format);
+	}
 
 	/**
 	 * Unwrap data and build ocs response


### PR DESCRIPTION
The OCSResponse differs from other responses in that it defaults to
XML. However we fell back to json by default.

This makes sure that if nothing is set we don't pass anything.
Which defaults then to the controllers default (which is often 'json')
but in the case of the OCSResponse 'xml'.

Backport of https://github.com/nextcloud/server/pull/480
Since @schiessle wants to use this already :)

CC: @LukasReschke @nickvergessen @BernhardPosselt 
