### PR TITLE
Fallback to "getTitle" / "getEntity" of filesystem theme in theming app

### DIFF
--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -50,6 +50,10 @@ class ThemingDefaults extends \OC_Defaults {
 	/** @var string */
 	private $name;
 	/** @var string */
+	private $title;
+	/** @var string */
+	private $entity;
+	/** @var string */
 	private $url;
 	/** @var string */
 	private $slogan;
@@ -93,6 +97,8 @@ class ThemingDefaults extends \OC_Defaults {
 		$this->appManager = $appManager;
 
 		$this->name = parent::getName();
+		$this->title = parent::getTitle();
+		$this->entity = parent::getEntity();
 		$this->url = parent::getBaseUrl();
 		$this->slogan = parent::getSlogan();
 		$this->color = parent::getColorPrimary();
@@ -110,11 +116,11 @@ class ThemingDefaults extends \OC_Defaults {
 	}
 
 	public function getTitle() {
-		return $this->getName();
+		return strip_tags($this->config->getAppValue('theming', 'name', $this->title));
 	}
 
 	public function getEntity() {
-		return $this->getName();
+		return strip_tags($this->config->getAppValue('theming', 'name', $this->entity));
 	}
 
 	public function getBaseUrl() {


### PR DESCRIPTION
This fixes an issue with custom filesystem themes that can define title, name and entity differently, but the theming app was only using the name as fallback (see #5374).

cc @juliushaertl 