### PR TITLE
don't remove owner property for public calendars

### DIFF
--- a/apps/dav/lib/CalDAV/Calendar.php
+++ b/apps/dav/lib/CalDAV/Calendar.php
@@ -282,7 +282,7 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IShareable {
 		return isset($this->calendarInfo['{http://owncloud.org/ns}public']);
 	}
 
-	private function isShared() {
+	protected function isShared() {
 		if (!isset($this->calendarInfo['{http://owncloud.org/ns}owner-principal'])) {
 			return false;
 		}

--- a/apps/dav/lib/CalDAV/CalendarObject.php
+++ b/apps/dav/lib/CalDAV/CalendarObject.php
@@ -43,7 +43,7 @@ class CalendarObject extends \Sabre\CalDAV\CalendarObject {
 		return $data;
 	}
 
-	private function isShared() {
+	protected function isShared() {
 		if (!isset($this->calendarInfo['{http://owncloud.org/ns}owner-principal'])) {
 			return false;
 		}

--- a/apps/dav/lib/CalDAV/PublicCalendar.php
+++ b/apps/dav/lib/CalDAV/PublicCalendar.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017, Georg Ehrke
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\CalDAV;
+
+use Sabre\DAV\Exception\NotFound;
+
+class PublicCalendar extends Calendar {
+
+	/**
+	 * @param string $name
+	 * @throws NotFound
+	 * @return PublicCalendarObject
+	 */
+	public function getChild($name) {
+		$obj = $this->caldavBackend->getCalendarObject($this->calendarInfo['id'], $name);
+
+		if (!$obj) {
+			throw new NotFound('Calendar object not found');
+		}
+		if ($obj['classification'] === CalDavBackend::CLASSIFICATION_PRIVATE) {
+			throw new NotFound('Calendar object not found');
+		}
+		$obj['acl'] = $this->getChildACL();
+
+		return new PublicCalendarObject($this->caldavBackend, $this->calendarInfo, $obj);
+	}
+
+	/**
+	 * @return PublicCalendarObject[]
+	 */
+	public function getChildren() {
+		$objs = $this->caldavBackend->getCalendarObjects($this->calendarInfo['id']);
+		$children = [];
+		foreach ($objs as $obj) {
+			if ($obj['classification'] === CalDavBackend::CLASSIFICATION_PRIVATE) {
+				continue;
+			}
+			$obj['acl'] = $this->getChildACL();
+			$children[] = new PublicCalendarObject($this->caldavBackend, $this->calendarInfo, $obj);
+		}
+		return $children;
+	}
+
+	/**
+	 * @param string[] $paths
+	 * @return PublicCalendarObject[]
+	 */
+	public function getMultipleChildren(array $paths) {
+		$objs = $this->caldavBackend->getMultipleCalendarObjects($this->calendarInfo['id'], $paths);
+		$children = [];
+		foreach ($objs as $obj) {
+			if ($obj['classification'] === CalDavBackend::CLASSIFICATION_PRIVATE) {
+				continue;
+			}
+			$obj['acl'] = $this->getChildACL();
+			$children[] = new PublicCalendarObject($this->caldavBackend, $this->calendarInfo, $obj);
+		}
+		return $children;
+	}
+
+	/**
+	 * public calendars are always shared
+	 * @return bool
+	 */
+	protected function isShared() {
+		return true;
+	}
+}

--- a/apps/dav/lib/CalDAV/PublicCalendarObject.php
+++ b/apps/dav/lib/CalDAV/PublicCalendarObject.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017, Georg Ehrke
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\CalDAV;
+
+class PublicCalendarObject extends CalendarObject {
+
+	/**
+	 * public calendars are always shared
+	 * @return bool
+	 */
+	protected function isShared() {
+		return true;
+	}
+}

--- a/apps/dav/lib/CalDAV/PublicCalendarRoot.php
+++ b/apps/dav/lib/CalDAV/PublicCalendarRoot.php
@@ -47,8 +47,7 @@ class PublicCalendarRoot extends Collection {
 	 */
 	function getChild($name) {
 		$calendar = $this->caldavBackend->getPublicCalendar($name);
-		$calendar['{http://owncloud.org/ns}owner-principal'] = '';
-		return new Calendar($this->caldavBackend, $calendar, $this->l10n);
+		return new PublicCalendar($this->caldavBackend, $calendar, $this->l10n);
 	}
 
 	/**

--- a/apps/dav/tests/unit/CalDAV/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarTest.php
@@ -34,7 +34,7 @@ use Test\TestCase;
 class CalendarTest extends TestCase {
 
 	/** @var IL10N */
-	private $l10n;
+	protected $l10n;
 
 	public function setUp() {
 		parent::setUp();

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
@@ -3,6 +3,7 @@
 namespace OCA\DAV\Tests\unit\CalDAV;
 
 use OCA\DAV\CalDAV\Calendar;
+use OCA\DAV\CalDAV\PublicCalendar;
 use OCA\DAV\Connector\Sabre\Principal;
 use OCP\IL10N;
 use OCA\DAV\CalDAV\CalDavBackend;
@@ -103,11 +104,11 @@ class PublicCalendarRootTest extends TestCase {
 		$this->backend->createCalendar(self::UNIT_TEST_USER, 'Example', []);
 
 		$calendarInfo = $this->backend->getCalendarsForUser(self::UNIT_TEST_USER)[0];
-		$calendar = new Calendar($this->backend, $calendarInfo, $this->l10n);
+		$calendar = new PublicCalendar($this->backend, $calendarInfo, $this->l10n);
 		$publicUri = $calendar->setPublishStatus(true);
 
 		$calendarInfo = $this->backend->getPublicCalendar($publicUri);
-		$calendar = new Calendar($this->backend, $calendarInfo, $this->l10n);
+		$calendar = new PublicCalendar($this->backend, $calendarInfo, $this->l10n);
 
 		return $calendar;
 	}

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarTest.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017, Georg Ehrke
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\unit\CalDAV;
+
+use OCA\DAV\CalDAV\PublicCalendar;
+use OCA\DAV\CalDAV\CalDavBackend;
+use Sabre\VObject\Reader;
+
+class PublicCalendarTest extends CalendarTest {
+
+	public function testPrivateClassification() {
+
+		$calObject0 = ['uri' => 'event-0', 'classification' => CalDavBackend::CLASSIFICATION_PUBLIC];
+		$calObject1 = ['uri' => 'event-1', 'classification' => CalDavBackend::CLASSIFICATION_CONFIDENTIAL];
+		$calObject2 = ['uri' => 'event-2', 'classification' => CalDavBackend::CLASSIFICATION_PRIVATE];
+
+		/** @var \PHPUnit_Framework_MockObject_MockObject | CalDavBackend $backend */
+		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
+		$backend->expects($this->any())->method('getCalendarObjects')->willReturn([
+			$calObject0, $calObject1, $calObject2
+		]);
+		$backend->expects($this->any())->method('getMultipleCalendarObjects')
+			->with(666, ['event-0', 'event-1', 'event-2'])
+			->willReturn([
+				$calObject0, $calObject1, $calObject2
+			]);
+		$backend->expects($this->any())->method('getCalendarObject')
+			->willReturn($calObject2)->with(666, 'event-2');
+
+		$calendarInfo = [
+			'{http://owncloud.org/ns}owner-principal' => 'user2',
+			'principaluri' => 'user2',
+			'id' => 666,
+			'uri' => 'cal',
+		];
+
+		$c = new PublicCalendar($backend, $calendarInfo, $this->l10n);
+		$children = $c->getChildren();
+		$this->assertEquals(2, count($children));
+		$children = $c->getMultipleChildren(['event-0', 'event-1', 'event-2']);
+		$this->assertEquals(2, count($children));
+
+		$this->assertFalse($c->childExists('event-2'));
+	}
+
+	public function testConfidentialClassification() {
+		$start = '20160609';
+		$end = '20160610';
+
+		$calData = <<<EOD
+BEGIN:VCALENDAR
+PRODID:-//ownCloud calendar v1.2.2
+BEGIN:VEVENT
+CREATED:20160602T133732
+DTSTAMP:20160602T133732
+LAST-MODIFIED:20160602T133732
+UID:wej2z68l9h
+SUMMARY:Test Event
+LOCATION:Somewhere ...
+ATTENDEE;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;CUTYPE=INDIVIDUAL;CN=de
+ epdiver:MAILTO:thomas.mueller@tmit.eu
+ORGANIZER;CN=deepdiver:MAILTO:thomas.mueller@tmit.eu
+DESCRIPTION:maybe ....
+DTSTART;TZID=Europe/Berlin;VALUE=DATE:$start
+DTEND;TZID=Europe/Berlin;VALUE=DATE:$end
+RRULE:FREQ=DAILY
+BEGIN:VALARM
+ACTION:AUDIO
+TRIGGER:-PT15M
+END:VALARM
+END:VEVENT
+BEGIN:VTIMEZONE
+TZID:Europe/Berlin
+BEGIN:DAYLIGHT
+DTSTART:19810329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+TZNAME:MESZ
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+END:DAYLIGHT
+BEGIN:STANDARD
+DTSTART:19961027T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+TZNAME:MEZ
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+END:STANDARD
+END:VTIMEZONE
+END:VCALENDAR
+EOD;
+
+		$calObject0 = ['uri' => 'event-0', 'classification' => CalDavBackend::CLASSIFICATION_PUBLIC];
+		$calObject1 = ['uri' => 'event-1', 'classification' => CalDavBackend::CLASSIFICATION_CONFIDENTIAL, 'calendardata' => $calData];
+		$calObject2 = ['uri' => 'event-2', 'classification' => CalDavBackend::CLASSIFICATION_PRIVATE];
+
+		/** @var \PHPUnit_Framework_MockObject_MockObject | CalDavBackend $backend */
+		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
+		$backend->expects($this->any())->method('getCalendarObjects')->willReturn([
+			$calObject0, $calObject1, $calObject2
+		]);
+		$backend->expects($this->any())->method('getMultipleCalendarObjects')
+			->with(666, ['event-0', 'event-1', 'event-2'])
+			->willReturn([
+				$calObject0, $calObject1, $calObject2
+			]);
+		$backend->expects($this->any())->method('getCalendarObject')
+			->willReturn($calObject1)->with(666, 'event-1');
+
+		$calendarInfo = [
+			'{http://owncloud.org/ns}owner-principal' => 'user1',
+			'principaluri' => 'user2',
+			'id' => 666,
+			'uri' => 'cal',
+		];
+		$c = new PublicCalendar($backend, $calendarInfo, $this->l10n);
+
+		$this->assertEquals(count($c->getChildren()), 2);
+
+		// test private event
+		$privateEvent = $c->getChild('event-1');
+		$calData = $privateEvent->get();
+		$event = Reader::read($calData);
+
+		$this->assertEquals($start, $event->VEVENT->DTSTART->getValue());
+		$this->assertEquals($end, $event->VEVENT->DTEND->getValue());
+
+		$this->assertEquals('Busy', $event->VEVENT->SUMMARY->getValue());
+		$this->assertArrayNotHasKey('ATTENDEE', $event->VEVENT);
+		$this->assertArrayNotHasKey('LOCATION', $event->VEVENT);
+		$this->assertArrayNotHasKey('DESCRIPTION', $event->VEVENT);
+		$this->assertArrayNotHasKey('ORGANIZER', $event->VEVENT);
+	}
+}


### PR DESCRIPTION
we can't remove the owner property as done in https://github.com/nextcloud/server/pull/4224/files#diff-d93b2e65badfbda223ac46eecdceb00bR50

We need the owner prop for https://github.com/nextcloud/calendar/pull/372

