### PR TITLE
Improve update notification layout and show non-default update server

### DIFF
--- a/apps/updatenotification/css/admin.css
+++ b/apps/updatenotification/css/admin.css
@@ -1,0 +1,3 @@
+#oca_updatenotification_section p {
+	margin: 25px 0;
+}

--- a/apps/updatenotification/lib/Controller/AdminController.php
+++ b/apps/updatenotification/lib/Controller/AdminController.php
@@ -105,6 +105,9 @@ class AdminController extends Controller implements ISettings {
 
 		$notifyGroups = json_decode($this->config->getAppValue('updatenotification', 'notify_groups', '["admin"]'), true);
 
+		$defaultUpdateServerURL = 'https://updates.nextcloud.com/server/';
+		$updateServerURL = $this->config->getSystemValue('updater.server.url', $defaultUpdateServerURL);
+
 		$params = [
 			'isNewVersionAvailable' => !empty($updateState['updateAvailable']),
 			'isUpdateChecked' => $lastUpdateCheckTimestamp > 0,
@@ -114,7 +117,8 @@ class AdminController extends Controller implements ISettings {
 			'newVersionString' => (empty($updateState['updateVersion'])) ? '' : $updateState['updateVersion'],
 			'downloadLink' => (empty($updateState['downloadLink'])) ? '' : $updateState['downloadLink'],
 			'updaterEnabled' => (empty($updateState['updaterEnabled'])) ? false : $updateState['updaterEnabled'],
-
+			'isDefaultUpdateServerURL' => $updateServerURL === $defaultUpdateServerURL,
+			'updateServerURL' => $updateServerURL,
 			'notify_groups' => implode('|', $notifyGroups),
 		];
 

--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -1,5 +1,6 @@
 <?php
 	script('updatenotification', 'admin');
+	style('updatenotification', 'admin');
 
 	/** @var array $_ */
 	/** @var bool $isNewVersionAvailable */
@@ -14,22 +15,36 @@
 	$channels = $_['channels'];
 	/** @var string $currentChannel */
 	$currentChannel = $_['currentChannel'];
+	/** @var string $updateServerURL */
+	$updateServerURL = $_['updateServerURL'];
+	/** @var bool $isDefaultUpdateServerURL */
+	$isDefaultUpdateServerURL = $_['isDefaultUpdateServerURL'];
 ?>
 <form id="oca_updatenotification_section" class="followupsection">
-	<?php if($isNewVersionAvailable === true) { ?>
-		<strong><?php p($l->t('A new version is available: %s', [$newVersionString])); ?></strong>
-		<?php if ($_['updaterEnabled']) { ?>
-			<input type="button" id="oca_updatenotification_button" value="<?php p($l->t('Open updater')) ?>">
+	<p>
+		<?php if ($isNewVersionAvailable === true) { ?>
+			<strong><?php p($l->t('A new version is available: %s', [$newVersionString])); ?></strong>
+			<?php if ($_['updaterEnabled']) { ?>
+				<input type="button" id="oca_updatenotification_button" value="<?php p($l->t('Open updater')) ?>">
+			<?php } ?>
+			<?php if (!empty($_['downloadLink'])) { ?>
+				<a href="<?php p($_['downloadLink']); ?>" class="button<?php if ($_['updaterEnabled']) { p(' hidden'); } ?>"><?php p($l->t('Download now')) ?></a>
+			<?php } ?>
+		<?php } elseif (!$isUpdateChecked) { ?>
+			<?php p($l->t('The update check is not yet finished. Please refresh the page.')); ?>
+		<?php } else { ?>
+			<?php p($l->t('Your version is up to date.')); ?>
+			<span class="icon-info svg" title="<?php p($l->t('Checked on %s', [$lastCheckedDate])) ?>"></span>
 		<?php } ?>
-		<?php if (!empty($_['downloadLink'])) { ?>
-			<a href="<?php p($_['downloadLink']); ?>" class="button<?php if ($_['updaterEnabled']) { p(' hidden'); } ?>"><?php p($l->t('Download now')) ?></a>
+
+		<?php if (!$isDefaultUpdateServerURL) { ?>
+			<br />
+			<em>
+				<?php p($l->t("A non-default update server is in use to be checked for updates:")); ?>
+				<code><?php p($updateServerURL); ?></code>
+			</em>
 		<?php } ?>
-	<?php } elseif (!$isUpdateChecked) { ?>
-		<?php p($l->t('The update check is not yet finished. Please refresh the page.')); ?>
-	<?php } else { ?>
-		<?php p($l->t('Your version is up to date.')); ?>
-		<span class="icon-info svg" title="<?php p($l->t('Checked on %s', [$lastCheckedDate])) ?>"></span>
-	<?php } ?>
+	</p>
 
 	<p>
 		<label for="release-channel"><?php p($l->t('Update channel:')) ?></label>
@@ -41,20 +56,16 @@
 				</option>
 			<?php } ?>
 		</select>
-		<span id="channel_save_msg" class="msg"></span>
-	</p>
-	<p>
-		<em><?php p($l->t('You can always update to a newer version / experimental channel. But you can never downgrade to a more stable channel.')); ?></em>
+		<span id="channel_save_msg" class="msg"></span><br />
+		<em><?php p($l->t('You can always update to a newer version / experimental channel. But you can never downgrade to a more stable channel.')); ?></em><br />
 		<em><?php p($l->t('Note that after a new release it can take some time before it shows up here. We roll out new versions spread out over time to our users and sometimes skip a version when issues are found.')); ?></em>
 	</p>
 
 
 	<p id="oca_updatenotification_groups">
-		<br />
 		<?php p($l->t('Notify members of the following groups about available updates:')); ?>
-		<input name="oca_updatenotification_groups_list" type="hidden" id="oca_updatenotification_groups_list" value="<?php p($_['notify_groups']) ?>" style="width: 400px">
+		<input name="oca_updatenotification_groups_list" type="hidden" id="oca_updatenotification_groups_list" value="<?php p($_['notify_groups']) ?>" style="width: 400px"><br />
 		<em class="<?php if (!in_array($currentChannel, ['daily', 'git'])) p('hidden'); ?>">
-			<br />
 			<?php p($l->t('Only notification for app updates are available.')); ?>
 			<?php if ($currentChannel === 'daily') p($l->t('The selected update channel makes dedicated notifications for the server obsolete.')); ?>
 			<?php if ($currentChannel === 'git') p($l->t('The selected update channel does not support updates of the server.')); ?>

--- a/apps/updatenotification/tests/Controller/AdminControllerTest.php
+++ b/apps/updatenotification/tests/Controller/AdminControllerTest.php
@@ -103,6 +103,11 @@ class AdminControllerTest extends TestCase {
 				['core', 'lastupdatedat', '', '12345'],
 				['updatenotification', 'notify_groups', '["admin"]', '["admin"]'],
 			]);
+		$this->config
+			->expects($this->once())
+			->method('getSystemValue')
+			->with('updater.server.url', 'https://updates.nextcloud.com/server/')
+			->willReturn('https://updates.nextcloud.com/server/');
 		$this->dateTimeFormatter
 			->expects($this->once())
 			->method('formatDateTime')
@@ -127,6 +132,8 @@ class AdminControllerTest extends TestCase {
 			'newVersionString' => '8.1.2',
 			'downloadLink' => 'https://downloads.nextcloud.org/server',
 			'updaterEnabled' => true,
+			'isDefaultUpdateServerURL' => true,
+			'updateServerURL' => 'https://updates.nextcloud.com/server/',
 			'notify_groups' => 'admin',
 		];
 
@@ -155,6 +162,11 @@ class AdminControllerTest extends TestCase {
 				['core', 'lastupdatedat', '', '12345'],
 				['updatenotification', 'notify_groups', '["admin"]', '["admin"]'],
 			]);
+		$this->config
+			->expects($this->once())
+			->method('getSystemValue')
+			->with('updater.server.url', 'https://updates.nextcloud.com/server/')
+			->willReturn('https://updates.nextcloud.com/server/');
 		$this->dateTimeFormatter
 			->expects($this->once())
 			->method('formatDateTime')
@@ -174,6 +186,8 @@ class AdminControllerTest extends TestCase {
 			'newVersionString' => '',
 			'downloadLink' => '',
 			'updaterEnabled' => 0,
+			'isDefaultUpdateServerURL' => true,
+			'updateServerURL' => 'https://updates.nextcloud.com/server/',
 			'notify_groups' => 'admin',
 		];
 


### PR DESCRIPTION
* shows now the update server URL if not the default one is set up
* properly introduces spacing into the layout


### Before
<img width="1394" alt="bildschirmfoto 2017-08-02 um 10 13 04" src="https://user-images.githubusercontent.com/245432/28865104-ffb574de-776e-11e7-9ae9-9aa5a674be71.png">

----

<img width="739" alt="bildschirmfoto 2017-08-02 um 10 13 11" src="https://user-images.githubusercontent.com/245432/28865105-ffd36cf0-776e-11e7-958e-e6d752bb8711.png">

### After
<img width="739" alt="bildschirmfoto 2017-08-02 um 10 11 55" src="https://user-images.githubusercontent.com/245432/28865112-05d5803e-776f-11e7-80fc-b5b5e3764ab1.png">

----

<img width="1181" alt="bildschirmfoto 2017-08-02 um 10 12 04" src="https://user-images.githubusercontent.com/245432/28865121-122bfffc-776f-11e7-8a7d-fe34990ea03c.png">
