### PR TITLE
Use indexed column path_hash to find the parent

### DIFF
--- a/lib/private/Repair/NC13/RepairInvalidPaths.php
+++ b/lib/private/Repair/NC13/RepairInvalidPaths.php
@@ -92,11 +92,11 @@ class RepairInvalidPaths implements IRepairStep {
 			$this->getIdQuery = $builder->select('fileid')
 				->from('filecache')
 				->where($builder->expr()->eq('storage', $builder->createParameter('storage')))
-				->andWhere($builder->expr()->eq('path', $builder->createParameter('path')));
+				->andWhere($builder->expr()->eq('path_hash', $builder->createParameter('path_hash')));
 		}
 
 		$this->getIdQuery->setParameter('storage', $storage, IQueryBuilder::PARAM_INT);
-		$this->getIdQuery->setParameter('path', $path);
+		$this->getIdQuery->setParameter('path_hash', md5($path));
 
 		return $this->getIdQuery->execute()->fetchColumn();
 	}


### PR DESCRIPTION
Fixed version of @noresistence patch in #6037 

Replace #6037 
Fix #6017 