### PR TITLE
Allow avatars for full numeric users

### DIFF
--- a/core/js/jquery.avatar.js
+++ b/core/js/jquery.avatar.js
@@ -48,8 +48,12 @@
 
 (function ($) {
 	$.fn.avatar = function(user, size, ie8fix, hidedefault, callback, displayname) {
-		user = String(user);
-		displayname = String(displayname);
+		if (typeof(user) !== 'undefined') {
+			user = String(user);
+		}
+		if (typeof(displayname) !== 'undefined') {
+			displayname = String(displayname);
+		}
 
 		if (typeof(size) === 'undefined') {
 			if (this.height() > 0) {

--- a/core/js/jquery.avatar.js
+++ b/core/js/jquery.avatar.js
@@ -48,6 +48,9 @@
 
 (function ($) {
 	$.fn.avatar = function(user, size, ie8fix, hidedefault, callback, displayname) {
+		user = String(user);
+		displayname = String(displayname);
+
 		if (typeof(size) === 'undefined') {
 			if (this.height() > 0) {
 				size = this.height();


### PR DESCRIPTION
Fixes #4087

Because of fancy javascript if a full numeric uid was used javascript
would convert this to an int. Now we just convert everything to a string
first.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>