### PR TITLE
Only use readable chars in Share Tokens

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -1925,7 +1925,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	public function setPublishStatus($value, $calendar) {
 		$query = $this->db->getQueryBuilder();
 		if ($value) {
-			$publicUri = $this->random->generate(16, ISecureRandom::CHAR_UPPER.ISecureRandom::CHAR_DIGITS);
+			$publicUri = $this->random->generate(16, ISecureRandom::CHAR_HUMAN_READABLE);
 			$query->insert('dav_shares')
 				->values([
 					'principaluri' => $query->createNamedParameter($calendar->getPrincipalURI()),

--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -541,8 +541,7 @@ class ShareByMailProvider implements IShareProvider {
 	 * @return string
 	 */
 	protected function generateToken($size = 15) {
-		$token = $this->secureRandom->generate(
-			$size, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_DIGITS);
+		$token = $this->secureRandom->generate($size, ISecureRandom::CHAR_HUMAN_READABLE);
 		return $token;
 	}
 

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -913,8 +913,7 @@ class Share extends Constants {
 					$token = $oldToken;
 				} else {
 					$token = \OC::$server->getSecureRandom()->generate(self::TOKEN_LENGTH,
-						\OCP\Security\ISecureRandom::CHAR_LOWER.\OCP\Security\ISecureRandom::CHAR_UPPER.
-						\OCP\Security\ISecureRandom::CHAR_DIGITS
+						\OCP\Security\ISecureRandom::CHAR_HUMAN_READABLE
 					);
 				}
 				$result = self::put($itemType, $itemSource, $shareType, $shareWith, $uidOwner, $permissions,

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -581,9 +581,7 @@ class Manager implements IManager {
 			$share->setToken(
 				$this->secureRandom->generate(
 					\OC\Share\Constants::TOKEN_LENGTH,
-					\OCP\Security\ISecureRandom::CHAR_LOWER.
-					\OCP\Security\ISecureRandom::CHAR_UPPER.
-					\OCP\Security\ISecureRandom::CHAR_DIGITS
+					\OCP\Security\ISecureRandom::CHAR_HUMAN_READABLE
 				)
 			);
 
@@ -601,9 +599,7 @@ class Manager implements IManager {
 			$share->setToken(
 				$this->secureRandom->generate(
 					\OC\Share\Constants::TOKEN_LENGTH,
-					\OCP\Security\ISecureRandom::CHAR_LOWER.
-					\OCP\Security\ISecureRandom::CHAR_UPPER.
-					\OCP\Security\ISecureRandom::CHAR_DIGITS
+					\OCP\Security\ISecureRandom::CHAR_HUMAN_READABLE
 				)
 			);
 		}


### PR DESCRIPTION
Fix #5688 