### PR TITLE
Fixes in files_drop.js

### DIFF
--- a/apps/files_sharing/js/files_drop.js
+++ b/apps/files_sharing/js/files_drop.js
@@ -14,7 +14,7 @@
 		'{{#if isUploading}}' +
 		'<span class="icon-loading-small"></span> {{name}}' +
 		'{{else}}' +
-		'<img src="' + OC.imagePath('core', 'actions/error.svg') + '"/> {{name}}' +
+		'<img src="{{iconSrc}}"/> {{name}}' +
 		'{{/if}}' +
 		'</li>';
 	var Drop = {
@@ -72,8 +72,8 @@
 			return true;
 		},
 		
-		setFileIcon: function (fileName,fileIcon) {
-			$('#public-upload ul li[data-name="' + fileName + '"]').html(fileIcon);
+		updateFileItem: function (fileName, fileItem) {
+			$('#public-upload ul li[data-name="' + fileName + '"]').replaceWith(fileItem);
 			$('[data-toggle="tooltip"]').tooltip();
 		},
 		
@@ -98,8 +98,8 @@
 				done: function(e, data) {
 					// Created
 					var mimeTypeUrl = OC.MimeType.getIconUrl(data.files[0].type);
-					var fileIcon = '<img src="' + escapeHTML(mimeTypeUrl) + '"/> ' + fileName;
-					Drop.setFileIcon(fileName,fileIcon);
+					var fileItem = output({isUploading: false, iconSrc: mimeTypeUrl, name: fileName});
+					Drop.updateFileItem(fileName, fileItem);
 				},
 				fail: function(e, data) {
 					OC.Notification.showTemporary(OC.L10N.translate(
@@ -107,8 +107,9 @@
 							'Could not upload "{filename}"',
 							{filename: fileName}
 							));
-					var fileIcon = output({isUploading: false, name: fileName});
-					Drop.setFileIcon(fileName,fileIcon);
+					var errorIconSrc = OC.imagePath('core', 'actions/error.svg');
+					var fileItem = output({isUploading: false, iconSrc: errorIconSrc, name: fileName});
+					Drop.updateFileItem(fileName, fileItem);
 				},
 				progressall: function (e, data) {
 					var progress = parseInt(data.loaded / data.total * 100, 10);

--- a/apps/files_sharing/js/files_drop.js
+++ b/apps/files_sharing/js/files_drop.js
@@ -101,7 +101,7 @@
 					var fileIcon = '<img src="' + escapeHTML(mimeTypeUrl) + '"/> ' + fileName;
 					Drop.setFileIcon(fileName,fileIcon);
 				},
-				fail: function(e, data, errorThrown) {
+				fail: function(e, data) {
 					OC.Notification.showTemporary(OC.L10N.translate(
 							'files_sharing',
 							'Could not upload "{filename}"',

--- a/apps/files_sharing/js/files_drop.js
+++ b/apps/files_sharing/js/files_drop.js
@@ -64,7 +64,7 @@
 			$('#drop-upload-done-indicator').addClass('hidden');
 			$('#drop-upload-progress-indicator').removeClass('hidden');
 			_.each(data['files'], function(file) {
-				$('#public-upload ul').append(output({isUploading: true, name: escapeHTML(file.name)}));
+				$('#public-upload ul').append(output({isUploading: true, name: file.name}));
 				$('[data-toggle="tooltip"]').tooltip();
 				data.submit();
 			});
@@ -83,14 +83,12 @@
 				e.preventDefault();
 			});
 			var output = this.template();
-			var fileName = undefined;
 			$('#public-upload').fileupload({
 				type: 'PUT',
 				dropZone: $('#public-upload'),
 				sequentialUploads: true,
 				add: function(e, data) {
 					Drop.addFileToUpload(e, data);
-					fileName = escapeHTML(data.files[0].name);
 					//we return true to keep trying to upload next file even
 					//if addFileToUpload did not like the privious one
 					return true;
@@ -98,18 +96,18 @@
 				done: function(e, data) {
 					// Created
 					var mimeTypeUrl = OC.MimeType.getIconUrl(data.files[0].type);
-					var fileItem = output({isUploading: false, iconSrc: mimeTypeUrl, name: fileName});
-					Drop.updateFileItem(fileName, fileItem);
+					var fileItem = output({isUploading: false, iconSrc: mimeTypeUrl, name: data.files[0].name});
+					Drop.updateFileItem(data.files[0].name, fileItem);
 				},
 				fail: function(e, data) {
 					OC.Notification.showTemporary(OC.L10N.translate(
 							'files_sharing',
 							'Could not upload "{filename}"',
-							{filename: fileName}
+							{filename: data.files[0].name}
 							));
 					var errorIconSrc = OC.imagePath('core', 'actions/error.svg');
-					var fileItem = output({isUploading: false, iconSrc: errorIconSrc, name: fileName});
-					Drop.updateFileItem(fileName, fileItem);
+					var fileItem = output({isUploading: false, iconSrc: errorIconSrc, name: data.files[0].name});
+					Drop.updateFileItem(data.files[0].name, fileItem);
 				},
 				progressall: function (e, data) {
 					var progress = parseInt(data.loaded / data.total * 100, 10);

--- a/apps/files_sharing/js/files_drop.js
+++ b/apps/files_sharing/js/files_drop.js
@@ -63,11 +63,10 @@
 	
 			$('#drop-upload-done-indicator').addClass('hidden');
 			$('#drop-upload-progress-indicator').removeClass('hidden');
-			_.each(data['files'], function(file) {
-				$('#public-upload ul').append(output({isUploading: true, name: file.name}));
-				$('[data-toggle="tooltip"]').tooltip();
-				data.submit();
-			});
+
+			$('#public-upload ul').append(output({isUploading: true, name: data.files[0].name}));
+			$('[data-toggle="tooltip"]').tooltip();
+			data.submit();
 	
 			return true;
 		},


### PR DESCRIPTION
The `singleFileUploads` option, which is enabled by default, causes the jQuery File Upload plugin to call the `add` callback once for each file to be uploaded. The `add` callback set in `OCA.FilesSharingDrop.initialize` stored the file name in the `fileName` variable; that variable was later used in the `done` callback to find the appropriate file in the list whose loading icon had to be replaced with a MIME type icon. However, when several files were added at the same time the `fileName` variable is overwritten with the name of each new file in the upload set. Thus, when the `done` callback was later called `fileName` contained the name of the last file and therefore the replaced icon was that of the last file.

There was no need to store the file name, though; as `singleFileUploads` is enabled the `files` property of the `data` parameter given to all the callbacks always contains a single file, which is the one that has been added, has finished uploading, or has failed uploading.

While fixing that (reported in #6060) I found other issues in _files_drop.js_ that I have partially fixed (like a `<li>` element nested inside another `<li>` element when a file upload failed); however, there are still some pending issues related to escape characters (like _"_ or _\\_) in file names that need to be fixed before merging this.

There are no automated tests for these issues yet, as they were way more cumbersome to set than I had expected; I will try to add them in the future.

Also, this fixes the issue with multiple uploaded files in _master_. However, #6060 is reported against Nextcloud 12.0.1; if there are no objections I will backport this pull request to _stable12_ once it is finished.
