### PR TITLE
Create users in non default backends first

### DIFF
--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -284,7 +284,20 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @return bool|IUser the created user or false
 	 */
 	public function createUser($uid, $password) {
+		$localBackends = [];
 		foreach ($this->backends as $backend) {
+			if ($backend instanceof Database) {
+				// First check if there is another user backend
+				$localBackends[] = $backend;
+				continue;
+			}
+
+			if ($backend->implementsActions(Backend::CREATE_USER)) {
+				return $this->createUserFromBackend($uid, $password, $backend);
+			}
+		}
+
+		foreach ($localBackends as $backend) {
 			if ($backend->implementsActions(Backend::CREATE_USER)) {
 				return $this->createUserFromBackend($uid, $password, $backend);
 			}


### PR DESCRIPTION
Most of the time, when people have multiple backends or add a
custom backend, they want to create the users there and not in
the default backend. But since that is registered first, users
were always created there.

Fix #5457 