### PR TITLE
Allow overwriting of IOS theming values

### DIFF
--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -55,6 +55,8 @@ class ThemingDefaults extends \OC_Defaults {
 	private $iTunesAppId;
 	/** @var string */
 	private $iOSClientUrl;
+	/** @var string */
+	private $AndroidClientUrl;
 
 	/**
 	 * ThemingDefaults constructor.
@@ -88,6 +90,7 @@ class ThemingDefaults extends \OC_Defaults {
 		$this->color = parent::getColorPrimary();
 		$this->iTunesAppId = parent::getiTunesAppId();
 		$this->iOSClientUrl = parent::getiOSClientUrl();
+		$this->AndroidClientUrl = parent::getAndroidClientUrl();
 	}
 
 	public function getName() {
@@ -198,6 +201,13 @@ class ThemingDefaults extends \OC_Defaults {
 	 */
 	public function getiOSClientUrl() {
 		return $this->config->getAppValue('theming', 'iOSClientUrl', $this->iOSClientUrl);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getAndroidClientUrl() {
+		return $this->config->getAppValue('theming', 'AndroidClientUrl', $this->AndroidClientUrl);
 	}
 
 

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -51,6 +51,10 @@ class ThemingDefaults extends \OC_Defaults {
 	private $color;
 	/** @var Util */
 	private $util;
+	/** @var string */
+	private $iTunesAppId;
+	/** @var string */
+	private $iOSClientUrl;
 
 	/**
 	 * ThemingDefaults constructor.
@@ -82,6 +86,8 @@ class ThemingDefaults extends \OC_Defaults {
 		$this->url = parent::getBaseUrl();
 		$this->slogan = parent::getSlogan();
 		$this->color = parent::getColorPrimary();
+		$this->iTunesAppId = parent::getiTunesAppId();
+		$this->iOSClientUrl = parent::getiOSClientUrl();
 	}
 
 	public function getName() {
@@ -178,6 +184,20 @@ class ThemingDefaults extends \OC_Defaults {
 		}
 
 		return $this->urlGenerator->linkToRoute('theming.Theming.getLoginBackground') . '?v=' . $cacheBusterCounter;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getiTunesAppId() {
+		return $this->config->getAppValue('theming', 'iTunesAppId', $this->iTunesAppId);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getiOSClientUrl() {
+		return $this->config->getAppValue('theming', 'iOSClientUrl', $this->iOSClientUrl);
 	}
 
 
@@ -290,5 +310,4 @@ class ThemingDefaults extends \OC_Defaults {
 
 		return $returnValue;
 	}
-
 }

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -543,4 +543,65 @@ class ThemingDefaultsTest extends TestCase {
 		];
 		$this->assertEquals($expected, $this->template->getScssVariables());
 	}
+
+	public function testGetDefaultAndroidURL() {
+		$this->config
+			->expects($this->once())
+			->method('getAppValue')
+			->with('theming', 'AndroidClientUrl', 'https://play.google.com/store/apps/details?id=com.nextcloud.client')
+			->willReturn('https://play.google.com/store/apps/details?id=com.nextcloud.client');
+
+		$this->assertEquals('https://play.google.com/store/apps/details?id=com.nextcloud.client', $this->template->getAndroidClientUrl());
+	}
+
+	public function testGetCustomAndroidURL() {
+		$this->config
+			->expects($this->once())
+			->method('getAppValue')
+			->with('theming', 'AndroidClientUrl', 'https://play.google.com/store/apps/details?id=com.nextcloud.client')
+			->willReturn('https://play.google.com/store/apps/details?id=com.mycloud.client');
+
+		$this->assertEquals('https://play.google.com/store/apps/details?id=com.mycloud.client', $this->template->getAndroidClientUrl());
+	}
+
+	public function testGetDefaultiOSURL() {
+		$this->config
+			->expects($this->once())
+			->method('getAppValue')
+			->with('theming', 'iOSClientUrl', 'https://itunes.apple.com/us/app/nextcloud/id1125420102?mt=8')
+			->willReturn('https://itunes.apple.com/us/app/nextcloud/id1125420102?mt=8');
+
+		$this->assertEquals('https://itunes.apple.com/us/app/nextcloud/id1125420102?mt=8', $this->template->getiOSClientUrl());
+	}
+
+	public function testGetCustomiOSURL() {
+		$this->config
+			->expects($this->once())
+			->method('getAppValue')
+			->with('theming', 'iOSClientUrl', 'https://itunes.apple.com/us/app/nextcloud/id1125420102?mt=8')
+			->willReturn('https://itunes.apple.com/us/app/nextcloud/id1234567890?mt=8');
+
+		$this->assertEquals('https://itunes.apple.com/us/app/nextcloud/id1234567890?mt=8', $this->template->getiOSClientUrl());
+	}
+
+	public function testGetDefaultiTunesAppId() {
+		$this->config
+			->expects($this->once())
+			->method('getAppValue')
+			->with('theming', 'iTunesAppId', '1125420102')
+			->willReturn('1125420102');
+
+		$this->assertEquals('1125420102', $this->template->getiTunesAppId());
+	}
+
+	public function testGetCustomiTunesAppId() {
+		$this->config
+			->expects($this->once())
+			->method('getAppValue')
+			->with('theming', 'iTunesAppId', '1125420102')
+			->willReturn('1234567890');
+
+		$this->assertEquals('1234567890', $this->template->getiTunesAppId());
+	}
+
 }


### PR DESCRIPTION
Fixes: #5780 

We can always make this better later. But for now lets not clutter the theming app to much.

Basically just run:

 ./occ config:app:set --value "1337" theming iTunesAppId
 ./occ config:app:set --value "https://my.com/fancy/url" theming iOSClientUrl
