### PR TITLE
Regenerate a session id for Apache authentication

### DIFF
--- a/lib/private/legacy/user.php
+++ b/lib/private/legacy/user.php
@@ -186,6 +186,8 @@ class OC_User {
 
 		if ($uid) {
 			if (self::getUser() !== $uid) {
+				self::getUserSession()->getSession()->regenerateId();
+				
 				self::setUserId($uid);
 				self::setDisplayName($uid);
 				self::getUserSession()->setLoginName($uid);


### PR DESCRIPTION
Regenerate a new session id when the IApacheBackend authentication source is used to avoid session token collision in a database.

While using an authentication backend implementing IApacheBackend interface, the following scenario may occur:

### Nextcloud version ###
11.0.1

### Web server ###
Apache 2.4.7

### PHP version ###
PHP 5.6.27

### Scenario ###

1. User authenticates using the custom Apache backend and close the tab on the browser.
2. Nextcloud session expires, but the session of custom ApacheBackend does not.
3. User access nextcloud and get the exception:
```
"Doctrine\\DBAL\\Exception\\UniqueConstraintViolationException","Message":"An exception occurred while executing 'INSERT INTO `oc_authtoken`(`uid`,`login_name`,`name`,`token`,`type`,`last_activity`) VALUES(?,?,?,?,?,?)' with params [\"user\", \"user\", \"Mozilla\\\/5.0 (X11; Linux x86_64) AppleWebKit\\\/537.36 (KHTML, like Gecko) Chrome\\\/56.0.2924.87 Safari\\\/537.36\", \"e5f5dc13c55d140aeb37a6dc6e53df948c9337f92db6252731c08e6a7c6b5f939f2487be737cc29699316cef446a0005068a8c712b0fea9ed16404e73eec128c\", 0, 1486457091]:\n\nSQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'e5f5dc13c55d140aeb37a6dc6e53df948c9337f92db6252731c08e6a7c6b5f93' for key 'authtoken_token_index'
```

Regenerating the session id prevents from attempt to put the token into database with the same session id.