### PR TITLE
Show checkbox where the favourite icon is now

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -502,7 +502,7 @@ table td.filename .uploadtext {
 	display: inline-block;
 	float: left;
 }
-#fileList tr td.filename .action-favorite {
+#fileList tr td.filename .action-favorite:not(.menuitem) {
 	display: block;
 	float: left;
 	width: 30px;

--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -308,6 +308,7 @@ table td.filename .thumbnail {
 	display: inline-block;
 	width: 32px;
 	height: 32px;
+	background-size: 32px;
 	margin-left: 9px;
 	margin-top: 9px;
 	cursor: pointer;

--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -502,7 +502,7 @@ table td.filename .uploadtext {
 	display: inline-block;
 	float: left;
 }
-#fileList tr td.filename .action-favorite:not(.menuitem) {
+#fileList tr td.filename .favorite-mark {
 	display: block;
 	float: left;
 	width: 30px;
@@ -569,7 +569,8 @@ a.action > img {
 	margin-bottom: -1px;
 }
 
-#fileList a.action {
+#fileList a.action,
+#fileList div.favorite-mark {
 	display: inline;
 	padding: 17px 8px;
 	line-height: 50px;
@@ -617,7 +618,7 @@ a.action > img {
 	padding-left: 6px;
 }
 
-#fileList .action.action-favorite.permanent {
+#fileList .favorite-mark.permanent {
 	opacity: 1;
 }
 
@@ -716,10 +717,22 @@ table.dragshadow td.size {
 
 #filestable .filename .action .icon,
 #filestable .selectedActions a .icon,
+#filestable .filename .favorite-mark .icon,
 #controls .actions .button .icon {
 	display: inline-block;
 	vertical-align: middle;
 	background-size: 16px 16px;
+}
+
+#filestable .filename .favorite-mark {
+	// Override default icons to always hide the star icon and always show the
+	// starred icon even when hovered or focused.
+	& .icon-star {
+		background-image: none;
+	}
+	& .icon-starred {
+		background-image: url('../../../core/img/actions/starred.svg?v=1');
+	}
 }
 
 #filestable .filename .action .icon.hidden,

--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -337,13 +337,14 @@ table td.filename .nametext, .modified, .column-last>span:first-child { float:le
 /* TODO fix usability bug (accidental file/folder selection) */
 table td.filename .nametext {
 	position: absolute;
-	left: 55px;
 	padding: 0;
+	padding-left: 55px;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	width: 70%;
 	max-width: 800px;
 	height: 100%;
+	z-index: 10;
 }
 table td.filename .uploadtext {
 	position: absolute;

--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -232,9 +232,6 @@ table th#headerName {
 	position: relative;
 	height: 50px;
 }
-.has-favorites #headerName-container {
-	padding-left: 50px;
-}
 
 table th#headerSize, table td.filesize {
 	text-align: right;
@@ -296,7 +293,12 @@ table td.filename a.name {
 	line-height: 50px;
 	padding: 0;
 }
-table td.filename label.icon-loading-small {
+table td.filename .thumbnail-wrapper {
+	position: absolute;
+	width: 50px;
+	height: 50px;
+}
+table td.filename .thumbnail-wrapper.icon-loading-small {
 	&:after {
 		z-index: 10;
 	}
@@ -312,7 +314,6 @@ table td.filename .thumbnail {
 	margin-left: 9px;
 	margin-top: 9px;
 	cursor: pointer;
-	float: left;
 	position: absolute;
 	z-index: 4;
 }
@@ -322,12 +323,9 @@ table td.filename input.filename {
 	margin-left: 48px;
 	cursor: text;
 }
-.has-favorites table td.filename input.filename {
-	margin-left: 52px;
-}
 
 table td.filename a, table td.login, table td.logout, table td.download, table td.upload, table td.create, table td.delete { padding:3px 8px 8px 3px; }
-table td.filename .nametext, .uploadtext, .modified, .column-last>span:first-child { float:left; padding:15px 0; }
+table td.filename .nametext, .modified, .column-last>span:first-child { float:left; padding:15px 0; }
 
 .modified, .column-last>span:first-child {
 	position: relative;
@@ -347,13 +345,13 @@ table td.filename .nametext {
 	max-width: 800px;
 	height: 100%;
 }
+table td.filename .uploadtext {
+	position: absolute;
+	left: 55px;
+}
 /* ellipsis on file names */
 table td.filename .nametext .innernametext {
 	max-width: calc(100% - 100px) !important;
-}
-.has-favorites #fileList td.filename a.name {
-	left: 50px;
-	margin-right: 50px;
 }
 
 .hide-hidden-files #fileList tr.hidden-file,
@@ -481,9 +479,6 @@ table td.filename .uploadtext {
 	left: 18px;
 	z-index: 10;
 }
-.has-favorites .select-all {
-	left: 68px;
-}
 
 #fileList tr td.filename {
 	position: relative;
@@ -504,9 +499,10 @@ table td.filename .uploadtext {
 	float: left;
 }
 #fileList tr td.filename .favorite-mark {
+	position: absolute;
 	display: block;
-	float: left;
-	width: 30px;
+	top: -6px;
+	right: -6px;
 	line-height: 100%;
 	text-align: center;
 }
@@ -570,8 +566,7 @@ a.action > img {
 	margin-bottom: -1px;
 }
 
-#fileList a.action,
-#fileList div.favorite-mark {
+#fileList a.action {
 	display: inline;
 	padding: 17px 8px;
 	line-height: 50px;
@@ -662,9 +657,6 @@ table tr.summary td {
 }
 .summary .info {
 	margin-left: 40px;
-}
-.has-favorites .summary .info {
-	margin-left: 90px;
 }
 
 table.dragshadow {

--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -441,14 +441,14 @@ table td.filename .uploadtext {
 
 /* File checkboxes */
 #fileList tr td.filename>.selectCheckBox + label:before {
-	opacity: 0;
+	opacity: 0.3;
 	position: absolute;
 	bottom: 4px;
 	right: 0;
 	z-index: 10;
 }
 
-/* Show checkbox when hovering, checked, or selected */
+/* Show checkbox with full opacity when hovering, checked, or selected */
 #fileList tr:hover td.filename>.selectCheckBox + label:before,
 #fileList tr:focus td.filename>.selectCheckBox + label:before,
 #fileList tr td.filename>.selectCheckBox:checked + label:before,

--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -438,46 +438,27 @@ table td.filename .uploadtext {
 	opacity: .5;
 }
 
+table td.selection {
+	padding: 0;
+}
+
 /* File checkboxes */
-#fileList tr td.filename>.selectCheckBox + label:before {
+#fileList tr td.selection>.selectCheckBox + label:before {
 	opacity: 0.3;
-	position: absolute;
-	bottom: 4px;
-	right: 0;
-	z-index: 10;
 }
 
 /* Show checkbox with full opacity when hovering, checked, or selected */
-#fileList tr:hover td.filename>.selectCheckBox + label:before,
-#fileList tr:focus td.filename>.selectCheckBox + label:before,
-#fileList tr td.filename>.selectCheckBox:checked + label:before,
-#fileList tr.selected td.filename>.selectCheckBox + label:before {
+#fileList tr:hover td.selection>.selectCheckBox + label:before,
+#fileList tr:focus td.selection>.selectCheckBox + label:before,
+#fileList tr td.selection>.selectCheckBox:checked + label:before,
+#fileList tr.selected td.selection>.selectCheckBox + label:before {
 	opacity: 1;
 }
 
 /* Use label to have bigger clickable size for checkbox */
-#fileList tr td.filename>.selectCheckBox + label,
+#fileList tr td.selection>.selectCheckBox + label,
 .select-all + label {
-	background-position: 30px 30px;
-	height: 50px;
-	position: absolute;
-	width: 50px;
-	z-index: 5;
-}
-#fileList tr td.filename>.selectCheckBox {
-	/* sometimes checkbox height is bigger (KDE/Qt), so setting to absolute
-	 * to prevent it to increase the height */
-	position: absolute;
-	z-index: 10;
-}
-.select-all + label {
-	top: 0;
-}
-.select-all + label:before {
-	position: absolute;
-	top: 18px;
-	left: 18px;
-	z-index: 10;
+	padding: 16px;
 }
 
 #fileList tr td.filename {

--- a/apps/files/css/mobile.scss
+++ b/apps/files/css/mobile.scss
@@ -24,10 +24,6 @@ table td.date {
 table td {
 	padding: 0;
 }
-/* and accordingly fix left margin of file list summary on mobile */
-.summary .info {
-	margin-left: 105px;
-}
 
 /* remove shift for multiselect bar to account for missing navigation */
 table.multiselect thead {

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -706,7 +706,7 @@
 	 * @property {String} mime mime type
 	 * @property {int} permissions permissions
 	 * @property {(Function|String)} icon icon path to the icon or function that returns it (deprecated, use iconClass instead)
-	 * @property {(Function|String)} iconClass class name of the icon (recommended for theming)
+	 * @property {(String|OCA.Files.FileActions~iconClassFunction)} iconClass class name of the icon (recommended for theming)
 	 * @property {OCA.Files.FileActions~renderActionFunction} [render] optional rendering function
 	 * @property {OCA.Files.FileActions~actionHandler} actionHandler action handler function
 	 */
@@ -743,6 +743,17 @@
 	 * @callback OCA.Files.FileActions~displayNameFunction
 	 * @param {OCA.Files.FileActionContext} context action context
 	 * @return {String} display name
+	 */
+
+	/**
+	 * Icon class function for actions.
+	 * The function returns the icon class of the action using
+	 * the given context information.
+	 *
+	 * @callback OCA.Files.FileActions~iconClassFunction
+	 * @param {String} fileName name of the file on which the action must be performed
+	 * @param {OCA.Files.FileActionContext} context action context
+	 * @return {String} icon class
 	 */
 
 	/**

--- a/apps/files/js/fileactionsmenu.js
+++ b/apps/files/js/fileactionsmenu.js
@@ -115,6 +115,11 @@
 					item = _.extend({}, item);
 					item.displayName = item.displayName(self._context);
 				}
+				if (_.isFunction(item.iconClass)) {
+					var fileName = self._context.$file.attr('data-file');
+					item = _.extend({}, item);
+					item.iconClass = item.iconClass(fileName, self._context);
+				}
 				return item;
 			});
 			items = items.sort(function(actionA, actionB) {

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -332,7 +332,7 @@
 
 			this.$fileList.on('click','td.filename>a.name, td.filesize, td.date', _.bind(this._onClickFile, this));
 
-			this.$fileList.on('change', 'td.filename>.selectCheckBox', _.bind(this._onClickFileCheckbox, this));
+			this.$fileList.on('change', 'td.selection>.selectCheckBox', _.bind(this._onClickFileCheckbox, this));
 			this.$el.on('show', _.bind(this._onShow, this));
 			this.$el.on('urlChanged', _.bind(this._onUrlChanged, this));
 			this.$el.find('.select-all').click(_.bind(this._onClickSelectAll, this));
@@ -593,7 +593,7 @@
 		 * @param {bool} state true to select, false to deselect
 		 */
 		_selectFileEl: function($tr, state, showDetailsView) {
-			var $checkbox = $tr.find('td.filename>.selectCheckBox');
+			var $checkbox = $tr.find('td.selection>.selectCheckBox');
 			var oldData = !!this._selectedFiles[$tr.data('id')];
 			var data;
 			$checkbox.prop('checked', state);
@@ -649,7 +649,7 @@
 				else {
 					this._lastChecked = $tr;
 				}
-				var $checkbox = $tr.find('td.filename>.selectCheckBox');
+				var $checkbox = $tr.find('td.selection>.selectCheckBox');
 				this._selectFileEl($tr, !$checkbox.prop('checked'));
 				this.updateSelectionSummary();
 			} else {
@@ -704,7 +704,7 @@
 		 */
 		_onClickSelectAll: function(e) {
 			var checked = $(e.target).prop('checked');
-			this.$fileList.find('td.filename>.selectCheckBox').prop('checked', checked)
+			this.$fileList.find('td.selection>.selectCheckBox').prop('checked', checked)
 				.closest('tr').toggleClass('selected', checked);
 			this._selectedFiles = {};
 			this._selectionSummary.clear();
@@ -1063,6 +1063,13 @@
 
 			this.$fileList.empty();
 
+			if (this._allowSelection) {
+				// The results table, which has no selection column, checks
+				// whether the main table has a selection column or not in order
+				// to align its contents with those of the main table.
+				this.$el.addClass('has-selection');
+			}
+
 			// clear "Select all" checkbox
 			this.$el.find('.select-all').prop('checked', false);
 
@@ -1192,6 +1199,20 @@
 				path = this.getCurrentDirectory();
 			}
 
+			// selection td
+			if (this._allowSelection) {
+				td = $('<td class="selection"></td>');
+
+				td.append(
+					'<input id="select-' + this.id + '-' + fileData.id +
+					'" type="checkbox" class="selectCheckBox checkbox"/><label for="select-' + this.id + '-' + fileData.id + '">' +
+					'<span class="hidden-visually">' + t('files', 'Select') + '</span>' +
+					'</label>'
+				);
+
+				tr.append(td);
+			}
+
 			// filename td
 			td = $('<td class="filename"></td>');
 
@@ -1202,14 +1223,6 @@
 			}
 			else {
 				linkUrl = this.getDownloadUrl(name, path, type === 'dir');
-			}
-			if (this._allowSelection) {
-				td.append(
-					'<input id="select-' + this.id + '-' + fileData.id +
-					'" type="checkbox" class="selectCheckBox checkbox"/><label for="select-' + this.id + '-' + fileData.id + '">' +
-					'<span class="hidden-visually">' + t('files', 'Select') + '</span>' +
-					'</label>'
-				);
 			}
 			var linkElem = $('<a></a>').attr({
 				"class": "name",
@@ -2613,6 +2626,13 @@
 		 */
 		_createSummary: function() {
 			var $tr = $('<tr class="summary"></tr>');
+
+			if (this._allowSelection) {
+				// Dummy column for selection, as all rows must have the same
+				// number of columns.
+				$tr.append('<td></td>');
+			}
+
 			this.$el.find('tfoot').append($tr);
 
 			return new OCA.Files.FileSummary($tr, {config: this._filesConfig});

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1207,17 +1207,16 @@
 				td.append(
 					'<input id="select-' + this.id + '-' + fileData.id +
 					'" type="checkbox" class="selectCheckBox checkbox"/><label for="select-' + this.id + '-' + fileData.id + '">' +
-					'<div class="thumbnail" style="background-image:url(' + icon + ');"></div>' +
 					'<span class="hidden-visually">' + t('files', 'Select') + '</span>' +
 					'</label>'
 				);
-			} else {
-				td.append('<div class="thumbnail" style="background-image:url(' + icon + ');"></div>');
 			}
 			var linkElem = $('<a></a>').attr({
 				"class": "name",
 				"href": linkUrl
 			});
+
+			linkElem.append('<div class="thumbnail-wrapper"><div class="thumbnail" style="background-image:url(' + icon + ');"></div></div>');
 
 			// from here work on the display name
 			name = fileData.displayName || name;

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1207,12 +1207,12 @@
 				td.append(
 					'<input id="select-' + this.id + '-' + fileData.id +
 					'" type="checkbox" class="selectCheckBox checkbox"/><label for="select-' + this.id + '-' + fileData.id + '">' +
-					'<div class="thumbnail" style="background-image:url(' + icon + '); background-size: 32px;"></div>' +
+					'<div class="thumbnail" style="background-image:url(' + icon + ');"></div>' +
 					'<span class="hidden-visually">' + t('files', 'Select') + '</span>' +
 					'</label>'
 				);
 			} else {
-				td.append('<div class="thumbnail" style="background-image:url(' + icon + '); background-size: 32px;"></div>');
+				td.append('<div class="thumbnail" style="background-image:url(' + icon + ');"></div>');
 			}
 			var linkElem = $('<a></a>').attr({
 				"class": "name",

--- a/apps/files/js/tagsplugin.js
+++ b/apps/files/js/tagsplugin.js
@@ -162,7 +162,6 @@
 
 		_extendFileList: function(fileList) {
 			// extend row prototype
-			fileList.$el.addClass('has-favorites');
 			var oldCreateRow = fileList._createRow;
 			fileList._createRow = function(fileData) {
 				var $tr = oldCreateRow.apply(this, arguments);

--- a/apps/files/js/tagsplugin.js
+++ b/apps/files/js/tagsplugin.js
@@ -175,7 +175,7 @@
 					}
 				}
 				var $icon = $(renderStar(isFavorite));
-				$tr.find('td:first').prepend($icon);
+				$tr.find('td.filename .thumbnail').append($icon);
 				return $tr;
 			};
 			var oldElementToFile = fileList.elementToFile;

--- a/apps/files/templates/list.php
+++ b/apps/files/templates/list.php
@@ -41,12 +41,14 @@
 <table id="filestable" data-allow-public-upload="<?php p($_['publicUploadEnabled'])?>" data-preview-x="32" data-preview-y="32">
 	<thead>
 		<tr>
+			<th id="headerSelection" class="hidden column-selection">
+				<input type="checkbox" id="select_all_files" class="select-all checkbox"/>
+				<label for="select_all_files">
+					<span class="hidden-visually"><?php p($l->t('Select all'))?></span>
+				</label>
+			</th>
 			<th id='headerName' class="hidden column-name">
 				<div id="headerName-container">
-					<input type="checkbox" id="select_all_files" class="select-all checkbox"/>
-					<label for="select_all_files">
-						<span class="hidden-visually"><?php p($l->t('Select all'))?></span>
-					</label>
 					<a class="name sort columntitle" data-sort="name"><span><?php p($l->t( 'Name' )); ?></span><span class="sort-indicator"></span></a>
 					<span id="selectedActionsList" class="selectedActions">
 						<a href="" class="copy-move">

--- a/apps/files/tests/js/fileactionsmenuSpec.js
+++ b/apps/files/tests/js/fileactionsmenuSpec.js
@@ -205,6 +205,34 @@ describe('OCA.Files.FileActionsMenu tests', function() {
 			expect(displayNameStub.calledWith(menuContext)).toEqual(true);
 			expect(menu.$el.find('a[data-action=Something]').text()).toEqual('Test');
 		});
+		it('uses plain iconClass', function() {
+			fileActions.registerAction({
+				name: 'Something',
+				mime: 'text/plain',
+				permissions: OC.PERMISSION_ALL,
+				iconClass: 'test'
+			});
+
+			menu.render();
+
+			expect(menu.$el.find('a[data-action=Something]').children('span.icon').hasClass('test')).toEqual(true);
+		});
+		it('calls iconClass function', function() {
+			var iconClassStub = sinon.stub().returns('test');
+
+			fileActions.registerAction({
+				name: 'Something',
+				mime: 'text/plain',
+				permissions: OC.PERMISSION_ALL,
+				iconClass: iconClassStub
+			});
+
+			menu.render();
+
+			expect(iconClassStub.calledOnce).toEqual(true);
+			expect(iconClassStub.calledWith(menuContext.$file.attr('data-file'), menuContext)).toEqual(true);
+			expect(menu.$el.find('a[data-action=Something]').children('span.icon').hasClass('test')).toEqual(true);
+		});
 	});
 
 	describe('action handler', function() {

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -712,8 +712,14 @@ describe('OCA.Files.FileList tests', function() {
 				fileList.add(testFiles[i], {silent: true});
 			}
 
+			$tr = fileList.findFileEl('One.txt');
+			expect($tr.find('a.name').css('display')).not.toEqual('none');
+
 			// trigger rename prompt
 			fileList.rename('One.txt');
+
+			expect($tr.find('a.name').css('display')).toEqual('none');
+
 			$input = fileList.$fileList.find('input.filename');
 			$input.val('Two.jpg');
 
@@ -735,12 +741,12 @@ describe('OCA.Files.FileList tests', function() {
 			$tr = fileList.findFileEl('One.txt');
 			expect($tr.length).toEqual(1);
 			expect($tr.find('a .nametext').text().trim()).toEqual('One.txt');
-			expect($tr.find('a.name').is(':visible')).toEqual(true);
+			expect($tr.find('a.name').css('display')).not.toEqual('none');
 
 			$tr = fileList.findFileEl('Two.jpg');
 			expect($tr.length).toEqual(1);
 			expect($tr.find('a .nametext').text().trim()).toEqual('Two.jpg');
-			expect($tr.find('a.name').is(':visible')).toEqual(true);
+			expect($tr.find('a.name').css('display')).not.toEqual('none');
 
 			// input and form are gone
 			expect(fileList.$fileList.find('input.filename').length).toEqual(0);
@@ -1741,7 +1747,7 @@ describe('OCA.Files.FileList tests', function() {
 		it('Selects a file when clicking its checkbox', function() {
 			var $tr = fileList.findFileEl('One.txt');
 			expect($tr.find('input:checkbox').prop('checked')).toEqual(false);
-			$tr.find('td.filename input:checkbox').click();
+			$tr.find('td.selection input:checkbox').click();
 
 			expect($tr.find('input:checkbox').prop('checked')).toEqual(true);
 		});
@@ -1779,7 +1785,7 @@ describe('OCA.Files.FileList tests', function() {
 			var $tr = fileList.findFileEl('One.txt');
 			var $tr2 = fileList.findFileEl('Three.pdf');
 			var e;
-			$tr.find('td.filename input:checkbox').click();
+			$tr.find('td.selection input:checkbox').click();
 			e = new $.Event('click');
 			e.shiftKey = true;
 			$tr2.find('td.filename .name').trigger(e);
@@ -1797,7 +1803,7 @@ describe('OCA.Files.FileList tests', function() {
 			var $tr = fileList.findFileEl('One.txt');
 			var $tr2 = fileList.findFileEl('Three.pdf');
 			var e;
-			$tr2.find('td.filename input:checkbox').click();
+			$tr2.find('td.selection input:checkbox').click();
 			e = new $.Event('click');
 			e.shiftKey = true;
 			$tr.find('td.filename .name').trigger(e);
@@ -1813,13 +1819,13 @@ describe('OCA.Files.FileList tests', function() {
 		});
 		it('Selecting all files will automatically check "select all" checkbox', function() {
 			expect($('.select-all').prop('checked')).toEqual(false);
-			$('#fileList tr td.filename input:checkbox').click();
+			$('#fileList tr td.selection input:checkbox').click();
 			expect($('.select-all').prop('checked')).toEqual(true);
 		});
 		it('Selecting all files on the first visible page will not automatically check "select all" checkbox', function() {
 			fileList.setFiles(generateFiles(0, 41));
 			expect($('.select-all').prop('checked')).toEqual(false);
-			$('#fileList tr td.filename input:checkbox').click();
+			$('#fileList tr td.selection input:checkbox').click();
 			expect($('.select-all').prop('checked')).toEqual(false);
 		});
 		it('Selecting all files also selects hidden files when invisible', function() {
@@ -1831,7 +1837,7 @@ describe('OCA.Files.FileList tests', function() {
 				size: 150
 			}));
 			$('.select-all').click();
-			expect($tr.find('td.filename input:checkbox').prop('checked')).toEqual(true);
+			expect($tr.find('td.selection input:checkbox').prop('checked')).toEqual(true);
 			expect(_.pluck(fileList.getSelectedFiles(), 'name')).toContain('.hidden');
 		});
 		it('Clicking "select all" will select/deselect all files', function() {

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -750,7 +750,7 @@ describe('OCA.Files.FileList tests', function() {
 			doRename();
 
 			expect(fileList.findFileEl('Tu_after_three.txt').find('.thumbnail').parent().attr('class'))
-				.toEqual('icon-loading-small');
+				.toContain('icon-loading-small');
 
 			deferredRename.reject(409);
 
@@ -838,7 +838,7 @@ describe('OCA.Files.FileList tests', function() {
 			fileList.move('One.txt', '/somedir');
 
 			expect(fileList.findFileEl('One.txt').find('.thumbnail').parent().attr('class'))
-				.toEqual('icon-loading-small');
+				.toContain('icon-loading-small');
 
 			expect(moveStub.calledOnce).toEqual(true);
 
@@ -935,7 +935,7 @@ describe('OCA.Files.FileList tests', function() {
 			fileList.copy('One.txt', '/somedir');
 
 			expect(fileList.findFileEl('One.txt').find('.thumbnail').parent().attr('class'))
-				.toEqual('icon-loading-small');
+				.toContain('icon-loading-small');
 
 			expect(copyStub.calledOnce).toEqual(true);
 
@@ -3150,7 +3150,7 @@ describe('OCA.Files.FileList tests', function() {
 			fileList.showFileBusyState('Two.jpg', true);
 			expect($tr.hasClass('busy')).toEqual(true);
 			expect($tr.find('.thumbnail').parent().attr('class'))
-				.toEqual('icon-loading-small');
+				.toContain('icon-loading-small');
 
 
 			fileList.showFileBusyState('Two.jpg', false);

--- a/apps/files/tests/js/tagspluginspec.js
+++ b/apps/files/tests/js/tagspluginspec.js
@@ -49,24 +49,24 @@ describe('OCA.Files.TagsPlugin tests', function() {
 
 	describe('Favorites icon', function() {
 		it('renders favorite icon and extra data', function() {
-			var $action, $tr;
+			var $favoriteMark, $tr;
 			fileList.setFiles(testFiles);
 			$tr = fileList.$el.find('tbody tr:first');
-			$action = $tr.find('.action-favorite');
-			expect($action.length).toEqual(1);
-			expect($action.hasClass('permanent')).toEqual(false);
+			$favoriteMark = $tr.find('.favorite-mark');
+			expect($favoriteMark.length).toEqual(1);
+			expect($favoriteMark.hasClass('permanent')).toEqual(false);
 
 			expect($tr.attr('data-tags').split('|')).toEqual(['tag1', 'tag2']);
 			expect($tr.attr('data-favorite')).not.toBeDefined();
 		});
 		it('renders permanent favorite icon and extra data', function() {
-			var $action, $tr;
+			var $favoriteMark, $tr;
 			testFiles[0].tags.push(OC.TAG_FAVORITE);
 			fileList.setFiles(testFiles);
 			$tr = fileList.$el.find('tbody tr:first');
-			$action = $tr.find('.action-favorite');
-			expect($action.length).toEqual(1);
-			expect($action.hasClass('permanent')).toEqual(true);
+			$favoriteMark = $tr.find('.favorite-mark');
+			expect($favoriteMark.length).toEqual(1);
+			expect($favoriteMark.hasClass('permanent')).toEqual(true);
 
 			expect($tr.attr('data-tags').split('|')).toEqual(['tag1', 'tag2', OC.TAG_FAVORITE]);
 			expect($tr.attr('data-favorite')).toEqual('true');
@@ -76,58 +76,11 @@ describe('OCA.Files.TagsPlugin tests', function() {
 		});
 	});
 	describe('Applying tags', function() {
-		it('sends request to server and updates icon', function() {
-			var request;
-			fileList.setFiles(testFiles);
-			var $tr = fileList.findFileEl('One.txt');
-			var $action = $tr.find('.action-favorite');
-			$action.click();
-
-			expect(fakeServer.requests.length).toEqual(1);
-			request = fakeServer.requests[0];
-			expect(JSON.parse(request.requestBody)).toEqual({
-				tags: ['tag1', 'tag2', OC.TAG_FAVORITE]
-			});
-			request.respond(200, {'Content-Type': 'application/json'}, JSON.stringify({
-				tags: ['tag1', 'tag2', 'tag3', OC.TAG_FAVORITE]
-			}));
-
-			// re-read the element as it was re-inserted
-			$tr = fileList.findFileEl('One.txt');
-			$action = $tr.find('.action-favorite');
-
-			expect($tr.attr('data-favorite')).toEqual('true');
-			expect($tr.attr('data-tags').split('|')).toEqual(['tag1', 'tag2', 'tag3', OC.TAG_FAVORITE]);
-			expect(fileList.files[0].tags).toEqual(['tag1', 'tag2', 'tag3', OC.TAG_FAVORITE]);
-			expect($action.find('.icon').hasClass('icon-star')).toEqual(false);
-			expect($action.find('.icon').hasClass('icon-starred')).toEqual(true);
-
-			$action.click();
-
-			expect(fakeServer.requests.length).toEqual(2);
-			request = fakeServer.requests[1];
-			expect(JSON.parse(request.requestBody)).toEqual({
-				tags: ['tag1', 'tag2', 'tag3']
-			});
-			request.respond(200, {'Content-Type': 'application/json'}, JSON.stringify({
-				tags: ['tag1', 'tag2', 'tag3']
-			}));
-
-			// re-read the element as it was re-inserted
-			$tr = fileList.findFileEl('One.txt');
-			$action = $tr.find('.action-favorite');
-
-			expect($tr.attr('data-favorite')).toBeFalsy();
-			expect($tr.attr('data-tags').split('|')).toEqual(['tag1', 'tag2', 'tag3']);
-			expect(fileList.files[0].tags).toEqual(['tag1', 'tag2', 'tag3']);
-			expect($action.find('.icon').hasClass('icon-star')).toEqual(true);
-			expect($action.find('.icon').hasClass('icon-starred')).toEqual(false);
-		});
 		it('through FileActionsMenu sends request to server and updates icon', function() {
 			var request;
 			fileList.setFiles(testFiles);
 			var $tr = fileList.findFileEl('One.txt');
-			var $action = $tr.find('.action-favorite');
+			var $favoriteMark = $tr.find('.favorite-mark');
 			var $showMenuAction = $tr.find('.action-menu');
 			$showMenuAction.click();
 			var $favoriteActionInMenu = $tr.find('.fileActionsMenu .action-favorite');
@@ -144,14 +97,14 @@ describe('OCA.Files.TagsPlugin tests', function() {
 
 			// re-read the element as it was re-inserted
 			$tr = fileList.findFileEl('One.txt');
-			$action = $tr.find('.action-favorite');
+			$favoriteMark = $tr.find('.favorite-mark');
 			$showMenuAction = $tr.find('.action-menu');
 
 			expect($tr.attr('data-favorite')).toEqual('true');
 			expect($tr.attr('data-tags').split('|')).toEqual(['tag1', 'tag2', 'tag3', OC.TAG_FAVORITE]);
 			expect(fileList.files[0].tags).toEqual(['tag1', 'tag2', 'tag3', OC.TAG_FAVORITE]);
-			expect($action.find('.icon').hasClass('icon-star')).toEqual(false);
-			expect($action.find('.icon').hasClass('icon-starred')).toEqual(true);
+			expect($favoriteMark.find('.icon').hasClass('icon-star')).toEqual(false);
+			expect($favoriteMark.find('.icon').hasClass('icon-starred')).toEqual(true);
 
 			// show again the menu and get the new action, as the menu was
 			// closed and removed (and with it, the previous action) when that
@@ -171,13 +124,13 @@ describe('OCA.Files.TagsPlugin tests', function() {
 
 			// re-read the element as it was re-inserted
 			$tr = fileList.findFileEl('One.txt');
-			$action = $tr.find('.action-favorite');
+			$favoriteMark = $tr.find('.favorite-mark');
 
 			expect($tr.attr('data-favorite')).toBeFalsy();
 			expect($tr.attr('data-tags').split('|')).toEqual(['tag1', 'tag2', 'tag3']);
 			expect(fileList.files[0].tags).toEqual(['tag1', 'tag2', 'tag3']);
-			expect($action.find('.icon').hasClass('icon-star')).toEqual(true);
-			expect($action.find('.icon').hasClass('icon-starred')).toEqual(false);
+			expect($favoriteMark.find('.icon').hasClass('icon-star')).toEqual(true);
+			expect($favoriteMark.find('.icon').hasClass('icon-starred')).toEqual(false);
 		});
 	});
 	describe('elementToFile', function() {

--- a/apps/files/tests/js/tagspluginspec.js
+++ b/apps/files/tests/js/tagspluginspec.js
@@ -71,9 +71,6 @@ describe('OCA.Files.TagsPlugin tests', function() {
 			expect($tr.attr('data-tags').split('|')).toEqual(['tag1', 'tag2', OC.TAG_FAVORITE]);
 			expect($tr.attr('data-favorite')).toEqual('true');
 		});
-		it('adds has-favorites class on table', function() {
-			expect(fileList.$el.hasClass('has-favorites')).toEqual(true);
-		});
 	});
 	describe('Applying tags', function() {
 		it('through FileActionsMenu sends request to server and updates icon', function() {

--- a/apps/files_trashbin/templates/index.php
+++ b/apps/files_trashbin/templates/index.php
@@ -21,12 +21,14 @@
 <table id="filestable">
 	<thead>
 		<tr>
+			<th id="headerSelection" class="hidden column-selection">
+				<input type="checkbox" id="select_all_trash" class="select-all checkbox"/>
+				<label for="select_all_trash">
+					<span class="hidden-visually"><?php p($l->t('Select all'))?></span>
+				</label>
+			</th>
 			<th id='headerName' class="hidden column-name">
 				<div id="headerName-container">
-					<input type="checkbox" id="select_all_trash" class="select-all checkbox"/>
-					<label for="select_all_trash">
-						<span class="hidden-visually"><?php p($l->t('Select all'))?></span>
-					</label>
 					<a class="name sort columntitle" data-sort="name"><span><?php p($l->t( 'Name' )); ?></span><span class="sort-indicator"></span></a>
 					<span id="selectedActionsList" class='selectedActions'>
 						<a href="" class="undelete">

--- a/core/search/css/results.css
+++ b/core/search/css/results.css
@@ -30,9 +30,6 @@
 	padding: 28px 0 28px 56px;
 	font-size: 18px;
 }
-.has-favorites:not(.hidden) ~ #searchresults .status {
-	padding-left: 102px;
-}
 #searchresults .status.fixed {
 	position: fixed;
 	bottom: 0;
@@ -66,10 +63,6 @@
 	padding: 5px 0;
 	background-position: right center;
 	background-repeat: no-repeat;
-}
-.has-favorites:not(.hidden) ~ #searchresults td.icon {
-	width: 86px;
-	background-size: 32px;
 }
 
 #searchresults tr.template {

--- a/core/search/css/results.css
+++ b/core/search/css/results.css
@@ -30,6 +30,9 @@
 	padding: 28px 0 28px 56px;
 	font-size: 18px;
 }
+.has-selection:not(.hidden) ~ #searchresults .status {
+	padding-left: 105px;
+}
 #searchresults .status.fixed {
 	position: fixed;
 	bottom: 0;
@@ -51,7 +54,7 @@
 }
 
 #searchresults td {
-	padding: 5px 19px;
+	padding: 5px 14px;
 	font-style: normal;
 	vertical-align: middle;
 	border-bottom: none;
@@ -63,6 +66,10 @@
 	padding: 5px 0;
 	background-position: right center;
 	background-repeat: no-repeat;
+}
+.has-selection:not(.hidden) ~ #searchresults td.icon {
+	width: 91px;
+	background-size: 32px;
 }
 
 #searchresults tr.template {

--- a/tests/acceptance/features/app-files.feature
+++ b/tests/acceptance/features/app-files.feature
@@ -145,6 +145,14 @@ Feature: app-files
     Given I am logged in
     And I create a new folder named "A name alphabetically lower than welcome.txt"
     And I see that "A name alphabetically lower than welcome.txt" precedes "welcome.txt" in the file list
+    # To mark the file as favorite the file actions menu has to be shown but, as
+    # the details view is opened automatically when the folder is created,
+    # clicking on the menu trigger could fail if it is covered by the details
+    # view due to its opening animation. Instead of ensuring that the animations
+    # of the contents and the details view have both finished it is easier to
+    # close the details view and wait until it is closed before continuing.
+    And I close the details view
+    And I see that the details view is closed
     When I mark "welcome.txt" as favorite
     Then I see that "welcome.txt" is marked as favorite
     And I see that "welcome.txt" precedes "A name alphabetically lower than welcome.txt" in the file list
@@ -153,6 +161,14 @@ Feature: app-files
     Given I am logged in
     And I create a new folder named "A name alphabetically lower than welcome.txt"
     And I see that "A name alphabetically lower than welcome.txt" precedes "welcome.txt" in the file list
+    # To mark the file as favorite the file actions menu has to be shown but, as
+    # the details view is opened automatically when the folder is created,
+    # clicking on the menu trigger could fail if it is covered by the details
+    # view due to its opening animation. Instead of ensuring that the animations
+    # of the contents and the details view have both finished it is easier to
+    # close the details view and wait until it is closed before continuing.
+    And I close the details view
+    And I see that the details view is closed
     And I mark "welcome.txt" as favorite
     And I see that "welcome.txt" is marked as favorite
     And I see that "welcome.txt" precedes "A name alphabetically lower than welcome.txt" in the file list

--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -278,16 +278,16 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
-	public static function favoriteActionForFile($fileName) {
-		return Locator::forThe()->css(".action-favorite")->descendantOf(self::rowForFile($fileName))->
-				describedAs("Favorite action for file $fileName in Files app");
+	public static function favoriteMarkForFile($fileName) {
+		return Locator::forThe()->css(".favorite-mark")->descendantOf(self::rowForFile($fileName))->
+				describedAs("Favorite mark for file $fileName in Files app");
 	}
 
 	/**
 	 * @return Locator
 	 */
 	public static function notFavoritedStateIconForFile($fileName) {
-		return Locator::forThe()->css(".icon-star")->descendantOf(self::favoriteActionForFile($fileName))->
+		return Locator::forThe()->css(".icon-star")->descendantOf(self::favoriteMarkForFile($fileName))->
 				describedAs("Not favorited state icon for file $fileName in Files app");
 	}
 
@@ -295,7 +295,7 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function favoritedStateIconForFile($fileName) {
-		return Locator::forThe()->css(".icon-starred")->descendantOf(self::favoriteActionForFile($fileName))->
+		return Locator::forThe()->css(".icon-starred")->descendantOf(self::favoriteMarkForFile($fileName))->
 				describedAs("Favorited state icon for file $fileName in Files app");
 	}
 

--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -341,6 +341,20 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function addToFavoritesMenuItem() {
+		return self::fileActionsMenuItemFor("Add to favorites");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function removeFromFavoritesMenuItem() {
+		return self::fileActionsMenuItemFor("Remove from favorites");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function viewFileInFolderMenuItem() {
 		return self::fileActionsMenuItemFor("View in folder");
 	}
@@ -393,7 +407,9 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	public function iMarkAsFavorite($fileName) {
 		$this->iSeeThatIsNotMarkedAsFavorite($fileName);
 
-		$this->actor->find(self::favoriteActionForFile($fileName), 10)->click();
+		$this->actor->find(self::fileActionsMenuButtonForFile($fileName), 10)->click();
+
+		$this->actor->find(self::addToFavoritesMenuItem(), 2)->click();
 	}
 
 	/**
@@ -402,7 +418,9 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	public function iUnmarkAsFavorite($fileName) {
 		$this->iSeeThatIsMarkedAsFavorite($fileName);
 
-		$this->actor->find(self::favoriteActionForFile($fileName), 10)->click();
+		$this->actor->find(self::fileActionsMenuButtonForFile($fileName), 10)->click();
+
+		$this->actor->find(self::removeFromFavoritesMenuItem(), 2)->click();
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -80,6 +80,15 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function closeDetailsViewButton() {
+		return Locator::forThe()->css(".icon-close")->
+				descendantOf(self::currentSectionDetailsView())->
+				describedAs("Close current section details view in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function fileDetailsInCurrentSectionDetailsViewWithText($fileDetailsText) {
 		return Locator::forThe()->xpath("//span[normalize-space() = '$fileDetailsText']")->
 				descendantOf(self::fileDetailsInCurrentSectionDetailsView())->
@@ -385,6 +394,13 @@ class FilesAppContext implements Context, ActorAwareInterface {
 		$this->actor->find(self::fileActionsMenuButtonForFile($fileName), 10)->click();
 
 		$this->actor->find(self::detailsMenuItem(), 2)->click();
+	}
+
+	/**
+	 * @Given I close the details view
+	 */
+	public function iCloseTheDetailsView() {
+		$this->actor->find(self::closeDetailsViewButton(), 10)->click();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #6361

The favourite icon is now just a mark shown on the thumbnail of favourited files (before it was also shown for not favourited files with a different colour). The center of the star is slightly below and to the left of the top right corner of the thumbnail instead of exactly at the corner because, at least for me, it looked better that way ;-) To get the right placement of the thumbnail, the favourite mark, the file text and so on I used a lot of element nesting; I do not know if that could noticeably slow down the rendering on very large file lists or not, but it may be something to keep an eye on ;-)

Marking a file as favourite or unmarking it is done now through the file actions menu (the three-dots menu). Unlike other actions in the file actions menu, the favourite action is a toggle; its text (and icon) change between _Remove from favorites_ and _Add to favorites_ depending on whether the file is already favourited or not (those texts where used instead of the shorter _Unfavorite_ and _Favorite_ due to [the lack of translation contexts](https://github.com/nextcloud/server/issues/6662)). The action was placed in the file actions menu between _Move or copy_ and _Download_ (for no special reason, to be honest).

Regarding the checkbox used to select files it was moved visually to the place where the favourite icon was before. In HTML and CSS, however, it was done by prepending a new column to those tables that allow selections; it was easier (at least, for me :P ) with respect to the CSS (as the CSS for the name column relies a lot in floats and absolute positions (just for the record, it was that way before I touched the code :-P), so accomodating a new element inside that column that sometimes had to be shown and sometimes not was difficult, and in fact for the favourite icon it was done by applying margins and left positions when the table had the CSS class `has-favorites`), and conceptually it also seemed like using an explicit column in the table to provide the selection was the most logical approach. Given that the checkbox is no longer placed on the thumbnail now clicking on the thumbnail opens the file, just like clicking on the file name (as requested in https://github.com/nextcloud/server/issues/6361#issuecomment-330064817).

The aforementioned `has-favorites` class was used before also to align the results table of the search with the main table; as the results table did not include the favourite action but the main table could have it or not the results table looked for the `has-favorites` class and, if it was found, it moved its content to the left as needed. The same approach is used now with the `has-selection` class. Also, the horizontal padding of `#searchresults td` was reduced from 19px to 14px (could this affect other apps?) to align the file names of the results with those of the main table (note that before these changes the space between the thumbnail and the file name in the file list changed slightly depending on whether the table had favourites or not, and that the file names in the results were aligned to the file names in tables with favourites, so the results were not perfectly aligned to tables without favourites; now there is always the same distance between thumbnail and file name, and the results are (or should be :-P ) always perfectly aligned :-) ).

Before, all files:
![swapcheckbox-before-allfiles](https://user-images.githubusercontent.com/26858233/31048979-24f8ea70-a62a-11e7-8362-abdd2d124390.png)

After moving the icon to the thumbnail, all files:
![swapcheckbox-afterthumbnail-allfiles](https://user-images.githubusercontent.com/26858233/31048981-277fee92-a62a-11e7-80a7-b7746e60f7ac.png)

After moving the checkbox to its own column, all files:
![swapcheckbox-aftercolumn-allfiles](https://user-images.githubusercontent.com/26858233/31048804-c8aaa19a-a625-11e7-9a96-50d774bd5c2b.png)

Before, recents:
![swapcheckbox-before-recents](https://user-images.githubusercontent.com/26858233/31048811-ea25e29e-a625-11e7-90fa-a3a1e0172aba.png)

After, recents:
![swapcheckbox-aftercolumn-recents](https://user-images.githubusercontent.com/26858233/31048812-f4885460-a625-11e7-8452-e9931b3df949.png)

Before, favorites:
![swapcheckbox-before-favorites](https://user-images.githubusercontent.com/26858233/31048817-0de2611c-a626-11e7-9422-a4282cc31162.png)

After, favorites:
![swapcheckbox-aftercolumn-favorites](https://user-images.githubusercontent.com/26858233/31048820-1332607c-a626-11e7-889b-6b52a3185190.png)

Before, all files with search:
![swapcheckbox-before-search](https://user-images.githubusercontent.com/26858233/31048826-23f48278-a626-11e7-9b94-7db7f873edc8.png)

After moving the icon to the thumbnail, all files with search:
![swapcheckbox-afterthumbnail-search](https://user-images.githubusercontent.com/26858233/31048828-2c80859a-a626-11e7-8013-af9cf02b831b.png)

After moving the checkbox to its own column, all files with search:
![swapcheckbox-aftercolumn-search](https://user-images.githubusercontent.com/26858233/31048829-333a8584-a626-11e7-96dc-6a79cdb6d582.png)

When taking these screenshots I found that search results are shown inconsistently (even on the _stable12_ branch) depending on whether you refresh a section (_All files_, _Recents_...) and then search or you come from a different section and then search (sometimes only the results were shown, sometimes the contents of the folder were shown along with the results, sometimes only the header of the table for the contents of the folder was shown along with the results). @jancborchardt when you have some time could you check that and open an issue detailing what should be the expected behaviour (as you know that better than me ;-) )? Thanks :-)

Back to the checkbox and favourites, on narrow screens keeping the checkbox on the thumbnail could be a better approach than having an exclusive column for the checkbox in order to save valuable horizontal space. However, this would bring back the original problem of selection not being intuitive, specially on touch based devices like mobile phones where it is not natural to hover over the elements; of course the file could be selected just by tapping on the thumbnail, but hovering was what revealed the checkbox and conveyed that it was selectable. Instead of only showing the checkboxes on hover, though, it could be enough to always show the checkboxes to more or less fix the discoverability problem (see the _After moving the icon to the thumbnail, all files_ screenshot above).

I leave that as something to be considered by @nextcloud/designers. In any case, if implemented it will probably be better done on a different pull request. And it will surely have to be done by someone else than me, because I already struggled too much and for too long with the CSS in this pull request and thinking of further changes makes me dizzy :-P

And now I summon @jancborchardt and @skjnldsv for review and, probably, CSS fixes ;-) Thanks!
