### PR TITLE
Make sure we don't scan files that can not be accessed

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -131,23 +131,12 @@ class Scanner extends BasicEmitter implements IScanner {
 	 * @throws \OCP\Lock\LockedException
 	 */
 	public function scanFile($file, $reuseExisting = 0, $parentId = -1, $cacheData = null, $lock = true) {
-
-		if (!\OC::$server->getDatabaseConnection()->supports4ByteText()) {
-			// verify database - e.g. mysql only 3-byte chars
-			if (preg_match('%(?:
-      \xF0[\x90-\xBF][\x80-\xBF]{2}      # planes 1-3
-    | [\xF1-\xF3][\x80-\xBF]{3}          # planes 4-15
-    | \xF4[\x80-\x8F][\x80-\xBF]{2}      # plane 16
-)%xs', $file)) {
-				// 4-byte characters are not supported in file names
+		if ($file !== '') {
+			try {
+				$this->storage->verifyPath(dirname($file), basename($file));
+			} catch (\Exception $e) {
 				return null;
 			}
-		}
-
-		try {
-			$this->storage->verifyPath(dirname($file), basename($file));
-		} catch (\Exception $e) {
-			return null;
 		}
 
 		// only proceed if $file is not a partial file nor a blacklisted file

--- a/lib/public/Files/EmptyFileNameException.php
+++ b/lib/public/Files/EmptyFileNameException.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Files;
+
+/**
+ * Class EmptyFileNameException
+ *
+ * @package OCP\Files
+ * @since 9.2.0
+ */
+class EmptyFileNameException extends InvalidPathException {
+}

--- a/lib/public/Files/InvalidDirectoryException.php
+++ b/lib/public/Files/InvalidDirectoryException.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Files;
+
+/**
+ * Class InvalidDirectoryException
+ *
+ * @package OCP\Files
+ * @since 9.2.0
+ */
+class InvalidDirectoryException extends InvalidPathException {
+}

--- a/tests/lib/Files/PathVerificationTest.php
+++ b/tests/lib/Files/PathVerificationTest.php
@@ -86,7 +86,7 @@ class PathVerificationTest extends \Test\TestCase {
 
 		if (!$connection->supports4ByteText()) {
 			$this->expectException(InvalidPathException::class);
-			$this->expectExceptionMessage('4-byte characters are not supported in file names');
+			$this->expectExceptionMessage('File name contains at least one invalid character');
 		}
 
 		$this->view->verifyPath('', $fileName);


### PR DESCRIPTION
### Steps
1. create a folder on the file system:
```
mkdir "data/admin/files/te
st"
```
2. Run `files:scan admin`
3. Try to delete the folder after realizing your problem

With this fix the file is not added on scanning.

@icewind1991 @MorrisJobke @LukasReschke 

Fix #1965