### PR TITLE
Always enable Zip64 extension for zipstreamer

### DIFF
--- a/lib/private/Streamer.php
+++ b/lib/private/Streamer.php
@@ -41,7 +41,7 @@ class Streamer {
 		if ($request->isUserAgent($this->preferTarFor)) {
 			$this->streamerInstance = new TarStreamer();
 		} else {
-			$this->streamerInstance = new ZipStreamer(['zip64' => PHP_INT_SIZE !== 4]);
+			$this->streamerInstance = new ZipStreamer();
 		}
 	}
 	


### PR DESCRIPTION
Is there any factual reason to disable zip64 on 32bit machines? ZipStreamer goes to quite some lengths to make sure it works properly on both 32bit and 64bit machines. It does not rely on 8 bit integers for zip64....