### PR TITLE
Show 'shared via' in share list for reshares

### DIFF
--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -190,6 +190,8 @@
 			var shareWithDisplayName = this.model.getShareWithDisplayName(shareIndex);
 			var shareWithTitle = '';
 			var shareType = this.model.getShareType(shareIndex);
+			var sharedBy = this.model.getSharedBy(shareIndex);
+			var sharedByDisplayName = this.model.getSharedByDisplayName(shareIndex);
 
 			var hasPermissionOverride = {};
 			if (shareType === OC.Share.SHARE_TYPE_GROUP) {
@@ -209,6 +211,17 @@
 				shareWithTitle = shareWith + " (" + t('core', 'email') + ')';
 			} else if (shareType === OC.Share.SHARE_TYPE_CIRCLE) {
 				shareWithTitle = shareWith;
+			}
+
+			if (sharedBy !== oc_current_user) {
+				var empty = shareWithTitle === '';
+				if (!empty) {
+					shareWithTitle += ' (';
+				}
+				shareWithTitle += t('core', 'shared by {sharer}', {sharer: sharedByDisplayName});
+				if (!empty) {
+					shareWithTitle += ')';
+				}
 			}
 
 			var share = this.model.get('shares')[shareIndex];

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -47,6 +47,7 @@
 	 * @property {Date} expiration optional?
 	 * @property {number} stime optional?
 	 * @property {string} uid_owner
+	 * @property {string} displayname_owner
 	 */
 
 	/**
@@ -405,6 +406,32 @@
 				throw "Unknown Share";
 			}
 			return share.share_with_displayname;
+		},
+
+		/**
+		 * @param shareIndex
+		 * @returns {string}
+		 */
+		getSharedBy: function(shareIndex) {
+			/** @type OC.Share.Types.ShareInfo **/
+			var share = this.get('shares')[shareIndex];
+			if(!_.isObject(share)) {
+				throw "Unknown Share";
+			}
+			return share.uid_owner;
+		},
+
+		/**
+		 * @param shareIndex
+		 * @returns {string}
+		 */
+		getSharedByDisplayName: function(shareIndex) {
+			/** @type OC.Share.Types.ShareInfo **/
+			var share = this.get('shares')[shareIndex];
+			if(!_.isObject(share)) {
+				throw "Unknown Share";
+			}
+			return share.displayname_owner;
 		},
 
 		/**


### PR DESCRIPTION
Fixes #1330

userA shares a file to userB
userB shares that file to userC

userA can see both userB and userC.
Now they can also see that userB shared it to user C

![untitled](https://cloud.githubusercontent.com/assets/45821/24868555/ae4baa1c-1e10-11e7-9123-271683c28b80.png)
