### PR TITLE
[stable12] Allow translations of the comments activity in the emails too

### DIFF
--- a/apps/comments/lib/Activity/Listener.php
+++ b/apps/comments/lib/Activity/Listener.php
@@ -115,15 +115,16 @@ class Listener {
 			->setAuthor($actor)
 			->setObject($event->getComment()->getObjectType(), (int) $event->getComment()->getObjectId())
 			->setMessage('add_comment_message', [
-				$event->getComment()->getId(),
+				'commentId' => $event->getComment()->getId(),
 			]);
 
 		foreach ($users as $user => $path) {
 			$activity->setAffectedUser($user);
 
 			$activity->setSubject('add_comment_subject', [
-				$actor,
-				$path,
+				'actor' => $actor,
+				'fileId' => (int) $event->getComment()->getObjectId(),
+				'filePath' => trim($path, '/'),
 			]);
 			$this->activityManager->publish($activity);
 		}

--- a/apps/comments/lib/Activity/Provider.php
+++ b/apps/comments/lib/Activity/Provider.php
@@ -116,11 +116,11 @@ class Provider implements IProvider {
 		$subjectParameters = $event->getSubjectParameters();
 
 		if ($event->getSubject() === 'add_comment_subject') {
-			if ($subjectParameters[0] === $this->activityManager->getCurrentUserId()) {
+			if ($subjectParameters['actor'] === $this->activityManager->getCurrentUserId()) {
 				$event->setParsedSubject($this->l->t('You commented'))
 					->setRichSubject($this->l->t('You commented'), []);
 			} else {
-				$author = $this->generateUserParameter($subjectParameters[0]);
+				$author = $this->generateUserParameter($subjectParameters['actor']);
 				$event->setParsedSubject($this->l->t('%1$s commented', [$author['name']]))
 					->setRichSubject($this->l->t('{author} commented'), [
 						'author' => $author,
@@ -142,22 +142,22 @@ class Provider implements IProvider {
 		$subjectParameters = $event->getSubjectParameters();
 
 		if ($event->getSubject() === 'add_comment_subject') {
-			if ($subjectParameters[0] === $this->activityManager->getCurrentUserId()) {
+			if ($subjectParameters['actor'] === $this->activityManager->getCurrentUserId()) {
 				$event->setParsedSubject($this->l->t('You commented on %1$s', [
-						trim($subjectParameters[1], '/'),
+						$subjectParameters['filePath'],
 					]))
 					->setRichSubject($this->l->t('You commented on {file}'), [
-						'file' => $this->generateFileParameter($event->getObjectId(), $subjectParameters[1]),
+						'file' => $this->generateFileParameter($subjectParameters['fileId'], $subjectParameters['filePath']),
 					]);
 			} else {
-				$author = $this->generateUserParameter($subjectParameters[0]);
+				$author = $this->generateUserParameter($subjectParameters['actor']);
 				$event->setParsedSubject($this->l->t('%1$s commented on %2$s', [
 						$author['name'],
-						trim($subjectParameters[1], '/'),
+						$subjectParameters['filePath'],
 					]))
 					->setRichSubject($this->l->t('{author} commented on {file}'), [
 						'author' => $author,
-						'file' => $this->generateFileParameter($event->getObjectId(), $subjectParameters[1]),
+						'file' => $this->generateFileParameter($subjectParameters['fileId'], $subjectParameters['filePath']),
 					]);
 			}
 		} else {
@@ -167,13 +167,34 @@ class Provider implements IProvider {
 		return $event;
 	}
 
+	protected function getSubjectParameters(IEvent $event) {
+		$subjectParameters = $event->getSubjectParameters();
+		if (isset($subjectParameters['fileId'])) {
+			return $subjectParameters;
+		}
+
+		// Fix subjects from 12.0.3 and older
+		return [
+			'actor' => $subjectParameters[0],
+			'fileId' => (int) $event->getObjectId(),
+			'filePath' => trim($subjectParameters[1], '/'),
+		];
+	}
+
 	/**
 	 * @param IEvent $event
 	 */
 	protected function parseMessage(IEvent $event) {
 		$messageParameters = $event->getMessageParameters();
+		if (empty($messageParameters)) {
+			// Email
+			return;
+		}
+
+		$commentId = isset($messageParameters['commentId']) ? $messageParameters['commentId'] : $messageParameters[0];
+
 		try {
-			$comment = $this->commentsManager->get((int) $messageParameters[0]);
+			$comment = $this->commentsManager->get((string) $commentId);
 			$message = $comment->getMessage();
 			$message = str_replace("\n", '<br />', str_replace(['<', '>'], ['&lt;', '&gt;'], $message));
 
@@ -210,7 +231,7 @@ class Provider implements IProvider {
 			'type' => 'file',
 			'id' => $id,
 			'name' => basename($path),
-			'path' => trim($path, '/'),
+			'path' => $path,
 			'link' => $this->url->linkToRouteAbsolute('files.viewcontroller.showFile', ['fileid' => $id]),
 		];
 	}


### PR DESCRIPTION
Message and object data is not available on emails atm,
so we can not use them either...

Backport #6369