### PR TITLE
Increase clickable area of app icon

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -458,20 +458,17 @@ nav {
 
 	li {
 		float: left;
-		display: inline-block;
-		vertical-align: top !important;
-		height: 20px;
-		padding: 12px;
 		cursor: pointer;
 
 		a {
-			opacity: 0.6;
+			position: relative;
+			display: inline-block;
 			margin: 0;
+			padding: 12px;
+			height: 21px;
 			text-align: center;
 			vertical-align: top !important;
-			position: relative;
-			height: 44px;
-			display: inline-block;
+			opacity: .6;
 		}
 	}
 
@@ -504,7 +501,7 @@ nav {
 		color: rgba(0, 0, 0, .6);
 		width: auto;
 		left: 50%;
-		top: 32px;
+		top: 45px;
 		transform: translateX(-50%);
 		padding: 4px 10px;
 		-webkit-filter: drop-shadow(0 0 5px rgba(150, 150, 150, .75));
@@ -531,7 +528,7 @@ nav {
 		border-width: 10px;
 		transform: translateX(-50%);
 		left: 50%;
-		top: 13px;
+		bottom: 0;
 		z-index: 100;
 		display: block;
 	}


### PR DESCRIPTION
New version of https://github.com/nextcloud/server/pull/4124

This is what it looked like before:
![capture du 2017-03-28 22-39-29](https://cloud.githubusercontent.com/assets/925062/24426346/b7e38576-1407-11e7-861f-30d5e09cca43.png)
The clickable area extended too far below, leading to the app area being overlapped. This fixes that.

Now also the full area is tappable:
![capture du 2017-04-07 21-01-50](https://cloud.githubusercontent.com/assets/925062/24815492/884956ee-1bd5-11e7-828e-e7b46828c941.png)

Also fixes that sometimes the tooltip below overlaps the header a bit.

Please review @nextcloud/designers 