### PR TITLE
throw 101 when an empty group string is provided

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -604,7 +604,7 @@ class UsersController extends OCSController {
 	public function removeFromGroup($userId, $groupid) {
 		$loggedInUser = $this->userSession->getUser();
 
-		if($groupid === null) {
+		if($groupid === null || trim($groupid) === '') {
 			throw new OCSException('', 101);
 		}
 

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -2119,6 +2119,20 @@ class UsersControllerTest extends TestCase {
 
 	/**
 	 * @expectedException \OCP\AppFramework\OCS\OCSException
+	 * @expectedExceptionCode 101
+	 */
+	public function testRemoveFromGroupWithEmptyTargetGroup() {
+		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->will($this->returnValue($loggedInUser));
+
+		$this->api->removeFromGroup('TargetUser', '');
+	}
+
+	/**
+	 * @expectedException \OCP\AppFramework\OCS\OCSException
 	 * @expectedExceptionCode 102
 	 */
 	public function testRemoveFromGroupWithNotExistingTargetGroup() {


### PR DESCRIPTION
Back in my parental leave I found a few minutes to check whether pyocclient works against Nextcloud. Turned out: its test succeed against NC 10, but since 11 they fail, because an error code changed (cf. https://github.com/blizzz/pyocclient/pull/3 respectively https://travis-ci.org/blizzz/pyocclient/builds/257903855).

This is how it was before: https://github.com/nextcloud/server/blob/stable10/apps/provisioning_api/lib/Users.php#L471-L474

Should be backported back to 11.
