### PR TITLE
Do not cache version info in the session

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -427,6 +427,12 @@ class OC_Util {
 	 */
 	public static function getChannel() {
 		OC_Util::loadVersion();
+
+		// Allow overriding update channel
+		if (\OC::$server->getSystemConfig()->getValue('installed', false)) {
+			self::$versionCache['OC_Channel'] = \OC::$server->getAppConfig()->getValue('core', 'OC_Channel');
+		}
+
 		return self::$versionCache['OC_Channel'];
 	}
 
@@ -457,21 +463,9 @@ class OC_Util {
 		self::$versionCache['OC_VersionString'] = $OC_VersionString;
 		/** @var $OC_Build string */
 		self::$versionCache['OC_Build'] = $OC_Build;
-			
-		// Allow overriding update channel
-		if (\OC::$server->getSystemConfig()->getValue('installed', false)) {
-			$channel = \OC::$server->getAppConfig()->getValue('core', 'OC_Channel');
-		} else {
-			/** @var $OC_Channel string */
-			$channel = $OC_Channel;
-		}
-			
-		if (!is_null($channel)) {
-			self::$versionCache['OC_Channel'] = $channel;
-		} else {
-			/** @var $OC_Channel string */
-			self::$versionCache['OC_Channel'] = $OC_Channel;
-		}
+
+		/** @var $OC_Channel string */
+		self::$versionCache['OC_Channel'] = $OC_Channel;
 	}
 
 	/**

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -66,6 +66,9 @@ class OC_Util {
 	private static $rootMounted = false;
 	private static $fsSetup = false;
 
+	/** @var array Local cache of version.php */
+	private static $versionCache = null;
+
 	protected static function getAppManager() {
 		return \OC::$server->getAppManager();
 	}
@@ -397,7 +400,7 @@ class OC_Util {
 	 */
 	public static function getVersion() {
 		OC_Util::loadVersion();
-		return \OC::$server->getSession()->get('OC_Version');
+		return self::$versionCache['OC_Version'];
 	}
 
 	/**
@@ -407,7 +410,7 @@ class OC_Util {
 	 */
 	public static function getVersionString() {
 		OC_Util::loadVersion();
-		return \OC::$server->getSession()->get('OC_VersionString');
+		return self::$versionCache['OC_VersionString'];
 	}
 
 	/**
@@ -424,7 +427,7 @@ class OC_Util {
 	 */
 	public static function getChannel() {
 		OC_Util::loadVersion();
-		return \OC::$server->getSession()->get('OC_Channel');
+		return self::$versionCache['OC_Channel'];
 	}
 
 	/**
@@ -433,41 +436,41 @@ class OC_Util {
 	 */
 	public static function getBuild() {
 		OC_Util::loadVersion();
-		return \OC::$server->getSession()->get('OC_Build');
+		return self::$versionCache['OC_Build'];
 	}
 
 	/**
 	 * @description load the version.php into the session as cache
 	 */
 	private static function loadVersion() {
+		if (self::$versionCache !== null) {
+			return;
+		}
+
 		$timestamp = filemtime(OC::$SERVERROOT . '/version.php');
-		if (!\OC::$server->getSession()->exists('OC_Version') or OC::$server->getSession()->get('OC_Version_Timestamp') != $timestamp) {
-			require OC::$SERVERROOT . '/version.php';
-			$session = \OC::$server->getSession();
-			/** @var $timestamp int */
-			$session->set('OC_Version_Timestamp', $timestamp);
-			/** @var $OC_Version string */
-			$session->set('OC_Version', $OC_Version);
-			/** @var $OC_VersionString string */
-			$session->set('OC_VersionString', $OC_VersionString);
-			/** @var $OC_Build string */
-			$session->set('OC_Build', $OC_Build);
+		require OC::$SERVERROOT . '/version.php';
+		/** @var $timestamp int */
+		self::$versionCache['OC_Version_Timestamp'] = $timestamp;
+		/** @var $OC_Version string */
+		self::$versionCache['OC_Version'] = $OC_Version;
+		/** @var $OC_VersionString string */
+		self::$versionCache['OC_VersionString'] = $OC_VersionString;
+		/** @var $OC_Build string */
+		self::$versionCache['OC_Build'] = $OC_Build;
 			
-			// Allow overriding update channel
+		// Allow overriding update channel
+		if (\OC::$server->getSystemConfig()->getValue('installed', false)) {
+			$channel = \OC::$server->getAppConfig()->getValue('core', 'OC_Channel');
+		} else {
+			/** @var $OC_Channel string */
+			$channel = $OC_Channel;
+		}
 			
-			if (\OC::$server->getSystemConfig()->getValue('installed', false)) {
-				$channel = \OC::$server->getAppConfig()->getValue('core', 'OC_Channel');
-			} else {
-				/** @var $OC_Channel string */
-				$channel = $OC_Channel;
-			}
-			
-			if (!is_null($channel)) {
-				$session->set('OC_Channel', $channel);
-			} else {
-				/** @var $OC_Channel string */
-				$session->set('OC_Channel', $OC_Channel);
-			}
+		if (!is_null($channel)) {
+			self::$versionCache['OC_Channel'] = $channel;
+		} else {
+			/** @var $OC_Channel string */
+			self::$versionCache['OC_Channel'] = $OC_Channel;
 		}
 	}
 

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -83,7 +83,6 @@ class Util {
 	 */
 	public static function setChannel($channel) {
 		//Flush timestamp to reload version.php
-		\OC::$server->getSession()->set('OC_Version_Timestamp', 0);
 		\OC::$server->getAppConfig()->setValue('core', 'OC_Channel', $channel);
 		\OC::$server->getConfig()->setSystemValue('updater.release.channel', $channel);
 	}


### PR DESCRIPTION
If the session is cleared and closed for whatever reason the loadVersion will write to the session anyways. This will lead to an exception.

This should fix #1303

CC: @MorrisJobke @LukasReschke @nickvergessen 
