### PR TITLE
L10N tests do not require DB

### DIFF
--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -15,7 +15,6 @@ use Test\TestCase;
  * Class FactoryTest
  *
  * @package Test\L10N
- * @group DB
  */
 class FactoryTest extends TestCase {
 
@@ -44,7 +43,9 @@ class FactoryTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->userSession = $this->getMock('\OCP\IUserSession');
+		$this->userSession = $this->getMockBuilder('\OCP\IUserSession')
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->serverRoot = \OC::$SERVERROOT;
 	}
@@ -110,7 +111,8 @@ class FactoryTest extends TestCase {
 			->method('getSystemValue')
 			->with('installed', false)
 			->willReturn(true);
-		$user = $this->getMock('\OCP\IUser');
+		$user = $this->getMockBuilder('\OCP\IUser')
+			->getMock();
 		$user->expects($this->once())
 			->method('getUID')
 			->willReturn('MyUserUid');
@@ -143,7 +145,8 @@ class FactoryTest extends TestCase {
 				->method('getSystemValue')
 				->with('installed', false)
 				->willReturn(true);
-		$user = $this->getMock('\OCP\IUser');
+		$user = $this->getMockBuilder('\OCP\IUser')
+			->getMock();
 		$user->expects($this->once())
 				->method('getUID')
 				->willReturn('MyUserUid');
@@ -185,7 +188,8 @@ class FactoryTest extends TestCase {
 				->method('getSystemValue')
 				->with('installed', false)
 				->willReturn(true);
-		$user = $this->getMock('\OCP\IUser');
+		$user = $this->getMockBuilder('\OCP\IUser')
+			->getMock();
 		$user->expects($this->once())
 				->method('getUID')
 				->willReturn('MyUserUid');
@@ -230,7 +234,8 @@ class FactoryTest extends TestCase {
 				->method('getSystemValue')
 				->with('installed', false)
 				->willReturn(true);
-		$user = $this->getMock('\OCP\IUser');
+		$user = $this->getMockBuilder('\OCP\IUser')
+			->getMock();
 		$user->expects($this->once())
 				->method('getUID')
 				->willReturn('MyUserUid');

--- a/tests/lib/L10N/L10nLegacyTest.php
+++ b/tests/lib/L10N/L10nLegacyTest.php
@@ -14,7 +14,6 @@ use DateTime;
 
 /**
  * Class Test_L10n
- * @group DB
  */
 class L10nLegacyTest extends \Test\TestCase {
 
@@ -124,7 +123,11 @@ class L10nLegacyTest extends \Test\TestCase {
 	}
 
 	public function testFactoryGetLanguageCode() {
-		$factory = new \OC\L10N\Factory($this->getMock('OCP\IConfig'), $this->getMock('OCP\IRequest'), $this->getMock('OCP\IUserSession'), \OC::$SERVERROOT);
+		$factory = new \OC\L10N\Factory(
+			$this->getMockBuilder('OCP\IConfig')->getMock(),
+			$this->getMockBuilder('OCP\IRequest')->getMock(),
+			$this->getMockBuilder('OCP\IUserSession')->getMock(),
+			\OC::$SERVERROOT);
 		$l = $factory->get('lib', 'de');
 		$this->assertEquals('de', $l->getLanguageCode());
 	}


### PR DESCRIPTION
- Makes CI a bit more efficient
- Cleanup getMock warning

Easy one

CC: @LukasReschke @nickvergessen @MorrisJobke @icewind1991 @blizzz 
