### PR TITLE
Fix integration test to use a valid URL

### DIFF
--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -501,15 +501,16 @@ Feature: provisioning
 	    Given As an "admin"
 		And user "user0" exists
 		And As an "user0"
-		When sending "GET" to "/index.php/apps/files"
+		When sending "GET" to "/cloud/capabilities"
 		Then the HTTP status code should be "200"
+		And the OCS status code should be "100"
 
 	Scenario: Making a web request with a disabled user
 	    Given As an "admin"
 		And user "user0" exists
 		And assure user "user0" is disabled
 		And As an "user0"
-		When sending "GET" to "/index.php/apps/files"
+		When sending "GET" to "/cloud/capabilities"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 


### PR DESCRIPTION
Previously we requested `ocs/v1.php/index.php/apps/files` which of course is not intended and might not always give a 200...

@MorrisJobke @rullzer @LukasReschke 
