### PR TITLE
Fix deprecated usages of getMock in federatedfilesharing

### DIFF
--- a/apps/federatedfilesharing/tests/AddressHandlerTest.php
+++ b/apps/federatedfilesharing/tests/AddressHandlerTest.php
@@ -43,8 +43,10 @@ class AddressHandlerTest extends \Test\TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->urlGenerator = $this->getMock('OCP\IURLGenerator');
-		$this->il10n = $this->getMock('OCP\IL10N');
+		$this->urlGenerator = $this->getMockBuilder('OCP\IURLGenerator')
+			->getMock();
+		$this->il10n = $this->getMockBuilder('OCP\IL10N')
+			->getMock();
 
 		$this->addressHandler = new AddressHandler($this->urlGenerator, $this->il10n);
 	}

--- a/apps/federatedfilesharing/tests/DiscoveryManagerTest.php
+++ b/apps/federatedfilesharing/tests/DiscoveryManagerTest.php
@@ -40,7 +40,8 @@ class DiscoveryManagerTest extends \Test\TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->cache = $this->getMock('\OCP\ICache');
+		$this->cache = $this->getMockBuilder('\OCP\ICache')
+			->getMock();
 		/** @var ICacheFactory $cacheFactory */
 		$cacheFactory = $this->getMockBuilder('\OCP\ICacheFactory')
 			->disableOriginalConstructor()->getMock();
@@ -67,7 +68,8 @@ class DiscoveryManagerTest extends \Test\TestCase {
 	}
 
 	public function testWithMalformedFormattedEndpointCached() {
-		$response = $this->getMock('\OCP\Http\Client\IResponse');
+		$response = $this->getMockBuilder('\OCP\Http\Client\IResponse')
+			->getMock();
 		$response
 			->expects($this->once())
 			->method('getStatusCode')
@@ -104,7 +106,8 @@ class DiscoveryManagerTest extends \Test\TestCase {
 	}
 
 	public function testGetWebDavEndpointWithValidFormattedEndpointAndNotCached() {
-		$response = $this->getMock('\OCP\Http\Client\IResponse');
+		$response = $this->getMockBuilder('\OCP\Http\Client\IResponse')
+			->getMock();
 		$response
 			->expects($this->once())
 			->method('getStatusCode')
@@ -127,7 +130,8 @@ class DiscoveryManagerTest extends \Test\TestCase {
 	}
 
 	public function testGetWebDavEndpointWithValidFormattedEndpointWithoutDataAndNotCached() {
-		$response = $this->getMock('\OCP\Http\Client\IResponse');
+		$response = $this->getMockBuilder('\OCP\Http\Client\IResponse')
+			->getMock();
 		$response
 			->expects($this->once())
 			->method('getStatusCode')
@@ -150,7 +154,8 @@ class DiscoveryManagerTest extends \Test\TestCase {
 	}
 
 	public function testGetShareEndpointWithValidFormattedEndpointAndNotCached() {
-		$response = $this->getMock('\OCP\Http\Client\IResponse');
+		$response = $this->getMockBuilder('\OCP\Http\Client\IResponse')
+			->getMock();
 		$response
 			->expects($this->once())
 			->method('getStatusCode')
@@ -173,7 +178,8 @@ class DiscoveryManagerTest extends \Test\TestCase {
 	}
 
 	public function testWithMaliciousEndpointCached() {
-		$response = $this->getMock('\OCP\Http\Client\IResponse');
+		$response = $this->getMockBuilder('\OCP\Http\Client\IResponse')
+			->getMock();
 		$response
 			->expects($this->once())
 			->method('getStatusCode')

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -80,15 +80,15 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$this->tokenHandler = $this->getMockBuilder('OCA\FederatedFileSharing\TokenHandler')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->l = $this->getMock('OCP\IL10N');
+		$this->l = $this->getMockBuilder('OCP\IL10N')->getMock();
 		$this->l->method('t')
 			->will($this->returnCallback(function($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			}));
-		$this->logger = $this->getMock('OCP\ILogger');
-		$this->rootFolder = $this->getMock('OCP\Files\IRootFolder');
-		$this->config = $this->getMock('OCP\IConfig');
-		$this->userManager = $this->getMock('OCP\IUserManager');
+		$this->logger = $this->getMockBuilder('OCP\ILogger')->getMock();
+		$this->rootFolder = $this->getMockBuilder('OCP\Files\IRootFolder')->getMock();
+		$this->config = $this->getMockBuilder('OCP\IConfig')->getMock();
+		$this->userManager = $this->getMockBuilder('OCP\IUserManager')->getMock();
 		//$this->addressHandler = new AddressHandler(\OC::$server->getURLGenerator(), $this->l);
 		$this->addressHandler = $this->getMockBuilder('OCA\FederatedFileSharing\AddressHandler')->disableOriginalConstructor()->getMock();
 
@@ -118,7 +118,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	public function testCreate() {
 		$share = $this->shareManager->newShare();
 
-		$node = $this->getMock('\OCP\Files\File');
+		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
@@ -189,7 +189,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	public function testCreateCouldNotFindServer() {
 		$share = $this->shareManager->newShare();
 
-		$node = $this->getMock('\OCP\Files\File');
+		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
@@ -245,7 +245,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	public function testCreateException() {
 		$share = $this->shareManager->newShare();
 
-		$node = $this->getMock('\OCP\Files\File');
+		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
@@ -301,7 +301,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	public function testCreateShareWithSelf() {
 		$share = $this->shareManager->newShare();
 
-		$node = $this->getMock('\OCP\Files\File');
+		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
@@ -340,7 +340,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	public function testCreateAlreadyShared() {
 		$share = $this->shareManager->newShare();
 
-		$node = $this->getMock('\OCP\Files\File');
+		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
@@ -406,7 +406,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 
 		$share = $this->shareManager->newShare();
 
-		$node = $this->getMock('\OCP\Files\File');
+		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
@@ -463,7 +463,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetSharedBy() {
-		$node = $this->getMock('\OCP\Files\File');
+		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
@@ -504,7 +504,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetSharedByWithNode() {
-		$node = $this->getMock('\OCP\Files\File');
+		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
@@ -523,7 +523,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setNode($node);
 		$this->provider->create($share);
 
-		$node2 = $this->getMock('\OCP\Files\File');
+		$node2 = $this->getMockBuilder('\OCP\Files\File')->getMock();
 		$node2->method('getId')->willReturn(43);
 		$node2->method('getName')->willReturn('myOtherFile');
 
@@ -542,7 +542,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetSharedByWithReshares() {
-		$node = $this->getMock('\OCP\Files\File');
+		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
@@ -575,7 +575,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetSharedByWithLimit() {
-		$node = $this->getMock('\OCP\Files\File');
+		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 

--- a/apps/federatedfilesharing/tests/NotificationsTest.php
+++ b/apps/federatedfilesharing/tests/NotificationsTest.php
@@ -47,10 +47,10 @@ class NotificationsTest extends \Test\TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->jobList = $this->getMock('OCP\BackgroundJob\IJobList');
+		$this->jobList = $this->getMockBuilder('OCP\BackgroundJob\IJobList')->getMock();
 		$this->discoveryManager = $this->getMockBuilder('OCA\FederatedFileSharing\DiscoveryManager')
 			->disableOriginalConstructor()->getMock();
-		$this->httpClientService = $this->getMock('OCP\Http\Client\IClientService');
+		$this->httpClientService = $this->getMockBuilder('OCP\Http\Client\IClientService')->getMock();
 		$this->addressHandler = $this->getMockBuilder('OCA\FederatedFileSharing\AddressHandler')
 			->disableOriginalConstructor()->getMock();
 

--- a/apps/federatedfilesharing/tests/TokenHandlerTest.php
+++ b/apps/federatedfilesharing/tests/TokenHandlerTest.php
@@ -42,7 +42,7 @@ class TokenHandlerTest extends \Test\TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->secureRandom = $this->getMock('OCP\Security\ISecureRandom');
+		$this->secureRandom = $this->getMockBuilder('OCP\Security\ISecureRandom')->getMock();
 
 		$this->tokenHandler = new TokenHandler($this->secureRandom);
 	}


### PR DESCRIPTION
Just fixes phpunit warnings

Easy one: @LukasReschke @MorrisJobke @nickvergessen 
