### PR TITLE
Fix deprecated getMock call in Federation app

### DIFF
--- a/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
@@ -73,15 +73,15 @@ class GetSharedSecretTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->httpClient = $this->getMock('OCP\Http\Client\IClient');
-		$this->jobList = $this->getMock('OCP\BackgroundJob\IJobList');
-		$this->urlGenerator = $this->getMock('OCP\IURLGenerator');
-		$this->trustedServers = $this->getMockBuilder('OCA\Federation\TrustedServers')
+		$this->httpClient = $this->getMockBuilder(IClient::class)->getMock();
+		$this->jobList = $this->getMockBuilder(IJobList::class)->getMock();
+		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)->getMock();
+		$this->trustedServers = $this->getMockBuilder(TrustedServers::class)
 			->disableOriginalConstructor()->getMock();
-		$this->dbHandler = $this->getMockBuilder('OCA\Federation\DbHandler')
+		$this->dbHandler = $this->getMockBuilder(DbHandler::class)
 			->disableOriginalConstructor()->getMock();
-		$this->logger = $this->getMock('OCP\ILogger');
-		$this->response = $this->getMock('OCP\Http\Client\IResponse');
+		$this->logger = $this->getMockBuilder(ILogger::class)->getMock();
+		$this->response = $this->getMockBuilder(IResponse::class)->getMock();
 
 		$this->getSharedSecret = new GetSharedSecret(
 			$this->httpClient,

--- a/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
@@ -61,14 +61,14 @@ class RequestSharedSecretTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->httpClient = $this->getMock('OCP\Http\Client\IClient');
-		$this->jobList = $this->getMock('OCP\BackgroundJob\IJobList');
-		$this->urlGenerator = $this->getMock('OCP\IURLGenerator');
-		$this->trustedServers = $this->getMockBuilder('OCA\Federation\TrustedServers')
+		$this->httpClient = $this->getMockBuilder(IClient::class)->getMock();
+		$this->jobList = $this->getMockBuilder(IJobList::class)->getMock();
+		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)->getMock();
+		$this->trustedServers = $this->getMockBuilder(TrustedServers::class)
 			->disableOriginalConstructor()->getMock();
-		$this->dbHandler = $this->getMockBuilder('OCA\Federation\DbHandler')
+		$this->dbHandler = $this->getMockBuilder(DbHandler::class)
 			->disableOriginalConstructor()->getMock();
-		$this->response = $this->getMock('OCP\Http\Client\IResponse');
+		$this->response = $this->getMockBuilder(IResponse::class)->getMock();
 
 		$this->requestSharedSecret = new RequestSharedSecret(
 			$this->httpClient,

--- a/apps/federation/tests/Controller/SettingsControllerTest.php
+++ b/apps/federation/tests/Controller/SettingsControllerTest.php
@@ -25,7 +25,10 @@ namespace OCA\Federation\Tests\Controller;
 
 
 use OCA\Federation\Controller\SettingsController;
+use OCA\Federation\TrustedServers;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\IL10N;
+use OCP\IRequest;
 use Test\TestCase;
 
 class SettingsControllerTest extends TestCase {
@@ -45,9 +48,9 @@ class SettingsControllerTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->request = $this->getMock('OCP\IRequest');
-		$this->l10n = $this->getMock('OCP\IL10N');
-		$this->trustedServers = $this->getMockBuilder('OCA\Federation\TrustedServers')
+		$this->request = $this->getMockBuilder(IRequest::class)->getMock();
+		$this->l10n = $this->getMockBuilder(IL10N::class)->getMock();
+		$this->trustedServers = $this->getMockBuilder(TrustedServers::class)
 			->disableOriginalConstructor()->getMock();
 
 		$this->controller = new SettingsController(

--- a/apps/federation/tests/DbHandlerTest.php
+++ b/apps/federation/tests/DbHandlerTest.php
@@ -53,7 +53,7 @@ class DbHandlerTest extends TestCase {
 		parent::setUp();
 
 		$this->connection = \OC::$server->getDatabaseConnection();
-		$this->il10n = $this->getMock('OCP\IL10N');
+		$this->il10n = $this->getMockBuilder(IL10N::class)->getMock();
 
 		$this->dbHandler = new DbHandler(
 			$this->connection,

--- a/apps/federation/tests/Middleware/AddServerMiddlewareTest.php
+++ b/apps/federation/tests/Middleware/AddServerMiddlewareTest.php
@@ -29,6 +29,7 @@ use OC\HintException;
 use OCA\Federation\Middleware\AddServerMiddleware;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\IL10N;
 use OCP\ILogger;
 use Test\TestCase;
 
@@ -49,9 +50,9 @@ class AddServerMiddlewareTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->logger = $this->getMock('OCP\ILogger');
-		$this->l10n = $this->getMock('OCP\IL10N');
-		$this->controller = $this->getMockBuilder('OCP\AppFramework\Controller')
+		$this->logger = $this->getMockBuilder(ILogger::class)->getMock();
+		$this->l10n = $this->getMockBuilder(IL10N::class)->getMock();
+		$this->controller = $this->getMockBuilder(Controller::class)
 			->disableOriginalConstructor()->getMock();
 
 		$this->middleware = new AddServerMiddleware(

--- a/apps/federation/tests/TrustedServersTest.php
+++ b/apps/federation/tests/TrustedServersTest.php
@@ -74,17 +74,17 @@ class TrustedServersTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->dbHandler = $this->getMockBuilder('\OCA\Federation\DbHandler')
+		$this->dbHandler = $this->getMockBuilder(DbHandler::class)
 			->disableOriginalConstructor()->getMock();
-		$this->dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')
+		$this->dispatcher = $this->getMockBuilder(EventDispatcherInterface::class)
 			->disableOriginalConstructor()->getMock();
-		$this->httpClientService = $this->getMock('OCP\Http\Client\IClientService');
-		$this->httpClient = $this->getMock('OCP\Http\Client\IClient');
-		$this->response = $this->getMock('OCP\Http\Client\IResponse');
-		$this->logger = $this->getMock('OCP\ILogger');
-		$this->jobList = $this->getMock('OCP\BackgroundJob\IJobList');
-		$this->secureRandom = $this->getMock('OCP\Security\ISecureRandom');
-		$this->config = $this->getMock('OCP\IConfig');
+		$this->httpClientService = $this->getMockBuilder(IClientService::class)->getMock();
+		$this->httpClient = $this->getMockBuilder(IClient::class)->getMock();
+		$this->response = $this->getMockBuilder(IResponse::class)->getMock();
+		$this->logger = $this->getMockBuilder(ILogger::class)->getMock();
+		$this->jobList = $this->getMockBuilder(IJobList::class)->getMock();
+		$this->secureRandom = $this->getMockBuilder(ISecureRandom::class)->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 
 		$this->trustedServers = new TrustedServers(
 			$this->dbHandler,


### PR DESCRIPTION
Another easy one: @LukasReschke @nickvergessen @MorrisJobke @icewind1991 
