### PR TITLE
Don't redirect requests to /core/img/manifest.json

### DIFF
--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -462,6 +462,7 @@ class Setup {
 			$content .= "\n  RewriteRule ^core/preview.png$ index.php [PT,E=PATH_INFO:$1]";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !\\.(css|js|svg|gif|png|html|ttf|woff|ico|jpg|jpeg)$";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !core/img/favicon.ico$";
+			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !core/img/manifest.json$";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/remote.php";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/public.php";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/cron.php";


### PR DESCRIPTION
Otherwise, the manifest file cannot be loaded with mod_rewrite activate and an error in the console is thrown.