### PR TITLE
Add beame-insta-ssl integration for secure remote access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 !/apps/theming
 !/apps/twofactor_backupcodes
 !/apps/workflowengine
+!/apps/beame_insta_ssl
 /apps/files_external/3rdparty/irodsphp/PHPUnitTest
 /apps/files_external/3rdparty/irodsphp/web
 /apps/files_external/3rdparty/irodsphp/prods/test

--- a/apps/beame_insta_ssl/appinfo/info.xml
+++ b/apps/beame_insta_ssl/appinfo/info.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
+	<!-- https://docs.nextcloud.com/server/12/developer_manual/app/info.html -->
+	<!-- TODO: ocsid -->
+	<id>beame_insta_ssl</id>
+	<name>Secure remote access (beame-insta-ssl)</name>
+	<description>beame-insta-ssl makes your Nextcloud accessible from the Internet even if it is behind a firewall or router. You must have beame-insta-ssl npm installed globally.</description>
+	<category>intergration</category>
+	<licence>AGPL</licence>
+	<author>Beame.io LTD</author>
+	<namespace>BeameInstaSsl</namespace>
+	<version>0.0.1</version>
+
+	<default_enable/>
+	<types>
+		<filesystem/>
+	</types>
+	<dependencies>
+		<nextcloud min-version="12" max-version="13" />
+		<command>bash</command>
+		<command>env</command>
+		<command>grep</command>
+		<command>nohup</command>
+		<command>ps</command>
+	</dependencies>
+	<website>https://www.beame.io/insta-ssl</website>
+	<settings>
+		<admin>OCA\BeameInstaSsl\Settings\Admin</admin>
+	</settings>
+</info>

--- a/apps/beame_insta_ssl/appinfo/routes.php
+++ b/apps/beame_insta_ssl/appinfo/routes.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Beame.io LTD.
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+return [
+	'routes' => [
+		['name' => 'settings#getCreds', 'url' => '/settings/get-creds', 'verb' => 'POST'],
+		['name' => 'settings#start',    'url' => '/settings/start',     'verb' => 'POST'],
+		['name' => 'settings#stop',     'url' => '/settings/stop',      'verb' => 'POST'],
+		['name' => 'settings#cleanup',  'url' => '/settings/cleanup',   'verb' => 'POST'],
+	],
+];

--- a/apps/beame_insta_ssl/css/settings-admin.css
+++ b/apps/beame_insta_ssl/css/settings-admin.css
@@ -1,0 +1,31 @@
+/**
+ * @author Copyright (c) 2017 Beame.io LTD <support@beame.io>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+#beame-insta-ssl textarea {
+	width: 100%;
+}
+#beame-insta-ssl a {
+	text-decoration: underline;
+}
+#beame-insta-ssl .error {
+	color: red;
+}
+#beame-insta-ssl .unobtrusive {
+	opacity: 0.4;
+}

--- a/apps/beame_insta_ssl/lib/BeameInstaSsl.php
+++ b/apps/beame_insta_ssl/lib/BeameInstaSsl.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Beame.io LTD <support@beame.io>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\BeameInstaSsl;
+
+class CommandRunError extends \Exception {
+	public function __construct($command, $exit_code, $stderr) {
+		$this->command = $command;
+		$this->exit_code = $exit_code;
+		$this->stderr = $stderr;
+	}
+}
+
+function getHome() {
+	$home = \OC::$server->getConfig()->getSystemValue('datadirectory') . '/beame-insta-ssl';
+	// TODO: move it somewhere so it runs once, on installation.
+	mkdir($home);
+	return $home;
+}
+
+
+function runCommand($cmd) {
+	$tmp = tempnam(sys_get_temp_dir(), 'beame-insta-ssl-stderr');
+	$cmd = "env HOME=".escapeshellarg(getHome()). " beame-insta-ssl $cmd --format json 2>".escapeshellarg($tmp);
+	exec($cmd, $output, $exit_code);
+	$stderr = file_get_contents($tmp);
+	unlink($tmp);
+	if($exit_code !== 0) {
+		error_log("[BeameInstaSsl] Failed to run beame-insta-ssl: $exit_code, $stderr");
+		return new CommandRunError($cmd, $exit_code, $stderr);
+	}
+	return json_decode(join('', $output));
+}
+
+function startTunnel($fqdn) {
+	$config = \OC::$server->getConfig();
+	$trusted_domains = $config->getSystemValue('trusted_domains', []);
+	if(!in_array($fqdn, $trusted_domains)) {
+		$j = json_encode($trusted_domains);
+		error_log("[BeameInstaSsl] adding to trusted domains: $fqdn (currently trusted domains are: $j)");
+		$trusted_domains[] = $fqdn;
+		$config->setSystemValue('trusted_domains', $trusted_domains);
+	}
+
+	$_cmd .= ' (beame-insta-ssl tunnel make --fqdn "$1" --dst 80 --proto http & echo $! >"$2") > >(logger -t beame-insta-ssl-stdout) 2> >(logger -t beame-insta-ssl-stderr)';
+	$_fqdn = escapeshellarg($fqdn);
+	$_pid_file = getHome() . '/run.pid';
+	exec("env HOME=".escapeshellarg(getHome())." nohup bash -c '$_cmd' -- $_fqdn $_pid_file >/dev/null 2>&1");
+	// putFile('run.pid', $pid);
+	putFile('run.fqdn', $fqdn);
+}
+
+function stopTunnel() {
+	$state = checkTunnelRunning();
+	if($state['mode'] != 'running') {
+		return false;
+	}
+	exec("kill -9 ".escapeshellarg($state['run_pid']));
+	cleanupRunFiles();
+}
+
+function checkTunnelRunning() {
+	$ret = [];
+	$run_pid = getFile('run.pid');
+	if($run_pid === null) {
+		$creds = listCredentials();
+		error_log('p0'.json_encode($creds->exit_code));
+		if(($creds instanceof CommandRunError) && ($creds->exit_code == 127)) {
+			error_log('p1');
+			$ret['mode'] = 'not-installed';
+		} else {
+			if($creds) {
+				$ret['mode'] = 'stopped';
+				$ret['creds'] = $creds;
+			} else {
+				$ret['mode'] = 'nocreds';
+			}
+		}
+	} else {
+		$ret['run_pid'] = $run_pid;
+		$ret['run_fqdn'] = getFile('run.fqdn');
+		$_run_pid = (int) $run_pid;
+		exec("ps aux | grep '\<$_run_pid\>.*beame-insta-ssl tunnel make' | grep -v grep", $output, $code);
+		if($code === 0) {
+			$ret['mode'] = 'running';
+			// Without trailing slash , there is redirect to HTTP
+			$l = 'https://'.$ret['run_fqdn'].\OC::$WEBROOT;
+			if(substr($l, -1) != '/') {
+				$l .= '/';
+			}
+			$ret['run_link'] = $l;
+		} else {
+			$ret['mode'] = 'stale';
+		}
+	}
+	return $ret;
+}
+
+function cleanupRunFiles() {
+	foreach(['run.pid', 'run.fqdn'] as $fname) {
+		$f = getHome() . '/' . $fname;
+		if(file_exists($f)) {
+			unlink($f);
+		}
+	}
+}
+
+function listCredentials() {
+	return runCommand("creds signers");
+}
+
+function getFile($fname) {
+	$f = getHome() . '/' . $fname;
+	if(!file_exists($f)) {
+		return null;
+	}
+	$ret = file_get_contents($f);
+	if($ret === false) {
+		return null;
+	}
+	// In case someone decides to "echo something >run.fqdn"
+	return trim($ret);
+}
+
+function putFile($fname, $data) {
+	$f = getHome() . '/' . $fname;
+	file_put_contents($f, $data);
+}
+

--- a/apps/beame_insta_ssl/lib/BeameInstaSsl.php
+++ b/apps/beame_insta_ssl/lib/BeameInstaSsl.php
@@ -70,7 +70,7 @@ function startTunnel($fqdn) {
 
 function stopTunnel() {
 	$state = checkTunnelRunning();
-	if($state['mode'] != 'running') {
+	if($state['mode'] !== 'running') {
 		return false;
 	}
 	exec("kill -9 ".escapeshellarg($state['run_pid']));
@@ -83,7 +83,7 @@ function checkTunnelRunning() {
 	if($run_pid === null) {
 		$creds = listCredentials();
 		error_log('p0'.json_encode($creds->exit_code));
-		if(($creds instanceof CommandRunError) && ($creds->exit_code == 127)) {
+		if(($creds instanceof CommandRunError) && ($creds->exit_code === 127)) {
 			error_log('p1');
 			$ret['mode'] = 'not-installed';
 		} else {
@@ -103,7 +103,7 @@ function checkTunnelRunning() {
 			$ret['mode'] = 'running';
 			// Without trailing slash , there is redirect to HTTP
 			$l = 'https://'.$ret['run_fqdn'].\OC::$WEBROOT;
-			if(substr($l, -1) != '/') {
+			if(substr($l, -1) !== '/') {
 				$l .= '/';
 			}
 			$ret['run_link'] = $l;

--- a/apps/beame_insta_ssl/lib/Controller/SettingsController.php
+++ b/apps/beame_insta_ssl/lib/Controller/SettingsController.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Beame.io LTD <support@beame.io>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\BeameInstaSsl\Controller;
+
+use OC\Authentication\Token\DefaultTokenMapper;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+
+require_once(__DIR__ . '/../BeameInstaSsl.php');
+// use OCA\BeameInstaSsl; // How this should work?
+
+class SettingsController extends Controller {
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
+	/**
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param IURLGenerator $urlGenerator
+	 */
+	public function __construct($appName, IRequest $request, IURLGenerator $urlGenerator, IConfig $config) {
+		parent::__construct($appName, $request);
+		$this->urlGenerator = $urlGenerator;
+		$this->config = $config;
+	}
+
+	/**
+	 * @param string $name
+	 * @return RedirectResponse
+	 * @NoCSRFRequired
+	 */
+	public function getCreds($token) {
+		set_time_limit(180); // Usually takes up to 30 seconds
+		$t = escapeshellarg($token);
+		$out = \OCA\BeameInstaSsl\runCommand("creds getCreds --regToken $t");
+		if($out instanceof \OCA\BeameInstaSsl\CommandRunError) {
+			$add = 'beame_insta_ssl_error='.urlencode($out->stderr);
+		} else {
+			error_log("[BeameInstaSsl] got credentials" . json_encode($out));
+			$add = 'beame_insta_ssl_got_creds=1';
+		}
+
+		return new RedirectResponse($this->urlGenerator->getAbsoluteURL('/index.php/settings/admin/additional?'.$add));
+	}
+
+	/**
+	 * @param string $fqdn
+	 * @return RedirectResponse
+	 * @NoCSRFRequired
+	 */
+	public function start($fqdn) {
+		$pid = \OCA\BeameInstaSsl\startTunnel($fqdn);
+		return new RedirectResponse($this->urlGenerator->getAbsoluteURL('/index.php/settings/admin/additional'));
+	}
+
+	/**
+	 * @return RedirectResponse
+	 * @NoCSRFRequired
+	 */
+	public function stop() {
+		\OCA\BeameInstaSsl\stopTunnel();
+		return new RedirectResponse($this->urlGenerator->getAbsoluteURL('/index.php/settings/admin/additional'));
+	}
+
+	/**
+	 * @return RedirectResponse
+	 * @NoCSRFRequired
+	 */
+	public function cleanup() {
+		$pid = \OCA\BeameInstaSsl\cleanupRunFiles();
+		return new RedirectResponse($this->urlGenerator->getAbsoluteURL('/index.php/settings/admin/additional'));
+	}
+
+}

--- a/apps/beame_insta_ssl/lib/Settings/Admin.php
+++ b/apps/beame_insta_ssl/lib/Settings/Admin.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Beame.io LTD <support@beame.io>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\BeameInstaSsl\Settings;
+
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Settings\ISettings;
+use OCP\IRequest;
+
+require_once(__DIR__ . '/../BeameInstaSsl.php');
+// use OCA\BeameInstaSsl; // How this should work?
+
+class Admin implements ISettings {
+
+	/** @var IRequest */
+	var $request;
+
+	public function __construct(IRequest $request) {
+		$this->request = $request;
+	}
+
+
+	/**
+	 * @return TemplateResponse
+	 */
+	public function getForm() {
+
+        $params = \OCA\BeameInstaSsl\checkTunnelRunning();
+		$params['error'] = $this->request->getParam('beame_insta_ssl_error');
+		$params['got_creds'] = $this->request->getParam('beame_insta_ssl_got_creds');
+
+		// p("CREDS $creds");
+		// https://github.com/nextcloud/server/blob/master/lib/public/AppFramework/Http/TemplateResponse.php
+		return new TemplateResponse('beame_insta_ssl', 'admin', $params, '');
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getSection() {
+		return 'additional';
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getPriority() {
+		return 0;
+	}
+}

--- a/apps/beame_insta_ssl/templates/admin.php
+++ b/apps/beame_insta_ssl/templates/admin.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Beame.io LTD <support@beame.io>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+$urlGenerator = \OC::$server->getURLGenerator();
+
+style('beame_insta_ssl', 'settings-admin');
+
+?>
+
+<div id="beame-insta-ssl" class="section">
+	<h2><?php p($l->t('Secure remote access (beame-insta-ssl)')); ?></h2>
+	<p class="settings-hint"><?php p($l->t('Access your site via https://xxxx.beameio.net/ without configuring your firewall or router.')); ?></p>
+
+<?php if($_['error']) { ?>
+<p>
+	<div class="error"><?php p($l->t('The following error occured while trying to configure beame-insta-ssl:')); ?></div>
+	<pre class="error"><?php foreach(preg_split('/[\r\n]+/', $_['error']) as $e) { p($e); print_unescaped('<br/>'); } ?></pre>
+</p>
+<?php } ?>
+
+<!--
+<?php if($_['got_creds']) { ?>
+<p class="msg">
+	<?php p($l->t("You've got certificate for HTTPS")); ?>
+</p>
+<?php } ?>
+-->
+
+<?php
+	switch($_['mode']) {
+	case 'not-installed': ?>
+<p>
+	<?php print_unescaped($l->t('Please install beame-insta-ssl npm using the following command: <pre><code>%s</code></pre>  Secure remote access is not available without beame-insta-ssl npm.', array('sudo npm -g install beame-insta-ssl')));?>
+
+</p>
+<p>
+	<a href="https://github.com/beameio/beame-insta-ssl" target="_blank" class="unobtrusive"><?php p($l->t('More information about beame-insta-ssl.'));?></a>
+</p>
+<!---------- not installed ---------->
+<?php
+		break;
+	case 'nocreds': ?>
+<!---------- not set up ---------->
+
+<p>
+<form method="post" action="<?php p($urlGenerator->linkToRoute('beame_insta_ssl.settings.getCreds')); ?>">
+	<label for="beame-insta-ssl-token"><?php print_unescaped($l->t('In order to use beame-insta-ssl remote access, please <a href="%s" target="_blank">register</a> and use your token below:', array('https://ypxf72akb6onjvrq.ohkv8odznwh5jpwm.v1.p.beameio.net/insta-ssl?from=nextcloud')));?></label><br/>
+	<textarea id="beame-insta-ssl-token" name="token" placeholder="<?php p($l->t('Long token from email, looks like:'))?> TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIHRlIGRpY3RhIG1hbG9ydW0gdm9sdXRwYXQgcXVpLCBl..."></textarea><br/>
+	<input type="submit" value="<?php p($l->t('Finish setup')); ?>"/><?php p($l->t('Typically takes about 30 seconds.'))?> <a href="https://github.com/beameio/beame-insta-ssl" target="_blank" class="unobtrusive"><?php p($l->t('More information about beame-insta-ssl.'));?></a>
+</form>
+</p>
+
+<?php
+		break;
+	case 'stopped': ?>
+<!---------- stopped ---------->
+
+<p>
+	<?php p($l->t('beame-insta-ssl is not running.'))?><br/>
+	<form method="post" action="<?php p($urlGenerator->linkToRoute('beame_insta_ssl.settings.start')); ?>">
+		<label for="beame-insta-ssl-fqdn"><?php p($l->t('HTTPS domain name to use (FQDN)'))?></label>
+		<select id="beame-insta-ssl-fqdn" name="fqdn">
+			<?php foreach($_['creds'] as $cred) { ?>
+				<option value="<?php p($cred->fqdn)?>"><?php p($cred->name)?></option>
+			<?php } ?>
+		</select>
+		<input type="submit" value="<?php p($l->t('Start')); ?>"/>
+	</form>
+</p>
+
+<?php
+		break;
+	case 'running': ?>
+<!---------- running ---------->
+<?php echo($l->t('beame-insta-ssl is running. Your secure remote access link is <a href="%s" target="_blank">%s</a> .The link will start working in a minute or two if it\'s the first time.', [$_['run_link'], $_['run_link']]))?><br/>
+<form method="post" action="<?php p($urlGenerator->linkToRoute('beame_insta_ssl.settings.stop')); ?>">
+	<input type="submit" value="<?php p($l->t('Stop')); ?>"/>
+</form>
+<?php
+		break;
+	case 'stale': ?>
+<!---------- stale ---------->
+<p class="error">
+	<?php p($l->t('beame-insta-ssl either crashed or did not start properly.'));?>
+	<form method="post" action="<?php p($urlGenerator->linkToRoute('beame_insta_ssl.settings.cleanup'));?>">
+		<input type="submit" value="<?php p($l->t('OK')); ?>"/>
+	</form>
+</p>
+<?php
+		break;
+	default:
+		echo($l->t('Internal error: unknown template mode %s', array($_['mode'])));
+} ?>
+
+</div>


### PR DESCRIPTION
[beame-insta-ssl](https://github.com/beameio/beame-insta-ssl/) allows secure remote access, similarly to pagekite. This PR contains Nextcloud integration with beame-insta-ssl.
