### PR TITLE
Fix filelist and checkbox vertical align

### DIFF
--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -206,7 +206,6 @@ input {
 			height: 1px;
 			overflow: hidden;
 			+ label {
-				padding: 6px 0;
 				user-select: none;
 			}
 			&:disabled + label,
@@ -220,8 +219,8 @@ input {
 				width: 12px;
 				vertical-align: middle;
 				border-radius: 50%;
-				margin: 6px;
-				margin-top: -2px;
+				margin: 3px;
+				margin-top: 1px;
 				border: 1px solid nc-lighten($color-main-text, 53%);
 			}
 			&:not(:disabled):not(:checked) + label:hover:before,


### PR DESCRIPTION
This was a design regression introduced by me accidentally commiting work-in-progress changes to inputs.scss I made locally as part of the AdBlock fix https://github.com/nextcloud/server/pull/4337

Current master (vertical alignment of checkboxes and filetype icons off:
![capture du 2017-04-26 16-48-18](https://cloud.githubusercontent.com/assets/925062/25440618/459f617e-2aa0-11e7-835a-1adf5633b2a2.png)

With this fix:
![capture du 2017-04-26 16-47-43](https://cloud.githubusercontent.com/assets/925062/25440619/45bae890-2aa0-11e7-9a8a-598dc69823f3.png)

Please review @nextcloud/designers @LukasReschke @MorrisJobke :)