### PR TITLE
Only initialize backbone once

### DIFF
--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -119,7 +119,6 @@ class OC_Template extends \OC\Template\Base {
 			OC_Util::addScript('select2-toggleselect');
 
 			OC_Util::addScript('oc-backbone', null, true);
-			OC_Util::addVendorScript('core', 'backbone/backbone', true);
 			OC_Util::addVendorScript('snapjs/dist/latest/snap', null, true);
 			OC_Util::addScript('mimetypelist', null, true);
 			OC_Util::addScript('mimetype', null, true);


### PR DESCRIPTION
We loaded backbone.js twice. Which caused the initialization to run twice.

Because of https://github.com/nextcloud/server/blob/master/core/js/oc-backbone.js#L13 when only loading backbone once the global `Backbone` will be set to undefined.

@nickvergessen this was the issue you had with https://github.com/nextcloud/server/pull/3795

Best solution is to always use OC.Backbone instead of Backbone directly. But this fix makes it work with Backbone again as well.