### PR TITLE
fix issue #1482 - mail invites through v1 webdav

### DIFF
--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -81,6 +81,8 @@ if ($debugging) {
 }
 
 $server->addPlugin(new \Sabre\CalDAV\ICSExportPlugin());
+$server->addPlugin(new \Sabre\CalDAV\Schedule\Plugin());
+$server->addPlugin(new \OCA\DAV\CalDAV\Schedule\IMipPlugin( \OC::$server->getMailer(), \OC::$server->getLogger()));
 $server->addPlugin(new ExceptionLoggerPlugin('caldav', \OC::$server->getLogger()));
 
 // And off we go!


### PR DESCRIPTION
Repalces: https://github.com/nextcloud/server/pull/1493

> Add Schedule and IMip plugins when receiving webdav v1 api calendar calls, allowing clients like Google Online Authenticator and DAVDroid to send mail invitations for meetings.
> 
> Fix #1482 

@ctodobom I took the liberty making the signoff-bot happy.

CC: @MorrisJobke @nickvergessen @LukasReschke @blizzz 
