### PR TITLE
Cache js, css and woff files for a week

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -21,8 +21,13 @@
   </IfModule>
 
   # Add cache control for static resources
-  <FilesMatch "\.(css|js|woff|svg|gif)$">
-    Header set Cache-Control "max-age=7200, public"
+  <FilesMatch "\.(css|js|svg|gif)$">
+    Header set Cache-Control "max-age=15778463"
+  </FilesMatch>
+  
+  # Let browsers cache WOFF files for a week
+  <FilesMatch "\.woff$">
+    Header set Cache-Control "max-age=604800"
   </FilesMatch>
 </IfModule>
 <IfModule mod_php5.c>


### PR DESCRIPTION
From: https://github.com/owncloud/core/pull/26591

increases the cache duration for css and js files from 2 hours to half a year. Should they change the versionhash changes as well and a new file is fetched. Half a year should be long enough for oc updates.

Also allows caching woff files for 7 days. Currently, there is no versionhash available, but pressing F5 will also refresh the woff files.

CC: @MorrisJobke @nickvergessen @LukasReschke @icewind1991 