### PR TITLE
[stable12] add missing parent::setUp that broke any other dav app test

### DIFF
--- a/apps/dav/tests/unit/Avatars/AvatarHomeTest.php
+++ b/apps/dav/tests/unit/Avatars/AvatarHomeTest.php
@@ -40,6 +40,7 @@ class AvatarHomeTest extends TestCase {
 	private $avatarManager;
 
 	public function setUp() {
+		parent::setUp();
 		$this->avatarManager = $this->createMock(IAvatarManager::class);
 		$this->home = new AvatarHome(['uri' => 'principals/users/admin'], $this->avatarManager);
 	}


### PR DESCRIPTION
backport of #5308 

make it possible to run only the dav tests on stable12