### PR TITLE
VCARDS don't hold binary data

### DIFF
--- a/apps/dav/lib/CardDAV/Converter.php
+++ b/apps/dav/lib/CardDAV/Converter.php
@@ -71,7 +71,7 @@ class Converter {
 						break;
 					case AccountManager::PROPERTY_AVATAR:
 						if ($image !== null) {
-							$vCard->add('PHOTO', $image->data(), ['ENCODING' => 'b', 'TYPE' => $image->mimeType()]);
+							$vCard->add('PHOTO', 'data:'.$image->mimeType().';base64,' . base64_encode($image->data()));
 						}
 						break;
 					case AccountManager::PROPERTY_EMAIL:

--- a/apps/dav/tests/unit/CardDAV/ConverterTest.php
+++ b/apps/dav/tests/unit/CardDAV/ConverterTest.php
@@ -134,11 +134,45 @@ class ConverterTest extends  TestCase {
 
 	public function providesNewUsers() {
 		return [
-			[null],
-			[null, null, 'foo@bar.net'],
-			[['cloud' => 'foo@cloud.net', 'email' => 'foo@bar.net'], null, 'foo@bar.net', 'foo@cloud.net'],
-			[['cloud' => 'foo@cloud.net', 'email' => 'foo@bar.net', 'fn' => 'Dr. Foo Bar'], "Dr. Foo Bar", "foo@bar.net", 'foo@cloud.net'],
-			[['cloud' => 'foo@cloud.net', 'fn' => 'Dr. Foo Bar'], "Dr. Foo Bar", null, "foo@cloud.net"],
+			[
+				null
+			],
+			[
+				null,
+				null,
+				'foo@bar.net'
+			],
+			[
+				[
+					'cloud' => 'foo@cloud.net',
+					'email' => 'foo@bar.net',
+					'photo' => 'data:image/jpeg;base64,MTIzNDU2Nzg5',
+				],
+				null,
+				'foo@bar.net',
+				'foo@cloud.net'
+			],
+			[
+				[
+					'cloud' => 'foo@cloud.net',
+					'email' => 'foo@bar.net',
+					'fn' => 'Dr. Foo Bar',
+					'photo' => 'data:image/jpeg;base64,MTIzNDU2Nzg5',
+				],
+				"Dr. Foo Bar",
+				"foo@bar.net",
+				'foo@cloud.net'
+			],
+			[
+				[
+					'cloud' => 'foo@cloud.net',
+					'fn' => 'Dr. Foo Bar',
+					'photo' => 'data:image/jpeg;base64,MTIzNDU2Nzg5',
+				],
+				"Dr. Foo Bar",
+				null,
+				"foo@cloud.net"
+			],
 		];
 	}
 
@@ -171,7 +205,7 @@ class ConverterTest extends  TestCase {
 	 */
 	protected function getUserMock($displayName, $eMailAddress, $cloudId) {
 		$image0 = $this->getMockBuilder(IImage::class)->disableOriginalConstructor()->getMock();
-		$image0->method('mimeType')->willReturn('JPEG');
+		$image0->method('mimeType')->willReturn('image/jpeg');
 		$image0->method('data')->willReturn('123456789');
 		$user = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$user->method('getUID')->willReturn('12345');


### PR DESCRIPTION
Should fix #2258

We need to base64 encode the avatar and not just dump binary data in there.

TODO:
- [x] Add tests