### PR TITLE
[stable11] LDAP's checkPassword should only catch when a user was not found

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -862,10 +862,6 @@ class Access extends LDAPUtility implements IUserTools {
 		$sr = $this->ldap->search($linkResources, $base, $filter, $attr);
 		$error = $this->ldap->errno($cr);
 		if(!is_array($sr) || $error !== 0) {
-			\OCP\Util::writeLog('user_ldap',
-				'Error when searching: '.$this->ldap->error($cr).
-					' code '.$this->ldap->errno($cr),
-				\OCP\Util::ERROR);
 			\OCP\Util::writeLog('user_ldap', 'Attempt for Paging?  '.print_r($pagedSearchOK, true), \OCP\Util::ERROR);
 			return false;
 		}

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -136,17 +136,16 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 	}
 
 	/**
-	 * Check if the password is correct
+	 * Check if the password is correct without logging in the user
+	 *
 	 * @param string $uid The username
 	 * @param string $password The password
 	 * @return false|string
-	 *
-	 * Check if the password is correct without logging in the user
 	 */
 	public function checkPassword($uid, $password) {
 		try {
 			$ldapRecord = $this->getLDAPUserByLoginName($uid);
-		} catch(\Exception $e) {
+		} catch(NotOnLDAP $e) {
 			if($this->ocConfig->getSystemValue('loglevel', Util::WARN) === Util::DEBUG) {
 				\OC::$server->getLogger()->logException($e, ['app' => 'user_ldap']);
 			}


### PR DESCRIPTION
Backport of #3324 fixes #2431 (at least partly for LDAP users)

Would be good to get it into today's RC 2

@karlitschek backport granted?

