### PR TITLE
[stable10] Move navigation entries without order to the end

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -508,7 +508,15 @@ class OC_App {
 		}
 		unset($navEntry);
 
-		usort($list, create_function('$a, $b', 'if( $a["order"] == $b["order"] ) {return 0;}elseif( $a["order"] < $b["order"] ) {return -1;}else{return 1;}'));
+		usort($list, function($a, $b) {
+			if (isset($a['order']) && isset($b['order'])) {
+				return ($a['order'] < $b['order']) ? -1 : 1;
+			} else if (isset($a['order']) || isset($b['order'])) {
+				return isset($a['order']) ? -1 : 1;
+			} else {
+				return ($a['name'] < $b['name']) ? -1 : 1;
+			}
+		});
 
 		return $list;
 	}


### PR DESCRIPTION
- backport of #1235 

cc @nickvergessen @LukasReschke @rullzer 

This fixes the log spam with:

```
Undefined index: order at lib/private/legacy/app.php(511) : runtime-created function#1
```

cc @karlitschek 
