### PR TITLE
Dont use the permissions mask while scanning

### DIFF
--- a/lib/private/Files/Storage/Wrapper/PermissionsMask.php
+++ b/lib/private/Files/Storage/Wrapper/PermissionsMask.php
@@ -147,4 +147,8 @@ class PermissionsMask extends Wrapper {
 		}
 		return $data;
 	}
+
+	public function getScanner($path = '', $storage = null) {
+		return parent::getScanner($path, $this->storage);
+	}
 }

--- a/tests/lib/Files/Storage/Wrapper/PermissionsMaskTest.php
+++ b/tests/lib/Files/Storage/Wrapper/PermissionsMaskTest.php
@@ -10,6 +10,9 @@ namespace Test\Files\Storage\Wrapper;
 
 use OCP\Constants;
 
+/**
+ * @group DB
+ */
 class PermissionsMaskTest extends \Test\Files\Storage\Storage {
 
 	/**
@@ -101,5 +104,14 @@ class PermissionsMaskTest extends \Test\Files\Storage\Storage {
 	public function testFopenNewFileNoCreate() {
 		$storage = $this->getMaskedStorage(Constants::PERMISSION_ALL - Constants::PERMISSION_CREATE);
 		$this->assertFalse($storage->fopen('foo', 'w'));
+	}
+
+	public function testScanNewFiles() {
+		$storage = $this->getMaskedStorage(Constants::PERMISSION_READ + Constants::PERMISSION_CREATE);
+		$storage->file_put_contents('foo', 'bar');
+		$storage->getScanner()->scan('');
+
+		$this->assertEquals(Constants::PERMISSION_ALL - Constants::PERMISSION_CREATE, $this->sourceStorage->getCache()->get('foo')->getPermissions());
+		$this->assertEquals(Constants::PERMISSION_READ, $storage->getCache()->get('foo')->getPermissions());
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/4243

The restricted permissions still apply when accessing the newly scanned item trough the cache, but not on the source storage