### PR TITLE
Don't try to parse empty body if there is no body

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -401,6 +401,8 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	protected function getContent() {
 		// If the content can't be parsed into an array then return a stream resource.
 		if ($this->method === 'PUT'
+			&& $this->getHeader('Content-Length') !== 0
+			&& $this->getHeader('Content-Length') !== null
 			&& strpos($this->getHeader('Content-Type'), 'application/x-www-form-urlencoded') === false
 			&& strpos($this->getHeader('Content-Type'), 'application/json') === false
 		) {

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -305,7 +305,10 @@ class RequestTest extends \Test\TestCase {
 		$vars = array(
 			'put' => $data,
 			'method' => 'PUT',
-			'server' => array('CONTENT_TYPE' => 'image/png'),
+			'server' => [
+				'CONTENT_TYPE' => 'image/png',
+				'CONTENT_LENGTH' => strlen($data)
+			],
 		);
 
 		$request = new Request(


### PR DESCRIPTION
Fixes #3890

If we do a put request without a body the current code still tries to
read the body. This patch makes sure that we do not try to read the body
if the content length is 0.

See RFC 2616 Section 4.3

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>