### PR TITLE
Do not use absolute urls in SCSS

### DIFF
--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -196,8 +196,8 @@ class ThemingDefaults extends \OC_Defaults {
 			'theming-background-mime' => "'" . $this->config->getAppValue('theming', 'backgroundMime', '') . "'"
 		];
 
-		$variables['image-logo'] = "'".$this->urlGenerator->getAbsoluteURL($this->getLogo())."'";
-		$variables['image-login-background'] = "'".$this->urlGenerator->getAbsoluteURL($this->getBackground())."'";
+		$variables['image-logo'] = "'".$this->getLogo()."'";
+		$variables['image-login-background'] = "'".$this->getBackground()."'";
 		$variables['image-login-plain'] = 'false';
 
 		if ($this->config->getAppValue('theming', 'color', null) !== null) {

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -524,18 +524,12 @@ class ThemingDefaultsTest extends TestCase {
 				['theming.Theming.getLoginBackground', [], 'custom-background'],
 			]);
 
-		$this->urlGenerator->expects($this->exactly(2))
-			->method('getAbsoluteURL')
-			->willReturnCallback(function ($path) {
-				return 'absolute-' . $path;
-			});
-
 		$expected = [
 			'theming-cachebuster' => '\'0\'',
 			'theming-logo-mime' => '\'jpeg\'',
 			'theming-background-mime' => '\'jpeg\'',
-			'image-logo' => "'absolute-custom-logo?v=0'",
-			'image-login-background' => "'absolute-custom-background?v=0'",
+			'image-logo' => "'custom-logo?v=0'",
+			'image-login-background' => "'custom-background?v=0'",
 			'color-primary' => $this->defaults->getColorPrimary(),
 			'color-primary-text' => '#ffffff',
 			'image-login-plain' => 'false'


### PR DESCRIPTION
Absolute urls will not work with multiple trusted domains, since they are cached here.

Fix for #5085 