### PR TITLE
Fix OCS CSRF

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -153,7 +153,7 @@ class SecurityMiddleware extends Middleware {
 			 */
 			if(!$this->request->passesCSRFCheck() && !(
 					$controller instanceof OCSController &&
-					$this->request->getHeader('OCS_APIREQUEST') === true)) {
+					$this->request->getHeader('OCS-APIREQUEST') === 'true')) {
 				throw new CrossSiteRequestForgeryException();
 			}
 		}

--- a/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
@@ -383,7 +383,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 			[$controller, true,  true],
 
 			[$ocsController, false, true],
-			[$ocsController, true,  true],
+			[$ocsController, true,  false],
 		];
 	}
 
@@ -396,6 +396,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	public function testCsrfOcsController(Controller $controller, $hasOcsApiHeader, $exception) {
 		$this->request
 			->method('getHeader')
+			->with('OCS-APIREQUEST')
 			->willReturn($hasOcsApiHeader ? 'true' : null);
 		$this->request->expects($this->once())
 			->method('passesStrictCookieCheck')


### PR DESCRIPTION
We should properly check for 'true' instaed of the bool

Found this when fixing the test for the Sharing API to AppFramework move ;)

CC: @LukasReschke @icewind1991 
