### PR TITLE
Fix floating of tabHeader items

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -616,6 +616,7 @@ em {
 }
 .tabHeaders .tabHeader, .tabHeaders .tabHeader a {
 	color: #888;
+	margin-bottom: 1px;
 }
 .tabHeaders .tabHeader.selected {
 	font-weight: 600;
@@ -628,6 +629,7 @@ em {
 .tabHeaders .tabHeader.selected a,
 .tabHeaders .tabHeader:hover,
 .tabHeaders .tabHeader:hover a {
+	margin-bottom: 0px;
 	color: #000;
 }
 .tabsContainer {


### PR DESCRIPTION
This PR fixes wrong floating of items in tabHeader for smaller window sizes.
To test this, resize the browser window smaller than ~1100px

Before:
![2016-11-29-111102_308x68_scrot](https://cloud.githubusercontent.com/assets/3404133/20705770/9c0cdd16-b624-11e6-9de3-efd0ba1c800e.png)


After:
![2016-11-29-111127_306x73_scrot](https://cloud.githubusercontent.com/assets/3404133/20705771/9e463c30-b624-11e6-9ff4-96782f73a70b.png)

please review @nextcloud/designers 