### PR TITLE
AppFramework add default values (ApiController) as parameters

### DIFF
--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -330,6 +330,12 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			);
 		});
 
+		/**
+		 * App Framework default arguments
+		 */
+		$this->registerParameter('corsMethods', 'PUT, POST, GET, DELETE, PATCH');
+		$this->registerParameter('corsAllowedHeaders', 'Authorization, Content-Type, Accept');
+		$this->registerParameter('corsMaxAge', 1728000);
 
 		/**
 		 * Middleware


### PR DESCRIPTION
This means that a controller inherriting from the ApiController and not
implementing their own constructor would fail.
- Unit tests updated

Found this while helping @schiessle debug.
CC: @BernhardPosselt @nickvergessen @MorrisJobke @LukasReschke 
