### PR TITLE
Add getAccessList to ShareManager

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -72,3 +72,7 @@ Options -Indexes
 <IfModule pagespeed_module>
   ModPagespeed Off
 </IfModule>
+#### DO NOT CHANGE ANYTHING ABOVE THIS LINE ####
+
+ErrorDocument 403 /core/templates/403.php
+ErrorDocument 404 /core/templates/404.php

--- a/.htaccess
+++ b/.htaccess
@@ -72,7 +72,3 @@ Options -Indexes
 <IfModule pagespeed_module>
   ModPagespeed Off
 </IfModule>
-#### DO NOT CHANGE ANYTHING ABOVE THIS LINE ####
-
-ErrorDocument 403 /core/templates/403.php
-ErrorDocument 404 /core/templates/404.php

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -142,7 +142,11 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getGroupManager(),
 				$c->getConfig()
 			);
-			return new Encryption\File($util);
+			return new Encryption\File(
+				$util,
+				$c->getRootFolder(),
+				$c->getShareManager()
+			);
 		});
 
 		$this->registerService('EncryptionKeyStorage', function (Server $c) {

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1143,7 +1143,7 @@ class Manager implements IManager {
 			$path = $path->getParent();
 		}
 
-		$users = [];
+		$users = [$owner => 'null'];
 		$public = false;
 		$remote = false;
 		foreach ($shares as $share) {

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -46,6 +46,7 @@ use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
+use OCP\Share\IShare;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -994,6 +995,7 @@ class Manager implements IManager {
 	 * @return Share[]
 	 */
 	public function getSharesByPath(\OCP\Files\Node $path, $page=0, $perPage=50) {
+		return [];
 	}
 
 	/**
@@ -1097,7 +1099,7 @@ class Manager implements IManager {
 
 	/**
 	 * Get access list to a path. This means
-	 * all the users and groups that can access a given path.
+	 * all the users that can access a given path.
 	 *
 	 * Consider:
 	 * -root
@@ -1106,20 +1108,76 @@ class Manager implements IManager {
 	 *   |-fileA
 	 *
 	 * fileA is shared with user1
-	 * folder2 is shared with group2
+	 * folder2 is shared with group2 (user4 is a member of group2)
 	 * folder1 is shared with user2
 	 *
 	 * Then the access list will to '/folder1/folder2/fileA' is:
 	 * [
-	 * 	'users' => ['user1', 'user2'],
-	 *  'groups' => ['group2']
+	 *  users => ['user1', 'user2', 'user4'],
+	 *  public => bool
+	 *  remote => bool
 	 * ]
 	 *
-	 * This is required for encryption
+	 * This is required for encryption/activities
 	 *
 	 * @param \OCP\Files\Node $path
+	 * @return array
 	 */
 	public function getAccessList(\OCP\Files\Node $path) {
+		$owner = $path->getOwner()->getUID();
+
+		//Get node for the owner
+		$userFolder = $this->rootFolder->getUserFolder($owner);
+		$path = $userFolder->getById($path->getId())[0];
+
+		$providers = $this->factory->getProviders();
+
+		/** @var IShare[] $shares */
+		$shares = [];
+
+		// Collect all the shares
+		while ($path !== $userFolder) {
+			foreach ($providers as $provider) {
+				$shares = array_merge($shares, $provider->getSharesByPath($path));
+			}
+			$path = $path->getParent();
+		}
+
+		$users = [];
+		$public = false;
+		$remote = false;
+		foreach ($shares as $share) {
+			if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER) {
+				$uid = $share->getSharedWith();
+
+				// Skip if user does not exist
+				if (!$this->userManager->userExists($uid)) {
+					continue;
+				}
+
+				$users[$uid] = null;
+			} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
+				$group = $this->groupManager->get($share->getSharedWith());
+
+				// If group does not exist skip
+				if ($group === null) {
+					continue;
+				}
+
+				$groupUsers = $group->getUsers();
+				foreach ($groupUsers as $groupUser) {
+					$users[$groupUser->getUID()] = null;
+				}
+			} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
+				$public = true;
+			} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_REMOTE) {
+				$remote = true;
+			}
+		}
+
+		$users = array_keys($users);
+
+		return ['users' => $users, 'public' => $public, 'remote' => $remote];
 	}
 
 	/**

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -163,4 +163,11 @@ class ProviderFactory implements IProviderFactory {
 
 		return $provider;
 	}
+
+	public function getProviders() {
+		return [
+			$this->defaultShareProvider(),
+			$this->federatedShareProvider(),
+		];
+	}
 }

--- a/lib/private/Share20/ShareHelper.php
+++ b/lib/private/Share20/ShareHelper.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OC\Share20;
+
+use OCP\Files\IRootFolder;
+use OCP\Files\Node;
+use OCP\Files\NotFoundException;
+
+class ShareHelper {
+	/** @var IRootFolder */
+	private $rootFolder;
+
+	public function __construct(IRootFolder $rootFolder) {
+		$this->rootFolder = $rootFolder;
+	}
+
+	/**
+	 * If a user has access to a file
+	 *
+	 * @param Node $node
+	 * @param array $users Array of userIds
+	 * @return array Mapping $uid to an array of nodes
+	 */
+	public function getPathsForAccessList(Node $node, $users) {
+		$result = [];
+
+		foreach ($users as $user) {
+			try {
+				$userFolder = $this->rootFolder->getUserFolder($user);
+			} catch (NotFoundException $e) {
+				continue;
+			}
+
+			$nodes = $userFolder->getById($node->getId());
+			if ($nodes === []) {
+				continue;
+			}
+
+			$result[$user] = $nodes;
+		}
+
+		return $result;
+	}
+}

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -180,6 +180,36 @@ interface IManager {
 	public function userDeletedFromGroup($uid, $gid);
 
 	/**
+	 * Get access list to a path. This means
+	 * all the users that can access a given path.
+	 *
+	 * Consider:
+	 * -root
+	 * |-folder1
+	 *  |-folder2
+	 *   |-fileA
+	 *
+	 * fileA is shared with user1
+	 * folder2 is shared with group2 (user4 is a member of group2)
+	 * folder1 is shared with user2
+	 *
+	 * Then the access list will to '/folder1/folder2/fileA' is:
+	 * [
+	 *  users => ['user1', 'user2', 'user4'],
+	 *  public => bool
+	 *  remote => bool
+	 * ]
+	 *
+	 * This is required for encryption/activity
+	 *
+	 * @param \OCP\Files\Node $path
+	 * @param bool $recursive Should we check all parent folders as well
+	 * @return array
+	 * @since 9.2.0
+	 */
+	public function getAccessList(\OCP\Files\Node $path, $recursive = true);
+
+	/**
 	 * Instantiates a new share object. This is to be passed to
 	 * createShare.
 	 *

--- a/lib/public/Share/IProviderFactory.php
+++ b/lib/public/Share/IProviderFactory.php
@@ -55,4 +55,10 @@ interface IProviderFactory {
 	 * @since 9.0.0
 	 */
 	public function getProviderForType($shareType);
+
+	/**
+	 * @return IShareProvider[]
+	 * @since 9.2.0
+	 */
+	public function getProviders();
 }

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -2606,7 +2606,7 @@ class ManagerTest extends \Test\TestCase {
 			->willReturn($userFolder);
 
 		$expected = [
-			'users' => ['user1', 'user2'],
+			'users' => ['owner', 'user1', 'user2'],
 			'public' => true,
 			'remote' => true,
 		];

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -2531,6 +2531,88 @@ class ManagerTest extends \Test\TestCase {
 
 		$this->manager->moveShare($share, 'recipient');
 	}
+
+	public function testGetAccessList() {
+		$owner = $this->createMock(IUser::class);
+		$owner->expects($this->once())
+			->method('getUID')
+			->willReturn('owner');
+
+		$node = $this->createMock(Node::class);
+		$node->expects($this->once())
+			->method('getOwner')
+			->willReturn($owner);
+		$node->expects($this->once())
+			->method('getId')
+			->willReturn(42);
+
+		$userFolder = $this->createMock(Folder::class);
+		$file = $this->createMock(File::class);
+		$folder = $this->createMock(Folder::class);
+
+		$file->method('getParent')
+			->willReturn($folder);
+		$folder->method('getParent')
+			->willReturn($userFolder);
+		$userFolder->method('getById')
+			->with($this->equalTo(42))
+			->willReturn([$file]);
+
+		$userShare = $this->createMock(IShare::class);
+		$userShare->method('getShareType')
+			->willReturn(\OCP\Share::SHARE_TYPE_USER);
+		$userShare->method('getSharedWith')
+			->willReturn('user1');
+		$groupShare = $this->createMock(IShare::class);
+		$groupShare->method('getShareType')
+			->willReturn(\OCP\Share::SHARE_TYPE_GROUP);
+		$groupShare->method('getSharedWith')
+			->willReturn('group1');
+		$publicShare = $this->createMock(IShare::class);
+		$publicShare->method('getShareType')
+			->willReturn(\OCP\Share::SHARE_TYPE_LINK);
+		$remoteShare = $this->createMock(IShare::class);
+		$remoteShare->method('getShareType')
+			->willReturn(\OCP\Share::SHARE_TYPE_REMOTE);
+
+		$this->userManager->method('userExists')
+			->with($this->equalTo('user1'))
+			->willReturn(true);
+
+		$user2 = $this->createMock(IUser::class);
+		$user2->method('getUID')
+			->willReturn('user2');
+		$group1 = $this->createMock(IGroup::class);
+		$this->groupManager->method('get')
+			->with($this->equalTo('group1'))
+			->willReturn($group1);
+		$group1->method('getUsers')
+			->willReturn([$user2]);
+
+		$this->defaultProvider->expects($this->any())
+			->method('getSharesByPath')
+			->will($this->returnCallback(function(Node $path) use ($file, $folder, $userShare, $groupShare, $publicShare, $remoteShare) {
+				if ($path === $file) {
+					return [$userShare, $publicShare];
+				} else if ($path === $folder) {
+					return [$groupShare, $remoteShare];
+				} else {
+					return [];
+				}
+			}));
+
+		$this->rootFolder->method('getUserFolder')
+			->with($this->equalTo('owner'))
+			->willReturn($userFolder);
+
+		$expected = [
+			'users' => ['user1', 'user2'],
+			'public' => true,
+			'remote' => true,
+		];
+
+		$this->assertEquals($expected, $this->manager->getAccessList($node));
+	}
 }
 
 class DummyFactory implements IProviderFactory {
@@ -2563,5 +2645,11 @@ class DummyFactory implements IProviderFactory {
 	 */
 	public function getProviderForType($shareType) {
 		return $this->provider;
+	}
+
+	public function getProviders() {
+		return [
+			$this->provider
+		];
 	}
 }

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -2552,11 +2552,17 @@ class ManagerTest extends \Test\TestCase {
 
 		$file->method('getParent')
 			->willReturn($folder);
+		$file->method('getPath')
+			->willReturn('/owner/files/folder/file');
 		$folder->method('getParent')
 			->willReturn($userFolder);
+		$folder->method('getPath')
+			->willReturn('/owner/files/folder');
 		$userFolder->method('getById')
 			->with($this->equalTo(42))
 			->willReturn([$file]);
+		$userFolder->method('getPath')
+			->willReturn('/owner/files');
 
 		$userShare = $this->createMock(IShare::class);
 		$userShare->method('getShareType')


### PR DESCRIPTION
Converting the getUsersSharingFile (https://github.com/nextcloud/server/blob/master/lib/public/Share.php#L91) to the share manager.

It now just returns an array. `[users => [], public => bool, remote=>bool]`.

There is not much fancy stuff around it.

@schiessle I think this is already enough for you?
@nickvergessen We then just write a simple helper function that for a given fileId gets the path.

Could you guys have a look?
