### PR TITLE
Unify box-shadow style, remove filter

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -601,11 +601,7 @@ kbd {
 	margin: 5px;
 	margin-top: -5px;
 	right: 0;
-	-webkit-filter: drop-shadow(0 0 5px $color-box-shadow);
-	-moz-filter: drop-shadow(0 0 5px $color-box-shadow);
-	-ms-filter: drop-shadow(0 0 5px $color-box-shadow);
-	-o-filter: drop-shadow(0 0 5px $color-box-shadow);
-	filter: drop-shadow(0 0 5px $color-box-shadow);
+	box-shadow: 0 1px 10px $color-box-shadow;
 	display: none;
 
 	&:after {

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -27,7 +27,7 @@
 	position: absolute;
 	top: 45px;
 	background-color: #fff;
-	box-shadow: 0 1px 10px rgba(150, 150, 150, 0.75);
+	box-shadow: 0 1px 10px $color-box-shadow;
 	border-radius: 0 0 3px 3px;
 	display: none;
 	box-sizing: border-box;
@@ -508,11 +508,7 @@ nav {
 		top: 45px;
 		transform: translateX(-50%);
 		padding: 4px 10px;
-		-webkit-filter: drop-shadow(0 0 5px rgba(150, 150, 150, .75));
-		-moz-filter: drop-shadow(0 0 5px rgba(150, 150, 150, .75));
-		-ms-filter: drop-shadow(0 0 5px rgba(150, 150, 150, .75));
-		-o-filter: drop-shadow(0 0 5px rgba(150, 150, 150, .75));
-		filter: drop-shadow(0 0 5px rgba(150, 150, 150, .75));
+		box-shadow: 0 1px 10px $color-box-shadow;
 	}
 
 	li:hover span {


### PR DESCRIPTION
The webkit-filter / filter was way too much, and especially made the shadow look double as crazy when both box-shadow and filter was applied.

Please review @nextcloud/designers 