### PR TITLE
Do reload shared views

### DIFF
--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -382,6 +382,12 @@
 
 			// Sort by expected sort comparator
 			return files.sort(this._sortComparator);
+		},
+
+		_onUrlChanged: function(e) {
+			if (e && _.isString(e.dir)) {
+				this.changeDirectory(e.dir, false, true);
+			}
 		}
 	});
 


### PR DESCRIPTION
Fixes #4248

The magic introduced in #3686 caused the shared views not to be updated
properly. Thus we just overwrite the _onUrlChange method in the
sharedfilelist.

To test:

1. Create a folder `foo`
2. Share that folder
3. Navigate to `Shared with others`
4. Navigate to `Shared with you`
5. Navigate to `Shared with others`

Before: empty
Now: not empty