### PR TITLE
add occ app:install command

### DIFF
--- a/core/Command/App/Install.php
+++ b/core/Command/App/Install.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ *
+ * @author Klaus Herberth <klaus@jsxc.org>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+use OC\Installer;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Install extends Command {
+
+	protected function configure() {
+		$this
+			->setName('app:install')
+			->setDescription('install an app')
+			->addArgument(
+				'app-id',
+				InputArgument::REQUIRED,
+				'install the specified app'
+			)
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$appId = $input->getArgument('app-id');
+
+		if (\OC_App::getAppPath($appId)) {
+			$output->writeln($appId . ' already installed');
+			return 1;
+		}
+
+		try {
+			$installer = new Installer(
+				\OC::$server->getAppFetcher(),
+				\OC::$server->getHTTPClientService(),
+				\OC::$server->getTempManager(),
+				\OC::$server->getLogger(),
+				\OC::$server->getConfig()
+			);
+			$installer->downloadApp($appId);
+			$result = $installer->installApp($appId);
+		} catch(\Exception $e) {
+			$output->writeln('Error: ' . $e->getMessage());
+			return 1;
+		}
+
+		if($result === false) {
+			$output->writeln($appId . ' couldn\'t be installed');
+			return 1;
+		}
+
+		$output->writeln($appId . ' installed');
+
+		return 0;
+	}
+}

--- a/core/Command/App/Install.php
+++ b/core/Command/App/Install.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace OC\Core\Command\App;
+
 use OC\Installer;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -59,9 +59,10 @@ $application->add(new \OC\Core\Command\Integrity\CheckCore(
 if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\App\Disable(\OC::$server->getAppManager()));
 	$application->add(new OC\Core\Command\App\Enable(\OC::$server->getAppManager()));
+	$application->add(new OC\Core\Command\App\Install());
 	$application->add(new OC\Core\Command\App\GetPath());
 	$application->add(new OC\Core\Command\App\ListApps(\OC::$server->getAppManager()));
-	
+
 	$application->add(new OC\Core\Command\TwoFactorAuth\Enable(
 		\OC::$server->getTwoFactorAuthManager(), \OC::$server->getUserManager()
 	));

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -404,6 +404,7 @@ return array(
     'OC\\Core\\Command\\App\\Disable' => $baseDir . '/core/Command/App/Disable.php',
     'OC\\Core\\Command\\App\\Enable' => $baseDir . '/core/Command/App/Enable.php',
     'OC\\Core\\Command\\App\\GetPath' => $baseDir . '/core/Command/App/GetPath.php',
+    'OC\\Core\\Command\\App\\Install' => $baseDir . '/core/Command/App/Install.php',
     'OC\\Core\\Command\\App\\ListApps' => $baseDir . '/core/Command/App/ListApps.php',
     'OC\\Core\\Command\\Background\\Ajax' => $baseDir . '/core/Command/Background/Ajax.php',
     'OC\\Core\\Command\\Background\\Base' => $baseDir . '/core/Command/Background/Base.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -434,6 +434,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Core\\Command\\App\\Disable' => __DIR__ . '/../../..' . '/core/Command/App/Disable.php',
         'OC\\Core\\Command\\App\\Enable' => __DIR__ . '/../../..' . '/core/Command/App/Enable.php',
         'OC\\Core\\Command\\App\\GetPath' => __DIR__ . '/../../..' . '/core/Command/App/GetPath.php',
+        'OC\\Core\\Command\\App\\Install' => __DIR__ . '/../../..' . '/core/Command/App/Install.php',
         'OC\\Core\\Command\\App\\ListApps' => __DIR__ . '/../../..' . '/core/Command/App/ListApps.php',
         'OC\\Core\\Command\\Background\\Ajax' => __DIR__ . '/../../..' . '/core/Command/Background/Ajax.php',
         'OC\\Core\\Command\\Background\\Base' => __DIR__ . '/../../..' . '/core/Command/Background/Base.php',


### PR DESCRIPTION
fix #1599

This new command downloads the specific app from the app store, but doesn't enable it.