### PR TITLE
Don't try the actual file upload if the checks already error out

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1113,6 +1113,9 @@ OC.Uploader.prototype = _.extend({
 				});
 				fileupload.on('fileuploaddrop', function(e, data) {
 					self.trigger('drop', e, data);
+					if (e.isPropagationStopped()) {
+						return false;
+					}
 				});
 
 			}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2795,6 +2795,7 @@
 					var isCreatable = (self.getDirectoryPermissions() & OC.PERMISSION_CREATE) !== 0;
 					if (!isCreatable) {
 						self._showPermissionDeniedNotification();
+						e.stopPropagation();
 						return false;
 					}
 

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2810,6 +2810,8 @@ describe('OCA.Files.FileList tests', function() {
 						target: $target
 					},
 					preventDefault: function () {
+					},
+					stopPropagation: function() {
 					}
 				};
 				uploader.trigger('drop', eventData, data || {});


### PR DESCRIPTION
Steps:

1. Share a folder `foo` to `user` read only
2. As `user` open that folder in the web UI
3. Drag a file into the folder and drop it

Before:
* There are 2 errors on the top (basically saying the same :P)
* The file is tried to be uploaded

Now:
* Only one error
* We don't try to upload the file even because it is not allowed.
