### PR TITLE
Add files drop capability for clients

### DIFF
--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -69,6 +69,7 @@ class Capabilities implements ICapability {
 
 				$public['send_mail'] = $this->config->getAppValue('core', 'shareapi_allow_public_notification', 'no') === 'yes';
 				$public['upload'] = $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes') === 'yes';
+				$public['upload_files_drop'] = $public['upload'];
 			}
 			$res["public"] = $public;
 

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -232,6 +232,7 @@ class CapabilitiesTest extends \Test\TestCase {
 		];
 		$result = $this->getResults($map);
 		$this->assertTrue($result['public']['upload']);
+		$this->assertTrue($result['public']['upload_files_drop']);
 	}
 
 	public function testLinkNoPublicUpload() {
@@ -242,6 +243,7 @@ class CapabilitiesTest extends \Test\TestCase {
 		];
 		$result = $this->getResults($map);
 		$this->assertFalse($result['public']['upload']);
+		$this->assertFalse($result['public']['upload_files_drop']);
 	}
 
 	public function testNoGroupSharing() {


### PR DESCRIPTION
@tobiasKaminsky as discussed

Add a very simple capability to indicate that we support files_drop stuff (basically enabled when uploading on public links is enabled).

This should make clients happier since they can now find out if they need to show it or not.

CC: @schiessle @LukasReschke @MorrisJobke @nickvergessen 
