### PR TITLE
[stable12] Show "Uploading..." in web UI for long uploads

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1021,6 +1021,10 @@ OC.Uploader.prototype = _.extend({
 					}
 
 					var h = moment.duration(smoothRemainingSeconds, "seconds").humanize();
+					if (!(smoothRemainingSeconds >= 0 && smoothRemainingSeconds < 14400)) {
+						// show "Uploading ..." for durations longer than 4 hours
+						h = t('files', 'Uploading...');
+					}
 					$('#uploadprogressbar .label .mobile').text(h);
 					$('#uploadprogressbar .label .desktop').text(h);
 					$('#uploadprogressbar').attr('original-title',


### PR DESCRIPTION
If the estimated upload time is bigger than 4 hours it shows the text "Uploading..." because the time then doesn't give any good hint to the user anyways.

Backport of #6239 

cc @oparoz 