### PR TITLE
show fewer warnings in karma test runs

### DIFF
--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -243,8 +243,9 @@ module.exports = function(config) {
 
 		proxies: {
 			// prevent warnings for images
-			'/context.html//core/img/': 'http://localhost:9876/base/core/img/',
-			'/context.html//core/css/': 'http://localhost:9876/base/core/css/',
+			'/base/tests/img/': 'http://localhost:9876/base/core/img/',
+			'/base/tests/css/': 'http://localhost:9876/base/core/css/',
+			'/actions/': 'http://localhost:9876/base/core/img/actions/',
 			'/context.html//core/fonts/': 'http://localhost:9876/base/core/fonts/'
 		},
 


### PR DESCRIPTION
# Before
```
10 01 2017 13:52:22.927:WARN [web-server]: 404: /context.html//index.php/apps/files_external/userglobalstorages?testOnly=true
10 01 2017 13:52:22.935:WARN [web-server]: 404: /context.html//index.php/apps/files_external/userstorages
10 01 2017 13:52:22.936:WARN [web-server]: 404: /base/core/fonts/OpenSans-Regular.woff
10 01 2017 13:52:22.937:WARN [web-server]: 404: /base/core/fonts/OpenSans-Light.woff
10 01 2017 13:52:22.938:WARN [web-server]: 404: /base/core/fonts/OpenSans-Semibold.woff
............................................10 01 2017 13:52:23.012:WARN [web-server]: 404: /base/tests/img/actions/caret.svg?v=1
.................................................................10 01 2017 13:52:23.397:WARN [web-server]: 404: /base/tests/img/actions/checkbox-checked.svg
10 01 2017 13:52:23.766:WARN [web-server]: 404: /base/tests/img/actions/more.svg?v=1
10 01 2017 13:52:23.767:WARN [web-server]: 404: /base/tests/img/actions/checkbox.svg
10 01 2017 13:52:23.767:WARN [web-server]: 404: /base/tests/img/actions/clippy.svg?v=2
10 01 2017 13:52:23.768:WARN [web-server]: 404: /base/tests/css/images/ui-bg_highlight-soft_100_eeeeee_1x100.png
..............10 01 2017 13:52:24.226:WARN [web-server]: 404: /base/tests/img/actions/checkbox-checked-disabled.svg
..............10 01 2017 13:52:24.229:WARN [web-server]: 404: /base/tests/img/actions/play-previous.svg?v=1
10 01 2017 13:52:24.229:WARN [web-server]: 404: /base/tests/img/actions/play-next.svg?v=1
10 01 2017 13:52:24.230:WARN [web-server]: 404: /base/tests/css/images/ui-bg_glass_100_f8f8f8_1x400.png
10 01 2017 13:52:24.230:WARN [web-server]: 404: /base/tests/css/images/ui-bg_flat_100_ffffff_40x100.png
............................................................10 01 2017 13:52:24.741:WARN [web-server]: 404: /base/tests/img/actions/checkmark.svg?v=1
10 01 2017 13:52:24.784:WARN [web-server]: 404: /base/tests/img/actions/rename.svg?v=1
10 01 2017 13:52:24.786:WARN [web-server]: 404: /base/tests/img/actions/delete.svg?v=1
10 01 2017 13:52:24.978:WARN [web-server]: 404: /base/tests/img/actions/close.svg?v=1
..................................10 01 2017 13:52:25.187:WARN [web-server]: 404: /base/tests/img/breadcrumb.svg?v=1
10 01 2017 13:52:25.319:WARN [web-server]: 404: /base/tests/img/actions/add.svg?v=1
............10 01 2017 13:52:25.325:WARN [web-server]: 404: /base/tests/img/actions/triangle-n.svg?v=1
10 01 2017 13:52:25.325:WARN [web-server]: 404: /base/tests/img/actions/triangle-s.svg?v=1
10 01 2017 13:52:25.326:WARN [web-server]: 404: /actions/download.svg
............10 01 2017 13:52:25.526:WARN [web-server]: 404: /base/tests/img/actions/details.svg?v=1
.............10 01 2017 13:52:25.846:WARN [web-server]: 404: /actions/download.svg
.............10 01 2017 13:52:25.850:WARN [web-server]: 404: /actions/download.svg
..................10 01 2017 13:52:26.171:WARN [web-server]: 404: /actions/download.svg
10 01 2017 13:52:27.308:WARN [web-server]: 404: /actions/download.svg
................10 01 2017 13:52:29.507:WARN [web-server]: 404: /actions/download.svg
...................................10 01 2017 13:52:31.065:WARN [web-server]: 404: /actions/download.svg
10 01 2017 13:52:31.066:WARN [web-server]: 404: /base/tests/img/actions/star.svg?v=1
................................10 01 2017 13:52:31.905:WARN [web-server]: 404: /actions/download.svg
.............................................10 01 2017 13:52:32.140:WARN [web-server]: 404: /actions/download.svg
............................10 01 2017 13:52:32.532:WARN [web-server]: 404: /base/tests/img/actions/starred.svg?v=1
10 01 2017 13:52:32.533:WARN [web-server]: 404: /base/tests/img/actions/history.svg?v=1
....................................10 01 2017 13:52:32.993:WARN [web-server]: 404: /svg
10 01 2017 13:52:33.328:WARN [web-server]: 404: /base/tests/img/actions/share.svg?v=1
.............10 01 2017 13:52:33.331:WARN [web-server]: 404: /base/tests/img/actions/public.svg?v=1
```
# After
```
10 01 2017 13:49:06.666:WARN [web-server]: 404: /context.html//index.php/apps/files_external/userglobalstorages?testOnly=true
10 01 2017 13:49:06.676:WARN [web-server]: 404: /context.html//index.php/apps/files_external/userstorages
10 01 2017 13:49:06.677:WARN [web-server]: 404: /base/core/fonts/OpenSans-Regular.woff
10 01 2017 13:49:06.678:WARN [web-server]: 404: /base/core/fonts/OpenSans-Light.woff
10 01 2017 13:49:06.678:WARN [web-server]: 404: /base/core/fonts/OpenSans-Semibold.woff
.................................................................10 01 2017 13:49:07.450:WARN [web-server]: 404: /base/core/css/images/ui-bg_highlight-soft_100_eeeeee_1x100.png
..............10 01 2017 13:49:07.896:WARN [web-server]: 404: /base/core/css/images/ui-bg_glass_100_f8f8f8_1x400.png
10 01 2017 13:49:07.899:WARN [web-server]: 404: /base/core/css/images/ui-bg_flat_100_ffffff_40x100.png
.............................................10 01 2017 13:49:15.983:WARN [web-server]: 404: /svg

```