### PR TITLE
white-space: pre-wrap is supported on all current browsers

### DIFF
--- a/apps/comments/css/comments.css
+++ b/apps/comments/css/comments.css
@@ -60,14 +60,7 @@
 }
 
 #commentsTabView .comment.collapsed .message {
-	white-space: -moz-pre-wrap !important;  /* Mozilla, since 1999 */
-	white-space: -webkit-pre-wrap; /*Chrome & Safari */
-	white-space: -pre-wrap;      /* Opera 4-6 */
-	white-space: -o-pre-wrap;    /* Opera 7 */
-	white-space: pre-wrap;       /* css-3 */
-	word-wrap: break-word;       /* Internet Explorer 5.5+ */
-	word-break: break-all;
-	white-space: normal;
+	white-space: pre-wrap;
 }
 
 #commentsTabView .comment.collapsed .message {


### PR DESCRIPTION
- Chrome 1, Firefox 3, IE8, Opera 8 and Safari 3
- see https://developer.mozilla.org/en-US/docs/Web/CSS/white-space

cc @nextcloud/designers @rullzer 
