### PR TITLE
print generated encryption key passwords directly after generating th…

### DIFF
--- a/apps/encryption/lib/Crypto/EncryptAll.php
+++ b/apps/encryption/lib/Crypto/EncryptAll.php
@@ -153,12 +153,8 @@ class EncryptAll {
 			$this->createKeyPairs();
 		}
 
-		//setup users file system and encrypt all files one by one (take should encrypt setting of storage into account)
-		$this->output->writeln("\n");
-		$this->output->writeln('Start to encrypt users files');
-		$this->output->writeln('----------------------------');
-		$this->output->writeln('');
-		$this->encryptAllUsersFiles();
+
+		// output generated encryption key passwords
 		if ($this->util->isMasterKeyEnabled() === false) {
 			//send-out or display password list and write it to a file
 			$this->output->writeln("\n");
@@ -167,6 +163,13 @@ class EncryptAll {
 			$this->output->writeln('');
 			$this->outputPasswords();
 		}
+
+		//setup users file system and encrypt all files one by one (take should encrypt setting of storage into account)
+		$this->output->writeln("\n");
+		$this->output->writeln('Start to encrypt users files');
+		$this->output->writeln('----------------------------');
+		$this->output->writeln('');
+		$this->encryptAllUsersFiles();
 		$this->output->writeln("\n");
 	}
 

--- a/apps/encryption/tests/Crypto/EncryptAllTest.php
+++ b/apps/encryption/tests/Crypto/EncryptAllTest.php
@@ -149,8 +149,8 @@ class EncryptAllTest extends TestCase {
 
 		$this->util->expects($this->any())->method('isMasterKeyEnabled')->willReturn(false);
 		$encryptAll->expects($this->at(0))->method('createKeyPairs')->with();
-		$encryptAll->expects($this->at(1))->method('encryptAllUsersFiles')->with();
-		$encryptAll->expects($this->at(2))->method('outputPasswords')->with();
+		$encryptAll->expects($this->at(1))->method('outputPasswords')->with();
+		$encryptAll->expects($this->at(2))->method('encryptAllUsersFiles')->with();
 
 		$encryptAll->encryptAll($this->inputInterface, $this->outputInterface);
 


### PR DESCRIPTION
…e keys so that errors during the encryption do not lead to a potentially massive data loss

Signed-off-by: Kenneth Newwood <kenneth@newwood.name>