### PR TITLE
Storage 503 message improvements

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
@@ -32,7 +32,7 @@ use Sabre\DAV\Exception;
 use Sabre\HTTP\Response;
 
 class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
-	protected $nonFatalExceptions = array(
+	protected $nonFatalExceptions = [
 		'Sabre\DAV\Exception\NotAuthenticated' => true,
 		// If tokenauth can throw this exception (which is basically as
 		// NotAuthenticated. So not fatal.
@@ -47,7 +47,10 @@ class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
 		// forbidden can be expected when trying to upload to
 		// read-only folders for example
 		'Sabre\DAV\Exception\Forbidden' => true,
-	);
+		// Happens when an external storage or federated share is temporarily
+		// not available
+		'Sabre\DAV\Exception\StorageNotAvailableException' => true,
+	];
 
 	/** @var string */
 	private $appName;

--- a/apps/dav/lib/Connector/Sabre/ObjectTree.php
+++ b/apps/dav/lib/Connector/Sabre/ObjectTree.php
@@ -159,7 +159,7 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			try {
 				$info = $this->fileView->getFileInfo($path);
 			} catch (StorageNotAvailableException $e) {
-				throw new \Sabre\DAV\Exception\ServiceUnavailable('Storage not available');
+				throw new \Sabre\DAV\Exception\ServiceUnavailable('Storage is temporarily not available');
 			} catch (StorageInvalidException $e) {
 				throw new \Sabre\DAV\Exception\NotFound('Storage ' . $path . ' is invalid');
 			} catch (LockedException $e) {

--- a/apps/files/ajax/list.php
+++ b/apps/files/ajax/list.php
@@ -79,12 +79,12 @@ try {
 	OCP\JSON::success(array('data' => $data));
 } catch (\OCP\Files\StorageNotAvailableException $e) {
 	\OCP\Util::logException('files', $e);
-	OCP\JSON::error(array(
-		'data' => array(
+	OCP\JSON::error([
+		'data' => [
 			'exception' => '\OCP\Files\StorageNotAvailableException',
-			'message' => $l->t('Storage not available')
-		)
-	));
+			'message' => $l->t('Storage is temporarily not available')
+		]
+	]);
 } catch (\OCP\Files\StorageInvalidException $e) {
 	\OCP\Util::logException('files', $e);
 	OCP\JSON::error(array(

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1602,7 +1602,7 @@
 					this.changeDirectory('/');
 					// TODO: read error message from exception
 					OC.Notification.showTemporary(
-						t('files', 'Storage not available')
+						t('files', 'Storage is temporarily not available')
 					);
 				}
 				return false;

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2668,7 +2668,7 @@ describe('OCA.Files.FileList tests', function() {
 		});
 		it('redirects to root folder and shows notification in case of storage not available', function () {
 			expect(notificationStub.notCalled).toEqual(true);
-			deferredList.reject(503, 'Storage not available');
+			deferredList.reject(503, 'Storage is temporarily not available');
 
 			expect(fileList.getCurrentDirectory()).toEqual('/');
 			expect(getFolderContentsStub.calledTwice).toEqual(true);

--- a/lib/public/Files/StorageNotAvailableException.php
+++ b/lib/public/Files/StorageNotAvailableException.php
@@ -58,7 +58,7 @@ class StorageNotAvailableException extends HintException {
 	 */
 	public function __construct($message = '', $code = self::STATUS_ERROR, \Exception $previous = null) {
 		$l = \OC::$server->getL10N('core');
-		parent::__construct($message, $l->t('Storage not available'), $code, $previous);
+		parent::__construct($message, $l->t('Storage is temporarily not available'), $code, $previous);
 	}
 
 	/**


### PR DESCRIPTION
"Storage not available" is now "Storage temporarily not available".
Exceptions are now logged in DEBUG level, not FATAL.
- see https://github.com/owncloud/core/pull/26145

cc @ChristophWurst @icewind1991 @nickvergessen @rullzer 
