### PR TITLE
\OC\Settings\Personal: Emit 'preRenderForm' event before rendering the personal settings form

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1001,6 +1001,10 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getThemingDefaults(),
 				$c->getAppManager()
 			);
+			$manager->listen('\OC\Settings\Personal', 'preFormRender', function (callable $cb) {
+				// Emit event publicly
+				\OC_Hook::emit('\OC\Settings\Personal', 'preFormRender', $cb);
+			});
 			return $manager;
 		});
 		$this->registerService(\OC\Files\AppData\Factory::class, function (Server $c) {

--- a/lib/public/Settings/IManager.php
+++ b/lib/public/Settings/IManager.php
@@ -24,6 +24,12 @@
 namespace OCP\Settings;
 
 /**
+ * Settings Manager
+ *
+ * Hooks available in scope \OC\Settings\Personal:
+ * - preFormRender(callable $cb)
+ *
+ * @package OC\Settings
  * @since 9.1
  */
 interface IManager {


### PR DESCRIPTION
This allows other apps to hook in and add their own section to the
'Personal Settings' page via:

    \OC_Hook::connect('\OC\Settings\Personal', 'preFormRender',\
        $this, 'onPreFormRender');
