### PR TITLE
Correctly remove admin sections and settings

### DIFF
--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -105,10 +105,10 @@ class Manager implements IManager {
 		$appInfo = \OC_App::getAppInfo($appId); // hello static legacy
 
 		if(isset($appInfo['settings'][IManager::KEY_ADMIN_SECTION])) {
-			$this->remove(self::TABLE_ADMIN_SECTIONS, $appInfo['settings'][IManager::KEY_ADMIN_SECTION]);
+			$this->remove(self::TABLE_ADMIN_SECTIONS, trim($appInfo['settings'][IManager::KEY_ADMIN_SECTION], '\\'));
 		}
 		if(isset($appInfo['settings'][IManager::KEY_ADMIN_SETTINGS])) {
-			$this->remove(self::TABLE_ADMIN_SETTINGS, $appInfo['settings'][IManager::KEY_ADMIN_SETTINGS]);
+			$this->remove(self::TABLE_ADMIN_SETTINGS, trim($appInfo['settings'][IManager::KEY_ADMIN_SETTINGS], '\\'));
 		}
 	}
 
@@ -302,7 +302,7 @@ class Manager implements IManager {
 
 		if(!$settings instanceof ISettings) {
 			$this->log->error(
-				'Admin section instance must implement \OCP\ISection. Invalid class: {class}',
+				'Admin section instance must implement \OCP\Settings\ISection. Invalid class: {class}',
 				['class' => $settingsClassName]
 			);
 			return;


### PR DESCRIPTION
### Steps
1. Enable "Server info" app
2. Disable "Server info" app
3. Go to the admin page with the log
4. Refresh page

See https://help.nextcloud.com/t/usage-report-0-1-5-error-in-logs-if-we-disable-this-app/2963
### Expected

nothing
### Actually

Each page refresh logs a new QueryException

We can't really create an update step for this, because on update apps are disabled and therefor we can't check, if the class would exist. So manual clean up is required.
