### PR TITLE
urldecode group principals in Cal- and CardDAV backend

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -276,6 +276,9 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 		// query for shared calendars
 		$principals = $this->principalBackend->getGroupMembership($principalUriOriginal, true);
+		$principals = array_map(function($principal) {
+			return urldecode($principal);
+		}, $principals);
 		$principals[]= $principalUri;
 
 		$fields = array_values($this->propertyMap);

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -162,6 +162,9 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 
 		// query for shared calendars
 		$principals = $this->principalBackend->getGroupMembership($principalUriOriginal, true);
+		$principals = array_map(function($principal) {
+			return urldecode($principal);
+		}, $principals);
 		$principals[]= $principalUri;
 
 		$query = $this->db->getQueryBuilder();

--- a/apps/dav/tests/unit/CalDAV/AbstractCalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/AbstractCalDavBackendTest.php
@@ -91,6 +91,9 @@ abstract class AbstractCalDavBackendTest extends TestCase {
 		if (is_null($this->backend)) {
 			return;
 		}
+		$this->principal->expects($this->any())->method('getGroupMembership')
+			->withAnyParameters()
+			->willReturn([self::UNIT_TEST_GROUP, self::UNIT_TEST_GROUP2]);
 		$calendars = $this->backend->getCalendarsForUser(self::UNIT_TEST_USER);
 		foreach ($calendars as $calendar) {
 			$this->dispatcher->expects($this->at(0))

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
@@ -46,6 +46,10 @@ class PublicCalendarRootTest extends TestCase {
 		$this->random = \OC::$server->getSecureRandom();
 		$dispatcher = $this->createMock(EventDispatcherInterface::class);
 
+		$this->principal->expects($this->any())->method('getGroupMembership')
+			->withAnyParameters()
+			->willReturn([]);
+
 		$this->backend = new CalDavBackend(
 			$db,
 			$this->principal,
@@ -66,6 +70,9 @@ class PublicCalendarRootTest extends TestCase {
 		if (is_null($this->backend)) {
 			return;
 		}
+		$this->principal->expects($this->any())->method('getGroupMembership')
+			->withAnyParameters()
+			->willReturn([]);
 		$books = $this->backend->getCalendarsForUser(self::UNIT_TEST_USER);
 		foreach ($books as $book) {
 			$this->backend->deleteCalendar($book['id']);

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -113,6 +113,10 @@ class CardDavBackendTest extends TestCase {
 		if (is_null($this->backend)) {
 			return;
 		}
+
+		$this->principal->method('getGroupMembership')
+			->withAnyParameters()
+			->willReturn([self::UNIT_TEST_GROUP]);
 		$books = $this->backend->getAddressBooksForUser(self::UNIT_TEST_USER);
 		foreach ($books as $book) {
 			$this->backend->deleteAddressBook($book['id']);


### PR DESCRIPTION
fixes #4885 

before:
```php
array(4) {
  ["admin"]=>
  string(23) "principals/groups/admin"
  ["x y"]=>
  string(21) "principals/groups/x+y"
  ["x&y"]=>
  string(23) "principals/groups/x%26y"
  ["x/y"]=>
  string(23) "principals/groups/x%2Fy"
}
```

after:
```php
array(4) {
  ["admin"]=>
  string(23) "principals/groups/admin"
  ["x y"]=>
  string(21) "principals/groups/x y"
  ["x&y"]=>
  string(21) "principals/groups/x&y"
  ["x/y"]=>
  string(21) "principals/groups/x/y"
}
```

There are absolutely no group-share related tests neither the Cal- nor the CardDav backend tests ...
We should maybe add them sometime soonish 