### PR TITLE
fix install on mb4 enabled mariadb/mysql

### DIFF
--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -41,7 +41,7 @@ class MySQL extends AbstractDatabase {
 		$tools = new MySqlTools();
 		if ($tools->supports4ByteCharset($connection)) {
 			$this->config->setValue('mysql.utf8mb4', true);
-			$connection = $this->connect();
+			$connection = $this->connect(['dbname' => null]);
 		}
 
 		$this->createSpecificUser($username, $connection);


### PR DESCRIPTION
# Issue

Try to install against MariaDB/MySQL with mb4 support enabled (as described in https://docs.nextcloud.com/server/11/admin_manual/maintenance/mysql_4byte_support.html) by providing admin credentials to the DB. The target database does not exist at this moment.

NC 12 is affected.

Introduced by https://github.com/nextcloud/server/pull/4514 (downstream…)

## Expected

Install succeeds

## Reality

Error while trying to create admin user: Failed to connect to the database: An exception occured in driver: SQLSTATE[HY000] [1049] Unknown database 'stable12'

## Fix

provide "null" as db name connection parameter as done with non-mb4-supported setup.