### PR TITLE
Use base url for cache prefix and SCSS caching

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -414,9 +414,11 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService(\OCP\IURLGenerator::class, function (Server $c) {
 			$config = $c->getConfig();
 			$cacheFactory = $c->getMemCacheFactory();
+			$request = $c->getRequest();
 			return new \OC\URLGenerator(
 				$config,
-				$cacheFactory
+				$cacheFactory,
+				$request
 			);
 		});
 		$this->registerAlias('URLGenerator', \OCP\IURLGenerator::class);
@@ -433,13 +435,15 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerAlias('UserCache', \OCP\ICache::class);
 
 		$this->registerService(Factory::class, function (Server $c) {
+
 			$arrayCacheFactory = new \OC\Memcache\Factory('', $c->getLogger(),
 				'\\OC\\Memcache\\ArrayCache',
 				'\\OC\\Memcache\\ArrayCache',
 				'\\OC\\Memcache\\ArrayCache'
 			);
 			$config = $c->getConfig();
-			$urlGenerator = new URLGenerator($config, $arrayCacheFactory);
+			$request = $c->getRequest();
+			$urlGenerator = new URLGenerator($config, $arrayCacheFactory, $request);
 
 			if ($config->getSystemValue('installed', false) && !(defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
 				$v = \OC_App::getAppVersions();

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -433,7 +433,13 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerAlias('UserCache', \OCP\ICache::class);
 
 		$this->registerService(Factory::class, function (Server $c) {
+			$arrayCacheFactory = new \OC\Memcache\Factory('', $c->getLogger(),
+				'\\OC\\Memcache\\ArrayCache',
+				'\\OC\\Memcache\\ArrayCache',
+				'\\OC\\Memcache\\ArrayCache'
+			);
 			$config = $c->getConfig();
+			$urlGenerator = new URLGenerator($config, $arrayCacheFactory);
 
 			if ($config->getSystemValue('installed', false) && !(defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
 				$v = \OC_App::getAppVersions();
@@ -441,19 +447,15 @@ class Server extends ServerContainer implements IServerContainer {
 				$version = implode(',', $v);
 				$instanceId = \OC_Util::getInstanceId();
 				$path = \OC::$SERVERROOT;
-				$prefix = md5($instanceId . '-' . $version . '-' . $path . '-' . \OC::$WEBROOT);
+				$prefix = md5($instanceId . '-' . $version . '-' . $path . '-' . $urlGenerator->getBaseUrl());
 				return new \OC\Memcache\Factory($prefix, $c->getLogger(),
 					$config->getSystemValue('memcache.local', null),
 					$config->getSystemValue('memcache.distributed', null),
 					$config->getSystemValue('memcache.locking', null)
 				);
 			}
+			return $arrayCacheFactory;
 
-			return new \OC\Memcache\Factory('', $c->getLogger(),
-				'\\OC\\Memcache\\ArrayCache',
-				'\\OC\\Memcache\\ArrayCache',
-				'\\OC\\Memcache\\ArrayCache'
-			);
 		});
 		$this->registerAlias('MemCacheFactory', Factory::class);
 		$this->registerAlias(ICacheFactory::class, Factory::class);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -443,7 +443,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 			if ($config->getSystemValue('installed', false) && !(defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
 				$v = \OC_App::getAppVersions();
-				$v['core'] = md5(file_get_contents(\OC::$SERVERROOT . '/version.php'));
+				$v['core'] = implode(',', \OC_Util::getVersion());
 				$version = implode(',', $v);
 				$instanceId = \OC_Util::getInstanceId();
 				$path = \OC::$SERVERROOT;

--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -92,7 +92,7 @@ class SCSSCacher {
 		$path = explode('/', $root . '/' . $file);
 
 		$fileNameSCSS = array_pop($path);
-		$fileNameCSS = $this->getBaseUrlHash() . '-' . str_replace('.scss', '.css', $fileNameSCSS);
+		$fileNameCSS = $this->prependBaseurlPrefix(str_replace('.scss', '.css', $fileNameSCSS));
 
 		$path = implode('/', $path);
 
@@ -119,7 +119,7 @@ class SCSSCacher {
 	 */
 	public function getCachedCSS($appName, $fileName) {
 		$folder = $this->appData->getFolder($appName);
-		return $folder->getFile($fileName);
+		return $folder->getFile($this->prependBaseurlPrefix($fileName));
 	}
 
 	/**
@@ -292,12 +292,17 @@ class SCSSCacher {
 	public function getCachedSCSS($appName, $fileName) {
 		$tmpfileLoc = explode('/', $fileName);
 		$fileName = array_pop($tmpfileLoc);
-		$fileName = $this->getBaseUrlHash() . '-' . str_replace('.scss', '.css', $fileName);
+		$fileName = $this->prependBaseurlPrefix(str_replace('.scss', '.css', $fileName));
 
 		return substr($this->urlGenerator->linkToRoute('core.Css.getCss', array('fileName' => $fileName, 'appName' => $appName)), strlen(\OC::$WEBROOT) + 1);
 	}
 
-	private function getBaseUrlHash() {
-		return md5($this->urlGenerator->getBaseUrl());
+	/**
+	 * Prepend hashed base url to the css file
+	 * @param $cssFile
+	 * @return string
+	 */
+	private function prependBaseurlPrefix($cssFile) {
+		return md5($this->urlGenerator->getBaseUrl()) . '-' . $cssFile;
 	}
 }

--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -92,7 +92,7 @@ class SCSSCacher {
 		$path = explode('/', $root . '/' . $file);
 
 		$fileNameSCSS = array_pop($path);
-		$fileNameCSS = str_replace('.scss', '.css', $fileNameSCSS);
+		$fileNameCSS = $this->getBaseUrlHash() . '-' . str_replace('.scss', '.css', $fileNameSCSS);
 
 		$path = implode('/', $path);
 
@@ -292,8 +292,12 @@ class SCSSCacher {
 	public function getCachedSCSS($appName, $fileName) {
 		$tmpfileLoc = explode('/', $fileName);
 		$fileName = array_pop($tmpfileLoc);
-		$fileName = str_replace('.scss', '.css', $fileName);
+		$fileName = $this->getBaseUrlHash() . '-' . str_replace('.scss', '.css', $fileName);
 
 		return substr($this->urlGenerator->linkToRoute('core.Css.getCss', array('fileName' => $fileName, 'appName' => $appName)), strlen(\OC::$WEBROOT) + 1);
+	}
+
+	private function getBaseUrlHash() {
+		return md5($this->urlGenerator->getBaseUrl());
 	}
 }

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -35,7 +35,9 @@ namespace OC;
 
 use OCP\ICacheFactory;
 use OCP\IConfig;
+use OCP\IRequest;
 use OCP\IURLGenerator;
+use OCP\Route\IRoute;
 use RuntimeException;
 
 /**
@@ -46,15 +48,20 @@ class URLGenerator implements IURLGenerator {
 	private $config;
 	/** @var ICacheFactory */
 	private $cacheFactory;
+	/** @var IRequest */
+	private $request;
 
 	/**
 	 * @param IConfig $config
 	 * @param ICacheFactory $cacheFactory
+	 * @param IRequest $request
 	 */
 	public function __construct(IConfig $config,
-								ICacheFactory $cacheFactory) {
+								ICacheFactory $cacheFactory,
+								IRequest $request) {
 		$this->config = $config;
 		$this->cacheFactory = $cacheFactory;
+		$this->request = $request;
 	}
 
 	/**
@@ -244,7 +251,6 @@ class URLGenerator implements IURLGenerator {
 	 * @return string base url of the current request
 	 */
 	public function getBaseUrl() {
-		$request = \OC::$server->getRequest();
-		return $request->getServerProtocol() . '://' . $request->getServerHost() . \OC::$WEBROOT;
+		return $this->request->getServerProtocol() . '://' . $this->request->getServerHost() . \OC::$WEBROOT;
 	}
 }

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -142,7 +142,7 @@ class URLGenerator implements IURLGenerator {
 	 * Returns the path to the image.
 	 */
 	public function imagePath($app, $image) {
-		$cache = $this->cacheFactory->create('imagePath');
+		$cache = $this->cacheFactory->create('imagePath-'.md5($this->getBaseUrl()).'-');
 		$cacheKey = $app.'-'.$image;
 		if($key = $cache->get($cacheKey)) {
 			return $key;
@@ -223,14 +223,12 @@ class URLGenerator implements IURLGenerator {
 		if (\OC::$CLI && !defined('PHPUNIT_RUN')) {
 			return rtrim($this->config->getSystemValue('overwrite.cli.url'), '/') . '/' . ltrim($url, '/');
 		}
-
 		// The ownCloud web root can already be prepended.
-		$webRoot = substr($url, 0, strlen(\OC::$WEBROOT)) === \OC::$WEBROOT
-			? ''
-			: \OC::$WEBROOT;
+		if(substr($url, 0, strlen(\OC::$WEBROOT)) === \OC::$WEBROOT) {
+			$url = substr($url, strlen(\OC::$WEBROOT));
+		}
 
-		$request = \OC::$server->getRequest();
-		return $request->getServerProtocol() . '://' . $request->getServerHost() . $webRoot . $separator . $url;
+		return $this->getBaseUrl() . $separator . $url;
 	}
 
 	/**
@@ -240,5 +238,13 @@ class URLGenerator implements IURLGenerator {
 	public function linkToDocs($key) {
 		$theme = \OC::$server->getThemingDefaults();
 		return $theme->buildDocLinkToKey($key);
+	}
+
+	/**
+	 * @return string base url of the current request
+	 */
+	public function getBaseUrl() {
+		$request = \OC::$server->getRequest();
+		return $request->getServerProtocol() . '://' . $request->getServerHost() . \OC::$WEBROOT;
 	}
 }

--- a/lib/public/IURLGenerator.php
+++ b/lib/public/IURLGenerator.php
@@ -91,4 +91,10 @@ interface IURLGenerator {
 	 * @since 8.0.0
 	 */
 	public function linkToDocs($key);
+
+	/**
+	 * @return string base url of the current request
+	 * @since 13.0.0
+	 */
+	public function getBaseUrl();
 }

--- a/tests/lib/Template/SCSSCacherTest.php
+++ b/tests/lib/Template/SCSSCacherTest.php
@@ -72,6 +72,10 @@ class SCSSCacherTest extends \Test\TestCase {
 			$this->depsCache
 		);
 		$this->themingDefaults->expects($this->any())->method('getScssVariables')->willReturn([]);
+
+		$this->urlGenerator->expects($this->any())
+			->method('getBaseUrl')
+			->willReturn('http://localhost/nextcloud');
 	}
 
 	public function testProcessUncachedFileNoAppDataFolder() {
@@ -84,14 +88,15 @@ class SCSSCacherTest extends \Test\TestCase {
 
 		$fileDeps = $this->createMock(ISimpleFile::class);
 		$gzfile = $this->createMock(ISimpleFile::class);
+		$filePrefix = md5('http://localhost/nextcloud') . '-';
 
 		$folder->method('getFile')
-			->will($this->returnCallback(function($path) use ($file, $gzfile) {
-				if ($path === 'styles.css') {
+			->will($this->returnCallback(function($path) use ($file, $gzfile, $filePrefix) {
+				if ($path === $filePrefix.'styles.css') {
 					return $file;
-				} else if ($path === 'styles.css.deps') {
+				} else if ($path === $filePrefix.'styles.css.deps') {
 					throw new NotFoundException();
-				} else if ($path === 'styles.css.gzip') {
+				} else if ($path === $filePrefix.'styles.css.gzip') {
 					return $gzfile;
 				} else {
 					$this->fail();
@@ -99,8 +104,12 @@ class SCSSCacherTest extends \Test\TestCase {
 			}));
 		$folder->expects($this->once())
 			->method('newFile')
-			->with('styles.css.deps')
+			->with($filePrefix.'styles.css.deps')
 			->willReturn($fileDeps);
+
+		$this->urlGenerator->expects($this->once())
+			->method('getBaseUrl')
+			->willReturn('http://localhost/nextcloud');
 
 		$actual = $this->scssCacher->process(\OC::$SERVERROOT, '/core/css/styles.scss', 'core');
 		$this->assertTrue($actual);
@@ -113,14 +122,15 @@ class SCSSCacherTest extends \Test\TestCase {
 		$file->expects($this->any())->method('getSize')->willReturn(1);
 		$fileDeps = $this->createMock(ISimpleFile::class);
 		$gzfile = $this->createMock(ISimpleFile::class);
+		$filePrefix = md5('http://localhost/nextcloud') . '-';
 
 		$folder->method('getFile')
-			->will($this->returnCallback(function($path) use ($file, $gzfile) {
-				if ($path === 'styles.css') {
+			->will($this->returnCallback(function($path) use ($file, $gzfile, $filePrefix) {
+				if ($path === $filePrefix.'styles.css') {
 					return $file;
-				} else if ($path === 'styles.css.deps') {
+				} else if ($path === $filePrefix.'styles.css.deps') {
 					throw new NotFoundException();
-				} else if ($path === 'styles.css.gzip') {
+				} else if ($path === $filePrefix.'styles.css.gzip') {
 					return $gzfile;
 				}else {
 					$this->fail();
@@ -128,7 +138,7 @@ class SCSSCacherTest extends \Test\TestCase {
 			}));
 		$folder->expects($this->once())
 			->method('newFile')
-			->with('styles.css.deps')
+			->with($filePrefix.'styles.css.deps')
 			->willReturn($fileDeps);
 
 		$actual = $this->scssCacher->process(\OC::$SERVERROOT, '/core/css/styles.scss', 'core');
@@ -142,14 +152,15 @@ class SCSSCacherTest extends \Test\TestCase {
 		$fileDeps = $this->createMock(ISimpleFile::class);
 		$fileDeps->expects($this->any())->method('getSize')->willReturn(1);
 		$gzFile = $this->createMock(ISimpleFile::class);
+		$filePrefix = md5('http://localhost/nextcloud') . '-';
 
 		$folder->method('getFile')
-			->will($this->returnCallback(function($name) use ($file, $fileDeps, $gzFile) {
-				if ($name === 'styles.css') {
+			->will($this->returnCallback(function($name) use ($file, $fileDeps, $gzFile, $filePrefix) {
+				if ($name === $filePrefix.'styles.css') {
 					return $file;
-				} else if ($name === 'styles.css.deps') {
+				} else if ($name === $filePrefix.'styles.css.deps') {
 					return $fileDeps;
-				} else if ($name === 'styles.css.gzip') {
+				} else if ($name === $filePrefix.'styles.css.gzip') {
 					return $gzFile;
 				}
 				$this->fail();
@@ -174,14 +185,14 @@ class SCSSCacherTest extends \Test\TestCase {
 		$fileDeps->expects($this->any())->method('getSize')->willReturn(1);
 
 		$gzFile = $this->createMock(ISimpleFile::class);
-
+		$filePrefix = md5('http://localhost/nextcloud') . '-';
 		$folder->method('getFile')
-			->will($this->returnCallback(function($name) use ($file, $fileDeps, $gzFile) {
-				if ($name === 'styles.css') {
+			->will($this->returnCallback(function($name) use ($file, $fileDeps, $gzFile, $filePrefix) {
+				if ($name === $filePrefix.'styles.css') {
 					return $file;
-				} else if ($name === 'styles.css.deps') {
+				} else if ($name === $filePrefix.'styles.css.deps') {
 					return $fileDeps;
-				} else if ($name === 'styles.css.gzip') {
+				} else if ($name === $filePrefix.'styles.css.gzip') {
 					return $gzFile;
 				}
 				$this->fail();
@@ -374,7 +385,7 @@ class SCSSCacherTest extends \Test\TestCase {
 		$this->urlGenerator->expects($this->once())
 			->method('linkToRoute')
 			->with('core.Css.getCss', [
-				'fileName' => 'styles.css',
+				'fileName' => md5('http://localhost/nextcloud') . '-styles.css',
 				'appName' => $appName
 			])
 			->willReturn(\OC::$WEBROOT . $result);

--- a/tests/lib/UrlGeneratorTest.php
+++ b/tests/lib/UrlGeneratorTest.php
@@ -9,6 +9,8 @@
 namespace Test;
 use OCP\ICacheFactory;
 use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IURLGenerator;
 
 /**
  * Class UrlGeneratorTest
@@ -17,6 +19,37 @@ use OCP\IConfig;
  */
 class UrlGeneratorTest extends \Test\TestCase {
 
+	/** @var \PHPUnit_Framework_MockObject_MockObject|IConfig */
+	private $config;
+	/** @var \PHPUnit_Framework_MockObject_MockObject|ICacheFactory */
+	private $cacheFactory;
+	/** @var \PHPUnit_Framework_MockObject_MockObject|IRequest */
+	private $request;
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
+	public function setUp() {
+		parent::setUp();
+		$this->config = $this->createMock(IConfig::class);
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->request = $this->createMock(IRequest::class);
+		$this->urlGenerator = new \OC\URLGenerator(
+			$this->config,
+			$this->cacheFactory,
+			$this->request
+		);
+	}
+
+	private function mockBaseUrl() {
+		$this->request->expects($this->once())
+			->method('getServerProtocol')
+			->willReturn('http');
+		$this->request->expects($this->once())
+			->method('getServerHost')
+			->willReturn('localhost');
+
+	}
+
 	/**
 	 * @small
 	 * test linkTo URL construction
@@ -24,11 +57,7 @@ class UrlGeneratorTest extends \Test\TestCase {
 	 */
 	public function testLinkToDocRoot($app, $file, $args, $expectedResult) {
 		\OC::$WEBROOT = '';
-		$config = $this->createMock(IConfig::class);
-		$cacheFactory = $this->createMock(ICacheFactory::class);
-		$urlGenerator = new \OC\URLGenerator($config, $cacheFactory);
-		$result = $urlGenerator->linkTo($app, $file, $args);
-
+		$result = $this->urlGenerator->linkTo($app, $file, $args);
 		$this->assertEquals($expectedResult, $result);
 	}
 
@@ -39,11 +68,7 @@ class UrlGeneratorTest extends \Test\TestCase {
 	 */
 	public function testLinkToSubDir($app, $file, $args, $expectedResult) {
 		\OC::$WEBROOT = '/owncloud';
-		$config = $this->createMock(IConfig::class);
-		$cacheFactory = $this->createMock(ICacheFactory::class);
-		$urlGenerator = new \OC\URLGenerator($config, $cacheFactory);
-		$result = $urlGenerator->linkTo($app, $file, $args);
-
+		$result = $this->urlGenerator->linkTo($app, $file, $args);
 		$this->assertEquals($expectedResult, $result);
 	}
 
@@ -51,13 +76,10 @@ class UrlGeneratorTest extends \Test\TestCase {
 	 * @dataProvider provideRoutes
 	 */
 	public function testLinkToRouteAbsolute($route, $expected) {
+		$this->mockBaseUrl();
 		\OC::$WEBROOT = '/owncloud';
-		$config = $this->createMock(IConfig::class);
-		$cacheFactory = $this->createMock(ICacheFactory::class);
-		$urlGenerator = new \OC\URLGenerator($config, $cacheFactory);
-		$result = $urlGenerator->linkToRouteAbsolute($route);
+		$result = $this->urlGenerator->linkToRouteAbsolute($route);
 		$this->assertEquals($expected, $result);
-
 	}
 
 	public function provideRoutes() {
@@ -89,13 +111,9 @@ class UrlGeneratorTest extends \Test\TestCase {
 	 * @dataProvider provideDocRootURLs
 	 */
 	function testGetAbsoluteURLDocRoot($url, $expectedResult) {
-
+		$this->mockBaseUrl();
 		\OC::$WEBROOT = '';
-		$config = $this->createMock(IConfig::class);
-		$cacheFactory = $this->createMock(ICacheFactory::class);
-		$urlGenerator = new \OC\URLGenerator($config, $cacheFactory);
-		$result = $urlGenerator->getAbsoluteURL($url);
-
+		$result = $this->urlGenerator->getAbsoluteURL($url);
 		$this->assertEquals($expectedResult, $result);
 	}
 
@@ -105,13 +123,9 @@ class UrlGeneratorTest extends \Test\TestCase {
 	 * @dataProvider provideSubDirURLs
 	 */
 	function testGetAbsoluteURLSubDir($url, $expectedResult) {
-
+		$this->mockBaseUrl();
 		\OC::$WEBROOT = '/owncloud';
-		$config = $this->createMock(IConfig::class);
-		$cacheFactory = $this->createMock(ICacheFactory::class);
-		$urlGenerator = new \OC\URLGenerator($config, $cacheFactory);
-		$result = $urlGenerator->getAbsoluteURL($url);
-
+		$result = $this->urlGenerator->getAbsoluteURL($url);
 		$this->assertEquals($expectedResult, $result);
 	}
 
@@ -132,5 +146,14 @@ class UrlGeneratorTest extends \Test\TestCase {
 			array("apps/index.php", "http://localhost/owncloud/apps/index.php"),
 			);
 	}
+
+	public function testGetBaseUrl() {
+		$this->mockBaseUrl();
+		\OC::$WEBROOT = '/nextcloud';
+		$actual = $this->urlGenerator->getBaseUrl();
+		$expected = "http://localhost/nextcloud";
+		$this->assertEquals($expected, $actual);
+	}
+
 }
 


### PR DESCRIPTION
- Add base url as cache prefix so cached imagePath calls will be stored for each base url (#5329)
- Prefix cached SCSS files with hashed baseurl (fix for #5085 as discussed in #5137)
- Cleanup URLGenerator test

