### PR TITLE
Use RESPOND_NOT_FOUND for non existing user

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -790,7 +790,7 @@ class UsersController extends OCSController {
 
 		$targetUser = $this->userManager->get($userId);
 		if($targetUser === null) {
-			throw new OCSException('', \OCP\API::RESPOND_UNAUTHORISED);
+			throw new OCSException('', \OCP\API::RESPOND_NOT_FOUND);
 		}
 
 		// Check if admin / subadmin

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -2707,7 +2707,7 @@ class UsersControllerTest extends TestCase {
 
 	/**
 	 * @expectedException \OCP\AppFramework\OCS\OCSException
-	 * @expectedExceptionCode 997
+	 * @expectedExceptionCode 998
 	 */
 	public function testResendWelcomeMessageWithNotExistingTargetUser() {
 		$this->userManager


### PR DESCRIPTION
* fixes https://github.com/nextcloud/documentation/pull/421#discussion_r112621298

@LukasReschke This would allow to detect which user is there or not for the sub admin. I guess this is already exposed on other endpoints, but this is up to you.

