### PR TITLE
dont preserve mtime when uploading trough the web interface

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -220,11 +220,6 @@ OC.FileUpload.prototype = {
 			this.data.headers['If-None-Match'] = '*';
 		}
 
-		if (file.lastModified) {
-			// preserve timestamp
-			this.data.headers['X-OC-Mtime'] = (file.lastModified / 1000).toFixed(0);
-		}
-
 		var userName = this.uploader.filesClient.getUserName();
 		var password = this.uploader.filesClient.getPassword();
 		if (userName) {


### PR DESCRIPTION
While mtime preservation is expected behaviour when using the sync client I think preserving mtime while uploading trough the web interface is not expected.