### PR TITLE
Match slashes in ../{id} resource routes

### DIFF
--- a/lib/private/AppFramework/Routing/RouteConfig.php
+++ b/lib/private/AppFramework/Routing/RouteConfig.php
@@ -231,9 +231,15 @@ class RouteConfig {
 
 				$routeName = $this->appName . '.' . strtolower($resource) . '.' . strtolower($method);
 
-				$this->router->create($routeName, $url)->method($verb)->action(
+				$route = $this->router->create($routeName, $url)->method($verb)->action(
 					new RouteActionHandler($this->container, $controllerName, $actionName)
 				);
+
+				if (!$collectionAction) {
+					$route->requirements([
+						'id' => '[^?]*'
+					]);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #2954

Before we could match on <prefix>/{id} however if the id contains a /
this would not match properly. But since we define the resource routes
internally we now make sure that we match all chars (up until the ?).

to test:

1. create a group `foo/bar`
2. Delete the group

Before: nope
Now: yes, master

CC: @hirschrobert