### PR TITLE
Add instance name to default sender

### DIFF
--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -111,7 +111,7 @@ class Mailer implements IMailer {
 		$debugMode = $this->config->getSystemValue('mail_smtpdebug', false);
 
 		if (sizeof($message->getFrom()) === 0) {
-			$message->setFrom([\OCP\Util::getDefaultEmailAddress($this->defaults->getName())]);
+			$message->setFrom([\OCP\Util::getDefaultEmailAddress($this->defaults->getName()) => $this->defaults->getName()]);
 		}
 
 		$failedRecipients = [];


### PR DESCRIPTION
Otherwise your mail program shows "foo@mail.com" instead of "Nextcloud" or whatever your instance name is.

Fixes https://github.com/nextcloud/server/issues/3653

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>