### PR TITLE
Gracefully deny users or groups with too long DNs

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -678,6 +678,9 @@ class Access extends LDAPUtility implements IUserTools {
 	 */
 	public function cacheUserDisplayName($ocName, $displayName, $displayName2 = '') {
 		$user = $this->userManager->get($ocName);
+		if($user === null) {
+			return;
+		}
 		$displayName = $user->composeAndStoreDisplayName($displayName, $displayName2);
 		$cacheKeyTrunk = 'getDisplayName';
 		$this->connection->writeToCache($cacheKeyTrunk.$ocName, $displayName);

--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -209,6 +209,17 @@ abstract class AbstractMapping {
 	 * @return bool
 	 */
 	public function map($fdn, $name, $uuid) {
+		if(mb_strlen($fdn) > 255) {
+			\OC::$server->getLogger()->error(
+				'Cannot map, because the DN exceeds 255 characters: {dn}',
+				[
+					'app' => 'user_ldap',
+					'dn' => $fdn,
+				]
+			);
+			return false;
+		}
+
 		$row = array(
 			'ldap_dn'        => $fdn,
 			'owncloud_name'  => $name,

--- a/apps/user_ldap/tests/Mapping/AbstractMappingTest.php
+++ b/apps/user_ldap/tests/Mapping/AbstractMappingTest.php
@@ -106,7 +106,8 @@ abstract class AbstractMappingTest extends \Test\TestCase {
 		list($mapper, $data) = $this->initTest();
 
 		// test that mapping will not happen when it shall not
-		$paramKeys = array('', 'dn', 'name', 'uuid');
+		$tooLongDN = 'uid=joann,ou=Secret Small Specialized Department,ou=Some Tremendously Important Department,ou=Another Very Important Department,ou=Pretty Meaningful Derpartment,ou=Quite Broad And General Department,ou=The Topmost Department,dc=hugelysuccessfulcompany,dc=com';
+		$paramKeys = array('', 'dn', 'name', 'uuid', $tooLongDN);
 		foreach($paramKeys as $key) {
 			$failEntry = $data[0];
 			if(!empty($key)) {


### PR DESCRIPTION
For #2213 

We limit the DN to 255 characters, as it is used on the DB as primary key.

Technically, there is no limit on the LDAP spec. Since X.500 has a limit on it, the safe way is to avoid those. If currently a user or group appears with a long DN, the DN is cut when inserting to the database and users page rendering is broken. Other side effects are possible.

This PR avoids that such an object gets mapped and used, avoiding such effects.

Possible support can be added in a seperate PR (requires database changes within the ldap backend).

cc @nextcloud/ldap @KB7777