### PR TITLE
Move lately used tags to the top

### DIFF
--- a/apps/dav/lib/SystemTag/SystemTagsObjectMappingCollection.php
+++ b/apps/dav/lib/SystemTag/SystemTagsObjectMappingCollection.php
@@ -192,7 +192,7 @@ class SystemTagsObjectMappingCollection implements ICollection {
 	 *
 	 * @param ISystemTag $tag
 	 *
-	 * @return SystemTagNode
+	 * @return SystemTagMappingNode
 	 */
 	private function makeNode(ISystemTag $tag) {
 		return new SystemTagMappingNode(

--- a/apps/systemtags/appinfo/routes.php
+++ b/apps/systemtags/appinfo/routes.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016, Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+return [
+	'routes' => [
+		['name' => 'LastUsed#getLastUsedTagIds', 'url' => '/lastused', 'verb' => 'GET'],
+	]
+];

--- a/apps/systemtags/js/admin.js
+++ b/apps/systemtags/js/admin.js
@@ -153,6 +153,12 @@
 			},
 			escapeMarkup: function(m) {
 				return m;
+			},
+			sortResults: function(results) {
+				results.sort(function(a, b) {
+					return OC.Util.naturalSortCompare(a.get('name'), b.get('name'));
+				});
+				return results;
 			}
 		}
 	};

--- a/apps/systemtags/lib/Activity/Listener.php
+++ b/apps/systemtags/lib/Activity/Listener.php
@@ -28,6 +28,7 @@ use OCP\App\IAppManager;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
+use OCP\IConfig;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
@@ -46,6 +47,8 @@ class Listener {
 	protected $activityManager;
 	/** @var IUserSession */
 	protected $session;
+	/** @var IConfig */
+	protected $config;
 	/** @var \OCP\SystemTag\ISystemTagManager */
 	protected $tagManager;
 	/** @var \OCP\App\IAppManager */
@@ -61,6 +64,7 @@ class Listener {
 	 * @param IGroupManager $groupManager
 	 * @param IManager $activityManager
 	 * @param IUserSession $session
+	 * @param IConfig $config
 	 * @param ISystemTagManager $tagManager
 	 * @param IAppManager $appManager
 	 * @param IMountProviderCollection $mountCollection
@@ -69,6 +73,7 @@ class Listener {
 	public function __construct(IGroupManager $groupManager,
 								IManager $activityManager,
 								IUserSession $session,
+								IConfig $config,
 								ISystemTagManager $tagManager,
 								IAppManager $appManager,
 								IMountProviderCollection $mountCollection,
@@ -76,6 +81,7 @@ class Listener {
 		$this->groupManager = $groupManager;
 		$this->activityManager = $activityManager;
 		$this->session = $session;
+		$this->config = $config;
 		$this->tagManager = $tagManager;
 		$this->appManager = $appManager;
 		$this->mountCollection = $mountCollection;
@@ -123,6 +129,11 @@ class Listener {
 				$activity->setAffectedUser($user->getUID());
 				$this->activityManager->publish($activity);
 			}
+		}
+
+
+		if ($actor !== '' && ($event->getEvent() === ManagerEvent::EVENT_CREATE || $event->getEvent() === ManagerEvent::EVENT_UPDATE)) {
+			$this->updateLastUsedTags($actor, $event->getTag());
 		}
 	}
 
@@ -211,6 +222,27 @@ class Listener {
 				$this->activityManager->publish($activity);
 			}
 		}
+
+		if ($actor !== '' && $event->getEvent() === MapperEvent::EVENT_ASSIGN) {
+			foreach ($tags as $tag) {
+				$this->updateLastUsedTags($actor, $tag);
+			}
+		}
+	}
+
+	/**
+	 * @param string $actor
+	 * @param ISystemTag $tag
+	 */
+	protected function updateLastUsedTags($actor, ISystemTag $tag) {
+		$lastUsedTags = $this->config->getUserValue($actor, 'systemtags', 'last_used', '[]');
+		$lastUsedTags = json_decode($lastUsedTags, true);
+
+		array_unshift($lastUsedTags, $tag->getId());
+		array_unique($lastUsedTags);
+		$lastUsedTags = array_slice($lastUsedTags, 0, 10);
+
+		$this->config->setUserValue($actor, 'systemtags', 'last_used', json_encode($lastUsedTags));
 	}
 
 	/**

--- a/apps/systemtags/lib/Controller/LastUsedController.php
+++ b/apps/systemtags/lib/Controller/LastUsedController.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\SystemTags\Controller;
+
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+class LastUsedController extends Controller {
+
+	/** @var IConfig */
+	protected $config;
+
+	/** @var IUserSession */
+	protected $userSession;
+
+	/**
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param IConfig $config
+	 * @param IUserSession $userSession
+	 */
+	public function __construct($appName, IRequest $request, IConfig $config, IUserSession $userSession) {
+		parent::__construct($appName, $request);
+		$this->config = $config;
+		$this->userSession = $userSession;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 */
+	public function getLastUsedTagIds() {
+		$lastUsed = $this->config->getUserValue($this->userSession->getUser()->getUID(), 'systemtags', 'last_used', '[]');
+		$tagIds = json_decode($lastUsed, true);
+		return new DataResponse(array_map(function($id) { return (string) $id; }, $tagIds));
+	}
+}

--- a/core/js/systemtags/systemtagsinputfield.js
+++ b/core/js/systemtags/systemtagsinputfield.js
@@ -57,6 +57,8 @@
 
 		_newTag: null,
 
+		_lastUsedTags: [],
+
 		className: 'systemTagsInputFieldContainer',
 
 		template: function(data) {
@@ -97,6 +99,8 @@
 				_.defer(self._refreshSelection);
 			});
 
+			_.defer(_.bind(this._getLastUsedTags, this));
+
 			_.bindAll(
 				this,
 				'_refreshSelection',
@@ -106,6 +110,17 @@
 				'_onDeselectTag',
 				'_onSubmitRenameTag'
 			);
+		},
+
+		_getLastUsedTags: function() {
+			var self = this;
+			$.ajax({
+				type: 'GET',
+				url: OC.generateUrl('/apps/systemtags/lastused'),
+				success: function (response) {
+					self._lastUsedTags = response;
+				}
+			});
 		},
 
 		/**
@@ -241,6 +256,7 @@
 			}
 			this._newTag = null;
 			this.trigger('select', tag);
+			this._lastUsedTags.unshift(tag.id);
 		},
 
 		/**
@@ -400,6 +416,20 @@
 						var aSelected = selectedItems.indexOf(a.id) >= 0;
 						var bSelected = selectedItems.indexOf(b.id) >= 0;
 						if (aSelected === bSelected) {
+							var aLastUsed = self._lastUsedTags.indexOf(a.id);
+							var bLastUsed = self._lastUsedTags.indexOf(b.id);
+
+							if (aLastUsed !== bLastUsed) {
+								if (bLastUsed === -1) {
+									return -1;
+								}
+								if (aLastUsed === -1) {
+									return 1;
+								}
+								return aLastUsed < bLastUsed ? -1 : 1;
+							}
+
+							// Both not found
 							return OC.Util.naturalSortCompare(a.name, b.name);
 						}
 						if (aSelected && !bSelected) {

--- a/core/js/systemtags/systemtagsinputfield.js
+++ b/core/js/systemtags/systemtagsinputfield.js
@@ -226,6 +226,7 @@
 				}, {
 					success: function(model) {
 						self._addToSelect2Selection(model.toJSON());
+						self._lastUsedTags.unshift(model.id);
 						self.trigger('select', model);
 					},
 					error: function(model, xhr) {
@@ -253,10 +254,10 @@
 				return false;
 			} else {
 				tag = this.collection.get(e.object.id);
+				this._lastUsedTags.unshift(tag.id);
 			}
 			this._newTag = null;
 			this.trigger('select', tag);
-			this._lastUsedTags.unshift(tag.id);
 		},
 
 		/**


### PR DESCRIPTION
- Add a tag to a file
- Open the sidebar of another file
- See the tag you just assigned being sorted first.

Stores up to 10 tags atm
Ref 2nd checkbox of https://github.com/nextcloud/server/issues/1465
