### PR TITLE
Fix misleading MySQL DB creation error (#25485)

### DIFF
--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -61,12 +61,20 @@ class MySQL extends AbstractDatabase {
 			//we can't use OC_BD functions here because we need to connect as the administrative user.
 			$query = "CREATE DATABASE IF NOT EXISTS `$name` CHARACTER SET utf8 COLLATE utf8_bin;";
 			$connection->executeUpdate($query);
+		} catch (\Exception $ex) {
+			$this->logger->error('Database creation failed: {error}', [
+				'app' => 'mysql.setup',
+				'error' => $ex->getMessage()
+			]);
+			return;
+		}
 
+		try {
 			//this query will fail if there aren't the right permissions, ignore the error
 			$query="GRANT ALL PRIVILEGES ON `$name` . * TO '$user'";
 			$connection->executeUpdate($query);
 		} catch (\Exception $ex) {
-			$this->logger->error('Database creation failed: {error}', [
+			$this->logger->debug('Could not automatically grant privileges, this can be ignored if database user already had privileges: {error}', [
 				'app' => 'mysql.setup',
 				'error' => $ex->getMessage()
 			]);


### PR DESCRIPTION
upstream improvements: https://github.com/owncloud/core/pull/25485

Whenever the GRANT ALL failed, it used to display "Database creation
failed" which is incorrect. It's only the privleges setting that failed.

This moves the privilege setting message to DEBUG and makes it more
precise.
