### PR TITLE
move select2 styles to core so it's universal, not only for tags

### DIFF
--- a/core/css/inputs.css
+++ b/core/css/inputs.css
@@ -224,6 +224,9 @@ select:hover {
 
 
 /* select2 adjustments */
+.select2-container {
+    margin: 3px 3px 3px 0 !important;
+}
 #select2-drop {
 	margin-top: -4px;
 }
@@ -267,7 +270,7 @@ select:hover {
 	box-sizing: content-box !important;
 	border-radius: 3px !important;
 	border: 1px solid #ddd !important;
-	margin: 3px 3px 3px 0 !important;
+	margin: 0 !important;
 	padding: 2px 0 !important;
 	min-height: auto !important;
 }

--- a/core/css/inputs.css
+++ b/core/css/inputs.css
@@ -6,6 +6,7 @@ input, textarea, select, button {
 }
 
 .select2-container-multi .select2-choices .select2-search-field input,
+.select2-search input,
 .ui-widget {
 	font-family: 'Open Sans', Frutiger, Calibri, 'Myriad Pro', Myriad, sans-serif !important;
 }
@@ -221,17 +222,115 @@ select:hover {
 }
 
 
+
+/* select2 adjustments */
+#select2-drop {
+	margin-top: -4px;
+}
+.select2-container .select2-choice,
+.select2-container .select2-default {
+	border: none !important;
+	border-radius: 0;
+	background: transparent !important;
+	box-shadow: none !important;
+	line-height: 32px !important;
+	padding-left: 38px;
+	background-color: transparent;
+}
+.select2-selected {
+	display: list-item !important;
+	background-color: #f8f8f8 !important;
+}
+.select2-highlighted,
+.select2-selected.select2-highlighted {
+	background: #f8f8f8 !important;
+	color: #000 !important;
+}
+
+.select2-result {
+	position: relative !important;
+}
+.select2-results {
+	max-height: 220px !important;
+	margin: 0 !important;
+	padding: 0 !important;
+}
+.select2-results .select2-result-label {
+	padding: 12px !important;
+}
+
 .select2-choices {
-	border: 1px solid #ddd;
-	border-radius: 3px;
-	color: #333;
-	background-image: none;
+	white-space: nowrap !important;
+	text-overflow: ellipsis !important;
+	background: #fff !important;
+	color: #555 !important;
+	box-sizing: content-box !important;
+	border-radius: 3px !important;
+	border: 1px solid #ddd !important;
+	margin: 3px 3px 3px 0 !important;
+	padding: 2px 0 !important;
+	min-height: auto !important;
 }
 .select2-dropdown-open .select2-choices {
-	border-bottom-left-radius: 0;
-	border-bottom-right-radius: 0;
-	border: 1px solid #3875d7;
+	border-bottom-left-radius: 0 !important;
+	border-bottom-right-radius: 0 !important;
 }
+
+.select2-search {
+	padding: 0 !important;
+}
+.select2-search input {
+	background-position: 100% -21px !important;
+	padding: 12px !important;
+	border-radius: 0 !important;
+	border: none !important;
+}
+
+.select2-choices .select2-search-choice {
+	line-height: 20px !important;
+	padding-left: 5px !important;
+}
+.select2-choices .select2-search-choice-close {
+	display: none !important;
+}
+.select2-choices .select2-search-field input {
+	line-height: 20px !important;
+}
+
+.select2-container-multi .select2-choices .select2-search-choice {
+	background-color: #f8f8f8 !important;
+	border-color: #f8f8f8 !important;
+	box-shadow: none !important;
+	background-image: none !important;
+}
+.select2-results .select2-highlighted {
+	background-color: #f8f8f8 !important;
+	color: #000 !important;
+}
+
+.select2-container-multi.select2-container-active .select2-choices,
+.select2-drop-active {
+	border-color: #ddd !important;
+}
+.select2-container-multi.select2-container-active .select2-choices {
+	-webkit-box-shadow: none !important;
+	box-shadow: none !important;
+}
+
+#select2-drop .avatar,
+.select2-chosen .avatar {
+	display: inline-block;
+	margin-right: 8px;
+	vertical-align: middle;
+}
+
+.select2-results .select2-no-results,
+.select2-results .select2-searching,
+.select2-results .select2-selection-limit {
+	background: #fff !important;
+	padding: 12px !important;
+}
+
 
 
 /* jQuery UI fixes */
@@ -255,6 +354,7 @@ select:hover {
     border: none !important;
     background: #f8f8f8 !important;
 }
+
 
 
 /* correctly align images inside of buttons */

--- a/core/css/systemtags.css
+++ b/core/css/systemtags.css
@@ -7,21 +7,7 @@
  * See the COPYING-README file.
  *
  */
-.systemtags-select2-dropdown .select2-selected {
-	display: list-item;
-	background-color: #f8f8f8;
-}
-.systemtags-select2-dropdown .select2-highlighted,
-.systemtags-select2-dropdown .select2-selected.select2-highlighted {
-	background: #f8f8f8;
-}
 
-.select2-result {
-	position: relative;
-}
-.systemtags-select2-dropdown .select2-highlighted {
-	color: #000000;
-}
 .systemtags-select2-dropdown .select2-result-label .checkmark {
 	visibility: hidden;
 }
@@ -44,8 +30,7 @@
 
 .systemtags-select2-dropdown .systemtags-actions {
 	position: absolute;
-	right: 0;
-	top: 3px;
+	right: 5px;
 }
 
 .systemtags-select2-dropdown .systemtags-rename-form {
@@ -57,62 +42,18 @@
 	width: 100%;
 }
 
-.systemtags-select2-container .select2-choices {
-	white-space: nowrap;
-	text-overflow: ellipsis;
-	background: #fff;
-	color: #555;
-	box-sizing: content-box;
-	border-radius: 3px;
-	border: 1px solid #ddd;
-	margin: 3px 3px 3px 0;
-	padding: 2px 0;
-	min-height: auto;
-}
-
-.systemtags-select2-container .select2-choices .select2-search-choice {
-	line-height: 20px;
-	padding-left: 5px;
-}
 
 .systemtags-select2-container .select2-choices .select2-search-choice.select2-locked .label {
 	opacity: 0.5;
 }
 
-.systemtags-select2-container .select2-choices .select2-search-choice-close {
-	display: none;
-}
-.systemtags-select2-container .select2-choices .select2-search-field input {
-	line-height: 20px;
-}
-.systemtags-select2-dropdown  .label {
+.systemtags-select2-dropdown .label {
 	width:85%;
 	display:-moz-inline-box;
 	display:inline-block;
 	overflow:hidden;
 	text-overflow:ellipsis;
 }
-
-.systemtags-select2-dropdown  .label.hidden {
+.systemtags-select2-dropdown .label.hidden {
 	display: none;
-}
-
-.select2-container-multi .select2-choices .select2-search-choice {
-	background-color: rgba(240,240,240,.9);
-	border-color: rgba(240,240,240,.9);
-	box-shadow: none;
-	background-image: none;
-}
-.select2-results .select2-highlighted {
-	background-color: rgba(240,240,240,.9);
-	color: #000;
-}
-
-.select2-container-multi.select2-container-active .select2-choices,
-.select2-drop-active {
-	border-color: #ddd;
-}
-.select2-container-multi.select2-container-active .select2-choices {
-	-webkit-box-shadow: none;
-	box-shadow: none;
 }

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -663,12 +663,3 @@ doesnotexist:-o-prefocus, .strengthify-wrapper {
 #warning {
 	color: red;
 }
-
-/* SELECT */
-
-.select2-container-multi .select2-choices .select2-search-choice {
-	background-color: rgba(240,240,240,.9)!important;
-	border-color: rgba(240,240,240,.9)!important;
-	box-shadow: none!important;
-	background-image: none!important;
-}


### PR DESCRIPTION
Before & after: Much more breathing space, less complexity and lines, nice Nextcloud style, and proper connection to the input field:
![capture du 2016-10-18 19-46-21](https://cloud.githubusercontent.com/assets/925062/19489481/bab175ee-956b-11e6-9872-fbb433c5fa21.png)![capture du 2016-10-18 19-54-38](https://cloud.githubusercontent.com/assets/925062/19489744/ba498a82-956c-11e6-87e2-13ade8b4442d.png)

Please review @nextcloud/designers @ErikPel @nextcloud/javascript you can test it with:
- System tags in the files sidebar
- Enabling apps only for specific users in apps mgmt
- New person selector in Spreed app: https://github.com/nextcloud/spreed/pull/55

The one problem which still occurs (also with old version) is that the dropdown is about 3 pixels too wide on the right. Any idea @nextcloud/javascript? (NOT A BLOCKER)
