### PR TITLE
do not show hyphen in og:title if slogan does not exist

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -401,7 +401,7 @@ class ShareController extends Controller {
 		}
 
 		// OpenGraph Support: http://ogp.me/
-		\OCP\Util::addHeader('meta', ['property' => "og:title", 'content' => $this->defaults->getName() . ' - ' . $this->defaults->getSlogan()]);
+		\OCP\Util::addHeader('meta', ['property' => "og:title", 'content' => $this->defaults->getName() . ($this->defaults->getSlogan() !== '' ? ' - ' . $this->defaults->getSlogan() : '')]);
 		\OCP\Util::addHeader('meta', ['property' => "og:description", 'content' => $this->l10n->t('%s is publicly shared', [$shareTmpl['filename']])]);
 		\OCP\Util::addHeader('meta', ['property' => "og:site_name", 'content' => $this->defaults->getName()]);
 		\OCP\Util::addHeader('meta', ['property' => "og:url", 'content' => $shareTmpl['shareUrl']]);


### PR DESCRIPTION
same syntax as in https://github.com/nextcloud/server/blob/c1c676f602fa199c6d8ae9b0ae27b60e5ce10417/apps/theming/lib/ThemingDefaults.php#L115