### PR TITLE
Fix for #3112

### DIFF
--- a/lib/private/IntegrityCheck/Iterator/ExcludeFileByNameFilterIterator.php
+++ b/lib/private/IntegrityCheck/Iterator/ExcludeFileByNameFilterIterator.php
@@ -25,7 +25,7 @@ namespace OC\IntegrityCheck\Iterator;
 
 /**
  * Class ExcludeFileByNameFilterIterator provides a custom iterator which excludes
- * entries with the specified file name from the file list.
+ * entries with the specified file name from the file list. These file names are matched exactly.
  *
  * @package OC\Integritycheck\Iterator
  */
@@ -41,8 +41,19 @@ class ExcludeFileByNameFilterIterator extends \RecursiveFilterIterator {
 		'.DS_Store', // Mac OS X
 		'Thumbs.db', // Microsoft Windows
 		'.directory', // Dolphin (KDE)
-		'.webapp', // Gentoo/Funtoo & derivatives use a tool known as webapp-config to manager wep-apps.
+		'.webapp', // Gentoo/Funtoo & derivatives use a tool known as webapp-config to manage wep-apps.
 	];
+
+	/**
+	 * Array of excluded file name parts. Those are not scanned by the integrity checker.
+	 * These strings are regular expressions and any file names
+	 * matching these expressions are ignored.
+	 *
+	 * @var array
+	 */
+	private $excludedFileNamePatterns = [
+		'/^\.webapp-nextcloud-.*/', // Gentoo/Funtoo & derivatives use a tool known as webapp-config to manage wep-apps.
+ 	];
 
 	/**
 	 * @return bool
@@ -52,10 +63,17 @@ class ExcludeFileByNameFilterIterator extends \RecursiveFilterIterator {
 			return true;
 		}
 
-		return !in_array(
-			$this->current()->getFilename(),
-			$this->excludedFilenames,
-			true
-		);
+		$currentFileName = $this->current()->getFilename();
+		if (in_array($currentFileName, $this->excludedFilenames, true)){
+			return false;
+		}
+
+		foreach ($this->excludedFileNamePatterns as $pattern){
+			if (preg_match($pattern, $currentFileName) > 0){
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/tests/lib/IntegrityCheck/Iterator/ExcludeFileByNameFilterIteratorTest.php
+++ b/tests/lib/IntegrityCheck/Iterator/ExcludeFileByNameFilterIteratorTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * @author Victor Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\IntegrityCheck\Iterator;
+
+use \OC\IntegrityCheck\Iterator\ExcludeFileByNameFilterIterator;
+use Test\TestCase;
+
+class ExcludeFileByNameFilterIteratorTest extends TestCase {
+	/** @var ExcludeFileByNameFilterIterator */
+	protected $filter;
+
+	public function setUp() {
+		parent::setUp();
+		$this->filter = $this->getMockBuilder(ExcludeFileByNameFilterIterator::class)
+			->disableOriginalConstructor()
+			->getMock()
+		;
+
+	}
+
+	public function fileNameProvider(){
+		return [
+			['a file', true],
+			['Thumbs.db', false],
+			['another file', true],
+			['.directory', false],
+			['.webapp-owncloud-obee', false],
+			['wx.webapp-owncloud-obee', true],
+		];
+	}
+
+	/**
+	 * @dataProvider fileNameProvider
+	 * @param string $fileName
+	 * @param bool $expectedResult
+	 */
+	public function testAcceptForFiles($fileName, $expectedResult){
+		$iteratorMock = $this->createMock(\DirectoryIterator::class);
+		$iteratorMock->method('getFilename')
+			->will($this->returnValue($fileName))
+		;
+
+		$this->filter->method('isDir')
+			->will($this->returnValue(false));
+		$this->filter->method('current')
+			->will($this->returnValue($iteratorMock))
+		;
+
+		$actualResult = $this->filter->accept();
+		$this->assertEquals($expectedResult, $actualResult);
+	}
+
+	/**
+	 * @dataProvider fileNameProvider
+	 * @param string $fileName
+	 * @param bool $fakeExpectedResult
+	 */
+	public function testAcceptForDirs($fileName, $fakeExpectedResult){
+		$iteratorMock = $this->createMock(\DirectoryIterator::class);
+		$iteratorMock->method('getFilename')
+			->will($this->returnValue($fileName))
+		;
+
+		$this->filter->method('isDir')
+			->will($this->returnValue(true));
+		$this->filter->method('current')
+			->will($this->returnValue($iteratorMock))
+		;
+
+		$actualResult = $this->filter->accept();
+		$this->assertFalse($actualResult);
+	}
+}

--- a/tests/lib/IntegrityCheck/Iterator/ExcludeFileByNameFilterIteratorTest.php
+++ b/tests/lib/IntegrityCheck/Iterator/ExcludeFileByNameFilterIteratorTest.php
@@ -43,8 +43,8 @@ class ExcludeFileByNameFilterIteratorTest extends TestCase {
 			['Thumbs.db', false],
 			['another file', true],
 			['.directory', false],
-			['.webapp-owncloud-obee', false],
-			['wx.webapp-owncloud-obee', true],
+			['.webapp-nextcloud-obee', false],
+			['wx.webapp-nextcloud-obee', true],
 		];
 	}
 


### PR DESCRIPTION
Adds support for filename pattern exclusion in integrity check. Allows ignoring of Gentoo's webapp files.