### PR TITLE
Cache deps list to memcache on write not on first read

### DIFF
--- a/lib/private/Template/JSCombiner.php
+++ b/lib/private/Template/JSCombiner.php
@@ -101,7 +101,6 @@ class JSCombiner {
 			if ($deps === null || $deps === '') {
 				$depFile = $folder->getFile($fileName);
 				$deps = $depFile->getContent();
-				$this->depsCache->set($folder->getName() . '-' . $fileName, $deps);
 			}
 			$deps = json_decode($deps, true);
 
@@ -162,8 +161,11 @@ class JSCombiner {
 
 		try {
 			$cachedfile->putContent($res);
-			$depFile->putContent(json_encode($deps));
+			$deps = json_encode($deps);
+			$depFile->putContent($deps);
+			$this->depsCache->set($folder->getName() . '-' . $depFileName, $deps);
 			$gzipFile->putContent(gzencode($res, 9));
+
 			return true;
 		} catch (NotPermittedException $e) {
 			return false;


### PR DESCRIPTION
Fixes #4886

Caching on first read leads to the bug that if the files are updated we
will never cache again. Since we will always fetch from the memcache
(which works) and then see that the files are newer.
