### PR TITLE
Do not clear CSRF token on logout (fix for #1303)

### DIFF
--- a/lib/private/Session/CryptoSessionData.php
+++ b/lib/private/Session/CryptoSessionData.php
@@ -129,7 +129,11 @@ class CryptoSessionData implements \ArrayAccess, ISession {
 	 * Reset and recreate the session
 	 */
 	public function clear() {
+		$requesttoken = $this->get('requesttoken');
 		$this->sessionValues = [];
+		if ($requesttoken !== null) {
+			$this->set('requesttoken', $requesttoken);
+		}
 		$this->isModified = true;
 		$this->session->clear();
 	}


### PR DESCRIPTION
This is a hacky way to allow the use case of #1303.

What happens is

1. User tries to login
2. PreLoginHook kicks in and figures out that the user need to change
their LDAP password or whatever => redirects user
3. While loading the redirect some logic of ours kicks in and logouts
the user (thus clearing the session).
4. We render the new page but now the session and the page disagree
about the CSRF token

This is kind of hacky but I don't think it introduces new attack
vectors.

TODO:
- [ ] Intergration tests

@GitHubUser4234 can you verify this fixes the issue?
@LukasReschke I hope it does not make your eyes bleed to much.... :see_no_evil: 