### PR TITLE
Destroy modal when closed

### DIFF
--- a/core/js/jquery.ocdialog.js
+++ b/core/js/jquery.ocdialog.js
@@ -212,8 +212,10 @@
 			// Ugly hack to catch remaining keyup events.
 			setTimeout(function() {
 				self._trigger('close', self);
-				self.$dialog.hide();
 			}, 200);
+
+			self.$dialog.remove();
+			this.destroy();
 		},
 		destroy: function() {
 			if(this.$title) {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/5368

Remove from the DOM a modal when closed.

As the modal wasn't destroyed, when the user was typing the wrong password a new modal was opened. The first one was just hidden. The code was changing the values of the buttons of the first modal. This is why it was showing the values Yes/No and not Confirm/Cancel.