### PR TITLE
allow using 'bucket' to set the swift container

### DIFF
--- a/lib/private/Files/ObjectStore/Swift.php
+++ b/lib/private/Files/ObjectStore/Swift.php
@@ -30,6 +30,7 @@ use OpenCloud\OpenStack;
 use OpenCloud\Rackspace;
 
 class Swift implements IObjectStore {
+
 	/**
 	 * @var \OpenCloud\OpenStack
 	 */
@@ -51,6 +52,9 @@ class Swift implements IObjectStore {
 	private $container;
 
 	public function __construct($params) {
+		if (isset($params['bucket'])) {
+			$params['container'] = $params['bucket'];
+		}
 		if (!isset($params['container'])) {
 			$params['container'] = 'owncloud';
 		}


### PR DESCRIPTION
For multibucket we always use `'bucket'` as config key.

Also using the same config key for swift and s3 makes things less confusing

Using `'container'` as config key still works