### PR TITLE
Handle log_type "nextcloud" more gracefully

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -330,18 +330,19 @@ class Log implements ILogger {
 	 * @internal
 	 */
 	public static function getLogClass($logType) {
-		// TODO: Drop backwards compatibility for config in the future
 		switch (strtolower($logType)) {
+			case 'errorlog':
+				return \OC\Log\Errorlog::class;
+			case 'syslog':
+				return \OC\Log\Syslog::class;
+			case 'file':
+				return \OC\Log\File::class;
+
+			// Backwards compatibility for old and fallback for unknown log types
 			case 'owncloud':
 			case 'nextcloud':
-				$logType = 'file';
+			default:
+				return \OC\Log\File::class;
 		}
-		$logClass = 'OC\\Log\\' . ucfirst($logType);
-
-		if (!class_exists($logClass)) {
-			$logClass = \OC\Log\File::class;
-		}
-
-		return $logClass;
 	}
 }

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -106,12 +106,8 @@ class Log implements ILogger {
 
 		// FIXME: Add this for backwards compatibility, should be fixed at some point probably
 		if($logger === null) {
-			// TODO: Drop backwards compatibility for config in the future
 			$logType = $this->config->getValue('log_type', 'file');
-			if($logType==='owncloud') {
-				$logType = 'file';
-			}
-			$this->logger = 'OC\\Log\\'.ucfirst($logType);
+			$this->logger = static::getLogClass($logType);
 			call_user_func(array($this->logger, 'init'));
 		} else {
 			$this->logger = $logger;
@@ -326,5 +322,26 @@ class Log implements ILogger {
 		$msg = isset($context['message']) ? $context['message'] : 'Exception';
 		$msg .= ': ' . json_encode($exception);
 		$this->error($msg, $context);
+	}
+
+	/**
+	 * @param string $logType
+	 * @return string
+	 * @internal
+	 */
+	public static function getLogClass($logType) {
+		// TODO: Drop backwards compatibility for config in the future
+		switch (strtolower($logType)) {
+			case 'owncloud':
+			case 'nextcloud':
+				$logType = 'file';
+		}
+		$logClass = 'OC\\Log\\' . ucfirst($logType);
+
+		if (!class_exists($logClass)) {
+			$logClass = 'OC\\Log\\File';
+		}
+
+		return $logClass;
 	}
 }

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -339,7 +339,7 @@ class Log implements ILogger {
 		$logClass = 'OC\\Log\\' . ucfirst($logType);
 
 		if (!class_exists($logClass)) {
-			$logClass = 'OC\\Log\\File';
+			$logClass = \OC\Log\File::class;
 		}
 
 		return $logClass;

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -418,9 +418,8 @@ class Server extends ServerContainer implements IServerContainer {
 			);
 		});
 		$this->registerService('Logger', function (Server $c) {
-			$logClass = $c->query('AllConfig')->getSystemValue('log_type', 'file');
-			// TODO: Drop backwards compatibility for config in the future
-			$logger = 'OC\\Log\\' . ucfirst($logClass=='owncloud' ? 'file' : $logClass);
+			$logType = $c->query('AllConfig')->getSystemValue('log_type', 'file');
+			$logger = Log::getLogClass($logType);
 			call_user_func(array($logger, 'init'));
 
 			return new Log($logger);

--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -138,4 +138,20 @@ class LoggerTest extends TestCase {
 		}
 	}
 
+	public function dataGetLogClass() {
+		return [
+			['owncloud', \OC\Log\File::class],
+			['nextcloud', \OC\Log\File::class],
+			['file', \OC\Log\File::class],
+			['errorlog', \OC\Log\Errorlog::class],
+			['syslog', \OC\Log\Syslog::class],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetLogClass
+	 */
+	public function testGetLogClass($type, $class) {
+		$this->assertEquals($class, Log::getLogClass($type));
+	}
 }

--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -140,11 +140,13 @@ class LoggerTest extends TestCase {
 
 	public function dataGetLogClass() {
 		return [
-			['owncloud', \OC\Log\File::class],
-			['nextcloud', \OC\Log\File::class],
 			['file', \OC\Log\File::class],
 			['errorlog', \OC\Log\Errorlog::class],
 			['syslog', \OC\Log\Syslog::class],
+
+			['owncloud', \OC\Log\File::class],
+			['nextcloud', \OC\Log\File::class],
+			['foobar', \OC\Log\File::class],
 		];
 	}
 


### PR DESCRIPTION
Fix #2687

Some people seem to have changed the log_type from `owncloud` to `nextcloud`. So this PR also adds fallback handling for `nextcloud`