### PR TITLE
[stable12] Fix copy from jailed storage

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -411,6 +411,12 @@ class Local extends \OC\Files\Storage\Common {
 	 */
 	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false) {
 		if ($sourceStorage->instanceOfStorage('\OC\Files\Storage\Local')) {
+			if ($sourceStorage->instanceOfStorage(Jail::class)) {
+				/**
+				 * @var \OC\Files\Storage\Wrapper\Jail $sourceStorage
+				 */
+				$sourceInternalPath = $sourceStorage->getUnjailedPath($sourceInternalPath);
+			}
 			/**
 			 * @var \OC\Files\Storage\Local $sourceStorage
 			 */


### PR DESCRIPTION
Backport of #6052 

If we have a jailed storage we must also fix the internal path on copy.
Else we pass in the wrong path.