### PR TITLE
Show info in admin settings about PHP opcache if disabled

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -148,6 +148,18 @@
 							type: OC.SetupChecks.MESSAGE_TYPE_ERROR
 						});
 					}
+					if(!data.isOpcacheProperlySetup) {
+						messages.push({
+							msg: t(
+								'core',
+								'The PHP Opcache is not properly configured. <a target="_blank" rel="noreferrer" href="{docLink}">For better performance we recommend ↗</a> to use following settings in the <code>php.ini</code>:',
+								{
+									docLink: data.phpOpcacheDocumentation,
+								}
+							) + "<pre><code>opcache.enable=On\nopcache.enable_cli=1\nopcache.interned_strings_buffer=8\nopcache.max_accelerated_files=10000\nopcache.memory_consumption=128\nopcache.save_comments=1\nopcache.revalidate_freq=1</code></pre>",
+							type: OC.SetupChecks.MESSAGE_TYPE_INFO
+						});
+					}
 				} else {
 					messages.push({
 						msg: t('core', 'Error occurred while checking server setup'),

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -155,6 +155,7 @@ describe('OC.SetupChecks tests', function() {
 					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
+					isOpcacheProperlySetup: true,
 				})
 			);
 
@@ -186,6 +187,7 @@ describe('OC.SetupChecks tests', function() {
 					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
+					isOpcacheProperlySetup: true,
 				})
 			);
 
@@ -218,6 +220,7 @@ describe('OC.SetupChecks tests', function() {
 					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
+					isOpcacheProperlySetup: true,
 				})
 			);
 
@@ -248,6 +251,7 @@ describe('OC.SetupChecks tests', function() {
 					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
+					isOpcacheProperlySetup: true,
 				})
 			);
 
@@ -276,6 +280,7 @@ describe('OC.SetupChecks tests', function() {
 					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: false,
 					hasPassedCodeIntegrityCheck: true,
+					isOpcacheProperlySetup: true,
 				})
 			);
 
@@ -304,6 +309,7 @@ describe('OC.SetupChecks tests', function() {
 					reverseProxyDocs: 'https://docs.owncloud.org/foo/bar.html',
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
+					isOpcacheProperlySetup: true,
 				})
 			);
 
@@ -353,6 +359,7 @@ describe('OC.SetupChecks tests', function() {
 					phpSupported: {eol: true, version: '5.4.0'},
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
+					isOpcacheProperlySetup: true,
 				})
 			);
 
@@ -361,6 +368,36 @@ describe('OC.SetupChecks tests', function() {
 					msg: 'You are currently running PHP 5.4.0. We encourage you to upgrade your PHP version to take advantage of <a target="_blank" rel="noreferrer" href="https://secure.php.net/supported-versions.php">performance and security updates provided by the PHP Group</a> as soon as your distribution supports it.',
 					type: OC.SetupChecks.MESSAGE_TYPE_INFO
 				}]);
+				done();
+			});
+		});
+
+		it('should return an info if server has no proper opcache', function(done) {
+			var async = OC.SetupChecks.checkSetup();
+
+			suite.server.requests[0].respond(
+				200,
+				{
+					'Content-Type': 'application/json'
+				},
+				JSON.stringify({
+					isUrandomAvailable: true,
+					securityDocs: 'https://docs.owncloud.org/myDocs.html',
+					serverHasInternetConnection: true,
+					isMemcacheConfigured: true,
+					forwardedForHeadersWorking: true,
+					isCorrectMemcachedPHPModuleInstalled: true,
+					hasPassedCodeIntegrityCheck: true,
+					isOpcacheProperlySetup: false,
+					phpOpcacheDocumentation: 'https://example.org/link/to/doc',
+				})
+			);
+
+			async.done(function( data, s, x ){
+				expect(data).toEqual([{
+						msg: 'The PHP Opcache is not properly configured. <a target="_blank" rel="noreferrer" href="https://example.org/link/to/doc">For better performance we recommend ↗</a> to use following settings in the <code>php.ini</code>:' + "<pre><code>opcache.enable=On\nopcache.enable_cli=1\nopcache.interned_strings_buffer=8\nopcache.max_accelerated_files=10000\nopcache.memory_consumption=128\nopcache.save_comments=1\nopcache.revalidate_freq=1</code></pre>",
+						type: OC.SetupChecks.MESSAGE_TYPE_INFO
+					}]);
 				done();
 			});
 		});

--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -26,6 +26,7 @@
 
 namespace OC\Settings\Controller;
 
+use bantu\IniGetWrapper\IniGetWrapper;
 use GuzzleHttp\Exception\ClientException;
 use OC\AppFramework\Http;
 use OC\IntegrityCheck\Checker;
@@ -355,6 +356,42 @@ Raw output
 	}
 
 	/**
+	 * Checks whether a PHP opcache is properly set up
+	 * @return bool
+	 */
+	private function isOpcacheProperlySetup() {
+		$iniWrapper = new IniGetWrapper();
+
+		$isOpcacheProperlySetUp = true;
+
+		if(!$iniWrapper->getBool('opcache.enable')) {
+			$isOpcacheProperlySetUp = false;
+		}
+
+		if(!$iniWrapper->getBool('opcache.save_comments')) {
+			$isOpcacheProperlySetUp = false;
+		}
+
+		if(!$iniWrapper->getBool('opcache.enable_cli')) {
+			$isOpcacheProperlySetUp = false;
+		}
+
+		if($iniWrapper->getNumeric('opcache.max_accelerated_files') < 10000) {
+			$isOpcacheProperlySetUp = false;
+		}
+
+		if($iniWrapper->getNumeric('opcache.memory_consumption') < 128) {
+			$isOpcacheProperlySetUp = false;
+		}
+
+		if($iniWrapper->getNumeric('opcache.interned_strings_buffer') < 8) {
+			$isOpcacheProperlySetUp = false;
+		}
+
+		return $isOpcacheProperlySetUp;
+	}
+
+	/**
 	 * @return DataResponse
 	 */
 	public function check() {
@@ -372,6 +409,8 @@ Raw output
 				'isCorrectMemcachedPHPModuleInstalled' => $this->isCorrectMemcachedPHPModuleInstalled(),
 				'hasPassedCodeIntegrityCheck' => $this->checker->hasPassedCheck(),
 				'codeIntegrityCheckerDocumentation' => $this->urlGenerator->linkToDocs('admin-code-integrity'),
+				'isOpcacheProperlySetup' => $this->isOpcacheProperlySetup(),
+				'phpOpcacheDocumentation' => $this->urlGenerator->linkToDocs('admin-php-opcache'),
 			]
 		);
 	}

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -311,6 +311,14 @@ class CheckSetupControllerTest extends TestCase {
 			->method('linkToDocs')
 			->with('admin-reverse-proxy')
 			->willReturn('reverse-proxy-doc-link');
+		$this->urlGenerator->expects($this->at(3))
+			->method('linkToDocs')
+			->with('admin-code-integrity')
+			->willReturn('http://doc.owncloud.org/server/go.php?to=admin-code-integrity');
+		$this->urlGenerator->expects($this->at(4))
+			->method('linkToDocs')
+			->with('admin-php-opcache')
+			->willReturn('http://doc.owncloud.org/server/go.php?to=admin-php-opcache');
 
 		$expected = new DataResponse(
 			[
@@ -328,7 +336,9 @@ class CheckSetupControllerTest extends TestCase {
 				'reverseProxyDocs' => 'reverse-proxy-doc-link',
 				'isCorrectMemcachedPHPModuleInstalled' => true,
 				'hasPassedCodeIntegrityCheck' => null,
-				'codeIntegrityCheckerDocumentation' => null,
+				'codeIntegrityCheckerDocumentation' => 'http://doc.owncloud.org/server/go.php?to=admin-code-integrity',
+				'isOpcacheProperlySetup' => false,
+				'phpOpcacheDocumentation' => 'http://doc.owncloud.org/server/go.php?to=admin-php-opcache',
 			]
 		);
 		$this->assertEquals($expected, $this->checkSetupController->check());


### PR DESCRIPTION
![bildschirmfoto 2017-02-15 um 00 04 03](https://cloud.githubusercontent.com/assets/245432/22963232/85048cba-f317-11e6-8ac0-7963c0c10ec5.png)

I tried really hard to write unit tests for this, but it's simply not possible to change those settings during runtime. 😢 

* [x] add this to documentation  https://github.com/nextcloud/documentation/pull/367