### PR TITLE
Enable every app to generate their scss file

### DIFF
--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -62,7 +62,7 @@ class CSSResourceLocator extends ResourceLocator {
 		$style = substr($style, strpos($style, '/')+1);
 		$app_path = \OC_App::getAppPath($app);
 		$app_url = \OC_App::getAppWebPath($app);
-		if(!$this->cacheAndAppendScssIfExist($this->serverroot.'/apps', $app.'/'.$style.'.scss', $app)) {
+		if(!$this->cacheAndAppendScssIfExist($app_path, $style.'.scss', $app)) {
 			$this->append($app_path, $style.'.css', $app_url);
 		}
 	}

--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -82,14 +82,13 @@ class CSSResourceLocator extends ResourceLocator {
 	 *
 	 * @param string $root path to check
 	 * @param string $file the filename
-	 * @param string|null $webRoot base for path, default map $root to $webRoot
 	 * @return bool True if the resource was found and cached, false otherwise
 	 */
-	protected function cacheAndAppendScssIfExist($root, $file, $webRoot = null, $app = 'core') {
+	protected function cacheAndAppendScssIfExist($root, $file, $app = 'core') {
 		if (is_file($root.'/'.$file)) {
 			if($this->scssCacher !== null) {
 				if($this->scssCacher->process($root, $file, $app)) {
-					$this->append($root, $this->scssCacher->getCachedSCSS($app, $file), $webRoot, false);
+					$this->append($root, $this->scssCacher->getCachedSCSS($app, $file), false);
 					return true;
 				} else {
 					$this->logger->error('Failed to compile and/or save '.$root.'/'.$file, ['app' => 'core']);

--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -49,20 +49,22 @@ class CSSResourceLocator extends ResourceLocator {
 	 * @param string $style
 	 */
 	public function doFind($style) {
+		$app = substr($style, 0, strpos($style, '/'));
 		if (strpos($style, '3rdparty') === 0
 			&& $this->appendIfExist($this->thirdpartyroot, $style.'.css')
-			|| $this->cacheAndAppendScssIfExist($this->serverroot, $style.'.scss')
+			|| $this->cacheAndAppendScssIfExist($this->serverroot, $style.'.scss', $app)
 			|| $this->cacheAndAppendScssIfExist($this->serverroot, 'core/'.$style.'.scss')
 			|| $this->appendIfExist($this->serverroot, $style.'.css')
 			|| $this->appendIfExist($this->serverroot, 'core/'.$style.'.css')
 		) {
 			return;
 		}
-		$app = substr($style, 0, strpos($style, '/'));
 		$style = substr($style, strpos($style, '/')+1);
 		$app_path = \OC_App::getAppPath($app);
 		$app_url = \OC_App::getAppWebPath($app);
-		$this->append($app_path, $style.'.css', $app_url);
+		if(!$this->cacheAndAppendScssIfExist($this->serverroot.'/apps', $app.'/'.$style.'.scss', $app)) {
+			$this->append($app_path, $style.'.css', $app_url);
+		}
 	}
 
 	/**
@@ -83,11 +85,11 @@ class CSSResourceLocator extends ResourceLocator {
 	 * @param string|null $webRoot base for path, default map $root to $webRoot
 	 * @return bool True if the resource was found and cached, false otherwise
 	 */
-	protected function cacheAndAppendScssIfExist($root, $file, $webRoot = null) {
+	protected function cacheAndAppendScssIfExist($root, $file, $webRoot = null, $app = 'core') {
 		if (is_file($root.'/'.$file)) {
 			if($this->scssCacher !== null) {
-				if($this->scssCacher->process($root, $file)) {
-					$this->append($root, $this->scssCacher->getCachedSCSS('core', $file), $webRoot, false);
+				if($this->scssCacher->process($root, $file, $app)) {
+					$this->append($root, $this->scssCacher->getCachedSCSS($app, $file), $webRoot, false);
 					return true;
 				} else {
 					$this->logger->error('Failed to compile and/or save '.$root.'/'.$file, ['app' => 'core']);

--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -63,9 +63,10 @@ class SCSSCacher {
 	 * Process the caching process if needed
 	 * @param string $root Root path to the nextcloud installation
 	 * @param string $file
+	 * @param string $app The app name
 	 * @return boolean
 	 */
-	public function process($root, $file) {
+	public function process($root, $file, $app) {
 		$path = explode('/', $root . '/' . $file);
 
 		$fileNameSCSS = array_pop($path);
@@ -78,10 +79,10 @@ class SCSSCacher {
 		$webDir = implode('/', $webDir);
 
 		try {
-			$folder = $this->appData->getFolder('core');
+			$folder = $this->appData->getFolder($app);
 		} catch(NotFoundException $e) {
 			// creating css appdata folder
-			$folder = $this->appData->newFolder('core');
+			$folder = $this->appData->newFolder($app);
 		}
 
 		if($this->isCached($fileNameCSS, $fileNameSCSS, $folder, $path)) {


### PR DESCRIPTION
With this pr, every app can use the core scss compile&cache system.
You just have to change your css file to a .scss and the server will handle the rest :)

 - Css files will be stored in the appdata inside the "css" folder and with the application key.
ex: `/core/css/styles.scss` will be stored under `appdata/css/core/styles.css`
or: `/settings/css/settings.scss` in `appdata/css/settings/settings.css`
or: `/apps/mail/css/mail.scss` in `appdata/mail/mail.css`


@eppfel, it will be helpful for your new app store design #3194 and #3195  :)

@nextcloud/security Can I have a validation from you? What are the possible outcome from such implementation?