### PR TITLE
do not reload the page if the server is (temporarily) unreachable

### DIFF
--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -924,7 +924,7 @@ describe('Core base tests', function() {
 			var dataProvider = [
 				[200, false],
 				[400, false],
-				[0, true],
+				[0, false],
 				[401, true],
 				[302, true],
 				[303, true],
@@ -978,6 +978,15 @@ describe('Core base tests', function() {
 
 			clock.tick(waitTimeMs);
 			expect(notificationStub.calledOnce).toEqual(true);
+		});
+		it('shows a temporary notification if the connection is lost', function() {
+			var xhr = { status: 0 };
+			spyOn(OC, '_ajaxConnectionLostHandler');
+
+			$(document).trigger(new $.Event('ajaxError'), xhr);
+			clock.tick(101);
+
+			expect(OC._ajaxConnectionLostHandler.calls.count()).toBe(1);
 		});
 	});
 });


### PR DESCRIPTION
Since it's quite annoying to see an ugly browser error message like `Server not found` when resuming my notebook, it would be great if we would _not_ reload in that case.
- [x] TODO: unit tests

cc @jancborchardt since we talked about that
