### PR TITLE
LDAP Wizard: do not attempt to recognise cert issue by using LDAPTLS_REQCERT

### DIFF
--- a/apps/user_ldap/lib/ILDAPWrapper.php
+++ b/apps/user_ldap/lib/ILDAPWrapper.php
@@ -82,14 +82,14 @@ interface ILDAPWrapper {
 	/**
 	 * Return the LDAP error number of the last LDAP command
 	 * @param resource $link LDAP link resource
-	 * @return string error message as string
+	 * @return int error code
 	 */
 	public function errno($link);
 
 	/**
 	 * Return the LDAP error message of the last LDAP command
 	 * @param resource $link LDAP link resource
-	 * @return int error code as integer
+	 * @return string error message
 	 */
 	public function error($link);
 

--- a/apps/user_ldap/lib/LDAP.php
+++ b/apps/user_ldap/lib/LDAP.php
@@ -100,7 +100,7 @@ class LDAP implements ILDAPWrapper {
 
 	/**
 	 * @param LDAP $link
-	 * @return mixed|string
+	 * @return integer
 	 */
 	public function errno($link) {
 		return $this->invokeLDAPMethod('errno', $link);
@@ -108,7 +108,7 @@ class LDAP implements ILDAPWrapper {
 
 	/**
 	 * @param LDAP $link
-	 * @return int|mixed
+	 * @return string
 	 */
 	public function error($link) {
 		return $this->invokeLDAPMethod('error', $link);


### PR DESCRIPTION
first, it does not work (at least not everywhere/reliably), second if it
did it was not reset properly. Removes a bit of complexity (and useless debug output).

Might be worth to backport… there is no known bug about this, but it would not be straight forward to track it hereto.

please review @nextcloud/ldap 