### PR TITLE
Do not show an email action for contacts with emtpy email addresses

### DIFF
--- a/lib/private/Contacts/ContactsMenu/Providers/EMailProvider.php
+++ b/lib/private/Contacts/ContactsMenu/Providers/EMailProvider.php
@@ -52,6 +52,10 @@ class EMailProvider implements IProvider {
 	public function process(IEntry $entry) {
 		$iconUrl = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'actions/mail.svg'));
 		foreach ($entry->getEMailAddresses() as $address) {
+			if (empty($address)) {
+				// Skip
+				continue;
+			}
 			$action = $this->actionFactory->newEMailAction($iconUrl, $address, $address);
 			$entry->addAction($action);
 		}

--- a/tests/lib/Contacts/ContactsMenu/Providers/EMailproviderTest.php
+++ b/tests/lib/Contacts/ContactsMenu/Providers/EMailproviderTest.php
@@ -79,4 +79,28 @@ class EMailproviderTest extends TestCase {
 		$this->provider->process($entry);
 	}
 
+	public function testProcessEmptyAddress() {
+		$entry = $this->createMock(IEntry::class);
+		$action = $this->createMock(ILinkAction::class);
+		$iconUrl = 'https://example.com/img/actions/icon.svg';
+		$this->urlGenerator->expects($this->once())
+			->method('imagePath')
+			->willReturn('img/actions/icon.svg');
+		$this->urlGenerator->expects($this->once())
+			->method('getAbsoluteURL')
+			->with('img/actions/icon.svg')
+			->willReturn($iconUrl);
+		$entry->expects($this->once())
+			->method('getEMailAddresses')
+			->willReturn([
+				'',
+		]);
+		$this->actionFactory->expects($this->never())
+			->method('newEMailAction');
+		$entry->expects($this->never())
+			->method('addAction');
+
+		$this->provider->process($entry);
+	}
+
 }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/4558

Not sure if empty email addresses should be stored, but since they kind of already found their way into the db we should ignore them here.