### PR TITLE
Make the capabilities manager more error proof

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -629,7 +629,7 @@ class Server extends ServerContainer implements IServerContainer {
 			return new Manager();
 		});
 		$this->registerService('CapabilitiesManager', function (Server $c) {
-			$manager = new \OC\CapabilitiesManager();
+			$manager = new \OC\CapabilitiesManager($c->getLogger());
 			$manager->registerCapability(function () use ($c) {
 				return new \OC\OCS\CoreCapabilities($c->getConfig());
 			});


### PR DESCRIPTION
If an app registers an invalid capabilty we should not crash hard.
Instead we should catch the exception. Log it (debug) and carry on.
- Added tests

CC: @nickvergessen @LukasReschke @schiessle @icewind1991 
