### PR TITLE
Add feedback for password change

### DIFF
--- a/settings/Controller/ChangePasswordController.php
+++ b/settings/Controller/ChangePasswordController.php
@@ -21,6 +21,7 @@
  */
 namespace OC\Settings\Controller;
 
+use OC\HintException;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
@@ -233,11 +234,21 @@ class ChangePasswordController extends Controller {
 				}
 			}
 		} else {
-			if ($targetUser->setPassword($password) === false) {
+			try {
+				if ($targetUser->setPassword($password) === false) {
+					return new JSONResponse([
+						'status' => 'error',
+						'data' => [
+							'message' => $this->l->t('Unable to change password'),
+						],
+					]);
+				}
+			// password policy app throws exception
+			} catch(HintException $e) {
 				return new JSONResponse([
 					'status' => 'error',
 					'data' => [
-						'message' => $this->l->t('Unable to change password'),
+						'message' => $e->getHint(),
 					],
 				]);
 			}

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -670,7 +670,9 @@ $(document).ready(function () {
 							OC.generateUrl('/settings/users/changepassword'),
 							{username: uid, password: $(this).val(), recoveryPassword: recoveryPasswordVal},
 							function (result) {
-								if (result.status != 'success') {
+								if (result.status === 'success') {
+									OC.Notification.showTemporary(t('admin', 'Password successfully changed'));
+								} else {
 									OC.Notification.showTemporary(t('admin', result.data.message));
 								}
 							}


### PR DESCRIPTION
- downstream of https://github.com/owncloud/core/pull/25756
- add hint if password policy disallows password change otherwise nothing is shown

cc @nickvergessen @LukasReschke @rullzer 

@karlitschek I would like to backport this otherwise it looks like the password can be changed even if the password is not allowed policy wise.
