### PR TITLE
[stable12] Fix ldap integration tests

### DIFF
--- a/apps/user_ldap/tests/Integration/AbstractIntegrationTest.php
+++ b/apps/user_ldap/tests/Integration/AbstractIntegrationTest.php
@@ -105,7 +105,6 @@ abstract class AbstractIntegrationTest {
 
 	/**
 	 * initializes an LDAP user manager instance
-	 * @return Manager
 	 */
 	protected function initUserManager() {
 		$this->userManager = new Manager(
@@ -115,7 +114,8 @@ abstract class AbstractIntegrationTest {
 			\OC::$server->getAvatarManager(),
 			new \OCP\Image(),
 			\OC::$server->getDatabaseConnection(),
-			\OC::$server->getUserManager()
+			\OC::$server->getUserManager(),
+			\OC::$server->getNotificationManager()
 		);
 	}
 	

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestAccessGroupsMatchFilter.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestAccessGroupsMatchFilter.php
@@ -117,6 +117,11 @@ class IntegrationTestAccessGroupsMatchFilter extends AbstractIntegrationTest {
 	}
 }
 
+/** @var string $host */
+/** @var int $port */
+/** @var string $adn */
+/** @var string $apwd */
+/** @var string $bdn */
 $test = new IntegrationTestAccessGroupsMatchFilter($host, $port, $adn, $apwd, $bdn);
 $test->init();
 $test->run();

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestAttributeDetection.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestAttributeDetection.php
@@ -49,7 +49,7 @@ class IntegrationTestAttributeDetection extends AbstractIntegrationTest {
 		$groupMapper->clear();
 		$this->access->setGroupMapper($groupMapper);
 
-		$userBackend = new User_LDAP($this->access, \OC::$server->getConfig());
+		$userBackend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager());
 		$userManager = \OC::$server->getUserManager();
 		$userManager->clearBackends();
 		$userManager->registerBackend($userBackend);

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestBackupServer.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestBackupServer.php
@@ -23,6 +23,7 @@
 
 namespace OCA\User_LDAP\Tests\Integration\Lib;
 
+use OC\ServerNotAvailableException;
 use OCA\User_LDAP\Tests\Integration\AbstractIntegrationTest;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User_LDAP;
@@ -64,7 +65,7 @@ class IntegrationTestBackupServer extends AbstractIntegrationTest {
 	protected function case1() {
 		try {
 			$this->connection->getConnectionResource();
-		} catch (\OC\ServerNotAvailableException $e) {
+		} catch (ServerNotAvailableException $e) {
 			return false;
 		}
 		return true;
@@ -85,7 +86,7 @@ class IntegrationTestBackupServer extends AbstractIntegrationTest {
 				'ldap_backup_port' => '32123',
 			]);
 			$this->connection->getConnectionResource();
-		} catch (\OC\ServerNotAvailableException $e) {
+		} catch (ServerNotAvailableException $e) {
 			return true;
 		}
 		return false;
@@ -106,13 +107,18 @@ class IntegrationTestBackupServer extends AbstractIntegrationTest {
 				'ldap_backup_port' => '',
 			]);
 			$this->connection->getConnectionResource();
-		} catch (\OC\ServerNotAvailableException $e) {
+		} catch (ServerNotAvailableException $e) {
 			return true;
 		}
 		return false;
 	}
 }
 
+/** @var string $host */
+/** @var int $port */
+/** @var string $adn */
+/** @var string $apwd */
+/** @var string $bdn */
 $test = new IntegrationTestBackupServer($host, $port, $adn, $apwd, $bdn);
 $test->init();
 $test->run();

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestBatchApplyUserAttributes.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestBatchApplyUserAttributes.php
@@ -29,6 +29,9 @@ use OCA\User_LDAP\Tests\Integration\AbstractIntegrationTest;
 require_once __DIR__ . '/../Bootstrap.php';
 
 class IntegrationTestBatchApplyUserAttributes extends AbstractIntegrationTest {
+	/** @var  UserMapping */
+	protected $mapping;
+
 	/**
 	 * prepares the LDAP environment and sets up a test configuration for
 	 * the LDAP backend.
@@ -68,6 +71,11 @@ class IntegrationTestBatchApplyUserAttributes extends AbstractIntegrationTest {
 
 }
 
+/** @var string $host */
+/** @var int $port */
+/** @var string $adn */
+/** @var string $apwd */
+/** @var string $bdn */
 $test = new IntegrationTestBatchApplyUserAttributes($host, $port, $adn, $apwd, $bdn);
 $test->init();
 $test->run();

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestConnect.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestConnect.php
@@ -23,6 +23,7 @@
 
 namespace OCA\User_LDAP\Tests\Integration\Lib;
 
+use OC\ServerNotAvailableException;
 use OCA\User_LDAP\Tests\Integration\AbstractIntegrationTest;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User_LDAP;
@@ -68,7 +69,7 @@ class IntegrationTestConnect extends AbstractIntegrationTest {
 		]);
 		try {
 			$this->connection->getConnectionResource();
-		} catch (\OC\ServerNotAvailableException $e) {
+		} catch (ServerNotAvailableException $e) {
 			return true;
 		}
 		return false;
@@ -87,7 +88,7 @@ class IntegrationTestConnect extends AbstractIntegrationTest {
 		]);
 		try {
 			$this->connection->getConnectionResource();
-		} catch (\OC\ServerNotAvailableException $e) {
+		} catch (ServerNotAvailableException $e) {
 			return false;
 		}
 		return true;
@@ -106,7 +107,7 @@ class IntegrationTestConnect extends AbstractIntegrationTest {
 		]);
 		try {
 			$this->connection->getConnectionResource();
-		} catch (\OC\ServerNotAvailableException $e) {
+		} catch (ServerNotAvailableException $e) {
 			return false;
 		}
 		return true;
@@ -125,7 +126,7 @@ class IntegrationTestConnect extends AbstractIntegrationTest {
 		]);
 		try {
 			$this->connection->getConnectionResource();
-		} catch (\OC\ServerNotAvailableException $e) {
+		} catch (ServerNotAvailableException $e) {
 			return false;
 		}
 		return true;
@@ -144,7 +145,7 @@ class IntegrationTestConnect extends AbstractIntegrationTest {
 		]);
 		try {
 			$this->connection->getConnectionResource();
-		} catch (\OC\ServerNotAvailableException $e) {
+		} catch (ServerNotAvailableException $e) {
 			return false;
 		}
 		return true;
@@ -161,6 +162,11 @@ class IntegrationTestConnect extends AbstractIntegrationTest {
 	}
 }
 
+/** @var string $host */
+/** @var int $port */
+/** @var string $adn */
+/** @var string $apwd */
+/** @var string $bdn */
 $test = new IntegrationTestConnect($host, $port, $adn, $apwd, $bdn);
 $test->init();
 $test->run();

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestCountUsersByLoginName.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestCountUsersByLoginName.php
@@ -61,6 +61,11 @@ class IntegrationTestCountUsersByLoginName extends AbstractIntegrationTest {
 	}
 }
 
+/** @var string $host */
+/** @var int $port */
+/** @var string $adn */
+/** @var string $apwd */
+/** @var string $bdn */
 $test = new IntegrationTestCountUsersByLoginName($host, $port, $adn, $apwd, $bdn);
 $test->init();
 $test->run();

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestFetchUsersByLoginName.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestFetchUsersByLoginName.php
@@ -47,7 +47,7 @@ class IntegrationTestFetchUsersByLoginName extends AbstractIntegrationTest {
 		$this->mapping = new UserMapping(\OC::$server->getDatabaseConnection());
 		$this->mapping->clear();
 		$this->access->setUserMapper($this->mapping);
-		$this->backend = new \OCA\User_LDAP\User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager());
+		$this->backend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager());
 	}
 
 	/**
@@ -74,6 +74,11 @@ class IntegrationTestFetchUsersByLoginName extends AbstractIntegrationTest {
 
 }
 
+/** @var string $host */
+/** @var int $port */
+/** @var string $adn */
+/** @var string $apwd */
+/** @var string $bdn */
 $test = new IntegrationTestFetchUsersByLoginName($host, $port, $adn, $apwd, $bdn);
 $test->init();
 $test->run();

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestPaging.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestPaging.php
@@ -44,7 +44,7 @@ class IntegrationTestPaging extends AbstractIntegrationTest {
 		require(__DIR__ . '/../setup-scripts/createExplicitUsers.php');
 		parent::init();
 
-		$this->backend = new \OCA\User_LDAP\User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager());
+		$this->backend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager());
 	}
 
 	/**
@@ -76,6 +76,11 @@ class IntegrationTestPaging extends AbstractIntegrationTest {
 	}
 }
 
+/** @var string $host */
+/** @var int $port */
+/** @var string $adn */
+/** @var string $apwd */
+/** @var string $bdn */
 $test = new IntegrationTestPaging($host, $port, $adn, $apwd, $bdn);
 $test->init();
 $test->run();

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestUserHome.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestUserHome.php
@@ -23,10 +23,13 @@
 
 namespace OCA\User_LDAP\Tests\Integration\Lib;
 
+use OCA\User_LDAP\FilesystemHelper;
+use OCA\User_LDAP\LogWrapper;
 use OCA\User_LDAP\User\Manager as LDAPUserManager;
 use OCA\User_LDAP\Tests\Integration\AbstractIntegrationTest;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User_LDAP;
+use OCP\Image;
 
 require_once __DIR__ . '/../Bootstrap.php';
 
@@ -48,7 +51,7 @@ class IntegrationTestUserHome extends AbstractIntegrationTest {
 		$this->mapping = new UserMapping(\OC::$server->getDatabaseConnection());
 		$this->mapping->clear();
 		$this->access->setUserMapper($this->mapping);
-		$this->backend = new \OCA\User_LDAP\User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager());
+		$this->backend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager());
 	}
 
 	/**
@@ -68,12 +71,13 @@ class IntegrationTestUserHome extends AbstractIntegrationTest {
 	protected function initUserManager() {
 		$this->userManager = new LDAPUserManager(
 			\OC::$server->getConfig(),
-			new \OCA\User_LDAP\FilesystemHelper(),
-			new \OCA\User_LDAP\LogWrapper(),
+			new FilesystemHelper(),
+			new LogWrapper(),
 			\OC::$server->getAvatarManager(),
-			new \OCP\Image(),
+			new Image(),
 			\OC::$server->getDatabaseConnection(),
-			\OC::$server->getUserManager()
+			\OC::$server->getUserManager(),
+			\OC::$server->getNotificationManager()
 		);
 	}
 
@@ -169,6 +173,11 @@ class IntegrationTestUserHome extends AbstractIntegrationTest {
 	}
 }
 
+/** @var string $host */
+/** @var int $port */
+/** @var string $adn */
+/** @var string $apwd */
+/** @var string $bdn */
 $test = new IntegrationTestUserHome($host, $port, $adn, $apwd, $bdn);
 $test->init();
 $test->run();

--- a/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserAvatar.php
+++ b/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserAvatar.php
@@ -25,9 +25,14 @@
 
 namespace OCA\User_LDAP\Tests\Integration\Lib\User;
 
+use OCA\User_LDAP\FilesystemHelper;
+use OCA\User_LDAP\LogWrapper;
+use OCA\User_LDAP\User\Manager;
 use OCA\User_LDAP\User\User;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\Tests\Integration\AbstractIntegrationTest;
+use OCA\User_LDAP\User_LDAP;
+use OCP\Image;
 
 require_once __DIR__ . '/../../Bootstrap.php';
 
@@ -45,7 +50,7 @@ class IntegrationTestUserAvatar extends AbstractIntegrationTest {
 		$this->mapping = new UserMapping(\OC::$server->getDatabaseConnection());
 		$this->mapping->clear();
 		$this->access->setUserMapper($this->mapping);
-		$userBackend  = new \OCA\User_LDAP\User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager());
+		$userBackend  = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager());
 		\OC_User::useBackend($userBackend);
 	}
 
@@ -123,12 +128,12 @@ class IntegrationTestUserAvatar extends AbstractIntegrationTest {
 	}
 
 	protected function initUserManager() {
-		$this->userManager = new \OCA\User_LDAP\User\Manager(
+		$this->userManager = new Manager(
 			\OC::$server->getConfig(),
-			new \OCA\User_LDAP\FilesystemHelper(),
-			new \OCA\User_LDAP\LogWrapper(),
+			new FilesystemHelper(),
+			new LogWrapper(),
 			\OC::$server->getAvatarManager(),
-			new \OCP\Image(),
+			new Image(),
 			\OC::$server->getDatabaseConnection(),
 			\OC::$server->getUserManager(),
 			\OC::$server->getNotificationManager()
@@ -149,6 +154,11 @@ class IntegrationTestUserAvatar extends AbstractIntegrationTest {
 	}
 }
 
+/** @var string $host */
+/** @var int $port */
+/** @var string $adn */
+/** @var string $apwd */
+/** @var string $bdn */
 $test = new IntegrationTestUserAvatar($host, $port, $adn, $apwd, $bdn);
 $test->init();
 $test->run();

--- a/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserDisplayName.php
+++ b/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserDisplayName.php
@@ -101,6 +101,11 @@ class IntegrationTestUserDisplayName extends AbstractIntegrationTest {
 	}
 }
 
+/** @var string $host */
+/** @var int $port */
+/** @var string $adn */
+/** @var string $apwd */
+/** @var string $bdn */
 $test = new IntegrationTestUserDisplayName($host, $port, $adn, $apwd, $bdn);
 $test->init();
 $test->run();

--- a/apps/user_ldap/tests/Integration/run-all.sh
+++ b/apps/user_ldap/tests/Integration/run-all.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+trigger_notification() {
+    which notify-send 1>/dev/null
+    if [[ $? == 1 ]] ; then
+        return
+    fi
+    export NOTIFY_USER=$SUDO_USER
+    export RESULT_STR=$1
+    # does not work. just pipe result into a non-sudo cmd
+    su "$NOTIFY_USER" -c "notify-send -u normal -t 43200000 -a Nextcloud -i Nextcloud \"LDAP Integration tests $RESULT_STR\""
+}
+
+FILES_ROOT=($(ls -d -p Lib/* | grep -v "/$"))
+FILES_USER=($(ls -d -p Lib/User/* | grep -v "/$"))
+# TODO: Loop through dirs (and subdirs?) once there are more
+TESTFILES=("${FILES_ROOT[@]}" "${FILES_USER[@]}")
+
+TESTCMD="./run-test.sh"
+
+echo "Running " ${#TESTFILES[@]} " tests"
+for TESTFILE in "${TESTFILES[@]}" ; do
+    echo -n "Test: $TESTFILE… "
+	STATE=`$TESTCMD "$TESTFILE" | grep -c "Tests succeeded"`
+	if [ "$STATE" -eq 0 ] ; then
+		echo "failed!"
+		trigger_notification "failed"
+		exit 1
+	fi
+    echo "succeeded"
+done
+
+echo -e "\nAll tests succeeded"
+trigger_notification "succeeded"


### PR DESCRIPTION
Backport of #5122 

```
$ sudo ./run-all.sh 
Running  11  tests
Test: Lib/IntegrationTestAccessGroupsMatchFilter.php… succeeded
Test: Lib/IntegrationTestAttributeDetection.php… succeeded
Test: Lib/IntegrationTestBackupServer.php… succeeded
Test: Lib/IntegrationTestBatchApplyUserAttributes.php… succeeded
Test: Lib/IntegrationTestConnect.php… succeeded
Test: Lib/IntegrationTestCountUsersByLoginName.php… succeeded
Test: Lib/IntegrationTestFetchUsersByLoginName.php… succeeded
Test: Lib/IntegrationTestPaging.php… succeeded
Test: Lib/IntegrationTestUserHome.php… succeeded
Test: Lib/User/IntegrationTestUserAvatar.php… succeeded
Test: Lib/User/IntegrationTestUserDisplayName.php… succeeded

All tests succeeded
```