### PR TITLE
Remove primary class from public link download button

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -84,7 +84,7 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 					<div id="imgframe"></div>
 				<?php endif; ?>
 				<div class="directDownload">
-					<a href="<?php p($_['downloadURL']); ?>" id="downloadFile" class="button primary">
+					<a href="<?php p($_['downloadURL']); ?>" id="downloadFile" class="button">
 						<span class="icon icon-download"></span>
 						<?php p($l->t('Download %s', array($_['filename'])))?> (<?php p($_['fileSize']) ?>)
 					</a>


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/4902 – I agree with @LukasReschke this looks strange, and I also just noticed it earlier today.

This was introduced through 4c47b8e3a3b8da9963d29fa7d0fc750c32e5c999 – sorry @skjnldsv ;)

Please review @nextcloud/designers @skjnldsv @juliushaertl @LukasReschke @MorrisJobke 