### PR TITLE
allow routes to specify that they dont need the filesystem to be setup in advance

### DIFF
--- a/apps/theming/appinfo/routes.php
+++ b/apps/theming/appinfo/routes.php
@@ -28,37 +28,44 @@ return ['routes' => [
 	[
 		'name' => 'Theming#updateStylesheet',
 		'url' => '/ajax/updateStylesheet',
-		'verb' => 'POST'
+		'verb' => 'POST',
+		'filesystem' => false
 	],
 	[
 		'name' => 'Theming#undo',
 		'url' => '/ajax/undoChanges',
-		'verb' => 'POST'
+		'verb' => 'POST',
+		'filesystem' => false
 	],
 	[
 		'name' => 'Theming#updateLogo',
 		'url' => '/ajax/updateLogo',
-		'verb' => 'POST'
+		'verb' => 'POST',
+		'filesystem' => false
 	],
 	[
 		'name' => 'Theming#getStylesheet',
 		'url' => '/styles',
 		'verb' => 'GET',
+		'filesystem' => false
 	],
 	[
 		'name' => 'Theming#getLogo',
 		'url' => '/logo',
 		'verb' => 'GET',
+		'filesystem' => false
 	],
 	[
 		'name' => 'Theming#getLoginBackground',
 		'url' => '/loginbackground',
 		'verb' => 'GET',
+		'filesystem' => false
 	],
 	[
 		'name' => 'Theming#getJavascript',
 		'url' => '/js/theming',
 		'verb' => 'GET',
+		'filesystem' => false
 	],
 ]];
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -968,7 +968,6 @@ class OC {
 					OC_App::loadApps();
 				}
 				self::checkSingleUserMode();
-				OC_Util::setupFS();
 				OC::$server->getRouter()->match(\OC::$server->getRequest()->getRawPathInfo());
 				return;
 			} catch (Symfony\Component\Routing\Exception\ResourceNotFoundException $e) {

--- a/lib/private/AppFramework/Routing/RouteConfig.php
+++ b/lib/private/AppFramework/Routing/RouteConfig.php
@@ -144,6 +144,7 @@ class RouteConfig {
 
 			$url = $simpleRoute['url'];
 			$verb = isset($simpleRoute['verb']) ? strtoupper($simpleRoute['verb']) : 'GET';
+			$filesystem = isset($simpleRoute['filesystem']) ? $simpleRoute['filesystem'] : true;
 
 			$split = explode('#', $name, 2);
 			if (count($split) != 2) {
@@ -159,7 +160,8 @@ class RouteConfig {
 			$handler = new RouteActionHandler($this->container, $controllerName, $actionName);
 			$router = $this->router->create($this->appName.'.'.$controller.'.'.$action . $postfix, $url)
 							->method($verb)
-							->action($handler);
+							->action($handler)
+							->setupFilesystem($filesystem);
 
 			// optionally register requirements for route. This is used to
 			// tell the route parser how url parameters should be matched

--- a/lib/private/Route/Route.php
+++ b/lib/private/Route/Route.php
@@ -32,6 +32,8 @@ use OCP\Route\IRoute;
 use Symfony\Component\Routing\Route as SymfonyRoute;
 
 class Route extends SymfonyRoute implements IRoute {
+	private $filesystem;
+
 	/**
 	 * Specify the method when this route is to be used
 	 *
@@ -154,5 +156,25 @@ class Route extends SymfonyRoute implements IRoute {
 			.'unset($param);'
 			.'require_once "'.$file.'";');
 		$this->action($function);
+	}
+
+	/**
+	 * Set whether or not the filesystem should be setup to handle this route
+	 *
+	 * @param bool $filesystem
+	 * @return \OCP\Route\IRoute
+	 */
+	public function setupFilesystem($filesystem) {
+		$this->filesystem = $filesystem;
+		return $this;
+	}
+
+	/**
+	 * Whether or not the filesystem should be setup to handle this route
+	 *
+	 * @return bool
+	 */
+	public function requiresFilesystem() {
+		return $this->filesystem;
 	}
 }

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -288,6 +288,11 @@ class Router implements IRouter {
 			}
 		}
 
+		$route = $this->root->get($parameters['_route']);
+		if (!($route instanceof \OCP\Route\IRoute && $route->requiresFilesystem() === false)) {
+			\OC_Util::setupFS();
+		}
+
 		\OC::$server->getEventLogger()->start('run_route', 'Run route');
 		if (isset($parameters['action'])) {
 			$action = $parameters['action'];

--- a/lib/public/Route/IRoute.php
+++ b/lib/public/Route/IRoute.php
@@ -115,4 +115,21 @@ interface IRoute {
 	 * @since 7.0.0
 	 */
 	public function put();
+
+	/**
+	 * Set whether or not the filesystem should be setup to handle this route
+	 *
+	 * @param bool $filesystem
+	 * @return \OCP\Route\IRoute
+	 * @since 9.2.0
+	 */
+	public function setupFilesystem($filesystem);
+
+	/**
+	 * Whether or not the filesystem should be setup to handle this route
+	 *
+	 * @return bool
+	 * @since 9.2.0
+	 */
+	public function requiresFilesystem();
 }


### PR DESCRIPTION
This way we don't have to do an expensive filesystem setup for requests that don't need it.

Note that this doesn't mean that the route can't use the filesystem, if a route gets the root folder from the server container it will still automatically setup the fs once it's used or the route can manually setup the fs if it wants to use the older api's

We can't enable this by default for legacy compatibility

cc @rullzer 
