### PR TITLE
Rename “Server settings” to “Basic settings”

### DIFF
--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -271,7 +271,7 @@ class Manager implements IManager {
 	public function getAdminSections() {
 		// built-in sections
 		$sections = [
-			0 => [new Section('server', $this->l->t('Server settings'), 0, $this->url->imagePath('settings', 'admin.svg'))],
+			0 => [new Section('server', $this->l->t('Basic settings'), 0, $this->url->imagePath('settings', 'admin.svg'))],
 			5 => [new Section('sharing', $this->l->t('Sharing'), 0, $this->url->imagePath('core', 'actions/share.svg'))],
 			10 => [new Section('security', $this->l->t('Security'), 0, $this->url->imagePath('core', 'actions/password.svg'))],
 			45 => [new Section('encryption', $this->l->t('Encryption'), 0, $this->url->imagePath('core', 'actions/password.svg'))],

--- a/tests/lib/Settings/ManagerTest.php
+++ b/tests/lib/Settings/ManagerTest.php
@@ -157,7 +157,7 @@ class ManagerTest extends TestCase {
 			]);
 
 		$this->assertEquals([
-			0 => [new Section('server', 'Server settings', 0, '1')],
+			0 => [new Section('server', 'Basic settings', 0, '1')],
 			5 => [new Section('sharing', 'Sharing', 0, '2')],
 			10 => [new Section('security', 'Security', 0, '3')],
 			45 => [new Section('encryption', 'Encryption', 0, '3')],
@@ -189,7 +189,7 @@ class ManagerTest extends TestCase {
 			]);
 
 		$this->assertEquals([
-			0 => [new Section('server', 'Server settings', 0, '1')],
+			0 => [new Section('server', 'Basic settings', 0, '1')],
 			5 => [new Section('sharing', 'Sharing', 0, '2')],
 			10 => [new Section('security', 'Security', 0, '3')],
 			45 => [new Section('encryption', 'Encryption', 0, '3')],


### PR DESCRIPTION
* fixes #4587 with the wording "Basic settings" as requested by @jancborchardt 
* replaces #4595 
* adjusted tests

@blizzz 

Signed-off-by: Marius Blüm <marius@lineone.io>