### PR TITLE
Fixes files_drop for sabre 3.2

### DIFF
--- a/apps/dav/lib/Files/Sharing/FilesDropPlugin.php
+++ b/apps/dav/lib/Files/Sharing/FilesDropPlugin.php
@@ -58,13 +58,13 @@ class FilesDropPlugin extends ServerPlugin {
 	 * @return void
 	 */
 	public function initialize(\Sabre\DAV\Server $server) {
-		$server->on('beforeMethod:PUT', [$this, 'beforeMethod']);
+		$server->on('beforeMethod', [$this, 'beforeMethod'], 999);
 		$this->enabled = false;
 	}
 
 	public function beforeMethod(RequestInterface $request, ResponseInterface $response){
 
-		if (!$this->enabled) {
+		if (!$this->enabled || $request->getMethod() !== 'PUT') {
 			return;
 		}
 


### PR DESCRIPTION
In the new sabre (3.2) the order of beforeMethod is switched. it used to
be that beforeMethod:METHOD was called after beforeMethod. But now it is
called before. Since we need the view this was broken.

try to upload the same file 2 times in files_drop

Before:  => BOOM
After:  => NO BOOM

CC: @LukasReschke @nickvergessen @MorrisJobke @icewind1991 