### PR TITLE
Don't set the HTTP status twice

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FakeLockerPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FakeLockerPlugin.php
@@ -138,7 +138,6 @@ class FakeLockerPlugin extends ServerPlugin {
 
 		$response->setStatus(200);
 		$response->setBody($body);
-		$response->setStatus(200);
 
 		return false;
 	}


### PR DESCRIPTION
Race condition between
https://github.com/nextcloud/server/pull/3621 &&
https://github.com/nextcloud/server/pull/3757
