### PR TITLE
Allow to call the files even when you are in another instance atm

### DIFF
--- a/console.php
+++ b/console.php
@@ -45,7 +45,7 @@ function exceptionHandler($exception) {
 	exit(1);
 }
 try {
-	require_once 'lib/base.php';
+	require_once __DIR__ . '/lib/base.php';
 
 	// set to run indefinitely if needed
 	set_time_limit(0);

--- a/cron.php
+++ b/cron.php
@@ -32,7 +32,7 @@
 
 try {
 
-	require_once 'lib/base.php';
+	require_once __DIR__ . '/lib/base.php';
 
 	if (\OCP\Util::needUpgrade()) {
 		\OCP\Util::writeLog('cron', 'Update required, skipping cron', \OCP\Util::DEBUG);

--- a/index.php
+++ b/index.php
@@ -34,8 +34,8 @@ if (version_compare(PHP_VERSION, '5.6.0') === -1) {
 }
 
 try {
-	
-	require_once 'lib/base.php';
+
+	require_once __DIR__ . '/lib/base.php';
 
 	OC::handleRequest();
 

--- a/ocs-provider/index.php
+++ b/ocs-provider/index.php
@@ -19,7 +19,7 @@
  *
  */
 
-require_once('../lib/base.php');
+require_once __DIR__ . '/../lib/base.php';
 
 header('Content-Type: application/json');
 

--- a/ocs/providers.php
+++ b/ocs/providers.php
@@ -23,7 +23,7 @@
  *
  */
 
-require_once '../lib/base.php';
+require_once __DIR__ . '/../lib/base.php';
 
 header('Content-type: application/xml');
 

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -29,7 +29,7 @@
  *
  */
 
-require_once '../lib/base.php';
+require_once __DIR__ . '/../lib/base.php';
 
 if (\OCP\Util::needUpgrade()
 	|| \OC::$server->getSystemConfig()->getValue('maintenance', false)

--- a/ocs/v2.php
+++ b/ocs/v2.php
@@ -20,4 +20,4 @@
  *
  */
 
-require_once 'v1.php';
+require_once __DIR__ . '/v1.php';

--- a/public.php
+++ b/public.php
@@ -29,7 +29,7 @@
  */
 try {
 
-	require_once 'lib/base.php';
+	require_once __DIR__ . '/lib/base.php';
 	if (\OCP\Util::needUpgrade()) {
 		// since the behavior of apps or remotes are unpredictable during
 		// an upgrade, return a 503 directly

--- a/remote.php
+++ b/remote.php
@@ -107,7 +107,7 @@ function resolveService($service) {
 }
 
 try {
-	require_once 'lib/base.php';
+	require_once __DIR__ . '/lib/base.php';
 
 	// All resources served via the DAV endpoint should have the strictest possible
 	// policy. Exempted from this is the SabreDAV browser plugin which overwrites

--- a/status.php
+++ b/status.php
@@ -29,7 +29,7 @@
 
 try {
 
-	require_once 'lib/base.php';
+	require_once __DIR__ . '/lib/base.php';
 
 	$systemConfig = \OC::$server->getSystemConfig();
 


### PR DESCRIPTION
### Steps
1. Have Nextcloud 11 installed in 11/server/
2. Have Nextcloud 10 installed in 10/server/
3. Open terminal in 10/server/
4. Run `../../11/server/occ config:system:get apps_paths`
### Expected

Path should be `11/server/apps/`
### Actually

Path is `10/server/apps/`

Problem is we are including the wrong `lib/base.php` Oo

@MorrisJobke @LukasReschke @BernhardPosselt 
@karlitschek should backport this 
