### PR TITLE
[Minor] Fix link to external storage settings on error notification

### DIFF
--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -182,7 +182,7 @@ OCA.External.StatusManager = {
 					} else {
 						OC.dialogs.confirm(t('files_external', 'There was an error with message: ') + mountData.error + '. Do you want to review mount point config in admin settings page?', t('files_external', 'External mount error'), function (e) {
 							if (e === true) {
-								OC.redirect(OC.generateUrl('/settings/admin#files_external'));
+								OC.redirect(OC.generateUrl('/settings/admin/externalstorages'));
 							}
 						});
 					}


### PR DESCRIPTION
The link still redirected to the old #link `settings/admin#files_external`.

I have searched the repo for other occurrences, but found only  `core/js/integritycheck-failed-notification.js` and I#m not sure, if it has to be changed as well.

@nickvergessen @icewind1991 @MorrisJobke 