### PR TITLE
[stable10] SVG defintions always take the first one

### DIFF
--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -238,7 +238,6 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		if (appfromstore) {
 			img += '<image x="0" y="0" width="72" height="72" preserveAspectRatio="xMinYMin meet" xlink:href="' + url + '"  class="app-icon" /></svg>';
 		} else {
-			img += '<defs><filter id="invertIcon"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0"></feColorMatrix></filter></defs>';
 			img += '<image x="0" y="0" width="72" height="72" preserveAspectRatio="xMinYMin meet" filter="url(#invertIcon)" xlink:href="' + url + '"  class="app-icon"></image></svg>';
 		}
 		return img;

--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -180,6 +180,9 @@ script(
 	</div>
 </div>
 <div id="app-content">
+	<svg height="0">
+		<defs><filter id="invertIcon"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0"></feColorMatrix></filter></defs>
+	</svg>
 	<div id="apps-list" class="icon-loading"></div>
 	<div id="apps-list-empty" class="hidden emptycontent emptycontent-search">
 		<div class="icon-search"></div>


### PR DESCRIPTION
- Move filter definition out
- backport of #937 

cc @LukasReschke @nickvergessen @rullzer 

I tested this and it works
