### PR TITLE
Don't fetch the translation from core but from files

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2720,7 +2720,7 @@
 		 * Shows a "permission denied" notification
 		 */
 		_showPermissionDeniedNotification: function() {
-			var message = t('core', 'You don’t have permission to upload or create files here');
+			var message = t('files', 'You don’t have permission to upload or create files here');
 			OC.Notification.show(message, {type: 'error'});
 		},
 


### PR DESCRIPTION
Steps:

1. Share a folder `foo` to `user` read only
2. Set user language to something other than EN
3. As `user` open that folder in the web UI
4. Drag a file into the folder and drop it


Now the error is properly translated.