### PR TITLE
Make the notify self test for subfolders more reliable

### DIFF
--- a/apps/files_external/lib/Command/Notify.php
+++ b/apps/files_external/lib/Command/Notify.php
@@ -184,15 +184,20 @@ class Notify extends Base {
 		$storage->file_put_contents('/.nc_test_file.txt', 'test content');
 		$storage->mkdir('/.nc_test_folder');
 		$storage->file_put_contents('/.nc_test_folder/subfile.txt', 'test content');
+
+		usleep(100 * 1000); //time for all changes to be processed
+		$changes = $notifyHandler->getChanges();
+
 		$storage->unlink('/.nc_test_file.txt');
 		$storage->unlink('/.nc_test_folder/subfile.txt');
 		$storage->rmdir('/.nc_test_folder');
+
 		usleep(100 * 1000); //time for all changes to be processed
+		$notifyHandler->getChanges(); // flush
 
 		$foundRootChange = false;
 		$foundSubfolderChange = false;
 
-		$changes = $notifyHandler->getChanges();
 		foreach ($changes as $change) {
 			if ($change->getPath() === '/.nc_test_file.txt') {
 				$foundRootChange = true;

--- a/apps/files_external/lib/Command/Notify.php
+++ b/apps/files_external/lib/Command/Notify.php
@@ -199,9 +199,9 @@ class Notify extends Base {
 		$foundSubfolderChange = false;
 
 		foreach ($changes as $change) {
-			if ($change->getPath() === '/.nc_test_file.txt') {
+			if ($change->getPath() === '/.nc_test_file.txt' || $change->getPath() === '.nc_test_file.txt') {
 				$foundRootChange = true;
-			} else if ($change->getPath() === '/.nc_test_folder/subfile.txt') {
+			} else if ($change->getPath() === '/.nc_test_folder/subfile.txt' || $change->getPath() === '.nc_test_folder/subfile.txt') {
 				$foundSubfolderChange = true;
 			}
 		}


### PR DESCRIPTION
Not all storages will like handling changes for files that are already deleted.

Deleting the files after listing changes should be more reliable