### PR TITLE
Better handling of errors durring scanning

### DIFF
--- a/lib/private/Files/Type/Loader.php
+++ b/lib/private/Files/Type/Loader.php
@@ -119,6 +119,10 @@ class Loader implements IMimeTypeLoader {
 				]);
 			$qb->execute();
 		} catch (UniqueConstraintViolationException $e) {
+			if ($this->dbConnection->inTransaction()) {
+				// if we're inside a transaction we can't recover safely
+				throw $e;
+			}
 			// something inserted it before us
 		}
 


### PR DESCRIPTION
Fixes the errors from https://github.com/nextcloud/server/pull/6245

Note that these errors so far only occur because of the way the unit tests are setup and the same error *shouldn't* occur in real life. Nevertheless properly handling them is nicer.