### PR TITLE
Fix encryption + remembered login due to missing login hook

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -361,6 +361,10 @@ class Server extends ServerContainer implements IServerContainer {
 				/** @var $user \OC\User\User */
 				\OC_Hook::emit('OC_User', 'post_login', array('run' => true, 'uid' => $user->getUID(), 'password' => $password));
 			});
+			$userSession->listen('\OC\User', 'postRememberedLogin', function ($user, $password) {
+				/** @var $user \OC\User\User */
+				\OC_Hook::emit('OC_User', 'post_login', array('run' => true, 'uid' => $user->getUID(), 'password' => $password));
+			});
 			$userSession->listen('\OC\User', 'logout', function () {
 				\OC_Hook::emit('OC_User', 'logout', array());
 			});

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -792,7 +792,13 @@ class Session implements IUserSession, Emitter {
 		$this->setToken($token->getId());
 		$this->lockdownManager->setToken($token);
 		$user->updateLastLoginTimestamp();
-		$this->manager->emit('\OC\User', 'postRememberedLogin', [$user]);
+		$password = null;
+		try {
+			$password = $this->tokenProvider->getPassword($token, $sessionId);
+		} catch (PasswordlessTokenException $ex) {
+			// Ignore
+		}
+		$this->manager->emit('\OC\User', 'postRememberedLogin', [$user, $password]);
 		return true;
 	}
 


### PR DESCRIPTION
The encryption app relies on the post_login hook to initialize its keys.
Since we do not emit it on a remembered login, the keys were always un-
initialized and the user was asked to log out and in again.
This patch *translates* the postRememberedLogin hook to a post_login
hook.

This should fix https://github.com/nextcloud/server/issues/4797.