### PR TITLE
[stable12] fix preview for public links

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -79,10 +79,12 @@ $server = $serverFactory->createServer($baseuri, $requestUri, $authPlugin, funct
 	\OC\Files\Filesystem::addStorageWrapper('sharePermissions', function ($mountPoint, $storage) use ($share) {
 		return new \OC\Files\Storage\Wrapper\PermissionsMask(array('storage' => $storage, 'mask' => $share->getPermissions() | \OCP\Constants::PERMISSION_SHARE));
 	});
+
 	\OC\Files\Filesystem::logWarningWhenAddingStorageWrapper($previousLog);
 
+	OC_Util::tearDownFS();
 	OC_Util::setupFS($owner);
-	$ownerView = \OC\Files\Filesystem::getView();
+	$ownerView = new \OC\Files\View('/'. $owner . '/files');
 	$path = $ownerView->getPath($fileId);
 	$fileInfo = $ownerView->getFileInfo($path);
 	$linkCheckPlugin->setFileInfo($fileInfo);


### PR DESCRIPTION
in case a user is already logged in on the same server from
which the public link comes from, we need to setup the owners
file system in order to show the preview

backport of https://github.com/nextcloud/server/pull/5803