### PR TITLE
Don't load handlebars in template

### DIFF
--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -3,7 +3,6 @@ style('settings', 'settings');
 vendor_script(
 	'core',
 	[
-		'handlebars/handlebars',
 		'marked/marked.min',
 	]
 );


### PR DESCRIPTION
It's already loaded in core.json

Fixes https://github.com/nextcloud/server/issues/4343

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>