### PR TITLE
Announce trusted server endpoints

### DIFF
--- a/apps/federation/appinfo/routes.php
+++ b/apps/federation/appinfo/routes.php
@@ -43,6 +43,7 @@ $application->registerRoutes(
 			],
 		],
 		'ocs' => [
+			// old endpoints, only used by Nextcloud and ownCloud
 			[
 				'name' => 'OCSAuthAPI#getSharedSecret',
 				'url' => '/api/v1/shared-secret',
@@ -51,6 +52,19 @@ $application->registerRoutes(
 			[
 				'name' => 'OCSAuthAPI#requestSharedSecret',
 				'url' => '/api/v1/request-shared-secret',
+				'verb' => 'POST',
+			],
+			// new endpoints, published as public api
+			[
+				'name' => 'OCSAuthAPI#getSharedSecret',
+				'root' => '/cloud',
+				'url' => '/shared-secret',
+				'verb' => 'GET',
+			],
+			[
+				'name' => 'OCSAuthAPI#requestSharedSecret',
+				'root' => '/cloud',
+				'url' => '/shared-secret',
 				'verb' => 'POST',
 			],
 		],

--- a/lib/private/OCS/Provider.php
+++ b/lib/private/OCS/Provider.php
@@ -70,6 +70,23 @@ class Provider extends \OCP\AppFramework\Controller {
 			];
 		}
 
+		if ($this->appManager->isEnabledForUser('federation')) {
+			if (isset($services['FEDERATED_SHARING'])) {
+				$services['FEDERATED_SHARING']['endpoints']['shared-secret'] = '/ocs/v2.php/cloud/shared-secret';
+				$services['FEDERATED_SHARING']['endpoints']['system-address-book'] = '/remote.php/dav/addressbooks/system/system/system';
+				$services['FEDERATED_SHARING']['endpoints']['carddav-user'] = 'system';
+			} else {
+				$services['FEDERATED_SHARING'] = [
+					'version' => 1,
+					'endpoints' => [
+						'shared-secret' => '/ocs/v2.php/cloud/shared-secret',
+						'system-address-book' => '/remote.php/dav/addressbooks/system/system/system',
+						'carddav-user' => 'system'
+					],
+				];
+			}
+		}
+
 		if($this->appManager->isEnabledForUser('activity')) {
 			$services['ACTIVITY'] = [
 				'version' => 1,

--- a/tests/lib/OCS/ProviderTest.php
+++ b/tests/lib/OCS/ProviderTest.php
@@ -48,10 +48,15 @@ class ProviderTest extends \Test\TestCase {
 		$this->appManager
 			->expects($this->at(1))
 			->method('isEnabledForUser')
-			->with('activity')
+			->with('federation')
 			->will($this->returnValue(false));
 		$this->appManager
 			->expects($this->at(2))
+			->method('isEnabledForUser')
+			->with('activity')
+			->will($this->returnValue(false));
+		$this->appManager
+			->expects($this->at(3))
 			->method('isEnabledForUser')
 			->with('provisioning_api')
 			->will($this->returnValue(false));
@@ -84,10 +89,15 @@ class ProviderTest extends \Test\TestCase {
 		$this->appManager
 			->expects($this->at(1))
 			->method('isEnabledForUser')
-			->with('activity')
+			->with('federation')
 			->will($this->returnValue(false));
 		$this->appManager
 			->expects($this->at(2))
+			->method('isEnabledForUser')
+			->with('activity')
+			->will($this->returnValue(false));
+		$this->appManager
+			->expects($this->at(3))
 			->method('isEnabledForUser')
 			->with('provisioning_api')
 			->will($this->returnValue(false));
@@ -124,6 +134,55 @@ class ProviderTest extends \Test\TestCase {
 		$this->assertEquals($expected, $this->ocsProvider->buildProviderList());
 	}
 
+	public function testBuildProviderListWithFederationEnabled() {
+		$this->appManager
+			->expects($this->at(0))
+			->method('isEnabledForUser')
+			->with('files_sharing')
+			->will($this->returnValue(false));
+		$this->appManager
+			->expects($this->at(1))
+			->method('isEnabledForUser')
+			->with('federation')
+			->will($this->returnValue(true));
+		$this->appManager
+			->expects($this->at(2))
+			->method('isEnabledForUser')
+			->with('activity')
+			->will($this->returnValue(false));
+		$this->appManager
+			->expects($this->at(3))
+			->method('isEnabledForUser')
+			->with('provisioning_api')
+			->will($this->returnValue(false));
+
+		$expected = new \OCP\AppFramework\Http\JSONResponse(
+			[
+				'version' => 2,
+				'services' => [
+					'PRIVATE_DATA' => [
+						'version' => 1,
+						'endpoints' => [
+							'store' => '/ocs/v2.php/privatedata/setattribute',
+							'read' => '/ocs/v2.php/privatedata/getattribute',
+							'delete' => '/ocs/v2.php/privatedata/deleteattribute',
+						],
+					],
+					'FEDERATED_SHARING' => [
+						'version' => 1,
+						'endpoints' => [
+							'shared-secret' => '/ocs/v2.php/cloud/shared-secret',
+							'system-address-book' => '/remote.php/dav/addressbooks/system/system/system',
+							'carddav-user' => 'system'
+						],
+					],
+				],
+			]
+		);
+
+		$this->assertEquals($expected, $this->ocsProvider->buildProviderList());
+	}
+
 	public function testBuildProviderListWithEverythingEnabled() {
 		$this->appManager
 			->expects($this->any())
@@ -147,6 +206,9 @@ class ProviderTest extends \Test\TestCase {
 						'endpoints' => [
 							'share' => '/ocs/v2.php/cloud/shares',
 							'webdav' => '/public.php/webdav/',
+							'shared-secret' => '/ocs/v2.php/cloud/shared-secret',
+							'system-address-book' => '/remote.php/dav/addressbooks/system/system/system',
+							'carddav-user' => 'system'
 						],
 					],
 					'SHARING' => [


### PR DESCRIPTION
Create new endpoints to exchange the shared secret between trusted servers (to make it more align with the other public endpoints we have regarding federation) and announce it as "ocs-provider"

A additional PR will follow where we make use of it. (https://github.com/nextcloud/server/pull/3614)

Note: We should backport it and announce the old routes on older versions.