### PR TITLE
detail wording: password reset instead of recovery

### DIFF
--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -99,7 +99,7 @@
 			<?php } ?>
 			<?php if($_['displayNameChangeSupported']) { ?>
 				<br />
-				<em><?php p($l->t('For password recovery and notifications')); ?></em>
+				<em><?php p($l->t('For password reset and notifications')); ?></em>
 			<?php } ?>
 			<span class="icon-checkmark hidden"/>
 			<input type="hidden" id="emailscope" value="<?php p($_['emailScope']) ?>">


### PR DESCRIPTION
Change »password recovery« to »password reset« because that’s the wording we use in the log in flow too.

»Recovery« is wrong cause you won’t be able to recover it anyway. Also, we use »admin recovery« for a different functionality.