### PR TITLE
allow to disable upload to lookup server, by default it is enabled

### DIFF
--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -931,7 +931,7 @@ class FederatedShareProvider implements IShareProvider {
 	 */
 	public function isOutgoingServer2serverShareEnabled() {
 		$result = $this->config->getAppValue('files_sharing', 'outgoing_server2server_share_enabled', 'yes');
-		return ($result === 'yes') ? true : false;
+		return ($result === 'yes');
 	}
 
 	/**
@@ -941,7 +941,7 @@ class FederatedShareProvider implements IShareProvider {
 	 */
 	public function isIncomingServer2serverShareEnabled() {
 		$result = $this->config->getAppValue('files_sharing', 'incoming_server2server_share_enabled', 'yes');
-		return ($result === 'yes') ? true : false;
+		return ($result === 'yes');
 	}
 
 	/**
@@ -951,7 +951,7 @@ class FederatedShareProvider implements IShareProvider {
 	 */
 	public function isLookupServerQueriesEnabled() {
 		$result = $this->config->getAppValue('files_sharing', 'lookupServerEnabled', 'no');
-		return ($result === 'yes') ? true : false;
+		return ($result === 'yes');
 	}
 
 
@@ -962,6 +962,6 @@ class FederatedShareProvider implements IShareProvider {
 	 */
 	public function isLookupServerUploadEnabled() {
 		$result = $this->config->getAppValue('files_sharing', 'lookupServerUploadEnabled', 'yes');
-		return ($result === 'yes') ? true : false;
+		return ($result === 'yes');
 	}
 }

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -953,4 +953,15 @@ class FederatedShareProvider implements IShareProvider {
 		$result = $this->config->getAppValue('files_sharing', 'lookupServerEnabled', 'no');
 		return ($result === 'yes') ? true : false;
 	}
+
+
+	/**
+	 * Check if it is allowed to publish user specific data to the lookup server
+	 *
+	 * @return bool
+	 */
+	public function isLookupServerUploadEnabled() {
+		$result = $this->config->getAppValue('files_sharing', 'lookupServerUploadEnabled', 'yes');
+		return ($result === 'yes') ? true : false;
+	}
 }

--- a/apps/federatedfilesharing/lib/Settings/Admin.php
+++ b/apps/federatedfilesharing/lib/Settings/Admin.php
@@ -44,6 +44,7 @@ class Admin implements ISettings {
 			'outgoingServer2serverShareEnabled' => $this->fedShareProvider->isOutgoingServer2serverShareEnabled(),
 			'incomingServer2serverShareEnabled' => $this->fedShareProvider->isIncomingServer2serverShareEnabled(),
 			'lookupServerEnabled' => $this->fedShareProvider->isLookupServerQueriesEnabled(),
+			'lookupServerUploadEnabled' => $this->fedShareProvider->isLookupServerUploadEnabled(),
 		];
 
 		return new TemplateResponse('federatedfilesharing', 'settings-admin', $parameters, '');

--- a/apps/federatedfilesharing/templates/settings-admin.php
+++ b/apps/federatedfilesharing/templates/settings-admin.php
@@ -29,7 +29,15 @@ script('federatedfilesharing', 'settings-admin');
 		<input type="checkbox" name="lookupServerEnabled" id="lookupServerEnabled" class="checkbox"
 			   value="1" <?php if ($_['lookupServerEnabled']) print_unescaped('checked="checked"'); ?> />
 		<label for="lookupServerEnabled">
-			<?php p($l->t('Search global and public address book for users'));?>
+			<?php p($l->t('Search global and public address book for users and let local users publish their data'));?>
 		</label><br/>
 	</p>
+	<p>
+		<input type="checkbox" name="lookupServerUploadEnabled" id="lookupServerUploadEnabled" class="checkbox"
+			   value="1" <?php if ($_['lookupServerUploadEnabled']) print_unescaped('checked="checked"'); ?> />
+		<label for="lookupServerUploadEnabled">
+			<?php p($l->t('Allow users to publish their data to a global and public address book'));?>
+		</label><br/>
+	</p>
+
 </div>

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -696,6 +696,38 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider dataTestFederatedSharingSettings
+	 *
+	 * @param string $isEnabled
+	 * @param bool $expected
+	 */
+	public function testIsLookupServerQueriesEnabled($isEnabled, $expected) {
+		$this->config->expects($this->once())->method('getAppValue')
+			->with('files_sharing', 'lookupServerEnabled', 'no')
+			->willReturn($isEnabled);
+
+		$this->assertSame($expected,
+			$this->provider->isLookupServerQueriesEnabled()
+		);
+	}
+
+	/**
+	 * @dataProvider dataTestFederatedSharingSettings
+	 *
+	 * @param string $isEnabled
+	 * @param bool $expected
+	 */
+	public function testIsLookupServerUploadEnabled($isEnabled, $expected) {
+		$this->config->expects($this->once())->method('getAppValue')
+			->with('files_sharing', 'lookupServerUploadEnabled', 'yes')
+			->willReturn($isEnabled);
+
+		$this->assertSame($expected,
+			$this->provider->isLookupServerUploadEnabled()
+		);
+	}
+
 	public function dataTestFederatedSharingSettings() {
 		return [
 			['yes', true],

--- a/apps/federatedfilesharing/tests/Settings/AdminTest.php
+++ b/apps/federatedfilesharing/tests/Settings/AdminTest.php
@@ -69,11 +69,16 @@ class AdminTest extends TestCase {
 			->expects($this->once())
 			->method('isLookupServerQueriesEnabled')
 			->willReturn($state);
+		$this->federatedShareProvider
+			->expects($this->once())
+			->method('isLookupServerUploadEnabled')
+			->willReturn($state);
 
 		$params = [
 			'outgoingServer2serverShareEnabled' => $state,
 			'incomingServer2serverShareEnabled' => $state,
 			'lookupServerEnabled' => $state,
+			'lookupServerUploadEnabled' => $state
 		];
 		$expected = new TemplateResponse('federatedfilesharing', 'settings-admin', $params, '');
 		$this->assertEquals($expected, $this->admin->getForm());

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -188,6 +188,10 @@ $tmpl->assign('certs', $certificateManager->listCertificates());
 $tmpl->assign('showCertificates', $enableCertImport);
 $tmpl->assign('urlGenerator', $urlGenerator);
 
+$lookupServerUploadEnabled = $config->getAppValue('files_sharing', 'lookupServerUploadEnabled', 'yes');
+$lookupServerUploadEnabled = $lookupServerUploadEnabled === 'yes';
+$tmpl->assign('lookupServerUploadEnabled', $lookupServerUploadEnabled);
+
 // Get array of group ids for this user
 $groups = \OC::$server->getGroupManager()->getUserIdGroups(OC_User::getUser());
 $groups2 = array_map(function($group) { return $group->getGID(); }, $groups);

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -61,7 +61,9 @@
 			</div>
 		</div>
 		<span class="icon-checkmark hidden"/>
+		<?php if($_['lookupServerUploadEnabled']) { ?>
 		<input type="hidden" id="avatarscope" value="<?php p($_['avatarScope']) ?>">
+		<?php } ?>
 	</form>
 </div>
 <?php endif; ?>
@@ -81,7 +83,9 @@
 				<span><?php if(isset($_['displayName']) && !empty($_['displayName'])) { p($_['displayName']); } else { p($l->t('No display name set')); } ?></span>
 			<?php } ?>
 			<span class="icon-checkmark hidden"/>
+			<?php if($_['lookupServerUploadEnabled']) { ?>
 			<input type="hidden" id="displaynamescope" value="<?php p($_['displayNameScope']) ?>">
+			<?php } ?>
 		</form>
 	</div>
 	<div class="personal-settings-setting-box">
@@ -102,9 +106,12 @@
 				<em><?php p($l->t('For password recovery and notifications')); ?></em>
 			<?php } ?>
 			<span class="icon-checkmark hidden"/>
+			<?php if($_['lookupServerUploadEnabled']) { ?>
 			<input type="hidden" id="emailscope" value="<?php p($_['emailScope']) ?>">
+			<?php } ?>
 		</form>
 	</div>
+	<?php if($_['lookupServerUploadEnabled']) { ?>
 	<div class="personal-settings-setting-box">
 		<form id="phoneform" class="section">
 			<h2>
@@ -159,7 +166,7 @@
 			<input type="hidden" id="twitterscope" value="<?php p($_['twitterScope']) ?>">
 		</form>
 	</div>
-
+	<?php } ?>
 	<span class="msg"></span>
 </div>
 </div>


### PR DESCRIPTION
In large enterprises or other organizations it is often forbidden to publish personal user data on a third party service. Therefore it makes sense to backport this setting to disable the lookup server upload.

(partial) backport of https://github.com/nextcloud/server/pull/4250