### PR TITLE
Improve focus highlight

### DIFF
--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -347,6 +347,15 @@ class ThemingController extends Controller {
 				'opacity: 0.4;' .
 				'color: '.$textColor.';'.
 				"}\n";
+
+			$responseCss .= 'input[type="text"]:focus, input[type="password"]:focus, input[type="search"]:focus, input[type="number"]:focus, input[type="email"]:focus, input[type="tel"]:focus, input[type="url"]:focus, input[type="time"]:focus, input[type="date"]:focus, textarea:focus, select:focus, button:focus, .button:focus, input[type="submit"]:focus, input[type="button"]:focus, #quota:focus, .pager li a:focus { '.
+							'	border: 1px solid ' . $color . ";" .
+							"}\n";
+
+			$responseCss .= 'input[type="submit"]:focus, input[type="button"]:focus, select:focus, button:focus, .button:focus {' .
+				            ' color: ' . $color. ';'.
+							"}\n";
+			
 			$responseCss .= '.ui-widget-header { border: 1px solid ' . $color . '; background: '. $color . '; color: #ffffff;' . "}\n";
 			$responseCss .= '.ui-state-active, .ui-widget-content .ui-state-active, .ui-widget-header .ui-state-active {' .
 				'border: 1px solid ' . $color . ';' .

--- a/apps/theming/tests/Controller/ThemingControllerTest.php
+++ b/apps/theming/tests/Controller/ThemingControllerTest.php
@@ -456,6 +456,15 @@ class ThemingControllerTest extends TestCase {
 			'opacity: 0.4;' .
 			'color: #ffffff;'.
 			"}\n";
+
+		$expectedData .= 'input[type="text"]:focus, input[type="password"]:focus, input[type="search"]:focus, input[type="number"]:focus, input[type="email"]:focus, input[type="tel"]:focus, input[type="url"]:focus, input[type="time"]:focus, input[type="date"]:focus, textarea:focus, select:focus, button:focus, .button:focus, input[type="submit"]:focus, input[type="button"]:focus, #quota:focus, .pager li a:focus { '.
+			'	border: 1px solid ' . $color . ";" .
+			"}\n";
+
+		$expectedData .= 'input[type="submit"]:focus, input[type="button"]:focus, select:focus, button:focus, .button:focus {' .
+			' color: ' . $color. ';'.
+			"}\n";
+
 		$expectedData .= '.ui-widget-header { border: 1px solid ' . $color . '; background: '. $color . '; color: #ffffff;' . "}\n";
 		$expectedData .= '.ui-state-active, .ui-widget-content .ui-state-active, .ui-widget-header .ui-state-active {' .
 			'border: 1px solid ' . $color . ';' .
@@ -543,6 +552,13 @@ class ThemingControllerTest extends TestCase {
 			'background-color: '.$elementColor.';'.
 			'opacity: 0.4;' .
 			'color: #000000;'.
+			"}\n";
+		$expectedData .= 'input[type="text"]:focus, input[type="password"]:focus, input[type="search"]:focus, input[type="number"]:focus, input[type="email"]:focus, input[type="tel"]:focus, input[type="url"]:focus, input[type="time"]:focus, input[type="date"]:focus, textarea:focus, select:focus, button:focus, .button:focus, input[type="submit"]:focus, input[type="button"]:focus, #quota:focus, .pager li a:focus { '.
+			'	border: 1px solid ' . $color . ";" .
+			"}\n";
+
+		$expectedData .= 'input[type="submit"]:focus, input[type="button"]:focus, select:focus, button:focus, .button:focus {' .
+			' color: ' . $color. ';'.
 			"}\n";
 		$expectedData .= '.ui-widget-header { border: 1px solid ' . $color . '; background: '. $color . '; color: #ffffff;' . "}\n";
 		$expectedData .= '.ui-state-active, .ui-widget-content .ui-state-active, .ui-widget-header .ui-state-active {' .
@@ -719,6 +735,13 @@ class ThemingControllerTest extends TestCase {
 			'opacity: 0.4;' .
 			'color: #ffffff;'.
 			"}\n";
+		$expectedData .= 'input[type="text"]:focus, input[type="password"]:focus, input[type="search"]:focus, input[type="number"]:focus, input[type="email"]:focus, input[type="tel"]:focus, input[type="url"]:focus, input[type="time"]:focus, input[type="date"]:focus, textarea:focus, select:focus, button:focus, .button:focus, input[type="submit"]:focus, input[type="button"]:focus, #quota:focus, .pager li a:focus { '.
+			'	border: 1px solid ' . $color . ";" .
+			"}\n";
+
+		$expectedData .= 'input[type="submit"]:focus, input[type="button"]:focus, select:focus, button:focus, .button:focus {' .
+			' color: ' . $color. ';'.
+			"}\n";
 		$expectedData .= '.ui-widget-header { border: 1px solid ' . $color . '; background: '. $color . '; color: #ffffff;' . "}\n";
 		$expectedData .= '.ui-state-active, .ui-widget-content .ui-state-active, .ui-widget-header .ui-state-active {' .
 			'border: 1px solid ' . $color . ';' .
@@ -823,6 +846,13 @@ class ThemingControllerTest extends TestCase {
 			'background-color: '.$elementColor.';'.
 			'opacity: 0.4;' .
 			'color: #000000;'.
+			"}\n";
+		$expectedData .= 'input[type="text"]:focus, input[type="password"]:focus, input[type="search"]:focus, input[type="number"]:focus, input[type="email"]:focus, input[type="tel"]:focus, input[type="url"]:focus, input[type="time"]:focus, input[type="date"]:focus, textarea:focus, select:focus, button:focus, .button:focus, input[type="submit"]:focus, input[type="button"]:focus, #quota:focus, .pager li a:focus { '.
+			'	border: 1px solid ' . $color . ";" .
+			"}\n";
+
+		$expectedData .= 'input[type="submit"]:focus, input[type="button"]:focus, select:focus, button:focus, .button:focus {' .
+			' color: ' . $color. ';'.
 			"}\n";
 		$expectedData .= '.ui-widget-header { border: 1px solid ' . $color . '; background: '. $color . '; color: #ffffff;' . "}\n";
 		$expectedData .= '.ui-state-active, .ui-widget-content .ui-state-active, .ui-widget-header .ui-state-active {' .

--- a/core/css/inputs.css
+++ b/core/css/inputs.css
@@ -81,6 +81,26 @@ textarea:hover, textarea:focus, textarea:active {
 	opacity: 1;
 }
 
+
+input[type="text"]:focus,
+input[type="password"]:focus,
+input[type="search"]:focus,
+input[type="number"]:focus,
+input[type="email"]:focus,
+input[type="tel"]:focus,
+input[type="url"]:focus,
+input[type="time"]:focus,
+input[type="date"]:focus,
+textarea:focus,
+select:focus,
+button:focus, .button:focus,
+input[type="submit"]:focus,
+input[type="button"]:focus,
+#quota:focus,
+.pager li a:focus {
+	border: 1px solid #0082c9;
+}
+
 input[type="checkbox"].checkbox {
 	position: absolute;
 	left:-10000px;
@@ -408,6 +428,11 @@ input[type="submit"] img, input[type="button"] img, button img, .button img { cu
 #header .button {
 	border: none;
 	box-shadow: none;
+}
+
+input[type="submit"]:focus, input[type="button"]:focus, select:focus,
+button:focus, .button:focus {
+	color: #0082c9;
 }
 
 /* disabled input fields and buttons */


### PR DESCRIPTION
The currently focused element (e.g. input field) is only hardly visible because the css files disable drawing of the outline. This is really bad for usability especially when using keyboard navigation (with the TAB key).