### PR TITLE
[11] use unmasked permissions in shared scanner

### DIFF
--- a/apps/files_sharing/lib/Scanner.php
+++ b/apps/files_sharing/lib/Scanner.php
@@ -31,6 +31,11 @@ use OC\Files\ObjectStore\NoopScanner;
  * Scanner for SharedStorage
  */
 class Scanner extends \OC\Files\Cache\Scanner {
+	/**
+	 * @var \OCA\Files_Sharing\SharedStorage $storage
+	 */
+	protected $storage;
+
 	private $sourceScanner;
 
 	/**
@@ -46,8 +51,8 @@ class Scanner extends \OC\Files\Cache\Scanner {
 		if ($data === null) {
 			return null;
 		}
-		list($sourceStorage, $internalPath) = $this->storage->resolvePath($path);
-		$data['permissions'] = $sourceStorage->getPermissions($internalPath);
+		$internalPath = $this->storage->getSourcePath($path);
+		$data['permissions'] = $this->storage->getSourceStorage()->getPermissions($internalPath);
 		return $data;
 	}
 

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -446,7 +446,8 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 	}
 
 	public function getSourceStorage() {
-		return $this->getWrapperStorage();
+		$this->init();
+		return $this->nonMaskedStorage;
 	}
 
 	public function getWrapperStorage() {

--- a/apps/files_sharing/tests/SharedStorageTest.php
+++ b/apps/files_sharing/tests/SharedStorageTest.php
@@ -531,4 +531,32 @@ class SharedStorageTest extends TestCase {
 		$this->shareManager->deleteShare($share1);
 		$this->shareManager->deleteShare($share2);
 	}
+
+	public function testOwnerPermissions() {
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$share = $this->share(
+			\OCP\Share::SHARE_TYPE_USER,
+			$this->folder,
+			self::TEST_FILES_SHARING_API_USER1,
+			self::TEST_FILES_SHARING_API_USER2,
+			\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_DELETE
+		);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+		$view = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$this->assertTrue($view->file_exists($this->folder));
+
+		$view->file_put_contents($this->folder . '/newfile.txt', 'asd');
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$this->assertTrue($this->view->file_exists($this->folder . '/newfile.txt'));
+		$this->assertEquals(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_CREATE,
+			$this->view->getFileInfo($this->folder . '/newfile.txt')->getPermissions());
+
+		$this->view->unlink($this->folder);
+		$this->shareManager->deleteShare($share);
+
+	}
 }

--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -427,3 +427,23 @@ Feature: webdav-related
 		And User "user0" uploads file with content "copytest" to "/copytest.txt"
 		When User "user0" copies file "/copytest.txt" to "/testcopypermissionsNotAllowed/copytest.txt"
 		Then the HTTP status code should be "403"
+
+	Scenario: Uploading a file as recipient with limited permissions
+		Given using new dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user1" exists
+		And user "user0" has a quota of "10 MB"
+		And user "user1" has a quota of "10 MB"
+		And As an "user1"
+		And user "user1" created a folder "/testfolder"
+		And as "user1" creating a share with
+			| path        | testfolder |
+			| shareType   | 0          |
+			| permissions | 23         |
+			| shareWith   | user0      |
+		And As an "user0"
+		And User "user0" uploads file "data/textfile.txt" to "/testfolder/asdf.txt"
+		And As an "user1"
+		When User "user1" deletes file "/testfolder/asdf.txt"
+		Then the HTTP status code should be "204"


### PR DESCRIPTION
Backport of #2673