### PR TITLE
Don't add the Encryption Storage Wrapper if there are no encryption modules

### DIFF
--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -44,7 +44,7 @@ if [ "$INSTALLED" == "true" ]; then
     $OCC app:enable files_external
 
     mkdir -p work/local_storage
-    OUTPUT_CREATE_STORAGE=`$OCC files_external:create local_storage local null::null -c datadir=./build/integration/work/local_storage`
+    OUTPUT_CREATE_STORAGE=`$OCC files_external:create local_storage local null::null -c datadir=$PWD/work/local_storage`
 
     ID_STORAGE=`echo $OUTPUT_CREATE_STORAGE | tr ' ' '\n' | tail -n1`
 

--- a/lib/private/Encryption/Manager.php
+++ b/lib/private/Encryption/Manager.php
@@ -254,8 +254,11 @@ class Manager implements IManager {
 	 * Add storage wrapper
 	 */
 	public function setupStorage() {
-		$encryptionWrapper = new EncryptionWrapper($this->arrayCache, $this, $this->logger);
-		Filesystem::addStorageWrapper('oc_encryption', array($encryptionWrapper, 'wrapStorage'), 2);
+		// If encryption is disabled and there are no loaded modules it makes no sense to load the wrapper
+		if (!empty($this->encryptionModules) || $this->isEnabled()) {
+			$encryptionWrapper = new EncryptionWrapper($this->arrayCache, $this, $this->logger);
+			Filesystem::addStorageWrapper('oc_encryption', array($encryptionWrapper, 'wrapStorage'), 2);
+		}
 	}
 
 


### PR DESCRIPTION
fixes #4125

If there is no encryption module enabled it makes no sense to setup the
encryption wrapper (because we can't do anything anyway).

This saves reading the header of files.
Especialy on external storage/objectstore this should improve
performance

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>