### PR TITLE
Add support for 2FA failure logging

### DIFF
--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -231,6 +231,7 @@ class Manager {
 			]);
 		} else {
 			$this->publishEvent($user, 'twofactor_failed', [
+				$this->logger->warning('twofactor authentication failed', ['app' => 'core']);
 				'provider' => $provider->getDisplayName(),
 			]);
 		}

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -231,9 +231,9 @@ class Manager {
 			]);
 		} else {
 			$this->publishEvent($user, 'twofactor_failed', [
-				$this->logger->warning('twofactor authentication failed', ['app' => 'core']);
 				'provider' => $provider->getDisplayName(),
 			]);
+			$this->logger->warning('Two-factor Authentcaion Failure', ['app' => 'core']);
 		}
 		return $passed;
 	}


### PR DESCRIPTION
Write 2FA failure to logs for better auditing and support for third-party tools like fail2ban.