### PR TITLE
use older php array syntax in index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -40,7 +40,7 @@ try {
 	OC::handleRequest();
 
 } catch(\OC\ServiceUnavailableException $ex) {
-	\OC::$server->getLogger()->logException($ex, ['app' => 'index']);
+	\OC::$server->getLogger()->logException($ex, array('app' => 'index'));
 
 	//show the user a detailed error page
 	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
@@ -49,13 +49,13 @@ try {
 	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
 	OC_Template::printErrorPage($ex->getMessage(), $ex->getHint());
 } catch (Exception $ex) {
-	\OC::$server->getLogger()->logException($ex, ['app' => 'index']);
+	\OC::$server->getLogger()->logException($ex, array('app' => 'index'));
 
 	//show the user a detailed error page
 	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
 	OC_Template::printExceptionErrorPage($ex);
 } catch (Error $ex) {
-	\OC::$server->getLogger()->logException($ex, ['app' => 'index']);
+	\OC::$server->getLogger()->logException($ex, array('app' => 'index'));
 	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
 	OC_Template::printExceptionErrorPage($ex);
 }


### PR DESCRIPTION
We should use the old array syntax in the index.php, because the shorthand version was introduced with PHP 5.4.
Users with an older PHP will only see an error message about the Syntax error in the index.php

fixes https://github.com/nextcloud/server/issues/1659

please review @MorrisJobke @nickvergessen @fancycode 
