### PR TITLE
Increase debounce time to make sure controls are resized after the sidebar disappeared

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1502,7 +1502,7 @@ function initCore() {
 
 		$(window).resize(_.debounce(adjustControlsWidth, 250));
 
-		$('body').delegate('#app-content', 'apprendered appresized', _.debounce(adjustControlsWidth, 100));
+		$('body').delegate('#app-content', 'apprendered appresized', _.debounce(adjustControlsWidth, 150));
 
 	}
 


### PR DESCRIPTION
Follow up of #2365 - Fixes #2346 😉 Still not perfect with Safari, but better than now 😅 It is now jumping back after some ms 😁 

Signed-off-by: Marius Blüm <marius@lineone.io>