### PR TITLE
Use the display name for files activities again

### DIFF
--- a/apps/files/lib/Activity/Provider.php
+++ b/apps/files/lib/Activity/Provider.php
@@ -43,6 +43,9 @@ class Provider implements IProvider {
 	/** @var IUserManager */
 	protected $userManager;
 
+	/** @var string[] cached displayNames - key is the UID and value the displayname */
+	protected $displayNames = [];
+
 	/**
 	 * @param IL10N $l
 	 * @param IURLGenerator $url

--- a/apps/files/lib/Activity/Provider.php
+++ b/apps/files/lib/Activity/Provider.php
@@ -26,6 +26,8 @@ use OCP\Activity\IManager;
 use OCP\Activity\IProvider;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
 
 class Provider implements IProvider {
 
@@ -38,15 +40,20 @@ class Provider implements IProvider {
 	/** @var IManager */
 	protected $activityManager;
 
+	/** @var IUserManager */
+	protected $userManager;
+
 	/**
 	 * @param IL10N $l
 	 * @param IURLGenerator $url
 	 * @param IManager $activityManager
+	 * @param IUserManager $userManager
 	 */
-	public function __construct(IL10N $l, IURLGenerator $url, IManager $activityManager) {
+	public function __construct(IL10N $l, IURLGenerator $url, IManager $activityManager, IUserManager $userManager) {
 		$this->l = $l;
 		$this->url = $url;
 		$this->activityManager = $activityManager;
+		$this->userManager = $userManager;
 	}
 
 	/**
@@ -265,11 +272,28 @@ class Provider implements IProvider {
 		];
 	}
 
-	protected function getRichUserParameter($parameter) {
+	protected function getRichUserParameter($uid) {
+		if (!isset($this->displayNames[$uid])) {
+			$this->displayNames[$uid] = $this->getDisplayName($uid);
+		}
+
 		return [
 			'type' => 'user',
-			'id' => $parameter,
-			'name' => $parameter,// FIXME Use display name
+			'id' => $uid,
+			'name' => $this->displayNames[$uid],
 		];
+	}
+
+	/**
+	 * @param string $uid
+	 * @return string
+	 */
+	protected function getDisplayName($uid) {
+		$user = $this->userManager->get($uid);
+		if ($user instanceof IUser) {
+			return $user->getDisplayName();
+		} else {
+			return $uid;
+		}
 	}
 }


### PR DESCRIPTION
# Steps
1. As user 1 share a folder with a user 2 (which has a display name)
2. As user 2 upload a file and tag it
3. As user 1 check your activity stream. Should show "display name" instead of "user 2"

@LukasReschke @rullzer @MorrisJobke easy review