### PR TITLE
Non-blocking session handler

### DIFF
--- a/lib/private/Session/FileSessionHandler.php
+++ b/lib/private/Session/FileSessionHandler.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace OC\Session;
+
+/**
+ * Non-locking session handler
+ *
+ * lib/private/Session/Internal.php:__construct()
+ *   session_set_save_handler(new FileSessionHandler(), true)
+ **/
+
+
+
+class FileSessionHandler extends \SessionHandler
+{
+    private $savePath;
+	private $firstCall=false;
+
+    public function open($savePath, $sessionName)
+    {
+        $this->savePath = $savePath;
+		return parent::open($savePath, $sessionName);
+    }
+
+    public function close()
+    {
+		if ($this->firstCall)
+			return parent::close();
+
+        return true;
+    }
+
+    public function read($id)
+    {
+		if (!file_exists("$this->savePath/sess_$id"))
+			$this->firstCall=true;
+
+		if ($this->firstCall)
+			return parent::read($id);
+
+        return (string)@file_get_contents("$this->savePath/sess_$id");
+    }
+
+    public function write($id, $data)
+    {
+		if ($this->firstCall)
+			return parent::write($id, $data);
+
+        return file_put_contents("$this->savePath/sess_$id", $data) === false ? false : true;
+    }
+
+    public function destroy($id)
+    {
+		if ($this->firstCall)
+			return parent::destroy($id);
+
+        $file = "$this->savePath/sess_$id";
+        if (file_exists($file)) {
+            unlink($file);
+        }
+
+        return true;
+    }
+
+    public function gc($maxlifetime)
+    {
+		if ($this->firstCall)
+			return parent::gc($maxlifetime);
+
+        foreach (glob("$this->savePath/sess_*") as $file) {
+            if (filemtime($file) + $maxlifetime < time() && file_exists($file)) {
+                unlink($file);
+            }
+        }
+
+        return true;
+    }
+}

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -42,12 +42,25 @@ class Internal extends Session {
 	 * @param string $name
 	 * @throws \Exception
 	 */
+    private $uniqId;
+    private $startTimestamp;
+	private function logTS($msg)
+	{
+		$diff=microtime(true)-$this->startTimestamp;
+		$fh=fopen("/tmp/session.log", "a+");
+		fprintf($fh, "%s %.1f - %s\n", $this->uniqId, $diff*1000, $msg);
+		fclose($fh);
+	}
 	public function __construct($name) {
+		$this->uniqId=uniqid();
+		$this->startTimestamp=microtime(true);
 		session_name($name);
 		set_error_handler(array($this, 'trapError'));
 		try {
-			session_set_save_handler(new FileSessionHandler(), true);
+			// session_set_save_handler(new FileSessionHandler(), true);
+			$this->logTS('Session start wait');
 			session_start();
+			$this->logTS('Session started');
 		} catch (\Exception $e) {
 			setcookie(session_name(), null, -1, \OC::$WEBROOT ? : '/');
 		}
@@ -103,6 +116,7 @@ class Internal extends Session {
 
 	public function close() {
 		session_write_close();
+		$this->logTS('Session end');
 		parent::close();
 	}
 

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -46,6 +46,7 @@ class Internal extends Session {
 		session_name($name);
 		set_error_handler(array($this, 'trapError'));
 		try {
+			session_set_save_handler(new FileSessionHandler(), true);
 			session_start();
 		} catch (\Exception $e) {
 			setcookie(session_name(), null, -1, \OC::$WEBROOT ? : '/');


### PR DESCRIPTION
I'm firing 4 ajax requests from an app simultaneously, and found them to be executed serially. This is caused by OC\Session\Internal keeping the session open for the whole request, which makes the php session blocking.
Reading http://php.net/manual/en/class.sessionhandlerinterface.php , I implemented that sample MySessionHandler, and found that this works in most situations, except for the login process which will create several sessions, but none workable.
So I derived the FileSessionHandler from the default SessionHandler, which checks if the session file is already present. If not, the standard blocking SessionHandler methods are called; otherwise, simple non-blocking reads and writes are used.
AFAICS, on a running session, only LAST_ACTIVITY will be set regularly, to limit session lifetime, so this appears quite safe to me.
