### PR TITLE
[stable12] Fix vertical alignment of loading icon and status message in Theming app

### DIFF
--- a/apps/theming/css/settings-admin.css
+++ b/apps/theming/css/settings-admin.css
@@ -58,12 +58,6 @@ form.uploadButton {
     vertical-align: top;
 }
 
-#theming .icon-loading-small {
-    display: inline-flex;
-    padding: 8px;
-    margin: 2px 0px;
-}
-
 #theming .icon-upload,
 #theming .icon-loading-small {
     padding: 8px 20px;
@@ -82,11 +76,6 @@ form.uploadButton {
     float: left;
     padding: 0;
     margin-right: 10px;
-}
-div#theming_settings_msg {
-    margin: 8px;
-    margin-left:20px;
-    display: inline-block;
 }
 
 #theming-preview-logo {

--- a/apps/theming/css/settings-admin.css
+++ b/apps/theming/css/settings-admin.css
@@ -47,10 +47,6 @@ form.uploadButton {
     visibility: visible;
 }
 
-#theming .icon-loading-small:after {
-    margin: -10px 0 0 -10px;
-}
-
 #theming label span {
     display: inline-block;
     min-width: 120px;
@@ -73,9 +69,13 @@ form.uploadButton {
 
 }
 #theming_settings_loading.icon-loading-small {
-    float: left;
-    padding: 0;
+    display: inline-block;
+    vertical-align: middle;
     margin-right: 10px;
+}
+
+#theming_settings_msg {
+    vertical-align: middle;
 }
 
 #theming-preview-logo {

--- a/apps/theming/css/settings-admin.css
+++ b/apps/theming/css/settings-admin.css
@@ -59,7 +59,7 @@ form.uploadButton {
 }
 
 #theming .icon-upload,
-#theming .icon-loading-small {
+#theming .uploadButton .icon-loading-small {
     padding: 8px 20px;
     width: 20px;
     margin: 2px 0px;

--- a/apps/theming/css/settings-admin.css
+++ b/apps/theming/css/settings-admin.css
@@ -68,7 +68,7 @@ form.uploadButton {
     margin: 10px;
 
 }
-#theming_settings_loading.icon-loading-small {
+#theming_settings_loading {
     display: inline-block;
     vertical-align: middle;
     margin-right: 10px;

--- a/apps/theming/css/settings-admin.css
+++ b/apps/theming/css/settings-admin.css
@@ -66,8 +66,8 @@ form.uploadButton {
 #theming_settings_status {
     height: 26px;
     margin: 10px;
-
 }
+
 #theming_settings_loading {
     display: inline-block;
     vertical-align: middle;


### PR DESCRIPTION
Backport of #5969 and #5982.

In the _stable12_ branch the offending commit from #5969 (_Do not use the same rules for loading icon than for upload icon_) already includes the fix from #5982.
