### PR TITLE
Removed else statement preventing Success message from displaying cau…

### DIFF
--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -235,19 +235,18 @@ $(document).ready(function () {
 					$(".personal-show-label").show();
 					$('#pass1').val('');
 					$('#pass2').val('').change();
+				}
+				if (typeof(data.data) !== "undefined") {
+					OC.msg.finishedSaving('#password-error-msg', data);
 				} else {
-					if (typeof(data.data) !== "undefined") {
-						OC.msg.finishedSaving('#password-error-msg', data);
-					} else {
-						OC.msg.finishedSaving('#password-error-msg',
-							{
-								'status' : 'error',
-								'data' : {
-									'message' : t('core', 'Unable to change password')
-								}
+					OC.msg.finishedSaving('#password-error-msg',
+						{
+							'status' : 'error',
+							'data' : {
+								'message' : t('core', 'Unable to change password')
 							}
-						);
-					}
+						}
+					);
 				}
 				$(".password-loading").remove();
 				$("#passwordbutton").removeAttr('disabled');


### PR DESCRIPTION
Removed else statement preventing "Saved" message from displaying causing bug #1875  .  Else statement is not needed since password-err-msg should show in both success and error situations.

Signed-off-by: Henry Mohn <hmohniii@gmail.com>