### PR TITLE
Add command to apply updates to custom themes

### DIFF
--- a/core/Command/Maintenance/UpdateTheme.php
+++ b/core/Command/Maintenance/UpdateTheme.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Core\Command\Maintenance;
+
+use OC\Core\Command\Maintenance\Mimetype\UpdateJS;
+use OCP\ICacheFactory;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use OCP\Files\IMimeTypeDetector;
+
+class UpdateTheme extends UpdateJS {
+
+	/** @var IMimeTypeDetector */
+	protected $mimetypeDetector;
+
+	/** @var ICacheFactory */
+	protected $cacheFactory;
+
+	public function __construct(
+		IMimeTypeDetector $mimetypeDetector,
+		ICacheFactory $cacheFactory
+	) {
+		parent::__construct($mimetypeDetector);
+		$this->cacheFactory = $cacheFactory;
+	}
+
+	protected function configure() {
+		$this
+			->setName('maintenance:theme:update')
+			->setDescription('Apply custom theme changes');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		// run mimetypelist.js update since themes might change mimetype icons
+		parent::execute($input, $output);
+
+		// cleanup image cache
+		$c = $this->cacheFactory->create('imagePath');
+		$c->clear('');
+		$output->writeln('<info>Image cache cleared');
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -125,6 +125,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateJS(\OC::$server->getMimeTypeDetector()));
 	$application->add(new OC\Core\Command\Maintenance\Mode(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Maintenance\UpdateHtaccess());
+	$application->add(new OC\Core\Command\Maintenance\UpdateTheme(\OC::$server->getMimeTypeDetector(), \OC::$server->getMemCacheFactory()));
 
 	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig(), \OC::$server->getLogger()));
 	$application->add(new OC\Core\Command\Maintenance\Repair(

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -447,6 +447,7 @@ return array(
     'OC\\Core\\Command\\Maintenance\\Mode' => $baseDir . '/core/Command/Maintenance/Mode.php',
     'OC\\Core\\Command\\Maintenance\\Repair' => $baseDir . '/core/Command/Maintenance/Repair.php',
     'OC\\Core\\Command\\Maintenance\\UpdateHtaccess' => $baseDir . '/core/Command/Maintenance/UpdateHtaccess.php',
+    'OC\\Core\\Command\\Maintenance\\UpdateTheme' => $baseDir . '/core/Command/Maintenance/UpdateTheme.php',
     'OC\\Core\\Command\\Security\\ImportCertificate' => $baseDir . '/core/Command/Security/ImportCertificate.php',
     'OC\\Core\\Command\\Security\\ListCertificates' => $baseDir . '/core/Command/Security/ListCertificates.php',
     'OC\\Core\\Command\\Security\\RemoveCertificate' => $baseDir . '/core/Command/Security/RemoveCertificate.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -477,6 +477,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Core\\Command\\Maintenance\\Mode' => __DIR__ . '/../../..' . '/core/Command/Maintenance/Mode.php',
         'OC\\Core\\Command\\Maintenance\\Repair' => __DIR__ . '/../../..' . '/core/Command/Maintenance/Repair.php',
         'OC\\Core\\Command\\Maintenance\\UpdateHtaccess' => __DIR__ . '/../../..' . '/core/Command/Maintenance/UpdateHtaccess.php',
+        'OC\\Core\\Command\\Maintenance\\UpdateTheme' => __DIR__ . '/../../..' . '/core/Command/Maintenance/UpdateTheme.php',
         'OC\\Core\\Command\\Security\\ImportCertificate' => __DIR__ . '/../../..' . '/core/Command/Security/ImportCertificate.php',
         'OC\\Core\\Command\\Security\\ListCertificates' => __DIR__ . '/../../..' . '/core/Command/Security/ListCertificates.php',
         'OC\\Core\\Command\\Security\\RemoveCertificate' => __DIR__ . '/../../..' . '/core/Command/Security/RemoveCertificate.php',

--- a/tests/Core/Command/Maintenance/UpdateTheme.php
+++ b/tests/Core/Command/Maintenance/UpdateTheme.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Tests\Core\Command\Maintenance;
+
+use OC\Core\Command\Maintenance\Mimetype\UpdateDB;
+use OC\Core\Command\Maintenance\UpdateTheme;
+use OC\Files\Type\Detection;
+use OC\Files\Type\Loader;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Test\TestCase;
+use OCP\Files\IMimeTypeDetector;
+use OCP\Files\IMimeTypeLoader;
+
+class UpdateThemeTest extends TestCase {
+	/** @var IMimeTypeDetector */
+	protected $detector;
+	/** @var ICacheFactory */
+	protected $cacheFactory;
+
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	protected $consoleInput;
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	protected $consoleOutput;
+
+	/** @var \Symfony\Component\Console\Command\Command */
+	protected $command;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->detector = $this->createMock(Detection::class);
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+
+		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
+
+		$this->command = new UpdateTheme($this->detector, $this->cacheFactory);
+	}
+
+	public function testThemeUpdate() {
+		$this->consoleInput->method('getOption')
+			->with('maintenance:theme:update')
+			->willReturn(true);
+		$this->detector->expects($this->once())
+			->method('getAllAliases')
+			->willReturn([]);
+		$cache = $this->createMock(ICache::class);
+		$cache->expects($this->once())
+			->method('clear')
+			->with('');
+		$this->cacheFactory->expects($this->once())
+			->method('create')
+			->with('imagePath')
+			->willReturn($cache);
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
+}


### PR DESCRIPTION
After changing a custom theme the image cache needs to be cleared to make the changes appear in the web interface. Also the mimetypelist.js file needs to be regenerated. 

This PR adds an additional occ command `occ maintenance:theme:update` to take care of this.

As discussed in https://github.com/nextcloud/server/issues/5284