### PR TITLE
Show correct status in update notification

### DIFF
--- a/apps/updatenotification/lib/Controller/AdminController.php
+++ b/apps/updatenotification/lib/Controller/AdminController.php
@@ -86,9 +86,8 @@ class AdminController extends Controller implements ISettings {
 	 * @return TemplateResponse
 	 */
 	public function displayPanel() {
-		$lastUpdateCheck = $this->dateTimeFormatter->formatDateTime(
-			$this->config->getAppValue('core', 'lastupdatedat')
-		);
+		$lastUpdateCheckTimestamp = $this->config->getAppValue('core', 'lastupdatedat');
+		$lastUpdateCheck = $this->dateTimeFormatter->formatDateTime($lastUpdateCheckTimestamp);
 
 		$channels = [
 			'daily',
@@ -108,6 +107,7 @@ class AdminController extends Controller implements ISettings {
 
 		$params = [
 			'isNewVersionAvailable' => !empty($updateState['updateAvailable']),
+			'isUpdateChecked' => $lastUpdateCheckTimestamp > 0,
 			'lastChecked' => $lastUpdateCheck,
 			'currentChannel' => $currentChannel,
 			'channels' => $channels,

--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -6,6 +6,8 @@
 	$isNewVersionAvailable = $_['isNewVersionAvailable'];
 	/** @var string $newVersionString */
 	$newVersionString = $_['newVersionString'];
+	/** @var bool $isUpdateChecked */
+	$isUpdateChecked = $_['isUpdateChecked'];
 	/** @var string $lastCheckedDate */
 	$lastCheckedDate = $_['lastChecked'];
 	/** @var array $channels */
@@ -22,6 +24,8 @@
 		<?php if (!empty($_['downloadLink'])) { ?>
 			<a href="<?php p($_['downloadLink']); ?>" class="button<?php if ($_['updaterEnabled']) { p(' hidden'); } ?>"><?php p($l->t('Download now')) ?></a>
 		<?php } ?>
+	<?php } elseif (!$isUpdateChecked) { ?>
+		<?php p($l->t('The update check is not yet finished. Please refresh the page.')); ?>
 	<?php } else { ?>
 		<?php p($l->t('Your version is up to date.')); ?>
 		<span class="icon-info svg" title="<?php p($l->t('Checked on %s', [$lastCheckedDate])) ?>"></span>

--- a/apps/updatenotification/tests/Controller/AdminControllerTest.php
+++ b/apps/updatenotification/tests/Controller/AdminControllerTest.php
@@ -120,6 +120,7 @@ class AdminControllerTest extends TestCase {
 
 		$params = [
 			'isNewVersionAvailable' => true,
+			'isUpdateChecked' => true,
 			'lastChecked' => 'LastCheckedReturnValue',
 			'currentChannel' => \OCP\Util::getChannel(),
 			'channels' => $channels,
@@ -166,6 +167,7 @@ class AdminControllerTest extends TestCase {
 
 		$params = [
 			'isNewVersionAvailable' => false,
+			'isUpdateChecked' => true,
 			'lastChecked' => 'LastCheckedReturnValue',
 			'currentChannel' => \OCP\Util::getChannel(),
 			'channels' => $channels,


### PR DESCRIPTION
Sometimes it could be the case that after a channel change the last updated timestamp is reset, but the check for updates is not yet completed. In this case the update notification showed "You are up to date" and the date was "1970-01-01 00:00:00". With this fix the state is properly shown.


Thanks @benediktg for noticing this 😉 