### PR TITLE
Make e-mail icon visible

### DIFF
--- a/core/css/icons.css
+++ b/core/css/icons.css
@@ -204,10 +204,6 @@ img.icon-loading-small-dark, object.icon-loading-small-dark, video.icon-loading-
 	background-image: url('../img/actions/mail.svg');
 }
 
-.icon-mail-grey {
-	background-image: url('../img/actions/mail-grey.svg');
-}
-
 .icon-menu {
 	background-image: url('../img/actions/menu.svg');
 }

--- a/core/css/share.css
+++ b/core/css/share.css
@@ -171,3 +171,7 @@ a.showCruds:hover,a.unshare:hover {
 	padding-top: 12px;
 	color: #999;
 }
+
+.shareTabView .mailView .icon-mail {
+	opacity: 0.5;
+}

--- a/core/js/sharedialogmailview.js
+++ b/core/js/sharedialogmailview.js
@@ -18,7 +18,7 @@
 			'    {{#if mailPublicNotificationEnabled}}' +
 			'<form id="emailPrivateLink" class="emailPrivateLinkForm oneline">' +
 			'    <input id="email" class="emailField" value="{{email}}" placeholder="{{mailPrivatePlaceholder}}" type="text" />' +
-			'    <a id="emailButton" class="icon icon-mail-grey" />' +
+			'    <a id="emailButton" class="icon icon-mail hasTooltip" title="Send e-mail"></a>' +
 			'</form>' +
 			'    {{/if}}' +
 			'{{/if}}'


### PR DESCRIPTION
Fixes #996
- Make mail icon visible
- Opacity to .5
- Add tooltip

Before:
![before](https://cloud.githubusercontent.com/assets/45821/17837219/03915654-67ad-11e6-9e4f-a5b505ed6fe5.png)

After:
![after](https://cloud.githubusercontent.com/assets/45821/17837221/076f0870-67ad-11e6-8459-c05239014d21.png)

CC: @zeugmatis  @jancborchardt @nickvergessen @MorrisJobke @blizzz @LukasReschke 

I'll backport this to NC10 once in.
