### PR TITLE
Fix "Copied" message for public links

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -177,9 +177,6 @@
 
 			var clipboard = new Clipboard('.clipboardButton');
 			clipboard.on('success', function(e) {
-				event.preventDefault();
-				event.stopPropagation();
-
 				var $input = $(e.trigger);
 				$input.tooltip('hide')
 					.attr('data-original-title', t('core', 'Copied!'))


### PR DESCRIPTION
* share a file/fodler by public link and click the copy to clipboard icon and watch the tooltip
* before: it said "Copy"
* after: it now says "Copied" after clicking the button
* went somehow in via #3679