### PR TITLE
GZip generated CSS/JS files

### DIFF
--- a/core/Controller/JsController.php
+++ b/core/Controller/JsController.php
@@ -29,6 +29,8 @@ use OCP\AppFramework\Http\FileDisplayResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
+use OCP\Files\SimpleFS\ISimpleFile;
+use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\IRequest;
 
 class JsController extends Controller {
@@ -63,12 +65,16 @@ class JsController extends Controller {
 	public function getJs($fileName, $appName) {
 		try {
 			$folder = $this->appData->getFolder($appName);
-			$jsFile = $folder->getFile($fileName);
+			$gzip = false;
+			$file = $this->getFile($folder, $fileName, $gzip);
 		} catch(NotFoundException $e) {
 			return new NotFoundResponse();
 		}
 
-		$response = new FileDisplayResponse($jsFile, Http::STATUS_OK, ['Content-Type' => 'application/javascript']);
+		$response = new FileDisplayResponse($file, Http::STATUS_OK, ['Content-Type' => 'application/javascript']);
+		if ($gzip) {
+			$response->addHeader('Content-Encoding', 'gzip');
+		}
 		$response->cacheFor(86400);
 		$expires = new \DateTime();
 		$expires->setTimestamp($this->timeFactory->getTime());
@@ -76,5 +82,27 @@ class JsController extends Controller {
 		$response->addHeader('Expires', $expires->format(\DateTime::RFC1123));
 		$response->addHeader('Pragma', 'cache');
 		return $response;
+	}
+
+	/**
+	 * @param ISimpleFolder $folder
+	 * @param string $fileName
+	 * @param bool $gzip is set to true if we use the gzip file
+	 * @return ISimpleFile
+	 */
+	private function getFile(ISimpleFolder $folder, $fileName, &$gzip) {
+		$encoding = $this->request->getHeader('Accept-Encoding');
+
+		if ($encoding !== null && strpos($encoding, 'gzip') !== false) {
+			try {
+				$gzip = true;
+				return $folder->getFile($fileName . '.gz');
+			} catch (NotFoundException $e) {
+				// continue
+			}
+		}
+
+		$gzip = false;
+		return $folder->getFile($fileName);
 	}
 }

--- a/lib/private/Template/JSCombiner.php
+++ b/lib/private/Template/JSCombiner.php
@@ -155,8 +155,15 @@ class JSCombiner {
 		}
 
 		try {
+			$gzipFile = $folder->getFile($fileName . '.gz');
+		} catch (NotFoundException $e) {
+			$gzipFile = $folder->newFile($fileName . '.gz');
+		}
+
+		try {
 			$cachedfile->putContent($res);
 			$depFile->putContent(json_encode($deps));
+			$gzipFile->putContent(gzencode($res, 9));
 			return true;
 		} catch (NotPermittedException $e) {
 			return false;

--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -186,9 +186,18 @@ class SCSSCacher {
 			return false;
 		}
 
+		// Gzip file
 		try {
-			$cachedfile->putContent($this->rebaseUrls($compiledScss, $webDir));
+			$gzipFile = $folder->getFile($fileNameCSS . '.gz');
+		} catch (NotFoundException $e) {
+			$gzipFile = $folder->newFile($fileNameCSS . '.gz');
+		}
+
+		try {
+			$data = $this->rebaseUrls($compiledScss, $webDir);
+			$cachedfile->putContent($data);
 			$depFile->putContent(json_encode($scss->getParsedFiles()));
+			$gzipFile->putContent(gzencode($data), 9);
 			$this->logger->debug($webDir.'/'.$fileNameSCSS.' compiled and successfully cached', ['app' => 'core']);
 			return true;
 		} catch(NotPermittedException $e) {

--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -197,7 +197,7 @@ class SCSSCacher {
 			$data = $this->rebaseUrls($compiledScss, $webDir);
 			$cachedfile->putContent($data);
 			$depFile->putContent(json_encode($scss->getParsedFiles()));
-			$gzipFile->putContent(gzencode($data), 9);
+			$gzipFile->putContent(gzencode($data, 9));
 			$this->logger->debug($webDir.'/'.$fileNameSCSS.' compiled and successfully cached', ['app' => 'core']);
 			return true;
 		} catch(NotPermittedException $e) {


### PR DESCRIPTION
Since in production the SCSS files are compiled once and the javascript
files are combined once we can just as well gzip them aggresively.

This means that once they are requested and the browser supports gzip we
can just serve the gzipped file saving precious bandwidth.


TODO:
- [x] Extend tests