### PR TITLE
Add missing maintenance plugin to new DAV endpoint

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -268,6 +268,15 @@ pipeline:
     when:
       matrix:
         TESTS: integration-auth
+  integration-maintenance-mode:
+    image: nextcloudci/integration-php7.0:integration-php7.0-3
+    commands:
+      - ./occ maintenance:install --admin-pass=admin
+      - cd build/integration
+      - ./run.sh features/maintenance-mode.feature
+    when:
+      matrix:
+        TESTS: integration-maintenance-mode
   integration-carddav:
     image: nextcloudci/integration-php7.0:integration-php7.0-3
     commands:
@@ -497,6 +506,7 @@ matrix:
     - TESTS: db-codecov
     - TESTS: integration-capabilities_features
     - TESTS: integration-federation_features
+    - TESTS: integration-maintenance-mode
     - TESTS: integration-auth
     - TESTS: integration-carddav
     - TESTS: integration-dav-v2

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -74,6 +74,9 @@ class Server {
 		$root = new RootCollection();
 		$this->server = new \OCA\DAV\Connector\Sabre\Server($root);
 
+		// Add maintenance plugin
+		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\MaintenancePlugin(\OC::$server->getConfig()));
+
 		// Backends
 		$authBackend = new Auth(
 			\OC::$server->getSession(),

--- a/build/integration/features/bootstrap/Auth.php
+++ b/build/integration/features/bootstrap/Auth.php
@@ -22,6 +22,7 @@
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Cookie\CookieJar;
 
 require __DIR__ . '/../../vendor/autoload.php';
@@ -67,6 +68,8 @@ trait Auth {
 			$request->setHeader('requesttoken', $this->requestToken);
 			$this->response = $this->client->send($request);
 		} catch (ClientException $ex) {
+			$this->response = $ex->getResponse();
+		} catch (ServerException $ex) {
 			$this->response = $ex->getResponse();
 		}
 	}

--- a/build/integration/features/bootstrap/CommandLineContext.php
+++ b/build/integration/features/bootstrap/CommandLineContext.php
@@ -36,6 +36,20 @@ class CommandLineContext implements \Behat\Behat\Context\Context {
 		$this->remoteBaseUrl = $baseUrl;
 	}
 
+	/**
+	 * @Given Maintenance mode is enabled
+	 */
+	public function maintenanceModeIsEnabled()  {
+		$this->runOcc(['maintenance:mode', '--on']);
+	}
+
+	/**
+	 * @Then Maintenance mode is disabled
+	 */
+	public function maintenanceModeIsDisabled()  {
+		$this->runOcc(['maintenance:mode', '--off']);
+	}
+
 	/** @BeforeScenario */
 	public function gatherContexts(BeforeScenarioScope $scope) {
 		$environment = $scope->getEnvironment();

--- a/build/integration/features/maintenance-mode.feature
+++ b/build/integration/features/maintenance-mode.feature
@@ -1,0 +1,34 @@
+Feature: maintenance-mode
+
+  Background:
+    Given Maintenance mode is enabled
+
+  Scenario: Accessing /index.php with maintenance mode enabled
+    When requesting "/index.php" with "GET"
+    Then the HTTP status code should be "503"
+    Then Maintenance mode is disabled
+
+  Scenario: Accessing /remote.php/webdav with maintenance mode enabled
+    When requesting "/remote.php/webdav" with "GET"
+    Then the HTTP status code should be "503"
+    Then Maintenance mode is disabled
+
+  Scenario: Accessing /remote.php/dav with maintenance mode enabled
+    When requesting "/remote.php/dav" with "GET"
+    Then the HTTP status code should be "503"
+    Then Maintenance mode is disabled
+
+  Scenario: Accessing /ocs/v1.php with maintenance mode enabled
+    When requesting "/ocs/v1.php" with "GET"
+    Then the HTTP status code should be "503"
+    Then Maintenance mode is disabled
+
+  Scenario: Accessing /ocs/v2.php with maintenance mode enabled
+    When requesting "/ocs/v2.php" with "GET"
+    Then the HTTP status code should be "503"
+    Then Maintenance mode is disabled
+
+  Scenario: Accessing /public.php/webdav with maintenance mode enabled
+    When requesting "/public.php/webdav" with "GET"
+    Then the HTTP status code should be "503"
+    Then Maintenance mode is disabled


### PR DESCRIPTION
The `/remote.php/dav/` endpoint was not implementing the MaintenancePlugin. Thus when the instance was put into maintenance mode the endpoints were still accessible and delivered empty content. Sync clients really do love this.

Try with `cadaver http://10.211.55.7/stable9/remote.php/dav` with your instance in maintenance mode.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>