### PR TITLE
Fix duplicate session token after remembered login

### DIFF
--- a/lib/private/Authentication/Token/DefaultTokenProvider.php
+++ b/lib/private/Authentication/Token/DefaultTokenProvider.php
@@ -195,6 +195,7 @@ class DefaultTokenProvider implements IProvider {
 		$newToken->setRemember($token->getRemember());
 		$newToken->setLastActivity($this->time->getTime());
 		$this->mapper->insert($newToken);
+		$this->mapper->delete($token);
 	}
 
 	/**

--- a/tests/lib/Authentication/Token/DefaultTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/DefaultTokenProviderTest.php
@@ -318,6 +318,10 @@ class DefaultTokenProviderTest extends TestCase {
 			->expects($this->at(1))
 			->method('insert')
 			->with($newToken);
+		$this->mapper
+			->expects($this->at(2))
+			->method('delete')
+			->with($token);
 
 		$this->tokenProvider->renewSessionToken('oldId', 'newId');
 	}
@@ -384,6 +388,10 @@ class DefaultTokenProviderTest extends TestCase {
 			->expects($this->at(1))
 			->method('insert')
 			->with($this->equalTo($newToken));
+		$this->mapper
+			->expects($this->at(2))
+			->method('delete')
+			->with($token);
 
 		$this->tokenProvider->renewSessionToken('oldId', 'newId');
 	}


### PR DESCRIPTION
On a remembered login session, we create a new session token
in the database with the values of the old one. As we actually
don't need the old session token anymore, we can delete it right
away.

IIRC this caused problems back when I [fixed the remember me login](https://github.com/nextcloud/server/pull/1347) last year. There, deleting the old token always logged the user out, for some unknown reason. Now I'm thinking that the issue fixed by #6360 could also have fixed this problem. Thus I've added the token deletion and it actually seems to work, as far as I could test this.

Steps to test this

1. Log into Nextcloud using the 'remember me' checkbox
2. Go to https://localhost/settings/user/security and try to remember the number of sessions. Or simply revoke all other sessions then there's only one 😉 
3. Close your browser
4. Open your browser and go to https://localhost/settings/user/security
5. You should still be logged in

On master, you'll see one additional session, which is the new one. On this PR's branch, however, you'll only see your new session.

This might look like a tiny difference, but if you use your Nextcloud many times a day and remember-me login is used all the time (because you close your browser in between) you'll see *a lot* of old sessions. This is confusing and bad for UX. Kind of related issues reported by @eggithub #6203 #5083 


FYI this is to review, but I'm a bit hesitant to label it like that as the session handling code has shown to be fragile in some situations and I'd like to extensively test this before we merge it to be super sure it doesn't break remember-me login again 😀 

cc @MorrisJobke this is more or less what we've been discussing recently. However, I'm afraid this does not yet solve #1075.