### PR TITLE
Avoid duplicate files in google with the same name

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Google.php
+++ b/apps/files_external/lib/Lib/Storage/Google.php
@@ -386,6 +386,19 @@ class Google extends \OC\Files\Storage\Common {
 	}
 
 	public function rename($path1, $path2) {
+		// Avoid duplicate files with the same name
+                $testRegex = '/^.+\.ocTransferId\d+\.part$/';
+                if (preg_match($testRegex, $path1)) {
+                        if ($this->is_file($path2)) {
+                                $testFile2 = $this->getDriveFile($path2);
+                                if ($testFile2) {
+                                        $this->service->files->trash($testFile2->getId());
+                                        \OCP\Util::writeLog('files_external', 'trash file '.$path2.
+                                        ' for renaming '.$path1.' on Google Drive.', \OCP\Util::DEBUG);
+                                }
+                        }
+                }
+		
 		$file = $this->getDriveFile($path1);
 		if ($file) {
 			$newFile = $this->getDriveFile($path2);


### PR DESCRIPTION
When it renames the temporary file, it tests if the file is already present. If so, it moves to trash the previous version to avoid duplicate files with the same name (message log: "Ignoring duplicate file name: ... on Google Drive for Google user: ...").
It doesn't handle duplicate files in Google Drive, it tries to avoid them.
You'll watch #4279 issue.

Logs file and images:
[logs-images.zip](https://github.com/nextcloud/server/files/946404/logs-images.zip)

I tested owncloud 9.1.5 yesterday and I saw that when it uploads the file for the second time, it handles Google's versions. No "temporary" file is created in Google. So my fix isn't necessary in it.
