### PR TITLE
Ldap password renewal fixes for NC12

### DIFF
--- a/apps/user_ldap/css/renewPassword.css
+++ b/apps/user_ldap/css/renewPassword.css
@@ -18,3 +18,8 @@
 #renewpassword .title {
 	background-color: transparent;
 }
+
+input.primary,
+button.primary {
+	background-color: #00a2e9 !important;
+}

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -346,7 +346,7 @@ class Access extends LDAPUtility implements IUserTools {
 			return false;
 		}
 		try {
-			return $this->invokeLDAPMethod('modReplace', $cr, $userDN, $password);
+			return @$this->invokeLDAPMethod('modReplace', $cr, $userDN, $password);
 		} catch(ConstraintViolationException $e) {
 			throw new HintException('Password change rejected.', \OC::$server->getL10N('user_ldap')->t('Password change rejected. Hint: ').$e->getMessage(), $e->getCode());
 		}

--- a/apps/user_ldap/lib/AppInfo/Application.php
+++ b/apps/user_ldap/lib/AppInfo/Application.php
@@ -45,6 +45,7 @@ class Application extends App {
 				$c->query('UserManager'),
 				$server->getConfig(),
 				$c->query('OCP\IL10N'),
+				$c->query('Session'),
 				$server->getURLGenerator()
 			);
 		});

--- a/apps/user_ldap/lib/Controller/RenewPasswordController.php
+++ b/apps/user_ldap/lib/Controller/RenewPasswordController.php
@@ -146,7 +146,7 @@ class RenewPasswordController extends Controller {
 				$this->session->set('loginMessages', [
 					[], [$this->l10n->t("Please login with the new password")]
 				]);
-				$this->session->remove('needPasswordRenewal');
+				$this->config->setUserValue($uid, 'user_ldap', 'needsPasswordReset', 'false');
 				return new RedirectResponse($this->urlGenerator->linkToRoute('core.login.showLoginForm', $args));
 			} else {
 				$this->session->set('renewPasswordMessages', [


### PR DESCRIPTION
Here are small code changes for four issues related to LDAP password renewal that were found in the official NC12 release:

- Missing function parameter causes the password renewal page to fail. While this is a bug and certainly has to be fixed, it is quite a mystery why it worked on NC11. Maybe due to some dependency injection magic?

 - Wrong removal of `needsPasswordReset `flag from session.

- A superfluous PHP error occurs when a password change is rejected due to password policy. As this is not an error that should be shown in the server logs (let alone as log level 3), this is now suppressed.

- Since css files have been moved around in NC12 and among others a new guest.css has been introduced, the submit button for password renewal doesn't look the same as the login button anymore. Assuming that adding the password renewal path to https://github.com/nextcloud/server/blob/master/lib/private/TemplateLayout.php#L169 wouldn't be appropriate, the simplest solution was to just copy over the correct css code from guest.css to renewPassword.css.