### PR TITLE
Invert themed favicons on bright colors

### DIFF
--- a/apps/theming/lib/IconBuilder.php
+++ b/apps/theming/lib/IconBuilder.php
@@ -58,7 +58,7 @@ class IconBuilder {
 			if ($icon === false) {
 				return false;
 			}
-			$icon->setImageFormat("png24");
+			$icon->setImageFormat("png32");
 			$data = $icon->getImageBlob();
 			$icon->destroy();
 			return $data;
@@ -77,7 +77,7 @@ class IconBuilder {
 			if ($icon === false) {
 				return false;
 			}
-			$icon->setImageFormat("png24");
+			$icon->setImageFormat("png32");
 			$data = $icon->getImageBlob();
 			$icon->destroy();
 			return $data;
@@ -161,8 +161,6 @@ class IconBuilder {
 		// center icon
 		$offset_w = 512 / 2 - $innerWidth / 2;
 		$offset_h = 512 / 2 - $innerHeight / 2;
-
-		$appIconFile->setImageFormat("png24");
 
 		$finalIconFile = new Imagick();
 		$finalIconFile->setBackgroundColor(new ImagickPixel('transparent'));

--- a/apps/theming/lib/IconBuilder.php
+++ b/apps/theming/lib/IconBuilder.php
@@ -145,6 +145,17 @@ class IconBuilder {
 			$appIconFile->setResolution($resX, $resY);
 			$appIconFile->setBackgroundColor(new ImagickPixel('transparent'));
 			$appIconFile->readImageBlob($svg);
+
+			/**
+			 * invert app icons for bright primary colors
+			 * the default nextcloud logo will not be inverted to black
+			 */
+			if ($this->util->invertTextColor($color)
+				&& !$appIcon instanceof ISimpleFile
+				&& $app !== "core"
+			) {
+				$appIconFile->negateImage(false);
+			}
 			$appIconFile->scaleImage(512, 512, true);
 		} else {
 			$appIconFile = new Imagick();


### PR DESCRIPTION
App icons displayed in the themed favicons will now be inverted on bright primary colors as it is handled in the app menu as well. 

Fixes #5650 and #4796

@nextcloud/theming 