### PR TITLE
Keep the filemtime for files when downloading them in a zip/tar

### DIFF
--- a/lib/private/Streamer.php
+++ b/lib/private/Streamer.php
@@ -76,8 +76,9 @@ class Streamer {
 			$file = $dir . '/' . $filename;
 			if(\OC\Files\Filesystem::is_file($file)) {
 				$filesize = \OC\Files\Filesystem::filesize($file);
+				$fileTime = \OC\Files\Filesystem::filemtime($file);
 				$fh = \OC\Files\Filesystem::fopen($file, 'r');
-				$this->addFileFromStream($fh, $internalDir . $filename, $filesize);
+				$this->addFileFromStream($fh, $internalDir . $filename, $filesize, $fileTime);
 				fclose($fh);
 			}elseif(\OC\Files\Filesystem::is_dir($file)) {
 				$this->addDirRecursive($file, $internalDir);
@@ -93,11 +94,18 @@ class Streamer {
 	 * @param int $size Filesize
 	 * @return bool $success
 	 */
-	public function addFileFromStream($stream, $internalName, $size){
+	public function addFileFromStream($stream, $internalName, $size, $time) {
+		$options = [];
+		if ($time) {
+			$options = [
+				'timestamp' => $time
+			];
+		}
+
 		if ($this->streamerInstance instanceof ZipStreamer) {
-			return $this->streamerInstance->addFileFromStream($stream, $internalName);
+			return $this->streamerInstance->addFileFromStream($stream, $internalName, $options);
 		} else {
-			return $this->streamerInstance->addFileFromStream($stream, $internalName, $size);
+			return $this->streamerInstance->addFileFromStream($stream, $internalName, $size, $options);
 		}
 	}
 

--- a/lib/private/Streamer.php
+++ b/lib/private/Streamer.php
@@ -92,6 +92,7 @@ class Streamer {
 	 * @param string $stream Stream to read data from
 	 * @param string $internalName Filepath and name to be used in the archive.
 	 * @param int $size Filesize
+	 * @param int|bool $time File mtime as int, or false
 	 * @return bool $success
 	 */
 	public function addFileFromStream($stream, $internalName, $size, $time) {

--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -153,8 +153,9 @@ class OC_Files {
 					$file = $dir . '/' . $file;
 					if (\OC\Files\Filesystem::is_file($file)) {
 						$fileSize = \OC\Files\Filesystem::filesize($file);
+						$fileTime = \OC\Files\Filesystem::filemtime($file);
 						$fh = \OC\Files\Filesystem::fopen($file, 'r');
-						$streamer->addFileFromStream($fh, basename($file), $fileSize);
+						$streamer->addFileFromStream($fh, basename($file), $fileSize, $fileTime);
 						fclose($fh);
 					} elseif (\OC\Files\Filesystem::is_dir($file)) {
 						$streamer->addDirRecursive($file);


### PR DESCRIPTION
Fix #2349 

@oparoz @LukasReschke 

Should we backport this? I don't think it's very critical?