### PR TITLE
Prevent flashing of apps and user menu on page load

### DIFF
--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -85,7 +85,7 @@
 				</ul>
 
 				<nav role="navigation">
-					<div id="navigation">
+					<div id="navigation" style="display: none;">
 						<div id="apps">
 							<ul>
 								<?php foreach($_['navigation'] as $entry): ?>
@@ -134,7 +134,7 @@
 						</div>
 						<div id="expandDisplayName" class="icon-settings-white"></div>
 					</div>
-					<div id="expanddiv">
+					<div id="expanddiv" style="display:none;">
 					<ul>
 					<?php foreach($_['settingsnavigation'] as $entry):?>
 						<li>


### PR DESCRIPTION
When you load the page, both the apps menu on the top left and the user menu on the top right are visible for a split-second. This is because they are hidden via Javascript and/or CSS which is called later. To prevent this, we hide them via inline CSS.

Please review @nextcloud/designers 
