### PR TITLE
support pushing to CappedMemoryCache

### DIFF
--- a/lib/private/Cache/CappedMemoryCache.php
+++ b/lib/private/Cache/CappedMemoryCache.php
@@ -47,7 +47,11 @@ class CappedMemoryCache implements ICache, \ArrayAccess {
 	}
 
 	public function set($key, $value, $ttl = 0) {
-		$this->cache[$key] = $value;
+		if (is_null($key)) {
+			$this->cache[] = $value;
+		} else {
+			$this->cache[$key] = $value;
+		}
 		$this->garbageCollect();
 	}
 

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -237,9 +237,10 @@ class Database extends Backend implements IUserBackend {
 	 * @return boolean true if user was found, false otherwise
 	 */
 	private function loadUser($uid) {
+		$uid = (string) $uid;
 		if (!isset($this->cache[$uid])) {
 			//guests $uid could be NULL or ''
-			if ($uid === null || $uid === '') {
+			if ($uid === '') {
 				$this->cache[$uid]=false;
 				return true;
 			}


### PR DESCRIPTION
Support doing `$cache[] = 'foo'`

Only the `CappedMemoryCache` is ever used that way, since doing this doesn't make sense on "real" memecaches