### PR TITLE
Fix closing app menu on mobile

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1574,6 +1574,10 @@ function initCore() {
 				$target.closest('.app-navigation-noclose').length) {
 				return;
 			}
+			if($target.is('.app-navigation-entry-utils-menu-button') ||
+				$target.closest('.app-navigation-entry-utils-menu-button').length) {
+				return;
+			}
 			if($target.is('.add-new') ||
 				$target.closest('.add-new').length) {
 				return;


### PR DESCRIPTION
Keep the app menu open on mobile when any app-navigation-entry-utils-menu-button was clicked, so that the user can access the menu.
