### PR TITLE
Use the master key by default

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionMasterKeyUploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionMasterKeyUploadTest.php
@@ -28,21 +28,21 @@ use OC\Files\View;
 use Test\Traits\EncryptionTrait;
 
 /**
- * Class EncryptionUploadTest
+ * Class EncryptionMasterKeyUploadTest
  *
  * @group DB
  *
  * @package OCA\DAV\Tests\Unit\Connector\Sabre\RequestTest
  */
-class EncryptionUploadTest extends UploadTest {
+class EncryptionMasterKeyUploadTest extends UploadTest {
 	use EncryptionTrait;
 
 	protected function setupUser($name, $password) {
 		$this->createUser($name, $password);
 		$tmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
 		$this->registerMount($name, '\OC\Files\Storage\Local', '/' . $name, ['datadir' => $tmpFolder]);
-		// we use per-user keys
-		\OC::$server->getConfig()->setAppValue('encryption', 'useMasterKey', '0');
+		// we use the master key
+		\OC::$server->getConfig()->setAppValue('encryption', 'useMasterKey', '1');
 		$this->setupForUser($name, $password);
 		$this->loginWithEncryption($name);
 		return new View('/' . $name . '/files');

--- a/apps/encryption/appinfo/app.php
+++ b/apps/encryption/appinfo/app.php
@@ -31,4 +31,5 @@ $app = new Application([], $encryptionSystemReady);
 if ($encryptionSystemReady) {
 	$app->registerEncryptionModule();
 	$app->registerHooks();
+	$app->setUp();
 }

--- a/apps/encryption/appinfo/info.xml
+++ b/apps/encryption/appinfo/info.xml
@@ -19,7 +19,7 @@
 		<user>user-encryption</user>
 		<admin>admin-encryption</admin>
 	</documentation>
-	<version>1.7.1</version>
+	<version>2.0.0</version>
 	<types>
 		<filesystem/>
 	</types>
@@ -36,4 +36,10 @@
 		<command>OCA\Encryption\Command\DisableMasterKey</command>
 		<command>OCA\Encryption\Command\MigrateKeys</command>
 	</commands>
+
+	<repair-steps>
+		<post-migration>
+			<step>OCA\Encryption\Migration\SetMasterKeyStatus</step>
+		</post-migration>
+	</repair-steps>
 </info>

--- a/apps/encryption/appinfo/info.xml
+++ b/apps/encryption/appinfo/info.xml
@@ -33,6 +33,7 @@
 	</settings>
 	<commands>
 		<command>OCA\Encryption\Command\EnableMasterKey</command>
+		<command>OCA\Encryption\Command\DisableMasterKey</command>
 		<command>OCA\Encryption\Command\MigrateKeys</command>
 	</commands>
 </info>

--- a/apps/encryption/lib/AppInfo/Application.php
+++ b/apps/encryption/lib/AppInfo/Application.php
@@ -67,7 +67,11 @@ class Application extends \OCP\AppFramework\App {
 			$session = $this->getContainer()->query('Session');
 			$session->setStatus(Session::RUN_MIGRATION);
 		}
-		if ($this->encryptionManager->isEnabled() && $encryptionSystemReady) {
+
+	}
+
+	public function setUp() {
+		if ($this->encryptionManager->isEnabled()) {
 			/** @var Setup $setup */
 			$setup = $this->getContainer()->query('UserSetup');
 			$setup->setupSystem();
@@ -77,7 +81,6 @@ class Application extends \OCP\AppFramework\App {
 	/**
 	 * register hooks
 	 */
-
 	public function registerHooks() {
 		if (!$this->config->getSystemValue('maintenance', false)) {
 

--- a/apps/encryption/lib/AppInfo/Application.php
+++ b/apps/encryption/lib/AppInfo/Application.php
@@ -196,7 +196,8 @@ class Application extends \OCP\AppFramework\App {
 				$c->getAppName(),
 				$server->getRequest(),
 				$server->getL10N($c->getAppName()),
-				$c->query('Session')
+				$c->query('Session'),
+				$server->getEncryptionManager()
 			);
 		});
 

--- a/apps/encryption/lib/Command/DisableMasterKey.php
+++ b/apps/encryption/lib/Command/DisableMasterKey.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Encryption\Command;
+
+
+use OCA\Encryption\Util;
+use OCP\IConfig;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class DisableMasterKey extends Command {
+
+	/** @var Util */
+	protected $util;
+
+	/** @var IConfig */
+	protected $config;
+
+	/** @var  QuestionHelper */
+	protected $questionHelper;
+
+	/**
+	 * @param Util $util
+	 * @param IConfig $config
+	 * @param QuestionHelper $questionHelper
+	 */
+	public function __construct(Util $util,
+								IConfig $config,
+								QuestionHelper $questionHelper) {
+
+		$this->util = $util;
+		$this->config = $config;
+		$this->questionHelper = $questionHelper;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('encryption:disable-master-key')
+			->setDescription('Disable the master key and use per-user keys instead. Only available for fresh installations with no existing encrypted data! There is no way to enable it again.');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+
+		$isMasterKeyEnabled = $this->util->isMasterKeyEnabled();
+
+		if(!$isMasterKeyEnabled) {
+			$output->writeln('Master key already disabled');
+		} else {
+			$question = new ConfirmationQuestion(
+				'Warning: Only perform this operation for a fresh installations with no existing encrypted data! '
+				. 'There is no way to enable the master key again. '
+				. 'We strongly recommend to keep the master key, it provides significant performance improvements '
+				. 'and is easier to handle for both, users and administrators. '
+				. 'Do you really want to switch to per-user keys? (y/n) ', false);
+			if ($this->questionHelper->ask($input, $output, $question)) {
+				$this->config->setAppValue('encryption', 'useMasterKey', '0');
+				$output->writeln('Master key successfully disabled.');
+			} else {
+				$output->writeln('aborted.');
+			}
+		}
+
+	}
+
+}

--- a/apps/encryption/lib/Controller/StatusController.php
+++ b/apps/encryption/lib/Controller/StatusController.php
@@ -28,6 +28,7 @@ namespace OCA\Encryption\Controller;
 use OCA\Encryption\Session;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\Encryption\IManager;
 use OCP\IL10N;
 use OCP\IRequest;
 
@@ -39,20 +40,26 @@ class StatusController extends Controller {
 	/** @var Session */
 	private $session;
 
+	/** @var IManager */
+	private $encryptionManager;
+
 	/**
 	 * @param string $AppName
 	 * @param IRequest $request
 	 * @param IL10N $l10n
 	 * @param Session $session
+	 * @param IManager $encryptionManager
 	 */
 	public function __construct($AppName,
 								IRequest $request,
 								IL10N $l10n,
-								Session $session
+								Session $session,
+								IManager $encryptionManager
 								) {
 		parent::__construct($AppName, $request);
 		$this->l = $l10n;
 		$this->session = $session;
+		$this->encryptionManager = $encryptionManager;
 	}
 
 	/**
@@ -78,9 +85,15 @@ class StatusController extends Controller {
 				break;
 			case Session::NOT_INITIALIZED:
 				$status = 'interactionNeeded';
-				$message = (string)$this->l->t(
-					'Encryption App is enabled, but your keys are not initialized. Please log-out and log-in again.'
-				);
+				if ($this->encryptionManager->isEnabled()) {
+					$message = (string)$this->l->t(
+						'Encryption App is enabled, but your keys are not initialized. Please log-out and log-in again.'
+					);
+				} else {
+					$message = (string)$this->l->t(
+						'Please enable server side encryption in the admin settings in order to use the encryption module.'
+					);
+				}
 				break;
 			case Session::INIT_SUCCESSFUL:
 				$status = 'success';

--- a/apps/encryption/lib/Crypto/Encryption.php
+++ b/apps/encryption/lib/Crypto/Encryption.php
@@ -569,4 +569,13 @@ class Encryption implements IEncryptionModule {
 	public function isReadyForUser($user) {
 		return $this->keyManager->userHasKeys($user);
 	}
+
+	/**
+	 * We only need a detailed access list if the master key is not enabled
+	 *
+	 * @return bool
+	 */
+	public function needDetailedAccessList() {
+		return !$this->util->isMasterKeyEnabled();
+	}
 }

--- a/apps/encryption/lib/KeyManager.php
+++ b/apps/encryption/lib/KeyManager.php
@@ -179,8 +179,8 @@ class KeyManager {
 			return;
 		}
 
-		$masterKey = $this->getPublicMasterKey();
-		if (empty($masterKey)) {
+		$publicMasterKey = $this->getPublicMasterKey();
+		if (empty($publicMasterKey)) {
 			$keyPair = $this->crypt->createKeyPair();
 
 			// Save public key
@@ -193,6 +193,15 @@ class KeyManager {
 			$header = $this->crypt->generateHeader();
 			$this->setSystemPrivateKey($this->masterKeyId, $header . $encryptedKey);
 		}
+
+		if (!$this->session->isPrivateKeySet()) {
+			$masterKey = $this->getSystemPrivateKey($this->masterKeyId);
+			$decryptedMasterKey = $this->crypt->decryptPrivateKey($masterKey, $this->getMasterKeyPassword(), $this->masterKeyId);
+			$this->session->setPrivateKey($decryptedMasterKey);
+		}
+
+		// after the encryption key is available we are ready to go
+		$this->session->setStatus(Session::INIT_SUCCESSFUL);
 	}
 
 	/**

--- a/apps/encryption/lib/Migration/SetMasterKeyStatus.php
+++ b/apps/encryption/lib/Migration/SetMasterKeyStatus.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Encryption\Migration;
+
+
+use OCP\IConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+/**
+ * Class SetPasswordColumn
+ *
+ * @package OCA\Files_Sharing\Migration
+ */
+class SetMasterKeyStatus implements IRepairStep {
+
+
+	/** @var  IConfig */
+	private $config;
+
+
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	/**
+	 * Returns the step's name
+	 *
+	 * @return string
+	 * @since 9.1.0
+	 */
+	public function getName() {
+		return 'Write default encryption module configuration to the database';
+	}
+
+	/**
+	 * @param IOutput $output
+	 */
+	public function run(IOutput $output) {
+		if (!$this->shouldRun()) {
+			return;
+		}
+
+		// if no config for the master key is set we set it explicitly to '0' in
+		// order not to break old installations because the default changed to '1'.
+		$configAlreadySet = $this->config->getAppValue('encryption', 'useMasterKey', false);
+		if ($configAlreadySet === false) {
+			$this->config->setAppValue('encryption', 'useMasterKey', '0');
+		}
+	}
+
+	protected function shouldRun() {
+		$appVersion = $this->config->getAppValue('encryption', 'installed_version', '0.0.0');
+		return version_compare($appVersion, '2.0.0', '<');
+	}
+
+}

--- a/apps/encryption/lib/Util.php
+++ b/apps/encryption/lib/Util.php
@@ -136,7 +136,7 @@ class Util {
 	 * @return bool
 	 */
 	public function isMasterKeyEnabled() {
-		$userMasterKey = $this->config->getAppValue('encryption', 'useMasterKey', '0');
+		$userMasterKey = $this->config->getAppValue('encryption', 'useMasterKey', '1');
 		return ($userMasterKey === '1');
 	}
 

--- a/apps/encryption/templates/settings-admin.php
+++ b/apps/encryption/templates/settings-admin.php
@@ -7,7 +7,7 @@ style('encryption', 'settings-admin');
 ?>
 <form id="ocDefaultEncryptionModule" class="sub-section">
 	<h3><?php p($l->t("Default encryption module")); ?></h3>
-	<?php if(!$_["initStatus"]): ?>
+	<?php if(!$_["initStatus"] && $_['masterKeyEnabled'] === false): ?>
 		<?php p($l->t("Encryption app is enabled but your keys are not initialized, please log-out and log-in again")); ?>
 	<?php else: ?>
 		<p id="encryptHomeStorageSetting">

--- a/apps/encryption/tests/Controller/StatusControllerTest.php
+++ b/apps/encryption/tests/Controller/StatusControllerTest.php
@@ -27,6 +27,7 @@ namespace OCA\Encryption\Tests\Controller;
 
 use OCA\Encryption\Controller\StatusController;
 use OCA\Encryption\Session;
+use OCP\Encryption\IManager;
 use OCP\IRequest;
 use Test\TestCase;
 
@@ -40,6 +41,9 @@ class StatusControllerTest extends TestCase {
 
 	/** @var  \OCA\Encryption\Session | \PHPUnit_Framework_MockObject_MockObject */
 	protected $sessionMock;
+
+	/** @var  IManager | \PHPUnit_Framework_MockObject_MockObject */
+	protected $encryptionManagerMock;
 
 	/** @var StatusController */
 	protected $controller;
@@ -59,11 +63,13 @@ class StatusControllerTest extends TestCase {
 			->will($this->returnCallback(function($message) {
 				return $message;
 			}));
+		$this->encryptionManagerMock = $this->createMock(IManager::class);
 
 		$this->controller = new StatusController('encryptionTest',
 			$this->requestMock,
 			$this->l10nMock,
-			$this->sessionMock);
+			$this->sessionMock,
+			$this->encryptionManagerMock);
 
 	}
 

--- a/apps/encryption/tests/UtilTest.php
+++ b/apps/encryption/tests/UtilTest.php
@@ -152,7 +152,7 @@ class UtilTest extends TestCase {
 	 */
 	public function testIsMasterKeyEnabled($value, $expect) {
 		$this->configMock->expects($this->once())->method('getAppValue')
-			->with('encryption', 'useMasterKey', '0')->willReturn($value);
+			->with('encryption', 'useMasterKey', '1')->willReturn($value);
 		$this->assertSame($expect,
 			$this->instance->isMasterKeyEnabled()
 		);

--- a/apps/files_sharing/tests/EncryptedSizePropagationTest.php
+++ b/apps/files_sharing/tests/EncryptedSizePropagationTest.php
@@ -36,8 +36,10 @@ class EncryptedSizePropagationTest extends SizePropagationTest {
 		$this->createUser($name, $password);
 		$tmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
 		$this->registerMount($name, '\OC\Files\Storage\Local', '/' . $name, ['datadir' => $tmpFolder]);
+		$this->config->setAppValue('encryption', 'useMasterKey', '0');
 		$this->setupForUser($name, $password);
 		$this->loginWithEncryption($name);
 		return new View('/' . $name . '/files');
 	}
+
 }

--- a/lib/private/Encryption/Update.php
+++ b/lib/private/Encryption/Update.php
@@ -168,6 +168,14 @@ class Update {
 	 */
 	public function update($path) {
 
+		$encryptionModule = $this->encryptionManager->getEncryptionModule();
+
+		// if the encryption module doesn't encrypt the files on a per-user basis
+		// we have nothing to do here.
+		if ($encryptionModule->needDetailedAccessList() === false) {
+			return;
+		}
+
 		// if a folder was shared, get a list of all (sub-)folders
 		if ($this->view->is_dir($path)) {
 			$allFiles = $this->util->getAllFiles($path);
@@ -175,7 +183,7 @@ class Update {
 			$allFiles = array($path);
 		}
 
-		$encryptionModule = $this->encryptionManager->getEncryptionModule();
+
 
 		foreach ($allFiles as $file) {
 			$usersSharing = $this->file->getAccessList($file);

--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -254,7 +254,10 @@ class Encryption extends Wrapper {
 			$sharePath = dirname($sharePath);
 		}
 
-		$accessList = $this->file->getAccessList($sharePath);
+		$accessList = [];
+		if ($this->encryptionModule->needDetailedAccessList()) {
+			$accessList = $this->file->getAccessList($sharePath);
+		}
 		$this->newHeader = $this->encryptionModule->begin($this->fullPath, $this->uid, $mode, $this->header, $accessList);
 
 		if (

--- a/lib/public/Encryption/IEncryptionModule.php
+++ b/lib/public/Encryption/IEncryptionModule.php
@@ -182,4 +182,14 @@ interface IEncryptionModule {
 	 */
 	public function isReadyForUser($user);
 
+	/**
+	 * Does the encryption module needs a detailed list of users with access to the file?
+	 * For example if the encryption module uses per-user encryption keys and needs to know
+	 * the users with access to the file to encrypt/decrypt it.
+	 *
+	 * @since 13.0.0
+	 * @return bool
+	 */
+	public function needDetailedAccessList();
+
 }

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -212,7 +212,7 @@ class EncryptionTest extends Storage {
 	protected function buildMockModule() {
 		$this->encryptionModule = $this->getMockBuilder('\OCP\Encryption\IEncryptionModule')
 			->disableOriginalConstructor()
-			->setMethods(['getId', 'getDisplayName', 'begin', 'end', 'encrypt', 'decrypt', 'update', 'shouldEncrypt', 'getUnencryptedBlockSize', 'isReadable', 'encryptAll', 'prepareDecryptAll', 'isReadyForUser'])
+			->setMethods(['getId', 'getDisplayName', 'begin', 'end', 'encrypt', 'decrypt', 'update', 'shouldEncrypt', 'getUnencryptedBlockSize', 'isReadable', 'encryptAll', 'prepareDecryptAll', 'isReadyForUser', 'needDetailedAccessList'])
 			->getMock();
 
 		$this->encryptionModule->expects($this->any())->method('getId')->willReturn('UNIT_TEST_MODULE');
@@ -225,6 +225,7 @@ class EncryptionTest extends Storage {
 		$this->encryptionModule->expects($this->any())->method('shouldEncrypt')->willReturn(true);
 		$this->encryptionModule->expects($this->any())->method('getUnencryptedBlockSize')->willReturn(8192);
 		$this->encryptionModule->expects($this->any())->method('isReadable')->willReturn(true);
+		$this->encryptionModule->expects($this->any())->method('needDetailedAccessList')->willReturn(false);
 		return $this->encryptionModule;
 	}
 

--- a/tests/lib/Traits/EncryptionTrait.php
+++ b/tests/lib/Traits/EncryptionTrait.php
@@ -64,6 +64,7 @@ trait EncryptionTrait {
 		/** @var Setup $userSetup */
 		$userSetup = $container->query('UserSetup');
 		$userSetup->setupUser($name, $password);
+		$this->encryptionApp->setUp();
 		$keyManager->init($name, $password);
 	}
 
@@ -99,6 +100,7 @@ trait EncryptionTrait {
 		if ($this->config) {
 			$this->config->setAppValue('core', 'encryption_enabled', $this->encryptionWasEnabled);
 			$this->config->setAppValue('core', 'default_encryption_module', $this->originalEncryptionModule);
+			$this->config->deleteAppValue('encryption', 'useMasterKey');
 		}
 	}
 }


### PR DESCRIPTION
Use the master key by default.

The master key has many advantages:

- way better performance because we don't need to encrypt the file key for each recipient separately
- users don't need to re-login after encryption was enabled
- works in fast changing environments (add/remove people from groups)
- no problem if people forget the password
- files can be transfered easily to another user
- works with all login techniques
- impersonate app let the admin recover users files, e.g. if someone left the company/organization

ToDo's:

- [x] Unit Tests

cc @nextcloud/encryption 