### PR TITLE
AllConfig setUserValue opt

### DIFF
--- a/apps/encryption/tests/MigrationTest.php
+++ b/apps/encryption/tests/MigrationTest.php
@@ -343,6 +343,10 @@ class MigrationTest extends \Test\TestCase {
 		unset($cache['files_encryption']);
 		$this->invokePrivate(\OC::$server->getAppConfig(), 'cache', [$cache]);
 
+		$cache = $this->invokePrivate($config, 'userCache');
+		unset($cache[self::TEST_ENCRYPTION_MIGRATION_USER1]);
+		$this->invokePrivate(\OC::$server->getAppConfig(), 'userCache', [$cache]);
+
 		// delete default values set by the encryption app during initialization
 
 		/** @var \OCP\IDBConnection $connection */

--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -215,6 +215,25 @@ class AllConfig implements \OCP\IConfig {
 		// TODO - FIXME
 		$this->fixDIInit();
 
+		if (isset($this->userCache[$userId][$appName][$key])) {
+			if ($this->userCache[$userId][$appName][$key] === (string)$value) {
+				return;
+			} else if ($preCondition !== null && $this->userCache[$userId][$appName][$key] !== (string)$preCondition) {
+				return;
+			} else {
+				$qb = $this->connection->getQueryBuilder();
+				$qb->update('preferences')
+					->set('configvalue', $qb->createNamedParameter($value))
+					->where($qb->expr()->eq('userid', $qb->createNamedParameter($userId)))
+					->andWhere($qb->expr()->eq('appid', $qb->createNamedParameter($appName)))
+					->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter($key)));
+				$qb->execute();
+
+				$this->userCache[$userId][$appName][$key] = $value;
+				return;
+			}
+		}
+
 		$preconditionArray = [];
 		if (isset($preCondition)) {
 			$preconditionArray = [


### PR DESCRIPTION
I noticed that when we do a SetUser value we first do and insert and if that fails we do an update. This for example happens everytime we refresh the ldap cache for a user at least 5 times.

Since often we have the user config fetched anyways we should take advantage of it. And only update if needed and if needed just update.

CC: @LukasReschke @nickvergessen @MorrisJobke 
