### PR TITLE
[stable10] Hack to prevent warning for read-only wrapper in public links

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -76,9 +76,12 @@ $server = $serverFactory->createServer($baseuri, $requestUri, $authBackend, func
 		return false;
 	}
 
+	// FIXME: should not add storage wrappers outside of preSetup, need to find a better way
+	$previousLog = \OC\Files\Filesystem::logWarningWhenAddingStorageWrapper(false);
 	\OC\Files\Filesystem::addStorageWrapper('sharePermissions', function ($mountPoint, $storage) use ($share) {
 		return new \OC\Files\Storage\Wrapper\PermissionsMask(array('storage' => $storage, 'mask' => $share->getPermissions() | \OCP\Constants::PERMISSION_SHARE));
 	});
+	\OC\Files\Filesystem::logWarningWhenAddingStorageWrapper($previousLog);
 
 	OC_Util::setupFS($owner);
 	$ownerView = \OC\Files\Filesystem::getView();

--- a/apps/files_sharing/ajax/shareinfo.php
+++ b/apps/files_sharing/ajax/shareinfo.php
@@ -63,9 +63,12 @@ $path = $data['realPath'];
 
 $isWritable = $share->getPermissions() & (\OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE);
 if (!$isWritable) {
+	// FIXME: should not add storage wrappers outside of preSetup, need to find a better way
+	$previousLog = \OC\Files\Filesystem::logWarningWhenAddingStorageWrapper(false);
 	\OC\Files\Filesystem::addStorageWrapper('readonly', function ($mountPoint, $storage) {
 		return new \OC\Files\Storage\Wrapper\PermissionsMask(array('storage' => $storage, 'mask' => \OCP\Constants::PERMISSION_READ + \OCP\Constants::PERMISSION_SHARE));
 	});
+	\OC\Files\Filesystem::logWarningWhenAddingStorageWrapper($previousLog);
 }
 
 $rootInfo = \OC\Files\Filesystem::getFileInfo($path);

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -213,10 +213,13 @@ class Filesystem {
 
 	/**
 	 * @param bool $shouldLog
+	 * @return bool previous value
 	 * @internal
 	 */
 	public static function logWarningWhenAddingStorageWrapper($shouldLog) {
+		$previousValue = self::$logWarningWhenAddingStorageWrapper;
 		self::$logWarningWhenAddingStorageWrapper = (bool) $shouldLog;
+		return $previousValue;
 	}
 
 	/**


### PR DESCRIPTION
* backport of #2122 
* fixes #1652 for stable10

cc @nickvergessen @schiessle @rullzer 

How to test:

* create public link share of folder
* open it
* before: error message like `Storage wrapper 'sharePermissions' was not registered via the 'OC_Filesystem - preSetup' hook which could cause potential problems.`
* after: no error message


I tested this and it works 👍 