### PR TITLE
take share by mail into consideration if we calculate the access list

### DIFF
--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -269,10 +269,10 @@ class Share extends Constants {
 				$query = \OC_DB::prepare('
 					SELECT `share_with`
 					FROM `*PREFIX*share`
-					WHERE `item_source` = ? AND `share_type` = ? AND `item_type` IN (\'file\', \'folder\')', 1
+					WHERE `item_source` = ? AND `share_type` IN (?, ?) AND `item_type` IN (\'file\', \'folder\')', 1
 				);
 
-				$result = $query->execute(array($source, self::SHARE_TYPE_LINK));
+				$result = $query->execute(array($source, self::SHARE_TYPE_LINK, self::SHARE_TYPE_EMAIL));
 
 				if (\OCP\DB::isError($result)) {
 					\OCP\Util::writeLog('OCP\Share', \OC_DB::getErrorMessage(), \OCP\Util::ERROR);
@@ -2881,7 +2881,7 @@ class Share extends Constants {
 
 	/**
 	 * @param IConfig $config
-	 * @return bool 
+	 * @return bool
 	 */
 	public static function enforcePassword(IConfig $config) {
 		$enforcePassword = $config->getAppValue('core', 'shareapi_enforce_links_password', 'no');


### PR DESCRIPTION
take share by mail into consideration if we calculate the access list to allow people to access encrypted files shared by mail.

cc @rullzer we still use the old API here, am I right that we don't have a similar function for the new share API? I only found, which looks scary https://github.com/nextcloud/server/blob/master/lib/private/Share20/Manager.php#L1194 😉 

fix https://github.com/nextcloud/server/issues/3751
