### PR TITLE
Show apps in header

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -547,7 +547,8 @@ nav {
 		display: block;
 	}
 	&.menu-open li:hover a:before,
-	&.menu-open li a.active:before {
+	&.menu-open li a.active:before,
+	&.menu-open li:hover span {
 		display: none !important;
 	}
 
@@ -563,7 +564,7 @@ nav {
 }
 
 /* use popover menu on mobile and small screens */
-@media only screen and (max-width: 768px) {
+@media only screen and (max-width: 600px) {
 
 	#header .header-appname-container {
 		display: inline-block !important;

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -192,9 +192,13 @@
 }
 
 /* NAVIGATION --------------------------------------------------------------- */
+nav {
+	margin-top: auto;
+}
+
 #navigation {
 	position: relative;
-	top: 69px;
+	top: 45px;
 	left: -100%;
 	width: 265px;
 	max-height: 85%;
@@ -538,7 +542,7 @@
 		border-width: 10px;
 		transform: translateX(-50%);
 		left: 50%;
-		top: 14px;
+		top: 12px;
 		z-index: 100;
 		display: block;
 	}

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -349,6 +349,9 @@
 #apps {
 	max-height: calc(100vh - 100px);
 	overflow: auto;
+	.in-header {
+		display: none;
+	}
 }
 
 /* USER MENU -----------------------------------------------------------------*/
@@ -553,9 +556,15 @@
     position: absolute;
     pointer-events: none;
     border-bottom-color: white;
-    border-width: 8px;
+    border-width: 10px;
     transform: translateX(-50%);
     left: 50%;
-	top: 17px;
+	top: 14px;
     z-index: 100;
+	display: block;
+}
+
+// do not show active indicator when hovering other icons
+#appmenu:hover li:not(:hover) a:before {
+	display:none;
 }

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -113,6 +113,7 @@
 		padding-top: 22px;
 		padding-right: 10px;
 		flex-shrink: 0;
+		display: none !important;
 	}
 	/* show caret indicator next to logo to make clear it is tappable */
 	.icon-caret {
@@ -181,7 +182,7 @@
 	font-size: 16px;
 	font-weight: 300;
 	margin: 0;
-	margin-top: -27px;
+	margin-top: -26px;
 	padding: 7px 0 7px 5px;
 	vertical-align: middle;
 }
@@ -212,7 +213,48 @@
 	z-index: 2000;
 	&:after {
 		left: 47%;
+		bottom: 100%;
+		border: solid transparent;
+		content: ' ';
+		height: 0;
+		width: 0;
+		position: absolute;
+		pointer-events: none;
+		border-color: rgba(0, 0, 0, 0);
+		border-bottom-color: rgba(255, 255, 255, 0.97);
+		border-width: 9px;
+		margin-left: -9px;
 	}
+}
+
+/* arrow look */
+
+#expanddiv:after {
+	bottom: 100%;
+	border: solid transparent;
+	content: ' ';
+	height: 0;
+	width: 0;
+	position: absolute;
+	pointer-events: none;
+	border-color: rgba(0, 0, 0, 0);
+	border-bottom-color: rgba(255, 255, 255, 0.97);
+	border-width: 10px;
+	margin-left: -10px;
+}
+
+/* position of dropdown arrow */
+
+#navigation:after {
+	left: 214px;
+}
+
+#expanddiv:after {
+	right: 15px;
+}
+
+#navigation {
+	box-sizing: border-box;
 	* {
 		box-sizing: border-box;
 	}
@@ -404,4 +446,116 @@
 			opacity: 1;
 		}
 	}
+}
+
+/* do not show display name when profile picture is present */
+
+#header {
+	.avatardiv.avatardiv-shown + #expandDisplayName {
+		display: none;
+	}
+	#expand {
+		display: block;
+	}
+}
+
+#appmenu {
+	display: inline-block;
+	width: auto;
+	clear: both;
+	height: 44px;
+}
+
+#appmenu ul {
+}
+
+#appmenu li {
+	float: left;
+	display: inline-block;
+	vertical-align: top !important;
+    height: 20px;
+	padding: 12px;
+}
+
+#appmenu li a {
+	opacity: 0.6;
+	margin: 0;
+	text-align: center;
+	vertical-align: top !important;
+    position: relative;
+	height: 44px;
+}
+
+#appmenu li:hover a,
+#appmenu li a.active {
+	opacity: 1;
+}
+
+#appmenu li img,
+#appmenu .icon-more-white {
+	display: inline-block;
+	width: 20px;
+	height: 20px;
+}
+
+#appmenu li span {
+	display: none;
+	position: absolute;
+	overflow: visible;
+	left: 0;
+	background-color: #FFF;
+	border: 1px solid #000;
+	color: #000;
+}
+
+#appmenu li:hover a {
+	position: relative
+}
+
+#appmenu li:hover span {
+	display: inline-block;
+	white-space: nowrap;
+	position: absolute;
+}
+
+#appmenu li:hover span {
+	background-color: white;
+	-webkit-border-radius: 3px;
+	-moz-border-radius: 3px;
+	border-radius: 3px;
+	border-top-left-radius: 0;
+	border-top-right-radius: 0;
+	margin-top: 0;
+	border: none;
+	color: #333;
+	width: auto;
+	left: 50%;
+	top: 31px;
+	transform: translateX(-50%);
+	padding: 2px 10px;
+	-webkit-filter: drop-shadow(0 0 5px rgba(150, 150, 150, 0.75));
+	-moz-filter: drop-shadow(0 0 5px rgba(150, 150, 150, 0.75));
+	-ms-filter: drop-shadow(0 0 5px rgba(150, 150, 150, 0.75));
+	-o-filter: drop-shadow(0 0 5px rgba(150, 150, 150, 0.75));
+	filter: drop-shadow(0 0 5px rgba(150, 150, 150, 0.75));
+}
+
+#appmenu li:hover span {
+	display: block;
+}
+
+#appmenu li:hover a:before,
+#appmenu li a.active:before {
+    content: " ";
+    border: solid transparent;
+    height: 0;
+    width: 0;
+    position: absolute;
+    pointer-events: none;
+    border-bottom-color: white;
+    border-width: 8px;
+    transform: translateX(-50%);
+    left: 50%;
+	top: 17px;
+    z-index: 100;
 }

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -175,6 +175,7 @@
 
 /* show appname next to logo */
 .header-appname {
+	display: inline-block;
 	position: relative;
 	color: #fff;
 	font-size: 16px;
@@ -184,8 +185,6 @@
 	padding: 7px 0 7px 5px;
 	vertical-align: middle;
 }
-
-
 
 /* do not show menu toggle on public share links as there is no menu */
 #body-public #header .icon-caret {
@@ -201,8 +200,8 @@
 	max-height: 85%;
 	margin-top: 0;
 	padding-bottom: 10px;
-	background-color: rgba(255, 255, 255, 0.97);
-	box-shadow: 0 1px 10px rgba(150, 150, 150, 0.75);
+	background-color: rgba(255, 255, 255, .97);
+	box-shadow: 0 1px 10px rgba(150, 150, 150, .75);
 	border-radius: 3px;
 	border-top-left-radius: 0;
 	border-top-right-radius: 0;
@@ -219,7 +218,7 @@
 		position: absolute;
 		pointer-events: none;
 		border-color: rgba(0, 0, 0, 0);
-		border-bottom-color: rgba(255, 255, 255, 0.97);
+		border-bottom-color: rgba(255, 255, 255, .97);
 		border-width: 9px;
 		margin-left: -9px;
 	}
@@ -236,7 +235,7 @@
 	position: absolute;
 	pointer-events: none;
 	border-color: rgba(0, 0, 0, 0);
-	border-bottom-color: rgba(255, 255, 255, 0.97);
+	border-bottom-color: rgba(255, 255, 255, .97);
 	border-width: 10px;
 	margin-left: -10px;
 }
@@ -418,7 +417,7 @@
 	z-index: 2000;
 	display: none;
 	background: rgb(255, 255, 255);
-	box-shadow: 0 1px 10px rgba(150, 150, 150, 0.75);
+	box-shadow: 0 1px 10px rgba(150, 150, 150, .75);
 	border-radius: 3px;
 	border-top-left-radius: 0;
 	border-top-right-radius: 0;
@@ -465,129 +464,118 @@
 	width: auto;
 	clear: both;
 	height: 44px;
+
+	li {
+		float: left;
+		display: inline-block;
+		vertical-align: top !important;
+		height: 20px;
+		padding: 12px;
+
+		a {
+			opacity: 0.6;
+			margin: 0;
+			text-align: center;
+			vertical-align: top !important;
+			position: relative;
+			height: 44px;
+		}
+	}
+
+	li:hover a,
+	li a.active {
+		opacity: 1;
+
+	}
+
+	li img,
+	.icon-more-white {
+		display: inline-block;
+		width: 20px;
+		height: 20px;
+	}
+
+	li span {
+		display: none;
+		position: absolute;
+		overflow: visible;
+		background-color: rgba(255, 255, 255, .97);
+		white-space: nowrap;
+		border: none;
+		-webkit-border-radius: 3px;
+		-moz-border-radius: 3px;
+		border-radius: 3px;
+		border-top-left-radius: 0;
+		border-top-right-radius: 0;
+		margin-top: 0;
+		color: rgba(0, 0, 0, .6);
+		width: auto;
+		left: 50%;
+		top: 31px;
+		transform: translateX(-50%);
+		padding: 4px 10px;
+		-webkit-filter: drop-shadow(0 0 5px rgba(150, 150, 150, .75));
+		-moz-filter: drop-shadow(0 0 5px rgba(150, 150, 150, .75));
+		-ms-filter: drop-shadow(0 0 5px rgba(150, 150, 150, .75));
+		-o-filter: drop-shadow(0 0 5px rgba(150, 150, 150, .75));
+		filter: drop-shadow(0 0 5px rgba(150, 150, 150, .75));
+	}
+
+	li:hover span {
+		display: inline-block;
+	}
+
+
+	li:hover a:before,
+	li a.active:before {
+		content: ' ';
+		height: 0;
+		width: 0;
+		position: absolute;
+		pointer-events: none;
+		border: 0 solid transparent;
+		border-bottom-color: white;
+		border-width: 10px;
+		transform: translateX(-50%);
+		left: 50%;
+		top: 14px;
+		z-index: 100;
+		display: block;
+	}
+	&.menu-open li:hover a:before,
+	&.menu-open li a.active:before {
+		display: none !important;
+	}
+
+	/* do not show active indicator when hovering other icons */
+	&:hover li:not(:hover) a:before {
+		display: none;
+	}
+
 }
 
-#appmenu ul {
-}
-
-#appmenu li {
-	float: left;
-	display: inline-block;
-	vertical-align: top !important;
-    height: 20px;
-	padding: 12px;
-}
-
-#appmenu li a {
-	opacity: 0.6;
-	margin: 0;
-	text-align: center;
-	vertical-align: top !important;
-    position: relative;
-	height: 44px;
-}
-
-#appmenu li:hover a,
-#appmenu li a.active {
-	opacity: 1;
-}
-
-#appmenu li img,
-#appmenu .icon-more-white {
-	display: inline-block;
-	width: 20px;
-	height: 20px;
-}
-
-#appmenu li span {
-	display: none;
-	position: absolute;
-	overflow: visible;
-	left: 0;
-	background-color: #FFF;
-	border: 1px solid #000;
-	color: #000;
-}
-
-#appmenu li:hover a {
-	position: relative
-}
-
-#appmenu li:hover span {
-	display: inline-block;
-	white-space: nowrap;
-	position: absolute;
-}
-
-#appmenu li:hover span {
-	background-color: white;
-	-webkit-border-radius: 3px;
-	-moz-border-radius: 3px;
-	border-radius: 3px;
-	border-top-left-radius: 0;
-	border-top-right-radius: 0;
-	margin-top: 0;
-	border: none;
-	color: #333;
-	width: auto;
-	left: 50%;
-	top: 31px;
-	transform: translateX(-50%);
-	padding: 2px 10px;
-	-webkit-filter: drop-shadow(0 0 5px rgba(150, 150, 150, 0.75));
-	-moz-filter: drop-shadow(0 0 5px rgba(150, 150, 150, 0.75));
-	-ms-filter: drop-shadow(0 0 5px rgba(150, 150, 150, 0.75));
-	-o-filter: drop-shadow(0 0 5px rgba(150, 150, 150, 0.75));
-	filter: drop-shadow(0 0 5px rgba(150, 150, 150, 0.75));
-}
-
-#appmenu li:hover span {
-	display: block;
-}
-
-#appmenu li:hover a:before,
-#appmenu li a.active:before {
-    content: " ";
-    border: solid transparent;
-    height: 0;
-    width: 0;
-    position: absolute;
-    pointer-events: none;
-    border-bottom-color: white;
-    border-width: 10px;
-    transform: translateX(-50%);
-    left: 50%;
-	top: 14px;
-    z-index: 100;
-	display: block;
-}
-
-// do not show active indicator when hovering other icons
-#appmenu:hover li:not(:hover) a:before {
-	display:none;
-}
+/* use popover menu on mobile and small screens */
 @media only screen and (max-width: 768px) {
 
 	#header .header-appname-container {
 		display: inline-block !important;
 	}
+
 	#appmenu {
 		display: none;
 	}
 
-	#apps {
-		.in-header {
-			display: inline-block;
-		}
+	#apps .in-header {
+		display: inline-block;
 	}
 
 	#navigation {
 		position: fixed;
 		top: 45px;
 		left: 10px;
-	}
-	#navigation:after {
-		left: 214px;
+		&:after {
+			left: 214px;
+		}
 	}
 
 }

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -556,6 +556,10 @@ nav {
 		display: none;
 	}
 
+	li.hidden {
+		display: none;
+	}
+
 }
 
 /* use popover menu on mobile and small screens */

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -109,11 +109,10 @@
 		height: 34px;
 	}
 	.header-appname-container {
-		display: inline-block;
+		display: none;
 		padding-top: 22px;
 		padding-right: 10px;
 		flex-shrink: 0;
-		display: none !important;
 	}
 	/* show caret indicator next to logo to make clear it is tappable */
 	.icon-caret {
@@ -176,7 +175,6 @@
 
 /* show appname next to logo */
 .header-appname {
-	display: inline-block;
 	position: relative;
 	color: #fff;
 	font-size: 16px;
@@ -196,9 +194,9 @@
 
 /* NAVIGATION --------------------------------------------------------------- */
 #navigation {
-	position: fixed;
-	top: 45px;
-	left: 10px;
+	position: relative;
+	top: 69px;
+	left: -100%;
 	width: 265px;
 	max-height: 85%;
 	margin-top: 0;
@@ -246,7 +244,7 @@
 /* position of dropdown arrow */
 
 #navigation:after {
-	left: 214px;
+	left: 242px;
 }
 
 #expanddiv:after {
@@ -567,4 +565,29 @@
 // do not show active indicator when hovering other icons
 #appmenu:hover li:not(:hover) a:before {
 	display:none;
+}
+@media only screen and (max-width: 768px) {
+
+	#header .header-appname-container {
+		display: inline-block !important;
+	}
+	#appmenu {
+		display: none;
+	}
+
+	#apps {
+		.in-header {
+			display: inline-block;
+		}
+	}
+
+	#navigation {
+		position: fixed;
+		top: 45px;
+		left: 10px;
+	}
+	#navigation:after {
+		left: 214px;
+	}
+
 }

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1369,8 +1369,11 @@ function initCore() {
 	 * If the screen is bigger, the main menu is not a toggle any more.
 	 */
 	function setupMainMenu() {
+
+    // init the more-apps menu
+    OC.registerMenu($('#more-apps'), $('#navigation'));
 		// toggle the navigation
-		var $toggle = $('#more-apps');
+		var $toggle = $('#header .header-appname-container');
 		var $navigation = $('#navigation');
 
 		// init the menu

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1370,8 +1370,9 @@ function initCore() {
 	 */
 	function setupMainMenu() {
 
-    // init the more-apps menu
-    OC.registerMenu($('#more-apps'), $('#navigation'));
+		// init the more-apps menu
+		OC.registerMenu($('#more-apps'), $('#navigation'));
+
 		// toggle the navigation
 		var $toggle = $('#header .header-appname-container');
 		var $navigation = $('#navigation');
@@ -1441,13 +1442,20 @@ function initCore() {
 	// move triangle of apps dropdown to align with app name triangle
 	// 2 is the additional offset between the triangles
 	if($('#navigation').length) {
-		$('#header #nextcloud + .menutoggle').one('click', function(){
-			var caretPosition = $('#more-apps').offset().left - 2;
+		$('#header #nextcloud + .menutoggle').on('click', function(){
+			$('#menu-css-helper').remove();
+			var caretPosition = $('.header-appname + .icon-caret').offset().left - 2;
 			if(caretPosition > 255) {
 				// if the app name is longer than the menu, just put the triangle in the middle
 				return;
 			} else {
-				$('head').append('<style>#navigation:after { left: '+ caretPosition +'px; }</style>');
+				$('head').append('<style id="menu-css-helper">#navigation:after { left: '+ caretPosition +'px; }</style>');
+			}
+		});
+		$('#header #appmenu .menutoggle').on('click', function() {
+			$('#appmenu').toggleClass('menu-open');
+			if($('#appmenu').is(':visible')) {
+				$('#menu-css-helper').remove();
 			}
 		});
 	}

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1370,7 +1370,7 @@ function initCore() {
 	 */
 	function setupMainMenu() {
 		// toggle the navigation
-		var $toggle = $('#header .header-appname-container');
+		var $toggle = $('#more-apps');
 		var $navigation = $('#navigation');
 
 		// init the menu
@@ -1439,7 +1439,7 @@ function initCore() {
 	// 2 is the additional offset between the triangles
 	if($('#navigation').length) {
 		$('#header #nextcloud + .menutoggle').one('click', function(){
-			var caretPosition = $('.header-appname + .icon-caret').offset().left - 2;
+			var caretPosition = $('#more-apps').offset().left - 2;
 			if(caretPosition > 255) {
 				// if the app name is longer than the menu, just put the triangle in the middle
 				return;

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -85,8 +85,9 @@
 							</li>
 							<?php
 							/* show "More apps" link to app administration directly in app navigation, as last entry */
+							if(OC_User::isAdminUser(OC_User::getUser())):
 							?>
-								<li id="apps-management" <?php if(OC_User::isAdminUser(OC_User::getUser()) && count($_['navigation'])>$headerIconCount-1): ?>class="hidden"<?php endif; ?>>
+								<li id="apps-management" <?php if(count($_['navigation'])>$headerIconCount-1): ?>class="hidden"<?php endif; ?>>
 									<a href="<?php print_unescaped(\OC::$server->getURLGenerator()->linkToRoute('settings.AppSettings.viewApps')); ?>" tabindex="4"
 										<?php if( $_['appsmanagement_active'] ): ?> class="active"<?php endif; ?>>
 										<img src="<?php print_unescaped(image_path('settings', 'apps.svg') . '?v=' . $_['versionHash']); ?>" />
@@ -97,6 +98,7 @@
 							</span>
 									</a>
 								</li>
+						<?php endif; ?>
 					</ul>
 				</div>
 

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -74,22 +74,19 @@
 								</a>
 							</li>
 						<?php endforeach; ?>
-						<?php if (count($_['navigation'])>$headerIconCount
-							|| (OC_User::isAdminUser(OC_User::getUser()) && count($_['navigation'])>=$headerIconCount)): ?>
-							<li id="more-apps" class="menutoggle">
+							<li id="more-apps" class="menutoggle<?php
+							if ( !(count($_['navigation']) > $headerIconCount
+									|| (OC_User::isAdminUser(OC_User::getUser()) && count($_['navigation'])>=$headerIconCount))): ?> hidden<?php endif; ?>">
 								<a href="#">
 									<div class="icon-more-white"></div>
-									<span>More apps
+									<span><?php p($l->t('More apps')); ?>
 							</span>
 								</a>
 							</li>
-						<?php endif; ?>
-						<?php if (count($_['navigation'])<$headerIconCount): ?>
 							<?php
 							/* show "More apps" link to app administration directly in app navigation, as last entry */
-							if(OC_User::isAdminUser(OC_User::getUser())):
-								?>
-								<li id="apps-management">
+							?>
+								<li id="apps-management" <?php if(OC_User::isAdminUser(OC_User::getUser()) && count($_['navigation'])>$headerIconCount-1): ?>class="hidden"<?php endif; ?>>
 									<a href="<?php print_unescaped(\OC::$server->getURLGenerator()->linkToRoute('settings.AppSettings.viewApps')); ?>" tabindex="4"
 										<?php if( $_['appsmanagement_active'] ): ?> class="active"<?php endif; ?>>
 										<img src="<?php print_unescaped(image_path('settings', 'apps.svg') . '?v=' . $_['versionHash']); ?>" />
@@ -100,8 +97,6 @@
 							</span>
 									</a>
 								</li>
-							<?php endif; ?>
-						<?php endif; ?>
 					</ul>
 				</div>
 

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -74,31 +74,22 @@
 								</a>
 							</li>
 						<?php endforeach; ?>
-							<li id="more-apps" class="menutoggle<?php
-							if ( !(count($_['navigation']) > $headerIconCount
-									|| (OC_User::isAdminUser(OC_User::getUser()) && count($_['navigation'])>=$headerIconCount))): ?> hidden<?php endif; ?>">
+							<li id="more-apps" class="menutoggle<?php if (!(count($_['navigation']) > $headerIconCount || (OC_User::isAdminUser(OC_User::getUser()) && count($_['navigation'])>=$headerIconCount))): ?> hidden<?php endif; ?>">
 								<a href="#">
 									<div class="icon-more-white"></div>
-									<span><?php p($l->t('More apps')); ?>
-							</span>
+									<span><?php p($l->t('More apps')); ?></span>
 								</a>
 							</li>
-							<?php
-							/* show "More apps" link to app administration directly in app navigation, as last entry */
-							if(OC_User::isAdminUser(OC_User::getUser())):
-							?>
+							<?php if(OC_User::isAdminUser(OC_User::getUser())):	?>
 								<li id="apps-management" <?php if(count($_['navigation'])>$headerIconCount-1): ?>class="hidden"<?php endif; ?>>
 									<a href="<?php print_unescaped(\OC::$server->getURLGenerator()->linkToRoute('settings.AppSettings.viewApps')); ?>" tabindex="4"
 										<?php if( $_['appsmanagement_active'] ): ?> class="active"<?php endif; ?>>
 										<img src="<?php print_unescaped(image_path('settings', 'apps.svg') . '?v=' . $_['versionHash']); ?>" />
-										</svg>
 										<div class="icon-loading-dark" style="display:none;"></div>
-										<span>
-								<?php p($l->t('Apps')); ?>
-							</span>
+										<span><?php p($l->t('Apps')); ?></span>
 									</a>
 								</li>
-						<?php endif; ?>
+							<?php endif; ?>
 					</ul>
 				</div>
 

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -61,8 +61,7 @@
 
 				<div id="appmenu">
 					<ul>
-						<?php $navigation = array_slice($_['navigation'], 0, 3); ?>
-						<?php foreach($navigation as $entry): ?>
+						<?php foreach($_['headernavigation'] as $entry): ?>
 							<li data-id="<?php p($entry['id']); ?>">
 								<a href="<?php print_unescaped($entry['href']); ?>" tabindex="3"
 									<?php if( $entry['active'] ): ?> class="active"<?php endif; ?>>
@@ -74,7 +73,7 @@
 								</a>
 							</li>
 						<?php endforeach; ?>
-						<?php if (count($_['navigation'])>3): ?>
+						<?php if (count($_['navigation'])>4): ?>
 							<li id="more-apps" class="menutoggle">
 								<a href="#">
 									<div class="icon-more-white"></div>
@@ -83,7 +82,7 @@
 								</a>
 							</li>
 						<?php endif; ?>
-						<?php if (count($_['navigation'])<=3): ?>
+						<?php if (count($_['navigation'])<=4): ?>
 							<?php
 							/* show "More apps" link to app administration directly in app navigation, as last entry */
 							if(OC_User::isAdminUser(OC_User::getUser())):
@@ -156,21 +155,24 @@
 		<nav role="navigation"><div id="navigation">
 			<div id="apps">
 				<ul>
-					<?php $navigation = array_slice($_['navigation'], 3); ?>
-					<?php foreach($navigation as $entry): ?>
-					<li data-id="<?php p($entry['id']); ?>">
-						<a href="<?php print_unescaped($entry['href']); ?>" tabindex="3"
-							<?php if( $entry['active'] ): ?> class="active"<?php endif; ?>>
-							<svg width="32" height="32" viewBox="0 0 32 32">
-								<defs><filter id="invert"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0"></feColorMatrix></filter></defs>
-								<image x="0" y="0" width="32" height="32" preserveAspectRatio="xMinYMin meet" filter="url(#invert)" xlink:href="<?php print_unescaped($entry['icon'] . '?v=' . $_['versionHash']); ?>"  class="app-icon"></image>
-							</svg>
-							<div class="icon-loading-dark" style="display:none;"></div>
-							<span>
+					<?php foreach($_['navigation'] as $entry): ?>
+						<?php if($entry['showInHeader']): ?>
+							<li data-id="<?php p($entry['id']); ?>" class="in-header">
+						<?php else: ?>
+							<li data-id="<?php p($entry['id']); ?>">
+						<?php endif; ?>
+								<a href="<?php print_unescaped($entry['href']); ?>" tabindex="3"
+									<?php if( $entry['active'] ): ?> class="active"<?php endif; ?>>
+									<svg width="32" height="32" viewBox="0 0 32 32">
+										<defs><filter id="invert"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0"></feColorMatrix></filter></defs>
+										<image x="0" y="0" width="32" height="32" preserveAspectRatio="xMinYMin meet" filter="url(#invert)" xlink:href="<?php print_unescaped($entry['icon'] . '?v=' . $_['versionHash']); ?>"  class="app-icon"></image>
+									</svg>
+									<div class="icon-loading-dark" style="display:none;"></div>
+									<span>
 								<?php p($entry['name']); ?>
 							</span>
-						</a>
-					</li>
+								</a>
+							</li>
 				<?php endforeach; ?>
 				<?php
 					/* show "More apps" link to app administration directly in app navigation, as last entry */

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -61,6 +61,7 @@
 
 				<div id="appmenu">
 					<ul>
+						<?php $headerIconCount = 8; ?>
 						<?php foreach($_['headernavigation'] as $entry): ?>
 							<li data-id="<?php p($entry['id']); ?>">
 								<a href="<?php print_unescaped($entry['href']); ?>" tabindex="3"
@@ -73,7 +74,7 @@
 								</a>
 							</li>
 						<?php endforeach; ?>
-						<?php if (count($_['navigation'])>4): ?>
+						<?php if (count($_['navigation'])>$headerIconCount): ?>
 							<li id="more-apps" class="menutoggle">
 								<a href="#">
 									<div class="icon-more-white"></div>
@@ -82,7 +83,7 @@
 								</a>
 							</li>
 						<?php endif; ?>
-						<?php if (count($_['navigation'])<=4): ?>
+						<?php if (count($_['navigation'])<=$headerIconCount): ?>
 							<?php
 							/* show "More apps" link to app administration directly in app navigation, as last entry */
 							if(OC_User::isAdminUser(OC_User::getUser())):
@@ -102,6 +103,51 @@
 						<?php endif; ?>
 					</ul>
 				</div>
+
+				<nav role="navigation"><div id="navigation">
+						<div id="apps">
+							<ul>
+								<?php foreach($_['navigation'] as $entry): ?>
+									<?php if($entry['showInHeader']): ?>
+										<li data-id="<?php p($entry['id']); ?>" class="in-header">
+									<?php else: ?>
+										<li data-id="<?php p($entry['id']); ?>">
+									<?php endif; ?>
+									<a href="<?php print_unescaped($entry['href']); ?>" tabindex="3"
+										<?php if( $entry['active'] ): ?> class="active"<?php endif; ?>>
+										<svg width="32" height="32" viewBox="0 0 32 32">
+											<defs><filter id="invert"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0"></feColorMatrix></filter></defs>
+											<image x="0" y="0" width="32" height="32" preserveAspectRatio="xMinYMin meet" filter="url(#invert)" xlink:href="<?php print_unescaped($entry['icon'] . '?v=' . $_['versionHash']); ?>"  class="app-icon"></image>
+										</svg>
+										<div class="icon-loading-dark" style="display:none;"></div>
+										<span>
+								<?php p($entry['name']); ?>
+							</span>
+									</a>
+									</li>
+								<?php endforeach; ?>
+								<?php
+								/* show "More apps" link to app administration directly in app navigation, as last entry */
+								if(OC_User::isAdminUser(OC_User::getUser())):
+									?>
+									<li id="apps-management">
+										<a href="<?php print_unescaped(\OC::$server->getURLGenerator()->linkToRoute('settings.AppSettings.viewApps')); ?>" tabindex="4"
+											<?php if( $_['appsmanagement_active'] ): ?> class="active"<?php endif; ?>>
+											<svg width="32" height="32" viewBox="0 0 32 32" class="app-icon">
+												<defs><filter id="invert"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0"></feColorMatrix></filter></defs>
+												<image x="0" y="0" width="32" height="32" preserveAspectRatio="xMinYMin meet" filter="url(#invert)" xlink:href="<?php print_unescaped(image_path('settings', 'apps.svg') . '?v=' . $_['versionHash']); ?>"></image>
+											</svg>
+											<div class="icon-loading-dark" style="display:none;"></div>
+											<span>
+								<?php p($l->t('Apps')); ?>
+							</span>
+										</a>
+									</li>
+								<?php endif; ?>
+
+							</ul>
+						</div>
+					</div></nav>
 
 			</div>
 
@@ -151,51 +197,6 @@
 				</div>
 			</div>
 		</div></header>
-
-		<nav role="navigation"><div id="navigation">
-			<div id="apps">
-				<ul>
-					<?php foreach($_['navigation'] as $entry): ?>
-						<?php if($entry['showInHeader']): ?>
-							<li data-id="<?php p($entry['id']); ?>" class="in-header">
-						<?php else: ?>
-							<li data-id="<?php p($entry['id']); ?>">
-						<?php endif; ?>
-								<a href="<?php print_unescaped($entry['href']); ?>" tabindex="3"
-									<?php if( $entry['active'] ): ?> class="active"<?php endif; ?>>
-									<svg width="32" height="32" viewBox="0 0 32 32">
-										<defs><filter id="invert"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0"></feColorMatrix></filter></defs>
-										<image x="0" y="0" width="32" height="32" preserveAspectRatio="xMinYMin meet" filter="url(#invert)" xlink:href="<?php print_unescaped($entry['icon'] . '?v=' . $_['versionHash']); ?>"  class="app-icon"></image>
-									</svg>
-									<div class="icon-loading-dark" style="display:none;"></div>
-									<span>
-								<?php p($entry['name']); ?>
-							</span>
-								</a>
-							</li>
-				<?php endforeach; ?>
-				<?php
-					/* show "More apps" link to app administration directly in app navigation, as last entry */
-					if(OC_User::isAdminUser(OC_User::getUser())):
-				?>
-					<li id="apps-management">
-						<a href="<?php print_unescaped(\OC::$server->getURLGenerator()->linkToRoute('settings.AppSettings.viewApps')); ?>" tabindex="4"
-							<?php if( $_['appsmanagement_active'] ): ?> class="active"<?php endif; ?>>
-							<svg width="32" height="32" viewBox="0 0 32 32" class="app-icon">
-								<defs><filter id="invert"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0"></feColorMatrix></filter></defs>
-								<image x="0" y="0" width="32" height="32" preserveAspectRatio="xMinYMin meet" filter="url(#invert)" xlink:href="<?php print_unescaped(image_path('settings', 'apps.svg') . '?v=' . $_['versionHash']); ?>"></image>
-							</svg>
-							<div class="icon-loading-dark" style="display:none;"></div>
-							<span>
-								<?php p($l->t('Apps')); ?>
-							</span>
-						</a>
-					</li>
-				<?php endif; ?>
-
-				</ul>
-			</div>
-		</div></nav>
 
 		<div id="sudo-login-background" class="hidden"></div>
 		<form id="sudo-login-form" class="hidden">

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -74,7 +74,8 @@
 								</a>
 							</li>
 						<?php endforeach; ?>
-						<?php if (count($_['navigation'])>$headerIconCount): ?>
+						<?php if (count($_['navigation'])>$headerIconCount
+							|| (OC_User::isAdminUser(OC_User::getUser()) && count($_['navigation'])>=$headerIconCount)): ?>
 							<li id="more-apps" class="menutoggle">
 								<a href="#">
 									<div class="icon-more-white"></div>
@@ -83,7 +84,7 @@
 								</a>
 							</li>
 						<?php endif; ?>
-						<?php if (count($_['navigation'])<=$headerIconCount): ?>
+						<?php if (count($_['navigation'])<$headerIconCount): ?>
 							<?php
 							/* show "More apps" link to app administration directly in app navigation, as last entry */
 							if(OC_User::isAdminUser(OC_User::getUser())):

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -58,9 +58,54 @@
 					</h1>
 					<div class="icon-caret"></div>
 				</a>
+
+				<div id="appmenu">
+					<ul>
+						<?php $navigation = array_slice($_['navigation'], 0, 3); ?>
+						<?php foreach($navigation as $entry): ?>
+							<li data-id="<?php p($entry['id']); ?>">
+								<a href="<?php print_unescaped($entry['href']); ?>" tabindex="3"
+									<?php if( $entry['active'] ): ?> class="active"<?php endif; ?>>
+									<img src="<?php print_unescaped($entry['icon'] . '?v=' . $_['versionHash']); ?>"  class="app-icon" />
+									<div class="icon-loading-dark" style="display:none;"></div>
+									<span>
+								<?php p($entry['name']); ?>
+							</span>
+								</a>
+							</li>
+						<?php endforeach; ?>
+						<?php if (count($_['navigation'])>3): ?>
+							<li id="more-apps" class="menutoggle">
+								<a href="#">
+									<div class="icon-more-white"></div>
+									<span>More apps
+							</span>
+								</a>
+							</li>
+						<?php endif; ?>
+						<?php if (count($_['navigation'])<=3): ?>
+							<?php
+							/* show "More apps" link to app administration directly in app navigation, as last entry */
+							if(OC_User::isAdminUser(OC_User::getUser())):
+								?>
+								<li id="apps-management">
+									<a href="<?php print_unescaped(\OC::$server->getURLGenerator()->linkToRoute('settings.AppSettings.viewApps')); ?>" tabindex="4"
+										<?php if( $_['appsmanagement_active'] ): ?> class="active"<?php endif; ?>>
+										<img src="<?php print_unescaped(image_path('settings', 'apps.svg') . '?v=' . $_['versionHash']); ?>" />
+										</svg>
+										<div class="icon-loading-dark" style="display:none;"></div>
+										<span>
+								<?php p($l->t('Apps')); ?>
+							</span>
+									</a>
+								</li>
+							<?php endif; ?>
+						<?php endif; ?>
+					</ul>
+				</div>
+
 			</div>
 
-			<div id="logo-claim" style="display:none;"><?php p($theme->getLogoClaim()); ?></div>
 			<div id="header-right">
 				<form class="searchbox" action="#" method="post" role="search" novalidate>
 					<label for="searchbox" class="hidden-visually">
@@ -102,6 +147,7 @@
 							</a>
 						</li>
 					</ul>
+
 					</div>
 				</div>
 			</div>
@@ -110,7 +156,8 @@
 		<nav role="navigation"><div id="navigation">
 			<div id="apps">
 				<ul>
-				<?php foreach($_['navigation'] as $entry): ?>
+					<?php $navigation = array_slice($_['navigation'], 3); ?>
+					<?php foreach($navigation as $entry): ?>
 					<li data-id="<?php p($entry['id']); ?>">
 						<a href="<?php print_unescaped($entry['href']); ?>" tabindex="3"
 							<?php if( $entry['active'] ): ?> class="active"<?php endif; ?>>

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -76,6 +76,8 @@ class TemplateLayout extends \OC_Template {
 			$this->assign( 'appid', $appId );
 			$navigation = \OC_App::getNavigation();
 			$this->assign( 'navigation', $navigation);
+			$navigation = \OC_App::getHeaderNavigation();
+			$this->assign( 'headernavigation', $navigation);
 			$settingsNavigation = \OC_App::getSettingsNavigation();
 			$this->assign( 'settingsnavigation', $settingsNavigation);
 			foreach($navigation as $entry) {

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -529,7 +529,7 @@ class OC_App {
 
 	// This is private as well. It simply works, so don't ask for more details
 	private static function proceedNavigation($list) {
-
+		$headerIconCount = 8;
 		usort($list, function($a, $b) {
 			if (isset($a['order']) && isset($b['order'])) {
 				return ($a['order'] < $b['order']) ? -1 : 1;
@@ -540,6 +540,7 @@ class OC_App {
 			}
 		});
 
+		$activeAppIndex = -1;
 		$activeApp = OC::$server->getNavigationManager()->getActiveEntry();
 		foreach ($list as $index => &$navEntry) {
 			if ($navEntry['id'] == $activeApp) {
@@ -551,18 +552,28 @@ class OC_App {
 		}
 		unset($navEntry);
 
+		if($activeAppIndex > ($headerIconCount-1)) {
+			$active = $list[$activeAppIndex];
+			$lastInHeader = $list[$headerIconCount-1];
+			$list[$headerIconCount-1] = $active;
+			$list[$activeAppIndex] = $lastInHeader;
+		}
 
 		foreach ($list as $index => &$navEntry) {
 			$navEntry['showInHeader'] = false;
-			if($index < 4) {
+			if($index < $headerIconCount) {
 				$navEntry['showInHeader'] = true;
 			}
 		}
+
+
 
 		return $list;
 	}
 
 	public static function proceedAppNavigation($entries) {
+		$headerIconCount = 8;
+		$activeAppIndex = -1;
 		$list = self::proceedNavigation($entries);
 
 		$activeApp = OC::$server->getNavigationManager()->getActiveEntry();
@@ -574,13 +585,15 @@ class OC_App {
 				$navEntry['active'] = false;
 			}
 		}
-		$list = array_slice($list, 0, 4);
 		// move active item to last position
-		if($activeAppIndex > 2) {
+		if($activeAppIndex > ($headerIconCount-1)) {
 			$active = $list[$activeAppIndex];
-			unset($list[$activeAppIndex]);
-			array_unshift($list, $active);
+			$lastInHeader = $list[$headerIconCount-1];
+			$list[$headerIconCount-1] = $active;
+			$list[$activeAppIndex] = $lastInHeader;
 		}
+		$list = array_slice($list, 0, $headerIconCount);
+
 		return $list;
 	}
 

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -530,6 +530,9 @@ class OC_App {
 	// This is private as well. It simply works, so don't ask for more details
 	private static function proceedNavigation($list) {
 		$headerIconCount = 8;
+		if(OC_User::isAdminUser(OC_User::getUser())) {
+			$headerIconCount--;
+		}
 		usort($list, function($a, $b) {
 			if (isset($a['order']) && isset($b['order'])) {
 				return ($a['order'] < $b['order']) ? -1 : 1;
@@ -573,6 +576,9 @@ class OC_App {
 
 	public static function proceedAppNavigation($entries) {
 		$headerIconCount = 8;
+		if(OC_User::isAdminUser(OC_User::getUser())) {
+			$headerIconCount--;
+		}
 		$activeAppIndex = -1;
 		$list = self::proceedNavigation($entries);
 

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -530,7 +530,6 @@ class OC_App {
 	// This is private as well. It simply works, so don't ask for more details
 	private static function proceedNavigation($list) {
 
-
 		usort($list, function($a, $b) {
 			if (isset($a['order']) && isset($b['order'])) {
 				return ($a['order'] < $b['order']) ? -1 : 1;
@@ -552,13 +551,36 @@ class OC_App {
 		}
 		unset($navEntry);
 
-		// Move active app to the first position
+
+		foreach ($list as $index => &$navEntry) {
+			$navEntry['showInHeader'] = false;
+			if($index < 4) {
+				$navEntry['showInHeader'] = true;
+			}
+		}
+
+		return $list;
+	}
+
+	public static function proceedAppNavigation($entries) {
+		$list = self::proceedNavigation($entries);
+
+		$activeApp = OC::$server->getNavigationManager()->getActiveEntry();
+		foreach ($list as $index => &$navEntry) {
+			if ($navEntry['id'] == $activeApp) {
+				$navEntry['active'] = true;
+				$activeAppIndex = $index;
+			} else {
+				$navEntry['active'] = false;
+			}
+		}
+		$list = array_slice($list, 0, 4);
+		// move active item to last position
 		if($activeAppIndex > 2) {
 			$active = $list[$activeAppIndex];
 			unset($list[$activeAppIndex]);
 			array_unshift($list, $active);
 		}
-
 		return $list;
 	}
 
@@ -748,6 +770,22 @@ class OC_App {
 	public static function getNavigation() {
 		$entries = OC::$server->getNavigationManager()->getAll();
 		$navigation = self::proceedNavigation($entries);
+		return $navigation;
+	}
+
+	/**
+	 * Returns the navigation inside the header bar
+	 *
+	 * @return array
+	 *
+	 * This function returns an array containing all entries added. The
+	 * entries are sorted by the key 'order' ascending. Additional to the keys
+	 * given for each app the following keys exist:
+	 *   - active: boolean, signals if the user is on this navigation entry
+	 */
+	public static function getHeaderNavigation() {
+		$entries = OC::$server->getNavigationManager()->getAll();
+		$navigation = self::proceedAppNavigation($entries);
 		return $navigation;
 	}
 

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -529,15 +529,7 @@ class OC_App {
 
 	// This is private as well. It simply works, so don't ask for more details
 	private static function proceedNavigation($list) {
-		$activeApp = OC::$server->getNavigationManager()->getActiveEntry();
-		foreach ($list as &$navEntry) {
-			if ($navEntry['id'] == $activeApp) {
-				$navEntry['active'] = true;
-			} else {
-				$navEntry['active'] = false;
-			}
-		}
-		unset($navEntry);
+
 
 		usort($list, function($a, $b) {
 			if (isset($a['order']) && isset($b['order'])) {
@@ -548,6 +540,24 @@ class OC_App {
 				return ($a['name'] < $b['name']) ? -1 : 1;
 			}
 		});
+
+		$activeApp = OC::$server->getNavigationManager()->getActiveEntry();
+		foreach ($list as $index => &$navEntry) {
+			if ($navEntry['id'] == $activeApp) {
+				$navEntry['active'] = true;
+				$activeAppIndex = $index;
+			} else {
+				$navEntry['active'] = false;
+			}
+		}
+		unset($navEntry);
+
+		// Move active app to the first position
+		if($activeAppIndex > 2) {
+			$active = $list[$activeAppIndex];
+			unset($list[$activeAppIndex]);
+			array_unshift($list, $active);
+		}
 
 		return $list;
 	}

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -451,22 +451,38 @@ OC.Settings.Apps = OC.Settings.Apps || {
 
 	rebuildNavigation: function() {
 		$.getJSON(OC.filePath('settings', 'ajax', 'navigationdetect.php')).done(function(response){
-			if(response.status === 'success'){
+			if(response.status === 'success') {
 				var idsToKeep = {};
-				var navEntries=response.nav_entries;
+				var navEntries = response.nav_entries;
 				var container = $('#apps ul');
-				for(var i=0; i< navEntries.length; i++){
+
+				// remove disabled apps
+				for (var i = 0; i < navEntries.length; i++) {
 					var entry = navEntries[i];
 					idsToKeep[entry.id] = true;
+				}
+				container.children('li[data-id]').each(function (index, el) {
+					if (!idsToKeep[$(el).data('id')]) {
+						$(el).remove();
+					}
+				});
+				$('#appmenu ul').children('li[data-id]').each(function (index, el) {
+					if (!idsToKeep[$(el).data('id')]) {
+						$(el).remove();
+					}
+				});
 
-					if(container.children('li[data-id="'+entry.id+'"]').length === 0){
-						var li=$('<li></li>');
+				// add enabled apps to #navigation and #appmenu
+				for (var i = 0; i < navEntries.length; i++) {
+					var entry = navEntries[i];
+					if (container.children('li[data-id="' + entry.id + '"]').length === 0) {
+						var li = $('<li></li>');
 						li.attr('data-id', entry.id);
 						var img = '<svg width="32" height="32" viewBox="0 0 32 32">';
 						img += '<defs><filter id="invert"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0" /></filter></defs>';
 						img += '<image x="0" y="0" width="32" height="32" preserveAspectRatio="xMinYMin meet" filter="url(#invert)" xlink:href="' + entry.icon + '"  class="app-icon" /></svg>';
-						var a=$('<a></a>').attr('href', entry.href);
-						var filename=$('<span></span>');
+						var a = $('<a></a>').attr('href', entry.href);
+						var filename = $('<span></span>');
 						var loading = $('<div class="icon-loading-dark"></div>').css('display', 'none');
 						filename.text(entry.name);
 						a.prepend(filename);
@@ -477,13 +493,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 						// append the new app as last item in the list
 						// which is the "add apps" entry with the id
 						// #apps-management
-						$('#apps-management').before(li);
-
-						// scroll the app navigation down
-						// so the newly added app is seen
-						$('#navigation').animate({
-							scrollTop: $('#navigation').height()
-						}, 'slow');
+						$('#navigation #apps-management').before(li);
 
 						// draw attention to the newly added app entry
 						// by flashing it twice
@@ -493,14 +503,42 @@ OC.Settings.Apps = OC.Settings.Apps || {
 							.animate({opacity: 0.5})
 							.animate({opacity: 1})
 							.animate({opacity: 0.75});
+
+						// do not show apps from #appmenu in #navigation
+						if(i < 7) {
+							$('#navigation li').eq(i).addClass('in-header');
+						}
+
+						// add apps to #appmenu until it is full
+						if ($('#appmenu li').not('.hidden').length < 8) {
+							var li = $('<li></li>');
+							li.attr('data-id', entry.id);
+							var img = '<img src="' + entry.icon + '" class="app-icon">';
+							var a = $('<a></a>').attr('href', entry.href);
+							var filename = $('<span></span>');
+							var loading = $('<div class="icon-loading-dark"></div>').css('display', 'none');
+							filename.text(entry.name);
+							a.prepend(filename);
+							a.prepend(loading);
+							a.prepend(img);
+							li.append(a);
+							$('#appmenu li#more-apps').before(li);
+							li.animate({opacity: 0.5})
+								.animate({opacity: 1})
+								.animate({opacity: 0.5})
+								.animate({opacity: 1})
+								.animate({opacity: 0.75});
+						}
 					}
 				}
 
-				container.children('li[data-id]').each(function(index, el) {
-					if (!idsToKeep[$(el).data('id')]) {
-						$(el).remove();
-					}
-				});
+				if (navEntries.length > 7) {
+					$('#more-apps').show();
+					$('#apps-management').hide();
+				} else {
+					$('#more-apps').hide();
+					$('#apps-management').show();
+				}
 			}
 		});
 	},


### PR DESCRIPTION
This is a experimental implementation of what we've discussed with @jancborchardt @eppfel and @skjnldsv to make apps accessible directly without a popover. See https://github.com/juliushaertl/direct_menu/issues/51

I'm still not totally happy with this, but I guess we should have some discussion so please have a look,  @nextcloud/designers

### Screenshots (updated)

Up to 8 apps:
![2017-03-03-151204_458x97_scrot](https://cloud.githubusercontent.com/assets/3404133/23554074/d8927590-0023-11e7-886d-7c3dc036d122.png)

More than 8 apps:
![2017-03-03-131705_491x96_scrot](https://cloud.githubusercontent.com/assets/3404133/23553987/791f2a18-0023-11e7-8d78-b5d3650bdee1.png)

![2017-03-03-131718_586x153_scrot](https://cloud.githubusercontent.com/assets/3404133/23553991/7dea3b82-0023-11e7-955c-d88bf54e6b1b.png)

![2017-03-03-131727_446x230_scrot](https://cloud.githubusercontent.com/assets/3404133/23553995/828619e0-0023-11e7-8da4-a6b7410bf527.png)

Mobile:
![2017-03-03-151025_342x168_scrot](https://cloud.githubusercontent.com/assets/3404133/23554011/93d17212-0023-11e7-8821-f08ca17984aa.png)


### ToDo

- [x] Show 8 apps in total
- [x] Mobile/small screens
- [x] Cleanup CSS code to make use of scss
- [x] Fix css formating issues
- [x] Fix positioning in mobile view
- [x] Hide popover app names when popover menu is shown
- [x] Fix popover positioning after window resize
- [x] Fix app name position on small window sizes
- [x] Adding apps doesn't work any more
