### PR TITLE
Remove LegacyDAVACL

### DIFF
--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -37,13 +37,11 @@ $authBackend = new Auth(
 	\OC::$server->getUserSession(),
 	\OC::$server->getRequest(),
 	\OC::$server->getTwoFactorAuthManager(),
-	\OC::$server->getBruteForceThrottler(),
-	'principals/'
+	\OC::$server->getBruteForceThrottler()
 );
 $principalBackend = new Principal(
 	\OC::$server->getUserManager(),
-	\OC::$server->getGroupManager(),
-	'principals/'
+	\OC::$server->getGroupManager()
 );
 $db = \OC::$server->getDatabaseConnection();
 $userManager = \OC::$server->getUserManager();
@@ -54,14 +52,16 @@ $calDavBackend = new CalDavBackend($db, $principalBackend, $userManager, $random
 $debugging = \OC::$server->getConfig()->getSystemValue('debug', false);
 
 // Root nodes
-$principalCollection = new \Sabre\CalDAV\Principal\Collection($principalBackend);
+$principalCollection = new \Sabre\CalDAV\Principal\Collection($principalBackend, 'principals/users/');
 $principalCollection->disableListing = !$debugging; // Disable listing
 
-$addressBookRoot = new CalendarRoot($principalBackend, $calDavBackend);
+$addressBookRoot = new CalendarRoot($principalBackend, $calDavBackend, 'principals/users/');
 $addressBookRoot->disableListing = !$debugging; // Disable listing
 
+$principals = new \Sabre\DAV\SimpleCollection('principals', [$principalCollection]);
+
 $nodes = array(
-	$principalCollection,
+	$principals,
 	$addressBookRoot,
 );
 

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -101,6 +101,7 @@ class Principal implements BackendInterface {
 	 */
 	public function getPrincipalByPath($path) {
 		list($prefix, $name) = URLUtil::splitPath($path);
+		$prefix = trim($prefix, '/');
 
 		if ($prefix === $this->principalPrefix) {
 			$user = $this->userManager->get($name);


### PR DESCRIPTION
Fixes: #2649

Seem that this code is now obsolete and actually breaks the old
endpoint. Since we request the current principal which then gets
converted to 'principals/users/<user>' but in the old endpoint we work
with 'principals/<user>'

CC: @awlx @smirkybg