### PR TITLE
Fix login controller test and consolidate login

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -250,7 +250,7 @@ class LoginController extends Controller {
 		}
 		// TODO: remove password checks from above and let the user session handle failures
 		// requires https://github.com/owncloud/core/pull/24616
-		$this->userSession->login($user, $password);
+		$this->userSession->completeLogin($loginResult, ['loginName' => $user, 'password' => $password]);
 		$this->userSession->createSessionToken($this->request, $loginResult->getUID(), $user, $password, (int)$remember_login);
 
 		// User has successfully logged in, now remove the password reset link, when it is available

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -207,6 +207,9 @@ class LoginController extends Controller {
 	 * @return RedirectResponse
 	 */
 	public function tryLogin($user, $password, $redirect_url, $remember_login = false, $timezone = '', $timezone_offset = '') {
+		if(!is_string($user)) {
+			throw new \InvalidArgumentException('Username must be string');
+		}
 		$currentDelay = $this->throttler->getDelay($this->request->getRemoteAddress(), 'login');
 		$this->throttler->sleepDelay($this->request->getRemoteAddress(), 'login');
 

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -63,6 +63,7 @@ class Log implements ILogger {
 
 	protected $methodsWithSensitiveParameters = [
 		// Session/User
+		'completeLogin',
 		'login',
 		'checkPassword',
 		'loginWithPassword',

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -573,7 +573,14 @@ class Session implements IUserSession, Emitter {
 			return false;
 		}
 
-		return $this->completeLogin($user, ['loginName' => $uid, 'password' => $password, 'token' => $dbToken], false);
+		return $this->completeLogin(
+			$user,
+			[
+				'loginName' => $dbToken->getLoginName(),
+				'password' => $password,
+				'token' => $dbToken
+			],
+			false);
 	}
 
 	/**

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -339,6 +339,8 @@ class Session implements IUserSession, Emitter {
 			throw new LoginException($message);
 		}
 
+		$this->session->regenerateId();
+
 		$this->setUser($user);
 		$this->setLoginName($loginDetails['loginName']);
 
@@ -559,6 +561,8 @@ class Session implements IUserSession, Emitter {
 		} catch (PasswordlessTokenException $ex) {
 			// Ignore and use empty string instead
 		}
+
+		$this->manager->emit('\OC\User', 'preLogin', array($uid, $password));
 
 		$user = $this->manager->get($uid);
 		if (is_null($user)) {

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -41,6 +41,7 @@ use OC\Authentication\Exceptions\PasswordLoginForbiddenException;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
 use OC\Hooks\Emitter;
+use OC\Hooks\PublicEmitter;
 use OC_User;
 use OC_Util;
 use OCA\DAV\Connector\Sabre\Auth;
@@ -78,7 +79,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class Session implements IUserSession, Emitter {
 
-	/** @var IUserManager $manager */
+	/** @var IUserManager|PublicEmitter $manager */
 	private $manager;
 
 	/** @var ISession $session */
@@ -156,7 +157,7 @@ class Session implements IUserSession, Emitter {
 	/**
 	 * get the manager object
 	 *
-	 * @return Manager
+	 * @return Manager|PublicEmitter
 	 */
 	public function getManager() {
 		return $this->manager;
@@ -322,6 +323,41 @@ class Session implements IUserSession, Emitter {
 			return $this->loginWithToken($password);
 		}
 		return $this->loginWithPassword($uid, $password);
+	}
+
+	/**
+	 * @param IUser $user
+	 * @param array $loginDetails
+	 * @return bool
+	 * @throws LoginException
+	 */
+	public function completeLogin(IUser $user, array $loginDetails) {
+		if (!$user->isEnabled()) {
+			// disabled users can not log in
+			// injecting l10n does not work - there is a circular dependency between session and \OCP\L10N\IFactory
+			$message = \OC::$server->getL10N('lib')->t('User disabled');
+			throw new LoginException($message);
+		}
+
+		$this->setUser($user);
+		$this->setLoginName($loginDetails['loginName']);
+
+		if(isset($loginDetails['token']) && $loginDetails['token'] instanceof IToken) {
+			$this->setToken($loginDetails['token']->getId());
+			\OC::$server->getLockdownManager()->setToken($loginDetails['token']);
+			$firstTimeLogin = false;
+		} else {
+			$this->setToken(null);
+			$firstTimeLogin = $user->updateLastLoginTimestamp();
+		}
+		$this->manager->emit('\OC\User', 'postLogin', [$user, $loginDetails['password']]);
+		if($this->isLoggedIn()) {
+			$this->prepareUserLogin($firstTimeLogin);
+			return true;
+		} else {
+			$message = \OC::$server->getL10N('lib')->t('Login canceled by app');
+			throw new LoginException($message);
+		}
 	}
 
 	/**
@@ -498,25 +534,7 @@ class Session implements IUserSession, Emitter {
 			return false;
 		}
 
-		if ($user->isEnabled()) {
-			$this->setUser($user);
-			$this->setLoginName($uid);
-			$this->setToken(null);
-			$firstTimeLogin = $user->updateLastLoginTimestamp();
-			$this->manager->emit('\OC\User', 'postLogin', [$user, $password]);
-			if ($this->isLoggedIn()) {
-				$this->prepareUserLogin($firstTimeLogin);
-				return true;
-			} else {
-				// injecting l10n does not work - there is a circular dependency between session and \OCP\L10N\IFactory
-				$message = \OC::$server->getL10N('lib')->t('Login canceled by app');
-				throw new LoginException($message);
-			}
-		} else {
-			// injecting l10n does not work - there is a circular dependency between session and \OCP\L10N\IFactory
-			$message = \OC::$server->getL10N('lib')->t('User disabled');
-			throw new LoginException($message);
-		}
+		return $this->completeLogin($user, ['loginName' => $uid, 'password' => $password]);
 	}
 
 	/**
@@ -547,29 +565,8 @@ class Session implements IUserSession, Emitter {
 			// user does not exist
 			return false;
 		}
-		if (!$user->isEnabled()) {
-			// disabled users can not log in
-			// injecting l10n does not work - there is a circular dependency between session and \OCP\L10N\IFactory
-			$message = \OC::$server->getL10N('lib')->t('User disabled');
-			throw new LoginException($message);
-		}
 
-		//login
-		$this->setUser($user);
-		$this->setLoginName($dbToken->getLoginName());
-		$this->setToken($dbToken->getId());
-		$this->lockdownManager->setToken($dbToken);
-		$this->manager->emit('\OC\User', 'postLogin', array($user, $password));
-
-		if ($this->isLoggedIn()) {
-			$this->prepareUserLogin(false); // token login cant be the first
-		} else {
-			// injecting l10n does not work - there is a circular dependency between session and \OCP\L10N\IFactory
-			$message = \OC::$server->getL10N('lib')->t('Login canceled by app');
-			throw new LoginException($message);
-		}
-
-		return true;
+		return $this->completeLogin($user, ['loginName' => $uid, 'password' => $password, 'token' => $dbToken]);
 	}
 
 	/**

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -328,10 +328,11 @@ class Session implements IUserSession, Emitter {
 	/**
 	 * @param IUser $user
 	 * @param array $loginDetails
+	 * @param bool $regenerateSessionId
 	 * @return bool
 	 * @throws LoginException
 	 */
-	public function completeLogin(IUser $user, array $loginDetails) {
+	public function completeLogin(IUser $user, array $loginDetails, $regenerateSessionId = true) {
 		if (!$user->isEnabled()) {
 			// disabled users can not log in
 			// injecting l10n does not work - there is a circular dependency between session and \OCP\L10N\IFactory
@@ -339,7 +340,9 @@ class Session implements IUserSession, Emitter {
 			throw new LoginException($message);
 		}
 
-		$this->session->regenerateId();
+		if($regenerateSessionId) {
+			$this->session->regenerateId();
+		}
 
 		$this->setUser($user);
 		$this->setLoginName($loginDetails['loginName']);
@@ -536,7 +539,7 @@ class Session implements IUserSession, Emitter {
 			return false;
 		}
 
-		return $this->completeLogin($user, ['loginName' => $uid, 'password' => $password]);
+		return $this->completeLogin($user, ['loginName' => $uid, 'password' => $password], false);
 	}
 
 	/**
@@ -570,7 +573,7 @@ class Session implements IUserSession, Emitter {
 			return false;
 		}
 
-		return $this->completeLogin($user, ['loginName' => $uid, 'password' => $password, 'token' => $dbToken]);
+		return $this->completeLogin($user, ['loginName' => $uid, 'password' => $password, 'token' => $dbToken], false);
 	}
 
 	/**

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -329,7 +329,7 @@ class Session implements IUserSession, Emitter {
 	 * @param IUser $user
 	 * @param array $loginDetails
 	 * @param bool $regenerateSessionId
-	 * @return bool
+	 * @return true returns true if login successful or an exception otherwise
 	 * @throws LoginException
 	 */
 	public function completeLogin(IUser $user, array $loginDetails, $regenerateSessionId = true) {

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -349,7 +349,7 @@ class Session implements IUserSession, Emitter {
 
 		if(isset($loginDetails['token']) && $loginDetails['token'] instanceof IToken) {
 			$this->setToken($loginDetails['token']->getId());
-			\OC::$server->getLockdownManager()->setToken($loginDetails['token']);
+			$this->lockdownManager->setToken($loginDetails['token']);
 			$firstTimeLogin = false;
 		} else {
 			$this->setToken(null);

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -334,6 +334,7 @@ class LoginControllerTest extends TestCase {
 		$user->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('uid'));
+		$loginName = 'loginli';
 		$user->expects($this->any())
 			->method('getLastLogin')
 			->willReturn(123456);
@@ -362,10 +363,10 @@ class LoginControllerTest extends TestCase {
 			->will($this->returnValue($user));
 		$this->userSession->expects($this->once())
 			->method('login')
-			->with($user, $password);
+			->with($loginName, $password);
 		$this->userSession->expects($this->once())
 			->method('createSessionToken')
-			->with($this->request, $user->getUID(), $user, $password, false);
+			->with($this->request, $user->getUID(), $loginName, $password, false);
 		$this->twoFactorManager->expects($this->once())
 			->method('isTwoFactorAuthenticated')
 			->with($user)
@@ -387,7 +388,7 @@ class LoginControllerTest extends TestCase {
 			);
 
 		$expected = new \OCP\AppFramework\Http\RedirectResponse($indexPageUrl);
-		$this->assertEquals($expected, $this->loginController->tryLogin($user, $password, null, false, 'Europe/Berlin', '1'));
+		$this->assertEquals($expected, $this->loginController->tryLogin($loginName, $password, null, false, 'Europe/Berlin', '1'));
 	}
 
 	public function testLoginWithValidCredentialsAndRememberMe() {
@@ -396,6 +397,7 @@ class LoginControllerTest extends TestCase {
 		$user->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('uid'));
+		$loginName  = 'loginli';
 		$password = 'secret';
 		$indexPageUrl = \OC_Util::getDefaultPageUrl();
 
@@ -421,10 +423,10 @@ class LoginControllerTest extends TestCase {
 			->will($this->returnValue($user));
 		$this->userSession->expects($this->once())
 			->method('login')
-			->with($user, $password);
+			->with($loginName, $password);
 		$this->userSession->expects($this->once())
 			->method('createSessionToken')
-			->with($this->request, $user->getUID(), $user, $password, true);
+			->with($this->request, $user->getUID(), $loginName, $password, true);
 		$this->twoFactorManager->expects($this->once())
 			->method('isTwoFactorAuthenticated')
 			->with($user)
@@ -437,7 +439,7 @@ class LoginControllerTest extends TestCase {
 			->with($user);
 
 		$expected = new \OCP\AppFramework\Http\RedirectResponse($indexPageUrl);
-		$this->assertEquals($expected, $this->loginController->tryLogin($user, $password, null, true));
+		$this->assertEquals($expected, $this->loginController->tryLogin($loginName, $password, null, true));
 	}
 
 	public function testLoginWithoutPassedCsrfCheckAndNotLoggedIn() {

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -362,8 +362,8 @@ class LoginControllerTest extends TestCase {
 			->method('checkPassword')
 			->will($this->returnValue($user));
 		$this->userSession->expects($this->once())
-			->method('login')
-			->with($loginName, $password);
+			->method('completeLogin')
+			->with($user, ['loginName' => $loginName, 'password' => $password]);
 		$this->userSession->expects($this->once())
 			->method('createSessionToken')
 			->with($this->request, $user->getUID(), $loginName, $password, false);
@@ -422,8 +422,8 @@ class LoginControllerTest extends TestCase {
 			->method('checkPassword')
 			->will($this->returnValue($user));
 		$this->userSession->expects($this->once())
-			->method('login')
-			->with($loginName, $password);
+			->method('completeLogin')
+			->with($user, ['loginName' => $loginName, 'password' => $password]);
 		$this->userSession->expects($this->once())
 			->method('createSessionToken')
 			->with($this->request, $user->getUID(), $loginName, $password, true);
@@ -606,8 +606,8 @@ class LoginControllerTest extends TestCase {
 			->method('checkPassword')
 			->will($this->returnValue($user));
 		$this->userSession->expects($this->once())
-			->method('login')
-			->with('john@doe.com', $password);
+			->method('completeLogin')
+			->with($user, ['loginName' => 'john@doe.com', 'password' => $password]);
 		$this->userSession->expects($this->once())
 			->method('createSessionToken')
 			->with($this->request, $user->getUID(), 'john@doe.com', $password, false);
@@ -673,8 +673,8 @@ class LoginControllerTest extends TestCase {
 			->method('checkPassword')
 			->will($this->returnValue($user));
 		$this->userSession->expects($this->once())
-			->method('login')
-			->with('john@doe.com', $password);
+			->method('completeLogin')
+			->with($user, ['loginName' => 'john@doe.com', 'password' => $password]);
 		$this->userSession->expects($this->once())
 			->method('createSessionToken')
 			->with($this->request, $user->getUID(), 'john@doe.com', $password, false);


### PR DESCRIPTION
Due to PHP 5.* LoginController cannot type hint against primitives. So the tests provided an IUser instance instead of a string and it went unnoticed.

Also, due to the Brutforce protection login was executed twice – once for testing and once within the session. This is unnecessary, especially when connected to external user backend. Plus, some code duplication was in place. This was now consolidated.

@LukasReschke @ChristophWurst @MorrisJobke 