### PR TITLE
fix PropPatch requests on calendars

### DIFF
--- a/apps/dav/lib/CalDAV/Calendar.php
+++ b/apps/dav/lib/CalDAV/Calendar.php
@@ -177,7 +177,7 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IShareable {
 	function propPatch(PropPatch $propPatch) {
 		$mutations = $propPatch->getMutations();
 		// If this is a shared calendar, the user can only change the enabled property, to hide it.
-		if (isset($this->calendarInfo['{http://owncloud.org/ns}owner-principal']) && (sizeof($mutations) !== 1 || !isset($mutations['{http://owncloud.org/ns}calendar-enabled']))) {
+		if ($this->isShared() && (sizeof($mutations) !== 1 || !isset($mutations['{http://owncloud.org/ns}calendar-enabled']))) {
 			throw new Forbidden();
 		}
 		parent::propPatch($propPatch);

--- a/apps/dav/tests/unit/CalDAV/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarTest.php
@@ -106,29 +106,40 @@ class CalendarTest extends TestCase {
 
 	public function dataPropPatch() {
 		return [
-			[[], true],
-			[[
+			['user1', 'user2', [], true],
+			['user1', 'user2', [
 				'{http://owncloud.org/ns}calendar-enabled' => true,
 			], false],
-			[[
+			['user1', 'user2', [
 				'{DAV:}displayname' => true,
 			], true],
-			[[
+			['user1', 'user2', [
 				'{DAV:}displayname' => true,
 				'{http://owncloud.org/ns}calendar-enabled' => true,
 			], true],
+			['user1', 'user1', [], false],
+			['user1', 'user1', [
+				'{http://owncloud.org/ns}calendar-enabled' => true,
+			], false],
+			['user1', 'user1', [
+				'{DAV:}displayname' => true,
+			], false],
+			['user1', 'user1', [
+				'{DAV:}displayname' => true,
+				'{http://owncloud.org/ns}calendar-enabled' => true,
+			], false],
 		];
 	}
 
 	/**
 	 * @dataProvider dataPropPatch
 	 */
-	public function testPropPatch($mutations, $throws) {
+	public function testPropPatch($ownerPrincipal, $principalUri, $mutations, $throws) {
 		/** @var \PHPUnit_Framework_MockObject_MockObject | CalDavBackend $backend */
 		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
 		$calendarInfo = [
-			'{http://owncloud.org/ns}owner-principal' => 'user1',
-			'principaluri' => 'user2',
+			'{http://owncloud.org/ns}owner-principal' => $ownerPrincipal,
+			'principaluri' => $principalUri,
 			'id' => 666,
 			'uri' => 'default'
 		];


### PR DESCRIPTION
issue wasn't reported yet.

fixes regression introduced with https://github.com/nextcloud/server/commit/6d1c0be47d2f3052f7e6c35377feee2ceb2cee29#diff-ded00a57c79a474ac4c4b43c620d6050R238
affects only master

The linked line sets `owner-principal` also on private calendars.
[This line](https://github.com/nextcloud/server/blob/master/apps/dav/lib/CalDAV/Calendar.php#L180) expected this property only on shared calendars.

This regression caused the server to only accept requests, that change `calendar-enabled` and only `calendar-enabled`. All other requests that change display name or color will fail with a 403.

please review @MorrisJobke @rullzer @nickvergessen 

some cURL requests for @rullzer:
These two calls should work only for the owner
```
curl 'http://nextcloud.dev/remote.php/dav/calendars/admin/asd/' -X PROPPATCH -H 'requesttoken: m0XhOKHHnAnr9f/KJsjEP97xyWFHpL481uvbnJyQ1jk=:1ALRdfej8n2ZvLyhDeOgS7CLqhMW4f97nYni2NvIuV8=' -H 'Origin: http://nextcloud.dev' -H 'Accept-Encoding: gzip, deflate, sdch' -H 'Accept-Language: en-US,en;q=0.8' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2910.0 Safari/537.36' -H 'Content-Type: application/xml; charset=UTF-8' -H 'Accept: */*' -H 'Cookie: nc_sameSiteCookielax=true; nc_sameSiteCookiestrict=true; oc_sessionPassphrase=lJeQuvOeNuthP7Rineqf%2BKPcOBi6e7SOTt3uyFJ5qfNEQUMnqRghOfDW%2FK7BRgo5rS4YQG7RJD6NkPjTYLYlyMwyigHbOUUuEhTvToHrqdCYnFEgksRxvXimsh7rqGFh; ocbtfiv5megx=j52aubh5di8mprof9dqlb2c8a6; XDEBUG_SESSION=IntelliJ' -H 'Connection: keep-alive' --data-binary '<d:propertyupdate xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:d="DAV:" xmlns:a="http://apple.com/ns/ical/" xmlns:o="http://owncloud.org/ns" xmlns:n="http://nextcloud.com/ns" xmlns:cs="http://calendarserver.org/ns/"><d:set><d:prop><a:calendar-color>#e7e774</a:calendar-color></d:prop></d:set></d:propertyupdate>' --compressed
```
```
curl 'http://nextcloud.dev/remote.php/dav/calendars/admin/asd/' -X PROPPATCH -H 'requesttoken: tCdaIx+FfirLqgjyodkl1ajRtgj0hZ4weMuZFdMFspE=:+2BqbknhEF6540uZivJBocar1XqlwN93M6mgUZRd3fc=' -H 'Origin: http://nextcloud.dev' -H 'Accept-Encoding: gzip, deflate, sdch' -H 'Accept-Language: en-US,en;q=0.8' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2910.0 Safari/537.36' -H 'Content-Type: application/xml; charset=UTF-8' -H 'Accept: */*' -H 'Cookie: nc_sameSiteCookielax=true; nc_sameSiteCookiestrict=true; oc_sessionPassphrase=lJeQuvOeNuthP7Rineqf%2BKPcOBi6e7SOTt3uyFJ5qfNEQUMnqRghOfDW%2FK7BRgo5rS4YQG7RJD6NkPjTYLYlyMwyigHbOUUuEhTvToHrqdCYnFEgksRxvXimsh7rqGFh; ocbtfiv5megx=j52aubh5di8mprof9dqlb2c8a6; XDEBUG_SESSION=IntelliJ' -H 'Connection: keep-alive' --data-binary '<d:propertyupdate xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:d="DAV:" xmlns:a="http://apple.com/ns/ical/" xmlns:o="http://owncloud.org/ns" xmlns:n="http://nextcloud.com/ns" xmlns:cs="http://calendarserver.org/ns/"><d:set><d:prop><a:calendar-color>#74e7d2</a:calendar-color><d:displayname>asd 123123</d:displayname></d:prop></d:set></d:propertyupdate>' --compressed
```

This is supposed to work for all users:
```
curl 'http://nextcloud.dev/remote.php/dav/calendars/admin/deleted_DOC2VODCE3CA72U_work/' -X PROPPATCH -H 'requesttoken: tCdaIx+FfirLqgjyodkl1ajRtgj0hZ4weMuZFdMFspE=:+2BqbknhEF6540uZivJBocar1XqlwN93M6mgUZRd3fc=' -H 'Origin: http://nextcloud.dev' -H 'Accept-Encoding: gzip, deflate, sdch' -H 'Accept-Language: en-US,en;q=0.8' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2910.0 Safari/537.36' -H 'Content-Type: application/xml; charset=UTF-8' -H 'Accept: */*' -H 'Cookie: nc_sameSiteCookielax=true; nc_sameSiteCookiestrict=true; oc_sessionPassphrase=lJeQuvOeNuthP7Rineqf%2BKPcOBi6e7SOTt3uyFJ5qfNEQUMnqRghOfDW%2FK7BRgo5rS4YQG7RJD6NkPjTYLYlyMwyigHbOUUuEhTvToHrqdCYnFEgksRxvXimsh7rqGFh; ocbtfiv5megx=j52aubh5di8mprof9dqlb2c8a6; XDEBUG_SESSION=IntelliJ' -H 'Connection: keep-alive' --data-binary '<d:propertyupdate xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:d="DAV:" xmlns:a="http://apple.com/ns/ical/" xmlns:o="http://owncloud.org/ns" xmlns:n="http://nextcloud.com/ns" xmlns:cs="http://calendarserver.org/ns/"><d:set><d:prop><o:calendar-enabled>0</o:calendar-enabled></d:prop></d:set></d:propertyupdate>' --compressed
```