### PR TITLE
Add explanation text to SSL root certificates

### DIFF
--- a/settings/templates/certificates.php
+++ b/settings/templates/certificates.php
@@ -1,5 +1,7 @@
 <div class="section">
-	<h2><?php p($l->t('SSL Root Certificates')); ?></h2>
+	<h2><?php p($l->t('SSL root certificates')); ?></h2>
+	<p class="settings-hint"><?php p($l->t('Explanation text.')); ?></p>
+
 	<table id="sslCertificate" class="grid" data-type="<?php p($_['type']); ?>">
 		<thead>
 			<tr>


### PR DESCRIPTION
Can anyone explain to me though what it is so I can add the actual text @icewind1991 @karlitschek @LukasReschke 

Also – why is this in the personal settings of every user? This sounds awfully admin-like and technical to me.

ref nextcloud/server#4478 nextcloud/server#4540