### PR TITLE
oc_token should be nc_token

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -98,7 +98,7 @@ class LoginController extends Controller {
 	 * @return RedirectResponse
 	 */
 	public function logout() {
-		$loginToken = $this->request->getCookie('oc_token');
+		$loginToken = $this->request->getCookie('nc_token');
 		if (!is_null($loginToken)) {
 			$this->config->deleteUserValue($this->userSession->getUser()->getUID(), 'login_token', $loginToken);
 		}

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -490,7 +490,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 * @return bool
 	 */
 	private function cookieCheckRequired() {
-		if($this->getCookie(session_name()) === null && $this->getCookie('oc_token') === null) {
+		if($this->getCookie(session_name()) === null && $this->getCookie('nc_token') === null) {
 			return false;
 		}
 

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -89,7 +89,7 @@ class LoginControllerTest extends TestCase {
 		$this->request
 			->expects($this->once())
 			->method('getCookie')
-			->with('oc_token')
+			->with('nc_token')
 			->willReturn(null);
 		$this->config
 			->expects($this->never())
@@ -108,7 +108,7 @@ class LoginControllerTest extends TestCase {
 		$this->request
 			->expects($this->once())
 			->method('getCookie')
-			->with('oc_token')
+			->with('nc_token')
 			->willReturn('MyLoginToken');
 		$user = $this->getMockBuilder('\\OCP\\IUser')->getMock();
 		$user

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -1651,7 +1651,7 @@ class RequestTest extends \Test\TestCase {
 						'HTTP_REQUESTTOKEN' => 'AAAHGxsTCTc3BgMQESAcNR0OAR0=:MyTotalSecretShareds',
 					],
 					'cookies' => [
-						'oc_token' => 'asdf',
+						'nc_token' => 'asdf',
 					],
 				],
 				$this->secureRandom,


### PR DESCRIPTION
I noticed this inconsistency when I took a look at https://github.com/nextcloud/server/pull/3361.

The cookie is set here: https://github.com/nextcloud/server/blob/a3f835872f17f749ae8f623b73ac30c9c2fbdc97/lib/private/User/Session.php#L795

@LukasReschke as discussed 😉 