### PR TITLE
Add nonce also to legacy CSP

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -61,7 +61,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	// Firefox User Agent from https://developer.mozilla.org/en-US/docs/Web/HTTP/Gecko_user_agent_string_reference
 	const USER_AGENT_FIREFOX = '/^Mozilla\/5\.0 \([^)]+\) Gecko\/[0-9.]+ Firefox\/[0-9.]+$/';
 	// Chrome User Agent from https://developer.chrome.com/multidevice/user-agent
-	const USER_AGENT_CHROME = '/^Mozilla\/5\.0 \([^)]+\) AppleWebKit\/[0-9.]+ \(KHTML, like Gecko\) Chrome\/[0-9.]+ (Mobile Safari|Safari)\/[0-9.]+$/';
+	const USER_AGENT_CHROME = '/^Mozilla\/5\.0 \([^)]+\) AppleWebKit\/[0-9.]+ \(KHTML, like Gecko\)( Ubuntu Chromium\/[0-9.]+|) Chrome\/[0-9.]+ (Mobile Safari|Safari)\/[0-9.]+$/';
 	// Safari User Agent from http://www.useragentstring.com/pages/Safari/
 	const USER_AGENT_SAFARI = '/^Mozilla\/5\.0 \([^)]+\) AppleWebKit\/[0-9.]+ \(KHTML, like Gecko\) Version\/[0-9.]+ Safari\/[0-9.A-Z]+$/';
 	// Android Chrome user agent: https://developers.google.com/chrome/mobile/docs/user-agent

--- a/lib/private/Security/CSP/ContentSecurityPolicyNonceManager.php
+++ b/lib/private/Security/CSP/ContentSecurityPolicyNonceManager.php
@@ -21,6 +21,7 @@
 
 namespace OC\Security\CSP;
 
+use OC\AppFramework\Http\Request;
 use OC\Security\CSRF\CsrfTokenManager;
 use OCP\IRequest;
 
@@ -65,8 +66,7 @@ class ContentSecurityPolicyNonceManager {
 	 */
 	public function browserSupportsCspV3() {
 		$browserWhitelist = [
-			// Chrome 40+
-			'/^Mozilla\/5\.0 \([^)]+\) AppleWebKit\/[0-9.]+ \(KHTML, like Gecko\) Chrome\/[4-9][0-9].[0-9.]+ (Mobile Safari|Safari)\/[0-9.]+$/',
+			Request::USER_AGENT_CHROME,
 			// Firefox 45+
 			'/^Mozilla\/5\.0 \([^)]+\) Gecko\/[0-9.]+ Firefox\/(4[5-9]|[5-9][0-9])\.[0-9.]+$/',
 			// Safari 10+

--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -247,7 +247,7 @@ class OC_Response {
 		 * @see \OCP\AppFramework\Http\Response::getHeaders
 		 */
 		$policy = 'default-src \'self\'; '
-			. 'script-src \'self\' \'unsafe-eval\'; '
+			. 'script-src \'self\' \'unsafe-eval\' \'nonce-'.\OC::$server->getContentSecurityPolicyNonceManager()->getNonce().'\'; '
 			. 'style-src \'self\' \'unsafe-inline\'; '
 			. 'frame-src *; '
 			. 'img-src * data: blob:; '

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -792,6 +792,20 @@ class RequestTest extends \Test\TestCase {
 				false,
 			],
 			[
+				'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36',
+				[
+					Request::USER_AGENT_CHROME
+				],
+				true,
+			],
+			[
+				'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/53.0.2785.143 Chrome/53.0.2785.143 Safari/537.36',
+				[
+					Request::USER_AGENT_CHROME
+				],
+				true,
+			],
+			[
 				'Mozilla/5.0 (Linux; Android 4.4; Nexus 4 Build/KRT16S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36',
 				[
 					Request::USER_AGENT_ANDROID_MOBILE_CHROME


### PR DESCRIPTION
Pages that do not use the AppFramework have its CSP inherited from `\OC_Response::addSecurityHeaders`. While those are not many anymore, there are some examples such as the "Help" page.

To stay completely backwards-compatible we should also add the nonce to the legacy CSP response.

To test that open your browser console and open the help page. Without this you will get a JS error. With this you won't.

Signed-off-by: Lukas Reschke lukas@statuscode.ch

cc @rullzer 
