### PR TITLE
change sharing tooltip with a more general description of all available share options

### DIFF
--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -22,7 +22,7 @@
 		'<div class="oneline">' +
 		'    <input id="shareWith-{{cid}}" class="shareWithField" type="text" placeholder="{{sharePlaceholder}}" />' +
 		'    <span class="shareWithLoading icon-loading-small hidden"></span>'+
-		'{{{remoteShareInfo}}}' +
+		'{{{shareInfo}}}' +
 		'</div>' +
 		'{{/if}}' +
 		'<div class="shareeListView subView"></div>' +
@@ -30,9 +30,9 @@
 		'<div class="expirationView subView"></div>' +
 		'<div class="loading hidden" style="height: 50px"></div>';
 
-	var TEMPLATE_REMOTE_SHARE_INFO =
-		'<a target="_blank" class="icon icon-info shareWithRemoteInfo hasTooltip" href="{{docLink}}" ' +
-		'title="{{tooltip}}"></a>';
+	var TEMPLATE_SHARE_INFO =
+		'<span class="icon icon-info shareWithRemoteInfo hasTooltip" ' +
+		'title="{{tooltip}}"></span>';
 
 	/**
 	 * @class OCA.Share.ShareDialogView
@@ -135,7 +135,7 @@
 			var $shareWithField = $('.shareWithField'),
 				view = this,
 				$loading = this.$el.find('.shareWithLoading'),
-				$remoteShareInfo = this.$el.find('.shareWithRemoteInfo');
+				$shareInfo = this.$el.find('.shareWithRemoteInfo');
 
 			var count = oc_config['sharing.minSearchStringLength'];
 			if (search.term.trim().length < count) {
@@ -160,7 +160,7 @@
 
 			$loading.removeClass('hidden');
 			$loading.addClass('inlineblock');
-			$remoteShareInfo.addClass('hidden');
+			$shareInfo.addClass('hidden');
 
 			$shareWithField.removeClass('error')
 				.tooltip('hide');
@@ -177,7 +177,7 @@
 				function (result) {
 					$loading.addClass('hidden');
 					$loading.removeClass('inlineblock');
-					$remoteShareInfo.removeClass('hidden');
+					$shareInfo.removeClass('hidden');
 					if (result.ocs.meta.statuscode === 100) {
 						var users   = result.ocs.data.exact.users.concat(result.ocs.data.users);
 						var groups  = result.ocs.data.exact.groups.concat(result.ocs.data.groups);
@@ -314,7 +314,7 @@
 			).fail(function() {
 				$loading.addClass('hidden');
 				$loading.removeClass('inlineblock');
-				$remoteShareInfo.removeClass('hidden');
+				$shareInfo.removeClass('hidden');
 				OC.Notification.show(t('core', 'An error occurred. Please try again'));
 				window.setTimeout(OC.Notification.hide, 5000);
 			});
@@ -359,22 +359,22 @@
 			var $loading = this.$el.find('.shareWithLoading');
 			$loading.removeClass('hidden')
 				.addClass('inlineblock');
-			var $remoteShareInfo = this.$el.find('.shareWithRemoteInfo');
-			$remoteShareInfo.addClass('hidden');
+			var $shareInfo = this.$el.find('.shareWithRemoteInfo');
+			$shareInfo.addClass('hidden');
 
 			this.model.addShare(s.item.value, {success: function() {
 				$(e.target).val('')
 					.attr('disabled', false);
 				$loading.addClass('hidden')
 					.removeClass('inlineblock');
-				$remoteShareInfo.removeClass('hidden');
+				$shareInfo.removeClass('hidden');
 			}, error: function(obj, msg) {
 				OC.Notification.showTemporary(msg);
 				$(e.target).attr('disabled', false)
 					.autocomplete('search', $(e.target).val());
 				$loading.addClass('hidden')
 					.removeClass('inlineblock');
-				$remoteShareInfo.removeClass('hidden');
+				$shareInfo.removeClass('hidden');
 			}});
 		},
 
@@ -412,7 +412,7 @@
 				cid: this.cid,
 				shareLabel: t('core', 'Share'),
 				sharePlaceholder: this._renderSharePlaceholderPart(),
-				remoteShareInfo: this._renderRemoteShareInfoPart(),
+				shareInfo: this._renderShareInfoPart(),
 				isSharingAllowed: this.model.sharePermissionPossible()
 			}));
 
@@ -457,17 +457,25 @@
 			this.linkShareView.showLink = this._showLink;
 		},
 
-		_renderRemoteShareInfoPart: function() {
-			var remoteShareInfo = '';
-			if(this.configModel.get('isRemoteShareAllowed')) {
-				var infoTemplate = this._getRemoteShareInfoTemplate();
-				remoteShareInfo = infoTemplate({
-					docLink: this.configModel.getFederatedShareDocLink(),
-					tooltip: t('core', 'Share with people on other servers using their Federated Cloud ID username@example.com/nextcloud')
+		_renderShareInfoPart: function() {
+			var shareInfo = '';
+			var infoTemplate = this._getShareInfoTemplate();
+
+			if(this.configModel.get('isMailShareAllowed') && this.configModel.get('isRemoteShareAllowed')) {
+				shareInfo = infoTemplate({
+					tooltip: t('core', 'Share with other people by entering a user or group, a federated cloud ID or an email address.')
+				});
+			} else if(this.configModel.get('isRemoteShareAllowed')) {
+				shareInfo = infoTemplate({
+					tooltip: t('core', 'Share with other people by entering a user or group or a federated cloud ID.')
+				});
+			} else if(this.configModel.get('isMailShareAllowed')) {
+				shareInfo = infoTemplate({
+					tooltip: t('core', 'Share with other people by entering a user or group or an email address.')
 				});
 			}
 
-			return remoteShareInfo;
+			return shareInfo;
 		},
 
 		_renderSharePlaceholderPart: function () {
@@ -520,8 +528,8 @@
 		 * @returns {Function}
 		 * @private
 		 */
-		_getRemoteShareInfoTemplate: function() {
-			return this._getTemplate('remoteShareInfo', TEMPLATE_REMOTE_SHARE_INFO);
+		_getShareInfoTemplate: function() {
+			return this._getTemplate('shareInfo', TEMPLATE_SHARE_INFO);
 		}
 	});
 

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -479,33 +479,20 @@
 		},
 
 		_renderSharePlaceholderPart: function () {
-			var allowGroupSharing = this.configModel.get('allowGroupSharing');
 			var allowRemoteSharing = this.configModel.get('isRemoteShareAllowed');
 			var allowMailSharing = this.configModel.get('isMailShareAllowed');
 
-			if (!allowGroupSharing && !allowRemoteSharing && allowMailSharing) {
-				return t('core', 'Share with users or by mail...');
+			if (!allowRemoteSharing && allowMailSharing) {
+				return t('core', 'Name or email address...');
 			}
-			if (!allowGroupSharing && allowRemoteSharing && !allowMailSharing) {
-				return t('core', 'Share with users or remote users...');
+			if (allowRemoteSharing && !allowMailSharing) {
+				return t('core', 'Name or federated cloud ID...');
 			}
-			if (!allowGroupSharing && allowRemoteSharing && allowMailSharing) {
-				return t('core', 'Share with users, remote users or by mail...');
-			}
-			if (allowGroupSharing && !allowRemoteSharing && !allowMailSharing) {
-				return t('core', 'Share with users or groups...');
-			}
-			if (allowGroupSharing && !allowRemoteSharing && allowMailSharing) {
-				return t('core', 'Share with users, groups or by mail...');
-			}
-			if (allowGroupSharing && allowRemoteSharing && !allowMailSharing) {
-				return t('core', 'Share with users, groups or remote users...');
-			}
-			if (allowGroupSharing && allowRemoteSharing && allowMailSharing) {
-				return t('core', 'Share with users, groups, remote users or by mail...');
+			if (allowRemoteSharing && allowMailSharing) {
+				return t('core', 'Name, federated cloud ID or email address...');
 			}
 
-			return 	t('core', 'Share with users...');
+			return 	t('core', 'Name...');
 		},
 
 		/**


### PR DESCRIPTION
I think it is no longer needed to point out federated shares specifically. They exists now for a long time. With the improvements we did over the time people will do more and more remote shares without entering the remote ID but just with auto completing users from their address book, trusted servers, lookup server, etc.

So I changed the tooltip into a general information about what share types are available so that people can discover it, even if the input field is to small to read it directly there.

