### PR TITLE
Fix initializing paged search under some circumstances

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1030,7 +1030,7 @@ class Access extends LDAPUtility implements IUserTools {
 	 * @param array $sr the array containing the LDAP search resources
 	 * @param string $filter the LDAP filter for the search
 	 * @param array $base an array containing the LDAP subtree(s) that shall be searched
-	 * @param int $iFoundItems number of results in the search operation
+	 * @param int $iFoundItems number of results in the single search operation
 	 * @param int $limit maximum results to be counted
 	 * @param int $offset a starting point
 	 * @param bool $pagedSearchOK whether a paged search has been executed
@@ -1180,15 +1180,18 @@ class Access extends LDAPUtility implements IUserTools {
 				return array();
 			}
 
+			$iFoundItems = 0;
 			foreach($sr as $res) {
 				$findings = array_merge($findings, $this->invokeLDAPMethod('getEntries', $cr, $res));
+				$iFoundItems = max($iFoundItems, $findings['count']);
+				unset($findings['count']);
 			}
 
-			$continue = $this->processPagedSearchStatus($sr, $filter, $base, $findings['count'],
+			$continue = $this->processPagedSearchStatus($sr, $filter, $base, $iFoundItems,
 				$limitPerPage, $offset, $pagedSearchOK,
 										$skipHandling);
 			$offset += $limitPerPage;
-		} while ($continue && $pagedSearchOK && ($limit === null || $findings['count'] < $limit));
+		} while ($continue && $pagedSearchOK && ($limit === null || count($findings) < $limit));
 		// reseting offset
 		$offset = $savedoffset;
 

--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -333,7 +333,7 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	public function getUserGidNumber($dn) {
 		$gidNumber = false;
 		if($this->access->connection->hasGidNumber) {
-			$gidNumber = $this->getEntryGidNumber($dn, 'gidNumber');
+			$gidNumber = $this->getEntryGidNumber($dn, $this->access->connection->ldapGidNumber);
 			if($gidNumber === false) {
 				$this->access->connection->hasGidNumber = false;
 			}

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestPaging.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestPaging.php
@@ -36,6 +36,9 @@ class IntegrationTestPaging extends AbstractIntegrationTest {
 	/** @var User_LDAP */
 	protected $backend;
 
+	/** @var int */
+	protected $pagingSize = 2;
+
 	/**
 	 * prepares the LDAP environment and sets up a test configuration for
 	 * the LDAP backend.
@@ -50,7 +53,7 @@ class IntegrationTestPaging extends AbstractIntegrationTest {
 	public function initConnection() {
 		parent::initConnection();
 		$this->connection->setConfiguration([
-			'ldapPagingSize' => 1
+			'ldapPagingSize' => $this->pagingSize
 		]);
 	}
 
@@ -61,19 +64,33 @@ class IntegrationTestPaging extends AbstractIntegrationTest {
 	 * @return bool
 	 */
 	protected function case1() {
-		$offset = 0;
-
 		$filter = 'objectclass=inetorgperson';
 		$attributes = ['cn', 'dn'];
 		$users = [];
-		do {
-			$result = $this->access->searchUsers($filter, $attributes, null, $offset);
-			foreach($result as $user) {
-				$users[] = $user['cn'];
-			}
-			$offset += count($users);
-		} while ($this->access->hasMoreResults());
-		if(count($users) === 2) {
+
+		$result = $this->access->searchUsers($filter, $attributes);
+		foreach($result as $user) {
+			$users[] = $user['cn'];
+		}
+
+		if(count($users) === 4) {
+			return true;
+		}
+
+		return false;
+	}
+
+	protected function case2() {
+		$filter = 'objectclass=inetorgperson';
+		$attributes = ['cn', 'dn'];
+		$users = [];
+
+		$result = $this->access->searchUsers($filter, $attributes, null, $this->pagingSize);
+		foreach($result as $user) {
+			$users[] = $user['cn'];
+		}
+
+		if(count($users) === 4 - $this->pagingSize) {
 			return true;
 		}
 

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestPaging.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestPaging.php
@@ -47,6 +47,13 @@ class IntegrationTestPaging extends AbstractIntegrationTest {
 		$this->backend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager());
 	}
 
+	public function initConnection() {
+		parent::initConnection();
+		$this->connection->setConfiguration([
+			'ldapPagingSize' => 1
+		]);
+	}
+
 	/**
 	 * tests that paging works properly against a simple example (reading all
 	 * of few users in smallest steps)
@@ -54,20 +61,18 @@ class IntegrationTestPaging extends AbstractIntegrationTest {
 	 * @return bool
 	 */
 	protected function case1() {
-		$limit = 1;
 		$offset = 0;
 
 		$filter = 'objectclass=inetorgperson';
 		$attributes = ['cn', 'dn'];
 		$users = [];
 		do {
-			$result = $this->access->searchUsers($filter, $attributes, $limit, $offset);
+			$result = $this->access->searchUsers($filter, $attributes, null, $offset);
 			foreach($result as $user) {
 				$users[] = $user['cn'];
 			}
-			$offset += $limit;
+			$offset += count($users);
 		} while ($this->access->hasMoreResults());
-
 		if(count($users) === 2) {
 			return true;
 		}

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestPaging.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestPaging.php
@@ -59,38 +59,60 @@ class IntegrationTestPaging extends AbstractIntegrationTest {
 
 	/**
 	 * tests that paging works properly against a simple example (reading all
-	 * of few users in smallest steps)
+	 * of few users in small steps)
 	 *
 	 * @return bool
 	 */
 	protected function case1() {
 		$filter = 'objectclass=inetorgperson';
 		$attributes = ['cn', 'dn'];
-		$users = [];
 
 		$result = $this->access->searchUsers($filter, $attributes);
-		foreach($result as $user) {
-			$users[] = $user['cn'];
-		}
-
-		if(count($users) === 4) {
+		if(count($result) === 7) {
 			return true;
 		}
 
 		return false;
 	}
 
+	/**
+	 * fetch first three, afterwards all users
+	 *
+	 * @return bool
+	 */
 	protected function case2() {
 		$filter = 'objectclass=inetorgperson';
 		$attributes = ['cn', 'dn'];
-		$users = [];
 
-		$result = $this->access->searchUsers($filter, $attributes, null, $this->pagingSize);
-		foreach($result as $user) {
-			$users[] = $user['cn'];
+		$result = $this->access->searchUsers($filter, $attributes, 4);
+		// beware, under circumstances, the result  set can be larger then
+		// the specified limit! In this case, if we specify a limit of 3,
+		// the result will be 4, because the highest possible paging size
+		// is 2 (as configured).
+		// But also with more than one search base, the limit can be outpaced.
+		if(count($result) !== 4) {
+			return false;
 		}
 
-		if(count($users) === 4 - $this->pagingSize) {
+		$result = $this->access->searchUsers($filter, $attributes);
+		if(count($result) !== 7) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * reads all remaining users starting first page
+	 *
+	 * @return bool
+	 */
+	protected function case3() {
+		$filter = 'objectclass=inetorgperson';
+		$attributes = ['cn', 'dn'];
+
+		$result = $this->access->searchUsers($filter, $attributes, null, $this->pagingSize);
+		if(count($result) === (7 - $this->pagingSize)) {
 			return true;
 		}
 

--- a/apps/user_ldap/tests/Integration/setup-scripts/createExplicitUsers.php
+++ b/apps/user_ldap/tests/Integration/setup-scripts/createExplicitUsers.php
@@ -50,7 +50,7 @@ if (true) {
 	}
 }
 
-$users = ['alice', 'boris'];
+$users = ['alice', 'boris', 'cynthia', 'derek'];
 
 foreach ($users as $uid) {
 	$newDN = 'uid=' . $uid . ',' . $ouDN;

--- a/apps/user_ldap/tests/Integration/setup-scripts/createExplicitUsers.php
+++ b/apps/user_ldap/tests/Integration/setup-scripts/createExplicitUsers.php
@@ -50,7 +50,7 @@ if (true) {
 	}
 }
 
-$users = ['alice', 'boris', 'cynthia', 'derek'];
+$users = ['alice', 'boris', 'cynthia', 'derek', 'evelina', 'fatima', 'gregor'];
 
 foreach ($users as $uid) {
 	$newDN = 'uid=' . $uid . ',' . $ouDN;


### PR DESCRIPTION
Fixes #5273 and #6388 

Basically the issue was, that a paged search might not be properly initialized, when no limit was given, but a previous search had a limit set. This resulted in strange behaviour as described in #5273. While debugging this, I figured out, @eigood recently also saw the wrong spot in the code as described in #6388.

Added Paged Search Integration tests cover the case.

Please test and review @nextcloud/ldap @zfzfzf33 @eigood @bline 

Backport is necessary.