### PR TITLE
Fix response header check

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -257,7 +257,7 @@
 				};
 
 				for (var header in securityHeaders) {
-					if(!xhr.getResponseHeader(header) || xhr.getResponseHeader(header).toLowerCase().indexOf(securityHeaders[header].toLowerCase()) === 1) {
+					if(!xhr.getResponseHeader(header) || xhr.getResponseHeader(header).toLowerCase().indexOf(securityHeaders[header].toLowerCase()) === -1) {
 						messages.push({
 							msg: t('core', 'The "{header}" HTTP header is not configured to equal to "{expected}". This is a potential security or privacy risk and we recommend adjusting this setting.', {header: header, expected: securityHeaders[header]}),
 							type: OC.SetupChecks.MESSAGE_TYPE_WARNING

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -257,7 +257,7 @@
 				};
 
 				for (var header in securityHeaders) {
-					if(!xhr.getResponseHeader(header) || xhr.getResponseHeader(header).toLowerCase() !== securityHeaders[header].toLowerCase()) {
+					if(!xhr.getResponseHeader(header) || xhr.getResponseHeader(header).toLowerCase().indexOf(securityHeaders[header].toLowerCase()) === 1) {
 						messages.push({
 							msg: t('core', 'The "{header}" HTTP header is not configured to equal to "{expected}". This is a potential security or privacy risk and we recommend adjusting this setting.', {header: header, expected: securityHeaders[header]}),
 							type: OC.SetupChecks.MESSAGE_TYPE_WARNING


### PR DESCRIPTION
If a webserver or reverse proxy itself also sets the required headers,
the check will yield a false negative since the header will be set twice
(once from nextcloud, once from the webserver).

From
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getResponseHeader:
`If there are multiple response headers with the same name, then their
values are returned as a single concatenated string, where each value is
separated from the previous one by a pair of comma and space`.

So in case the header is set twice, `getResponseHeader` will return
something like `SAMEORIGIN, SAMEORIGIN` and the equals check will fail
and therefore result in a false negative. Using String.indexOf() to
search for a substring will prevent this.