### PR TITLE
optimize Folder::getById to use less queries

### DIFF
--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -402,8 +402,10 @@ class Share20OCS extends OCSController {
 		} catch (GenericShareException $e) {
 			$code = $e->getCode() === 0 ? 403 : $e->getCode();
 			throw new OCSException($e->getHint(), $code);
-		}catch (\Exception $e) {
+		} catch (\Exception $e) {
 			throw new OCSForbiddenException($e->getMessage());
+		} finally {
+			$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
 		}
 
 		$output = $this->formatShare($share);

--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -414,8 +414,6 @@ class Share20OCS extends OCSController {
 			throw new OCSException($e->getHint(), $code);
 		} catch (\Exception $e) {
 			throw new OCSForbiddenException($e->getMessage());
-		} finally {
-			$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
 		}
 
 		$output = $this->formatShare($share);

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -29,6 +29,7 @@
 
 namespace OCA\Files_Sharing\Tests;
 
+use OC\Files\Cache\Scanner;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
@@ -72,6 +73,8 @@ class ApiTest extends TestCase {
 		$this->view->mkdir($this->folder . $this->subfolder . $this->subsubfolder);
 		$this->view->file_put_contents($this->folder.$this->filename, $this->data);
 		$this->view->file_put_contents($this->folder . $this->subfolder . $this->filename, $this->data);
+		$mount = $this->view->getMount($this->filename);
+		$mount->getStorage()->getScanner()->scan('', Scanner::SCAN_RECURSIVE);
 
 		$this->userFolder = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER1);
 	}
@@ -113,10 +116,8 @@ class ApiTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @medium
-	 */
 	function testCreateShareUserFile() {
+		$this->setUp(); // for some reasons phpunit refuses to do this for us only for this test
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -1194,14 +1194,11 @@ class ApiTest extends TestCase {
 	 * Tests mounting a folder that is an external storage mount point.
 	 */
 	public function testShareStorageMountPoint() {
-		self::$tempStorage = new \OC\Files\Storage\Temporary(array());
-		self::$tempStorage->file_put_contents('test.txt', 'abcdef');
-		self::$tempStorage->getScanner()->scan('');
+		$tempStorage = new \OC\Files\Storage\Temporary(array());
+		$tempStorage->file_put_contents('test.txt', 'abcdef');
+		$tempStorage->getScanner()->scan('');
 
-		// needed because the sharing code sometimes switches the user internally and mounts the user's
-		// storages. In our case the temp storage isn't mounted automatically, so doing it in the post hook
-		// (similar to how ext storage works)
-		\OCP\Util::connectHook('OC_Filesystem', 'post_initMountPoints', '\OCA\Files_Sharing\Tests\ApiTest', 'initTestMountPointsHook');
+		$this->registerMount(self::TEST_FILES_SHARING_API_USER1, $tempStorage, self::TEST_FILES_SHARING_API_USER1 . '/files' . self::TEST_FOLDER_NAME);
 
 		// logging in will auto-mount the temp storage for user1 as well
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -628,7 +628,7 @@ class ApiTest extends TestCase {
 		);
 		foreach ($testValues as $value) {
 
-				$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER2);
+			$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER2);
 			$result = $ocs->getShares('false', 'false', 'true', $value['query']);
 			$ocs->cleanup();
 
@@ -765,6 +765,7 @@ class ApiTest extends TestCase {
 	 * @medium
 	 */
 	function testGetShareMultipleSharedFolder() {
+		$this->setUp();
 		$node1 = $this->userFolder->get($this->folder . $this->subfolder);
 		$share1 = $this->shareManager->newShare();
 		$share1->setNode($node1)
@@ -790,8 +791,9 @@ class ApiTest extends TestCase {
 			->setPermissions(1);
 		$share3 = $this->shareManager->createShare($share3);
 
+		// $request = $this->createRequest(['path' => $this->subfolder]);
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER2);
-		$result1 = $ocs->getShares();
+		$result1 = $ocs->getShares('false','false','false', $this->subfolder);
 		$ocs->cleanup();
 
 		// test should return one share within $this->folder
@@ -799,8 +801,9 @@ class ApiTest extends TestCase {
 		$this->assertCount(1, $data1);
 		$s1 = reset($data1);
 
+		//$request = $this->createRequest(['path' => $this->folder.$this->subfolder]);
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER2);
-		$result2 = $ocs->getShares();
+		$result2 = $ocs->getShares('false', 'false', 'false', $this->folder . $this->subfolder);
 		$ocs->cleanup();
 
 		// test should return one share within $this->folder
@@ -808,7 +811,7 @@ class ApiTest extends TestCase {
 		$this->assertCount(1, $data2);
 		$s2 = reset($data2);
 
-		$this->assertEquals($this->folder.$this->subfolder, $s1['path']);
+		$this->assertEquals($this->subfolder, $s1['path']);
 		$this->assertEquals($this->folder.$this->subfolder, $s2['path']);
 
 		$this->shareManager->deleteShare($share1);

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -58,7 +58,7 @@ class ManagerTest extends TestCase {
 	 * @var \OCP\IUser
 	 */
 	private $user;
-	private $mountProvider;
+	private $testMountProvider;
 
 	protected function setUp() {
 		parent::setUp();
@@ -82,13 +82,13 @@ class ManagerTest extends TestCase {
 			$discoveryManager,
 			$this->uid
 		);
-		$this->mountProvider = new MountProvider(\OC::$server->getDatabaseConnection(), function() {
+		$this->testMountProvider = new MountProvider(\OC::$server->getDatabaseConnection(), function() {
 			return $this->manager;
 		});
 	}
 
 	private function setupMounts() {
-		$mounts = $this->mountProvider->getMountsForUser($this->user, new StorageFactory());
+		$mounts = $this->testMountProvider->getMountsForUser($this->user, new StorageFactory());
 		foreach ($mounts as $mount) {
 			$this->mountManager->addMount($mount);
 		}

--- a/apps/files_sharing/tests/SizePropagationTest.php
+++ b/apps/files_sharing/tests/SizePropagationTest.php
@@ -38,7 +38,6 @@ use Test\Traits\UserTrait;
  */
 class SizePropagationTest extends TestCase {
 	use UserTrait;
-	use MountProviderTrait;
 
 	protected function setupUser($name, $password = '') {
 		$this->createUser($name, $password);

--- a/apps/files_sharing/tests/TestCase.php
+++ b/apps/files_sharing/tests/TestCase.php
@@ -31,8 +31,10 @@
 
 namespace OCA\Files_Sharing\Tests;
 
+use OC\Files\Cache\Scanner;
 use OC\Files\Filesystem;
 use OCA\Files_Sharing\AppInfo\Application;
+use Test\Traits\MountProviderTrait;
 
 /**
  * Class TestCase
@@ -42,6 +44,7 @@ use OCA\Files_Sharing\AppInfo\Application;
  * Base class for sharing tests.
  */
 abstract class TestCase extends \Test\TestCase {
+	use MountProviderTrait;
 
 	const TEST_FILES_SHARING_API_USER1 = "test-share-user1";
 	const TEST_FILES_SHARING_API_USER2 = "test-share-user2";

--- a/lib/private/Files/Config/CachedMountInfo.php
+++ b/lib/private/Files/Config/CachedMountInfo.php
@@ -54,6 +54,11 @@ class CachedMountInfo implements ICachedMountInfo {
 	protected $mountId;
 
 	/**
+	 * @var string
+	 */
+	protected $rootInternalPath;
+
+	/**
 	 * CachedMountInfo constructor.
 	 *
 	 * @param IUser $user
@@ -61,13 +66,15 @@ class CachedMountInfo implements ICachedMountInfo {
 	 * @param int $rootId
 	 * @param string $mountPoint
 	 * @param int|null $mountId
+	 * @param string $rootInternalPath
 	 */
-	public function __construct(IUser $user, $storageId, $rootId, $mountPoint, $mountId = null) {
+	public function __construct(IUser $user, $storageId, $rootId, $mountPoint, $mountId = null, $rootInternalPath = '') {
 		$this->user = $user;
 		$this->storageId = $storageId;
 		$this->rootId = $rootId;
 		$this->mountPoint = $mountPoint;
 		$this->mountId = $mountId;
+		$this->rootInternalPath = $rootInternalPath;
 	}
 
 	/**
@@ -121,5 +128,14 @@ class CachedMountInfo implements ICachedMountInfo {
 	 */
 	public function getMountId() {
 		return $this->mountId;
+	}
+
+	/**
+	 * Get the internal path (within the storage) of the root of the mount
+	 *
+	 * @return string
+	 */
+	public function getRootInternalPath() {
+		return $this->rootInternalPath;
 	}
 }

--- a/lib/private/Files/Config/LazyStorageMountInfo.php
+++ b/lib/private/Files/Config/LazyStorageMountInfo.php
@@ -76,4 +76,13 @@ class LazyStorageMountInfo extends CachedMountInfo {
 	public function getMountId() {
 		return $this->mount->getMountId();
 	}
+
+	/**
+	 * Get the internal path (within the storage) of the root of the mount
+	 *
+	 * @return string
+	 */
+	public function getRootInternalPath() {
+		return $this->mount->getInternalPath($this->mount->getMountPoint());
+	}
 }

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -28,6 +28,7 @@ namespace OC\Files\Node;
 
 use OC\DB\QueryBuilder\Literal;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\Config\ICachedMountInfo;
 use OCP\Files\FileInfo;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException;
@@ -83,7 +84,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 	public function getDirectoryListing() {
 		$folderContent = $this->view->getDirectoryContent($this->path);
 
-		return array_map(function(FileInfo $info) {
+		return array_map(function (FileInfo $info) {
 			if ($info->getMimetype() === 'httpd/unix-directory') {
 				return new Folder($this->root, $this->view, $info->getPath(), $info);
 			} else {
@@ -253,7 +254,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 			}
 		}
 
-		return array_map(function(FileInfo $file) {
+		return array_map(function (FileInfo $file) {
 			return $this->createNode($file->getPath(), $file);
 		}, $files);
 	}
@@ -263,29 +264,45 @@ class Folder extends Node implements \OCP\Files\Folder {
 	 * @return \OC\Files\Node\Node[]
 	 */
 	public function getById($id) {
+		$mountCache = $this->root->getUserMountCache();
+		$mountsContainingFile = $mountCache->getMountsForFileId($id);
 		$mounts = $this->root->getMountsIn($this->path);
 		$mounts[] = $this->root->getMount($this->path);
-		// reverse the array so we start with the storage this view is in
-		// which is the most likely to contain the file we're looking for
-		$mounts = array_reverse($mounts);
+		/** @var IMountPoint[] $folderMounts */
+		$folderMounts = array_combine(array_map(function (IMountPoint $mountPoint) {
+			return $mountPoint->getMountPoint();
+		}, $mounts), $mounts);
 
-		$nodes = array();
-		foreach ($mounts as $mount) {
-			/**
-			 * @var \OC\Files\Mount\MountPoint $mount
-			 */
-			if ($mount->getStorage()) {
-				$cache = $mount->getStorage()->getCache();
-				$internalPath = $cache->getPathById($id);
-				if (is_string($internalPath)) {
-					$fullPath = $mount->getMountPoint() . $internalPath;
-					if (!is_null($path = $this->getRelativePath($fullPath))) {
-						$nodes[] = $this->get($path);
-					}
-				}
-			}
+		/** @var ICachedMountInfo[] $mountsContainingFile */
+		$mountsContainingFile = array_values(array_filter($mountsContainingFile, function (ICachedMountInfo $cachedMountInfo) use ($folderMounts) {
+			return isset($folderMounts[$cachedMountInfo->getMountPoint()]);
+		}));
+
+		if (count($mountsContainingFile) === 0) {
+			return [];
 		}
-		return $nodes;
+
+		// we only need to get the cache info once, since all mounts we found point to the same storage
+
+		$mount = $folderMounts[$mountsContainingFile[0]->getMountPoint()];
+		$cacheEntry = $mount->getStorage()->getCache()->get($id);
+		// cache jails will hide the "true" internal path
+		$internalPath = ltrim($mountsContainingFile[0]->getRootInternalPath() . '/' . $cacheEntry->getPath(), '/');
+
+		$nodes = array_map(function (ICachedMountInfo $cachedMountInfo) use ($cacheEntry, $folderMounts, $internalPath) {
+			$mount = $folderMounts[$cachedMountInfo->getMountPoint()];
+			$pathRelativeToMount = substr($internalPath, strlen($cachedMountInfo->getRootInternalPath()));
+			$pathRelativeToMount = ltrim($pathRelativeToMount, '/');
+			$absolutePath = $cachedMountInfo->getMountPoint() . $pathRelativeToMount;
+			return $this->root->createNode($absolutePath, new \OC\Files\FileInfo(
+				$absolutePath, $mount->getStorage(), $cacheEntry->getPath(), $cacheEntry, $mount,
+				\OC::$server->getUserManager()->get($mount->getStorage()->getOwner($pathRelativeToMount))
+			));
+		}, $mountsContainingFile);
+
+		return array_filter($nodes, function (Node $node) {
+			return $this->getRelativePath($node->getPath());
+		});
 	}
 
 	public function getFreeSpace() {

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -265,7 +265,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 	 */
 	public function getById($id) {
 		$mountCache = $this->root->getUserMountCache();
-		$mountsContainingFile = $mountCache->getMountsForFileId($id);
+		$mountsContainingFile = $mountCache->getMountsForFileId((int)$id);
 		$mounts = $this->root->getMountsIn($this->path);
 		$mounts[] = $this->root->getMount($this->path);
 		/** @var IMountPoint[] $folderMounts */
@@ -285,7 +285,10 @@ class Folder extends Node implements \OCP\Files\Folder {
 		// we only need to get the cache info once, since all mounts we found point to the same storage
 
 		$mount = $folderMounts[$mountsContainingFile[0]->getMountPoint()];
-		$cacheEntry = $mount->getStorage()->getCache()->get($id);
+		$cacheEntry = $mount->getStorage()->getCache()->get((int)$id);
+		if (!$cacheEntry) {
+			return [];
+		}
 		// cache jails will hide the "true" internal path
 		$internalPath = ltrim($mountsContainingFile[0]->getRootInternalPath() . '/' . $cacheEntry->getPath(), '/');
 

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -31,6 +31,7 @@ namespace OC\Files\Node;
 use OC\Cache\CappedMemoryCache;
 use OC\Files\Mount\Manager;
 use OC\Files\Mount\MountPoint;
+use OCP\Files\Config\IUserMountCache;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OC\Hooks\PublicEmitter;
@@ -75,16 +76,23 @@ class Root extends Folder implements IRootFolder {
 	private $userFolderCache;
 
 	/**
+	 * @var IUserMountCache
+	 */
+	private $userMountCache;
+
+	/**
 	 * @param \OC\Files\Mount\Manager $manager
 	 * @param \OC\Files\View $view
 	 * @param \OC\User\User|null $user
+	 * @param IUserMountCache $userMountCache
 	 */
-	public function __construct($manager, $view, $user) {
+	public function __construct($manager, $view, $user, IUserMountCache $userMountCache) {
 		parent::__construct($this, $view, '');
 		$this->mountManager = $manager;
 		$this->user = $user;
 		$this->emitter = new PublicEmitter();
 		$this->userFolderCache = new CappedMemoryCache();
+		$this->userMountCache = $userMountCache;
 	}
 
 	/**
@@ -360,5 +368,9 @@ class Root extends Folder implements IRootFolder {
 
 	public function clearCache() {
 		$this->userFolderCache = new CappedMemoryCache();
+	}
+
+	public function getUserMountCache() {
+		return $this->userMountCache;
 	}
 }

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -175,10 +175,10 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('SystemTagObjectMapper', function (Server $c) {
 			return $c->query('SystemTagManagerFactory')->getObjectMapper();
 		});
-		$this->registerService('RootFolder', function () {
+		$this->registerService('RootFolder', function (Server $c) {
 			$manager = \OC\Files\Filesystem::getMountManager(null);
 			$view = new View();
-			$root = new Root($manager, $view, null);
+			$root = new Root($manager, $view, null, $c->getUserMountCache());
 			$connector = new HookConnector($root, $view);
 			$connector->viewToNode();
 			return $root;

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -614,8 +614,11 @@ class Manager implements IManager {
 			throw new \Exception($error);
 		}
 
+		$oldShare = $share;
 		$provider = $this->factory->getProviderForType($share->getShareType());
 		$share = $provider->create($share);
+		//reuse the node we already have
+		$share->setNode($oldShare->getNode());
 
 		// Post share hook
 		$postHookData = [

--- a/lib/private/Share20/Share.php
+++ b/lib/private/Share20/Share.php
@@ -160,7 +160,7 @@ class Share implements \OCP\Share\IShare {
 
 			$nodes = $userFolder->getById($this->fileId);
 			if (empty($nodes)) {
-				throw new NotFoundException();
+				throw new NotFoundException('Node for share not found, fileid: ' . $this->fileId);
 			}
 
 			$this->node = $nodes[0];

--- a/lib/public/Files/Config/ICachedMountInfo.php
+++ b/lib/public/Files/Config/ICachedMountInfo.php
@@ -68,4 +68,12 @@ interface ICachedMountInfo {
 	 * @since 9.1.0
 	 */
 	public function getMountId();
+
+	/**
+	 * Get the internal path (within the storage) of the root of the mount
+	 *
+	 * @return string
+	 * @since 9.2.0
+	 */
+	public function getRootInternalPath();
 }

--- a/tests/lib/Files/Node/FileTest.php
+++ b/tests/lib/Files/Node/FileTest.php
@@ -21,6 +21,9 @@ class FileTest extends \Test\TestCase {
 	/** @var \OC\Files\View|\PHPUnit_Framework_MockObject_MockObject */
 	private $view;
 
+	/** @var \OCP\Files\Config\IUserMountCache|\PHPUnit_Framework_MockObject_MockObject */
+	private $userMountCache;
+
 	protected function setUp() {
 		parent::setUp();
 		$config = $this->getMockBuilder('\OCP\IConfig')
@@ -32,6 +35,9 @@ class FileTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$this->view = $this->getMockBuilder('\OC\Files\View')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->userMountCache = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -52,7 +58,7 @@ class FileTest extends \Test\TestCase {
 	public function testDelete() {
 		/** @var \OC\Files\Node\Root|\PHPUnit_Framework_MockObject_MockObject $root */
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
-			->setConstructorArgs([$this->manager, $this->view, $this->user])
+			->setConstructorArgs([$this->manager, $this->view, $this->user, $this->userMountCache])
 			->getMock();
 
 		$root->expects($this->exactly(2))
@@ -102,7 +108,7 @@ class FileTest extends \Test\TestCase {
 			$hooksRun++;
 		};
 
-		$root = new \OC\Files\Node\Root($this->manager, $this->view, $this->user);
+		$root = new \OC\Files\Node\Root($this->manager, $this->view, $this->user, $this->userMountCache);
 		$root->listen('\OC\Files', 'preDelete', $preListener);
 		$root->listen('\OC\Files', 'postDelete', $postListener);
 
@@ -132,7 +138,7 @@ class FileTest extends \Test\TestCase {
 	public function testDeleteNotPermitted() {
 		/** @var \OC\Files\Node\Root|\PHPUnit_Framework_MockObject_MockObject $root */
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
-			->setConstructorArgs([$this->manager, $this->view, $this->user])
+			->setConstructorArgs([$this->manager, $this->view, $this->user, $this->userMountCache])
 			->getMock();
 
 		$root->expects($this->any())
@@ -151,7 +157,7 @@ class FileTest extends \Test\TestCase {
 	public function testGetContent() {
 		/** @var \OC\Files\Node\Root|\PHPUnit_Framework_MockObject_MockObject $root */
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
-			->setConstructorArgs([$this->manager, $this->view, $this->user])
+			->setConstructorArgs([$this->manager, $this->view, $this->user, $this->userMountCache])
 			->getMock();
 
 		$hook = function ($file) {
@@ -181,7 +187,7 @@ class FileTest extends \Test\TestCase {
 	public function testGetContentNotPermitted() {
 		/** @var \OC\Files\Node\Root|\PHPUnit_Framework_MockObject_MockObject $root */
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
-			->setConstructorArgs([$this->manager, $this->view, $this->user])
+			->setConstructorArgs([$this->manager, $this->view, $this->user, $this->userMountCache])
 			->getMock();
 
 		$root->expects($this->any())
@@ -200,7 +206,7 @@ class FileTest extends \Test\TestCase {
 	public function testPutContent() {
 		/** @var \OC\Files\Node\Root|\PHPUnit_Framework_MockObject_MockObject $root */
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
-			->setConstructorArgs([$this->manager, $this->view, $this->user])
+			->setConstructorArgs([$this->manager, $this->view, $this->user, $this->userMountCache])
 			->getMock();
 
 		$root->expects($this->any())
@@ -227,7 +233,7 @@ class FileTest extends \Test\TestCase {
 	public function testPutContentNotPermitted() {
 		/** @var \OC\Files\Node\Root|\PHPUnit_Framework_MockObject_MockObject $root */
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
-			->setConstructorArgs([$this->manager, $this->view, $this->user])
+			->setConstructorArgs([$this->manager, $this->view, $this->user, $this->userMountCache])
 			->getMock();
 
 		$this->view->expects($this->once())
@@ -242,7 +248,7 @@ class FileTest extends \Test\TestCase {
 	public function testGetMimeType() {
 		/** @var \OC\Files\Node\Root|\PHPUnit_Framework_MockObject_MockObject $root */
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
-			->setConstructorArgs([$this->manager, $this->view, $this->user])
+			->setConstructorArgs([$this->manager, $this->view, $this->user, $this->userMountCache])
 			->getMock();
 
 		$this->view->expects($this->once())
@@ -259,7 +265,7 @@ class FileTest extends \Test\TestCase {
 		fwrite($stream, 'bar');
 		rewind($stream);
 
-		$root = new \OC\Files\Node\Root($this->manager, $this->view, $this->user);
+		$root = new \OC\Files\Node\Root($this->manager, $this->view, $this->user, $this->userMountCache);
 
 		$hook = function ($file) {
 			throw new \Exception('Hooks are not supposed to be called');
@@ -287,7 +293,7 @@ class FileTest extends \Test\TestCase {
 	public function testFOpenWrite() {
 		$stream = fopen('php://memory', 'w+');
 
-		$root = new \OC\Files\Node\Root($this->manager, new $this->view, $this->user);
+		$root = new \OC\Files\Node\Root($this->manager, new $this->view, $this->user, $this->userMountCache);
 
 		$hooksCalled = 0;
 		$hook = function ($file) use (&$hooksCalled) {
@@ -320,7 +326,7 @@ class FileTest extends \Test\TestCase {
 	 * @expectedException \OCP\Files\NotPermittedException
 	 */
 	public function testFOpenReadNotPermitted() {
-		$root = new \OC\Files\Node\Root($this->manager, $this->view, $this->user);
+		$root = new \OC\Files\Node\Root($this->manager, $this->view, $this->user, $this->userMountCache);
 
 		$hook = function ($file) {
 			throw new \Exception('Hooks are not supposed to be called');
@@ -339,7 +345,7 @@ class FileTest extends \Test\TestCase {
 	 * @expectedException \OCP\Files\NotPermittedException
 	 */
 	public function testFOpenReadWriteNoReadPermissions() {
-		$root = new \OC\Files\Node\Root($this->manager, $this->view, $this->user);
+		$root = new \OC\Files\Node\Root($this->manager, $this->view, $this->user, $this->userMountCache);
 
 		$hook = function () {
 			throw new \Exception('Hooks are not supposed to be called');
@@ -358,7 +364,7 @@ class FileTest extends \Test\TestCase {
 	 * @expectedException \OCP\Files\NotPermittedException
 	 */
 	public function testFOpenReadWriteNoWritePermissions() {
-		$root = new \OC\Files\Node\Root($this->manager, new $this->view, $this->user);
+		$root = new \OC\Files\Node\Root($this->manager, new $this->view, $this->user, $this->userMountCache);
 
 		$hook = function () {
 			throw new \Exception('Hooks are not supposed to be called');
@@ -376,7 +382,7 @@ class FileTest extends \Test\TestCase {
 	public function testCopySameStorage() {
 		/** @var \OC\Files\Node\Root|\PHPUnit_Framework_MockObject_MockObject $root */
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
-			->setConstructorArgs([$this->manager, $this->view, $this->user])
+			->setConstructorArgs([$this->manager, $this->view, $this->user, $this->userMountCache])
 			->getMock();
 
 		$this->view->expects($this->any())
@@ -409,7 +415,7 @@ class FileTest extends \Test\TestCase {
 	public function testCopyNotPermitted() {
 		/** @var \OC\Files\Node\Root|\PHPUnit_Framework_MockObject_MockObject $root */
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
-			->setConstructorArgs([$this->manager, $this->view, $this->user])
+			->setConstructorArgs([$this->manager, $this->view, $this->user, $this->userMountCache])
 			->getMock();
 
 		/**
@@ -447,7 +453,7 @@ class FileTest extends \Test\TestCase {
 	public function testCopyNoParent() {
 		/** @var \OC\Files\Node\Root|\PHPUnit_Framework_MockObject_MockObject $root */
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
-			->setConstructorArgs([$this->manager, $this->view, $this->user])
+			->setConstructorArgs([$this->manager, $this->view, $this->user, $this->userMountCache])
 			->getMock();
 
 		$this->view->expects($this->never())
@@ -469,7 +475,7 @@ class FileTest extends \Test\TestCase {
 	public function testCopyParentIsFile() {
 		/** @var \OC\Files\Node\Root|\PHPUnit_Framework_MockObject_MockObject $root */
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
-			->setConstructorArgs([$this->manager, $this->view, $this->user])
+			->setConstructorArgs([$this->manager, $this->view, $this->user, $this->userMountCache])
 			->getMock();
 
 		$this->view->expects($this->never())
@@ -490,7 +496,7 @@ class FileTest extends \Test\TestCase {
 	public function testMoveSameStorage() {
 		/** @var \OC\Files\Node\Root|\PHPUnit_Framework_MockObject_MockObject $root */
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
-			->setConstructorArgs([$this->manager, $this->view, $this->user])
+			->setConstructorArgs([$this->manager, $this->view, $this->user, $this->userMountCache])
 			->getMock();
 
 		$this->view->expects($this->any())
@@ -520,7 +526,7 @@ class FileTest extends \Test\TestCase {
 	public function testMoveNotPermitted() {
 		/** @var \OC\Files\Node\Root|\PHPUnit_Framework_MockObject_MockObject $root */
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
-			->setConstructorArgs([$this->manager, $this->view, $this->user])
+			->setConstructorArgs([$this->manager, $this->view, $this->user, $this->userMountCache])
 			->getMock();
 
 		$this->view->expects($this->any())
@@ -547,7 +553,7 @@ class FileTest extends \Test\TestCase {
 	public function testMoveNoParent() {
 		/** @var \OC\Files\Node\Root|\PHPUnit_Framework_MockObject_MockObject $root */
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
-			->setConstructorArgs([$this->manager, $this->view, $this->user])
+			->setConstructorArgs([$this->manager, $this->view, $this->user, $this->userMountCache])
 			->getMock();
 
 		/**
@@ -577,7 +583,7 @@ class FileTest extends \Test\TestCase {
 	public function testMoveParentIsFile() {
 		/** @var \OC\Files\Node\Root|\PHPUnit_Framework_MockObject_MockObject $root */
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
-			->setConstructorArgs([$this->manager, $this->view, $this->user])
+			->setConstructorArgs([$this->manager, $this->view, $this->user, $this->userMountCache])
 			->getMock();
 
 		$this->view->expects($this->never())

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -9,6 +9,8 @@
 namespace Test\Files\Node;
 
 use OC\Files\Cache\Cache;
+use OC\Files\Cache\CacheEntry;
+use OC\Files\Config\CachedMountInfo;
 use OC\Files\FileInfo;
 use OC\Files\Mount\Manager;
 use OC\Files\Mount\MountPoint;
@@ -32,9 +34,15 @@ use OCP\Files\Storage;
 class FolderTest extends \Test\TestCase {
 	private $user;
 
+	/** @var \OCP\Files\Config\IUserMountCache|\PHPUnit_Framework_MockObject_MockObject */
+	private $userMountCache;
+
 	protected function setUp() {
 		parent::setUp();
 		$this->user = new \OC\User\User('', new \Test\Util\User\Dummy);
+		$this->userMountCache = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	protected function getMockStorage() {
@@ -56,7 +64,7 @@ class FolderTest extends \Test\TestCase {
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->getMockBuilder(Root::class)
-			->setConstructorArgs([$manager, $view, $this->user])
+			->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])
 			->getMock();
 		$root->expects($this->any())
 			->method('getUser')
@@ -110,7 +118,7 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
+		$root = new \OC\Files\Node\Root($manager, $view, $this->user, $this->userMountCache);
 		$root->listen('\OC\Files', 'preDelete', $preListener);
 		$root->listen('\OC\Files', 'postDelete', $postListener);
 
@@ -142,7 +150,7 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -163,7 +171,7 @@ class FolderTest extends \Test\TestCase {
 		 */
 		$view = $this->createMock(View::class);
 		$root = $this->getMockBuilder(Root::class)
-			->setConstructorArgs([$manager, $view, $this->user])
+			->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])
 			->getMock();
 		$root->expects($this->any())
 			->method('getUser')
@@ -194,7 +202,7 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -213,7 +221,7 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -235,7 +243,7 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -255,7 +263,7 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -285,7 +293,7 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -305,7 +313,7 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -335,7 +343,7 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -355,7 +363,7 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -375,7 +383,7 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -423,7 +431,8 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])->setConstructorArgs([$manager, $view, $this->user])->getMock();
+		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])
+			->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -471,7 +480,7 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -519,7 +528,7 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -567,7 +576,7 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user])->getMock();
+		$root = $this->getMockBuilder(Root::class)->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -647,26 +656,34 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])->setConstructorArgs([$manager, $view, $this->user])->getMock();
-		$root->expects($this->any())
-			->method('getUser')
-			->will($this->returnValue($this->user));
+		$root = $this->getMockBuilder(Root::class)->setMethods(['getMountsIn', 'getMount'])
+			->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		$storage = $this->createMock(\OC\Files\Storage\Storage::class);
 		$mount = new MountPoint($storage, '/bar');
 		$cache = $this->getMockBuilder(Cache::class)->setConstructorArgs([''])->getMock();
 
-		$view->expects($this->once())
-			->method('getFileInfo')
-			->will($this->returnValue(new FileInfo('/bar/foo/qwerty', null, 'qwerty', ['mimetype' => 'text/plain'], null)));
+		$fileInfo = new CacheEntry(['path' => 'foo/qwerty', 'mimetype' => 'text/plain'], null);
 
 		$storage->expects($this->once())
 			->method('getCache')
 			->will($this->returnValue($cache));
 
+		$this->userMountCache->expects($this->any())
+			->method('getMountsForFileId')
+			->with(1)
+			->will($this->returnValue([new CachedMountInfo(
+				$this->user,
+				1,
+				0,
+				'/bar/',
+				1,
+				''
+			)]));
+
 		$cache->expects($this->once())
-			->method('getPathById')
-			->with('1')
-			->will($this->returnValue('foo/qwerty'));
+			->method('get')
+			->with(1)
+			->will($this->returnValue($fileInfo));
 
 		$root->expects($this->once())
 			->method('getMountsIn')
@@ -690,22 +707,34 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])->setConstructorArgs([$manager, $view, $this->user])->getMock();
-		$root->expects($this->any())
-			->method('getUser')
-			->will($this->returnValue($this->user));
+		$root = $this->getMockBuilder(Root::class)->setMethods(['getMountsIn', 'getMount'])
+			->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		$storage = $this->createMock(\OC\Files\Storage\Storage::class);
 		$mount = new MountPoint($storage, '/bar');
 		$cache = $this->getMockBuilder(Cache::class)->setConstructorArgs([''])->getMock();
+
+		$fileInfo = new CacheEntry(['path' => 'foobar', 'mimetype' => 'text/plain'], null);
 
 		$storage->expects($this->once())
 			->method('getCache')
 			->will($this->returnValue($cache));
 
+		$this->userMountCache->expects($this->any())
+			->method('getMountsForFileId')
+			->with(1)
+			->will($this->returnValue([new CachedMountInfo(
+				$this->user,
+				1,
+				0,
+				'/bar/',
+				1,
+				''
+			)]));
+
 		$cache->expects($this->once())
-			->method('getPathById')
-			->with('1')
-			->will($this->returnValue('foobar'));
+			->method('get')
+			->with(1)
+			->will($this->returnValue($fileInfo));
 
 		$root->expects($this->once())
 			->method('getMountsIn')
@@ -719,7 +748,7 @@ class FolderTest extends \Test\TestCase {
 
 		$node = new \OC\Files\Node\Folder($root, $view, '/bar/foo');
 		$result = $node->getById(1);
-		$this->assertCount(0, $result);
+		$this->assertEquals(0, count($result));
 	}
 
 	public function testGetByIdMultipleStorages() {
@@ -728,27 +757,49 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])->setConstructorArgs([$manager, $view, $this->user])->getMock();
-		$root->expects($this->any())
-			->method('getUser')
-			->will($this->returnValue($this->user));
+		$root = $this->getMockBuilder(Root::class)->setMethods(['getMountsIn', 'getMount'])
+			->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		$storage = $this->createMock(\OC\Files\Storage\Storage::class);
 		$mount1 = new MountPoint($storage, '/bar');
 		$mount2 = new MountPoint($storage, '/bar/foo/asd');
 		$cache = $this->getMockBuilder(Cache::class)->setConstructorArgs([''])->getMock();
 
-		$view->expects($this->any())
-			->method('getFileInfo')
-			->will($this->returnValue(new FileInfo('/bar/foo/qwerty', null, 'qwerty', ['mimetype' => 'plain'], null)));
+		$fileInfo = new CacheEntry(['path' => 'foo/qwerty', 'mimetype' => 'text/plain'], null);
+
+		$storage->expects($this->once())
+			->method('getCache')
+			->will($this->returnValue($cache));
+
+		$this->userMountCache->expects($this->any())
+			->method('getMountsForFileId')
+			->with(1)
+			->will($this->returnValue([
+				new CachedMountInfo(
+					$this->user,
+					1,
+					0,
+					'/bar/',
+					1,
+					''
+				),
+				new CachedMountInfo(
+					$this->user,
+					1,
+					0,
+					'/bar/foo/asd/',
+					1,
+					''
+				)
+			]));
 
 		$storage->expects($this->any())
 			->method('getCache')
 			->will($this->returnValue($cache));
 
 		$cache->expects($this->any())
-			->method('getPathById')
-			->with('1')
-			->will($this->returnValue('foo/qwerty'));
+			->method('get')
+			->with(1)
+			->will($this->returnValue($fileInfo));
 
 		$root->expects($this->any())
 			->method('getMountsIn')
@@ -786,7 +837,8 @@ class FolderTest extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->createMock(View::class);
-		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])->setConstructorArgs([$manager, $view, $this->user])->getMock();
+		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])
+			->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 
 		$view->expects($this->any())
 			->method('file_exists')
@@ -811,7 +863,8 @@ class FolderTest extends \Test\TestCase {
 		 */
 		$view = $this->createMock(View::class);
 		/** @var \PHPUnit_Framework_MockObject_MockObject|\OC\Files\Node\Root $root */
-		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])->setConstructorArgs([$manager, $view, $this->user])->getMock();
+		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])
+			->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		/** @var \PHPUnit_Framework_MockObject_MockObject|\OC\Files\FileInfo $folderInfo */
 		$folderInfo = $this->getMockBuilder('\OC\Files\FileInfo')
 			->disableOriginalConstructor()->getMock();
@@ -869,7 +922,8 @@ class FolderTest extends \Test\TestCase {
 		 */
 		$view = $this->createMock(View::class);
 		/** @var \PHPUnit_Framework_MockObject_MockObject|\OC\Files\Node\Root $root */
-		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])->setConstructorArgs([$manager, $view, $this->user])->getMock();
+		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])
+			->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		/** @var \PHPUnit_Framework_MockObject_MockObject|\OC\Files\FileInfo $folderInfo */
 		$folderInfo = $this->getMockBuilder('\OC\Files\FileInfo')
 			->disableOriginalConstructor()->getMock();
@@ -925,7 +979,8 @@ class FolderTest extends \Test\TestCase {
 		 */
 		$view = $this->createMock(View::class);
 		/** @var \PHPUnit_Framework_MockObject_MockObject|\OC\Files\Node\Root $root */
-		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])->setConstructorArgs([$manager, $view, $this->user])->getMock();
+		$root = $this->getMockBuilder(Root::class)->setMethods(['getUser', 'getMountsIn', 'getMount'])
+			->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache])->getMock();
 		/** @var \PHPUnit_Framework_MockObject_MockObject|\OC\Files\FileInfo $folderInfo */
 		$folderInfo = $this->getMockBuilder('\OC\Files\FileInfo')
 			->disableOriginalConstructor()->getMock();

--- a/tests/lib/Files/Node/HookConnectorTest.php
+++ b/tests/lib/Files/Node/HookConnectorTest.php
@@ -50,7 +50,12 @@ class HookConnectorTest extends TestCase {
 		$this->registerMount($this->userId, new Temporary(), '/' . $this->userId . '/files/');
 		\OC_Util::setupFS($this->userId);
 		$this->view = new View();
-		$this->root = new Root(Filesystem::getMountManager(), $this->view, \OC::$server->getUserManager()->get($this->userId));
+		$this->root = new Root(
+			Filesystem::getMountManager(),
+			$this->view,
+			\OC::$server->getUserManager()->get($this->userId),
+			\OC::$server->getUserMountCache()
+		);
 	}
 
 	public function tearDown() {

--- a/tests/lib/Files/Node/IntegrationTest.php
+++ b/tests/lib/Files/Node/IntegrationTest.php
@@ -47,7 +47,7 @@ class IntegrationTest extends \Test\TestCase {
 		$this->loginAsUser($user->getUID());
 
 		$this->view = new View();
-		$this->root = new Root($manager, $this->view, $user);
+		$this->root = new Root($manager, $this->view, $user, \OC::$server->getUserMountCache());
 		$storage = new Temporary(array());
 		$subStorage = new Temporary(array());
 		$this->storages[] = $storage;

--- a/tests/lib/Files/Node/NodeTest.php
+++ b/tests/lib/Files/Node/NodeTest.php
@@ -22,6 +22,8 @@ class NodeTest extends \Test\TestCase {
 
 	/** @var \OC\Files\Node\Root|\PHPUnit_Framework_MockObject_MockObject */
 	private $root;
+	/** @var \OCP\Files\Config\IUserMountCache|\PHPUnit_Framework_MockObject_MockObject */
+	private $userMountCache;
 
 	protected function setUp() {
 		parent::setUp();
@@ -41,8 +43,11 @@ class NodeTest extends \Test\TestCase {
 		$this->view = $this->getMockBuilder('\OC\Files\View')
 			->disableOriginalConstructor()
 			->getMock();
+		$this->userMountCache = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')
+			->disableOriginalConstructor()
+			->getMock();
 		$this->root = $this->getMockBuilder('\OC\Files\Node\Root')
-			->setConstructorArgs([$this->manager, $this->view, $this->user])
+			->setConstructorArgs([$this->manager, $this->view, $this->user, $this->userMountCache])
 			->getMock();
 	}
 
@@ -268,7 +273,7 @@ class NodeTest extends \Test\TestCase {
 			$hooksRun++;
 		};
 
-		$root = new \OC\Files\Node\Root($this->manager, $this->view, $this->user);
+		$root = new \OC\Files\Node\Root($this->manager, $this->view, $this->user, $this->userMountCache);
 		$root->listen('\OC\Files', 'preTouch', $preListener);
 		$root->listen('\OC\Files', 'postTouch', $postListener);
 

--- a/tests/lib/Files/Node/RootTest.php
+++ b/tests/lib/Files/Node/RootTest.php
@@ -16,6 +16,8 @@ class RootTest extends \Test\TestCase {
 
 	/** @var \OC\Files\Mount\Manager */
 	private $manager;
+	/** @var \OCP\Files\Config\IUserMountCache|\PHPUnit_Framework_MockObject_MockObject */
+	private $userMountCache;
 
 	protected function setUp() {
 		parent::setUp();
@@ -30,6 +32,9 @@ class RootTest extends \Test\TestCase {
 		$this->user = new \OC\User\User('', new \Test\Util\User\Dummy, null, $config, $urlgenerator);
 
 		$this->manager = $this->getMockBuilder('\OC\Files\Mount\Manager')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->userMountCache = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -51,7 +56,7 @@ class RootTest extends \Test\TestCase {
 		$view = $this->getMockBuilder('\OC\Files\View')
 			->disableOriginalConstructor()
 			->getMock();
-		$root = new \OC\Files\Node\Root($this->manager, $view, $this->user);
+		$root = new \OC\Files\Node\Root($this->manager, $view, $this->user, $this->userMountCache);
 
 		$view->expects($this->once())
 			->method('getFileInfo')
@@ -80,7 +85,7 @@ class RootTest extends \Test\TestCase {
 		$view = $this->getMockBuilder('\OC\Files\View')
 			->disableOriginalConstructor()
 			->getMock();
-		$root = new \OC\Files\Node\Root($this->manager, $view, $this->user);
+		$root = new \OC\Files\Node\Root($this->manager, $view, $this->user, $this->userMountCache);
 
 		$view->expects($this->once())
 			->method('getFileInfo')
@@ -101,7 +106,7 @@ class RootTest extends \Test\TestCase {
 		$view = $this->getMockBuilder('\OC\Files\View')
 			->disableOriginalConstructor()
 			->getMock();
-		$root = new \OC\Files\Node\Root($this->manager, $view, $this->user);
+		$root = new \OC\Files\Node\Root($this->manager, $view, $this->user, $this->userMountCache);
 
 		$root->get('/../foo');
 	}
@@ -116,7 +121,7 @@ class RootTest extends \Test\TestCase {
 		$view = $this->getMockBuilder('\OC\Files\View')
 			->disableOriginalConstructor()
 			->getMock();
-		$root = new \OC\Files\Node\Root($this->manager, $view, $this->user);
+		$root = new \OC\Files\Node\Root($this->manager, $view, $this->user, $this->userMountCache);
 
 		$root->get('/bar/foo');
 	}


### PR DESCRIPTION
Instead of using N+M queries, use 3

(N being the number of storages for a user (including recieving shares, M being the number of storages that contain the matching file)

`UserMountCache::getMountsForFileId` has also been optimized 

Fixes https://github.com/nextcloud/server/issues/1435
