### PR TITLE
Add a repair step to drop the account_terms table on oc migration

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -743,6 +743,7 @@ return array(
     'OC\\Repair\\NC12\\UpdateLanguageCodes' => $baseDir . '/lib/private/Repair/NC12/UpdateLanguageCodes.php',
     'OC\\Repair\\NC13\\RepairInvalidPaths' => $baseDir . '/lib/private/Repair/NC13/RepairInvalidPaths.php',
     'OC\\Repair\\OldGroupMembershipShares' => $baseDir . '/lib/private/Repair/OldGroupMembershipShares.php',
+    'OC\\Repair\\Owncloud\\DropAccountTermsTable' => $baseDir . '/lib/private/Repair/Owncloud/DropAccountTermsTable.php',
     'OC\\Repair\\Owncloud\\SaveAccountsTableData' => $baseDir . '/lib/private/Repair/Owncloud/SaveAccountsTableData.php',
     'OC\\Repair\\RemoveRootShares' => $baseDir . '/lib/private/Repair/RemoveRootShares.php',
     'OC\\Repair\\RepairInvalidShares' => $baseDir . '/lib/private/Repair/RepairInvalidShares.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -773,6 +773,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Repair\\NC12\\UpdateLanguageCodes' => __DIR__ . '/../../..' . '/lib/private/Repair/NC12/UpdateLanguageCodes.php',
         'OC\\Repair\\NC13\\RepairInvalidPaths' => __DIR__ . '/../../..' . '/lib/private/Repair/NC13/RepairInvalidPaths.php',
         'OC\\Repair\\OldGroupMembershipShares' => __DIR__ . '/../../..' . '/lib/private/Repair/OldGroupMembershipShares.php',
+        'OC\\Repair\\Owncloud\\DropAccountTermsTable' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/DropAccountTermsTable.php',
         'OC\\Repair\\Owncloud\\SaveAccountsTableData' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/SaveAccountsTableData.php',
         'OC\\Repair\\RemoveRootShares' => __DIR__ . '/../../..' . '/lib/private/Repair/RemoveRootShares.php',
         'OC\\Repair\\RepairInvalidShares' => __DIR__ . '/../../..' . '/lib/private/Repair/RepairInvalidShares.php',

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -40,6 +40,7 @@ use OC\Repair\NC11\MoveAvatars;
 use OC\Repair\NC12\InstallCoreBundle;
 use OC\Repair\NC12\UpdateLanguageCodes;
 use OC\Repair\OldGroupMembershipShares;
+use OC\Repair\Owncloud\DropAccountTermsTable;
 use OC\Repair\Owncloud\SaveAccountsTableData;
 use OC\Repair\RemoveRootShares;
 use OC\Repair\NC13\RepairInvalidPaths;
@@ -174,6 +175,7 @@ class Repair implements IOutput{
 			new Collation(\OC::$server->getConfig(), \OC::$server->getLogger(), $connection, true),
 			new SqliteAutoincrement($connection),
 			new SaveAccountsTableData($connection, $config),
+			new DropAccountTermsTable($connection),
 		];
 
 		return $steps;

--- a/lib/private/Repair/Owncloud/DropAccountTermsTable.php
+++ b/lib/private/Repair/Owncloud/DropAccountTermsTable.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Repair\Owncloud;
+
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class DropAccountTermsTable implements IRepairStep {
+
+	/** @var IDBConnection */
+	protected $db;
+
+	/**
+	 * @param IDBConnection $db
+	 */
+	public function __construct(IDBConnection $db) {
+		$this->db = $db;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getName() {
+		return 'Drop account terms table when migrating from ownCloud';
+	}
+
+	/**
+	 * @param IOutput $output
+	 */
+	public function run(IOutput $output) {
+		if (!$this->db->tableExists('account_terms')) {
+			return;
+		}
+
+		$this->db->dropTable('account_terms');
+	}
+}
+

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -199,9 +199,7 @@ class Updater extends BasicEmitter {
 				'11.0.0.10',
 			], true)) {
 				$currentVendor = 'nextcloud';
-			} else if (in_array($oldVersion, [
-					'10.0.0.12',
-				], true)) {
+			} else if (isset($allowedPreviousVersions['owncloud'][$oldVersion])) {
 				$currentVendor = 'owncloud';
 			}
 		}

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(12, 0, 1, 1);
+$OC_Version = array(12, 0, 1, 2);
 
 // The human readable string
 $OC_VersionString = '12.0.1 RC2';
@@ -38,6 +38,8 @@ $OC_VersionCanBeUpgradedFrom = [
 	],
 	'owncloud' => [
 		'10.0.0.12' => true,
+		'10.0.1.5' => true,
+		'10.0.2.1' => true,
 	],
 ];
 

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@
 $OC_Version = array(12, 0, 1, 2);
 
 // The human readable string
-$OC_VersionString = '12.0.1 RC2';
+$OC_VersionString = '12.0.1 RC3';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Abusing the backport label for a forward port to master.