### PR TITLE
allow using the full height of the header for the logo

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -115,7 +115,8 @@
 		background-repeat: no-repeat;
 		background-position: center center;
 		width: 62px;
-		height: 34px;
+		height: 44px;
+		margin-top: -5px;
 	}
 	.header-appname-container {
 		display: none;


### PR DESCRIPTION
Before

![image](https://cloud.githubusercontent.com/assets/1283854/25587095/cbe53a6e-2ea2-11e7-8597-f0265054c832.png)

After

![image](https://cloud.githubusercontent.com/assets/1283854/25587099/d3b7ee6c-2ea2-11e7-9e8c-04718ce7cd58.png)

The stock logo will still have the same size since that one is also limited by width