### PR TITLE
Add a SSL/TLS status text to the LDAP server settings

### DIFF
--- a/apps/user_ldap/css/settings.css
+++ b/apps/user_ldap/css/settings.css
@@ -73,6 +73,26 @@
 	margin-right: 0;
 }
 
+.ldap_tls_on {
+	background-color: green !important;
+}
+
+.ldap_tls_off {
+	background-color: red !important;
+}
+
+#ldap_tls[disabled] {
+	background-color: #777 !important;
+}
+
+#ldap_tls {
+	font-weight: bold;
+	white-space: pre;
+	color: white;
+	background-color: #777;
+	padding: 5px;
+}
+
 .tableCellInput {
 	margin-left: -40%;
 	width: 100%;

--- a/apps/user_ldap/js/wizard/wizardDetectorPort.js
+++ b/apps/user_ldap/js/wizard/wizardDetectorPort.js
@@ -32,11 +32,25 @@ OCA = OCA || {};
 		 */
 		run: function(model, configID) {
 			model.notifyAboutDetectionStart('ldap_port');
+			model.notifyAboutDetectionStart('ldap_tls');
 			var params = OC.buildQueryString({
 				action: 'guessPortAndTLS',
 				ldap_serverconfig_chooser: configID
 			});
-			return model.callWizard(params, this.processResult, this);
+			return model.callWizard(params, this.processResultPort.bind(this), this);
+		},
+
+		/**
+		 * processes the results and sends an extra signal
+		 * about completion of the 'ldap_tls' item.
+		 *
+		 * @param {OCA.LDAP.Wizard.ConfigModel} model
+		 * @param {WizardDetectorGeneric} detector
+		 * @param {object} result
+		 */
+		processResultPort: function(model, detector, result) {
+			this.processResult(model, detector, result);
+			model['notifyAboutDetectionCompletion']('ldap_tls');
 		}
 	});
 

--- a/apps/user_ldap/js/wizard/wizardTabElementary.js
+++ b/apps/user_ldap/js/wizard/wizardTabElementary.js
@@ -41,6 +41,10 @@ OCA = OCA || {};
 					setMethod: 'setPort',
 					$relatedElements: $('.ldapDetectPort')
 				},
+				ldap_tls: {
+					$element: $('#ldap_tls'),
+					setMethod: 'setTls'
+				},
 				ldap_dn: {
 					$element: $('#ldap_dn'),
 					setMethod: 'setAgentDN',
@@ -125,6 +129,23 @@ OCA = OCA || {};
 		 */
 		setPort: function(port) {
 			this.setElementValue(this.managedItems.ldap_port.$element, port);
+		},
+
+		/**
+		 * updates the SSL/TLS status text
+		 */
+		setTls: function() {
+			this.managedItems.ldap_port.$element.removeClass('ldap_tls_on');
+			this.managedItems.ldap_port.$element.removeClass('ldap_tls_off');
+			if(this.configModel.configuration.ldap_host !== ''
+				&& this.configModel.configuration.ldap_port !== '') {
+				if(this.configModel.configuration.ldap_tls === '1'
+					|| this.configModel.configuration.ldap_host.indexOf('ldaps://') === 0) {
+					this.managedItems.ldap_tls.$element.addClass('ldap_tls_on');
+				} else {
+					this.managedItems.ldap_tls.$element.addClass('ldap_tls_off');
+				}
+			}
 		},
 
 		/**

--- a/apps/user_ldap/js/wizard/wizardTabGeneric.js
+++ b/apps/user_ldap/js/wizard/wizardTabGeneric.js
@@ -254,7 +254,7 @@ OCA = OCA || {};
 				$element.button("enable");
 			}
 			else if(!isMS || (isMS && hasOptions)) {
-				$element.prop('disabled', false);
+				$element.attr('disabled', false);
 			}
 		},
 
@@ -269,7 +269,7 @@ OCA = OCA || {};
 			} else if ($element.hasClass(this.bjQuiButtonClass)) {
 				$element.button("disable");
 			} else {
-				$element.prop('disabled', 'disabled');
+				$element.attr('disabled', 'disabled');
 			}
 		},
 

--- a/apps/user_ldap/lib/Wizard.php
+++ b/apps/user_ldap/lib/Wizard.php
@@ -702,8 +702,9 @@ class Wizard extends LDAPUtility {
 					'ldapTLS' => (int)$t
 				);
 				$this->configuration->setConfiguration($config);
-				\OCP\Util::writeLog('user_ldap', 'Wiz: detected Port ' . $p, \OCP\Util::DEBUG);
+				\OCP\Util::writeLog('user_ldap', 'Wiz: detected Port ' . $p . ', TLS '. $t, \OCP\Util::DEBUG);
 				$this->result->addChange('ldap_port', $p);
+				$this->result->addChange('ldap_tls', $t);
 				return $this->result;
 			}
 		}

--- a/apps/user_ldap/templates/part.wizard-server.php
+++ b/apps/user_ldap/templates/part.wizard-server.php
@@ -40,8 +40,9 @@
 						<span class="hostPortCombinatorSpan">
 							<input type="number" id="ldap_port" name="ldap_port"
 								placeholder="<?php p($l->t('Port'));?>" />
+							<span id="ldap_tls" name="ldap_tls"><?php p($l->t('SSL/TLS'));?></span>
 							<button class="ldapDetectPort" name="ldapDetectPort" type="button">
-								<?php p($l->t('Detect Port'));?>
+								<?php p($l->t('Detect Port and StartTLS'));?>
 							</button>
 						</span>
 					</div>


### PR DESCRIPTION
At the moment, the settings wizard shows no information whether the connection to the LDAP server is encrypted or not. It's also not mentioned that the "Detect Port" action actually does the SSL/TLS detection as well. This PR fixes these flaws by adding a SSL/TLS status text to the server tab after the port field and by changing the button text to "Detect Port and SSL/TLS".

This is how the status is shown:
- A grey background is shown, if the LDAP host and port is not configured
<img width="706" alt="nc-ldap-tls-status" src="https://user-images.githubusercontent.com/1615339/27308568-e5cf69aa-5557-11e7-8482-fd54375bc975.png">

- A red background is shown, if ldap_tls is off
<img width="687" alt="nc-ldap-tls-status-off" src="https://user-images.githubusercontent.com/1615339/27308576-f77ebb92-5557-11e7-8874-4946d99c7d8c.png">

- A green background is shown, if ldap_tls is on or the LDAP host url starts with "ldaps://"
<img width="686" alt="nc-ldap-tls-status-on" src="https://user-images.githubusercontent.com/1615339/27308580-fcb6b222-5557-11e7-97fa-ccf3252dc0e0.png">