### PR TITLE
fix scrollbar in settings area in Firefox, improve on @pgys pull request

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -481,6 +481,8 @@
 #app-settings-content,
 #app-settings-header {
 	border-right: 1px solid #eee;
+	width: 250px;
+	box-sizing: border-box;
 }
 
 /* display input fields at full width */

--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -463,12 +463,10 @@
 #app-settings {
 	position: fixed;
 	width: 250px; /* change to 100% when layout positions are absolute */
-	max-height: 80%;
 	bottom: 0;
 	z-index: 140;
-	overflow-x: hidden;
-	overflow-y: scroll;
 }
+#app-settings.open #app-settings-content,
 #app-settings.opened #app-settings-content {
 	display: block;
 }
@@ -476,9 +474,6 @@
 	display: none;
 	padding: 10px;
 	background-color: #fff;
-}
-#app-settings.open #app-settings-content {
-	display: block;
 	/* restrict height of settings and make scrollable */
 	max-height: 300px;
 	overflow-y: auto;


### PR DESCRIPTION
With the recent scrollability improvement, there was a small bug in Firefox where a permanent scrollbar was showing:
![capture du 2016-11-14 11-48-59](https://cloud.githubusercontent.com/assets/925062/20261956/619fc8d4-aa60-11e6-859c-20b8a15890e3.png)

This is fixed by making the content scrollable rather than the whole container. :) cc @pgys @jakobsack  @nextcloud/designers for review.