### PR TITLE
add proper classes for white audio and video icons

### DIFF
--- a/core/css/icons.css
+++ b/core/css/icons.css
@@ -117,6 +117,9 @@ img.icon-loading-small-dark, object.icon-loading-small-dark, video.icon-loading-
 .icon-audio {
 	background-image: url('../img/actions/audio.svg?v=1');
 }
+.icon-audio-white {
+	background-image: url('../img/actions/audio-white.svg?v=1');
+}
 
 .icon-caret {
 	background-image: url('../img/actions/caret.svg?v=1');
@@ -315,6 +318,9 @@ img.icon-loading-small-dark, object.icon-loading-small-dark, video.icon-loading-
 
 .icon-video {
 	background-image: url('../img/actions/video.svg?v=1');
+}
+.icon-video-white {
+	background-image: url('../img/actions/video-white.svg?v=1');
 }
 
 .icon-view-close {


### PR DESCRIPTION
Forgot something important in https://github.com/nextcloud/server/pull/1451 ;)

cc @LukasReschke @MorrisJobke @nextcloud/designers
