### PR TITLE
Fix federation scope dropdown

### DIFF
--- a/settings/js/federationscopemenu.js
+++ b/settings/js/federationscopemenu.js
@@ -111,7 +111,7 @@
 		 */
 		show: function(context) {
 			this._context = context;
-			var currentlyActiveValue = $('#'+context.target.closest('form').id).find('.icon-checkmark > input')[0].value;
+			var currentlyActiveValue = $('#'+context.target.closest('form').id).find('input[type="hidden"]')[0].value;
 
 			for(var i in this._scopes) {
 				this._scopes[i].active = false;


### PR DESCRIPTION
Regression from #6031

* click the icon to change the scope of a personal attribute in the personal settings
* before: dropdown does not open
* after: dropdown opens as before

Needs to be backported to stable12 as well.