### PR TITLE
fix LDAP User deletion (cleanup), fixes #3365

### DIFF
--- a/apps/user_ldap/appinfo/app.php
+++ b/apps/user_ldap/appinfo/app.php
@@ -44,9 +44,10 @@ if(count($configPrefixes) > 0) {
 			'name' => $l->t('LDAP user and group backend'),
 		];
 	});
+	$userSession = \OC::$server->getUserSession();
 
 	$userBackend  = new OCA\User_LDAP\User_Proxy(
-		$configPrefixes, $ldapWrapper, $ocConfig, $notificationManager
+		$configPrefixes, $ldapWrapper, $ocConfig, $notificationManager, $userSession
 	);
 	$groupBackend  = new OCA\User_LDAP\Group_Proxy($configPrefixes, $ldapWrapper);
 	// register user backend

--- a/apps/user_ldap/appinfo/register_command.php
+++ b/apps/user_ldap/appinfo/register_command.php
@@ -36,7 +36,8 @@ $uBackend = new User_Proxy(
 	$helper->getServerConfigurationPrefixes(true),
 	new LDAP(),
 	$ocConfig,
-	\OC::$server->getNotificationManager()
+	\OC::$server->getNotificationManager(),
+	\OC::$server->getUserSession()
 );
 $deletedUsersIndex = new DeletedUsersIndex(
 	$ocConfig, $dbConnection, $userMapping

--- a/apps/user_ldap/lib/Command/Search.php
+++ b/apps/user_ldap/lib/Command/Search.php
@@ -120,7 +120,13 @@ class Search extends Command {
 				$limit = null;
 			}
 		} else {
-			$proxy = new User_Proxy($configPrefixes, $ldapWrapper, $this->ocConfig, \OC::$server->getNotificationManager());
+			$proxy = new User_Proxy(
+				$configPrefixes,
+				$ldapWrapper,
+				$this->ocConfig,
+				\OC::$server->getNotificationManager(),
+				\OC::$server->getUserSession()
+			);
 			$getMethod = 'getDisplayNames';
 			$printID = true;
 		}

--- a/apps/user_ldap/lib/Helper.php
+++ b/apps/user_ldap/lib/Helper.php
@@ -294,9 +294,10 @@ class Helper {
 		$ldapWrapper = new LDAP();
 		$ocConfig = \OC::$server->getConfig();
 		$notificationManager = \OC::$server->getNotificationManager();
+		$userSession = \OC::$server->getUserSession();
 
 		$userBackend  = new User_Proxy(
-			$configPrefixes, $ldapWrapper, $ocConfig, $notificationManager
+			$configPrefixes, $ldapWrapper, $ocConfig, $notificationManager, $userSession
 		);
 		$uid = $userBackend->loginName2UserName($param['uid'] );
 		if($uid !== false) {

--- a/apps/user_ldap/lib/Jobs/CleanUp.php
+++ b/apps/user_ldap/lib/Jobs/CleanUp.php
@@ -99,7 +99,8 @@ class CleanUp extends TimedJob {
 				$this->ldapHelper->getServerConfigurationPrefixes(true),
 				new LDAP(),
 				$this->ocConfig,
-				\OC::$server->getNotificationManager()
+				\OC::$server->getNotificationManager(),
+				\OC::$server->getUserSession()
 			);
 		}
 

--- a/apps/user_ldap/lib/Migration/UUIDFixGroup.php
+++ b/apps/user_ldap/lib/Migration/UUIDFixGroup.php
@@ -33,6 +33,6 @@ class UUIDFixGroup extends UUIDFix {
 	public function __construct(GroupMapping $mapper, LDAP $ldap, IConfig $config, Helper $helper) {
 		$this->mapper = $mapper;
 		$this->proxy = new User_Proxy($helper->getServerConfigurationPrefixes(true), $ldap, $config, 
-			\OC::$server->getNotificationManager());
+			\OC::$server->getNotificationManager(), \OC::$server->getUserSession());
 	}
 }

--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -31,6 +31,7 @@ namespace OCA\User_LDAP;
 
 use OCA\User_LDAP\User\User;
 use OCP\IConfig;
+use OCP\IUserSession;
 use OCP\Notification\IManager as INotificationManager;
 
 class User_Proxy extends Proxy implements \OCP\IUserBackend, \OCP\UserInterface, IUserLDAP {
@@ -39,14 +40,19 @@ class User_Proxy extends Proxy implements \OCP\IUserBackend, \OCP\UserInterface,
 
 	/**
 	 * Constructor
+	 *
 	 * @param array $serverConfigPrefixes array containing the config Prefixes
+	 * @param ILDAPWrapper $ldap
+	 * @param IConfig $ocConfig
+	 * @param INotificationManager $notificationManager
+	 * @param IUserSession $userSession
 	 */
 	public function __construct(array $serverConfigPrefixes, ILDAPWrapper $ldap, IConfig $ocConfig,
-		INotificationManager $notificationManager) {
+		INotificationManager $notificationManager, IUserSession $userSession) {
 		parent::__construct($ldap);
 		foreach($serverConfigPrefixes as $configPrefix) {
 			$this->backends[$configPrefix] =
-				new User_LDAP($this->getAccess($configPrefix), $ocConfig, $notificationManager);
+				new User_LDAP($this->getAccess($configPrefix), $ocConfig, $notificationManager, $userSession);
 			if(is_null($this->refBackend)) {
 				$this->refBackend = &$this->backends[$configPrefix];
 			}

--- a/apps/user_ldap/tests/Integration/AbstractIntegrationTest.php
+++ b/apps/user_ldap/tests/Integration/AbstractIntegrationTest.php
@@ -144,11 +144,17 @@ abstract class AbstractIntegrationTest {
 		foreach($methods as $method) {
 			if(strpos($method, 'case') === 0) {
 				print("running $method " . PHP_EOL);
-				if(!$this->$method()) {
-					print(PHP_EOL . '>>> !!! Test ' . $method . ' FAILED !!! <<<' . PHP_EOL . PHP_EOL);
+				try {
+					if(!$this->$method()) {
+						print(PHP_EOL . '>>> !!! Test ' . $method . ' FAILED !!! <<<' . PHP_EOL . PHP_EOL);
+						exit(1);
+					}
+					$atLeastOneCaseRan = true;
+				} catch(\Exception $e) {
+					print(PHP_EOL . '>>> !!! Test ' . $method . ' RAISED AN EXCEPTION !!! <<<' . PHP_EOL);
+					print($e->getMessage() . PHP_EOL . PHP_EOL);
 					exit(1);
 				}
-				$atLeastOneCaseRan = true;
 			}
 		}
 		if($atLeastOneCaseRan) {

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestAttributeDetection.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestAttributeDetection.php
@@ -49,7 +49,7 @@ class IntegrationTestAttributeDetection extends AbstractIntegrationTest {
 		$groupMapper->clear();
 		$this->access->setGroupMapper($groupMapper);
 
-		$userBackend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager());
+		$userBackend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager(), \OC::$server->getUserSession());
 		$userManager = \OC::$server->getUserManager();
 		$userManager->clearBackends();
 		$userManager->registerBackend($userBackend);

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestFetchUsersByLoginName.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestFetchUsersByLoginName.php
@@ -47,7 +47,7 @@ class IntegrationTestFetchUsersByLoginName extends AbstractIntegrationTest {
 		$this->mapping = new UserMapping(\OC::$server->getDatabaseConnection());
 		$this->mapping->clear();
 		$this->access->setUserMapper($this->mapping);
-		$this->backend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager());
+		$this->backend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager(), \OC::$server->getUserSession());
 	}
 
 	/**

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestPaging.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestPaging.php
@@ -47,7 +47,7 @@ class IntegrationTestPaging extends AbstractIntegrationTest {
 		require(__DIR__ . '/../setup-scripts/createExplicitUsers.php');
 		parent::init();
 
-		$this->backend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager());
+		$this->backend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager(), \OC::$server->getUserSession());
 	}
 
 	public function initConnection() {

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestUserHome.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestUserHome.php
@@ -51,7 +51,7 @@ class IntegrationTestUserHome extends AbstractIntegrationTest {
 		$this->mapping = new UserMapping(\OC::$server->getDatabaseConnection());
 		$this->mapping->clear();
 		$this->access->setUserMapper($this->mapping);
-		$this->backend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager());
+		$this->backend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager(), \OC::$server->getUserSession());
 	}
 
 	/**

--- a/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserAvatar.php
+++ b/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserAvatar.php
@@ -50,7 +50,7 @@ class IntegrationTestUserAvatar extends AbstractIntegrationTest {
 		$this->mapping = new UserMapping(\OC::$server->getDatabaseConnection());
 		$this->mapping->clear();
 		$this->access->setUserMapper($this->mapping);
-		$userBackend  = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager());
+		$userBackend  = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager(), \OC::$server->getUserSession());
 		\OC_User::useBackend($userBackend);
 	}
 

--- a/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserDisplayName.php
+++ b/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserDisplayName.php
@@ -43,7 +43,7 @@ class IntegrationTestUserDisplayName extends AbstractIntegrationTest {
 		$this->mapping = new UserMapping(\OC::$server->getDatabaseConnection());
 		$this->mapping->clear();
 		$this->access->setUserMapper($this->mapping);
-		$userBackend  = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager());
+		$userBackend  = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager(), \OC::$server->getUserSession());
 		\OC_User::useBackend($userBackend);
 	}
 

--- a/apps/user_ldap/tests/User_ProxyTest.php
+++ b/apps/user_ldap/tests/User_ProxyTest.php
@@ -24,6 +24,7 @@ namespace OCA\User_LDAP\Tests;
 use OCA\User_LDAP\ILDAPWrapper;
 use OCA\User_LDAP\User_Proxy;
 use OCP\IConfig;
+use OCP\IUserSession;
 use OCP\Notification\IManager as INotificationManager;
 use Test\TestCase;
 
@@ -32,8 +33,10 @@ class User_ProxyTest extends TestCase  {
 	private $ldapWrapper;
 	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
 	private $config;
-	/** @var IManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var INotificationManager|\PHPUnit_Framework_MockObject_MockObject */
 	private $notificationManager;
+	/** @var IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	private $userSession;
 	/** @var User_Proxy|\PHPUnit_Framework_MockObject_MockObject */
 	private $proxy;
 
@@ -43,12 +46,14 @@ class User_ProxyTest extends TestCase  {
 		$this->ldapWrapper = $this->createMock(ILDAPWrapper::class);
 		$this->config = $this->createMock(IConfig::class);
 		$this->notificationManager = $this->createMock(INotificationManager::class);
+		$this->userSession = $this->createMock(IUserSession::class);
 		$this->proxy = $this->getMockBuilder(User_Proxy::class)
 			->setConstructorArgs([
 				[],
 				$this->ldapWrapper,
 				$this->config,
 				$this->notificationManager,
+				$this->userSession,
 			])
 			->setMethods(['handleRequest'])
 			->getMock();


### PR DESCRIPTION
I investigated another  case at #3365 and despite the recent PR,  there was still  a small detail  wrong (unfortunately also with the integration  test that returned a  false positive)… 😿 


```
$ ./occ ldap:check-user b9bf0cf3-52f1-4d96-b2a7-da76f660d754
The user is still available on LDAP.
$ ldapdelete  -H ldap://localhost:7770 -D cn=root,dc=nc,dc=zara -W "uid=user_1160,ou=users,ou=medium,dc=nc,dc=zara"
$ ./occ ldap:check-user b9bf0cf3-52f1-4d96-b2a7-da76f660d754
The user does not exists on LDAP anymore.
Clean up the user's remnants by: ./occ user:delete "b9bf0cf3-52f1-4d96-b2a7-da76f660d754"
$ ./occ user:delete b9bf0cf3-52f1-4d96-b2a7-da76f660d754
The specified user was deleted
```

Before:

```
$ ./occ user:delete d4549eb6-9495-499a-97c0-48ad45e8aed5

                                                                    
  [OC\User\NoUserException]                                         
  d4549eb6-9495-499a-97c0-48ad45e8aed5 is not a valid user anymore                                                        
```

please test and review @nextcloud/ldap @ArnY 