### PR TITLE
[stable9] Fix layout of success message and text

### DIFF
--- a/apps/updatenotification/controller/admincontroller.php
+++ b/apps/updatenotification/controller/admincontroller.php
@@ -148,7 +148,7 @@ class AdminController extends Controller {
 	public function setChannel($channel) {
 		\OCP\Util::setChannel($channel);
 		$this->config->setAppValue('core', 'lastupdatedat', 0);
-		return new DataResponse(['status' => 'success', 'data' => ['message' => $this->l10n->t('Updated channel')]]);
+		return new DataResponse(['status' => 'success', 'data' => ['message' => $this->l10n->t('Channel updated')]]);
 	}
 
 	/**

--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -40,7 +40,7 @@
 				</option>
 			<?php } ?>
 		</select>
-		<span id="channel_save_msg"></span>
+		<span id="channel_save_msg" class="msg"></span>
 	</p>
 	<p>
 		<em><?php p($l->t('You can always update to a newer version / experimental channel. But you can never downgrade to a more stable channel.')); ?></em>


### PR DESCRIPTION
- backport of #1307 
- tested and works
- URL was correct already

cc @LukasReschke @nextcloud/designers @nickvergessen @rullzer @karlitschek @MariusBluem 
