### PR TITLE
Add exemptions for incompatible UAs

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -506,8 +506,22 @@ class OC {
 	 * also we can't directly interfere with PHP's session mechanism.
 	 */
 	private static function performSameSiteCookieProtection() {
+		$request = \OC::$server->getRequest();
+
+		// Some user agents are notorious and don't really properly follow HTTP
+		// specifications. For those, have an automated opt-out. Since the protection
+		// for remote.php is applied in base.php as starting point we need to opt out
+		// here.
+		$incompatibleUserAgents = [
+			// OS X Finder
+			'/^WebDAVFS/',
+		];
+		if($request->isUserAgent($incompatibleUserAgents)) {
+			return;
+		}
+
+
 		if(count($_COOKIE) > 0) {
-			$request = \OC::$server->getRequest();
 			$requestUri = $request->getScriptName();
 			$processingScript = explode('/', $requestUri);
 			$processingScript = $processingScript[count($processingScript)-1];


### PR DESCRIPTION
Some user agents are notorious and don't really properly follow HTTP
 specifications. For those, have an automated opt-out. Since the protection
for remote.php is applied in base.php as starting point we need to opt out
here.

Fixes https://github.com/nextcloud/server/issues/223
Fixes https://github.com/nextcloud/server/issues/1237

In combination with https://github.com/nextcloud/server/pull/797
