### PR TITLE
fix ordering of user menu entries

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -443,7 +443,7 @@ class OC_App {
 			$settings = array(
 				array(
 					"id" => "help",
-					"order" => 1000,
+					"order" => 4,
 					"href" => $urlGenerator->linkToRoute('settings_help'),
 					"name" => $l->t("Help"),
 					"icon" => $urlGenerator->imagePath("settings", "help.svg")
@@ -472,7 +472,7 @@ class OC_App {
 				// admin users menu
 				$settings[] = array(
 					"id" => "core_users",
-					"order" => 2,
+					"order" => 3,
 					"href" => $urlGenerator->linkToRoute('settings_users'),
 					"name" => $l->t("Users"),
 					"icon" => $urlGenerator->imagePath("settings", "users.svg")
@@ -484,7 +484,7 @@ class OC_App {
 				// admin settings
 				$settings[] = array(
 					"id" => "admin",
-					"order" => 1000,
+					"order" => 2,
 					"href" => $urlGenerator->linkToRoute('settings.AdminSettings.index'),
 					"name" => $l->t("Admin"),
 					"icon" => $urlGenerator->imagePath("settings", "admin.svg")


### PR DESCRIPTION
Help and Admin had the same order ID, leading to random ordering … fixed that.

First come Personal settings, then Admin settings because these two are very similar (and to be combined). Then Users, then Help, then Log out.

Before & after:
![capture du 2016-08-27 22-35-24](https://cloud.githubusercontent.com/assets/925062/18029970/8e6e00ca-6ca7-11e6-8237-de739e365caa.png) ![capture du 2016-08-27 22-34-35](https://cloud.githubusercontent.com/assets/925062/18029971/8e71eafa-6ca7-11e6-806c-7987a5b44830.png)

Please review @LukasReschke @ChristophWurst ;)
