### PR TITLE
Resend notification email

### DIFF
--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -69,6 +69,11 @@ return [
 			'verb' => 'POST',
 		],
 		[
+			'name' => 'ShareAPI#resendMailNotification',
+			'url'  => '/api/v1/shares/{id}/resendMailNotification',
+			'verb' => 'POST',
+		],
+		[
 			'name' => 'ShareAPI#getShare',
 			'url'  => '/api/v1/shares/{id}',
 			'verb' => 'GET',

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -486,6 +486,31 @@ class ShareAPIController extends OCSController {
 	}
 
 	/**
+	 * Sends again the e-mail notification for a share
+	 *
+	 * @NoAdminRequired
+	 *
+	 * @param string $id
+	 * @return DataResponse
+	 * @throws OCSNotFoundException
+	 */
+	public function resendMailNotification($id) {
+		try {
+			$share = $this->getShareById($id);
+		} catch (ShareNotFound $e) {
+			throw new OCSNotFoundException($this->l->t('Wrong share ID, share doesn\'t exist', $id));
+		}
+
+		if (!$this->canAccessShare($share)) {
+			throw new OCSNotFoundException($this->l->t('Wrong share ID, share doesn\'t exist', $id));
+		}
+
+		$this->shareManager->resendMailNotification($share);
+
+		return new DataResponse();
+	}
+
+	/**
 	 * @param \OCP\Files\File|\OCP\Files\Folder $node
 	 * @param boolean $includeTags
 	 * @return DataResponse

--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -181,21 +181,23 @@ class ShareesAPIController extends OCSController {
 				if (strtolower($uid) === $lowerSearch) {
 					$foundUserById = true;
 				}
-				$this->result['exact']['users'][] = [
+				$userData = [
 					'label' => $userDisplayName,
 					'value' => [
 						'shareType' => Share::SHARE_TYPE_USER,
 						'shareWith' => $uid,
 					],
 				];
+				$this->result['exact']['users'][] = $userData;
 			} else {
-				$this->result['users'][] = [
+				$userData = [
 					'label' => $userDisplayName,
 					'value' => [
 						'shareType' => Share::SHARE_TYPE_USER,
 						'shareWith' => $uid,
 					],
 				];
+				$this->result['users'][] = $userData;
 			}
 		}
 
@@ -213,13 +215,14 @@ class ShareesAPIController extends OCSController {
 				}
 
 				if ($addUser) {
-					array_push($this->result['exact']['users'], [
+					$userData = [
 						'label' => $user->getDisplayName(),
 						'value' => [
 							'shareType' => Share::SHARE_TYPE_USER,
 							'shareWith' => $user->getUID(),
 						],
-					]);
+					];
+					$this->result['exact']['users'][] = $userData;
 				}
 			}
 		}

--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -188,6 +188,9 @@ class ShareesAPIController extends OCSController {
 						'shareWith' => $uid,
 					],
 				];
+				if ($user->getEMailAddress()) {
+					$userData['value']['emailAddress'] = $user->getEMailAddress();
+				}
 				$this->result['exact']['users'][] = $userData;
 			} else {
 				$userData = [
@@ -197,6 +200,9 @@ class ShareesAPIController extends OCSController {
 						'shareWith' => $uid,
 					],
 				];
+				if ($user->getEMailAddress()) {
+					$userData['value']['emailAddress'] = $user->getEMailAddress();
+				}
 				$this->result['users'][] = $userData;
 			}
 		}
@@ -222,6 +228,9 @@ class ShareesAPIController extends OCSController {
 							'shareWith' => $user->getUID(),
 						],
 					];
+					if ($user->getEMailAddress()) {
+						$userData['value']['emailAddress'] = $user->getEMailAddress();
+					}
 					$this->result['exact']['users'][] = $userData;
 				}
 			}

--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -156,9 +156,9 @@ class ShareesAPIController extends OCSController {
 			// Search in all the groups this user is part of
 			$userGroups = $this->groupManager->getUserGroupIds($this->userSession->getUser());
 			foreach ($userGroups as $userGroup) {
-				$usersTmp = $this->groupManager->displayNamesInGroup($userGroup, $search, $this->limit, $this->offset);
-				foreach ($usersTmp as $uid => $userDisplayName) {
-					$users[$uid] = $userDisplayName;
+				$usersTmp = $this->groupManager->usersInGroup($userGroup, $search, $this->limit, $this->offset);
+				foreach ($usersTmp as $uid => $user) {
+					$users[$uid] = $user;
 				}
 			}
 		} else {
@@ -166,7 +166,7 @@ class ShareesAPIController extends OCSController {
 			$usersTmp = $this->userManager->searchDisplayName($search, $this->limit, $this->offset);
 
 			foreach ($usersTmp as $user) {
-				$users[$user->getUID()] = $user->getDisplayName();
+				$users[$user->getUID()] = $user;
 			}
 		}
 
@@ -176,13 +176,13 @@ class ShareesAPIController extends OCSController {
 
 		$foundUserById = false;
 		$lowerSearch = strtolower($search);
-		foreach ($users as $uid => $userDisplayName) {
-			if (strtolower($uid) === $lowerSearch || strtolower($userDisplayName) === $lowerSearch) {
+		foreach ($users as $uid => $user) {
+			if (strtolower($uid) === $lowerSearch || strtolower($user->getDisplayName()) === $lowerSearch) {
 				if (strtolower($uid) === $lowerSearch) {
 					$foundUserById = true;
 				}
 				$userData = [
-					'label' => $userDisplayName,
+					'label' => $user->getDisplayName(),
 					'value' => [
 						'shareType' => Share::SHARE_TYPE_USER,
 						'shareWith' => $uid,
@@ -191,7 +191,7 @@ class ShareesAPIController extends OCSController {
 				$this->result['exact']['users'][] = $userData;
 			} else {
 				$userData = [
-					'label' => $userDisplayName,
+					'label' => $user->getDisplayName(),
 					'value' => [
 						'shareType' => Share::SHARE_TYPE_USER,
 						'shareWith' => $uid,

--- a/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
@@ -119,9 +119,10 @@ class ShareesAPIControllerTest extends TestCase {
 	/**
 	 * @param string $uid
 	 * @param string $displayName
+	 * @param string $emailAddress
 	 * @return \OCP\IUser|\PHPUnit_Framework_MockObject_MockObject
 	 */
-	protected function getUserMock($uid, $displayName) {
+	protected function getUserMock($uid, $displayName, $emailAddress = '') {
 		$user = $this->getMockBuilder('OCP\IUser')
 			->disableOriginalConstructor()
 			->getMock();
@@ -133,6 +134,10 @@ class ShareesAPIControllerTest extends TestCase {
 		$user->expects($this->any())
 			->method('getDisplayName')
 			->willReturn($displayName);
+
+		$user->expects($this->any())
+			->method('getEMailAddress')
+			->willReturn($emailAddress);
 
 		return $user;
 	}
@@ -175,10 +180,22 @@ class ShareesAPIControllerTest extends TestCase {
 				], [], true, $this->getUserMock('test', 'Test')
 			],
 			[
+				'test', false, true, [], [],
+				[
+					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'emailAddress' => 'test@server.com']],
+				], [], true, $this->getUserMock('test', 'Test', 'test@server.com')
+			],
+			[
 				'test', false, false, [], [],
 				[
 					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test']],
 				], [], true, $this->getUserMock('test', 'Test')
+			],
+			[
+				'test', false, false, [], [],
+				[
+					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'emailAddress' => 'test@server.com']],
+				], [], true, $this->getUserMock('test', 'Test', 'test@server.com')
 			],
 			[
 				'test', true, true, [], [],
@@ -195,12 +212,24 @@ class ShareesAPIControllerTest extends TestCase {
 				], [], true, $this->getUserMock('test', 'Test')
 			],
 			[
+				'test', true, true, ['test-group'], [['test-group', 'test', 2, 0, []]],
+				[
+					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'emailAddress' => 'test@server.com']],
+				], [], true, $this->getUserMock('test', 'Test', 'test@server.com')
+			],
+			[
 				'test', true, false, ['test-group'], [['test-group', 'test', 2, 0, []]],
 				[
 					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test']],
 				], [], true, $this->getUserMock('test', 'Test')
 			],
 			[
+				'test', true, false, ['test-group'], [['test-group', 'test', 2, 0, []]],
+				[
+					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'emailAddress' => 'test@server.com']],
+				], [], true, $this->getUserMock('test', 'Test', 'test@server.com')
+			],
+			[
 				'test',
 				false,
 				true,
@@ -211,6 +240,21 @@ class ShareesAPIControllerTest extends TestCase {
 				[],
 				[
 					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1']],
+				],
+				true,
+				false,
+			],
+			[
+				'test',
+				false,
+				true,
+				[],
+				[
+					$this->getUserMock('test1', 'Test One', 'test1@server.com'),
+				],
+				[],
+				[
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'emailAddress' => 'test1@server.com']],
 				],
 				true,
 				false,
@@ -241,6 +285,23 @@ class ShareesAPIControllerTest extends TestCase {
 				[
 					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1']],
 					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2']],
+				],
+				false,
+				false,
+			],
+			[
+				'test',
+				false,
+				true,
+				[],
+				[
+					$this->getUserMock('test1', 'Test One', 'test1@server.com'),
+					$this->getUserMock('test2', 'Test Two', 'test2@server.com'),
+				],
+				[],
+				[
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'emailAddress' => 'test1@server.com']],
+					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2', 'emailAddress' => 'test2@server.com']],
 				],
 				false,
 				false,
@@ -282,6 +343,26 @@ class ShareesAPIControllerTest extends TestCase {
 			[
 				'test',
 				false,
+				true,
+				[],
+				[
+					$this->getUserMock('test0', 'Test', 'test0@server.com'),
+					$this->getUserMock('test1', 'Test One', 'test1@server.com'),
+					$this->getUserMock('test2', 'Test Two', 'test2@server.com'),
+				],
+				[
+					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test0', 'emailAddress' => 'test0@server.com']],
+				],
+				[
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'emailAddress' => 'test1@server.com']],
+					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2', 'emailAddress' => 'test2@server.com']],
+				],
+				false,
+				false,
+			],
+			[
+				'test',
+				false,
 				false,
 				[],
 				[
@@ -291,6 +372,23 @@ class ShareesAPIControllerTest extends TestCase {
 				],
 				[
 					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test0']],
+				],
+				[],
+				true,
+				false,
+			],
+			[
+				'test',
+				false,
+				false,
+				[],
+				[
+					$this->getUserMock('test0', 'Test', 'test0@server.com'),
+					$this->getUserMock('test1', 'Test One', 'test1@server.com'),
+					$this->getUserMock('test2', 'Test Two', 'test2@server.com'),
+				],
+				[
+					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test0', 'emailAddress' => 'test0@server.com']],
 				],
 				[],
 				true,
@@ -308,6 +406,22 @@ class ShareesAPIControllerTest extends TestCase {
 				[],
 				[
 					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1']],
+				],
+				true,
+				false,
+			],
+			[
+				'test',
+				true,
+				true,
+				['abc', 'xyz'],
+				[
+					['abc', 'test', 2, 0, ['test1' => $this->getUserMock('test1', 'Test One', 'test1@server.com')]],
+					['xyz', 'test', 2, 0, []],
+				],
+				[],
+				[
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'emailAddress' => 'test1@server.com']],
 				],
 				true,
 				false,
@@ -345,6 +459,29 @@ class ShareesAPIControllerTest extends TestCase {
 				[
 					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1']],
 					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2']],
+				],
+				false,
+				false,
+			],
+			[
+				'test',
+				true,
+				true,
+				['abc', 'xyz'],
+				[
+					['abc', 'test', 2, 0, [
+						'test1' => $this->getUserMock('test1', 'Test One', 'test1@server.com'),
+						'test2' => $this->getUserMock('test2', 'Test Two', 'test2@server.com'),
+					]],
+					['xyz', 'test', 2, 0, [
+						'test1' => $this->getUserMock('test1', 'Test One', 'test1@server.com'),
+						'test2' => $this->getUserMock('test2', 'Test Two', 'test2@server.com'),
+					]],
+				],
+				[],
+				[
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test1', 'emailAddress' => 'test1@server.com']],
+					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2', 'emailAddress' => 'test2@server.com']],
 				],
 				false,
 				false,
@@ -394,6 +531,28 @@ class ShareesAPIControllerTest extends TestCase {
 			[
 				'test',
 				true,
+				true,
+				['abc', 'xyz'],
+				[
+					['abc', 'test', 2, 0, [
+						'test' => $this->getUserMock('test', 'Test One', 'test@server.com'),
+					]],
+					['xyz', 'test', 2, 0, [
+						'test2' => $this->getUserMock('test2', 'Test Two', 'test2@server.com'),
+					]],
+				],
+				[
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'emailAddress' => 'test@server.com']],
+				],
+				[
+					['label' => 'Test Two', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test2', 'emailAddress' => 'test2@server.com']],
+				],
+				false,
+				false,
+			],
+			[
+				'test',
+				true,
 				false,
 				['abc', 'xyz'],
 				[
@@ -406,6 +565,26 @@ class ShareesAPIControllerTest extends TestCase {
 				],
 				[
 					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test']],
+				],
+				[],
+				true,
+				false,
+			],
+			[
+				'test',
+				true,
+				false,
+				['abc', 'xyz'],
+				[
+					['abc', 'test', 2, 0, [
+						'test' => $this->getUserMock('test', 'Test One', 'test@server.com'),
+					]],
+					['xyz', 'test', 2, 0, [
+						'test2' => $this->getUserMock('test2', 'Test Two', 'test2@server.com'),
+					]],
+				],
+				[
+					['label' => 'Test One', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test', 'emailAddress' => 'test@server.com']],
 				],
 				[],
 				true,

--- a/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
@@ -302,7 +302,7 @@ class ShareesAPIControllerTest extends TestCase {
 				true,
 				['abc', 'xyz'],
 				[
-					['abc', 'test', 2, 0, ['test1' => 'Test One']],
+					['abc', 'test', 2, 0, ['test1' => $this->getUserMock('test1', 'Test One')]],
 					['xyz', 'test', 2, 0, []],
 				],
 				[],
@@ -318,7 +318,7 @@ class ShareesAPIControllerTest extends TestCase {
 				false,
 				['abc', 'xyz'],
 				[
-					['abc', 'test', 2, 0, ['test1' => 'Test One']],
+					['abc', 'test', 2, 0, ['test1' => $this->getUserMock('test1', 'Test One')]],
 					['xyz', 'test', 2, 0, []],
 				],
 				[],
@@ -333,12 +333,12 @@ class ShareesAPIControllerTest extends TestCase {
 				['abc', 'xyz'],
 				[
 					['abc', 'test', 2, 0, [
-						'test1' => 'Test One',
-						'test2' => 'Test Two',
+						'test1' => $this->getUserMock('test1', 'Test One'),
+						'test2' => $this->getUserMock('test2', 'Test Two'),
 					]],
 					['xyz', 'test', 2, 0, [
-						'test1' => 'Test One',
-						'test2' => 'Test Two',
+						'test1' => $this->getUserMock('test1', 'Test One'),
+						'test2' => $this->getUserMock('test2', 'Test Two'),
 					]],
 				],
 				[],
@@ -356,12 +356,12 @@ class ShareesAPIControllerTest extends TestCase {
 				['abc', 'xyz'],
 				[
 					['abc', 'test', 2, 0, [
-						'test1' => 'Test One',
-						'test2' => 'Test Two',
+						'test1' => $this->getUserMock('test1', 'Test One'),
+						'test2' => $this->getUserMock('test2', 'Test Two'),
 					]],
 					['xyz', 'test', 2, 0, [
-						'test1' => 'Test One',
-						'test2' => 'Test Two',
+						'test1' => $this->getUserMock('test1', 'Test One'),
+						'test2' => $this->getUserMock('test2', 'Test Two'),
 					]],
 				],
 				[],
@@ -376,10 +376,10 @@ class ShareesAPIControllerTest extends TestCase {
 				['abc', 'xyz'],
 				[
 					['abc', 'test', 2, 0, [
-						'test' => 'Test One',
+						'test' => $this->getUserMock('test', 'Test One'),
 					]],
 					['xyz', 'test', 2, 0, [
-						'test2' => 'Test Two',
+						'test2' => $this->getUserMock('test2', 'Test Two'),
 					]],
 				],
 				[
@@ -398,10 +398,10 @@ class ShareesAPIControllerTest extends TestCase {
 				['abc', 'xyz'],
 				[
 					['abc', 'test', 2, 0, [
-						'test' => 'Test One',
+						'test' => $this->getUserMock('test', 'Test One'),
 					]],
 					['xyz', 'test', 2, 0, [
-						'test2' => 'Test Two',
+						'test2' => $this->getUserMock('test2', 'Test Two'),
 					]],
 				],
 				[
@@ -460,7 +460,7 @@ class ShareesAPIControllerTest extends TestCase {
 			}
 
 			$this->groupManager->expects($this->exactly(sizeof($groupResponse)))
-				->method('displayNamesInGroup')
+				->method('usersInGroup')
 				->with($this->anything(), $searchTerm, $this->invokePrivate($this->sharees, 'limit'), $this->invokePrivate($this->sharees, 'offset'))
 				->willReturnMap($userResponse);
 		}

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -313,14 +313,14 @@ class Manager extends PublicEmitter implements IGroupManager {
 	}
 
 	/**
-	 * get a list of all display names in a group
+	 * get a list of all users in a group
 	 * @param string $gid
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
-	 * @return array an array of display names (value) and user ids (key)
+	 * @return array an array of users (value) and user ids (key)
 	 */
-	public function displayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0) {
+	public function usersInGroup($gid, $search = '', $limit = -1, $offset = 0) {
 		$group = $this->get($gid);
 		if(is_null($group)) {
 			return array();
@@ -358,7 +358,23 @@ class Manager extends PublicEmitter implements IGroupManager {
 
 		$matchingUsers = array();
 		foreach($groupUsers as $groupUser) {
-			$matchingUsers[$groupUser->getUID()] = $groupUser->getDisplayName();
+			$matchingUsers[$groupUser->getUID()] = $groupUser;
+		}
+		return $matchingUsers;
+	}
+
+	/**
+	 * get a list of all display names in a group
+	 * @param string $gid
+	 * @param string $search
+	 * @param int $limit
+	 * @param int $offset
+	 * @return array an array of display names (value) and user ids (key)
+	 */
+	public function displayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0) {
+		$matchingUsers = array();
+		foreach($this->usersInGroup($gid, $search, $limit, $offset) as $uid => $user) {
+			$matchingUsers[$uid] = $user->getDisplayName();
 		}
 		return $matchingUsers;
 	}

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -678,6 +678,39 @@ class Manager implements IManager {
 	}
 
 	/**
+	 * Sends again the e-mail notification for a share
+	 *
+	 * @param \OCP\Share\IShare $share
+	 * @return \OCP\Share\IShare the share object
+	 * @throws \InvalidArgumentException if share type does not support mail
+	 *         notifications or the sharee has no known e-mail address
+	 * @throws \Exception if mail could not be sent
+	 */
+	public function resendMailNotification(\OCP\Share\IShare $share) {
+		$this->canShare($share);
+
+		if ($share->getShareType() !== \OCP\Share::SHARE_TYPE_USER) {
+			throw new \InvalidArgumentException("Share mail notification can be sent only for user shares");
+		}
+
+		$user = $this->userManager->get($share->getSharedWith());
+		$emailAddress = $user->getEMailAddress();
+
+		if ($emailAddress === null || $emailAddress === '') {
+			throw new \InvalidArgumentException("Share mail notification can not be sent to a user without a mail");
+		}
+
+		$this->sendMailNotification(
+			$share->getNode()->getName(),
+			$this->urlGenerator->linkToRouteAbsolute('files.viewcontroller.showFile', [ 'fileid' => $share->getNode()->getId() ]),
+			$share->getSharedBy(),
+			$emailAddress
+		);
+
+		return $share;
+	}
+
+	/**
 	 * @param string $filename file/folder name
 	 * @param string $link link to the file/folder
 	 * @param string $initiator user ID of share sender

--- a/lib/public/IGroupManager.php
+++ b/lib/public/IGroupManager.php
@@ -110,6 +110,18 @@ interface IGroupManager {
 	public function getUserGroupIds(IUser $user);
 
 	/**
+	 * get a list of all users in a group
+	 *
+	 * @param string $gid
+	 * @param string $search
+	 * @param int $limit
+	 * @param int $offset
+	 * @return array an array of users (value) and user ids (key)
+	 * @since 13.0.0
+	 */
+	public function usersInGroup($gid, $search = '', $limit = -1, $offset = 0);
+
+	/**
 	 * get a list of all display names in a group
 	 *
 	 * @param string $gid

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -45,6 +45,18 @@ interface IManager {
 	public function createShare(IShare $share);
 
 	/**
+	 * Sends again the e-mail notification for a share
+	 *
+	 * @param IShare $share
+	 * @return IShare The share object
+	 * @throws \InvalidArgumentException if share type does not support mail
+	 *         notifications or the sharee has no known e-mail address
+	 * @throws \Exception if mail could not be sent
+	 * @since 13.0.0
+	 */
+	public function resendMailNotification(IShare $share);
+
+	/**
 	 * Update a share.
 	 * The target of the share can't be changed this way: use moveShare
 	 * The share can't be removed this way (permission 0): use deleteShare

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -2004,6 +2004,163 @@ class ManagerTest extends \Test\TestCase {
 		$manager->createShare($share);
 	}
 
+	public function testResendMailNotificationUserType() {
+		$manager = $this->createManagerMock()
+			->setMethods(['canShare', 'sendMailNotification'])
+			->getMock();
+
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn('fileId');
+		$file->method('getName')->willReturn('fileName');
+
+		$share = $this->createShare(null, \OCP\Share::SHARE_TYPE_USER, $file, 'user0', 'sharer', null, null);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getEMailAddress')->willReturn('user0@server.com');
+
+		$this->userManager->method('get')->with('user0')->willReturn($user);
+
+		$manager->expects($this->once())
+			->method('canShare')
+			->with($share)
+			->willReturn(true);
+
+		$this->urlGenerator
+			->method('linkToRouteAbsolute')
+			->with('files.viewcontroller.showFile',
+				   ['fileid' => 'fileId'])
+			->willReturn('absolute/route/to/file');
+
+		$manager->expects($this->once())
+			->method('sendMailNotification')
+			->with('fileName',
+				   'absolute/route/to/file',
+				   'sharer',
+				   'user0@server.com');
+
+		$manager->resendMailNotification($share);
+	}
+
+	public function testResendMailNotificationUserTypeWithoutMail() {
+		$manager = $this->createManagerMock()
+			->setMethods(['canShare', 'sendMailNotification'])
+			->getMock();
+
+		$share = $this->createShare(null, \OCP\Share::SHARE_TYPE_USER, null, 'user0', null, null, null);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getEMailAddress')->willReturn('');
+
+		$this->userManager->method('get')->with('user0')->willReturn($user);
+
+		$manager->expects($this->once())
+			->method('canShare')
+			->with($share)
+			->willReturn(true);
+
+		$manager->expects($this->never())
+			->method('sendMailNotification');
+
+		try {
+			$manager->resendMailNotification($share);
+
+			$this->fail('InvalidArgumentException was not thrown');
+		} catch (\InvalidArgumentException $e) {
+		}
+	}
+
+	public function testResendMailNotificationGroupType() {
+		$manager = $this->createManagerMock()
+			->setMethods(['canShare', 'sendMailNotification'])
+			->getMock();
+
+		$share = $this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, null, null, null, null, null);
+
+		$manager->expects($this->once())
+			->method('canShare')
+			->with($share)
+			->willReturn(true);
+
+		$manager->expects($this->never())
+			->method('sendMailNotification');
+
+		try {
+			$manager->resendMailNotification($share);
+
+			$this->fail('InvalidArgumentException was not thrown');
+		} catch (\InvalidArgumentException $e) {
+		}
+	}
+
+	public function testResendMailNotificationLinkType() {
+		$manager = $this->createManagerMock()
+			->setMethods(['canShare', 'sendMailNotification'])
+			->getMock();
+
+		$share = $this->createShare(null, \OCP\Share::SHARE_TYPE_LINK, null, null, null, null, null);
+
+		$manager->expects($this->once())
+			->method('canShare')
+			->with($share)
+			->willReturn(true);
+
+		$manager->expects($this->never())
+			->method('sendMailNotification');
+
+		try {
+			$manager->resendMailNotification($share);
+
+			$this->fail('InvalidArgumentException was not thrown');
+		} catch (\InvalidArgumentException $e) {
+		}
+	}
+
+	public function testResendMailNotificationRemoteType() {
+		$manager = $this->createManagerMock()
+			->setMethods(['canShare', 'sendMailNotification'])
+			->getMock();
+
+		$share = $this->createShare(null, \OCP\Share::SHARE_TYPE_REMOTE, null, null, null, null, null);
+
+		$manager->expects($this->once())
+			->method('canShare')
+			->with($share)
+			->willReturn(true);
+
+		$manager->expects($this->never())
+			->method('sendMailNotification');
+
+		try {
+			$manager->resendMailNotification($share);
+
+			$this->fail('InvalidArgumentException was not thrown');
+		} catch (\InvalidArgumentException $e) {
+		}
+	}
+
+	public function testResendMailNotificationEmailType() {
+		$manager = $this->createManagerMock()
+			->setMethods(['canShare', 'sendMailNotification'])
+			->getMock();
+
+		$share = $this->createShare(null, \OCP\Share::SHARE_TYPE_EMAIL, null, null, null, null, null);
+
+		$manager->expects($this->once())
+			->method('canShare')
+			->with($share)
+			->willReturn(true);
+
+		$manager->expects($this->never())
+			->method('sendMailNotification');
+
+		try {
+			$manager->resendMailNotification($share);
+
+			$this->fail('InvalidArgumentException was not thrown');
+		} catch (\InvalidArgumentException $e) {
+		}
+	}
+
 	public function testGetSharesBy() {
 		$share = $this->manager->newShare();
 


### PR DESCRIPTION
This is an extract of the PHP backend code for #6276 

I would like to hear your feedback on this. The idea is to have then later an entry in the share list inside of the 3 dots menu that says "resend share notification" and is an way for the sharer to resend the notification. This PR basically is the base for this, to provide the needed API endpoints.

cc @jancborchardt form a UX point of view: does it make sense to introduce such a functionality?

I tested #6276 and it worked fine there. I had a view at the code and it looks fine. 👍 