### PR TITLE
Add undo handler to allow undoing actions in apps

### DIFF
--- a/core/js/tests/specs/undoSpec.js
+++ b/core/js/tests/specs/undoSpec.js
@@ -1,0 +1,155 @@
+/**
+ * @copyright 2016 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2016 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+describe('Undo handler', function() {
+	var execute, undo, cmd;
+	var clock;
+
+	beforeEach(function() {
+		jasmine.clock().install();
+		clock = jasmine.clock();
+
+		// Reset the handler
+		OC.Undo.execute();
+
+		execute = jasmine.createSpy('execute');
+		undo = jasmine.createSpy('undo');
+		cmd = new OC.Undo.Command(execute, undo);
+	});
+
+	afterEach(function() {
+		jasmine.clock().uninstall();
+	});
+
+	it('shows a notification when a command is added', function() {
+		spyOn(OC.Notification, 'showHtml').and.callThrough();
+
+		OC.Undo.push(cmd, 'My action');
+
+		expect(OC.Notification.showHtml.calls.count()).toBe(1);
+		expect(OC.Notification.showHtml).toHaveBeenCalledWith('<span>My action</span> <a>Click to undo</a>');
+	});
+
+	it('hides the notification after 7sec and executes the command', function() {
+		var $row = $('<div/>');
+		spyOn(OC.Notification, 'showHtml').and.callFake(function() {
+			return $row;
+		});
+		spyOn(OC.Notification, 'hide');
+
+		OC.Undo.push(cmd, 'My action');
+		clock.tick(3000);
+		expect(execute).not.toHaveBeenCalled();
+		expect(undo).not.toHaveBeenCalled();
+
+		clock.tick(4200);
+		expect(execute).toHaveBeenCalled();
+		expect(undo).not.toHaveBeenCalled();
+		expect(OC.Notification.hide).toHaveBeenCalledWith($row);
+	});
+
+	it('executes undo if the user clicks the notification', function() {
+		var $row = $('<div/>');
+		spyOn(OC.Notification, 'showHtml').and.callFake(function() {
+			return $row;
+		});
+		spyOn(OC.Notification, 'hide');
+
+		OC.Undo.push(cmd, 'My action');
+		clock.tick(3000);
+		expect(execute).not.toHaveBeenCalled();
+		expect(undo).not.toHaveBeenCalled();
+
+		$row.trigger('click');
+		expect(execute).not.toHaveBeenCalled();
+		expect(undo).toHaveBeenCalled();
+		expect(OC.Notification.hide).toHaveBeenCalledWith($row);
+	});
+
+	it('executes the previous command if a second one is added', function() {
+		spyOn(OC.Notification, 'showHtml').and.callThrough();
+
+		OC.Undo.push(cmd, 'My action');
+		clock.tick(3000);
+		expect(execute).not.toHaveBeenCalled();
+		expect(undo).not.toHaveBeenCalled();
+
+		var cmd2 = new OC.Undo.Command(function() {}, function() {});
+		OC.Undo.push(cmd2, 'My second action');
+
+		expect(execute).toHaveBeenCalled();
+		expect(undo).not.toHaveBeenCalled();
+	});
+
+	it('executes the added command', function() {
+		OC.Undo.push(cmd, 'My action');
+		clock.tick(3000);
+		OC.Undo.execute();
+
+		expect(execute).toHaveBeenCalled();
+		expect(undo).not.toHaveBeenCalled();
+	});
+});
+
+describe('undoable command', function() {
+	var execute, undo;
+
+	beforeEach(function() {
+		execute = jasmine.createSpy('execute');
+		undo = jasmine.createSpy('undo');
+	});
+
+	it('constructs the command correctly', function() {
+		var cmd = new OC.Undo.Command(execute, undo);
+
+		expect(cmd._executed).toBe(false);
+		expect(cmd._undone).toBe(false);
+	});
+
+	it('does not execute a command twice', function() {
+		var cmd = new OC.Undo.Command(execute, undo);
+
+		cmd.execute();
+
+		expect(execute.calls.count()).toBe(1);
+		expect(cmd._executed).toBe(true);
+
+		cmd.execute();
+
+		expect(execute.calls.count()).toBe(1);
+		expect(cmd._executed).toBe(true);
+	});
+
+	it('does not undo a command twice', function() {
+		var cmd = new OC.Undo.Command(execute, undo);
+
+		cmd.undo();
+
+		expect(undo.calls.count()).toBe(1);
+		expect(cmd._undone).toBe(true);
+
+		cmd.execute();
+
+		expect(undo.calls.count()).toBe(1);
+		expect(cmd._undone).toBe(true);
+	});
+});


### PR DESCRIPTION
For [NC11 we want to finally implement undo file deletion](https://github.com/nextcloud/server/issues/745). Since this is a generic software pattern, I'd like to implement it in a reusable undo-handler that can later be used by Nextcloud apps too (e.g. we want to have a fake-undo for sending messages in Mail).

This PR is based on the command pattern, where the handler holds reference of a single command at a time. As soon as another command is added, we execute the previous one. That means that the commands are actually executed deferred, but I'm not yet sure if that is the preferred way for all actions we want to have an undo. Maybe some can be executed immediately, then we could add an option to the command. The current design should be flexible enough to work with both.

@nextcloud/javascript let me know what you think.

TODO:
- [ ] listen to the `onpageunload` event on `window` and execute the command if one is set
- [x] add unit tests
- [ ] fully implement one undo action (e.g. file deletion)
