### PR TITLE
Bold federation scope title in dropdown menu, as intended

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -230,6 +230,10 @@ input#passwordbutton {
 	line-height: 1.6em;
 }
 
+.federationScopeMenu.popovermenu .menuitem .menuitem-text {
+	font-weight: 600;
+}
+
 .federationScopeMenu.popovermenu .menuitem .menuitem-text-detail {
 	opacity: .75;
 }


### PR DESCRIPTION
Can’t take screenshot right now cause of https://github.com/nextcloud/server/issues/6078

This semibolds the federation scope title (Private, Contacts, Public) in the personal details of the settings section. This makes it a bit easier to distinguish, otherwise it’s all normal text.

Please review @nextcloud/designers @schiessle 