### PR TITLE
Do not log WebDAV maintenance mode exception

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
@@ -28,8 +28,7 @@
 namespace OCA\DAV\Connector\Sabre;
 
 use OCP\ILogger;
-use Sabre\DAV\Exception;
-use Sabre\HTTP\Response;
+use Sabre\DAV\Exception\ServiceUnavailable;
 
 class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
 	protected $nonFatalExceptions = [
@@ -90,7 +89,12 @@ class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
 	public function logException(\Exception $ex) {
 		$exceptionClass = get_class($ex);
 		$level = \OCP\Util::FATAL;
-		if (isset($this->nonFatalExceptions[$exceptionClass])) {
+		if (isset($this->nonFatalExceptions[$exceptionClass]) ||
+			(
+				$exceptionClass === ServiceUnavailable::class &&
+				$ex->getMessage() === 'System in maintenance mode.'
+			)
+		) {
 			$level = \OCP\Util::DEBUG;
 		}
 

--- a/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
@@ -28,6 +28,7 @@ use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin as PluginToTest;
 use OC\Log;
 use PHPUnit_Framework_MockObject_MockObject;
 use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\Exception\ServiceUnavailable;
 use Sabre\DAV\Server;
 use Test\TestCase;
 
@@ -77,6 +78,8 @@ class ExceptionLoggerPluginTest extends TestCase {
 	public function providesExceptions() {
 		return [
 			[0, '', new NotFound()],
+			[0, 'System in maintenance mode.', new ServiceUnavailable('System in maintenance mode.')],
+			[4, 'Upgrade needed', new ServiceUnavailable('Upgrade needed')],
 			[4, 'This path leads to nowhere', new InvalidPath('This path leads to nowhere')]
 		];
 	}


### PR DESCRIPTION
Log the maintenance mode exception only in debug level. Fixes #6124


How to test:

* enable maintenance mode
* enable log level 0 (debug)
* access webdav (PROPFIND against root for example)
* before: maintenance mode is logged in error log level (4)
* after: maintenance mode is logging in debug level (0)
* additional: update needed should still be logged in error level