### PR TITLE
Fix unselecting items on multi select dropdowns

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -93,6 +93,7 @@ function addSelect2 ($elements, userListLimit) {
 		placeholder: t('files_external', 'All users. Type to select user or group.'),
 		allowClear: true,
 		multiple: true,
+		toggleSelect: true,
 		dropdownCssClass: 'files-external-select2',
 		//minimumInputLength: 1,
 		ajax: {

--- a/apps/systemtags/js/systemtagsfilelist.js
+++ b/apps/systemtags/js/systemtagsfilelist.js
@@ -88,6 +88,7 @@
 				placeholder: t('systemtags', 'Select tags to filter by'),
 				allowClear: false,
 				multiple: true,
+				toggleSelect: true,
 				separator: ',',
 				query: _.bind(this._queryTagsAutocomplete, this),
 

--- a/core/js/merged-template-prepend.json
+++ b/core/js/merged-template-prepend.json
@@ -12,6 +12,7 @@
   "mimetype.js",
   "mimetypelist.js",
   "oc-backbone.js",
+  "select2-toggleselect.js",
   "placeholder.js",
   "jquery.avatar.js",
   "jquery.contactsmenu.js"

--- a/settings/js/settings.js
+++ b/settings/js/settings.js
@@ -30,6 +30,7 @@ OC.Settings = _.extend(OC.Settings, {
 				placeholder: t('core', 'Groups'),
 				allowClear: true,
 				multiple: true,
+				toggleSelect: true,
 				separator: '|',
 				query: _.debounce(function(query) {
 					var queryData = {};

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -15,6 +15,7 @@ default:
         - FilesSharingAppContext
         - LoginPageContext
         - NotificationContext
+        - SettingsContext
         - SettingsMenuContext
         - UsersSettingsContext
   extensions:

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -9,6 +9,7 @@ default:
         - ActorContext
         - NextcloudTestServerContext
 
+        - AppNavigationContext
         - FeatureContext
         - FilesAppContext
         - FilesSharingAppContext

--- a/tests/acceptance/features/app-files.feature
+++ b/tests/acceptance/features/app-files.feature
@@ -69,6 +69,78 @@ Feature: app-files
     When I open the input field for tags in the details view
     Then I see that the input field for tags in the details view is shown
 
+  Scenario: create tags using the Administration settings
+    Given I am logged in as the admin
+    And I visit the settings page
+    And I open the "Workflow" section
+    # The "create" button does nothing before JavaScript was initialized, and
+    # the only way to detect that is waiting for the button to select tags to be
+    # shown.
+    And I see that the button to select tags is shown
+    When I create the tag "tag1" in the settings
+    Then I see that the dropdown for tags in the settings eventually contains the tag "tag1"
+
+  Scenario: add tags using the dropdown in the details view
+    Given I am logged in as the admin
+    And I visit the settings page
+    And I open the "Workflow" section
+    # The "create" button does nothing before JavaScript was initialized, and
+    # the only way to detect that is waiting for the button to select tags to be
+    # shown.
+    And I see that the button to select tags is shown
+    And I create the tag "tag1" in the settings
+    And I create the tag "tag2" in the settings
+    And I create the tag "tag3" in the settings
+    And I create the tag "tag4" in the settings
+    And I see that the dropdown for tags in the settings eventually contains the tag "tag1"
+    And I see that the dropdown for tags in the settings eventually contains the tag "tag2"
+    And I see that the dropdown for tags in the settings eventually contains the tag "tag3"
+    And I see that the dropdown for tags in the settings eventually contains the tag "tag4"
+    And I log out
+    And I am logged in
+    And I open the details view for "welcome.txt"
+    And I open the input field for tags in the details view
+    # When the input field is opened the dropdown is also opened automatically.
+    When I check the tag "tag2" in the dropdown for tags in the details view
+    And I check the tag "tag4" in the dropdown for tags in the details view
+    Then I see that the tag "tag2" in the dropdown for tags in the details view is checked
+    And I see that the tag "tag4" in the dropdown for tags in the details view is checked
+    And I see that the input field for tags in the details view contains the tag "tag2"
+    And I see that the input field for tags in the details view contains the tag "tag4"
+
+  Scenario: remove tags using the dropdown in the details view
+    Given I am logged in as the admin
+    And I visit the settings page
+    And I open the "Workflow" section
+    # The "create" button does nothing before JavaScript was initialized, and
+    # the only way to detect that is waiting for the button to select tags to be
+    # shown.
+    And I see that the button to select tags is shown
+    And I create the tag "tag1" in the settings
+    And I create the tag "tag2" in the settings
+    And I create the tag "tag3" in the settings
+    And I create the tag "tag4" in the settings
+    And I see that the dropdown for tags in the settings eventually contains the tag "tag1"
+    And I see that the dropdown for tags in the settings eventually contains the tag "tag2"
+    And I see that the dropdown for tags in the settings eventually contains the tag "tag3"
+    And I see that the dropdown for tags in the settings eventually contains the tag "tag4"
+    And I log out
+    And I am logged in
+    And I open the details view for "welcome.txt"
+    And I open the input field for tags in the details view
+    # When the input field is opened the dropdown is also opened automatically.
+    And I check the tag "tag2" in the dropdown for tags in the details view
+    And I check the tag "tag4" in the dropdown for tags in the details view
+    And I check the tag "tag3" in the dropdown for tags in the details view
+    When I uncheck the tag "tag2" in the dropdown for tags in the details view
+    And I uncheck the tag "tag4" in the dropdown for tags in the details view
+    Then I see that the tag "tag2" in the dropdown for tags in the details view is not checked
+    And I see that the tag "tag4" in the dropdown for tags in the details view is not checked
+    And I see that the tag "tag3" in the dropdown for tags in the details view is checked
+    And I see that the input field for tags in the details view does not contain the tag "tag2"
+    And I see that the input field for tags in the details view does not contain the tag "tag4"
+    And I see that the input field for tags in the details view contains the tag "tag3"
+
   Scenario: marking a file as favorite causes the file list to be sorted again
     Given I am logged in
     And I create a new folder named "A name alphabetically lower than welcome.txt"

--- a/tests/acceptance/features/bootstrap/AppNavigationContext.php
+++ b/tests/acceptance/features/bootstrap/AppNavigationContext.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2017, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use Behat\Behat\Context\Context;
+
+class AppNavigationContext implements Context, ActorAwareInterface {
+
+	use ActorAware;
+
+	/**
+	 * @return Locator
+	 */
+	public static function appNavigation() {
+		return Locator::forThe()->id("app-navigation")->
+				describedAs("App navigation");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function appNavigationSectionItemFor($sectionText) {
+		return Locator::forThe()->xpath("//li[normalize-space() = '$sectionText']")->
+				descendantOf(self::appNavigation())->
+				describedAs($sectionText . " section item in App Navigation");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function appNavigationCurrentSectionItem() {
+		return Locator::forThe()->css(".active")->descendantOf(self::appNavigation())->
+				describedAs("Current section item in App Navigation");
+	}
+
+	/**
+	 * @Given I open the :section section
+	 */
+	public function iOpenTheSection($section) {
+		$this->actor->find(self::appNavigationSectionItemFor($section), 10)->click();
+	}
+
+	/**
+	 * @Then I see that the current section is :section
+	 */
+	public function iSeeThatTheCurrentSectionIs($section) {
+		PHPUnit_Framework_Assert::assertEquals($this->actor->find(self::appNavigationCurrentSectionItem(), 10)->getText(), $section);
+	}
+
+}

--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -107,6 +107,41 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function itemInInputFieldForTagsInCurrentSectionDetailsViewForTag($tag) {
+		return Locator::forThe()->xpath("//span[normalize-space() = '$tag']")->
+				descendantOf(self::inputFieldForTagsInCurrentSectionDetailsView())->
+				describedAs("Item in input field for tags in current section details view for tag $tag in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function itemInDropdownForTag($tag) {
+		return Locator::forThe()->xpath("//*[contains(concat(' ', normalize-space(@class), ' '), ' select2-result-label ')]//span[normalize-space() = '$tag']/ancestor::li")->
+				descendantOf(self::select2Dropdown())->
+				describedAs("Item in dropdown for tag $tag in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function checkmarkInItemInDropdownForTag($tag) {
+		return Locator::forThe()->css(".checkmark")->
+				descendantOf(self::itemInDropdownForTag($tag))->
+				describedAs("Checkmark in item in dropdown for tag $tag in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	private static function select2Dropdown() {
+		return Locator::forThe()->css("#select2-drop")->
+				describedAs("Select2 dropdown in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function tabHeaderInCurrentSectionDetailsViewNamed($tabHeaderName) {
 		return Locator::forThe()->xpath("//li[normalize-space() = '$tabHeaderName']")->
 				descendantOf(self::tabHeadersInCurrentSectionDetailsView())->
@@ -396,6 +431,24 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	}
 
 	/**
+	 * @When I check the tag :tag in the dropdown for tags in the details view
+	 */
+	public function iCheckTheTagInTheDropdownForTagsInTheDetailsView($tag) {
+		$this->iSeeThatTheTagInTheDropdownForTagsInTheDetailsViewIsNotChecked($tag);
+
+		$this->actor->find(self::itemInDropdownForTag($tag), 10)->click();
+	}
+
+	/**
+	 * @When I uncheck the tag :tag in the dropdown for tags in the details view
+	 */
+	public function iUncheckTheTagInTheDropdownForTagsInTheDetailsView($tag) {
+		$this->iSeeThatTheTagInTheDropdownForTagsInTheDetailsViewIsChecked($tag);
+
+		$this->actor->find(self::itemInDropdownForTag($tag), 10)->click();
+	}
+
+	/**
 	 * @When I protect the shared link with the password :password
 	 */
 	public function iProtectTheSharedLinkWithThePassword($password) {
@@ -473,6 +526,46 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	public function iSeeThatTheInputFieldForTagsInTheDetailsViewIsShown() {
 		PHPUnit_Framework_Assert::assertTrue(
 				$this->actor->find(self::inputFieldForTagsInCurrentSectionDetailsView(), 10)->isVisible());
+	}
+
+	/**
+	 * @Then I see that the input field for tags in the details view contains the tag :tag
+	 */
+	public function iSeeThatTheInputFieldForTagsInTheDetailsViewContainsTheTag($tag) {
+		PHPUnit_Framework_Assert::assertTrue(
+				$this->actor->find(self::itemInInputFieldForTagsInCurrentSectionDetailsViewForTag($tag), 10)->isVisible());
+	}
+
+	/**
+	 * @Then I see that the input field for tags in the details view does not contain the tag :tag
+	 */
+	public function iSeeThatTheInputFieldForTagsInTheDetailsViewDoesNotContainTheTag($tag) {
+		$this->iSeeThatTheInputFieldForTagsInTheDetailsViewIsShown();
+
+		try {
+			PHPUnit_Framework_Assert::assertFalse(
+					$this->actor->find(self::itemInInputFieldForTagsInCurrentSectionDetailsViewForTag($tag))->isVisible());
+		} catch (NoSuchElementException $exception) {
+		}
+	}
+
+	/**
+	 * @Then I see that the tag :tag in the dropdown for tags in the details view is checked
+	 */
+	public function iSeeThatTheTagInTheDropdownForTagsInTheDetailsViewIsChecked($tag) {
+		PHPUnit_Framework_Assert::assertTrue(
+				$this->actor->find(self::checkmarkInItemInDropdownForTag($tag), 10)->isVisible());
+	}
+
+	/**
+	 * @Then I see that the tag :tag in the dropdown for tags in the details view is not checked
+	 */
+	public function iSeeThatTheTagInTheDropdownForTagsInTheDetailsViewIsNotChecked($tag) {
+		PHPUnit_Framework_Assert::assertTrue(
+				$this->actor->find(self::itemInDropdownForTag($tag), 10)->isVisible());
+
+		PHPUnit_Framework_Assert::assertFalse(
+				$this->actor->find(self::checkmarkInItemInDropdownForTag($tag))->isVisible());
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -123,7 +123,7 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
-	public static function inputFieldForTagsInCurrentSectionDetails() {
+	public static function inputFieldForTagsInCurrentSectionDetailsView() {
 		return Locator::forThe()->css(".systemTagsInfoView")->
 				descendantOf(self::currentSectionDetailsView())->
 				describedAs("Input field for tags in current section details view in Files app");
@@ -511,7 +511,7 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 */
 	public function iSeeThatTheInputFieldForTagsInTheDetailsViewIsShown() {
 		PHPUnit_Framework_Assert::assertTrue(
-				$this->actor->find(self::inputFieldForTagsInCurrentSectionDetails(), 10)->isVisible());
+				$this->actor->find(self::inputFieldForTagsInCurrentSectionDetailsView(), 10)->isVisible());
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -44,31 +44,6 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
-	public static function appNavigation() {
-		return Locator::forThe()->id("app-navigation")->
-				describedAs("App navigation");
-	}
-
-	/**
-	 * @return Locator
-	 */
-	public static function appNavigationSectionItemFor($sectionText) {
-		return Locator::forThe()->xpath("//li[normalize-space() = '$sectionText']")->
-				descendantOf(self::appNavigation())->
-				describedAs($sectionText . " section item in App Navigation");
-	}
-
-	/**
-	 * @return Locator
-	 */
-	public static function appNavigationCurrentSectionItem() {
-		return Locator::forThe()->css(".active")->descendantOf(self::appNavigation())->
-				describedAs("Current section item in App Navigation");
-	}
-
-	/**
-	 * @return Locator
-	 */
 	public static function mainViewForSection($section) {
 		$sectionId = self::sections()[$section];
 
@@ -355,13 +330,6 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	}
 
 	/**
-	 * @Given I open the :section section
-	 */
-	public function iOpenTheSection($section) {
-		$this->actor->find(self::appNavigationSectionItemFor($section), 10)->click();
-	}
-
-	/**
 	 * @Given I open the details view for :fileName
 	 */
 	public function iOpenTheDetailsViewFor($fileName) {
@@ -443,13 +411,6 @@ class FilesAppContext implements Context, ActorAwareInterface {
 		PHPUnit_Framework_Assert::assertStringStartsWith(
 				$this->actor->locatePath("/apps/files/"),
 				$this->actor->getSession()->getCurrentUrl());
-	}
-
-	/**
-	 * @Then I see that the current section is :section
-	 */
-	public function iSeeThatTheCurrentSectionIs($section) {
-		PHPUnit_Framework_Assert::assertEquals($this->actor->find(self::appNavigationCurrentSectionItem(), 10)->getText(), $section);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/SettingsContext.php
+++ b/tests/acceptance/features/bootstrap/SettingsContext.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2017, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use Behat\Behat\Context\Context;
+
+class SettingsContext implements Context, ActorAwareInterface {
+
+	use ActorAware;
+
+	/**
+	 * @return Locator
+	 */
+	public static function systemTagsSelectTagButton() {
+		return Locator::forThe()->id("s2id_systemtag")->
+				describedAs("Select tag button in system tags section in Administration Settings");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function systemTagsItemInDropdownForTag($tag) {
+		return Locator::forThe()->xpath("//*[contains(concat(' ', normalize-space(@class), ' '), ' select2-result-label ')]//span[normalize-space() = '$tag']/ancestor::li")->
+				descendantOf(self::select2Dropdown())->
+				describedAs("Item in dropdown for tag $tag in system tags section in Administration Settings");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	private static function select2Dropdown() {
+		return Locator::forThe()->css("#select2-drop")->
+				describedAs("Select2 dropdown in Settings");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	private static function select2DropdownMask() {
+		return Locator::forThe()->css("#select2-drop-mask")->
+				describedAs("Select2 dropdown mask in Settings");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function systemTagsTagNameInput() {
+		return Locator::forThe()->id("systemtag_name")->
+				describedAs("Tag name input in system tags section in Administration Settings");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function systemTagsCreateOrUpdateButton() {
+		return Locator::forThe()->id("systemtag_submit")->
+				describedAs("Create/Update button in system tags section in Administration Settings");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function systemTagsResetButton() {
+		return Locator::forThe()->id("systemtag_reset")->
+				describedAs("Reset button in system tags section in Administration Settings");
+	}
+
+	/**
+	 * @When I create the tag :tag in the settings
+	 */
+	public function iCreateTheTagInTheSettings($tag) {
+		$this->actor->find(self::systemTagsResetButton(), 10)->click();
+		$this->actor->find(self::systemTagsTagNameInput())->setValue($tag);
+		$this->actor->find(self::systemTagsCreateOrUpdateButton())->click();
+	}
+
+	/**
+	 * @Then I see that the button to select tags is shown
+	 */
+	public function iSeeThatTheButtonToSelectTagsIsShown() {
+		PHPUnit_Framework_Assert::assertTrue($this->actor->find(self::systemTagsSelectTagButton(), 10)->isVisible());
+	}
+
+	/**
+	 * @Then I see that the dropdown for tags in the settings eventually contains the tag :tag
+	 */
+	public function iSeeThatTheDropdownForTagsInTheSettingsEventuallyContainsTheTag($tag) {
+		// When the dropdown is opened it is not automatically updated if new
+		// tags are added to the server, and when a tag is created, no explicit
+		// feedback is provided to the user about the completion of that
+		// operation (that is, when the tag is added to the server). Therefore,
+		// to verify that creating a tag does in fact add it to the server it is
+		// necessary to repeatedly open the dropdown until the tag is shown in
+		// the dropdown (or the limit of tries is reached).
+
+		PHPUnit_Framework_Assert::assertTrue($this->actor->find(self::systemTagsSelectTagButton(), 10)->isVisible());
+
+		$actor = $this->actor;
+
+		$tagFoundInDropdownCallback = function() use($actor, $tag) {
+			// Open the dropdown to look for the tag.
+			$actor->find(self::systemTagsSelectTagButton())->click();
+
+			// When the dropdown is opened it is initially empty, and its
+			// contents are updated once received from the server. Therefore, a
+			// timeout must be used when looking for the tags.
+			try {
+				$tagFound = $this->actor->find(self::systemTagsItemInDropdownForTag($tag), 10)->isVisible();
+			} catch (NoSuchElementException $exception) {
+				$tagFound = false;
+			}
+
+			// Close again the dropdown after looking for the tag. When a
+			// dropdown is opened Select2 creates a special element that masks
+			// every other element but the dropdown to get all mouse clicks;
+			// this is used by Select2 to close the dropdown when the user
+			// clicks outside it.
+			$actor->find(self::select2DropdownMask())->click();
+
+			return $tagFound;
+		};
+
+		$numberOfTries = 5;
+		for ($i = 0; $i < $numberOfTries; $i++) {
+			if ($tagFoundInDropdownCallback()) {
+				return;
+			}
+		}
+
+		PHPUnit_Framework_Assert::fail("The dropdown in system tags section in Administration Settings does not contain the tag $tag after $numberOfTries tries");
+	}
+
+}


### PR DESCRIPTION
Fixes #5510

By default, items in a multi-select dropdown can not be unselected by clicking on them. That feature is provided by an extension, [select2-toggleselect](https://github.com/nextcloud/server/blob/ffba6d0a7e1988bed1c0f0dfa2334092a65c568d/core/js/select2-toggleselect.js), which must be explicitly enabled in the property `toggleSelect` of each Select2 object. For example, as it is done in the [system tags](https://github.com/nextcloud/server/blob/a9ccfe06d95905d923b2871a3acd162f3d1aec1a/core/js/systemtags/systemtagsinputfield.js#L413).

However, unselecting items was also broken in the system tags; the reason is that _select2-toggleselect.js_ was never loaded, and thus the `toggleSelect` property had no effect. It seems that it slipped through when moving things around in commit 6a470e5935.

This pull request provides acceptance tests for unselecting items in the system tags dropdown in the details view of the _Files_ app, loads again _select2-toggleselect.js_ and enables `toggleSelect` in the rest of the multi-select dropdowns (I would have made instead that all the multi-select dropdowns use `toggleSelect` by default unless explicitly disabled, but I do not know if that could break other apps).

However, note that the markup and/or style of items in the multi-select dropdowns was not modified. Thus, the system tags dropdown in the details view of the _Files_ app shows a checkmark in those items that are selected, but other dropdowns (like the one in the _Tags_ section of the _Files_ app) do not. The common style for dropdowns uses a different background color for those items that are selected, though, so feedback about the selected items is provided anyway (however, that background is the same used for highlighted but not selected yet items, which persists even if the cursor is moved outside the dropdown; the difference between a selected item and an highlighted but not selected yet item then is just a subtle stronger font in the case of the highlighted item. I do not know if @nextcloud/designers are aware of that).

Just for the record, the markup of items in the dropdown is set through the function assigned to the `formatResult` property of the Select2 object. See, for example, [the function assigned to that property in the system tags](https://github.com/nextcloud/server/blob/a9ccfe06d95905d923b2871a3acd162f3d1aec1a/core/js/systemtags/systemtagsinputfield.js#L312).

Finally, should this be backported to Nextcloud 12? I would say yes but, again, you know better than me ;-) (however this time at least @nickvergessen [also thinks that it should](https://github.com/nextcloud/server/issues/5510#issue-237774708) :-P ).