### PR TITLE
Favorites integration tests for shared files

### DIFF
--- a/build/integration/features/favorites.feature
+++ b/build/integration/features/favorites.feature
@@ -133,3 +133,16 @@ Feature: favorite
         Then user "user0" in folder "/subfolder" should have favorited the following elements
             | /subfolder/textfile0.txt |
             | /subfolder/textfile2.txt |
+
+    Scenario: moving a favorite file out of a share keeps favorite state
+        Given using old dav path
+        And As an "admin"
+        And user "user0" exists
+        And user "user1" exists
+        And user "user0" created a folder "/shared"
+        And User "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
+        And folder "/shared" of user "user0" is shared with user "user1"
+        And user "user1" favorites element "/shared/shared_file.txt"
+        When User "user1" moved file "/shared/shared_file.txt" to "/taken_out.txt"
+        Then user "user1" in folder "/" should have favorited the following elements
+            | /taken_out.txt |


### PR DESCRIPTION
* this is the extracted failing integration test from #3905

@rullzer @schiessle It returns 403 Forbidden when a (favourited) files is moved from a shared folder to the root. Is this intended? I think it's a bug :/