### PR TITLE
Update uuidAttributes list to include FreeIPA's ipauniqueid

### DIFF
--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -339,7 +339,7 @@ class Connection extends LDAPUtility {
 				$this->configuration->$effectiveSetting = $uuidOverride;
 			} else {
 				$uuidAttributes = array('auto', 'entryuuid', 'nsuniqueid',
-										'objectguid', 'guid');
+										'objectguid', 'guid', 'ipauniqueid');
 				if(!in_array($this->configuration->$effectiveSetting,
 							$uuidAttributes)
 					&& (!is_null($this->configID))) {


### PR DESCRIPTION
The uuidAttributes list in lib/Connection.php for the user_ldap app lacks the FreeIPA UUID attribute that is listed in, and automatically detected by lib/Access.php. Due to it not being in the uuidAttributes list in doSoftValidation(), it is never considered valid when it is detected and the connection->uuidAttrs will reset to 'auto'. No mappings will ever be created as a result for FreeIPA directories. By updating this list, user_ldap will be able to work with FreeIPA 4.x without Expert tab configuration changes under LDAP / AD Integration settings.