### PR TITLE
Fix getMock phpunit warnings

### DIFF
--- a/tests/Settings/Controller/UsersControllerTest.php
+++ b/tests/Settings/Controller/UsersControllerTest.php
@@ -13,6 +13,9 @@ namespace Tests\Settings\Controller;
 use \OC\Settings\Application;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\IAvatar;
+use OCP\IAvatarManager;
+use OCP\IUser;
 
 /**
  * @group DB
@@ -60,11 +63,11 @@ class UsersControllerTest extends \Test\TestCase {
 		/*
 		 * Set default avtar behaviour for whole testsuite
 		 */
-		$this->container['OCP\\IAvatarManager'] = $this->getMock('OCP\IAvatarManager');
+		$this->container['OCP\\IAvatarManager'] = $this->createMock(IAvatarManager::class);
 
-		$avatarExists = $this->getMock('OCP\IAvatar');
+		$avatarExists = $this->createMock(IAvatar::class);
 		$avatarExists->method('exists')->willReturn(true);
-		$avatarNotExists = $this->getMock('OCP\IAvatar');
+		$avatarNotExists = $this->createMock(IAvatar::class);
 		$avatarNotExists->method('exists')->willReturn(false);
 		$this->container['OCP\\IAvatarManager']
 			->method('getAvatar')
@@ -1861,7 +1864,7 @@ class UsersControllerTest extends \Test\TestCase {
 	}
 
 	public function testSetDisplayNameNull() {
-		$user = $this->getMock('\OCP\IUser');
+		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('userName');
 
 		$this->container['UserSession']
@@ -1885,33 +1888,33 @@ class UsersControllerTest extends \Test\TestCase {
 	public function dataSetDisplayName() {
 		$data = [];
 
-		$user1 = $this->getMock('\OCP\IUser');
+		$user1 = $this->createMock(IUser::class);
 		$user1->method('getUID')->willReturn('user1');
 		$user1->method('canChangeDisplayName')->willReturn(true);
 		$data[] = [$user1, $user1, false, false, true];
 
-		$user1 = $this->getMock('\OCP\IUser');
+		$user1 = $this->createMock(IUser::class);
 		$user1->method('getUID')->willReturn('user1');
 		$user1->method('canChangeDisplayName')->willReturn(false);
 		$data[] = [$user1, $user1, false, false, false];
 
-		$user1 = $this->getMock('\OCP\IUser');
+		$user1 = $this->createMock(IUser::class);
 		$user1->method('getUID')->willReturn('user1');
-		$user2 = $this->getMock('\OCP\IUser');
+		$user2 = $this->createMock(IUser::class);
 		$user2->method('getUID')->willReturn('user2');
 		$user2->method('canChangeDisplayName')->willReturn(true);
 		$data[] = [$user1, $user2, false, false, false];
 
-		$user1 = $this->getMock('\OCP\IUser');
+		$user1 = $this->createMock(IUser::class);
 		$user1->method('getUID')->willReturn('user1');
-		$user2 = $this->getMock('\OCP\IUser');
+		$user2 = $this->createMock(IUser::class);
 		$user2->method('getUID')->willReturn('user2');
 		$user2->method('canChangeDisplayName')->willReturn(true);
 		$data[] = [$user1, $user2, true, false, true];
 
-		$user1 = $this->getMock('\OCP\IUser');
+		$user1 = $this->createMock(IUser::class);
 		$user1->method('getUID')->willReturn('user1');
-		$user2 = $this->getMock('\OCP\IUser');
+		$user2 = $this->createMock(IUser::class);
 		$user2->method('getUID')->willReturn('user2');
 		$user2->method('canChangeDisplayName')->willReturn(true);
 		$data[] = [$user1, $user2, false, true, true];
@@ -1981,7 +1984,7 @@ class UsersControllerTest extends \Test\TestCase {
 	}
 
 	public function testSetDisplayNameFails() {
-		$user = $this->getMock('\OCP\IUser');
+		$user = $this->createMock(IUser::class);
 		$user->method('canChangeDisplayname')->willReturn(true);
 		$user->method('getUID')->willReturn('user');
 		$user->expects($this->once())

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -8,6 +8,7 @@
  */
 
 namespace Test;
+use OC\AppConfig;
 use OCP\IAppConfig;
 
 /**
@@ -476,13 +477,11 @@ class AppTest extends \Test\TestCase {
 
 
 	private function setupAppConfigMock() {
-		$appConfig = $this->getMock(
-			'\OC\AppConfig',
-			array('getValues'),
-			array(\OC::$server->getDatabaseConnection()),
-			'',
-			false
-		);
+		$appConfig = $this->getMockBuilder(AppConfig::class)
+			->setMethods(['getValues'])
+			->setConstructorArgs([\OC::$server->getDatabaseConnection()])
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->registerAppConfig($appConfig);
 		return $appConfig;

--- a/tests/lib/BackgroundJob/JobListTest.php
+++ b/tests/lib/BackgroundJob/JobListTest.php
@@ -8,8 +8,10 @@
 
 namespace Test\BackgroundJob;
 
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJob;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IConfig;
 use Test\TestCase;
 
 /**
@@ -36,8 +38,8 @@ class JobListTest extends TestCase {
 
 		$this->connection = \OC::$server->getDatabaseConnection();
 		$this->clearJobsList();
-		$this->config = $this->getMock('OCP\IConfig');
-		$this->timeFactory = $this->getMock('OCP\AppFramework\Utility\ITimeFactory');
+		$this->config = $this->createMock(IConfig::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->instance = new \OC\BackgroundJob\JobList(
 			$this->connection,
 			$this->config,

--- a/tests/lib/Cache/FileCacheTest.php
+++ b/tests/lib/Cache/FileCacheTest.php
@@ -21,6 +21,7 @@
  */
 
 namespace Test\Cache;
+use OC\Files\Storage\Local;
 
 /**
  * Class FileCacheTest
@@ -102,11 +103,10 @@ class FileCacheTest extends TestCache {
 	}
 
 	private function setupMockStorage() {
-		$mockStorage = $this->getMock(
-			'\OC\Files\Storage\Local',
-			['filemtime', 'unlink'],
-			[['datadir' => \OC::$server->getTempManager()->getTemporaryFolder()]]
-		);
+		$mockStorage = $this->getMockBuilder(Local::class)
+			->setMethods(['filemtime', 'unlink'])
+			->setConstructorArgs([['datadir' => \OC::$server->getTempManager()->getTemporaryFolder()]])
+			->getMock();
 
 		\OC\Files\Filesystem::mount($mockStorage, array(), '/test/cache');
 

--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -3,6 +3,7 @@
 namespace Test\Comments;
 
 use OCP\Comments\ICommentsManager;
+use OCP\IUser;
 use Test\TestCase;
 
 /**
@@ -561,7 +562,7 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testSetMarkRead() {
-		$user = $this->getMock('\OCP\IUser');
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('alice'));
@@ -577,7 +578,7 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testSetMarkReadUpdate() {
-		$user = $this->getMock('\OCP\IUser');
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('alice'));
@@ -596,7 +597,7 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testReadMarkDeleteUser() {
-		$user = $this->getMock('\OCP\IUser');
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('alice'));
@@ -613,7 +614,7 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testReadMarkDeleteObject() {
-		$user = $this->getMock('\OCP\IUser');
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('alice'));

--- a/tests/lib/Encryption/DecryptAllTest.php
+++ b/tests/lib/Encryption/DecryptAllTest.php
@@ -29,6 +29,7 @@ use OC\Encryption\Manager;
 use OC\Files\FileInfo;
 use OC\Files\View;
 use OCP\IUserManager;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Test\TestCase;
 
 /**
@@ -78,7 +79,7 @@ class DecryptAllTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 
 		$this->outputInterface->expects($this->any())->method('getFormatter')
-			->willReturn($this->getMock('\Symfony\Component\Console\Formatter\OutputFormatterInterface'));
+			->willReturn($this->createMock(OutputFormatterInterface::class));
 
 		$this->instance = new DecryptAll($this->encryptionManager, $this->userManager, $this->view);
 

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -10,6 +10,7 @@ namespace Test\Files\Cache;
 
 
 use Doctrine\DBAL\Platforms\MySqlPlatform;
+use OC\Files\Cache\Cache;
 
 class LongId extends \OC\Files\Storage\Temporary {
 	public function getId() {
@@ -500,7 +501,10 @@ class CacheTest extends \Test\TestCase {
 		/**
 		 * @var \OC\Files\Cache\Cache | \PHPUnit_Framework_MockObject_MockObject $cacheMock
 		 */
-		$cacheMock = $this->getMock('\OC\Files\Cache\Cache', array('normalize'), array($this->storage), '', true);
+		$cacheMock = $this->getMockBuilder(Cache::class)
+			->setMethods(['normalize'])
+			->setConstructorArgs([$this->storage])
+			->getMock();
 
 		$cacheMock->expects($this->any())
 			->method('normalize')

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -47,7 +47,7 @@ class UserMountCacheTest extends TestCase {
 		$userBackend->createUser('u1', '');
 		$userBackend->createUser('u2', '');
 		$this->userManager->registerBackend($userBackend);
-		$this->cache = new \OC\Files\Config\UserMountCache($this->connection, $this->userManager, $this->getMock('\OC\Log'));
+		$this->cache = new \OC\Files\Config\UserMountCache($this->connection, $this->userManager, $this->createMock(Log::class));
 	}
 
 	public function tearDown() {

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -10,13 +10,17 @@ namespace Test\Files\Node;
 
 use OC\Files\Cache\Cache;
 use OC\Files\FileInfo;
+use OC\Files\Mount\Manager;
 use OC\Files\Mount\MountPoint;
 use OC\Files\Node\Node;
+use OC\Files\Node\Root;
 use OC\Files\Storage\Temporary;
 use OC\Files\Storage\Wrapper\Jail;
+use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OC\Files\View;
+use OCP\Files\Storage;
 
 /**
  * Class FolderTest
@@ -34,7 +38,7 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	protected function getMockStorage() {
-		$storage = $this->getMock('\OCP\Files\Storage');
+		$storage = $this->createMock(Storage::class);
 		$storage->expects($this->any())
 			->method('getId')
 			->will($this->returnValue('home::someuser'));
@@ -46,12 +50,14 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testDelete() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array(), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
+			->setConstructorArgs([$manager, $view, $this->user])
+			->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -99,11 +105,11 @@ class FolderTest extends \Test\TestCase {
 		/**
 		 * @var \OC\Files\Mount\Manager $manager
 		 */
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
+		$view = $this->createMock(View::class);
 		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
 		$root->listen('\OC\Files', 'preDelete', $preListener);
 		$root->listen('\OC\Files', 'postDelete', $postListener);
@@ -131,12 +137,12 @@ class FolderTest extends \Test\TestCase {
 	 * @expectedException \OCP\Files\NotPermittedException
 	 */
 	public function testDeleteNotPermitted() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array(), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -151,12 +157,14 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testGetDirectoryContent() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array(), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
+			->setConstructorArgs([$manager, $view, $this->user])
+			->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -181,12 +189,12 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testGet() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array(), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -200,12 +208,12 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testNodeExists() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array(), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -222,12 +230,12 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testNodeExistsNotExists() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array(), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -242,12 +250,12 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testNewFolder() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array(), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -272,12 +280,12 @@ class FolderTest extends \Test\TestCase {
 	 * @expectedException \OCP\Files\NotPermittedException
 	 */
 	public function testNewFolderNotPermitted() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array(), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -292,12 +300,12 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testNewFile() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array(), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -322,12 +330,12 @@ class FolderTest extends \Test\TestCase {
 	 * @expectedException \OCP\Files\NotPermittedException
 	 */
 	public function testNewFileNotPermitted() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array(), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -342,12 +350,12 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testGetFreeSpace() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array(), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -362,23 +370,23 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testSearch() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array(), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
-		$storage = $this->getMock('\OC\Files\Storage\Storage');
-		$cache = $this->getMock('\OC\Files\Cache\Cache', array(), array(''));
+		$storage = $this->createMock(Storage::class);
+		$cache = $this->getMockBuilder(Cache::class)->setConstructorArgs([''])->getMock();
 
 		$storage->expects($this->once())
 			->method('getCache')
 			->will($this->returnValue($cache));
 
-		$mount = $this->getMock('\OCP\Files\Mount\IMountPoint');
+		$mount = $this->createMock(IMountPoint::class);
 		$mount->expects($this->once())
 			->method('getStorage')
 			->will($this->returnValue($storage));
@@ -410,19 +418,19 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testSearchInRoot() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn', 'getMount'), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
-		$storage = $this->getMock('\OC\Files\Storage\Storage');
-		$cache = $this->getMock('\OC\Files\Cache\Cache', array(), array(''));
+		$storage = $this->createMock(Storage::class);
+		$cache = $this->getMockBuilder(Cache::class)->setConstructorArgs([''])->getMock();
 
-		$mount = $this->getMock('\OCP\Files\Mount\IMountPoint');
+		$mount = $this->createMock(IMountPoint::class);
 		$mount->expects($this->once())
 			->method('getStorage')
 			->will($this->returnValue($storage));
@@ -458,19 +466,19 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testSearchInStorageRoot() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array(), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
-		$storage = $this->getMock('\OC\Files\Storage\Storage');
-		$cache = $this->getMock('\OC\Files\Cache\Cache', array(), array(''));
+		$storage = $this->createMock(Storage::class);
+		$cache = $this->getMockBuilder(Cache::class)->setConstructorArgs([''])->getMock();
 
-		$mount = $this->getMock('\OCP\Files\Mount\IMountPoint');
+		$mount = $this->createMock(IMountPoint::class);
 		$mount->expects($this->once())
 			->method('getStorage')
 			->will($this->returnValue($storage));
@@ -506,19 +514,19 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testSearchByTag() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array(), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
-		$storage = $this->getMock('\OC\Files\Storage\Storage');
-		$cache = $this->getMock('\OC\Files\Cache\Cache', array(), array(''));
+		$storage = $this->createMock(Storage::class);
+		$cache = $this->getMockBuilder(Cache::class)->setConstructorArgs([''])->getMock();
 
-		$mount = $this->getMock('\OCP\Files\Mount\IMountPoint');
+		$mount = $this->createMock(IMountPoint::class);
 		$mount->expects($this->once())
 			->method('getStorage')
 			->will($this->returnValue($storage));
@@ -554,22 +562,22 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testSearchSubStorages() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array(), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
-		$storage = $this->getMock('\OC\Files\Storage\Storage');
-		$cache = $this->getMock('\OC\Files\Cache\Cache', array(), array(''));
-		$subCache = $this->getMock('\OC\Files\Cache\Cache', array(), array(''));
-		$subStorage = $this->getMock('\OC\Files\Storage\Storage');
-		$subMount = $this->getMock('\OC\Files\Mount\MountPoint', array(), array(null, ''));
+		$storage = $this->createMock(Storage::class);
+		$cache = $this->getMockBuilder(Cache::class)->setConstructorArgs([''])->getMock();
+		$subCache = $this->getMockBuilder(Cache::class)->setConstructorArgs([''])->getMock();
+		$subStorage = $this->createMock(Storage::class);
+		$subMount = $this->getMockBuilder(MountPoint::class)->setConstructorArgs([null, ''])->getMock();
 
-		$mount = $this->getMock('\OCP\Files\Mount\IMountPoint');
+		$mount = $this->createMock(IMountPoint::class);
 		$mount->expects($this->once())
 			->method('getStorage')
 			->will($this->returnValue($storage));
@@ -634,18 +642,18 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testGetById() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn', 'getMount'), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
-		$storage = $this->getMock('\OC\Files\Storage\Storage');
+		$storage = $this->createMock(\OC\Files\Storage\Storage::class);
 		$mount = new MountPoint($storage, '/bar');
-		$cache = $this->getMock('\OC\Files\Cache\Cache', array(), array(''));
+		$cache = $this->getMockBuilder(Cache::class)->setConstructorArgs([''])->getMock();
 
 		$view->expects($this->once())
 			->method('getFileInfo')
@@ -677,18 +685,18 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testGetByIdOutsideFolder() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn', 'getMount'), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
-		$storage = $this->getMock('\OC\Files\Storage\Storage');
+		$storage = $this->createMock(\OC\Files\Storage\Storage::class);
 		$mount = new MountPoint($storage, '/bar');
-		$cache = $this->getMock('\OC\Files\Cache\Cache', array(), array(''));
+		$cache = $this->getMockBuilder(Cache::class)->setConstructorArgs([''])->getMock();
 
 		$storage->expects($this->once())
 			->method('getCache')
@@ -715,19 +723,19 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testGetByIdMultipleStorages() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn', 'getMount'), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
-		$storage = $this->getMock('\OC\Files\Storage\Storage');
+		$storage = $this->createMock(\OC\Files\Storage\Storage::class);
 		$mount1 = new MountPoint($storage, '/bar');
 		$mount2 = new MountPoint($storage, '/bar/foo/asd');
-		$cache = $this->getMock('\OC\Files\Cache\Cache', array(), array(''));
+		$cache = $this->getMockBuilder(Cache::class)->setConstructorArgs([''])->getMock();
 
 		$view->expects($this->any())
 			->method('getFileInfo')
@@ -772,13 +780,13 @@ class FolderTest extends \Test\TestCase {
 	 * @dataProvider uniqueNameProvider
 	 */
 	public function testGetUniqueName($name, $existingFiles, $expected) {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		$folderPath = '/bar/foo';
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn', 'getMount'), array($manager, $view, $this->user));
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])->setConstructorArgs([$manager, $view, $this->user])->getMock();
 
 		$view->expects($this->any())
 			->method('file_exists')
@@ -796,14 +804,14 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testRecent() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		$folderPath = '/bar/foo';
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
+		$view = $this->createMock(View::class);
 		/** @var \PHPUnit_Framework_MockObject_MockObject|\OC\Files\Node\Root $root */
-		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn', 'getMount'), array($manager, $view, $this->user));
+		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		/** @var \PHPUnit_Framework_MockObject_MockObject|\OC\Files\FileInfo $folderInfo */
 		$folderInfo = $this->getMockBuilder('\OC\Files\FileInfo')
 			->disableOriginalConstructor()->getMock();
@@ -854,14 +862,14 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testRecentFolder() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		$folderPath = '/bar/foo';
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
+		$view = $this->createMock(View::class);
 		/** @var \PHPUnit_Framework_MockObject_MockObject|\OC\Files\Node\Root $root */
-		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn', 'getMount'), array($manager, $view, $this->user));
+		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		/** @var \PHPUnit_Framework_MockObject_MockObject|\OC\Files\FileInfo $folderInfo */
 		$folderInfo = $this->getMockBuilder('\OC\Files\FileInfo')
 			->disableOriginalConstructor()->getMock();
@@ -910,14 +918,14 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	public function testRecentJail() {
-		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		$folderPath = '/bar/foo';
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMock('\OC\Files\View');
+		$view = $this->createMock(View::class);
 		/** @var \PHPUnit_Framework_MockObject_MockObject|\OC\Files\Node\Root $root */
-		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn', 'getMount'), array($manager, $view, $this->user));
+		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])->setConstructorArgs([$manager, $view, $this->user])->getMock();
 		/** @var \PHPUnit_Framework_MockObject_MockObject|\OC\Files\FileInfo $folderInfo */
 		$folderInfo = $this->getMockBuilder('\OC\Files\FileInfo')
 			->disableOriginalConstructor()->getMock();

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -10,6 +10,7 @@ namespace Test\Files\Storage\Wrapper;
 
 //ensure the constants are loaded
 use OC\Files\Cache\CacheEntry;
+use OC\Files\Storage\Local;
 
 \OC::$loader->load('\OC\Files\Filesystem');
 
@@ -75,11 +76,10 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 	}
 
 	public function testFreeSpaceWithUnknownDiskSpace() {
-		$storage = $this->getMock(
-			'\OC\Files\Storage\Local',
-			array('free_space'),
-			array(array('datadir' => $this->tmpDir))
-		);
+		$storage = $this->getMockBuilder(Local::class)
+			->setMethods(['free_space'])
+			->setConstructorArgs([['datadir' => $this->tmpDir]])
+			->getMock();
 		$storage->expects($this->any())
 			->method('free_space')
 			->will($this->returnValue(-2));
@@ -132,10 +132,10 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 	}
 
 	public function testReturnFalseWhenFopenFailed() {
-		$failStorage = $this->getMock(
-			'\OC\Files\Storage\Local',
-			array('fopen'),
-			array(array('datadir' => $this->tmpDir)));
+		$failStorage = $this->getMockBuilder(Local::class)
+			->setMethods(['fopen'])
+			->setConstructorArgs([['datadir' => $this->tmpDir]])
+			->getMock();
 		$failStorage->expects($this->any())
 			->method('fopen')
 			->will($this->returnValue(false));

--- a/tests/lib/Files/Utils/ScannerTest.php
+++ b/tests/lib/Files/Utils/ScannerTest.php
@@ -11,6 +11,7 @@ namespace Test\Files\Utils;
 use OC\Files\Filesystem;
 use OC\Files\Mount\MountPoint;
 use OC\Files\Storage\Temporary;
+use OCP\Files\Config\IMountProvider;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\IUser;
 
@@ -107,7 +108,7 @@ class ScannerTest extends \Test\TestCase {
 		$uid = $this->getUniqueID();
 		$this->userBackend->createUser($uid, 'test');
 
-		$mountProvider = $this->getMock('\OCP\Files\Config\IMountProvider');
+		$mountProvider = $this->createMock(IMountProvider::class);
 
 		$storage = new Temporary(array());
 		$mount = new MountPoint($storage, '/' . $uid . '/files/foo');

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -12,8 +12,10 @@ use OC\Files\Cache\Watcher;
 use OC\Files\Storage\Common;
 use OC\Files\Mount\MountPoint;
 use OC\Files\Storage\Temporary;
+use OCP\Files\Config\IMountProvider;
 use OCP\Files\FileInfo;
 use OCP\Lock\ILockingProvider;
+use Test\TestMoveableMountPoint;
 
 class TemporaryNoTouch extends \OC\Files\Storage\Temporary {
 	public function touch($path, $mtime = null) {
@@ -1529,14 +1531,13 @@ class ViewTest extends \Test\TestCase {
 				->setMethods([])
 				->getMock();
 
-			$mounts[] = $this->getMock(
-				'\Test\TestMoveableMountPoint',
-				['moveMount'],
-				[$storage, $mountPoint]
-			);
+			$mounts[] = $this->getMockBuilder(TestMoveableMountPoint::class)
+				->setMethods(['moveMount'])
+				->setConstructorArgs([$storage, $mountPoint])
+				->getMock();
 		}
 
-		$mountProvider = $this->getMock('\OCP\Files\Config\IMountProvider');
+		$mountProvider = $this->createMock(IMountProvider::class);
 		$mountProvider->expects($this->any())
 			->method('getMountsForUser')
 			->will($this->returnValue($mounts));

--- a/tests/lib/HelperStorageTest.php
+++ b/tests/lib/HelperStorageTest.php
@@ -7,6 +7,7 @@
  */
 
 namespace Test;
+use OC\Files\Storage\Temporary;
 
 /**
  * Test the storage functions of OC_Helper
@@ -62,12 +63,10 @@ class HelperStorageTest extends \Test\TestCase {
 	 * @return \OC\Files\Storage\Storage
 	 */
 	private function getStorageMock($freeSpace = 12) {
-		$this->storageMock = $this->getMock(
-			'\OC\Files\Storage\Temporary',
-			array('free_space'),
-			array('')
-		);
-
+		$this->storageMock = $this->getMockBuilder(Temporary::class)
+			->setMethods(['free_space'])
+			->setConstructorArgs([''])
+			->getMock();
 
 		$this->storageMock->expects($this->once())
 			->method('free_space')

--- a/tests/lib/Lock/DBLockingProviderTest.php
+++ b/tests/lib/Lock/DBLockingProviderTest.php
@@ -21,6 +21,7 @@
 
 namespace Test\Lock;
 
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Lock\ILockingProvider;
 
 /**
@@ -50,7 +51,7 @@ class DBLockingProviderTest extends LockingProvider {
 
 	public function setUp() {
 		$this->currentTime = time();
-		$this->timeFactory = $this->getMock('\OCP\AppFramework\Utility\ITimeFactory');
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->timeFactory->expects($this->any())
 			->method('getTime')
 			->will($this->returnCallback(function () {

--- a/tests/lib/Repair/RepairUnmergedSharesTest.php
+++ b/tests/lib/Repair/RepairUnmergedSharesTest.php
@@ -24,6 +24,7 @@ namespace Test\Repair;
 
 use OC\Repair\RepairUnmergedShares;
 use OC\Share\Constants;
+use OCP\IUser;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use Test\TestCase;
@@ -69,8 +70,8 @@ class RepairUnmergedSharesTest extends TestCase {
 		$this->connection = \OC::$server->getDatabaseConnection();
 		$this->deleteAllShares();
 
-		$this->userManager = $this->getMock('\OCP\IUserManager');
-		$this->groupManager = $this->getMock('\OCP\IGroupManager');
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
 
 		// used to generate incremental stimes
 		$this->lastShareTime = time();
@@ -487,12 +488,12 @@ class RepairUnmergedSharesTest extends TestCase {
 	 * @dataProvider sharesDataProvider
 	 */
 	public function testMergeGroupShares($shares, $expectedShares) {
-		$user1 = $this->getMock('\OCP\IUser');
+		$user1 = $this->createMock(IUser::class);
 		$user1->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('user1'));
 
-		$user2 = $this->getMock('\OCP\IUser');
+		$user2 = $this->createMock(IUser::class);
 		$user2->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('user2'));

--- a/tests/lib/Security/CertificateManagerTest.php
+++ b/tests/lib/Security/CertificateManagerTest.php
@@ -9,6 +9,7 @@
 namespace Test\Security;
 
 use \OC\Security\CertificateManager;
+use OCP\IConfig;
 
 /**
  * Class CertificateManagerTest
@@ -38,7 +39,7 @@ class CertificateManagerTest extends \Test\TestCase {
 		\OC\Files\Filesystem::tearDown();
 		\OC_Util::setupFS($this->username);
 
-		$config = $this->getMock('OCP\IConfig');
+		$config = $this->createMock(IConfig::class);
 		$config->expects($this->any())->method('getSystemValue')
 			->with('installed', false)->willReturn(true);
 
@@ -138,7 +139,7 @@ class CertificateManagerTest extends \Test\TestCase {
 
 		$view = $this->getMockBuilder('OC\Files\View')
 			->disableOriginalConstructor()->getMock();
-		$config = $this->getMock('OCP\IConfig');
+		$config = $this->createMock(IConfig::class);
 
 		/** @var CertificateManager | \PHPUnit_Framework_MockObject_MockObject $certificateManager */
 		$certificateManager = $this->getMockBuilder('OC\Security\CertificateManager')

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -2413,7 +2413,7 @@ class ManagerTest extends \Test\TestCase {
 		$tomorrow->setTime(0,0,0);
 		$tomorrow->add(new \DateInterval('P1D'));
 
-		$file = $this->getMock('OCP\Files\File', [], [], 'File');
+		$file = $this->createMock(File::class);
 		$file->method('getId')->willReturn(100);
 
 		$share = $this->manager->newShare();

--- a/tests/lib/TagsTest.php
+++ b/tests/lib/TagsTest.php
@@ -21,6 +21,7 @@
 */
 
 namespace Test;
+use OCP\IUserSession;
 
 /**
  * Class TagsTest
@@ -49,7 +50,7 @@ class TagsTest extends \Test\TestCase {
 		\OC::$server->getUserManager()->createUser($userId, 'pass');
 		\OC_User::setUserId($userId);
 		$this->user = new \OC\User\User($userId, null);
-		$this->userSession = $this->getMock('\OCP\IUserSession');
+		$this->userSession = $this->createMock(IUserSession::class);
 		$this->userSession
 			->expects($this->any())
 			->method('getUser')
@@ -70,7 +71,7 @@ class TagsTest extends \Test\TestCase {
 	}
 
 	public function testTagManagerWithoutUserReturnsNull() {
-		$this->userSession = $this->getMock('\OCP\IUserSession');
+		$this->userSession = $this->createMock(IUserSession::class);
 		$this->userSession
 			->expects($this->any())
 			->method('getUser')
@@ -294,7 +295,7 @@ class TagsTest extends \Test\TestCase {
 		$otherUserId = $this->getUniqueID('user2_');
 		\OC::$server->getUserManager()->createUser($otherUserId, 'pass');
 		\OC_User::setUserId($otherUserId);
-		$otherUserSession = $this->getMock('\OCP\IUserSession');
+		$otherUserSession = $this->createMock(IUserSession::class);
 		$otherUserSession
 			->expects($this->any())
 			->method('getUser')

--- a/tests/lib/UrlGeneratorTest.php
+++ b/tests/lib/UrlGeneratorTest.php
@@ -7,6 +7,8 @@
  */
 
 namespace Test;
+use OCP\ICacheFactory;
+use OCP\IConfig;
 
 /**
  * Class UrlGeneratorTest
@@ -22,8 +24,8 @@ class UrlGeneratorTest extends \Test\TestCase {
 	 */
 	public function testLinkToDocRoot($app, $file, $args, $expectedResult) {
 		\OC::$WEBROOT = '';
-		$config = $this->getMock('\OCP\IConfig');
-		$cacheFactory = $this->getMock('\OCP\ICacheFactory');
+		$config = $this->createMock(IConfig::class);
+		$cacheFactory = $this->createMock(ICacheFactory::class);
 		$urlGenerator = new \OC\URLGenerator($config, $cacheFactory);
 		$result = $urlGenerator->linkTo($app, $file, $args);
 
@@ -37,8 +39,8 @@ class UrlGeneratorTest extends \Test\TestCase {
 	 */
 	public function testLinkToSubDir($app, $file, $args, $expectedResult) {
 		\OC::$WEBROOT = '/owncloud';
-		$config = $this->getMock('\OCP\IConfig');
-		$cacheFactory = $this->getMock('\OCP\ICacheFactory');
+		$config = $this->createMock(IConfig::class);
+		$cacheFactory = $this->createMock(ICacheFactory::class);
 		$urlGenerator = new \OC\URLGenerator($config, $cacheFactory);
 		$result = $urlGenerator->linkTo($app, $file, $args);
 
@@ -50,8 +52,8 @@ class UrlGeneratorTest extends \Test\TestCase {
 	 */
 	public function testLinkToRouteAbsolute($route, $expected) {
 		\OC::$WEBROOT = '/owncloud';
-		$config = $this->getMock('\OCP\IConfig');
-		$cacheFactory = $this->getMock('\OCP\ICacheFactory');
+		$config = $this->createMock(IConfig::class);
+		$cacheFactory = $this->createMock(ICacheFactory::class);
 		$urlGenerator = new \OC\URLGenerator($config, $cacheFactory);
 		$result = $urlGenerator->linkToRouteAbsolute($route);
 		$this->assertEquals($expected, $result);
@@ -89,8 +91,8 @@ class UrlGeneratorTest extends \Test\TestCase {
 	function testGetAbsoluteURLDocRoot($url, $expectedResult) {
 
 		\OC::$WEBROOT = '';
-		$config = $this->getMock('\OCP\IConfig');
-		$cacheFactory = $this->getMock('\OCP\ICacheFactory');
+		$config = $this->createMock(IConfig::class);
+		$cacheFactory = $this->createMock(ICacheFactory::class);
 		$urlGenerator = new \OC\URLGenerator($config, $cacheFactory);
 		$result = $urlGenerator->getAbsoluteURL($url);
 
@@ -105,8 +107,8 @@ class UrlGeneratorTest extends \Test\TestCase {
 	function testGetAbsoluteURLSubDir($url, $expectedResult) {
 
 		\OC::$WEBROOT = '/owncloud';
-		$config = $this->getMock('\OCP\IConfig');
-		$cacheFactory = $this->getMock('\OCP\ICacheFactory');
+		$config = $this->createMock(IConfig::class);
+		$cacheFactory = $this->createMock(ICacheFactory::class);
 		$urlGenerator = new \OC\URLGenerator($config, $cacheFactory);
 		$result = $urlGenerator->getAbsoluteURL($url);
 

--- a/tests/lib/User/DatabaseTest.php
+++ b/tests/lib/User/DatabaseTest.php
@@ -45,7 +45,7 @@ class DatabaseTest extends Backend {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcher');
+		$this->eventDispatcher = $this->createMock(EventDispatcher::class);
 
 		$this->backend=new \OC\User\Database($this->eventDispatcher);
 	}

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -8,6 +8,7 @@
  */
 
 namespace Test\User;
+use OC\User\Database;
 
 /**
  * Class ManagerTest
@@ -18,11 +19,11 @@ namespace Test\User;
  */
 class ManagerTest extends \Test\TestCase {
 	public function testGetBackends() {
-		$userDummyBackend = $this->getMock('\Test\Util\User\Dummy');
+		$userDummyBackend = $this->createMock(\Test\Util\User\Dummy::class);
 		$manager = new \OC\User\Manager();
 		$manager->registerBackend($userDummyBackend);
 		$this->assertEquals([$userDummyBackend], $manager->getBackends());
-		$dummyDatabaseBackend = $this->getMock('\OC_User_Database');
+		$dummyDatabaseBackend = $this->createMock(Database::class);
 		$manager->registerBackend($dummyDatabaseBackend);
 		$this->assertEquals([$userDummyBackend, $dummyDatabaseBackend], $manager->getBackends());
 	}
@@ -32,7 +33,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('userExists')
 			->with($this->equalTo('foo'))
@@ -48,7 +49,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('userExists')
 			->with($this->equalTo('foo'))
@@ -70,7 +71,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend1
 		 */
-		$backend1 = $this->getMock('\Test\Util\User\Dummy');
+		$backend1 = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend1->expects($this->once())
 			->method('userExists')
 			->with($this->equalTo('foo'))
@@ -79,7 +80,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend2
 		 */
-		$backend2 = $this->getMock('\Test\Util\User\Dummy');
+		$backend2 = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend2->expects($this->once())
 			->method('userExists')
 			->with($this->equalTo('foo'))
@@ -96,7 +97,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend1
 		 */
-		$backend1 = $this->getMock('\Test\Util\User\Dummy');
+		$backend1 = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend1->expects($this->once())
 			->method('userExists')
 			->with($this->equalTo('foo'))
@@ -105,7 +106,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend2
 		 */
-		$backend2 = $this->getMock('\Test\Util\User\Dummy');
+		$backend2 = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend2->expects($this->never())
 			->method('userExists');
 
@@ -120,7 +121,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('checkPassword')
 			->with($this->equalTo('foo'), $this->equalTo('bar'))
@@ -147,7 +148,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->never())
 			->method('checkPassword');
 
@@ -165,7 +166,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('userExists')
 			->with($this->equalTo('foo'))
@@ -181,7 +182,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('userExists')
 			->with($this->equalTo('foo'))
@@ -197,7 +198,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('getUsers')
 			->with($this->equalTo('fo'))
@@ -216,7 +217,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend1
 		 */
-		$backend1 = $this->getMock('\Test\Util\User\Dummy');
+		$backend1 = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend1->expects($this->once())
 			->method('getUsers')
 			->with($this->equalTo('fo'), $this->equalTo(3), $this->equalTo(1))
@@ -225,7 +226,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend2
 		 */
-		$backend2 = $this->getMock('\Test\Util\User\Dummy');
+		$backend2 = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend2->expects($this->once())
 			->method('getUsers')
 			->with($this->equalTo('fo'), $this->equalTo(3), $this->equalTo(1))
@@ -246,7 +247,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnValue(true));
@@ -274,7 +275,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnValue(true));
@@ -297,7 +298,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnValue(false));
@@ -329,7 +330,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend1
 		 */
-		$backend1 = $this->getMock('\Test\Util\User\Dummy');
+		$backend1 = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend1->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnValue(true));
@@ -345,7 +346,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend2
 		 */
-		$backend2 = $this->getMock('\Test\Util\User\Dummy');
+		$backend2 = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend2->expects($this->any())
 			->method('implementsActions')
 			->will($this->returnValue(true));
@@ -377,7 +378,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('countUsers')
 			->will($this->returnValue(7));
@@ -406,7 +407,7 @@ class ManagerTest extends \Test\TestCase {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend1 = $this->getMock('\Test\Util\User\Dummy');
+		$backend1 = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend1->expects($this->once())
 			->method('countUsers')
 			->will($this->returnValue(7));
@@ -419,7 +420,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('getBackendName')
 			->will($this->returnValue('Mock_Test_Util_User_Dummy'));
 
-		$backend2 = $this->getMock('\Test\Util\User\Dummy');
+		$backend2 = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend2->expects($this->once())
 			->method('countUsers')
 			->will($this->returnValue(16));

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -10,6 +10,7 @@
 namespace Test\User;
 
 use OC\Hooks\PublicEmitter;
+use OC\User\Database;
 
 /**
  * Class UserTest
@@ -23,7 +24,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\OC\User\Backend');
+		$backend = $this->createMock(\OC\User\Backend::class);
 		$backend->expects($this->once())
 			->method('getDisplayName')
 			->with($this->equalTo('foo'))
@@ -45,7 +46,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\OC\User\Backend');
+		$backend = $this->createMock(\OC\User\Backend::class);
 		$backend->expects($this->once())
 			->method('getDisplayName')
 			->with($this->equalTo('foo'))
@@ -64,7 +65,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\OC\User\Backend');
+		$backend = $this->createMock(\OC\User\Backend::class);
 		$backend->expects($this->never())
 			->method('getDisplayName');
 
@@ -81,7 +82,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('setPassword')
 			->with($this->equalTo('foo'), $this->equalTo('bar'));
@@ -104,7 +105,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->never())
 			->method('setPassword');
 
@@ -120,7 +121,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('Test\User\AvatarUserDummy');
+		$backend = $this->createMock(AvatarUserDummy::class);
 		$backend->expects($this->once())
 			->method('canChangeAvatar')
 			->with($this->equalTo('foo'))
@@ -144,7 +145,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('Test\User\AvatarUserDummy');
+		$backend = $this->createMock(AvatarUserDummy::class);
 		$backend->expects($this->once())
 			->method('canChangeAvatar')
 			->with($this->equalTo('foo'))
@@ -168,7 +169,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('Test\User\AvatarUserDummy');
+		$backend = $this->createMock(AvatarUserDummy::class);
 		$backend->expects($this->never())
 			->method('canChangeAvatar');
 
@@ -186,7 +187,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('deleteUser')
 			->with($this->equalTo('foo'));
@@ -199,7 +200,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('getHome')
 			->with($this->equalTo('foo'))
@@ -230,7 +231,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->never())
 			->method('getHome');
 
@@ -257,7 +258,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 
 		$backend->expects($this->any())
 			->method('implementsActions')
@@ -277,7 +278,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 
 		$backend->expects($this->any())
 			->method('implementsActions')
@@ -291,7 +292,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 
 		$backend->expects($this->any())
 			->method('implementsActions')
@@ -311,7 +312,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 
 		$backend->expects($this->any())
 			->method('implementsActions')
@@ -325,7 +326,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\OC\User\Database');
+		$backend = $this->createMock(Database::class);
 
 		$backend->expects($this->any())
 			->method('implementsActions')
@@ -354,7 +355,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\OC\User\Database');
+		$backend = $this->createMock(Database::class);
 
 		$backend->expects($this->any())
 			->method('implementsActions')
@@ -375,7 +376,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\OC\User\Database');
+		$backend = $this->createMock(Database::class);
 
 		$backend->expects($this->any())
 			->method('implementsActions')
@@ -398,7 +399,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('setPassword');
 
@@ -439,7 +440,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$backend->expects($this->once())
 			->method('deleteUser');
 
@@ -464,7 +465,7 @@ class UserTest extends \Test\TestCase {
 		/**
 		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
 		 */
-		$backend = $this->getMock('\Test\Util\User\Dummy');
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$urlGenerator = $this->getMockBuilder('\OC\URLGenerator')
 				->setMethods(['getAbsoluteURL'])
 				->disableOriginalConstructor()->getMock();

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -9,7 +9,14 @@
 namespace Test;
 
 use OC_Util;
+use OCP\App\IAppManager;
 
+/**
+ * Class UtilTest
+ *
+ * @package Test
+ * @group DB
+ */
 class UtilTest extends \Test\TestCase {
 	public function testGetVersion() {
 		$version = \OCP\Util::getVersion();
@@ -300,7 +307,7 @@ class UtilTest extends \Test\TestCase {
 		$oldWebRoot = \OC::$WEBROOT;
 		\OC::$WEBROOT = '';
 
-		$appManager = $this->getMock('\OCP\App\IAppManager');
+		$appManager = $this->createMock(IAppManager::class);
 		$appManager->expects($this->any())
 			->method('isEnabledForUser')
 			->will($this->returnCallback(function($appId) use ($enabledApps){


### PR DESCRIPTION
PHPUnit output should be as clean as possible.
- No more getMock warnings

CC: @MorrisJobke @nickvergessen @LukasReschke 
