### PR TITLE
Clear onpopstate handlers after unit tests

### DIFF
--- a/core/js/tests/specHelper.js
+++ b/core/js/tests/specHelper.js
@@ -177,6 +177,10 @@ window.isPhantom = /phantom/i.test(navigator.userAgent);
 		delete($.fn.select2);
 
 		ajaxErrorStub.restore();
+
+		// reset pop state handlers
+		OC.Util.History._handlers = [];
+
 	});
 })();
 


### PR DESCRIPTION
Fixes issue when running Karma tests in Firefox.

* downstream of https://github.com/owncloud/core/pull/27260

cc @nextcloud/javascript 