### PR TITLE
Remove group restrictions when those are not allowed anymore

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -221,6 +221,21 @@ class AppManager implements IAppManager {
 	}
 
 	/**
+	 * Whether a list of types contains a protected app type
+	 *
+	 * @param string[] $types
+	 * @return bool
+	 */
+	public function hasProtectedAppType($types) {
+		if (empty($types)) {
+			return false;
+		}
+
+		$protectedTypes = array_intersect($this->protectedAppTypes, $types);
+		return !empty($protectedTypes);
+	}
+
+	/**
 	 * Enable an app only for specific groups
 	 *
 	 * @param string $appId

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -273,9 +273,17 @@ class OC_App {
 			$appTypes = implode(',', $appData['types']);
 		} else {
 			$appTypes = '';
+			$appData['types'] = [];
 		}
 
 		\OC::$server->getAppConfig()->setValue($app, 'types', $appTypes);
+
+		if (\OC::$server->getAppManager()->hasProtectedAppType($appData['types'])) {
+			$enabled = \OC::$server->getAppConfig()->getValue($app, 'enabled', 'yes');
+			if ($enabled !== 'yes' && $enabled !== 'no') {
+				\OC::$server->getAppConfig()->setValue($app, 'enabled', 'yes');
+			}
+		}
 	}
 
 	/**

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -62,6 +62,15 @@ interface IAppManager {
 	public function enableApp($appId);
 
 	/**
+	 * Whether a list of types contains a protected app type
+	 *
+	 * @param string[] $types
+	 * @return bool
+	 * @since 12.0.0
+	 */
+	public function hasProtectedAppType($types);
+
+	/**
 	 * Enable an app only for specific groups
 	 *
 	 * @param string $appId


### PR DESCRIPTION
Noticed while implementing https://github.com/nextcloud/spreed/pull/203

When an app was restricted to a group and then the app was changed to not allow this anymore, the app was still restricted until it was disabled and re-enabled.