### PR TITLE
Only create the migration directory when necessary

### DIFF
--- a/core/Command/Db/Migrations/GenerateCommand.php
+++ b/core/Command/Db/Migrations/GenerateCommand.php
@@ -136,6 +136,8 @@ class <classname> extends SimpleMigrationStep {
 		];
 		$code = str_replace($placeHolders, $replacements, self::$_templateSimple);
 		$dir = $ms->getMigrationsDirectory();
+
+		$this->ensureMigrationDirExists($dir);
 		$path = $dir . '/' . $className . '.php';
 
 		if (file_put_contents($path, $code) === false) {
@@ -145,4 +147,19 @@ class <classname> extends SimpleMigrationStep {
 		return $path;
 	}
 
+	private function ensureMigrationDirExists($directory) {
+		if (file_exists($directory) && is_dir($directory)) {
+			return;
+		}
+
+		if (file_exists($directory)) {
+			throw new \RuntimeException("Could not create folder \"$directory\"");
+		}
+
+		$this->ensureMigrationDirExists(dirname($directory));
+
+		if (!@mkdir($directory) && !is_dir($directory)) {
+			throw new \RuntimeException("Could not create folder \"$directory\"");
+		}
+	}
 }

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -25,7 +25,6 @@
 
 namespace OC\DB;
 
-use Doctrine\DBAL\Schema\Schema;
 use OC\IntegrityCheck\Helpers\AppLocator;
 use OC\Migration\SimpleOutput;
 use OCP\AppFramework\App;
@@ -78,14 +77,6 @@ class MigrationService {
 			$namespace = App::buildAppNamespace($appName);
 			$this->migrationsPath = "$appPath/lib/Migration";
 			$this->migrationsNamespace = $namespace . '\\Migration';
-
-			if (!@mkdir($appPath . '/lib') && !is_dir($appPath . '/lib')) {
-				throw new \RuntimeException("Could not create migration folder \"{$this->migrationsPath}\"");
-			}
-		}
-
-		if (!@mkdir($this->migrationsPath) && !is_dir($this->migrationsPath)) {
-			throw new \RuntimeException("Could not create migration folder \"{$this->migrationsPath}\"");
 		}
 	}
 
@@ -164,6 +155,10 @@ class MigrationService {
 
 	protected function findMigrations() {
 		$directory = realpath($this->migrationsPath);
+		if (!file_exists($directory) || !is_dir($directory)) {
+			return [];
+		}
+
 		$iterator = new \RegexIterator(
 			new \RecursiveIteratorIterator(
 				new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -131,6 +131,7 @@ class Installer {
 
 		// check for required dependencies
 		\OC_App::checkAppDependencies($this->config, $l, $info);
+		\OC_App::registerAutoloading($appId, $basedir);
 
 		//install the database
 		if(is_file($basedir.'/appinfo/database.xml')) {
@@ -144,7 +145,6 @@ class Installer {
 			$ms->migrate();
 		}
 
-		\OC_App::registerAutoloading($appId, $basedir);
 		\OC_App::setupBackgroundJobs($info['background-jobs']);
 		if(isset($info['settings']) && is_array($info['settings'])) {
 			\OC::$server->getSettingsManager()->setupSettings($info['settings']);


### PR DESCRIPTION
For me there were empty folders created for every app that had no db schema file and triggered an update.

Also installing failed, tested with the spreed app. Autoloading was registered too late.