### PR TITLE
Fix renaming of non-renamble mounts

### DIFF
--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -331,11 +331,10 @@
 						case 'C':
 						case 'K':
 							data.permissions |= OC.PERMISSION_CREATE;
-							if (!isFile) {
-								data.permissions |= OC.PERMISSION_UPDATE;
-							}
 							break;
 						case 'W':
+						case 'N':
+						case 'V':
 							data.permissions |= OC.PERMISSION_UPDATE;
 							break;
 						case 'D':

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -779,14 +779,18 @@ class View {
 				$this->changeLock($path1, ILockingProvider::LOCK_EXCLUSIVE, true);
 				$this->changeLock($path2, ILockingProvider::LOCK_EXCLUSIVE, true);
 
-				if ($internalPath1 === '' and $mount1 instanceof MoveableMount) {
-					if ($this->isTargetAllowed($absolutePath2)) {
-						/**
-						 * @var \OC\Files\Mount\MountPoint | \OC\Files\Mount\MoveableMount $mount1
-						 */
-						$sourceMountPoint = $mount1->getMountPoint();
-						$result = $mount1->moveMount($absolutePath2);
-						$manager->moveMount($sourceMountPoint, $mount1->getMountPoint());
+				if ($internalPath1 === '') {
+					if ($mount1 instanceof MoveableMount) {
+						if ($this->isTargetAllowed($absolutePath2)) {
+							/**
+							 * @var \OC\Files\Mount\MountPoint | \OC\Files\Mount\MoveableMount $mount1
+							 */
+							$sourceMountPoint = $mount1->getMountPoint();
+							$result = $mount1->moveMount($absolutePath2);
+							$manager->moveMount($sourceMountPoint, $mount1->getMountPoint());
+						} else {
+							$result = false;
+						}
 					} else {
 						$result = false;
 					}


### PR DESCRIPTION
- Properly block attempts to rename non movable mountpoint roots
- Fix the parsing of dav permissions so non-movable mounts dont show as movable in the web ui

Fixes https://github.com/nextcloud/groupfolders/issues/33