### PR TITLE
Add exemption for incompatible UA (Sailfish CalDAV/CardDAV client)

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -515,6 +515,8 @@ class OC {
 		$incompatibleUserAgents = [
 			// OS X Finder
 			'/^WebDAVFS/',
+			// Sailfish caldav/carddav client
+			'/^Mozilla\/5\.0$/',
 		];
 		if($request->isUserAgent($incompatibleUserAgents)) {
 			return;


### PR DESCRIPTION
Same as #1328 but for Jolla/Sailfish CalDAV/CardDAV client. That UA identifies as exactly `Mozilla/5.0`.
