### PR TITLE
Deprecate static writeLog() method

### DIFF
--- a/lib/private/App/CodeChecker/DeprecationCheck.php
+++ b/lib/private/App/CodeChecker/DeprecationCheck.php
@@ -157,6 +157,7 @@ class DeprecationCheck extends AbstractCheck implements ICheck {
 			'OCP\Util::mb_str_replace' => '8.2.0',
 			'OCP\Util::mb_substr_replace' => '8.2.0',
 			'OCP\Util::sendMail' => '8.1.0',
+			'OCP\Util::writeLog' => '13.0.0',
 		];
 	}
 }

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -150,6 +150,7 @@ class Util {
 	 * @param string $message
 	 * @param int $level
 	 * @since 4.0.0
+	 * @deprecated 13.0.0 use log of \OCP\ILogger
 	 */
 	public static function writeLog( $app, $message, $level ) {
 		$context = ['app' => $app];


### PR DESCRIPTION
In the future the ILogger interface should be used.