### PR TITLE
Allow using '/' as external storage mountpoint

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -960,7 +960,7 @@ MountConfigListView.prototype = _.extend({
 			success: function(result) {
 				var onCompletion = jQuery.Deferred();
 				$.each(result, function(i, storageParams) {
-					storageParams.mountPoint = storageParams.mountPoint.substr(1); // trim leading slash
+					storageParams.mountPoint = (storageParams.mountPoint === '/')? '/' : storageParams.mountPoint.substr(1); // trim leading slash
 					var storageConfig = new self._storageConfigClass();
 					_.extend(storageConfig, storageParams);
 					var $tr = self.newStorage(storageConfig, onCompletion);

--- a/apps/files_external/lib/Controller/StoragesController.php
+++ b/apps/files_external/lib/Controller/StoragesController.php
@@ -143,7 +143,7 @@ abstract class StoragesController extends Controller {
 	 */
 	protected function validate(StorageConfig $storage) {
 		$mountPoint = $storage->getMountPoint();
-		if ($mountPoint === '' || $mountPoint === '/') {
+		if ($mountPoint === '') {
 			return new DataResponse(
 				array(
 					'message' => (string)$this->l10n->t('Invalid mount point')


### PR DESCRIPTION
Allow the admin to configure the mounpoint of an external storage as `'/'`, making it that the user only sees the external storage.

Note that this is different than using a primary storage, since anything outside `/$user/files`, such as thumbnails, will still be stored locally