### PR TITLE
Correctly handle multi-values when converting VCards to array

### DIFF
--- a/apps/dav/lib/CardDAV/AddressBookImpl.php
+++ b/apps/dav/lib/CardDAV/AddressBookImpl.php
@@ -28,6 +28,7 @@ use OCP\Constants;
 use OCP\IAddressBook;
 use OCP\IURLGenerator;
 use Sabre\VObject\Component\VCard;
+use Sabre\VObject\Property;
 use Sabre\VObject\Property\Text;
 use Sabre\VObject\Reader;
 use Sabre\VObject\UUIDUtil;
@@ -225,7 +226,7 @@ class AddressBookImpl implements IAddressBook {
 		];
 
 		foreach ($vCard->children as $property) {
-			$result[$property->name] = $property->getValue();
+			/** @var \Sabre\VObject\Property\Unknown $property */
 			if ($property->name === 'PHOTO' && $property->getValueType() === 'BINARY') {
 				$url = $this->urlGenerator->getAbsoluteURL(
 					$this->urlGenerator->linkTo('', 'remote.php') . '/dav/');
@@ -237,14 +238,53 @@ class AddressBookImpl implements IAddressBook {
 				]) . '?photo';
 
 				$result['PHOTO'] = 'VALUE=uri:' . $url;
+
+			} else if ($property->name === 'X-SOCIALPROFILE') {
+				$type = $this->getTypeFromProperty($property);
+
+				// Type is the social network, when it's empty we don't need this.
+				if ($type !== null) {
+					if (!isset($result[$property->name])) {
+						$result[$property->name] = [];
+					}
+					$result[$property->name][$type] = $property->getValue();
+				}
+
+			// The following properties can be set multiple times
+			} else if (in_array($property->name, ['CLOUD', 'EMAIL', 'IMPP', 'TEL', 'URL'])) {
+				if (!isset($result[$property->name])) {
+					$result[$property->name] = [];
+				}
+
+				$result[$property->name][] = $property->getValue();
+
 			} else {
 				$result[$property->name] = $property->getValue();
 			}
 		}
+
 		if ($this->addressBookInfo['principaluri'] === 'principals/system/system' &&
 			$this->addressBookInfo['uri'] === 'system') {
 			$result['isLocalSystemBook'] = true;
 		}
 		return $result;
+	}
+
+	/**
+	 * Get the type of the current property
+	 *
+	 * @param Property $property
+	 * @return null|string
+	 */
+	protected function getTypeFromProperty(Property $property) {
+		$parameters = $property->parameters();
+		// Type is the social network, when it's empty we don't need this.
+		if (isset($parameters['TYPE'])) {
+			/** @var \Sabre\VObject\Parameter $type */
+			$type = $parameters['TYPE'];
+			return $type->getValue();
+		}
+
+		return null;
 	}
 }


### PR DESCRIPTION
This affects "only" the php API of our implementation, not related to sync or whatever.
### Steps
1. Create a contact named "Hello Testing" (with the contacts app)
2. Add 2 cloud ids: `admin@nextcloud.com`, `admin@example.tld`
3. Open the share dropdown in the files view and type `admin@` into the box
### Expected

Two results for federated sharing:
- `Hello Testing (at nextcloud.com)`
- `Hello Testing (at example.tld)`
### Actual

Only one result for federated sharing (the second cloud id you entered):
- `Hello Testing (at example.tld)`

@karlitschek requesting backport to 10 and 9, since this is quite heavy. The same happens for emails and addresses (used by calendar) and it also makes the activity app not finding matches when it's not the first cloud id.

@rullzer @MorrisJobke 
