### PR TITLE
[stable10] Document updater channel & check for correct PHP version in updater

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -522,6 +522,17 @@ $CONFIG = array(
 'updater.server.url' => 'https://updates.nextcloud.com/updater_server/',
 
 /**
+ * The channel that Nextcloud should use to look for updates
+ *
+ * Supported values:
+ *   - ``daily``
+ *   - ``beta`
+ *   - ``stable``
+ *   - ``production``
+ */
+'updater.release.channel' => 'stable',
+
+/**
  * Is Nextcloud connected to the Internet or running in a closed network?
  */
 'has_internet_connection' => true,

--- a/lib/private/Updater/VersionCheck.php
+++ b/lib/private/Updater/VersionCheck.php
@@ -73,6 +73,9 @@ class VersionCheck {
 		$version['updatechannel'] = \OC_Util::getChannel();
 		$version['edition'] = \OC_Util::getEditionString();
 		$version['build'] = \OC_Util::getBuild();
+		$version['php_major'] = PHP_MAJOR_VERSION;
+		$version['php_minor'] = PHP_MINOR_VERSION;
+		$version['php_release'] = PHP_RELEASE_VERSION;
 		$versionString = implode('x', $version);
 
 		//fetch xml data from updater

--- a/tests/lib/Updater/VersionCheckTest.php
+++ b/tests/lib/Updater/VersionCheckTest.php
@@ -50,7 +50,7 @@ class VersionCheckTest extends \Test\TestCase {
 	 * @return string
 	 */
 	private function buildUpdateUrl($baseUrl) {
-		return $baseUrl . '?version='.implode('x', Util::getVersion()).'xinstalledatxlastupdatedatx'.\OC_Util::getChannel().'x'.\OC_Util::getEditionString().'x';
+		return $baseUrl . '?version='.implode('x', Util::getVersion()).'xinstalledatxlastupdatedatx'.\OC_Util::getChannel().'x'.\OC_Util::getEditionString().'xx'.PHP_MAJOR_VERSION.'x'.PHP_MINOR_VERSION.'x'.PHP_RELEASE_VERSION;
 	}
 
 	public function testCheckInCache() {


### PR DESCRIPTION
* see https://github.com/nextcloud/updater/issues/53
* backport of #2521 


@karlitschek This backport would be nice. Otherwise there is no easy way to see if the instance that requests an update information runs a supported version.

cc @LukasReschke @rullzer 