### PR TITLE
Don't disable apps on update if PHP >= 7.0.0

### DIFF
--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -82,6 +82,12 @@ class Updater extends BasicEmitter {
 		$this->log = $log;
 		$this->config = $config;
 		$this->checker = $checker;
+
+		// If at least PHP 7.0.0 is used we don't need to disable apps as we catch
+		// fatal errors and exceptions and disable the app just instead.
+		if(version_compare(phpversion(), '7.0.0', '>=')) {
+			$this->skip3rdPartyAppsDisable = true;
+		}
 	}
 
 	/**

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(12, 0, 0, 10);
+$OC_Version = array(12, 0, 0, 11);
 
 // The human readable string
 $OC_VersionString = '12.0 alpha';


### PR DESCRIPTION
When PHP in a version higher than 7.0.0 is used we catch fatal exceptions in app.php and gracefully already disable the app. There is thus no need to also disable the apps on updates.

This has been requested by Jan to fix because that is "the most annoying thing ever" ™️. – I'd say we give it a try and if that causes problems in the future we can consider alternative approaches. Note that apps that are not compatible in info.xml will regardless get disabled.

cc @jancborchardt 