### PR TITLE
Add Gnome Nautilus agent and DAVdroid agent to incompatible user agents

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -515,6 +515,10 @@ class OC {
 		$incompatibleUserAgents = [
 			// OS X Finder
 			'/^WebDAVFS/',
+			// Gnome Nautilus
+			'/^gvfs/',
+			// DAVdroid
+			'/^DAVdroid/',
 		];
 		if($request->isUserAgent($incompatibleUserAgents)) {
 			return;


### PR DESCRIPTION
Needed for OVH shared server. See #223.
