### PR TITLE
Expose getAppPath to public API

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -31,6 +31,7 @@
 
 namespace OC\App;
 
+use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
 use OCP\App\ManagerEvent;
 use OCP\IAppConfig;
@@ -263,6 +264,21 @@ class AppManager implements IAppManager {
 			ManagerEvent::EVENT_APP_DISABLE, $appId
 		));
 		$this->clearAppsCache();
+	}
+
+	/**
+	 * Get the directory for the given app.
+	 *
+	 * @param string $appId
+	 * @return string
+	 * @throws AppPathNotFoundException if app folder can't be found
+	 */
+	public function getAppPath($appId) {
+		$appPath = \OC_App::getAppPath($appId);
+		if($appPath === false) {
+			throw new AppPathNotFoundException('Could not find path for ' . $appId);
+		}
+		return $appPath;
 	}
 
 	/**

--- a/lib/public/App/AppPathNotFoundException.php
+++ b/lib/public/App/AppPathNotFoundException.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\App;
+
+/**
+ * Class AppPathNotFoundException
+ *
+ * @package OCP\App
+ * @since 11.0.0
+ */
+class AppPathNotFoundException extends \Exception {}

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -79,6 +79,16 @@ interface IAppManager {
 	public function disableApp($appId);
 
 	/**
+	 * Get the directory for the given app.
+	 *
+	 * @param string $appId
+	 * @return string
+	 * @since 11.0.0
+	 * @throws AppPathNotFoundException
+	 */
+	public function getAppPath($appId);
+
+	/**
 	 * List all apps enabled for a user
 	 *
 	 * @param \OCP\IUser $user

--- a/tests/lib/App/ManagerTest.php
+++ b/tests/lib/App/ManagerTest.php
@@ -11,6 +11,7 @@ namespace Test\App;
 
 use OC\Group\Group;
 use OC\User\User;
+use OCP\App\AppPathNotFoundException;
 use Test\TestCase;
 
 /**
@@ -258,6 +259,15 @@ class ManagerTest extends TestCase {
 		$this->appConfig->setValue('test', 'enabled', 'no');
 		$user = $this->newUser('user1');
 		$this->assertFalse($this->manager->isEnabledForUser('test', $user));
+	}
+
+	public function testGetAppPath() {
+		$this->assertEquals(\OC::$SERVERROOT . '/apps/files', $this->manager->getAppPath('files'));
+	}
+
+	public function testGetAppPathFail() {
+		$this->expectException(AppPathNotFoundException::class);
+		$this->manager->getAppPath('testnotexisting');
 	}
 
 	public function testIsEnabledForUserEnabledForGroup() {


### PR DESCRIPTION
As discussed with @rullzer in #840 

I'm not sure if this is fine for now or if the whole logic of getAppPath should be moved from OC_App to the AppManager.

