### PR TITLE
introduce NEXTCLOUD_CONFIG_DIR env variable (see #300)

### DIFF
--- a/core/Controller/SetupController.php
+++ b/core/Controller/SetupController.php
@@ -40,7 +40,7 @@ class SetupController {
 	 * @param Setup $setupHelper
 	 */
 	function __construct(Setup $setupHelper) {
-		$this->autoConfigFile = \OC::$SERVERROOT.'/config/autoconfig.php';
+		$this->autoConfigFile = \OC::$configDir.'autoconfig.php';
 		$this->setupHelper = $setupHelper;
 	}
 

--- a/cron.php
+++ b/cron.php
@@ -90,7 +90,7 @@ try {
 			exit(0);
 		}
 		$user = posix_getpwuid(posix_getuid());
-		$configUser = posix_getpwuid(fileowner(OC::$SERVERROOT . '/config/config.php'));
+		$configUser = posix_getpwuid(fileowner(OC::$configDir . 'config.php'));
 		if ($user['name'] !== $configUser['name']) {
 			echo "Console has to be executed with the same user as the web server is operated" . PHP_EOL;
 			echo "Current user: " . $user['name'] . PHP_EOL;

--- a/lib/base.php
+++ b/lib/base.php
@@ -123,6 +123,8 @@ class OC {
 			self::$configDir = OC::$SERVERROOT . '/' . PHPUNIT_CONFIG_DIR . '/';
 		} elseif(defined('PHPUNIT_RUN') and PHPUNIT_RUN and is_dir(OC::$SERVERROOT . '/tests/config/')) {
 			self::$configDir = OC::$SERVERROOT . '/tests/config/';
+		} elseif($dir = getenv('NEXTCLOUD_CONFIG_DIR')) {
+			self::$configDir = rtrim($dir, '/') . '/';
 		} else {
 			self::$configDir = OC::$SERVERROOT . '/config/';
 		}
@@ -216,7 +218,7 @@ class OC {
 		// set the right include path
 		set_include_path(
 			OC::$SERVERROOT . '/lib/private' . PATH_SEPARATOR .
-			OC::$SERVERROOT . '/config' . PATH_SEPARATOR .
+			self::$configDir . PATH_SEPARATOR .
 			OC::$SERVERROOT . '/3rdparty' . PATH_SEPARATOR .
 			implode(PATH_SEPARATOR, $paths) . PATH_SEPARATOR .
 			get_include_path() . PATH_SEPARATOR .

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -616,7 +616,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('MimeTypeDetector', function (Server $c) {
 			return new \OC\Files\Type\Detection(
 				$c->getURLGenerator(),
-				\OC::$SERVERROOT . '/config/',
+				\OC::$configDir,
 				\OC::$SERVERROOT . '/resources/config/'
 			);
 		});


### PR DESCRIPTION
nextcloud by default uses the `/config/` directory in the source/application tree for its config file(s). with this commit that directory can be overridden by the `NEXTCLOUD_CONFIG_DIR` environment variable.

in uwsgi, you would use the option `--env "NEXTCLOUD_CONFIG_DIR=/tmp/nx-config/"`
in apache use `SetENV …`
and the cli command can be run with: `NEXTCLOUD_CONFIG_DIR=/tmp/nx-config ./occ` (or just use `export` once in the shell).

NEXTCLOUD_CONFIG_DIR can be supplied with or without the trailing slash (`/`), but in all cases `$configDir` will have it automatically added if needed.

The other changes are several occurrences of `OC::$SERVERROOT . '/config'` to `OC::$configDir`.
