### PR TITLE
Set proper status code in OCS AppFramework Middleware

### DIFF
--- a/lib/private/AppFramework/Middleware/OCSMiddleware.php
+++ b/lib/private/AppFramework/Middleware/OCSMiddleware.php
@@ -56,7 +56,12 @@ class OCSMiddleware extends Middleware {
 			if ($code === 0) {
 				$code = Http::STATUS_INTERNAL_SERVER_ERROR;
 			}
-			return new OCSResponse($format, $code, $exception->getMessage());
+			$response = new OCSResponse($format, $code, $exception->getMessage());
+
+			if ($this->request->getScriptName() === '/ocs/v2.php') {
+				$response->setStatus($code);
+			}
+			return $response;
 		}
 
 		throw $exception;

--- a/tests/lib/AppFramework/Middleware/OCSMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/OCSMiddlewareTest.php
@@ -88,7 +88,10 @@ class OCSMiddlewareTest extends \Test\TestCase {
 	 * @param string $message
 	 * @param int $code
 	 */
-	public function testAfterException($controller, $exception, $forward, $message = '', $code = 0) {
+	public function testAfterExceptionOCSv1($controller, $exception, $forward, $message = '', $code = 0) {
+		$this->request
+			->method('getScriptName')
+			->willReturn('/ocs/v1.php');
 		$OCSMiddleware = new OCSMiddleware($this->request);
 
 		try {
@@ -99,6 +102,37 @@ class OCSMiddlewareTest extends \Test\TestCase {
 
 			$this->assertSame($message, $this->invokePrivate($result, 'message'));
 			$this->assertSame($code, $this->invokePrivate($result, 'statuscode'));
+			$this->assertSame(200, $result->getStatus());
+		} catch (\Exception $e) {
+			$this->assertTrue($forward);
+			$this->assertEquals($exception, $e);
+		}
+	}
+
+	/**
+	 * @dataProvider dataAfterException
+	 *
+	 * @param Controller $controller
+	 * @param \Exception $exception
+	 * @param bool $forward
+	 * @param string $message
+	 * @param int $code
+	 */
+	public function testAfterExceptionOCSv2($controller, $exception, $forward, $message = '', $code = 0) {
+		$this->request
+			->method('getScriptName')
+			->willReturn('/ocs/v2.php');
+		$OCSMiddleware = new OCSMiddleware($this->request);
+
+		try {
+			$result = $OCSMiddleware->afterException($controller, 'method', $exception);
+			$this->assertFalse($forward);
+
+			$this->assertInstanceOf('OCP\AppFramework\Http\OCSResponse', $result);
+
+			$this->assertSame($message, $this->invokePrivate($result, 'message'));
+			$this->assertSame($code, $this->invokePrivate($result, 'statuscode'));
+			$this->assertSame($code, $result->getStatus());
 		} catch (\Exception $e) {
 			$this->assertTrue($forward);
 			$this->assertEquals($exception, $e);


### PR DESCRIPTION
The route '/ocs/v1.php' always uses the HTTP_OK as status. But in `/ocs/v2.php` we use the provided code.

CC: @LukasReschke 
