### PR TITLE
fix personal page password form layout

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -568,15 +568,16 @@ label.infield {
 	padding-right: 30px;
 }
 
-#personal-show + label {
-	height: 14px;
-	margin-top: -25px;
-	left: 267px;
-	display: block;
+.personal-show-container {
+	position: relative;
+	display: inline-block;
+	margin-right: 6px;
 }
-
-#passwordbutton {
-	margin-left: .5em;
+#personal-show + label {
+	display: block;
+	right: 0;
+	margin-top: -36px;
+    padding: 6px 4px;
 }
 
 /* Database selector */

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -848,7 +848,7 @@ span.indeterminate {
 /* PASSWORD */
 #passwordform .strengthify-wrapper {
 	position: absolute;
-	left: 166px;
+	left: 0;
 	width: 130px;
 	margin-top: -6px;
 }

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -186,12 +186,14 @@ if($_['passwordChangeSupported']) {
 	<input type="password" id="pass1" name="oldpassword"
 		placeholder="<?php p($l->t('Current password'));?>"
 		autocomplete="off" autocapitalize="off" autocorrect="off" />
-	<label for="pass2" class="hidden-visually"><?php p($l->t('New password'));?>: </label>
-	<input type="password" id="pass2" name="newpassword"
-		placeholder="<?php p($l->t('New password')); ?>"
-		data-typetoggle="#personal-show"
-		autocomplete="off" autocapitalize="off" autocorrect="off" />
-	<input type="checkbox" id="personal-show" name="show" /><label for="personal-show" class="personal-show-label"></label>
+	<div class="personal-show-container">
+		<label for="pass2" class="hidden-visually"><?php p($l->t('New password'));?>: </label>
+		<input type="password" id="pass2" name="newpassword"
+			placeholder="<?php p($l->t('New password')); ?>"
+			data-typetoggle="#personal-show"
+			autocomplete="off" autocapitalize="off" autocorrect="off" />
+		<input type="checkbox" id="personal-show" name="show" /><label for="personal-show" class="personal-show-label"></label>
+	</div>
 	<input id="passwordbutton" type="submit" value="<?php p($l->t('Change password')); ?>" />
 	<br/>
 </form>


### PR DESCRIPTION
On narrow mobile screens, this happened:
![capture du 2017-01-25 12-06-30](https://cloud.githubusercontent.com/assets/925062/22288367/e4cbec5a-e2f6-11e6-9b54-81723e28a81e.png)

Fixed now:
![capture du 2017-01-25 12-04-58](https://cloud.githubusercontent.com/assets/925062/22288366/e4cb6316-e2f6-11e6-97fa-467448c131bb.png)

Please review @nextcloud/designers 
