### PR TITLE
Missing array assignment in Swift.php

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Swift.php
+++ b/apps/files_external/lib/Lib/Storage/Swift.php
@@ -75,11 +75,6 @@ class Swift extends \OC\Files\Storage\Common {
 	private $id;
 
 	/**
-	 * @var array
-	 */
-	private static $tmpFiles = array();
-
-	/**
 	 * Key value cache mapping path to data object. Maps path to
 	 * \OpenCloud\OpenStack\ObjectStorage\Resource\DataObject for existing
 	 * paths and path to false for not existing paths.
@@ -617,7 +612,7 @@ class Swift extends \OC\Files\Storage\Common {
 		$fileData = fopen($tmpFile, 'r');
 		$this->getContainer()->uploadObject($path, $fileData);
 		// invalidate target object to force repopulation on fetch
-		$this->objectCache->remove(self::$tmpFiles[$tmpFile]);
+		$this->objectCache->remove($path);
 		unlink($tmpFile);
 	}
 


### PR DESCRIPTION
The array is referenced with the tmpfile index in the callback function.

Fix #6019 .