### PR TITLE
Add build/bin to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,7 @@ RCS/*
 .project
 .settings
 
-# netbeans 
+# netbeans
 nbproject
 
 # phpStorm
@@ -90,7 +90,7 @@ nbproject
 
 # ack(-grep)
 .ackrc
-	
+
 # Mac OS
 .DS_Store
 
@@ -105,6 +105,7 @@ nbproject
 /build/node_modules/
 
 # nodejs
+/build/bin
 /build/lib/
 /build/jsdocs/
 /npm-debug.log


### PR DESCRIPTION
When phantomjs and karma are not installed globally, they are installed into this folder.
