### PR TITLE
Fix loading icon size

### DIFF
--- a/core/css/icons.scss
+++ b/core/css/icons.scss
@@ -30,8 +30,8 @@
 	&:after {
 		z-index: 2;
 		content: '';
-		height: 30px;
-		width: 30px;
+		height: 28px;
+		width: 28px;
 		margin: -16px 0 0 -16px;
 		position: absolute;
 		top: 50%;
@@ -55,8 +55,8 @@
 
 .icon-loading-small:after,
 .icon-loading-small-dark:after {
-	height: 14px;
-	width: 14px;
+	height: 12px;
+	width: 12px;
 	margin: -8px 0 0 -8px;
 }
 


### PR DESCRIPTION
Fix #5970 
Loaders are now 16 and 32px width.

Apparently I can't count... ref #2482 🙈 😲 