### PR TITLE
comment mentions: show displayname not uid

### DIFF
--- a/apps/comments/appinfo/app.php
+++ b/apps/comments/appinfo/app.php
@@ -71,3 +71,14 @@ $commentsManager->registerEventHandler(function () {
 	$handler = $application->getContainer()->query(\OCA\Comments\EventHandler::class);
 	return $handler;
 });
+$commentsManager->registerDisplayNameResolver('user', function($id) {
+	$manager = \OC::$server->getUserManager();
+	$user = $manager->get($id);
+	if(is_null($user)) {
+		$l = \OC::$server->getL10N('comments');
+		$displayName = $l->t('Unknown user');
+	} else {
+		$displayName = $user->getDisplayName();
+	}
+	return $displayName;
+});

--- a/apps/comments/css/comments.css
+++ b/apps/comments/css/comments.css
@@ -64,6 +64,10 @@
 	line-height: 32px;
 }
 
+#commentsTabView .comment .message .avatar {
+	display: inline-block;
+}
+
 #activityTabView li.comment.collapsed .activitymessage,
 #commentsTabView .comment.collapsed .message {
 	white-space: pre-wrap;

--- a/apps/comments/js/commentmodel.js
+++ b/apps/comments/js/commentmodel.js
@@ -35,7 +35,8 @@
 			'creationDateTime': '{' + NS_OWNCLOUD + '}creationDateTime',
 			'objectType': '{' + NS_OWNCLOUD + '}objectType',
 			'objectId': '{' + NS_OWNCLOUD + '}objectId',
-			'isUnread': '{' + NS_OWNCLOUD + '}isUnread'
+			'isUnread': '{' + NS_OWNCLOUD + '}isUnread',
+			'mentions': '{' + NS_OWNCLOUD + '}mentions'
 		},
 
 		parse: function(data) {
@@ -48,8 +49,30 @@
 				creationDateTime: data.creationDateTime,
 				objectType: data.objectType,
 				objectId: data.objectId,
-				isUnread: (data.isUnread === 'true')
+				isUnread: (data.isUnread === 'true'),
+				mentions: this._parseMentions(data.mentions)
 			};
+		},
+
+		_parseMentions: function(mentions) {
+			if(_.isUndefined(mentions)) {
+				return {};
+			}
+			var result = {};
+			for(var i in mentions) {
+				var mention = mentions[i];
+				if(_.isUndefined(mention.localName) || mention.localName !== 'mention') {
+					continue;
+				}
+				result[i] = {};
+				for (var child = mention.firstChild; child; child = child.nextSibling) {
+					if(_.isUndefined(child.localName) || !child.localName.startsWith('mention')) {
+						continue;
+					}
+					result[i][child.localName] = child.textContent;
+				}
+			}
+			return result;
 		}
 	});
 

--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -257,10 +257,17 @@
 			for(var i in mentions) {
 				var mention = '@' + mentions[i].mentionId;
 
+				var avatar = '';
+				if(this._avatarsEnabled) {
+					avatar = '<div class="avatar" '
+						+ 'data-user="' + _.escape(mentions[i].mentionId) + '"'
+						+' data-user-display-name="'
+						+ _.escape(mentions[i].mentionDisplayName) + '"></div>';
+				}
 
 				// escape possible regex characters in the name
 				mention = mention.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-				var displayName = '<b>'+ _.escape(mentions[i].mentionDisplayName)+'</b>';
+				var displayName = avatar + ' <strong>'+ _.escape(mentions[i].mentionDisplayName)+'</strong>';
 
 				// replace every mention either at the start of the input or after a whitespace
 				// followed by a non-word character.

--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -307,7 +307,7 @@
 			$formRow.find('textarea').on('keydown input change', this._onTypeComment);
 
 			// copy avatar element from original to avoid flickering
-			$formRow.find('.avatar').replaceWith($comment.find('.avatar').clone());
+			$formRow.find('.avatar:first').replaceWith($comment.find('.avatar:first').clone());
 			$formRow.find('.has-tooltip').tooltip();
 
 			// Enable autosize

--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -264,7 +264,7 @@
 
 				// replace every mention either at the start of the input or after a whitespace
 				// followed by a non-word character.
-				message = message.replace(new RegExp("(^|\\s)(" + mention + ")(\\b|?![_-@.])", 'g'),
+				message = message.replace(new RegExp("(^|\\s)(" + mention + ")\\b", 'g'),
 					function(match, p1) {
 						// to  get number of whitespaces (0 vs 1) right
 						return p1+displayName;

--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -256,9 +256,20 @@
 
 			for(var i in mentions) {
 				var mention = '@' + mentions[i].mentionId;
+
+
+				// escape possible regex characters in the name
 				mention = mention.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 				var displayName = '<b>'+ _.escape(mentions[i].mentionDisplayName)+'</b>';
-				message = message.replace(new RegExp(mention, 'g'), displayName);
+
+				// replace every mention either at the start of the input or after a whitespace
+				// followed by a non-word character.
+				message = message.replace(new RegExp("(^|\\s)(" + mention + ")(\\b|?![_-@.])", 'g'),
+					function(match, p1) {
+						// to  get number of whitespaces (0 vs 1) right
+						return p1+displayName;
+					}
+				);
 			}
 
 			return message;

--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -401,16 +401,20 @@
 						$row.data('commentEl')
 							.removeClass('hidden')
 							.find('.message')
-							.html(self._formatMessage(model.get('message'), model.get('mentions')));
+							.html(self._formatMessage(model.get('message'), model.get('mentions')))
+							.find('.avatar')
+							.each(function () { $(this).avatar(); });
 						$row.remove();
 					} else {
 						var $row = $form.closest('.comments');
-						console.log($form);
 						$('.commentsTabView .comments').find('li:first')
 							.find('.message')
-							.html(self._formatMessage(model.get('message'), model.get('mentions')));
+							.html(self._formatMessage(model.get('message'), model.get('mentions')))
+							.find('.avatar')
+							.each(function () { $(this).avatar(); });
 						$textArea.val('').prop('disabled', false);
 					}
+
 				},
 				error: function () {
 					$submit.removeClass('hidden');

--- a/apps/comments/tests/Unit/Notification/ListenerTest.php
+++ b/apps/comments/tests/Unit/Notification/ListenerTest.php
@@ -72,10 +72,6 @@ class ListenerTest extends TestCase {
 	 * @param string $notificationMethod
 	 */
 	public function testEvaluate($eventType, $notificationMethod) {
-		$message = '@foobar and @barfoo you should know, @foo@bar.com is valid' .
-			' and so is @bar@foo.org@foobar.io I hope that clarifies everything.' .
-			' cc @23452-4333-54353-2342 @yolo!';
-
 		/** @var IComment|\PHPUnit_Framework_MockObject_MockObject $comment */
 		$comment = $this->getMockBuilder('\OCP\Comments\IComment')->getMock();
 		$comment->expects($this->any())
@@ -85,8 +81,15 @@ class ListenerTest extends TestCase {
 			->method('getCreationDateTime')
 			->will($this->returnValue(new \DateTime()));
 		$comment->expects($this->once())
-			->method('getMessage')
-			->will($this->returnValue($message));
+			->method('getMentions')
+			->willReturn([
+				[ 'type' => 'user', 'id' => 'foobar'],
+				[ 'type' => 'user', 'id' => 'barfoo'],
+				[ 'type' => 'user', 'id' => 'foo@bar.com'],
+				[ 'type' => 'user', 'id' => 'bar@foo.org@foobar.io'],
+				[ 'type' => 'user', 'id' => '23452-4333-54353-2342'],
+				[ 'type' => 'user', 'id' => 'yolo'],
+			]);
 
 		/** @var CommentsEvent|\PHPUnit_Framework_MockObject_MockObject $event */
 		$event = $this->getMockBuilder('\OCP\Comments\CommentsEvent')
@@ -134,8 +137,6 @@ class ListenerTest extends TestCase {
 	 * @param string $eventType
 	 */
 	public function testEvaluateNoMentions($eventType) {
-		$message = 'a boring comment without mentions';
-
 		/** @var IComment|\PHPUnit_Framework_MockObject_MockObject $comment */
 		$comment = $this->getMockBuilder('\OCP\Comments\IComment')->getMock();
 		$comment->expects($this->any())
@@ -145,8 +146,8 @@ class ListenerTest extends TestCase {
 			->method('getCreationDateTime')
 			->will($this->returnValue(new \DateTime()));
 		$comment->expects($this->once())
-			->method('getMessage')
-			->will($this->returnValue($message));
+			->method('getMentions')
+			->willReturn([]);
 
 		/** @var CommentsEvent|\PHPUnit_Framework_MockObject_MockObject $event */
 		$event = $this->getMockBuilder('\OCP\Comments\CommentsEvent')
@@ -173,8 +174,6 @@ class ListenerTest extends TestCase {
 	}
 
 	public function testEvaluateUserDoesNotExist() {
-		$message = '@foobar bla bla bla';
-
 		/** @var IComment|\PHPUnit_Framework_MockObject_MockObject $comment */
 		$comment = $this->getMockBuilder('\OCP\Comments\IComment')->getMock();
 		$comment->expects($this->any())
@@ -184,8 +183,8 @@ class ListenerTest extends TestCase {
 			->method('getCreationDateTime')
 			->will($this->returnValue(new \DateTime()));
 		$comment->expects($this->once())
-			->method('getMessage')
-			->will($this->returnValue($message));
+			->method('getMentions')
+			->willReturn([[ 'type' => 'user', 'id' => 'foobar']]);
 
 		/** @var CommentsEvent|\PHPUnit_Framework_MockObject_MockObject $event */
 		$event = $this->getMockBuilder('\OCP\Comments\CommentsEvent')
@@ -221,119 +220,4 @@ class ListenerTest extends TestCase {
 
 		$this->listener->evaluate($event);
 	}
-
-	/**
-	 * @dataProvider eventProvider
-	 * @param string $eventType
-	 * @param string $notificationMethod
-	 */
-	public function testEvaluateOneMentionPerUser($eventType, $notificationMethod) {
-		$message = '@foobar bla bla bla @foobar';
-
-		/** @var IComment|\PHPUnit_Framework_MockObject_MockObject $comment */
-		$comment = $this->getMockBuilder('\OCP\Comments\IComment')->getMock();
-		$comment->expects($this->any())
-			->method('getObjectType')
-			->will($this->returnValue('files'));
-		$comment->expects($this->any())
-			->method('getCreationDateTime')
-			->will($this->returnValue(new \DateTime()));
-		$comment->expects($this->once())
-			->method('getMessage')
-			->will($this->returnValue($message));
-
-		/** @var CommentsEvent|\PHPUnit_Framework_MockObject_MockObject $event */
-		$event = $this->getMockBuilder('\OCP\Comments\CommentsEvent')
-			->disableOriginalConstructor()
-			->getMock();
-		$event->expects($this->once())
-			->method('getComment')
-			->will($this->returnValue($comment));
-		$event->expects(($this->any()))
-			->method(('getEvent'))
-			->will($this->returnValue($eventType));
-
-		/** @var INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
-		$notification = $this->getMockBuilder('\OCP\Notification\INotification')->getMock();
-		$notification->expects($this->any())
-			->method($this->anything())
-			->will($this->returnValue($notification));
-		$notification->expects($this->once())
-			->method('setUser');
-
-		$this->notificationManager->expects($this->once())
-			->method('createNotification')
-			->will($this->returnValue($notification));
-		$this->notificationManager->expects($this->once())
-			->method($notificationMethod)
-			->with($this->isInstanceOf('\OCP\Notification\INotification'));
-
-		$this->userManager->expects($this->once())
-			->method('userExists')
-			->withConsecutive(
-				['foobar']
-			)
-			->will($this->returnValue(true));
-
-		$this->listener->evaluate($event);
-	}
-
-	/**
-	 * @dataProvider eventProvider
-	 * @param string $eventType
-	 */
-	public function testEvaluateNoSelfMention($eventType) {
-		$message = '@foobar bla bla bla';
-
-		/** @var IComment|\PHPUnit_Framework_MockObject_MockObject $comment */
-		$comment = $this->getMockBuilder('\OCP\Comments\IComment')->getMock();
-		$comment->expects($this->any())
-			->method('getObjectType')
-			->will($this->returnValue('files'));
-		$comment->expects($this->any())
-			->method('getActorType')
-			->will($this->returnValue('users'));
-		$comment->expects($this->any())
-			->method('getActorId')
-			->will($this->returnValue('foobar'));
-		$comment->expects($this->any())
-			->method('getCreationDateTime')
-			->will($this->returnValue(new \DateTime()));
-		$comment->expects($this->once())
-			->method('getMessage')
-			->will($this->returnValue($message));
-
-		/** @var CommentsEvent|\PHPUnit_Framework_MockObject_MockObject $event */
-		$event = $this->getMockBuilder('\OCP\Comments\CommentsEvent')
-			->disableOriginalConstructor()
-			->getMock();
-		$event->expects($this->once())
-			->method('getComment')
-			->will($this->returnValue($comment));
-		$event->expects(($this->any()))
-			->method(('getEvent'))
-			->will($this->returnValue($eventType));
-
-		/** @var INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
-		$notification = $this->getMockBuilder('\OCP\Notification\INotification')->getMock();
-		$notification->expects($this->any())
-			->method($this->anything())
-			->will($this->returnValue($notification));
-		$notification->expects($this->never())
-			->method('setUser');
-
-		$this->notificationManager->expects($this->once())
-			->method('createNotification')
-			->will($this->returnValue($notification));
-		$this->notificationManager->expects($this->never())
-			->method('notify');
-		$this->notificationManager->expects($this->never())
-			->method('markProcessed');
-
-		$this->userManager->expects($this->never())
-			->method('userExists');
-
-		$this->listener->evaluate($event);
-	}
-
 }

--- a/apps/dav/lib/Comments/CommentNode.php
+++ b/apps/dav/lib/Comments/CommentNode.php
@@ -45,6 +45,7 @@ class CommentNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 	const PROPERTY_NAME_MENTION = '{http://owncloud.org/ns}mention';
 	const PROPERTY_NAME_MENTION_TYPE = '{http://owncloud.org/ns}mentionType';
 	const PROPERTY_NAME_MENTION_ID = '{http://owncloud.org/ns}mentionId';
+	const PROPERTY_NAME_MENTION_DISPLAYNAME = '{http://owncloud.org/ns}mentionDisplayName';
 
 	/** @var  IComment */
 	public $comment;
@@ -125,6 +126,7 @@ class CommentNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 			self::PROPERTY_NAME_MENTION,
 			self::PROPERTY_NAME_MENTION_TYPE,
 			self::PROPERTY_NAME_MENTION_ID,
+			self::PROPERTY_NAME_MENTION_DISPLAYNAME,
 		];
 	}
 
@@ -283,10 +285,19 @@ class CommentNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 	 */
 	protected function composeMentionsPropertyValue() {
 		return array_map(function($mention) {
+			try {
+				$displayName = $this->commentsManager->resolveDisplayName($mention['type'], $mention['id']);
+			} catch (\OutOfBoundsException $e) {
+				$this->logger->logException($e);
+				// No displayname, upon client's discretion what to display.
+				$displayName = '';
+			}
+
 			return [
 				self::PROPERTY_NAME_MENTION => [
-					self::PROPERTY_NAME_MENTION_TYPE => $mention['type'],
-					self::PROPERTY_NAME_MENTION_ID   => $mention['id'],
+					self::PROPERTY_NAME_MENTION_TYPE        => $mention['type'],
+					self::PROPERTY_NAME_MENTION_ID          => $mention['id'],
+					self::PROPERTY_NAME_MENTION_DISPLAYNAME => $displayName,
 				]
 			];
 		}, $this->comment->getMentions());

--- a/apps/dav/lib/Comments/CommentNode.php
+++ b/apps/dav/lib/Comments/CommentNode.php
@@ -41,6 +41,10 @@ class CommentNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 	const PROPERTY_NAME_UNREAD = '{http://owncloud.org/ns}isUnread';
 	const PROPERTY_NAME_MESSAGE = '{http://owncloud.org/ns}message';
 	const PROPERTY_NAME_ACTOR_DISPLAYNAME = '{http://owncloud.org/ns}actorDisplayName';
+	const PROPERTY_NAME_MENTIONS = '{http://owncloud.org/ns}mentions';
+	const PROPERTY_NAME_MENTION = '{http://owncloud.org/ns}mention';
+	const PROPERTY_NAME_MENTION_TYPE = '{http://owncloud.org/ns}mentionType';
+	const PROPERTY_NAME_MENTION_ID = '{http://owncloud.org/ns}mentionId';
 
 	/** @var  IComment */
 	public $comment;
@@ -85,6 +89,9 @@ class CommentNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 			return strpos($name, 'get') === 0;
 		});
 		foreach($methods as $getter) {
+			if($getter === 'getMentions') {
+				continue;	// special treatment
+			}
 			$name = '{'.self::NS_OWNCLOUD.'}' . lcfirst(substr($getter, 3));
 			$this->properties[$name] = $getter;
 		}
@@ -113,7 +120,11 @@ class CommentNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 			// re-used property names are defined as constants
 			self::PROPERTY_NAME_MESSAGE,
 			self::PROPERTY_NAME_ACTOR_DISPLAYNAME,
-			self::PROPERTY_NAME_UNREAD
+			self::PROPERTY_NAME_UNREAD,
+			self::PROPERTY_NAME_MENTIONS,
+			self::PROPERTY_NAME_MENTION,
+			self::PROPERTY_NAME_MENTION_TYPE,
+			self::PROPERTY_NAME_MENTION_ID,
 		];
 	}
 
@@ -240,6 +251,8 @@ class CommentNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 			$result[self::PROPERTY_NAME_ACTOR_DISPLAYNAME] = $displayName;
 		}
 
+		$result[self::PROPERTY_NAME_MENTIONS] = $this->composeMentionsPropertyValue();
+
 		$unread = null;
 		$user =  $this->userSession->getUser();
 		if(!is_null($user)) {
@@ -259,5 +272,23 @@ class CommentNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 		$result[self::PROPERTY_NAME_UNREAD] = $unread;
 
 		return $result;
+	}
+
+	/**
+	 * transforms a mentions array as returned from IComment->getMentions to an
+	 * array with DAV-compatible structure that can be assigned to the
+	 * PROPERTY_NAME_MENTION property.
+	 *
+	 * @return array
+	 */
+	protected function composeMentionsPropertyValue() {
+		return array_map(function($mention) {
+			return [
+				self::PROPERTY_NAME_MENTION => [
+					self::PROPERTY_NAME_MENTION_TYPE => $mention['type'],
+					self::PROPERTY_NAME_MENTION_ID   => $mention['id'],
+				]
+			];
+		}, $this->comment->getMentions());
 	}
 }

--- a/apps/dav/tests/unit/Comments/CommentsNodeTest.php
+++ b/apps/dav/tests/unit/Comments/CommentsNodeTest.php
@@ -373,6 +373,10 @@ class CommentsNodeTest extends \Test\TestCase {
 			$ns . 'topmostParentId' => '2',
 			$ns . 'childrenCount' => 3,
 			$ns . 'message' => 'such a nice file you have…',
+			$ns . 'mentions' => [
+				[ $ns . 'mention' => [ $ns . 'mentionType' => 'user', $ns . 'mentionId' => 'alice'] ],
+				[ $ns . 'mention' => [ $ns . 'mentionType' => 'user', $ns . 'mentionId' => 'bob'] ],
+			],
 			$ns . 'verb' => 'comment',
 			$ns . 'actorType' => 'users',
 			$ns . 'actorId' => 'alice',
@@ -403,6 +407,13 @@ class CommentsNodeTest extends \Test\TestCase {
 		$this->comment->expects($this->once())
 			->method('getMessage')
 			->will($this->returnValue($expected[$ns . 'message']));
+
+		$this->comment->expects($this->once())
+			->method('getMentions')
+			->willReturn([
+				['type' => 'user', 'id' => 'alice'],
+				['type' => 'user', 'id' => 'bob'],
+			]);
 
 		$this->comment->expects($this->once())
 			->method('getVerb')
@@ -474,6 +485,10 @@ class CommentsNodeTest extends \Test\TestCase {
 		$this->comment->expects($this->any())
 			->method('getCreationDateTime')
 			->will($this->returnValue($creationDT));
+
+		$this->comment->expects($this->any())
+			->method('getMentions')
+			->willReturn([]);
 
 		$this->commentsManager->expects($this->once())
 			->method('getReadMark')

--- a/apps/dav/tests/unit/Comments/CommentsNodeTest.php
+++ b/apps/dav/tests/unit/Comments/CommentsNodeTest.php
@@ -27,11 +27,14 @@ namespace OCA\DAV\Tests\unit\Comments;
 
 use OCA\DAV\Comments\CommentNode;
 use OCP\Comments\IComment;
+use OCP\Comments\ICommentsManager;
 use OCP\Comments\MessageTooLongException;
 
 class CommentsNodeTest extends \Test\TestCase {
 
+	/** @var  ICommentsManager|\PHPUnit_Framework_MockObject_MockObject */
 	protected $commentsManager;
+
 	protected $comment;
 	protected $node;
 	protected $userManager;
@@ -374,8 +377,16 @@ class CommentsNodeTest extends \Test\TestCase {
 			$ns . 'childrenCount' => 3,
 			$ns . 'message' => 'such a nice file you have…',
 			$ns . 'mentions' => [
-				[ $ns . 'mention' => [ $ns . 'mentionType' => 'user', $ns . 'mentionId' => 'alice'] ],
-				[ $ns . 'mention' => [ $ns . 'mentionType' => 'user', $ns . 'mentionId' => 'bob'] ],
+				[ $ns . 'mention' => [
+					$ns . 'mentionType' => 'user',
+					$ns . 'mentionId' => 'alice',
+					$ns . 'mentionDisplayName' => 'Alice Al-Isson',
+				] ],
+				[ $ns . 'mention' => [
+					$ns . 'mentionType' => 'user',
+					$ns . 'mentionId' => 'bob',
+					$ns . 'mentionDisplayName' => 'Unknown user',
+				] ],
 			],
 			$ns . 'verb' => 'comment',
 			$ns . 'actorType' => 'users',
@@ -387,6 +398,14 @@ class CommentsNodeTest extends \Test\TestCase {
 			$ns . 'objectId' => '1848',
 			$ns . 'isUnread' => null,
 		];
+
+		$this->commentsManager->expects($this->exactly(2))
+			->method('resolveDisplayName')
+			->withConsecutive(
+				[$this->equalTo('user'), $this->equalTo('alice')],
+				[$this->equalTo('user'), $this->equalTo('bob')]
+			)
+			->willReturnOnConsecutiveCalls('Alice Al-Isson', 'Unknown user');
 
 		$this->comment->expects($this->once())
 			->method('getId')

--- a/lib/private/Comments/Comment.php
+++ b/lib/private/Comments/Comment.php
@@ -204,6 +204,43 @@ class Comment implements IComment {
 	}
 
 	/**
+	 * returns an array containing mentions that are included in the comment
+	 *
+	 * @return array each mention provides a 'type' and an 'id', see example below
+	 * @since 9.2.0
+	 *
+	 * The return array looks like:
+	 * [
+	 *   [
+	 *     'type' => 'user',
+	 *     'id' => 'citizen4'
+	 *   ],
+	 *   [
+	 *     'type' => 'group',
+	 *     'id' => 'media'
+	 *   ],
+	 *   …
+	 * ]
+	 *
+	 */
+	public function getMentions() {
+		$ok = preg_match_all('/\B@[a-z0-9_\-@\.\']+/i', $this->getMessage(), $mentions);
+		if(!$ok || !isset($mentions[0]) || !is_array($mentions[0])) {
+			return [];
+		}
+		$uids = array_unique($mentions[0]);
+		$result = [];
+		foreach ($uids as $uid) {
+			// exclude author, no self-mentioning
+			if($uid === '@' . $this->getActorId()) {
+				continue;
+			}
+			$result[] = ['type' => 'user', 'id' => substr($uid, 1)];
+		}
+		return $result;
+	}
+
+	/**
 	 * returns the verb of the comment
 	 *
 	 * @return string

--- a/lib/public/Comments/IComment.php
+++ b/lib/public/Comments/IComment.php
@@ -133,6 +133,28 @@ interface IComment {
 	public function setMessage($message);
 
 	/**
+	 * returns an array containing mentions that are included in the comment
+	 *
+	 * @return array each mention provides a 'type' and an 'id', see example below
+	 * @since 9.2.0
+	 *
+	 * The return array looks like:
+	 * [
+	 *   [
+	 *     'type' => 'user',
+	 *     'id' => 'citizen4'
+	 *   ],
+	 *   [
+	 *     'type' => 'group',
+	 *     'id' => 'media'
+	 *   ],
+	 *   …
+	 * ]
+	 *
+	 */
+	public function getMentions();
+
+	/**
 	 * returns the verb of the comment
 	 *
 	 * @return string

--- a/lib/public/Comments/ICommentsManager.php
+++ b/lib/public/Comments/ICommentsManager.php
@@ -246,4 +246,32 @@ interface ICommentsManager {
 	 */
 	public function registerEventHandler(\Closure $closure);
 
+	/**
+	 * registers a method that resolves an ID to a display name for a given type
+	 *
+	 * @param string $type
+	 * @param \Closure $closure
+	 * @throws \OutOfBoundsException
+	 * @since 9.2.0
+	 *
+	 * Only one resolver shall be registered per type. Otherwise a
+	 * \OutOfBoundsException has to thrown.
+	 */
+	public function registerDisplayNameResolver($type, \Closure $closure);
+
+	/**
+	 * resolves a given ID of a given Type to a display name.
+	 *
+	 * @param string $type
+	 * @param string $id
+	 * @return string
+	 * @throws \OutOfBoundsException
+	 * @since 9.2.0
+	 *
+	 * If a provided type was not registered, an \OutOfBoundsException shall
+	 * be thrown. It is upon the resolver discretion what to return of the
+	 * provided ID is unknown. It must be ensured that a string is returned.
+	 */
+	public function resolveDisplayName($type, $id);
+
 }

--- a/tests/lib/Comments/FakeManager.php
+++ b/tests/lib/Comments/FakeManager.php
@@ -40,4 +40,8 @@ class FakeManager implements \OCP\Comments\ICommentsManager {
 	public function deleteReadMarksOnObject($objectType, $objectId) {}
 
 	public function registerEventHandler(\Closure $closure) {}
+
+	public function registerDisplayNameResolver($type, \Closure $closure) {}
+
+	public function resolveDisplayName($type, $id) {}
 }

--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -664,4 +664,82 @@ class ManagerTest extends TestCase {
 		$manager->delete($comment->getId());
 	}
 
+	public function testResolveDisplayName() {
+		$manager = $this->getManager();
+
+		$planetClosure = function($name) {
+			return ucfirst($name);
+		};
+
+		$galaxyClosure = function($name) {
+			return strtoupper($name);
+		};
+
+		$manager->registerDisplayNameResolver('planet', $planetClosure);
+		$manager->registerDisplayNameResolver('galaxy', $galaxyClosure);
+
+		$this->assertSame('Neptune', $manager->resolveDisplayName('planet', 'neptune'));
+		$this->assertSame('SOMBRERO', $manager->resolveDisplayName('galaxy', 'sombrero'));
+	}
+
+	/**
+	 * @expectedException \OutOfBoundsException
+	 */
+	public function testRegisterResolverDuplicate() {
+		$manager = $this->getManager();
+
+		$planetClosure = function($name) {
+			return ucfirst($name);
+		};
+		$manager->registerDisplayNameResolver('planet', $planetClosure);
+		$manager->registerDisplayNameResolver('planet', $planetClosure);
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testRegisterResolverInvalidType() {
+		$manager = $this->getManager();
+
+		$planetClosure = function($name) {
+			return ucfirst($name);
+		};
+		$manager->registerDisplayNameResolver(1337, $planetClosure);
+	}
+
+	/**
+	 * @expectedException \OutOfBoundsException
+	 */
+	public function testResolveDisplayNameUnregisteredType() {
+		$manager = $this->getManager();
+
+		$planetClosure = function($name) {
+			return ucfirst($name);
+		};
+
+		$manager->registerDisplayNameResolver('planet', $planetClosure);
+		$manager->resolveDisplayName('galaxy', 'sombrero');
+	}
+
+	public function testResolveDisplayNameDirtyResolver() {
+		$manager = $this->getManager();
+
+		$planetClosure = function() { return null; };
+
+		$manager->registerDisplayNameResolver('planet', $planetClosure);
+		$this->assertTrue(is_string($manager->resolveDisplayName('planet', 'neptune')));
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testResolveDisplayNameInvalidType() {
+		$manager = $this->getManager();
+
+		$planetClosure = function() { return null; };
+
+		$manager->registerDisplayNameResolver('planet', $planetClosure);
+		$this->assertTrue(is_string($manager->resolveDisplayName(1337, 'neptune')));
+	}
+
 }


### PR DESCRIPTION
- [x] requires #1449 

contributes to #753, items 2 and 4.
## comment flow
1. Write a comment  with  a mentions

![1-create](https://cloud.githubusercontent.com/assets/2184312/19436952/6badc176-9473-11e6-9343-7ad594af2459.png)
1. After saving, the rendered comment will show the displayname

![2-done](https://cloud.githubusercontent.com/assets/2184312/19436986/90721084-9473-11e6-91a4-3d8019b7c54f.png)
1. Oops! You forgot to mention someone else! Editing the comment will show the uids

![3-edit](https://cloud.githubusercontent.com/assets/2184312/19437010/a57a09c8-9473-11e6-99d0-ac4b9339c05f.png)
1. When the edit is done, the comment is rendered with display names again

![4-done](https://cloud.githubusercontent.com/assets/2184312/19437017/b4bfe2d6-9473-11e6-84a6-571a036e0f68.png)
## Tech background

In the back, the DAV endpoint will send mention information with the raw message.

![spectacle f10473](https://cloud.githubusercontent.com/assets/2184312/19437079/019a051e-9474-11e6-8c6b-242ad1630e9b.png)

The client (web ui here) replaces the uid with the displayname for presentation.

The next step (follow-up PR) will introduce autocomplete. After typing @ a search within the recipients of this file is supposed to happen. The client would make sure that the raw user id stays in the message, but its editing/composing abilities would hide this from the end user. That's the idea at least.
## Todos left
- [ ] evaluate JS tests (adjust, add, or neither?)
