### PR TITLE
Cloudflare support

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -610,7 +610,11 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 				}
 			}
 		}
-
+		// Support Cloudflare 'proxy'
+		$cloudflare = $this->config->getSystemValue('cloudflare');
+		if($cloudflare && (isset($_SERVER['HTTP_CF_CONNECTING_IP']))
+		   return $_SERVER['HTTP_CF_CONNECTING_IP'];
+		   
 		return $remoteAddress;
 	}
 

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -612,7 +612,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		}
 		// Support Cloudflare 'proxy'
 		$cloudflare = $this->config->getSystemValue('cloudflare');
-		if($cloudflare && (isset($_SERVER['HTTP_CF_CONNECTING_IP']))
+		if($cloudflare && (isset($_SERVER['HTTP_CF_CONNECTING_IP'])))
 		   return $_SERVER['HTTP_CF_CONNECTING_IP'];
 		   
 		return $remoteAddress;


### PR DESCRIPTION
Cloudflare changes ['REMOTE_ADDR'] so you need to use ['HTTP_CF_CONNECTING_IP'] to get the real client ip.
Enable feature in configfile: 'cloudflare' => true,