### PR TITLE
OCS correctly handle login exception

### DIFF
--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -508,6 +508,6 @@ Feature: provisioning
 		And assure user "user0" is disabled
 		And As an "user0"
 		When sending "GET" to "/index.php/apps/files"
-		Then the OCS status code should be "999"
-    	And the HTTP status code should be "200"
+		Then the OCS status code should be "997"
+		And the HTTP status code should be "401"
 

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -85,6 +85,8 @@ try {
 	OC_Response::setStatus(405);
 } catch (\OC\OCS\Exception $ex) {
 	OC_API::respond($ex->getResult(), OC_API::requestedFormat());
+} catch (\OC\User\LoginException $e) {
+	OC_API::respond(new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED, 'Unauthorised'));
 } catch (\Exception $e) {
 	OC_API::setContentType();
 	OC_OCS::notFound();


### PR DESCRIPTION
Missed case

Basically when a login exception is thrown (bad token/password/disabled user) we should repond with the proper OCS code.

CC: @LukasReschke 
