### PR TITLE
Remove avatar on user deletion

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1362,6 +1362,9 @@ class View {
 		$path = Filesystem::normalizePath($this->fakeRoot . '/' . $path);
 
 		$mount = Filesystem::getMountManager()->find($path);
+		if (!$mount) {
+			return false;
+		}
 		$storage = $mount->getStorage();
 		$internalPath = $mount->getInternalPath($path);
 		if ($storage) {
@@ -1411,6 +1414,9 @@ class View {
 		$path = $this->getAbsolutePath($directory);
 		$path = Filesystem::normalizePath($path);
 		$mount = $this->getMount($directory);
+		if (!$mount) {
+			return [];
+		}
 		$storage = $mount->getStorage();
 		$internalPath = $mount->getInternalPath($path);
 		if ($storage) {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -133,6 +133,7 @@ use OCP\Share;
 use OCP\Share\IShareHelper;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Class Server
@@ -348,6 +349,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$defaultTokenProvider = null;
 			}
 
+			$dispatcher = $c->getEventDispatcher();
+
 			$userSession = new \OC\User\Session($manager, $session, $timeFactory, $defaultTokenProvider, $c->getConfig(), $c->getSecureRandom(), $c->getLockdownManager());
 			$userSession->listen('\OC\User', 'preCreateUser', function ($uid, $password) {
 				\OC_Hook::emit('OC_User', 'pre_createUser', array('run' => true, 'uid' => $uid, 'password' => $password));
@@ -356,9 +359,10 @@ class Server extends ServerContainer implements IServerContainer {
 				/** @var $user \OC\User\User */
 				\OC_Hook::emit('OC_User', 'post_createUser', array('uid' => $user->getUID(), 'password' => $password));
 			});
-			$userSession->listen('\OC\User', 'preDelete', function ($user) {
+			$userSession->listen('\OC\User', 'preDelete', function ($user) use ($dispatcher) {
 				/** @var $user \OC\User\User */
 				\OC_Hook::emit('OC_User', 'pre_deleteUser', array('run' => true, 'uid' => $user->getUID()));
+				$dispatcher->dispatch('OCP\IUser::preDelete', new GenericEvent($user));
 			});
 			$userSession->listen('\OC\User', 'postDelete', function ($user) {
 				/** @var $user \OC\User\User */

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -118,6 +118,7 @@ use OCP\Defaults;
 use OCA\Theming\Util;
 use OCP\Federation\ICloudIdManager;
 use OCP\Authentication\LoginCredentials\IStore;
+use OCP\Files\NotFoundException;
 use OCP\ICacheFactory;
 use OCP\IDBConnection;
 use OCP\IL10N;
@@ -1151,6 +1152,8 @@ class Server extends ServerContainer implements IServerContainer {
 			try {
 				$avatar = $manager->getAvatar($user->getUID());
 				$avatar->remove();
+			} catch (NotFoundException $e) {
+				// no avatar to remove
 			} catch (\Exception $e) {
 				// Ignore exceptions
 				$logger->info('Could not cleanup avatar of ' . $user->getUID());


### PR DESCRIPTION
Fixes #6621 

Basically I added a new event to the event dispatcher: `OCP\IUser::preDelete`
And then connected this to remove the avatar.