### PR TITLE
Fix link password toggle

### DIFF
--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -802,7 +802,7 @@
 							isLinkShare: true,
 							id: share.id,
 							token: share.token,
-							password: share.password,
+							password: share.share_with,
 							link: link,
 							permissions: share.permissions,
 							// currently expiration is only effective for link shares.


### PR DESCRIPTION
We took the wrong field from the share api response. So the password was
never shown as set.

To test:

1. Share a file by link
2. Set a password
3. Reload page
4. Look at the share tab for the file

Before: No password set shown
Now: Password set shown