### PR TITLE
[stable10] skip shared files, if files get decrypted only for a specific user

### DIFF
--- a/lib/private/Encryption/DecryptAll.php
+++ b/lib/private/Encryption/DecryptAll.php
@@ -210,6 +210,10 @@ class DecryptAll {
 		while ($root = array_pop($directories)) {
 			$content = $this->rootView->getDirectoryContent($root);
 			foreach ($content as $file) {
+				// only decrypt files owned by the user
+				if($file->getStorage()->instanceOfStorage('OC\Files\Storage\Shared')) {
+					continue;
+				}
 				$path = $root . '/' . $file['name'];
 				if ($this->rootView->is_dir($path)) {
 					$directories[] = $path;

--- a/tests/lib/Encryption/DecryptAllTest.php
+++ b/tests/lib/Encryption/DecryptAllTest.php
@@ -251,18 +251,29 @@ class DecryptAllTest extends TestCase {
 			->setMethods(['decryptFile'])
 			->getMock();
 
+		$storage = $this->getMockBuilder('OCP\Files\Storage')
+			->disableOriginalConstructor()->getMock();
+
+
+		$sharedStorage = $this->getMockBuilder('OCP\Files\Storage')
+			->disableOriginalConstructor()->getMock();
+
+		$sharedStorage->expects($this->once())->method('instanceOfStorage')
+			->with('OC\Files\Storage\Shared')->willReturn(true);
+
 		$this->view->expects($this->at(0))->method('getDirectoryContent')
 			->with('/user1/files')->willReturn(
 				[
-					new FileInfo('path', null, 'intPath', ['name' => 'foo', 'type'=>'dir'], null),
-					new FileInfo('path', null, 'intPath', ['name' => 'bar', 'type'=>'file', 'encrypted'=>true], null)
+					new FileInfo('path', $storage, 'intPath', ['name' => 'foo', 'type'=>'dir'], null),
+					new FileInfo('path', $storage, 'intPath', ['name' => 'bar', 'type'=>'file', 'encrypted'=>true], null),
+					new FileInfo('path', $sharedStorage, 'intPath', ['name' => 'shared', 'type'=>'file', 'encrypted'=>true], null),
 				]
 			);
 
 		$this->view->expects($this->at(3))->method('getDirectoryContent')
 			->with('/user1/files/foo')->willReturn(
 				[
-					new FileInfo('path', null, 'intPath', ['name' => 'subfile', 'type'=>'file', 'encrypted'=>true], null)
+					new FileInfo('path', $storage, 'intPath', ['name' => 'subfile', 'type'=>'file', 'encrypted'=>true], null)
 				]
 			);
 


### PR DESCRIPTION
skip shared files, if files get decrypted only for a specific user we shouldn't touch files owned by a different user.

backport of https://github.com/nextcloud/server/pull/608
