### PR TITLE
Fix sorting of favorite files in file list

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1566,11 +1566,16 @@
 			this._sort = sort;
 			this._sortDirection = (direction === 'desc')?'desc':'asc';
 			this._sortComparator = function(fileInfo1, fileInfo2) {
-				if(fileInfo1.isFavorite && !fileInfo2.isFavorite) {
+				var isFavorite = function(fileInfo) {
+					return fileInfo.tags && fileInfo.tags.indexOf(OC.TAG_FAVORITE) >= 0;
+				};
+
+				if (isFavorite(fileInfo1) && !isFavorite(fileInfo2)) {
 					return -1;
-				} else if(!fileInfo1.isFavorite && fileInfo2.isFavorite) {
+				} else if (!isFavorite(fileInfo1) && isFavorite(fileInfo2)) {
 					return 1;
 				}
+
 				return direction === 'asc' ? comparator(fileInfo1, fileInfo2) : -comparator(fileInfo1, fileInfo2);
 			};
 

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2476,6 +2476,120 @@ describe('OCA.Files.FileList tests', function() {
 
 			sortStub.restore();
 		});
+		describe('with favorites', function() {
+			it('shows favorite files on top', function() {
+				testFiles.push(new FileInfo({
+					id: 5,
+					type: 'file',
+					name: 'ZZY Before last file in ascending order',
+					mimetype: 'text/plain',
+					mtime: 999999998,
+					size: 9999998,
+					// Tags would be added by TagsPlugin
+					tags: [OC.TAG_FAVORITE],
+				}), new FileInfo({
+					id: 6,
+					type: 'file',
+					name: 'ZZZ Last file in ascending order',
+					mimetype: 'text/plain',
+					mtime: 999999999,
+					size: 9999999,
+					// Tags would be added by TagsPlugin
+					tags: [OC.TAG_FAVORITE],
+				}));
+
+				fileList.setFiles(testFiles);
+
+				// Sort by name in ascending order (default sorting is by name
+				// in ascending order, but setFiles does not trigger a sort, so
+				// the files must be sorted before being set or a sort must be
+				// triggered afterwards by clicking on the header).
+				fileList.$el.find('.column-name .columntitle').click();
+				fileList.$el.find('.column-name .columntitle').click();
+
+				expect(fileList.findFileEl('ZZY Before last file in ascending order').index()).toEqual(0);
+				expect(fileList.findFileEl('ZZZ Last file in ascending order').index()).toEqual(1);
+				expect(fileList.findFileEl('somedir').index()).toEqual(2);
+				expect(fileList.findFileEl('One.txt').index()).toEqual(3);
+				expect(fileList.findFileEl('Three.pdf').index()).toEqual(4);
+				expect(fileList.findFileEl('Two.jpg').index()).toEqual(5);
+
+				// Sort by size in ascending order
+				fileList.$el.find('.column-size .columntitle').click();
+				fileList.$el.find('.column-size .columntitle').click();
+
+				expect(fileList.findFileEl('ZZY Before last file in ascending order').index()).toEqual(0);
+				expect(fileList.findFileEl('ZZZ Last file in ascending order').index()).toEqual(1);
+				expect(fileList.findFileEl('One.txt').index()).toEqual(2);
+				expect(fileList.findFileEl('somedir').index()).toEqual(3);
+				expect(fileList.findFileEl('Two.jpg').index()).toEqual(4);
+				expect(fileList.findFileEl('Three.pdf').index()).toEqual(5);
+
+				// Sort by modification time in ascending order
+				fileList.$el.find('.column-mtime .columntitle').click();
+				fileList.$el.find('.column-mtime .columntitle').click();
+
+				expect(fileList.findFileEl('ZZY Before last file in ascending order').index()).toEqual(0);
+				expect(fileList.findFileEl('ZZZ Last file in ascending order').index()).toEqual(1);
+				expect(fileList.findFileEl('One.txt').index()).toEqual(2);
+				expect(fileList.findFileEl('somedir').index()).toEqual(3);
+				expect(fileList.findFileEl('Three.pdf').index()).toEqual(4);
+				expect(fileList.findFileEl('Two.jpg').index()).toEqual(5);
+			});
+			it('shows favorite files on top also when using descending order', function() {
+				testFiles.push(new FileInfo({
+					id: 5,
+					type: 'file',
+					name: 'AAB Before last file in descending order',
+					mimetype: 'text/plain',
+					mtime: 2,
+					size: 2,
+					// Tags would be added by TagsPlugin
+					tags: [OC.TAG_FAVORITE],
+				}), new FileInfo({
+					id: 6,
+					type: 'file',
+					name: 'AAA Last file in descending order',
+					mimetype: 'text/plain',
+					mtime: 1,
+					size: 1,
+					// Tags would be added by TagsPlugin
+					tags: [OC.TAG_FAVORITE],
+				}));
+
+				fileList.setFiles(testFiles);
+
+				// Sort by name in descending order
+				fileList.$el.find('.column-name .columntitle').click();
+
+				expect(fileList.findFileEl('AAB Before last file in descending order').index()).toEqual(0);
+				expect(fileList.findFileEl('AAA Last file in descending order').index()).toEqual(1);
+				expect(fileList.findFileEl('Two.jpg').index()).toEqual(2);
+				expect(fileList.findFileEl('Three.pdf').index()).toEqual(3);
+				expect(fileList.findFileEl('One.txt').index()).toEqual(4);
+				expect(fileList.findFileEl('somedir').index()).toEqual(5);
+
+				// Sort by size in descending order
+				fileList.$el.find('.column-size .columntitle').click();
+
+				expect(fileList.findFileEl('AAB Before last file in descending order').index()).toEqual(0);
+				expect(fileList.findFileEl('AAA Last file in descending order').index()).toEqual(1);
+				expect(fileList.findFileEl('Three.pdf').index()).toEqual(2);
+				expect(fileList.findFileEl('Two.jpg').index()).toEqual(3);
+				expect(fileList.findFileEl('somedir').index()).toEqual(4);
+				expect(fileList.findFileEl('One.txt').index()).toEqual(5);
+
+				// Sort by modification time in descending order
+				fileList.$el.find('.column-mtime .columntitle').click();
+
+				expect(fileList.findFileEl('AAB Before last file in descending order').index()).toEqual(0);
+				expect(fileList.findFileEl('AAA Last file in descending order').index()).toEqual(1);
+				expect(fileList.findFileEl('Two.jpg').index()).toEqual(2);
+				expect(fileList.findFileEl('Three.pdf').index()).toEqual(3);
+				expect(fileList.findFileEl('somedir').index()).toEqual(4);
+				expect(fileList.findFileEl('One.txt').index()).toEqual(5);
+			});
+		});
 	});
 	describe('create file', function() {
 		var deferredCreate;

--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -304,13 +304,6 @@
 				data.hasPreview = true;
 			}
 
-			var isFavorite = props['{' + Client.NS_OWNCLOUD + '}favorite'];
-			if (!_.isUndefined(isFavorite)) {
-				data.isFavorite = isFavorite === '1';
-			} else {
-				data.isFavorite = false;
-			}
-
 			var contentType = props[Client.PROPERTY_GETCONTENTTYPE];
 			if (!_.isUndefined(contentType)) {
 				data.mimetype = contentType;

--- a/core/js/files/fileinfo.js
+++ b/core/js/files/fileinfo.js
@@ -132,12 +132,7 @@
 		/**
 		 * @type boolean
 		 */
-		hasPreview: true,
-
-		/**
-		 * @type boolean
-		 */
-		isFavorite: false
+		hasPreview: true
 	};
 
 	if (!OC.Files) {

--- a/tests/acceptance/features/app-files.feature
+++ b/tests/acceptance/features/app-files.feature
@@ -68,3 +68,22 @@ Feature: app-files
     And I see that the "Sharing" tab in the details view is eventually loaded
     When I open the input field for tags in the details view
     Then I see that the input field for tags in the details view is shown
+
+  Scenario: marking a file as favorite causes the file list to be sorted again
+    Given I am logged in
+    And I create a new folder named "A name alphabetically lower than welcome.txt"
+    And I see that "A name alphabetically lower than welcome.txt" precedes "welcome.txt" in the file list
+    When I mark "welcome.txt" as favorite
+    Then I see that "welcome.txt" is marked as favorite
+    And I see that "welcome.txt" precedes "A name alphabetically lower than welcome.txt" in the file list
+
+  Scenario: unmarking a file as favorite causes the file list to be sorted again
+    Given I am logged in
+    And I create a new folder named "A name alphabetically lower than welcome.txt"
+    And I see that "A name alphabetically lower than welcome.txt" precedes "welcome.txt" in the file list
+    And I mark "welcome.txt" as favorite
+    And I see that "welcome.txt" is marked as favorite
+    And I see that "welcome.txt" precedes "A name alphabetically lower than welcome.txt" in the file list
+    When I unmark "welcome.txt" as favorite
+    Then I see that "welcome.txt" is not marked as favorite
+    And I see that "A name alphabetically lower than welcome.txt" precedes "welcome.txt" in the file list

--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -216,6 +216,40 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function createMenuButton() {
+		return Locator::forThe()->css("#controls .button.new")->
+				descendantOf(self::currentSectionMainView())->
+				describedAs("Create menu button in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function createNewFolderMenuItem() {
+		return self::createMenuItemFor("New folder");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function createNewFolderMenuItemNameInput() {
+		return Locator::forThe()->css(".filenameform input")->
+				descendantOf(self::createNewFolderMenuItem())->
+				describedAs("Name input in create new folder menu item in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	private static function createMenuItemFor($newType) {
+		return Locator::forThe()->xpath("//div[contains(concat(' ', normalize-space(@class), ' '), ' newFileMenu ')]//span[normalize-space() = '$newType']/ancestor::li")->
+				descendantOf(self::currentSectionMainView())->
+				describedAs("Create $newType menu item in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function rowForFile($fileName) {
 		return Locator::forThe()->xpath("//*[@id = 'fileList']//span[contains(concat(' ', normalize-space(@class), ' '), ' nametext ') and normalize-space() = '$fileName']/ancestor::tr")->
 				descendantOf(self::currentSectionMainView())->
@@ -225,9 +259,26 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function rowForFilePreceding($fileName1, $fileName2) {
+		return Locator::forThe()->xpath("//preceding-sibling::tr//span[contains(concat(' ', normalize-space(@class), ' '), ' nametext ') and normalize-space() = '$fileName1']/ancestor::tr")->
+				descendantOf(self::rowForFile($fileName2))->
+				describedAs("Row for file $fileName1 preceding $fileName2 in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function favoriteActionForFile($fileName) {
 		return Locator::forThe()->css(".action-favorite")->descendantOf(self::rowForFile($fileName))->
 				describedAs("Favorite action for file $fileName in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function notFavoritedStateIconForFile($fileName) {
+		return Locator::forThe()->css(".icon-star")->descendantOf(self::favoriteActionForFile($fileName))->
+				describedAs("Not favorited state icon for file $fileName in Files app");
 	}
 
 	/**
@@ -294,6 +345,16 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	}
 
 	/**
+	 * @Given I create a new folder named :folderName
+	 */
+	public function iCreateANewFolderNamed($folderName) {
+		$this->actor->find(self::createMenuButton(), 10)->click();
+
+		$this->actor->find(self::createNewFolderMenuItem(), 2)->click();
+		$this->actor->find(self::createNewFolderMenuItemNameInput(), 2)->setValue($folderName . "\r");
+	}
+
+	/**
 	 * @Given I open the :section section
 	 */
 	public function iOpenTheSection($section) {
@@ -327,6 +388,17 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @Given I mark :fileName as favorite
 	 */
 	public function iMarkAsFavorite($fileName) {
+		$this->iSeeThatIsNotMarkedAsFavorite($fileName);
+
+		$this->actor->find(self::favoriteActionForFile($fileName), 10)->click();
+	}
+
+	/**
+	 * @Given I unmark :fileName as favorite
+	 */
+	public function iUnmarkAsFavorite($fileName) {
+		$this->iSeeThatIsMarkedAsFavorite($fileName);
+
 		$this->actor->find(self::favoriteActionForFile($fileName), 10)->click();
 	}
 
@@ -414,10 +486,24 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	}
 
 	/**
+	 * @Then I see that :fileName1 precedes :fileName2 in the file list
+	 */
+	public function iSeeThatPrecedesInTheFileList($fileName1, $fileName2) {
+		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::rowForFilePreceding($fileName1, $fileName2), 10));
+	}
+
+	/**
 	 * @Then I see that :fileName is marked as favorite
 	 */
 	public function iSeeThatIsMarkedAsFavorite($fileName) {
 		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::favoritedStateIconForFile($fileName), 10));
+	}
+
+	/**
+	 * @Then I see that :fileName is not marked as favorite
+	 */
+	public function iSeeThatIsNotMarkedAsFavorite($fileName) {
+		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::notFavoritedStateIconForFile($fileName), 10));
 	}
 
 	/**


### PR DESCRIPTION
Fix for #5410

In the end I decided that making the sort comparator extensible by plugins was not worth it right now; I prefer to defer that until there are more use cases in order to get a better idea of the needed API. Also, as @nickvergessen  pointed out, favorite files is a core feature of the file list even if implemented as a plugin, so it is not so terrible if it is taken into account in the main sorting logic ;)

Acceptance tests for the original issue could not be provided, as at this time the acceptance test system only supports tests that exclusively depend on the core server (and the original issue was related to the text editor, which is a separate app). However, acceptance tests were provided for a related issue: marking a file as a favorite should sort again the file list.

I assumed that it was a bug, but I prefer to notify @nextcloud/designers  just in case: before, when you marked a file as a favorite, the file stayed in the same position in the file list. However, when you reloaded the file list (for example reloading the page, or changing to a different folder and then going back to the original one), the file the appeared at the top of the file list with the other favorite files. Now, when you mark a file as a favorite, the file is immediately moved to the top with the other favorite files (personally I would add a quick animation for that position change, but that is another matter ;) ). As I said I assumed that it was a bug, but maybe it was an explicit design decision to prevent a "Where did my file just go?" reaction from the user.

In any case, once it is confirmed that it now works as it should, should I backport the fix to Nextcloud 12? I would say yes, as it is just a small bugfix, but you know better than me ;)
