### PR TITLE
Properly decide on actual users if instance is too big

### DIFF
--- a/core/templates/update.use-cli.php
+++ b/core/templates/update.use-cli.php
@@ -3,7 +3,7 @@
 		<h2 class="title"><?php p($l->t('Update needed')) ?></h2>
 		<div class="infogroup">
 			<?php if ($_['tooBig']) {
-				p($l->t('Please use the command line updater because you have a big instance.'));
+				p($l->t('Please use the command line updater because you have a big instance with more than 50 users.'));
 			} else {
 				p($l->t('Please use the command line updater because automatic updating is disabled in the config.php.'));
 			} ?><br><br>


### PR DESCRIPTION
cc @blizzz and @LukasReschke for this

The user_saml either uses the build in users or the ones in the user_saml table. I tested this only with user_ldap, but because it's just the same code it should work for user_saml too.

This at least mitigates a bit the problem with small instances that use user_ldap - like in #4353.

@rullzer @nickvergessen @blizzz @LukasReschke What do you think: Too risky for 12 or fine?

Fixes https://github.com/nextcloud/documentation/issues/318
Fixes #3518