### PR TITLE
Do not write and read rootcerts.crt at the same time

### DIFF
--- a/lib/private/Security/CertificateManager.php
+++ b/lib/private/Security/CertificateManager.php
@@ -119,7 +119,8 @@ class CertificateManager implements ICertificateManager {
 			return;
 		}
 
-		$fhCerts = $this->view->fopen($path . '/rootcerts.crt', 'w');
+		$certPath = $path . 'rootcerts.crt';
+		$fhCerts = $this->view->fopen($certPath, 'w');
 
 		// Write user certificates
 		foreach ($certs as $cert) {
@@ -136,7 +137,7 @@ class CertificateManager implements ICertificateManager {
 
 		// Append the system certificate bundle
 		$systemBundle = $this->getCertificateBundle(null);
-		if ($this->view->file_exists($systemBundle)) {
+		if ($systemBundle !== $certPath && $this->view->file_exists($systemBundle)) {
 			$systemCertificates = $this->view->file_get_contents($systemBundle);
 			fwrite($fhCerts, $systemCertificates);
 		}


### PR DESCRIPTION
(Possibly) fixes #3470

When updating the main file /files_external/rootcerts.crt we should not
read from /files_external/rootcerts.crt at the same time.

For 2 reasons: writing to a file and reading from it at the same time
can have non deterministic results

And we don't want all the certificates to appear 2 times in there.

This isn't caught by our standard file locking (that does not allow this
actually) because it is in a non locked path.... :see_no_evil: 

I can't guarantee it fixes #3470 as I can't reproduce that locally. But I would not be surprised if this had something to do with it.