### PR TITLE
Remove setUidAsDisplayName

### DIFF
--- a/lib/private/legacy/user.php
+++ b/lib/private/legacy/user.php
@@ -173,18 +173,6 @@ class OC_User {
 		if ($uid) {
 			if (self::getUser() !== $uid) {
 				self::setUserId($uid);
-				$setUidAsDisplayName = true;
-				if($backend instanceof \OCP\UserInterface
-					&& $backend->implementsActions(\OC\User\Backend::GET_DISPLAYNAME)) {
-
-					$backendDisplayName = $backend->getDisplayName($uid);
-					if(is_string($backendDisplayName) && trim($backendDisplayName) !== '') {
-						$setUidAsDisplayName = false;
-					}
-				}
-				if($setUidAsDisplayName) {
-					self::setDisplayName($uid);
-				}
 				$userSession = self::getUserSession();
 				$userSession->setLoginName($uid);
 				$request = OC::$server->getRequest();


### PR DESCRIPTION
This code is a leftover from the old Shibboleth implementation from ownCloud days, nowadays it causes more issues than it does good (such as https://github.com/nextcloud/user_saml/pull/137). Let's remove it for the future thus.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>