### PR TITLE
Use login name to fix password confirm with ldap users

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -298,14 +298,10 @@ class LoginController extends Controller {
 		$currentDelay = $this->throttler->getDelay($this->request->getRemoteAddress());
 		$this->throttler->sleepDelay($this->request->getRemoteAddress());
 
-		$user = $this->userSession->getUser();
-		if (!$user instanceof IUser) {
-			return new DataResponse([], Http::STATUS_UNAUTHORIZED);
-		}
-
-		$loginResult = $this->userManager->checkPassword($user->getUID(), $password);
+		$loginName = $this->userSession->getLoginName();
+		$loginResult = $this->userManager->checkPassword($loginName, $password);
 		if ($loginResult === false) {
-			$this->throttler->registerAttempt('sudo', $this->request->getRemoteAddress(), ['user' => $user->getUID()]);
+			$this->throttler->registerAttempt('sudo', $this->request->getRemoteAddress(), ['user' => $loginName]);
 			if ($currentDelay === 0) {
 				$this->throttler->sleepDelay($this->request->getRemoteAddress());
 			}

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -743,6 +743,7 @@ class Session implements IUserSession, Emitter {
 
 		//login
 		$this->setUser($user);
+		$this->setLoginName($this->tokenProvider->getToken($sessionId)->getLoginName());
 		$user->updateLastLoginTimestamp();
 		$this->manager->emit('\OC\User', 'postRememberedLogin', [$user]);
 		return true;

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -528,7 +528,7 @@ class SessionTest extends \Test\TestCase {
 			->getMock();
 		$userSession = $this->getMockBuilder(Session::class)
 			//override, otherwise tests will fail because of setcookie()
-			->setMethods(['setMagicInCookie'])
+			->setMethods(['setMagicInCookie', 'setLoginName'])
 			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->random])
 			->getMock();
 
@@ -566,6 +566,15 @@ class SessionTest extends \Test\TestCase {
 			->with($oldSessionId, $sessionId)
 			->will($this->returnValue(true));
 
+		$tokenObject = $this->createMock(IToken::class);
+		$tokenObject->expects($this->once())
+			->method('getLoginName')
+			->willReturn('foobar');
+		$this->tokenProvider->expects($this->once())
+			->method('getToken')
+			->with($sessionId)
+			->willReturn($tokenObject);
+
 		$user->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('foo'));
@@ -576,6 +585,9 @@ class SessionTest extends \Test\TestCase {
 		$session->expects($this->once())
 			->method('set')
 			->with('user_id', 'foo');
+		$userSession->expects($this->once())
+			->method('setLoginName')
+			->willReturn('foobar');
 
 		$granted = $userSession->loginWithCookie('foo', $token, $oldSessionId);
 

--- a/tests/lib/UserTest.php
+++ b/tests/lib/UserTest.php
@@ -25,7 +25,7 @@ class UserTest extends TestCase {
 	protected function setUp(){
 		parent::setUp();
 
-		$this->backend = $this->getMock('\Test\Util\User\Dummy');
+		$this->backend = $this->createMock(\Test\Util\User\Dummy::class);
 		$manager = \OC::$server->getUserManager();
 		$manager->registerBackend($this->backend);
 	}


### PR DESCRIPTION
- [x] loginname was not set for me on my first try, need to find out why and where.

Fix #2734 

cc @ChristophWurst for the above issue, i guess it was because of "remember me"