### PR TITLE
Use realpath to obtain the webroot.

### DIFF
--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -117,7 +117,7 @@ class CSSResourceLocator extends ResourceLocator {
 			parent::append($root, $file, $webRoot, $throw);
 		} else {
 			if (!$webRoot) {
-				$tmpRoot = $root;
+				$tmpRoot = realpath($root);
 				/*
 				 * traverse the potential web roots upwards in the path
 				 *

--- a/lib/private/Template/ResourceLocator.php
+++ b/lib/private/Template/ResourceLocator.php
@@ -125,7 +125,7 @@ abstract class ResourceLocator {
 		}
 
 		if (!$webRoot) {
-			$tmpRoot = $root;
+			$tmpRoot = realpath($root);
 			/*
 			 * traverse the potential web roots upwards in the path
 			 *


### PR DESCRIPTION
Use realpath to get the correct webroot path, even if it is symlinked. Thanks @sileht: https://gist.github.com/sileht/5753118ee048352778c2a0c5b23ea47d