### PR TITLE
Replace deprecated $.tipsy(...) by $.tooltip(...)

### DIFF
--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -272,7 +272,7 @@
 						// set the path of this one as title for the ellipsis
 						this.$el.find('.crumb.ellipsized')
 							.attr('title', $crumb.attr('data-dir'))
-							.tipsy();
+							.tooltip();
 						this.$el.find('.ellipsis')
 							.wrap('<a class="ellipsislink" href="' + encodeURI(OC.generateUrl('apps/files/?dir=' + $crumb.attr('data-dir'))) + '"></a>');
 					}

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -895,7 +895,7 @@ OC.Uploader.prototype = _.extend({
 				start: function(e) {
 					self.log('start', e, null);
 					//hide the tooltip otherwise it covers the progress bar
-					$('#upload').tipsy('hide');
+					$('#upload').tooltip('hide');
 				},
 				fail: function(e, data) {
 					var upload = self.getUpload(data);
@@ -991,7 +991,7 @@ OC.Uploader.prototype = _.extend({
 							+ '</span><span class="mobile">'
 							+ t('files', '...')
 							+ '</span></em>');
-                    $('#uploadprogressbar').tipsy({gravity:'n', fade:true, live:true});
+					$('#uploadprogressbar').toopltip({placement: 'bottom'});
 					self._showProgressBar();
 					self.trigger('start', e, data);
 				});

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -991,7 +991,7 @@ OC.Uploader.prototype = _.extend({
 							+ '</span><span class="mobile">'
 							+ t('files', '...')
 							+ '</span></em>');
-					$('#uploadprogressbar').toopltip({placement: 'bottom'});
+					$('#uploadprogressbar').tooltip({placement: 'bottom'});
 					self._showProgressBar();
 					self.trigger('start', e, data);
 				});

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -302,7 +302,7 @@ OC.Share = _.extend(OC.Share || {}, {
 			}
 			action.html('<span> ' + message + '</span>').prepend(icon);
 			if (owner || recipients) {
-				action.find('.remoteAddress').tipsy({gravity: 's'});
+				action.find('.remoteAddress').tooltip({placement: 'top'});
 			}
 		}
 		else {

--- a/core/js/tests/specs/shareSpec.js
+++ b/core/js/tests/specs/shareSpec.js
@@ -23,10 +23,10 @@
 describe('OC.Share tests', function() {
 	describe('markFileAsShared', function() {
 		var $file;
-		var tipsyStub;
+		var tooltipStub;
 
 		beforeEach(function() {
-			tipsyStub = sinon.stub($.fn, 'tipsy');
+			tooltipStub = sinon.stub($.fn, 'tooltip');
 			$file = $('<tr><td class="filename"><div class="thumbnail"></div><span class="name">File name</span></td></tr>');
 			$file.find('.filename').append(
 				'<span class="fileactions">' +
@@ -38,7 +38,7 @@ describe('OC.Share tests', function() {
 		});
 		afterEach(function() {
 			$file = null;
-			tipsyStub.restore();
+			tooltipStub.restore();
 		});
 		describe('displaying the share owner', function() {
 			function checkOwner(input, output, title) {
@@ -54,8 +54,8 @@ describe('OC.Share tests', function() {
 				} else {
 					expect($action.find('.remoteAddress').attr('title')).not.toBeDefined();
 				}
-				expect(tipsyStub.calledOnce).toEqual(true);
-				tipsyStub.reset();
+				expect(tooltipStub.calledOnce).toEqual(true);
+				tooltipStub.reset();
 			}
 
 			it('displays the local share owner as is', function() {
@@ -172,8 +172,8 @@ describe('OC.Share tests', function() {
 				} else {
 						expect($action.find('.remoteAddress').attr('title')).not.toBeDefined();
 				}
-				expect(tipsyStub.calledOnce).toEqual(true);
-				tipsyStub.reset();
+				expect(tooltipStub.calledOnce).toEqual(true);
+				tooltipStub.reset();
 			}
 
 			it('displays the local share owner as is', function() {


### PR DESCRIPTION
Manually replacing what https://github.com/nextcloud/server/blob/019574014702657fa34acac4a631f78e27c20db8/core/js/js.js#L2220-L2271 does at runtime. I could not locate all the different tipsies/tooltips in the UI to verify it still works.

The breadcrumb tooltip does not show up even without those changes. Might be broken in general.

This removes all deprecation warnings from the karma test output 🚀 