### PR TITLE
Map .mobi files to text filetype

### DIFF
--- a/resources/config/mimetypealiases.dist.json
+++ b/resources/config/mimetypealiases.dist.json
@@ -65,6 +65,7 @@
 	"application/x-font": "image",
 	"application/x-gimp": "image",
 	"application/x-gzip": "package/x-generic",
+	"application/x-mobipocket-ebook": "text",
 	"application/x-perl": "text/code",
 	"application/x-photoshop": "image",
 	"application/x-php": "text/code",


### PR DESCRIPTION
At the moment [mobi](https://en.wikipedia.org/wiki/Mobipocket) files are shown as generic in the file list, but they are e-book files (similar to epub).
