### PR TITLE
Fix required permissions for webdav move and copy

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ObjectTree.php
+++ b/apps/dav/lib/Connector/Sabre/ObjectTree.php
@@ -205,7 +205,11 @@ class ObjectTree extends \Sabre\DAV\Tree {
 
 		$infoDestination = $this->fileView->getFileInfo(dirname($destinationPath));
 		$infoSource = $this->fileView->getFileInfo($sourcePath);
-		$destinationPermission = $infoDestination && $infoDestination->isUpdateable();
+		if ($this->fileView->file_exists($destinationPath)) {
+			$destinationPermission = $infoDestination && $infoDestination->isUpdateable();
+		} else {
+			$destinationPermission = $infoDestination && $infoDestination->isCreatable();
+		}
 		$sourcePermission =  $infoSource && $infoSource->isDeletable();
 
 		if (!$destinationPermission || !$sourcePermission) {
@@ -298,7 +302,12 @@ class ObjectTree extends \Sabre\DAV\Tree {
 
 
 		$info = $this->fileView->getFileInfo(dirname($destination));
-		if ($info && !$info->isUpdateable()) {
+		if ($this->fileView->file_exists($destination)) {
+			$destinationPermission = $info && $info->isUpdateable();
+		} else {
+			$destinationPermission = $info && $info->isCreatable();
+		}
+		if (!$destinationPermission) {
 			throw new Forbidden('No permissions to copy object.');
 		}
 

--- a/apps/dav/lib/Connector/Sabre/ObjectTree.php
+++ b/apps/dav/lib/Connector/Sabre/ObjectTree.php
@@ -204,13 +204,18 @@ class ObjectTree extends \Sabre\DAV\Tree {
 		}
 
 		$infoDestination = $this->fileView->getFileInfo(dirname($destinationPath));
-		$infoSource = $this->fileView->getFileInfo($sourcePath);
-		if ($this->fileView->file_exists($destinationPath)) {
-			$destinationPermission = $infoDestination && $infoDestination->isUpdateable();
+		if (dirname($destinationPath) === dirname($sourcePath)) {
+			$sourcePermission = $infoDestination && $infoDestination->isUpdateable();
+			$destinationPermission = $sourcePermission;
 		} else {
-			$destinationPermission = $infoDestination && $infoDestination->isCreatable();
+			$infoSource = $this->fileView->getFileInfo($sourcePath);
+			if ($this->fileView->file_exists($destinationPath)) {
+				$destinationPermission = $infoDestination && $infoDestination->isUpdateable();
+			} else {
+				$destinationPermission = $infoDestination && $infoDestination->isCreatable();
+			}
+			$sourcePermission =  $infoSource && $infoSource->isDeletable();
 		}
-		$sourcePermission =  $infoSource && $infoSource->isDeletable();
 
 		if (!$destinationPermission || !$sourcePermission) {
 			throw new Forbidden('No permissions to move object.');


### PR DESCRIPTION
3571207bd956de5dc8aece2ba879f31f3696fef6 broke the `test_sharePermissions.py` smashbox test

@rullzer @MorrisJobke @schiessle 

Should backport to 10 and 9
