### PR TITLE
Show theming icons on external storage folders

### DIFF
--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -539,7 +539,11 @@ OCA.External.StatusManager.Utils = {
 	 * of the tr matching the folder name
 	 */
 	getIconRoute: function (tr) {
-		var icon = OC.imagePath('core', 'filetypes/folder-external');
+		if (OCA.Theming) {
+			var icon = OC.generateUrl('/apps/theming/img/core/filetypes/folder-external.svg?v=' + OCA.Theming.cacheBuster);
+		} else {
+			var icon = OC.imagePath('core', 'filetypes/folder-external');
+		}
 		var backend = null;
 
 		if (tr instanceof $) {


### PR DESCRIPTION
Fix for #2574

I decided to keep the custom icon logic in files external, as it might be used again in the future when there is a sharepoint integration.

Please test @jospoortvliet @nextcloud/theming 