### PR TITLE
Test if a file is a valid jpg file

### DIFF
--- a/lib/private/legacy/image.php
+++ b/lib/private/legacy/image.php
@@ -562,7 +562,11 @@ class OC_Image implements \OCP\IImage {
 				break;
 			case IMAGETYPE_JPEG:
 				if (imagetypes() & IMG_JPG) {
-					$this->resource = imagecreatefromjpeg($imagePath);
+					if (getimagesize($imagePath) !== false) {
+						$this->resource = imagecreatefromjpeg($imagePath);
+					} else {
+						$this->logger->debug('OC_Image->loadFromFile, JPG image not valid: ' . $imagePath, array('app' => 'core'));
+					}
 				} else {
 					$this->logger->debug('OC_Image->loadFromFile, JPG images not supported: ' . $imagePath, array('app' => 'core'));
 				}


### PR DESCRIPTION
During preview generation if we provide an invalid JPG file the system
errors out with a PHP Fatal Error. Now we can't catch Fatal Errors (in
5.6). I suspect that exif_imagetype to fall back to the extention.

However a valid jpg file has a size. So we request the size of the image
and just drop out if that returns false.