### PR TITLE
Add caching imageexport

### DIFF
--- a/apps/dav/lib/CardDAV/ImageExportPlugin.php
+++ b/apps/dav/lib/CardDAV/ImageExportPlugin.php
@@ -86,6 +86,11 @@ class ImageExportPlugin extends ServerPlugin {
 		}
 
 		if ($result = $this->getPhoto($node)) {
+			// Allow caching
+			$response->setHeader('Cache-Control', 'private, max-age=3600, must-revalidate');
+			$response->setHeader('Etag', $node->getETag() );
+			$response->setHeader('Pragma', 'public');
+
 			$response->setHeader('Content-Type', $result['Content-Type']);
 			$response->setHeader('Content-Disposition', 'attachment');
 			$response->setStatus(200);

--- a/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
@@ -102,6 +102,8 @@ class ImageExportPluginTest extends TestCase {
 		$this->request->expects($this->once())->method('getPath')->willReturn('/files/welcome.txt');
 
 		$card = $this->getMockBuilder('Sabre\CardDAV\Card')->disableOriginalConstructor()->getMock();
+		$card->method('getETag')
+			->willReturn('"myEtag"');
 		$this->tree->expects($this->once())->method('getNodeForPath')->with('/files/welcome.txt')->willReturn($card);
 
 		$this->plugin->expects($this->once())->method('getPhoto')->willReturn($getPhotoResult);
@@ -110,9 +112,21 @@ class ImageExportPluginTest extends TestCase {
 			$this->response
 				->expects($this->at(0))
 				->method('setHeader')
-				->with('Content-Type', $getPhotoResult['Content-Type']);
+				->with('Cache-Control', 'private, max-age=3600, must-revalidate');
 			$this->response
 				->expects($this->at(1))
+				->method('setHeader')
+				->with('Etag', '"myEtag"');
+			$this->response
+				->expects($this->at(2))
+				->method('setHeader')
+				->with('Pragma', 'public');
+			$this->response
+				->expects($this->at(3))
+				->method('setHeader')
+				->with('Content-Type', $getPhotoResult['Content-Type']);
+			$this->response
+				->expects($this->at(4))
 				->method('setHeader')
 				->with('Content-Disposition', 'attachment');
 			$this->response


### PR DESCRIPTION
Fixes: https://github.com/nextcloud/server/issues/4637

Since we now heavily use this endpoint for the contacts menu we better set proper caching on the images. Else this gets reload over and over again leading to slow loading menu and unneded bytes transfered.
    
* cache for 1 hour by default
* added ETag for validation
* Fixed tests
