### PR TITLE
Remove upload_limit in files app as it is not needed with PUT upload

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -769,8 +769,7 @@ OC.Uploader.prototype = _.extend({
 						data.originalFiles.selection = {
 							uploads: [],
 							filesToUpload: data.originalFiles.length,
-							totalBytes: 0,
-							biggestFileBytes: 0
+							totalBytes: 0
 						};
 					}
 					// TODO: move originalFiles to a separate container, maybe inside OC.Upload
@@ -825,18 +824,6 @@ OC.Uploader.prototype = _.extend({
 					} else {
 						// add size
 						selection.totalBytes += file.size;
-						// update size of biggest file
-						selection.biggestFileBytes = Math.max(selection.biggestFileBytes, file.size);
-					}
-
-					// check PHP upload limit against biggest file
-					if (selection.biggestFileBytes > $('#upload_limit').val()) {
-						data.textStatus = 'sizeexceedlimit';
-						data.errorThrown = t('files',
-							'Total file size {size1} exceeds upload limit {size2}', {
-							'size1': humanFileSize(selection.biggestFileBytes),
-							'size2': humanFileSize($('#upload_limit').val())
-						});
 					}
 
 					// check free space

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -59,7 +59,6 @@
 				return;
 			}
 			if (response.data !== undefined && response.data.uploadMaxFilesize !== undefined) {
-				$('#max_upload').val(response.data.uploadMaxFilesize);
 				$('#free_space').val(response.data.freeSpace);
 				$('#upload.button').attr('data-original-title', response.data.maxHumanFilesize);
 				$('#usedSpacePercent').val(response.data.usedSpacePercent);
@@ -71,7 +70,6 @@
 				return;
 			}
 			if (response[0].uploadMaxFilesize !== undefined) {
-				$('#max_upload').val(response[0].uploadMaxFilesize);
 				$('#upload.button').attr('data-original-title', response[0].maxHumanFilesize);
 				$('#usedSpacePercent').val(response[0].usedSpacePercent);
 				Files.displayStorageWarnings();

--- a/apps/files/list.php
+++ b/apps/files/list.php
@@ -24,11 +24,9 @@
 $config = \OC::$server->getConfig();
 // TODO: move this to the generated config.js
 $publicUploadEnabled = $config->getAppValue('core', 'shareapi_allow_public_upload', 'yes');
-$uploadLimit=OCP\Util::uploadLimit();
 
 // renders the controls and table headers template
 $tmpl = new OCP\Template('files', 'list', '');
-$tmpl->assign('uploadLimit', $uploadLimit); // PHP upload limit
 $tmpl->assign('publicUploadEnabled', $publicUploadEnabled);
 $tmpl->printPage();
 

--- a/apps/files/templates/list.php
+++ b/apps/files/templates/list.php
@@ -15,8 +15,6 @@
 			 through ajax instead (updateStorageStatistics).
 	*/ ?>
 	<input type="hidden" name="permissions" value="" id="permissions">
-	<input type="hidden" id="max_upload" name="MAX_FILE_SIZE" value="<?php isset($_['uploadMaxFilesize']) ? p($_['uploadMaxFilesize']) : '' ?>">
-	<input type="hidden" id="upload_limit" value="<?php isset($_['uploadLimit']) ? p($_['uploadLimit']) : '' ?>">
 	<input type="hidden" id="free_space" value="<?php isset($_['freeSpace']) ? p($_['freeSpace']) : '' ?>">
 	<?php if(isset($_['dirToken'])):?>
 	<input type="hidden" id="publicUploadRequestToken" name="requesttoken" value="<?php p($_['requesttoken']) ?>" />

--- a/apps/files/tests/js/fileUploadSpec.js
+++ b/apps/files/tests/js/fileUploadSpec.js
@@ -35,7 +35,6 @@ describe('OC.Upload tests', function() {
 		// need a dummy button because file-upload checks on it
 		$('#testArea').append(
 			'<input type="file" id="file_upload_start" name="files[]" multiple="multiple">' +
-			'<input type="hidden" id="upload_limit" name="upload_limit" value="10000000">' + // 10 MB
 			'<input type="hidden" id="free_space" name="free_space" value="50000000">' + // 50 MB
 			// TODO: handlebars!
 			'<div id="new">' +
@@ -96,19 +95,6 @@ describe('OC.Upload tests', function() {
 			expect(result[0]).not.toEqual(null);
 			expect(result[0].submit.calledOnce).toEqual(true);
 			expect(failStub.notCalled).toEqual(true);
-		});
-		it('does not add file if it exceeds upload limit', function() {
-			var result;
-			$('#upload_limit').val(1000);
-
-			result = addFiles(uploader, [testFile]);
-
-			expect(result[0]).toEqual(null);
-			expect(failStub.calledOnce).toEqual(true);
-			expect(failStub.getCall(0).args[1].textStatus).toEqual('sizeexceedlimit');
-			expect(failStub.getCall(0).args[1].errorThrown).toEqual(
-				'Total file size 5 KB exceeds upload limit 1000 B'
-			);
 		});
 		it('does not add file if it exceeds free space', function() {
 			var result;

--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -342,9 +342,8 @@ class ShareController extends Controller {
 				$freeSpace = (INF > 0) ? INF: PHP_INT_MAX; // work around https://bugs.php.net/bug.php?id=69188
 			}
 
-			$uploadLimit = Util::uploadLimit();
-			$maxUploadFilesize = min($freeSpace, $uploadLimit);
 			$hideFileList = $share->getPermissions() & \OCP\Constants::PERMISSION_READ ? false : true;
+			$maxUploadFilesize = $freeSpace;
 
 			$folder = new Template('files', 'list', '');
 			$folder->assign('dir', $rootFolder->getRelativePath($folderNode->getPath()));
@@ -356,7 +355,6 @@ class ShareController extends Controller {
 			$folder->assign('uploadMaxFilesize', $maxUploadFilesize);
 			$folder->assign('uploadMaxHumanFilesize', \OCP\Util::humanFileSize($maxUploadFilesize));
 			$folder->assign('freeSpace', $freeSpace);
-			$folder->assign('uploadLimit', $uploadLimit); // PHP upload limit
 			$folder->assign('usedSpacePercent', 0);
 			$folder->assign('trash', false);
 			$shareTmpl['folder'] = $folder->fetchPage();


### PR DESCRIPTION
From https://github.com/owncloud/core/pull/26069
- [x] requires https://github.com/nextcloud/server/pull/1283

The web UI now uses for PUT uploads which aren't restricted by PHP's
upload_max_filesize and post_max_size

Signed-off-by: Lukas Reschke lukas@statuscode.ch
