### PR TITLE
Automatically redirect calls to occ with the correct user to allow autocompletion

### DIFF
--- a/occ
+++ b/occ
@@ -8,4 +8,4 @@
  */
 
 //$argv = $_SERVER['argv'];
-require_once __DIR__ . '/console.php';
+require_once __DIR__ . '/core/console.php';


### PR DESCRIPTION
@schiessle @karlitschek as discussed. The only real disadvantage I can see with this is, that when you add the completion to your bashrc, everytime you open your terminal, you are prompted for your sudo password:
> [sudo] Passwort für nickv: 

Not sure if that is too confusing without any additional note, but that is the case for all solutions.