### PR TITLE
LDAP Connectivity Fixes

### DIFF
--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -599,17 +599,10 @@ class Connection extends LDAPUtility {
 	 * Binds to LDAP
 	 */
 	public function bind() {
-		static $getConnectionResourceAttempt = false;
 		if(!$this->configuration->ldapConfigurationActive) {
 			return false;
 		}
-		if($getConnectionResourceAttempt) {
-			$getConnectionResourceAttempt = false;
-			return false;
-		}
-		$getConnectionResourceAttempt = true;
 		$cr = $this->getConnectionResource();
-		$getConnectionResourceAttempt = false;
 		if(!$this->ldap->isResource($cr)) {
 			return false;
 		}

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -543,7 +543,7 @@ class Connection extends LDAPUtility {
 				if($bindStatus === true) {
 					return $bindStatus;
 				}
-			} catch (\OC\ServerNotAvailableException $e) {
+			} catch (ServerNotAvailableException $e) {
 				if(trim($this->configuration->ldapBackupHost) === "") {
 					throw $e;
 				}
@@ -586,16 +586,16 @@ class Connection extends LDAPUtility {
 		$this->ldapConnectionRes = $this->ldap->connect($host, $port);
 
 		if(!$this->ldap->setOption($this->ldapConnectionRes, LDAP_OPT_PROTOCOL_VERSION, 3)) {
-			throw new \OC\ServerNotAvailableException('Could not set required LDAP Protocol version.');
+			throw new ServerNotAvailableException('Could not set required LDAP Protocol version.');
 		}
 
 		if(!$this->ldap->setOption($this->ldapConnectionRes, LDAP_OPT_REFERRALS, 0)) {
-			throw new \OC\ServerNotAvailableException('Could not disable LDAP referrals.');
+			throw new ServerNotAvailableException('Could not disable LDAP referrals.');
 		}
 
 		if($this->configuration->ldapTLS) {
 			if(!$this->ldap->startTls($this->ldapConnectionRes)) {
-				throw new \OC\ServerNotAvailableException('Start TLS failed, when connecting to LDAP host ' . $host . '.');
+				throw new ServerNotAvailableException('Start TLS failed, when connecting to LDAP host ' . $host . '.');
 			}
 		}
 

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -590,6 +590,8 @@ class Connection extends LDAPUtility {
 						throw new \OC\ServerNotAvailableException('Start TLS failed, when connecting to LDAP host ' . $host . '.');
 					}
 				}
+			} else {
+				throw new \OC\ServerNotAvailableException('Could not disable LDAP referrals.');
 			}
 		} else {
 			throw new \OC\ServerNotAvailableException('Could not set required LDAP Protocol version.');

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -582,20 +582,23 @@ class Connection extends LDAPUtility {
 		if ($host === '') {
 			return false;
 		}
+
 		$this->ldapConnectionRes = $this->ldap->connect($host, $port);
-		if($this->ldap->setOption($this->ldapConnectionRes, LDAP_OPT_PROTOCOL_VERSION, 3)) {
-			if($this->ldap->setOption($this->ldapConnectionRes, LDAP_OPT_REFERRALS, 0)) {
-				if($this->configuration->ldapTLS) {
-					if(!$this->ldap->startTls($this->ldapConnectionRes)) {
-						throw new \OC\ServerNotAvailableException('Start TLS failed, when connecting to LDAP host ' . $host . '.');
-					}
-				}
-			} else {
-				throw new \OC\ServerNotAvailableException('Could not disable LDAP referrals.');
-			}
-		} else {
+
+		if(!$this->ldap->setOption($this->ldapConnectionRes, LDAP_OPT_PROTOCOL_VERSION, 3)) {
 			throw new \OC\ServerNotAvailableException('Could not set required LDAP Protocol version.');
 		}
+
+		if(!$this->ldap->setOption($this->ldapConnectionRes, LDAP_OPT_REFERRALS, 0)) {
+			throw new \OC\ServerNotAvailableException('Could not disable LDAP referrals.');
+		}
+
+		if($this->configuration->ldapTLS) {
+			if(!$this->ldap->startTls($this->ldapConnectionRes)) {
+				throw new \OC\ServerNotAvailableException('Start TLS failed, when connecting to LDAP host ' . $host . '.');
+			}
+		}
+
 		return true;
 	}
 

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -586,7 +586,9 @@ class Connection extends LDAPUtility {
 		if($this->ldap->setOption($this->ldapConnectionRes, LDAP_OPT_PROTOCOL_VERSION, 3)) {
 			if($this->ldap->setOption($this->ldapConnectionRes, LDAP_OPT_REFERRALS, 0)) {
 				if($this->configuration->ldapTLS) {
-					$this->ldap->startTls($this->ldapConnectionRes);
+					if(!$this->ldap->startTls($this->ldapConnectionRes)) {
+						throw new \OC\ServerNotAvailableException('Start TLS failed, when connecting to LDAP host ' . $host . '.');
+					}
 				}
 			}
 		} else {

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -617,10 +617,17 @@ class Connection extends LDAPUtility {
 										$this->configuration->ldapAgentName,
 										$this->configuration->ldapAgentPassword);
 		if(!$ldapLogin) {
+			$errno = $this->ldap->errno($cr);
+
 			\OCP\Util::writeLog('user_ldap',
-				'Bind failed: ' . $this->ldap->errno($cr) . ': ' . $this->ldap->error($cr),
+				'Bind failed: ' . $errno . ': ' . $this->ldap->error($cr),
 				\OCP\Util::WARN);
-			$this->ldapConnectionRes = null;
+
+			// Set to failure mode, if LDAP error code is not LDAP_SUCCESS or LDAP_INVALID_CREDENTIALS
+			if($errno !== 0x00 && $errno !== 0x31) {
+				$this->ldapConnectionRes = null;
+			}
+
 			return false;
 		}
 		return true;

--- a/apps/user_ldap/tests/ConnectionTest.php
+++ b/apps/user_ldap/tests/ConnectionTest.php
@@ -111,6 +111,10 @@ class ConnectionTest extends \Test\TestCase {
 			->method('connect')
 			->will($this->returnValue('ldapResource'));
 
+		$this->ldap->expects($this->any())
+			->method('errno')
+			->will($this->returnValue(0));
+
 		// Not called often enough? Then, the fallback to the backup server is broken.
 		$this->connection->expects($this->exactly(4))
 			->method('getFromCache')


### PR DESCRIPTION
This fixes the inconsistent behaviour of the user_ldap app, when a Start TLS negotiation fails. This might also (partly) fix issue #5237.

Currently, for example a Nextcloud login failure can result into a server error like this:
1. An LDAP server is configured to localhost with Start TLS enabled
2. A user tries to login to Nextcloud with a valid LDAP username, but an incorrect password
3. The bind function is called in Connection.php
4. In establishConnection first the main LDAP server is tried: Now, if the Start TLS negotiation fails, an LDAP error code is registered. The bind after that doesn't result into a registered error due to the recursion fix 86d72b9a61f5e8a9b57c6f0bb431eb6722aa12a3.
5. This leads to establishConnection trying the backup LDAP server, whether it's configured or not. The recursion fix 86d72b9a61f5e8a9b57c6f0bb431eb6722aa12a3 doesn't catch a second bind attempt anymore, so ldapConnectionRes is set to null after a failing bind.
6. Finally getConnectionResource throws a ServerNotAvailableException.

What's fixed in this PR:
- LDAP_INVALID_CREDENTIALS isn't handled as a connection error (resource not set to null)
- The backup LDAP server error handling is improved and connecting to it is tried only if it's configured
- Start TLS negotiation failures throw a ServerNotAvailableException, which prevents the app from sending plain-text bind requests
    - Check out also PR #5476, which adds the SSL/TLS status information to the LDAP settings wizard. It would be beneficial for the server admins to see that information after Start TLS failures throw an exception. Apparently some old configs might have ldap_tls enabled by default.