### PR TITLE
Fix workflow engine mimetype detection when creating a directory

### DIFF
--- a/apps/workflowengine/lib/Check/FileMimeType.php
+++ b/apps/workflowengine/lib/Check/FileMimeType.php
@@ -77,6 +77,12 @@ class FileMimeType extends AbstractStringCheck {
 		}
 
 		if ($this->isWebDAVRequest()) {
+			// Creating a folder
+			if ($this->request->getMethod() === 'MKCOL') {
+				$this->mimeType[$this->storage->getId()][$this->path] = 'httpd/unix-directory';
+				return $this->mimeType[$this->storage->getId()][$this->path];
+			}
+
 			if ($this->request->getMethod() === 'PUT') {
 				$path = $this->request->getPathInfo();
 				$this->mimeType[$this->storage->getId()][$this->path] = $this->mimeTypeDetector->detectPath($path);


### PR DESCRIPTION
Fix https://github.com/nextcloud/files_accesscontrol/issues/58