### PR TITLE
Add avatar info to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,8 @@ NC 11 (????-??-??)
 * Core preview route changed:
   * Route for the urlgenerator changed from 'core_ajax_preview' to 'core.Preview.getPreview'
   * $urlGenerator->linkToRoute('core_ajax_preview', ...) => $urlGenerator->linkToRoute('core.Preview.getPreview', ...)
+* Avatars are cached
+* Avatars are moved to AppData
+  * For existing avatars this happens automatically in a background job which means that on upgrade you might
+    not see your avatar right away. However after the job has run it should show up again automatically.
+


### PR DESCRIPTION
Just so it is there.

For #2399

@jospoortvliet can you make sure that in the release notes it is reflected that avatars are moved in a backgroundjob. So it might vanish on upgrade but should return soon.