### PR TITLE
Dont reparse info xml + cache AppInfo XML

### DIFF
--- a/core/register_command.php
+++ b/core/register_command.php
@@ -36,7 +36,7 @@
 $application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
 $application->add(new OC\Core\Command\Status);
 $application->add(new OC\Core\Command\Check(\OC::$server->getConfig()));
-$infoParser = new \OC\App\InfoParser(\OC::$server->getURLGenerator());
+$infoParser = new \OC\App\InfoParser();
 $application->add(new OC\Core\Command\App\CheckCode($infoParser));
 $application->add(new OC\Core\Command\L10n\CreateJs());
 $application->add(new \OC\Core\Command\Integrity\SignApp(

--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -26,19 +26,7 @@
 
 namespace OC\App;
 
-use OCP\IURLGenerator;
-
 class InfoParser {
-
-	/** @var IURLGenerator */
-	private $urlGenerator;
-
-	/**
-	 * @param IURLGenerator $urlGenerator
-	 */
-	public function __construct(IURLGenerator $urlGenerator) {
-		$this->urlGenerator = $urlGenerator;
-	}
 
 	/**
 	 * @param string $file the xml file to be loaded
@@ -52,15 +40,18 @@ class InfoParser {
 		libxml_use_internal_errors(true);
 		$loadEntities = libxml_disable_entity_loader(false);
 		$xml = simplexml_load_file($file);
+
 		libxml_disable_entity_loader($loadEntities);
-		if ($xml == false) {
+		if ($xml === false) {
 			libxml_clear_errors();
 			return null;
 		}
 		$array = $this->xmlToArray($xml);
+
 		if (is_null($array)) {
 			return null;
 		}
+
 		if (!array_key_exists('info', $array)) {
 			$array['info'] = [];
 		}
@@ -98,17 +89,6 @@ class InfoParser {
 			$array['two-factor-providers'] = [];
 		}
 
-		if (array_key_exists('documentation', $array) && is_array($array['documentation'])) {
-			foreach ($array['documentation'] as $key => $url) {
-				// If it is not an absolute URL we assume it is a key
-				// i.e. admin-ldap will get converted to go.php?to=admin-ldap
-				if (!$this->isHTTPURL($url)) {
-					$url = $this->urlGenerator->linkToDocs($url);
-				}
-
-				$array['documentation'][$key] = $url;
-			}
-		}
 		if (array_key_exists('types', $array)) {
 			if (is_array($array['types'])) {
 				foreach ($array['types'] as $type => $v) {
@@ -192,9 +172,5 @@ class InfoParser {
 		}
 
 		return $array;
-	}
-
-	private function isHTTPURL($url) {
-		return stripos($url, 'https://') === 0 || stripos($url, 'http://') === 0;
 	}
 }

--- a/lib/private/AppFramework/App.php
+++ b/lib/private/AppFramework/App.php
@@ -59,24 +59,11 @@ class App {
 			return $topNamespace . self::$nameSpaceCache[$appId];
 		}
 
-		// first try to parse the app's appinfo/info.xml <namespace> tag
-		$appPath = OC_App::getAppPath($appId);
-		if ($appPath !== false) {
-			$filePath = "$appPath/appinfo/info.xml";
-			if (is_file($filePath)) {
-				$loadEntities = libxml_disable_entity_loader(false);
-				$xml = @simplexml_load_file($filePath);
-				libxml_disable_entity_loader($loadEntities);
-				if ($xml) {
-					$result = $xml->xpath('/info/namespace');
-					if ($result && count($result) > 0) {
-						self::$nameSpaceCache[$appId] = trim((string) $result[0]);
-						// take first namespace result
-						return $topNamespace . self::$nameSpaceCache[$appId];
-					}
-				}
-			}
+		$appInfo = \OC_App::getAppInfo($appId);
+		if (isset($appInfo['namespace'])) {
+			return $topNamespace . trim($appInfo['namespace']);
 		}
+
 		// if the tag is not found, fall back to uppercasing the first letter
 		self::$nameSpaceCache[$appId] = ucfirst($appId);
 		return $topNamespace . self::$nameSpaceCache[$appId];

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -47,6 +47,7 @@
  *
  */
 use OC\App\DependencyAnalyzer;
+use OC\App\InfoParser;
 use OC\App\Platform;
 use OC\Installer;
 use OC\OCSClient;
@@ -681,7 +682,7 @@ class OC_App {
 			$file = $appPath . '/appinfo/info.xml';
 		}
 
-		$parser = new \OC\App\InfoParser(\OC::$server->getURLGenerator());
+		$parser = new InfoParser();
 		$data = $parser->parse($file);
 
 		if (is_array($data)) {
@@ -847,6 +848,7 @@ class OC_App {
 		$blacklist = \OC::$server->getAppManager()->getAlwaysEnabledApps();
 		$appList = array();
 		$langCode = \OC::$server->getL10N('core')->getLanguageCode();
+		$urlGenerator = \OC::$server->getURLGenerator();
 
 		foreach ($installedApps as $app) {
 			if (array_search($app, $blacklist) === false) {
@@ -900,6 +902,19 @@ class OC_App {
 						}
 					}
 				}
+				// fix documentation
+				if (isset($info['documentation']) && is_array($info['documentation'])) {
+					foreach ($info['documentation'] as $key => $url) {
+						// If it is not an absolute URL we assume it is a key
+						// i.e. admin-ldap will get converted to go.php?to=admin-ldap
+						if (stripos($url, 'https://') !== 0 && stripos($url, 'http://') !== 0) {
+							$url = $urlGenerator->linkToDocs($url);
+						}
+
+						$info['documentation'][$key] = $url;
+					}
+				}
+
 				$info['version'] = OC_App::getAppVersion($app);
 				$appList[] = $info;
 			}

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -682,7 +682,7 @@ class OC_App {
 			$file = $appPath . '/appinfo/info.xml';
 		}
 
-		$parser = new InfoParser();
+		$parser = new InfoParser(\OC::$server->getMemCacheFactory()->create('core.appinfo'));
 		$data = $parser->parse($file);
 
 		if (is_array($data)) {

--- a/tests/data/app/expected-info.json
+++ b/tests/data/app/expected-info.json
@@ -10,8 +10,8 @@
 	"requiremin": "4",
 	"shipped": "true",
 	"documentation": {
-		"user": "https://docs.example.com/server/go.php?to=user-encryption",
-		"admin": "https://docs.example.com/server/go.php?to=admin-encryption"
+		"user": "user-encryption",
+		"admin": "admin-encryption"
 	},
 	"rememberlogin": "false",
 	"types": ["filesystem"],

--- a/tests/lib/App/CodeChecker/InfoCheckerTest.php
+++ b/tests/lib/App/CodeChecker/InfoCheckerTest.php
@@ -44,9 +44,7 @@ class InfoCheckerTest extends TestCase {
 
 	protected function setUp() {
 		parent::setUp();
-		$infoParser = new InfoParser(\OC::$server->getURLGenerator());
-
-		$this->infoChecker = new InfoChecker($infoParser);
+		$this->infoChecker = new InfoChecker(new InfoParser());
 	}
 
 	public function appInfoData() {

--- a/tests/lib/App/InfoParserTest.php
+++ b/tests/lib/App/InfoParserTest.php
@@ -10,27 +10,16 @@
 namespace Test\App;
 
 use OC;
-use OCP\IURLGenerator;
+use OC\App\InfoParser;
 use Test\TestCase;
 
 class InfoParserTest extends TestCase {
 
-	/** @var \OC\App\InfoParser */
+	/** @var InfoParser */
 	private $parser;
 
 	public function setUp() {
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
-			->disableOriginalConstructor()
-			->getMock();
-
-		/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject $urlGenerator */
-		$urlGenerator->expects($this->any())
-			->method('linkToDocs')
-			->will($this->returnCallback(function ($url) {
-				return "https://docs.example.com/server/go.php?to=$url";
-			}));
-
-		$this->parser = new \OC\App\InfoParser($urlGenerator);
+		$this->parser = new InfoParser();
 	}
 
 	/**


### PR DESCRIPTION
This is a cherry-pick of https://github.com/owncloud/core/pull/25968, which we wouldn't necessary require since we have this optimised already at another place. But it's nice to keep the code kinda aligned for now.

In addition, I noticed that it's easily possible to gain at least 20ms on every request. By caching the appinfo in the configured memory cache, see https://github.com/nextcloud/server/commit/0c2b17c80f54027aaebbc43b8efb21fdaffe8d45

Trace: https://blackfire.io/profiles/compare/fc326ad3-100d-49b8-8ea9-8343240f53f3/graph
