### PR TITLE
Remove notifications upon user deletion

### DIFF
--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -214,6 +214,10 @@ class User implements IUser {
 
 			\OC::$server->getCommentsManager()->deleteReferencesOfActor('users', $this->uid);
 			\OC::$server->getCommentsManager()->deleteReadMarksFromUser($this);
+
+			$notification = \OC::$server->getNotificationManager()->createNotification();
+			$notification->setUser($this->uid);
+			\OC::$server->getNotificationManager()->markProcessed($notification);
 		}
 
 		if ($this->emitter) {

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -218,10 +218,10 @@ class User implements IUser {
 			$notification = \OC::$server->getNotificationManager()->createNotification();
 			$notification->setUser($this->uid);
 			\OC::$server->getNotificationManager()->markProcessed($notification);
-		}
 
-		if ($this->emitter) {
-			$this->emitter->emit('\OC\User', 'postDelete', array($this));
+			if ($this->emitter) {
+				$this->emitter->emit('\OC\User', 'postDelete', array($this));
+			}
 		}
 		return !($result === false);
 	}

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -435,16 +435,17 @@ class UserTest extends \Test\TestCase {
 
 	public function dataDeleteHooks() {
 		return [
-			[true],
-			[false],
+			[true, 2],
+			[false, 1],
 		];
 	}
 
 	/**
 	 * @dataProvider dataDeleteHooks
 	 * @param bool $result
+	 * @param int $expectedHooks
 	 */
-	public function testDeleteHooks($result) {
+	public function testDeleteHooks($result, $expectedHooks) {
 		$hooksCalled = 0;
 		$test = $this;
 
@@ -521,7 +522,7 @@ class UserTest extends \Test\TestCase {
 		$this->restoreService('CommentsManager');
 		$this->restoreService('NotificationManager');
 
-		$this->assertEquals(2, $hooksCalled);
+		$this->assertEquals($expectedHooks, $hooksCalled);
 	}
 
 	public function testGetCloudId() {


### PR DESCRIPTION
Ref #1551 

Not sure if this is correct, or if it should be done by the app. When it's done by the app, each of the apps would need to listen to the hook. What's different from comments to notifications, is that comments stores the data inside "core/server" instead of an app.

@LukasReschke @MorrisJobke thoughts?
