### PR TITLE
fix emptycontent font color lightness

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -298,7 +298,7 @@ body {
 }
 
 #emptycontent, .emptycontent {
-	color: nc-darken($color-main-background, 8%);
+	color: nc-lighten($color-main-text, 53%);
 	text-align: center;
 	margin-top: 30vh;
 	width: 100%;


### PR DESCRIPTION
This was some erroneous replacement in https://github.com/nextcloud/server/pull/3530/commits/7381a2ec5c4d2fa5324e8927e81f858b11005ce7 which made the font color too light. Please review @juliushaertl @nextcloud/designers :)

Before:
![capture du 2017-03-26 15-20-28](https://cloud.githubusercontent.com/assets/925062/24331611/fd8bcdbc-1237-11e7-9852-9be11d5330dc.png)

After:
![capture du 2017-03-26 15-21-08](https://cloud.githubusercontent.com/assets/925062/24331610/fd8b220e-1237-11e7-9134-3da02f63ccac.png)