### PR TITLE
Don't throw an error when the table doesn't exist

### DIFF
--- a/lib/private/Repair/Owncloud/SaveAccountsTableData.php
+++ b/lib/private/Repair/Owncloud/SaveAccountsTableData.php
@@ -24,6 +24,7 @@
 namespace OC\Repair\Owncloud;
 
 use Doctrine\DBAL\Exception\InvalidFieldNameException;
+use Doctrine\DBAL\Exception\TableNotFoundException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -95,6 +96,8 @@ class SaveAccountsTableData implements IRepairStep {
 			$query->execute();
 			return true;
 		} catch (InvalidFieldNameException $e) {
+			return false;
+		} catch (TableNotFoundException $e) {
 			return false;
 		}
 	}


### PR DESCRIPTION
@fancycode ended up in this somehow. So let's add this little thing so the pre-update repair step is not breaking the update