### PR TITLE
Check for nextcloud version as well

### DIFF
--- a/core/Command/App/CheckCode.php
+++ b/core/Command/App/CheckCode.php
@@ -135,7 +135,7 @@ class CheckCode extends Command implements CompletionAwareInterface  {
 			});
 
 			$infoChecker->listen('InfoChecker', 'missingRequirement', function($minMax) use ($output) {
-				$output->writeln("<comment>ownCloud $minMax version requirement missing (will be an error in ownCloud 11 and later)</comment>");
+				$output->writeln("<comment>Nextcloud $minMax version requirement missing (will be an error in Nextcloud 12 and later)</comment>");
 			});
 
 			$infoChecker->listen('InfoChecker', 'duplicateRequirement', function($minMax) use ($output) {

--- a/lib/private/App/CodeChecker/InfoChecker.php
+++ b/lib/private/App/CodeChecker/InfoChecker.php
@@ -86,7 +86,10 @@ class InfoChecker extends BasicEmitter {
 				'type' => 'duplicateRequirement',
 				'field' => 'min',
 			];
-		} else if (!isset($info['dependencies']['owncloud']['@attributes']['min-version'])) {
+		} else if (
+			!isset($info['dependencies']['owncloud']['@attributes']['min-version']) &&
+			!isset($info['dependencies']['nextcloud']['@attributes']['min-version'])
+		) {
 			$this->emit('InfoChecker', 'missingRequirement', ['min']);
 		}
 
@@ -96,7 +99,10 @@ class InfoChecker extends BasicEmitter {
 				'type' => 'duplicateRequirement',
 				'field' => 'max',
 			];
-		} else if (!isset($info['dependencies']['owncloud']['@attributes']['max-version'])) {
+		} else if (
+			!isset($info['dependencies']['owncloud']['@attributes']['max-version']) &&
+			!isset($info['dependencies']['nextcloud']['@attributes']['max-version'])
+		) {
 			$this->emit('InfoChecker', 'missingRequirement', ['max']);
 		}
 


### PR DESCRIPTION
The code checker didn't consider the "nextcloud" version before, resulting in fails such as https://travis-ci.org/nextcloud/richdocuments/jobs/181470760#L415-L416

cc @rullzer @MorrisJobke  