### PR TITLE
[stable10] Prevent error with orphaned shares when updating user mount cache

### DIFF
--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -246,6 +246,11 @@ class SharedMount extends MountPoint implements MoveableMount {
 			->from('filecache')
 			->where($builder->expr()->eq('fileid', $builder->createNamedParameter($this->getStorageRootId())));
 
-		return $query->execute()->fetchColumn();
+		$result = $query->execute();
+		$row = $result->fetch();
+		if ($row) {
+			return $row['storage'];
+		}
+		return -1;
 	}
 }

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -248,6 +248,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 
 		$result = $query->execute();
 		$row = $result->fetch();
+		$result->closeCursor();
 		if ($row) {
 			return $row['storage'];
 		}

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -159,7 +159,8 @@ class UserMountCache implements IUserMountCache {
 				'mount_id' => $mount->getMountId()
 			], ['root_id', 'user_id']);
 		} else {
-			$this->logger->error('Error getting storage info for mount at ' . $mount->getMountPoint());
+			// in some cases this is legitimate, like orphaned shares
+			$this->logger->debug('Could not get storage info for mount at ' . $mount->getMountPoint());
 		}
 	}
 


### PR DESCRIPTION
@icewind1991 This is a partial cherry-pick of https://github.com/owncloud/core/pull/25948, care to take a look? It also includes https://github.com/owncloud/core/pull/25979

It does not include https://github.com/owncloud/core/pull/25948/files#diff-d802c5d8dc58cc57f6375a3a4f32b2bfR108 since we have another logic for that bug. 
