### PR TITLE
Revert "fix objectstore rename"

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -517,7 +517,6 @@ class File extends Node implements IFile {
 		// TODO: in the future use ChunkHandler provided by storage
 		return !$storage->instanceOfStorage('OCA\Files_Sharing\External\Storage') &&
 			!$storage->instanceOfStorage('OC\Files\Storage\OwnCloud') &&
-			!$storage->instanceOfStorage('OC\Files\ObjectStore\ObjectStoreStorage') &&
 			$storage->needsPartFile();
 	}
 


### PR DESCRIPTION
This reverts commit 5334a3dc337b5883763ac8e1eaef58c1a435144b.

Few things:

1. If we don't want a storage to use part files we should not use this magic but use https://github.com/nextcloud/server/blob/master/lib/public/Files/Storage.php#L462
2. I don't get why using this on ObjectStorage is needed. The rename is cheap (just in the DB) and avoids nasty things (like creating the version directly etc).