### PR TITLE
BirthdayCalendar: fix issue with birthyear to high when birthday on Dec 31st

### DIFF
--- a/apps/dav/lib/CalDAV/BirthdayService.php
+++ b/apps/dav/lib/CalDAV/BirthdayService.php
@@ -1,10 +1,12 @@
 <?php
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @copyright Copyright (c) 2016, Georg Ehrke
  *
  * @author Achim Königs <garfonso@tratschtante.de>
  * @author Robin Appelman <robin@icewind.nl>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Georg Ehrke <georg@nextcloud.com>
  *
  * @license AGPL-3.0
  *
@@ -147,6 +149,8 @@ class BirthdayService {
 		} catch (Exception $e) {
 			return null;
 		}
+
+		$summary = $title . ' (' . $summarySymbol . $date->format('Y') . ')';
 		$vCal = new VCalendar();
 		$vCal->VERSION = '2.0';
 		$vEvent = $vCal->createComponent('VEVENT');
@@ -163,7 +167,7 @@ class BirthdayService {
 		$vEvent->DTEND['VALUE'] = 'DATE';
 		$vEvent->{'UID'} = $doc->UID;
 		$vEvent->{'RRULE'} = 'FREQ=YEARLY';
-		$vEvent->{'SUMMARY'} = $title . ' (' . $summarySymbol . $date->format('Y') . ')';
+		$vEvent->{'SUMMARY'} = $summary;
 		$vEvent->{'TRANSP'} = 'TRANSPARENT';
 		$alarm = $vCal->createComponent('VALARM');
 		$alarm->add($vCal->createProperty('TRIGGER', '-PT0M', ['VALUE' => 'DURATION']));

--- a/apps/dav/tests/unit/CardDAV/BirthdayServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/BirthdayServiceTest.php
@@ -240,6 +240,7 @@ class BirthdayServiceTest extends TestCase {
 			[true, "BEGIN:VCARD\r\nVERSION:3.0\r\nPRODID:-//Sabre//Sabre VObject 4.1.1//EN\r\nUID:12345\r\nFN:12345\r\nN:12345;;;;\r\nBDAY:\r\nEND:VCARD\r\n", "Dr. Foo Bar"],
 			[true, "BEGIN:VCARD\r\nVERSION:3.0\r\nPRODID:-//Sabre//Sabre VObject 4.1.1//EN\r\nUID:12345\r\nFN:12345\r\nN:12345;;;;\r\nBDAY:someday\r\nEND:VCARD\r\n", "Dr. Foo Bar"],
 			[false, "BEGIN:VCARD\r\nVERSION:3.0\r\nPRODID:-//Sabre//Sabre VObject 4.1.1//EN\r\nUID:12345\r\nFN:12345\r\nN:12345;;;;\r\nBDAY:1900-01-01\r\nEND:VCARD\r\n", "Dr. Foo Bar"],
+			[false, "BEGIN:VCARD\r\nVERSION:3.0\r\nPRODID:-//Sabre//Sabre VObject 4.1.1//EN\r\nUID:12345\r\nFN:12345\r\nN:12345;;;;\r\nBDAY:1900-12-31\r\nEND:VCARD\r\n", "Dr. Foo Bar"],
 		];
 	}
 }


### PR DESCRIPTION
fixes #2171 

please review @drupalwonder @MariusBluem @MorrisJobke 

Example vcard data:
```
BEGIN:VCARD
VERSION:3.0
PRODID:-//Apple Inc.//Mac OS X 10.12.1//EN
N:BAR;FOO;;;
FN:FOO BAR
BDAY:1900-12-31
END:VCARD
```

On master it will show `FOO BAR (*1901)`, with this patch it'll be `FOO BAR (*1900)`