### PR TITLE
Do not add invites into read-only calendars

### DIFF
--- a/apps/dav/lib/CalDAV/CalendarHome.php
+++ b/apps/dav/lib/CalDAV/CalendarHome.php
@@ -42,6 +42,13 @@ class CalendarHome extends \Sabre\CalDAV\CalendarHome {
 	}
 
 	/**
+	 * @return BackendInterface
+	 */
+	public function getCalDAVBackend() {
+		return $this->caldavBackend;
+	}
+
+	/**
 	 * @inheritdoc
 	 */
 	function getChildren() {


### PR DESCRIPTION
💥 **WARNING:** I have no idea what I'm doing 💥 

So my account on c.nc.com was created together with a group. The group already had a calendar or two assigned. In 10.0.0 there was a bug where this caused the first login not to generate the personal calendar. So the first calendar that was created for me is the "Contacts brithday" calendar.
Currently all invites are saved to the first calendar that is owned by the user. But for me that is the read-only "Contacts brithday" calendar. The problem is, I can not move the events to my personal calendar which I created afterwards. The second issue is that on the next ccron execution which syncs the birthdays with existing contacts, the event is deleted.

I would even make this a bit simpler now, after thinking some time and always use the personal calendar, and if it does not exist, create it again...

Ideas, opinions? @LukasReschke @rullzer @georgehrke 


### Steps to 💥 
1. Enable calendar and contacts app
2. As user1 add your@email.tld as your email address
3. As user1 add a contact which has a birthday date
4. Run the cron job to make sure the birthday calendar appears
5. As user1 delete the personal calendar, so only the subscription birthday calendar remains
6. As user2 create an event and in the attendees section add user1 as attendee
7. As user1 see the event in your birthday reminders... completly useless
