### PR TITLE
fix bottom margin of shared pdfviewer links

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1297,6 +1297,7 @@ fieldset {
 /* hidden input type=file field */
 
 .hiddenuploadfield {
+	display: none;
 	width: 0;
 	height: 0;
 	opacity: 0;


### PR DESCRIPTION
Before & after:
![capture du 2017-02-21 19-56-10](https://cloud.githubusercontent.com/assets/925062/23180445/bc32b0fe-f871-11e6-8172-7b323b6c6f88.png)
Note the double scrollbar and white bottom margin there ^

![capture du 2017-02-21 19-56-49](https://cloud.githubusercontent.com/assets/925062/23180443/bc13a77c-f871-11e6-822c-3832b23ad420.png)


Please review @nextcloud/designers 