### PR TITLE
limit the user when searching for a file by id if we know the user already

### DIFF
--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -280,7 +280,12 @@ class Folder extends Node implements \OCP\Files\Folder {
 	 */
 	public function getById($id) {
 		$mountCache = $this->root->getUserMountCache();
-		$mountsContainingFile = $mountCache->getMountsForFileId((int)$id);
+		if (strpos($this->getPath(), '/', 1) > 0) {
+			list(, $user) = explode('/', $this->getPath());
+		} else {
+			$user = null;
+		}
+		$mountsContainingFile = $mountCache->getMountsForFileId((int)$id, $user);
 		$mounts = $this->root->getMountsIn($this->path);
 		$mounts[] = $this->root->getMount($this->path);
 		/** @var IMountPoint[] $folderMounts */

--- a/lib/public/Files/Config/IUserMountCache.php
+++ b/lib/public/Files/Config/IUserMountCache.php
@@ -53,10 +53,11 @@ interface IUserMountCache {
 	 * Get all cached mounts by storage
 	 *
 	 * @param int $numericStorageId
+	 * @param string|null $user limit the results to a single user @since 12.0.0
 	 * @return ICachedMountInfo[]
 	 * @since 9.0.0
 	 */
-	public function getMountsForStorageId($numericStorageId);
+	public function getMountsForStorageId($numericStorageId, $user = null);
 
 	/**
 	 * Get all cached mounts by root
@@ -71,10 +72,11 @@ interface IUserMountCache {
 	 * Get all cached mounts that contain a file
 	 *
 	 * @param int $fileId
+	 * @param string|null $user optionally restrict the results to a single user @since 12.0.0
 	 * @return ICachedMountInfo[]
 	 * @since 9.0.0
 	 */
-	public function getMountsForFileId($fileId);
+	public function getMountsForFileId($fileId, $user = null);
 
 	/**
 	 * Remove all cached mounts for a user


### PR DESCRIPTION
Saves performances when higher numbers of users have access to the same file, either trough shares or external storage.

See https://github.com/nextcloud/server/issues/4407

[Comparison with 10 users](https://blackfire.io/profiles/compare/2bb0fd1c-5208-4ef2-b8ab-f1bdeacf0e39/graph)