### PR TITLE
Add layer on top of LDAP methods to catch server disconnects and attempt re-connection

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -47,6 +47,8 @@ use OCA\User_LDAP\User\Manager;
 use OCA\User_LDAP\User\OfflineUser;
 use OCA\User_LDAP\Mapping\AbstractMapping;
 
+use OC\ServerNotAvailableException;
+
 /**
  * Class Access
  * @package OCA\User_LDAP
@@ -167,12 +169,6 @@ class Access extends LDAPUtility implements IUserTools {
 				\OCP\Util::WARN);
 			return false;
 		}
-		$cr = $this->connection->getConnectionResource();
-		if(!$this->ldap->isResource($cr)) {
-			//LDAP not available
-			\OCP\Util::writeLog('user_ldap', 'LDAP resource not available.', \OCP\Util::DEBUG);
-			return false;
-		}
 		//Cancel possibly running Paged Results operation, otherwise we run in
 		//LDAP protocol errors
 		$this->abandonPagedSearch();
@@ -190,7 +186,7 @@ class Access extends LDAPUtility implements IUserTools {
 		$values = [];
 		$isRangeRequest = false;
 		do {
-			$result = $this->executeRead($cr, $dn, $attrToRead, $filter, $maxResults);
+			$result = $this->executeRead($dn, $attrToRead, $filter, $maxResults);
 			if(is_bool($result)) {
 				// when an exists request was run and it was successful, an empty
 				// array must be returned
@@ -232,7 +228,6 @@ class Access extends LDAPUtility implements IUserTools {
 	/**
 	 * Runs an read operation against LDAP
 	 *
-	 * @param resource $cr the LDAP connection
 	 * @param string $dn
 	 * @param string $attribute
 	 * @param string $filter
@@ -241,10 +236,10 @@ class Access extends LDAPUtility implements IUserTools {
 	 *                    was performed and the requested DN found, array with the
 	 *                    returned data on a successful usual operation
 	 */
-	public function executeRead($cr, $dn, $attribute, $filter, $maxResults) {
+	public function executeRead($dn, $attribute, $filter, $maxResults) {
 		$this->initPagedSearch($filter, array($dn), array($attribute), $maxResults, 0);
 		$dn = $this->helper->DNasBaseParameter($dn);
-		$rr = @$this->ldap->read($cr, $dn, $filter, array($attribute));
+		$rr = @$this->invokeLDAPMethod('read', $dn, $filter, array($attribute));
 		if (!$this->ldap->isResource($rr)) {
 			if ($attribute !== '') {
 				//do not throw this message on userExists check, irritates
@@ -253,18 +248,18 @@ class Access extends LDAPUtility implements IUserTools {
 			//in case an error occurs , e.g. object does not exist
 			return false;
 		}
-		if ($attribute === '' && ($filter === 'objectclass=*' || $this->ldap->countEntries($cr, $rr) === 1)) {
+		if ($attribute === '' && ($filter === 'objectclass=*' || $this->invokeLDAPMethod('countEntries', $rr) === 1)) {
 			\OCP\Util::writeLog('user_ldap', 'readAttribute: ' . $dn . ' found', \OCP\Util::DEBUG);
 			return true;
 		}
-		$er = $this->ldap->firstEntry($cr, $rr);
+		$er = $this->invokeLDAPMethod('firstEntry', $rr);
 		if (!$this->ldap->isResource($er)) {
 			//did not match the filter, return false
 			return false;
 		}
 		//LDAP attributes are not case sensitive
 		$result = \OCP\Util::mb_array_change_key_case(
-			$this->ldap->getAttributes($cr, $er), MB_CASE_LOWER, 'UTF-8');
+			$this->invokeLDAPMethod('getAttributes', $er), MB_CASE_LOWER, 'UTF-8');
 
 		return $result;
 	}
@@ -337,15 +332,8 @@ class Access extends LDAPUtility implements IUserTools {
 		if(intval($this->connection->turnOnPasswordChange) !== 1) {
 			throw new \Exception('LDAP password changes are disabled.');
 		}
-		$cr = $this->connection->getConnectionResource();
-		if(!$this->ldap->isResource($cr)) {
-			//LDAP not available
-			\OCP\Util::writeLog('user_ldap', 'LDAP resource not available.', \OCP\Util::DEBUG);
-			return false;
-		}
-		
 		try {
-			return $this->ldap->modReplace($cr, $userDN, $password);
+			return $this->invokeLDAPMethod('modReplace', $userDN, $password);
 		} catch(ConstraintViolationException $e) {
 			throw new HintException('Password change rejected.', \OC::$server->getL10N('user_ldap')->t('Password change rejected. Hint: ').$e->getMessage(), $e->getCode());
 		}
@@ -938,6 +926,52 @@ class Access extends LDAPUtility implements IUserTools {
 	}
 
 	/**
+	 * @return mixed
+	 */
+	private function invokeLDAPMethod() {
+		$arguments = func_get_args();
+		$command = array_shift($arguments);
+		if (!method_exists($this->ldap, $command)) {
+			return null;
+		}
+		$cr = $this->connection->getConnectionResource();
+		if(!$this->ldap->isResource($cr)) {
+			// Seems like we didn't find any resource.
+			\OCP\Util::writeLog('user_ldap', "Could not $command, because resource is missing.", \OCP\Util::DEBUG);
+			return false;
+		}
+		array_unshift($arguments, $cr);
+		// php no longer supports call-time pass-by-reference
+		// make special case for controlPagedResultResponse as the third argument is a reference
+		$doMethod = function () use ($command, &$arguments) {
+			if ($command == 'controlPagedResultResponse') {
+				return $this->ldap->controlPagedResultResponse($arguments[0], $arguments[1], $arguments[2]);
+			} else {
+				return call_user_func_array(array($this->ldap, $command), $arguments);
+			}
+		};
+		try {
+			$ret = $doMethod();
+		} catch (ServerNotAvailableException $e) {
+			/* Server connection lost, attempt to reestablish it
+			 * Maybe implement exponential backoff?
+			 * This was enough to get solr indexer working which has large delays between LDAP fetches.
+			 */
+			\OCP\Util::writeLog('user_ldap', "Connection lost on $command, attempting to reestablish.", \OCP\Util::DEBUG);
+			$this->connection = clone $this->connection;
+			$cr = $this->connection->getConnectionResource();
+			if(!$this->ldap->isResource($cr)) {
+				// Seems like we didn't find any resource.
+				\OCP\Util::writeLog('user_ldap', "Could not $command, because resource is missing.", \OCP\Util::DEBUG);
+				return false;
+			}
+			$arguments[0] = $cr;
+			$ret = $doMethod();
+		}
+		return $ret;
+	}
+
+	/**
 	 * retrieved. Results will according to the order in the array.
 	 * @param int $limit optional, maximum results to be counted
 	 * @param int $offset optional, a starting point
@@ -962,7 +996,23 @@ class Access extends LDAPUtility implements IUserTools {
 		$pagedSearchOK = $this->initPagedSearch($filter, $base, $attr, intval($limit), $offset);
 
 		$linkResources = array_pad(array(), count($base), $cr);
-		$sr = $this->ldap->search($linkResources, $base, $filter, $attr);
+		try {
+			$sr = $this->ldap->search($linkResources, $base, $filter, $attr);
+		} catch (ServerNotAvailableException $e) {
+			/* Server connection lost, attempt to reestablish it
+			 * According to MS docs, LDAP cookies survive reconnects
+			 */
+			\OCP\Util::writeLog('user_ldap', "Connection lost on search, attempting to reestablish.", \OCP\Util::DEBUG);
+			$this->connection = clone $this->connection;
+			$cr = $this->connection->getConnectionResource();
+			if(!$this->ldap->isResource($cr)) {
+				// Seems like we didn't find any resource.
+				\OCP\Util::writeLog('user_ldap', "Could not search, because resource is missing.", \OCP\Util::DEBUG);
+				return false;
+			}
+			$linkResources = array_pad(array(), count($base), $cr);
+			$sr = $this->ldap->search($linkResources, $base, $filter, $attr);
+		}
 		$error = $this->ldap->errno($cr);
 		if(!is_array($sr) || $error !== 0) {
 			\OCP\Util::writeLog('user_ldap', 'Attempt for Paging?  '.print_r($pagedSearchOK, true), \OCP\Util::ERROR);
@@ -990,7 +1040,7 @@ class Access extends LDAPUtility implements IUserTools {
 		if($pagedSearchOK) {
 			$cr = $this->connection->getConnectionResource();
 			foreach($sr as $key => $res) {
-				if($this->ldap->controlPagedResultResponse($cr, $res, $cookie)) {
+				if($this->invokeLDAPMethod('controlPagedResultResponse', $res, $cookie)) {
 					$this->setPagedResultCookie($base[$key], $filter, $limit, $offset, $cookie);
 				}
 			}
@@ -1079,7 +1129,7 @@ class Access extends LDAPUtility implements IUserTools {
 		$counter = 0;
 
 		foreach($searchResults as $res) {
-			$count = intval($this->ldap->countEntries($cr, $res));
+			$count = intval($this->invokeLDAPMethod('countEntries', $res));
 			$counter += $count;
 		}
 
@@ -1129,7 +1179,7 @@ class Access extends LDAPUtility implements IUserTools {
 			}
 
 			foreach($sr as $res) {
-				$findings = array_merge($findings, $this->ldap->getEntries($cr	, $res ));
+				$findings = array_merge($findings, $this->invokeLDAPMethod('getEntries', $res));
 			}
 
 			$continue = $this->processPagedSearchStatus($sr, $filter, $base, $findings['count'],
@@ -1691,8 +1741,7 @@ class Access extends LDAPUtility implements IUserTools {
 	 */
 	private function abandonPagedSearch() {
 		if($this->connection->hasPagedResultSupport) {
-			$cr = $this->connection->getConnectionResource();
-			$this->ldap->controlPagedResult($cr, 0, false, $this->lastCookie);
+			$this->invokeLDAPMethod('controlPagedResult', 0, false, $this->lastCookie);
 			$this->getPagedSearchResultState();
 			$this->lastCookie = '';
 			$this->cookies = array();
@@ -1818,9 +1867,7 @@ class Access extends LDAPUtility implements IUserTools {
 				if(!is_null($cookie)) {
 					//since offset = 0, this is a new search. We abandon other searches that might be ongoing.
 					$this->abandonPagedSearch();
-					$pagedSearchOK = $this->ldap->controlPagedResult(
-						$this->connection->getConnectionResource(), $limit,
-						false, $cookie);
+					$pagedSearchOK = $this->invokeLDAPMethod('controlPagedResult', $limit, false, $cookie);
 					if(!$pagedSearchOK) {
 						return false;
 					}
@@ -1846,9 +1893,7 @@ class Access extends LDAPUtility implements IUserTools {
 			// in case someone set it to 0 … use 500, otherwise no results will
 			// be returned.
 			$pageSize = intval($this->connection->ldapPagingSize) > 0 ? intval($this->connection->ldapPagingSize) : 500;
-			$pagedSearchOK = $this->ldap->controlPagedResult(
-				$this->connection->getConnectionResource(), $pageSize, false, ''
-			);
+			$pagedSearchOK = $this->invokeLDAPMethod('controlPagedResult', $pageSize, false, '');
 		}
 
 		return $pagedSearchOK;

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -169,6 +169,12 @@ class Access extends LDAPUtility implements IUserTools {
 				\OCP\Util::WARN);
 			return false;
 		}
+		$cr = $this->connection->getConnectionResource();
+		if(!$this->ldap->isResource($cr)) {
+			//LDAP not available
+			\OCP\Util::writeLog('user_ldap', 'LDAP resource not available.', \OCP\Util::DEBUG);
+			return false;
+		}
 		//Cancel possibly running Paged Results operation, otherwise we run in
 		//LDAP protocol errors
 		$this->abandonPagedSearch();
@@ -186,7 +192,7 @@ class Access extends LDAPUtility implements IUserTools {
 		$values = [];
 		$isRangeRequest = false;
 		do {
-			$result = $this->executeRead($dn, $attrToRead, $filter, $maxResults);
+			$result = $this->executeRead($cr, $dn, $attrToRead, $filter, $maxResults);
 			if(is_bool($result)) {
 				// when an exists request was run and it was successful, an empty
 				// array must be returned
@@ -228,6 +234,7 @@ class Access extends LDAPUtility implements IUserTools {
 	/**
 	 * Runs an read operation against LDAP
 	 *
+	 * @param resource $cr the LDAP connection
 	 * @param string $dn
 	 * @param string $attribute
 	 * @param string $filter
@@ -236,10 +243,10 @@ class Access extends LDAPUtility implements IUserTools {
 	 *                    was performed and the requested DN found, array with the
 	 *                    returned data on a successful usual operation
 	 */
-	public function executeRead($dn, $attribute, $filter, $maxResults) {
+	public function executeRead($cr, $dn, $attribute, $filter, $maxResults) {
 		$this->initPagedSearch($filter, array($dn), array($attribute), $maxResults, 0);
 		$dn = $this->helper->DNasBaseParameter($dn);
-		$rr = @$this->invokeLDAPMethod('read', $dn, $filter, array($attribute));
+		$rr = @$this->invokeLDAPMethod('read', $cr, $dn, $filter, array($attribute));
 		if (!$this->ldap->isResource($rr)) {
 			if ($attribute !== '') {
 				//do not throw this message on userExists check, irritates
@@ -248,18 +255,18 @@ class Access extends LDAPUtility implements IUserTools {
 			//in case an error occurs , e.g. object does not exist
 			return false;
 		}
-		if ($attribute === '' && ($filter === 'objectclass=*' || $this->invokeLDAPMethod('countEntries', $rr) === 1)) {
+		if ($attribute === '' && ($filter === 'objectclass=*' || $this->invokeLDAPMethod('countEntries', $cr, $rr) === 1)) {
 			\OCP\Util::writeLog('user_ldap', 'readAttribute: ' . $dn . ' found', \OCP\Util::DEBUG);
 			return true;
 		}
-		$er = $this->invokeLDAPMethod('firstEntry', $rr);
+		$er = $this->invokeLDAPMethod('firstEntry', $cr, $rr);
 		if (!$this->ldap->isResource($er)) {
 			//did not match the filter, return false
 			return false;
 		}
 		//LDAP attributes are not case sensitive
 		$result = \OCP\Util::mb_array_change_key_case(
-			$this->invokeLDAPMethod('getAttributes', $er), MB_CASE_LOWER, 'UTF-8');
+			$this->invokeLDAPMethod('getAttributes', $cr, $er), MB_CASE_LOWER, 'UTF-8');
 
 		return $result;
 	}
@@ -332,8 +339,14 @@ class Access extends LDAPUtility implements IUserTools {
 		if(intval($this->connection->turnOnPasswordChange) !== 1) {
 			throw new \Exception('LDAP password changes are disabled.');
 		}
+		$cr = $this->connection->getConnectionResource();
+		if(!$this->ldap->isResource($cr)) {
+			//LDAP not available
+			\OCP\Util::writeLog('user_ldap', 'LDAP resource not available.', \OCP\Util::DEBUG);
+			return false;
+		}
 		try {
-			return $this->invokeLDAPMethod('modReplace', $userDN, $password);
+			return $this->invokeLDAPMethod('modReplace', $cr, $userDN, $password);
 		} catch(ConstraintViolationException $e) {
 			throw new HintException('Password change rejected.', \OC::$server->getL10N('user_ldap')->t('Password change rejected. Hint: ').$e->getMessage(), $e->getCode());
 		}
@@ -926,19 +939,20 @@ class Access extends LDAPUtility implements IUserTools {
 	}
 
 	/**
+	 * Returns the LDAP handler
+	 * @throws \OC\ServerNotAvailableException
+	 */
+
+	/**
 	 * @return mixed
+	 * @throws \OC\ServerNotAvailableException
 	 */
 	private function invokeLDAPMethod() {
 		$arguments = func_get_args();
 		$command = array_shift($arguments);
+		$cr = array_shift($arguments);
 		if (!method_exists($this->ldap, $command)) {
 			return null;
-		}
-		$cr = $this->connection->getConnectionResource();
-		if(!$this->ldap->isResource($cr)) {
-			// Seems like we didn't find any resource.
-			\OCP\Util::writeLog('user_ldap', "Could not $command, because resource is missing.", \OCP\Util::DEBUG);
-			return false;
 		}
 		array_unshift($arguments, $cr);
 		// php no longer supports call-time pass-by-reference
@@ -977,6 +991,7 @@ class Access extends LDAPUtility implements IUserTools {
 	 * @param int $offset optional, a starting point
 	 * @return array|false array with the search result as first value and pagedSearchOK as
 	 * second | false if not successful
+	 * @throws \OC\ServerNotAvailableException
 	 */
 	private function executeSearch($filter, $base, &$attr = null, $limit = null, $offset = null) {
 		if(!is_null($attr) && !is_array($attr)) {
@@ -996,23 +1011,7 @@ class Access extends LDAPUtility implements IUserTools {
 		$pagedSearchOK = $this->initPagedSearch($filter, $base, $attr, intval($limit), $offset);
 
 		$linkResources = array_pad(array(), count($base), $cr);
-		try {
-			$sr = $this->ldap->search($linkResources, $base, $filter, $attr);
-		} catch (ServerNotAvailableException $e) {
-			/* Server connection lost, attempt to reestablish it
-			 * According to MS docs, LDAP cookies survive reconnects
-			 */
-			\OCP\Util::writeLog('user_ldap', "Connection lost on search, attempting to reestablish.", \OCP\Util::DEBUG);
-			$this->connection = clone $this->connection;
-			$cr = $this->connection->getConnectionResource();
-			if(!$this->ldap->isResource($cr)) {
-				// Seems like we didn't find any resource.
-				\OCP\Util::writeLog('user_ldap', "Could not search, because resource is missing.", \OCP\Util::DEBUG);
-				return false;
-			}
-			$linkResources = array_pad(array(), count($base), $cr);
-			$sr = $this->ldap->search($linkResources, $base, $filter, $attr);
-		}
+		$sr = $this->invokeLDAPMethod('search', $linkResources, $base, $filter, $attr);
 		$error = $this->ldap->errno($cr);
 		if(!is_array($sr) || $error !== 0) {
 			\OCP\Util::writeLog('user_ldap', 'Attempt for Paging?  '.print_r($pagedSearchOK, true), \OCP\Util::ERROR);
@@ -1040,7 +1039,7 @@ class Access extends LDAPUtility implements IUserTools {
 		if($pagedSearchOK) {
 			$cr = $this->connection->getConnectionResource();
 			foreach($sr as $key => $res) {
-				if($this->invokeLDAPMethod('controlPagedResultResponse', $res, $cookie)) {
+				if($this->invokeLDAPMethod('controlPagedResultResponse', $cr, $res, $cookie)) {
 					$this->setPagedResultCookie($base[$key], $filter, $limit, $offset, $cookie);
 				}
 			}
@@ -1129,7 +1128,7 @@ class Access extends LDAPUtility implements IUserTools {
 		$counter = 0;
 
 		foreach($searchResults as $res) {
-			$count = intval($this->invokeLDAPMethod('countEntries', $res));
+			$count = intval($this->invokeLDAPMethod('countEntries', $cr, $res));
 			$counter += $count;
 		}
 
@@ -1179,7 +1178,7 @@ class Access extends LDAPUtility implements IUserTools {
 			}
 
 			foreach($sr as $res) {
-				$findings = array_merge($findings, $this->invokeLDAPMethod('getEntries', $res));
+				$findings = array_merge($findings, $this->invokeLDAPMethod('getEntries', $cr, $res));
 			}
 
 			$continue = $this->processPagedSearchStatus($sr, $filter, $base, $findings['count'],
@@ -1741,7 +1740,8 @@ class Access extends LDAPUtility implements IUserTools {
 	 */
 	private function abandonPagedSearch() {
 		if($this->connection->hasPagedResultSupport) {
-			$this->invokeLDAPMethod('controlPagedResult', 0, false, $this->lastCookie);
+			$cr = $this->connection->getConnectionResource();
+			$this->invokeLDAPMethod('controlPagedResult', $cr, 0, false, $this->lastCookie);
 			$this->getPagedSearchResultState();
 			$this->lastCookie = '';
 			$this->cookies = array();
@@ -1867,7 +1867,9 @@ class Access extends LDAPUtility implements IUserTools {
 				if(!is_null($cookie)) {
 					//since offset = 0, this is a new search. We abandon other searches that might be ongoing.
 					$this->abandonPagedSearch();
-					$pagedSearchOK = $this->invokeLDAPMethod('controlPagedResult', $limit, false, $cookie);
+					$pagedSearchOK = $this->invokeLDAPMethod('controlPagedResult',
+						$this->connection->getConnectionResource(), $limit,
+						false, $cookie);
 					if(!$pagedSearchOK) {
 						return false;
 					}
@@ -1893,7 +1895,9 @@ class Access extends LDAPUtility implements IUserTools {
 			// in case someone set it to 0 … use 500, otherwise no results will
 			// be returned.
 			$pageSize = intval($this->connection->ldapPagingSize) > 0 ? intval($this->connection->ldapPagingSize) : 500;
-			$pagedSearchOK = $this->invokeLDAPMethod('controlPagedResult', $pageSize, false, '');
+			$pagedSearchOK = $this->invokeLDAPMethod('controlPagedResult',
+				$this->connection->getConnectionResource(),
+				$pageSize, false, '');
 		}
 
 		return $pagedSearchOK;


### PR DESCRIPTION
This pull request adds a wrapper to calls to LDAP.php in order to trap server disconnects and attempt a reconnect. This happens on long running processes such as nextant solr indexer when the AD server times out the connection. This solves nextcloud/nextant#175 for me.

