### PR TITLE
First process group shares and then user shares

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -188,7 +188,7 @@ class TransferOwnership extends Command {
 		$output->writeln("Collecting all share information for files and folder of $this->sourceUser ...");
 
 		$progress = new ProgressBar($output, count($this->shares));
-		foreach([\OCP\Share::SHARE_TYPE_USER, \OCP\Share::SHARE_TYPE_GROUP, \OCP\Share::SHARE_TYPE_LINK, \OCP\Share::SHARE_TYPE_REMOTE] as $shareType) {
+		foreach([\OCP\Share::SHARE_TYPE_GROUP, \OCP\Share::SHARE_TYPE_USER, \OCP\Share::SHARE_TYPE_LINK, \OCP\Share::SHARE_TYPE_REMOTE] as $shareType) {
 		$offset = 0;
 			while (true) {
 				$sharePage = $this->shareManager->getSharesBy($this->sourceUser, $shareType, null, true, 50, $offset);


### PR DESCRIPTION
From https://github.com/owncloud/core/pull/26526

This prevents a validation failure where the code checks whether a file
is already shared with another user, but the check disables itself when
the owner is the same. Processing the groups first prevents the check
to kick in too early when the group share still has the old owner while
we try transferring the user share.

CC: @nickvergessen @MorrisJobke @LukasReschke @icewind1991 