### PR TITLE
Ensure log message is UTF-8 encoded

### DIFF
--- a/lib/private/Log/File.php
+++ b/lib/private/Log/File.php
@@ -117,7 +117,18 @@ class File {
 			'userAgent',
 			'version'
 		);
-		$entry = json_encode($entry);
+		// PHP's json_encode only accept proper UTF-8 strings, loop over all
+		// elements to ensure that they are properly UTF-8 compliant or convert
+		// them manually.
+		foreach($entry as $key => $value) {
+			if(is_string($value)) {
+				$testEncode = json_encode($value);
+				if($testEncode === false) {
+					$entry[$key] = utf8_encode($value);
+				}
+			}
+		}
+		$entry = json_encode($entry, JSON_PARTIAL_OUTPUT_ON_ERROR);
 		$handle = @fopen(self::$logFile, 'a');
 		if ((fileperms(self::$logFile) & 0777) != 0640) {
 			@chmod(self::$logFile, 0640);


### PR DESCRIPTION
PHP's json_encode only accept proper UTF-8 strings, loop over all
elements to ensure that they are properly UTF-8 compliant or convert
them manually.

Without this somebody passing an invalid User Agent may make json_encode
return false which will get logged as empty newline.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>