### PR TITLE
Revert "Always add activities for comments to the stream"

### DIFF
--- a/apps/comments/lib/Activity/Extension.php
+++ b/apps/comments/lib/Activity/Extension.php
@@ -82,8 +82,8 @@ class Extension implements IExtension {
 
 		return array(
 			self::APP_NAME => [
-				'desc' => (string) $l->t('<strong>Comments</strong> for files <em>(always listed in stream)</em>'),
-				'methods' => [self::METHOD_MAIL], // self::METHOD_STREAM is forced true by the default value
+				'desc' => (string) $l->t('<strong>Comments</strong> for files'),
+				'methods' => [self::METHOD_MAIL, self::METHOD_STREAM],
 			],
 		);
 	}
@@ -278,11 +278,7 @@ class Extension implements IExtension {
 	 */
 	public function filterNotificationTypes($types, $filter) {
 		if ($filter === self::APP_NAME) {
-			return [self::APP_NAME];
-		}
-		if (in_array($filter, ['all', 'by', 'self', 'filter'])) {
-			$types[] = self::APP_NAME;
-			return $types;
+			return array_intersect($types, [self::APP_NAME]);
 		}
 		return false;
 	}


### PR DESCRIPTION
This reverts commit 48c41b888c6a464f645de3e9087a39c163086d9f

We didn't do the comments/activity sidebar merging, so there is no need to force this to be enabled.

Ref #735 

@MorrisJobke @LukasReschke @rullzer 

Should backport to 10 as well.
