### PR TITLE
Setup root FS for multibucket object storage

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -884,7 +884,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getConfig(),
 				$c->getThemingDefaults(),
 				\OC::$SERVERROOT,
-				$cacheFactory->createLocal('SCSS')
+				$cacheFactory->create('SCSS')
 			);
 		});
 		$this->registerService(EventDispatcher::class, function () {


### PR DESCRIPTION
Uses first bucket of a multi bucket setup for the root FS


### How to test

Install https://github.com/jubos/fake-s3 and start it:

```
sudo gem install fakes3
mkdir /tmp/s3
fakes3 -r /tmp/s3 -p 4567
```

Configure multibucket:

```php
'objectstore_multibucket' => [
	'class' => 'OC\\Files\\ObjectStore\\S3',
	'arguments' => [
		'bucket' => 'abc',
		'num_buckets' => 64,
		'key' => '123',
		'secret' => 'abc',
		'hostname' => 'localhost',
		'port' => '4567',
		'use_ssl' => false,
		'use_path_style' => 'true',
	],
],
```

Check out that the data dir only holds the log file and no appdata_* folders.


