### PR TITLE
Make sure the AppFetcher fetches the new applist from the appstore

### DIFF
--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -46,14 +46,7 @@ class AppFetcher extends Fetcher {
 		);
 
 		$this->fileName = 'apps.json';
-
-		$versionArray = explode('.', $this->config->getSystemValue('version'));
-		$this->endpointUrl = sprintf(
-			'https://apps.nextcloud.com/api/v1/platform/%d.%d.%d/apps.json',
-			$versionArray[0],
-			$versionArray[1],
-			$versionArray[2]
-		);
+		$this->setEndpoint();
 	}
 
 	/**
@@ -68,7 +61,7 @@ class AppFetcher extends Fetcher {
 		/** @var mixed[] $response */
 		$response = parent::fetch($ETag, $content);
 
-		$ncVersion = $this->config->getSystemValue('version');
+		$ncVersion = $this->getVersion();
 		$ncMajorVersion = explode('.', $ncVersion)[0];
 		foreach($response['data'] as $dataKey => $app) {
 			$releases = [];
@@ -117,5 +110,23 @@ class AppFetcher extends Fetcher {
 
 		$response['data'] = array_values($response['data']);
 		return $response;
+	}
+
+	private function setEndpoint() {
+		$versionArray = explode('.', $this->getVersion());
+		$this->endpointUrl = sprintf(
+			'https://apps.nextcloud.com/api/v1/platform/%d.%d.%d/apps.json',
+			$versionArray[0],
+			$versionArray[1],
+			$versionArray[2]
+		);
+	}
+
+	/**
+	 * @param string $version
+	 */
+	public function setVersion($version) {
+		parent::setVersion($version);
+		$this->setEndpoint();
 	}
 }

--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -43,6 +43,8 @@ abstract class Fetcher {
 	protected $fileName;
 	/** @var string */
 	protected $endpointUrl;
+	/** @var string */
+	protected $version;
 
 	/**
 	 * @param IAppData $appData
@@ -95,7 +97,7 @@ abstract class Fetcher {
 		}
 
 		$responseJson['timestamp'] = $this->timeFactory->getTime();
-		$responseJson['ncversion'] = $this->config->getSystemValue('version');
+		$responseJson['ncversion'] = $this->getVersion();
 		if ($ETag !== '') {
 			$responseJson['ETag'] = $ETag;
 		}
@@ -127,7 +129,7 @@ abstract class Fetcher {
 			if (is_array($jsonBlob)) {
 
 				// No caching when the version has been updated
-				if (isset($jsonBlob['ncversion']) && $jsonBlob['ncversion'] === $this->config->getSystemValue('version', '0.0.0')) {
+				if (isset($jsonBlob['ncversion']) && $jsonBlob['ncversion'] === $this->getVersion()) {
 
 					// If the timestamp is older than 300 seconds request the files new
 					if ((int)$jsonBlob['timestamp'] > ($this->timeFactory->getTime() - self::INVALIDATE_AFTER_SECONDS)) {
@@ -153,5 +155,24 @@ abstract class Fetcher {
 		} catch (\Exception $e) {
 			return [];
 		}
+	}
+
+	/**
+	 * Get the currently Nextcloud version
+	 * @return string
+	 */
+	protected function getVersion() {
+		if ($this->version === null) {
+			$this->version = $this->config->getSystemValue('version', '0.0.0');
+		}
+		return $this->version;
+	}
+
+	/**
+	 * Set the current Nextcloud version
+	 * @param string $version
+	 */
+	public function setVersion($version) {
+		$this->version = $version;
 	}
 }

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -420,7 +420,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('AppHelper', function ($c) {
 			return new \OC\AppHelper();
 		});
-		$this->registerService('AppFetcher', function ($c) {
+		$this->registerService(AppFetcher::class, function ($c) {
 			return new AppFetcher(
 				$this->getAppDataDir('appstore'),
 				$this->getHTTPClientService(),
@@ -428,6 +428,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$this->getConfig()
 			);
 		});
+		$this->registerAlias('AppFetcher', AppFetcher::class);
+
 		$this->registerService('CategoryFetcher', function ($c) {
 			return new CategoryFetcher(
 				$this->getAppDataDir('appstore'),
@@ -820,9 +822,6 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerAlias('MimeTypeLoader', \OCP\Files\IMimeTypeLoader::class);
 		$this->registerService(BundleFetcher::class, function () {
 			return new BundleFetcher($this->getL10N('lib'));
-		});
-		$this->registerService(AppFetcher::class, function() {
-			return $this->getAppFetcher();
 		});
 		$this->registerService(\OCP\Notification\IManager::class, function (Server $c) {
 			return new Manager(

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -32,6 +32,7 @@
 
 namespace OC;
 
+use OC\App\AppStore\Fetcher\AppFetcher;
 use OC\Hooks\BasicEmitter;
 use OC\IntegrityCheck\Checker;
 use OC_App;
@@ -245,6 +246,9 @@ class Updater extends BasicEmitter {
 		// update all shipped apps
 		$this->checkAppsRequirements();
 		$this->doAppUpgrade();
+
+		// Update the appfetchers version so it downloads the correct list from the appstore
+		\OC::$server->getAppFetcher()->setVersion($currentVersion);
 
 		// upgrade appstore apps
 		$this->upgradeAppStoreApps(\OC::$server->getAppManager()->getInstalledApps());

--- a/tests/lib/App/AppStore/Fetcher/AppFetcherTest.php
+++ b/tests/lib/App/AppStore/Fetcher/AppFetcherTest.php
@@ -72,26 +72,16 @@ EOD;
 	}
 
 	public function testGetWithFilter() {
-		$this->config
-			->expects($this->at(0))
-			->method('getSystemValue')
-			->with('appstoreenabled', true)
-			->willReturn(true);
-		$this->config
-			->expects($this->at(1))
-			->method('getSystemValue')
-			->with('appstoreenabled', true)
-			->willReturn(true);
-		$this->config
-			->expects($this->at(2))
-			->method('getSystemValue')
-			->with('version')
-			->willReturn('11.0.0.2');
-		$this->config
-			->expects($this->at(3))
-			->method('getSystemValue')
-			->with('version')
-			->willReturn('11.0.0.2');
+		$this->config->method('getSystemValue')
+			->willReturnCallback(function($key, $default) {
+				if ($key === 'appstoreenabled') {
+					return true;
+				} else if ($key === 'version') {
+					return '11.0.0.2';
+				} else {
+					return $default;
+				}
+			});
 
 		$file = $this->createMock(ISimpleFile::class);
 		$folder = $this->createMock(ISimpleFolder::class);

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(12, 0, 0, 16);
+$OC_Version = array(12, 0, 0, 17);
 
 // The human readable string
 $OC_VersionString = '12.0 beta 1';


### PR DESCRIPTION
When in the upgrade process the version in the config is still the old
version. (Since we only upgrade it after the upgrade is complete).
However the app list fetched from the appstore must be the new list.

Fixes https://github.com/nextcloud/server/issues/4642

To test:

1. Install stable11
2. Upgrade to master
3. Error about not being able to install core bundle

Now:
1. Install stable11
2. Checkout this branch
3. :rocket: :guitar: :drum: :beer: 

