### PR TITLE
Fix sinon.stub deprecation warnings

### DIFF
--- a/apps/federatedfilesharing/tests/js/externalSpec.js
+++ b/apps/federatedfilesharing/tests/js/externalSpec.js
@@ -8,6 +8,8 @@
  *
  */
 
+/* global sinon */
+
 describe('OCA.Sharing external tests', function() {
 	var plugin;
 	var urlQueryStub;
@@ -24,8 +26,8 @@ describe('OCA.Sharing external tests', function() {
 		plugin = OCA.Sharing.ExternalShareDialogPlugin;
 		urlQueryStub = sinon.stub(OC.Util.History, 'parseUrlQuery');
 
-		confirmDialogStub = sinon.stub(OC.dialogs, 'confirm', dummyShowDialog);
-		promptDialogStub = sinon.stub(OC.dialogs, 'prompt', dummyShowDialog);
+		confirmDialogStub = sinon.stub(OC.dialogs, 'confirm').callsFake(dummyShowDialog);
+		promptDialogStub = sinon.stub(OC.dialogs, 'prompt').callsFake(dummyShowDialog);
 
 		plugin.filesApp = {
 			fileList: {

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2273,7 +2273,7 @@ describe('OCA.Files.FileList tests', function() {
 			var actionStub = sinon.stub();
 			var readyHandler = sinon.stub();
 			var clock = sinon.useFakeTimers();
-			var debounceStub = sinon.stub(_, 'debounce', function(callback) {
+			var debounceStub = sinon.stub(_, 'debounce').callsFake(function(callback) {
 				return function() {
 					// defer instead of debounce, to make it work with clock
 					_.defer(callback);

--- a/apps/files_external/tests/js/settingsSpec.js
+++ b/apps/files_external/tests/js/settingsSpec.js
@@ -15,7 +15,7 @@ describe('OCA.External.Settings tests', function() {
 
 	beforeEach(function() {
 		clock = sinon.useFakeTimers();
-		select2Stub = sinon.stub($.fn, 'select2', function(args) {
+		select2Stub = sinon.stub($.fn, 'select2').callsFake(function(args) {
 			if (args === 'val') {
 				return select2ApplicableUsers;
 			}

--- a/core/js/tests/specs/jquery.avatarSpec.js
+++ b/core/js/tests/specs/jquery.avatarSpec.js
@@ -186,7 +186,7 @@ describe('jquery.avatar tests', function() {
 		});
 
 		it('with ie8 fix', function() {
-			sinon.stub(Math, 'random', function() {
+			sinon.stub(Math, 'random').callsFake(function() {
 				return 0.5;
 			});
 

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -19,7 +19,7 @@
 *
 */
 
-/* global oc_appconfig */
+/* global oc_appconfig, sinon */
 describe('OC.Share.ShareDialogView', function() {
 	var $container;
 	var oldAppConfig;
@@ -90,7 +90,7 @@ describe('OC.Share.ShareDialogView', function() {
 			linkShare: {isLinkShare: false}
 		});
 
-		autocompleteStub = sinon.stub($.fn, 'autocomplete', function() {
+		autocompleteStub = sinon.stub($.fn, 'autocomplete').callsFake(function() {
 			// dummy container with the expected attributes
 			if (!$(this).length) {
 				// simulate the real autocomplete that returns


### PR DESCRIPTION
Calls to `sinon.stub(obj, 'meth', fn)` are deprecated and therefore
replaced by `sinon.stub(obj, 'meth).callsFake(fn)` as instructed by
the deprecation warning.

This makes the js unit testing output readable again.

```
INFO: 'sinon.stub(obj, 'meth', fn) is deprecated and will be removed from the public API in a future version of sinon.
 Use stub(obj, 'meth').callsFake(fn).
 Codemod available at https://github.com/hurrymaplelad/sinon-codemod'
```

