### PR TITLE
Throw proper DI exception

### DIFF
--- a/lib/private/AppFramework/App.php
+++ b/lib/private/AppFramework/App.php
@@ -88,7 +88,7 @@ class App {
 
 		// first try $controllerName then go for \OCA\AppName\Controller\$controllerName
 		try {
-			$controller = $container->query($controllerName);
+			$controller = $container->queryNoFallback($controllerName);
 		} catch(QueryException $e) {
 			if ($appName === 'core') {
 				$appNameSpace = 'OC\\Core';
@@ -98,7 +98,7 @@ class App {
 				$appNameSpace = self::buildAppNamespace($appName);
 			}
 			$controllerName = $appNameSpace . '\\Controller\\' . $controllerName;
-			$controller = $container->query($controllerName);
+			$controller = $container->queryNoFallback($controllerName);
 		}
 
 		// initialize the dispatcher and run all the middleware before the controller

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -412,7 +412,15 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		try {
 			return $this->queryNoFallback($name);
 		} catch (QueryException $e) {
-			return $this->getServer()->query($name);
+			if (strpos($name, \OC\AppFramework\App::buildAppNamespace($this['AppName']) . '\\') === 0) {
+				throw $e;
+			}
+
+			try {
+				return $this->getServer()->query($name);
+			} catch (QueryException $e2) {
+				throw $e;
+			}
 		}
 	}
 

--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -70,7 +70,11 @@ class SimpleContainer extends Container implements IContainer {
 						$parameters[] = $parameter->getDefaultValue();
 					} else if ($parameterClass !== null) {
 						$resolveName = $parameter->getName();
-						$parameters[] = $this->query($resolveName);
+						try {
+							$parameters[] = $this->query($resolveName);
+						} catch (QueryException $e2) {
+							throw $e;
+						}
 					} else {
 						throw $e;
 					}


### PR DESCRIPTION
When we query the for a container element and it fails. We often
fallback to:

* querying by the name
* to the server container for a wider query

However, we should not throw the final exception up. But rather the
first exception. As the fallback mechanisms are not the real issue.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>