### PR TITLE
show active indicator on current app even when hovering other icons

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -494,7 +494,7 @@ nav {
 		display: inline-block;
 	}
 
-
+	/* show triangle below active app */
 	li:hover a:before,
 	li a.active:before {
 		content: ' ';
@@ -515,11 +515,6 @@ nav {
 	&.menu-open li a.active:before,
 	&.menu-open li:hover span {
 		display: none !important;
-	}
-
-	/* do not show active indicator when hovering other icons */
-	&:hover li:not(:hover) a:before {
-		display: none;
 	}
 
 	li.hidden {


### PR DESCRIPTION
What do you think @nextcloud/designers @juliushaertl @eppfel? For me it was a bit too twitchy hiding the arrow on the current app, and it’s also a bit wrong since the app is still there. :)