### PR TITLE
[stable11] Fix cookie name (nc_token instead of oc_token)

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -98,7 +98,7 @@ class LoginController extends Controller {
 	 * @return RedirectResponse
 	 */
 	public function logout() {
-		$loginToken = $this->request->getCookie('oc_token');
+		$loginToken = $this->request->getCookie('nc_token');
 		if (!is_null($loginToken)) {
 			$this->config->deleteUserValue($this->userSession->getUser()->getUID(), 'login_token', $loginToken);
 		}

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -89,7 +89,7 @@ class LoginControllerTest extends TestCase {
 		$this->request
 			->expects($this->once())
 			->method('getCookie')
-			->with('oc_token')
+			->with('nc_token')
 			->willReturn(null);
 		$this->config
 			->expects($this->never())
@@ -108,7 +108,7 @@ class LoginControllerTest extends TestCase {
 		$this->request
 			->expects($this->once())
 			->method('getCookie')
-			->with('oc_token')
+			->with('nc_token')
 			->willReturn('MyLoginToken');
 		$user = $this->getMockBuilder('\\OCP\\IUser')->getMock();
 		$user


### PR DESCRIPTION
Backport as requested by @LukasReschke in https://github.com/nextcloud/server/pull/3362#pullrequestreview-20249826.