### PR TITLE
[12] still remove the federated share even if we cant notify the remote

### DIFF
--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -366,8 +366,13 @@ class Manager {
 		$result = $getShare->execute(array($hash, $this->uid));
 
 		if ($result) {
-			$share = $getShare->fetch();
-			$this->sendFeedbackToRemote($share['remote'], $share['share_token'], $share['remote_id'], 'decline');
+			try {
+				$share = $getShare->fetch();
+				$this->sendFeedbackToRemote($share['remote'], $share['share_token'], $share['remote_id'], 'decline');
+			} catch (\Exception $e) {
+				// if we fail to notify the remote (probably cause the remote is down)
+				// we still want the share to be gone to prevent undeletable remotes
+			}
 		}
 		$getShare->closeCursor();
 


### PR DESCRIPTION
Backport of https://github.com/nextcloud/server/pull/5753