### PR TITLE
Fix empty version previews

### DIFF
--- a/apps/files_versions/js/versioncollection.js
+++ b/apps/files_versions/js/versioncollection.js
@@ -81,7 +81,8 @@
 					name: version.name,
 					fullPath: fullPath,
 					timestamp: revision,
-					size: version.size
+					size: version.size,
+					mimetype: version.mimetype
 				};
 			});
 			this._endReached = result.data.endReached;

--- a/apps/files_versions/js/versionstabview.js
+++ b/apps/files_versions/js/versionstabview.js
@@ -254,15 +254,12 @@
 		 * @param etag file etag (for caching)
 		 */
 		_lazyLoadPreview : function(options) {
-			var self = this;
 			var url = options.url;
 			var mime = options.mime;
 			var ready = options.callback;
 
 			// get mime icon url
 			var iconURL = OC.MimeType.getIconUrl(mime);
-			var previewURL,
-				urlSpec = {};
 			ready(iconURL); // set mimeicon URL
 
 			var img = new Image();

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -467,6 +467,7 @@ class Storage {
 						$versions[$key]['path'] = Filesystem::normalizePath($pathinfo['dirname'] . '/' . $filename);
 						$versions[$key]['name'] = $versionedFile;
 						$versions[$key]['size'] = $view->filesize($dir . '/' . $entryName);
+						$versions[$key]['mimetype'] = \OC::$server->getMimeTypeDetector()->detectPath($versionedFile);
 					}
 				}
 			}

--- a/apps/files_versions/tests/js/versionstabviewSpec.js
+++ b/apps/files_versions/tests/js/versionstabviewSpec.js
@@ -24,14 +24,16 @@ describe('OCA.Versions.VersionsTabView', function() {
 			timestamp: time1,
 			name: 'some file.txt',
 			size: 140,
-			fullPath: '/subdir/some file.txt'
+			fullPath: '/subdir/some file.txt',
+			mimetype: 'text/plain'
 		});
 		var version2 = new VersionModel({
 			id: time2,
 			timestamp: time2,
 			name: 'some file.txt',
 			size: 150,
-			fullPath: '/subdir/some file.txt'
+			fullPath: '/subdir/some file.txt',
+			mimetype: 'text/plain'
 		});
 
 		testVersions = [version1, version2];
@@ -80,14 +82,14 @@ describe('OCA.Versions.VersionsTabView', function() {
 			expect($item.find('.versiondate').text()).toEqual('seconds ago');
 			expect($item.find('.size').text()).toEqual('< 1 KB');
 			expect($item.find('.revertVersion').length).toEqual(1);
-			expect($item.find('.preview').attr('src')).toEqual(version1.getPreviewUrl());
+			expect($item.find('.preview').attr('src')).toEqual('http://localhost/core/img/filetypes/text.svg');
 
 			$item = $versions.eq(1);
 			expect($item.find('.downloadVersion').attr('href')).toEqual(version2.getDownloadUrl());
 			expect($item.find('.versiondate').text()).toEqual('2 days ago');
 			expect($item.find('.size').text()).toEqual('< 1 KB');
 			expect($item.find('.revertVersion').length).toEqual(1);
-			expect($item.find('.preview').attr('src')).toEqual(version2.getPreviewUrl());
+			expect($item.find('.preview').attr('src')).toEqual('http://localhost/core/img/filetypes/text.svg');
 		});
 
 		it('does not render revert button when no update permissions', function() {
@@ -104,13 +106,13 @@ describe('OCA.Versions.VersionsTabView', function() {
 			expect($item.find('.downloadVersion').attr('href')).toEqual(version1.getDownloadUrl());
 			expect($item.find('.versiondate').text()).toEqual('seconds ago');
 			expect($item.find('.revertVersion').length).toEqual(0);
-			expect($item.find('.preview').attr('src')).toEqual(version1.getPreviewUrl());
+			expect($item.find('.preview').attr('src')).toEqual('http://localhost/core/img/filetypes/text.svg');
 
 			$item = $versions.eq(1);
 			expect($item.find('.downloadVersion').attr('href')).toEqual(version2.getDownloadUrl());
 			expect($item.find('.versiondate').text()).toEqual('2 days ago');
 			expect($item.find('.revertVersion').length).toEqual(0);
-			expect($item.find('.preview').attr('src')).toEqual(version2.getPreviewUrl());
+			expect($item.find('.preview').attr('src')).toEqual('http://localhost/core/img/filetypes/text.svg');
 		});
 	});
 
@@ -156,7 +158,8 @@ describe('OCA.Versions.VersionsTabView', function() {
 				timestamp: time3,
 				name: 'some file.txt',
 				size: 54,
-				fullPath: '/subdir/some file.txt'
+				fullPath: '/subdir/some file.txt',
+				mimetype: 'text/plain'
 			});
 
 			tabView.collection.add(version3);
@@ -167,7 +170,7 @@ describe('OCA.Versions.VersionsTabView', function() {
 			expect($item.find('.downloadVersion').attr('href')).toEqual(version3.getDownloadUrl());
 			expect($item.find('.versiondate').text()).toEqual('7 days ago');
 			expect($item.find('.revertVersion').length).toEqual(1);
-			expect($item.find('.preview').attr('src')).toEqual(version3.getPreviewUrl());
+			expect($item.find('.preview').attr('src')).toEqual('http://localhost/core/img/filetypes/text.svg');
 		});
 	});
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/2413

Now we use lazypreviews here (just like in the filelist). So it feels even more responsive!

CC: @schiessle @nickvergessen @MorrisJobke @LukasReschke 