### PR TITLE
Add redis support to our CI jobs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -553,11 +553,14 @@ matrix:
     - TESTS: translation-check
     - TESTS: htaccess-checker
     - TESTS: nodb-codecov
+      ENABLE_REDIS: true
     - TESTS: db-codecov
+      ENABLE_REDIS: true
     - TESTS: integration-capabilities_features
     - TESTS: integration-federation_features
     - TESTS: integration-maintenance-mode
     - TESTS: integration-ratelimiting
+      ENABLE_REDIS: true
     - TESTS: integration-auth
     - TESTS: integration-carddav
     - TESTS: integration-dav-v2
@@ -605,28 +608,41 @@ matrix:
     - TESTS: sqlite-php7.0-samba-non-native
     - TEST: memcache-memcached
     - TESTS: sqlite-php7.0-webdav-apache
+      ENABLE_REDIS: true
     - DB: NODB
       PHP: 5.6
+      ENABLE_REDIS: true
     - DB: NODB
       PHP: 7.0
+      ENABLE_REDIS: true
     - DB: NODB
       PHP: 7.1
+      ENABLE_REDIS: true
     - DB: sqlite
       PHP: 5.6
+      ENABLE_REDIS: true
     - DB: sqlite
       PHP: 7.0
+      ENABLE_REDIS: true
     - DB: sqlite
       PHP: 7.1
+      ENABLE_REDIS: true
     - DB: mysql
       PHP: 5.6
+      ENABLE_REDIS: true
     - DB: postgres
       PHP: 5.6
+      ENABLE_REDIS: true
     - DB: mysqlmb4
       PHP: 5.6
+      ENABLE_REDIS: true
 
 services:
   cache:
     image: redis
+    when:
+      matrix:
+       ENABLE_REDIS: true
   postgres:
     image: postgres
     environment:

--- a/autotest.sh
+++ b/autotest.sh
@@ -143,6 +143,10 @@ function cleanup_config {
 	if [ -f config/autotest-storage-swift.config.php ]; then
 		rm config/autotest-storage-swift.config.php
 	fi
+	# Remove autotest redis config
+	if [ -f config/redis.config.php ]; then
+		rm config/redis.config.php
+	fi
 	# Remove mysqlmb4.config.php
 	rm -f config/mysqlmb4.config.php
 }
@@ -177,6 +181,10 @@ function execute_tests {
 		cp tests/objectstore/swift.config.php config/autotest-storage-swift.config.php
 	fi
 	cp tests/preseed-config.php config/config.php
+
+	if [ "$ENABLE_REDIS" == "true" ] ; then
+		cp tests/redis.config.php config/redis.config.php
+	fi
 
 	_DB=$DB
 

--- a/tests/redis.config.php
+++ b/tests/redis.config.php
@@ -1,0 +1,12 @@
+<?php
+
+$CONFIG = [
+	'memcache.local' => '\\OC\\Memcache\\Redis',
+	'memcache.distributed' => '\\OC\\Memcache\\Redis',
+	'memcache.locking' => '\\OC\\Memcache\\Redis',
+	'redis' => [
+		'host' => 'localhost',
+		'port' => 6379,
+		'timeout' => 0,
+	],
+];


### PR DESCRIPTION
Let's see how this runs in our CI system. Should also reduce some load for jobs that don't need redis. I will add redis later to the integration tests as well.