### PR TITLE
Default cache value for null user

### DIFF
--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -75,6 +75,7 @@ class Database extends Backend implements IUserBackend {
 	 */
 	public function __construct($eventDispatcher = null) {
 		$this->cache = new CappedMemoryCache();
+		$this->cache[null] = false;
 		$this->eventDispatcher = $eventDispatcher ? $eventDispatcher : \OC::$server->getEventDispatcher();
 	}
 


### PR DESCRIPTION
For guest users on every request executes query:

```sql
SELECT `uid`, `displayname` FROM `users` WHERE LOWER(`uid`) = LOWER(null)
```
as I see, uid can't be equal to null by design.