### PR TITLE
Remove unneeded CSS

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -25,10 +25,6 @@ input#openid, input#webdav {
 	background-image: url('../img/toggle-filelist.svg?v=1');
 }
 
-.nav-icon-apppasswords {
-	background-image: url('../img/password.svg?v=1');
-}
-
 .nav-icon-clientsbox {
 	background-image: url('../img/change.svg?v=1');
 }


### PR DESCRIPTION
* was removed with #5166 so there is no more apppasswords-section

Signed-off-by: Marius Blüm <marius@lineone.io>