### PR TITLE
trust private non-experimental apps

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -693,12 +693,16 @@ $CONFIG = array(
  * file system path to the app folder. The key ``url`` defines the HTTP Web path
  * to that folder, starting from the Nextcloud webroot. The key ``writable``
  * indicates if a Web server can write files to that folder.
+ * The key ``trusted`` indicates that all apps in this folder shouldn't be checked 
+ * against central repositories for validation, but considered trustworthy and
+ * non-experimental.
  */
 'apps_paths' => array(
 	array(
 		'path'=> '/var/www/nextcloud/apps',
 		'url' => '/apps',
 		'writable' => true,
+		'trusted' => false,
 	),
 ),
 

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -426,6 +426,8 @@ class Updater extends BasicEmitter {
 		$apps = OC_App::getEnabledApps();
 		$version = \OCP\Util::getVersion();
 		$disabledApps = [];
+		$localTrustApps=OC_App::getAllApps(true);
+		
 		foreach ($apps as $app) {
 			// check if the app is compatible with this version of ownCloud
 			$info = OC_App::getAppInfo($app);
@@ -439,6 +441,10 @@ class Updater extends BasicEmitter {
 			}
 			// shipped apps will remain enabled
 			if (OC_App::isShipped($app)) {
+				continue;
+			}
+			// locally trusted apps remain enabled
+			if (array_search($app, $localTrustApps)) {
 				continue;
 			}
 			// authentication and session apps will remain enabled as well

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -798,7 +798,7 @@ class OC_App {
 	 * @return array an array of app names (string IDs)
 	 * @todo: change the name of this method to getInstalledApps, which is more accurate
 	 */
-	public static function getAllApps() {
+	public static function getAllApps($onlyLocalTrusted=false) {
 
 		$apps = array();
 
@@ -807,6 +807,10 @@ class OC_App {
 				\OCP\Util::writeLog('core', 'unable to read app folder : ' . $apps_dir['path'], \OCP\Util::WARN);
 				continue;
 			}
+			if ($onlyLocalTrusted && ! (array_key_exists('trusted', $apps_dir) &&  $apps_dir['trusted'])) {
+				continue;
+			}
+			
 			$dh = opendir($apps_dir['path']);
 
 			if (is_resource($dh)) {
@@ -842,6 +846,7 @@ class OC_App {
 
 		//we don't want to show configuration for these
 		$blacklist = \OC::$server->getAppManager()->getAlwaysEnabledApps();
+		$localTrustApps=OC_App::getAllApps(true);
 		$appList = array();
 
 		foreach ($installedApps as $app) {
@@ -880,6 +885,10 @@ class OC_App {
 					$info['removable'] = true;
 				}
 
+				if (array_search($app, $localTrustApps)) {
+					$info['level'] = 50;
+				}
+				
 				$info['update'] = ($includeUpdateInfo) ? Installer::isUpdateAvailable($app) : null;
 
 				$appPath = self::getAppPath($app);

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -366,6 +366,9 @@ span.version {
 .app-level .approved {
 	border-color: #0082c9;
 }
+.app-level .private-trusted {
+	border-color: #000000;
+}
 .app-level .experimental {
 	background-color: #ce3702;
 	border-color: #ce3702;

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -15,6 +15,8 @@ Handlebars.registerHelper('level', function() {
 			return new Handlebars.SafeString('<span class="official icon-checkmark">' + t('settings', 'Official') + '</span>');
 		} else if(this.level === 100) {
 			return new Handlebars.SafeString('<span class="approved">' + t('settings', 'Approved') + '</span>');
+		} else if(this.level === 50) {
+			return new Handlebars.SafeString('<span class="private-trusted">' + t('settings', 'Private trusted') + '</span>');
 		} else {
 			return new Handlebars.SafeString('<span class="experimental">' + t('settings', 'Experimental') + '</span>');
 		}


### PR DESCRIPTION
Referencing https://github.com/nextcloud/server/issues/561

Using the key 'trusted', an apps directory configured using apps_paths in config.php can be marked as non-experimental and trusted, despite not being listed in apps repositories.
All apps in the marked directory get an $app['level'] of 50, which is displayed as "private trusted" in the apps app, and won't get disabled when upgrading.
