### PR TITLE
Check whether an app archive can be extracted

### DIFF
--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -288,7 +288,14 @@ class Installer {
 					$archive = new TAR($tempFile);
 
 					if($archive) {
-						$archive->extract($extractDir);
+						if (!$archive->extract($extractDir)) {
+							throw new \Exception(
+								sprintf(
+									'Could not extract app %s',
+									$appId
+								)
+							);
+						}
 						$allFiles = scandir($extractDir);
 						$folders = array_diff($allFiles, ['.', '..']);
 						$folders = array_values($folders);


### PR DESCRIPTION
For some (yet unknown) reason the installation/update of apps fails under certain conditions. Most annoyingly, the error message is misleading.

* https://github.com/nextcloud/mail/issues/492
* https://github.com/nextcloud/twofactor_u2f/issues/52
* https://github.com/nextcloud/dashboard/issues/16

If extraction fails we should not continue the installation/update
process as the info.xml cannot be loaded and an unrelated error
occurs.

As far as I followed the code paths it looks like we're checking wether the temp directory is writable. Hence I'm unsure why exactly it fails to unpack the archive on some installations.

Fixes https://github.com/nextcloud/mail/issues/492, https://github.com/nextcloud/twofactor_u2f/issues/52, https://github.com/nextcloud/dashboard/issues/16
