### PR TITLE
Set exit code to 1 if integration test is failing

### DIFF
--- a/autotest-external.sh
+++ b/autotest-external.sh
@@ -210,14 +210,17 @@ EOF
 				rm -rf "coverage-external-html-$1-$name"
 				mkdir "coverage-external-html-$1-$name"
 				"$PHPUNIT" --configuration phpunit-autotest-external.xml --log-junit "autotest-external-results-$1-$name.xml" --coverage-clover "autotest-external-clover-$1-$name.xml" --coverage-html "coverage-external-html-$1-$name" "$FILES_EXTERNAL_BACKEND_PATH/$testToRun"
-				RESULT=$?
 			else
 				echo "No coverage"
 				"$PHPUNIT" --configuration phpunit-autotest-external.xml --log-junit "autotest-external-results-$1-$name.xml" "$FILES_EXTERNAL_BACKEND_PATH/$testToRun"
-				RESULT=$?
 			fi
 		else
 		    DOEXIT=1
+		fi
+
+		if [[ $? -ne 0 ]]; then
+		    echo "Error during phpunit execution ... terminating"
+		    exit 1
 		fi
 
 		# calculate stop file


### PR DESCRIPTION
Before it just checked the unit tests and ignored the integration test results. See https://drone.nextcloud.com/nextcloud/server/3374/35 for details.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>