### PR TITLE
Skip FailedStorage in background scan

### DIFF
--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -123,6 +123,12 @@ class Scanner extends PublicEmitter {
 			if (is_null($storage)) {
 				continue;
 			}
+
+			// don't bother scanning failed storages (shortcut for same result)
+			if ($storage->instanceOfStorage('OC\Files\Storage\FailedStorage')) {
+				continue;
+			}
+
 			// don't scan the root storage
 			if ($storage->instanceOfStorage('\OC\Files\Storage\Local') && $mount->getMountPoint() === '/') {
 				continue;
@@ -166,6 +172,12 @@ class Scanner extends PublicEmitter {
 			if (is_null($storage)) {
 				continue;
 			}
+
+			// don't bother scanning failed storages (shortcut for same result)
+			if ($storage->instanceOfStorage('OC\Files\Storage\FailedStorage')) {
+				continue;
+			}
+
 			// if the home storage isn't writable then the scanner is run as the wrong user
 			if ($storage->instanceOfStorage('\OC\Files\Storage\Home') and
 				(!$storage->isCreatable('') or !$storage->isCreatable('files'))


### PR DESCRIPTION
The background job that scans storages must skip failed storages to
avoid potential exceptions, especially when the failed storage comes
from a shared storage where the source is not accessible.

* downstream of https://github.com/owncloud/core/pull/26529/commits