### PR TITLE
Remove tooltip of delete button for systemtags

### DIFF
--- a/core/js/systemtags/systemtagsinputfield.js
+++ b/core/js/systemtags/systemtagsinputfield.js
@@ -198,6 +198,7 @@
 			var $item = $(ev.target).closest('.systemtags-item');
 			var tagId = $item.attr('data-id');
 			this.collection.get(tagId).destroy();
+			$(ev.target).tooltip('hide');
 			$item.closest('.select2-result').remove();
 			// TODO: spinner
 			return false;


### PR DESCRIPTION
* fixes #3967

Steps:
* click the delete button of a tag in the sidebar
* before: "Delete" tooltip stayed there
* after: tooltip is gone

cc @SteveQi 