### PR TITLE
Get proper accesslist for userFolder

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1233,7 +1233,7 @@ class Manager implements IManager {
 
 		//Get node for the owner
 		$userFolder = $this->rootFolder->getUserFolder($owner);
-		if (!$userFolder->isSubNode($path)) {
+		if ($path->getId() !== $userFolder->getId() && !$userFolder->isSubNode($path)) {
 			$path = $userFolder->getById($path->getId())[0];
 		}
 
@@ -1245,7 +1245,12 @@ class Manager implements IManager {
 
 		if ($currentAccess) {
 			$ownerPath = $path->getPath();
-			list(, , , $ownerPath) = explode('/', $ownerPath, 4);
+			$ownerPath = explode('/', $ownerPath, 4);
+			if (count($ownerPath) < 4) {
+				$ownerPath = '';
+			} else {
+				$ownerPath = $ownerPath[3];
+			}
 			$al['users'][$owner] = [
 				'node_id' => $path->getId(),
 				'node_path' => '/' . $ownerPath,

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -2767,8 +2767,7 @@ class ManagerTest extends \Test\TestCase {
 		$node->expects($this->once())
 			->method('getOwner')
 			->willReturn($owner);
-		$node->expects($this->once())
-			->method('getId')
+		$node->method('getId')
 			->willReturn(42);
 
 		$userFolder = $this->createMock(Folder::class);


### PR DESCRIPTION
If the accesslist is requested for a users root folder we should properly construct the path.

Fixes a bunch of errors when the activity app is there on installation