### PR TITLE
Change language code from fi_FI to fi

### DIFF
--- a/l10n/.tx/config
+++ b/l10n/.tx/config
@@ -1,6 +1,6 @@
 [main]
 host = https://www.transifex.com
-lang_map = ja_JP: ja
+lang_map = bg_BG: bg, cs_CZ: cs, fi_FI: fi, hu_HU: hu, nb_NO: nb, sk_SK: sk, th_TH: th, ja_JP: ja
 
 [nextcloud.core]
 file_filter = <lang>/core.po

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -686,6 +686,7 @@ return array(
     'OC\\Repair\\NC11\\FixMountStorages' => $baseDir . '/lib/private/Repair/NC11/FixMountStorages.php',
     'OC\\Repair\\NC11\\MoveAvatars' => $baseDir . '/lib/private/Repair/NC11/MoveAvatars.php',
     'OC\\Repair\\NC11\\MoveAvatarsBackgroundJob' => $baseDir . '/lib/private/Repair/NC11/MoveAvatarsBackgroundJob.php',
+    'OC\\Repair\\NC12\\UpdateLanguageCodes' => $baseDir . '/lib/private/Repair/NC12/UpdateLanguageCodes.php',
     'OC\\Repair\\OldGroupMembershipShares' => $baseDir . '/lib/private/Repair/OldGroupMembershipShares.php',
     'OC\\Repair\\RemoveRootShares' => $baseDir . '/lib/private/Repair/RemoveRootShares.php',
     'OC\\Repair\\RepairInvalidShares' => $baseDir . '/lib/private/Repair/RepairInvalidShares.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -716,6 +716,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Repair\\NC11\\FixMountStorages' => __DIR__ . '/../../..' . '/lib/private/Repair/NC11/FixMountStorages.php',
         'OC\\Repair\\NC11\\MoveAvatars' => __DIR__ . '/../../..' . '/lib/private/Repair/NC11/MoveAvatars.php',
         'OC\\Repair\\NC11\\MoveAvatarsBackgroundJob' => __DIR__ . '/../../..' . '/lib/private/Repair/NC11/MoveAvatarsBackgroundJob.php',
+        'OC\\Repair\\NC12\\UpdateLanguageCodes' => __DIR__ . '/../../..' . '/lib/private/Repair/NC12/UpdateLanguageCodes.php',
         'OC\\Repair\\OldGroupMembershipShares' => __DIR__ . '/../../..' . '/lib/private/Repair/OldGroupMembershipShares.php',
         'OC\\Repair\\RemoveRootShares' => __DIR__ . '/../../..' . '/lib/private/Repair/RemoveRootShares.php',
         'OC\\Repair\\RepairInvalidShares' => __DIR__ . '/../../..' . '/lib/private/Repair/RepairInvalidShares.php',

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -36,6 +36,7 @@ use OC\Repair\MoveUpdaterStepFile;
 use OC\Repair\NC11\CleanPreviews;
 use OC\Repair\NC11\FixMountStorages;
 use OC\Repair\NC11\MoveAvatars;
+use OC\Repair\NC12\UpdateLanguageCodes;
 use OC\Repair\OldGroupMembershipShares;
 use OC\Repair\RemoveRootShares;
 use OC\Repair\SqliteAutoincrement;
@@ -134,6 +135,7 @@ class Repair implements IOutput{
 				\OC::$server->getConfig()
 			),
 			new FixMountStorages(\OC::$server->getDatabaseConnection()),
+			new UpdateLanguageCodes(\OC::$server->getDatabaseConnection()),
 		];
 	}
 

--- a/lib/private/Repair/NC12/UpdateLanguageCodes.php
+++ b/lib/private/Repair/NC12/UpdateLanguageCodes.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Morris Jobke <hey@morrisjobke.de>
+ *
+ * @author Morris Jobke <hey@morrisjobke.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Repair\NC12;
+
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class UpdateLanguageCodes implements IRepairStep {
+	/** @var IDBConnection */
+	private $connection;
+
+	/**
+	 * @param IDBConnection $db
+	 */
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getName() {
+		return 'Repair language codes';
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function run(IOutput $output) {
+		$languages = [
+			'bg_BG' => 'bg',
+			'cs_CZ' => 'cs',
+			'fi_FI' => 'fi',
+			'hu_HU' => 'hu',
+			'nb_NO' => 'nb',
+			'sk_SK' => 'sk',
+			'th_TH' => 'th',
+		];
+
+		foreach ($languages as $oldCode => $newCode) {
+			$qb = $this->connection->getQueryBuilder();
+
+			$affectedRows = $qb->update('preferences')
+				->set('configvalue', $qb->createNamedParameter($newCode))
+				->where($qb->expr()->eq('appid', $qb->createNamedParameter('core')))
+				->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter('lang')))
+				->andWhere($qb->expr()->eq('configvalue', $qb->createNamedParameter($oldCode)))
+				->execute();
+
+			$output->info('Changed ' . $affectedRows . ' setting(s) from "' . $oldCode . '" to "' . $newCode . '" in properties table.');
+		}
+	}
+}

--- a/lib/private/Repair/NC12/UpdateLanguageCodes.php
+++ b/lib/private/Repair/NC12/UpdateLanguageCodes.php
@@ -69,7 +69,7 @@ class UpdateLanguageCodes implements IRepairStep {
 				->andWhere($qb->expr()->eq('configvalue', $qb->createNamedParameter($oldCode)))
 				->execute();
 
-			$output->info('Changed ' . $affectedRows . ' setting(s) from "' . $oldCode . '" to "' . $newCode . '" in properties table.');
+			$output->info('Changed ' . $affectedRows . ' setting(s) from "' . $oldCode . '" to "' . $newCode . '" in preferences table.');
 		}
 	}
 }

--- a/tests/lib/Repair/NC12/UpdateLanguageCodesTest.php
+++ b/tests/lib/Repair/NC12/UpdateLanguageCodesTest.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Morris Jobke <hey@morrisjobke.de>
+ *
+ * @author Morris Jobke <hey@morrisjobke.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Test\Repair\NC12;
+
+use OC\Repair\NC12\UpdateLanguageCodes;
+use OCP\Migration\IOutput;
+use Test\TestCase;
+
+/**
+ * Class UpdateLanguageCodesTest
+ *
+ * @group DB
+ *
+ * @package Test\Repair
+ */
+class UpdateLanguageCodesTest extends TestCase {
+	/** @var \OCP\IDBConnection */
+	protected $connection;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->connection = \OC::$server->getDatabaseConnection();
+	}
+
+	public function testRun() {
+
+		$users = [
+			['userid' => 'user1', 'configvalue' => 'fi_FI'],
+			['userid' => 'user2', 'configvalue' => 'de'],
+			['userid' => 'user3', 'configvalue' => 'fi'],
+			['userid' => 'user4', 'configvalue' => 'ja'],
+			['userid' => 'user5', 'configvalue' => 'bg_BG'],
+			['userid' => 'user6', 'configvalue' => 'ja'],
+			['userid' => 'user7', 'configvalue' => 'th_TH'],
+		];
+
+		// insert test data
+		$qb = $this->connection->getQueryBuilder();
+		$sql = $qb->insert('preferences')
+				->values([
+					'userid' => '?',
+					'appid' => '?',
+					'configkey' => '?',
+					'configvalue' => '?',
+				])
+				->getSQL();
+		foreach ($users as $user) {
+			$this->connection->executeUpdate($sql, [$user['userid'], 'core', 'lang', $user['configvalue']]);
+		}
+
+		// check if test data is written to DB
+		$qb = $this->connection->getQueryBuilder();
+		$result = $qb->select(['userid', 'configvalue'])
+			->from('preferences')
+			->where($qb->expr()->eq('appid', $qb->createNamedParameter('core')))
+			->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter('lang')))
+			->execute();
+
+		$rows = $result->fetchAll();
+		$result->closeCursor();
+
+		$this->assertSame($users, $rows, 'Asserts that the entries are the ones from the test data set');
+
+		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $outputMock */
+		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$outputMock->expects($this->at(0))
+			->method('info')
+			->with('Changed 1 setting(s) from "bg_BG" to "bg" in properties table.');
+		$outputMock->expects($this->at(1))
+			->method('info')
+			->with('Changed 0 setting(s) from "cs_CZ" to "cs" in properties table.');
+		$outputMock->expects($this->at(2))
+			->method('info')
+			->with('Changed 1 setting(s) from "fi_FI" to "fi" in properties table.');
+		$outputMock->expects($this->at(3))
+			->method('info')
+			->with('Changed 0 setting(s) from "hu_HU" to "hu" in properties table.');
+		$outputMock->expects($this->at(4))
+			->method('info')
+			->with('Changed 0 setting(s) from "nb_NO" to "nb" in properties table.');
+		$outputMock->expects($this->at(5))
+			->method('info')
+			->with('Changed 0 setting(s) from "sk_SK" to "sk" in properties table.');
+		$outputMock->expects($this->at(6))
+			->method('info')
+			->with('Changed 1 setting(s) from "th_TH" to "th" in properties table.');
+
+		// run repair step
+		$repair = new UpdateLanguageCodes($this->connection);
+		$repair->run($outputMock);
+
+		// check if test data is correctly modified in DB
+		$qb = $this->connection->getQueryBuilder();
+		$result = $qb->select(['userid', 'configvalue'])
+			->from('preferences')
+			->where($qb->expr()->eq('appid', $qb->createNamedParameter('core')))
+			->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter('lang')))
+			->orderBy('userid')
+			->execute();
+
+		$rows = $result->fetchAll();
+		$result->closeCursor();
+
+		// value has changed for one user
+		$users[0]['configvalue'] = 'fi';
+		$users[4]['configvalue'] = 'bg';
+		$users[6]['configvalue'] = 'th';
+		$this->assertSame($users, $rows, 'Asserts that the entries are updated correctly.');
+
+		// remove test data
+		foreach ($users as $user) {
+			$qb = $this->connection->getQueryBuilder();
+			$qb->delete('preferences')
+				->where($qb->expr()->eq('userid', $qb->createNamedParameter($user['userid'])))
+				->andWhere($qb->expr()->eq('appid', $qb->createNamedParameter('core')))
+				->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter('lang')))
+				->andWhere($qb->expr()->eq('configvalue', $qb->createNamedParameter($user['configvalue'])))
+				->execute();
+		}
+	}
+
+}


### PR DESCRIPTION
- then the language is not that specific and get also matched for fi
- fallback from fi_FI to fi is supported - the other way around not
- contains repair script
- contains tests for repair script
- fixes #869 

@kohtala @rullzer 

I will also update all the transifex files in all apps to match the settings here.
