### PR TITLE
more efficient check if addressbook and calendar exists for user

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -133,6 +133,29 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	}
 
 	/**
+	 * Return the number of calendars for a principal
+	 *
+	 * By default this excludes the automatically generated birthday calendar
+	 *
+	 * @param $principalUri
+	 * @param bool $excludeBirthday
+	 * @return int
+	 */
+	public function getCalendarsForUserCount($principalUri, $excludeBirthday = true) {
+		$principalUri = $this->convertPrincipal($principalUri, true);
+		$query = $this->db->getQueryBuilder();
+		$query->select($query->createFunction('COUNT(*)'))
+			->from('calendars')
+			->where($query->expr()->eq('principaluri', $query->createNamedParameter($principalUri)));
+
+		if ($excludeBirthday) {
+			$query->andWhere($query->expr()->neq('uri', $query->createNamedParameter(BirthdayService::BIRTHDAY_CALENDAR_URI)));
+		}
+
+		return $query->execute()->fetchColumn();
+	}
+
+	/**
 	 * Returns a list of calendars for a principal.
 	 *
 	 * Every project is an array with the following keys:

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -99,6 +99,22 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	}
 
 	/**
+	 * Return the number of address books for a principal
+	 *
+	 * @param $principalUri
+	 * @return int
+	 */
+	public function getAddressBooksForUserCount($principalUri) {
+		$principalUri = $this->convertPrincipal($principalUri, true);
+		$query = $this->db->getQueryBuilder();
+		$query->select($query->createFunction('COUNT(*)'))
+			->from('addressbooks')
+			->where($query->expr()->eq('principaluri', $query->createNamedParameter($principalUri)));
+
+		return $query->execute()->fetchColumn();
+	}
+
+	/**
 	 * Returns the list of address books for a specific user.
 	 *
 	 * Every addressbook should have the following properties:

--- a/apps/dav/lib/HookManager.php
+++ b/apps/dav/lib/HookManager.php
@@ -104,8 +104,7 @@ class HookManager {
 		$user = $this->userManager->get($params['uid']);
 		if (!is_null($user)) {
 			$principal = 'principals/users/' . $user->getUID();
-			$calendars = $this->calDav->getCalendarsForUser($principal);
-			if (empty($calendars) || (count($calendars) === 1 && $calendars[0]['uri'] === BirthdayService::BIRTHDAY_CALENDAR_URI)) {
+			if ($this->calDav->getCalendarsForUserCount($principal) === 0) {
 				try {
 					$this->calDav->createCalendar($principal, 'personal', [
 						'{DAV:}displayname' => 'Personal']);
@@ -113,8 +112,7 @@ class HookManager {
 					\OC::$server->getLogger()->logException($ex);
 				}
 			}
-			$books = $this->cardDav->getAddressBooksForUser($principal);
-			if (empty($books)) {
+			if ($this->cardDav->getAddressBooksForUserCount($principal) === 0) {
 				try {
 					$this->cardDav->createAddressBook($principal, 'contacts', [
 						'{DAV:}displayname' => 'Contacts']);

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -53,6 +53,7 @@ class CalDavBackendTest extends AbstractCalDavBackendTest {
 		]);
 		$this->backend->updateCalendar($calendarId, $patch);
 		$patch->commit();
+		$this->assertEquals(1, $this->backend->getCalendarsForUserCount(self::UNIT_TEST_USER));
 		$books = $this->backend->getCalendarsForUser(self::UNIT_TEST_USER);
 		$this->assertEquals(1, count($books));
 		$this->assertEquals('Unit test', $books[0]['{DAV:}displayname']);

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -118,6 +118,7 @@ class CardDavBackendTest extends TestCase {
 		// create a new address book
 		$this->backend->createAddressBook(self::UNIT_TEST_USER, 'Example', []);
 
+		$this->assertEquals(1, $this->backend->getAddressBooksForUserCount(self::UNIT_TEST_USER));
 		$books = $this->backend->getAddressBooksForUser(self::UNIT_TEST_USER);
 		$this->assertEquals(1, count($books));
 		$this->assertEquals('Example', $books[0]['{DAV:}displayname']);

--- a/apps/dav/tests/unit/DAV/HookManagerTest.php
+++ b/apps/dav/tests/unit/DAV/HookManagerTest.php
@@ -53,7 +53,7 @@ class HookManagerTest extends TestCase {
 		$cal = $this->getMockBuilder('OCA\DAV\CalDAV\CalDavBackend')
 			->disableOriginalConstructor()
 			->getMock();
-		$cal->expects($this->once())->method('getCalendarsForUser')->willReturn([]);
+		$cal->expects($this->once())->method('getCalendarsForUserCount')->willReturn(0);
 		$cal->expects($this->once())->method('createCalendar')->with(
 			'principals/users/newUser',
 			'personal', ['{DAV:}displayname' => 'Personal']);
@@ -62,7 +62,7 @@ class HookManagerTest extends TestCase {
 		$card = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')
 			->disableOriginalConstructor()
 			->getMock();
-		$card->expects($this->once())->method('getAddressBooksForUser')->willReturn([]);
+		$card->expects($this->once())->method('getAddressBooksForUserCount')->willReturn(0);
 		$card->expects($this->once())->method('createAddressBook')->with(
 			'principals/users/newUser',
 			'contacts', ['{DAV:}displayname' => 'Contacts']);
@@ -92,18 +92,14 @@ class HookManagerTest extends TestCase {
 		$cal = $this->getMockBuilder('OCA\DAV\CalDAV\CalDavBackend')
 			->disableOriginalConstructor()
 			->getMock();
-		$cal->expects($this->once())->method('getCalendarsForUser')->willReturn([
-			['uri' => 'my-events']
-		]);
+		$cal->expects($this->once())->method('getCalendarsForUserCount')->willReturn(1);
 		$cal->expects($this->never())->method('createCalendar');
 
 		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $card */
 		$card = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')
 			->disableOriginalConstructor()
 			->getMock();
-		$card->expects($this->once())->method('getAddressBooksForUser')->willReturn([
-			['uri' => 'my-contacts']
-		]);
+		$card->expects($this->once())->method('getAddressBooksForUserCount')->willReturn(1);
 		$card->expects($this->never())->method('createAddressBook');
 
 		$hm = new HookManager($userManager, $syncService, $cal, $card);
@@ -131,9 +127,7 @@ class HookManagerTest extends TestCase {
 		$cal = $this->getMockBuilder('OCA\DAV\CalDAV\CalDavBackend')
 			->disableOriginalConstructor()
 			->getMock();
-		$cal->expects($this->once())->method('getCalendarsForUser')->willReturn([
-			['uri' => BirthdayService::BIRTHDAY_CALENDAR_URI]
-		]);
+		$cal->expects($this->once())->method('getCalendarsForUserCount')->willReturn(0);
 		$cal->expects($this->once())->method('createCalendar')->with(
 			'principals/users/newUser',
 			'personal', ['{DAV:}displayname' => 'Personal']);
@@ -142,7 +136,7 @@ class HookManagerTest extends TestCase {
 		$card = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')
 			->disableOriginalConstructor()
 			->getMock();
-		$card->expects($this->once())->method('getAddressBooksForUser')->willReturn([]);
+		$card->expects($this->once())->method('getAddressBooksForUserCount')->willReturn(0);
 		$card->expects($this->once())->method('createAddressBook')->with(
 			'principals/users/newUser',
 			'contacts', ['{DAV:}displayname' => 'Contacts']);


### PR DESCRIPTION
No need to completely construct the addressbooks and calendars just to see if they exist.

Saves (at least) 4 database queries for each login
