### PR TITLE
Revert "Quote database and role in queries"

### DIFF
--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -111,7 +111,7 @@ class PostgreSQL extends AbstractDatabase {
 	private function createDatabase(IDBConnection $connection) {
 		if (!$this->databaseExists($connection)) {
 			//The database does not exists... let's create it
-			$query = $connection->prepare("CREATE DATABASE \"" . addslashes($this->dbName) . "\" OWNER '" . addslashes($this->dbUser) . "'");
+			$query = $connection->prepare("CREATE DATABASE " . addslashes($this->dbName) . " OWNER " . addslashes($this->dbUser));
 			try {
 				$query->execute();
 			} catch (DatabaseException $e) {
@@ -119,7 +119,7 @@ class PostgreSQL extends AbstractDatabase {
 				$this->logger->logException($e);
 			}
 		} else {
-			$query = $connection->prepare("REVOKE ALL PRIVILEGES ON DATABASE \"" . addslashes($this->dbName) . "\" FROM PUBLIC");
+			$query = $connection->prepare("REVOKE ALL PRIVILEGES ON DATABASE " . addslashes($this->dbName) . " FROM PUBLIC");
 			try {
 				$query->execute();
 			} catch (DatabaseException $e) {
@@ -153,10 +153,10 @@ class PostgreSQL extends AbstractDatabase {
 		try {
 			if ($this->userExists($connection)) {
 				// change the password
-				$query = $connection->prepare("ALTER ROLE \"" . addslashes($this->dbUser) . "\" WITH CREATEDB PASSWORD '" . addslashes($this->dbPassword) . "'");
+				$query = $connection->prepare("ALTER ROLE " . addslashes($this->dbUser) . " WITH CREATEDB PASSWORD '" . addslashes($this->dbPassword) . "'");
 			} else {
 				// create the user
-				$query = $connection->prepare("CREATE USER \"" . addslashes($this->dbUser) . "\" CREATEDB PASSWORD '" . addslashes($this->dbPassword) . "'");
+				$query = $connection->prepare("CREATE USER " . addslashes($this->dbUser) . " CREATEDB PASSWORD '" . addslashes($this->dbPassword) . "'");
 			}
 			$query->execute();
 		} catch (DatabaseException $e) {

--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -60,7 +60,7 @@ class PostgreSQL extends AbstractDatabase {
 				//use the admin login data for the new database user
 
 				//add prefix to the postgresql user name to prevent collisions
-				$this->dbUser = 'oc_' . $username;
+				$this->dbUser = 'oc_' . strtolower($username);
 				//create a new password so we don't need to store the admin config in the config file
 				$this->dbPassword = \OC::$server->getSecureRandom()->generate(30, \OCP\Security\ISecureRandom::CHAR_LOWER . \OCP\Security\ISecureRandom::CHAR_DIGITS);
 


### PR DESCRIPTION
This reverts commit 9ebd5d5bb20af9178e071c3c6f3b41d9a9bc8be0 from #2556 

This broke the travis installation of all apps.
I had a look at the docs and it only mentions quotes around the password and that already has some.

The issue that it is supposed to fix was reported against 10, not 11. There is another difference between 11 and 10 on the verify same code: https://github.com/nextcloud/server/commit/7fb88ec506bca6490b4db07d1ab60308cd6675c9

So we should backport #1268 as I already mentioned in #2535 

cc @icewind1991 @rullzer @LukasReschke 
