### PR TITLE
Add the column so we keep the value from before the update

### DIFF
--- a/apps/federatedfilesharing/tests/Controller/RequestHandlerControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/RequestHandlerControllerTest.php
@@ -381,7 +381,8 @@ class RequestHandlerControllerTest extends TestCase {
 			'accepted' => '0',
 			'expiration' => null,
 			'password' => null,
-			'mail_send' => '0'
+			'mail_send' => '0',
+			'share_name' => null,
 		];
 
 		$searchToken = $correctToken ? 'token' : 'wrongToken';

--- a/db_structure.xml
+++ b/db_structure.xml
@@ -922,6 +922,14 @@
 				<length>1</length>
 			</field>
 
+			<field>
+				<name>share_name</name>
+				<type>text</type>
+				<default></default>
+				<notnull>false</notnull>
+				<length>64</length>
+			</field>
+
 			<index>
 				<name>item_share_type_index</name>
 				<field>

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(12, 0, 0, 21);
+$OC_Version = array(12, 0, 0, 22);
 
 // The human readable string
 $OC_VersionString = '12.0 beta 4';


### PR DESCRIPTION
This retains the share name column from oc migration, in case we want to use it in the future