### PR TITLE
Only use realpath for real directories (#26058)

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -54,7 +54,12 @@ class Local extends \OC\Files\Storage\Common {
 			throw new \InvalidArgumentException('No data directory set for local storage');
 		}
 		$this->datadir = $arguments['datadir'];
-		$this->realDataDir = rtrim(realpath($this->datadir), '/') . '/';
+		// some crazy code uses a local storage on root...
+		if ($this->datadir === '/') {
+			$this->realDataDir = $this->datadir;
+		} else {
+			$this->realDataDir = rtrim(realpath($this->datadir), '/') . '/';
+		}
 		if (substr($this->datadir, -1) !== '/') {
 			$this->datadir .= '/';
 		}


### PR DESCRIPTION
In some cross-local-storage use cases, the Local storage is
instantiated with "/" as data directory. In such cases, calling
realpath() would cause PHP warnings when open_basedir is set.

This fix bypasses the realpath() call when dealing with a root storage.

Downstreaming of https://github.com/owncloud/core/pull/26058

Signed-off-by: Lukas Reschke lukas@statuscode.ch
