### PR TITLE
Refactor webroot detection in resource locator

### DIFF
--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -117,38 +117,18 @@ class CSSResourceLocator extends ResourceLocator {
 			parent::append($root, $file, $webRoot, $throw);
 		} else {
 			if (!$webRoot) {
-				$tmpRoot = realpath($root);
-				/*
-				 * traverse the potential web roots upwards in the path
-				 *
-				 * example:
-				 *   - root: /srv/www/apps/myapp
-				 *   - available mappings: ['/srv/www']
-				 *
-				 * First we check if a mapping for /srv/www/apps/myapp is available,
-				 * then /srv/www/apps, /srv/www/apps, /srv/www, ... until we find a
-				 * valid web root
-				 */
-				do {
-					if (isset($this->mapping[$tmpRoot])) {
-						$webRoot = $this->mapping[$tmpRoot];
-						break;
-					}
+				$webRoot = $this->findWebRoot($root);
 
-					if ($tmpRoot === '/') {
-						$webRoot = '';
-						$this->logger->error('ResourceLocator can not find a web root (root: {root}, file: {file}, webRoot: {webRoot}, throw: {throw})', [
-							'app' => 'lib',
-							'root' => $root,
-							'file' => $file,
-							'webRoot' => $webRoot,
-							'throw' => $throw ? 'true' : 'false'
-						]);
-						break;
-					}
-					$tmpRoot = dirname($tmpRoot);
-				} while(true);
-
+				if (!$webRoot) {
+					$webRoot = '';
+					$this->logger->error('ResourceLocator can not find a web root (root: {root}, file: {file}, webRoot: {webRoot}, throw: {throw})', [
+						'app' => 'lib',
+						'root' => $root,
+						'file' => $file,
+						'webRoot' => $webRoot,
+						'throw' => $throw ? 'true' : 'false'
+					]);
+				}
 			}
 
 			if ($throw && $tmpRoot === '/') {

--- a/lib/private/Template/ResourceLocator.php
+++ b/lib/private/Template/ResourceLocator.php
@@ -107,6 +107,50 @@ abstract class ResourceLocator {
 	}
 
 	/**
+	 * Attempt to find the webRoot
+	 *
+	 * traverse the potential web roots upwards in the path
+	 *
+	 * example:
+	 *   - root: /srv/www/apps/myapp
+	 *   - available mappings: ['/srv/www']
+	 *
+	 * First we check if a mapping for /srv/www/apps/myapp is available,
+	 * then /srv/www/apps, /srv/www/apps, /srv/www, ... until we find a
+	 * valid web root
+	 *
+	 * @param string $root
+	 * @return string|null The web root or null on failure
+	 */
+	protected function findWebRoot($root) {
+		$webRoot = null;
+		$tmpRoot = $root;
+
+		while ($webRoot === null) {
+			if (isset($this->mapping[$tmpRoot])) {
+				$webRoot = $this->mapping[$tmpRoot];
+				break;
+			}
+
+			if ($tmpRoot === '/') {
+				break;
+			}
+
+			$tmpRoot = dirname($tmpRoot);
+		}
+
+		if (!$webRoot) {
+			$realpath = realpath($root);
+
+			if ($realpath && ($realpath !== $root)) {
+				return $this->findWebRoot($realpath);
+			}
+		}
+
+		return $webRoot;
+	}
+
+	/**
 	 * append the $file resource at $root
 	 *
 	 * @param string $root path to check
@@ -125,38 +169,18 @@ abstract class ResourceLocator {
 		}
 
 		if (!$webRoot) {
-			$tmpRoot = realpath($root);
-			/*
-			 * traverse the potential web roots upwards in the path
-			 *
-			 * example:
-			 *   - root: /srv/www/apps/myapp
-			 *   - available mappings: ['/srv/www']
-			 *
-			 * First we check if a mapping for /srv/www/apps/myapp is available,
-			 * then /srv/www/apps, /srv/www/apps, /srv/www, ... until we find a
-			 * valid web root
-			 */
-			do {
-				if (isset($this->mapping[$tmpRoot])) {
-					$webRoot = $this->mapping[$tmpRoot];
-					break;
-				}
+			$webRoot = $this->findWebRoot($root);
 
-				if ($tmpRoot === '/') {
-					$webRoot = '';
-					$this->logger->error('ResourceLocator can not find a web root (root: {root}, file: {file}, webRoot: {webRoot}, throw: {throw})', [
-						'app' => 'lib',
-						'root' => $root,
-						'file' => $file,
-						'webRoot' => $webRoot,
-						'throw' => $throw ? 'true' : 'false'
-					]);
-					break;
-				}
-				$tmpRoot = dirname($tmpRoot);
-			} while(true);
-
+			if (!$webRoot) {
+				$webRoot = '';
+				$this->logger->error('ResourceLocator can not find a web root (root: {root}, file: {file}, webRoot: {webRoot}, throw: {throw})', [
+					'app' => 'lib',
+					'root' => $root,
+					'file' => $file,
+					'webRoot' => $webRoot,
+					'throw' => $throw ? 'true' : 'false'
+				]);
+			}
 		}
 		$this->resources[] = array($root, $webRoot, $file);
 


### PR DESCRIPTION
The current implementation breaks installations with symlinks to
directories inside the webroot (i.E. apps).

With this change both variants, directory and symlinks) will be detected
correctly.

Fixes: #6028