### PR TITLE
some sharing settings

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -415,13 +415,13 @@ class ShareesAPIController extends OCSController {
 	public function search($search = '', $itemType = null, $page = 1, $perPage = 200, $shareType = null, $lookup = true) {
 
 		// only search for string larger than a given threshold
-		$threshold = intval($this->config->getSystemValue('sharing.minSearchStringLength', 0));
+		$threshold = (int)$this->config->getSystemValue('sharing.minSearchStringLength', 0);
 		if (strlen($search) < $threshold) {
 			return new DataResponse($this->result);
 		}
 
 		// never return more than the max. number of results configured in the config.php
-		$maxResults = intval($this->config->getSystemValue('sharing.maxAutocompleteResults', 0));
+		$maxResults = (int)$this->config->getSystemValue('sharing.maxAutocompleteResults', 0);
 		if ($maxResults > 0) {
 			$perPage = min($perPage, $maxResults);
 		}

--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -24,7 +24,7 @@
  */
 namespace OCA\Files_Sharing\Controller;
 
-use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCSController;
 use OCP\Contacts\IManager;
@@ -409,7 +409,7 @@ class ShareesAPIController extends OCSController {
 	 * @param int $perPage
 	 * @param int|int[] $shareType
 	 * @param bool $lookup
-	 * @return Http\DataResponse
+	 * @return DataResponse
 	 * @throws OCSBadRequestException
 	 */
 	public function search($search = '', $itemType = null, $page = 1, $perPage = 200, $shareType = null, $lookup = true) {
@@ -417,7 +417,7 @@ class ShareesAPIController extends OCSController {
 		// only search for string larger than a given threshold
 		$threshold = intval($this->config->getSystemValue('sharing.minSearchStringLength', 0));
 		if (strlen($search) < $threshold) {
-			return new Http\DataResponse($this->result);
+			return new DataResponse($this->result);
 		}
 
 		// never return more than the max. number of results configured in the config.php
@@ -493,7 +493,7 @@ class ShareesAPIController extends OCSController {
 	 * @param int $page
 	 * @param int $perPage
 	 * @param bool $lookup
-	 * @return Http\DataResponse
+	 * @return DataResponse
 	 * @throws OCSBadRequestException
 	 */
 	protected function searchSharees($search, $itemType, array $shareTypes, $page, $perPage, $lookup) {
@@ -545,7 +545,7 @@ class ShareesAPIController extends OCSController {
 			$this->result['exact']['emails'] = $mailResults['exact'];
 		}
 
-		$response = new Http\DataResponse($this->result);
+		$response = new DataResponse($this->result);
 
 		if (sizeof($this->reachedEndFor) < 3) {
 			$response->addHeader('Link', $this->getPaginationLink($page, [

--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -413,6 +413,18 @@ class ShareesAPIController extends OCSController {
 	 * @throws OCSBadRequestException
 	 */
 	public function search($search = '', $itemType = null, $page = 1, $perPage = 200, $shareType = null, $lookup = true) {
+
+		// only search for string larger than a given threshold
+		$threshold = $this->config->getSystemValue('sharing.minSearchStringLength', 0);
+		if (strlen($search) < $threshold) {
+			return new Http\DataResponse($this->result);
+		}
+
+		// never return more than the max. number of results configured in the config.php
+		$maxResults = $this->config->getSystemValue('sharing.maxAutocompleteResults', 0);
+		if ($maxResults > 0) {
+			$perPage = min($perPage, $maxResults);
+		}
 		if ($perPage <= 0) {
 			throw new OCSBadRequestException('Invalid perPage argument');
 		}

--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -415,13 +415,13 @@ class ShareesAPIController extends OCSController {
 	public function search($search = '', $itemType = null, $page = 1, $perPage = 200, $shareType = null, $lookup = true) {
 
 		// only search for string larger than a given threshold
-		$threshold = $this->config->getSystemValue('sharing.minSearchStringLength', 0);
+		$threshold = intval($this->config->getSystemValue('sharing.minSearchStringLength', 0));
 		if (strlen($search) < $threshold) {
 			return new Http\DataResponse($this->result);
 		}
 
 		// never return more than the max. number of results configured in the config.php
-		$maxResults = $this->config->getSystemValue('sharing.maxAutocompleteResults', 0);
+		$maxResults = intval($this->config->getSystemValue('sharing.maxAutocompleteResults', 0));
 		if ($maxResults > 0) {
 			$perPage = min($perPage, $maxResults);
 		}

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -188,7 +188,7 @@ $CONFIG = array(
 
 /**
  * Lifetime of the remember login cookie, which is set when the user clicks
- * the ``remember`` checkbox on the login screen. 
+ * the ``remember`` checkbox on the login screen.
  *
  * Defaults to ``60*60*24*15`` seconds (15 days)
  */
@@ -497,20 +497,20 @@ $CONFIG = array(
  *
  * Available values:
  *
- * * ``auto``      
- *     default setting. keeps files and folders in the trash bin for 30 days 
- *     and automatically deletes anytime after that if space is needed (note: 
+ * * ``auto``
+ *     default setting. keeps files and folders in the trash bin for 30 days
+ *     and automatically deletes anytime after that if space is needed (note:
  *     files may not be deleted if space is not needed).
- * * ``D, auto``   
- *     keeps files and folders in the trash bin for D+ days, delete anytime if 
+ * * ``D, auto``
+ *     keeps files and folders in the trash bin for D+ days, delete anytime if
  *     space needed (note: files may not be deleted if space is not needed)
- * * ``auto, D``   
- *     delete all files in the trash bin that are older than D days   
+ * * ``auto, D``
+ *     delete all files in the trash bin that are older than D days
  *     automatically, delete other files anytime if space needed
- * * ``D1, D2``    
- *     keep files and folders in the trash bin for at least D1 days and 
+ * * ``D1, D2``
+ *     keep files and folders in the trash bin for at least D1 days and
  *     delete when exceeds D2 days
- * * ``disabled``  
+ * * ``disabled``
  *     trash bin auto clean disabled, files and folders will be kept forever
  *
  * Defaults to ``auto``
@@ -539,19 +539,19 @@ $CONFIG = array(
  *
  * Available values:
  *
- * * ``auto``      
- *     default setting. Automatically expire versions according to expire 
+ * * ``auto``
+ *     default setting. Automatically expire versions according to expire
  *     rules. Please refer to :doc:`../configuration_files/file_versioning` for
  *     more information.
- * * ``D, auto``   
- *     keep versions at least for D days, apply expire rules to all versions 
+ * * ``D, auto``
+ *     keep versions at least for D days, apply expire rules to all versions
  *     that are older than D days
- * * ``auto, D``   
- *     delete all versions that are older than D days automatically, delete 
+ * * ``auto, D``
+ *     delete all versions that are older than D days automatically, delete
  *     other versions according to expire rules
- * * ``D1, D2``    
+ * * ``D1, D2``
  *     keep versions for at least D1 days and delete when exceeds D2 days
- * * ``disabled``  
+ * * ``disabled``
  *     versions auto clean disabled, versions will be kept forever
  *
  * Defaults to ``auto``
@@ -1185,6 +1185,17 @@ $CONFIG = array(
  */
 'sharing.managerFactory' => '\OC\Share20\ProviderFactory',
 
+/**
+ * Define max number of results returned by the user search for auto-completion
+ * Default is unlimited (value set to 0).
+ */
+'sharing.maxAutocompleteResults' => 0,
+
+/**
+ * Define the minimum length of the search string before we start auto-completion
+ * Default is no limit (value set to 0)
+ */
+'sharing.minSearchStringLength' => 0,
 
 
 /**

--- a/core/css/share.scss
+++ b/core/css/share.scss
@@ -78,6 +78,11 @@
 	}
 }
 
+.ui-autocomplete .autocomplete-note {
+	padding: 5px 10px;
+	color: rgba(0, 0, 0, .3);
+}
+
 #shareWithList {
 	list-style-type: none;
 	padding: 8px;

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -267,7 +267,10 @@
 
 							// show a notice that the list is truncated
 							// this is the case if one of the search results is at least as long as the max result config option
-							if(Math.min(perPage, oc_config['sharing.maxAutocompleteResults']) <= Math.max(users.length, groups.length, remotes.length, emails.length, lookup.length)) {
+							if(oc_config['sharing.maxAutocompleteResults'] > 0 &&
+								Math.min(perPage, oc_config['sharing.maxAutocompleteResults'])
+								<= Math.max(users.length, groups.length, remotes.length, emails.length, lookup.length)) {
+
 								var message = t('core', 'This list is maybe truncated - please refine your search term to see more results.');
 								$('.ui-autocomplete').append('<li class="autocomplete-note">' + message + '</li>');
 							}

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -138,7 +138,7 @@
 			var count = oc_config['sharing.minSearchStringLength'];
 			if (search.term.trim().length < count) {
 				var title = n('core',
-					'At least {count} character are needed for autocompletion',
+					'At least {count} character is needed for autocompletion',
 					'At least {count} characters are needed for autocompletion',
 					count,
 					{ count: count }

--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -206,7 +206,9 @@ class JSConfigHelper {
 				'versionstring'		=> \OC_Util::getVersionString(),
 				'enable_avatars'	=> true, // here for legacy reasons - to not crash existing code that relies on this value
 				'lost_password_link'=> $this->config->getSystemValue('lost_password_link', null),
-				'modRewriteWorking'	=> (\OC::$server->getConfig()->getSystemValue('htaccess.IgnoreFrontController', false) === true || getenv('front_controller_active') === 'true'),
+				'modRewriteWorking'	=> ($this->config->getSystemValue('htaccess.IgnoreFrontController', false) === true || getenv('front_controller_active') === 'true'),
+				'sharing.maxAutocompleteResults' => $this->config->getSystemValue('sharing.maxAutocompleteResults', 0),
+				'sharing.minSearchStringLength' => $this->config->getSystemValue('sharing.minSearchStringLength', 0),
 			]),
 			"oc_appconfig" => json_encode([
 				'core' => [

--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -207,8 +207,8 @@ class JSConfigHelper {
 				'enable_avatars'	=> true, // here for legacy reasons - to not crash existing code that relies on this value
 				'lost_password_link'=> $this->config->getSystemValue('lost_password_link', null),
 				'modRewriteWorking'	=> ($this->config->getSystemValue('htaccess.IgnoreFrontController', false) === true || getenv('front_controller_active') === 'true'),
-				'sharing.maxAutocompleteResults' => $this->config->getSystemValue('sharing.maxAutocompleteResults', 0),
-				'sharing.minSearchStringLength' => $this->config->getSystemValue('sharing.minSearchStringLength', 0),
+				'sharing.maxAutocompleteResults' => intval($this->config->getSystemValue('sharing.maxAutocompleteResults', 0)),
+				'sharing.minSearchStringLength' => intval($this->config->getSystemValue('sharing.minSearchStringLength', 0)),
 			]),
 			"oc_appconfig" => json_encode([
 				'core' => [


### PR DESCRIPTION
allow the administrator to define a min length of the search string before we start auto-completion and a max number of results per search query.
