### PR TITLE
disabling dropping on dragging objects temporarily

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -379,14 +379,19 @@ var dragOptions={
 			$selectedFiles = $(this);
 		}
 		$selectedFiles.closest('tr').addClass('animate-opacity dragging');
+		$selectedFiles.closest('tr').filter('.ui-droppable').droppable( 'disable' );
+
 	},
 	stop: function(event, ui) {
 		var $selectedFiles = $('td.filename input:checkbox:checked');
 		if (!$selectedFiles.length) {
 			$selectedFiles = $(this);
 		}
+
 		var $tr = $selectedFiles.closest('tr');
 		$tr.removeClass('dragging');
+		$tr.filter('.ui-droppable').droppable( 'enable' );
+
 		setTimeout(function() {
 			$tr.removeClass('animate-opacity');
 		}, 300);
@@ -454,4 +459,3 @@ function fileDownloadPath(dir, file) {
 
 // for backward compatibility
 window.Files = OCA.Files.Files;
-


### PR DESCRIPTION
* downstream of https://github.com/owncloud/core/pull/26555/commits
* how to test: try to drag a folder and drop it on itself (before: "Could not move "%filename%"" is shown, after: it's not possible to drop there)

I tested this and it works 👍 

cc @nickvergessen @nextcloud/javascript @rullzer 
