### PR TITLE
Add rate limit to TOTP solve challenge controller

### DIFF
--- a/core/Controller/TwoFactorChallengeController.php
+++ b/core/Controller/TwoFactorChallengeController.php
@@ -143,6 +143,8 @@ class TwoFactorChallengeController extends Controller {
 	 * @NoCSRFRequired
 	 * @UseSession
 	 *
+	 * @UserRateThrottle(limit=5, period=100)
+	 *
 	 * @param string $challengeProviderId
 	 * @param string $challenge
 	 * @param string $redirect_url


### PR DESCRIPTION
Limits the amount of solvechallenge requests to 5 per user in 100 seconds. Note that you need to have Redis enabled to be able to test it :)

Fixes https://github.com/nextcloud/server/issues/2626

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>