### PR TITLE
open popup menu in share dialog only for one sharee on render

### DIFF
--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -284,9 +284,13 @@
 			this.$('.popovermenu').on('afterHide', function() {
 				_this._menuOpen = false;
 			});
-			if (this._menuOpen) {
+			if (this._menuOpen != false) {
 				// Open menu again if it was opened before
-				OC.showMenu(null, this.$('.popovermenu'));
+				var shareId = parseInt(this._menuOpen, 10);
+				if(!_.isNaN(shareId)) {
+					var liSelector = 'li[data-share-id=' + shareId + ']';
+					OC.showMenu(null, this.$(liSelector + ' .popovermenu'));
+				}
 			}
 
 			this.delegateEvents();
@@ -344,7 +348,7 @@
 			var $menu = $li.find('.popovermenu');
 
 			OC.showMenu(null, $menu);
-			this._menuOpen = true;
+			this._menuOpen = $li.data('share-id');
 		},
 
 		onPermissionChange: function(event) {


### PR DESCRIPTION
The _menuOpen marker was binary, so that the render method was showing it for every sharee after an action happened (#2329). Now the marker stores the share id (or false).

@ChristophWurst @schiessle @rullzer 