### PR TITLE
pass complete share as reference, allowing to manipulate it by an app

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -624,6 +624,7 @@ class Manager implements IManager {
 			'shareWith' => $share->getSharedWith(),
 			'run' => &$run,
 			'error' => &$error,
+			'share' => &$share
 		];
 		\OC_Hook::emit('OCP\Share', 'pre_shared', $preHookData);
 


### PR DESCRIPTION
Allow apps to listen to a hook to manipulate a share, e.g. apply their own name conventions.

@seaneble this should work for you. If we approve this changes you can write a small app to apply your naming conventions.

You just need to listen to the hook in your apps.php:

````
\OCP\Util::connectHook('OCP\Share', 'pre_shared', <your class>, <your method>);
````

and create `<your class>` with `<your method>` which does something along this line:

````
      public function pre($params) {
               /** @var OCP\Share\IShare\IShare $share */
               $share = $params['share'];
               $share->setTarget('the target you like');
       }
````

cc @rullzer please have a look, thanks!

solution proposed for https://github.com/nextcloud/server/pull/2895