### PR TITLE
Remove unneeded parameter in DatabaseException

### DIFF
--- a/lib/private/DatabaseException.php
+++ b/lib/private/DatabaseException.php
@@ -24,15 +24,4 @@
 namespace OC;
 
 class DatabaseException extends \Exception {
-	private $query;
-
-	//FIXME getQuery seems to be unused, maybe use parent constructor with $message, $code and $previous
-	public function __construct($message, $query = null){
-		parent::__construct($message);
-		$this->query = $query;
-	}
-
-	public function getQuery() {
-		return $this->query;
-	}
 }

--- a/lib/private/legacy/db.php
+++ b/lib/private/legacy/db.php
@@ -65,7 +65,7 @@ class OC_DB {
 		try {
 			$result =$connection->prepare($query, $limit, $offset);
 		} catch (\Doctrine\DBAL\DBALException $e) {
-			throw new \OC\DatabaseException($e->getMessage(), $query);
+			throw new \OC\DatabaseException($e->getMessage());
 		}
 		// differentiate between query and manipulation
 		$result = new OC_DB_StatementWrapper($result, $isManipulation);
@@ -214,7 +214,7 @@ class OC_DB {
 			} else {
 				$message .= ', Root cause:' . self::getErrorMessage();
 			}
-			throw new \OC\DatabaseException($message, \OC::$server->getDatabaseConnection()->errorCode());
+			throw new \OC\DatabaseException($message);
 		}
 	}
 


### PR DESCRIPTION
Found while digging a bit in old code. I remove the only usage of this parameter and the get method was not used anyway.