### PR TITLE
Fix styling of slogan on login page for longer text

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -272,7 +272,6 @@ body {
 	text-align: center;
 }
 #body-login p.info {
-	width: 22em;
 	margin: 0 auto;
 	padding-top: 20px;
 	-webkit-user-select: none;
@@ -424,10 +423,6 @@ label.infield {
 #body-login p.info a:hover,
 #body-login p.info a:focus  {
 	opacity: .6;
-}
-
-#body-login footer .info {
-	white-space: nowrap;
 }
 
 /* Show password toggle */


### PR DESCRIPTION
Fixes #851

## Before
![2016-11-25-104234_948x412_scrot](https://cloud.githubusercontent.com/assets/3404133/20620909/5838c080-b2fc-11e6-99b3-cd2ba62e1485.png)
## After
![2016-11-25-104244_950x431_scrot](https://cloud.githubusercontent.com/assets/3404133/20620910/584b7a90-b2fc-11e6-84a0-ed267cf35681.png)

Please review @nextcloud/designers @Bugsbane @alenkovich