### PR TITLE
Explain local link

### DIFF
--- a/apps/files/js/mainfileinfodetailview.js
+++ b/apps/files/js/mainfileinfodetailview.js
@@ -169,7 +169,7 @@
 					starAltText: isFavorite ? t('files', 'Favorited') : t('files', 'Favorite'),
 					starClass: isFavorite ? 'icon-starred' : 'icon-star',
 					permalink: this._makePermalink(this.model.get('id')),
-					permalinkTitle: t('files', 'Copy local link')
+					permalinkTitle: t('files', 'Copy direct link (only works for users who have access to this file/folder)')
 				}));
 
 				// TODO: we really need OC.Previews


### PR DESCRIPTION
The local link is a clever thing and the clients should support this imho but it might not be clear to all users. For one, the term 'local link' is a bit odd. Local with respect to what? It links directly to the file or folder, so direct link seems to make more sense to me. And we should explain the difference with a public link. So this PR:
* renames local link to direct link 
* adds a short explanation, noting it only works for users who have access to this file/folder.

As other links are called public link you could also consider calling this 'private link', I suppose. But the links we sent by mail to ppl could also be called 'private link' (they are for one user, who git it by email) so I think it might be confusing. What do @nextcloud/designers think?