### PR TITLE
make sure that 'getCurrentUser' gets an array in order to manipulate the data to match the old API

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -194,6 +194,42 @@ class UsersController extends OCSController {
 	 * @throws OCSException
 	 */
 	public function getUser($userId) {
+		$data = $this->getUserData($userId);
+		return new DataResponse($data);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoSubAdminRequired
+	 *
+	 * gets user info from the currently logged in user
+	 *
+	 * @return DataResponse
+	 * @throws OCSException
+	 */
+	public function getCurrentUser() {
+		$user = $this->userSession->getUser();
+		if ($user) {
+			$data =  $this->getUserData($user->getUID());
+			// rename "displayname" to "display-name" only for this call to keep
+			// the API stable.
+			$data['display-name'] = $data['displayname'];
+			unset($data['displayname']);
+			return new DataResponse($data);
+
+		}
+
+		throw new OCSException('', \OCP\API::RESPOND_UNAUTHORISED);
+	}
+
+	/**
+	 * creates a array with all user data
+	 *
+	 * @param $userId
+	 * @return array
+	 * @throws OCSException
+	 */
+	protected function getUserData($userId) {
 		$currentLoggedInUser = $this->userSession->getUser();
 
 		$data = [];
@@ -227,31 +263,7 @@ class UsersController extends OCSController {
 		$data['webpage'] = $userAccount[\OC\Accounts\AccountManager::PROPERTY_WEBSITE]['value'];
 		$data['twitter'] = $userAccount[\OC\Accounts\AccountManager::PROPERTY_TWITTER]['value'];
 
-		return new DataResponse($data);
-	}
-
-	/**
-	 * @NoAdminRequired
-	 * @NoSubAdminRequired
-	 *
-	 * gets user info from the currently logged in user
-	 *
-	 * @return DataResponse
-	 * @throws OCSException
-	 */
-	public function getCurrentUser() {
-		$user = $this->userSession->getUser();
-		if ($user) {
-			$result =  $this->getUser($user->getUID());
-			// rename "displayname" to "display-name" only for this call to keep
-			// the API stable.
-			$result['display-name'] = $result['displayname'];
-			unset($result['displayname']);
-			return $result;
-
-		}
-
-		throw new OCSException('', \OCP\API::RESPOND_UNAUTHORISED);
+		return $data;
 	}
 
 	/**

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -634,7 +634,7 @@ class UsersControllerTest extends OriginalTest {
 		$this->api->getUser('UserToGet');
 	}
 
-	public function testGetUserAsAdmin() {
+	public function testGetUserDataAsAdmin() {
 		$loggedInUser = $this->getMockBuilder('OCP\IUser')
 			->disableOriginalConstructor()
 			->getMock();
@@ -702,10 +702,10 @@ class UsersControllerTest extends OriginalTest {
 			'webpage' => 'website',
 			'twitter' => 'twitter'
 		];
-		$this->assertEquals($expected, $this->api->getUser('UserToGet')->getData());
+		$this->assertEquals($expected, $this->invokePrivate($this->api, 'getUserData', ['UserToGet']));
 	}
 
-	public function testGetUserAsSubAdminAndUserIsAccessible() {
+	public function testGetUserDataAsSubAdminAndUserIsAccessible() {
 		$loggedInUser = $this->getMockBuilder('OCP\IUser')
 			->disableOriginalConstructor()
 			->getMock();
@@ -786,7 +786,7 @@ class UsersControllerTest extends OriginalTest {
 			'webpage' => 'website',
 			'twitter' => 'twitter'
 		];
-		$this->assertEquals($expected, $this->api->getUser('UserToGet')->getData());
+		$this->assertEquals($expected, $this->invokePrivate($this->api, 'getUserData', ['UserToGet']));
 	}
 
 
@@ -794,7 +794,7 @@ class UsersControllerTest extends OriginalTest {
 	 * @expectedException \OCP\AppFramework\OCS\OCSException
 	 * @expectedExceptionCode 997
 	 */
-	public function testGetUserAsSubAdminAndUserIsNotAccessible() {
+	public function testGetUserDataAsSubAdminAndUserIsNotAccessible() {
 		$loggedInUser = $this->getMockBuilder('OCP\IUser')
 			->disableOriginalConstructor()
 			->getMock();
@@ -832,10 +832,10 @@ class UsersControllerTest extends OriginalTest {
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
 
-		$this->api->getUser('UserToGet');
+		$this->invokePrivate($this->api, 'getUserData', ['UserToGet']);
 	}
 
-	public function testGetUserAsSubAdminSelfLookup() {
+	public function testGetUserDataAsSubAdminSelfLookup() {
 		$loggedInUser = $this->getMockBuilder('OCP\IUser')
 			->disableOriginalConstructor()
 			->getMock();
@@ -910,7 +910,7 @@ class UsersControllerTest extends OriginalTest {
 			'webpage' => 'website',
 			'twitter' => 'twitter'
 		];
-		$this->assertEquals($expected, $this->api->getUser('subadmin')->getData());
+		$this->assertEquals($expected, $this->invokePrivate($this->api, 'getUserData', ['subadmin']));
 	}
 
 	public function testEditUserRegularUserSelfEditChangeDisplayName() {
@@ -2573,10 +2573,10 @@ class UsersControllerTest extends OriginalTest {
 				$this->accountManager,
 				$this->logger,
 			])
-			->setMethods(['getUser'])
+			->setMethods(['getUserData'])
 			->getMock();
 
-		$api->expects($this->once())->method('getUser')->with('UID')
+		$api->expects($this->once())->method('getUserData')->with('UID')
 			->willReturn(
 				[
 					'id' => 'UID',
@@ -2603,7 +2603,7 @@ class UsersControllerTest extends OriginalTest {
 			'display-name' => 'Demo User'
 		];
 
-		$this->assertSame($expected, $api->getCurrentUser());
+		$this->assertSame($expected, $api->getCurrentUser()->getData());
 	}
 
 	/**
@@ -2617,5 +2617,40 @@ class UsersControllerTest extends OriginalTest {
 		$this->api->getCurrentUser();
 	}
 
+
+	public function testGetUser() {
+		/** @var UsersController | PHPUnit_Framework_MockObject_MockObject $api */
+		$api = $this->getMockBuilder('OCA\Provisioning_API\Controller\UsersController')
+			->setConstructorArgs([
+				'provisioning_api',
+				$this->request,
+				$this->userManager,
+				$this->config,
+				$this->groupManager,
+				$this->userSession,
+				$this->accountManager,
+				$this->logger,
+			])
+			->setMethods(['getUserData'])
+			->getMock();
+
+		$expected = [
+			'id' => 'UID',
+			'enabled' => 'true',
+			'quota' => ['DummyValue'],
+			'email' => 'demo@owncloud.org',
+			'phone' => 'phone',
+			'address' => 'address',
+			'webpage' => 'website',
+			'twitter' => 'twitter',
+			'displayname' => 'Demo User'
+		];
+
+		$api->expects($this->once())->method('getUserData')
+			->with('uid')
+			->willReturn($expected);
+
+		$this->assertSame($expected, $api->getUser('uid')->getData());
+	}
 
 }


### PR DESCRIPTION
fix the issue detected here: https://github.com/nextcloud/server/pull/3259

cc @MorrisJobke @nickvergessen 