### PR TITLE
Fixup getURLParameter 'null' return and encoding support

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1723,7 +1723,7 @@ function formatDate(timestamp){
  */
 function getURLParameter(name) {
 	return decodeURI(
-			(RegExp(name + '=' + '(.+?)(&|$)').exec(location.search) || [, null])[1]
+			(RegExp(name + '=' + '(.+?)(&|$)').exec(location.search) || [, ''])[1]
 			);
 }
 

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1722,9 +1722,10 @@ function formatDate(timestamp){
  * @return {string}
  */
 function getURLParameter(name) {
-	return decodeURI(
-			(RegExp(name + '=' + '(.+?)(&|$)').exec(location.search) || [, ''])[1]
-			);
+	return decodeURIComponent(
+		(new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(
+			location.search)||[,''])[1].replace(/\+/g, '%20')
+		)||'';
 }
 
 /**


### PR DESCRIPTION
This PR has two commits which change the behavior of getURLParameter to make more sense. The first one is simple and can be merged with little risk to break things ('null' return will instead return ''). 

The second commit probably requires some more thought and might break existing callers of this API which have implemented their own decoding for urlencoded parameter values. It might even be ok to never merge this and keep the current behavior and add it to the docs that the caller are expected to decode values if they need them unencoded.

So please check what the indented behavior should be before merging. At least https://github.com/nextcloud/server/commit/1e9d52304633eed8ad97a1764f4a19cbc6c2b9ed should be cherry-picked asap.
