### PR TITLE
Add IPv6 to “localhost” regex (#440)

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -67,7 +67,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	// Android Chrome user agent: https://developers.google.com/chrome/mobile/docs/user-agent
 	const USER_AGENT_ANDROID_MOBILE_CHROME = '#Android.*Chrome/[.0-9]*#';
 	const USER_AGENT_FREEBOX = '#^Mozilla/5\.0$#';
-	const REGEX_LOCALHOST = '/^(127\.0\.0\.1|localhost)$/';
+	const REGEX_LOCALHOST = '/^(127\.0\.0\.1|localhost|::1)$/';
 
 	/**
 	 * @deprecated use \OCP\IRequest::USER_AGENT_CLIENT_IOS instead


### PR DESCRIPTION
Add the IPv6 (::1) to the regex for “localhost” 

Fix  #440