### PR TITLE
Delete files on encryption error

### DIFF
--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -29,7 +29,6 @@ namespace OCA\Encryption\Crypto;
 
 use OC\Encryption\Exceptions\DecryptionFailedException;
 use OC\Encryption\Exceptions\EncryptionFailedException;
-use OC\HintException;
 use OCA\Encryption\Exceptions\MultiKeyDecryptException;
 use OCA\Encryption\Exceptions\MultiKeyEncryptException;
 use OCP\Encryption\Exceptions\GenericEncryptionException;
@@ -476,12 +475,12 @@ class Crypt {
 	 * @param string $data
 	 * @param string $passPhrase
 	 * @param string $expectedSignature
-	 * @throws HintException
+	 * @throws GenericEncryptionException
 	 */
 	private function checkSignature($data, $passPhrase, $expectedSignature) {
 		$signature = $this->createSignature($data, $passPhrase);
 		if (!hash_equals($expectedSignature, $signature)) {
-			throw new HintException('Bad Signature', $this->l->t('Bad Signature'));
+			throw new GenericEncryptionException('Bad Signature', $this->l->t('Bad Signature'));
 		}
 	}
 
@@ -552,7 +551,7 @@ class Crypt {
 	 * @param string $catFile
 	 * @param string $cipher
 	 * @return bool
-	 * @throws HintException
+	 * @throws GenericEncryptionException
 	 */
 	private function hasSignature($catFile, $cipher) {
 		$meta = substr($catFile, -93);
@@ -560,7 +559,7 @@ class Crypt {
 
 		// enforce signature for the new 'CTR' ciphers
 		if ($signaturePosition === false && strpos(strtolower($cipher), 'ctr') !== false) {
-			throw new HintException('Missing Signature', $this->l->t('Missing Signature'));
+			throw new GenericEncryptionException('Missing Signature', $this->l->t('Missing Signature'));
 		}
 
 		return ($signaturePosition !== false);

--- a/apps/encryption/tests/Crypto/CryptTest.php
+++ b/apps/encryption/tests/Crypto/CryptTest.php
@@ -247,7 +247,7 @@ class CryptTest extends TestCase {
 
 	/**
 	 * @dataProvider dataTestHasSignatureFail
-	 * @expectedException \OC\HintException
+	 * @expectedException \OCP\Encryption\Exceptions\GenericEncryptionException
 	 */
 	public function testHasSignatureFail($cipher) {
 		$data = 'encryptedContent00iv001234567890123456xx';

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -31,6 +31,7 @@ namespace OCA\Files_Trashbin\Tests;
 
 use OC\Files\Storage\Temporary;
 use OC\Files\Filesystem;
+use OCP\ILogger;
 
 /**
  * Class Storage
@@ -528,9 +529,11 @@ class StorageTest extends \Test\TestCase {
 			->disableOriginalConstructor()->getMock();
 		$userManager->expects($this->any())
 			->method('userExists')->willReturn($userExists);
+		$logger = $this->getMockBuilder(ILogger::class)->getMock();
 		$storage = new \OCA\Files_Trashbin\Storage(
 			['mountPoint' => $mountPoint, 'storage' => $tmpStorage],
-			$userManager
+			$userManager,
+			$logger
 		);
 
 		$this->assertSame($expected,


### PR DESCRIPTION
Deleting files shouldn't fail on corrupted encrypted files. In this case we just delete them right away instead of moving them to the trash bin.

fix https://github.com/nextcloud/server/issues/3579