### PR TITLE
[stable10] Remove reading PATH_INFO from server variable

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -701,10 +701,6 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 * @return string|false Path info or false when not found
 	 */
 	public function getPathInfo() {
-		if(isset($this->server['PATH_INFO'])) {
-			return $this->server['PATH_INFO'];
-		}
-
 		$pathInfo = $this->getRawPathInfo();
 		// following is taken from \Sabre\HTTP\URLUtil::decodePathSegment
 		$pathInfo = rawurldecode($pathInfo);

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -1063,22 +1063,6 @@ class RequestTest extends \Test\TestCase {
 		$this->assertSame('www.owncloud.org', self::invokePrivate($request, 'getOverwriteHost'));
 	}
 
-	public function testGetPathInfoWithSetEnv() {
-		$request = new Request(
-			[
-				'server' => [
-					'PATH_INFO' => 'apps/files/',
-				]
-			],
-			$this->secureRandom,
-			$this->config,
-			$this->csrfTokenManager,
-			$this->stream
-		);
-
-		$this->assertSame('apps/files/',  $request->getPathInfo());
-	}
-
 	/**
 	 * @expectedException \Exception
 	 * @expectedExceptionMessage The requested uri(/foo.php) cannot be processed by the script '/var/www/index.php')


### PR DESCRIPTION
Backport of https://github.com/nextcloud/server/pull/984, talked with @ChristophWurst about it today and not having this in stable10 causes problems with the TOTP app.
