### PR TITLE
Use the correct principal for shared addressbooks

### DIFF
--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -180,7 +180,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 				$addressBooks[$row['id']] = [
 					'id'  => $row['id'],
 					'uri' => $uri,
-					'principaluri' => $principalUri,
+					'principaluri' => $principalUriOriginal,
 					'{DAV:}displayname' => $displayName,
 					'{' . Plugin::NS_CARDDAV . '}addressbook-description' => $row['description'],
 					'{http://calendarserver.org/ns/}getctag' => $row['synctoken'],


### PR DESCRIPTION
Steps are in the issue

Fix #3583 

Fix is confirmed by reporter.

@karlitschek should backport, so shared addressbooks also work on the old DAV endpoint.