### PR TITLE
[master] Tear down FS between cron jobs (#26223)

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -119,6 +119,8 @@ try {
 
 			$logger->debug('Run ' . get_class($job) . ' job with ID ' . $job->getId(), ['app' => 'cron']);
 			$job->execute($jobList, $logger);
+			// clean up after unclean jobs
+			\OC_Util::tearDownFS();
 			$logger->debug('Finished ' . get_class($job) . ' job with ID ' . $job->getId(), ['app' => 'cron']);
 
 			$jobList->setLastJob($job);


### PR DESCRIPTION
Because some cron jobs do not always properly clean up their FS usage
and others might not clean up before setting up the FS, this could
cause potential side effects.

To make sure we exclude side effects, we tear down the FS between cron
jobs.

From: https://github.com/owncloud/core/pull/26257

CC: @nickvergessen @MorrisJobke @icewind1991 
