### PR TITLE
Fix permanent display of favorite icon

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -617,6 +617,12 @@ a.action > img {
 	opacity: .7;
 }
 
+#fileList .action.action-favorite.permanent {
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
+	filter: alpha(opacity=100);
+	opacity: 1;
+}
+
 #fileList .fileActionsMenu a.action:hover,
 #fileList .fileActionsMenu a.action:focus,
 /* show share action of shared items darker to distinguish from non-shared */


### PR DESCRIPTION
Maybe this happened during the SCSS move. The favorites icon in files had the same transparency as the grey non-favorited icon so due to the yellow color it was actually less visible.

Before / after:
![screenshot from 2017-08-25 14-25-55](https://user-images.githubusercontent.com/925062/29714019-7205ecaa-89a1-11e7-94d7-f8689ead789b.png)![screenshot from 2017-08-25 14-24-52](https://user-images.githubusercontent.com/925062/29714020-72093e28-89a1-11e7-8ef8-d9ad9c107def.png)

Please review @nextcloud/designers 