### PR TITLE
Always log cron execution

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -739,13 +739,6 @@ $CONFIG = array(
 'log_query' => false,
 
 /**
- * Log successful cron runs.
- *
- * Defaults to ``true``
- */
-'cron_log' => true,
-
-/**
  * Enables log rotation and limits the total size of logfiles. The default is 0,
  * or no rotation. Specify a size in bytes, for example 104857600 (100 megabytes
  * = 100 * 1024 * 1024 bytes). A new logfile is created with a new name when the

--- a/cron.php
+++ b/cron.php
@@ -152,9 +152,7 @@ try {
 	}
 
 	// Log the successful cron execution
-	if (\OC::$server->getConfig()->getSystemValue('cron_log', true)) {
-		\OC::$server->getConfig()->setAppValue('core', 'lastcron', time());
-	}
+	\OC::$server->getConfig()->setAppValue('core', 'lastcron', time());
 	exit();
 
 } catch (Exception $ex) {

--- a/lib/private/Settings/Admin/Server.php
+++ b/lib/private/Settings/Admin/Server.php
@@ -130,7 +130,6 @@ class Server implements ISettings {
 
 			// Background jobs
 			'backgroundjobs_mode' => $this->config->getAppValue('core', 'backgroundjobs_mode', 'ajax'),
-			'cron_log'            => $this->config->getSystemValue('cron_log', true),
 			'lastcron'            => $this->config->getAppValue('core', 'lastcron', false),
 			'cronErrors'		  => $this->config->getAppValue('core', 'cronErrors'),
 			'cli_based_cron_possible' => function_exists('posix_getpwuid'),

--- a/settings/templates/settings/admin/server.php
+++ b/settings/templates/settings/admin/server.php
@@ -156,28 +156,26 @@
 
 <div class="section" id="backgroundjobs">
 	<h2 class="inlineblock"><?php p($l->t('Background jobs'));?></h2>
-	<?php if ($_['cron_log']): ?>
-		<p class="cronlog inlineblock">
-			<?php if ($_['lastcron'] !== false):
-				$relative_time = relative_modified_date($_['lastcron']);
-				$absolute_time = OC_Util::formatDate($_['lastcron']);
-				if (time() - $_['lastcron'] <= 3600): ?>
-					<span class="status success"></span>
-					<span class="crondate" title="<?php p($absolute_time);?>">
-					<?php p($l->t("Last job ran %s.", [$relative_time]));?>
-				</span>
-				<?php else: ?>
-					<span class="status error"></span>
-					<span class="crondate" title="<?php p($absolute_time);?>">
-					<?php p($l->t("Last job execution ran %s. Something seems wrong.", [$relative_time]));?>
-				</span>
-				<?php endif;
-			else: ?>
+	<p class="cronlog inlineblock">
+		<?php if ($_['lastcron'] !== false):
+			$relative_time = relative_modified_date($_['lastcron']);
+			$absolute_time = OC_Util::formatDate($_['lastcron']);
+			if (time() - $_['lastcron'] <= 3600): ?>
+				<span class="status success"></span>
+				<span class="crondate" title="<?php p($absolute_time);?>">
+				<?php p($l->t("Last job ran %s.", [$relative_time]));?>
+			</span>
+			<?php else: ?>
 				<span class="status error"></span>
-				<?php p($l->t("Background job didn’t run yet!"));
-			endif; ?>
-		</p>
-	<?php endif; ?>
+				<span class="crondate" title="<?php p($absolute_time);?>">
+				<?php p($l->t("Last job execution ran %s. Something seems wrong.", [$relative_time]));?>
+			</span>
+			<?php endif;
+		else: ?>
+			<span class="status error"></span>
+			<?php p($l->t("Background job didn’t run yet!"));
+		endif; ?>
+	</p>
 	<a target="_blank" rel="noreferrer" class="icon-info"
 	   title="<?php p($l->t('Open documentation'));?>"
 	   href="<?php p(link_to_docs('admin-background-jobs')); ?>"></a>

--- a/tests/lib/Settings/Admin/ServerTest.php
+++ b/tests/lib/Settings/Admin/ServerTest.php
@@ -80,12 +80,12 @@ class ServerTest extends TestCase {
 			->with('core', 'backgroundjobs_mode', 'ajax')
 			->willReturn('ajax');
 		$this->config
-			->expects($this->at(4))
+			->expects($this->at(3))
 			->method('getAppValue')
 			->with('core', 'lastcron', false)
 			->willReturn(false);
 		$this->config
-			->expects($this->at(5))
+			->expects($this->at(4))
 			->method('getAppValue')
 			->with('core', 'cronErrors')
 			->willReturn('');
@@ -93,11 +93,6 @@ class ServerTest extends TestCase {
 			->expects($this->at(1))
 			->method('getSystemValue')
 			->with('check_for_working_wellknown_setup', true)
-			->willReturn(true);
-		$this->config
-			->expects($this->at(3))
-			->method('getSystemValue')
-			->with('cron_log', true)
 			->willReturn(true);
 		$this->l10n
 			->expects($this->at(0))
@@ -139,7 +134,6 @@ class ServerTest extends TestCase {
 
 				// Background jobs
 				'backgroundjobs_mode' => 'ajax',
-				'cron_log'            => true,
 				'lastcron'            => false,
 				'cronErrors'		  => '',
 				'cli_based_cron_possible' => true,


### PR DESCRIPTION
There was a setting to disable the last execution of cron. There is no known problem with this write access and it was also questioned when this feature was build in https://github.com/owncloud/core/pull/7689#issuecomment-38264707

Recently there was also a bug report about a non-visible last cron execution (#6088) - let's better remove this.
