### PR TITLE
Make sure the file information is available when sending the email

### DIFF
--- a/apps/files/lib/Activity/FavoriteProvider.php
+++ b/apps/files/lib/Activity/FavoriteProvider.php
@@ -138,12 +138,21 @@ class FavoriteProvider implements IProvider {
 	 * @param string $subject
 	 */
 	protected function setSubjects(IEvent $event, $subject) {
+		$subjectParams = $event->getSubjectParameters();
+		if (empty($subjectParams)) {
+			// Try to fall back to the old way, but this does not work for emails.
+			// But at least old activities still work.
+			$subjectParams = [
+				'id' => $event->getObjectId(),
+				'path' => $event->getObjectName(),
+			];
+		}
 		$parameter = [
 			'type' => 'file',
-			'id' => $event->getObjectId(),
-			'name' => basename($event->getObjectName()),
-			'path' => trim($event->getObjectName(), '/'),
-			'link' => $this->url->linkToRouteAbsolute('files.viewcontroller.showFile', ['fileid' => $event->getObjectId()]),
+			'id' => $subjectParams['id'],
+			'name' => basename($subjectParams['path']),
+			'path' => trim($subjectParams['path'], '/'),
+			'link' => $this->url->linkToRouteAbsolute('files.viewcontroller.showFile', ['fileid' => $subjectParams['id']]),
 		];
 
 		$event->setParsedSubject(str_replace('{file}', $parameter['path'], $subject))

--- a/apps/files/lib/Service/TagService.php
+++ b/apps/files/lib/Service/TagService.php
@@ -116,14 +116,21 @@ class TagService {
 		}
 
 		$event = $this->activityManager->generateEvent();
-		$event->setApp('files')
-			->setObject('files', $fileId, $path)
-			->setType('favorite')
-			->setAuthor($user->getUID())
-			->setAffectedUser($user->getUID())
-			->setTimestamp(time())
-			->setSubject($addToFavorite ? FavoriteProvider::SUBJECT_ADDED : FavoriteProvider::SUBJECT_REMOVED);
-		$this->activityManager->publish($event);
+		try {
+			$event->setApp('files')
+				->setObject('files', $fileId, $path)
+				->setType('favorite')
+				->setAuthor($user->getUID())
+				->setAffectedUser($user->getUID())
+				->setTimestamp(time())
+				->setSubject(
+					$addToFavorite ? FavoriteProvider::SUBJECT_ADDED : FavoriteProvider::SUBJECT_REMOVED,
+					['id' => $fileId, 'path' => $path]
+				);
+			$this->activityManager->publish($event);
+		} catch (\InvalidArgumentException $e) {
+		} catch (\BadMethodCallException $e) {
+		}
 	}
 }
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/activity/issues/108

@Huster-at-github can you test this? Would be awesome.
Note: it only works for new actions. Already triggered action can not be adjusted.


### Steps
1. Un-/Favorite a file and select to receive emails for it.
2. Send the email by running cron (change activity_mq.amq_latest_send and jobs.last_run and jobs.last_checked for cheating)
3. See the email