### PR TITLE
Serve robots.txt if the RewriteBase is configured

### DIFF
--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -451,6 +451,7 @@ class Setup {
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/status.php";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/ocs/v1.php";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/ocs/v2.php";
+			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/robots.txt";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/updater/";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/ocs-provider/";
 			$content .= "\n  RewriteCond %{REQUEST_URI} !^/.well-known/acme-challenge/.*";


### PR DESCRIPTION
If htaccess.RewriteBase is enabled, requests to /robots.txt are redirected to index.php.
This PR adds an Rewrite Condition which serves the File correctly.