### PR TITLE
Remove useless dependency on SQLite (non-PDO)

### DIFF
--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -125,8 +125,8 @@ class Setup {
 	public function getSupportedDatabases($allowAllDatabases = false) {
 		$availableDatabases = array(
 			'sqlite' =>  array(
-				'type' => 'class',
-				'call' => 'SQLite3',
+				'type' => 'pdo',
+				'call' => 'sqlite',
 				'name' => 'SQLite'
 			),
 			'mysql' => array(
@@ -163,9 +163,7 @@ class Setup {
 				$type = $availableDatabases[$database]['type'];
 				$call = $availableDatabases[$database]['call'];
 
-				if($type === 'class') {
-					$working = $this->class_exists($call);
-				} elseif ($type === 'function') {
+				if ($type === 'function') {
 					$working = $this->is_callable($call);
 				} elseif($type === 'pdo') {
 					$working = in_array($call, $this->getAvailableDbDriversForPdo(), TRUE);

--- a/tests/lib/SetupTest.php
+++ b/tests/lib/SetupTest.php
@@ -55,16 +55,12 @@ class SetupTest extends \Test\TestCase {
 			));
 		$this->setupClass
 			->expects($this->once())
-			->method('class_exists')
-			->will($this->returnValue(true));
-		$this->setupClass
-			->expects($this->once())
 			->method('is_callable')
 			->will($this->returnValue(false));
 		$this->setupClass
 			->expects($this->any())
 			->method('getAvailableDbDriversForPdo')
-			->will($this->returnValue([]));
+			->will($this->returnValue(['sqlite']));
 		$result = $this->setupClass->getSupportedDatabases();
 		$expectedResult = array(
 			'sqlite' => 'SQLite'
@@ -80,10 +76,6 @@ class SetupTest extends \Test\TestCase {
 			->will($this->returnValue(
 				array('sqlite', 'mysql', 'oci', 'pgsql')
 			));
-		$this->setupClass
-			->expects($this->any())
-			->method('class_exists')
-			->will($this->returnValue(false));
 		$this->setupClass
 			->expects($this->any())
 			->method('is_callable')
@@ -106,16 +98,12 @@ class SetupTest extends \Test\TestCase {
 			));
 		$this->setupClass
 			->expects($this->any())
-			->method('class_exists')
-			->will($this->returnValue(true));
-		$this->setupClass
-			->expects($this->any())
 			->method('is_callable')
 			->will($this->returnValue(true));
 		$this->setupClass
 			->expects($this->any())
 			->method('getAvailableDbDriversForPdo')
-			->will($this->returnValue(['mysql', 'pgsql']));
+			->will($this->returnValue(['sqlite', 'mysql', 'pgsql']));
 		$result = $this->setupClass->getSupportedDatabases();
 		$expectedResult = array(
 			'sqlite' => 'SQLite',


### PR DESCRIPTION
* we only require the PDO driver
* fixes #481

cc @nickvergessen @lukasreschke @icewind1991 @pmattern

I tested this and it still works (I disabled the PHP module sqlite3 ;))