### PR TITLE
Fixes visible sidebar even if hidden is applied

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -117,6 +117,9 @@ kbd {
 		width: 100%;
 		box-sizing: border-box;
 	}
+	&.hidden {
+		display: none;
+	}
 	&.without-app-settings {
 		padding-bottom: 0;
 	}


### PR DESCRIPTION
* the selector for the flexbox was just stronger than the one for hidden - this fixes it
* fixes https://github.com/nextcloud/richdocuments/issues/44

Thanks to @michag86 