### PR TITLE
allow using .well-known script to customize the resolving of cloud ids

### DIFF
--- a/apps/federatedfilesharing/tests/AddressHandlerTest.php
+++ b/apps/federatedfilesharing/tests/AddressHandlerTest.php
@@ -52,7 +52,7 @@ class AddressHandlerTest extends \Test\TestCase {
 		$this->il10n = $this->getMockBuilder('OCP\IL10N')
 			->getMock();
 
-		$this->cloudIdManager = new CloudIdManager();
+		$this->cloudIdManager = new CloudIdManager($this->createMock(IClientService::class), $this->createMock(ICache::class));
 
 		$this->addressHandler = new AddressHandler($this->urlGenerator, $this->il10n, $this->cloudIdManager);
 	}

--- a/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
@@ -98,7 +98,7 @@ class MountPublicLinkControllerTest extends \Test\TestCase {
 		$this->l10n = $this->getMockBuilder('OCP\IL10N')->disableOriginalConstructor()->getMock();
 		$this->userSession = $this->getMockBuilder('OCP\IUserSession')->disableOriginalConstructor()->getMock();
 		$this->clientService = $this->getMockBuilder('OCP\Http\Client\IClientService')->disableOriginalConstructor()->getMock();
-		$this->cloudIdManager = new CloudIdManager();
+		$this->cloudIdManager = new CloudIdManager($this->createMock(IClientService::class), $this->createMock(ICache::class));
 
 		$this->controller = new MountPublicLinkController(
 			'federatedfilesharing', $this->request,

--- a/apps/federatedfilesharing/tests/Controller/RequestHandlerControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/RequestHandlerControllerTest.php
@@ -106,7 +106,7 @@ class RequestHandlerControllerTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->userManager = $this->getMockBuilder('OCP\IUserManager')->getMock();
 
-		$this->cloudIdManager = new CloudIdManager();
+		$this->cloudIdManager = new CloudIdManager($this->createMock(IClientService::class), $this->createMock(ICache::class));
 		
 		$this->registerHttpHelper($httpHelperMock);
 

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -32,6 +32,8 @@ use OCA\FederatedFileSharing\Notifications;
 use OCA\FederatedFileSharing\TokenHandler;
 use OCP\Federation\ICloudIdManager;
 use OCP\Files\IRootFolder;
+use OCP\Http\Client\IClientService;
+use OCP\ICache;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
@@ -99,7 +101,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 
 		$this->userManager->expects($this->any())->method('userExists')->willReturn(true);
 
-		$this->cloudIdManager = new CloudIdManager();
+		$this->cloudIdManager = new CloudIdManager($this->createMock(IClientService::class), $this->createMock(ICache::class));
 
 		$this->provider = new FederatedShareProvider(
 			$this->connection,

--- a/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
@@ -32,6 +32,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\Federation\ICloudIdManager;
 use OCP\Http\Client\IClientService;
+use OCP\ICache;
 use OCP\Share;
 
 /**
@@ -98,7 +99,7 @@ class ShareesAPIControllerTest extends TestCase {
 
 		$this->clientService = $this->createMock(IClientService::class);
 
-		$this->cloudIdManager = new CloudIdManager();
+		$this->cloudIdManager = new CloudIdManager($this->createMock(IClientService::class), $this->createMock(ICache::class));
 
 		$this->sharees = new ShareesAPIController(
 			'files_sharing',

--- a/apps/files_sharing/tests/External/CacheTest.php
+++ b/apps/files_sharing/tests/External/CacheTest.php
@@ -27,6 +27,8 @@ namespace OCA\Files_Sharing\Tests\External;
 use OC\Federation\CloudIdManager;
 use OCA\Files_Sharing\Tests\TestCase;
 use OCP\Federation\ICloudIdManager;
+use OCP\Http\Client\IClientService;
+use OCP\ICache;
 
 /**
  * Class Cache
@@ -58,7 +60,7 @@ class CacheTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->cloudIdManager = new CloudIdManager();
+		$this->cloudIdManager = new CloudIdManager($this->createMock(IClientService::class), $this->createMock(ICache::class));
 		$this->remoteUser = $this->getUniqueID('remoteuser');
 
 		$this->storage = $this->getMockBuilder('\OCA\Files_Sharing\External\Storage')

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -32,6 +32,7 @@ use OCA\Files_Sharing\External\Manager;
 use OCA\Files_Sharing\External\MountProvider;
 use OCA\Files_Sharing\Tests\TestCase;
 use OCP\Http\Client\IClientService;
+use OCP\ICache;
 use Test\Traits\UserTrait;
 
 /**
@@ -85,7 +86,7 @@ class ManagerTest extends TestCase {
 		);
 		$this->testMountProvider = new MountProvider(\OC::$server->getDatabaseConnection(), function() {
 			return $this->manager;
-		}, new CloudIdManager());
+		}, new CloudIdManager($this->createMock(IClientService::class), $this->createMock(ICache::class)));
 	}
 
 	private function setupMounts() {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -217,8 +217,8 @@ class Server extends ServerContainer implements IServerContainer {
 
 			return $root;
 		});
-		$this->registerService('LazyRootFolder', function(Server $c) {
-			return new LazyRoot(function() use ($c) {
+		$this->registerService('LazyRootFolder', function (Server $c) {
+			return new LazyRoot(function () use ($c) {
 				return $c->query('RootFolder');
 			});
 		});
@@ -250,7 +250,7 @@ class Server extends ServerContainer implements IServerContainer {
 			});
 			return $groupManager;
 		});
-		$this->registerService(Store::class, function(Server $c) {
+		$this->registerService(Store::class, function (Server $c) {
 			$session = $c->getSession();
 			if (\OC::$server->getSystemConfig()->getValue('installed', false)) {
 				$tokenProvider = $c->query('OC\Authentication\Token\IProvider');
@@ -556,7 +556,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('MountConfigManager', function (Server $c) {
 			$loader = \OC\Files\Filesystem::getLoader();
 			$mountCache = $c->query('UserMountCache');
-			$manager =  new \OC\Files\Config\MountProviderCollection($loader, $mountCache);
+			$manager = new \OC\Files\Config\MountProviderCollection($loader, $mountCache);
 
 			// builtin providers
 
@@ -577,7 +577,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('TrustedDomainHelper', function ($c) {
 			return new TrustedDomainHelper($this->getConfig());
 		});
-		$this->registerService('Throttler', function(Server $c) {
+		$this->registerService('Throttler', function (Server $c) {
 			return new Throttler(
 				$c->getDatabaseConnection(),
 				new TimeFactory(),
@@ -588,7 +588,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('IntegrityCodeChecker', function (Server $c) {
 			// IConfig and IAppManager requires a working database. This code
 			// might however be called when ownCloud is not yet setup.
-			if(\OC::$server->getSystemConfig()->getValue('installed', false)) {
+			if (\OC::$server->getSystemConfig()->getValue('installed', false)) {
 				$config = $c->getConfig();
 				$appManager = $c->getAppManager();
 			} else {
@@ -597,13 +597,13 @@ class Server extends ServerContainer implements IServerContainer {
 			}
 
 			return new Checker(
-					new EnvironmentHelper(),
-					new FileAccessHelper(),
-					new AppLocator(),
-					$config,
-					$c->getMemCacheFactory(),
-					$appManager,
-					$c->getTempManager()
+				new EnvironmentHelper(),
+				new FileAccessHelper(),
+				new AppLocator(),
+				$config,
+				$c->getMemCacheFactory(),
+				$appManager,
+				$c->getTempManager()
 			);
 		});
 		$this->registerService('Request', function ($c) {
@@ -647,10 +647,10 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getThemingDefaults()
 			);
 		});
-		$this->registerService('LDAPProvider', function(Server $c) {
+		$this->registerService('LDAPProvider', function (Server $c) {
 			$config = $c->getConfig();
 			$factoryClass = $config->getSystemValue('ldapProviderFactory', null);
-			if(is_null($factoryClass)) {
+			if (is_null($factoryClass)) {
 				throw new \Exception('ldapProviderFactory not set');
 			}
 			/** @var \OCP\LDAP\ILDAPProviderFactory $factory */
@@ -699,14 +699,14 @@ class Server extends ServerContainer implements IServerContainer {
 			});
 			return $manager;
 		});
-		$this->registerService('CommentsManager', function(Server $c) {
+		$this->registerService('CommentsManager', function (Server $c) {
 			$config = $c->getConfig();
 			$factoryClass = $config->getSystemValue('comments.managerFactory', '\OC\Comments\ManagerFactory');
 			/** @var \OCP\Comments\ICommentsManagerFactory $factory */
 			$factory = new $factoryClass($this);
 			return $factory->getManager();
 		});
-		$this->registerService('ThemingDefaults', function(Server $c) {
+		$this->registerService('ThemingDefaults', function (Server $c) {
 			/*
 			 * Dark magic for autoloader.
 			 * If we do a class_exists it will try to load the class which will
@@ -774,13 +774,13 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('ContentSecurityPolicyManager', function (Server $c) {
 			return new ContentSecurityPolicyManager();
 		});
-		$this->registerService('ContentSecurityPolicyNonceManager', function(Server $c) {
+		$this->registerService('ContentSecurityPolicyNonceManager', function (Server $c) {
 			return new ContentSecurityPolicyNonceManager(
 				$c->getCsrfTokenManager(),
 				$c->getRequest()
 			);
 		});
-		$this->registerService('ShareManager', function(Server $c) {
+		$this->registerService('ShareManager', function (Server $c) {
 			$config = $c->getConfig();
 			$factoryClass = $config->getSystemValue('sharing.managerFactory', '\OC\Share20\ProviderFactory');
 			/** @var \OCP\Share\IProviderFactory $factory */
@@ -802,7 +802,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 			return $manager;
 		});
-		$this->registerService('SettingsManager', function(Server $c) {
+		$this->registerService('SettingsManager', function (Server $c) {
 			$manager = new \OC\Settings\Manager(
 				$c->getLogger(),
 				$c->getDatabaseConnection(),
@@ -828,7 +828,10 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 
 		$this->registerService(ICloudIdManager::class, function (Server $c) {
-			return new CloudIdManager();
+			return new CloudIdManager(
+				$c->getHTTPClientService(),
+				$c->getMemCacheFactory()->create('cloudid_manager')
+			);
 		});
 
 		/* To trick DI since we don't extend the DIContainer here */

--- a/tests/lib/Federation/CloudIdManagerTest.php
+++ b/tests/lib/Federation/CloudIdManagerTest.php
@@ -22,15 +22,25 @@
 namespace Test\Federation;
 
 use OC\Federation\CloudIdManager;
+use OCP\Http\Client\IClientService;
+use OCP\ICache;
 use Test\TestCase;
 
 class CloudIdManagerTest extends TestCase {
 	/** @var CloudIdManager */
 	private $cloudIdManager;
 
+	/** @var IClientService|\PHPUnit_Framework_MockObject_MockObject */
+	private $clientService;
+
+	/** @var ICache|\PHPUnit_Framework_MockObject_MockObject */
+	private $cache;
+
 	protected function setUp() {
 		parent::setUp();
-		$this->cloudIdManager = new CloudIdManager();
+		$this->clientService = $this->createMock(IClientService::class);
+		$this->cache = $this->createMock(ICache::class);
+		$this->cloudIdManager = new CloudIdManager($this->clientService, $this->cache);
 	}
 
 	public function cloudIdProvider() {


### PR DESCRIPTION
When making a federated share to `me@example.com`, Nc will make a request to `https://example.com/.well-known/cloud-id?id=me@example.com`.

If `example.com` replies with something in the form of

```json
{
    "found": true,
    "user": "someuser",
    "remote": "cloud.example.com"
}
```

Then the sharing Nc instance will use the returned user info when initiating the fed. share.
This allows the admin of example.com to setup cleaner federated cloud id's for it's user (such as re-using email addresses as cloud ids)

TODO

- [ ] Tests
- [ ] Allow customization of what cloud id is shown for a user in "Personal"