### PR TITLE
Fix gap by filter svg and empty search message overflow

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -492,6 +492,12 @@ input.userFilter {width: 200px;}
 
 /* APPS */
 
+#app-content > svg {
+	float: left;
+	height: 0;
+	width: 0;
+}
+
 .appinfo { margin: 1em 40px; }
 #app-navigation .appwarning {
 	background: #fcc;
@@ -542,6 +548,10 @@ span.version {
 	flex-wrap: wrap;
 	align-content: flex-start;
 }
+#apps-list.hidden {
+	display: none;
+}
+
 #apps-list .section {
 	position: relative;
 	flex: 0 0 auto;

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -492,7 +492,7 @@ input.userFilter {width: 200px;}
 
 /* APPS */
 
-#app-content > svg {
+#app-content > svg.app-filter {
 	float: left;
 	height: 0;
 	width: 0;

--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -150,7 +150,7 @@ script(
 	</ul>
 </div>
 <div id="app-content">
-	<svg height="0">
+	<svg>
 		<defs><filter id="invertIcon"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0"></feColorMatrix></filter></defs>
 	</svg>
 	<div id="apps-list" class="icon-loading"></div>

--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -150,7 +150,7 @@ script(
 	</ul>
 </div>
 <div id="app-content">
-	<svg>
+	<svg class="app-filter">
 		<defs><filter id="invertIcon"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0"></feColorMatrix></filter></defs>
 	</svg>
 	<div id="apps-list" class="icon-loading"></div>


### PR DESCRIPTION
The svg with the filter definition was using space, fixed with float.

With the change to flexbox the display:none of the .hidden class was overwritten.