### PR TITLE
TwoFactorMiddleware should forward Exception

### DIFF
--- a/core/Middleware/TwoFactorMiddleware.php
+++ b/core/Middleware/TwoFactorMiddleware.php
@@ -129,6 +129,8 @@ class TwoFactorMiddleware extends Middleware {
 		if ($exception instanceof UserAlreadyLoggedInException) {
 			return new RedirectResponse($this->urlGenerator->linkToRoute('files.view.index'));
 		}
+
+		throw $exception;
 	}
 
 }


### PR DESCRIPTION
Middleware should rethrow the exception if it can't handle it.

CC: @BernhardPosselt @MorrisJobke @LukasReschke @ChristophWurst 
