### PR TITLE
Allow to enable the external storage app via the web ui

### DIFF
--- a/apps/files_external/lib/Settings/PersonalSection.php
+++ b/apps/files_external/lib/Settings/PersonalSection.php
@@ -50,18 +50,4 @@ class PersonalSection extends Section {
 		$this->userGlobalStoragesService = $userGlobalStoragesService;
 		$this->backendService = $backendService;
 	}
-
-	public function getID() {
-		if (!$this->userSession->isLoggedIn()) {
-			// we need to return the proper id while installing/upgrading the app
-			return parent::getID();
-		}
-
-		if (count($this->userGlobalStoragesService->getStorages()) > 0 || $this->backendService->isUserMountingAllowed()) {
-			return parent::getID();
-		} else {
-			// by returning a different id, no matching settings will be found and the item will be hidden
-			return null;
-		}
-	}
 }


### PR DESCRIPTION
Fix #5603


We should fix the problem,this hack is trying to solve, in a different way.

Empty sections are not displayed in the UI. So we should add a condition to the settings panel if it applies and then simply not register it.
Sounds cleaner than hacking around and returning wrong ids.