### PR TITLE
Fix style in comment

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -538,7 +538,7 @@ $CONFIG = array(
  *
  * Supported values:
  *   - ``daily``
- *   - ``beta`
+ *   - ``beta``
  *   - ``stable``
  *   - ``production``
  */


### PR DESCRIPTION
Add missing grave accent to fix the highlighting in the documentation.