### PR TITLE
Dispatch event postUnshareFromSelf when the recipient of a share unshares it

### DIFF
--- a/lib/private/Share20/LegacyHooks.php
+++ b/lib/private/Share20/LegacyHooks.php
@@ -40,6 +40,7 @@ class LegacyHooks {
 
 		$this->eventDispatcher->addListener('OCP\Share::preUnshare', [$this, 'preUnshare']);
 		$this->eventDispatcher->addListener('OCP\Share::postUnshare', [$this, 'postUnshare']);
+		$this->eventDispatcher->addListener('OCP\Share::postUnshareFromSelf', [$this, 'postUnshareFromSelf']);
 	}
 
 	/**
@@ -72,6 +73,20 @@ class LegacyHooks {
 		$formatted['deletedShares'] = $formattedDeletedShares;
 
 		\OC_Hook::emit('OCP\Share', 'post_unshare', $formatted);
+	}
+
+	/**
+	 * @param GenericEvent $e
+	 */
+	public function postUnshareFromSelf(GenericEvent $e) {
+		/** @var IShare $share */
+		$share = $e->getSubject();
+
+		$formatted = $this->formatHookParams($share);
+		$formatted['itemTarget'] = $formatted['fileTarget'];
+		$formatted['unsharedItems'] = [$formatted];
+
+		\OC_Hook::emit('OCP\Share', 'post_unshareFromSelf', $formatted);
 	}
 
 	private function formatHookParams(IShare $share) {

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -873,6 +873,8 @@ class Manager implements IManager {
 		$provider = $this->factory->getProvider($providerId);
 
 		$provider->deleteFromSelf($share, $recipientId);
+		$event = new GenericEvent($share);
+		$this->eventDispatcher->dispatch('OCP\Share::postUnshareFromSelf', $event);
 	}
 
 	/**

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -332,6 +332,40 @@ class ManagerTest extends \Test\TestCase {
 		$manager->deleteShare($share1);
 	}
 
+	public function testDeleteFromSelf() {
+		$manager = $this->createManagerMock()
+			->setMethods(['getShareById'])
+			->getMock();
+
+		$recipientId = 'unshareFrom';
+		$share = $this->manager->newShare();
+		$share->setId(42)
+			->setProviderId('prov')
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith('sharedWith')
+			->setSharedBy('sharedBy')
+			->setShareOwner('shareOwner')
+			->setTarget('myTarget')
+			->setNodeId(1)
+			->setNodeType('file');
+
+		$this->defaultProvider
+			->expects($this->once())
+			->method('deleteFromSelf')
+			->with($share, $recipientId);
+
+		$this->eventDispatcher->expects($this->at(0))
+			->method('dispatch')
+			->with(
+				'OCP\Share::postUnshareFromSelf',
+				$this->callBack(function(GenericEvent $e) use ($share) {
+					return $e->getSubject() === $share;
+				})
+			);
+
+		$manager->deleteFromSelf($share, $recipientId);
+	}
+
 	public function testDeleteChildren() {
 		$manager = $this->createManagerMock()
 			->setMethods(['deleteShare'])


### PR DESCRIPTION
In the old Share library, there used to be signal `post_unshareFromSelf` emitted when the recipient of a share unshares it. In the Share 2.0 library, this signal is missing, and hence it is impossible for applications to know if file has become unavailable as a result of "unshare from self".

This PR adds dispatching of event `OCP\Share::postUnshareFromSelf`, and mapping from it to the legacy hook signal `post_unshareFromSelf`.

This is a port from https://github.com/owncloud/core/pull/28401.
