### PR TITLE
Fix popover width

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -549,14 +549,6 @@ html.ie8 #fileList tr.selected td.filename>.selectCheckBox {
 	border-top-right-radius: 3px;
 	min-width: 100px;
 }
-.bubble:after,
-#app-navigation .app-navigation-entry-menu:after {
-	right: 12px;
-}
-.bubble:before,
-#app-navigation .app-navigation-entry-menu:before {
-	right: 6px;
-}
 
 /* force show the loading icon, not only on hover */
 #fileList .icon-loading-small {

--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -293,6 +293,7 @@
 	border-radius: 3px;
 	border-top-right-radius: 0;
 	z-index: 110;
+	margin: 5px;
 	margin-top: -5px;
 	right: 0;
 	-webkit-filter: drop-shadow(0 0 5px rgba(150, 150, 150, 0.75));
@@ -316,7 +317,7 @@
 .bubble:after,
 #app-navigation .app-navigation-entry-menu:after {
 	bottom: 100%;
-	right: 0; /* change this to adjust the arrow position */
+	right: 6px; /* change this to adjust the arrow position */
 	border: solid transparent;
 	content: " ";
 	height: 0;
@@ -329,7 +330,6 @@
 	border-color: rgba(238, 238, 238, 0);
 	border-bottom-color: #fff;
 	border-width: 10px;
-	margin-left: -10px;
 }
 .bubble .action {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)" !important;

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -110,6 +110,7 @@ input#openid, input#webdav { width:20em; }
 }
 .federationScopeMenu {
 	top: 44px;
+	margin: -5px 0px 0;
 }
 .federationScopeMenu.bubble::after {
 	right: 50%;


### PR DESCRIPTION
Fix #2544

For référence: the popover menu should be inside the div containing the dots icon.
The required right distance to the border (or padding, whatever you want to use) of the three-dot icon should be 14px (5 for menu margin and 6 for arrow position)
![capture d ecran_2016-12-07_10-50-09](https://cloud.githubusercontent.com/assets/14975046/20962755/f102bff6-bc6a-11e6-9082-b8b2fef6032e.png)


Is there a place in the dev docs where I can put that?

@juliushaertl 