### PR TITLE
Manage Google Drive version without uploading temporary files.

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Google.php
+++ b/apps/files_external/lib/Lib/Storage/Google.php
@@ -733,5 +733,9 @@ class Google extends \OC\Files\Storage\Common {
 	public static function checkDependencies() {
 		return true;
 	}
+	
+	public function needsPartFile() {
+		return false;
+	}
 
 }


### PR DESCRIPTION
In agreement with "https://central.owncloud.org/t/issue-with-versioning-on-google-drive/1683/8" and after "nextcloud@13e50cb", I propose to set "needsPartFile" to "false" in Google external storage.

With this change when "nextcloud" upload an existent file on Google, the file is uploaded without a temporary file and Google creates a new version of it.