### PR TITLE
Fix margins of followup sections

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -949,9 +949,6 @@ span.version {
 	display: block;
 	padding: 0 30px 30px 30px;
 	color: #555;
-	margin-bottom: 24px;
-	margin-top: -30px;
-	position: relative;
 }
 
 .app-image {


### PR DESCRIPTION
Fixes #6520 

Only update notifications and sharing uses it as of now anyways.

Before:

![bildschirmfoto 2017-09-15 um 15 01 43](https://user-images.githubusercontent.com/245432/30485781-c5b5d214-9a2e-11e7-95b4-7f28d8a88272.png)
![bildschirmfoto 2017-09-15 um 15 57 43](https://user-images.githubusercontent.com/245432/30485783-c5fc1c2e-9a2e-11e7-87bf-528a69ab99cb.png)

After:

![bildschirmfoto 2017-09-15 um 15 01 34](https://user-images.githubusercontent.com/245432/30485794-cf1c25ec-9a2e-11e7-87f9-1cb76cba79c5.png)
![bildschirmfoto 2017-09-15 um 15 57 09](https://user-images.githubusercontent.com/245432/30485793-cf16b698-9a2e-11e7-918c-18305cb19012.png)
