### PR TITLE
Use icon-more in breadcrumb for unshared folders instead of icon-share, fix #3564

### DIFF
--- a/apps/files_sharing/css/sharebreadcrumb.scss
+++ b/apps/files_sharing/css/sharebreadcrumb.scss
@@ -21,7 +21,8 @@
  */
 
 div.crumb span.icon-shared,
-div.crumb span.icon-public {
+div.crumb span.icon-public,
+div.crumb span.icon-more {
 	display: inline-block;
 	cursor: pointer;
 	opacity: 0.2;

--- a/apps/files_sharing/js/sharebreadcrumbview.js
+++ b/apps/files_sharing/js/sharebreadcrumbview.js
@@ -44,7 +44,7 @@
 
 			if (this._dirInfo !== null && (this._dirInfo.path !== '/' || this._dirInfo.name !== '')) {
 				var isShared = data.dirInfo && data.dirInfo.shareTypes && data.dirInfo.shareTypes.length > 0;
-				this.$el.removeClass('shared icon-public icon-shared');
+				this.$el.removeClass('shared icon-public icon-shared icon-more');
 				if (isShared) {
 					this.$el.addClass('shared');
 					if (data.dirInfo.shareTypes.indexOf(OC.Share.SHARE_TYPE_LINK) !== -1) {
@@ -53,12 +53,12 @@
 						this.$el.addClass('icon-shared');
 					}
 				} else {
-					this.$el.addClass('icon-shared');
+					this.$el.addClass('icon-more');
 				}
 				this.$el.show();
 				this.delegateEvents();
 			} else {
-				this.$el.removeClass('shared icon-public icon-shared');
+				this.$el.removeClass('shared icon-public icon-shared icon-more');
 				this.$el.hide();
 			}
 

--- a/apps/files_sharing/tests/js/sharedbreadcrumviewSpec.js
+++ b/apps/files_sharing/tests/js/sharedbreadcrumviewSpec.js
@@ -57,6 +57,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			bc.setDirectory('');
 			bc.render();
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
+			expect(bc.$el.find('.icon-more').length).toEqual(0);
 			expect(bc.$el.find('.icon-shared').length).toEqual(0);
 			expect(bc.$el.find('.shared').length).toEqual(0);
 			expect(bc.$el.find('.icon-public').length).toEqual(0);
@@ -71,7 +72,8 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			bc.setDirectory('/foo');
 			bc.render();
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
-			expect(bc.$el.find('.icon-shared').length).toEqual(1);
+			expect(bc.$el.find('.icon-more').length).toEqual(1);
+			expect(bc.$el.find('.icon-share').length).toEqual(0);
 			expect(bc.$el.find('.shared').length).toEqual(0);
 			expect(bc.$el.find('.icon-public').length).toEqual(0);
 		});
@@ -86,6 +88,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			bc.setDirectory('/foo');
 			bc.render();
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
+			expect(bc.$el.find('.icon-more').length).toEqual(0);
 			expect(bc.$el.find('.icon-shared').length).toEqual(1);
 			expect(bc.$el.find('.shared').length).toEqual(1);
 			expect(bc.$el.find('.icon-public').length).toEqual(0);
@@ -101,6 +104,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			bc.setDirectory('/foo');
 			bc.render();
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
+			expect(bc.$el.find('.icon-more').length).toEqual(0);
 			expect(bc.$el.find('.icon-shared').length).toEqual(1);
 			expect(bc.$el.find('.shared').length).toEqual(1);
 			expect(bc.$el.find('.icon-public').length).toEqual(0);
@@ -116,6 +120,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			bc.setDirectory('/foo');
 			bc.render();
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
+			expect(bc.$el.find('.icon-more').length).toEqual(0);
 			expect(bc.$el.find('.icon-shared').length).toEqual(0);
 			expect(bc.$el.find('.shared').length).toEqual(1);
 			expect(bc.$el.find('.icon-public').length).toEqual(1);
@@ -131,6 +136,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			bc.setDirectory('/foo');
 			bc.render();
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
+			expect(bc.$el.find('.icon-more').length).toEqual(0);
 			expect(bc.$el.find('.icon-shared').length).toEqual(1);
 			expect(bc.$el.find('.shared').length).toEqual(1);
 			expect(bc.$el.find('.icon-public').length).toEqual(0);
@@ -146,6 +152,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			bc.setDirectory('/foo');
 			bc.render();
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
+			expect(bc.$el.find('.icon-more').length).toEqual(0);
 			expect(bc.$el.find('.icon-shared').length).toEqual(1);
 			expect(bc.$el.find('.shared').length).toEqual(1);
 			expect(bc.$el.find('.icon-public').length).toEqual(0);
@@ -168,6 +175,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			bc.setDirectory('/foo');
 			bc.render();
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
+			expect(bc.$el.find('.icon-more').length).toEqual(0);
 			expect(bc.$el.find('.icon-shared').length).toEqual(0);
 			expect(bc.$el.find('.shared').length).toEqual(1);
 			expect(bc.$el.find('.icon-public').length).toEqual(1);
@@ -199,7 +207,8 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			shareTab.trigger('sharesChanged', model);
 
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
-			expect(bc.$el.find('.icon-shared').length).toEqual(1);
+			expect(bc.$el.find('.icon-more').length).toEqual(1);
+			expect(bc.$el.find('.icon-shared').length).toEqual(0);
 			expect(bc.$el.find('.shared').length).toEqual(0);
 			expect(bc.$el.find('.icon-public').length).toEqual(0);
 		});
@@ -232,6 +241,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			shareTab.trigger('sharesChanged', model);
 
 			expect(bc.$el.hasClass('breadcrumb')).toEqual(true);
+			expect(bc.$el.find('.icon-more').length).toEqual(0);
 			expect(bc.$el.find('.icon-shared').length).toEqual(0);
 			expect(bc.$el.find('.shared').length).toEqual(1);
 			expect(bc.$el.find('.icon-public').length).toEqual(1);


### PR DESCRIPTION
Please review @MorrisJobke @te-online 

Non-shared folders are now not using the share icon anymore but rather the 3-dot icon to open the sidebar. This prevents the confusion that you could think the folder is already shared.
![screenshot from 2017-08-16 00-53-13](https://user-images.githubusercontent.com/925062/29340061-7cafa4a6-821d-11e7-8028-61e52af99bd3.png)
Actually shared folder, as usual:
![screenshot from 2017-08-16 00-53-27](https://user-images.githubusercontent.com/925062/29340060-7cad3e00-821d-11e7-8958-1035631a06b0.png)


The only possible issue I see is that there’s a 3-dot icon right above, in the navigation. However it’s kinda the same use »show more« and it only appears if you have a lot of apps installed so maybe a non-issue. cc @nextcloud/designers 

fix #3564