### PR TITLE
Prevent sending second WWW-Authenticate header

### DIFF
--- a/apps/dav/lib/Connector/Sabre/BearerAuth.php
+++ b/apps/dav/lib/Connector/Sabre/BearerAuth.php
@@ -25,6 +25,8 @@ use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUserSession;
 use Sabre\DAV\Auth\Backend\AbstractBearer;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
 
 class BearerAuth extends AbstractBearer {
 	/** @var IUserSession */
@@ -76,5 +78,17 @@ class BearerAuth extends AbstractBearer {
 		}
 
 		return false;
+	}
+
+	/**
+	 * \Sabre\DAV\Auth\Backend\AbstractBearer::challenge sets an WWW-Authenticate
+	 * header which some DAV clients can't handle. Thus we override this function
+	 * and make it simply return a 401.
+	 *
+	 * @param RequestInterface $request
+	 * @param ResponseInterface $response
+	 */
+	public function challenge(RequestInterface $request, ResponseInterface $response) {
+		$response->setStatus(401);
 	}
 }

--- a/apps/dav/tests/unit/Connector/Sabre/BearerAuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BearerAuthTest.php
@@ -21,9 +21,6 @@
 
 namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
-use OC\Authentication\TwoFactorAuth\Manager;
-use OC\Security\Bruteforce\Throttler;
-use OC\User\Session;
 use OCA\DAV\Connector\Sabre\BearerAuth;
 use OCP\IRequest;
 use OCP\ISession;
@@ -84,5 +81,14 @@ class BearerAuthTest extends TestCase {
 			->willReturn($user);
 
 		$this->assertSame('principals/users/admin', $this->bearerAuth->validateBearerToken('Token'));
+	}
+
+	public function testChallenge() {
+		/** @var \PHPUnit_Framework_MockObject_MockObject|RequestInterface $request */
+		$request = $this->createMock(RequestInterface::class);
+		/** @var \PHPUnit_Framework_MockObject_MockObject|ResponseInterface $response */
+		$response = $this->createMock(ResponseInterface::class);
+		$result = $this->bearerAuth->challenge($request, $response);
+		$this->assertEmpty($result);
 	}
 }

--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -8,7 +8,7 @@ Feature: webdav-related
 		Then the HTTP status code should be "401"
 		And there are no duplicate headers
 		And The following headers should be set
-			|WWW-Authenticate|Basic realm="Nextcloud", Bearer realm="Nextcloud"|
+			|WWW-Authenticate|Basic realm="Nextcloud"|
 
 	Scenario: Unauthenticated call new dav path
 		Given using new dav path
@@ -16,7 +16,7 @@ Feature: webdav-related
 		Then the HTTP status code should be "401"
 		And there are no duplicate headers
 		And The following headers should be set
-			|WWW-Authenticate|Bearer realm="Nextcloud", Basic realm="Nextcloud"|
+			|WWW-Authenticate|Basic realm="Nextcloud"|
 
 	Scenario: Moving a file
 		Given using old dav path


### PR DESCRIPTION
Overrides \Sabre\DAV\Auth\Backend\AbstractBearer::challenge to prevent sending a second WWW-Authenticate header which is standard-compliant but most DAV clients simply fail hard.

Fixes https://github.com/nextcloud/server/issues/5088

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>