### PR TITLE
Strict CSP for OCS API

### DIFF
--- a/build/integration/features/bootstrap/Sharing.php
+++ b/build/integration/features/bootstrap/Sharing.php
@@ -514,5 +514,28 @@ trait Sharing {
 			throw new \Exception('Expected the same link share to be returned');
 		}
 	}
+
+	/**
+	 * @Then The following headers should be set
+	 * @param \Behat\Gherkin\Node\TableNode $table
+	 * @throws \Exception
+	 */
+	public function theFollowingHeadersShouldBeSet(\Behat\Gherkin\Node\TableNode $table) {
+		foreach($table->getTable() as $header) {
+			$headerName = $header[0];
+			$expectedHeaderValue = $header[1];
+			$returnedHeader = $this->response->getHeader($headerName);
+			if($returnedHeader !== $expectedHeaderValue) {
+				throw new \Exception(
+					sprintf(
+						"Expected value '%s' for header '%s', got '%s'",
+						$expectedHeaderValue,
+						$headerName,
+						$returnedHeader
+					)
+				);
+			}
+		}
+	}
 }
 

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -13,6 +13,8 @@ Feature: sharing
       | shareType | 0 |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
+    And The following headers should be set
+      | Content-Security-Policy | default-src 'none' |
 
   Scenario: Creating a share with a group
     Given user "user0" exists

--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -37,6 +37,7 @@ use OC\AppFramework\Middleware\Security\Exceptions\StrictCookieMissingException;
 use OC\AppFramework\Utility\ControllerMethodReflector;
 use OC\Security\CSP\ContentSecurityPolicyManager;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\AppFramework\Http\EmptyContentSecurityPolicy;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Middleware;
@@ -181,6 +182,10 @@ class SecurityMiddleware extends Middleware {
 	 */
 	public function afterController($controller, $methodName, Response $response) {
 		$policy = !is_null($response->getContentSecurityPolicy()) ? $response->getContentSecurityPolicy() : new ContentSecurityPolicy();
+
+		if (get_class($policy) === EmptyContentSecurityPolicy::class) {
+			return $response;
+		}
 
 		$defaultPolicy = $this->contentSecurityPolicyManager->getDefaultPolicy();
 		$defaultPolicy = $this->contentSecurityPolicyManager->mergePolicies($defaultPolicy, $policy);

--- a/lib/private/AppFramework/OCS/BaseResponse.php
+++ b/lib/private/AppFramework/OCS/BaseResponse.php
@@ -23,6 +23,7 @@
 namespace OC\AppFramework\OCS;
 
 use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\EmptyContentSecurityPolicy;
 use OCP\AppFramework\Http\Response;
 
 abstract class BaseResponse extends Response   {
@@ -67,7 +68,7 @@ abstract class BaseResponse extends Response   {
 		$this->setETag($dataResponse->getETag());
 		$this->setLastModified($dataResponse->getLastModified());
 		$this->setCookies($dataResponse->getCookies());
-		$this->setContentSecurityPolicy($dataResponse->getContentSecurityPolicy());
+		$this->setContentSecurityPolicy(new EmptyContentSecurityPolicy());
 
 		if ($format === 'json') {
 			$this->addHeader(

--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -248,18 +248,18 @@ class Response {
 
 	/**
 	 * Set a Content-Security-Policy
-	 * @param ContentSecurityPolicy $csp Policy to set for the response object
+	 * @param EmptyContentSecurityPolicy $csp Policy to set for the response object
 	 * @return $this
 	 * @since 8.1.0
 	 */
-	public function setContentSecurityPolicy(ContentSecurityPolicy $csp) {
+	public function setContentSecurityPolicy(EmptyContentSecurityPolicy $csp) {
 		$this->contentSecurityPolicy = $csp;
 		return $this;
 	}
 
 	/**
 	 * Get the currently used Content-Security-Policy
-	 * @return ContentSecurityPolicy|null Used Content-Security-Policy or null if
+	 * @return EmptyContentSecurityPolicy|null Used Content-Security-Policy or null if
 	 *                                    none specified.
 	 * @since 8.1.0
 	 */

--- a/tests/lib/AppFramework/Controller/OCSControllerTest.php
+++ b/tests/lib/AppFramework/Controller/OCSControllerTest.php
@@ -26,6 +26,7 @@ namespace Test\AppFramework\Controller;
 
 use OC\AppFramework\Http\Request;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\EmptyContentSecurityPolicy;
 use OCP\AppFramework\OCSController;
 use OCP\IConfig;
 use OCP\Security\ISecureRandom;
@@ -92,8 +93,9 @@ class OCSControllerTest extends \Test\TestCase {
 
 		$params = new DataResponse(['test' => 'hi']);
 
-		$out = $controller->buildResponse($params, 'xml')->render();
-		$this->assertEquals($expected, $out);
+		$response = $controller->buildResponse($params, 'xml');
+		$this->assertSame(EmptyContentSecurityPolicy::class, get_class($response->getContentSecurityPolicy()));
+		$this->assertEquals($expected, $response->render());
 	}
 
 	public function testJSON() {
@@ -111,8 +113,10 @@ class OCSControllerTest extends \Test\TestCase {
 		            '"totalitems":"","itemsperpage":""},"data":{"test":"hi"}}}';
 		$params = new DataResponse(['test' => 'hi']);
 
-		$out = $controller->buildResponse($params, 'json')->render();
-		$this->assertEquals($expected, $out);
+		$response = $controller->buildResponse($params, 'json');
+		$this->assertSame(EmptyContentSecurityPolicy::class, get_class($response->getContentSecurityPolicy()));
+		$this->assertEquals($expected, $response->render());
+		$this->assertEquals($expected, $response->render());
 	}
 
 	public function testXMLV2() {
@@ -141,8 +145,9 @@ class OCSControllerTest extends \Test\TestCase {
 
 		$params = new DataResponse(['test' => 'hi']);
 
-		$out = $controller->buildResponse($params, 'xml')->render();
-		$this->assertEquals($expected, $out);
+		$response = $controller->buildResponse($params, 'xml');
+		$this->assertSame(EmptyContentSecurityPolicy::class, get_class($response->getContentSecurityPolicy()));
+		$this->assertEquals($expected, $response->render());
 	}
 
 	public function testJSONV2() {
@@ -159,7 +164,8 @@ class OCSControllerTest extends \Test\TestCase {
 		$expected = '{"ocs":{"meta":{"status":"ok","statuscode":200,"message":"OK"},"data":{"test":"hi"}}}';
 		$params = new DataResponse(['test' => 'hi']);
 
-		$out = $controller->buildResponse($params, 'json')->render();
-		$this->assertEquals($expected, $out);
+		$response = $controller->buildResponse($params, 'json');
+		$this->assertSame(EmptyContentSecurityPolicy::class, get_class($response->getContentSecurityPolicy()));
+		$this->assertEquals($expected, $response->render());
 	}
 }


### PR DESCRIPTION
Disable loading of all dynamic resources on OCS API responses. There is no need for them.

@LukasReschke as discussed
