### PR TITLE
Do not stop on scss compilation failure

### DIFF
--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -183,6 +183,8 @@ class SCSSCacher {
 			$path,
 			\OC::$SERVERROOT . '/core/css/',
 		]);
+		// Continue after throw
+		$scss->setIgnoreErrors(true);
 		if($this->config->getSystemValue('debug')) {
 			// Debug mode
 			$scss->setFormatter(Expanded::class);


### PR DESCRIPTION
This will allow older versions (we need to backport this after merge) to not break if a variable is missing (for example) as future apps releases may use some newly implemented variable that have not been backported 😉 

The error is still thrown in the log file, but either the css gets cancelled or the variable is ignored. :)