### PR TITLE
Don't log the password on confirmPassword when LDAP throws an exception

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -88,7 +88,8 @@ class Log implements ILogger {
 		'decrypt',
 
 		//LoginController
-		'tryLogin'
+		'tryLogin',
+		'confirmPassword',
 	];
 
 	/**


### PR DESCRIPTION
Signed-off-by: Joas Schilling <coding@schilljs.com>