### PR TITLE
Fix missing "unsigned" on integer columns

### DIFF
--- a/core/Command/Db/Migrations/GenerateFromSchemaFileCommand.php
+++ b/core/Command/Db/Migrations/GenerateFromSchemaFileCommand.php
@@ -139,6 +139,13 @@ EOT
 EOT
 					);
 				}
+				if ($column->getUnsigned()) {
+					$content .= <<<'EOT'
+				'unsigned' => true,
+
+EOT;
+				}
+
 				$content .= <<<'EOT'
 			]);
 

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -33,15 +33,6 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 	 * @param IOutput $output
 	 * @param \Closure $schemaClosure The `\Closure` returns a `Schema`
 	 * @param array $options
-	 * @since 13.0.0
-	 */
-	public function preSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
-	}
-
-	/**
-	 * @param IOutput $output
-	 * @param \Closure $schemaClosure The `\Closure` returns a `Schema`
-	 * @param array $options
 	 * @return null|Schema
 	 * @since 13.0.0
 	 */
@@ -416,6 +407,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 				'autoincrement' => true,
 				'notnull' => true,
 				'length' => 4,
+				'unsigned' => true,
 			]);
 			$table->addColumn('class', 'string', [
 				'notnull' => true,
@@ -472,6 +464,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 				'autoincrement' => true,
 				'notnull' => true,
 				'length' => 4,
+				'unsigned' => true,
 			]);
 			$table->addColumn('uid', 'string', [
 				'notnull' => true,
@@ -499,21 +492,25 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 				'notnull' => true,
 				'length' => 2,
 				'default' => 0,
+				'unsigned' => true,
 			]);
 			$table->addColumn('remember', 'smallint', [
 				'notnull' => true,
 				'length' => 1,
 				'default' => 0,
+				'unsigned' => true,
 			]);
 			$table->addColumn('last_activity', 'integer', [
 				'notnull' => true,
 				'length' => 4,
 				'default' => 0,
+				'unsigned' => true,
 			]);
 			$table->addColumn('last_check', 'integer', [
 				'notnull' => true,
 				'length' => 4,
 				'default' => 0,
+				'unsigned' => true,
 			]);
 			$table->addColumn('scope', 'text', [
 				'notnull' => false,
@@ -529,6 +526,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 				'autoincrement' => true,
 				'notnull' => true,
 				'length' => 4,
+				'unsigned' => true,
 			]);
 			$table->addColumn('action', 'string', [
 				'notnull' => true,
@@ -539,6 +537,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 				'notnull' => true,
 				'length' => 4,
 				'default' => 0,
+				'unsigned' => true,
 			]);
 			$table->addColumn('ip', 'string', [
 				'notnull' => true,
@@ -566,6 +565,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 				'autoincrement' => true,
 				'notnull' => true,
 				'length' => 4,
+				'unsigned' => true,
 			]);
 			$table->addColumn('uid', 'string', [
 				'notnull' => true,
@@ -594,11 +594,13 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 				'notnull' => true,
 				'length' => 4,
 				'default' => 0,
+				'unsigned' => true,
 			]);
 			$table->addColumn('categoryid', 'integer', [
 				'notnull' => true,
 				'length' => 4,
 				'default' => 0,
+				'unsigned' => true,
 			]);
 			$table->addColumn('type', 'string', [
 				'notnull' => true,
@@ -615,6 +617,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 				'autoincrement' => true,
 				'notnull' => true,
 				'length' => 4,
+				'unsigned' => true,
 			]);
 			$table->addColumn('name', 'string', [
 				'notnull' => true,
@@ -651,6 +654,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 				'notnull' => true,
 				'length' => 4,
 				'default' => 0,
+				'unsigned' => true,
 			]);
 			$table->addUniqueIndex(['objecttype', 'objectid', 'systemtagid'], 'mapping');
 		}
@@ -661,6 +665,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 				'notnull' => true,
 				'length' => 4,
 				'default' => 0,
+				'unsigned' => true,
 			]);
 			$table->addColumn('gid', 'string', [
 				'notnull' => true,
@@ -674,6 +679,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 				'autoincrement' => true,
 				'notnull' => true,
 				'length' => 4,
+				'unsigned' => true,
 			]);
 			$table->addColumn('lock', 'integer', [
 				'notnull' => true,
@@ -700,21 +706,25 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 				'autoincrement' => true,
 				'notnull' => true,
 				'length' => 4,
+				'unsigned' => true,
 			]);
 			$table->addColumn('parent_id', 'integer', [
 				'notnull' => true,
 				'length' => 4,
 				'default' => 0,
+				'unsigned' => true,
 			]);
 			$table->addColumn('topmost_parent_id', 'integer', [
 				'notnull' => true,
 				'length' => 4,
 				'default' => 0,
+				'unsigned' => true,
 			]);
 			$table->addColumn('children_count', 'integer', [
 				'notnull' => true,
 				'length' => 4,
 				'default' => 0,
+				'unsigned' => true,
 			]);
 			$table->addColumn('actor_type', 'string', [
 				'notnull' => true,
@@ -905,12 +915,4 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 		return $schema;
 	}
 
-	/**
-	 * @param IOutput $output
-	 * @param \Closure $schemaClosure The `\Closure` returns a `Schema`
-	 * @param array $options
-	 * @since 13.0.0
-	 */
-	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
-	}
 }

--- a/core/Migrations/Version13000Date20170919121250.php
+++ b/core/Migrations/Version13000Date20170919121250.php
@@ -1,0 +1,102 @@
+<?php
+namespace OC\Core\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version13000Date20170919121250 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param \Closure $schemaClosure The `\Closure` returns a `Schema`
+	 * @param array $options
+	 * @since 13.0.0
+	 */
+	public function preSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param \Closure $schemaClosure The `\Closure` returns a `Schema`
+	 * @param array $options
+	 * @return null|Schema
+	 * @since 13.0.0
+	 */
+	public function changeSchema(IOutput $output, \Closure $schemaClosure, array $options) {
+		/** @var Schema $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('jobs');
+		$column = $table->getColumn('id');
+		$column->setUnsigned(true);
+
+		$table = $schema->getTable('authtoken');
+		$column = $table->getColumn('id');
+		$column->setUnsigned(true);
+		$column = $table->getColumn('type');
+		$column->setUnsigned(true);
+		$column = $table->getColumn('remember');
+		$column->setUnsigned(true);
+		$column = $table->getColumn('last_activity');
+		$column->setUnsigned(true);
+		$column = $table->getColumn('last_check');
+		$column->setUnsigned(true);
+
+		$table = $schema->getTable('bruteforce_attempts');
+		$column = $table->getColumn('id');
+		$column->setUnsigned(true);
+		$column = $table->getColumn('occurred');
+		$column->setUnsigned(true);
+
+		$table = $schema->getTable('comments');
+		$column = $table->getColumn('id');
+		$column->setUnsigned(true);
+		$column = $table->getColumn('parent_id');
+		$column->setUnsigned(true);
+		$column = $table->getColumn('topmost_parent_id');
+		$column->setUnsigned(true);
+		$column = $table->getColumn('children_count');
+		$column->setUnsigned(true);
+
+		$table = $schema->getTable('file_locks');
+		$column = $table->getColumn('id');
+		$column->setUnsigned(true);
+
+		$table = $schema->getTable('systemtag');
+		$column = $table->getColumn('id');
+		$column->setUnsigned(true);
+
+		$table = $schema->getTable('systemtag_object_mapping');
+		$column = $table->getColumn('systemtagid');
+		$column->setUnsigned(true);
+
+		$table = $schema->getTable('systemtag_group');
+		$column = $table->getColumn('systemtagid');
+		$column->setUnsigned(true);
+
+		$table = $schema->getTable('vcategory');
+		$column = $table->getColumn('id');
+		$column->setUnsigned(true);
+
+		$table = $schema->getTable('vcategory_to_object');
+		$column = $table->getColumn('objid');
+		$column->setUnsigned(true);
+		$column = $table->getColumn('categoryid');
+		$column->setUnsigned(true);
+
+		return $schema;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param \Closure $schemaClosure The `\Closure` returns a `Schema`
+	 * @param array $options
+	 * @since 13.0.0
+	 */
+	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+	}
+}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -495,6 +495,7 @@ return array(
     'OC\\Core\\Migrations\\Version13000Date20170705121758' => $baseDir . '/core/Migrations/Version13000Date20170705121758.php',
     'OC\\Core\\Migrations\\Version13000Date20170718121200' => $baseDir . '/core/Migrations/Version13000Date20170718121200.php',
     'OC\\Core\\Migrations\\Version13000Date20170814074715' => $baseDir . '/core/Migrations/Version13000Date20170814074715.php',
+    'OC\\Core\\Migrations\\Version13000Date20170919121250' => $baseDir . '/core/Migrations/Version13000Date20170919121250.php',
     'OC\\DB\\Adapter' => $baseDir . '/lib/private/DB/Adapter.php',
     'OC\\DB\\AdapterMySQL' => $baseDir . '/lib/private/DB/AdapterMySQL.php',
     'OC\\DB\\AdapterOCI8' => $baseDir . '/lib/private/DB/AdapterOCI8.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -525,6 +525,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Core\\Migrations\\Version13000Date20170705121758' => __DIR__ . '/../../..' . '/core/Migrations/Version13000Date20170705121758.php',
         'OC\\Core\\Migrations\\Version13000Date20170718121200' => __DIR__ . '/../../..' . '/core/Migrations/Version13000Date20170718121200.php',
         'OC\\Core\\Migrations\\Version13000Date20170814074715' => __DIR__ . '/../../..' . '/core/Migrations/Version13000Date20170814074715.php',
+        'OC\\Core\\Migrations\\Version13000Date20170919121250' => __DIR__ . '/../../..' . '/core/Migrations/Version13000Date20170919121250.php',
         'OC\\DB\\Adapter' => __DIR__ . '/../../..' . '/lib/private/DB/Adapter.php',
         'OC\\DB\\AdapterMySQL' => __DIR__ . '/../../..' . '/lib/private/DB/AdapterMySQL.php',
         'OC\\DB\\AdapterOCI8' => __DIR__ . '/../../..' . '/lib/private/DB/AdapterOCI8.php',

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(13, 0, 0, 3);
+$OC_Version = array(13, 0, 0, 4);
 
 // The human readable string
 $OC_VersionString = '13.0.0 alpha';


### PR DESCRIPTION
Actually the missing unsigned in the #6264 PR where due to the script ignoring it 🙈 
Dav app is fixed in #6562 

So this fixes the old migration, which you shouldn't do, but we want to prevent changing the tables twice on huge instances and this was never in a release so far, so should be okay.