### PR TITLE
Override config.php values through environment variables 

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -39,6 +39,9 @@ namespace OC;
  * configuration file of ownCloud.
  */
 class Config {
+
+	const ENV_PREFIX = 'OC_';
+
 	/** @var array Associative array ($key => $value) */
 	protected $cache = array();
 	/** @var string */
@@ -71,15 +74,22 @@ class Config {
 	}
 
 	/**
-	 * Gets a value from config.php
+	 * Returns a config value
 	 *
-	 * If it does not exist, $default will be returned.
+	 * gets its value from an `OC_` prefixed environment variable
+	 * if it doesn't exist from config.php
+	 * if this doesn't exist either, it will return the given `$default`
 	 *
 	 * @param string $key key
 	 * @param mixed $default = null default value
 	 * @return mixed the value or $default
 	 */
 	public function getValue($key, $default = null) {
+		$envValue = getenv(self::ENV_PREFIX . $key);
+		if ($envValue) {
+			return $envValue;
+		}
+
 		if (isset($this->cache[$key])) {
 			return $this->cache[$key];
 		}

--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -86,7 +86,7 @@ class Config {
 	 */
 	public function getValue($key, $default = null) {
 		$envValue = getenv(self::ENV_PREFIX . $key);
-		if ($envValue) {
+		if ($envValue !== false) {
 			return $envValue;
 		}
 

--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -40,7 +40,7 @@ namespace OC;
  */
 class Config {
 
-	const ENV_PREFIX = 'OC_';
+	const ENV_PREFIX = 'NC_';
 
 	/** @var array Associative array ($key => $value) */
 	protected $cache = array();
@@ -76,7 +76,7 @@ class Config {
 	/**
 	 * Returns a config value
 	 *
-	 * gets its value from an `OC_` prefixed environment variable
+	 * gets its value from an `NC_` prefixed environment variable
 	 * if it doesn't exist from config.php
 	 * if this doesn't exist either, it will return the given `$default`
 	 *

--- a/tests/lib/ConfigTest.php
+++ b/tests/lib/ConfigTest.php
@@ -48,6 +48,12 @@ class ConfigTest extends TestCase {
 		$this->assertSame(array('Appenzeller', 'Guinness', 'Kölsch'), $this->config->getValue('beers'));
 	}
 
+	public function testGetValueReturnsEnvironmentValueIfSet() {
+		$this->assertEquals('bar', $this->config->getValue('foo'));
+		putenv('OC_foo=baz');
+		$this->assertEquals('baz', $this->config->getValue('foo'));
+	}
+
 	public function testSetValue() {
 		$this->config->setValue('foo', 'moo');
 		$expectedConfig = $this->initialConfig;

--- a/tests/lib/ConfigTest.php
+++ b/tests/lib/ConfigTest.php
@@ -50,7 +50,7 @@ class ConfigTest extends TestCase {
 
 	public function testGetValueReturnsEnvironmentValueIfSet() {
 		$this->assertEquals('bar', $this->config->getValue('foo'));
-		putenv('OC_foo=baz');
+		putenv('NC_foo=baz');
 		$this->assertEquals('baz', $this->config->getValue('foo'));
 	}
 

--- a/tests/lib/ConfigTest.php
+++ b/tests/lib/ConfigTest.php
@@ -52,6 +52,21 @@ class ConfigTest extends TestCase {
 		$this->assertEquals('bar', $this->config->getValue('foo'));
 		putenv('NC_foo=baz');
 		$this->assertEquals('baz', $this->config->getValue('foo'));
+		putenv('NC_foo'); // unset the env variable
+	}
+
+	public function testGetValueReturnsEnvironmentValueIfSetToZero() {
+		$this->assertEquals('bar', $this->config->getValue('foo'));
+		putenv('NC_foo=0');
+		$this->assertEquals('0', $this->config->getValue('foo'));
+		putenv('NC_foo'); // unset the env variable
+	}
+
+	public function testGetValueReturnsEnvironmentValueIfSetToFalse() {
+		$this->assertEquals('bar', $this->config->getValue('foo'));
+		putenv('NC_foo=false');
+		$this->assertEquals('false', $this->config->getValue('foo'));
+		putenv('NC_foo'); // unset the env variable
 	}
 
 	public function testSetValue() {


### PR DESCRIPTION
* added functionality to override config.php values with 'OC_' prefixed environment variables
* use getenv to read environment variables since apache does not set $_ENV variables, fixed test
* fixes #3926 
* downstream of https://github.com/owncloud/core/pull/26570

@LukasReschke @nickvergessen @rullzer @karlitschek Should we rename the env variables to NC_ or should leave them?