### PR TITLE
fix clickable area of app entries

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -446,7 +446,7 @@ nav {
 			text-align: center;
 			vertical-align: top !important;
 			position: relative;
-			height: 44px;
+			height: 32px;
 			display: inline-block;
 		}
 	}


### PR DESCRIPTION
This is what it looked like before:
![capture du 2017-03-28 22-39-29](https://cloud.githubusercontent.com/assets/925062/24426346/b7e38576-1407-11e7-861f-30d5e09cca43.png)

The clickable area extended too far below, leading to the app area being overlapped. This fixes that.

Please review @nextcloud/designers 