### PR TITLE
Allow to find local users by their email address

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -593,24 +593,47 @@ class ShareesAPIController extends OCSController {
 	 * @return array
 	 */
 	protected function getEmail($search) {
-		$result = ['results' => [], 'exact' => []];
+		$result = ['results' => [], 'exact' => [], 'exactIdMatch' => false];
 
 		// Search in contacts
 		//@todo Pagination missing
 		$addressBookContacts = $this->contactsManager->search($search, ['EMAIL', 'FN']);
-		$result['exactIdMatch'] = false;
+		$lowerSearch = strtolower($search);
 		foreach ($addressBookContacts as $contact) {
-			if (isset($contact['isLocalSystemBook'])) {
-				continue;
-			}
 			if (isset($contact['EMAIL'])) {
 				$emailAddresses = $contact['EMAIL'];
 				if (!is_array($emailAddresses)) {
 					$emailAddresses = [$emailAddresses];
 				}
 				foreach ($emailAddresses as $emailAddress) {
-					if (strtolower($contact['FN']) === strtolower($search) || strtolower($emailAddress) === strtolower($search)) {
-						if (strtolower($emailAddress) === strtolower($search)) {
+					$exactEmailMatch = strtolower($emailAddress) === $lowerSearch;
+					if ($exactEmailMatch || strtolower($contact['FN']) === $lowerSearch) {
+						if (isset($contact['isLocalSystemBook'])) {
+							if ($exactEmailMatch) {
+								$cloud = $this->cloudIdManager->resolveCloudId($contact['CLOUD'][0]);
+								$this->result['exact']['users'][] = [
+									'label' => $contact['FN'] . " ($emailAddress)",
+									'value' => [
+										'shareType' => Share::SHARE_TYPE_USER,
+										'shareWith' => $cloud->getUser(),
+									],
+								];
+								return ['results' => [], 'exact' => [], 'exactIdMatch' => true];
+							}
+							if ($this->shareeEnumeration) {
+								$cloud = $this->cloudIdManager->resolveCloudId($contact['CLOUD'][0]);
+								$this->result['users'][] = [
+									'label' => $contact['FN'] . " ($emailAddress)",
+									'value' => [
+										'shareType' => Share::SHARE_TYPE_USER,
+										'shareWith' => $cloud->getUser(),
+									],
+								];
+							}
+							continue;
+						}
+
+						if ($exactEmailMatch) {
 							$result['exactIdMatch'] = true;
 						}
 						$result['exact'][] = [

--- a/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
@@ -1272,6 +1272,21 @@ class ShareesAPIControllerTest extends TestCase {
 				['results' => [], 'exact' => [], 'exactIdMatch' => false],
 				true,
 			],
+			// Local user found by email
+			[
+				'test@example.com',
+				[
+					[
+						'FN' => 'User',
+						'EMAIL' => ['test@example.com'],
+						'CLOUD' => ['test@localhost'],
+						'isLocalSystemBook' => true,
+					]
+				],
+				false,
+				['results' => [], 'exact' => [], 'exactIdMatch' => true],
+				false,
+			]
 		];
 	}
 


### PR DESCRIPTION
* Allow type-ahead of local users via email address
* If we match a complete email address, use a local user share and hide email + remote share options


I guess tests may fail, will adjust them then later.