### PR TITLE
Fix post_unshareFromSelf hook parameter format

### DIFF
--- a/apps/files_sharing/tests/GroupEtagPropagationTest.php
+++ b/apps/files_sharing/tests/GroupEtagPropagationTest.php
@@ -122,4 +122,26 @@ class GroupEtagPropagationTest extends PropagationTestCase {
 
 		$this->assertAllUnchanged();
 	}
+
+	public function testRecipientUnsharesFromSelf() {
+		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue(
+			$this->rootView->unlink('/' . self::TEST_FILES_SHARING_API_USER2 . '/files/test')
+		);
+		$this->assertEtagsChanged([self::TEST_FILES_SHARING_API_USER2]);
+
+		$this->assertAllUnchanged();
+	}
+
+	public function testRecipientUnsharesFromSelfUniqueGroupShare() {
+		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER2);
+		// rename to create an extra entry in the share table
+		$this->rootView->rename('/' . self::TEST_FILES_SHARING_API_USER2 . '/files/test', '/' . self::TEST_FILES_SHARING_API_USER2 . '/files/test_renamed');
+		$this->assertTrue(
+			$this->rootView->unlink('/' . self::TEST_FILES_SHARING_API_USER2 . '/files/test_renamed')
+		);
+		$this->assertEtagsChanged([self::TEST_FILES_SHARING_API_USER2]);
+
+		$this->assertAllUnchanged();
+	}
 }

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -1059,7 +1059,7 @@ class Share extends Constants {
 			if (isset($groupShare['file_target'])) {
 				$shareTmp['fileTarget'] = $groupShare['file_target'];
 			}
-			$listOfUnsharedItems = array_merge($listOfUnsharedItems, array($groupShare));
+			$listOfUnsharedItems = array_merge($listOfUnsharedItems, [$shareTmp]);
 			$itemUnshared = true;
 		} elseif (!$itemUnshared && isset($uniqueGroupShare)) {
 			$query = \OC_DB::prepare('UPDATE `*PREFIX*share` SET `permissions` = ? WHERE `id` = ?');
@@ -1074,7 +1074,7 @@ class Share extends Constants {
 			if (isset($uniqueGroupShare['file_target'])) {
 				$shareTmp['fileTarget'] = $uniqueGroupShare['file_target'];
 			}
-			$listOfUnsharedItems = array_merge($listOfUnsharedItems, array($uniqueGroupShare));
+			$listOfUnsharedItems = array_merge($listOfUnsharedItems, [$shareTmp]);
 			$itemUnshared = true;
 		}
 


### PR DESCRIPTION
When unsharing from self in a group share situation, the share items
passed to the post_unshareFromSelf hook were using the wrong format in
which the attribute names (ex: "share_type") have non camel-case format.

This fix makes sure that in group sharing case we use the correct
format. It looks like the code was already producing it but in
array_merge it was not using it and adding the unprocessed one.
- downstream of https://github.com/owncloud/core/pull/26391
- tested with an unshare from a group - works as expected

cc @rullzer @nickvergessen @schiessle @icewind1991 
