### PR TITLE
round the mtime in touch

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -569,7 +569,7 @@ class View {
 				$mtime = time();
 			}
 			//if native touch fails, we emulate it by changing the mtime in the cache
-			$this->putFileInfo($path, array('mtime' => $mtime));
+			$this->putFileInfo($path, array('mtime' => floor($mtime)));
 		}
 		return true;
 	}

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -591,6 +591,23 @@ class ViewTest extends \Test\TestCase {
 	/**
 	 * @medium
 	 */
+	public function testTouchFloat() {
+		$storage = $this->getTestStorage(true, TemporaryNoTouch::class);
+
+		Filesystem::mount($storage, array(), '/');
+
+		$rootView = new View('');
+		$oldCachedData = $rootView->getFileInfo('foo.txt');
+
+		$rootView->touch('foo.txt', 500.5);
+
+		$cachedData = $rootView->getFileInfo('foo.txt');
+		$this->assertEquals(500, $cachedData['mtime']);
+	}
+
+	/**
+	 * @medium
+	 */
 	public function testViewHooks() {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();


### PR DESCRIPTION
Postgres doesn't like it when you try to put a float in an int.

Likely caused by a browser reportinig a frational mtime.

Fixes #4095

@marcobrt can you check if this fixes the problem for you