### PR TITLE
Exclude Directories

### DIFF
--- a/apps/dav/lib/Connector/Sabre/CustomPropertiesBackend.php
+++ b/apps/dav/lib/Connector/Sabre/CustomPropertiesBackend.php
@@ -106,6 +106,9 @@ class CustomPropertiesBackend implements BackendInterface {
 		} catch (ServiceUnavailable $e) {
 			// might happen for unavailable mount points, skip
 			return;
+		} catch (Forbidden $e) {
+			// might happen for excluded mount points, skip
+			return;
 		} catch (NotFound $e) {
 			// in some rare (buggy) cases the node might not be found,
 			// we catch the exception to prevent breaking the whole list with a 404

--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -107,17 +107,12 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node
 	 */
 	public function createFile($name, $data = null) {
 
-		# the check here is necessary, because createFile uses put covered in sabre/file.php 
-		# and not touch covered in files/view.php
+		// the check here is necessary, because createFile uses put covered in sabre/file.php 
+		// and not touch covered in files/view.php
 		if (\OC\Files\Filesystem::isForbiddenFileOrDir($name)) {
 			throw new \Sabre\DAV\Exception\Forbidden();
 		}
 		try {
-			# the check here is necessary, because createFile uses put covered in sabre/file.php 
-			# and not touch covered in files/view.php
-			if (\OC\Files\Filesystem::isForbiddenFileOrDir($name)) {
-				throw new \Sabre\DAV\Exception\Forbidden();
-			}
 			// for chunked upload also updating a existing file is a "createFile"
 			// because we create all the chunks before re-assemble them to the existing file.
 			if (isset($_SERVER['HTTP_OC_CHUNKED'])) {

--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -107,7 +107,17 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node
 	 */
 	public function createFile($name, $data = null) {
 
+		# the check here is necessary, because createFile uses put covered in sabre/file.php 
+		# and not touch covered in files/view.php
+		if (\OC\Files\Filesystem::isForbiddenFileOrDir($name)) {
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
 		try {
+			# the check here is necessary, because createFile uses put covered in sabre/file.php 
+			# and not touch covered in files/view.php
+			if (\OC\Files\Filesystem::isForbiddenFileOrDir($name)) {
+				throw new \Sabre\DAV\Exception\Forbidden();
+			}
 			// for chunked upload also updating a existing file is a "createFile"
 			// because we create all the chunks before re-assemble them to the existing file.
 			if (isset($_SERVER['HTTP_OC_CHUNKED'])) {
@@ -156,7 +166,13 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node
 	 * @throws \Sabre\DAV\Exception\ServiceUnavailable
 	 */
 	public function createDirectory($name) {
+
 		try {
+			# the check here is necessary, because createDirectory does not use the methods in files/view.php
+			if (\OC\Files\Filesystem::isForbiddenFileOrDir($name)) {
+				throw new \Sabre\DAV\Exception\Forbidden();
+			}
+			
 			if (!$this->info->isCreatable()) {
 				throw new \Sabre\DAV\Exception\Forbidden();
 			}

--- a/apps/dav/lib/Connector/Sabre/ObjectTree.php
+++ b/apps/dav/lib/Connector/Sabre/ObjectTree.php
@@ -109,6 +109,7 @@ class ObjectTree extends \Sabre\DAV\Tree {
 	 * @throws InvalidPath
 	 * @throws \Sabre\DAV\Exception\Locked
 	 * @throws \Sabre\DAV\Exception\NotFound
+	 * @throws \Sabre\DAV\Exception\Forbidden
 	 * @throws \Sabre\DAV\Exception\ServiceUnavailable
 	 */
 	public function getNodeForPath($path) {
@@ -116,6 +117,11 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable('filesystem not setup');
 		}
 
+		// check the path, also called when the path has been entered manually eg via a file explorer
+		if (\OC\Files\Filesystem::isForbiddenFileOrDir($path)) {
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
+		
 		$path = trim($path, '/');
 
 		if (isset($this->cache[$path])) {
@@ -128,6 +134,11 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			} catch (\OCP\Files\InvalidPathException $ex) {
 				throw new InvalidPath($ex->getMessage());
 			}
+		}
+
+		// check the path, also called when the path has been entered manually eg via a file explorer
+		if (\OC\Files\Filesystem::isForbiddenFileOrDir($path)) {
+			throw new \Sabre\DAV\Exception\Forbidden();
 		}
 
 		// Is it the root node?
@@ -203,6 +214,11 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable('filesystem not setup');
 		}
 
+		# check the destination path, for source see below
+		if (\OC\Files\Filesystem::isForbiddenFileOrDir($destinationPath)) {
+ 			throw new \Sabre\DAV\Exception\Forbidden();
+		}
+		
 		$infoDestination = $this->fileView->getFileInfo(dirname($destinationPath));
 		if (dirname($destinationPath) === dirname($sourcePath)) {
 			$sourcePermission = $infoDestination && $infoDestination->isUpdateable();
@@ -222,6 +238,9 @@ class ObjectTree extends \Sabre\DAV\Tree {
 		}
 
 		$targetNodeExists = $this->nodeExists($destinationPath);
+
+		// at getNodeForPath we also check the path for isForbiddenFileOrDir
+		// with that we have covered both source and destination
 		$sourceNode = $this->getNodeForPath($sourcePath);
 		if ($sourceNode instanceof \Sabre\DAV\ICollection && $targetNodeExists) {
 			throw new \Sabre\DAV\Exception\Forbidden('Could not copy directory ' . $sourceNode->getName() . ', target exists');
@@ -316,7 +335,13 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			throw new Forbidden('No permissions to copy object.');
 		}
 
-		// this will trigger existence check
+		# check the destination path, for source see below
+		if (\OC\Files\Filesystem::isForbiddenFileOrDir($destination)) {
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
+
+		// at getNodeForPath we also check the path for isForbiddenFileOrDir
+		// with that we have covered both source and destination
 		$this->getNodeForPath($source);
 
 		list($destinationDir, $destinationName) = \Sabre\HTTP\URLUtil::splitPath($destination);

--- a/apps/dav/lib/Connector/Sabre/ObjectTree.php
+++ b/apps/dav/lib/Connector/Sabre/ObjectTree.php
@@ -113,15 +113,16 @@ class ObjectTree extends \Sabre\DAV\Tree {
 	 * @throws \Sabre\DAV\Exception\ServiceUnavailable
 	 */
 	public function getNodeForPath($path) {
-		if (!$this->fileView) {
-			throw new \Sabre\DAV\Exception\ServiceUnavailable('filesystem not setup');
-		}
-
 		// check the path, also called when the path has been entered manually eg via a file explorer
 		if (\OC\Files\Filesystem::isForbiddenFileOrDir($path)) {
 			throw new \Sabre\DAV\Exception\Forbidden();
 		}
 		
+
+		if (!$this->fileView) {
+			throw new \Sabre\DAV\Exception\ServiceUnavailable('filesystem not setup');
+		}
+
 		$path = trim($path, '/');
 
 		if (isset($this->cache[$path])) {
@@ -134,11 +135,6 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			} catch (\OCP\Files\InvalidPathException $ex) {
 				throw new InvalidPath($ex->getMessage());
 			}
-		}
-
-		// check the path, also called when the path has been entered manually eg via a file explorer
-		if (\OC\Files\Filesystem::isForbiddenFileOrDir($path)) {
-			throw new \Sabre\DAV\Exception\Forbidden();
 		}
 
 		// Is it the root node?

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1119,6 +1119,20 @@ $CONFIG = array(
 'blacklisted_files' => array('.htaccess'),
 
 /**
+ * Exclude specific directory names and disallow scanning, creating and renaming
+ * using these names. Case insensitive.
+ * Excluded directory names are queried at any path part like at the beginning, 
+ * in the middle or at the end and will not be further processed if found.
+ * Please see the documentation for details and examples.
+ * Use when the storage backend supports eg snapshot directories to be excluded.
+ * WARNING: USE THIS ONLY IF YOU KNOW WHAT YOU ARE DOING.
+ */
+'excluded_directories' =>
+	array (
+		'.snapshot',
+		'~snapshot',
+	),
+/**
  * Define a default folder for shared files and folders other than root.
  */
 'share_folder' => '/',

--- a/core/Controller/AvatarController.php
+++ b/core/Controller/AvatarController.php
@@ -194,7 +194,7 @@ class AvatarController extends Controller {
 			if (
 				$files['error'][0] === 0 &&
 				 is_uploaded_file($files['tmp_name'][0]) &&
-				!\OC\Files\Filesystem::isFileBlacklisted($files['tmp_name'][0])
+				!\OC\Files\Filesystem::isForbiddenFileOrDir($files['tmp_name'][0])
 			) {
 				if ($files['size'][0] > 20*1024*1024) {
 					return new JSONResponse(

--- a/lib/base.php
+++ b/lib/base.php
@@ -874,8 +874,8 @@ class OC {
 	 */
 	public static function registerFilesystemHooks() {
 		// Check for blacklisted files
-		OC_Hook::connect('OC_Filesystem', 'write', 'OC\Files\Filesystem', 'isBlacklisted');
-		OC_Hook::connect('OC_Filesystem', 'rename', 'OC\Files\Filesystem', 'isBlacklisted');
+		OC_Hook::connect('OC_Filesystem', 'write', 'OC\Files\Filesystem', 'isForbiddenFileOrDir_Hook');
+		OC_Hook::connect('OC_Filesystem', 'rename', 'OC\Files\Filesystem', 'isForbiddenFileOrDir_Hook');
 	}
 
 	/**

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -347,7 +347,7 @@ class Scanner extends BasicEmitter implements IScanner {
 		if ($dh = $this->storage->opendir($folder)) {
 			if (is_resource($dh)) {
 				while (($file = readdir($dh)) !== false) {
-					if (!Filesystem::isIgnoredDir($file)) {
+					if (!Filesystem::isIgnoredDir($file) && !Filesystem::isForbiddenFileOrDir($file)) {
 						$children[] = trim(\OC\Files\Filesystem::normalizePath($file), '/');
 					}
 				}

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -650,7 +650,6 @@ class Filesystem {
 	}
 
 	/**
-	/**
 	 * following functions are equivalent to their php builtin equivalents for arguments/return values.
 	 */
 	static public function mkdir($path) {

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -565,29 +565,26 @@ class Filesystem {
 	 *
 	 * @param array $data from hook
 	 */
-	static public function isBlacklisted($data) {
+	static public function isForbiddenFileOrDir_Hook($data) {
 		if (isset($data['path'])) {
 			$path = $data['path'];
 		} else if (isset($data['newpath'])) {
 			$path = $data['newpath'];
 		}
 		if (isset($path)) {
-			if (self::isFileBlacklisted($path)) {
+			if (self::isForbiddenFileOrDir($path)) {
 				$data['run'] = false;
 			}
 		}
 	}
 
 	/**
+	 * depriciated, replaced by isForbiddenFileOrDir
 	 * @param string $filename
-	 * @return bool
+	 * @return boolean
 	 */
 	static public function isFileBlacklisted($filename) {
-		$filename = self::normalizePath($filename);
-
-		$blacklist = \OC::$server->getConfig()->getSystemValue('blacklisted_files', array('.htaccess'));
-		$filename = strtolower(basename($filename));
-		return in_array($filename, $blacklist);
+		return self::isForbiddenFileOrDir($filename);
 	}
 
 	/**
@@ -604,6 +601,55 @@ class Filesystem {
 		return false;
 	}
 
+/**
+	* Check if the directory path / file name contains a Blacklisted or Excluded name
+	* config.php parameter arrays can contain file names to be blacklisted or directory names to be excluded
+	* Blacklist ... files that may harm the owncloud environment like a foreign .htaccess file
+	* Excluded  ... directories that are excluded from beeing further processed, like snapshot directories
+	* The parameter $ed is only used in conjunction with unit tests as we handover here the excluded
+	* directory name to be tested against. $ed and the query with can be redesigned if filesystem.php will get 
+	* a constructor where it is then possible to define the excluded directory names for unit tests.
+	* @param string $FileOrDir
+	* @param array $ed
+	* @return boolean
+	*/
+	static public function isForbiddenFileOrDir($FileOrDir, $ed = array()) {
+		$excluded = array();
+		$blacklist = array();
+		$path_parts = array();
+		$ppx = array();
+		$blacklist = \OC::$server->getSystemConfig()->getValue('blacklisted_files', array('.htaccess'));
+		if ($ed) {
+			$excluded = $ed;
+		} else {
+			$excluded = \OC::$server->getSystemConfig()->getValue('excluded_directories', $ed);
+		}
+		// explode '/'
+		$ppx = array_filter(explode('/', $FileOrDir), 'strlen');
+		$ppx = array_map('strtolower', $ppx);
+		// further explode each array element with '\' and add to result array if found  
+		foreach($ppx as $pp) {
+			// only add an array element if strlen != 0
+			$path_parts = array_merge($path_parts, array_filter(explode('\\', $pp), 'strlen'));
+		}
+		if ($excluded) {
+			$excluded = array_map('trim', $excluded);
+			$excluded = array_map('strtolower', $excluded);
+			$match = array_intersect($path_parts, $excluded);
+			if ($match) {
+				return true;
+			}
+		}
+		$blacklist = array_map('trim', $blacklist);
+		$blacklist = array_map('strtolower', $blacklist);
+		$match = array_intersect($path_parts, $blacklist);
+		if ($match) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
 	/**
 	 * following functions are equivalent to their php builtin equivalents for arguments/return values.
 	 */

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -209,7 +209,7 @@ abstract class Common implements Storage, ILockingStorage {
 			$dir = $this->opendir($path1);
 			$this->mkdir($path2);
 			while ($file = readdir($dir)) {
-				if (!Filesystem::isIgnoredDir($file)) {
+				if (!Filesystem::isIgnoredDir($file) && !Filesystem::isForbiddenFileOrDir($file)) {
 					if (!$this->copy($path1 . '/' . $file, $path2 . '/' . $file)) {
 						return false;
 					}
@@ -557,7 +557,7 @@ abstract class Common implements Storage, ILockingStorage {
 			$result = $this->mkdir($targetInternalPath);
 			if (is_resource($dh)) {
 				while ($result and ($file = readdir($dh)) !== false) {
-					if (!Filesystem::isIgnoredDir($file)) {
+					if (!Filesystem::isIgnoredDir($file) && !Filesystem::isForbiddenFileOrDir($file)) {
 						$result &= $this->copyFromStorage($sourceStorage, $sourceInternalPath . '/' . $file, $targetInternalPath . '/' . $file);
 					}
 				}

--- a/lib/private/Security/CertificateManager.php
+++ b/lib/private/Security/CertificateManager.php
@@ -139,7 +139,7 @@ class CertificateManager implements ICertificateManager {
 	 * @throws \Exception If the certificate could not get added
 	 */
 	public function addCertificate($certificate, $name) {
-		if (!Filesystem::isValidPath($name) or Filesystem::isFileBlacklisted($name)) {
+		if (!Filesystem::isValidPath($name) or Filesystem::isForbiddenFileOrDir($name)) {
 			throw new \Exception('Filename is not valid');
 		}
 

--- a/lib/private/legacy/helper.php
+++ b/lib/private/legacy/helper.php
@@ -187,7 +187,7 @@ class OC_Helper {
 					self::copyr("$src/$file", "$dest/$file");
 				}
 			}
-		} elseif (file_exists($src) && !\OC\Files\Filesystem::isFileBlacklisted($src)) {
+		} elseif (file_exists($src) && !\OC\Files\Filesystem::isForbiddenFileOrDir($src)) {
 			copy($src, $dest);
 		}
 	}

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -259,7 +259,7 @@ class FilesystemTest extends \Test\TestCase {
 			array('.htaccess\\', true),
 			array('/etc/foo\bar/.htaccess\\', true),
 			array('/etc/foo\bar/.htaccess/', true),
-			array('/etc/foo\bar/.htaccess/foo', false),
+			array('/etc/foo\bar/.htaccess/foo', true),
 			array('//foo//bar/\.htaccess/', true),
 			array('\foo\bar\.HTAccess', true),
 		);
@@ -269,7 +269,30 @@ class FilesystemTest extends \Test\TestCase {
 	 * @dataProvider isFileBlacklistedData
 	 */
 	public function testIsFileBlacklisted($path, $expected) {
-		$this->assertSame($expected, \OC\Files\Filesystem::isFileBlacklisted($path));
+		$this->assertSame($expected, \OC\Files\Filesystem::isForbiddenFileOrDir($path));
+	}
+
+	public function isExcludedData() {
+		return array(
+			array('.snapshot', true),
+			array('.snapshot/', true),
+			array('.snapshot\\', true),
+			array('/etc/foo/bar/foo.txt', false),
+			array('/.snapshot/etc/foo/bar/foo.txt', true),
+			array('/.snapShot/etc/foo/bar/foo.txt', true),
+			array('\.snapshot\etc\foo/bar\foo.txt', true),
+			array('/etc/foo/.snapshot', true),
+			array('/etc/foo/.snapshot/bar', true),
+		);
+	}
+
+	/**
+	 * The parameter array can be redesigned if filesystem.php will get a constructor where it is possible to 
+	 * define the excluded directories for unit tests
+	 * @dataProvider isExcludedData
+	 */
+	public function testIsExcluded($path, $expected) {
+		$this->assertSame($expected, \OC\Files\Filesystem::isForbiddenFileOrDir($path, array('.snapshot')));
 	}
 
 	public function testNormalizePathUTF8() {


### PR DESCRIPTION
Feature PR, references: Exclude Directories (merged, for professional…… Storage use) in owncloud/core/pull/19235

Adds the ability to define directories in config.php which will not be further processed (scanned, shown, created ect). These directories exist in the source filesystem but will not handled in nextcloud.

Usecase: eg. filesystems which have the ability of snapshots have a defined folder naming for these snapshots. Processing them is in most cases not sensful.

For a detailed description pls see also the documentation PR.
