### PR TITLE
Theming using SCSS variables

### DIFF
--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -1,0 +1,64 @@
+.nc-theming-main-background {
+	background-color: $color-primary;
+}
+
+.nc-theming-main-text {
+	color: $color-primary-text;
+}
+
+.nc-theming-contrast {
+	color: $color-primary-text;
+}
+
+/* invert header icons on bright background */
+@if (lightness($color-primary) > 50) {
+	#header .icon-caret {
+		background-image: url(../../../core/img/actions/caret-dark.svg);
+	}
+	.searchbox input[type="search"] {
+		background: transparent url(../../../core/img/actions/search.svg) no-repeat 6px center;
+	}
+	#appmenu li a img {
+		-webkit-filter: invert(1);
+		filter: invert(1);
+		filter: progid:DXImageTransform.Microsoft.BasicImage(invert='1');
+	}
+}
+
+/* Colorized svg images */
+.icon-file, .icon-filetype-text {
+	background-image: url(../img/core/filetypes/text.svg?v=#{$theming-cachebuster});
+}
+
+.icon-folder, .icon-filetype-folder {
+	background-image: url(./img/core/filetypes/folder.svg?v=#{$theming-cachebuster});
+}
+
+.icon-filetype-folder-drag-accept {
+	background-image: url(./img/core/filetypes/folder-drag-accept.svg?v=#{$theming-cachebuster}) !important;
+}
+
+/* override styles for login screen in guest.css */
+#header .logo,
+#header .logo-icon {
+	background-size: contain;
+	background-image: url(#{$image-logo}?v=#{$theming-cachebuster});
+}
+
+#body-login,
+#firstrunwizard .firstrunwizard-header {
+	background-image: url(#{$image-login-background}?v=#{$theming-cachebuster});
+	background-color: $color-primary;
+}
+
+input.primary {
+	background-color: nc-lighten($color-primary, .9);
+	border: 1px solid $color-primary;
+	color: $color-primary-text;
+}
+
+@if (lightness($color-primary) > 50) {
+	#body-login input.login {
+		background-image: url(../../../core/img/actions/confirm.svg);
+	}
+}

--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -27,6 +27,8 @@
 
 namespace OCA\Theming\Controller;
 
+use OC\Files\AppData\Factory;
+use OC\Template\SCSSCacher;
 use OCA\Theming\ThemingDefaults;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -40,9 +42,11 @@ use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\IConfig;
 use OCP\IL10N;
+use OCP\ILogger;
 use OCP\IRequest;
 use OCA\Theming\Util;
 use OCP\ITempManager;
+use OCP\IURLGenerator;
 
 /**
  * Class ThemingController
@@ -53,19 +57,21 @@ use OCP\ITempManager;
  */
 class ThemingController extends Controller {
 	/** @var ThemingDefaults */
-	private $template;
+	private $themingDefaults;
 	/** @var Util */
 	private $util;
 	/** @var ITimeFactory */
 	private $timeFactory;
 	/** @var IL10N */
-	private $l;
+	private $l10n;
 	/** @var IConfig */
 	private $config;
 	/** @var ITempManager */
 	private $tempManager;
 	/** @var IAppData */
 	private $appData;
+	/** @var SCSSCacher */
+	private $scssCacher;
 
 	/**
 	 * ThemingController constructor.
@@ -73,33 +79,36 @@ class ThemingController extends Controller {
 	 * @param string $appName
 	 * @param IRequest $request
 	 * @param IConfig $config
-	 * @param ThemingDefaults $template
+	 * @param ThemingDefaults $themingDefaults
 	 * @param Util $util
 	 * @param ITimeFactory $timeFactory
 	 * @param IL10N $l
 	 * @param ITempManager $tempManager
 	 * @param IAppData $appData
+	 * @param SCSSCacher $scssCacher
 	 */
 	public function __construct(
 		$appName,
 		IRequest $request,
 		IConfig $config,
-		ThemingDefaults $template,
+		ThemingDefaults $themingDefaults,
 		Util $util,
 		ITimeFactory $timeFactory,
 		IL10N $l,
 		ITempManager $tempManager,
-		IAppData $appData
+		IAppData $appData,
+		SCSSCacher $scssCacher
 	) {
 		parent::__construct($appName, $request);
 
-		$this->template = $template;
+		$this->themingDefaults = $themingDefaults;
 		$this->util = $util;
 		$this->timeFactory = $timeFactory;
-		$this->l = $l;
+		$this->l10n = $l;
 		$this->config = $config;
 		$this->tempManager = $tempManager;
 		$this->appData = $appData;
+		$this->scssCacher = $scssCacher;
 	}
 
 	/**
@@ -115,7 +124,7 @@ class ThemingController extends Controller {
 				if (strlen($value) > 250) {
 					return new DataResponse([
 						'data' => [
-							'message' => $this->l->t('The given name is too long'),
+							'message' => $this->l10n->t('The given name is too long'),
 						],
 						'status' => 'error'
 					]);
@@ -125,7 +134,7 @@ class ThemingController extends Controller {
 				if (strlen($value) > 500) {
 					return new DataResponse([
 						'data' => [
-							'message' => $this->l->t('The given web address is too long'),
+							'message' => $this->l10n->t('The given web address is too long'),
 						],
 						'status' => 'error'
 					]);
@@ -135,7 +144,7 @@ class ThemingController extends Controller {
 				if (strlen($value) > 500) {
 					return new DataResponse([
 						'data' => [
-							'message' => $this->l->t('The given slogan is too long'),
+							'message' => $this->l10n->t('The given slogan is too long'),
 						],
 						'status' => 'error'
 					]);
@@ -145,7 +154,7 @@ class ThemingController extends Controller {
 				if (!preg_match('/^\#([0-9a-f]{3}|[0-9a-f]{6})$/i', $value)) {
 					return new DataResponse([
 						'data' => [
-							'message' => $this->l->t('The given color is invalid'),
+							'message' => $this->l10n->t('The given color is invalid'),
 						],
 						'status' => 'error'
 					]);
@@ -153,12 +162,12 @@ class ThemingController extends Controller {
 				break;
 		}
 
-		$this->template->set($setting, $value);
+		$this->themingDefaults->set($setting, $value);
 		return new DataResponse(
 			[
 				'data' =>
 					[
-						'message' => $this->l->t('Saved')
+						'message' => $this->l10n->t('Saved')
 					],
 				'status' => 'success'
 			]
@@ -177,7 +186,7 @@ class ThemingController extends Controller {
 			return new DataResponse(
 				[
 					'data' => [
-						'message' => $this->l->t('No file uploaded')
+						'message' => $this->l10n->t('No file uploaded')
 					]
 				],
 				Http::STATUS_UNPROCESSABLE_ENTITY
@@ -191,20 +200,20 @@ class ThemingController extends Controller {
 			$folder = $this->appData->newFolder('images');
 		}
 
-		if(!empty($newLogo)) {
+		if (!empty($newLogo)) {
 			$target = $folder->newFile('logo');
 			$target->putContent(file_get_contents($newLogo['tmp_name'], 'r'));
-			$this->template->set('logoMime', $newLogo['type']);
+			$this->themingDefaults->set('logoMime', $newLogo['type']);
 			$name = $newLogo['name'];
 		}
-		if(!empty($newBackgroundLogo)) {
+		if (!empty($newBackgroundLogo)) {
 			$target = $folder->newFile('background');
 			$image = @imagecreatefromstring(file_get_contents($newBackgroundLogo['tmp_name'], 'r'));
-			if($image === false) {
+			if ($image === false) {
 				return new DataResponse(
 					[
 						'data' => [
-							'message' => $this->l->t('Unsupported image type'),
+							'message' => $this->l10n->t('Unsupported image type'),
 						],
 						'status' => 'failure',
 					],
@@ -215,10 +224,10 @@ class ThemingController extends Controller {
 			// Optimize the image since some people may upload images that will be
 			// either to big or are not progressive rendering.
 			$tmpFile = $this->tempManager->getTemporaryFile();
-			if(function_exists('imagescale')) {
+			if (function_exists('imagescale')) {
 				// FIXME: Once PHP 5.5.0 is a requirement the above check can be removed
 				// Workaround for https://bugs.php.net/bug.php?id=65171
-				$newHeight = imagesy($image)/(imagesx($image)/1920);
+				$newHeight = imagesy($image) / (imagesx($image) / 1920);
 				$image = imagescale($image, 1920, $newHeight);
 			}
 			imageinterlace($image, 1);
@@ -226,7 +235,7 @@ class ThemingController extends Controller {
 			imagedestroy($image);
 
 			$target->putContent(file_get_contents($tmpFile, 'r'));
-			$this->template->set('backgroundMime', $newBackgroundLogo['type']);
+			$this->themingDefaults->set('backgroundMime', $newBackgroundLogo['type']);
 			$name = $newBackgroundLogo['name'];
 		}
 
@@ -235,7 +244,7 @@ class ThemingController extends Controller {
 				'data' =>
 					[
 						'name' => $name,
-						'message' => $this->l->t('Saved')
+						'message' => $this->l10n->t('Saved')
 					],
 				'status' => 'success'
 			]
@@ -249,13 +258,13 @@ class ThemingController extends Controller {
 	 * @return DataResponse
 	 */
 	public function undo($setting) {
-		$value = $this->template->undo($setting);
+		$value = $this->themingDefaults->undo($setting);
 		return new DataResponse(
 			[
 				'data' =>
 					[
 						'value' => $value,
-						'message' => $this->l->t('Saved')
+						'message' => $this->l10n->t('Saved')
 					],
 				'status' => 'success'
 			]
@@ -316,128 +325,34 @@ class ThemingController extends Controller {
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 *
-	 * @return DataDownloadResponse
+	 * @return FileDisplayResponse|NotFoundResponse
 	 */
 	public function getStylesheet() {
-		$cacheBusterValue = $this->config->getAppValue('theming', 'cachebuster', '0');
-		$responseCss = '';
-		$color = $this->config->getAppValue($this->appName, 'color');
-		$elementColor = $this->util->elementColor($color);
-
-		if($this->util->invertTextColor($color)) {
-			$textColor = '#000000';
-		} else {
-			$textColor = '#ffffff';
+		$appPath = substr(\OC::$server->getAppManager()->getAppPath('theming'), strlen(\OC::$SERVERROOT) + 1);
+		/* SCSSCacher is required here
+		 * We cannot rely on automatic caching done by \OC_Util::addStyle,
+		 * since we need to add the cacheBuster value to the url
+		 */
+		$cssCached = $this->scssCacher->process(\OC::$SERVERROOT, $appPath . '/css/theming.scss', 'theming');
+		if(!$cssCached) {
+			return new NotFoundResponse();
 		}
 
-		if($color !== '') {
-			$responseCss .= sprintf(
-				'#body-user #header,#body-settings #header,#body-public #header,#body-login,.searchbox input[type="search"]:focus,.searchbox input[type="search"]:active,.searchbox input[type="search"]:valid {background-color: %s}' . "\n",
-				$color
-			);
-			$responseCss .= sprintf('input[type="checkbox"].checkbox:checked:enabled:not(.checkbox--white) + label:before {' .
-				'background-image:url(\'%s/core/img/actions/checkmark-white.svg\');' .
-				'background-color: %s; background-position: center center; background-size:contain;' .
-				'width:12px; height:12px; padding:0; margin:2px 6px 6px 2px; border-radius:1px;' .
-				"}\n",
-				\OC::$WEBROOT,
-				$elementColor
-			);
-			$responseCss .= 'input[type="radio"].radio:checked:not(.radio--white):not(:disabled) + label:before {' .
-				'background-image: url(\'data:image/svg+xml;base64,'.$this->util->generateRadioButton($elementColor).'\');' .
-				"}\n";
-			$responseCss .= '.primary, input[type="submit"].primary, input[type="button"].primary, button.primary, .button.primary,' .
-				'.primary:active, input[type="submit"].primary:active, input[type="button"].primary:active, button.primary:active, .button.primary:active {' .
-				'border: 1px solid '.$elementColor.';'.
-				'background-color: '.$elementColor.';'.
-				'color: ' . $textColor . ';'.
-				"}\n" .
-				'.primary:hover, input[type="submit"].primary:hover, input[type="button"].primary:hover, button.primary:hover, .button.primary:hover,' .
-				'.primary:focus, input[type="submit"].primary:focus, input[type="button"].primary:focus, button.primary:focus, .button.primary:focus {' .
-				'border: 1px solid '.$elementColor.';'.
-				'background-color: '.$elementColor.';'.
-				'color: ' . $textColor . ';'.
-				"}\n" .
-				'.primary:disabled, input[type="submit"].primary:disabled, input[type="button"].primary:disabled, button.primary:disabled, .button.primary:disabled,' .
-				'.primary:disabled:hover, input[type="submit"].primary:disabled:hover, input[type="button"].primary:disabled:hover, button.primary:disabled:hover, .button.primary:disabled:hover,' .
-				'.primary:disabled:focus, input[type="submit"].primary:disabled:focus, input[type="button"].primary:disabled:focus, button.primary:disabled:focus, .button.primary:disabled:focus {' .
-				'border: 1px solid '.$elementColor.';'.
-				'background-color: '.$elementColor.';'.
-				'opacity: 0.4;' .
-				'color: '.$textColor.';'.
-				"}\n";
-			$responseCss .= '.ui-widget-header { border: 1px solid ' . $color . '; background: '. $color . '; color: #ffffff;' . "}\n";
-			$responseCss .= '.ui-state-active, .ui-widget-content .ui-state-active, .ui-widget-header .ui-state-active {' .
-				'border: 1px solid ' . $color . ';' .
-				'color: ' . $elementColor . ';' .
-				"}\n";
-			$responseCss .= '.ui-state-active a, .ui-state-active a:link, .ui-state-active a:visited {' .
-				'color: ' . $elementColor . ';' .
-				"}\n";
-			$responseCss .= '
-				#firstrunwizard .firstrunwizard-header {
-					background-color: ' . $color . ';
-				}
-				#firstrunwizard p a {
-					color: ' . $color . ';
-				}
-				';
-			$responseCss .= sprintf('.nc-theming-main-background {background-color: %s}' . "\n", $color);
-			$responseCss .= sprintf('.nc-theming-main-text {color: %s}' . "\n", $color);
-			$responseCss .= sprintf('#app-navigation li:hover > a, #app-navigation li:focus > a, #app-navigation a:focus, #app-navigation .selected, #app-navigation .selected a, #app-navigation .active, #app-navigation .active a {box-shadow: inset 2px 0 %s}' . "\n", $color);
-
+		try {
+			$cssFile = $this->scssCacher->getCachedCSS('theming', 'theming.css');
+			$response = new FileDisplayResponse($cssFile, Http::STATUS_OK, ['Content-Type' => 'text/css']);
+			$response->cacheFor(86400);
+			$expires = new \DateTime();
+			$expires->setTimestamp($this->timeFactory->getTime());
+			$expires->add(new \DateInterval('PT24H'));
+			$response->addHeader('Expires', $expires->format(\DateTime::RFC1123));
+			$response->addHeader('Pragma', 'cache');
+			return $response;
+		} catch (NotFoundException $e) {
+			return new NotFoundResponse();
 		}
-		$logo = $this->config->getAppValue($this->appName, 'logoMime');
-		if($logo !== '') {
-			$responseCss .= sprintf(
-				'#header .logo {' .
-				'background-image: url(\'./logo?v='.$cacheBusterValue.'\');' .
-				'background-size: contain;' .
-				'}' . "\n" .
-				'#header .logo-icon {' .
-				'background-image: url(\'./logo?v='.$cacheBusterValue.'\');' .
-				'background-size: contain;' .
-				'}' . "\n" .
-				'#firstrunwizard .firstrunwizard-header .logo {' .
-				'background-image: url(\'./logo?v='.$cacheBusterValue.'\');' .
-				'background-size: contain;' .
-				'}' . "\n"
-			);
-		}
-		$backgroundLogo = $this->config->getAppValue($this->appName, 'backgroundMime');
-		if($backgroundLogo !== '') {
-			$responseCss .= '#body-login {background-image: url(\'./loginbackground?v='.$cacheBusterValue.'\');}' . "\n";
-			$responseCss .= '#firstrunwizard .firstrunwizard-header {' .
-				'background-image: url(\'./loginbackground?v='.$cacheBusterValue.'\');' .
-			'}' . "\n";
-		}
-		if($this->util->invertTextColor($color)) {
-			$responseCss .= '#header .header-appname, #expandDisplayName { color: #000000; }' . "\n";
-			$responseCss .= '#header .icon-caret { background-image: url(\'' . \OC::$WEBROOT . '/core/img/actions/caret-dark.svg\'); }' . "\n";
-			$responseCss .= '.searchbox input[type="search"] { background: transparent url(\'' . \OC::$WEBROOT . '/core/img/actions/search.svg\') no-repeat 6px center; color: #000; }' . "\n";
-			$responseCss .= '.searchbox input[type="search"]:focus,.searchbox input[type="search"]:active,.searchbox input[type="search"]:valid { color: #000; border: 1px solid rgba(0, 0, 0, .5); }' . "\n";
-			$responseCss .= '#body-login input.login { background-image: url(\'' . \OC::$WEBROOT . '/core/img/actions/confirm.svg?v=2\'); }' . "\n";
-			$responseCss .= '.nc-theming-contrast {color: #000000}' . "\n";
-			$responseCss .= '.ui-widget-header { color: #000000; }' . "\n";
-		} else {
-			$responseCss .= '.nc-theming-contrast {color: #ffffff}' . "\n";
-		}
-
-		if($logo !== '' or $color !== '') {
-			$responseCss .= '.icon-file,.icon-filetype-text {' .
-				'background-image: url(\'./img/core/filetypes/text.svg?v='.$cacheBusterValue.'\');' . "}\n" .
-				'.icon-folder, .icon-filetype-folder {' .
-				'background-image: url(\'./img/core/filetypes/folder.svg?v='.$cacheBusterValue.'\');' . "}\n" .
-				'.icon-filetype-folder-drag-accept {' .
-				'background-image: url(\'./img/core/filetypes/folder-drag-accept.svg?v='.$cacheBusterValue.'\')!important;' . "}\n";
-		}
-
-		$response = new DataDownloadResponse($responseCss, 'style', 'text/css');
-		$response->addHeader('Expires', date(\DateTime::RFC2822, $this->timeFactory->getTime()));
-		$response->addHeader('Pragma', 'cache');
-		$response->cacheFor(3600);
-		return $response;
 	}
+
 	/**
 	 * @NoCSRFRequired
 	 * @PublicPage
@@ -448,12 +363,12 @@ class ThemingController extends Controller {
 		$cacheBusterValue = $this->config->getAppValue('theming', 'cachebuster', '0');
 		$responseJS = '(function() {
 	OCA.Theming = {
-		name: ' . json_encode($this->template->getName()) . ',
-		url: ' . json_encode($this->template->getBaseUrl()) . ',
-		slogan: ' . json_encode($this->template->getSlogan()) . ',
-		color: ' . json_encode($this->template->getColorPrimary()) . ',
-		inverted: ' . json_encode($this->util->invertTextColor($this->template->getColorPrimary())) . ',
-		cacheBuster: ' . json_encode($cacheBusterValue). '
+		name: ' . json_encode($this->themingDefaults->getName()) . ',
+		url: ' . json_encode($this->themingDefaults->getBaseUrl()) . ',
+		slogan: ' . json_encode($this->themingDefaults->getSlogan()) . ',
+		color: ' . json_encode($this->themingDefaults->getColorPrimary()) . ',
+		inverted: ' . json_encode($this->util->invertTextColor($this->themingDefaults->getColorPrimary())) . ',
+		cacheBuster: ' . json_encode($cacheBusterValue) . '
 	};
 })();';
 		$response = new DataDownloadResponse($responseJS, 'javascript', 'text/javascript');

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -169,7 +169,7 @@ class ThemingDefaults extends \OC_Defaults {
 			return $this->urlGenerator->imagePath('core','background.jpg');
 		}
 
-		return $this->urlGenerator->linkToRoute('theming.Theming.getLoginBackground');
+		return $this->urlGenerator->linkToRouteAbsolute('theming.Theming.getLoginBackground');
 	}
 
 

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -144,10 +144,10 @@ class ThemingDefaults extends \OC_Defaults {
 		$cacheBusterCounter = $this->config->getAppValue('theming', 'cachebuster', '0');
 
 		if(!$logo || !$logoExists) {
-			return $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core','logo.svg') . '?v=' . $cacheBusterCounter);
+			return $this->urlGenerator->imagePath('core','logo.svg') . '?v=' . $cacheBusterCounter;
 		}
 
-		return $this->urlGenerator->linkToRouteAbsolute('theming.Theming.getLogo') . '?v=' . $cacheBusterCounter;
+		return $this->urlGenerator->linkToRoute('theming.Theming.getLogo') . '?v=' . $cacheBusterCounter;
 	}
 
 	/**
@@ -169,7 +169,7 @@ class ThemingDefaults extends \OC_Defaults {
 			return $this->urlGenerator->imagePath('core','background.jpg');
 		}
 
-		return $this->urlGenerator->linkToRouteAbsolute('theming.Theming.getLoginBackground');
+		return $this->urlGenerator->linkToRoute('theming.Theming.getLoginBackground');
 	}
 
 
@@ -186,8 +186,8 @@ class ThemingDefaults extends \OC_Defaults {
 			'theming-cachebuster' => "'" . $this->config->getAppValue('theming', 'cachebuster', '0') . "'",
 		];
 
-		$variables['image-logo'] = "'".$this->getLogo()."'";
-		$variables['image-login-background'] = "'".$this->getBackground()."'";
+		$variables['image-logo'] = "'".$this->urlGenerator->getAbsoluteURL($this->getLogo())."'";
+		$variables['image-login-background'] = "'".$this->urlGenerator->getAbsoluteURL($this->getBackground())."'";
 
 		if ($this->config->getAppValue('theming', 'color', null) !== null) {
 			if ($this->util->invertTextColor($this->getColorPrimary())) {

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -25,7 +25,11 @@ namespace OCA\Theming\Tests;
 
 use OCA\Theming\ThemingDefaults;
 use OCP\Files\IAppData;
+use OCA\Theming\Util;
+use OCP\Files\NotFoundException;
+use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
+use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IL10N;
@@ -47,14 +51,20 @@ class ThemingDefaultsTest extends TestCase {
 	private $cacheFactory;
 	/** @var ThemingDefaults */
 	private $template;
+	/** @var Util|\PHPUnit_Framework_MockObject_MockObject */
+	private $util;
+	/** @var ICache|\PHPUnit_Framework_MockObject_MockObject */
+	private $cache;
 
 	public function setUp() {
 		parent::setUp();
 		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->l10n = $this->getMockBuilder(IL10N::class)->getMock();
-		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)->getMock();
+		$this->urlGenerator = \OC::$server->query(IURLGenerator::class);
 		$this->appData = $this->createMock(IAppData::class);
-		$this->cacheFactory = $this->getMockBuilder(ICacheFactory::class)->getMock();
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->cache = $this->createMock(ICache::class);
+		$this->util = $this->createMock(Util::class);
 		$this->defaults = $this->getMockBuilder(\OC_Defaults::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -74,13 +84,19 @@ class ThemingDefaultsTest extends TestCase {
 			->expects($this->at(3))
 			->method('getColorPrimary')
 			->willReturn('#000');
+		$this->cacheFactory
+			->expects($this->any())
+			->method('create')
+			->with('theming')
+			->willReturn($this->cache);
 		$this->template = new ThemingDefaults(
 			$this->config,
 			$this->l10n,
 			$this->urlGenerator,
 			$this->defaults,
 			$this->appData,
-			$this->cacheFactory
+			$this->cacheFactory,
+			$this->util
 		);
 	}
 
@@ -265,7 +281,10 @@ class ThemingDefaultsTest extends TestCase {
 			->expects($this->at(2))
 			->method('setAppValue')
 			->with('theming', 'cachebuster', 16);
-
+		$this->cache
+			->expects($this->once())
+			->method('clear')
+			->with('getScssVariables');
 		$this->template->set('MySetting', 'MyValue');
 	}
 
@@ -380,6 +399,11 @@ class ThemingDefaultsTest extends TestCase {
 	}
 
 	public function testGetBackgroundDefault() {
+		$folder = $this->createMock(ISimpleFolder::class);
+		$file = $this->createMock(ISimpleFile::class);
+		$this->appData->expects($this->once())
+			->method('getFolder')
+			->willThrowException(new NotFoundException());
 		$this->config
 			->expects($this->once())
 			->method('getAppValue')
@@ -395,6 +419,12 @@ class ThemingDefaultsTest extends TestCase {
 	}
 
 	public function testGetBackgroundCustom() {
+		$folder = $this->createMock(ISimpleFolder::class);
+		$file = $this->createMock(ISimpleFile::class);
+		$folder->expects($this->once())->method('getFile')->willReturn($file);
+		$this->appData->expects($this->once())
+			->method('getFolder')
+			->willReturn($folder);
 		$this->config
 			->expects($this->once())
 			->method('getAppValue')
@@ -411,11 +441,14 @@ class ThemingDefaultsTest extends TestCase {
 			->method('getFile')
 			->with('background')
 			->willReturn('');
-		$expected = $this->urlGenerator->linkToRoute('theming.Theming.getLoginBackground');
+		$expected = $this->urlGenerator->linkToRouteAbsolute('theming.Theming.getLoginBackground');
 		$this->assertEquals($expected, $this->template->getBackground());
 	}
 
 	public function testGetLogoDefault() {
+		$this->appData->expects($this->once())
+			->method('getFolder')
+			->willThrowException(new NotFoundException());
 		$this->config
 			->expects($this->at(0))
 			->method('getAppValue')
@@ -431,11 +464,17 @@ class ThemingDefaultsTest extends TestCase {
 			->method('getFolder')
 			->with('images')
 			->willThrowException(new \Exception());
-		$expected = $this->urlGenerator->imagePath('core','logo.svg') . '?v=0';
+		$expected = $this->urlGenerator->getAbsoluteURL('/core/img/logo.svg') . '?v=0';
 		$this->assertEquals($expected, $this->template->getLogo());
 	}
 
 	public function testGetLogoCustom() {
+		$folder = $this->createMock(ISimpleFolder::class);
+		$file = $this->createMock(ISimpleFile::class);
+		$folder->expects($this->once())->method('getFile')->willReturn($file);
+		$this->appData->expects($this->once())
+			->method('getFolder')
+			->willReturn($folder);
 		$this->config
 			->expects($this->at(0))
 			->method('getAppValue')
@@ -457,7 +496,39 @@ class ThemingDefaultsTest extends TestCase {
 			->method('getFile')
 			->with('logo')
 			->willReturn('');
-		$expected = $this->urlGenerator->linkToRoute('theming.Theming.getLogo') . '?v=0';
+		$expected = $this->urlGenerator->getAbsoluteURL('index.php/apps/theming/logo') . '?v=0';
 		$this->assertEquals($expected, $this->template->getLogo());
+	}
+
+	public function testGetScssVariablesCached() {
+		$this->cache->expects($this->once())->method('get')->with('getScssVariables')->willReturn(['foo'=>'bar']);
+		$this->assertEquals(['foo'=>'bar'], $this->template->getScssVariables());
+	}
+
+	public function testGetScssVariables() {
+		$this->config->expects($this->at(0))->method('getAppValue')->with('theming', 'cachebuster', '0')->willReturn('0');
+		$this->config->expects($this->at(1))->method('getAppValue')->with('theming', 'logoMime', false)->willReturn('jpeg');
+		$this->config->expects($this->at(2))->method('getAppValue')->with('theming', 'backgroundMime', false)->willReturn('jpeg');
+		$this->config->expects($this->at(3))->method('getAppValue')->with('theming', 'color', null)->willReturn('#000000');
+		$this->config->expects($this->at(4))->method('getAppValue')->with('theming', 'color', '#000')->willReturn('#000000');
+		$this->config->expects($this->at(5))->method('getAppValue')->with('theming', 'color', '#000')->willReturn('#000000');
+
+		$this->util->expects($this->any())->method('invertTextColor')->with('#000000')->willReturn(false);
+		$this->cache->expects($this->once())->method('get')->with('getScssVariables')->willReturn(null);
+		$folder = $this->createMock(ISimpleFolder::class);
+		$file = $this->createMock(ISimpleFile::class);
+		$folder->expects($this->any())->method('getFile')->willReturn($file);
+		$this->appData->expects($this->any())
+			->method('getFolder')
+			->willReturn($folder);
+		$expected = [
+			'theming-cachebuster' => '\'0\'',
+			'image-logo' => '\'' . $this->urlGenerator->getAbsoluteURL('index.php/apps/theming/logo') . '?v=0\'',
+			'image-login-background' => '\'' . $this->urlGenerator->getAbsoluteURL('index.php/apps/theming/loginbackground') . '\'',
+			'color-primary' => '#000000',
+			'color-primary-text' => '#ffffff'
+
+		];
+		$this->assertEquals($expected, $this->template->getScssVariables());
 	}
 }

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -432,8 +432,7 @@ class ThemingDefaultsTest extends TestCase {
 			->method('getAppValue')
 			->with('theming', 'backgroundMime', false)
 			->willReturn('image/svg+xml');
-		$expected = $this->urlGenerator->linkToRouteAbsolute('theming.Theming.getLoginBackground');
-		$this->assertEquals($expected, $this->template->getBackground());
+		$this->assertEquals('/index.php/apps/theming/loginbackground', $this->template->getBackground());
 	}
 
 	public function testGetLogoDefault() {
@@ -455,8 +454,7 @@ class ThemingDefaultsTest extends TestCase {
 			->method('getFolder')
 			->with('images')
 			->willThrowException(new \Exception());
-		$expected = $this->urlGenerator->getAbsoluteURL('/core/img/logo.svg') . '?v=0';
-		$this->assertEquals($expected, $this->template->getLogo());
+		$this->assertEquals('/core/img/logo.svg?v=0', $this->template->getLogo());
 	}
 
 	public function testGetLogoCustom() {
@@ -478,8 +476,7 @@ class ThemingDefaultsTest extends TestCase {
 			->method('getAppValue')
 			->with('theming', 'cachebuster', '0')
 			->willReturn('0');
-		$expected = $this->urlGenerator->getAbsoluteURL('index.php/apps/theming/logo') . '?v=0';
-		$this->assertEquals($expected, $this->template->getLogo());
+		$this->assertEquals('/index.php/apps/theming/logo?v=0', $this->template->getLogo());
 	}
 
 	public function testGetScssVariablesCached() {

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -421,26 +421,17 @@ class ThemingDefaultsTest extends TestCase {
 	public function testGetBackgroundCustom() {
 		$folder = $this->createMock(ISimpleFolder::class);
 		$file = $this->createMock(ISimpleFile::class);
-		$folder->expects($this->once())->method('getFile')->willReturn($file);
+		$folder->expects($this->once())
+			->method('getFile')
+			->willReturn($file);
 		$this->appData->expects($this->once())
 			->method('getFolder')
 			->willReturn($folder);
 		$this->config
 			->expects($this->once())
 			->method('getAppValue')
-			->with('theming', 'backgroundMime')
+			->with('theming', 'backgroundMime', false)
 			->willReturn('image/svg+xml');
-		$simpleFolder = $this->createMock(ISimpleFolder::class);
-		$this->appData
-			->expects($this->once())
-			->method('getFolder')
-			->with('images')
-			->willReturn($simpleFolder);
-		$simpleFolder
-			->expects($this->once())
-			->method('getFile')
-			->with('background')
-			->willReturn('');
 		$expected = $this->urlGenerator->linkToRouteAbsolute('theming.Theming.getLoginBackground');
 		$this->assertEquals($expected, $this->template->getBackground());
 	}
@@ -471,31 +462,22 @@ class ThemingDefaultsTest extends TestCase {
 	public function testGetLogoCustom() {
 		$folder = $this->createMock(ISimpleFolder::class);
 		$file = $this->createMock(ISimpleFile::class);
-		$folder->expects($this->once())->method('getFile')->willReturn($file);
+		$folder->expects($this->once())
+			->method('getFile')
+			->willReturn($file);
 		$this->appData->expects($this->once())
 			->method('getFolder')
 			->willReturn($folder);
 		$this->config
 			->expects($this->at(0))
 			->method('getAppValue')
-			->with('theming', 'logoMime')
+			->with('theming', 'logoMime', false)
 			->willReturn('image/svg+xml');
 		$this->config
 			->expects($this->at(1))
 			->method('getAppValue')
 			->with('theming', 'cachebuster', '0')
 			->willReturn('0');
-		$simpleFolder = $this->createMock(ISimpleFolder::class);
-		$this->appData
-			->expects($this->once())
-			->method('getFolder')
-			->with('images')
-			->willReturn($simpleFolder);
-		$simpleFolder
-			->expects($this->once())
-			->method('getFile')
-			->with('logo')
-			->willReturn('');
 		$expected = $this->urlGenerator->getAbsoluteURL('index.php/apps/theming/logo') . '?v=0';
 		$this->assertEquals($expected, $this->template->getLogo());
 	}
@@ -508,10 +490,11 @@ class ThemingDefaultsTest extends TestCase {
 	public function testGetScssVariables() {
 		$this->config->expects($this->at(0))->method('getAppValue')->with('theming', 'cachebuster', '0')->willReturn('0');
 		$this->config->expects($this->at(1))->method('getAppValue')->with('theming', 'logoMime', false)->willReturn('jpeg');
-		$this->config->expects($this->at(2))->method('getAppValue')->with('theming', 'backgroundMime', false)->willReturn('jpeg');
-		$this->config->expects($this->at(3))->method('getAppValue')->with('theming', 'color', null)->willReturn('#000000');
-		$this->config->expects($this->at(4))->method('getAppValue')->with('theming', 'color', '#000')->willReturn('#000000');
+		$this->config->expects($this->at(2))->method('getAppValue')->with('theming', 'cachebuster', '0')->willReturn('0');
+		$this->config->expects($this->at(3))->method('getAppValue')->with('theming', 'backgroundMime', false)->willReturn('jpeg');
+		$this->config->expects($this->at(4))->method('getAppValue')->with('theming', 'color', null)->willReturn('#000000');
 		$this->config->expects($this->at(5))->method('getAppValue')->with('theming', 'color', '#000')->willReturn('#000000');
+		$this->config->expects($this->at(6))->method('getAppValue')->with('theming', 'color', '#000')->willReturn('#000000');
 
 		$this->util->expects($this->any())->method('invertTextColor')->with('#000000')->willReturn(false);
 		$this->cache->expects($this->once())->method('get')->with('getScssVariables')->willReturn(null);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -95,9 +95,12 @@ use OC\Security\TrustedDomainHelper;
 use OC\Session\CryptoWrapper;
 use OC\Share20\ShareHelper;
 use OC\Tagging\TagMapper;
+use OC\Template\SCSSCacher;
 use OCA\Theming\ThemingDefaults;
+
 use OCP\App\IAppManager;
 use OCP\Defaults;
+use OCA\Theming\Util;
 use OCP\Federation\ICloudIdManager;
 use OCP\Authentication\LoginCredentials\IStore;
 use OCP\ICacheFactory;
@@ -849,10 +852,24 @@ class Server extends ServerContainer implements IServerContainer {
 					$c->getURLGenerator(),
 					new \OC_Defaults(),
 					$c->getAppDataDir('theming'),
-					$c->getMemCacheFactory()
+					$c->getMemCacheFactory(),
+					new Util($c->getConfig(), $this->getRootFolder(), $this->getAppManager())
 				);
 			}
 			return new \OC_Defaults();
+		});
+		$this->registerService(SCSSCacher::class, function(Server $c) {
+			/** @var Factory $cacheFactory */
+			$cacheFactory = $c->query(Factory::class);
+			return new SCSSCacher(
+				$c->getLogger(),
+				$c->query(\OC\Files\AppData\Factory::class),
+				$c->getURLGenerator(),
+				$c->getConfig(),
+				$c->getThemingDefaults(),
+				\OC::$SERVERROOT,
+				$cacheFactory->createLocal('SCSS')
+			);
 		});
 		$this->registerService(EventDispatcher::class, function () {
 			return new EventDispatcher();

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -197,7 +197,9 @@ class TemplateLayout extends \OC_Template {
 			// allows chrome workspace mapping in debug mode
 			return "";
 		}
-
+		if ($this->config->getSystemValue('installed', false) && \OC::$server->getAppManager()->isInstalled('theming')) {
+			return '?v=' . self::$versionHash . '-' . $this->config->getAppValue('theming', 'cachebuster', '0');
+		}
 		return '?v=' . self::$versionHash;
 	}
 

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -58,6 +58,7 @@ class TemplateLayout extends \OC_Template {
 		// yes - should be injected ....
 		$this->config = \OC::$server->getConfig();
 
+
 		// Decide which page we show
 		if($renderAs == 'user') {
 			parent::__construct( 'core', 'layout.user' );
@@ -209,16 +210,7 @@ class TemplateLayout extends \OC_Template {
 		$theme = \OC_Util::getTheme();
 
 		if($compileScss) {
-			/** @var \OC\Memcache\Factory $cache */
-			$cache = \OC::$server->query('MemCacheFactory');
-			$SCSSCacher = new SCSSCacher(
-				\OC::$server->getLogger(),
-				\OC::$server->getAppDataDir('css'),
-				\OC::$server->getURLGenerator(),
-				\OC::$server->getConfig(),
-				\OC::$SERVERROOT,
-				$cache->createLocal('SCSS')
-			);
+			$SCSSCacher = \OC::$server->query(SCSSCacher::class);
 		} else {
 			$SCSSCacher = null;
 		}
@@ -228,7 +220,8 @@ class TemplateLayout extends \OC_Template {
 			$theme,
 			array( \OC::$SERVERROOT => \OC::$WEBROOT ),
 			array( \OC::$SERVERROOT => \OC::$WEBROOT ),
-			$SCSSCacher);
+			$SCSSCacher
+		);
 		$locator->find($styles);
 		return $locator->getResources();
 	}

--- a/lib/private/legacy/defaults.php
+++ b/lib/private/legacy/defaults.php
@@ -290,6 +290,16 @@ class OC_Defaults {
 		return $this->defaultColorPrimary;
 	}
 
+	/**
+	 * @return array scss variables to overwrite
+	 */
+	public function getScssVariables() {
+		if($this->themeExist('getScssVariables')) {
+			return $this->theme->getScssVariables();
+		}
+		return [];
+	}
+
 	public function shouldReplaceIcons() {
 		return false;
 	}

--- a/themes/example/defaults.php
+++ b/themes/example/defaults.php
@@ -151,4 +151,14 @@ class OC_Theme {
 		return '#745bca';
 	}
 
+	/**
+	 * Returns variables to overload defaults from core/css/variables.scss
+	 * @return array
+	 */
+	public function getScssVariables() {
+		return [
+			'color-primary' => '#745bca'
+		];
+	}
+
 }


### PR DESCRIPTION
Requires #3256

Custom themes as well as the theming app will get a lot simpler with #3256. We can just overwrite the existing SCSS variables and can drop most of the string concatenated CSS code inside of the ThemingController. 

There will be also much less maintenance work for the theming app in order to keep up with any CSS code changes.

@skjnldsv @nextcloud/theming @nextcloud/designers 

### Custom themes

With this you can apply a different color scheme to custom themes like this:

```
class OC_Theme {
	public function getScssVariables() {
		return [
			'color-primary' => '#000000',
			'color-primary-text' => '#ffffff',
                        'color-main-text' => '#ffffff',
                        'color-main-background' => '#333333'
		];
	}
}
```

### ToDo

- [x] Theming code cleanup
- [x] Fix tests
