### PR TITLE
Fix logo being too big on log in page, fix #4585

### DIFF
--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -45,6 +45,9 @@
 #header .logo,
 #header .logo-icon {
 	background-image: url(#{$image-logo});
+	@if $theming-logo-mime != '' {
+		background-size: contain;
+	}
 }
 
 #body-login,

--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -44,7 +44,6 @@
 /* override styles for login screen in guest.css */
 #header .logo,
 #header .logo-icon {
-	background-size: contain;
 	background-image: url(#{$image-logo});
 }
 

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -192,6 +192,8 @@ class ThemingDefaults extends \OC_Defaults {
 
 		$variables = [
 			'theming-cachebuster' => "'" . $this->config->getAppValue('theming', 'cachebuster', '0') . "'",
+			'theming-logo-mime' => "'" . $this->config->getAppValue('theming', 'logoMime', '') . "'",
+			'theming-background-mime' => "'" . $this->config->getAppValue('theming', 'backgroundMime', '') . "'"
 		];
 
 		$variables['image-logo'] = "'".$this->urlGenerator->getAbsoluteURL($this->getLogo())."'";

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -499,12 +499,14 @@ class ThemingDefaultsTest extends TestCase {
 	public function testGetScssVariables() {
 		$this->config->expects($this->at(0))->method('getAppValue')->with('theming', 'cachebuster', '0')->willReturn('0');
 		$this->config->expects($this->at(1))->method('getAppValue')->with('theming', 'logoMime', false)->willReturn('jpeg');
-		$this->config->expects($this->at(2))->method('getAppValue')->with('theming', 'cachebuster', '0')->willReturn('0');
-		$this->config->expects($this->at(3))->method('getAppValue')->with('theming', 'backgroundMime', false)->willReturn('jpeg');
+		$this->config->expects($this->at(2))->method('getAppValue')->with('theming', 'backgroundMime', false)->willReturn('jpeg');
+		$this->config->expects($this->at(3))->method('getAppValue')->with('theming', 'logoMime', false)->willReturn('jpeg');
 		$this->config->expects($this->at(4))->method('getAppValue')->with('theming', 'cachebuster', '0')->willReturn('0');
-		$this->config->expects($this->at(5))->method('getAppValue')->with('theming', 'color', null)->willReturn($this->defaults->getColorPrimary());
-		$this->config->expects($this->at(6))->method('getAppValue')->with('theming', 'color', $this->defaults->getColorPrimary())->willReturn($this->defaults->getColorPrimary());
-		$this->config->expects($this->at(7))->method('getAppValue')->with('theming', 'color', $this->defaults->getColorPrimary())->willReturn($this->defaults->getColorPrimary());
+		$this->config->expects($this->at(5))->method('getAppValue')->with('theming', 'backgroundMime', false)->willReturn('jpeg');
+		$this->config->expects($this->at(6))->method('getAppValue')->with('theming', 'cachebuster', '0')->willReturn('0');
+		$this->config->expects($this->at(7))->method('getAppValue')->with('theming', 'color', null)->willReturn($this->defaults->getColorPrimary());
+		$this->config->expects($this->at(8))->method('getAppValue')->with('theming', 'color', $this->defaults->getColorPrimary())->willReturn($this->defaults->getColorPrimary());
+		$this->config->expects($this->at(9))->method('getAppValue')->with('theming', 'color', $this->defaults->getColorPrimary())->willReturn($this->defaults->getColorPrimary());
 
 		$this->util->expects($this->any())->method('invertTextColor')->with($this->defaults->getColorPrimary())->willReturn(false);
 		$this->cache->expects($this->once())->method('get')->with('getScssVariables')->willReturn(null);
@@ -530,6 +532,8 @@ class ThemingDefaultsTest extends TestCase {
 
 		$expected = [
 			'theming-cachebuster' => '\'0\'',
+			'theming-logo-mime' => '\'jpeg\'',
+			'theming-background-mime' => '\'jpeg\'',
 			'image-logo' => "'absolute-custom-logo?v=0'",
 			'image-login-background' => "'absolute-custom-background?v=0'",
 			'color-primary' => $this->defaults->getColorPrimary(),


### PR DESCRIPTION
Please review @nextcloud/designers @MorrisJobke @MariusBluem @juliushaertl – it was caused by theming changes. Removing them makes theming still work, and fixes the issue with the logos being way too big, for example even touching the .warning box on error pages.

Before / after:
<img width="1165" alt="bildschirmfoto 2017-05-14 um 22 30 38" src="https://cloud.githubusercontent.com/assets/245432/26041749/fec7236e-38f4-11e7-9387-d3495e53f057.png">
<img width="1000" alt="bildschirmfoto 2017-05-14 um 22 30 27" src="https://cloud.githubusercontent.com/assets/245432/26041750/fecca154-38f4-11e7-9ccf-508696cf766d.png">