### PR TITLE
fix password check when using remember me login

### DIFF
--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -127,10 +127,9 @@ class JSConfigHelper {
 		}
 
 		if ($this->currentUser instanceof IUser) {
-			$lastConfirmTimestamp = $this->currentUser->getLastLogin();
-			$sessionTime = $this->session->get('last-password-confirm');
-			if (is_int($sessionTime)) {
-				$lastConfirmTimestamp = $sessionTime;
+			$lastConfirmTimestamp = $this->session->get('last-password-confirm');
+			if (!is_int($lastConfirmTimestamp)) {
+				$lastConfirmTimestamp = 0;
 			}
 		} else {
 			$lastConfirmTimestamp = 0;


### PR DESCRIPTION
When using "remember me" the `last-password-confirm` isn't said (and it shouldn't be) but `lastLogin` is, thus we shouldn't fallback to `lastLogin` when telling js whether a password recheck is needed

fixes #2289

cc @LukasReschke 