### PR TITLE
Make DAV external storage test more reliable

### DIFF
--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -436,10 +436,14 @@ abstract class Common implements Storage, ILockingStorage {
 	 * @return bool
 	 */
 	public function test() {
-		if ($this->stat('')) {
-			return true;
+		try {
+			if ($this->stat('')) {
+				return true;
+			}
+			return false;
+		} catch (\Exception $e) {
+			return false;
 		}
-		return false;
 	}
 
 	/**

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -569,8 +569,8 @@ class DAV extends Common {
 	public function stat($path) {
 		try {
 			$response = $this->propfind($path);
-			if ($response === false) {
-				return [];
+			if (!$response) {
+				return false;
 			}
 			return [
 				'mtime' => strtotime($response['{DAV:}getlastmodified']),


### PR DESCRIPTION
- `propfind` can return null on error instead of only false
- handle exceptions as failures