### PR TITLE
Define max-width for Contacts menu for mobile

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1072,6 +1072,7 @@ span.ui-icon {
 	/* show ~4.5 entries */
 	height: 278px;
 	width: 350px;
+	max-width: 90%;
 	right: 13px;
 
 	&::after {


### PR DESCRIPTION
So that on mobile it doesn’t overflow to the left. Same max-width as the Notifications popup.

Please review @nextcloud/designers