### PR TITLE
Exit from upgrade without reporting error

### DIFF
--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -47,7 +47,7 @@ class Upgrade extends Command {
 	const ERROR_SUCCESS = 0;
 	const ERROR_NOT_INSTALLED = 1;
 	const ERROR_MAINTENANCE_MODE = 2;
-	const ERROR_UP_TO_DATE = 3;
+	const ERROR_UP_TO_DATE = 0;
 	const ERROR_INVALID_ARGUMENTS = 4;
 	const ERROR_FAILURE = 5;
 


### PR DESCRIPTION
As reported at https://help.nextcloud.com/t/silent-mode-for-occ-upgrade/2120 we should exit with a return value of 0 (zero) if the current instance is already up to date so that automatic deployment tools don't recognize that as an error.
