### PR TITLE
[upstream] Fix fed share test call to return proper result

### DIFF
--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -186,7 +186,7 @@ class Storage extends DAV implements ISharedStorage {
 
 	public function test() {
 		try {
-			parent::test();
+			return parent::test();
 		} catch (StorageInvalidException $e) {
 			// check if it needs to be removed
 			$this->checkStorageAvailability();

--- a/apps/files_sharing/tests/ExternalStorageTest.php
+++ b/apps/files_sharing/tests/ExternalStorageTest.php
@@ -67,14 +67,11 @@ class ExternalStorageTest extends \Test\TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider optionsProvider
-	 */
-	public function testStorageMountOptions($inputUri, $baseUri) {
+	private function getTestStorage($uri) {
 		$certificateManager = \OC::$server->getCertificateManager();
-		$storage = new TestSharingExternalStorage(
+		return new TestSharingExternalStorage(
 			array(
-				'remote' => $inputUri,
+				'remote' => $uri,
 				'owner' => 'testOwner',
 				'mountpoint' => 'remoteshare',
 				'token' => 'abcdef',
@@ -83,7 +80,19 @@ class ExternalStorageTest extends \Test\TestCase {
 				'certificateManager' => $certificateManager
 			)
 		);
+	}
+
+	/**
+	 * @dataProvider optionsProvider
+	 */
+	public function testStorageMountOptions($inputUri, $baseUri) {
+		$storage = $this->getTestStorage($inputUri);
 		$this->assertEquals($baseUri, $storage->getBaseUri());
+	}
+
+	public function testIfTestReturnsTheValue() {
+		$result = $this->getTestStorage('https://remoteserver')->test();
+		$this->assertSame(true, $result);
 	}
 }
 
@@ -94,5 +103,12 @@ class TestSharingExternalStorage extends \OCA\Files_Sharing\External\Storage {
 
 	public function getBaseUri() {
 		return $this->createBaseUri();
+	}
+
+	public function stat($path) {
+		if ($path === '') {
+			return true;
+		}
+		return parent::stat($path);
 	}
 }


### PR DESCRIPTION
Fixes an issue where retrying a previously failed federated share would
not properly reset the availability flag because the return value was
undefined instead of "true".

Upstream of https://github.com/owncloud/core/pull/26038
