### PR TITLE
DummyGetResponsePlugin: ownCloud -> Nexcloud

### DIFF
--- a/apps/dav/lib/Connector/Sabre/DummyGetResponsePlugin.php
+++ b/apps/dav/lib/Connector/Sabre/DummyGetResponsePlugin.php
@@ -58,7 +58,7 @@ class DummyGetResponsePlugin extends \Sabre\DAV\ServerPlugin {
 	 */
 	function httpGet(RequestInterface $request, ResponseInterface $response) {
 		$string = 'This is the WebDAV interface. It can only be accessed by ' .
-			'WebDAV clients such as the ownCloud desktop sync client.';
+			'WebDAV clients such as the Nextcloud desktop sync client.';
 		$stream = fopen('php://memory','r+');
 		fwrite($stream, $string);
 		rewind($stream);


### PR DESCRIPTION
When opening nextcloud/remote.php/dav/ in a browser, it still reads "ownCloud" instead of Nextcloud". This commit fixes the visible part, source still attributes to ownCloud.
