### PR TITLE
[downstream] When grouping shares, sort by stime then id (#26777)

### DIFF
--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -123,7 +123,7 @@ class MountProvider implements IMountProvider {
 		// sort by stime, the super share will be based on the least recent share
 		foreach ($tmp as &$tmp2) {
 			@usort($tmp2, function($a, $b) {
-				if ($a->getShareTime() < $b->getShareTime()) {
+				if ($a->getShareTime() <= $b->getShareTime()) {
 					return -1;
 				}
 				return 1;


### PR DESCRIPTION
From https://github.com/owncloud/core/pull/26777