### PR TITLE
fix bug with shared_by for own calendars if shared

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -279,6 +279,10 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 		$readOnlyPropertyName = '{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}read-only';
 		while($row = $result->fetch()) {
+			if ($row['principaluri'] === $principalUri) {
+				continue;
+			}
+
 			$readOnly = (int) $row['access'] === Backend::ACCESS_READ;
 			if (isset($calendars[$row['id']])) {
 				if ($readOnly) {

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -174,6 +174,10 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 
 		$readOnlyPropertyName = '{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}read-only';
 		while($row = $result->fetch()) {
+			if ($row['principaluri'] === $principalUri) {
+				continue;
+			}
+
 			$readOnly = (int) $row['access'] === Backend::ACCESS_READ;
 			if (isset($addressBooks[$row['id']])) {
 				if ($readOnly) {


### PR DESCRIPTION
fix bug introduced with https://github.com/nextcloud/server/commit/2eb27c636d7fc73e9d25f8531b49f96908506a19

Master:
Users see "shared_by_user" for their own calendars

That's not the wanted behavior.

This branch:
no "shared_by_user" for your own calendars

please review @LukasReschke @nickvergessen 