### PR TITLE
do not remember session tokens by default

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -558,7 +558,7 @@ class Session implements IUserSession, Emitter {
 		try {
 			$sessionId = $this->session->getId();
 			$pwd = $this->getPassword($password);
-			$this->tokenProvider->generateToken($sessionId, $uid, $loginName, $pwd, $name, IToken::TEMPORARY_TOKEN, IToken::REMEMBER);
+			$this->tokenProvider->generateToken($sessionId, $uid, $loginName, $pwd, $name, IToken::TEMPORARY_TOKEN, $remember);
 			return true;
 		} catch (SessionNotAvailableException $ex) {
 			// This can happen with OCC, where a memory session is used

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -800,7 +800,7 @@ class SessionTest extends \Test\TestCase {
 
 		$this->tokenProvider->expects($this->once())
 			->method('generateToken')
-			->with($sessionId, $uid, $loginName, $password, 'Firefox', IToken::DO_NOT_REMEMBER, IToken::TEMPORARY_TOKEN);
+			->with($sessionId, $uid, $loginName, $password, 'Firefox', IToken::TEMPORARY_TOKEN, IToken::DO_NOT_REMEMBER);
 
 		$this->assertTrue($userSession->createSessionToken($request, $uid, $loginName, $password));
 	}


### PR DESCRIPTION
We have to respect the value of the remember-me checkbox. Due to an error
in the source code the default value for the session token was to remember
it.