### PR TITLE
show non landscape logos bigger on the login page

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -71,14 +71,14 @@ h3 {
 	background-position: center;
 	width: 252px;
 	min-height: 120px;
-	max-height: 300px;
+	max-height: 200px;
 	margin: 0 auto;
 }
 
 #header .logo img {
 	opacity: 0;
 	max-width: 100%;
-	max-height: 300px;
+	max-height: 200px;
 }
 .wrapper {
 	min-height: 100%;

--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -70,8 +70,15 @@ h3 {
 	background-size: 175px;
 	background-position: center;
 	width: 252px;
-	height: 120px;
+	min-height: 120px;
+	max-height: 300px;
 	margin: 0 auto;
+}
+
+#header .logo img {
+	opacity: 0;
+	max-width: 100%;
+	max-height: 300px;
 }
 .wrapper {
 	min-height: 100%;

--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -40,6 +40,9 @@
 								<h1 class="hidden-visually">
 									<?php p($theme->getName()); ?>
 								</h1>
+								<?php if(\OC::$server->getConfig()->getAppValue('theming', 'logoMime', false)): ?>
+									<img src="<?php p(\OC::$server->getURLGenerator()->getAbsoluteURL('apps/theming/logo') . '?' . \OC::$server->getConfig()->getAppValue('theming', 'cachebuster', '0')) ?>"/>
+								<?php endif; ?>
 							</div>
 							<div id="logo-claim" style="display:none;"><?php p($theme->getLogoClaim()); ?></div>
 						</div>

--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -41,7 +41,7 @@
 									<?php p($theme->getName()); ?>
 								</h1>
 								<?php if(\OC::$server->getConfig()->getAppValue('theming', 'logoMime', false)): ?>
-									<img src="<?php p(\OC::$server->getURLGenerator()->getAbsoluteURL('apps/theming/logo') . '?' . \OC::$server->getConfig()->getAppValue('theming', 'cachebuster', '0')) ?>"/>
+									<img src="<?php p($theme->getLogo()); ?>"/>
 								<?php endif; ?>
 							</div>
 							<div id="logo-claim" style="display:none;"><?php p($theme->getLogoClaim()); ?></div>


### PR DESCRIPTION
If a custom logo is set, we add a transparent image inside the div to scale the div to the aspect ratio of the logo.

Instead of always limiting the height to `120px` the height is now dynamically scaled between `120px` and `300px` based on the aspect ratio of the logo.

Before:

![before](https://i.imgur.com/O0vgMN7.png)

After:

![after](https://i.imgur.com/bIv2zcP.png)