### PR TITLE
Increase device password entropy.

### DIFF
--- a/lib/public/Security/ISecureRandom.php
+++ b/lib/public/Security/ISecureRandom.php
@@ -45,6 +45,13 @@ interface ISecureRandom {
 	const CHAR_SYMBOLS = '!\"#$%&\\\'()* +,-./:;<=>?@[\]^_`{|}~';
 
 	/**
+	 * Characters that can be used for <code>generate($length, $characters)</code>, to
+	 * generate human readable random strings. Lower- and upper-case characters and digits 
+	 * are included. Characters which are ambiguous are excluded, such as I, l, and 1 and so on.
+	 */
+	const CHAR_HUMAN_READABLE = "abcdefgijkmnopqrstwxyzABCDEFGHJKLMNPQRSTWXYZ23456789";
+
+	/**
 	 * Convenience method to get a low strength random number generator.
 	 *
 	 * Low Strength should be used anywhere that random strings are needed

--- a/settings/Controller/AuthSettingsController.php
+++ b/settings/Controller/AuthSettingsController.php
@@ -154,16 +154,16 @@ class AuthSettingsController extends Controller {
 	}
 
 	/**
-	 * Return a 20 digit device password
+	 * Return a 25 digit device password
 	 *
-	 * Example: ABCDE-FGHIJ-KLMNO-PQRST
+	 * Example: AbCdE-fGhIj-KlMnO-pQrSt-12345
 	 *
 	 * @return string
 	 */
 	private function generateRandomDeviceToken() {
 		$groups = [];
-		for ($i = 0; $i < 4; $i++) {
-			$groups[] = $this->random->generate(5, implode('', range('A', 'Z')));
+		for ($i = 0; $i < 5; $i++) {
+			$groups[] = $this->random->generate(5, ISecureRandom::CHAR_HUMAN_READABLE);
 		}
 		return implode('-', $groups);
 	}

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -343,7 +343,7 @@ table.nostyle td { padding: 0.2em 0; }
 
 #new-app-login-name,
 #new-app-password {
-	width: 186px;
+	width: 245px;
 	font-family: monospace;
 	background-color: lightyellow;
 }

--- a/tests/Settings/Controller/AuthSettingsControllerTest.php
+++ b/tests/Settings/Controller/AuthSettingsControllerTest.php
@@ -133,11 +133,11 @@ class AuthSettingsControllerTest extends TestCase {
 			->method('getLoginName')
 			->will($this->returnValue('User13'));
 
-		$this->secureRandom->expects($this->exactly(4))
+		$this->secureRandom->expects($this->exactly(5))
 			->method('generate')
-			->with(5, implode('', range('A', 'Z')))
+			->with(5, ISecureRandom::CHAR_HUMAN_READABLE)
 			->will($this->returnValue('XXXXX'));
-		$newToken = 'XXXXX-XXXXX-XXXXX-XXXXX';
+		$newToken = 'XXXXX-XXXXX-XXXXX-XXXXX-XXXXX';
 
 		$this->tokenProvider->expects($this->once())
 			->method('generateToken')


### PR DESCRIPTION
Use lower, upper case characters and digits, also increased number of digits to 25.

Fixes #3873 