### PR TITLE
Fix share tab view

### DIFF
--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -109,12 +109,14 @@
 .shareTabView .icon-loading-small {
 	display: inline-block;
 	z-index: 1;
-	padding: 2px 0;
+	margin-right: 4px;
+	vertical-align: text-top;
 }
 
-.shareTabView .shareWithList .icon-loading-small,
-.shareTabView .linkShareView .icon-loading-small {
-	position: absolute;
+.shareTabView .shareWithList .icon-loading-small:not(.hidden) + span,
+.shareTabView .linkShareView .icon-loading-small:not(.hidden) + input + label:before {
+	/* Hide if loader is visible */
+	display: none !important;
 }
 
 .linkShareView {

--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -84,6 +84,10 @@
 	display: inline-block;
 }
 
+#shareWithList .sharingOptionsGroup .popovermenu:after {
+	right: 3px;
+}
+
 #shareWithList label input[type=checkbox] {
 	margin-left: 0;
 	position: relative;

--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -71,7 +71,7 @@
 }
 
 #shareWithList .unshare {
-	padding: 4px;
+	padding: 1px 6px;
 	vertical-align: text-bottom;
 }
 #shareWithList .unshare .icon {
@@ -81,6 +81,7 @@
 #shareWithList .unshare .icon-delete {
 	padding-right: 4px;
 	background-position-x: 0;
+	display: inline-block;
 }
 
 #shareWithList label input[type=checkbox] {

--- a/core/css/share.css
+++ b/core/css/share.css
@@ -132,7 +132,6 @@ a.unshare {
 	display:inline-block;
 	opacity:.5;
 	padding: 10px;
-	margin-top: -5px;
 }
 
 #link {


### PR DESCRIPTION
- Share icon position (fix #2477)
- Fix loading icon position (best with #2482)
- Fix loading icon visibility with checkbox (link share) and delete icon (in dropdown)

![capture d ecran_2016-12-02_18-06-06](https://cloud.githubusercontent.com/assets/14975046/20843025/03f50588-b8ba-11e6-99a2-bd9999dd7caa.png)


@schiessle @jancborchardt @MorrisJobke @nextcloud/designers 