### PR TITLE
cache loginName2UserName and cover the method with unit tests

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -54,6 +54,7 @@ class Access extends LDAPUtility implements IUserTools {
 	 * @var \OCA\User_LDAP\Connection
 	 */
 	public $connection;
+	/** @var Manager */
 	public $userManager;
 	//never ever check this var directly, always use getPagedSearchResultState
 	protected $pagedSearchedSuccessful;

--- a/apps/user_ldap/lib/Exceptions/NotOnLDAP.php
+++ b/apps/user_ldap/lib/Exceptions/NotOnLDAP.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_LDAP\Exceptions;
+
+class NotOnLDAP extends \Exception {}

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -36,6 +36,7 @@
 namespace OCA\User_LDAP;
 
 use OC\User\NoUserException;
+use OCA\User_LDAP\Exceptions\NotOnLDAP;
 use OCA\User_LDAP\User\OfflineUser;
 use OCA\User_LDAP\User\User;
 use OCP\IConfig;
@@ -80,14 +81,26 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 	 * @return string|false
 	 */
 	public function loginName2UserName($loginName) {
+		$cacheKey = 'loginName2UserName-'.$loginName;
+		$username = $this->access->connection->getFromCache($cacheKey);
+		if(!is_null($username)) {
+			return $username;
+		}
+
 		try {
 			$ldapRecord = $this->getLDAPUserByLoginName($loginName);
 			$user = $this->access->userManager->get($ldapRecord['dn'][0]);
 			if($user instanceof OfflineUser) {
+				// this path is not really possible, however get() is documented
+				// to return User or OfflineUser so we are very defensive here.
+				$this->access->connection->writeToCache($cacheKey, false);
 				return false;
 			}
-			return $user->getUsername();
-		} catch (\Exception $e) {
+			$username = $user->getUsername();
+			$this->access->connection->writeToCache($cacheKey, $username);
+			return $username;
+		} catch (NotOnLDAP $e) {
+			$this->access->connection->writeToCache($cacheKey, false);
 			return false;
 		}
 	}
@@ -107,14 +120,14 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 	 *
 	 * @param string $loginName
 	 * @return array
-	 * @throws \Exception
+	 * @throws NotOnLDAP
 	 */
 	public function getLDAPUserByLoginName($loginName) {
 		//find out dn of the user name
 		$attrs = $this->access->userManager->getAttributes();
 		$users = $this->access->fetchUsersByLoginName($loginName, $attrs);
 		if(count($users) < 1) {
-			throw new \Exception('No user available for the given login name on ' .
+			throw new NotOnLDAP('No user available for the given login name on ' .
 				$this->access->connection->ldapHost . ':' . $this->access->connection->ldapPort);
 		}
 		return $users[0];


### PR DESCRIPTION
@LukasReschke saw a code path that was talking to LDAP on any request. Turns out, it did not cache the result. Covered by unit tests, please review. @nextcloud/ldap 
