### PR TITLE
rename secure drop back to files drop

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -441,7 +441,7 @@
 				popoverMenu: popover,
 				publicUploadRWLabel: t('core', 'Allow upload and editing'),
 				publicUploadRLabel: t('core', 'Read only'),
-				publicUploadWLabel: t('core', 'Secure drop (upload only)'),
+				publicUploadWLabel: t('core', 'File drop (upload only)'),
 				publicUploadRWValue: OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_READ | OC.PERMISSION_DELETE,
 				publicUploadRValue: OC.PERMISSION_READ,
 				publicUploadWValue: OC.PERMISSION_CREATE,

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -262,7 +262,7 @@
 				createPermissionLabel: t('core', 'Can create'),
 				updatePermissionLabel: t('core', 'Can change'),
 				deletePermissionLabel: t('core', 'Can delete'),
-				secureDropLabel: t('core', 'Secure drop (upload only)'),
+				secureDropLabel: t('core', 'File drop (upload only)'),
 				expireDateLabel: t('core', 'Set expiration date'),
 				passwordLabel: t('core', 'Password protect'),
 				crudsLabel: t('core', 'Access control'),


### PR DESCRIPTION
rename secure drop back to files drop because of name collision with securedrop.org

fix https://github.com/nextcloud/server/issues/4674