### PR TITLE
Fix avatar and caret position

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -399,7 +399,6 @@ nav {
 
 	/* Profile picture in header */
 	.avatardiv {
-		margin-right: 8px;
 		cursor: pointer;
 		height: 32px;
 		width: 32px;
@@ -457,9 +456,6 @@ nav {
 #header {
 	.avatardiv.avatardiv-shown + #expandDisplayName {
 		display: none;
-	}
-	#expand {
-		display: block;
 	}
 }
 


### PR DESCRIPTION
* Avatar image was not vertically aligned
* The caret was below the avatar
* The surrounding <div> exceeded the title bar

Problem:
![nc-old-pic](https://cloud.githubusercontent.com/assets/1718822/24081627/d1e9400c-0cb7-11e7-9160-2cadaf02dac6.png)

![nc-old-pic_model](https://cloud.githubusercontent.com/assets/1718822/24081628/d1ef33a4-0cb7-11e7-8b11-7abef9d596d4.png)

Fixed:
![nc-new-pic](https://cloud.githubusercontent.com/assets/1718822/24081626/d1e00e60-0cb7-11e7-9ce7-f20cb1d95b34.png)


fixes #3920 
