### PR TITLE
Fix return value of getAllowedPreviousVersions()

### DIFF
--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -163,7 +163,7 @@ class Updater extends BasicEmitter {
 		// this should really be a JSON file
 		require \OC::$SERVERROOT . '/version.php';
 		/** @var array $OC_VersionCanBeUpgradedFrom */
-		return implode('.', $OC_VersionCanBeUpgradedFrom);
+		return $OC_VersionCanBeUpgradedFrom;
 	}
 
 	/**


### PR DESCRIPTION
* followup to  #3184 
* try to upgrade 😉 


```
TypeError: Argument 3 passed to OC\Updater::isUpgradePossible() must be of the type array, string given, called in /srv/projects/server/lib/private/Updater.php on line 215 and defined in /srv/projects/server/lib/private/Updater.php:188
Stack trace:
#0 /srv/projects/server/lib/private/Updater.php(215): OC\Updater->isUpgradePossible('9.1.3.2', '12.0.0.12', 'Array.Array')
#1 /srv/projects/server/lib/private/Updater.php(130): OC\Updater->doUpgrade('12.0.0.12', '9.1.3.2')
#2 /srv/projects/server/core/Command/Upgrade.php(261): OC\Updater->upgrade()
#3 /srv/projects/server/3rdparty/symfony/console/Command/Command.php(256): OC\Core\Command\Upgrade->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#4 /srv/projects/server/3rdparty/symfony/console/Application.php(818): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#5 /srv/projects/server/3rdparty/symfony/console/Application.php(186): Symfony\Component\Console\Application->doRunCommand(Object(OC\Core\Command\Upgrade), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 /srv/projects/server/3rdparty/symfony/console/Application.php(117): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /srv/projects/server/lib/private/Console/Application.php(169): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /srv/projects/server/console.php(90): OC\Console\Application->run()
#9 /srv/projects/server/occ(11): require_once('/srv/projects/s...')
```