### PR TITLE
close the file handle after readfile

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -431,6 +431,7 @@ class View {
 				echo fread($handle, $chunkSize);
 				flush();
 			}
+			fclose($handle);
 			$size = $this->filesize($path);
 			return $size;
 		}


### PR DESCRIPTION
potential fix for "Access to undeclared static property: OC\Files\Filesystem::$normalizedPathCache"