### PR TITLE
Introduce option to display the full path of the node a share originated from to the recipient

### DIFF
--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -54,6 +54,8 @@ class Capabilities implements ICapability {
 		} else {
 			$res['api_enabled'] = true;
 
+			$res['preserve_full_name'] = $this->config->getAppValue('core', 'shareapi_preserve_full_name', 'no') === 'yes';
+
 			$public = [];
 			$public['enabled'] = $this->config->getAppValue('core', 'shareapi_allow_links', 'yes') === 'yes';
 			if ($public['enabled']) {

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -83,6 +83,24 @@ class CapabilitiesTest extends \Test\TestCase {
 		$this->assertNotContains('resharing', $result);
 	}
 
+	public function testPreserveNames() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_preserve_full_name', 'no', 'yes'],
+		];
+		$result = $this->getResults($map);
+		$this->assertTrue($result['preserve_full_name']);
+	}
+
+	public function testNoPreserveNames() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_preserve_full_name', 'no', 'no'],
+		];
+		$result = $this->getResults($map);
+		$this->assertFalse($result['preserve_full_name']);
+	}
+
 	public function testNoLinkSharing() {
 		$map = [
 			['core', 'shareapi_enabled', 'yes', 'yes'],

--- a/build/integration/capabilities_features/capabilities.feature
+++ b/build/integration/capabilities_features/capabilities.feature
@@ -11,6 +11,7 @@ Feature: capabilities
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
 			| files_sharing | api_enabled | 1 |
+			| files_sharing | preserve_full_name | 0 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | 1 |
 			| files_sharing | resharing | 1 |
@@ -31,6 +32,7 @@ Feature: capabilities
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
 			| files_sharing | api_enabled | 1 |
+			| files_sharing | preserve_full_name | 0 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | EMPTY |
 			| files_sharing | resharing | 1 |
@@ -51,6 +53,7 @@ Feature: capabilities
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
 			| files_sharing | api_enabled | EMPTY |
+			| files_sharing | preserve_full_name | EMPTY |
 			| files_sharing | public@@@enabled | EMPTY |
 			| files_sharing | public@@@upload | EMPTY |
 			| files_sharing | resharing | EMPTY |
@@ -70,6 +73,7 @@ Feature: capabilities
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
 			| files_sharing | api_enabled | 1 |
+			| files_sharing | preserve_full_name | 0 |
 			| files_sharing | public@@@enabled | EMPTY |
 			| files_sharing | public@@@upload | EMPTY |
 			| files_sharing | resharing | 1 |
@@ -90,6 +94,7 @@ Feature: capabilities
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
 			| files_sharing | api_enabled | 1 |
+			| files_sharing | preserve_full_name | 0 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | 1 |
 			| files_sharing | resharing | EMPTY |
@@ -110,6 +115,7 @@ Feature: capabilities
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
 			| files_sharing | api_enabled | 1 |
+			| files_sharing | preserve_full_name | 0 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | 1 |
 			| files_sharing | resharing | 1 |
@@ -130,6 +136,7 @@ Feature: capabilities
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
 			| files_sharing | api_enabled | 1 |
+			| files_sharing | preserve_full_name | 0 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | 1 |
 			| files_sharing | resharing | 1 |
@@ -150,6 +157,7 @@ Feature: capabilities
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
 			| files_sharing | api_enabled | 1 |
+			| files_sharing | preserve_full_name | 0 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | 1 |
 			| files_sharing | public@@@password@@@enforced | 1 |
@@ -171,6 +179,7 @@ Feature: capabilities
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
 			| files_sharing | api_enabled | 1 |
+			| files_sharing | preserve_full_name | 0 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | 1 |
 			| files_sharing | public@@@send_mail | 1 |
@@ -192,6 +201,7 @@ Feature: capabilities
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
 			| files_sharing | api_enabled | 1 |
+			| files_sharing | preserve_full_name | 0 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | 1 |
 			| files_sharing | public@@@expire_date@@@enabled | 1 |
@@ -214,6 +224,7 @@ Feature: capabilities
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
 			| files_sharing | api_enabled | 1 |
+			| files_sharing | preserve_full_name | 0 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | 1 |
 			| files_sharing | public@@@expire_date@@@enabled | 1 |
@@ -236,12 +247,34 @@ Feature: capabilities
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
 			| files_sharing | api_enabled | 1 |
+			| files_sharing | preserve_full_name | 0 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | 1 |
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | 1 |
 			| files_sharing | group_sharing         | EMPTY |
+			| files | bigfilechunking | 1 |
+			| files | undelete | 1 |
+			| files | versioning | 1 |
+
+	Scenario: Changing option for preserving full path supported
+		Given As an "admin"
+		And parameter "shareapi_preserve_full_name" of app "core" is set to "no"
+		When sending "GET" to "/cloud/capabilities"
+		Then the HTTP status code should be "200"
+		And fields of capabilities match with
+			| capability | path_to_element | value |
+			| core | pollinterval | 60 |
+			| core | webdav-root | remote.php/webdav |
+			| files_sharing | api_enabled | 1 |
+			| files_sharing | preserve_full_name | 1 |
+			| files_sharing | public@@@enabled | 1 |
+			| files_sharing | public@@@upload | 1 |
+			| files_sharing | resharing | 1 |
+			| files_sharing | federation@@@outgoing | 1 |
+			| files_sharing | federation@@@incoming | 1 |
+			| files_sharing | group_sharing         | 1 |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |

--- a/build/integration/features/bootstrap/CapabilitiesContext.php
+++ b/build/integration/features/bootstrap/CapabilitiesContext.php
@@ -65,6 +65,7 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 	protected function resetAppConfigs() {
 		$this->modifyServerConfig('core', 'shareapi_enabled', 'yes');
 		$this->modifyServerConfig('core', 'shareapi_allow_links', 'yes');
+		$this->modifyServerConfig('core', 'shareapi_preserve_full_name', 'no');
 		$this->modifyServerConfig('core', 'shareapi_allow_public_upload', 'yes');
 		$this->modifyServerConfig('core', 'shareapi_allow_resharing', 'yes');
 		$this->modifyServerConfig('files_sharing', 'outgoing_server2server_share_enabled', 'yes');

--- a/lib/private/Settings/Admin/Sharing.php
+++ b/lib/private/Settings/Admin/Sharing.php
@@ -51,6 +51,7 @@ class Sharing implements ISettings {
 		$parameters = [
 			// Built-In Sharing
 			'allowGroupSharing'               => $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes'),
+			'preserveFullName'                => $this->config->getAppValue('core', 'shareapi_preserve_full_name', 'no'),
 			'allowLinks'                      => $this->config->getAppValue('core', 'shareapi_allow_links', 'yes'),
 			'allowPublicUpload'               => $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes'),
 			'allowResharing'                  => $this->config->getAppValue('core', 'shareapi_allow_resharing', 'yes'),

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -605,7 +605,22 @@ class Manager implements IManager {
 		}
 
 		// Generate the target
-		$target = $this->config->getSystemValue('share_folder', '/') .'/'. $share->getNode()->getName();
+
+		// Should we preserver the full name?
+		if ($this->shareApiPreserveFullName()) {
+			$current_node = $share->getNode();
+			$label = [];
+			do {
+				$label[] = $current_node->getName();
+				$current_node = $current_node->getParent();
+			} while (!empty($current_node->getName()));
+			array_pop($label);
+			array_pop($label);
+			$label = implode(' | ', array_reverse($label));
+			$target = $this->config->getSystemValue('share_folder', '/') . '/' . $label;
+		} else {
+			$target = $this->config->getSystemValue('share_folder', '/') . '/' . $share->getNode()->getName();
+		}
 		$target = \OC\Files\Filesystem::normalizePath($target);
 		$share->setTarget($target);
 
@@ -1209,7 +1224,16 @@ class Manager implements IManager {
 	 * @return bool
 	 */
 	public function shareApiEnabled() {
-		return $this->config->getAppValue('core', 'shareapi_enabled', 'yes') === 'yes';
+		return $this->config->getAppValue('core', 'shareapi_enabled', 'no') === 'yes';
+	}
+
+	/**
+	 * Preserve full path of source node within name of target node
+	 *
+	 * @return bool
+	 */
+	public function shareApiPreserveFullName() {
+		return $this->config->getAppValue('core', 'shareapi_preserve_full_name', 'yes') === 'yes';
 	}
 
 	/**

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1224,7 +1224,7 @@ class Manager implements IManager {
 	 * @return bool
 	 */
 	public function shareApiEnabled() {
-		return $this->config->getAppValue('core', 'shareapi_enabled', 'no') === 'yes';
+		return $this->config->getAppValue('core', 'shareapi_enabled', 'yes') === 'yes';
 	}
 
 	/**
@@ -1233,7 +1233,7 @@ class Manager implements IManager {
 	 * @return bool
 	 */
 	public function shareApiPreserveFullName() {
-		return $this->config->getAppValue('core', 'shareapi_preserve_full_name', 'yes') === 'yes';
+		return $this->config->getAppValue('core', 'shareapi_preserve_full_name', 'no') === 'yes';
 	}
 
 	/**

--- a/settings/templates/admin/sharing.php
+++ b/settings/templates/admin/sharing.php
@@ -37,6 +37,11 @@
 		<label for="shareAPIEnabled"><?php p($l->t('Allow apps to use the Share API'));?></label><br/>
 	</p>
 	<p class="<?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
+		<input type="checkbox" name="shareapi_preserve_full_name" id="preserveFullName" class="checkbox"
+			   value="1" <?php if ($_['preserveFullName'] === 'yes') print_unescaped('checked="checked"'); ?> />
+		<label for="preserveFullName"><?php p($l->t('Preserve full path of source object as name of target share'));?></label><br/>
+	</p>
+	<p class="<?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
 		<input type="checkbox" name="shareapi_allow_links" id="allowLinks" class="checkbox"
 			   value="1" <?php if ($_['allowLinks'] === 'yes') print_unescaped('checked="checked"'); ?> />
 		<label for="allowLinks"><?php p($l->t('Allow users to share via link'));?></label><br/>

--- a/tests/lib/Settings/Admin/SharingTest.php
+++ b/tests/lib/Settings/Admin/SharingTest.php
@@ -104,6 +104,11 @@ class SharingTest extends TestCase {
 			->method('getAppValue')
 			->with('core', 'shareapi_public_link_disclaimertext', null)
 			->willReturn('Lorem ipsum');
+		$this->config
+			->expects($this->at(12))
+			->method('getAppValue')
+			->with('core', 'shareapi_preserve_full_name', 'no')
+			->willReturn('no');
 
 		$expected = new TemplateResponse(
 			'settings',


### PR DESCRIPTION
The default is to use the original node name as the node name for a newly created share. In special cases, this can lead to frustration on the receiving side, because a number of nodes all appear with the exactly same name.

Think about the following structure:

    /Project A
        /Plans (-> shared with Group "Example")
        /…
    /Projekt B
        /Plans (-> shared with Group "Example")
        /…

The group members suddenly find two new folders in their view, both with the name "Plans". Confusing.

For a project we developed a small configuration option, which, when enabled, creates the name of the target nodes as

  * "Project A | Plans"
  * "Project B | Plans"

The option can be switched on and off by administrators. One could also imagine the option to be available on the sharing panel or elsewhere.
We'd be glad to find this feature included in the core. What do others think about it?

Beware: First-time contribution to nextcloud. Please point out flaws, we'll be glad to fix them.