### PR TITLE
Allow also an update from 10.0.2.0

### DIFF
--- a/version.php
+++ b/version.php
@@ -39,6 +39,7 @@ $OC_VersionCanBeUpgradedFrom = [
 	'owncloud' => [
 		'10.0.0.12' => true,
 		'10.0.1.5' => true,
+		'10.0.2.0' => true,
 		'10.0.2.1' => true,
 	],
 ];


### PR DESCRIPTION
Some installations have 10.0.2.0 it seems, this should help with that. Can we allow any 10.0.2.* instead or should we not?

https://help.nextcloud.com/t/nextcloud-12-0-1rc4-help-test/18860/28

Signed-off-by: Jos Poortvliet <jospoortvliet@gmail.com>
