### PR TITLE
Start with unified Shared entry to view all shares, ref #5559

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -94,6 +94,7 @@
 .nav-icon-favorites {
 	background-image: url('../img/star.svg?v=1');
 }
+.nav-icon-sharing,
 .nav-icon-sharingin,
 .nav-icon-sharingout {
 	background-image: url('../img/share.svg?v=1');

--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -48,6 +48,17 @@ if ($config->getAppValue('core', 'shareapi_enabled', 'yes') === 'yes') {
 	\OCA\Files\App::getNavigationManager()->add(function () {
 		$l = \OC::$server->getL10N('files_sharing');
 		return [
+			'id' => 'sharing',
+			'appname' => 'files_sharing',
+			'script' => 'list.php',
+			'order' => 14,
+			'name' => $l->t('Shared'),
+		];
+	});
+
+	\OCA\Files\App::getNavigationManager()->add(function () {
+		$l = \OC::$server->getL10N('files_sharing');
+		return [
 			'id' => 'sharingin',
 			'appname' => 'files_sharing',
 			'script' => 'list.php',

--- a/apps/files_sharing/js/app.js
+++ b/apps/files_sharing/js/app.js
@@ -19,8 +19,34 @@ if (!OCA.Sharing) {
  */
 OCA.Sharing.App = {
 
+	_sharingFileList: null,
 	_inFileList: null,
 	_outFileList: null,
+	_linkFileList: null,
+
+	initSharing: function($el) {
+		if (this._sharingFileList) {
+			return this._sharingFileList;
+		}
+
+		this._sharingFileList = new OCA.Sharing.FileList(
+			$el,
+			{
+				id: 'shares.all',
+				scrollContainer: $('#app-content'),
+				sharedWithUser: true,
+				fileActions: this._createFileActions(),
+				config: OCA.Files.App.getFilesConfig()
+			}
+		);
+
+		this._extendFileList(this._sharingFileList);
+		this._sharingFileList.appName = t('files_sharing', 'Shared');
+		this._sharingFileList.$el.find('#emptycontent').html('<div class="icon-shared"></div>' +
+			'<h2>' + t('files_sharing', 'Nothing shared yet') + '</h2>' +
+			'<p>' + t('files_sharing', 'Shared files and folders will show up here') + '</p>');
+		return this._sharingFileList;
+	},
 
 	initSharingIn: function($el) {
 		if (this._inFileList) {
@@ -92,6 +118,12 @@ OCA.Sharing.App = {
 		return this._linkFileList;
 	},
 
+	removeSharing: function() {
+		if (this._sharingFileList) {
+			this._sharingFileList.$fileList.empty();
+		}
+	},
+
 	removeSharingIn: function() {
 		if (this._inFileList) {
 			this._inFileList.$fileList.empty();
@@ -116,9 +148,11 @@ OCA.Sharing.App = {
 	destroy: function() {
 		OCA.Files.fileActions.off('setDefault.app-sharing', this._onActionsUpdated);
 		OCA.Files.fileActions.off('registerAction.app-sharing', this._onActionsUpdated);
+		this.removeSharing();
 		this.removeSharingIn();
 		this.removeSharingOut();
 		this.removeSharingLinks();
+		this._sharingFileList = null;
 		this._inFileList = null;
 		this._outFileList = null;
 		this._linkFileList = null;
@@ -175,6 +209,12 @@ OCA.Sharing.App = {
 };
 
 $(document).ready(function() {
+	$('#app-content-sharing').on('show', function(e) {
+		OCA.Sharing.App.initSharing($(e.target));
+	});
+	$('#app-content-sharing').on('hide', function() {
+		OCA.Sharing.App.removeSharing();
+	});
 	$('#app-content-sharingin').on('show', function(e) {
 		OCA.Sharing.App.initSharingIn($(e.target));
 	});


### PR DESCRIPTION
My uneducated start at getting an Overview of all shared files – ref #5559. The goal is to have the »Shared« entry list all shares, and be collapsed by default. Only expanding it will show the detailed views we have now.

Need help / some proper developer to take over obviously, mainly on two fronts:
- [ ] We need to list all shares: with you, with others and by link. The parameter `sharedWithUser` doesn’t give the flexibility to return all? »linksOnly« is false by default so that should work.
- [ ] The current »Shared with you«, »Shared with others« and »Shared by link« should become subfolders of the new »Shared« folder. `getNavigationManager()->add()` doesn’t seem to have the flexibility to add subfolders instead of blindly into the list either.

Then there’s of course stuff like handling cases where some share settings are disabled and entries don’t show up anyway, and fixing the tests – which seem incomplete in the first place as link shares are missing?

cc @nextcloud/sharing @nextcloud/javascript 