### PR TITLE
Fix new app menu on firefox

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -33,7 +33,6 @@
 		width: 0;
 		position: absolute;
 		pointer-events: none;
-		margin-left: -10px;
 	}
 }
 
@@ -479,6 +478,7 @@ nav {
 			vertical-align: top !important;
 			position: relative;
 			height: 44px;
+			display: inline-block;
 		}
 	}
 
@@ -511,7 +511,7 @@ nav {
 		color: rgba(0, 0, 0, .6);
 		width: auto;
 		left: 50%;
-		top: 31px;
+		top: 32px;
 		transform: translateX(-50%);
 		padding: 4px 10px;
 		-webkit-filter: drop-shadow(0 0 5px rgba(150, 150, 150, .75));

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -105,8 +105,8 @@
 									<a href="<?php print_unescaped($entry['href']); ?>" tabindex="3"
 										<?php if( $entry['active'] ): ?> class="active"<?php endif; ?>>
 										<svg width="32" height="32" viewBox="0 0 32 32">
-											<defs><filter id="invert"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0"></feColorMatrix></filter></defs>
-											<image x="0" y="0" width="32" height="32" preserveAspectRatio="xMinYMin meet" filter="url(#invert)" xlink:href="<?php print_unescaped($entry['icon'] . '?v=' . $_['versionHash']); ?>"  class="app-icon"></image>
+											<defs><filter id="invert-<?php p($entry['id']); ?>"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0"></feColorMatrix></filter></defs>
+											<image x="0" y="0" width="32" height="32" preserveAspectRatio="xMinYMin meet" filter="url(#invert-<?php p($entry['id']); ?>)" xlink:href="<?php print_unescaped($entry['icon'] . '?v=' . $_['versionHash']); ?>"  class="app-icon"></image>
 										</svg>
 										<div class="icon-loading-dark" style="display:none;"></div>
 										<span>
@@ -123,8 +123,8 @@
 										<a href="<?php print_unescaped(\OC::$server->getURLGenerator()->linkToRoute('settings.AppSettings.viewApps')); ?>" tabindex="4"
 											<?php if( $_['appsmanagement_active'] ): ?> class="active"<?php endif; ?>>
 											<svg width="32" height="32" viewBox="0 0 32 32" class="app-icon">
-												<defs><filter id="invert"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0"></feColorMatrix></filter></defs>
-												<image x="0" y="0" width="32" height="32" preserveAspectRatio="xMinYMin meet" filter="url(#invert)" xlink:href="<?php print_unescaped(image_path('settings', 'apps.svg') . '?v=' . $_['versionHash']); ?>"></image>
+												<defs><filter id="invert-appsmanagement"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0"></feColorMatrix></filter></defs>
+												<image x="0" y="0" width="32" height="32" preserveAspectRatio="xMinYMin meet" filter="url(#invert-appsmanagement)" xlink:href="<?php print_unescaped(image_path('settings', 'apps.svg') . '?v=' . $_['versionHash']); ?>"></image>
 											</svg>
 											<div class="icon-loading-dark" style="display:none;"></div>
 											<span>


### PR DESCRIPTION
- Correct positionioning of the popover menu on firefox

before:
![2017-03-20-082451_285x94_scrot](https://cloud.githubusercontent.com/assets/3404133/24091188/d56327ea-0d46-11e7-9998-c24ccb3638f2.png)

after:
![2017-03-20-082415_303x81_scrot](https://cloud.githubusercontent.com/assets/3404133/24091190/dca768e0-0d46-11e7-9b44-d61d3824db28.png)

- Use unique ids for filters (fix for #3921)
