### PR TITLE
Allow dir-listing also when one child is blocked by access control

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -288,10 +288,16 @@ class FilesPlugin extends ServerPlugin {
 		$httpRequest = $this->server->httpRequest;
 
 		if ($node instanceof \OCA\DAV\Connector\Sabre\Node) {
+			/**
+			 * This was disabled, because it made dir listing throw an exception,
+			 * so users were unable to navigate into folders where one subitem
+			 * is blocked by the files_accesscontrol app, see:
+			 * https://github.com/nextcloud/files_accesscontrol/issues/65
 			if (!$node->getFileInfo()->isReadable()) {
 				// avoid detecting files through this means
 				throw new NotFound();
 			}
+			 */
 
 			$propFind->handle(self::FILEID_PROPERTYNAME, function() use ($node) {
 				return $node->getFileId();

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -341,11 +341,12 @@ class FilesPluginTest extends TestCase {
 		$this->assertEquals('my_fingerprint', $propFind->get(self::DATA_FINGERPRINT_PROPERTYNAME));
 	}
 
-	/**
-	 * @expectedException \Sabre\DAV\Exception\NotFound
-	 */
 	public function testGetPropertiesWhenNoPermission() {
-		/** @var \OCA\DAV\Connector\Sabre\Directory | \PHPUnit_Framework_MockObject_MockObject $node */
+		// No read permissions can be caused by files access control.
+		// But we still want to load the directory list, so this is okay for us.
+		// $this->expectException(\Sabre\DAV\Exception\NotFound::class);
+
+		/** @var \OCA\DAV\Connector\Sabre\Directory|\PHPUnit_Framework_MockObject_MockObject $node */
 		$node = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\Directory')
 			->disableOriginalConstructor()
 			->getMock();


### PR DESCRIPTION
Regression from https://github.com/nextcloud/server/issues/4524
Fix https://github.com/nextcloud/files_accesscontrol/issues/65