### PR TITLE
DefaultTokenProviderTest mocked/asserted the wrong method

### DIFF
--- a/tests/lib/Authentication/Token/DefaultTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/DefaultTokenProviderTest.php
@@ -294,7 +294,7 @@ class DefaultTokenProviderTest extends TestCase {
 			->willReturn('MyTokenName');
 		$token
 			->expects($this->at(3))
-			->method('getRememberMe')
+			->method('getRemember')
 			->willReturn(IToken::DO_NOT_REMEMBER);
 		$this->config
 			->expects($this->exactly(2))
@@ -349,7 +349,7 @@ class DefaultTokenProviderTest extends TestCase {
 			->willReturn('MyTokenName');
 		$token
 			->expects($this->at(3))
-			->method('getRememberMe')
+			->method('getRemember')
 			->willReturn(IToken::REMEMBER);
 		$this->crypto
 			->expects($this->any(0))


### PR DESCRIPTION
It's 'getRemember' instead of 'getRememberMe', hence some warnings
were generated by phpunit.

Partially fixes
```
There were 3 warnings:
1) Test\Authentication\Token\DefaultTokenProviderTest::testRenewSessionTokenWithoutPassword
Trying to configure method "getRememberMe" which cannot be configured because it does not exist, has not been specified, is final, or is static
2) Test\Authentication\Token\DefaultTokenProviderTest::testRenewSessionTokenWithPassword
Trying to configure method "getRememberMe" which cannot be configured because it does not exist, has not been specified, is final, or is static
3) OCA\Provisioning_API\Tests\Controller\UsersControllerTest::testGetCurrentUserLoggedIn
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead
```

Seen in https://drone.nextcloud.com/nextcloud/server/5553/3