### PR TITLE
Prevent SQL error message in case of error

### DIFF
--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -92,7 +92,11 @@ class Database extends Backend implements IUserBackend {
 			$event = new GenericEvent($password);
 			$this->eventDispatcher->dispatch('OCP\PasswordPolicy::validate', $event);
 			$query = \OC_DB::prepare('INSERT INTO `*PREFIX*users` ( `uid`, `password` ) VALUES( ?, ? )');
-			$result = $query->execute(array($uid, \OC::$server->getHasher()->hash($password)));
+			try {
+				$result = $query->execute(array($uid, \OC::$server->getHasher()->hash($password)));
+			} catch (\Exception $e) {
+				$result = false;
+			}
 
 			// Clear cache
 			unset($this->cache[$uid]);

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -349,7 +349,10 @@ class Manager extends PublicEmitter implements IUserManager {
 		}
 
 		$this->emit('\OC\User', 'preCreateUser', [$uid, $password]);
-		$backend->createUser($uid, $password);
+		$state = $backend->createUser($uid, $password);
+		if($state === false) {
+			throw new \InvalidArgumentException($l->t('Could not create user'));
+		}
 		$user = $this->getUserObject($uid, $backend);
 		if ($user instanceof IUser) {
 			$this->emit('\OC\User', 'postCreateUser', [$user, $password]);

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -9,6 +9,7 @@
 
 namespace Test\User;
 use OC\User\Database;
+use OC\User\Manager;
 use OCP\IConfig;
 use OCP\IUser;
 use Test\TestCase;
@@ -304,7 +305,6 @@ class ManagerTest extends TestCase {
 
 		$this->setExpectedException(\InvalidArgumentException::class, $exception);
 		$manager->createUser($uid, $password);
-
 	}
 
 	public function testCreateUserSingleBackendNotExists() {
@@ -383,6 +383,25 @@ class ManagerTest extends TestCase {
 		$manager = new \OC\User\Manager($this->config);
 
 		$this->assertFalse($manager->createUser('foo', 'bar'));
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 * @expectedExceptionMessage Could not create user
+	 */
+	public function testCreateUserFromBackendWithBackendError() {
+		/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject $config */
+		$config = $this->createMock(IConfig::class);
+		/** @var \Test\Util\User\Dummy|\PHPUnit_Framework_MockObject_MockObject $backend */
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
+		$backend
+			->expects($this->once())
+			->method('createUser')
+			->with('MyUid', 'MyPassword')
+			->willReturn(false);
+
+		$manager = new Manager($config);
+		$manager->createUserFromBackend('MyUid', 'MyPassword', $backend);
 	}
 
 	/**


### PR DESCRIPTION
`\OC\User\Database::createUser` can throw a PHP exception in case the UID is longer than
permitted in the database. This is against it's PHPDocs and we should cast this to `false`,
so that the regular error handling triggers in.

The easiest way to reproduce is on MySQL:

1. Create user `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` in admin panel
2. Create user `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` in admin panel again
3. See SQL exception as error message

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>