### PR TITLE
Fix MissingMandatoryParametersException for share notifications

### DIFF
--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -123,7 +123,7 @@ class MailNotifications {
 
 			$link = $this->urlGenerator->linkToRouteAbsolute(
 				'files.viewcontroller.showFile',
-				['fileId' => $items[0]['item_source']]
+				['fileid' => $items[0]['item_source']]
 			);
 
 			list($htmlBody, $textBody) = $this->createMailBody($filename, $link, $expiration, 'internal');

--- a/tests/lib/Share/MailNotificationsTest.php
+++ b/tests/lib/Share/MailNotificationsTest.php
@@ -241,10 +241,8 @@ class MailNotificationsTest extends \Test\TestCase {
 		$this->urlGenerator->expects($this->once())
 			->method('linkToRouteAbsolute')
 			->with(
-				$this->equalTo('files.viewcontroller.showFile'),
-				$this->equalTo([
-					'fileId' => 123,
-				])
+				'files.viewcontroller.showFile',
+				['fileid' => 123]
 			);
 
 		$recipientList = [$recipient];


### PR DESCRIPTION
The routing system is non-forgiving.

@rullzer @schiessle 
### Steps
1. Enable share notifications
2. Set up a second user with email
3. Share a file with the user
4. Send notification
### Expected

Email is sent, return is 200
### Actual

> Symfony\Component\Routing\Exception\MissingMandatoryParametersException
> Some mandatory parameters are missing (&quot;fileid&quot;) to generate a URL for route &quot;files.viewcontroller.showFile&quot;

No email

Fix #1277
