### PR TITLE
Add nextcloud_announcements to shipped.json

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -23,6 +23,7 @@
     "gallery",
     "logreader",
     "lookup_server_connector",
+    "nextcloud_announcements",
     "notifications",
     "password_policy",
     "provisioning_api",


### PR DESCRIPTION
Otherwise on the update from beta1 to beta2 the app would be disabled again as incompatible:

```
root@cloud:/var/www/html# sudo -u www-data php occ upgrade
Nextcloud or one of the apps require upgrade - only a limited number of commands are available
You may use your browser or the occ upgrade command to do the upgrade
Set log level to debug
Turned on maintenance mode
Updating database schema
Updated database
Disabled 3rd-party app: calendar
Disabled 3rd-party app: contacts
Disabled 3rd-party app: nextcloud_announcements
Disabled 3rd-party app: spreed
Update 3rd-party app: calendar
Update 3rd-party app: contacts
```

@MorrisJobke @rullzer Easy one.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>