### PR TITLE
Allow registering setting forms lazily

### DIFF
--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -35,7 +35,7 @@ require_once __DIR__ . '/../3rdparty/autoload.php';
 \OC_Mount_Config::$app = new \OCA\Files_External\AppInfo\Application();
 $appContainer = \OC_Mount_Config::$app->getContainer();
 
-\OC_Mount_Config::$app->registerSettings();
+\OC::$server->getEventDispatcher()->addListener('OC\Settings::loadAdditionalForms', [\OC_Mount_Config::$app, 'registerSettings']);
 
 $l = \OC::$server->getL10N('files_external');
 

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -736,6 +736,7 @@ class OC_App {
 	 * @return array
 	 */
 	public static function getForms($type) {
+		\OC::$server->getEventDispatcher()->dispatch('OC\Settings::loadAdditionalForms');
 		$forms = array();
 		switch ($type) {
 			case 'admin':


### PR DESCRIPTION
The new check for whether or not we need to show the files_external settings in personal is not free so we should only make the check when actually loading the settings page
