### PR TITLE
add new config switched for the global scale architecture

### DIFF
--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -30,6 +30,7 @@ use OCA\FederatedFileSharing\Controller\RequestHandlerController;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\FederatedFileSharing\Notifications;
 use OCP\AppFramework\App;
+use OCP\GlobalScale\IConfig;
 
 class Application extends App {
 
@@ -91,6 +92,7 @@ class Application extends App {
 	 * initialize federated share provider
 	 */
 	protected function initFederatedShareProvider() {
+		$c = $this->getContainer();
 		$addressHandler = new \OCA\FederatedFileSharing\AddressHandler(
 			\OC::$server->getURLGenerator(),
 			\OC::$server->getL10N('federatedfilesharing'),
@@ -116,7 +118,8 @@ class Application extends App {
 			\OC::$server->getLazyRootFolder(),
 			\OC::$server->getConfig(),
 			\OC::$server->getUserManager(),
-			\OC::$server->getCloudIdManager()
+			\OC::$server->getCloudIdManager(),
+			$c->query(IConfig::class)
 		);
 	}
 

--- a/apps/federatedfilesharing/lib/Settings/Admin.php
+++ b/apps/federatedfilesharing/lib/Settings/Admin.php
@@ -25,6 +25,7 @@ namespace OCA\FederatedFileSharing\Settings;
 
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\GlobalScale\IConfig;
 use OCP\Settings\ISettings;
 
 class Admin implements ISettings {
@@ -32,15 +33,27 @@ class Admin implements ISettings {
 	/** @var FederatedShareProvider */
 	private $fedShareProvider;
 
-	public function __construct(FederatedShareProvider $fedShareProvider) {
+	/** @var IConfig */
+	private $gsConfig;
+
+	/**
+	 * Admin constructor.
+	 *
+	 * @param FederatedShareProvider $fedShareProvider
+	 * @param IConfig $globalScaleConfig
+	 */
+	public function __construct(FederatedShareProvider $fedShareProvider, IConfig $globalScaleConfig) {
 		$this->fedShareProvider = $fedShareProvider;
+		$this->gsConfig = $globalScaleConfig;
 	}
 
 	/**
 	 * @return TemplateResponse
 	 */
 	public function getForm() {
+
 		$parameters = [
+			'internalOnly' => $this->gsConfig->onlyInternalFederation(),
 			'outgoingServer2serverShareEnabled' => $this->fedShareProvider->isOutgoingServer2serverShareEnabled(),
 			'incomingServer2serverShareEnabled' => $this->fedShareProvider->isIncomingServer2serverShareEnabled(),
 			'lookupServerEnabled' => $this->fedShareProvider->isLookupServerQueriesEnabled(),

--- a/apps/federatedfilesharing/settings-personal.php
+++ b/apps/federatedfilesharing/settings-personal.php
@@ -53,7 +53,7 @@ if(\OC::$server->getAppManager()->isEnabledForUser("theming")) {
 			$textColor = "#000000";
 		}
 	} catch (OCP\AppFramework\QueryException $e) {
-		
+
 	}
 }
 

--- a/apps/federatedfilesharing/templates/settings-admin.php
+++ b/apps/federatedfilesharing/templates/settings-admin.php
@@ -4,6 +4,8 @@
 script('federatedfilesharing', 'settings-admin');
 ?>
 
+<?php if($_['internalOnly'] === false): ?>
+
 <div id="fileSharingSettings" class="followupsection">
 	<h3><?php p($l->t('Federated Cloud Sharing'));?></h3>
 	<a target="_blank" rel="noreferrer" class="icon-info svg"
@@ -42,3 +44,5 @@ script('federatedfilesharing', 'settings-admin');
 	</p>
 
 </div>
+
+<?php endif; ?>

--- a/apps/federatedfilesharing/tests/Settings/AdminTest.php
+++ b/apps/federatedfilesharing/tests/Settings/AdminTest.php
@@ -25,6 +25,7 @@ namespace OCA\FederatedFileSharing\Tests\Settings;
 
 use OCA\FederatedFileSharing\Settings\Admin;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\GlobalScale\IConfig;
 use Test\TestCase;
 
 class AdminTest extends TestCase {
@@ -32,12 +33,17 @@ class AdminTest extends TestCase {
 	private $admin;
 	/** @var \OCA\FederatedFileSharing\FederatedShareProvider */
 	private $federatedShareProvider;
+	/** @var  IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	private $gsConfig;
 
 	public function setUp() {
 		parent::setUp();
-		$this->federatedShareProvider = $this->getMockBuilder('\OCA\FederatedFileSharing\FederatedShareProvider')->disableOriginalConstructor()->getMock();
+		$this->federatedShareProvider = $this->getMockBuilder('\OCA\FederatedFileSharing\FederatedShareProvider')
+			->disableOriginalConstructor()->getMock();
+		$this->gsConfig = $this->getMock(IConfig::class);
 		$this->admin = new Admin(
-			$this->federatedShareProvider
+			$this->federatedShareProvider,
+			$this->gsConfig
 		);
 	}
 
@@ -73,8 +79,11 @@ class AdminTest extends TestCase {
 			->expects($this->once())
 			->method('isLookupServerUploadEnabled')
 			->willReturn($state);
+		$this->gsConfig->expects($this->once())->method('onlyInternalFederation')
+			->willReturn($state);
 
 		$params = [
+			'internalOnly' => $state,
 			'outgoingServer2serverShareEnabled' => $state,
 			'incomingServer2serverShareEnabled' => $state,
 			'lookupServerEnabled' => $state,

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1242,13 +1242,13 @@ $CONFIG = array(
  * During setup, if requirements are met (see below), this setting is set to true
  * and MySQL can handle 4 byte characters instead of 3 byte characters.
  *
- * If you want to convert an existing 3-byte setup into a 4-byte setup please 
+ * If you want to convert an existing 3-byte setup into a 4-byte setup please
  * set the parameters in MySQL as mentioned below and run the migration command:
  *  ./occ db:convert-mysql-charset
  * The config setting will be set automatically after a successful run.
- * 
+ *
  * Consult the documentation for more details.
- * 
+ *
  * MySQL requires a special setup for longer indexes (> 767 bytes) which are
  * needed:
  *
@@ -1529,5 +1529,16 @@ $CONFIG = array(
  * use a custom lookup server to publish user data
  */
 'lookup_server' => 'https://lookup.nextcloud.com',
+
+/**
+ * set to true if the server is used in a setup based on Nextcloud's Global Scale architecture
+ */
+'gs.enabled' => false,
+
+/**
+ * by default federation is only used internally in a Global Scale setup
+ * If you want to allow federation outside of your environment set it to 'global'
+ */
+'gs.federation' => 'internal',
 
 );

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -53,6 +53,7 @@ use OCP\AppFramework\IAppContainer;
 use OCP\AppFramework\QueryException;
 use OCP\Files\Folder;
 use OCP\Files\IAppData;
+use OCP\GlobalScale\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IServerContainer;
@@ -157,6 +158,10 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 
 		$this->registerService('OCP\Encryption\IManager', function ($c) {
 			return $this->getServer()->getEncryptionManager();
+		});
+
+		$this->registerService(IConfig::class, function ($c) {
+			return $c->query(OC\GlobalScale\Config::class);
 		});
 
 		$this->registerService(IValidator::class, function($c) {

--- a/lib/private/GlobalScale/Config.php
+++ b/lib/private/GlobalScale/Config.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OC\GlobalScale;
+
+
+use OCP\IConfig;
+
+class Config implements \OCP\GlobalScale\IConfig {
+
+	/** @var IConfig */
+	private $config;
+
+	/**
+	 * Config constructor.
+	 *
+	 * @param IConfig $config
+	 */
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	/**
+	 * check if global scale is enabled
+	 *
+	 * @since 12.0.1
+	 * @return bool
+	 */
+	public function isGlobalScaleEnabled() {
+		$enabled = $this->config->getSystemValue('gs.enabled', false);
+		return $enabled !== false;
+	}
+
+	/**
+	 * check if federation should only be used internally in a global scale setup
+	 *
+	 * @since 12.0.1
+	 * @return bool
+	 */
+	public function onlyInternalFederation() {
+		// if global scale is disabled federation works always globally
+		$gsEnabled = $this->isGlobalScaleEnabled();
+		if ($gsEnabled === false) {
+			return false;
+		}
+
+		$enabled = $this->config->getSystemValue('gs.federation', 'internal');
+
+		return $enabled === 'internal';
+	}
+
+}

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -24,6 +24,7 @@
 namespace OC\Share20;
 
 use OC\CapabilitiesManager;
+use OC\GlobalScale\Config;
 use OCA\FederatedFileSharing\AddressHandler;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\FederatedFileSharing\Notifications;
@@ -125,7 +126,8 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->getLazyRootFolder(),
 				$this->serverContainer->getConfig(),
 				$this->serverContainer->getUserManager(),
-				$this->serverContainer->getCloudIdManager()
+				$this->serverContainer->getCloudIdManager(),
+				$this->serverContainer->query(Config::class)
 			);
 		}
 

--- a/lib/public/GlobalScale/IConfig.php
+++ b/lib/public/GlobalScale/IConfig.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCP\GlobalScale;
+
+/**
+ * Interface IConfig
+ *
+ * Configuration of the global scale architecture
+ *
+ * @package OCP\GlobalScale
+ * @since 12.0.1
+ */
+interface IConfig {
+
+	/**
+	 * check if global scale is enabled
+	 *
+	 * @since 12.0.1
+	 * @return bool
+	 */
+	public function isGlobalScaleEnabled();
+
+	/**
+	 * check if federation should only be used internally in a global scale setup
+	 *
+	 * @since 12.0.1
+	 * @return bool
+	 */
+	public function onlyInternalFederation();
+
+}

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -212,8 +212,14 @@ $tmpl->assign('certs', $certificateManager->listCertificates());
 $tmpl->assign('showCertificates', $enableCertImport);
 $tmpl->assign('urlGenerator', $urlGenerator);
 
-$lookupServerUploadEnabled = $config->getAppValue('files_sharing', 'lookupServerUploadEnabled', 'yes');
-$lookupServerUploadEnabled = $lookupServerUploadEnabled === 'yes';
+$federatedFileSharingEnabled = \OC::$server->getAppManager()->isEnabledForUser('federatedfilesharing');
+$lookupServerUploadEnabled = false;
+if ($federatedFileSharingEnabled) {
+	$federatedFileSharing = new \OCA\FederatedFileSharing\AppInfo\Application();
+	$shareProvider = $federatedFileSharing->getFederatedShareProvider();
+	$lookupServerUploadEnabled = $shareProvider->isLookupServerUploadEnabled();
+}
+
 $tmpl->assign('lookupServerUploadEnabled', $lookupServerUploadEnabled);
 
 // Get array of group ids for this user

--- a/tests/lib/GlobalScale/ConfigTest.php
+++ b/tests/lib/GlobalScale/ConfigTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace Test\GlobalScale;
+
+
+use OC\GlobalScale\Config;
+use OCP\IConfig;
+use Test\TestCase;
+
+class ConfigTest extends TestCase {
+
+	/** @var  IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	private $config;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+	}
+
+	/**
+	 * @param array $mockMethods
+	 * @return Config|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	public function getInstance($mockMethods = []) {
+
+		if (!empty($mockMethods)) {
+			return $this->getMockBuilder(Config::class)
+				->setConstructorArgs([$this->config])
+				->setMethods($mockMethods)
+				->getMock();
+		}
+
+		return new Config($this->config);
+	}
+
+	public function testIsGlobalScaleEnabled() {
+		$gsConfig = $this->getInstance();
+		$this->config->expects($this->once())->method('getSystemValue')
+			->with('gs.enabled', false)->willReturn(true);
+
+		$result = $gsConfig->isGlobalScaleEnabled();
+
+		$this->assertTrue($result);
+	}
+
+
+	/**
+	 * @dataProvider dataTestOnlyInternalFederation
+	 *
+	 * @param bool $gsEnabled
+	 * @param string $gsFederation
+	 * @param bool $expected
+	 */
+	public function testOnlyInternalFederation($gsEnabled, $gsFederation, $expected) {
+		$gsConfig = $this->getInstance(['isGlobalScaleEnabled']);
+
+		$gsConfig->expects($this->any())->method('isGlobalScaleEnabled')->willReturn($gsEnabled);
+
+		$this->config->expects($this->any())->method('getSystemValue')
+			->with('gs.federation', 'internal')->willReturn($gsFederation);
+
+		$this->assertSame($expected, $gsConfig->onlyInternalFederation());
+	}
+
+	public function dataTestOnlyInternalFederation() {
+		return [
+			[true, 'global', false],
+			[true, 'internal', true],
+			[false, 'global', false],
+			[false, 'internal', false]
+		];
+	}
+
+}


### PR DESCRIPTION
Introduce two config switches:

- `gs.enabled`, default is false, if it is set to true the server runs in a global scale setup
- 'gs.federation', default is 'internal'. This means that federation is only used within the global scale setup. If you run a global scale setup and want to allow federation with outside you need to set it to 'global'

Rationals:

- in a global scale setup it doesn't make sense to let user update the lookup server or to verify their accounts. The lookup server will be maintained by the admin.
- It makes sense to restrict federation to the internal nodes of a global scale architecture by default.

cc @MorrisJobke @oparoz 