### PR TITLE
small password check improvements

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1579,6 +1579,7 @@ OC.PasswordConfirmation = {
 				}
 			},
 			error: function() {
+				OC.PasswordConfirmation.requirePasswordConfirmation(self.callback);
 				OC.Notification.showTemporary(t('core', 'Failed to authenticate, try again'));
 			}
 		});

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -149,6 +149,7 @@ var OCdialogs = {
 				modal        : modal,
 				buttons      : buttonlist
 			});
+			input.focus();
 			OCdialogs.dialogsCounter++;
 		});
 	},


### PR DESCRIPTION
* add focus to input field so that the user can start to type the password right away
* show the dialog again on error, typically people want to retry if it fails. If not they can click on "cancel" at any time

@nickvergessen please have a look