### PR TITLE
[stable11] Rename database password toggle

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -426,26 +426,26 @@ label.infield {
 }
 
 /* Show password toggle */
-#show, #dbpassword {
+#show, #dbpassword-toggle {
 	position: absolute;
 	right: 1em;
 	top: .8em;
 	float: right;
 }
-#show, #dbpassword, #personal-show {
+#show, #dbpassword-toggle, #personal-show {
 	display: none;
 }
-#show + label, #dbpassword + label {
+#show + label, #dbpassword-toggle + label {
 	right: 21px;
 	top: 15px !important;
 	margin: -14px !important;
 	padding: 14px !important;
 }
-#show:checked + label, #dbpassword:checked + label, #personal-show:checked + label {
+#show:checked + label, #dbpassword-toggle:checked + label, #personal-show:checked + label {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=80)";
 	opacity: .8;
 }
-#show + label, #dbpassword + label, #personal-show + label {
+#show + label, #dbpassword-toggle + label, #personal-show + label {
 	position: absolute !important;
 	height: 20px;
 	width: 24px;
@@ -455,7 +455,7 @@ label.infield {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=30)";
 	opacity: .3;
 }
-#show + label:before, #dbpassword + label:before, #personal-show + label:before {
+#show + label:before, #dbpassword-toggle + label:before, #personal-show + label:before {
 	display: none;
 }
 #pass2, input[name="personal-password-clone"] {

--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -108,13 +108,13 @@ script('core', [
 					autocomplete="off" autocapitalize="off" autocorrect="off">
 			</p>
 			<p class="groupmiddle">
-				<input type="password" name="dbpass" id="dbpass" data-typetoggle="#dbpassword"
+				<input type="password" name="dbpass" id="dbpass" data-typetoggle="#dbpassword-toggle"
 					placeholder="<?php p($l->t( 'Database password' )); ?>"
 					value="<?php p($_['dbpass']); ?>"
 					autocomplete="off" autocapitalize="off" autocorrect="off">
 				<label for="dbpass" class="infield"><?php p($l->t( 'Database password' )); ?></label>
-				<input type="checkbox" id="dbpassword" name="dbpassword">
-				<label for="dbpassword"></label>
+				<input type="checkbox" id="dbpassword-toggle" name="dbpassword-toggle">
+				<label for="dbpassword-toggle"></label>
 			</p>
 			<p class="groupmiddle">
 				<label for="dbname" class="infield"><?php p($l->t( 'Database name' )); ?></label>


### PR DESCRIPTION
* otherwise submitting the form with the password show will be overwritten
* see https://github.com/nextcloud/server/blob/2c9d7eeb763d2f907eea8234f6c60a829a5d39f7/core/Controller/SetupController.php#L59
* seems to be a legacy fallback
* fixes #3381 
* backport of #3403 
