### PR TITLE
Allow to enforce update via web UI

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -178,6 +178,17 @@ input.updateButton,
 input.update-continue {
 	padding: 10px 20px; /* larger log in and installation buttons */
 }
+.updateAnyways a.updateAnywaysButton {
+	font-size: 14px;
+	padding: 10px 20px;
+	color: #666 !important;
+	display: inline-block;
+	border-radius: 3px;
+	margin: 15px 5px;
+}
+.updateAnyways a.updateAnywaysButton:hover {
+	color: #222 !important;
+}
 input.primary,
 button.primary {
 	border: 1px solid #0082c9;
@@ -441,6 +452,9 @@ form #selectDbType label.ui-state-active {
 	text-align: left;
 	border-radius: 3px;
 	cursor: default;
+}
+.warning.updateAnyways {
+	text-align: center;
 }
 .warning legend,
 .warning a,

--- a/core/templates/update.use-cli.php
+++ b/core/templates/update.use-cli.php
@@ -11,4 +11,13 @@
 			print_unescaped($l->t('For help, see the  <a target="_blank" rel="noreferrer" href="%s">documentation</a>.', [link_to_docs('admin-cli-upgrade')])); ?><br><br>
 		</div>
 	</div>
+
+	<?php if ($_['tooBig']) { ?>
+		<div class="warning updateAnyways">
+			<?php p($l->t('I know that if I continue doing the update via web UI has the risk, that the request runs into a timeout and could cause data loss, but I have a backup and know how to restore my instance in case of a failure.' )); ?>
+			<a href="?IKnowThatThisIsABigInstanceAndTheUpdateRequestCouldRunIntoATimeoutAndHowToRestoreABackup=IAmSuperSureToDoThis" class="button updateAnywaysButton"><?php p($l->t('Upgrade via web on my own risk' )); ?></a>
+		</div>
+	<?php } ?>
+
+
 </div>

--- a/lib/base.php
+++ b/lib/base.php
@@ -343,7 +343,10 @@ class OC {
 				$tooBig = ($totalUsers > 50);
 			}
 		}
-		if ($disableWebUpdater || $tooBig) {
+		$ignoreTooBigWarning = isset($_GET['IKnowThatThisIsABigInstanceAndTheUpdateRequestCouldRunIntoATimeoutAndHowToRestoreABackup']) &&
+			$_GET['IKnowThatThisIsABigInstanceAndTheUpdateRequestCouldRunIntoATimeoutAndHowToRestoreABackup'] === 'IAmSuperSureToDoThis';
+
+		if ($disableWebUpdater || ($tooBig && !$ignoreTooBigWarning)) {
 			// send http status 503
 			header('HTTP/1.1 503 Service Temporarily Unavailable');
 			header('Status: 503 Service Temporarily Unavailable');


### PR DESCRIPTION
* adds a disclaimer that an update via web UI is on own risk
* allows to skip the warning
* fixes #4353


Shows now this and after clicking it shows our "normal" updater page where you can click "Start update"

![bildschirmfoto 2017-05-10 um 22 23 18](https://cloud.githubusercontent.com/assets/245432/25931118/f81fc4da-35cf-11e7-977c-5f61beb6c6a2.png)


@karlitschek @jancborchardt @jospoortvliet I'm open for refinements in the wording. Usually I don't want to scare people and lower the trust into our product, but for the web UI this is tricky and we can't do much if the update takes longer than 30 seconds (which is usually not the case, but could be).

And it's up to you if this should land in 12 or in 13. From my point of view this has a very low risk of breakage, because it's basically a button and a super extreme specific get parameter ;) Of course I would like to see this in 12 to not have more people complaining about this.

