### PR TITLE
Use clearer name setUpScenario

### DIFF
--- a/build/integration/features/bootstrap/Auth.php
+++ b/build/integration/features/bootstrap/Auth.php
@@ -31,7 +31,7 @@ trait Auth {
 	private $clientToken;
 
 	/** @BeforeScenario */
-	public function tearUpScenario() {
+	public function setUpScenario() {
 		$this->client = new Client();
 		$this->responseXml = '';
 	}

--- a/build/integration/features/bootstrap/CalDavContext.php
+++ b/build/integration/features/bootstrap/CalDavContext.php
@@ -50,7 +50,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	}
 
 	/** @BeforeScenario */
-	public function tearUpScenario() {
+	public function setUpScenario() {
 		$this->client = new Client();
 		$this->responseXml = '';
 	}

--- a/build/integration/features/bootstrap/CardDavContext.php
+++ b/build/integration/features/bootstrap/CardDavContext.php
@@ -50,7 +50,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	}
 
 	/** @BeforeScenario */
-	public function tearUpScenario() {
+	public function setUpScenario() {
 		$this->client = new Client();
 		$this->responseXml = '';
 	}

--- a/build/integration/features/bootstrap/ChecksumsContext.php
+++ b/build/integration/features/bootstrap/ChecksumsContext.php
@@ -48,7 +48,7 @@ class ChecksumsContext implements \Behat\Behat\Context\Context {
 	}
 
 	/** @BeforeScenario */
-	public function tearUpScenario() {
+	public function setUpScenario() {
 		$this->client = new Client();
 	}
 

--- a/build/integration/features/bootstrap/TagsContext.php
+++ b/build/integration/features/bootstrap/TagsContext.php
@@ -50,7 +50,7 @@ class TagsContext implements \Behat\Behat\Context\Context {
 	}
 
 	/** @BeforeScenario */
-	public function tearUpScenario() {
+	public function setUpScenario() {
 		$this->client = new Client();
 	}
 


### PR DESCRIPTION
Issue #3558 
The name tearUpScenario was confusing when I was looking at how some existing tests were set up. In English, "tear up" is what you do with a printed contract when you do not like it! It is a destructive thing.

Rename it to setUpScenario