### PR TITLE
Don't update value if it is already set to the same value

### DIFF
--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -215,11 +215,14 @@ class AllConfig implements \OCP\IConfig {
 		// TODO - FIXME
 		$this->fixDIInit();
 
+		// warm up the cache to avoid updating the value if it is already set to this value before
+		$this->getUserValue($userId, $appName, $key);
+
 		if (isset($this->userCache[$userId][$appName][$key])) {
 			if ($this->userCache[$userId][$appName][$key] === (string)$value) {
 				return;
 			} else if ($preCondition !== null && $this->userCache[$userId][$appName][$key] !== (string)$preCondition) {
-				return;
+				throw new PreConditionNotMetException();
 			} else {
 				$qb = $this->connection->getQueryBuilder();
 				$qb->update('preferences')

--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -215,13 +215,12 @@ class AllConfig implements \OCP\IConfig {
 		// TODO - FIXME
 		$this->fixDIInit();
 
-		// warm up the cache to avoid updating the value if it is already set to this value before
-		$this->getUserValue($userId, $appName, $key);
+		$prevValue = $this->getUserValue($userId, $appName, $key, null);
 
-		if (isset($this->userCache[$userId][$appName][$key])) {
-			if ($this->userCache[$userId][$appName][$key] === (string)$value) {
+		if ($prevValue !== null) {
+			if ($prevValue === (string)$value) {
 				return;
-			} else if ($preCondition !== null && $this->userCache[$userId][$appName][$key] !== (string)$preCondition) {
+			} else if ($preCondition !== null && $prevValue !== (string)$preCondition) {
 				throw new PreConditionNotMetException();
 			} else {
 				$qb = $this->connection->getQueryBuilder();


### PR DESCRIPTION
* this PR makes sure to warm up the cache for that user
* then the logic within the "if is in cache" code can be used to reduce needed queries
* inspired by @andreas-p's PR: https://github.com/nextcloud/server/pull/2128
* it also fixes a not thrown exception if the precondition is not met (wasn't covered by the unit tests because the caches aren't warmed and thus this code wasn't executed then)

cc @rullzer @LukasReschke @nickvergessen 