### PR TITLE
deleted files, fix mimetype detection

### DIFF
--- a/apps/files_trashbin/lib/Helper.php
+++ b/apps/files_trashbin/lib/Helper.php
@@ -78,11 +78,12 @@ class Helper {
 					$originalPath = substr($originalPath, 0, -1);
 				}
 			}
+			$type = $entry->getMimeType() === ICacheEntry::DIRECTORY_MIMETYPE ? 'dir' : 'file';
 			$i = array(
 				'name' => $name,
 				'mtime' => $timestamp,
-				'mimetype' => $entry->getMimeType(),
-				'type' => $entry->getMimeType() === ICacheEntry::DIRECTORY_MIMETYPE ? 'dir' : 'file',
+				'mimetype' => $type === 'dir' ? 'httpd/unix-directory' : \OC::$server->getMimeTypeDetector()->detectPath($name),
+				'type' => $type,
 				'directory' => ($dir === '/') ? '' : $dir,
 				'size' => $entry->getSize(),
 				'etag' => '',


### PR DESCRIPTION
detect the correct mimetype of the files in the trashbin, therefore we have to check the filename without the appended timestamp

bug was introduced here: https://github.com/nextcloud/server/commit/435cd31fa6a250559b28b32f6185e4fcfc7fdff9

We can't rely on the file cache, because the files in the trash bin are named `<filename>.<extension>.d<timestamp>` to get the correct mimetype we need to check the real filename without the time stamp when we compile the list.

cc @MorrisJobke @icewind1991 

fix  https://github.com/nextcloud/server/issues/1337
