### PR TITLE
add groups to user info output

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -252,6 +252,11 @@ class UsersController extends OCSController {
 		}
 
 		$userAccount = $this->accountManager->getUser($targetUserObject);
+		$groups = $this->groupManager->getUserGroups($targetUserObject);
+		$gids = [];
+		foreach ($groups as $group) {
+			$gids[] = $group->getDisplayName();
+		}
 
 		// Find the data
 		$data['id'] = $targetUserObject->getUID();
@@ -262,6 +267,7 @@ class UsersController extends OCSController {
 		$data['address'] = $userAccount[\OC\Accounts\AccountManager::PROPERTY_ADDRESS]['value'];
 		$data['webpage'] = $userAccount[\OC\Accounts\AccountManager::PROPERTY_WEBSITE]['value'];
 		$data['twitter'] = $userAccount[\OC\Accounts\AccountManager::PROPERTY_TWITTER]['value'];
+		$data['groups'] = $gids;
 
 		return $data;
 	}

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -635,6 +635,9 @@ class UsersControllerTest extends OriginalTest {
 	}
 
 	public function testGetUserDataAsAdmin() {
+		$group = $this->getMockBuilder(IGroup::class)
+			->disableOriginalConstructor()
+			->getMock();
 		$loggedInUser = $this->getMockBuilder('OCP\IUser')
 			->disableOriginalConstructor()
 			->getMock();
@@ -662,6 +665,19 @@ class UsersControllerTest extends OriginalTest {
 			->method('isAdmin')
 			->with('admin')
 			->will($this->returnValue(true));
+		$this->groupManager
+			->expects($this->any())
+			->method('getUserGroups')
+			->willReturn([$group, $group, $group]);
+		$group->expects($this->at(0))
+			->method('getDisplayName')
+			->willReturn('group0');
+		$group->expects($this->at(1))
+			->method('getDisplayName')
+			->willReturn('group1');
+		$group->expects($this->at(2))
+			->method('getDisplayName')
+			->willReturn('group2');
 		$this->accountManager->expects($this->any())->method('getUser')
 			->with($targetUser)
 			->willReturn(
@@ -700,7 +716,8 @@ class UsersControllerTest extends OriginalTest {
 			'phone' => 'phone',
 			'address' => 'address',
 			'webpage' => 'website',
-			'twitter' => 'twitter'
+			'twitter' => 'twitter',
+			'groups' => ['group0', 'group1', 'group2']
 		];
 		$this->assertEquals($expected, $this->invokePrivate($this->api, 'getUserData', ['UserToGet']));
 	}
@@ -734,6 +751,10 @@ class UsersControllerTest extends OriginalTest {
 			->method('isAdmin')
 			->with('subadmin')
 			->will($this->returnValue(false));
+		$this->groupManager
+			->expects($this->any())
+			->method('getUserGroups')
+			->willReturn([]);
 		$subAdminManager = $this->getMockBuilder('OC\SubAdmin')
 			->disableOriginalConstructor()
 			->getMock();
@@ -784,7 +805,8 @@ class UsersControllerTest extends OriginalTest {
 			'phone' => 'phone',
 			'address' => 'address',
 			'webpage' => 'website',
-			'twitter' => 'twitter'
+			'twitter' => 'twitter',
+			'groups' => []
 		];
 		$this->assertEquals($expected, $this->invokePrivate($this->api, 'getUserData', ['UserToGet']));
 	}
@@ -872,6 +894,10 @@ class UsersControllerTest extends OriginalTest {
 			->expects($this->once())
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
+		$this->groupManager
+			->expects($this->any())
+			->method('getUserGroups')
+			->willReturn([]);
 		$this->api
 			->expects($this->once())
 			->method('fillStorageInfo')
@@ -908,7 +934,8 @@ class UsersControllerTest extends OriginalTest {
 			'phone' => 'phone',
 			'address' => 'address',
 			'webpage' => 'website',
-			'twitter' => 'twitter'
+			'twitter' => 'twitter',
+			'groups' => []
 		];
 		$this->assertEquals($expected, $this->invokePrivate($this->api, 'getUserData', ['subadmin']));
 	}


### PR DESCRIPTION
Example call:

````
curl -X GET http://admin:admin@localhost/master/ocs/v1.php/cloud/users/admin -H  "OCS-APIRequest: true"
````

Result:

````
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>ok</status>
  <statuscode>100</statuscode>
  <message>OK</message>
  <totalitems></totalitems>
  <itemsperpage></itemsperpage>
 </meta>
 <data>
  <enabled>true</enabled>
  <quota>
   <free>338696790016</free>
   <used>7438874</used>
   <total>338704228890</total>
   <relative>0</relative>
   <quota>-3</quota>
  </quota>
  <email>user@foo.de</email>
  <displayname>admin</displayname>
  <phone></phone>
  <address></address>
  <webpage></webpage>
  <twitter>schiessle</twitter>
  <groups>
    <element>group0</element>
    <element>group1</element>
  </groups>
 </data>
</ocs>
````

for https://github.com/nextcloud/android/issues/591