### PR TITLE
add share by mail activity

### DIFF
--- a/apps/files_sharing/lib/Activity.php
+++ b/apps/files_sharing/lib/Activity.php
@@ -72,7 +72,6 @@ class Activity implements IExtension {
 	const SUBJECT_LINK_EXPIRED = 'link_expired';
 	const SUBJECT_LINK_BY_EXPIRED = 'link_by_expired';
 
-	const SUBJECT_SHARED_EMAIL = 'shared_with_email';
 	const SUBJECT_SHARED_FILE_BY_EMAIL_DOWNLOADED = 'file_shared_with_email_downloaded';
 	const SUBJECT_SHARED_FOLDER_BY_EMAIL_DOWNLOADED = 'folder_shared_with_email_downloaded';
 
@@ -250,8 +249,6 @@ class Activity implements IExtension {
 			case self::SUBJECT_UNSHARED_BY:
 				return (string) $l->t('%2$s removed the share for %1$s', $params);
 
-			case self::SUBJECT_SHARED_EMAIL:
-				return (string) $l->t('You shared %1$s with %2$s', $params);
 			case self::SUBJECT_SHARED_FILE_BY_EMAIL_DOWNLOADED:
 				return (string) $l->t('File %1$s shared by email with %2$s was downloaded', $params);
 			case self::SUBJECT_SHARED_FOLDER_BY_EMAIL_DOWNLOADED:
@@ -307,8 +304,6 @@ class Activity implements IExtension {
 			case self::SUBJECT_SHARED_WITH_BY:
 				return (string) $l->t('Shared by %2$s', $params);
 
-			case self::SUBJECT_SHARED_EMAIL:
-				return (string) $l->t('Shared with %2$s', $params);
 			case self::SUBJECT_SHARED_FILE_BY_EMAIL_DOWNLOADED:
 			case self::SUBJECT_SHARED_FOLDER_BY_EMAIL_DOWNLOADED:
 				return (string) $l->t('Downloaded by %2$s', $params);

--- a/apps/files_sharing/lib/Activity.php
+++ b/apps/files_sharing/lib/Activity.php
@@ -73,6 +73,9 @@ class Activity implements IExtension {
 	const SUBJECT_LINK_BY_EXPIRED = 'link_by_expired';
 
 	const SUBJECT_SHARED_EMAIL = 'shared_with_email';
+	const SUBJECT_SHARED_FILE_BY_EMAIL_DOWNLOADED = 'file_shared_with_email_downloaded';
+	const SUBJECT_SHARED_FOLDER_BY_EMAIL_DOWNLOADED = 'folder_shared_with_email_downloaded';
+
 	const SUBJECT_SHARED_WITH_BY = 'shared_with_by';
 	const SUBJECT_UNSHARED_BY = 'unshared_by';
 
@@ -113,7 +116,7 @@ class Activity implements IExtension {
 		return array(
 			self::TYPE_SHARED => (string) $l->t('A file or folder has been <strong>shared</strong>'),
 			self::TYPE_REMOTE_SHARE => (string) $l->t('A file or folder was shared from <strong>another server</strong>'),
-			self::TYPE_PUBLIC_LINKS => (string) $l->t('A public shared file or folder was <strong>downloaded</strong>'),
+			self::TYPE_PUBLIC_LINKS => (string) $l->t('A file or folder shared by mail or by public link was <strong>downloaded</strong>'),
 		);
 	}
 
@@ -246,8 +249,13 @@ class Activity implements IExtension {
 				return (string) $l->t('%2$s shared %1$s with you', $params);
 			case self::SUBJECT_UNSHARED_BY:
 				return (string) $l->t('%2$s removed the share for %1$s', $params);
+
 			case self::SUBJECT_SHARED_EMAIL:
 				return (string) $l->t('You shared %1$s with %2$s', $params);
+			case self::SUBJECT_SHARED_FILE_BY_EMAIL_DOWNLOADED:
+				return (string) $l->t('File %1$s shared by email with %2$s was downloaded', $params);
+			case self::SUBJECT_SHARED_FOLDER_BY_EMAIL_DOWNLOADED:
+				return (string) $l->t('Folder %1$s shared by email with %2$s was downloaded', $params);
 		}
 
 		return false;
@@ -298,8 +306,12 @@ class Activity implements IExtension {
 
 			case self::SUBJECT_SHARED_WITH_BY:
 				return (string) $l->t('Shared by %2$s', $params);
+
 			case self::SUBJECT_SHARED_EMAIL:
 				return (string) $l->t('Shared with %2$s', $params);
+			case self::SUBJECT_SHARED_FILE_BY_EMAIL_DOWNLOADED:
+			case self::SUBJECT_SHARED_FOLDER_BY_EMAIL_DOWNLOADED:
+				return (string) $l->t('Downloaded by %2$s', $params);
 
 			default:
 				return false;
@@ -312,6 +324,7 @@ class Activity implements IExtension {
 	 * Currently known types are:
 	 * * file		=> will strip away the path of the file and add a tooltip with it
 	 * * username	=> will add the avatar of the user
+	 * * email	    => will add a mailto link
 	 *
 	 * @param string $app
 	 * @param string $text
@@ -347,10 +360,11 @@ class Activity implements IExtension {
 						1 => 'username',
 						2 => '',
 					];
-				case self::SUBJECT_SHARED_EMAIL:
+				case self::SUBJECT_SHARED_FILE_BY_EMAIL_DOWNLOADED:
+				case self::SUBJECT_SHARED_FOLDER_BY_EMAIL_DOWNLOADED:
 					return array(
 						0 => 'file',
-						1 => '',// 'email' is neither supported nor planned for now
+						1 => 'email',
 					);
 
 				case self::SUBJECT_SHARED_USER_SELF:

--- a/apps/sharebymail/appinfo/app.php
+++ b/apps/sharebymail/appinfo/app.php
@@ -22,3 +22,10 @@
 $settings = new \OCA\ShareByMail\Settings();
 
 \OCP\Util::connectHook('\OCP\Config', 'js', $settings, 'announceShareProvider');
+
+\OC::$server->getActivityManager()->registerExtension(function() {
+	return new \OCA\ShareByMail\Activity(
+		\OC::$server->query('L10NFactory'),
+		\OC::$server->getActivityManager()
+	);
+});

--- a/apps/sharebymail/lib/Activity.php
+++ b/apps/sharebymail/lib/Activity.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\ShareByMail;
+
+
+use OCP\Activity\IExtension;
+use OCP\Activity\IManager;
+use OCP\IL10N;
+use OCP\L10N\IFactory;
+
+class Activity implements IExtension {
+
+	const SHARE_BY_MAIL_APP = 'sharebymail';
+
+	const SUBJECT_SHARED_EMAIL_SELF = 'shared_with_email_self';
+	const SUBJECT_SHARED_EMAIL_BY = 'shared_with_email_by';
+
+	/** @var IFactory */
+	private $languageFactory;
+
+	/** @var IManager */
+	private $activityManager;
+
+	/**
+	 * @param IFactory $languageFactory
+	 * @param IManager $activityManager
+	 */
+	public function __construct(IFactory $languageFactory, IManager $activityManager) {
+		$this->languageFactory = $languageFactory;
+		$this->activityManager = $activityManager;
+	}
+
+	/**
+	 * The extension can return an array of additional notification types.
+	 * If no additional types are to be added false is to be returned
+	 *
+	 * @param string $languageCode
+	 * @return array|false Array "stringID of the type" => "translated string description for the setting"
+	 *                or Array "stringID of the type" => [
+	 *                    'desc' => "translated string description for the setting"
+	 *                    'methods' => [self::METHOD_*],
+	 *                ]
+	 * @since 8.0.0 - 8.2.0: Added support to allow limiting notifications to certain methods
+	 */
+	public function getNotificationTypes($languageCode) {
+		return false;
+	}
+
+	/**
+	 * For a given method additional types to be displayed in the settings can be returned.
+	 * In case no additional types are to be added false is to be returned.
+	 *
+	 * @param string $method
+	 * @return array|false
+	 * @since 8.0.0
+	 */
+	public function getDefaultTypes($method) {
+		return false;
+	}
+
+	/**
+	 * A string naming the css class for the icon to be used can be returned.
+	 * If no icon is known for the given type false is to be returned.
+	 *
+	 * @param string $type
+	 * @return string|false
+	 * @since 8.0.0
+	 */
+	public function getTypeIcon($type) {
+		return false;
+	}
+
+	/**
+	 * The extension can translate a given message to the requested languages.
+	 * If no translation is available false is to be returned.
+	 *
+	 * @param string $app
+	 * @param string $text
+	 * @param array $params
+	 * @param boolean $stripPath
+	 * @param boolean $highlightParams
+	 * @param string $languageCode
+	 * @return string|false
+	 * @since 8.0.0
+	 */
+	public function translate($app, $text, $params, $stripPath, $highlightParams, $languageCode) {
+		if ($app !== self::SHARE_BY_MAIL_APP) {
+			return false;
+		}
+
+		$l = $this->getL10N($languageCode);
+
+		if ($this->activityManager->isFormattingFilteredObject()) {
+			$translation = $this->translateShort($text, $l, $params);
+			if ($translation !== false) {
+				return $translation;
+			}
+		}
+
+		return $this->translateLong($text, $l, $params);
+	}
+
+
+	/**
+	 * The extension can define the type of parameters for translation
+	 *
+	 * Currently known types are:
+	 * * file        => will strip away the path of the file and add a tooltip with it
+	 * * username    => will add the avatar of the user
+	 *
+	 * @param string $app
+	 * @param string $text
+	 * @return array|false
+	 * @since 8.0.0
+	 */
+	public function getSpecialParameterList($app, $text) {
+		if ($app === self::SHARE_BY_MAIL_APP) {
+			switch ($text) {
+				case self::SUBJECT_SHARED_EMAIL_BY:
+					return [
+						0 => 'file',
+						1 => 'email',
+						2 => 'user',
+					];
+				case self::SUBJECT_SHARED_EMAIL_SELF:
+					return [
+						0 => 'file',
+						1 => 'email',
+					];
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * The extension can define the parameter grouping by returning the index as integer.
+	 * In case no grouping is required false is to be returned.
+	 *
+	 * @param array $activity
+	 * @return integer|false
+	 * @since 8.0.0
+	 */
+	public function getGroupParameter($activity) {
+		if ($activity['app'] === self::SHARE_BY_MAIL_APP) {
+			switch ($activity['subject']) {
+				case self::SUBJECT_SHARED_EMAIL_BY:
+					// Group by file name
+					return 0;
+				case self::SUBJECT_SHARED_EMAIL_SELF:
+					// Group by user/group
+					return 1;
+			}
+		}
+
+		return false;
+
+	}
+
+	/**
+	 * The extension can define additional navigation entries. The array returned has to contain two keys 'top'
+	 * and 'apps' which hold arrays with the relevant entries.
+	 * If no further entries are to be added false is no be returned.
+	 *
+	 * @return array|false
+	 * @since 8.0.0
+	 */
+	public function getNavigation() {
+		return false;
+	}
+
+	/**
+	 * The extension can check if a customer filter (given by a query string like filter=abc) is valid or not.
+	 *
+	 * @param string $filterValue
+	 * @return boolean
+	 * @since 8.0.0
+	 */
+	public function isFilterValid($filterValue) {
+		return false;
+	}
+
+	/**
+	 * The extension can filter the types based on the filter if required.
+	 * In case no filter is to be applied false is to be returned unchanged.
+	 *
+	 * @param array $types
+	 * @param string $filter
+	 * @return array|false
+	 * @since 8.0.0
+	 */
+	public function filterNotificationTypes($types, $filter) {
+		return false;
+	}
+
+	/**
+	 * For a given filter the extension can specify the sql query conditions including parameters for that query.
+	 * In case the extension does not know the filter false is to be returned.
+	 * The query condition and the parameters are to be returned as array with two elements.
+	 * E.g. return array('`app` = ? and `message` like ?', array('mail', 'ownCloud%'));
+	 *
+	 * @param string $filter
+	 * @return array|false
+	 * @since 8.0.0
+	 */
+	public function getQueryForFilter($filter) {
+		return false;
+	}
+
+	protected function getL10N($languageCode = null) {
+		return $this->languageFactory->get(self::SHARE_BY_MAIL_APP, $languageCode);
+	}
+
+	/**
+	 * @param string $text
+	 * @param IL10N $l
+	 * @param array $params
+	 * @return bool|string
+	 */
+	protected function translateLong($text, IL10N $l, array $params) {
+
+		switch ($text) {
+			case self::SUBJECT_SHARED_EMAIL_SELF:
+				return (string) $l->t('You shared %1$s with %2$s by mail', $params);
+			case self::SUBJECT_SHARED_EMAIL_BY:
+				return (string) $l->t('%3$s shared %1$s with %2$s by mail', $params);
+		}
+
+		return false;
+	}
+
+	/**
+	 * @param string $text
+	 * @param IL10N $l
+	 * @param array $params
+	 * @return bool|string
+	 */
+	protected function translateShort($text, IL10N $l, array $params) {
+		switch ($text) {
+			case self::SUBJECT_SHARED_EMAIL_SELF:
+				return (string) $l->t('Shared with %2$s', $params);
+			case self::SUBJECT_SHARED_EMAIL_BY:
+				return (string) $l->t('Shared with %3$s by %2ks', $params);
+		}
+
+		return false;
+	}
+
+}

--- a/apps/sharebymail/lib/Activity.php
+++ b/apps/sharebymail/lib/Activity.php
@@ -166,7 +166,7 @@ class Activity implements IExtension {
 			switch ($activity['subject']) {
 				case self::SUBJECT_SHARED_EMAIL_BY:
 					// Group by file name
-					return 0;
+					return 1;
 				case self::SUBJECT_SHARED_EMAIL_SELF:
 					// Group by user/group
 					return 1;
@@ -260,7 +260,7 @@ class Activity implements IExtension {
 			case self::SUBJECT_SHARED_EMAIL_SELF:
 				return (string) $l->t('Shared with %2$s', $params);
 			case self::SUBJECT_SHARED_EMAIL_BY:
-				return (string) $l->t('Shared with %3$s by %2ks', $params);
+				return (string) $l->t('Shared with %3$s by %2$s', $params);
 		}
 
 		return false;

--- a/apps/sharebymail/tests/ActivityTest.php
+++ b/apps/sharebymail/tests/ActivityTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\ShareByMail\Tests;
+
+
+use OCA\ShareByMail\Activity;
+
+class ActivityTest extends \Test\TestCase   {
+
+	/**
+	 * @var \OCA\ShareByMail\Activity
+	 */
+	private $activity;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->activity = new Activity(
+			$this->getMockBuilder('OCP\L10N\IFactory')
+				->disableOriginalConstructor()
+				->getMock(),
+			$this->getMockBuilder('OCP\Activity\IManager')
+				->disableOriginalConstructor()
+				->getMock()
+		);
+	}
+
+	/**
+	 * @dataProvider dataTestGetSpecialParameterList
+	 *
+	 */
+	public function testGetSpecialParameterList($app, $text, $expected) {
+		$result = $this->activity->getSpecialParameterList($app, $text);
+		$this->assertSame($expected, $result);
+	}
+
+	public function dataTestGetSpecialParameterList() {
+		return [
+			['sharebymail', Activity::SUBJECT_SHARED_EMAIL_SELF, [0 => 'file', 1 => 'email']],
+			['sharebymail', Activity::SUBJECT_SHARED_EMAIL_BY, [0 => 'file', 1 => 'email', 2 => 'user']],
+			['sharebymail', 'unknown', false],
+			['randomApp', Activity::SUBJECT_SHARED_EMAIL_SELF, false],
+			['randomApp', Activity::SUBJECT_SHARED_EMAIL_BY, false],
+
+		];
+	}
+
+}
+

--- a/apps/sharebymail/tests/ShareByMailProviderTest.php
+++ b/apps/sharebymail/tests/ShareByMailProviderTest.php
@@ -76,6 +76,9 @@ class ShareByMailProviderTest extends TestCase {
 	/** @var  IShare | \PHPUnit_Framework_MockObject_MockObject */
 	private $share;
 
+	/** @var  \OCP\Activity\IManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $activityManager;
+
 	public function setUp() {
 		parent::setUp();
 
@@ -94,6 +97,7 @@ class ShareByMailProviderTest extends TestCase {
 		$this->mailer = $this->getMockBuilder('\OCP\Mail\IMailer')->getMock();
 		$this->urlGenerator = $this->getMockBuilder('\OCP\IUrlGenerator')->getMock();
 		$this->share = $this->getMockBuilder('\OCP\Share\IShare')->getMock();
+		$this->activityManager = $this->getMockBuilder('OCP\Activity\IManager')->getMock();
 
 		$this->userManager->expects($this->any())->method('userExists')->willReturn(true);
 	}
@@ -116,7 +120,8 @@ class ShareByMailProviderTest extends TestCase {
 					$this->l,
 					$this->logger,
 					$this->mailer,
-					$this->urlGenerator
+					$this->urlGenerator,
+					$this->activityManager
 				]
 			);
 
@@ -133,7 +138,8 @@ class ShareByMailProviderTest extends TestCase {
 			$this->l,
 			$this->logger,
 			$this->mailer,
-			$this->urlGenerator
+			$this->urlGenerator,
+			$this->activityManager
 		);
 
 	}
@@ -148,10 +154,11 @@ class ShareByMailProviderTest extends TestCase {
 		$share = $this->getMockBuilder('\OCP\Share\IShare')->getMock();
 		$share->expects($this->once())->method('getSharedWith')->willReturn('user1');
 
-		$instance = $this->getInstance(['getSharedWith', 'createMailShare', 'getRawShare', 'createShareObject']);
+		$instance = $this->getInstance(['getSharedWith', 'createMailShare', 'getRawShare', 'createShareObject', 'createActivity']);
 
 		$instance->expects($this->once())->method('getSharedWith')->willReturn([]);
 		$instance->expects($this->once())->method('createMailShare')->with($share)->willReturn(42);
+		$instance->expects($this->once())->method('createActivity')->with($share);
 		$instance->expects($this->once())->method('getRawShare')->with(42)->willReturn('rawShare');
 		$instance->expects($this->once())->method('createShareObject')->with('rawShare')->willReturn('shareObject');
 
@@ -614,7 +621,7 @@ class ShareByMailProviderTest extends TestCase {
 		$userManager = \OC::$server->getUserManager();
 		$rootFolder = \OC::$server->getRootFolder();
 
-		$provider = $this->getInstance(['sendMailNotification']);
+		$provider = $this->getInstance(['sendMailNotification', 'createActivity']);
 
 		$u1 = $userManager->createUser('testFed', md5(time()));
 		$u2 = $userManager->createUser('testFed2', md5(time()));
@@ -651,5 +658,5 @@ class ShareByMailProviderTest extends TestCase {
 		$u1->delete();
 		$u2->delete();
 	}
-	
+
 }

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -153,7 +153,8 @@ class ProviderFactory implements IProviderFactory {
 				$l,
 				$this->serverContainer->getLogger(),
 				$this->serverContainer->getMailer(),
-				$this->serverContainer->getURLGenerator()
+				$this->serverContainer->getURLGenerator(),
+				$this->serverContainer->getActivityManager()
 			);
 		}
 

--- a/lib/public/Activity/IExtension.php
+++ b/lib/public/Activity/IExtension.php
@@ -103,6 +103,7 @@ interface IExtension {
 	 * Currently known types are:
 	 * * file		=> will strip away the path of the file and add a tooltip with it
 	 * * username	=> will add the avatar of the user
+	 * * email 	    => will add a mailto link
 	 *
 	 * @param string $app
 	 * @param string $text

--- a/lib/public/RichObjectStrings/definitions.json
+++ b/lib/public/RichObjectStrings/definitions.json
@@ -224,5 +224,24 @@
         "example": "Support Team"
       }
     }
+  },
+  "email": {
+    "author": "Nextcloud",
+    "app": "sharebymail",
+    "since": "9.2.0",
+    "parameters": {
+      "id": {
+        "since": "9.2.0",
+        "required": true,
+        "description": "The mail-address used to identify the event on the instance",
+        "example": "test@localhost"
+      },
+      "name": {
+        "since": "9.2.0",
+        "required": true,
+        "description": "The display name of a matching contact or the email (fallback) which should be used in the visual representation",
+        "example": "Foo Bar"
+      }
+    }
   }
 }


### PR DESCRIPTION
Add share by mail activity. If a file shared by mail gets downloaded the user will see this activity:

![activity](https://cloud.githubusercontent.com/assets/1589737/19965953/c09d9144-a1c9-11e6-8dde-13d1b9459f52.png)

Following PR introduces the "email" formatter to the activity app: https://github.com/nextcloud/activity/pull/63

cc @nickvergessen  @rullzer 