### PR TITLE
Move sharing page options to menu in top right

### DIFF
--- a/apps/files_sharing/css/mobile.scss
+++ b/apps/files_sharing/css/mobile.scss
@@ -5,11 +5,6 @@
 	position: absolute !important;
 }
 
-/* hide text of download button, only show icon */
-#download-text {
-	display: none;
-}
-
 /* hide size and date columns */
 table th#headerSize,
 table td.filesize,

--- a/apps/files_sharing/css/mobile.scss
+++ b/apps/files_sharing/css/mobile.scss
@@ -46,5 +46,13 @@ table td.filename .nametext {
 	text-overflow: ellipsis;
 }
 
+// Hide Download label of 3-dot-menu on public share pages
+.share-menutoggle-text {
+	display: none;
+}
+#header .menutoggle {
+    padding-right: 14px;
+    background-position: center;
+}
 
 }

--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -5,6 +5,9 @@
 
 #header .menutoggle {
 	padding: 14px;
+	padding-right: 40px;
+	background-position: right 15px center;
+	color: $color-primary-text;
 	cursor: pointer;
 }
 

--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -225,6 +225,7 @@ thead {
 	position: relative;
 	top: -10px;
 	font-weight: 300;
-	font-size: 12px;
+	font-size: 11px;
+	opacity: .57;
 	margin-top: 10px;
 }

--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -94,6 +94,10 @@ thead {
 	margin-right: auto;
 }
 
+.download-size {
+	opacity: .5;
+}
+
 .directLink label {
 	font-weight: normal;
 	opacity: .5;
@@ -129,7 +133,6 @@ thead {
 
 #remote_address {
 	width: 200px;
-
 	margin-right: 4px;
 	height: 31px;
 }

--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -3,6 +3,11 @@
 	min-height: calc(100vh - 120px);
 }
 
+#header .menutoggle {
+	padding: 14px;
+	cursor: pointer;
+}
+
 /* force layout to make sure the content element's height matches its contents' height */
 .ie #content {
 	display: inline-block;
@@ -78,12 +83,6 @@ thead {
 	margin: 0;
 }
 
-
-.directDownload,
-.directLink {
-	margin-bottom: 20px;
-}
-
 /* keep long file names in one line to not overflow download button on mobile */
 .directDownload #downloadFile {
 	white-space: nowrap;
@@ -125,6 +124,7 @@ thead {
 /* within #save */
 #save .save-form {
 	position: relative;
+	margin-right: -10px;
 }
 
 #remote_address {
@@ -138,10 +138,9 @@ thead {
 	position: absolute;
 	background-color: transparent;
 	border: none;
-	margin: 2px 4px !important;
-	right: 7px;
-	top: -8px;
-	height: 30px;
+	margin: 0;
+	right: 0px;
+	height: 40px;
 }
 
 #public-upload .avatardiv {

--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -101,14 +101,13 @@ thead {
 	opacity: .5;
 }
 
-.directLink label {
-	font-weight: normal;
-	opacity: .5;
+#directLink-container {
+	flex-wrap: wrap;
 }
-.directLink input {
-	margin-left: 5px;
-	width: 300px;
-	max-width: 90%;
+
+#directLink {
+	margin-left: 30px;
+	flex-basis: 100%;
 }
 
 /* header buttons */

--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -1,6 +1,6 @@
 #content {
 	height: initial;
-	min-height: calc(100vh - 120px);
+	min-height: calc(100vh - 160px);
 }
 
 #header .menutoggle {

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -424,4 +424,18 @@ $(document).ready(function () {
 			return App.fileList.generatePreviewUrl(urlSpec);
 		};
 	}
+
+	$('#share-menutoggle').click(function() {
+		$('#share-menu').show();
+	});
+});
+
+
+$(document).mouseup(function(e) {
+	var container = $('#share-menu');
+
+	// if the target of the click isn't the container nor a descendant of the container
+	if (!container.is(e.target) && container.has(e.target).length === 0) {
+		container.hide();
+	}
 });

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -426,7 +426,7 @@ $(document).ready(function () {
 	}
 
 	$('#share-menutoggle').click(function() {
-		$('#share-menu').show();
+		$('#share-menu').toggleClass('open');
 	});
 });
 
@@ -436,6 +436,6 @@ $(document).mouseup(function(e) {
 
 	// if the target of the click isn't the container nor a descendant of the container
 	if (!container.is(e.target) && container.has(e.target).length === 0) {
-		container.hide();
+		container.removeClass('open');
 	}
 });

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -116,7 +116,8 @@ OCA.Sharing.PublicApp = {
 			scalingup: 0
 		};
 
-		var imgcontainer = $('<a href="' + $('#previewURL').val() + '" target="_blank"><img class="publicpreview" alt=""></a>');
+		var imgcontainer = $('<a href="' + $('#previewURL').val()
+			+ '" target="_blank"><img class="publicpreview" alt=""></a>');
 		var img = imgcontainer.find('.publicpreview');
 		img.css({
 			'max-width': previewWidth,

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -116,7 +116,8 @@ OCA.Sharing.PublicApp = {
 			scalingup: 0
 		};
 
-		var img = $('<img class="publicpreview" alt="">');
+		var imgcontainer = $('<a href="' + $('#previewURL').val() + '" target="_blank"><img class="publicpreview" alt=""></a>');
+		var img = imgcontainer.find('.publicpreview');
 		img.css({
 			'max-width': previewWidth,
 			'max-height': previewHeight
@@ -128,7 +129,7 @@ OCA.Sharing.PublicApp = {
 		if (mimetype === 'image/gif' &&
 			(maxGifSize === -1 || fileSize <= (maxGifSize * 1024 * 1024))) {
 			img.attr('src', $('#downloadURL').val());
-			img.appendTo('#imgframe');
+			imgcontainer.appendTo('#imgframe');
 		} else if (mimetype.substr(0, mimetype.indexOf('/')) === 'text' && window.btoa) {
 			// Undocumented Url to public WebDAV endpoint
 			var url = parent.location.protocol + '//' + location.host + OC.linkTo('', 'public.php/webdav');
@@ -145,11 +146,11 @@ OCA.Sharing.PublicApp = {
 			mimetype.substr(0, mimetype.indexOf('/')) === 'image' &&
 			mimetype !== 'image/svg+xml') {
 			img.attr('src', OC.filePath('files_sharing', 'ajax', 'publicpreview.php') + '?' + OC.buildQueryString(params));
-			img.appendTo('#imgframe');
+			imgcontainer.appendTo('#imgframe');
 		} else if (mimetype.substr(0, mimetype.indexOf('/')) !== 'video') {
 			img.attr('src', OC.Util.replaceSVGIcon(mimetypeIcon));
 			img.attr('width', 128);
-			img.appendTo('#imgframe');
+			imgcontainer.appendTo('#imgframe');
 		}
 		else if (previewSupported === 'true') {
 			$('#imgframe > video').attr('poster', OC.filePath('files_sharing', 'ajax', 'publicpreview.php') + '?' + OC.buildQueryString(params));

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -49,7 +49,7 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 
 		<div class="header-right">
 			<?php if (!isset($_['hideFileList']) || (isset($_['hideFileList']) && $_['hideFileList'] === false)) { ?>
-			<a href="#" title="<?php p($l->t('Download & link')) ?>" id="share-menutoggle" class="menutoggle icon-more-white"></a>
+			<a href="#" id="share-menutoggle" class="menutoggle icon-more-white"><?php p($l->t('Download')) ?></a>
 			<div id="share-menu" class="popovermenu menu hidden" style="display: block;">
 				<ul>
 					<li>

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -49,8 +49,8 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 
 		<div class="header-right">
 			<?php if (!isset($_['hideFileList']) || (isset($_['hideFileList']) && $_['hideFileList'] === false)) { ?>
-			<a href="#" id="share-menutoggle" class="menutoggle icon-more-white"><?php p($l->t('Download')) ?></a>
-			<div id="share-menu" class="popovermenu menu hidden" style="display: block;">
+			<a href="#" id="share-menutoggle" class="menutoggle icon-more-white"><span class="share-menutoggle-text"><?php p($l->t('Download')) ?></span></a>
+			<div id="share-menu" class="popovermenu menu hidden">
 				<ul>
 					<li>
 						<a href="<?php p($_['downloadURL']); ?>" id="download">

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -55,7 +55,7 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 					<li>
 						<a href="<?php p($_['downloadURL']); ?>" id="download">
 							<span class="icon icon-download"></span>
-							<span id="download-text"><?php p($l->t('Download'))?> (<?php p($_['fileSize']) ?>)</span>
+							<?php p($l->t('Download'))?>&nbsp;<span class="download-size">(<?php p($_['fileSize']) ?>)</span>
 						</a>
 					</li>
 					<li>

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -48,22 +48,38 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 		</div>
 
 		<div class="header-right">
-			<?php if (!isset($_['hideFileList']) || (isset($_['hideFileList']) && $_['hideFileList'] === false)) {
-				if ($_['server2serversharing']) {
-					?>
-					<span id="save" data-protected="<?php p($_['protected']) ?>"
-						  data-owner-display-name="<?php p($_['displayName']) ?>" data-owner="<?php p($_['owner']) ?>" data-name="<?php p($_['filename']) ?>">
-					<button id="save-button"><?php p($l->t('Add to your Nextcloud')) ?></button>
-					<form class="save-form hidden" action="#">
-						<input type="text" id="remote_address" placeholder="user@yourNextcloud.org"/>
-						<button id="save-button-confirm" class="icon-confirm svg" disabled></button>
-					</form>
-				</span>
-				<?php } ?>
-				<a href="<?php p($_['downloadURL']); ?>" id="download" class="button">
-					<span class="icon icon-download"></span>
-					<span id="download-text"><?php p($l->t('Download'))?></span>
-				</a>
+			<?php if (!isset($_['hideFileList']) || (isset($_['hideFileList']) && $_['hideFileList'] === false)) { ?>
+			<a href="#" title="<?php p($l->t('Download & link')) ?>" id="share-menutoggle" class="menutoggle icon-more-white"></a>
+			<div id="share-menu" class="popovermenu menu hidden" style="display: block;">
+				<ul>
+					<li>
+						<a href="<?php p($_['downloadURL']); ?>" id="download">
+							<span class="icon icon-download"></span>
+							<span id="download-text"><?php p($l->t('Download'))?> (<?php p($_['fileSize']) ?>)</span>
+						</a>
+					</li>
+					<li>
+						<a href="#">
+							<span class="icon icon-public"></span>
+							<label for="directLink"><?php p($l->t('Direct link')) ?></label>
+							<input id="directLink" class="hidden" type="text" readonly value="<?php p($_['downloadURL']); ?>">
+						</a>
+					</li>
+					<?php if ($_['server2serversharing']) { ?>
+					<li>
+						<a href="#" id="save" data-protected="<?php p($_['protected']) ?>"
+							  data-owner-display-name="<?php p($_['displayName']) ?>" data-owner="<?php p($_['owner']) ?>" data-name="<?php p($_['filename']) ?>">
+							<span class="icon icon-external"></span>
+							<span id="save-button"><?php p($l->t('Add to your Nextcloud')) ?></span>
+							<form class="save-form hidden" action="#">
+								<input type="text" id="remote_address" placeholder="user@yourNextcloud.org"/>
+								<button id="save-button-confirm" class="icon-confirm svg" disabled></button>
+							</form>
+						</a>
+					</li>
+					<?php } ?>
+				</ul>
+			</div>
 			<?php } ?>
 		</div>
 	</div></header>
@@ -84,16 +100,14 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 					<!-- Preview frame is filled via JS to support SVG images for modern browsers -->
 					<div id="imgframe"></div>
 				<?php endif; ?>
+				<?php if ($_['previewURL'] === $_['downloadURL']): ?>
 				<div class="directDownload">
 					<a href="<?php p($_['downloadURL']); ?>" id="downloadFile" class="button">
 						<span class="icon icon-download"></span>
 						<?php p($l->t('Download %s', array($_['filename'])))?> (<?php p($_['fileSize']) ?>)
 					</a>
 				</div>
-				<div class="directLink">
-					<label for="directLink"><?php p($l->t('Direct link')) ?></label>
-					<input id="directLink" type="text" readonly value="<?php p($_['previewURL']); ?>">
-				</div>
+				<?php endif; ?>
 			<?php endif; ?>
 		</div>
 		</div>

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -59,10 +59,10 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 						</a>
 					</li>
 					<li>
-						<a href="#">
+						<a href="#" id="directLink-container">
 							<span class="icon icon-public"></span>
 							<label for="directLink"><?php p($l->t('Direct link')) ?></label>
-							<input id="directLink" class="hidden" type="text" readonly value="<?php p($_['downloadURL']); ?>">
+							<input id="directLink" type="text" readonly value="<?php p($_['previewURL']); ?>">
 						</a>
 					</li>
 					<?php if ($_['server2serversharing']) { ?>

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -16,6 +16,7 @@
 <input type="hidden" id="isPublic" name="isPublic" value="1">
 <input type="hidden" name="dir" value="<?php p($_['dir']) ?>" id="dir">
 <input type="hidden" name="downloadURL" value="<?php p($_['downloadURL']) ?>" id="downloadURL">
+<input type="hidden" name="previewURL" value="<?php p($_['previewURL']) ?>" id="previewURL">
 <input type="hidden" name="sharingToken" value="<?php p($_['sharingToken']) ?>" id="sharingToken">
 <input type="hidden" name="filename" value="<?php p($_['filename']) ?>" id="filename">
 <input type="hidden" name="mimetype" value="<?php p($_['mimetype']) ?>" id="mimetype">

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -50,7 +50,7 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 		<div class="header-right">
 			<?php if (!isset($_['hideFileList']) || (isset($_['hideFileList']) && $_['hideFileList'] === false)) { ?>
 			<a href="#" id="share-menutoggle" class="menutoggle icon-more-white"><span class="share-menutoggle-text"><?php p($l->t('Download')) ?></span></a>
-			<div id="share-menu" class="popovermenu menu hidden">
+			<div id="share-menu" class="popovermenu menu">
 				<ul>
 					<li>
 						<a href="<?php p($_['downloadURL']); ?>" id="download">

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -143,6 +143,8 @@
 	#header-left, .header-left {
 		flex: 0 0;
 		flex-grow: 1;
+		overflow: hidden;
+		white-space: nowrap;
 	}
 
 	#header-right, .header-right {

--- a/core/css/mobile.scss
+++ b/core/css/mobile.scss
@@ -31,11 +31,6 @@
 	align-items: center;
 }
 
-/* on mobile public share, show only the icon of the logo, hide the text */
-#body-public #header .header-appname-container {
-	display: none;
-}
-
 /* do not show update notification on mobile */
 #update-notification {
 	display: none !important;


### PR DESCRIPTION
Making the sharing page a bit cleaner. Before & after:
![screenshot from 2017-09-26 16-56-45](https://user-images.githubusercontent.com/925062/30868167-26df17be-a2de-11e7-9efc-a7af5bb3a6a9.png)
![screenshot from 2017-09-26 17-13-26](https://user-images.githubusercontent.com/925062/30868168-26ebfff6-a2de-11e7-894d-96b5c03d3c8c.png)

TO DO:
- [x] Make the dropdown interactive – need @nextcloud/javascript help for this
- [ ] ~~Clicking »Direct link« should copy it to clipboard and give that as feedback in a tooltip~~
- [x] When there is no preview but only filetype icon (like for zip files etc), the download button should show directly under the filetype icon too