### PR TITLE
Improve design and wording of various error messages

### DIFF
--- a/apps/dav/templates/exception.php
+++ b/apps/dav/templates/exception.php
@@ -23,10 +23,9 @@ style('core', ['styles', 'header']);
 /** @param $_ array */
 ?>
 <span class="error error-wide">
-	<h2><strong><?php p($_['title']) ?></strong></h2>
-	<br>
+	<h2><?php p($_['title']) ?></h2>
 
-	<h2><strong><?php p($l->t('Technical details')) ?></strong></h2>
+	<h3><strong><?php p($l->t('Technical details')) ?></strong></h3>
 	<ul>
 		<li><?php p($l->t('Remote Address: %s', $_['remoteAddr'])) ?></li>
 		<li><?php p($l->t('Request ID: %s', $_['requestID'])) ?></li>

--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -492,6 +492,11 @@ form #selectDbType label.ui-state-active {
 .warning {
 	margin-top: 15px;
 }
+.warning h2,
+.update h2,
+.error h2 {
+	text-align: center;
+}
 .warning.updateAnyways {
 	text-align: center;
 }

--- a/core/templates/error.php
+++ b/core/templates/error.php
@@ -1,10 +1,13 @@
-<ul class="error-wide">
+<div class="error">
+	<h2><?php p($l->t('Error')) ?></h2>
+	<ul>
 	<?php foreach($_["errors"] as $error):?>
-		<li class='error'>
-			<?php p($error['error']) ?><br>
+		<li>
+			<p><?php p($error['error']) ?></p>
 			<?php if(isset($error['hint']) && $error['hint']): ?>
 				<p class='hint'><?php p($error['hint']) ?></p>
 			<?php endif;?>
 		</li>
 	<?php endforeach ?>
-</ul>
+	</ul>
+</div>

--- a/core/templates/exception.php
+++ b/core/templates/exception.php
@@ -25,7 +25,7 @@ style('core', ['styles', 'header']);
 
 	<?php if($_['debugMode']): ?>
 		<br />
-		<h2><strong><?php p($l->t('Trace')) ?></strong></h2>
+		<h3><?php p($l->t('Trace')) ?></h3>
 		<pre><?php p($_['trace']) ?></pre>
 	<?php endif; ?>
 </div>

--- a/core/templates/exception.php
+++ b/core/templates/exception.php
@@ -4,14 +4,13 @@
 
 style('core', ['styles', 'header']);
 ?>
-<span class="error error-wide">
-	<h2><strong><?php p($l->t('Internal Server Error')) ?></strong></h2>
-		<p><?php p($l->t('The server encountered an internal error and was unable to complete your request.')) ?></p>
-		<p><?php p($l->t('Please contact the server administrator if this error reappears multiple times, please include the technical details below in your report.')) ?></p>
-		<p><?php p($l->t('More details can be found in the server log.')) ?></p>
-	<br>
+<div class="error error-wide">
+	<h2><?php p($l->t('Internal Server Error')) ?></h2>
+	<p><?php p($l->t('The server encountered an internal error and was unable to complete your request.')) ?></p>
+	<p><?php p($l->t('Please contact the server administrator if this error reappears multiple times, please include the technical details below in your report.')) ?></p>
+	<p><?php p($l->t('More details can be found in the server log.')) ?></p>
 
-	<h2><strong><?php p($l->t('Technical details')) ?></strong></h2>
+	<h3><?php p($l->t('Technical details')) ?></h3>
 	<ul>
 		<li><?php p($l->t('Remote Address: %s', $_['remoteAddr'])) ?></li>
 		<li><?php p($l->t('Request ID: %s', $_['requestID'])) ?></li>
@@ -29,4 +28,4 @@ style('core', ['styles', 'header']);
 		<h2><strong><?php p($l->t('Trace')) ?></strong></h2>
 		<pre><?php p($_['trace']) ?></pre>
 	<?php endif; ?>
-</span>
+</div>

--- a/core/templates/untrustedDomain.php
+++ b/core/templates/untrustedDomain.php
@@ -1,19 +1,17 @@
 <?php /** @var $_ array */ ?>
 
-<ul class="error-wide">
-	<li class='error'>
-		<?php p($l->t('You are accessing the server from an untrusted domain.')); ?><br>
+<div class="error">
+	<h2><?php p($l->t('Access through untrusted domain')); ?></h2>
 
-		<p class='hint'>
-			<?php p($l->t('Please contact your administrator. If you are an administrator of this instance, configure the "trusted_domains" setting in config/config.php. An example configuration is provided in config/config.sample.php.')); ?>
-			<br>
-			<?php p($l->t('Depending on your configuration, as an administrator you might also be able to use the button below to trust this domain.')); ?>
-			<br><br>
-			<p style="text-align:center;">
-				<a href="<?php print_unescaped(\OC::$server->getURLGenerator()->getAbsoluteURL(\OCP\Util::linkToRoute('settings.AdminSettings.index'))); ?>?trustDomain=<?php p($_['domain']); ?>" class="button">
-					<?php p($l->t('Add "%s" as trusted domain', array($_['domain']))); ?>
-				</a>
-			</p>
-		</p>
-	</li>
-</ul>
+	<p>
+		<?php p($l->t('Please contact your administrator. If you are an administrator of this instance, configure the "trusted_domains" setting in config/config.php. An example configuration is provided in config/config.sample.php.')); ?>
+	</p>
+	<p>
+		<?php p($l->t('Depending on your configuration, as an administrator you might also be able to use the button below to trust this domain.')); ?>
+	</p>
+	<p style="text-align:center;">
+		<a href="<?php print_unescaped(\OC::$server->getURLGenerator()->getAbsoluteURL(\OCP\Util::linkToRoute('settings.AdminSettings.index'))); ?>?trustDomain=<?php p($_['domain']); ?>" class="button">
+			<?php p($l->t('Add "%s" as trusted domain', array($_['domain']))); ?>
+		</a>
+	</p>
+</div>

--- a/core/templates/untrustedDomain.php
+++ b/core/templates/untrustedDomain.php
@@ -4,10 +4,10 @@
 	<h2><?php p($l->t('Access through untrusted domain')); ?></h2>
 
 	<p>
-		<?php p($l->t('Please contact your administrator. If you are an administrator of this instance, configure the "trusted_domains" setting in config/config.php. An example configuration is provided in config/config.sample.php.')); ?>
+		<?php p($l->t('Please contact your administrator. If you are an administrator, edit the "trusted_domains" setting in config/config.php like the example in config.sample.php.')); ?>
 	</p>
 	<p>
-		<?php p($l->t('Depending on your configuration, as an administrator you might also be able to use the button below to trust this domain.')); ?>
+		<?php p($l->t('Depending on your configuration, this button could also work to trust the domain:')); ?>
 	</p>
 	<p style="text-align:center;">
 		<a href="<?php print_unescaped(\OC::$server->getURLGenerator()->getAbsoluteURL(\OCP\Util::linkToRoute('settings.AdminSettings.index'))); ?>?trustDomain=<?php p($_['domain']); ?>" class="button">


### PR DESCRIPTION
This needs to be thoroughly tested and hence is set to Nextcloud 13. We also have to really check when to use `.error` (works for untrusted domain, share link errors etc) and when `.error-wide` (only really needed when there’s big log output or something else verbose).

- Share link errors
- Untrusted domain
- Generic errors

Please review @nextcloud/designers. Is there a way to easily test all the different error pages @rullzer @LukasReschke @MorrisJobke?