### PR TITLE
Fix whitespace between sharee name and icons #2384

### DIFF
--- a/apps/files/css/mobile.css
+++ b/apps/files/css/mobile.css
@@ -61,11 +61,6 @@ table td.filename .nametext .innernametext {
 	max-width: 50%;
 }
 
-/* ellipsis on user names in share sidebar, less on mobile */
-#shareWithList .username {
-	max-width: 80px !important;
-}
-
 /* proper notification area for multi line messages */
 #notification-container {
 	display: -webkit-box;

--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -56,6 +56,8 @@
 	padding-bottom: 5px;
 	font-weight: bold;
 	white-space: normal;
+	display: inline-flex;
+	align-items: center;
 }
 
 #shareWithList .unshare img, #shareWithList .showCruds img {
@@ -89,7 +91,6 @@
 	padding-right: 8px;
 	white-space: nowrap;
 	text-overflow: ellipsis;
-	max-width: 110px;
 	display: inline-block;
 	overflow: hidden;
 	vertical-align: middle;

--- a/core/css/share.css
+++ b/core/css/share.css
@@ -74,7 +74,7 @@
 	font-weight: bold;
 	line-height: 21px;
 	white-space: normal;
-	max-width: 100%;
+	width: 100%;
 }
 
 #shareWithList .sharingOptionsGroup {
@@ -108,6 +108,7 @@
 	display: inline-block;
 	overflow: hidden;
 	vertical-align: middle;
+	flex-grow: 5;
 }
 #shareWithList li label{
 	margin-right: 8px;

--- a/core/css/share.css
+++ b/core/css/share.css
@@ -74,16 +74,18 @@
 	font-weight: bold;
 	line-height: 21px;
 	white-space: normal;
+	max-width: 100%;
 }
 
 #shareWithList .sharingOptionsGroup {
-	position: absolute;
-	right: 15px;
+	flex-shrink: 0;
+	position: relative;
 }
 
 #shareWithList .sharingOptionsGroup .popovermenu {
-	right: -14px;
+	right: -6px;
 	top: 40px;
+	padding: 3px 6px;
 }
 
 #shareWithList .shareOption {
@@ -103,7 +105,6 @@
 	padding-right: 8px;
 	white-space: nowrap;
 	text-overflow: ellipsis;
-	max-width: 254px;
 	display: inline-block;
 	overflow: hidden;
 	vertical-align: middle;


### PR DESCRIPTION
Too much whitespace between sharee name and icons #2384
![capture d ecran_2016-11-29_07-05-57](https://cloud.githubusercontent.com/assets/14975046/20698600/6f34689e-b602-11e6-8d4e-2488d28f820c.png)

@blizzz @nextcloud/designers 