### PR TITLE
[stable9] Don't print exception message in HTML

### DIFF
--- a/apps/dav/lib/files/browsererrorpageplugin.php
+++ b/apps/dav/lib/files/browsererrorpageplugin.php
@@ -31,7 +31,6 @@ use Sabre\DAV\Server;
 use Sabre\DAV\ServerPlugin;
 
 class BrowserErrorPagePlugin extends ServerPlugin {
-
 	/** @var Server */
 	private $server;
 
@@ -88,8 +87,7 @@ class BrowserErrorPagePlugin extends ServerPlugin {
 
 	/**
 	 * @codeCoverageIgnore
-	 * @param \Exception $ex
-	 * @param int $httpCode
+	 * @param \Exception $exception
 	 * @return bool|string
 	 */
 	public function generateBody(\Exception $exception) {
@@ -109,10 +107,11 @@ class BrowserErrorPagePlugin extends ServerPlugin {
 		return $content->fetchPage();
 	}
 
-	/*
+	/**
 	 * @codeCoverageIgnore
 	 */
 	public function sendResponse() {
 		$this->server->sapi->sendResponse($this->server->httpResponse);
+		exit();
 	}
 }

--- a/apps/dav/templates/exception.php
+++ b/apps/dav/templates/exception.php
@@ -6,7 +6,6 @@ style('core', ['styles', 'header']);
 ?>
 <span class="error error-wide">
 	<h2><strong><?php p($_['title']) ?></strong></h2>
-		<p><?php p($_['message']) ?></p>
 	<br>
 
 	<h2><strong><?php p($l->t('Technical details')) ?></strong></h2>


### PR DESCRIPTION
The exception message is potentially influenced by user input and could thus be confusing (e.g. somebody could try to open a file like "Please send a mail to support@foo.com", and then the message would include that string.

It is thus reasonable to not show the exception message by default. Also for the browser view I added an `exit()` at the end, as otherwise the XML exception would be attached.

Stable9 of https://github.com/nextcloud/server/pull/1342
