### PR TITLE
Read appinfo from a local cache

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -600,7 +600,7 @@ class OC_App {
 			$file = $appPath . '/appinfo/info.xml';
 		}
 
-		$parser = new InfoParser(\OC::$server->getMemCacheFactory()->create('core.appinfo'));
+		$parser = new InfoParser(\OC::$server->getMemCacheFactory()->createLocal('core.appinfo'));
 		$data = $parser->parse($file);
 
 		if (is_array($data)) {


### PR DESCRIPTION
This safes hitting redis on each requests (and scales with the number of apps).

@icewind1991 maybe we should add proper support to create a local cache to the factory interface?