### PR TITLE
Increase theming performance

### DIFF
--- a/apps/theming/js/settings-admin.js
+++ b/apps/theming/js/settings-admin.js
@@ -157,8 +157,8 @@ $(document).ready(function () {
 		submit: function(e, response) {
 			OC.msg.startSaving('#theming_settings_msg');
 		},
-		fail: function (e, data){
-			OC.msg.finishedSaving('#theming_settings_msg', response);
+		fail: function (e, response){
+			OC.msg.finishedError('#theming_settings_msg', response._response.jqXHR.responseJSON.data.message);
 		}
 	};
 	var uploadParamsLogin = {
@@ -171,8 +171,8 @@ $(document).ready(function () {
 		submit: function(e, response) {
 			OC.msg.startSaving('#theming_settings_msg');
 		},
-		fail: function (e, data){
-			OC.msg.finishedSaving('#theming_settings_msg', response);
+		fail: function (e, response){
+			OC.msg.finishedError('#theming_settings_msg', response._response.jqXHR.responseJSON.data.message);
 		}
 	};
 

--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -39,6 +39,7 @@ use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCA\Theming\Util;
+use OCP\ITempManager;
 
 /**
  * Class ThemingController
@@ -60,6 +61,8 @@ class ThemingController extends Controller {
 	private $config;
 	/** @var IRootFolder */
 	private $rootFolder;
+	/** @var ITempManager */
+	private $tempManager;
 
 	/**
 	 * ThemingController constructor.
@@ -72,6 +75,7 @@ class ThemingController extends Controller {
 	 * @param ITimeFactory $timeFactory
 	 * @param IL10N $l
 	 * @param IRootFolder $rootFolder
+	 * @param ITempManager $tempManager
 	 */
 	public function __construct(
 		$appName,
@@ -81,7 +85,8 @@ class ThemingController extends Controller {
 		Util $util,
 		ITimeFactory $timeFactory,
 		IL10N $l,
-		IRootFolder $rootFolder
+		IRootFolder $rootFolder,
+		ITempManager $tempManager
 	) {
 		parent::__construct($appName, $request);
 
@@ -91,6 +96,7 @@ class ThemingController extends Controller {
 		$this->l = $l;
 		$this->config = $config;
 		$this->rootFolder = $rootFolder;
+		$this->tempManager = $tempManager;
 	}
 
 	/**
@@ -199,14 +205,16 @@ class ThemingController extends Controller {
 
 			// Optimize the image since some people may upload images that will be
 			// either to big or are not progressive rendering.
+			$tmpFile = $this->tempManager->getTemporaryFile();
 			if(function_exists('imagescale')) {
 				// FIXME: Once PHP 5.5.0 is a requirement the above check can be removed
 				$image = imagescale($image, 1920);
 			}
 			imageinterlace($image, 1);
-			imagejpeg($image, $target->fopen('w'), 75);
+			imagejpeg($image, $tmpFile, 75);
 			imagedestroy($image);
 
+			stream_copy_to_stream(fopen($tmpFile, 'r'), $target->fopen('w'));
 			$this->template->set('backgroundMime', $newBackgroundLogo['type']);
 			$name = $newBackgroundLogo['name'];
 		}

--- a/apps/theming/tests/Controller/ThemingControllerTest.php
+++ b/apps/theming/tests/Controller/ThemingControllerTest.php
@@ -32,6 +32,7 @@ use OCP\Files\IRootFolder;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\ITempManager;
 use Test\TestCase;
 use OCA\Theming\ThemingDefaults;
 
@@ -52,6 +53,8 @@ class ThemingControllerTest extends TestCase {
 	private $themingController;
 	/** @var IRootFolder|\PHPUnit_Framework_MockObject_MockObject */
 	private $rootFolder;
+	/** @var ITempManager */
+	private $tempManager;
 
 	public function setUp() {
 		$this->request = $this->getMockBuilder('OCP\IRequest')->getMock();
@@ -64,10 +67,10 @@ class ThemingControllerTest extends TestCase {
 			->getMock();
 		$this->l10n = $this->getMockBuilder('OCP\IL10N')->getMock();
 		$this->rootFolder = $this->getMockBuilder('OCP\Files\IRootFolder')->getMock();
-
 		$this->timeFactory->expects($this->any())
 			->method('getTime')
 			->willReturn(123);
+		$this->tempManager = \OC::$server->getTempManager();
 
 		$this->themingController = new ThemingController(
 			'theming',
@@ -77,7 +80,8 @@ class ThemingControllerTest extends TestCase {
 			$this->util,
 			$this->timeFactory,
 			$this->l10n,
-			$this->rootFolder
+			$this->rootFolder,
+			$this->tempManager
 		);
 
 		return parent::setUp();

--- a/apps/theming/tests/Controller/ThemingControllerTest.php
+++ b/apps/theming/tests/Controller/ThemingControllerTest.php
@@ -214,6 +214,7 @@ class ThemingControllerTest extends TestCase {
 		$destination = \OC::$server->getTempManager()->getTemporaryFolder();
 
 		touch($tmpLogo);
+		file_put_contents($tmpLogo, file_get_contents(__DIR__  . '/../../../../tests/data/desktopapp.png'));
 		$this->request
 			->expects($this->at(0))
 			->method('getUploadedFile')
@@ -257,6 +258,52 @@ class ThemingControllerTest extends TestCase {
 					],
 				'status' => 'success'
 			]
+		);
+		$this->assertEquals($expected, $this->themingController->updateLogo());
+	}
+
+	public function testUpdateLogoLoginScreenUploadWithInvalidImage() {
+		$tmpLogo = \OC::$server->getTempManager()->getTemporaryFolder() . '/logo.svg';
+		$destination = \OC::$server->getTempManager()->getTemporaryFolder();
+
+		touch($tmpLogo);
+		file_put_contents($tmpLogo, file_get_contents(__DIR__  . '/../../../../tests/data/data.zip'));
+		$this->request
+			->expects($this->at(0))
+			->method('getUploadedFile')
+			->with('uploadlogo')
+			->willReturn(null);
+		$this->request
+			->expects($this->at(1))
+			->method('getUploadedFile')
+			->with('upload-login-background')
+			->willReturn([
+				'tmp_name' => $tmpLogo,
+				'type' => 'text/svg',
+				'name' => 'logo.svg',
+			]);
+		$this->l10n
+			->expects($this->once())
+			->method('t')
+			->with('Unsupported image type')
+			->willReturn('Unsupported image type');
+		$file = $this->getMockBuilder('\\OCP\\Files\\File')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->rootFolder
+			->expects($this->once())
+			->method('newFile')
+			->with('themedbackgroundlogo')
+			->willReturn($file);
+		$expected = new DataResponse(
+			[
+				'data' =>
+					[
+						'message' => 'Unsupported image type',
+					],
+				'status' => 'failure'
+			],
+			Http::STATUS_UNPROCESSABLE_ENTITY
 		);
 		$this->assertEquals($expected, $this->themingController->updateLogo());
 	}
@@ -311,6 +358,7 @@ class ThemingControllerTest extends TestCase {
 		$expected->addHeader('Expires', date(\DateTime::RFC2822, 123));
 		$expected->addHeader('Content-Disposition', 'attachment');
 		$expected->addHeader('Content-Type', 'text/svg');
+		$expected->addHeader('Pragma', 'cache');
 		@$this->assertEquals($expected, $this->themingController->getLogo());
 	}
 
@@ -340,6 +388,7 @@ class ThemingControllerTest extends TestCase {
 		$expected->addHeader('Expires', date(\DateTime::RFC2822, 123));
 		$expected->addHeader('Content-Disposition', 'attachment');
 		$expected->addHeader('Content-Type', 'image/png');
+		$expected->addHeader('Pragma', 'cache');
 		@$this->assertEquals($expected, $this->themingController->getLoginBackground());
 	}
 
@@ -422,6 +471,7 @@ class ThemingControllerTest extends TestCase {
 
 		$expected->cacheFor(3600);
 		$expected->addHeader('Expires', date(\DateTime::RFC2822, 123));
+		$expected->addHeader('Pragma', 'cache');
 		@$this->assertEquals($expected, $this->themingController->getStylesheet());
 	}
 
@@ -510,6 +560,7 @@ class ThemingControllerTest extends TestCase {
 
 		$expected->cacheFor(3600);
 		$expected->addHeader('Expires', date(\DateTime::RFC2822, 123));
+		$expected->addHeader('Pragma', 'cache');
 		@$this->assertEquals($expected, $this->themingController->getStylesheet());
 	}
 
@@ -553,6 +604,7 @@ class ThemingControllerTest extends TestCase {
 
 		$expected->cacheFor(3600);
 		$expected->addHeader('Expires', date(\DateTime::RFC2822, 123));
+		$expected->addHeader('Pragma', 'cache');
 		@$this->assertEquals($expected, $this->themingController->getStylesheet());
 	}
 
@@ -588,6 +640,7 @@ class ThemingControllerTest extends TestCase {
 
 		$expected->cacheFor(3600);
 		$expected->addHeader('Expires', date(\DateTime::RFC2822, 123));
+		$expected->addHeader('Pragma', 'cache');
 		@$this->assertEquals($expected, $this->themingController->getStylesheet());
 	}
 
@@ -687,6 +740,7 @@ class ThemingControllerTest extends TestCase {
 
 		$expected->cacheFor(3600);
 		$expected->addHeader('Expires', date(\DateTime::RFC2822, 123));
+		$expected->addHeader('Pragma', 'cache');
 		@$this->assertEquals($expected, $this->themingController->getStylesheet());
 	}
 
@@ -791,6 +845,7 @@ class ThemingControllerTest extends TestCase {
 		$expected = new Http\DataDownloadResponse($expectedData, 'style', 'text/css');
 		$expected->cacheFor(3600);
 		$expected->addHeader('Expires', date(\DateTime::RFC2822, 123));
+		$expected->addHeader('Pragma', 'cache');
 		@$this->assertEquals($expected, $this->themingController->getStylesheet());
 	}
 
@@ -825,6 +880,7 @@ class ThemingControllerTest extends TestCase {
 		$expected = new Http\DataDisplayResponse($expectedResponse);
 		$expected->addHeader("Content-type","text/javascript");
 		$expected->addHeader('Expires', date(\DateTime::RFC2822, $this->timeFactory->getTime()));
+		$expected->addHeader('Pragma', 'cache');
 		$expected->cacheFor(3600);
 		@$this->assertEquals($expected, $this->themingController->getJavascript());
 	}
@@ -858,6 +914,7 @@ class ThemingControllerTest extends TestCase {
 		$expected = new Http\DataDisplayResponse($expectedResponse);
 		$expected->addHeader("Content-type","text/javascript");
 		$expected->addHeader('Expires', date(\DateTime::RFC2822, $this->timeFactory->getTime()));
+		$expected->addHeader('Pragma', 'cache');
 		$expected->cacheFor(3600);
 		@$this->assertEquals($expected, $this->themingController->getJavascript());
 	}


### PR DESCRIPTION
1. Set proper caching headers (`Pragma: cache`)
2. Resize image proportionally to a max size of 1920px
3. Store images with progressive mode

This resizes a previous 2.8 MB picture to 300kb and makes it rendering going down from 11 seconds to less than 1 here. And future requests won't have to download the file newly.

As a comparison these two GIFs show the rendering before and after the PR on initial page load:

![old](https://cloud.githubusercontent.com/assets/878997/18029546/25a6b174-6c9b-11e6-8b50-9c7fbd21804c.gif)
![new](https://cloud.githubusercontent.com/assets/878997/18029566/ab3ea846-6c9b-11e6-945e-47c5a38d3e75.gif)

(force reload the page to see it rendering)

Note that due the caching headers all future page loads will instantly show the right data. Something that is at the moment not properly done.

@ChristophWurst This should make you happier :wink:

---

Fixes https://github.com/nextcloud/server/issues/1099
