### PR TITLE
Fix Regex for iPhone and add iPad

### DIFF
--- a/settings/js/authtoken_view.js
+++ b/settings/js/authtoken_view.js
@@ -129,7 +129,8 @@
 				safari: /^Mozilla\/5\.0 \([^)]*(Windows|OS X)[^)]+\) AppleWebKit\/[0-9.]+ \(KHTML, like Gecko\)(?: Version\/([0-9]+)[0-9.]+)? Safari\/[0-9.A-Z]+$/,
 				// Android Chrome user agent: https://developers.google.com/chrome/mobile/docs/user-agent
 				androidChrome: /Android.*(?:; (.*) Build\/).*Chrome\/(\d+)[0-9.]+/,
-				iphone: / *CPU +iPhone +OS +(\d+)_\d+ +like +Mac +OS +X */,
+				iphone: / *CPU +iPhone +OS +([0-9]+)_(?:[0-9_])+ +like +Mac +OS +X */,
+				ipad: /\(iPad\; *CPU +OS +([0-9]+)_(?:[0-9_])+ +like +Mac +OS +X */,
 				iosClient: /^Mozilla\/5\.0 \(iOS\) ownCloud\-iOS.*$/,
 				androidClient:/^Mozilla\/5\.0 \(Android\) ownCloud\-android.*$/,
 				// DAVdroid/1.2 (2016/07/03; dav4android; okhttp3) Android/6.0.1
@@ -146,7 +147,8 @@
 				chrome: t('setting', 'Google Chrome'),
 				safari: t('setting', 'Safari'),
 				androidChrome: t('setting', 'Google Chrome for Android'),
-				iphone: t('setting', 'iPhone'),
+				iphone: t('setting', 'iPhone iOS'),
+				ipad: t('setting', 'iPad iOS'),
 				iosClient: t('setting', 'iOS Client'),
 				androidClient: t('setting', 'Android Client'),
 				davDroid: 'DAVdroid',


### PR DESCRIPTION
The previous Regex worked for an iPhone with version "10.0" but not with "10.0.1" which was wrong. I modified the Regex to also match for those situations.

I also added a Regex for the iPad

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>

cc @icewind1991 @MorrisJobke 