### PR TITLE
Fit federationScopeMenu to guidelines

### DIFF
--- a/settings/js/federationscopemenu.js
+++ b/settings/js/federationscopemenu.js
@@ -37,7 +37,7 @@
 	 */
 	var FederationScopeMenu = OC.Backbone.View.extend({
 		tagName: 'div',
-		className: 'federationScopeMenu popovermenu bubble hidden open menu',
+		className: 'federationScopeMenu popovermenu bubble hidden menu',
 		field: undefined,
 		_scopes: undefined,
 


### PR DESCRIPTION
The open class is needed only when opened.
After #3024 the workarround will not work and the design will have to fit the css guidelines :)