### PR TITLE
fix PROPPATCH requests to read-only shared calendars

### DIFF
--- a/apps/dav/lib/CalDAV/Calendar.php
+++ b/apps/dav/lib/CalDAV/Calendar.php
@@ -145,11 +145,16 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IShareable {
 			];
 		}
 
-		if ($this->isShared()) {
+		$acl = $this->caldavBackend->applyShareAcl($this->getResourceId(), $acl);
+
+		if (!$this->isShared()) {
 			return $acl;
 		}
 
-		return $this->caldavBackend->applyShareAcl($this->getResourceId(), $acl);
+		$allowedPrincipals = [$this->getOwner(), parent::getOwner(), 'principals/system/public'];
+		return array_filter($acl, function($rule) use ($allowedPrincipals) {
+			return in_array($rule['principal'], $allowedPrincipals);
+		});
 	}
 
 	public function getChildACL() {

--- a/apps/dav/tests/unit/CalDAV/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarTest.php
@@ -246,6 +246,7 @@ class CalendarTest extends TestCase {
 			]);
 		$backend->expects($this->any())->method('getCalendarObject')
 			->willReturn($calObject2)->with(666, 'event-2');
+		$backend->expects($this->any())->method('applyShareAcl')->willReturnArgument(1);
 
 		$calendarInfo = [
 			'principaluri' => 'user2',
@@ -333,6 +334,7 @@ EOD;
 			]);
 		$backend->expects($this->any())->method('getCalendarObject')
 			->willReturn($calObject1)->with(666, 'event-1');
+		$backend->expects($this->any())->method('applyShareAcl')->willReturnArgument(1);
 
 		$calendarInfo = [
 			'{http://owncloud.org/ns}owner-principal' => $isShared ? 'user1' : 'user2',

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarTest.php
@@ -51,6 +51,7 @@ class PublicCalendarTest extends CalendarTest {
 			]);
 		$backend->expects($this->any())->method('getCalendarObject')
 			->willReturn($calObject2)->with(666, 'event-2');
+		$backend->expects($this->any())->method('applyShareAcl')->willReturnArgument(1);
 
 		$calendarInfo = [
 			'{http://owncloud.org/ns}owner-principal' => 'user2',
@@ -135,6 +136,7 @@ EOD;
 			]);
 		$backend->expects($this->any())->method('getCalendarObject')
 			->willReturn($calObject1)->with(666, 'event-1');
+		$backend->expects($this->any())->method('applyShareAcl')->willReturnArgument(1);
 
 		$calendarInfo = [
 			'{http://owncloud.org/ns}owner-principal' => 'user1',


### PR DESCRIPTION
To test this:

As user 1:

1. create a new calendar
2. share calendar (read-only) with user2

As user 2:
 
3. open the calendar app
4. try to enable the shared calendar
5. check network console.

On master you'll see a 404 (for PROPPATCH to `calendar_shared_by_user1`)
On this branch the request will succeed without any errors

This bug was introduced by https://github.com/nextcloud/server/pull/3595 and only affects master