### PR TITLE
Improve user list rendering perf by not resorting after every add (#2…

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -398,7 +398,7 @@ var UserList = {
 					if(UserList.has(user.name)) {
 						return true;
 					}
-					var $tr = UserList.add(user, user.lastLogin, false, user.backend);
+					var $tr = UserList.add(user, false);
 					trs.push($tr);
 					loadedUsers++;
 				});


### PR DESCRIPTION
…6282)

The call to UserList.add() was wrong and was passing "user.lastLogin"
as the sort argument which would cause the list to be resorted over and
over again for every added item after loading the next page of users.

Downstream of owncloud/core#26282

I tested this with LDAP and it works.

cc @blizzz @nickvergessen @rullzer 
