### PR TITLE
Use more verbose text for upload menu

### DIFF
--- a/apps/files/js/newfilemenu.js
+++ b/apps/files/js/newfilemenu.js
@@ -65,7 +65,7 @@
 
 			this._menuItems = [{
 				id: 'folder',
-				displayName: t('files', 'Folder'),
+				displayName: t('files', 'New folder'),
 				templateName: t('files', 'New folder'),
 				iconClass: 'icon-folder',
 				fileType: 'folder',
@@ -223,7 +223,7 @@
 		render: function() {
 			this.$el.html(this.template({
 				uploadMaxHumanFileSize: 'TODO',
-				uploadLabel: t('files', 'Upload'),
+				uploadLabel: t('files', 'Upload file'),
 				items: this._menuItems
 			}));
 			OC.Util.scaleFixForIE8(this.$('.svg'));


### PR DESCRIPTION
This came up in a usability test. No reason that we are not more verbose here. »Upload« could be understood as a header of the menu, especially when the entries »Folder« and »Text file« are below it and cause many apps distinguish between uploading pictures, videos etc.

![screenshot from 2017-05-16 16-24-25](https://cloud.githubusercontent.com/assets/925062/26158764/022e8842-3b1d-11e7-8d15-682ee3df3301.png)


Please review @nextcloud/designers 