### PR TITLE
Add filename and sharer in public page

### DIFF
--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -215,3 +215,13 @@ thead {
 	max-width: 400px;
 	text-align: left;
 }
+
+#header .header-shared-by  {
+	display: inline-block;
+	color: $color-primary-text;
+	position: relative;
+	top: -10px;
+	font-weight: 300;
+	font-size: 12px;
+	margin-top: 10px;
+}

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -36,13 +36,15 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 
 <header><div id="header" class="<?php p((isset($_['folder']) ? 'share-folder' : 'share-file')) ?>">
 		<div id="header-left">
-			<a href="<?php print_unescaped(link_to('', 'index.php')); ?>"
-				title="" id="nextcloud">
+			<span id="nextcloud">
 				<div class="logo logo-icon svg"></div>
 				<h1 class="header-appname">
-					<?php p($theme->getName()); ?>
+					<?php p($_['filename']); ?>
 				</h1>
-			</a>
+				<div class="header-shared-by">
+					<?php echo p($l->t('shared by %s', [$_['displayName']])); ?>
+				</div>
+			</span>
 		</div>
 
 		<div id="logo-claim" style="display:none;"><?php p($theme->getLogoClaim()); ?></div>


### PR DESCRIPTION
* shows the filename and sharer on the public page
* allows the user to identify, that this is a user page and not an official page of the Nextcloud hosting
* also works with theming
* works for single file and folder shares
 * remove link on logo that redirects to login (fixes #5720)

I talked with @LukasReschke about this and he said, that this would be a nice way to avoid phishing attacks. Especially for stuff like embedding the rendered markdown (see https://github.com/nextcloud/files_texteditor/pull/48)

It looks like this (after and before):

![bildschirmfoto 2017-07-21 um 18 22 35](https://user-images.githubusercontent.com/245432/28472909-db1a90e4-6e42-11e7-939b-95eb3d5edac4.png)
![bildschirmfoto 2017-07-21 um 18 24 33](https://user-images.githubusercontent.com/245432/28472914-db3d300e-6e42-11e7-900d-20756533f5d9.png)
![bildschirmfoto 2017-07-21 um 18 23 37](https://user-images.githubusercontent.com/245432/28472911-db39f6aa-6e42-11e7-8eb6-c70f1570370c.png)
![bildschirmfoto 2017-07-21 um 18 24 17](https://user-images.githubusercontent.com/245432/28472912-db3abc52-6e42-11e7-9e5e-726a86c965e7.png)
![bildschirmfoto 2017-07-21 um 18 28 07](https://user-images.githubusercontent.com/245432/28472913-db3bf5ea-6e42-11e7-8629-093d2b071745.png)


@nextcloud/designers Opinions?