### PR TITLE
Make sure we try to autoload the class

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -631,7 +631,14 @@ class Server extends ServerContainer implements IServerContainer {
 			return $factory->getManager();
 		});
 		$this->registerService('ThemingDefaults', function(Server $c) {
-			if(class_exists('OCA\Theming\Template', false) && $this->getConfig()->getSystemValue('installed', false) && $this->getAppManager()->isInstalled('theming')) {
+			try {
+				$classExists = class_exists('OCA\Theming\Template');
+			} catch (\OCP\AutoloadNotAllowedException $e) {
+				// App disabled or in maintenance mode
+				$classExists = false;
+			}
+
+			if ($classExists && $this->getConfig()->getSystemValue('installed', false) && $this->getAppManager()->isInstalled('theming')) {
 				return new Template(
 					$this->getConfig(),
 					$this->getL10N('theming'),

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -30,7 +30,8 @@
  */
 
 namespace OC;
-use OCP\Defaults;
+
+
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IURLGenerator;


### PR DESCRIPTION
### Steps
1. Change color
2. Reload the admin page
3. Check value in the box

The problem is with disabled autoloading the class does not exist, on the first load. So the wrong OC_Defaults is used. So we do autoload and catch the path exception instead when the app is not enabled/loaded.

@schiessle as discussed

Should backport all the way
