### PR TITLE
Don't force displayname if backend already provides one

### DIFF
--- a/lib/private/legacy/user.php
+++ b/lib/private/legacy/user.php
@@ -187,7 +187,18 @@ class OC_User {
 		if ($uid) {
 			if (self::getUser() !== $uid) {
 				self::setUserId($uid);
-				self::setDisplayName($uid);
+				$setUidAsDisplayName = true;
+				if($backend instanceof \OCP\UserInterface
+					&& $backend->implementsActions(OC_User_Backend::GET_DISPLAYNAME)) {
+
+					$backendDisplayName = $backend->getDisplayName($uid);
+					if(is_string($backendDisplayName) && trim($backendDisplayName) !== '') {
+						$setUidAsDisplayName = false;
+					}
+				}
+				if($setUidAsDisplayName) {
+					self::setDisplayName($uid);
+				}
 				self::getUserSession()->setLoginName($uid);
 				$request = OC::$server->getRequest();
 				self::getUserSession()->createSessionToken($request, $uid, $uid);


### PR DESCRIPTION
`\OC_User::loginWithApache` is used in combination with backend mechanisms like our SSO / SAML integration. Those can optionally already provide a displayname using other means. For example by mapping SAML attributes.

The current approach makes it however impossible for backends using `\OCP\Authentication\IApacheBackend` to set a displayname on their own. Because the display name will simply be overwritten with the loginname.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>