### PR TITLE
Extend Same Site cookie user_saml exemption rule

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -528,7 +528,7 @@ class OC {
 			//
 			// Questions about this code? Ask Lukas ;-)
 			$currentUrl = substr(explode('?',$request->getRequestUri(), 2)[0], strlen(\OC::$WEBROOT));
-			if($currentUrl === '/index.php/apps/user_saml/saml/acs') {
+			if($currentUrl === '/index.php/apps/user_saml/saml/acs' || $currentUrl === '/apps/user_saml/saml/acs') {
 				return;
 			}
 			// For the "index.php" endpoint only a lax cookie is required.


### PR DESCRIPTION
The current check does not trigger if $request->getRequestUri() does not return index.php as a prefix
(on my config this was occuring using nginx to serve Nextcloud)

Signed-off-by: Vincent Vanackere <vincent.vanackere@trustelem.com>