### PR TITLE
Fix gzip files for Safari

### DIFF
--- a/core/Controller/CssController.php
+++ b/core/Controller/CssController.php
@@ -95,7 +95,7 @@ class CssController extends Controller {
 		if ($encoding !== null && strpos($encoding, 'gzip') !== false) {
 			try {
 				$gzip = true;
-				return $folder->getFile($fileName . '.gz');
+				return $folder->getFile($fileName . '.gzip'); # Safari doesn't like .gz
 			} catch (NotFoundException $e) {
 				// continue
 			}

--- a/core/Controller/JsController.php
+++ b/core/Controller/JsController.php
@@ -96,7 +96,7 @@ class JsController extends Controller {
 		if ($encoding !== null && strpos($encoding, 'gzip') !== false) {
 			try {
 				$gzip = true;
-				return $folder->getFile($fileName . '.gz');
+				return $folder->getFile($fileName . '.gzip'); # Safari doesn't like .gz
 			} catch (NotFoundException $e) {
 				// continue
 			}

--- a/lib/private/Template/JSCombiner.php
+++ b/lib/private/Template/JSCombiner.php
@@ -155,9 +155,9 @@ class JSCombiner {
 		}
 
 		try {
-			$gzipFile = $folder->getFile($fileName . '.gz');
+			$gzipFile = $folder->getFile($fileName . '.gzip'); # Safari doesn't like .gz
 		} catch (NotFoundException $e) {
-			$gzipFile = $folder->newFile($fileName . '.gz');
+			$gzipFile = $folder->newFile($fileName . '.gzip'); # Safari doesn't like .gz
 		}
 
 		try {

--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -188,9 +188,9 @@ class SCSSCacher {
 
 		// Gzip file
 		try {
-			$gzipFile = $folder->getFile($fileNameCSS . '.gz');
+			$gzipFile = $folder->getFile($fileNameCSS . '.gzip'); # Safari doesn't like .gz
 		} catch (NotFoundException $e) {
-			$gzipFile = $folder->newFile($fileNameCSS . '.gz');
+			$gzipFile = $folder->newFile($fileNameCSS . '.gzip'); # Safari doesn't like .gz
 		}
 
 		try {

--- a/tests/Core/Controller/CssControllerTest.php
+++ b/tests/Core/Controller/CssControllerTest.php
@@ -121,7 +121,7 @@ class CssControllerTest extends TestCase {
 			->willReturn($folder);
 
 		$folder->method('getFile')
-			->with('file.css.gz')
+			->with('file.css.gzip')
 			->willReturn($gzipFile);
 
 		$this->request->method('getHeader')

--- a/tests/Core/Controller/JsControllerTest.php
+++ b/tests/Core/Controller/JsControllerTest.php
@@ -120,7 +120,7 @@ class JsControllerTest extends TestCase {
 			->willReturn($folder);
 
 		$folder->method('getFile')
-			->with('file.js.gz')
+			->with('file.js.gzip')
 			->willReturn($gzipFile);
 
 		$this->request->method('getHeader')

--- a/tests/lib/Template/JSCombinerTest.php
+++ b/tests/lib/Template/JSCombinerTest.php
@@ -111,7 +111,7 @@ class JSCombinerTest extends \Test\TestCase {
 					return $file;
 				} else if ($path === 'combine.js.deps') {
 					throw new NotFoundException();
-				} else if ($path === 'combine.js.gz') {
+				} else if ($path === 'combine.js.gzip') {
 					return $gzfile;
 				}
 				$this->fail();
@@ -148,7 +148,7 @@ class JSCombinerTest extends \Test\TestCase {
 					return $file;
 				} else if ($path === 'combine.js.deps') {
 					throw new NotFoundException();
-				} else if ($path === 'combine.js.gz') {
+				} else if ($path === 'combine.js.gzip') {
 					return $gzfile;
 				}
 				$this->fail();
@@ -302,7 +302,7 @@ class JSCombinerTest extends \Test\TestCase {
 					return $file;
 				} else if ($filename === 'combine.js.deps') {
 					return $depsFile;
-				} else if ($filename === 'combine.js.gz') {
+				} else if ($filename === 'combine.js.gzip') {
 					return $gzFile;
 				}
 				$this->fail();
@@ -333,7 +333,7 @@ class JSCombinerTest extends \Test\TestCase {
 					return $file;
 				} else if ($filename === 'combine.js.deps') {
 					return $depsFile;
-				} else if ($filename === 'combine.js.gz') {
+				} else if ($filename === 'combine.js.gzip') {
 					return $gzFile;
 				}
 				$this->fail();
@@ -401,7 +401,7 @@ var b = \'world\';
 					return $file;
 				} else if ($filename === 'combine.js.deps') {
 					return $depsFile;
-				} else if ($filename === 'combine.js.gz') {
+				} else if ($filename === 'combine.js.gzip') {
 					return $gzFile;
 				}
 				$this->fail();

--- a/tests/lib/Template/SCSSCacherTest.php
+++ b/tests/lib/Template/SCSSCacherTest.php
@@ -81,7 +81,7 @@ class SCSSCacherTest extends \Test\TestCase {
 					return $file;
 				} else if ($path === 'styles.css.deps') {
 					throw new NotFoundException();
-				} else if ($path === 'styles.css.gz') {
+				} else if ($path === 'styles.css.gzip') {
 					return $gzfile;
 				} else {
 					$this->fail();
@@ -110,7 +110,7 @@ class SCSSCacherTest extends \Test\TestCase {
 					return $file;
 				} else if ($path === 'styles.css.deps') {
 					throw new NotFoundException();
-				} else if ($path === 'styles.css.gz') {
+				} else if ($path === 'styles.css.gzip') {
 					return $gzfile;
 				}else {
 					$this->fail();
@@ -228,7 +228,7 @@ class SCSSCacherTest extends \Test\TestCase {
 				return $file;
 			} else if ($fileName === 'styles.css.deps') {
 				return $depsFile;
-			} else if ($fileName === 'styles.css.gz') {
+			} else if ($fileName === 'styles.css.gzip') {
 				return $gzipFile;
 			}
 			throw new \Exception();
@@ -258,7 +258,7 @@ class SCSSCacherTest extends \Test\TestCase {
 				return $file;
 			} else if ($fileName === 'styles.css.deps') {
 				return $depsFile;
-			} else if ($fileName === 'styles.css.gz') {
+			} else if ($fileName === 'styles.css.gzip') {
 				return $gzipFile;
 			}
 			throw new \Exception();
@@ -288,7 +288,7 @@ class SCSSCacherTest extends \Test\TestCase {
 				return $file;
 			} else if ($fileName === 'styles-success.css.deps') {
 				return $depsFile;
-			} else if ($fileName === 'styles-success.css.gz') {
+			} else if ($fileName === 'styles-success.css.gzip') {
 				return $gzipFile;
 			}
 			throw new \Exception();


### PR DESCRIPTION
* Safari support gzip only if the filename does not end on `.gz` - so this renames them to .gzip
* followup to #4070 

cc @nextcloud/mac Please test - it's easy: open Nextcloud in Safari before and after this ;) You will notice the difference, because neither JS nor CSS is loaded before. 