### PR TITLE
Fix style of link share password input view

### DIFF
--- a/apps/files_sharing/css/authenticate.css
+++ b/apps/files_sharing/css/authenticate.css
@@ -1,12 +1,15 @@
 #password {
-	padding: 10px;
-	margin:	6px;
+	margin-right: 0 !important;
+	border-top-right-radius: 0;
+	border-bottom-right-radius: 0;
 }
 
 input[type='submit'] {
 	width: 45px;
 	height: 45px;
-	margin:	6px;
+	margin-left: 0 !important;
+	border-top-left-radius: 0;
+	border-bottom-left-radius: 0;
 }
 
 fieldset > p {

--- a/apps/files_sharing/css/authenticate.css
+++ b/apps/files_sharing/css/authenticate.css
@@ -1,7 +1,16 @@
+form fieldset {
+	display: flex !important;
+	flex-direction: column;
+}
+
 #password {
 	margin-right: 0 !important;
 	border-top-right-radius: 0;
 	border-bottom-right-radius: 0;
+	height: 45px;
+	flex: 1 1 auto;
+	width: 100% !important;
+	min-width: 0; /* FF hack for to override default value */
 }
 
 input[type='submit'] {
@@ -13,7 +22,5 @@ input[type='submit'] {
 }
 
 fieldset > p {
-	position: relative;
-	display: flex;
-	align-items: center;
+	display: inline-flex;
 }

--- a/apps/files_sharing/templates/authenticate.php
+++ b/apps/files_sharing/templates/authenticate.php
@@ -5,7 +5,7 @@
 	script('files_sharing', 'authenticate'); 
 ?>
 <form method="post">
-	<fieldset>
+	<fieldset class="warning">
 		<?php if (!isset($_['wrongpw'])): ?>
 			<div class="warning-info"><?php p($l->t('This share is password-protected')); ?></div>
 		<?php endif; ?>


### PR DESCRIPTION
- Add box around link share password box, fix #5560
- Also move link share password box and button together so they are visually better related

Before:
![](https://user-images.githubusercontent.com/213943/27684887-2a34a92c-5ccc-11e7-808e-522c5e2bc9e2.png)

After:
![screenshot from 2017-06-29 16-34-35](https://user-images.githubusercontent.com/925062/27693259-2eec013c-5ce9-11e7-945f-cfa27e7cba1d.png) ![screenshot from 2017-06-29 16-34-47](https://user-images.githubusercontent.com/925062/27693258-2ee9f112-5ce9-11e7-90eb-43abdb46f2dc.png)

Please review @nickvergessen @nextcloud/sharing 