### PR TITLE
use https by default if no protocol is given.

### DIFF
--- a/apps/federatedfilesharing/lib/AddressHandler.php
+++ b/apps/federatedfilesharing/lib/AddressHandler.php
@@ -161,6 +161,22 @@ class AddressHandler {
 	}
 
 	/**
+	 * check if the url contain the protocol (http or https)
+	 *
+	 * @param string $url
+	 * @return bool
+	 */
+	public function urlContainProtocol($url) {
+		if (strpos($url, 'https://') === 0 ||
+			strpos($url, 'http://') === 0) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Strips away a potential file names and trailing slashes:
 	 * - http://localhost
 	 * - http://localhost/

--- a/apps/federatedfilesharing/tests/AddressHandlerTest.php
+++ b/apps/federatedfilesharing/tests/AddressHandlerTest.php
@@ -178,6 +178,26 @@ class AddressHandlerTest extends \Test\TestCase {
 	}
 
 	/**
+	 * @dataProvider dataTestUrlContainProtocol
+	 *
+	 * @param string $url
+	 * @param bool $expectedResult
+	 */
+	public function testUrlContainProtocol($url, $expectedResult) {
+		$result = $this->addressHandler->urlContainProtocol($url);
+		$this->assertSame($expectedResult, $result);
+	}
+
+	public function dataTestUrlContainProtocol() {
+		return [
+			['http://nextcloud.com', true],
+			['https://nextcloud.com', true],
+			['nextcloud.com', false],
+			['httpserver.com', false],
+		];
+	}
+
+	/**
 	 * @dataProvider dataTestFixRemoteUrl
 	 *
 	 * @param string $url

--- a/apps/federatedfilesharing/tests/NotificationsTest.php
+++ b/apps/federatedfilesharing/tests/NotificationsTest.php
@@ -58,7 +58,7 @@ class NotificationsTest extends \Test\TestCase {
 
 	/**
 	 * get instance of Notifications class
-	 * 
+	 *
 	 * @param array $mockedMethods methods which should be mocked
 	 * @return Notifications | \PHPUnit_Framework_MockObject_MockObject
 	 */
@@ -81,7 +81,7 @@ class NotificationsTest extends \Test\TestCase {
 					]
 				)->setMethods($mockedMethods)->getMock();
 		}
-		
+
 		return $instance;
 	}
 
@@ -94,7 +94,7 @@ class NotificationsTest extends \Test\TestCase {
 	 * @param bool $expected
 	 */
 	public function testSendUpdateToRemote($try, $httpRequestResult, $expected) {
-		$remote = 'remote';
+		$remote = 'http://remote';
 		$id = 42;
 		$timestamp = 63576;
 		$token = 'token';
@@ -105,9 +105,6 @@ class NotificationsTest extends \Test\TestCase {
 		$instance->expects($this->once())->method('tryHttpPostToShareEndpoint')
 			->with($remote, '/'.$id.'/unshare', ['token' => $token, 'data1Key' => 'data1Value'])
 			->willReturn($httpRequestResult);
-
-		$this->addressHandler->expects($this->once())->method('removeProtocolFromUrl')
-			->with($remote)->willReturn($remote);
 
 		// only add background job on first try
 		if ($try === 0 && $expected === false) {


### PR DESCRIPTION
Until now we always used a http connection as fall-back if https falied which is not perfect from a security point of view.

This pr changes the behaviour to always use https. Only excption: if http is explicitly given (`user@http://server.org`). Existing shares continue to work because we always store the protocol as part of the server url in the share table.

cc @LukasReschke we already discussed this in the past