### PR TITLE
Various scss fixes

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -549,7 +549,6 @@ em {
 	background-color: #fff;
 	color: #333;
 	border-radius: 3px;
-	border-top-right-radius: 0;
 	z-index: 110;
 	margin: 5px;
 	margin-top: -5px;
@@ -582,7 +581,6 @@ em {
 		transform: translateX(50%);
 		right: 50%;
 		margin-right: 0;
-		border-top-right-radius: 3px;
 		&:after {
 			right: 50%;
 			transform: translateX(50%);
@@ -593,8 +591,6 @@ em {
 		right: auto;
 		left: 0;
 		margin-right: 0;
-		border-top-left-radius: 0;
-		border-top-right-radius: 3px;
 		&:after {
 			left: 6px;
 			right: auto;

--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -96,13 +96,12 @@ em {
 		color: #000;
 		opacity: .57;
 	}
-	li:hover > a,
-	li:focus > a,
-	a:focus,
+	> ul > li:hover > a,
+	> ul > li:focus > a,
 	.selected,
-	.selected a,
+	.selected > a,
 	.active,
-	.active a {
+	.active > a {
 		opacity: 1;
 		box-shadow: inset 2px 0 #0082c9;
 	}

--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -60,6 +60,18 @@ em {
 		width: inherit;
 		overflow: auto;
 		box-sizing: border-box;
+		> li {
+			&:focus,
+			&:hover,
+			&.active,
+			a.selected {
+				&,
+				> a {
+					opacity: 1;
+					box-shadow: inset 2px 0 #0082c9;
+				}
+			}
+		}
 	}
 	li {
 		position: relative;
@@ -95,15 +107,6 @@ em {
 		text-overflow: ellipsis;
 		color: #000;
 		opacity: .57;
-	}
-	> ul > li:hover > a,
-	> ul > li:focus > a,
-	.selected,
-	.selected > a,
-	.active,
-	.active > a {
-		opacity: 1;
-		box-shadow: inset 2px 0 #0082c9;
 	}
 	li > a:first-child img {
 	    margin-bottom: -3px;

--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -625,6 +625,7 @@ em {
 			margin: 0;
 			font-weight: inherit;
 			box-shadow: none;
+			color: #333 !important; /* Overwrite app-navigation li */
 			/* prevent .action class to break the design */
 			&.action {
 				padding: inherit !important;
@@ -639,15 +640,15 @@ em {
 				cursor: pointer;
 				white-space: nowrap;
 			}
+			span {
+				-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=70)' !important;
+				filter: alpha(opacity = 70) !important;
+				opacity: .7 !important;
+			}
 			> p {
 				width: 150px;
 				line-height: 1.6em;
 				padding: 8px 0;
-				> span {
-					-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=70)' !important;
-					filter: alpha(opacity = 70) !important;
-					opacity: .7 !important;
-				}
 			}
 			/* Add padding if contains icon+text */
 			&:not(:empty) {
@@ -666,7 +667,8 @@ em {
 			padding: 18px 0 18px 36px;
 			min-width: 0; /* Overwrite icons*/
 			min-height: 0;
-			background-position: 10px center
+			background-position: 10px center;
+			opacity: 0.7; /* Default button icon override */
 		}
 	}
 }

--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -52,6 +52,8 @@ em {
 	-ms-user-select: none;
 	user-select: none;
 	border-right: 1px solid #eee;
+	display: flex;
+	flex-direction: column;
 	> ul {
 		position: relative;
 		height: 100%;


### PR DESCRIPTION
This includes:
1. All corners on the popover menu are now rounded https://github.com/nextcloud/server/issues/2798#issuecomment-274796229
2. Colour and opacity across the popover menu are now unified
3. #app-navigation now uses flex in column, so we don't need to use a calc to make it scrollable. All is now automatic (see [mail](https://github.com/nextcloud/mail/blob/83d078b6e4c6dd5c16bca72f7a58f30a169df12d/css/mail.css#L148), [contacts](https://github.com/nextcloud/contacts/blob/664646299b96205a55fdf43760b70e986c2a9d5e/css/public/style.css#L506)...)
4. Fixed blue shadow too global selector, fix #3288 & fix nextcloud/calendar#321
