### PR TITLE
Add hint for federated sharing

### DIFF
--- a/apps/federatedfilesharing/templates/settings-personal.php
+++ b/apps/federatedfilesharing/templates/settings-personal.php
@@ -8,6 +8,7 @@ style('federatedfilesharing', 'settings-personal');
 <?php if ($_['outgoingServer2serverShareEnabled']): ?>
 	<div id="fileSharingSettings" class="section">
 		<h2><?php p($l->t('Federated Cloud')); ?></h2>
+		<p class="settings-hint"><?php p($l->t('You can share with anyone who uses Nextcloud, ownCloud or Pydio! Just put their Federated Cloud ID in the share dialog. It looks like person@cloud.example.com')); ?></p>
 
 		<p>
 			<?php p($l->t('Your Federated Cloud ID:')); ?>


### PR DESCRIPTION
* followup to #4540 
* @karlitschek proposed to not show Nextcloud in branded instances. If we do this then every single branded on (even if only the color is changed) will not show this text anymore. I guess we need to find another way to hide this. Because this is a user setting and allows the discovery of the feature.

@nickvergessen @juliushaertl @rullzer Any idea?