### PR TITLE
Prefer custom theme over the theming app

### DIFF
--- a/apps/theming/appinfo/app.php
+++ b/apps/theming/appinfo/app.php
@@ -23,33 +23,39 @@
  *
  */
 
-$linkToCSS = \OC::$server->getURLGenerator()->linkToRoute(
-	'theming.Theming.getStylesheet',
-	[
-		'v' => \OC::$server->getConfig()->getAppValue('theming', 'cachebuster', '0'),
-	]
-);
-\OCP\Util::addHeader(
-	'link',
-	[
-		'rel' => 'stylesheet',
-		'href' => $linkToCSS,
-	]
-);
-
-$linkToJs = \OC::$server->getURLGenerator()->linkToRoute(
-	'theming.Theming.getJavascript',
-	[
-		'v' => \OC::$server->getConfig()->getAppValue('theming', 'cachebuster', '0'),
-	]
-);
-\OCP\Util::addHeader(
-	'script',
-	[
-		'src' => $linkToJs,
-		'nonce' => \OC::$server->getContentSecurityPolicyNonceManager()->getNonce()
-	], ''
-);
-
 $app = new \OCP\AppFramework\App('theming');
-$app->getContainer()->registerCapability(\OCA\Theming\Capabilities::class);
+/** @var \OCA\Theming\Util $util */
+$util = $app->getContainer()->query(\OCA\Theming\Util::class);
+if(!$util->isAlreadyThemed()) {
+
+	$app->getContainer()->registerCapability(\OCA\Theming\Capabilities::class);
+
+	$linkToCSS = \OC::$server->getURLGenerator()->linkToRoute(
+		'theming.Theming.getStylesheet',
+		[
+			'v' => \OC::$server->getConfig()->getAppValue('theming', 'cachebuster', '0'),
+		]
+	);
+	\OCP\Util::addHeader(
+		'link',
+		[
+			'rel' => 'stylesheet',
+			'href' => $linkToCSS,
+		]
+	);
+
+	$linkToJs = \OC::$server->getURLGenerator()->linkToRoute(
+		'theming.Theming.getJavascript',
+		[
+			'v' => \OC::$server->getConfig()->getAppValue('theming', 'cachebuster', '0'),
+		]
+	);
+	\OCP\Util::addHeader(
+		'script',
+		[
+			'src' => $linkToJs,
+			'nonce' => \OC::$server->getContentSecurityPolicyNonceManager()->getNonce()
+		], ''
+	);
+
+}

--- a/apps/theming/lib/Util.php
+++ b/apps/theming/lib/Util.php
@@ -199,4 +199,17 @@ class Util {
 		return $svg;
 	}
 
+	/**
+	 * Check if a custom theme is set in the server configuration
+	 * 
+	 * @return bool
+	 */
+	public function isAlreadyThemed() {
+		$theme = $this->config->getSystemValue('theme', '');
+		if ($theme !== '') {
+			return true;
+		}
+		return false;
+	}
+
 }

--- a/apps/theming/tests/UtilTest.php
+++ b/apps/theming/tests/UtilTest.php
@@ -180,4 +180,24 @@ class UtilTest extends TestCase {
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testIsAlreadyThemedFalse() {
+		$theme = $this->config->getSystemValue('theme', '');
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('theme', '')
+			->willReturn('');
+		$actual = $this->util->isAlreadyThemed();
+		$this->assertFalse($actual);
+	}
+
+	public function testIsAlreadyThemedTrue() {
+		$theme = $this->config->getSystemValue('theme', '');
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('theme', '')
+			->willReturn('example');
+		$actual = $this->util->isAlreadyThemed();
+		$this->assertTrue($actual);
+	}
+
 }

--- a/core/js/mimetype.js
+++ b/core/js/mimetype.js
@@ -91,7 +91,7 @@ OC.MimeType = {
 				path += icon;
 			}
 		}
-		if(OCA.Theming) {
+		if(OCA.Theming && gotIcon === null) {
 			path = OC.generateUrl('/apps/theming/img/core/filetypes/');
 			path += OC.MimeType._getFile(mimeType, OC.MimeTypeList.files);
 			gotIcon = true;

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -166,19 +166,7 @@ class URLGenerator implements IURLGenerator {
 		// Check if the app is in the app folder
 		$path = '';
 		$themingEnabled = $this->config->getSystemValue('installed', false) && \OCP\App::isEnabled('theming') && \OC_App::isAppLoaded('theming');
-		if($themingEnabled && $image === 'favicon.ico' && \OC::$server->getThemingDefaults()->shouldReplaceIcons()) {
-			$cacheBusterValue = $this->config->getAppValue('theming', 'cachebuster', '0');
-			if($app === '') { $app = 'core'; }
-			$path = $this->linkToRoute('theming.Icon.getFavicon', [ 'app' => $app ]) . '?v='. $cacheBusterValue;
-		} elseif($themingEnabled && $image === 'favicon-touch.png' && \OC::$server->getThemingDefaults()->shouldReplaceIcons()) {
-			$cacheBusterValue = $this->config->getAppValue('theming', 'cachebuster', '0');
-			if($app === '') { $app = 'core'; }
-			$path = $this->linkToRoute('theming.Icon.getTouchIcon', [ 'app' => $app ]) . '?v='. $cacheBusterValue;
-		} elseif($themingEnabled && $image === 'favicon-fb.png' && \OC::$server->getThemingDefaults()->shouldReplaceIcons()) {
-			$cacheBusterValue = $this->config->getAppValue('theming', 'cachebuster', '0');
-			if($app === '') { $app = 'core'; }
-			$path = $this->linkToRoute('theming.Icon.getTouchIcon', [ 'app' => $app ]) . '?v='. $cacheBusterValue;
-		} elseif (file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$image")) {
+		if (file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$image")) {
 			$path = \OC::$WEBROOT . "/themes/$theme/apps/$app/img/$image";
 		} elseif (!file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$basename.svg")
 			&& file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$basename.png")) {
@@ -193,6 +181,14 @@ class URLGenerator implements IURLGenerator {
 		} elseif (!file_exists(\OC::$SERVERROOT . "/themes/$theme/core/img/$basename.svg")
 			&& file_exists(\OC::$SERVERROOT . "/themes/$theme/core/img/$basename.png")) {
 			$path =  \OC::$WEBROOT . "/themes/$theme/core/img/$basename.png";
+		} elseif($themingEnabled && $image === "favicon.ico" && \OC::$server->getThemingDefaults()->shouldReplaceIcons()) {
+			$cacheBusterValue = $this->config->getAppValue('theming', 'cachebuster', '0');
+			if($app==="") { $app = "core"; }
+			$path = $this->linkToRoute('theming.Icon.getFavicon', [ 'app' => $app ]) . '?v='. $cacheBusterValue;
+		} elseif($themingEnabled && $image === "favicon-touch.png" && \OC::$server->getThemingDefaults()->shouldReplaceIcons()) {
+			$cacheBusterValue = $this->config->getAppValue('theming', 'cachebuster', '0');
+			if($app==="") { $app = "core"; }
+			$path = $this->linkToRoute('theming.Icon.getTouchIcon', [ 'app' => $app ]) . '?v='. $cacheBusterValue;
 		} elseif ($appPath && file_exists($appPath . "/img/$image")) {
 			$path =  \OC_App::getAppWebPath($app) . "/img/$image";
 		} elseif ($appPath && !file_exists($appPath . "/img/$basename.svg")


### PR DESCRIPTION
This PR will prevent the theming app from loading its CSS/JavaScript/Images in case a custom theme is used.

This occured in https://github.com/nextcloud/server/issues/5036 and https://github.com/nextcloud/server/issues/3094 

I think this is better default behavior.

