### PR TITLE
Default to empty string

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -277,7 +277,7 @@ class Log implements ILogger {
 					$request = \OC::$server->getRequest();
 
 					// if token is found in the request change set the log condition to satisfied
-					if($request && hash_equals($logCondition['shared_secret'], $request->getParam('log_secret'))) {
+					if($request && hash_equals($logCondition['shared_secret'], $request->getParam('log_secret', ''))) {
 						$this->logConditionSatisfied = true;
 					}
 				}


### PR DESCRIPTION
Otherwise `null` is returned which leads to a ton of similar error messages if the log condition setting is enabled.:

```
{"reqId":"3wVBarnDfOV3qkI1bVCU","remoteAddr":"89.98.78.41","app":"PHP","message":"hash_equals(): Expected user_string to be a string, null given at \/var\/www\/html\/lib\/private\/Log.php#275","level":3,"time":"2016-10-07T14:22:15+00:00","method":"PROPFIND","url":"\/remote.php\/webdav\/","user":"icewind"}
```
