### PR TITLE
Escape the name for the jquery selector

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1175,7 +1175,7 @@
 			var innernameSpan = $('<span></span>').addClass('innernametext').text(basename);
 
 			if (path && path !== '/') {
-				var conflictingItems = this.$fileList.find('tr[data-file="' + name.replace( /(:|\.|\[|\]|,|=)/g, "\\$1") + '"]');
+				var conflictingItems = this.$fileList.find('tr[data-file="' + this._jqSelEscape(name) + '"]');
 				if (conflictingItems.length !== 0) {
 					if (conflictingItems.length === 1) {
 						// Update the path on the first conflicting item
@@ -1259,6 +1259,14 @@
 			tr.find('.filesize').text(simpleSize);
 			tr.append(td);
 			return tr;
+		},
+
+		/* escape a selector expression for jQuery */
+		_jqSelEscape: function (expression) {
+			if (expression) {
+				return expression.replace(/[!"#$%&'()*+,.\/:;<=>?@\[\\\]^`{|}~]/g, '\\$&');
+			}
+			return null;
 		},
 
 		/**


### PR DESCRIPTION
Copied the method from [OCA.External.StatusManager](https://github.com/nextcloud/server/blob/b12db1b494376dc6ae35c11d127b35f3a156a97e/apps/files_external/js/statusmanager.js#L596-L602)
Not sure where the old code was from.

Fix https://help.nextcloud.com/t/nc11-files-missing-from-gui-but-available-on-disk-and-in-shared-link/6434/9

@rullzer @LukasReschke 

Fix #2942

Should backport to 11