### PR TITLE
Notifications: Add highlight type definition

### DIFF
--- a/lib/public/RichObjectStrings/Definitions.php
+++ b/lib/public/RichObjectStrings/Definitions.php
@@ -252,6 +252,31 @@ class Definitions {
 				],
 			],
 		],
+		'highlight' => [
+			'author' => 'Nextcloud',
+			'app' => 'core',
+			'since' => '13.0.0',
+			'parameters' => [
+				'id' => [
+					'since' => '13.0.0',
+					'required' => true,
+					'description' => 'The id used to identify the highlighted object on the instance',
+					'example' => '42',
+				],
+				'name' => [
+					'since' => '13.0.0',
+					'required' => true,
+					'description' => 'The string that should be highlighted.',
+					'example' => 'Hello World',
+				],
+				'link' => [
+					'since' => '13.0.0',
+					'required' => false,
+					'description' => 'The full URL that should be opened when clicking the highlighted text.',
+					'example' => 'http://localhost/index.php/f/42',
+				],
+			],
+		],
 		'open-graph' => [
 			'author' => 'Maxence Lange',
 			'app' => 'mood',


### PR DESCRIPTION
Rendering is already supported by a default rule in the notifications app, but it is currently not possible to use this from the notifications API.
https://github.com/nextcloud/notifications/blob/master/js/richObjectStringParser.js#L69-L80

This allows apps to set various strings to be highlighted and optionally linked to some URL.

cc @nickvergessen 