### PR TITLE
[uc] Prevent PHP request to get killed when using fclose callback (#26775)

### DIFF
--- a/apps/dav/appinfo/v1/webdav.php
+++ b/apps/dav/appinfo/v1/webdav.php
@@ -25,6 +25,7 @@
 
 // no php execution timeout for webdav
 set_time_limit(0);
+ignore_user_abort(true);
 
 // Turn off output buffering to prevent memory problems
 \OC_Util::obEnd();

--- a/apps/dav/appinfo/v2/remote.php
+++ b/apps/dav/appinfo/v2/remote.php
@@ -21,6 +21,7 @@
  */
 // no php execution timeout for webdav
 set_time_limit(0);
+ignore_user_abort(true);
 
 // Turn off output buffering to prevent memory problems
 \OC_Util::obEnd();

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1146,6 +1146,8 @@ class View {
 				$unlockLater = false;
 				if ($this->lockingEnabled && $operation === 'fopen' && is_resource($result)) {
 					$unlockLater = true;
+					// make sure our unlocking callback will still be called if connection is aborted
+					ignore_user_abort(true);
 					$result = CallbackWrapper::wrap($result, null, null, function () use ($hooks, $path) {
 						if (in_array('write', $hooks)) {
 							$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);

--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -148,6 +148,7 @@ class OC_Files {
 			$streamer->sendHeaders($name);
 			$executionTime = intval(OC::$server->getIniWrapper()->getNumeric('max_execution_time'));
 			set_time_limit(0);
+			ignore_user_abort(true);
 			if ($getType === self::ZIP_FILES) {
 				foreach ($files as $file) {
 					$file = $dir . '/' . $file;


### PR DESCRIPTION
* Prevent PHP request to get killed when using fclose callback
* Add ignore_user_abort everywhere where the time limit is set to 0

From https://github.com/owncloud/core/pull/26775

For https://github.com/nextcloud/server/issues/1166