### PR TITLE
Convert the group limit to match the same behaviour as the user search

### DIFF
--- a/apps/user_ldap/lib/Command/Search.php
+++ b/apps/user_ldap/lib/Command/Search.php
@@ -114,6 +114,11 @@ class Search extends Command {
 			$proxy = new Group_Proxy($configPrefixes, $ldapWrapper);
 			$getMethod = 'getGroups';
 			$printID = false;
+			// convert the limit of groups to null. This will show all the groups available instead of
+			// nothing, and will match the same behaviour the search for users has.
+			if ($limit === 0) {
+				$limit = null;
+			}
 		} else {
 			$proxy = new User_Proxy($configPrefixes, $ldapWrapper, $this->ocConfig);
 			$getMethod = 'getDisplayNames';


### PR DESCRIPTION
Signed-off-by: Arthur Schiwon <blizzz@arthur-schiwon.de>

Downstream of https://github.com/owncloud/user_ldap/pull/9

This is adjusted in this command instead of the user/group backend, because IUserBackend and IGroupBackend accept the limit parameters differently.

Please review @nextcloud/ldap 