### PR TITLE
Background on error pages, consistent with login page theming

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -26,7 +26,7 @@ body {
 #body-login {
 	text-align: center;
 	background-color: #0082c9;
-	background-image: url('../img/background.jpg');
+	background-image: url('../../index.php/apps/theming/loginbackground?v=45'), url('../img/background.jpg?v=1');
 	background-position: 50% 50%;
 	background-repeat: no-repeat;
 	background-size: cover;


### PR DESCRIPTION
Uses the admin-set theme image for error pages, just as we currently do for the login page to make theming more consistent.

Falls back to the current image if theme image doesn't exist, such as if the theming app is uninstalled (in which case it will still match the login page as that reverts to the default image, too).

To be honest, I'm not exactly sure what the v variable does, but it already pre-existed for the themed login image, so I'm assuming that reusing it for the error page is safe also.

Fixes #762
