### PR TITLE
fix /nc/ocs/* urls

### DIFF
--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -166,8 +166,12 @@ class Router implements IRouter {
 
 			// Also add the OCS collection
 			$collection = $this->getCollection('root.ocs');
+			$ocsCollection = clone $collection;
 			$collection->addPrefix('/ocsapp');
 			$this->root->addCollection($collection);
+
+			$ocsCollection->addPrefix('/ocs');
+			$this->root->addCollection($ocsCollection);
 		}
 		if ($this->loaded) {
 			// include ocs routes, must be loaded last for /ocs prefix


### PR DESCRIPTION
https://github.com/nextcloud/server/pull/777 broke login in from the mobile app which sends a request to `example.com/nextcloud/ocs/cloud/user`, with #777 it only works on `/ocsapp/cloud/user`, this adds compatibility for the `/ocs/*` urls for the core ocs routes

cc @rullzer 
