### PR TITLE
Add repair step and revert "Open updater" button

### DIFF
--- a/apps/updatenotification/js/admin.js
+++ b/apps/updatenotification/js/admin.js
@@ -13,7 +13,33 @@
 /**
  * Creates a new authentication token and loads the updater URL
  */
+var loginToken = '';
 $(document).ready(function(){
+	$('#oca_updatenotification_button').click(function() {
+		// Load the new token
+		$.ajax({
+			url: OC.generateUrl('/apps/updatenotification/credentials')
+		}).success(function(data) {
+			loginToken = data;
+			$.ajax({
+				url: OC.webroot+'/updater/',
+				headers: {
+					'X-Updater-Auth': loginToken
+				},
+				method: 'POST',
+				success: function(data){
+					if(data !== 'false') {
+						var body = $('body');
+						$('head').remove();
+						body.html(data);
+						body.removeAttr('id');
+						body.attr('id', 'body-settings');
+					}
+				}
+			});
+		});
+	});
+
 	$('#release-channel').change(function() {
 		var newChannel = $('#release-channel').find(":selected").val();
 

--- a/apps/updatenotification/lib/Controller/AdminController.php
+++ b/apps/updatenotification/lib/Controller/AdminController.php
@@ -112,7 +112,6 @@ class AdminController extends Controller implements ISettings {
 			'currentChannel' => $currentChannel,
 			'channels' => $channels,
 			'newVersionString' => ($updateState === []) ? '' : $updateState['updateVersion'],
-			'downloadLink' => (empty($updateState['downloadLink'])) ? '' : $updateState['downloadLink'],
 
 			'notify_groups' => implode('|', $notifyGroups),
 		];

--- a/apps/updatenotification/lib/UpdateChecker.php
+++ b/apps/updatenotification/lib/UpdateChecker.php
@@ -49,9 +49,6 @@ class UpdateChecker {
 			if(substr($data['web'], 0, 8) === 'https://') {
 				$result['updateLink'] = $data['web'];
 			}
-			if(substr($data['url'], 0, 8) === 'https://') {
-				$result['downloadLink'] = $data['url'];
-			}
 
 			return $result;
 		}

--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -16,9 +16,7 @@
 <form id="oca_updatenotification_section" class="followupsection">
 	<?php if($isNewVersionAvailable === true): ?>
 		<strong><?php p($l->t('A new version is available: %s', [$newVersionString])); ?></strong>
-		<?php if ($_['downloadLink']): ?>
-			<a href="<?php p($_['downloadLink']); ?>" class="button"><?php p($l->t('Download now')) ?></a>
-		<?php endif; ?>
+		<input type="button" id="oca_updatenotification_button" value="<?php p($l->t('Open updater')) ?>">
 	<?php else: ?>
 		<strong><?php print_unescaped($l->t('Your version is up to date.')); ?></strong>
 		<span class="icon-info svg" title="<?php p($l->t('Checked on %s', [$lastCheckedDate])) ?>"></span>

--- a/apps/updatenotification/tests/Controller/AdminControllerTest.php
+++ b/apps/updatenotification/tests/Controller/AdminControllerTest.php
@@ -111,10 +111,7 @@ class AdminControllerTest extends TestCase {
 		$this->updateChecker
 			->expects($this->once())
 			->method('getUpdateState')
-			->willReturn([
-				'updateVersion' => '8.1.2',
-				'downloadLink' => 'https://downloads.nextcloud.org/server',
-			]);
+			->willReturn(['updateVersion' => '8.1.2']);
 
 		$params = [
 			'isNewVersionAvailable' => true,
@@ -123,7 +120,6 @@ class AdminControllerTest extends TestCase {
 			'channels' => $channels,
 			'newVersionString' => '8.1.2',
 			'notify_groups' => 'admin',
-			'downloadLink' => 'https://downloads.nextcloud.org/server',
 		];
 
 		$expected = new TemplateResponse('updatenotification', 'admin', $params, '');
@@ -168,7 +164,6 @@ class AdminControllerTest extends TestCase {
 			'channels' => $channels,
 			'newVersionString' => '',
 			'notify_groups' => 'admin',
-			'downloadLink' => '',
 		];
 
 		$expected = new TemplateResponse('updatenotification', 'admin', $params, '');

--- a/apps/updatenotification/tests/UpdateCheckerTest.php
+++ b/apps/updatenotification/tests/UpdateCheckerTest.php
@@ -74,7 +74,6 @@ class UpdateCheckerTest extends TestCase {
 			'updateAvailable' => true,
 			'updateVersion' => 'Nextcloud 123',
 			'updateLink' => 'https://docs.nextcloud.com/myUrl',
-			'downloadLink' => 'https://downloads.nextcloud.org/server',
 		];
 		$this->assertSame($expected, $this->updateChecker->getUpdateState());
 	}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -635,6 +635,7 @@ return array(
     'OC\\Repair\\DropOldTables' => $baseDir . '/lib/private/Repair/DropOldTables.php',
     'OC\\Repair\\FillETags' => $baseDir . '/lib/private/Repair/FillETags.php',
     'OC\\Repair\\InnoDB' => $baseDir . '/lib/private/Repair/InnoDB.php',
+    'OC\\Repair\\MoveUpdaterStepFile' => $baseDir . '/lib/private/Repair/MoveUpdaterStepFile.php',
     'OC\\Repair\\OldGroupMembershipShares' => $baseDir . '/lib/private/Repair/OldGroupMembershipShares.php',
     'OC\\Repair\\Preview' => $baseDir . '/lib/private/Repair/Preview.php',
     'OC\\Repair\\RemoveGetETagEntries' => $baseDir . '/lib/private/Repair/RemoveGetETagEntries.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -665,6 +665,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Repair\\DropOldTables' => __DIR__ . '/../../..' . '/lib/private/Repair/DropOldTables.php',
         'OC\\Repair\\FillETags' => __DIR__ . '/../../..' . '/lib/private/Repair/FillETags.php',
         'OC\\Repair\\InnoDB' => __DIR__ . '/../../..' . '/lib/private/Repair/InnoDB.php',
+        'OC\\Repair\\MoveUpdaterStepFile' => __DIR__ . '/../../..' . '/lib/private/Repair/MoveUpdaterStepFile.php',
         'OC\\Repair\\OldGroupMembershipShares' => __DIR__ . '/../../..' . '/lib/private/Repair/OldGroupMembershipShares.php',
         'OC\\Repair\\Preview' => __DIR__ . '/../../..' . '/lib/private/Repair/Preview.php',
         'OC\\Repair\\RemoveGetETagEntries' => __DIR__ . '/../../..' . '/lib/private/Repair/RemoveGetETagEntries.php',

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -35,6 +35,7 @@ use OC\Repair\AvatarPermissions;
 use OC\Repair\CleanTags;
 use OC\Repair\Collation;
 use OC\Repair\DropOldJobs;
+use OC\Repair\MoveUpdaterStepFile;
 use OC\Repair\OldGroupMembershipShares;
 use OC\Repair\RemoveGetETagEntries;
 use OC\Repair\RemoveOldShares;
@@ -147,6 +148,7 @@ class Repair implements IOutput{
 				\OC::$server->getUserManager(),
 				\OC::$server->getGroupManager()
 			),
+			new MoveUpdaterStepFile(\OC::$server->getConfig()),
 		];
 	}
 

--- a/lib/private/Repair/MoveUpdaterStepFile.php
+++ b/lib/private/Repair/MoveUpdaterStepFile.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Morris Jobke <hey@morrisjobke.de>
+ *
+ * @author Morris Jobke <hey@morrisjobke.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Repair;
+
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class MoveUpdaterStepFile implements IRepairStep {
+
+	/** @var \OCP\IConfig */
+	protected $config;
+
+	/**
+	 * @param \OCP\IConfig $config
+	 */
+	public function __construct($config) {
+		$this->config = $config;
+	}
+
+	public function getName() {
+		return 'Move .step file of updater to backup location';
+	}
+
+	public function run(IOutput $output) {
+
+		$dataDir = $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT);
+		$instanceId = $this->config->getSystemValue('instanceid', null);
+
+		if(!is_string($instanceId) || empty($instanceId)) {
+			return;
+		}
+
+		$updaterFolderPath = $dataDir . '/updater-' . $instanceId;
+		$stepFile = $updaterFolderPath . '/.step';
+		if(file_exists($stepFile)) {
+			$output->info('.step file exists');
+
+			$previousStepFile = $updaterFolderPath . '/.step-previous-update';
+
+			// cleanup
+			if(file_exists($previousStepFile)) {
+				if(\OC_Helper::rmdirr($previousStepFile)) {
+					$output->info('.step-previous-update removed');
+				} else {
+					$output->info('.step-previous-update can\'t be removed - abort move of .step file');
+					return;
+				}
+			}
+
+			// move step file
+			if(rename($stepFile, $previousStepFile)) {
+				$output->info('.step file moved to .step-previous-update');
+			} else {
+				$output->warning('.step file can\'t be moved');
+			}
+		}
+	}
+}
+

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -85,6 +85,7 @@ class Util {
 		//Flush timestamp to reload version.php
 		\OC::$server->getSession()->set('OC_Version_Timestamp', 0);
 		\OC::$server->getAppConfig()->setValue('core', 'OC_Channel', $channel);
+		\OC::$server->getConfig()->setSystemValue('updater.release.channel', $channel);
 	}
 	
 	/**


### PR DESCRIPTION
- fixes both items in #1485
- repair step moves the update step file `data/updater-INSTANCEID/.step` to a file named `.step-previous-update` to not show all steps as done on the next update
- reverts  202ae42

cc @LukasReschke @nickvergessen @karlitschek 

I will open the PRs for stable9 and stable10 soon
