### PR TITLE
[stable10] Fix typo in advertisment footer

### DIFF
--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -186,7 +186,7 @@ if($_['passwordChangeSupported']) {
 			<?php print_unescaped($l->t('If you want to support the project
 		<a href="https://nextcloud.com/contribute"
 			target="_blank" rel="noreferrer">join development</a>
-		<or></or>
+		or
 		<a href="https://nextcloud.com/contribute"
 			target="_blank" rel="noreferrer">spread the word</a>!'));?>
 		</p>


### PR DESCRIPTION
Fix https://www.transifex.com/nextcloud/nextcloud/translate/#199/settings-1/95182166/

Affects 10 only, but keeps confusing translators, because they see strings of all versions in the UI