### PR TITLE
handle permissions errors when copying the skeleton for a read only user

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -46,6 +46,7 @@ use OC_User;
 use OC_Util;
 use OCA\DAV\Connector\Sabre\Auth;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\NotPermittedException;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\ISession;
@@ -480,8 +481,12 @@ class Session implements IUserSession, Emitter {
 			//trigger creation of user home and /files folder
 			$userFolder = \OC::$server->getUserFolder($user);
 
-			// copy skeleton
-			\OC_Util::copySkeleton($user, $userFolder);
+			try {
+				// copy skeleton
+				\OC_Util::copySkeleton($user, $userFolder);
+			} catch (NotPermittedException $ex) {
+				// read only uses
+			}
 
 			// trigger any other initialization
 			\OC::$server->getEventDispatcher()->dispatch(IUser::class . '::firstLogin', new GenericEvent($this->getUser()));


### PR DESCRIPTION
Needed to make the guests app work properly