### PR TITLE
Fix require once for actionInclude

### DIFF
--- a/lib/private/Route/Route.php
+++ b/lib/private/Route/Route.php
@@ -152,7 +152,7 @@ class Route extends SymfonyRoute implements IRoute {
 			unset($param["_route"]);
 			$_GET=array_merge($_GET, $param);
 			unset($param);
-			require_once "'.$file.'";
+			require_once "$file";
 		} ;
 		$this->action($function);
 	}


### PR DESCRIPTION
* regression from #5791
* errors like:

```
require_once(): Failed opening required ''.settings/users.php.''
```

Caused when opening the user management page or just look at the failing integration tests. 🙈 