### PR TITLE
Fix login with basic auth

### DIFF
--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -293,7 +293,6 @@ class Manager {
 					return false;
 				}
 			} catch (InvalidTokenException $e) {
-				return true;
 			}
 		}
 

--- a/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
@@ -566,6 +566,8 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testNeedsSecondFactorInvalidToken() {
+		$this->prepareNoProviders();
+
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')
 			->willReturn('user');
@@ -579,6 +581,8 @@ class ManagerTest extends TestCase {
 			->with('mysessionid')
 			->willThrowException(new OC\Authentication\Exceptions\InvalidTokenException());
 
-		$this->assertTrue($this->manager->needsSecondFactor($user));
+		$this->config->method('getUserKeys')->willReturn([]);
+
+		$this->assertFalse($this->manager->needsSecondFactor($user));
 	}
 }


### PR DESCRIPTION
Should fix infinite loop introduced by https://github.com/nextcloud/server/pull/6296

Basically if we can't find the token we continue with the other checks. Else a login with basic auth is doomed to fail.

@LukasReschke please have a look