### PR TITLE
Add CSP frame-ancestors support

### DIFF
--- a/lib/private/Security/CSP/ContentSecurityPolicy.php
+++ b/lib/private/Security/CSP/ContentSecurityPolicy.php
@@ -197,4 +197,18 @@ class ContentSecurityPolicy extends \OCP\AppFramework\Http\ContentSecurityPolicy
 		$this->allowedChildSrcDomains = $allowedChildSrcDomains;
 	}
 
+	/**
+	 * @return array
+	 */
+	public function getAllowedFrameAncestors() {
+		return $this->allowedFrameAncestors;
+	}
+
+	/**
+	 * @param array $allowedFrameAncestors
+	 */
+	public function setAllowedFrameAncestors($allowedFrameAncestors) {
+		$this->allowedFrameAncestors = $allowedFrameAncestors;
+	}
+
 }

--- a/lib/public/AppFramework/Http/ContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/ContentSecurityPolicy.php
@@ -84,4 +84,7 @@ class ContentSecurityPolicy extends EmptyContentSecurityPolicy {
 	];
 	/** @var array Domains from which web-workers and nested browsing content can load elements */
 	protected $allowedChildSrcDomains = [];
+
+	/** @var array Domains which can embeed this Nextcloud instance */
+	protected $allowedFrameAncestors = [];
 }

--- a/lib/public/AppFramework/Http/ContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/ContentSecurityPolicy.php
@@ -85,6 +85,6 @@ class ContentSecurityPolicy extends EmptyContentSecurityPolicy {
 	/** @var array Domains from which web-workers and nested browsing content can load elements */
 	protected $allowedChildSrcDomains = [];
 
-	/** @var array Domains which can embeed this Nextcloud instance */
+	/** @var array Domains which can embed this Nextcloud instance */
 	protected $allowedFrameAncestors = [];
 }

--- a/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
@@ -68,6 +68,8 @@ class EmptyContentSecurityPolicy {
 	protected $allowedFontDomains = null;
 	/** @var array Domains from which web-workers and nested browsing content can load elements */
 	protected $allowedChildSrcDomains = null;
+	/** @var array Domains which can embeed this Nextcloud instance */
+	protected $allowedFrameAncestors = null;
 
 	/**
 	 * Whether inline JavaScript snippets are allowed or forbidden
@@ -327,6 +329,30 @@ class EmptyContentSecurityPolicy {
 	}
 
 	/**
+	 * Domains which can embeed an iFrame of the Nextcloud instance
+	 *
+	 * @param string $domain
+	 * @return $this
+	 * @since 12.x
+	 */
+	public function addAllowedFrameAncestorDomain($domain) {
+		$this->allowedFrameAncestors[] = $domain;
+		return $this;
+	}
+
+	/**
+	 * Domains which can embeed an iFrame of the Nextcloud instance
+	 *
+	 * @param string $domain
+	 * @return $this
+	 * @since 12.x
+	 */
+	public function disallowFrameAncestorDomain($domain) {
+		$this->allowedFrameAncestors = array_diff($this->allowedFrameAncestors, [$domain]);
+		return $this;
+	}
+
+	/**
 	 * Get the generated Content-Security-Policy as a string
 	 * @return string
 	 * @since 8.1.0
@@ -402,6 +428,11 @@ class EmptyContentSecurityPolicy {
 
 		if(!empty($this->allowedChildSrcDomains)) {
 			$policy .= 'child-src ' . implode(' ', $this->allowedChildSrcDomains);
+			$policy .= ';';
+		}
+
+		if(!empty($this->allowedFrameAncestors)) {
+			$policy .= 'frame-ancestors ' . implode(' ', $this->allowedFrameAncestors);
 			$policy .= ';';
 		}
 

--- a/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
@@ -68,7 +68,7 @@ class EmptyContentSecurityPolicy {
 	protected $allowedFontDomains = null;
 	/** @var array Domains from which web-workers and nested browsing content can load elements */
 	protected $allowedChildSrcDomains = null;
-	/** @var array Domains which can embeed this Nextcloud instance */
+	/** @var array Domains which can embed this Nextcloud instance */
 	protected $allowedFrameAncestors = null;
 
 	/**
@@ -329,11 +329,11 @@ class EmptyContentSecurityPolicy {
 	}
 
 	/**
-	 * Domains which can embeed an iFrame of the Nextcloud instance
+	 * Domains which can embed an iFrame of the Nextcloud instance
 	 *
 	 * @param string $domain
 	 * @return $this
-	 * @since 12.x
+	 * @since 13.0.0
 	 */
 	public function addAllowedFrameAncestorDomain($domain) {
 		$this->allowedFrameAncestors[] = $domain;
@@ -341,11 +341,11 @@ class EmptyContentSecurityPolicy {
 	}
 
 	/**
-	 * Domains which can embeed an iFrame of the Nextcloud instance
+	 * Domains which can embed an iFrame of the Nextcloud instance
 	 *
 	 * @param string $domain
 	 * @return $this
-	 * @since 12.x
+	 * @since 13.0.0
 	 */
 	public function disallowFrameAncestorDomain($domain) {
 		$this->allowedFrameAncestors = array_diff($this->allowedFrameAncestors, [$domain]);

--- a/tests/lib/AppFramework/Http/ContentSecurityPolicyTest.php
+++ b/tests/lib/AppFramework/Http/ContentSecurityPolicyTest.php
@@ -426,4 +426,45 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org')->disallowChildSrcDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
+
+
+
+	public function testGetAllowedFrameAncestorDomain() {
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self';frame-ancestors sub.nextcloud.com";
+
+		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('sub.nextcloud.com');
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
+
+	public function testGetPolicyFrameAncestorValidMultiple() {
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self';frame-ancestors sub.nextcloud.com foo.nextcloud.com";
+
+		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('sub.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('foo.nextcloud.com');
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
+
+	public function testGetPolicyDisallowFrameAncestorDomain() {
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
+
+		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowFrameAncestorDomain('www.nextcloud.com');
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
+
+	public function testGetPolicyDisallowFrameAncestorDomainMultiple() {
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self';frame-ancestors www.nextcloud.com";
+
+		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowFrameAncestorDomain('www.nextcloud.org');
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
+
+	public function testGetPolicyDisallowFrameAncestorDomainMultipleStakes() {
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
+
+		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org')->disallowChildSrcDomain('www.owncloud.com');
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
 }


### PR DESCRIPTION
Needed to embeed nextcloud in an iframe, for instance for the calendar public page feature (see https://github.com/nextcloud/calendar/issues/169).

White-listing domains could be done in an app such as https://github.com/nextcloud/jsloader (the best would be that the (calendar) users would add that manually, but I guess this is too much).

(Didn't set the `@since` annotation yet)

Also, since I had [this issue](https://github.com/nextcloud/server/issues/5235) while running tests, I upgraded them locally for phpunit 6/php 7.1 support, but it shouldn't matter here.