### PR TITLE
IServerContainer is effectively an IContainer

### DIFF
--- a/lib/public/IServerContainer.php
+++ b/lib/public/IServerContainer.php
@@ -54,7 +54,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * This container holds all ownCloud services
  * @since 6.0.0
  */
-interface IServerContainer {
+interface IServerContainer extends IContainer {
 
 	/**
 	 * The contacts manager will act as a broker between consumers for contacts information and


### PR DESCRIPTION
I'm trying to get the server container injected by its interface in https://github.com/nextcloud/server/pull/3233/files#diff-10c7bf81f96fbeeca5d0e0ab1ce99aadR45. This does work, although the interface actually does not implement the `query` method. It, however, effectively implements that method. I only noticed this because PHPUnit complained the method wouldn't exists so I had a closer look at the current class hierarchy.

# Before
![bildschirmfoto von 2017-02-20 11-37-29](https://cloud.githubusercontent.com/assets/1374172/23121871/63fcd7bc-f762-11e6-9ae1-c7a1e1b436dc.png)

As you can see, the server implements the `IServerContainer` interface, but the direct connection to the `IContainer` interface (which has the `query` method) is missing.

# After
![bildschirmfoto von 2017-02-20 11-37-57](https://cloud.githubusercontent.com/assets/1374172/23121926/93c00410-f762-11e6-9921-99d2738f3a4b.png)

As far as I can tell does *should* not break anything, so we're backwards compatible.