### PR TITLE
Use app ID instead of object

### DIFF
--- a/settings/ajax/enableapp.php
+++ b/settings/ajax/enableapp.php
@@ -35,7 +35,7 @@ try {
 	$appId = (string)$_POST['appid'];
 	$appId = OC_App::cleanAppId($appId);
 	$app->enable($appId, $groups);
-	OC_JSON::success(['data' => ['update_required' => \OC_App::shouldUpgrade($app)]]);
+	OC_JSON::success(['data' => ['update_required' => \OC_App::shouldUpgrade($appId)]]);
 } catch (Exception $e) {
 	\OCP\Util::writeLog('core', $e->getMessage(), \OCP\Util::ERROR);
 	OC_JSON::error(array("data" => array("message" => $e->getMessage()) ));


### PR DESCRIPTION
Fixes several error messages when installing an app from the appstore, including:

```
Illegal offset type in isset or empty at /media/psf/stable9/lib/private/legacy/app.php#662
Illegal offset type at /media/psf/stable9/lib/private/legacy/app.php#663
Illegal offset type at /media/psf/stable9/lib/private/legacy/app.php#661
Object of class OC_App could not be converted to string at /media/psf/stable9/lib/private/legacy/app.php#81
trim() expects parameter 1 to be string, object given at /media/psf/stable9/lib/private/legacy/app.php#628
```

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>

cc @rullzer @MorrisJobke 