### PR TITLE
Increase width of clickable area in file row to open file/folder

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -342,6 +342,7 @@ table td.filename .nametext {
 	padding: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	width: 70%;
 	max-width: 800px;
 	height: 100%;
 }


### PR DESCRIPTION
Currently it’s only the width of the filename. This is confusing when clicking right next to it and the sidebar opens instead.

Pleae review @nextcloud/designers 