### PR TITLE
Cap the number of queries we save in the query logger

### DIFF
--- a/lib/private/Cache/CappedMemoryCache.php
+++ b/lib/private/Cache/CappedMemoryCache.php
@@ -77,6 +77,10 @@ class CappedMemoryCache implements ICache, \ArrayAccess {
 		$this->remove($offset);
 	}
 
+	public function getData() {
+		return $this->cache;
+	}
+
 
 	private function garbageCollect() {
 		while (count($this->cache) > $this->capacity) {

--- a/lib/private/Diagnostics/QueryLogger.php
+++ b/lib/private/Diagnostics/QueryLogger.php
@@ -23,6 +23,7 @@
 
 namespace OC\Diagnostics;
 
+use OC\Cache\CappedMemoryCache;
 use OCP\Diagnostics\IQueryLogger;
 
 class QueryLogger implements IQueryLogger {
@@ -34,7 +35,15 @@ class QueryLogger implements IQueryLogger {
 	/**
 	 * @var \OC\Diagnostics\Query[]
 	 */
-	protected $queries = array();
+	protected $queries;
+
+	/**
+	 * QueryLogger constructor.
+	 */
+	public function __construct() {
+		$this->queries = new CappedMemoryCache(1024);
+	}
+
 
 	/**
 	 * @param string $sql
@@ -65,6 +74,6 @@ class QueryLogger implements IQueryLogger {
 	 * @return Query[]
 	 */
 	public function getQueries() {
-		return $this->queries;
+		return $this->queries->getData();
 	}
 }


### PR DESCRIPTION
Prevent memory issues when doing a lot of queries in a single request (files scan)