### PR TITLE
Reduce the number of cache operations for dav operations

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -29,6 +29,7 @@
 
 namespace OCA\DAV\Connector\Sabre;
 
+use OC\Files\Node\Folder;
 use OCA\DAV\Files\BrowserErrorPagePlugin;
 use OCP\Files\Mount\IMountManager;
 use OCP\IConfig;
@@ -135,7 +136,11 @@ class ServerFactory {
 			
 			/** @var \OC\Files\View $view */
 			$view = $viewCallBack($server);
-			$rootInfo = $view->getFileInfo('');
+			if ($userFolder instanceof Folder && $userFolder->getPath() === $view->getRoot()) {
+				$rootInfo = $userFolder;
+			} else {
+				$rootInfo = $view->getFileInfo('');
+			}
 
 			// Create ownCloud Dir
 			if ($rootInfo->getType() === 'dir') {

--- a/lib/private/Files/Mount/MountPoint.php
+++ b/lib/private/Files/Mount/MountPoint.php
@@ -41,6 +41,7 @@ class MountPoint implements IMountPoint {
 	protected $storage = null;
 	protected $class;
 	protected $storageId;
+	protected $rootId = null;
 
 	/**
 	 * Configuration options for the storage backend
@@ -264,7 +265,10 @@ class MountPoint implements IMountPoint {
 	 * @return int
 	 */
 	public function getStorageRootId() {
-		return (int)$this->getStorage()->getCache()->getId('');
+		if (is_null($this->rootId)) {
+			$this->rootId = (int)$this->getStorage()->getCache()->getId('');
+		}
+		return $this->rootId;
 	}
 
 	public function getMountId() {

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -28,6 +28,7 @@
 
 namespace OC\Files\Node;
 
+use OC\Cache\CappedMemoryCache;
 use OC\Files\Mount\Manager;
 use OC\Files\Mount\MountPoint;
 use OCP\Files\NotFoundException;
@@ -71,6 +72,8 @@ class Root extends Folder implements IRootFolder {
 	 */
 	private $user;
 
+	private $userFolderCache;
+
 	/**
 	 * @param \OC\Files\Mount\Manager $manager
 	 * @param \OC\Files\View $view
@@ -81,6 +84,7 @@ class Root extends Folder implements IRootFolder {
 		$this->mountManager = $manager;
 		$this->user = $user;
 		$this->emitter = new PublicEmitter();
+		$this->userFolderCache = new CappedMemoryCache();
 	}
 
 	/**
@@ -335,25 +339,31 @@ class Root extends Folder implements IRootFolder {
 	 * @return \OCP\Files\Folder
 	 */
 	public function getUserFolder($userId) {
-		\OC\Files\Filesystem::initMountPoints($userId);
-		$dir = '/' . $userId;
-		$folder = null;
+		if (!$this->userFolderCache->hasKey($userId)) {
+			\OC\Files\Filesystem::initMountPoints($userId);
+			$dir = '/' . $userId;
+			$folder = null;
 
-		try {
-			$folder = $this->get($dir);
-		} catch (NotFoundException $e) {
-			$folder = $this->newFolder($dir);
+			try {
+				$folder = $this->get($dir);
+			} catch (NotFoundException $e) {
+				$folder = $this->newFolder($dir);
+			}
+
+			$dir = '/files';
+			try {
+				$folder = $folder->get($dir);
+			} catch (NotFoundException $e) {
+				$folder = $folder->newFolder($dir);
+				\OC_Util::copySkeleton($userId, $folder);
+			}
+			$this->userFolderCache->set($userId, $folder);
 		}
 
-		$dir = '/files';
-		try {
-			$folder = $folder->get($dir);
-		} catch (NotFoundException $e) {
-			$folder = $folder->newFolder($dir);
-			\OC_Util::copySkeleton($userId, $folder);
-		}
+		return $this->userFolderCache->get($userId);
+	}
 
-		return $folder;
-
+	public function clearCache() {
+		$this->userFolderCache = new CappedMemoryCache();
 	}
 }

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -341,22 +341,17 @@ class Root extends Folder implements IRootFolder {
 	public function getUserFolder($userId) {
 		if (!$this->userFolderCache->hasKey($userId)) {
 			\OC\Files\Filesystem::initMountPoints($userId);
-			$dir = '/' . $userId;
-			$folder = null;
 
 			try {
-				$folder = $this->get($dir);
+				$folder = $this->get('/' . $userId . '/files');
 			} catch (NotFoundException $e) {
-				$folder = $this->newFolder($dir);
-			}
-
-			$dir = '/files';
-			try {
-				$folder = $folder->get($dir);
-			} catch (NotFoundException $e) {
-				$folder = $folder->newFolder($dir);
+				if (!$this->nodeExists('/' . $userId)) {
+					$this->newFolder('/' . $userId);
+				}
+				$folder = $this->newFolder('/' . $userId . '/files');
 				\OC_Util::copySkeleton($userId, $folder);
 			}
+
 			$this->userFolderCache->set($userId, $folder);
 		}
 

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -356,6 +356,7 @@ class OC_Util {
 	 */
 	public static function tearDownFS() {
 		\OC\Files\Filesystem::tearDown();
+		\OC::$server->getRootFolder()->clearCache();
 		self::$fsSetup = false;
 		self::$rootMounted = false;
 	}

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -24,6 +24,7 @@ namespace Test;
 
 use DOMDocument;
 use DOMNode;
+use OC\Cache\CappedMemoryCache;
 use OC\Command\QueueBus;
 use OC\Files\Filesystem;
 use OC\Template\Base;


### PR DESCRIPTION
- Reuse fileinfo from userfolder when possible
- cache root id in mountpoint
- cache userfolder in root
- optimize getUserFolder for the common case where the user is already setup

Reduces the number of cache operations done for the most basic (and common) dav operation (propfind with depth:0 on the root) from 7 to 2
