### PR TITLE
ensure theming app is loaded when showing an error page

### DIFF
--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -292,6 +292,11 @@ class OC_Template extends \OC\Template\Base {
 		* @param string $hint An optional hint message - needs to be properly escaped
 		*/
 	public static function printErrorPage( $error_msg, $hint = '' ) {
+		if (\OC_App::isEnabled('theming') && !\OC_App::isAppLoaded('theming')) {
+			\OC_App::loadApp('theming');
+		}
+
+
 		if ($error_msg === $hint) {
 			// If the hint is the same as the message there is no need to display it twice.
 			$hint = '';


### PR DESCRIPTION
Prevent un-themed error pages when an error is triggered before the theming app can load naturally.

You can reproduce the problem with the guests app and trying to access an app guests do not have access to as guest