### PR TITLE
Adjust shadows and fix positioning in header menus

### DIFF
--- a/core/css/header.css
+++ b/core/css/header.css
@@ -152,7 +152,7 @@
 	margin-top: 0;
 	padding-bottom: 10px;
 	background-color: rgba(255, 255, 255, .97);
-	box-shadow: 0 1px 10px rgba(50, 50, 50, .7);
+	box-shadow: 0 1px 10px rgba(150, 150, 150, .75);
 	border-radius: 3px;
 	border-top-left-radius: 0;
 	border-top-right-radius: 0;
@@ -339,13 +339,12 @@
 }
 #expanddiv {
 	position: absolute;
-	right: 10px;
+	right: 13px;
 	top: 45px;
 	z-index: 2000;
 	display: none;
 	background: rgb(255, 255, 255);
-	border: 1px solid rgb(204, 204, 204);
-	box-shadow: 0 1px 10px rgba(50, 50, 50, .7);
+	box-shadow: 0 1px 10px rgba(150, 150, 150, .75);
 	border-radius: 3px;
 	border-top-left-radius: 0;
 	border-top-right-radius: 0;


### PR DESCRIPTION
- Make the shadows of the app menu and settings menu lighter as discussed with @jancborchardt 
- Fix small positioning issue of the settings menu

Before:
![2016-12-17-194527_502x575_scrot](https://cloud.githubusercontent.com/assets/3404133/21289106/7f442bac-c494-11e6-8294-a466e3de3f9a.png)
After:
![2016-12-17-194806_331x515_scrot](https://cloud.githubusercontent.com/assets/3404133/21289107/7f475d2c-c494-11e6-93cc-b04ee79d864a.png)

