### PR TITLE
add missing parent::setUp that broke any other dav app test

### DIFF
--- a/apps/dav/tests/unit/Avatars/AvatarHomeTest.php
+++ b/apps/dav/tests/unit/Avatars/AvatarHomeTest.php
@@ -40,6 +40,7 @@ class AvatarHomeTest extends TestCase {
 	private $avatarManager;
 
 	public function setUp() {
+		parent::setUp();
 		$this->avatarManager = $this->createMock(IAvatarManager::class);
 		$this->home = new AvatarHome(['uri' => 'principals/users/admin'], $this->avatarManager);
 	}


### PR DESCRIPTION
#4440 drove me so crazy that I finally did a git bisect.

it was introduced by https://github.com/nextcloud/server/commit/3e93f491f260b79987d90b5123f07d1a7d1298cd and caused by a missing `parent::setUp()`.

This pr adds the missing `parent::setUp()`

stable12 is also affected by this. Therefore I would like it to be backported