### PR TITLE
Support Circles

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -134,6 +134,8 @@
 								hasShares = true;
 							} else if (shareType === OC.Share.SHARE_TYPE_REMOTE) {
 								hasShares = true;
+							} else if (shareType === OC.Share.SHARE_TYPE_CIRCLE) {
+								hasShares = true;
 							}
 						});
 						OCA.Sharing.Util._updateFileActionIcon($tr, hasShares, hasLink);

--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -92,12 +92,14 @@ class ShareesAPIController extends OCSController {
 			'groups' => [],
 			'remotes' => [],
 			'emails' => [],
+			'circles' => [],
 		],
 		'users' => [],
 		'groups' => [],
 		'remotes' => [],
 		'emails' => [],
 		'lookup' => [],
+		'circles' => [],
 	];
 
 	protected $reachedEndFor = [];
@@ -294,6 +296,23 @@ class ShareesAPIController extends OCSController {
 		}
 	}
 
+
+	/**
+	 * @param string $search
+	 */
+	protected function getCircles($search) {
+		$this->result['circles'] = $this->result['exact']['circles'] = [];
+
+		$result = \OCA\Circles\Api\Sharees::search($search, $this->limit, $this->offset);
+		if (array_key_exists('circles', $result['exact'])) {
+			$this->result['exact']['circles'] = $result['exact']['circles'];
+		}
+		if (array_key_exists('circles', $result)) {
+			$this->result['circles'] = $result['circles'];
+		}
+	}
+
+
 	/**
 	 * @param string $search
 	 * @return array
@@ -453,6 +472,10 @@ class ShareesAPIController extends OCSController {
 			$shareTypes[] = Share::SHARE_TYPE_EMAIL;
 		}
 
+		if (\OCP\App::isEnabled('circles')) {
+			$shareTypes[] = Share::SHARE_TYPE_CIRCLE;
+		}
+
 		if (isset($_GET['shareType']) && is_array($_GET['shareType'])) {
 			$shareTypes = array_intersect($shareTypes, $_GET['shareType']);
 			sort($shareTypes);
@@ -511,6 +534,12 @@ class ShareesAPIController extends OCSController {
 		if (in_array(Share::SHARE_TYPE_GROUP, $shareTypes)) {
 			$this->getGroups($search);
 		}
+
+		// Get circles
+		if (in_array(Share::SHARE_TYPE_CIRCLE, $shareTypes)) {
+			$this->getCircles($search);
+		}
+
 
 		// Get remote
 		$remoteResults = ['results' => [], 'exact' => [], 'exactIdMatch' => false];

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -68,8 +68,11 @@ class MountProvider implements IMountProvider {
 	 * @return \OCP\Files\Mount\IMountPoint[]
 	 */
 	public function getMountsForUser(IUser $user, IStorageFactory $storageFactory) {
+
 		$shares = $this->shareManager->getSharedWith($user->getUID(), \OCP\Share::SHARE_TYPE_USER, null, -1);
 		$shares = array_merge($shares, $this->shareManager->getSharedWith($user->getUID(), \OCP\Share::SHARE_TYPE_GROUP, null, -1));
+		$shares = array_merge($shares, $this->shareManager->getSharedWith($user->getUID(), \OCP\Share::SHARE_TYPE_CIRCLE, null, -1));
+
 		// filter out excluded shares and group shares that includes self
 		$shares = array_filter($shares, function (\OCP\Share\IShare $share) use ($user) {
 			return $share->getPermissions() > 0 && $share->getShareOwner() !== $user->getUID();

--- a/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
@@ -1576,20 +1576,22 @@ class ShareesAPIControllerTest extends TestCase {
 		return [
 			['test', 'folder', [Share::SHARE_TYPE_USER, Share::SHARE_TYPE_GROUP, Share::SHARE_TYPE_REMOTE], 1, 2, false, [], [], ['results' => [], 'exact' => [], 'exactIdMatch' => false],
 				[
-					'exact' => ['users' => [], 'groups' => [], 'remotes' => [], 'emails' => []],
+					'exact' => ['users' => [], 'groups' => [], 'remotes' => [], 'circles' => [], 'emails' => []],
 					'users' => [],
 					'groups' => [],
 					'remotes' => [],
 					'emails' => [],
+					'circles' => [],
 					'lookup' => [],
 				], false],
 			['test', 'folder', [Share::SHARE_TYPE_USER, Share::SHARE_TYPE_GROUP, Share::SHARE_TYPE_REMOTE], 1, 2, false, [], [], ['results' => [], 'exact' => [], 'exactIdMatch' => false],
 				[
-					'exact' => ['users' => [], 'groups' => [], 'remotes' => [], 'emails' => []],
+					'exact' => ['users' => [], 'groups' => [], 'remotes' => [], 'circles' => [], 'emails' => []],
 					'users' => [],
 					'groups' => [],
 					'remotes' => [],
 					'emails' => [],
+					'circles' => [],
 					'lookup' => [],
 				], false],
 			[
@@ -1601,7 +1603,7 @@ class ShareesAPIControllerTest extends TestCase {
 					'results' => [['label' => 'testz@remote', 'value' => ['shareType' => Share::SHARE_TYPE_REMOTE, 'shareWith' => 'testz@remote']]], 'exact' => [], 'exactIdMatch' => false,
 				],
 				[
-					'exact' => ['users' => [], 'groups' => [], 'remotes' => [], 'emails' => []],
+					'exact' => ['users' => [], 'groups' => [], 'remotes' => [], 'circles' => [], 'emails' => []],
 					'users' => [
 						['label' => 'test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1']],
 					],
@@ -1612,6 +1614,7 @@ class ShareesAPIControllerTest extends TestCase {
 						['label' => 'testz@remote', 'value' => ['shareType' => Share::SHARE_TYPE_REMOTE, 'shareWith' => 'testz@remote']],
 					],
 					'emails' => [],
+					'circles' => [],
 					'lookup' => [],
 				], true,
 			],
@@ -1623,7 +1626,7 @@ class ShareesAPIControllerTest extends TestCase {
 					'results' => [['label' => 'testz@remote', 'value' => ['shareType' => Share::SHARE_TYPE_REMOTE, 'shareWith' => 'testz@remote']]], 'exact' => [], 'exactIdMatch' => false
 				],
 				[
-					'exact' => ['users' => [], 'groups' => [], 'remotes' => [], 'emails' => []],
+					'exact' => ['users' => [], 'groups' => [], 'remotes' => [], 'circles' => [], 'emails' => []],
 					'users' => [
 						['label' => 'test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1']],
 					],
@@ -1632,6 +1635,7 @@ class ShareesAPIControllerTest extends TestCase {
 						['label' => 'testz@remote', 'value' => ['shareType' => Share::SHARE_TYPE_REMOTE, 'shareWith' => 'testz@remote']],
 					],
 					'emails' => [],
+					'circles' => [],
 					'lookup' => [],
 				], false,
 			],
@@ -1641,13 +1645,14 @@ class ShareesAPIControllerTest extends TestCase {
 					['label' => 'test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1']],
 				], null, null,
 				[
-					'exact' => ['users' => [], 'groups' => [], 'remotes' => [], 'emails' => []],
+					'exact' => ['users' => [], 'groups' => [], 'remotes' => [], 'circles' => [], 'emails' => []],
 					'users' => [
 						['label' => 'test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1']],
 					],
 					'groups' => [],
 					'remotes' => [],
 					'emails' => [],
+					'circles' => [],
 					'lookup' => [],
 				], false,
 			],
@@ -1658,7 +1663,7 @@ class ShareesAPIControllerTest extends TestCase {
 					['label' => 'test 2', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2']],
 				], null, null,
 				[
-					'exact' => ['users' => [], 'groups' => [], 'remotes' => [], 'emails' => []],
+					'exact' => ['users' => [], 'groups' => [], 'remotes' => [], 'circles' => [], 'emails' => []],
 					'users' => [
 						['label' => 'test 1', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1']],
 						['label' => 'test 2', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2']],
@@ -1666,6 +1671,7 @@ class ShareesAPIControllerTest extends TestCase {
 					'groups' => [],
 					'remotes' => [],
 					'emails' => [],
+					'circles' => [],
 					'lookup' => [],
 				], true,
 			],

--- a/apps/files_sharing/tests/MountProviderTest.php
+++ b/apps/files_sharing/tests/MountProviderTest.php
@@ -113,6 +113,8 @@ class MountProviderTest extends \Test\TestCase {
 			$this->makeMockShare(4, 101, 'user2', '/share4', 31), 
 			$this->makeMockShare(5, 100, 'user1', '/share4', 31), 
 		];
+		// tests regarding circles are made in the app itself.
+		$circleShares = [];
 		$this->user->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('user1'));
@@ -124,6 +126,10 @@ class MountProviderTest extends \Test\TestCase {
 			->method('getSharedWith')
 			->with('user1', \OCP\Share::SHARE_TYPE_GROUP, null, -1)
 			->will($this->returnValue($groupShares));
+		$this->shareManager->expects($this->at(2))
+			->method('getSharedWith')
+			->with('user1', \OCP\Share::SHARE_TYPE_CIRCLE, null, -1)
+			->will($this->returnValue($circleShares));
 		$this->shareManager->expects($this->any())
 			->method('newShare')
 			->will($this->returnCallback(function() use ($rootFolder, $userManager) {
@@ -293,6 +299,8 @@ class MountProviderTest extends \Test\TestCase {
 			->method('getUID')
 			->will($this->returnValue('user1'));
 
+		// tests regarding circles are made in the app itself.
+		$circleShares = [];
 		$this->shareManager->expects($this->at(0))
 			->method('getSharedWith')
 			->with('user1', \OCP\Share::SHARE_TYPE_USER)
@@ -301,6 +309,10 @@ class MountProviderTest extends \Test\TestCase {
 			->method('getSharedWith')
 			->with('user1', \OCP\Share::SHARE_TYPE_GROUP, null, -1)
 			->will($this->returnValue($groupShares));
+		$this->shareManager->expects($this->at(2))
+			->method('getSharedWith')
+			->with('user1', \OCP\Share::SHARE_TYPE_CIRCLE, null, -1)
+			->will($this->returnValue($circleShares));
 		$this->shareManager->expects($this->any())
 			->method('newShare')
 			->will($this->returnCallback(function() use ($rootFolder, $userManager) {

--- a/apps/files_sharing/tests/js/sharedbreadcrumviewSpec.js
+++ b/apps/files_sharing/tests/js/sharedbreadcrumviewSpec.js
@@ -120,6 +120,21 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			expect(bc.$el.find('.shared').length).toEqual(1);
 			expect(bc.$el.find('.icon-public').length).toEqual(1);
 		});
+		it('Render shared if dir is shared by circle', function() {
+			var dirInfo = new OC.Files.FileInfo({
+				id: 42,
+				path: '/foo',
+				type: 'dir',
+				shareTypes: [OC.Share.SHARE_TYPE_CIRCLE]
+			});
+			bc.setDirectoryInfo(dirInfo);
+			bc.setDirectory('/foo');
+			bc.render();
+			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
+			expect(bc.$el.find('.icon-share').length).toEqual(1);
+			expect(bc.$el.find('.shared').length).toEqual(1);
+			expect(bc.$el.find('.icon-public').length).toEqual(0);
+		});
 		it('Render shared if dir is shared with remote', function() {
 			var dirInfo = new OC.Files.FileInfo({
 				id: 42,
@@ -145,7 +160,8 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 					OC.Share.SHARE_TYPE_GROUP,
 					OC.Share.SHARE_TYPE_LINK,
 					OC.Share.SHARE_TYPE_EMAIL,
-					OC.Share.SHARE_TYPE_REMOTE
+					OC.Share.SHARE_TYPE_REMOTE,
+					OC.Share.SHARE_TYPE_CIRCLE
 				]
 			});
 			bc.setDirectoryInfo(dirInfo);

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -9,6 +9,7 @@ OC.Share = _.extend(OC.Share || {}, {
 	SHARE_TYPE_LINK:3,
 	SHARE_TYPE_EMAIL:4,
 	SHARE_TYPE_REMOTE:6,
+	SHARE_TYPE_CIRCLE:7,
 
 	/**
 	 * Regular expression for splitting parts of remote share owners:

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -158,6 +158,7 @@
 				shareWithDisplayName = shareWithDisplayName + " (" + t('core', 'remote') + ')';
 			} else if (shareType === OC.Share.SHARE_TYPE_EMAIL) {
 				shareWithDisplayName = shareWithDisplayName + " (" + t('core', 'email') + ')';
+			} else if (shareType === OC.Share.SHARE_TYPE_CIRCLE) {
 			}
 
 			if (shareType === OC.Share.SHARE_TYPE_GROUP) {
@@ -166,6 +167,8 @@
 				shareWithTitle = shareWith + " (" + t('core', 'remote') + ')';
 			} else if (shareType === OC.Share.SHARE_TYPE_EMAIL) {
 				shareWithTitle = shareWith + " (" + t('core', 'email') + ')';
+			} else if (shareType === OC.Share.SHARE_TYPE_CIRCLE) {
+				shareWithTitle = shareWith;
 			}
 
 			return _.extend(hasPermissionOverride, {
@@ -183,6 +186,7 @@
 				modSeed: shareType !== OC.Share.SHARE_TYPE_USER,
 				isRemoteShare: shareType === OC.Share.SHARE_TYPE_REMOTE,
 				isMailShare: shareType === OC.Share.SHARE_TYPE_EMAIL,
+				isCircleShare: shareType === OC.Share.SHARE_TYPE_CIRCLE,
 				isFileSharedByMail: shareType === OC.Share.SHARE_TYPE_EMAIL && !this.model.isFolder()
 			});
 		},

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -186,18 +186,24 @@
 						} else {
 							var emails = [];
 						}
+						if (typeof(result.ocs.data.circles) !== 'undefined') {
+							var circles = result.ocs.data.exact.circles.concat(result.ocs.data.circles);
+						} else {
+							var circles = [];
+						}
 
 						var usersLength;
 						var groupsLength;
 						var remotesLength;
 						var emailsLength;
+						var circlesLength;
 						var lookupLength;
 
 						var i, j;
 
 						//Filter out the current user
 						usersLength = users.length;
-						for (i = 0 ; i < usersLength; i++) {
+						for (i = 0; i < usersLength; i++) {
 							if (users[i].value.shareWith === OC.currentUser) {
 								users.splice(i, 1);
 								break;
@@ -254,10 +260,18 @@
 										break;
 									}
 								}
+							} else if (share.share_type === OC.Share.SHARE_TYPE_CIRCLE) {
+								circlesLength = circles.length;
+								for (j = 0; j < circlesLength; j++) {
+									if (circles[j].value.shareWith === share.share_with) {
+										circles.splice(j, 1);
+										break;
+									}
+								}
 							}
 						}
 
-						var suggestions = users.concat(groups).concat(remotes).concat(emails).concat(lookup);
+						var suggestions = users.concat(groups).concat(remotes).concat(emails).concat(circles).concat(lookup);
 
 						if (suggestions.length > 0) {
 							$shareWithField
@@ -313,6 +327,8 @@
 				text = t('core', '{sharee} (remote)', { sharee: text }, undefined, { escape: false });
 			} else if (item.value.shareType === OC.Share.SHARE_TYPE_EMAIL) {
 				text = t('core', '{sharee} (email)', { sharee: text }, undefined, { escape: false });
+			} else if (item.value.shareType === OC.Share.SHARE_TYPE_CIRCLE) {
+				text = t('core', '{sharee} ({type}, {owner})', {sharee: text, type: item.value.circleInfo, owner: item.value.circleOwner}, undefined, {escape: false});
 			}
 			var insert = $("<div class='share-autocomplete-item'/>");
 			var avatar = $("<div class='avatardiv'></div>").appendTo(insert);

--- a/lib/private/Share/Constants.php
+++ b/lib/private/Share/Constants.php
@@ -32,6 +32,7 @@ class Constants {
 	const SHARE_TYPE_EMAIL = 4;
 	const SHARE_TYPE_CONTACT = 5; // ToDo Check if it is still in use otherwise remove it
 	const SHARE_TYPE_REMOTE = 6;
+	const SHARE_TYPE_CIRCLE = 7;
 
 	const FORMAT_NONE = -1;
 	const FORMAT_STATUSES = -2;

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -190,9 +190,14 @@ class Manager implements IManager {
 			if ($share->getSharedWith() === null) {
 				throw new \InvalidArgumentException('SharedWith should not be empty');
 			}
+		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_CIRCLE) {
+			$circle = \OCA\Circles\Api\Circles::detailsCircle($share->getSharedWith());
+			if ($circle === null) {
+				throw new \InvalidArgumentException('SharedWith is not a valid circle');
+			}
 		} else {
 			// We can't handle other types yet
-			throw new \InvalidArgumentException('unkown share type');
+			throw new \InvalidArgumentException('unknown share type');
 		}
 
 		// Verify the initiator of the share is set

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -622,7 +622,7 @@ class ManagerTest extends \Test\TestCase {
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK,  $file, $user2, $user0, $user0, 31, null, null), 'SharedWith should be empty', true],
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK,  $file, $group0, $user0, $user0, 31, null, null), 'SharedWith should be empty', true],
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_LINK,  $file, 'foo@bar.com', $user0, $user0, 31, null, null), 'SharedWith should be empty', true],
-			[$this->createShare(null, -1, $file, null, $user0, $user0, 31, null, null), 'unkown share type', true],
+			[$this->createShare(null, -1, $file, null, $user0, $user0, 31, null, null), 'unknown share type', true],
 
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_USER,  $file, $user2, null, $user0, 31, null, null), 'SharedBy should be set', true],
 			[$this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $file, $group0, null, $user0, 31, null, null), 'SharedBy should be set', true],


### PR DESCRIPTION
This PR will add support to a non-admin group shares.

It includes:

* call to the Circles Sharees API to search for Circles when the user want to share a file/folder.
* call to the Circles Share Provider when browsing files (as file owner and as shared user) and editing rights/permissions.