### PR TITLE
Fix hovering on all popover types

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -668,6 +668,16 @@ kbd {
 			margin: 0;
 			font-weight: 300;
 			box-shadow: none;
+			width: 100%;
+			/* Override the app-navigation li opacity */
+			-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=70)' !important;
+			filter: alpha(opacity = 70) !important;
+			opacity: .7 !important;
+			&:hover, &:focus, &.active {
+				-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=100)' !important;
+				filter: alpha(opacity = 100) !important;
+				opacity: 1 !important;
+			}
 			/* prevent .action class to break the design */
 			&.action {
 				padding: inherit !important;
@@ -689,17 +699,6 @@ kbd {
 			> img {
 				width: 16px;
 				padding: 0 10px;
-			}
-		}
-		.menuitem {
-			width: 100%;
-			-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=70)';
-			filter: alpha(opacity = 70);
-			opacity: .7;
-			&:hover, &:focus, &.active {
-				-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=100)';
-				filter: alpha(opacity = 100);
-				opacity: 1;
 			}
 		}
 		[class^='icon-'],


### PR DESCRIPTION
When hovering some popover who don't use the menuitem class (we're suppose to have dropped this requirement) the highlight effect do not work for two reasons:
 - Wrong element selectors
 - No !important overriding for the popovers in the app-navigation

This will need a backport I think.

.
@nextcloud/designers please review

> Example of location to check:
>  - contacts app: settings
>  - mail app: app-navigation, main account
>  - calendar app: app-navigation, calendar element
>  - main settings: user info visibility (private, public...)