### PR TITLE
don't add server automatically to trusted server

### DIFF
--- a/apps/federation/lib/TrustedServers.php
+++ b/apps/federation/lib/TrustedServers.php
@@ -137,7 +137,7 @@ class TrustedServers {
 	 * @return bool
 	 */
 	public function getAutoAddServers() {
-		$value = $this->config->getAppValue('federation', 'autoAddServers', '1');
+		$value = $this->config->getAppValue('federation', 'autoAddServers', '0');
 		return $value === '1';
 	}
 

--- a/apps/federation/tests/TrustedServersTest.php
+++ b/apps/federation/tests/TrustedServersTest.php
@@ -172,7 +172,7 @@ class TrustedServersTest extends TestCase {
 	 */
 	public function testGetAutoAddServers($status, $expected) {
 		$this->config->expects($this->once())->method('getAppValue')
-			->with('federation', 'autoAddServers', '1')->willReturn($status);
+			->with('federation', 'autoAddServers', '0')->willReturn($status);
 
 		$this->assertSame($expected,
 			$this->trustedServers->getAutoAddServers()


### PR DESCRIPTION
by default we no longer add servers automatically to the list of trusted servers after a federated share was established successfully.

part of https://github.com/nextcloud/server/issues/2134

cc @LukasReschke @nickvergessen easy one. :wink: 