### PR TITLE
Add Clear-Site-Data header

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -107,7 +107,9 @@ class LoginController extends Controller {
 		}
 		$this->userSession->logout();
 
-		return new RedirectResponse($this->urlGenerator->linkToRouteAbsolute('core.login.showLoginForm'));
+		$response = new RedirectResponse($this->urlGenerator->linkToRouteAbsolute('core.login.showLoginForm'));
+		$response->addHeader('Clear-Site-Data', '"cache", "cookies", "storage", "executionContexts"');
+		return $response;
 	}
 
 	/**

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -95,6 +95,7 @@ class LoginControllerTest extends TestCase {
 			->willReturn('/login');
 
 		$expected = new RedirectResponse('/login');
+		$expected->addHeader('Clear-Site-Data', '"cache", "cookies", "storage", "executionContexts"');
 		$this->assertEquals($expected, $this->loginController->logout());
 	}
 
@@ -124,6 +125,7 @@ class LoginControllerTest extends TestCase {
 			->willReturn('/login');
 
 		$expected = new RedirectResponse('/login');
+		$expected->addHeader('Clear-Site-Data', '"cache", "cookies", "storage", "executionContexts"');
 		$this->assertEquals($expected, $this->loginController->logout());
 	}
 


### PR DESCRIPTION
This adds a Clear-Site-Data header to the logout response which will delete all relevant data in the caches which may contain potentially sensitive content.

See https://w3c.github.io/webappsec-clear-site-data/#header for the definition of the types. Requires Canary + Experimental Web Platform features but will soon be shipped in stable 🙏  – so let's try this in master :)  

Ref https://twitter.com/mikewest/status/877149667909406723

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>