### PR TITLE
We need to ensure that the app holding the objectstore implementation…

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -98,6 +98,11 @@ class OC_Util {
 		}
 
 		// instantiate object store implementation
+		$name = $config['class'];
+		if (strpos($name, 'OCA\\') === 0 && substr_count($name, '\\') >= 2) {
+			$segments = explode('\\', $name);
+			OC_App::loadApp(strtolower($segments[1]));
+		}
 		$config['arguments']['objectstore'] = new $config['class']($config['arguments']);
 		// mount with plain / root object store implementation
 		$config['class'] = '\OC\Files\ObjectStore\ObjectStoreStorage';


### PR DESCRIPTION
… is loaded - fixes owncloud/core#26299

* also fixes the setup issue with other objectstores
* steps: configure objectstore in config.php before installing, then run the installer

cc @icewind1991 @rullzer 

@icewind1991 or did you fixed this differently in your objectstore implementation? This helps to load the apps that are not shipped in core by default.