### PR TITLE
Reset opcache if update is detected

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -292,6 +292,9 @@ class OC {
 	 */
 	public static function checkUpgrade($showTemplate = true) {
 		if (\OCP\Util::needUpgrade()) {
+			if (function_exists('opcache_reset')) {
+				opcache_reset();
+			}
 			$systemConfig = \OC::$server->getSystemConfig();
 			if ($showTemplate && !$systemConfig->getValue('maintenance', false)) {
 				self::printUpgradePage();


### PR DESCRIPTION
This even works if opcache_reset is in the disabled_functions php.ini setting.

As discussed with @LukasReschke - this should solve the issue with the shortly visible maintenance mode page.