### PR TITLE
Allow setting a maximun number of buckets for multibucket

### DIFF
--- a/lib/private/Files/Mount/ObjectHomeMountProvider.php
+++ b/lib/private/Files/Mount/ObjectHomeMountProvider.php
@@ -121,7 +121,8 @@ class ObjectHomeMountProvider implements IHomeMountProvider {
 				$config['arguments']['bucket'] = '';
 			}
 			$mapper = new \OC\Files\ObjectStore\Mapper($user);
-			$config['arguments']['bucket'] .= $mapper->getBucket();
+			$numBuckets = isset($config['arguments']['num_buckets']) ? $config['arguments']['num_buckets'] : 64;
+			$config['arguments']['bucket'] .= $mapper->getBucket($numBuckets);
 
 			$this->config->setUserValue($user->getUID(), 'homeobjectstore', 'bucket', $config['arguments']['bucket']);
 		} else {

--- a/lib/private/Files/ObjectStore/Mapper.php
+++ b/lib/private/Files/ObjectStore/Mapper.php
@@ -44,10 +44,12 @@ class Mapper {
 	}
 
 	/**
+	 * @param int $numBuckets
 	 * @return string
 	 */
-	public function getBucket() {
+	public function getBucket($numBuckets = 64) {
 		$hash = md5($this->user->getUID());
-		return substr($hash, 0, 3);
+		$num = hexdec(substr($hash, 0, 4));
+		return (string)($num % $numBuckets);
 	}
 }

--- a/tests/lib/Files/Mount/ObjectHomeMountProviderTest.php
+++ b/tests/lib/Files/Mount/ObjectHomeMountProviderTest.php
@@ -80,7 +80,7 @@ class ObjectHomeMountProviderTest extends \Test\TestCase {
 				$this->equalTo('uid'),
 				$this->equalTo('homeobjectstore'),
 				$this->equalTo('bucket'),
-				$this->equalTo('987'),
+				$this->equalTo('49'),
 				$this->equalTo(null)
 			);
 
@@ -94,7 +94,7 @@ class ObjectHomeMountProviderTest extends \Test\TestCase {
 		$this->assertArrayHasKey('objectstore', $config['arguments']);
 		$this->assertInstanceOf('Test\Files\Mount\FakeObjectStore', $config['arguments']['objectstore']);
 		$this->assertArrayHasKey('bucket', $config['arguments']);
-		$this->assertEquals('987', $config['arguments']['bucket']);
+		$this->assertEquals('49', $config['arguments']['bucket']);
 	}
 
 	public function testMultiBucketWithPrefix() {
@@ -127,7 +127,7 @@ class ObjectHomeMountProviderTest extends \Test\TestCase {
 				$this->equalTo('uid'),
 				$this->equalTo('homeobjectstore'),
 				$this->equalTo('bucket'),
-				$this->equalTo('myBucketPrefix987'),
+				$this->equalTo('myBucketPrefix49'),
 				$this->equalTo(null)
 			);
 
@@ -141,7 +141,7 @@ class ObjectHomeMountProviderTest extends \Test\TestCase {
 		$this->assertArrayHasKey('objectstore', $config['arguments']);
 		$this->assertInstanceOf('Test\Files\Mount\FakeObjectStore', $config['arguments']['objectstore']);
 		$this->assertArrayHasKey('bucket', $config['arguments']);
-		$this->assertEquals('myBucketPrefix987', $config['arguments']['bucket']);
+		$this->assertEquals('myBucketPrefix49', $config['arguments']['bucket']);
 	}
 
 	public function testMultiBucketBucketAlreadySet() {

--- a/tests/lib/Files/ObjectStore/MapperTest.php
+++ b/tests/lib/Files/ObjectStore/MapperTest.php
@@ -28,24 +28,28 @@ class MapperTest extends \Test\TestCase {
 
 	public function dataGetBucket() {
 		return [
-			['user', substr(md5('user'), 0, 3)],
-			['USER', substr(md5('USER'), 0, 3)],
-			['bc0e8b52-a66c-1035-90c6-d9663bda9e3f', substr(md5('bc0e8b52-a66c-1035-90c6-d9663bda9e3f'), 0, 3)],
+			['user', 64, '17'],
+			['USER', 64, '0'],
+			['bc0e8b52-a66c-1035-90c6-d9663bda9e3f', 64, '56'],
+			['user', 8, '1'],
+			['user', 2, '1'],
+			['USER', 2, '0'],
 		];
 	}
 
 	/**
 	 * @dataProvider dataGetBucket
 	 * @param string $username
+	 * @param int $numBuckets
 	 * @param string $expectedBucket
 	 */
-	public function testGetBucket($username, $expectedBucket) {
+	public function testGetBucket($username, $numBuckets, $expectedBucket) {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')
 			->willReturn($username);
 
 		$mapper = new Mapper($user);
 
-		$this->assertSame($expectedBucket, $mapper->getBucket());
+		$this->assertSame($expectedBucket, $mapper->getBucket($numBuckets));
 	}
 }


### PR DESCRIPTION
Note that changing this value on an existing instance is non breaking since we save the bucket for a user in the db once it's setup for the first time

cc @rullzer @MorrisJobke 