### PR TITLE
Fix previews for federated shares

### DIFF
--- a/lib/private/Preview/GeneratorHelper.php
+++ b/lib/private/Preview/GeneratorHelper.php
@@ -60,7 +60,8 @@ class GeneratorHelper {
 	 * This is required to create the old view and path
 	 */
 	private function getViewAndPath(File $file) {
-		$owner = $file->getOwner()->getUID();
+		$absPath = ltrim($file->getPath(), '/');
+		$owner = explode('/', $absPath)[0];
 
 		$userFolder = $this->rootFolder->getUserFolder($owner)->getParent();
 


### PR DESCRIPTION
Fixes #2298 

The owner of a federated file is the federated user. For which we obviously can't setup a view. Long term solution is to pass Nodes to the preview providers. Short term solution is to do string magic.

CC: @LukasReschke 