### PR TITLE
fix position of the spinner on the personal settings

### DIFF
--- a/core/css/header.css
+++ b/core/css/header.css
@@ -309,6 +309,7 @@
 	margin-bottom: -3px;
 	margin-right: 6px;
 	background-size: 16px 16px;
+	vertical-align: middle;
 }
 #expand {
 	display: block;

--- a/core/css/icons.css
+++ b/core/css/icons.css
@@ -33,7 +33,8 @@
 	height: 32px;
 	width: 32px;
 	margin: -17px 0 0 -17px;
-	position: absolute;
+	position: relative;
+	display: inline-block;
 	top: 50%;
 	left: 50%;
 	border-radius: 100%;


### PR DESCRIPTION
Fix positioning of the spinner in Chromium for the personal settings. The spinner was shown in the middle of the profile information of the user. Now we show it in the section where it belongs.

fix https://github.com/nextcloud/server/issues/2198

cc @jancborchardt this is what we observed last week in Stuttgart