### PR TITLE
Fix thumbnail size of search results

### DIFF
--- a/core/search/css/results.css
+++ b/core/search/css/results.css
@@ -69,6 +69,7 @@
 }
 .has-favorites:not(.hidden) ~ #searchresults td.icon {
 	width: 86px;
+	background-size: 32px;
 }
 
 #searchresults tr.template {


### PR DESCRIPTION
* fixes #3466

before:

![bildschirmfoto 2017-02-20 um 12 48 28](https://cloud.githubusercontent.com/assets/245432/23138075/039e519e-f76b-11e6-8c1b-2bd3f2ebf245.png)

after:

![bildschirmfoto 2017-02-20 um 12 48 08](https://cloud.githubusercontent.com/assets/245432/23138076/075647d8-f76b-11e6-9474-92bd58f81040.png)


cc @nextcloud/designers 