### PR TITLE
Cache registered autoloaders

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -66,6 +66,7 @@ class OC_App {
 	static private $appTypes = array();
 	static private $loadedApps = array();
 	static private $altLogin = array();
+	static private $alreadyRegistered = [];
 	const officialApp = 200;
 
 	/**
@@ -167,6 +168,11 @@ class OC_App {
 	 * @param string $path
 	 */
 	public static function registerAutoloading($app, $path) {
+		$key = $app . '-' . $path;
+		if(isset(self::$alreadyRegistered[$key])) {
+			return;
+		}
+		self::$alreadyRegistered[$key] = true;
 		// Register on PSR-4 composer autoloader
 		$appNamespace = \OC\AppFramework\App::buildAppNamespace($app);
 		\OC::$composerAutoloader->addPsr4($appNamespace . '\\', $path . '/lib/', true);


### PR DESCRIPTION
This saves more than 20ms (!) on every request, the previous problem was that `\OC_App::registerAutoloading` calls `\OC\AppFramework\App::buildAppNamespace` which parses the appinfo.xml. Since that was also called multiple times (e.g. on cloud.nextcloud.com over 200 times) that had a significant performance impact. Also on simple PROPFIND requests.

https://blackfire.io/profiles/compare/65a53e6e-7f35-4974-b559-4c81abd01c3b/graph shows the difference nicely.

@rullzer @icewind1991 @nickvergessen Do you see any problems with that?
@karlitschek If above mentioned persons don't I'd even propose to backport this down to stable10 as 20ms for every request is significant… 🙈 
