### PR TITLE
Display link reshares

### DIFF
--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -82,10 +82,15 @@
 				'</li>' +
 			'{{/each}}' +
 			'{{#each linkReshares}}' +
-				'<li data-share-id="{{shareId}}" data-share-type="{{shareType}}">' +
-					'<span class="icon icon-public"></span>' +
-					'<span class="has-tooltip username" title="{{shareInitiator}}">{{shareInitiatorDisplayName}}</span>' +
-					'<a href="#" class="unshare"><span class="icon-loading-small hidden"></span><span class="icon icon-delete"></span><span class="hidden-visually">{{unshareLabel}}</span></a>' +
+				'<span data-share-id="{{shareId}}" data-share-type="{{shareType}}">' +
+					'{{#if avatarEnabled}}' +
+					'<div class="avatar" data-username="{{shareInitiator}}"></div>' +
+					'{{/if}}' +
+					'<span class="has-tooltip username" title="{{shareInitiator}}">' + t('core', '{{shareInitiatorDisplayName}} shared via link') + '</span>' +
+
+					'<span class="sharingOptionsGroup">' +
+						'<a href="#" class="unshare"><span class="icon-loading-small hidden"></span><span class="icon icon-delete"></span><span class="hidden-visually">{{unshareLabel}}</span></a>' +
+					'</span>' +
 				'</li>' +
 			'{{/each}}' +
 			'</ul>'
@@ -216,6 +221,7 @@
 		getLinkReshares: function() {
 			var universal = {
 				unshareLabel: t('core', 'Unshare'),
+				avatarEnabled: this.configModel.areAvatarsEnabled(),
 			};
 
 			if(!this.model.hasUserShares()) {

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -81,7 +81,15 @@
 					'</span>' +
 				'</li>' +
 			'{{/each}}' +
-			'</ul>';
+			'{{#each linkReshares}}' +
+				'<li data-share-id="{{shareId}}" data-share-type="{{shareType}}">' +
+					'<span class="icon icon-public"></span>' +
+					'<span class="has-tooltip username" title="{{shareInitiator}}">{{shareInitiatorDisplayName}}</span>' +
+					'<a href="#" class="unshare"><span class="icon-loading-small hidden"></span><span class="icon icon-delete"></span><span class="hidden-visually">{{unshareLabel}}</span></a>' +
+				'</li>' +
+			'{{/each}}' +
+			'</ul>'
+		;
 
 	/**
 	 * @class OCA.Share.ShareDialogShareeListView
@@ -192,9 +200,42 @@
 			var shares = this.model.get('shares');
 			var list = [];
 			for(var index = 0; index < shares.length; index++) {
+				var share = this.getShareeObject(index);
+
+				if (share.shareType === OC.Share.SHARE_TYPE_LINK) {
+					continue;
+				}
 				// first empty {} is necessary, otherwise we get in trouble
 				// with references
-				list.push(_.extend({}, universal, this.getShareeObject(index)));
+				list.push(_.extend({}, universal, share));
+			}
+
+			return list;
+		},
+
+		getLinkReshares: function() {
+			var universal = {
+				unshareLabel: t('core', 'Unshare'),
+			};
+
+			if(!this.model.hasUserShares()) {
+				return [];
+			}
+
+			var shares = this.model.get('shares');
+			var list = [];
+			for(var index = 0; index < shares.length; index++) {
+				var share = this.getShareeObject(index);
+
+				if (share.shareType !== OC.Share.SHARE_TYPE_LINK) {
+					continue;
+				}
+				// first empty {} is necessary, otherwise we get in trouble
+				// with references
+				list.push(_.extend({}, universal, share, {
+					shareInitiator: shares[index].uid_owner,
+					shareInitiatorDisplayName: shares[index].displayname_owner
+				}));
 			}
 
 			return list;
@@ -203,7 +244,8 @@
 		render: function() {
 			this.$el.html(this.template({
 				cid: this.cid,
-				sharees: this.getShareeList()
+				sharees: this.getShareeList(),
+				linkReshares: this.getLinkReshares()
 			}));
 
 			if(this.configModel.areAvatarsEnabled()) {

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -82,7 +82,7 @@
 				'</li>' +
 			'{{/each}}' +
 			'{{#each linkReshares}}' +
-				'<span data-share-id="{{shareId}}" data-share-type="{{shareType}}">' +
+				'<li data-share-id="{{shareId}}" data-share-type="{{shareType}}">' +
 					'{{#if avatarEnabled}}' +
 					'<div class="avatar" data-username="{{shareInitiator}}"></div>' +
 					'{{/if}}' +

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -763,7 +763,7 @@
 						 * FIXME: Find a way to display properly
 						 */
 						if (share.uid_owner !== OC.currentUser) {
-							return share;
+							return;
 						}
 
 						var link = window.location.protocol + '//' + window.location.host;


### PR DESCRIPTION
- No longer filterout all other link shares
- Display link shares in shareelist (below normal shares)

Scenario:
1. user0 shares a file with user1
2. user1 reshares the share by link

Before:
user0 has no way to see this link share

![before](https://cloud.githubusercontent.com/assets/45821/18036078/e49ffd16-6d62-11e6-9d42-15077bb86c8a.png)

After:
user0 can see the link share (and delete it)

![after](https://cloud.githubusercontent.com/assets/45821/18036079/e94e0790-6d62-11e6-8c0a-cf7024ed5569.png)

It needs more styling (CC: @nextcloud/designers).

@LukasReschke to make you happy.

@schiessle @nickvergessen @MorrisJobke comments?
