### PR TITLE
Fix pop over menu opacity

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -622,7 +622,6 @@ html.ie8 .column-mtime .selectedActions {
 #fileList tr:hover a.action,
 #fileList a.action.permanent,
 #fileList tr:focus a.action,
-#fileList a.action.permanent,
 #fileList tr:hover a.action.no-permission:hover,
 #fileList tr:focus a.action.no-permission:focus,
 /*#fileList .name:focus .action,*/
@@ -648,6 +647,19 @@ html.ie8 .column-mtime .selectedActions {
 	opacity: .7;
 	display:inline;
 }
+
+#fileList .fileActionsMenu a.action.permanent {
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=70)" !important;
+	filter: alpha(opacity=70) !important;
+	opacity: .7 !important;
+}
+#fileList .fileActionsMenu a.action.permanent:hover,
+#fileList .fileActionsMenu a.action.permanent:focus {
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)" !important;
+	filter: alpha(opacity=100) !important;
+	opacity: 1 !important;
+}
+
 #fileList tr a.action.disabled {
 	background: none;
 }
@@ -655,8 +667,8 @@ html.ie8 .column-mtime .selectedActions {
 /* show share action of shared items darker to distinguish from non-shared */
 #fileList a.action.action-share.permanent.shared-style,
 /* show hovered permanent entries darker */
-#fileList tr a.action.action.permanent:hover,
-#fileList tr a.action.action.permanent:focus {
+#fileList tr a.action.permanent:hover,
+#fileList tr a.action.permanent:focus {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=70)" !important;
 	filter: alpha(opacity=70) !important;
 	opacity: .7 !important;

--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -8,9 +8,9 @@
  * @copyright Copyright (c) 2016, Roeland Jago Douma <rullzer@owncloud.com>
  * @copyright Copyright (c) 2016, jowi <sjw@gmx.ch>
  * @copyright Copyright (c) 2015, Hendrik Leppelsack <hendrik@leppelsack.de>
- * @copyright Copyright (c) 2015, Jan-Christoph Borchardt <hey@jancborchardt.net>
  * @copyright Copyright (c) 2015, Thomas Müller <thomas.mueller@tmit.eu>
  * @copyright Copyright (c) 2015, Vincent Petry <pvince81@owncloud.com>
+ * @copyright Copyright (c) 2014-2017, Jan-Christoph Borchardt <hey@jancborchardt.net>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -664,10 +664,10 @@ em {
 			}
 		}
 		.menuitem {
-			-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=70)' !important;
-			filter: alpha(opacity = 70) !important;
-			opacity: .7 !important;
-			&:hover, &:focus {
+			-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=50)' !important;
+			filter: alpha(opacity = 50) !important;
+			opacity: .5 !important;
+			&:hover, &:focus, &.active {
 				-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=100)' !important;
 				filter: alpha(opacity = 100) !important;
 				opacity: 1 !important;

--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -632,9 +632,6 @@ em {
 			cursor: pointer;
 			line-height: 36px;
 			border: 0;
-			-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=50)' !important;
-			filter: alpha(opacity = 50) !important;
-			opacity: .5 !important;
 			background-color: transparent;
 			display: flex;
 			align-items: center;
@@ -643,25 +640,13 @@ em {
 			margin: 0;
 			font-weight: inherit;
 			box-shadow: none;
-			color: nc-lighten($color-main-text, 20%) !important; /* Overwrite app-navigation li */
 			/* prevent .action class to break the design */
 			&.action {
 				padding: inherit !important;
 			}
-			&:hover, &:focus {
-				-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=100)' !important;
-				filter: alpha(opacity = 100) !important;
-				opacity: 1 !important;
-				background-color: transparent;
-			}
 			> span {
 				cursor: pointer;
 				white-space: nowrap;
-			}
-			span {
-				-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=70)' !important;
-				filter: alpha(opacity = 70) !important;
-				opacity: .7 !important;
 			}
 			> p {
 				width: 150px;
@@ -676,6 +661,16 @@ em {
 			> img {
 				width: 16px;
 				padding: 0 10px;
+			}
+		}
+		.menuitem {
+			-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=70)' !important;
+			filter: alpha(opacity = 70) !important;
+			opacity: .7 !important;
+			&:hover, &:focus {
+				-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=100)' !important;
+				filter: alpha(opacity = 100) !important;
+				opacity: 1 !important;
 			}
 		}
 		[class^='icon-'],


### PR DESCRIPTION
Before:

<img width="398" alt="bildschirmfoto 2017-03-26 um 14 10 34" src="https://cloud.githubusercontent.com/assets/245432/24334785/063ba734-122e-11e7-9563-dc2603eb6071.png">
<img width="342" alt="bildschirmfoto 2017-03-26 um 14 10 37" src="https://cloud.githubusercontent.com/assets/245432/24334786/065649ae-122e-11e7-9646-f240f3f3afbf.png">

After:

<img width="315" alt="bildschirmfoto 2017-03-26 um 14 10 10" src="https://cloud.githubusercontent.com/assets/245432/24334789/0b18ed34-122e-11e7-960c-15a4d84a926a.png">
<img width="445" alt="bildschirmfoto 2017-03-26 um 14 10 13" src="https://cloud.githubusercontent.com/assets/245432/24334788/0b17639c-122e-11e7-9858-34018fe9c963.png">

Fixes #3522

cc @nextcloud/designers @ChristophWurst @nickvergessen @rullzer @skjnldsv @juliushaertl 
