### PR TITLE
Force refresh file list when clicking on breadcrumb even if target directory equals current directory.

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -837,7 +837,7 @@
 
 			if ($targetDir !== undefined && e.which === 1) {
 				e.preventDefault();
-				this.changeDirectory($targetDir);
+				this.changeDirectory($targetDir, true, true);
 				this.updateSearch();
 			}
 		},


### PR DESCRIPTION
Fix #2332 

### Problem
On the file list view, clicking on current directory on the breadcrumb does not refresh the file list. This is because the [changeDirectory function does nothing](https://github.com/nextcloud/server/blob/cdb6b0295abaf9138e4bbc928acf12714c1a232a/apps/files/js/filelist.js#L1511-L1513) if it is asked to go to the same directory it already is in. This check is the right thing to do in general, and removing the check will cause unit tests to fail. It is needed as a base case for terminating a series of indirectly recursive calls (changeDirectory('/') -> reload() -> reloadCallback() -> if status is, say, 404, it would get stuck in an infinite loop when it calls changeDirectory('/') again).

### Solution
Use the force flag to force the refresh. All tests are still passing :)

### Testing done
1. Open two tabs in the browser, for both tabs go to the same folder (e.g. /foo/bar)
2. On one tab, upload a file (e.g. abc.txt).
3. Go to the other tab, click on 'bar' on the breadcrumb.
4. This refreshed the file list and shows abc.txt.