### PR TITLE
Fix default of mail_smtpmode

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -310,9 +310,9 @@ $CONFIG = array(
  * For ``qmail`` the binary is /var/qmail/bin/sendmail, and it must be installed
  * on your Unix system.
  *
- * Defaults to ``sendmail``
+ * Defaults to ``php``
  */
-'mail_smtpmode' => 'sendmail',
+'mail_smtpmode' => 'php',
 
 /**
  * This depends on ``mail_smtpmode``. Specify the IP address of your mail

--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -200,7 +200,7 @@ class Mailer implements IMailer {
 	 * @return \Swift_SendmailTransport
 	 */
 	protected function getSendMailInstance() {
-		switch ($this->config->getSystemValue('mail_smtpmode', 'sendmail')) {
+		switch ($this->config->getSystemValue('mail_smtpmode', 'php')) {
 			case 'qmail':
 				$binaryPath = '/var/qmail/bin/sendmail';
 				break;

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -44,7 +44,7 @@ class MailerTest extends TestCase {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
-			->with('mail_smtpmode', 'sendmail')
+			->with('mail_smtpmode', 'php')
 			->will($this->returnValue('sendmail'));
 
 		$this->assertEquals(\Swift_SendmailTransport::newInstance('/usr/sbin/sendmail -bs'), self::invokePrivate($this->mailer, 'getSendMailInstance'));
@@ -54,7 +54,7 @@ class MailerTest extends TestCase {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
-			->with('mail_smtpmode', 'sendmail')
+			->with('mail_smtpmode', 'php')
 			->will($this->returnValue('qmail'));
 
 		$this->assertEquals(\Swift_SendmailTransport::newInstance('/var/qmail/bin/sendmail -bs'), self::invokePrivate($this->mailer, 'getSendMailInstance'));


### PR DESCRIPTION
 - fixes #3102 

I don't want to change the behaviour of the code. The line 203 is only executed if the setting is sendmail or qmail. As this setting was previously checked with a default value of `php` this is only the case if it is set. So it doesn't has any impact, because this default value is usually never user and even if would result in the very same switch branch (the `default` one). So I adjusted the config.sample.php.

cc @j-ed 