### PR TITLE
Make ContactsStore a public API

### DIFF
--- a/apps/dav/appinfo/app.php
+++ b/apps/dav/appinfo/app.php
@@ -53,6 +53,8 @@ $cm->register(function() use ($cm, $app) {
 	$user = \OC::$server->getUserSession()->getUser();
 	if (!is_null($user)) {
 		$app->setupContactsProvider($cm, $user->getUID());
+	} else {
+		$app->setupSystemContactsProvider($cm);
 	}
 });
 

--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -76,6 +76,16 @@ class Application extends App {
 	}
 
 	/**
+	 * @param IManager $contactsManager
+	 */
+	public function setupSystemContactsProvider(IContactsManager $contactsManager) {
+		/** @var ContactsManager $cm */
+		$cm = $this->getContainer()->query(ContactsManager::class);
+		$urlGenerator = $this->getContainer()->getServer()->getURLGenerator();
+		$cm->setupSystemContactsProvider($contactsManager, $urlGenerator);
+	}
+
+	/**
 	 * @param ICalendarManager $calendarManager
 	 * @param string $userId
 	 */

--- a/apps/dav/lib/CardDAV/ContactsManager.php
+++ b/apps/dav/lib/CardDAV/ContactsManager.php
@@ -55,6 +55,14 @@ class ContactsManager {
 	public function setupContactsProvider(IManager $cm, $userId, IURLGenerator $urlGenerator) {
 		$addressBooks = $this->backend->getAddressBooksForUser("principals/users/$userId");
 		$this->register($cm, $addressBooks, $urlGenerator);
+		$this->setupSystemContactsProvider($cm, $urlGenerator);
+	}
+
+	/**
+	 * @param IManager $cm
+	 * @param IURLGenerator $urlGenerator
+	 */
+	public function setupSystemContactsProvider(IManager $cm, IURLGenerator $urlGenerator) {
 		$addressBooks = $this->backend->getAddressBooksForUser("principals/system/system");
 		$this->register($cm, $addressBooks, $urlGenerator);
 	}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -93,6 +93,7 @@ return array(
     'OCP\\Contacts' => $baseDir . '/lib/public/Contacts.php',
     'OCP\\Contacts\\ContactsMenu\\IAction' => $baseDir . '/lib/public/Contacts/ContactsMenu/IAction.php',
     'OCP\\Contacts\\ContactsMenu\\IActionFactory' => $baseDir . '/lib/public/Contacts/ContactsMenu/IActionFactory.php',
+    'OCP\\Contacts\\ContactsMenu\\IContactsStore' => $baseDir . '/lib/public/Contacts/ContactsMenu/IContactsStore.php',
     'OCP\\Contacts\\ContactsMenu\\IEntry' => $baseDir . '/lib/public/Contacts/ContactsMenu/IEntry.php',
     'OCP\\Contacts\\ContactsMenu\\ILinkAction' => $baseDir . '/lib/public/Contacts/ContactsMenu/ILinkAction.php',
     'OCP\\Contacts\\ContactsMenu\\IProvider' => $baseDir . '/lib/public/Contacts/ContactsMenu/IProvider.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -123,6 +123,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Contacts' => __DIR__ . '/../../..' . '/lib/public/Contacts.php',
         'OCP\\Contacts\\ContactsMenu\\IAction' => __DIR__ . '/../../..' . '/lib/public/Contacts/ContactsMenu/IAction.php',
         'OCP\\Contacts\\ContactsMenu\\IActionFactory' => __DIR__ . '/../../..' . '/lib/public/Contacts/ContactsMenu/IActionFactory.php',
+        'OCP\\Contacts\\ContactsMenu\\IContactsStore' => __DIR__ . '/../../..' . '/lib/public/Contacts/ContactsMenu/IContactsStore.php',
         'OCP\\Contacts\\ContactsMenu\\IEntry' => __DIR__ . '/../../..' . '/lib/public/Contacts/ContactsMenu/IEntry.php',
         'OCP\\Contacts\\ContactsMenu\\ILinkAction' => __DIR__ . '/../../..' . '/lib/public/Contacts/ContactsMenu/ILinkAction.php',
         'OCP\\Contacts\\ContactsMenu\\IProvider' => __DIR__ . '/../../..' . '/lib/public/Contacts/ContactsMenu/IProvider.php',

--- a/lib/private/Contacts/ContactsMenu/ContactsStore.php
+++ b/lib/private/Contacts/ContactsMenu/ContactsStore.php
@@ -35,8 +35,9 @@ use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\Contacts\ContactsMenu\IContactsStore;
 
-class ContactsStore {
+class ContactsStore implements IContactsStore {
 
 	/** @var IManager */
 	private $contactsManager;

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -115,6 +115,7 @@ use OCA\Theming\ThemingDefaults;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Collaboration\AutoComplete\IManager;
+use OCP\Contacts\ContactsMenu\IContactsStore;
 use OCP\Defaults;
 use OCA\Theming\Util;
 use OCP\Federation\ICloudIdManager;
@@ -1130,7 +1131,7 @@ class Server extends ServerContainer implements IServerContainer {
 			return new InstanceFactory($memcacheFactory->createLocal('remoteinstance.'), $c->getHTTPClientService());
 		});
 
-		$this->registerService(\OCP\Contacts\ContactsMenu\IContactsStore::class, function(Server $c) {
+		$this->registerService(IContactsStore::class, function(Server $c) {
 			return new ContactsStore(
 				$c->getContactsManager(),
 				$c->getConfig(),
@@ -1138,6 +1139,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getGroupManager()
 			);
 		});
+		$this->registerAlias(IContactsStore::class, ContactsStore::class);
 
 		$this->connectDispatcher();
 	}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -63,6 +63,7 @@ use OC\Collaboration\Collaborators\RemotePlugin;
 use OC\Collaboration\Collaborators\UserPlugin;
 use OC\Command\CronBus;
 use OC\Contacts\ContactsMenu\ActionFactory;
+use OC\Contacts\ContactsMenu\ContactsStore;
 use OC\Diagnostics\EventLogger;
 use OC\Diagnostics\QueryLogger;
 use OC\Federation\CloudIdManager;
@@ -1127,6 +1128,15 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService(IInstanceFactory::class, function(Server $c) {
 			$memcacheFactory = $c->getMemCacheFactory();
 			return new InstanceFactory($memcacheFactory->createLocal('remoteinstance.'), $c->getHTTPClientService());
+		});
+
+		$this->registerService(\OCP\Contacts\ContactsMenu\IContactsStore::class, function(Server $c) {
+			return new ContactsStore(
+				$c->getContactsManager(),
+				$c->getConfig(),
+				$c->getUserManager(),
+				$c->getGroupManager()
+			);
 		});
 
 		$this->connectDispatcher();

--- a/lib/public/Contacts/ContactsMenu/IContactsStore.php
+++ b/lib/public/Contacts/ContactsMenu/IContactsStore.php
@@ -4,6 +4,9 @@ namespace OCP\Contacts\ContactsMenu;
 
 use OCP\IUser;
 
+/**
+ * @since 13.0.0
+ */
 interface IContactsStore {
 
 
@@ -11,6 +14,7 @@ interface IContactsStore {
 	 * @param IUser $user
 	 * @param $filter
 	 * @return IEntry[]
+	 * @since 13.0.0
 	 */
 	public function getContacts(IUser $user, $filter);
 
@@ -20,6 +24,7 @@ interface IContactsStore {
 	 * @param integer $shareType
 	 * @param string $shareWith
 	 * @return IEntry|null
+	 * @since 13.0.0
 	 */
 	public function findOne(IUser $user, $shareType, $shareWith);
 

--- a/lib/public/Contacts/ContactsMenu/IContactsStore.php
+++ b/lib/public/Contacts/ContactsMenu/IContactsStore.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace OCP\Contacts\ContactsMenu;
+
+use OCP\IUser;
+
+interface IContactsStore {
+
+
+	/**
+	 * @param IUser $user
+	 * @param $filter
+	 * @return IEntry[]
+	 */
+	public function getContacts(IUser $user, $filter);
+
+	/**
+	 * @brief finds a contact by specifying the property to search on ($shareType) and the value ($shareWith)
+	 * @param IUser $user
+	 * @param integer $shareType
+	 * @param string $shareWith
+	 * @return IEntry|null
+	 */
+	public function findOne(IUser $user, $shareType, $shareWith);
+
+}


### PR DESCRIPTION
This makes the ContactsStore a public API which can be used by apps. As I described here: https://github.com/nextcloud/server/pull/5585#issuecomment-320496777 this is needed for e.g. the Chat app to know which users are allowed to Chat with other users. 
