### PR TITLE
do not delete app data directoy after each test

### DIFF
--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -311,13 +311,17 @@ abstract class TestCase extends TestCasePhpUnitCompatibility {
 	 * @param string $dataDir
 	 */
 	static protected function tearDownAfterClassCleanStrayDataFiles($dataDir) {
-		$knownEntries = array(
+		$knownEntries = [
 			'nextcloud.log' => true,
 			'owncloud.db' => true,
 			'.ocdata' => true,
 			'..' => true,
 			'.' => true,
-		);
+		];
+		$instanceId = \OC::$server->getSystemConfig()->getValue('instanceid', null);
+		if (!is_null($instanceId)) {
+			$knownEntries['appdata_' . $instanceId] = true;
+		}
 
 		if ($dh = opendir($dataDir)) {
 			while (($file = readdir($dh)) !== false) {


### PR DESCRIPTION
Everytime I run unit tests locally, where the test class extended server's test case, the app data directory disappeared. After adding the app data directoy to the list of files that should not be deleted, I can run unit tests locally without destroying the installation :rocket:

I do not know if this has consequences on other tests. Let's see what drone reports :wink:

cc @rullzer 