### PR TITLE
Fixes files_drop when avatars are disabled

### DIFF
--- a/apps/files_sharing/js/files_drop.js
+++ b/apps/files_sharing/js/files_drop.js
@@ -117,7 +117,7 @@
 	};
 
 	$(document).ready(function() {
-		if($('#upload-only-interface').val() === "1") {
+		if($('#upload-only-interface').val() === "1" && oc_config.enable_avatars) {
 			$('.avatardiv').avatar($('#sharingUserId').val(), 128, true);
 		}
 


### PR DESCRIPTION
Fixes: #2080

Since we don't load the avatar.jquery.js stuff we can't call the avatar.

To test: 

1. disable avatars in config.php
2. Try to upload a file in files_drop

Before: BOOM
After: NO BOOM

CC: @michag86 @MorrisJobke @nickvergessen @LukasReschke 