### PR TITLE
Don't check Same-Site attribute for mobile chrome

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -520,6 +520,14 @@ class OC {
 			return;
 		}
 
+		// Chrome on Android has a bug that it doesn't sent cookies with the
+		// same-site attribute for the download manager. To work around that
+		// all same-site cookies get deleted and recreated directly. Awesome!
+		// FIXME: Remove once Chrome 54 is deployed to end-users
+		// @see https://github.com/nextcloud/server/pull/1454
+		if($request->isUserAgent([\OC\AppFramework\Http\Request::USER_AGENT_ANDROID_MOBILE_CHROME])) {
+			return;
+		}
 
 		if(count($_COOKIE) > 0) {
 			$requestUri = $request->getScriptName();


### PR DESCRIPTION
Android is really insane when it is about cookies. So what happens is:
1. Nextcloud sets cookies with a Same-Site attribute
2. Chrome Android accepts it and sends it properly
3. The first download using Chrome works
4. It is redownloaded with the Download Manager which does just completely drops cookies with the same-site attribute

This makes downloads fails on mobile Chrome.

Fixes https://github.com/nextcloud/server/issues/342
