### PR TITLE
Update mobile.css

### DIFF
--- a/apps/files/css/mobile.css
+++ b/apps/files/css/mobile.css
@@ -58,7 +58,7 @@ table td.filename .nametext {
 
 /* ellipsis on file names */
 table td.filename .nametext .innernametext {
-	max-width: 50%;
+	max-width: calc(100% - 175px);
 }
 
 /* proper notification area for multi line messages */


### PR DESCRIPTION
Changed maxi-width to resolve the file name extension issue if overlapping the share icon when viewed on the mobile device with 320px wide
### The screenshot below is from Google Chrome inspector with 320px width 
![Alt Text](https://s23.postimg.org/nsy7d22dn/Screeshot_01.png)
### The result with the applied changes
![Alt text](https://s23.postimg.org/sqbry64cr/Screesho_02.png)