### PR TITLE
Use IUser

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -42,6 +42,7 @@ use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IURLGenerator;
+use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Mail\IMailer;
 use OCP\Security\IHasher;


### PR DESCRIPTION
This is broken and will never work as the phan CI step pointed out at https://drone.nextcloud.com/nextcloud/server/523/48

> lib/private/Share20/Manager.php:720 PhanUndeclaredClassInstanceof Checking instanceof against undeclared class \OC\Share20\IUser

Pro-tip of the day: Check why CI fails before merging :see_no_evil:

Looking at @morrisjobke and @rullzer  for a review :wink: