### PR TITLE
dont write a certificate bundle if the shipped ca bundle is empty

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -482,7 +482,7 @@ class Server extends ServerContainer implements IServerContainer {
 			$uid = $user ? $user : null;
 			return new ClientService(
 				$c->getConfig(),
-				new \OC\Security\CertificateManager($uid, new View(), $c->getConfig())
+				new \OC\Security\CertificateManager($uid, new View(), $c->getConfig(), $c->getLogger())
 			);
 		});
 		$this->registerService('EventLogger', function (Server $c) {
@@ -1220,7 +1220,7 @@ class Server extends ServerContainer implements IServerContainer {
 			}
 			$userId = $user->getUID();
 		}
-		return new CertificateManager($userId, new View(), $this->getConfig());
+		return new CertificateManager($userId, new View(), $this->getConfig(), $this->getLogger());
 	}
 
 	/**

--- a/tests/lib/Security/CertificateManagerTest.php
+++ b/tests/lib/Security/CertificateManagerTest.php
@@ -8,8 +8,10 @@
 
 namespace Test\Security;
 
+use OC\Files\Storage\Temporary;
 use \OC\Security\CertificateManager;
 use OCP\IConfig;
+use OCP\ILogger;
 
 /**
  * Class CertificateManagerTest
@@ -43,7 +45,7 @@ class CertificateManagerTest extends \Test\TestCase {
 		$config->expects($this->any())->method('getSystemValue')
 			->with('installed', false)->willReturn(true);
 
-		$this->certificateManager = new CertificateManager($this->username, new \OC\Files\View(), $config);
+		$this->certificateManager = new CertificateManager($this->username, new \OC\Files\View(), $config, $this->createMock(ILogger::class));
 	}
 
 	protected function tearDown() {
@@ -143,7 +145,7 @@ class CertificateManagerTest extends \Test\TestCase {
 
 		/** @var CertificateManager | \PHPUnit_Framework_MockObject_MockObject $certificateManager */
 		$certificateManager = $this->getMockBuilder('OC\Security\CertificateManager')
-			->setConstructorArgs([$uid, $view, $config])
+			->setConstructorArgs([$uid, $view, $config, $this->createMock(ILogger::class)])
 			->setMethods(['getFilemtimeOfCaBundle', 'getCertificateBundle'])
 			->getMock();
 
@@ -210,5 +212,4 @@ class CertificateManagerTest extends \Test\TestCase {
 			[null, 10, 5, 8, false, true],
 		];
 	}
-
 }


### PR DESCRIPTION
For #2910

Instead of breaking, we log