### PR TITLE
Fix PHPUnit warnings on NODB runs

### DIFF
--- a/apps/encryption/tests/HookManagerTest.php
+++ b/apps/encryption/tests/HookManagerTest.php
@@ -26,6 +26,7 @@ namespace OCA\Encryption\Tests;
 
 
 use OCA\Encryption\HookManager;
+use OCP\IConfig;
 use Test\TestCase;
 
 class HookManagerTest extends TestCase {
@@ -42,7 +43,7 @@ class HookManagerTest extends TestCase {
 		self::$instance->registerHook([
 			$this->getMockBuilder('OCA\Encryption\Hooks\Contracts\IHook')->disableOriginalConstructor()->getMock(),
 			$this->getMockBuilder('OCA\Encryption\Hooks\Contracts\IHook')->disableOriginalConstructor()->getMock(),
-			$this->getMock('NotIHook')
+			$this->createMock(IConfig::class)
 		]);
 
 		$hookInstances = self::invokePrivate(self::$instance, 'hookInstances');

--- a/apps/twofactor_backupcodes/tests/Unit/Service/BackupCodeStorageTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Service/BackupCodeStorageTest.php
@@ -170,7 +170,7 @@ class BackupCodeStorageTest extends TestCase {
 			->will($this->returnValue($codes));
 		$this->hasher->expects($this->once())
 			->method('verify')
-			->with('CHALLENGE', 'HASHEDVALUE')
+			->with('CHALLENGE', 'HASHEDVALUE', $this->anything())
 			->will($this->returnValue(true));
 		$this->mapper->expects($this->once())
 			->method('update')
@@ -195,7 +195,7 @@ class BackupCodeStorageTest extends TestCase {
 			->with($user)
 			->will($this->returnValue($codes));
 		$this->hasher->expects($this->never())
-			->method('verifiy');
+			->method('verify');
 		$this->mapper->expects($this->never())
 			->method('update');
 

--- a/tests/Settings/Controller/AuthSettingsControllerTest.php
+++ b/tests/Settings/Controller/AuthSettingsControllerTest.php
@@ -25,9 +25,15 @@ namespace Test\Settings\Controller;
 use OC\AppFramework\Http;
 use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\DefaultToken;
+use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
 use OC\Settings\Controller\AuthSettingsController;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Security\ISecureRandom;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 use Test\TestCase;
 
@@ -45,13 +51,13 @@ class AuthSettingsControllerTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->request = $this->getMock('\OCP\IRequest');
-		$this->tokenProvider = $this->getMock('\OC\Authentication\Token\IProvider');
-		$this->userManager = $this->getMock('\OCP\IUserManager');
-		$this->session = $this->getMock('\OCP\ISession');
-		$this->secureRandom = $this->getMock('\OCP\Security\ISecureRandom');
+		$this->request = $this->createMock(IRequest::class);
+		$this->tokenProvider = $this->createMock(IProvider::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->session = $this->createMock(ISession::class);
+		$this->secureRandom = $this->createMock(ISecureRandom::class);
 		$this->uid = 'jane';
-		$this->user = $this->getMock('\OCP\IUser');
+		$this->user = $this->createMock(IUser::class);
 
 		$this->controller = new AuthSettingsController('core', $this->request, $this->tokenProvider, $this->userManager, $this->session, $this->secureRandom, $this->uid);
 	}
@@ -105,8 +111,8 @@ class AuthSettingsControllerTest extends TestCase {
 
 	public function testCreate() {
 		$name = 'Nexus 4';
-		$sessionToken = $this->getMock('\OC\Authentication\Token\IToken');
-		$deviceToken = $this->getMock('\OC\Authentication\Token\IToken');
+		$sessionToken = $this->createMock(IToken::class);
+		$deviceToken = $this->createMock(IToken::class);
 		$password = '123456';
 
 		$this->session->expects($this->once())
@@ -175,7 +181,7 @@ class AuthSettingsControllerTest extends TestCase {
 
 	public function testDestroy() {
 		$id = 123;
-		$user = $this->getMock('\OCP\IUser');
+		$user = $this->createMock(IUser::class);
 
 		$this->userManager->expects($this->once())
 			->method('get')

--- a/tests/lib/AppFramework/Db/MapperTestUtility.php
+++ b/tests/lib/AppFramework/Db/MapperTestUtility.php
@@ -49,7 +49,7 @@ abstract class MapperTestUtility extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->query = $this->getMock('\PDOStatement');
+		$this->query = $this->createMock('\PDOStatement');
 		$this->queryAt = 0;
 		$this->prepareAt = 0;
 		$this->iterators = [];

--- a/tests/lib/Command/Integrity/SignAppTest.php
+++ b/tests/lib/Command/Integrity/SignAppTest.php
@@ -24,6 +24,8 @@ use OC\Core\Command\Integrity\SignApp;
 use OC\IntegrityCheck\Checker;
 use OC\IntegrityCheck\Helpers\FileAccessHelper;
 use OCP\IURLGenerator;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class SignAppTest extends TestCase {
@@ -38,12 +40,9 @@ class SignAppTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->checker = $this->getMockBuilder('\OC\IntegrityCheck\Checker')
-			->disableOriginalConstructor()->getMock();
-		$this->fileAccessHelper = $this->getMockBuilder('\OC\IntegrityCheck\Helpers\FileAccessHelper')
-			->disableOriginalConstructor()->getMock();
-		$this->urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
-				->disableOriginalConstructor()->getMock();
+		$this->checker = $this->createMock(Checker::class);
+		$this->fileAccessHelper = $this->createMock(FileAccessHelper::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->signApp = new SignApp(
 			$this->checker,
 			$this->fileAccessHelper,
@@ -52,8 +51,8 @@ class SignAppTest extends TestCase {
 	}
 
 	public function testExecuteWithMissingPath() {
-		$inputInterface = $this->getMock('\Symfony\Component\Console\Input\InputInterface');
-		$outputInterface = $this->getMock('\Symfony\Component\Console\Output\OutputInterface');
+		$inputInterface = $this->createMock(InputInterface::class);
+		$outputInterface = $this->createMock(OutputInterface::class);
 
 		$inputInterface
 			->expects($this->at(0))
@@ -80,8 +79,8 @@ class SignAppTest extends TestCase {
 	}
 
 	public function testExecuteWithMissingPrivateKey() {
-		$inputInterface = $this->getMock('\Symfony\Component\Console\Input\InputInterface');
-		$outputInterface = $this->getMock('\Symfony\Component\Console\Output\OutputInterface');
+		$inputInterface = $this->createMock(InputInterface::class);
+		$outputInterface = $this->createMock(OutputInterface::class);
 
 		$inputInterface
 			->expects($this->at(0))
@@ -108,8 +107,8 @@ class SignAppTest extends TestCase {
 	}
 
 	public function testExecuteWithMissingCertificate() {
-		$inputInterface = $this->getMock('\Symfony\Component\Console\Input\InputInterface');
-		$outputInterface = $this->getMock('\Symfony\Component\Console\Output\OutputInterface');
+		$inputInterface = $this->createMock(InputInterface::class);
+		$outputInterface = $this->createMock(OutputInterface::class);
 
 		$inputInterface
 			->expects($this->at(0))
@@ -136,8 +135,8 @@ class SignAppTest extends TestCase {
 	}
 
 	public function testExecuteWithNotExistingPrivateKey() {
-		$inputInterface = $this->getMock('\Symfony\Component\Console\Input\InputInterface');
-		$outputInterface = $this->getMock('\Symfony\Component\Console\Output\OutputInterface');
+		$inputInterface = $this->createMock(InputInterface::class);
+		$outputInterface = $this->createMock(OutputInterface::class);
 
 		$inputInterface
 			->expects($this->at(0))
@@ -170,8 +169,8 @@ class SignAppTest extends TestCase {
 	}
 
 	public function testExecuteWithNotExistingCertificate() {
-		$inputInterface = $this->getMock('\Symfony\Component\Console\Input\InputInterface');
-		$outputInterface = $this->getMock('\Symfony\Component\Console\Output\OutputInterface');
+		$inputInterface = $this->createMock(InputInterface::class);
+		$outputInterface = $this->createMock(OutputInterface::class);
 
 		$inputInterface
 			->expects($this->at(0))
@@ -209,8 +208,8 @@ class SignAppTest extends TestCase {
 	}
 
 	public function testExecute() {
-		$inputInterface = $this->getMock('\Symfony\Component\Console\Input\InputInterface');
-		$outputInterface = $this->getMock('\Symfony\Component\Console\Output\OutputInterface');
+		$inputInterface = $this->createMock(InputInterface::class);
+		$outputInterface = $this->createMock(OutputInterface::class);
 
 		$inputInterface
 			->expects($this->at(0))

--- a/tests/lib/Command/Integrity/SignCoreTest.php
+++ b/tests/lib/Command/Integrity/SignCoreTest.php
@@ -23,6 +23,8 @@ namespace Test\Command\Integrity;
 use OC\Core\Command\Integrity\SignCore;
 use OC\IntegrityCheck\Checker;
 use OC\IntegrityCheck\Helpers\FileAccessHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class SignCoreTest extends TestCase {
@@ -35,10 +37,8 @@ class SignCoreTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->checker = $this->getMockBuilder('\OC\IntegrityCheck\Checker')
-			->disableOriginalConstructor()->getMock();
-		$this->fileAccessHelper = $this->getMockBuilder('\OC\IntegrityCheck\Helpers\FileAccessHelper')
-			->disableOriginalConstructor()->getMock();
+		$this->checker = $this->createMock(Checker::class);
+		$this->fileAccessHelper = $this->createMock(FileAccessHelper::class);
 		$this->signCore = new SignCore(
 			$this->checker,
 			$this->fileAccessHelper
@@ -46,8 +46,8 @@ class SignCoreTest extends TestCase {
 	}
 
 	public function testExecuteWithMissingPrivateKey() {
-		$inputInterface = $this->getMock('\Symfony\Component\Console\Input\InputInterface');
-		$outputInterface = $this->getMock('\Symfony\Component\Console\Output\OutputInterface');
+		$inputInterface = $this->createMock(InputInterface::class);
+		$outputInterface = $this->createMock(OutputInterface::class);
 
 		$inputInterface
 			->expects($this->at(0))
@@ -69,8 +69,8 @@ class SignCoreTest extends TestCase {
 	}
 
 	public function testExecuteWithMissingCertificate() {
-		$inputInterface = $this->getMock('\Symfony\Component\Console\Input\InputInterface');
-		$outputInterface = $this->getMock('\Symfony\Component\Console\Output\OutputInterface');
+		$inputInterface = $this->createMock(InputInterface::class);
+		$outputInterface = $this->createMock(OutputInterface::class);
 
 		$inputInterface
 			->expects($this->at(0))
@@ -92,8 +92,8 @@ class SignCoreTest extends TestCase {
 	}
 
 	public function testExecuteWithNotExistingPrivateKey() {
-		$inputInterface = $this->getMock('\Symfony\Component\Console\Input\InputInterface');
-		$outputInterface = $this->getMock('\Symfony\Component\Console\Output\OutputInterface');
+		$inputInterface = $this->createMock(InputInterface::class);
+		$outputInterface = $this->createMock(OutputInterface::class);
 
 		$inputInterface
 			->expects($this->at(0))
@@ -126,8 +126,8 @@ class SignCoreTest extends TestCase {
 	}
 
 	public function testExecuteWithNotExistingCertificate() {
-		$inputInterface = $this->getMock('\Symfony\Component\Console\Input\InputInterface');
-		$outputInterface = $this->getMock('\Symfony\Component\Console\Output\OutputInterface');
+		$inputInterface = $this->createMock(InputInterface::class);
+		$outputInterface = $this->createMock(OutputInterface::class);
 
 		$inputInterface
 			->expects($this->at(0))
@@ -165,8 +165,8 @@ class SignCoreTest extends TestCase {
 	}
 
 	public function testExecute() {
-		$inputInterface = $this->getMock('\Symfony\Component\Console\Input\InputInterface');
-		$outputInterface = $this->getMock('\Symfony\Component\Console\Output\OutputInterface');
+		$inputInterface = $this->createMock(InputInterface::class);
+		$outputInterface = $this->createMock(OutputInterface::class);
 
 		$inputInterface
 			->expects($this->at(0))

--- a/tests/lib/Encryption/EncryptionWrapperTest.php
+++ b/tests/lib/Encryption/EncryptionWrapperTest.php
@@ -24,6 +24,9 @@ namespace Test\Encryption;
 
 
 use OC\Encryption\EncryptionWrapper;
+use OC\Encryption\Manager;
+use OC\Memcache\ArrayCache;
+use OCP\ILogger;
 use Test\TestCase;
 
 class EncryptionWrapperTest extends TestCase {
@@ -43,10 +46,10 @@ class EncryptionWrapperTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->arrayCache = $this->getMock('OC\Memcache\ArrayCache');
-		$this->manager = $this->getMockBuilder('OC\Encryption\Manager')
-			->disableOriginalConstructor()->getMock();
-		$this->logger = $this->getMock('OCP\ILogger');
+		$this->arrayCache = $this->createMock(ArrayCache::class);
+		$this->manager = $this->createMock(Manager::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->logger = $this->createMock(ILogger::class);
 
 		$this->instance = new EncryptionWrapper($this->arrayCache, $this->manager, $this->logger);
 	}

--- a/tests/lib/Encryption/ManagerTest.php
+++ b/tests/lib/Encryption/ManagerTest.php
@@ -3,6 +3,13 @@
 namespace Test\Encryption;
 
 use OC\Encryption\Manager;
+use OC\Encryption\Util;
+use OC\Files\View;
+use OC\Memcache\ArrayCache;
+use OCP\Encryption\IEncryptionModule;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\ILogger;
 use Test\TestCase;
 
 class ManagerTest extends TestCase {
@@ -30,12 +37,12 @@ class ManagerTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->config = $this->getMock('\OCP\IConfig');
-		$this->logger = $this->getMock('\OCP\ILogger');
-		$this->l10n = $this->getMock('\OCP\Il10n');
-		$this->view = $this->getMock('\OC\Files\View');
-		$this->util = $this->getMockBuilder('\OC\Encryption\Util')->disableOriginalConstructor()->getMock();
-		$this->arrayCache = $this->getMock('OC\Memcache\ArrayCache');
+		$this->config = $this->createMock(IConfig::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->view = $this->createMock(View::class);
+		$this->util = $this->createMock(Util::class);
+		$this->arrayCache = $this->createMock(ArrayCache::class);
 		$this->manager = new Manager($this->config, $this->logger, $this->l10n, $this->view, $this->util, $this->arrayCache);
 	}
 
@@ -50,7 +57,7 @@ class ManagerTest extends TestCase {
 
 	public function testManagerIsDisabledIfDisabledButModules() {
 		$this->config->expects($this->any())->method('getAppValue')->willReturn(false);
-		$em = $this->getMock('\OCP\Encryption\IEncryptionModule');
+		$em = $this->createMock(IEncryptionModule::class);
 		$em->expects($this->any())->method('getId')->willReturn('id');
 		$em->expects($this->any())->method('getDisplayName')->willReturn('TestDummyModule0');
 		$this->manager->registerEncryptionModule('id', 'TestDummyModule0', function() use ($em) {return $em;});
@@ -235,7 +242,7 @@ class ManagerTest extends TestCase {
 //	}
 
 	protected function addNewEncryptionModule(Manager $manager, $id) {
-		$encryptionModule = $this->getMock('\OCP\Encryption\IEncryptionModule');
+		$encryptionModule = $this->createMock(IEncryptionModule::class);
 		$encryptionModule->expects($this->any())
 			->method('getId')
 			->willReturn('ID' . $id);

--- a/tests/lib/Encryption/UtilTest.php
+++ b/tests/lib/Encryption/UtilTest.php
@@ -3,6 +3,7 @@
 namespace Test\Encryption;
 
 use OC\Encryption\Util;
+use OCP\Encryption\IEncryptionModule;
 use Test\TestCase;
 
 class UtilTest extends TestCase {
@@ -77,7 +78,7 @@ class UtilTest extends TestCase {
 	 */
 	public function testCreateHeader($expected, $header, $moduleId) {
 
-		$em = $this->getMock('\OCP\Encryption\IEncryptionModule');
+		$em = $this->createMock(IEncryptionModule::class);
 		$em->expects($this->any())->method('getId')->willReturn($moduleId);
 
 		$result = $this->util->createHeader($header, $em);
@@ -100,7 +101,7 @@ class UtilTest extends TestCase {
 
 		$header = array('header1' => 1, 'header2' => 2, 'oc_encryption_module' => 'foo');
 
-		$em = $this->getMock('\OCP\Encryption\IEncryptionModule');
+		$em = $this->createMock(IEncryptionModule::class);
 		$em->expects($this->any())->method('getId')->willReturn('moduleId');
 
 		$this->util->createHeader($header, $em);

--- a/tests/lib/FileChunkingTest.php
+++ b/tests/lib/FileChunkingTest.php
@@ -20,6 +20,8 @@
  */
 namespace Test;
 
+use OCP\ICache;
+
 class FileChunkingTest extends \Test\TestCase {
 
 	public function dataIsComplete() {
@@ -54,7 +56,7 @@ class FileChunkingTest extends \Test\TestCase {
 			]])
 			->getMock();
 
-		$cache = $this->getMock('\OCP\ICache');
+		$cache = $this->createMock(ICache::class);
 
 		$cache->expects($this->atLeastOnce())
 			->method('hasKey')

--- a/tests/lib/Files/Mount/MountPointTest.php
+++ b/tests/lib/Files/Mount/MountPointTest.php
@@ -8,15 +8,18 @@
 
 namespace Test\Files\Mount;
 
+use OC\Files\Storage\StorageFactory;
+use OCP\Files\Storage;
+
 class MountPointTest extends \Test\TestCase {
 
 	public function testGetStorage() {
-		$storage = $this->getMock('\OCP\Files\Storage');
+		$storage = $this->createMock(Storage::class);
 		$storage->expects($this->once())
 			->method('getId')
 			->will($this->returnValue(123));
 
-		$loader = $this->getMock('\OC\Files\Storage\StorageFactory');
+		$loader = $this->createMock(StorageFactory::class);
 		$loader->expects($this->once())
 			->method('wrap')
 			->will($this->returnValue($storage));
@@ -38,7 +41,7 @@ class MountPointTest extends \Test\TestCase {
 	}
 
 	public function testInvalidStorage() {
-		$loader = $this->getMock('\OC\Files\Storage\StorageFactory');
+		$loader = $this->createMock(StorageFactory::class);
 		$loader->expects($this->once())
 			->method('wrap')
 			->will($this->throwException(new \Exception('Test storage init exception')));

--- a/tests/lib/Files/Mount/ObjectHomeMountProviderTest.php
+++ b/tests/lib/Files/Mount/ObjectHomeMountProviderTest.php
@@ -24,9 +24,9 @@ class ObjectHomeMountProviderTest extends \Test\TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->config = $this->getMock('OCP\IConfig');
-		$this->user = $this->getMock('OCP\IUser');
-		$this->loader = $this->getMock('OCP\Files\Storage\IStorageFactory');
+		$this->config = $this->createMock(IConfig::class);
+		$this->user = $this->createMock(IUser::class);
+		$this->loader = $this->createMock(IStorageFactory::class);
 
 		$this->provider = new ObjectHomeMountProvider($this->config);
 	}

--- a/tests/lib/Files/ObjectStore/MapperTest.php
+++ b/tests/lib/Files/ObjectStore/MapperTest.php
@@ -22,6 +22,7 @@ namespace Test\Files\ObjectStore;
 
 
 use OC\Files\ObjectStore\Mapper;
+use OCP\IUser;
 
 class MapperTest extends \Test\TestCase {
 
@@ -39,7 +40,7 @@ class MapperTest extends \Test\TestCase {
 	 * @param string $expectedBucket
 	 */
 	public function testGetBucket($username, $expectedBucket) {
-		$user = $this->getMock('OCP\IUser');
+		$user = $this->createMock(IUser::class);
 		$user->method('getUID')
 			->willReturn($username);
 

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -5,7 +5,10 @@ namespace Test\Files\Storage\Wrapper;
 use OC\Encryption\Util;
 use OC\Files\Storage\Temporary;
 use OC\Files\View;
+use OC\Log;
+use OC\Memcache\ArrayCache;
 use OC\User\Manager;
+use OCP\Files\Cache\ICache;
 use Test\Files\Storage\Storage;
 
 class EncryptionTest extends Storage {
@@ -108,7 +111,7 @@ class EncryptionTest extends Storage {
 			->method('getEncryptionModule')
 			->willReturn($mockModule);
 
-		$this->arrayCache = $this->getMock('OC\Memcache\ArrayCache');
+		$this->arrayCache = $this->createMock(ArrayCache::class);
 		$this->config = $this->getMockBuilder('\OCP\IConfig')
 			->disableOriginalConstructor()
 			->getMock();
@@ -116,10 +119,10 @@ class EncryptionTest extends Storage {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->util = $this->getMock(
-			'\OC\Encryption\Util',
-			['getUidAndFilename', 'isFile', 'isExcluded'],
-			[new View(), new Manager(), $this->groupManager, $this->config, $this->arrayCache]);
+		$this->util = $this->getMockBuilder('\OC\Encryption\Util')
+			->setMethods(['getUidAndFilename', 'isFile', 'isExcluded'])
+			->setConstructorArgs([new View(), new Manager(), $this->groupManager, $this->config, $this->arrayCache])
+			->getMock();
 		$this->util->expects($this->any())
 			->method('getUidAndFilename')
 			->willReturnCallback(function ($path) {
@@ -132,7 +135,7 @@ class EncryptionTest extends Storage {
 			->getMock();
 		$this->file->expects($this->any())->method('getAccessList')->willReturn([]);
 
-		$this->logger = $this->getMock('\OC\Log');
+		$this->logger = $this->createMock(Log::class);
 
 		$this->sourceStorage = new Temporary(array());
 
@@ -713,7 +716,7 @@ class EncryptionTest extends Storage {
 				$temp = \OC::$server->getTempManager();
 				return fopen($temp->getTemporaryFile(), $mode);
 			});
-		$cache = $this->getMock('\OCP\Files\Cache\ICache');
+		$cache = $this->createMock(ICache::class);
 		$cache->expects($this->once())
 			->method('get')
 			->with($sourceInternalPath)
@@ -763,7 +766,7 @@ class EncryptionTest extends Storage {
 				return fopen($temp->getTemporaryFile(), $mode);
 			});
 		if($expectedEncrypted) {
-			$cache = $this->getMock('\OCP\Files\Cache\ICache');
+			$cache = $this->createMock(ICache::class);
 			$cache->expects($this->once())
 				->method('get')
 				->with($sourceInternalPath)

--- a/tests/lib/Files/Stream/EncryptionTest.php
+++ b/tests/lib/Files/Stream/EncryptionTest.php
@@ -3,6 +3,7 @@
 namespace Test\Files\Stream;
 
 use OC\Files\View;
+use OC\Memcache\ArrayCache;
 
 class EncryptionTest extends \Test\TestCase {
 
@@ -31,7 +32,7 @@ class EncryptionTest extends \Test\TestCase {
 		$config = $this->getMockBuilder('\OCP\IConfig')
 			->disableOriginalConstructor()
 			->getMock();
-		$arrayCache = $this->getMock('OC\Memcache\ArrayCache');
+		$arrayCache = $this->createMock(ArrayCache::class);
 		$groupManager = $this->getMockBuilder('\OC\Group\Manager')
 			->disableOriginalConstructor()
 			->getMock();
@@ -40,11 +41,10 @@ class EncryptionTest extends \Test\TestCase {
 			->setMethods(['getAccessList'])
 			->getMock();
 		$file->expects($this->any())->method('getAccessList')->willReturn([]);
-		$util = $this->getMock(
-			'\OC\Encryption\Util',
-			['getUidAndFilename'],
-			[new View(), new \OC\User\Manager(), $groupManager, $config, $arrayCache]
-		);
+		$util = $this->getMockBuilder('\OC\Encryption\Util')
+			->setMethods(['getUidAndFilename'])
+			->setConstructorArgs([new View(), new \OC\User\Manager(), $groupManager, $config, $arrayCache])
+			->getMock();
 		$util->expects($this->any())
 			->method('getUidAndFilename')
 			->willReturn(['user1', $internalPath]);

--- a/tests/lib/Group/MetaDataTest.php
+++ b/tests/lib/Group/MetaDataTest.php
@@ -22,6 +22,8 @@
 
 namespace Test\Group;
 
+use OCP\IUserSession;
+
 class MetaDataTest extends \Test\TestCase {
 	/** @var \OC\Group\Manager */
 	private $groupManager;
@@ -37,7 +39,7 @@ class MetaDataTest extends \Test\TestCase {
 		$this->groupManager = $this->getMockBuilder('\OC\Group\Manager')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->userSession = $this->getMock('\OCP\IUserSession');
+		$this->userSession = $this->createMock(IUserSession::class);
 		$this->groupMetadata = new \OC\Group\MetaData(
 			'foo',
 			$this->isAdmin,

--- a/tests/lib/HTTPHelperTest.php
+++ b/tests/lib/HTTPHelperTest.php
@@ -8,6 +8,8 @@
 
 namespace Test;
 
+use OCP\Http\Client\IClientService;
+
 class HTTPHelperTest extends \Test\TestCase {
 
 	/** @var \OCP\IConfig*/
@@ -22,7 +24,7 @@ class HTTPHelperTest extends \Test\TestCase {
 
 		$this->config = $this->getMockBuilder('\OCP\IConfig')
 			->disableOriginalConstructor()->getMock();
-		$this->clientService = $this->getMock('\OCP\Http\Client\IClientService');
+		$this->clientService = $this->createMock(IClientService::class);
 		$this->httpHelperMock = $this->getMockBuilder('\OC\HTTPHelper')
 			->setConstructorArgs(array($this->config, $this->clientService))
 			->setMethods(array('getHeaders'))

--- a/tests/lib/Http/Client/ClientServiceTest.php
+++ b/tests/lib/Http/Client/ClientServiceTest.php
@@ -11,14 +11,16 @@ namespace Test\Http\Client;
 use GuzzleHttp\Client as GuzzleClient;
 use OC\Http\Client\Client;
 use OC\Http\Client\ClientService;
+use OCP\ICertificateManager;
+use OCP\IConfig;
 
 /**
  * Class ClientServiceTest
  */
 class ClientServiceTest extends \Test\TestCase {
 	public function testNewClient() {
-		$config = $this->getMock('\OCP\IConfig');
-		$certificateManager = $this->getMock('\OCP\ICertificateManager');
+		$config = $this->createMock(IConfig::class);
+		$certificateManager = $this->createMock(ICertificateManager::class);
 
 		$expected = new Client($config, $certificateManager, new GuzzleClient());
 		$clientService = new ClientService($config, $certificateManager);

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -10,6 +10,7 @@ namespace Test\Http\Client;
 
 use GuzzleHttp\Message\Response;
 use OC\Http\Client\Client;
+use OCP\ICertificateManager;
 use OCP\IConfig;
 
 /**
@@ -25,11 +26,11 @@ class ClientTest extends \Test\TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->config = $this->getMock('\OCP\IConfig');
+		$this->config = $this->createMock(IConfig::class);
 		$this->guzzleClient = $this->getMockBuilder('\GuzzleHttp\Client')
 			->disableOriginalConstructor()
 			->getMock();
-		$certificateManager = $this->getMock('\OCP\ICertificateManager');
+		$certificateManager = $this->createMock(ICertificateManager::class);
 		$this->client = new Client(
 			$this->config,
 			$certificateManager,

--- a/tests/lib/IntegrityCheck/CheckerTest.php
+++ b/tests/lib/IntegrityCheck/CheckerTest.php
@@ -51,12 +51,12 @@ class CheckerTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->environmentHelper = $this->getMock('\OC\IntegrityCheck\Helpers\EnvironmentHelper');
-		$this->fileAccessHelper = $this->getMock('\OC\IntegrityCheck\Helpers\FileAccessHelper');
-		$this->appLocator = $this->getMock('\OC\IntegrityCheck\Helpers\AppLocator');
-		$this->config = $this->getMock('\OCP\IConfig');
-		$this->cacheFactory = $this->getMock('\OCP\ICacheFactory');
-		$this->appManager = $this->getMock('\OCP\App\IAppManager');
+		$this->environmentHelper = $this->createMock(EnvironmentHelper::class);
+		$this->fileAccessHelper = $this->createMock(FileAccessHelper::class);
+		$this->appLocator = $this->createMock(AppLocator::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->appManager = $this->createMock(IAppManager::class);
 
 		$this->cacheFactory
 			->expects($this->any())

--- a/tests/lib/L10N/L10nTest.php
+++ b/tests/lib/L10N/L10nTest.php
@@ -12,6 +12,8 @@ namespace Test\L10N;
 use DateTime;
 use OC\L10N\Factory;
 use OC\L10N\L10N;
+use OCP\IConfig;
+use OCP\IRequest;
 use OCP\IUserSession;
 use Test\TestCase;
 
@@ -26,11 +28,11 @@ class L10nTest extends TestCase {
 	 */
 	protected function getFactory() {
 		/** @var \OCP\IConfig $config */
-		$config = $this->getMock('OCP\IConfig');
+		$config = $this->createMock(IConfig::class);
 		/** @var \OCP\IRequest $request */
-		$request = $this->getMock('OCP\IRequest');
+		$request = $this->createMock(IRequest::class);
 		/** @var IUserSession $userSession */
-		$userSession = $this->getMock('OCP\IUserSession');
+		$userSession = $this->createMock(IUserSession::class);
 		return new Factory($config, $request, $userSession, \OC::$SERVERROOT);
 	}
 

--- a/tests/lib/LegacyHelperTest.php
+++ b/tests/lib/LegacyHelperTest.php
@@ -8,6 +8,7 @@
 
 namespace Test;
 
+use OC\Files\View;
 use OC_Helper;
 
 class LegacyHelperTest extends \Test\TestCase {
@@ -129,7 +130,7 @@ class LegacyHelperTest extends \Test\TestCase {
 	}
 
 	function testBuildNotExistingFileNameForView() {
-		$viewMock = $this->getMock('\OC\Files\View', array(), array(), '', false);
+		$viewMock = $this->createMock(View::class);
 		$this->assertEquals('/filename', OC_Helper::buildNotExistingFileNameForView('/', 'filename', $viewMock));
 		$this->assertEquals('dir/filename.ext', OC_Helper::buildNotExistingFileNameForView('dir', 'filename.ext', $viewMock));
 

--- a/tests/lib/Migration/BackgroundRepairTest.php
+++ b/tests/lib/Migration/BackgroundRepairTest.php
@@ -75,7 +75,9 @@ class BackgroundRepairTest extends TestCase {
 		$this->logger = $this->getMockBuilder('OCP\ILogger')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->job = $this->getMock('OC\Migration\BackgroundRepair', ['loadApp']);
+		$this->job = $this->getMockBuilder(BackgroundRepair::class)
+			->setMethods(['loadApp'])
+			->getMock();
 	}
 
 	public function testNoArguments() {
@@ -105,7 +107,7 @@ class BackgroundRepairTest extends TestCase {
 
 	public function testWorkingStep() {
 		/** @var EventDispatcher | \PHPUnit_Framework_MockObject_MockObject $dispatcher */
-		$dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcher', []);
+		$dispatcher = $this->createMock(EventDispatcher::class);
 		$dispatcher->expects($this->once())->method('dispatch')
 			->with('\OC\Repair::step', new GenericEvent('\OC\Repair::step', ['A test repair step']));
 

--- a/tests/lib/OCSClientTest.php
+++ b/tests/lib/OCSClientTest.php
@@ -22,7 +22,9 @@
 namespace Test;
 
 use OC\OCSClient;
+use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
+use OCP\Http\Client\IResponse;
 use OCP\IConfig;
 use OCP\ILogger;
 
@@ -44,8 +46,8 @@ class OCSClientTest extends \Test\TestCase {
 
 		$this->config = $this->getMockBuilder('\OCP\IConfig')
 			->disableOriginalConstructor()->getMock();
-		$this->clientService = $this->getMock('\OCP\Http\Client\IClientService');
-		$this->logger = $this->getMock('\OCP\ILogger');
+		$this->clientService = $this->createMock(IClientService::class);
+		$this->logger = $this->createMock(ILogger::class);
 
 		$this->ocsClient = new OCSClient(
 			$this->clientService,
@@ -102,7 +104,7 @@ class OCSClientTest extends \Test\TestCase {
 			->with('appstoreurl', 'https://api.owncloud.com/v1')
 			->will($this->returnValue('https://api.owncloud.com/v1'));
 
-		$client = $this->getMock('\OCP\Http\Client\IClient');
+		$client = $this->createMock(IClient::class);
 		$client
 			->expects($this->once())
 			->method('get')
@@ -145,13 +147,13 @@ class OCSClientTest extends \Test\TestCase {
 			->with('appstoreurl', 'https://api.owncloud.com/v1')
 			->will($this->returnValue('https://api.owncloud.com/v1'));
 
-		$response = $this->getMock('\OCP\Http\Client\IResponse');
+		$response = $this->createMock(IResponse::class);
 		$response
 			->expects($this->once())
 			->method('getBody')
 			->will($this->returnValue('MyInvalidXml'));
 
-		$client = $this->getMock('\OCP\Http\Client\IClient');
+		$client = $this->createMock(IClient::class);
 		$client
 			->expects($this->once())
 			->method('get')
@@ -194,7 +196,7 @@ class OCSClientTest extends \Test\TestCase {
 			->with('appstoreurl', 'https://api.owncloud.com/v1')
 			->will($this->returnValue('https://api.owncloud.com/v1'));
 
-		$response = $this->getMock('\OCP\Http\Client\IResponse');
+		$response = $this->createMock(IResponse::class);
 		$response
 			->expects($this->once())
 			->method('getBody')
@@ -235,7 +237,7 @@ class OCSClientTest extends \Test\TestCase {
 				</ocs>
 				'));
 
-		$client = $this->getMock('\OCP\Http\Client\IClient');
+		$client = $this->createMock(IClient::class);
 		$client
 			->expects($this->once())
 			->method('get')
@@ -285,7 +287,7 @@ class OCSClientTest extends \Test\TestCase {
 			->with('appstoreurl', 'https://api.owncloud.com/v1')
 			->will($this->returnValue('https://api.owncloud.com/v1'));
 
-		$client = $this->getMock('\OCP\Http\Client\IClient');
+		$client = $this->createMock(IClient::class);
 		$client
 			->expects($this->once())
 			->method('get')
@@ -336,13 +338,13 @@ class OCSClientTest extends \Test\TestCase {
 			->with('appstoreurl', 'https://api.owncloud.com/v1')
 			->will($this->returnValue('https://api.owncloud.com/v1'));
 
-		$response = $this->getMock('\OCP\Http\Client\IResponse');
+		$response = $this->createMock(IResponse::class);
 		$response
 			->expects($this->once())
 			->method('getBody')
 			->will($this->returnValue('MyInvalidXml'));
 
-		$client = $this->getMock('\OCP\Http\Client\IClient');
+		$client = $this->createMock(IClient::class);
 		$client
 			->expects($this->once())
 			->method('get')
@@ -393,7 +395,7 @@ class OCSClientTest extends \Test\TestCase {
 			->with('appstoreurl', 'https://api.owncloud.com/v1')
 			->will($this->returnValue('https://api.owncloud.com/v1'));
 
-		$response = $this->getMock('\OCP\Http\Client\IResponse');
+		$response = $this->createMock(IResponse::class);
 		$response
 			->expects($this->once())
 			->method('getBody')
@@ -478,7 +480,7 @@ class OCSClientTest extends \Test\TestCase {
 				 </data>
 				</ocs> '));
 
-		$client = $this->getMock('\OCP\Http\Client\IClient');
+		$client = $this->createMock(IClient::class);
 		$client
 			->expects($this->once())
 			->method('get')
@@ -568,7 +570,7 @@ class OCSClientTest extends \Test\TestCase {
 			->with('appstoreurl', 'https://api.owncloud.com/v1')
 			->will($this->returnValue('https://api.owncloud.com/v1'));
 
-		$client = $this->getMock('\OCP\Http\Client\IClient');
+		$client = $this->createMock(IClient::class);
 		$client
 			->expects($this->once())
 			->method('get')
@@ -611,13 +613,13 @@ class OCSClientTest extends \Test\TestCase {
 			->with('appstoreurl', 'https://api.owncloud.com/v1')
 			->will($this->returnValue('https://api.owncloud.com/v1'));
 
-		$response = $this->getMock('\OCP\Http\Client\IResponse');
+		$response = $this->createMock(IResponse::class);
 		$response
 			->expects($this->once())
 			->method('getBody')
 			->will($this->returnValue('MyInvalidXml'));
 
-		$client = $this->getMock('\OCP\Http\Client\IClient');
+		$client = $this->createMock(IClient::class);
 		$client
 			->expects($this->once())
 			->method('get')
@@ -660,7 +662,7 @@ class OCSClientTest extends \Test\TestCase {
 			->with('appstoreurl', 'https://api.owncloud.com/v1')
 			->will($this->returnValue('https://api.owncloud.com/v1'));
 
-		$response = $this->getMock('\OCP\Http\Client\IResponse');
+		$response = $this->createMock(IResponse::class);
 		$response
 			->expects($this->once())
 			->method('getBody')
@@ -745,7 +747,7 @@ class OCSClientTest extends \Test\TestCase {
 			</ocs>
 			'));
 
-		$client = $this->getMock('\OCP\Http\Client\IClient');
+		$client = $this->createMock(IClient::class);
 		$client
 			->expects($this->once())
 			->method('get')
@@ -796,7 +798,7 @@ class OCSClientTest extends \Test\TestCase {
 				->with('appstoreurl', 'https://api.owncloud.com/v1')
 				->will($this->returnValue('https://api.owncloud.com/v1'));
 
-		$response = $this->getMock('\OCP\Http\Client\IResponse');
+		$response = $this->createMock(IResponse::class);
 		$response
 				->expects($this->once())
 				->method('getBody')
@@ -881,7 +883,7 @@ class OCSClientTest extends \Test\TestCase {
 			</ocs>
 			'));
 
-		$client = $this->getMock('\OCP\Http\Client\IClient');
+		$client = $this->createMock(IClient::class);
 		$client
 				->expects($this->once())
 				->method('get')
@@ -932,7 +934,7 @@ class OCSClientTest extends \Test\TestCase {
 			->with('appstoreurl', 'https://api.owncloud.com/v1')
 			->will($this->returnValue('https://api.owncloud.com/v1'));
 
-		$response = $this->getMock('\OCP\Http\Client\IResponse');
+		$response = $this->createMock(IResponse::class);
 		$response
 			->expects($this->once())
 			->method('getBody')
@@ -946,7 +948,7 @@ class OCSClientTest extends \Test\TestCase {
 			</ocs>
 			'));
 
-		$client = $this->getMock('\OCP\Http\Client\IClient');
+		$client = $this->createMock(IClient::class);
 		$client
 			->expects($this->once())
 			->method('get')
@@ -988,7 +990,7 @@ class OCSClientTest extends \Test\TestCase {
 			->with('appstoreurl', 'https://api.owncloud.com/v1')
 			->will($this->returnValue('https://api.owncloud.com/v1'));
 
-		$client = $this->getMock('\OCP\Http\Client\IClient');
+		$client = $this->createMock(IClient::class);
 		$client
 			->expects($this->once())
 			->method('get')
@@ -1031,13 +1033,13 @@ class OCSClientTest extends \Test\TestCase {
 			->with('appstoreurl', 'https://api.owncloud.com/v1')
 			->will($this->returnValue('https://api.owncloud.com/v1'));
 
-		$response = $this->getMock('\OCP\Http\Client\IResponse');
+		$response = $this->createMock(IResponse::class);
 		$response
 			->expects($this->once())
 			->method('getBody')
 			->will($this->returnValue('MyInvalidXml'));
 
-		$client = $this->getMock('\OCP\Http\Client\IClient');
+		$client = $this->createMock(IClient::class);
 		$client
 			->expects($this->once())
 			->method('get')
@@ -1080,7 +1082,7 @@ class OCSClientTest extends \Test\TestCase {
 			->with('appstoreurl', 'https://api.owncloud.com/v1')
 			->will($this->returnValue('https://api.owncloud.com/v1'));
 
-		$response = $this->getMock('\OCP\Http\Client\IResponse');
+		$response = $this->createMock(IResponse::class);
 		$response
 			->expects($this->once())
 			->method('getBody')
@@ -1104,7 +1106,7 @@ class OCSClientTest extends \Test\TestCase {
 				</ocs>
 				'));
 
-		$client = $this->getMock('\OCP\Http\Client\IClient');
+		$client = $this->createMock(IClient::class);
 		$client
 			->expects($this->once())
 			->method('get')

--- a/tests/lib/Repair/RepairSharePropagationTest.php
+++ b/tests/lib/Repair/RepairSharePropagationTest.php
@@ -9,6 +9,7 @@
 namespace Test\Repair;
 
 use OC\Repair\SharePropagation;
+use OCP\IConfig;
 use OCP\Migration\IOutput;
 
 class RepairSharePropagationTest extends \Test\TestCase {
@@ -27,7 +28,7 @@ class RepairSharePropagationTest extends \Test\TestCase {
 	 */
 	public function testRemovePropagationEntries(array $startKeys, array $expectedRemovedKeys) {
 		/** @var \PHPUnit_Framework_MockObject_MockObject|\OCP\IConfig $config */
-		$config = $this->getMock('\OCP\IConfig');
+		$config = $this->createMock(IConfig::class);
 		$config->expects($this->once())
 			->method('getAppKeys')
 			->with('files_sharing')

--- a/tests/lib/Security/Bruteforce/ThrottlerTest.php
+++ b/tests/lib/Security/Bruteforce/ThrottlerTest.php
@@ -44,9 +44,9 @@ class ThrottlerTest extends TestCase {
 	private $config;
 
 	public function setUp() {
-		$this->dbConnection = $this->getMock('\OCP\IDBConnection');
-		$this->logger = $this->getMock('\OCP\ILogger');
-		$this->config = $this->getMock('\OCP\IConfig');
+		$this->dbConnection = $this->createMock(IDBConnection::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->config = $this->createMock(IConfig::class);
 
 		$this->throttler = new Throttler(
 			$this->dbConnection,

--- a/tests/lib/Security/CredentialsManagerTest.php
+++ b/tests/lib/Security/CredentialsManagerTest.php
@@ -38,7 +38,7 @@ class CredentialsManagerTest extends \Test\TestCase {
 
 	protected function setUp() {
 		parent::setUp();
-		$this->crypto = $this->getMock('\OCP\Security\ICrypto');
+		$this->crypto = $this->createMock(ICrypto::class);
 		$this->dbConnection = $this->getMockBuilder('\OC\DB\Connection')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/lib/SetupTest.php
+++ b/tests/lib/SetupTest.php
@@ -8,7 +8,11 @@
 
 namespace Test;
 
+use bantu\IniGetWrapper\IniGetWrapper;
 use OCP\IConfig;
+use OCP\IL10N;
+use OCP\ILogger;
+use OCP\Security\ISecureRandom;
 
 class SetupTest extends \Test\TestCase {
 
@@ -30,15 +34,16 @@ class SetupTest extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->config = $this->getMock('\OCP\IConfig');
-		$this->iniWrapper = $this->getMock('\bantu\IniGetWrapper\IniGetWrapper');
-		$this->l10n = $this->getMock('\OCP\IL10N');
-		$this->defaults = $this->getMock('\OC_Defaults');
-		$this->logger = $this->getMock('\OCP\ILogger');
-		$this->random = $this->getMock('\OCP\Security\ISecureRandom');
-		$this->setupClass = $this->getMock('\OC\Setup',
-			['class_exists', 'is_callable', 'getAvailableDbDriversForPdo'],
-			[$this->config, $this->iniWrapper, $this->l10n, $this->defaults, $this->logger, $this->random]);
+		$this->config = $this->createMock(IConfig::class);
+		$this->iniWrapper = $this->createMock(IniGetWrapper::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->defaults = $this->createMock(\OC_Defaults::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->random = $this->createMock(ISecureRandom::class);
+		$this->setupClass = $this->getMockBuilder('\OC\Setup')
+			->setMethods(['class_exists', 'is_callable', 'getAvailableDbDriversForPdo'])
+			->setConstructorArgs([$this->config, $this->iniWrapper, $this->l10n, $this->defaults, $this->logger, $this->random])
+			->getMock();
 	}
 
 	public function testGetSupportedDatabasesWithOneWorking() {

--- a/tests/lib/Share/MailNotificationsTest.php
+++ b/tests/lib/Share/MailNotificationsTest.php
@@ -60,7 +60,7 @@ class MailNotificationsTest extends \Test\TestCase {
 				->disableOriginalConstructor()->getMock();
 		$this->user = $this->getMockBuilder('\OCP\IUser')
 				->disableOriginalConstructor()->getMock();
-		$this->urlGenerator = $this->getMock('\OCP\IURLGenerator');
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 
 		$this->l10n->expects($this->any())
 			->method('t')
@@ -212,14 +212,17 @@ class MailNotificationsTest extends \Test\TestCase {
 		$this->setupMailerMock('TestUser shared »welcome.txt« with you', ['recipient@owncloud.com' => 'Recipient'], false);
 
 		/** @var MailNotifications | \PHPUnit_Framework_MockObject_MockObject $mailNotifications */
-		$mailNotifications = $this->getMock('OC\Share\MailNotifications',['getItemSharedWithUser'], [
+		$mailNotifications = $this->getMockBuilder(MailNotifications::class)
+			->setMethods(['getItemSharedWithUser'])
+			->setConstructorArgs([
 				$this->user,
 				$this->l10n,
 				$this->mailer,
 				$this->logger,
 				$this->defaults,
 				$this->urlGenerator
-		]);
+			])
+			->getMock();
 
 		$mailNotifications->method('getItemSharedWithUser')
 			->withAnyParameters()

--- a/tests/lib/Share20/ShareTest.php
+++ b/tests/lib/Share20/ShareTest.php
@@ -21,6 +21,7 @@
 namespace Test\Share20;
 
 use OCP\Files\IRootFolder;
+use OCP\IUserManager;
 
 /**
  * Class ShareTest
@@ -35,8 +36,8 @@ class ShareTest extends \Test\TestCase {
 	protected $share;
 
 	public function setUp() {
-		$this->rootFolder = $this->getMock('\OCP\Files\IRootFolder');
-		$this->userManager = $this->getMock('OCP\IUserManager');
+		$this->rootFolder = $this->createMock(IRootFolder::class);
+		$this->userManager = $this->createMock(IUserManager::class);
 		$this->share = new \OC\Share20\Share($this->rootFolder, $this->userManager);
 	}
 

--- a/tests/lib/TempManagerTest.php
+++ b/tests/lib/TempManagerTest.php
@@ -10,6 +10,7 @@
 namespace Test;
 
 use OC\Log;
+use OCP\IConfig;
 
 class NullLogger extends Log {
 	public function __construct($logger = null) {
@@ -50,7 +51,7 @@ class TempManagerTest extends \Test\TestCase {
 			$logger = new NullLogger();
 		}
 		if (!$config) {
-			$config = $this->getMock('\OCP\IConfig');
+			$config = $this->createMock(IConfig::class);
 			$config->method('getSystemValue')
 				->with('tempdirectory', null)
 				->willReturn('/tmp');
@@ -140,7 +141,7 @@ class TempManagerTest extends \Test\TestCase {
 	public function testLogCantCreateFile() {
 		$this->markTestSkipped('TODO: Disable because fails on drone');
 
-		$logger = $this->getMock('\Test\NullLogger');
+		$logger = $this->createMock(NullLogger::class);
 		$manager = $this->getManager($logger);
 		chmod($this->baseDir, 0500);
 		$logger->expects($this->once())
@@ -152,7 +153,7 @@ class TempManagerTest extends \Test\TestCase {
 	public function testLogCantCreateFolder() {
 		$this->markTestSkipped('TODO: Disable because fails on drone');
 
-		$logger = $this->getMock('\Test\NullLogger');
+		$logger = $this->createMock(NullLogger::class);
 		$manager = $this->getManager($logger);
 		chmod($this->baseDir, 0500);
 		$logger->expects($this->once())
@@ -162,7 +163,7 @@ class TempManagerTest extends \Test\TestCase {
 	}
 
 	public function testBuildFileNameWithPostfix() {
-		$logger = $this->getMock('\Test\NullLogger');
+		$logger = $this->createMock(NullLogger::class);
 		$tmpManager = self::invokePrivate(
 			$this->getManager($logger),
 			'buildFileNameWithSuffix',
@@ -173,7 +174,7 @@ class TempManagerTest extends \Test\TestCase {
 	}
 
 	public function testBuildFileNameWithoutPostfix() {
-		$logger = $this->getMock('\Test\NullLogger');
+		$logger = $this->createMock(NullLogger::class);
 		$tmpManager = self::invokePrivate(
 			$this->getManager($logger),
 					'buildFileNameWithSuffix',
@@ -184,7 +185,7 @@ class TempManagerTest extends \Test\TestCase {
 	}
 
 	public function testBuildFileNameWithSuffixPathTraversal() {
-		$logger = $this->getMock('\Test\NullLogger');
+		$logger = $this->createMock(NullLogger::class);
 		$tmpManager = self::invokePrivate(
 			$this->getManager($logger),
 			'buildFileNameWithSuffix',
@@ -198,7 +199,7 @@ class TempManagerTest extends \Test\TestCase {
 	public function testGetTempBaseDirFromConfig() {
 		$dir = $this->getManager()->getTemporaryFolder();
 
-		$config = $this->getMock('\OCP\IConfig');
+		$config = $this->createMock(IConfig::class);
 		$config->expects($this->once())
 			->method('getSystemValue')
 			->with('tempdirectory', null)

--- a/tests/lib/Template/ResourceLocatorTest.php
+++ b/tests/lib/Template/ResourceLocatorTest.php
@@ -9,6 +9,7 @@
 namespace Test\Template;
 
 use OC\Template\ResourceNotFoundException;
+use OCP\ILogger;
 
 class ResourceLocatorTest extends \Test\TestCase {
 	/** @var \PHPUnit_Framework_MockObject_MockObject */
@@ -16,7 +17,7 @@ class ResourceLocatorTest extends \Test\TestCase {
 
 	protected function setUp() {
 		parent::setUp();
-		$this->logger = $this->getMock('OCP\ILogger');
+		$this->logger = $this->createMock(ILogger::class);
 	}
 
 	/**

--- a/tests/lib/Updater/VersionCheckTest.php
+++ b/tests/lib/Updater/VersionCheckTest.php
@@ -41,8 +41,10 @@ class VersionCheckTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->updater = $this->getMock('\OC\Updater\VersionCheck',
-			['getUrlContent'], [$clientService, $this->config]);
+		$this->updater = $this->getMockBuilder(VersionCheck::class)
+			->setMethods(['getUrlContent'])
+			->setConstructorArgs([$clientService, $this->config])
+			->getMock();
 	}
 
 	/**


### PR DESCRIPTION
Lots of getMock fixes.
Cleans up the unit test output significantly and makes spotting new warnings a lot easier!

CC: @MorrisJobke @nickvergessen @LukasReschke @icewind1991 
