### PR TITLE
Remove white background from loading icon

### DIFF
--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -104,7 +104,6 @@
 .shareTabView .icon-loading-small {
 	display: inline-block;
 	z-index: 1;
-	background-color: white;
 	padding: 2px 0;
 }
 
@@ -122,6 +121,5 @@
 }
 
 .shareTabView .icon {
-	display: inline-block;
 	background-size: 16px 16px;
 }

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -134,6 +134,8 @@
 			var $loading = this.$el.find('.shareWithLoading');
 			$loading.removeClass('hidden');
 			$loading.addClass('inlineblock');
+			var $remoteShareInfo = this.$el.find('.shareWithRemoteInfo');
+			$remoteShareInfo.addClass('hidden');
 			$.get(
 				OC.linkToOCS('apps/files_sharing/api/v1') + 'sharees',
 				{
@@ -145,6 +147,7 @@
 				function (result) {
 					$loading.addClass('hidden');
 					$loading.removeClass('inlineblock');
+					$remoteShareInfo.removeClass('hidden');
 					if (result.ocs.meta.statuscode === 100) {
 						var users   = result.ocs.data.exact.users.concat(result.ocs.data.users);
 						var groups  = result.ocs.data.exact.groups.concat(result.ocs.data.groups);
@@ -256,6 +259,7 @@
 			).fail(function() {
 				$loading.addClass('hidden');
 				$loading.removeClass('inlineblock');
+				$remoteShareInfo.removeClass('hidden');
 				OC.Notification.show(t('core', 'An error occurred. Please try again'));
 				window.setTimeout(OC.Notification.hide, 5000);
 			});
@@ -298,18 +302,22 @@
 			var $loading = this.$el.find('.shareWithLoading');
 			$loading.removeClass('hidden')
 				.addClass('inlineblock');
+			var $remoteShareInfo = this.$el.find('.shareWithRemoteInfo');
+			$remoteShareInfo.addClass('hidden');
 
 			this.model.addShare(s.item.value, {success: function() {
 				$(e.target).val('')
 					.attr('disabled', false);
 				$loading.addClass('hidden')
 					.removeClass('inlineblock');
+				$remoteShareInfo.removeClass('hidden');
 			}, error: function(obj, msg) {
 				OC.Notification.showTemporary(msg);
 				$(e.target).attr('disabled', false)
 					.autocomplete('search', $(e.target).val());
 				$loading.addClass('hidden')
 					.removeClass('inlineblock');
+				$remoteShareInfo.removeClass('hidden');
 			}});
 		},
 


### PR DESCRIPTION
* allows to use the loading icon on non-white background (disabled input fields for example)
* fixes #2466

cc @nextcloud/designers @enoch85 @rullzer @skjnldsv @juliushaertl @nickvergessen @schiessle 

I tested this in Firefox, Safari, Chrome, Edge and IE11