### PR TITLE
Share email to ocs

### DIFF
--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -25,12 +25,6 @@
 					'<div class="avatar {{#if modSeed}}imageplaceholderseed{{/if}}" data-username="{{shareWith}}" {{#if modSeed}}data-seed="{{shareWith}} {{shareType}}"{{/if}}></div>' +
 					'{{/if}}' +
 					'<span class="has-tooltip username" title="{{shareWith}}">{{shareWithDisplayName}}</span>' +
-					'{{#if mailNotificationEnabled}}  {{#unless isRemoteShare}}' +
-					'<span class="shareOption">' +
-						'<input id="mail-{{cid}}-{{shareWith}}" type="checkbox" name="mailNotification" class="mailNotification checkbox" {{#if wasMailSent}}checked="checked"{{/if}} />' +
-						'<label for="mail-{{cid}}-{{shareWith}}">{{notifyByMailLabel}}</label>' +
-					'</span>' +
-					'{{/unless}} {{/if}}' +
 					'<span class="sharingOptionsGroup">' +
 						'{{#if editPermissionPossible}}' +
 						'<span class="shareOption">' +
@@ -122,7 +116,6 @@
 			'click .unshare': 'onUnshare',
 			'click .icon-more': 'onToggleMenu',
 			'click .permissions': 'onPermissionChange',
-			'click .mailNotification': 'onSendMailNotification'
 		},
 
 		initialize: function(options) {
@@ -175,7 +168,6 @@
 		getShareeList: function() {
 			var universal = {
 				avatarEnabled: this.configModel.areAvatarsEnabled(),
-				mailNotificationEnabled: this.configModel.isMailNotificationEnabled(),
 				notifyByMailLabel: t('core', 'notify by email'),
 				unshareLabel: t('core', 'Unshare'),
 				canShareLabel: t('core', 'can reshare'),
@@ -371,15 +363,6 @@
 
 			this.model.updateShare(shareId, {permissions: permissions});
 		},
-
-		onSendMailNotification: function(event) {
-			var $target = $(event.target);
-			var $li = $(event.target).closest('li[data-share-id]');
-			var shareType = $li.data('share-type');
-			var shareWith = $li.attr('data-share-with');
-
-			this.model.sendNotificationForShare(shareType, shareWith, $target.is(':checked'));
-		}
 	});
 
 	OC.Share.ShareDialogShareeListView = ShareDialogShareeListView;

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -427,35 +427,6 @@
 		},
 
 		/**
-		 * Sends an email notification for the given share
-		 *
-		 * @param {int} shareType share type
-		 * @param {string} shareWith recipient
-		 * @param {bool} state whether to set the notification flag or remove it
-		 */
-		sendNotificationForShare: function(shareType, shareWith, state) {
-			var itemType = this.get('itemType');
-			var itemSource = this.get('itemSource');
-
-			return $.post(
-				OC.generateUrl('core/ajax/share.php'),
-				{
-					action: state ? 'informRecipients' : 'informRecipientsDisabled',
-					recipient: shareWith,
-					shareType: shareType,
-					itemSource: itemSource,
-					itemType: itemType
-				},
-				function(result) {
-					if (result.status !== 'success') {
-						// FIXME: a model should not show dialogs
-						OC.dialogs.alert(t('core', result.data.message), t('core', 'Warning'));
-					}
-				}
-			);
-		},
-
-		/**
 		 * Send the link share information by email
 		 *
 		 * @param {string} recipientEmail recipient email address

--- a/core/js/tests/specs/sharedialogshareelistview.js
+++ b/core/js/tests/specs/sharedialogshareelistview.js
@@ -139,23 +139,6 @@ describe('OC.Share.ShareDialogShareeListView', function () {
 			listView.$el.find('a.showCruds').click();
 			expect(listView.$el.find('li.cruds').hasClass('hidden')).toEqual(false);
 		});
-
-		it('sends notification to user when checkbox clicked', function () {
-			shareModel.set('shares', [{
-				id: 100,
-				item_source: 123,
-				permissions: 1,
-				share_type: OC.Share.SHARE_TYPE_USER,
-				share_with: 'user1',
-				share_with_displayname: 'User One'
-			}]);
-			listView.render();
-			var notificationStub = sinon.stub(listView.model, 'sendNotificationForShare');
-			listView.$el.find("input[name='mailNotification']").click();
-			expect(notificationStub.called).toEqual(true);
-			notificationStub.restore();
-		});
-
 	});
 
 });

--- a/settings/templates/admin/sharing.php
+++ b/settings/templates/admin/sharing.php
@@ -55,10 +55,6 @@
 			   value="1" <?php if ($_['shareDefaultExpireDateSet'] === 'yes') print_unescaped('checked="checked"'); ?> />
 		<label for="shareapiDefaultExpireDate"><?php p($l->t('Set default expiration date'));?></label><br/>
 
-		<input type="checkbox" name="shareapi_allow_public_notification" id="allowPublicMailNotification" class="checkbox"
-			   value="1" <?php if ($_['allowPublicMailNotification'] == 'yes') print_unescaped('checked="checked"'); ?> />
-		<label for="allowPublicMailNotification"><?php p($l->t('Allow users to send mail notification for shared files'));?></label><br/>
-
 	</p>
 	<p id="setDefaultExpireDate" class="double-indent <?php if ($_['allowLinks'] !== 'yes' || $_['shareDefaultExpireDateSet'] === 'no' || $_['shareAPIEnabled'] === 'no') p('hidden');?>">
 		<?php p($l->t( 'Expire after ' )); ?>

--- a/tests/lib/Share/MailNotificationsTest.php
+++ b/tests/lib/Share/MailNotificationsTest.php
@@ -208,54 +208,6 @@ class MailNotificationsTest extends \Test\TestCase {
 		$this->assertSame(['lukas@owncloud.com'], $mailNotifications->sendLinkShareMail('lukas@owncloud.com', 'MyFile', 'https://owncloud.com/file/?foo=bar', 3600));
 	}
 
-	public function testSendInternalShareMail() {
-		$this->setupMailerMock('TestUser shared »welcome.txt« with you', ['recipient@owncloud.com' => 'Recipient'], false);
-
-		/** @var MailNotifications | \PHPUnit_Framework_MockObject_MockObject $mailNotifications */
-		$mailNotifications = $this->getMockBuilder(MailNotifications::class)
-			->setMethods(['getItemSharedWithUser'])
-			->setConstructorArgs([
-				$this->user,
-				$this->l10n,
-				$this->mailer,
-				$this->logger,
-				$this->defaults,
-				$this->urlGenerator
-			])
-			->getMock();
-
-		$mailNotifications->method('getItemSharedWithUser')
-			->withAnyParameters()
-			->willReturn([
-				['file_target' => '/welcome.txt', 'item_source' => 123],
-			]);
-
-		$recipient = $this->getMockBuilder('\OCP\IUser')
-				->disableOriginalConstructor()->getMock();
-		$recipient
-				->expects($this->once())
-				->method('getEMailAddress')
-				->willReturn('recipient@owncloud.com');
-		$recipient
-				->expects($this->once())
-				->method('getDisplayName')
-				->willReturn('Recipient');
-
-		$this->urlGenerator->expects($this->once())
-			->method('linkToRouteAbsolute')
-			->with(
-				$this->equalTo('files.viewcontroller.showFile'),
-				$this->equalTo([
-					'fileId' => 123,
-				])
-			);
-
-		$recipientList = [$recipient];
-		$result = $mailNotifications->sendInternalShareMail($recipientList, '3', 'file');
-		$this->assertSame([], $result);
-
-	}
-
 	/**
 	 * @param string $subject
 	 */


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/1277
- Adds a new endpoint to send email for a link share
- Removed the possibility to notify recipients of a share
  - They can configure themselfs if they want notifications
  - Long term plan is still to also accept local shares
  - Would require adding a new endpoint that we'd have to support for long time

Currently we use the mailer as is. Which is not really testable. But I want a working version in sooner rather than later.

CC: @MorrisJobke @nickvergessen @LukasReschke @icewind1991 
