### PR TITLE
Add focus to autofocus form element on slide toggle

### DIFF
--- a/core/js/apps.js
+++ b/core/js/apps.js
@@ -79,6 +79,10 @@
 					area.slideDown(OC.menuSpeed*4, function() {
 						area.trigger(new $.Event('show'));
 					});
+					var input = $(areaSelector + ' [autofocus]');
+					if (input.length === 1) {
+						input.focus();
+					}
 				}
 
 				// do nothing if the area is animated


### PR DESCRIPTION
This improves ux, when a ui element (`<input>`) has set `autofocus`. When shown, the element is focused, which saves a click on that element.

In particular this improves the new calendar dialog in the calendar app, because the cursor is right where you want to type.

<img width="505" alt="bildschirmfoto 2016-10-22 um 12 04 38" src="https://cloud.githubusercontent.com/assets/1899308/19619326/b2247c72-9864-11e6-9d7a-0527ec2deef4.png">

I would like to discuss, if there might be a better option. We could for example introduce an attribute (e.g `data-focus-after-toggle`), where you could define the element which should gain focus, because now you need the element to set autofocus to, which may be unwanted.

@nextcloud/calendar What are your thoughts on this? 
Are there other apps affected by this?
