### PR TITLE
dont update the auth token twice

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -597,7 +597,6 @@ class Session implements IUserSession, Emitter {
 			}
 
 			$dbToken->setLastCheck($now);
-			$this->tokenProvider->updateToken($dbToken);
 			return true;
 		}
 
@@ -608,7 +607,6 @@ class Session implements IUserSession, Emitter {
 			return false;
 		}
 		$dbToken->setLastCheck($now);
-		$this->tokenProvider->updateToken($dbToken);
 		return true;
 	}
 

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -890,9 +890,6 @@ class SessionTest extends \Test\TestCase {
 			->method('getPassword')
 			->with($token, 'APP-PASSWORD')
 			->will($this->throwException(new \OC\Authentication\Exceptions\PasswordlessTokenException()));
-		$tokenProvider->expects($this->once())
-			->method('updateToken')
-			->with($token);
 
 		$this->invokePrivate($userSession, 'validateSession', [$user]);
 


### PR DESCRIPTION
The token is already updated in `updateTokenActivity`

Saves an update query for each request made

stacktraces for both queries on master:

![](https://i.imgur.com/wg09yD6.png)

cc @ChristophWurst 
