### PR TITLE
Don't force the use of Accept-Language anymore

### DIFF
--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -271,24 +271,6 @@ class Factory implements IFactory {
 	}
 
 	/**
-	 * @param string|null $app App id or null for core
-	 * @return string
-	 */
-	public function setLanguageFromRequest($app = null) {
-
-		try {
-			$requestLanguage = $this->getLanguageFromRequest($app);
-		} catch (LanguageNotFoundException $e) {
-			$requestLanguage = 'en';
-		}
-
-		if ($app === null && !$this->requestLanguage) {
-			$this->requestLanguage = $requestLanguage;
-		}
-		return $requestLanguage;
-	}
-
-	/**
 	 * Checks if $sub is a subdirectory of $parent
 	 *
 	 * @param string $sub

--- a/lib/public/L10N/IFactory.php
+++ b/lib/public/L10N/IFactory.php
@@ -62,14 +62,6 @@ interface IFactory {
 	public function languageExists($app, $lang);
 
 	/**
-	 * @param string|null $app App id or null for core
-	 * @return string
-	 * @since 9.0.0
-	 */
-	public function setLanguageFromRequest($app = null);
-
-
-	/**
 	 * Creates a function from the plural string
 	 *
 	 * @param string $string

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -54,9 +54,6 @@ try {
 	// load all apps to get all api routes properly setup
 	OC_App::loadApps();
 
-	// force language as given in the http request
-	\OC::$server->getL10NFactory()->setLanguageFromRequest();
-
 	OC::$server->getRouter()->match('/ocs'.\OC::$server->getRequest()->getRawPathInfo());
 	return;
 } catch (ResourceNotFoundException $e) {

--- a/remote.php
+++ b/remote.php
@@ -136,9 +136,6 @@ try {
 		throw new RemoteException('Path not found', OC_Response::STATUS_NOT_FOUND);
 	}
 
-	// force language as given in the http request
-	\OC::$server->getL10NFactory()->setLanguageFromRequest();
-
 	$file=ltrim($file, '/');
 
 	$parts=explode('/', $file, 2);


### PR DESCRIPTION
This is not intended anymore, since it falls back to force english
when the header is not set. Also 0228bc6e66cbcb2848eacb41f1de6e7f63ebcb65
makes clear that the order should be:

1. User setting
2. Accept language
3. Admin default

This is the case since the commit from above, unless via OCS and DAV.
Both forced to accept-language falling back to english.
By removing the force, it now also matches the w3 priority list:
https://www.w3.org/International/questions/qa-lang-priorities
