### PR TITLE
Use a proper date format for transfer ownership

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -114,7 +114,7 @@ class TransferOwnership extends Command {
 			return 2;
 		}
 
-		$date = date('c');
+		$date = date('Y-m-d H-i-s');
 		$this->finalTarget = "$this->destinationUser/files/transferred from $this->sourceUser on $date";
 
 		// setup filesystem


### PR DESCRIPTION
* on Windows : is not allowed as filename and doesn't get synced then
* uses 2017-03-02 22-00-00 instead of 2017-03-02T22:00:00+00:00 as format
* backport of #3687 