### PR TITLE
fix wording of File drop, ref #2207

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -337,7 +337,7 @@
 				publicUploadChecked: publicUploadChecked,
 				hideFileListChecked: hideFileListChecked,
 				publicUploadLabel: t('core', 'Allow upload and editing'),
-				hideFileListLabel: t('core', 'Hide file listing'),
+				hideFileListLabel: t('core', 'File drop (upload only)'),
 				mailPrivatePlaceholder: t('core', 'Email link to person'),
 				mailButtonText: t('core', 'Send')
 			}));


### PR DESCRIPTION
This is the first half of what @jasonbayton proposed in https://github.com/nextcloud/server/issues/2207

The wording improvement is already good on its own. We could additionally improve it by showing both options, making them radio buttons, with »Allow upload and editing« being the default. This is probably something for Nextcloud 12 though since feature freeze? cc @nextcloud/javascript

(@jasonbayton I think the greying out would confuse people as to the clickability of the second option, so a radio button is better here. :)