### PR TITLE
not to backquote LIMIT on CalDavBackend.php

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -1437,7 +1437,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 			$query = "SELECT `uri`, `operation` FROM `*PREFIX*calendarchanges` WHERE `synctoken` >= ? AND `synctoken` < ? AND `calendarid` = ? ORDER BY `synctoken`";
 			if ($limit>0) {
-				$query.= " `LIMIT` " . (int)$limit;
+				$query.= " LIMIT " . (int)$limit;
 			}
 
 			// Fetching all changes


### PR DESCRIPTION
apps/dav/lib/CalDAV/CalDavBackend.php tries to limit SQL output like
```
`LIMIT`
```
, which seems to be typo.

This `LIMIT` is not column name but a syntax element and must not be quated. This caused error to my environment, using OneCalendar from Windows Store as CalDAV client.