### PR TITLE
Clear brute force table on successful login.

### DIFF
--- a/lib/private/Security/Bruteforce/Throttler.php
+++ b/lib/private/Security/Bruteforce/Throttler.php
@@ -186,6 +186,17 @@ class Throttler {
 	}
 
 	/**
+	 * Remove the throttle for a client
+	 * @param string $ip
+	 */
+
+	public function clearAttempts($ip){
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete('bruteforce_attempts');
+		$qb->setValue('ip', $ip);
+	}
+
+	/**
 	 * Get the throttling delay (in milliseconds)
 	 *
 	 * @param string $ip

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -346,6 +346,9 @@ class Session implements IUserSession, Emitter {
 			$this->createSessionToken($request, $this->getUser()->getUID(), $user, $password);
 		}
 
+		// Login success clear brute force table for this ip
+		$throttler->clearAttempts($request->getRemoteAddress());
+
 		return true;
 	}
 


### PR DESCRIPTION
Only the attempts from the ip that logged in succesfully are deleted.
Fixes #3156 
Signed-off-by: brantje <brantje@gmail.com>