### PR TITLE
Check if image files for theming are empty

### DIFF
--- a/apps/theming/lib/Controller/IconController.php
+++ b/apps/theming/lib/Controller/IconController.php
@@ -94,6 +94,9 @@ class IconController extends Controller {
 			$iconFile = $this->imageManager->getCachedImage("icon-" . $app . '-' . str_replace("/","_",$image));
 		} catch (NotFoundException $exception) {
 			$icon = $this->iconBuilder->colorSvg($app, $image);
+			if ($icon === false || $icon === "") {
+				return new NotFoundResponse();
+			}
 			$iconFile = $this->imageManager->setCachedImage("icon-" . $app . '-' . str_replace("/","_",$image), $icon);
 		}
 		if ($iconFile !== false) {

--- a/apps/theming/lib/IconBuilder.php
+++ b/apps/theming/lib/IconBuilder.php
@@ -172,7 +172,7 @@ class IconBuilder {
 			return false;
 		}
 		$svg = file_get_contents($imageFile);
-		if ($svg !== false) {
+		if ($svg !== false && $svg !== "") {
 			$color = $this->util->elementColor($this->themingDefaults->getMailHeaderColor());
 			$svg = $this->util->colorizeSvg($svg, $color);
 			return $svg;


### PR DESCRIPTION
This PR will ensure we don't save an empty image generated by the IconBuilder. 

Fix for #2564 

Please review @Lartza @nextcloud/theming 