### PR TITLE
Fix emitting of legacy hook post_unshare

### DIFF
--- a/lib/private/Share20/LegacyHooks.php
+++ b/lib/private/Share20/LegacyHooks.php
@@ -71,7 +71,7 @@ class LegacyHooks {
 
 		$formatted['deletedShares'] = $formattedDeletedShares;
 
-		\OC_Hook::emit('OCP\Share', 'pre_unshare', $formatted);
+		\OC_Hook::emit('OCP\Share', 'post_unshare', $formatted);
 	}
 
 	private function formatHookParams(IShare $share) {

--- a/tests/lib/Share20/LegacyHooksTest.php
+++ b/tests/lib/Share20/LegacyHooksTest.php
@@ -99,7 +99,7 @@ class LegacyHooksTest extends TestCase {
 			->setTarget('myTarget');
 
 		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'pre_unshare', $hookListner, 'post');
+		\OCP\Util::connectHook('OCP\Share', 'post_unshare', $hookListner, 'post');
 
 		$hookListnerExpectsPost = [
 			'id' => 42,


### PR DESCRIPTION
When a file was unshared, the legacy hook `pre_unshare` fired twice and the hook `post_unshare` did not fire at all. This was obviously a copy-paste error.