### PR TITLE
Support out-of-app config directory.

### DIFF
--- a/core/Controller/SetupController.php
+++ b/core/Controller/SetupController.php
@@ -40,7 +40,12 @@ class SetupController {
 	 * @param Setup $setupHelper
 	 */
 	function __construct(Setup $setupHelper) {
-		$this->autoConfigFile = \OC::$SERVERROOT.'/config/autoconfig.php';
+		$config_directory = getenv('NEXTCLOUD_CONFIG_DIR');
+		if ($config_directory) {
+			$this->autoConfigFile = $config_directory.'/autoconfig.php';
+		} else {
+			$this->autoConfigFile = \OC::$SERVERROOT.'/config/autoconfig.php';
+		}
 		$this->setupHelper = $setupHelper;
 	}
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -124,7 +124,12 @@ class OC {
 		} elseif(defined('PHPUNIT_RUN') and PHPUNIT_RUN and is_dir(OC::$SERVERROOT . '/tests/config/')) {
 			self::$configDir = OC::$SERVERROOT . '/tests/config/';
 		} else {
-			self::$configDir = OC::$SERVERROOT . '/config/';
+			$config_directory = getenv('NEXTCLOUD_CONFIG_DIR');
+			if($config_directory) {
+				self::$configDir = $config_directory.'/';
+			} else {
+				self::$configDir = OC::$SERVERROOT . '/config/';
+			}
 		}
 		self::$config = new \OC\Config(self::$configDir);
 


### PR DESCRIPTION
As requested by @oparoz and @jospoortvliet:

The Nextcloud pi drive device is based upon snappy ubuntu core. Snaps are squashfs images which by definition are read-only. This makes the Nextcloud config read-only as well, which greatly limits its usefulness. This PR introduces support for hosting the config out of the main application (in the case of the snap, in a writable area so the rest of the application can remain read-only). It does this by using the environment variable `$NEXTCLOUD_CONFIG_DIR`. If it's set, it is used as the config directory. If not set, it uses the default `<root>/config/`.

Note that this is fairly well-tested, but I can't pretend to have hit every code path that uses the config. There may be a better place to put this code. If so, please let me know.
