### PR TITLE
Update notification readable version (10.0.1 instead of 9.1.1.5)

### DIFF
--- a/apps/updatenotification/lib/Notification/BackgroundJob.php
+++ b/apps/updatenotification/lib/Notification/BackgroundJob.php
@@ -98,7 +98,7 @@ class BackgroundJob extends TimedJob {
 
 		$status = $updater->check();
 		if (isset($status['version'])) {
-			$url = $this->urlGenerator->linkToRouteAbsolute('settings_admin') . '#updater';
+			$url = $this->urlGenerator->linkToRouteAbsolute('settings.AdminSettings.index') . '#updater';
 			$this->createNotifications('core', $status['version'], $url, $status['versionstring']);
 		}
 	}

--- a/apps/updatenotification/lib/Notification/BackgroundJob.php
+++ b/apps/updatenotification/lib/Notification/BackgroundJob.php
@@ -99,7 +99,7 @@ class BackgroundJob extends TimedJob {
 		$status = $updater->check();
 		if (isset($status['version'])) {
 			$url = $this->urlGenerator->linkToRouteAbsolute('settings_admin') . '#updater';
-			$this->createNotifications('core', $status['version'], $url);
+			$this->createNotifications('core', $status['version'], $url, $status['versionstring']);
 		}
 	}
 
@@ -123,8 +123,9 @@ class BackgroundJob extends TimedJob {
 	 * @param string $app
 	 * @param string $version
 	 * @param string $url
+	 * @param string $visibleVersion
 	 */
-	protected function createNotifications($app, $version, $url) {
+	protected function createNotifications($app, $version, $url, $visibleVersion = '') {
 		$lastNotification = $this->config->getAppValue('updatenotification', $app, false);
 		if ($lastNotification === $version) {
 			// We already notified about this update
@@ -139,8 +140,13 @@ class BackgroundJob extends TimedJob {
 		$notification->setApp('updatenotification')
 			->setDateTime(new \DateTime())
 			->setObject($app, $version)
-			->setSubject('update_available')
 			->setLink($url);
+
+		if ($visibleVersion !== '') {
+			$notification->setSubject('update_available', ['version' => $visibleVersion]);
+		} else {
+			$notification->setSubject('update_available');
+		}
 
 		foreach ($this->getUsersToNotify() as $uid) {
 			$notification->setUser($uid);

--- a/apps/updatenotification/lib/Notification/Notifier.php
+++ b/apps/updatenotification/lib/Notification/Notifier.php
@@ -66,9 +66,10 @@ class Notifier implements INotifier {
 
 		$l = $this->l10NFactory->get('updatenotification', $languageCode);
 		if ($notification->getObjectType() === 'core') {
-			$appName = $l->t('Nextcloud core');
-
 			$this->updateAlreadyInstalledCheck($notification, $this->getCoreVersions());
+
+			$parameters = $notification->getSubjectParameters();
+			$notification->setParsedSubject($l->t('Update to %1$s is available.', [$parameters['version']]));
 		} else {
 			$appInfo = $this->getAppInfo($notification->getObjectType());
 			$appName = ($appInfo === null) ? $notification->getObjectType() : $appInfo['name'];
@@ -76,9 +77,10 @@ class Notifier implements INotifier {
 			if (isset($this->appVersions[$notification->getObjectType()])) {
 				$this->updateAlreadyInstalledCheck($notification, $this->appVersions[$notification->getObjectType()]);
 			}
+
+			$notification->setParsedSubject($l->t('Update for %1$s to version %2$s is available.', [$appName, $notification->getObjectId()]));
 		}
 
-		$notification->setParsedSubject($l->t('Update for %1$s to version %2$s is available.', [$appName, $notification->getObjectId()]));
 		return $notification;
 	}
 

--- a/apps/updatenotification/tests/Notification/BackgroundJobTest.php
+++ b/apps/updatenotification/tests/Notification/BackgroundJobTest.php
@@ -104,20 +104,23 @@ class BackgroundJobTest extends TestCase {
 
 	public function dataCheckCoreUpdate() {
 		return [
-			['daily', null, null],
-			['git', null, null],
-			['beta', false, null],
+			['daily', null, null, null],
+			['git', null, null, null],
+			['beta', false, null, null],
 			['beta', [
 				'version' => '9.2.0',
-			], '9.2.0'],
-			['stable', false, null],
+				'versionstring' => 'Nextcloud 11.0.0',
+			], '9.2.0', 'Nextcloud 11.0.0'],
+			['stable', false, null, null],
 			['stable', [
 				'version' => '9.2.0',
-			], '9.2.0'],
-			['production', false, null],
+				'versionstring' => 'Nextcloud 11.0.0',
+			], '9.2.0', 'Nextcloud 11.0.0'],
+			['production', false, null, null],
 			['production', [
 				'version' => '9.2.0',
-			], '9.2.0'],
+				'versionstring' => 'Nextcloud 11.0.0',
+			], '9.2.0', 'Nextcloud 11.0.0'],
 		];
 	}
 
@@ -127,8 +130,9 @@ class BackgroundJobTest extends TestCase {
 	 * @param string $channel
 	 * @param mixed $versionCheck
 	 * @param null|string $notification
+	 * @param null|string $readableVersion
 	 */
-	public function testCheckCoreUpdate($channel, $versionCheck, $notification) {
+	public function testCheckCoreUpdate($channel, $versionCheck, $notification, $readableVersion) {
 		$job = $this->getJob([
 			'getChannel',
 			'createVersionCheck',
@@ -169,7 +173,7 @@ class BackgroundJobTest extends TestCase {
 
 			$job->expects($this->once())
 				->method('createNotifications')
-				->willReturn('core', $notification, 'admin-url#updater');
+				->willReturn('core', $notification, 'admin-url#updater', $readableVersion);
 		}
 
 		$this->invokePrivate($job, 'checkCoreUpdate');

--- a/apps/updatenotification/tests/Notification/BackgroundJobTest.php
+++ b/apps/updatenotification/tests/Notification/BackgroundJobTest.php
@@ -168,7 +168,7 @@ class BackgroundJobTest extends TestCase {
 		} else {
 			$this->urlGenerator->expects($this->once())
 				->method('linkToRouteAbsolute')
-				->with('settings_admin')
+				->with('settings.AdminSettings.index')
 				->willReturn('admin-url');
 
 			$job->expects($this->once())


### PR DESCRIPTION
@MorrisJobke @tflidd 

For testing you can apply the following patch:

``` diff
diff --git a/apps/updatenotification/lib/Notification/Notifier.php b/apps/updatenotification/lib/Notification/Notifier.php
index 3e1bc94..d003265 100644
--- a/apps/updatenotification/lib/Notification/Notifier.php
+++ b/apps/updatenotification/lib/Notification/Notifier.php
@@ -66,7 +66,7 @@ class Notifier implements INotifier {

                $l = $this->l10NFactory->get('updatenotification', $languageCode);
                if ($notification->getObjectType() === 'core') {
-                       $this->updateAlreadyInstalledCheck($notification, $this->getCoreVersions());
+                       #$this->updateAlreadyInstalledCheck($notification, $this->getCoreVersions());

                        $parameters = $notification->getSubjectParameters();
                        $notification->setParsedSubject($l->t('Update to %1$s is available.', [$parameters['version']]));

diff --git a/lib/private/Updater/VersionCheck.php b/lib/private/Updater/VersionCheck.php
index f66e109..ffafc4a 100644
--- a/lib/private/Updater/VersionCheck.php
+++ b/lib/private/Updater/VersionCheck.php
@@ -56,7 +56,7 @@ class VersionCheck {
        public function check() {
                // Look up the cache - it is invalidated all 30 minutes
                if (((int)$this->config->getAppValue('core', 'lastupdatedat') + 1800) > time()) {
-                       return json_decode($this->config->getAppValue('core', 'lastupdateResult'), true);
+                       #return json_decode($this->config->getAppValue('core', 'lastupdateResult'), true);
                }

                $updaterUrl = $this->config->getSystemValue('updater.server.url', 'https://updates.nextcloud.com/updater_server/');
@@ -67,7 +67,7 @@ class VersionCheck {
                        $this->config->setAppValue('core', 'installedat', microtime(true));
                }

-               $version = Util::getVersion();
+               $version = [9,1,0,9];//Util::getVersion();
                $version['installed'] = $this->config->getAppValue('core', 'installedat');
                $version['updated'] = $this->config->getAppValue('core', 'lastupdatedat');
                $version['updatechannel'] = \OC_Util::getChannel();
```

@karlitschek should backport the first commit down to stable10

Fix #1605 
