### PR TITLE
Use 11.0 instead 9.2

### DIFF
--- a/apps/admin_audit/appinfo/info.xml
+++ b/apps/admin_audit/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<author>Nextcloud</author>
 	<version>1.1.0</version>
 	<dependencies>
-		<owncloud min-version="9.2" max-version="9.2" />
+		<nextcloud min-version="11" max-version="11" />
 	</dependencies>
 	<types>
 		<logging/>

--- a/apps/comments/appinfo/info.xml
+++ b/apps/comments/appinfo/info.xml
@@ -8,7 +8,7 @@
 	<default_enable/>
 	<version>1.1.0</version>
 	<dependencies>
-		<owncloud min-version="9.2" max-version="9.2" />
+		<nextcloud min-version="11" max-version="11" />
 	</dependencies>
 	<types>
 		<logging/>

--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -15,7 +15,7 @@
 		<webdav>appinfo/v1/publicwebdav.php</webdav>
 	</public>
 	<dependencies>
-		<owncloud min-version="9.2" max-version="9.2" />
+		<nextcloud min-version="11" max-version="11" />
 	</dependencies>
 	<background-jobs>
 		<job>OCA\DAV\CardDAV\SyncJob</job>

--- a/apps/encryption/appinfo/info.xml
+++ b/apps/encryption/appinfo/info.xml
@@ -25,7 +25,7 @@
 	</types>
 	<dependencies>
 		<lib>openssl</lib>
-		<owncloud min-version="9.2" max-version="9.2" />
+		<nextcloud min-version="11" max-version="11" />
 	</dependencies>
 	<settings>
 		<admin>OCA\Encryption\Settings\Admin</admin>

--- a/apps/federatedfilesharing/appinfo/info.xml
+++ b/apps/federatedfilesharing/appinfo/info.xml
@@ -9,7 +9,7 @@
     <namespace>FederatedFileSharing</namespace>
     <category>other</category>
     <dependencies>
-        <owncloud min-version="9.2" max-version="9.2" />
+        <nextcloud min-version="11" max-version="11" />
     </dependencies>
     <settings>
         <admin>OCA\FederatedFileSharing\Settings\Admin</admin>

--- a/apps/federation/appinfo/info.xml
+++ b/apps/federation/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<namespace>Federation</namespace>
 	<category>other</category>
 	<dependencies>
-		<owncloud min-version="9.2" max-version="9.2" />
+		<nextcloud min-version="11" max-version="11" />
 	</dependencies>
 	<default_enable/>
 	<types>

--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -11,7 +11,7 @@
 		<filesystem/>
 	</types>
 	<dependencies>
-		<owncloud min-version="9.2" max-version="9.2" />
+		<nextcloud min-version="11" max-version="11" />
 	</dependencies>
 	<documentation>
 		<user>user-files</user>

--- a/apps/files_external/appinfo/info.xml
+++ b/apps/files_external/appinfo/info.xml
@@ -22,7 +22,7 @@
 	<namespace>Files_External</namespace>
 
 	<dependencies>
-		<owncloud min-version="9.2" max-version="9.2" />
+		<nextcloud min-version="11" max-version="11" />
 	</dependencies>
 
 	<settings>

--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -15,7 +15,7 @@ Turning the feature off removes shared files and folders on the server for all s
 		<filesystem/>
 	</types>
 	<dependencies>
-		<owncloud min-version="9.2" max-version="9.2" />
+		<nextcloud min-version="11" max-version="11" />
 	</dependencies>
 	<public>
 		<files>public.php</files>

--- a/apps/files_trashbin/appinfo/info.xml
+++ b/apps/files_trashbin/appinfo/info.xml
@@ -16,7 +16,7 @@ To prevent a user from running out of disk space, the Deleted files app will not
 	</types>
 	<namespace>Files_Trashbin</namespace>
 	<dependencies>
-		<owncloud min-version="9.2" max-version="9.2" />
+		<nextcloud min-version="11" max-version="11" />
 	</dependencies>
 	<documentation>
 		<user>user-trashbin</user>

--- a/apps/files_versions/appinfo/info.xml
+++ b/apps/files_versions/appinfo/info.xml
@@ -14,7 +14,7 @@ In addition to the expiry of versions, the versions app makes certain never to u
 	</types>
 	<namespace>Files_Versions</namespace>
 	<dependencies>
-		<owncloud min-version="9.2" max-version="9.2" />
+		<nextcloud min-version="11" max-version="11" />
 	</dependencies>
 	<documentation>
 		<user>user-versions</user>

--- a/apps/provisioning_api/appinfo/info.xml
+++ b/apps/provisioning_api/appinfo/info.xml
@@ -23,6 +23,6 @@
 		<prevent_group_restriction/>
 	</types>
 	<dependencies>
-		<owncloud min-version="9.2" max-version="9.2" />
+		<nextcloud min-version="11" max-version="11" />
 	</dependencies>
 </info>

--- a/apps/sharebymail/appinfo/info.xml
+++ b/apps/sharebymail/appinfo/info.xml
@@ -9,7 +9,7 @@
     <namespace>ShareByMail</namespace>
     <category>other</category>
     <dependencies>
-        <owncloud min-version="9.2" max-version="9.2" />
+        <nextcloud min-version="11" max-version="11" />
     </dependencies>
     <default_enable/>
 </info>

--- a/apps/systemtags/appinfo/info.xml
+++ b/apps/systemtags/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<default_enable/>
 	<version>1.1.3</version>
 	<dependencies>
-		<owncloud min-version="9.2" max-version="9.2" />
+		<nextcloud min-version="11" max-version="11" />
 	</dependencies>
 	<namespace>SystemTags</namespace>
 	<types>

--- a/apps/testing/appinfo/info.xml
+++ b/apps/testing/appinfo/info.xml
@@ -7,6 +7,6 @@
 	<author>Joas Schilling</author>
 	<version>1.1.0</version>
 	<dependencies>
-		<owncloud min-version="9.2" max-version="9.2" />
+		<nextcloud min-version="11" max-version="11" />
 	</dependencies>
 </info>

--- a/apps/theming/appinfo/info.xml
+++ b/apps/theming/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<category>other</category>
 
 	<dependencies>
-		<owncloud min-version="9.2" max-version="9.2" />
+		<nextcloud min-version="11" max-version="11" />
 	</dependencies>
 
 	<types>

--- a/apps/twofactor_backupcodes/appinfo/info.xml
+++ b/apps/twofactor_backupcodes/appinfo/info.xml
@@ -14,6 +14,6 @@
 	</two-factor-providers>
 
 	<dependencies>
-		<owncloud min-version="9.2" max-version="9.2" />
+		<nextcloud min-version="11" max-version="11" />
 	</dependencies>
 </info>

--- a/apps/updatenotification/appinfo/info.xml
+++ b/apps/updatenotification/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<namespace>UpdateNotification</namespace>
 	<default_enable/>
 	<dependencies>
-		<owncloud min-version="9.2" max-version="9.2" />
+		<nextcloud min-version="11" max-version="11" />
 	</dependencies>
 
 	<background-jobs>

--- a/apps/user_ldap/appinfo/info.xml
+++ b/apps/user_ldap/appinfo/info.xml
@@ -18,7 +18,7 @@ A user logs into ownCloud with their LDAP or AD credentials, and is granted acce
 	</documentation>
 	<dependencies>
 		<lib>ldap</lib>
-		<owncloud min-version="9.2" max-version="9.2" />
+		<nextcloud min-version="11" max-version="11" />
 	</dependencies>
 
 	<namespace>User_LDAP</namespace>

--- a/apps/workflowengine/appinfo/info.xml
+++ b/apps/workflowengine/appinfo/info.xml
@@ -18,7 +18,7 @@
 	</types>
 
 	<dependencies>
-		<owncloud min-version="9.2" max-version="9.2" />
+		<nextcloud min-version="11" max-version="11" />
 	</dependencies>
 
 	<settings>

--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -734,7 +734,7 @@
 		/**
 		 * Returns the dav.Client instance used internally
 		 *
-		 * @since 9.2
+		 * @since 11.0.0
 		 * @return {dav.Client}
 		 */
 		getClient: function() {
@@ -744,7 +744,7 @@
 		/**
 		 * Returns the user name
 		 *
-		 * @since 9.2
+		 * @since 11.0.0
 		 * @return {String} userName
 		 */
 		getUserName: function() {
@@ -754,7 +754,7 @@
 		/**
 		 * Returns the password 
 		 *
-		 * @since 9.2
+		 * @since 11.0.0
 		 * @return {String} password
 		 */
 		getPassword: function() {
@@ -764,7 +764,7 @@
 		/**
 		 * Returns the base URL
 		 *
-		 * @since 9.2
+		 * @since 11.0.0
 		 * @return {String} base URL
 		 */
 		getBaseUrl: function() {

--- a/core/js/public/appconfig.js
+++ b/core/js/public/appconfig.js
@@ -20,7 +20,7 @@
 
 /**
  * @namespace
- * @since 9.2.0
+ * @since 11.0.0
  */
 OCP.AppConfig = {
 	/**
@@ -46,7 +46,7 @@ OCP.AppConfig = {
 	/**
 	 * @param {Object} [options]
 	 * @param {function} [options.success]
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	getApps: function(options) {
 		this._call('get', '', options);
@@ -57,7 +57,7 @@ OCP.AppConfig = {
 	 * @param {Object} [options]
 	 * @param {function} [options.success]
 	 * @param {function} [options.error]
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	getKeys: function(app, options) {
 		this._call('get', '/' + app, options);
@@ -70,7 +70,7 @@ OCP.AppConfig = {
 	 * @param {Object} [options]
 	 * @param {function} [options.success]
 	 * @param {function} [options.error]
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	getValue: function(app, key, defaultValue, options) {
 		options = options || {};
@@ -88,7 +88,7 @@ OCP.AppConfig = {
 	 * @param {Object} [options]
 	 * @param {function} [options.success]
 	 * @param {function} [options.error]
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	setValue: function(app, key, value, options) {
 		options = options || {};
@@ -105,7 +105,7 @@ OCP.AppConfig = {
 	 * @param {Object} [options]
 	 * @param {function} [options.success]
 	 * @param {function} [options.error]
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	deleteKey: function(app, key, options) {
 		this._call('delete', '/' + app + '/' + key, options);

--- a/lib/private/App/DependencyAnalyzer.php
+++ b/lib/private/App/DependencyAnalyzer.php
@@ -336,13 +336,9 @@ class DependencyAnalyzer {
 		switch ($version) {
 			case '9.1':
 				return '10';
-			case '9.2':
-				return '11';
 			default:
 				if (strpos($version, '9.1.') === 0) {
 					$version = '10.0.' . substr($version, 4);
-				} else if (strpos($version, '9.2.') === 0) {
-					$version = '11.0.' . substr($version, 4);
 				}
 				return $version;
 		}

--- a/lib/private/AppFramework/Db/Db.php
+++ b/lib/private/AppFramework/Db/Db.php
@@ -306,7 +306,7 @@ class Db implements IDb {
 	 * Check whether or not the current database support 4byte wide unicode
 	 *
 	 * @return bool
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function supports4ByteText() {
 		return $this->connection->supports4ByteText();

--- a/lib/private/Comments/Comment.php
+++ b/lib/private/Comments/Comment.php
@@ -207,7 +207,7 @@ class Comment implements IComment {
 	 * returns an array containing mentions that are included in the comment
 	 *
 	 * @return array each mention provides a 'type' and an 'id', see example below
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 *
 	 * The return array looks like:
 	 * [

--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -768,7 +768,7 @@ class Manager implements ICommentsManager {
 	 * @param string $type
 	 * @param \Closure $closure
 	 * @throws \OutOfBoundsException
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 *
 	 * Only one resolver shall be registered per type. Otherwise a
 	 * \OutOfBoundsException has to thrown.
@@ -790,7 +790,7 @@ class Manager implements ICommentsManager {
 	 * @param string $id
 	 * @return string
 	 * @throws \OutOfBoundsException
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 *
 	 * If a provided type was not registered, an \OutOfBoundsException shall
 	 * be thrown. It is upon the resolver discretion what to return of the

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -412,7 +412,7 @@ class Connection extends \Doctrine\DBAL\Connection implements IDBConnection {
 	 * Check whether or not the current database support 4byte wide unicode
 	 *
 	 * @return bool
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function supports4ByteText() {
 		return ! ($this->getDatabasePlatform() instanceof MySqlPlatform && $this->getParams()['charset'] !== 'utf8mb4');

--- a/lib/private/Notification/Notification.php
+++ b/lib/private/Notification/Notification.php
@@ -289,7 +289,7 @@ class Notification implements INotification {
 	 * @param array $parameters
 	 * @return $this
 	 * @throws \InvalidArgumentException if the subject or parameters are invalid
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function setRichSubject($subject, array $parameters = []) {
 		if (!is_string($subject) || $subject === '') {
@@ -304,7 +304,7 @@ class Notification implements INotification {
 
 	/**
 	 * @return string
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getRichSubject() {
 		return $this->subjectRich;
@@ -312,7 +312,7 @@ class Notification implements INotification {
 
 	/**
 	 * @return array[]
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getRichSubjectParameters() {
 		return $this->subjectRichParameters;
@@ -379,7 +379,7 @@ class Notification implements INotification {
 	 * @param array $parameters
 	 * @return $this
 	 * @throws \InvalidArgumentException if the message or parameters are invalid
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function setRichMessage($message, array $parameters = []) {
 		if (!is_string($message) || $message === '') {
@@ -394,7 +394,7 @@ class Notification implements INotification {
 
 	/**
 	 * @return string
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getRichMessage() {
 		return $this->messageRich;
@@ -402,7 +402,7 @@ class Notification implements INotification {
 
 	/**
 	 * @return array[]
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getRichMessageParameters() {
 		return $this->messageRichParameters;
@@ -434,7 +434,7 @@ class Notification implements INotification {
 	 * @param string $icon
 	 * @return $this
 	 * @throws \InvalidArgumentException if the icon is invalid
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function setIcon($icon) {
 		if (!is_string($icon) || $icon === '' || isset($icon[4000])) {
@@ -446,7 +446,7 @@ class Notification implements INotification {
 
 	/**
 	 * @return string
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getIcon() {
 		return $this->icon;

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -155,7 +155,7 @@ class PreviewManager implements IPreview {
 	 * @param string $mimeType
 	 * @return ISimpleFile
 	 * @throws NotFoundException
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getPreview(File $file, $width = -1, $height = -1, $crop = false, $mode = IPreview::MODE_FILL, $mimeType = null) {
 		if ($this->generator === null) {

--- a/lib/private/RichObjectStrings/Validator.php
+++ b/lib/private/RichObjectStrings/Validator.php
@@ -30,7 +30,7 @@ use OCP\RichObjectStrings\IValidator;
  * Class Validator
  *
  * @package OCP\RichObjectStrings
- * @since 9.2.0
+ * @since 11.0.0
  */
 class Validator implements IValidator {
 
@@ -53,7 +53,7 @@ class Validator implements IValidator {
 	 * @param string $subject
 	 * @param array[] $parameters
 	 * @throws InvalidObjectExeption
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function validate($subject, array $parameters) {
 		$matches = [];

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -375,7 +375,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * returns how many users have logged in once
 	 *
 	 * @return int
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function countSeenUsers() {
 		$queryBuilder = \OC::$server->getDatabaseConnection()->getQueryBuilder();
@@ -395,7 +395,7 @@ class Manager extends PublicEmitter implements IUserManager {
 
 	/**
 	 * @param \Closure $callback
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function callForSeenUsers(\Closure $callback) {
 		$limit = 1000;

--- a/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
@@ -88,7 +88,7 @@ class EmptyContentSecurityPolicy {
 	 *
 	 * @param string $nonce
 	 * @return $this
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function useJsNonce($nonce) {
 		$this->useJsNonce = $nonce;

--- a/lib/public/AppFramework/Http/FileDisplayResponse.php
+++ b/lib/public/AppFramework/Http/FileDisplayResponse.php
@@ -28,7 +28,7 @@ use OCP\AppFramework\Http;
  * Class FileDisplayResponse
  *
  * @package OCP\AppFramework\Http
- * @since 9.2.0
+ * @since 11.0.0
  */
 class FileDisplayResponse extends Response implements ICallbackResponse {
 
@@ -41,7 +41,7 @@ class FileDisplayResponse extends Response implements ICallbackResponse {
 	 * @param \OCP\Files\File|\OCP\Files\SimpleFS\ISimpleFile $file
 	 * @param int $statusCode
 	 * @param array $headers
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function __construct($file, $statusCode=Http::STATUS_OK,
 								$headers=[]) {
@@ -58,7 +58,7 @@ class FileDisplayResponse extends Response implements ICallbackResponse {
 
 	/**
 	 * @param IOutput $output
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function callback(IOutput $output) {
 		if ($output->getHttpResponseCode() !== Http::STATUS_NOT_MODIFIED) {

--- a/lib/public/AppFramework/OCSController.php
+++ b/lib/public/AppFramework/OCSController.php
@@ -76,7 +76,7 @@ abstract class OCSController extends ApiController {
 
 	/**
 	 * @param int $version
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 * @internal
 	 */
 	public function setOCSVersion($version) {

--- a/lib/public/Comments/IComment.php
+++ b/lib/public/Comments/IComment.php
@@ -136,7 +136,7 @@ interface IComment {
 	 * returns an array containing mentions that are included in the comment
 	 *
 	 * @return array each mention provides a 'type' and an 'id', see example below
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 *
 	 * The return array looks like:
 	 * [

--- a/lib/public/Comments/ICommentsEventHandler.php
+++ b/lib/public/Comments/ICommentsEventHandler.php
@@ -27,13 +27,13 @@ namespace OCP\Comments;
  * Interface ICommentsEventHandler
  *
  * @package OCP\Comments
- * @since 9.2.0
+ * @since 11.0.0
  */
 interface ICommentsEventHandler {
 
 	/**
 	 * @param CommentsEvent $event
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function handle(CommentsEvent $event);
 }

--- a/lib/public/Comments/ICommentsManager.php
+++ b/lib/public/Comments/ICommentsManager.php
@@ -242,7 +242,7 @@ interface ICommentsManager {
 	 * to consumers of the comments infrastructure
 	 *
 	 * @param \Closure $closure
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function registerEventHandler(\Closure $closure);
 
@@ -252,7 +252,7 @@ interface ICommentsManager {
 	 * @param string $type
 	 * @param \Closure $closure
 	 * @throws \OutOfBoundsException
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 *
 	 * Only one resolver shall be registered per type. Otherwise a
 	 * \OutOfBoundsException has to thrown.
@@ -266,7 +266,7 @@ interface ICommentsManager {
 	 * @param string $id
 	 * @return string
 	 * @throws \OutOfBoundsException
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 *
 	 * If a provided type was not registered, an \OutOfBoundsException shall
 	 * be thrown. It is upon the resolver discretion what to return of the

--- a/lib/public/Diagnostics/IQuery.php
+++ b/lib/public/Diagnostics/IQuery.php
@@ -50,13 +50,13 @@ interface IQuery {
 
 	/**
 	 * @return float
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getStartTime();
 
 	/**
 	 * @return array
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getStacktrace();
 }

--- a/lib/public/Files/Config/ICachedMountInfo.php
+++ b/lib/public/Files/Config/ICachedMountInfo.php
@@ -73,7 +73,7 @@ interface ICachedMountInfo {
 	 * Get the internal path (within the storage) of the root of the mount
 	 *
 	 * @return string
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getRootInternalPath();
 }

--- a/lib/public/Files/IAppData.php
+++ b/lib/public/Files/IAppData.php
@@ -28,7 +28,7 @@ use OCP\Files\SimpleFS\ISimpleRoot;
  * Interface IAppData
  *
  * @package OCP\Files
- * @since 9.2.0
+ * @since 11.0.0
  * @internal This interface is experimental and might change for NC12
  */
 interface IAppData extends ISimpleRoot  {

--- a/lib/public/Files/SimpleFS/ISimpleFile.php
+++ b/lib/public/Files/SimpleFS/ISimpleFile.php
@@ -28,7 +28,7 @@ use OCP\Files\NotPermittedException;
  * Interface ISimpleFile
  *
  * @package OCP\Files\SimpleFS
- * @since 9.2.0
+ * @since 11.0.0
  * @internal This interface is experimental and might change for NC12
  */
 interface ISimpleFile {
@@ -37,7 +37,7 @@ interface ISimpleFile {
 	 * Get the name
 	 *
 	 * @return string
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getName();
 
@@ -45,7 +45,7 @@ interface ISimpleFile {
 	 * Get the size in bytes
 	 *
 	 * @return int
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getSize();
 
@@ -53,7 +53,7 @@ interface ISimpleFile {
 	 * Get the ETag
 	 *
 	 * @return string
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getETag();
 
@@ -61,7 +61,7 @@ interface ISimpleFile {
 	 * Get the last modification time
 	 *
 	 * @return int
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getMTime();
 
@@ -69,7 +69,7 @@ interface ISimpleFile {
 	 * Get the content
 	 *
 	 * @return string
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getContent();
 
@@ -78,7 +78,7 @@ interface ISimpleFile {
 	 *
 	 * @param string $data
 	 * @throws NotPermittedException
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function putContent($data);
 
@@ -86,7 +86,7 @@ interface ISimpleFile {
 	 * Delete the file
 	 *
 	 * @throws NotPermittedException
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function delete();
 
@@ -94,7 +94,7 @@ interface ISimpleFile {
 	 * Get the MimeType
 	 *
 	 * @return string
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getMimeType();
 }

--- a/lib/public/Files/SimpleFS/ISimpleFolder.php
+++ b/lib/public/Files/SimpleFS/ISimpleFolder.php
@@ -29,7 +29,7 @@ use OCP\Files\NotPermittedException;
  * Interface ISimpleFolder
  *
  * @package OCP\Files\SimpleFS
- * @since 9.2.0
+ * @since 11.0.0
  * @internal This interface is experimental and might change for NC12
  */
 interface ISimpleFolder {
@@ -37,7 +37,7 @@ interface ISimpleFolder {
 	 * Get all the files in a folder
 	 *
 	 * @return ISimpleFile[]
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getDirectoryListing();
 
@@ -46,7 +46,7 @@ interface ISimpleFolder {
 	 *
 	 * @param string $name
 	 * @return bool
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function fileExists($name);
 
@@ -56,7 +56,7 @@ interface ISimpleFolder {
 	 * @param string $name
 	 * @return ISimpleFile
 	 * @throws NotFoundException
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getFile($name);
 
@@ -66,7 +66,7 @@ interface ISimpleFolder {
 	 * @param string $name
 	 * @return ISimpleFile
 	 * @throws NotPermittedException
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function newFile($name);
 
@@ -74,7 +74,7 @@ interface ISimpleFolder {
 	 * Remove the folder and all the files in it
 	 *
 	 * @throws NotPermittedException
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function delete();
 
@@ -82,7 +82,7 @@ interface ISimpleFolder {
 	 * Get the folder name
 	 *
 	 * @return string
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getName();
 }

--- a/lib/public/Files/SimpleFS/ISimpleRoot.php
+++ b/lib/public/Files/SimpleFS/ISimpleRoot.php
@@ -29,7 +29,7 @@ use OCP\Files\NotPermittedException;
  * Interface ISimpleRoot
  *
  * @package OCP\Files\SimpleFS
- * @since 9.2.0
+ * @since 11.0.0
  * @internal This interface is experimental and might change for NC12
  */
 interface ISimpleRoot {
@@ -40,7 +40,7 @@ interface ISimpleRoot {
 	 * @return ISimpleFolder
 	 * @throws NotFoundException
 	 * @throws \RuntimeException
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getFolder($name);
 
@@ -50,7 +50,7 @@ interface ISimpleRoot {
 	 * @return ISimpleFolder[]
 	 * @throws NotFoundException
 	 * @throws \RuntimeException
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getDirectoryListing();
 
@@ -61,7 +61,7 @@ interface ISimpleRoot {
 	 * @return ISimpleFolder
 	 * @throws NotPermittedException
 	 * @throws \RuntimeException
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function newFolder($name);
 }

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -256,7 +256,7 @@ interface IDBConnection {
 	 * Check whether or not the current database support 4byte wide unicode
 	 *
 	 * @return bool
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function supports4ByteText();
 }

--- a/lib/public/IPreview.php
+++ b/lib/public/IPreview.php
@@ -99,7 +99,7 @@ interface IPreview {
 	 * @param string $mimeType To force a given mimetype for the file (files_versions needs this)
 	 * @return ISimpleFile
 	 * @throws NotFoundException
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getPreview(File $file, $width = -1, $height = -1, $crop = false, $mode = IPreview::MODE_FILL, $mimeType = null);
 

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -148,13 +148,13 @@ interface IUserManager {
 	 * returns how many users have logged in once
 	 *
 	 * @return int
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function countSeenUsers();
 
 	/**
 	 * @param \Closure $callback
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function callForSeenUsers(\Closure $callback);
 

--- a/lib/public/LDAP/IDeletionFlagSupport.php
+++ b/lib/public/LDAP/IDeletionFlagSupport.php
@@ -26,20 +26,20 @@ namespace OCP\LDAP;
  * Interface IDeletionFlagSupport
  *
  * @package OCP\LDAP
- * @since 9.2.0
+ * @since 11.0.0
  */
 interface IDeletionFlagSupport {
 	/**
 	 * Flag record for deletion.
 	 * @param string $uid user id
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function flagRecord($uid);
 	
 	/**
 	 * Unflag record for deletion.
 	 * @param string $uid user id
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function unflagRecord($uid);
 }

--- a/lib/public/LDAP/ILDAPProvider.php
+++ b/lib/public/LDAP/ILDAPProvider.php
@@ -26,14 +26,14 @@ namespace OCP\LDAP;
  * Interface ILDAPProvider
  *
  * @package OCP\LDAP
- * @since 9.2.0
+ * @since 11.0.0
  */
 interface ILDAPProvider {
 	/**
 	 * Translate a user id to LDAP DN.
 	 * @param string $uid user id
 	 * @return string
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getUserDN($uid);
 	
@@ -42,7 +42,7 @@ interface ILDAPProvider {
 	 * @param string $dn LDAP DN
 	 * @return string with the internal user name
 	 * @throws \Exception if translation was unsuccessful
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getUserName($dn);
 	
@@ -50,7 +50,7 @@ interface ILDAPProvider {
 	 * Convert a stored DN so it can be used as base parameter for LDAP queries.
 	 * @param string $dn the DN
 	 * @return string
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function DNasBaseParameter($dn);
 	
@@ -58,7 +58,7 @@ interface ILDAPProvider {
 	 * Sanitize a DN received from the LDAP server.
 	 * @param array $dn the DN in question
 	 * @return array the sanitized DN
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function sanitizeDN($dn);
 	
@@ -66,7 +66,7 @@ interface ILDAPProvider {
 	 * Return a new LDAP connection resource for the specified user. 
 	 * @param string $uid user id
 	 * @return resource of the LDAP connection
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getLDAPConnection($uid);
 	
@@ -75,7 +75,7 @@ interface ILDAPProvider {
 	 * @param string $uid user id
 	 * @return string the base for users
 	 * @throws \Exception if user id was not found in LDAP
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getLDAPBaseUsers($uid);
 	
@@ -84,7 +84,7 @@ interface ILDAPProvider {
 	 * @param string $uid user id
 	 * @return string the base for groups
 	 * @throws \Exception if user id was not found in LDAP
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getLDAPBaseGroups($uid);
 	
@@ -92,14 +92,14 @@ interface ILDAPProvider {
 	 * Check whether a LDAP DN exists
 	 * @param string $dn LDAP DN
 	 * @return bool whether the DN exists
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function dnExists($dn);
 	
 	/**
 	 * Clear the cache if a cache is used, otherwise do nothing.
 	 * @param string $uid user id
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function clearCache($uid);
 }

--- a/lib/public/LDAP/ILDAPProviderFactory.php
+++ b/lib/public/LDAP/ILDAPProviderFactory.php
@@ -31,7 +31,7 @@ use OCP\IServerContainer;
  * instance.
  *
  * @package OCP\LDAP
- * @since 9.2.0
+ * @since 11.0.0
  */
 interface ILDAPProviderFactory {
 
@@ -39,7 +39,7 @@ interface ILDAPProviderFactory {
 	 * Constructor for the LDAP provider factory
 	 *
 	 * @param IServerContainer $serverContainer server container
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function __construct(IServerContainer $serverContainer);
 	
@@ -47,7 +47,7 @@ interface ILDAPProviderFactory {
 	 * creates and returns an instance of the ILDAPProvider
 	 *
 	 * @return ILDAPProvider
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getLDAPProvider();
 }

--- a/lib/public/Notification/INotification.php
+++ b/lib/public/Notification/INotification.php
@@ -132,19 +132,19 @@ interface INotification {
 	 * @param array $parameters
 	 * @return $this
 	 * @throws \InvalidArgumentException if the subject or parameters are invalid
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function setRichSubject($subject, array $parameters = []);
 
 	/**
 	 * @return string
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getRichSubject();
 
 	/**
 	 * @return array[]
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getRichSubjectParameters();
 
@@ -188,19 +188,19 @@ interface INotification {
 	 * @param array $parameters
 	 * @return $this
 	 * @throws \InvalidArgumentException if the message or parameters are invalid
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function setRichMessage($message, array $parameters = []);
 
 	/**
 	 * @return string
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getRichMessage();
 
 	/**
 	 * @return array[]
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getRichMessageParameters();
 
@@ -222,13 +222,13 @@ interface INotification {
 	 * @param string $icon
 	 * @return $this
 	 * @throws \InvalidArgumentException if the icon is invalid
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function setIcon($icon);
 
 	/**
 	 * @return string
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getIcon();
 

--- a/lib/public/RichObjectStrings/Definitions.php
+++ b/lib/public/RichObjectStrings/Definitions.php
@@ -26,12 +26,12 @@ namespace OCP\RichObjectStrings;
  * Class Definitions
  *
  * @package OCP\RichObjectStrings
- * @since 9.2.0
+ * @since 11.0.0
  */
 class Definitions {
 	/**
 	 * @var array
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public $definitions = [
 		'addressbook' => [
@@ -284,7 +284,7 @@ class Definitions {
 	 * @param string $type
 	 * @return array
 	 * @throws InvalidObjectExeption
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getDefinition($type) {
 		if (isset($this->definitions[$type])) {

--- a/lib/public/RichObjectStrings/IValidator.php
+++ b/lib/public/RichObjectStrings/IValidator.php
@@ -25,7 +25,7 @@ namespace OCP\RichObjectStrings;
  * Class Validator
  *
  * @package OCP\RichObjectStrings
- * @since 9.2.0
+ * @since 11.0.0
  */
 interface IValidator {
 
@@ -33,7 +33,7 @@ interface IValidator {
 	 * @param string $subject
 	 * @param array[] $parameters
 	 * @throws InvalidObjectExeption
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function validate($subject, array $parameters);
 }

--- a/lib/public/RichObjectStrings/InvalidObjectExeption.php
+++ b/lib/public/RichObjectStrings/InvalidObjectExeption.php
@@ -25,7 +25,7 @@ namespace OCP\RichObjectStrings;
  * Class InvalidObjectExeption
  *
  * @package OCP\RichObjectStrings
- * @since 9.2.0
+ * @since 11.0.0
  */
 class InvalidObjectExeption extends \InvalidArgumentException {
 }

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -95,7 +95,7 @@ interface IManager {
 	 * @param Folder $node
 	 * @param bool $reshares
 	 * @return IShare[][] [$fileId => IShare[], ...]
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getSharesInFolder($userId, Folder $node, $reshares = false);
 
@@ -290,7 +290,7 @@ interface IManager {
 	 * Check if a given share provider exists
 	 * @param int $shareType
 	 * @return bool
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function shareProviderExists($shareType);
 

--- a/lib/public/Share/IProviderFactory.php
+++ b/lib/public/Share/IProviderFactory.php
@@ -58,7 +58,7 @@ interface IProviderFactory {
 
 	/**
 	 * @return IShareProvider[]
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getAllProviders();
 }

--- a/lib/public/Share/IShareProvider.php
+++ b/lib/public/Share/IShareProvider.php
@@ -99,7 +99,7 @@ interface IShareProvider {
 	 * @param Folder $node
 	 * @param bool $reshares Also get the shares where $user is the owner instead of just the shares where $user is the initiator
 	 * @return \OCP\Share\IShare[]
-	 * @since 9.2.0
+	 * @since 11.0.0
 	 */
 	public function getSharesInFolder($userId, Folder $node, $reshares);
 

--- a/settings/Controller/AppSettingsController.php
+++ b/settings/Controller/AppSettingsController.php
@@ -169,10 +169,10 @@ class AppSettingsController extends Controller {
 			$nextCloudVersion = $versionParser->getVersion($app['releases'][0]['rawPlatformVersionSpec']);
 			$nextCloudVersionDependencies = [];
 			if($nextCloudVersion->getMinimumVersion() !== '') {
-				$nextCloudVersionDependencies['owncloud']['@attributes']['min-version'] = $nextCloudVersion->getMinimumVersion();
+				$nextCloudVersionDependencies['nextcloud']['@attributes']['min-version'] = $nextCloudVersion->getMinimumVersion();
 			}
 			if($nextCloudVersion->getMaximumVersion() !== '') {
-				$nextCloudVersionDependencies['owncloud']['@attributes']['max-version'] = $nextCloudVersion->getMaximumVersion();
+				$nextCloudVersionDependencies['nextcloud']['@attributes']['max-version'] = $nextCloudVersion->getMaximumVersion();
 			}
 			$phpVersion = $versionParser->getVersion($app['releases'][0]['rawPhpVersionSpec']);
 			$existsLocally = (\OC_App::getAppPath($app['id']) !== false) ? true : false;
@@ -331,8 +331,8 @@ class AppSettingsController extends Controller {
 			$app['canInstall'] = empty($missing);
 			$app['missingDependencies'] = $missing;
 
-			$app['missingMinOwnCloudVersion'] = !isset($app['dependencies']['owncloud']['@attributes']['min-version']);
-			$app['missingMaxOwnCloudVersion'] = !isset($app['dependencies']['owncloud']['@attributes']['max-version']);
+			$app['missingMinOwnCloudVersion'] = !isset($app['dependencies']['nextcloud']['@attributes']['min-version']);
+			$app['missingMaxOwnCloudVersion'] = !isset($app['dependencies']['nextcloud']['@attributes']['max-version']);
 
 			return $app;
 		}, $apps);

--- a/tests/lib/App/AppStore/Fetcher/AppFetcherTest.php
+++ b/tests/lib/App/AppStore/Fetcher/AppFetcherTest.php
@@ -27,7 +27,7 @@ class AppFetcherTest extends FetcherBase {
 	public function setUp() {
 		parent::setUp();
 		$this->fileName = 'apps.json';
-		$this->endpoint = 'https://apps.nextcloud.com/api/v1/platform/9.2.0/apps.json';
+		$this->endpoint = 'https://apps.nextcloud.com/api/v1/platform/11.0.0/apps.json';
 
 		$this->fetcher = new AppFetcher(
 			$this->appData,

--- a/tests/lib/App/DependencyAnalyzerTest.php
+++ b/tests/lib/App/DependencyAnalyzerTest.php
@@ -295,12 +295,24 @@ class DependencyAnalyzerTest extends TestCase {
 			],
 			[
 				[
-					'Server version 11 or higher is required.',
+					'Server version 9.2 or higher is required.',
 				],
 				[
 					'nextcloud' => [
 						'@attributes' => [
 							'min-version' => '9.2',
+						],
+					],
+				],
+			],
+			[
+				[
+					'Server version 11 or higher is required.',
+				],
+				[
+					'nextcloud' => [
+						'@attributes' => [
+							'min-version' => '11',
 						],
 					],
 				],
@@ -388,7 +400,7 @@ class DependencyAnalyzerTest extends TestCase {
 			],
 			[
 				[
-					'Server version 11 or higher is required.',
+					'Server version 9.2 or higher is required.',
 				],
 				[
 					'owncloud' => [

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 2, 0, 5);
+$OC_Version = array(11, 0, 0, 0);
 
 // The human readable string
 $OC_VersionString = '11.0 alpha';


### PR DESCRIPTION
As discussed we're changing the version from 9.2 to 11.0 to make some more sense. (ref https://github.com/nextcloud/server/issues/2134)

This still requires the following work that I'm on at the moment:

- [x] Increase versions of apps in the Nextcloud organisation
  - [x] spreed (https://github.com/nextcloud/spreed/pull/87)
  - [x] calendar (already done)
  - [x] contacts (already done)
  - [x] nextant (already done)
  - [x] logreader (already done)
  - [x] firstrunwizard (https://github.com/nextcloud/firstrunwizard/pull/23)
  - [x] activity (https://github.com/nextcloud/activity/pull/73)
  - [x] files_pdfviewer (https://github.com/nextcloud/files_pdfviewer/pull/14)
  - [x] twofactor_sms (https://github.com/nextcloud/twofactor_sms/pull/11)
  - [x] files_texteditor (https://github.com/nextcloud/files_texteditor/pull/17)
  - [x] files_videoplayer (https://github.com/nextcloud/files_videoplayer/pull/10)
  - [x] gallery (https://github.com/nextcloud/gallery/pull/174)
  - [x] notifications (https://github.com/nextcloud/notifications/pull/39)
  - [x] serverinfo (https://github.com/nextcloud/serverinfo/pull/63)
  - [x] survey_client (https://github.com/nextcloud/survey_client/pull/42)
  - [x] external (https://github.com/nextcloud/apps/pull/17)
  - [x] files_automatedtagger (https://github.com/nextcloud/files_automatedtagging/pull/18)
  - [x] files_accesscontrol (https://github.com/nextcloud/files_accesscontrol/pull/47)
  - [x] templateeditor (https://github.com/nextcloud/templateeditor/pull/12)
  - [x] files_retention (https://github.com/nextcloud/files_retention/pull/12)
  - [x] announcementcenter (https://github.com/nextcloud/announcementcenter/pull/56)
  - [x] files_antivirus (https://github.com/nextcloud/files_antivirus/pull/11)
  - [x] user_saml (https://github.com/nextcloud/user_saml/pull/52)
  - [x] twofactor_totp (https://github.com/nextcloud/twofactor_totp/pull/83)
  - [x] twofactor_u2f (https://github.com/nextcloud/twofactor_u2f/pull/10)
  - [x] bookmarks (https://github.com/nextcloud/bookmarks/pull/304)
  - [x] nextcloud_announcements (https://github.com/nextcloud/nextcloud_announcements/pull/9)
- [x] Mail people that have uploaded already their app on the beta on apps.nextcloud.com
- [x] Adjust previous fallbacks
- [x] Replace `@since 9.2` with `@since 11.0`

cc @rullzer @icewind1991 @schiessle 

----

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>