### PR TITLE
Fix dev manual link for NC11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ like `git config --global alias.ci 'commit -s'`. Now you can commit with
 
 In case you are not sure how to add or update the license header correctly please have a look at [contribute/HowToApplyALicense.md][applyalicense]
 
-[devmanual]: https://docs.nextcloud.org/server/10/developer_manual/
+[devmanual]: https://docs.nextcloud.org/server/11/developer_manual/
 [dcofile]: https://github.com/nextcloud/server/blob/master/contribute/developer-certificate-of-origin
 [applyalicense]: https://github.com/nextcloud/server/blob/master/contribute/HowToApplyALicense.md
 

--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -24,7 +24,7 @@ script(
 
 <?php if($_['appstoreEnabled']): ?>
 	<li>
-		<a class="app-external" target="_blank" rel="noreferrer" href="https://docs.nextcloud.org/server/10/developer_manual/"><?php p($l->t('Developer documentation'));?> ↗</a>
+		<a class="app-external" target="_blank" rel="noreferrer" href="https://docs.nextcloud.org/server/11/developer_manual/"><?php p($l->t('Developer documentation'));?> ↗</a>
 	</li>
 <?php endif; ?>
 </script>


### PR DESCRIPTION
Noticed it on the apps page of NC11 and apparently it was not updated in our contributing file too.