### PR TITLE
Move Interface Definitions to the ServerContainer

### DIFF
--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -82,10 +82,6 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		/**
 		 * Core services
 		 */
-		$this->registerService('OCP\\IAppConfig', function($c) {
-			return $this->getServer()->getAppConfig();
-		});
-
 		$this->registerService('OCP\\App\\IAppManager', function($c) {
 			return $this->getServer()->getAppManager();
 		});
@@ -123,10 +119,6 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 
 		$this->registerService('OCP\Comments\ICommentsManager', function($c) {
 			return $this->getServer()->getCommentsManager();
-		});
-
-		$this->registerService('OCP\\IConfig', function($c) {
-			return $this->getServer()->getConfig();
 		});
 
 		$this->registerService('OCP\\Contacts\\IManager', function($c) {

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -43,12 +43,11 @@ use OC\AppFramework\Middleware\OCSMiddleware;
 use OC\AppFramework\Middleware\Security\SecurityMiddleware;
 use OC\AppFramework\Middleware\SessionMiddleware;
 use OC\AppFramework\Utility\SimpleContainer;
-use OC\AppFramework\Utility\TimeFactory;
 use OC\Core\Middleware\TwoFactorMiddleware;
 use OC\RichObjectStrings\Validator;
-use OC\Security\Bruteforce\Throttler;
 use OCP\AppFramework\IApi;
 use OCP\AppFramework\IAppContainer;
+use OCP\AppFramework\QueryException;
 use OCP\Federation\ICloudIdManager;
 use OCP\Files\IAppData;
 use OCP\Files\Mount\IMountManager;
@@ -568,7 +567,16 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		});
 	}
 
-	public function query($name) {
-		return parent::query($name);
+	public function query($name, $checkServerContainer = true) {
+		$name = $this->sanitizeName($name);
+		try {
+			return parent::query($name);
+		} catch (QueryException $e) {
+			if ($checkServerContainer === false) {
+				throw $e;
+			}
+		}
+
+		return $this->getServer()->query($name);
 	}
 }

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -559,13 +559,17 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		});
 	}
 
-	public function query($name, $checkServerContainer = true) {
+	public function query($name) {
 		$name = $this->sanitizeName($name);
+
 		try {
 			return parent::query($name);
 		} catch (QueryException $e) {
-			if ($checkServerContainer === false) {
-				throw $e;
+			if (strpos($name, 'OCA\\') === 0 && substr_count($name, '\\') >= 2) {
+				$segments = explode('\\', $name);
+				if (strtolower($segments[1]) === strtolower($this['AppName'])) {
+					throw new QueryException();
+				}
 			}
 		}
 

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -51,6 +51,7 @@ use OCP\AppFramework\QueryException;
 use OCP\Federation\ICloudIdManager;
 use OCP\Files\IAppData;
 use OCP\Files\Mount\IMountManager;
+use OCP\IServerContainer;
 use OCP\RichObjectStrings\IValidator;
 use OCP\Util;
 
@@ -61,18 +62,25 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 	 */
 	private $middleWares = array();
 
+	/** @var IServerContainer */
+	private $server;
+
 	/**
 	 * Put your class dependencies in here
 	 * @param string $appName the name of the app
+	 * @param array $urlParams
+	 * @param IServerContainer $server
 	 */
-	public function __construct($appName, $urlParams = array()){
+	public function __construct($appName, $urlParams = array(), IServerContainer $server = null){
 		parent::__construct();
 		$this['AppName'] = $appName;
 		$this['urlParams'] = $urlParams;
 
 		/** @var \OC\ServerContainer $server */
-		$server = $this->getServer();
-		$server->registerAppContainer($appName, $this);
+		if ($server === null) {
+			$this->server = \OC::$server;
+		}
+		$this->server->registerAppContainer($appName, $this);
 
 		// aliases
 		$this->registerAlias('appName', 'AppName');
@@ -481,7 +489,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 	 */
 	function getServer()
 	{
-		return OC::$server;
+		return $this->server;
 	}
 
 	/**

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -92,10 +92,6 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		/**
 		 * Core services
 		 */
-		$this->registerService('OCP\\App\\IAppManager', function($c) {
-			return $this->getServer()->getAppManager();
-		});
-
 		$this->registerService('OCP\\AppFramework\\Http\\IOutput', function($c){
 			return new Output($this->getServer()->getWebRoot());
 		});
@@ -117,10 +113,6 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 
 		$this->registerService('OCP\\ICache', function($c) {
 			return $this->getServer()->getCache();
-		});
-
-		$this->registerService('OCP\\ICacheFactory', function($c) {
-			return $this->getServer()->getMemCacheFactory();
 		});
 
 		$this->registerService('OC\\CapabilitiesManager', function($c) {
@@ -241,10 +233,6 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 
 		$this->registerService('OCP\\ITagManager', function($c) {
 			return $this->getServer()->getTagManager();
-		});
-
-		$this->registerService('OCP\\ITempManager', function($c) {
-			return $this->getServer()->getTempManager();
 		});
 
 		$this->registerAlias('OCP\\AppFramework\\Utility\\ITimeFactory', 'OC\AppFramework\Utility\TimeFactory');
@@ -580,6 +568,8 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				if (strtolower($segments[1]) === strtolower($this['AppName'])) {
 					return parent::query($name);
 				}
+			} else if ($this['AppName'] === 'settings' && strpos($name, 'OC\\Settings\\') === 0) {
+				return parent::query($name);
 			}
 		}
 

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -386,6 +386,8 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				}
 			} else if ($this['AppName'] === 'settings' && strpos($name, 'OC\\Settings\\') === 0) {
 				return parent::query($name);
+			} else if ($this['AppName'] === 'core' && strpos($name, 'OC\\Core\\') === 0) {
+				return parent::query($name);
 			}
 		}
 

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -46,13 +46,15 @@ use OC\AppFramework\Utility\SimpleContainer;
 use OC\Core\Middleware\TwoFactorMiddleware;
 use OC\RichObjectStrings\Validator;
 use OC\ServerContainer;
+use OCP\AppFramework\Http\IOutput;
 use OCP\AppFramework\IApi;
 use OCP\AppFramework\IAppContainer;
-use OCP\AppFramework\QueryException;
-use OCP\Federation\ICloudIdManager;
+use OCP\Files\Folder;
 use OCP\Files\IAppData;
-use OCP\Files\Mount\IMountManager;
+use OCP\IL10N;
+use OCP\IRequest;
 use OCP\IServerContainer;
+use OCP\IUserSession;
 use OCP\RichObjectStrings\IValidator;
 use OCP\Util;
 
@@ -92,232 +94,46 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		/**
 		 * Core services
 		 */
-		$this->registerService('OCP\\AppFramework\\Http\\IOutput', function($c){
+		$this->registerService(IOutput::class, function($c){
 			return new Output($this->getServer()->getWebRoot());
 		});
 
-		$this->registerService(\OCP\Authentication\LoginCredentials\IStore::class, function() {
-			return $this->getServer()->query(\OCP\Authentication\LoginCredentials\IStore::class);
-		});
-
-		$this->registerService('OCP\\IAvatarManager', function($c) {
-			return $this->getServer()->getAvatarManager();
-		});
-
-		$this->registerService('OCP\\Activity\\IManager', function($c) {
-			return $this->getServer()->getActivityManager();
-		});
-		$this->registerService(\OCP\Activity\IEventMerger::class, function($c) {
-			return $this->getServer()->query(\OCP\Activity\IEventMerger::class);
-		});
-
-		$this->registerService('OCP\\ICache', function($c) {
-			return $this->getServer()->getCache();
-		});
-
-		$this->registerService('OC\\CapabilitiesManager', function($c) {
-			return $this->getServer()->getCapabilitiesManager();
-		});
-
-		$this->registerService('OCP\Comments\ICommentsManager', function($c) {
-			return $this->getServer()->getCommentsManager();
-		});
-
-		$this->registerService('OCP\\Contacts\\IManager', function($c) {
-			return $this->getServer()->getContactsManager();
-		});
-
-		$this->registerService('OCP\\IDateTimeZone', function($c) {
-			return $this->getServer()->getDateTimeZone();
-		});
-
-		$this->registerService('OCP\\IDateTimeFormatter', function($c) {
-			return $this->getServer()->getDateTimeFormatter();
-		});
-
-		$this->registerService('OCP\\IDBConnection', function($c) {
-			return $this->getServer()->getDatabaseConnection();
-		});
-
-		$this->registerService('OCP\\Diagnostics\\IEventLogger', function($c) {
-			return $this->getServer()->getEventLogger();
-		});
-
-		$this->registerService('OCP\\Diagnostics\\IQueryLogger', function($c) {
-			return $this->getServer()->getQueryLogger();
-		});
-
-		$this->registerService(ICloudIdManager::class, function($c) {
-			return $this->getServer()->getCloudIdManager();
-		});
-
-		$this->registerService('OCP\\Files\\IMimeTypeDetector', function($c) {
-			return $this->getServer()->getMimeTypeDetector();
-		});
-
-		$this->registerService('OCP\\Files\\Config\\IMountProviderCollection', function($c) {
-			return $this->getServer()->getMountProviderCollection();
-		});
-
-		$this->registerService('OCP\\Files\\Config\\IUserMountCache', function($c) {
-			return $this->getServer()->getUserMountCache();
-		});
-
-		$this->registerService('OCP\\Files\\IRootFolder', function($c) {
-			return $this->getServer()->getRootFolder();
-		});
-
-		$this->registerService('OCP\\Files\\Folder', function() {
+		$this->registerService(Folder::class, function() {
 			return $this->getServer()->getUserFolder();
-		});
-
-		$this->registerService('OCP\\Http\\Client\\IClientService', function($c) {
-			return $this->getServer()->getHTTPClientService();
 		});
 
 		$this->registerService(IAppData::class, function (SimpleContainer $c) {
 			return $this->getServer()->getAppDataDir($c->query('AppName'));
 		});
 
-		$this->registerService('OCP\\IGroupManager', function($c) {
-			return $this->getServer()->getGroupManager();
-		});
-
-		$this->registerService('OCP\\Http\\Client\\IClientService', function() {
-			return $this->getServer()->getHTTPClientService();
-		});
-
-		$this->registerService('OCP\\IL10N', function($c) {
+		$this->registerService(IL10N::class, function($c) {
 			return $this->getServer()->getL10N($c->query('AppName'));
 		});
 
-		$this->registerService('OCP\\L10N\\IFactory', function($c) {
-			return $this->getServer()->getL10NFactory();
+		$this->registerAlias(\OCP\AppFramework\Utility\IControllerMethodReflector::class, \OC\AppFramework\Utility\ControllerMethodReflector::class);
+		$this->registerAlias('ControllerMethodReflector', \OCP\AppFramework\Utility\IControllerMethodReflector::class);
+
+		$this->registerService(IRequest::class, function() {
+			return $this->getServer()->query(IRequest::class);
 		});
+		$this->registerAlias('Request', IRequest::class);
 
-		$this->registerService('OCP\\ILogger', function($c) {
-			return $this->getServer()->getLogger();
-		});
+		$this->registerAlias(\OCP\AppFramework\Utility\ITimeFactory::class, \OC\AppFramework\Utility\TimeFactory::class);
+		$this->registerAlias('TimeFactory', \OCP\AppFramework\Utility\ITimeFactory::class);
 
-		$this->registerService('OCP\\BackgroundJob\\IJobList', function($c) {
-			return $this->getServer()->getJobList();
-		});
-
-		$this->registerAlias('OCP\\AppFramework\\Utility\\IControllerMethodReflector', 'OC\AppFramework\Utility\ControllerMethodReflector');
-		$this->registerAlias('ControllerMethodReflector', 'OCP\\AppFramework\\Utility\\IControllerMethodReflector');
-
-		$this->registerService('OCP\\Files\\IMimeTypeDetector', function($c) {
-			return $this->getServer()->getMimeTypeDetector();
-		});
-
-		$this->registerService('OCP\\Mail\\IMailer', function() {
-			return $this->getServer()->getMailer();
-		});
-
-		$this->registerService('OCP\\INavigationManager', function($c) {
-			return $this->getServer()->getNavigationManager();
-		});
-
-		$this->registerService('OCP\\Notification\IManager', function($c) {
-			return $this->getServer()->getNotificationManager();
-		});
-
-		$this->registerService('OCP\\IPreview', function($c) {
-			return $this->getServer()->getPreviewManager();
-		});
-
-		$this->registerService('OCP\\IRequest', function () {
-			return $this->getServer()->getRequest();
-		});
-		$this->registerAlias('Request', 'OCP\\IRequest');
-
-		$this->registerService('OCP\\ITagManager', function($c) {
-			return $this->getServer()->getTagManager();
-		});
-
-		$this->registerAlias('OCP\\AppFramework\\Utility\\ITimeFactory', 'OC\AppFramework\Utility\TimeFactory');
-		$this->registerAlias('TimeFactory', 'OCP\\AppFramework\\Utility\\ITimeFactory');
-
-
-		$this->registerService('OCP\\Route\\IRouter', function($c) {
-			return $this->getServer()->getRouter();
-		});
-
-		$this->registerService('OCP\\ISearch', function($c) {
-			return $this->getServer()->getSearch();
-		});
-
-		$this->registerService('OCP\\ISearch', function($c) {
-			return $this->getServer()->getSearch();
-		});
-
-		$this->registerService('OCP\\Security\\ICrypto', function($c) {
-			return $this->getServer()->getCrypto();
-		});
-
-		$this->registerService('OCP\\Security\\IHasher', function($c) {
-			return $this->getServer()->getHasher();
-		});
-
-		$this->registerService('OCP\\Security\\ICredentialsManager', function($c) {
-			return $this->getServer()->getCredentialsManager();
-		});
-
-		$this->registerService('OCP\\Security\\ISecureRandom', function($c) {
-			return $this->getServer()->getSecureRandom();
-		});
-
-		$this->registerService('OCP\\Share\\IManager', function($c) {
-			return $this->getServer()->getShareManager();
-		});
-
-		$this->registerService('OCP\\SystemTag\\ISystemTagManager', function() {
-			return $this->getServer()->getSystemTagManager();
-		});
-
-		$this->registerService('OCP\\SystemTag\\ISystemTagObjectMapper', function() {
-			return $this->getServer()->getSystemTagObjectMapper();
-		});
-
-		$this->registerService('OCP\\IURLGenerator', function($c) {
-			return $this->getServer()->getURLGenerator();
-		});
-
-		$this->registerService('OCP\\IUserManager', function($c) {
-			return $this->getServer()->getUserManager();
-		});
-
-		$this->registerService('OCP\\IUserSession', function($c) {
-			return $this->getServer()->getUserSession();
-		});
 		$this->registerAlias(\OC\User\Session::class, \OCP\IUserSession::class);
 
-		$this->registerService('OCP\\ISession', function($c) {
-			return $this->getServer()->getSession();
-		});
-
-		$this->registerService('OCP\\Security\\IContentSecurityPolicyManager', function($c) {
-			return $this->getServer()->getContentSecurityPolicyManager();
-		});
-
-		$this->registerService('ServerContainer', function ($c) {
+		$this->registerService(IServerContainer::class, function ($c) {
 			return $this->getServer();
 		});
-		$this->registerAlias('OCP\\IServerContainer', 'ServerContainer');
+		$this->registerAlias('ServerContainer', IServerContainer::class);
 
-		$this->registerService('Symfony\Component\EventDispatcher\EventDispatcherInterface', function ($c) {
-			return $this->getServer()->getEventDispatcher();
-		});
-
-		$this->registerService('OCP\WorkflowEngine\IManager', function ($c) {
+		$this->registerService(\OCP\WorkflowEngine\IManager::class, function ($c) {
 			return $c->query('OCA\WorkflowEngine\Manager');
 		});
 
-		$this->registerService('OCP\\AppFramework\\IAppContainer', function ($c) {
+		$this->registerService(\OCP\AppFramework\IAppContainer::class, function ($c) {
 			return $c;
-		});
-		$this->registerService(IMountManager::class, function () {
-			return $this->getServer()->getMountManager();
 		});
 
 		// commonly used attributes
@@ -417,7 +233,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return new CORSMiddleware(
 				$c['Request'],
 				$c['ControllerMethodReflector'],
-				$c['OCP\IUserSession'],
+				$c->query(IUserSession::class),
 				$c->getServer()->getBruteForceThrottler()
 			);
 		});

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -338,17 +338,25 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getUserSession(),
 				$c->getGroupManager());
 		});
-		$this->registerService('AllConfig', function (Server $c) {
+
+		$this->registerService(\OC\AllConfig::class, function (Server $c) {
 			return new \OC\AllConfig(
 				$c->getSystemConfig()
 			);
 		});
+		$this->registerAlias('AllConfig', \OC\AllConfig::class);
+		$this->registerAlias(\OCP\IConfig::class, \OC\AllConfig::class);
+
 		$this->registerService('SystemConfig', function ($c) use ($config) {
 			return new \OC\SystemConfig($config);
 		});
-		$this->registerService('AppConfig', function (Server $c) {
+
+		$this->registerService(\OC\AppConfig::class, function (Server $c) {
 			return new \OC\AppConfig($c->getDatabaseConnection());
 		});
+		$this->registerAlias('AppConfig', \OC\AppConfig::class);
+		$this->registerAlias(\OCP\IAppConfig::class, \OC\AppConfig::class);
+
 		$this->registerService('L10NFactory', function (Server $c) {
 			return new \OC\L10N\Factory(
 				$c->getConfig(),

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -46,6 +46,7 @@ use OC\App\AppManager;
 use OC\App\AppStore\Fetcher\AppFetcher;
 use OC\App\AppStore\Fetcher\CategoryFetcher;
 use OC\AppFramework\Http\Request;
+use OC\AppFramework\Utility\SimpleContainer;
 use OC\AppFramework\Utility\TimeFactory;
 use OC\Authentication\LoginCredentials\Store;
 use OC\Command\AsyncBus;
@@ -125,11 +126,10 @@ class Server extends ServerContainer implements IServerContainer {
 		parent::__construct();
 		$this->webRoot = $webRoot;
 
-		$this->registerService('ContactsManager', function ($c) {
-			return new ContactsManager();
-		});
+		$this->registerAlias(\OCP\Contacts\IManager::class, \OC\ContactsManager::class);
+		$this->registerAlias('ContactsManager', \OCP\Contacts\IManager::class);
 
-		$this->registerService('PreviewManager', function (Server $c) {
+		$this->registerService(\OCP\IPreview::class, function (Server $c) {
 			return new PreviewManager(
 				$c->getConfig(),
 				$c->getRootFolder(),
@@ -138,6 +138,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getSession()->get('user_id')
 			);
 		});
+		$this->registerAlias('PreviewManager', \OCP\IPreview::class);
 
 		$this->registerService(\OC\Preview\Watcher::class, function (Server $c) {
 			return new \OC\Preview\Watcher(
@@ -187,10 +188,13 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('TagMapper', function (Server $c) {
 			return new TagMapper($c->getDatabaseConnection());
 		});
-		$this->registerService('TagManager', function (Server $c) {
+
+		$this->registerService(\OCP\ITagManager::class, function (Server $c) {
 			$tagMapper = $c->query('TagMapper');
 			return new TagManager($tagMapper, $c->getUserSession());
 		});
+		$this->registerAlias('TagManager', \OCP\ITagManager::class);
+
 		$this->registerService('SystemTagManagerFactory', function (Server $c) {
 			$config = $c->getConfig();
 			$factoryClass = $config->getSystemValue('systemtags.managerFactory', '\OC\SystemTag\ManagerFactory');
@@ -198,10 +202,12 @@ class Server extends ServerContainer implements IServerContainer {
 			$factory = new $factoryClass($this);
 			return $factory;
 		});
-		$this->registerService('SystemTagManager', function (Server $c) {
+		$this->registerService(\OCP\SystemTag\ISystemTagManager::class, function (Server $c) {
 			return $c->query('SystemTagManagerFactory')->getManager();
 		});
-		$this->registerService('SystemTagObjectMapper', function (Server $c) {
+		$this->registerAlias('SystemTagManager', \OCP\SystemTag\ISystemTagManager::class);
+
+		$this->registerService(\OCP\SystemTag\ISystemTagObjectMapper::class, function (Server $c) {
 			return $c->query('SystemTagManagerFactory')->getObjectMapper();
 		});
 		$this->registerService('RootFolder', function (Server $c) {
@@ -223,16 +229,22 @@ class Server extends ServerContainer implements IServerContainer {
 
 			return $root;
 		});
-		$this->registerService('LazyRootFolder', function(Server $c) {
+		$this->registerAlias('SystemTagObjectMapper', \OCP\SystemTag\ISystemTagObjectMapper::class);
+
+		$this->registerService(\OCP\Files\IRootFolder::class, function(Server $c) {
 			return new LazyRoot(function() use ($c) {
 				return $c->query('RootFolder');
 			});
 		});
-		$this->registerService('UserManager', function (Server $c) {
+		$this->registerAlias('LazyRootFolder', \OCP\Files\IRootFolder::class);
+
+		$this->registerService(\OCP\IUserManager::class, function (Server $c) {
 			$config = $c->getConfig();
 			return new \OC\User\Manager($config);
 		});
-		$this->registerService('GroupManager', function (Server $c) {
+		$this->registerAlias('UserManager', \OCP\IUserManager::class);
+
+		$this->registerService(\OCP\IGroupManager::class, function (Server $c) {
 			$groupManager = new \OC\Group\Manager($this->getUserManager(), $this->getLogger());
 			$groupManager->listen('\OC\Group', 'preCreate', function ($gid) {
 				\OC_Hook::emit('OC_Group', 'pre_createGroup', array('run' => true, 'gid' => $gid));
@@ -256,6 +268,8 @@ class Server extends ServerContainer implements IServerContainer {
 			});
 			return $groupManager;
 		});
+		$this->registerAlias('GroupManager', \OCP\IGroupManager::class);
+
 		$this->registerService(Store::class, function(Server $c) {
 			$session = $c->getSession();
 			if (\OC::$server->getSystemConfig()->getValue('installed', false)) {
@@ -280,7 +294,8 @@ class Server extends ServerContainer implements IServerContainer {
 			return new \OC\Authentication\Token\DefaultTokenProvider($mapper, $crypto, $config, $logger, $timeFactory);
 		});
 		$this->registerAlias('OC\Authentication\Token\IProvider', 'OC\Authentication\Token\DefaultTokenProvider');
-		$this->registerService('UserSession', function (Server $c) {
+
+		$this->registerService(\OCP\IUserSession::class, function (Server $c) {
 			$manager = $c->getUserManager();
 			$session = new \OC\Session\Memory('');
 			$timeFactory = new TimeFactory();
@@ -332,18 +347,20 @@ class Server extends ServerContainer implements IServerContainer {
 			});
 			return $userSession;
 		});
+		$this->registerAlias('UserSession', \OCP\IUserSession::class);
 
 		$this->registerService(\OC\Authentication\TwoFactorAuth\Manager::class, function (Server $c) {
 			return new \OC\Authentication\TwoFactorAuth\Manager($c->getAppManager(), $c->getSession(), $c->getConfig(), $c->getActivityManager(), $c->getLogger());
 		});
 
-		$this->registerService('NavigationManager', function (Server $c) {
+		$this->registerService(\OCP\INavigationManager::class, function (Server $c) {
 			return new \OC\NavigationManager($c->getAppManager(),
 				$c->getURLGenerator(),
 				$c->getL10NFactory(),
 				$c->getUserSession(),
 				$c->getGroupManager());
 		});
+		$this->registerAlias('NavigationManager', \OCP\INavigationManager::class);
 
 		$this->registerService(\OC\AllConfig::class, function (Server $c) {
 			return new \OC\AllConfig(
@@ -363,7 +380,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerAlias('AppConfig', \OC\AppConfig::class);
 		$this->registerAlias(\OCP\IAppConfig::class, \OC\AppConfig::class);
 
-		$this->registerService('L10NFactory', function (Server $c) {
+		$this->registerService(\OCP\L10N\IFactory::class, function (Server $c) {
 			return new \OC\L10N\Factory(
 				$c->getConfig(),
 				$c->getRequest(),
@@ -371,7 +388,9 @@ class Server extends ServerContainer implements IServerContainer {
 				\OC::$SERVERROOT
 			);
 		});
-		$this->registerService('URLGenerator', function (Server $c) {
+		$this->registerAlias('L10NFactory', \OCP\L10N\IFactory::class);
+
+		$this->registerService(\OCP\IURLGenerator::class, function (Server $c) {
 			$config = $c->getConfig();
 			$cacheFactory = $c->getMemCacheFactory();
 			return new \OC\URLGenerator(
@@ -379,6 +398,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$cacheFactory
 			);
 		});
+		$this->registerAlias('URLGenerator', \OCP\IURLGenerator::class);
+
 		$this->registerService('AppHelper', function ($c) {
 			return new \OC\AppHelper();
 		});
@@ -398,9 +419,12 @@ class Server extends ServerContainer implements IServerContainer {
 				$this->getConfig()
 			);
 		});
-		$this->registerService('UserCache', function ($c) {
+
+		$this->registerService(\OCP\ICache::class, function ($c) {
 			return new Cache\File();
 		});
+		$this->registerAlias('UserCache', \OCP\ICache::class);
+
 		$this->registerService(Factory::class, function (Server $c) {
 			$config = $c->getConfig();
 
@@ -431,7 +455,8 @@ class Server extends ServerContainer implements IServerContainer {
 			$systemConfig = $c->getSystemConfig();
 			return new RedisFactory($systemConfig);
 		});
-		$this->registerService('ActivityManager', function (Server $c) {
+
+		$this->registerService(\OCP\Activity\IManager::class, function (Server $c) {
 			return new \OC\Activity\Manager(
 				$c->getRequest(),
 				$c->getUserSession(),
@@ -439,13 +464,16 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->query(IValidator::class)
 			);
 		});
+		$this->registerAlias('ActivityManager', \OCP\Activity\IManager::class);
+
 		$this->registerService(\OCP\Activity\IEventMerger::class, function (Server $c) {
 			return new \OC\Activity\EventMerger(
 				$c->getL10N('lib')
 			);
 		});
 		$this->registerAlias(IValidator::class, Validator::class);
-		$this->registerService('AvatarManager', function (Server $c) {
+
+		$this->registerService(\OCP\IAvatarManager::class, function (Server $c) {
 			return new AvatarManager(
 				$c->getUserManager(),
 				$c->getAppDataDir('avatar'),
@@ -454,14 +482,18 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getConfig()
 			);
 		});
-		$this->registerService('Logger', function (Server $c) {
+		$this->registerAlias('AvatarManager', \OCP\IAvatarManager::class);
+
+		$this->registerService(\OCP\ILogger::class, function (Server $c) {
 			$logType = $c->query('AllConfig')->getSystemValue('log_type', 'file');
 			$logger = Log::getLogClass($logType);
 			call_user_func(array($logger, 'init'));
 
 			return new Log($logger);
 		});
-		$this->registerService('JobList', function (Server $c) {
+		$this->registerAlias('Logger', \OCP\ILogger::class);
+
+		$this->registerService(\OCP\BackgroundJob\IJobList::class, function (Server $c) {
 			$config = $c->getConfig();
 			return new \OC\BackgroundJob\JobList(
 				$c->getDatabaseConnection(),
@@ -469,7 +501,9 @@ class Server extends ServerContainer implements IServerContainer {
 				new TimeFactory()
 			);
 		});
-		$this->registerService('Router', function (Server $c) {
+		$this->registerAlias('JobList', \OCP\BackgroundJob\IJobList::class);
+
+		$this->registerService(\OCP\Route\IRouter::class, function (Server $c) {
 			$cacheFactory = $c->getMemCacheFactory();
 			$logger = $c->getLogger();
 			if ($cacheFactory->isAvailable()) {
@@ -479,21 +513,33 @@ class Server extends ServerContainer implements IServerContainer {
 			}
 			return $router;
 		});
-		$this->registerService('Search', function ($c) {
+		$this->registerAlias('Router', \OCP\Route\IRouter::class);
+
+		$this->registerService(\OCP\ISearch::class, function ($c) {
 			return new Search();
 		});
-		$this->registerService('SecureRandom', function ($c) {
+		$this->registerAlias('Search', \OCP\ISearch::class);
+
+		$this->registerService(\OCP\Security\ISecureRandom::class, function ($c) {
 			return new SecureRandom();
 		});
-		$this->registerService('Crypto', function (Server $c) {
+		$this->registerAlias('SecureRandom', \OCP\Security\ISecureRandom::class);
+
+		$this->registerService(\OCP\Security\ICrypto::class, function (Server $c) {
 			return new Crypto($c->getConfig(), $c->getSecureRandom());
 		});
-		$this->registerService('Hasher', function (Server $c) {
+		$this->registerAlias('Crypto', \OCP\Security\ICrypto::class);
+
+		$this->registerService(\OCP\Security\IHasher::class, function (Server $c) {
 			return new Hasher($c->getConfig());
 		});
-		$this->registerService('CredentialsManager', function (Server $c) {
+		$this->registerAlias('Hasher', \OCP\Security\IHasher::class);
+
+		$this->registerService(\OCP\Security\ICredentialsManager::class, function (Server $c) {
 			return new CredentialsManager($c->getCrypto(), $c->getDatabaseConnection());
 		});
+		$this->registerAlias('CredentialsManager', \OCP\Security\ICredentialsManager::class);
+
 		$this->registerService(IDBConnection::class, function (Server $c) {
 			$systemConfig = $c->getSystemConfig();
 			$factory = new \OC\DB\ConnectionFactory($systemConfig);
@@ -507,6 +553,7 @@ class Server extends ServerContainer implements IServerContainer {
 			return $connection;
 		});
 		$this->registerAlias('DatabaseConnection', IDBConnection::class);
+
 		$this->registerService('HTTPHelper', function (Server $c) {
 			$config = $c->getConfig();
 			return new HTTPHelper(
@@ -514,7 +561,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getHTTPClientService()
 			);
 		});
-		$this->registerService('HttpClientService', function (Server $c) {
+
+		$this->registerService(\OCP\Http\Client\IClientService::class, function (Server $c) {
 			$user = \OC_User::getUser();
 			$uid = $user ? $user : null;
 			return new ClientService(
@@ -522,20 +570,26 @@ class Server extends ServerContainer implements IServerContainer {
 				new \OC\Security\CertificateManager($uid, new View(), $c->getConfig(), $c->getLogger())
 			);
 		});
-		$this->registerService('EventLogger', function (Server $c) {
+		$this->registerAlias('HttpClientService', \OCP\Http\Client\IClientService::class);
+
+		$this->registerService(\OCP\Diagnostics\IEventLogger::class, function (Server $c) {
 			if ($c->getSystemConfig()->getValue('debug', false)) {
 				return new EventLogger();
 			} else {
 				return new NullEventLogger();
 			}
 		});
-		$this->registerService('QueryLogger', function (Server $c) {
+		$this->registerAlias('EventLogger', \OCP\Diagnostics\IEventLogger::class);
+
+		$this->registerService(\OCP\Diagnostics\IQueryLogger::class, function (Server $c) {
 			if ($c->getSystemConfig()->getValue('debug', false)) {
 				return new QueryLogger();
 			} else {
 				return new NullQueryLogger();
 			}
 		});
+		$this->registerAlias('QueryLogger', \OCP\Diagnostics\IQueryLogger::class);
+
 		$this->registerService(TempManager::class, function (Server $c) {
 			return new TempManager(
 				$c->getLogger(),
@@ -557,13 +611,15 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerAlias('AppManager', AppManager::class);
 		$this->registerAlias(IAppManager::class, AppManager::class);
 
-		$this->registerService('DateTimeZone', function (Server $c) {
+		$this->registerService(\OCP\IDateTimeZone::class, function (Server $c) {
 			return new DateTimeZone(
 				$c->getConfig(),
 				$c->getSession()
 			);
 		});
-		$this->registerService('DateTimeFormatter', function (Server $c) {
+		$this->registerAlias('DateTimeZone', \OCP\IDateTimeZone::class);
+
+		$this->registerService(\OCP\IDateTimeFormatter::class, function (Server $c) {
 			$language = $c->getConfig()->getUserValue($c->getSession()->get('user_id'), 'core', 'lang', null);
 
 			return new DateTimeFormatter(
@@ -571,13 +627,17 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getL10N('lib', $language)
 			);
 		});
-		$this->registerService('UserMountCache', function (Server $c) {
+		$this->registerAlias('DateTimeFormatter', \OCP\IDateTimeFormatter::class);
+
+		$this->registerService(\OCP\Files\Config\IUserMountCache::class, function (Server $c) {
 			$mountCache = new UserMountCache($c->getDatabaseConnection(), $c->getUserManager(), $c->getLogger());
 			$listener = new UserMountCacheListener($mountCache);
 			$listener->listen($c->getUserManager());
 			return $mountCache;
 		});
-		$this->registerService('MountConfigManager', function (Server $c) {
+		$this->registerAlias('UserMountCache', \OCP\Files\Config\IUserMountCache::class);
+
+		$this->registerService(\OCP\Files\Config\IMountProviderCollection::class, function (Server $c) {
 			$loader = \OC\Files\Filesystem::getLoader();
 			$mountCache = $c->query('UserMountCache');
 			$manager =  new \OC\Files\Config\MountProviderCollection($loader, $mountCache);
@@ -591,6 +651,8 @@ class Server extends ServerContainer implements IServerContainer {
 
 			return $manager;
 		});
+		$this->registerAlias('MountConfigManager', \OCP\Files\Config\IMountProviderCollection::class);
+
 		$this->registerService('IniWrapper', function ($c) {
 			return new IniGetWrapper();
 		});
@@ -630,7 +692,7 @@ class Server extends ServerContainer implements IServerContainer {
 					$c->getTempManager()
 			);
 		});
-		$this->registerService('Request', function ($c) {
+		$this->registerService(\OCP\IRequest::class, function ($c) {
 			if (isset($this['urlParams'])) {
 				$urlParams = $this['urlParams'];
 			} else {
@@ -664,13 +726,17 @@ class Server extends ServerContainer implements IServerContainer {
 				$stream
 			);
 		});
-		$this->registerService('Mailer', function (Server $c) {
+		$this->registerAlias('Request', \OCP\IRequest::class);
+
+		$this->registerService(\OCP\Mail\IMailer::class, function (Server $c) {
 			return new Mailer(
 				$c->getConfig(),
 				$c->getLogger(),
 				$c->getThemingDefaults()
 			);
 		});
+		$this->registerAlias('Mailer', \OCP\Mail\IMailer::class);
+
 		$this->registerService('LDAPProvider', function(Server $c) {
 			$config = $c->getConfig();
 			$factoryClass = $config->getSystemValue('ldapProviderFactory', null);
@@ -696,40 +762,53 @@ class Server extends ServerContainer implements IServerContainer {
 			}
 			return new NoopLockingProvider();
 		});
-		$this->registerService('MountManager', function () {
+
+		$this->registerService(\OCP\Files\Mount\IMountManager::class, function () {
 			return new \OC\Files\Mount\Manager();
 		});
-		$this->registerService('MimeTypeDetector', function (Server $c) {
+		$this->registerAlias('MountManager', \OCP\Files\Mount\IMountManager::class);
+
+		$this->registerService(\OCP\Files\IMimeTypeDetector::class, function (Server $c) {
 			return new \OC\Files\Type\Detection(
 				$c->getURLGenerator(),
 				\OC::$configDir,
 				\OC::$SERVERROOT . '/resources/config/'
 			);
 		});
-		$this->registerService('MimeTypeLoader', function (Server $c) {
+		$this->registerAlias('MimeTypeDetector', \OCP\Files\IMimeTypeDetector::class);
+
+		$this->registerService(\OCP\Files\IMimeTypeLoader::class, function (Server $c) {
 			return new \OC\Files\Type\Loader(
 				$c->getDatabaseConnection()
 			);
 		});
-		$this->registerService('NotificationManager', function (Server $c) {
+		$this->registerAlias('MimeTypeLoader', \OCP\Files\IMimeTypeLoader::class);
+
+		$this->registerService(\OCP\Notification\IManager::class, function (Server $c) {
 			return new Manager(
 				$c->query(IValidator::class)
 			);
 		});
-		$this->registerService('CapabilitiesManager', function (Server $c) {
+		$this->registerAlias('NotificationManager', \OCP\Notification\IManager::class);
+
+		$this->registerService(\OC\CapabilitiesManager::class, function (Server $c) {
 			$manager = new \OC\CapabilitiesManager($c->getLogger());
 			$manager->registerCapability(function () use ($c) {
 				return new \OC\OCS\CoreCapabilities($c->getConfig());
 			});
 			return $manager;
 		});
-		$this->registerService('CommentsManager', function(Server $c) {
+		$this->registerAlias('CapabilitiesManager', \OC\CapabilitiesManager::class);
+
+		$this->registerService(\OCP\Comments\ICommentsManager::class, function(Server $c) {
 			$config = $c->getConfig();
 			$factoryClass = $config->getSystemValue('comments.managerFactory', '\OC\Comments\ManagerFactory');
 			/** @var \OCP\Comments\ICommentsManagerFactory $factory */
 			$factory = new $factoryClass($this);
 			return $factory->getManager();
 		});
+		$this->registerAlias('CommentsManager', \OCP\Comments\ICommentsManager::class);
+
 		$this->registerService('ThemingDefaults', function(Server $c) {
 			/*
 			 * Dark magic for autoloader.
@@ -798,16 +877,19 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService(SessionStorage::class, function (Server $c) {
 			return new SessionStorage($c->getSession());
 		});
-		$this->registerService('ContentSecurityPolicyManager', function (Server $c) {
+		$this->registerService(\OCP\Security\IContentSecurityPolicyManager::class, function (Server $c) {
 			return new ContentSecurityPolicyManager();
 		});
+		$this->registerAlias('ContentSecurityPolicyManager', \OCP\Security\IContentSecurityPolicyManager::class);
+
 		$this->registerService('ContentSecurityPolicyNonceManager', function(Server $c) {
 			return new ContentSecurityPolicyNonceManager(
 				$c->getCsrfTokenManager(),
 				$c->getRequest()
 			);
 		});
-		$this->registerService('ShareManager', function(Server $c) {
+
+		$this->registerService(\OCP\Share\IManager::class, function(Server $c) {
 			$config = $c->getConfig();
 			$factoryClass = $config->getSystemValue('sharing.managerFactory', '\OC\Share20\ProviderFactory');
 			/** @var \OCP\Share\IProviderFactory $factory */
@@ -829,6 +911,8 @@ class Server extends ServerContainer implements IServerContainer {
 
 			return $manager;
 		});
+		$this->registerAlias('ShareManager', \OCP\Share\IManager::class);
+
 		$this->registerService('SettingsManager', function(Server $c) {
 			$manager = new \OC\Settings\Manager(
 				$c->getLogger(),
@@ -867,6 +951,16 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getJobList(),
 				new TimeFactory()
 			);
+		});
+
+		$this->registerAlias(\OCP\AppFramework\Utility\IControllerMethodReflector::class, \OC\AppFramework\Utility\ControllerMethodReflector::class);
+		$this->registerAlias('ControllerMethodReflector', \OCP\AppFramework\Utility\IControllerMethodReflector::class);
+
+		$this->registerAlias(\OCP\AppFramework\Utility\ITimeFactory::class, \OC\AppFramework\Utility\TimeFactory::class);
+		$this->registerAlias('TimeFactory', \OCP\AppFramework\Utility\ITimeFactory::class);
+
+		$this->registerService(\OCP\ISession::class, function(SimpleContainer $c) {
+			return $c->query(\OCP\IUserSession::class)->getSession();
 		});
 	}
 

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -93,6 +93,7 @@ use OC\Tagging\TagMapper;
 use OCA\Theming\ThemingDefaults;
 use OCP\Federation\ICloudIdManager;
 use OCP\Authentication\LoginCredentials\IStore;
+use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IServerContainer;
 use OCP\RichObjectStrings\IValidator;
@@ -485,7 +486,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('CredentialsManager', function (Server $c) {
 			return new CredentialsManager($c->getCrypto(), $c->getDatabaseConnection());
 		});
-		$this->registerService('DatabaseConnection', function (Server $c) {
+		$this->registerService(IDBConnection::class, function (Server $c) {
 			$systemConfig = $c->getSystemConfig();
 			$factory = new \OC\DB\ConnectionFactory($systemConfig);
 			$type = $systemConfig->getValue('dbtype', 'sqlite');
@@ -497,6 +498,7 @@ class Server extends ServerContainer implements IServerContainer {
 			$connection->getConfiguration()->setSQLLogger($c->getQueryLogger());
 			return $connection;
 		});
+		$this->registerAlias('DatabaseConnection', IDBConnection::class);
 		$this->registerService('HTTPHelper', function (Server $c) {
 			$config = $c->getConfig();
 			return new HTTPHelper(
@@ -740,9 +742,12 @@ class Server extends ServerContainer implements IServerContainer {
 			}
 			return new \OC_Defaults();
 		});
-		$this->registerService('EventDispatcher', function () {
+		$this->registerService(EventDispatcher::class, function () {
 			return new EventDispatcher();
 		});
+		$this->registerAlias('EventDispatcher', EventDispatcher::class);
+		$this->registerAlias(EventDispatcherInterface::class, EventDispatcher::class);
+
 		$this->registerService('CryptoWrapper', function (Server $c) {
 			// FIXME: Instantiiated here due to cyclic dependency
 			$request = new Request(

--- a/lib/private/ServerContainer.php
+++ b/lib/private/ServerContainer.php
@@ -79,7 +79,7 @@ class ServerContainer extends SimpleContainer {
 			$segments = explode('\\', $name);
 			$appContainer = $this->getAppContainer(strtolower($segments[1]));
 			try {
-				return $appContainer->query($name);
+				return $appContainer->query($name, false);
 			} catch (QueryException $e) {
 				// Didn't find the service in the respective app container,
 				// ignore it and fall back to the core container.

--- a/lib/private/ServerContainer.php
+++ b/lib/private/ServerContainer.php
@@ -79,7 +79,7 @@ class ServerContainer extends SimpleContainer {
 			$segments = explode('\\', $name);
 			$appContainer = $this->getAppContainer(strtolower($segments[1]));
 			try {
-				return $appContainer->query($name, false);
+				return $appContainer->query($name);
 			} catch (QueryException $e) {
 				// Didn't find the service in the respective app container,
 				// ignore it and fall back to the core container.

--- a/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
+++ b/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
@@ -27,23 +27,29 @@
 namespace Test\AppFramework\DependencyInjection;
 
 
+use OC\AppFramework\Core\API;
+use OC\AppFramework\DependencyInjection\DIContainer;
 use \OC\AppFramework\Http\Request;
+use OCP\AppFramework\QueryException;
+use OCP\IConfig;
+use OCP\Security\ISecureRandom;
 
 /**
  * @group DB
  */
 class DIContainerTest extends \Test\TestCase {
 
+	/** @var DIContainer|\PHPUnit_Framework_MockObject_MockObject */
 	private $container;
 	private $api;
 
 	protected function setUp(){
 		parent::setUp();
-		$this->container = $this->getMockBuilder('OC\AppFramework\DependencyInjection\DIContainer')
+		$this->container = $this->getMockBuilder(DIContainer::class)
 			->setMethods(['isAdminUser'])
 			->setConstructorArgs(['name'])
 			->getMock();
-		$this->api = $this->getMockBuilder('OC\AppFramework\Core\API')
+		$this->api = $this->getMockBuilder(API::class)
 			->setConstructorArgs(['hi'])
 			->getMock();
 	}
@@ -80,10 +86,10 @@ class DIContainerTest extends \Test\TestCase {
 	public function testMiddlewareDispatcherIncludesSecurityMiddleware(){
 		$this->container['Request'] = new Request(
 			['method' => 'GET'],
-			$this->getMockBuilder('\OCP\Security\ISecureRandom')
+			$this->getMockBuilder(ISecureRandom::class)
 				->disableOriginalConstructor()
 				->getMock(),
-			$this->getMockBuilder('\OCP\IConfig')
+			$this->getMockBuilder(IConfig::class)
 				->disableOriginalConstructor()
 				->getMock()
 		);
@@ -93,5 +99,8 @@ class DIContainerTest extends \Test\TestCase {
 		$this->assertContains($security, $dispatcher->getMiddlewares());
 	}
 
-
+	public function testInvalidAppClass() {
+		$this->expectException(QueryException::class);
+		$this->container->query('\OCA\Name\Foo');
+	}
 }

--- a/tests/lib/AppFramework/DependencyInjection/DIIntergrationTests.php
+++ b/tests/lib/AppFramework/DependencyInjection/DIIntergrationTests.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * @copyright 2017, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace Test\AppFramework\DependencyInjection;
+
+use OC\AppFramework\DependencyInjection\DIContainer;
+use OC\AppFramework\Utility\SimpleContainer;
+use OC\ServerContainer;
+use Test\TestCase;
+
+interface Interface1 {}
+
+class ClassA1 implements Interface1 {}
+
+class ClassA2 implements Interface1 {}
+
+class ClassB {
+	/** @var Interface1 */
+	public $interface1;
+
+	/**
+	 * ClassB constructor.
+	 *
+	 * @param Interface1 $interface1
+	 */
+	public function __construct(Interface1 $interface1) {
+		$this->interface1 = $interface1;
+	}
+}
+
+class DIIntergrationTests extends TestCase {
+
+	/** @var DIContainer */
+	private $container;
+
+	/** @var ServerContainer */
+	private $server;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->server = new ServerContainer();
+		$this->container = new DIContainer('App1', [], $this->server);
+	}
+
+	public function testInjectFromServer() {
+		$this->server->registerService(Interface1::class, function () {
+			return new ClassA1();
+		});
+
+		$this->server->registerService(ClassB::class, function (SimpleContainer $c) {
+			return new ClassB(
+				$c->query(Interface1::class)
+			);
+		});
+
+		/** @var ClassB $res */
+		$res = $this->container->query(ClassB::class);
+		$this->assertSame(ClassA1::class, get_class($res->interface1));
+	}
+
+	public function testInjectDepFromServer() {
+		$this->server->registerService(Interface1::class, function () {
+			return new ClassA1();
+		});
+
+		$this->container->registerService(ClassB::class, function (SimpleContainer $c) {
+			return new ClassB(
+				$c->query(Interface1::class)
+			);
+		});
+
+		/** @var ClassB $res */
+		$res = $this->container->query(ClassB::class);
+		$this->assertSame(ClassA1::class, get_class($res->interface1));
+	}
+
+	public function testOverwriteDepFromServer() {
+		$this->server->registerService(Interface1::class, function () {
+			return new ClassA1();
+		});
+
+		$this->container->registerService(Interface1::class, function () {
+			return new ClassA2();
+		});
+
+		$this->container->registerService(ClassB::class, function (SimpleContainer $c) {
+			return new ClassB(
+				$c->query(Interface1::class)
+			);
+		});
+
+		/** @var ClassB $res */
+		$res = $this->container->query(ClassB::class);
+		$this->assertSame(ClassA2::class, get_class($res->interface1));
+	}
+
+	public function testIgnoreOverwriteInServerClass() {
+		$this->server->registerService(Interface1::class, function () {
+			return new ClassA1();
+		});
+
+		$this->container->registerService(Interface1::class, function () {
+			return new ClassA2();
+		});
+
+		$this->server->registerService(ClassB::class, function (SimpleContainer $c) {
+			return new ClassB(
+				$c->query(Interface1::class)
+			);
+		});
+
+		/** @var ClassB $res */
+		$res = $this->container->query(ClassB::class);
+		$this->assertSame(ClassA1::class, get_class($res->interface1));
+	}
+}

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -139,7 +139,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 			if (is_null(self::$realDatabase)) {
 				self::$realDatabase = \OC::$server->getDatabaseConnection();
 			}
-			\OC::$server->registerService('DatabaseConnection', function () {
+			\OC::$server->registerService(IDBConnection::class, function () {
 				$this->fail('Your test case is not allowed to access the database.');
 			});
 		}
@@ -158,7 +158,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 
 		// restore database connection
 		if (!$this->IsDatabaseAccessAllowed()) {
-			\OC::$server->registerService('DatabaseConnection', function () {
+			\OC::$server->registerService(IDBConnection::class, function () {
 				return self::$realDatabase;
 			});
 		}
@@ -171,7 +171,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 
 		// restore database connection
 		if (!$this->IsDatabaseAccessAllowed()) {
-			\OC::$server->registerService('DatabaseConnection', function () {
+			\OC::$server->registerService(IDBConnection::class, function () {
 				return self::$realDatabase;
 			});
 		}
@@ -259,7 +259,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		if (!self::$wasDatabaseAllowed && self::$realDatabase !== null) {
 			// in case an error is thrown in a test, PHPUnit jumps straight to tearDownAfterClass,
 			// so we need the database again
-			\OC::$server->registerService('DatabaseConnection', function () {
+			\OC::$server->registerService(IDBConnection::class, function () {
 				return self::$realDatabase;
 			});
 		}


### PR DESCRIPTION
Followup of https://github.com/nextcloud/server/pull/3897
Implementation of https://github.com/nextcloud/server/issues/2043#issuecomment-287348294

This should allow us to the interface defintions to the servercontainer. So we don't duplicate everything for each App.