### PR TITLE
Add fallback to jQuery.fn.globalEval

### DIFF
--- a/apps/updatenotification/js/admin.js
+++ b/apps/updatenotification/js/admin.js
@@ -32,6 +32,13 @@ $(document).ready(function(){
 						var body = $('body');
 						$('head').remove();
 						body.html(data);
+
+						// Eval the script elements in the response
+						var dom = $(data);
+						dom.filter('script').each(function() {
+							eval(this.text || this.textContent || this.innerHTML || '');
+						});
+
 						body.removeAttr('id');
 						body.attr('id', 'body-settings');
 					}


### PR DESCRIPTION
The Nextcloud updater used `.html()` to inject the `/updater/index.php` which also contains JavaScript. This internally calls `jQuery.globalEval` which is forbidden by us.

To make this work on the admin page for the updater this adds a fallback the `jquery.unsafeGlobalEval`.

To test this:

1. Setup Beta 1
2. Change channel to beta
3. Try the updater via web => Button to start the update does not work.
4. Apply this changes => Try the updater via web => Button to start the update does work.

Fixes https://github.com/nextcloud/updater/issues/108
Fixes https://github.com/nextcloud/server/issues/4782