### PR TITLE
Fix check for cache value in JSCombiner

### DIFF
--- a/lib/private/Template/JSCombiner.php
+++ b/lib/private/Template/JSCombiner.php
@@ -98,7 +98,7 @@ class JSCombiner {
 		$fileName = str_replace('.json', '.js', $fileName) . '.deps';
 		try {
 			$deps = $this->depsCache->get($folder->getName() . '-' . $fileName);
-			if ($deps === null) {
+			if ($deps === null || $deps === '') {
 				$depFile = $folder->getFile($fileName);
 				$deps = $depFile->getContent();
 				$this->depsCache->set($folder->getName() . '-' . $fileName, $deps);


### PR DESCRIPTION
* fixes following log output, because there was empty string
  stored in the cache

```
Invalid argument supplied for foreach() at lib/private/Template/JSCombiner.php#108
```