### PR TITLE
Fix misleading wording: searching is affected, not user access.

### DIFF
--- a/apps/user_ldap/templates/part.wizard-userfilter.php
+++ b/apps/user_ldap/templates/part.wizard-userfilter.php
@@ -1,7 +1,7 @@
 <fieldset id="ldapWizard2">
 	<div>
 		<p>
-			<?php p($l->t('%s access is limited to users meeting these criteria:', $theme->getName()));?>
+			<?php p($l->t('Listing and searching for users is constrained by these criteria:'));?>
 		</p>
 		<p>
 			<label for="ldap_userfilter_objectclass">


### PR DESCRIPTION
What the title says. Label fix, not a code one.

Since the wording is confusing and misleading, it is worth to backport this change. OKs, @karlitschek?