### PR TITLE
only reload on errors when logged in

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -776,7 +776,7 @@ var OCP = {},
 			return;
 		}
 
-		if (_.contains([302, 303, 307, 401], xhr.status)) {
+		if (_.contains([302, 303, 307, 401], xhr.status) && OC.currentUser) {
 			// sometimes "beforeunload" happens later, so need to defer the reload a bit
 			setTimeout(function() {
 				if (!self._userIsNavigatingAway && !self._reloadCalled) {

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -969,8 +969,11 @@ describe('Core base tests', function() {
 		var reloadStub, ajaxErrorStub, clock;
 		var notificationStub;
 		var waitTimeMs = 6000;
+		var oldCurrentUser;
 
 		beforeEach(function() {
+			oldCurrentUser = OC.currentUser;
+			OC.currentUser = 'dummy';
 			clock = sinon.useFakeTimers();
 			reloadStub = sinon.stub(OC, 'reload');
 			notificationStub = sinon.stub(OC.Notification, 'show');
@@ -980,6 +983,7 @@ describe('Core base tests', function() {
 			window.initCore();
 		});
 		afterEach(function() {
+			OC.currentUser = oldCurrentUser;
 			reloadStub.restore();
 			notificationStub.restore();
 			clock.restore();


### PR DESCRIPTION
To test:

- have the gallery app enabled
- be logged out
- goto `http://example.com/login?redirect_url=/owncloud/apps/files`
- wait 10+ sec

The gallery app will see `apps/files` in the url, think it's in the files app and serve it's script.
The gallery scripts will try to load the config trough an ajax call, the ajax call will fail since the user is logged out, the 401 error will be detected and a reload will be scheduled.
This keeps repeating itself over and over again.

Note that this could be fixed in the gallery app (although not trivially since it needs to load it scripts on non logged in public shares) but preventing apps from ever triggering this case seems useful.

This bug is brought to you by running master in production and having parents who can't type in their passwords within 5 seconds.