### PR TITLE
Remove unused $view from FilesPlugin (#26549)

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -115,7 +115,6 @@ class FilesPlugin extends ServerPlugin {
 
 	/**
 	 * @param Tree $tree
-	 * @param View $view
 	 * @param IConfig $config
 	 * @param IRequest $request
 	 * @param IPreview $previewManager
@@ -123,14 +122,12 @@ class FilesPlugin extends ServerPlugin {
 	 * @param bool $downloadAttachment
 	 */
 	public function __construct(Tree $tree,
-								View $view,
 								IConfig $config,
 								IRequest $request,
 								IPreview $previewManager,
 								$isPublic = false,
 								$downloadAttachment = true) {
 		$this->tree = $tree;
-		$this->fileView = $view;
 		$this->config = $config;
 		$this->request = $request;
 		$this->isPublic = $isPublic;

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -153,7 +153,6 @@ class ServerFactory {
 			$server->addPlugin(
 				new \OCA\DAV\Connector\Sabre\FilesPlugin(
 					$objectTree,
-					$view,
 					$this->config,
 					$this->request,
 					$this->previewManager,

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -171,7 +171,6 @@ class Server {
 				$this->server->addPlugin(
 					new FilesPlugin(
 						$this->server->tree,
-						$view,
 						\OC::$server->getConfig(),
 						$this->request,
 						\OC::$server->getPreviewManager(),

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -68,11 +68,6 @@ class FilesPluginTest extends TestCase {
 	private $plugin;
 
 	/**
-	 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject
-	 */
-	private $view;
-
-	/**
 	 * @var \OCP\IConfig | \PHPUnit_Framework_MockObject_MockObject
 	 */
 	private $config;
@@ -95,12 +90,7 @@ class FilesPluginTest extends TestCase {
 		$this->tree = $this->getMockBuilder('\Sabre\DAV\Tree')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->view = $this->getMockBuilder('\OC\Files\View')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->config = $this->getMockBuilder('\OCP\IConfig')
-			->disableOriginalConstructor()
-			->getMock();
+		$this->config = $this->createMock('\OCP\IConfig');
 		$this->config->expects($this->any())->method('getSystemValue')
 			->with($this->equalTo('data-fingerprint'), $this->equalTo(''))
 			->willReturn('my_fingerprint');
@@ -113,7 +103,6 @@ class FilesPluginTest extends TestCase {
 
 		$this->plugin = new FilesPlugin(
 			$this->tree,
-			$this->view,
 			$this->config,
 			$this->request,
 			$this->previewManager
@@ -246,7 +235,6 @@ class FilesPluginTest extends TestCase {
 	public function testGetPublicPermissions() {
 		$this->plugin = new FilesPlugin(
 			$this->tree,
-			$this->view,
 			$this->config,
 			$this->getMockBuilder('\OCP\IRequest')
 				->disableOriginalConstructor()

--- a/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
@@ -380,7 +380,6 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$this->server->addPlugin(
 			new \OCA\DAV\Connector\Sabre\FilesPlugin(
 				$this->tree,
-				$this->view,
 				$config,
 				$this->getMockBuilder('\OCP\IRequest')
 					->disableOriginalConstructor()


### PR DESCRIPTION
The Sabre FilesPlugin never uses the view so remove it.

From https://github.com/owncloud/core/pull/26549