### PR TITLE
navigate to the root directory when showing the main filelist

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -565,6 +565,7 @@
 		 */
 		_onShow: function(e) {
 			if (this.shown) {
+				this._setCurrentDir('/', false);
 				this.reload();
 			}
 			this.shown = true;


### PR DESCRIPTION
Possible fix for https://github.com/nextcloud/server/issues/6641

To test:

- Navigate into a folder
- Go to "Recent Files"
- Go to "All files"

On master it should briefly flash the content of the folder you previously navigated into before going to the home folder.
With this patch it should immediately go to the root folder.