### PR TITLE
Fix show password button for password change

### DIFF
--- a/settings/js/settings/personalInfo.js
+++ b/settings/js/settings/personalInfo.js
@@ -169,7 +169,6 @@ $(document).ready(function () {
 				if (data.status === "success") {
 					$("#passwordbutton").after("<span class='checkmark icon icon-checkmark password-state'></span>");
 					removeloader();
-					$(".personal-show-label").show();
 					$('#pass1').val('');
 					$('#pass2').val('').change();
 				}
@@ -185,6 +184,7 @@ $(document).ready(function () {
 						}
 					);
 				}
+				$(".personal-show-label").show();
 				$(".password-loading").remove();
 				$("#passwordbutton").removeAttr('disabled');
 			});


### PR DESCRIPTION
* fix the show password button on the personal page
* before: if the password change failed the show password icon was not shown again
* after: show password icon is visible
* regression from #1229

Should be backported at least to stable12.