### PR TITLE
don't try to render the avatars if avatars are disabled

### DIFF
--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -276,11 +276,13 @@
 				text = t('core', '{sharee} (email)', { sharee: text }, undefined, { escape: false });
 			}
 			var insert = $("<div class='share-autocomplete-item'/>");
-			var avatar = $("<div class='avatardiv'></div>").appendTo(insert);
-			if (item.value.shareType === OC.Share.SHARE_TYPE_USER) {
-				avatar.avatar(item.value.shareWith, 32, undefined, undefined, undefined, item.label);
-			} else {
-				avatar.imageplaceholder(text, undefined, 32);
+			if (oc_config.enable_avatars === true) {
+				var avatar = $("<div class='avatardiv'></div>").appendTo(insert);
+				if (item.value.shareType === OC.Share.SHARE_TYPE_USER) {
+					avatar.avatar(item.value.shareWith, 32, undefined, undefined, undefined, item.label);
+				} else {
+					avatar.imageplaceholder(text, undefined, 32);
+				}
 			}
 
 			$("<div class='autocomplete-item-text'></div>")


### PR DESCRIPTION
The option to disable avatars was removed for Nextcloud12, nevertheless it should work for Nextcloud 11.


fix at least partially https://github.com/nextcloud/server/issues/3001