### PR TITLE
Delete theming images when logo/background is reset to default

### DIFF
--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -40,6 +40,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\File;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\ILogger;
@@ -265,6 +266,24 @@ class ThemingController extends Controller {
 		$value = $this->themingDefaults->undo($setting);
 		// reprocess server scss for preview
 		$cssCached = $this->scssCacher->process(\OC::$SERVERROOT, '/core/css/server.scss', 'core');
+
+		if($setting === 'logoMime') {
+			try {
+				$file = $this->appData->getFolder('images')->getFile('logo');
+				$file->delete();
+			} catch (NotFoundException $e) {
+			} catch (NotPermittedException $e) {
+			}
+		}
+		if($setting === 'backgroundMime') {
+			try {
+				$file = $this->appData->getFolder('images')->getFile('background');
+				$file->delete();
+			} catch (NotFoundException $e) {
+			} catch (NotPermittedException $e) {
+			}
+		}
+
 		return new DataResponse(
 			[
 				'data' =>

--- a/apps/theming/tests/Controller/ThemingControllerTest.php
+++ b/apps/theming/tests/Controller/ThemingControllerTest.php
@@ -385,6 +385,56 @@ class ThemingControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->themingController->undo('MySetting'));
 	}
 
+	public function dataUndoDelete() {
+		return [
+			[ 'backgroundMime', 'background' ],
+			[ 'logoMime', 'logo' ]
+		];
+	}
+
+	/** @dataProvider dataUndoDelete */
+	public function testUndoDelete($value, $filename) {
+		$this->l10n
+			->expects($this->once())
+			->method('t')
+			->with('Saved')
+			->willReturn('Saved');
+		$this->themingDefaults
+			->expects($this->once())
+			->method('undo')
+			->with($value)
+			->willReturn($value);
+		$folder = $this->createMock(ISimpleFolder::class);
+		$file = $this->createMock(ISimpleFile::class);
+		$this->appData
+			->expects($this->once())
+			->method('getFolder')
+			->with('images')
+			->willReturn($folder);
+		$folder
+			->expects($this->once())
+			->method('getFile')
+			->with($filename)
+			->willReturn($file);
+		$file
+			->expects($this->once())
+			->method('delete');
+
+		$expected = new DataResponse(
+			[
+				'data' =>
+					[
+						'value' => $value,
+						'message' => 'Saved',
+					],
+				'status' => 'success'
+			]
+		);
+		$this->assertEquals($expected, $this->themingController->undo($value));
+	}
+
+
+
 	public function testGetLogoNotExistent() {
 		$this->appData->method('getFolder')
 			->with($this->equalTo('images'))


### PR DESCRIPTION
Otherwise the theming image routes will still return the old logo/background

Steps to reproduce in the themings app:
1. Set a logo
2. Reset it to default nextcloud logo
3. Open /index.php/apps/theming/logo

The endpoint will now return a correct 404 instead of the old logo.

Fix for https://github.com/nextcloud/server/issues/4111

Please review @usselite @nextcloud/theming 