### PR TITLE
Remove padding from apps navigation if there is no settings area

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -43,6 +43,10 @@
 	box-sizing: border-box;
 }
 
+#app-navigation.without-app-settings {
+	padding-bottom: 0;
+}
+
 #app-navigation .active.with-menu > a,
 #app-navigation .with-counter > a {
 	padding-right: 50px;

--- a/core/js/apps.js
+++ b/core/js/apps.js
@@ -59,6 +59,10 @@
 	var registerAppsSlideToggle = function () {
 		var buttons = $('[data-apps-slide-toggle]');
 
+		if (buttons.length === 0) {
+			$('#app-navigation').addClass('without-app-settings');
+		}
+
 		$(document).click(function (event) {
 
 			if (dynamicSlideToggleEnabled) {


### PR DESCRIPTION
* fixes #2189
* see personal page for example (there should be no padding) and the files app (there should be padding)

cc @BernhardPosselt @nextcloud/designers @nextcloud/javascript @juliushaertl @skjnldsv 