### PR TITLE
[stable9] Add theming information to capabilities for the client

### DIFF
--- a/apps/theming/appinfo/app.php
+++ b/apps/theming/appinfo/app.php
@@ -39,4 +39,4 @@ $linkToCSS = \OC::$server->getURLGenerator()->linkToRoute(
 );
 
 $app = new \OCP\AppFramework\App('theming');
-$app->getContainer()->registerCapability(\OCA\Theming\Capabilities::class);
+$app->getContainer()->registerCapability('OCA\Theming\Capabilities');

--- a/apps/theming/appinfo/app.php
+++ b/apps/theming/appinfo/app.php
@@ -38,3 +38,5 @@ $linkToCSS = \OC::$server->getURLGenerator()->linkToRoute(
 	]
 );
 
+$app = new \OCP\AppFramework\App('theming');
+$app->getContainer()->registerCapability(\OCA\Theming\Capabilities::class);

--- a/apps/theming/lib/capabilities.php
+++ b/apps/theming/lib/capabilities.php
@@ -36,17 +36,11 @@ class Capabilities implements ICapability {
 	/** @var ThemingDefaults */
 	protected $theming;
 
-
-	/** @var IURLGenerator */
-	protected $url;
-
 	/**
 	 * @param ThemingDefaults $theming
-	 * @param IURLGenerator $url
 	 */
-	public function __construct(ThemingDefaults $theming, IURLGenerator $url) {
+	public function __construct(ThemingDefaults $theming) {
 		$this->theming = $theming;
-		$this->url = $url;
 	}
 
 	/**
@@ -61,8 +55,6 @@ class Capabilities implements ICapability {
 				'url' => $this->theming->getBaseUrl(),
 				'slogan' => $this->theming->getSlogan(),
 				'color' => $this->theming->getMailHeaderColor(),
-				'logo' => $this->url->getAbsoluteURL($this->theming->getLogo()),
-				'background' => $this->url->getAbsoluteURL($this->theming->getBackground()),
 			],
 		];
 	}

--- a/apps/theming/lib/capabilities.php
+++ b/apps/theming/lib/capabilities.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016, Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Theming;
+
+use OCP\Capabilities\ICapability;
+
+/**
+ * Class Capabilities
+ *
+ * @package OCA\Theming
+ */
+class Capabilities implements ICapability {
+
+	/** @var ThemingDefaults */
+	protected $theming;
+
+	/**
+	 * @param ThemingDefaults $theming
+	 */
+	public function __construct(ThemingDefaults $theming) {
+		$this->theming = $theming;
+	}
+
+	/**
+	 * Return this classes capabilities
+	 *
+	 * @return array
+	 */
+	public function getCapabilities() {
+		return [
+			'theming' => [
+				'name' => $this->theming->getName(),
+				'url' => $this->theming->getBaseUrl(),
+				'slogan' => $this->theming->getSlogan(),
+				'color' => $this->theming->getMailHeaderColor(),
+			],
+		];
+	}
+}

--- a/apps/theming/lib/capabilities.php
+++ b/apps/theming/lib/capabilities.php
@@ -24,6 +24,7 @@
 namespace OCA\Theming;
 
 use OCP\Capabilities\ICapability;
+use OCP\IURLGenerator;
 
 /**
  * Class Capabilities
@@ -35,11 +36,17 @@ class Capabilities implements ICapability {
 	/** @var ThemingDefaults */
 	protected $theming;
 
+
+	/** @var IURLGenerator */
+	protected $url;
+
 	/**
 	 * @param ThemingDefaults $theming
+	 * @param IURLGenerator $url
 	 */
-	public function __construct(ThemingDefaults $theming) {
+	public function __construct(ThemingDefaults $theming, IURLGenerator $url) {
 		$this->theming = $theming;
+		$this->url = $url;
 	}
 
 	/**
@@ -54,6 +61,8 @@ class Capabilities implements ICapability {
 				'url' => $this->theming->getBaseUrl(),
 				'slogan' => $this->theming->getSlogan(),
 				'color' => $this->theming->getMailHeaderColor(),
+				'logo' => $this->url->getAbsoluteURL($this->theming->getLogo()),
+				'background' => $this->url->getAbsoluteURL($this->theming->getBackground()),
 			],
 		];
 	}

--- a/apps/theming/lib/capabilities.php
+++ b/apps/theming/lib/capabilities.php
@@ -24,7 +24,6 @@
 namespace OCA\Theming;
 
 use OCP\Capabilities\ICapability;
-use OCP\IURLGenerator;
 
 /**
  * Class Capabilities
@@ -33,13 +32,13 @@ use OCP\IURLGenerator;
  */
 class Capabilities implements ICapability {
 
-	/** @var ThemingDefaults */
+	/** @var Template */
 	protected $theming;
 
 	/**
-	 * @param ThemingDefaults $theming
+	 * @param Template $theming
 	 */
-	public function __construct(ThemingDefaults $theming) {
+	public function __construct(Template $theming) {
 		$this->theming = $theming;
 	}
 

--- a/apps/theming/tests/CapabilitiesTest.php
+++ b/apps/theming/tests/CapabilitiesTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Theming\Tests;
+
+use OCA\Theming\Capabilities;
+use OCA\Theming\Controller\ThemingController;
+use OCA\Theming\Settings\Admin;
+use OCA\Theming\Settings\Section;
+use OCA\Theming\ThemingDefaults;
+use OCA\Theming\Util;
+use OCP\AppFramework\App;
+use OCP\Capabilities\ICapability;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\Settings\ISection;
+use OCP\Settings\ISettings;
+use Test\TestCase;
+
+/**
+ * Class CapabilitiesTest
+ *
+ * @group DB
+ * @package OCA\Theming\Tests
+ */
+class CapabilitiesTest extends TestCase  {
+	/** @var ThemingDefaults|\PHPUnit_Framework_MockObject_MockObject */
+	protected $theming;
+
+	/** @var IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
+	protected $url;
+
+	/** @var Capabilities */
+	protected $capabilities;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->theming = $this->getMockBuilder(ThemingDefaults::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$this->url = $this->getMockBuilder(IURLGenerator::class)
+			->getMock();
+
+		$this->capabilities = new Capabilities($this->theming, $this->url);
+	}
+
+	public function dataGetCapabilities() {
+		return [
+			['name', 'url', 'slogan', 'color', 'logo', 'background', 'http://absolute/', [
+				'name' => 'name',
+				'url' => 'url',
+				'slogan' => 'slogan',
+				'color' => 'color',
+				'logo' => 'http://absolute/logo',
+				'background' => 'http://absolute/background',
+			]],
+			['name1', 'url2', 'slogan3', 'color4', 'logo5', 'background6', 'http://localhost/', [
+				'name' => 'name1',
+				'url' => 'url2',
+				'slogan' => 'slogan3',
+				'color' => 'color4',
+				'logo' => 'http://localhost/logo5',
+				'background' => 'http://localhost/background6',
+			]],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetCapabilities
+	 * @param string $name
+	 * @param string $url
+	 * @param string $slogan
+	 * @param string $color
+	 * @param string $logo
+	 * @param string $background
+	 * @param string $baseUrl
+	 * @param string[] $expected
+	 */
+	public function testGetCapabilities($name, $url, $slogan, $color, $logo, $background, $baseUrl, array $expected) {
+		$this->theming->expects($this->once())
+			->method('getName')
+			->willReturn($name);
+		$this->theming->expects($this->once())
+			->method('getBaseUrl')
+			->willReturn($url);
+		$this->theming->expects($this->once())
+			->method('getSlogan')
+			->willReturn($slogan);
+		$this->theming->expects($this->once())
+			->method('getMailHeaderColor')
+			->willReturn($color);
+		$this->theming->expects($this->once())
+			->method('getLogo')
+			->willReturn($logo);
+		$this->theming->expects($this->once())
+			->method('getBackground')
+			->willReturn($background);
+
+		$this->url->expects($this->exactly(2))
+			->method('getAbsoluteURL')
+			->willReturnCallback(function($url) use($baseUrl) {
+				return $baseUrl . $url;
+			});
+
+		$this->assertEquals(['theming' => $expected], $this->capabilities->getCapabilities());
+	}
+}

--- a/apps/theming/tests/CapabilitiesTest.php
+++ b/apps/theming/tests/CapabilitiesTest.php
@@ -36,9 +36,6 @@ class CapabilitiesTest extends TestCase  {
 	/** @var ThemingDefaults|\PHPUnit_Framework_MockObject_MockObject */
 	protected $theming;
 
-	/** @var IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
-	protected $url;
-
 	/** @var Capabilities */
 	protected $capabilities;
 
@@ -48,29 +45,23 @@ class CapabilitiesTest extends TestCase  {
 		$this->theming = $this->getMockBuilder('OCA\Theming\ThemingDefaults')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->url = $this->getMockBuilder('OCP\IURLGenerator')
-			->getMock();
 
-		$this->capabilities = new Capabilities($this->theming, $this->url);
+		$this->capabilities = new Capabilities($this->theming);
 	}
 
 	public function dataGetCapabilities() {
 		return [
-			['name', 'url', 'slogan', 'color', 'logo', 'background', 'http://absolute/', [
+			['name', 'url', 'slogan', 'color', [
 				'name' => 'name',
 				'url' => 'url',
 				'slogan' => 'slogan',
 				'color' => 'color',
-				'logo' => 'http://absolute/logo',
-				'background' => 'http://absolute/background',
 			]],
-			['name1', 'url2', 'slogan3', 'color4', 'logo5', 'background6', 'http://localhost/', [
+			['name1', 'url2', 'slogan3', 'color4', [
 				'name' => 'name1',
 				'url' => 'url2',
 				'slogan' => 'slogan3',
 				'color' => 'color4',
-				'logo' => 'http://localhost/logo5',
-				'background' => 'http://localhost/background6',
 			]],
 		];
 	}
@@ -81,12 +72,9 @@ class CapabilitiesTest extends TestCase  {
 	 * @param string $url
 	 * @param string $slogan
 	 * @param string $color
-	 * @param string $logo
-	 * @param string $background
-	 * @param string $baseUrl
 	 * @param string[] $expected
 	 */
-	public function testGetCapabilities($name, $url, $slogan, $color, $logo, $background, $baseUrl, array $expected) {
+	public function testGetCapabilities($name, $url, $slogan, $color, array $expected) {
 		$this->theming->expects($this->once())
 			->method('getName')
 			->willReturn($name);
@@ -99,18 +87,6 @@ class CapabilitiesTest extends TestCase  {
 		$this->theming->expects($this->once())
 			->method('getMailHeaderColor')
 			->willReturn($color);
-		$this->theming->expects($this->once())
-			->method('getLogo')
-			->willReturn($logo);
-		$this->theming->expects($this->once())
-			->method('getBackground')
-			->willReturn($background);
-
-		$this->url->expects($this->exactly(2))
-			->method('getAbsoluteURL')
-			->willReturnCallback(function($url) use($baseUrl) {
-				return $baseUrl . $url;
-			});
 
 		$this->assertEquals(['theming' => $expected], $this->capabilities->getCapabilities());
 	}

--- a/apps/theming/tests/CapabilitiesTest.php
+++ b/apps/theming/tests/CapabilitiesTest.php
@@ -22,8 +22,7 @@
 namespace OCA\Theming\Tests;
 
 use OCA\Theming\Capabilities;
-use OCA\Theming\ThemingDefaults;
-use OCP\IURLGenerator;
+use OCA\Theming\Template;
 use Test\TestCase;
 
 /**
@@ -33,7 +32,7 @@ use Test\TestCase;
  * @package OCA\Theming\Tests
  */
 class CapabilitiesTest extends TestCase  {
-	/** @var ThemingDefaults|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var Template|\PHPUnit_Framework_MockObject_MockObject */
 	protected $theming;
 
 	/** @var Capabilities */
@@ -42,7 +41,7 @@ class CapabilitiesTest extends TestCase  {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->theming = $this->getMockBuilder('OCA\Theming\ThemingDefaults')
+		$this->theming = $this->getMockBuilder('OCA\Theming\Template')
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/apps/theming/tests/CapabilitiesTest.php
+++ b/apps/theming/tests/CapabilitiesTest.php
@@ -22,17 +22,8 @@
 namespace OCA\Theming\Tests;
 
 use OCA\Theming\Capabilities;
-use OCA\Theming\Controller\ThemingController;
-use OCA\Theming\Settings\Admin;
-use OCA\Theming\Settings\Section;
 use OCA\Theming\ThemingDefaults;
-use OCA\Theming\Util;
-use OCP\AppFramework\App;
-use OCP\Capabilities\ICapability;
-use OCP\IL10N;
 use OCP\IURLGenerator;
-use OCP\Settings\ISection;
-use OCP\Settings\ISettings;
 use Test\TestCase;
 
 /**
@@ -54,10 +45,10 @@ class CapabilitiesTest extends TestCase  {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->theming = $this->getMockBuilder(ThemingDefaults::class)
+		$this->theming = $this->getMockBuilder('OCA\Theming\ThemingDefaults')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->url = $this->getMockBuilder(IURLGenerator::class)
+		$this->url = $this->getMockBuilder('OCP\IURLGenerator')
 			->getMock();
 
 		$this->capabilities = new Capabilities($this->theming, $this->url);

--- a/apps/theming/tests/ServicesTest.php
+++ b/apps/theming/tests/ServicesTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Theming\Tests;
+
+use OCA\Theming\Capabilities;
+use OCA\Theming\Controller\ThemingController;
+use OCA\Theming\Settings\Admin;
+use OCA\Theming\Settings\Section;
+use OCA\Theming\ThemingDefaults;
+use OCA\Theming\Util;
+use OCP\AppFramework\App;
+use OCP\Capabilities\ICapability;
+use OCP\IL10N;
+use OCP\Settings\ISection;
+use OCP\Settings\ISettings;
+use Test\TestCase;
+
+/**
+ * Class ServicesTest
+ *
+ * @group DB
+ * @package OCA\Theming\Tests
+ */
+class ServicesTest extends TestCase  {
+	/** @var \OCA\Activity\AppInfo\Application */
+	protected $app;
+
+	/** @var \OCP\AppFramework\IAppContainer */
+	protected $container;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->app = new App('theming');
+		$this->container = $this->app->getContainer();
+	}
+
+	public function queryData() {
+		return [
+			[IL10N::class],
+
+			// lib/
+			[Capabilities::class],
+			[Capabilities::class, ICapability::class],
+			[ThemingDefaults::class],
+			[ThemingDefaults::class, \OC_Defaults::class],
+			[Util::class],
+
+			// Controller
+			[ThemingController::class, ThemingController::class],
+
+			// Settings
+			[Admin::class],
+			[Admin::class, ISettings::class],
+			[Section::class],
+			[Section::class, ISection::class],
+		];
+	}
+
+	/**
+	 * @dataProvider queryData
+	 * @param string $service
+	 * @param string $expected
+	 */
+	public function testContainerQuery($service, $expected = null) {
+		if ($expected === null) {
+			$expected = $service;
+		}
+		$this->assertTrue($this->container->query($service) instanceof $expected);
+	}
+}

--- a/apps/theming/tests/ServicesTest.php
+++ b/apps/theming/tests/ServicesTest.php
@@ -50,18 +50,11 @@ class ServicesTest extends TestCase  {
 			// lib/
 			['OCA\Theming\Capabilities'],
 			['OCA\Theming\Capabilities', 'OCP\Capabilities\ICapability'],
-			['OCA\Theming\ThemingDefaults'],
-			['OCA\Theming\ThemingDefaults', 'OC_Defaults'],
-			['OCA\Theming\Util'],
+			['OCA\Theming\Template'],
+			['OCA\Theming\Template', 'OC_Defaults'],
 
-			// Controller
+			// controller/
 			['OCA\Theming\Controller\ThemingController'],
-
-			// Settings
-			['OCA\Theming\Settings\Admin'],
-			['OCA\Theming\Settings\Admin', 'OCP\Settings\ISettings'],
-			['OCA\Theming\Settings\Section'],
-			['OCA\Theming\Settings\Section', 'OCP\Settings\ISection'],
 		];
 	}
 

--- a/apps/theming/tests/ServicesTest.php
+++ b/apps/theming/tests/ServicesTest.php
@@ -21,17 +21,7 @@
 
 namespace OCA\Theming\Tests;
 
-use OCA\Theming\Capabilities;
-use OCA\Theming\Controller\ThemingController;
-use OCA\Theming\Settings\Admin;
-use OCA\Theming\Settings\Section;
-use OCA\Theming\ThemingDefaults;
-use OCA\Theming\Util;
 use OCP\AppFramework\App;
-use OCP\Capabilities\ICapability;
-use OCP\IL10N;
-use OCP\Settings\ISection;
-use OCP\Settings\ISettings;
 use Test\TestCase;
 
 /**
@@ -55,23 +45,23 @@ class ServicesTest extends TestCase  {
 
 	public function queryData() {
 		return [
-			[IL10N::class],
+			['OCP\IL10N'],
 
 			// lib/
-			[Capabilities::class],
-			[Capabilities::class, ICapability::class],
-			[ThemingDefaults::class],
-			[ThemingDefaults::class, \OC_Defaults::class],
-			[Util::class],
+			['OCA\Theming\Capabilities'],
+			['OCA\Theming\Capabilities', 'OCP\Capabilities\ICapability'],
+			['OCA\Theming\ThemingDefaults'],
+			['OCA\Theming\ThemingDefaults', 'OC_Defaults'],
+			['OCA\Theming\Util'],
 
 			// Controller
-			[ThemingController::class, ThemingController::class],
+			['OCA\Theming\Controller\ThemingController'],
 
 			// Settings
-			[Admin::class],
-			[Admin::class, ISettings::class],
-			[Section::class],
-			[Section::class, ISection::class],
+			['OCA\Theming\Settings\Admin'],
+			['OCA\Theming\Settings\Admin', 'OCP\Settings\ISettings'],
+			['OCA\Theming\Settings\Section'],
+			['OCA\Theming\Settings\Section', 'OCP\Settings\ISection'],
 		];
 	}
 


### PR DESCRIPTION
Backport #1272 
- Restored 5.4 and 5.5 compatibility
- Logo and Background are not available in 10 and 9

@MorrisJobke @rullzer 
