### PR TITLE
allow PropPatch requests to contact_birthdays

### DIFF
--- a/apps/dav/lib/CalDAV/Calendar.php
+++ b/apps/dav/lib/CalDAV/Calendar.php
@@ -122,7 +122,14 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IShareable {
 				'principal' => $this->getOwner(),
 				'protected' => true,
 			];
+		} else {
+			$acl[] = [
+				'privilege' => '{DAV:}write-properties',
+				'principal' => $this->getOwner(),
+				'protected' => true,
+			];
 		}
+
 		if ($this->getOwner() !== parent::getOwner()) {
 			$acl[] =  [
 					'privilege' => '{DAV:}read',

--- a/apps/dav/tests/unit/CalDAV/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarTest.php
@@ -191,6 +191,10 @@ class CalendarTest extends TestCase {
 				'privilege' => '{DAV:}read',
 				'principal' => $hasOwnerSet ? 'user1' : 'user2',
 				'protected' => true
+			], [
+				'privilege' => '{DAV:}write-properties',
+				'principal' => $hasOwnerSet ? 'user1' : 'user2',
+				'protected' => true
 			]];
 		}
 		if ($hasOwnerSet) {


### PR DESCRIPTION
fixes #5077 

This will allow users to send PropPatch requests to the `contact_birthdays` calendar in order to change it's name, color, order, etc.

This will **not** make it writable.