### PR TITLE
allow users to send PropPatch request when calendar is group-shared with them

### DIFF
--- a/apps/dav/lib/CalDAV/Calendar.php
+++ b/apps/dav/lib/CalDAV/Calendar.php
@@ -135,6 +135,12 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IShareable {
 					'principal' => parent::getOwner(),
 					'protected' => true,
 				];
+			} else {
+				$acl[] = [
+					'privilege' => '{DAV:}write-properties',
+					'principal' => parent::getOwner(),
+					'protected' => true,
+				];
 			}
 		}
 		if ($this->isPublic()) {

--- a/apps/dav/tests/unit/CalDAV/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarTest.php
@@ -205,6 +205,12 @@ class CalendarTest extends TestCase {
 					'principal' => 'user2',
 					'protected' => true
 				];
+			} else {
+				$expectedAcl[] = [
+					'privilege' => '{DAV:}write-properties',
+					'principal' => 'user2',
+					'protected' => true
+				];
 			}
 		}
 		$this->assertEquals($expectedAcl, $acl);


### PR DESCRIPTION
There is no corresponding ticket for this.

To reproduce: 
1. Login as user1
2. create a calendar
3. share calendar with a group and read-only permissions
4. login as user2 (who is a member of the group)
5. enable the shared calendar

on master:

6. you will see a 404 in the network console
7. when you reload the page the shared calendar will be hidden again

on this branch:

6. no 404, but a successful 207
7. calendar is still visible after reloading the page

