### PR TITLE
Fix more icon in apps menu on bright backgrounds

### DIFF
--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -26,6 +26,9 @@
 	#settings .icon-settings-white {
 		background-image: url('../../../core/img/actions/settings-dark.svg');
 	}
+	#appmenu .icon-more-white {
+		background-image: url('../../../core/img/actions/more.svg');
+	}
 }
 
 /* Colorized svg images */


### PR DESCRIPTION
Before:
![2017-06-17-100917_357x52_scrot](https://user-images.githubusercontent.com/3404133/27251341-2395693e-5345-11e7-9a9a-b851901ab5ec.png)

After:
![2017-06-17-100903_368x46_scrot](https://user-images.githubusercontent.com/3404133/27251342-25469bfe-5345-11e7-877a-de6482645c3c.png)
