### PR TITLE
Fix wrong preserveAspectRatio at app menu icons

### DIFF
--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -115,7 +115,7 @@
 							<?php if( $entry['active'] ): ?> class="active"<?php endif; ?>>
 							<svg width="32" height="32" viewBox="0 0 32 32">
 								<defs><filter id="invert"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0" /></filter></defs>
-								<image x="0" y="0" width="32" height="32" preserveAspectRatio="true" filter="url(#invert)" xlink:href="<?php print_unescaped($entry['icon']); ?>"  class="app-icon"/>
+								<image x="0" y="0" width="32" height="32" preserveAspectRatio="xMinYMin meet" filter="url(#invert)" xlink:href="<?php print_unescaped($entry['icon']); ?>"  class="app-icon"/>
 							</svg>
 							<div class="icon-loading-dark" style="display:none;"></div>
 							<span>
@@ -133,7 +133,7 @@
 							<?php if( $_['appsmanagement_active'] ): ?> class="active"<?php endif; ?>>
 							<svg width="32" height="32" viewBox="0 0 32 32" class="app-icon">
 								<defs><filter id="invert"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0" /></filter></defs>
-								<image x="0" y="0" width="32" height="32" preserveAspectRatio="true" filter="url(#invert)" xlink:href="<?php print_unescaped(image_path('settings', 'apps.svg')); ?>"/>
+								<image x="0" y="0" width="32" height="32" preserveAspectRatio="xMinYMin meet" filter="url(#invert)" xlink:href="<?php print_unescaped(image_path('settings', 'apps.svg')); ?>"/>
 							</svg>
 							<div class="icon-loading-dark" style="display:none;"></div>
 							<span>


### PR DESCRIPTION
There was a wrong attribute causing an error in the javascript console with chrome, introduced with #627 

> Error: <image> attribute preserveAspectRatio: Unrecognized enumerated value, "true".

While "true" worked, this PR uses the correct values.
