### PR TITLE
recognize groupOfUniqueNames as valid LDAP group object

### DIFF
--- a/apps/user_ldap/lib/Wizard.php
+++ b/apps/user_ldap/lib/Wizard.php
@@ -419,7 +419,7 @@ class Wizard extends LDAPUtility {
 	 * @throws \Exception
 	 */
 	public function fetchGroups($dbKey, $confKey) {
-		$obclasses = array('posixGroup', 'group', 'zimbraDistributionList', 'groupOfNames');
+		$obclasses = array('posixGroup', 'group', 'zimbraDistributionList', 'groupOfNames', 'groupOfUniqueNames');
 
 		$filterParts = array();
 		foreach($obclasses as $obclass) {


### PR DESCRIPTION
This was already partly done in f88109b but was missed in the `fetchGroups` function.