### PR TITLE
Prevent endless loop in \OC\Files\View::createParentDirectories

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -2104,14 +2104,19 @@ class View {
 	 * @return bool
 	 */
 	private function createParentDirectories($filePath) {
-		$parentDirectory = dirname($filePath);
-		while(!$this->file_exists($parentDirectory)) {
-			$result = $this->createParentDirectories($parentDirectory);
-			if($result === false) {
+		$directoryParts = explode('/', $filePath);
+		$directoryParts = array_filter($directoryParts);
+		foreach($directoryParts as $key => $part) {
+			$currentPathElements = array_slice($directoryParts, 0, $key);
+			$currentPath = '/' . implode('/', $currentPathElements);
+			if($this->is_file($currentPath)) {
 				return false;
 			}
+			if(!$this->file_exists($currentPath)) {
+				$this->mkdir($currentPath);
+			}
 		}
-		$this->mkdir($filePath);
+
 		return true;
 	}
 }


### PR DESCRIPTION
…ories

\OC\Files\View::createParentDirectories was previously prone to an endless loop. If a path such as /foo/existingfile.txt/bar/foo was passed and existingfile.txt existed in foo the loop was never left and running until the PHP process timed out.

This commit changes the logic to a foreach loop over an array and additionally additional error handling using is_file.

cc @nickvergessen @rullzer @icewind1991 