### PR TITLE
add data from the users profile to the provisioning api

### DIFF
--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -45,6 +45,7 @@ return [
 		['root' => '/cloud', 'name' => 'Users#getUsers', 'url' => '/users', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Users#addUser', 'url' => '/users', 'verb' => 'POST'],
 		['root' => '/cloud', 'name' => 'Users#getUser', 'url' => '/users/{userId}', 'verb' => 'GET'],
+		['root' => '/cloud', 'name' => 'Users#getCurrentUser', 'url' => '/user', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Users#editUser', 'url' => '/users/{userId}', 'verb' => 'PUT'],
 		['root' => '/cloud', 'name' => 'Users#deleteUser', 'url' => '/users/{userId}', 'verb' => 'DELETE'],
 		['root' => '/cloud', 'name' => 'Users#enableUser', 'url' => '/users/{userId}/enable', 'verb' => 'PUT'],

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -218,6 +218,7 @@ class UsersController extends OCSController {
 		$userAccount = $this->accountManager->getUser($targetUserObject);
 
 		// Find the data
+		$data['id'] = $targetUserObject->getUID();
 		$data['quota'] = $this->fillStorageInfo($userId);
 		$data['email'] = $targetUserObject->getEMailAddress();
 		$data['displayname'] = $targetUserObject->getDisplayName();
@@ -227,6 +228,30 @@ class UsersController extends OCSController {
 		$data['twitter'] = $userAccount[\OC\Accounts\AccountManager::PROPERTY_TWITTER]['value'];
 
 		return new DataResponse($data);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoSubAdminRequired
+	 *
+	 * gets user info from the currently logged in user
+	 *
+	 * @return DataResponse
+	 * @throws OCSException
+	 */
+	public function getCurrentUser() {
+		$user = $this->userSession->getUser();
+		if ($user) {
+			$result =  $this->getUser($user->getUID());
+			// rename "displayname" to "display-name" only for this call to keep
+			// the API stable.
+			$result['display-name'] = $result['displayname'];
+			unset($result['displayname']);
+			return $result;
+
+		}
+
+		throw new OCSException('', \OCP\API::RESPOND_UNAUTHORISED);
 	}
 
 	/**

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -29,6 +29,7 @@
 
 namespace OCA\Provisioning_API\Controller;
 
+use OC\Accounts\AccountManager;
 use \OC_Helper;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSException;
@@ -53,6 +54,8 @@ class UsersController extends OCSController {
 	private $groupManager;
 	/** @var IUserSession */
 	private $userSession;
+	/** @var AccountManager */
+	private $accountManager;
 	/** @var ILogger */
 	private $logger;
 
@@ -63,6 +66,7 @@ class UsersController extends OCSController {
 	 * @param IConfig $config
 	 * @param IGroupManager $groupManager
 	 * @param IUserSession $userSession
+	 * @param AccountManager $accountManager
 	 * @param ILogger $logger
 	 */
 	public function __construct($appName,
@@ -71,6 +75,7 @@ class UsersController extends OCSController {
 								IConfig $config,
 								IGroupManager $groupManager,
 								IUserSession $userSession,
+								AccountManager $accountManager,
 								ILogger $logger) {
 		parent::__construct($appName, $request);
 
@@ -78,6 +83,7 @@ class UsersController extends OCSController {
 		$this->config = $config;
 		$this->groupManager = $groupManager;
 		$this->userSession = $userSession;
+		$this->accountManager = $accountManager;
 		$this->logger = $logger;
 	}
 
@@ -107,7 +113,7 @@ class UsersController extends OCSController {
 			}
 
 			if($offset === null) {
-				$offset = 0; 
+				$offset = 0;
 			}
 
 			$users = [];
@@ -159,7 +165,7 @@ class UsersController extends OCSController {
 				throw new OCSException('no group specified (required for subadmins)', 106);
 			}
 		}
-		
+
 		try {
 			$newUser = $this->userManager->createUser($userid, $password);
 			$this->logger->info('Successful addUser call with userid: '.$userid, ['app' => 'ocs_api']);
@@ -209,10 +215,16 @@ class UsersController extends OCSController {
 			}
 		}
 
+		$userAccount = $this->accountManager->getUser($targetUserObject);
+
 		// Find the data
 		$data['quota'] = $this->fillStorageInfo($userId);
 		$data['email'] = $targetUserObject->getEMailAddress();
 		$data['displayname'] = $targetUserObject->getDisplayName();
+		$data['phone'] = $userAccount[\OC\Accounts\AccountManager::PROPERTY_PHONE]['value'];
+		$data['address'] = $userAccount[\OC\Accounts\AccountManager::PROPERTY_ADDRESS]['value'];
+		$data['webpage'] = $userAccount[\OC\Accounts\AccountManager::PROPERTY_WEBSITE]['value'];
+		$data['twitter'] = $userAccount[\OC\Accounts\AccountManager::PROPERTY_TWITTER]['value'];
 
 		return new DataResponse($data);
 	}
@@ -436,7 +448,7 @@ class UsersController extends OCSController {
 				throw new OCSException('', \OCP\API::RESPOND_UNAUTHORISED);
 			}
 		}
-		
+
 	}
 
 	/**

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -29,6 +29,7 @@
 
 namespace OCA\Provisioning_API\Tests\Controller;
 
+use OC\Accounts\AccountManager;
 use OCA\Provisioning_API\Controller\UsersController;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IGroup;
@@ -41,7 +42,7 @@ use Test\TestCase as OriginalTest;
 use OCP\ILogger;
 
 class UsersControllerTest extends OriginalTest {
-	
+
 	/** @var IUserManager | PHPUnit_Framework_MockObject_MockObject */
 	protected $userManager;
 	/** @var IConfig | PHPUnit_Framework_MockObject_MockObject */
@@ -54,6 +55,8 @@ class UsersControllerTest extends OriginalTest {
 	protected $logger;
 	/** @var UsersController | PHPUnit_Framework_MockObject_MockObject */
 	protected $api;
+	/** @var  AccountManager | PHPUnit_Framework_MockObject_MockObject */
+	protected $accountManager;
 
 	protected function tearDown() {
 		parent::tearDown();
@@ -80,6 +83,9 @@ class UsersControllerTest extends OriginalTest {
 		$request = $this->getMockBuilder('OCP\IRequest')
 			->disableOriginalConstructor()
 			->getMock();
+		$this->accountManager = $this->getMockBuilder(AccountManager::class)
+			->disableOriginalConstructor()
+			->getMock();
 		$this->api = $this->getMockBuilder('OCA\Provisioning_API\Controller\UsersController')
 			->setConstructorArgs([
 				'provisioning_api',
@@ -88,6 +94,7 @@ class UsersControllerTest extends OriginalTest {
 				$this->config,
 				$this->groupManager,
 				$this->userSession,
+				$this->accountManager,
 				$this->logger,
 			])
 			->setMethods(['fillStorageInfo'])
@@ -652,6 +659,16 @@ class UsersControllerTest extends OriginalTest {
 			->method('isAdmin')
 			->with('admin')
 			->will($this->returnValue(true));
+		$this->accountManager->expects($this->any())->method('getUser')
+			->with($targetUser)
+			->willReturn(
+				[
+					AccountManager::PROPERTY_ADDRESS => ['value' => 'address'],
+					AccountManager::PROPERTY_PHONE => ['value' => 'phone'],
+					AccountManager::PROPERTY_TWITTER => ['value' => 'twitter'],
+					AccountManager::PROPERTY_WEBSITE => ['value' => 'website'],
+				]
+			);
 		$this->config
 			->expects($this->at(0))
 			->method('getUserValue')
@@ -672,6 +689,10 @@ class UsersControllerTest extends OriginalTest {
 			'quota' => ['DummyValue'],
 			'email' => 'demo@owncloud.org',
 			'displayname' => 'Demo User',
+			'phone' => 'phone',
+			'address' => 'address',
+			'webpage' => 'website',
+			'twitter' => 'twitter'
 		];
 		$this->assertEquals($expected, $this->api->getUser('UserToGet')->getData());
 	}
@@ -731,12 +752,26 @@ class UsersControllerTest extends OriginalTest {
 			->expects($this->once())
 			->method('getDisplayName')
 			->will($this->returnValue('Demo User'));
+		$this->accountManager->expects($this->any())->method('getUser')
+			->with($targetUser)
+			->willReturn(
+				[
+					AccountManager::PROPERTY_ADDRESS => ['value' => 'address'],
+					AccountManager::PROPERTY_PHONE => ['value' => 'phone'],
+					AccountManager::PROPERTY_TWITTER => ['value' => 'twitter'],
+					AccountManager::PROPERTY_WEBSITE => ['value' => 'website'],
+				]
+			);
 
 		$expected = [
 			'enabled' => 'true',
 			'quota' => ['DummyValue'],
 			'email' => 'demo@owncloud.org',
 			'displayname' => 'Demo User',
+			'phone' => 'phone',
+			'address' => 'address',
+			'webpage' => 'website',
+			'twitter' => 'twitter'
 		];
 		$this->assertEquals($expected, $this->api->getUser('UserToGet')->getData());
 	}
@@ -837,11 +872,25 @@ class UsersControllerTest extends OriginalTest {
 			->expects($this->once())
 			->method('getEMailAddress')
 			->will($this->returnValue('subadmin@owncloud.org'));
+		$this->accountManager->expects($this->any())->method('getUser')
+			->with($targetUser)
+			->willReturn(
+				[
+					AccountManager::PROPERTY_ADDRESS => ['value' => 'address'],
+					AccountManager::PROPERTY_PHONE => ['value' => 'phone'],
+					AccountManager::PROPERTY_TWITTER => ['value' => 'twitter'],
+					AccountManager::PROPERTY_WEBSITE => ['value' => 'website'],
+				]
+			);
 
 		$expected = [
 			'quota' => ['DummyValue'],
 			'email' => 'subadmin@owncloud.org',
 			'displayname' => 'Subadmin User',
+			'phone' => 'phone',
+			'address' => 'address',
+			'webpage' => 'website',
+			'twitter' => 'twitter'
 		];
 		$this->assertEquals($expected, $this->api->getUser('subadmin')->getData());
 	}

--- a/core/Controller/OCSController.php
+++ b/core/Controller/OCSController.php
@@ -106,20 +106,6 @@ class OCSController extends \OCP\AppFramework\OCSController {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 * @return DataResponse
-	 */
-	public function getCurrentUser() {
-		$userObject = $this->userSession->getUser();
-		$data  = [
-			'id' => $userObject->getUID(),
-			'display-name' => $userObject->getDisplayName(),
-			'email' => $userObject->getEMailAddress(),
-		];
-		return new DataResponse($data);
-	}
-
-	/**
 	 * @PublicPage
 	 *
 	 * @param string $login

--- a/core/routes.php
+++ b/core/routes.php
@@ -59,7 +59,6 @@ $application->registerRoutes($this, [
 	],
 	'ocs' => [
 		['root' => '/cloud', 'name' => 'OCS#getCapabilities', 'url' => '/capabilities', 'verb' => 'GET'],
-		['root' => '/cloud', 'name' => 'OCS#getCurrentUser', 'url' => '/user', 'verb' => 'GET'],
 		['root' => '', 'name' => 'OCS#getConfig', 'url' => '/config', 'verb' => 'GET'],
 		['root' => '/person', 'name' => 'OCS#personCheck', 'url' => '/check', 'verb' => 'POST'],
 		['root' => '/identityproof', 'name' => 'OCS#getIdentityProof', 'url' => '/key/{cloudId}', 'verb' => 'GET'],

--- a/tests/Core/Controller/OCSControllerTest.php
+++ b/tests/Core/Controller/OCSControllerTest.php
@@ -116,24 +116,6 @@ class OCSControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->controller->getCapabilities());
 	}
 
-	public function testGetCurrentUser() {
-		$user = $this->createMock(IUser::class);
-		$user->method('getUID')->willReturn('uid');
-		$user->method('getDisplayName')->willReturn('displayName');
-		$user->method('getEMailAddress')->willReturn('e@mail.com');
-
-
-		$this->userSession->method('getUser')
-			->willReturn($user);
-
-		$expected = new DataResponse([
-			'id' => 'uid',
-			'display-name' => 'displayName',
-			'email' => 'e@mail.com',
-		]);
-		$this->assertEquals($expected, $this->controller->getCurrentUser());
-	}
-
 	public function testPersonCheckValid() {
 		$this->request->method('getRemoteAddress')
 			->willReturn('1.2.3.4');


### PR DESCRIPTION
add additional data from the users profile to the output of the previsioning api.

Example call:

````
curl -X GET http://admin:admin@localhost/master/ocs/v1.php/cloud/users/admin -H  "OCS-APIRequest: true"
````

Result:

````
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>ok</status>
  <statuscode>100</statuscode>
  <message>OK</message>
  <totalitems></totalitems>
  <itemsperpage></itemsperpage>
 </meta>
 <data>
  <enabled>true</enabled>
  <quota>
   <free>338696790016</free>
   <used>7438874</used>
   <total>338704228890</total>
   <relative>0</relative>
   <quota>-3</quota>
  </quota>
  <email>user@foo.de</email>
  <displayname>admin</displayname>
  <phone></phone>
  <address></address>
  <webpage></webpage>
  <twitter>schiessle</twitter>
 </data>
</ocs>
````