### PR TITLE
Redirect to 2FA selection screen

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -981,9 +981,9 @@ class OC_Util {
 			);
 			exit();
 		}
-		// Redirect to index page if 2FA challenge was not solved yet
+		// Redirect to 2FA challenge selection if 2FA challenge was not solved yet
 		if (\OC::$server->getTwoFactorAuthManager()->needsSecondFactor(\OC::$server->getUserSession()->getUser())) {
-			header('Location: ' . \OCP\Util::linkToAbsolute('', 'index.php'));
+			header('Location: ' . \OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.selectChallenge'));
 			exit();
 		}
 	}


### PR DESCRIPTION
Apps like 'rainloop' use \OCP\Util::isLoggedIn() to check whether the
current request is authenticated. Since we redirected to the index
page before, it resulted in an infinite redirection loop. This change
sets the redirection URL to the 2FA selection page, which is the only
allowed page in that authentication state.

Fixes https://github.com/nextcloud/server/issues/3702

cc Loki3000