### PR TITLE
Throw an exception when a shipped app was not replaced before the update

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -377,6 +377,7 @@ class OC {
 		\OCP\Util::addScript('update');
 		\OCP\Util::addStyle('update');
 
+		/** @var \OCP\App\IAppManager $appManager */
 		$appManager = \OC::$server->getAppManager();
 
 		$tmpl = new OC_Template('', 'update.admin', 'guest');
@@ -385,8 +386,17 @@ class OC {
 
 		// get third party apps
 		$ocVersion = \OCP\Util::getVersion();
+		$incompatibleApps = $appManager->getIncompatibleApps($ocVersion);
+		foreach ($incompatibleApps as $appInfo) {
+			if ($appManager->isShipped($appInfo['id'])) {
+				$l = \OC::$server->getL10N('core');
+				$hint = $l->t('The files of the app "%$1s" (%$2s) were not replaced correctly.', [$appInfo['name'], $appInfo['id']]);
+				throw new \OC\HintException('The files of the app "' . $appInfo['name'] . '" (' . $appInfo['id'] . ') were not replaced correctly.', $hint);
+			}
+		}
+
 		$tmpl->assign('appsToUpgrade', $appManager->getAppsNeedingUpgrade($ocVersion));
-		$tmpl->assign('incompatibleAppsList', $appManager->getIncompatibleApps($ocVersion));
+		$tmpl->assign('incompatibleAppsList', $incompatibleApps);
 		$tmpl->assign('productName', 'Nextcloud'); // for now
 		$tmpl->assign('oldTheme', $oldTheme);
 		$tmpl->printPage();

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -381,6 +381,9 @@ class Updater extends BasicEmitter {
 			// check if the app is compatible with this version of ownCloud
 			$info = OC_App::getAppInfo($app);
 			if(!OC_App::isAppCompatible($version, $info)) {
+				if (OC_App::isShipped($app)) {
+					throw new \UnexpectedValueException('The files of the app "' . $app . '" were not correctly replaced before running the update');
+				}
 				OC_App::disable($app);
 				$this->emit('\OC\Updater', 'incompatibleAppDisabled', array($app));
 			}


### PR DESCRIPTION
A little patch to prevent errors like #1959 

Fix #1959 

@MorrisJobke @LukasReschke @rullzer 

@karlitschek should backport to stabalize the update experience.