### PR TITLE
Prevent parse error on editing an HTML comment

### DIFF
--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -32,7 +32,7 @@
 		'{{/if}}' +
 		'    </div>' +
 		'    <form class="newCommentForm">' +
-		'        <input type="text" class="message" placeholder="{{newMessagePlaceholder}}" value="{{{message}}}" />' +
+		'        <input type="text" class="message" placeholder="{{newMessagePlaceholder}}" value="{{message}}" />' +
 		'        <input class="submit icon-confirm" type="submit" value="" />' +
 		'{{#if isEditMode}}' +
 		'        <input class="cancel pull-right" type="button" value="{{cancelText}}" />' +


### PR DESCRIPTION
### Steps
1. Post comment `" style="border: 1px solid blue;`
2. Click on "Edit comment" pencil
3. Enjoy the blue border on your empty input

@LukasReschke as discussed
@rullzer @blizzz please review

I will create the backports
