### PR TITLE
Add buttom border for header

### DIFF
--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -116,3 +116,23 @@ input.primary {
 		}
 	}
 }
+
+@if ($color-primary == #ffffff) {
+	/* show grey border below header */
+	#body-user #header,
+	#body-settings #header,
+	#body-public #header {
+		border-bottom: 1px solid #ebebeb;
+	}
+
+	/* show triangle in header in grey */
+	#appmenu li a.active:before,
+	.header-right #settings #expand:before {
+		border-bottom-color:#ebebeb;
+	}
+
+	/* show border around quota bar in files app */
+	.app-files #quota .quota-container {
+		border: 1px solid #ebebeb;
+	}
+}

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -528,6 +528,11 @@ nav {
 		left: 50%;
 		bottom: 0;
 		z-index: 100;
+		display: none;
+	}
+	li a.active:before,
+	li:hover a:before,
+	li:hover a.active:before {
 		display: block;
 	}
 	&.menu-open li:hover a:before,


### PR DESCRIPTION
* allows to distinct the header from the rest of the UI for bright colors
* ref #5654


How to test:

* set the color in the theming app to pure white

Before:

![bildschirmfoto 2017-08-11 um 10 55 11](https://user-images.githubusercontent.com/245432/29207104-2e0d1662-7e85-11e7-9262-e6a32363829d.png)


After:

![bildschirmfoto 2017-08-11 um 11 03 06](https://user-images.githubusercontent.com/245432/29207102-292add14-7e85-11e7-9187-8f3fc76abff9.png)


cc @nextcloud/designers @LukasReschke 