### PR TITLE
Fix working icon placement on password save

### DIFF
--- a/apps/files_sharing/css/sharetabview.scss
+++ b/apps/files_sharing/css/sharetabview.scss
@@ -14,7 +14,8 @@
 }
 
 .shareTabView .shareWithRemoteInfo,
-.shareTabView .clipboardButton {
+.shareTabView .clipboardButton,
+.shareTabView .linkPass .icon-loading-small {
 	position: absolute;
 	right: -7px;
 	top: -4px;
@@ -152,7 +153,7 @@
 }
 
 .shareTabView .linkPass .icon-loading-small {
-	margin-top: 9px;
+	margin-right: 0px;
 }
 
 .shareTabView .icon {

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -60,14 +60,14 @@
 			'<input type="checkbox" name="showPassword" id="showPassword-{{cid}}" class="checkbox showPasswordCheckbox" {{#if isPasswordSet}}checked="checked"{{/if}} value="1" />' +
 			'<label for="showPassword-{{cid}}">{{enablePasswordLabel}}</label>' +
 			'    {{/if}}' +
-			'<div id="linkPass" class="linkPass {{#unless isPasswordSet}}hidden{{/unless}}">' +
+			'<div id="linkPass" class="oneline linkPass {{#unless isPasswordSet}}hidden{{/unless}}">' +
 			'    <label for="linkPassText-{{cid}}" class="hidden-visually">{{passwordLabel}}</label>' +
 			'    {{#if showPasswordCheckBox}}' +
 			'    <input id="linkPassText-{{cid}}" class="linkPassText" type="password" placeholder="{{passwordPlaceholder}}" />' +
 			'    {{else}}' +
 			'    <input id="linkPassText-{{cid}}" class="linkPassText" type="password" placeholder="{{passwordPlaceholderInitial}}" />' +
 			'    {{/if}}' +
-			'    <span class="icon-loading-small hidden"></span>' +
+			'    <span class="icon icon-loading-small hidden"></span>' +
 			'</div>' +
 			'{{else}}' +
 			// FIXME: this doesn't belong in this view


### PR DESCRIPTION
I do not know how you wanted to fix #4135, but this pull request provides a possible fix:

**Before**, protect password:
![before-protect](https://cloud.githubusercontent.com/assets/26858233/25331746/6dbfc396-28e4-11e7-9a85-9b9a7a28ec70.png)

**After**, protect password:
![after-protect](https://cloud.githubusercontent.com/assets/26858233/25331764/818cc9dc-28e4-11e7-9abb-6584965459c4.png)

**Before**, enforce password:
![before-enforce](https://cloud.githubusercontent.com/assets/26858233/25331788/93fbaa3e-28e4-11e7-844a-6f9ca918a1c3.png)

**After**, enforce password:
![after-enforce](https://cloud.githubusercontent.com/assets/26858233/25331798/9dba16fa-28e4-11e7-97dc-0baa380ca232.png)
