### PR TITLE
Sort apps by enabled/disabled but not by official/in-appstore in App Management

### DIFF
--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -114,11 +114,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 							if (a.active !== b.active) {
 								return (a.active ? -1 : 1)
 							} else {
-								var levelDiff = b.level - a.level;
-								if (levelDiff === 0) {
-									return OC.Util.naturalSortCompare(a.name, b.name);
-								}
-								return levelDiff;
+							    	return OC.Util.naturalSortCompare(a.name, b.name);
 							}
 						});
 					}

--- a/settings/tests/js/appsSpec.js
+++ b/settings/tests/js/appsSpec.js
@@ -172,7 +172,7 @@ describe('OC.Settings.Apps tests', function() {
 			return results;
 		}
 
-		it('sorts all applications using the level', function() {
+		it('does not sort applications using the level', function() {
 			Apps.loadCategory('TestId');
 
 			suite.server.requests[0].respond(
@@ -223,7 +223,7 @@ describe('OC.Settings.Apps tests', function() {
 
 			var results = getResultsFromDom();
 			expect(results.length).toEqual(5);
-			expect(results).toEqual(['alpha', 'delta', 'zork', 'foo', 'nolevel']);
+			expect(results).toEqual(['alpha', 'foo', 'delta', 'nolevel', 'zork']);
 			expect(OC.Settings.Apps.State.apps).toEqual({
 				'foo': {
 					id: 'foo',


### PR DESCRIPTION
Fix #5960 

### Problem:
In Apps > Your apps, apps that are also available in the appstore start sorting from A-Z again even though they are disabled.

The proper behavior should be:
1. Enabled apps A–Z
2. Disabled apps A–Z

### Solution:
Currently the front-end sorting logic groups the apps by whether it is official or in-appstore. This is done by using the 'level' attribute. I dropped the 'level' part in the sorting function. I also updated the unit test.

Before:
![unnatural-sorting](https://user-images.githubusercontent.com/3045168/30253237-bff12542-9635-11e7-8775-ea43b804007c.png)

After:
![level-agnostic-sort](https://user-images.githubusercontent.com/3045168/30253238-c3ac7952-9635-11e7-8f7e-0f11a8d7b255.png)


Signed-off-by: Chon Kou <k.kou@alumni.ubc.ca>