### PR TITLE
Fix CSRF token generation / validation

### DIFF
--- a/lib/private/Security/CSRF/CsrfToken.php
+++ b/lib/private/Security/CSRF/CsrfToken.php
@@ -51,8 +51,8 @@ class CsrfToken {
 	 */
 	public function getEncryptedValue() {
 		if($this->encryptedValue === '') {
-			$sharedSecret = base64_encode(random_bytes(strlen($this->value)));
-			$this->encryptedValue = base64_encode($this->value ^ $sharedSecret) . ':' . $sharedSecret;
+			$sharedSecret = random_bytes(strlen($this->value));
+			$this->encryptedValue = base64_encode($this->value ^ $sharedSecret) . ':' . base64_encode($sharedSecret);
 		}
 
 		return $this->encryptedValue;
@@ -71,6 +71,6 @@ class CsrfToken {
 		}
 		$obfuscatedToken = $token[0];
 		$secret = $token[1];
-		return base64_decode($obfuscatedToken) ^ $secret;
+		return base64_decode($obfuscatedToken) ^ base64_decode($secret);
 	}
 }

--- a/tests/lib/Security/CSRF/CsrfTokenManagerTest.php
+++ b/tests/lib/Security/CSRF/CsrfTokenManagerTest.php
@@ -137,15 +137,19 @@ class CsrfTokenManagerTest extends \Test\TestCase {
 	}
 
 	public function testIsTokenValidWithValidToken() {
+		$a = 'abc';
+		$b = 'def';
+		$xorB64 = 'BQcF';
+		$tokenVal = sprintf('%s:%s', $xorB64, base64_encode($a));
 		$this->storageInterface
 				->expects($this->once())
 				->method('hasToken')
 				->willReturn(true);
-		$token = new \OC\Security\CSRF\CsrfToken('XlQhHjgWCgBXAEI0Khl+IQEiCXN2LUcDHAQTQAc1HQs=:qgkUlg8l3m8WnkOG4XM9Az33pAt1vSVMx4hcJFsxdqc=');
+		$token = new \OC\Security\CSRF\CsrfToken($tokenVal);
 		$this->storageInterface
 				->expects($this->once())
 				->method('getToken')
-				->willReturn('/3JKTq2ldmzcDr1f5zDJ7Wt0lEgqqfKF');
+				->willReturn($b);
 
 		$this->assertSame(true, $this->csrfTokenManager->isTokenValid($token));
 	}

--- a/tests/lib/Security/CSRF/CsrfTokenTest.php
+++ b/tests/lib/Security/CSRF/CsrfTokenTest.php
@@ -36,7 +36,11 @@ class CsrfTokenTest extends \Test\TestCase {
 	}
 
 	public function testGetDecryptedValue() {
-		$csrfToken = new \OC\Security\CSRF\CsrfToken('XlQhHjgWCgBXAEI0Khl+IQEiCXN2LUcDHAQTQAc1HQs=:qgkUlg8l3m8WnkOG4XM9Az33pAt1vSVMx4hcJFsxdqc=');
-		$this->assertSame('/3JKTq2ldmzcDr1f5zDJ7Wt0lEgqqfKF', $csrfToken->getDecryptedValue());
+		$a = 'abc';
+		$b = 'def';
+		$xorB64 = 'BQcF';
+		$tokenVal = sprintf('%s:%s', $xorB64, base64_encode($a));
+		$csrfToken = new \OC\Security\CSRF\CsrfToken($tokenVal);
+		$this->assertSame($b, $csrfToken->getDecryptedValue());
 	}
 }


### PR DESCRIPTION
Operate on raw bytes instead of base64-encoded strings.
Issue was introduced in a977465