### PR TITLE
Fix #5349, no themed icon when dragging folder

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -363,7 +363,7 @@ var createDragShadow = function(event) {
 		tbody.append(newtr);
 		if (elem.type === 'dir') {
 			newtr.find('td.filename')
-				.css('background-image', 'url(' + OC.imagePath('core', 'filetypes/folder.svg') + ')');
+				.css('background-image', 'url(' + OC.MimeType.getIconUrl('folder') + ')');
 		} else {
 			var path = dir + '/' + elem.name;
 			Files.lazyLoadPreview(path, elem.mimetype, function(previewpath) {


### PR DESCRIPTION
Fixes #5349.  Working again:
![image](https://user-images.githubusercontent.com/2029878/27089875-f00b9606-505b-11e7-801e-0acde15df5fc.png)
