### PR TITLE
Stop cron after update

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -135,7 +135,7 @@ try {
 
 	} else {
 		// We call cron.php from some website
-		if ($appMode == 'cron') {
+		if ($appMode === 'cron') {
 			// Cron is cron :-P
 			OC_JSON::error(array('data' => array('message' => 'Backgroundjobs are using system cron!')));
 		} else {
@@ -151,7 +151,7 @@ try {
 	}
 
 	// Log the successful cron execution
-	\OC::$server->getConfig()->setAppValue('core', 'lastcron', time());
+	$config->setAppValue('core', 'lastcron', time());
 	exit();
 
 } catch (Exception $ex) {

--- a/cron.php
+++ b/cron.php
@@ -112,6 +112,7 @@ try {
 		// We only ask for jobs for 14 minutes, because after 15 minutes the next
 		// system cron task should spawn.
 		$endTime = time() + 14 * 60;
+		$currentVersion = $config->getSystemValue('version', '');
 
 		$executedJobs = [];
 		while ($job = $jobList->getNext()) {
@@ -128,7 +129,11 @@ try {
 			$executedJobs[$job->getId()] = true;
 			unset($job);
 
-			if (time() > $endTime) {
+			if (time() > $endTime ||
+				$config->getSystemValue('maintenance', false) ||
+				$currentVersion !== $config->getSystemValue('version', '')
+				) {
+				// Time over or there is/was an update, make sure we don't continue with old cached data...
 				break;
 			}
 		}


### PR DESCRIPTION
Ref #4978

Need a way to refresh the `OC\Config::$cache` array or to ignore it.

The best option I see atm is to pipe a method `purgeConfigCache` through AllConfig > SystemConfig > Config
The problem is currently we don't re-read the config file, so all this checking is useless...