### PR TITLE
Ldap agent credentials save

### DIFF
--- a/apps/user_ldap/css/settings.css
+++ b/apps/user_ldap/css/settings.css
@@ -209,11 +209,6 @@ select[multiple=multiple] + button {
 	color: #777;
 }
 
-.outoftheway {
-	position: absolute;
-	left: -2000px;
-}
-
 #ldapSettings {
 	background-color: white;
 	padding: 0;

--- a/apps/user_ldap/js/wizard/wizardTabElementary.js
+++ b/apps/user_ldap/js/wizard/wizardTabElementary.js
@@ -43,11 +43,15 @@ OCA = OCA || {};
 				},
 				ldap_dn: {
 					$element: $('#ldap_dn'),
-					setMethod: 'setAgentDN'
+					setMethod: 'setAgentDN',
+					preventAutoSave: true,
+					$saveButton: $('.ldapSaveAgentCredentials')
 				},
 				ldap_agent_password: {
 					$element: $('#ldap_agent_password'),
-					setMethod: 'setAgentPwd'
+					setMethod: 'setAgentPwd',
+					preventAutoSave: true,
+					$saveButton: $('.ldapSaveAgentCredentials')
 				},
 				ldap_base: {
 					$element: $('#ldap_base'),
@@ -65,7 +69,11 @@ OCA = OCA || {};
 				}
 			};
 			this.setManagedItems(items);
-			_.bindAll(this, 'onPortButtonClick', 'onBaseDNButtonClick', 'onBaseDNTestButtonClick');
+			_.bindAll(this,
+				'onPortButtonClick',
+				'onBaseDNButtonClick',
+				'onBaseDNTestButtonClick'
+			);
 			this.managedItems.ldap_port.$relatedElements.click(this.onPortButtonClick);
 			this.managedItems.ldap_base.$detectButton.click(this.onBaseDNButtonClick);
 			this.managedItems.ldap_base.$testButton.click(this.onBaseDNTestButtonClick);

--- a/apps/user_ldap/js/wizard/wizardTabGeneric.js
+++ b/apps/user_ldap/js/wizard/wizardTabGeneric.js
@@ -53,6 +53,7 @@ OCA = OCA || {};
 		setManagedItems: function(managedItems) {
 			this.managedItems = managedItems;
 			this._enableAutoSave();
+			this._enableSaveButton();
 		},
 
 		/**
@@ -319,7 +320,10 @@ OCA = OCA || {};
 
 			for(var id in this.managedItems) {
 				if(_.isUndefined(this.managedItems[id].$element)
-				   || _.isUndefined(this.managedItems[id].setMethod)) {
+					|| _.isUndefined(this.managedItems[id].setMethod)
+					|| (!_.isUndefined(this.managedItems[id].preventAutoSave)
+						&& this.managedItems[id].preventAutoSave === true)
+				) {
 					continue;
 				}
 				var $element = this.managedItems[id].$element;
@@ -328,6 +332,35 @@ OCA = OCA || {};
 						view._requestSave($(this));
 					});
 				}
+			}
+		},
+
+		/**
+		 * set's up save-button behavior (essentially used for agent dn and pwd)
+		 *
+		 * @private
+		 */
+		_enableSaveButton: function() {
+			var view = this;
+
+			// TODO: this is not nice, because it fires one request per change
+			// in the scenario this happens twice, causes detectors to run
+			// duplicated etc. To have this work properly, the wizard endpoint
+			// must accept setting multiple changes. Instead of messing around
+			// with old ajax/wizard.php use this opportunity and create a
+			// Controller
+			for(var id in this.managedItems) {
+				if(_.isUndefined(this.managedItems[id].$element)
+					|| _.isUndefined(this.managedItems[id].$saveButton)
+				) {
+					continue;
+				}
+				(function (item) {
+					item.$saveButton.click(function(event) {
+						event.preventDefault();
+						view._requestSave(item.$element);
+					});
+				})(this.managedItems[id]);
 			}
 		},
 

--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -190,8 +190,8 @@ class Configuration {
 			if(is_array($applied)) {
 				$applied[] = $inputKey;
 				// storing key as index avoids duplication, and as value for simplicity
-				$this->unsavedChanges[$key] = $key;
 			}
+			$this->unsavedChanges[$key] = $key;
 		}
 		return null;
 	}

--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -38,6 +38,8 @@ class Configuration {
 
 	protected $configPrefix = null;
 	protected $configRead = false;
+	/** @var string[]  */
+	protected $unsavedChanges = [];
 
 	//settings
 	protected $config = array(
@@ -185,6 +187,8 @@ class Configuration {
 			$this->$setMethod($key, $val);
 			if(is_array($applied)) {
 				$applied[] = $inputKey;
+				// storing key as index avoids duplication, and as value for simplicity
+				$this->unsavedChanges[$key] = $key;
 			}
 		}
 		return null;
@@ -238,11 +242,12 @@ class Configuration {
 	}
 
 	/**
-	 * saves the current Configuration in the database
+	 * saves the current config changes in the database
 	 */
 	public function saveConfiguration() {
 		$cta = array_flip($this->getConfigTranslationArray());
-		foreach($this->config as $key => $value) {
+		foreach($this->unsavedChanges as $key) {
+			$value = $this->config[$key];
 			switch ($key) {
 				case 'ldapAgentPassword':
 					$value = base64_encode($value);
@@ -273,6 +278,7 @@ class Configuration {
 			}
 			$this->saveValue($cta[$key], $value);
 		}
+		$this->unsavedChanges = [];
 	}
 
 	/**

--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -35,11 +35,13 @@ namespace OCA\User_LDAP;
  * @property int ldapPagingSize holds an integer
  */
 class Configuration {
-
 	protected $configPrefix = null;
 	protected $configRead = false;
-	/** @var string[]  */
-	protected $unsavedChanges = [];
+	/**
+	 * @var string[] pre-filled with one reference key so that at least one entry is written on save request and
+	 *               the config ID is registered
+	 */
+	protected $unsavedChanges = ['ldapConfigurationActive' => 'ldapConfigurationActive'];
 
 	//settings
 	protected $config = array(

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -146,7 +146,7 @@ class Connection extends LDAPUtility {
 		$this->configuration->$name = $value;
 		$after = $this->configuration->$name;
 		if($before !== $after) {
-			if ($this->configID !== '') {
+			if ($this->configID !== '' && $this->configID !== null) {
 				$this->configuration->saveConfiguration();
 			}
 			$this->validateConfiguration();

--- a/apps/user_ldap/templates/part.wizard-server.php
+++ b/apps/user_ldap/templates/part.wizard-server.php
@@ -61,6 +61,9 @@
 				placeholder="<?php p($l->t('Password'));?>" autocomplete="off"
 				title="<?php p($l->t('For anonymous access, leave DN and Password empty.'));?>"
 				/>
+				<button class="ldapSaveAgentCredentials" name="ldapSaveAgentCredentials" type="button">
+					<?php p($l->t('Save Credentials'));?>
+				</button>
 			</div>
 
 			<div class="tablerow">

--- a/apps/user_ldap/templates/part.wizard-server.php
+++ b/apps/user_ldap/templates/part.wizard-server.php
@@ -1,10 +1,3 @@
-<div class="outoftheway">
-	<!-- Hack for Safari and Chromium/Chrome which ignore autocomplete="off" -->
-	<input type="text" id="fake_user" name="fake_user" autocomplete="off" />
-	<input type="password" id="fake_password" name="fake_password"
-				autocomplete="off" />
-</div>
-
 <fieldset id="ldapWizard1">
 		<p>
 		<select id="ldap_serverconfig_chooser" name="ldap_serverconfig_chooser">

--- a/apps/user_ldap/templates/part.wizard-server.php
+++ b/apps/user_ldap/templates/part.wizard-server.php
@@ -47,6 +47,7 @@
 					</div>
 				</div>
 			</div>
+			<div class="tablerow">&nbsp;</div>
 			<div class="tablerow">
 				<input type="text" id="ldap_dn" name="ldap_dn"
 				class="tablecell"
@@ -65,6 +66,7 @@
 					<?php p($l->t('Save Credentials'));?>
 				</button>
 			</div>
+			<div class="tablerow">&nbsp;</div>
 
 			<div class="tablerow">
 				<textarea id="ldap_base" name="ldap_base"


### PR DESCRIPTION
Fixes #4476 

Some notes, first about the GUI. @nextcloud/designers !

![spectacle v18547](https://user-images.githubusercontent.com/2184312/27729903-c4ea558c-5d87-11e7-9969-2251f75a1668.png)

The _Save Credentials_ button is new, now, and always enabled (since you can allow anonymous access to LDAP). Imho it is not clear the this button must be pressed on changes to the DN or password. Also, it feels to dense. Possible enhancements:

* have a border around the DN, Password and Save button
* disable button if dn+pw were not changed, but pretty useless with browser auto-complete. Nevertheless migth still be a good idea.

What do you think? If you have other suggestions, appreciated.

Second, some technical notes:

* This also fixes a minor (i believe downstreamed) bug
* When saving LDAP config only actualy changes are written (previously everything)
* The wizard and endpoints only support saving one change a time. Which is annoying in this case, but works so far. Fixing this, requires some more changes that are out of bounds for this PR (cf. TODO in wizardTabGeneric.js)

@nextcloud/ldap 
