### PR TITLE
Optimize performance / Load CSS and JS in parallel on firefox

### DIFF
--- a/lib/private/legacy/template/functions.php
+++ b/lib/private/legacy/template/functions.php
@@ -96,11 +96,11 @@ function emit_script_tag($src, $script_content='') {
  * @param hash $obj all the script information from template
 */
 function emit_script_loading_tags($obj) {
-	if (!empty($obj['inline_ocjs'])) {
-		emit_script_tag('', $obj['inline_ocjs']);
-	}
 	foreach($obj['jsfiles'] as $jsfile) {
 		emit_script_tag($jsfile, '');
+	}
+	if (!empty($obj['inline_ocjs'])) {
+		emit_script_tag('', $obj['inline_ocjs']);
 	}
 }
 


### PR DESCRIPTION
Move the inline <script> after the external <script> because the internal JS between CSS <link> and external JS makes firefox loading CSS and JS not in parallel.
The internal js is now parsed last but will still be executed first since everything else is deferred js.