### PR TITLE
Make rename file tooltip error text change

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2140,6 +2140,7 @@
 				} catch (error) {
 					input.attr('title', error);
 					input.tooltip({placement: 'right', trigger: 'manual'});
+					input.tooltip('fixTitle');
 					input.tooltip('show');
 					input.addClass('error');
 				}
@@ -2154,6 +2155,7 @@
 				} catch (error) {
 					input.attr('title', error);
 					input.tooltip({placement: 'right', trigger: 'manual'});
+					input.tooltip('fixTitle');
 					input.tooltip('show');
 					input.addClass('error');
 				}

--- a/apps/files/js/newfilemenu.js
+++ b/apps/files/js/newfilemenu.js
@@ -156,6 +156,7 @@
 				} catch (error) {
 					$input.attr('title', error);
 					$input.tooltip({placement: 'right', trigger: 'manual'});
+					$input.tooltip('fixTitle');
 					$input.tooltip('show');
 					$input.addClass('error');
 				}


### PR DESCRIPTION
Issue: #5001 

Problem:
1) Create 2 files in a folder
2) Rename one file, first blank out the whole file name and file type. "File name cannot be empty" is displayed in the tooltip -good.
3) Now type a name that exactly matches the name of the other file in the folder. The tooltip displays again, but it still says "File name cannot be empty".

After this fix, at step (3) the tooltip pops up and says "file.type already exists"
and as you blank out the filename, put a single "." etc, the tooltip text changes.