### PR TITLE
Properly decode id from URI

### DIFF
--- a/core/js/oc-backbone-webdav.js
+++ b/core/js/oc-backbone-webdav.js
@@ -128,7 +128,7 @@
 			// so we take the part before that
 		} while (!result && parts.length > 0);
 
-		return result;
+		return decodeURIComponent(result);
 	}
 
 	function isSuccessStatus(status) {


### PR DESCRIPTION
When parsing an href to get the id of a WebdavNode, make sure to also
decode it.

Downstream 27511