### PR TITLE
Fix name of external storages

### DIFF
--- a/apps/files_external/js/app.js
+++ b/apps/files_external/js/app.js
@@ -35,7 +35,7 @@ OCA.External.App = {
 		);
 
 		this._extendFileList(this.fileList);
-		this.fileList.appName = t('files_external', 'External storage');
+		this.fileList.appName = t('files_external', 'External storages');
 		return this.fileList;
 	},
 
@@ -111,4 +111,3 @@ $(document).ready(function() {
 	}
 	/* End Status Manager */
 });
-

--- a/apps/files_external/js/mountsfilelist.js
+++ b/apps/files_external/js/mountsfilelist.js
@@ -28,7 +28,7 @@
 
 	FileList.prototype = _.extend({}, OCA.Files.FileList.prototype,
 		/** @lends OCA.External.FileList.prototype */ {
-		appName: 'External storage',
+		appName: 'External storages',
 
 		/**
 		 * @private

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -88,7 +88,7 @@
 ?>
 
 <form data-can-create="<?php echo $canCreateMounts?'true':'false' ?>" id="files_external" class="section" data-encryption-enabled="<?php echo $_['encryptionEnabled']?'true': 'false'; ?>">
-	<h2 data-anchor-name="external-storage"><?php p($l->t('External storage')); ?></h2>
+	<h2 data-anchor-name="external-storage"><?php p($l->t('External storages')); ?></h2>
 	<?php if (isset($_['dependencies']) and ($_['dependencies']<>'') and $canCreateMounts) print_unescaped(''.$_['dependencies'].''); ?>
 	<table id="externalStorage" class="grid" data-admin='<?php print_unescaped(json_encode($_['visibilityType'] === BackendService::VISIBILITY_ADMIN)); ?>'>
 		<thead>


### PR DESCRIPTION
Fix from »External storage« to »External storage**s**« as we used the plural some places and it makes more sense.

Does anyone have a clue where the icon in the navigation went? Wasn’t it there before?

Please review @rullzer @MorrisJobke 