### PR TITLE
Add heading to account access page

### DIFF
--- a/core/templates/loginflow/authpicker.php
+++ b/core/templates/loginflow/authpicker.php
@@ -30,7 +30,10 @@ $urlGenerator = $_['urlGenerator'];
 <div class="picker-window">
 	<h2><?php p($l->t('Account access')) ?></h2>
 	<p class="info">
-		<?php p($l->t('You are about to grant "%s" access to your %s account.', [$_['client'], $_['instanceName']])) ?>
+		<?php print_unescaped($l->t('You are about to grant "%s" access to your %s account.', [
+								'<strong>' . \OCP\Util::sanitizeHTML($_['client']) . '</strong>',
+								\OCP\Util::sanitizeHTML($_['instanceName'])
+							])) ?>
 	</p>
 
 	<br/>

--- a/core/templates/loginflow/authpicker.php
+++ b/core/templates/loginflow/authpicker.php
@@ -30,7 +30,7 @@ $urlGenerator = $_['urlGenerator'];
 <div class="picker-window">
 	<h2><?php p($l->t('Account access')) ?></h2>
 	<p class="info">
-		<?php print_unescaped($l->t('You are about to grant "%s" access to your %s account.', [
+		<?php print_unescaped($l->t('You are about to grant %s access to your %s account.', [
 								'<strong>' . \OCP\Util::sanitizeHTML($_['client']) . '</strong>',
 								\OCP\Util::sanitizeHTML($_['instanceName'])
 							])) ?>

--- a/core/templates/loginflow/authpicker.php
+++ b/core/templates/loginflow/authpicker.php
@@ -28,6 +28,7 @@ $urlGenerator = $_['urlGenerator'];
 ?>
 
 <div class="picker-window">
+	<h2><?php p($l->t('Account access')) ?></h2>
 	<p class="info">
 		<?php p($l->t('You are about to grant "%s" access to your %s account.', [$_['client'], $_['instanceName']])) ?>
 	</p>


### PR DESCRIPTION
It would also be awesome if we could bold the client requesting access so it stands out. Like:

> You are about to grant **Fairphone** access to your Nextcloud account.

Is that possible @MorrisJobke @LukasReschke?