### PR TITLE
Use mail for encrypting the password reset token as well

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -44,6 +44,7 @@ class Application extends App {
 		parent::__construct('core');
 
 		$container = $this->getContainer();
+
 		$container->registerService('defaultMailAddress', function() {
 			return Util::getDefaultEmailAddress('lostpassword-noreply');
 		});

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -40,6 +40,7 @@ use \OCP\IL10N;
 use \OCP\IConfig;
 use OCP\IUserManager;
 use OCP\Mail\IMailer;
+use OCP\Security\ICrypto;
 use OCP\Security\ISecureRandom;
 
 /**
@@ -71,6 +72,8 @@ class LostController extends Controller {
 	protected $mailer;
 	/** @var ITimeFactory */
 	protected $timeFactory;
+	/** @var ICrypto */
+	protected $crypto;
 
 	/**
 	 * @param string $appName
@@ -85,6 +88,7 @@ class LostController extends Controller {
 	 * @param IManager $encryptionManager
 	 * @param IMailer $mailer
 	 * @param ITimeFactory $timeFactory
+	 * @param ICrypto $crypto
 	 */
 	public function __construct($appName,
 								IRequest $request,
@@ -97,7 +101,8 @@ class LostController extends Controller {
 								$defaultMailAddress,
 								IManager $encryptionManager,
 								IMailer $mailer,
-								ITimeFactory $timeFactory) {
+								ITimeFactory $timeFactory,
+								ICrypto $crypto) {
 		parent::__construct($appName, $request);
 		$this->urlGenerator = $urlGenerator;
 		$this->userManager = $userManager;
@@ -109,6 +114,7 @@ class LostController extends Controller {
 		$this->config = $config;
 		$this->mailer = $mailer;
 		$this->timeFactory = $timeFactory;
+		$this->crypto = $crypto;
 	}
 
 	/**
@@ -150,8 +156,19 @@ class LostController extends Controller {
 	 */
 	private function checkPasswordResetToken($token, $userId) {
 		$user = $this->userManager->get($userId);
+		if($user === null) {
+			throw new \Exception($this->l10n->t('Couldn\'t reset password because the token is invalid'));
+		}
 
-		$splittedToken = explode(':', $this->config->getUserValue($userId, 'core', 'lostpassword', null));
+		try {
+			$encryptedToken = $this->config->getUserValue($userId, 'core', 'lostpassword', null);
+			$mailAddress = !is_null($user->getEMailAddress()) ? $user->getEMailAddress() : '';
+			$decryptedToken = $this->crypto->decrypt($encryptedToken, $mailAddress.$this->config->getSystemValue('secret'));
+		} catch (\Exception $e) {
+			throw new \Exception($this->l10n->t('Couldn\'t reset password because the token is invalid'));
+		}
+
+		$splittedToken = explode(':', $decryptedToken);
 		if(count($splittedToken) !== 2) {
 			throw new \Exception($this->l10n->t('Couldn\'t reset password because the token is invalid'));
 		}
@@ -249,11 +266,20 @@ class LostController extends Controller {
 			);
 		}
 
-		$token = $this->secureRandom->generate(21,
+		// Generate the token. It is stored encrypted in the database with the
+		// secret being the users' email address appended with the system secret.
+		// This makes the token automatically invalidate once the user changes
+		// their email address.
+		$token = $this->secureRandom->generate(
+			21,
 			ISecureRandom::CHAR_DIGITS.
 			ISecureRandom::CHAR_LOWER.
-			ISecureRandom::CHAR_UPPER);
-		$this->config->setUserValue($user, 'core', 'lostpassword', $this->timeFactory->getTime() .':'. $token);
+			ISecureRandom::CHAR_UPPER
+		);
+		$tokenValue = $this->timeFactory->getTime() .':'. $token;
+		$mailAddress = !is_null($userObject->getEMailAddress()) ? $userObject->getEMailAddress() : '';
+		$encryptedValue = $this->crypto->encrypt($tokenValue, $mailAddress.$this->config->getSystemValue('secret'));
+		$this->config->setUserValue($user, 'core', 'lostpassword', $encryptedValue);
 
 		$link = $this->urlGenerator->linkToRouteAbsolute('core.lost.resetform', array('userId' => $user, 'token' => $token));
 


### PR DESCRIPTION
This uses the mail address as well as the instance secret for encrypting the password reset token. Causing the following advantages:
1. If a user changes their mail address, old reset tokens do expire.
2. If the entry in the DB leaks one won't be able to decrypt it without also having read access to the  config file.
