### PR TITLE
Apply text input styling to 'tel' inputs too

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -148,6 +148,7 @@ select {
 	cursor: pointer;
 }
 input[type='text'],
+input[type='tel'],
 input[type='password'],
 input[type='email'] {
 	width: 249px;


### PR DESCRIPTION
The input styling for public pages (guest.css) did not cover inputs of type 'tel'. This is required for the TOTP app.

# Before
![bildschirmfoto von 2017-03-07 08-52-24](https://cloud.githubusercontent.com/assets/1374172/23646915/7040c2a6-0313-11e7-8384-698f9c699366.png)

# After
![bildschirmfoto von 2017-03-07 08-52-13](https://cloud.githubusercontent.com/assets/1374172/23646919/75fba44a-0313-11e7-80e6-6674ce9dadb9.png)