### PR TITLE
Set the meta data before everything

### DIFF
--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -384,8 +384,7 @@ class ShareByMailProvider implements IShareProvider {
 
 		$message = $this->mailer->createMessage();
 
-		$emailTemplate = $this->mailer->createEMailTemplate();
-		$emailTemplate->setMetaData('sharebymail.RecipientNotification', [
+		$emailTemplate = $this->mailer->createEMailTemplate('sharebymail.RecipientNotification', [
 			'filename' => $filename,
 			'link' => $link,
 			'initiator' => $initiatorDisplayName,
@@ -462,8 +461,7 @@ class ShareByMailProvider implements IShareProvider {
 
 		$message = $this->mailer->createMessage();
 
-		$emailTemplate = $this->mailer->createEMailTemplate();
-		$emailTemplate->setMetaData('sharebymail.RecipientPasswordNotification', [
+		$emailTemplate = $this->mailer->createEMailTemplate('sharebymail.RecipientPasswordNotification', [
 			'filename' => $filename,
 			'password' => $password,
 			'initiator' => $initiatorDisplayName,
@@ -530,8 +528,7 @@ class ShareByMailProvider implements IShareProvider {
 		$bodyPart = $this->l->t("You just shared »%s« with %s. The share was already send to the recipient. Due to the security policies defined by the administrator of %s each share needs to be protected by password and it is not allowed to send the password directly to the recipient. Therefore you need to forward the password manually to the recipient.", [$filename, $shareWith, $this->defaults->getName()]);
 
 		$message = $this->mailer->createMessage();
-		$emailTemplate = $this->mailer->createEMailTemplate();
-		$emailTemplate->setMetaData('sharebymail.OwnerPasswordNotification', [
+		$emailTemplate = $this->mailer->createEMailTemplate('sharebymail.OwnerPasswordNotification', [
 			'filename' => $filename,
 			'password' => $password,
 			'initiator' => $initiatorDisplayName,

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -305,8 +305,7 @@ class LostController extends Controller {
 
 		$link = $this->urlGenerator->linkToRouteAbsolute('core.lost.resetform', array('userId' => $user->getUID(), 'token' => $token));
 
-		$emailTemplate = $this->mailer->createEMailTemplate();
-		$emailTemplate->setMetaData('core.ResetPassword', [
+		$emailTemplate = $this->mailer->createEMailTemplate('core.ResetPassword', [
 			'link' => $link,
 		]);
 

--- a/lib/private/Mail/EMailTemplate.php
+++ b/lib/private/Mail/EMailTemplate.php
@@ -342,24 +342,18 @@ EOF;
 	 * @param Defaults $themingDefaults
 	 * @param IURLGenerator $urlGenerator
 	 * @param IL10N $l10n
+	 * @param string $emailId
+	 * @param array $data
 	 */
 	public function __construct(Defaults $themingDefaults,
 								IURLGenerator $urlGenerator,
-								IL10N $l10n) {
+								IL10N $l10n,
+								$emailId,
+								array $data) {
 		$this->themingDefaults = $themingDefaults;
 		$this->urlGenerator = $urlGenerator;
 		$this->l10n = $l10n;
 		$this->htmlBody .= $this->head;
-	}
-
-	/**
-	 * Set meta data of an email
-	 *
-	 * @param string $emailId
-	 * @param array $data
-	 * @since 12.0.3
-	 */
-	public function setMetaData($emailId, array $data = []) {
 		$this->emailId = $emailId;
 		$this->data = $data;
 	}

--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -26,6 +26,7 @@ use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\Mail\IEMailTemplate;
 use OCP\Mail\IMailer;
 use OCP\ILogger;
 
@@ -89,21 +90,33 @@ class Mailer implements IMailer {
 		return new Message(new \Swift_Message());
 	}
 
-	public function createEMailTemplate() {
+	/**
+	 * Creates a new email template object
+	 *
+	 * @param string $emailId
+	 * @param array $data
+	 * @return IEMailTemplate
+	 * @since 12.0.0
+	 */
+	public function createEMailTemplate($emailId, array $data = []) {
 		$class = $this->config->getSystemValue('mail_template_class', '');
 
 		if ($class !== '' && class_exists($class) && is_a($class, EMailTemplate::class, true)) {
 			return new $class(
 				$this->defaults,
 				$this->urlGenerator,
-				$this->l10n
+				$this->l10n,
+				$emailId,
+				$data
 			);
 		}
 
 		return new EMailTemplate(
 			$this->defaults,
 			$this->urlGenerator,
-			$this->l10n
+			$this->l10n,
+			$emailId,
+			$data
 		);
 	}
 

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -696,8 +696,7 @@ class Manager implements IManager {
 
 		$message = $this->mailer->createMessage();
 
-		$emailTemplate = $this->mailer->createEMailTemplate();
-		$emailTemplate->setMetaData('files_sharing.RecipientNotification', [
+		$emailTemplate = $this->mailer->createEMailTemplate('files_sharing.RecipientNotification', [
 			'filename' => $filename,
 			'link' => $link,
 			'initiator' => $initiatorDisplayName,

--- a/lib/public/Mail/IEMailTemplate.php
+++ b/lib/public/Mail/IEMailTemplate.php
@@ -51,12 +51,6 @@ namespace OCP\Mail;
  * @since 12.0.0
  */
 interface IEMailTemplate {
-	/**
-	 * Set meta data of an email
-	 *
-	 * @since 12.0.3
-	 */
-	public function setMetaData($emailId, array $data = []);
 
 	/**
 	 * Adds a header to the email

--- a/lib/public/Mail/IMailer.php
+++ b/lib/public/Mail/IMailer.php
@@ -57,10 +57,12 @@ interface IMailer {
 	/**
 	 * Creates a new email template object
 	 *
+	 * @param string $emailId
+	 * @param array $data
 	 * @return IEMailTemplate
-	 * @since 12.0.0
+	 * @since 12.0.0 Parameters added in 12.0.3
 	 */
-	public function createEMailTemplate();
+	public function createEMailTemplate($emailId, array $data = []);
 
 	/**
 	 * Send the specified message. Also sets the from address to the value defined in config.php

--- a/settings/Controller/MailSettingsController.php
+++ b/settings/Controller/MailSettingsController.php
@@ -147,9 +147,7 @@ class MailSettingsController extends Controller {
 			try {
 				$displayName = $this->userSession->getUser()->getDisplayName();
 
-				$template = $this->mailer->createEMailTemplate();
-
-				$template->setMetaData('settings.TestEmail', [
+				$template = $this->mailer->createEMailTemplate('settings.TestEmail', [
 					'displayname' => $displayName,
 				]);
 

--- a/settings/Hooks.php
+++ b/settings/Hooks.php
@@ -117,8 +117,7 @@ class Hooks {
 		$this->activityManager->publish($event);
 
 		if ($user->getEMailAddress() !== null) {
-			$template = $this->mailer->createEMailTemplate();
-			$template->setMetaData('settings.PasswordChanged', [
+			$template = $this->mailer->createEMailTemplate('settings.PasswordChanged', [
 				'displayname' => $user->getDisplayName(),
 				'emailAddress' => $user->getEMailAddress(),
 				'instanceUrl' => $instanceUrl,
@@ -188,8 +187,7 @@ class Hooks {
 
 
 		if ($oldMailAddress !== null) {
-			$template = $this->mailer->createEMailTemplate();
-			$template->setMetaData('settings.EmailChanged', [
+			$template = $this->mailer->createEMailTemplate('settings.EmailChanged', [
 				'displayname' => $user->getDisplayName(),
 				'newEMailAddress' => $user->getEMailAddress(),
 				'oldEMailAddress' => $oldMailAddress,

--- a/settings/Mailer/NewUserMailHelper.php
+++ b/settings/Mailer/NewUserMailHelper.php
@@ -116,8 +116,7 @@ class NewUserMailHelper {
 		$displayName = $user->getDisplayName();
 		$userId = $user->getUID();
 
-		$emailTemplate = $this->mailer->createEMailTemplate();
-		$emailTemplate->setMetaData('settings.Welcome', [
+		$emailTemplate = $this->mailer->createEMailTemplate('settings.Welcome', [
 			'link' => $link,
 			'displayname' => $displayName,
 			'userid' => $userId,

--- a/settings/Mailer/NewUserMailHelper.php
+++ b/settings/Mailer/NewUserMailHelper.php
@@ -21,7 +21,6 @@
 
 namespace OC\Settings\Mailer;
 
-use OC\Mail\EMailTemplate;
 use OCP\Mail\IEMailTemplate;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Defaults;
@@ -96,7 +95,7 @@ class NewUserMailHelper {
 	/**
 	 * @param IUser $user
 	 * @param bool $generatePasswordResetToken
-	 * @return EMailTemplate
+	 * @return IEMailTemplate
 	 */
 	public function generateTemplate(IUser $user, $generatePasswordResetToken = false) {
 		if ($generatePasswordResetToken) {
@@ -114,11 +113,19 @@ class NewUserMailHelper {
 		} else {
 			$link = $this->urlGenerator->getAbsoluteURL('/');
 		}
-
-		$emailTemplate = $this->mailer->createEMailTemplate();
-		$emailTemplate->addHeader();
 		$displayName = $user->getDisplayName();
 		$userId = $user->getUID();
+
+		$emailTemplate = $this->mailer->createEMailTemplate();
+		$emailTemplate->setMetaData('settings.Welcome', [
+			'link' => $link,
+			'displayname' => $displayName,
+			'userid' => $userId,
+			'instancename' => $this->themingDefaults->getName(),
+			'resetTokenGenerated' => $generatePasswordResetToken,
+		]);
+
+		$emailTemplate->addHeader();
 		if ($displayName === $userId) {
 			$emailTemplate->addHeading($this->l10n->t('Welcome aboard'));
 		} else {
@@ -138,14 +145,6 @@ class NewUserMailHelper {
 			'https://nextcloud.com/install/#install-clients'
 		);
 		$emailTemplate->addFooter();
-
-		$emailTemplate->setMetaData('settings.Welcome', [
-			'link' => $link,
-			'displayname' => $displayName,
-			'userid' => $userId,
-			'instancename' => $this->themingDefaults->getName(),
-			'resetTokenGenerated' => $generatePasswordResetToken,
-		]);
 
 		return $emailTemplate;
 	}

--- a/tests/Settings/Mailer/NewUserMailHelperTest.php
+++ b/tests/Settings/Mailer/NewUserMailHelperTest.php
@@ -66,7 +66,9 @@ class NewUserMailHelperTest extends TestCase {
 		$template = new EMailTemplate(
 			$this->defaults,
 			$this->urlGenerator,
-			$this->l10n
+			$this->l10n,
+			'test.TestTemplate',
+			[]
 		);
 		$this->mailer->method('createEMailTemplate')
 			->will($this->returnValue($template));

--- a/tests/lib/Mail/EMailTemplateTest.php
+++ b/tests/lib/Mail/EMailTemplateTest.php
@@ -49,7 +49,9 @@ class EMailTemplateTest extends TestCase {
 		$this->emailTemplate = new EMailTemplate(
 			$this->defaults,
 			$this->urlGenerator,
-			$this->l10n
+			$this->l10n,
+			'test.TestTemplate',
+			[]
 		);
 	}
 

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -133,6 +133,6 @@ class MailerTest extends TestCase {
 	}
 
 	public function testCreateEMailTemplate() {
-		$this->assertSame(EMailTemplate::class, get_class($this->mailer->createEMailTemplate()));
+		$this->assertSame(EMailTemplate::class, get_class($this->mailer->createEMailTemplate('tests.MailerTest')));
 	}
 }


### PR DESCRIPTION
If the meta data is not set in the beginning customisation can only be done on the final out put method instead of in all of the methods.

While thinking about this. Should we merge the function into the `createEMailTemplate` function and the constructor?