### PR TITLE
Try to start browser sessions again when they fail in acceptance tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -488,21 +488,21 @@ pipeline:
   acceptance-access-levels:
       image: nextcloudci/php7.0:php7.0-7
       commands:
-        - tests/acceptance/run-local.sh allow-git-repository-modifications features/access-levels.feature
+        - tests/acceptance/run-local.sh --timeout-multiplier 10 allow-git-repository-modifications features/access-levels.feature
       when:
         matrix:
           TESTS-ACCEPTANCE: access-levels
   acceptance-app-files:
       image: nextcloudci/php7.0:php7.0-7
       commands:
-        - tests/acceptance/run-local.sh allow-git-repository-modifications features/app-files.feature
+        - tests/acceptance/run-local.sh --timeout-multiplier 10 allow-git-repository-modifications features/app-files.feature
       when:
         matrix:
           TESTS-ACCEPTANCE: app-files
   acceptance-login:
       image: nextcloudci/php7.0:php7.0-7
       commands:
-        - tests/acceptance/run-local.sh allow-git-repository-modifications features/login.feature
+        - tests/acceptance/run-local.sh --timeout-multiplier 10 allow-git-repository-modifications features/login.feature
       when:
         matrix:
           TESTS-ACCEPTANCE: login

--- a/tests/acceptance/features/core/Actor.php
+++ b/tests/acceptance/features/core/Actor.php
@@ -165,6 +165,18 @@ class Actor {
 	public function find($elementLocator, $timeout = 0, $timeoutStep = 0.5) {
 		$timeout = $timeout * $this->findTimeoutMultiplier;
 
+		return $this->findInternal($elementLocator, $timeout, $timeoutStep);
+	}
+
+	/**
+	 * Finds an element in the Mink Session of this Actor.
+	 *
+	 * The timeout is not affected by the multiplier set using
+	 * setFindTimeoutMultiplier().
+	 *
+	 * @see find($elementLocator, $timeout, $timeoutStep)
+	 */
+	private function findInternal($elementLocator, $timeout, $timeoutStep) {
 		$element = null;
 		$selector = $elementLocator->getSelector();
 		$locator = $elementLocator->getLocator();
@@ -211,7 +223,7 @@ class Actor {
 		$ancestorElement = $elementLocator->getAncestor();
 		if ($ancestorElement instanceof Locator) {
 			try {
-				$ancestorElement = $this->find($ancestorElement, $timeout, $timeoutStep);
+				$ancestorElement = $this->findInternal($ancestorElement, $timeout, $timeoutStep);
 			} catch (NoSuchElementException $exception) {
 				// Little hack to show the stack of ancestor elements that could
 				// not be found, as Behat only shows the message of the last

--- a/tests/acceptance/features/core/ActorContext.php
+++ b/tests/acceptance/features/core/ActorContext.php
@@ -39,7 +39,7 @@ use Behat\MinkExtension\Context\RawMinkContext;
  * propagates its inherited "base_url" Mink parameter to the Actors as needed.
  *
  * By default no multiplier for the find timeout is set in the Actors. However,
- * it can be customized using the "actorFindTimeoutMultiplier" parameter of the
+ * it can be customized using the "actorTimeoutMultiplier" parameter of the
  * ActorContext in "behat.yml".
  *
  * Every actor used in the scenarios must have a corresponding Mink session
@@ -66,16 +66,16 @@ class ActorContext extends RawMinkContext {
 	/**
 	 * @var float
 	 */
-	private $actorFindTimeoutMultiplier;
+	private $actorTimeoutMultiplier;
 
 	/**
 	 * Creates a new ActorContext.
 	 *
-	 * @param float $actorFindTimeoutMultiplier the find timeout multiplier to
-	 *        set in the Actors.
+	 * @param float $actorTimeoutMultiplier the timeout multiplier for Actor
+	 *        related timeouts.
 	 */
-	public function __construct($actorFindTimeoutMultiplier = 1) {
-		$this->actorFindTimeoutMultiplier = $actorFindTimeoutMultiplier;
+	public function __construct($actorTimeoutMultiplier = 1) {
+		$this->actorTimeoutMultiplier = $actorTimeoutMultiplier;
 	}
 
 	/**
@@ -110,7 +110,7 @@ class ActorContext extends RawMinkContext {
 		$this->sharedNotebook = array();
 
 		$this->actors["default"] = new Actor($this->getSession(), $this->getMinkParameter("base_url"), $this->sharedNotebook);
-		$this->actors["default"]->setFindTimeoutMultiplier($this->actorFindTimeoutMultiplier);
+		$this->actors["default"]->setFindTimeoutMultiplier($this->actorTimeoutMultiplier);
 
 		$this->currentActor = $this->actors["default"];
 	}
@@ -134,7 +134,7 @@ class ActorContext extends RawMinkContext {
 	public function iActAs($actorName) {
 		if (!array_key_exists($actorName, $this->actors)) {
 			$this->actors[$actorName] = new Actor($this->getSession($actorName), $this->getMinkParameter("base_url"), $this->sharedNotebook);
-			$this->actors[$actorName]->setFindTimeoutMultiplier($this->actorFindTimeoutMultiplier);
+			$this->actors[$actorName]->setFindTimeoutMultiplier($this->actorTimeoutMultiplier);
 		}
 
 		$this->currentActor = $this->actors[$actorName];

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -197,6 +197,22 @@ trap cleanUp EXIT
 # the Git working directory to the container) expect that.
 cd "$(dirname $0)"
 
+# "--timeout-multiplier N" option can be provided before the specific scenario
+# to run, if any, to set the timeout multiplier to be used in the acceptance
+# tests.
+TIMEOUT_MULTIPLIER_OPTION=""
+if [ "$1" = "--timeout-multiplier" ]; then
+	if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+		echo "--timeout-multiplier must be followed by a positive integer"
+
+		exit 1
+	fi
+
+	TIMEOUT_MULTIPLIER_OPTION="--timeout-multiplier $2"
+
+	shift 2
+fi
+
 # If no parameter is provided to this script all the acceptance tests are run.
 SCENARIO_TO_RUN=$1
 
@@ -206,4 +222,4 @@ prepareSelenium
 prepareDocker
 
 echo "Running tests"
-docker exec $NEXTCLOUD_LOCAL_CONTAINER bash -c "cd nextcloud && tests/acceptance/run-local.sh allow-git-repository-modifications $SCENARIO_TO_RUN"
+docker exec $NEXTCLOUD_LOCAL_CONTAINER bash -c "cd nextcloud && tests/acceptance/run-local.sh $TIMEOUT_MULTIPLIER_OPTION allow-git-repository-modifications $SCENARIO_TO_RUN"


### PR DESCRIPTION
This is another of the needed changes to fix [the sporadic failures of the acceptance tests](https://github.com/nextcloud/server/issues/4498) (note that there are still other changes needed, so the acceptance tests may fail for this pull request with `Element is no longer attached to the DOM` or `Element is not currently visible and so may not be interacted with`).

Sometimes, acceptance tests fail because the timeout to start a web browser session expires (`org.openqa.selenium.firefox.NotConnectedException: Unable to connect to host 127.0.0.1 on port 7055 after 45000 ms`). This pull request basically adds support for trying to start the session several times before giving up.

Note that this issue is not fixable. I mean, nothing guarantees you that the session will be started before certain timeout expires, but you can not wait indefinitely for it either; sooner or later you have to give up. The time needed to start the session increases with the load of the system, so the acceptance tests run by Drone now try to start the session ten times before giving up; ten looked like a reasonable value, but it was not backed by any hard data, so it may need to be tweaked.

Acceptance tests run in a local development machine still use a default timeout multiplier of one, although a larger value can be specified when executing `run.sh` using the `--timeout-multiplier N` option.
