### PR TITLE
Don't throw an exception when php-xml is missing

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -673,7 +673,9 @@ class OC {
 		stream_wrapper_register('quota', 'OC\Files\Stream\Quota');
 
 		\OC::$server->getEventLogger()->start('init_session', 'Initialize session');
-		OC_App::loadApps(array('session'));
+		if (function_exists('simplexml_load_file')) {
+			OC_App::loadApps(array('session'));
+		}
 		if (!self::$CLI) {
 			self::initSession();
 		}


### PR DESCRIPTION
@LukasReschke I guess we can also backport this later, so up to you if 11 or not

Fix #2180 