### PR TITLE
[stable12] Fix show password button for password change

### DIFF
--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -168,7 +168,6 @@ $(document).ready(function () {
 				if (data.status === "success") {
 					$("#passwordbutton").after("<span class='checkmark icon icon-checkmark password-state'></span>");
 					removeloader();
-					$(".personal-show-label").show();
 					$('#pass1').val('');
 					$('#pass2').val('').change();
 				}
@@ -184,6 +183,7 @@ $(document).ready(function () {
 						}
 					);
 				}
+				$(".personal-show-label").show();
 				$(".password-loading").remove();
 				$("#passwordbutton").removeAttr('disabled');
 			});


### PR DESCRIPTION
* fix the show password button on the personal page
* before: if the password change failed the show password icon was not shown again
* after: show password icon is visible
* backport of #5895 


Would be nice to have this in 12.0.1 🙈 