### PR TITLE
Use proper methods for checkPasswordProtectedShare

### DIFF
--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -283,7 +283,7 @@ class Share extends Constants {
 		}
 
 		// password protected shares need to be authenticated
-		if ($checkPasswordProtection && !\OCP\Share::checkPasswordProtectedShare($row)) {
+		if ($checkPasswordProtection && !\OC\Share\Share::checkPasswordProtectedShare($row)) {
 			return false;
 		}
 

--- a/lib/public/Share.php
+++ b/lib/public/Share.php
@@ -235,15 +235,4 @@ class Share extends \OC\Share\Constants {
 	public static function getBackend($itemType) {
 		return \OC\Share\Share::getBackend($itemType);
 	}
-
-	/**
-	 * In case a password protected link is not yet authenticated this function will return false
-	 *
-	 * @param array $linkItem
-	 * @return bool
-	 * @since 7.0.0
-	 */
-	public static function checkPasswordProtectedShare(array $linkItem) {
-		return \OC\Share\Share::checkPasswordProtectedShare($linkItem);
-	}
 }

--- a/tests/lib/Share/ShareTest.php
+++ b/tests/lib/Share/ShareTest.php
@@ -501,7 +501,7 @@ class ShareTest extends \Test\TestCase {
 	 */
 	public function testCheckPasswordProtectedShare($expected, $item) {
 		\OC::$server->getSession()->set('public_link_authenticated', '100');
-		$result = \OCP\Share::checkPasswordProtectedShare($item);
+		$result = \OC\Share\Share::checkPasswordProtectedShare($item);
 		$this->assertEquals($expected, $result);
 	}
 


### PR DESCRIPTION
To prepare for #6115. Ref #6116. I also could not find any usage in any of the apps in the App Store nor in our github org.