### PR TITLE
Transparent white checkbox

### DIFF
--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -265,16 +265,13 @@ input {
 		&.radio--white,
 		&.checkbox--white {
 			+ label:before {
-				border-color: #aaa;
+				border-color: #ddd;
 			}
 			&:not(:disabled):not(:checked) + label:hover:before,
 			&:focus + label:before {
 				border-color: #fff;
 			}
-			&:checked + label:before,
-			&.checkbox:indeterminate + label:before {
-			/* ^ :indeterminate have a strange behavior on radio,
-			so we respecified the checkbox class again to be safe */
+			&:checked + label:before {
 				box-shadow: inset 0px 0px 0px 2px #000;
 				background-color: #eee;
 				border-color: #eee
@@ -290,7 +287,10 @@ input {
 			}
 		}
 		&.checkbox--white {
-			&:checked + label:before {
+			&:checked + label:before,
+			&:indeterminate + label:before {
+				background-color: transparent !important; /* Override default checked */
+				border-color: #fff !important; /* Override default checked */
 				background-image: url('../img/actions/checkbox-mark-white.svg');
 			}
 			&:indeterminate + label:before {

--- a/core/img/actions/checkbox-mark-white.svg
+++ b/core/img/actions/checkbox-mark-white.svg
@@ -1,1 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16"><path d="M11.924 4.066l-4.932 4.97-2.828-2.83L2.75 7.618l4.242 4.243 6.365-6.365-1.433-1.432z"/></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16" height="16" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <path d="m0 0v16h16v-16h-16zm11.924 4.0664l1.4336 1.4297-6.3652 6.3652-4.2422-4.2441 1.4141-1.4121 2.8281 2.8301 4.9316-4.9688z" fill="#fff"/>
+</svg>

--- a/core/img/actions/checkbox-mixed-white.svg
+++ b/core/img/actions/checkbox-mixed-white.svg
@@ -1,1 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M4 7v2h8V7H4z"/></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16" height="16" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <path d="m0 0v16h16v-16h-16zm4 7h8v2h-8v-2z" fill="#fff"/>
+</svg>


### PR DESCRIPTION
Following https://github.com/nextcloud/server/pull/3257#issuecomment-275119862
More-or-less related: #3257 

@nextcloud/designers what do you think? We give up css colouring but we gain transparency, is it worth it?

**Technology used:** we now have a big white square with a transparent mark on it (checked or mixed) and we set is as background with an hidden overflow .

![capture d ecran_2017-01-31_19-30-12](https://cloud.githubusercontent.com/assets/14975046/22478808/be6d4992-e7eb-11e6-9766-74fc05100460.png)
