### PR TITLE
cache loadUser if not exists

### DIFF
--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -234,7 +234,7 @@ class Database extends Backend implements IUserBackend {
 	/**
 	 * Load an user in the cache
 	 * @param string $uid the username
-	 * @return boolean
+	 * @return boolean true if user was found, false otherwise
 	 */
 	private function loadUser($uid) {
 		if (!isset($this->cache[$uid])) {
@@ -254,9 +254,14 @@ class Database extends Backend implements IUserBackend {
 
 			$this->cache[$uid] = false;
 
+			// "uid" is primary key, so there can only be a single result
 			if ($row = $result->fetchRow()) {
 				$this->cache[$uid]['uid'] = $row['uid'];
 				$this->cache[$uid]['displayname'] = $row['displayname'];
+				$result->closeCursor();
+			} else {
+				$result->closeCursor();
+				return false;
 			}
 		}
 

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -254,7 +254,7 @@ class Database extends Backend implements IUserBackend {
 
 			$this->cache[$uid] = false;
 
-			while ($row = $result->fetchRow()) {
+			if ($row = $result->fetchRow()) {
 				$this->cache[$uid]['uid'] = $row['uid'];
 				$this->cache[$uid]['displayname'] = $row['displayname'];
 			}

--- a/tests/lib/User/DatabaseTest.php
+++ b/tests/lib/User/DatabaseTest.php
@@ -87,7 +87,7 @@ class DatabaseTest extends Backend {
 		$this->eventDispatcher->expects($this->once())->method('dispatch')
 			->willReturnCallback(
 				function ($eventName, GenericEvent $event) {
-					$this->assertSame('OCP\PasswordPolicy::validate',  $eventName);
+					$this->assertSame('OCP\PasswordPolicy::validate', $eventName);
 					$this->assertSame('newpass', $event->getSubject());
 					throw new HintException('password change failed', 'password change failed');
 				}
@@ -95,5 +95,22 @@ class DatabaseTest extends Backend {
 
 		$this->backend->setPassword($user, 'newpass');
 		$this->assertSame($user, $this->backend->checkPassword($user, 'newpass'));
+	}
+
+	public function testCreateUserInvalidatesCache() {
+		$user1 = $this->getUniqueID('test_');
+		$this->assertFalse($this->backend->userExists($user1));
+		$this->backend->createUser($user1, 'pw');
+		$this->assertTrue($this->backend->userExists($user1));
+	}
+
+	public function testDeleteUserInvalidatesCache() {
+		$user1 = $this->getUniqueID('test_');
+		$this->backend->createUser($user1, 'pw');
+		$this->assertTrue($this->backend->userExists($user1));
+		$this->backend->deleteUser($user1);
+		$this->assertFalse($this->backend->userExists($user1));
+		$this->backend->createUser($user1, 'pw2');
+		$this->assertTrue($this->backend->userExists($user1));
 	}
 }


### PR DESCRIPTION
* downstream of https://github.com/owncloud/core/pull/27068

I can't see the requests in our code. Before and after are the same 8 queries run for doing the login (I send the login form and then profiled this via blackfire.)


@icewind1991 @rullzer @blizzz @nickvergessen I would like your feedback on this. We can also go for the stuff that looks good (like the `if` instead the `while`, the PHPDoc comment and the additional unit tests).