### PR TITLE
Also repair storage id's when repairing invalid entries

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -332,7 +332,7 @@ class Cache implements ICache {
 	protected function buildParts(array $data) {
 		$fields = array(
 			'path', 'parent', 'name', 'mimetype', 'size', 'mtime', 'storage_mtime', 'encrypted',
-			'etag', 'permissions', 'checksum');
+			'etag', 'permissions', 'checksum', 'storage');
 
 		$doNotCopyStorageMTime = false;
 		if (array_key_exists('mtime', $data) && $data['mtime'] === null) {

--- a/lib/private/Repair/NC13/RepairInvalidPaths.php
+++ b/lib/private/Repair/NC13/RepairInvalidPaths.php
@@ -64,7 +64,7 @@ class RepairInvalidPaths implements IRepairStep {
 		);
 
 		//select f.path, f.parent,p.path from oc_filecache f inner join oc_filecache p on f.parent=p.fileid and p.path!='' where f.path != p.path || '/' || f.name;
-		$query = $builder->select('f.fileid', 'f.path', 'p.path AS parent_path', 'f.name', 'f.parent', 'f.storage')
+		$query = $builder->select('f.fileid', 'f.path', 'p.path AS parent_path', 'f.name', 'f.parent', 'f.storage', 'p.storage as parent_storage')
 			->from('filecache', 'f')
 			->innerJoin('f', 'filecache', 'p', $builder->expr()->andX(
 				$builder->expr()->eq('f.parent', 'p.fileid'),
@@ -102,19 +102,22 @@ class RepairInvalidPaths implements IRepairStep {
 	/**
 	 * @param string $fileid
 	 * @param string $newPath
+	 * @param string $newStorage
 	 * @suppress SqlInjectionChecker
 	 */
-	private function update($fileid, $newPath) {
+	private function update($fileid, $newPath, $newStorage) {
 		if (!$this->updateQuery) {
 			$builder = $this->connection->getQueryBuilder();
 
 			$this->updateQuery = $builder->update('filecache')
 				->set('path', $builder->createParameter('newpath'))
 				->set('path_hash', $builder->func()->md5($builder->createParameter('newpath')))
+				->set('storage', $builder->createParameter('newstorage'))
 				->where($builder->expr()->eq('fileid', $builder->createParameter('fileid')));
 		}
 
 		$this->updateQuery->setParameter('newpath', $newPath);
+		$this->updateQuery->setParameter('newstorage', $newStorage);
 		$this->updateQuery->setParameter('fileid', $fileid, IQueryBuilder::PARAM_INT);
 
 		$this->updateQuery->execute();
@@ -155,12 +158,12 @@ class RepairInvalidPaths implements IRepairStep {
 		foreach ($entries as $entry) {
 			$count++;
 			$calculatedPath = $entry['parent_path'] . '/' . $entry['name'];
-			if ($newId = $this->getId($entry['storage'], $calculatedPath)) {
+			if ($newId = $this->getId($entry['parent_storage'], $calculatedPath)) {
 				// a new entry with the correct path has already been created, reuse that one and delete the incorrect entry
 				$this->reparent($entry['fileid'], $newId);
 				$this->delete($entry['fileid']);
 			} else {
-				$this->update($entry['fileid'], $calculatedPath);
+				$this->update($entry['fileid'], $calculatedPath, $entry['parent_storage']);
 			}
 		}
 		$this->connection->commit();


### PR DESCRIPTION
When the invalid move was across storages the parent's storage id can be different to the child's parent id which can lead to duplicate cache entries