### PR TITLE
Dont setup the universe to serve some static css files

### DIFF
--- a/core/css.php
+++ b/core/css.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Robin Appelman <robin@icewind.nl>
+ *
+ * @author Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @param string $app
+ * @param string $file
+ * @return bool
+ */
+function serveCachedCss($app, $file) {
+	require __DIR__ . '/../config/config.php';
+
+	$appData = $CONFIG['datadirectory'] . '/appdata_' . $CONFIG['instanceid'];
+	$cssPath = "$appData/css/$app/$file";
+
+	if (file_exists($cssPath)) {
+		$expires = new \DateTime();
+		$expires->setTimestamp(time());
+		$expires->add(new \DateInterval('PT24H'));
+		header('Expires: ' . $expires->format(\DateTime::RFC1123));
+		header('Pragma: cache');
+		header('Cache-Control: max-age=86400, must-revalidate');
+		header("Content-type: text/css");
+		readfile($cssPath);
+		return true;
+	} else {
+		return false;
+	}
+}

--- a/index.php
+++ b/index.php
@@ -33,13 +33,24 @@ if (version_compare(PHP_VERSION, '5.6.0') === -1) {
 	return;
 }
 
+// serving the compiled css is just serving a static file
+// setting up the full universe to just serve a single file is a massive waste of resources
+// so instead we use some basic plain css to serve it
+$requestUri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '';
+if (preg_match('%css/([^/]+)/([^/]+.css)%', $requestUri, $matches)) {
+	require 'core/css.php';
+	if (serveCachedCss($matches[1], $matches[2])) {
+		exit;
+	}
+}
+
 try {
 
 	require_once __DIR__ . '/lib/base.php';
 
 	OC::handleRequest();
 
-} catch(\OC\ServiceUnavailableException $ex) {
+} catch (\OC\ServiceUnavailableException $ex) {
 	\OC::$server->getLogger()->logException($ex, array('app' => 'index'));
 
 	//show the user a detailed error page


### PR DESCRIPTION
Spending ~70ms to serve a css file seems like a bad idea if we need over a dozen of css files for every page load.

Spending ~200µs per file sounds a lot better so lets add some ugly hacks to bypass the universe and just serve the god damm files
