### PR TITLE
Drone postgres

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -622,9 +622,9 @@ matrix:
     - DB: mysql
       PHP: 5.6
       ENABLE_REDIS: true
-#    - DB: postgres
-#      PHP: 5.6
-#      ENABLE_REDIS: true
+    - DB: postgres
+      PHP: 5.6
+      ENABLE_REDIS: true
     - DB: mysqlmb4
       PHP: 5.6
       ENABLE_REDIS: true
@@ -644,7 +644,7 @@ services:
     image: postgres
     environment:
       - POSTGRES_USER=oc_autotest
-      - POSTGRES_PASSWORD=oc_autotest
+      - POSTGRES_PASSWORD=owncloud
     when:
       matrix:
         DB: postgres


### PR DESCRIPTION
For @benediktg as discussed. We use https://hub.docker.com/_/postgres/ and it states, that the password is required if not connecting from localhost. Maybe the password was wrong in the past. I just updated it. Let's see if this already fixes the problem.