### PR TITLE
Transfer ownership only analyze home storage

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -157,6 +157,11 @@ class TransferOwnership extends Command {
 		$this->walkFiles($view, "$this->sourceUser/files",
 				function (FileInfo $fileInfo) use ($progress, $self) {
 					if ($fileInfo->getType() === FileInfo::TYPE_FOLDER) {
+						// only analyze into folders from main storage,
+						// sub-storages have an empty internal path
+						if ($fileInfo->getInternalPath() === '' && $fileInfo->getPath() !== '') {
+							return false;
+						}
 						return true;
 					}
 					$progress->advance();

--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -27,6 +27,7 @@ namespace OCA\Files\Command;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OCP\Files\FileInfo;
+use OCP\Files\IHomeStorage;
 use OCP\Files\Mount\IMountManager;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -158,8 +159,7 @@ class TransferOwnership extends Command {
 				function (FileInfo $fileInfo) use ($progress, $self) {
 					if ($fileInfo->getType() === FileInfo::TYPE_FOLDER) {
 						// only analyze into folders from main storage,
-						// sub-storages have an empty internal path
-						if ($fileInfo->getInternalPath() === '' && $fileInfo->getPath() !== '') {
+						if (!$fileInfo->getStorage()->instanceOfStorage(IHomeStorage::class)) {
 							return false;
 						}
 						return true;


### PR DESCRIPTION
From: https://github.com/owncloud/core/pull/26533

When transferring ownership, only the local files will be transferred
during the rename operation. This means that the analyzing code doesn't
need to recurse into any mount points.

Furthermore this fixes issues where FailedStorage might appear as mount
points as a result of inaccessible external storages or shares. So this
makes it more robust.