### PR TITLE
Do not fetch the whole text file for the sidebar preview

### DIFF
--- a/apps/files/js/sidebarpreviewtext.js
+++ b/apps/files/js/sidebarpreviewtext.js
@@ -35,7 +35,12 @@
 		},
 
 		getFileContent: function (path) {
-			return $.get(OC.linkToRemoteBase('files' + path));
+			return $.ajax({
+				url: OC.linkToRemoteBase('files' + path),
+				headers: {
+					'Range': 'bytes=0-10240'
+				}
+			});
 		}
 	};
 


### PR DESCRIPTION
Just fetch the first 10kb. This should be more than enough in 99% of the
cases. And avoid downloading a 10mb text file just to display a tiny
portion.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>