### PR TITLE
Cache the build ControllerName

### DIFF
--- a/lib/private/AppFramework/Routing/RouteConfig.php
+++ b/lib/private/AppFramework/Routing/RouteConfig.php
@@ -36,14 +36,25 @@ use OCP\Route\IRouter;
  * @package OC\AppFramework\routing
  */
 class RouteConfig {
+	/** @var DIContainer */
 	private $container;
+
+	/** @var IRouter */
 	private $router;
+
+	/** @var array */
 	private $routes;
+
+	/** @var string */
 	private $appName;
+
+	/** @var string[] */
+	private $controllerNameCache = [];
 
 	/**
 	 * @param \OC\AppFramework\DependencyInjection\DIContainer $container
 	 * @param \OCP\Route\IRouter $router
+	 * @param array $routes
 	 * @internal param $appName
 	 */
 	public function __construct(DIContainer $container, IRouter $router, $routes) {
@@ -234,7 +245,10 @@ class RouteConfig {
 	 */
 	private function buildControllerName($controller)
 	{
-		return $this->underScoreToCamelCase(ucfirst($controller)) . 'Controller';
+		if (!isset($this->controllerNameCache[$controller])) {
+			$this->controllerNameCache[$controller] = $this->underScoreToCamelCase(ucfirst($controller)) . 'Controller';
+		}
+		return $this->controllerNameCache[$controller];
 	}
 
 	/**


### PR DESCRIPTION
Often a route.php file will have many N routes but only M controllers.
Where N >= M. Which means that in most cases the ControllerName will be
converted multiple times. This is of course far from ideal.

Note that this is per app so the cache will contain at most N entries.
Which is not to bad.

On my system this shaves off about a ms per request.
Which is fair enough for the amount of work.
