### PR TITLE
remove button shadow effect, fix #3203

### DIFF
--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -115,11 +115,6 @@ input[type='reset'] {
 	cursor: pointer;
 	box-sizing: border-box;
 	background-color: #fafafa;
-	box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.15);
-	&:active,
-	&.active {
-		box-shadow: inset 0 -1px 0 0 rgba(0, 0, 0, 0.15);
-	}
 }
 
 /* Buttons */
@@ -134,7 +129,7 @@ input[type='reset'] {
 	}
 }
 button, .button {
-	> span { 
+	> span {
 		/* icon position inside buttons */
 		&[class^='icon-'],
 		&[class*=' icon-'] {


### PR DESCRIPTION
fix #3203 (Shadow for buttons look strange & off-style)

This fixes the style to look consistent with Nextcloud style. cc @nextcloud/designers 

Before:
![capture du 2017-01-23 09-11-29](https://cloud.githubusercontent.com/assets/925062/22196329/16641ef0-e14d-11e6-8b73-c31ad2115ef3.png)
![capture du 2017-01-23 09-11-06](https://cloud.githubusercontent.com/assets/925062/22196330/16674f12-e14d-11e6-957b-1d2c853417eb.png)

After:
![capture du 2017-01-23 09-18-15](https://cloud.githubusercontent.com/assets/925062/22196352/2aada598-e14d-11e6-9a4a-1da9f7dab2f2.png)
![capture du 2017-01-23 09-17-33](https://cloud.githubusercontent.com/assets/925062/22196353/2ae441f2-e14d-11e6-93bd-f225cc3b081c.png)
