### PR TITLE
Long app names will have ellipsis in the app menu popover.

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -272,6 +272,7 @@ nav {
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;
+			max-width: 110px;
 		}
 		svg,
 		span {


### PR DESCRIPTION
Fixes #5021 - which was marked as a 12.0.1 milestone issue.

I'm not a big fan of static values in CSS, in this case it makes sense since the menu itself is hard-coded to 160px. Take 24px for padding and 10px for `span` padding and you get to a real `max-width`. Plus the whole code for ellipsis was already present, but not working because span was ignoring space allocation.