### PR TITLE
copy remember-me value when renewing a session token

### DIFF
--- a/lib/private/Authentication/Token/DefaultTokenProvider.php
+++ b/lib/private/Authentication/Token/DefaultTokenProvider.php
@@ -192,6 +192,7 @@ class DefaultTokenProvider implements IProvider {
 		$newToken->setName($token->getName());
 		$newToken->setToken($this->hashToken($sessionId));
 		$newToken->setType(IToken::TEMPORARY_TOKEN);
+		$newToken->setRemember($token->getRemember());
 		$newToken->setLastActivity($this->time->getTime());
 		$this->mapper->insert($newToken);
 	}

--- a/tests/lib/Authentication/Token/DefaultTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/DefaultTokenProviderTest.php
@@ -292,6 +292,10 @@ class DefaultTokenProviderTest extends TestCase {
 			->expects($this->at(3))
 			->method('getName')
 			->willReturn('MyTokenName');
+		$token
+			->expects($this->at(3))
+			->method('getRememberMe')
+			->willReturn(IToken::DO_NOT_REMEMBER);
 		$this->config
 			->expects($this->exactly(2))
 			->method('getSystemValue')
@@ -308,6 +312,7 @@ class DefaultTokenProviderTest extends TestCase {
 		$newToken->setName('MyTokenName');
 		$newToken->setToken(hash('sha512', 'newId' . 'MyInstanceSecret'));
 		$newToken->setType(IToken::TEMPORARY_TOKEN);
+		$newToken->setRemember(IToken::DO_NOT_REMEMBER);
 		$newToken->setLastActivity(1313131);
 		$this->mapper
 			->expects($this->at(1))
@@ -342,6 +347,10 @@ class DefaultTokenProviderTest extends TestCase {
 			->expects($this->at(4))
 			->method('getName')
 			->willReturn('MyTokenName');
+		$token
+			->expects($this->at(3))
+			->method('getRememberMe')
+			->willReturn(IToken::REMEMBER);
 		$this->crypto
 			->expects($this->any(0))
 			->method('decrypt')
@@ -368,12 +377,13 @@ class DefaultTokenProviderTest extends TestCase {
 		$newToken->setName('MyTokenName');
 		$newToken->setToken(hash('sha512', 'newId' . 'MyInstanceSecret'));
 		$newToken->setType(IToken::TEMPORARY_TOKEN);
+		$newToken->setRemember(IToken::REMEMBER);
 		$newToken->setLastActivity(1313131);
 		$newToken->setPassword('EncryptedPassword');
 		$this->mapper
 			->expects($this->at(1))
 			->method('insert')
-			->with($newToken);
+			->with($this->equalTo($newToken));
 
 		$this->tokenProvider->renewSessionToken('oldId', 'newId');
 	}


### PR DESCRIPTION
On renew, a session token is duplicated. For some reason we did
not copy over the remember-me attribute value. Hence, the new token
was deleted too early in the background job and remember-me did
not work properly.

Signed-off-by: Christoph Wurst <christoph@winzerhof-wurst.at>