### PR TITLE
Fix share indicator handling

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -189,13 +189,16 @@
 					// remove icon, if applicable
 					OC.Share.markFileAsShared($tr, false, false);
 				}
-				var newIcon = $tr.attr('data-icon');
-				// in case markFileAsShared decided to change the icon,
-				// we need to modify the model
-				// (FIXME: yes, this is hacky)
-				if (fileInfoModel.get('icon') !== newIcon) {
-					fileInfoModel.set('icon', newIcon);
-				}
+
+				// FIXME: this is too convoluted. We need to get rid of the above updates
+				// and only ever update the model and let the events take care of rerendering
+				fileInfoModel.set({
+					shareTypes: shareModel.getShareTypes(),
+					// in case markFileAsShared decided to change the icon,
+					// we need to modify the model
+					// (FIXME: yes, this is hacky)
+					icon: $tr.attr('data-icon')
+				});
 			});
 			fileList.registerTabView(shareTab);
 

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -841,6 +841,20 @@
 				}
 			}
 			return time;
+		},
+
+		/**
+		 * Returns a list of share types from the existing shares.
+		 *
+		 * @return {Array.<int>} array of share types
+		 */
+		getShareTypes: function() {
+			var result;
+			result = _.pluck(this.getSharesWithCurrentItem(), 'share_type');
+			if (this.hasLinkShare()) {
+				result.push(OC.Share.SHARE_TYPE_LINK);
+			}
+			return _.uniq(result);
 		}
 	});
 

--- a/core/js/tests/specs/shareitemmodelSpec.js
+++ b/core/js/tests/specs/shareitemmodelSpec.js
@@ -924,5 +924,66 @@ describe('OC.Share.ShareItemModel', function() {
 			expect(errorStub.lastCall.args[1]).toEqual('Some error message');
 		});
 	});
+
+	describe('getShareTypes', function() {
+
+		var dataProvider = [
+			[
+			],
+			[
+				OC.Share.SHARE_TYPE_USER,
+				OC.Share.SHARE_TYPE_USER,
+			],
+			[
+				OC.Share.SHARE_TYPE_USER,
+				OC.Share.SHARE_TYPE_GROUP,
+				OC.Share.SHARE_TYPE_LINK,
+				OC.Share.SHARE_TYPE_REMOTE
+			],
+			[
+				OC.Share.SHARE_TYPE_USER,
+				OC.Share.SHARE_TYPE_GROUP,
+				OC.Share.SHARE_TYPE_GROUP,
+				OC.Share.SHARE_TYPE_LINK,
+				OC.Share.SHARE_TYPE_LINK,
+				OC.Share.SHARE_TYPE_REMOTE,
+				OC.Share.SHARE_TYPE_REMOTE,
+				OC.Share.SHARE_TYPE_REMOTE
+			],
+			[
+				OC.Share.SHARE_TYPE_LINK,
+				OC.Share.SHARE_TYPE_LINK,
+				OC.Share.SHARE_TYPE_USER
+			]
+		];
+
+		_.each(dataProvider, function testCase(shareTypes, i) {
+			it('returns set of share types for case ' + i, function() {
+				/* jshint camelcase: false */
+				fetchReshareDeferred.resolve(makeOcsResponse([]));
+
+				var id = 100;
+				var shares = _.map(shareTypes, function(shareType) {
+					return {
+						id: id++,
+						item_source: 123,
+						permissions: 31,
+						share_type: shareType,
+						uid_owner: 'root'
+					};
+				});
+
+				var expectedResult = _.uniq(shareTypes).sort();
+
+				fetchSharesDeferred.resolve(makeOcsResponse(shares));
+
+				OC.currentUser = 'root';
+
+				model.fetch();
+
+				expect(model.getShareTypes().sort()).toEqual(expectedResult);
+			});
+		});
+	});
 });
 


### PR DESCRIPTION
Properly update the fileInfoModel with the updated share types, which
also updates the file list row indicator properly

Downstream 25838

Steps:
1. Create a folder
2. Share with any kind
3. Check if the row updates immediately or only after refreshing the page