### PR TITLE
Highlight everyone group by default

### DIFF
--- a/settings/js/users/groups.js
+++ b/settings/js/users/groups.js
@@ -222,7 +222,6 @@ GroupList = {
 		UserList.update(gid === '_everyone' ? '' : gid);
 		$userGroupList.find('li').removeClass('active');
 		if (gid !== undefined) {
-			//TODO: treat Everyone properly
 			GroupList.getGroupLI(gid).addClass('active');
 		}
 	},

--- a/settings/js/users/groups.js
+++ b/settings/js/users/groups.js
@@ -380,4 +380,7 @@ $(document).ready( function () {
 	$('#newgroupname').on('input', function(){
 		GroupList.handleAddGroupInput(this.value);
 	});
+
+	// highlight `everyone` group at DOMReady by default
+	GroupList.showGroup('_everyone');
 });


### PR DESCRIPTION
This PR fix #4938 by highlighting `everyone` group by default in the group admin page.