### PR TITLE
fix sizing of logo in header

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -114,6 +114,7 @@
 		background-image: url($image-logo);
 		background-repeat: no-repeat;
 		background-position: center center;
+		background-size: contain;
 		width: 62px;
 		height: 34px;
 	}


### PR DESCRIPTION
This was somehow broken by https://github.com/nextcloud/server/pull/4617

Before:

![image](https://cloud.githubusercontent.com/assets/1283854/25805526/53ce9580-3400-11e7-9f48-2b69f180d2ee.png)

After:

![image](https://cloud.githubusercontent.com/assets/1283854/25805534/58452fe8-3400-11e7-9233-3f48a7bb4bd0.png)