### PR TITLE
Add support for `\OCP\Share\IShare::getMailSend` back

### DIFF
--- a/build/integration/federation_features/federated.feature
+++ b/build/integration/federation_features/federated.feature
@@ -113,7 +113,7 @@ Feature: federated
 			| permissions | 19 |
 			| stime | A_NUMBER |
 			| storage | A_NUMBER |
-			| mail_send | 0 |
+			| mail_send | 1 |
 			| uid_owner | user1 |
 			| file_parent | A_NUMBER |
 			| displayname_owner | user1 |

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -183,6 +183,9 @@ class DefaultShareProvider implements IShareProvider {
 			throw new ShareNotFound();
 		}
 
+		$mailSendValue = $share->getMailSend();
+		$data['mail_send'] = ($mailSendValue === null) ? true : $mailSendValue;
+
 		$share = $this->createShare($data);
 		return $share;
 	}
@@ -837,7 +840,7 @@ class DefaultShareProvider implements IShareProvider {
 			->setShareType((int)$data['share_type'])
 			->setPermissions((int)$data['permissions'])
 			->setTarget($data['file_target'])
-			->setMailSend(true);
+			->setMailSend((bool)$data['mail_send']);
 
 		$shareTime = new \DateTime();
 		$shareTime->setTimestamp((int)$data['stime']);

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -837,7 +837,7 @@ class DefaultShareProvider implements IShareProvider {
 			->setShareType((int)$data['share_type'])
 			->setPermissions((int)$data['permissions'])
 			->setTarget($data['file_target'])
-			->setMailSend((bool)$data['mail_send']);
+			->setMailSend(true);
 
 		$shareTime = new \DateTime();
 		$shareTime->setTimestamp((int)$data['stime']);


### PR DESCRIPTION
This adds back the support for `\OCP\Share\IShare::getMailSend`, one example is creating bulk shares via API which where previously blocking due to the share notification emails.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>