### PR TITLE
dont die if we try to access the shared cache while setting up the shared storage

### DIFF
--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -27,6 +27,7 @@
 
 namespace OCA\Files_Sharing;
 
+use OC\Files\Cache\FailedCache;
 use OC\Files\Cache\Wrapper\CacheJail;
 use OCP\Files\Cache\ICacheEntry;
 
@@ -68,7 +69,13 @@ class Cache extends CacheJail {
 
 	public function getCache() {
 		if (is_null($this->cache)) {
-			$this->cache = $this->storage->getSourceStorage()->getCache();
+			$sourceStorage = $this->storage->getSourceStorage();
+			if ($sourceStorage) {
+				$this->cache = $sourceStorage->getCache();
+			} else {
+				// don't set $this->cache here since sourceStorage will be set later
+				return new FailedCache();
+			}
 		}
 		return $this->cache;
 	}


### PR DESCRIPTION
While setting up the shared storage it tries to get the file by id, this can call `getPathById` on the shared storage that is being setup at the moment, leading to a source storage that isn't set yet.

Fixes https://github.com/nextcloud/server/issues/3110

@idmacdonald @znerol can you verify that this fixes the problem for you