### PR TITLE
return unknown free space from nullstorage

### DIFF
--- a/lib/private/Lockdown/Filesystem/NullStorage.php
+++ b/lib/private/Lockdown/Filesystem/NullStorage.php
@@ -20,6 +20,7 @@
 namespace OC\Lockdown\Filesystem;
 
 use Icewind\Streams\IteratorDirectory;
+use OC\Files\FileInfo;
 use OC\Files\Storage\Common;
 
 class NullStorage extends Common {
@@ -128,7 +129,7 @@ class NullStorage extends Common {
 	}
 
 	public function free_space($path) {
-		return 0;
+		return FileInfo::SPACE_UNKNOWN;
 	}
 
 	public function touch($path, $mtime = null) {

--- a/tests/lib/Lockdown/Filesystem/NullStorageTest.php
+++ b/tests/lib/Lockdown/Filesystem/NullStorageTest.php
@@ -27,6 +27,7 @@ use Icewind\Streams\IteratorDirectory;
 use OC\ForbiddenException;
 use OC\Lockdown\Filesystem\NullCache;
 use OC\Lockdown\Filesystem\NullStorage;
+use OC\Files\FileInfo;
 use OCP\Files\Storage;
 use Test\TestCase;
 
@@ -182,7 +183,7 @@ class NullStorageTest extends TestCase  {
 	}
 
 	public function testFree_space() {
-		$this->assertSame(0, $this->storage->free_space('foo'));
+		$this->assertSame(FileInfo::SPACE_UNKNOWN, $this->storage->free_space('foo'));
 	}
 
 	public function testTouch() {


### PR DESCRIPTION
Fixes #3085

Cal/Carddav does a quota check when creating new items, so we need to have a nonzero free space