### PR TITLE
Fix left padding for settings sidebar

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -744,7 +744,7 @@ table.grid td.date{
 	width: 16px;
 }
 #app-navigation li span.no-icon {
-	padding-left: 25px;
+	padding-left: 32px;
 }
 
 #security-warning li {


### PR DESCRIPTION
* followup to #3151

Before:

<img width="226" alt="bildschirmfoto 2017-01-24 um 10 58 50" src="https://cloud.githubusercontent.com/assets/245432/22257726/8a1df956-e224-11e6-82e6-5e44e7e04111.png">

After:

<img width="249" alt="bildschirmfoto 2017-01-24 um 10 58 41" src="https://cloud.githubusercontent.com/assets/245432/22257737/8ecb3cb6-e224-11e6-9329-5cff3a854468.png">


I will fix the icons now :)