### PR TITLE
properly block file upload to non-active filelist

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2742,6 +2742,7 @@
 
 				if (self.$el.hasClass('hidden')) {
 					// do not upload to invisible lists
+					e.preventDefault();
 					return false;
 				}
 
@@ -2753,6 +2754,7 @@
 					&& !self.$el.has(dropTarget).length // dropped inside list
 					&& !dropTarget.is(self.$container) // dropped on main container
 					) {
+					e.preventDefault();
 					return false;
 				}
 

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2808,22 +2808,24 @@ describe('OCA.Files.FileList tests', function() {
 				var eventData = {
 					delegatedEvent: {
 						target: $target
+					},
+					preventDefault: function () {
 					}
 				};
 				uploader.trigger('drop', eventData, data || {});
 				return !!data.targetDir;
 			}
 
-			it('drop on a tr or crumb outside file list does not trigger upload', function() {
-				var $anotherTable = $('<table><tbody><tr><td>outside<div class="crumb">crumb</div></td></tr></table>');
-				var ev;
-				$('#testArea').append($anotherTable);
-				ev = dropOn($anotherTable.find('tr'), uploadData);
-				expect(ev).toEqual(false);
+				it('drop on a tr or crumb outside file list does not trigger upload', function() {
+					var $anotherTable = $('<table><tbody><tr><td>outside<div class="crumb">crumb</div></td></tr></table>');
+					var ev;
+					$('#testArea').append($anotherTable);
+					ev = dropOn($anotherTable.find('tr'), uploadData);
+					expect(ev).toEqual(false);
 
-				ev = dropOn($anotherTable.find('.crumb'), uploadData);
-				expect(ev).toEqual(false);
-			});
+					ev = dropOn($anotherTable.find('.crumb'), uploadData);
+					expect(ev).toEqual(false);
+				});
 			it('drop on an element outside file list container does not trigger upload', function() {
 				var $anotherEl = $('<div>outside</div>');
 				var ev;


### PR DESCRIPTION
This fixes users being able to upload by dragging files into custom filelists (recent, favorites, etc).