### PR TITLE
[stable10] Add app name to the call

### DIFF
--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -614,7 +614,7 @@ class Installer {
 		}
 
 		$codeChecker = new CodeChecker(new PrivateCheck(new EmptyCheck()));
-		$errors = $codeChecker->analyseFolder($folder);
+		$errors = $codeChecker->analyseFolder(basename($folder), $folder);
 
 		return empty($errors);
 	}


### PR DESCRIPTION
Regression from 69b063f4c614a46bbe5f0ffcab11ddb08c183f04 aka #1225
Fix #1437 
Backport of #1683 
### Steps
1. `./occ config:system:set appcodechecker --value true --type boolean`
2. Install an app from the app store

@MorrisJobke @rullzer @LukasReschke 
