### PR TITLE
Fix comment count tooltip

### DIFF
--- a/apps/comments/js/filesplugin.js
+++ b/apps/comments/js/filesplugin.js
@@ -39,7 +39,7 @@
 			}
 			return this._commentsUnreadTemplate({
 				count: count,
-				countMessage: t('comments', '{count} unread comments', {count: count}),
+				countMessage: n('comments', '%n unread comment', '%n unread comments', count),
 				iconUrl: OC.imagePath('core', 'actions/comment')
 			});
 		},


### PR DESCRIPTION
`count` seems to be a special magic string, that does not work:

> ![bildschirmfoto vom 2016-09-28 10-51-57](https://cloud.githubusercontent.com/assets/213943/18906990/1e9c28d6-856a-11e6-8c6f-44af7eb02a8f.png)

Since I touched the string anyway, I just turned it into a plural.

@blizzz @MorrisJobke 
