### PR TITLE
fix width of filename in sidebar to accommodate local link

### DIFF
--- a/apps/files/css/detailsView.css
+++ b/apps/files/css/detailsView.css
@@ -97,7 +97,7 @@
 }
 
 #app-sidebar .fileName h3 {
-	max-width: 300px;
+	max-width: 85%;
 	display: inline-block;
 	padding: 5px 0;
 	margin: -5px 0;

--- a/apps/files/css/detailsView.css
+++ b/apps/files/css/detailsView.css
@@ -27,11 +27,6 @@
 	width: 90%;
 }
 
-#app-sidebar .file-details-container {
-	display: inline-block;
-	float: left;
-}
-
 #app-sidebar .thumbnailContainer.large {
 	margin-left: -15px;
 	margin-right: -35px; /* 15 + 20 for the close button */
@@ -97,7 +92,7 @@
 }
 
 #app-sidebar .fileName h3 {
-	max-width: 85%;
+	width: calc(100% - 36px); /* 36px is the with of the copy link icon */
 	display: inline-block;
 	padding: 5px 0;
 	margin: -5px 0;


### PR DESCRIPTION
Before / after:
![capture du 2016-12-02 14-48-14](https://cloud.githubusercontent.com/assets/925062/20836208/9a3aea38-b89e-11e6-943e-38e3bad64841.png)
![capture du 2016-12-02 14-49-42](https://cloud.githubusercontent.com/assets/925062/20836206/9a1bdcd8-b89e-11e6-9f3d-c14175c5f848.png)
Please review @nextcloud/designers 