### PR TITLE
README.md: Add notes how to run master checkouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ changed it substantially:
 
 More information how to contribute: https://nextcloud.com/contribute/
 
+## Running master checkouts
+
+Third-party components are handled as git submodules which have to be initialized first. So aside from the regular git checkout invoking `git submodule update --init` or a similar command is needed, for details see Git documentation.
+
+Several apps by default included in regular releases like [firstrunwizard](https://github.com/nextcloud/firstrunwizard) or [gallery](https://github.com/nextcloud/gallery) are missing in `master` and have to be installed manually as required.
+
+That aside Git checkouts can be handled the same as release archives.
+
+Note they should never be used on production systems.
+
 ## Nextcloud VM
 If you're not familiar with Linux, or simply just want to get up and running on a pre-configured system in no time - we have developed a VM that you can download. Just extract it and mount it in VMware or VirtualBox and you're all set.
 


### PR DESCRIPTION
Running VCS checkouts of Nextcloud is easy but involves some steps which are not so obvious. This PR complements the server's `README.md` with some corresponding explanation.
The aim is to help testing Nextcloud by avoiding errors due to faulty handling of those checkouts.
