### PR TITLE
Fix loading icon inside upload button in Theming app

### DIFF
--- a/apps/theming/css/settings-admin.css
+++ b/apps/theming/css/settings-admin.css
@@ -56,7 +56,8 @@ form.uploadButton {
     vertical-align: top;
 }
 
-#theming .icon-upload {
+#theming .icon-upload,
+#theming .uploadButton .icon-loading-small {
     padding: 8px 20px;
     width: 20px;
     margin: 2px 0px;


### PR DESCRIPTION
Pull request #5969 fixed the vertical alignment of loading icon and status message in Theming app, but in doing so it broke the loading icon inside the upload button.

When an image is being uploaded the upload icon is replaced by a loading icon, so the loading icon and the upload icon have to share their CSS rules, but only in that specific case.
