### PR TITLE
Fix anchor name for federated sharing settings

### DIFF
--- a/apps/federatedfilesharing/templates/settings-personal.php
+++ b/apps/federatedfilesharing/templates/settings-personal.php
@@ -7,7 +7,7 @@ style('federatedfilesharing', 'settings-personal');
 
 <?php if ($_['outgoingServer2serverShareEnabled']): ?>
 	<div id="fileSharingSettings" class="section">
-		<h2><?php p($l->t('Federated Cloud')); ?></h2>
+		<h2 data-anchor-name="federated-cloud"><?php p($l->t('Federated Cloud')); ?></h2>
 		<p class="settings-hint"><?php p($l->t('You can share with anyone who uses Nextcloud, ownCloud or Pydio! Just put their Federated Cloud ID in the share dialog. It looks like person@cloud.example.com')); ?></p>
 
 		<p>


### PR DESCRIPTION
* for #5911 

Only has a real effect in stable12, because there the sidebar icon is based on this. Let me create a backport to stable12.