### PR TITLE
Rebuild SCSS files if frontend controller value changes

### DIFF
--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -303,6 +303,7 @@ class SCSSCacher {
 	 * @return string
 	 */
 	private function prependBaseurlPrefix($cssFile) {
-		return md5($this->urlGenerator->getBaseUrl()) . '-' . $cssFile;
+		$frontendController = ($this->config->getSystemValue('htaccess.IgnoreFrontController', false) === true || getenv('front_controller_active') === 'true');
+		return md5($this->urlGenerator->getBaseUrl() . $frontendController) . '-' . $cssFile;
 	}
 }


### PR DESCRIPTION
Otherwise users will need to change a theming value to trigger the rebuild with correctly rebased urls in SCSS files.

fixes #6271