### PR TITLE
Chunking NG: Assemble in natural sort order of files

### DIFF
--- a/apps/dav/lib/Upload/AssemblyStream.php
+++ b/apps/dav/lib/Upload/AssemblyStream.php
@@ -67,7 +67,7 @@ class AssemblyStream implements \Icewind\Streams\File {
 		$nodes = $this->nodes;
 		// http://stackoverflow.com/a/10985500
 		@usort($nodes, function(IFile $a, IFile $b) {
-			return strcmp($a->getName(), $b->getName());
+			return strnatcmp($a->getName(), $b->getName());
 		});
 		$this->nodes = $nodes;
 

--- a/apps/dav/tests/unit/Upload/AssemblyStreamTest.php
+++ b/apps/dav/tests/unit/Upload/AssemblyStreamTest.php
@@ -52,6 +52,15 @@ class AssemblyStreamTest extends \Test\TestCase {
 	function providesNodes() {
 		$data8k = $this->makeData(8192);
 		$dataLess8k = $this->makeData(8191);
+
+		$tonofnodes = [];
+		$tonofdata = "";
+		for ($i = 0; $i < 101; $i++) {
+			$thisdata =  rand(0,100); // variable length and content
+			$tonofdata .= $thisdata;
+			array_push($tonofnodes, $this->buildNode($i,$thisdata));
+		}
+
 		return[
 			'one node zero bytes' => [
 				'', [
@@ -90,6 +99,9 @@ class AssemblyStreamTest extends \Test\TestCase {
 				$this->buildNode('1', $data8k . 'X'),
 				$this->buildNode('0', $data8k)
 			]],
+			'a ton of nodes' => [
+				$tonofdata, $tonofnodes
+			]
 		];
 	}
 


### PR DESCRIPTION
For https://github.com/owncloud/client/pull/5476

Before this, the assembly could be bogusly in the order 0,1,10,11,2,3 etc.

As per the spec "The name of every chunk should be its chunk number."
https://github.com/cernbox/smashbox/blob/master/protocol/chunking.md

* downstream of https://github.com/owncloud/core/pull/26995