### PR TITLE
fix preview for public links

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -79,10 +79,12 @@ $server = $serverFactory->createServer($baseuri, $requestUri, $authPlugin, funct
 	\OC\Files\Filesystem::addStorageWrapper('sharePermissions', function ($mountPoint, $storage) use ($share) {
 		return new \OC\Files\Storage\Wrapper\PermissionsMask(array('storage' => $storage, 'mask' => $share->getPermissions() | \OCP\Constants::PERMISSION_SHARE));
 	});
+
 	\OC\Files\Filesystem::logWarningWhenAddingStorageWrapper($previousLog);
 
+	OC_Util::tearDownFS();
 	OC_Util::setupFS($owner);
-	$ownerView = \OC\Files\Filesystem::getView();
+	$ownerView = new \OC\Files\View('/'. $owner . '/files');
 	$path = $ownerView->getPath($fileId);
 	$fileInfo = $ownerView->getFileInfo($path);
 	$linkCheckPlugin->setFileInfo($fileInfo);


### PR DESCRIPTION
in case a user is already logged in on the same server from
which the public link comes from, we need to setup the owners
file system in order to show the preview

Steps to test:

1. login with user1 and create a public link for a text file
2. login as user2
3. open the public link

Result without this patch:

No preview is shown because the filesystem of user2 is setup and not the filesystem of user1 (the owner of the share)

Result with this patch:

we setup the correct filesystem and the preview is shown.

stable12 and stable11 are also affected, I will create the backports.
