### PR TITLE
Increase contrast of dropdown menu text, fix accessibility & visibility issues

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -598,7 +598,7 @@ kbd {
 .popovermenu {
 	position: absolute;
 	background-color: $color-main-background;
-	color: nc-lighten($color-main-text, 20%);
+	color: $color-main-text;
 	border-radius: 3px;
 	z-index: 110;
 	margin: 5px;
@@ -693,9 +693,9 @@ kbd {
 		}
 		.menuitem {
 			width: 100%;
-			-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=50)';
-			filter: alpha(opacity = 50);
-			opacity: .5;
+			-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=70)';
+			filter: alpha(opacity = 70);
+			opacity: .7;
 			&:hover, &:focus, &.active {
 				-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=100)';
 				filter: alpha(opacity = 100);
@@ -710,7 +710,6 @@ kbd {
 			min-width: 0; /* Overwrite icons*/
 			min-height: 0;
 			background-position: 10px center;
-			opacity: 0.7; /* Default button icon override */
 		}
 	}
 }

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -277,8 +277,8 @@ nav {
 		}
 		svg,
 		span {
-			-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=50)';
-			opacity: .5;
+			-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=70)';
+			opacity: .7;
 		}
 		svg {
 			margin-bottom: 2px;
@@ -427,10 +427,10 @@ nav {
 		display: block;
 		height: 40px;
 		color: $color-main-text;
-		opacity: .5;
 		padding: 10px 12px 0;
-		-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=50)';
 		box-sizing: border-box;
+		-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=70)';
+		opacity: .7;
 		img {
 			margin-bottom: -3px;
 			margin-right: 6px;
@@ -500,7 +500,7 @@ nav {
 		border-top-left-radius: 0;
 		border-top-right-radius: 0;
 		margin-top: 0;
-		color: rgba(0, 0, 0, .6);
+		color: rgba(0, 0, 0, .7);
 		width: auto;
 		left: 50%;
 		top: 45px;


### PR DESCRIPTION
For example the upload menu, before & after:
![screenshot from 2017-08-21 12-08-11](https://user-images.githubusercontent.com/925062/29514673-a32d007e-8669-11e7-91fc-8a24698d5ba7.png)

The base contrast of the text to the white background was raised to meet [WCAG AA standards of contrast](http://contrastchecker.com/):
![screenshot from 2017-08-21 12-12-03](https://user-images.githubusercontent.com/925062/29514773-025714fe-866a-11e7-8594-bffccf2bf309.png)
(the hex color is black with 70% opacity, as defined in the CSS)
