### PR TITLE
Use PHP 7.1 RC5 for CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -107,7 +107,7 @@ pipeline:
         DB: NODB
         PHP: "7.0"
   nodb-php7.1:
-    image: nextcloudci/php7.1:php7.1-6
+    image: nextcloudci/php7.1:php7.1-8
     commands:
       - NOCOVERAGE=true TEST_SELECTION=NODB ./autotest.sh sqlite
     when:
@@ -131,7 +131,7 @@ pipeline:
         DB: sqlite
         PHP: "7.0"
   sqlite-php7.1:
-    image: nextcloudci/php7.1:php7.1-6
+    image: nextcloudci/php7.1:php7.1-8
     commands:
       - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh sqlite
     when:


### PR DESCRIPTION
This image has PHP 7.1 RC5 inside and the currently used one only RC4.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>