### PR TITLE
Mark OAuth app as always enabled

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -41,6 +41,7 @@
     "federatedfilesharing",
     "lookup_server_connector",
     "provisioning_api",
+    "oauth2",
     "twofactor_backupcodes",
     "workflowengine"
   ]

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -140,7 +140,7 @@ class AppManagerTest extends TestCase {
 		$this->assertEquals('no', $this->appConfig->getValue(
 			'some_random_name_which_i_hope_is_not_an_app', 'enabled', 'no'
 		));
-  	}
+	}
 
 	public function testEnableAppForGroups() {
 		$groups = array(
@@ -333,6 +333,7 @@ class AppManagerTest extends TestCase {
 			'federatedfilesharing',
 			'files',
 			'lookup_server_connector',
+			'oauth2',
 			'provisioning_api',
 			'test1',
 			'test3',
@@ -358,11 +359,12 @@ class AppManagerTest extends TestCase {
 			'federatedfilesharing',
 			'files',
 			'lookup_server_connector',
+			'oauth2',
 			'provisioning_api',
 			'test1',
 			'test3',
 			'twofactor_backupcodes',
-			'workflowengine'
+			'workflowengine',
 		];
 		$this->assertEquals($enabled, $this->manager->getEnabledAppsForUser($user));
 	}
@@ -387,6 +389,7 @@ class AppManagerTest extends TestCase {
 			'testnoversion' => ['id' => 'testnoversion', 'requiremin' => '8.2.0'],
 			'twofactor_backupcodes' => ['id' => 'twofactor_backupcodes'],
 			'workflowengine' => ['id' => 'workflowengine'],
+			'oauth2' => ['id' => 'oauth2'],
 		];
 
 		$manager->expects($this->any())
@@ -395,7 +398,7 @@ class AppManagerTest extends TestCase {
 				function($appId) use ($appInfos) {
 					return $appInfos[$appId];
 				}
-		));
+			));
 
 		$this->appConfig->setValue('test1', 'enabled', 'yes');
 		$this->appConfig->setValue('test1', 'installed_version', '1.0.0');
@@ -432,6 +435,7 @@ class AppManagerTest extends TestCase {
 			'testnoversion' => ['id' => 'testnoversion', 'requiremin' => '8.2.0'],
 			'twofactor_backupcodes' => ['id' => 'twofactor_backupcodes'],
 			'workflowengine' => ['id' => 'workflowengine'],
+			'oauth2' => ['id' => 'oauth2'],
 		];
 
 		$manager->expects($this->any())
@@ -440,7 +444,7 @@ class AppManagerTest extends TestCase {
 				function($appId) use ($appInfos) {
 					return $appInfos[$appId];
 				}
-		));
+			));
 
 		$this->appConfig->setValue('test1', 'enabled', 'yes');
 		$this->appConfig->setValue('test2', 'enabled', 'yes');

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -353,6 +353,7 @@ class AppTest extends \Test\TestCase {
 					'dav',
 					'federatedfilesharing',
 					'lookup_server_connector',
+					'oauth2',
 					'provisioning_api',
 					'twofactor_backupcodes',
 					'workflowengine',
@@ -371,6 +372,7 @@ class AppTest extends \Test\TestCase {
 					'dav',
 					'federatedfilesharing',
 					'lookup_server_connector',
+					'oauth2',
 					'provisioning_api',
 					'twofactor_backupcodes',
 					'workflowengine',
@@ -390,6 +392,7 @@ class AppTest extends \Test\TestCase {
 					'dav',
 					'federatedfilesharing',
 					'lookup_server_connector',
+					'oauth2',
 					'provisioning_api',
 					'twofactor_backupcodes',
 					'workflowengine',
@@ -409,6 +412,7 @@ class AppTest extends \Test\TestCase {
 					'dav',
 					'federatedfilesharing',
 					'lookup_server_connector',
+					'oauth2',
 					'provisioning_api',
 					'twofactor_backupcodes',
 					'workflowengine',
@@ -428,6 +432,7 @@ class AppTest extends \Test\TestCase {
 					'dav',
 					'federatedfilesharing',
 					'lookup_server_connector',
+					'oauth2',
 					'provisioning_api',
 					'twofactor_backupcodes',
 					'workflowengine',
@@ -508,11 +513,11 @@ class AppTest extends \Test\TestCase {
 			);
 
 		$apps = \OC_App::getEnabledApps();
-		$this->assertEquals(array('files', 'app3', 'dav', 'federatedfilesharing', 'lookup_server_connector', 'provisioning_api', 'twofactor_backupcodes', 'workflowengine'), $apps);
+		$this->assertEquals(array('files', 'app3', 'dav', 'federatedfilesharing', 'lookup_server_connector', 'oauth2', 'provisioning_api', 'twofactor_backupcodes', 'workflowengine'), $apps);
 
 		// mock should not be called again here
 		$apps = \OC_App::getEnabledApps();
-		$this->assertEquals(array('files', 'app3', 'dav', 'federatedfilesharing', 'lookup_server_connector', 'provisioning_api', 'twofactor_backupcodes', 'workflowengine'), $apps);
+		$this->assertEquals(array('files', 'app3', 'dav', 'federatedfilesharing', 'lookup_server_connector', 'oauth2', 'provisioning_api', 'twofactor_backupcodes', 'workflowengine'), $apps);
 
 		$this->restoreAppConfig();
 		\OC_User::setUserId(null);


### PR DESCRIPTION
At the moment we don't support disabling the OAuth app

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>