### PR TITLE
Make read/write options in sharing view radiobuttons

### DIFF
--- a/core/css/share.scss
+++ b/core/css/share.scss
@@ -43,6 +43,9 @@
 		font-weight: 400;
 		white-space: nowrap;
 	}
+	input[type='radio'].radio + label {
+		margin-left: -1px;
+	}
 	input[type='checkbox'] {
 		margin: 0 3px 0 8px;
 		vertical-align: middle;

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -38,17 +38,17 @@
 			'{{#if publicUpload}}' +
 				'<div>' +
 					'<span class="icon-loading-small hidden"></span>' +
-					'<input type="radio" class="radio" name="publicUpload" value="{{publicUploadRValue}}" id="sharingDialogAllowPublicUpload-r-{{cid}}" class="publicUploadRadio" {{{publicUploadRChecked}}} />' +
+					'<input type="radio" name="publicUpload" value="{{publicUploadRValue}}" id="sharingDialogAllowPublicUpload-r-{{cid}}" class="radio publicUploadRadio" {{{publicUploadRChecked}}} />' +
 					'<label for="sharingDialogAllowPublicUpload-r-{{cid}}">{{publicUploadRLabel}}</label>' +
 				'</div>' +
 				'<div>' +
 					'<span class="icon-loading-small hidden"></span>' +
-					'<input type="radio" class="radio" name="publicUpload" value="{{publicUploadRWValue}}" id="sharingDialogAllowPublicUpload-rw-{{cid}}" class="publicUploadRadio" {{{publicUploadRWChecked}}} />' +
+					'<input type="radio" name="publicUpload" value="{{publicUploadRWValue}}" id="sharingDialogAllowPublicUpload-rw-{{cid}}" class="radio publicUploadRadio" {{{publicUploadRWChecked}}} />' +
 					'<label for="sharingDialogAllowPublicUpload-rw-{{cid}}">{{publicUploadRWLabel}}</label>' +
 				'</div>' +
 				'<div>' +
 					'<span class="icon-loading-small hidden"></span>' +
-					'<input type="radio" class="radio" name="publicUpload" value="{{publicUploadWValue}}" id="sharingDialogAllowPublicUpload-w-{{cid}}" class="publicUploadRadio" {{{publicUploadWChecked}}} />' +
+					'<input type="radio" name="publicUpload" value="{{publicUploadWValue}}" id="sharingDialogAllowPublicUpload-w-{{cid}}" class="radio publicUploadRadio" {{{publicUploadWChecked}}} />' +
 					'<label for="sharingDialogAllowPublicUpload-w-{{cid}}">{{publicUploadWLabel}}</label>' +
 				'</div>' +
 			'{{/if}}' +

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -39,7 +39,7 @@
 				'<div>' +
 					'<span class="icon-loading-small hidden"></span>' +
 					'<input type="radio" name="publicUpload" value="{{publicUploadRValue}}" id="sharingDialogAllowPublicUpload-r-{{cid}}" class="publicUploadRadio" {{{publicUploadRChecked}}} />' +
-					'<label for="sharingDialogAllowPublicUpload-rw-{{cid}}">{{publicUploadRLabel}}</label>' +
+					'<label for="sharingDialogAllowPublicUpload-r-{{cid}}">{{publicUploadRLabel}}</label>' +
 				'</div>' +
 				'<div>' +
 					'<span class="icon-loading-small hidden"></span>' +

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -38,17 +38,17 @@
 			'{{#if publicUpload}}' +
 				'<div>' +
 					'<span class="icon-loading-small hidden"></span>' +
-					'<input type="radio" name="publicUpload" value="{{publicUploadRValue}}" id="sharingDialogAllowPublicUpload-r-{{cid}}" class="publicUploadRadio" {{{publicUploadRChecked}}} />' +
+					'<input type="radio" class="radio" name="publicUpload" value="{{publicUploadRValue}}" id="sharingDialogAllowPublicUpload-r-{{cid}}" class="publicUploadRadio" {{{publicUploadRChecked}}} />' +
 					'<label for="sharingDialogAllowPublicUpload-r-{{cid}}">{{publicUploadRLabel}}</label>' +
 				'</div>' +
 				'<div>' +
 					'<span class="icon-loading-small hidden"></span>' +
-					'<input type="radio" name="publicUpload" value="{{publicUploadRWValue}}" id="sharingDialogAllowPublicUpload-rw-{{cid}}" class="publicUploadRadio" {{{publicUploadRWChecked}}} />' +
+					'<input type="radio" class="radio" name="publicUpload" value="{{publicUploadRWValue}}" id="sharingDialogAllowPublicUpload-rw-{{cid}}" class="publicUploadRadio" {{{publicUploadRWChecked}}} />' +
 					'<label for="sharingDialogAllowPublicUpload-rw-{{cid}}">{{publicUploadRWLabel}}</label>' +
 				'</div>' +
 				'<div>' +
 					'<span class="icon-loading-small hidden"></span>' +
-					'<input type="radio" name="publicUpload" value="{{publicUploadWValue}}" id="sharingDialogAllowPublicUpload-w-{{cid}}" class="publicUploadRadio" {{{publicUploadWChecked}}} />' +
+					'<input type="radio" class="radio" name="publicUpload" value="{{publicUploadWValue}}" id="sharingDialogAllowPublicUpload-w-{{cid}}" class="publicUploadRadio" {{{publicUploadWChecked}}} />' +
 					'<label for="sharingDialogAllowPublicUpload-w-{{cid}}">{{publicUploadWLabel}}</label>' +
 				'</div>' +
 			'{{/if}}' +

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -35,20 +35,23 @@
 				'{{{popoverMenu}}}' +
 			'{{/if}}' +
 			'</div>' +
-			'    {{#if publicUpload}}' +
-			'<div id="allowPublicUploadWrapper">' +
-			'    <span class="icon-loading-small hidden"></span>' +
-			'    <input type="checkbox" value="1" name="allowPublicUpload" id="sharingDialogAllowPublicUpload-{{cid}}" class="checkbox publicUploadCheckbox" {{{publicUploadChecked}}} />' +
-			'<label for="sharingDialogAllowPublicUpload-{{cid}}">{{publicUploadLabel}}</label>' +
-			'</div>' +
-			'        {{#if hideFileList}}' +
-			'<div id="hideFileListWrapper">' +
-			'    <span class="icon-loading-small hidden"></span>' +
-			'    <input type="checkbox" value="1" name="hideFileList" id="sharingDialogHideFileList-{{cid}}" class="checkbox hideFileListCheckbox" {{{hideFileListChecked}}} />' +
-			'<label for="sharingDialogHideFileList-{{cid}}">{{hideFileListLabel}}</label>' +
-			'</div>' +
-			'        {{/if}}' +
-			'    {{/if}}' +
+			'{{#if publicUpload}}' +
+				'<div>' +
+					'<span class="icon-loading-small hidden"></span>' +
+					'<input type="radio" name="publicUpload" value="{{publicUploadRValue}}" id="sharingDialogAllowPublicUpload-r-{{cid}}" class="publicUploadRadio" {{{publicUploadRChecked}}} />' +
+					'<label for="sharingDialogAllowPublicUpload-rw-{{cid}}">{{publicUploadRLabel}}</label>' +
+				'</div>' +
+				'<div>' +
+					'<span class="icon-loading-small hidden"></span>' +
+					'<input type="radio" name="publicUpload" value="{{publicUploadRWValue}}" id="sharingDialogAllowPublicUpload-rw-{{cid}}" class="publicUploadRadio" {{{publicUploadRWChecked}}} />' +
+					'<label for="sharingDialogAllowPublicUpload-rw-{{cid}}">{{publicUploadRWLabel}}</label>' +
+				'</div>' +
+				'<div>' +
+					'<span class="icon-loading-small hidden"></span>' +
+					'<input type="radio" name="publicUpload" value="{{publicUploadWValue}}" id="sharingDialogAllowPublicUpload-w-{{cid}}" class="publicUploadRadio" {{{publicUploadWChecked}}} />' +
+					'<label for="sharingDialogAllowPublicUpload-w-{{cid}}">{{publicUploadWLabel}}</label>' +
+				'</div>' +
+			'{{/if}}' +
 			'     {{#if publicEditing}}' +
 			'<div id="allowPublicEditingWrapper">' +
 			'    <span class="icon-loading-small hidden"></span>' +
@@ -126,12 +129,11 @@
 			'keyup input.linkPassText': 'onPasswordKeyUp',
 			'click .linkCheckbox': 'onLinkCheckBoxChange',
 			'click .linkText': 'onLinkTextClick',
-			'change .publicUploadCheckbox': 'onAllowPublicUploadChange',
 			'change .publicEditingCheckbox': 'onAllowPublicEditingChange',
-			'change .hideFileListCheckbox': 'onHideFileListChange',
 			'click .showPasswordCheckbox': 'onShowPasswordClick',
 			'click .icon-more': 'onToggleMenu',
-			'click .pop-up': 'onPopUpClick'
+			'click .pop-up': 'onPopUpClick',
+			'change .publicUploadRadio': 'onPublicUploadChange'
 		},
 
 		initialize: function(options) {
@@ -170,9 +172,8 @@
 				'onPasswordKeyUp',
 				'onLinkTextClick',
 				'onShowPasswordClick',
-				'onHideFileListChange',
-				'onAllowPublicUploadChange',
-				'onAllowPublicEditingChange'
+				'onAllowPublicEditingChange',
+				'onPublicUploadChange'
 			);
 
 			var clipboard = new Clipboard('.clipboardButton');
@@ -318,20 +319,6 @@
 			});
 		},
 
-		onAllowPublicUploadChange: function() {
-			var $checkbox = this.$('.publicUploadCheckbox');
-			$checkbox.siblings('.icon-loading-small').removeClass('hidden').addClass('inlineblock');
-
-			var permissions = OC.PERMISSION_READ;
-			if($checkbox.is(':checked')) {
-				permissions = OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_READ | OC.PERMISSION_DELETE;
-			}
-
-			this.model.saveLinkShare({
-				permissions: permissions
-			});
-		},
-
 		onAllowPublicEditingChange: function() {
 			var $checkbox = this.$('.publicEditingCheckbox');
 			$checkbox.siblings('.icon-loading-small').removeClass('hidden').addClass('inlineblock');
@@ -346,15 +333,9 @@
 			});
 		},
 
-		onHideFileListChange: function () {
-			var $checkbox = this.$('.hideFileListCheckbox');
-			$checkbox.siblings('.icon-loading-small').removeClass('hidden').addClass('inlineblock');
 
-			var permissions = OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_READ | OC.PERMISSION_DELETE;
-			if ($checkbox.is(':checked')) {
-				permissions = OC.PERMISSION_CREATE;
-			}
-
+	onPublicUploadChange: function(e) {
+			var permissions = e.currentTarget.value;
 			this.model.saveLinkShare({
 				permissions: permissions
 			});
@@ -382,22 +363,25 @@
 				&& this.model.createPermissionPossible()
 				&& this.configModel.isPublicUploadEnabled();
 
-			var publicUploadChecked = '';
-			if(this.model.isPublicUploadAllowed()) {
-				publicUploadChecked = 'checked="checked"';
+			var publicUploadRWChecked = '';
+			var publicUploadRChecked = '';
+			var publicUploadWChecked = '';
+
+			switch (this.model.linkSharePermissions()) {
+				case OC.PERMISSION_READ:
+					publicUploadRChecked = 'checked';
+					break;
+				case OC.PERMISSION_CREATE:
+					publicUploadWChecked = 'checked';
+					break;
+				case OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_READ | OC.PERMISSION_DELETE:
+					publicUploadRWChecked = 'checked';
+					break;
 			}
 
 			var publicEditingChecked = '';
 			if(this.model.isPublicEditingAllowed()) {
 				publicEditingChecked = 'checked="checked"';
-			}
-
-
-			var hideFileList = publicUploadChecked;
-
-			var hideFileListChecked = '';
-			if(this.model.isHideFileListSet()) {
-				hideFileListChecked = 'checked="checked"';
 			}
 
 			var isLinkShare = this.model.get('linkShare').isLinkShare;
@@ -437,7 +421,6 @@
 			this.$el.html(linkShareTemplate({
 				cid: this.cid,
 				shareAllowed: true,
-				hideFileList: hideFileList,
 				isLinkShare: isLinkShare,
 				shareLinkURL: this.model.get('linkShare').link,
 				linkShareLabel: t('core', 'Share link'),
@@ -449,17 +432,22 @@
 				isPasswordSet: isPasswordSet,
 				showPasswordCheckBox: showPasswordCheckBox,
 				publicUpload: publicUpload && isLinkShare,
-				publicUploadChecked: publicUploadChecked,
-				hideFileListChecked: hideFileListChecked,
-				publicUploadLabel: t('core', 'Allow upload and editing'),
 				publicEditing: publicEditable,
 				publicEditingChecked: publicEditingChecked,
 				publicEditingLabel: t('core', 'Allow editing'),
-				hideFileListLabel: 'Secure drop (' + t('core', 'upload only') + ')',
 				mailPrivatePlaceholder: t('core', 'Email link to person'),
 				mailButtonText: t('core', 'Send'),
 				singleAction: OC.Share.Social.Collection.size() == 0,
-				popoverMenu: popover
+				popoverMenu: popover,
+				publicUploadRWLabel: t('core', 'Allow upload and editing'),
+				publicUploadRLabel: t('core', 'Read only'),
+				publicUploadWLabel: t('core', 'Secure drop (upload only)'),
+				publicUploadRWValue: OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_READ | OC.PERMISSION_DELETE,
+				publicUploadRValue: OC.PERMISSION_READ,
+				publicUploadWValue: OC.PERMISSION_CREATE,
+				publicUploadRWChecked: publicUploadRWChecked,
+				publicUploadRChecked: publicUploadRChecked,
+				publicUploadWChecked: publicUploadWChecked
 			}));
 
 			if (OC.Share.Social.Collection.size() == 0) {

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -487,6 +487,13 @@
 		},
 
 		/**
+		 * @return {int}
+		 */
+		getPermissions: function() {
+			return this.get('permissions');
+		},
+
+		/**
 		 * @returns {boolean}
 		 */
 		sharePermissionPossible: function() {
@@ -566,6 +573,17 @@
 			return    this.hasCreatePermission(shareIndex)
 				   || this.hasUpdatePermission(shareIndex)
 				   || this.hasDeletePermission(shareIndex);
+		},
+
+		/**
+		 * @returns {int}
+		 */
+		linkSharePermissions: function() {
+			if (!this.hasLinkShare()) {
+				return -1;
+			} else {
+				return this.get('linkShare').permissions;
+			}
 		},
 
 		_getUrl: function(base, params) {


### PR DESCRIPTION
Follow up to PR #3784 to make the files_drop sharing feature more prominent as proposed in #2207 .

I added the `radio` class to the radiobuttons for styling and fixed a small typo.

<img width="315" alt="bildschirmfoto 2017-05-04 um 01 28 15" src="https://cloud.githubusercontent.com/assets/1899308/25685897/ba73f2ba-306a-11e7-9f66-d9632a1243a3.png">

Tested on macOS 10.11.6 in Chrome, Firefox and Safari

Sadly it does not seem to work anymore, because the radio buttons have no effect. Maybe due to rebasing...
@rullzer Care to have a look?
