### PR TITLE
Testing md5home (#26854)

### DIFF
--- a/apps/testing/appinfo/app.php
+++ b/apps/testing/appinfo/app.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+$app = new \OCA\Testing\Application();
+

--- a/apps/testing/appinfo/info.xml
+++ b/apps/testing/appinfo/info.xml
@@ -9,4 +9,7 @@
 	<dependencies>
 		<nextcloud min-version="12" max-version="12" />
 	</dependencies>
+	<types>
+		<type>prelogin</type>
+	</types>
 </info>

--- a/apps/testing/lib/AlternativeHomeUserBackend.php
+++ b/apps/testing/lib/AlternativeHomeUserBackend.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Testing;
+
+/**
+ * Alternative home user backend.
+ *
+ * It returns a md5 of the home folder instead of the user id.
+ * To configure, need to add this in config.php:
+ *	'user_backends' => [
+ *			'default' => false, [
+ *				'class' => '\\OCA\\Testing\\AlternativeHomeUserBackend',
+ *				'arguments' => [],
+ *			],
+ *	]
+ */
+class AlternativeHomeUserBackend extends \OC\User\Database {
+	public function __construct() {
+		parent::__construct();
+	}
+	/**
+	 * get the user's home directory
+	 * @param string $uid the username
+	 * @return string|false
+	 */
+	public function getHome($uid) {
+		if ($this->userExists($uid)) {
+			// workaround to avoid killing the admin
+			if ($uid !== 'admin') {
+				$uid = md5($uid);
+			}
+			return \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data') . '/' . $uid;
+		}
+
+		return false;
+	}
+}

--- a/apps/testing/lib/Application.php
+++ b/apps/testing/lib/Application.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Testing;
+
+use OCP\AppFramework\App;
+
+class Application extends App {
+	public function __construct (array $urlParams = array()) {
+		parent::__construct('testing', $urlParams);
+	}
+}

--- a/lib/private/legacy/user.php
+++ b/lib/private/legacy/user.php
@@ -125,9 +125,16 @@ class OC_User {
 	 * setup the configured backends in config.php
 	 */
 	public static function setupBackends() {
-		OC_App::loadApps(array('prelogin'));
-		$backends = \OC::$server->getSystemConfig()->getValue('user_backends', array());
+		OC_App::loadApps(['prelogin']);
+		$backends = \OC::$server->getSystemConfig()->getValue('user_backends', []);
+		if (isset($backends['default']) && !$backends['default']) {
+			// clear default backends
+			self::clearBackends();
+		}
 		foreach ($backends as $i => $config) {
+			if (!is_array($config)) {
+				continue;
+			}
 			$class = $config['class'];
 			$arguments = $config['arguments'];
 			if (class_exists($class)) {


### PR DESCRIPTION
* Allow clearing default user backends in config.php

When specifying "user_backends" in config.php, a new option "default"
when set to false will prevent the default user backend to be
registered. The default one is the database backend.
This makes it possible to select exclusive user backends from apps.

* Testing app provides test user backend for alternative homes

The backend provide md5 result to getHome()

* Only md5 the user home when it's not the admin

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>

From https://github.com/owncloud/core/pull/26854