### PR TITLE
CalDAV sharing permissions should not depend on the order

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -278,6 +278,10 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->execute();
 
 		while($row = $result->fetch()) {
+			if (isset($calendars[$row['id']])) {
+				continue;
+			}
+
 			list(, $name) = URLUtil::splitPath($row['principaluri']);
 			$uri = $row['uri'] . '_shared_by_' . $name;
 			$row['displayname'] = $row['displayname'] . ' (' . $this->getUserDisplayName($name) . ')';
@@ -301,9 +305,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 				$calendar[$xmlName] = $row[$dbName];
 			}
 
-			if (!isset($calendars[$calendar['id']])) {
-				$calendars[$calendar['id']] = $calendar;
-			}
+			$calendars[$calendar['id']] = $calendar;
 		}
 		$result->closeCursor();
 

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -173,22 +173,25 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			->execute();
 
 		while($row = $result->fetch()) {
+			if (isset($addressBooks[$row['id']])) {
+				continue;
+			}
+
 			list(, $name) = URLUtil::splitPath($row['principaluri']);
 			$uri = $row['uri'] . '_shared_by_' . $name;
 			$displayName = $row['displayname'] . ' (' . $this->getUserDisplayName($name) . ')';
-			if (!isset($addressBooks[$row['id']])) {
-				$addressBooks[$row['id']] = [
-					'id'  => $row['id'],
-					'uri' => $uri,
-					'principaluri' => $principalUriOriginal,
-					'{DAV:}displayname' => $displayName,
-					'{' . Plugin::NS_CARDDAV . '}addressbook-description' => $row['description'],
-					'{http://calendarserver.org/ns/}getctag' => $row['synctoken'],
-					'{http://sabredav.org/ns}sync-token' => $row['synctoken']?$row['synctoken']:'0',
-					'{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}owner-principal' => $row['principaluri'],
-					'{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}read-only' => (int)$row['access'] === Backend::ACCESS_READ,
-				];
-			}
+
+			$addressBooks[$row['id']] = [
+				'id'  => $row['id'],
+				'uri' => $uri,
+				'principaluri' => $principalUriOriginal,
+				'{DAV:}displayname' => $displayName,
+				'{' . Plugin::NS_CARDDAV . '}addressbook-description' => $row['description'],
+				'{http://calendarserver.org/ns/}getctag' => $row['synctoken'],
+				'{http://sabredav.org/ns}sync-token' => $row['synctoken']?$row['synctoken']:'0',
+				'{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}owner-principal' => $row['principaluri'],
+				'{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}read-only' => (int)$row['access'] === Backend::ACCESS_READ,
+			];
 		}
 		$result->closeCursor();
 

--- a/apps/dav/tests/unit/CalDAV/AbstractCalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/AbstractCalDavBackendTest.php
@@ -55,6 +55,7 @@ abstract class AbstractCalDavBackendTest extends TestCase {
 	const UNIT_TEST_USER = 'principals/users/caldav-unit-test';
 	const UNIT_TEST_USER1 = 'principals/users/caldav-unit-test1';
 	const UNIT_TEST_GROUP = 'principals/groups/caldav-unit-test-group';
+	const UNIT_TEST_GROUP2 = 'principals/groups/caldav-unit-test-group2';
 
 	public function setUp() {
 		parent::setUp();
@@ -71,7 +72,7 @@ abstract class AbstractCalDavBackendTest extends TestCase {
 			]);
 		$this->principal->expects($this->any())->method('getGroupMembership')
 			->withAnyParameters()
-			->willReturn([self::UNIT_TEST_GROUP]);
+			->willReturn([self::UNIT_TEST_GROUP, self::UNIT_TEST_GROUP2]);
 
 		$db = \OC::$server->getDatabaseConnection();
 		$this->random = \OC::$server->getSecureRandom();

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -83,6 +83,26 @@ class CalDavBackendTest extends AbstractCalDavBackendTest {
 					'readOnly' => true
 				]
 			]],
+			[true, true, true, false, [
+				[
+					'href' => 'principal:' . self::UNIT_TEST_GROUP,
+					'readOnly' => true,
+				],
+				[
+					'href' => 'principal:' . self::UNIT_TEST_GROUP2,
+					'readOnly' => false,
+				],
+			]],
+			[true, true, true, true, [
+				[
+					'href' => 'principal:' . self::UNIT_TEST_GROUP,
+					'readOnly' => false,
+				],
+				[
+					'href' => 'principal:' . self::UNIT_TEST_GROUP2,
+					'readOnly' => true,
+				],
+			]],
 			[true, false, false, false, [
 				[
 					'href' => 'principal:' . self::UNIT_TEST_USER1,


### PR DESCRIPTION
### Steps
1. Create a calendar as admin
2. Create a user test1 that is part of group1 and group2
3. Share calendar with group1
4. Share calendar with group2
5. Tick the "can edit" box for group1

### Expected
test1 should be able to create events and see the calendar in the normal list.

### Actually
test1 sees the calendar in the subscription list and therefor can not add events.

### Workarounds
Swap step 4 and 5 makes it work. But you can then again break it, when you remove the "can edit" from all shares and add it to the first group again....

PS: CardDAV has no adjustable test for this...

I'd like to backport this (apart from the first commit)

Fix #3677