### PR TITLE
Setup.php: Don't assume that RewriteEngine is already on

### DIFF
--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -440,6 +440,7 @@ class Setup {
 		if($rewriteBase !== '') {
 			$content .= "\n<IfModule mod_rewrite.c>";
 			$content .= "\n  Options -MultiViews";
+			$content .= "\n  RewriteEngine on";
 			$content .= "\n  RewriteRule ^core/js/oc.js$ index.php [PT,E=PATH_INFO:$1]";
 			$content .= "\n  RewriteRule ^core/preview.png$ index.php [PT,E=PATH_INFO:$1]";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !\\.(css|js|svg|gif|png|html|ttf|woff|ico|jpg|jpeg)$";


### PR DESCRIPTION
None of the rewrite rules are honored when `RewriteEngine` is off, causing a redirect loop. This commit adds `RewriteEngine on` to `.htaccess`.