### PR TITLE
Fix "Uninitialized string offset: 0 at \/media\/psf\/stable9\/lib\/pr…

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -184,12 +184,12 @@ class LoginController extends Controller {
 		}
 
 		// OpenGraph Support: http://ogp.me/
-		Util::addHeader('meta', ['property' => "og:title", 'content' => Util::sanitizeHTML($this->defaults->getName())]);
-		Util::addHeader('meta', ['property' => "og:description", 'content' => Util::sanitizeHTML($this->defaults->getSlogan())]);
-		Util::addHeader('meta', ['property' => "og:site_name", 'content' => Util::sanitizeHTML($this->defaults->getName())]);
-		Util::addHeader('meta', ['property' => "og:url", 'content' => $this->urlGenerator->getAbsoluteURL('')]);
-		Util::addHeader('meta', ['property' => "og:type", 'content' => "website"]);
-		Util::addHeader('meta', ['property' => "og:image", 'content' => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core','favicon-touch.png'))]);
+		Util::addHeader('meta', ['property' => 'og:title', 'content' => Util::sanitizeHTML($this->defaults->getName())]);
+		Util::addHeader('meta', ['property' => 'og:description', 'content' => Util::sanitizeHTML($this->defaults->getSlogan())]);
+		Util::addHeader('meta', ['property' => 'og:site_name', 'content' => Util::sanitizeHTML($this->defaults->getName())]);
+		Util::addHeader('meta', ['property' => 'og:url', 'content' => $this->urlGenerator->getAbsoluteURL('/')]);
+		Util::addHeader('meta', ['property' => 'og:type', 'content' => 'website']);
+		Util::addHeader('meta', ['property' => 'og:image', 'content' => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core','favicon-touch.png'))]);
 
 		return new TemplateResponse(
 			$this->appName, 'login', $parameters, 'guest'


### PR DESCRIPTION
…ivate\/URLGenerator.php#224"

The URLGenerator doesn't support `` as target for absolute URLs, we need to link to `/` thus.

Regression introduced with https://github.com/nextcloud/server/commit/46229a00f39e507249dbe3ceb7507277da3fa4f8

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>