### PR TITLE
Allow to close sidebar for text files

### DIFF
--- a/apps/files/css/detailsView.scss
+++ b/apps/files/css/detailsView.scss
@@ -124,4 +124,5 @@
 	padding: 15px;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 	opacity: .5;
+	z-index: 1;
 }


### PR DESCRIPTION
* the close button was overlapped by the text preview and you could not close the sidebar then
* before: no close button for the sidebar visible for text files
* after: close button visible

cc @nextcloud/designers 