### PR TITLE
Fix checkboxes when theming color is enabled

### DIFF
--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -319,7 +319,7 @@ class ThemingController extends Controller {
 			$responseCss .= sprintf('input[type="checkbox"].checkbox:checked:enabled:not(.checkbox--white) + label:before {' .
 				'background-image:url(\'%s/core/img/actions/checkmark-white.svg\');' .
 				'background-color: %s; background-position: center center; background-size:contain;' .
-				'width:12px; height:12px; padding:0; margin:2px 6px 6px 9px; border-radius:1px;' .
+				'width:12px; height:12px; padding:0; margin:2px 6px 6px 2px; border-radius:1px;' .
 				"}\n",
 				\OC::$WEBROOT,
 				$elementColor

--- a/apps/theming/tests/Controller/ThemingControllerTest.php
+++ b/apps/theming/tests/Controller/ThemingControllerTest.php
@@ -428,7 +428,7 @@ class ThemingControllerTest extends TestCase {
 		$expectedData .= sprintf('input[type="checkbox"].checkbox:checked:enabled:not(.checkbox--white) + label:before {' .
 			'background-image:url(\'%s/core/img/actions/checkmark-white.svg\');' .
 			'background-color: %s; background-position: center center; background-size:contain;' .
-			'width:12px; height:12px; padding:0; margin:2px 6px 6px 9px; border-radius:1px;' .
+			'width:12px; height:12px; padding:0; margin:2px 6px 6px 2px; border-radius:1px;' .
 			"}\n",
 			\OC::$WEBROOT,
 			$color
@@ -517,7 +517,7 @@ class ThemingControllerTest extends TestCase {
 		$expectedData .= sprintf('input[type="checkbox"].checkbox:checked:enabled:not(.checkbox--white) + label:before {' .
 			'background-image:url(\'%s/core/img/actions/checkmark-white.svg\');' .
 			'background-color: #555555; background-position: center center; background-size:contain;' .
-			'width:12px; height:12px; padding:0; margin:2px 6px 6px 9px; border-radius:1px;' .
+			'width:12px; height:12px; padding:0; margin:2px 6px 6px 2px; border-radius:1px;' .
 			"}\n",
 			\OC::$WEBROOT
 		);
@@ -691,7 +691,7 @@ class ThemingControllerTest extends TestCase {
 		$expectedData .= sprintf('input[type="checkbox"].checkbox:checked:enabled:not(.checkbox--white) + label:before {' .
 			'background-image:url(\'%s/core/img/actions/checkmark-white.svg\');' .
 			'background-color: %s; background-position: center center; background-size:contain;' .
-			'width:12px; height:12px; padding:0; margin:2px 6px 6px 9px; border-radius:1px;' .
+			'width:12px; height:12px; padding:0; margin:2px 6px 6px 2px; border-radius:1px;' .
 			"}\n",
 			\OC::$WEBROOT,
 			$color
@@ -797,7 +797,7 @@ class ThemingControllerTest extends TestCase {
 		$expectedData .= sprintf('input[type="checkbox"].checkbox:checked:enabled:not(.checkbox--white) + label:before {' .
 			'background-image:url(\'%s/core/img/actions/checkmark-white.svg\');' .
 			'background-color: #555555; background-position: center center; background-size:contain;' .
-			'width:12px; height:12px; padding:0; margin:2px 6px 6px 9px; border-radius:1px;' .
+			'width:12px; height:12px; padding:0; margin:2px 6px 6px 2px; border-radius:1px;' .
 			"}\n",
 			\OC::$WEBROOT
 		);

--- a/core/css/multiselect.css
+++ b/core/css/multiselect.css
@@ -31,9 +31,6 @@ ul.multiselectoptions.up {
 ul.multiselectoptions>li {
 	overflow: hidden;
 	white-space: nowrap;
-}
-
-ul.multiselectoptions > li > input[type="checkbox"]+label:before {
 	margin-left: 7px;
 }
 ul.multiselectoptions > li input[type='checkbox']+label {
@@ -106,6 +103,7 @@ ul.multiselectoptions input.new {
 
 ul.multiselectoptions > li.creator {
 	padding: 10px;
+	margin: 0;
 	font-weight: bold;
 }
 ul.multiselectoptions > li.creator > input {


### PR DESCRIPTION
fix #2089

Before
![2016-11-16-140019_354x186_scrot](https://cloud.githubusercontent.com/assets/3404133/20348322/25a9a650-ac05-11e6-8ba1-f9680718114f.png)
After
![2016-11-16-140025_353x185_scrot](https://cloud.githubusercontent.com/assets/3404133/20348323/25a9f38a-ac05-11e6-95d5-8a3d8ec46ba6.png)

Checkboxes in user management also still work (#1782) - These should also be tested since the original fix #1971 has been reverted here.

Please review @nextcloud/designers @nickvergessen 