### PR TITLE
Add ShareesAPI E-mail search

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -83,10 +83,12 @@ class ShareesAPIController extends OCSController {
 			'users' => [],
 			'groups' => [],
 			'remotes' => [],
+			'emails' => [],
 		],
 		'users' => [],
 		'groups' => [],
 		'remotes' => [],
+		'emails' => [],
 	];
 
 	protected $reachedEndFor = [];
@@ -403,6 +405,68 @@ class ShareesAPIController extends OCSController {
 	}
 
 	/**
+	 * @param string $search
+	 */
+	protected function getEmails($search) {
+		$this->result['emails'] = [];
+		$this->result['exact']['emails'] = [];
+
+		$foundEmail = false;
+
+		// Search in contacts
+		//@todo Pagination missing
+		$addressBookContacts = $this->contactsManager->search($search, ['FN', 'EMAIL']);
+		foreach ($addressBookContacts as $contact) {
+			if (!isset($contact['EMAIL'])) {
+				continue;
+			}
+
+			$emails = $contact['EMAIL'];
+			if (!is_array($emails)) {
+				$emails = [$emails];
+			}
+
+			foreach ($emails as $email) {
+				if (strtolower($search) === strtolower($contact['FN']) ||
+					strtolower($search) === strtolower($email)
+				) {
+					if (strtolower($search) === strtolower($email)) {
+						$foundEmail = true;
+					}
+
+					$this->result['exact']['emails'][] = [
+						'label' => $contact['FN'],
+						'value' => [
+							'shareType' => Share::SHARE_TYPE_EMAIL,
+							'shareWith' => $email,
+						],
+					];
+				} else if ($this->shareeEnumeration) {
+					$this->result['emails'][] = [
+						'label' => $contact['FN'],
+						'value' => [
+							'shareType' => Share::SHARE_TYPE_EMAIL,
+							'shareWith' => $email,
+						],
+					];
+				}
+			}
+		}
+
+		if (!$foundEmail && substr_count($search, '@') >= 1 && $this->offset === 0) {
+			$this->result['exact']['emails'][] = [
+				'label' => $search,
+				'value' => [
+					'shareType' => Share::SHARE_TYPE_EMAIL,
+					'shareWith' => $search,
+				],
+			];
+		}
+
+		$this->reachedEndFor[] = 'emails';
+	}
+
+	/**
 	 * @NoAdminRequired
 	 *
 	 * @param string $search
@@ -429,6 +493,7 @@ class ShareesAPIController extends OCSController {
 			$shareTypes[] = Share::SHARE_TYPE_GROUP;
 		}
 
+		$shareTypes[] = Share::SHARE_TYPE_EMAIL;
 		$shareTypes[] = Share::SHARE_TYPE_REMOTE;
 
 		if (is_array($shareType)) {
@@ -497,6 +562,11 @@ class ShareesAPIController extends OCSController {
 		// Get remote
 		if (in_array(Share::SHARE_TYPE_REMOTE, $shareTypes)) {
 			$this->getRemote($search);
+		}
+
+		// Get email
+		if (in_array(Share::SHARE_TYPE_EMAIL, $shareTypes)) {
+			$this->getEmails($search);
 		}
 
 		$response = new Http\DataResponse($this->result);


### PR DESCRIPTION
- Allow to search for SHARE_TYPE_EMAIL (4)
- Added tests

Needed for https://github.com/nextcloud/server/pull/1801

@nickvergessen as discussed
@schiessle this is probabaly also usefull for https://github.com/nextcloud/server/pull/657

Please review

CC: @LukasReschke @MorrisJobke @icewind1991 @blizzz 
