### PR TITLE
[stable9] Add repair step and revert "Open updater" button

### DIFF
--- a/apps/updatenotification/controller/admincontroller.php
+++ b/apps/updatenotification/controller/admincontroller.php
@@ -81,33 +81,6 @@ class AdminController extends Controller {
 	}
 
 	/**
-	 * Whether the instance is compatible with the updater
-	 *
-	 * @return bool
-	 */
-	protected function isCompatibleWithUpdater() {
-		$updaterCompatible = true;
-		if(!function_exists('proc_open') || !function_exists('shell_exec')) {
-			$updaterCompatible = false;
-		} else {
-			$whichUnzip = shell_exec('command -v unzip');
-			if(!class_exists('ZipArchive') && empty($whichUnzip)) {
-				$updaterCompatible = false;
-			}
-
-			$whichPhp = shell_exec('command -v php');
-			if(empty($whichPhp)) {
-				$updaterCompatible = false;
-			}
-		}
-		if(!function_exists('curl_exec')) {
-			$updaterCompatible = false;
-		}
-
-		return $updaterCompatible;
-	}
-
-	/**
 	 * @return TemplateResponse
 	 */
 	public function displayPanel() {
@@ -122,6 +95,7 @@ class AdminController extends Controller {
 			'production',
 		];
 		$currentChannel = \OCP\Util::getChannel();
+
 		// Remove the currently used channel from the channels list
 		if(($key = array_search($currentChannel, $channels)) !== false) {
 			unset($channels[$key]);
@@ -133,7 +107,6 @@ class AdminController extends Controller {
 			'currentChannel' => $currentChannel,
 			'channels' => $channels,
 			'newVersionString' => ($updateState === []) ? '' : $updateState['updateVersion'],
-			'updaterRequirementsFulfilled' => $this->isCompatibleWithUpdater(),
 		];
 
 		return new TemplateResponse($this->appName, 'admin', $params, '');

--- a/apps/updatenotification/controller/admincontroller.php
+++ b/apps/updatenotification/controller/admincontroller.php
@@ -134,7 +134,6 @@ class AdminController extends Controller {
 			'channels' => $channels,
 			'newVersionString' => ($updateState === []) ? '' : $updateState['updateVersion'],
 			'updaterRequirementsFulfilled' => $this->isCompatibleWithUpdater(),
-			'downloadLink' => (empty($updateState['downloadLink'])) ? '' : $updateState['downloadLink'],
 		];
 
 		return new TemplateResponse($this->appName, 'admin', $params, '');

--- a/apps/updatenotification/js/admin.js
+++ b/apps/updatenotification/js/admin.js
@@ -13,7 +13,32 @@
 /**
  * Creates a new authentication token and loads the updater URL
  */
+var loginToken = '';
 $(document).ready(function(){
+	$('#oca_updatenotification_button').click(function() {
+		// Load the new token
+		$.ajax({
+			url: OC.generateUrl('/apps/updatenotification/credentials')
+		}).success(function(data) {
+			loginToken = data;
+			$.ajax({
+				url: OC.webroot+'/updater/',
+				headers: {
+					'X-Updater-Auth': loginToken
+				},
+				method: 'POST',
+				success: function(data){
+					if(data !== 'false') {
+						var body = $('body');
+						$('head').remove();
+						body.html(data);
+						body.removeAttr('id');
+						body.attr('id', 'body-settings');
+					}
+				}
+			});
+		});
+	});
 	$('#release-channel').change(function() {
 		var newChannel = $('#release-channel').find(":selected").val();
 		$.post(

--- a/apps/updatenotification/lib/updatechecker.php
+++ b/apps/updatenotification/lib/updatechecker.php
@@ -48,9 +48,6 @@ class UpdateChecker {
 			if(substr($data['web'], 0, 8) === 'https://') {
 				$result['updateLink'] = $data['web'];
 			}
-			if(substr($data['url'], 0, 8) === 'https://') {
-				$result['downloadLink'] = $data['url'];
-			}
 
 			return $result;
 		}

--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -12,19 +12,13 @@
 	$channels = $_['channels'];
 	/** @var string $currentChannel */
 	$currentChannel = $_['currentChannel'];
-	/** @var bool $updaterRequirementsFulfilled */
-	$updaterRequirementsFulfilled = $_['updaterRequirementsFulfilled'];
 ?>
 <form id="oca_updatenotification_section" class="section">
 	<h2><?php p($l->t('Updater')); ?></h2>
 
 	<?php if($isNewVersionAvailable === true): ?>
 		<strong><?php p($l->t('A new version is available: %s', [$newVersionString])); ?></strong>
-		<?php if($updaterRequirementsFulfilled === true): ?>
-			<input type="button" id="oca_updatenotification_button" value="<?php p($l->t('Open updater')) ?>">
-		<?php else: ?>
-			<br/><?php p($l->t('At the moment only manual updates are supported on your environment. This is very likely the case because functions such as shell_exec are not available.')); ?>
-		<?php endif; ?>
+		<input type="button" id="oca_updatenotification_button" value="<?php p($l->t('Open updater')) ?>">
 	<?php else: ?>
 		<strong><?php print_unescaped($l->t('Your version is up to date.')); ?></strong>
 		<span class="icon-info svg" title="<?php p($l->t('Checked on %s', [$lastCheckedDate])) ?>"></span>

--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -20,8 +20,10 @@
 
 	<?php if($isNewVersionAvailable === true): ?>
 		<strong><?php p($l->t('A new version is available: %s', [$newVersionString])); ?></strong>
-		<?php if ($_['downloadLink']): ?>
-			<a href="<?php p($_['downloadLink']); ?>" class="button"><?php p($l->t('Download now')) ?></a>
+		<?php if($updaterRequirementsFulfilled === true): ?>
+			<input type="button" id="oca_updatenotification_button" value="<?php p($l->t('Open updater')) ?>">
+		<?php else: ?>
+			<br/><?php p($l->t('At the moment only manual updates are supported on your environment. This is very likely the case because functions such as shell_exec are not available.')); ?>
 		<?php endif; ?>
 	<?php else: ?>
 		<strong><?php print_unescaped($l->t('Your version is up to date.')); ?></strong>

--- a/apps/updatenotification/tests/UpdateCheckerTest.php
+++ b/apps/updatenotification/tests/UpdateCheckerTest.php
@@ -46,14 +46,13 @@ class UpdateCheckerTest extends TestCase {
 			->method('check')
 			->willReturn([
 				'version' => 123,
-				'versionstring' => 'Nextcloud 123',
+				'versionstring' => 'ownCloud 123',
 				'web'=> 'javascript:alert(1)',
-				'url'=> 'javascript:alert(2)',
 			]);
 
 		$expected = [
 			'updateAvailable' => true,
-			'updateVersion' => 'Nextcloud 123',
+			'updateVersion' => 'ownCloud 123',
 		];
 		$this->assertSame($expected, $this->updateChecker->getUpdateState());
 	}
@@ -64,16 +63,14 @@ class UpdateCheckerTest extends TestCase {
 			->method('check')
 			->willReturn([
 				'version' => 123,
-				'versionstring' => 'Nextcloud 123',
-				'web'=> 'https://docs.nextcloud.com/myUrl',
-				'url'=> 'https://downloads.nextcloud.org/server',
+				'versionstring' => 'ownCloud 123',
+				'web'=> 'https://owncloud.org/myUrl',
 			]);
 
 		$expected = [
 			'updateAvailable' => true,
-			'updateVersion' => 'Nextcloud 123',
-			'updateLink' => 'https://docs.nextcloud.com/myUrl',
-			'downloadLink' => 'https://downloads.nextcloud.org/server',
+			'updateVersion' => 'ownCloud 123',
+			'updateLink' => 'https://owncloud.org/myUrl',
 		];
 		$this->assertSame($expected, $this->updateChecker->getUpdateState());
 	}

--- a/apps/updatenotification/tests/controller/AdminControllerTest.php
+++ b/apps/updatenotification/tests/controller/AdminControllerTest.php
@@ -68,23 +68,17 @@ class AdminControllerTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->dateTimeFormatter = $this->getMock('\\OCP\\IDateTimeFormatter');
 
-		$this->adminController = $this->getMockBuilder('\OCA\UpdateNotification\Controller\AdminController')
-			->setConstructorArgs(
-				[
-					'updatenotification',
-					$this->request,
-					$this->jobList,
-					$this->secureRandom,
-					$this->config,
-					$this->timeFactory,
-					$this->l10n,
-					$this->updateChecker,
-					$this->dateTimeFormatter,
-				]
-			)
-			->setMethods(['isCompatibleWithUpdater'])
-			->getMock()
-		;
+		$this->adminController = new AdminController(
+			'updatenotification',
+			$this->request,
+			$this->jobList,
+			$this->secureRandom,
+			$this->config,
+			$this->timeFactory,
+			$this->l10n,
+			$this->updateChecker,
+			$this->dateTimeFormatter
+		);
 	}
 
 	public function testDisplayPanelWithUpdate() {
@@ -115,10 +109,6 @@ class AdminControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getUpdateState')
 			->willReturn(['updateVersion' => '8.1.2']);
-		$this->adminController
-			->expects($this->once())
-			->method('isCompatibleWithUpdater')
-			->willReturn(true);
 
 		$params = [
 			'isNewVersionAvailable' => true,
@@ -126,53 +116,6 @@ class AdminControllerTest extends TestCase {
 			'currentChannel' => \OCP\Util::getChannel(),
 			'channels' => $channels,
 			'newVersionString' => '8.1.2',
-			'updaterRequirementsFulfilled' => true,
-		];
-
-		$expected = new TemplateResponse('updatenotification', 'admin', $params, '');
-		$this->assertEquals($expected, $this->adminController->displayPanel());
-	}
-
-	public function testDisplayPanelWithUpdateAndIncompatibleUpdaterApp() {
-		$channels = [
-			'daily',
-			'beta',
-			'stable',
-			'production',
-		];
-		$currentChannel = \OCP\Util::getChannel();
-
-		// Remove the currently used channel from the channels list
-		if(($key = array_search($currentChannel, $channels)) !== false) {
-			unset($channels[$key]);
-		}
-
-		$this->config
-			->expects($this->once())
-			->method('getAppValue')
-			->with('core', 'lastupdatedat')
-			->willReturn('12345');
-		$this->dateTimeFormatter
-			->expects($this->once())
-			->method('formatDateTime')
-			->with('12345')
-			->willReturn('LastCheckedReturnValue');
-		$this->updateChecker
-			->expects($this->once())
-			->method('getUpdateState')
-			->willReturn(['updateVersion' => '8.1.2']);
-		$this->adminController
-			->expects($this->once())
-			->method('isCompatibleWithUpdater')
-			->willReturn(false);
-
-		$params = [
-			'isNewVersionAvailable' => true,
-			'lastChecked' => 'LastCheckedReturnValue',
-			'currentChannel' => \OCP\Util::getChannel(),
-			'channels' => $channels,
-			'newVersionString' => '8.1.2',
-			'updaterRequirementsFulfilled' => false,
 		];
 
 		$expected = new TemplateResponse('updatenotification', 'admin', $params, '');
@@ -207,10 +150,6 @@ class AdminControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getUpdateState')
 			->willReturn([]);
-		$this->adminController
-			->expects($this->once())
-			->method('isCompatibleWithUpdater')
-			->willReturn(true);
 
 		$params = [
 			'isNewVersionAvailable' => false,
@@ -218,7 +157,6 @@ class AdminControllerTest extends TestCase {
 			'currentChannel' => \OCP\Util::getChannel(),
 			'channels' => $channels,
 			'newVersionString' => '',
-			'updaterRequirementsFulfilled' => true,
 		];
 
 		$expected = new TemplateResponse('updatenotification', 'admin', $params, '');

--- a/apps/updatenotification/tests/controller/AdminControllerTest.php
+++ b/apps/updatenotification/tests/controller/AdminControllerTest.php
@@ -127,7 +127,6 @@ class AdminControllerTest extends TestCase {
 			'channels' => $channels,
 			'newVersionString' => '8.1.2',
 			'updaterRequirementsFulfilled' => true,
-			'downloadLink' => '',
 		];
 
 		$expected = new TemplateResponse('updatenotification', 'admin', $params, '');
@@ -161,10 +160,7 @@ class AdminControllerTest extends TestCase {
 		$this->updateChecker
 			->expects($this->once())
 			->method('getUpdateState')
-			->willReturn([
-				'updateVersion' => '8.1.2',
-				'downloadLink' => 'https://downloads.nextcloud.org/server',
-			]);
+			->willReturn(['updateVersion' => '8.1.2']);
 		$this->adminController
 			->expects($this->once())
 			->method('isCompatibleWithUpdater')
@@ -177,7 +173,6 @@ class AdminControllerTest extends TestCase {
 			'channels' => $channels,
 			'newVersionString' => '8.1.2',
 			'updaterRequirementsFulfilled' => false,
-			'downloadLink' => 'https://downloads.nextcloud.org/server',
 		];
 
 		$expected = new TemplateResponse('updatenotification', 'admin', $params, '');
@@ -224,7 +219,6 @@ class AdminControllerTest extends TestCase {
 			'channels' => $channels,
 			'newVersionString' => '',
 			'updaterRequirementsFulfilled' => true,
-			'downloadLink' => '',
 		];
 
 		$expected = new TemplateResponse('updatenotification', 'admin', $params, '');

--- a/lib/private/repair.php
+++ b/lib/private/repair.php
@@ -41,6 +41,7 @@ use OC\Repair\CopyRewriteBaseToConfig;
 use OC\Repair\DropOldJobs;
 use OC\Repair\EncryptionCompatibility;
 use OC\Repair\MoveChannelToSystemConfig;
+use OC\Repair\MoveUpdaterStepFile;
 use OC\Repair\OldGroupMembershipShares;
 use OC\Repair\RemoveGetETagEntries;
 use OC\Repair\SqliteAutoincrement;
@@ -123,6 +124,7 @@ class Repair extends BasicEmitter {
 			new RepairInvalidShares(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection()),
 			new AvatarPermissions(\OC::$server->getDatabaseConnection()),
 			new MoveChannelToSystemConfig(\OC::$server->getConfig()),
+			new MoveUpdaterStepFile(\OC::$server->getConfig()),
 		];
 	}
 

--- a/lib/private/repair/moveupdaterstepfile.php
+++ b/lib/private/repair/moveupdaterstepfile.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Morris Jobke <hey@morrisjobke.de>
+ *
+ * @author Morris Jobke <hey@morrisjobke.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Repair;
+
+use OC\Hooks\BasicEmitter;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class MoveUpdaterStepFile extends BasicEmitter  implements \OC\RepairStep {
+
+	/** @var \OCP\IConfig */
+	protected $config;
+
+	/**
+	 * @param \OCP\IConfig $config
+	 */
+	public function __construct($config) {
+		$this->config = $config;
+	}
+
+	public function getName() {
+		return 'Move .step file of updater to backup location';
+	}
+
+	public function run() {
+
+		$dataDir = $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT);
+		$instanceId = $this->config->getSystemValue('instanceid', null);
+
+		if(!is_string($instanceId) || empty($instanceId)) {
+			return;
+		}
+
+		$updaterFolderPath = $dataDir . '/updater-' . $instanceId;
+		$stepFile = $updaterFolderPath . '/.step';
+		if(file_exists($stepFile)) {
+			$this->emit('\OC\Repair', 'info', array('.step file exists'));
+
+			$previousStepFile = $updaterFolderPath . '/.step-previous-update';
+
+			// cleanup
+			if(file_exists($previousStepFile)) {
+				if(\OC_Helper::rmdirr($previousStepFile)) {
+					$this->emit('\OC\Repair', 'info', array('.step-previous-update removed'));
+				} else {
+					$this->emit('\OC\Repair', 'info', array('.step-previous-update can\'t be removed - abort move of .step file'));
+					return;
+				}
+			}
+
+			// move step file
+			if(rename($stepFile, $previousStepFile)) {
+				$this->emit('\OC\Repair', 'info', array('.step file moved to .step-previous-update'));
+			} else {
+				$this->emit('\OC\Repair', 'warning', array('.step file can\'t be moved'));
+			}
+		}
+	}
+}
+


### PR DESCRIPTION
- backport of #1499 to stable9
- fixes both items in #1485
- repair step moves the update step file `data/updater-INSTANCEID/.step` to a file named `.step-previous-update` to not show all steps as done on the next update
- reverts  202ae42

cc @LukasReschke @nickvergessen @karlitschek
