### PR TITLE
Move log out and backup codes link into 2fa box for better readability

### DIFF
--- a/core/templates/twofactorselectchallenge.php
+++ b/core/templates/twofactorselectchallenge.php
@@ -18,13 +18,16 @@
 			<?php endforeach; ?>
 		</ul>
 	</p>
+	<p class="two-factor-link">
+		<a <?php print_unescaped($_['logout_attribute']); ?>><?php p($l->t('Cancel log in')) ?></a>
+		<?php if (!is_null($_['backupProvider'])): ?>
+		<br>
+		<a href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.showChallenge',
+												[
+													'challengeProviderId' => $_['backupProvider']->getId(),
+													'redirect_url' => $_['redirect_url'],
+												]
+											)) ?>"><?php p($l->t('Use backup code')) ?></a>
+		<?php endif; ?>
+	</p>
 </div>
-<a class="two-factor-link" <?php print_unescaped($_['logout_attribute']); ?>><?php p($l->t('Cancel log in')) ?></a>
-<?php if (!is_null($_['backupProvider'])): ?>
-<a class="two-factor-link" href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.showChallenge',
-										[
-											'challengeProviderId' => $_['backupProvider']->getId(),
-											'redirect_url' => $_['redirect_url'],
-										]
-									)) ?>"><?php p($l->t('Use backup code')) ?></a>
-<?php endif;

--- a/core/templates/twofactorselectchallenge.php
+++ b/core/templates/twofactorselectchallenge.php
@@ -19,10 +19,9 @@
 		</ul>
 	</p>
 	<p class="two-factor-link">
-		<a <?php print_unescaped($_['logout_attribute']); ?>><?php p($l->t('Cancel log in')) ?></a>
+		<a class="button" <?php print_unescaped($_['logout_attribute']); ?>><?php p($l->t('Cancel log in')) ?></a>
 		<?php if (!is_null($_['backupProvider'])): ?>
-		<br>
-		<a href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.showChallenge',
+		<a class="button" href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.showChallenge',
 												[
 													'challengeProviderId' => $_['backupProvider']->getId(),
 													'redirect_url' => $_['redirect_url'],

--- a/core/templates/twofactorshowchallenge.php
+++ b/core/templates/twofactorshowchallenge.php
@@ -22,10 +22,9 @@ $template = $_['template'];
 	<?php endif; ?>
 	<?php print_unescaped($template); ?>
 	<p class="two-factor-link">
-		<a <?php print_unescaped($_['logout_attribute']); ?>><?php p($l->t('Cancel log in')) ?></a>
+		<a class="button" <?php print_unescaped($_['logout_attribute']); ?>><?php p($l->t('Cancel log in')) ?></a>
 		<?php if (!is_null($_['backupProvider'])): ?>
-		<br>
-		<a href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.showChallenge',
+		<a class="button" href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.showChallenge',
 												[
 													'challengeProviderId' => $_['backupProvider']->getId(),
 													'redirect_url' => $_['redirect_url'],

--- a/core/templates/twofactorshowchallenge.php
+++ b/core/templates/twofactorshowchallenge.php
@@ -12,22 +12,25 @@ $template = $_['template'];
 ?>
 
 <div class="warning">
-		<h2 class="two-factor-header"><?php p($provider->getDisplayName()); ?></h2>
-		<?php if ($error): ?>
+	<h2 class="two-factor-header"><?php p($provider->getDisplayName()); ?></h2>
+	<?php if ($error): ?>
 			<?php if($error_message): ?>
 				<p><strong><?php p($error_message); ?></strong></p>
 			<?php else: ?>
 				<p><strong><?php p($l->t('Error while validating your second factor')); ?></strong></p>
 			<?php endif; ?>
+	<?php endif; ?>
+	<?php print_unescaped($template); ?>
+	<p class="two-factor-link">
+		<a <?php print_unescaped($_['logout_attribute']); ?>><?php p($l->t('Cancel log in')) ?></a>
+		<?php if (!is_null($_['backupProvider'])): ?>
+		<br>
+		<a href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.showChallenge',
+												[
+													'challengeProviderId' => $_['backupProvider']->getId(),
+													'redirect_url' => $_['redirect_url'],
+												]
+											)) ?>"><?php p($l->t('Use backup code')) ?></a>
 		<?php endif; ?>
-		<?php print_unescaped($template); ?>
+	</p>
 </div>
-<a class="two-factor-link" <?php print_unescaped($_['logout_attribute']); ?>><?php p($l->t('Cancel log in')) ?></a>
-<?php if (!is_null($_['backupProvider'])): ?>
-<a class="two-factor-link" href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.showChallenge',
-										[
-											'challengeProviderId' => $_['backupProvider']->getId(),
-											'redirect_url' => $_['redirect_url'],
-										]
-									)) ?>"><?php p($l->t('Use backup code')) ?></a>
-<?php endif;


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/2538

## Without backup codes
![bildschirmfoto von 2016-12-12 10-13-17](https://cloud.githubusercontent.com/assets/1374172/21093956/dca388f4-c054-11e6-8cac-8cbbf165605a.png)
![bildschirmfoto von 2016-12-12 10-12-09](https://cloud.githubusercontent.com/assets/1374172/21093958/dca59ce8-c054-11e6-8469-1d559e52a551.png)
## With backup codes
![bildschirmfoto von 2016-12-12 10-17-27](https://cloud.githubusercontent.com/assets/1374172/21093955/dc9d73a6-c054-11e6-8210-97f1a6e9acfe.png)
![bildschirmfoto von 2016-12-12 10-17-19](https://cloud.githubusercontent.com/assets/1374172/21093957/dca40770-c054-11e6-8bf7-88cecd0a8ae4.png)
