### PR TITLE
fix sidebar tab headers margin

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -601,6 +601,7 @@ em {
 
 /* generic tab styles */
 .tabHeaders {
+	display: inline-block;
 	margin: 15px;
 }
 .tabHeaders .tabHeader {


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/server/pull/1469 – There was insufficient whitespace when the Tags thing was not expanded. Please review @nickvergessen @nextcloud/designers 

Also we should backport both this and https://github.com/nextcloud/server/pull/1469 cc @karlitschek 
