### PR TITLE
Update existing auth token on apache login

### DIFF
--- a/lib/private/legacy/api.php
+++ b/lib/private/legacy/api.php
@@ -332,7 +332,9 @@ class OC_API {
 		$userSession = \OC::$server->getUserSession();
 		$request = \OC::$server->getRequest();
 		try {
-			if ($userSession->tryTokenLogin($request)
+			if (OC_User::handleApacheAuth()) {
+				self::$logoutRequired = false;
+			} else if ($userSession->tryTokenLogin($request)
 				|| $userSession->tryBasicAuthLogin($request, \OC::$server->getBruteForceThrottler())) {
 				self::$logoutRequired = true;
 			} else {

--- a/lib/private/legacy/user.php
+++ b/lib/private/legacy/user.php
@@ -200,6 +200,7 @@ class OC_User {
 					self::setDisplayName($uid);
 				}
 				$userSession = self::getUserSession();
+				$userSession->getSession()->regenerateId();
 				$userSession->setLoginName($uid);
 				$request = OC::$server->getRequest();
 				$userSession->createSessionToken($request, $uid, $uid);


### PR DESCRIPTION
* regenerate session ID on apache login
* ocs needs to be able to login via apache
* improved version of #4002
* downstream of owncloud/core#27223

@LukasReschke @ChristophWurst @icewind1991 Please have an in detail look into this. Does this make sense? I only resolved one conflict and naively ported this. Login still works, but I can't judge on this change.