### PR TITLE
Do not generate the max preview twice

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -111,6 +111,11 @@ class Generator {
 		// Calculate the preview size
 		list($width, $height) = $this->calculateSize($width, $height, $crop, $mode, $maxWidth, $maxHeight);
 
+		// No need to generate a preview that is just the max preview
+		if ($width === $maxWidth && $height === $maxHeight) {
+			return $maxPreview;
+		}
+
 		// Try to get a cached preview. Else generate (and store) one
 		try {
 			$file = $this->getCachedPreview($previewFolder, $width, $height, $crop);

--- a/tests/lib/Preview/GeneratorTest.php
+++ b/tests/lib/Preview/GeneratorTest.php
@@ -399,6 +399,10 @@ class GeneratorTest extends \Test\TestCase {
 			);
 
 		$result = $this->generator->getPreview($file, $reqX, $reqY, $crop, $mode);
-		$this->assertSame($preview, $result);
+		if ($expectedX === $maxX && $expectedY === $maxY) {
+			$this->assertSame($maxPreview, $result);
+		} else {
+			$this->assertSame($preview, $result);
+		}
 	}
 }


### PR DESCRIPTION
If you request a preview of X by Y. And after calculating X and Y are
equal to maxWidth and maxHeight then there is no reason to create a
preview of that size.