### PR TITLE
add a new dav event to allow apps to register their own sabredav plugins

### DIFF
--- a/apps/dav/appinfo/v1/webdav.php
+++ b/apps/dav/appinfo/v1/webdav.php
@@ -67,5 +67,10 @@ $server = $serverFactory->createServer($baseuri, $requestUri, $authPlugin, funct
 	return \OC\Files\Filesystem::getView();
 });
 
+$dispatcher = \OC::$server->getEventDispatcher();
+// allow setup of additional plugins
+$event = new \OCP\SabrePluginEvent($server);
+$dispatcher->dispatch('OCA\DAV\Connector\Sabre::addPlugin', $event);
+
 // And off we go!
 $server->exec();

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -163,6 +163,9 @@ class Server {
 
 		$this->server->addPlugin(new CopyEtagHeaderPlugin());
 
+		// allow setup of additional plugins
+		$dispatcher->dispatch('OCA\DAV\Connector\Sabre::addPlugin', $event);
+
 		// Some WebDAV clients do require Class 2 WebDAV support (locking), since
 		// we do not provide locking we emulate it using a fake locking plugin.
 		if($request->isUserAgent([


### PR DESCRIPTION
@rullzer @LukasReschke please review

I could also use the 'OCA\DAV\Connector\Sabre::authInit' in L103 but it feels wrong to use the "authInit" event to register a plugin.