### PR TITLE
2fa challenge styling

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -38,8 +38,11 @@ body {
 
 .two-factor-provider {
 	text-align: center;
-	width: 100%;
+	width: 258px !important;
 	display: inline-block;
+	margin-bottom: 0 !important;
+	background-color: rgba(0,0,0,0.3) !important;
+	border: none !important;
 }
 
 a.two-factor-cancel {

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -32,6 +32,10 @@ body {
 	background-size: cover;
 }
 
+.two-factor-header {
+	text-align: center;
+}
+
 .two-factor-provider {
 	text-align: center;
 	width: 100%;

--- a/core/templates/twofactorselectchallenge.php
+++ b/core/templates/twofactorselectchallenge.php
@@ -1,11 +1,11 @@
 <div class="warning">
-	<h2 class="two-factor-header"><?php p($l->t('Two-step verification')) ?></h2>
-	<p><?php p($l->t('Enhanced security has been enabled for your account. Please authenticate using a second factor.')) ?></p>
+	<h2 class="two-factor-header"><?php p($l->t('Two-factor authentication')) ?></h2>
+	<p><?php p($l->t('Enhanced security is enabled for your account. Please authenticate using a second factor.')) ?></p>
 	<p>
 		<ul>
 			<?php foreach ($_['providers'] as $provider): ?>
 				<li>
-					<a class="two-factor-provider"
+					<a class="button two-factor-provider"
 					   href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.showChallenge',
 										[
 											'challengeProviderId' => $provider->getId(),

--- a/core/templates/twofactorselectchallenge.php
+++ b/core/templates/twofactorselectchallenge.php
@@ -1,22 +1,22 @@
-<fieldset class="warning">
-		<legend><strong><?php p($l->t('Two-step verification')) ?></strong></legend>
-		<p><?php p($l->t('Enhanced security has been enabled for your account. Please authenticate using a second factor.')) ?></p>
-</fieldset>
-<fieldset class="warning">
-<ul>
-<?php foreach ($_['providers'] as $provider): ?>
-	<li>
-		<a class="two-factor-provider"
-		   href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.showChallenge',
-							[
-								'challengeProviderId' => $provider->getId(),
-								'redirect_url' => $_['redirect_url'],
-							]
-						)) ?>">
-			<?php p($provider->getDescription()) ?>
-		</a>
-	</li>
-<?php endforeach; ?>
-</ul>
-</fieldset>
+<div class="warning">
+	<h2 class="two-factor-header"><?php p($l->t('Two-step verification')) ?></h2>
+	<p><?php p($l->t('Enhanced security has been enabled for your account. Please authenticate using a second factor.')) ?></p>
+	<p>
+		<ul>
+			<?php foreach ($_['providers'] as $provider): ?>
+				<li>
+					<a class="two-factor-provider"
+					   href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.showChallenge',
+										[
+											'challengeProviderId' => $provider->getId(),
+											'redirect_url' => $_['redirect_url'],
+										]
+									)) ?>">
+						<?php p($provider->getDescription()) ?>
+					</a>
+				</li>
+			<?php endforeach; ?>
+		</ul>
+	</p>
+</div>
 <a class="two-factor-cancel" <?php print_unescaped($_['logout_attribute']); ?>><?php p($l->t('Cancel log in')) ?></a>

--- a/core/templates/twofactorselectchallenge.php
+++ b/core/templates/twofactorselectchallenge.php
@@ -19,4 +19,4 @@
 <?php endforeach; ?>
 </ul>
 </fieldset>
-<a class="two-factor-cancel" <?php print_unescaped($_['logout_attribute']); ?>><?php p($l->t('Cancel login')) ?></a>
+<a class="two-factor-cancel" <?php print_unescaped($_['logout_attribute']); ?>><?php p($l->t('Cancel log in')) ?></a>

--- a/core/templates/twofactorshowchallenge.php
+++ b/core/templates/twofactorshowchallenge.php
@@ -10,7 +10,7 @@ $template = $_['template'];
 ?>
 
 <div class="warning">
-		<h2><?php p($provider->getDisplayName()); ?></h2>
+		<h2 class="two-factor-header"><?php p($provider->getDisplayName()); ?></h2>
 		<?php if ($error): ?>
 		<p><?php p($l->t('An error occured while verifying the token')); ?></p>
 		<?php endif; ?>

--- a/core/templates/twofactorshowchallenge.php
+++ b/core/templates/twofactorshowchallenge.php
@@ -11,10 +11,9 @@ $template = $_['template'];
 
 <div class="warning">
 		<h2><?php p($provider->getDisplayName()); ?></h2>
-		<p><?php p($l->t('Please authenticate using the selected factor.')) ?></p>
 		<?php if ($error): ?>
 		<p><?php p($l->t('An error occured while verifying the token')); ?></p>
 		<?php endif; ?>
 		<?php print_unescaped($template); ?>
 </div>
-<a class="two-factor-cancel" <?php print_unescaped($_['logout_attribute']); ?>><?php p($l->t('Cancel login')) ?></a>
+<a class="two-factor-cancel" <?php print_unescaped($_['logout_attribute']); ?>><?php p($l->t('Cancel log in')) ?></a>

--- a/core/templates/twofactorshowchallenge.php
+++ b/core/templates/twofactorshowchallenge.php
@@ -9,12 +9,12 @@ $provider = $_['provider'];
 $template = $_['template'];
 ?>
 
-<fieldset class="warning">
-		<legend><strong><?php p($provider->getDisplayName()); ?></strong></legend>
+<div class="warning">
+		<h2><?php p($provider->getDisplayName()); ?></h2>
 		<p><?php p($l->t('Please authenticate using the selected factor.')) ?></p>
-</fieldset>
-<?php if ($error): ?>
-<span class="warning"><?php p($l->t('An error occured while verifying the token')); ?></span>
-<?php endif; ?>
-<?php print_unescaped($template); ?>
+		<?php if ($error): ?>
+		<p><?php p($l->t('An error occured while verifying the token')); ?></p>
+		<?php endif; ?>
+		<?php print_unescaped($template); ?>
+</div>
 <a class="two-factor-cancel" <?php print_unescaped($_['logout_attribute']); ?>><?php p($l->t('Cancel login')) ?></a>

--- a/core/templates/twofactorshowchallenge.php
+++ b/core/templates/twofactorshowchallenge.php
@@ -12,7 +12,7 @@ $template = $_['template'];
 <div class="warning">
 		<h2 class="two-factor-header"><?php p($provider->getDisplayName()); ?></h2>
 		<?php if ($error): ?>
-		<p><?php p($l->t('An error occured while verifying the token')); ?></p>
+		<p><strong><?php p($l->t('Error while validating your second factor')); ?></strong></p>
 		<?php endif; ?>
 		<?php print_unescaped($template); ?>
 </div>


### PR DESCRIPTION
Before
![bildschirmfoto von 2016-08-27 12-27-55](https://cloud.githubusercontent.com/assets/1374172/18026778/c155b9e8-6c51-11e6-977c-88860d29114a.png)
![bildschirmfoto von 2016-08-27 11-14-46](https://cloud.githubusercontent.com/assets/1374172/18026463/9482e9d6-6c47-11e6-9634-a5907210dbb0.png)

After
![bildschirmfoto von 2016-08-27 12-28-03](https://cloud.githubusercontent.com/assets/1374172/18026779/c770a964-6c51-11e6-89a2-e238f308abfd.png)
![bildschirmfoto von 2016-08-27 11-14-55](https://cloud.githubusercontent.com/assets/1374172/18026464/94c12480-6c47-11e6-89e2-134ed08f3143.png)
- Remove "Please authenticate using the selected factor."
- Use a single box to display the header and the 2FA provider's template
- Rename "Cancel login" to "Cancel log in"
- Use h2 for page headers and centered text

most changes were made by @jancborchardt 
