### PR TITLE
don't setted status when file is lock

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FakeLockerPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FakeLockerPlugin.php
@@ -137,6 +137,7 @@ class FakeLockerPlugin extends ServerPlugin {
 		]);
 
 		$response->setBody($body);
+		$response->setStatus(200);
 
 		return false;
 	}


### PR DESCRIPTION
When you try save new file, using win10 native client, nextcloud server response 503 error "No subsystem set a valid HTTP status code. Something must have interrupted the request without providing further detail." because nobody set response status.