### PR TITLE
Add space between app menu and right icons

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -150,6 +150,7 @@
 	#header-left {
 		flex: 0 0;
 		flex-grow: 1;
+		margin-right: 176px;
 	}
 
 	#header-right {

--- a/core/css/mobile.scss
+++ b/core/css/mobile.scss
@@ -75,6 +75,10 @@
 	width: 250px !important;
 }
 
+#header #header-left {
+	margin-right: 44px;
+}
+
 #app-content {
 	width: 100% !important;
 	left: 0 !important;

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1512,7 +1512,7 @@ function initCore() {
 
 	var resizeMenu = function() {
 		var appList = $('#appmenu li');
-		var availableWidth = $('#header-left').width() - $('#nextcloud').width() - 44;
+		var availableWidth = $('#header-left').width() - $('#nextcloud').width();
 		var appCount = Math.floor((availableWidth)/44);
 		// show at least 2 apps in the popover
 		if(appList.length-1-appCount >= 1) {


### PR DESCRIPTION
As proposed in #5135 

> I think it looks bad and super crowded if every available pixel in the header is used. Can we make sure that we have a bit more whitespace between the most right app icon and the search icon?

- Add 4 icons space on desktop browsers
- Add 1 icon space on mobile

please review @nextcloud/designers 
