### PR TITLE
Public capabilities API

### DIFF
--- a/apps/theming/lib/Capabilities.php
+++ b/apps/theming/lib/Capabilities.php
@@ -23,7 +23,7 @@
 
 namespace OCA\Theming;
 
-use OCP\Capabilities\ICapability;
+use OCP\Capabilities\IPublicCapability;
 use OCP\IConfig;
 use OCP\IURLGenerator;
 
@@ -32,7 +32,7 @@ use OCP\IURLGenerator;
  *
  * @package OCA\Theming
  */
-class Capabilities implements ICapability {
+class Capabilities implements IPublicCapability {
 
 	/** @var ThemingDefaults */
 	protected $theming;

--- a/core/Controller/OCSController.php
+++ b/core/Controller/OCSController.php
@@ -80,7 +80,8 @@ class OCSController extends \OCP\AppFramework\OCSController {
 	}
 
 	/**
-	 * @NoAdminRequired
+	 * @PublicPage
+	 *
 	 * @return DataResponse
 	 */
 	public function getCapabilities() {
@@ -94,7 +95,11 @@ class OCSController extends \OCP\AppFramework\OCSController {
 			'edition' => '',
 		);
 
-		$result['capabilities'] = $this->capabilitiesManager->getCapabilities();
+		if($this->userSession->isLoggedIn()) {
+			$result['capabilities'] = $this->capabilitiesManager->getCapabilities();
+		} else {
+			$result['capabilities'] = $this->capabilitiesManager->getCapabilities(true);
+		}
 
 		return new DataResponse($result);
 	}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -66,6 +66,7 @@ return array(
     'OCP\\BackgroundJob\\IJob' => $baseDir . '/lib/public/BackgroundJob/IJob.php',
     'OCP\\BackgroundJob\\IJobList' => $baseDir . '/lib/public/BackgroundJob/IJobList.php',
     'OCP\\Capabilities\\ICapability' => $baseDir . '/lib/public/Capabilities/ICapability.php',
+    'OCP\\Capabilities\\IPublicCapability' => $baseDir . '/lib/public/Capabilities/IPublicCapability.php',
     'OCP\\Command\\IBus' => $baseDir . '/lib/public/Command/IBus.php',
     'OCP\\Command\\ICommand' => $baseDir . '/lib/public/Command/ICommand.php',
     'OCP\\Comments\\CommentsEntityEvent' => $baseDir . '/lib/public/Comments/CommentsEntityEvent.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -96,6 +96,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\BackgroundJob\\IJob' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/IJob.php',
         'OCP\\BackgroundJob\\IJobList' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/IJobList.php',
         'OCP\\Capabilities\\ICapability' => __DIR__ . '/../../..' . '/lib/public/Capabilities/ICapability.php',
+        'OCP\\Capabilities\\IPublicCapability' => __DIR__ . '/../../..' . '/lib/public/Capabilities/IPublicCapability.php',
         'OCP\\Command\\IBus' => __DIR__ . '/../../..' . '/lib/public/Command/IBus.php',
         'OCP\\Command\\ICommand' => __DIR__ . '/../../..' . '/lib/public/Command/ICommand.php',
         'OCP\\Comments\\CommentsEntityEvent' => __DIR__ . '/../../..' . '/lib/public/Comments/CommentsEntityEvent.php',

--- a/lib/private/CapabilitiesManager.php
+++ b/lib/private/CapabilitiesManager.php
@@ -57,7 +57,7 @@ class CapabilitiesManager {
 			}
 
 			if ($c instanceof ICapability) {
-				if(!$public || ($public && $c instanceof IPublicCapability)) {
+				if(!$public || $c instanceof IPublicCapability) {
 					$capabilities = array_replace_recursive($capabilities, $c->getCapabilities());
 				}
 			} else {

--- a/lib/private/CapabilitiesManager.php
+++ b/lib/private/CapabilitiesManager.php
@@ -24,6 +24,7 @@ namespace OC;
 
 use OCP\AppFramework\QueryException;
 use OCP\Capabilities\ICapability;
+use OCP\Capabilities\IPublicCapability;
 use OCP\ILogger;
 
 class CapabilitiesManager {
@@ -41,10 +42,11 @@ class CapabilitiesManager {
 	/**
 	 * Get an array of al the capabilities that are registered at this manager
      *
+	 * @param bool $public get public capabilities only
 	 * @throws \InvalidArgumentException
 	 * @return array
 	 */
-	public function getCapabilities() {
+	public function getCapabilities($public = false) {
 		$capabilities = [];
 		foreach($this->capabilities as $capability) {
 			try {
@@ -55,7 +57,9 @@ class CapabilitiesManager {
 			}
 
 			if ($c instanceof ICapability) {
-				$capabilities = array_replace_recursive($capabilities, $c->getCapabilities());
+				if(!$public || ($public && $c instanceof IPublicCapability)) {
+					$capabilities = array_replace_recursive($capabilities, $c->getCapabilities());
+				}
 			} else {
 				throw new \InvalidArgumentException('The given Capability (' . get_class($c) . ') does not implement the ICapability interface');
 			}

--- a/lib/public/Capabilities/IPublicCapability.php
+++ b/lib/public/Capabilities/IPublicCapability.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Capabilities;
+
+/**
+ * @inheritdoc
+ *
+ * @since 13.0.0
+ */
+interface IPublicCapability extends ICapability {}
+

--- a/tests/Core/Controller/OCSControllerTest.php
+++ b/tests/Core/Controller/OCSControllerTest.php
@@ -85,6 +85,9 @@ class OCSControllerTest extends TestCase {
 	}
 
 	public function testGetCapabilities() {
+		$this->userSession->expects($this->once())
+			->method('isLoggedIn')
+			->willReturn(true);
 		list($major, $minor, $micro) = \OCP\Util::getVersion();
 
 		$result = [];
@@ -104,6 +107,38 @@ class OCSControllerTest extends TestCase {
 			]
 		];
 		$this->capabilitiesManager->method('getCapabilities')
+			->willReturn($capabilities);
+
+		$result['capabilities'] = $capabilities;
+
+		$expected = new DataResponse($result);
+		$this->assertEquals($expected, $this->controller->getCapabilities());
+	}
+
+	public function testGetCapabilitiesPublic() {
+		$this->userSession->expects($this->once())
+			->method('isLoggedIn')
+			->willReturn(false);
+		list($major, $minor, $micro) = \OCP\Util::getVersion();
+
+		$result = [];
+		$result['version'] = array(
+			'major' => $major,
+			'minor' => $minor,
+			'micro' => $micro,
+			'string' => \OC_Util::getVersionString(),
+			'edition' => '',
+		);
+
+		$capabilities = [
+			'foo' => 'bar',
+			'a' => [
+				'b' => true,
+				'c' => 11,
+			]
+		];
+		$this->capabilitiesManager->method('getCapabilities')
+			->with(true)
 			->willReturn($capabilities);
 
 		$result['capabilities'] = $capabilities;

--- a/tests/lib/CapabilitiesManagerTest.php
+++ b/tests/lib/CapabilitiesManagerTest.php
@@ -24,6 +24,7 @@ namespace Test;
 use OC\CapabilitiesManager;
 use OCP\AppFramework\QueryException;
 use OCP\Capabilities\ICapability;
+use OCP\Capabilities\IPublicCapability;
 use OCP\ILogger;
 
 class CapabilitiesManagerTest extends TestCase {
@@ -35,6 +36,7 @@ class CapabilitiesManagerTest extends TestCase {
 	private $logger;
 
 	public function setUp() {
+		parent::setUp();
 		$this->logger = $this->getMockBuilder('OCP\ILogger')->getMock();
 		$this->manager = new CapabilitiesManager($this->logger);
 	}
@@ -56,6 +58,24 @@ class CapabilitiesManagerTest extends TestCase {
 		});
 
 		$res = $this->manager->getCapabilities();
+		$this->assertEquals(['foo' => 1], $res);
+	}
+
+	/**
+	 * Test a public capabilitie
+	 */
+	public function testPublicCapability() {
+		$this->manager->registerCapability(function() {
+			return new PublicSimpleCapability1();
+		});
+		$this->manager->registerCapability(function() {
+			return new SimpleCapability2();
+		});
+		$this->manager->registerCapability(function() {
+			return new SimpleCapability3();
+		});
+
+		$res = $this->manager->getCapabilities(true);
 		$this->assertEquals(['foo' => 1], $res);
 	}
 
@@ -156,6 +176,14 @@ class SimpleCapability3 implements ICapability {
 	public function getCapabilities() {
 		return [
 			'bar' => ['y' => 2]
+		];
+	}
+}
+
+class PublicSimpleCapability1 implements IPublicCapability {
+	public function getCapabilities() {
+		return [
+			'foo' => 1
 		];
 	}
 }


### PR DESCRIPTION
This PR allows apps to expose capabilities to unauthenticated users as proposed in https://github.com/nextcloud/server/issues/4510.

Apps can make use of this by implementing IPublicCapability instead of ICapability.

The second commit will expose theming values to public to allow clients to obtain those values even before login.

