### PR TITLE
Fix PHPUnit warnings

### DIFF
--- a/apps/federatedfilesharing/tests/Settings/AdminTest.php
+++ b/apps/federatedfilesharing/tests/Settings/AdminTest.php
@@ -23,6 +23,7 @@
 
 namespace OCA\FederatedFileSharing\Tests\Settings;
 
+use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\FederatedFileSharing\Settings\Admin;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\GlobalScale\IConfig;
@@ -38,9 +39,8 @@ class AdminTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->federatedShareProvider = $this->getMockBuilder('\OCA\FederatedFileSharing\FederatedShareProvider')
-			->disableOriginalConstructor()->getMock();
-		$this->gsConfig = $this->getMock(IConfig::class);
+		$this->federatedShareProvider = $this->createMock(FederatedShareProvider::class);
+		$this->gsConfig = $this->createMock(IConfig::class);
 		$this->admin = new Admin(
 			$this->federatedShareProvider,
 			$this->gsConfig


### PR DESCRIPTION
```
1) OCA\FederatedFileSharing\Tests\Settings\AdminTest::testGetForm with data set #0 (true)
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

2) OCA\FederatedFileSharing\Tests\Settings\AdminTest::testGetForm with data set #1 (false)
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

3) OCA\FederatedFileSharing\Tests\Settings\AdminTest::testGetSection
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

4) OCA\FederatedFileSharing\Tests\Settings\AdminTest::testGetPriority
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead
```

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>