### PR TITLE
Show a hint for system based cron user name

### DIFF
--- a/lib/private/Settings/Admin/Server.php
+++ b/lib/private/Settings/Admin/Server.php
@@ -124,6 +124,8 @@ class Server implements ISettings {
 			'cron_log'            => $this->config->getSystemValue('cron_log', true),
 			'lastcron'            => $this->config->getAppValue('core', 'lastcron', false),
 			'cronErrors'		  => $this->config->getAppValue('core', 'cronErrors'),
+			'cli_based_cron_possible' => function_exists('posix_getpwuid'),
+			'cli_based_cron_user' => function_exists('posix_getpwuid') ? posix_getpwuid(fileowner(\OC::$configDir . 'config.php'))['name'] : '',
 		];
 
 		return new TemplateResponse('settings', 'admin/server', $parameters, '');

--- a/settings/templates/admin/server.php
+++ b/settings/templates/admin/server.php
@@ -201,9 +201,22 @@
 		<input type="radio" name="mode" value="cron" class="radio"
 			   id="backgroundjobs_cron" <?php if ($_['backgroundjobs_mode'] === "cron") {
 			print_unescaped('checked="checked"');
-		} ?>>
+		}
+		if (!$_['cli_based_cron_possible']) {
+			print_unescaped('disabled');
+		}?>>
 		<label for="backgroundjobs_cron">Cron</label><br/>
-		<em><?php p($l->t("Use system's cron service to call the cron.php file every 15 minutes.")); ?></em>
+		<em><?php p($l->t("Use system's cron service to call the cron.php file every 15 minutes.")); ?>
+			<?php if($_['cli_based_cron_possible']) {
+				p($l->t('The cron.php needs to be executed by the system user "%s".', [$_['cli_based_cron_user']]));
+			} else {
+				print_unescaped(str_replace(
+					['{linkstart}', '{linkend}'],
+					['<a href="http://php.net/manual/en/book.posix.php">', ' ↗</a>'],
+					$l->t('To run this you need the PHP posix extension. See {linkstart}PHP documentation{linkend} for more details.')
+				));
+		} ?></em>
+
 	</p>
 </div>
 

--- a/tests/lib/Settings/Admin/ServerTest.php
+++ b/tests/lib/Settings/Admin/ServerTest.php
@@ -136,7 +136,9 @@ class ServerTest extends TestCase {
 				'backgroundjobs_mode' => 'ajax',
 				'cron_log'            => true,
 				'lastcron'            => false,
-				'cronErrors'		  => ''
+				'cronErrors'		  => '',
+				'cli_based_cron_possible' => true,
+				'cli_based_cron_user' => function_exists('posix_getpwuid') ? posix_getpwuid(fileowner(\OC::$configDir . 'config.php'))['name'] : '', // to not explode here because of posix extension not being disabled - which is already checked in the line above
 			],
 			''
 		);


### PR DESCRIPTION
* makes it easier to setup cron job
* gives hints for PHP documentation
* disables the cron setting if requirements not met
* fixes #1989
* this was a papercut reported by @ronnyhartenstein

This is how it looks:

<img width="663" alt="bildschirmfoto 2016-11-03 um 10 20 53" src="https://cloud.githubusercontent.com/assets/245432/19960793/3b825b08-a1af-11e6-8576-038d7104c8e9.png">

<img width="678" alt="bildschirmfoto 2016-11-03 um 10 15 35" src="https://cloud.githubusercontent.com/assets/245432/19960754/03b3a006-a1af-11e6-9f4d-8d1ebde0a181.png">
