### PR TITLE
Changes Throttle from subnet to ip based

### DIFF
--- a/lib/private/Security/Bruteforce/Throttler.php
+++ b/lib/private/Security/Bruteforce/Throttler.php
@@ -201,7 +201,7 @@ class Throttler {
 		$qb->select('*')
 			->from('bruteforce_attempts')
 			->where($qb->expr()->gt('occurred', $qb->createNamedParameter($cutoffTime)))
-			->andWhere($qb->expr()->eq('subnet', $qb->createNamedParameter($this->getSubnet($ip))));
+			->andWhere($qb->expr()->eq('ip', $qb->createNamedParameter($ip)));
 
 		if ($action !== '') {
 			$qb->andWhere($qb->expr()->eq('action', $qb->createNamedParameter($action)));


### PR DESCRIPTION
In case of a brute force attack, the throttle should only effect the
attacker’s ip and not the whole subnet. Inside of a local network, that
would effect everyone else in the network using nextcloud. If you
expect a real brute force attack from the internet, the attacker
wouldn’t be so dumb and have all attacking computers in the same
subnet. So I don’t really get why blocking the subnet would make sense
in any case.
#3971 