### PR TITLE
Allow apps to use scss styles

### DIFF
--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -58,10 +58,17 @@ class CSSResourceLocator extends ResourceLocator {
 		) {
 			return;
 		}
+
+
 		$app = substr($style, 0, strpos($style, '/'));
 		$style = substr($style, strpos($style, '/')+1);
 		$app_path = \OC_App::getAppPath($app);
 		$app_url = \OC_App::getAppWebPath($app);
+
+		if ($this->cacheAndAppendScssIfExist($app_path, $style.'.scss', null, $app)) {
+			return;
+		}
+
 		$this->append($app_path, $style.'.css', $app_url);
 	}
 
@@ -81,13 +88,14 @@ class CSSResourceLocator extends ResourceLocator {
 	 * @param string $root path to check
 	 * @param string $file the filename
 	 * @param string|null $webRoot base for path, default map $root to $webRoot
+	 * @param string $app
 	 * @return bool True if the resource was found and cached, false otherwise
 	 */
-	protected function cacheAndAppendScssIfExist($root, $file, $webRoot = null) {
+	protected function cacheAndAppendScssIfExist($root, $file, $webRoot = null, $app = 'core') {
 		if (is_file($root.'/'.$file)) {
 			if($this->scssCacher !== null) {
-				if($this->scssCacher->process($root, $file)) {
-					$this->append($root, $this->scssCacher->getCachedSCSS('core', $file), $webRoot, false);
+				if($this->scssCacher->process($root, $file, $app)) {
+					$this->append($root, $this->scssCacher->getCachedSCSS($app, $file), $webRoot, false);
 					return true;
 				} else {
 					$this->logger->error('Failed to compile and/or save '.$root.'/'.$file, ['app' => 'core']);

--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -65,7 +65,7 @@ class SCSSCacher {
 	 * @param string $file
 	 * @return boolean
 	 */
-	public function process($root, $file) {
+	public function process($root, $file, $app = 'core') {
 		$path = explode('/', $root . '/' . $file);
 
 		$fileNameSCSS = array_pop($path);
@@ -78,10 +78,10 @@ class SCSSCacher {
 		$webDir = implode('/', $webDir);
 
 		try {
-			$folder = $this->appData->getFolder('core');
+			$folder = $this->appData->getFolder($app);
 		} catch(NotFoundException $e) {
 			// creating css appdata folder
-			$folder = $this->appData->newFolder('core');
+			$folder = $this->appData->newFolder($app);
 		}
 
 		if($this->isCached($fileNameCSS, $fileNameSCSS, $folder, $path)) {


### PR DESCRIPTION
Apps can use scss the same way core does, simply using `scss` instead of `css` as extension