### PR TITLE
[stable10] Show info in updater if running PHP < 5.6

### DIFF
--- a/apps/updatenotification/lib/Controller/AdminController.php
+++ b/apps/updatenotification/lib/Controller/AdminController.php
@@ -114,7 +114,7 @@ class AdminController extends Controller implements ISettings {
 			'newVersionString' => (empty($updateState['updateVersion'])) ? '' : $updateState['updateVersion'],
 			'downloadLink' => (empty($updateState['downloadLink'])) ? '' : $updateState['downloadLink'],
 			'updaterEnabled' => (empty($updateState['updaterEnabled'])) ? false : $updateState['updaterEnabled'],
-
+			'outdatedPHP' => version_compare(PHP_VERSION, '5.6') === -1,
 			'notify_groups' => implode('|', $notifyGroups),
 		];
 

--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -14,6 +14,13 @@
 	$currentChannel = $_['currentChannel'];
 ?>
 <form id="oca_updatenotification_section" class="followupsection">
+
+	<?php if($_['outdatedPHP'] === true) { ?>
+		<p class="warning" style="margin-bottom: 15px;">
+			<?php p($l->t('You are running PHP %s. To allow you to upgrade to Nextcloud 11 and higher you need to run at least PHP 5.6. Once you upgraded your PHP version you will be able to receive update notifications for these newer versions.', [PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION])); ?>
+		</p>
+	<?php } ?>
+
 	<?php if($isNewVersionAvailable === true) { ?>
 		<strong><?php p($l->t('A new version is available: %s', [$newVersionString])); ?></strong>
 		<?php if ($_['updaterEnabled']) { ?>

--- a/apps/updatenotification/tests/Controller/AdminControllerTest.php
+++ b/apps/updatenotification/tests/Controller/AdminControllerTest.php
@@ -125,6 +125,7 @@ class AdminControllerTest extends TestCase {
 			'newVersionString' => '8.1.2',
 			'downloadLink' => 'https://downloads.nextcloud.org/server',
 			'updaterEnabled' => true,
+			'outdatedPHP' => version_compare(PHP_VERSION, '5.6') === -1,
 			'notify_groups' => 'admin',
 		];
 
@@ -171,6 +172,7 @@ class AdminControllerTest extends TestCase {
 			'newVersionString' => '',
 			'downloadLink' => '',
 			'updaterEnabled' => 0,
+			'outdatedPHP' => version_compare(PHP_VERSION, '5.6') === -1,
 			'notify_groups' => 'admin',
 		];
 


### PR DESCRIPTION
* Nextcloud 11 needs PHP 5.6+

cc @nickvergessen @LukasReschke @rullzer @jancborchardt 

This then looks like this

<img width="610" alt="bildschirmfoto 2016-12-06 um 00 08 06" src="https://cloud.githubusercontent.com/assets/245432/20906393/1b169ea8-bb48-11e6-9a7a-9b5535ea1fe2.png">

