### PR TITLE
Replace loading icon GIF with pure CSS in login button

### DIFF
--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -66,7 +66,7 @@ input.primary {
 }
 
 @if (lightness($color-primary) > 50) {
-	#body-login input.login {
+	#body-login #submit-icon.icon-confirm-white {
 		background-image: url('../../../core/img/actions/confirm.svg');
 	}
 }

--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -131,6 +131,21 @@ form #datadirField legend {
 }
 
 /* Buttons and input */
+#submit-wrapper {
+	position: relative; /* Make the wrapper the containing block of its
+						   absolutely positioned descendant icons */
+}
+#submit-wrapper .icon-confirm-white {
+	position: absolute;
+	top: 23px;
+	right: 23px;
+}
+#submit-wrapper .icon-loading-small {
+	position: absolute;
+	top: 22px;
+	right: 24px;
+}
+
 input, textarea, select, button {
 	font-family: 'Open Sans', Frutiger, Calibri, 'Myriad Pro', Myriad, sans-serif;
 }

--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -146,6 +146,13 @@ form #datadirField legend {
 	right: 24px;
 }
 
+#submit-wrapper #submit-icon {
+	pointer-events: none; /* The submit icon is positioned on the submit button.
+							 From the user point of view the icon is part of the
+							 button, so the clicks on the icon have to be
+							 applied to the button instead. */
+}
+
 input, textarea, select, button {
 	font-family: 'Open Sans', Frutiger, Calibri, 'Myriad Pro', Myriad, sans-serif;
 }

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -754,6 +754,22 @@ label.infield {
 
 /* Log in and install button */
 
+#body-login #submit-wrapper {
+	position: relative; /* Make the wrapper the containing block of its
+						   absolutely positioned descendant icons */
+
+	.icon-confirm-white {
+		position: absolute;
+		top: 23px;
+		right: 23px;
+	}
+	.icon-loading-small {
+		position: absolute;
+		top: 22px;
+		right: 24px;
+	}
+}
+
 #body-login input {
 	font-size: 20px;
 	margin: 5px;

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -768,6 +768,13 @@ label.infield {
 		top: 22px;
 		right: 24px;
 	}
+
+	#submit-icon {
+		pointer-events: none; /* The submit icon is positioned on the submit
+								 button. From the user point of view the icon is
+								 part of the button, so the clicks on the icon
+								 have to be applied to the button instead. */
+	}
 }
 
 #body-login input {

--- a/core/js/login.js
+++ b/core/js/login.js
@@ -12,9 +12,10 @@
  */
 OC.Login = _.extend(OC.Login || {}, {
 	onLogin: function () {
-		$('#submit')
+		$('#submit-icon')
 			.removeClass('icon-confirm-white')
-			.addClass('icon-loading-small')
+			.addClass('icon-loading-small');
+		$('#submit')
 			.attr('value', t('core', 'Logging in …'));
 		return true;
 	},

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -61,7 +61,10 @@ script('core', 'merged-login');
 			</p>
 		<?php } ?>
 
-		<input type="submit" id="submit" class="login primary icon-confirm-white" title="" value="<?php p($l->t('Log in')); ?>" disabled="disabled" />
+		<div id="submit-wrapper">
+			<input type="submit" id="submit" class="login primary" title="" value="<?php p($l->t('Log in')); ?>" disabled="disabled" />
+			<div id="submit-icon" class="icon-confirm-white"></div>
+		</div>
 
 		<div class="login-additional">
 			<div class="remember-login-container">


### PR DESCRIPTION
Fixes #4470

Before:
![before-login](https://user-images.githubusercontent.com/26858233/28940145-fe470c18-7893-11e7-8483-abe37e87ede2.png)

After:
![after-login](https://user-images.githubusercontent.com/26858233/28940157-051357fe-7894-11e7-8ebd-6440f638c7bb.png)

Instead of converting the button from `<input>` to `<a class="button">` (which required several CSS changes) I kept the button as is and applied the `icon-loading-small` class to a different element. I used the same approach as, for example, in the _Sharing_ tab of the details view of the Files app to position the icons to the right of the input fields, that is, the icon is absolutely positioned inside a wrapper that contains both the input field and the icon.

The margins used for the confirm-white icon are 23px and 23px, but the margins used for the loading icon are 22px and 24px, which serve as an example of the issue #5970.

Using a different element positioned on the button has a problem, though: visually, the icon is part of the button, so clicking on the icon should be the same as clicking on the button. As it is a different element that is not the case, so I used JavaScript to redirect clicks on the icon to the button (although it feels a little hacky...). Only clicks are taken into account; I do not know if this could cause an accessibility problem with other types of interactions, although as the icon is not focusable I suppose it would be ignored anyway.

Another option would have been to use `pointer-events: none` on the icon so it ignored the clicks and let the element underneath it (that is, the button) receive them. [It seems to have good support in browsers](http://www.caniuse.com/#feat=pointer-events), so it may be a better option than using JavaScript. Any thoughts on this?

Finally, please note that __I have not tested the rules added in `styles.scss`__, as I do not know where they are being used; I have added them based on their neighbour rules assuming that they are used somewhere along with _core/templates/login.php_, but I do not even know if that assumption is right!
