### PR TITLE
add .htaccess in root to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /apps/inc.php
 /assets
 /.htaccess
+.htaccess
 
 # ignore all apps except core ones
 /apps*/*


### PR DESCRIPTION
Any reason why this is not in the gitignore already? When setting up a local development environment, the .htaccess comes up as changed because the 403 and 404 error pages are added.