### PR TITLE
Fix files mobile view

### DIFF
--- a/apps/files/css/mobile.css
+++ b/apps/files/css/mobile.css
@@ -1,4 +1,7 @@
-@media only screen and (max-width: 768px) {
+/* 938 = table min-width(688) + app-navigation width: 250
+   769 = size where app-navigation (768) is hidden +1
+   688 = table min-width */
+@media only screen and (max-width: 938px) and (min-width: 769px), only screen and (max-width: 688px) {
 
 .app-files #app-content.dir-drop{
 	background-color: rgba(255, 255, 255, 1)!important;


### PR DESCRIPTION
Fix #3185
![kazam_screencast_00001](https://cloud.githubusercontent.com/assets/14975046/22518698/d8c183a4-e8ad-11e6-9d9a-05ebec17dc63.gif)

Added two width settings for the mobile view activation
Mobile view: `screen<688` AND `769<screen<938`
Reasons: since the table has a min-width, there was a small transition where the table will be cut on the left (between the 688 min width and the 768px width when the app-navigation sidebar is hidden)

@nextcloud/designers 