### PR TITLE
expand clickable area of popover menu entries to full width

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -693,6 +693,7 @@ kbd {
 			}
 		}
 		.menuitem {
+			width: 100%;
 			-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=50)' !important;
 			filter: alpha(opacity = 50) !important;
 			opacity: .5 !important;


### PR DESCRIPTION
Before & after:
![capture du 2017-02-22 17-28-55](https://cloud.githubusercontent.com/assets/925062/23221225/cfe601ba-f924-11e6-8853-e77bde96933c.png)

Better for clickability, the area should always expand to the whitespace around too. Please review @nextcloud/designers 