### PR TITLE
Show sharee in dropdown to send notification mail again

### DIFF
--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -65,6 +65,11 @@ return [
 			'verb' => 'POST',
 		],
 		[
+			'name' => 'ShareAPI#resendMailNotification',
+			'url'  => '/api/v1/shares/{id}/resendMailNotification',
+			'verb' => 'POST',
+		],
+		[
 			'name' => 'ShareAPI#getShare',
 			'url'  => '/api/v1/shares/{id}',
 			'verb' => 'GET',

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -491,6 +491,31 @@ class ShareAPIController extends OCSController {
 	}
 
 	/**
+	 * Sends again the e-mail notification for a share
+	 *
+	 * @NoAdminRequired
+	 *
+	 * @param string $id
+	 * @return DataResponse
+	 * @throws OCSNotFoundException
+	 */
+	public function resendMailNotification($id) {
+		try {
+			$share = $this->getShareById($id);
+		} catch (ShareNotFound $e) {
+			throw new OCSNotFoundException($this->l->t('Wrong share ID, share doesn\'t exist', $id));
+		}
+
+		if (!$this->canAccessShare($share)) {
+			throw new OCSNotFoundException($this->l->t('Wrong share ID, share doesn\'t exist', $id));
+		}
+
+		$this->shareManager->resendMailNotification($share);
+
+		return new DataResponse();
+	}
+
+	/**
 	 * @param \OCP\Files\File|\OCP\Files\Folder $node
 	 * @param boolean $includeTags
 	 * @return DataResponse

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -1153,6 +1153,118 @@ class ShareAPIControllerTest extends TestCase {
 		$ocs->createShare('valid-path', \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_USER, 'validUser');
 	}
 
+	public function testResendMailNotification() {
+		$share = $this->createShare(42, \OCP\Share::SHARE_TYPE_USER, null, null, null, null, null, null, null, null, null, null);
+
+		/** @var \OCA\Files_Sharing\Controller\ShareAPIController $ocs */
+		$ocs = $this->getMockBuilder(ShareAPIController::class)
+				->setConstructorArgs([
+					$this->appName,
+					$this->request,
+					$this->shareManager,
+					$this->groupManager,
+					$this->userManager,
+					$this->rootFolder,
+					$this->urlGenerator,
+					$this->currentUser,
+					$this->l,
+				])->setMethods(['canAccessShare'])
+				->getMock();
+
+		$this->shareManager
+			->expects($this->once())
+			->method('getShareById')
+			->with('ocinternal:42')
+			->willReturn($share);
+
+		$ocs->expects($this->once())
+			->method('canAccessShare')
+			->with($share)
+			->willReturn(true);
+
+		$this->shareManager
+			->expects($this->once())
+			->method('resendMailNotification')
+			->with($share);
+
+		$ocs->resendMailNotification(42);
+	}
+
+	/**
+	 * @expectedException \OCP\AppFramework\OCS\OCSNotFoundException
+	 * @expectedExceptionMessage Wrong share ID, share doesn't exist
+	 */
+	public function testResendMailNotificationShareNotFound() {
+		$share = $this->createShare(42, \OCP\Share::SHARE_TYPE_USER, null, null, null, null, null, null, null, null, null, null);
+
+		/** @var \OCA\Files_Sharing\Controller\ShareAPIController $ocs */
+		$ocs = $this->getMockBuilder(ShareAPIController::class)
+				->setConstructorArgs([
+					$this->appName,
+					$this->request,
+					$this->shareManager,
+					$this->groupManager,
+					$this->userManager,
+					$this->rootFolder,
+					$this->urlGenerator,
+					$this->currentUser,
+					$this->l,
+				])->setMethods(['canAccessShare'])
+				->getMock();
+
+		$this->shareManager
+			->expects($this->once())
+			->method('getShareById')
+			->with('ocinternal:42')
+			->will($this->throwException(new \OCP\Share\Exceptions\ShareNotFound()));
+
+		$this->shareManager
+			->expects($this->never())
+			->method('resendMailNotification');
+
+		$ocs->resendMailNotification(42);
+	}
+
+	/**
+	 * @expectedException \OCP\AppFramework\OCS\OCSNotFoundException
+	 * @expectedExceptionMessage Wrong share ID, share doesn't exist
+	 */
+	public function testResendMailNotificationCanNotAccess() {
+		$share = $this->createShare(42, \OCP\Share::SHARE_TYPE_USER, null, null, null, null, null, null, null, null, null, null);
+
+		/** @var \OCA\Files_Sharing\Controller\ShareAPIController $ocs */
+		$ocs = $this->getMockBuilder(ShareAPIController::class)
+				->setConstructorArgs([
+					$this->appName,
+					$this->request,
+					$this->shareManager,
+					$this->groupManager,
+					$this->userManager,
+					$this->rootFolder,
+					$this->urlGenerator,
+					$this->currentUser,
+					$this->l,
+				])->setMethods(['canAccessShare'])
+				->getMock();
+
+		$this->shareManager
+			->expects($this->once())
+			->method('getShareById')
+			->with('ocinternal:42')
+			->willReturn($share);
+
+		$ocs->expects($this->once())
+			->method('canAccessShare')
+			->with($share)
+			->willReturn(false);
+
+		$this->shareManager
+			->expects($this->never())
+			->method('resendMailNotification');
+
+		$ocs->resendMailNotification(42);
+	}
+
 	/**
 	 * @expectedException \OCP\AppFramework\OCS\OCSNotFoundException
 	 * @expectedExceptionMessage Wrong share ID, share doesn't exist

--- a/core/css/share.scss
+++ b/core/css/share.scss
@@ -70,6 +70,10 @@
 
 .share-autocomplete-item {
 	display: flex;
+	position: relative; // A relative position is needed here to place the mail
+						// icon to the right of the item and, like the text, to
+						// also get its position modified by the invisible
+						// border added when the item is focused.
 	.autocomplete-item-text {
 		margin-left: 10px;
 		margin-right: 10px;
@@ -78,6 +82,11 @@
 		overflow: hidden;
 		line-height: 32px;
 		vertical-align: middle;
+	}
+	.icon-mail {
+		position: absolute;
+		top: 8px;
+		right: 8px;
 	}
 }
 

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -238,7 +238,7 @@
 								usersLength = users.length;
 								for (j = 0; j < usersLength; j++) {
 									if (users[j].value.shareWith === share.share_with) {
-										if (users[j].value.emailAddress !== undefined) {
+										if (users[j].value.hasEmailAddress === true) {
 											users[j].resendMailNotification = share.id;
 										} else {
 											users.splice(j, 1);

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -263,6 +263,38 @@
 		},
 
 		/**
+		 * Sends again the e-mail notification for a share
+		 *
+		 * @param {int} shareId the share ID
+		 * @param {object} options an object with optional callbacks for success
+		 *        and error
+		 * @return {jqXHR}
+		 */
+		resendMailNotification: function(shareId, options) {
+			return $.ajax({
+				type: 'POST',
+				url: this._getUrl('shares/' + encodeURIComponent(shareId) + "/resendMailNotification"),
+				dataType: 'json'
+			}).done(function() {
+				if (_.isFunction(options.success)) {
+					options.success(t('core', 'E-mail notification sent again'));
+				}
+			}).fail(function(xhr) {
+				var msg = t('core', 'Error');
+				var result = xhr.responseJSON;
+				if (result && result.ocs && result.ocs.meta) {
+					msg = result.ocs.meta.message;
+				}
+
+				if (_.isFunction(options.error)) {
+					options.error(self, msg);
+				} else {
+					OC.dialogs.alert(msg, t('core', 'Error when sending again the e-mail notification'));
+				}
+			});
+		},
+
+		/**
 		 * @returns {boolean}
 		 */
 		isPublicUploadAllowed: function() {

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -737,7 +737,7 @@ describe('OC.Share.ShareDialogView', function() {
 										'value': {
 											'shareType': OC.Share.SHARE_TYPE_USER,
 											'shareWith': 'user1',
-											'emailAddress': 'user1@server.com'
+											'hasEmailAddress': true
 										},
 									},
 									{
@@ -761,7 +761,7 @@ describe('OC.Share.ShareDialogView', function() {
 					);
 					expect(response.calledWithExactly([{
 						'label': 'bob',
-						'value': {'shareType': OC.Share.SHARE_TYPE_USER, 'shareWith': 'user1', 'emailAddress': 'user1@server.com'},
+						'value': {'shareType': OC.Share.SHARE_TYPE_USER, 'shareWith': 'user1', 'hasEmailAddress': true},
 						'resendMailNotification': 100
 					}, {
 						'label': 'bobby',
@@ -1023,7 +1023,7 @@ describe('OC.Share.ShareDialogView', function() {
 					value: {
 						shareType: OC.Share.SHARE_TYPE_USER,
 						shareWith: 'user1',
-						emailAddress: 'user1@server.com'
+						hasEmailAddress: true
 					},
 					resendMailNotification: 100
 				}
@@ -1059,7 +1059,7 @@ describe('OC.Share.ShareDialogView', function() {
 					value: {
 						shareType: OC.Share.SHARE_TYPE_USER,
 						shareWith: 'user1',
-						emailAddress: 'user1@server.com'
+						hasEmailAddress: true
 					},
 					resendMailNotification: 100
 				}

--- a/core/js/tests/specs/shareitemmodelSpec.js
+++ b/core/js/tests/specs/shareitemmodelSpec.js
@@ -924,6 +924,51 @@ describe('OC.Share.ShareItemModel', function() {
 			expect(errorStub.lastCall.args[1]).toEqual('Some error message');
 		});
 	});
+	describe('resending share notification', function() {
+		it('sends POST method to endpoint with passed values', function() {
+			model.resendMailNotification(42);
+
+			expect(fakeServer.requests.length).toEqual(1);
+			expect(fakeServer.requests[0].method).toEqual('POST');
+			expect(fakeServer.requests[0].url).toEqual(
+				OC.linkToOCS('apps/files_sharing/api/v1', 2) +
+				'shares/42/resendMailNotification?format=json'
+			);
+			expect(fakeServer.requests[0].requestBody).toBeNull();
+		});
+		it('calls success callback on success', function() {
+			fakeServer.respondImmediately = true;
+
+			fakeServer.respondWith([
+				200,
+				{},
+				''
+			]);
+
+			var successCallback = sinon.spy();
+			var errorCallback = sinon.spy();
+			model.resendMailNotification(42, {success: successCallback, error: errorCallback});
+
+			expect(successCallback.calledOnce).toBeTruthy();
+			expect(errorCallback.called).toBeFalsy();
+		});
+		it('calls error callback on fail', function() {
+			fakeServer.respondImmediately = true;
+
+			fakeServer.respondWith([
+				404,
+				{},
+				''
+			]);
+
+			var successCallback = sinon.spy();
+			var errorCallback = sinon.spy();
+			model.resendMailNotification(42, {success: successCallback, error: errorCallback});
+
+			expect(errorCallback.calledOnce).toBeTruthy();
+			expect(successCallback.called).toBeFalsy();
+		});
+	});
 
 	describe('getShareTypes', function() {
 

--- a/lib/private/Collaboration/Collaborators/MailPlugin.php
+++ b/lib/private/Collaboration/Collaborators/MailPlugin.php
@@ -90,6 +90,7 @@ class MailPlugin implements ISearchPlugin {
 									'value' => [
 										'shareType' => Share::SHARE_TYPE_USER,
 										'shareWith' => $cloud->getUser(),
+										'hasEmailAddress' => true,
 									],
 								]];
 								$searchResult->addResultSet($userType, [], $singleResult);
@@ -111,6 +112,7 @@ class MailPlugin implements ISearchPlugin {
 									'value' => [
 										'shareType' => Share::SHARE_TYPE_USER,
 										'shareWith' => $cloud->getUser(),
+										'hasEmailAddress' => true,
 									]],
 								];
 								$searchResult->addResultSet($userType, $singleResult, []);

--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -94,21 +94,23 @@ class UserPlugin implements ISearchPlugin {
 				if (strtolower($uid) === $lowerSearch) {
 					$foundUserById = true;
 				}
-				$result['exact'][] = [
+				$userData = [
 					'label' => $userDisplayName,
 					'value' => [
 						'shareType' => Share::SHARE_TYPE_USER,
 						'shareWith' => $uid,
 					],
 				];
+				$result['exact'][] = $userData;
 			} else {
-				$result['wide'][] = [
+				$userData = [
 					'label' => $userDisplayName,
 					'value' => [
 						'shareType' => Share::SHARE_TYPE_USER,
 						'shareWith' => $uid,
 					],
 				];
+				$result['wide'][] = $userData;
 			}
 		}
 
@@ -126,13 +128,14 @@ class UserPlugin implements ISearchPlugin {
 				}
 
 				if ($addUser) {
-					array_push($result['exact'], [
+					$userData = [
 						'label' => $user->getDisplayName(),
 						'value' => [
 							'shareType' => Share::SHARE_TYPE_USER,
 							'shareWith' => $user->getUID(),
 						],
-					]);
+					];
+					$result['exact'][] = $userData;
 				}
 			}
 		}

--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -102,7 +102,7 @@ class UserPlugin implements ISearchPlugin {
 					],
 				];
 				if ($user->getEMailAddress()) {
-					$userData['value']['emailAddress'] = $user->getEMailAddress();
+					$userData['value']['hasEmailAddress'] = true;
 				}
 				$result['exact'][] = $userData;
 			} else {
@@ -114,7 +114,7 @@ class UserPlugin implements ISearchPlugin {
 					],
 				];
 				if ($user->getEMailAddress()) {
-					$userData['value']['emailAddress'] = $user->getEMailAddress();
+					$userData['value']['hasEmailAddress'] = true;
 				}
 				$result['wide'][] = $userData;
 			}
@@ -142,7 +142,7 @@ class UserPlugin implements ISearchPlugin {
 						],
 					];
 					if ($user->getEMailAddress()) {
-						$userData['value']['emailAddress'] = $user->getEMailAddress();
+						$userData['value']['hasEmailAddress'] = true;
 					}
 					$result['exact'][] = $userData;
 				}

--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -69,9 +69,9 @@ class UserPlugin implements ISearchPlugin {
 			// Search in all the groups this user is part of
 			$userGroups = $this->groupManager->getUserGroupIds($this->userSession->getUser());
 			foreach ($userGroups as $userGroup) {
-				$usersTmp = $this->groupManager->displayNamesInGroup($userGroup, $search, $limit, $offset);
-				foreach ($usersTmp as $uid => $userDisplayName) {
-					$users[$uid] = $userDisplayName;
+				$usersTmp = $this->groupManager->usersInGroup($userGroup, $search, $limit, $offset);
+				foreach ($usersTmp as $uid => $user) {
+					$users[$uid] = $user;
 				}
 			}
 		} else {
@@ -79,7 +79,7 @@ class UserPlugin implements ISearchPlugin {
 			$usersTmp = $this->userManager->searchDisplayName($search, $limit, $offset);
 
 			foreach ($usersTmp as $user) {
-				$users[$user->getUID()] = $user->getDisplayName();
+				$users[$user->getUID()] = $user;
 			}
 		}
 
@@ -89,13 +89,13 @@ class UserPlugin implements ISearchPlugin {
 
 		$foundUserById = false;
 		$lowerSearch = strtolower($search);
-		foreach ($users as $uid => $userDisplayName) {
-			if (strtolower($uid) === $lowerSearch || strtolower($userDisplayName) === $lowerSearch) {
+		foreach ($users as $uid => $user) {
+			if (strtolower($uid) === $lowerSearch || strtolower($user->getDisplayName()) === $lowerSearch) {
 				if (strtolower($uid) === $lowerSearch) {
 					$foundUserById = true;
 				}
 				$userData = [
-					'label' => $userDisplayName,
+					'label' => $user->getDisplayName(),
 					'value' => [
 						'shareType' => Share::SHARE_TYPE_USER,
 						'shareWith' => $uid,
@@ -104,7 +104,7 @@ class UserPlugin implements ISearchPlugin {
 				$result['exact'][] = $userData;
 			} else {
 				$userData = [
-					'label' => $userDisplayName,
+					'label' => $user->getDisplayName(),
 					'value' => [
 						'shareType' => Share::SHARE_TYPE_USER,
 						'shareWith' => $uid,

--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -101,6 +101,9 @@ class UserPlugin implements ISearchPlugin {
 						'shareWith' => $uid,
 					],
 				];
+				if ($user->getEMailAddress()) {
+					$userData['value']['emailAddress'] = $user->getEMailAddress();
+				}
 				$result['exact'][] = $userData;
 			} else {
 				$userData = [
@@ -110,6 +113,9 @@ class UserPlugin implements ISearchPlugin {
 						'shareWith' => $uid,
 					],
 				];
+				if ($user->getEMailAddress()) {
+					$userData['value']['emailAddress'] = $user->getEMailAddress();
+				}
 				$result['wide'][] = $userData;
 			}
 		}
@@ -135,6 +141,9 @@ class UserPlugin implements ISearchPlugin {
 							'shareWith' => $user->getUID(),
 						],
 					];
+					if ($user->getEMailAddress()) {
+						$userData['value']['emailAddress'] = $user->getEMailAddress();
+					}
 					$result['exact'][] = $userData;
 				}
 			}

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -330,14 +330,14 @@ class Manager extends PublicEmitter implements IGroupManager {
 	}
 
 	/**
-	 * get a list of all display names in a group
+	 * get a list of all users in a group
 	 * @param string $gid
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
-	 * @return array an array of display names (value) and user ids (key)
+	 * @return array an array of users (value) and user ids (key)
 	 */
-	public function displayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0) {
+	public function usersInGroup($gid, $search = '', $limit = -1, $offset = 0) {
 		$group = $this->get($gid);
 		if(is_null($group)) {
 			return array();
@@ -375,7 +375,23 @@ class Manager extends PublicEmitter implements IGroupManager {
 
 		$matchingUsers = array();
 		foreach($groupUsers as $groupUser) {
-			$matchingUsers[$groupUser->getUID()] = $groupUser->getDisplayName();
+			$matchingUsers[$groupUser->getUID()] = $groupUser;
+		}
+		return $matchingUsers;
+	}
+
+	/**
+	 * get a list of all display names in a group
+	 * @param string $gid
+	 * @param string $search
+	 * @param int $limit
+	 * @param int $offset
+	 * @return array an array of display names (value) and user ids (key)
+	 */
+	public function displayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0) {
+		$matchingUsers = array();
+		foreach($this->usersInGroup($gid, $search, $limit, $offset) as $uid => $user) {
+			$matchingUsers[$uid] = $user->getDisplayName();
 		}
 		return $matchingUsers;
 	}

--- a/lib/public/IGroupManager.php
+++ b/lib/public/IGroupManager.php
@@ -118,6 +118,18 @@ interface IGroupManager {
 	public function getUserGroupIds(IUser $user);
 
 	/**
+	 * get a list of all users in a group
+	 *
+	 * @param string $gid
+	 * @param string $search
+	 * @param int $limit
+	 * @param int $offset
+	 * @return array an array of users (value) and user ids (key)
+	 * @since 13.0.0
+	 */
+	public function usersInGroup($gid, $search = '', $limit = -1, $offset = 0);
+
+	/**
 	 * get a list of all display names in a group
 	 *
 	 * @param string $gid

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -50,6 +50,18 @@ interface IManager {
 	public function createShare(IShare $share);
 
 	/**
+	 * Sends again the e-mail notification for a share
+	 *
+	 * @param IShare $share
+	 * @return IShare The share object
+	 * @throws \InvalidArgumentException if share type does not support mail
+	 *         notifications or the sharee has no known e-mail address
+	 * @throws \Exception if mail could not be sent
+	 * @since 13.0.0
+	 */
+	public function resendMailNotification(IShare $share);
+
+	/**
 	 * Update a share.
 	 * The target of the share can't be changed this way: use moveShare
 	 * The share can't be removed this way (permission 0): use deleteShare

--- a/tests/lib/Collaboration/Collaborators/MailPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/MailPluginTest.php
@@ -327,9 +327,24 @@ class MailPluginTest extends TestCase {
 					]
 				],
 				false,
-				['users' => [], 'exact' => ['users' => [['label' => 'User (test@example.com)','value' => ['shareType' => 0, 'shareWith' => 'test'],]]]],
+				['users' => [], 'exact' => ['users' => [['label' => 'User (test@example.com)','value' => ['shareType' => 0, 'shareWith' => 'test', 'hasEmailAddress' => true],]]]],
 				true,
 				false,
+			],
+			[
+				'test@ex',
+				[
+					[
+						'FN' => 'User',
+						'EMAIL' => ['test@example.com'],
+						'CLOUD' => ['test@localhost'],
+						'isLocalSystemBook' => true,
+					]
+				],
+				true,
+				['users' => [['label' => 'User (test@example.com)','value' => ['shareType' => 0, 'shareWith' => 'test', 'hasEmailAddress' => true],]], 'emails' => [], 'exact' => ['users' => [], 'emails' => []]],
+				false,
+				true,
 			]
 		];
 	}

--- a/tests/lib/Collaboration/Collaborators/UserPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/UserPluginTest.php
@@ -122,7 +122,7 @@ class UserPluginTest extends TestCase {
 			[
 				'test', false, true, [], [],
 				[
-					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'emailAddress' => 'test@server.com']],
+					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'hasEmailAddress' => true]],
 				], [], true, $this->getUserMock('test', 'Test', 'test@server.com')
 			],
 			[
@@ -134,7 +134,7 @@ class UserPluginTest extends TestCase {
 			[
 				'test', false, false, [], [],
 				[
-					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'emailAddress' => 'test@server.com']],
+					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'hasEmailAddress' => true]],
 				], [], true, $this->getUserMock('test', 'Test', 'test@server.com')
 			],
 			[
@@ -154,7 +154,7 @@ class UserPluginTest extends TestCase {
 			[
 				'test', true, true, ['test-group'], [['test-group', 'test', 2, 0, []]],
 				[
-					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'emailAddress' => 'test@server.com']],
+					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'hasEmailAddress' => true]],
 				], [], true, $this->getUserMock('test', 'Test', 'test@server.com')
 			],
 			[
@@ -166,7 +166,7 @@ class UserPluginTest extends TestCase {
 			[
 				'test', true, false, ['test-group'], [['test-group', 'test', 2, 0, []]],
 				[
-					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'emailAddress' => 'test@server.com']],
+					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'hasEmailAddress' => true]],
 				], [], true, $this->getUserMock('test', 'Test', 'test@server.com')
 			],
 			[
@@ -194,7 +194,7 @@ class UserPluginTest extends TestCase {
 				],
 				[],
 				[
-					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'emailAddress' => 'test1@server.com']],
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'hasEmailAddress' => true]],
 				],
 				true,
 				false,
@@ -240,8 +240,8 @@ class UserPluginTest extends TestCase {
 				],
 				[],
 				[
-					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'emailAddress' => 'test1@server.com']],
-					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2', 'emailAddress' => 'test2@server.com']],
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'hasEmailAddress' => true]],
+					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2', 'hasEmailAddress' => true]],
 				],
 				false,
 				false,
@@ -291,11 +291,11 @@ class UserPluginTest extends TestCase {
 					$this->getUserMock('test2', 'Test Two', 'test2@server.com'),
 				],
 				[
-					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test0', 'emailAddress' => 'test0@server.com']],
+					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test0', 'hasEmailAddress' => true]],
 				],
 				[
-					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'emailAddress' => 'test1@server.com']],
-					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2', 'emailAddress' => 'test2@server.com']],
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'hasEmailAddress' => true]],
+					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2', 'hasEmailAddress' => true]],
 				],
 				false,
 				false,
@@ -328,7 +328,7 @@ class UserPluginTest extends TestCase {
 					$this->getUserMock('test2', 'Test Two', 'test2@server.com'),
 				],
 				[
-					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test0', 'emailAddress' => 'test0@server.com']],
+					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test0', 'hasEmailAddress' => true]],
 				],
 				[],
 				true,
@@ -361,7 +361,7 @@ class UserPluginTest extends TestCase {
 				],
 				[],
 				[
-					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'emailAddress' => 'test1@server.com']],
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'hasEmailAddress' => true]],
 				],
 				true,
 				false,
@@ -420,8 +420,8 @@ class UserPluginTest extends TestCase {
 				],
 				[],
 				[
-					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'emailAddress' => 'test1@server.com']],
-					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2', 'emailAddress' => 'test2@server.com']],
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'hasEmailAddress' => true]],
+					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2', 'hasEmailAddress' => true]],
 				],
 				false,
 				false,
@@ -482,10 +482,10 @@ class UserPluginTest extends TestCase {
 					]],
 				],
 				[
-					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'emailAddress' => 'test@server.com']],
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'hasEmailAddress' => true]],
 				],
 				[
-					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2', 'emailAddress' => 'test2@server.com']],
+					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2', 'hasEmailAddress' => true]],
 				],
 				false,
 				false,
@@ -524,7 +524,7 @@ class UserPluginTest extends TestCase {
 					]],
 				],
 				[
-					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'emailAddress' => 'test@server.com']],
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'hasEmailAddress' => true]],
 				],
 				[],
 				true,

--- a/tests/lib/Collaboration/Collaborators/UserPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/UserPluginTest.php
@@ -89,7 +89,7 @@ class UserPluginTest extends TestCase {
 		);
 	}
 
-	public function getUserMock($uid, $displayName) {
+	public function getUserMock($uid, $displayName, $emailAddress = '') {
 		$user = $this->createMock(IUser::class);
 
 		$user->expects($this->any())
@@ -99,6 +99,10 @@ class UserPluginTest extends TestCase {
 		$user->expects($this->any())
 			->method('getDisplayName')
 			->willReturn($displayName);
+
+		$user->expects($this->any())
+			->method('getEMailAddress')
+			->willReturn($emailAddress);
 
 		return $user;
 	}
@@ -116,10 +120,22 @@ class UserPluginTest extends TestCase {
 				], [], true, $this->getUserMock('test', 'Test')
 			],
 			[
+				'test', false, true, [], [],
+				[
+					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'emailAddress' => 'test@server.com']],
+				], [], true, $this->getUserMock('test', 'Test', 'test@server.com')
+			],
+			[
 				'test', false, false, [], [],
 				[
 					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test']],
 				], [], true, $this->getUserMock('test', 'Test')
+			],
+			[
+				'test', false, false, [], [],
+				[
+					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'emailAddress' => 'test@server.com']],
+				], [], true, $this->getUserMock('test', 'Test', 'test@server.com')
 			],
 			[
 				'test', true, true, [], [],
@@ -136,12 +152,24 @@ class UserPluginTest extends TestCase {
 				], [], true, $this->getUserMock('test', 'Test')
 			],
 			[
+				'test', true, true, ['test-group'], [['test-group', 'test', 2, 0, []]],
+				[
+					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'emailAddress' => 'test@server.com']],
+				], [], true, $this->getUserMock('test', 'Test', 'test@server.com')
+			],
+			[
 				'test', true, false, ['test-group'], [['test-group', 'test', 2, 0, []]],
 				[
 					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test']],
 				], [], true, $this->getUserMock('test', 'Test')
 			],
 			[
+				'test', true, false, ['test-group'], [['test-group', 'test', 2, 0, []]],
+				[
+					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'emailAddress' => 'test@server.com']],
+				], [], true, $this->getUserMock('test', 'Test', 'test@server.com')
+			],
+			[
 				'test',
 				false,
 				true,
@@ -152,6 +180,21 @@ class UserPluginTest extends TestCase {
 				[],
 				[
 					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1']],
+				],
+				true,
+				false,
+			],
+			[
+				'test',
+				false,
+				true,
+				[],
+				[
+					$this->getUserMock('test1', 'Test One', 'test1@server.com'),
+				],
+				[],
+				[
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'emailAddress' => 'test1@server.com']],
 				],
 				true,
 				false,
@@ -182,6 +225,23 @@ class UserPluginTest extends TestCase {
 				[
 					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1']],
 					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2']],
+				],
+				false,
+				false,
+			],
+			[
+				'test',
+				false,
+				true,
+				[],
+				[
+					$this->getUserMock('test1', 'Test One', 'test1@server.com'),
+					$this->getUserMock('test2', 'Test Two', 'test2@server.com'),
+				],
+				[],
+				[
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'emailAddress' => 'test1@server.com']],
+					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2', 'emailAddress' => 'test2@server.com']],
 				],
 				false,
 				false,
@@ -223,6 +283,26 @@ class UserPluginTest extends TestCase {
 			[
 				'test',
 				false,
+				true,
+				[],
+				[
+					$this->getUserMock('test0', 'Test', 'test0@server.com'),
+					$this->getUserMock('test1', 'Test One', 'test1@server.com'),
+					$this->getUserMock('test2', 'Test Two', 'test2@server.com'),
+				],
+				[
+					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test0', 'emailAddress' => 'test0@server.com']],
+				],
+				[
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'emailAddress' => 'test1@server.com']],
+					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2', 'emailAddress' => 'test2@server.com']],
+				],
+				false,
+				false,
+			],
+			[
+				'test',
+				false,
 				false,
 				[],
 				[
@@ -232,6 +312,23 @@ class UserPluginTest extends TestCase {
 				],
 				[
 					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test0']],
+				],
+				[],
+				true,
+				false,
+			],
+			[
+				'test',
+				false,
+				false,
+				[],
+				[
+					$this->getUserMock('test0', 'Test', 'test0@server.com'),
+					$this->getUserMock('test1', 'Test One', 'test1@server.com'),
+					$this->getUserMock('test2', 'Test Two', 'test2@server.com'),
+				],
+				[
+					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test0', 'emailAddress' => 'test0@server.com']],
 				],
 				[],
 				true,
@@ -249,6 +346,22 @@ class UserPluginTest extends TestCase {
 				[],
 				[
 					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1']],
+				],
+				true,
+				false,
+			],
+			[
+				'test',
+				true,
+				true,
+				['abc', 'xyz'],
+				[
+					['abc', 'test', 2, 0, ['test1' => $this->getUserMock('test1', 'Test One', 'test1@server.com')]],
+					['xyz', 'test', 2, 0, []],
+				],
+				[],
+				[
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'emailAddress' => 'test1@server.com']],
 				],
 				true,
 				false,
@@ -286,6 +399,29 @@ class UserPluginTest extends TestCase {
 				[
 					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1']],
 					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2']],
+				],
+				false,
+				false,
+			],
+			[
+				'test',
+				true,
+				true,
+				['abc', 'xyz'],
+				[
+					['abc', 'test', 2, 0, [
+						'test1' => $this->getUserMock('test1', 'Test One', 'test1@server.com'),
+						'test2' => $this->getUserMock('test2', 'Test Two', 'test2@server.com'),
+					]],
+					['xyz', 'test', 2, 0, [
+						'test1' => $this->getUserMock('test1', 'Test One', 'test1@server.com'),
+						'test2' => $this->getUserMock('test2', 'Test Two', 'test2@server.com'),
+					]],
+				],
+				[],
+				[
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'emailAddress' => 'test1@server.com']],
+					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2', 'emailAddress' => 'test2@server.com']],
 				],
 				false,
 				false,
@@ -335,6 +471,28 @@ class UserPluginTest extends TestCase {
 			[
 				'test',
 				true,
+				true,
+				['abc', 'xyz'],
+				[
+					['abc', 'test', 2, 0, [
+						'test' => $this->getUserMock('test', 'Test One', 'test@server.com'),
+					]],
+					['xyz', 'test', 2, 0, [
+						'test2' => $this->getUserMock('test2', 'Test Two', 'test2@server.com'),
+					]],
+				],
+				[
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'emailAddress' => 'test@server.com']],
+				],
+				[
+					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2', 'emailAddress' => 'test2@server.com']],
+				],
+				false,
+				false,
+			],
+			[
+				'test',
+				true,
 				false,
 				['abc', 'xyz'],
 				[
@@ -347,6 +505,26 @@ class UserPluginTest extends TestCase {
 				],
 				[
 					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test']],
+				],
+				[],
+				true,
+				false,
+			],
+			[
+				'test',
+				true,
+				false,
+				['abc', 'xyz'],
+				[
+					['abc', 'test', 2, 0, [
+						'test' => $this->getUserMock('test', 'Test One', 'test@server.com'),
+					]],
+					['xyz', 'test', 2, 0, [
+						'test2' => $this->getUserMock('test2', 'Test Two', 'test2@server.com'),
+					]],
+				],
+				[
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'emailAddress' => 'test@server.com']],
 				],
 				[],
 				true,

--- a/tests/lib/Collaboration/Collaborators/UserPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/UserPluginTest.php
@@ -243,7 +243,7 @@ class UserPluginTest extends TestCase {
 				true,
 				['abc', 'xyz'],
 				[
-					['abc', 'test', 2, 0, ['test1' => 'Test One']],
+					['abc', 'test', 2, 0, ['test1' => $this->getUserMock('test1', 'Test One')]],
 					['xyz', 'test', 2, 0, []],
 				],
 				[],
@@ -259,7 +259,7 @@ class UserPluginTest extends TestCase {
 				false,
 				['abc', 'xyz'],
 				[
-					['abc', 'test', 2, 0, ['test1' => 'Test One']],
+					['abc', 'test', 2, 0, ['test1' => $this->getUserMock('test1', 'Test One')]],
 					['xyz', 'test', 2, 0, []],
 				],
 				[],
@@ -274,12 +274,12 @@ class UserPluginTest extends TestCase {
 				['abc', 'xyz'],
 				[
 					['abc', 'test', 2, 0, [
-						'test1' => 'Test One',
-						'test2' => 'Test Two',
+						'test1' => $this->getUserMock('test1', 'Test One'),
+						'test2' => $this->getUserMock('test2', 'Test Two'),
 					]],
 					['xyz', 'test', 2, 0, [
-						'test1' => 'Test One',
-						'test2' => 'Test Two',
+						'test1' => $this->getUserMock('test1', 'Test One'),
+						'test2' => $this->getUserMock('test2', 'Test Two'),
 					]],
 				],
 				[],
@@ -297,12 +297,12 @@ class UserPluginTest extends TestCase {
 				['abc', 'xyz'],
 				[
 					['abc', 'test', 2, 0, [
-						'test1' => 'Test One',
-						'test2' => 'Test Two',
+						'test1' => $this->getUserMock('test1', 'Test One'),
+						'test2' => $this->getUserMock('test2', 'Test Two'),
 					]],
 					['xyz', 'test', 2, 0, [
-						'test1' => 'Test One',
-						'test2' => 'Test Two',
+						'test1' => $this->getUserMock('test1', 'Test One'),
+						'test2' => $this->getUserMock('test2', 'Test Two'),
 					]],
 				],
 				[],
@@ -317,10 +317,10 @@ class UserPluginTest extends TestCase {
 				['abc', 'xyz'],
 				[
 					['abc', 'test', 2, 0, [
-						'test' => 'Test One',
+						'test' => $this->getUserMock('test', 'Test One'),
 					]],
 					['xyz', 'test', 2, 0, [
-						'test2' => 'Test Two',
+						'test2' => $this->getUserMock('test2', 'Test Two'),
 					]],
 				],
 				[
@@ -339,10 +339,10 @@ class UserPluginTest extends TestCase {
 				['abc', 'xyz'],
 				[
 					['abc', 'test', 2, 0, [
-						'test' => 'Test One',
+						'test' => $this->getUserMock('test', 'Test One'),
 					]],
 					['xyz', 'test', 2, 0, [
-						'test2' => 'Test Two',
+						'test2' => $this->getUserMock('test2', 'Test Two'),
 					]],
 				],
 				[
@@ -422,7 +422,7 @@ class UserPluginTest extends TestCase {
 			}
 
 			$this->groupManager->expects($this->exactly(sizeof($groupResponse)))
-				->method('displayNamesInGroup')
+				->method('usersInGroup')
 				->with($this->anything(), $searchTerm, $this->limit, $this->offset)
 				->willReturnMap($userResponse);
 		}


### PR DESCRIPTION
When a file is shared with a user and that user has an e-mail set in her profile a mail notification is sent to that e-mail. However, once a file has been shared there is currently no way to send again that e-mail notification if needed for any reason.

Users that are already sharees are no longer shown in the share dropdown, so one option could be to provide an additional action in the share menu; however, although this would work for a small list of sharees it could be slow if there are a lot of them. Therefore, instead of adding an action in the share menu, the share dropdown was modified so if a user is already a sharee and she has an e-mail set in her profile then the user will appear in the dropdown and clicking on it will send again the e-mail notification.

In the example screenshot below _user0_ has an e-mail address set in the profile while _user1_ does not:
![share-dropdown](https://user-images.githubusercontent.com/26858233/29751956-5648ab6e-8b55-11e7-8f51-4b9917211e32.png)

Note that this applies only to shares to another user; shares to an e-mail address are not taken into account here, as they use a different workflow.

Although sending the e-mail should work (as I just copied some code from the `createShares`) __it should be explicitly tested__, as I could not do that yet. In the same way __please review the PHP changes carefully__, as I am not familiar with the area that I had to modify to get this working.
