### PR TITLE
Mark IP as whitelisted if brute force protection is disabled

### DIFF
--- a/lib/private/Security/Bruteforce/Throttler.php
+++ b/lib/private/Security/Bruteforce/Throttler.php
@@ -133,6 +133,10 @@ class Throttler {
 	 * @return bool
 	 */
 	private function isIPWhitelisted($ip) {
+		if($this->config->getSystemValue('auth.bruteforce.protection.enabled', true) === false) {
+			return true;
+		}
+
 		$keys = $this->config->getAppKeys('bruteForce');
 		$keys = array_filter($keys, function($key) {
 			$regex = '/^whitelist_/S';

--- a/tests/lib/Security/Bruteforce/ThrottlerTest.php
+++ b/tests/lib/Security/Bruteforce/ThrottlerTest.php
@@ -137,7 +137,7 @@ class ThrottlerTest extends TestCase {
 
 	/**
 	 * @param string $ip
-	 * @param string[]$whitelists
+	 * @param string[] $whitelists
 	 * @param bool $isWhiteListed
 	 * @param bool $enabled
 	 */


### PR DESCRIPTION
Currently, when disabling the brute force protection no new brute force attempts are logged. However, the ones logged within the last 24 hours will still be used for throttling.

This is quite an unexpected behaviour and caused some support issues. With this change when the brute force protection is disabled also the existing attempts within the last 24 hours will be disregarded.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>