### PR TITLE
Public upload share permission handling

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -700,6 +700,7 @@ class ShareAPIController extends OCSController {
 
 			if ($permissions !== null) {
 				$newPermissions = (int)$permissions;
+				$newPermissions = $newPermissions & ~\OCP\Constants::PERMISSION_SHARE;
 			}
 
 			if ($newPermissions !== null &&


### PR DESCRIPTION
If you set the permissions on a public share the SHARE permission makes
no sense. So instead of throwing a warning. Just filter out the share
permission.

Found by @tobiasKaminsky in the android client.