### PR TITLE
fix shared-as-busy events for owner

### DIFF
--- a/apps/dav/lib/CalDAV/CalendarObject.php
+++ b/apps/dav/lib/CalDAV/CalendarObject.php
@@ -1,8 +1,10 @@
 <?php
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @copyright Copyright (c) 2017, Georg Ehrke
  *
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Georg Ehrke <oc.list@georgehrke.com>
  *
  * @license AGPL-3.0
  *
@@ -42,7 +44,11 @@ class CalendarObject extends \Sabre\CalDAV\CalendarObject {
 	}
 
 	private function isShared() {
-		return isset($this->calendarInfo['{http://owncloud.org/ns}owner-principal']);
+		if (!isset($this->calendarInfo['{http://owncloud.org/ns}owner-principal'])) {
+			return false;
+		}
+
+		return $this->calendarInfo['{http://owncloud.org/ns}owner-principal'] !== $this->calendarInfo['principaluri'];
 	}
 
 	/**

--- a/apps/dav/tests/unit/CalDAV/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarTest.php
@@ -334,16 +334,14 @@ EOD;
 			->willReturn($calObject1)->with(666, 'event-1');
 
 		$calendarInfo = [
+			'{http://owncloud.org/ns}owner-principal' => $isShared ? 'user1' : 'user2',
 			'principaluri' => 'user2',
 			'id' => 666,
 			'uri' => 'cal',
 		];
-
-		if ($isShared) {
-			$calendarInfo['{http://owncloud.org/ns}owner-principal'] = 'user1';
-
-		}
 		$c = new Calendar($backend, $calendarInfo, $this->l10n);
+
+		$this->assertEquals(count($c->getChildren()), $expectedChildren);
 
 		// test private event
 		$privateEvent = $c->getChild('event-1');


### PR DESCRIPTION
backport of https://github.com/nextcloud/server/pull/3275

