### PR TITLE
Fix mentioned user not clickable after posting or editing a comment

### DIFF
--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -239,8 +239,12 @@
 					username, 0, $el.find('.authorRow'));
 			}
 
-			var message = $el.find('.message');
-			message.find('.avatar').each(function() {
+			var $message = $el.find('.message');
+			this._postRenderMessage($message);
+		},
+
+		_postRenderMessage: function($el) {
+			$el.find('.avatar').each(function() {
 				var avatar = $(this);
 				var strong = $(this).next();
 				var appendTo = $(this).parent();
@@ -419,10 +423,13 @@
 						$textArea.val('').prop('disabled', false);
 					}
 
-					$target.find('.message')
+					var $message = $target.find('.message');
+					$message
 						.html(self._formatMessage(model.get('message'), model.get('mentions')))
 						.find('.avatar')
 						.each(function () { $(this).avatar(); });
+
+					self._postRenderMessage($message);
 				},
 				error: function () {
 					self._onSubmitError($form, commentId);

--- a/apps/comments/tests/js/commentstabviewSpec.js
+++ b/apps/comments/tests/js/commentstabviewSpec.js
@@ -154,9 +154,11 @@ describe('OCA.Comments.CommentsTabView tests', function() {
 			expect($comment.length).toEqual(1);
 			expect($comment.find('.avatar[data-user=macbeth]').length).toEqual(1);
 			expect($comment.find('strong:first').text()).toEqual('Thane of Cawdor');
+			expect($comment.find('.avatar[data-user=macbeth] ~ .contactsmenu-popover').length).toEqual(1);
 
 			expect($comment.find('.avatar[data-user=banquo]').length).toEqual(1);
 			expect($comment.find('.avatar-name-wrapper:last-child strong').text()).toEqual('Lord Banquo');
+			expect($comment.find('.avatar[data-user=banquo] ~ .contactsmenu-popover').length).toEqual(1);
 		});
 
 	});
@@ -292,6 +294,7 @@ describe('OCA.Comments.CommentsTabView tests', function() {
 			expect($message.find('.avatar').length).toEqual(1);
 			expect($message.find('.avatar[data-user=anotheruser]').length).toEqual(1);
 			expect($message.find('.avatar[data-user=anotheruser] ~ strong').text()).toEqual('Another User');
+			expect($message.find('.avatar[data-user=anotheruser] ~ .contactsmenu-popover').length).toEqual(1);
 		});
 		it('does not create a comment if the field is empty', function() {
 			view.$el.find('.message').val('   ');
@@ -502,6 +505,7 @@ describe('OCA.Comments.CommentsTabView tests', function() {
 			expect($message.find('.avatar').length).toEqual(1);
 			expect($message.find('.avatar[data-user=anotheruser]').length).toEqual(1);
 			expect($message.find('.avatar[data-user=anotheruser] ~ strong').text()).toEqual('Another User');
+			expect($message.find('.avatar[data-user=anotheruser] ~ .contactsmenu-popover').length).toEqual(1);
 
 			// form row is gone
 			$formRow = view.$el.find('.newCommentRow.comment[data-id=3]');


### PR DESCRIPTION
The contactsMenu plugin was called on avatar elements from `_postRenderItem`, which is called when a new comment is added to the collection. Due to this contactsMenu was not called when messages were
edited; when a new comment is posted `_postRenderItem` is called, but at that time the _mentions_ attribute is not filled yet, so _@username_ is not replaced by avatars in the message and thus  contactsMenu has no avatars to be called on.

Calling contactsMenu was moved to a new method, `_postRenderMessage`, which is called from `_postRenderItem` and from the success callback when fetching the model in `_onSubmitSuccess` (which replaces _@username_ by avatars in the message after posting or editing a comment).

Fixes #4555