### PR TITLE
Allow to reuse the same name when installing a new instance on postgres

### DIFF
--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -150,14 +150,16 @@ class PostgreSQL extends AbstractDatabase {
 	}
 
 	private function createDBUser(IDBConnection $connection) {
+		$dbUser = $this->dbUser;
 		try {
-			if ($this->userExists($connection)) {
-				// change the password
-				$query = $connection->prepare("ALTER ROLE " . addslashes($this->dbUser) . " WITH CREATEDB PASSWORD '" . addslashes($this->dbPassword) . "'");
-			} else {
-				// create the user
-				$query = $connection->prepare("CREATE USER " . addslashes($this->dbUser) . " CREATEDB PASSWORD '" . addslashes($this->dbPassword) . "'");
-			}
+			$i = 1;
+			while ($this->userExists($connection)) {
+				$i++;
+				$this->dbUser = $dbUser . $i;
+			};
+
+			// create the user
+			$query = $connection->prepare("CREATE USER " . addslashes($this->dbUser) . " CREATEDB PASSWORD '" . addslashes($this->dbPassword) . "'");
 			$query->execute();
 		} catch (DatabaseException $e) {
 			$this->logger->error('Error while trying to create database user');


### PR DESCRIPTION
@icewind1991 @MorrisJobke @pmattern @andreas-p

### Steps
1. Install an instance with user name admin
2. Install a second instance with user name admin
3. Try to access instance 1 again

### After
Instead of changing the password of oc_admin, it now generates oc_admin2, oc_admin3, ... just like mysql always did.

On 10 and 9 it's even worse and fails on 2. with a SQL syntax error leaking the password, so I'd like to backport this.