### PR TITLE
dont show shares you own in "shared with you"

### DIFF
--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -42,6 +42,7 @@ use OCP\Share\IManager;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\Exceptions\GenericShareException;
 use OCP\Lock\ILockingProvider;
+use OCP\Share\IShare;
 
 /**
  * Class Share20OCS
@@ -419,6 +420,10 @@ class Share20OCS extends OCSController {
 		$groupShares = $this->shareManager->getSharedWith($this->currentUser->getUID(), \OCP\Share::SHARE_TYPE_GROUP, $node, -1, 0);
 
 		$shares = array_merge($userShares, $groupShares);
+
+		$shares = array_filter($shares, function(IShare $share) {
+			return $share->getShareOwner() !== $this->currentUser->getUID();
+		});
 
 		$formatted = [];
 		foreach ($shares as $share) {


### PR DESCRIPTION
You can be the recipient of a share if it's shared with a group you're part of, it's already filtered out from the filesystem but atm it still shows up in the "shared with you" list which adds confusion

Fix #1256 
