### PR TITLE
Always use the LazyRoot

### DIFF
--- a/lib/private/Files/Node/LazyRoot.php
+++ b/lib/private/Files/Node/LazyRoot.php
@@ -139,7 +139,7 @@ class LazyRoot implements IRootFolder {
 	 * @inheritDoc
 	 */
 	public function get($path) {
-		$this->__call(__FUNCTION__, func_get_args());
+		return $this->__call(__FUNCTION__, func_get_args());
 	}
 
 	/**

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -185,7 +185,7 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 		$this->registerService('LazyRootFolder', function(Server $c) {
 			return new LazyRoot(function() use ($c) {
-				return $c->getRootFolder();
+				return $c->query('RootFolder');
 			});
 		});
 		$this->registerService('UserManager', function (Server $c) {
@@ -838,7 +838,7 @@ class Server extends ServerContainer implements IServerContainer {
 	 * @return \OCP\Files\IRootFolder
 	 */
 	public function getRootFolder() {
-		return $this->query('RootFolder');
+		return $this->query('LazyRootFolder');
 	}
 
 	/**


### PR DESCRIPTION
Ok lets see what our CI says about this.

Since setting up the filesystem is crazy expensive we should only do it if we use it. This allows classes to depend on the RootFolder while not adding the overhead to functions that don't use it.

@icewind1991 any objections?
