### PR TITLE
Remove reading PATH_INFO from server variable

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -700,10 +700,6 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 * @return string|false Path info or false when not found
 	 */
 	public function getPathInfo() {
-		if(isset($this->server['PATH_INFO'])) {
-			return $this->server['PATH_INFO'];
-		}
-
 		$pathInfo = $this->getRawPathInfo();
 		// following is taken from \Sabre\HTTP\URLUtil::decodePathSegment
 		$pathInfo = rawurldecode($pathInfo);

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -1063,22 +1063,6 @@ class RequestTest extends \Test\TestCase {
 		$this->assertSame('www.owncloud.org', self::invokePrivate($request, 'getOverwriteHost'));
 	}
 
-	public function testGetPathInfoWithSetEnv() {
-		$request = new Request(
-			[
-				'server' => [
-					'PATH_INFO' => 'apps/files/',
-				]
-			],
-			$this->secureRandom,
-			$this->config,
-			$this->csrfTokenManager,
-			$this->stream
-		);
-
-		$this->assertSame('apps/files/',  $request->getPathInfo());
-	}
-
 	/**
 	 * @expectedException \Exception
 	 * @expectedExceptionMessage The requested uri(/foo.php) cannot be processed by the script '/var/www/index.php')


### PR DESCRIPTION
Having two code paths for this is unreliable and can lead to bugs. Also, in some cases Apache isn't setting the PATH_INFO variable when mod_rewrite is used.

Fixes https://github.com/nextcloud/server/issues/983
