### PR TITLE
Part 1 of LDAP Backend OCS Api

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -417,6 +417,7 @@ pipeline:
       image: nextcloudci/integration-php7.0:integration-php7.0-3
       commands:
         - ./occ maintenance:install --admin-pass=admin
+        - ./occ app:enable user_ldap
         - cd build/integration
         - ./run.sh ldap_features/ldap-ocs.feature
       when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -413,6 +413,15 @@ pipeline:
     when:
       matrix:
         TESTS: integration-transfer-ownership-features
+    integration-ldap-features:
+        image: nextcloudci/integration-php7.0:integration-php7.0-3
+        commands:
+          - ./occ maintenance:install --admin-pass=admin
+          - cd build/integration
+          - ./run.sh ldap_features/ldap-ocs.feature
+        when:
+          matrix:
+            TESTS: integration-ldap-features
   nodb-codecov:
     image: nextcloudci/php7.0:php7.0-7
     commands:
@@ -480,6 +489,7 @@ matrix:
     - TESTS: integration-setup-features
     - TESTS: integration-filesdrop-features
     - TESTS: integration-transfer-ownership-features
+    - TESTS: integration-ldap-features
     - TESTS: jsunit
     - TESTS: check-autoloader
     - TESTS: app-check-code

--- a/.drone.yml
+++ b/.drone.yml
@@ -413,15 +413,15 @@ pipeline:
     when:
       matrix:
         TESTS: integration-transfer-ownership-features
-    integration-ldap-features:
-        image: nextcloudci/integration-php7.0:integration-php7.0-3
-        commands:
-          - ./occ maintenance:install --admin-pass=admin
-          - cd build/integration
-          - ./run.sh ldap_features/ldap-ocs.feature
-        when:
-          matrix:
-            TESTS: integration-ldap-features
+  integration-ldap-features:
+      image: nextcloudci/integration-php7.0:integration-php7.0-3
+      commands:
+        - ./occ maintenance:install --admin-pass=admin
+        - cd build/integration
+        - ./run.sh ldap_features/ldap-ocs.feature
+      when:
+        matrix:
+          TESTS: integration-ldap-features
   nodb-codecov:
     image: nextcloudci/php7.0:php7.0-7
     commands:

--- a/apps/user_ldap/appinfo/routes.php
+++ b/apps/user_ldap/appinfo/routes.php
@@ -36,3 +36,10 @@ $this->create('user_ldap_ajax_testConfiguration', 'ajax/testConfiguration.php')
 	->actionInclude('user_ldap/ajax/testConfiguration.php');
 $this->create('user_ldap_ajax_wizard', 'ajax/wizard.php')
 	->actionInclude('user_ldap/ajax/wizard.php');
+
+$application = new \OCP\AppFramework\App('user_ldap');
+$application->registerRoutes($this, [
+	'ocs' => [
+		['name' => 'ConfigAPI#create', 'url' => '/api/v1/config', 'verb' => 'POST'],
+	]
+]);

--- a/apps/user_ldap/appinfo/routes.php
+++ b/apps/user_ldap/appinfo/routes.php
@@ -41,6 +41,7 @@ $application = new \OCP\AppFramework\App('user_ldap');
 $application->registerRoutes($this, [
 	'ocs' => [
 		['name' => 'ConfigAPI#create', 'url' => '/api/v1/config', 'verb' => 'POST'],
+		['name' => 'ConfigAPI#modify', 'url' => '/api/v1/config/{configID}', 'verb' => 'PUT'],
 		['name' => 'ConfigAPI#delete', 'url' => '/api/v1/config/{configID}', 'verb' => 'DELETE'],
 	]
 ]);

--- a/apps/user_ldap/appinfo/routes.php
+++ b/apps/user_ldap/appinfo/routes.php
@@ -41,6 +41,7 @@ $application = new \OCP\AppFramework\App('user_ldap');
 $application->registerRoutes($this, [
 	'ocs' => [
 		['name' => 'ConfigAPI#create', 'url' => '/api/v1/config', 'verb' => 'POST'],
+		['name' => 'ConfigAPI#show',   'url' => '/api/v1/config/{configID}', 'verb' => 'GET'],
 		['name' => 'ConfigAPI#modify', 'url' => '/api/v1/config/{configID}', 'verb' => 'PUT'],
 		['name' => 'ConfigAPI#delete', 'url' => '/api/v1/config/{configID}', 'verb' => 'DELETE'],
 	]

--- a/apps/user_ldap/appinfo/routes.php
+++ b/apps/user_ldap/appinfo/routes.php
@@ -41,5 +41,6 @@ $application = new \OCP\AppFramework\App('user_ldap');
 $application->registerRoutes($this, [
 	'ocs' => [
 		['name' => 'ConfigAPI#create', 'url' => '/api/v1/config', 'verb' => 'POST'],
+		['name' => 'ConfigAPI#delete', 'url' => '/api/v1/config/{configID}', 'verb' => 'DELETE'],
 	]
 ]);

--- a/apps/user_ldap/lib/Command/CreateEmptyConfig.php
+++ b/apps/user_ldap/lib/Command/CreateEmptyConfig.php
@@ -29,6 +29,7 @@ use OCA\User_LDAP\Configuration;
 use OCA\User_LDAP\Helper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class CreateEmptyConfig extends Command {
@@ -47,29 +48,24 @@ class CreateEmptyConfig extends Command {
 		$this
 			->setName('ldap:create-empty-config')
 			->setDescription('creates an empty LDAP configuration')
+			->addOption(
+				'only-print-prefix',
+				'p',
+				InputOption::VALUE_NONE,
+				'outputs only the prefix'
+			)
 		;
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$configPrefix = $this->getNewConfigurationPrefix();
-		$output->writeln("Created new configuration with configID '{$configPrefix}'");
-
+		$configPrefix = $this->helper->getNextServerConfigurationPrefix();
 		$configHolder = new Configuration($configPrefix);
 		$configHolder->saveConfiguration();
-	}
 
-	protected function getNewConfigurationPrefix() {
-		$serverConnections = $this->helper->getServerConfigurationPrefixes();
-
-		// first connection uses no prefix
-		if(sizeof($serverConnections) == 0) {
-			return '';
+		$prose = '';
+		if(!$input->getOption('only-print-prefix')) {
+			$prose = 'Created new configuration with configID ';
 		}
-
-		sort($serverConnections);
-		$lastKey = array_pop($serverConnections);
-		$lastNumber = intval(str_replace('s', '', $lastKey));
-		$nextPrefix = 's' . str_pad($lastNumber + 1, 2, '0', STR_PAD_LEFT);
-		return $nextPrefix;
+		$output->writeln($prose . "{$configPrefix}");
 	}
 }

--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -393,9 +393,12 @@ class Configuration {
 	 * @return bool
 	 */
 	protected function saveValue($varName, $value) {
-		return \OCP\Config::setAppValue('user_ldap',
-										$this->configPrefix.$varName,
-										$value);
+		\OC::$server->getConfig()->setAppValue(
+			'user_ldap',
+			$this->configPrefix.$varName,
+			$value
+		);
+		return true;
 	}
 
 	/**

--- a/apps/user_ldap/lib/Controller/ConfigAPIController.php
+++ b/apps/user_ldap/lib/Controller/ConfigAPIController.php
@@ -214,6 +214,100 @@ class ConfigAPIController extends OCSController {
 	}
 
 	/**
+	 * retrieves a configuration
+	 *
+	 * <?xml version="1.0"?>
+	 * <ocs>
+	 *   <meta>
+	 *     <status>ok</status>
+	 *     <statuscode>200</statuscode>
+	 *     <message>OK</message>
+	 *   </meta>
+	 *   <data>
+	 *     <ldapHost>ldaps://my.ldap.server</ldapHost>
+	 *     <ldapPort>7770</ldapPort>
+	 *     <ldapBackupHost></ldapBackupHost>
+	 *     <ldapBackupPort></ldapBackupPort>
+	 *     <ldapBase>ou=small,dc=my,dc=ldap,dc=server</ldapBase>
+	 *     <ldapBaseUsers>ou=users,ou=small,dc=my,dc=ldap,dc=server</ldapBaseUsers>
+	 *     <ldapBaseGroups>ou=small,dc=my,dc=ldap,dc=server</ldapBaseGroups>
+	 *     <ldapAgentName>cn=root,dc=my,dc=ldap,dc=server</ldapAgentName>
+	 *     <ldapAgentPassword>clearTextWithShowPassword=1</ldapAgentPassword>
+	 *     <ldapTLS>1</ldapTLS>
+	 *     <turnOffCertCheck>0</turnOffCertCheck>
+	 *     <ldapIgnoreNamingRules/>
+	 *     <ldapUserDisplayName>displayname</ldapUserDisplayName>
+	 *     <ldapUserDisplayName2>uid</ldapUserDisplayName2>
+	 *     <ldapUserFilterObjectclass>inetOrgPerson</ldapUserFilterObjectclass>
+	 *     <ldapUserFilterGroups></ldapUserFilterGroups>
+	 *     <ldapUserFilter>(&amp;(objectclass=nextcloudUser)(nextcloudEnabled=TRUE))</ldapUserFilter>
+	 *     <ldapUserFilterMode>1</ldapUserFilterMode>
+	 *     <ldapGroupFilter>(&amp;(|(objectclass=nextcloudGroup)))</ldapGroupFilter>
+	 *     <ldapGroupFilterMode>0</ldapGroupFilterMode>
+	 *     <ldapGroupFilterObjectclass>nextcloudGroup</ldapGroupFilterObjectclass>
+	 *     <ldapGroupFilterGroups></ldapGroupFilterGroups>
+	 *     <ldapGroupDisplayName>cn</ldapGroupDisplayName>
+	 *     <ldapGroupMemberAssocAttr>memberUid</ldapGroupMemberAssocAttr>
+	 *     <ldapLoginFilter>(&amp;(|(objectclass=inetOrgPerson))(uid=%uid))</ldapLoginFilter>
+	 *     <ldapLoginFilterMode>0</ldapLoginFilterMode>
+	 *     <ldapLoginFilterEmail>0</ldapLoginFilterEmail>
+	 *     <ldapLoginFilterUsername>1</ldapLoginFilterUsername>
+	 *     <ldapLoginFilterAttributes></ldapLoginFilterAttributes>
+	 *     <ldapQuotaAttribute></ldapQuotaAttribute>
+	 *     <ldapQuotaDefault></ldapQuotaDefault>
+	 *     <ldapEmailAttribute>mail</ldapEmailAttribute>
+	 *     <ldapCacheTTL>20</ldapCacheTTL>
+	 *     <ldapUuidUserAttribute>auto</ldapUuidUserAttribute>
+	 *     <ldapUuidGroupAttribute>auto</ldapUuidGroupAttribute>
+	 *     <ldapOverrideMainServer></ldapOverrideMainServer>
+	 *     <ldapConfigurationActive>1</ldapConfigurationActive>
+	 *     <ldapAttributesForUserSearch>uid;sn;givenname</ldapAttributesForUserSearch>
+	 *     <ldapAttributesForGroupSearch></ldapAttributesForGroupSearch>
+	 *     <ldapExperiencedAdmin>0</ldapExperiencedAdmin>
+	 *     <homeFolderNamingRule></homeFolderNamingRule>
+	 *     <hasPagedResultSupport></hasPagedResultSupport>
+	 *     <hasMemberOfFilterSupport></hasMemberOfFilterSupport>
+	 *     <useMemberOfToDetectMembership>1</useMemberOfToDetectMembership>
+	 *     <ldapExpertUsernameAttr>uid</ldapExpertUsernameAttr>
+	 *     <ldapExpertUUIDUserAttr>uid</ldapExpertUUIDUserAttr>
+	 *     <ldapExpertUUIDGroupAttr></ldapExpertUUIDGroupAttr>
+	 *     <lastJpegPhotoLookup>0</lastJpegPhotoLookup>
+	 *     <ldapNestedGroups>0</ldapNestedGroups>
+	 *     <ldapPagingSize>500</ldapPagingSize>
+	 *     <turnOnPasswordChange>1</turnOnPasswordChange>
+	 *     <ldapDynamicGroupMemberURL></ldapDynamicGroupMemberURL>
+	 *   </data>
+	 * </ocs>
+	 *
+	 * @param string $configID
+	 * @param bool|string $showPassword
+	 * @return DataResponse
+	 * @throws OCSException
+	 */
+	public function show($configID, $showPassword = false) {
+		$this->ensureConfigIDExists($configID);
+
+		try {
+			$config = new Configuration($configID);
+			$data = $config->getConfiguration();
+			if(!boolval(intval($showPassword))) {
+				$data['ldapAgentPassword'] = '***';
+			}
+			foreach ($data as $key => $value) {
+				if(is_array($value)) {
+					$value = implode(';', $value);
+					$data[$key] = $value;
+				}
+			}
+		} catch (\Exception $e) {
+			$this->logger->logException($e);
+			throw new OCSException('An issue occurred when modifying the config.');
+		}
+
+		return new DataResponse($data);
+	}
+
+	/**
 	 * if the given config ID is not available, an exception is thrown
 	 *
 	 * @param string $configID

--- a/apps/user_ldap/lib/Controller/ConfigAPIController.php
+++ b/apps/user_ldap/lib/Controller/ConfigAPIController.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_LDAP\Controller;
+
+use OC\CapabilitiesManager;
+use OC\Core\Controller\OCSController;
+use OC\Security\Bruteforce\Throttler;
+use OC\Security\IdentityProof\Manager;
+use OCA\User_LDAP\Configuration;
+use OCA\User_LDAP\Helper;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCS\OCSException;
+use OCP\ILogger;
+use OCP\IRequest;
+use OCP\IUserManager;
+use OCP\IUserSession;
+
+class ConfigAPIController extends OCSController {
+
+	/** @var Helper */
+	private $ldapHelper;
+
+	/** @var ILogger */
+	private $logger;
+
+	public function __construct(
+		$appName,
+		IRequest $request,
+		CapabilitiesManager $capabilitiesManager,
+		IUserSession $userSession,
+		IUserManager $userManager,
+		Throttler $throttler,
+		Manager $keyManager,
+		Helper $ldapHelper,
+		ILogger $logger
+	) {
+		parent::__construct(
+			$appName,
+			$request,
+			$capabilitiesManager,
+			$userSession,
+			$userManager,
+			$throttler,
+			$keyManager
+		);
+
+
+		$this->ldapHelper = $ldapHelper;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * creates a new (empty) configuration and returns the resulting prefix
+	 *
+	 * Example: curl -X POST -H "OCS-APIREQUEST: true"  -u $admin:$password \
+	 *   https://nextcloud.server/ocs/v1.php/apps/user_ldap/api/v1/config
+	 *
+	 * results in:
+	 *
+	 * <?xml version="1.0"?>
+	 * <ocs>
+	 *   <meta>
+	 *     <status>ok</status>
+	 *     <statuscode>100</statuscode>
+	 *     <message>OK</message>
+	 *     <totalitems></totalitems>
+	 *     <itemsperpage></itemsperpage>
+	 *   </meta>
+	 *   <data>
+	 *     <prefix>s40</prefix>
+	 *   </data>
+	 * </ocs>
+	 *
+	 * Failing example: if an exception is thrown (e.g. Database connection lost)
+	 * the detailed error will be logged. The output will then look like:
+	 *
+	 * <?xml version="1.0"?>
+	 * <ocs>
+	 *   <meta>
+	 *     <status>failure</status>
+	 *     <statuscode>999</statuscode>
+	 *     <message>An issue occurred when creating the new config.</message>
+	 *     <totalitems></totalitems>
+	 *     <itemsperpage></itemsperpage>
+	 *   </meta>
+	 *   <data/>
+	 * </ocs>
+	 *
+	 * For JSON output provide the format=json parameter
+	 *
+	 * @return DataResponse
+	 * @throws OCSException
+	 */
+	public function create() {
+		try {
+			$configPrefix = $this->ldapHelper->getNextServerConfigurationPrefix();
+			$configHolder = new Configuration($configPrefix);
+			$configHolder->saveConfiguration();
+		} catch (\Exception $e) {
+			$this->logger->logException($e);
+			throw new OCSException('An issue occurred when creating the new config.');
+		}
+		return new DataResponse(['prefix' => $configPrefix]);
+	}
+}

--- a/apps/user_ldap/lib/Controller/ConfigAPIController.php
+++ b/apps/user_ldap/lib/Controller/ConfigAPIController.php
@@ -76,7 +76,7 @@ class ConfigAPIController extends OCSController {
 	 * creates a new (empty) configuration and returns the resulting prefix
 	 *
 	 * Example: curl -X POST -H "OCS-APIREQUEST: true"  -u $admin:$password \
-	 *   https://nextcloud.server/ocs/v1.php/apps/user_ldap/api/v1/config
+	 *   https://nextcloud.server/ocs/v2.php/apps/user_ldap/api/v1/config
 	 *
 	 * results in:
 	 *
@@ -84,10 +84,8 @@ class ConfigAPIController extends OCSController {
 	 * <ocs>
 	 *   <meta>
 	 *     <status>ok</status>
-	 *     <statuscode>100</statuscode>
+	 *     <statuscode>200</statuscode>
 	 *     <message>OK</message>
-	 *     <totalitems></totalitems>
-	 *     <itemsperpage></itemsperpage>
 	 *   </meta>
 	 *   <data>
 	 *     <configID>s40</configID>
@@ -103,8 +101,6 @@ class ConfigAPIController extends OCSController {
 	 *     <status>failure</status>
 	 *     <statuscode>999</statuscode>
 	 *     <message>An issue occurred when creating the new config.</message>
-	 *     <totalitems></totalitems>
-	 *     <itemsperpage></itemsperpage>
 	 *   </meta>
 	 *   <data/>
 	 * </ocs>
@@ -131,7 +127,7 @@ class ConfigAPIController extends OCSController {
 	 *
 	 * Example:
 	 *   curl -X DELETE -H "OCS-APIREQUEST: true" -u $admin:$password \
-	 *    https://nextcloud.server/ocs/v1.php/apps/user_ldap/api/v1/config/s60
+	 *    https://nextcloud.server/ocs/v2.php/apps/user_ldap/api/v1/config/s60
 	 *
 	 * <?xml version="1.0"?>
 	 * <ocs>
@@ -139,8 +135,6 @@ class ConfigAPIController extends OCSController {
 	 *     <status>ok</status>
 	 *     <statuscode>100</statuscode>
 	 *     <message>OK</message>
-	 *     <totalitems></totalitems>
-	 *     <itemsperpage></itemsperpage>
 	 *   </meta>
 	 *   <data/>
 	 * </ocs>
@@ -178,7 +172,7 @@ class ConfigAPIController extends OCSController {
 	 * Example:
 	 *   curl -X PUT -d "key=ldapHost&value=ldaps://my.ldap.server" \
 	 *    -H "OCS-APIREQUEST: true" -u $admin:$password \
-	 *    https://nextcloud.server/ocs/v1.php/apps/user_ldap/api/v1/config/s60
+	 *    https://nextcloud.server/ocs/v2.php/apps/user_ldap/api/v1/config/s60
 	 *
 	 * <?xml version="1.0"?>
 	 * <ocs>
@@ -186,8 +180,6 @@ class ConfigAPIController extends OCSController {
 	 *     <status>ok</status>
 	 *     <statuscode>100</statuscode>
 	 *     <message>OK</message>
-	 *     <totalitems></totalitems>
-	 *     <itemsperpage></itemsperpage>
 	 *   </meta>
 	 *   <data/>
 	 * </ocs>

--- a/apps/user_ldap/lib/Controller/ConfigAPIController.php
+++ b/apps/user_ldap/lib/Controller/ConfigAPIController.php
@@ -90,7 +90,7 @@ class ConfigAPIController extends OCSController {
 	 *     <itemsperpage></itemsperpage>
 	 *   </meta>
 	 *   <data>
-	 *     <prefix>s40</prefix>
+	 *     <configID>s40</configID>
 	 *   </data>
 	 * </ocs>
 	 *
@@ -123,7 +123,7 @@ class ConfigAPIController extends OCSController {
 			$this->logger->logException($e);
 			throw new OCSException('An issue occurred when creating the new config.');
 		}
-		return new DataResponse(['prefix' => $configPrefix]);
+		return new DataResponse(['configID' => $configPrefix]);
 	}
 
 	/**

--- a/apps/user_ldap/lib/Helper.php
+++ b/apps/user_ldap/lib/Helper.php
@@ -105,6 +105,25 @@ class Helper {
 		return $result;
 	}
 
+	/**
+	 * return the next available configuration prefix
+	 *
+	 * @return string
+	 */
+	public function getNextServerConfigurationPrefix() {
+		$serverConnections = $this->getServerConfigurationPrefixes();
+
+		if(count($serverConnections) === 0) {
+			return 's01';
+		}
+
+		sort($serverConnections);
+		$lastKey = array_pop($serverConnections);
+		$lastNumber = intval(str_replace('s', '', $lastKey));
+		$nextPrefix = 's' . str_pad($lastNumber + 1, 2, '0', STR_PAD_LEFT);
+		return $nextPrefix;
+	}
+
 	private function getServersConfig($value) {
 		$regex = '/' . $value . '$/S';
 

--- a/build/integration/config/behat.yml
+++ b/build/integration/config/behat.yml
@@ -75,6 +75,16 @@ default:
               - admin
               - admin
             regular_user_password: 123456
+    ldap:
+      paths:
+        - %paths.base%/../ldap_features
+      contexts:
+        - LDAPContext:
+            baseUrl: http://localhost:8080
+            admin:
+              - admin
+              - admin
+            regular_user_password: what_for
 
   extensions:
       jarnaiz\JUnitFormatter\JUnitFormatterExtension:

--- a/build/integration/features/bootstrap/LDAPContext.php
+++ b/build/integration/features/bootstrap/LDAPContext.php
@@ -40,9 +40,9 @@ class LDAPContext implements Context {
 	}
 
 	/**
-	 * @Given /^creating a configuration at "([^"]*)"$/
+	 * @Given /^creating an LDAP configuration at "([^"]*)"$/
 	 */
-	public function creatingAConfigurationAt($apiUrl) {
+	public function creatingAnLDAPConfigurationAt($apiUrl) {
 		$this->apiUrl = $apiUrl;
 		$this->sendingToWith('POST', $this->apiUrl, null);
 		$configElements = $this->response->xml()->data[0]->configID;
@@ -50,9 +50,20 @@ class LDAPContext implements Context {
 	}
 
 	/**
-	 * @When /^deleting the configuration$/
+	 * @When /^deleting the LDAP configuration$/
 	 */
-	public function deletingTheConfiguration() {
+	public function deletingTheLDAPConfiguration() {
 		$this->sendingToWith('DELETE', $this->apiUrl . '/' . $this->configID, null);
+	}
+
+	/**
+	 * @When /^setting "([^"]*)" of the LDAP configuration to "([^"]*)"$/
+	 */
+	public function settingOfTheLDAPConfigurationTo($key, $value) {
+		$this->sendingToWith(
+			'PUT',
+			$this->apiUrl . '/' . $this->configID,
+			new \Behat\Gherkin\Node\TableNode([['key', $key], ['value', $value]])
+		);
 	}
 }

--- a/build/integration/features/bootstrap/LDAPContext.php
+++ b/build/integration/features/bootstrap/LDAPContext.php
@@ -66,4 +66,23 @@ class LDAPContext implements Context {
 			new \Behat\Gherkin\Node\TableNode([['key', $key], ['value', $value]])
 		);
 	}
+
+	/**
+	 * @Given /^the response should contain a tag "([^"]*)" with value "([^"]*)"$/
+	 */
+	public function theResponseShouldContainATagWithValue($tagName, $expectedValue) {
+		$data = $this->response->xml()->data[0]->$tagName;
+		PHPUnit_Framework_Assert::assertEquals($expectedValue, $data[0]);
+	}
+
+	/**
+	 * @When /^getting the LDAP configuration with showPassword "([^"]*)"$/
+	 */
+	public function gettingTheLDAPConfigurationWithShowPassword($showPassword) {
+		$this->sendingToWith(
+			'GET',
+			$this->apiUrl . '/' . $this->configID . '?showPassword=' . $showPassword,
+			null
+		);
+	}
 }

--- a/build/integration/features/bootstrap/LDAPContext.php
+++ b/build/integration/features/bootstrap/LDAPContext.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2017 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use Behat\Behat\Context\Context;
+
+class LDAPContext implements Context {
+	use BasicStructure;
+
+	protected $configID;
+
+	protected $apiUrl;
+
+	/**
+	 * @Given /^the response should contain a tag "([^"]*)"$/
+	 */
+	public function theResponseShouldContainATag($arg1) {
+		$configID = $this->response->xml()->data[0]->$arg1;
+		PHPUnit_Framework_Assert::assertInstanceOf(SimpleXMLElement::class, $configID[0]);
+	}
+
+	/**
+	 * @Given /^creating a configuration at "([^"]*)"$/
+	 */
+	public function creatingAConfigurationAt($apiUrl) {
+		$this->apiUrl = $apiUrl;
+		$this->sendingToWith('POST', $this->apiUrl, null);
+		$configElements = $this->response->xml()->data[0]->configID;
+		$this->configID = $configElements[0];
+	}
+
+	/**
+	 * @When /^deleting the configuration$/
+	 */
+	public function deletingTheConfiguration() {
+		$this->sendingToWith('DELETE', $this->apiUrl . '/' . $this->configID, null);
+	}
+}

--- a/build/integration/features/bootstrap/LDAPContext.php
+++ b/build/integration/features/bootstrap/LDAPContext.php
@@ -23,6 +23,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\TableNode;
 
 class LDAPContext implements Context {
 	use BasicStructure;
@@ -57,17 +58,6 @@ class LDAPContext implements Context {
 	}
 
 	/**
-	 * @When /^setting "([^"]*)" of the LDAP configuration to "([^"]*)"$/
-	 */
-	public function settingOfTheLDAPConfigurationTo($key, $value) {
-		$this->sendingToWith(
-			'PUT',
-			$this->apiUrl . '/' . $this->configID,
-			new \Behat\Gherkin\Node\TableNode([['key', $key], ['value', $value]])
-		);
-	}
-
-	/**
 	 * @Given /^the response should contain a tag "([^"]*)" with value "([^"]*)"$/
 	 */
 	public function theResponseShouldContainATagWithValue($tagName, $expectedValue) {
@@ -84,5 +74,12 @@ class LDAPContext implements Context {
 			$this->apiUrl . '/' . $this->configID . '?showPassword=' . $showPassword,
 			null
 		);
+	}
+
+	/**
+	 * @Given /^setting the LDAP configuration to$/
+	 */
+	public function settingTheLDAPConfigurationTo(TableNode $configData) {
+		$this->sendingToWith('PUT', $this->apiUrl . '/' . $this->configID, $configData);
 	}
 }

--- a/build/integration/features/ldap-ocs.feature
+++ b/build/integration/features/ldap-ocs.feature
@@ -1,0 +1,7 @@
+Feature: LDAP
+
+  Scenario: Creating an new, empty configuration
+    Given As an "admin"
+    When sending "POST" to "/apps/user_ldap/api/v1/config"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"

--- a/build/integration/features/ldap-ocs.feature
+++ b/build/integration/features/ldap-ocs.feature
@@ -5,3 +5,17 @@ Feature: LDAP
     When sending "POST" to "/apps/user_ldap/api/v1/config"
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
+
+  Scenario: Delete a non-existing configuration
+    Given As an "admin"
+    When sending "DELETE" to "/apps/user_ldap/api/v1/config/s666"
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "200"
+
+  Scenario: Delete an invalid configuration
+    Given As an "admin"
+    When sending "DELETE" to "/apps/user_ldap/api/v1/config/hack0r"
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "200"
+
+  # TODO: Scenario deleting an existing config ID (needs to be created before)

--- a/build/integration/ldap_features/ldap-ocs.feature
+++ b/build/integration/ldap_features/ldap-ocs.feature
@@ -39,7 +39,7 @@ Feature: LDAP
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
 
-  Scenario: Modiying a non-existing configuration
+  Scenario: Modifying a non-existing configuration
     Given As an "admin"
     When sending "PUT" to "/apps/user_ldap/api/v1/config/s666" with
       | key | ldapHost |

--- a/build/integration/ldap_features/ldap-ocs.feature
+++ b/build/integration/ldap_features/ldap-ocs.feature
@@ -46,3 +46,25 @@ Feature: LDAP
       | value | ldaps://my.ldap.server |
     Then the OCS status code should be "404"
     And the HTTP status code should be "404"
+
+  Scenario: create, modify and get a configuration
+    Given As an "admin"
+    And creating an LDAP configuration at "/apps/user_ldap/api/v1/config"
+    And setting "ldapHost" of the LDAP configuration to "ldaps://my.ldap.server"
+    And setting "ldapLoginFilter" of the LDAP configuration to "(&(|(objectclass=inetOrgPerson))(uid=%uid))"
+    And setting "ldapAgentPassword" of the LDAP configuration to "psst,secret"
+    When getting the LDAP configuration with showPassword "0"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the response should contain a tag "ldapHost" with value "ldaps://my.ldap.server"
+    And the response should contain a tag "ldapLoginFilter" with value "(&(|(objectclass=inetOrgPerson))(uid=%uid))"
+    And the response should contain a tag "ldapAgentPassword" with value "***"
+
+  Scenario: receiving password in plain text
+    Given As an "admin"
+    And creating an LDAP configuration at "/apps/user_ldap/api/v1/config"
+    And setting "ldapAgentPassword" of the LDAP configuration to "psst,secret"
+    When getting the LDAP configuration with showPassword "1"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the response should contain a tag "ldapAgentPassword" with value "psst,secret"

--- a/build/integration/ldap_features/ldap-ocs.feature
+++ b/build/integration/ldap_features/ldap-ocs.feature
@@ -31,28 +31,33 @@ Feature: LDAP
   Scenario: Create and modify a configuration
     Given As an "admin"
     And creating an LDAP configuration at "/apps/user_ldap/api/v1/config"
-    When setting "ldapHost" of the LDAP configuration to "ldaps://my.ldap.server"
+    When setting the LDAP configuration to
+      | configData[ldapHost] | ldaps://my.ldap.server |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    # Testing an invalid config key
-    When setting "crack0r" of the LDAP configuration to "foobar"
-    Then the OCS status code should be "400"
-    And the HTTP status code should be "400"
 
   Scenario: Modifying a non-existing configuration
     Given As an "admin"
     When sending "PUT" to "/apps/user_ldap/api/v1/config/s666" with
-      | key | ldapHost |
-      | value | ldaps://my.ldap.server |
+      | configData[ldapHost] | ldaps://my.ldap.server |
     Then the OCS status code should be "404"
     And the HTTP status code should be "404"
+
+  Scenario: Modifying an existing configuration with malformed configData
+    Given As an "admin"
+    And creating an LDAP configuration at "/apps/user_ldap/api/v1/config"
+    When setting the LDAP configuration to
+      | configData | ldapHost=ldaps://my.ldap.server |
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
 
   Scenario: create, modify and get a configuration
     Given As an "admin"
     And creating an LDAP configuration at "/apps/user_ldap/api/v1/config"
-    And setting "ldapHost" of the LDAP configuration to "ldaps://my.ldap.server"
-    And setting "ldapLoginFilter" of the LDAP configuration to "(&(|(objectclass=inetOrgPerson))(uid=%uid))"
-    And setting "ldapAgentPassword" of the LDAP configuration to "psst,secret"
+    And setting the LDAP configuration to
+      | configData[ldapHost] | ldaps://my.ldap.server |
+      | configData[ldapLoginFilter] | (&(\|(objectclass=inetOrgPerson))(uid=%uid)) |
+      | configData[ldapAgentPassword] | psst,secret |
     When getting the LDAP configuration with showPassword "0"
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
@@ -63,7 +68,8 @@ Feature: LDAP
   Scenario: receiving password in plain text
     Given As an "admin"
     And creating an LDAP configuration at "/apps/user_ldap/api/v1/config"
-    And setting "ldapAgentPassword" of the LDAP configuration to "psst,secret"
+    And setting the LDAP configuration to
+      | configData[ldapAgentPassword] | psst,secret |
     When getting the LDAP configuration with showPassword "1"
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"

--- a/build/integration/ldap_features/ldap-ocs.feature
+++ b/build/integration/ldap_features/ldap-ocs.feature
@@ -1,9 +1,11 @@
 Feature: LDAP
+  Background:
+    Given using api version "2"
 
   Scenario: Creating an new, empty configuration
     Given As an "admin"
     When sending "POST" to "/apps/user_ldap/api/v1/config"
-    Then the OCS status code should be "100"
+    Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the response should contain a tag "configID"
 
@@ -11,31 +13,31 @@ Feature: LDAP
     Given As an "admin"
     When sending "DELETE" to "/apps/user_ldap/api/v1/config/s666"
     Then the OCS status code should be "404"
-    And the HTTP status code should be "200"
+    And the HTTP status code should be "404"
 
   Scenario: Delete an invalid configuration
     Given As an "admin"
     When sending "DELETE" to "/apps/user_ldap/api/v1/config/hack0r"
     Then the OCS status code should be "400"
-    And the HTTP status code should be "200"
+    And the HTTP status code should be "400"
 
   Scenario: Create and delete a configuration
     Given As an "admin"
     And creating an LDAP configuration at "/apps/user_ldap/api/v1/config"
     When deleting the LDAP configuration
-    Then the OCS status code should be "100"
+    Then the OCS status code should be "200"
     And the HTTP status code should be "200"
 
   Scenario: Create and modify a configuration
     Given As an "admin"
     And creating an LDAP configuration at "/apps/user_ldap/api/v1/config"
     When setting "ldapHost" of the LDAP configuration to "ldaps://my.ldap.server"
-    Then the OCS status code should be "100"
+    Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     # Testing an invalid config key
     When setting "crack0r" of the LDAP configuration to "foobar"
     Then the OCS status code should be "400"
-    And the HTTP status code should be "200"
+    And the HTTP status code should be "400"
 
   Scenario: Modiying a non-existing configuration
     Given As an "admin"
@@ -43,4 +45,4 @@ Feature: LDAP
       | key | ldapHost |
       | value | ldaps://my.ldap.server |
     Then the OCS status code should be "404"
-    And the HTTP status code should be "200"
+    And the HTTP status code should be "404"

--- a/build/integration/ldap_features/ldap-ocs.feature
+++ b/build/integration/ldap_features/ldap-ocs.feature
@@ -15,12 +15,6 @@ Feature: LDAP
     Then the OCS status code should be "404"
     And the HTTP status code should be "404"
 
-  Scenario: Delete an invalid configuration
-    Given As an "admin"
-    When sending "DELETE" to "/apps/user_ldap/api/v1/config/hack0r"
-    Then the OCS status code should be "400"
-    And the HTTP status code should be "400"
-
   Scenario: Create and delete a configuration
     Given As an "admin"
     And creating an LDAP configuration at "/apps/user_ldap/api/v1/config"

--- a/build/integration/ldap_features/ldap-ocs.feature
+++ b/build/integration/ldap_features/ldap-ocs.feature
@@ -5,6 +5,7 @@ Feature: LDAP
     When sending "POST" to "/apps/user_ldap/api/v1/config"
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
+    And the response should contain a tag "configID"
 
   Scenario: Delete a non-existing configuration
     Given As an "admin"
@@ -18,4 +19,9 @@ Feature: LDAP
     Then the OCS status code should be "400"
     And the HTTP status code should be "200"
 
-  # TODO: Scenario deleting an existing config ID (needs to be created before)
+  Scenario: Create and delete a configuration
+    Given As an "admin"
+    And creating a configuration at "/apps/user_ldap/api/v1/config"
+    When deleting the configuration
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"

--- a/build/integration/ldap_features/ldap-ocs.feature
+++ b/build/integration/ldap_features/ldap-ocs.feature
@@ -21,7 +21,26 @@ Feature: LDAP
 
   Scenario: Create and delete a configuration
     Given As an "admin"
-    And creating a configuration at "/apps/user_ldap/api/v1/config"
-    When deleting the configuration
+    And creating an LDAP configuration at "/apps/user_ldap/api/v1/config"
+    When deleting the LDAP configuration
     Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+
+  Scenario: Create and modify a configuration
+    Given As an "admin"
+    And creating an LDAP configuration at "/apps/user_ldap/api/v1/config"
+    When setting "ldapHost" of the LDAP configuration to "ldaps://my.ldap.server"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    # Testing an invalid config key
+    When setting "crack0r" of the LDAP configuration to "foobar"
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "200"
+
+  Scenario: Modiying a non-existing configuration
+    Given As an "admin"
+    When sending "PUT" to "/apps/user_ldap/api/v1/config/s666" with
+      | key | ldapHost |
+      | value | ldaps://my.ldap.server |
+    Then the OCS status code should be "404"
     And the HTTP status code should be "200"


### PR DESCRIPTION
Contributes to #2694 

It brings OCS Api methods for creating, reading, modifying and deleting an LDAP configuration. Including  integration tests (Configuration manipulation is against DB only, no LDAP server interaction).

General appconfig does not suffice here, because some values are not written to the DB as is, but need to be transformed first (i.e. multiline values, password). Also some sanity-checking is happening.

Please review @nextcloud/ldap 