### PR TITLE
Add Sabre Plugin to include a content disposition header for vcard exports

### DIFF
--- a/apps/dav/lib/CardDAV/ContactExportPlugin.php
+++ b/apps/dav/lib/CardDAV/ContactExportPlugin.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DAV\CardDAV;
+
+use Sabre\CardDAV\Card;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Sabre\VObject\Reader;
+
+class ContactExportPlugin extends ServerPlugin {
+
+	/** @var  Server */
+	protected $server;
+
+	/**
+	 * This initializes the plugin.
+	 *
+	 * This function is called by Sabre\DAV\Server, after
+	 * addPlugin is called.
+	 *
+	 * This method should set up the required event subscriptions.
+	 *
+	 * @param Server $server
+	 * @return void
+	 */
+	function initialize(Server $server) {
+		$this->server = $server;
+		$this->server->on('method:GET', [$this, 'httpGet'], 90);
+	}
+
+	/**
+	 * Injects a Content-Disposition header to GET requests on VCard with
+	 * export parameter. The full name of the vcard will be used as filename
+	 * instead of the original one, for usability reasons. If none is present
+	 * a fallback to the original filename is done.
+	 *
+	 * @param RequestInterface $request
+	 * @param ResponseInterface $response
+	 * @return bool|void
+	 */
+	function httpGet(RequestInterface $request, ResponseInterface $response) {
+		$path = $request->getPath();
+		$node = $this->server->tree->getNodeForPath($path);
+		$queryParams = $request->getQueryParameters();
+
+		if (!$node instanceof Card || !array_key_exists('export', $queryParams)) {
+			return;
+		}
+
+		$vCard = Reader::read($node->get());
+		$fn = $vCard->FN;
+		if($fn === null) {
+			return;
+		}
+
+		$filenameUtf8 = trim($fn->getValue());
+		$filename = trim(preg_replace('/[^a-zA-Z0-9-_ ]/um', '', $filenameUtf8));
+
+		if($filename === '' && $filenameUtf8 === '') {
+			return;
+		}
+
+		if($filename === '') {
+			$filename = $node->getName();
+		} else {
+			$filename .= '.vcf';
+		}
+
+		$filenameUtf8 = urlencode($filenameUtf8) . '.vcf';
+
+		$httpHeaders = $this->server->getHTTPHeaders($path);
+		$httpHeaders['Content-Disposition'] =
+			'attachment;' .
+			'filename*=UTF8\'\''.$filenameUtf8.';' .
+			'filename="'.$filename.'"'
+		;
+		$response->addHeaders($httpHeaders);
+	}
+}

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -29,6 +29,7 @@
 namespace OCA\DAV;
 
 use OCA\DAV\CalDAV\Schedule\IMipPlugin;
+use OCA\DAV\CardDAV\ContactExportPlugin;
 use OCA\DAV\CardDAV\ImageExportPlugin;
 use OCA\DAV\Comments\CommentsPlugin;
 use OCA\DAV\Connector\Sabre\Auth;
@@ -134,6 +135,7 @@ class Server {
 		$this->server->addPlugin(new \OCA\DAV\CardDAV\Plugin());
 		$this->server->addPlugin(new VCFExportPlugin());
 		$this->server->addPlugin(new ImageExportPlugin(\OC::$server->getLogger()));
+		$this->server->addPlugin(new ContactExportPlugin());
 
 		// system tags plugins
 		$this->server->addPlugin(new SystemTagPlugin(

--- a/apps/dav/tests/unit/CardDAV/ContactExportPluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/ContactExportPluginTest.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DAV\Tests\unit\CardDAV;
+
+use OCA\DAV\CardDAV\ContactExportPlugin;
+use Sabre\CardDAV\Card;
+use Sabre\DAV\Server;
+use Sabre\DAV\Tree;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Test\TestCase;
+
+class ContactExportPluginTest extends TestCase {
+	/** @var ResponseInterface | \PHPUnit_Framework_MockObject_MockObject */
+	private $response;
+
+	/** @var RequestInterface | \PHPUnit_Framework_MockObject_MockObject */
+	private $request;
+
+	/** @var ContactExportPlugin | \PHPUnit_Framework_MockObject_MockObject */
+	private $plugin;
+
+	/** @var Server | \PHPUnit_Framework_MockObject_MockObject */
+	private $server;
+
+	/** @var Tree | \PHPUnit_Framework_MockObject_MockObject */
+	private $tree;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->request = $this->createMock(RequestInterface::class);
+		$this->response = $this->createMock(ResponseInterface::class);
+		$this->server = $this->createMock(Server::class);
+		$this->tree = $this->createMock(Tree::class);
+		$this->server->tree = $this->tree;
+
+		$this->plugin = new ContactExportPlugin();
+		$this->plugin->initialize($this->server);
+	}
+
+	/**
+	 * @dataProvider providesQueryParams
+	 * @param $param
+	 */
+	public function testQueryParams($param) {
+		$this->request->expects($this->once())
+			->method('getQueryParameters')
+			->willReturn($param);
+
+		$this->response->expects($this->never())
+			->method('addHeaders');
+
+		$result = $this->plugin->httpGet($this->request, $this->response);
+		$this->assertNull($result);
+	}
+
+	public function providesQueryParams() {
+		return [
+			[[]],
+			[['1']],
+			[['foo' => 'bar']],
+		];
+	}
+
+	public function testNotACard() {
+		$this->request->expects($this->once())
+			->method('getQueryParameters')
+			->willReturn(['export' => true]);
+		$this->request->expects($this->once())
+			->method('getPath')
+			->willReturn('/files/welcome.txt');
+
+		$this->tree->expects($this->once())
+			->method('getNodeForPath')
+			->with('/files/welcome.txt')
+			->willReturn(null);
+
+		$this->response->expects($this->never())
+			->method('addHeaders');
+
+		$result = $this->plugin->httpGet($this->request, $this->response);
+		$this->assertNull($result);
+	}
+
+	public function fullNameProvider() {
+		return [
+			[100, 'Joanna Doe', 'Joanna Doe.vcf', 'Joanna+Doe.vcf'],
+			[101, 'MixУп', 'Mix.vcf', 'Mix%D0%A3%D0%BF.vcf'],
+			[110, 'Дшон До', '110.vcf', '%D0%94%D1%88%D0%BE%D0%BD+%D0%94%D0%BE.vcf'],
+			[111, '🙉🙈🙊', '111.vcf', '%F0%9F%99%89%F0%9F%99%88%F0%9F%99%8A.vcf']
+		];
+	}
+
+	/**
+	 * @dataProvider fullNameProvider
+	 *
+	 * @param $fullName
+	 * @param $expectedFilename
+	 * @param $expectedFileNameUtf8
+	 */
+	public function testCard($uuid, $fullName, $expectedFilename, $expectedFileNameUtf8) {
+		$path = '/files/' . $uuid . '.vcf';
+		$expectedContentDisposition =
+			'attachment;' .
+			'filename*=UTF8\'\''.$expectedFileNameUtf8.';' .
+			'filename="'.$expectedFilename.'"'
+		;
+
+		$this->request->expects($this->once())
+			->method('getQueryParameters')
+			->willReturn(['export' => true]);
+		$this->request->expects($this->once())
+			->method('getPath')
+			->willReturn($path);
+
+		$vcard = '
+BEGIN:VCARD
+VERSION:3.0
+FN:'.$fullName.'
+UID:'.$uuid.'
+REV:20170104T133952Z
+END:VCARD'
+		;
+
+		$node = $this->createMock(Card::class);
+		$node->expects($this->once())
+			->method('get')
+			->willReturn($vcard);
+		$node->expects($this->any())
+			->method('getName')
+			->willReturn($uuid . '.vcf');
+
+		$this->tree->expects($this->once())
+			->method('getNodeForPath')
+			->with($path)
+			->willReturn($node);
+
+		$this->server->expects($this->once())
+			->method('getHTTPHeaders')
+			->willReturn([]);
+
+		$this->response->expects($this->once())
+			->method('addHeaders')
+			->with(['Content-Disposition' => $expectedContentDisposition]);
+
+		$this->plugin->httpGet($this->request, $this->response);
+	}
+
+	public function testEmptyCard() {
+		$uuid = '1000';
+		$path = '/files/' . $uuid . '.vcf';
+
+		$this->request->expects($this->once())
+			->method('getQueryParameters')
+			->willReturn(['export' => true]);
+		$this->request->expects($this->once())
+			->method('getPath')
+			->willReturn($path);
+
+		$vcard = '
+BEGIN:VCARD
+VERSION:3.0
+UID:'.$uuid.'
+REV:20170104T133952Z
+END:VCARD'
+		;
+
+		$node = $this->createMock(Card::class);
+		$node->expects($this->once())
+			->method('get')
+			->willReturn($vcard);
+		$node->expects($this->never())
+			->method('getName');
+
+		$this->tree->expects($this->once())
+			->method('getNodeForPath')
+			->with($path)
+			->willReturn($node);
+
+		$this->server->expects($this->never())
+			->method('getHTTPHeaders');
+
+		$this->response->expects($this->never())
+			->method('addHeaders');
+
+		$this->plugin->httpGet($this->request, $this->response);
+	}
+}


### PR DESCRIPTION
refs #2880

Also refs https://github.com/nextcloud/contacts/issues/68

This plugin injects a content disposition header when vcards are requested and a export parameter is set. 

To test this 

1. Enable contacts app
2. Create a contact and refresh the page
3. Inspect the Download arrow and add a ``?export`` to the URL
4. Click the download arrow and compare the resulting file name. If your contact has a "full name" this will be used as file name.

![contact-vcf-export](https://cloud.githubusercontent.com/assets/2184312/21649719/f8adba8c-d2a2-11e6-9127-443af90de06e.png)


Alternatively, you copy the download URL and use it on CLI with, for instance, wget:

```
$ wget --content-disposition -S http://user:pwd@nextcloud.server/remote.php/dav/addressbooks/users/master/default/1f4766bd-5559-4929-a8a7-d6cef2e8d685.vcf?export
…
HTTP request sent, awaiting response...
…
Content-Disposition: attachment; filename*=UTF8''%F0%9F%99%8A%F0%9F%99%89%F0%9F%99%88.vcf; filename="1f4766bd-5559-4929-a8a7-d6cef2e8d685.vcf"
…
Saving to: ‘🙊🙉🙈.vcf’
```

→ Yes, a proper browser (or wget) accepts non-ascii characters, and for others we have a fallback.

I tested with Firefox and Chromium.

@MorrisJobke @skjnldsv @LukasReschke @rullzer 