### PR TITLE
Check if the theming app is loaded

### DIFF
--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -158,7 +158,7 @@ class URLGenerator implements IURLGenerator {
 
 		// Check if the app is in the app folder
 		$path = '';
-		$themingEnabled = $this->config->getSystemValue('installed', false) && \OCP\App::isEnabled('theming');
+		$themingEnabled = $this->config->getSystemValue('installed', false) && \OCP\App::isEnabled('theming') && \OC_App::isAppLoaded('theming');
 		if($themingEnabled && $image === "favicon.ico" && \OC::$server->getThemingDefaults()->shouldReplaceIcons()) {
 			$cacheBusterValue = $this->config->getAppValue('theming', 'cachebuster', '0');
 			if($app==="") { $app = "core"; }


### PR DESCRIPTION
Fix for https://github.com/nextcloud/server/issues/2558

When calling /core/templates/403.php directly the theming app is not loaded. We should only return a route to theming if the app has been loaded before.

Please review @Lartza @MorrisJobke @nextcloud/theming