### PR TITLE
create new encryption keys on password reset and backup the old one

### DIFF
--- a/apps/encryption/lib/KeyManager.php
+++ b/apps/encryption/lib/KeyManager.php
@@ -560,11 +560,10 @@ class KeyManager {
 
 	/**
 	 * @param string $purpose
-	 * @param bool $timestamp
-	 * @param bool $includeUserKeys
+	 * @param string $uid
 	 */
-	public function backupAllKeys($purpose, $timestamp = true, $includeUserKeys = true) {
-//		$backupDir = $this->keyStorage->;
+	public function backupUserKeys($purpose, $uid) {
+		$this->keyStorage->backupUserKeys(Encryption::ID, $purpose, $uid);
 	}
 
 	/**
@@ -573,7 +572,6 @@ class KeyManager {
 	 * @param string $uid
 	 */
 	public function deleteUserKeys($uid) {
-		$this->backupAllKeys('password_reset');
 		$this->deletePublicKey($uid);
 		$this->deletePrivateKey($uid);
 	}

--- a/apps/encryption/tests/KeyManagerTest.php
+++ b/apps/encryption/tests/KeyManagerTest.php
@@ -657,4 +657,10 @@ class KeyManagerTest extends TestCase {
 		$this->instance->setVersion('/admin/files/myfile.txt', 5, $view);
 	}
 
+	public function testBackupUserKeys() {
+		$this->keyStorageMock->expects($this->once())->method('backupUserKeys')
+			->with('OC_DEFAULT_MODULE', 'test', 'user1');
+		$this->instance->backupUserKeys('test', 'user1');
+	}
+
 }

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -234,6 +234,8 @@ class LostController extends Controller {
 			$this->checkPasswordResetToken($token, $userId);
 			$user = $this->userManager->get($userId);
 
+			\OC_Hook::emit('\OC\Core\LostPassword\Controller\LostController', 'pre_passwordReset', array('uid' => $userId, 'password' => $password));
+
 			if (!$user->setPassword($password)) {
 				throw new \Exception();
 			}
@@ -242,11 +244,6 @@ class LostController extends Controller {
 
 			$this->config->deleteUserValue($userId, 'core', 'lostpassword');
 			@\OC_User::unsetMagicInCookie();
-		} catch (PrivateKeyMissingException $e) {
-			// in this case it is OK if we couldn't reset the users private key
-			// They chose explicitely to continue at the password reset dialog
-			// (see $proceed flag)
-			return $this->success();
 		} catch (\Exception $e){
 			return $this->error($e->getMessage());
 		}

--- a/core/js/lostpassword.js
+++ b/core/js/lostpassword.js
@@ -4,7 +4,7 @@ OC.Lostpassword = {
 
 	sendSuccessMsg : t('core', 'The link to reset your password has been sent to your email. If you do not receive it within a reasonable amount of time, check your spam/junk folders.<br>If it is not there ask your local administrator.'),
 
-	encryptedMsg : t('core', "Your files are encrypted. If you haven't enabled the recovery key, there will be no way to get your data back after your password is reset.<br />If you are not sure what to do, please contact your administrator before you continue. <br />Do you really want to continue?")
+	encryptedMsg : t('core', "Your files are encrypted. There will be no way to get your data back after your password is reset.<br />If you are not sure what to do, please contact your administrator before you continue. <br />Do you really want to continue?")
 			+ ('<br /><input type="checkbox" id="encrypted-continue" value="Yes" />')
 			+ '<label for="encrypted-continue">'
 			+ t('core', 'I know what I\'m doing')

--- a/lib/private/Encryption/Keys/Storage.php
+++ b/lib/private/Encryption/Keys/Storage.php
@@ -51,6 +51,9 @@ class Storage implements IStorage {
 	/** @var string */
 	private $encryption_base_dir;
 
+	/** @var string */
+	private $backup_base_dir;
+
 	/** @var array */
 	private $keyCache = [];
 
@@ -64,6 +67,7 @@ class Storage implements IStorage {
 
 		$this->encryption_base_dir = '/files_encryption';
 		$this->keys_base_dir = $this->encryption_base_dir .'/keys';
+		$this->backup_base_dir = $this->encryption_base_dir .'/backup';
 		$this->root_dir = $this->util->getKeyStorageRoot();
 	}
 
@@ -284,6 +288,37 @@ class Storage implements IStorage {
 		}
 
 		return false;
+	}
+
+	/**
+	 * backup keys of a given encryption module
+	 *
+	 * @param string $encryptionModuleId
+	 * @param string $purpose
+	 * @param string $uid
+	 * @return bool
+	 * @since 12.0.0
+	 */
+	public function backupUserKeys($encryptionModuleId, $purpose, $uid) {
+		$source = $uid . $this->encryption_base_dir . '/' . $encryptionModuleId;
+		$backupDir = $uid . $this->backup_base_dir;
+		if (!$this->view->file_exists($backupDir)) {
+			$this->view->mkdir($backupDir);
+		}
+
+		$backupDir = $backupDir . '/' . $purpose . '.' . $encryptionModuleId . '.' . $this->getTimestamp();
+		$this->view->mkdir($backupDir);
+
+		return $this->view->copy($source, $backupDir);
+	}
+
+	/**
+	 * get the current timestamp
+	 *
+	 * @return int
+	 */
+	protected function getTimestamp() {
+		return time();
 	}
 
 	/**

--- a/lib/public/Encryption/Keys/IStorage.php
+++ b/lib/public/Encryption/Keys/IStorage.php
@@ -170,4 +170,14 @@ interface IStorage {
 	 */
 	public function copyKeys($source, $target);
 
+	/**
+	 * backup keys of a given encryption module
+	 *
+	 * @param string $encryptionModuleId
+	 * @param string $purpose
+	 * @param string $uid
+	 * @return bool
+	 * @since 12.0.0
+	 */
+	public function backupUserKeys($encryptionModuleId, $purpose, $uid);
 }

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -591,42 +591,4 @@ class LostControllerTest extends \Test\TestCase {
 		$this->assertSame($expectedResponse, $response);
 	}
 
-	public function testSetPasswordEncryptionProceed() {
-
-		/** @var LostController | PHPUnit_Framework_MockObject_MockObject $lostController */
-		$lostController = $this->getMockBuilder(LostController::class)
-			->setConstructorArgs(
-				[
-					'Core',
-					$this->request,
-					$this->urlGenerator,
-					$this->userManager,
-					$this->defaults,
-					$this->l10n,
-					$this->config,
-					$this->secureRandom,
-					'lostpassword-noreply@localhost',
-					$this->encryptionManager,
-					$this->mailer,
-					$this->timeFactory,
-					$this->crypto
-				]
-			)->setMethods(['checkPasswordResetToken'])->getMock();
-
-		$lostController->expects($this->once())->method('checkPasswordResetToken')->willReturn(true);
-
-		$user = $this->createMock(IUser::class);
-		$user->method('setPassword')->willReturnCallback(
-			function() {
-				throw new PrivateKeyMissingException('user');
-			}
-		);
-		$this->userManager->method('get')->with('user')->willReturn($user);
-
-		$response = $lostController->setPassword('myToken', 'user', 'newpass', true);
-
-		$expectedResponse = ['status' => 'success'];
-		$this->assertSame($expectedResponse, $response);
-	}
-
 }


### PR DESCRIPTION
Some improvements how password reset is handled:
We backup the users private/public key and create new one (that's the most common use case)

fix https://github.com/nextcloud/server/issues/2907 
fix https://github.com/nextcloud/server/issues/427
fix https://github.com/nextcloud/server/issues/2908