### PR TITLE
Fix details view not closed when viewing a file in its folder

### DIFF
--- a/apps/files/js/gotoplugin.js
+++ b/apps/files/js/gotoplugin.js
@@ -40,6 +40,7 @@
 				type: OCA.Files.FileActions.TYPE_DROPDOWN,
 				actionHandler: function (fileName, context) {
 					var fileModel = context.fileInfoModel;
+					OC.Apps.hideAppSidebar($('.detailsView'));
 					OCA.Files.App.setActiveView('files', {silent: true});
 					OCA.Files.App.fileList.changeDirectory(fileModel.get('path'), true, true).then(function() {
 						OCA.Files.App.fileList.scrollTo(fileModel.get('name'));

--- a/tests/acceptance/features/app-files.feature
+++ b/tests/acceptance/features/app-files.feature
@@ -1,5 +1,28 @@
 Feature: app-files
 
+  Scenario: viewing a favorite file in its folder closes the details view
+    Given I am logged in
+    And I mark "welcome.txt" as favorite
+    And I see that "welcome.txt" is marked as favorite
+    And I open the "Favorites" section
+    And I open the details view for "welcome.txt"
+    And I see that the details view for "Favorites" section is open
+    When I view "welcome.txt" in folder
+    Then I see that the current section is "All files"
+    And I see that the details view is closed
+
+  Scenario: viewing a favorite file in its folder does not prevent opening the details view in "All files" section
+    Given I am logged in
+    And I mark "welcome.txt" as favorite
+    And I see that "welcome.txt" is marked as favorite
+    And I open the "Favorites" section
+    And I open the details view for "welcome.txt"
+    And I see that the details view for "Favorites" section is open
+    And I view "welcome.txt" in folder
+    And I see that the current section is "All files"
+    When I open the details view for "welcome.txt"
+    Then I see that the details view for "All files" section is open
+
   Scenario: set a password to a shared link
     Given I am logged in
     And I share the link for "welcome.txt"


### PR DESCRIPTION
As far as I understand, #1448 occurs because [`setActiveView` is called with `silent: true`](https://github.com/nextcloud/server/blob/d623763aac3c1c4c0480f0d3ca7182dd2eb68357/apps/files/js/gotoplugin.js#L43). This [prevents the `itemChanged` event to be triggered](https://github.com/nextcloud/server/blob/581227324a8510688c40e9effc8b2fe6a355eba1/apps/files/js/navigation.js#L105-L110), which [would have otherwise closed the details view](https://github.com/nextcloud/server/blob/0ecaf8e6023622393090c1f2ff4c728c96eb2718/apps/files/js/app.js#L221).

I suppose (but I do not really know) that setting the active item is done in silent mode to avoid an unnecessary [reload of the _/_ directory in `_onNavigationChanged`](https://github.com/nextcloud/server/blob/0ecaf8e6023622393090c1f2ff4c728c96eb2718/apps/files/js/app.js#L220) (as the plugin then loads the folder of the selected file). Therefore, I fixed it by closing the details view in the plugin itself, just like it would have been closed by `_onNavigationChanged`.

This does not tackle the other problem mentioned in the issue, which is having several details view with the same `app-sidebar` id. It could be solved by giving each details view its own id, which would require a change in the CSS as currently `#app-sidebar` is used to position its contents, or by using a single details view for all the file lists, although it will probably involve deeper changes as right now every file list expect its own details view to be available for its lifetime.

Anyway, despite being "wrong" the current approach of several details view with the same id works, and with [a possible redesign of the dashboard](https://github.com/nextcloud/server/issues/4273) being discussed a proper fix could be just wasted effort...

(Some files of this pull request conflict with those in other pull request that I have opened; I will rebase this pull request or the other one as needed if they got merged)
