### PR TITLE
Use proper casing of username in avatar filesystem setup

### DIFF
--- a/lib/private/AvatarManager.php
+++ b/lib/private/AvatarManager.php
@@ -91,6 +91,8 @@ class AvatarManager implements IAvatarManager {
 		if (is_null($user)) {
 			throw new \Exception('user does not exist');
 		}
+		// sanitize userID - fixes casing issue (needed for the filesystem stuff that is done below)
+		$userId = $user->getUID();
 
 		/*
 		 * Fix for #22119

--- a/lib/private/AvatarManager.php
+++ b/lib/private/AvatarManager.php
@@ -91,14 +91,20 @@ class AvatarManager implements IAvatarManager {
 		if (is_null($user)) {
 			throw new \Exception('user does not exist');
 		}
+
 		// sanitize userID - fixes casing issue (needed for the filesystem stuff that is done below)
 		$userId = $user->getUID();
 
 		/*
 		 * Fix for #22119
-		 * Basically we do not want to copy the skeleton folder
+		 * Basically we do not want to copy the skeleton folder.
+		 *
+		 * For unit test purposes this is ignored when run in PHPUnit.
 		 */
-		\OC\Files\Filesystem::initMountPoints($userId);
+		if(!defined('PHPUNIT_RUN')) {
+			\OC\Files\Filesystem::initMountPoints($userId);
+		}
+
 		$dir = '/' . $userId;
 		/** @var Folder $folder */
 		$folder = $this->rootFolder->get($dir);


### PR DESCRIPTION
- before you could request an avatar for User instead of user
  which sets up the filesystem for that user twice causing
  the sharing codes collision detection to detect a lot of
  collisions

cc @icewind1991 @rullzer @schiessle 

I will also check all other usages of initMountPoints to be called with the correct casing to avoid such issues again. We also should avoid to use those internal methods in the higher level application code.

@karlitschek I would love to backport this, because it creates a lot of appended (2) for all received shares.
