### PR TITLE
Fix detection of the new iOS app

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -32,7 +32,6 @@
 namespace OCA\DAV\Connector\Sabre;
 
 use Exception;
-use OC\AppFramework\Http\Request;
 use OC\Authentication\Exceptions\PasswordLoginForbiddenException;
 use OC\Authentication\TwoFactorAuth\Manager;
 use OC\Security\Bruteforce\Throttler;
@@ -177,9 +176,9 @@ class Auth extends AbstractBasic {
 
 		// Official ownCloud clients require no checks
 		if($this->request->isUserAgent([
-			Request::USER_AGENT_OWNCLOUD_DESKTOP,
-			Request::USER_AGENT_OWNCLOUD_ANDROID,
-			Request::USER_AGENT_OWNCLOUD_IOS,
+			IRequest::USER_AGENT_CLIENT_DESKTOP,
+			IRequest::USER_AGENT_CLIENT_ANDROID,
+			IRequest::USER_AGENT_CLIENT_IOS,
 		])) {
 			return false;
 		}

--- a/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
@@ -302,7 +302,7 @@ class AuthTest extends TestCase {
 			->with([
 				'/^Mozilla\/5\.0 \([A-Za-z ]+\) (mirall|csyncoC)\/.*$/',
 				'/^Mozilla\/5\.0 \(Android\) ownCloud\-android.*$/',
-				'/^Mozilla\/5\.0 \(iOS\) ownCloud\-iOS.*$/',
+				'/^Mozilla\/5\.0 \(iOS\) (ownCloud|Nextcloud)\-iOS.*$/',
 			])
 			->willReturn(false);
 		$this->session
@@ -352,7 +352,7 @@ class AuthTest extends TestCase {
 			->with([
 				'/^Mozilla\/5\.0 \([A-Za-z ]+\) (mirall|csyncoC)\/.*$/',
 				'/^Mozilla\/5\.0 \(Android\) ownCloud\-android.*$/',
-				'/^Mozilla\/5\.0 \(iOS\) ownCloud\-iOS.*$/',
+				'/^Mozilla\/5\.0 \(iOS\) (ownCloud|Nextcloud)\-iOS.*$/',
 			])
 			->willReturn(false);
 		$this->session
@@ -406,7 +406,7 @@ class AuthTest extends TestCase {
 			->with([
 				'/^Mozilla\/5\.0 \([A-Za-z ]+\) (mirall|csyncoC)\/.*$/',
 				'/^Mozilla\/5\.0 \(Android\) ownCloud\-android.*$/',
-				'/^Mozilla\/5\.0 \(iOS\) ownCloud\-iOS.*$/',
+				'/^Mozilla\/5\.0 \(iOS\) (ownCloud|Nextcloud)\-iOS.*$/',
 			])
 			->willReturn(false);
 		$this->session
@@ -452,7 +452,7 @@ class AuthTest extends TestCase {
 			->with([
 				'/^Mozilla\/5\.0 \([A-Za-z ]+\) (mirall|csyncoC)\/.*$/',
 				'/^Mozilla\/5\.0 \(Android\) ownCloud\-android.*$/',
-				'/^Mozilla\/5\.0 \(iOS\) ownCloud\-iOS.*$/',
+				'/^Mozilla\/5\.0 \(iOS\) (ownCloud|Nextcloud)\-iOS.*$/',
 			])
 			->willReturn(true);
 		$this->session

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -72,7 +72,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	/**
 	 * @deprecated use \OCP\IRequest::USER_AGENT_CLIENT_IOS instead
 	 */
-	const USER_AGENT_OWNCLOUD_IOS = '/^Mozilla\/5\.0 \(iOS\) ownCloud\-iOS.*$/';
+	const USER_AGENT_OWNCLOUD_IOS = '/^Mozilla\/5\.0 \(iOS\) (ownCloud|Nextcloud)\-iOS.*$/';
 	/**
 	 * @deprecated use \OCP\IRequest::USER_AGENT_CLIENT_ANDROID instead
 	 */

--- a/lib/public/IRequest.php
+++ b/lib/public/IRequest.php
@@ -76,7 +76,7 @@ interface IRequest {
 	/**
 	 * @since 9.1.0
 	 */
-	const USER_AGENT_CLIENT_IOS = '/^Mozilla\/5\.0 \(iOS\) ownCloud\-iOS.*$/';
+	const USER_AGENT_CLIENT_IOS = '/^Mozilla\/5\.0 \(iOS\) (ownCloud|Nextcloud)\-iOS.*$/';
 
 	/**
 	 * @param string $name

--- a/settings/js/authtoken_view.js
+++ b/settings/js/authtoken_view.js
@@ -131,7 +131,7 @@
 				androidChrome: /Android.*(?:; (.*) Build\/).*Chrome\/(\d+)[0-9.]+/,
 				iphone: / *CPU +iPhone +OS +([0-9]+)_(?:[0-9_])+ +like +Mac +OS +X */,
 				ipad: /\(iPad\; *CPU +OS +([0-9]+)_(?:[0-9_])+ +like +Mac +OS +X */,
-				iosClient: /^Mozilla\/5\.0 \(iOS\) ownCloud\-iOS.*$/,
+				iosClient: /^Mozilla\/5\.0 \(iOS\) (ownCloud|Nextcloud)\-iOS.*$/,
 				androidClient:/^Mozilla\/5\.0 \(Android\) ownCloud\-android.*$/,
 				// DAVdroid/1.2 (2016/07/03; dav4android; okhttp3) Android/6.0.1
 				davDroid: /DAVdroid\/([0-9.]+)/,


### PR DESCRIPTION
Need to backport to 11 and 10 since it breaks access control and autotagging:

Fix https://github.com/nextcloud/files_automatedtagging/issues/22

@MorrisJobke @LukasReschke 