### PR TITLE
Adjust settings navigation headings to style used in Mail & Calendar

### DIFF
--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -1267,7 +1267,14 @@ doesnotexist:-o-prefocus, .strengthify-wrapper {
 .settings-caption {
 	font-weight: bold;
 	line-height: 44px;
-	padding: 0 12px;
+	padding: 0 44px;
 	white-space: nowrap;
 	text-overflow: ellipsis;
+	// !important to overwrite specific hover and focus
+	opacity: .4 !important;
+	box-shadow: none !important;
+
+	&:not(:first-child) {
+		margin-top: 22px;
+	}
 }


### PR DESCRIPTION
This is the last step before we standardize this, to see that it works across apps.

Before & after:
![screenshot from 2017-09-27 12-26-59](https://user-images.githubusercontent.com/925062/30908843-32f8825a-a37f-11e7-90b0-5cd11ae94ffa.png) ![screenshot from 2017-09-27 12-25-54](https://user-images.githubusercontent.com/925062/30908844-32fe18be-a37f-11e7-908b-e20f5a460dcc.png)

- Proper whitespace above heading to separate sections
- Remove hover effect
- Indent to be in one flow with the rest of the text
- Adjust to look like the headings in the Mail app
- Remove bold as we only use that in the navigation for unread / important items (we could use it if some settings need your attention)
- Less prominence as compared to the list entries because in the navigation the actual entries are more important than the headings

Please review @nextcloud/designers 