### PR TITLE
Load proper fonts in guest.css

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -637,3 +637,27 @@ footer,
 	height: 1px;
 	overflow: hidden;
 }
+
+/* for low-res screens, use Regular font-weight instead of Light */
+@media (-webkit-max-device-pixel-ratio: 1.3), (max-resolution: 124.8dpi) {
+	@font-face {
+		font-family: 'Open Sans';
+		font-style: normal;
+		font-weight: normal;
+		src: local('Open Sans'), local('OpenSans'), url('../fonts/OpenSans-Regular.woff') format('woff');
+	}
+}
+
+@font-face {
+	font-family: 'Open Sans';
+	font-style: normal;
+	font-weight: 300;
+	src: local('Open Sans Light'), local('OpenSans-Light'), url('../fonts/OpenSans-Light.woff') format('woff');
+}
+
+@font-face {
+	font-family: 'Open Sans';
+	font-style: normal;
+	font-weight: 600;
+	src: local('Open Sans Semibold'), local('OpenSans-Semibold'), url('../fonts/OpenSans-Semibold.woff') format('woff');
+}


### PR DESCRIPTION
Fixes #4676

Before:
![before](https://cloud.githubusercontent.com/assets/45821/25702117/d0723b98-30cf-11e7-8550-0ce9f3b0cd20.png)

After:
![after](https://cloud.githubusercontent.com/assets/45821/25702121/d642ca9c-30cf-11e7-94bd-d8f15abb0cea.png)

Very subtle since my font is already close. But you can see for yourself if you set a horrible default font.

Easy one.