### PR TITLE
Improve exception handling

### DIFF
--- a/index.php
+++ b/index.php
@@ -47,7 +47,16 @@ try {
 	OC_Template::printExceptionErrorPage($ex);
 } catch (\OC\HintException $ex) {
 	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
-	OC_Template::printErrorPage($ex->getMessage(), $ex->getHint());
+	try {
+		OC_Template::printErrorPage($ex->getMessage(), $ex->getHint());
+	} catch (Exception $ex2) {
+		\OC::$server->getLogger()->logException($ex, array('app' => 'index'));
+		\OC::$server->getLogger()->logException($ex2, array('app' => 'index'));
+
+		//show the user a detailed error page
+		OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
+		OC_Template::printExceptionErrorPage($ex);
+	}
 } catch (\OC\User\LoginException $ex) {
 	OC_Response::setStatus(OC_Response::STATUS_FORBIDDEN);
 	OC_Template::printErrorPage($ex->getMessage(), $ex->getMessage());

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -331,6 +331,9 @@ class Log implements ILogger {
 			'Line' => $exception->getLine(),
 		);
 		$data['Trace'] = preg_replace('!(' . implode('|', $this->methodsWithSensitiveParameters) . ')\(.*\)!', '$1(*** sensitive parameters replaced ***)', $data['Trace']);
+		if ($exception instanceof HintException) {
+			$data['Hint'] = $exception->getHint();
+		}
 		$msg = isset($context['message']) ? $context['message'] : 'Exception';
 		$msg .= ': ' . json_encode($data);
 		$this->log($level, $msg, $context);


### PR DESCRIPTION
If there is an exception in the template handling then a white page is shown. This improves the handling of this and shows text only about the internal error.

To test this just setup redis as cache and then disable the php-redis module.

And I added a log entry for the hint. Before the log only said, that redis is not available and the hint only contained the "Have you installed and enabled the PHP module?". With this that is now also included in the logs.

