### PR TITLE
Allow status.php before install

### DIFF
--- a/core/Command/Status.php
+++ b/core/Command/Status.php
@@ -38,11 +38,13 @@ class Status extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
+		$installed = (bool) \OC::$server->getConfig()->getSystemValue('installed', false);
+
 		$values = array(
-			'installed' => (bool) \OC::$server->getConfig()->getSystemValue('installed', false),
+			'installed' => $installed,
 			'version' => implode('.', \OCP\Util::getVersion()),
 			'versionstring' => \OC_Util::getVersionString(),
-			'edition' => \OC_Util::getEditionString(),
+			'edition' => $installed ? \OC_Util::getEditionString() : '',
 		);
 
 		$this->writeArrayInOutputFormat($input, $output, $values);

--- a/lib/base.php
+++ b/lib/base.php
@@ -264,7 +264,7 @@ class OC {
 			return;
 		}
 		// Redirect to installer if not installed
-		if (!\OC::$server->getSystemConfig()->getValue('installed', false) && OC::$SUBURI != '/index.php') {
+		if (!\OC::$server->getSystemConfig()->getValue('installed', false) && OC::$SUBURI !== '/index.php' && OC::$SUBURI !== '/status.php') {
 			if (OC::$CLI) {
 				throw new Exception('Not installed');
 			} else {

--- a/status.php
+++ b/status.php
@@ -43,7 +43,7 @@ try {
 		'maintenance' => $maintenance,
 		'version'=>implode('.', \OCP\Util::getVersion()),
 		'versionstring'=>OC_Util::getVersionString(),
-		'edition'=>OC_Util::getEditionString(),
+		'edition'=> $installed ? OC_Util::getEditionString() : '',
 		'productname'=>$defaults->getName());
 	if (OC::$CLI) {
 		print_r($values);


### PR DESCRIPTION
### Steps
1. Remove config.php
2. `curl -v http://nextcloud11.local/status.php`
### Expected

```
{"installed":false,"maintenance":false,"version":"9.2.0.3","versionstring":"11.0 alpha","edition":"","productname":"Nextcloud"}
```
### Actual

```
HTTP/1.1 302 Found
```

@MorrisJobke @LukasReschke 
@longsleep as discussed 
