### PR TITLE
[stable10] postpone filesystem-dependnt instantion during ldap auth, fixes #1251

### DIFF
--- a/apps/user_ldap/ajax/wizard.php
+++ b/apps/user_ldap/ajax/wizard.php
@@ -55,7 +55,7 @@ $userManager = new \OCA\User_LDAP\User\Manager(
 	\OC::$server->getConfig(),
 	new \OCA\User_LDAP\FilesystemHelper(),
 	new \OCA\User_LDAP\LogWrapper(),
-	\OC::$server->getAvatarManager(),
+	function() { return \OC::$server->getAvatarManager(); },
 	new \OCP\Image(),
 	\OC::$server->getDatabaseConnection(),
 	\OC::$server->getUserManager());

--- a/apps/user_ldap/appinfo/app.php
+++ b/apps/user_ldap/appinfo/app.php
@@ -36,7 +36,7 @@ if(count($configPrefixes) === 1) {
 	$userManager = new OCA\User_LDAP\User\Manager($ocConfig,
 		new OCA\User_LDAP\FilesystemHelper(),
 		new OCA\User_LDAP\LogWrapper(),
-		\OC::$server->getAvatarManager(),
+		function() {return \OC::$server->getAvatarManager(); },
 		new \OCP\Image(),
 		$dbc,
 		\OC::$server->getUserManager()

--- a/apps/user_ldap/lib/Jobs/UpdateGroups.php
+++ b/apps/user_ldap/lib/Jobs/UpdateGroups.php
@@ -183,7 +183,7 @@ class UpdateGroups extends \OC\BackgroundJob\TimedJob {
 				\OC::$server->getConfig(),
 				new FilesystemHelper(),
 				new LogWrapper(),
-				\OC::$server->getAvatarManager(),
+				function() { return \OC::$server->getAvatarManager(); },
 				new \OCP\Image(),
 				$dbc,
 				\OC::$server->getUserManager());

--- a/apps/user_ldap/lib/Proxy.php
+++ b/apps/user_ldap/lib/Proxy.php
@@ -68,7 +68,7 @@ abstract class Proxy {
 			$ocConfig = \OC::$server->getConfig();
 			$fs       = new FilesystemHelper();
 			$log      = new LogWrapper();
-			$avatarM  = \OC::$server->getAvatarManager();
+			$avatarM  = function() { return \OC::$server->getAvatarManager(); };
 			$db       = \OC::$server->getDatabaseConnection();
 			$userMap  = new UserMapping($db);
 			$groupMap = new GroupMapping($db);

--- a/apps/user_ldap/lib/User/Manager.php
+++ b/apps/user_ldap/lib/User/Manager.php
@@ -60,8 +60,8 @@ class Manager {
 	/** @var Image */
 	protected $image;
 
-	/** @param \OCP\IAvatarManager */
-	protected $avatarManager;
+	/** @param \Closure */
+	protected $avatarManagerClosure;
 
 	/**
 	 * @var CappedMemoryCache $usersByDN
@@ -77,25 +77,25 @@ class Manager {
 	 * @param \OCA\User_LDAP\FilesystemHelper $ocFilesystem object that
 	 * gives access to necessary functions from the OC filesystem
 	 * @param  \OCA\User_LDAP\LogWrapper $ocLog
-	 * @param IAvatarManager $avatarManager
+	 * @param \Closure $avatarManagerClosure
 	 * @param Image $image an empty image instance
 	 * @param IDBConnection $db
 	 * @throws \Exception when the methods mentioned above do not exist
 	 */
 	public function __construct(IConfig $ocConfig,
 								FilesystemHelper $ocFilesystem, LogWrapper $ocLog,
-								IAvatarManager $avatarManager, Image $image,
+								\Closure $avatarManagerClosure, Image $image,
 								IDBConnection $db, IUserManager $userManager) {
 
-		$this->ocConfig      = $ocConfig;
-		$this->ocFilesystem  = $ocFilesystem;
-		$this->ocLog         = $ocLog;
-		$this->avatarManager = $avatarManager;
-		$this->image         = $image;
-		$this->db            = $db;
-		$this->userManager   = $userManager;
-		$this->usersByDN     = new CappedMemoryCache();
-		$this->usersByUid    = new CappedMemoryCache();
+		$this->ocConfig             = $ocConfig;
+		$this->ocFilesystem         = $ocFilesystem;
+		$this->ocLog                = $ocLog;
+		$this->avatarManagerClosure = $avatarManagerClosure;
+		$this->image                = $image;
+		$this->db                   = $db;
+		$this->userManager          = $userManager;
+		$this->usersByDN            = new CappedMemoryCache();
+		$this->usersByUid           = new CappedMemoryCache();
 	}
 
 	/**
@@ -118,7 +118,7 @@ class Manager {
 		$this->checkAccess();
 		$user = new User($uid, $dn, $this->access, $this->ocConfig,
 			$this->ocFilesystem, clone $this->image, $this->ocLog,
-			$this->avatarManager, $this->userManager);
+			$this->avatarManagerClosure, $this->userManager);
 		$this->usersByDN[$dn]   = $user;
 		$this->usersByUid[$uid] = $user;
 		return $user;

--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -68,6 +68,10 @@ class User {
 	 */
 	protected $avatarManager;
 	/**
+	 * @var \Closure
+	 */
+	protected $avatarManagerClosure;
+	/**
 	 * @var IUserManager
 	 */
 	protected $userManager;
@@ -104,23 +108,24 @@ class User {
 	 * @param FilesystemHelper $fs
 	 * @param Image $image any empty instance
 	 * @param LogWrapper $log
-	 * @param IAvatarManager $avatarManager
+	 * @param \Closure $avatarManagerClosure - instantiation of filesystem
+	 * 		  dependent features should be delayed in authentication apps
 	 * @param IUserManager $userManager
 	 */
 	public function __construct($username, $dn, IUserTools $access,
 		IConfig $config, FilesystemHelper $fs, Image $image,
-		LogWrapper $log, IAvatarManager $avatarManager, IUserManager $userManager) {
+		LogWrapper $log, \Closure $avatarManagerClosure, IUserManager $userManager) {
 
-		$this->access        = $access;
-		$this->connection    = $access->getConnection();
-		$this->config        = $config;
-		$this->fs            = $fs;
-		$this->dn            = $dn;
-		$this->uid           = $username;
-		$this->image         = $image;
-		$this->log           = $log;
-		$this->avatarManager = $avatarManager;
-		$this->userManager   = $userManager;
+		$this->access               = $access;
+		$this->connection           = $access->getConnection();
+		$this->config               = $config;
+		$this->fs                   = $fs;
+		$this->dn                   = $dn;
+		$this->uid                  = $username;
+		$this->image                = $image;
+		$this->log                  = $log;
+		$this->avatarManagerClosure = $avatarManagerClosure;
+		$this->userManager          = $userManager;
 	}
 
 	/**
@@ -521,6 +526,9 @@ class User {
 		}
 
 		try {
+			if(is_null($this->avatarManager)) {
+				$this->avatarManager = $this->avatarManagerClosure();
+			}
 			$avatar = $this->avatarManager->getAvatar($this->uid);
 			$avatar->set($this->image);
 		} catch (\Exception $e) {

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -56,7 +56,7 @@ class AccessTest extends \Test\TestCase {
 				$this->getMock('\OCP\IConfig'),
 				$this->getMock('\OCA\User_LDAP\FilesystemHelper'),
 				$this->getMock('\OCA\User_LDAP\LogWrapper'),
-				$this->getMock('\OCP\IAvatarManager'),
+				function() { return $this->getMock('\OCP\IAvatarManager'); },
 				$this->getMock('\OCP\Image'),
 				$this->getMock('\OCP\IDBConnection'),
 				$this->getMock('\OCP\IUserManager')));

--- a/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserAvatar.php
+++ b/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserAvatar.php
@@ -127,7 +127,7 @@ class IntegrationTestUserAvatar extends AbstractIntegrationTest {
 			\OC::$server->getConfig(),
 			new \OCA\User_LDAP\FilesystemHelper(),
 			new \OCA\User_LDAP\LogWrapper(),
-			\OC::$server->getAvatarManager(),
+			function() { return \OC::$server->getAvatarManager(); },
 			new \OCP\Image(),
 			\OC::$server->getDatabaseConnection(),
 			\OC::$server->getUserManager()

--- a/apps/user_ldap/tests/User/ManagerTest.php
+++ b/apps/user_ldap/tests/User/ManagerTest.php
@@ -42,7 +42,7 @@ class ManagerTest extends \Test\TestCase {
 		$config = $this->getMock('\OCP\IConfig');
 		$filesys = $this->getMock('\OCA\User_LDAP\FilesystemHelper');
 		$log = $this->getMock('\OCA\User_LDAP\LogWrapper');
-		$avaMgr = $this->getMock('\OCP\IAvatarManager');
+		$avaMgr = function() { return $this->getMock('\OCP\IAvatarManager'); };
 		$image = $this->getMock('\OCP\Image');
 		$dbc = $this->getMock('\OCP\IDBConnection');
 		$userMgr = $this->getMock('\OCP\IUserManager');
@@ -82,7 +82,7 @@ class ManagerTest extends \Test\TestCase {
 
 		$manager = new Manager($config, $filesys, $log, $avaMgr, $image, $dbc, $userMgr);
 		$manager->setLdapAccess($access);
-		$user = $manager->get($inputDN);
+		$manager->get($inputDN);
 
 		// Now we fetch the user again. If this leads to a failing test,
 		// runtime caching the manager is broken.

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -81,7 +81,7 @@ class User_LDAPTest extends TestCase {
 				$this->configMock,
 				$this->getMock('\OCA\User_LDAP\FilesystemHelper'),
 				$this->getMock('\OCA\User_LDAP\LogWrapper'),
-				$this->getMock('\OCP\IAvatarManager'),
+				function() { return  $this->getMock('\OCP\IAvatarManager'); },
 				$this->getMock('\OCP\Image'),
 				$this->getMock('\OCP\IDBConnection'),
 				$this->getMock('\OCP\IUserManager')


### PR DESCRIPTION
A quick shot: puts AvatarManager instantiation into a closure. This should survive app init and not pull in filesystem apps to early.

Test steps:
1. Enable and configure LDAP on stable10 (somehow i cannot replicate on master – would need a fwd port nevertheless)
2. Enable External Storages
3. Allow users to setup external storages
4. Login as LDAP user and go to Personal

Before this fix, External Storages section is missing, now it's there as expected.

Fix #1251

@pasbec @nickvergessen @jmccoy555 @nextcloud/ldap 
