### PR TITLE
Use correct theming when returning the defaults

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -30,7 +30,9 @@
 
 namespace OC\Core;
 
+use OC\Core\Controller\OCJSController;
 use OC\Security\IdentityProof\Manager;
+use OC\Server;
 use OCP\AppFramework\App;
 use OC\Core\Controller\CssController;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -64,6 +66,25 @@ class Application extends App {
 				$container->query(IRequest::class),
 				\OC::$server->getAppDataDir('css'),
 				$container->query(ITimeFactory::class)
+			);
+		});
+		$container->registerService(OCJSController::class, function () use ($container) {
+			/** @var Server $server */
+			$server = $container->getServer();
+			return new OCJSController(
+				$container->query('appName'),
+				$server->getRequest(),
+				$server->getL10N('core'),
+				// This is required for the theming to overwrite the `OC_Defaults`, see
+				// https://github.com/nextcloud/server/issues/3148
+				$server->getThemingDefaults(),
+				$server->getAppManager(),
+				$server->getSession(),
+				$server->getUserSession(),
+				$server->getConfig(),
+				$server->getGroupManager(),
+				$server->getIniWrapper(),
+				$server->getURLGenerator()
 			);
 		});
 	}


### PR DESCRIPTION
Fix #3148

To test with firefox/chrome, just remove the following lines:
https://github.com/nextcloud/server/blob/7d221ff8f4d5616b24d52bb363ed2df06a45f6cf/lib/private/Security/CSP/ContentSecurityPolicyNonceManager.php#L69-L71

cc @LukasReschke @MorrisJobke 

Should backport to 11