### PR TITLE
Bring user deletion account

### DIFF
--- a/lib/private/User/Backend.php
+++ b/lib/private/User/Backend.php
@@ -45,6 +45,7 @@ abstract class Backend implements UserInterface {
 	const SET_DISPLAYNAME	= 1048576;		// 1 << 20
 	const PROVIDE_AVATAR	= 16777216;		// 1 << 24
 	const COUNT_USERS		= 268435456;	// 1 << 28
+	const DELETE_USER		= 4294967296;	// 1 << 32
 
 	protected $possibleActions = array(
 		self::CREATE_USER => 'createUser',
@@ -55,6 +56,7 @@ abstract class Backend implements UserInterface {
 		self::SET_DISPLAYNAME => 'setDisplayName',
 		self::PROVIDE_AVATAR => 'canChangeAvatar',
 		self::COUNT_USERS => 'countUsers',
+		self::DELETE_USER => 'deleteUser',
 	);
 
 	/**

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -318,7 +318,7 @@ class User implements IUser {
 	 */
 	public function canDeleteAccount() {
 		// TODO : Change this
-		if (!filter_var($this->config->getAppValue('core', 'user_own_account_deletion', false), FILTER_VALIDATE_BOOLEAN)) {
+		if (!(bool)$this->config->getAppValue('core', 'user_own_account_deletion', 0)) {
 			return false;
 		}
 		return $this->backend->implementsActions(Backend::DELETE_USER);

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -312,6 +312,19 @@ class User implements IUser {
 	}
 
 	/**
+	 * check if the backend supports deleting user
+	 *
+	 * @return bool
+	 */
+	public function canDeleteAccount() {
+		// TODO : Change this
+		if (!filter_var($this->config->getAppValue('core', 'user_own_account_deletion', false), FILTER_VALIDATE_BOOLEAN)) {
+			return false;
+		}
+		return $this->backend->implementsActions(Backend::DELETE_USER);
+	}
+
+	/**
 	 * check if the user is enabled
 	 *
 	 * @return bool

--- a/lib/public/IUser.php
+++ b/lib/public/IUser.php
@@ -133,6 +133,14 @@ interface IUser {
 	public function canChangeDisplayName();
 
 	/**
+	 * check if the backend supports deleting user
+	 *
+	 * @return bool
+	 * @since 11.0.0
+	 */
+	public function canDeleteAccount();
+
+	/**
 	 * check if the user is enabled
 	 *
 	 * @return bool

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -41,6 +41,21 @@ jQuery.fn.keyUpDelayedOrEnter = function (callback, allowEmptyValue) {
 	});
 };
 
+OC.Settings.Personal = OC.Settings.Personal || {
+	deleteAccount: function() {
+		OC.dialogs.confirm('Do you really want to delete your account ? All your data will be lost !', 'Delete your account ?', function (res) {
+			if (res) {
+				$.ajax({
+					type: 'DELETE',
+					url: OC.generateUrl('/settings/users/users/' + OC.getCurrentUser().uid),
+					success: function (data) {
+						// redirect to login page
+					}
+				});
+			}
+		}, true);
+	}
+};
 
 /**
  * Post the email address change to the server.
@@ -268,6 +283,8 @@ $(document).ready(function () {
 
 	$('#displayName').keyUpDelayedOrEnter(changeDisplayName);
 	$('#email').keyUpDelayedOrEnter(changeEmailAddress, true);
+
+	$("#deleteAccount-btn").click(OC.Settings.Personal.deleteAccount);
 
 	$("#languageinput").change(function () {
 		// Serialize the data

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -938,6 +938,15 @@ $(document).ready(function () {
 		}
 	});
 
+	// Option for users to delete their own accounts
+	$('#CheckboxUserDeletionAccount').click(function() {
+		if ($('#CheckboxUserDeletionAccount').is(':checked')) {
+			OC.AppConfig.setValue('core', 'user_own_account_deletion', 'true');
+		} else {
+			OC.AppConfig.setValue('core', 'user_own_account_deletion', 'false');
+		}
+	});
+
 	// calculate initial limit of users to load
 	var initialUserCountLimit = UserList.initialUsersToLoad,
 		containerHeight = $('#app-content').height();

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -941,9 +941,9 @@ $(document).ready(function () {
 	// Option for users to delete their own accounts
 	$('#CheckboxUserDeletionAccount').click(function() {
 		if ($('#CheckboxUserDeletionAccount').is(':checked')) {
-			OC.AppConfig.setValue('core', 'user_own_account_deletion', 'true');
+			OCP.AppConfig.setValue('core', 'user_own_account_deletion', '1');
 		} else {
-			OC.AppConfig.setValue('core', 'user_own_account_deletion', 'false');
+			OCP.AppConfig.setValue('core', 'user_own_account_deletion', '0');
 		}
 	});
 

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -142,6 +142,8 @@ if ($externalStorageEnabled) {
 	$enableCertImport = $backendService->isUserMountingAllowed();
 }
 
+// show account deletion button only if it's enabled and if the backend supports it
+$accountDeletionEnabled = $config->getAppValue('core', 'user_own_account_deletion', false) && $user->getBackendClassName() === 'Database';
 
 // Return template
 $l = \OC::$server->getL10N('settings');
@@ -167,6 +169,7 @@ $tmpl->assign('avatarChangeSupported', OC_User::canUserChangeAvatar(OC_User::get
 $tmpl->assign('certs', $certificateManager->listCertificates());
 $tmpl->assign('showCertificates', $enableCertImport);
 $tmpl->assign('urlGenerator', $urlGenerator);
+$tmpl->assign('accountDeletionEnabled', $accountDeletionEnabled);
 
 // Get array of group ids for this user
 $groups = \OC::$server->getGroupManager()->getUserIdGroups(OC_User::getUser());

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -142,9 +142,6 @@ if ($externalStorageEnabled) {
 	$enableCertImport = $backendService->isUserMountingAllowed();
 }
 
-// show account deletion button only if it's enabled and if the backend supports it
-$accountDeletionEnabled = $config->getAppValue('core', 'user_own_account_deletion', false) && $user->getBackendClassName() === 'Database';
-
 // Return template
 $l = \OC::$server->getL10N('settings');
 $tmpl = new OC_Template( 'settings', 'personal', 'user');
@@ -169,7 +166,7 @@ $tmpl->assign('avatarChangeSupported', OC_User::canUserChangeAvatar(OC_User::get
 $tmpl->assign('certs', $certificateManager->listCertificates());
 $tmpl->assign('showCertificates', $enableCertImport);
 $tmpl->assign('urlGenerator', $urlGenerator);
-$tmpl->assign('accountDeletionEnabled', $accountDeletionEnabled);
+$tmpl->assign('accountDeletionEnabled', $user->canDeleteAccount());
 
 // Get array of group ids for this user
 $groups = \OC::$server->getGroupManager()->getUserIdGroups(OC_User::getUser());
@@ -216,6 +213,10 @@ $formsMap = array_map(function($form){
 }, $forms);
 
 $formsAndMore = array_merge($formsAndMore, $formsMap);
+
+if ($user->canDeleteAccount()) {
+	$formsAndMore[] = ['anchor' => 'deleteAccount', 'section-name' => $l->t('Account deletion')];
+}
 
 $tmpl->assign('forms', $formsAndMore);
 $tmpl->printPage();

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -247,18 +247,18 @@ if($_['passwordChangeSupported']) {
 	</div>
 </div>
 
-<?php if ($_['accountDeletionEnabled']) { ?>
-<div id="deleteAccount" class="section">
-	<h2><?php p($l->t('Account deletion'));?></h2>
-	<button id="deleteAccount-btn"><?php p($l->t('Delete your account')); ?></button>
-</div>
-<?php } ?>
-
 <?php foreach($_['forms'] as $form) {
 	if (isset($form['form'])) {?>
 	<div id="<?php isset($form['anchor']) ? p($form['anchor']) : p('');?>"><?php print_unescaped($form['form']);?></div>
 	<?php }
 };?>
+
+<?php if ($_['accountDeletionEnabled']) { ?>
+	<div id="deleteAccount" class="section">
+		<h2><?php p($l->t('Account deletion'));?></h2>
+		<button id="deleteAccount-btn"><?php p($l->t('Delete your account')); ?></button>
+	</div>
+<?php } ?>
 
 <div class="section">
 	<h2><?php p($l->t('Version'));?></h2>

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -247,6 +247,13 @@ if($_['passwordChangeSupported']) {
 	</div>
 </div>
 
+<?php if ($_['accountDeletionEnabled']) { ?>
+<div id="deleteAccount" class="section">
+	<h2><?php p($l->t('Account deletion'));?></h2>
+	<button id="deleteAccount-btn"><?php p($l->t('Delete your account')); ?></button>
+</div>
+<?php } ?>
+
 <?php foreach($_['forms'] as $form) {
 	if (isset($form['form'])) {?>
 	<div id="<?php isset($form['anchor']) ? p($form['anchor']) : p('');?>"><?php print_unescaped($form['form']);?></div>

--- a/settings/templates/users/main.php
+++ b/settings/templates/users/main.php
@@ -46,7 +46,7 @@ translation('settings');
 			<div id="userlistoptions">
 				<p>
 					<input type="checkbox" name="userDeletionAccount" value="userDeletionAccount" id="CheckboxUserDeletionAccount"
-						   class="checkbox" <?php if ($_['user_own_account_deletion'] === 'true') print_unescaped('checked="checked"'); ?> />
+						   class="checkbox" <?php if ($_['user_own_account_deletion']) print_unescaped('checked="checked"'); ?> />
 					<label for="CheckboxUserDeletionAccount">
 						<?php p($l->t('Users can delete their accounts')) ?>
 					</label>

--- a/settings/templates/users/main.php
+++ b/settings/templates/users/main.php
@@ -45,6 +45,13 @@ translation('settings');
 
 			<div id="userlistoptions">
 				<p>
+					<input type="checkbox" name="userDeletionAccount" value="userDeletionAccount" id="CheckboxUserDeletionAccount"
+						   class="checkbox" <?php if ($_['user_own_account_deletion'] === 'true') print_unescaped('checked="checked"'); ?> />
+					<label for="CheckboxUserDeletionAccount">
+						<?php p($l->t('Users can delete their accounts')) ?>
+					</label>
+				</p>
+				<p>
 					<input type="checkbox" name="StorageLocation" value="StorageLocation" id="CheckboxStorageLocation" 
 						class="checkbox" <?php if ($_['show_storage_location'] === 'true') print_unescaped('checked="checked"'); ?> />
 					<label for="CheckboxStorageLocation">

--- a/settings/users.php
+++ b/settings/users.php
@@ -125,5 +125,6 @@ $tmpl->assign('show_last_login', $config->getAppValue('core', 'umgmt_show_last_l
 $tmpl->assign('show_email', $config->getAppValue('core', 'umgmt_show_email', 'false'));
 $tmpl->assign('show_backend', $config->getAppValue('core', 'umgmt_show_backend', 'false'));
 $tmpl->assign('send_email', $config->getAppValue('core', 'umgmt_send_email', 'false'));
+$tmpl->assign('user_own_account_deletion', $config->getAppValue('core', 'user_own_account_deletion', 'false'));
 
 $tmpl->printPage();

--- a/settings/users.php
+++ b/settings/users.php
@@ -125,6 +125,6 @@ $tmpl->assign('show_last_login', $config->getAppValue('core', 'umgmt_show_last_l
 $tmpl->assign('show_email', $config->getAppValue('core', 'umgmt_show_email', 'false'));
 $tmpl->assign('show_backend', $config->getAppValue('core', 'umgmt_show_backend', 'false'));
 $tmpl->assign('send_email', $config->getAppValue('core', 'umgmt_send_email', 'false'));
-$tmpl->assign('user_own_account_deletion', $config->getAppValue('core', 'user_own_account_deletion', 'false'));
+$tmpl->assign('user_own_account_deletion', (bool)$config->getAppValue('core', 'user_own_account_deletion', 0));
 
 $tmpl->printPage();

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -392,6 +392,57 @@ class UserTest extends \Test\TestCase {
 		$this->assertEquals('foo',$user->getDisplayName());
 	}
 
+	public function testCanDeleteAccount() {
+		/**
+		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 */
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
+
+		/**
+		 * @var \OCP\IConfig | \PHPUnit_Framework_MockObject_MockObject $config
+		 */
+		$config = $this->getMockBuilder('\OCP\IConfig')
+			->disableOriginalConstructor()
+			->getMock();
+		$config->expects($this->any())
+			->method('getAppValue')
+			->will($this->returnValue(true));
+
+		$backend->expects($this->any())
+			->method('implementsActions')
+			->will($this->returnCallback(function ($actions) {
+				if ($actions === \OC\User\Backend::DELETE_USER) {
+					return true;
+				} else {
+					return false;
+				}
+			}));
+
+		$user = new \OC\User\User('foo', $backend, null, $config);
+		$this->assertTrue($user->canDeleteAccount());
+	}
+
+	public function testCanDeleteAccountNotSupported() {
+		/**
+		 * @var \OC\User\Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 */
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
+
+		$config = $this->getMockBuilder('\OCP\IConfig')
+			->disableOriginalConstructor()
+			->getMock();
+		$config->expects($this->any())
+			->method('getAppValue')
+			->will($this->returnValue(true));
+
+		$backend->expects($this->any())
+			->method('implementsActions')
+			->will($this->returnValue(false));
+
+		$user = new \OC\User\User('foo', $backend, null, $config);
+		$this->assertFalse($user->canDeleteAccount());
+	}
+
 	public function testSetPasswordHooks() {
 		$hooksCalled = 0;
 		$test = $this;


### PR DESCRIPTION
Bring the possibility for an user to delete it's own account. Administrators can enable/disable this functionality.

See https://github.com/owncloud/core/issues/158
- [ ] Security issues
- [ ] Redirect to login with js after deleting account
- [x] Tests
