### PR TITLE
Invert new header icons on bright theming colors

### DIFF
--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -12,22 +12,25 @@
 
 /* invert header icons on bright background */
 @if (lightness($color-primary) > 50) {
-	#header .icon-caret {
-		background-image: url(../../../core/img/actions/caret-dark.svg);
-	}
 	.searchbox input[type="search"] {
-		background: transparent url(../../../core/img/actions/search.svg) no-repeat 6px center;
+		background: transparent url('../../../core/img/actions/search.svg') no-repeat 6px center;
 	}
 	#appmenu li a img {
 		-webkit-filter: invert(1);
 		filter: invert(1);
 		filter: progid:DXImageTransform.Microsoft.BasicImage(invert='1');
 	}
+	#contactsmenu .icon-contacts {
+		background-image: url('../../../core/img/places/contacts-dark.svg');
+	}
+	#settings .icon-settings-white {
+		background-image: url('../../../core/img/actions/settings-dark.svg');
+	}
 }
 
 /* Colorized svg images */
 .icon-file, .icon-filetype-text {
-	background-image: url(../img/core/filetypes/text.svg?v=#{$theming-cachebuster});
+	background-image: url(./img/core/filetypes/text.svg?v=#{$theming-cachebuster});
 }
 
 .icon-folder, .icon-filetype-folder {
@@ -59,6 +62,6 @@ input.primary {
 
 @if (lightness($color-primary) > 50) {
 	#body-login input.login {
-		background-image: url(../../../core/img/actions/confirm.svg);
+		background-image: url('../../../core/img/actions/confirm.svg');
 	}
 }

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1064,7 +1064,7 @@ span.ui-icon {
 		background-size: 16px 16px;
 		padding: 14px;
 		cursor: pointer;
-		opacity: .7;
+		opacity: .6;
 	}
 }
 


### PR DESCRIPTION
Fix for https://github.com/nextcloud/server/issues/4552

- Use dark icons on bright background
- Make sure opacity of the icons is the same


Please review @nextcloud/designers @nextcloud/theming 