### PR TITLE
Fix position of share autocomplete loading icon

### DIFF
--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -9,8 +9,8 @@
 
 .shareTabView .shareWithLoading {
 	padding-left: 10px;
-	right: 30px;
-	top: 2px;
+	right: 35px;
+	top: 0px;
 }
 
 .shareTabView .shareWithRemoteInfo,


### PR DESCRIPTION
Before & after:

<img width="566" alt="bildschirmfoto 2017-02-21 um 17 04 49" src="https://cloud.githubusercontent.com/assets/245432/23189943/fd2498fa-f85a-11e6-9816-d2774695f4ec.png">

<img width="603" alt="bildschirmfoto 2017-02-21 um 17 03 13" src="https://cloud.githubusercontent.com/assets/245432/23190333/d7451a04-f85c-11e6-9f61-09c878044662.png">


cc @nextcloud/designers 
