### PR TITLE
Smaller input field for update notification groups

### DIFF
--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -47,7 +47,7 @@
 	<p id="oca_updatenotification_groups">
 		<br />
 		<?php p($l->t('Notify members of the following groups about available updates:')); ?>
-		<input name="oca_updatenotification_groups_list" type="hidden" id="oca_updatenotification_groups_list" value="<?php p($_['notify_groups']) ?>" style="width: 400px">
+		<input name="oca_updatenotification_groups_list" type="hidden" id="oca_updatenotification_groups_list" value="<?php p($_['notify_groups']) ?>" style="width: 200px">
 		<em class="<?php if (!in_array($currentChannel, ['daily', 'git'])) p('hidden'); ?>">
 			<br />
 			<?php p($l->t('Only notification for app updates are available.')); ?>


### PR DESCRIPTION
Fixes a paper cut from #2672 - cc @nextcloud/designers 

Before:

<img width="966" alt="bildschirmfoto 2017-05-11 um 19 32 02" src="https://cloud.githubusercontent.com/assets/245432/25977332/8d0264ee-3680-11e7-879a-7903fc53c6c9.png">


After:

<img width="971" alt="bildschirmfoto 2017-05-11 um 19 31 38" src="https://cloud.githubusercontent.com/assets/245432/25977327/7eaac3dc-3680-11e7-907f-dbd37c9c3c55.png">

