### PR TITLE
Check that set_time_limit is not disabled before calling it

### DIFF
--- a/apps/dav/appinfo/v1/webdav.php
+++ b/apps/dav/appinfo/v1/webdav.php
@@ -24,7 +24,9 @@
  */
 
 // no php execution timeout for webdav
-set_time_limit(0);
+if (strpos(@ini_get('disable_functions'), 'set_time_limit') === false) {
+	@set_time_limit(0);
+}
 ignore_user_abort(true);
 
 // Turn off output buffering to prevent memory problems

--- a/apps/dav/appinfo/v2/remote.php
+++ b/apps/dav/appinfo/v2/remote.php
@@ -20,7 +20,9 @@
  *
  */
 // no php execution timeout for webdav
-set_time_limit(0);
+if (strpos(@ini_get('disable_functions'), 'set_time_limit') === false) {
+	@set_time_limit(0);
+}
 ignore_user_abort(true);
 
 // Turn off output buffering to prevent memory problems

--- a/console.php
+++ b/console.php
@@ -48,7 +48,9 @@ try {
 	require_once __DIR__ . '/lib/base.php';
 
 	// set to run indefinitely if needed
-	set_time_limit(0);
+	if (strpos(@ini_get('disable_functions'), 'set_time_limit') === false) {
+		@set_time_limit(0);
+	}
 
 	if (!OC::$CLI) {
 		echo "This script can be run from the command line only" . PHP_EOL;

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -29,7 +29,10 @@
  */
 use Symfony\Component\EventDispatcher\GenericEvent;
 
-set_time_limit(0);
+if (strpos(@ini_get('disable_functions'), 'set_time_limit') === false) {
+	@set_time_limit(0);
+}
+
 require_once '../../lib/base.php';
 
 $l = \OC::$server->getL10N('core');

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -160,6 +160,14 @@
 							type: OC.SetupChecks.MESSAGE_TYPE_INFO
 						});
 					}
+					if(!data.isSettimelimitAvailable) {
+						messages.push({
+							msg: t(
+								'core',
+								'The PHP function "set_time_limit" is not available. This could result in scripts being halted mid-execution, breaking your installation. We strongly recommend enabling this function.'),
+							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+						});
+					}
 				} else {
 					messages.push({
 						msg: t('core', 'Error occurred while checking server setup'),

--- a/cron.php
+++ b/cron.php
@@ -84,7 +84,9 @@ try {
 
 	if (OC::$CLI) {
 		// set to run indefinitely if needed
-		set_time_limit(0);
+		if (strpos(@ini_get('disable_functions'), 'set_time_limit') === false) {
+			@set_time_limit(0);
+		}
 
 		// the cron job must be executed with the right user
 		if (!function_exists('posix_getuid')) {

--- a/lib/base.php
+++ b/lib/base.php
@@ -616,7 +616,9 @@ class OC {
 		//Let´s try to overwrite some defaults anyway
 
 		//try to set the maximum execution time to 60min
-		@set_time_limit(3600);
+		if (strpos(@ini_get('disable_functions'), 'set_time_limit') === false) {
+			@set_time_limit(3600);
+		}
 		@ini_set('max_execution_time', 3600);
 		@ini_set('max_input_time', 3600);
 

--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -147,7 +147,9 @@ class OC_Files {
 
 			$streamer->sendHeaders($name);
 			$executionTime = intval(OC::$server->getIniWrapper()->getNumeric('max_execution_time'));
-			set_time_limit(0);
+			if (strpos(@ini_get('disable_functions'), 'set_time_limit') === false) {
+				@set_time_limit(0);
+			}
 			ignore_user_abort(true);
 			if ($getType === self::ZIP_FILES) {
 				foreach ($files as $file) {

--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -286,6 +286,20 @@ class CheckSetupController extends Controller {
 	}
 
 	/**
+	 * Checks if set_time_limit is not disabled.
+	 *
+	 * @return bool
+	 */
+	private function isSettimelimitAvailable() {
+		if (function_exists('set_time_limit')
+			&& strpos(@ini_get('disable_functions'), 'set_time_limit') === false) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * @return RedirectResponse
 	 */
 	public function rescanFailedIntegrityCheck() {
@@ -411,6 +425,7 @@ Raw output
 				'codeIntegrityCheckerDocumentation' => $this->urlGenerator->linkToDocs('admin-code-integrity'),
 				'isOpcacheProperlySetup' => $this->isOpcacheProperlySetup(),
 				'phpOpcacheDocumentation' => $this->urlGenerator->linkToDocs('admin-php-opcache'),
+				'isSettimelimitAvailable' => $this->isSettimelimitAvailable(),
 			]
 		);
 	}

--- a/settings/Controller/EncryptionController.php
+++ b/settings/Controller/EncryptionController.php
@@ -105,7 +105,9 @@ class EncryptionController extends Controller {
 	 */
 	public function startMigration() {
         // allow as long execution on the web server as possible
-		set_time_limit(0);
+		if (strpos(@ini_get('disable_functions'), 'set_time_limit') === false) {
+			@set_time_limit(0);
+		}
 
 		try {
 


### PR DESCRIPTION
Fixes issue #3669. There exist shared hosting providers that disable set_time_limit. This prevents the log file from clogging.

There is another call to set_time_limit in /apps/files_external/3rdparty/Dropbox/API.php, but as that is marked as external third-party code and a different coding style seems to apply there, I wasn't sure whether I should also update this there.