### PR TITLE
fix quota calculation when a filesystem is mounted in a user home

### DIFF
--- a/lib/private/legacy/helper.php
+++ b/lib/private/legacy/helper.php
@@ -600,7 +600,7 @@ class OC_Helper {
 			/** @var \OC\Files\Storage\Wrapper\Quota $storage */
 			$quota = $sourceStorage->getQuota();
 		}
-		$free = $sourceStorage->free_space('');
+		$free = $sourceStorage->free_space($rootInfo->getInternalPath());
 		if ($free >= 0) {
 			$total = $free + $used;
 		} else {


### PR DESCRIPTION
See https://github.com/nextcloud/server/issues/801

Fixes quota calculation when a different hdd is mounted at /nextcloud/data/user/files

@riegercloud can you verify that this fixes quota calculation with `'quota_include_external_storage' => false` for you
