### PR TITLE
Make public links work with master key

### DIFF
--- a/apps/encryption/lib/KeyManager.php
+++ b/apps/encryption/lib/KeyManager.php
@@ -399,17 +399,28 @@ class KeyManager {
 	 * @return string
 	 */
 	public function getFileKey($path, $uid) {
+		if ($uid === '') {
+			$uid = null;
+		}
+		$publicAccess = is_null($uid);
 		$encryptedFileKey = $this->keyStorage->getFileKey($path, $this->fileKeyId, Encryption::ID);
 
 		if (empty($encryptedFileKey)) {
 			return '';
 		}
 
-		if (!is_null($uid) && $this->util->isMasterKeyEnabled()) {
+		if ($this->util->isMasterKeyEnabled()) {
 			$uid = $this->getMasterKeyId();
-		}
-
-		if (is_null($uid)) {
+			$shareKey = $this->getShareKey($path, $uid);
+			if ($publicAccess) {
+				$privateKey = $this->getSystemPrivateKey($uid);
+				$privateKey = $this->crypt->decryptPrivateKey($privateKey, $this->getMasterKeyPassword(), $uid);
+			} else {
+				// when logged in, the master key is already decrypted in the session
+				$privateKey = $this->session->getPrivateKey();
+			}
+		} else if ($publicAccess) {
+			// use public share key for public links
 			$uid = $this->getPublicShareKeyId();
 			$shareKey = $this->getShareKey($path, $uid);
 			$privateKey = $this->keyStorage->getSystemUserKey($this->publicShareKeyId . '.privateKey', Encryption::ID);

--- a/apps/encryption/lib/KeyManager.php
+++ b/apps/encryption/lib/KeyManager.php
@@ -405,7 +405,7 @@ class KeyManager {
 			return '';
 		}
 
-		if ($this->util->isMasterKeyEnabled()) {
+		if (!is_null($uid) && $this->util->isMasterKeyEnabled()) {
 			$uid = $this->getMasterKeyId();
 		}
 

--- a/apps/encryption/tests/KeyManagerTest.php
+++ b/apps/encryption/tests/KeyManagerTest.php
@@ -418,7 +418,11 @@ class KeyManagerTest extends TestCase {
 			['', false, 'privateKey', true],
 			['', false, false, ''],
 			['', true, 'privateKey', true],
-			['', true, false, '']
+			['', true, false, ''],
+			[null, false, 'privateKey', true],
+			[null, false, false, ''],
+			[null, true, 'privateKey', true],
+			[null, true, false, '']
 		];
 	}
 

--- a/apps/encryption/tests/KeyManagerTest.php
+++ b/apps/encryption/tests/KeyManagerTest.php
@@ -349,6 +349,19 @@ class KeyManagerTest extends TestCase {
 		$this->assertTrue($this->instance->getEncryptedFileKey('/'));
 	}
 
+	public function dataTestGetFileKey() {
+		return [
+			['user1', false, 'privateKey', true],
+			['user1', false, false, ''],
+			['user1', true, 'privateKey', true],
+			['user1', true, false, ''],
+			[null, false, 'privateKey', true],
+			[null, false, false, ''],
+			[null, true, 'privateKey', true],
+			[null, true, false, '']
+		];
+	}
+
 	/**
 	 * @dataProvider dataTestGetFileKey
 	 *
@@ -363,6 +376,10 @@ class KeyManagerTest extends TestCase {
 
 		if ($isMasterKeyEnabled) {
 			$expectedUid = 'masterKeyId';
+			$this->configMock->expects($this->any())->method('getSystemValue')->with('secret')
+				->willReturn('password');
+		} else if (!$uid) {
+			$expectedUid = 'systemKeyId';
 		} else {
 			$expectedUid = $uid;
 		}
@@ -379,6 +396,9 @@ class KeyManagerTest extends TestCase {
 			->with($path, $expectedUid . '.shareKey', 'OC_DEFAULT_MODULE')
 			->willReturn(true);
 
+		$this->utilMock->expects($this->any())->method('isMasterKeyEnabled')
+			->willReturn($isMasterKeyEnabled);
+
 		if (is_null($uid)) {
 			$this->keyStorageMock->expects($this->once())
 				->method('getSystemUserKey')
@@ -389,8 +409,6 @@ class KeyManagerTest extends TestCase {
 		} else {
 			$this->keyStorageMock->expects($this->never())
 				->method('getSystemUserKey');
-			$this->utilMock->expects($this->once())->method('isMasterKeyEnabled')
-				->willReturn($isMasterKeyEnabled);
 			$this->sessionMock->expects($this->once())->method('getPrivateKey')->willReturn($privateKey);
 		}
 
@@ -407,23 +425,6 @@ class KeyManagerTest extends TestCase {
 			$this->instance->getFileKey($path, $uid)
 		);
 
-	}
-
-	public function dataTestGetFileKey() {
-		return [
-			['user1', false, 'privateKey', true],
-			['user1', false, false, ''],
-			['user1', true, 'privateKey', true],
-			['user1', true, false, ''],
-			['', false, 'privateKey', true],
-			['', false, false, ''],
-			['', true, 'privateKey', true],
-			['', true, false, ''],
-			[null, false, 'privateKey', true],
-			[null, false, false, ''],
-			[null, true, 'privateKey', true],
-			[null, true, false, '']
-		];
 	}
 
 	public function testDeletePrivateKey() {


### PR DESCRIPTION
Make master key work for public links

fix for https://github.com/owncloud/core/issues/27261

Steps to test:


1. setup nextcloud
2. occ app:enable encryption
3. occ encryption:enable
4. occ encryption:enable-master-key, answer yes
5. Create a user "user1"
6. Login as "user1"
7. Create a file "bacon.txt"
9.  Share "bacon.txt" with link
10. Log out
11. Open link
12. Download file

* downstream of https://github.com/owncloud/core/pull/27335

@nextcloud/encryption 