### PR TITLE
Fix loading icon for workflowengine

### DIFF
--- a/apps/workflowengine/css/admin.css
+++ b/apps/workflowengine/css/admin.css
@@ -41,3 +41,8 @@
 	cursor: pointer;
 }
 
+.workflowengine .rules .icon-loading-small {
+	display: inline-block;
+	margin-right: 5px;
+}
+


### PR DESCRIPTION
Before:

<img width="299" alt="bildschirmfoto 2016-07-27 um 13 18 47" src="https://cloud.githubusercontent.com/assets/245432/17173721/d0a55592-53fc-11e6-9d5e-c80822f281e4.png">

After:

<img width="296" alt="bildschirmfoto 2016-07-27 um 13 18 33" src="https://cloud.githubusercontent.com/assets/245432/17173724/d532682a-53fc-11e6-89e3-b2683cb07be1.png">

cc @nextcloud/designers @nickvergessen 
