### PR TITLE
fix fseek (Swift backend) against string not resource by removing append support

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Swift.php
+++ b/apps/files_external/lib/Lib/Storage/Swift.php
@@ -373,6 +373,10 @@ class Swift extends \OC\Files\Storage\Common {
 		$path = $this->normalizePath($path);
 
 		switch ($mode) {
+			case 'a':
+			case 'ab':
+			case 'a+':
+				return false;
 			case 'r':
 			case 'rb':
 				try {
@@ -395,12 +399,9 @@ class Swift extends \OC\Files\Storage\Common {
 				}
 			case 'w':
 			case 'wb':
-			case 'a':
-			case 'ab':
 			case 'r+':
 			case 'w+':
 			case 'wb+':
-			case 'a+':
 			case 'x':
 			case 'x+':
 			case 'c':
@@ -419,10 +420,6 @@ class Swift extends \OC\Files\Storage\Common {
 					}
 					$source = $this->fopen($path, 'r');
 					file_put_contents($tmpFile, $source);
-					// Seek to end if required
-					if ($mode[0] === 'a') {
-						fseek($tmpFile, 0, SEEK_END);
-					}
 				}
 				$handle = fopen($tmpFile, $mode);
 				return CallbackWrapper::wrap($handle, null, null, function () use ($path, $tmpFile) {


### PR DESCRIPTION
While consultating some code on Storage backends ``fopen`` implementation I saw that fseek was attempted on the file string instead of a handle.

After discussing with @icewind1991 the suggestion was to remove and unsupport the slow append mode in general. 

Quoting the discussion

> @icewind1991 the entire append mode should just be removed, it's barely supported by any storage backend and where it is it's mostly slow
@Blizzz then it needs to be removed in favor of read/copy, and overwrite the whole file? just ignoring append wouldn't work would it? or should it simply return false?
@icewind1991 just return falser
@Blizzz dropbox and amazon backends just delegate it to native fopen. Swift does essentially the same without this fault fseek, so it should just continue to work while only removing the three lines
@icewind1991 I would return false anyway
apps relying on complex fopen behavior will just hurt future optimizitations
@Blizzz and it's not really used anyway? Only possible scenario would be if an app would deliberately make use of this, correct?
@icewind1991 y
@Blizzz removing this for nothing would just cut out a standard operation.

So for now I just return false on append operations and removed the broken and unnecessary lines.