### PR TITLE
Don't add a LIKE condition when it's not needed

### DIFF
--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -890,7 +890,11 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			$or->add($query2->expr()->eq('cp.name', $query->createNamedParameter($property)));
 		}
 		$query2->andWhere($or);
-		$query2->andWhere($query2->expr()->ilike('cp.value', $query->createNamedParameter('%' . $this->db->escapeLikeParameter($pattern) . '%')));
+
+		// No need for like when the pattern is empty
+		if ('' !== $pattern) {
+			$query2->andWhere($query2->expr()->ilike('cp.value', $query->createNamedParameter('%' . $this->db->escapeLikeParameter($pattern) . '%')));
+		}
 
 		$query->select('c.carddata', 'c.uri')->from($this->dbCardsTable, 'c')
 			->where($query->expr()->in('c.id', $query->createFunction($query2->getSQL())));


### PR DESCRIPTION
Detected as long query:
```sql
SELECT `c`.`carddata`, `c`.`uri` FROM `oc_cards` c WHERE `c`.`id` IN (
    SELECT DISTINCT `cp`.`cardid` FROM `oc_cards_properties` cp WHERE (
           `cp`.`addressbookid` = '2') AND 
           (`cp`.`name` = 'FN') AND 
           (`cp`.`value`  COLLATE UTF8_general_ci LIKE '%%')
);
```