### PR TITLE
Fix depreccated getMock in Core/Command tests

### DIFF
--- a/tests/Core/Command/Config/App/DeleteConfigTest.php
+++ b/tests/Core/Command/Config/App/DeleteConfigTest.php
@@ -23,10 +23,13 @@ namespace Tests\Core\Command\Config\App;
 
 
 use OC\Core\Command\Config\App\DeleteConfig;
+use OCP\IConfig;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class DeleteConfigTest extends TestCase {
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
 	protected $config;
 
 	/** @var \PHPUnit_Framework_MockObject_MockObject */
@@ -40,14 +43,13 @@ class DeleteConfigTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$config = $this->config = $this->getMockBuilder('OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
-		/** @var \OCP\IConfig $config */
-		$this->command = new DeleteConfig($config);
+		$this->command = new DeleteConfig($this->config);
 	}
 
 

--- a/tests/Core/Command/Config/App/GetConfigTest.php
+++ b/tests/Core/Command/Config/App/GetConfigTest.php
@@ -23,6 +23,9 @@ namespace Tests\Core\Command\Config\App;
 
 
 use OC\Core\Command\Config\App\GetConfig;
+use OCP\IConfig;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class GetConfigTest extends TestCase {
@@ -40,11 +43,11 @@ class GetConfigTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$config = $this->config = $this->getMockBuilder('OCP\IConfig')
+		$config = $this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		/** @var \OCP\IConfig $config */
 		$this->command = new GetConfig($config);

--- a/tests/Core/Command/Config/App/SetConfigTest.php
+++ b/tests/Core/Command/Config/App/SetConfigTest.php
@@ -23,6 +23,9 @@ namespace Tests\Core\Command\Config\App;
 
 
 use OC\Core\Command\Config\App\SetConfig;
+use OCP\IConfig;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class SetConfigTest extends TestCase {
@@ -40,11 +43,11 @@ class SetConfigTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$config = $this->config = $this->getMockBuilder('OCP\IConfig')
+		$config = $this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		/** @var \OCP\IConfig $config */
 		$this->command = new SetConfig($config);

--- a/tests/Core/Command/Config/ImportTest.php
+++ b/tests/Core/Command/Config/ImportTest.php
@@ -23,6 +23,9 @@ namespace Tests\Core\Command\Config;
 
 
 use OC\Core\Command\Config\Import;
+use OCP\IConfig;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class ImportTest extends TestCase {
@@ -40,11 +43,11 @@ class ImportTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$config = $this->config = $this->getMockBuilder('OCP\IConfig')
+		$config = $this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		/** @var \OCP\IConfig $config */
 		$this->command = new Import($config);

--- a/tests/Core/Command/Config/ListConfigsTest.php
+++ b/tests/Core/Command/Config/ListConfigsTest.php
@@ -23,7 +23,11 @@ namespace Tests\Core\Command\Config;
 
 
 use OC\Core\Command\Config\ListConfigs;
+use OC\SystemConfig;
+use OCP\IAppConfig;
 use OCP\IConfig;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class ListConfigsTest extends TestCase {
@@ -43,14 +47,14 @@ class ListConfigsTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$systemConfig = $this->systemConfig = $this->getMockBuilder('OC\SystemConfig')
+		$systemConfig = $this->systemConfig = $this->getMockBuilder(SystemConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$appConfig = $this->appConfig = $this->getMockBuilder('OCP\IAppConfig')
+		$appConfig = $this->appConfig = $this->getMockBuilder(IAppConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		/** @var \OC\SystemConfig $systemConfig */
 		/** @var \OCP\IAppConfig $appConfig */

--- a/tests/Core/Command/Config/System/DeleteConfigTest.php
+++ b/tests/Core/Command/Config/System/DeleteConfigTest.php
@@ -23,6 +23,9 @@ namespace Tests\Core\Command\Config\System;
 
 
 use OC\Core\Command\Config\System\DeleteConfig;
+use OC\SystemConfig;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class DeleteConfigTest extends TestCase {
@@ -40,11 +43,11 @@ class DeleteConfigTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$systemConfig = $this->systemConfig = $this->getMockBuilder('OC\SystemConfig')
+		$systemConfig = $this->systemConfig = $this->getMockBuilder(SystemConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		/** @var \OC\SystemConfig $systemConfig */
 		$this->command = new DeleteConfig($systemConfig);

--- a/tests/Core/Command/Config/System/GetConfigTest.php
+++ b/tests/Core/Command/Config/System/GetConfigTest.php
@@ -23,6 +23,9 @@ namespace Tests\Core\Command\Config\System;
 
 
 use OC\Core\Command\Config\System\GetConfig;
+use OC\SystemConfig;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class GetConfigTest extends TestCase {
@@ -40,11 +43,11 @@ class GetConfigTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$systemConfig = $this->systemConfig = $this->getMockBuilder('OC\SystemConfig')
+		$systemConfig = $this->systemConfig = $this->getMockBuilder(SystemConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		/** @var \OC\SystemConfig $systemConfig */
 		$this->command = new GetConfig($systemConfig);

--- a/tests/Core/Command/Config/System/SetConfigTest.php
+++ b/tests/Core/Command/Config/System/SetConfigTest.php
@@ -23,6 +23,9 @@ namespace Tests\Core\Command\Config\System;
 
 
 use OC\Core\Command\Config\System\SetConfig;
+use OC\SystemConfig;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class SetConfigTest extends TestCase {
@@ -40,11 +43,11 @@ class SetConfigTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$systemConfig = $this->systemConfig = $this->getMockBuilder('OC\SystemConfig')
+		$systemConfig = $this->systemConfig = $this->getMockBuilder(SystemConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		/** @var \OC\SystemConfig $systemConfig */
 		$this->command = new SetConfig($systemConfig);

--- a/tests/Core/Command/Encryption/ChangeKeyStorageRootTest.php
+++ b/tests/Core/Command/Encryption/ChangeKeyStorageRootTest.php
@@ -28,6 +28,8 @@ use OC\Encryption\Util;
 use OC\Files\View;
 use OCP\IConfig;
 use OCP\IUserManager;
+use OCP\UserInterface;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -65,16 +67,16 @@ class ChangeKeyStorageRootTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->view = $this->getMock('\OC\Files\View');
-		$this->userManager = $this->getMock('\OCP\IUserManager');
-		$this->config = $this->getMock('\OCP\IConfig');
+		$this->view = $this->getMockBuilder(View::class)->getMock();
+		$this->userManager = $this->getMockBuilder(IUserManager::class)->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->util = $this->getMockBuilder('OC\Encryption\Util')->disableOriginalConstructor()->getMock();
-		$this->questionHelper = $this->getMock('Symfony\Component\Console\Helper\QuestionHelper');
-		$this->inputInterface = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->outputInterface = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
-		$this->userInterface = $this->getMock('\OCP\UserInterface');
+		$this->questionHelper = $this->getMockBuilder(QuestionHelper::class)->getMock();
+		$this->inputInterface = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->outputInterface = $this->getMockBuilder(OutputInterface::class)->getMock();
+		$this->userInterface = $this->getMockBuilder(UserInterface::class)->getMock();
 
-		$outputFormatterInterface = $this->getMock('Symfony\Component\Console\Formatter\OutputFormatterInterface');
+		$outputFormatterInterface = $this->getMockBuilder(OutputFormatterInterface::class)->getMock();
 		$this->outputInterface->expects($this->any())->method('getFormatter')
 			->willReturn($outputFormatterInterface);
 

--- a/tests/Core/Command/Encryption/DecryptAllTest.php
+++ b/tests/Core/Command/Encryption/DecryptAllTest.php
@@ -24,6 +24,12 @@ namespace Tests\Core\Command\Encryption;
 
 
 use OC\Core\Command\Encryption\DecryptAll;
+use OCP\App\IAppManager;
+use OCP\Encryption\IManager;
+use OCP\IConfig;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class DecryptAllTest extends TestCase {
@@ -52,22 +58,22 @@ class DecryptAllTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->config = $this->getMockBuilder('OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->encryptionManager = $this->getMockBuilder('OCP\Encryption\IManager')
+		$this->encryptionManager = $this->getMockBuilder(IManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->appManager = $this->getMockBuilder('OCP\App\IAppManager')
+		$this->appManager = $this->getMockBuilder(IAppManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->questionHelper = $this->getMockBuilder('Symfony\Component\Console\Helper\QuestionHelper')
+		$this->questionHelper = $this->getMockBuilder(QuestionHelper::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->decryptAll = $this->getMockBuilder('OC\Encryption\DecryptAll')
+		$this->decryptAll = $this->getMockBuilder(\OC\Encryption\DecryptAll::class)
 			->disableOriginalConstructor()->getMock();
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		$this->config->expects($this->any())
 			->method('getSystemValue')

--- a/tests/Core/Command/Encryption/DisableTest.php
+++ b/tests/Core/Command/Encryption/DisableTest.php
@@ -23,6 +23,9 @@ namespace Tests\Core\Command\Encryption;
 
 
 use OC\Core\Command\Encryption\Disable;
+use OCP\IConfig;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class DisableTest extends TestCase {
@@ -39,11 +42,11 @@ class DisableTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$config = $this->config = $this->getMockBuilder('OCP\IConfig')
+		$config = $this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		/** @var \OCP\IConfig $config */
 		$this->command = new Disable($config);

--- a/tests/Core/Command/Encryption/EnableTest.php
+++ b/tests/Core/Command/Encryption/EnableTest.php
@@ -23,6 +23,10 @@ namespace Tests\Core\Command\Encryption;
 
 
 use OC\Core\Command\Encryption\Enable;
+use OCP\Encryption\IManager;
+use OCP\IConfig;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class EnableTest extends TestCase {
@@ -41,14 +45,14 @@ class EnableTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$config = $this->config = $this->getMockBuilder('OCP\IConfig')
+		$config = $this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$manager = $this->manager = $this->getMockBuilder('OCP\Encryption\IManager')
+		$manager = $this->manager = $this->getMockBuilder(IManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		/** @var \OCP\IConfig $config */
 		/** @var \OCP\Encryption\IManager $manager */

--- a/tests/Core/Command/Encryption/EncryptAllTest.php
+++ b/tests/Core/Command/Encryption/EncryptAllTest.php
@@ -24,6 +24,13 @@ namespace Tests\Core\Command\Encryption;
 
 
 use OC\Core\Command\Encryption\EncryptAll;
+use OCP\App\IAppManager;
+use OCP\Encryption\IEncryptionModule;
+use OCP\Encryption\IManager;
+use OCP\IConfig;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class EncryptAllTest extends TestCase {
@@ -55,23 +62,23 @@ class EncryptAllTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->config = $this->getMockBuilder('OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->encryptionManager = $this->getMockBuilder('OCP\Encryption\IManager')
+		$this->encryptionManager = $this->getMockBuilder(IManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->appManager = $this->getMockBuilder('OCP\App\IAppManager')
+		$this->appManager = $this->getMockBuilder(IAppManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->encryptionModule = $this->getMockBuilder('\OCP\Encryption\IEncryptionModule')
+		$this->encryptionModule = $this->getMockBuilder(IEncryptionModule::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->questionHelper = $this->getMockBuilder('Symfony\Component\Console\Helper\QuestionHelper')
+		$this->questionHelper = $this->getMockBuilder(QuestionHelper::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 	}
 

--- a/tests/Core/Command/Encryption/SetDefaultModuleTest.php
+++ b/tests/Core/Command/Encryption/SetDefaultModuleTest.php
@@ -23,6 +23,9 @@ namespace Tests\Core\Command\Encryption;
 
 
 use OC\Core\Command\Encryption\SetDefaultModule;
+use OCP\Encryption\IManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class SetDefaultModuleTest extends TestCase {
@@ -39,11 +42,11 @@ class SetDefaultModuleTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$manager = $this->manager = $this->getMockBuilder('OCP\Encryption\IManager')
+		$manager = $this->manager = $this->getMockBuilder(IManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		/** @var \OCP\Encryption\IManager $manager */
 		$this->command = new SetDefaultModule($manager);

--- a/tests/Core/Command/Log/FileTest.php
+++ b/tests/Core/Command/Log/FileTest.php
@@ -23,6 +23,9 @@ namespace Tests\Core\Command\Log;
 
 
 use OC\Core\Command\Log\File;
+use OCP\IConfig;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class FileTest extends TestCase {
@@ -39,11 +42,11 @@ class FileTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$config = $this->config = $this->getMockBuilder('OCP\IConfig')
+		$config = $this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		$this->command = new File($config);
 	}

--- a/tests/Core/Command/Log/ManageTest.php
+++ b/tests/Core/Command/Log/ManageTest.php
@@ -23,6 +23,9 @@ namespace Tests\Core\Command\Log;
 
 
 use OC\Core\Command\Log\Manage;
+use OCP\IConfig;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class ManageTest extends TestCase {
@@ -39,11 +42,11 @@ class ManageTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$config = $this->config = $this->getMockBuilder('OCP\IConfig')
+		$config = $this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		$this->command = new Manage($config);
 	}

--- a/tests/Core/Command/Maintenance/DataFingerprintTest.php
+++ b/tests/Core/Command/Maintenance/DataFingerprintTest.php
@@ -24,6 +24,8 @@ namespace Tests\Core\Command\Maintenance;
 use OC\Core\Command\Maintenance\DataFingerprint;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class DataFingerprintTest extends TestCase {
@@ -42,10 +44,10 @@ class DataFingerprintTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->config = $this->getMock('OCP\IConfig');
-		$this->timeFactory = $this->getMock('OCP\AppFramework\Utility\ITimeFactory');
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
+		$this->timeFactory = $this->getMockBuilder(ITimeFactory::class)->getMock();
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		/** @var \OCP\IConfig $config */
 		$this->command = new DataFingerprint($this->config, $this->timeFactory);

--- a/tests/Core/Command/Maintenance/Mimetype/UpdateDBTest.php
+++ b/tests/Core/Command/Maintenance/Mimetype/UpdateDBTest.php
@@ -22,6 +22,10 @@
 namespace Tests\Core\Command\Maintenance\Mimetype;
 
 use OC\Core\Command\Maintenance\Mimetype\UpdateDB;
+use OC\Files\Type\Detection;
+use OC\Files\Type\Loader;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\IMimeTypeLoader;
@@ -43,15 +47,15 @@ class UpdateDBTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->detector = $this->getMockBuilder('OC\Files\Type\Detection')
+		$this->detector = $this->getMockBuilder(Detection::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->loader = $this->getMockBuilder('OC\Files\Type\Loader')
+		$this->loader = $this->getMockBuilder(Loader::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		$this->command = new UpdateDB($this->detector, $this->loader);
 	}

--- a/tests/Core/Command/Maintenance/SingleUserTest.php
+++ b/tests/Core/Command/Maintenance/SingleUserTest.php
@@ -23,6 +23,9 @@ namespace Tests\Core\Command\Maintenance;
 
 
 use OC\Core\Command\Maintenance\SingleUser;
+use OCP\IConfig;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class SingleUserTest extends TestCase {
@@ -39,11 +42,11 @@ class SingleUserTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$config = $this->config = $this->getMockBuilder('OCP\IConfig')
+		$config = $this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		/** @var \OCP\IConfig $config */
 		$this->command = new SingleUser($config);

--- a/tests/Core/Command/User/DeleteTest.php
+++ b/tests/Core/Command/User/DeleteTest.php
@@ -23,6 +23,10 @@ namespace Tests\Core\Command\User;
 
 
 use OC\Core\Command\User\Delete;
+use OCP\IUser;
+use OCP\IUserManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class DeleteTest extends TestCase {
@@ -39,11 +43,11 @@ class DeleteTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$userManager = $this->userManager = $this->getMockBuilder('OCP\IUserManager')
+		$userManager = $this->userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		/** @var \OCP\IUserManager $userManager */
 		$this->command = new Delete($userManager);
@@ -64,7 +68,7 @@ class DeleteTest extends TestCase {
 	 * @param string $expectedString
 	 */
 	public function testValidUser($deleteSuccess, $expectedString) {
-		$user = $this->getMock('OCP\IUser');
+		$user = $this->getMockBuilder(IUser::class)->getMock();
 		$user->expects($this->once())
 			->method('delete')
 			->willReturn($deleteSuccess);

--- a/tests/Core/Command/User/LastSeenTest.php
+++ b/tests/Core/Command/User/LastSeenTest.php
@@ -23,6 +23,10 @@ namespace Tests\Core\Command\User;
 
 
 use OC\Core\Command\User\LastSeen;
+use OCP\IUser;
+use OCP\IUserManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class LastSeenTest extends TestCase {
@@ -39,11 +43,11 @@ class LastSeenTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$userManager = $this->userManager = $this->getMockBuilder('OCP\IUserManager')
+		$userManager = $this->userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		/** @var \OCP\IUserManager $userManager */
 		$this->command = new LastSeen($userManager);
@@ -63,7 +67,7 @@ class LastSeenTest extends TestCase {
 	 * @param string $expectedString
 	 */
 	public function testValidUser($lastSeen, $expectedString) {
-		$user = $this->getMock('OCP\IUser');
+		$user = $this->getMockBuilder(IUser::class)->getMock();
 		$user->expects($this->once())
 			->method('getLastLogin')
 			->willReturn($lastSeen);

--- a/tests/Core/Command/User/SettingTest.php
+++ b/tests/Core/Command/User/SettingTest.php
@@ -23,6 +23,11 @@ namespace Tests\Core\Command\User;
 
 
 use OC\Core\Command\User\Setting;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IUserManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class SettingTest extends TestCase {
@@ -40,19 +45,19 @@ class SettingTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->userManager = $this->getMockBuilder('OCP\IUserManager')
+		$this->userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->config = $this->getMockBuilder('OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->connection = $this->getMockBuilder('OCP\IDBConnection')
+		$this->connection = $this->getMockBuilder(IDBConnection::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleInput = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->consoleOutput = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 	}


### PR DESCRIPTION
Easy one. Just for unit test output

CC: @nickvergessen @MorrisJobke @LukasReschke 
