### PR TITLE
Fix JS unit failure because of Jasmine 2.6 and the phantomjs launcher

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "bower": "~1.8.0",
     "handlebars": "^4.0.5",
-    "jasmine-core": "^2.5.2",
+    "jasmine-core": "~2.5.2",
     "jasmine-sinon": "^0.4.0",
     "jsdoc": "~3.4.0",
     "karma": "^1.5.0",


### PR DESCRIPTION
* fixes #4487

cc @ChristophWurst @LukasReschke 