### PR TITLE
Fix group management which was broken since #5847

### DIFF
--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -45,6 +45,7 @@ use OCP\Files\Config\IUserMountCache;
 use OCP\Encryption\IEncryptionModule;
 use OCP\Encryption\IManager;
 use OCP\IConfig;
+use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IRequest;
@@ -70,7 +71,7 @@ class UsersController extends Controller {
 	private $isAdmin;
 	/** @var IUserManager */
 	private $userManager;
-	/** @var \OC\Group\Manager */
+	/** @var IGroupManager */
 	private $groupManager;
 	/** @var IConfig */
 	private $config;
@@ -112,7 +113,7 @@ class UsersController extends Controller {
 	 * @param string $appName
 	 * @param IRequest $request
 	 * @param IUserManager $userManager
-	 * @param \OC\Group\Manager $groupManager
+	 * @param IGroupManager $groupManager
 	 * @param IUserSession $userSession
 	 * @param IConfig $config
 	 * @param bool $isAdmin
@@ -135,7 +136,7 @@ class UsersController extends Controller {
 	public function __construct($appName,
 								IRequest $request,
 								IUserManager $userManager,
-								\OC\Group\Manager $groupManager,
+								IGroupManager $groupManager,
 								IUserSession $userSession,
 								IConfig $config,
 								$isAdmin,


### PR DESCRIPTION
In the users admin section, the information that a user belongs to a group was missing. For example the following call:
```
curl 'http://nc-dev.local/index.php/settings/users/users?offset=0&limit=50&gid=admin&pattern='
```
would return an empty array.


Ref #5847
