### PR TITLE
[Stable10] OCSController requires DataResponse

### DIFF
--- a/lib/public/AppFramework/OCSController.php
+++ b/lib/public/AppFramework/OCSController.php
@@ -88,25 +88,18 @@ abstract class OCSController extends ApiController {
 	/**
 	 * Unwrap data and build ocs response
 	 * @param string $format json or xml
-	 * @param array|DataResponse $data the data which should be transformed
+	 * @param DataResponse $data the data which should be transformed
 	 * @since 8.1.0
+	 * @return OCSResponse
 	 */
-	private function buildOCSResponse($format, $data) {
-		if ($data instanceof DataResponse) {
-			$data = $data->getData();
-		}
-
+	private function buildOCSResponse($format, DataResponse $data) {
 		$params = [
 			'statuscode' => 100,
 			'message' => 'OK',
-			'data' => [],
+			'data' => $data->getData(),
 			'itemscount' => '',
 			'itemsperpage' => ''
 		];
-
-		foreach ($data as $key => $value) {
-			$params[$key] = $value;
-		}
 
 		return new OCSResponse(
 			$format, $params['statuscode'],

--- a/tests/lib/AppFramework/Controller/OCSControllerTest.php
+++ b/tests/lib/AppFramework/Controller/OCSControllerTest.php
@@ -75,8 +75,8 @@ class OCSControllerTest extends \Test\TestCase {
 		$expected = "<?xml version=\"1.0\"?>\n" .
 		"<ocs>\n" .
 		" <meta>\n" .
-		"  <status>failure</status>\n" .
-		"  <statuscode>400</statuscode>\n" .
+		"  <status>ok</status>\n" .
+		"  <statuscode>100</statuscode>\n" .
 		"  <message>OK</message>\n" .
 		"  <totalitems></totalitems>\n" .
 		"  <itemsperpage></itemsperpage>\n" .
@@ -86,53 +86,11 @@ class OCSControllerTest extends \Test\TestCase {
 		" </data>\n" .
 		"</ocs>\n";
 
-		$params = [
-			'data' => [
-				'test' => 'hi'
-			],
-			'statuscode' => 400
-		];
+		$params = new DataResponse(['test' => 'hi']);
 
 		$out = $controller->buildResponse($params, 'xml')->render();
 		$this->assertEquals($expected, $out);
 	}
-
-
-	public function testXMLDataResponse() {
-		$controller = new ChildOCSController('app', new Request(
-			[],
-			$this->getMockBuilder('\OCP\Security\ISecureRandom')
-				->disableOriginalConstructor()
-				->getMock(),
-			$this->getMockBuilder('\OCP\IConfig')
-				->disableOriginalConstructor()
-				->getMock()
-		));
-		$expected = "<?xml version=\"1.0\"?>\n" .
-		"<ocs>\n" .
-		" <meta>\n" .
-		"  <status>failure</status>\n" .
-		"  <statuscode>400</statuscode>\n" .
-		"  <message>OK</message>\n" .
-		"  <totalitems></totalitems>\n" .
-		"  <itemsperpage></itemsperpage>\n" .
-		" </meta>\n" .
-		" <data>\n" .
-		"  <test>hi</test>\n" .
-		" </data>\n" .
-		"</ocs>\n";
-
-		$params = new DataResponse([
-			'data' => [
-				'test' => 'hi'
-			],
-			'statuscode' => 400
-		]);
-
-		$out = $controller->buildResponse($params, 'xml')->render();
-		$this->assertEquals($expected, $out);
-	}
-
 
 	public function testJSON() {
 		$controller = new ChildOCSController('app', new Request(
@@ -144,14 +102,9 @@ class OCSControllerTest extends \Test\TestCase {
 				->disableOriginalConstructor()
 				->getMock()
 		));
-		$expected = '{"ocs":{"meta":{"status":"failure","statuscode":400,"message":"OK",' .
+		$expected = '{"ocs":{"meta":{"status":"ok","statuscode":100,"message":"OK",' .
 		            '"totalitems":"","itemsperpage":""},"data":{"test":"hi"}}}';
-		$params = [
-			'data' => [
-				'test' => 'hi'
-			],
-			'statuscode' => 400
-		];
+		$params = new DataResponse(['test' => 'hi']);
 
 		$out = $controller->buildResponse($params, 'json')->render();
 		$this->assertEquals($expected, $out);


### PR DESCRIPTION
Backport of first part of https://github.com/nextcloud/server/pull/807

The OCS Controller requires a DataResponse object to be returned.
This means that all error handling will have to be done via exceptions
thrown and handling in the middleware.

CC: @schiessle @LukasReschke 

@schiessle please also update your app ;)
