### PR TITLE
fix white screen of death in maintenance mode when theming is disabled

### DIFF
--- a/lib/private/legacy/defaults.php
+++ b/lib/private/legacy/defaults.php
@@ -283,4 +283,7 @@ class OC_Defaults {
 		}
 	}
 
+	public function shouldReplaceIcons() {
+		return false;
+	}
 }


### PR DESCRIPTION
When the theming app is enabled it overwrites \OC_Defaults with a version that has `shouldReplaceIcons`, the url generator depends on `shouldReplaceIcons`