### PR TITLE
Fix mimetype detection on public uploads for the workflow engine 

### DIFF
--- a/apps/workflowengine/lib/AppInfo/Application.php
+++ b/apps/workflowengine/lib/AppInfo/Application.php
@@ -48,6 +48,8 @@ class Application extends \OCP\AppFramework\App {
 				]);
 
 				script('core', [
+					'files/fileinfo',
+					'files/client',
 					'oc-backbone-webdav',
 					'systemtags/systemtags',
 					'systemtags/systemtagmodel',


### PR DESCRIPTION
### Steps
1. activate the file access control app
2. create a file mime type rule that matches text/plain
2. create a share via link of a folder with allow upload and editing
3. open the share via the provided link
4. upload a file with the .txt extension

Fix https://github.com/nextcloud/files_accesscontrol/issues/55

@karlitschek should backport to 11 and 10