### PR TITLE
fix remember me login

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -196,9 +196,10 @@ class LoginController extends Controller {
 	 * @param string $user
 	 * @param string $password
 	 * @param string $redirect_url
+	 * @param boolean $remember_login
 	 * @return RedirectResponse
 	 */
-	public function tryLogin($user, $password, $redirect_url) {
+	public function tryLogin($user, $password, $redirect_url, $remember_login = false) {
 		$currentDelay = $this->throttler->getDelay($this->request->getRemoteAddress());
 		$this->throttler->sleepDelay($this->request->getRemoteAddress());
 
@@ -236,13 +237,13 @@ class LoginController extends Controller {
 		// TODO: remove password checks from above and let the user session handle failures
 		// requires https://github.com/owncloud/core/pull/24616
 		$this->userSession->login($user, $password);
-		$this->userSession->createSessionToken($this->request, $loginResult->getUID(), $user, $password);
+		$this->userSession->createSessionToken($this->request, $loginResult->getUID(), $user, $password, $remember_login);
 
 		// User has successfully logged in, now remove the password reset link, when it is available
 		$this->config->deleteUserValue($loginResult->getUID(), 'core', 'lostpassword');
 
 		if ($this->twoFactorManager->isTwoFactorAuthenticated($loginResult)) {
-			$this->twoFactorManager->prepareTwoFactorLogin($loginResult);
+			$this->twoFactorManager->prepareTwoFactorLogin($loginResult, $remember_login);
 
 			$providers = $this->twoFactorManager->getProviders($loginResult);
 			if (count($providers) === 1) {
@@ -263,6 +264,10 @@ class LoginController extends Controller {
 			}
 
 			return new RedirectResponse($this->urlGenerator->linkToRoute($url, $urlParams));
+		}
+
+		if ($remember_login) {
+			$this->userSession->createRememberMeToken($loginResult);
 		}
 
 		return $this->generateRedirect($redirect_url);

--- a/db_structure.xml
+++ b/db_structure.xml
@@ -1126,6 +1126,15 @@
 			</field>
 
 			<field>
+				<name>remember</name>
+				<type>integer</type>
+				<default>0</default>
+				<notnull>true</notnull>
+				<unsigned>true</unsigned>
+				<length>1</length>
+			</field>
+
+			<field>
 				<name>last_activity</name>
 				<type>integer</type>
 				<default>0</default>

--- a/lib/base.php
+++ b/lib/base.php
@@ -1035,6 +1035,12 @@ class OC {
 		if ($userSession->tryTokenLogin($request)) {
 			return true;
 		}
+		if (isset($_COOKIE['nc_username'])
+			&& isset($_COOKIE['nc_token'])
+			&& isset($_COOKIE['nc_session_id'])
+			&& $userSession->loginWithCookie($_COOKIE['nc_username'], $_COOKIE['nc_token'], $_COOKIE['nc_session_id'])) {
+			return true;
+		}
 		if ($userSession->tryBasicAuthLogin($request, \OC::$server->getBruteForceThrottler())) {
 			return true;
 		}

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -290,6 +290,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		$this->registerService('OCP\\IUserSession', function($c) {
 			return $this->getServer()->getUserSession();
 		});
+		$this->registerAlias(\OC\User\Session::class, \OCP\IUserSession::class);
 
 		$this->registerService('OCP\\ISession', function($c) {
 			return $this->getServer()->getSession();

--- a/lib/private/Authentication/Token/DefaultToken.php
+++ b/lib/private/Authentication/Token/DefaultToken.php
@@ -35,6 +35,8 @@ use OCP\AppFramework\Db\Entity;
  * @method string getToken()
  * @method void setType(string $type)
  * @method int getType()
+ * @method void setRemember(int $remember)
+ * @method int getRemember()
  * @method void setLastActivity(int $lastActivity)
  * @method int getLastActivity()
  */
@@ -69,6 +71,11 @@ class DefaultToken extends Entity implements IToken {
 	 * @var int
 	 */
 	protected $type;
+
+	/**
+	 * @var int
+	 */
+	protected $remember;
 
 	/**
 	 * @var int

--- a/lib/private/Authentication/Token/DefaultTokenMapper.php
+++ b/lib/private/Authentication/Token/DefaultTokenMapper.php
@@ -40,24 +40,25 @@ class DefaultTokenMapper extends Mapper {
 	 * @param string $token
 	 */
 	public function invalidate($token) {
+		/* @var $qb IQueryBuilder */
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete('authtoken')
-			->andWhere($qb->expr()->eq('token', $qb->createParameter('token')))
+			->where($qb->expr()->eq('token', $qb->createParameter('token')))
 			->setParameter('token', $token)
 			->execute();
 	}
 
 	/**
 	 * @param int $olderThan
+	 * @param int $remember
 	 */
-	public function invalidateOld($olderThan) {
+	public function invalidateOld($olderThan, $remember = IToken::DO_NOT_REMEMBER) {
 		/* @var $qb IQueryBuilder */
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete('authtoken')
-			->where($qb->expr()->lt('last_activity', $qb->createParameter('last_activity')))
-			->andWhere($qb->expr()->eq('type', $qb->createParameter('type')))
-			->setParameter('last_activity', $olderThan, IQueryBuilder::PARAM_INT)
-			->setParameter('type', IToken::TEMPORARY_TOKEN, IQueryBuilder::PARAM_INT)
+			->where($qb->expr()->lt('last_activity', $qb->createNamedParameter($olderThan, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('type', $qb->createNamedParameter(IToken::TEMPORARY_TOKEN, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('remember', $qb->createNamedParameter($remember, IQueryBuilder::PARAM_INT)))
 			->execute();
 	}
 
@@ -71,7 +72,7 @@ class DefaultTokenMapper extends Mapper {
 	public function getToken($token) {
 		/* @var $qb IQueryBuilder */
 		$qb = $this->db->getQueryBuilder();
-		$result = $qb->select('id', 'uid', 'login_name', 'password', 'name', 'type', 'token', 'last_activity', 'last_check')
+		$result = $qb->select('id', 'uid', 'login_name', 'password', 'name', 'type', 'remember', 'token', 'last_activity', 'last_check')
 			->from('authtoken')
 			->where($qb->expr()->eq('token', $qb->createParameter('token')))
 			->setParameter('token', $token)
@@ -97,7 +98,7 @@ class DefaultTokenMapper extends Mapper {
 	public function getTokenByUser(IUser $user) {
 		/* @var $qb IQueryBuilder */
 		$qb = $this->db->getQueryBuilder();
-		$qb->select('id', 'uid', 'login_name', 'password', 'name', 'type', 'token', 'last_activity', 'last_check')
+		$qb->select('id', 'uid', 'login_name', 'password', 'name', 'type', 'remember', 'token', 'last_activity', 'last_check')
 			->from('authtoken')
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
 			->setMaxResults(1000);

--- a/lib/private/Authentication/Token/DefaultTokenProvider.php
+++ b/lib/private/Authentication/Token/DefaultTokenProvider.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @copyright Copyright (c) 2016, Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @author Christoph Wurst <christoph@owncloud.com>
  *
@@ -56,7 +57,11 @@ class DefaultTokenProvider implements IProvider {
 	 * @param ILogger $logger
 	 * @param ITimeFactory $time
 	 */
-	public function __construct(DefaultTokenMapper $mapper, ICrypto $crypto, IConfig $config, ILogger $logger, ITimeFactory $time) {
+	public function __construct(DefaultTokenMapper $mapper,
+								ICrypto $crypto,
+								IConfig $config,
+								ILogger $logger,
+								ITimeFactory $time) {
 		$this->mapper = $mapper;
 		$this->crypto = $crypto;
 		$this->config = $config;
@@ -98,6 +103,7 @@ class DefaultTokenProvider implements IProvider {
 	 * Save the updated token
 	 *
 	 * @param IToken $token
+	 * @throws InvalidTokenException
 	 */
 	public function updateToken(IToken $token) {
 		if (!($token instanceof DefaultToken)) {
@@ -156,6 +162,7 @@ class DefaultTokenProvider implements IProvider {
 	/**
 	 * @param string $oldSessionId
 	 * @param string $sessionId
+	 * @throws InvalidTokenException
 	 */
 	public function renewSessionToken($oldSessionId, $sessionId) {
 		$token = $this->getToken($oldSessionId);

--- a/lib/private/Authentication/Token/IProvider.php
+++ b/lib/private/Authentication/Token/IProvider.php
@@ -28,6 +28,7 @@ use OCP\IUser;
 
 interface IProvider {
 
+
 	/**
 	 * Create and persist a new token
 	 *
@@ -37,9 +38,10 @@ interface IProvider {
 	 * @param string|null $password
 	 * @param string $name
 	 * @param int $type token type
+	 * @param int $remember whether the session token should be used for remember-me
 	 * @return IToken
 	 */
-	public function generateToken($token, $uid, $loginName, $password, $name, $type = IToken::TEMPORARY_TOKEN);
+	public function generateToken($token, $uid, $loginName, $password, $name, $type = IToken::TEMPORARY_TOKEN, $remember = IToken::DO_NOT_REMEMBER);
 
 	/**
 	 * Get a token by token id
@@ -49,6 +51,12 @@ interface IProvider {
 	 * @return IToken
 	 */
 	public function getToken($tokenId) ;
+
+	/**
+	 * @param string $oldSessionId
+	 * @param string $sessionId
+	 */
+	public function renewSessionToken($oldSessionId, $sessionId);
 
 	/**
 	 * Invalidate (delete) the given session token

--- a/lib/private/Authentication/Token/IProvider.php
+++ b/lib/private/Authentication/Token/IProvider.php
@@ -55,6 +55,7 @@ interface IProvider {
 	/**
 	 * @param string $oldSessionId
 	 * @param string $sessionId
+	 * @throws InvalidTokenException
 	 */
 	public function renewSessionToken($oldSessionId, $sessionId);
 

--- a/lib/private/Authentication/Token/IProvider.php
+++ b/lib/private/Authentication/Token/IProvider.php
@@ -53,6 +53,8 @@ interface IProvider {
 	public function getToken($tokenId) ;
 
 	/**
+	 * Duplicate an existing session token
+	 *
 	 * @param string $oldSessionId
 	 * @param string $sessionId
 	 * @throws InvalidTokenException

--- a/lib/private/Authentication/Token/IToken.php
+++ b/lib/private/Authentication/Token/IToken.php
@@ -28,6 +28,8 @@ interface IToken extends JsonSerializable {
 
 	const TEMPORARY_TOKEN = 0;
 	const PERMANENT_TOKEN = 1;
+	const DO_NOT_REMEMBER = 0;
+	const REMEMBER = 1;
 
 	/**
 	 * Get the token ID

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -37,7 +37,7 @@ class Manager {
 	const SESSION_UID_KEY = 'two_factor_auth_uid';
 	const BACKUP_CODES_APP_ID = 'twofactor_backupcodes';
 	const BACKUP_CODES_PROVIDER_ID = 'backup_codes';
-	const REMEBER_LOGIN = 'two_factor_remember_login';
+	const REMEMBER_LOGIN = 'two_factor_remember_login';
 
 	/** @var AppManager */
 	private $appManager;
@@ -175,12 +175,12 @@ class Manager {
 
 		$passed = $provider->verifyChallenge($user, $challenge);
 		if ($passed) {
-			if ($this->session->get(self::REMEBER_LOGIN) === true) {
+			if ($this->session->get(self::REMEMBER_LOGIN) === true) {
 				// TODO: resolve cyclic dependency and use DI
 				\OC::$server->getUserSession()->createRememberMeToken($user);
 			}
 			$this->session->remove(self::SESSION_UID_KEY);
-			$this->session->remove(self::REMEBER_LOGIN);
+			$this->session->remove(self::REMEMBER_LOGIN);
 		}
 		return $passed;
 	}
@@ -216,7 +216,7 @@ class Manager {
 	 */
 	public function prepareTwoFactorLogin(IUser $user, $rememberMe) {
 		$this->session->set(self::SESSION_UID_KEY, $user->getUID());
-		$this->session->set(self::REMEBER_LOGIN, $rememberMe);
+		$this->session->set(self::REMEMBER_LOGIN, $rememberMe);
 	}
 
 }

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -52,7 +52,6 @@ class Manager {
 	 * @param AppManager $appManager
 	 * @param ISession $session
 	 * @param IConfig $config
-	 * @param Session $userSession
 	 */
 	public function __construct(AppManager $appManager, ISession $session, IConfig $config) {
 		$this->appManager = $appManager;
@@ -116,6 +115,7 @@ class Manager {
 	 * @param IUser $user
 	 * @param bool $includeBackupApp
 	 * @return IProvider[]
+	 * @throws Exception
 	 */
 	public function getProviders(IUser $user, $includeBackupApp = false) {
 		$allApps = $this->appManager->getEnabledAppsForUser($user);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -242,7 +242,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$defaultTokenProvider = null;
 			}
 
-			$userSession = new \OC\User\Session($manager, $session, $timeFactory, $defaultTokenProvider, $c->getConfig());
+			$userSession = new \OC\User\Session($manager, $session, $timeFactory, $defaultTokenProvider, $c->getConfig(), $c->getSecureRandom());
 			$userSession->listen('\OC\User', 'preCreateUser', function ($uid, $password) {
 				\OC_Hook::emit('OC_User', 'pre_createUser', array('run' => true, 'uid' => $uid, 'password' => $password));
 			});

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -283,7 +283,7 @@ class Server extends ServerContainer implements IServerContainer {
 			return $userSession;
 		});
 
-		$this->registerService('\OC\Authentication\TwoFactorAuth\Manager', function (Server $c) {
+		$this->registerService(\OC\Authentication\TwoFactorAuth\Manager::class, function (Server $c) {
 			return new \OC\Authentication\TwoFactorAuth\Manager($c->getAppManager(), $c->getSession(), $c->getConfig());
 		});
 

--- a/lib/private/legacy/user.php
+++ b/lib/private/legacy/user.php
@@ -155,10 +155,11 @@ class OC_User {
 	 * @deprecated use \OCP\IUserSession::loginWithCookie()
 	 * @param string $uid The username of the user to log in
 	 * @param string $token
+	 * @param string $oldSessionId
 	 * @return bool
 	 */
-	public static function loginWithCookie($uid, $token) {
-		return self::getUserSession()->loginWithCookie($uid, $token);
+	public static function loginWithCookie($uid, $token, $oldSessionId) {
+		return self::getUserSession()->loginWithCookie($uid, $token, $oldSessionId);
 	}
 
 	/**

--- a/lib/public/IRequest.php
+++ b/lib/public/IRequest.php
@@ -145,7 +145,7 @@ interface IRequest {
 	 * Shortcut for getting cookie variables
 	 *
 	 * @param string $key the key that will be taken from the $_COOKIE array
-	 * @return string the value in the $_COOKIE element
+	 * @return string|null the value in the $_COOKIE element
 	 * @since 6.0.0
 	 */
 	public function getCookie($key);

--- a/tests/lib/Authentication/Token/DefaultTokenMapperTest.php
+++ b/tests/lib/Authentication/Token/DefaultTokenMapperTest.php
@@ -130,6 +130,7 @@ class DefaultTokenMapperTest extends TestCase {
 		$token->setName('Firefox on Android');
 		$token->setToken('1504445f1524fc801035448a95681a9378ba2e83930c814546c56e5d6ebde221198792fd900c88ed5ead0555780dad1ebce3370d7e154941cd5de87eb419899b');
 		$token->setType(IToken::TEMPORARY_TOKEN);
+		$token->setRemember(IToken::DO_NOT_REMEMBER);
 		$token->setLastActivity($this->time - 60 * 60 * 24 * 3);
 		$token->setLastCheck($this->time - 10);
 

--- a/tests/lib/Authentication/Token/DefaultTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/DefaultTokenProviderTest.php
@@ -1,8 +1,8 @@
 <?php
-
 /**
  * @author Christoph Wurst <christoph@owncloud.com>
  *
+ * @copyright Copyright (c) 2016, Lukas Reschke <lukas@statuscode.ch>
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  * @license AGPL-3.0
  *
@@ -25,6 +25,7 @@ namespace Test\Authentication\Token;
 use OC\Authentication\Token\DefaultToken;
 use OC\Authentication\Token\DefaultTokenProvider;
 use OC\Authentication\Token\IToken;
+use OCP\AppFramework\Db\Mapper;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
 use OCP\ILogger;
@@ -34,13 +35,19 @@ use Test\TestCase;
 
 class DefaultTokenProviderTest extends TestCase {
 
-	/** @var DefaultTokenProvider */
+	/** @var DefaultTokenProvider|\PHPUnit_Framework_MockObject_MockObject */
 	private $tokenProvider;
+	/** @var Mapper|\PHPUnit_Framework_MockObject_MockObject */
 	private $mapper;
+	/** @var ICrypto|\PHPUnit_Framework_MockObject_MockObject */
 	private $crypto;
+	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
 	private $config;
+	/** @var ILogger|\PHPUnit_Framework_MockObject_MockObject */
 	private $logger;
+	/** @var ITimeFactory|\PHPUnit_Framework_MockObject_MockObject */
 	private $timeFactory;
+	/** @var int */
 	private $time;
 
 	protected function setUp() {
@@ -260,6 +267,113 @@ class DefaultTokenProviderTest extends TestCase {
 			->with($this->time - 300);
 
 		$this->tokenProvider->invalidateOldTokens();
+	}
+
+	public function testRenewSessionTokenWithoutPassword() {
+		$token = $this->getMockBuilder(DefaultToken::class)
+			->disableOriginalConstructor()
+			->setMethods(['getUID', 'getLoginName', 'getPassword', 'getName'])
+			->getMock();
+		$token
+			->expects($this->at(0))
+			->method('getUID')
+			->willReturn('UserUid');
+		$token
+			->expects($this->at(1))
+			->method('getLoginName')
+			->willReturn('UserLoginName');
+		$token
+			->expects($this->at(2))
+			->method('getPassword')
+			->willReturn(null);
+		$token
+			->expects($this->at(3))
+			->method('getName')
+			->willReturn('MyTokenName');
+		$this->config
+			->expects($this->exactly(2))
+			->method('getSystemValue')
+			->with('secret')
+			->willReturn('MyInstanceSecret');
+		$this->mapper
+			->expects($this->at(0))
+			->method('getToken')
+			->with(hash('sha512', 'oldId' . 'MyInstanceSecret'))
+			->willReturn($token);
+		$newToken = new DefaultToken();
+		$newToken->setUid('UserUid');
+		$newToken->setLoginName('UserLoginName');
+		$newToken->setName('MyTokenName');
+		$newToken->setToken(hash('sha512', 'newId' . 'MyInstanceSecret'));
+		$newToken->setType(IToken::TEMPORARY_TOKEN);
+		$newToken->setLastActivity(1313131);
+		$this->mapper
+			->expects($this->at(1))
+			->method('insert')
+			->with($newToken);
+
+		$this->tokenProvider->renewSessionToken('oldId', 'newId');
+	}
+
+	public function testRenewSessionTokenWithPassword() {
+		$token = $this->getMockBuilder(DefaultToken::class)
+			->disableOriginalConstructor()
+			->setMethods(['getUID', 'getLoginName', 'getPassword', 'getName'])
+			->getMock();
+		$token
+			->expects($this->at(0))
+			->method('getUID')
+			->willReturn('UserUid');
+		$token
+			->expects($this->at(1))
+			->method('getLoginName')
+			->willReturn('UserLoginName');
+		$token
+			->expects($this->at(2))
+			->method('getPassword')
+			->willReturn('EncryptedPassword');
+		$token
+			->expects($this->at(3))
+			->method('getPassword')
+			->willReturn('EncryptedPassword');
+		$token
+			->expects($this->at(4))
+			->method('getName')
+			->willReturn('MyTokenName');
+		$this->crypto
+			->expects($this->any(0))
+			->method('decrypt')
+			->with('EncryptedPassword', 'oldIdMyInstanceSecret')
+			->willReturn('ClearTextPassword');
+		$this->crypto
+			->expects($this->any(1))
+			->method('encrypt')
+			->with('ClearTextPassword', 'newIdMyInstanceSecret')
+			->willReturn('EncryptedPassword');
+		$this->config
+			->expects($this->exactly(4))
+			->method('getSystemValue')
+			->with('secret')
+			->willReturn('MyInstanceSecret');
+		$this->mapper
+			->expects($this->at(0))
+			->method('getToken')
+			->with(hash('sha512', 'oldId' . 'MyInstanceSecret'))
+			->willReturn($token);
+		$newToken = new DefaultToken();
+		$newToken->setUid('UserUid');
+		$newToken->setLoginName('UserLoginName');
+		$newToken->setName('MyTokenName');
+		$newToken->setToken(hash('sha512', 'newId' . 'MyInstanceSecret'));
+		$newToken->setType(IToken::TEMPORARY_TOKEN);
+		$newToken->setLastActivity(1313131);
+		$newToken->setPassword('EncryptedPassword');
+		$this->mapper
+			->expects($this->at(1))
+			->method('insert')
+			->with($newToken);
+
+		$this->tokenProvider->renewSessionToken('oldId', 'newId');
 	}
 
 }

--- a/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
@@ -233,8 +233,15 @@ class ManagerTest extends TestCase {
 			->with($this->user, $challenge)
 			->will($this->returnValue(true));
 		$this->session->expects($this->once())
+			->method('get')
+			->with('two_factor_remember_login')
+			->will($this->returnValue(false));
+		$this->session->expects($this->at(1))
 			->method('remove')
 			->with('two_factor_auth_uid');
+		$this->session->expects($this->at(2))
+			->method('remove')
+			->with('two_factor_remember_login');
 
 		$this->assertTrue($this->manager->verifyChallenge('email', $this->user, $challenge));
 	}
@@ -304,11 +311,29 @@ class ManagerTest extends TestCase {
 			->method('getUID')
 			->will($this->returnValue('ferdinand'));
 
-		$this->session->expects($this->once())
+		$this->session->expects($this->at(0))
 			->method('set')
 			->with('two_factor_auth_uid', 'ferdinand');
+		$this->session->expects($this->at(1))
+			->method('set')
+			->with('two_factor_remember_login', true);
 
-		$this->manager->prepareTwoFactorLogin($this->user);
+		$this->manager->prepareTwoFactorLogin($this->user, true);
+	}
+
+	public function testPrepareTwoFactorLoginDontRemember() {
+		$this->user->expects($this->once())
+			->method('getUID')
+			->will($this->returnValue('ferdinand'));
+
+		$this->session->expects($this->at(0))
+			->method('set')
+			->with('two_factor_auth_uid', 'ferdinand');
+		$this->session->expects($this->at(1))
+			->method('set')
+			->with('two_factor_remember_login', false);
+
+		$this->manager->prepareTwoFactorLogin($this->user, false);
 	}
 
 }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 2, 0, 4);
+$OC_Version = array(9, 2, 0, 5);
 
 // The human readable string
 $OC_VersionString = '11.0 alpha';


### PR DESCRIPTION
fixes https://github.com/nextcloud/server/issues/1067

I somehow refactored away the remember-me funcionality while working on the auth code :see_no_evil: 

TODO:
- [x] ~~update session token in the DB~~ duplicate token, otherwise the validation fails and the user is logged out
- [x] only set remember cookies when the 2FA challenge was solved successfully
- [x] only set remember cookie when the checkbox was checked on the login page
- [x] flag remember-me session tokens and don't delete them after 24h, but rather after the max remember-me lifetime elapsed, relative to the last usage time
- [x] tests

cc @LukasReschke 
