### PR TITLE
Disable the cookie check when authorization headers are send.

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -490,7 +490,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 * @return bool
 	 */
 	private function cookieCheckRequired() {
-		if($this->getCookie(session_name()) === null && $this->getCookie('oc_token') === null) {
+		if($this->getCookie(session_name()) === null && $this->getCookie('oc_token') === null || (isset($this->items['server']['PHP_AUTH_USER']) && isset($this->items['server']['PHP_AUTH_PW']) )) {
 			return false;
 		}
 


### PR DESCRIPTION
I had a really hard time detecting my redirecting errors.

Finally found them, seems that when the extension calls an endpoint (with an Authorization header set) it send the cookies with them, and no way to disable that.
Nextcloud see's the cookie's and does a check on them using `passesLaxCookieCheck` and `cookieCheckRequired`.
In my opinion the cookie check is not needed when using an Authorization header, since you already supply the credentials with it.

Really hope that this could get merged fast, since this is the major blocker for releasing the passman extension.