### PR TITLE
Exclude tests and composer dir from coverage

### DIFF
--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -29,10 +29,15 @@
 				<directory suffix=".php">../apps/files_trashbin/tests</directory>
 				<directory suffix=".php">../apps/files_versions/tests</directory>
 				<directory suffix=".php">../apps/provisioning_api/tests</directory>
+				<directory suffix=".php">../apps/systemtags/tests</directory>
+				<directory suffix=".php">../apps/theming/tests</directory>
+				<directory suffix=".php">../apps/twofactor_backupcodes/tests</directory>
 				<directory suffix=".php">../apps/updatenotification/tests</directory>
 				<directory suffix=".php">../apps/user_ldap/tests</directory>
+				<directory suffix=".php">../apps/workflowengine/tests</directory>
 				<directory suffix=".php">../tests</directory>
 				<directory suffix=".php">../build</directory>
+				<directory suffix=".php">../lib/composer</directory>
 			</exclude>
 		</whitelist>
 	</filter>


### PR DESCRIPTION
No need to cover tests dirs or the composer files.

CC: @LukasReschke @nickvergessen @MorrisJobke 
