### PR TITLE
Make sure we use the passed-in storage when there is one

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -266,6 +266,9 @@ class Scanner extends BasicEmitter implements IScanner {
 	 * @return int the id of the added file
 	 */
 	protected function addToCache($path, $data, $fileId = -1) {
+		if (isset($data['scan_permissions'])) {
+			$data['permissions'] = $data['scan_permissions'];
+		}
 		\OC_Hook::emit('Scanner', 'addToCache', array('file' => $path, 'data' => $data));
 		$this->emit('\OC\Files\Cache\Scanner', 'addToCache', array($path, $this->storageId, $data));
 		if ($this->cacheActive) {

--- a/lib/private/Files/Cache/Wrapper/CachePermissionsMask.php
+++ b/lib/private/Files/Cache/Wrapper/CachePermissionsMask.php
@@ -40,6 +40,7 @@ class CachePermissionsMask extends CacheWrapper {
 
 	protected function formatCacheEntry($entry) {
 		if (isset($entry['permissions'])) {
+			$entry['scan_permissions'] = $entry['permissions'];
 			$entry['permissions'] &= $this->mask;
 		}
 		return $entry;

--- a/lib/private/Files/Storage/Wrapper/PermissionsMask.php
+++ b/lib/private/Files/Storage/Wrapper/PermissionsMask.php
@@ -149,6 +149,9 @@ class PermissionsMask extends Wrapper {
 	}
 
 	public function getScanner($path = '', $storage = null) {
-		return parent::getScanner($path, $this->storage);
+		if (!$storage) {
+			$storage = $this->storage;
+		}
+		return parent::getScanner($path, $storage);
 	}
 }

--- a/lib/private/Files/Storage/Wrapper/PermissionsMask.php
+++ b/lib/private/Files/Storage/Wrapper/PermissionsMask.php
@@ -143,7 +143,8 @@ class PermissionsMask extends Wrapper {
 		$data = parent::getMetaData($path);
 
 		if ($data && isset($data['permissions'])) {
-			$data['permissions'] = $data['permissions'] & $this->mask;
+			$data['scan_permissions'] = $data['permissions'];
+			$data['permissions'] &= $this->mask;
 		}
 		return $data;
 	}

--- a/tests/lib/Files/Storage/Wrapper/PermissionsMaskTest.php
+++ b/tests/lib/Files/Storage/Wrapper/PermissionsMaskTest.php
@@ -8,7 +8,9 @@
 
 namespace Test\Files\Storage\Wrapper;
 
+use OC\Files\Storage\Wrapper\Wrapper;
 use OCP\Constants;
+use OCP\Files\Cache\IScanner;
 
 /**
  * @group DB
@@ -113,5 +115,50 @@ class PermissionsMaskTest extends \Test\Files\Storage\Storage {
 
 		$this->assertEquals(Constants::PERMISSION_ALL - Constants::PERMISSION_CREATE, $this->sourceStorage->getCache()->get('foo')->getPermissions());
 		$this->assertEquals(Constants::PERMISSION_READ, $storage->getCache()->get('foo')->getPermissions());
+	}
+
+	public function testScanNewWrappedFiles() {
+		$storage = $this->getMaskedStorage(Constants::PERMISSION_READ + Constants::PERMISSION_CREATE);
+		$wrappedStorage = new Wrapper(['storage' => $storage]);
+		$wrappedStorage->file_put_contents('foo', 'bar');
+		$wrappedStorage->getScanner()->scan('');
+
+		$this->assertEquals(Constants::PERMISSION_ALL - Constants::PERMISSION_CREATE, $this->sourceStorage->getCache()->get('foo')->getPermissions());
+		$this->assertEquals(Constants::PERMISSION_READ, $storage->getCache()->get('foo')->getPermissions());
+	}
+
+	public function testScanUnchanged() {
+		$this->sourceStorage->mkdir('foo');
+		$this->sourceStorage->file_put_contents('foo/bar.txt', 'bar');
+
+		$this->sourceStorage->getScanner()->scan('foo');
+
+		$storage = $this->getMaskedStorage(Constants::PERMISSION_READ);
+		$scanner = $storage->getScanner();
+		$called = false;
+		$scanner->listen('\OC\Files\Cache\Scanner', 'addToCache', function () use (&$called) {
+			$called = true;
+		});
+		$scanner->scan('foo', IScanner::SCAN_RECURSIVE, IScanner::REUSE_ETAG | IScanner::REUSE_SIZE);
+
+		$this->assertFalse($called);
+	}
+
+	public function testScanUnchangedWrapped() {
+		$this->sourceStorage->mkdir('foo');
+		$this->sourceStorage->file_put_contents('foo/bar.txt', 'bar');
+
+		$this->sourceStorage->getScanner()->scan('foo');
+
+		$storage = $this->getMaskedStorage(Constants::PERMISSION_READ);
+		$wrappedStorage = new Wrapper(['storage' => $storage]);
+		$scanner = $wrappedStorage->getScanner();
+		$called = false;
+		$scanner->listen('\OC\Files\Cache\Scanner', 'addToCache', function () use (&$called) {
+			$called = true;
+		});
+		$scanner->scan('foo', IScanner::SCAN_RECURSIVE, IScanner::REUSE_ETAG | IScanner::REUSE_SIZE);
+
+		$this->assertFalse($called);
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/files_automatedtagging/issues/30
Fixes https://github.com/nextcloud/server/issues/4903

@icewind1991 please have a look. All other storage wrappers correctly use the passed in (wrapped) storage. But the PermissionsMask did not. This caused auto-tagging to not work on public links/files drop, because the Scanner used the unwrapped version of the cache.
I don't think this is intentional, but can you confirm?