### PR TITLE
move apps management from left apps menu to right settings menu

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -321,30 +321,6 @@ nav {
 	}
 }
 
-/* Apps management */
-.apps-management {
-	min-height: initial;
-	height: initial;
-	margin: 0;
-	a {
-		svg,
-		span {
-			-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=30)';
-			opacity: .3;
-		}
-		/* icon opacity and hover effect */
-		&:hover svg,
-		&:focus svg,
-		&.active svg,
-		&:hover span,
-		&:focus span,
-		&.active span {
-			-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=100)';
-			opacity: 1;
-		}
-	}
-}
-
 #apps {
 	max-height: calc(100vh - 100px);
 	overflow: auto;

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -80,16 +80,6 @@
 									<span><?php p($l->t('More apps')); ?></span>
 								</a>
 							</li>
-							<?php if(OC_User::isAdminUser(OC_User::getUser())):	?>
-								<li <?php if(count($_['navigation'])>$headerIconCount-1): ?> class="hidden apps-management"<?php else: ?> class="apps-management"  <?php endif; ?>>
-									<a href="<?php print_unescaped(\OC::$server->getURLGenerator()->linkToRoute('settings.AppSettings.viewApps')); ?>" tabindex="4"
-										<?php if( $_['appsmanagement_active'] ): ?> class="active"<?php endif; ?>>
-										<img src="<?php print_unescaped(image_path('settings', 'apps.svg') . '?v=' . $_['versionHash']); ?>" />
-										<div class="icon-loading-dark" style="display:none;"></div>
-										<span><?php p($l->t('Apps')); ?></span>
-									</a>
-								</li>
-							<?php endif; ?>
 					</ul>
 				</div>
 
@@ -115,25 +105,6 @@
 									</a>
 									</li>
 								<?php endforeach; ?>
-								<?php
-								/* show "More apps" link to app administration directly in app navigation, as last entry */
-								if(OC_User::isAdminUser(OC_User::getUser())):
-									?>
-									<li class="apps-management">
-										<a href="<?php print_unescaped(\OC::$server->getURLGenerator()->linkToRoute('settings.AppSettings.viewApps')); ?>" tabindex="4"
-											<?php if( $_['appsmanagement_active'] ): ?> class="active"<?php endif; ?>>
-											<svg width="32" height="32" viewBox="0 0 32 32" class="app-icon">
-												<defs><filter id="invert-appsmanagement"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0"></feColorMatrix></filter></defs>
-												<image x="0" y="0" width="32" height="32" preserveAspectRatio="xMinYMin meet" filter="url(#invert-appsmanagement)" xlink:href="<?php print_unescaped(image_path('settings', 'apps.svg') . '?v=' . $_['versionHash']); ?>"></image>
-											</svg>
-											<div class="icon-loading-dark" style="display:none;"></div>
-											<span>
-								<?php p($l->t('Apps')); ?>
-							</span>
-										</a>
-									</li>
-								<?php endif; ?>
-
 							</ul>
 						</div>
 					</div></nav>
@@ -174,6 +145,15 @@
 							</a>
 						</li>
 					<?php endforeach; ?>
+						<?php if(OC_User::isAdminUser(OC_User::getUser())):	?>
+						<li>
+							<a href="<?php print_unescaped(\OC::$server->getURLGenerator()->linkToRoute('settings.AppSettings.viewApps')); ?>"
+								<?php if( $_['appsmanagement_active'] ): ?> class="active"<?php endif; ?>>
+								<img src="<?php print_unescaped(image_path('settings', 'apps.svg') . '?v=' . $_['versionHash']); ?>" />
+								<?php p($l->t('Apps')); ?>
+							</a>
+						</li>
+						<?php endif; ?>
 						<li>
 							<a id="logout" <?php print_unescaped(OC_User::getLogoutAttribute()); ?>>
 								<img alt="" src="<?php print_unescaped(image_path('', 'actions/logout.svg') . '?v=' . $_['versionHash']); ?>">

--- a/settings/img/apps.svg
+++ b/settings/img/apps.svg
@@ -1,1 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="32" width="32" version="1"><path d="M14 6v8H6v4h8v8h4v-8h8v-4h-8V6h-4z" fill="#FFF"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" version="1">
+ <path d="m7 2v5h-5v2h5v5h2v-5h5v-2h-5v-5z"/>
+</svg>

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -539,12 +539,10 @@ OC.Settings.Apps = OC.Settings.Apps || {
 
 
 
-				if (navEntries.length > 7) {
+				if (navEntries.length > 8) {
 					$('#more-apps').show();
-					$('.apps-management').hide();
 				} else {
 					$('#more-apps').hide();
-					$('.apps-management').show();
 				}
 			}
 		});


### PR DESCRIPTION
The problem was that apps management was just way too present there. Apps aren’t added and managed that often so it shouldn’t be that directly visible.

Also when you only have few apps, the plus icon is very easy to confuse with the upload button, and it’s a lot bigger too.

Before & after:
![capture du 2017-03-26 19-14-30](https://cloud.githubusercontent.com/assets/925062/24333446/803080c6-1258-11e7-827f-98f2fb821586.png) ![capture du 2017-03-26 19-14-42](https://cloud.githubusercontent.com/assets/925062/24333447/80306884-1258-11e7-8dc6-fc8b979f1f86.png)

As discussed @karlitschek Please review @nextcloud/designers 

Oh and btw @nickvergessen @schiessle I guess someone of you can help me with placing it correctly – I actually want the »Apps« entry between »Admin« and »Users« in the menu. Currently it’s just between Help and Log out which is strange.
