### PR TITLE
Fix message display on user creation error

### DIFF
--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -366,7 +366,7 @@ class UsersController extends Controller {
 				array(
 					'message' => (string) $message,
 				),
-				Http::STATUS_FORBIDDEN
+				Http::STATUS_BAD_REQUEST
 			);
 		}
 
@@ -426,7 +426,7 @@ class UsersController extends Controller {
 			array(
 				'message' => (string)$this->l10n->t('Unable to create user.')
 			),
-			Http::STATUS_FORBIDDEN
+			Http::STATUS_BAD_REQUEST
 		);
 
 	}


### PR DESCRIPTION
I don't have any error message when I try to create a user account with an invalid password - i.e. too weak or common one. A network diagnosis shows that the response to `/settings/users/users` request made [here](https://github.com/nextcloud/server/blob/master/settings/js/users/users.js#L835) is with `403 Forbidden` status code and contains plain HTML page.

I tried to change the status code which is returned in case of an error and it changes the output. It now returns a proper JSON response and the error message is well displayed. I think there is maybe two questions here:
* is `403 Forbidden` status code appropriate when the user cannot be created - due to the password length for example? I purpose `400 Bad request` status code here instead, but it's more to illustrate this issue...
* why - if I'm right and if it's not due to my installation - the response changes when the status code is different? It results here in an unexpected response which is not interpreted [here](https://github.com/nextcloud/server/blob/master/settings/js/users/users.js#L863) as it's not JSON formatted...

I'm running Nextcloud v10.0.1 with NGINX and behind a reverse proxy.

I can provide more information as needed. Thanks in advance!