### PR TITLE
Fix 500 Internal Server Error on writing

### DIFF
--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -1117,7 +1117,7 @@ class DefaultShareProvider implements IShareProvider {
 				$gid = $row['share_with'];
 				$group = $this->groupManager->get($gid);
 
-				if ($gid === null) {
+				if ($group === null) {
 					continue;
 				}
 


### PR DESCRIPTION
In some not yet completely determined configurations, the following error could occur while writing a file:

```
Error: Call to a member function getUsers() on null
    /var/www/nextcloud/lib/private/Share20/Manager.php - line 1277: OC\Share20\DefaultShareProvider->getAccessList(Array, true)
    /var/www/nextcloud/lib/private/Share20/ShareHelper.php - line 51: OC\Share20\Manager->getAccessList(Object(OC\Files\Node\Folder), true, true)
    /var/www/nextcloud/apps/activity/lib/FilesHooks.php - line 616: OC\Share20\ShareHelper->getPathsForAccessList(Object(OC\Files\Node\File))
    /var/www/nextcloud/apps/activity/lib/FilesHooks.php - line 196: OCA\Activity\FilesHooks->getUserPathsFromPath('/path/to/file', 'user')
    /var/www/nextcloud/apps/activity/lib/FilesHooks.php - line 157: OCA\Activity\FilesHooks->addNotificationsForFileAction('/path/to/file', 'file_changed', 'changed_self', 'changed_by')
    /var/www/nextcloud/apps/activity/lib/FilesHooksStatic.php - line 55: OCA\Activity\FilesHooks->fileUpdate('/path/to/file')
    /var/www/nextcloud/lib/private/legacy/hook.php - line 106: OCA\Activity\FilesHooksStatic fileUpdate(Array)
    /var/www/nextcloud/lib/private/Files/View.php - line 1245: OC_Hook emit('OC_Filesystem', 'post_update', Array)
    /var/www/nextcloud/lib/private/Files/View.php - line 1173: OC\Files\View->runHooks(Array, '/path/to/file', true)
    /var/www/nextcloud/lib/private/Files/View.php - line 679: OC\Files\View->basicOperation('file_put_conten...', '/path/to/file', Array, '<?xml version="...')
    /var/www/nextcloud/lib/private/Files/Node/File.php - line 64: OC\Files\View->file_put_contents('/path/to/file', '<?xml version="...')
    [...]
```

Signed-off-by: Jan-Philipp Litza <janphilipp@litza.de>