### PR TITLE
Change LDAP method names

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -595,8 +595,8 @@ class Access extends LDAPUtility implements IUserTools {
 	 *
 	 * gives back the user names as they are used ownClod internally
 	 */
-	public function ownCloudUserNames($ldapUsers) {
-		return $this->ldap2ownCloudNames($ldapUsers, true);
+	public function nextcloudUserNames($ldapUsers) {
+		return $this->ldap2NextcloudNames($ldapUsers, true);
 	}
 
 	/**
@@ -606,8 +606,8 @@ class Access extends LDAPUtility implements IUserTools {
 	 *
 	 * gives back the group names as they are used ownClod internally
 	 */
-	public function ownCloudGroupNames($ldapGroups) {
-		return $this->ldap2ownCloudNames($ldapGroups, false);
+	public function nextcloudGroupNames($ldapGroups) {
+		return $this->ldap2NextcloudNames($ldapGroups, false);
 	}
 
 	/**
@@ -615,14 +615,14 @@ class Access extends LDAPUtility implements IUserTools {
 	 * @param bool $isUsers
 	 * @return array
 	 */
-	private function ldap2ownCloudNames($ldapObjects, $isUsers) {
+	private function ldap2NextcloudNames($ldapObjects, $isUsers) {
 		if($isUsers) {
 			$nameAttribute = $this->connection->ldapUserDisplayName;
 			$sndAttribute  = $this->connection->ldapUserDisplayName2;
 		} else {
 			$nameAttribute = $this->connection->ldapGroupDisplayName;
 		}
-		$ownCloudNames = array();
+		$nextcloudNames = array();
 
 		foreach($ldapObjects as $ldapObject) {
 			$nameByLDAP = null;
@@ -634,9 +634,9 @@ class Access extends LDAPUtility implements IUserTools {
 				$nameByLDAP = $ldapObject[$nameAttribute][0];
 			}
 
-			$ocName = $this->dn2ocname($ldapObject['dn'][0], $nameByLDAP, $isUsers);
-			if($ocName) {
-				$ownCloudNames[] = $ocName;
+			$ncName = $this->dn2ocname($ldapObject['dn'][0], $nameByLDAP, $isUsers);
+			if($ncName) {
+				$nextcloudNames[] = $ncName;
 				if($isUsers) {
 					//cache the user names so it does not need to be retrieved
 					//again later (e.g. sharing dialogue).
@@ -645,11 +645,11 @@ class Access extends LDAPUtility implements IUserTools {
 					}
 					$sndName = isset($ldapObject[$sndAttribute][0])
 						? $ldapObject[$sndAttribute][0] : '';
-					$this->cacheUserDisplayName($ocName, $nameByLDAP, $sndName);
+					$this->cacheUserDisplayName($ncName, $nameByLDAP, $sndName);
 				}
 			}
 		}
-		return $NextcloudNames;
+		return $nextcloudNames;
 	}
 
 	/**

--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -388,7 +388,7 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface {
 				$limit,
 				$offset
 			);
-			return $this->access->ownCloudUserNames($users);
+			return $this->access->nextcloudUserNames($users);
 		} catch (\Exception $e) {
 			return array();
 		}
@@ -541,7 +541,7 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface {
 			$groups = array_merge($groups, $this->cachedGroupsByMember[$uid]);
 		} else {
 			$groupsByMember = array_values($this->getGroupsByMember($uid));
-			$groupsByMember = $this->access->ownCloudGroupNames($groupsByMember);
+			$groupsByMember = $this->access->nextcloudGroupNames($groupsByMember);
 			$this->cachedGroupsByMember[$uid] = $groupsByMember;
 			$groups = array_merge($groups, $groupsByMember);
 		}
@@ -804,7 +804,7 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface {
 				array($this->access->connection->ldapGroupDisplayName, 'dn'),
 				$limit,
 				$offset);
-		$ldap_groups = $this->access->ownCloudGroupNames($ldap_groups);
+		$ldap_groups = $this->access->nextcloudGroupNames($ldap_groups);
 
 		$this->access->connection->writeToCache($cacheKey, $ldap_groups);
 		return $ldap_groups;

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -234,7 +234,7 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 			$filter,
 			$this->access->userManager->getAttributes(true),
 			$limit, $offset);
-		$ldap_users = $this->access->ownCloudUserNames($ldap_users);
+		$ldap_users = $this->access->nextcloudUserNames($ldap_users);
 		Util::writeLog('user_ldap', 'getUsers: '.count($ldap_users). ' Users found', Util::DEBUG);
 
 		$this->access->connection->writeToCache($cachekey, $ldap_users);

--- a/apps/user_ldap/tests/Group_LDAPTest.php
+++ b/apps/user_ldap/tests/Group_LDAPTest.php
@@ -315,7 +315,7 @@ class Group_LDAPTest extends \Test\TestCase {
 		$this->enableGroups($access);
 
 		$access->expects($this->once())
-			->method('ownCloudGroupNames')
+			->method('nextcloudGroupNames')
 			->will($this->returnValue(array('group1', 'group2')));
 
 		$groupBackend = new GroupLDAP($access);
@@ -350,7 +350,7 @@ class Group_LDAPTest extends \Test\TestCase {
 			->will($this->returnValue('cn=foobar,dc=foo,dc=bar'));
 
 		$access->expects($this->once())
-			->method('ownCloudUserNames')
+			->method('nextcloudUserNames')
 			->will($this->returnValue(array('lisa', 'bart', 'kira', 'brad')));
 
 		$groupBackend = new GroupLDAP($access);
@@ -451,7 +451,7 @@ class Group_LDAPTest extends \Test\TestCase {
 			->with($dn, 'memberOf');
 
 		$access->expects($this->once())
-			->method('ownCloudGroupNames')
+			->method('nextcloudGroupNames')
 			->will($this->returnValue([]));
 
 		$groupBackend = new GroupLDAP($access);
@@ -496,7 +496,7 @@ class Group_LDAPTest extends \Test\TestCase {
 		];
 
 		$access->expects($this->once())
-			->method('ownCloudGroupNames')
+			->method('nextcloudGroupNames')
 			->with([$group1, $group2])
 			->will($this->returnValue(['group1', 'group2']));
 

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -349,7 +349,7 @@ class User_LDAPTest extends TestCase {
 			   }));
 
 		$access->expects($this->any())
-			   ->method('ownCloudUserNames')
+			   ->method('nextcloudUserNames')
 			   ->will($this->returnArgument(0));
 	}
 


### PR DESCRIPTION
@blizzz You need to say if this makes sense. If that name is stored in the DB we should not do that.

based on #4311 