### PR TITLE
Add share indicator for mail shares

### DIFF
--- a/apps/dav/lib/Connector/Sabre/SharesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/SharesPlugin.php
@@ -120,7 +120,8 @@ class SharesPlugin extends \Sabre\DAV\ServerPlugin {
 			\OCP\Share::SHARE_TYPE_USER,
 			\OCP\Share::SHARE_TYPE_GROUP,
 			\OCP\Share::SHARE_TYPE_LINK,
-			\OCP\Share::SHARE_TYPE_REMOTE
+			\OCP\Share::SHARE_TYPE_REMOTE,
+			\OCP\Share::SHARE_TYPE_EMAIL,
 		];
 		foreach ($requestedShareTypes as $requestedShareType) {
 			// one of each type is enough to find out about the types

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -114,6 +114,8 @@
 							shareType = parseInt(shareType, 10);
 							if (shareType === OC.Share.SHARE_TYPE_LINK) {
 								hasLink = true;
+							} else if (shareType === OC.Share.SHARE_TYPE_EMAIL) {
+								hasLink = true;
 							} else if (shareType === OC.Share.SHARE_TYPE_USER) {
 								hasShares = true;
 							} else if (shareType === OC.Share.SHARE_TYPE_GROUP) {

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -161,8 +161,17 @@
 			shareTab.on('sharesChanged', function(shareModel) {
 				var fileInfoModel = shareModel.fileInfoModel;
 				var $tr = fileList.findFileEl(fileInfoModel.get('name'));
+
+				// We count email shares as link share
+				var hasLinkShare = shareModel.hasLinkShare();
+				shareModel.get('shares').forEach(function (share) {
+					if (share.share_type === OC.Share.SHARE_TYPE_EMAIL) {
+						hasLinkShare = true;
+					}
+				});
+
 				OCA.Sharing.Util._updateFileListDataAttributes(fileList, $tr, shareModel);
-				if (!OCA.Sharing.Util._updateFileActionIcon($tr, shareModel.hasUserShares(), shareModel.hasLinkShare())) {
+				if (!OCA.Sharing.Util._updateFileActionIcon($tr, shareModel.hasUserShares(), hasLinkShare)) {
 					// remove icon, if applicable
 					OC.Share.markFileAsShared($tr, false, false);
 				}

--- a/apps/sharebymail/appinfo/info.xml
+++ b/apps/sharebymail/appinfo/info.xml
@@ -5,13 +5,17 @@
     <description>Share provider which allows you to share files by mail</description>
     <licence>AGPL</licence>
     <author>Bjoern Schiessle</author>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <namespace>ShareByMail</namespace>
     <category>other</category>
     <dependencies>
         <nextcloud min-version="11" max-version="11" />
     </dependencies>
     <default_enable/>
+
+    <types>
+        <filesystem/>
+    </types>
 
     <activity>
         <providers>

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -206,6 +206,10 @@ class ProviderFactory implements IProviderFactory {
 	}
 
 	public function getAllProviders() {
+		$shareByMail = $this->getShareByMailProvider();
+		if ($shareByMail !== null) {
+			return [$this->defaultShareProvider(), $this->federatedShareProvider(), $shareByMail];
+		}
 		return [$this->defaultShareProvider(), $this->federatedShareProvider()];
 	}
 }


### PR DESCRIPTION
Fix #2369 

### steps
1. Share an item by mail
2. Refresh the page and try to find the share indicator in the file list

@rullzer @schiessle 