### PR TITLE
Preview trash cleanup

### DIFF
--- a/lib/private/Preview/Watcher.php
+++ b/lib/private/Preview/Watcher.php
@@ -77,10 +77,16 @@ class Watcher {
 		}
 
 		/** @var Folder $node */
-		$nodes = $node->search('');
+		$this->deleteFolder($node);
+	}
+
+	private function deleteFolder(Folder $folder) {
+		$nodes = $folder->getDirectoryListing();
 		foreach ($nodes as $node) {
 			if ($node instanceof File) {
 				$this->toDelete[] = $node->getId();
+			} else if ($node instanceof Folder) {
+				$this->deleteFolder($node);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #5558
* [x] Requires: #5836

By not deleting via the view but via the node api we ensure the correct events are fired and thus we can cleanup the previews.

To test:

1. Upload a file with preview (some image)
2. Check the appdata_*/preview/ folder to see your file has a preview generated
3. Delete the file
4. Go to trash
5. Delete the file from the trash
6. Previews should be gone from the system