### PR TITLE
Fixes not allowed increasing of link share permissions

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -692,6 +692,7 @@ class ShareAPIController extends OCSController {
 
 			if ($newPermissions !== null) {
 				$share->setPermissions($newPermissions);
+				$permissions = $newPermissions;
 			}
 
 			if ($expireDate === '') {

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -971,3 +971,20 @@ Feature: sharing
     When Deleting last share
     Then etag of element "/" of user "user1" has changed
     And etag of element "/PARENT" of user "user0" has not changed
+
+  Scenario: do not allow to increase link share permissions on reshare
+    Given As an "admin"
+    And user "admin" created a folder "/TMP"
+    And user "user0" exists
+    And creating a share with
+      | path | TMP |
+      | shareType | 0 |
+      | shareWith | user0 |
+      | permissions | 17  |
+    When As an "user0"
+    And creating a share with
+      | path | TMP |
+      | shareType | 3 |
+    And Updating last share with
+      | publicUpload | true |
+    Then the OCS status code should be "404"


### PR DESCRIPTION
Fixes the following:

1. user0 shares folder with user1 (RO but with sharing permissions)
2. user1 shares by link
3. Get the share id of the link share: `curl -u user:pass -H 'OCS-APIREQUEST: true' http://<server>/ocs/v2.php/apps/files_sharing/api/v1/shares`
4. user1 send 'publicUpload=true' OCS request to the link share: `curl -u user:pass -H 'OCS-APIREQUEST: true' http://<server>/ocs/v2.php/apps/files_sharing/api/v1/shares/<id> -X PUT -d 'publicUpload=true`

before this increased the permissions of the link share. Which should
not happen.

now: API reponds with an error that the permissions can't be increased.

CC: @LukasReschke @schiessle @nickvergessen @MorrisJobke 