### PR TITLE
Fix for mb strlen

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -526,7 +526,7 @@ class Cache implements ICache {
 			$this->connection->beginTransaction();
 			if ($sourceData['mimetype'] === 'httpd/unix-directory') {
 				//update all child entries
-				$sourceLength = strlen($sourcePath);
+				$sourceLength = mb_strlen($sourcePath);
 				$query = $this->connection->getQueryBuilder();
 
 				$fun = $query->func();


### PR DESCRIPTION
In some languages (for example, Russian) directories will be moved with error because $sourceLength is longer, then real length in symbols. Because of this for different files had the same MD5-hash and same value of index "fs_storage_path_hash" in table `oc_filecache`

For example:
```php
$sourcePath = "files/Индустрия_Инженерные системы ЦОД";
$targetPath = "files/Индустрия_Инженерные системы ЦОД1";
strlen($sourcePath) == 68;

$file1 = "files/Индустрия_Инженерные системы ЦОД/1.txt";
$file2 = "files/Индустрия_Инженерные системы ЦОД/2.txt";

substr($file1, 69) === substr($file2, 69)
```

`path_hash` same for file1 and file2.