### PR TITLE
Move social buttons to bottom on admin page

### DIFF
--- a/lib/private/Settings/Admin/ServerDevNotice.php
+++ b/lib/private/Settings/Admin/ServerDevNotice.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @copyright 2016, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OC\Settings\Admin;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use OC\Lock\DBLockingProvider;
+use OC\Lock\NoopLockingProvider;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IL10N;
+use OCP\Lock\ILockingProvider;
+use OCP\Settings\ISettings;
+
+class ServerDevNotice implements ISettings {
+	/**
+	 * @return TemplateResponse
+	 */
+	public function getForm() {
+		return new TemplateResponse('settings', 'admin/server.development.notice');
+	}
+
+	/**
+	 * @return string the section ID, e.g. 'sharing'
+	 */
+	public function getSection() {
+		return 'server';
+	}
+
+	/**
+	 * @return int whether the form should be rather on the top or bottom of
+	 * the admin section. The forms are arranged in ascending order of the
+	 * priority values. It is required to return a value between 0 and 100.
+	 *
+	 * E.g.: 70
+	 */
+	public function getPriority() {
+		return 1000;
+	}
+}

--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -369,6 +369,8 @@ class Manager implements IManager {
 				/** @var ISettings $form */
 				$form = new Admin\Server($this->dbc, $this->config, $this->lockingProvider, $this->l);
 				$forms[$form->getPriority()] = [$form];
+				$form = new Admin\ServerDevNotice();
+				$forms[$form->getPriority()] = [$form];
 			}
 			if($section === 'encryption') {
 				/** @var ISettings $form */

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -193,7 +193,7 @@ table.nostyle td { padding: 0.2em 0; }
 }
 
 .social-button {
-	padding-left: 0;
+	padding-left: 0 !important;
 	margin-left: -10px
 }
 .social-button img {

--- a/settings/templates/admin/server.development.notice.php
+++ b/settings/templates/admin/server.development.notice.php
@@ -1,0 +1,3 @@
+<div class="section">
+	<p><?php include(__DIR__ . '/../settings.development.notice.php'); ?></p>
+</div>

--- a/settings/templates/admin/server.php
+++ b/settings/templates/admin/server.php
@@ -224,5 +224,4 @@
 	<!-- should be the last part, so Updater can follow if enabled (it has no heading therefore). -->
 	<h2><?php p($l->t('Version'));?></h2>
 	<p><a href="<?php print_unescaped($theme->getBaseUrl()); ?>" rel="noreferrer" target="_blank"><?php p($theme->getTitle()); ?></a> <?php p(OC_Util::getHumanVersion()) ?></p>
-	<p><?php include(__DIR__ . '/../settings.development.notice.php'); ?></p>
 </div>


### PR DESCRIPTION
For #2134

Before:
![before](https://cloud.githubusercontent.com/assets/45821/20342364/682ff4d6-abea-11e6-9f45-0a303a16a5ec.png)

After:
![after](https://cloud.githubusercontent.com/assets/45821/20342369/6b2ad782-abea-11e6-8a4b-e800c4e471a5.png)

I know there is a lot of white space. But that is because the icons are now in a separate section.

CC: @nextcloud/designers