### PR TITLE
Chunk if you have too many contacts/events

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -621,7 +621,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		}
 
 		$chunks = array_chunk($uris, 100);
-		$result = [];
+		$objects = [];
 
 		$query = $this->db->getQueryBuilder();
 		$query->select(['id', 'uri', 'lastmodified', 'etag', 'calendarid', 'size', 'calendardata', 'componenttype', 'classification'])
@@ -631,10 +631,10 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 		foreach ($chunks as $uris) {
 			$query->setParameter('uri', $uris, IQueryBuilder::PARAM_STR_ARRAY);
-			$stmt = $query->execute();
+			$result = $query->execute();
 
-			while($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
-				$result[] = [
+			while ($row = $result->fetch()) {
+				$objects[] = [
 					'id'           => $row['id'],
 					'uri'          => $row['uri'],
 					'lastmodified' => $row['lastmodified'],
@@ -646,8 +646,9 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 					'classification' => (int)$row['classification']
 				];
 			}
+			$result->closeCursor();
 		}
-		return $result;
+		return $objects;
 	}
 
 	/**

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -499,11 +499,12 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			$query->setParameter('uri', $uris, IQueryBuilder::PARAM_STR_ARRAY);
 			$result = $query->execute();
 
-			while($row = $result->fetch()) {
+			while ($row = $result->fetch()) {
 				$row['etag'] = '"' . $row['etag'] . '"';
 				$row['carddata'] = $this->readBlob($row['carddata']);
 				$cards[] = $row;
 			}
+			$result->closeCursor();
 		}
 		return $cards;
 	}

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -482,23 +482,29 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	 * @return array
 	 */
 	function getMultipleCards($addressBookId, array $uris) {
+		if (empty($uris)) {
+			return [];
+		}
+
+		$chunks = array_chunk($uris, 100);
+		$cards = [];
+
 		$query = $this->db->getQueryBuilder();
 		$query->select(['id', 'uri', 'lastmodified', 'etag', 'size', 'carddata'])
 			->from('cards')
 			->where($query->expr()->eq('addressbookid', $query->createNamedParameter($addressBookId)))
-			->andWhere($query->expr()->in('uri', $query->createParameter('uri')))
-			->setParameter('uri', $uris, IQueryBuilder::PARAM_STR_ARRAY);
+			->andWhere($query->expr()->in('uri', $query->createParameter('uri')));
 
-		$cards = [];
+		foreach ($chunks as $uris) {
+			$query->setParameter('uri', $uris, IQueryBuilder::PARAM_STR_ARRAY);
+			$result = $query->execute();
 
-		$result = $query->execute();
-		while($row = $result->fetch()) {
-			$row['etag'] = '"' . $row['etag'] . '"';
-			$row['carddata'] = $this->readBlob($row['carddata']);
-			$cards[] = $row;
+			while($row = $result->fetch()) {
+				$row['etag'] = '"' . $row['etag'] . '"';
+				$row['carddata'] = $this->readBlob($row['carddata']);
+				$cards[] = $row;
+			}
 		}
-		$result->closeCursor();
-
 		return $cards;
 	}
 


### PR DESCRIPTION
This can't happen for us coders/nerds, but other people might have more events/contacts then parameters are allowed by the DB backend, so we chunk them.

@karlitschek I think we should backport this to avoid problems when people set up a new calendar/contact sync client that tries to get all on the first sync request.

@LukasReschke @MorrisJobke @nblock 

Fix #791 

Reviewed best without whitespaces: https://github.com/nextcloud/server/pull/1408/files?w=1
