### PR TITLE
Fix active entry highlight in certain apps

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -93,7 +93,8 @@ kbd {
 	border-right: 1px solid nc-darken($color-main-background, 8%);
 	display: flex;
 	flex-direction: column;
-	> ul {
+	> ul,
+	.with-icon > ul {
 		position: relative;
 		height: 100%;
 		width: inherit;


### PR DESCRIPTION
For example in the Mail app:
Before (no highlight) / After (proper highlight)
![screenshot from 2017-09-07 02-49-37](https://user-images.githubusercontent.com/925062/30140791-4ab5d14e-9377-11e7-99d8-f39aee9b0a89.png) ![screenshot from 2017-09-07 02-48-53](https://user-images.githubusercontent.com/925062/30140790-4ab542ec-9377-11e7-91a5-2baa3e146ac8.png)

This is due to specific container structure. This pull request makes sure that our standard `.with-icon` class is used as identifying element.

Please review @nextcloud/designers @ChristophWurst @nextcloud/mail 