### PR TITLE
endorse password for share links

### DIFF
--- a/core/js/config.php
+++ b/core/js/config.php
@@ -69,6 +69,9 @@ $outgoingServer2serverShareEnabled = $config->getAppValue('files_sharing', 'outg
 
 $countOfDataLocation = 0;
 
+$value = $config->getAppValue('core', 'shareapi_enable_link_password_by_default', 'no');
+$enableLinkPasswordByDefault = ($value === 'yes') ? true : false;
+
 $dataLocation = str_replace(OC::$SERVERROOT .'/', '', $config->getSystemValue('datadirectory', ''), $countOfDataLocation);
 if($countOfDataLocation !== 1 || !OC_User::isAdminUser(OC_User::getUser())){
 	$dataLocation = false;
@@ -164,6 +167,7 @@ $array = array(
 				'defaultExpireDate' => $defaultExpireDate,
 				'defaultExpireDateEnforced' => $enforceDefaultExpireDate,
 				'enforcePasswordForPublicLink' => \OCP\Util::isPublicLinkPasswordRequired(),
+				'enableLinkPasswordByDefault' => $enableLinkPasswordByDefault,
 				'sharingDisabledForUser' => \OCP\Util::isSharingDisabledForUser(),
 				'resharingAllowed' => \OCP\Share::isResharingAllowed(),
 				'remoteShareAllowed' => $outgoingServer2serverShareEnabled,

--- a/core/js/shareconfigmodel.js
+++ b/core/js/shareconfigmodel.js
@@ -22,6 +22,7 @@
 		defaults: {
 			publicUploadEnabled: false,
 			enforcePasswordForPublicLink: oc_appconfig.core.enforcePasswordForPublicLink,
+			enableLinkPasswordByDefault: oc_appconfig.core.enableLinkPasswordByDefault,
 			isDefaultExpireDateEnforced: oc_appconfig.core.defaultExpireDateEnforced === true,
 			isDefaultExpireDateEnabled: oc_appconfig.core.defaultExpireDateEnabled === true,
 			isRemoteShareAllowed: oc_appconfig.core.remoteShareAllowed,

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -17,6 +17,7 @@
 
 	var PASSWORD_PLACEHOLDER = '**********';
 	var PASSWORD_PLACEHOLDER_MESSAGE = t('core', 'Choose a password for the public link');
+	var PASSWORD_PLACEHOLDER_MESSAGE_OPTIONAL = t('core', 'Choose a password for the public link or press enter');
 
 	var TEMPLATE =
 			'{{#if shareAllowed}}' +
@@ -49,7 +50,11 @@
 			'    {{/if}}' +
 			'<div id="linkPass" class="linkPass {{#unless isPasswordSet}}hidden{{/unless}}">' +
 			'    <label for="linkPassText-{{cid}}" class="hidden-visually">{{passwordLabel}}</label>' +
+			'    {{#if showPasswordCheckBox}}' +
 			'    <input id="linkPassText-{{cid}}" class="linkPassText" type="password" placeholder="{{passwordPlaceholder}}" />' +
+			'    {{else}}' +
+			'    <input id="linkPassText-{{cid}}" class="linkPassText" type="password" placeholder="{{passwordPlaceholderInitial}}" />' +
+			'    {{/if}}' +
 			'    <span class="icon-loading-small hidden"></span>' +
 			'</div>' +
 			'{{else}}' +
@@ -172,7 +177,7 @@
 			}
 
 			if($checkBox.is(':checked')) {
-				if(this.configModel.get('enforcePasswordForPublicLink') === false) {
+				if(this.configModel.get('enforcePasswordForPublicLink') === false && this.configModel.get('enableLinkPasswordByDefault') === false) {
 					$loading.removeClass('hidden');
 					// this will create it
 					this.model.saveLinkShare();
@@ -222,9 +227,19 @@
 			var $input = this.$el.find('.linkPassText');
 			$input.removeClass('error');
 			var password = $input.val();
-			// in IE9 the password might be the placeholder due to bugs in the placeholders polyfill
-			if(password === '' || password === PASSWORD_PLACEHOLDER || password === PASSWORD_PLACEHOLDER_MESSAGE) {
-				return;
+
+			if (this.$el.find('.linkPassText').attr('placeholder') === PASSWORD_PLACEHOLDER_MESSAGE_OPTIONAL) {
+
+				// in IE9 the password might be the placeholder due to bugs in the placeholders polyfill
+				if(password === PASSWORD_PLACEHOLDER_MESSAGE_OPTIONAL) {
+					password = '';
+				}
+			} else {
+
+				// in IE9 the password might be the placeholder due to bugs in the placeholders polyfill
+				if(password === '' || password === PASSWORD_PLACEHOLDER || password === PASSWORD_PLACEHOLDER_MESSAGE) {
+					return;
+				}
 			}
 
 			$loading
@@ -313,6 +328,8 @@
 			var showPasswordCheckBox = isLinkShare
 				&& (   !this.configModel.get('enforcePasswordForPublicLink')
 					|| !this.model.get('linkShare').password);
+			var passwordPlaceholderInitial = this.configModel.get('enforcePasswordForPublicLink')
+				? PASSWORD_PLACEHOLDER_MESSAGE : PASSWORD_PLACEHOLDER_MESSAGE_OPTIONAL;
 
 			this.$el.html(linkShareTemplate({
 				cid: this.cid,
@@ -325,6 +342,7 @@
 				enablePasswordLabel: t('core', 'Password protect'),
 				passwordLabel: t('core', 'Password'),
 				passwordPlaceholder: isPasswordSet ? PASSWORD_PLACEHOLDER : PASSWORD_PLACEHOLDER_MESSAGE,
+				passwordPlaceholderInitial: passwordPlaceholderInitial,
 				isPasswordSet: isPasswordSet,
 				showPasswordCheckBox: showPasswordCheckBox,
 				publicUpload: publicUpload && isLinkShare,

--- a/lib/private/Settings/Admin/Sharing.php
+++ b/lib/private/Settings/Admin/Sharing.php
@@ -57,6 +57,7 @@ class Sharing implements ISettings {
 			'allowPublicUpload'               => $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes'),
 			'allowResharing'                  => $this->config->getAppValue('core', 'shareapi_allow_resharing', 'yes'),
 			'allowShareDialogUserEnumeration' => $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes'),
+			'enableLinkPasswordByDefault'     => $this->config->getAppValue('core', 'shareapi_enable_link_password_by_default', 'no'),
 			'enforceLinkPassword'             => Util::isPublicLinkPasswordRequired(),
 			'onlyShareWithGroupMembers'       => Share::shareWithGroupMembersOnly(),
 			'shareAPIEnabled'                 => $this->config->getAppValue('core', 'shareapi_enabled', 'yes'),

--- a/settings/templates/admin/sharing.php
+++ b/settings/templates/admin/sharing.php
@@ -47,6 +47,10 @@
 			   value="1" <?php if ($_['allowPublicUpload'] == 'yes') print_unescaped('checked="checked"'); ?> />
 		<label for="allowPublicUpload"><?php p($l->t('Allow public uploads'));?></label><br/>
 
+		<input type="checkbox" name="shareapi_enable_link_password_by_default" id="enableLinkPasswordByDefault" class="checkbox"
+			   value="1" <?php if ($_['enableLinkPasswordByDefault'] === 'yes') print_unescaped('checked="checked"'); ?> />
+		<label for="enableLinkPasswordByDefault"><?php p($l->t('Always ask for a password'));?></label><br/>
+
 		<input type="checkbox" name="shareapi_enforce_links_password" id="enforceLinkPassword" class="checkbox"
 			   value="1" <?php if ($_['enforceLinkPassword']) print_unescaped('checked="checked"'); ?> />
 		<label for="enforceLinkPassword"><?php p($l->t('Enforce password protection'));?></label><br/>


### PR DESCRIPTION
works like "enforce password protection", but let the
user optionally remove the password protection after the
password is set.
- downstream of https://github.com/owncloud/core/pull/26376

cc @rullzer @schiessle @nickvergessen 

I tested this and it works 
