### PR TITLE
[stable10] Workaround for disappearing app icons for Firefox before version 51

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1957,6 +1957,17 @@ OC.Util.History = {
 		}
 		if (window.history.pushState) {
 			var url = location.pathname + '?' + strParams;
+			// Workaround for bug with SVG and window.history.pushState on Firefox < 51
+			// https://bugzilla.mozilla.org/show_bug.cgi?id=652991
+			var isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+			if (isFirefox && parseInt(navigator.userAgent.split('/').pop()) < 51) {
+				var patterns = document.querySelectorAll(selector || '[fill^="url(#"], [stroke^="url(#"]');
+				for (var i = 0, ii = patterns.length, pattern; i < ii; i++) {
+					pattern = patterns[i];
+					pattern.style.fill = pattern.style.fill;
+					pattern.style.stroke = pattern.style.stroke;
+				}
+			}
 			if (replace) {
 				window.history.replaceState(params, '', url);
 			} else {


### PR DESCRIPTION
backport of #2018 