### PR TITLE
Factorize query for searching contacts

### DIFF
--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -872,9 +872,11 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 
 		$query2->selectDistinct('cp.cardid')->from($this->dbCardsPropertiesTable, 'cp');
 		$query2->andWhere($query2->expr()->eq('cp.addressbookid', $query->createNamedParameter($addressBookId)));
+		$or = $query2->expr()->orX();
 		foreach ($searchProperties as $property) {
-			$query2->expr()->orX($query2->expr()->eq('cp.name', $query->createNamedParameter($property)));
+			$or->add($query2->expr()->eq('cp.name', $query->createNamedParameter($property)));
 		}
+		$query2->andWhere($or);
 		$query2->andWhere($query2->expr()->ilike('cp.value', $query->createNamedParameter('%' . $this->db->escapeLikeParameter($pattern) . '%')));
 
 		$query->select('c.carddata', 'c.uri')->from($this->dbCardsTable, 'c')

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -869,16 +869,13 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	public function search($addressBookId, $pattern, $searchProperties) {
 		$query = $this->db->getQueryBuilder();
 		$query2 = $this->db->getQueryBuilder();
+
 		$query2->selectDistinct('cp.cardid')->from($this->dbCardsPropertiesTable, 'cp');
-		foreach ($searchProperties as $property) {
-			$query2->orWhere(
-				$query2->expr()->andX(
-					$query2->expr()->eq('cp.name', $query->createNamedParameter($property)),
-					$query2->expr()->ilike('cp.value', $query->createNamedParameter('%' . $this->db->escapeLikeParameter($pattern) . '%'))
-				)
-			);
-		}
 		$query2->andWhere($query2->expr()->eq('cp.addressbookid', $query->createNamedParameter($addressBookId)));
+		foreach ($searchProperties as $property) {
+			$query2->expr()->orX($query2->expr()->eq('cp.name', $query->createNamedParameter($property)));
+		}
+		$query2->andWhere($query2->expr()->ilike('cp.value', $query->createNamedParameter('%' . $this->db->escapeLikeParameter($pattern) . '%')));
 
 		$query->select('c.carddata', 'c.uri')->from($this->dbCardsTable, 'c')
 			->where($query->expr()->in('c.id', $query->createFunction($query2->getSQL())));


### PR DESCRIPTION
Detecting this as slow mysql queries.

It changes from
```
SELECT c.carddata, c.uri 
FROM oc_cards c 
WHERE c.id IN (
   SELECT DISTINCT cp.cardid 
   FROM oc_cardsproperties cp 
   WHERE (
      (
          (cp.name = 'EMAIL') AND (cp.value COLLATE UTF8 general_ci LIKE '%P%')
       ) OR (
          (cp.name = 'FN') AND (cp.value COLLATE UTF8_general_ci LIKE '%P%'))
       ) AND (cp.addressbookid = '2'
   )
);
```
to something like
```
SELECT c.carddata, c.uri
FROM oc_cards c
WHERE c.id IN (
    SELECT DISTINCT cp.cardid 
    FROM oc_cardsproperties cp 
    WHERE (
        (
            (cp.name = 'EMAIL') OR (cp.name = 'FN')
        ) AND (cp.value COLLATE UTF8_general_ci LIKE '%P%')
        ) AND (cp.addressbookid = '2')
    );
```