### PR TITLE
Allow social sharing to specify if a new window is opened

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -85,7 +85,7 @@
 				'</li>' +
 				'{{#each social}}' +
 					'<li>' +
-						'<a href="#" class="shareOption menuitem pop-up" data-url="{{url}}">' +
+						'<a href="#" class="shareOption menuitem pop-up" data-url="{{url}}" data-window="{{newWindow}}">' +
 							'<span class="icon {{iconClass}}"' +
 								'></span><span>{{label}}' +
 							'</span>' +
@@ -424,7 +424,8 @@
 					url: url,
 					label: t('core', 'Share to {name}', {name: model.get('name')}),
 					name: model.get('name'),
-					iconClass: model.get('iconClass')
+					iconClass: model.get('iconClass'),
+					newWindow: model.get('newWindow')
 				});
 			});
 
@@ -515,14 +516,19 @@
 			event.stopPropagation();
 
 			var url = $(event.currentTarget).data('url');
+			var newWindow = $(event.currentTarget).data('window');
 			$(event.currentTarget).tooltip('hide');
 			if (url) {
-				var width = 600;
-				var height = 400;
-				var left = (screen.width/2)-(width/2);
-				var top = (screen.height/2)-(height/2);
+				if (newWindow === true) {
+					var width = 600;
+					var height = 400;
+					var left = (screen.width / 2) - (width / 2);
+					var top = (screen.height / 2) - (height / 2);
 
-				window.open(url, 'name', 'width=' + width + ', height=' + height + ', top=' + top + ', left=' + left);
+					window.open(url, 'name', 'width=' + width + ', height=' + height + ', top=' + top + ', left=' + left);
+				} else {
+					window.location.href = url;
+				}
 			}
 		}
 

--- a/core/js/sharesocialmanager.js
+++ b/core/js/sharesocialmanager.js
@@ -36,7 +36,9 @@
 			/** Name to show in the tooltip */
 			name: null,
 			/** Icon class to display */
-			iconClass: null
+			iconClass: null,
+			/** Open in new windows */
+			newWindow: true
 		}
 	});
 


### PR DESCRIPTION
For https://github.com/nextcloud/socialsharing/pull/5

For example mail shares should not open a new window because it looks
weird.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>