### PR TITLE
validate file name before uploading in upload only folder

### DIFF
--- a/apps/files_sharing/js/files_drop.js
+++ b/apps/files_sharing/js/files_drop.js
@@ -46,7 +46,14 @@
 					var errors = [];
 
 					var name = data.files[0].name;
-
+					try {
+						// FIXME: not so elegant... need to refactor that method to return a value
+						Files.isFileNameValid(name);
+					}
+					catch (errorMessage) {
+						OC.Notification.show(errorMessage, {type: 'error'});
+						return false;
+					}
 					var base = OC.getProtocol() + '://' + OC.getHost();
 					data.url = base + OC.getRootPath() + '/public.php/webdav/' + encodeURI(name);
 

--- a/apps/files_sharing/js/files_drop.js
+++ b/apps/files_sharing/js/files_drop.js
@@ -20,9 +20,11 @@
 	var Drop = {
 		/** @type {Function} **/
 		_template: undefined,
-
-		initialize: function () {
-
+	
+		addFileToUpload: function(e, data) {
+			var errors = [];
+			var output = this.template();
+			
 			var filesClient = new OC.Files.Client({
 				host: OC.getHost(),
 				port: OC.getPort(),
@@ -32,7 +34,45 @@
 				root: OC.getRootPath() + '/public.php/webdav',
 				useHTTPS: OC.getProtocol() === 'https'
 			});
-
+			
+			var name = data.files[0].name;
+			try {
+				// FIXME: not so elegant... need to refactor that method to return a value
+				Files.isFileNameValid(name);
+			}
+			catch (errorMessage) {
+				OC.Notification.show(errorMessage, {type: 'error'});
+				return false;
+			}
+			var base = OC.getProtocol() + '://' + OC.getHost();
+			data.url = base + OC.getRootPath() + '/public.php/webdav/' + encodeURI(name);
+	
+			data.multipart = false;
+	
+			if (!data.headers) {
+				data.headers = {};
+			}
+	
+			var userName = filesClient.getUserName();
+			var password = filesClient.getPassword();
+			if (userName) {
+				// copy username/password from DAV client
+				data.headers['Authorization'] =
+					'Basic ' + btoa(userName + ':' + (password || ''));
+			}
+	
+			$('#drop-upload-done-indicator').addClass('hidden');
+			$('#drop-upload-progress-indicator').removeClass('hidden');
+			_.each(data['files'], function(file) {
+				$('#public-upload ul').append(output({isUploading: true, name: escapeHTML(file.name)}));
+				$('[data-toggle="tooltip"]').tooltip();
+				data.submit();
+			});
+	
+			return true;
+		},
+		
+		initialize: function () {
 			$(document).bind('drop dragover', function (e) {
 				// Prevent the default browser drop action:
 				e.preventDefault();
@@ -43,42 +83,9 @@
 				dropZone: $('#public-upload'),
 				sequentialUploads: true,
 				add: function(e, data) {
-					var errors = [];
-
-					var name = data.files[0].name;
-					try {
-						// FIXME: not so elegant... need to refactor that method to return a value
-						Files.isFileNameValid(name);
-					}
-					catch (errorMessage) {
-						OC.Notification.show(errorMessage, {type: 'error'});
-						return false;
-					}
-					var base = OC.getProtocol() + '://' + OC.getHost();
-					data.url = base + OC.getRootPath() + '/public.php/webdav/' + encodeURI(name);
-
-					data.multipart = false;
-
-					if (!data.headers) {
-						data.headers = {};
-					}
-
-					var userName = filesClient.getUserName();
-					var password = filesClient.getPassword();
-					if (userName) {
-						// copy username/password from DAV client
-						data.headers['Authorization'] =
-							'Basic ' + btoa(userName + ':' + (password || ''));
-					}
-
-					$('#drop-upload-done-indicator').addClass('hidden');
-					$('#drop-upload-progress-indicator').removeClass('hidden');
-					_.each(data['files'], function(file) {
-						$('#public-upload ul').append(output({isUploading: true, name: escapeHTML(file.name)}));
-						$('[data-toggle="tooltip"]').tooltip();
-						data.submit();
-					});
-
+					Drop.addFileToUpload(e, data);
+					//we return true to keep trying to upload next file even
+					//if addFileToUpload did not like the privious one
 					return true;
 				},
 				done: function(e, data) {
@@ -123,15 +130,13 @@
 		}
 	};
 
+	OCA.FilesSharingDrop = Drop;
+
 	$(document).ready(function() {
 		if($('#upload-only-interface').val() === "1") {
 			$('.avatardiv').avatar($('#sharingUserId').val(), 128, true);
 		}
 
-		OCA.Files_Sharing_Drop = Drop;
-		OCA.Files_Sharing_Drop.initialize();
+		OCA.FilesSharingDrop.initialize();
 	});
-
-
 })(jQuery);
-

--- a/apps/files_sharing/tests/js/fileDropSpec.js
+++ b/apps/files_sharing/tests/js/fileDropSpec.js
@@ -1,0 +1,99 @@
+/**
+ *
+ * @copyright Copyright (c) 2017, Artur Neumann (info@individual-it.net)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+describe("files Drop tests", function() {
+	//some testing data
+	var sharingToken = "fVCiSMhScgWfiuv";
+	var testFiles = [
+		{ name: 'test.txt', expectedValidationResult: true },
+		{ name: 'testनेपाल.txt', expectedValidationResult: true },
+		{ name: 'test.part', expectedValidationResult: false },
+		{ name: 'test.filepart', expectedValidationResult: false },
+		{ name: '.', expectedValidationResult: false },
+		{ name: '..', expectedValidationResult: false },
+	];
+
+	//this pre/post positions should not change the result of the file name validation
+	var prePostPositions = [""," ","  ","	"];
+	
+	//use the testFiles and the pre/post positions to generate more testing data
+	var replicatedTestFiles = [];
+	prePostPositions.map(function (prePostPosition) {
+		testFiles.map(function (testFile) {
+			replicatedTestFiles.push(
+				{
+					name: testFile.name + prePostPosition,
+					expectedValidationResult: testFile.expectedValidationResult
+				}
+			);
+			replicatedTestFiles.push(
+				{
+					name: prePostPosition + testFile.name,
+					expectedValidationResult: testFile.expectedValidationResult
+				}
+			);
+			replicatedTestFiles.push(
+				{
+					name: prePostPosition + testFile.name + prePostPosition,
+					expectedValidationResult: testFile.expectedValidationResult
+				}
+			);
+		});
+	});
+
+	beforeEach (function () {
+		//fake input for the sharing token
+		$('#testArea').append(
+				'<input name="sharingToken" value="" id="sharingToken" type="hidden">'
+		);
+	});
+
+
+	replicatedTestFiles.map(function (testFile) {
+		fit("validates the filenames correctly", function() {
+			testFile = { name: 'test.txt', expectedValidationResult: true };
+				data = {
+					'submit': function() {},
+					'files': [testFile]
+				}
+				expect(OCA.FilesSharingDrop.addFileToUpload('',data)).
+					toBe(
+						testFile.expectedValidationResult,
+						'wrongly validated file named "'+testFile.name+'"'
+						);
+		});
+		
+		if (testFile.expectedValidationResult === true) {
+			it("should set correct PUT URL, Auth header and submit", function () {
+				data = {
+						'submit': sinon.stub(),
+						'files': [testFile]
+					}
+				$('#sharingToken').val(sharingToken);
+				
+				OCA.FilesSharingDrop.addFileToUpload('',data);
+				expect(data.submit.calledOnce).toEqual(true);
+				expect(data.url).toContain("/public.php/webdav/" + encodeURI(testFile.name));
+				expect(data.headers['Authorization']).toEqual('Basic ' + btoa(sharingToken+":"));
+			});
+		}
+	});
+});

--- a/apps/files_sharing/tests/js/fileDropSpec.js
+++ b/apps/files_sharing/tests/js/fileDropSpec.js
@@ -68,7 +68,7 @@ describe("files Drop tests", function() {
 
 
 	replicatedTestFiles.map(function (testFile) {
-		fit("validates the filenames correctly", function() {
+		it("validates the filenames correctly", function() {
 			testFile = { name: 'test.txt', expectedValidationResult: true };
 				data = {
 					'submit': function() {},

--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -56,7 +56,8 @@ module.exports = function(config) {
 					'apps/files_sharing/js/share.js',
 					'apps/files_sharing/js/sharebreadcrumbview.js',
 					'apps/files_sharing/js/public.js',
-					'apps/files_sharing/js/sharetabview.js'
+					'apps/files_sharing/js/sharetabview.js',
+					'apps/files_sharing/js/files_drop.js'
 				],
 				testFiles: ['apps/files_sharing/tests/js/*.js']
 			},


### PR DESCRIPTION
before uploading in a upload-only folder the file name was not checked with JS and no error was presented to the user if an invalid file was uploaded.
Even worse the UI would list the invalid file in the "Uploaded files" list.
This PR adds a check that is the same as in https://github.com/nextcloud/server/blob/master/apps/files/js/file-upload.js#L793
fixes #4211