### PR TITLE
Optimize sanitizeName

### DIFF
--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -157,7 +157,10 @@ class SimpleContainer extends Container implements IContainer {
 	 * @return string
 	 */
 	protected function sanitizeName($name) {
-		return ltrim($name, '\\');
+		if (isset($name[0]) && $name[0] === '\\') {
+			return ltrim($name, '\\');
+		}
+		return $name;
 	}
 
 }


### PR DESCRIPTION
Even tough ltrim seems easy it does a lot of parsing matching etc. So lets only call it is we need it. In 99% of the cases the function is called by the framework so it is already correct.

Some becnhmarks locally with 1M entries

| Input | `\\OC\\Foo\\Bar` | `OC\\Foo\\Bar` |
| --- | --- | --- |
| old time (in ms) | 751 | 741 |
| new time (in ms) | 824 | 499 |

Not to bad I would say. No change in behaviour just a quick sanity check. And as mentioned in most cases we already pass the $name without leady '\'

CC: @nickvergessen @MorrisJobke @LukasReschke @icewind1991 
