### PR TITLE
Merge similar properties and standardize the arrow to the menu class

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -20,6 +20,21 @@
 	-webkit-user-select: none;
 	-moz-user-select: none;
 	-ms-user-select: none;
+
+	/* Dropdown menu arrow */
+	&.menu:after,
+	.menu:after {
+		border: 10px solid transparent;
+		border-color: transparent;
+		border-bottom-color: #fff;
+		bottom: 100%;
+		content: ' ';
+		height: 0;
+		width: 0;
+		position: absolute;
+		pointer-events: none;
+		margin-left: -10px;
+	}
 }
 
 /* removed until content-focusing issue is fixed */
@@ -194,21 +209,8 @@
 	border-top-right-radius: 0;
 	display: none;
 	box-sizing: border-box;
-	/*overflow-y: auto;
-	overflow-x: hidden;*/
 	z-index: 2000;
 	&:after {
-		bottom: 100%;
-		border: solid transparent;
-		content: ' ';
-		height: 0;
-		width: 0;
-		position: absolute;
-		pointer-events: none;
-		border-color: rgba(0, 0, 0, 0);
-		border-bottom-color: rgba(255, 255, 255, 0.97);
-		border-width: 10px;
-		margin-left: -10px;
 		left: 47%;
 	}
 	* {
@@ -381,16 +383,6 @@
 	&:after {
 		/* position of dropdown arrow */
 		right: 15px;
-		border: 10px solid transparent;
-		border-color: transparent;
-		border-bottom-color: #fff;
-		bottom: 100%;
-		content: ' ';
-		height: 0;
-		width: 0;
-		position: absolute;
-		pointer-events: none;
-		margin-left: -10px;
 	}
 	a {
 		display: block;


### PR DESCRIPTION
1. set the menu class
2. define the position of the :after element

~~fix~~ ref #3274

![capture d ecran_2017-01-26_15-58-48](https://cloud.githubusercontent.com/assets/14975046/22335808/60a2ab86-e3e0-11e6-824d-6c0956402e6d.png) ![capture d ecran_2017-01-26_15-58-54](https://cloud.githubusercontent.com/assets/14975046/22335806/6064445e-e3e0-11e6-8663-b7cf1e99bd30.png) ![capture d ecran_2017-01-26_15-59-02](https://cloud.githubusercontent.com/assets/14975046/22335807/608049a6-e3e0-11e6-8e07-707fbb303ee8.png)


@nextcloud/designers 