### PR TITLE
Use appdata logo when generating icons

### DIFF
--- a/apps/theming/lib/Util.php
+++ b/apps/theming/lib/Util.php
@@ -25,6 +25,9 @@ namespace OCA\Theming;
 
 use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
+use OCP\Files\IAppData;
+use OCP\Files\NotFoundException;
+use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\IConfig;
 use OCP\Files\IRootFolder;
 
@@ -33,23 +36,23 @@ class Util {
 	/** @var IConfig */
 	private $config;
 
-	/** @var IRootFolder */
-	private $rootFolder;
-
 	/** @var IAppManager */
 	private $appManager;
+
+	/** @var IAppData */
+	private $appData;
 
 	/**
 	 * Util constructor.
 	 *
 	 * @param IConfig $config
-	 * @param IRootFolder $rootFolder
 	 * @param IAppManager $appManager
+	 * @param IAppData $appData
 	 */
-	public function __construct(IConfig $config, IRootFolder $rootFolder, IAppManager $appManager) {
+	public function __construct(IConfig $config, IAppManager $appManager, IAppData $appData) {
 		$this->config = $config;
-		$this->rootFolder = $rootFolder;
 		$this->appManager = $appManager;
+		$this->appData = $appData;
 	}
 
 	/**
@@ -111,7 +114,7 @@ class Util {
 
 	/**
 	 * @param $app string app name
-	 * @return string path to app icon / logo
+	 * @return string|ISimpleFile path to app icon / file of logo
 	 */
 	public function getAppIcon($app) {
 		$app = str_replace(array('\0', '/', '\\', '..'), '', $app);
@@ -127,8 +130,14 @@ class Util {
 			}
 		} catch (AppPathNotFoundException $e) {}
 
-		if($this->config->getAppValue('theming', 'logoMime', '') !== '' && $this->rootFolder->nodeExists('/themedinstancelogo')) {
-			return $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data') . '/themedinstancelogo';
+		if ($this->config->getAppValue('theming', 'logoMime', '') !== '') {
+			$logoFile = null;
+			try {
+				$folder = $this->appData->getFolder('images');
+				if ($folder !== null) {
+					return $folder->getFile('logo');
+				}
+			} catch (NotFoundException $e) {}
 		}
 		return \OC::$SERVERROOT . '/core/img/logo.svg';
 	}

--- a/apps/theming/tests/Controller/ThemingControllerTest.php
+++ b/apps/theming/tests/Controller/ThemingControllerTest.php
@@ -62,8 +62,6 @@ class ThemingControllerTest extends TestCase {
 	private $l10n;
 	/** @var ThemingController */
 	private $themingController;
-	/** @var IRootFolder|\PHPUnit_Framework_MockObject_MockObject */
-	private $rootFolder;
 	/** @var ITempManager */
 	private $tempManager;
 	/** @var IAppManager|\PHPUnit_Framework_MockObject_MockObject */
@@ -79,14 +77,13 @@ class ThemingControllerTest extends TestCase {
 		$this->themingDefaults = $this->createMock(ThemingDefaults::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->l10n = $this->createMock(L10N::class);
-		$this->rootFolder = $this->createMock(IRootFolder::class);
+		$this->appData = $this->createMock(IAppData::class);
 		$this->appManager = $this->createMock(IAppManager::class);
-		$this->util = new Util($this->config, $this->rootFolder, $this->appManager);
+		$this->util = new Util($this->config, $this->appManager, $this->appData);
 		$this->timeFactory->expects($this->any())
 			->method('getTime')
 			->willReturn(123);
 		$this->tempManager = \OC::$server->getTempManager();
-		$this->appData = $this->createMock(IAppData::class);
 		$this->scssCacher = $this->createMock(SCSSCacher::class);
 
 		$this->themingController = new ThemingController(

--- a/apps/theming/tests/IconBuilderTest.php
+++ b/apps/theming/tests/IconBuilderTest.php
@@ -27,7 +27,9 @@ use OCA\Theming\ThemingDefaults;
 use OCA\Theming\Util;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http\NotFoundResponse;
+use OCP\Files\IAppData;
 use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
 use OCP\IConfig;
 use Test\TestCase;
 
@@ -35,8 +37,8 @@ class IconBuilderTest extends TestCase {
 
 	/** @var IConfig */
 	protected $config;
-	/** @var IRootFolder */
-	protected $rootFolder;
+	/** @var IAppData */
+	protected $appData;
 	/** @var ThemingDefaults */
 	protected $themingDefaults;
 	/** @var Util */
@@ -50,11 +52,11 @@ class IconBuilderTest extends TestCase {
 		parent::setUp();
 
 		$this->config = $this->getMockBuilder('\OCP\IConfig')->getMock();
-		$this->rootFolder = $this->getMockBuilder('OCP\Files\IRootFolder')->getMock();
+		$this->appData = $this->createMock(IAppData::class);
 		$this->themingDefaults = $this->getMockBuilder('OCA\Theming\ThemingDefaults')
 			->disableOriginalConstructor()->getMock();
 		$this->appManager = $this->getMockBuilder('OCP\App\IAppManager')->getMock();
-		$this->util = new Util($this->config, $this->rootFolder, $this->appManager);
+		$this->util = new Util($this->config, $this->appManager, $this->appData);
 		$this->iconBuilder = new IconBuilder($this->themingDefaults, $this->util);
 	}
 
@@ -89,6 +91,10 @@ class IconBuilderTest extends TestCase {
 		$this->themingDefaults->expects($this->once())
 			->method('getColorPrimary')
 			->willReturn($color);
+		$this->appData->expects($this->once())
+			->method('getFolder')
+			->with('images')
+			->willThrowException(new NotFoundException());
 
 		$expectedIcon = new \Imagick(realpath(dirname(__FILE__)). "/data/" . $file);
 		$icon = $this->iconBuilder->renderAppIcon($app, 512);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -853,7 +853,7 @@ class Server extends ServerContainer implements IServerContainer {
 					$c->getURLGenerator(),
 					$c->getAppDataDir('theming'),
 					$c->getMemCacheFactory(),
-					new Util($c->getConfig(), $this->getRootFolder(), $this->getAppManager())
+					new Util($c->getConfig(), $this->getAppManager(), $this->getAppDataDir('theming'))
 				);
 			}
 			return new \OC_Defaults();


### PR DESCRIPTION
After moving the theming logo to AppData, generating custom icons like the favicon/touch has been broken.

Steps to reproduce:
1. Upload a custom logo
2. Browse the generated icon: /index.php/apps/theming/icon/core

Follow-up of https://github.com/nextcloud/server/pull/3413

@nextcloud/theming 