### PR TITLE
Update styles.scss to fix public download display in default custom theme

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1284,7 +1284,7 @@ div.crumb {
 		color: nc-lighten($color-main-text, 33%);
 		text-align: center;
 		margin: 0 auto;
-		padding: 10px 0;
+		padding: 5px 0;
 		a {
 			color: nc-lighten($color-main-text, 33%);
 			font-weight: 600;

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1284,7 +1284,7 @@ div.crumb {
 		color: nc-lighten($color-main-text, 33%);
 		text-align: center;
 		margin: 0 auto;
-		padding: 20px 0;
+		padding: 10px 0;
 		a {
 			color: nc-lighten($color-main-text, 33%);
 			font-weight: 600;


### PR DESCRIPTION
Default custom theme has two lines of footer instead of one, which will introduce an unnecessary scroll bar in the browser. This quick fix will make it much easier to manage custom themes.