### PR TITLE
Download a file in a subfolder in a sharedlink is not working

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -487,7 +487,7 @@ class ShareController extends Controller {
 				// Single file download
 				$this->singleFileDownloaded($share, $share->getNode());
 			} else if (!empty($files_list)) {
-				$this->fileListDownloaded($share, $files_list);
+				$this->fileListDownloaded($share, $files_list, $node);
 			} else {
 				// The folder is downloaded
 				$this->singleFileDownloaded($share, $share->getNode());
@@ -542,9 +542,9 @@ class ShareController extends Controller {
 	 * @param Share\IShare $share
 	 * @param array $files_list
 	 */
-	protected function fileListDownloaded(Share\IShare $share, array $files_list) {
+	protected function fileListDownloaded(Share\IShare $share, array $files_list, \OCP\Files\Folder $node) {
 		foreach ($files_list as $file) {
-			$subNode = $share->getNode()->get($file);
+			$subNode = $node->get($file);
 			$this->singleFileDownloaded($share, $subNode);
 		}
 

--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -541,6 +541,7 @@ class ShareController extends Controller {
 	 *
 	 * @param Share\IShare $share
 	 * @param array $files_list
+	 * @param \OCP\Files\Folder $node
 	 */
 	protected function fileListDownloaded(Share\IShare $share, array $files_list, \OCP\Files\Folder $node) {
 		foreach ($files_list as $file) {


### PR DESCRIPTION
Downloading a file in a subfolder returns a 404.
[The $node created using the path (GET) parameter](https://github.com/nextcloud/server/blob/9ef8d25e4620d818c582db4ba1f26bf1fa83d36f/apps/files_sharing/lib/Controller/ShareController.php#L475) is not used when executing fileListDownloaded()

