### PR TITLE
Adding a optional disclaimer to the anonymous upload page

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -168,6 +168,10 @@ thead {
 	margin: 0 auto;
 }
 
+#emptycontent.has-disclaimer {
+	margin-top: 10vh;
+}
+
 #public-upload #emptycontent h2 {
 	margin: 10px 0 5px 0;
 }
@@ -221,4 +225,11 @@ thead {
 #public-upload li span.icon-loading-small {
 	padding-left: 18px;
 	margin-right: 7px;
+}
+
+
+.disclaimer {
+	margin: -20px auto 30px;
+	max-width: 400px;
+	text-align: left;
 }

--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -227,7 +227,6 @@ thead {
 	margin-right: 7px;
 }
 
-
 .disclaimer {
 	margin: -20px auto 30px;
 	max-width: 400px;

--- a/apps/files_sharing/lib/Controllers/ShareController.php
+++ b/apps/files_sharing/lib/Controllers/ShareController.php
@@ -357,6 +357,7 @@ class ShareController extends Controller {
 		$shareTmpl['previewEnabled'] = $this->config->getSystemValue('enable_previews', true);
 		$shareTmpl['previewMaxX'] = $this->config->getSystemValue('preview_max_x', 1024);
 		$shareTmpl['previewMaxY'] = $this->config->getSystemValue('preview_max_y', 1024);
+		$shareTmpl['disclaimer'] = $this->config->getAppValue('core', 'shareapi_public_link_disclaimertext', null);
 
 		// Load files we need
 		\OCP\Util::addScript('files', 'file-upload');

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -104,10 +104,13 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 		<?php } else { ?>
 		<input type="hidden" id="upload-only-interface" value="1"/>
 			<div id="public-upload">
-				<div id="emptycontent" class="">
+				<div id="emptycontent" class="<?php if (!empty($_['disclaimer'])) { ?>has-disclaimer<?php } ?>">
 					<div id="displayavatar"><div class="avatardiv"></div></div>
 					<h2><?php p($l->t('Upload files to %s', [$_['shareOwner']])) ?></h2>
 					<p><span class="icon-folder"></span> <?php p($_['filename']) ?></p>
+					<?php if (!empty($_['disclaimer'])) { ?>
+					<p class="disclaimer"><?php p($_['disclaimer']); ?></p>
+					<?php } ?>
 					<input type="file" name="files[]" class="hidden" multiple>
 
 					<a href="#" class="button icon-upload"><?php p($l->t('Select or drop files')) ?></a>

--- a/apps/files_sharing/tests/Controllers/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controllers/ShareControllerTest.php
@@ -357,6 +357,11 @@ class ShareControllerTest extends \Test\TestCase {
 			->method('getShareByToken')
 			->with('token')
 			->willReturn($share);
+		$this->config
+			->expects($this->once())
+			->method('getAppValue')
+			->with('core', 'shareapi_public_link_disclaimertext', null)
+			->willReturn('My disclaimer text');
 
 		$this->userManager->method('get')->with('ownerUID')->willReturn($owner);
 
@@ -385,7 +390,8 @@ class ShareControllerTest extends \Test\TestCase {
 			'previewMaxX' => 1024,
 			'previewMaxY' => 1024,
 			'hideFileList' => false,
-			'shareOwner' => 'ownerDisplay'
+			'shareOwner' => 'ownerDisplay',
+			'disclaimer' => 'My disclaimer text',
 		);
 
 		$csp = new \OCP\AppFramework\Http\ContentSecurityPolicy();

--- a/lib/private/Settings/Admin/Sharing.php
+++ b/lib/private/Settings/Admin/Sharing.php
@@ -65,6 +65,7 @@ class Sharing implements ISettings {
 			'shareEnforceExpireDate'          => $this->config->getAppValue('core', 'shareapi_enforce_expire_date', 'no'),
 			'shareExcludeGroups'              => $this->config->getAppValue('core', 'shareapi_exclude_groups', 'no') === 'yes' ? true : false,
 			'shareExcludedGroupsList'         => $excludeGroupsList,
+			'publicShareDisclaimerText'       => $this->config->getAppValue('core', 'shareapi_public_link_disclaimertext', null),
 		];
 
 		return new TemplateResponse('settings', 'admin/sharing', $parameters, '');

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -499,6 +499,14 @@ table.grid td.date{
 	display: inline-block;
 }
 
+#publicShareDisclaimerText {
+	width: calc(100% - 23px); /* 20 px left margin, 3 px right margin */
+	max-width: 600px;
+	height: 150px;
+	margin-left: 20px;
+	box-sizing: border-box;
+}
+
 /* correctly display help icons next to headings */
 .icon-info {
 	padding: 11px 20px;

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -90,7 +90,7 @@ $(document).ready(function(){
 		}
 	});
 
-	$('#shareAPI input:not(#excludedGroups)').change(function() {
+	$('#shareAPI input:not(.noJSAutoUpdate)').change(function() {
 		var value = $(this).val();
 		if ($(this).attr('type') === 'checkbox') {
 			if (this.checked) {
@@ -104,6 +104,45 @@ $(document).ready(function(){
 
 	$('#shareapiDefaultExpireDate').change(function() {
 		$("#setDefaultExpireDate").toggleClass('hidden', !this.checked);
+	});
+
+	$('#publicShareDisclaimer').change(function() {
+		$("#publicShareDisclaimerText").toggleClass('hidden', !this.checked);
+		if(!this.checked) {
+			savePublicShareDisclaimerText('');
+		}
+	});
+
+	var savePublicShareDisclaimerText = _.debounce(function(value) {
+		var data = {
+			app:'core',
+			key:'shareapi_public_link_disclaimertext'
+		};
+		if (_.isString(value) && value !== '') {
+			data['action'] = 'setValue';
+			data['value'] = value;
+		} else {
+			data['action'] = 'deleteKey';
+			$('#publicShareDisclaimerText').val('');
+		}
+
+		OC.msg.startSaving('#publicShareDisclaimerStatus');
+		$.post(
+			OC.AppConfig.url,
+			data,
+			function(result){
+				if(result.status === 'success'){
+					OC.msg.finishedSuccess('#publicShareDisclaimerStatus', t('core', 'Saved'))
+				} else {
+					OC.msg.finishedError('#publicShareDisclaimerStatus', t('core', 'Not saved'))
+				}
+			},
+			'json'
+		);
+	}, 500);
+
+	$('#publicShareDisclaimerText').on('change, keyup', function() {
+		savePublicShareDisclaimerText(this.value);
 	});
 
 	$('#allowLinks').change(function() {

--- a/settings/templates/admin/sharing.php
+++ b/settings/templates/admin/sharing.php
@@ -95,7 +95,7 @@
 		<label for="shareapiExcludeGroups"><?php p($l->t('Exclude groups from sharing'));?></label><br/>
 	</p>
 	<p id="selectExcludedGroups" class="indent <?php if (!$_['shareExcludeGroups'] || $_['shareAPIEnabled'] === 'no') p('hidden'); ?>">
-		<input name="shareapi_exclude_groups_list" type="hidden" id="excludedGroups" value="<?php p($_['shareExcludedGroupsList']) ?>" style="width: 400px"/>
+		<input name="shareapi_exclude_groups_list" type="hidden" id="excludedGroups" value="<?php p($_['shareExcludedGroupsList']) ?>" style="width: 400px" class="noJSAutoUpdate"/>
 		<br />
 		<em><?php p($l->t('These groups will still be able to receive shares, but not to initiate them.')); ?></em>
 	</p>
@@ -103,5 +103,13 @@
 		<input type="checkbox" name="shareapi_allow_share_dialog_user_enumeration" value="1" id="shareapi_allow_share_dialog_user_enumeration" class="checkbox"
 			<?php if ($_['allowShareDialogUserEnumeration'] === 'yes') print_unescaped('checked="checked"'); ?> />
 		<label for="shareapi_allow_share_dialog_user_enumeration"><?php p($l->t('Allow username autocompletion in share dialog. If this is disabled the full username needs to be entered.'));?></label><br />
+	</p>
+	<p>
+		<input type="checkbox" id="publicShareDisclaimer" class="checkbox noJSAutoUpdate"
+			<?php if ($_['publicShareDisclaimerText'] !== null) print_unescaped('checked="checked"'); ?> />
+		<label for="publicShareDisclaimer"><?php p($l->t('Show disclaimer text on the public link upload page. (Only shown when the file list is hidden.)'));?></label>
+		<span id="publicShareDisclaimerStatus" class="msg" style="display:none"></span>
+		<br/>
+		<textarea placeholder="This text will be shown on the public link upload page when the file list is hidden." id="publicShareDisclaimerText" <?php if ($_['publicShareDisclaimerText'] === null) { print_unescaped('class="hidden"'); } ?>><?php p($_['publicShareDisclaimerText']) ?></textarea>
 	</p>
 </div>

--- a/settings/templates/admin/sharing.php
+++ b/settings/templates/admin/sharing.php
@@ -110,6 +110,6 @@
 		<label for="publicShareDisclaimer"><?php p($l->t('Show disclaimer text on the public link upload page. (Only shown when the file list is hidden.)'));?></label>
 		<span id="publicShareDisclaimerStatus" class="msg" style="display:none"></span>
 		<br/>
-		<textarea placeholder="This text will be shown on the public link upload page when the file list is hidden." id="publicShareDisclaimerText" <?php if ($_['publicShareDisclaimerText'] === null) { print_unescaped('class="hidden"'); } ?>><?php p($_['publicShareDisclaimerText']) ?></textarea>
+		<textarea placeholder="<?php p($l->t('This text will be shown on the public link upload page when the file list is hidden.')) ?>" id="publicShareDisclaimerText" <?php if ($_['publicShareDisclaimerText'] === null) { print_unescaped('class="hidden"'); } ?>><?php p($_['publicShareDisclaimerText']) ?></textarea>
 	</p>
 </div>

--- a/tests/lib/Settings/Admin/SharingTest.php
+++ b/tests/lib/Settings/Admin/SharingTest.php
@@ -109,6 +109,11 @@ class SharingTest extends TestCase {
 			->method('getAppValue')
 			->with('core', 'shareapi_exclude_groups', 'no')
 			->willReturn('no');
+		$this->config
+			->expects($this->at(13))
+			->method('getAppValue')
+			->with('core', 'shareapi_public_link_disclaimertext', null)
+			->willReturn('Lorem ipsum');
 
 		$expected = new TemplateResponse(
 			'settings',
@@ -129,6 +134,7 @@ class SharingTest extends TestCase {
 				'shareEnforceExpireDate'          => 'no',
 				'shareExcludeGroups'              => false,
 				'shareExcludedGroupsList'         => '',
+				'publicShareDisclaimer'           => 'Lorem ipsum',
 			],
 			''
 		);
@@ -202,6 +208,11 @@ class SharingTest extends TestCase {
 			->method('getAppValue')
 			->with('core', 'shareapi_exclude_groups', 'no')
 			->willReturn('yes');
+		$this->config
+			->expects($this->at(13))
+			->method('getAppValue')
+			->with('core', 'shareapi_public_link_disclaimertext', null)
+			->willReturn('Lorem ipsum');
 
 		$expected = new TemplateResponse(
 			'settings',
@@ -222,6 +233,7 @@ class SharingTest extends TestCase {
 				'shareEnforceExpireDate'          => 'no',
 				'shareExcludeGroups'              => true,
 				'shareExcludedGroupsList'         => 'NoSharers|OtherNoSharers',
+				'publicShareDisclaimer'           => 'Lorem ipsum',
 			],
 			''
 		);

--- a/tests/lib/Settings/Admin/SharingTest.php
+++ b/tests/lib/Settings/Admin/SharingTest.php
@@ -134,7 +134,7 @@ class SharingTest extends TestCase {
 				'shareEnforceExpireDate'          => 'no',
 				'shareExcludeGroups'              => false,
 				'shareExcludedGroupsList'         => '',
-				'publicShareDisclaimer'           => 'Lorem ipsum',
+				'publicShareDisclaimerText'           => 'Lorem ipsum',
 			],
 			''
 		);
@@ -233,7 +233,7 @@ class SharingTest extends TestCase {
 				'shareEnforceExpireDate'          => 'no',
 				'shareExcludeGroups'              => true,
 				'shareExcludedGroupsList'         => 'NoSharers|OtherNoSharers',
-				'publicShareDisclaimer'           => 'Lorem ipsum',
+				'publicShareDisclaimerText'           => 'Lorem ipsum',
 			],
 			''
 		);


### PR DESCRIPTION
We got a lot of requests how to add a disclaimer text to the upload page. This adds a really simple way to show a disclaimer right on the side:

![bildschirmfoto 2016-09-08 um 09 09 26](https://cloud.githubusercontent.com/assets/245432/18340367/d70db54a-75a4-11e6-8a3d-82f10059b37a.png)
- [x] add a setting to the sharing admin section to enter this disclaimer
- [ ] writing a documentation page about how to add a disclaimer text

@nextcloud/designers Feedback about the design is very welcome

cc @LukasReschke 
