### PR TITLE
Fix style of federation scope menu triangles, simplify CSS

### DIFF
--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -13,11 +13,6 @@ input {
 	clear: both;
 }
 
-.icon-federation-menu {
-	width: 16px;
-	float: right;
-}
-
 /* icons for sidebar */
 .nav-icon-personal-settings {
 	background-image: url('../img/personal.svg?v=1');
@@ -121,12 +116,19 @@ input {
 	}
 }
 
-#personal-settings-avatar-container h2 span[class^="icon-"] {
+.icon-federation-menu {
+	float: right;
 	padding-left: 16px;
 	background-size: 16px;
 	background-position: left 8px;
 	opacity: .3;
 	cursor: pointer;
+
+	.icon-triangle-s {
+		display: inline-block;
+		vertical-align: middle;
+		cursor: pointer;
+	}
 }
 
 .personal-show-container {
@@ -167,13 +169,6 @@ input {
 		h2 {
 			position: relative;
 			margin-bottom: 5px;
-			span[class^="icon-"] {
-				padding-left: 16px;
-				background-size: 16px;
-				background-position: left 8px;
-				opacity: .3;
-				cursor: pointer;
-			}
 		}
 		> form span {
 			&[class^="icon-checkmark"], &[class^="icon-error"] {

--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -219,7 +219,7 @@ input {
 
 .federationScopeMenu {
 	top: 44px;
-	margin: -5px 5px 0;
+	margin-right: calc(-50% + 30px); /* half - the triangle icon width - borders */
 	&.bubble::after {
 		right: 50%;
 		transform: translate(50%, 0);

--- a/settings/js/federationscopemenu.js
+++ b/settings/js/federationscopemenu.js
@@ -137,16 +137,6 @@
 			this.$el.removeClass('hidden');
 
 			OC.showMenu(null, this.$el);
-
-			//Set the menuwidth
-			var menuWidth = this.$el.width();
-			this.$el.css('width', menuWidth);
-
-			//Calculate menu position
-			var l = offsetIcon.left - offsetHeading.left;
-			l = l - (menuWidth / 2) + ($el.outerWidth()/2);
-			this.$el.css('left', l);
-
 		}
 	});
 

--- a/settings/templates/settings/personal/personal.info.php
+++ b/settings/templates/settings/personal/personal.info.php
@@ -56,7 +56,9 @@ vendor_style('jcrop/css/jquery.Jcrop');
 	<div id="personal-settings-avatar-container">
 		<form id="avatarform" class="section" method="post" action="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.avatar.postAvatar')); ?>">
 			<h2>
-				<label><?php p($l->t('Profile picture')); ?></label><span class="icon-federation-menu icon-password">&#9662;<span/>
+				<label><?php p($l->t('Profile picture')); ?></label><span class="icon-federation-menu icon-password">
+					<span class="icon-triangle-s"></span>
+				</span>
 			</h2>
 			<div id="displayavatar">
 				<div class="avatardiv"></div>
@@ -90,7 +92,9 @@ vendor_style('jcrop/css/jquery.Jcrop');
 			<form id="displaynameform" class="section">
 				<h2>
 					<label for="displayname"><?php p($l->t('Full name')); ?></label>
-					<span class="icon-federation-menu icon-password">&#9662;<span/>
+					<span class="icon-federation-menu icon-password">
+						<span class="icon-triangle-s"></span>
+					</span>
 				</h2>
 				<input type="text" id="displayname" name="displayname"
 					<?php if(!$_['displayNameChangeSupported']) { print_unescaped('class="hidden"'); } ?>
@@ -110,7 +114,9 @@ vendor_style('jcrop/css/jquery.Jcrop');
 			<form id="emailform" class="section">
 				<h2>
 					<label for="email"><?php p($l->t('Email')); ?></label>
-					<span class="icon-federation-menu icon-password">&#9662;<span/>
+					<span class="icon-federation-menu icon-password">
+						<span class="icon-triangle-s"></span>
+					</span>
 				</h2>
 				<div class="verify <?php if ($_['email'] === ''  || $_['emailScope'] !== 'public') p('hidden'); ?>">
 					<img id="verify-email" title="<?php p($_['emailMessage']); ?>" data-status="<?php p($_['emailVerification']) ?>" src="
@@ -149,7 +155,9 @@ vendor_style('jcrop/css/jquery.Jcrop');
 			<form id="phoneform" class="section">
 				<h2>
 					<label for="phone"><?php p($l->t('Phone number')); ?></label>
-					<span class="icon-federation-menu icon-password">&#9662;<span/>
+					<span class="icon-federation-menu icon-password">
+						<span class="icon-triangle-s"></span>
+					</span>
 				</h2>
 				<input type="tel" id="phone" name="phone" <?php if(!$_['lookupServerUploadEnabled']) print_unescaped('disabled="1"'); ?>
 					   value="<?php p($_['phone']) ?>"
@@ -167,7 +175,9 @@ vendor_style('jcrop/css/jquery.Jcrop');
 			<form id="addressform" class="section">
 				<h2>
 					<label for="address"><?php p($l->t('Address')); ?></label>
-					<span class="icon-federation-menu icon-password">&#9662;<span/>
+					<span class="icon-federation-menu icon-password">
+						<span class="icon-triangle-s"></span>
+					</span>
 				</h2>
 				<input type="text" id="address" name="address" <?php if(!$_['lookupServerUploadEnabled']) print_unescaped('disabled="1"');  ?>
 					   placeholder="<?php p($l->t('Your postal address')); ?>"
@@ -185,7 +195,9 @@ vendor_style('jcrop/css/jquery.Jcrop');
 			<form id="websiteform" class="section">
 				<h2>
 					<label for="website"><?php p($l->t('Website')); ?></label>
-					<span class="icon-federation-menu icon-password">&#9662;<span/>
+					<span class="icon-federation-menu icon-password">
+						<span class="icon-triangle-s"></span>
+					</span>
 				</h2>
 				<?php if($_['lookupServerUploadEnabled']) { ?>
 				<div class="verify <?php if ($_['website'] === ''  || $_['websiteScope'] !== 'public') p('hidden'); ?>">
@@ -230,7 +242,9 @@ vendor_style('jcrop/css/jquery.Jcrop');
 			<form id="twitterform" class="section">
 				<h2>
 					<label for="twitter"><?php p($l->t('Twitter')); ?></label>
-					<span class="icon-federation-menu icon-password">&#9662;<span/>
+					<span class="icon-federation-menu icon-password">
+						<span class="icon-triangle-s"></span>
+					</span>
 				</h2>
 				<?php if($_['lookupServerUploadEnabled']) { ?>
 				<div class="verify <?php if ($_['twitter'] === ''  || $_['twitterScope'] !== 'public') p('hidden'); ?>">


### PR DESCRIPTION
Before we used the strange-looking elongated unicode arrows:
![screenshot from 2017-09-27 12-19-56](https://user-images.githubusercontent.com/925062/30908681-a20a9256-a37e-11e7-9570-cbf4d929f78d.png)
Now it’s the proper ones, compare to the language selection field:
![screenshot from 2017-09-27 12-19-27](https://user-images.githubusercontent.com/925062/30908682-a21132e6-a37e-11e7-8740-d0e74a4ed5e3.png)

TODO

- [ ] I need help with the positioning of the popover menu as you can see that’s wrong atm. @nextcloud/javascript 