### PR TITLE
do not double encode the redirect url

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -236,7 +236,7 @@ class SecurityMiddleware extends Middleware {
 					$url = $this->urlGenerator->linkToRoute(
 						'core.login.showLoginForm',
 						[
-							'redirect_url' => urlencode($this->request->server['REQUEST_URI']),
+							'redirect_url' => $this->request->server['REQUEST_URI'],
 						]
 					);
 					$response = new RedirectResponse($url);

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -978,7 +978,7 @@ class OC_Util {
 			header('Location: ' . \OC::$server->getURLGenerator()->linkToRoute(
 						'core.login.showLoginForm',
 						[
-							'redirect_url' => urlencode(\OC::$server->getRequest()->getRequestUri()),
+							'redirect_url' => \OC::$server->getRequest()->getRequestUri(),
 						]
 					)
 			);

--- a/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
@@ -454,7 +454,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 				'server' =>
 					[
 						'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-						'REQUEST_URI' => 'owncloud/index.php/apps/specialapp'
+						'REQUEST_URI' => 'nextcloud/index.php/apps/specialapp'
 					]
 			],
 			$this->createMock(ISecureRandom::class),
@@ -467,10 +467,10 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 			->with(
 				'core.login.showLoginForm',
 				[
-					'redirect_url' => 'owncloud%2Findex.php%2Fapps%2Fspecialapp',
+					'redirect_url' => 'nextcloud/index.php/apps/specialapp',
 				]
 			)
-			->will($this->returnValue('http://localhost/index.php/login?redirect_url=owncloud%2Findex.php%2Fapps%2Fspecialapp'));
+			->will($this->returnValue('http://localhost/nextcloud/index.php/login?redirect_url=nextcloud/index.php/apps/specialapp'));
 		$this->logger
 			->expects($this->once())
 			->method('debug')
@@ -480,7 +480,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 			'test',
 			new NotLoggedInException()
 		);
-		$expected = new RedirectResponse('http://localhost/index.php/login?redirect_url=owncloud%2Findex.php%2Fapps%2Fspecialapp');
+		$expected = new RedirectResponse('http://localhost/nextcloud/index.php/login?redirect_url=nextcloud/index.php/apps/specialapp');
 		$this->assertEquals($expected , $response);
 	}
 
@@ -489,7 +489,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 			[
 				'server' => [
 					'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-					'REQUEST_URI' => 'owncloud/index.php/apps/specialapp',
+					'REQUEST_URI' => 'nextcloud/index.php/apps/specialapp',
 				],
 			],
 			$this->createMock(ISecureRandom::class),
@@ -535,7 +535,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 				'server' =>
 					[
 						'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-						'REQUEST_URI' => 'owncloud/index.php/apps/specialapp'
+						'REQUEST_URI' => 'nextcloud/index.php/apps/specialapp'
 					]
 			],
 			$this->createMock(ISecureRandom::class),


### PR DESCRIPTION
Steps to test:
1. log out
2. go to ``/index.php/apps/files``

Before: ``/index.php/login?redirect_url=%252Findex.php%252Fapps%252Ffiles``
After: ``/index.php/login?redirect_url=/index.php/apps/files``

Parameter and other special characters are correctly escaped, e.g. ``/index.php/apps/files?param1=hello&param2=nextcloud`` becomes ``/index.php/login?redirect_url=/index.php/apps/files%3Fparam1%3Dhello%26param2%3Dnextcloud``

cc @icewind1991 @LukasReschke