### PR TITLE
Deferred script loading v2

### DIFF
--- a/core/templates/layout.base.php
+++ b/core/templates/layout.base.php
@@ -18,15 +18,15 @@
 		<?php foreach($_['printcssfiles'] as $cssfile): ?>
 			<link rel="stylesheet" href="<?php print_unescaped($cssfile); ?>" media="print">
 		<?php endforeach; ?>
+		<?php foreach ($_['jsfiles'] as $jsfile): ?>
+			<script defer nonce="<?php p(\OC::$server->getContentSecurityPolicyNonceManager()->getNonce()) ?>" src="<?php print_unescaped($jsfile); ?>"></script>
+		<?php endforeach; ?>
+		<?php print_unescaped($_['headers']); ?>
 		<?php if (isset($_['inline_ocjs'])): ?>
-			<script nonce="<?php p(\OC::$server->getContentSecurityPolicyNonceManager()->getNonce()) ?>" type="text/javascript">
+			<script nonce="<?php p(\OC::$server->getContentSecurityPolicyNonceManager()->getNonce()) ?>">
 				<?php print_unescaped($_['inline_ocjs']); ?>
 			</script>
 		<?php endif; ?>
-		<?php foreach ($_['jsfiles'] as $jsfile): ?>
-			<script nonce="<?php p(\OC::$server->getContentSecurityPolicyNonceManager()->getNonce()) ?>" src="<?php print_unescaped($jsfile); ?>"></script>
-		<?php endforeach; ?>
-		<?php print_unescaped($_['headers']); ?>
 	</head>
 	<body id="body-public">
 		<?php include('layout.noscript.warning.php'); ?>

--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -19,15 +19,15 @@
 		<?php foreach($_['printcssfiles'] as $cssfile): ?>
 			<link rel="stylesheet" href="<?php print_unescaped($cssfile); ?>" media="print">
 		<?php endforeach; ?>
+		<?php foreach($_['jsfiles'] as $jsfile): ?>
+			<script defer nonce="<?php p(\OC::$server->getContentSecurityPolicyNonceManager()->getNonce()) ?>" src="<?php print_unescaped($jsfile); ?>"></script>
+		<?php endforeach; ?>
+		<?php print_unescaped($_['headers']); ?>
 		<?php if (isset($_['inline_ocjs'])): ?>
-			<script nonce="<?php p(\OC::$server->getContentSecurityPolicyNonceManager()->getNonce()) ?>" type="text/javascript">
+			<script nonce="<?php p(\OC::$server->getContentSecurityPolicyNonceManager()->getNonce()) ?>">
 				<?php print_unescaped($_['inline_ocjs']); ?>
 			</script>
 		<?php endif; ?>
-		<?php foreach($_['jsfiles'] as $jsfile): ?>
-			<script nonce="<?php p(\OC::$server->getContentSecurityPolicyNonceManager()->getNonce()) ?>" src="<?php print_unescaped($jsfile); ?>"></script>
-		<?php endforeach; ?>
-		<?php print_unescaped($_['headers']); ?>
 	</head>
 	<body id="<?php p($_['bodyid']);?>">
 		<?php include('layout.noscript.warning.php'); ?>

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -26,15 +26,15 @@
 		<?php foreach($_['printcssfiles'] as $cssfile): ?>
 			<link rel="stylesheet" href="<?php print_unescaped($cssfile); ?>" media="print">
 		<?php endforeach; ?>
+		<?php foreach($_['jsfiles'] as $jsfile): ?>
+			<script defer nonce="<?php p(\OC::$server->getContentSecurityPolicyNonceManager()->getNonce()) ?>" src="<?php print_unescaped($jsfile); ?>"></script>
+		<?php endforeach; ?>
+		<?php print_unescaped($_['headers']); ?>
 		<?php if (isset($_['inline_ocjs'])): ?>
-			<script nonce="<?php p(\OC::$server->getContentSecurityPolicyNonceManager()->getNonce()) ?>" type="text/javascript">
+			<script nonce="<?php p(\OC::$server->getContentSecurityPolicyNonceManager()->getNonce()) ?>">
 				<?php print_unescaped($_['inline_ocjs']); ?>
 			</script>
 		<?php endif; ?>
-		<?php foreach($_['jsfiles'] as $jsfile): ?>
-			<script nonce="<?php p(\OC::$server->getContentSecurityPolicyNonceManager()->getNonce()) ?>" src="<?php print_unescaped($jsfile); ?>"></script>
-		<?php endforeach; ?>
-		<?php print_unescaped($_['headers']); ?>
 	</head>
 	<body id="<?php p($_['bodyid']);?>">
 	<?php include('layout.noscript.warning.php'); ?>

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -223,6 +223,9 @@ class OC_Template extends \OC\Template\Base {
 			$headers = '';
 			foreach(OC_Util::$headers as $header) {
 				$headers .= '<'.\OCP\Util::sanitizeHTML($header['tag']);
+				if ( strcasecmp($header['tag'], 'script') === 0 && in_array('src', array_map('strtolower', array_keys($header['attributes']))) ) {
+					$headers .= ' defer';
+				}
 				foreach($header['attributes'] as $name=>$value) {
 					$headers .= ' '.\OCP\Util::sanitizeHTML($name).'="'.\OCP\Util::sanitizeHTML($value).'"';
 				}


### PR DESCRIPTION
Slightly improved version of  https://github.com/nextcloud/server/pull/3656

Problem before this PR:

`<script>` loading was performed asynchronously, loading 50-100 external js scripts an executing them sequentially was slow.

Example:
Full reload of "Files" app with almost all AddOns activated lasts 12.1 sec, loading 125 external .js.

Full discussion: #2272

Fix provided by this PR:

Script loading is done deferred with `<script defer>`.
That means:
* Script download starts as soon as the parser reaches the script tag
* Scripts will be downloaded simultaneously 
* Script execution is performed in order(!) after parsing is finished

Modifications:

Templates:
Placed loading of all external resources close together without any interruption by inline script or other code. The inline script code is placed last in the document - but will be executed first(!) because all other external script are deferred (see above).

Unnecessary `type=` has been removed from inline `<script>`

template.php:
`<script>` tags injected by AddOns take the 'defer' attributes here, but only when `src` attribute is present, otherwise `defer` is not allowed.

`<script defer>`:
https://www.w3schools.com/tags/att_script_defer.asp
https://developer.mozilla.org/de/docs/Web/HTML/Element/script
https://varvy.com/pagespeed/defer-loading-javascript.html
http://www.growingwiththeweb.com/2014/02/async-vs-defer-attributes.html
http://peter.sh/experiments/asynchronous-and-deferred-javascript-execution-explained/
https://www.html5rocks.com/en/tutorials/speed/script-loading/

New behavior:
Full (re)loading of NC webpages is now 3-10 times faster, depending on link latency and the underlying protocol (http1, http2) .
When using http2 (or http1 pipelining...) huge amounts of external resource should not be a problem any more.  

=> Full reload of "Files" app with almost all AddOns activated now lasts 2.3 sec, loading 125 external .js.

Possible drawback of this solution:
IE<=9 does not support `defer` properly, order of execution is NOT guaranteed. This may cause problems with script dependencies! 