### PR TITLE
Add multipart upload for s3

### DIFF
--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -74,7 +74,7 @@ trait S3ObjectTrait {
 
 	}
 
-	private function singlePartUpload($urn, $stream) {
+	protected function singlePartUpload($urn, $stream) {
 		$this->getConnection()->putObject([
 			'Bucket' => $this->bucket,
 			'Key' => $urn,
@@ -82,7 +82,7 @@ trait S3ObjectTrait {
 		]);
 	}
 
-	private function multiPartUpload($urn, $stream) {
+	protected function multiPartUpload($urn, $stream) {
 		$uploader = new MultipartUploader($this->getConnection(), $stream, [
 			'bucket' => $this->bucket,
 			'key' => $urn,

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -26,7 +26,7 @@ use Aws\S3\MultipartUploader;
 use Aws\S3\S3Client;
 use Psr\Http\Message\StreamInterface;
 
-const S3_UPLOAD_PART_SIZE = 5368709120;
+const S3_UPLOAD_PART_SIZE = 524288000; // 500MB
 
 trait S3ObjectTrait {
 	/**
@@ -86,6 +86,7 @@ trait S3ObjectTrait {
 		$uploader = new MultipartUploader($this->getConnection(), $stream, [
 			'bucket' => $this->bucket,
 			'key' => $urn,
+			'part_size' => S3_UPLOAD_PART_SIZE
 		]);
 
 		$tries = 0;
@@ -94,6 +95,7 @@ trait S3ObjectTrait {
 			try {
 				$result = $uploader->upload();
 			} catch (MultipartUploadException $e) {
+				\OC::$server->getLogger()->logException($e);
 				rewind($stream);
 				$tries++;
 

--- a/tests/lib/Files/ObjectStore/S3Test.php
+++ b/tests/lib/Files/ObjectStore/S3Test.php
@@ -23,19 +23,32 @@ namespace Test\Files\ObjectStore;
 
 use OC\Files\ObjectStore\S3;
 
+class MultiPartUploadS3 extends S3 {
+	public function multiPartUpload($urn, $stream) {
+		parent::multiPartUpload($urn, $stream);
+	}
+}
+
 /**
  * @group PRIMARY-s3
  */
 class S3Test extends ObjectStoreTest {
-	/**
-	 * @return \OCP\Files\ObjectStore\IObjectStore
-	 */
 	protected function getInstance() {
 		$config = \OC::$server->getConfig()->getSystemValue('objectstore');
 		if (!is_array($config) || $config['class'] !== 'OC\\Files\\ObjectStore\\S3') {
 			$this->markTestSkipped('objectstore not configured for s3');
 		}
 
-		return new S3($config['arguments']);
+		return new MultiPartUploadS3($config['arguments']);
+	}
+
+	public function testMultiPartUploader() {
+		$s3 = $this->getInstance();
+
+		$s3->multiPartUpload('multiparttest', fopen(__FILE__, 'r'));
+
+		$result = $s3->readObject('multiparttest');
+
+		$this->assertEquals(file_get_contents(__FILE__), stream_get_contents($result));
 	}
 }


### PR DESCRIPTION
When trying to upload a large file, use multipart upload instead

Fix #6796