### PR TITLE
Enable acceptance tests again on Drone 0.7

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -469,21 +469,21 @@ pipeline:
   acceptance-access-levels:
       image: nextcloudci/integration-php7.0:integration-php7.0-4
       commands:
-        - tests/acceptance/run-local.sh --timeout-multiplier 10 allow-git-repository-modifications features/access-levels.feature
+        - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-access-levels --selenium-server selenium:4444 allow-git-repository-modifications features/access-levels.feature
       when:
         matrix:
           TESTS-ACCEPTANCE: access-levels
   acceptance-app-files:
       image: nextcloudci/integration-php7.0:integration-php7.0-4
       commands:
-        - tests/acceptance/run-local.sh --timeout-multiplier 10 allow-git-repository-modifications features/app-files.feature
+        - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-app-files --selenium-server selenium:4444 allow-git-repository-modifications features/app-files.feature
       when:
         matrix:
           TESTS-ACCEPTANCE: app-files
   acceptance-login:
       image: nextcloudci/integration-php7.0:integration-php7.0-4
       commands:
-        - tests/acceptance/run-local.sh --timeout-multiplier 10 allow-git-repository-modifications features/login.feature
+        - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-login --selenium-server selenium:4444 allow-git-repository-modifications features/login.feature
       when:
         matrix:
           TESTS-ACCEPTANCE: login
@@ -574,12 +574,12 @@ matrix:
     - TESTS: integration-transfer-ownership-features
     - TESTS: integration-ldap-features
     - TESTS: integration-trashbin
-#    - TESTS: acceptance
-#      TESTS-ACCEPTANCE: access-levels
-#    - TESTS: acceptance
-#      TESTS-ACCEPTANCE: app-files
-#    - TESTS: acceptance
-#      TESTS-ACCEPTANCE: login
+    - TESTS: acceptance
+      TESTS-ACCEPTANCE: access-levels
+    - TESTS: acceptance
+      TESTS-ACCEPTANCE: app-files
+    - TESTS: acceptance
+      TESTS-ACCEPTANCE: login
     - TESTS: jsunit
     - TESTS: syntax-php5.6
     - TESTS: syntax-php7.0

--- a/tests/acceptance/features/core/NextcloudTestServerLocalHelper.php
+++ b/tests/acceptance/features/core/NextcloudTestServerLocalHelper.php
@@ -35,12 +35,20 @@
  * the Nextcloud server; the last commit in that Git repository must provide the
  * initial state for the Nextcloud server expected by the acceptance tests.
  *
- * The Nextcloud server is available at "127.0.0.1", so it is expected to see
- * "127.0.0.1" as a trusted domain (which would be the case if it was installed
- * by running "occ maintenance:install"). The base URL to access the Nextcloud
+ * The Nextcloud server is available at "$nextcloudServerDomain", which can be
+ * optionally specified when the NextcloudTestServerLocalHelper is created; if
+ * no value is given "127.0.0.1" is used by default. In any case, the value of
+ * "$nextcloudServerDomain" must be seen as a trusted domain by the Nextcloud
+ * server (which would be the case for "127.0.0.1" if it was installed by
+ * running "occ maintenance:install"). The base URL to access the Nextcloud
  * server can be got from "getBaseUrl".
  */
 class NextcloudTestServerLocalHelper implements NextcloudTestServerHelper {
+
+	/**
+	 * @var string
+	 */
+	private $nextcloudServerDomain;
 
 	/**
 	 * @var string
@@ -50,7 +58,9 @@ class NextcloudTestServerLocalHelper implements NextcloudTestServerHelper {
 	/**
 	 * Creates a new NextcloudTestServerLocalHelper.
 	 */
-	public function __construct() {
+	public function __construct($nextcloudServerDomain = "127.0.0.1") {
+		$this->nextcloudServerDomain = $nextcloudServerDomain;
+
 		$this->phpServerPid = "";
 	}
 
@@ -77,7 +87,7 @@ class NextcloudTestServerLocalHelper implements NextcloudTestServerHelper {
 		// execOrException is not used because the server is started in the
 		// background, so the command will always succeed even if the server
 		// itself fails.
-		$this->phpServerPid = exec("php -S 127.0.0.1:80 -t ../../ >/dev/null 2>&1 & echo $!");
+		$this->phpServerPid = exec("php -S " . $this->nextcloudServerDomain . ":80 -t ../../ >/dev/null 2>&1 & echo $!");
 
 		$timeout = 60;
 		if (!Utils::waitForServer($this->getBaseUrl(), $timeout)) {
@@ -100,7 +110,7 @@ class NextcloudTestServerLocalHelper implements NextcloudTestServerHelper {
 	 * @return string the base URL of the Nextcloud test server.
 	 */
 	public function getBaseUrl() {
-		return "http://127.0.0.1/index.php";
+		return "http://" . $this->nextcloudServerDomain . "/index.php";
 	}
 
 	/**

--- a/tests/acceptance/installAndConfigureServer.sh
+++ b/tests/acceptance/installAndConfigureServer.sh
@@ -25,6 +25,18 @@
 
 set -o errexit
 
+NEXTCLOUD_SERVER_DOMAIN=""
+if [ "$1" = "--nextcloud-server-domain" ]; then
+	NEXTCLOUD_SERVER_DOMAIN=$2
+
+	shift 2
+fi
+
 php occ maintenance:install --admin-pass=admin
 
 OC_PASS=123456acb php occ user:add --password-from-env user0
+
+if [ "$NEXTCLOUD_SERVER_DOMAIN" != "" ]; then
+	# Default first trusted domain is "localhost"; replace it with given domain.
+	php occ config:system:set trusted_domains 0 --value="$NEXTCLOUD_SERVER_DOMAIN"
+fi


### PR DESCRIPTION
Running the acceptance tests on Drone relied on the pod-style networking used by services (service containers were available at 127.0.0.1 from the build containers). However, as noted by @MorrisJobke in #5724, in Drone 0.7 that is no longer the case; now service and build containers must be accessed from each other using their domain name (which is the same as their container name if no alias was specified).

This pull request adds support to the acceptance test system for using different domains for the Selenium server and the Nextcloud test server, and uses that new feature to enable again the acceptance tests on Drone; by default the acceptance tests still assume that the Selenium server and the Nextcloud test server are both available at 127.0.0.1, so the changes do not affect the acceptance tests when run on a local machine (that is, through _run.sh_).

I will promote this pull request to _To review_ once Drone finishes running and I can confirm that everything works as expected.

By the way, should this be backported to the _stable12_ branch?
