### PR TITLE
Fix cursor on user settings table

### DIFF
--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -543,7 +543,7 @@ td {
 	&.displayName > img, &.quota > img {
 		visibility: hidden;
 	}
-	&.password, &.quota, &.displayName {
+	&.password, &.displayName {
 		width: 12em;
 		cursor: pointer;
 	}

--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -547,6 +547,9 @@ td {
 		width: 12em;
 		cursor: pointer;
 	}
+	&.mailAddress {
+		cursor: pointer;
+	}
 	&.password > span, &.quota > span {
 		margin-right: 1.2em;
 		color: #C7C7C7;
@@ -636,11 +639,11 @@ span.usersLastLoginTooltip {
 }
 
 tr:hover > td {
-	&.password > span, &.displayName > span {
+	&.password > span, &.displayName > span, &.mailAddress > span {
 		margin: 0;
 		cursor: pointer;
 	}
-	&.password > img, &.displayName > img, &.quota > img {
+	&.password > img, &.displayName > img, &.mailAddress > img, &.quota > img {
 		visibility: visible;
 		cursor: pointer;
 	}

--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -540,7 +540,7 @@ td {
 			visibility: hidden;
 		}
 	}
-	&.displayName > img, &.quota > img {
+	&.displayName > img {
 		visibility: hidden;
 	}
 	&.password, &.displayName {
@@ -550,7 +550,7 @@ td {
 	&.mailAddress {
 		cursor: pointer;
 	}
-	&.password > span, &.quota > span {
+	&.password > span {
 		margin-right: 1.2em;
 		color: #C7C7C7;
 	}
@@ -643,7 +643,7 @@ tr:hover > td {
 		margin: 0;
 		cursor: pointer;
 	}
-	&.password > img, &.displayName > img, &.mailAddress > img, &.quota > img {
+	&.password > img, &.displayName > img, &.mailAddress > img {
 		visibility: visible;
 		cursor: pointer;
 	}


### PR DESCRIPTION
The table shown in the user settings used a pointer cursor when hovering on _Full name_, _Password_ and _Quota_ cells to communicate the user that the cells could be clicked.

This was wrong for the _Quota_ cells, as in this case clicking on the cell itself made nothing; you had to click on the select element itself for the dropdown to be shown.

Besides that, the email address cells (hidden by default; you have to show them through _Show email address_ in the _Settings_ in the app navigation bar) showed the default cursor, while it should show the pointer cursor instead (as, like with _Full name_ and _Password_, clicking anywhere on the cell showed the input field).

This pull request fixes those issues and also removes some unneeded CSS rules related to the quota cell.