### PR TITLE
Remove exception for Chrome on Mobile

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -538,15 +538,6 @@ class OC {
 			return;
 		}
 
-		// Chrome on Android has a bug that it doesn't sent cookies with the
-		// same-site attribute for the download manager. To work around that
-		// all same-site cookies get deleted and recreated directly. Awesome!
-		// FIXME: Remove once Chrome 54 is deployed to end-users
-		// @see https://github.com/nextcloud/server/pull/1454
-		if($request->isUserAgent([\OC\AppFramework\Http\Request::USER_AGENT_ANDROID_MOBILE_CHROME])) {
-			return;
-		}
-
 		if(count($_COOKIE) > 0) {
 			$requestUri = $request->getScriptName();
 			$processingScript = explode('/', $requestUri);


### PR DESCRIPTION
This didn't really work anyways and Chrome 54 for Android has been pushed out via Google Play on October 19th. So we should remove this. (https://googlechromereleases.blogspot.ch/2016/10/chrome-for-android-update.html)

This is only in master and doesn't affect any stable branch.

Fixes https://github.com/nextcloud/server/issues/2318

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>

@juliushaertl Can you test?