### PR TITLE
jQuery dropdown fixes

### DIFF
--- a/core/css/jquery-ui-fixes.css
+++ b/core/css/jquery-ui-fixes.css
@@ -136,3 +136,7 @@
 	opacity: .2;
 	border-radius: 5px;
 }
+
+.ui-menu .ui-menu-item a {
+	padding: 6px;
+}

--- a/core/css/share.css
+++ b/core/css/share.css
@@ -182,9 +182,9 @@ a.showCruds:hover,a.unshare:hover {
 }
 
 .ui-autocomplete { /* limit dropdown height to 4 1/2 entries */
-	max-height:103px;
-	overflow-y:auto;
-	overflow-x:hidden;
+	max-height: 200px;
+	overflow-y: auto;
+	overflow-x: hidden;
 }
 
 .notCreatable {


### PR DESCRIPTION
- correct clickable area of 44px
- correct max-height of 4 1/2 entries

Before & after:
![capture du 2016-11-17 23-50-14](https://cloud.githubusercontent.com/assets/925062/20411291/28907ee4-ad21-11e6-98f7-3e3f80d93952.png)

Please review @nextcloud/designers @ChristophWurst 