### PR TITLE
[stable9] Catch status code 400

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1489,7 +1489,7 @@
 				return false;
 			}
 
-			if (status === 404 || status === 405) {
+			if (status === 400 || status === 404 || status === 405) {
 				// go back home
 				this.changeDirectory('/');
 				return false;

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1357,6 +1357,11 @@ describe('OCA.Files.FileList tests', function() {
 			deferredList.reject(404);
 			expect(fileList.getCurrentDirectory()).toEqual('/');
 		});
+		it('switches to root dir when current directory returns 400', function() {
+			fileList.changeDirectory('/unexist');
+			deferredList.reject(400);
+			expect(fileList.getCurrentDirectory()).toEqual('/');
+		});
 		it('switches to root dir when current directory returns 405', function() {
 			fileList.changeDirectory('/unexist');
 			deferredList.reject(405);


### PR DESCRIPTION
In case the server returns a statuscode 400 we should also gracefully return to the home directory.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>