### PR TITLE
[stable11] Call right function after sudo mode

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -414,7 +414,7 @@ var UserList = {
 
 	applyGroupSelect: function (element, user, checked) {
 		if (OC.PasswordConfirmation.requiresPasswordConfirmation()) {
-			OC.PasswordConfirmation.requirePasswordConfirmation(_.bind(this.applySubadminSelect, this, element, user, checked));
+			OC.PasswordConfirmation.requirePasswordConfirmation(_.bind(this.applyGroupSelect, this, element, user, checked));
 			return;
 		}
 


### PR DESCRIPTION
This should call the `applyGroupSelect` and not the `applySubadminSelect`.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>

Backport of https://github.com/nextcloud/server/pull/3819 to stable11