### PR TITLE
two-factor activities

### DIFF
--- a/apps/twofactor_backupcodes/appinfo/info.xml
+++ b/apps/twofactor_backupcodes/appinfo/info.xml
@@ -26,6 +26,7 @@
 		</settings>
 		<providers>
 			<provider>OCA\TwoFactorBackupCodes\Activity\GenericProvider</provider>
+			<provider>OCA\TwoFactorBackupCodes\Activity\Provider</provider>
 		</providers>
 	</activity>
 </info>

--- a/apps/twofactor_backupcodes/appinfo/info.xml
+++ b/apps/twofactor_backupcodes/appinfo/info.xml
@@ -16,4 +16,16 @@
 	<dependencies>
 		<nextcloud min-version="12" max-version="12" />
 	</dependencies>
+
+	<activity>
+		<filters>
+			<filter>OCA\TwoFactorBackupCodes\Activity\GenericFilter</filter>
+		</filters>
+		<settings>
+			<setting>OCA\TwoFactorBackupCodes\Activity\GenericSetting</setting>
+		</settings>
+		<providers>
+			<provider>OCA\TwoFactorBackupCodes\Activity\GenericProvider</provider>
+		</providers>
+	</activity>
 </info>

--- a/apps/twofactor_backupcodes/lib/Activity/GenericFilter.php
+++ b/apps/twofactor_backupcodes/lib/Activity/GenericFilter.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\TwoFactorBackupCodes\Activity;
+
+use OCP\Activity\IFilter;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+
+class GenericFilter implements IFilter {
+
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
+	/** @var IL10N */
+	private $l10n;
+
+	public function __construct(IURLGenerator $urlGenerator, IL10N $l10n) {
+		$this->urlGenerator = $urlGenerator;
+		$this->l10n = $l10n;
+	}
+
+	public function allowedApps() {
+		return null;
+	}
+
+	public function filterTypes(array $types) {
+		return array_intersect(['twofactor'], $types);
+	}
+
+	public function getIcon() {
+		return $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'actions/password.svg'));
+	}
+
+	public function getIdentifier() {
+		return 'twofactor';
+	}
+
+	public function getName() {
+		return $this->l10n->t('Two-factor authentication');
+	}
+
+	public function getPriority() {
+		return 30;
+	}
+
+}

--- a/apps/twofactor_backupcodes/lib/Activity/GenericFilter.php
+++ b/apps/twofactor_backupcodes/lib/Activity/GenericFilter.php
@@ -40,7 +40,7 @@ class GenericFilter implements IFilter {
 	}
 
 	public function allowedApps() {
-		return null;
+		return [];
 	}
 
 	public function filterTypes(array $types) {

--- a/apps/twofactor_backupcodes/lib/Activity/GenericProvider.php
+++ b/apps/twofactor_backupcodes/lib/Activity/GenericProvider.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Copyright (c) 2016 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Two-factor backup codes
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactorBackupCodes\Activity;
+
+use InvalidArgumentException;
+use OCP\Activity\IEvent;
+use OCP\Activity\IProvider;
+use OCP\ILogger;
+use OCP\IURLGenerator;
+use OCP\L10N\IFactory as L10nFactory;
+
+class GenericProvider implements IProvider {
+
+	/** @var L10nFactory */
+	private $l10n;
+
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
+	/** @var ILogger */
+	private $logger;
+
+	public function __construct(L10nFactory $l10n, IURLGenerator $urlGenerator, ILogger $logger) {
+		$this->logger = $logger;
+		$this->urlGenerator = $urlGenerator;
+		$this->l10n = $l10n;
+	}
+
+	public function parse($language, IEvent $event, IEvent $previousEvent = null) {
+		if ($event->getType() !== 'twofactor') {
+			throw new InvalidArgumentException();
+		}
+
+		$l = $this->l10n->get('core', $language);
+
+		switch ($event->getSubject()) {
+			case 'twofactor_success':
+				$params = $event->getSubjectParameters();
+				error_log(json_encode($params['provider']));
+				$event->setParsedSubject($l->t('You successfully logged in using two-factor authentication (%1$s)', [
+							$params['provider'],
+					]));
+				$event->setIcon($this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'actions/password.svg')));
+				break;
+			case 'twofactor_failed':
+				$params = $event->getSubjectParameters();
+				$event->setParsedSubject($l->t('A login attempt using two-factor authenticatoin failed (%1$s)', [
+							$params['provider'],
+					]));
+				$event->setIcon($this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'actions/password.svg')));
+				break;
+			default:
+				throw new InvalidArgumentException();
+		}
+		return $event;
+	}
+
+}

--- a/apps/twofactor_backupcodes/lib/Activity/GenericProvider.php
+++ b/apps/twofactor_backupcodes/lib/Activity/GenericProvider.php
@@ -63,7 +63,7 @@ class GenericProvider implements IProvider {
 				break;
 			case 'twofactor_failed':
 				$params = $event->getSubjectParameters();
-				$event->setParsedSubject($l->t('A login attempt using two-factor authenticatoin failed (%1$s)', [
+				$event->setParsedSubject($l->t('A login attempt using two-factor authentication failed (%1$s)', [
 							$params['provider'],
 					]));
 				$event->setIcon($this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'actions/password.svg')));

--- a/apps/twofactor_backupcodes/lib/Activity/GenericSetting.php
+++ b/apps/twofactor_backupcodes/lib/Activity/GenericSetting.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Copyright (c) 2016 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Two-factor backup codes
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactorBackupCodes\Activity;
+
+use OCP\Activity\ISetting;
+use OCP\IL10N;
+
+class GenericSetting implements ISetting {
+
+	/** @var IL10N */
+	private $l10n;
+
+	public function __construct(IL10N $l10n) {
+		$this->l10n = $l10n;
+	}
+
+	public function canChangeMail() {
+		return false;
+	}
+
+	public function canChangeStream() {
+		return false;
+	}
+
+	public function getIdentifier() {
+		return 'twofactor';
+	}
+
+	public function getName() {
+		return $this->l10n->t('Two-factor authentication');
+	}
+
+	public function getPriority() {
+		return 30;
+	}
+
+	public function isDefaultEnabledMail() {
+		return true;
+	}
+
+	public function isDefaultEnabledStream() {
+		return true;
+	}
+
+}

--- a/apps/twofactor_backupcodes/lib/Activity/Provider.php
+++ b/apps/twofactor_backupcodes/lib/Activity/Provider.php
@@ -29,7 +29,7 @@ use OCP\ILogger;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory as L10nFactory;
 
-class GenericProvider implements IProvider {
+class Provider implements IProvider {
 
 	/** @var L10nFactory */
 	private $l10n;
@@ -47,25 +47,15 @@ class GenericProvider implements IProvider {
 	}
 
 	public function parse($language, IEvent $event, IEvent $previousEvent = null) {
-		if ($event->getType() !== 'twofactor') {
+		if ($event->getApp() !== 'twofactor_backupcodes') {
 			throw new InvalidArgumentException();
 		}
 
-		$l = $this->l10n->get('core', $language);
+		$l = $this->l10n->get('twofactor_backupcodes', $language);
 
 		switch ($event->getSubject()) {
-			case 'twofactor_success':
-				$params = $event->getSubjectParameters();
-				$event->setParsedSubject($l->t('You successfully logged in using two-factor authentication (%1$s)', [
-							$params['provider'],
-					]));
-				$event->setIcon($this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'actions/password.svg')));
-				break;
-			case 'twofactor_failed':
-				$params = $event->getSubjectParameters();
-				$event->setParsedSubject($l->t('A login attempt using two-factor authenticatoin failed (%1$s)', [
-							$params['provider'],
-					]));
+			case 'codes_generated':
+				$event->setParsedSubject($l->t('You created backup codes for your account'));
 				$event->setIcon($this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'actions/password.svg')));
 				break;
 			default:

--- a/apps/twofactor_backupcodes/lib/Activity/Provider.php
+++ b/apps/twofactor_backupcodes/lib/Activity/Provider.php
@@ -55,7 +55,7 @@ class Provider implements IProvider {
 
 		switch ($event->getSubject()) {
 			case 'codes_generated':
-				$event->setParsedSubject($l->t('You created backup codes for your account'));
+				$event->setParsedSubject($l->t('You created two-factor backup codes for your account'));
 				$event->setIcon($this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'actions/password.svg')));
 				break;
 			default:

--- a/apps/twofactor_backupcodes/lib/Service/BackupCodeStorage.php
+++ b/apps/twofactor_backupcodes/lib/Service/BackupCodeStorage.php
@@ -22,7 +22,7 @@
 
 namespace OCA\TwoFactorBackupCodes\Service;
 
-use Exception;
+use BadMethodCallException;
 use OCA\TwoFactorBackupCodes\Db\BackupCode;
 use OCA\TwoFactorBackupCodes\Db\BackupCodeMapper;
 use OCP\Activity\IManager;
@@ -100,7 +100,7 @@ class BackupCodeStorage {
 			->setSubject($event);
 		try {
 			$this->activityManager->publish($activity);
-		} catch (Exception $e) {
+		} catch (BadMethodCallException $e) {
 			$this->logger->warning('could not publish backup code creation activity', ['app' => 'twofactor_backupcodes']);
 			$this->logger->logException($e, ['app' => 'twofactor_backupcodes']);
 		}

--- a/apps/twofactor_backupcodes/tests/Unit/Activity/GenericFilterTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Activity/GenericFilterTest.php
@@ -26,7 +26,6 @@ use OCA\TwoFactorBackupCodes\Activity\GenericFilter;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use Test\TestCase;
-use function returnValue;
 
 class GenericFilterTest extends TestCase {
 
@@ -46,7 +45,7 @@ class GenericFilterTest extends TestCase {
 	}
 
 	public function testAllowedApps() {
-		$this->assertEquals(0, $this->filter->allowedApps());
+		$this->assertEquals([], $this->filter->allowedApps());
 	}
 
 	public function testFilterTypes() {

--- a/apps/twofactor_backupcodes/tests/Unit/Activity/GenericFilterTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Activity/GenericFilterTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\TwoFactorBackupCodes\Test\Unit\Activity;
+
+use OCA\TwoFactorBackupCodes\Activity\GenericFilter;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use Test\TestCase;
+use function returnValue;
+
+class GenericFilterTest extends TestCase {
+
+	private $urlGenerator;
+	private $l10n;
+
+	/** @var GenericFilter */
+	private $filter;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->l10n = $this->createMock(IL10N::class);
+
+		$this->filter = new GenericFilter($this->urlGenerator, $this->l10n);
+	}
+
+	public function testAllowedApps() {
+		$this->assertEquals(0, $this->filter->allowedApps());
+	}
+
+	public function testFilterTypes() {
+		$this->assertEquals(['twofactor'], $this->filter->filterTypes(['comments', 'twofactor']));
+	}
+
+	public function testGetIcon() {
+		$this->urlGenerator->expects($this->once())
+			->method('imagePath')
+			->with('core', 'actions/password.svg')
+			->will($this->returnValue('path/to/icon.svg'));
+		$this->urlGenerator->expects($this->once())
+			->method('getAbsoluteURL')
+			->with('path/to/icon.svg')
+			->will($this->returnValue('abs/path/to/icon.svg'));
+		$this->assertEquals('abs/path/to/icon.svg', $this->filter->getIcon());
+	}
+
+	public function testGetIdentifier() {
+		$this->assertEquals('twofactor', $this->filter->getIdentifier());
+	}
+
+	public function testGetName() {
+		$this->l10n->expects($this->once())
+			->method('t')
+			->with('Two-factor authentication')
+			->will($this->returnValue('translated'));
+		$this->assertEquals('translated', $this->filter->getName());
+	}
+
+	public function testGetPriority() {
+		$this->assertEquals(30, $this->filter->getPriority());
+	}
+
+}

--- a/apps/twofactor_backupcodes/tests/Unit/Activity/ProviderTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Activity/ProviderTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Copyright (c) 2016 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Two-factor backup codes
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactorBackupCodes\Test\Unit\Activity;
+
+use InvalidArgumentException;
+use OCA\TwoFactorBackupCodes\Activity\GenericProvider;
+use OCP\Activity\IEvent;
+use OCP\IL10N;
+use OCP\ILogger;
+use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
+use Test\TestCase;
+
+class ProviderTest extends TestCase {
+
+	private $l10n;
+	private $urlGenerator;
+	private $logger;
+
+	/** @var GenericProvider */
+	private $provider;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->l10n = $this->createMock(IFactory::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->logger = $this->createMock(ILogger::class);
+
+		$this->provider = new GenericProvider($this->l10n, $this->urlGenerator, $this->logger);
+	}
+
+	public function testParseUnrelated() {
+		$lang = 'ru';
+		$event = $this->createMock(IEvent::class);
+		$event->expects($this->once())
+			->method('getType')
+			->will($this->returnValue('comments'));
+		$this->setExpectedException(InvalidArgumentException::class);
+
+		$this->provider->parse($lang, $event);
+	}
+
+	public function subjectData() {
+		return [
+				['twofactor_success'],
+				['twofactor_failed'],
+		];
+	}
+
+	/**
+	 * @dataProvider subjectData
+	 */
+	public function testParse($subject) {
+		$lang = 'ru';
+		$event = $this->createMock(IEvent::class);
+		$l = $this->createMock(IL10N::class);
+
+		$event->expects($this->once())
+			->method('getType')
+			->will($this->returnValue('twofactor'));
+		$this->l10n->expects($this->once())
+			->method('get')
+			->with('core', $lang)
+			->will($this->returnValue($l));
+		$this->urlGenerator->expects($this->once())
+			->method('imagePath')
+			->with('core', 'actions/password.svg')
+			->will($this->returnValue('path/to/image'));
+		$this->urlGenerator->expects($this->once())
+			->method('getAbsoluteURL')
+			->with('path/to/image')
+			->will($this->returnValue('absolute/path/to/image'));
+		$event->expects($this->once())
+			->method('setIcon')
+			->with('absolute/path/to/image');
+		$event->expects($this->once())
+			->method('getSubject')
+			->will($this->returnValue($subject));
+		$event->expects($this->once())
+			->method('setParsedSubject');
+
+		$this->provider->parse($lang, $event);
+	}
+
+}

--- a/apps/twofactor_backupcodes/tests/Unit/Activity/SettingTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Activity/SettingTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Copyright (c) 2016 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Two-factor backup codes
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactorBackupCodes\Test\Unit\Activity;
+
+use OCA\TwoFactorBackupCodes\Activity\GenericSetting;
+use OCP\IL10N;
+use Test\TestCase;
+
+class SettingTest extends TestCase {
+
+	private $l10n;
+
+	/** @var GenericSetting */
+	private $setting;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->l10n = $this->createMock(IL10N::class);
+
+		$this->setting = new GenericSetting($this->l10n);
+	}
+
+	public function testCanChangeMail() {
+		$this->assertFalse($this->setting->canChangeMail());
+	}
+
+	public function testCanChangeStream() {
+		$this->assertFalse($this->setting->canChangeStream());
+	}
+
+	public function testGetIdentifier() {
+		$this->assertEquals('twofactor', $this->setting->getIdentifier());
+	}
+
+	public function testGetName() {
+		$this->l10n->expects($this->once())
+			->method('t')
+			->with('Two-factor authentication')
+			->will($this->returnValue('Zwei-Faktor-Authentifizierung'));
+		$this->assertEquals('Zwei-Faktor-Authentifizierung', $this->setting->getName());
+	}
+
+	public function testGetPriority() {
+		$this->assertEquals(30, $this->setting->getPriority());
+	}
+
+	public function testIsDefaultEnabled() {
+		$this->assertTrue($this->setting->isDefaultEnabledMail());
+		$this->assertTrue($this->setting->isDefaultEnabledStream());
+	}
+
+}

--- a/apps/twofactor_backupcodes/tests/Unit/Service/BackupCodeStorageTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Service/BackupCodeStorageTest.php
@@ -27,6 +27,7 @@ use OCA\TwoFactorBackupCodes\Db\BackupCodeMapper;
 use OCA\TwoFactorBackupCodes\Service\BackupCodeStorage;
 use OCP\Activity\IEvent;
 use OCP\Activity\IManager;
+use OCP\ILogger;
 use OCP\IUser;
 use OCP\Security\IHasher;
 use OCP\Security\ISecureRandom;
@@ -46,6 +47,9 @@ class BackupCodeStorageTest extends TestCase {
 	/** @var IManager|\PHPUnit_Framework_MockObject_MockObject */
 	private $activityManager;
 
+	/** @var ILogger|\PHPUnit_Framework_MockObject_MockObject */
+	private $logger;
+
 	/** @var BackupCodeStorage */
 	private $storage;
 
@@ -58,7 +62,9 @@ class BackupCodeStorageTest extends TestCase {
 		$this->random = $this->getMockBuilder(ISecureRandom::class)->getMock();
 		$this->hasher = $this->getMockBuilder(IHasher::class)->getMock();
 		$this->activityManager = $this->createMock(IManager::class);
-		$this->storage = new BackupCodeStorage($this->mapper, $this->random, $this->hasher, $this->activityManager);
+		$this->logger = $this->createMock(ILogger::class);
+
+		$this->storage = new BackupCodeStorage($this->mapper, $this->random, $this->hasher, $this->activityManager, $this->logger);
 	}
 
 	public function testCreateCodes() {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -312,7 +312,7 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 
 		$this->registerService(\OC\Authentication\TwoFactorAuth\Manager::class, function (Server $c) {
-			return new \OC\Authentication\TwoFactorAuth\Manager($c->getAppManager(), $c->getSession(), $c->getConfig(), $c->getActivityManager());
+			return new \OC\Authentication\TwoFactorAuth\Manager($c->getAppManager(), $c->getSession(), $c->getConfig(), $c->getActivityManager(), $c->getLogger());
 		});
 
 		$this->registerService('NavigationManager', function ($c) {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -312,7 +312,7 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 
 		$this->registerService(\OC\Authentication\TwoFactorAuth\Manager::class, function (Server $c) {
-			return new \OC\Authentication\TwoFactorAuth\Manager($c->getAppManager(), $c->getSession(), $c->getConfig());
+			return new \OC\Authentication\TwoFactorAuth\Manager($c->getAppManager(), $c->getSession(), $c->getConfig(), $c->getActivityManager());
 		});
 
 		$this->registerService('NavigationManager', function ($c) {

--- a/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
@@ -26,8 +26,11 @@ use Exception;
 use OC;
 use OC\App\AppManager;
 use OC\Authentication\TwoFactorAuth\Manager;
+use OCP\Activity\IEvent;
+use OCP\Activity\IManager;
 use OCP\Authentication\TwoFactorAuth\IProvider;
 use OCP\IConfig;
+use OCP\ILogger;
 use OCP\ISession;
 use OCP\IUser;
 use Test\TestCase;
@@ -49,6 +52,12 @@ class ManagerTest extends TestCase {
 	/** @var IConfig|PHPUnit_Framework_MockObject_MockObject */
 	private $config;
 
+	/** @var IManager|PHPUnit_Framework_MockObject_MockObject */
+	private $activityManager;
+
+	/** @var ILogger|PHPUnit_Framework_MockObject_MockObject */
+	private $logger;
+
 	/** @var IProvider|PHPUnit_Framework_MockObject_MockObject */
 	private $fakeProvider;
 
@@ -59,14 +68,14 @@ class ManagerTest extends TestCase {
 		parent::setUp();
 
 		$this->user = $this->createMock(IUser::class);
-		$this->appManager = $this->getMockBuilder('\OC\App\AppManager')
-			->disableOriginalConstructor()
-			->getMock();
+		$this->appManager = $this->createMock('\OC\App\AppManager');
 		$this->session = $this->createMock(ISession::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->activityManager = $this->createMock(IManager::class);
+		$this->logger = $this->createMock(ILogger::class);
 
 		$this->manager = $this->getMockBuilder('\OC\Authentication\TwoFactorAuth\Manager')
-			->setConstructorArgs([$this->appManager, $this->session, $this->config])
+			->setConstructorArgs([$this->appManager, $this->session, $this->config, $this->activityManager, $this->logger])
 			->setMethods(['loadTwoFactorApp']) // Do not actually load the apps
 			->getMock();
 
@@ -228,6 +237,7 @@ class ManagerTest extends TestCase {
 		$this->prepareProviders();
 
 		$challenge = 'passme';
+		$event = $this->createMock(IEvent::class);
 		$this->fakeProvider->expects($this->once())
 			->method('verifyChallenge')
 			->with($this->user, $challenge)
@@ -242,6 +252,37 @@ class ManagerTest extends TestCase {
 		$this->session->expects($this->at(2))
 			->method('remove')
 			->with('two_factor_remember_login');
+		$this->activityManager->expects($this->once())
+			->method('generateEvent')
+			->willReturn($event);
+		$this->user->expects($this->any())
+			->method('getUID')
+			->willReturn('jos');
+		$event->expects($this->once())
+			->method('setApp')
+			->with($this->equalTo('twofactor_generic'))
+			->willReturnSelf();
+		$event->expects($this->once())
+			->method('setType')
+			->with($this->equalTo('twofactor'))
+			->willReturnSelf();
+		$event->expects($this->once())
+			->method('setAuthor')
+			->with($this->equalTo('jos'))
+			->willReturnSelf();
+		$event->expects($this->once())
+			->method('setAffectedUser')
+			->with($this->equalTo('jos'))
+			->willReturnSelf();
+		$this->fakeProvider->expects($this->once())
+			->method('getDisplayName')
+			->willReturn('Fake 2FA');
+		$event->expects($this->once())
+			->method('setSubject')
+			->with($this->equalTo('twofactor_success'), $this->equalTo([
+				'provider' => 'Fake 2FA',
+			]))
+			->willReturnSelf();
 
 		$this->assertTrue($this->manager->verifyChallenge('email', $this->user, $challenge));
 	}
@@ -263,12 +304,44 @@ class ManagerTest extends TestCase {
 		$this->prepareProviders();
 
 		$challenge = 'dontpassme';
+		$event = $this->createMock(IEvent::class);
 		$this->fakeProvider->expects($this->once())
 			->method('verifyChallenge')
 			->with($this->user, $challenge)
 			->will($this->returnValue(false));
 		$this->session->expects($this->never())
 			->method('remove');
+		$this->activityManager->expects($this->once())
+			->method('generateEvent')
+			->willReturn($event);
+		$this->user->expects($this->any())
+			->method('getUID')
+			->willReturn('jos');
+		$event->expects($this->once())
+			->method('setApp')
+			->with($this->equalTo('twofactor_generic'))
+			->willReturnSelf();
+		$event->expects($this->once())
+			->method('setType')
+			->with($this->equalTo('twofactor'))
+			->willReturnSelf();
+		$event->expects($this->once())
+			->method('setAuthor')
+			->with($this->equalTo('jos'))
+			->willReturnSelf();
+		$event->expects($this->once())
+			->method('setAffectedUser')
+			->with($this->equalTo('jos'))
+			->willReturnSelf();
+		$this->fakeProvider->expects($this->once())
+			->method('getDisplayName')
+			->willReturn('Fake 2FA');
+		$event->expects($this->once())
+			->method('setSubject')
+			->with($this->equalTo('twofactor_failed'), $this->equalTo([
+				'provider' => 'Fake 2FA',
+			]))
+			->willReturnSelf();
 
 		$this->assertFalse($this->manager->verifyChallenge('email', $this->user, $challenge));
 	}


### PR DESCRIPTION
This adds generic support for two-factor activities (setting, filter and provider). The backup codes provider is the first that sends custom events when the user creates codes. I will add enabled/disable events to TOTP and U2F too. I added the generic classes to the backup provider too because those are registered per app and it's shipped with the server.

* Publishes an activity when a 2fa attempt failed
* Publishes an activity when a 2fa attempf succeeded
* Publishes an activity when backup codes are generated

@LukasReschke as requested :-)

cc @nickvergessen 

## Screenshot
![bildschirmfoto von 2016-12-13 10-48-42](https://cloud.githubusercontent.com/assets/1374172/21135418/1bb59b04-c122-11e6-9a49-674b9c7b0b9a.png)
