### PR TITLE
Use displayname instead of username for sharee view

### DIFF
--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -22,7 +22,7 @@
 			'{{#each sharees}}' +
 				'<li data-share-id="{{shareId}}" data-share-type="{{shareType}}" data-share-with="{{shareWith}}">' +
 					'{{#if avatarEnabled}}' +
-					'<div class="avatar {{#if modSeed}}imageplaceholderseed{{/if}}" data-username="{{shareWith}}" {{#if modSeed}}data-seed="{{shareWith}} {{shareType}}"{{/if}}></div>' +
+					'<div class="avatar {{#if modSeed}}imageplaceholderseed{{/if}}" data-username="{{shareWith}}" data-displayname="{{shareWithDisplayName}}" {{#if modSeed}}data-seed="{{shareWith}} {{shareType}}"{{/if}}></div>' +
 					'{{/if}}' +
 					'<span class="has-tooltip username" title="{{shareWithTitle}}">{{shareWithDisplayName}}</span>' +
 					'<span class="sharingOptionsGroup">' +
@@ -269,7 +269,8 @@
 						$this.css({width: 32, height: 32});
 						$this.imageplaceholder($this.data('seed'));
 					} else {
-						$this.avatar($this.data('username'), 32);
+						//                         user,   size,  ie8fix, hidedefault,  callback, displayname
+						$this.avatar($this.data('username'), 32, undefined, undefined, undefined, $this.data('displayname'));
 					}
 				});
 			}

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -464,8 +464,9 @@ describe('OC.Share.ShareDialogView', function() {
 
 			it('test avatar user', function() {
 				var args = avatarStub.getCall(1).args;
-				expect(args.length).toEqual(2);
+				expect(args.length).toEqual(6);
 				expect(args[0]).toEqual('user1');
+				expect(args[5]).toEqual('User One');
 			});
 
 			it('test avatar for groups', function() {


### PR DESCRIPTION
We should use the same data to generate the placeholder/avatar.
Now we have the same colours as the settings/users page.

![capture d ecran_2016-11-29_11-25-39](https://cloud.githubusercontent.com/assets/14975046/20706242/98469eb8-b626-11e6-893b-c92c0be9b016.png)
![capture d ecran_2016-11-29_11-25-48](https://cloud.githubusercontent.com/assets/14975046/20706243/9846a53e-b626-11e6-8c86-82b7092b2821.png)
