### PR TITLE
Fix undefined index oauthState

### DIFF
--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -193,6 +193,7 @@ class ClientFlowLoginController extends Controller {
 				'urlGenerator' => $this->urlGenerator,
 				'stateToken' => $stateToken,
 				'serverHost' => $this->request->getServerHost(),
+				'oauthState' => $this->session->get('oauth.state'),
 			],
 			'guest'
 		);

--- a/tests/Core/Controller/ClientFlowLoginControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginControllerTest.php
@@ -149,6 +149,11 @@ class ClientFlowLoginControllerTest extends TestCase {
 			->expects($this->once())
 			->method('set')
 			->with('client.flow.state.token', 'StateToken');
+		$this->session
+			->expects($this->once())
+			->method('get')
+			->with('oauth.state')
+			->willReturn('OauthStateToken');
 		$this->defaults
 			->expects($this->once())
 			->method('getName')
@@ -168,6 +173,7 @@ class ClientFlowLoginControllerTest extends TestCase {
 				'urlGenerator' => $this->urlGenerator,
 				'stateToken' => 'StateToken',
 				'serverHost' => 'example.com',
+				'oauthState' => 'OauthStateToken',
 			],
 			'guest'
 		);
@@ -199,6 +205,11 @@ class ClientFlowLoginControllerTest extends TestCase {
 			->expects($this->once())
 			->method('set')
 			->with('client.flow.state.token', 'StateToken');
+		$this->session
+			->expects($this->once())
+			->method('get')
+			->with('oauth.state')
+			->willReturn('OauthStateToken');
 		$this->defaults
 			->expects($this->once())
 			->method('getName')
@@ -218,6 +229,7 @@ class ClientFlowLoginControllerTest extends TestCase {
 				'urlGenerator' => $this->urlGenerator,
 				'stateToken' => 'StateToken',
 				'serverHost' => 'example.com',
+				'oauthState' => 'OauthStateToken',
 			],
 			'guest'
 		);


### PR DESCRIPTION
Fixes the log entries:

```
Undefined index: oauthState at core/templates/loginflow/authpicker.php#38
```

Reported on stable12

cc @AndyScherzinger 