### PR TITLE
Make sure we use the correct storage id and parent id when scanning a jailed storage

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -168,7 +168,7 @@ class Scanner extends BasicEmitter implements IScanner {
 					$parent = '';
 				}
 				if ($parentId === -1) {
-					$parentId = $this->cache->getId($parent);
+					$parentId = $this->cache->getParentId($file);
 				}
 
 				// scan the parent if it's not in the cache (id -1) and the current file is not the root folder

--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -142,11 +142,7 @@ class CacheJail extends CacheWrapper {
 	 * @return int
 	 */
 	public function getParentId($file) {
-		if ($file === '') {
-			return -1;
-		} else {
-			return $this->getCache()->getParentId($this->getSourcePath($file));
-		}
+		return $this->getCache()->getParentId($this->getSourcePath($file));
 	}
 
 	/**

--- a/lib/private/Files/Storage/Wrapper/Jail.php
+++ b/lib/private/Files/Storage/Wrapper/Jail.php
@@ -58,7 +58,7 @@ class Jail extends Wrapper {
 	}
 
 	public function getId() {
-		return 'link:' . parent::getId() . ':' . $this->rootPath;
+		return parent::getId();
 	}
 
 	/**


### PR DESCRIPTION
Signed-off-by: Robin Appelman <robin@icewind.nl>