### PR TITLE
Redirect unlink to rmdir

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -692,7 +692,11 @@ class View {
 		if ($mount and $mount->getInternalPath($absolutePath) === '') {
 			return $this->removeMount($mount, $absolutePath);
 		}
-		$result = $this->basicOperation('unlink', $path, array('delete'));
+		if ($this->is_dir($path)) {
+			$result = $this->basicOperation('rmdir', $path, ['delete']);
+		} else {
+			$result = $this->basicOperation('unlink', $path, ['delete']);
+		}
 		if (!$result && !$this->file_exists($path)) { //clear ghost files from the cache on delete
 			$storage = $mount->getStorage();
 			$internalPath = $mount->getInternalPath($absolutePath);

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -9,24 +9,31 @@ namespace Test\Files;
 
 use OC\Cache\CappedMemoryCache;
 use OC\Files\Cache\Watcher;
+use OC\Files\Filesystem;
 use OC\Files\Storage\Common;
 use OC\Files\Mount\MountPoint;
 use OC\Files\Storage\Temporary;
+use OC\Files\Stream\Quota;
 use OC\Files\View;
+use OCP\Constants;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\FileInfo;
 use OCP\Lock\ILockingProvider;
+use OCP\Lock\LockedException;
+use OCP\Share;
+use OCP\Util;
 use Test\TestMoveableMountPoint;
+use Test\HookHelper;
 
-class TemporaryNoTouch extends \OC\Files\Storage\Temporary {
+class TemporaryNoTouch extends Temporary {
 	public function touch($path, $mtime = null) {
 		return false;
 	}
 }
 
-class TemporaryNoCross extends \OC\Files\Storage\Temporary {
-	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
-		return Common::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+class TemporaryNoCross extends Temporary {
+	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = null) {
+		return Common::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime);
 	}
 
 	public function moveFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
@@ -34,7 +41,7 @@ class TemporaryNoCross extends \OC\Files\Storage\Temporary {
 	}
 }
 
-class TemporaryNoLocal extends \OC\Files\Storage\Temporary {
+class TemporaryNoLocal extends Temporary {
 	public function instanceOfStorage($className) {
 		if ($className === '\OC\Files\Storage\Local') {
 			return false;
@@ -91,10 +98,10 @@ class ViewTest extends \Test\TestCase {
 		$this->groupObject = $groupManager->createGroup('group1');
 		$this->groupObject->addUser($this->userObject);
 
-		$this->loginAsUser($this->user);
+		self::loginAsUser($this->user);
 		// clear mounts but somehow keep the root storage
 		// that was initialized above...
-		\OC\Files\Filesystem::clearMounts();
+		Filesystem::clearMounts();
 
 		$this->tempStorage = null;
 	}
@@ -111,13 +118,13 @@ class ViewTest extends \Test\TestCase {
 			system('rm -rf ' . escapeshellarg($this->tempStorage->getDataDir()));
 		}
 
-		$this->logout();
+		self::logout();
 
 		$this->userObject->delete();
 		$this->groupObject->delete();
 
 		$mountProviderCollection = \OC::$server->getMountProviderCollection();
-		\Test\TestCase::invokePrivate($mountProviderCollection, 'providers', [[]]);
+		self::invokePrivate($mountProviderCollection, 'providers', [[]]);
 
 		parent::tearDown();
 	}
@@ -129,10 +136,10 @@ class ViewTest extends \Test\TestCase {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
 		$storage3 = $this->getTestStorage();
-		$root = $this->getUniqueID('/');
-		\OC\Files\Filesystem::mount($storage1, array(), $root . '/');
-		\OC\Files\Filesystem::mount($storage2, array(), $root . '/substorage');
-		\OC\Files\Filesystem::mount($storage3, array(), $root . '/folder/anotherstorage');
+		$root = self::getUniqueID('/');
+		Filesystem::mount($storage1, array(), $root . '/');
+		Filesystem::mount($storage2, array(), $root . '/substorage');
+		Filesystem::mount($storage3, array(), $root . '/folder/anotherstorage');
 		$textSize = strlen("dummy file data\n");
 		$imageSize = filesize(\OC::$SERVERROOT . '/core/img/logo.png');
 		$storageSize = $textSize * 2 + $imageSize;
@@ -140,7 +147,7 @@ class ViewTest extends \Test\TestCase {
 		$storageInfo = $storage3->getCache()->get('');
 		$this->assertEquals($storageSize, $storageInfo['size']);
 
-		$rootView = new \OC\Files\View($root);
+		$rootView = new View($root);
 
 		$cachedData = $rootView->getFileInfo('/foo.txt');
 		$this->assertEquals($textSize, $cachedData['size']);
@@ -168,7 +175,7 @@ class ViewTest extends \Test\TestCase {
 		 * foo.txt
 		 * substorage
 		 */
-		$this->assertEquals(4, count($folderData));
+		$this->assertCount(4, $folderData);
 		$this->assertEquals('folder', $folderData[0]['name']);
 		$this->assertEquals('foo.png', $folderData[1]['name']);
 		$this->assertEquals('foo.txt', $folderData[2]['name']);
@@ -186,12 +193,12 @@ class ViewTest extends \Test\TestCase {
 		 * foo.png
 		 * foo.txt
 		 */
-		$this->assertEquals(3, count($folderData));
+		$this->assertCount(3, $folderData);
 		$this->assertEquals('folder', $folderData[0]['name']);
 		$this->assertEquals('foo.png', $folderData[1]['name']);
 		$this->assertEquals('foo.txt', $folderData[2]['name']);
 
-		$folderView = new \OC\Files\View($root . '/folder');
+		$folderView = new View($root . '/folder');
 		$this->assertEquals($rootView->getFileInfo('/folder'), $folderView->getFileInfo('/'));
 
 		$cachedData = $rootView->getFileInfo('/foo.txt');
@@ -212,11 +219,11 @@ class ViewTest extends \Test\TestCase {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
 		$storage3 = $this->getTestStorage();
-		\OC\Files\Filesystem::mount($storage1, array(), '/');
-		\OC\Files\Filesystem::mount($storage2, array(), '/substorage');
-		\OC\Files\Filesystem::mount($storage3, array(), '/folder/anotherstorage');
+		Filesystem::mount($storage1, array(), '/');
+		Filesystem::mount($storage2, array(), '/substorage');
+		Filesystem::mount($storage3, array(), '/folder/anotherstorage');
 
-		$rootView = new \OC\Files\View('');
+		$rootView = new View('');
 
 		$cachedData = $rootView->getFileInfo('/foo.txt');
 		/** @var int $id1 */
@@ -228,22 +235,22 @@ class ViewTest extends \Test\TestCase {
 		$id2 = $cachedData['fileid'];
 		$this->assertEquals('/substorage/foo.txt', $rootView->getPath($id2));
 
-		$folderView = new \OC\Files\View('/substorage');
+		$folderView = new View('/substorage');
 		$this->assertEquals('/foo.txt', $folderView->getPath($id2));
 	}
 
 	/**
 	 * @expectedException \OCP\Files\NotFoundException
 	 */
-	function testGetPathNotExisting() {
+	public function testGetPathNotExisting() {
 		$storage1 = $this->getTestStorage();
-		\OC\Files\Filesystem::mount($storage1, [], '/');
+		Filesystem::mount($storage1, [], '/');
 
-		$rootView = new \OC\Files\View('');
+		$rootView = new View('');
 		$cachedData = $rootView->getFileInfo('/foo.txt');
 		/** @var int $id1 */
 		$id1 = $cachedData['fileid'];
-		$folderView = new \OC\Files\View('/substorage');
+		$folderView = new View('/substorage');
 		$this->assertNull($folderView->getPath($id1));
 	}
 
@@ -254,12 +261,12 @@ class ViewTest extends \Test\TestCase {
 		$storage1 = $this->getTestStorage(false);
 		$storage2 = $this->getTestStorage();
 		$storage1->mkdir('substorage');
-		\OC\Files\Filesystem::mount($storage1, array(), '/');
-		\OC\Files\Filesystem::mount($storage2, array(), '/substorage');
+		Filesystem::mount($storage1, array(), '/');
+		Filesystem::mount($storage2, array(), '/substorage');
 
-		$rootView = new \OC\Files\View('');
+		$rootView = new View('');
 		$folderContent = $rootView->getDirectoryContent('/');
-		$this->assertEquals(4, count($folderContent));
+		$this->assertCount(4, $folderContent);
 	}
 
 	public function sharingDisabledPermissionProvider() {
@@ -274,7 +281,7 @@ class ViewTest extends \Test\TestCase {
 	 */
 	public function testRemoveSharePermissionWhenSharingDisabledForUser($excludeGroups, $excludeGroupsList, $expectedShareable) {
 		// Reset sharing disabled for users cache
-		$this->invokePrivate(\OC::$server->getShareManager(), 'sharingDisabledForUsersCache', [new CappedMemoryCache()]);
+		self::invokePrivate(\OC::$server->getShareManager(), 'sharingDisabledForUsersCache', [new CappedMemoryCache()]);
 
 		$appConfig = \OC::$server->getAppConfig();
 		$oldExcludeGroupsFlag = $appConfig->getValue('core', 'shareapi_exclude_groups', 'no');
@@ -284,10 +291,10 @@ class ViewTest extends \Test\TestCase {
 
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
-		\OC\Files\Filesystem::mount($storage1, array(), '/');
-		\OC\Files\Filesystem::mount($storage2, array(), '/mount');
+		Filesystem::mount($storage1, array(), '/');
+		Filesystem::mount($storage2, array(), '/mount');
 
-		$view = new \OC\Files\View('/');
+		$view = new View('/');
 
 		$folderContent = $view->getDirectoryContent('');
 		$this->assertEquals($expectedShareable, $folderContent[0]->isShareable());
@@ -299,31 +306,31 @@ class ViewTest extends \Test\TestCase {
 		$appConfig->setValue('core', 'shareapi_exclude_groups_list', $oldExcludeGroupsList);
 
 		// Reset sharing disabled for users cache
-		$this->invokePrivate(\OC::$server->getShareManager(), 'sharingDisabledForUsersCache', [new CappedMemoryCache()]);
+		self::invokePrivate(\OC::$server->getShareManager(), 'sharingDisabledForUsersCache', [new CappedMemoryCache()]);
 	}
 
 	public function testCacheIncompleteFolder() {
 		$storage1 = $this->getTestStorage(false);
-		\OC\Files\Filesystem::clearMounts();
-		\OC\Files\Filesystem::mount($storage1, array(), '/incomplete');
-		$rootView = new \OC\Files\View('/incomplete');
+		Filesystem::clearMounts();
+		Filesystem::mount($storage1, array(), '/incomplete');
+		$rootView = new View('/incomplete');
 
 		$entries = $rootView->getDirectoryContent('/');
-		$this->assertEquals(3, count($entries));
+		$this->assertCount(3, $entries);
 
 		// /folder will already be in the cache but not scanned
 		$entries = $rootView->getDirectoryContent('/folder');
-		$this->assertEquals(1, count($entries));
+		$this->assertCount(1, $entries);
 	}
 
 	public function testAutoScan() {
 		$storage1 = $this->getTestStorage(false);
 		$storage2 = $this->getTestStorage(false);
-		\OC\Files\Filesystem::mount($storage1, array(), '/');
-		\OC\Files\Filesystem::mount($storage2, array(), '/substorage');
+		Filesystem::mount($storage1, array(), '/');
+		Filesystem::mount($storage2, array(), '/substorage');
 		$textSize = strlen("dummy file data\n");
 
-		$rootView = new \OC\Files\View('');
+		$rootView = new View('');
 
 		$cachedData = $rootView->getFileInfo('/');
 		$this->assertEquals('httpd/unix-directory', $cachedData['mimetype']);
@@ -341,17 +348,17 @@ class ViewTest extends \Test\TestCase {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
 		$storage3 = $this->getTestStorage();
-		\OC\Files\Filesystem::mount($storage1, array(), '/');
-		\OC\Files\Filesystem::mount($storage2, array(), '/substorage');
-		\OC\Files\Filesystem::mount($storage3, array(), '/folder/anotherstorage');
+		Filesystem::mount($storage1, array(), '/');
+		Filesystem::mount($storage2, array(), '/substorage');
+		Filesystem::mount($storage3, array(), '/folder/anotherstorage');
 
-		$rootView = new \OC\Files\View('');
+		$rootView = new View('');
 
 		$results = $rootView->search('foo');
-		$this->assertEquals(6, count($results));
+		$this->assertCount(6, $results);
 		$paths = array();
 		foreach ($results as $result) {
-			$this->assertEquals($result['path'], \OC\Files\Filesystem::normalizePath($result['path']));
+			$this->assertEquals($result['path'], Filesystem::normalizePath($result['path']));
 			$paths[] = $result['path'];
 		}
 		$this->assertContains('/foo.txt', $paths);
@@ -361,9 +368,9 @@ class ViewTest extends \Test\TestCase {
 		$this->assertContains('/folder/anotherstorage/foo.txt', $paths);
 		$this->assertContains('/folder/anotherstorage/foo.png', $paths);
 
-		$folderView = new \OC\Files\View('/folder');
+		$folderView = new View('/folder');
 		$results = $folderView->search('bar');
-		$this->assertEquals(2, count($results));
+		$this->assertCount(2, $results);
 		$paths = array();
 		foreach ($results as $result) {
 			$paths[] = $result['path'];
@@ -372,7 +379,7 @@ class ViewTest extends \Test\TestCase {
 		$this->assertContains('/bar.txt', $paths);
 
 		$results = $folderView->search('foo');
-		$this->assertEquals(2, count($results));
+		$this->assertCount(2, $results);
 		$paths = array();
 		foreach ($results as $result) {
 			$paths[] = $result['path'];
@@ -380,8 +387,8 @@ class ViewTest extends \Test\TestCase {
 		$this->assertContains('/anotherstorage/foo.txt', $paths);
 		$this->assertContains('/anotherstorage/foo.png', $paths);
 
-		$this->assertEquals(6, count($rootView->searchByMime('text')));
-		$this->assertEquals(3, count($folderView->searchByMime('text')));
+		$this->assertCount(6, $rootView->searchByMime('text'));
+		$this->assertCount(3, $folderView->searchByMime('text'));
 	}
 
 	/**
@@ -389,10 +396,10 @@ class ViewTest extends \Test\TestCase {
 	 */
 	public function testWatcher() {
 		$storage1 = $this->getTestStorage();
-		\OC\Files\Filesystem::mount($storage1, array(), '/');
+		Filesystem::mount($storage1, array(), '/');
 		$storage1->getWatcher()->setPolicy(Watcher::CHECK_ALWAYS);
 
-		$rootView = new \OC\Files\View('');
+		$rootView = new View('');
 
 		$cachedData = $rootView->getFileInfo('foo.txt');
 		$this->assertEquals(16, $cachedData['size']);
@@ -409,8 +416,8 @@ class ViewTest extends \Test\TestCase {
 	 * @medium
 	 */
 	public function testCopyBetweenStorageNoCross() {
-		$storage1 = $this->getTestStorage(true, '\Test\Files\TemporaryNoCross');
-		$storage2 = $this->getTestStorage(true, '\Test\Files\TemporaryNoCross');
+		$storage1 = $this->getTestStorage(true, TemporaryNoCross::class);
+		$storage2 = $this->getTestStorage(true, TemporaryNoCross::class);
 		$this->copyBetweenStorages($storage1, $storage2);
 	}
 
@@ -427,16 +434,16 @@ class ViewTest extends \Test\TestCase {
 	 * @medium
 	 */
 	public function testCopyBetweenStorageCrossNonLocal() {
-		$storage1 = $this->getTestStorage(true, '\Test\Files\TemporaryNoLocal');
-		$storage2 = $this->getTestStorage(true, '\Test\Files\TemporaryNoLocal');
+		$storage1 = $this->getTestStorage(true, TemporaryNoLocal::class);
+		$storage2 = $this->getTestStorage(true, TemporaryNoLocal::class);
 		$this->copyBetweenStorages($storage1, $storage2);
 	}
 
-	function copyBetweenStorages($storage1, $storage2) {
-		\OC\Files\Filesystem::mount($storage1, array(), '/');
-		\OC\Files\Filesystem::mount($storage2, array(), '/substorage');
+	public function copyBetweenStorages($storage1, $storage2) {
+		Filesystem::mount($storage1, array(), '/');
+		Filesystem::mount($storage2, array(), '/substorage');
 
-		$rootView = new \OC\Files\View('');
+		$rootView = new View('');
 		$rootView->mkdir('substorage/emptyfolder');
 		$rootView->copy('substorage', 'anotherfolder');
 		$this->assertTrue($rootView->is_dir('/anotherfolder'));
@@ -455,8 +462,8 @@ class ViewTest extends \Test\TestCase {
 	 * @medium
 	 */
 	public function testMoveBetweenStorageNoCross() {
-		$storage1 = $this->getTestStorage(true, '\Test\Files\TemporaryNoCross');
-		$storage2 = $this->getTestStorage(true, '\Test\Files\TemporaryNoCross');
+		$storage1 = $this->getTestStorage(true, TemporaryNoCross::class);
+		$storage2 = $this->getTestStorage(true, TemporaryNoCross::class);
 		$this->moveBetweenStorages($storage1, $storage2);
 	}
 
@@ -473,16 +480,16 @@ class ViewTest extends \Test\TestCase {
 	 * @medium
 	 */
 	public function testMoveBetweenStorageCrossNonLocal() {
-		$storage1 = $this->getTestStorage(true, '\Test\Files\TemporaryNoLocal');
-		$storage2 = $this->getTestStorage(true, '\Test\Files\TemporaryNoLocal');
+		$storage1 = $this->getTestStorage(true, TemporaryNoLocal::class);
+		$storage2 = $this->getTestStorage(true, TemporaryNoLocal::class);
 		$this->moveBetweenStorages($storage1, $storage2);
 	}
 
-	function moveBetweenStorages($storage1, $storage2) {
-		\OC\Files\Filesystem::mount($storage1, array(), '/');
-		\OC\Files\Filesystem::mount($storage2, array(), '/substorage');
+	public function moveBetweenStorages($storage1, $storage2) {
+		Filesystem::mount($storage1, array(), '/');
+		Filesystem::mount($storage2, array(), '/substorage');
 
-		$rootView = new \OC\Files\View('');
+		$rootView = new View('');
 		$rootView->rename('foo.txt', 'substorage/folder/foo.txt');
 		$this->assertFalse($rootView->file_exists('foo.txt'));
 		$this->assertTrue($rootView->file_exists('substorage/folder/foo.txt'));
@@ -498,10 +505,10 @@ class ViewTest extends \Test\TestCase {
 	public function testUnlink() {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
-		\OC\Files\Filesystem::mount($storage1, array(), '/');
-		\OC\Files\Filesystem::mount($storage2, array(), '/substorage');
+		Filesystem::mount($storage1, array(), '/');
+		Filesystem::mount($storage2, array(), '/substorage');
 
-		$rootView = new \OC\Files\View('');
+		$rootView = new View('');
 		$rootView->file_put_contents('/foo.txt', 'asd');
 		$rootView->file_put_contents('/substorage/bar.txt', 'asd');
 
@@ -524,7 +531,7 @@ class ViewTest extends \Test\TestCase {
 	 */
 	public function testRmdir($method) {
 		$storage1 = $this->getTestStorage();
-		\OC\Files\Filesystem::mount($storage1, [], '/');
+		Filesystem::mount($storage1, [], '/');
 
 		$rootView = new View('');
 		$rootView->mkdir('sub');
@@ -544,10 +551,10 @@ class ViewTest extends \Test\TestCase {
 	public function testUnlinkRootMustFail() {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
-		\OC\Files\Filesystem::mount($storage1, array(), '/');
-		\OC\Files\Filesystem::mount($storage2, array(), '/substorage');
+		Filesystem::mount($storage1, array(), '/');
+		Filesystem::mount($storage2, array(), '/substorage');
 
-		$rootView = new \OC\Files\View('');
+		$rootView = new View('');
 		$rootView->file_put_contents('/foo.txt', 'asd');
 		$rootView->file_put_contents('/substorage/bar.txt', 'asd');
 
@@ -561,11 +568,11 @@ class ViewTest extends \Test\TestCase {
 	 * @medium
 	 */
 	public function testTouch() {
-		$storage = $this->getTestStorage(true, '\Test\Files\TemporaryNoTouch');
+		$storage = $this->getTestStorage(true, TemporaryNoTouch::class);
 
-		\OC\Files\Filesystem::mount($storage, array(), '/');
+		Filesystem::mount($storage, array(), '/');
 
-		$rootView = new \OC\Files\View('');
+		$rootView = new View('');
 		$oldCachedData = $rootView->getFileInfo('foo.txt');
 
 		$rootView->touch('foo.txt', 500);
@@ -587,13 +594,13 @@ class ViewTest extends \Test\TestCase {
 	public function testViewHooks() {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
-		$defaultRoot = \OC\Files\Filesystem::getRoot();
-		\OC\Files\Filesystem::mount($storage1, array(), '/');
-		\OC\Files\Filesystem::mount($storage2, array(), $defaultRoot . '/substorage');
+		$defaultRoot = Filesystem::getRoot();
+		Filesystem::mount($storage1, array(), '/');
+		Filesystem::mount($storage2, array(), $defaultRoot . '/substorage');
 		\OC_Hook::connect('OC_Filesystem', 'post_write', $this, 'dummyHook');
 
-		$rootView = new \OC\Files\View('');
-		$subView = new \OC\Files\View($defaultRoot . '/substorage');
+		$rootView = new View('');
+		$subView = new View($defaultRoot . '/substorage');
 		$this->hookPath = null;
 
 		$rootView->file_put_contents('/foo.txt', 'asd');
@@ -611,12 +618,12 @@ class ViewTest extends \Test\TestCase {
 
 	public function testSearchNotOutsideView() {
 		$storage1 = $this->getTestStorage();
-		\OC\Files\Filesystem::mount($storage1, array(), '/');
+		Filesystem::mount($storage1, array(), '/');
 		$storage1->rename('folder', 'foo');
 		$scanner = $storage1->getScanner();
 		$scanner->scan('');
 
-		$view = new \OC\Files\View('/foo');
+		$view = new View('/foo');
 
 		$result = $view->search('.txt');
 		$this->assertCount(1, $result);
@@ -627,7 +634,7 @@ class ViewTest extends \Test\TestCase {
 	 * @param string $class
 	 * @return \OC\Files\Storage\Storage
 	 */
-	private function getTestStorage($scan = true, $class = '\OC\Files\Storage\Temporary') {
+	private function getTestStorage($scan = true, $class = Temporary::class) {
 		/**
 		 * @var \OC\Files\Storage\Storage $storage
 		 */
@@ -653,12 +660,12 @@ class ViewTest extends \Test\TestCase {
 	public function testViewHooksIfRootStartsTheSame() {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
-		$defaultRoot = \OC\Files\Filesystem::getRoot();
-		\OC\Files\Filesystem::mount($storage1, array(), '/');
-		\OC\Files\Filesystem::mount($storage2, array(), $defaultRoot . '_substorage');
+		$defaultRoot = Filesystem::getRoot();
+		Filesystem::mount($storage1, array(), '/');
+		Filesystem::mount($storage2, array(), $defaultRoot . '_substorage');
 		\OC_Hook::connect('OC_Filesystem', 'post_write', $this, 'dummyHook');
 
-		$subView = new \OC\Files\View($defaultRoot . '_substorage');
+		$subView = new View($defaultRoot . '_substorage');
 		$this->hookPath = null;
 
 		$subView->file_put_contents('/foo.txt', 'asd');
@@ -684,14 +691,14 @@ class ViewTest extends \Test\TestCase {
 	public function testEditNoCreateHook() {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
-		$defaultRoot = \OC\Files\Filesystem::getRoot();
-		\OC\Files\Filesystem::mount($storage1, array(), '/');
-		\OC\Files\Filesystem::mount($storage2, array(), $defaultRoot);
+		$defaultRoot = Filesystem::getRoot();
+		Filesystem::mount($storage1, array(), '/');
+		Filesystem::mount($storage2, array(), $defaultRoot);
 		\OC_Hook::connect('OC_Filesystem', 'post_create', $this, 'dummyHookCreate');
 		\OC_Hook::connect('OC_Filesystem', 'post_update', $this, 'dummyHookUpdate');
 		\OC_Hook::connect('OC_Filesystem', 'post_write', $this, 'dummyHookWrite');
 
-		$view = new \OC\Files\View($defaultRoot);
+		$view = new View($defaultRoot);
 		$this->hookWritePath = $this->hookUpdatePath = $this->hookCreatePath = null;
 
 		$view->file_put_contents('/asd.txt', 'foo');
@@ -716,9 +723,9 @@ class ViewTest extends \Test\TestCase {
 	 */
 	public function testResolvePath($expected, $pathToTest) {
 		$storage1 = $this->getTestStorage();
-		\OC\Files\Filesystem::mount($storage1, array(), '/');
+		Filesystem::mount($storage1, array(), '/');
 
-		$view = new \OC\Files\View('');
+		$view = new View('');
 
 		$result = $view->resolvePath($pathToTest);
 		$this->assertEquals($expected, $result[1]);
@@ -730,7 +737,7 @@ class ViewTest extends \Test\TestCase {
 		$this->assertTrue($exists);
 	}
 
-	function resolvePathTestProvider() {
+	public function resolvePathTestProvider() {
 		return array(
 			array('foo.txt', 'foo.txt'),
 			array('foo.txt', '/foo.txt'),
@@ -748,10 +755,10 @@ class ViewTest extends \Test\TestCase {
 	public function testUTF8Names() {
 		$names = array('虚', '和知しゃ和で', 'regular ascii', 'sɨˈrɪlɪk', 'ѨѬ', 'أنا أحب القراءة كثيرا');
 
-		$storage = new \OC\Files\Storage\Temporary(array());
-		\OC\Files\Filesystem::mount($storage, array(), '/');
+		$storage = new Temporary(array());
+		Filesystem::mount($storage, array(), '/');
 
-		$rootView = new \OC\Files\View('');
+		$rootView = new View('');
 		foreach ($names as $name) {
 			$rootView->file_put_contents('/' . $name, 'dummy content');
 		}
@@ -777,10 +784,10 @@ class ViewTest extends \Test\TestCase {
 
 	public function xtestLongPath() {
 
-		$storage = new \OC\Files\Storage\Temporary(array());
-		\OC\Files\Filesystem::mount($storage, array(), '/');
+		$storage = new Temporary(array());
+		Filesystem::mount($storage, array(), '/');
 
-		$rootView = new \OC\Files\View('');
+		$rootView = new View('');
 
 		$longPath = '';
 		$ds = DIRECTORY_SEPARATOR;
@@ -828,11 +835,11 @@ class ViewTest extends \Test\TestCase {
 	public function testTouchNotSupported() {
 		$storage = new TemporaryNoTouch(array());
 		$scanner = $storage->getScanner();
-		\OC\Files\Filesystem::mount($storage, array(), '/test/');
+		Filesystem::mount($storage, array(), '/test/');
 		$past = time() - 100;
 		$storage->file_put_contents('test', 'foobar');
 		$scanner->scan('');
-		$view = new \OC\Files\View('');
+		$view = new View('');
 		$info = $view->getFileInfo('/test/test');
 
 		$view->touch('/test/test', $past);
@@ -848,14 +855,14 @@ class ViewTest extends \Test\TestCase {
 		$scanner1 = $storage1->getScanner();
 		$scanner2 = $storage2->getScanner();
 		$storage1->mkdir('sub');
-		\OC\Files\Filesystem::mount($storage1, array(), '/test/');
-		\OC\Files\Filesystem::mount($storage2, array(), '/test/sub/storage');
+		Filesystem::mount($storage1, array(), '/test/');
+		Filesystem::mount($storage2, array(), '/test/sub/storage');
 
 		$past = time() - 100;
 		$storage2->file_put_contents('test.txt', 'foobar');
 		$scanner1->scan('');
 		$scanner2->scan('');
-		$view = new \OC\Files\View('');
+		$view = new View('');
 
 		$storage2->getWatcher('')->setPolicy(Watcher::CHECK_ALWAYS);
 
@@ -878,17 +885,17 @@ class ViewTest extends \Test\TestCase {
 	 * @dataProvider absolutePathProvider
 	 */
 	public function testGetAbsolutePath($expectedPath, $relativePath) {
-		$view = new \OC\Files\View('/files');
+		$view = new View('/files');
 		$this->assertEquals($expectedPath, $view->getAbsolutePath($relativePath));
 	}
 
 	public function testPartFileInfo() {
 		$storage = new Temporary(array());
 		$scanner = $storage->getScanner();
-		\OC\Files\Filesystem::mount($storage, array(), '/test/');
+		Filesystem::mount($storage, array(), '/test/');
 		$storage->file_put_contents('test.part', 'foobar');
 		$scanner->scan('');
-		$view = new \OC\Files\View('/test');
+		$view = new View('/test');
 		$info = $view->getFileInfo('test.part');
 
 		$this->assertInstanceOf('\OCP\Files\FileInfo', $info);
@@ -896,7 +903,7 @@ class ViewTest extends \Test\TestCase {
 		$this->assertEquals(6, $info->getSize());
 	}
 
-	function absolutePathProvider() {
+	public function absolutePathProvider() {
 		return array(
 			array('/files/', ''),
 			array('/files/0', '0'),
@@ -911,8 +918,8 @@ class ViewTest extends \Test\TestCase {
 	/**
 	 * @dataProvider chrootRelativePathProvider
 	 */
-	function testChrootGetRelativePath($root, $absolutePath, $expectedPath) {
-		$view = new \OC\Files\View('/files');
+	public function testChrootGetRelativePath($root, $absolutePath, $expectedPath) {
+		$view = new View('/files');
 		$view->chroot($root);
 		$this->assertEquals($expectedPath, $view->getRelativePath($absolutePath));
 	}
@@ -925,7 +932,7 @@ class ViewTest extends \Test\TestCase {
 	 * @dataProvider initRelativePathProvider
 	 */
 	public function testInitGetRelativePath($root, $absolutePath, $expectedPath) {
-		$view = new \OC\Files\View($root);
+		$view = new View($root);
 		$this->assertEquals($expectedPath, $view->getRelativePath($absolutePath));
 	}
 
@@ -1008,9 +1015,9 @@ class ViewTest extends \Test\TestCase {
 		$storage = new Temporary(array());
 		$scanner = $storage->getScanner();
 		$storage->file_put_contents('foo.txt', 'bar');
-		\OC\Files\Filesystem::mount($storage, array(), '/test/');
+		Filesystem::mount($storage, array(), '/test/');
 		$scanner->scan('');
-		$view = new \OC\Files\View('/test/foo.txt');
+		$view = new View('/test/foo.txt');
 
 		$this->assertEquals('bar', $view->file_get_contents(''));
 		$fh = tmpfile();
@@ -1034,11 +1041,11 @@ class ViewTest extends \Test\TestCase {
 			$longPath .= '/' . $folderName;
 		}
 
-		$storage = new \OC\Files\Storage\Temporary(array());
+		$storage = new Temporary(array());
 		$this->tempStorage = $storage; // for later hard cleanup
-		\OC\Files\Filesystem::mount($storage, array(), '/');
+		Filesystem::mount($storage, array(), '/');
 
-		$rootView = new \OC\Files\View('');
+		$rootView = new View('');
 
 		if ($param0 === '@0') {
 			$param0 = $longPath;
@@ -1101,16 +1108,14 @@ class ViewTest extends \Test\TestCase {
 	public function testRenameCrossStoragePreserveMtime() {
 		$storage1 = new Temporary(array());
 		$storage2 = new Temporary(array());
-		$scanner1 = $storage1->getScanner();
-		$scanner2 = $storage2->getScanner();
 		$storage1->mkdir('sub');
 		$storage1->mkdir('foo');
 		$storage1->file_put_contents('foo.txt', 'asd');
 		$storage1->file_put_contents('foo/bar.txt', 'asd');
-		\OC\Files\Filesystem::mount($storage1, array(), '/test/');
-		\OC\Files\Filesystem::mount($storage2, array(), '/test/sub/storage');
+		Filesystem::mount($storage1, array(), '/test/');
+		Filesystem::mount($storage2, array(), '/test/sub/storage');
 
-		$view = new \OC\Files\View('');
+		$view = new View('');
 		$time = time() - 200;
 		$view->touch('/test/foo.txt', $time);
 		$view->touch('/test/foo', $time);
@@ -1135,8 +1140,8 @@ class ViewTest extends \Test\TestCase {
 
 	private function doTestCopyRenameFail($operation) {
 		$storage1 = new Temporary(array());
-		/** @var \PHPUnit_Framework_MockObject_MockObject | \OC\Files\Storage\Temporary $storage2 */
-		$storage2 = $this->getMockBuilder('\Test\Files\TemporaryNoCross')
+		/** @var \PHPUnit_Framework_MockObject_MockObject|Temporary $storage2 */
+		$storage2 = $this->getMockBuilder(TemporaryNoCross::class)
 			->setConstructorArgs([[]])
 			->setMethods(['fopen'])
 			->getMock();
@@ -1146,7 +1151,7 @@ class ViewTest extends \Test\TestCase {
 			->will($this->returnCallback(function ($path, $mode) use ($storage2) {
 				/** @var \PHPUnit_Framework_MockObject_MockObject | \OC\Files\Storage\Temporary $storage2 */
 				$source = fopen($storage2->getSourcePath($path), $mode);
-				return \OC\Files\Stream\Quota::wrap($source, 9);
+				return Quota::wrap($source, 9);
 			}));
 
 		$storage1->mkdir('sub');
@@ -1157,11 +1162,11 @@ class ViewTest extends \Test\TestCase {
 		$storage2->file_put_contents('existing.txt', '0123');
 		$storage1->getScanner()->scan('');
 		$storage2->getScanner()->scan('');
-		\OC\Files\Filesystem::mount($storage1, array(), '/test/');
-		\OC\Files\Filesystem::mount($storage2, array(), '/test/sub/storage');
+		Filesystem::mount($storage1, array(), '/test/');
+		Filesystem::mount($storage2, array(), '/test/sub/storage');
 
 		// move file
-		$view = new \OC\Files\View('');
+		$view = new View('');
 		$this->assertTrue($storage1->file_exists('foo.txt'));
 		$this->assertFalse($storage2->file_exists('foo.txt'));
 		$this->assertFalse($view->$operation('/test/foo.txt', '/test/sub/storage/foo.txt'));
@@ -1187,10 +1192,8 @@ class ViewTest extends \Test\TestCase {
 	}
 
 	public function testDeleteFailKeepCache() {
-		/**
-		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Files\Storage\Temporary $storage
-		 */
-		$storage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
+		/** @var Temporary|\PHPUnit_Framework_MockObject_MockObject $storage */
+		$storage = $this->getMockBuilder(Temporary::class)
 			->setConstructorArgs(array(array()))
 			->setMethods(array('unlink'))
 			->getMock();
@@ -1201,15 +1204,15 @@ class ViewTest extends \Test\TestCase {
 		$cache = $storage->getCache();
 		$storage->file_put_contents('foo.txt', 'asd');
 		$scanner->scan('');
-		\OC\Files\Filesystem::mount($storage, array(), '/test/');
+		Filesystem::mount($storage, array(), '/test/');
 
-		$view = new \OC\Files\View('/test');
+		$view = new View('/test');
 
 		$this->assertFalse($view->unlink('foo.txt'));
 		$this->assertTrue($cache->inCache('foo.txt'));
 	}
 
-	function directoryTraversalProvider() {
+	public function directoryTraversalProvider() {
 		return [
 			['../test/'],
 			['..\\test\\my/../folder'],
@@ -1223,7 +1226,7 @@ class ViewTest extends \Test\TestCase {
 	 * @param string $root
 	 */
 	public function testConstructDirectoryTraversalException($root) {
-		new \OC\Files\View($root);
+		new View($root);
 	}
 
 	public function testRenameOverWrite() {
@@ -1234,22 +1237,22 @@ class ViewTest extends \Test\TestCase {
 		$storage->file_put_contents('foo.txt', 'asd');
 		$storage->file_put_contents('foo/bar.txt', 'asd');
 		$scanner->scan('');
-		\OC\Files\Filesystem::mount($storage, array(), '/test/');
-		$view = new \OC\Files\View('');
+		Filesystem::mount($storage, array(), '/test/');
+		$view = new View('');
 		$this->assertTrue($view->rename('/test/foo.txt', '/test/foo/bar.txt'));
 	}
 
 	public function testSetMountOptionsInStorage() {
-		$mount = new MountPoint('\OC\Files\Storage\Temporary', '/asd/', [[]], \OC\Files\Filesystem::getLoader(), ['foo' => 'bar']);
-		\OC\Files\Filesystem::getMountManager()->addMount($mount);
+		$mount = new MountPoint(Temporary::class, '/asd/', [[]], Filesystem::getLoader(), ['foo' => 'bar']);
+		Filesystem::getMountManager()->addMount($mount);
 		/** @var \OC\Files\Storage\Common $storage */
 		$storage = $mount->getStorage();
 		$this->assertEquals($storage->getMountOption('foo'), 'bar');
 	}
 
 	public function testSetMountOptionsWatcherPolicy() {
-		$mount = new MountPoint('\OC\Files\Storage\Temporary', '/asd/', [[]], \OC\Files\Filesystem::getLoader(), ['filesystem_check_changes' => Watcher::CHECK_NEVER]);
-		\OC\Files\Filesystem::getMountManager()->addMount($mount);
+		$mount = new MountPoint(Temporary::class, '/asd/', [[]], Filesystem::getLoader(), ['filesystem_check_changes' => Watcher::CHECK_NEVER]);
+		Filesystem::getMountManager()->addMount($mount);
 		/** @var \OC\Files\Storage\Common $storage */
 		$storage = $mount->getStorage();
 		$watcher = $storage->getWatcher();
@@ -1257,12 +1260,12 @@ class ViewTest extends \Test\TestCase {
 	}
 
 	public function testGetAbsolutePathOnNull() {
-		$view = new \OC\Files\View();
+		$view = new View();
 		$this->assertNull($view->getAbsolutePath(null));
 	}
 
 	public function testGetRelativePathOnNull() {
-		$view = new \OC\Files\View();
+		$view = new View();
 		$this->assertNull($view->getRelativePath(null));
 	}
 
@@ -1270,7 +1273,7 @@ class ViewTest extends \Test\TestCase {
 	 * @expectedException \InvalidArgumentException
 	 */
 	public function testNullAsRoot() {
-		new \OC\Files\View(null);
+		new View(null);
 	}
 
 	/**
@@ -1287,9 +1290,9 @@ class ViewTest extends \Test\TestCase {
 		$rootPath = str_replace('{folder}', 'files', $rootPath);
 		$pathPrefix = str_replace('{folder}', 'files', $pathPrefix);
 
-		$view = new \OC\Files\View($rootPath);
+		$view = new View($rootPath);
 		$storage = new Temporary(array());
-		\OC\Files\Filesystem::mount($storage, [], '/');
+		Filesystem::mount($storage, [], '/');
 		$this->assertTrue($view->lockFile($pathPrefix . '/foo/bar', ILockingProvider::LOCK_EXCLUSIVE));
 		$view->lockFile($pathPrefix . '/foo/bar/asd', ILockingProvider::LOCK_SHARED);
 	}
@@ -1306,9 +1309,9 @@ class ViewTest extends \Test\TestCase {
 		$rootPath = str_replace('{folder}', 'files_encryption', $rootPath);
 		$pathPrefix = str_replace('{folder}', 'files_encryption', $pathPrefix);
 
-		$view = new \OC\Files\View($rootPath);
+		$view = new View($rootPath);
 		$storage = new Temporary(array());
-		\OC\Files\Filesystem::mount($storage, [], '/');
+		Filesystem::mount($storage, [], '/');
 		$this->assertFalse($view->lockFile($pathPrefix . '/foo/bar', ILockingProvider::LOCK_EXCLUSIVE));
 		$this->assertFalse($view->lockFile($pathPrefix . '/foo/bar/asd', ILockingProvider::LOCK_SHARED));
 	}
@@ -1327,9 +1330,9 @@ class ViewTest extends \Test\TestCase {
 		$rootPath = str_replace('{folder}', 'files', $rootPath);
 		$pathPrefix = str_replace('{folder}', 'files', $pathPrefix);
 
-		$view = new \OC\Files\View($rootPath);
+		$view = new View($rootPath);
 		$storage = new Temporary(array());
-		\OC\Files\Filesystem::mount($storage, [], '/');
+		Filesystem::mount($storage, [], '/');
 		$this->assertTrue($view->lockFile($pathPrefix . '/foo/bar', ILockingProvider::LOCK_SHARED));
 		$view->lockFile($pathPrefix . '/foo/bar', ILockingProvider::LOCK_EXCLUSIVE);
 	}
@@ -1346,9 +1349,9 @@ class ViewTest extends \Test\TestCase {
 		$rootPath = str_replace('{folder}', 'files_encryption', $rootPath);
 		$pathPrefix = str_replace('{folder}', 'files_encryption', $pathPrefix);
 
-		$view = new \OC\Files\View($rootPath);
+		$view = new View($rootPath);
 		$storage = new Temporary(array());
-		\OC\Files\Filesystem::mount($storage, [], '/');
+		Filesystem::mount($storage, [], '/');
 		$this->assertFalse($view->lockFile($pathPrefix . '/foo/bar', ILockingProvider::LOCK_SHARED));
 		$this->assertFalse($view->lockFile($pathPrefix . '/foo/bar', ILockingProvider::LOCK_EXCLUSIVE));
 	}
@@ -1358,11 +1361,11 @@ class ViewTest extends \Test\TestCase {
 	 */
 	public function testLockLocalMountPointPathInsteadOfStorageRoot() {
 		$lockingProvider = \OC::$server->getLockingProvider();
-		$view = new \OC\Files\View('/testuser/files/');
+		$view = new View('/testuser/files/');
 		$storage = new Temporary([]);
-		\OC\Files\Filesystem::mount($storage, [], '/');
+		Filesystem::mount($storage, [], '/');
 		$mountedStorage = new Temporary([]);
-		\OC\Files\Filesystem::mount($mountedStorage, [], '/testuser/files/mountpoint');
+		Filesystem::mount($mountedStorage, [], '/testuser/files/mountpoint');
 
 		$this->assertTrue(
 			$view->lockFile('/mountpoint', ILockingProvider::LOCK_EXCLUSIVE, true),
@@ -1375,7 +1378,7 @@ class ViewTest extends \Test\TestCase {
 		$thrown = false;
 		try {
 			$storage->acquireLock('/testuser/files/mountpoint', ILockingProvider::LOCK_EXCLUSIVE, $lockingProvider);
-		} catch (\OCP\Lock\LockedException $e) {
+		} catch (LockedException $e) {
 			$thrown = true;
 		}
 		$this->assertTrue($thrown, 'Mount point path was locked on root storage');
@@ -1388,11 +1391,11 @@ class ViewTest extends \Test\TestCase {
 	 */
 	public function testLockStorageRootButNotLocalMountPoint() {
 		$lockingProvider = \OC::$server->getLockingProvider();
-		$view = new \OC\Files\View('/testuser/files/');
+		$view = new View('/testuser/files/');
 		$storage = new Temporary([]);
-		\OC\Files\Filesystem::mount($storage, [], '/');
+		Filesystem::mount($storage, [], '/');
 		$mountedStorage = new Temporary([]);
-		\OC\Files\Filesystem::mount($mountedStorage, [], '/testuser/files/mountpoint');
+		Filesystem::mount($mountedStorage, [], '/testuser/files/mountpoint');
 
 		$this->assertTrue(
 			$view->lockFile('/mountpoint', ILockingProvider::LOCK_EXCLUSIVE, false),
@@ -1402,7 +1405,7 @@ class ViewTest extends \Test\TestCase {
 		$thrown = false;
 		try {
 			$mountedStorage->acquireLock('', ILockingProvider::LOCK_EXCLUSIVE, $lockingProvider);
-		} catch (\OCP\Lock\LockedException $e) {
+		} catch (LockedException $e) {
 			$thrown = true;
 		}
 		$this->assertTrue($thrown, 'Mount point storage root was locked on original storage');
@@ -1418,11 +1421,11 @@ class ViewTest extends \Test\TestCase {
 	 */
 	public function testLockMountPointPathFailReleasesBoth() {
 		$lockingProvider = \OC::$server->getLockingProvider();
-		$view = new \OC\Files\View('/testuser/files/');
+		$view = new View('/testuser/files/');
 		$storage = new Temporary([]);
-		\OC\Files\Filesystem::mount($storage, [], '/');
+		Filesystem::mount($storage, [], '/');
 		$mountedStorage = new Temporary([]);
-		\OC\Files\Filesystem::mount($mountedStorage, [], '/testuser/files/mountpoint.txt');
+		Filesystem::mount($mountedStorage, [], '/testuser/files/mountpoint.txt');
 
 		// this would happen if someone is writing on the mount point
 		$mountedStorage->acquireLock('', ILockingProvider::LOCK_EXCLUSIVE, $lockingProvider);
@@ -1432,7 +1435,7 @@ class ViewTest extends \Test\TestCase {
 			// this actually acquires two locks, one on the mount point and one on the storage root,
 			// but the one on the storage root will fail
 			$view->lockFile('/mountpoint.txt', ILockingProvider::LOCK_SHARED);
-		} catch (\OCP\Lock\LockedException $e) {
+		} catch (LockedException $e) {
 			$thrown = true;
 		}
 		$this->assertTrue($thrown, 'Cannot acquire shared lock because storage root is already locked');
@@ -1468,7 +1471,7 @@ class ViewTest extends \Test\TestCase {
 	 * @dataProvider pathRelativeToFilesProvider
 	 */
 	public function testGetPathRelativeToFiles($path, $expectedPath) {
-		$view = new \OC\Files\View();
+		$view = new View();
 		$this->assertEquals($expectedPath, $view->getPathRelativeToFiles($path));
 	}
 
@@ -1487,14 +1490,14 @@ class ViewTest extends \Test\TestCase {
 	 * @expectedException \InvalidArgumentException
 	 */
 	public function testGetPathRelativeToFilesWithInvalidArgument($path) {
-		$view = new \OC\Files\View();
+		$view = new View();
 		$view->getPathRelativeToFiles($path);
 	}
 
 	public function testChangeLock() {
-		$view = new \OC\Files\View('/testuser/files/');
+		$view = new View('/testuser/files/');
 		$storage = new Temporary(array());
-		\OC\Files\Filesystem::mount($storage, [], '/');
+		Filesystem::mount($storage, [], '/');
 
 		$view->lockFile('/test/sub', ILockingProvider::LOCK_SHARED);
 		$this->assertTrue($this->isFileLocked($view, '/test//sub', ILockingProvider::LOCK_SHARED));
@@ -1532,14 +1535,14 @@ class ViewTest extends \Test\TestCase {
 	 * @param $shouldEmit
 	 */
 	public function testHookPaths($root, $path, $shouldEmit) {
-		$filesystemReflection = new \ReflectionClass('\OC\Files\Filesystem');
+		$filesystemReflection = new \ReflectionClass(Filesystem::class);
 		$defaultRootValue = $filesystemReflection->getProperty('defaultInstance');
 		$defaultRootValue->setAccessible(true);
 		$oldRoot = $defaultRootValue->getValue();
-		$defaultView = new \OC\Files\View('/foo/files');
+		$defaultView = new View('/foo/files');
 		$defaultRootValue->setValue($defaultView);
-		$view = new \OC\Files\View($root);
-		$result = $this->invokePrivate($view, 'shouldEmitHooks', [$path]);
+		$view = new View($root);
+		$result = self::invokePrivate($view, 'shouldEmitHooks', [$path]);
 		$defaultRootValue->setValue($oldRoot);
 		$this->assertEquals($shouldEmit, $result);
 	}
@@ -1553,7 +1556,7 @@ class ViewTest extends \Test\TestCase {
 	private function createTestMovableMountPoints($mountPoints) {
 		$mounts = [];
 		foreach ($mountPoints as $mountPoint) {
-			$storage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
+			$storage = $this->getMockBuilder(Temporary::class)
 				->setMethods([])
 				->getMock();
 
@@ -1563,6 +1566,7 @@ class ViewTest extends \Test\TestCase {
 				->getMock();
 		}
 
+		/** @var IMountProvider|\PHPUnit_Framework_MockObject_MockObject $mountProvider */
 		$mountProvider = $this->createMock(IMountProvider::class);
 		$mountProvider->expects($this->any())
 			->method('getMountsForUser')
@@ -1578,7 +1582,7 @@ class ViewTest extends \Test\TestCase {
 	 * Test mount point move
 	 */
 	public function testMountPointMove() {
-		$this->loginAsUser($this->user);
+		self::loginAsUser($this->user);
 
 		list($mount1, $mount2) = $this->createTestMovableMountPoints([
 			$this->user . '/files/mount1',
@@ -1592,7 +1596,7 @@ class ViewTest extends \Test\TestCase {
 			->method('moveMount')
 			->will($this->returnValue(true));
 
-		$view = new \OC\Files\View('/' . $this->user . '/files/');
+		$view = new View('/' . $this->user . '/files/');
 		$view->mkdir('sub');
 
 		$this->assertTrue($view->rename('mount1', 'renamed_mount'), 'Can rename mount point');
@@ -1603,7 +1607,7 @@ class ViewTest extends \Test\TestCase {
 	 * Test that moving a mount point into another is forbidden
 	 */
 	public function testMoveMountPointIntoAnother() {
-		$this->loginAsUser($this->user);
+		self::loginAsUser($this->user);
 
 		list($mount1, $mount2) = $this->createTestMovableMountPoints([
 			$this->user . '/files/mount1',
@@ -1616,7 +1620,7 @@ class ViewTest extends \Test\TestCase {
 		$mount2->expects($this->never())
 			->method('moveMount');
 
-		$view = new \OC\Files\View('/' . $this->user . '/files/');
+		$view = new View('/' . $this->user . '/files/');
 
 		$this->assertFalse($view->rename('mount1', 'mount2'), 'Cannot overwrite another mount point');
 		$this->assertFalse($view->rename('mount1', 'mount2/sub'), 'Cannot move a mount point into another');
@@ -1626,7 +1630,7 @@ class ViewTest extends \Test\TestCase {
 	 * Test that moving a mount point into a shared folder is forbidden
 	 */
 	public function testMoveMountPointIntoSharedFolder() {
-		$this->loginAsUser($this->user);
+		self::loginAsUser($this->user);
 
 		list($mount1) = $this->createTestMovableMountPoints([
 			$this->user . '/files/mount1',
@@ -1635,20 +1639,20 @@ class ViewTest extends \Test\TestCase {
 		$mount1->expects($this->never())
 			->method('moveMount');
 
-		$view = new \OC\Files\View('/' . $this->user . '/files/');
+		$view = new View('/' . $this->user . '/files/');
 		$view->mkdir('shareddir');
 		$view->mkdir('shareddir/sub');
 		$view->mkdir('shareddir/sub2');
 
 		$fileId = $view->getFileInfo('shareddir')->getId();
 		$userObject = \OC::$server->getUserManager()->createUser('test2', 'IHateNonMockableStaticClasses');
-		$this->assertTrue(\OCP\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, 'test2', \OCP\Constants::PERMISSION_READ));
+		$this->assertTrue(Share::shareItem('folder', $fileId, Share::SHARE_TYPE_USER, 'test2', Constants::PERMISSION_READ));
 
 		$this->assertFalse($view->rename('mount1', 'shareddir'), 'Cannot overwrite shared folder');
 		$this->assertFalse($view->rename('mount1', 'shareddir/sub'), 'Cannot move mount point into shared folder');
 		$this->assertFalse($view->rename('mount1', 'shareddir/sub/sub2'), 'Cannot move mount point into shared subfolder');
 
-		$this->assertTrue(\OCP\Share::unshare('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, 'test2'));
+		$this->assertTrue(Share::unshare('folder', $fileId, Share::SHARE_TYPE_USER, 'test2'));
 		$userObject->delete();
 	}
 
@@ -1772,7 +1776,7 @@ class ViewTest extends \Test\TestCase {
 	 * @param string $lockedPath path of the locked item to check
 	 * @param string $hookType hook type
 	 * @param int $expectedLockBefore expected lock during pre hooks
-	 * @param int $expectedLockduring expected lock during operation
+	 * @param int $expectedLockDuring expected lock during operation
 	 * @param int $expectedLockAfter expected lock during post hooks
 	 * @param int $expectedStrayLock expected lock after returning, should
 	 * be null (unlock) for most operations
@@ -1787,13 +1791,14 @@ class ViewTest extends \Test\TestCase {
 		$expectedLockAfter = ILockingProvider::LOCK_SHARED,
 		$expectedStrayLock = null
 	) {
-		$view = new \OC\Files\View('/' . $this->user . '/files/');
+		$view = new View('/' . $this->user . '/files/');
 
-		$storage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
+		/** @var Temporary|\PHPUnit_Framework_MockObject_MockObject $storage */
+		$storage = $this->getMockBuilder(Temporary::class)
 			->setMethods([$operation])
 			->getMock();
 
-		\OC\Files\Filesystem::mount($storage, array(), $this->user . '/');
+		Filesystem::mount($storage, array(), $this->user . '/');
 
 		// work directly on disk because mkdir might be mocked
 		$realPath = $storage->getSourcePath('');
@@ -1835,14 +1840,15 @@ class ViewTest extends \Test\TestCase {
 	 * This code path uses $storage->fopen instead
 	 */
 	public function testLockFilePutContentWithStream() {
-		$view = new \OC\Files\View('/' . $this->user . '/files/');
+		$view = new View('/' . $this->user . '/files/');
 
 		$path = 'test_file_put_contents.txt';
-		$storage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
+		/** @var Temporary|\PHPUnit_Framework_MockObject_MockObject $storage */
+		$storage = $this->getMockBuilder(Temporary::class)
 			->setMethods(['fopen'])
 			->getMock();
 
-		\OC\Files\Filesystem::mount($storage, array(), $this->user . '/');
+		Filesystem::mount($storage, array(), $this->user . '/');
 		$storage->mkdir('files');
 
 		$storage->expects($this->once())
@@ -1873,14 +1879,15 @@ class ViewTest extends \Test\TestCase {
 	 * Test locks for fopen with fclose at the end
 	 */
 	public function testLockFopen() {
-		$view = new \OC\Files\View('/' . $this->user . '/files/');
+		$view = new View('/' . $this->user . '/files/');
 
 		$path = 'test_file_put_contents.txt';
-		$storage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
+		/** @var Temporary|\PHPUnit_Framework_MockObject_MockObject $storage */
+		$storage = $this->getMockBuilder(Temporary::class)
 			->setMethods(['fopen'])
 			->getMock();
 
-		\OC\Files\Filesystem::mount($storage, array(), $this->user . '/');
+		Filesystem::mount($storage, array(), $this->user . '/');
 		$storage->mkdir('files');
 
 		$storage->expects($this->once())
@@ -1925,13 +1932,14 @@ class ViewTest extends \Test\TestCase {
 		$operationArgs,
 		$path
 	) {
-		$view = new \OC\Files\View('/' . $this->user . '/files/');
+		$view = new View('/' . $this->user . '/files/');
 
-		$storage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
+		/** @var Temporary|\PHPUnit_Framework_MockObject_MockObject $storage */
+		$storage = $this->getMockBuilder(Temporary::class)
 			->setMethods([$operation])
 			->getMock();
 
-		\OC\Files\Filesystem::mount($storage, array(), $this->user . '/');
+		Filesystem::mount($storage, array(), $this->user . '/');
 
 		// work directly on disk because mkdir might be mocked
 		$realPath = $storage->getSourcePath('');
@@ -1975,19 +1983,20 @@ class ViewTest extends \Test\TestCase {
 		$path,
 		$hookType
 	) {
-		$view = new \OC\Files\View('/' . $this->user . '/files/');
+		$view = new View('/' . $this->user . '/files/');
 
-		$storage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
+		/** @var Temporary|\PHPUnit_Framework_MockObject_MockObject $storage */
+		$storage = $this->getMockBuilder(Temporary::class)
 			->setMethods([$operation])
 			->getMock();
 
-		\OC\Files\Filesystem::mount($storage, array(), $this->user . '/');
+		Filesystem::mount($storage, array(), $this->user . '/');
 		$storage->mkdir('files');
 
-		\OCP\Util::connectHook(
-			\OC\Files\Filesystem::CLASSNAME,
+		Util::connectHook(
+			Filesystem::CLASSNAME,
 			$hookType,
-			'\Test\HookHelper',
+			HookHelper::class,
 			'cancellingCallback'
 		);
 
@@ -2013,9 +2022,10 @@ class ViewTest extends \Test\TestCase {
 	 * the operation
 	 */
 	public function testLockFileRename($operation, $expectedLockTypeSourceDuring) {
-		$view = new \OC\Files\View('/' . $this->user . '/files/');
+		$view = new View('/' . $this->user . '/files/');
 
-		$storage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
+		/** @var Temporary|\PHPUnit_Framework_MockObject_MockObject $storage */
+		$storage = $this->getMockBuilder(Temporary::class)
 			->setMethods([$operation, 'filemtime'])
 			->getMock();
 
@@ -2026,7 +2036,7 @@ class ViewTest extends \Test\TestCase {
 		$sourcePath = 'original.txt';
 		$targetPath = 'target.txt';
 
-		\OC\Files\Filesystem::mount($storage, array(), $this->user . '/');
+		Filesystem::mount($storage, array(), $this->user . '/');
 		$storage->mkdir('files');
 		$view->file_put_contents($sourcePath, 'meh');
 
@@ -2068,16 +2078,17 @@ class ViewTest extends \Test\TestCase {
 	 * @expectedException \Exception
 	 */
 	public function testLockFileCopyException() {
-		$view = new \OC\Files\View('/' . $this->user . '/files/');
+		$view = new View('/' . $this->user . '/files/');
 
-		$storage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
+		/** @var Temporary|\PHPUnit_Framework_MockObject_MockObject $storage */
+		$storage = $this->getMockBuilder(Temporary::class)
 			->setMethods(['copy'])
 			->getMock();
 
 		$sourcePath = 'original.txt';
 		$targetPath = 'target.txt';
 
-		\OC\Files\Filesystem::mount($storage, array(), $this->user . '/');
+		Filesystem::mount($storage, array(), $this->user . '/');
 		$storage->mkdir('files');
 		$view->file_put_contents($sourcePath, 'meh');
 
@@ -2108,9 +2119,9 @@ class ViewTest extends \Test\TestCase {
 	 * Test rename operation: unlock first path when second path was locked
 	 */
 	public function testLockFileRenameUnlockOnException() {
-		$this->loginAsUser('test');
+		self::loginAsUser('test');
 
-		$view = new \OC\Files\View('/' . $this->user . '/files/');
+		$view = new View('/' . $this->user . '/files/');
 
 		$sourcePath = 'original.txt';
 		$targetPath = 'target.txt';
@@ -2125,7 +2136,7 @@ class ViewTest extends \Test\TestCase {
 		$thrown = false;
 		try {
 			$view->rename($sourcePath, $targetPath);
-		} catch (\OCP\Lock\LockedException $e) {
+		} catch (LockedException $e) {
 			$thrown = true;
 		}
 
@@ -2141,9 +2152,9 @@ class ViewTest extends \Test\TestCase {
 	 * Test rename operation: unlock first path when second path was locked
 	 */
 	public function testGetOwner() {
-		$this->loginAsUser('test');
+		self::loginAsUser('test');
 
-		$view = new \OC\Files\View('/test/files/');
+		$view = new View('/test/files/');
 
 		$path = 'foo.txt';
 		$view->file_put_contents($path, 'meh');
@@ -2158,7 +2169,7 @@ class ViewTest extends \Test\TestCase {
 		$this->assertEquals('test', $folderInfo[0]->getOwner()->getUID());
 
 		$subStorage = new Temporary();
-		\OC\Files\Filesystem::mount($subStorage, [], '/test/files/asd');
+		Filesystem::mount($subStorage, [], '/test/files/asd');
 
 		$folderInfo = $view->getDirectoryContent('');
 		$folderInfo = array_values(array_filter($folderInfo, function (FileInfo $info) {
@@ -2186,12 +2197,14 @@ class ViewTest extends \Test\TestCase {
 	 * the operation
 	 */
 	public function testLockFileRenameCrossStorage($viewOperation, $storageOperation, $expectedLockTypeSourceDuring) {
-		$view = new \OC\Files\View('/' . $this->user . '/files/');
+		$view = new View('/' . $this->user . '/files/');
 
-		$storage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
+		/** @var Temporary|\PHPUnit_Framework_MockObject_MockObject $storage */
+		$storage = $this->getMockBuilder(Temporary::class)
 			->setMethods([$storageOperation])
 			->getMock();
-		$storage2 = $this->getMockBuilder('\OC\Files\Storage\Temporary')
+		/** @var Temporary|\PHPUnit_Framework_MockObject_MockObject $storage2 */
+		$storage2 = $this->getMockBuilder(Temporary::class)
 			->setMethods([$storageOperation, 'filemtime'])
 			->getMock();
 
@@ -2202,8 +2215,8 @@ class ViewTest extends \Test\TestCase {
 		$sourcePath = 'original.txt';
 		$targetPath = 'substorage/target.txt';
 
-		\OC\Files\Filesystem::mount($storage, array(), $this->user . '/');
-		\OC\Files\Filesystem::mount($storage2, array(), $this->user . '/files/substorage');
+		Filesystem::mount($storage, array(), $this->user . '/');
+		Filesystem::mount($storage2, array(), $this->user . '/files/substorage');
 		$storage->mkdir('files');
 		$view->file_put_contents($sourcePath, 'meh');
 
@@ -2244,13 +2257,13 @@ class ViewTest extends \Test\TestCase {
 	 * Test locks when moving a mount point
 	 */
 	public function testLockMoveMountPoint() {
-		$this->loginAsUser('test');
+		self::loginAsUser('test');
 
 		list($mount) = $this->createTestMovableMountPoints([
 			$this->user . '/files/substorage',
 		]);
 
-		$view = new \OC\Files\View('/' . $this->user . '/files/');
+		$view = new View('/' . $this->user . '/files/');
 		$view->mkdir('subdir');
 
 		$sourcePath = 'substorage';
@@ -2305,7 +2318,7 @@ class ViewTest extends \Test\TestCase {
 	 * Connect hook callbacks for hook type
 	 *
 	 * @param string $hookType hook type or null for none
-	 * @param \OC\Files\View $view view to check the lock on
+	 * @param View $view view to check the lock on
 	 * @param string $path path for which to check the lock
 	 * @param int $lockTypePre variable to receive lock type that was active in the pre-hook
 	 * @param int $lockTypePost variable to receive lock type that was active in the post-hook
@@ -2337,14 +2350,14 @@ class ViewTest extends \Test\TestCase {
 			));
 
 		if ($hookType !== null) {
-			\OCP\Util::connectHook(
-				\OC\Files\Filesystem::CLASSNAME,
+			Util::connectHook(
+				Filesystem::CLASSNAME,
 				$hookType,
 				$eventHandler,
 				'preCallback'
 			);
-			\OCP\Util::connectHook(
-				\OC\Files\Filesystem::CLASSNAME,
+			Util::connectHook(
+				Filesystem::CLASSNAME,
 				'post_' . $hookType,
 				$eventHandler,
 				'postCallback'
@@ -2355,14 +2368,14 @@ class ViewTest extends \Test\TestCase {
 	/**
 	 * Returns the file lock type
 	 *
-	 * @param \OC\Files\View $view view
+	 * @param View $view view
 	 * @param string $path path
 	 * @param bool $onMountPoint true to check the mount point instead of the
 	 * mounted storage
 	 *
 	 * @return int lock type or null if file was not locked
 	 */
-	private function getFileLockType(\OC\Files\View $view, $path, $onMountPoint = false) {
+	private function getFileLockType(View $view, $path, $onMountPoint = false) {
 		if ($this->isFileLocked($view, $path, ILockingProvider::LOCK_EXCLUSIVE, $onMountPoint)) {
 			return ILockingProvider::LOCK_EXCLUSIVE;
 		} else if ($this->isFileLocked($view, $path, ILockingProvider::LOCK_SHARED, $onMountPoint)) {
@@ -2376,9 +2389,8 @@ class ViewTest extends \Test\TestCase {
 		$mountPoint = '/' . $this->user . '/files/mount/';
 
 		// Mock the mount point
-		$mount = $this->getMockBuilder('\Test\TestMoveableMountPoint')
-			->disableOriginalConstructor()
-			->getMock();
+		/** @var TestMoveableMountPoint|\PHPUnit_Framework_MockObject_MockObject $mount */
+		$mount = $this->createMock(TestMoveableMountPoint::class);
 		$mount->expects($this->once())
 			->method('getMountPoint')
 			->willReturn($mountPoint);
@@ -2390,7 +2402,7 @@ class ViewTest extends \Test\TestCase {
 			->willReturn('');
 
 		// Register mount
-		\OC\Files\Filesystem::getMountManager()->addMount($mount);
+		Filesystem::getMountManager()->addMount($mount);
 
 		// Listen for events
 		$eventHandler = $this->getMockBuilder('\stdclass')
@@ -2398,25 +2410,25 @@ class ViewTest extends \Test\TestCase {
 			->getMock();
 		$eventHandler->expects($this->once())
 			->method('umount')
-			->with([\OC\Files\Filesystem::signal_param_path => '/mount']);
+			->with([Filesystem::signal_param_path => '/mount']);
 		$eventHandler->expects($this->once())
 			->method('post_umount')
-			->with([\OC\Files\Filesystem::signal_param_path => '/mount']);
-		\OCP\Util::connectHook(
-			\OC\Files\Filesystem::CLASSNAME,
+			->with([Filesystem::signal_param_path => '/mount']);
+		Util::connectHook(
+			Filesystem::CLASSNAME,
 			'umount',
 			$eventHandler,
 			'umount'
 		);
-		\OCP\Util::connectHook(
-			\OC\Files\Filesystem::CLASSNAME,
+		Util::connectHook(
+			Filesystem::CLASSNAME,
 			'post_umount',
 			$eventHandler,
 			'post_umount'
 		);
 
 		//Delete the mountpoint
-		$view = new \OC\Files\View('/' . $this->user . '/files');
+		$view = new View('/' . $this->user . '/files');
 		$this->assertEquals('foo', $view->rmdir('mount'));
 	}
 
@@ -2436,9 +2448,9 @@ class ViewTest extends \Test\TestCase {
 	 */
 	public function testGetDirectoryContentMimeFilter($filter, $expected) {
 		$storage1 = new Temporary();
-		$root = $this->getUniqueID('/');
-		\OC\Files\Filesystem::mount($storage1, array(), $root . '/');
-		$view = new \OC\Files\View($root);
+		$root = self::getUniqueID('/');
+		Filesystem::mount($storage1, array(), $root . '/');
+		$view = new View($root);
 
 		$view->file_put_contents('test1.txt', 'asd');
 		$view->file_put_contents('test2.txt', 'asd');
@@ -2459,10 +2471,10 @@ class ViewTest extends \Test\TestCase {
 		$storage = new Temporary(array());
 		$scanner = $storage->getScanner();
 		$storage->file_put_contents('foo.txt', 'bar');
-		\OC\Files\Filesystem::mount($storage, array(), '/test/');
+		Filesystem::mount($storage, array(), '/test/');
 		$scanner->scan('');
 
-		$view = new \OC\Files\View('/test/foo.txt');
+		$view = new View('/test/foo.txt');
 		$view->putFileInfo('.', ['checksum' => '42']);
 
 		$this->assertEquals('bar', $view->file_get_contents(''));
@@ -2480,14 +2492,14 @@ class ViewTest extends \Test\TestCase {
 		$scanner = $storage->getScanner();
 		$cache = $storage->getCache();
 		$storage->file_put_contents('foo.txt', 'bar');
-		\OC\Files\Filesystem::mount($storage, array(), '/test/');
+		Filesystem::mount($storage, array(), '/test/');
 		$scanner->scan('');
 
 		$storage->unlink('foo.txt');
 
 		$this->assertTrue($cache->inCache('foo.txt'));
 
-		$view = new \OC\Files\View('/test');
+		$view = new View('/test');
 		$rootInfo = $view->getFileInfo('');
 		$this->assertEquals(3, $rootInfo->getSize());
 		$view->unlink('foo.txt');
@@ -2504,7 +2516,7 @@ class ViewTest extends \Test\TestCase {
 		$cache = $storage->getCache();
 		$storage->mkdir('foo');
 		$storage->file_put_contents('foo/foo.txt', 'bar');
-		\OC\Files\Filesystem::mount($storage, array(), '/test/');
+		Filesystem::mount($storage, array(), '/test/');
 		$scanner->scan('');
 
 		$storage->rmdir('foo');
@@ -2512,7 +2524,7 @@ class ViewTest extends \Test\TestCase {
 		$this->assertTrue($cache->inCache('foo'));
 		$this->assertTrue($cache->inCache('foo/foo.txt'));
 
-		$view = new \OC\Files\View('/test');
+		$view = new View('/test');
 		$rootInfo = $view->getFileInfo('');
 		$this->assertEquals(3, $rootInfo->getSize());
 		$view->rmdir('foo');

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -515,6 +515,30 @@ class ViewTest extends \Test\TestCase {
 		$this->assertFalse($rootView->file_exists('substorage/bar.txt'));
 	}
 
+	public function rmdirOrUnlinkDataProvider() {
+		return [['rmdir'], ['unlink']];
+	}
+
+	/**
+	 * @dataProvider rmdirOrUnlinkDataProvider
+	 */
+	public function testRmdir($method) {
+		$storage1 = $this->getTestStorage();
+		$storage2 = $this->getTestStorage();
+		Filesystem::mount($storage1, [], '/');
+
+		$rootView = new View('');
+		$rootView->mkdir('sub');
+		$rootView->mkdir('sub/deep');
+		$rootView->file_put_contents('/sub/deep/foo.txt', 'asd');
+
+		$this->assertTrue($rootView->file_exists('sub/deep/foo.txt'));
+
+		$this->assertTrue($rootView->$method('sub'));
+
+		$this->assertFalse($rootView->file_exists('sub'));
+	}
+
 	/**
 	 * @medium
 	 */

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -524,8 +524,7 @@ class ViewTest extends \Test\TestCase {
 	 */
 	public function testRmdir($method) {
 		$storage1 = $this->getTestStorage();
-		$storage2 = $this->getTestStorage();
-		Filesystem::mount($storage1, [], '/');
+		\OC\Files\Filesystem::mount($storage1, [], '/');
 
 		$rootView = new View('');
 		$rootView->mkdir('sub');


### PR DESCRIPTION
Many API callers will call unlink even for directories and it can mess
up with some wrappers like the encryption wrapper

* downstream https://github.com/owncloud/core/pull/27101