### PR TITLE
Hide update notification if notification center is enabled

### DIFF
--- a/apps/updatenotification/appinfo/app.php
+++ b/apps/updatenotification/appinfo/app.php
@@ -33,7 +33,8 @@ if(\OC::$server->getConfig()->getSystemValue('updatechecker', true) === true) {
 
 	$userObject = \OC::$server->getUserSession()->getUser();
 	if($userObject !== null) {
-		if(\OC::$server->getGroupManager()->isAdmin($userObject->getUID())) {
+		if(\OC::$server->getGroupManager()->isAdmin($userObject->getUID()) &&
+			!\OC::$server->getAppManager()->isEnabledForUser('notifications')) {
 			if($updateChecker->getUpdateState() !== []) {
 				\OCP\Util::addScript('updatenotification', 'notification');
 				OC_Hook::connect('\OCP\Config', 'js', $updateChecker, 'getJavaScript');


### PR DESCRIPTION
* then the notification center already contains this info
* fixes #129

Tests:
* when update available and notifications app enabled: don't show the notification banner
* when update available and notifications app disabled: show the notification banner

With notifications app:

<img width="589" alt="bildschirmfoto 2016-12-21 um 15 24 32" src="https://cloud.githubusercontent.com/assets/245432/21393412/95d0e74a-c794-11e6-87dc-0229415d3297.png">

Without notifications app:

<img width="510" alt="bildschirmfoto 2016-12-21 um 15 46 20" src="https://cloud.githubusercontent.com/assets/245432/21393423/a36fe84c-c794-11e6-8089-78ce7e240327.png">

