### PR TITLE
add whitespace above share link so it's visually distinguished more

### DIFF
--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -96,6 +96,10 @@
 	position: absolute;
 }
 
+.linkShareView {
+	margin-top: 16px;
+}
+
 .shareTabView .linkPass .icon-loading-small {
 	margin-top: 9px;
 }


### PR DESCRIPTION
Just a bit more separation from the share with user section. Please review @nextcloud/designers 
