### PR TITLE
Get shared storage numeric id directly from DB

### DIFF
--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -235,4 +235,13 @@ class SharedMount extends MountPoint implements MoveableMount {
 	public function getStorageRootId() {
 		return $this->getShare()->getNodeId();
 	}
+
+	public function getStorageNumericId() {
+		$query = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$query->select('storage')
+			->from('filecache')
+			->where($query->expr()->eq('fileid', $query->createNamedParameter($this->share->getNodeId())));
+
+		return $query->execute()->fetchColumn();
+	}
 }

--- a/lib/private/Files/Config/LazyStorageMountInfo.php
+++ b/lib/private/Files/Config/LazyStorageMountInfo.php
@@ -48,11 +48,15 @@ class LazyStorageMountInfo extends CachedMountInfo {
 	 */
 	public function getStorageId() {
 		if (!$this->storageId) {
-			$storage = $this->mount->getStorage();
-			if (!$storage) {
-				return -1;
+			if (method_exists($this->mount, 'getStorageNumericId')) {
+				$this->storageId = $this->mount->getStorageNumericId();
+			} else {
+				$storage = $this->mount->getStorage();
+				if (!$storage) {
+					return -1;
+				}
+				$this->storageId = $storage->getStorageCache()->getNumericId();
 			}
-			$this->storageId = $storage->getStorageCache()->getNumericId();
 		}
 		return parent::getStorageId();
 	}


### PR DESCRIPTION
To prevent recursions in initMountPoints which requires the numeric id
to populate oc_mounts

cherry-pick from https://github.com/owncloud/core/pull/25754
