### PR TITLE
add stacktrace to query logger

### DIFF
--- a/lib/private/Diagnostics/Query.php
+++ b/lib/private/Diagnostics/Query.php
@@ -34,15 +34,18 @@ class Query implements IQuery {
 
 	private $end;
 
+	private $stack;
+
 	/**
 	 * @param string $sql
 	 * @param array $params
 	 * @param int $start
 	 */
-	public function __construct($sql, $params, $start) {
+	public function __construct($sql, $params, $start, array $stack) {
 		$this->sql = $sql;
 		$this->params = $params;
 		$this->start = $start;
+		$this->stack = $stack;
 	}
 
 	public function end($time) {
@@ -68,5 +71,13 @@ class Query implements IQuery {
 	 */
 	public function getDuration() {
 		return $this->end - $this->start;
+	}
+
+	public function getStartTime() {
+		return $this->start;
+	}
+
+	public function getStacktrace() {
+		return $this->stack;
 	}
 }

--- a/lib/private/Diagnostics/QueryLogger.php
+++ b/lib/private/Diagnostics/QueryLogger.php
@@ -42,7 +42,15 @@ class QueryLogger implements IQueryLogger {
 	 * @param array $types
 	 */
 	public function startQuery($sql, array $params = null, array $types = null) {
-		$this->activeQuery = new Query($sql, $params, microtime(true));
+		$this->activeQuery = new Query($sql, $params, microtime(true), $this->getStack());
+	}
+
+	private function getStack() {
+		$stack = debug_backtrace();
+		array_shift($stack);
+		array_shift($stack);
+		array_shift($stack);
+		return $stack;
 	}
 
 	public function stopQuery() {

--- a/lib/public/Diagnostics/IQuery.php
+++ b/lib/public/Diagnostics/IQuery.php
@@ -47,4 +47,16 @@ interface IQuery {
 	 * @since 8.0.0
 	 */
 	public function getDuration();
+
+	/**
+	 * @return float
+	 * @since 9.2.0
+	 */
+	public function getStartTime();
+
+	/**
+	 * @return array
+	 * @since 9.2.0
+	 */
+	public function getStacktrace();
 }


### PR DESCRIPTION
Allows debug tools to get the stacktrace for all queries to make it easier to figure out why queries are executed
