### PR TITLE
Show an download button instead of the updater

### DIFF
--- a/apps/updatenotification/js/admin.js
+++ b/apps/updatenotification/js/admin.js
@@ -13,33 +13,7 @@
 /**
  * Creates a new authentication token and loads the updater URL
  */
-var loginToken = '';
 $(document).ready(function(){
-	$('#oca_updatenotification_button').click(function() {
-		// Load the new token
-		$.ajax({
-			url: OC.generateUrl('/apps/updatenotification/credentials')
-		}).success(function(data) {
-			loginToken = data;
-			$.ajax({
-				url: OC.webroot+'/updater/',
-				headers: {
-					'X-Updater-Auth': loginToken
-				},
-				method: 'POST',
-				success: function(data){
-					if(data !== 'false') {
-						var body = $('body');
-						$('head').remove();
-						body.html(data);
-						body.removeAttr('id');
-						body.attr('id', 'body-settings');
-					}
-				}
-			});
-		});
-	});
-
 	$('#release-channel').change(function() {
 		var newChannel = $('#release-channel').find(":selected").val();
 

--- a/apps/updatenotification/lib/Controller/AdminController.php
+++ b/apps/updatenotification/lib/Controller/AdminController.php
@@ -112,6 +112,7 @@ class AdminController extends Controller implements ISettings {
 			'currentChannel' => $currentChannel,
 			'channels' => $channels,
 			'newVersionString' => ($updateState === []) ? '' : $updateState['updateVersion'],
+			'downloadLink' => (empty($updateState['downloadLink'])) ? '' : $updateState['downloadLink'],
 
 			'notify_groups' => implode('|', $notifyGroups),
 		];

--- a/apps/updatenotification/lib/UpdateChecker.php
+++ b/apps/updatenotification/lib/UpdateChecker.php
@@ -49,6 +49,9 @@ class UpdateChecker {
 			if(substr($data['web'], 0, 8) === 'https://') {
 				$result['updateLink'] = $data['web'];
 			}
+			if(substr($data['url'], 0, 8) === 'https://') {
+				$result['downloadLink'] = $data['url'];
+			}
 
 			return $result;
 		}

--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -16,7 +16,9 @@
 <form id="oca_updatenotification_section" class="followupsection">
 	<?php if($isNewVersionAvailable === true): ?>
 		<strong><?php p($l->t('A new version is available: %s', [$newVersionString])); ?></strong>
-		<input type="button" id="oca_updatenotification_button" value="<?php p($l->t('Open updater')) ?>">
+		<?php if ($_['downloadLink']): ?>
+			<a href="<?php p($_['downloadLink']); ?>" class="button"><?php p($l->t('Download now')) ?></a>
+		<?php endif; ?>
 	<?php else: ?>
 		<strong><?php print_unescaped($l->t('Your version is up to date.')); ?></strong>
 		<span class="icon-info svg" title="<?php p($l->t('Checked on %s', [$lastCheckedDate])) ?>"></span>

--- a/apps/updatenotification/tests/Controller/AdminControllerTest.php
+++ b/apps/updatenotification/tests/Controller/AdminControllerTest.php
@@ -111,7 +111,10 @@ class AdminControllerTest extends TestCase {
 		$this->updateChecker
 			->expects($this->once())
 			->method('getUpdateState')
-			->willReturn(['updateVersion' => '8.1.2']);
+			->willReturn([
+				'updateVersion' => '8.1.2',
+				'downloadLink' => 'https://downloads.nextcloud.org/server',
+			]);
 
 		$params = [
 			'isNewVersionAvailable' => true,
@@ -120,6 +123,7 @@ class AdminControllerTest extends TestCase {
 			'channels' => $channels,
 			'newVersionString' => '8.1.2',
 			'notify_groups' => 'admin',
+			'downloadLink' => 'https://downloads.nextcloud.org/server',
 		];
 
 		$expected = new TemplateResponse('updatenotification', 'admin', $params, '');
@@ -164,6 +168,7 @@ class AdminControllerTest extends TestCase {
 			'channels' => $channels,
 			'newVersionString' => '',
 			'notify_groups' => 'admin',
+			'downloadLink' => '',
 		];
 
 		$expected = new TemplateResponse('updatenotification', 'admin', $params, '');

--- a/apps/updatenotification/tests/UpdateCheckerTest.php
+++ b/apps/updatenotification/tests/UpdateCheckerTest.php
@@ -47,13 +47,14 @@ class UpdateCheckerTest extends TestCase {
 			->method('check')
 			->willReturn([
 				'version' => 123,
-				'versionstring' => 'ownCloud 123',
+				'versionstring' => 'Nextcloud 123',
 				'web'=> 'javascript:alert(1)',
+				'url'=> 'javascript:alert(2)',
 			]);
 
 		$expected = [
 			'updateAvailable' => true,
-			'updateVersion' => 'ownCloud 123',
+			'updateVersion' => 'Nextcloud 123',
 		];
 		$this->assertSame($expected, $this->updateChecker->getUpdateState());
 	}
@@ -64,14 +65,16 @@ class UpdateCheckerTest extends TestCase {
 			->method('check')
 			->willReturn([
 				'version' => 123,
-				'versionstring' => 'ownCloud 123',
-				'web'=> 'https://owncloud.org/myUrl',
+				'versionstring' => 'Nextcloud 123',
+				'web'=> 'https://docs.nextcloud.com/myUrl',
+				'url'=> 'https://downloads.nextcloud.org/server',
 			]);
 
 		$expected = [
 			'updateAvailable' => true,
-			'updateVersion' => 'ownCloud 123',
-			'updateLink' => 'https://owncloud.org/myUrl',
+			'updateVersion' => 'Nextcloud 123',
+			'updateLink' => 'https://docs.nextcloud.com/myUrl',
+			'downloadLink' => 'https://downloads.nextcloud.org/server',
 		];
 		$this->assertSame($expected, $this->updateChecker->getUpdateState());
 	}

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -519,7 +519,7 @@ $CONFIG = array(
 /**
  * URL that Nextcloud should use to look for updates
  */
-'updater.server.url' => 'https://updates.nextcloud.org/server/',
+'updater.server.url' => 'https://updates.nextcloud.com/update-server/',
 
 /**
  * Is Nextcloud connected to the Internet or running in a closed network?

--- a/lib/private/Updater/VersionCheck.php
+++ b/lib/private/Updater/VersionCheck.php
@@ -59,7 +59,7 @@ class VersionCheck {
 			return json_decode($this->config->getAppValue('core', 'lastupdateResult'), true);
 		}
 
-		$updaterUrl = $this->config->getSystemValue('updater.server.url', 'https://updates.nextcloud.com/server/');
+		$updaterUrl = $this->config->getSystemValue('updater.server.url', 'https://updates.nextcloud.com/update-server/');
 
 		$this->config->setAppValue('core', 'lastupdatedat', time());
 

--- a/tests/lib/Updater/VersionCheckTest.php
+++ b/tests/lib/Updater/VersionCheckTest.php
@@ -93,8 +93,8 @@ class VersionCheckTest extends \Test\TestCase {
 		$this->config
 			->expects($this->at(1))
 			->method('getSystemValue')
-			->with('updater.server.url', 'https://updates.nextcloud.com/server/')
-			->willReturn('https://updates.nextcloud.com/server/');
+			->with('updater.server.url', 'https://updates.nextcloud.com/update-server/')
+			->willReturnArgument(1);
 		$this->config
 			->expects($this->at(2))
 			->method('setAppValue')
@@ -124,7 +124,7 @@ class VersionCheckTest extends \Test\TestCase {
 		$this->updater
 			->expects($this->once())
 			->method('getUrlContent')
-			->with($this->buildUpdateUrl('https://updates.nextcloud.com/server/'))
+			->with($this->buildUpdateUrl('https://updates.nextcloud.com/update-server/'))
 			->will($this->returnValue($updateXml));
 
 		$this->assertSame($expectedResult, $this->updater->check());
@@ -139,8 +139,8 @@ class VersionCheckTest extends \Test\TestCase {
 		$this->config
 			->expects($this->at(1))
 			->method('getSystemValue')
-			->with('updater.server.url', 'https://updates.nextcloud.com/server/')
-			->willReturn('https://updates.nextcloud.com/server/');
+			->with('updater.server.url', 'https://updates.nextcloud.com/update-server/')
+			->willReturnArgument(1);
 		$this->config
 			->expects($this->at(2))
 			->method('setAppValue')
@@ -164,7 +164,7 @@ class VersionCheckTest extends \Test\TestCase {
 		$this->updater
 			->expects($this->once())
 			->method('getUrlContent')
-			->with($this->buildUpdateUrl('https://updates.nextcloud.com/server/'))
+			->with($this->buildUpdateUrl('https://updates.nextcloud.com/update-server/'))
 			->will($this->returnValue($updateXml));
 
 		$this->assertSame([], $this->updater->check());
@@ -186,8 +186,8 @@ class VersionCheckTest extends \Test\TestCase {
 		$this->config
 			->expects($this->at(1))
 			->method('getSystemValue')
-			->with('updater.server.url', 'https://updates.nextcloud.com/server/')
-			->willReturn('https://updates.nextcloud.com/server/');
+			->with('updater.server.url', 'https://updates.nextcloud.com/update-server/')
+			->willReturnArgument(1);
 		$this->config
 			->expects($this->at(2))
 			->method('setAppValue')
@@ -213,7 +213,7 @@ class VersionCheckTest extends \Test\TestCase {
 		$this->updater
 			->expects($this->once())
 			->method('getUrlContent')
-			->with($this->buildUpdateUrl('https://updates.nextcloud.com/server/'))
+			->with($this->buildUpdateUrl('https://updates.nextcloud.com/update-server/'))
 			->will($this->returnValue($updateXml));
 
 		$this->assertSame($expectedResult, $this->updater->check());
@@ -230,8 +230,8 @@ class VersionCheckTest extends \Test\TestCase {
 		$this->config
 			->expects($this->at(1))
 			->method('getSystemValue')
-			->with('updater.server.url', 'https://updates.nextcloud.com/server/')
-			->willReturn('https://updates.nextcloud.com/server/');
+			->with('updater.server.url', 'https://updates.nextcloud.com/update-server/')
+			->willReturnArgument(1);
 		$this->config
 			->expects($this->at(2))
 			->method('setAppValue')
@@ -255,7 +255,7 @@ class VersionCheckTest extends \Test\TestCase {
 		$this->updater
 			->expects($this->once())
 			->method('getUrlContent')
-			->with($this->buildUpdateUrl('https://updates.nextcloud.com/server/'))
+			->with($this->buildUpdateUrl('https://updates.nextcloud.com/update-server/'))
 			->will($this->returnValue($updateXml));
 
 		$this->assertSame($expectedResult, $this->updater->check());


### PR DESCRIPTION
@karlitschek @schiessle as discussed

cc @LukasReschke @MorrisJobke 

for testing:

``` diff
diff --git a/lib/private/Updater/VersionCheck.php b/lib/private/Updater/VersionCheck.php
index 88ba9b6..eed1728 100644
--- a/lib/private/Updater/VersionCheck.php
+++ b/lib/private/Updater/VersionCheck.php
@@ -56,7 +56,7 @@ class VersionCheck {
        public function check() {
                // Look up the cache - it is invalidated all 30 minutes
                if (((int)$this->config->getAppValue('core', 'lastupdatedat') + 1800) > time()) {
-                       return json_decode($this->config->getAppValue('core', 'lastupdateResult'), true);
+               #       return json_decode($this->config->getAppValue('core', 'lastupdateResult'), true);
                }

                $updaterUrl = $this->config->getSystemValue('updater.server.url', 'https://updates.nextcloud.com/server/');
@@ -79,7 +79,12 @@ class VersionCheck {
                $url = $updaterUrl . '?version=' . $versionString;

                $tmp = [];
-               $xml = $this->getUrlContent($url);
+               $xml = '<nextcloud>
+ <version>12.0.51</version>
+ <versionstring>Nextcloud 12.0.51</versionstring>
+ <url>https://download.nextcloud.com/server/releases/nextcloud-12.0.51.zip</url>
+ <web>https://docs.nextcloud.org/server/10/admin_manual/maintenance/upgrade.html</web>
+</nextcloud>';//$this->getUrlContent($url);
                if ($xml) {
                        $loadEntities = libxml_disable_entity_loader(true);
                        $data = @simplexml_load_string($xml);
```
