### PR TITLE
Fixing issues with themed icons

### DIFF
--- a/apps/theming/lib/IconBuilder.php
+++ b/apps/theming/lib/IconBuilder.php
@@ -103,7 +103,7 @@ class IconBuilder {
 		// generate background image with rounded corners
 		$background = '<?xml version="1.0" encoding="UTF-8"?>' .
 			'<svg xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:cc="http://creativecommons.org/ns#" width="512" height="512" xmlns:xlink="http://www.w3.org/1999/xlink">' .
-			'<rect x="0" y="0" rx="75" ry="75" width="512" height="512" style="fill:' . $color . ';" />' .
+			'<rect x="0" y="0" rx="100" ry="100" width="512" height="512" style="fill:' . $color . ';" />' .
 			'</svg>';
 		// resize svg magic as this seems broken in Imagemagick
 		if($mime === "image/svg+xml" || substr($appIconContent, 0, 4) === "<svg") {

--- a/apps/theming/lib/IconBuilder.php
+++ b/apps/theming/lib/IconBuilder.php
@@ -52,11 +52,10 @@ class IconBuilder {
 	 * @return string|false image blob
 	 */
 	public function getFavicon($app) {
-		$icon = $this->renderAppIcon($app);
+		$icon = $this->renderAppIcon($app, 32);
 		if($icon === false) {
 			return false;
 		}
-		$icon->resizeImage(32, 32, Imagick::FILTER_LANCZOS, 1);
 		$icon->setImageFormat("png24");
 		$data = $icon->getImageBlob();
 		$icon->destroy();
@@ -68,7 +67,7 @@ class IconBuilder {
 	 * @return string|false image blob
 	 */
 	public function getTouchIcon($app) {
-		$icon = $this->renderAppIcon($app);
+		$icon = $this->renderAppIcon($app, 512);
 		if($icon === false) {
 			return false;
 		}
@@ -83,9 +82,10 @@ class IconBuilder {
 	 * fallback to logo
 	 *
 	 * @param $app string app name
+	 * @param $size int size of the icon in px
 	 * @return Imagick|false
 	 */
-	public function renderAppIcon($app) {
+	public function renderAppIcon($app, $size) {
 		try {
 			$appIcon = $this->util->getAppIcon($app);
 			$appIconContent = file_get_contents($appIcon);
@@ -157,7 +157,8 @@ class IconBuilder {
 		$finalIconFile->setImageVirtualPixelMethod(Imagick::VIRTUALPIXELMETHOD_TRANSPARENT);
 		$finalIconFile->setImageArtifact('compose:args', "1,0,-0.5,0.5");
 		$finalIconFile->compositeImage($appIconFile, Imagick::COMPOSITE_ATOP, $offset_w, $offset_h);
-		$finalIconFile->resizeImage(512, 512, Imagick::FILTER_LANCZOS, 1);
+		$finalIconFile->setImageFormat('png24');
+		$finalIconFile->resizeImage($size, $size, Imagick::INTERPOLATE_BICUBIC, 1, false);
 
 		$appIconFile->destroy();
 		return $finalIconFile;

--- a/apps/theming/lib/IconBuilder.php
+++ b/apps/theming/lib/IconBuilder.php
@@ -153,6 +153,7 @@ class IconBuilder {
 		$appIconFile->setImageFormat("png24");
 
 		$finalIconFile = new Imagick();
+		$finalIconFile->setBackgroundColor(new ImagickPixel('transparent'));
 		$finalIconFile->readImageBlob($background);
 		$finalIconFile->setImageVirtualPixelMethod(Imagick::VIRTUALPIXELMETHOD_TRANSPARENT);
 		$finalIconFile->setImageArtifact('compose:args', "1,0,-0.5,0.5");

--- a/apps/theming/tests/IconBuilderTest.php
+++ b/apps/theming/tests/IconBuilderTest.php
@@ -91,7 +91,7 @@ class IconBuilderTest extends TestCase {
 			->willReturn($color);
 
 		$expectedIcon = new \Imagick(realpath(dirname(__FILE__)). "/data/" . $file);
-		$icon = $this->iconBuilder->renderAppIcon($app);
+		$icon = $this->iconBuilder->renderAppIcon($app, 512);
 
 		$this->assertEquals(true, $icon->valid());
 		$this->assertEquals(512, $icon->getImageWidth());


### PR DESCRIPTION
This PR fixes some minor issues with the themed icons:

- Increase border radius to make it visible in the favicons
Before/After:
![2016-12-04-131515_202x28_scrot](https://cloud.githubusercontent.com/assets/3404133/20866093/fbe246e2-ba23-11e6-8db7-bfa17a9d2fe1.png)

- Fix transparency when using homescreen shortcuts on android
![screenshot_20161204-131414](https://cloud.githubusercontent.com/assets/3404133/20866098/36c5cd06-ba24-11e6-9d36-66b9bf7df87f.png)


please review @nextcloud/designers @nextcloud/theming 