### PR TITLE
Add new bundle

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -326,6 +326,7 @@ return array(
     'OC\\App\\AppStore\\Bundles\\Bundle' => $baseDir . '/lib/private/App/AppStore/Bundles/Bundle.php',
     'OC\\App\\AppStore\\Bundles\\BundleFetcher' => $baseDir . '/lib/private/App/AppStore/Bundles/BundleFetcher.php',
     'OC\\App\\AppStore\\Bundles\\CoreBundle' => $baseDir . '/lib/private/App/AppStore/Bundles/CoreBundle.php',
+    'OC\\App\\AppStore\\Bundles\\EducationBundle' => $baseDir . '/lib/private/App/AppStore/Bundles/EducationBundle.php',
     'OC\\App\\AppStore\\Bundles\\EnterpriseBundle' => $baseDir . '/lib/private/App/AppStore/Bundles/EnterpriseBundle.php',
     'OC\\App\\AppStore\\Bundles\\GroupwareBundle' => $baseDir . '/lib/private/App/AppStore/Bundles/GroupwareBundle.php',
     'OC\\App\\AppStore\\Bundles\\SocialSharingBundle' => $baseDir . '/lib/private/App/AppStore/Bundles/SocialSharingBundle.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -356,6 +356,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\App\\AppStore\\Bundles\\Bundle' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Bundles/Bundle.php',
         'OC\\App\\AppStore\\Bundles\\BundleFetcher' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Bundles/BundleFetcher.php',
         'OC\\App\\AppStore\\Bundles\\CoreBundle' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Bundles/CoreBundle.php',
+        'OC\\App\\AppStore\\Bundles\\EducationBundle' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Bundles/EducationBundle.php',
         'OC\\App\\AppStore\\Bundles\\EnterpriseBundle' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Bundles/EnterpriseBundle.php',
         'OC\\App\\AppStore\\Bundles\\GroupwareBundle' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Bundles/GroupwareBundle.php',
         'OC\\App\\AppStore\\Bundles\\SocialSharingBundle' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Bundles/SocialSharingBundle.php',

--- a/lib/private/App/AppStore/Bundles/BundleFetcher.php
+++ b/lib/private/App/AppStore/Bundles/BundleFetcher.php
@@ -42,6 +42,7 @@ class BundleFetcher {
 			new EnterpriseBundle($this->l10n),
 			new GroupwareBundle($this->l10n),
 			new SocialSharingBundle($this->l10n),
+			new EducationBundle($this->l10n),
 		];
 	}
 

--- a/lib/private/App/AppStore/Bundles/EducationBundle.php
+++ b/lib/private/App/AppStore/Bundles/EducationBundle.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Lukas Reschke <lukas@statuscode.ch>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\App\AppStore\Bundles;
+
+class EducationBundle extends Bundle {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getName() {
+		return (string)$this->l10n->t('Education Edition');
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getAppIdentifiers() {
+		return [
+			'zenodo',
+			'dashboard',
+			'circles',
+			'groupfolders',
+			'announcementcenter',
+			'admin_notifications',
+			'quota_warning',
+			'orcid',
+			'user_saml',
+		];
+	}
+
+}

--- a/tests/lib/App/AppStore/Bundles/BundleFetcherTest.php
+++ b/tests/lib/App/AppStore/Bundles/BundleFetcherTest.php
@@ -23,6 +23,7 @@ namespace Test\App\AppStore\Bundles;
 
 use OC\App\AppStore\Bundles\BundleFetcher;
 use OC\App\AppStore\Bundles\CoreBundle;
+use OC\App\AppStore\Bundles\EducationBundle;
 use OC\App\AppStore\Bundles\EnterpriseBundle;
 use OC\App\AppStore\Bundles\GroupwareBundle;
 use OC\App\AppStore\Bundles\SocialSharingBundle;
@@ -50,6 +51,7 @@ class BundleFetcherTest extends TestCase {
 			new EnterpriseBundle($this->l10n),
 			new GroupwareBundle($this->l10n),
 			new SocialSharingBundle($this->l10n),
+			new EducationBundle($this->l10n),
 		];
 		$this->assertEquals($expected, $this->bundleFetcher->getBundles());
 	}

--- a/tests/lib/App/AppStore/Bundles/EducationBundleTest.php
+++ b/tests/lib/App/AppStore/Bundles/EducationBundleTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Lukas Reschke <lukas@statuscode.ch>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Test\App\AppStore\Bundles;
+
+use OC\App\AppStore\Bundles\EducationBundle;
+
+class EducationBundleTest extends BundleBase {
+	public function setUp() {
+		parent::setUp();
+		$this->bundle = new EducationBundle($this->l10n);
+		$this->bundleIdentifier = 'EducationBundle';
+		$this->bundleName = 'Education Edition';
+		$this->bundleAppIds = [
+			'zenodo',
+			'dashboard',
+			'circles',
+			'groupfolders',
+			'announcementcenter',
+			'admin_notifications',
+			'quota_warning',
+			'orcid',
+			'user_saml',
+		];
+	}
+}


### PR DESCRIPTION
Apps on the appstore:

- [x] zenodo
- [x] dashboard
- [x] circles
- [x] groupfolders
- [x] announcementcenter
- [x] admin_notifications
- [x] quota_warning
- [x] sharepoint
- [x] orcid
- [x] user_saml

For the remaining apps I'm waiting on @daita confirming that they can be bundled as in the Git repository. 

@jospoortvliet @daita Please review. Apps may not get listed yet as it can't find an app on the appstore for some of them for master. If the list is ok I'll open a backport to 12.0.1.