### PR TITLE
Allow getting the unread comment count for an entire folder at once

### DIFF
--- a/apps/dav/lib/Connector/Sabre/CommentPropertiesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/CommentPropertiesPlugin.php
@@ -42,6 +42,10 @@ class CommentPropertiesPlugin extends ServerPlugin {
 	/** @var IUserSession */
 	private $userSession;
 
+	private $cachedUnreadCount = [];
+
+	private $cachedFolders = [];
+
 	public function __construct(ICommentsManager $commentsManager, IUserSession $userSession) {
 		$this->commentsManager = $commentsManager;
 		$this->userSession = $userSession;
@@ -79,6 +83,18 @@ class CommentPropertiesPlugin extends ServerPlugin {
 			return;
 		}
 
+		// need prefetch ?
+		if ($node instanceof \OCA\DAV\Connector\Sabre\Directory
+			&& $propFind->getDepth() !== 0
+			&& !is_null($propFind->getStatus(self::PROPERTY_NAME_UNREAD))
+		) {
+			$unreadCounts = $this->commentsManager->getNumberOfUnreadCommentsForFolder($node->getId(), $this->userSession->getUser());
+			$this->cachedFolders[] = $node->getPath();
+			foreach ($unreadCounts as $id => $count) {
+				$this->cachedUnreadCount[$id] = $count;
+			}
+		}
+
 		$propFind->handle(self::PROPERTY_NAME_COUNT, function() use ($node) {
 			return $this->commentsManager->getNumberOfCommentsForObject('files', strval($node->getId()));
 		});
@@ -88,7 +104,20 @@ class CommentPropertiesPlugin extends ServerPlugin {
 		});
 
 		$propFind->handle(self::PROPERTY_NAME_UNREAD, function() use ($node) {
-			return $this->getUnreadCount($node);
+			if (isset($this->cachedUnreadCount[$node->getId()])) {
+				return $this->cachedUnreadCount[$node->getId()];
+			} else {
+				list($parentPath,) = \Sabre\Uri\split($node->getPath());
+				if ($parentPath === '') {
+					$parentPath = '/';
+				}
+				// if we already cached the folder this file is in we know there are no shares for this file
+				if (array_search($parentPath, $this->cachedFolders) === false) {
+					return $this->getUnreadCount($node);
+				} else {
+					return 0;
+				}
+			}
 		});
 	}
 

--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -412,15 +412,12 @@ class Manager implements ICommentsManager {
 	 */
 	public function getNumberOfUnreadCommentsForFolder($folderId, IUser $user) {
 		$qb = $this->dbConn->getQueryBuilder();
-		$castAs = ($this->dbConn->getDatabasePlatform() instanceof MySqlPlatform) ? 'unsigned integer' : 'int';
 		$query = $qb->select('fileid', $qb->createFunction(
 			'COUNT(' . $qb->getColumnName('c.id') . ')')
 		)->from('comments', 'c')
 			->innerJoin('c', 'filecache', 'f', $qb->expr()->andX(
 				$qb->expr()->eq('c.object_type', $qb->createNamedParameter('files')),
-				$qb->expr()->eq('f.fileid', $qb->createFunction(
-					'cast(' . $qb->getColumnName('c.object_id') . ' as ' . $castAs . ')'
-				))
+				$qb->expr()->eq('f.fileid', $qb->expr()->castColumn('c.object_id', IQueryBuilder::PARAM_INT))
 			))
 			->leftJoin('c', 'comments_read_markers', 'm', $qb->expr()->andX(
 				$qb->expr()->eq('m.object_type', $qb->createNamedParameter('files')),

--- a/lib/private/DB/QueryBuilder/QuoteHelper.php
+++ b/lib/private/DB/QueryBuilder/QuoteHelper.php
@@ -73,7 +73,7 @@ class QuoteHelper {
 				return $string;
 			}
 
-			return $alias . '.`' . $columnName . '`';
+			return '`' . $alias . '`.`' . $columnName . '`';
 		}
 
 		return '`' . $string . '`';

--- a/lib/private/Repair/CleanTags.php
+++ b/lib/private/Repair/CleanTags.php
@@ -173,7 +173,7 @@ class CleanTags implements IRepairStep {
 
 		$qb->select('d.' . $deleteId)
 			->from($deleteTable, 'd')
-			->leftJoin('d', $sourceTable, 's', $qb->expr()->eq('d.' . $deleteId, ' s.' . $sourceId))
+			->leftJoin('d', $sourceTable, 's', $qb->expr()->eq('d.' . $deleteId, 's.' . $sourceId))
 			->where(
 				$qb->expr()->eq('d.type', $qb->expr()->literal('files'))
 			)

--- a/lib/public/Comments/ICommentsManager.php
+++ b/lib/public/Comments/ICommentsManager.php
@@ -23,6 +23,8 @@
  */
 namespace OCP\Comments;
 
+use OCP\IUser;
+
 /**
  * Interface ICommentsManager
  *
@@ -124,6 +126,16 @@ interface ICommentsManager {
 	 * @since 9.0.0
 	 */
 	public function getNumberOfCommentsForObject($objectType, $objectId, \DateTime $notOlderThan = null);
+
+	/**
+	 * Get the number of unread comments for all files in a folder
+	 *
+	 * @param int $folderId
+	 * @param IUser $user
+	 * @return array [$fileId => $unreadCount]
+	 * @since 12.0.0
+	 */
+	public function getNumberOfUnreadCommentsForFolder($folderId, IUser $user);
 
 	/**
 	 * creates a new comment and returns it. At this point of time, it is not

--- a/tests/lib/Comments/FakeManager.php
+++ b/tests/lib/Comments/FakeManager.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Test\Comments;
+use OCP\IUser;
 
 /**
  * Class FakeManager
@@ -44,4 +45,6 @@ class FakeManager implements \OCP\Comments\ICommentsManager {
 	public function registerDisplayNameResolver($type, \Closure $closure) {}
 
 	public function resolveDisplayName($type, $id) {}
+
+	public function getNumberOfUnreadCommentsForFolder($folderId, IUser $user) {}
 }

--- a/tests/lib/DB/QueryBuilder/QueryBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/QueryBuilderTest.php
@@ -1200,7 +1200,7 @@ class QueryBuilderTest extends \Test\TestCase {
 	public function dataGetColumnName() {
 		return [
 			['column', '', '`column`'],
-			['column', 'a', 'a.`column`'],
+			['column', 'a', '`a`.`column`'],
 		];
 	}
 

--- a/tests/lib/DB/QueryBuilder/QuoteHelperTest.php
+++ b/tests/lib/DB/QueryBuilder/QuoteHelperTest.php
@@ -65,7 +65,7 @@ class QuoteHelperTest extends \Test\TestCase {
 	public function dataQuoteColumnNames() {
 		return [
 			// Single case
-			['d.column', 'd.`column`'],
+			['d.column', '`d`.`column`'],
 			['column', '`column`'],
 			[new Literal('literal'), 'literal'],
 			[new Literal(1), '1'],


### PR DESCRIPTION
Instead of doing 2 queries per file in a folder, we do a single query to get all unread comment counts.

[comparison with 100 files](https://blackfire.io/profiles/compare/0f2705d7-7d07-45e8-81eb-f18589fda1d2/graph)