### PR TITLE
[Stable9] updatestate can be empty

### DIFF
--- a/apps/updatenotification/controller/admincontroller.php
+++ b/apps/updatenotification/controller/admincontroller.php
@@ -108,7 +108,7 @@ class AdminController extends Controller {
 			'channels' => $channels,
 			'newVersionString' => (empty($updateState['updateVersion'])) ? '' : $updateState['updateVersion'],
 			'downloadLink' => (empty($updateState['downloadLink'])) ? '' : $updateState['downloadLink'],
-			'updaterEnabled' => $updateState['updaterEnabled'],
+			'updaterEnabled' => (empty($updateState['updaterEnabled'])) ? false : $updateState['updaterEnabled'],
 		];
 
 		return new TemplateResponse($this->appName, 'admin', $params, '');


### PR DESCRIPTION
This leads to log messages such as "Undefined index: updaterEnabled at /media/psf/nextcloud/apps/updatenotification/lib/Controller/AdminController.php#116".

Backport of https://github.com/nextcloud/server/pull/1554
