### PR TITLE
make it possible to share the current folder

### DIFF
--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -45,6 +45,7 @@
 		if (options.getCrumbUrl) {
 			this.getCrumbUrl = options.getCrumbUrl;
 		}
+		this._detailViews = [];
 	};
 	/**
 	 * @memberof OCA.Files
@@ -52,6 +53,7 @@
 	BreadCrumb.prototype = {
 		$el: null,
 		dir: null,
+		dirInfo: null,
 
 		/**
 		 * Total width of all breadcrumbs
@@ -77,6 +79,20 @@
 				this.dir = dir;
 				this.render();
 			}
+		},
+
+		setDirectoryInfo: function(dirInfo) {
+			if (dirInfo !== this.dirInfo) {
+				this.dirInfo = dirInfo;
+				this.render();
+			}
+		},
+
+		/**
+		 * @param {Backbone.View} detailView
+		 */
+		addDetailView: function(detailView) {
+			this._detailViews.push(detailView);
 		},
 
 		/**
@@ -121,6 +137,13 @@
 				}
 			}
 			$crumb.addClass('last');
+
+			_.each(this._detailViews, function(view) {
+				view.render({
+					dirInfo: this.dirInfo
+				});
+				$crumb.append(view.$el);
+			}, this);
 
 			// in case svg is not supported by the browser we need to execute the fallback mechanism
 			if (!OC.Util.hasSVGSupport()) {

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1646,6 +1646,7 @@
 
 			// first entry is the root
 			this.dirInfo = result.shift();
+			this.breadcrumb.setDirectoryInfo(this.dirInfo);
 
 			if (this.dirInfo.permissions) {
 				this.setDirectoryPermissions(this.dirInfo.permissions);
@@ -2953,6 +2954,15 @@
 		registerDetailView: function(detailView) {
 			if (this._detailsView) {
 				this._detailsView.addDetailView(detailView);
+			}
+		},
+
+		/**
+		 * Register a view to be added to the breadcrumb view
+		 */
+		registerBreadCrumbDetailView: function(detailView) {
+			if (this.breadcrumb) {
+				this.breadcrumb.addDetailView(detailView);
 			}
 		}
 	};

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -518,12 +518,15 @@
 				OC.Apps.showAppSidebar(this._detailsView.$el);
 			}
 
-			var $tr = this.findFileEl(fileName);
-			var model = this.getModelForFile($tr);
+			if (_.isObject(fileName)) {
+				var model = new OCA.Files.FileInfoModel(fileName);
+			} else {
+				var $tr = this.findFileEl(fileName);
+				var model = this.getModelForFile($tr);
+				$tr.addClass('highlighted');
+			}
 
 			this._currentFileModel = model;
-
-			$tr.addClass('highlighted');
 
 			this._detailsView.setFileInfo(model);
 			this._detailsView.$el.scrollTop(0);

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -473,7 +473,7 @@
 		 * Displays the details view for the given file and
 		 * selects the given tab
 		 *
-		 * @param {string} fileName file name for which to show details
+		 * @param {string|OCA.Files.FileInfoModel} fileName file name or FileInfoModel for which to show details
 		 * @param {string} [tabId] optional tab id to select
 		 */
 		showDetailsView: function(fileName, tabId) {
@@ -487,7 +487,7 @@
 		/**
 		 * Update the details view to display the given file
 		 *
-		 * @param {string} fileName file name from the current list
+		 * @param {string|OCA.Files.FileInfoModel} fileName file name from the current list or a FileInfoModel object
 		 * @param {boolean} [show=true] whether to open the sidebar if it was closed
 		 */
 		_updateDetailsView: function(fileName, show) {
@@ -518,8 +518,8 @@
 				OC.Apps.showAppSidebar(this._detailsView.$el);
 			}
 
-			if (_.isObject(fileName)) {
-				var model = new OCA.Files.FileInfoModel(fileName);
+			if (fileName instanceof OCA.Files.FileInfoModel) {
+				var model = fileName;
 			} else {
 				var $tr = this.findFileEl(fileName);
 				var model = this.getModelForFile($tr);
@@ -2025,7 +2025,7 @@
 
 			function updateInList(fileInfo) {
 				self.updateRow(tr, fileInfo);
-				self._updateDetailsView(fileInfo.name, false);
+				self._updateDetailsView(fileInfo, false);
 			}
 
 			// TODO: too many nested blocks, move parts into functions

--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -42,6 +42,7 @@ $eventDispatcher->addListener(
 	function() {
 		\OCP\Util::addScript('files_sharing', 'share');
 		\OCP\Util::addScript('files_sharing', 'sharetabview');
+		\OCP\Util::addScript('files_sharing', 'sharebreadcrumbview');
 		\OCP\Util::addStyle('files_sharing', 'sharetabview');
 	}
 );

--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -44,6 +44,7 @@ $eventDispatcher->addListener(
 		\OCP\Util::addScript('files_sharing', 'sharetabview');
 		\OCP\Util::addScript('files_sharing', 'sharebreadcrumbview');
 		\OCP\Util::addStyle('files_sharing', 'sharetabview');
+		\OCP\Util::addStyle('files_sharing', 'sharebreadcrumb');
 	}
 );
 

--- a/apps/files_sharing/css/sharebreadcrumb.css
+++ b/apps/files_sharing/css/sharebreadcrumb.css
@@ -1,0 +1,33 @@
+/**
+ * @copyright 2016 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2016 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+div.crumb span.icon-share {
+	display: inline-block;
+	width: 32px;
+	vertical-align: sub;
+	cursor: pointer;
+	opacity: 0.2;
+}
+
+div.crumb span.icon-share.shared {
+	opacity: 0.7;
+}

--- a/apps/files_sharing/css/sharebreadcrumb.css
+++ b/apps/files_sharing/css/sharebreadcrumb.css
@@ -20,12 +20,15 @@
  *
  */
 
-div.crumb span.icon-share {
+div.crumb span.icon-share,
+div.crumb span.icon-public {
 	display: inline-block;
 	cursor: pointer;
 	opacity: 0.2;
+	margin-right: 6px;
 }
 
-div.crumb span.icon-share.shared {
+div.crumb span.icon-share.shared,
+div.crumb span.icon-public.shared {
 	opacity: 0.7;
 }

--- a/apps/files_sharing/css/sharebreadcrumb.css
+++ b/apps/files_sharing/css/sharebreadcrumb.css
@@ -22,7 +22,6 @@
 
 div.crumb span.icon-share {
 	display: inline-block;
-	vertical-align: sub;
 	cursor: pointer;
 	opacity: 0.2;
 }

--- a/apps/files_sharing/css/sharebreadcrumb.css
+++ b/apps/files_sharing/css/sharebreadcrumb.css
@@ -22,7 +22,6 @@
 
 div.crumb span.icon-share {
 	display: inline-block;
-	width: 32px;
 	vertical-align: sub;
 	cursor: pointer;
 	opacity: 0.2;

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -36,19 +36,7 @@
 			var oldCreateRow = fileList._createRow;
 			fileList._createRow = function(fileData) {
 				var tr = oldCreateRow.apply(this, arguments);
-				var sharePermissions = fileData.permissions;
-				if (fileData.mountType && fileData.mountType === "external-root"){
-					// for external storages we can't use the permissions of the mountpoint
-					// instead we show all permissions and only use the share permissions from the mountpoint to handle resharing
-					sharePermissions = sharePermissions | (OC.PERMISSION_ALL & ~OC.PERMISSION_SHARE);
-				}
-				if (fileData.type === 'file') {
-					// files can't be shared with delete permissions
-					sharePermissions = sharePermissions & ~OC.PERMISSION_DELETE;
-
-					// create permissions don't mean anything for files
-					sharePermissions = sharePermissions & ~OC.PERMISSION_CREATE;
-				}
+				var sharePermissions = OCA.Sharing.Util.getSharePermissions(fileData);
 				tr.attr('data-share-permissions', sharePermissions);
 				if (fileData.shareOwner) {
 					tr.attr('data-share-owner', fileData.shareOwner);
@@ -251,6 +239,27 @@
 				text += ', +' + (count - maxRecipients);
 			}
 			return text;
+		},
+
+		/**
+		 * @param {Array} fileData
+		 * @returns {String}
+		 */
+		getSharePermissions: function(fileData) {
+			var sharePermissions = fileData.permissions;
+			if (fileData.mountType && fileData.mountType === "external-root"){
+				// for external storages we can't use the permissions of the mountpoint
+				// instead we show all permissions and only use the share permissions from the mountpoint to handle resharing
+				sharePermissions = sharePermissions | (OC.PERMISSION_ALL & ~OC.PERMISSION_SHARE);
+			}
+			if (fileData.type === 'file') {
+				// files can't be shared with delete permissions
+				sharePermissions = sharePermissions & ~OC.PERMISSION_DELETE;
+
+				// create permissions don't mean anything for files
+				sharePermissions = sharePermissions & ~OC.PERMISSION_CREATE;
+			}
+			return sharePermissions;
 		}
 	};
 })();

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -185,6 +185,9 @@
 				}
 			});
 			fileList.registerTabView(shareTab);
+
+			var breadCrumbSharingDetailView = new OCA.Sharing.ShareBreadCrumbView();
+			fileList.registerBreadCrumbDetailView(breadCrumbSharingDetailView);
 		},
 
 		/**

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -174,7 +174,7 @@
 			});
 			fileList.registerTabView(shareTab);
 
-			var breadCrumbSharingDetailView = new OCA.Sharing.ShareBreadCrumbView();
+			var breadCrumbSharingDetailView = new OCA.Sharing.ShareBreadCrumbView({shareTab: shareTab});
 			fileList.registerBreadCrumbDetailView(breadCrumbSharingDetailView);
 		},
 

--- a/apps/files_sharing/js/sharebreadcrumbview.js
+++ b/apps/files_sharing/js/sharebreadcrumbview.js
@@ -33,6 +33,10 @@
 
 	var BreadCrumbView = OC.Backbone.View.extend({
 		tagName: 'span',
+		events: {
+			click: '_onClick'
+		},
+		_dirInfo: undefined,
 		_template: undefined,
 		template: function(data) {
 			if (!this._template) {
@@ -41,13 +45,21 @@
 			return this._template(data);
 		},
 		render: function(data) {
+			this._dirInfo = data.dirInfo;
+
 			var isShared = data.dirInfo && data.dirInfo.shareTypes && data.dirInfo.shareTypes.length > 0;
 
 			this.$el.html(this.template({
 				isShared: isShared
 			}));
+			this.delegateEvents();
 
 			return this;
+		},
+		_onClick: function(e) {
+			e.preventDefault();
+
+			OCA.Files.App.fileList.showDetailsView(this._dirInfo, 'shareTabView');
 		}
 	});
 

--- a/apps/files_sharing/js/sharebreadcrumbview.js
+++ b/apps/files_sharing/js/sharebreadcrumbview.js
@@ -1,0 +1,56 @@
+/* global Handlebars, OC */
+
+/**
+ * @copyright 2016 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2016 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+(function() {
+	'use strict';
+
+	var TEMPLATE = '{{#if isShared}}'
+		+ 'Shared!'
+		+ '{{else}}'
+		+ 'Not shared!'
+		+ '{{/if}}';
+
+	var BreadCrumbView = OC.Backbone.View.extend({
+		tagName: 'span',
+		_template: undefined,
+		template: function(data) {
+			if (!this._template) {
+				this._template = Handlebars.compile(TEMPLATE);
+			}
+			return this._template(data);
+		},
+		render: function(data) {
+			var isShared = data.dirInfo && data.dirInfo.shareTypes && data.dirInfo.shareTypes.length > 0;
+
+			this.$el.html(this.template({
+				isShared: isShared
+			}));
+
+			return this;
+		}
+	});
+
+	OCA.Sharing.ShareBreadCrumbView = BreadCrumbView;
+})();
+

--- a/apps/files_sharing/js/sharebreadcrumbview.js
+++ b/apps/files_sharing/js/sharebreadcrumbview.js
@@ -25,11 +25,7 @@
 (function() {
 	'use strict';
 
-	var TEMPLATE = '{{#if isShared}}'
-		+ 'Shared!'
-		+ '{{else}}'
-		+ 'Not shared!'
-		+ '{{/if}}';
+	var TEMPLATE = '<span class="icon icon-share {{#if isShared}}shared{{/if}}"></span>';
 
 	var BreadCrumbView = OC.Backbone.View.extend({
 		tagName: 'span',

--- a/apps/files_sharing/js/sharebreadcrumbview.js
+++ b/apps/files_sharing/js/sharebreadcrumbview.js
@@ -41,7 +41,7 @@
 			return this._template(data);
 		},
 		render: function(data) {
-			this._dirInfo = data.dirInfo;
+			this._dirInfo = data.dirInfo || null;
 
 			if (this._dirInfo !== null && (this._dirInfo.path !== '/' || this._dirInfo.name !== '')) {
 				var isShared = data.dirInfo && data.dirInfo.shareTypes && data.dirInfo.shareTypes.length > 0;
@@ -60,7 +60,15 @@
 		_onClick: function(e) {
 			e.preventDefault();
 
-			OCA.Files.App.fileList.showDetailsView(this._dirInfo, 'shareTabView');
+			var fileInfoModel = new OCA.Files.FileInfoModel(this._dirInfo);
+			var self = this;
+			fileInfoModel.on('change', function() {
+				console.log('CHANGE');
+				self.render({
+					dirInfo: self._dirInfo
+				});
+			});
+			OCA.Files.App.fileList.showDetailsView(fileInfoModel, 'shareTabView');
 		}
 	});
 

--- a/apps/files_sharing/js/sharebreadcrumbview.js
+++ b/apps/files_sharing/js/sharebreadcrumbview.js
@@ -43,12 +43,17 @@
 		render: function(data) {
 			this._dirInfo = data.dirInfo;
 
-			var isShared = data.dirInfo && data.dirInfo.shareTypes && data.dirInfo.shareTypes.length > 0;
-
-			this.$el.html(this.template({
-				isShared: isShared
-			}));
-			this.delegateEvents();
+			if (this._dirInfo !== null && (this._dirInfo.path !== '/' || this._dirInfo.name !== '')) {
+				var isShared = data.dirInfo && data.dirInfo.shareTypes && data.dirInfo.shareTypes.length > 0;
+				this.$el.html(this.template({
+					isShared: isShared
+				}));
+				this.$el.show();
+				this.delegateEvents();
+			} else {
+				this.$el.empty();
+				this.$el.hide();
+			}
 
 			return this;
 		},

--- a/apps/files_sharing/js/sharebreadcrumbview.js
+++ b/apps/files_sharing/js/sharebreadcrumbview.js
@@ -34,6 +34,14 @@
 		},
 		_dirInfo: undefined,
 		_template: undefined,
+
+		/** @type OCA.Sharing.ShareTabView */
+		_shareTab: undefined,
+
+		initialize: function(options) {
+			this._shareTab = options.shareTab;
+		},
+
 		template: function(data) {
 			if (!this._template) {
 				this._template = Handlebars.compile(TEMPLATE);
@@ -67,6 +75,9 @@
 				self.render({
 					dirInfo: self._dirInfo
 				});
+			});
+			this._shareTab.on('sharesChanged', function(shareModel) {
+				alert('aaoobb');
 			});
 			OCA.Files.App.fileList.showDetailsView(fileInfoModel, 'shareTabView');
 		}

--- a/apps/files_sharing/js/sharebreadcrumbview.js
+++ b/apps/files_sharing/js/sharebreadcrumbview.js
@@ -25,15 +25,12 @@
 (function() {
 	'use strict';
 
-	var TEMPLATE = '<span class="icon-share {{#if isShared}}shared{{/if}}"></span>';
-
 	var BreadCrumbView = OC.Backbone.View.extend({
 		tagName: 'span',
 		events: {
 			click: '_onClick'
 		},
 		_dirInfo: undefined,
-		_template: undefined,
 
 		/** @type OCA.Sharing.ShareTabView */
 		_shareTab: undefined,
@@ -42,24 +39,26 @@
 			this._shareTab = options.shareTab;
 		},
 
-		template: function(data) {
-			if (!this._template) {
-				this._template = Handlebars.compile(TEMPLATE);
-			}
-			return this._template(data);
-		},
 		render: function(data) {
 			this._dirInfo = data.dirInfo || null;
 
 			if (this._dirInfo !== null && (this._dirInfo.path !== '/' || this._dirInfo.name !== '')) {
 				var isShared = data.dirInfo && data.dirInfo.shareTypes && data.dirInfo.shareTypes.length > 0;
-				this.$el.html(this.template({
-					isShared: isShared
-				}));
+				this.$el.removeClass('shared icon-public icon-share');
+				if (isShared) {
+					this.$el.addClass('shared');
+					if (data.dirInfo.shareTypes.indexOf(OC.Share.SHARE_TYPE_LINK) !== -1) {
+						this.$el.addClass('icon-public');
+					} else {
+						this.$el.addClass('icon-share');
+					}
+				} else {
+					this.$el.addClass('icon-share');
+				}
 				this.$el.show();
 				this.delegateEvents();
 			} else {
-				this.$el.empty();
+				this.$el.removeClass('shared icon-public icon-share');
 				this.$el.hide();
 			}
 

--- a/apps/files_sharing/js/sharebreadcrumbview.js
+++ b/apps/files_sharing/js/sharebreadcrumbview.js
@@ -25,7 +25,7 @@
 (function() {
 	'use strict';
 
-	var TEMPLATE = '<span class="icon icon-share {{#if isShared}}shared{{/if}}"></span>';
+	var TEMPLATE = '<span class="icon-share {{#if isShared}}shared{{/if}}"></span>';
 
 	var BreadCrumbView = OC.Backbone.View.extend({
 		tagName: 'span',
@@ -85,4 +85,3 @@
 
 	OCA.Sharing.ShareBreadCrumbView = BreadCrumbView;
 })();
-

--- a/apps/files_sharing/js/sharebreadcrumbview.js
+++ b/apps/files_sharing/js/sharebreadcrumbview.js
@@ -77,7 +77,25 @@
 				});
 			});
 			this._shareTab.on('sharesChanged', function(shareModel) {
-				alert('aaoobb');
+				var shareTypes = [];
+				var shares = shareModel.getSharesWithCurrentItem();
+
+				for(var i = 0; i < shares.length; i++) {
+					if (shareTypes.indexOf(shares[i].share_type) === -1) {
+						shareTypes.push(shares[i].share_type);
+					}
+				}
+
+				if (shareModel.hasLinkShare()) {
+					shareTypes.push(OC.Share.SHARE_TYPE_LINK);
+				}
+
+				// Since the dirInfo isn't updated we need to do this dark hackery
+				self._dirInfo.shareTypes = shareTypes;
+
+				self.render({
+					dirInfo: self._dirInfo
+				});
 			});
 			OCA.Files.App.fileList.showDetailsView(fileInfoModel, 'shareTabView');
 		}

--- a/apps/files_sharing/js/sharebreadcrumbview.js
+++ b/apps/files_sharing/js/sharebreadcrumbview.js
@@ -70,7 +70,6 @@
 			var fileInfoModel = new OCA.Files.FileInfoModel(this._dirInfo);
 			var self = this;
 			fileInfoModel.on('change', function() {
-				console.log('CHANGE');
 				self.render({
 					dirInfo: self._dirInfo
 				});

--- a/apps/files_sharing/js/sharetabview.js
+++ b/apps/files_sharing/js/sharetabview.js
@@ -50,6 +50,10 @@
 			if (this.model) {
 				this.$el.html(this.template());
 
+				if (_.isUndefined(this.model.get('sharePermissions'))) {
+					this.model.set('sharePermissions', OCA.Sharing.Util.getSharePermissions(this.model.attributes));
+				}
+
 				// TODO: the model should read these directly off the passed fileInfoModel
 				var attributes = {
 					itemType: this.model.isDirectory() ? 'folder' : 'file',

--- a/apps/files_sharing/tests/js/sharedbreadcrumviewSpec.js
+++ b/apps/files_sharing/tests/js/sharedbreadcrumviewSpec.js
@@ -1,0 +1,224 @@
+/**
+ * @copyright 2016, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
+	var BreadCrumb = OCA.Files.BreadCrumb;
+	var SharedBreadCrum = OCA.Sharing.ShareBreadCrumbView;
+
+	describe('Rendering', function() {
+		var bc;
+		var sbc;
+		var shareTab;
+		beforeEach(function() {
+			bc = new BreadCrumb({
+				getCrumbUrl: function(part, index) {
+					// for testing purposes
+					return part.dir + '#' + index;
+				}
+			});
+			shareTab = new OCA.Sharing.ShareTabView();
+			sbc = new SharedBreadCrum({
+				shareTab: shareTab
+			});
+			bc.addDetailView(sbc);
+		});
+		afterEach(function() {
+			bc = null;
+			sbc = null;
+			shareModel = null;
+		});
+		it('Do not render in root', function() {
+			var dirInfo = new OC.Files.FileInfo({
+				id: 42,
+				path: '/',
+				type: 'dir',
+				name: ''
+			});
+			bc.setDirectoryInfo(dirInfo);
+			bc.setDirectory('');
+			bc.render();
+			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
+			expect(bc.$el.find('.icon-share').length).toEqual(0);
+			expect(bc.$el.find('.shared').length).toEqual(0);
+			expect(bc.$el.find('.icon-public').length).toEqual(0);
+		});
+		it('Render in dir', function() {
+			var dirInfo = new OC.Files.FileInfo({
+				id: 42,
+				path: '/foo',
+				type: 'dir'
+			});
+			bc.setDirectoryInfo(dirInfo);
+			bc.setDirectory('/foo');
+			bc.render();
+			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
+			expect(bc.$el.find('.icon-share').length).toEqual(1);
+			expect(bc.$el.find('.shared').length).toEqual(0);
+			expect(bc.$el.find('.icon-public').length).toEqual(0);
+		});
+		it('Render shared if dir is shared with user', function() {
+			var dirInfo = new OC.Files.FileInfo({
+				id: 42,
+				path: '/foo',
+				type: 'dir',
+				shareTypes: [OC.Share.SHARE_TYPE_USER]
+			});
+			bc.setDirectoryInfo(dirInfo);
+			bc.setDirectory('/foo');
+			bc.render();
+			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
+			expect(bc.$el.find('.icon-share').length).toEqual(1);
+			expect(bc.$el.find('.shared').length).toEqual(1);
+			expect(bc.$el.find('.icon-public').length).toEqual(0);
+		});
+		it('Render shared if dir is shared with group', function() {
+			var dirInfo = new OC.Files.FileInfo({
+				id: 42,
+				path: '/foo',
+				type: 'dir',
+				shareTypes: [OC.Share.SHARE_TYPE_GROUP]
+			});
+			bc.setDirectoryInfo(dirInfo);
+			bc.setDirectory('/foo');
+			bc.render();
+			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
+			expect(bc.$el.find('.icon-share').length).toEqual(1);
+			expect(bc.$el.find('.shared').length).toEqual(1);
+			expect(bc.$el.find('.icon-public').length).toEqual(0);
+		});
+		it('Render shared if dir is shared by link', function() {
+			var dirInfo = new OC.Files.FileInfo({
+				id: 42,
+				path: '/foo',
+				type: 'dir',
+				shareTypes: [OC.Share.SHARE_TYPE_LINK]
+			});
+			bc.setDirectoryInfo(dirInfo);
+			bc.setDirectory('/foo');
+			bc.render();
+			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
+			expect(bc.$el.find('.icon-share').length).toEqual(0);
+			expect(bc.$el.find('.shared').length).toEqual(1);
+			expect(bc.$el.find('.icon-public').length).toEqual(1);
+		});
+		it('Render shared if dir is shared with remote', function() {
+			var dirInfo = new OC.Files.FileInfo({
+				id: 42,
+				path: '/foo',
+				type: 'dir',
+				shareTypes: [OC.Share.SHARE_TYPE_REMOTE]
+			});
+			bc.setDirectoryInfo(dirInfo);
+			bc.setDirectory('/foo');
+			bc.render();
+			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
+			expect(bc.$el.find('.icon-share').length).toEqual(1);
+			expect(bc.$el.find('.shared').length).toEqual(1);
+			expect(bc.$el.find('.icon-public').length).toEqual(0);
+		});
+		it('Render link shared if at least one is a link share', function() {
+			var dirInfo = new OC.Files.FileInfo({
+				id: 42,
+				path: '/foo',
+				type: 'dir',
+				shareTypes: [
+					OC.Share.SHARE_TYPE_USER,
+					OC.Share.SHARE_TYPE_GROUP,
+					OC.Share.SHARE_TYPE_LINK,
+					OC.Share.SHARE_TYPE_EMAIL,
+					OC.Share.SHARE_TYPE_REMOTE
+				]
+			});
+			bc.setDirectoryInfo(dirInfo);
+			bc.setDirectory('/foo');
+			bc.render();
+			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
+			expect(bc.$el.find('.icon-share').length).toEqual(0);
+			expect(bc.$el.find('.shared').length).toEqual(1);
+			expect(bc.$el.find('.icon-public').length).toEqual(1);
+		});
+		it('Remove shared status from user share', function() {
+			var dirInfo = new OC.Files.FileInfo({
+				id: 42,
+				path: '/foo',
+				type: 'dir',
+				shareTypes: [OC.Share.SHARE_TYPE_USER]
+			});
+
+			bc.setDirectory('/foo');
+			bc.setDirectoryInfo(dirInfo);
+			bc.render();
+
+			var mock = sinon.createStubInstance(OCA.Files.FileList);
+			mock.showDetailsView = function() { };
+			OCA.Files.App.fileList = mock;
+			var spy = sinon.spy(mock, 'showDetailsView');
+			bc.$el.find('.icon-share').click();
+
+			expect(spy.calledOnce).toEqual(true);
+
+			var model = sinon.createStubInstance(OC.Share.ShareItemModel);
+			model.getSharesWithCurrentItem = function() { return [] };
+			model.hasLinkShare = function() { return false; };
+
+			shareTab.trigger('sharesChanged', model);
+
+			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
+			expect(bc.$el.find('.icon-share').length).toEqual(1);
+			expect(bc.$el.find('.shared').length).toEqual(0);
+			expect(bc.$el.find('.icon-public').length).toEqual(0);
+		});
+		it('Add link share to user share', function() {
+			var dirInfo = new OC.Files.FileInfo({
+				id: 42,
+				path: '/foo',
+				type: 'dir',
+				shareTypes: [OC.Share.SHARE_TYPE_USER]
+			});
+
+			bc.setDirectory('/foo');
+			bc.setDirectoryInfo(dirInfo);
+			bc.render();
+
+			var mock = sinon.createStubInstance(OCA.Files.FileList);
+			mock.showDetailsView = function() { };
+			OCA.Files.App.fileList = mock;
+			var spy = sinon.spy(mock, 'showDetailsView');
+			bc.$el.find('.icon-share').click();
+
+			expect(spy.calledOnce).toEqual(true);
+
+			var model = sinon.createStubInstance(OC.Share.ShareItemModel);
+			model.getSharesWithCurrentItem = function() { return [
+				{share_type: OC.Share.SHARE_TYPE_USER}
+			] };
+			model.hasLinkShare = function() { return true; };
+
+			shareTab.trigger('sharesChanged', model);
+
+			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
+			expect(bc.$el.find('.icon-share').length).toEqual(0);
+			expect(bc.$el.find('.shared').length).toEqual(1);
+			expect(bc.$el.find('.icon-public').length).toEqual(1);
+		});
+	});
+});

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -901,7 +901,7 @@ div.crumb > span {
 	color: #555;
 }
 div.crumb.last a {
-	padding-right: 14px;
+	padding-right: 0px;
 }
 div.crumb:first-child a {
 	position: relative;

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -894,11 +894,14 @@ div.crumb.hidden {
 	display: none;
 }
 div.crumb a,
-div.crumb span {
+div.crumb > span {
 	position: relative;
 	top: 12px;
 	padding: 14px 24px 14px 17px;
 	color: #555;
+}
+div.crumb.last a {
+	padding-right: 14px;
 }
 div.crumb:first-child a {
 	position: relative;

--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -54,7 +54,7 @@ module.exports = function(config) {
 					'apps/files_sharing/js/app.js',
 					'apps/files_sharing/js/sharedfilelist.js',
 					'apps/files_sharing/js/share.js',
-					'apps/files_sharing/js/external.js',
+					'apps/files_sharing/js/sharebreadcrumbview.js',
 					'apps/files_sharing/js/public.js',
 					'apps/files_sharing/js/sharetabview.js'
 				],


### PR DESCRIPTION
With this PR I want to add a little share icon to the file list breadcrumb view to reflect whether the current folder is shared or not. On top of this enhancement, I'll add a click handler for opening the share tab view, to finally be able _share the current folder_ without having to navigate up one level.

@rullzer @schiessle I'm totally new to the sharing code. What's the best way to determine whether the current folder has been shared or not? From inspecting responses on my test env I've observed that the `share-types` property of the directory's PROPFIND request is only set if the folder was shared. Is that correct? Can I rely on that property or should I use something different?

TODO:
- [x] show `Shared` + icon when the folder is shared, similar to the file list rows
- [x] show nothing for now if the folder is not shared (there should be a icon/button later though)
- [x] bind to `change` events on the directory's file info model and update the UI accordingly
- [x] add tests

Fix #1072 
