### PR TITLE
Fix mimetype update query

### DIFF
--- a/lib/private/Files/Type/Loader.php
+++ b/lib/private/Files/Type/Loader.php
@@ -158,11 +158,15 @@ class Loader implements IMimeTypeLoader {
 	 * @return int number of changed rows
 	 */
 	public function updateFilecache($ext, $mimetypeId) {
+		$is_folderId = $this->getId('httpd/unix-directory');
 		$update = $this->dbConnection->getQueryBuilder();
 		$update->update('filecache')
 			->set('mimetype', $update->createNamedParameter($mimetypeId))
 			->where($update->expr()->neq(
 				'mimetype', $update->createNamedParameter($mimetypeId)
+			))
+			->andwhere($update->expr()->neq(
+				'mimetype', $update->createNamedParameter($is_folderId)
 			))
 			->andWhere($update->expr()->like(
 				$update->createFunction('LOWER(`name`)'), $update->createNamedParameter($ext)

--- a/lib/private/Files/Type/Loader.php
+++ b/lib/private/Files/Type/Loader.php
@@ -154,19 +154,19 @@ class Loader implements IMimeTypeLoader {
 	 * Update filecache mimetype based on file extension
 	 *
 	 * @param string $ext file extension
-	 * @param int $mimetypeId
+	 * @param int $mimeTypeId
 	 * @return int number of changed rows
 	 */
-	public function updateFilecache($ext, $mimetypeId) {
-		$isFolderId = $this->getId('httpd/unix-directory');
+	public function updateFilecache($ext, $mimeTypeId) {
+		$folderMimeTypeId = $this->getId('httpd/unix-directory');
 		$update = $this->dbConnection->getQueryBuilder();
 		$update->update('filecache')
-			->set('mimetype', $update->createNamedParameter($mimetypeId))
+			->set('mimetype', $update->createNamedParameter($mimeTypeId))
 			->where($update->expr()->neq(
-				'mimetype', $update->createNamedParameter($mimetypeId)
+				'mimetype', $update->createNamedParameter($mimeTypeId)
 			))
 			->andWhere($update->expr()->neq(
-				'mimetype', $update->createNamedParameter($isFolderId)
+				'mimetype', $update->createNamedParameter($folderMimeTypeId)
 			))
 			->andWhere($update->expr()->like(
 				$update->createFunction('LOWER(' . $update->getColumnName('name') . ')'),

--- a/lib/private/Files/Type/Loader.php
+++ b/lib/private/Files/Type/Loader.php
@@ -158,7 +158,7 @@ class Loader implements IMimeTypeLoader {
 	 * @return int number of changed rows
 	 */
 	public function updateFilecache($ext, $mimetypeId) {
-		$is_folderId = $this->getId('httpd/unix-directory');
+		$isFolderId = $this->getId('httpd/unix-directory');
 		$update = $this->dbConnection->getQueryBuilder();
 		$update->update('filecache')
 			->set('mimetype', $update->createNamedParameter($mimetypeId))
@@ -166,10 +166,11 @@ class Loader implements IMimeTypeLoader {
 				'mimetype', $update->createNamedParameter($mimetypeId)
 			))
 			->andwhere($update->expr()->neq(
-				'mimetype', $update->createNamedParameter($is_folderId)
+				'mimetype', $update->createNamedParameter($isFolderId)
 			))
 			->andWhere($update->expr()->like(
-				$update->createFunction('LOWER(`name`)'), $update->createNamedParameter($ext)
+				$update->createFunction('LOWER(' . $update->getColumnName('name') . ')'),
+				'%' . $this->dbConnection->escapeLikeParameter($update->createNamedParameter('.' . $ext))
 			));
 		return $update->execute();
 	}

--- a/lib/private/Files/Type/Loader.php
+++ b/lib/private/Files/Type/Loader.php
@@ -165,12 +165,12 @@ class Loader implements IMimeTypeLoader {
 			->where($update->expr()->neq(
 				'mimetype', $update->createNamedParameter($mimetypeId)
 			))
-			->andwhere($update->expr()->neq(
+			->andWhere($update->expr()->neq(
 				'mimetype', $update->createNamedParameter($isFolderId)
 			))
 			->andWhere($update->expr()->like(
 				$update->createFunction('LOWER(' . $update->getColumnName('name') . ')'),
-				'%' . $this->dbConnection->escapeLikeParameter($update->createNamedParameter('.' . $ext))
+				$update->createNamedParameter('%' . $this->dbConnection->escapeLikeParameter('.' . $ext))
 			));
 		return $update->execute();
 	}


### PR DESCRIPTION
Downstream 27668

1. Create a folder called `wav`
1. Create a folder called `.wav`
1. Create a file called `test.wav`
1. Delete the mimetype `audio/wav` from oc_mimetypes
1. Run `occ maintenance:mimetype:update-db --repair-filecache`

### Expected
`test.wav` has mimetype `audio/wav`

### Actual
`wav` has mimetype `audio/wav`

with the first commit nothing has `audio/wav` (oc), but I fixed it.


Fixes #4318