### PR TITLE
Fix selection of workflowengine rules and operators

### DIFF
--- a/apps/workflowengine/js/admin.js
+++ b/apps/workflowengine/js/admin.js
@@ -21,7 +21,7 @@
 (function() {
 	Handlebars.registerHelper('selectItem', function(currentValue, itemValue) {
 		if(currentValue === itemValue) {
-			return 'selected=selected';
+			return 'selected="selected"';
 		}
 
 		return "";

--- a/apps/workflowengine/js/filemimetypeplugin.js
+++ b/apps/workflowengine/js/filemimetypeplugin.js
@@ -41,9 +41,9 @@
 				return;
 			}
 
-			var placeholder = t('workflowengine', 'text/plain');
+			var placeholder = 'text/plain';
 			if (check['operator'] === 'matches' || check['operator'] === '!matches') {
-				placeholder = t('workflowengine', '/^text\\/(plain|html)$/i');
+				placeholder = '/^text\\/(plain|html)$/i';
 
 				if (this._validateRegex(check['value'])) {
 					$(element).removeClass('invalid-input');

--- a/apps/workflowengine/js/requesturlplugin.js
+++ b/apps/workflowengine/js/requesturlplugin.js
@@ -42,10 +42,10 @@
 				return;
 			}
 
-			var placeholder = t('workflowengine', 'https://localhost/index.php');
+			var placeholder = 'https://localhost/index.php';
 
 			if (check['operator'] === 'matches' || check['operator'] === '!matches') {
-				placeholder = t('workflowengine', '/^https\\:\\/\\/localhost\\/index\\.php$/i');
+				placeholder = '/^https\\:\\/\\/localhost\\/index\\.php$/i';
 			}
 
 			$(element).css('width', '250px')

--- a/apps/workflowengine/js/requestuseragentplugin.js
+++ b/apps/workflowengine/js/requestuseragentplugin.js
@@ -42,10 +42,10 @@
 				return;
 			}
 
-			var placeholder = t('workflowengine', 'Mozilla/5.0 User Agent');
+			var placeholder = 'Mozilla/5.0 User Agent';
 
 			if (check['operator'] === 'matches' || check['operator'] === '!matches') {
-				placeholder = t('workflowengine', '/^Mozilla\\/5\\.0 (.?)$/i');
+				placeholder = '/^Mozilla\\/5\\.0 (.?)$/i';
 			}
 
 			$(element).css('width', '250px')

--- a/apps/workflowengine/templates/admin.php
+++ b/apps/workflowengine/templates/admin.php
@@ -55,12 +55,12 @@
 				<div class="check" data-id="{{@index}}">
 					<select class="check-class">
 						{{#each ../classes}}
-						<option value="{{class}}" {{selectItem class ../class}}>{{name}}</option>
+						<option value="{{class}}" {{{selectItem class ../class}}}>{{name}}</option>
 						{{/each}}
 					</select>
 					<select class="check-operator">
 						{{#each (getOperators class)}}
-						<option value="{{operator}}" {{selectItem operator ../operator}}>{{name}}</option>
+						<option value="{{operator}}" {{{selectItem operator ../operator}}}>{{name}}</option>
 						{{/each}}
 					</select>
 					<input type="text" class="check-value" value="{{value}}">


### PR DESCRIPTION
Broken by #1429 

``` irc
<nickvergessen> MorrisJobke: did we update handlebars lately?
<MorrisJobke> nickvergessen: I think so :(
<nickvergessen> broke selection of workflow rules
<nickvergessen> but will fix it easily
<MorrisJobke> nickvergessen: https://github.com/nextcloud/server/pull/1429
<nickvergessen> it escapes = now
<nickvergessen> therefor select=select needs {{{ instead of {{
```

@MorrisJobke @rullzer 
