### PR TITLE
set 'no-store' cache header if we do not want FF to cache

### DIFF
--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -43,11 +43,11 @@ use OCP\AppFramework\Http;
 class Response {
 
 	/**
-	 * Headers - defaults to ['Cache-Control' => 'no-cache, must-revalidate']
+	 * Headers - defaults to ['Cache-Control' => 'no-cache, no-store, must-revalidate']
 	 * @var array
 	 */
 	private $headers = array(
-		'Cache-Control' => 'no-cache, must-revalidate'
+		'Cache-Control' => 'no-cache, no-store, must-revalidate'
 	);
 
 

--- a/tests/lib/AppFramework/Controller/ControllerTest.php
+++ b/tests/lib/AppFramework/Controller/ControllerTest.php
@@ -182,7 +182,7 @@ class ControllerTest extends \Test\TestCase {
 	public function testFormatDataResponseJSON() {
 		$expectedHeaders = [
 			'test' => 'something',
-			'Cache-Control' => 'no-cache, must-revalidate',
+			'Cache-Control' => 'no-cache, no-store, must-revalidate',
 			'Content-Type' => 'application/json; charset=utf-8',
 			'Content-Security-Policy' => "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'",
 		];

--- a/tests/lib/AppFramework/Http/DataResponseTest.php
+++ b/tests/lib/AppFramework/Http/DataResponseTest.php
@@ -67,7 +67,7 @@ class DataResponseTest extends \Test\TestCase {
 		$response = new DataResponse($data, $code, $headers);
 
 		$expectedHeaders = [
-			'Cache-Control' => 'no-cache, must-revalidate',
+			'Cache-Control' => 'no-cache, no-store, must-revalidate',
 			'Content-Security-Policy' => "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'",
 		];
 		$expectedHeaders = array_merge($expectedHeaders, $headers);

--- a/tests/lib/AppFramework/Http/ResponseTest.php
+++ b/tests/lib/AppFramework/Http/ResponseTest.php
@@ -97,7 +97,7 @@ class ResponseTest extends \Test\TestCase {
 
 	public function testCacheHeadersAreDisabledByDefault(){
 		$headers = $this->childResponse->getHeaders();
-		$this->assertEquals('no-cache, must-revalidate', $headers['Cache-Control']);
+		$this->assertEquals('no-cache, no-store, must-revalidate', $headers['Cache-Control']);
 	}
 
 


### PR DESCRIPTION
I noticed that FF often restores tabs either after closing the whole browser or a single tab and going back with (ctrl+shift+t). Those pages loaded faster, but could also lead to unexpected errors in single page apps like Mail because the complete browser state is saved. In fact, I even saw that FF caches ajax requests/responses in its bfcache which is totally weird IMO.
We even set 'no-store' already, but only if someone calls 'cacheFor(0)', so this was kind of incosistent https://github.com/nextcloud/server/blob/fe6416072d417b6ef166695008d9f94f07775dc9/lib/public/AppFramework/Http/Response.php#L86-L101


ref http://stackoverflow.com/questions/1195440/ajax-back-button-and-dom-updates/1195934#1195934 https://developer.mozilla.org/en-US/Firefox/Releases/1.5/Using_Firefox_1.5_caching http://stackoverflow.com/questions/866822/why-both-no-cache-and-no-store-should-be-used-in-http-response

cc @jancborchardt @Gomez maybe you guys have experienced this too