### PR TITLE
Remove the char because it breaks the export from transifex

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -17,7 +17,7 @@
 
 	var PASSWORD_PLACEHOLDER = '**********';
 	var PASSWORD_PLACEHOLDER_MESSAGE = t('core', 'Choose a password for the public link');
-	var PASSWORD_PLACEHOLDER_MESSAGE_OPTIONAL = t('core', 'Choose a password for the public link or press "Enter ↵"');
+	var PASSWORD_PLACEHOLDER_MESSAGE_OPTIONAL = t('core', 'Choose a password for the public link or press the "Enter" key');
 
 	var TEMPLATE =
 			'{{#if shareAllowed}}' +


### PR DESCRIPTION
The character has special handling on transifex and can't be translated correctly, causing a JS console error:
> SyntaxError: unterminated string literal [More information]  de.js:130:67