### PR TITLE
Only request "IndexIgnore" if mod_autoindex is loaded

### DIFF
--- a/apps/user_ldap/tests/.htaccess
+++ b/apps/user_ldap/tests/.htaccess
@@ -11,4 +11,6 @@ Satisfy All
 </ifModule>
 
 # section for Apache 2.2 and 2.4
+<ifModule mod_autoindex.c>
 IndexIgnore *
+</ifModule>

--- a/build/.htaccess
+++ b/build/.htaccess
@@ -9,4 +9,6 @@ deny from all
 </ifModule>
 
 # section for Apache 2.2 and 2.4
+<ifModule mod_autoindex.c>
 IndexIgnore *
+</ifModule>

--- a/config/.htaccess
+++ b/config/.htaccess
@@ -9,4 +9,6 @@ deny from all
 </ifModule>
 
 # section for Apache 2.2 and 2.4
+<ifModule mod_autoindex.c>
 IndexIgnore *
+</ifModule>

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -492,7 +492,9 @@ class Setup {
 		$content.= "Satisfy All\n";
 		$content.= "</ifModule>\n\n";
 		$content.= "# section for Apache 2.2 and 2.4\n";
+		$content.= "<ifModule mod_autoindex.c>\n";
 		$content.= "IndexIgnore *\n";
+		$content.= "</ifModule>\n";
 
 		$baseDir = \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data');
 		file_put_contents($baseDir . '/.htaccess', $content);


### PR DESCRIPTION
Only request "IndexIgnore" if mod_autoindex is loaded, otherwise this leads to HTTP 500 status response codes. These indeed do not have any impact on the overall desired result, however HTTP 500 status response codes might waken up one or the other Apache access_log analyzer or simply a sensitive administrator.