### PR TITLE
Unshare event

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -775,6 +775,7 @@ return array(
     'OC\\Share20\\Exception\\InvalidShare' => $baseDir . '/lib/private/Share20/Exception/InvalidShare.php',
     'OC\\Share20\\Exception\\ProviderException' => $baseDir . '/lib/private/Share20/Exception/ProviderException.php',
     'OC\\Share20\\Hooks' => $baseDir . '/lib/private/Share20/Hooks.php',
+    'OC\\Share20\\LegacyHooks' => $baseDir . '/lib/private/Share20/LegacyHooks.php',
     'OC\\Share20\\Manager' => $baseDir . '/lib/private/Share20/Manager.php',
     'OC\\Share20\\ProviderFactory' => $baseDir . '/lib/private/Share20/ProviderFactory.php',
     'OC\\Share20\\Share' => $baseDir . '/lib/private/Share20/Share.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -805,6 +805,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Share20\\Exception\\InvalidShare' => __DIR__ . '/../../..' . '/lib/private/Share20/Exception/InvalidShare.php',
         'OC\\Share20\\Exception\\ProviderException' => __DIR__ . '/../../..' . '/lib/private/Share20/Exception/ProviderException.php',
         'OC\\Share20\\Hooks' => __DIR__ . '/../../..' . '/lib/private/Share20/Hooks.php',
+        'OC\\Share20\\LegacyHooks' => __DIR__ . '/../../..' . '/lib/private/Share20/LegacyHooks.php',
         'OC\\Share20\\Manager' => __DIR__ . '/../../..' . '/lib/private/Share20/Manager.php',
         'OC\\Share20\\ProviderFactory' => __DIR__ . '/../../..' . '/lib/private/Share20/ProviderFactory.php',
         'OC\\Share20\\Share' => __DIR__ . '/../../..' . '/lib/private/Share20/Share.php',

--- a/lib/private/Share20/LegacyHooks.php
+++ b/lib/private/Share20/LegacyHooks.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @copyright 2017, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OC\Share20;
+
+use OCP\Share\IShare;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class LegacyHooks {
+	/** @var EventDispatcher */
+	private $eventDispatcher;
+
+	/**
+	 * LegacyHooks constructor.
+	 *
+	 * @param EventDispatcher $eventDispatcher
+	 */
+	public function __construct(EventDispatcher $eventDispatcher) {
+		$this->eventDispatcher = $eventDispatcher;
+
+		$this->eventDispatcher->addListener('OCP\Share::preUnshare', [$this, 'preUnshare']);
+		$this->eventDispatcher->addListener('OCP\Share::postUnshare', [$this, 'postUnshare']);
+	}
+
+	/**
+	 * @param GenericEvent $e
+	 */
+	public function preUnshare(GenericEvent $e) {
+		/** @var IShare $share */
+		$share = $e->getSubject();
+
+		$formatted = $this->formatHookParams($share);
+		\OC_Hook::emit('OCP\Share', 'pre_unshare', $formatted);
+	}
+
+	/**
+	 * @param GenericEvent $e
+	 */
+	public function postUnshare(GenericEvent $e) {
+		/** @var IShare $share */
+		$share = $e->getSubject();
+
+		$formatted = $this->formatHookParams($share);
+
+		/** @var IShare[] $deletedShares */
+		$deletedShares = $e->getArgument('deletedShares');
+
+		$formattedDeletedShares = array_map(function($share) {
+			return $this->formatHookParams($share);
+		}, $deletedShares);
+
+		$formatted['deletedShares'] = $formattedDeletedShares;
+
+		\OC_Hook::emit('OCP\Share', 'pre_unshare', $formatted);
+	}
+
+	private function formatHookParams(IShare $share) {
+		// Prepare hook
+		$shareType = $share->getShareType();
+		$sharedWith = '';
+		if ($shareType === \OCP\Share::SHARE_TYPE_USER ||
+			$shareType === \OCP\Share::SHARE_TYPE_GROUP ||
+			$shareType === \OCP\Share::SHARE_TYPE_REMOTE) {
+			$sharedWith = $share->getSharedWith();
+		}
+
+		$hookParams = [
+			'id' => $share->getId(),
+			'itemType' => $share->getNodeType(),
+			'itemSource' => $share->getNodeId(),
+			'shareType' => $shareType,
+			'shareWith' => $sharedWith,
+			'itemparent' => method_exists($share, 'getParent') ? $share->getParent() : '',
+			'uidOwner' => $share->getSharedBy(),
+			'fileSource' => $share->getNodeId(),
+			'fileTarget' => $share->getTarget()
+		];
+		return $hookParams;
+	}
+}

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -803,6 +803,9 @@ class Manager implements IManager {
 			throw new \InvalidArgumentException('Share does not have a full id');
 		}
 
+		$event = new GenericEvent($share);
+		$this->eventDispatcher->dispatch('OCP\Share::preUnshare', $event);
+
 		$formatHookParams = function(\OCP\Share\IShare $share) {
 			// Prepare hook
 			$shareType = $share->getShareType();
@@ -852,6 +855,8 @@ class Manager implements IManager {
 		$hookParams['deletedShares'] = $formattedDeletedShares;
 
 		// Emit post hook
+		$event->setArgument('deletedShares', $deletedShares);
+		$this->eventDispatcher->dispatch('OCP\Share::postUnshare', $event);
 		\OC_Hook::emit('OCP\Share', 'post_unshare', $hookParams);
 	}
 

--- a/tests/lib/Share20/LegacyHooksTest.php
+++ b/tests/lib/Share20/LegacyHooksTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * @copyright 2017, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace Test\Share20;
+
+use OC\Share20\LegacyHooks;
+use OC\Share20\Manager;
+use OCP\Files\File;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Test\TestCase;
+
+class LegacyHooksTest extends TestCase {
+
+	/** @var LegacyHooks */
+	private $hooks;
+
+	/** @var EventDispatcher */
+	private $eventDispatcher;
+
+	/** @var Manager */
+	private $manager;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->eventDispatcher = new EventDispatcher();
+		$this->hooks = new LegacyHooks($this->eventDispatcher);
+		$this->manager = \OC::$server->getShareManager();
+	}
+
+	public function testPreUnshare() {
+		$path = $this->createMock(File::class);
+		$path->method('getId')->willReturn(1);
+
+		$share = $this->manager->newShare();
+		$share->setId(42)
+			->setProviderId('prov')
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith('awesomeUser')
+			->setSharedBy('sharedBy')
+			->setNode($path)
+			->setTarget('myTarget');
+
+		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['pre'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'pre_unshare', $hookListner, 'pre');
+
+		$hookListnerExpectsPre = [
+			'id' => 42,
+			'itemType' => 'file',
+			'itemSource' => 1,
+			'shareType' => \OCP\Share::SHARE_TYPE_USER,
+			'shareWith' => 'awesomeUser',
+			'itemparent' => null,
+			'uidOwner' => 'sharedBy',
+			'fileSource' => 1,
+			'fileTarget' => 'myTarget',
+		];
+
+		$hookListner
+			->expects($this->exactly(1))
+			->method('pre')
+			->with($hookListnerExpectsPre);
+
+		$event = new GenericEvent($share);
+		$this->eventDispatcher->dispatch('OCP\Share::preUnshare', $event);
+	}
+
+	public function testPostUnshare() {
+		$path = $this->createMock(File::class);
+		$path->method('getId')->willReturn(1);
+
+		$share = $this->manager->newShare();
+		$share->setId(42)
+			->setProviderId('prov')
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith('awesomeUser')
+			->setSharedBy('sharedBy')
+			->setNode($path)
+			->setTarget('myTarget');
+
+		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'pre_unshare', $hookListner, 'post');
+
+		$hookListnerExpectsPost = [
+			'id' => 42,
+			'itemType' => 'file',
+			'itemSource' => 1,
+			'shareType' => \OCP\Share::SHARE_TYPE_USER,
+			'shareWith' => 'awesomeUser',
+			'itemparent' => null,
+			'uidOwner' => 'sharedBy',
+			'fileSource' => 1,
+			'fileTarget' => 'myTarget',
+			'deletedShares' => [
+				[
+					'id' => 42,
+					'itemType' => 'file',
+					'itemSource' => 1,
+					'shareType' => \OCP\Share::SHARE_TYPE_USER,
+					'shareWith' => 'awesomeUser',
+					'itemparent' => null,
+					'uidOwner' => 'sharedBy',
+					'fileSource' => 1,
+					'fileTarget' => 'myTarget',
+				],
+			],
+		];
+
+		$hookListner
+			->expects($this->exactly(1))
+			->method('post')
+			->with($hookListnerExpectsPost);
+
+		$event = new GenericEvent($share);
+		$event->setArgument('deletedShares', [$share]);
+		$this->eventDispatcher->dispatch('OCP\Share::postUnshare', $event);
+	}
+}

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -196,56 +196,23 @@ class ManagerTest extends \Test\TestCase {
 			->method('delete')
 			->with($share);
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['pre', 'post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'pre_unshare', $hookListner, 'pre');
-		\OCP\Util::connectHook('OCP\Share', 'post_unshare', $hookListner, 'post');
-
-		$hookListnerExpectsPre = [
-			'id' => 42,
-			'itemType' => 'file',
-			'itemSource' => 1,
-			'shareType' => $shareType,
-			'shareWith' => $sharedWith,
-			'itemparent' => null,
-			'uidOwner' => 'sharedBy',
-			'fileSource' => 1,
-			'fileTarget' => 'myTarget',
-		];
-
-		$hookListnerExpectsPost = [
-			'id' => 42,
-			'itemType' => 'file',
-			'itemSource' => 1,
-			'shareType' => $shareType,
-			'shareWith' => $sharedWith,
-			'itemparent' => null,
-			'uidOwner' => 'sharedBy',
-			'fileSource' => 1,
-			'fileTarget' => 'myTarget',
-			'deletedShares' => [
-				[
-					'id' => 42,
-					'itemType' => 'file',
-					'itemSource' => 1,
-					'shareType' => $shareType,
-					'shareWith' => $sharedWith,
-					'itemparent' => null,
-					'uidOwner' => 'sharedBy',
-					'fileSource' => 1,
-					'fileTarget' => 'myTarget',
-				],
-			],
-		];
-
-
-		$hookListner
-			->expects($this->exactly(1))
-			->method('pre')
-			->with($hookListnerExpectsPre);
-		$hookListner
-			->expects($this->exactly(1))
-			->method('post')
-			->with($hookListnerExpectsPost);
+		$this->eventDispatcher->expects($this->at(0))
+			->method('dispatch')
+			->with(
+				'OCP\Share::preUnshare',
+				$this->callBack(function(GenericEvent $e) use ($share) {
+					return $e->getSubject() === $share;
+				})
+			);
+		$this->eventDispatcher->expects($this->at(1))
+			->method('dispatch')
+			->with(
+				'OCP\Share::postUnshare',
+				$this->callBack(function(GenericEvent $e) use ($share) {
+					return $e->getSubject() === $share &&
+						$e->getArgument('deletedShares') === [$share];
+				})
+			);
 
 		$manager->deleteShare($share);
 	}
@@ -275,56 +242,23 @@ class ManagerTest extends \Test\TestCase {
 			->method('delete')
 			->with($share);
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['pre', 'post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'pre_unshare', $hookListner, 'pre');
-		\OCP\Util::connectHook('OCP\Share', 'post_unshare', $hookListner, 'post');
-
-		$hookListnerExpectsPre = [
-			'id' => 42,
-			'itemType' => 'file',
-			'itemSource' => 1,
-			'shareType' => \OCP\Share::SHARE_TYPE_USER,
-			'shareWith' => 'sharedWith',
-			'itemparent' => null,
-			'uidOwner' => 'sharedBy',
-			'fileSource' => 1,
-			'fileTarget' => 'myTarget',
-		];
-
-		$hookListnerExpectsPost = [
-			'id' => 42,
-			'itemType' => 'file',
-			'itemSource' => 1,
-			'shareType' => \OCP\Share::SHARE_TYPE_USER,
-			'shareWith' => 'sharedWith',
-			'itemparent' => null,
-			'uidOwner' => 'sharedBy',
-			'fileSource' => 1,
-			'fileTarget' => 'myTarget',
-			'deletedShares' => [
-				[
-					'id' => 42,
-					'itemType' => 'file',
-					'itemSource' => 1,
-					'shareType' => \OCP\Share::SHARE_TYPE_USER,
-					'shareWith' => 'sharedWith',
-					'itemparent' => null,
-					'uidOwner' => 'sharedBy',
-					'fileSource' => 1,
-					'fileTarget' => 'myTarget',
-				],
-			],
-		];
-
-
-		$hookListner
-			->expects($this->exactly(1))
-			->method('pre')
-			->with($hookListnerExpectsPre);
-		$hookListner
-			->expects($this->exactly(1))
-			->method('post')
-			->with($hookListnerExpectsPost);
+		$this->eventDispatcher->expects($this->at(0))
+			->method('dispatch')
+			->with(
+				'OCP\Share::preUnshare',
+				$this->callBack(function(GenericEvent $e) use ($share) {
+					return $e->getSubject() === $share;
+				})
+			);
+		$this->eventDispatcher->expects($this->at(1))
+			->method('dispatch')
+			->with(
+				'OCP\Share::postUnshare',
+				$this->callBack(function(GenericEvent $e) use ($share) {
+					return $e->getSubject() === $share &&
+						$e->getArgument('deletedShares') === [$share];
+				})
+			);
 
 		$manager->deleteShare($share);
 	}
@@ -377,77 +311,23 @@ class ManagerTest extends \Test\TestCase {
 			->method('delete')
 			->withConsecutive($share3, $share2, $share1);
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['pre', 'post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'pre_unshare', $hookListner, 'pre');
-		\OCP\Util::connectHook('OCP\Share', 'post_unshare', $hookListner, 'post');
-
-		$hookListnerExpectsPre = [
-			'id' => 42,
-			'itemType' => 'file',
-			'itemSource' => 1,
-			'shareType' => \OCP\Share::SHARE_TYPE_USER,
-			'shareWith' => 'sharedWith1',
-			'itemparent' => null,
-			'uidOwner' => 'sharedBy1',
-			'fileSource' => 1,
-			'fileTarget' => 'myTarget1',
-		];
-
-		$hookListnerExpectsPost = [
-			'id' => 42,
-			'itemType' => 'file',
-			'itemSource' => 1,
-			'shareType' => \OCP\Share::SHARE_TYPE_USER,
-			'shareWith' => 'sharedWith1',
-			'itemparent' => null,
-			'uidOwner' => 'sharedBy1',
-			'fileSource' => 1,
-			'fileTarget' => 'myTarget1',
-			'deletedShares' => [
-				[
-					'id' => 44,
-					'itemType' => 'file',
-					'itemSource' => 1,
-					'shareType' => \OCP\Share::SHARE_TYPE_LINK,
-					'shareWith' => '',
-					'itemparent' => 43,
-					'uidOwner' => 'sharedBy3',
-					'fileSource' => 1,
-					'fileTarget' => 'myTarget3',
-				],
-				[
-					'id' => 43,
-					'itemType' => 'file',
-					'itemSource' => 1,
-					'shareType' => \OCP\Share::SHARE_TYPE_GROUP,
-					'shareWith' => 'sharedWith2',
-					'itemparent' => 42,
-					'uidOwner' => 'sharedBy2',
-					'fileSource' => 1,
-					'fileTarget' => 'myTarget2',
-				],
-				[
-					'id' => 42,
-					'itemType' => 'file',
-					'itemSource' => 1,
-					'shareType' => \OCP\Share::SHARE_TYPE_USER,
-					'shareWith' => 'sharedWith1',
-					'itemparent' => null,
-					'uidOwner' => 'sharedBy1',
-					'fileSource' => 1,
-					'fileTarget' => 'myTarget1',
-				],
-			],
-		];
-
-		$hookListner
-			->expects($this->exactly(1))
-			->method('pre')
-			->with($hookListnerExpectsPre);
-		$hookListner
-			->expects($this->exactly(1))
-			->method('post')
-			->with($hookListnerExpectsPost);
+		$this->eventDispatcher->expects($this->at(0))
+			->method('dispatch')
+			->with(
+				'OCP\Share::preUnshare',
+				$this->callBack(function(GenericEvent $e) use ($share1) {
+					return $e->getSubject() === $share1;
+				})
+			);
+		$this->eventDispatcher->expects($this->at(1))
+			->method('dispatch')
+			->with(
+				'OCP\Share::postUnshare',
+				$this->callBack(function(GenericEvent $e) use ($share1, $share2, $share3) {
+					return $e->getSubject() === $share1 &&
+						$e->getArgument('deletedShares') === [$share3, $share2, $share1];
+				})
+			);
 
 		$manager->deleteShare($share1);
 	}


### PR DESCRIPTION
Fix for #3348

We now emit an event containing the share before for the pre and post delete events. This makes sure recipients have all the info we do.

A new helper class is added to still emit the original \OC_Hooks