### PR TITLE
Fix #5059 by adding sanity checks before using var

### DIFF
--- a/settings/BackgroundJobs/VerifyUserData.php
+++ b/settings/BackgroundJobs/VerifyUserData.php
@@ -231,7 +231,7 @@ class VerifyUserData extends Job {
 
 			$body = json_decode($response->getBody(), true);
 
-			if ($body['federationId'] === $cloudId) {
+			if (is_array($body) && isset($body['federationId']) && $body['federationId'] === $cloudId) {
 				return $body;
 			}
 


### PR DESCRIPTION
Added two simple sanity checks to be sure that federationId array key is set before using it. This prevents the notice and the occuring log message in the NC-log.