### PR TITLE
Add standard border-radius to datepicker

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -992,6 +992,8 @@ code {
 	margin-top: 10px;
 	padding: 4px 8px;
 	width: auto;
+	border-radius: 3px;
+	border: none;
 
 	.ui-state-default,
 	.ui-widget-content .ui-state-default,


### PR DESCRIPTION
Just a tiny detail I noticed about the new datepicker, that the 3px border-radius was missing. Ref https://github.com/nextcloud/server/pull/5713

Easy fix, please review @pixelipo @nextcloud/designers :)

![screenshot from 2017-08-25 14-06-02](https://user-images.githubusercontent.com/925062/29713374-8d1b92cc-899e-11e7-9b11-befd15eeafe6.png)![screenshot from 2017-08-25 14-07-44](https://user-images.githubusercontent.com/925062/29713433-cd69b610-899e-11e7-8e66-875f19b187df.png)

