### PR TITLE
Remove unused CSS

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -436,44 +436,21 @@ table td.filename .uploadtext {
 	opacity: .5;
 }
 
-.ie8 input[type="checkbox"]{
-	padding: 0;
-}
-
 /* File checkboxes */
-html:not(.ie8) #fileList tr td.filename>.selectCheckBox + label:before {
+#fileList tr td.filename>.selectCheckBox + label:before {
 	opacity: 0;
 	position: absolute;
 	bottom: 4px;
 	right: 0;
 	z-index: 10;
 }
-html.ie8 #fileList tr td.filename>.selectCheckBox {
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
-	filter: alpha(opacity=0);
-	opacity: 0;
-	float: left;
-	top: 0;
-	margin: 32px 0 4px 32px; /* bigger clickable area doesn’t work in FF width:2.8em; height:2.4em;*/
-}
 
 /* Show checkbox when hovering, checked, or selected */
-html.ie8 #fileList tr:hover td.filename>.selectCheckBox,
-html.ie8 #fileList tr:focus td.filename>.selectCheckBox,
-html.ie8 #fileList tr td.filename>.selectCheckBox:checked,
-html.ie8 #fileList tr.selected td.filename>.selectCheckBox,
-html:not(.ie8) #fileList tr:hover td.filename>.selectCheckBox + label:before,
-html:not(.ie8) #fileList tr:focus td.filename>.selectCheckBox + label:before,
-html:not(.ie8) #fileList tr td.filename>.selectCheckBox:checked + label:before,
-html:not(.ie8) #fileList tr.selected td.filename>.selectCheckBox + label:before {
+#fileList tr:hover td.filename>.selectCheckBox + label:before,
+#fileList tr:focus td.filename>.selectCheckBox + label:before,
+#fileList tr td.filename>.selectCheckBox:checked + label:before,
+#fileList tr.selected td.filename>.selectCheckBox + label:before {
 	opacity: 1;
-}
-html.ie8 #fileList tr:hover td.filename>.selectCheckBox,
-html.ie8 #fileList tr:focus td.filename>.selectCheckBox,
-html.ie8 #fileList tr td.filename>.selectCheckBox[checked=checked],
-html.ie8 #fileList tr.selected td.filename>.selectCheckBox {
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
-	filter: alpha(opacity=100);
 }
 
 /* Use label to have bigger clickable size for checkbox */
@@ -494,7 +471,6 @@ html.ie8 #fileList tr.selected td.filename>.selectCheckBox {
 .select-all + label {
 	top: 0;
 }
-.ie8 .select-all,
 .select-all + label:before {
 	position: absolute;
 	top: 18px;
@@ -558,8 +534,6 @@ html.ie8 #fileList tr.selected td.filename>.selectCheckBox {
 	display: inline !important;
 }
 
-#fileList img.move2trash { display:inline; margin:-8px 0; padding:16px 8px 16px 8px !important; float:right; }
-
 #fileList .action.action-share-notification span, #fileList a.name {
 	cursor: default !important;
 }
@@ -594,10 +568,6 @@ a.action > img {
 	margin-bottom: -1px;
 }
 
-html.ie8 .column-mtime .selectedActions {
-	top: -95px;
-}
-
 #fileList a.action {
 	display: inline;
 	padding: 17px 8px;
@@ -618,15 +588,12 @@ html.ie8 .column-mtime .selectedActions {
 	padding-right: 14px;
 }
 
-.ie8 #fileList a.action img,
 #fileList tr:hover a.action,
 #fileList a.action.permanent,
 #fileList tr:focus a.action,
 #fileList tr:hover a.action.no-permission:hover,
 #fileList tr:focus a.action.no-permission:focus,
-/*#fileList .name:focus .action,*/
 /* also enforce the low opacity for disabled links that are hovered/focused */
-.ie8 #fileList a.action.disabled:hover img,
 #fileList tr:hover a.action.disabled:hover,
 #fileList tr:focus a.action.disabled:focus,
 #fileList .name:focus a.action.disabled:focus,
@@ -635,7 +602,6 @@ html.ie8 .column-mtime .selectedActions {
 	filter: alpha(opacity=30);
 	opacity: .3;
 }
-.ie8 #fileList a.action:hover img,
 #fileList tr a.action.disabled.action-download,
 #fileList tr:hover a.action.disabled.action-download:hover,
 #fileList tr:focus a.action.disabled.action-download:focus,
@@ -741,14 +707,6 @@ table.dragshadow td.filename {
 table.dragshadow td.size {
 	padding-right:8px;
 }
-#upgrade {
-	width: 400px;
-	position: absolute;
-	top: 200px;
-	left: 50%;
-	text-align: center;
-	margin-left: -200px;
-}
 .mask {
 	z-index: 50;
 	position: absolute;
@@ -769,10 +727,6 @@ table.dragshadow td.size {
 }
 .mask.transparent{
 	opacity: 0;
-}
-
-html.ie8 #controls .button.new {
-	padding-right: 0;
 }
 
 .newFileMenu {

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1057,12 +1057,6 @@ span.ui-icon {
 	margin: 3px 7px 30px 0;
 }
 
-.move2trash {
-	/* decrease spinner size */
-	width: 16px;
-	height: 16px;
-}
-
 /* ---- TOOLTIPS ---- */
 
 .extra-data {


### PR DESCRIPTION
* `.ie8` is not applied anymore so those rules are useless
* `.move2trash` I could not find any trace of this
* `#upgrade` I could also don't find any trace for this one and during update we only load the `guest.css`

cc @skjnldsv @juliushaertl @rullzer @nickvergessen @eppfel 