### PR TITLE
LDAP's checkPassword should only catch when a user was not found, fixes #2431

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -965,10 +965,6 @@ class Access extends LDAPUtility implements IUserTools {
 		$sr = $this->ldap->search($linkResources, $base, $filter, $attr);
 		$error = $this->ldap->errno($cr);
 		if(!is_array($sr) || $error !== 0) {
-			\OCP\Util::writeLog('user_ldap',
-				'Error when searching: '.$this->ldap->error($cr).
-					' code '.$this->ldap->errno($cr),
-				\OCP\Util::ERROR);
 			\OCP\Util::writeLog('user_ldap', 'Attempt for Paging?  '.print_r($pagedSearchOK, true), \OCP\Util::ERROR);
 			return false;
 		}

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -136,17 +136,16 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 	}
 
 	/**
-	 * Check if the password is correct
+	 * Check if the password is correct without logging in the user
+	 *
 	 * @param string $uid The username
 	 * @param string $password The password
 	 * @return false|string
-	 *
-	 * Check if the password is correct without logging in the user
 	 */
 	public function checkPassword($uid, $password) {
 		try {
 			$ldapRecord = $this->getLDAPUserByLoginName($uid);
-		} catch(\Exception $e) {
+		} catch(NotOnLDAP $e) {
 			if($this->ocConfig->getSystemValue('loglevel', Util::WARN) === Util::DEBUG) {
 				\OC::$server->getLogger()->logException($e, ['app' => 'user_ldap']);
 			}


### PR DESCRIPTION
LDAP's checkPassword() always returned false, no matter whether the user who tried to log in could not be found on the server, or the server is unavailable. This was due to too broadly catching Exceptions, which now is fixed.

While debugging I figured out that ldap_search calls did not pass error processing in the wrapper, because of a different return format. 

In order to reproduce the whole thing I
1. set a breakpoint at https://github.com/nextcloud/server/blob/master/lib/private/User/Session.php#L632 (often it wouldn't stop, a breakpoint at L518 and some stepping helps then)
2.  I kept the client running, restarted the webserver, and changed something in the synced folder
3. When  the IDE stopped at the breakpoint, I turned of the LDAP server

When letting it go, usually the app password got revoked. 