### PR TITLE
use indexed path_hash for efficient selection instead of path

### DIFF
--- a/lib/private/Repair/NC13/RepairInvalidPaths.php
+++ b/lib/private/Repair/NC13/RepairInvalidPaths.php
@@ -92,7 +92,7 @@ class RepairInvalidPaths implements IRepairStep {
 			$this->getIdQuery = $builder->select('fileid')
 				->from('filecache')
 				->where($builder->expr()->eq('storage', $builder->createParameter('storage')))
-				->andWhere($builder->expr()->eq('path', $builder->createParameter('path')));
+				->andWhere($builder->expr()->eq('path_hash', $builder->func()->md5($builder->createParameter('path'))));
 		}
 
 		$this->getIdQuery->setParameter('storage', $storage, IQueryBuilder::PARAM_INT);


### PR DESCRIPTION
Solves the long queries in issue https://github.com/nextcloud/server/issues/6017 - with this, the upgrade succeeds like a charm and the part that caused an multiple-hour-delay is not noticable anymore, only takes some seconds, if any.