### PR TITLE
Allow to retrieve the quota itself via the provisioning api

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -623,6 +623,7 @@ class UsersController extends OCSController {
 				'used' => $storage['used'],
 				'total' => $storage['total'],
 				'relative' => $storage['relative'],
+				'quota' => $storage['quota'],
 			];
 		} catch (NotFoundException $ex) {
 			$data = [];

--- a/lib/public/Files/FileInfo.php
+++ b/lib/public/Files/FileInfo.php
@@ -53,7 +53,7 @@ interface FileInfo {
 	 */
 	const SPACE_UNKNOWN = -2;
 	/**
-	 * @const \OCP\Files\FileInfo::SPACE_UNKNOWN Return value for unlimited space
+	 * @const \OCP\Files\FileInfo::SPACE_UNLIMITED Return value for unlimited space
 	 * @since 8.0.0
 	 */
 	const SPACE_UNLIMITED = -3;


### PR DESCRIPTION
Fix #879 

@AndyScherzinger special values are `<0`:
https://github.com/nextcloud/server/blob/e321ecd592fef123772c6e61e175b6a34a3c5044/lib/public/Files/FileInfo.php#L45-L59

I guess it would be nice to backport this, and since the patch is very little, it should also be save to do so.
