### PR TITLE
use ? instead of X for avatar name fallback

### DIFF
--- a/core/js/jquery.avatar.js
+++ b/core/js/jquery.avatar.js
@@ -29,7 +29,7 @@
  * 3. $('.avatardiv').avatar();
  * This will search the DOM for 'user' data, to use as the username. If there
  * is no username available it will default to a placeholder with the value of
- * "x". The size will be determined the same way, as the second example.
+ * "?". The size will be determined the same way, as the second example.
  *
  * 4. $('.avatardiv').avatar('jdoe', 128, true);
  * This will behave like the first example, except it will also append random
@@ -65,7 +65,7 @@
 			if (typeof(this.data('user')) !== 'undefined') {
 				user = this.data('user');
 			} else {
-				this.imageplaceholder('x');
+				this.imageplaceholder('?');
 				return;
 			}
 		}
@@ -105,7 +105,7 @@
 							$div.imageplaceholder(user, result.data.displayname);
 						} else {
 							// User does not exist
-							$div.imageplaceholder(user, 'X');
+							$div.imageplaceholder(user, '?');
 							$div.css('background-color', '#b9b9b9');
 						}
 					} else {

--- a/core/js/tests/specs/jquery.avatarSpec.js
+++ b/core/js/tests/specs/jquery.avatarSpec.js
@@ -65,7 +65,7 @@ describe('jquery.avatar tests', function() {
 
 		$div.avatar();
 		
-		expect($div.imageplaceholder).toHaveBeenCalledWith('x');
+		expect($div.imageplaceholder).toHaveBeenCalledWith('?');
 	});
 
 	describe('no avatar', function() {
@@ -96,7 +96,7 @@ describe('jquery.avatar tests', function() {
 				})
 			);
 
-			expect($div.imageplaceholder).toHaveBeenCalledWith('foo', 'X');
+			expect($div.imageplaceholder).toHaveBeenCalledWith('foo', '?');
 		});
 
 		it('show no placeholder', function() {


### PR DESCRIPTION
When the name can’t be found or there’s another error, we show an X currently. This is a bit strange especially since there are names starting with X. ;) Changed it to a »?«.

Please review @rullzer @Kondou-ger @nextcloud/javascript 