### PR TITLE
Primary key is too long for oracle

### DIFF
--- a/apps/twofactor_backupcodes/appinfo/database.xml
+++ b/apps/twofactor_backupcodes/appinfo/database.xml
@@ -5,7 +5,7 @@
 	<overwrite>false</overwrite>
 	<charset>utf8</charset>
 	<table>
-		<name>*dbprefix*twofactor_backup_codes</name>
+		<name>*dbprefix*twofactor_backupcodes</name>
 		<declaration>
 			<field>
 				<name>id</name>

--- a/apps/twofactor_backupcodes/appinfo/database.xml
+++ b/apps/twofactor_backupcodes/appinfo/database.xml
@@ -37,7 +37,7 @@
 			</field>
 
 			<index>
-				<name>two_factor_backupcodes_user_id</name>
+				<name>twofactor_backupcodes_uid</name>
 				<field>
 					<name>user_id</name>
 					<sorting>ascending</sorting>

--- a/apps/twofactor_backupcodes/appinfo/info.xml
+++ b/apps/twofactor_backupcodes/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>A two-factor auth backup codes provider</description>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
-	<version>1.1.0</version>
+	<version>1.1.1</version>
 	<namespace>TwoFactorBackupCodes</namespace>
 	<category>other</category>
 
@@ -29,4 +29,10 @@
 			<provider>OCA\TwoFactorBackupCodes\Activity\Provider</provider>
 		</providers>
 	</activity>
+
+	<repair-steps>
+		<post-migration>
+			<step>OCA\TwoFactorBackupCodes\Migration\CopyEntriesFromOldTable</step>
+		</post-migration>
+	</repair-steps>
 </info>

--- a/apps/twofactor_backupcodes/lib/Db/BackupCodeMapper.php
+++ b/apps/twofactor_backupcodes/lib/Db/BackupCodeMapper.php
@@ -22,13 +22,14 @@
 namespace OCA\TwoFactorBackupCodes\Db;
 
 use OCP\AppFramework\Db\Mapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\IUser;
 
 class BackupCodeMapper extends Mapper {
 
 	public function __construct(IDBConnection $db) {
-		parent::__construct($db, 'twofactor_backup_codes');
+		parent::__construct($db, 'twofactor_backupcodes');
 	}
 
 	/**
@@ -40,7 +41,7 @@ class BackupCodeMapper extends Mapper {
 		$qb = $this->db->getQueryBuilder();
 
 		$qb->select('id', 'user_id', 'code', 'used')
-			->from('twofactor_backup_codes')
+			->from('twofactor_backupcodes')
 			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($user->getUID())));
 		$result = $qb->execute();
 
@@ -66,7 +67,7 @@ class BackupCodeMapper extends Mapper {
 		/* @var IQueryBuilder $qb */
 		$qb = $this->db->getQueryBuilder();
 
-		$qb->delete('twofactor_backup_codes')
+		$qb->delete('twofactor_backupcodes')
 			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($uid)));
 		$qb->execute();
 	}

--- a/apps/twofactor_backupcodes/lib/Migration/CopyEntriesFromOldTable.php
+++ b/apps/twofactor_backupcodes/lib/Migration/CopyEntriesFromOldTable.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\TwoFactorBackupCodes\Migration;
+
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class CopyEntriesFromOldTable implements IRepairStep {
+
+	/** @var IDBConnection */
+	protected $connection;
+
+	/** @var IConfig */
+	protected $config;
+
+	/**
+	 * @param IDBConnection $connection
+	 * @param IConfig $config
+	 */
+	public function __construct(IDBConnection $connection, IConfig $config) {
+		$this->connection = $connection;
+		$this->config = $config;
+	}
+
+	/**
+	 * Returns the step's name
+	 *
+	 * @return string
+	 * @since 9.1.0
+	 */
+	public function getName() {
+		return 'Copy twofactor backup codes from legacy table';
+	}
+
+	/**
+	 * Run repair step.
+	 * Must throw exception on error.
+	 *
+	 * @since 9.1.0
+	 * @param IOutput $output
+	 * @throws \Exception in case of failure
+	 */
+	public function run(IOutput $output) {
+		$version = $this->config->getAppValue('twofactor_backupcodes', 'installed_version', '0.0.0');
+		if (version_compare($version, '1.1.1', '>=')) {
+			return;
+		}
+
+		if (!$this->connection->tableExists('twofactor_backup_codes')) {
+			// Legacy table does not exist
+			return;
+		}
+
+		$insert = $this->connection->getQueryBuilder();
+		$insert->insert('twofactor_backupcodes')
+			->values([
+				// Inserting with id might fail: 'id' => $insert->createParameter('id'),
+				'user_id' => $insert->createParameter('user_id'),
+				'code' => $insert->createParameter('code'),
+				'used' => $insert->createParameter('used'),
+			]);
+
+		$query = $this->connection->getQueryBuilder();
+		$query->select('*')
+			->from('twofactor_backup_codes')
+			->orderBy('id', 'ASC');
+		$result = $query->execute();
+
+		$output->startProgress();
+		while ($row = $result->fetch()) {
+			$output->advance();
+
+			$insert
+				// Inserting with id might fail: ->setParameter('id', $row['id'], IQueryBuilder::PARAM_INT)
+				->setParameter('user_id', $row['user_id'], IQueryBuilder::PARAM_STR)
+				->setParameter('code', $row['code'], IQueryBuilder::PARAM_STR)
+				->setParameter('used', $row['used'], IQueryBuilder::PARAM_INT)
+				->execute();
+		}
+		$output->finishProgress();
+
+		$this->connection->dropTable('twofactor_backup_codes');
+	}
+}


### PR DESCRIPTION
This is somewhat a crucial problem. The app is force enabled but breaks the installation on oracle.

Tested with https://github.com/nextcloud/notifications/pull/75
Broken: https://travis-ci.org/nextcloud/notifications/builds/224355934#L1273
With this little change it passes: https://travis-ci.org/nextcloud/notifications/builds/224360873

The problem is, the old name was too long:
* 3 chars prefix: `oc_`
* 22 chars table name: `twofactor_backup_codes`
* 6 key suffix: `_AI_PK`

=> 31 chars, but the maximum is 30.

The only way I see is, that we rename the table manually on a pre-update step for existing installations. Otherwise all backup codes will be dropped on the update.

cc @MorrisJobke @ChristophWurst @LukasReschke @rullzer 