### PR TITLE
Error log spam: Cast "isFeatured" to "featured"

### DIFF
--- a/settings/Controller/AppSettingsController.php
+++ b/settings/Controller/AppSettingsController.php
@@ -154,6 +154,9 @@ class AppSettingsController extends Controller {
 		$formattedApps = [];
 		$apps = $this->appFetcher->get();
 		foreach($apps as $app) {
+			if (isset($app['isFeatured'])) {
+				$app['featured'] = $app['isFeatured'];
+			}
 
 			// Skip all apps not in the requested category
 			$isInCategory = false;


### PR DESCRIPTION
The appstore returns a "isFeatured" in the current API revision. We need to cast this thus. (the local apps still use "featured" and I wasn't to keen on changing all existing legacy code)

Fixes the following error log message when opening the tab "Customization":

> Undefined index: featured at /media/psf/stable9/settings/Controller/AppSettingsController.php#233

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>