### PR TITLE
Skip updating unchanged user settings

### DIFF
--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -212,13 +212,15 @@ class AllConfig implements \OCP\IConfig {
 			throw new \UnexpectedValueException('Only integers, floats and strings are allowed as value');
 		}
 
-		// do not change identical value to reduce database traffic
 		$curval=$this->getUserValue($userId, $appName, $key);
+		if (isset($preCondition)) {
+			if ($curval !== $preCondition)
+				throw new OCP\PreConditionNotMetException();				
+		}
+			
+		// do not change identical value to reduce database traffic
 		if ($curval === $value)
 			return;
-
-		// TODO - FIXME
-		$this->fixDIInit();
 
 		$preconditionArray = [];
 		if (isset($preCondition)) {

--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -212,6 +212,11 @@ class AllConfig implements \OCP\IConfig {
 			throw new \UnexpectedValueException('Only integers, floats and strings are allowed as value');
 		}
 
+		// do not change identical value to reduce database traffic
+		$curval=$this->getUserValue($userId, $appName, $key);
+		if ($curval === $value)
+			return;
+
 		// TODO - FIXME
 		$this->fixDIInit();
 


### PR DESCRIPTION
This partially addresses https://github.com/nextcloud/server/issues/366

This small check will skip updating the user settings if the value doesn't change. Each unnecessary update will create two database roundtrips (one failed insert, one update). In case of PostgreSQL, a multitude of constraint violations is logged, and the table is bloated. 
I found an average ajax call execution time reduced by 10% by suppressing unnecessary user_ldap:uid and user_ldap:displayName updates.