### PR TITLE
Use darker colors for app icons in app management.

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -378,16 +378,7 @@ span.version {
 	width: 80px;
 	height: 80px;
 }
-.app-image img {
-	max-width: 80px;
-	max-height: 80px;
-}
-.app-image-icon img {
-	background-color: #ccc;
-	width: 60px;
-	padding: 10px;
-	border-radius: 3px;
-}
+
 .app-name,
 .app-version,
 .app-score,

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -377,8 +377,8 @@ span.version {
 	padding-right: 10px;
 	width: 80px;
 	height: 80px;
+	opacity: 0.8;
 }
-
 .app-name,
 .app-version,
 .app-score,

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -196,13 +196,13 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		if (app.preview && !OC.Util.isIE()) {
 			var currentImage = new Image();
 			currentImage.src = app.preview;
-
-			currentImage.onload = function() {
-				page.find('.app-image')
-					.append(this)
-					.fadeIn();
-			};
 		}
+
+		currentImage.onload = function() {
+			page.find('.app-image')
+				.append(OC.Settings.Apps.imageUrl(app.preview))
+				.fadeIn();
+		};
 
 		// set group select properly
 		if(OC.Settings.Apps.isType(app, 'filesystem') || OC.Settings.Apps.isType(app, 'prelogin') ||
@@ -224,6 +224,17 @@ OC.Settings.Apps = OC.Settings.Apps || {
 				page.find(".groups-enable").hide();
 			}
 		}
+	},
+
+	/**
+	 * Returns the image for apps listing
+	 */
+
+	imageUrl : function (url) {
+		var img = '<svg width="72" height="72" viewBox="0 0 72 72">';
+		img += '<defs><filter id="invert"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0" /></filter></defs>';
+		img += '<image x="0" y="0" width="72" height="72" preserveAspectRatio="xMinYMin meet" filter="url(#invert)" xlink:href="' + url + '"  class="app-icon" /></svg>';
+		return img;
 	},
 
 	isType: function(app, type){

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -200,7 +200,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 
 		currentImage.onload = function() {
 			page.find('.app-image')
-				.append(OC.Settings.Apps.imageUrl(app.preview))
+				.append(OC.Settings.Apps.imageUrl(app.preview, app.detailpage))
 				.fadeIn();
 		};
 
@@ -228,12 +228,18 @@ OC.Settings.Apps = OC.Settings.Apps || {
 
 	/**
 	 * Returns the image for apps listing
+	 * url : the url of the image
+	 * appfromstore: bool to check whether the app is fetched from store or not.
 	 */
 
-	imageUrl : function (url) {
+	imageUrl : function (url, appfromstore) {
 		var img = '<svg width="72" height="72" viewBox="0 0 72 72">';
-		img += '<defs><filter id="invert"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0" /></filter></defs>';
-		img += '<image x="0" y="0" width="72" height="72" preserveAspectRatio="xMinYMin meet" filter="url(#invert)" xlink:href="' + url + '"  class="app-icon" /></svg>';
+		if (appfromstore) {
+			img += '<image x="0" y="0" width="72" height="72" preserveAspectRatio="xMinYMin meet" xlink:href="' + url + '"  class="app-icon" /></svg>';
+		} else {
+			img += '<defs><filter id="invert"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0" /></filter></defs>';
+			img += '<image x="0" y="0" width="72" height="72" preserveAspectRatio="xMinYMin meet" filter="url(#invert)" xlink:href="' + url + '"  class="app-icon" /></svg>';
+		}
 		return img;
 	},
 


### PR DESCRIPTION
Should ideally fix https://github.com/nextcloud/server/issues/649, but the icons are coming as white for me, though I have changed the fills of all the icons. Can someone cross check if it is working fine for them? 

@jancborchardt I am not using #000 but #404040 which is the exact colour when you hover the icons in the app navigation. #000 cause a lot of contrast. :-)

Btw this is my first PR to NC ;-)
