### PR TITLE
Allow to set the logout redirected url through config

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -242,6 +242,11 @@ $CONFIG = array(
 'lost_password_link' => 'https://example.org/link/to/password/reset',
 
 /**
+ * The URL to redirect to after the user has been logged out.
+ */
+'logout_url' => 'https://example.org/',
+
+/**
  * Mail Parameters
  *
  * These configure the email settings for Nextcloud notifications and password

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -100,7 +100,10 @@ class LoginController extends Controller {
 		}
 		$this->userSession->logout();
 
-		return new RedirectResponse($this->urlGenerator->linkToRouteAbsolute('core.login.showLoginForm'));
+		$redirectUrl = $this->config->getSystemValue('logout_url',
+			$this->urlGenerator->linkToRouteAbsolute('core.login.showLoginForm')
+		);
+		return new RedirectResponse($redirectUrl);
 	}
 
 	/**


### PR DESCRIPTION
It allows one to specify in the config the URL to redirect to after the user has been logged out. It is especially useful when using an external authentication mechanism - i.e. SSO. We need it for example in [YunoHost](https://yunohost.org) to allow the user to log out from the integrated SSO when clicking on the Logout button from Nextcloud. It is by the way a feature that we already find in other Web applications.

It's bound to be improved especially regarding the documentation and also with some checks on the `logout_url` value before redirect to it. As I don't really know what's the process to add a new configuration key and each file to update - and also if it will be accepted, I merely purpose you this feature in the hope you will consider and integrate it. I would be glad to try to improve it if it's accepted.
