### PR TITLE
allow passing callbacks to registerAdmin/registerPersonal

### DIFF
--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -68,18 +68,20 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 	 * Register settings templates
 	 */
 	public function registerSettings() {
-		$container = $this->getContainer();
-		$userSession = $container->getServer()->getUserSession();
-		if (!$userSession->isLoggedIn()) {
-			return;
-		}
-		$backendService = $container->query('OCA\\Files_External\\Service\\BackendService');
+		\OCP\App::registerPersonal('files_external', function () {
+			$container = $this->getContainer();
+			$userSession = $container->getServer()->getUserSession();
+			if (!$userSession->isLoggedIn()) {
+				return;
+			}
+			$backendService = $container->query('OCA\\Files_External\\Service\\BackendService');
 
-		/** @var \OCA\Files_External\Service\UserGlobalStoragesService $userGlobalStoragesService */
-		$userGlobalStoragesService = $container->query('OCA\Files_External\Service\UserGlobalStoragesService');
-		if (count($userGlobalStoragesService->getStorages()) > 0 || $backendService->isUserMountingAllowed()) {
-			\OCP\App::registerPersonal('files_external', 'personal');
-		}
+			/** @var \OCA\Files_External\Service\UserGlobalStoragesService $userGlobalStoragesService */
+			$userGlobalStoragesService = $container->query('OCA\Files_External\Service\UserGlobalStoragesService');
+			if (count($userGlobalStoragesService->getStorages()) > 0 || $backendService->isUserMountingAllowed()) {
+				return 'personal';
+			}
+		});
 	}
 
 	/**

--- a/lib/public/App.php
+++ b/lib/public/App.php
@@ -90,7 +90,7 @@ class App {
 	/**
 	 * Register a Configuration Screen that should appear in the personal settings section.
 	 * @param string $app appid
-	 * @param string $page page to be included
+	 * @param string|callable $page page to be included
 	 * @return void
 	 * @since 4.0.0
 	*/
@@ -101,7 +101,7 @@ class App {
 	/**
 	 * Register a Configuration Screen that should appear in the Admin section.
 	 * @param string $app string appid
-	 * @param string $page string page to be included
+	 * @param string|callable $page string page to be included
 	 * @return void
 	 * @since 4.0.0
 	 */


### PR DESCRIPTION
This can be used by an app to prevent having to determine what settings pages needs to be added if the result is never used

Adjusted the files_external settings page to use the new callback option, this saved 4 db queries for each request made