### PR TITLE
fix default value for logdateformat

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -716,7 +716,9 @@ $CONFIG = array(
 /**
  * This uses PHP.date formatting; see http://php.net/manual/en/function.date.php
  *
- * Defaults to ``Y-m-d\TH:i:sO`` (ISO8601) - see \DateTime::ISO8601
+ * Defaults to ``Y-m-d\TH:i:sP`` (ISO8601 but with colon between hours and
+ * minutes of the timezone) - see \DateTime::ISO8601
+ * (https://secure.php.net/manual/en/class.datetime.php#datetime.constants.iso8601)
  */
 'logdateformat' => 'F d, Y H:i:s',
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -716,7 +716,7 @@ $CONFIG = array(
 /**
  * This uses PHP.date formatting; see http://php.net/manual/en/function.date.php
  *
- * Defaults to ``Y-m-d\TH:i:sO`` (ISO8601)
+ * Defaults to ``Y-m-d\TH:i:sO`` (ISO8601) - see \DateTime::ISO8601
  */
 'logdateformat' => 'F d, Y H:i:s',
 

--- a/lib/private/Console/TimestampFormatter.php
+++ b/lib/private/Console/TimestampFormatter.php
@@ -101,7 +101,7 @@ class TimestampFormatter implements OutputFormatterInterface {
 		$timeZone = $timeZone !== null ? new \DateTimeZone($timeZone) : null;
 
 		$time = new \DateTime('now', $timeZone);
-		$timestampInfo = $time->format($this->config->getSystemValue('logdateformat', 'c'));
+		$timestampInfo = $time->format($this->config->getSystemValue('logdateformat', \DateTime::ISO8601));
 
 		return $timestampInfo . ' ' . $this->formatter->format($message);
 	}

--- a/lib/private/Log/File.php
+++ b/lib/private/Log/File.php
@@ -75,8 +75,8 @@ class File {
 		$config = \OC::$server->getSystemConfig();
 
 		// default to ISO8601
-		$format = $config->getValue('logdateformat', 'c');
-		$logTimeZone = $config->getValue( "logtimezone", 'UTC' );
+		$format = $config->getValue('logdateformat', \DateTime::ISO8601);
+		$logTimeZone = $config->getValue('logtimezone', 'UTC');
 		try {
 			$timezone = new \DateTimeZone($logTimeZone);
 		} catch (\Exception $e) {


### PR DESCRIPTION
 - fixes #3107 
- no functional change - only streamlines to use the very same code instead of different codes for the same value

cc @j-ed 