### PR TITLE
Adjust badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Nextcloud Server
-[![Build Status](https://drone.nextcloud.com/api/badges/nextcloud/server/status.svg)](https://drone.nextcloud.com/nextcloud/server)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/nextcloud/server/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/nextcloud/server/?branch=master)
+[![codecov](https://codecov.io/gh/nextcloud/server/branch/master/graph/badge.svg)](https://codecov.io/gh/nextcloud/server)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/209/badge)](https://bestpractices.coreinfrastructure.org/projects/209)
 [![irc](https://img.shields.io/badge/IRC-%23nextcloud%20on%20freenode-orange.svg)](https://webchat.freenode.net/?channels=nextcloud)
 [![irc](https://img.shields.io/badge/IRC-%23nextcloud--dev%20on%20freenode-blue.svg)](https://webchat.freenode.net/?channels=nextcloud-dev)
 


### PR DESCRIPTION
- Removes the Drone badge
  - This one is lying most of the time since it isn't checking master but the latest build. Thus it fails when it effectively doesn't fail. Let's remove that since it makes us look bad.
- Add CodeCov badge
- Add CII badge

cc @rullzer @MorrisJobke @jospoortvliet 

---

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>