### PR TITLE
Do not add SharedMount if it is invalid

### DIFF
--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -36,6 +36,7 @@ use OC\Files\Cache\FailedCache;
 use OCA\Files_Sharing\ISharedStorage;
 use OCP\Constants;
 use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IStorage;
 use OCP\Lock\ILockingProvider;
 
@@ -94,6 +95,9 @@ class Shared extends \OC\Files\Storage\Wrapper\Jail implements ISharedStorage {
 			$sourcePath = $this->ownerView->getPath($this->superShare->getNodeId());
 			list($this->storage, $this->rootPath) = $this->ownerView->resolvePath($sourcePath);
 			$this->sourceRootInfo = $this->storage->getCache()->get($this->rootPath);
+		} catch (NotFoundException $e) {
+			$this->storage = new FailedStorage(['exception' => $e]);
+			$this->rootPath = '';
 		} catch (\Exception $e) {
 			$this->storage = new FailedStorage(['exception' => $e]);
 			$this->rootPath = '';


### PR DESCRIPTION
If a shared file is moved to the trash the share entry is still alive.
However the sharee can't initialise the share since it is not in the
owners dir <user>/files.

So check if it is there and if not log a debug and carry on.

Fixes #938 

@icewind1991 This is safe right (we do it later in the code otherwise anyways that is where the error comes from). But this will not trigger depenency setup right?

CC: @LukasReschke @nickvergessen @MorrisJobke @blizzz 
