### PR TITLE
Add 10 seconds sleep time after postgres startup

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -311,6 +311,8 @@ function execute_tests {
 				echo "[ERROR] Waited 60 seconds, no response" >&2
 				exit 1
 			fi
+			echo "Give it 10 additional seconds ..."
+			sleep 10
 
 			if [ -z "$DRONE" ] ; then # no need to drop the DB when we are on CI
 				dropdb -U "$DATABASEUSER" "$DATABASENAME" || true


### PR DESCRIPTION
Makes the postgres failures even more unlikely. Recently there was one, where the port was open already but the DB was just finishing the startup procedure. 🙈 