### PR TITLE
Register the autoloading earlier so we can load the background jobs

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -1054,10 +1054,9 @@ class OC_App {
 			self::loadApp($appId);
 			include $appPath . '/appinfo/update.php';
 		}
+		self::registerAutoloading($appId, $appPath);
 		self::setupBackgroundJobs($appData['background-jobs']);
 		if(isset($appData['settings']) && is_array($appData['settings'])) {
-			$appPath = self::getAppPath($appId);
-			self::registerAutoloading($appId, $appPath);
 			\OC::$server->getSettingsManager()->setupSettings($appData['settings']);
 		}
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/news/issues/155

See https://github.com/nextcloud/server/blob/be33234266db3cae8f2836c579be21b926aea162/lib/private/Installer.php#L144-L148 for comparison, maybe we should deduplicate all these calls...