### PR TITLE
Avatar fixes for access-control app

### DIFF
--- a/core/Controller/AvatarController.php
+++ b/core/Controller/AvatarController.php
@@ -189,7 +189,22 @@ class AvatarController extends Controller {
 					Http::STATUS_BAD_REQUEST
 				);
 			}
-			$content = $node->getContent();
+
+			if ($node->getMimeType() !== 'image/jpeg' && $node->getMimeType() !== 'image/png') {
+				return new JSONResponse(
+					['data' => ['message' => $this->l->t('The selected file is not an image.')]],
+					Http::STATUS_BAD_REQUEST
+				);
+			}
+
+			try {
+				$content = $node->getContent();
+			} catch (\OCP\Files\NotPermittedException $e) {
+				return new JSONResponse(
+					['data' => ['message' => $this->l->t('The selected file cannot be read.')]],
+					Http::STATUS_BAD_REQUEST
+				);
+			}
 		} elseif (!is_null($files)) {
 			if (
 				$files['error'][0] === 0 &&

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -306,8 +306,8 @@ $(document).ready(function () {
 				msg = data.jqXHR.responseJSON.data.message;
 			}
 			avatarResponseHandler({
-			data: {
-					message: t('settings', 'An error occurred: {message}', { message: msg })
+				data: {
+					message: msg
 				}
 			});
 		}
@@ -324,7 +324,7 @@ $(document).ready(function () {
 					url: OC.generateUrl('/avatar/'),
 					data: { path: path }
 				}).done(avatarResponseHandler)
-					.fail(function(jqXHR, status){
+					.fail(function(jqXHR) {
 						var msg = jqXHR.statusText + ' (' + jqXHR.status + ')';
 						if (!_.isUndefined(jqXHR.responseJSON) &&
 							!_.isUndefined(jqXHR.responseJSON.data) &&
@@ -334,7 +334,7 @@ $(document).ready(function () {
 						}
 						avatarResponseHandler({
 							data: {
-								message: t('settings', 'An error occurred: {message}', { message: msg })
+								message: msg
 							}
 						});
 					});


### PR DESCRIPTION
Fix https://github.com/nextcloud/files_accesscontrol/issues/32
### Steps
1. Create files access rule to block by "File tagged with `test`"
2. Upload an image
3. Assign tag `test` to the image
4. Go to personal settings, select avatar from folder and select the tagged image
### Before

> An error occurred: Internal Server Error (500)
### After

> The selected file cannot be read
