### PR TITLE
Hide default avatar in secure drop

### DIFF
--- a/apps/files_sharing/js/files_drop.js
+++ b/apps/files_sharing/js/files_drop.js
@@ -134,7 +134,7 @@
 
 	$(document).ready(function() {
 		if($('#upload-only-interface').val() === "1") {
-			$('.avatardiv').avatar($('#sharingUserId').val(), 128, true);
+			$('.avatardiv').avatar($('#sharingUserId').val(), 128, true, true);
 		}
 
 		OCA.FilesSharingDrop.initialize();


### PR DESCRIPTION
* fixes #1896

I'm a bit unsure if we should do it - @nextcloud/designers please give feedback.

Before:

![bildschirmfoto 2017-04-30 um 19 25 05](https://cloud.githubusercontent.com/assets/245432/25568516/fded411e-2dda-11e7-9629-041a4fb19f28.png)


After:

![bildschirmfoto 2017-04-30 um 19 24 28](https://cloud.githubusercontent.com/assets/245432/25568517/033e6cf6-2ddb-11e7-8ecf-f6e20e455f5a.png)
![bildschirmfoto 2017-04-30 um 19 24 53](https://cloud.githubusercontent.com/assets/245432/25568518/0388e268-2ddb-11e7-9cd0-3e6a9899fd93.png)