### PR TITLE
Expose the needupgrade status (#26209)

### DIFF
--- a/status.php
+++ b/status.php
@@ -41,6 +41,7 @@ try {
 	$values=array(
 		'installed'=>$installed,
 		'maintenance' => $maintenance,
+		'needsDbUpgrade' => \OCP\Util::needUpgrade(),
 		'version'=>implode('.', \OCP\Util::getVersion()),
 		'versionstring'=>OC_Util::getVersionString(),
 		'edition'=> '',


### PR DESCRIPTION
During upgrades, before the DB migration is complete, the system is not
usable, but there's no way for monitoring systems to detect this.
Add the 'needupgrade' field to the status json so monitoring systems can
detect this.

From: https://github.com/owncloud/core/pull/26209
By: @kprovost 

CC: @nickvergessen @MorrisJobke @LukasReschke 
