### PR TITLE
[stable12] Removed cast to integer in getSize

### DIFF
--- a/lib/private/Files/FileInfo.php
+++ b/lib/private/Files/FileInfo.php
@@ -193,7 +193,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	 */
 	public function getSize() {
 		$this->updateEntryfromSubMounts();
-		return isset($this->data['size']) ? (int) $this->data['size'] : 0;
+		return isset($this->data['size']) ? 0 + $this->data['size'] : 0;
 	}
 
 	/**


### PR DESCRIPTION
Fixes - Wrong or no sizes of files/folders #5031 for 32-bit systems a direct cast to integer causes problems.
Backport from #5744

Signed-off-by: Sebastian Kostka <sebastian.kostka@gmail.com>