### PR TITLE
only chmod logfile if necessary

### DIFF
--- a/lib/private/Log/File.php
+++ b/lib/private/Log/File.php
@@ -116,7 +116,9 @@ class File {
 		);
 		$entry = json_encode($entry);
 		$handle = @fopen(self::$logFile, 'a');
-		@chmod(self::$logFile, 0640);
+		if ((fileperms(self::$logFile) & 0777) != 0640) {
+			@chmod(self::$logFile, 0640);
+		}
 		if ($handle) {
 			fwrite($handle, $entry."\n");
 			fclose($handle);


### PR DESCRIPTION
otherwise e.g. on SELinux this will log an error, so we better avoid it if not necessary.