### PR TITLE
Select2 adjustments: ellipsize, and adjust height

### DIFF
--- a/core/css/inputs.css
+++ b/core/css/inputs.css
@@ -254,7 +254,7 @@ select:hover {
 	position: relative !important;
 }
 .select2-results {
-	max-height: 220px !important;
+	max-height: 250px !important;
 	margin: 0 !important;
 	padding: 0 !important;
 }

--- a/core/css/inputs.css
+++ b/core/css/inputs.css
@@ -260,6 +260,9 @@ select:hover {
 }
 .select2-results .select2-result-label {
 	padding: 12px !important;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .select2-choices {

--- a/core/css/inputs.css
+++ b/core/css/inputs.css
@@ -264,6 +264,9 @@ select:hover {
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
+.select2-results .select2-result-label span {
+	cursor: pointer;
+}
 
 .select2-choices {
 	white-space: nowrap !important;
@@ -328,6 +331,12 @@ select:hover {
 	display: inline-block;
 	margin-right: 8px;
 	vertical-align: middle;
+}
+#select2-drop .avatar img,
+.select2-chosen .avatar img,
+#select2-drop .avatar,
+.select2-chosen .avatar {
+	cursor: pointer;
 }
 
 .select2-results .select2-no-results,


### PR DESCRIPTION
- ellipsize long names with no line break
- make sure dropdown always shows a last half entry to hint at more (instead of having the height contain exactly 4 entries which doesn’t make it immediately obvious there’s more)

Before & after
![capture du 2016-11-17 17-26-32](https://cloud.githubusercontent.com/assets/925062/20397758/37e699cc-aceb-11e6-814c-4f22744a601e.png)![capture du 2016-11-17 17-25-56](https://cloud.githubusercontent.com/assets/925062/20397759/37e97ce6-aceb-11e6-96e5-bc9a98957a7c.png)


Please review @nextcloud/designers cc @skjnldsv also something for the inputs SCSS PR I needed to fix right now though ;)

cc @Ivansss @MorrisJobke cause it fixes Spreed style