### PR TITLE
Use flexbox on app page

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -384,14 +384,21 @@ span.version {
 	position: relative;
 	height: 100%;
 	display: flex;
-	flex-flow: row wrap;
+	flex-wrap: wrap;
+	align-content: flex-start;
 }
-.section {
+#apps-list .section {
 	position: relative;
-	width: 300px;
+	flex: 1 0 330px;
+	margin: 0;
+	padding-right: 50px;
+}
+#apps-list .section.apps-experimental {
+	flex-basis: 90%;
 }
 .section h2.app-name {
 	margin-bottom: 8px;
+	display: inline;
 }
 .followupsection {
 	display: block;

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -383,9 +383,12 @@ span.version {
 #apps-list {
 	position: relative;
 	height: 100%;
+	display: flex;
+	flex-flow: row wrap;
 }
 .section {
 	position: relative;
+	width: 300px;
 }
 .section h2.app-name {
 	margin-bottom: 8px;


### PR DESCRIPTION
The amount of white space on the app page was annoying me. So I decided to give flexbox a try.

Before:
![before](https://cloud.githubusercontent.com/assets/45821/18410392/280bfba0-7762-11e6-8551-f3a4f77f32ce.png)

After:
![after](https://cloud.githubusercontent.com/assets/45821/18410395/2d03e4ec-7762-11e6-8773-c9c098894086.png)

Which looks a lot better to me.

However it does need work as you can see on the notenabled page:
![not_enabled](https://cloud.githubusercontent.com/assets/45821/18410461/ead5e9a6-7763-11e6-851b-f97a03c60c4e.png)

Far from done.
- [x] Experimental apps display
- [ ] Fix per app layout a bit more
- [ ] Full Safari/IE support
- [ ] Restrict to apps only (currently affects personal/admin settings, too)

CC: @nextcloud/designers @MorrisJobke 
