### PR TITLE
remove extra file size padding to fix action menu position

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -608,13 +608,6 @@ html.ie8 .column-mtime .selectedActions {
 	padding-right: 14px;
 }
 
-#fileList .filesize {
-	padding-top: 0;
-	padding-bottom: 0;
-	padding-left: 60px;
-	padding-right: 15px;
-}
-
 #fileList .popovermenu {
 	margin-right: 6px;
 }


### PR DESCRIPTION
Not sure why the giant space was there in the first place … created a very weird floating action menu.

Before:
![capture du 2016-07-30 18-31-46](https://cloud.githubusercontent.com/assets/925062/17271726/f714e3b2-5683-11e6-83f1-afaf80e0c586.png)
After:
![capture du 2016-07-30 18-31-14](https://cloud.githubusercontent.com/assets/925062/17271727/f7169004-5683-11e6-95b1-1f118b5b667f.png)

Please review @nextcloud/designers :)
