### PR TITLE
show triangle below user menu too when an entry inside there is active

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -457,6 +457,7 @@ nav {
 		vertical-align: top !important;
 		height: 20px;
 		padding: 12px;
+		cursor: pointer;
 
 		a {
 			opacity: 0.6;

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -385,8 +385,13 @@ nav {
 
 	#expandDisplayName {
 		padding: 8px;
-		opacity: .7;
+		opacity: .6;
 	}
+}
+
+/* full opacity for gear icon if active */
+#body-settings #expandDisplayName {
+	opacity: 1;
 }
 
 /* show triangle below user menu if active */

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -344,6 +344,7 @@ nav {
 
 /* User menu on the right */
 #expand {
+	position: relative;
 	display: flex;
 	align-items: center;
 	padding: 7px 20px 6px 10px;
@@ -386,6 +387,23 @@ nav {
 		padding: 8px;
 		opacity: .7;
 	}
+}
+
+/* show triangle below user menu if active */
+#body-settings #expand:before {
+	content: ' ';
+	height: 0;
+	width: 0;
+	position: absolute;
+	pointer-events: none;
+	border: 0 solid transparent;
+	border-bottom-color: white;
+	border-width: 10px;
+	transform: translateX(-50%);
+	left: 26px;
+	bottom: 0;
+	z-index: 100;
+	display: block;
 }
 
 #expanddiv {

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -187,7 +187,7 @@ body {
 		-webkit-transition: all 100ms;
 		transition: all 100ms;
 		-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=70)';
-		opacity: .7;
+		opacity: .6;
 		&:focus, &:active, &:valid {
 			color: $color-primary-text;
 			width: 155px;


### PR DESCRIPTION
For nicer consistency with other aspects – please review @nextcloud/designers 

Before:
![capture du 2017-03-27 20-20-03](https://cloud.githubusercontent.com/assets/925062/24371391/e62ba48c-132a-11e7-9cf6-c6f64898347e.png)
After (see top right)
![capture du 2017-03-27 20-20-37](https://cloud.githubusercontent.com/assets/925062/24371390/e6120ea0-132a-11e7-8322-e0e0059e359d.png)
