### PR TITLE
Design fixes for updates

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -550,6 +550,7 @@ h2 {
 	font-size: 20px;
 	font-weight: 300;
 	margin-bottom: 12px;
+	line-height: 140%;
 }
 h3 {
 	font-size: 15px;

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -242,7 +242,7 @@ a.two-factor-cancel {
 }
 
 #body-login .update h2 {
-	margin: 12px 0 20px;
+	margin: 0 0 20px;
 }
 
 #body-login .update a {

--- a/core/css/update.css
+++ b/core/css/update.css
@@ -7,6 +7,7 @@
 #update-progress-message-error,
 #update-progress-message-warnings {
 	font-weight: 600;
+	margin-bottom: 10px;
 }
 
 #update-progress-message {
@@ -16,6 +17,7 @@
 .update-show-detailed {
 	padding: 13px;
 	display: block;
+	opacity: .75;
 }
 
 #body-login .update a.update-show-detailed {

--- a/core/css/update.css
+++ b/core/css/update.css
@@ -4,6 +4,11 @@
 	background-size: 32px;
 }
 
+#update-progress-message-error,
+#update-progress-message-warnings {
+	font-weight: 600;
+}
+
 #update-progress-message {
 	margin-bottom: 10px;
 }

--- a/core/js/update.js
+++ b/core/js/update.js
@@ -13,7 +13,7 @@
 		_started : false,
 
 		/**
-		 * Start the upgrade process.
+		 * Start the update process.
 		 *
 		 * @param $el progress list element
 		 */
@@ -31,12 +31,12 @@
 			var self = this;
 
 			$(window).on('beforeunload.inprogress', function () {
-				return t('core', 'The upgrade is in progress, leaving this page might interrupt the process in some environments.');
+				return t('core', 'The update is in progress, leaving this page might interrupt the process in some environments.');
 			});
 
 			$('#update-progress-title').html(t(
 				'core',
-				'Updating to {version}', {
+				'Update to {version}', {
 					version: options.version
 				})
 			);
@@ -91,17 +91,15 @@
 
 				if (hasWarnings) {
 					$el.find('.update-show-detailed').before(
-						$('<span>')
-							.append('<br />')
-							.append(t('core', 'The update was successful. There were warnings.'))
+						$('<input type="button" class="update-continue" value="'+t('core', 'Continue to Nextcloud')+'">').on('click', function() {
+							window.location.reload();
+						})
 					);
-					var message = t('core', 'Please reload the page.');
-					$('<span>').append(message).append('<br />').appendTo($el);
 				} else {
 					// FIXME: use product name
-					$('<span>')
-						.append(t('core', 'The update was successful. Redirecting you to Nextcloud now.'))
-						.appendTo($el);
+					$el.find('.update-show-detailed').before(
+						$('<p>'+t('core', 'The update was successful. Redirecting you to Nextcloud now.')+'</p>')
+					);
 					setTimeout(function () {
 						OC.redirect(OC.webroot + '/');
 					}, 3000);
@@ -127,7 +125,7 @@
 				.append(message)
 				.append($('<br>'));
 		},
-		
+
 		setErrorMessage: function (message) {
 			$('#update-progress-message-error')
 				.show()

--- a/core/templates/update.admin.php
+++ b/core/templates/update.admin.php
@@ -36,8 +36,10 @@
 		</div>
 		<input class="updateButton" type="button" value="<?php p($l->t('Start update')) ?>">
 		<div class="infogroup">
+			<em>
 			<?php p($l->t('To avoid timeouts with larger installations, you can instead run the following command from your installation directory:')) ?>
 			<pre>./occ upgrade</pre>
+			</em>
 		</div>
 	</div>
 
@@ -48,6 +50,6 @@
 		<ul id="update-progress-message-warnings" class="hidden"></ul>
 		<p id="update-progress-message"></p>
 		<a class="update-show-detailed"><?php p($l->t( 'Detailed logs' )); ?> <img src="<?php print_unescaped(image_path('', 'actions/caret.svg')); ?>" /></a>
-		<div id="update-progress-detailed" class="hidden warning"></div>
+		<div id="update-progress-detailed" class="hidden"></div>
 	</div>
 </div>

--- a/core/templates/update.admin.php
+++ b/core/templates/update.admin.php
@@ -44,8 +44,8 @@
 	<div class="update-progress hidden">
 		<h2 id="update-progress-title"></h2>
 		<div id="update-progress-icon" class="icon-loading-dark"></div>
-		<p id="update-progress-message-error" class="warning hidden"></p>
-		<ul id="update-progress-message-warnings" class="warning hidden"></ul>
+		<p id="update-progress-message-error" class="hidden"></p>
+		<ul id="update-progress-message-warnings" class="hidden"></ul>
 		<p id="update-progress-message"></p>
 		<a class="update-show-detailed"><?php p($l->t( 'Detailed logs' )); ?> <img src="<?php print_unescaped(image_path('', 'actions/caret.svg')); ?>" /></a>
 		<div id="update-progress-detailed" class="hidden warning"></div>

--- a/lib/base.php
+++ b/lib/base.php
@@ -359,7 +359,7 @@ class OC {
 
 			// render error page
 			$template = new OC_Template('', 'update.use-cli', 'guest');
-			$template->assign('productName', 'owncloud'); // for now
+			$template->assign('productName', 'nextcloud'); // for now
 			$template->assign('version', OC_Util::getVersionString());
 			$template->assign('tooBig', $tooBig);
 
@@ -390,7 +390,7 @@ class OC {
 		$ocVersion = \OCP\Util::getVersion();
 		$tmpl->assign('appsToUpgrade', $appManager->getAppsNeedingUpgrade($ocVersion));
 		$tmpl->assign('incompatibleAppsList', $appManager->getIncompatibleApps($ocVersion));
-		$tmpl->assign('productName', 'ownCloud'); // for now
+		$tmpl->assign('productName', 'Nextcloud'); // for now
 		$tmpl->assign('oldTheme', $oldTheme);
 		$tmpl->printPage();
 	}


### PR DESCRIPTION
Before & after:
![capture du 2016-08-03 18-57-32](https://cloud.githubusercontent.com/assets/925062/17374362/8ab9ff46-59ac-11e6-843e-c32d6b27c395.png)![capture du 2016-08-04 12-36-37](https://cloud.githubusercontent.com/assets/925062/17399344/dcc9db90-5a41-11e6-9302-11ae7d591911.png)
- remove box-in-box for the error messages and the detailed log
- remove unnecessary info like »there were errors« cause the errors are shown
- introduce button to »Continue to Nextcloud« instead of needing to manually refresh the page

Please review @nextcloud/designers @MorrisJobke 
