### PR TITLE
Typecast shared mount's storage_id to int as documented + some refactor to avoid similar bugs

### DIFF
--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -253,7 +253,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 			$row = $result->fetch();
 			$result->closeCursor();
 			if ($row) {
-				return $row['storage'];
+				return (int)$row['storage'];
 			}
 			return -1;
 		}

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -163,6 +163,7 @@ class Cache implements ICache {
 		$data['encryptedVersion'] = (int)$data['encrypted'];
 		$data['encrypted'] = (bool)$data['encrypted'];
 		$data['storage_id'] = $data['storage'];
+		$data['storage'] = (int)$data['storage'];
 		$data['mimetype'] = $mimetypeLoader->getMimetypeById($data['mimetype']);
 		$data['mimepart'] = $mimetypeLoader->getMimetypeById($data['mimepart']);
 		if ($data['storage_mtime'] == 0) {
@@ -206,6 +207,7 @@ class Cache implements ICache {
 				$file['mtime'] = (int)$file['mtime'];
 				$file['storage_mtime'] = (int)$file['storage_mtime'];
 				$file['size'] = 0 + $file['size'];
+				$file['storage'] = (int)$file['storage'];
 			}
 			return array_map(function (array $data) {
 				return new CacheEntry($data);


### PR DESCRIPTION
Fixes #3461 

Basically both paths of apps/files_sharing/lib/SharedMount.php/getNumericStorageId() returned a string (oups), which caused (maybe among other things) an === comparison to fail in determining if the mounts should be updated in the database. In my ~30 users/desktop clients 11.0.1 instance with ~20 folders shared each, this caused a ~10s extra delay in every page load.

55a37c1 fixes the problem with casts were applicable, and cc511ac refactors "CacheEntry" object creation in Cache.php to use the already existing and wonderful cacheEntryFromData() function which does all casts properly to allow CacheEntry data to return results as documented, instead of semi-regularly casting some of that data. 

Feel free to merge any of these commits separately if needed. Also, this should be backported to at least stable11 (as it is affected by #3461) and maybe older versions (haven't tested the bug on them).

Finally, note that I'm not that familiar with (or setup for) web development so the master checkout I did (**before these changes**) had some test failures (when running autotest) - I didn't know if it was the master failing or some system php packages missing and these changes don't cause more failures, but it should nevertheless be retested before merging.