### PR TITLE
Unify appearance of avatars for undefined and unknown users

### DIFF
--- a/core/js/jquery.avatar.js
+++ b/core/js/jquery.avatar.js
@@ -73,6 +73,7 @@
 				user = this.data('user');
 			} else {
 				this.imageplaceholder('?');
+				this.css('background-color', '#b9b9b9');
 				return;
 			}
 		}

--- a/core/js/jquery.avatar.js
+++ b/core/js/jquery.avatar.js
@@ -48,6 +48,11 @@
 
 (function ($) {
 	$.fn.avatar = function(user, size, ie8fix, hidedefault, callback, displayname) {
+		var setAvatarForUnknownUser = function(target) {
+			target.imageplaceholder('?');
+			target.css('background-color', '#b9b9b9');
+		};
+
 		if (typeof(user) !== 'undefined') {
 			user = String(user);
 		}
@@ -72,8 +77,7 @@
 			if (typeof(this.data('user')) !== 'undefined') {
 				user = this.data('user');
 			} else {
-				this.imageplaceholder('?');
-				this.css('background-color', '#b9b9b9');
+				setAvatarForUnknownUser(this);
 				return;
 			}
 		}
@@ -113,8 +117,7 @@
 							$div.imageplaceholder(user, result.data.displayname);
 						} else {
 							// User does not exist
-							$div.imageplaceholder('?');
-							$div.css('background-color', '#b9b9b9');
+							setAvatarForUnknownUser($div);
 						}
 					} else {
 						$div.hide();

--- a/core/js/jquery.avatar.js
+++ b/core/js/jquery.avatar.js
@@ -113,7 +113,7 @@
 							$div.imageplaceholder(user, result.data.displayname);
 						} else {
 							// User does not exist
-							$div.imageplaceholder(user, '?');
+							$div.imageplaceholder('?');
 							$div.css('background-color', '#b9b9b9');
 						}
 					} else {

--- a/core/js/tests/specs/jquery.avatarSpec.js
+++ b/core/js/tests/specs/jquery.avatarSpec.js
@@ -62,10 +62,12 @@ describe('jquery.avatar tests', function() {
 
 	it('undefined user', function() {
 		spyOn($div, 'imageplaceholder');
+		spyOn($div, 'css');
 
 		$div.avatar();
 		
 		expect($div.imageplaceholder).toHaveBeenCalledWith('?');
+		expect($div.css).toHaveBeenCalledWith('background-color', '#b9b9b9');
 	});
 
 	describe('no avatar', function() {
@@ -86,6 +88,7 @@ describe('jquery.avatar tests', function() {
 
 		it('show placeholder for non existing user', function() {
 			spyOn($div, 'imageplaceholder');
+			spyOn($div, 'css');
 			$div.avatar('foo');
 
 			fakeServer.requests[0].respond(
@@ -97,6 +100,7 @@ describe('jquery.avatar tests', function() {
 			);
 
 			expect($div.imageplaceholder).toHaveBeenCalledWith('foo', '?');
+			expect($div.css).toHaveBeenCalledWith('background-color', '#b9b9b9');
 		});
 
 		it('show no placeholder', function() {

--- a/core/js/tests/specs/jquery.avatarSpec.js
+++ b/core/js/tests/specs/jquery.avatarSpec.js
@@ -99,7 +99,7 @@ describe('jquery.avatar tests', function() {
 				})
 			);
 
-			expect($div.imageplaceholder).toHaveBeenCalledWith('foo', '?');
+			expect($div.imageplaceholder).toHaveBeenCalledWith('?');
 			expect($div.css).toHaveBeenCalledWith('background-color', '#b9b9b9');
 		});
 


### PR DESCRIPTION
When calling the jQuery avatar plugin with a user that did not exist __*__ (that is, users for which `/avatar/{user}/{size}` return a JSON response with an empty _displayname_ value) "_?_" on a grey background was shown. However, if the jQuery avatar plugin was called with an `undefined` JavaScript value then "_?_" was shown on a bluish background. This pull request unifies both cases to use the grey background.

Before:
![before-unifying](https://user-images.githubusercontent.com/26858233/30652858-c25d1f2e-9e29-11e7-86c1-96cae56cb7f9.png)

After:
![after-unifying](https://user-images.githubusercontent.com/26858233/30652871-c8c08856-9e29-11e7-91a1-2676b4227bda.png)

__*__ Since https://github.com/nextcloud/server/pull/6293, to prevent leaking that information, it is no longer possible to know whether a user exists or not just by sending a request to the public URL `/avatar/{user}/{size}`; I have not removed the _User does not exist_ branch in the `if` just in case `/avatar/{user}/{size}` returns an empty `displayname` property again in the future (unlikely, though).

In any case, due to that change please note that you can no longer rely on the jQuery avatar plugin to automatically show the unknown user avatar if the provided user does not exist, you must do it explicitly by calling it like `.avatar(undefined, desiredAvatarSize)`.
