### PR TITLE
Fix variable definitions in oc dialogs

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -150,7 +150,7 @@ var OCP = {},
 		_.defaults(allOptions, defaultOptions);
 
 		var _build = function (text, vars) {
-			var vars = vars || [];
+			vars = vars || [];
 			return text.replace(/{([^{}]*)}/g,
 				function (a, b) {
 					var r = (vars[b]);

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -813,11 +813,13 @@ var OCdialogs = {
 
 			$.each(files, function(idx, entry) {
 				entry.icon = OC.MimeType.getIconUrl(entry.mimetype);
+				var simpleSize, sizeColor;
 				if (typeof(entry.size) !== 'undefined' && entry.size >= 0) {
-					var simpleSize = humanFileSize(parseInt(entry.size, 10), true);
-					var sizeColor = Math.round(160 - Math.pow((entry.size / (1024 * 1024)), 2));
+					simpleSize = humanFileSize(parseInt(entry.size, 10), true);
+					sizeColor = Math.round(160 - Math.pow((entry.size / (1024 * 1024)), 2));
 				} else {
 					simpleSize = t('files', 'Pending');
+					sizeColor = 80;
 				}
 				var $row = self.$listTmpl.octemplate({
 					type: entry.type,

--- a/core/js/octemplate.js
+++ b/core/js/octemplate.js
@@ -94,7 +94,7 @@
 	};
 
 	$.fn.octemplate = function(vars, options) {
-		var vars = vars ? vars : {};
+		vars = vars || {};
 		if(this.length) {
 			var _template = Object.create(Template);
 			return _template.init(vars, options, this);


### PR DESCRIPTION
* some of the `var abc` definitions redefined already existing variable (because handed in as parameter)
* some move the `var ...` statement out of `if ... else ...` blocks
* makes JSLint a bit more happy - see also #4610, #4611, #4612 & #4613 
* the one in oc-dialogs looks like a possible bug (fix)