### PR TITLE
Cleanup usage of shareItem in internal code base

### DIFF
--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -1209,7 +1209,7 @@ class ApiTest extends TestCase {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
 		$id = PHP_INT_MAX - 1;
-		\OCP\Share::shareItem('file', $id, \OCP\Share::SHARE_TYPE_LINK, self::TEST_FILES_SHARING_API_USER2, 31);
+		\OC\Share\Share::shareItem('file', $id, \OCP\Share::SHARE_TYPE_LINK, self::TEST_FILES_SHARING_API_USER2, 31);
 	}
 
 	/**
@@ -1222,7 +1222,7 @@ class ApiTest extends TestCase {
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
-		\OCP\Share::shareItem('file', $info->getId(), \OCP\Share::SHARE_TYPE_LINK, self::TEST_FILES_SHARING_API_USER2, 31);
+		\OC\Share\Share::shareItem('file', $info->getId(), \OCP\Share::SHARE_TYPE_LINK, self::TEST_FILES_SHARING_API_USER2, 31);
 	}
 
 	public function datesProvider() {

--- a/apps/files_sharing/tests/BackendTest.php
+++ b/apps/files_sharing/tests/BackendTest.php
@@ -74,9 +74,9 @@ class BackendTest extends TestCase {
 		$fileinfo2 = $this->view->getFileInfo($this->folder . $this->subfolder . $this->subsubfolder);
 		$fileinfo3 = $this->view->getFileInfo($this->folder . $this->subfolder . $this->subsubfolder . $this->filename);
 
-		$this->assertTrue(\OCP\Share::shareItem('folder', $fileinfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+		$this->assertTrue(\OC\Share\Share::shareItem('folder', $fileinfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
 				self::TEST_FILES_SHARING_API_USER2, 31));
-		$this->assertTrue(\OCP\Share::shareItem('folder', $fileinfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
+		$this->assertTrue(\OC\Share\Share::shareItem('folder', $fileinfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
 				self::TEST_FILES_SHARING_API_USER3, 31));
 
 		$backend = new \OCA\Files_Sharing\ShareBackend\Folder();

--- a/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
+++ b/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
@@ -136,7 +136,7 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 		$fileId = $fileInfo->getId();
 
 		$this->assertTrue(
-			\OCP\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ),
+			\OC\Share\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ),
 			'Failed asserting that user 1 successfully shared "test/sub" with user 2.'
 		);
 
@@ -159,7 +159,7 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 		\OCP\Share::registerBackend('test', 'Test\Share\Backend');
 
 		$this->assertTrue(
-			\OCP\Share::shareItem('test', 'test.txt', \OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ),
+			\OC\Share\Share::shareItem('test', 'test.txt', \OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ),
 			'Failed asserting that user 1 successfully shared something with user 2.'
 		);
 

--- a/apps/files_sharing/tests/ExpireSharesJobTest.php
+++ b/apps/files_sharing/tests/ExpireSharesJobTest.php
@@ -138,7 +138,7 @@ class ExpireSharesJobTest extends \Test\TestCase {
 		$fileInfo = $view->getFileInfo('files/test');
 
 		$this->assertNotNull(
-			\OCP\Share::shareItem('folder', $fileInfo->getId(), \OCP\Share::SHARE_TYPE_LINK, null, \OCP\Constants::PERMISSION_READ),
+			\OC\Share\Share::shareItem('folder', $fileInfo->getId(), \OCP\Share::SHARE_TYPE_LINK, null, \OCP\Constants::PERMISSION_READ),
 			'Failed asserting that user 1 successfully shared "test" by link.'
 		);
 
@@ -192,7 +192,7 @@ class ExpireSharesJobTest extends \Test\TestCase {
 		$fileInfo = $view->getFileInfo('files/test');
 
 		$this->assertNotNull(
-			\OCP\Share::shareItem('folder', $fileInfo->getId(), \OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ),
+			\OC\Share\Share::shareItem('folder', $fileInfo->getId(), \OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ),
 			'Failed asserting that user 1 successfully shared "test" by link with user2.'
 		);
 

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -351,11 +351,12 @@ class Share extends Constants {
 	 * @param string $shareWith User or group the item is being shared with
 	 * @param int $permissions CRUDS
 	 * @param string $itemSourceName
-	 * @param \DateTime $expirationDate
-	 * @param bool $passwordChanged
+	 * @param \DateTime|null $expirationDate
+	 * @param bool|null $passwordChanged
 	 * @return boolean|string Returns true on success or false on failure, Returns token on success for links
 	 * @throws \OC\HintException when the share type is remote and the shareWith is invalid
 	 * @throws \Exception
+	 * @since 5.0.0 - parameter $itemSourceName was added in 6.0.0, parameter $expirationDate was added in 7.0.0, parameter $passwordChanged added in 9.0.0
 	 */
 	public static function shareItem($itemType, $itemSource, $shareType, $shareWith, $permissions, $itemSourceName = null, \DateTime $expirationDate = null, $passwordChanged = null) {
 

--- a/lib/public/Share.php
+++ b/lib/public/Share.php
@@ -181,25 +181,6 @@ class Share extends \OC\Share\Constants {
 	}
 
 	/**
-	 * Share an item with a user, group, or via private link
-	 * @param string $itemType
-	 * @param string $itemSource
-	 * @param int $shareType SHARE_TYPE_USER, SHARE_TYPE_GROUP, or SHARE_TYPE_LINK
-	 * @param string $shareWith User or group the item is being shared with
-	 * @param int $permissions CRUDS
-	 * @param string $itemSourceName
-	 * @param \DateTime|null $expirationDate
-	 * @param bool|null $passwordChanged
-	 * @return bool|string Returns true on success or false on failure, Returns token on success for links
-	 * @throws \OC\HintException when the share type is remote and the shareWith is invalid
-	 * @throws \Exception
-	 * @since 5.0.0 - parameter $itemSourceName was added in 6.0.0, parameter $expirationDate was added in 7.0.0, parameter $passwordChanged added in 9.0.0
-	 */
-	public static function shareItem($itemType, $itemSource, $shareType, $shareWith, $permissions, $itemSourceName = null, \DateTime $expirationDate = null, $passwordChanged = null) {
-		return \OC\Share\Share::shareItem($itemType, $itemSource, $shareType, $shareWith, $permissions, $itemSourceName, $expirationDate, $passwordChanged);
-	}
-
-	/**
 	 * Unshare an item from a user, group, or delete a private link
 	 * @param string $itemType
 	 * @param string $itemSource

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -1666,7 +1666,7 @@ class ViewTest extends \Test\TestCase {
 
 		$fileId = $view->getFileInfo('shareddir')->getId();
 		$userObject = \OC::$server->getUserManager()->createUser('test2', 'IHateNonMockableStaticClasses');
-		$this->assertTrue(Share::shareItem('folder', $fileId, Share::SHARE_TYPE_USER, 'test2', Constants::PERMISSION_READ));
+		$this->assertTrue(\OC\Share\Share::shareItem('folder', $fileId, Share::SHARE_TYPE_USER, 'test2', Constants::PERMISSION_READ));
 
 		$this->assertFalse($view->rename('mount1', 'shareddir'), 'Cannot overwrite shared folder');
 		$this->assertFalse($view->rename('mount1', 'shareddir/sub'), 'Cannot move mount point into shared folder');

--- a/tests/lib/Share/ShareTest.php
+++ b/tests/lib/Share/ShareTest.php
@@ -137,7 +137,7 @@ class ShareTest extends \Test\TestCase {
 	public function testShareInvalidShareType() {
 		$message = 'Share type foobar is not valid for test.txt';
 		try {
-			\OCP\Share::shareItem('test', 'test.txt', 'foobar', $this->user2, \OCP\Constants::PERMISSION_READ);
+			\OC\Share\Share::shareItem('test', 'test.txt', 'foobar', $this->user2, \OCP\Constants::PERMISSION_READ);
 		} catch (\Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
 		}
@@ -157,7 +157,7 @@ class ShareTest extends \Test\TestCase {
 		$fileId = $fileInfo->getId();
 
 		$this->assertTrue(
-			\OCP\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user2->getUID(), \OCP\Constants::PERMISSION_READ),
+			\OC\Share\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user2->getUID(), \OCP\Constants::PERMISSION_READ),
 			'Failed asserting that user 1 successfully shared "test/sub" with user 2.'
 		);
 
@@ -195,7 +195,7 @@ class ShareTest extends \Test\TestCase {
 		$fileId = $fileInfo->getId();
 
 		$this->assertTrue(
-			\OCP\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_GROUP, $this->group1->getGID(), \OCP\Constants::PERMISSION_READ + \OCP\Constants::PERMISSION_CREATE),
+			\OC\Share\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_GROUP, $this->group1->getGID(), \OCP\Constants::PERMISSION_READ + \OCP\Constants::PERMISSION_CREATE),
 			'Failed asserting that user 1 successfully shared "test/sub1" with group 1.'
 		);
 
@@ -208,7 +208,7 @@ class ShareTest extends \Test\TestCase {
 		$fileId = $fileInfo->getId();
 
 		$this->assertTrue(
-			\OCP\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user4->getUID(), \OCP\Constants::PERMISSION_READ),
+			\OC\Share\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user4->getUID(), \OCP\Constants::PERMISSION_READ),
 			'Failed asserting that user 1 successfully shared "test/sub1/sub2" with user 4.'
 		);
 
@@ -233,12 +233,12 @@ class ShareTest extends \Test\TestCase {
 		$fileId = $fileInfo->getId();
 
 		$this->assertTrue(
-			\OCP\Share::shareItem('folder', $folderId, \OCP\Share::SHARE_TYPE_GROUP, $this->group2->getGID(), \OCP\Constants::PERMISSION_READ + \OCP\Constants::PERMISSION_UPDATE),
+			\OC\Share\Share::shareItem('folder', $folderId, \OCP\Share::SHARE_TYPE_GROUP, $this->group2->getGID(), \OCP\Constants::PERMISSION_READ + \OCP\Constants::PERMISSION_UPDATE),
 			'Failed asserting that user 1 successfully shared "test/sub1" with group 2.'
 		);
 
 		$this->assertTrue(
-			\OCP\Share::shareItem('file', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user2->getUID(), \OCP\Constants::PERMISSION_READ),
+			\OC\Share\Share::shareItem('file', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user2->getUID(), \OCP\Constants::PERMISSION_READ),
 			'Failed asserting that user 1 successfully shared "test/sub1/file.txt" with user 2.'
 		);
 
@@ -258,7 +258,7 @@ class ShareTest extends \Test\TestCase {
 	 */
 	public function testShareWithGroupThenUnshare() {
 		\OC_User::setUserId($this->user5->getUID());
-		\OCP\Share::shareItem(
+		\OC\Share\Share::shareItem(
 			'test',
 			'test.txt',
 			\OCP\Share::SHARE_TYPE_GROUP,
@@ -401,7 +401,7 @@ class ShareTest extends \Test\TestCase {
 	}
 
 	public function testGetShareSubItemsWhenUserNotInGroup() {
-		\OCP\Share::shareItem('test', 'test.txt', \OCP\Share::SHARE_TYPE_GROUP, $this->group1->getGID(), \OCP\Constants::PERMISSION_READ);
+		\OC\Share\Share::shareItem('test', 'test.txt', \OCP\Share::SHARE_TYPE_GROUP, $this->group1->getGID(), \OCP\Constants::PERMISSION_READ);
 
 		$result = \OCP\Share::getItemsSharedWithUser('test', $this->user2->getUID());
 		$this->assertCount(1, $result);
@@ -445,7 +445,7 @@ class ShareTest extends \Test\TestCase {
 		$config->setAppValue('core', 'shareapi_default_expire_date', 'yes');
 		$config->setAppValue('core', 'shareapi_expire_after_n_days', '2');
 
-		$token = \OCP\Share::shareItem('test', 'test.txt', \OCP\Share::SHARE_TYPE_LINK, null, \OCP\Constants::PERMISSION_READ);
+		$token = \OC\Share\Share::shareItem('test', 'test.txt', \OCP\Share::SHARE_TYPE_LINK, null, \OCP\Constants::PERMISSION_READ);
 		$this->assertInternalType(
 			'string',
 			$token,
@@ -491,7 +491,7 @@ class ShareTest extends \Test\TestCase {
 	 */
 	public function testShareWithRemoteUserAndRemoteIsInvalid($remoteId) {
 		\OC_User::setUserId($this->user1->getUID());
-		\OCP\Share::shareItem('test', 'test.txt', \OCP\Share::SHARE_TYPE_REMOTE, $remoteId, \OCP\Constants::PERMISSION_ALL);
+		\OC\Share\Share::shareItem('test', 'test.txt', \OCP\Share::SHARE_TYPE_REMOTE, $remoteId, \OCP\Constants::PERMISSION_ALL);
 	}
 
 	/**
@@ -572,7 +572,7 @@ class ShareTest extends \Test\TestCase {
 			->with($this->stringStartsWith('http://' . $urlHost . '/ocs/v2.php/cloud/shares'), $this->anything())
 			->willReturn(['success' => true, 'result' => json_encode(['ocs' => ['meta' => ['statuscode' => 100]]])]);
 
-		\OCP\Share::shareItem('test', 'test.txt', \OCP\Share::SHARE_TYPE_REMOTE, $shareWith, \OCP\Constants::PERMISSION_READ);
+		\OC\Share\Share::shareItem('test', 'test.txt', \OCP\Share::SHARE_TYPE_REMOTE, $shareWith, \OCP\Constants::PERMISSION_READ);
 		$shares = \OCP\Share::getItemShared('test', 'test.txt');
 		$share = array_shift($shares);
 
@@ -680,13 +680,13 @@ class ShareTest extends \Test\TestCase {
 			->with($this->stringStartsWith('https://localhost/ocs/v2.php/cloud/shares'), $this->anything())
 			->willReturn(['success' => true, 'result' => json_encode(['ocs' => ['meta' => ['statuscode' => 100]]])]);
 
-		\OCP\Share::shareItem('test', 'test.txt', \OCP\Share::SHARE_TYPE_REMOTE, 'foo@localhost', \OCP\Constants::PERMISSION_READ);
+		\OC\Share\Share::shareItem('test', 'test.txt', \OCP\Share::SHARE_TYPE_REMOTE, 'foo@localhost', \OCP\Constants::PERMISSION_READ);
 		$shares = \OCP\Share::getItemShared('test', 'test.txt');
 		$share = array_shift($shares);
 
 		//Try share again
 		try {
-			\OCP\Share::shareItem('test', 'test.txt', \OCP\Share::SHARE_TYPE_REMOTE, 'foo@localhost', \OCP\Constants::PERMISSION_READ);
+			\OC\Share\Share::shareItem('test', 'test.txt', \OCP\Share::SHARE_TYPE_REMOTE, 'foo@localhost', \OCP\Constants::PERMISSION_READ);
 			$this->fail('Identical remote shares are not allowed');
 		} catch (\Exception $e) {
 			$this->assertEquals('Sharing test.txt failed, because this item is already shared with foo@localhost', $e->getMessage());
@@ -714,11 +714,11 @@ class ShareTest extends \Test\TestCase {
 		$fileId = $fileInfo->getId();
 
 		$this->assertTrue(
-			\OCP\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user2->getUID(), \OCP\Constants::PERMISSION_ALL),
+			\OC\Share\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user2->getUID(), \OCP\Constants::PERMISSION_ALL),
 			'Failed asserting that user 1 successfully shared "test" with user 2.'
 		);
 		$this->assertTrue(
-			\OCP\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user3->getUID(), \OCP\Constants::PERMISSION_ALL),
+			\OC\Share\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user3->getUID(), \OCP\Constants::PERMISSION_ALL),
 			'Failed asserting that user 1 successfully shared "test" with user 3.'
 		);
 
@@ -729,7 +729,7 @@ class ShareTest extends \Test\TestCase {
 		$fileId = $fileInfo->getId();
 
 		$this->assertTrue(
-			\OCP\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user4->getUID(), \OCP\Constants::PERMISSION_ALL),
+			\OC\Share\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user4->getUID(), \OCP\Constants::PERMISSION_ALL),
 			'Failed asserting that user 1 successfully shared "test" with user 4.'
 		);
 
@@ -743,7 +743,7 @@ class ShareTest extends \Test\TestCase {
 		$this->assertCount(3, $res);
 
 		$this->assertTrue(
-			\OCP\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user5->getUID(), \OCP\Constants::PERMISSION_ALL),
+			\OC\Share\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user5->getUID(), \OCP\Constants::PERMISSION_ALL),
 			'Failed asserting that user 1 successfully shared "test" with user 5.'
 		);
 
@@ -767,7 +767,7 @@ class ShareTest extends \Test\TestCase {
 		$fileId = $fileInfo->getId();
 
 		try {
-			\OCP\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user1->getUID(), \OCP\Constants::PERMISSION_ALL);
+			\OC\Share\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user1->getUID(), \OCP\Constants::PERMISSION_ALL);
 			$this->fail();
 		} catch (\Exception $e) {
 			$this->assertEquals('Sharing /folder1 failed, because you can not share with yourself', $e->getMessage());
@@ -785,13 +785,13 @@ class ShareTest extends \Test\TestCase {
 		$fileId = $fileInfo->getId();
 
 		$this->assertTrue(
-			\OCP\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user2->getUID(), \OCP\Constants::PERMISSION_ALL),
+			\OC\Share\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user2->getUID(), \OCP\Constants::PERMISSION_ALL),
 			'Failed asserting that user 1 successfully shared "test" with user 2.'
 		);
 
 		\OC_User::setUserId($this->user2->getUID());
 		try {
-			\OCP\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user1->getUID(), \OCP\Constants::PERMISSION_ALL);
+			\OC\Share\Share::shareItem('folder', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->user1->getUID(), \OCP\Constants::PERMISSION_ALL);
 			$this->fail();
 		} catch (\Exception $e) {
 			$this->assertEquals('Sharing failed, because the user ' . $this->user1->getUID() . ' is the original sharer', $e->getMessage());

--- a/tests/lib/TagsTest.php
+++ b/tests/lib/TagsTest.php
@@ -306,7 +306,7 @@ class TagsTest extends \Test\TestCase {
 		$this->assertFalse($otherTagger->hasTag($testTag));
 
 		\OC_User::setUserId($this->user->getUID());
-		\OCP\Share::shareItem('test', 1, \OCP\Share::SHARE_TYPE_USER, $otherUserId, \OCP\Constants::PERMISSION_READ);
+		\OC\Share\Share::shareItem('test', 1, \OCP\Share::SHARE_TYPE_USER, $otherUserId, \OCP\Constants::PERMISSION_READ);
 
 		\OC_User::setUserId($otherUserId);
 		$otherTagger = $otherTagMgr->load('test', array(), true); // Update tags, load shared ones.


### PR DESCRIPTION
To prepare for #6115. Ref #6116. I also could not find any usage in any of the apps in the App Store nor in our github org. The only app using it is spreedme, but there it is in the code path that is build for ownCloud and it will not run into this with Nextcloud 9+, because there the new sharing was already included.