### PR TITLE
add invalidateOldTokens to IProvider interface

### DIFF
--- a/lib/private/Authentication/Token/DefaultTokenCleanupJob.php
+++ b/lib/private/Authentication/Token/DefaultTokenCleanupJob.php
@@ -28,9 +28,8 @@ use OC\BackgroundJob\Job;
 class DefaultTokenCleanupJob extends Job {
 
 	protected function run($argument) {
-		/* @var $provider DefaultTokenProvider */
-		// TODO: add OC\Authentication\Token\IProvider::invalidateOldTokens and query interface
-		$provider = OC::$server->query('OC\Authentication\Token\DefaultTokenProvider');
+		/* @var $provider IProvider */
+		$provider = OC::$server->query('OC\Authentication\Token\IProvider');
 		$provider->invalidateOldTokens();
 	}
 

--- a/lib/private/Authentication/Token/IProvider.php
+++ b/lib/private/Authentication/Token/IProvider.php
@@ -66,6 +66,11 @@ interface IProvider {
 	public function invalidateTokenById(IUser $user, $id);
 
 	/**
+	 * Invalidate (delete) old session tokens
+	 */
+	public function invalidateOldTokens();
+
+	/**
 	 * Save the updated token
 	 *
 	 * @param IToken $token


### PR DESCRIPTION
This removes the dependency to the specific `DefaultTokenProvider` implementation.
