### PR TITLE
Bypass permission checks

### DIFF
--- a/console.php
+++ b/console.php
@@ -63,9 +63,11 @@ try {
 		echo "The posix extensions are required - see http://php.net/manual/en/book.posix.php" . PHP_EOL;
 		exit(1);
 	}
+
+	$bypassPermissionsCheck = getenv('IGNORE_PERMISSION_CHECK') === 'true';
 	$user = posix_getpwuid(posix_getuid());
 	$configUser = posix_getpwuid(fileowner(OC::$configDir . 'config.php'));
-	if ($user['name'] !== $configUser['name']) {
+	if (!$bypassPermissionsCheck && $user['name'] !== $configUser['name']) {
 		echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
 		echo "Current user: " . $user['name'] . PHP_EOL;
 		echo "Owner of config.php: " . $configUser['name'] . PHP_EOL;


### PR DESCRIPTION
Some clustering environments set a random user id on every execution, thus managing files based on group permissions. While not optimal this approach here allows passing an environment variable to bypass the permission check.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>