### PR TITLE
Make sure file list files config always exists

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -207,6 +207,10 @@
 				this._filesConfig = options.config;
 			} else if (!_.isUndefined(OCA.Files) && !_.isUndefined(OCA.Files.App)) {
 				this._filesConfig = OCA.Files.App.getFilesConfig();
+			} else {
+				this._filesConfig = new OC.Backbone.Model({
+					'showhidden': false
+				});
 			}
 
 			if (options.dragOptions) {


### PR DESCRIPTION
Initialize files config with defaults in case none was passed

From https://github.com/owncloud/core/pull/25886
