### PR TITLE
Pass redirect_url through setup form

### DIFF
--- a/core/js/setup.js
+++ b/core/js/setup.js
@@ -79,6 +79,17 @@ $(document).ready(function() {
 			form.append(input);
 		}
 
+		// Add redirect_url
+		var redirectURL = getURLParameter('redirect_url');
+		if (redirectURL) {
+			var redirectURLInput = $('<input type="hidden">');
+			redirectURLInput.attr({
+				name: 'redirect_url',
+				value: redirectURL
+			});
+			form.append(redirectURLInput);
+		}
+
 		// Submit the form
 		form.appendTo(document.body);
 		form.submit();


### PR DESCRIPTION
When accessing a 'not set up' Nextcloud with a redirect_url parameter
the parameter will is added to the setup POST request, resulting in the
requested redirect after setup is complete.

This is required in scenarios where Nextcloud is used as authorization
provider like on the Spreedbox to allow redirection to the required page
when normally a login form would be shown but the setup form is shown
instead.
