### PR TITLE
Allow apps to check for a given nextcloud version

### DIFF
--- a/lib/private/App/DependencyAnalyzer.php
+++ b/lib/private/App/DependencyAnalyzer.php
@@ -304,15 +304,37 @@ class DependencyAnalyzer {
 
 		if (!is_null($minVersion)) {
 			if ($this->compareSmaller($this->platform->getOcVersion(), $minVersion)) {
-				$missing[] = (string)$this->l->t('Server version %s or higher is required.', $minVersion);
+				$missing[] = (string)$this->l->t('Server version %s or higher is required.', $this->toVisibleVersion($minVersion));
 			}
 		}
 		if (!is_null($maxVersion)) {
 			if ($this->compareBigger($this->platform->getOcVersion(), $maxVersion)) {
-				$missing[] = (string)$this->l->t('Server version %s or lower is required.', $maxVersion);
+				$missing[] = (string)$this->l->t('Server version %s or lower is required.', $this->toVisibleVersion($maxVersion));
 			}
 		}
 		return $missing;
+	}
+
+	/**
+	 * Map the internal version number to the Nextcloud version
+	 *
+	 * @param string $version
+	 * @return string
+	 */
+	protected function toVisibleVersion($version) {
+		switch ($version) {
+			case '9.1':
+				return '10';
+			case '9.2':
+				return '11';
+			default:
+				if (strpos($version, '9.1.') === 0) {
+					$version = '10.0.' . substr($version, 4);
+				} else if (strpos($version, '9.2.') === 0) {
+					$version = '11.0.' . substr($version, 4);
+				}
+				return $version;
+		}
 	}
 
 	/**

--- a/tests/lib/App/DependencyAnalyzerTest.php
+++ b/tests/lib/App/DependencyAnalyzerTest.php
@@ -16,7 +16,7 @@ use Test\TestCase;
 
 class DependencyAnalyzerTest extends TestCase {
 
-	/** @var Platform */
+	/** @var Platform|\PHPUnit_Framework_MockObject_MockObject */
 	private $platformMock;
 
 	/** @var IL10N */
@@ -206,6 +206,8 @@ class DependencyAnalyzerTest extends TestCase {
 			array(array(), array('@attributes' => array('min-version' => '8.0.2', 'max-version' => '8.0.2'))),
 			array(array('Server version 8.0.3 or higher is required.'), array('@attributes' => array('min-version' => '8.0.3'))),
 			array(array('Server version 9 or higher is required.'), array('@attributes' => array('min-version' => '9'))),
+			array(array('Server version 10 or higher is required.'), array('@attributes' => array('min-version' => '9.1'))),
+			array(array('Server version 11 or higher is required.'), array('@attributes' => array('min-version' => '9.2'))),
 			[['Server version 8.0.1 or lower is required.'], ['@attributes' => ['max-version' => '8.0.1']]],
 		);
 	}


### PR DESCRIPTION
Translates the displayed server version in dependency errors
- `10.0*` maps to `9.1*`
- `11.0*` maps to `9.2*`

@MorrisJobke @LukasReschke 

@karlitschek I'd like to backport this down to 9, so new apps are displayed/denied with the correct information.
