### PR TITLE
fix searching and ordering on getlastmodified

### DIFF
--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -113,7 +113,7 @@ class FileSearchBackend implements ISearchBackend {
 			// queryable properties
 			new SearchPropertyDefinition('{DAV:}displayname', true, false, true),
 			new SearchPropertyDefinition('{DAV:}getcontenttype', true, true, true),
-			new SearchPropertyDefinition('{DAV:}getlastmodifed', true, true, true, SearchPropertyDefinition::DATATYPE_DATETIME),
+			new SearchPropertyDefinition('{DAV:}getlastmodified', true, true, true, SearchPropertyDefinition::DATATYPE_DATETIME),
 			new SearchPropertyDefinition(FilesPlugin::SIZE_PROPERTYNAME, true, true, true, SearchPropertyDefinition::DATATYPE_NONNEGATIVE_INTEGER),
 			new SearchPropertyDefinition(TagsPlugin::FAVORITE_PROPERTYNAME, true, true, true, SearchPropertyDefinition::DATATYPE_BOOLEAN),
 
@@ -236,7 +236,7 @@ class FileSearchBackend implements ISearchBackend {
 				return 'name';
 			case '{DAV:}getcontenttype':
 				return 'mimetype';
-			case '{DAV:}getlastmodifed':
+			case '{DAV:}getlastmodified':
 				return 'mtime';
 			case FilesPlugin::SIZE_PROPERTYNAME:
 				return 'size';
@@ -261,6 +261,8 @@ class FileSearchBackend implements ISearchBackend {
 					case SearchPropertyDefinition::DATATYPE_INTEGER:
 					case SearchPropertyDefinition::DATATYPE_NONNEGATIVE_INTEGER:
 						return 0 + $value;
+					case SearchPropertyDefinition::DATATYPE_DATETIME:
+						return \DateTime::createFromFormat(\DateTime::ATOM, $value)->getTimestamp();
 					default:
 						return $value;
 				}

--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -262,7 +262,11 @@ class FileSearchBackend implements ISearchBackend {
 					case SearchPropertyDefinition::DATATYPE_NONNEGATIVE_INTEGER:
 						return 0 + $value;
 					case SearchPropertyDefinition::DATATYPE_DATETIME:
-						return \DateTime::createFromFormat(\DateTime::ATOM, $value)->getTimestamp();
+						if (is_numeric($value)) {
+							return 0 + $value;
+						}
+						$date = \DateTime::createFromFormat(\DateTime::ATOM, $value);
+						return ($date instanceof  \DateTime) ? $date->getTimestamp() : 0;
 					default:
 						return $value;
 				}

--- a/apps/dav/tests/unit/Files/FileSearchBackendTest.php
+++ b/apps/dav/tests/unit/Files/FileSearchBackendTest.php
@@ -216,7 +216,7 @@ class FileSearchBackendTest extends TestCase {
 				new \OC\Files\Node\Folder($this->rootFolder, $this->view, '/test/path')
 			]));
 
-		$query = $this->getBasicQuery(Operator::OPERATION_GREATER_THAN, '{DAV:}getlastmodifed', 10);
+		$query = $this->getBasicQuery(Operator::OPERATION_GREATER_THAN, '{DAV:}getlastmodified', 10);
 		$result = $this->search->search($query);
 
 		$this->assertCount(1, $result);


### PR DESCRIPTION
Example query:

    curl -u test:test -X SEARCH https://localcloud.icewind.me/remote.php/dav -H 'Content-Type: text/xml' --data '<?xml version="1.0" encoding="UTF-8"?><d:searchrequest xmlns:d="DAV:" xmlns:oc="http://nextcloud.com/ns"><d:basicsearch><d:select><d:prop><d:getcontenttype/><d:resourcetype/><d:getcontentlength/><d:getlastmodified/><d:getetag/><oc:permissions xmlns:oc="http://owncloud.org/ns"/><oc:id xmlns:oc="http://owncloud.org/ns"/><oc:size xmlns:oc="http://owncloud.org/ns"/><oc:favorite xmlns:oc="http://owncloud.org/ns"/></d:prop></d:select><d:from><d:scope><d:href>/files/test</d:href><d:depth>infinity</d:depth></d:scope></d:from><d:where><d:gt><d:prop><d:getlastmodified/></d:prop><d:literal>2017-03-10T22:06:30Z</d:literal></d:gt></d:where><d:orderby><d:order><d:prop><d:getlastmodified/></d:prop><d:descending/></d:order></d:orderby></d:basicsearch></d:searchrequest>'