### PR TITLE
Fix escaping of user and group names in "shared by" message

### DIFF
--- a/core/js/sharedialogresharerinfoview.js
+++ b/core/js/sharedialogresharerinfoview.js
@@ -80,13 +80,17 @@
 					{
 						group: this.model.getReshareWithDisplayName(),
 						owner: ownerDisplayName
-					}
+					},
+					undefined,
+					{escape: false}
 				);
 			}  else {
 				sharedByText = t(
 					'core',
 					'Shared with you by {owner}',
-					{ owner: ownerDisplayName }
+					{ owner: ownerDisplayName },
+					undefined,
+					{escape: false}
 				);
 			}
 


### PR DESCRIPTION
1. Have a `&` in your display name
2. Share an item with a group that has a `&` in their name
3. As recipient open the sidebar of the folder

### Expected
`Shared with you and the group x&y by Ad&min`

### Actual
`Shared with you and the group x&amp;y by Ad&amp;min`