### PR TITLE
Fix order of parameters when getting notified of smb renames

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -457,9 +457,11 @@ class SMB extends Common implements INotifyStorage {
 			if (is_null($type)) {
 				return true;
 			}
-			if ($type === INotifyStorage::NOTIFY_RENAMED && !is_null($oldRenamePath)) {
-				$result = $callback($type, $path, $oldRenamePath);
-				$oldRenamePath = null;
+			if ($type === INotifyStorage::NOTIFY_RENAMED) {
+				if (!is_null($oldRenamePath)) {
+					$result = $callback($type, $oldRenamePath, $path);
+					$oldRenamePath = null;
+				}
 			} else {
 				$result = $callback($type, $path);
 			}


### PR DESCRIPTION
Fixes #2547

Note that the order doesn't affect anything besides the messages verbose log messages from the command