### PR TITLE
Popovermenu files css fix

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -759,10 +759,6 @@ table.dragshadow td.size {
 	opacity: 0;
 }
 
-#fileList .popovermenu a.action img {
-	padding: initial;
-}
-
 html.ie8 #controls .button.new {
 	padding-right: 0;
 }


### PR DESCRIPTION
from 
<img width="916" alt="screen shot 2017-02-14 at 22 44 28" src="https://cloud.githubusercontent.com/assets/14975046/22953725/b749d3b0-f312-11e6-9733-ec9f174c9fcf.png">
to 
![capture d ecran_2017-02-15_00-06-39](https://cloud.githubusercontent.com/assets/14975046/22953731/baedf1b8-f312-11e6-9a1c-a88d178d46a2.png)
