### PR TITLE
Cleanup js tests

### DIFF
--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -967,8 +967,9 @@ describe('Core base tests', function() {
 			fadeOutStub.restore();
 		});
 		it('hides the first notification when calling hide without arguments', function() {
-			var $row1 = OC.Notification.show('One');
+			OC.Notification.show('One');
 			var $row2 = OC.Notification.show('Two');
+			spyOn(console, 'warn');
 
 			var $el = $('#notification');
 			var $rows = $el.find('.row');
@@ -976,6 +977,7 @@ describe('Core base tests', function() {
 
 			OC.Notification.hide();
 
+			expect(console.warn).toHaveBeenCalled();
 			$rows = $el.find('.row');
 			expect($rows.length).toEqual(1);
 			expect($rows.eq(0).is($row2)).toEqual(true);

--- a/core/js/tests/specs/l10nSpec.js
+++ b/core/js/tests/specs/l10nSpec.js
@@ -21,6 +21,7 @@ describe('OC.L10N tests', function() {
 
 	describe('text translation', function() {
 		beforeEach(function() {
+			spyOn(console, 'warn');
 			OC.L10N.register(TEST_APP, {
 				'Hello world!': 'Hallo Welt!',
 				'Hello {name}, the weather is {weather}': 'Hallo {name}, das Wetter ist {weather}',
@@ -78,8 +79,10 @@ describe('OC.L10N tests', function() {
 		}
 
 		it('generates plural for default text when translation does not exist', function() {
+			spyOn(console, 'warn');
 			OC.L10N.register(TEST_APP, {
 			});
+			expect(console.warn).toHaveBeenCalled();
 			expect(
 				n(TEST_APP, 'download %n file', 'download %n files', 0)
 			).toEqual('download 0 files');
@@ -94,10 +97,12 @@ describe('OC.L10N tests', function() {
 			).toEqual('download 1024 files');
 		});
 		it('generates plural with default function when no forms specified', function() {
+			spyOn(console, 'warn');
 			OC.L10N.register(TEST_APP, {
 				'_download %n file_::_download %n files_':
 					['%n Datei herunterladen', '%n Dateien herunterladen']
 			});
+			expect(console.warn).toHaveBeenCalled();
 			checkPlurals();
 		});
 		it('generates plural with generated function when forms is specified', function() {
@@ -150,9 +155,11 @@ describe('OC.L10N tests', function() {
 		it('calls callback if translation already available', function() {
 			var promiseStub = sinon.stub();
 			var callbackStub = sinon.stub();
+			spyOn(console, 'warn');
 			OC.L10N.register(TEST_APP, {
 				'Hello world!': 'Hallo Welt!'
 			});
+			expect(console.warn).toHaveBeenCalled();
 			OC.L10N.load(TEST_APP, callbackStub).then(promiseStub);
 			expect(callbackStub.calledOnce).toEqual(true);
 			expect(promiseStub.calledOnce).toEqual(true);

--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -220,6 +220,7 @@ module.exports = function(config) {
 
 	// serve images to avoid warnings
 	files.push({pattern: 'core/img/**/*', watched: false, included: false, served: true});
+	files.push({pattern: 'core/css/images/*', watched: false, included: false, served: true});
 	
 	// include core CSS
 	files.push({pattern: 'core/css/*.css', watched: true, included: true, served: true});
@@ -248,6 +249,7 @@ module.exports = function(config) {
 			// prevent warnings for images
 			'/base/tests/img/': 'http://localhost:9876/base/core/img/',
 			'/base/tests/css/': 'http://localhost:9876/base/core/css/',
+			'/base/core/css/images/': 'http://localhost:9876/base/core/css/images/',
 			'/actions/': 'http://localhost:9876/base/core/img/actions/',
 			'/base/core/fonts/': 'http://localhost:9876/base/core/fonts/'
 		},
@@ -270,7 +272,7 @@ module.exports = function(config) {
 			reporters: [
 				{ type: 'html' },
 				{ type: 'cobertura' },
-				{ type: 'lcovonly' },
+				{ type: 'lcovonly' }
 			]
 		},
 

--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -225,6 +225,9 @@ module.exports = function(config) {
 	files.push({pattern: 'core/css/*.css', watched: true, included: true, served: true});
 	files.push({pattern: 'tests/css/*.css', watched: true, included: true, served: true});
 
+	// Allow fonts
+	files.push({pattern: 'core/fonts/*', watched: false, included: false, served: true});
+
 	config.set({
 
 		// base path, that will be used to resolve files and exclude
@@ -246,7 +249,7 @@ module.exports = function(config) {
 			'/base/tests/img/': 'http://localhost:9876/base/core/img/',
 			'/base/tests/css/': 'http://localhost:9876/base/core/css/',
 			'/actions/': 'http://localhost:9876/base/core/img/actions/',
-			'/context.html//core/fonts/': 'http://localhost:9876/base/core/fonts/'
+			'/base/core/fonts/': 'http://localhost:9876/base/core/fonts/'
 		},
 
 		// test results reporter to use


### PR DESCRIPTION
This removes some of the warnings. There's still some work to do, but I could not find all the code that triggers the warnings.

# Before
```
PhantomJS 2.1.1 (Linux 0.0.0) LOG: 'JQMIGRATE: Migrate is installed, version 1.4.0'
13 01 2017 11:50:29.460:WARN [web-server]: 404: /context.html//index.php/apps/files_external/userglobalstorages?testOnly=true
13 01 2017 11:50:29.463:WARN [web-server]: 404: /context.html//index.php/apps/files_external/userstorages
13 01 2017 11:50:29.493:WARN [web-server]: 404: /base/core/fonts/OpenSans-Regular.woff
13 01 2017 11:50:29.497:WARN [web-server]: 404: /base/core/fonts/OpenSans-Light.woff
13 01 2017 11:50:29.499:WARN [web-server]: 404: /base/core/fonts/OpenSans-Semibold.woff
................................................................................
..................
WARN: 'Missing argument $row in OC.Notification.hide() call, caller needs to be adjusted to only dismiss its own notification'
...........................................................
WARN: 'Missing plural form in language file'
.
WARN: 'Missing plural form in language file'
.
WARN: 'Missing plural form in language file'
.
WARN: 'Missing plural form in language file'
.
WARN: 'Missing plural form in language file'
.
WARN: 'Missing plural form in language file'
.
WARN: 'Missing plural form in language file'
.
WARN: 'Missing plural form in language file'
.
WARN: 'Missing plural form in language file'
....
WARN: 'Missing plural form in language file'
....................................................................13 01 2017 11:50:31.429:WARN [web-server]: 404: /base/core/css/images/ui-bg_highlight-soft_100_eeeeee_1x100.png
............
..13 01 2017 11:50:32.470:WARN [web-server]: 404: /base/core/css/images/ui-bg_glass_100_f8f8f8_1x400.png
13 01 2017 11:50:32.471:WARN [web-server]: 404: /base/core/css/images/ui-bg_flat_100_ffffff_40x100.png
..............................................................................
......................
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.............
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
...........................
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.............................................................................
WARN: 'Missing argument $row in OC.Notification.hide() call, caller needs to be adjusted to only dismiss its own notification'
................................................................................
................................................................................
.................................................................
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
...
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
...
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
..
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
................
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
..
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
...
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
................................................................................
...................
WARN: 'Missing argument $row in OC.Notification.hide() call, caller needs to be adjusted to only dismiss its own notification'
.
WARN: 'Missing argument $row in OC.Notification.hide() call, caller needs to be adjusted to only dismiss its own notification'
.
WARN: 'Missing argument $row in OC.Notification.hide() call, caller needs to be adjusted to only dismiss its own notification'
.
WARN: 'Missing argument $row in OC.Notification.hide() call, caller needs to be adjusted to only dismiss its own notification'
.
WARN: 'Missing argument $row in OC.Notification.hide() call, caller needs to be adjusted to only dismiss its own notification'
..
WARN: 'Missing argument $row in OC.Notification.hide() call, caller needs to be adjusted to only dismiss its own notification'
.
WARN: 'Missing argument $row in OC.Notification.hide() call, caller needs to be adjusted to only dismiss its own notification'
.
PhantomJS 2.1.1 (Linux 0.0.0): Executed 840 of 842 (skipped 2) SUCCESS (33.094 secs / 31.627 secs)
```
# After
```
PhantomJS 2.1.1 (Linux 0.0.0) LOG: 'JQMIGRATE: Migrate is installed, version 1.4.0'
13 01 2017 11:51:38.700:WARN [web-server]: 404: /context.html//index.php/apps/files_external/userglobalstorages?testOnly=true
13 01 2017 11:51:38.730:WARN [web-server]: 404: /context.html//index.php/apps/files_external/userstorages
................................................................................
................................................................................
................................................................................
................................................................................
...............................
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.............
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
...........................
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
............................................................
WARN: 'Missing argument $row in OC.Notification.hide() call, caller needs to be adjusted to only dismiss its own notification'
................................................................................
................................................................................
................................................................................
..
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
...
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
...
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
..
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
................
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
..
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
...
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
.
WARN: 'Deprecation warning: tipsy is deprecated. Use tooltip instead.'
................................................................................
...................
WARN: 'Missing argument $row in OC.Notification.hide() call, caller needs to be adjusted to only dismiss its own notification'
.
WARN: 'Missing argument $row in OC.Notification.hide() call, caller needs to be adjusted to only dismiss its own notification'
.
WARN: 'Missing argument $row in OC.Notification.hide() call, caller needs to be adjusted to only dismiss its own notification'
.
WARN: 'Missing argument $row in OC.Notification.hide() call, caller needs to be adjusted to only dismiss its own notification'
.
WARN: 'Missing argument $row in OC.Notification.hide() call, caller needs to be adjusted to only dismiss its own notification'
..
WARN: 'Missing argument $row in OC.Notification.hide() call, caller needs to be adjusted to only dismiss its own notification'
.
WARN: 'Missing argument $row in OC.Notification.hide() call, caller needs to be adjusted to only dismiss its own notification'
.
PhantomJS 2.1.1 (Linux 0.0.0): Executed 840 of 842 (skipped 2) SUCCESS (38.095 secs / 36.499 secs)
```