### PR TITLE
[stable11] Set vendor during install

### DIFF
--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -359,6 +359,7 @@ class Setup {
 			$config = \OC::$server->getConfig();
 			$config->setAppValue('core', 'installedat', microtime(true));
 			$config->setAppValue('core', 'lastupdatedat', microtime(true));
+			$config->setAppValue('core', 'vendor', $this->getVendor());
 
 			$group =\OC::$server->getGroupManager()->createGroup('admin');
 			$group->addUser($user);
@@ -498,5 +499,19 @@ class Setup {
 		$baseDir = \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data');
 		file_put_contents($baseDir . '/.htaccess', $content);
 		file_put_contents($baseDir . '/index.html', '');
+	}
+
+	/**
+	 * Return vendor from which this version was published
+	 *
+	 * @return string Get the vendor
+	 *
+	 * Copy of \OC\Updater::getVendor()
+	 */
+	private function getVendor() {
+		// this should really be a JSON file
+		require \OC::$SERVERROOT . '/version.php';
+		/** @var string $vendor */
+		return (string) $vendor;
 	}
 }


### PR DESCRIPTION
* backport of #3425 
* this would mitigate a bit the issue described in https://github.com/nextcloud/server/pull/3184#discussion_r100473008

@LukasReschke @nickvergessen We maybe disallow upgrades from 11.0.0 or 11.0.1 directly to 12.0 in our updater server and give them the in-between update.

And maybe write a little easy to find section in our release notes, that upgrades from fresh installed 11.0.0/11.0.1 to 12.0 are not possible with an SQL that fixes this.