### PR TITLE
Fix undefined variable $tmpRoot

### DIFF
--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -128,14 +128,14 @@ class CSSResourceLocator extends ResourceLocator {
 						'webRoot' => $webRoot,
 						'throw' => $throw ? 'true' : 'false'
 					]);
+
+					if ($throw) {
+						throw new ResourceNotFoundException($file, $webRoot);
+					}
 				}
 			}
 
-			if ($throw && $tmpRoot === '/') {
-				throw new ResourceNotFoundException($file, $webRoot);
-			}
-
-			$this->resources[] = array($tmpRoot, $webRoot, $file);
+			$this->resources[] = array($webRoot? : '/', $webRoot, $file);
 		}
 	}
 }


### PR DESCRIPTION
Refactoring of webroot detection left an unused variable as reported in #6415.
This PR fixes this issue.