### PR TITLE
reuse the known rootinfo in the shared cache when possible

### DIFF
--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -57,6 +57,8 @@ class Cache extends CacheJail {
 	 */
 	private $sourceCache;
 
+	private $rootUnchanged = true;
+
 	/**
 	 * @param \OCA\Files_Sharing\SharedStorage $storage
 	 * @param IStorage $sourceStorage
@@ -79,6 +81,33 @@ class Cache extends CacheJail {
 		} else {
 			return false;
 		}
+	}
+
+	public function get($file) {
+		if ($this->rootUnchanged && ($file === '' || $file === $this->sourceRootInfo->getId())) {
+			return $this->formatCacheEntry(clone $this->sourceRootInfo);
+		}
+		return parent::get($file);
+	}
+
+	public function update($id, array $data) {
+		$this->rootUnchanged = false;
+		parent::update($id, $data);
+	}
+
+	public function insert($file, array $data) {
+		$this->rootUnchanged = false;
+		return parent::insert($file, $data);
+	}
+
+	public function remove($file) {
+		$this->rootUnchanged = false;
+		parent::remove($file);
+	}
+
+	public function moveFromCache(\OCP\Files\Cache\ICache $sourceCache, $sourcePath, $targetPath) {
+		$this->rootUnchanged = false;
+		return parent::moveFromCache($sourceCache, $sourcePath, $targetPath);
 	}
 
 	protected function formatCacheEntry($entry) {

--- a/apps/files_sharing/lib/SharedPropagator.php
+++ b/apps/files_sharing/lib/SharedPropagator.php
@@ -39,6 +39,6 @@ class SharedPropagator extends Propagator {
 	public function propagateChange($internalPath, $time, $sizeDifference = 0) {
 		/** @var \OC\Files\Storage\Storage $storage */
 		list($storage, $sourceInternalPath) = $this->storage->resolvePath($internalPath);
-		return $storage->getPropagator()->propagateChange($sourceInternalPath, $time, $sizeDifference);
+		$storage->getPropagator()->propagateChange($sourceInternalPath, $time, $sizeDifference);
 	}
 }

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -311,6 +311,9 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 	}
 
 	public function getCache($path = '', $storage = null) {
+		if ($this->cache) {
+			return $this->cache;
+		}
 		$this->init();
 		if (is_null($this->storage) || $this->storage instanceof FailedStorage) {
 			return new FailedCache(false);
@@ -318,7 +321,8 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 		if (!$storage) {
 			$storage = $this;
 		}
-		return new \OCA\Files_Sharing\Cache($storage, $this->storage, $this->sourceRootInfo);
+		$this->cache = new \OCA\Files_Sharing\Cache($storage, $this->storage, $this->sourceRootInfo);
+		return $this->cache;
 	}
 
 	public function getScanner($path = '', $storage = null) {

--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -27,6 +27,7 @@
 
 namespace OC\Files\Cache\Wrapper;
 use OC\Files\Cache\Cache;
+use OCP\Files\Cache\ICacheEntry;
 
 /**
  * Jail to a subdirectory of the wrapped cache
@@ -73,7 +74,7 @@ class CacheJail extends CacheWrapper {
 	}
 
 	/**
-	 * @param array $entry
+	 * @param ICacheEntry|array $entry
 	 * @return array
 	 */
 	protected function formatCacheEntry($entry) {


### PR DESCRIPTION
While nothing has changed in the shared cache we already have the cacheentry for the root, we can reuse that instead of querying the db.

Saves 1 query per receiving share.

cc @rullzer @MorrisJobke 