### PR TITLE
Remove single quotes around search query like in user search

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2553,7 +2553,7 @@
 				$('#searchresults').addClass('filter-empty');
 				$('#searchresults .emptycontent').addClass('emptycontent-search');
 				if ( $('#searchresults').length === 0 || $('#searchresults').hasClass('hidden') ) {
-					var error = t('files', "No search results in other folders for '{tag}{filter}{endtag}'", {filter:this._filter}, null, {'escape': false});
+					var error = t('files', 'No search results in other folders for {tag}{filter}{endtag}', {filter:this._filter});
 					this.$el.find('.nofilterresults').removeClass('hidden').
 						find('p').html(error.replace('{tag}', '<strong>').replace('{endtag}', '</strong>'));
 				}

--- a/core/search/js/search.js
+++ b/core/search/js/search.js
@@ -216,9 +216,9 @@
 				if (count === 0) {
 					$status.addClass('emptycontent').removeClass('status');
 					$status.html('');
-					$status.append('<div class="icon-search"></div>');
-					var error = t('core', "No search results in other folders for '{tag}{filter}{endtag}'", {filter:lastQuery});
-					$status.append('<h2>' + error.replace('{tag}', '<strong>').replace('{endtag}', '</strong>') + '</h2>');
+					$status.append($('<div>').addClass('icon-search'));
+					var error = t('core', 'No search results in other folders for {tag}{filter}{endtag}', {filter:lastQuery});
+					$status.append($('<h2>').html(error.replace('{tag}', '<strong>').replace('{endtag}', '</strong>')));
 				} else {
 					$status.removeClass('emptycontent').addClass('status');
 					$status.text(n('core', '{count} search result in another folder', '{count} search results in other folders', count, {count:count}));


### PR DESCRIPTION
Bringing the search message in line with the newly changed user no-result message from #3671