### PR TITLE
Use full percentages in quota bar percentages

### DIFF
--- a/lib/private/Settings/Personal/PersonalInfo.php
+++ b/lib/private/Settings/Personal/PersonalInfo.php
@@ -116,7 +116,7 @@ class PersonalInfo implements ISettings {
 		$parameters = [
 			'total_space' => $totalSpace,
 			'usage' => \OC_Helper::humanFileSize($storageInfo['used']),
-			'usage_relative' => $storageInfo['relative'],
+			'usage_relative' => round($storageInfo['relative']),
 			'quota' => $storageInfo['quota'],
 			'avatarChangeSupported' => $user->canChangeAvatar(),
 			'lookupServerUploadEnabled' => $lookupServerUploadEnabled,


### PR DESCRIPTION
Nobody needs to know that one uses 53.77% of the available quota. 54 % percent is fully enough.

Before and after:

![bildschirmfoto 2017-09-28 um 17 58 58](https://user-images.githubusercontent.com/245432/30977088-cd91d170-a476-11e7-8046-feed97ee861f.png)
![bildschirmfoto 2017-09-28 um 17 58 29](https://user-images.githubusercontent.com/245432/30977091-d0ae1a94-a476-11e7-945b-8c231bc28743.png)
