### PR TITLE
Documentation fix IGroup::getDisplayName is available since version 12

### DIFF
--- a/lib/public/IGroup.php
+++ b/lib/public/IGroup.php
@@ -41,7 +41,7 @@ interface IGroup {
 	 * Returns the group display name
 	 *
 	 * @return string
-	 * @since 9.2
+	 * @since 12.0.0
 	 */
 	public function getDisplayName();
 


### PR DESCRIPTION
Since https://github.com/nextcloud/server/pull/2833 has not been backported 

Signed-off-by: Julius Härtl <jus@bitgrid.net>