### PR TITLE
minor storage interface tweaks

### DIFF
--- a/lib/public/Files/Cache/IScanner.php
+++ b/lib/public/Files/Cache/IScanner.php
@@ -32,6 +32,7 @@ interface IScanner {
 	const SCAN_RECURSIVE = true;
 	const SCAN_SHALLOW = false;
 
+	const REUSE_NONE = 0;
 	const REUSE_ETAG = 1;
 	const REUSE_SIZE = 2;
 

--- a/lib/public/Files/Storage/IStorage.php
+++ b/lib/public/Files/Storage/IStorage.php
@@ -383,7 +383,7 @@ interface IStorage {
 	public function verifyPath($path, $fileName);
 
 	/**
-	 * @param \OCP\Files\Storage $sourceStorage
+	 * @param \OCP\Files\Storage|\OCP\Files\Storage\IStorage $sourceStorage
 	 * @param string $sourceInternalPath
 	 * @param string $targetInternalPath
 	 * @return bool
@@ -392,7 +392,7 @@ interface IStorage {
 	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath);
 
 	/**
-	 * @param \OCP\Files\Storage $sourceStorage
+	 * @param \OCP\Files\Storage|\OCP\Files\Storage\IStorage $sourceStorage
 	 * @param string $sourceInternalPath
 	 * @param string $targetInternalPath
 	 * @return bool


### PR DESCRIPTION
- Add an explicit argument to reuse nothing while scanning
- Since \OCP\Files\Storage inherits \OCP\Files\Storage\IStorage and not the other way around we need to allow both to keep phpstorm from complaining