### PR TITLE
Fix error message on untrusted domain error page

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -866,7 +866,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$classExists = false;
 			}
 
-			if ($classExists && $c->getConfig()->getSystemValue('installed', false) && $c->getAppManager()->isInstalled('theming')) {
+			if ($classExists && $c->getConfig()->getSystemValue('installed', false) && $c->getAppManager()->isInstalled('theming') && $c->getTrustedDomainHelper()->isTrustedDomain($c->getRequest()->getInsecureServerHost())) {
 				return new ThemingDefaults(
 					$c->getConfig(),
 					$c->getL10N('theming'),


### PR DESCRIPTION
Fixes #5347


Before the theming app theme was loaded on that error page but all assets were not loaded because of the trusted domain error. So this changes the theme to the default one if the domain is untrusted.