### PR TITLE
Wording detail fix for favorite emptycontent view

### DIFF
--- a/apps/files/templates/simplelist.php
+++ b/apps/files/templates/simplelist.php
@@ -2,7 +2,7 @@
 
 <div id="emptycontent" class="hidden">
 	<div class="icon-starred"></div>
-	<h2><?php p($l->t('No favorites')); ?></h2>
+	<h2><?php p($l->t('No favorites yet')); ?></h2>
 	<p><?php p($l->t('Files and folders you mark as favorite will show up here')); ?></p>
 </div>
 
@@ -40,4 +40,3 @@
 	<tfoot>
 	</tfoot>
 </table>
-


### PR DESCRIPTION
Just changing »No favorites« to the more friendly »No favorites yet«.

Please review @nextcloud/designers 

cc @marinofaggiana @mario @AndyScherzinger @tobiasKaminsky please make sure that the mobile apps use the same wording and style for the respective views :)
![capture du 2017-04-21 14-12-52](https://cloud.githubusercontent.com/assets/925062/25276925/c5e96170-269c-11e7-8315-58b5c1fc1ed8.png)
