### PR TITLE
Do not reload the filelist on first open

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -92,6 +92,12 @@
 		initialized: false,
 
 		/**
+		 * Wheater the file list was already shown once
+		 * @type boolean
+		 */
+		shown: false,
+
+		/**
 		 * Number of files per page
 		 *
 		 * @return {int} page size
@@ -557,7 +563,10 @@
 		 * Event handler when leaving previously hidden state
 		 */
 		_onShow: function(e) {
-			this.reload();
+			if (this.shown) {
+				this.reload();
+			}
+			this.shown = true;
 		},
 
 		/**

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1509,6 +1509,12 @@ describe('OCA.Files.FileList tests', function() {
 		});
 		it('reloads the list when leaving hidden state', function() {
 			var reloadStub = sinon.stub(fileList, 'reload');
+
+			// First show should not trigger
+			$('#app-content-files').trigger(new $.Event('show'));
+			expect(reloadStub.calledOnce).toEqual(false);
+
+			// Second show should!
 			$('#app-content-files').trigger(new $.Event('show'));
 			expect(reloadStub.calledOnce).toEqual(true);
 			reloadStub.restore();


### PR DESCRIPTION
Fixes: #4644

Without this patch the filelist would always reload. However since not
all the correct data was set yet it would often:

1. fireoff a propfind to ../webdav/
2. fireoff a propfind to ../webdav/<PATH>

When just opening the file list those are the same so the result is just
fine. However if opening a direct link it means that there is a race
condition on which finishes first.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>