### PR TITLE
the 10px make's a scrollbar at bottom

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1109,7 +1109,7 @@ span.ui-icon {
 		display: flex;
 		position: relative;
 		align-items: center;
-		padding: 3px 3px 3px 10px;
+		padding: 3px;
 		border-bottom: 1px solid #eeeeee;
 
 		:last-of-type {


### PR DESCRIPTION
![screen 00000](https://cloud.githubusercontent.com/assets/7925717/26480059/f25f61fe-41d7-11e7-91bc-541fce12a604.jpg)
![screen 00001](https://cloud.githubusercontent.com/assets/7925717/26480062/f266578e-41d7-11e7-871e-5178448fc74e.jpg)
![screen 00002](https://cloud.githubusercontent.com/assets/7925717/26480061/f265ab5e-41d7-11e7-80a3-8888bcf60cad.jpg)
![screen 00003](https://cloud.githubusercontent.com/assets/7925717/26480057/f25338de-41d7-11e7-83a1-321040cf78a2.jpg)
![screen 00004](https://cloud.githubusercontent.com/assets/7925717/26480056/f2380320-41d7-11e7-8cc8-0bf575551d6b.jpg)
![screen 00005](https://cloud.githubusercontent.com/assets/7925717/26480058/f25c61d4-41d7-11e7-9418-645148d79432.jpg)
![screen 00006](https://cloud.githubusercontent.com/assets/7925717/26480060/f25ff7ae-41d7-11e7-9139-1cafe2790995.jpg)





Hi,

the patting 3px 3px 3px 10px 
makes to become at bottom an scrollbar and looks terrible ,
for remove it, to make at all 3px around and the "error" it is resolved
and we have a clean Contactsearchbar menu at bottom
with only a scrollbar at right side :)

Firefox 53.0.3 / Windows 7 64Bit

best regards
Blacky

Signed-off-by Blackcrack (mailadress by github)