### PR TITLE
[stable10] UpdateState is empty if no update is available

### DIFF
--- a/apps/updatenotification/lib/Controller/AdminController.php
+++ b/apps/updatenotification/lib/Controller/AdminController.php
@@ -113,7 +113,7 @@ class AdminController extends Controller implements ISettings {
 			'channels' => $channels,
 			'newVersionString' => (empty($updateState['updateVersion'])) ? '' : $updateState['updateVersion'],
 			'downloadLink' => (empty($updateState['downloadLink'])) ? '' : $updateState['downloadLink'],
-			'updaterEnabled' => $updateState['updaterEnabled'],
+			'updaterEnabled' => (empty($updateState['updaterEnabled'])) ? false : $updateState['updaterEnabled'],
 
 			'notify_groups' => implode('|', $notifyGroups),
 		];

--- a/apps/updatenotification/tests/Controller/AdminControllerTest.php
+++ b/apps/updatenotification/tests/Controller/AdminControllerTest.php
@@ -161,7 +161,7 @@ class AdminControllerTest extends TestCase {
 		$this->updateChecker
 			->expects($this->once())
 			->method('getUpdateState')
-			->willReturn(['updaterEnabled' => false]);
+			->willReturn([]);
 
 		$params = [
 			'isNewVersionAvailable' => false,


### PR DESCRIPTION
This leads to log messages such as "Undefined index: updaterEnabled at /media/psf/nextcloud/apps/updatenotification/lib/Controller/AdminController.php#116".

Backport of https://github.com/nextcloud/server/pull/1554
