### PR TITLE
also apply permissions mask in getMetaData

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -491,7 +491,7 @@ class Scanner extends BasicEmitter implements IScanner {
 		} else {
 			$lastPath = null;
 			while (($path = $this->cache->getIncomplete()) !== false && $path !== $lastPath) {
-				$this->runBackgroundScanJob(function() use ($path) {
+				$this->runBackgroundScanJob(function () use ($path) {
 					$this->scan($path, self::SCAN_RECURSIVE_INCOMPLETE, self::REUSE_ETAG | self::REUSE_SIZE);
 				}, $path);
 				// FIXME: this won't proceed with the next item, needs revamping of getIncomplete()

--- a/lib/private/Files/Storage/Wrapper/PermissionsMask.php
+++ b/lib/private/Files/Storage/Wrapper/PermissionsMask.php
@@ -138,4 +138,13 @@ class PermissionsMask extends Wrapper {
 		$sourceCache = parent::getCache($path, $storage);
 		return new CachePermissionsMask($sourceCache, $this->mask);
 	}
+
+	public function getMetaData($path) {
+		$data = parent::getMetaData($path);
+
+		if ($data && isset($data['permissions'])) {
+			$data['permissions'] = $data['permissions'] & $this->mask;
+		}
+		return $data;
+	}
 }


### PR DESCRIPTION
Fixes modified dates of all folders being set the current time when scanning an external storage.

Otherwise the scanner will detect the difference in permissions and think the file has been updated, triggering the propagator. Resulting in changed etags for folders (causing the client to have to re-discover) and updating the modified dates for folders to the current time.

@kwstone can you verify that this fixes the modified date problem for you