### PR TITLE
Add command to move a calendar from an user to another

### DIFF
--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -41,6 +41,7 @@
 	<commands>
 		<command>OCA\DAV\Command\CreateAddressBook</command>
 		<command>OCA\DAV\Command\CreateCalendar</command>
+		<command>OCA\DAV\Command\MoveCalendar</command>
 		<command>OCA\DAV\Command\SyncBirthdayCalendar</command>
 		<command>OCA\DAV\Command\SyncSystemAddressBook</command>
 		<command>OCA\DAV\Command\RemoveInvalidShares</command>

--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -42,6 +42,7 @@
 		<command>OCA\DAV\Command\CreateAddressBook</command>
 		<command>OCA\DAV\Command\CreateCalendar</command>
 		<command>OCA\DAV\Command\MoveCalendar</command>
+		<command>OCA\DAV\Command\ListCalendars</command>
 		<command>OCA\DAV\Command\SyncBirthdayCalendar</command>
 		<command>OCA\DAV\Command\SyncSystemAddressBook</command>
 		<command>OCA\DAV\Command\RemoveInvalidShares</command>

--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -79,6 +79,8 @@ return array(
     'OCA\\DAV\\CardDAV\\Xml\\Groups' => $baseDir . '/../lib/CardDAV/Xml/Groups.php',
     'OCA\\DAV\\Command\\CreateAddressBook' => $baseDir . '/../lib/Command/CreateAddressBook.php',
     'OCA\\DAV\\Command\\CreateCalendar' => $baseDir . '/../lib/Command/CreateCalendar.php',
+    'OCA\\DAV\\Command\\ListCalendars' => $baseDir . '/../lib/Command/ListCalendars.php',
+    'OCA\\DAV\\Command\\MoveCalendar' => $baseDir . '/../lib/Command/MoveCalendar.php',
     'OCA\\DAV\\Command\\RemoveInvalidShares' => $baseDir . '/../lib/Command/RemoveInvalidShares.php',
     'OCA\\DAV\\Command\\SyncBirthdayCalendar' => $baseDir . '/../lib/Command/SyncBirthdayCalendar.php',
     'OCA\\DAV\\Command\\SyncSystemAddressBook' => $baseDir . '/../lib/Command/SyncSystemAddressBook.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -94,6 +94,8 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\CardDAV\\Xml\\Groups' => __DIR__ . '/..' . '/../lib/CardDAV/Xml/Groups.php',
         'OCA\\DAV\\Command\\CreateAddressBook' => __DIR__ . '/..' . '/../lib/Command/CreateAddressBook.php',
         'OCA\\DAV\\Command\\CreateCalendar' => __DIR__ . '/..' . '/../lib/Command/CreateCalendar.php',
+        'OCA\\DAV\\Command\\ListCalendars' => __DIR__ . '/..' . '/../lib/Command/ListCalendars.php',
+        'OCA\\DAV\\Command\\MoveCalendar' => __DIR__ . '/..' . '/../lib/Command/MoveCalendar.php',
         'OCA\\DAV\\Command\\RemoveInvalidShares' => __DIR__ . '/..' . '/../lib/Command/RemoveInvalidShares.php',
         'OCA\\DAV\\Command\\SyncBirthdayCalendar' => __DIR__ . '/..' . '/../lib/Command/SyncBirthdayCalendar.php',
         'OCA\\DAV\\Command\\SyncSystemAddressBook' => __DIR__ . '/..' . '/../lib/Command/SyncSystemAddressBook.php',

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -2539,32 +2539,6 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	}
 
 	/**
-	 * @param string $displayName
-	 * @param string|null $principalUri
-	 * @return array
-	 */
-	public function findCalendarsUrisByDisplayName($displayName, $principalUri = null)
-	{
-		// Ideally $displayName would be sanitized the same way as stringUtility.js does in calendar
-
-		$query = $this->db->getQueryBuilder();
-		$query->select('uri')
-			->from('calendars')
-			->where($query->expr()->iLike('displayname',
-				$query->createNamedParameter('%'.$this->db->escapeLikeParameter($displayName).'%')));
-		if ($principalUri) {
-			$query->andWhere($query->expr()->eq('principaluri', $query->createNamedParameter($principalUri)));
-		}
-		$result = $query->execute();
-
-		$calendarUris = [];
-		while($row = $result->fetch()) {
-			$calendarUris[] = $row['uri'];
-		}
-		return $calendarUris;
-	}
-
-	/**
 	 * read VCalendar data into a VCalendar object
 	 *
 	 * @param string $objectData

--- a/apps/dav/lib/Command/ListCalendars.php
+++ b/apps/dav/lib/Command/ListCalendars.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018, Georg Ehrke
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ * @author Thomas Citharel <tcit@tcit.fr>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\Command;
+
+use OCA\DAV\CalDAV\BirthdayService;
+use OCA\DAV\CalDAV\CalDavBackend;
+use OCA\DAV\Connector\Sabre\Principal;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\Share\IManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListCalendars extends Command {
+
+	/** @var IUserManager */
+	protected $userManager;
+
+	/** @var CalDavBackend */
+	private $caldav;
+
+	/**
+	 * @param IUserManager $userManager
+	 * @param CalDavBackend $caldav
+	 */
+	function __construct(IUserManager $userManager, CalDavBackend $caldav) {
+		parent::__construct();
+		$this->userManager = $userManager;
+		$this->caldav = $caldav;
+	}
+
+	protected function configure() {
+		$this
+			->setName('dav:list-calendars')
+			->setDescription('List all calendars of a user')
+			->addArgument('user',
+				InputArgument::REQUIRED,
+				'User for whom all calendars will be listed');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$user = $input->getArgument('user');
+		if (!$this->userManager->userExists($user)) {
+			throw new \InvalidArgumentException("User <$user> is unknown.");
+		}
+
+		$calendars = $this->caldav->getCalendarsForUser("principals/users/$user");
+
+		$calendarTableData = [];
+		foreach($calendars as $calendar) {
+			// skip birthday calendar
+			if ($calendar['uri'] === BirthdayService::BIRTHDAY_CALENDAR_URI) {
+				continue;
+			}
+
+			$readOnly = false;
+			$readOnlyIndex = '{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}read-only';
+			if (isset($calendar[$readOnlyIndex])) {
+				$readOnly = $calendar[$readOnlyIndex];
+			}
+
+			$calendarTableData[] = [
+				$calendar['uri'],
+				$calendar['{DAV:}displayname'],
+				$calendar['{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}owner-principal'],
+				$calendar['{' . \OCA\DAV\DAV\Sharing\Plugin::NS_NEXTCLOUD . '}owner-displayname'],
+				$readOnly ? ' x ' : ' ✓ ',
+			];
+		}
+
+		if (count($calendarTableData) > 0) {
+			$table = new Table($output);
+			$table->setHeaders(['uri', 'displayname', 'owner\'s userid', 'owner\'s displayname', 'writable'])
+				->setRows($calendarTableData);
+
+			$table->render();
+		} else {
+			$output->writeln("<info>User <$user> has no calendars</info>");
+		}
+	}
+
+}

--- a/apps/dav/lib/Command/ListCalendars.php
+++ b/apps/dav/lib/Command/ListCalendars.php
@@ -59,13 +59,13 @@ class ListCalendars extends Command {
 		$this
 			->setName('dav:list-calendars')
 			->setDescription('List all calendars of a user')
-			->addArgument('user',
+			->addArgument('uid',
 				InputArgument::REQUIRED,
 				'User for whom all calendars will be listed');
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$user = $input->getArgument('user');
+		$user = $input->getArgument('uid');
 		if (!$this->userManager->userExists($user)) {
 			throw new \InvalidArgumentException("User <$user> is unknown.");
 		}

--- a/apps/dav/lib/Command/MoveCalendar.php
+++ b/apps/dav/lib/Command/MoveCalendar.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * @author Thomas Citharel <tcit@tcit.fr>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\Command;
+
+use OCA\DAV\CalDAV\CalDavBackend;
+use OCA\DAV\CalDAV\Calendar;
+use OCA\DAV\Connector\Sabre\Principal;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IL10N;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class MoveCalendar extends Command {
+
+	/** @var IUserManager */
+	protected $userManager;
+
+	/** @var IGroupManager $groupManager */
+	private $groupManager;
+
+	/** @var \OCP\IDBConnection */
+	protected $dbConnection;
+
+	/** @var IL10N */
+	protected $l10n;
+
+	/** @var SymfonyStyle */
+	private $io;
+
+	/** @var CalDavBackend */
+	private $caldav;
+
+	const URI_USERS = 'principals/users/';
+
+	/**
+	 * @param IUserManager $userManager
+	 * @param IGroupManager $groupManager
+	 * @param IDBConnection $dbConnection
+	 * @param IL10N $l10n
+	 */
+	function __construct(IUserManager $userManager, IGroupManager $groupManager, IDBConnection $dbConnection, IL10N $l10n) {
+		parent::__construct();
+		$this->userManager = $userManager;
+		$this->groupManager = $groupManager;
+		$this->dbConnection = $dbConnection;
+		$this->l10n = $l10n;
+	}
+
+	protected function configure() {
+		$this
+			->setName('dav:move-calendar')
+			->setDescription('Move a calendar from an user to another')
+			->addArgument('name',
+				InputArgument::REQUIRED,
+				'Name of the calendar to move')
+			->addArgument('userorigin',
+				InputArgument::REQUIRED,
+				'User who currently owns the calendar')
+			->addArgument('userdestination',
+				InputArgument::REQUIRED,
+				'User who will receive the calendar')
+			->addOption('force', 'f', InputOption::VALUE_NONE, "Force the migration by removing shares with groups that the destination user is not in");
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$userOrigin = $input->getArgument('userorigin');
+		$userDestination = $input->getArgument('userdestination');
+
+		$this->io = new SymfonyStyle($input, $output);
+
+		if (in_array('system', [$userOrigin, $userDestination], true)) {
+			throw new \InvalidArgumentException("User can't be system");
+		}
+
+		if (!$this->userManager->userExists($userOrigin)) {
+			throw new \InvalidArgumentException("User <$userOrigin> is unknown.");
+		}
+
+
+		if (!$this->userManager->userExists($userDestination)) {
+			throw new \InvalidArgumentException("User <$userDestination> is unknown.");
+		}
+
+		$principalBackend = new Principal(
+			$this->userManager,
+			$this->groupManager
+		);
+		$random = \OC::$server->getSecureRandom();
+		$dispatcher = \OC::$server->getEventDispatcher();
+
+		$name = $input->getArgument('name');
+		$this->caldav = new CalDavBackend($this->dbConnection, $principalBackend, $this->userManager, $random, $dispatcher);
+
+		$calendar = $this->caldav->getCalendarByUri(self::URI_USERS . $userOrigin, $name);
+
+		if (null === $calendar) {
+			/**  If we got no matching calendar with URI, let's try the display names */
+			$suggestedUris = $this->caldav->findCalendarsUrisByDisplayName($name, self::URI_USERS . $userOrigin);
+			if (count($suggestedUris) > 0) {
+				$this->io->note('No calendar with this URI was found, but you may want to try with these?');
+				$this->io->listing($suggestedUris);
+			}
+			throw new \InvalidArgumentException("User <$userOrigin> has no calendar named <$name>.");
+		}
+
+		if (null !== $this->caldav->getCalendarByUri(self::URI_USERS . $userDestination, $name)) {
+			throw new \InvalidArgumentException("User <$userDestination> already has a calendar named <$name>.");
+		}
+
+		$this->checkShares($calendar, $userDestination, $input->getOption('force'));
+
+		$this->caldav->moveCalendar($name, self::URI_USERS . $userOrigin, self::URI_USERS . $userDestination);
+
+		$this->io->success("Calendar <$name> was moved from user <$userOrigin> to <$userDestination>");
+	}
+
+	/**
+	 * Check that user destination is member of the groups which whom the calendar was shared
+	 * If we ask to force the migration, the share with the group is dropped
+	 *
+	 * @param $calendar
+	 * @param $userDestination
+	 * @param bool $force
+	 */
+	private function checkShares($calendar, $userDestination, $force = false)
+	{
+		$shares = $this->caldav->getShares($calendar['id']);
+		foreach ($shares as $share) {
+			list($prefix, $group) = str_split($share['href'], 28);
+			if ('principal:principals/groups/' === $prefix && !$this->groupManager->isInGroup($userDestination, $group)) {
+				if ($force) {
+					$this->caldav->updateShares(new Calendar($this->caldav, $calendar, $this->l10n), [], ['href' => 'principal:principals/groups/' . $group]);
+				} else {
+					throw new \InvalidArgumentException("User <$userDestination> is not part of the group <$group> with which the calendar <" . $calendar['uri'] . "> was shared. You may use -f to move the calendar while deleting this share.");
+				}
+			}
+		}
+	}
+}

--- a/apps/dav/lib/Command/MoveCalendar.php
+++ b/apps/dav/lib/Command/MoveCalendar.php
@@ -93,18 +93,18 @@ class MoveCalendar extends Command {
 			->addArgument('name',
 				InputArgument::REQUIRED,
 				'Name of the calendar to move')
-			->addArgument('userorigin',
+			->addArgument('sourceuid',
 				InputArgument::REQUIRED,
 				'User who currently owns the calendar')
-			->addArgument('userdestination',
+			->addArgument('destinationuid',
 				InputArgument::REQUIRED,
 				'User who will receive the calendar')
-			->addOption('force', 'f', InputOption::VALUE_NONE, "Force the migration by removing shares with groups that the destination user is not in");
+			->addOption('force', 'f', InputOption::VALUE_NONE, "Force the migration by removing existing shares");
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$userOrigin = $input->getArgument('userorigin');
-		$userDestination = $input->getArgument('userdestination');
+		$userOrigin = $input->getArgument('sourceuid');
+		$userDestination = $input->getArgument('destinationuid');
 
 		$this->io = new SymfonyStyle($input, $output);
 
@@ -128,9 +128,7 @@ class MoveCalendar extends Command {
 			throw new \InvalidArgumentException("User <$userDestination> already has a calendar named <$name>.");
 		}
 
-		if ($this->shareManager->shareWithGroupMembersOnly() === true) {
-			$this->checkShares($calendar, $userDestination, $input->getOption('force'));
-		}
+		$this->checkShares($calendar, $userOrigin, $userDestination, $input->getOption('force'));
 
 		$this->calDav->moveCalendar($name, self::URI_USERS . $userOrigin, self::URI_USERS . $userDestination);
 
@@ -138,25 +136,50 @@ class MoveCalendar extends Command {
 	}
 
 	/**
-	 * Check that user destination is member of the groups which whom the calendar was shared
-	 * If we ask to force the migration, the share with the group is dropped
+	 * Check that moving the calendar won't break shares
 	 *
-	 * @param $calendar
-	 * @param $userDestination
+	 * @param array $calendar
+	 * @param string $userOrigin
+	 * @param string $userDestination
 	 * @param bool $force
 	 */
-	private function checkShares($calendar, $userDestination, $force = false)
+	private function checkShares(array $calendar, string $userOrigin, string $userDestination, bool $force = false)
 	{
 		$shares = $this->calDav->getShares($calendar['id']);
 		foreach ($shares as $share) {
-			list(, $prefix, $group) = explode('/', $share['href'], 3);
-			if ('groups' === $prefix && !$this->groupManager->isInGroup($userDestination, $group)) {
+			list(, $prefix, $userOrGroup) = explode('/', $share['href'], 3);
+
+			/**
+			 * Check that user destination is member of the groups which whom the calendar was shared
+			 * If we ask to force the migration, the share with the group is dropped
+			 */
+			if ($this->shareManager->shareWithGroupMembersOnly() === true && 'groups' === $prefix && !$this->groupManager->isInGroup($userDestination, $userOrGroup)) {
 				if ($force) {
-					$this->calDav->updateShares(new Calendar($this->calDav, $calendar, $this->l10n, $this->config), [], ['href' => 'principal:principals/groups/' . $group]);
+					$this->calDav->updateShares(new Calendar($this->calDav, $calendar, $this->l10n, $this->config), [], ['href' => 'principal:principals/groups/' . $userOrGroup]);
 				} else {
-					throw new \InvalidArgumentException("User <$userDestination> is not part of the group <$group> with whom the calendar <" . $calendar['uri'] . "> was shared. You may use -f to move the calendar while deleting this share.");
+					throw new \InvalidArgumentException("User <$userDestination> is not part of the group <$userOrGroup> with whom the calendar <" . $calendar['uri'] . "> was shared. You may use -f to move the calendar while deleting this share.");
 				}
 			}
+
+			/**
+			 * Check that calendar isn't already shared with user destination
+			 */
+			if ($userOrGroup === $userDestination) {
+				if ($force) {
+					$this->calDav->updateShares(new Calendar($this->calDav, $calendar, $this->l10n, $this->config), [], ['href' => 'principal:principals/users/' . $userOrGroup]);
+				} else {
+					throw new \InvalidArgumentException("The calendar <" . $calendar['uri'] . "> is already shared to user <$userDestination>.You may use -f to move the calendar while deleting this share.");
+				}
+			}
+		}
+		/**
+		 * Warn that share links have changed if there are shares
+		 */
+		if (count($shares) > 0) {
+			$this->io->note([
+				"Please note that moving calendar " . $calendar['uri'] . " from user <$userOrigin> to <$userDestination> has caused share links to change.", 
+				"Sharees will need to change \"example.com/remote.php/dav/calendars/uid/" . $calendar['uri'] . "_shared_by_$userOrigin\" to \"example.com/remote.php/dav/calendars/uid/" . $calendar['uri'] . "_shared_by_$userDestination\""
+			]);
 		}
 	}
 }

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -983,4 +983,21 @@ EOD;
 
 		$this->assertEquals(null, $this->backend->getCalendarObject($subscriptionId, $uri, CalDavBackend::CALENDAR_TYPE_SUBSCRIPTION));
 	}
+
+	public function testCalendarMovement()
+	{
+		$this->backend->createCalendar(self::UNIT_TEST_USER, 'Example', []);
+
+		$this->assertCount(1, $this->backend->getCalendarsForUser(self::UNIT_TEST_USER));
+
+		$calendarInfoUser = $this->backend->getCalendarsForUser(self::UNIT_TEST_USER)[0];
+
+		$this->backend->moveCalendar('Example', self::UNIT_TEST_USER, self::UNIT_TEST_USER1);
+		$this->assertCount(0, $this->backend->getCalendarsForUser(self::UNIT_TEST_USER));
+		$this->assertCount(1, $this->backend->getCalendarsForUser(self::UNIT_TEST_USER1));
+
+		$calendarInfoUser1 = $this->backend->getCalendarsForUser(self::UNIT_TEST_USER1)[0];
+		$this->assertEquals($calendarInfoUser['id'], $calendarInfoUser1['id']);
+		$this->assertEquals($calendarInfoUser['uri'], $calendarInfoUser1['uri']);
+	}
 }

--- a/apps/dav/tests/unit/Command/ListCalendarsTest.php
+++ b/apps/dav/tests/unit/Command/ListCalendarsTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * @author Thomas Citharel <tcit@tcit.fr>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Command;
+
+use InvalidArgumentException;
+use OCA\DAV\CalDAV\BirthdayService;
+use OCA\DAV\CalDAV\CalDavBackend;
+use OCA\DAV\Command\ListCalendars;
+use OCP\IUserManager;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+
+
+/**
+ * Class ListCalendarsTest
+ *
+ * @package OCA\DAV\Tests\Command
+ */
+class ListCalendarsTest extends TestCase {
+
+	/** @var \OCP\IUserManager|\PHPUnit_Framework_MockObject_MockObject $userManager */
+	private $userManager;
+
+	/** @var CalDavBackend|\PHPUnit_Framework_MockObject_MockObject $l10n */
+	private $calDav;
+
+	/** @var ListCalendars */
+	private $command;
+
+	const USERNAME = 'username';
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->calDav = $this->createMock(CalDavBackend::class);
+
+		$this->command = new ListCalendars(
+			$this->userManager,
+			$this->calDav
+		);
+	}
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testWithBadUser()
+	{
+		$this->userManager->expects($this->once())
+			->method('userExists')
+			->with(self::USERNAME)
+			->willReturn(false);
+
+		$commandTester = new CommandTester($this->command);
+		$commandTester->execute([
+			'user' => self::USERNAME,
+		]);
+		$this->assertContains("User <" . self::USERNAME . "> in unknown", $commandTester->getDisplay());
+	}
+
+	public function testWithCorrectUserWithNoCalendars()
+	{
+		$this->userManager->expects($this->once())
+			->method('userExists')
+			->with(self::USERNAME)
+			->willReturn(true);
+
+		$this->calDav->expects($this->once())
+			->method('getCalendarsForUser')
+			->with('principals/users/' . self::USERNAME)
+			->willReturn([]);
+
+		$commandTester = new CommandTester($this->command);
+		$commandTester->execute([
+			'user' => self::USERNAME,
+		]);
+		$this->assertContains("User <" . self::USERNAME . "> has no calendars\n", $commandTester->getDisplay());
+	}
+
+	public function dataExecute()
+	{
+		return [
+			[false, '✓'],
+			[true, 'x']
+		];
+	}
+
+	/**
+	 * @dataProvider dataExecute
+	 */
+	public function testWithCorrectUser(bool $readOnly, string $output)
+	{
+		$this->userManager->expects($this->once())
+			->method('userExists')
+			->with(self::USERNAME)
+			->willReturn(true);
+
+		$this->calDav->expects($this->once())
+			->method('getCalendarsForUser')
+			->with('principals/users/' . self::USERNAME)
+			->willReturn([
+				[
+					'uri' => BirthdayService::BIRTHDAY_CALENDAR_URI,
+				],
+				[
+					'{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}read-only' => $readOnly,
+					'uri' => 'test',
+					'{DAV:}displayname' => 'dp',
+					'{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}owner-principal' => 'owner-principal',
+					'{' . \OCA\DAV\DAV\Sharing\Plugin::NS_NEXTCLOUD . '}owner-displayname' => 'owner-dp',
+				]
+			]);
+
+		$commandTester = new CommandTester($this->command);
+		$commandTester->execute([
+			'user' => self::USERNAME,
+		]);
+		$this->assertContains($output, $commandTester->getDisplay());
+		$this->assertNotContains(BirthdayService::BIRTHDAY_CALENDAR_URI, $commandTester->getDisplay());
+	}
+}

--- a/apps/dav/tests/unit/Command/ListCalendarsTest.php
+++ b/apps/dav/tests/unit/Command/ListCalendarsTest.php
@@ -36,10 +36,10 @@ use Test\TestCase;
  */
 class ListCalendarsTest extends TestCase {
 
-	/** @var \OCP\IUserManager|\PHPUnit_Framework_MockObject_MockObject $userManager */
+	/** @var \OCP\IUserManager|\PHPUnit\Framework\MockObject\MockObject $userManager */
 	private $userManager;
 
-	/** @var CalDavBackend|\PHPUnit_Framework_MockObject_MockObject $l10n */
+	/** @var CalDavBackend|\PHPUnit\Framework\MockObject\MockObject $l10n */
 	private $calDav;
 
 	/** @var ListCalendars */
@@ -71,7 +71,7 @@ class ListCalendarsTest extends TestCase {
 
 		$commandTester = new CommandTester($this->command);
 		$commandTester->execute([
-			'user' => self::USERNAME,
+			'uid' => self::USERNAME,
 		]);
 		$this->assertContains("User <" . self::USERNAME . "> in unknown", $commandTester->getDisplay());
 	}
@@ -90,7 +90,7 @@ class ListCalendarsTest extends TestCase {
 
 		$commandTester = new CommandTester($this->command);
 		$commandTester->execute([
-			'user' => self::USERNAME,
+			'uid' => self::USERNAME,
 		]);
 		$this->assertContains("User <" . self::USERNAME . "> has no calendars\n", $commandTester->getDisplay());
 	}
@@ -131,7 +131,7 @@ class ListCalendarsTest extends TestCase {
 
 		$commandTester = new CommandTester($this->command);
 		$commandTester->execute([
-			'user' => self::USERNAME,
+			'uid' => self::USERNAME,
 		]);
 		$this->assertContains($output, $commandTester->getDisplay());
 		$this->assertNotContains(BirthdayService::BIRTHDAY_CALENDAR_URI, $commandTester->getDisplay());

--- a/apps/dav/tests/unit/Command/MoveCalendarTest.php
+++ b/apps/dav/tests/unit/Command/MoveCalendarTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * @author Thomas Citharel <tcit@tcit.fr>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Command;
+
+use InvalidArgumentException;
+use OCA\DAV\Command\MoveCalendar;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IL10N;
+use OCP\IUserManager;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+
+
+/**
+ * Class MoveCalendarTest
+ *
+ * @package OCA\DAV\Tests\Command
+ * @group DB
+ */
+class MoveCalendarTest extends TestCase {
+
+	/** @var \OCP\IUserManager|\PHPUnit_Framework_MockObject_MockObject $userManager */
+	private $userManager;
+
+	/** @var \OCP\IGroupManager|\PHPUnit_Framework_MockObject_MockObject $groupManager */
+	private $groupManager;
+
+	/** @var \OCP\IDBConnection|\PHPUnit_Framework_MockObject_MockObject $dbConnection */
+	private $dbConnection;
+
+	/** @var \OCP\IL10N|\PHPUnit_Framework_MockObject_MockObject $l10n */
+	private $l10n;
+
+	/** @var MoveCalendar */
+	private $command;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->dbConnection = $this->createMock(IDBConnection::class);
+		$this->l10n = $this->createMock(IL10N::class);
+
+		$this->command = new MoveCalendar(
+			$this->userManager,
+			$this->groupManager,
+			$this->dbConnection,
+			$this->l10n
+		);
+	}
+
+	public function dataExecute() {
+		return [
+			[false, true],
+			[true, false]
+		];
+	}
+
+	/**
+	 * @dataProvider dataExecute
+	 *
+	 * @expectedException InvalidArgumentException
+	 * @param $userOriginExists
+	 * @param $userDestinationExists
+	 */
+	public function testWithBadUserOrigin($userOriginExists, $userDestinationExists)
+	{
+		$this->userManager->expects($this->at(0))
+			->method('userExists')
+			->with('user')
+			->willReturn($userOriginExists);
+
+		if (!$userDestinationExists) {
+			$this->userManager->expects($this->at(1))
+				->method('userExists')
+				->with('user2')
+				->willReturn($userDestinationExists);
+		}
+
+		$commandTester = new CommandTester($this->command);
+		$commandTester->execute([
+			'name' => $this->command->getName(),
+			'userorigin' => 'user',
+			'userdestination' => 'user2',
+		]);
+	}
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 * @expectedExceptionMessage User can't be system
+	 */
+	public function testTryToMoveToOrFromSystem()
+	{
+		$commandTester = new CommandTester($this->command);
+		$commandTester->execute([
+			'name' => $this->command->getName(),
+			'userorigin' => 'system',
+			'userdestination' => 'user2',
+		]);
+	}
+}


### PR DESCRIPTION
Implement #5158

Command is : `occ dav:move-calendar %name% %userorigin% %userdestination% [-f]` where `-f` allows to delete the calendar shares with a group if the destination user is not in this group. Otherwise it just fails.

The `uri` name of the calendar is needed, so maybe it would be nice to suggest names based on the actual display names if none are found at first.

A few tests would be nice (but there's not much in nextcloud to have a look at 😉  )

- [x] Test ListCalendars command