### PR TITLE
Allow 4byte unicode filenames on supported platforms

### DIFF
--- a/lib/private/AppFramework/Db/Db.php
+++ b/lib/private/AppFramework/Db/Db.php
@@ -31,6 +31,7 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDb;
 use OCP\IDBConnection;
 use OCP\PreConditionNotMetException;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 
 /**
  * @deprecated use IDBConnection directly, will be removed in ownCloud 10
@@ -299,5 +300,15 @@ class Db implements IDb {
 	 */
 	public function escapeLikeParameter($param) {
 		return $this->connection->escapeLikeParameter($param);
+	}
+
+	/**
+	 * Check whether or not the current database support 4byte wide unicode
+	 *
+	 * @return bool
+	 * @since 9.2.0
+	 */
+	public function supports4ByteText() {
+		return $this->connection->supports4ByteText();
 	}
 }

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -33,6 +33,7 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use OC\DB\QueryBuilder\QueryBuilder;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
@@ -401,5 +402,15 @@ class Connection extends \Doctrine\DBAL\Connection implements IDBConnection {
 	 */
 	public function escapeLikeParameter($param) {
 		return addcslashes($param, '\\_%');
+	}
+
+	/**
+	 * Check whether or not the current database support 4byte wide unicode
+	 *
+	 * @return bool
+	 * @since 9.2.0
+	 */
+	public function supports4ByteText() {
+		return ! ($this->getDatabasePlatform() instanceof MySqlPlatform && $this->getParams()['charset'] !== 'utf8mb4');
 	}
 }

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1806,13 +1806,15 @@ class View {
 			throw new InvalidPathException($l10n->t('Dot files are not allowed'));
 		}
 
-		// verify database - e.g. mysql only 3-byte chars
-		if (preg_match('%(?:
+		if (!\OC::$server->getDatabaseConnection()->supports4ByteText()) {
+			// verify database - e.g. mysql only 3-byte chars
+			if (preg_match('%(?:
       \xF0[\x90-\xBF][\x80-\xBF]{2}      # planes 1-3
     | [\xF1-\xF3][\x80-\xBF]{3}          # planes 4-15
     | \xF4[\x80-\x8F][\x80-\xBF]{2}      # plane 16
 )%xs', $fileName)) {
-			throw new InvalidPathException($l10n->t('4-byte characters are not supported in file names'));
+				throw new InvalidPathException($l10n->t('4-byte characters are not supported in file names'));
+			}
 		}
 
 		try {

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -251,4 +251,12 @@ interface IDBConnection {
 	 * @since 9.0.0
 	 */
 	public function escapeLikeParameter($param);
+
+	/**
+	 * Check whether or not the current database support 4byte wide unicode
+	 *
+	 * @return bool
+	 * @since 9.2.0
+	 */
+	public function supports4ByteText();
 }

--- a/tests/lib/Files/PathVerificationTest.php
+++ b/tests/lib/Files/PathVerificationTest.php
@@ -9,6 +9,7 @@ namespace Test\Files;
 
 use OC\Files\Storage\Local;
 use OC\Files\View;
+use OCP\Files\InvalidPathException;
 
 /**
  * Class PathVerificationTest
@@ -79,10 +80,15 @@ class PathVerificationTest extends \Test\TestCase {
 
 	/**
 	 * @dataProvider providesAstralPlane
-	 * @expectedException \OCP\Files\InvalidPathException
-	 * @expectedExceptionMessage 4-byte characters are not supported in file names
 	 */
 	public function testPathVerificationAstralPlane($fileName) {
+		$connection = \OC::$server->getDatabaseConnection();
+
+		if (!$connection->supports4ByteText()) {
+			$this->expectException(InvalidPathException::class);
+			$this->expectExceptionMessage('4-byte characters are not supported in file names');
+		}
+
 		$this->view->verifyPath('', $fileName);
 	}
 


### PR DESCRIPTION
Tested with postgres, sqlite and mysql with and without utf8mb4 (without not allowing 💩 in filenames as expected)

cc @nickvergessen @MorrisJobke 
