### PR TITLE
Highlight active federation scope menu entry with bold heading

### DIFF
--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -237,11 +237,13 @@ input {
 		.menuitem {
 			font-size: 12.8px;
 			line-height: 1.6em;
-			.menuitem-text {
-				font-weight: 600;
-			}
 			.menuitem-text-detail {
 				opacity: .75;
+			}
+			&.active {
+				.menuitem-text {
+					font-weight: 600;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Yet another fix of this as it was messed up by the contrast enhancements. Before & after:
![screenshot from 2017-09-26 15-13-47](https://user-images.githubusercontent.com/925062/30862132-56dc8778-a2cd-11e7-9a2e-48f2c60240d2.png) ![screenshot from 2017-09-26 15-13-25](https://user-images.githubusercontent.com/925062/30862133-5704772e-a2cd-11e7-979f-49eae961d6c7.png)

Please review @nextcloud/designers @schiessle 