### PR TITLE
Improve sharing pagination

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1053,6 +1053,11 @@ class Manager implements IManager {
 				}
 			}
 
+			// If we did not fetch more shares than the limit then there are no more shares
+			if (count($shares) < $limit) {
+				break;
+			}
+
 			if (count($shares2) === $limit) {
 				break;
 			}


### PR DESCRIPTION
Basically we did in almost all cases did a query to much.
This resulted in an extra query for each share type.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>