### PR TITLE
Share API use parameters

### DIFF
--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -473,6 +473,11 @@ class Share20OCS extends OCSController {
 	 *
 	 * @NoAdminRequired
 	 *
+	 * @param string $shared_with_me
+	 * @param string $reshares
+	 * @param string $subfiles
+	 * @param string $path
+	 *
 	 * - Get shares by the current user
 	 * - Get shares by the current user and reshares (?reshares=true)
 	 * - Get shares with the current user (?shared_with_me=true)
@@ -482,11 +487,12 @@ class Share20OCS extends OCSController {
 	 * @return DataResponse
 	 * @throws OCSNotFoundException
 	 */
-	public function getShares() {
-		$sharedWithMe = $this->request->getParam('shared_with_me', null);
-		$reshares = $this->request->getParam('reshares', null);
-		$subfiles = $this->request->getParam('subfiles');
-		$path = $this->request->getParam('path', null);
+	public function getShares(
+		$shared_with_me = 'false',
+		$reshares = 'false',
+		$subfiles = 'false',
+		$path = null
+	) {
 
 		if ($path !== null) {
 			$userFolder = $this->rootFolder->getUserFolder($this->currentUser->getUID());
@@ -500,7 +506,7 @@ class Share20OCS extends OCSController {
 			}
 		}
 
-		if ($sharedWithMe === 'true') {
+		if ($shared_with_me === 'true') {
 			$result = $this->getSharedWithMe($path);
 			return $result;
 		}
@@ -543,12 +549,22 @@ class Share20OCS extends OCSController {
 	 * @NoAdminRequired
 	 *
 	 * @param int $id
+	 * @param int $permissions
+	 * @param string $password
+	 * @param string $publicUpload
+	 * @param string $expireDate
 	 * @return DataResponse
 	 * @throws OCSNotFoundException
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function updateShare($id) {
+	public function updateShare(
+		$id,
+		$permissions = null,
+		$password = null,
+		$publicUpload = null,
+		$expireDate = null
+	) {
 		try {
 			$share = $this->getShareById($id);
 		} catch (ShareNotFound $e) {
@@ -560,11 +576,6 @@ class Share20OCS extends OCSController {
 		if (!$this->canAccessShare($share, false)) {
 			throw new OCSNotFoundException($this->l->t('Wrong share ID, share doesn\'t exist'));
 		}
-
-		$permissions = $this->request->getParam('permissions', null);
-		$password = $this->request->getParam('password', null);
-		$publicUpload = $this->request->getParam('publicUpload', null);
-		$expireDate = $this->request->getParam('expireDate', null);
 
 		/*
 		 * expirationdate, password and publicUpload only make sense for link shares

--- a/apps/files_sharing/tests/API/Share20OCSTest.php
+++ b/apps/files_sharing/tests/API/Share20OCSTest.php
@@ -46,31 +46,31 @@ class Share20OCSTest extends \Test\TestCase {
 	/** @var string */
 	private $appName = 'files_sharing';
 
-	/** @var \OC\Share20\Manager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\Share20\Manager|\PHPUnit_Framework_MockObject_MockObject */
 	private $shareManager;
 
-	/** @var IGroupManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IGroupManager|\PHPUnit_Framework_MockObject_MockObject */
 	private $groupManager;
 
-	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager|\PHPUnit_Framework_MockObject_MockObject */
 	private $userManager;
 
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest|\PHPUnit_Framework_MockObject_MockObject */
 	private $request;
 
-	/** @var IRootFolder | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRootFolder|\PHPUnit_Framework_MockObject_MockObject */
 	private $rootFolder;
 
-	/** @var IURLGenerator */
+	/** @var IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
 	private $urlGenerator;
 
-	/** @var IUser */
+	/** @var IUser|\PHPUnit_Framework_MockObject_MockObject */
 	private $currentUser;
 
 	/** @var Share20OCS */
 	private $ocs;
 
-	/** @var IL10N */
+	/** @var IL10N|\PHPUnit_Framework_MockObject_MockObject */
 	private $l;
 
 	protected function setUp() {

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -130,14 +130,9 @@ class ApiTest extends TestCase {
 	 * @medium
 	 */
 	function testCreateShareUserFile() {
-		// simulate a post request
-		$data['path'] = $this->filename;
-		$data['shareWith'] = self::TEST_FILES_SHARING_API_USER2;
-		$data['shareType'] = \OCP\Share::SHARE_TYPE_USER;
-
-		$request = $this->createRequest($data);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare();
+		$result = $ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -154,14 +149,9 @@ class ApiTest extends TestCase {
 	}
 
 	function testCreateShareUserFolder() {
-		// simulate a post request
-		$data['path'] = $this->folder;
-		$data['shareWith'] = self::TEST_FILES_SHARING_API_USER2;
-		$data['shareType'] = \OCP\Share::SHARE_TYPE_USER;
-
-		$request = $this->createRequest($data);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare();
+		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -179,14 +169,9 @@ class ApiTest extends TestCase {
 
 
 	function testCreateShareGroupFile() {
-		// simulate a post request
-		$data['path'] = $this->filename;
-		$data['shareWith'] = self::TEST_FILES_SHARING_API_GROUP1;
-		$data['shareType'] = \OCP\Share::SHARE_TYPE_GROUP;
-
-		$request = $this->createRequest($data);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare();
+		$result = $ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_GROUP, self::TEST_FILES_SHARING_API_GROUP1);
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -202,14 +187,9 @@ class ApiTest extends TestCase {
 	}
 
 	function testCreateShareGroupFolder() {
-		// simulate a post request
-		$data['path'] = $this->folder;
-		$data['shareWith'] = self::TEST_FILES_SHARING_API_GROUP1;
-		$data['shareType'] = \OCP\Share::SHARE_TYPE_GROUP;
-
-		$request = $this->createRequest($data);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare();
+		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_GROUP, self::TEST_FILES_SHARING_API_GROUP1);
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -226,13 +206,9 @@ class ApiTest extends TestCase {
 	}
 
 	public function testCreateShareLink() {
-		// simulate a post request
-		$data['path'] = $this->folder;
-		$data['shareType'] = \OCP\Share::SHARE_TYPE_LINK;
-
-		$request = $this->createRequest($data);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare();
+		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK);
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -253,14 +229,9 @@ class ApiTest extends TestCase {
 	}
 
 	public function testCreateShareLinkPublicUpload() {
-		// simulate a post request
-		$data['path'] = $this->folder;
-		$data['shareType'] = \OCP\Share::SHARE_TYPE_LINK;
-		$data['publicUpload'] = 'true';
-
-		$request = $this->createRequest($data);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare();
+		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK, null, 'true');
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -291,30 +262,20 @@ class ApiTest extends TestCase {
 		$appConfig = \OC::$server->getAppConfig();
 		$appConfig->setValue('core', 'shareapi_enforce_links_password', 'yes');
 
-		// don't allow to share link without a password
-		$data['path'] = $this->folder;
-		$data['shareType'] = \OCP\Share::SHARE_TYPE_LINK;
-
-		$request = $this->createRequest($data);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
 		try {
-			$ocs->createShare();
+			$ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK);
 			$this->fail();
 		} catch (OCSForbiddenException $e) {
 
 		}
 		$ocs->cleanup();
 
-		// don't allow to share link without a empty password
-		$data = [];
-		$data['path'] = $this->folder;
-		$data['shareType'] = \OCP\Share::SHARE_TYPE_LINK;
-		$data['password'] = '';
-
-		$request = $this->createRequest($data);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
 		try {
-			$ocs->createShare();
+			$ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK, null, 'false', '');
 			$this->fail();
 		} catch (OCSForbiddenException $e) {
 
@@ -322,14 +283,9 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 
 		// share with password should succeed
-		$data = [];
-		$data['path'] = $this->folder;
-		$data['shareType'] = \OCP\Share::SHARE_TYPE_LINK;
-		$data['password'] = 'foo';
-
-		$request = $this->createRequest($data);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare();
+		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK, null, 'false', 'bar');
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -373,13 +329,10 @@ class ApiTest extends TestCase {
 		// sharing file to a user should work if shareapi_exclude_groups is set
 		// to no
 		\OC::$server->getAppConfig()->setValue('core', 'shareapi_exclude_groups', 'no');
-		$post['path'] = $this->filename;
-		$post['shareWith'] = self::TEST_FILES_SHARING_API_USER2;
-		$post['shareType'] = \OCP\Share::SHARE_TYPE_USER;
 
-		$request = $this->createRequest($post);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare();
+		$result = $ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -388,21 +341,16 @@ class ApiTest extends TestCase {
 
 		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->deleteShare($data['id']);
+		$ocs->deleteShare($data['id']);
 		$ocs->cleanup();
 
 		// exclude groups, but not the group the user belongs to. Sharing should still work
 		\OC::$server->getAppConfig()->setValue('core', 'shareapi_exclude_groups', 'yes');
 		\OC::$server->getAppConfig()->setValue('core', 'shareapi_exclude_groups_list', 'admin,group1,group2');
 
-		$post = [];
-		$post['path'] = $this->filename;
-		$post['shareWith'] = self::TEST_FILES_SHARING_API_USER2;
-		$post['shareType'] = \OCP\Share::SHARE_TYPE_USER;
-
-		$request = $this->createRequest($post);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare();
+		$result = $ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -417,14 +365,9 @@ class ApiTest extends TestCase {
 		// now we exclude the group the user belongs to ('group'), sharing should fail now
 		\OC::$server->getAppConfig()->setValue('core', 'shareapi_exclude_groups_list', 'admin,group');
 
-		$post = [];
-		$post['path'] = $this->filename;
-		$post['shareWith'] = self::TEST_FILES_SHARING_API_USER2;
-		$post['shareType'] = \OCP\Share::SHARE_TYPE_USER;
-
-		$request = $this->createRequest($post);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
-		$ocs->createShare();
+		$ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();
 
 		// cleanup
@@ -492,13 +435,9 @@ class ApiTest extends TestCase {
 	 * @medium
 	 */
 	function testPublicLinkUrl() {
-		// simulate a post request
-		$post['path'] = $this->folder;
-		$post['shareType'] = \OCP\Share::SHARE_TYPE_LINK;
-
-		$request = $this->createRequest($post);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare();
+		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK);
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -1473,15 +1412,11 @@ class ApiTest extends TestCase {
 	 * @dataProvider datesProvider
 	 */
 	public function testPublicLinkExpireDate($date, $valid) {
-		$request = $this->createRequest([
-			'path' => $this->folder,
-			'shareType' => \OCP\Share::SHARE_TYPE_LINK,
-			'expireDate' => $date,
-		]);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
 
 		try {
-			$result = $ocs->createShare();
+			$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK, null, 'false', '', $date);
 			$this->assertTrue($valid);
 		} catch (OCSNotFoundException $e) {
 			$this->assertFalse($valid);
@@ -1516,13 +1451,9 @@ class ApiTest extends TestCase {
 		$date = new \DateTime();
 		$date->add(new \DateInterval('P5D'));
 
-		$request = $this->createRequest([
-			'path' => $this->folder,
-			'shareType' => \OCP\Share::SHARE_TYPE_LINK,
-			'expireDate' => $date->format('Y-m-d'),
-		]);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare();
+		$result = $ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK, null, 'false', '', $date->format('Y-m-d'));
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -1553,15 +1484,11 @@ class ApiTest extends TestCase {
 		$date = new \DateTime();
 		$date->add(new \DateInterval('P8D'));
 
-		$request = $this->createRequest([
-			'path' => $this->folder,
-			'shareType' => \OCP\Share::SHARE_TYPE_LINK,
-			'expireDate' => $date->format('Y-m-d'),
-		]);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
 
 		try {
-			$ocs->createShare();
+			$ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK, null, 'false', '', $date->format('Y-m-d'));
 			$this->fail();
 		} catch (OCSException $e) {
 			$this->assertEquals(404, $e->getCode());
@@ -1579,15 +1506,11 @@ class ApiTest extends TestCase {
 		$date = new \DateTime();
 		$date->sub(new \DateInterval('P8D'));
 
-		$request = $this->createRequest([
-			'path' => $this->folder,
-			'shareType' => \OCP\Share::SHARE_TYPE_LINK,
-			'expireDate' => $date->format('Y-m-d'),
-		]);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
 
 		try {
-			$result = $ocs->createShare();
+			$ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK, null, 'false', '', $date->format('Y-m-d'));
 			$this->fail();
 		} catch(OCSException $e) {
 			$this->assertEquals(404, $e->getCode());
@@ -1605,13 +1528,9 @@ class ApiTest extends TestCase {
 	 */
 	public function testInvisibleSharesUser() {
 		// simulate a post request
-		$request = $this->createRequest([
-			'path' => $this->folder,
-			'shareWith' => self::TEST_FILES_SHARING_API_USER2,
-			'shareType' => \OCP\Share::SHARE_TYPE_USER
-		]);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare();
+		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();
 		$data = $result->getData();
 
@@ -1622,7 +1541,7 @@ class ApiTest extends TestCase {
 			'shareType' => \OCP\Share::SHARE_TYPE_LINK,
 		]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER2);
-		$result = $ocs->createShare();
+		$ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK);
 		$ocs->cleanup();
 
 		$request = $this->createRequest([]);
@@ -1646,24 +1565,17 @@ class ApiTest extends TestCase {
 	 */
 	public function testInvisibleSharesGroup() {
 		// simulate a post request
-		$request = $this->createRequest([
-			'path' => $this->folder,
-			'shareWith' => self::TEST_FILES_SHARING_API_GROUP1,
-			'shareType' => \OCP\Share::SHARE_TYPE_GROUP
-		]);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare();
+		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_GROUP, self::TEST_FILES_SHARING_API_GROUP1);
 		$ocs->cleanup();
 		$data = $result->getData();
 
 		$topId = $data['id'];
 
-		$request = $this->createRequest([
-			'path' => $this->folder . $this->subfolder,
-			'shareType' => \OCP\Share::SHARE_TYPE_LINK,
-		]);
+		$request = $this->createRequest([]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER2);
-		$result = $ocs->createShare();
+		$ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK);
 		$ocs->cleanup();
 
 		$request = $this->createRequest([]);

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -88,27 +88,10 @@ class ApiTest extends TestCase {
 	}
 
 	/**
-	 * @param array $data
-	 * @return \OCP\IRequest
-	 */
-	private function createRequest(array $data) {
-		$request = $this->getMockBuilder('\OCP\IRequest')->getMock();
-		$request->method('getParam')
-			->will($this->returnCallback(function($param, $default = null) use ($data) {
-				if (isset($data[$param])) {
-					return $data[$param];
-				}
-				return $default;
-			}));
-		return $request;
-	}
-
-	/**
-	 * @param \OCP\IRequest $request
 	 * @param string $userId The userId of the caller
 	 * @return \OCA\Files_Sharing\API\Share20OCS
 	 */
-	private function createOCS($request, $userId) {
+	private function createOCS($userId) {
 		$currentUser = \OC::$server->getUserManager()->get($userId);
 
 		$l = $this->getMockBuilder('\OCP\IL10N')->getMock();
@@ -119,7 +102,7 @@ class ApiTest extends TestCase {
 
 		return new \OCA\Files_Sharing\API\Share20OCS(
 			self::APP_NAME,
-			$request,
+			$this->getMockBuilder('OCP\IRequest')->getMock(),
 			$this->shareManager,
 			\OC::$server->getGroupManager(),
 			\OC::$server->getUserManager(),
@@ -134,8 +117,7 @@ class ApiTest extends TestCase {
 	 * @medium
 	 */
 	function testCreateShareUserFile() {
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();
 
@@ -145,16 +127,14 @@ class ApiTest extends TestCase {
 
 		$this->shareManager->getShareById('ocinternal:'.$data['id']);
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->deleteShare($data['id']);
 
 		$ocs->cleanup();
 	}
 
 	function testCreateShareUserFolder() {
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();
 
@@ -164,8 +144,7 @@ class ApiTest extends TestCase {
 
 		$this->shareManager->getShareById('ocinternal:'.$data['id']);
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->deleteShare($data['id']);
 		$ocs->cleanup();
 
@@ -173,8 +152,7 @@ class ApiTest extends TestCase {
 
 
 	function testCreateShareGroupFile() {
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_GROUP, self::TEST_FILES_SHARING_API_GROUP1);
 		$ocs->cleanup();
 
@@ -184,15 +162,13 @@ class ApiTest extends TestCase {
 
 		$this->shareManager->getShareById('ocinternal:'.$data['id']);
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->deleteShare($data['id']);
 		$ocs->cleanup();
 	}
 
 	function testCreateShareGroupFolder() {
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_GROUP, self::TEST_FILES_SHARING_API_GROUP1);
 		$ocs->cleanup();
 
@@ -202,16 +178,14 @@ class ApiTest extends TestCase {
 
 		$this->shareManager->getShareById('ocinternal:'.$data['id']);
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->deleteShare($data['id']);
 		$ocs->cleanup();
 
 	}
 
 	public function testCreateShareLink() {
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK);
 		$ocs->cleanup();
 
@@ -226,15 +200,13 @@ class ApiTest extends TestCase {
 
 		$this->shareManager->getShareById('ocinternal:'.$data['id']);
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->deleteShare($data['id']);
 		$ocs->cleanup();
 	}
 
 	public function testCreateShareLinkPublicUpload() {
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK, null, 'true');
 		$ocs->cleanup();
 
@@ -255,8 +227,7 @@ class ApiTest extends TestCase {
 
 		$this->shareManager->getShareById('ocinternal:'.$data['id']);
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->deleteShare($data['id']);
 		$ocs->cleanup();
 	}
@@ -266,8 +237,7 @@ class ApiTest extends TestCase {
 		$appConfig = \OC::$server->getAppConfig();
 		$appConfig->setValue('core', 'shareapi_enforce_links_password', 'yes');
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		try {
 			$ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK);
 			$this->fail();
@@ -276,8 +246,7 @@ class ApiTest extends TestCase {
 		}
 		$ocs->cleanup();
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		try {
 			$ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK, null, 'false', '');
 			$this->fail();
@@ -287,25 +256,19 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 
 		// share with password should succeed
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK, null, 'false', 'bar');
 		$ocs->cleanup();
 
 		$data = $result->getData();
 
 		// setting new password should succeed
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->updateShare($data['id'], null, 'bar');
 		$ocs->cleanup();
 
 		// removing password should fail
-		$data2 = [
-			'password' => '',
-		];
-		$request = $this->createRequest($data2);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		try {
 			$ocs->updateShare($data['id']);
 			$this->fail();
@@ -315,8 +278,7 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 
 		// cleanup
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->deleteShare($data['id']);
 		$ocs->cleanup();
 
@@ -331,8 +293,7 @@ class ApiTest extends TestCase {
 		// to no
 		\OC::$server->getAppConfig()->setValue('core', 'shareapi_exclude_groups', 'no');
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();
 
@@ -340,8 +301,7 @@ class ApiTest extends TestCase {
 
 		$this->shareManager->getShareById('ocinternal:'.$data['id']);
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->deleteShare($data['id']);
 		$ocs->cleanup();
 
@@ -349,8 +309,7 @@ class ApiTest extends TestCase {
 		\OC::$server->getAppConfig()->setValue('core', 'shareapi_exclude_groups', 'yes');
 		\OC::$server->getAppConfig()->setValue('core', 'shareapi_exclude_groups_list', 'admin,group1,group2');
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();
 
@@ -358,16 +317,14 @@ class ApiTest extends TestCase {
 
 		$this->shareManager->getShareById('ocinternal:' . $data['id']);
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->deleteShare($data['id']);
 		$ocs->cleanup();
 
 		// now we exclude the group the user belongs to ('group'), sharing should fail now
 		\OC::$server->getAppConfig()->setValue('core', 'shareapi_exclude_groups_list', 'admin,group');
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();
 
@@ -392,8 +349,7 @@ class ApiTest extends TestCase {
 
 		$share = $this->shareManager->createShare($share);
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->getShares();
 		$ocs->cleanup();
 
@@ -421,8 +377,7 @@ class ApiTest extends TestCase {
 			->setPermissions(31);
 		$share2 = $this->shareManager->createShare($share2);
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER2);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER2);
 		$result = $ocs->getShares('true');
 		$ocs->cleanup();
 
@@ -436,8 +391,7 @@ class ApiTest extends TestCase {
 	 * @medium
 	 */
 	function testPublicLinkUrl() {
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK);
 		$ocs->cleanup();
 
@@ -452,8 +406,7 @@ class ApiTest extends TestCase {
 		$this->assertEquals($url, $data['url']);
 
 		// check for link in getall shares
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->getShares();
 		$ocs->cleanup();
 
@@ -461,8 +414,7 @@ class ApiTest extends TestCase {
 		$this->assertEquals($url, current($data)['url']);
 
 		// check for path
-		$request = $this->createRequest(['path' => $this->folder]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->getShares();
 		$ocs->cleanup();
 
@@ -470,16 +422,14 @@ class ApiTest extends TestCase {
 		$this->assertEquals($url, current($data)['url']);
 
 		// check in share id
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->getShare($id);
 		$ocs->cleanup();
 
 		$data = $result->getData();
 		$this->assertEquals($url, current($data)['url']);
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->deleteShare($id);
 		$ocs->cleanup();
 	}
@@ -506,8 +456,7 @@ class ApiTest extends TestCase {
 			->setPermissions(1);
 		$share2 = $this->shareManager->createShare($share);
 
-		$request = $this->createRequest(['path' => $this->filename]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->getShares();
 		$ocs->cleanup();
 
@@ -541,8 +490,7 @@ class ApiTest extends TestCase {
 			->setPermissions(19);
 		$share2 = $this->shareManager->createShare($share2);
 
-		$request = $this->createRequest(['path' => $this->filename]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->getShares();
 		$ocs->cleanup();
 
@@ -550,8 +498,7 @@ class ApiTest extends TestCase {
 		$this->assertTrue(count($result->getData()) === 1);
 
 		// now also ask for the reshares
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->getShares('false', 'true', 'false', $this->filename);
 		$ocs->cleanup();
 
@@ -577,8 +524,7 @@ class ApiTest extends TestCase {
 		$share1 = $this->shareManager->createShare($share1);
 
 		// call getShare() with share ID
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->getShare($share1->getId());
 		$ocs->cleanup();
 
@@ -610,8 +556,7 @@ class ApiTest extends TestCase {
 		$share2 = $this->shareManager->createShare($share2);
 
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->getShares('false', 'false', 'true', $this->folder);
 		$ocs->cleanup();
 
@@ -632,8 +577,7 @@ class ApiTest extends TestCase {
 			->setPermissions(19);
 		$share1 = $this->shareManager->createShare($share1);
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		try {
 			$ocs->getShares('false', 'false', 'true', $this->filename);
 			$this->fail();
@@ -683,8 +627,7 @@ class ApiTest extends TestCase {
 		);
 		foreach ($testValues as $value) {
 
-			$request = $this->createRequest([]);
-			$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER2);
+				$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER2);
 			$result = $ocs->getShares('false', 'false', 'true', $value['query']);
 			$ocs->cleanup();
 
@@ -722,8 +665,7 @@ class ApiTest extends TestCase {
 			->setPermissions(1);
 		$share2 = $this->shareManager->createShare($share2);
 
-		$request = $this->createRequest(['path' => '/', 'subfiles' => 'true']);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER2);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER2);
 		$result = $ocs->getShares();
 		$ocs->cleanup();
 
@@ -773,7 +715,7 @@ class ApiTest extends TestCase {
 		 * Test as recipient
 		 */
 		$request = $this->createRequest(['path' => '/', 'subfiles' => 'true']);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER3);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER3);
 		$result = $ocs->getShares();
 		$ocs->cleanup();
 
@@ -787,8 +729,7 @@ class ApiTest extends TestCase {
 		/*
 		 * Test for first owner/initiator
 		 */
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->getShares();
 		$ocs->cleanup();
 
@@ -802,8 +743,7 @@ class ApiTest extends TestCase {
 		/*
 		 * Test for second initiator
 		 */
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER2);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER2);
 		$result = $ocs->getShares();
 		$ocs->cleanup();
 
@@ -849,8 +789,7 @@ class ApiTest extends TestCase {
 			->setPermissions(1);
 		$share3 = $this->shareManager->createShare($share3);
 
-		$request = $this->createRequest(['path' => $this->subfolder]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER2);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER2);
 		$result1 = $ocs->getShares();
 		$ocs->cleanup();
 
@@ -859,8 +798,7 @@ class ApiTest extends TestCase {
 		$this->assertCount(1, $data1);
 		$s1 = reset($data1);
 
-		$request = $this->createRequest(['path' => $this->folder.$this->subfolder]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER2);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER2);
 		$result2 = $ocs->getShares();
 		$ocs->cleanup();
 
@@ -910,8 +848,7 @@ class ApiTest extends TestCase {
 			->setPermissions(1);
 		$share3 = $this->shareManager->createShare($share3);
 
-		$request = $this->createRequest(['path' => '/', 'subfiles' => 'true']);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER3);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER3);
 		$result = $ocs->getShares();
 		$ocs->cleanup();
 
@@ -932,8 +869,7 @@ class ApiTest extends TestCase {
 	 * @medium
 	 */
 	function testGetShareFromUnknownId() {
-		$request = $this->createRequest(['path' => '/', 'subfiles' => 'true']);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER3);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER3);
 		try {
 			$ocs->getShare(0);
 			$this->fail();
@@ -966,8 +902,7 @@ class ApiTest extends TestCase {
 		$share2 = $this->shareManager->createShare($share2);
 
 		// update permissions
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->updateShare($share1->getId(), 1);
 		$ocs->cleanup();
 
@@ -977,16 +912,14 @@ class ApiTest extends TestCase {
 		// update password for link share
 		$this->assertNull($share2->getPassword());
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->updateShare($share2->getId(), null, 'foo');
 		$ocs->cleanup();
 
 		$share2 = $this->shareManager->getShareById('ocinternal:' . $share2->getId());
 		$this->assertNotNull($share2->getPassword());
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->updateShare($share2->getId(), null, '');
 		$ocs->cleanup();
 
@@ -1011,8 +944,7 @@ class ApiTest extends TestCase {
 			->setPermissions(19);
 		$share1 = $this->shareManager->createShare($share1);
 
-		$request = $this->createRequest(['permissions' => \OCP\Constants::PERMISSION_ALL]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		try {
 			$ocs->updateShare($share1->getId());
 			$this->fail();
@@ -1041,8 +973,7 @@ class ApiTest extends TestCase {
 		$share1 = $this->shareManager->createShare($share1);
 
 		// update public upload
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->updateShare($share1->getId(), null, null, 'true');
 		$ocs->cleanup();
 
@@ -1085,8 +1016,7 @@ class ApiTest extends TestCase {
 		$dateOutOfRange->add(new \DateInterval('P8D'));
 
 		// update expire date to a valid value
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->updateShare($share1->getId(), null, null, null, $dateWithinRange->format('Y-m-d'));
 		$ocs->cleanup();
 
@@ -1096,8 +1026,7 @@ class ApiTest extends TestCase {
 		$this->assertEquals($dateWithinRange, $share1->getExpirationDate());
 
 		// update expire date to a value out of range
-		$request = $this->createRequest(['expireDate' => $dateOutOfRange->format('Y-m-d')]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		try {
 			$ocs->updateShare($share1->getId());
 			$this->fail();
@@ -1112,8 +1041,7 @@ class ApiTest extends TestCase {
 		$this->assertEquals($dateWithinRange, $share1->getExpirationDate());
 
 		// Try to remove expire date
-		$request = $this->createRequest(['expireDate' => '']);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		try {
 			$ocs->updateShare($share1->getId());
 			$this->fail();
@@ -1154,13 +1082,11 @@ class ApiTest extends TestCase {
 			->setPermissions(1);
 		$share2 = $this->shareManager->createShare($share1);
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->deleteShare($share1->getId());
 		$ocs->cleanup();
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->deleteShare($share2->getId());
 		$ocs->cleanup();
 
@@ -1191,8 +1117,7 @@ class ApiTest extends TestCase {
 		$share2 = $this->shareManager->createShare($share2);
 
 		// test if we can unshare the link again
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER2);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER2);
 		$ocs->deleteShare($share2->getId());
 		$ocs->cleanup();
 
@@ -1301,7 +1226,8 @@ class ApiTest extends TestCase {
 
 		$this->shareManager->deleteShare($share);
 
-		\OC_Hook::clear('OC_Filesystem', 'post_initMountPoints', '\OCA\Files_Sharing\Tests\ApiTest', 'initTestMountPointsHook');
+		\OC_Hook::clear('OC_Filesystem', 'post_initMountPoints');
+		\OC_Hook::clear('\OCA\Files_Sharing\Tests\ApiTest', 'initTestMountPointsHook');
 	}
 	/**
 	 * @expectedException \Exception
@@ -1406,8 +1332,7 @@ class ApiTest extends TestCase {
 	 * @dataProvider datesProvider
 	 */
 	public function testPublicLinkExpireDate($date, $valid) {
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 
 		try {
 			$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK, null, 'false', '', $date);
@@ -1445,8 +1370,7 @@ class ApiTest extends TestCase {
 		$date = new \DateTime();
 		$date->add(new \DateInterval('P5D'));
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK, null, 'false', '', $date->format('Y-m-d'));
 		$ocs->cleanup();
 
@@ -1478,8 +1402,7 @@ class ApiTest extends TestCase {
 		$date = new \DateTime();
 		$date->add(new \DateInterval('P8D'));
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 
 		try {
 			$ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK, null, 'false', '', $date->format('Y-m-d'));
@@ -1500,8 +1423,7 @@ class ApiTest extends TestCase {
 		$date = new \DateTime();
 		$date->sub(new \DateInterval('P8D'));
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 
 		try {
 			$ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK, null, 'false', '', $date->format('Y-m-d'));
@@ -1522,31 +1444,22 @@ class ApiTest extends TestCase {
 	 */
 	public function testInvisibleSharesUser() {
 		// simulate a post request
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();
 		$data = $result->getData();
 
 		$topId = $data['id'];
 
-		$request = $this->createRequest([
-			'path' => $this->folder . $this->subfolder,
-			'shareType' => \OCP\Share::SHARE_TYPE_LINK,
-		]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER2);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER2);
 		$ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK);
 		$ocs->cleanup();
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->deleteShare($topId);
 		$ocs->cleanup();
 
-		$request = $this->createRequest([
-			'reshares' => 'true',
-		]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->getShares();
 		$ocs->cleanup();
 
@@ -1559,28 +1472,22 @@ class ApiTest extends TestCase {
 	 */
 	public function testInvisibleSharesGroup() {
 		// simulate a post request
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_GROUP, self::TEST_FILES_SHARING_API_GROUP1);
 		$ocs->cleanup();
 		$data = $result->getData();
 
 		$topId = $data['id'];
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER2);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER2);
 		$ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK);
 		$ocs->cleanup();
 
-		$request = $this->createRequest([]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$ocs->deleteShare($topId);
 		$ocs->cleanup();
 
-		$request = $this->createRequest([
-			'reshares' => 'true',
-		]);
-		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
+		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->getShares();
 		$ocs->cleanup();
 


### PR DESCRIPTION
More code cleanup. And mainly also test cleanup which are now a lot more readable.

CC: @schiessle @LukasReschke @nickvergessen @MorrisJobke 
