### PR TITLE
Fix AdBlock blocking share icon, ref #866

### DIFF
--- a/apps/files_sharing/css/sharebreadcrumb.scss
+++ b/apps/files_sharing/css/sharebreadcrumb.scss
@@ -20,7 +20,7 @@
  *
  */
 
-div.crumb span.icon-share,
+div.crumb span.icon-shared,
 div.crumb span.icon-public {
 	display: inline-block;
 	cursor: pointer;
@@ -28,7 +28,7 @@ div.crumb span.icon-public {
 	margin-right: 6px;
 }
 
-div.crumb span.icon-share.shared,
+div.crumb span.icon-shared.shared,
 div.crumb span.icon-public.shared {
 	opacity: 0.7;
 }

--- a/apps/files_sharing/js/app.js
+++ b/apps/files_sharing/js/app.js
@@ -40,7 +40,7 @@ OCA.Sharing.App = {
 
 		this._extendFileList(this._inFileList);
 		this._inFileList.appName = t('files_sharing', 'Shared with you');
-		this._inFileList.$el.find('#emptycontent').html('<div class="icon-share"></div>' +
+		this._inFileList.$el.find('#emptycontent').html('<div class="icon-shared"></div>' +
 			'<h2>' + t('files_sharing', 'Nothing shared with you yet') + '</h2>' +
 			'<p>' + t('files_sharing', 'Files and folders others share with you will show up here') + '</p>');
 		return this._inFileList;
@@ -63,7 +63,7 @@ OCA.Sharing.App = {
 
 		this._extendFileList(this._outFileList);
 		this._outFileList.appName = t('files_sharing', 'Shared with others');
-		this._outFileList.$el.find('#emptycontent').html('<div class="icon-share"></div>' +
+		this._outFileList.$el.find('#emptycontent').html('<div class="icon-shared"></div>' +
 			'<h2>' + t('files_sharing', 'Nothing shared yet') + '</h2>' +
 			'<p>' + t('files_sharing', 'Files and folders you share will show up here') + '</p>');
 		return this._outFileList;
@@ -194,4 +194,3 @@ $(document).ready(function() {
 		OCA.Sharing.App.removeSharingLinks();
 	});
 });
-

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -154,7 +154,7 @@
 				altText: t('core', 'Share'),
 				mime: 'all',
 				permissions: OC.PERMISSION_ALL,
-				iconClass: 'icon-share',
+				iconClass: 'icon-shared',
 				type: OCA.Files.FileActions.TYPE_INLINE,
 				actionHandler: function(fileName) {
 					fileList.showDetailsView(fileName, 'shareTabView');

--- a/apps/files_sharing/js/sharebreadcrumbview.js
+++ b/apps/files_sharing/js/sharebreadcrumbview.js
@@ -44,21 +44,21 @@
 
 			if (this._dirInfo !== null && (this._dirInfo.path !== '/' || this._dirInfo.name !== '')) {
 				var isShared = data.dirInfo && data.dirInfo.shareTypes && data.dirInfo.shareTypes.length > 0;
-				this.$el.removeClass('shared icon-public icon-share');
+				this.$el.removeClass('shared icon-public icon-shared');
 				if (isShared) {
 					this.$el.addClass('shared');
 					if (data.dirInfo.shareTypes.indexOf(OC.Share.SHARE_TYPE_LINK) !== -1) {
 						this.$el.addClass('icon-public');
 					} else {
-						this.$el.addClass('icon-share');
+						this.$el.addClass('icon-shared');
 					}
 				} else {
-					this.$el.addClass('icon-share');
+					this.$el.addClass('icon-shared');
 				}
 				this.$el.show();
 				this.delegateEvents();
 			} else {
-				this.$el.removeClass('shared icon-public icon-share');
+				this.$el.removeClass('shared icon-public icon-shared');
 				this.$el.hide();
 			}
 

--- a/apps/files_sharing/tests/js/shareSpec.js
+++ b/apps/files_sharing/tests/js/shareSpec.js
@@ -84,7 +84,7 @@ describe('OCA.Sharing.Util tests', function() {
 			}]);
 			$tr = fileList.$el.find('tbody tr:first');
 			$action = $tr.find('.action-share');
-			expect($action.find('.icon').hasClass('icon-share')).toEqual(true);
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(true);
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(false);
 			expect(OC.basename(getImageUrl($tr.find('.filename .thumbnail')))).toEqual('folder.svg');
 		});
@@ -104,7 +104,7 @@ describe('OCA.Sharing.Util tests', function() {
 			$tr = fileList.$el.find('tbody tr:first');
 			$action = $tr.find('.action-share');
 			expect($action.find('>span').text().trim()).toEqual('Shared');
-			expect($action.find('.icon').hasClass('icon-share')).toEqual(true);
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(true);
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(false);
 			expect(OC.basename(getImageUrl($tr.find('.filename .thumbnail')))).toEqual('folder-shared.svg');
 		});
@@ -125,7 +125,7 @@ describe('OCA.Sharing.Util tests', function() {
 			$tr = fileList.$el.find('tbody tr:first');
 			$action = $tr.find('.action-share');
 			expect($action.find('>span').text().trim()).toEqual('Shared');
-			expect($action.find('.icon').hasClass('icon-share')).toEqual(false);
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(false);
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(true);
 			expect(OC.basename(getImageUrl($tr.find('.filename .thumbnail')))).toEqual('folder-public.svg');
 		});
@@ -146,7 +146,7 @@ describe('OCA.Sharing.Util tests', function() {
 			$tr = fileList.$el.find('tbody tr:first');
 			$action = $tr.find('.action-share');
 			expect($action.find('>span').text().trim()).toEqual('User One');
-			expect($action.find('.icon').hasClass('icon-share')).toEqual(true);
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(true);
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(false);
 			expect(OC.basename(getImageUrl($tr.find('.filename .thumbnail')))).toEqual('folder-shared.svg');
 		});
@@ -167,7 +167,7 @@ describe('OCA.Sharing.Util tests', function() {
 			$tr = fileList.$el.find('tbody tr:first');
 			$action = $tr.find('.action-share');
 			expect($action.find('>span').text().trim()).toEqual('Shared with User One, User Two');
-			expect($action.find('.icon').hasClass('icon-share')).toEqual(true);
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(true);
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(false);
 			expect(OC.basename(getImageUrl($tr.find('.filename .thumbnail')))).toEqual('folder-shared.svg');
 		});
@@ -274,7 +274,7 @@ describe('OCA.Sharing.Util tests', function() {
 			expect($tr.attr('data-share-recipients')).toEqual('Group One, Group Two, User One, User Two');
 
 			expect($action.find('>span').text().trim()).toEqual('Shared with Group One, Group Two, User One, User Two');
-			expect($action.find('.icon').hasClass('icon-share')).toEqual(true);
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(true);
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(false);
 		});
 		it('updates share icon after updating shares of a file', function() {
@@ -307,7 +307,7 @@ describe('OCA.Sharing.Util tests', function() {
 			expect($tr.attr('data-share-recipients')).toEqual('User One, User Three, User Two');
 
 			expect($action.find('>span').text().trim()).toEqual('Shared with User One, User Three, User Two');
-			expect($action.find('.icon').hasClass('icon-share')).toEqual(true);
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(true);
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(false);
 		});
 		it('removes share icon after removing all shares from a file', function() {
@@ -363,7 +363,7 @@ describe('OCA.Sharing.Util tests', function() {
 			expect($tr.attr('data-share-recipients')).toEqual('User Two');
 
 			expect($action.find('>span').text().trim()).toEqual('User One');
-			expect($action.find('.icon').hasClass('icon-share')).toEqual(true);
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(true);
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(false);
 		});
 		it('keep share text after unsharing reshare', function() {
@@ -394,7 +394,7 @@ describe('OCA.Sharing.Util tests', function() {
 			expect($tr.attr('data-share-recipients')).not.toBeDefined();
 
 			expect($action.find('>span').text().trim()).toEqual('User One');
-			expect($action.find('.icon').hasClass('icon-share')).toEqual(true);
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(true);
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(false);
 		});
 	});
@@ -469,5 +469,5 @@ describe('OCA.Sharing.Util tests', function() {
 			expect($('[data-share-recipient]').length).toEqual(0);
 		});
 	});
-	
+
 });

--- a/apps/files_sharing/tests/js/sharedbreadcrumviewSpec.js
+++ b/apps/files_sharing/tests/js/sharedbreadcrumviewSpec.js
@@ -57,7 +57,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			bc.setDirectory('');
 			bc.render();
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
-			expect(bc.$el.find('.icon-share').length).toEqual(0);
+			expect(bc.$el.find('.icon-shared').length).toEqual(0);
 			expect(bc.$el.find('.shared').length).toEqual(0);
 			expect(bc.$el.find('.icon-public').length).toEqual(0);
 		});
@@ -71,7 +71,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			bc.setDirectory('/foo');
 			bc.render();
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
-			expect(bc.$el.find('.icon-share').length).toEqual(1);
+			expect(bc.$el.find('.icon-shared').length).toEqual(1);
 			expect(bc.$el.find('.shared').length).toEqual(0);
 			expect(bc.$el.find('.icon-public').length).toEqual(0);
 		});
@@ -86,7 +86,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			bc.setDirectory('/foo');
 			bc.render();
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
-			expect(bc.$el.find('.icon-share').length).toEqual(1);
+			expect(bc.$el.find('.icon-shared').length).toEqual(1);
 			expect(bc.$el.find('.shared').length).toEqual(1);
 			expect(bc.$el.find('.icon-public').length).toEqual(0);
 		});
@@ -101,7 +101,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			bc.setDirectory('/foo');
 			bc.render();
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
-			expect(bc.$el.find('.icon-share').length).toEqual(1);
+			expect(bc.$el.find('.icon-shared').length).toEqual(1);
 			expect(bc.$el.find('.shared').length).toEqual(1);
 			expect(bc.$el.find('.icon-public').length).toEqual(0);
 		});
@@ -116,7 +116,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			bc.setDirectory('/foo');
 			bc.render();
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
-			expect(bc.$el.find('.icon-share').length).toEqual(0);
+			expect(bc.$el.find('.icon-shared').length).toEqual(0);
 			expect(bc.$el.find('.shared').length).toEqual(1);
 			expect(bc.$el.find('.icon-public').length).toEqual(1);
 		});
@@ -131,7 +131,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			bc.setDirectory('/foo');
 			bc.render();
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
-			expect(bc.$el.find('.icon-share').length).toEqual(1);
+			expect(bc.$el.find('.icon-shared').length).toEqual(1);
 			expect(bc.$el.find('.shared').length).toEqual(1);
 			expect(bc.$el.find('.icon-public').length).toEqual(0);
 		});
@@ -146,7 +146,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			bc.setDirectory('/foo');
 			bc.render();
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
-			expect(bc.$el.find('.icon-share').length).toEqual(1);
+			expect(bc.$el.find('.icon-shared').length).toEqual(1);
 			expect(bc.$el.find('.shared').length).toEqual(1);
 			expect(bc.$el.find('.icon-public').length).toEqual(0);
 		});
@@ -168,7 +168,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			bc.setDirectory('/foo');
 			bc.render();
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
-			expect(bc.$el.find('.icon-share').length).toEqual(0);
+			expect(bc.$el.find('.icon-shared').length).toEqual(0);
 			expect(bc.$el.find('.shared').length).toEqual(1);
 			expect(bc.$el.find('.icon-public').length).toEqual(1);
 		});
@@ -188,7 +188,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			mock.showDetailsView = function() { };
 			OCA.Files.App.fileList = mock;
 			var spy = sinon.spy(mock, 'showDetailsView');
-			bc.$el.find('.icon-share').click();
+			bc.$el.find('.icon-shared').click();
 
 			expect(spy.calledOnce).toEqual(true);
 
@@ -199,7 +199,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			shareTab.trigger('sharesChanged', model);
 
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
-			expect(bc.$el.find('.icon-share').length).toEqual(1);
+			expect(bc.$el.find('.icon-shared').length).toEqual(1);
 			expect(bc.$el.find('.shared').length).toEqual(0);
 			expect(bc.$el.find('.icon-public').length).toEqual(0);
 		});
@@ -219,7 +219,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			mock.showDetailsView = function() { };
 			OCA.Files.App.fileList = mock;
 			var spy = sinon.spy(mock, 'showDetailsView');
-			bc.$el.find('.icon-share').click();
+			bc.$el.find('.icon-shared').click();
 
 			expect(spy.calledOnce).toEqual(true);
 
@@ -232,7 +232,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			shareTab.trigger('sharesChanged', model);
 
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
-			expect(bc.$el.find('.icon-share').length).toEqual(0);
+			expect(bc.$el.find('.icon-shared').length).toEqual(0);
 			expect(bc.$el.find('.shared').length).toEqual(1);
 			expect(bc.$el.find('.icon-public').length).toEqual(1);
 		});

--- a/core/css/icons.scss
+++ b/core/css/icons.scss
@@ -326,12 +326,10 @@ img, object, video, button, textarea, input, select {
 	background-image: url('../img/actions/settings-white.svg?v=1');
 }
 
+/* always use icon-shared, AdBlock blocks icon-share */
+.icon-shared,
 .icon-share {
 	background-image: url('../img/actions/share.svg?v=1');
-}
-
-.icon-shared {
-	background-image: url('../img/actions/shared.svg?v=1');
 }
 
 .icon-sound {

--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -206,6 +206,7 @@ input {
 			height: 1px;
 			overflow: hidden;
 			+ label {
+				padding: 6px 0;
 				user-select: none;
 			}
 			&:disabled + label,
@@ -219,8 +220,8 @@ input {
 				width: 12px;
 				vertical-align: middle;
 				border-radius: 50%;
-				margin: 3px;
-				margin-top: 1px;
+				margin: 6px;
+				margin-top: -2px;
 				border: 1px solid nc-lighten($color-main-text, 53%);
 			}
 			&:not(:disabled):not(:checked) + label:hover:before,

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -107,7 +107,7 @@ OC.Share = _.extend(OC.Share || {}, {
 		}
 		// TODO: iterating over the files might be more efficient
 		for (item in OC.Share.statuses){
-			var iconClass = 'icon-share';
+			var iconClass = 'icon-shared';
 			var data = OC.Share.statuses[item];
 			var hasLink = data.link;
 			// Links override shared in terms of icon display
@@ -115,7 +115,7 @@ OC.Share = _.extend(OC.Share || {}, {
 				iconClass = 'icon-public';
 			}
 			if (itemType !== 'file' && itemType !== 'folder') {
-				$('a.share[data-item="'+item+'"] .icon').removeClass('icon-share icon-public').addClass(iconClass);
+				$('a.share[data-item="'+item+'"] .icon').removeClass('icon-shared icon-public').addClass(iconClass);
 			} else {
 				// TODO: ultimately this part should be moved to files_sharing app
 				var file = $fileList.find('tr[data-id="'+item+'"]');
@@ -173,12 +173,12 @@ OC.Share = _.extend(OC.Share || {}, {
 					}
 				} else if (OC.Share.itemShares[index].length > 0) {
 					shares = true;
-					iconClass = 'icon-share';
+					iconClass = 'icon-shared';
 				}
 			}
 		});
 		if (itemType != 'file' && itemType != 'folder') {
-			$('a.share[data-item="'+itemSource+'"] .icon').removeClass('icon-share icon-public').addClass(iconClass);
+			$('a.share[data-item="'+itemSource+'"] .icon').removeClass('icon-shared icon-public').addClass(iconClass);
 		} else {
 			var $tr = $('tr').filterAttr('data-id', String(itemSource));
 			if ($tr.length > 0) {
@@ -262,7 +262,7 @@ OC.Share = _.extend(OC.Share || {}, {
 		var recipients;
 		var owner = $tr.attr('data-share-owner');
 		var shareFolderIcon;
-		var iconClass = 'icon-share';
+		var iconClass = 'icon-shared';
 		action.removeClass('shared-style');
 		// update folder icon
 		if (type === 'dir' && (hasShares || hasLink || owner)) {
@@ -312,7 +312,7 @@ OC.Share = _.extend(OC.Share || {}, {
 		if (hasLink) {
 			iconClass = 'icon-public';
 		}
-		icon.removeClass('icon-share icon-public').addClass(iconClass);
+		icon.removeClass('icon-shared icon-public').addClass(iconClass);
 	},
 	/**
 	 *


### PR DESCRIPTION
This finally takes care of the share icon being blocked by AdBlock (or other adblocking plugins). As the user bases of Adblock and Nextcloud probably have some reasonable overlap, we should fix this.

This is simply achieved by renaming the class from icon-share to icon-shared, which doesn’t seem to be blocked.

Ref #866, please review @kumzugloom @Pommesumdreher @MariusBluem @Bullnados @GetBoz @schiessle 

Before: share icon is missing, and with that you don’t really know where to click / how to share:
![adblock share icon issue](https://cloud.githubusercontent.com/assets/925062/24974266/eb186ed2-1fc1-11e7-9143-3e9f81ecaa03.png)
After: it’s displayed, as intended – same as when you don’t have Adblock:
![adblock share icon fix](https://cloud.githubusercontent.com/assets/925062/24974267/eb24850a-1fc1-11e7-9f37-27f45947d6a1.png)


Will also open pull requests to open this in other apps using the icons, like Calendar and Contacts.

Also, I would say this is a bugfix to backport – any objection @rullzer? ;)