### PR TITLE
log error when setting timezone to UTC fails

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -626,7 +626,7 @@ class OC {
 		@ini_set('log_errors', 1);
 
 		if(!date_default_timezone_set('UTC')) {
-			\OC::$server->getLogger()->error('Could not set timezone to UTC');
+			throw new \RuntimeException('Could not set timezone to UTC');
 		};
 
 		//try to configure php to enable big file uploads.

--- a/lib/base.php
+++ b/lib/base.php
@@ -625,7 +625,9 @@ class OC {
 		@ini_set('display_errors', 0);
 		@ini_set('log_errors', 1);
 
-		date_default_timezone_set('UTC');
+		if(!date_default_timezone_set('UTC')) {
+			\OC::$server->getLogger()->error('Could not set timezone to UTC');
+		};
 
 		//try to configure php to enable big file uploads.
 		//this doesn´t work always depending on the webserver and php configuration.


### PR DESCRIPTION
- https://github.com/owncloud/core/pull/26354
- I changed the behaviour to throw an exception instead (which is also logged), because the logger causes the session to be initialized, but it is too early in the request cycle for this so it will cause other issues later anyway:

```
{"reqId":"ewks8J0ntN8CFb2NrEZX","remoteAddr":"::1","app":"no app in context","message":"Could not set timezone to UTC","level":3,"time":"2016-10-24T13:01:26+00:00","method":"GET","url":"\/server\/index.php\/apps\/files\/","user":"--","version":"9.2.0.4"}
{"reqId":"ewks8J0ntN8CFb2NrEZX","remoteAddr":"::1","app":"index","message":"Exception: {\"Exception\":\"Exception\",\"Message\":\"Session has been closed - no further changes to the session are allowed\",\"Code\":0,\"Trace\":\"#0 \\\/Users\\\/morrisjobke\\\/Projects\\\/nextcloud\\\/server\\\/lib\\\/private\\\/Session\\\/Memory.php(53): OC\\\\Session\\\\Memory->validateSession()\\n#1 \\\/Users\\\/morrisjobke\\\/Projects\\\/nextcloud\\\/server\\\/lib\\\/private\\\/Security\\\/CSRF\\\/TokenStorage\\\/SessionStorage.php(64): OC\\\\Session\\\\Memory->set('requesttoken', 'JC7jm151ExVnRMb...')\\n#2 \\\/Users\\\/morrisjobke\\\/Projects\\\/nextcloud\\\/server\\\/lib\\\/private\\\/Security\\\/CSRF\\\/CsrfTokenManager.php(58): OC\\\\Security\\\\CSRF\\\\TokenStorage\\\\SessionStorage->setToken('JC7jm151ExVnRMb...')\\n#3 \\\/Users\\\/morrisjobke\\\/Projects\\\/nextcloud\\\/server\\\/lib\\\/public\\\/Util.php(507): OC\\\\Security\\\\CSRF\\\\CsrfTokenManager->getToken(*** sensitive parameters replaced ***)\\n#4 \\\/Users\\\/morrisjobke\\\/Projects\\\/nextcloud\\\/server\\\/lib\\\/private\\\/AppFramework\\\/Middleware\\\/Security\\\/SecurityMiddleware.php(148): OCP\\\\Util::callRegister()\\n#5 \\\/Users\\\/morrisjobke\\\/Projects\\\/nextcloud\\\/server\\\/lib\\\/private\\\/AppFramework\\\/Middleware\\\/MiddlewareDispatcher.php(94): OC\\\\AppFramework\\\\Middleware\\\\Security\\\\SecurityMiddleware->beforeController(Object(OCA\\\\Files\\\\Controller\\\\ViewController), 'index')\\n#6 \\\/Users\\\/morrisjobke\\\/Projects\\\/nextcloud\\\/server\\\/lib\\\/private\\\/AppFramework\\\/Http\\\/Dispatcher.php(89): OC\\\\AppFramework\\\\Middleware\\\\MiddlewareDispatcher->beforeController(Object(OCA\\\\Files\\\\Controller\\\\ViewController), 'index')\\n#7 \\\/Users\\\/morrisjobke\\\/Projects\\\/nextcloud\\\/server\\\/lib\\\/private\\\/AppFramework\\\/App.php(114): OC\\\\AppFramework\\\\Http\\\\Dispatcher->dispatch(Object(OCA\\\\Files\\\\Controller\\\\ViewController), 'index')\\n#8 \\\/Users\\\/morrisjobke\\\/Projects\\\/nextcloud\\\/server\\\/lib\\\/private\\\/AppFramework\\\/Routing\\\/RouteActionHandler.php(47): OC\\\\AppFramework\\\\App::main('ViewController', 'index', Object(OC\\\\AppFramework\\\\DependencyInjection\\\\DIContainer), Array)\\n#9 [internal function]: OC\\\\AppFramework\\\\Routing\\\\RouteActionHandler->__invoke(Array)\\n#10 \\\/Users\\\/morrisjobke\\\/Projects\\\/nextcloud\\\/server\\\/lib\\\/private\\\/Route\\\/Router.php(298): call_user_func(Object(OC\\\\AppFramework\\\\Routing\\\\RouteActionHandler), Array)\\n#11 \\\/Users\\\/morrisjobke\\\/Projects\\\/nextcloud\\\/server\\\/lib\\\/base.php(996): OC\\\\Route\\\\Router->match('\\\/apps\\\/files\\\/')\\n#12 \\\/Users\\\/morrisjobke\\\/Projects\\\/nextcloud\\\/server\\\/index.php(40): OC::handleRequest()\\n#13 {main}\",\"File\":\"\\\/Users\\\/morrisjobke\\\/Projects\\\/nextcloud\\\/server\\\/lib\\\/private\\\/Session\\\/Memory.php\",\"Line\":120}","level":3,"time":"2016-10-24T13:01:26+00:00","method":"GET","url":"\/server\/index.php\/apps\/files\/","user":"admin","version":"9.2.0.4"}
```

So I changed it and it now looks like this:

```
{"reqId":"FBckFlQ6bTs5jJyDo3jC","remoteAddr":"::1","app":"index","message":"Exception: {\"Exception\":\"RuntimeException\",\"Message\":\"Could not set timezone to UTC\",\"Code\":0,\"Trace\":\"#0 \\\/Users\\\/morrisjobke\\\/Projects\\\/nextcloud\\\/server\\\/lib\\\/base.php(1073): OC::init()\\n#1 \\\/Users\\\/morrisjobke\\\/Projects\\\/nextcloud\\\/server\\\/index.php(38): require_once('\\\/Users\\\/morrisjo...')\\n#2 {main}\",\"File\":\"\\\/Users\\\/morrisjobke\\\/Projects\\\/nextcloud\\\/server\\\/lib\\\/base.php\",\"Line\":631}","level":3,"time":"2016-10-24T13:02:08+00:00","method":"GET","url":"\/server\/index.php\/apps\/files\/","user":"--","version":"9.2.0.4"}
```

cc @LukasReschke @nickvergessen @rullzer 
