### PR TITLE
Replace unecessary unescaped prints with print

### DIFF
--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -23,7 +23,7 @@
 			<a href="<?php p($_['downloadLink']); ?>" class="button<?php if ($_['updaterEnabled']) { p(' hidden'); } ?>"><?php p($l->t('Download now')) ?></a>
 		<?php } ?>
 	<?php } else { ?>
-		<strong><?php print_unescaped($l->t('Your version is up to date.')); ?></strong>
+		<strong><?php p($l->t('Your version is up to date.')); ?></strong>
 		<span class="icon-info svg" title="<?php p($l->t('Checked on %s', [$lastCheckedDate])) ?>"></span>
 	<?php } ?>
 

--- a/core/templates/error.php
+++ b/core/templates/error.php
@@ -3,7 +3,7 @@
 		<li class='error'>
 			<?php p($error['error']) ?><br>
 			<?php if(isset($error['hint']) && $error['hint']): ?>
-				<p class='hint'><?php print_unescaped($error['hint']) ?></p>
+				<p class='hint'><?php p($error['hint']) ?></p>
 			<?php endif;?>
 		</li>
 	<?php endforeach ?>


### PR DESCRIPTION
There's no need to have those unescaped from what I can see.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>