### PR TITLE
Create a notification when the update server couldn't be reached for …

### DIFF
--- a/apps/updatenotification/lib/Notification/BackgroundJob.php
+++ b/apps/updatenotification/lib/Notification/BackgroundJob.php
@@ -98,11 +98,13 @@ class BackgroundJob extends TimedJob {
 			if (in_array($errors, $this->connectionNotifications, true)) {
 				$this->sendErrorNotifications($errors);
 			}
-		} else if (isset($status['version'])) {
+		} else if (is_array($status)) {
 			$this->config->setAppValue('updatenotification', 'update_check_errors', 0);
 			$this->clearErrorNotifications();
 
-			$this->createNotifications('core', $status['version'], $status['versionstring']);
+			if (isset($status['version'])) {
+				$this->createNotifications('core', $status['version'], $status['versionstring']);
+			}
 		}
 	}
 

--- a/apps/updatenotification/tests/Notification/BackgroundJobTest.php
+++ b/apps/updatenotification/tests/Notification/BackgroundJobTest.php
@@ -166,7 +166,7 @@ class BackgroundJobTest extends TestCase {
 		if ($version === null) {
 			$job->expects($this->never())
 				->method('createNotifications');
-			$job->expects($this->never())
+			$job->expects($versionCheck === null ? $this->never() : $this->once())
 				->method('clearErrorNotifications');
 		} else if ($version === false) {
 			$job->expects($this->never())

--- a/apps/updatenotification/tests/Notification/NotifierTest.php
+++ b/apps/updatenotification/tests/Notification/NotifierTest.php
@@ -24,6 +24,7 @@ namespace OCA\UpdateNotification\Tests\Notification;
 
 
 use OCA\UpdateNotification\Notification\Notifier;
+use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
@@ -36,6 +37,8 @@ class NotifierTest extends TestCase {
 
 	/** @var IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
 	protected $urlGenerator;
+	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	protected $config;
 	/** @var IManager|\PHPUnit_Framework_MockObject_MockObject */
 	protected $notificationManager;
 	/** @var IFactory|\PHPUnit_Framework_MockObject_MockObject */
@@ -49,6 +52,7 @@ class NotifierTest extends TestCase {
 		parent::setUp();
 
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->config = $this->createMock(IConfig::class);
 		$this->notificationManager = $this->createMock(IManager::class);
 		$this->l10nFactory = $this->createMock(IFactory::class);
 		$this->userSession = $this->createMock(IUserSession::class);
@@ -63,6 +67,7 @@ class NotifierTest extends TestCase {
 		if (empty($methods)) {
 			return new Notifier(
 				$this->urlGenerator,
+				$this->config,
 				$this->notificationManager,
 				$this->l10nFactory,
 				$this->userSession,
@@ -72,6 +77,7 @@ class NotifierTest extends TestCase {
 			return $this->getMockBuilder(Notifier::class)
 				->setConstructorArgs([
 					$this->urlGenerator,
+					$this->config,
 					$this->notificationManager,
 					$this->l10nFactory,
 					$this->userSession,

--- a/lib/private/Updater/VersionCheck.php
+++ b/lib/private/Updater/VersionCheck.php
@@ -82,7 +82,12 @@ class VersionCheck {
 		$url = $updaterUrl . '?version=' . $versionString;
 
 		$tmp = [];
-		$xml = $this->getUrlContent($url);
+		try {
+			$xml = $this->getUrlContent($url);
+		} catch (\Exception $e) {
+			return false;
+		}
+
 		if ($xml) {
 			$loadEntities = libxml_disable_entity_loader(true);
 			$data = @simplexml_load_string($xml);
@@ -108,16 +113,13 @@ class VersionCheck {
 	/**
 	 * @codeCoverageIgnore
 	 * @param string $url
-	 * @return bool|resource|string
+	 * @return resource|string
+	 * @throws \Exception
 	 */
 	protected function getUrlContent($url) {
-		try {
-			$client = $this->clientService->newClient();
-			$response = $client->get($url);
-			return $response->getBody();
-		} catch (\Exception $e) {
-			return false;
-		}
+		$client = $this->clientService->newClient();
+		$response = $client->get($url);
+		return $response->getBody();
 	}
 }
 


### PR DESCRIPTION
Notifications are generated after: 3, 7, 14 and 30 errors (days)

### For testing
https://github.com/nextcloud/server/blob/cb8e1215fe19e12496b99c38704aa51facadaede/apps/updatenotification/lib/Notification/BackgroundJob.php#L68-L68
```php
$this->setInterval(1);
```
https://github.com/nextcloud/server/blob/cb8e1215fe19e12496b99c38704aa51facadaede/apps/updatenotification/lib/Notification/BackgroundJob.php#L248-L248
```php
return 'stable';
```
https://github.com/nextcloud/server/blob/cb8e1215fe19e12496b99c38704aa51facadaede/lib/private/Updater/VersionCheck.php#L59-L59
```php
#return json_decode($this->config->getAppValue('core', 'lastupdateResult'), true);
```
### To error
https://github.com/nextcloud/server/blob/5679f04cb1a7fb761590b3a6b501044ddeeebc01/lib/private/Http/Client/Client.php#L67-L78
```php
$this->client->setDefaultOption('verify', '');
```