### PR TITLE
Remove named selectors from acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -106,7 +106,11 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function shareLinkCheckbox() {
-		return Locator::forThe()->content("Share link")->descendantOf(self::currentSectionDetailsView())->
+		// forThe()->checkbox("Share link") can not be used here; that would
+		// return the checkbox itself, but the element that the user interacts
+		// with is the label.
+		return Locator::forThe()->xpath("//label[normalize-space() = 'Share link']")->
+				descendantOf(self::currentSectionDetailsView())->
 				describedAs("Share link checkbox in the details view in Files app");
 	}
 
@@ -122,7 +126,11 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function passwordProtectCheckbox() {
-		return Locator::forThe()->content("Password protect")->descendantOf(self::currentSectionDetailsView())->
+		// forThe()->checkbox("Password protect") can not be used here; that
+		// would return the checkbox itself, but the element that the user
+		// interacts with is the label.
+		return Locator::forThe()->xpath("//label[normalize-space() = 'Password protect']")->
+				descendantOf(self::currentSectionDetailsView())->
 				describedAs("Password protect checkbox in the details view in Files app");
 	}
 
@@ -163,7 +171,7 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function favoritedStateIconForFile($fileName) {
-		return Locator::forThe()->content("Favorited")->descendantOf(self::favoriteActionForFile($fileName))->
+		return Locator::forThe()->css(".icon-starred")->descendantOf(self::favoriteActionForFile($fileName))->
 				describedAs("Favorited state icon for file $fileName in Files app");
 	}
 
@@ -210,7 +218,8 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	private static function fileActionsMenuItemFor($itemText) {
-		return Locator::forThe()->content($itemText)->descendantOf(self::fileActionsMenu())->
+		return Locator::forThe()->xpath("//a[normalize-space() = '$itemText']")->
+				descendantOf(self::fileActionsMenu())->
 				describedAs($itemText . " item in file actions menu in Files app");
 	}
 

--- a/tests/acceptance/features/bootstrap/FilesSharingAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesSharingAppContext.php
@@ -47,7 +47,7 @@ class FilesSharingAppContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function wrongPasswordMessage() {
-		return Locator::forThe()->content("The password is wrong. Try again.")->
+		return Locator::forThe()->xpath("//*[@class = 'warning' and normalize-space() = 'The password is wrong. Try again.']")->
 				describedAs("Wrong password message in Authenticate page");
 	}
 

--- a/tests/acceptance/features/bootstrap/LoginPageContext.php
+++ b/tests/acceptance/features/bootstrap/LoginPageContext.php
@@ -66,7 +66,7 @@ class LoginPageContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function wrongPasswordMessage() {
-		return Locator::forThe()->content("Wrong password. Reset it?")->
+		return Locator::forThe()->xpath("//*[@class = 'warning' and normalize-space() = 'Wrong password. Reset it?']")->
 				describedAs("Wrong password message in Login page");
 	}
 

--- a/tests/acceptance/features/bootstrap/NotificationContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationContext.php
@@ -31,7 +31,8 @@ class NotificationContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function notificationMessage($message) {
-		return Locator::forThe()->content($message)->descendantOf(self::notificationContainer())->
+		return Locator::forThe()->xpath("//*[@class = 'row' and normalize-space() = '$message']")->
+				descendantOf(self::notificationContainer())->
 				describedAs("$message notification");
 	}
 

--- a/tests/acceptance/features/bootstrap/SettingsMenuContext.php
+++ b/tests/acceptance/features/bootstrap/SettingsMenuContext.php
@@ -61,7 +61,8 @@ class SettingsMenuContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	private static function menuItemFor($itemText) {
-		return Locator::forThe()->content($itemText)->descendantOf(self::settingsMenu())->
+		return Locator::forThe()->xpath("//a[normalize-space() = '$itemText']")->
+				descendantOf(self::settingsMenu())->
 				describedAs($itemText . " item in Settings menu");
 	}
 

--- a/tests/acceptance/features/core/Locator.php
+++ b/tests/acceptance/features/core/Locator.php
@@ -134,7 +134,7 @@ class LocatorBuilder {
 	 * @return LocatorBuilderSecondStep
 	 */
 	public function id($value) {
-		return $this->customSelector("named", array("id", $value));
+		return $this->customSelector("named_exact", array("id", $value));
 	}
 
 	/**
@@ -142,7 +142,7 @@ class LocatorBuilder {
 	 * @return LocatorBuilderSecondStep
 	 */
 	public function idOrName($value) {
-		return $this->customSelector("named", array("id_or_name", $value));
+		return $this->customSelector("named_exact", array("id_or_name", $value));
 	}
 
 	/**
@@ -150,7 +150,7 @@ class LocatorBuilder {
 	 * @return LocatorBuilderSecondStep
 	 */
 	public function link($value) {
-		return $this->customSelector("named", array("link", $value));
+		return $this->customSelector("named_exact", array("link", $value));
 	}
 
 	/**
@@ -158,7 +158,7 @@ class LocatorBuilder {
 	 * @return LocatorBuilderSecondStep
 	 */
 	public function button($value) {
-		return $this->customSelector("named", array("button", $value));
+		return $this->customSelector("named_exact", array("button", $value));
 	}
 
 	/**
@@ -166,7 +166,7 @@ class LocatorBuilder {
 	 * @return LocatorBuilderSecondStep
 	 */
 	public function linkOrButton($value) {
-		return $this->customSelector("named", array("link_or_button", $value));
+		return $this->customSelector("named_exact", array("link_or_button", $value));
 	}
 
 	/**
@@ -174,7 +174,7 @@ class LocatorBuilder {
 	 * @return LocatorBuilderSecondStep
 	 */
 	public function field($value) {
-		return $this->customSelector("named", array("field", $value));
+		return $this->customSelector("named_exact", array("field", $value));
 	}
 
 	/**
@@ -182,7 +182,7 @@ class LocatorBuilder {
 	 * @return LocatorBuilderSecondStep
 	 */
 	public function selectField($value) {
-		return $this->customSelector("named", array("select", $value));
+		return $this->customSelector("named_exact", array("select", $value));
 	}
 
 	/**
@@ -190,7 +190,7 @@ class LocatorBuilder {
 	 * @return LocatorBuilderSecondStep
 	 */
 	public function checkbox($value) {
-		return $this->customSelector("named", array("checkbox", $value));
+		return $this->customSelector("named_exact", array("checkbox", $value));
 	}
 
 	/**
@@ -198,7 +198,7 @@ class LocatorBuilder {
 	 * @return LocatorBuilderSecondStep
 	 */
 	public function radioButton($value) {
-		return $this->customSelector("named", array("radio", $value));
+		return $this->customSelector("named_exact", array("radio", $value));
 	}
 
 	/**
@@ -206,7 +206,7 @@ class LocatorBuilder {
 	 * @return LocatorBuilderSecondStep
 	 */
 	public function fileInput($value) {
-		return $this->customSelector("named", array("file", $value));
+		return $this->customSelector("named_exact", array("file", $value));
 	}
 
 	/**
@@ -214,7 +214,7 @@ class LocatorBuilder {
 	 * @return LocatorBuilderSecondStep
 	 */
 	public function optionGroup($value) {
-		return $this->customSelector("named", array("optgroup", $value));
+		return $this->customSelector("named_exact", array("optgroup", $value));
 	}
 
 	/**
@@ -222,7 +222,7 @@ class LocatorBuilder {
 	 * @return LocatorBuilderSecondStep
 	 */
 	public function option($value) {
-		return $this->customSelector("named", array("option", $value));
+		return $this->customSelector("named_exact", array("option", $value));
 	}
 
 	/**
@@ -230,7 +230,7 @@ class LocatorBuilder {
 	 * @return LocatorBuilderSecondStep
 	 */
 	public function fieldSet($value) {
-		return $this->customSelector("named", array("fieldset", $value));
+		return $this->customSelector("named_exact", array("fieldset", $value));
 	}
 
 	/**
@@ -238,7 +238,7 @@ class LocatorBuilder {
 	 * @return LocatorBuilderSecondStep
 	 */
 	public function table($value) {
-		return $this->customSelector("named", array("table", $value));
+		return $this->customSelector("named_exact", array("table", $value));
 	}
 
 }

--- a/tests/acceptance/features/core/Locator.php
+++ b/tests/acceptance/features/core/Locator.php
@@ -173,14 +173,6 @@ class LocatorBuilder {
 	 * @param string $value
 	 * @return LocatorBuilderSecondStep
 	 */
-	public function content($value) {
-		return $this->customSelector("named", array("content", $value));
-	}
-
-	/**
-	 * @param string $value
-	 * @return LocatorBuilderSecondStep
-	 */
 	public function field($value) {
 		return $this->customSelector("named", array("field", $value));
 	}


### PR DESCRIPTION
This is one of the needed changes to fix [the sporadic failures of the acceptance tests](https://github.com/nextcloud/server/issues/4498).

It basically fixes a problem caused by the looked for element appearing between two find calls made by Mink, one looking for an exact match and another looking for a partial match. Please see the commit messages for further details.
