### PR TITLE
User mgmt settings design improvements

### DIFF
--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -1,12 +1,12 @@
 /**
  * @copyright Copyright (c) 2016, John Molakvoæ <skjnldsv@protonmail.com>
  * @copyright Copyright (c) 2016, Morris Jobke <hey@morrisjobke.de>
- * @copyright Copyright (c) 2016, Jan-Christoph Borchardt <hey@jancborchardt.net>
  * @copyright Copyright (c) 2016, Joas Schilling <coding@schilljs.com>
  * @copyright Copyright (c) 2016, Julius Haertl <jus@bitgrid.net>
  * @copyright Copyright (c) 2016, jowi <sjw@gmx.ch>
  * @copyright Copyright (c) 2015, Joas Schilling <nickvergessen@owncloud.com>
  * @copyright Copyright (c) 2015, Hendrik Leppelsack <hendrik@leppelsack.de>
+ * @copyright Copyright (c) 2014-2017, Jan-Christoph Borchardt <hey@jancborchardt.net>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -297,6 +297,21 @@ input {
 			}
 			&:indeterminate:disabled + label:after {
 				background-color: nc-lighten($color-main-text, 73%);
+			}
+		}
+	}
+}
+#app-settings-content {
+	input {
+		&[type='checkbox'],
+		&[type='radio'] {
+			&.radio,
+			&.checkbox {
+				+ label {
+					display: inline-block;
+					width: 100%;
+					padding: 5px 0;
+				}
 			}
 		}
 	}

--- a/settings/templates/users/main.php
+++ b/settings/templates/users/main.php
@@ -52,17 +52,24 @@ translation('settings');
 					</label>
 				</p>
 				<p>
-					<input type="checkbox" name="LastLogin" value="LastLogin" id="CheckboxLastLogin"
-						class="checkbox" <?php if ($_['show_last_login'] === 'true') print_unescaped('checked="checked"'); ?> />
-					<label for="CheckboxLastLogin">
-						<?php p($l->t('Show last log in')) ?>
-					</label>
-				</p>
-				<p>
 					<input type="checkbox" name="UserBackend" value="UserBackend" id="CheckboxUserBackend"
 						class="checkbox" <?php if ($_['show_backend'] === 'true') print_unescaped('checked="checked"'); ?> />
 					<label for="CheckboxUserBackend">
 						<?php p($l->t('Show user backend')) ?>
+					</label>
+				</p>
+				<p>
+					<input type="checkbox" name="LastLogin" value="LastLogin" id="CheckboxLastLogin"
+						class="checkbox" <?php if ($_['show_last_login'] === 'true') print_unescaped('checked="checked"'); ?> />
+					<label for="CheckboxLastLogin">
+						<?php p($l->t('Show last login')) ?>
+					</label>
+				</p>
+				<p>
+					<input type="checkbox" name="EmailAddress" value="EmailAddress" id="CheckboxEmailAddress"
+						class="checkbox" <?php if ($_['show_email'] === 'true') print_unescaped('checked="checked"'); ?> />
+					<label for="CheckboxEmailAddress">
+						<?php p($l->t('Show email address')) ?>
 					</label>
 				</p>
 				<p>
@@ -73,14 +80,7 @@ translation('settings');
 					</label>
 				</p>
 				<p class="info-text">
-					<?php p($l->t('When the password of the new user is left empty an activation email with a link to set the password is send to the user')) ?>
-				</p>
-				<p>
-					<input type="checkbox" name="EmailAddress" value="EmailAddress" id="CheckboxEmailAddress"
-						class="checkbox" <?php if ($_['show_email'] === 'true') print_unescaped('checked="checked"'); ?> />
-					<label for="CheckboxEmailAddress">
-						<?php p($l->t('Show email address')) ?>
-					</label>
+					<?php p($l->t('When the password of a new user is left empty, an activation email with a link to set the password is sent.')) ?>
 				</p>
 			</div>
 		</div>


### PR DESCRIPTION
Before & after:
![capture du 2017-03-01 22-45-17](https://cloud.githubusercontent.com/assets/925062/23635242/d4090fe0-02ce-11e7-8a98-db0478bd53b8.png)![capture du 2017-03-06 18-02-48](https://cloud.githubusercontent.com/assets/925062/23635241/d4079188-02ce-11e7-8215-18715ee5ba5a.png)

- sorting of options corresponds to the fields sorting
- email settings are next to each other with the info text being on the bottom
- more padding for better clickability (in the general CSS, also works in the Files app)

Please review @nextcloud/designers @gsambrotta 