### PR TITLE
Check if the file isReadable() before sending a (cached) preview

### DIFF
--- a/core/ajax/preview.php
+++ b/core/ajax/preview.php
@@ -53,6 +53,8 @@ $info = \OC\Files\Filesystem::getFileInfo($file);
 
 if (!$info instanceof OCP\Files\FileInfo || !$always && !\OC::$server->getPreviewManager()->isAvailable($info)) {
 	\OC_Response::setStatus(404);
+} else if (!$info->isReadable()) {
+	\OC_Response::setStatus(403);
 } else {
 	$preview = new \OC\Preview(\OC_User::getUser(), 'files');
 	$preview->setFile($file, $info);

--- a/lib/private/Preview.php
+++ b/lib/private/Preview.php
@@ -763,7 +763,7 @@ class Preview {
 
 		$this->preview = null;
 		$fileInfo = $this->getFileInfo();
-		if ($fileInfo === null || $fileInfo === false) {
+		if ($fileInfo === null || $fileInfo === false || !$fileInfo->isReadable()) {
 			return new \OC_Image();
 		}
 


### PR DESCRIPTION
This is required for the access controls, so the storage wrapper can deny the displaying and generation of previews: https://github.com/nextcloud/files_accesscontrol/issues/30
Also fixes the gallery with named issue.

@icewind1991 @LukasReschke 
