### PR TITLE
Prevent setting email and triggering events at login time (#25553)

### DIFF
--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -435,7 +435,10 @@ class User {
 		if(!is_null($email)) {
 			$user = $this->userManager->get($this->uid);
 			if (!is_null($user)) {
-				$user->setEMailAddress($email);
+				$currentEmail = $user->getEMailAddress();
+				if ($currentEmail !== $email) {
+					$user->setEMailAddress($email);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
fix from upstream: https://github.com/owncloud/core/pull/25553

Whenever an LDAP user also has an email address defined in LDAP, the
LDAP code will try and update the email address of the locally known
user. This happens at login time or every time the user's LDAP
attributes are processed.

There is code listening to the email setting hook which updates the
system address book, which also will trigger FS setup due to avatars
and other things.

This fix only sets the email address when really necessary.
