### PR TITLE
Remove unneeded int casts to work on new app store OCS API

### DIFF
--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -237,7 +237,7 @@ class Installer {
 	/**
 	 * update an app by it's id
 	 *
-	 * @param integer $ocsId
+	 * @param string $ocsId
 	 * @return bool
 	 * @throws \Exception
 	 */

--- a/lib/private/OCSClient.php
+++ b/lib/private/OCSClient.php
@@ -155,7 +155,7 @@ class OCSClient {
 		$cats = [];
 
 		foreach ($tmp->category as $value) {
-			$id = (int)$value->id;
+			$id = (string)$value->id;
 			$name = (string)$value->name;
 			$cats[$id] = $name;
 		}
@@ -286,7 +286,7 @@ class OCSClient {
 		}
 
 		$app = [];
-		$app['id'] = (int)$id;
+		$app['id'] = (string)$id;
 		$app['name'] = (string)$tmp->name;
 		$app['version'] = (string)$tmp->version;
 		$app['type'] = (string)$tmp->typeid;

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -933,7 +933,7 @@ class OC_App {
 	 * @return string|false
 	 */
 	public static function getInternalAppIdByOcs($ocsID) {
-		if(is_numeric($ocsID)) {
+		if($ocsID) {
 			$idArray = \OC::$server->getAppConfig()->getValues(false, 'ocsid');
 			if(array_search($ocsID, $idArray)) {
 				return array_search($ocsID, $idArray);

--- a/tests/lib/OCSClientTest.php
+++ b/tests/lib/OCSClientTest.php
@@ -764,7 +764,7 @@ class OCSClientTest extends \Test\TestCase {
 			->will($this->returnValue($client));
 
 		$expected = [
-			'id' => 166053,
+			'id' => '166053',
 			'name' => 'Versioning',
 			'version' => '0.0.1',
 			'type' => '925',
@@ -900,7 +900,7 @@ class OCSClientTest extends \Test\TestCase {
 				->will($this->returnValue($client));
 
 		$expected = [
-				'id' => 166053,
+				'id' => '166053',
 				'name' => 'Versioning',
 				'version' => '0.0.1',
 				'type' => '925',


### PR DESCRIPTION
Removes all the unnecessary int casts for categories and ocs ids so that it can actually be made to work with the new app store :D

Can be tested in conjunction with https://github.com/nextcloud/appstore/pull/326

Easy diff: https://github.com/nextcloud/server/pull/1598/files?w=1

@LukasReschke @MorrisJobke @nickvergessen 
