### PR TITLE
Avatar picker improvements

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -30,9 +30,39 @@ input#openid, input#webdav { width:20em; }
 }
 #avatar #cropper {
 	float: left;
-	background-color: #fff;
 	z-index: 500;
-	position: relative;
+	/* float cropper above settings page to prevent unexpected flowing from dynamically sized element */
+	position: fixed;
+	background-color: rgba(0, 0, 0, .2);
+	/*opacity: .20;*/
+	box-sizing: border-box;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	padding-top: 45px;
+	text-align: center;
+}
+#avatar #cropper .inner-container {
+	display: inline-block;
+	margin-top: 160px;
+	margin-left: 30px;
+	background: #fff;
+	color: #333;
+	border-radius: 3px;
+	box-shadow: 0 0 7px #888;
+	padding: 15px;
+	text-align: left;
+}
+
+#avatar #cropper .inner-container .jcrop-holder {
+	box-shadow: 0 0 7px #888;
+}
+#avatar #cropper .inner-container .button {
+	margin-top: 15px;
+}
+#avatar #cropper .inner-container .primary {
+	float: right;
 }
 
 #displaynameform,

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -34,25 +34,23 @@ input#openid, input#webdav { width:20em; }
 	/* float cropper above settings page to prevent unexpected flowing from dynamically sized element */
 	position: fixed;
 	background-color: rgba(0, 0, 0, .2);
-	/*opacity: .20;*/
 	box-sizing: border-box;
-	top: 0;
+	top: 45px;
 	left: 0;
 	width: 100%;
-	height: 100%;
-	padding-top: 45px;
-	text-align: center;
+	height: calc(100% - 45px);
 }
 #avatar #cropper .inner-container {
-	display: inline-block;
-	margin-top: 160px;
-	margin-left: 30px;
+	z-index: 2001; /* above the top bar if needed */
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
 	background: #fff;
 	color: #333;
 	border-radius: 3px;
 	box-shadow: 0 0 7px #888;
 	padding: 15px;
-	text-align: left;
 }
 
 #avatar #cropper .inner-container .jcrop-holder {

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -130,8 +130,8 @@ function updateAvatar (hidedefault) {
 function showAvatarCropper () {
 	var $cropper = $('#cropper');
 	var $cropperImage = $('<img/>');
-	$cropperImage.css('opacity', 0);
-	$cropper.prepend($cropperImage);
+	$cropperImage.css('opacity', 0); // prevent showing the unresized image
+	$cropper.children('.inner-container').prepend($cropperImage);
 
 	$cropperImage.attr('src',
 		OC.generateUrl('/avatar/tmp') + '?requesttoken=' + encodeURIComponent(oc_requesttoken) + '#' + Math.floor(Math.random() * 1000));
@@ -148,8 +148,6 @@ function showAvatarCropper () {
 			boxHeight: 500,
 			boxWidth: 500,
 			setSelect: [0, 0, 300, 300]
-		}, function() {
-			$cropperImage.css('opacity', 1);
 		});
 	});
 }

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -129,8 +129,9 @@ function updateAvatar (hidedefault) {
 
 function showAvatarCropper () {
 	var $cropper = $('#cropper');
-	$cropper.prepend("<img>");
-	var $cropperImage = $('#cropper img');
+	var $cropperImage = $('<img/>');
+	$cropperImage.css('opacity', 0);
+	$cropper.prepend($cropperImage);
 
 	$cropperImage.attr('src',
 		OC.generateUrl('/avatar/tmp') + '?requesttoken=' + encodeURIComponent(oc_requesttoken) + '#' + Math.floor(Math.random() * 1000));
@@ -147,6 +148,8 @@ function showAvatarCropper () {
 			boxHeight: 500,
 			boxWidth: 500,
 			setSelect: [0, 0, 300, 300]
+		}, function() {
+			$cropperImage.css('opacity', 1);
 		});
 	});
 }

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -139,7 +139,6 @@ function showAvatarCropper () {
 	// Looks weird, but on('load', ...) doesn't work in IE8
 	$cropperImage.ready(function () {
 		$('#displayavatar').hide();
-		$cropper.show();
 
 		$cropperImage.Jcrop({
 			onChange: saveCoords,
@@ -148,6 +147,8 @@ function showAvatarCropper () {
 			boxHeight: 500,
 			boxWidth: 500,
 			setSelect: [0, 0, 300, 300]
+		}, function() {
+			$cropper.show();
 		});
 	});
 }

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -139,16 +139,18 @@ function showAvatarCropper () {
 	$cropperImage.attr('src',
 		OC.generateUrl('/avatar/tmp') + '?requesttoken=' + encodeURIComponent(oc_requesttoken) + '#' + Math.floor(Math.random() * 1000));
 
-	// Looks weird, but on('load', ...) doesn't work in IE8
-	$cropperImage.ready(function () {
-
+	$cropperImage.load(function () {
+		var img = $cropperImage.get()[0];
+		var selectSize = Math.min(img.width, img.height);
+		var offsetX = (img.width - selectSize) / 2;
+		var offsetY = (img.height - selectSize) / 2;
 		$cropperImage.Jcrop({
 			onChange: saveCoords,
 			onSelect: saveCoords,
 			aspectRatio: 1,
 			boxHeight: 500,
 			boxWidth: 500,
-			setSelect: [0, 0, 300, 300]
+			setSelect: [offsetX, offsetY, selectSize, selectSize]
 		}, function() {
 			$cropper.show();
 		});

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -148,8 +148,8 @@ function showAvatarCropper () {
 			onChange: saveCoords,
 			onSelect: saveCoords,
 			aspectRatio: 1,
-			boxHeight: 500,
-			boxWidth: 500,
+			boxHeight: Math.min(500, $('#app-content').height() -100),
+			boxWidth: Math.min(500, $('#app-content').width()),
 			setSelect: [offsetX, offsetY, selectSize, selectSize]
 		}, function() {
 			$cropper.show();

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -112,7 +112,10 @@ function updateAvatar (hidedefault) {
 		$('#header .avatardiv').addClass('avatardiv-shown');
 	}
 	$displaydiv.css({'background-color': ''});
-	$displaydiv.avatar(OC.currentUser, 145, true);
+	$displaydiv.avatar(OC.currentUser, 145, true, null, function() {
+		$displaydiv.removeClass('loading');
+		$('#displayavatar img').show();
+	});
 	$.get(OC.generateUrl(
 		'/avatar/{user}/{size}',
 		{
@@ -138,7 +141,6 @@ function showAvatarCropper () {
 
 	// Looks weird, but on('load', ...) doesn't work in IE8
 	$cropperImage.ready(function () {
-		$('#displayavatar').hide();
 
 		$cropperImage.Jcrop({
 			onChange: saveCoords,
@@ -295,6 +297,8 @@ $(document).ready(function () {
 			avatarResponseHandler(response);
 		},
 		submit: function(e, data) {
+			$('#displayavatar img').hide();
+			$('#displayavatar .avatardiv').addClass('loading');
 			data.formData = _.extend(data.formData || {}, {
 				requesttoken: OC.requestToken
 			});
@@ -321,6 +325,8 @@ $(document).ready(function () {
 		OC.dialogs.filepicker(
 			t('settings', "Select a profile picture"),
 			function (path) {
+				$('#displayavatar img').hide();
+				$('#displayavatar .avatardiv').addClass('loading');
 				$.ajax({
 					type: "POST",
 					url: OC.generateUrl('/avatar/'),
@@ -358,6 +364,8 @@ $(document).ready(function () {
 	});
 
 	$('#abortcropperbutton').click(function () {
+		$('#displayavatar .avatardiv').removeClass('loading');
+		$('#displayavatar img').show();
 		cleanCropper();
 	});
 

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -50,8 +50,10 @@
 	</div>
 
 	<div id="cropper" class="hidden">
-		<div class="inlineblock button" id="abortcropperbutton"><?php p($l->t('Cancel')); ?></div>
-		<div class="inlineblock button primary" id="sendcropperbutton"><?php p($l->t('Choose as profile picture')); ?></div>
+		<div class="inner-container">
+			<div class="inlineblock button" id="abortcropperbutton"><?php p($l->t('Cancel')); ?></div>
+			<div class="inlineblock button primary" id="sendcropperbutton"><?php p($l->t('Choose as profile picture')); ?></div>
+		</div>
 	</div>
 </form>
 <?php endif; ?>


### PR DESCRIPTION
- Don't flash the full size image before the cropper can load
- Float the cropper over the page instead of the awkward, half overlapping, half messing with the layout it was before
- Hide the cropper dialog until it's loaded
- Show spinner while while loading/cropping the avatar

Before:

![](https://i.imgur.com/UcP8YXN.png)

After:

![](https://i.imgur.com/GOEz9KH.png?1)

cc @nextcloud/designers 
