### PR TITLE
Hanlde Core and Settings app in AppFramework

### DIFF
--- a/lib/private/AppFramework/App.php
+++ b/lib/private/AppFramework/App.php
@@ -93,7 +93,13 @@ class App {
 		try {
 			$controller = $container->query($controllerName);
 		} catch(QueryException $e) {
-			$appNameSpace = self::buildAppNamespace($appName);
+			if ($appName === 'core') {
+				$appNameSpace = 'OC\\Core';
+			} else if ($appName === 'settings') {
+				$appNameSpace = 'OC\\Settings';
+			} else {
+				$appNameSpace = self::buildAppNamespace($appName);
+			}
 			$controllerName = $appNameSpace . '\\Controller\\' . $controllerName;
 			$controller = $container->query($controllerName);
 		}

--- a/tests/lib/AppFramework/AppTest.php
+++ b/tests/lib/AppFramework/AppTest.php
@@ -162,4 +162,55 @@ class AppTest extends \Test\TestCase {
 		App::main($this->controllerName, $this->controllerMethod, $this->container, []);
 	}
 
+	public function testCoreApp() {
+		$this->container['AppName'] = 'core';
+		$this->container['OC\Core\Controller\Foo'] = $this->controller;
+
+		$return = array(null, array(), array(), null, new Response());
+		$this->dispatcher->expects($this->once())
+			->method('dispatch')
+			->with($this->equalTo($this->controller),
+				$this->equalTo($this->controllerMethod))
+			->will($this->returnValue($return));
+
+		$this->io->expects($this->never())
+			->method('setOutput');
+
+		App::main('Foo', $this->controllerMethod, $this->container);
+	}
+
+	public function testSettingsApp() {
+		$this->container['AppName'] = 'settings';
+		$this->container['OC\Settings\Controller\Foo'] = $this->controller;
+
+		$return = array(null, array(), array(), null, new Response());
+		$this->dispatcher->expects($this->once())
+			->method('dispatch')
+			->with($this->equalTo($this->controller),
+				$this->equalTo($this->controllerMethod))
+			->will($this->returnValue($return));
+
+		$this->io->expects($this->never())
+			->method('setOutput');
+
+		App::main('Foo', $this->controllerMethod, $this->container);
+	}
+
+	public function testApp() {
+		$this->container['AppName'] = 'bar';
+		$this->container['OCA\Bar\Controller\Foo'] = $this->controller;
+
+		$return = array(null, array(), array(), null, new Response());
+		$this->dispatcher->expects($this->once())
+			->method('dispatch')
+			->with($this->equalTo($this->controller),
+				$this->equalTo($this->controllerMethod))
+			->will($this->returnValue($return));
+
+		$this->io->expects($this->never())
+			->method('setOutput');
+
+		App::main('Foo', $this->controllerMethod, $this->container);
+	}
+
 }


### PR DESCRIPTION
'core' and 'settings' are just apps but we treat them slightly different. Make sure that we construct the correct namespace so we can actually do automatic AppFramework stuff.

Came across this when porting some 'core' OCS routes to the AppFramework.

CC: @BernhardPosselt @LukasReschke @MorrisJobke @icewind1991 
