### PR TITLE
Move X-Frame-Options into PHP

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -14,7 +14,6 @@
     Header set X-Content-Type-Options "nosniff"
     Header set X-XSS-Protection "1; mode=block"
     Header set X-Robots-Tag "none"
-    Header set X-Frame-Options "SAMEORIGIN"
     Header set X-Download-Options "noopen"
     Header set X-Permitted-Cross-Domain-Policies "none"
     SetEnv modHeadersAvailable true

--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -255,13 +255,13 @@ class OC_Response {
 			. 'media-src *; ' 
 			. 'connect-src *';
 		header('Content-Security-Policy:' . $policy);
+		header('X-Frame-Options: Sameorigin'); // Disallow iFraming from other domains
 
 		// Send fallback headers for installations that don't have the possibility to send
 		// custom headers on the webserver side
 		if(getenv('modHeadersAvailable') !== 'true') {
 			header('X-XSS-Protection: 1; mode=block'); // Enforce browser based XSS filters
 			header('X-Content-Type-Options: nosniff'); // Disable sniffing the content type for IE
-			header('X-Frame-Options: Sameorigin'); // Disallow iFraming from other domains
 			header('X-Robots-Tag: none'); // https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag
 			header('X-Download-Options: noopen'); // https://msdn.microsoft.com/en-us/library/jj542450(v=vs.85).aspx
 			header('X-Permitted-Cross-Domain-Policies: none'); // https://www.adobe.com/devnet/adobe-media-server/articles/cross-domain-xml-for-streaming.html


### PR DESCRIPTION
The public calendar view should be embeddable and we can't do that if the .htaccess sets a global X-Frame-Options.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>

