### PR TITLE
added method needsPartFile() in Storage

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -505,9 +505,9 @@ class File extends Node implements IFile {
 	 */
 	private function needsPartFile($storage) {
 		// TODO: in the future use ChunkHandler provided by storage
-		// and/or add method on Storage called "needsPartFile()"
 		return !$storage->instanceOfStorage('OCA\Files_Sharing\External\Storage') &&
-		!$storage->instanceOfStorage('OC\Files\Storage\OwnCloud');
+			!$storage->instanceOfStorage('OC\Files\Storage\OwnCloud') &&
+			$storage->needsPartFile();
 	}
 
 	/**

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -711,4 +711,11 @@ abstract class Common implements Storage, ILockingStorage {
 	public function setAvailability($isAvailable) {
 		$this->getStorageCache()->setAvailability($isAvailable);
 	}
+
+	/**
+	 * @return bool
+	 */
+	public function needsPartFile() {
+		return true;
+	}
 }

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -610,4 +610,11 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage {
 			$this->getWrapperStorage()->changeLock($path, $type, $provider);
 		}
 	}
+
+	/**
+	 * @return bool
+	 */
+	public function needsPartFile() {
+		return $this->getWrapperStorage()->needsPartFile();
+	}
 }

--- a/lib/public/Files/Storage.php
+++ b/lib/public/Files/Storage.php
@@ -457,4 +457,6 @@ interface Storage extends IStorage {
 	 * @param bool $isAvailable
 	 */
 	public function setAvailability($isAvailable);
+
+	public function needsPartFile();
 }


### PR DESCRIPTION
Added the method needsPartFile in Storage, as expected in the TODO.

I need this method because I am creating a files_external storage that does not support part file.