### PR TITLE
Allow ocs/v2.php/cloud/... routes

### DIFF
--- a/lib/private/AppFramework/Routing/RouteConfig.php
+++ b/lib/private/AppFramework/Routing/RouteConfig.php
@@ -86,7 +86,13 @@ class RouteConfig {
 				$postfix = $ocsRoute['postfix'];
 			}
 
-			$url = $ocsRoute['url'];
+			if (isset($ocsRoute['root'])) {
+				$root = $ocsRoute['root'];
+			} else {
+				$root = '/apps/'.$this->appName;
+			}
+
+			$url = $root . $ocsRoute['url'];
 			$verb = isset($ocsRoute['verb']) ? strtoupper($ocsRoute['verb']) : 'GET';
 
 			$split = explode('#', $name, 2);

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -154,7 +154,7 @@ class Router implements IRouter {
 
 				// Also add the OCS collection
 				$collection = $this->getCollection($app.'.ocs');
-				$collection->addPrefix('/ocsapp/apps/' . $app);
+				$collection->addPrefix('/ocsapp');
 				$this->root->addCollection($collection);
 			}
 		}

--- a/tests/lib/AppFramework/Routing/RoutingTest.php
+++ b/tests/lib/AppFramework/Routing/RoutingTest.php
@@ -24,7 +24,7 @@ class RoutingTest extends \Test\TestCase
 			]
 		];
 
-		$this->assertSimpleOCSRoute($routes, 'folders.open', 'GET', '/folders/{folderId}/open', 'FoldersController', 'open');
+		$this->assertSimpleOCSRoute($routes, 'folders.open', 'GET', '/apps/app1/folders/{folderId}/open', 'FoldersController', 'open');
 	}
 
 	public function testSimpleRouteWithMissingVerb()
@@ -42,7 +42,7 @@ class RoutingTest extends \Test\TestCase
 			]
 		];
 
-		$this->assertSimpleOCSRoute($routes, 'folders.open', 'GET', '/folders/{folderId}/open', 'FoldersController', 'open');
+		$this->assertSimpleOCSRoute($routes, 'folders.open', 'GET', '/apps/app1/folders/{folderId}/open', 'FoldersController', 'open');
 	}
 
 	public function testSimpleRouteWithLowercaseVerb()
@@ -60,7 +60,7 @@ class RoutingTest extends \Test\TestCase
 			]
 		];
 
-		$this->assertSimpleOCSRoute($routes, 'folders.open', 'DELETE', '/folders/{folderId}/open', 'FoldersController', 'open');
+		$this->assertSimpleOCSRoute($routes, 'folders.open', 'DELETE', '/apps/app1/folders/{folderId}/open', 'FoldersController', 'open');
 	}
 
 	public function testSimpleRouteWithRequirements()
@@ -78,7 +78,7 @@ class RoutingTest extends \Test\TestCase
 			]
 		];
 
-		$this->assertSimpleOCSRoute($routes, 'folders.open', 'DELETE', '/folders/{folderId}/open', 'FoldersController', 'open', ['something']);
+		$this->assertSimpleOCSRoute($routes, 'folders.open', 'DELETE', '/apps/app1/folders/{folderId}/open', 'FoldersController', 'open', ['something']);
 	}
 
 	public function testSimpleRouteWithDefaults()
@@ -97,7 +97,7 @@ class RoutingTest extends \Test\TestCase
 			]
 		];
 
-		$this->assertSimpleOCSRoute($routes, 'folders.open', 'DELETE', '/folders/{folderId}/open', 'FoldersController', 'open', [], ['param' => 'foobar']);
+		$this->assertSimpleOCSRoute($routes, 'folders.open', 'DELETE', '/apps/app1/folders/{folderId}/open', 'FoldersController', 'open', [], ['param' => 'foobar']);
 	}
 
 	public function testSimpleRouteWithPostfix()
@@ -115,7 +115,7 @@ class RoutingTest extends \Test\TestCase
 			]
 		];
 
-		$this->assertSimpleOCSRoute($routes, 'folders.open', 'DELETE', '/folders/{folderId}/open', 'FoldersController', 'open', [], [], '_something');
+		$this->assertSimpleOCSRoute($routes, 'folders.open', 'DELETE', '/apps/app1/folders/{folderId}/open', 'FoldersController', 'open', [], [], '_something');
 	}
 
 	/**
@@ -175,7 +175,7 @@ class RoutingTest extends \Test\TestCase
 			['name' => 'admin_folders#open_current', 'url' => '/folders/{folderId}/open', 'verb' => 'delete']
 		]];
 
-		$this->assertSimpleOCSRoute($routes, 'admin_folders.open_current', 'DELETE', '/folders/{folderId}/open', 'AdminFoldersController', 'openCurrent');
+		$this->assertSimpleOCSRoute($routes, 'admin_folders.open_current', 'DELETE', '/apps/app1/folders/{folderId}/open', 'AdminFoldersController', 'openCurrent');
 	}
 
 	public function testResource()


### PR DESCRIPTION
One of the possibilities of the old OCS API is that you can define the
url yourself.

This PR makes this possible again by adding an optional root elemenet to
the route. Routes are thus:

`.../ocs/v2.php/<root>/<url>`

By default `<root>` = `apps/<app>`

This will allow for example the provisioning API etc to be in
`../ovs/v2.php/cloud/users`
