### PR TITLE
ellipsize sharee name to not overlap with can edit option on mobile

### DIFF
--- a/apps/files/css/mobile.css
+++ b/apps/files/css/mobile.css
@@ -61,6 +61,11 @@ table td.filename .nametext .innernametext {
 	max-width: 50%;
 }
 
+/* ellipsis on user names in share sidebar */
+#shareWithList .username {
+    max-width: 80px !important;
+}
+
 /* proper notification area for multi line messages */
 #notification-container {
 	display: -webkit-box;


### PR DESCRIPTION
Before (even worse with longer names, overlapping the text)
![capture du 2016-10-18 11-16-52](https://cloud.githubusercontent.com/assets/925062/19471701/b60109a2-9524-11e6-827d-8b9e4fe0511e.png)
After
![capture du 2016-10-18 11-16-28](https://cloud.githubusercontent.com/assets/925062/19471700/b5f9ee42-9524-11e6-832a-657aa1ca6377.png)

Please review @nextcloud/designers 
