### PR TITLE
fix undefined index error when the backup codes provider is not active

### DIFF
--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -106,6 +106,9 @@ class Manager {
 	 */
 	public function getBackupProvider(IUser $user) {
 		$providers = $this->getProviders($user, true);
+		if (!isset($providers[self::BACKUP_CODES_PROVIDER_ID])) {
+			return null;
+		}
 		return $providers[self::BACKUP_CODES_PROVIDER_ID];
 	}
 


### PR DESCRIPTION
In users have not created backup codes yet the app is not enabled for that user
and therefore we got an undefined index error because the code assumed it was
always there. It now properly returns null.

fixes https://github.com/nextcloud/server/issues/1957