### PR TITLE
Do not prevent subfolder uploads if same file exists in current direc…

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -644,6 +644,12 @@ OC.Uploader.prototype = _.extend({
 				// no list to check against
 				return true;
 			}
+
+			// We cannot detect conflicts in other folders
+			if (fileList.getCurrentDirectory() !== upload.getTargetFolder()) {
+				return true;
+			}
+
 			var fileInfo = fileList.findFile(file.name);
 			if (fileInfo) {
 				conflicts.push([


### PR DESCRIPTION
…tory

@MorrisJobke some js tests are failing, but I'm unsure if they should even pass. For example https://github.com/nextcloud/server/blob/fa96b9e356cc52207a7a8ea5caf569203157ad1b/apps/files/tests/js/fileUploadSpec.js#L164-L187 looks fishy. Why would we show the conflict dialog if there are no conflicts? I don't get it 🙊 

fixes https://github.com/nextcloud/server/issues/1218