### PR TITLE
[stable10] Make sure the primary action is always the first one

### DIFF
--- a/lib/private/Notification/Notification.php
+++ b/lib/private/Notification/Notification.php
@@ -397,9 +397,13 @@ class Notification implements INotification {
 			}
 
 			$this->hasPrimaryParsedAction = true;
+
+			// Make sure the primary action is always the first one
+			array_unshift($this->actionsParsed, $action);
+		} else {
+			$this->actionsParsed[] = $action;
 		}
 
-		$this->actionsParsed[] = $action;
 		return $this;
 	}
 

--- a/tests/lib/Notification/NotificationTest.php
+++ b/tests/lib/Notification/NotificationTest.php
@@ -495,6 +495,35 @@ class NotificationTest extends TestCase {
 		$this->notification->addParsedAction($action);
 	}
 
+	public function testAddActionParsedPrimaryEnd() {
+		/** @var \OCP\Notification\IAction|\PHPUnit_Framework_MockObject_MockObject $action */
+		$action1 = $this->getMockBuilder('OCP\Notification\IAction')
+			->disableOriginalConstructor()
+			->getMock();
+		$action1->expects($this->exactly(2))
+			->method('isValidParsed')
+			->willReturn(true);
+		$action1->expects($this->exactly(2))
+			->method('isPrimary')
+			->willReturn(false);
+		/** @var \OCP\Notification\IAction|\PHPUnit_Framework_MockObject_MockObject $action */
+		$action2 = $this->getMockBuilder('OCP\Notification\IAction')
+			->disableOriginalConstructor()
+			->getMock();
+		$action2->expects($this->once())
+			->method('isValidParsed')
+			->willReturn(true);
+		$action2->expects($this->once())
+			->method('isPrimary')
+			->willReturn(true);
+
+		$this->assertSame($this->notification, $this->notification->addParsedAction($action1));
+		$this->assertSame($this->notification, $this->notification->addParsedAction($action2));
+		$this->assertSame($this->notification, $this->notification->addParsedAction($action1));
+
+		$this->assertEquals([$action2, $action1, $action1], $this->notification->getParsedActions());
+	}
+
 	public function dataIsValid() {
 		return [
 			[false, '', false],


### PR DESCRIPTION
Backport of #867 

@MorrisJobke @LukasReschke 
