### PR TITLE
Fix font-weight of settings button

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -477,7 +477,7 @@ kbd {
 	border-radius: 0;
 	text-align: left;
 	padding-left: 42px;
-	font-weight: 300;
+	font-weight: 400;
 	&:hover,
 	&:focus {
 		background-color: $color-main-background;


### PR DESCRIPTION
* fixes weight of settings button in files app

Before:

<img width="338" alt="bildschirmfoto 2017-04-18 um 21 23 38" src="https://cloud.githubusercontent.com/assets/245432/25161069/7da608e2-247f-11e7-9fd9-e0fbfc9f22c6.png">

After:

<img width="314" alt="bildschirmfoto 2017-04-18 um 21 23 32" src="https://cloud.githubusercontent.com/assets/245432/25161075/81d38f34-247f-11e7-97b1-c49164da16fe.png">
