### PR TITLE
Fix deleted objectstore shares

### DIFF
--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -642,7 +642,8 @@ class DefaultShareProvider implements IShareProvider {
 		// exclude shares leading to trashbin on home storages
 		$pathSections = explode('/', $data['path'], 2);
 		// FIXME: would not detect rare md5'd home storage case properly
-		if ($pathSections[0] !== 'files' && explode(':', $data['storage_string_id'], 2)[0] === 'home') {
+		if ($pathSections[0] !== 'files' 
+		    	&& in_array(explode(':', $data['storage_string_id'], 2)[0], array('home', 'object'))) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
While using the object store, the shares, that are moved to trashbin were still detected as accessible and cause broken shares to be shown in file/folder listing. This fixes #3779