### PR TITLE
Execute MoveAvatars repair step only once

### DIFF
--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -153,7 +153,7 @@ class Repair implements IOutput{
 			new MoveUpdaterStepFile(\OC::$server->getConfig()),
 			new MoveAvatars(
 				\OC::$server->getJobList(),
-				\OC::$server->getSystemConfig()
+				\OC::$server->getConfig()
 			),
 		];
 	}


### PR DESCRIPTION
- avoids that this expensive repair step is executed on every update - for a more general way we should discuss this in #2270

cc @rullzer @nickvergessen @LukasReschke @schiessle @blizzz 