### PR TITLE
Do not disable 3rdparty apps on occ upgrade

### DIFF
--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -87,12 +87,6 @@ class Upgrade extends Command {
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
 
-		$skip3rdPartyAppsDisable = false;
-
-		if ($input->getOption('no-app-disable')) {
-			$skip3rdPartyAppsDisable = true;
-		}
-
 		if(\OC::checkUpgrade(false)) {
 			if (OutputInterface::VERBOSITY_NORMAL < $output->getVerbosity()) {
 				// Prepend each line with a little timestamp
@@ -107,7 +101,9 @@ class Upgrade extends Command {
 					$this->logger
 			);
 
-			$updater->setSkip3rdPartyAppsDisable($skip3rdPartyAppsDisable);
+			if ($input->getOption('no-app-disable')) {
+				$updater->setSkip3rdPartyAppsDisable(true);
+			}
 			$dispatcher = \OC::$server->getEventDispatcher();
 			$progress = new ProgressBar($output);
 			$progress->setFormat(" %message%\n %current%/%max% [%bar%] %percent:3s%%");


### PR DESCRIPTION
Steps:

* have calendar and contacts enabled
* do an upgrade via `occ upgrade` (before just change the version in config.php to a smaller number to trigger an update)
* before: both apps are disabled with output like "Disabled 3rd-party app: contacts"
* after: they kept enabled

Verify that you run on PHP 7.0+

Background: before the CLI flag was forcefully setting this option to false, which has overwritten the logic in the `Updater` constructor: https://github.com/nextcloud/server/blob/f000e22a97b9bae756cc5977badeffbc7a6852e9/lib/private/Updater.php#L88

Discussed this already with @LukasReschke - in the web UI this works already fine.