### PR TITLE
Correct incorrectly typed X-OC-Mtime header

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -206,7 +206,12 @@ class File extends Node implements IFile {
 			// allow sync clients to send the mtime along in a header
 			$request = \OC::$server->getRequest();
 			if (isset($request->server['HTTP_X_OC_MTIME'])) {
-				if ($this->fileView->touch($this->path, $request->server['HTTP_X_OC_MTIME'])) {
+				$mtimeStr = $request->server['HTTP_X_OC_MTIME'];
+				if (!is_numeric($mtimeStr)) {
+					throw new \InvalidArgumentException('X-OC-Mtime header must be an integer (unix timestamp).');
+				}
+				$mtime = intval($mtimeStr);
+				if ($this->fileView->touch($this->path, $mtime)) {
 					header('X-OC-MTime: accepted');
 				}
 			}

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -222,7 +222,7 @@ OC.FileUpload.prototype = {
 
 		if (file.lastModified) {
 			// preserve timestamp
-			this.data.headers['X-OC-Mtime'] = file.lastModified / 1000;
+			this.data.headers['X-OC-Mtime'] = (file.lastModified / 1000).toFixed(0);
 		}
 
 		var userName = this.uploader.filesClient.getUserName();


### PR DESCRIPTION
This bug causes file uploads to show an error message when using the Postgres database and a storage backend that uses the filecache system.

The error message you get in the HTTP response is something like:

```
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
  <s:exception>Doctrine\DBAL\Exception\DriverException</s:exception>
  <s:message>An exception occurred while executing 'UPDATE "oc_filecache" SET "path_hash" = ?, "path" = ?, "parent" = ?, "name" = ?, "mimepart" = ?, "mimetype" = ?, "size" = ?, "mtime" = ?, "storage_mtime" = ?, "encrypted" = ?, "etag" = ?, "permissions" = ?, "checksum"=? WHERE ("path_hash" &lt;&gt; ? OR "path" &lt;&gt; ? OR "parent" &lt;&gt; ? OR "name" &lt;&gt; ? OR "mimepart" &lt;&gt; ? OR "mimetype" &lt;&gt; ? OR "size" &lt;&gt; ? OR "mtime" &lt;&gt; ? OR "storage_mtime" &lt;&gt; ? OR "encrypted" &lt;&gt; ? OR "etag" &lt;&gt; ? OR "permissions" &lt;&gt; ? OR "checksum" &lt;&gt; ? OR "path_hash" IS NULL OR "path" IS NULL OR "parent" IS NULL OR "name" IS NULL OR "mimepart" IS NULL OR "mimetype" IS NULL OR "size" IS NULL OR "mtime" IS NULL OR "storage_mtime" IS NULL OR "encrypted" IS NULL OR "etag" IS NULL OR "permissions" IS NULL OR "checksum" IS NULL) AND "fileid" = ? ' with params ["2b720af9543ff5bc9757e518c0de0d43", "files\/some-testfile.txt", 2, "some-testfile.txt", 10, 11, 4, "1489115007.243", 1489124931, 0, "58c23e439fb08", 27, null, "2b720af9543ff5bc9757e518c0de0d43", "files\/some-testfile.txt", 2, "some-testfile.txt", 10, 11, 4, "1489115007.243", 1489124931, 0, "58c23e439fb08", 27, null, 110]:

SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for integer: "1489115007.243"</s:message>
</d:error>
```

As can be seen, the value passed in for the mtime column is a string representation of a floating point number. In postgres this column is an integer, and so the update fails.