### PR TITLE
Properly handle deleted users in UserMountCache

### DIFF
--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -194,9 +194,31 @@ class UserMountCache implements IUserMountCache {
 	private function dbRowToMountInfo(array $row) {
 		$user = $this->userManager->get($row['user_id']);
 		if (is_null($user)) {
+			// user does not exist any more, delete all mounts of that user directly
+			$builder = $this->connection->getQueryBuilder();
+			$query = $builder->delete('mounts')
+				->where($builder->expr()->eq('user_id', $builder->createNamedParameter($row['user_id'])));
+			$query->execute();
 			return null;
 		}
 		return new CachedMountInfo($user, (int)$row['storage_id'], (int)$row['root_id'], $row['mount_point'], $row['mount_id'], isset($row['path'])? $row['path']:'');
+	}
+
+	/**
+	 * Convert DB rows to CachedMountInfo
+	 *
+	 * @param array $rows DB rows
+	 * @return CachedMountInfo[]
+	 */
+	private function convertRows($rows) {
+		$mountInfos = [];
+		foreach ($rows as $row) {
+			$mountInfo = $this->dbRowToMountInfo($row);
+			if (!is_null($mountInfo)) {
+				$mountInfos[] = $mountInfo;
+			}
+		}
+		return $mountInfos;
 	}
 
 	/**
@@ -213,7 +235,7 @@ class UserMountCache implements IUserMountCache {
 
 			$rows = $query->execute()->fetchAll();
 
-			$this->mountsForUsers[$user->getUID()] = array_filter(array_map([$this, 'dbRowToMountInfo'], $rows));
+			$this->mountsForUsers[$user->getUID()] = $this->convertRows($rows);
 		}
 		return $this->mountsForUsers[$user->getUID()];
 	}
@@ -231,7 +253,7 @@ class UserMountCache implements IUserMountCache {
 
 		$rows = $query->execute()->fetchAll();
 
-		return array_filter(array_map([$this, 'dbRowToMountInfo'], $rows));
+		return $this->convertRows($rows);
 	}
 
 	/**
@@ -247,7 +269,7 @@ class UserMountCache implements IUserMountCache {
 
 		$rows = $query->execute()->fetchAll();
 
-		return array_filter(array_map([$this, 'dbRowToMountInfo'], $rows));
+		return $this->convertRows($rows);
 	}
 
 	/**

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -47,6 +47,7 @@ class UserMountCacheTest extends TestCase {
 		$userBackend = new Dummy();
 		$userBackend->createUser('u1', '');
 		$userBackend->createUser('u2', '');
+		$userBackend->createUser('u3', '');
 		$this->userManager->registerBackend($userBackend);
 		$this->cache = new \OC\Files\Config\UserMountCache($this->connection, $this->userManager, $this->createMock(Log::class));
 	}
@@ -211,6 +212,7 @@ class UserMountCacheTest extends TestCase {
 	public function testGetMountsForUser() {
 		$user1 = $this->userManager->get('u1');
 		$user2 = $this->userManager->get('u2');
+		$user3 = $this->userManager->get('u3');
 
 		list($storage1, $id1) = $this->getStorage(1);
 		list($storage2, $id2) = $this->getStorage(2);
@@ -219,8 +221,11 @@ class UserMountCacheTest extends TestCase {
 
 		$this->cache->registerMounts($user1, [$mount1, $mount2]);
 		$this->cache->registerMounts($user2, [$mount2]);
+		$this->cache->registerMounts($user3, [$mount2]);
 
 		$this->clearCache();
+
+		$user3->delete();
 
 		$cachedMounts = $this->cache->getMountsForUser($user1);
 
@@ -234,6 +239,9 @@ class UserMountCacheTest extends TestCase {
 		$this->assertEquals($user1, $cachedMounts[1]->getUser());
 		$this->assertEquals($id2, $cachedMounts[1]->getRootId());
 		$this->assertEquals(2, $cachedMounts[1]->getStorageId());
+
+		$cachedMounts = $this->cache->getMountsForUser($user3);
+		$this->assertEmpty($cachedMounts);
 	}
 
 	public function testGetMountsByStorageId() {
@@ -430,5 +438,23 @@ class UserMountCacheTest extends TestCase {
 		$cachedMounts = $this->cache->getMountsForFileId($fileId);
 
 		$this->assertCount(0, $cachedMounts);
+	}
+
+	public function testGetMountsForFileIdDeletedUser() {
+		$user1 = $this->userManager->get('u1');
+
+		$rootId = $this->createCacheEntry('', 2);
+
+		$mount1 = new MountPoint($this->getStorage(2, $rootId), '/foo/');
+
+		$this->cache->registerMounts($user1, [$mount1]);
+
+		$user1->delete();
+
+		$this->clearCache();
+
+		$cachedMounts = $this->cache->getMountsForFileId($rootId);
+
+		$this->assertEmpty($cachedMounts);
 	}
 }


### PR DESCRIPTION
When encountering entries from a deleted user, discard such entries.

* downstream of https://github.com/owncloud/core/pull/27028


@icewind1991 Does that make sense? You added the array_filter before and upstream added the deletion as well.