### PR TITLE
Opening the trashbin causes errors in log for files without preview

### DIFF
--- a/apps/files_trashbin/ajax/preview.php
+++ b/apps/files_trashbin/ajax/preview.php
@@ -72,6 +72,8 @@ try{
 	$preview->setScalingUp($scalingUp);
 
 	$preview->showPreview();
+} catch (\OC\PreviewNotAvailableException $e) {
+	\OC_Response::setStatus(404);
 }catch(\Exception $e) {
 	\OC_Response::setStatus(500);
 	\OCP\Util::writeLog('core', $e->getmessage(), \OCP\Util::DEBUG);

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -598,6 +598,7 @@ return array(
     'OC\\OCS\\Result' => $baseDir . '/lib/private/OCS/Result.php',
     'OC\\Preview' => $baseDir . '/lib/private/Preview.php',
     'OC\\PreviewManager' => $baseDir . '/lib/private/PreviewManager.php',
+    'OC\\PreviewNotAvailableException' => $baseDir . '/lib/private/PreviewNotAvailableException.php',
     'OC\\Preview\\BMP' => $baseDir . '/lib/private/Preview/BMP.php',
     'OC\\Preview\\Bitmap' => $baseDir . '/lib/private/Preview/Bitmap.php',
     'OC\\Preview\\Font' => $baseDir . '/lib/private/Preview/Font.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -628,6 +628,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\OCS\\Result' => __DIR__ . '/../../..' . '/lib/private/OCS/Result.php',
         'OC\\Preview' => __DIR__ . '/../../..' . '/lib/private/Preview.php',
         'OC\\PreviewManager' => __DIR__ . '/../../..' . '/lib/private/PreviewManager.php',
+        'OC\\PreviewNotAvailableException' => __DIR__ . '/../../..' . '/lib/private/PreviewNotAvailableException.php',
         'OC\\Preview\\BMP' => __DIR__ . '/../../..' . '/lib/private/Preview/BMP.php',
         'OC\\Preview\\Bitmap' => __DIR__ . '/../../..' . '/lib/private/Preview/Bitmap.php',
         'OC\\Preview\\Font' => __DIR__ . '/../../..' . '/lib/private/Preview/Font.php',

--- a/lib/private/Preview.php
+++ b/lib/private/Preview.php
@@ -791,6 +791,7 @@ class Preview {
 	 * @param null|string $mimeTypeForHeaders the media type to use when sending back the reply
 	 *
 	 * @throws NotFoundException
+	 * @throws PreviewNotAvailableException
 	 */
 	public function showPreview($mimeTypeForHeaders = null) {
 		// Check if file is valid
@@ -1172,6 +1173,7 @@ class Preview {
 
 	/**
 	 * Defines the media icon, for the media type of the original file, as the preview
+	 * @throws PreviewNotAvailableException
 	 */
 	private function getMimeIcon() {
 		$image = new \OC_Image();
@@ -1180,6 +1182,10 @@ class Preview {
 			$mimeIconServerPath = \OC::$SERVERROOT . $mimeIconWebPath;
 		} else {
 			$mimeIconServerPath = str_replace(\OC::$WEBROOT, \OC::$SERVERROOT, $mimeIconWebPath);
+		}
+		// we can't load SVGs into an image
+		if (substr($mimeIconWebPath, -4) === '.svg') {
+			throw new PreviewNotAvailableException('SVG mimetype cannot be rendered');
 		}
 		$image->loadFromFile($mimeIconServerPath);
 

--- a/lib/private/PreviewNotAvailableException.php
+++ b/lib/private/PreviewNotAvailableException.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Morris Jobke <hey@morrisjobke.de>
+ *
+ * @author Morris Jobke <hey@morrisjobke.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC;
+
+class PreviewNotAvailableException extends \Exception {
+}


### PR DESCRIPTION
- put a file without a generated preview in the trashbin
  (e.g. a *.docx file)
- open the trashbin
- following errors will show up in the nextcloud.log:
  - filesize(): stat failed for ...
  - fopen(...): failed to open stream: No such file or directory at ...
  - fread() expects parameter 1 to be resource, boolean given at ...
  - fclose() expects parameter 1 to be resource, boolean given at ...
  - imagecreatefromstring(): Empty string or invalid image at ...

This is because the preview code tries to load an SVG image, which
is obviously only text.

The fix simply handles this before the loading happens and the web UI
keeps showing the default mimetype icon.

cc @nickvergessen @rullzer @icewind1991 @LukasReschke 

@karlitschek I would like to backport this one.
