### PR TITLE
Address book data lost when any user receiving a share is deleted

### DIFF
--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -195,7 +195,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		return array_values($addressBooks);
 	}
 
-	function getUsersOwnAddressBooks($principalUri) {
+	public function getUsersOwnAddressBooks($principalUri) {
 		$principalUriOriginal = $principalUri;
 		$principalUri = $this->convertPrincipal($principalUri, true);
 		$query = $this->db->getQueryBuilder();

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -195,6 +195,33 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		return array_values($addressBooks);
 	}
 
+	function getUsersOwnAddressBooks($principalUri) {
+		$principalUriOriginal = $principalUri;
+		$principalUri = $this->convertPrincipal($principalUri, true);
+		$query = $this->db->getQueryBuilder();
+		$query->select(['id', 'uri', 'displayname', 'principaluri', 'description', 'synctoken'])
+			  ->from('addressbooks')
+			  ->where($query->expr()->eq('principaluri', $query->createNamedParameter($principalUri)));
+
+		$addressBooks = [];
+
+		$result = $query->execute();
+		while($row = $result->fetch()) {
+			$addressBooks[$row['id']] = [
+				'id'  => $row['id'],
+				'uri' => $row['uri'],
+				'principaluri' => $this->convertPrincipal($row['principaluri'], false),
+				'{DAV:}displayname' => $row['displayname'],
+				'{' . Plugin::NS_CARDDAV . '}addressbook-description' => $row['description'],
+				'{http://calendarserver.org/ns/}getctag' => $row['synctoken'],
+				'{http://sabredav.org/ns}sync-token' => $row['synctoken']?$row['synctoken']:'0',
+			];
+		}
+		$result->closeCursor();
+
+		return array_values($addressBooks);
+	}
+
 	private function getUserDisplayName($uid) {
 		if (!isset($this->userDisplayNames[$uid])) {
 			$user = $this->userManager->get($uid);

--- a/apps/dav/lib/HookManager.php
+++ b/apps/dav/lib/HookManager.php
@@ -96,7 +96,7 @@ class HookManager {
 		$uid = $params['uid'];
 		$this->usersToDelete[$uid] = $this->userManager->get($uid);
 		$this->calendarsToDelete = $this->calDav->getUsersOwnCalendars('principals/users/' . $uid);
-		$this->addressBooksToDelete = $this->cardDav->getAddressBooksForUser('principals/users/' . $uid);
+		$this->addressBooksToDelete = $this->cardDav->getUsersOwnAddressBooks('principals/users/' . $uid);
 	}
 
 	public function postDeleteUser($params) {

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -273,7 +273,7 @@ class CardDavBackendTest extends TestCase {
 
 		// create a new address book
 		$this->backend->createAddressBook(self::UNIT_TEST_USER, 'Example', []);
-		$books = $this->backend->getAddressBooksForUser(self::UNIT_TEST_USER);
+		$books = $this->backend->getUsersOwnAddressBooks(self::UNIT_TEST_USER);
 		$this->assertEquals(1, count($books));
 
 		$bookId = $books[0]['id'];

--- a/apps/dav/tests/unit/DAV/HookManagerTest.php
+++ b/apps/dav/tests/unit/DAV/HookManagerTest.php
@@ -195,7 +195,7 @@ class HookManagerTest extends TestCase {
 		$card = $this->getMockBuilder(CardDavBackend::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$card->expects($this->once())->method('getAddressBooksForUser')->willReturn([
+		$card->expects($this->once())->method('getUsersOwnAddressBooks')->willReturn([
 			['id' => 'personal']
 		]);
 		$card->expects($this->once())->method('deleteAddressBook');


### PR DESCRIPTION
Fix nextcloud/contacts#64 
Reference: #1545

@nextcloud/contacts @cemrich @jeweloper @nickallevato

> ### Steps to reproduce
> 1. Create user1 with an address book shared to group1
> 1. Create user2 of group1 to view the address book
> 1. Delete user2
> 
> ### Expected behaviour
> User2 gets deleted but the shared address book of user1 remains intact. 
> 
> ### Actual behaviour
> The shared address book of user1 gets deleted. The tables ``oc_addressbooks`` and ``oc_cards`` are wiped of all information regarding this address book. If the given address book is the only one of user1, the "infinite loading bug" as described in #58 appears.
> 
> ### Server configuration
> **Operating system**: ?
> 
> **Web server:** ?
> 
> **Database:** mysql 5.1.73
> 
> **PHP version:** 7.0.13
> 
> **Nextcloud version:** 11.0.0 (stable)
> 
> **Contacts version:** 1.5.2
> 
> **Updated from an older Nextcloud or fresh install:** fresh install
> 
> **Signing status:**
> 
> ```
> No errors have been found.
> ```
> 
> **Are you using an external user-backend, if yes which one:** no
> 
> ### Client configuration
> **Browser:** Firefox 50.0.2 and Chrome 54.0.2840.99 m (64-bit)
> 
> **Operating system:** Windows 10
> 