### PR TITLE
[stable10] Increase the max length for components

### DIFF
--- a/apps/dav/appinfo/database.xml
+++ b/apps/dav/appinfo/database.xml
@@ -363,7 +363,7 @@ CREATE TABLE calendarobjects (
 		<field>
 			<name>components</name>
 			<type>text</type>
-			<length>20</length>
+			<length>64</length>
 		</field>
 		<field>
 			<name>transparent</name>

--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>WebDAV endpoint</description>
 	<licence>AGPL</licence>
 	<author>owncloud.org</author>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<default_enable/>
 	<types>
 		<filesystem/>


### PR DESCRIPTION
Backport of #1543 

Going with 64, because all components we know appended comma-separated are 49

@MorrisJobke @LukasReschke
