### PR TITLE
Allow to set text versions for the plain text email

### DIFF
--- a/lib/private/Mail/EMailTemplate.php
+++ b/lib/private/Mail/EMailTemplate.php
@@ -295,24 +295,32 @@ EOF;
 	 * Adds a heading to the email
 	 *
 	 * @param string $title
+	 * @param string $plainTitle Title that is used in the plain text email - if empty the $title is used
 	 */
-	public function addHeading($title) {
+	public function addHeading($title, $plainTitle = '') {
 		if ($this->footerAdded) {
 			return;
 		}
+		if ($plainTitle === '') {
+			$plainTitle = $title;
+		}
 
 		$this->htmlBody .= vsprintf($this->heading, [$title]);
-		$this->plainBody .= $title . PHP_EOL . PHP_EOL;
+		$this->plainBody .= $plainTitle . PHP_EOL . PHP_EOL;
 	}
 
 	/**
 	 * Adds a paragraph to the body of the email
 	 *
 	 * @param string $text
+	 * @param string $plainText Text that is used in the plain text email - if empty the $text is used
 	 */
-	public function addBodyText($text) {
+	public function addBodyText($text, $plainText = '') {
 		if ($this->footerAdded) {
 			return;
+		}
+		if ($plainText === '') {
+			$plainText = $text;
 		}
 
 		if (!$this->bodyOpened) {
@@ -321,7 +329,7 @@ EOF;
 		}
 
 		$this->htmlBody .= vsprintf($this->bodyText, [$text]);
-		$this->plainBody .= $text . PHP_EOL . PHP_EOL;
+		$this->plainBody .= $plainText . PHP_EOL . PHP_EOL;
 	}
 
 	/**
@@ -331,10 +339,19 @@ EOF;
 	 * @param string $urlLeft URL of left button
 	 * @param string $textRight Text of right button
 	 * @param string $urlRight URL of right button
+	 * @param string $plainTextLeft Text of left button that is used in the plain text version - if unset the $textLeft is used
+	 * @param string $plainTextRight Text of right button that is used in the plain text version - if unset the $textRight is used
 	 */
-	public function addBodyButtonGroup($textLeft, $urlLeft, $textRight, $urlRight) {
+	public function addBodyButtonGroup($textLeft, $urlLeft, $textRight, $urlRight, $plainTextLeft = '', $plainTextRight = '') {
 		if ($this->footerAdded) {
 			return;
+		}
+		if ($plainTextLeft === '') {
+			$plainTextLeft = $textLeft;
+		}
+
+		if ($plainTextRight === '') {
+			$plainTextRight = $textRight;
 		}
 
 		if (!$this->bodyOpened) {
@@ -344,8 +361,8 @@ EOF;
 
 		$color = $this->themingDefaults->getColorPrimary();
 		$this->htmlBody .= vsprintf($this->buttonGroup, [$color, $color, $urlLeft, $color, $textLeft, $urlRight, $textRight]);
-		$this->plainBody .= $textLeft . ': ' . $urlLeft . PHP_EOL;
-		$this->plainBody .= $textRight . ': ' . $urlRight . PHP_EOL . PHP_EOL;
+		$this->plainBody .= $plainTextLeft . ': ' . $urlLeft . PHP_EOL;
+		$this->plainBody .= $plainTextRight . ': ' . $urlRight . PHP_EOL . PHP_EOL;
 
 	}
 

--- a/lib/public/Mail/IEMailTemplate.php
+++ b/lib/public/Mail/IEMailTemplate.php
@@ -62,19 +62,21 @@ interface IEMailTemplate {
 	 * Adds a heading to the email
 	 *
 	 * @param string $title
+	 * @param string $plainTitle Title that is used in the plain text email - if empty the $title is used
 	 *
 	 * @since 12.0.0
 	 */
-	public function addHeading($title);
+	public function addHeading($title, $plainTitle = '');
 
 	/**
 	 * Adds a paragraph to the body of the email
 	 *
 	 * @param string $text
+	 * @param string $plainText Text that is used in the plain text email - if empty the $text is used
 	 *
 	 * @since 12.0.0
 	 */
-	public function addBodyText($text);
+	public function addBodyText($text, $plainText = '');
 
 	/**
 	 * Adds a button group of two buttons to the body of the email
@@ -83,10 +85,12 @@ interface IEMailTemplate {
 	 * @param string $urlLeft URL of left button
 	 * @param string $textRight Text of right button
 	 * @param string $urlRight URL of right button
+	 * @param string $plainTextLeft Text of left button that is used in the plain text version - if empty the $textLeft is used
+	 * @param string $plainTextRight Text of right button that is used in the plain text version - if empty the $textRight is used
 	 *
 	 * @since 12.0.0
 	 */
-	public function addBodyButtonGroup($textLeft, $urlLeft, $textRight, $urlRight);
+	public function addBodyButtonGroup($textLeft, $urlLeft, $textRight, $urlRight, $plainTextLeft = '', $plainTextRight = '');
 
 	/**
 	 * Adds a logo and a text to the footer. <br> in the text will be replaced by new lines in the plain text email

--- a/tests/data/emails/new-account-email-custom-text-alternative.txt
+++ b/tests/data/emails/new-account-email-custom-text-alternative.txt
@@ -1,0 +1,11 @@
+Welcome aboard - text
+
+You have now an Nextcloud account, you can add, protect, and share your data. - text
+
+Your username is: abc
+
+Set your password - text: https://example.org/resetPassword/123
+Install Client - text: https://nextcloud.com/install/#install-clients
+
+--
+TestCloud - A safe home for your data

--- a/tests/lib/Mail/EMailTemplateTest.php
+++ b/tests/lib/Mail/EMailTemplateTest.php
@@ -126,4 +126,46 @@ class EMailTemplateTest extends TestCase {
 	}
 
 
+
+	public function testEMailTemplateAlternativePlainTexts() {
+		$this->defaults
+			->expects($this->any())
+			->method('getColorPrimary')
+			->willReturn('#0082c9');
+		$this->defaults
+			->expects($this->any())
+			->method('getName')
+			->willReturn('TestCloud');
+		$this->defaults
+			->expects($this->any())
+			->method('getSlogan')
+			->willReturn('A safe home for your data');
+		$this->defaults
+			->expects($this->any())
+			->method('getLogo')
+			->willReturn('/img/logo-mail-header.png');
+		$this->urlGenerator
+			->expects($this->once())
+			->method('getAbsoluteURL')
+			->with('/img/logo-mail-header.png')
+			->willReturn('https://example.org/img/logo-mail-header.png');
+
+		$this->emailTemplate->addHeader();
+		$this->emailTemplate->addHeading('Welcome aboard', 'Welcome aboard - text');
+		$this->emailTemplate->addBodyText('You have now an Nextcloud account, you can add, protect, and share your data.', 'You have now an Nextcloud account, you can add, protect, and share your data. - text');
+		$this->emailTemplate->addBodyText('Your username is: abc');
+		$this->emailTemplate->addBodyButtonGroup(
+			'Set your password', 'https://example.org/resetPassword/123',
+			'Install Client', 'https://nextcloud.com/install/#install-clients',
+			'Set your password - text', 'Install Client - text'
+		);
+		$this->emailTemplate->addFooter();
+
+		$expectedHTML = file_get_contents(\OC::$SERVERROOT . '/tests/data/emails/new-account-email-custom.html');
+		$this->assertSame($expectedHTML, $this->emailTemplate->renderHTML());
+		$expectedTXT = file_get_contents(\OC::$SERVERROOT . '/tests/data/emails/new-account-email-custom-text-alternative.txt');
+		$this->assertSame($expectedTXT, $this->emailTemplate->renderText());
+	}
+
+
 }


### PR DESCRIPTION
* allows different texts for HTML and text version of the email

@LukasReschke @rullzer Comments are welcome - the idea behind this: The body says something like "Click the button below to reset your password". For the text only version it should be "Click the link below to reset your password".
