### PR TITLE
Make tooltip intransparent

### DIFF
--- a/core/css/tooltip.scss
+++ b/core/css/tooltip.scss
@@ -33,8 +33,8 @@
 	z-index: 100000;
 	filter: alpha(opacity = 0);
 	&.in {
-		opacity: 0.9;
-		filter: alpha(opacity = 90);
+		opacity: 1;
+		filter: alpha(opacity = 100);
 	}
 
 	&.top {


### PR DESCRIPTION
Before:

<img width="247" alt="bildschirmfoto 2017-04-29 um 10 46 55" src="https://cloud.githubusercontent.com/assets/245432/25555937/42d36186-2cc9-11e7-88c9-f72bd97eb109.png">

After:

<img width="390" alt="bildschirmfoto 2017-04-29 um 10 44 47" src="https://cloud.githubusercontent.com/assets/245432/25555941/47482120-2cc9-11e7-94be-d23ae222fd17.png">


cc @nextcloud/designers @MariusBluem 