### PR TITLE
Fix invalid path repair step not getting all invalid entries

### DIFF
--- a/lib/private/Repair/NC13/RepairInvalidPaths.php
+++ b/lib/private/Repair/NC13/RepairInvalidPaths.php
@@ -76,7 +76,7 @@ class RepairInvalidPaths implements IRepairStep {
 				yield $row;
 			}
 			$result->closeCursor();
-		} while (count($rows) >= self::MAX_ROWS);
+		} while (count($rows) > 0);
 	}
 
 	private function getId($storage, $path) {


### PR DESCRIPTION
Somehow the db does not always return `maxResults` results even when there are still entries left to correct (Maybe related nested invalid paths), this changes to loop to keep trying until there are no more invalid paths.