### PR TITLE
Drop mod_env for prettyURLs (no index.php)

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -9,7 +9,7 @@
  * consider important for your instance to your working ``config.php``, and
  * apply configuration options that are pertinent for your instance.
  *
- * This file is used to generate the configuration documentation. 
+ * This file is used to generate the configuration documentation.
  * Please consider following requirements of the current parser:
  *  * all comments need to start with `/**` and end with ` *\/` - each on their
  *    own line
@@ -398,11 +398,8 @@ $CONFIG = array(
  * cases where this may not apply. However, to avoid any update problems this
  * configuration value is explicitly opt-in.
  *
- * After setting this value run `occ maintenance:update:htaccess` and when following
- * conditions are met Nextcloud uses URLs without index.php in it:
- *
- * - `mod_rewrite` is installed
- * - `mod_env` is installed
+ * After setting this value run `occ maintenance:update:htaccess` and when
+ * `mod_rewrite` is installed Nextcloud uses URLs without index.php in it.
  */
 'htaccess.RewriteBase' => '/',
 
@@ -439,20 +436,20 @@ $CONFIG = array(
  *
  * Available values:
  *
- * * ``auto``      
- *     default setting. keeps files and folders in the trash bin for 30 days 
- *     and automatically deletes anytime after that if space is needed (note: 
+ * * ``auto``
+ *     default setting. keeps files and folders in the trash bin for 30 days
+ *     and automatically deletes anytime after that if space is needed (note:
  *     files may not be deleted if space is not needed).
- * * ``D, auto``   
- *     keeps files and folders in the trash bin for D+ days, delete anytime if 
+ * * ``D, auto``
+ *     keeps files and folders in the trash bin for D+ days, delete anytime if
  *     space needed (note: files may not be deleted if space is not needed)
- * * ``auto, D``   
- *     delete all files in the trash bin that are older than D days   
+ * * ``auto, D``
+ *     delete all files in the trash bin that are older than D days
  *     automatically, delete other files anytime if space needed
- * * ``D1, D2``    
- *     keep files and folders in the trash bin for at least D1 days and 
+ * * ``D1, D2``
+ *     keep files and folders in the trash bin for at least D1 days and
  *     delete when exceeds D2 days
- * * ``disabled``  
+ * * ``disabled``
  *     trash bin auto clean disabled, files and folders will be kept forever
  */
 'trashbin_retention_obligation' => 'auto',
@@ -479,19 +476,19 @@ $CONFIG = array(
  *
  * Available values:
  *
- * * ``auto``      
- *     default setting. Automatically expire versions according to expire 
+ * * ``auto``
+ *     default setting. Automatically expire versions according to expire
  *     rules. Please refer to :doc:`../configuration_files/file_versioning` for
  *     more information.
- * * ``D, auto``   
- *     keep versions at least for D days, apply expire rules to all versions 
+ * * ``D, auto``
+ *     keep versions at least for D days, apply expire rules to all versions
  *     that are older than D days
- * * ``auto, D``   
- *     delete all versions that are older than D days automatically, delete 
+ * * ``auto, D``
+ *     delete all versions that are older than D days automatically, delete
  *     other versions according to expire rules
- * * ``D1, D2``    
+ * * ``D1, D2``
  *     keep versions for at least D1 days and delete when exceeds D2 days
- * * ``disabled``  
+ * * ``disabled``
  *     versions auto clean disabled, versions will be kept forever
  */
 'versions_retention_obligation' => 'auto',
@@ -865,9 +862,9 @@ $CONFIG = array(
 /**
  * Enable maintenance mode to disable Nextcloud
  *
- * If you want to prevent users from logging in to Nextcloud before you start 
- * doing some maintenance work, you need to set the value of the maintenance 
- * parameter to true. Please keep in mind that users who are already logged-in 
+ * If you want to prevent users from logging in to Nextcloud before you start
+ * doing some maintenance work, you need to set the value of the maintenance
+ * parameter to true. Please keep in mind that users who are already logged-in
  * are kicked out of Nextcloud instantly.
  */
 'maintenance' => false,
@@ -1155,7 +1152,7 @@ $CONFIG = array(
 
 /**
  * Specifies how often the local filesystem (the Nextcloud data/ directory, and
- * NFS mounts in data/) is checked for changes made outside Nextcloud. This 
+ * NFS mounts in data/) is checked for changes made outside Nextcloud. This
  * does not apply to external storages.
  *
  * 0 -> Never check the filesystem for outside changes, provides a performance
@@ -1195,7 +1192,7 @@ $CONFIG = array(
 
 /**
  * List of trusted proxy servers
- * 
+ *
  * If you configure these also consider setting `forwarded_for_headers` which
  * otherwise defaults to `HTTP_X_FORWARDED_FOR` (the `X-Forwarded-For` header).
  */

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -5,6 +5,7 @@
  * @author Bart Visscher <bartv@thisnet.nl>
  * @author Björn Schießle <bjoern@schiessle.org>
  * @author Clark Tomlinson <fallen013@gmail.com>
+ * @author Felix Anand Epp <work@felixepp.de>
  * @author Guillaume AMAT <guillaume.amat@informatique-libre.com>
  * @author Hasso Tepper <hasso@zone.ee>
  * @author Joas Schilling <coding@schilljs.com>
@@ -155,7 +156,7 @@ $array = array(
 			'versionstring'		=> OC_Util::getVersionString(),
 			'enable_avatars'	=> \OC::$server->getConfig()->getSystemValue('enable_avatars', true) === true,
 			'lost_password_link'=> \OC::$server->getConfig()->getSystemValue('lost_password_link', null),
-			'modRewriteWorking'	=> (getenv('front_controller_active') === 'true'),
+			'modRewriteWorking'	=> (\OC::$server->getConfig()->getSystemValue('htaccess.RewriteBase', '') !== ''),
 		)
 	),
 	"oc_appconfig" => json_encode(

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -4,6 +4,7 @@
  *
  * @author Bart Visscher <bartv@thisnet.nl>
  * @author Bernhard Posselt <dev@bernhard-posselt.com>
+ * @author Felix Anand Epp <work@felixepp.de>
  * @author Joas Schilling <coding@schilljs.com>
  * @author Jörn Friedrich Dreyer <jfd@butonic.de>
  * @author Lukas Reschke <lukas@statuscode.ch>
@@ -71,7 +72,7 @@ class Router implements IRouter {
 	public function __construct(ILogger $logger) {
 		$this->logger = $logger;
 		$baseUrl = \OC::$WEBROOT;
-		if(!(getenv('front_controller_active') === 'true')) {
+		if(\OC::$server->getConfig()->getSystemValue('htaccess.RewriteBase', '') === '') {
 			$baseUrl = \OC::$server->getURLGenerator()->linkTo('', 'index.php');
 		}
 		if (!\OC::$CLI) {

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -8,6 +8,7 @@
  * @author Bernhard Posselt <dev@bernhard-posselt.com>
  * @author Brice Maron <brice@bmaron.net>
  * @author Christoph Wurst <christoph@owncloud.com>
+ * @author Felix Anand Epp <work@felixepp.de>
  * @author François Kubler <francois@kubler.org>
  * @author Jakob Sack <mail@jakobsack.de>
  * @author Joas Schilling <coding@schilljs.com>
@@ -461,11 +462,8 @@ class Setup {
 			$content .= "\n  RewriteCond %{REQUEST_URI} !^/.well-known/acme-challenge/.*";
 			$content .= "\n  RewriteRule . index.php [PT,E=PATH_INFO:$1]";
 			$content .= "\n  RewriteBase " . $rewriteBase;
-			$content .= "\n  <IfModule mod_env.c>";
-			$content .= "\n    SetEnv front_controller_active true";
-			$content .= "\n    <IfModule mod_dir.c>";
-			$content .= "\n      DirectorySlash off";
-			$content .= "\n    </IfModule>";
+			$content .= "\n  <IfModule mod_dir.c>";
+			$content .= "\n    DirectorySlash off";
 			$content .= "\n  </IfModule>";
 			$content .= "\n</IfModule>";
 		}

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -3,6 +3,7 @@
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
  * @author Bart Visscher <bartv@thisnet.nl>
+ * @author Felix Anand Epp <work@felixepp.de>
  * @author Joas Schilling <coding@schilljs.com>
  * @author Jörn Friedrich Dreyer <jfd@butonic.de>
  * @author Lukas Reschke <lukas@statuscode.ch>
@@ -93,7 +94,7 @@ class URLGenerator implements IURLGenerator {
 	 * Returns a url to the given app and file.
 	 */
 	public function linkTo( $app, $file, $args = array() ) {
-		$frontControllerActive = (getenv('front_controller_active') === 'true');
+		$frontControllerActive = !empty($this->config->getSystemValue('htaccess.RewriteBase'));
 
 		if( $app != '' ) {
 			$app_path = \OC_App::getAppPath($app);

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -94,7 +94,8 @@ class URLGenerator implements IURLGenerator {
 	 * Returns a url to the given app and file.
 	 */
 	public function linkTo( $app, $file, $args = array() ) {
-		$frontControllerActive = !empty($this->config->getSystemValue('htaccess.RewriteBase'));
+		$rewriteBase = $this->config->getSystemValue('htaccess.RewriteBase');
+		$frontControllerActive = ($rewriteBase !== null && $rewriteBase !== '');
 
 		if( $app != '' ) {
 			$app_path = \OC_App::getAppPath($app);

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -14,6 +14,7 @@
  * @author Christoph Wurst <christoph@owncloud.com>
  * @author Clark Tomlinson <fallen013@gmail.com>
  * @author cmeh <cmeh@users.noreply.github.com>
+ * @author Felix Anand Epp <work@felixepp.de>
  * @author Florin Peter <github@florin-peter.de>
  * @author Frank Karlitschek <frank@karlitschek.de>
  * @author Georg Ehrke <georg@owncloud.com>
@@ -425,16 +426,16 @@ class OC_Util {
 			$session->set('OC_VersionString', $OC_VersionString);
 			/** @var $OC_Build string */
 			$session->set('OC_Build', $OC_Build);
-			
+
 			// Allow overriding update channel
-			
+
 			if (\OC::$server->getSystemConfig()->getValue('installed', false)) {
 				$channel = \OC::$server->getAppConfig()->getValue('core', 'OC_Channel');
 			} else {
 				/** @var $OC_Channel string */
 				$channel = $OC_Channel;
 			}
-			
+
 			if (!is_null($channel)) {
 				$session->set('OC_Channel', $channel);
 			} else {
@@ -500,7 +501,7 @@ class OC_Util {
 	 *
 	 * @param string $application application id
 	 * @param string $languageCode language code, defaults to the current language
-	 * @param bool $prepend prepend the Script to the beginning of the list 
+	 * @param bool $prepend prepend the Script to the beginning of the list
 	 */
 	public static function addTranslations($application, $languageCode = null, $prepend = false) {
 		if (is_null($languageCode)) {
@@ -545,7 +546,7 @@ class OC_Util {
 	 *
 	 * @param string $application application id
 	 * @param bool $prepend prepend the file to the beginning of the list
-	 * @param string $path 
+	 * @param string $path
 	 * @param string $type (script or style)
 	 * @return void
 	 */
@@ -1060,7 +1061,7 @@ class OC_Util {
 					}
 				}
 
-				if(getenv('front_controller_active') === 'true') {
+				if(\OC::$server->getConfig()->getSystemValue('htaccess.RewriteBase', '') !== '') {
 					$location = $urlGenerator->getAbsoluteURL('/apps/' . $appId . '/');
 				} else {
 					$location = $urlGenerator->getAbsoluteURL('/index.php/apps/' . $appId . '/');

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -349,21 +349,20 @@ class UtilTest extends \Test\TestCase {
 	}
 
 	public function testGetDefaultPageUrlWithRedirectUrlWithoutFrontController() {
-		putenv('front_controller_active=false');
-
+		\OC::$server->getConfig()->deleteSystemValue('htaccess.RewriteBase');
 		$_REQUEST['redirect_url'] = 'myRedirectUrl.com';
 		$this->assertSame('http://localhost'.\OC::$WEBROOT.'/myRedirectUrl.com', OC_Util::getDefaultPageUrl());
 	}
 
 	public function testGetDefaultPageUrlWithRedirectUrlRedirectBypassWithoutFrontController() {
-		putenv('front_controller_active=false');
-
+		\OC::$server->getConfig()->deleteSystemValue('htaccess.RewriteBase');
 		$_REQUEST['redirect_url'] = 'myRedirectUrl.com@foo.com:a';
 		$this->assertSame('http://localhost'.\OC::$WEBROOT.'/index.php/apps/files/', OC_Util::getDefaultPageUrl());
 	}
 
 	public function testGetDefaultPageUrlWithRedirectUrlRedirectBypassWithFrontController() {
-		putenv('front_controller_active=true');
+		\OC::$WEBROOT = '/nextcloud';
+		\OC::$server->getConfig()->setSystemValue('htaccess.RewriteBase', \OC::$WEBROOT);
 		$_REQUEST['redirect_url'] = 'myRedirectUrl.com@foo.com:a';
 		$this->assertSame('http://localhost'.\OC::$WEBROOT.'/apps/files/', OC_Util::getDefaultPageUrl());
 	}


### PR DESCRIPTION
In an issue at owncloud/core#24972 I proposed to drop mod_env for prettyURLs, because currently mod_rewrite has to be activated manually anyway. I replaced all occurrences of 'front_controller_active' with checking the system config 'htaccess.RewriteBase' directly.

I tested the changes manually on my live installation in 9.0.53 and 10.0.0 for some time and without problems. I could not complete a full autotest due to environment limits, but completed the corresponding unit tests and phantomJS, which is reflected in a code change and a change of one test.
@LukasReschke : Maybe you should have a look, as you introduced prettyURLs in owncloud/core#14081

I can create a PR for stable10, if desired.

As this is my first PR, any feedback on my code or procedure is appreciated.
