### PR TITLE
Still throw a locked exception when the path is not relative to $user/files/

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -2057,7 +2057,7 @@ class View {
 			return ($pathSegments[2] === 'files') && (count($pathSegments) > 3);
 		}
 
-		return true;
+		return strpos($path, '/appdata_') !== 0;
 	}
 
 	/**

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1941,11 +1941,18 @@ class View {
 					);
 				}
 			} catch (\OCP\Lock\LockedException $e) {
-				// rethrow with the a human-readable path
-				throw new \OCP\Lock\LockedException(
-					$this->getPathRelativeToFiles($absolutePath),
-					$e
-				);
+				try {
+					// rethrow with the a human-readable path
+					throw new \OCP\Lock\LockedException(
+						$this->getPathRelativeToFiles($absolutePath),
+						$e
+					);
+				} catch (\InvalidArgumentException $e) {
+					throw new \OCP\Lock\LockedException(
+						$absolutePath,
+						$e
+					);
+				}
 			}
 		}
 


### PR DESCRIPTION
This turns `InvalidArgumentException: $absolutePath must be relative to "files"` from #5219 into a locked exception. Now the question is, why is the `appdata_` folder locked?

@LukasReschke is it okay to throw with the path, if it is not relative to a users `files/` directory?

Fix #5219 