### PR TITLE
Choose button remains disbaled for httpd/unix-directory

### DIFF
--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -821,7 +821,11 @@ var OCdialogs = {
 		self._fillFilePicker(dir);
 		var getOcDialog = this.closest('.oc-dialog');
 		var buttonEnableDisable = $('.primary', getOcDialog);
-		buttonEnableDisable.prop("disabled", true);
+		if (this.$filePicker.data('mimetype') === "http/unix-directory") {
+			buttonEnableDisable.prop("disabled", false);
+		} else {
+			buttonEnableDisable.prop("disabled", true);
+		}
 	},
 	/**
 	 * handle clicks made in the filepicker
@@ -837,7 +841,11 @@ var OCdialogs = {
 			buttonEnableDisable.prop("disabled", false);
 		} else if ( $element.data('type') === 'dir' ) {
 			this._fillFilePicker(this.$filePicker.data('path') + '/' + $element.data('entryname'));
-			buttonEnableDisable.prop("disabled", true);
+			if (this.$filePicker.data('mimetype') === "httpd/unix-directory") {
+				buttonEnableDisable.prop("disabled", false);
+			} else {
+				buttonEnableDisable.prop("disabled", true);
+			}
 		}
 	}
 };


### PR DESCRIPTION
This is not correct. Hence in this patch we validate
if the mimetype is 'httpd/unix-directory'. If so we
don't disable it.

This patch addresses solution for issue: owncloud/core#26034

Signed-off-by: Sujith Haridasan Sujith_Haridasan@mentor.com
## 
- downstream of owncloud/core#26061
- I tested it and it works afterwards
- no need to backport this to stable10 - works there

cc @nickvergessen @rullzer @MariusBluem 
