### PR TITLE
user_saml is shipped via appstore

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -33,7 +33,6 @@
     "updatenotification",
     "user_external",
     "user_ldap",
-    "user_saml",
     "workflowengine"
   ],
   "alwaysEnabled": [


### PR DESCRIPTION
Keeping it in the shipped.json leads to odd side-effects such as https://help.nextcloud.com/t/earn-a-t-shirt-by-testing-nextcloud-12-beta-2/12374/41?u=lukasreschke in case a previous version was installed.

See https://apps.nextcloud.com/apps/user_saml

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>