### PR TITLE
Set max-width of image to 100px in Outlook as well

### DIFF
--- a/lib/private/Mail/EMailTemplate.php
+++ b/lib/private/Mail/EMailTemplate.php
@@ -100,7 +100,10 @@ EOF;
 							<tbody>
 							<tr style="padding:0;text-align:left;vertical-align:top">
 								<center data-parsed="" style="min-width:580px;width:100%%">
+									<!-- convince Outlook to have a max-width of 100px -->
+									<!--[if mso]><table><tr><td width="100"><![endif]-->
 									<img class="logo float-center" src="%s" alt="%s" align="center" style="-ms-interpolation-mode:bicubic;Margin:0 auto;clear:both;display:block;float:none;margin:0 auto;max-height:100%%;max-width:100px;outline:0;text-align:center;text-decoration:none;width:auto">
+									<!--[if mso]></td></tr></table><![endif]-->
 								</center>
 							</tr>
 							</tbody>

--- a/tests/Settings/Mailer/NewUserMailHelperTest.php
+++ b/tests/Settings/Mailer/NewUserMailHelperTest.php
@@ -182,7 +182,10 @@ class NewUserMailHelperTest extends TestCase {
 							<tbody>
 							<tr style="padding:0;text-align:left;vertical-align:top">
 								<center data-parsed="" style="min-width:580px;width:100%">
+									<!-- convince Outlook to have a max-width of 100px -->
+									<!--[if mso]><table><tr><td width="100"><![endif]-->
 									<img class="logo float-center" src="" alt="TestCloud" align="center" style="-ms-interpolation-mode:bicubic;Margin:0 auto;clear:both;display:block;float:none;margin:0 auto;max-height:100%;max-width:100px;outline:0;text-align:center;text-decoration:none;width:auto">
+									<!--[if mso]></td></tr></table><![endif]-->
 								</center>
 							</tr>
 							</tbody>
@@ -415,7 +418,10 @@ EOF;
 							<tbody>
 							<tr style="padding:0;text-align:left;vertical-align:top">
 								<center data-parsed="" style="min-width:580px;width:100%">
+									<!-- convince Outlook to have a max-width of 100px -->
+									<!--[if mso]><table><tr><td width="100"><![endif]-->
 									<img class="logo float-center" src="" alt="TestCloud" align="center" style="-ms-interpolation-mode:bicubic;Margin:0 auto;clear:both;display:block;float:none;margin:0 auto;max-height:100%;max-width:100px;outline:0;text-align:center;text-decoration:none;width:auto">
+									<!--[if mso]></td></tr></table><![endif]-->
 								</center>
 							</tr>
 							</tbody>

--- a/tests/data/emails/new-account-email-custom.html
+++ b/tests/data/emails/new-account-email-custom.html
@@ -23,7 +23,10 @@
 							<tbody>
 							<tr style="padding:0;text-align:left;vertical-align:top">
 								<center data-parsed="" style="min-width:580px;width:100%">
+									<!-- convince Outlook to have a max-width of 100px -->
+									<!--[if mso]><table><tr><td width="100"><![endif]-->
 									<img class="logo float-center" src="https://example.org/img/logo-mail-header.png" alt="TestCloud" align="center" style="-ms-interpolation-mode:bicubic;Margin:0 auto;clear:both;display:block;float:none;margin:0 auto;max-height:100%;max-width:100px;outline:0;text-align:center;text-decoration:none;width:auto">
+									<!--[if mso]></td></tr></table><![endif]-->
 								</center>
 							</tr>
 							</tbody>

--- a/tests/data/emails/new-account-email-single-button.html
+++ b/tests/data/emails/new-account-email-single-button.html
@@ -23,7 +23,10 @@
 							<tbody>
 							<tr style="padding:0;text-align:left;vertical-align:top">
 								<center data-parsed="" style="min-width:580px;width:100%">
+									<!-- convince Outlook to have a max-width of 100px -->
+									<!--[if mso]><table><tr><td width="100"><![endif]-->
 									<img class="logo float-center" src="https://example.org/img/logo-mail-header.png" alt="TestCloud" align="center" style="-ms-interpolation-mode:bicubic;Margin:0 auto;clear:both;display:block;float:none;margin:0 auto;max-height:100%;max-width:100px;outline:0;text-align:center;text-decoration:none;width:auto">
+									<!--[if mso]></td></tr></table><![endif]-->
 								</center>
 							</tr>
 							</tbody>

--- a/tests/data/emails/new-account-email.html
+++ b/tests/data/emails/new-account-email.html
@@ -23,7 +23,10 @@
 							<tbody>
 							<tr style="padding:0;text-align:left;vertical-align:top">
 								<center data-parsed="" style="min-width:580px;width:100%">
+									<!-- convince Outlook to have a max-width of 100px -->
+									<!--[if mso]><table><tr><td width="100"><![endif]-->
 									<img class="logo float-center" src="https://example.org/img/logo-mail-header.png" alt="TestCloud" align="center" style="-ms-interpolation-mode:bicubic;Margin:0 auto;clear:both;display:block;float:none;margin:0 auto;max-height:100%;max-width:100px;outline:0;text-align:center;text-decoration:none;width:auto">
+									<!--[if mso]></td></tr></table><![endif]-->
 								</center>
 							</tr>
 							</tbody>


### PR DESCRIPTION
Should™ fix the issues with the too stretched logos in emails in Outlook.