### PR TITLE
improve systemtags selector styling

### DIFF
--- a/core/css/systemtags.css
+++ b/core/css/systemtags.css
@@ -10,6 +10,9 @@
 
 .systemtags-select2-dropdown .select2-result-label .checkmark {
 	visibility: hidden;
+	margin-left: -5px;
+	margin-right: 5px;
+	padding: 4px;
 }
 
 .systemtags-select2-dropdown .select2-result-label .new-item .systemtags-actions {
@@ -42,6 +45,22 @@
 	width: 100%;
 }
 
+#select2-drop.systemtags-select2-dropdown .select2-results li.select2-result {
+	padding: 5px;
+}
+
+.systemtags-select2-dropdown span {
+	line-height: 25px;
+}
+
+.systemtags-select2-dropdown .systemtags-item {
+	display: inline-block;
+	height: 25px;
+}
+
+.systemtags-select2-dropdown .select2-result-label {
+	height: 25px;
+}
 
 .systemtags-select2-container .select2-choices .select2-search-choice.select2-locked .label {
 	opacity: 0.5;


### PR DESCRIPTION
Reduced wasted vertical space and align checkbox properly

Before:

![](https://i.imgur.com/taKTtpE.png)

After:

![](https://i.imgur.com/JPW5tVA.png)