### PR TITLE
External has been moved to appstore

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -5,7 +5,6 @@
     "comments",
     "dav",
     "encryption",
-    "external",
     "federatedfilesharing",
     "federation",
     "files",


### PR DESCRIPTION
As discussed with Joas. Ref https://apps.nextcloud.com/apps/external

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>