### PR TITLE
Allow to run autotest with phpunit options

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -389,7 +389,7 @@ if [ -z "$1" ]
 	done
 else
 	FILENAME="$2"
-	if [ ! -z "$2" ] && [ ! -f "tests/$FILENAME" ]; then
+	if [ ! -z "$2" ] && [ ! -f "tests/$FILENAME" ] && [ "${FILENAME:0:2}" != "--" ]; then
 		FILENAME="../$FILENAME"
 	fi
 	execute_tests "$1" "$FILENAME" "$3"


### PR DESCRIPTION
### Example
`./autotest.sh sqlite --stop-on-error`

### Before
`phpunit ../--stop-on-error`

### After
`phpunit --stop-on-error`

@MorrisJobke @rullzer 
