### PR TITLE
remove slight transparency of primary action button, ref #1615

### DIFF
--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -396,6 +396,7 @@ class ThemingController extends Controller {
 			$responseCss .= '#header .icon-caret { background-image: url(\'' . \OC::$WEBROOT . '/core/img/actions/caret-dark.svg\'); }' . "\n";
 			$responseCss .= '.searchbox input[type="search"] { background: transparent url(\'' . \OC::$WEBROOT . '/core/img/actions/search.svg\') no-repeat 6px center; color: #000; }' . "\n";
 			$responseCss .= '.searchbox input[type="search"]:focus,.searchbox input[type="search"]:active,.searchbox input[type="search"]:valid { color: #000; border: 1px solid rgba(0, 0, 0, .5); }' . "\n";
+			$responseCss .= '#body-login input.login { background-image: url(\'' . \OC::$WEBROOT . '/core/img/actions/confirm.svg?v=2\'); }' . "\n";
 			$responseCss .= '.nc-theming-contrast {color: #000000}' . "\n";
 			$responseCss .= '.ui-widget-header { color: #000000; }' . "\n";
 		} else {

--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -331,14 +331,12 @@ class ThemingController extends Controller {
 				'.primary:active, input[type="submit"].primary:active, input[type="button"].primary:active, button.primary:active, .button.primary:active {' .
 				'border: 1px solid '.$elementColor.';'.
 				'background-color: '.$elementColor.';'.
-				'opacity: 0.8;' .
 				'color: ' . $textColor . ';'.
 				"}\n" .
 				'.primary:hover, input[type="submit"].primary:hover, input[type="button"].primary:hover, button.primary:hover, .button.primary:hover,' .
 				'.primary:focus, input[type="submit"].primary:focus, input[type="button"].primary:focus, button.primary:focus, .button.primary:focus {' .
 				'border: 1px solid '.$elementColor.';'.
 				'background-color: '.$elementColor.';'.
-				'opacity: 1.0;' .
 				'color: ' . $textColor . ';'.
 				"}\n" .
 				'.primary:disabled, input[type="submit"].primary:disabled, input[type="button"].primary:disabled, button.primary:disabled, .button.primary:disabled,' .

--- a/apps/theming/tests/Controller/ThemingControllerTest.php
+++ b/apps/theming/tests/Controller/ThemingControllerTest.php
@@ -566,6 +566,7 @@ class ThemingControllerTest extends TestCase {
 		$expectedData .= '#header .icon-caret { background-image: url(\'' . \OC::$WEBROOT . '/core/img/actions/caret-dark.svg\'); }' . "\n";
 		$expectedData .= '.searchbox input[type="search"] { background: transparent url(\'' . \OC::$WEBROOT . '/core/img/actions/search.svg\') no-repeat 6px center; color: #000; }' . "\n";
 		$expectedData .= '.searchbox input[type="search"]:focus,.searchbox input[type="search"]:active,.searchbox input[type="search"]:valid { color: #000; border: 1px solid rgba(0, 0, 0, .5); }' . "\n";
+		$expectedData .= '#body-login input.login { background-image: url(\'' . \OC::$WEBROOT . '/core/img/actions/confirm.svg?v=2\'); }' . "\n";
 		$expectedData .= '.nc-theming-contrast {color: #000000}' . "\n";
 		$expectedData .= '.ui-widget-header { color: #000000; }' . "\n";
 
@@ -863,6 +864,7 @@ class ThemingControllerTest extends TestCase {
 		$expectedData .= '#header .icon-caret { background-image: url(\'' . \OC::$WEBROOT . '/core/img/actions/caret-dark.svg\'); }' . "\n";
 		$expectedData .= '.searchbox input[type="search"] { background: transparent url(\'' . \OC::$WEBROOT . '/core/img/actions/search.svg\') no-repeat 6px center; color: #000; }' . "\n";
 		$expectedData .= '.searchbox input[type="search"]:focus,.searchbox input[type="search"]:active,.searchbox input[type="search"]:valid { color: #000; border: 1px solid rgba(0, 0, 0, .5); }' . "\n";
+		$expectedData .= '#body-login input.login { background-image: url(\'' . \OC::$WEBROOT . '/core/img/actions/confirm.svg?v=2\'); }' . "\n";
 		$expectedData .= '.nc-theming-contrast {color: #000000}' . "\n";
 		$expectedData .= '.ui-widget-header { color: #000000; }' . "\n";
 

--- a/apps/theming/tests/Controller/ThemingControllerTest.php
+++ b/apps/theming/tests/Controller/ThemingControllerTest.php
@@ -440,14 +440,12 @@ class ThemingControllerTest extends TestCase {
 			'.primary:active, input[type="submit"].primary:active, input[type="button"].primary:active, button.primary:active, .button.primary:active {' .
 			'border: 1px solid '.$color.';'.
 			'background-color: '.$color.';'.
-			'opacity: 0.8;' .
 			'color: #ffffff;'.
 			"}\n" .
 			'.primary:hover, input[type="submit"].primary:hover, input[type="button"].primary:hover, button.primary:hover, .button.primary:hover,' .
 			'.primary:focus, input[type="submit"].primary:focus, input[type="button"].primary:focus, button.primary:focus, .button.primary:focus {' .
 			'border: 1px solid '.$color.';'.
 			'background-color: '.$color.';'.
-			'opacity: 1.0;' .
 			'color: #ffffff;'.
 			"}\n" .
 			'.primary:disabled, input[type="submit"].primary:disabled, input[type="button"].primary:disabled, button.primary:disabled, .button.primary:disabled,' .
@@ -530,14 +528,12 @@ class ThemingControllerTest extends TestCase {
 			'.primary:active, input[type="submit"].primary:active, input[type="button"].primary:active, button.primary:active, .button.primary:active {' .
 			'border: 1px solid '.$elementColor.';'.
 			'background-color: '.$elementColor.';'.
-			'opacity: 0.8;' .
 			'color: #000000;'.
 			"}\n" .
 			'.primary:hover, input[type="submit"].primary:hover, input[type="button"].primary:hover, button.primary:hover, .button.primary:hover,' .
 			'.primary:focus, input[type="submit"].primary:focus, input[type="button"].primary:focus, button.primary:focus, .button.primary:focus {' .
 			'border: 1px solid '.$elementColor.';'.
 			'background-color: '.$elementColor.';'.
-			'opacity: 1.0;' .
 			'color: #000000;'.
 			"}\n" .
 			'.primary:disabled, input[type="submit"].primary:disabled, input[type="button"].primary:disabled, button.primary:disabled, .button.primary:disabled,' .
@@ -706,14 +702,12 @@ class ThemingControllerTest extends TestCase {
 			'.primary:active, input[type="submit"].primary:active, input[type="button"].primary:active, button.primary:active, .button.primary:active {' .
 			'border: 1px solid '.$color.';'.
 			'background-color: '.$color.';'.
-			'opacity: 0.8;' .
 			'color: #ffffff;'.
 			"}\n" .
 			'.primary:hover, input[type="submit"].primary:hover, input[type="button"].primary:hover, button.primary:hover, .button.primary:hover,' .
 			'.primary:focus, input[type="submit"].primary:focus, input[type="button"].primary:focus, button.primary:focus, .button.primary:focus {' .
 			'border: 1px solid '.$color.';'.
 			'background-color: '.$color.';'.
-			'opacity: 1.0;' .
 			'color: #ffffff;'.
 			"}\n" .
 			'.primary:disabled, input[type="submit"].primary:disabled, input[type="button"].primary:disabled, button.primary:disabled, .button.primary:disabled,' .
@@ -813,14 +807,12 @@ class ThemingControllerTest extends TestCase {
 			'.primary:active, input[type="submit"].primary:active, input[type="button"].primary:active, button.primary:active, .button.primary:active {' .
 			'border: 1px solid '.$elementColor.';'.
 			'background-color: '.$elementColor.';'.
-			'opacity: 0.8;' .
 			'color: #000000;'.
 			"}\n" .
 			'.primary:hover, input[type="submit"].primary:hover, input[type="button"].primary:hover, button.primary:hover, .button.primary:hover,' .
 			'.primary:focus, input[type="submit"].primary:focus, input[type="button"].primary:focus, button.primary:focus, .button.primary:focus {' .
 			'border: 1px solid '.$elementColor.';'.
 			'background-color: '.$elementColor.';'.
-			'opacity: 1.0;' .
 			'color: #000000;'.
 			"}\n" .
 			'.primary:disabled, input[type="submit"].primary:disabled, input[type="button"].primary:disabled, button.primary:disabled, .button.primary:disabled,' .


### PR DESCRIPTION
Fix the first part of @ChristophWurst’s comment in https://github.com/nextcloud/server/issues/1615#issuecomment-255662882 about the log in button when themed

@juliushaertl how would I use the class .icon-confirm (instead of .icon-confirm-white) when the primary color is set so the text switches to black? :)

cc @nextcloud/designers 
