### PR TITLE
[stable12] Update acceptance tests for issue #4921

### DIFF
--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -210,6 +210,13 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function detailsMenuItem() {
+		return self::fileActionsMenuItemFor("Details");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function viewFileInFolderMenuItem() {
 		return self::fileActionsMenuItemFor("View in folder");
 	}
@@ -234,7 +241,9 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @Given I open the details view for :fileName
 	 */
 	public function iOpenTheDetailsViewFor($fileName) {
-		$this->actor->find(self::mainLinkForFile($fileName), 10)->click();
+		$this->actor->find(self::fileActionsMenuButtonForFile($fileName), 10)->click();
+
+		$this->actor->find(self::detailsMenuItem(), 2)->click();
 	}
 
 	/**


### PR DESCRIPTION
Acceptance tests opened the details view by clicking on the middle of
the file row, but due to the changes made in issue #4921 that now opens
the file instead; this commit updates the acceptance tests to open the
details view through the "Details" item in the file actions menu.

* fixes #5012 for stable12

