### PR TITLE
Hide but leave the collapse button above link

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -312,7 +312,12 @@ kbd {
 		/* Fallback for old collapse button.
 		   TODO: to be removed. Leaved here for retro compatibility */
 		.collapse {
-			display: none;
+			opacity: 0;
+			position: absolute;
+			width: 44px;
+			height: 44px;
+			margin: 0;
+			z-index: 110;
 		}
 		&:after {
 			position: absolute;


### PR DESCRIPTION
This will greatly improve our retro-compatibility with the new app-navigation guidelines
@nextcloud/designers 