### PR TITLE
Use preDelete hook to delete encryption keys 

### DIFF
--- a/apps/encryption/lib/Hooks/UserHooks.php
+++ b/apps/encryption/lib/Hooks/UserHooks.php
@@ -155,9 +155,9 @@ class UserHooks implements IHook {
 				'postCreateUser');
 
 			OCUtil::connectHook('OC_User',
-				'post_deleteUser',
+				'pre_deleteUser',
 				$this,
-				'postDeleteUser');
+				'preDeleteUser');
 		}
 	}
 
@@ -212,7 +212,7 @@ class UserHooks implements IHook {
 	 * @param array $params : uid, password
 	 * @note This method should never be called for users using client side encryption
 	 */
-	public function postDeleteUser($params) {
+	public function preDeleteUser($params) {
 
 		if (App::isEnabled('encryption')) {
 			$this->keyManager->deletePublicKey($params['uid']);

--- a/apps/encryption/tests/Hooks/UserHooksTest.php
+++ b/apps/encryption/tests/Hooks/UserHooksTest.php
@@ -111,12 +111,12 @@ class UserHooksTest extends TestCase {
 		$this->assertTrue(true);
 	}
 
-	public function testPostDeleteUser() {
+	public function testPreDeleteUser() {
 		$this->keyManagerMock->expects($this->once())
 			->method('deletePublicKey')
 			->with('testUser');
 
-		$this->instance->postDeleteUser($this->params);
+		$this->instance->preDeleteUser($this->params);
 		$this->assertTrue(true);
 	}
 


### PR DESCRIPTION
Because we sometimes need to mount the user's home before deleting
encryption keys, this must happen in a preDelete hook because the
postDelete is too late. In postDelete the user's home already doesn't
exist any more and cannot be mounted.

* downstream of https://github.com/owncloud/core/pull/26938