### PR TITLE
Add autoloader before enabling apps

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -364,6 +364,8 @@ class OC_App {
 			// check for required dependencies
 			$info = self::getAppInfo($appId);
 			self::checkAppDependencies($config, $l, $info);
+			$appPath = self::getAppPath($appId);
+			self::registerAutoloading($appId, $appPath);
 			$installer->installApp($appId);
 		}
 


### PR DESCRIPTION
Else apps that require already autoloading in the installer
(files_antivius) die hard!

Fixes: https://github.com/nextcloud/files_antivirus/pull/11

CC: @nickvergessen @MorrisJobke @LukasReschke @icewind1991 