### PR TITLE
provide api to convert link to mail share

### DIFF
--- a/core/Controller/LegacyShareController.php
+++ b/core/Controller/LegacyShareController.php
@@ -68,6 +68,7 @@ class LegacyShareController extends Controller {
 	}
 
 	/**
+	 * @NoAdminRequired
 	 * @param string $action
 	 * @param string $toaddress
 	 * @param string $link

--- a/core/Controller/LegacyShareController.php
+++ b/core/Controller/LegacyShareController.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OC\Core\Controller;
+
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\Share\IManager;
+
+/**
+ * Class LegacyShareController
+ *
+ * Implements a ajax call to send a link share by mail by creating a dedicated mail
+ * share
+ *
+ * This class is used to stay compatible with the ownCloud sync client.
+ * Can be removed as soon as compatibility is no longer required
+ *
+ * @package OC\Core\Controller
+ */
+class LegacyShareController extends Controller {
+
+	/** @var IManager */
+	private $shareManager;
+
+	/**
+	 * LegacyShareController constructor.
+	 *
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param IManager $shareManager
+	 */
+	public function __construct($appName, IRequest $request, IManager $shareManager) {
+		parent::__construct($appName, $request);
+		$this->shareManager = $shareManager;
+	}
+
+	/**
+	 * @param string $action
+	 * @param string $toaddress
+	 * @param string $link
+	 * @return JSONResponse
+	 */
+	public function link2Mail($action, $toaddress, $link) {
+		if ($action !== 'email') {
+			return new JSONResponse([], Http::STATUS_GONE);
+		}
+
+		$recipients = $this->getEmailAddresses($toaddress);
+
+		try {
+			$token = $this->getTokenFromUrl($link);
+			$share = $this->shareManager->getShareByToken($token);
+			$share->setShareType(\OCP\Share::SHARE_TYPE_EMAIL);
+			foreach ($recipients as $to) {
+				$share->setSharedWith($to);
+				$this->shareManager->createShare($share);
+			}
+		} catch (\Exception $e) {
+			return new JSONResponse(['data' => ['message' => 'Failed to send link by mail']], Http::STATUS_BAD_REQUEST);
+		}
+		return new JSONResponse();
+	}
+
+	/**
+	 * exctract token from url
+	 *
+	 * @param string $url
+	 * @return string
+	 */
+	protected function getTokenFromUrl($url) {
+		$start = strrpos($url, '/') + 1;
+		$token = substr($url, $start);
+		return $token;
+	}
+
+	/**
+	 * seperate multiple email addresses by ','
+	 *
+	 * @param string $addresses
+	 * @return array
+	 */
+	protected function getEmailAddresses($addresses) {
+		return explode(',' , $addresses);
+	}
+
+}

--- a/core/routes.php
+++ b/core/routes.php
@@ -56,6 +56,7 @@ $application->registerRoutes($this, [
 		['name' => 'Preview#getPreview', 'url' => '/core/preview', 'verb' => 'GET'],
 		['name' => 'Preview#getPreview', 'url' => '/core/preview.png', 'verb' => 'GET'],
 		['name' => 'Css#getCss', 'url' => '/css/{appName}/{fileName}', 'verb' => 'GET'],
+		['name' => 'LegacyShare#link2Mail', 'url' => '/core/ajax/share.php', 'verb' => 'POST'],
 	],
 	'ocs' => [
 		['root' => '/cloud', 'name' => 'OCS#getCapabilities', 'url' => '/capabilities', 'verb' => 'GET'],


### PR DESCRIPTION
Providing a endpoint for the old API to send a public link by mail. In our case we will create a full featured mail share.

I tested it by repeating the API call with Curl, but would be good to test it with the actual sync client to make sure that's really the end point they use.

@rullzer can you test this with the upcoming sync client to see if it works as expected.