### PR TITLE
[stable10] fixes registering of theming settings where server return OC_Defaults

### DIFF
--- a/apps/theming/lib/Settings/Admin.php
+++ b/apps/theming/lib/Settings/Admin.php
@@ -29,20 +29,21 @@ use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\Settings\ISettings;
+use \OC_Defaults;
 
 class Admin implements ISettings {
 	/** @var IConfig */
 	private $config;
 	/** @var IL10N */
 	private $l;
-	/** @var ThemingDefaults */
+	/** @var ThemingDefaults|OC_Defaults */
 	private $themingDefaults;
 	/** @var IURLGenerator */
 	private $urlGenerator;
 
 	public function __construct(IConfig $config,
 								IL10N $l,
-								ThemingDefaults $themingDefaults,
+								OC_Defaults $themingDefaults,
 								IURLGenerator $urlGenerator) {
 		$this->config = $config;
 		$this->l = $l;


### PR DESCRIPTION
… instead of ThemingDefaults

Otherwise, no admin settings for theming aka unsuable.

@nickvergessen @rullzer 
