### PR TITLE
symfony replaced table helper by class, fixes two broken LDAP occ com…

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -304,7 +304,6 @@ class Access extends LDAPUtility implements IUserTools {
 	}
 
 	/**
-	public function ocname2dn($name, $isUser) {
 	 * returns the internal ownCloud name for the given LDAP DN of the group, false on DN outside of search DN or failure
 	 * @param string $fdn the dn of the group object
 	 * @param string $ldapName optional, the display name of the object

--- a/apps/user_ldap/lib/Command/ShowConfig.php
+++ b/apps/user_ldap/lib/Command/ShowConfig.php
@@ -26,6 +26,7 @@
 namespace OCA\User_LDAP\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -91,7 +92,7 @@ class ShowConfig extends Command {
 			$configuration = $configHolder->getConfiguration();
 			ksort($configuration);
 
-			$table = $this->getHelperSet()->get('table');
+			$table = new Table($output);
 			$table->setHeaders(array('Configuration', $id));
 			$rows = array();
 			foreach($configuration as $key => $value) {

--- a/apps/user_ldap/lib/Command/ShowRemnants.php
+++ b/apps/user_ldap/lib/Command/ShowRemnants.php
@@ -26,6 +26,7 @@
 namespace OCA\User_LDAP\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -64,7 +65,7 @@ class ShowRemnants extends Command {
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		/** @var \Symfony\Component\Console\Helper\Table $table */
-		$table = $this->getHelperSet()->get('table');
+		$table = new Table($output);
 		$table->setHeaders(array(
 			'ownCloud name', 'Display Name', 'LDAP UID', 'LDAP DN', 'Last Login',
 			'Dir', 'Sharer'));


### PR DESCRIPTION
…mands

Before:

```
$ suww ./occ ldap:show-config
[sudo] password for blizzz: 


  [Symfony\Component\Console\Exception\InvalidArgumentException]  
  The helper "table" is not defined.                              


ldap:show-config [--show-password] [--] [<configID>]
```

Now prints your LDAP config again.

Only master is affected. I I have not seen other usages within the server repo.

Please test and review @nextcloud/ldap @MorrisJobke 
