### PR TITLE
remove obsolete hack (#26928)

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -205,18 +205,7 @@ class Local extends \OC\Files\Storage\Common {
 	}
 
 	public function file_get_contents($path) {
-		// file_get_contents() has a memory leak: https://bugs.php.net/bug.php?id=61961
-		$fileName = $this->getSourcePath($path);
-
-		$fileSize = filesize($fileName);
-		if ($fileSize === 0) {
-			return '';
-		}
-
-		$handle = fopen($fileName, 'rb');
-		$content = fread($handle, $fileSize);
-		fclose($handle);
-		return $content;
+		return file_get_contents($this->getSourcePath($path));
 	}
 
 	public function file_put_contents($path, $data) {


### PR DESCRIPTION
* remove obsolete hack

> // file_get_contents() has a memory leak: https://bugs.php.net/bug.php?id=61961
was closed 4 years ago. we could also use the Common implementation

https://github.com/owncloud/core/pull/26928