### PR TITLE
Remove DOMPurify from srcFiles

### DIFF
--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -112,8 +112,7 @@ module.exports = function(config) {
 				srcFiles: [
 					'settings/js/apps.js',
 					'settings/js/users/deleteHandler.js',
-					'core/vendor/marked/marked.min.js',
-					'core/vendor/DOMPurify/dist/purify.min.js'
+					'core/vendor/marked/marked.min.js'
 				],
 				testFiles: [
 					'settings/tests/js/appsSpec.js',


### PR DESCRIPTION
It is already included via core.json. Let's see if that has any impact on the JS test execution.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>