### PR TITLE
Get the user folder of the correct user for mention notifications

### DIFF
--- a/apps/comments/lib/Notification/Notifier.php
+++ b/apps/comments/lib/Notification/Notifier.php
@@ -23,7 +23,7 @@ namespace OCA\Comments\Notification;
 
 use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException;
-use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
@@ -35,8 +35,8 @@ class Notifier implements INotifier {
 	/** @var IFactory */
 	protected $l10nFactory;
 
-	/** @var Folder  */
-	protected $userFolder;
+	/** @var IRootFolder  */
+	protected $rootFolder;
 
 	/** @var ICommentsManager  */
 	protected $commentsManager;
@@ -49,13 +49,13 @@ class Notifier implements INotifier {
 
 	public function __construct(
 		IFactory $l10nFactory,
-		Folder $userFolder,
+		IRootFolder $rootFolder,
 		ICommentsManager $commentsManager,
 		IURLGenerator $url,
 		IUserManager $userManager
 	) {
 		$this->l10nFactory = $l10nFactory;
-		$this->userFolder = $userFolder;
+		$this->rootFolder = $rootFolder;
 		$this->commentsManager = $commentsManager;
 		$this->url = $url;
 		$this->userManager = $userManager;
@@ -93,7 +93,8 @@ class Notifier implements INotifier {
 				if($parameters[0] !== 'files') {
 					throw new \InvalidArgumentException('Unsupported comment object');
 				}
-				$nodes = $this->userFolder->getById($parameters[1]);
+				$userFolder = $this->rootFolder->getUserFolder($notification->getUser());
+				$nodes = $userFolder->getById($parameters[1]);
 				if(empty($nodes)) {
 					throw new \InvalidArgumentException('Cannot resolve file id to Node instance');
 				}

--- a/apps/comments/tests/Unit/AppInfo/ApplicationTest.php
+++ b/apps/comments/tests/Unit/AppInfo/ApplicationTest.php
@@ -22,6 +22,7 @@
 namespace OCA\Comments\Tests\Unit\AppInfo;
 
 use OCA\Comments\AppInfo\Application;
+use OCA\Comments\Notification\Notifier;
 use Test\TestCase;
 
 /**
@@ -56,7 +57,8 @@ class ApplicationTest extends TestCase {
 			'OCA\Comments\Activity\Listener',
 			'OCA\Comments\Activity\Provider',
 			'OCA\Comments\Activity\Setting',
-			'OCA\Comments\Notification\Listener'
+			'OCA\Comments\Notification\Listener',
+			Notifier::class,
 		];
 
 		foreach($services as $service) {


### PR DESCRIPTION
Noticed while implementing push notifications.
The path was the wrong one, since it uses the path of the commenter, not the mentioned person.