### PR TITLE
up the minimum size of the public share video a bit, use 16/9 ratio

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -30,10 +30,15 @@
 	margin:0 auto;
 }
 
+
 #imgframe img,
 #imgframe video {
-	max-height:100%;
-	max-width:100%;
+	max-height: 100% !important;
+	max-width: 100% !important;
+}
+#imgframe video {
+	width: 854px;
+	height: 480px;
 }
 
 #imgframe .text-preview {


### PR DESCRIPTION
fix #603 – ended up using half the size of Youtube’s 854*480px since that is a bit _too_ big.

Please review @icewind1991 @oparoz @schiessle 
