### PR TITLE
make timeout for brute force operation configurable

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -192,8 +192,9 @@ class SecurityMiddleware extends Middleware {
 		}
 
 		if($this->reflector->hasAnnotation('BruteForceProtection')) {
+			$timeout = $this->getTimeout();
 			$action = $this->reflector->getAnnotationParameter('BruteForceProtection');
-			$this->throttler->sleepDelay($this->request->getRemoteAddress(), $action);
+			$this->throttler->sleepDelay($this->request->getRemoteAddress(), $action, $timeout);
 			$this->throttler->registerAttempt($action, $this->request->getRemoteAddress());
 		}
 
@@ -208,6 +209,24 @@ class SecurityMiddleware extends Middleware {
 		}
 
 	}
+
+	/**
+	 * get timeout for brute force protection in minutes
+	 * @return int timeout in seconds
+	 */
+	protected function getTimeout() {
+		// default timeout: 10 minutes
+		$timeout = 600;
+		if($this->reflector->hasAnnotation('BruteForceProtectionTimeout')) {
+			$parameter = $this->reflector->getAnnotationParameter('BruteForceProtectionTimeout');
+			if (is_int($parameter) || ctype_digit($parameter)) {
+				$timeout = (int)$parameter;
+			}
+		}
+
+		return $timeout;
+	}
+
 
 	/**
 	 * Performs the default CSP modifications that may be injected by other

--- a/lib/private/Security/Bruteforce/Throttler.php
+++ b/lib/private/Security/Bruteforce/Throttler.php
@@ -190,11 +190,12 @@ class Throttler {
 	 *
 	 * @param string $ip
 	 * @param string $action optionally filter by action
+	 * @param int $timeout how long to we go back in time to count attempts to call the API in seconds
 	 * @return int
 	 */
-	public function getDelay($ip, $action = '') {
+	public function getDelay($ip, $action = '', $timeout = 43200) {
 		$cutoffTime = (new \DateTime())
-			->sub($this->getCutoff(43200))
+			->sub($this->getCutoff($timeout))
 			->getTimestamp();
 
 		$qb = $this->db->getQueryBuilder();
@@ -232,10 +233,11 @@ class Throttler {
 	 *
 	 * @param string $ip
 	 * @param string $action optionally filter by action
+	 * @param int $timeout how long to we go back in time to count attempts to call the API in seconds
 	 * @return int the time spent sleeping
 	 */
-	public function sleepDelay($ip, $action = '') {
-		$delay = $this->getDelay($ip, $action);
+	public function sleepDelay($ip, $action = '', $timeout = 43200) {
+		$delay = $this->getDelay($ip, $action, $timeout);
 		usleep($delay * 1000);
 		return $delay;
 	}

--- a/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
@@ -768,6 +768,10 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		return [
 			[true, 60, 60],
 			[true, '60', 60],
+			[true, '60.3', 600],
+			[true, 60.3, 600],
+			[true, '60f', 600],
+			[true, true, 600],
 			[true, 'foo', 600],
 			[false, 60, 600],
 		];

--- a/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
@@ -665,21 +665,25 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		/** @var ControllerMethodReflector|\PHPUnit_Framework_MockObject_MockObject $reader */
 		$reader = $this->getMockBuilder(ControllerMethodReflector::class)->disableOriginalConstructor()->getMock();
 
-		$middleware = new SecurityMiddleware(
-			$this->request,
-			$reader,
-			$this->navigationManager,
-			$this->urlGenerator,
-			$this->logger,
-			$this->session,
-			'files',
-			false,
-			false,
-			$this->contentSecurityPolicyManager,
-			$this->csrfTokenManager,
-			$this->cspNonceManager,
-			$this->bruteForceThrottler
-		);
+		/** @var SecurityMiddleware | \PHPUnit_Framework_MockObject_MockObject $middleware */
+		$middleware = $this->getMockBuilder(SecurityMiddleware::class)
+			->setConstructorArgs(
+				[
+					$this->request,
+					$reader,
+					$this->navigationManager,
+					$this->urlGenerator,
+					$this->logger,
+					$this->session,
+					'files',
+					false,
+					false,
+					$this->contentSecurityPolicyManager,
+					$this->csrfTokenManager,
+					$this->cspNonceManager,
+					$this->bruteForceThrottler
+				]
+			)->setMethods(['getTimeout'])->getMock();
 
 		$reader->expects($this->any())->method('hasAnnotation')
 			->willReturnCallback(
@@ -704,11 +708,13 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->request->expects($this->any())->method('getRemoteAddress')->willReturn('remoteAddress');
 
 		if ($bruteForceProtectionEnabled) {
+			$middleware->expects($this->once())->method('getTimeout')->willReturn(42);
 			$this->bruteForceThrottler->expects($this->once())->method('sleepDelay')
-				->with('remoteAddress', 'action');
+				->with('remoteAddress', 'action', 42);
 			$this->bruteForceThrottler->expects($this->once())->method('registerAttempt')
 				->with('action', 'remoteAddress');
 		} else {
+			$middleware->expects($this->never())->method('getTimeout');
 			$this->bruteForceThrottler->expects($this->never())->method('sleepDelay');
 			$this->bruteForceThrottler->expects($this->never())->method('registerAttempt');
 		}
@@ -723,4 +729,48 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 			[false]
 		];
 	}
+
+	/**
+	 * @dataProvider dataTestGetTimeout
+	 * @param bool $hasAnnotation
+	 * @param mixed $parameter
+	 * @param int $expected
+	 */
+	public function testGetTimestamp($hasAnnotation, $parameter, $expected) {
+		/** @var ControllerMethodReflector|\PHPUnit_Framework_MockObject_MockObject $reader */
+		$reader = $this->getMockBuilder(ControllerMethodReflector::class)->disableOriginalConstructor()->getMock();
+
+		$middleware = new SecurityMiddleware(
+			$this->request,
+			$reader,
+			$this->navigationManager,
+			$this->urlGenerator,
+			$this->logger,
+			$this->session,
+			'files',
+			false,
+			false,
+			$this->contentSecurityPolicyManager,
+			$this->csrfTokenManager,
+			$this->cspNonceManager,
+			$this->bruteForceThrottler
+		);
+
+		$reader->expects($this->any())->method('hasAnnotation')->with('BruteForceProtectionTimeout')
+			->willReturn($hasAnnotation);
+		$reader->expects($this->any())->method('getAnnotationParameter')->with('BruteForceProtectionTimeout')
+			->willReturn($parameter);
+
+		$this->assertSame($expected, $this->invokePrivate($middleware, 'getTimeout'));
+	}
+
+	public function dataTestGetTimeout() {
+		return [
+			[true, 60, 60],
+			[true, '60', 60],
+			[true, 'foo', 600],
+			[false, 60, 600],
+		];
+	}
+
 }


### PR DESCRIPTION
General default is 12 hours, default for API calls is 10 minutes. If you want to adjust it for your API call use:

````
/**
 * @BruteForceProtection <myapi>
 * @BruteForceProtectionTimeout <seconds>
 */
````


fix https://github.com/nextcloud/server/issues/3276