### PR TITLE
[stable11] Safari CSPv3 support is sub-par

### DIFF
--- a/lib/private/Security/CSP/ContentSecurityPolicyNonceManager.php
+++ b/lib/private/Security/CSP/ContentSecurityPolicyNonceManager.php
@@ -69,8 +69,6 @@ class ContentSecurityPolicyNonceManager {
 			Request::USER_AGENT_CHROME,
 			// Firefox 45+
 			'/^Mozilla\/5\.0 \([^)]+\) Gecko\/[0-9.]+ Firefox\/(4[5-9]|[5-9][0-9])\.[0-9.]+$/',
-			// Safari 10+
-			'/^Mozilla\/5\.0 \([^)]+\) AppleWebKit\/[0-9.]+ \(KHTML, like Gecko\) Version\/1[0-9.]+ Safari\/[0-9.A-Z]+$/',
 		];
 
 		if($this->request->isUserAgent($browserWhitelist)) {


### PR DESCRIPTION
With 10.0.1 CSPv3 is broken in Safari if it doesn't run from a local IP. Awesome.

=> Let's remove this for Safari and keep chrome and Firefox in the whitelist.

Backport of https://github.com/nextcloud/server/pull/2668