### PR TITLE
Fix update notification

### DIFF
--- a/apps/updatenotification/lib/Controller/AdminController.php
+++ b/apps/updatenotification/lib/Controller/AdminController.php
@@ -128,7 +128,7 @@ class AdminController extends Controller implements ISettings {
 	public function setChannel($channel) {
 		\OCP\Util::setChannel($channel);
 		$this->config->setAppValue('core', 'lastupdatedat', 0);
-		return new DataResponse(['status' => 'success', 'data' => ['message' => $this->l10n->t('Updated channel')]]);
+		return new DataResponse(['status' => 'success', 'data' => ['message' => $this->l10n->t('Channel updated')]]);
 	}
 
 	/**

--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -32,7 +32,7 @@
 				</option>
 			<?php } ?>
 		</select>
-		<span id="channel_save_msg"></span>
+		<span id="channel_save_msg" class="msg"></span>
 	</p>
 	<p>
 		<em><?php p($l->t('You can always update to a newer version / experimental channel. But you can never downgrade to a more stable channel.')); ?></em>

--- a/lib/private/Updater/VersionCheck.php
+++ b/lib/private/Updater/VersionCheck.php
@@ -59,7 +59,7 @@ class VersionCheck {
 			return json_decode($this->config->getAppValue('core', 'lastupdateResult'), true);
 		}
 
-		$updaterUrl = $this->config->getSystemValue('updater.server.url', 'https://updates.owncloud.com/server/');
+		$updaterUrl = $this->config->getSystemValue('updater.server.url', 'https://updates.nextcloud.com/server/');
 
 		$this->config->setAppValue('core', 'lastupdatedat', time());
 

--- a/tests/lib/Updater/VersionCheckTest.php
+++ b/tests/lib/Updater/VersionCheckTest.php
@@ -91,8 +91,8 @@ class VersionCheckTest extends \Test\TestCase {
 		$this->config
 			->expects($this->at(1))
 			->method('getSystemValue')
-			->with('updater.server.url', 'https://updates.owncloud.com/server/')
-			->willReturn('https://updates.owncloud.com/server/');
+			->with('updater.server.url', 'https://updates.nextcloud.com/server/')
+			->willReturn('https://updates.nextcloud.com/server/');
 		$this->config
 			->expects($this->at(2))
 			->method('setAppValue')
@@ -122,7 +122,7 @@ class VersionCheckTest extends \Test\TestCase {
 		$this->updater
 			->expects($this->once())
 			->method('getUrlContent')
-			->with($this->buildUpdateUrl('https://updates.owncloud.com/server/'))
+			->with($this->buildUpdateUrl('https://updates.nextcloud.com/server/'))
 			->will($this->returnValue($updateXml));
 
 		$this->assertSame($expectedResult, $this->updater->check());
@@ -137,8 +137,8 @@ class VersionCheckTest extends \Test\TestCase {
 		$this->config
 			->expects($this->at(1))
 			->method('getSystemValue')
-			->with('updater.server.url', 'https://updates.owncloud.com/server/')
-			->willReturn('https://updates.owncloud.com/server/');
+			->with('updater.server.url', 'https://updates.nextcloud.com/server/')
+			->willReturn('https://updates.nextcloud.com/server/');
 		$this->config
 			->expects($this->at(2))
 			->method('setAppValue')
@@ -162,7 +162,7 @@ class VersionCheckTest extends \Test\TestCase {
 		$this->updater
 			->expects($this->once())
 			->method('getUrlContent')
-			->with($this->buildUpdateUrl('https://updates.owncloud.com/server/'))
+			->with($this->buildUpdateUrl('https://updates.nextcloud.com/server/'))
 			->will($this->returnValue($updateXml));
 
 		$this->assertSame([], $this->updater->check());
@@ -184,8 +184,8 @@ class VersionCheckTest extends \Test\TestCase {
 		$this->config
 			->expects($this->at(1))
 			->method('getSystemValue')
-			->with('updater.server.url', 'https://updates.owncloud.com/server/')
-			->willReturn('https://updates.owncloud.com/server/');
+			->with('updater.server.url', 'https://updates.nextcloud.com/server/')
+			->willReturn('https://updates.nextcloud.com/server/');
 		$this->config
 			->expects($this->at(2))
 			->method('setAppValue')
@@ -211,7 +211,7 @@ class VersionCheckTest extends \Test\TestCase {
 		$this->updater
 			->expects($this->once())
 			->method('getUrlContent')
-			->with($this->buildUpdateUrl('https://updates.owncloud.com/server/'))
+			->with($this->buildUpdateUrl('https://updates.nextcloud.com/server/'))
 			->will($this->returnValue($updateXml));
 
 		$this->assertSame($expectedResult, $this->updater->check());
@@ -228,8 +228,8 @@ class VersionCheckTest extends \Test\TestCase {
 		$this->config
 			->expects($this->at(1))
 			->method('getSystemValue')
-			->with('updater.server.url', 'https://updates.owncloud.com/server/')
-			->willReturn('https://updates.owncloud.com/server/');
+			->with('updater.server.url', 'https://updates.nextcloud.com/server/')
+			->willReturn('https://updates.nextcloud.com/server/');
 		$this->config
 			->expects($this->at(2))
 			->method('setAppValue')
@@ -253,7 +253,7 @@ class VersionCheckTest extends \Test\TestCase {
 		$this->updater
 			->expects($this->once())
 			->method('getUrlContent')
-			->with($this->buildUpdateUrl('https://updates.owncloud.com/server/'))
+			->with($this->buildUpdateUrl('https://updates.nextcloud.com/server/'))
 			->will($this->returnValue($updateXml));
 
 		$this->assertSame($expectedResult, $this->updater->check());


### PR DESCRIPTION
- fixes the layout of the success message:

<img width="326" alt="bildschirmfoto 2016-09-07 um 16 42 51" src="https://cloud.githubusercontent.com/assets/245432/18316243/254ee214-751a-11e6-8922-fca25a10d104.png">

to

<img width="346" alt="bildschirmfoto 2016-09-07 um 16 35 12" src="https://cloud.githubusercontent.com/assets/245432/18316248/2a992504-751a-11e6-927a-496fa15390f1.png">
- updates the default updater URL to our server - this server is currently returning nothing, but this allows us in the future to provide update notifications
- I tested the update server URL and it has no negative impact, that it simply provides an empty response

cc @LukasReschke @nextcloud/designers @nickvergessen @rullzer @karlitschek 

@karlitschek I would like to backport at least the URL change to stable9 and stable10
