### PR TITLE
OCS API endpoint to resend welcome message

### DIFF
--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -56,6 +56,7 @@ return [
 		['root' => '/cloud', 'name' => 'Users#getUserSubAdminGroups', 'url' => '/users/{userId}/subadmins', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Users#addSubAdmin', 'url' => '/users/{userId}/subadmins', 'verb' => 'POST'],
 		['root' => '/cloud', 'name' => 'Users#removeSubAdmin', 'url' => '/users/{userId}/subadmins', 'verb' => 'DELETE'],
+		['root' => '/cloud', 'name' => 'Users#resendWelcomeMessage', 'url' => '/users/{userId}/welcome', 'verb' => 'POST'],
 
 		// Config
 		['name' => 'AppConfig#getApps', 'url' => '/api/v1/config/apps', 'verb' => 'GET'],

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -344,6 +344,10 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return Util::getDefaultEmailAddress('no-reply');
 		});
 
+		$this->registerService('OC_Defaults', function ($c) {
+			return $c->getServer()->getThemingDefaults();
+		});
+
 		$this->registerService('OCP\Encryption\IManager', function ($c) {
 			return $this->getServer()->getEncryptionManager();
 		});

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -53,6 +53,7 @@ use OCP\Federation\ICloudIdManager;
 use OCP\Files\IAppData;
 use OCP\Files\Mount\IMountManager;
 use OCP\RichObjectStrings\IValidator;
+use OCP\Util;
 
 class DIContainer extends SimpleContainer implements IAppContainer {
 
@@ -337,6 +338,10 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 
 		$this->registerService('WebRoot', function ($c) {
 			return $c->query('ServerContainer')->getWebRoot();
+		});
+
+		$this->registerService('fromMailAddress', function() {
+			return Util::getDefaultEmailAddress('no-reply');
 		});
 
 		$this->registerService('OCP\Encryption\IManager', function ($c) {


### PR DESCRIPTION
* send a POST request to ocs/v1.php/cloud/users/USERNAME/resendWelcomeMessage to trigger
  the welcome message to be send
* fixes #3367

example curl statement:

```
curl -i https://example.org/ocs/v1.php/cloud/users/USERNAME/welcome -H  "OCS-APIRequest: true" -u admin:password -X POST
```

cc @nickvergessen @blizzz @schiessle 