### PR TITLE
Fix position of triangle in app menu

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -537,7 +537,7 @@ nav {
 		border-width: 10px;
 		transform: translateX(-50%);
 		left: 50%;
-		top: 12px;
+		top: 13px;
 		z-index: 100;
 		display: block;
 	}


### PR DESCRIPTION
Before (Firefox, Chrome, Safari):

<img width="989" alt="bildschirmfoto 2017-03-21 um 16 46 21" src="https://cloud.githubusercontent.com/assets/245432/24174459/4511670e-0e56-11e7-8a3e-da7e0d008397.png">

After:

<img width="974" alt="bildschirmfoto 2017-03-21 um 16 47 45" src="https://cloud.githubusercontent.com/assets/245432/24174468/50229b36-0e56-11e7-87cf-2cd6e0e5b16f.png">

Followup to #3951
