### PR TITLE
Allows files/folders to be copied.

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -631,6 +631,20 @@
 				}
 			});
 
+			this.registerAction({
+				name: 'Copy',
+				displayName: t('files', 'Copy'),
+				mime: 'all',
+				order: -25,
+				permissions: OC.PERMISSION_READ,
+				iconClass: 'icon-external',
+				actionHandler: function (filename, context) {
+					OC.dialogs.filepicker(t('files', 'Target folder'), function(targetPath) {
+						context.fileList.copy(filename, targetPath);
+					}, false, "httpd/unix-directory", true);
+				}
+			});
+
 			this.register('dir', 'Open', OC.PERMISSION_READ, '', function (filename, context) {
 				var dir = context.$file.attr('data-path') || context.fileList.getCurrentDirectory();
 				context.fileList.changeDirectory(OC.joinPaths(dir, filename), true, false, parseInt(context.$file.attr('data-id'), 10));

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -618,30 +618,21 @@
 			});
 
 			this.registerAction({
-				name: 'Move',
-				displayName: t('files', 'Move'),
+				name: 'CopyMove',
+				displayName: t('files', 'Copy or Move'),
 				mime: 'all',
 				order: -25,
 				permissions: OC.PERMISSION_UPDATE,
 				iconClass: 'icon-external',
 				actionHandler: function (filename, context) {
-					OC.dialogs.filepicker(t('files', 'Target folder'), function(targetPath) {
-						context.fileList.move(filename, targetPath);
-					}, false, "httpd/unix-directory", true);
-				}
-			});
-
-			this.registerAction({
-				name: 'Copy',
-				displayName: t('files', 'Copy'),
-				mime: 'all',
-				order: -25,
-				permissions: OC.PERMISSION_READ,
-				iconClass: 'icon-external',
-				actionHandler: function (filename, context) {
-					OC.dialogs.filepicker(t('files', 'Target folder'), function(targetPath) {
-						context.fileList.copy(filename, targetPath);
-					}, false, "httpd/unix-directory", true);
+					OC.dialogs.filepicker(t('files', 'Target folder'), function(targetPath, type) {
+						if (type === OC.dialogs.FILEPICKER_TYPE_COPY) {
+							context.fileList.copy(filename, targetPath);
+						}
+						if (type === OC.dialogs.FILEPICKER_TYPE_MOVE) {
+							context.fileList.move(filename, targetPath);
+						}
+					}, false, "httpd/unix-directory", true, OC.dialogs.FILEPICKER_TYPE_COPY_MOVE);
 				}
 			});
 

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -618,8 +618,8 @@
 			});
 
 			this.registerAction({
-				name: 'CopyMove',
-				displayName: t('files', 'Copy or Move'),
+				name: 'MoveCopy',
+				displayName: t('files', 'Move or copy'),
 				mime: 'all',
 				order: -25,
 				permissions: OC.PERMISSION_UPDATE,

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -337,11 +337,7 @@
 			this.$el.on('urlChanged', _.bind(this._onUrlChanged, this));
 			this.$el.find('.select-all').click(_.bind(this._onClickSelectAll, this));
 			this.$el.find('.download').click(_.bind(this._onClickDownloadSelected, this));
-<<<<<<< HEAD
-			this.$el.find('.move').click(_.bind(this._onClickMoveSelected, this));
-=======
-			this.$el.find('.copy').click(_.bind(this._onClickCopySelected, this));
->>>>>>> Allow files to be copied through action menu & multiple files actions
+			this.$el.find('.copy-move').click(_.bind(this._onClickCopyMoveSelected, this));
 			this.$el.find('.delete-selected').click(_.bind(this._onClickDeleteSelected, this));
 
 			this.$el.find('.selectedActions a').tooltip({placement:'top'});
@@ -765,7 +761,7 @@
 		/**
 		 * Event handler for when clicking on "Move" for the selected files
 		 */
-		_onClickMoveSelected: function(event) {
+		_onClickCopyMoveSelected: function(event) {
 			var files;
 			var self = this;
 
@@ -783,10 +779,14 @@
 				OCA.Files.FileActions.updateFileActionSpinner(moveFileAction, false);
 			};
 
-			OCA.Files.FileActions.updateFileActionSpinner(moveFileAction, true);
-			OC.dialogs.filepicker(t('files', 'Target folder'), function(targetPath) {
-				self.move(files, targetPath, disableLoadingState);
-			}, false, "httpd/unix-directory", true);
+			OC.dialogs.filepicker(t('files', 'Target folder'), function(targetPath, type) {
+				if (type === OC.dialogs.FILEPICKER_TYPE_COPY) {
+					self.copy(files, targetPath, disableLoadingState);
+				}
+				if (type === OC.dialogs.FILEPICKER_TYPE_MOVE) {
+					self.move(files, targetPath, disableLoadingState);
+				}
+			}, false, "httpd/unix-directory", true, OC.dialogs.FILEPICKER_TYPE_COPY_MOVE);
 			return false;
 		},
 

--- a/apps/files/templates/list.php
+++ b/apps/files/templates/list.php
@@ -49,7 +49,7 @@
 					<span id="selectedActionsList" class="selectedActions">
 						<a href="" class="copy-move">
 							<span class="icon icon-external"></span>
-							<span><?php p($l->t('Copy or Move'))?></span>
+							<span><?php p($l->t('Move or copy'))?></span>
 						</a>
 						<a href="" class="download">
 							<span class="icon icon-download"></span>

--- a/apps/files/templates/list.php
+++ b/apps/files/templates/list.php
@@ -47,9 +47,9 @@
 					</label>
 					<a class="name sort columntitle" data-sort="name"><span><?php p($l->t( 'Name' )); ?></span><span class="sort-indicator"></span></a>
 					<span id="selectedActionsList" class="selectedActions">
-						<a href="" class="move">
+						<a href="" class="copy-move">
 							<span class="icon icon-external"></span>
-							<span><?php p($l->t('Move'))?></span>
+							<span><?php p($l->t('Copy or Move'))?></span>
 						</a>
 						<a href="" class="download">
 							<span class="icon icon-download"></span>

--- a/core/css/jquery.ocdialog.css
+++ b/core/css/jquery.ocdialog.css
@@ -38,6 +38,9 @@
 .oc-dialog-buttonrow.twobuttons button:nth-child(1) {
 	float: left;
 }
+.oc-dialog-buttonrow.twobuttons.aside button:nth-child(1) {
+	float: none;
+}
 .oc-dialog-buttonrow.twobuttons button:nth-child(2) {
 	float: right;
 }

--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -737,6 +737,51 @@
 		},
 
 		/**
+		 * Copies path to another path
+		 *
+		 * @param {String} path path to copy
+		 * @param {String} destinationPath destination path
+		 * @param {boolean} [allowOverwrite=false] true to allow overwriting,
+		 * false otherwise
+		 *
+		 * @return {Promise} promise
+		 */
+		copy: function (path, destinationPath, allowOverwrite) {
+			if (!path) {
+				throw 'Missing argument "path"';
+			}
+			if (!destinationPath) {
+				throw 'Missing argument "destinationPath"';
+			}
+
+			var self = this;
+			var deferred = $.Deferred();
+			var promise = deferred.promise();
+			var headers = {
+				'Destination' : this._buildUrl(destinationPath)
+			};
+
+			if (!allowOverwrite) {
+				headers.Overwrite = 'F';
+			}
+
+			this._client.request(
+				'COPY',
+				this._buildUrl(path),
+				headers
+			).then(
+				function(response) {
+					if (self._isSuccessStatus(response.status)) {
+						deferred.resolve(response.status);
+					} else {
+						deferred.reject(response.status);
+					}
+				}
+			);
+			return promise;
+		},
+
+		/**
 		 * Add a file info parser function
 		 *
 		 * @param {OC.Files.Client~parseFileInfo>}

--- a/core/js/jquery.ocdialog.js
+++ b/core/js/jquery.ocdialog.js
@@ -130,6 +130,11 @@
 						});
 					this._setSizes();
 					break;
+				case 'style':
+					if (value.buttons !== undefined) {
+						this.$buttonrow.addClass(value.buttons);
+					}
+					break;
 				case 'closeButton':
 					if(value) {
 						var $closeButton = $('<a class="oc-dialog-close"></a>');

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -257,7 +257,6 @@ var OCdialogs = {
 			};
 
 			var copyCallback = function () {
-				console.log('copy callback');
 				functionToCall(OCdialogs.FILEPICKER_TYPE_COPY);
 			};
 

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -29,6 +29,12 @@ var OCdialogs = {
 	// dialog button types
 	YES_NO_BUTTONS:		70,
 	OK_BUTTONS:		71,
+
+	FILEPICKER_TYPE_CHOOSE: 1,
+	FILEPICKER_TYPE_MOVE: 2,
+	FILEPICKER_TYPE_COPY: 3,
+	FILEPICKER_TYPE_COPY_MOVE: 4,
+
 	// used to name each dialog
 	dialogsCounter: 0,
 	/**
@@ -174,13 +180,19 @@ var OCdialogs = {
 	 * @param multiselect whether it should be possible to select multiple files
 	 * @param mimetypeFilter mimetype to filter by - directories will always be included
 	 * @param modal make the dialog modal
+	 * @param type Type of file picker : Choose, copy, move, copy and move
 	*/
-	filepicker:function(title, callback, multiselect, mimetypeFilter, modal) {
+	filepicker:function(title, callback, multiselect, mimetypeFilter, modal, type) {
 		var self = this;
 		// avoid opening the picker twice
 		if (this.filepicker.loading) {
 			return;
 		}
+
+		if (type === undefined) {
+			type = this.FILEPICKER_TYPE_CHOOSE;
+		}
+
 		this.filepicker.loading = true;
 		this.filepicker.filesClient = (OCA.Sharing && OCA.Sharing.PublicApp && OCA.Sharing.PublicApp.fileList)? OCA.Sharing.PublicApp.fileList.filesClient: OC.Files.getClient();
 		$.when(this._getFilePickerTemplate()).then(function($tmpl) {
@@ -210,15 +222,17 @@ var OCdialogs = {
 			self.$filePicker.ready(function() {
 				self.$filelist = self.$filePicker.find('.filelist tbody');
 				self.$dirTree = self.$filePicker.find('.dirtree');
-				self.$dirTree.on('click', 'div:not(:last-child)', self, self._handleTreeListSelect.bind(self));
+				self.$dirTree.on('click', 'div:not(:last-child)', self, function (event) {
+					self._handleTreeListSelect(event, type);
+				});
 				self.$filelist.on('click', 'tr', function(event) {
-					self._handlePickerClick(event, $(this));
+					self._handlePickerClick(event, $(this), type);
 				});
 				self._fillFilePicker('');
 			});
 
 			// build buttons
-			var functionToCall = function() {
+			var functionToCall = function(returnType) {
 				if (callback !== undefined) {
 					var datapath;
 					if (multiselect === true) {
@@ -233,15 +247,47 @@ var OCdialogs = {
 							datapath += '/' + selectedName;
 						}
 					}
-					callback(datapath);
+					callback(datapath, returnType);
 					self.$filePicker.ocdialog('close');
 				}
 			};
-			var buttonlist = [{
-				text: t('core', 'Choose'),
-				click: functionToCall,
-				defaultButton: true
-			}];
+
+			var chooseCallback = function () {
+				functionToCall(OCdialogs.FILEPICKER_TYPE_CHOOSE);
+			};
+
+			var copyCallback = function () {
+				console.log('copy callback');
+				functionToCall(OCdialogs.FILEPICKER_TYPE_COPY);
+			};
+
+			var moveCallback = function () {
+				functionToCall(OCdialogs.FILEPICKER_TYPE_MOVE);
+			};
+
+			var buttonlist = [];
+			if (type === OCdialogs.FILEPICKER_TYPE_CHOOSE) {
+				buttonlist.push({
+					text: t('core', 'Choose'),
+					click: chooseCallback,
+					defaultButton: true
+				});
+			} else {
+				if (type === OCdialogs.FILEPICKER_TYPE_COPY || type === OCdialogs.FILEPICKER_TYPE_COPY_MOVE) {
+					buttonlist.push({
+						text: t('core', 'Copy'),
+						click: copyCallback,
+						defaultButton: false
+					});
+				}
+				if (type === OCdialogs.FILEPICKER_TYPE_MOVE || type === OCdialogs.FILEPICKER_TYPE_COPY_MOVE) {
+					buttonlist.push({
+						text: t('core', 'Move'),
+						click: moveCallback,
+						defaultButton: true
+					});
+				}
+			}
 
 			self.$filePicker.ocdialog({
 				closeOnEscape: true,
@@ -250,6 +296,9 @@ var OCdialogs = {
 				height: 500,
 				modal: modal,
 				buttons: buttonlist,
+				style: {
+					buttons: 'aside',
+				},
 				close: function() {
 					try {
 						$(this).ocdialog('destroy').remove();
@@ -879,12 +928,13 @@ var OCdialogs = {
 	/**
 	 * handle selection made in the tree list
 	*/
-	_handleTreeListSelect:function(event) {
+	_handleTreeListSelect:function(event, type) {
 		var self = event.data;
 		var dir = $(event.target).parent().data('dir');
 		self._fillFilePicker(dir);
 		var getOcDialog = (event.target).closest('.oc-dialog');
 		var buttonEnableDisable = $('.primary', getOcDialog);
+		this._changeButtonsText(type, dir.split(/[/]+/).pop());
 		if (this.$filePicker.data('mimetype') === "httpd/unix-directory") {
 			buttonEnableDisable.prop("disabled", false);
 		} else {
@@ -894,7 +944,7 @@ var OCdialogs = {
 	/**
 	 * handle clicks made in the filepicker
 	*/
-	_handlePickerClick:function(event, $element) {
+	_handlePickerClick:function(event, $element, type) {
 		var getOcDialog = this.$filePicker.closest('.oc-dialog');
 		var buttonEnableDisable = getOcDialog.find('.primary');
 		if ($element.data('type') === 'file') {
@@ -905,11 +955,38 @@ var OCdialogs = {
 			buttonEnableDisable.prop("disabled", false);
 		} else if ( $element.data('type') === 'dir' ) {
 			this._fillFilePicker(this.$filePicker.data('path') + '/' + $element.data('entryname'));
+			this._changeButtonsText(type, $element.data('entryname'));
 			if (this.$filePicker.data('mimetype') === "httpd/unix-directory") {
 				buttonEnableDisable.prop("disabled", false);
 			} else {
 				buttonEnableDisable.prop("disabled", true);
 			}
+		}
+	},
+
+	/**
+	 * Handle
+	 * @param type of action
+	 * @param dir on which to change buttons text
+	 * @private
+	 */
+	_changeButtonsText(type, dir) {
+		var copyText = dir === '' ? t('core', 'Copy') : t('core', 'Copy to {folder}', {folder: dir});
+		var moveText = dir === '' ? t('core', 'Move') : t('core', 'Move to {folder}', {folder: dir});
+		var buttons = $('.oc-dialog-buttonrow button');
+		switch (type) {
+			case this.FILEPICKER_TYPE_CHOOSE:
+				break;
+			case this.FILEPICKER_TYPE_COPY:
+				buttons.text(copyText);
+				break;
+			case this.FILEPICKER_TYPE_MOVE:
+				buttons.text(moveText);
+				break;
+			case this.FILEPICKER_TYPE_COPY_MOVE:
+				buttons.eq(0).text(copyText);
+				buttons.eq(1).text(moveText);
+				break;
 		}
 	}
 };

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -970,7 +970,7 @@ var OCdialogs = {
 	 * @param dir on which to change buttons text
 	 * @private
 	 */
-	_changeButtonsText(type, dir) {
+	_changeButtonsText: function(type, dir) {
 		var copyText = dir === '' ? t('core', 'Copy') : t('core', 'Copy to {folder}', {folder: dir});
 		var moveText = dir === '' ? t('core', 'Move') : t('core', 'Move to {folder}', {folder: dir});
 		var buttons = $('.oc-dialog-buttonrow button');


### PR DESCRIPTION
Adds a Copy action in the file action menu.
This also enables copy ~~and move~~ actions on selected files.

I know this is not how @jancborchardt designed it [here](https://github.com/nextcloud/server/issues/3206#issuecomment-297966461), and that the [files_clipboard](https://github.com/leizh/owncloud-files_clipboard) app is being developed but hey, this works for me, so it might be worth a look. :)
Ref. https://github.com/nextcloud/server/issues/3206

Needs : 
- [x] Tests
- [ ] ~~Copy action icon~~
- [ ] Tests on federated shares, remote storage, ...
- [ ] Tests for regressions on filepicker UI

The move feature has been moved at #6273