### PR TITLE
Consolidate all the code checkers into one job

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,30 +12,14 @@ pipeline:
     when:
       matrix:
         TESTS: jsunit
-  check-autoloader:
+  checkers:
     image: nextcloudci/php7.0:php7.0-7
     commands:
       - bash ./build/autoloaderchecker.sh
-    when:
-      matrix:
-        TESTS: check-autoloader
-  check-mergejs:
-    image: nextcloudci/php7.0:php7.0-7
-    commands:
       - bash ./build/mergejschecker.sh
-    when:
-      matrix:
-        TESTS: check-mergejs
-  translation-check:
-    image: nextcloudci/php7.0:php7.0-7
-    commands:
+      - php ./build/signed-off-checker.php
       - php ./build/translation-checker.php
-    when:
-      matrix:
-        TESTS: translation-check
-  app-check-code:
-    image: nextcloudci/php7.0:php7.0-7
-    commands:
+      - php ./build/htaccess-checker.php
       - ./occ app:check-code admin_audit
       - ./occ app:check-code comments
       - ./occ app:check-code federation
@@ -45,21 +29,7 @@ pipeline:
       - ./occ app:check-code workflowengine
     when:
       matrix:
-        TESTS: app-check-code
-  signed-off-check:
-    image: nextcloudci/php7.0:php7.0-7
-    commands:
-      - php ./build/signed-off-checker.php
-    when:
-      matrix:
-        TESTS: signed-off-check
-  htaccess-checker:
-    image: nextcloudci/php7.0:php7.0-7
-    commands:
-      - php ./build/htaccess-checker.php
-    when:
-      matrix:
-        TESTS: htaccess-checker
+        TESTS: checkers
   syntax-php5.6:
     image: nextcloudci/php5.6:php5.6-7
     commands:
@@ -549,9 +519,7 @@ pipeline:
         TEST: memcache-memcached
 matrix:
   include:
-    - TESTS: signed-off-check
-    - TESTS: translation-check
-    - TESTS: htaccess-checker
+    - TESTS: checkers
     - TESTS: nodb-codecov
     - TESTS: db-codecov
     - TESTS: integration-capabilities_features
@@ -587,9 +555,6 @@ matrix:
     - TESTS: acceptance
       TESTS-ACCEPTANCE: login
     - TESTS: jsunit
-    - TESTS: check-autoloader
-    - TESTS: check-mergejs
-    - TESTS: app-check-code
     - TESTS: syntax-php5.6
     - TESTS: syntax-php7.0
     - TESTS: syntax-php7.1


### PR DESCRIPTION
* moves all the small checks that basically only that a few seconds into one job
* removes overhead of cloning it 6 times