### PR TITLE
Always enable avatars

### DIFF
--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -23,9 +23,7 @@
 	var EDIT_COMMENT_TEMPLATE =
 		'<div class="newCommentRow comment" data-id="{{id}}">' +
 		'    <div class="authorRow">' +
-		'        {{#if avatarEnabled}}' +
 		'        <div class="avatar" data-username="{{actorId}}"></div>' +
-		'        {{/if}}' +
 		'        <div class="author">{{actorDisplayName}}</div>' +
 		'{{#if isEditMode}}' +
 		'        <a href="#" class="action delete icon icon-delete has-tooltip" title="{{deleteTooltip}}"></a>' +
@@ -44,9 +42,7 @@
 	var COMMENT_TEMPLATE =
 		'<li class="comment{{#if isUnread}} unread{{/if}}{{#if isLong}} collapsed{{/if}}" data-id="{{id}}">' +
 		'    <div class="authorRow">' +
-		'        {{#if avatarEnabled}}' +
 		'        <div class="avatar" {{#if actorId}}data-username="{{actorId}}"{{/if}}> </div>' +
-		'        {{/if}}' +
 		'        <div class="author">{{actorDisplayName}}</div>' +
 		'{{#if isUserAuthor}}' +
 		'        <a href="#" class="action edit icon icon-rename has-tooltip" title="{{editTooltip}}"></a>' +
@@ -85,8 +81,6 @@
 			this.collection.on('sync', this._onEndRequest, this);
 			this.collection.on('add', this._onAddModel, this);
 
-			this._avatarsEnabled = !!OC.config.enable_avatars;
-
 			this._commentMaxThreshold = this._commentMaxLength * 0.9;
 
 			// TODO: error handling
@@ -99,7 +93,6 @@
 			}
 			var currentUser = OC.getCurrentUser();
 			return this._template(_.extend({
-				avatarEnabled: this._avatarsEnabled,
 				actorId: currentUser.uid,
 				actorDisplayName: currentUser.displayName
 			}, params));
@@ -111,7 +104,6 @@
 			}
 			var currentUser = OC.getCurrentUser();
 			return this._editCommentTemplate(_.extend({
-				avatarEnabled: this._avatarsEnabled,
 				actorId: currentUser.uid,
 				actorDisplayName: currentUser.displayName,
 				newMessagePlaceholder: t('comments', 'New comment …'),
@@ -127,7 +119,6 @@
 			}
 
 			params = _.extend({
-				avatarEnabled: this._avatarsEnabled,
 				editTooltip: t('comments', 'Edit comment'),
 				isUserAuthor: OC.getCurrentUser().uid === params.actorId,
 				isLong: this._isLong(params.message)
@@ -169,9 +160,7 @@
 			this.$el.find('.comments').before(this.editCommentTemplate({}));
 			this.$el.find('.has-tooltip').tooltip();
 			this.$container = this.$el.find('ul.comments');
-			if (this._avatarsEnabled) {
-				this.$el.find('.avatar').avatar(OC.getCurrentUser().uid, 32);
-			}
+			this.$el.find('.avatar').avatar(OC.getCurrentUser().uid, 32);
 			this.delegateEvents();
 			this.$el.find('.message').on('keydown input change', this._onTypeComment);
 
@@ -239,12 +228,10 @@
 
 		_postRenderItem: function($el) {
 			$el.find('.has-tooltip').tooltip();
-			if(this._avatarsEnabled) {
-				$el.find('.avatar').each(function() {
-					var $this = $(this);
-					$this.avatar($this.attr('data-username'), 32);
-				});
-			}
+			$el.find('.avatar').each(function() {
+				var $this = $(this);
+				$this.avatar($this.attr('data-username'), 32);
+			});
 		},
 
 		/**
@@ -257,13 +244,10 @@
 			for(var i in mentions) {
 				var mention = '@' + mentions[i].mentionId;
 
-				var avatar = '';
-				if(this._avatarsEnabled) {
-					avatar = '<div class="avatar" '
-						+ 'data-user="' + _.escape(mentions[i].mentionId) + '"'
-						+' data-user-display-name="'
-						+ _.escape(mentions[i].mentionDisplayName) + '"></div>';
-				}
+				var avatar = '<div class="avatar" '
+					+ 'data-user="' + _.escape(mentions[i].mentionId) + '"'
+					+' data-user-display-name="'
+					+ _.escape(mentions[i].mentionDisplayName) + '"></div>';
 
 				// escape possible regex characters in the name
 				mention = mention.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/apps/comments/tests/js/commentstabviewSpec.js
+++ b/apps/comments/tests/js/commentstabviewSpec.js
@@ -43,7 +43,6 @@ describe('OCA.Comments.CommentsTabView tests', function() {
 		clock = sinon.useFakeTimers(Date.UTC(2016, 1, 3, 10, 5, 9));
 		fetchStub = sinon.stub(OCA.Comments.CommentCollection.prototype, 'fetchNext');
 		view = new OCA.Comments.CommentsTabView();
-		view._avatarsEnabled = false;
 		fileInfoModel = new OCA.Files.FileInfoModel({
 			id: 5,
 			name: 'One.txt',
@@ -146,7 +145,6 @@ describe('OCA.Comments.CommentsTabView tests', function() {
 		});
 
 		it('renders mentioned user id to avatar and displayname', function() {
-			view._avatarsEnabled = true;
 			view.collection.set(testComments);
 
 			var $comment = view.$el.find('.comment[data-id=3] .message');
@@ -155,18 +153,6 @@ describe('OCA.Comments.CommentsTabView tests', function() {
 			expect($comment.find('strong:first').text()).toEqual('Thane of Cawdor');
 
 			expect($comment.find('.avatar[data-user=banquo]').length).toEqual(1);
-			expect($comment.find('strong:last-child').text()).toEqual('Lord Banquo');
-		});
-
-		it('renders mentioned user id to displayname, avatars disabled', function() {
-			view.collection.set(testComments);
-
-			var $comment = view.$el.find('.comment[data-id=3] .message');
-			expect($comment.length).toEqual(1);
-			expect($comment.find('.avatar[data-user=macbeth]').length).toEqual(0);
-			expect($comment.find('strong:first-child').text()).toEqual('Thane of Cawdor');
-
-			expect($comment.find('.avatar[data-user=banquo]').length).toEqual(0);
 			expect($comment.find('strong:last-child').text()).toEqual('Lord Banquo');
 		});
 
@@ -316,11 +302,13 @@ describe('OCA.Comments.CommentsTabView tests', function() {
 	describe('editing comments', function() {
 		var saveStub;
 		var fetchStub;
+		var avatarStub;
 		var currentUserStub;
 
 		beforeEach(function() {
 			saveStub = sinon.stub(OCA.Comments.CommentModel.prototype, 'save');
 			fetchStub = sinon.stub(OCA.Comments.CommentModel.prototype, 'fetch');
+			avatarStub = sinon.stub($.fn, 'avatar');
 			currentUserStub = sinon.stub(OC, 'getCurrentUser');
 			currentUserStub.returns({
 				uid: 'testuser',
@@ -348,6 +336,7 @@ describe('OCA.Comments.CommentsTabView tests', function() {
 		afterEach(function() {
 			saveStub.restore();
 			fetchStub.restore();
+			avatarStub.restore();
 			currentUserStub.restore();
 		});
 

--- a/apps/files_sharing/js/files_drop.js
+++ b/apps/files_sharing/js/files_drop.js
@@ -117,7 +117,7 @@
 	};
 
 	$(document).ready(function() {
-		if($('#upload-only-interface').val() === "1" && oc_config.enable_avatars) {
+		if($('#upload-only-interface').val() === "1") {
 			$('.avatardiv').avatar($('#sharingUserId').val(), 128, true);
 		}
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -181,15 +181,6 @@ $CONFIG = array(
 'knowledgebaseenabled' => true,
 
 /**
- * ``true`` enables avatars, or user profile photos. These appear on the User
- * page, on user's Personal pages and are used by some apps (contacts, mail,
- * etc). ``false`` disables them.
- *
- * Defaults to ``true``
- */
-'enable_avatars' => true,
-
-/**
  * ``true`` allows users to change their display names (on their Personal
  * pages), and ``false`` prevents them from changing their display names.
  */

--- a/core/js/shareconfigmodel.js
+++ b/core/js/shareconfigmodel.js
@@ -33,9 +33,10 @@
 
 		/**
 		 * @returns {boolean}
+		 * @deprecated here for legacy reasons - will always return true
 		 */
 		areAvatarsEnabled: function() {
-			return oc_config.enable_avatars === true;
+			return true;
 		},
 
 		/**

--- a/core/js/sharedialogresharerinfoview.js
+++ b/core/js/sharedialogresharerinfoview.js
@@ -17,9 +17,7 @@
 
 	var TEMPLATE =
 		'<span class="reshare">' +
-		'    {{#if avatarEnabled}}' +
 		'    <div class="avatar" data-userName="{{reshareOwner}}"></div>' +
-		'    {{/if}}' +
 		'    {{sharedByText}}' +
 		'</span><br/>'
 		;
@@ -93,17 +91,14 @@
 			}
 
 			this.$el.html(reshareTemplate({
-				avatarEnabled: this.configModel.areAvatarsEnabled(),
 				reshareOwner: this.model.getReshareOwner(),
 				sharedByText: sharedByText
 			}));
 
-			if(this.configModel.areAvatarsEnabled()) {
-				this.$el.find('.avatar').each(function() {
-					var $this = $(this);
-					$this.avatar($this.data('username'), 32);
-				});
-			}
+			this.$el.find('.avatar').each(function() {
+				var $this = $(this);
+				$this.avatar($this.data('username'), 32);
+			});
 
 			return this;
 		},

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -21,9 +21,7 @@
 			'<ul id="shareWithList" class="shareWithList">' +
 			'{{#each sharees}}' +
 				'<li data-share-id="{{shareId}}" data-share-type="{{shareType}}" data-share-with="{{shareWith}}">' +
-					'{{#if avatarEnabled}}' +
 					'<div class="avatar {{#if modSeed}}imageplaceholderseed{{/if}}" data-username="{{shareWith}}" data-displayname="{{shareWithDisplayName}}" {{#if modSeed}}data-seed="{{shareWith}} {{shareType}}"{{/if}}></div>' +
-					'{{/if}}' +
 					'<span class="has-tooltip username" title="{{shareWithTitle}}">{{shareWithDisplayName}}</span>' +
 					'<span class="sharingOptionsGroup">' +
 						'{{#if editPermissionPossible}}' +
@@ -41,9 +39,7 @@
 			'{{/each}}' +
 			'{{#each linkReshares}}' +
 				'<li data-share-id="{{shareId}}" data-share-type="{{shareType}}">' +
-					'{{#if avatarEnabled}}' +
 					'<div class="avatar" data-username="{{shareInitiator}}"></div>' +
-					'{{/if}}' +
 					'<span class="has-tooltip username" title="{{shareInitiator}}">' + t('core', '{{shareInitiatorDisplayName}} shared via link') + '</span>' +
 
 					'<span class="sharingOptionsGroup">' +
@@ -193,7 +189,6 @@
 
 		getShareProperties: function() {
 			return {
-				avatarEnabled: this.configModel.areAvatarsEnabled(),
 				unshareLabel: t('core', 'Unshare'),
 				canShareLabel: t('core', 'can reshare'),
 				canEditLabel: t('core', 'can edit'),
@@ -247,7 +242,6 @@
 		getLinkReshares: function() {
 			var universal = {
 				unshareLabel: t('core', 'Unshare'),
-				avatarEnabled: this.configModel.areAvatarsEnabled(),
 			};
 
 			if(!this.model.hasUserShares()) {
@@ -281,18 +275,16 @@
 					linkReshares: this.getLinkReshares()
 				}));
 
-				if (this.configModel.areAvatarsEnabled()) {
-					this.$('.avatar').each(function () {
-						var $this = $(this);
-						if ($this.hasClass('imageplaceholderseed')) {
-							$this.css({width: 32, height: 32});
-							$this.imageplaceholder($this.data('seed'));
-						} else {
-						    //                         user,   size,  ie8fix, hidedefault,  callback, displayname
-							$this.avatar($this.data('username'), 32, undefined, undefined, undefined, $this.data('displayname'));
-						}
-					});
-				}
+				this.$('.avatar').each(function () {
+					var $this = $(this);
+					if ($this.hasClass('imageplaceholderseed')) {
+						$this.css({width: 32, height: 32});
+						$this.imageplaceholder($this.data('seed'));
+					} else {
+						//                         user,   size,  ie8fix, hidedefault,  callback, displayname
+						$this.avatar($this.data('username'), 32, undefined, undefined, undefined, $this.data('displayname'));
+					}
+				});
 
 				this.$('.has-tooltip').tooltip({
 					placement: 'bottom'

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -24,7 +24,6 @@ describe('OC.Share.ShareDialogView', function() {
 	var $container;
 	var oldAppConfig;
 	var autocompleteStub;
-	var oldEnableAvatars;
 	var avatarStub;
 	var placeholderStub;
 	var oldCurrentUser;
@@ -103,8 +102,6 @@ describe('OC.Share.ShareDialogView', function() {
 			return $el;
 		});
 
-		oldEnableAvatars = oc_config.enable_avatars;
-		oc_config.enable_avatars = false;
 		avatarStub = sinon.stub($.fn, 'avatar');
 		placeholderStub = sinon.stub($.fn, 'imageplaceholder');
 
@@ -123,7 +120,6 @@ describe('OC.Share.ShareDialogView', function() {
 		autocompleteStub.restore();
 		avatarStub.restore();
 		placeholderStub.restore();
-		oc_config.enable_avatars = oldEnableAvatars;
 	});
 	describe('Share with link', function() {
 		// TODO: test ajax calls
@@ -440,18 +436,13 @@ describe('OC.Share.ShareDialogView', function() {
 
 		describe('avatars enabled', function() {
 			beforeEach(function() {
-				oc_config.enable_avatars = true;
 				avatarStub.reset();
 				dialog.render();
 			});
 
-			afterEach(function() {
-				oc_config.enable_avatars = false;
-			});
-
 			it('test correct function calls', function() {
 				expect(avatarStub.calledTwice).toEqual(true);
-				expect(placeholderStub.calledTwice).toEqual(true);
+				expect(placeholderStub.callCount).toEqual(4);
 				expect(dialog.$('.shareWithList').children().length).toEqual(3);
 				expect(dialog.$('.avatar').length).toEqual(4);
 			});
@@ -479,18 +470,6 @@ describe('OC.Share.ShareDialogView', function() {
 				var args = placeholderStub.getCall(1).args;
 				expect(args.length).toEqual(1);
 				expect(args[0]).toEqual('foo@bar.com/baz ' + OC.Share.SHARE_TYPE_REMOTE);
-			});
-		});
-
-		describe('avatars disabled', function() {
-			beforeEach(function() {
-				dialog.render();
-			});
-
-			it('no avatar classes', function() {
-				expect($('.avatar').length).toEqual(0);
-				expect(avatarStub.callCount).toEqual(0);
-				expect(placeholderStub.callCount).toEqual(0);
 			});
 		});
 	});

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -73,7 +73,6 @@
 				</form>
 				<div id="settings">
 					<div id="expand" tabindex="6" role="link" class="menutoggle">
-						<?php if ($_['enableAvatars']): ?>
 						<div class="avatardiv<?php if ($_['userAvatarSet']) { print_unescaped(' avatardiv-shown'); } else { print_unescaped('" style="display: none'); } ?>">
 							<?php if ($_['userAvatarSet']): ?>
 								<img alt="" width="32" height="32"
@@ -82,7 +81,6 @@
 								>
 							<?php endif; ?>
 						</div>
-						<?php endif; ?>
 						<span id="expandDisplayName"><?php  p(trim($_['user_displayname']) != '' ? $_['user_displayname'] : $_['user_uid']) ?></span>
 						<div class="icon-caret"></div>
 					</div>

--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -204,7 +204,7 @@ class JSConfigHelper {
 				'session_keepalive'	=> $this->config->getSystemValue('session_keepalive', true),
 				'version'			=> implode('.', \OCP\Util::getVersion()),
 				'versionstring'		=> \OC_Util::getVersionString(),
-				'enable_avatars'	=> $this->config->getSystemValue('enable_avatars', true) === true,
+				'enable_avatars'	=> true, // here for legacy reasons - to not crash existing code that relies on this value
 				'lost_password_link'=> $this->config->getSystemValue('lost_password_link', null),
 				'modRewriteWorking'	=> (\OC::$server->getConfig()->getSystemValue('htaccess.IgnoreFrontController', false) === true || getenv('front_controller_active') === 'true'),
 			]),

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -100,7 +100,6 @@ class TemplateLayout extends \OC_Template {
 			$this->assign('user_displayname', $userDisplayName);
 			$this->assign('user_uid', \OC_User::getUser());
 			$this->assign('appsmanagement_active', $appsMgmtActive);
-			$this->assign('enableAvatars', $this->config->getSystemValue('enable_avatars', true) === true);
 
 			if (\OC_User::getUser() === false) {
 				$this->assign('userAvatarSet', false);

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -121,10 +121,8 @@ class OC_Template extends \OC\Template\Base {
 			OC_Util::addStyle("styles",null,true);
 
 			// avatars
-			if (\OC::$server->getSystemConfig()->getValue('enable_avatars', true) === true) {
-				\OC_Util::addScript('jquery.avatar', null, true);
-				\OC_Util::addScript('placeholder', null, true);
-			}
+			\OC_Util::addScript('jquery.avatar', null, true);
+			\OC_Util::addScript('placeholder', null, true);
 
 			OC_Util::addVendorScript('select2/select2');
 			OC_Util::addVendorStyle('select2/select2', null, true);

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -188,12 +188,10 @@ class UsersController extends Controller {
 		}
 
 		$avatarAvailable = false;
-		if ($this->config->getSystemValue('enable_avatars', true) === true) {
-			try {
-				$avatarAvailable = $this->avatarManager->getAvatar($user->getUID())->exists();
-			} catch (\Exception $e) {
-				//No avatar yet
-			}
+		try {
+			$avatarAvailable = $this->avatarManager->getAvatar($user->getUID())->exists();
+		} catch (\Exception $e) {
+			//No avatar yet
 		}
 
 		return [

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -334,15 +334,13 @@ $(document).ready(function () {
 	});
 
 	// Load the big avatar
-	if (oc_config.enable_avatars) {
-		$('#avatarform .avatardiv').avatar(OC.currentUser, 145, true, null, function() {
-			if($('#displayavatar img').length === 0) {
-				$('#removeavatar').removeClass('inlineblock').addClass('hidden');
-			} else {
-				$('#removeavatar').removeClass('hidden').addClass('inlineblock');
-			}
-		});
-	}
+	$('#avatarform .avatardiv').avatar(OC.currentUser, 145, true, null, function() {
+		if($('#displayavatar img').length === 0) {
+			$('#removeavatar').removeClass('inlineblock').addClass('hidden');
+		} else {
+			$('#removeavatar').removeClass('hidden').addClass('inlineblock');
+		}
+	});
 	
 
 	// Show token views

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -57,10 +57,8 @@ OC_Util::addStyle( 'settings', 'settings' );
 \OC_Util::addVendorScript('strengthify/jquery.strengthify');
 \OC_Util::addVendorStyle('strengthify/strengthify');
 \OC_Util::addScript('files', 'jquery.fileupload');
-if ($config->getSystemValue('enable_avatars', true) === true) {
-	\OC_Util::addVendorScript('jcrop/js/jquery.Jcrop');
-	\OC_Util::addVendorStyle('jcrop/css/jquery.Jcrop');
-}
+\OC_Util::addVendorScript('jcrop/js/jquery.Jcrop');
+\OC_Util::addVendorStyle('jcrop/css/jquery.Jcrop');
 
 \OC::$server->getEventDispatcher()->dispatch('OC\Settings\Personal::loadAdditionalScripts');
 
@@ -182,7 +180,6 @@ $tmpl->assign('websiteScope', $userData[\OC\Accounts\AccountManager::PROPERTY_WE
 $tmpl->assign('twitterScope', $userData[\OC\Accounts\AccountManager::PROPERTY_TWITTER]['scope']);
 $tmpl->assign('addressScope', $userData[\OC\Accounts\AccountManager::PROPERTY_ADDRESS]['scope']);
 
-$tmpl->assign('enableAvatars', $config->getSystemValue('enable_avatars', true) === true);
 $tmpl->assign('avatarChangeSupported', OC_User::canUserChangeAvatar(OC_User::getUser()));
 $tmpl->assign('certs', $certificateManager->listCertificates());
 $tmpl->assign('showCertificates', $enableCertImport);

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -35,7 +35,6 @@
 </div>
 
 <div id="personal-settings">
-<?php if ($_['enableAvatars']): ?>
 <div id="personal-settings-avatar-container">
 	<form id="avatarform" class="section" method="post" action="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.avatar.postAvatar')); ?>">
 		<h2>
@@ -66,7 +65,6 @@
 		<input type="hidden" id="avatarscope" value="<?php p($_['avatarScope']) ?>">
 	</form>
 </div>
-<?php endif; ?>
 
 <div id="personal-settings-container">
 	<div class="personal-settings-setting-box">

--- a/settings/templates/users/part.userlist.php
+++ b/settings/templates/users/part.userlist.php
@@ -1,9 +1,7 @@
 <table id="userlist" class="hascontrols grid" data-groups="<?php p($_['allGroups']);?>">
 	<thead>
 		<tr>
-		<?php if ($_['enableAvatars']): ?>
 			<th id="headerAvatar" scope="col"></th>
-		<?php endif; ?>
 			<th id="headerName" scope="col"><?php p($l->t('Username'))?></th>
 			<th id="headerDisplayName" scope="col"><?php p($l->t( 'Full name' )); ?></th>
 			<th id="headerPassword" scope="col"><?php p($l->t( 'Password' )); ?></th>
@@ -22,9 +20,7 @@
 	<tbody>
 		<!-- the following <tr> is used as a template for the JS part -->
 		<tr style="display:none">
-		<?php if ($_['enableAvatars']): ?>
 			<td class="avatar"><div class="avatardiv"></div></td>
-		<?php endif; ?>
 			<th class="name" scope="row"></th>
 			<td class="displayName"><span></span> <img class="action"
 				src="<?php p(image_path('core', 'actions/rename.svg'))?>"

--- a/settings/users.php
+++ b/settings/users.php
@@ -118,7 +118,6 @@ $tmpl->assign('quota_preset', $quotaPreset);
 $tmpl->assign('default_quota', $defaultQuota);
 $tmpl->assign('defaultQuotaIsUserDefined', $defaultQuotaIsUserDefined);
 $tmpl->assign('recoveryAdminEnabled', $recoveryAdminEnabled);
-$tmpl->assign('enableAvatars', \OC::$server->getConfig()->getSystemValue('enable_avatars', true) === true);
 
 $tmpl->assign('show_storage_location', $config->getAppValue('core', 'umgmt_show_storage_location', 'false'));
 $tmpl->assign('show_last_login', $config->getAppValue('core', 'umgmt_show_last_login', 'false'));

--- a/tests/Settings/Controller/UsersControllerTest.php
+++ b/tests/Settings/Controller/UsersControllerTest.php
@@ -96,10 +96,6 @@ class UsersControllerTest extends \Test\TestCase {
 				['bar', $avatarExists],
 				['admin', $avatarNotExists],
 			]));
-
-		$this->config->method('getSystemValue')
-			->with('enable_avatars', true)
-			->willReturn(true);
 	}
 
 	/**


### PR DESCRIPTION
* we introduced this setting in the begining because our
  avatar support caused some performance issues, but we
  fixed them and should only provide one way how Nextcloud
  looks
* we have seen multiple issues with instances where avatars are disabled and it's not really a first class citizen UI experience
* fixes #3451

cc @nextcloud/designers @LukasReschke @rullzer @nickvergessen 