### PR TITLE
No need to log guzzle exception

### DIFF
--- a/apps/federation/lib/BackgroundJob/GetSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/GetSharedSecret.php
@@ -179,7 +179,7 @@ class GetSharedSecret extends Job{
 			if ($status === Http::STATUS_FORBIDDEN) {
 				$this->logger->info($target . ' refused to exchange a shared secret with you.', ['app' => 'federation']);
 			} else {
-				$this->logger->logException($e, ['app' => 'federation']);
+				$this->logger->info($target . ' responded with a ' . $status . ' containing: ' . $e->getMessage(), ['app' => 'federation']);
 			}
 		} catch (\Exception $e) {
 			$status = Http::STATUS_INTERNAL_SERVER_ERROR;

--- a/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
@@ -177,7 +177,7 @@ class RequestSharedSecret extends Job {
 			if ($status === Http::STATUS_FORBIDDEN) {
 				$this->logger->info($target . ' refused to ask for a shared secret.', ['app' => 'federation']);
 			} else {
-				$this->logger->logException($e, ['app' => 'federation']);
+				$this->logger->info($target . ' responded with a ' . $status . ' containing: ' . $e->getMessage(), ['app' => 'federation']);
 			}
 		} catch (\Exception $e) {
 			$status = Http::STATUS_INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
When getting/requesting a shared secret there is no need to log the full
exception when an unexpected status code is returned since this won't
really tell us anything as the bad stuff happened on a remote server

Fixes #3380

@bcutter @mightyBroccoli please have a look. the changes are rather easy.