### PR TITLE
MP3 without cover don't get a preview

### DIFF
--- a/lib/private/Preview/MP3.php
+++ b/lib/private/Preview/MP3.php
@@ -61,24 +61,6 @@ class MP3 extends Provider {
 			}
 		}
 
-		return $this->getNoCoverThumbnail();
+		return false;
 	}
-
-	/**
-	 * Generates a default image when the file has no cover
-	 *
-	 * @return bool|\OCP\IImage false if the default image is missing or invalid
-	 */
-	private function getNoCoverThumbnail() {
-		$icon = \OC::$SERVERROOT . '/core/img/filetypes/audio.svg';
-
-		if(!file_exists($icon)) {
-			return false;
-		}
-
-		$image = new \OC_Image();
-		$image->loadFromFile($icon);
-		return $image->valid() ? $image : false;
-	}
-
 }


### PR DESCRIPTION
* Fixes #2739

It tries to create an image from an SVG file. Which we don't support. So
this fails and prints an log line. Then we fall back anyways to the 404
and fetch the default icon.

This basically makes sure we don't try to create an invalid image on the request.

To test just upload an MP3 without cover. 

Before: 
 * error in log

After:
 * No error in log