### PR TITLE
dont set the mimetype on public video previews

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -87,7 +87,7 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 				<?php if ($_['previewEnabled'] && substr($_['mimetype'], 0, strpos($_['mimetype'], '/')) == 'video'): ?>
 					<div id="imgframe">
 						<video tabindex="0" controls="" preload="none" style="max-width: <?php p($_['previewMaxX']); ?>px; max-height: <?php p($_['previewMaxY']); ?>px">
-							<source src="<?php p($_['downloadURL']); ?>" type="<?php p($_['mimetype']); ?>" />
+							<source src="<?php p($_['downloadURL']); ?>" />
 						</video>
 					</div>
 				<?php else: ?>


### PR DESCRIPTION
Chrome(ium) refuses to play mkv files if it know's it's an mkv video.

If you don't tell chrome it's an mkv it will play the file without complaints (assuming you have the codecs of course)

Not setting the type doesn't seem to have any negative effect from what I can tell with a bit of testing in chrome and ff
