### PR TITLE
Do not show social menu when there is no link share

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -30,7 +30,7 @@
 			'{{#if singleAction}}' +
 				'<a class="{{#unless isLinkShare}}hidden-visually{{/unless}} clipboardButton icon icon-clippy" data-clipboard-target="#linkText-{{cid}}"></a>' +
 			'{{else}}' +
-				'<a href="#"><span class="linkMore icon icon-more"></span></a>' +
+				'<a class="{{#unless isLinkShare}}hidden-visually{{/unless}}" href="#"><span class="linkMore icon icon-more"></span></a>' +
 				'{{{popoverMenu}}}' +
 			'{{/if}}' +
 			'</div>' +


### PR DESCRIPTION
Easy one...

1. Have a socialsharing plugin enabled
2. open the share dialog

before: weird ...
after: no weird ...