### PR TITLE
Cleanup settings application again

### DIFF
--- a/settings/Application.php
+++ b/settings/Application.php
@@ -34,21 +34,9 @@ use OC\App\AppStore\Fetcher\AppFetcher;
 use OC\App\AppStore\Fetcher\CategoryFetcher;
 use OC\AppFramework\Utility\TimeFactory;
 use OC\Authentication\Token\IProvider;
-use OC\Files\View;
 use OC\Server;
-use OC\Settings\Controller\AppSettingsController;
-use OC\Settings\Controller\AuthSettingsController;
-use OC\Settings\Controller\CertificateController;
-use OC\Settings\Controller\CheckSetupController;
-use OC\Settings\Controller\EncryptionController;
-use OC\Settings\Controller\GroupsController;
-use OC\Settings\Controller\LogSettingsController;
-use OC\Settings\Controller\MailSettingsController;
-use OC\Settings\Controller\SecuritySettingsController;
-use OC\Settings\Controller\UsersController;
 use OC\Settings\Middleware\SubadminMiddleware;
 use OCP\AppFramework\App;
-use OCP\AppFramework\IAppContainer;
 use OCP\IContainer;
 use OCP\Settings\IManager;
 use OCP\Util;
@@ -70,130 +58,6 @@ class Application extends App {
 		// Register Middleware
 		$container->registerAlias('SubadminMiddleware', SubadminMiddleware::class);
 		$container->registerMiddleWare('SubadminMiddleware');
-
-		/**
-		 * Controllers
-		 */
-		$container->registerService('MailSettingsController', function(IContainer $c) {
-			return new MailSettingsController(
-				$c->query('AppName'),
-				$c->query('Request'),
-				$c->query('L10N'),
-				$c->query('Config'),
-				$c->query('UserSession'),
-				$c->query('Defaults'),
-				$c->query('Mailer'),
-				$c->query('DefaultMailAddress')
-			);
-		});
-		$container->registerService('EncryptionController', function(IContainer $c) {
-			return new EncryptionController(
-				$c->query('AppName'),
-				$c->query('Request'),
-				$c->query('L10N'),
-				$c->query('Config'),
-				$c->query('DatabaseConnection'),
-				$c->query('UserManager'),
-				new View(),
-				$c->query('Logger')
-			);
-		});
-
-		$container->registerService('AppSettingsController', function(IContainer $c) {
-			return new AppSettingsController(
-				$c->query('AppName'),
-				$c->query('Request'),
-				$c->query('L10N'),
-				$c->query('Config'),
-				$c->query('INavigationManager'),
-				$c->query('IAppManager'),
-				$c->query('CategoryFetcher'),
-				$c->query('AppFetcher'),
-				\OC::$server->getL10NFactory()
-			);
-		});
-		$container->registerService('AuthSettingsController', function(IContainer $c) {
-			return new AuthSettingsController(
-				$c->query('AppName'),
-				$c->query('Request'),
-				$c->query('ServerContainer')->query('OC\Authentication\Token\IProvider'),
-				$c->query('UserManager'),
-				$c->query('ServerContainer')->getSession(),
-				$c->query('ServerContainer')->getSecureRandom(),
-				$c->query('UserId')
-			);
-		});
-		$container->registerService('SecuritySettingsController', function(IContainer $c) {
-			return new SecuritySettingsController(
-				$c->query('AppName'),
-				$c->query('Request'),
-				$c->query('Config')
-			);
-		});
-		$container->registerService('AccountManager', function(IAppContainer $c) {
-			return new AccountManager($c->getServer()->getDatabaseConnection());
-		});
-		$container->registerService('CertificateController', function(IContainer $c) {
-			return new CertificateController(
-				$c->query('AppName'),
-				$c->query('Request'),
-				$c->query('CertificateManager'),
-				$c->query('SystemCertificateManager'),
-				$c->query('L10N'),
-				$c->query('IAppManager')
-			);
-		});
-		$container->registerService('GroupsController', function(IContainer $c) {
-			return new GroupsController(
-				$c->query('AppName'),
-				$c->query('Request'),
-				$c->query('GroupManager'),
-				$c->query('UserSession'),
-				$c->query('IsAdmin'),
-				$c->query('L10N')
-			);
-		});
-		$container->registerService('UsersController', function(IContainer $c) {
-			return new UsersController(
-				$c->query('AppName'),
-				$c->query('Request'),
-				$c->query('UserManager'),
-				$c->query('GroupManager'),
-				$c->query('UserSession'),
-				$c->query('Config'),
-				$c->query('IsAdmin'),
-				$c->query('L10N'),
-				$c->query('Logger'),
-				$c->query('Defaults'),
-				$c->query('Mailer'),
-				$c->query('DefaultMailAddress'),
-				$c->query('URLGenerator'),
-				$c->query('OCP\\App\\IAppManager'),
-				$c->query('OCP\\IAvatarManager'),
-				$c->query('AccountManager')
-			);
-		});
-		$container->registerService('LogSettingsController', function(IContainer $c) {
-			return new LogSettingsController(
-				$c->query('AppName'),
-				$c->query('Request'),
-				$c->query('Config'),
-				$c->query('L10N')
-			);
-		});
-		$container->registerService('CheckSetupController', function(IContainer $c) {
-			return new CheckSetupController(
-				$c->query('AppName'),
-				$c->query('Request'),
-				$c->query('Config'),
-				$c->query('ClientService'),
-				$c->query('URLGenerator'),
-				$c->query('Util'),
-				$c->query('L10N'),
-				$c->query('Checker')
-			);
-		});
-
 
 		/**
 		 * Core class wrappers


### PR DESCRIPTION
`./autotest.sh sqlite tests/Settings/ApplicationTest.php` takes care that the classes can still be created. So this is tested.

Reverts the accidential addition from: https://github.com/nextcloud/server/pull/1946/files#diff-cea6eb52b9904c975f4e7302a59d4396


@LukasReschke @ChristophWurst 