### PR TITLE
handle non existing owners when handling dav requests

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -317,12 +317,19 @@ class FilesPlugin extends ServerPlugin {
 
 			$propFind->handle(self::OWNER_ID_PROPERTYNAME, function() use ($node) {
 				$owner = $node->getOwner();
-				return $owner->getUID();
+				if (!$owner) {
+					return null;
+				} else {
+					return $owner->getUID();
+				}
 			});
 			$propFind->handle(self::OWNER_DISPLAY_NAME_PROPERTYNAME, function() use ($node) {
 				$owner = $node->getOwner();
-				$displayName = $owner->getDisplayName();
-				return $displayName;
+				if (!$owner) {
+					return null;
+				} else {
+					return $owner->getDisplayName();
+				}
 			});
 
 			$propFind->handle(self::HAS_PREVIEW_PROPERTYNAME, function () use ($node) {


### PR DESCRIPTION
Instead of a hard error we just return no owner