### PR TITLE
Extend OCS Middleware

### DIFF
--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -396,6 +396,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		$this->registerService('MiddlewareDispatcher', function($c) use (&$middleWares) {
 			$dispatcher = new MiddlewareDispatcher();
 			$dispatcher->registerMiddleware($c['CORSMiddleware']);
+			$dispatcher->registerMiddleware($c['OCSMiddleware']);
 			$dispatcher->registerMiddleware($c['SecurityMiddleware']);
 			$dispatcher->registerMiddleWare($c['TwoFactorMiddleware']);
 
@@ -404,7 +405,6 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			}
 
 			$dispatcher->registerMiddleware($c['SessionMiddleware']);
-			$dispatcher->registerMiddleware($c['OCSMiddleware']);
 			return $dispatcher;
 		});
 


### PR DESCRIPTION
I found out when moving the provisioning API over that still functionlity was missing.
- Move OCSMiddleware up in registration so we can catch NotLoggedIn stuff properly
- Set proper OCS Status code
- Always set 401 (v1.php and v2.php)
- Set proper error codes for v2.php
- Catch 401 and 403 responses and convert them to OCS Responses
- Add tests

I'll also prepare my provisioning api PR to see if this all still work.
