### PR TITLE
HTTP 1.1 used when giving 403 and 404 errors while attempting to down…

### DIFF
--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -264,12 +264,12 @@ class OC_Files {
 		if (\OC\Files\Filesystem::isReadable($filename)) {
 			self::sendHeaders($filename, $name, $rangeArray);
 		} elseif (!\OC\Files\Filesystem::file_exists($filename)) {
-			header("HTTP/1.0 404 Not Found");
+			header("HTTP/1.1 404 Not Found");
 			$tmpl = new OC_Template('', '404', 'guest');
 			$tmpl->printPage();
 			exit();
 		} else {
-			header("HTTP/1.0 403 Forbidden");
+			header("HTTP/1.1 403 Forbidden");
 			die('403 Forbidden');
 		}
 		if (isset($params['head']) && $params['head']) {


### PR DESCRIPTION
* downstream of https://github.com/owncloud/core/pull/27254

cc @icewind1991 @LukasReschke Wasn't this in because it had some problems with some proxies? Or is there any other reason?