### PR TITLE
[stable10] Increase stable10 version to allow migration

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 1, 6, 1);
+$OC_Version = array(9, 1, 50, 1);
 
 // The human readable string
-$OC_VersionString = '10.0.6';
+$OC_VersionString = '10.0.50';
 
 $OC_VersionCanBeUpgradedFrom = array(9, 0);
 


### PR DESCRIPTION
This avoids stuff like #6489 and https://help.nextcloud.com/t/migration-from-owncloud-9-1-6-to-nextcloud-10-0-6-fails/20908/3

OC uses for the 9.1.6 the patch level 2 and we have patch level .1, but it was the last stable10 release. So we maybe want to repackage the 10.0.6 as 10.0.50 and avoid future updates of that to still allow migration.

cc @LukasReschke @schiessle @jospoortvliet Opinions?

Then the OC 10 -> NC 10 -> 11 -> 12 upgrade path works fine.