### PR TITLE
Do not show empty admin sections

### DIFF
--- a/settings/Controller/AdminSettingsController.php
+++ b/settings/Controller/AdminSettingsController.php
@@ -135,6 +135,10 @@ class AdminSettingsController extends Controller {
 		/** @var \OC\Settings\Section[] $prioritizedSections */
 		foreach($sections as $prioritizedSections) {
 			foreach ($prioritizedSections as $section) {
+				if (empty($this->settingsManager->getAdminSettings($section->getID()))) {
+					continue;
+				}
+
 				$icon = '';
 				if ($section instanceof IIconSection) {
 					$icon = $section->getIcon();


### PR DESCRIPTION
Fixes #4393 

It is far from efficient code. But then again it is easy to understand
and I doubt admins will browse it 24/7