### PR TITLE
Update PHP 7.1 containers

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -36,7 +36,7 @@ pipeline:
       matrix:
         TESTS: syntax-php7.0
   syntax-php7.1:
-    image: nextcloudci/php7.1:php7.1-11
+    image: nextcloudci/php7.1:php7.1-12
     commands:
       - composer install
       - ./lib/composer/bin/parallel-lint --exclude lib/composer/jakub-onderka/ --exclude 3rdparty/symfony/polyfill-php70/Resources/stubs/ --exclude 3rdparty/patchwork/utf8/src/Patchwork/Utf8/Bootup/ --exclude 3rdparty/paragonie/random_compat/lib/ --exclude lib/composer/composer/autoload_static.php --exclude 3rdparty/composer/autoload_static.php .
@@ -44,11 +44,11 @@ pipeline:
       matrix:
         TESTS: syntax-php7.1
   phan:
-    image: nextcloudci/php7.0:php7.0-13
+    image: nextcloudci/php7.1:php7.1-12
     commands:
-      - rm /etc/php/7.0/cli/conf.d/20-xdebug.ini
+      - rm /etc/php/7.1/cli/conf.d/20-xdebug.ini
       - composer install
-      - composer require --dev "etsy/phan:0.8.x-dev"
+      - composer require --dev "etsy/phan:dev-master"
       - ./lib/composer/etsy/phan/phan -k build/.phan/config.php
     when:
       matrix:
@@ -161,7 +161,7 @@ pipeline:
         DB: NODB
         PHP: "7.0"
   nodb-php7.1:
-    image: nextcloudci/php7.1:php7.1-11
+    image: nextcloudci/php7.1:php7.1-12
     commands:
       - NOCOVERAGE=true TEST_SELECTION=NODB ./autotest.sh sqlite
     when:
@@ -185,7 +185,7 @@ pipeline:
         DB: sqlite
         PHP: "7.0"
   sqlite-php7.1:
-    image: nextcloudci/php7.1:php7.1-11
+    image: nextcloudci/php7.1:php7.1-12
     commands:
       - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh sqlite
     when:


### PR DESCRIPTION
Previously this container used a very old CentOS version. It has been migrated to Debian Jessie now using the deb.sury.org repositories.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>