### PR TITLE
Highlight files and update storage stats at end of upload (#26164)

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1071,6 +1071,7 @@ OC.Uploader.prototype = _.extend({
 
 					self.clear();
 					self._hideProgressBar();
+					self.trigger('stop', e, data);
 				});
 				fileupload.on('fileuploadfail', function(e, data) {
 					self.log('progress handle fileuploadfail', e, data);

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2810,8 +2810,8 @@
 				$.when.apply($, promises).then(function() {
 					// highlight uploaded files
 					self.highlightFiles(fileNames);
+					self.updateStorageStatistics();
 				});
-				self.updateStorageStatistics();
 
 				var uploadText = self.$fileList.find('tr .uploadtext');
 				self.showFileBusyState(uploadText.closest('tr'), false);

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2794,13 +2794,22 @@ describe('OCA.Files.FileList tests', function() {
 
 				highlightStub.restore();
 			});
-			it('queries storage stats', function() {
+			it('queries storage stats after all fetches are done', function() {
 				var statStub = sinon.stub(fileList, 'updateStorageStatistics');
-				addFile(createUpload('upload.txt', '/subdir'));
-				expect(statStub.notCalled).toEqual(true);
+				var highlightStub = sinon.stub(fileList, 'highlightFiles');
+				var def1 = addFile(createUpload('upload.txt', '/subdir'));
+				var def2 = addFile(createUpload('upload2.txt', '/subdir'));
+				var def3 = addFile(createUpload('upload3.txt', '/another'));
 				uploader.trigger('stop', {});
+
+				expect(statStub.notCalled).toEqual(true);
+				def1.resolve();
+				expect(statStub.notCalled).toEqual(true);
+				def2.resolve();
+				def3.resolve();
 				expect(statStub.calledOnce).toEqual(true);
-				statStub.restore();
+
+				highlightStub.restore();
 			});
 		});
 	});


### PR DESCRIPTION
Properly trigger the "stop" even from the uploader.
Also update storage stats at the end of all uploads instead of for each
upload.
- downstream https://github.com/owncloud/core/pull/26164
