### PR TITLE
Fix the FreeBusy request handling for proper scheduling support

### DIFF
--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -44,6 +44,8 @@ $authBackend = new Auth(
 $principalBackend = new Principal(
 	\OC::$server->getUserManager(),
 	\OC::$server->getGroupManager(),
+	\OC::$server->getShareManager(),
+	\OC::$server->getUserSession(),
 	'principals/'
 );
 $db = \OC::$server->getDatabaseConnection();

--- a/apps/dav/appinfo/v1/carddav.php
+++ b/apps/dav/appinfo/v1/carddav.php
@@ -45,6 +45,8 @@ $authBackend = new Auth(
 $principalBackend = new Principal(
 	\OC::$server->getUserManager(),
 	\OC::$server->getGroupManager(),
+	\OC::$server->getShareManager(),
+	\OC::$server->getUserSession(),
 	'principals/'
 );
 $db = \OC::$server->getDatabaseConnection();

--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -30,6 +30,8 @@ return array(
     'OCA\\DAV\\CalDAV\\CalendarObject' => $baseDir . '/../lib/CalDAV/CalendarObject.php',
     'OCA\\DAV\\CalDAV\\CalendarRoot' => $baseDir . '/../lib/CalDAV/CalendarRoot.php',
     'OCA\\DAV\\CalDAV\\Plugin' => $baseDir . '/../lib/CalDAV/Plugin.php',
+    'OCA\\DAV\\CalDAV\\Principal\\Collection' => $baseDir . '/../lib/CalDAV/Principal/Collection.php',
+    'OCA\\DAV\\CalDAV\\Principal\\User' => $baseDir . '/../lib/CalDAV/Principal/User.php',
     'OCA\\DAV\\CalDAV\\PublicCalendar' => $baseDir . '/../lib/CalDAV/PublicCalendar.php',
     'OCA\\DAV\\CalDAV\\PublicCalendarObject' => $baseDir . '/../lib/CalDAV/PublicCalendarObject.php',
     'OCA\\DAV\\CalDAV\\PublicCalendarRoot' => $baseDir . '/../lib/CalDAV/PublicCalendarRoot.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -45,6 +45,8 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\CalDAV\\CalendarObject' => __DIR__ . '/..' . '/../lib/CalDAV/CalendarObject.php',
         'OCA\\DAV\\CalDAV\\CalendarRoot' => __DIR__ . '/..' . '/../lib/CalDAV/CalendarRoot.php',
         'OCA\\DAV\\CalDAV\\Plugin' => __DIR__ . '/..' . '/../lib/CalDAV/Plugin.php',
+        'OCA\\DAV\\CalDAV\\Principal\\Collection' => __DIR__ . '/..' . '/../lib/CalDAV/Principal/Collection.php',
+        'OCA\\DAV\\CalDAV\\Principal\\User' => __DIR__ . '/..' . '/../lib/CalDAV/Principal/User.php',
         'OCA\\DAV\\CalDAV\\PublicCalendar' => __DIR__ . '/..' . '/../lib/CalDAV/PublicCalendar.php',
         'OCA\\DAV\\CalDAV\\PublicCalendarObject' => __DIR__ . '/..' . '/../lib/CalDAV/PublicCalendarObject.php',
         'OCA\\DAV\\CalDAV\\PublicCalendarRoot' => __DIR__ . '/..' . '/../lib/CalDAV/PublicCalendarRoot.php',

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -353,7 +353,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 				'{' . Plugin::NS_CALENDARSERVER . '}getctag' => 'http://sabre.io/ns/sync/' . ($row['synctoken']?$row['synctoken']:'0'),
 				'{http://sabredav.org/ns}sync-token' => $row['synctoken']?$row['synctoken']:'0',
 				'{' . Plugin::NS_CALDAV . '}supported-calendar-component-set' => new SupportedCalendarComponentSet($components),
-				'{' . Plugin::NS_CALDAV . '}schedule-calendar-transp' => new ScheduleCalendarTransp($row['transparent']?'transparent':'opaque'),
+				'{' . Plugin::NS_CALDAV . '}schedule-calendar-transp' => new ScheduleCalendarTransp('transparent'),
 				'{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}owner-principal' => $this->convertPrincipal($row['principaluri'], !$this->legacyEndpoint),
 				$readOnlyPropertyName => $readOnly,
 			];

--- a/apps/dav/lib/CalDAV/Principal/Collection.php
+++ b/apps/dav/lib/CalDAV/Principal/Collection.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2017, Christoph Seitz <christoph.seitz@posteo.de>
+ *
+ * @author Christoph Seitz <christoph.seitz@posteo.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\CalDAV\Principal;
+
+use OCA\DAV\CalDAV\Principal\User;
+
+/**
+ * Class Collection
+ *
+ * @package OCA\DAV\CalDAV\Principal
+ */
+class Collection extends \Sabre\CalDAV\Principal\Collection {
+
+	/**
+	 * Returns a child object based on principal information
+	 *
+	 * @param array $principalInfo
+	 * @return User
+	 */
+	function getChildForPrincipal(array $principalInfo) {
+		return new User($this->principalBackend, $principalInfo);
+	}
+
+}

--- a/apps/dav/lib/CalDAV/Principal/User.php
+++ b/apps/dav/lib/CalDAV/Principal/User.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2017, Christoph Seitz <christoph.seitz@posteo.de>
+ *
+ * @author Christoph Seitz <christoph.seitz@posteo.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\CalDAV\Principal;
+
+/**
+ * Class User
+ *
+ * @package OCA\DAV\CalDAV\Principal
+ */
+class User extends \Sabre\CalDAV\Principal\User {
+
+	/**
+	 * Returns a list of ACE's for this node.
+	 *
+	 * Each ACE has the following properties:
+	 *   * 'privilege', a string such as {DAV:}read or {DAV:}write. These are
+	 *     currently the only supported privileges
+	 *   * 'principal', a url to the principal who owns the node
+	 *   * 'protected' (optional), indicating that this ACE is not allowed to
+	 *      be updated.
+	 *
+	 * @return array
+	 */
+	function getACL() {
+		$acl = parent::getACL();
+		$acl[] = [
+			'privilege' => '{DAV:}read',
+			'principal' => '{DAV:}authenticated',
+			'protected' => true,
+		];
+		return $acl;
+	}
+
+}

--- a/apps/dav/lib/Command/CreateCalendar.php
+++ b/apps/dav/lib/Command/CreateCalendar.php
@@ -75,7 +75,9 @@ class CreateCalendar extends Command {
 		}
 		$principalBackend = new Principal(
 			$this->userManager,
-			$this->groupManager
+			$this->groupManager,
+			\OC::$server->getShareManager(),
+			\OC::$server->getUserSession()
 		);
 		$random = \OC::$server->getSecureRandom();
 		$logger = \OC::$server->getLogger();

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -34,6 +34,8 @@ use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\Share\IManager as IShareManager;
 use Sabre\DAV\Exception;
 use \Sabre\DAV\PropPatch;
 use Sabre\DAVACL\PrincipalBackend\BackendInterface;
@@ -47,6 +49,12 @@ class Principal implements BackendInterface {
 	/** @var IGroupManager */
 	private $groupManager;
 
+	/** @var IShareManager */
+	private $shareManager;
+
+	/** @var IUserSession */
+	private $userSession;
+
 	/** @var string */
 	private $principalPrefix;
 
@@ -56,13 +64,19 @@ class Principal implements BackendInterface {
 	/**
 	 * @param IUserManager $userManager
 	 * @param IGroupManager $groupManager
+	 * @param IShareManager $shareManager
+	 * @param IUserSession $userSession
 	 * @param string $principalPrefix
 	 */
 	public function __construct(IUserManager $userManager,
 								IGroupManager $groupManager,
+								IShareManager $shareManager,
+								IUserSession $userSession,
 								$principalPrefix = 'principals/users/') {
 		$this->userManager = $userManager;
 		$this->groupManager = $groupManager;
+		$this->shareManager = $shareManager;
+		$this->userSession = $userSession;
 		$this->principalPrefix = trim($principalPrefix, '/');
 		$this->hasGroups = ($principalPrefix === 'principals/users/');
 	}
@@ -106,7 +120,7 @@ class Principal implements BackendInterface {
 		if ($prefix === $this->principalPrefix) {
 			$user = $this->userManager->get($name);
 
-			if (!is_null($user)) {
+			if ($user !== null) {
 				return $this->userToPrincipal($user);
 			}
 		}
@@ -189,37 +203,65 @@ class Principal implements BackendInterface {
 	 * @param string $test
 	 * @return array
 	 */
-	function searchUserPrincipals(array $searchProperties, $test = 'allof') {
+	protected function searchUserPrincipals(array $searchProperties, $test = 'allof') {
 		$results = [];
 
-		//TODO: If more properties should be supported, hook this up to a db query
+		// If sharing is disabled, return the empty array
+		if (!$this->shareManager->shareApiEnabled()) {
+			return [];
+		}
+
+		// If sharing is restricted to group members only,
+		// return only members that have groups in common
+		$restrictGroups = false;
+		if ($this->shareManager->shareWithGroupMembersOnly()) {
+			$user = $this->userSession->getUser();
+			if (!$user) {
+				return [];
+			}
+
+			$restrictGroups = $this->groupManager->getUserGroupIds($user);
+		}
+
 		foreach ($searchProperties as $prop => $value) {
 			switch ($prop) {
 				case '{http://sabredav.org/ns}email-address':
 					$users = $this->userManager->getByEmail($value);
-					$results[] =  array_map(function ($user) {
-						return $this->principalPrefix . '/' . $user->getUID();
-					}, $users);
+
+					$results[] = array_reduce($users, function(array $carry, IUser $user) use ($restrictGroups) {
+						// is sharing restricted to groups only?
+						if ($restrictGroups !== false) {
+							$userGroups = $this->groupManager->getUserGroupIds($user);
+							if (count(array_intersect($userGroups, $restrictGroups)) === 0) {
+								return $carry;
+							}
+						}
+
+						$carry[] = $this->principalPrefix . '/' . $user->getUID();
+						return $carry;
+					}, []);
 					break;
+
 				default:
 					$results[] = [];
 					break;
 			}
 		}
 
-		if (count($results) == 1) {
+		// results is an array of arrays, so this is not the first search result
+		// but the results of the first searchProperty
+		if (count($results) === 1) {
 			return $results[0];
 		}
 
 		switch ($test) {
-			case 'allof':
-
-				return array_intersect(...$results);
 			case 'anyof':
 				return array_unique(array_merge(...$results));
-		}
 
-		return [];
+			case 'allof':
+			default:
+				return array_intersect(...$results);
+		}
 	}
 
 	/**
@@ -229,13 +271,14 @@ class Principal implements BackendInterface {
 	 * @return array
 	 */
 	function searchPrincipals($prefixPath, array $searchProperties, $test = 'allof') {
-		if (count($searchProperties) == 0) {
+		if (count($searchProperties) === 0) {
 			return [];
 		}
 
 		switch ($prefixPath) {
 			case 'principals/users':
 				return $this->searchUserPrincipals($searchProperties, $test);
+
 			default:
 				return [];
 		}
@@ -247,17 +290,43 @@ class Principal implements BackendInterface {
 	 * @return string
 	 */
 	function findByUri($uri, $principalPrefix) {
-		if (substr($uri, 0, 7) === 'mailto:') {
-			if ($principalPrefix === principals/users) {
-				$email = substr($uri, 7);
-				$users = $this->userManager->getByEmail($email);
-				if (count($users) === 1) {
-					return $this->principalPrefix . '/' . $users[0]->getUID();
+		// If sharing is disabled, return null as in user not found
+		if (!$this->shareManager->shareApiEnabled()) {
+			return null;
+		}
+
+		// If sharing is restricted to group members only,
+		// return only members that have groups in common
+		$restrictGroups = false;
+		if ($this->shareManager->shareWithGroupMembersOnly()) {
+			$user = $this->userSession->getUser();
+			if (!$user) {
+				return null;
+			}
+
+			$restrictGroups = $this->groupManager->getUserGroupIds($user);
+		}
+
+		if (strpos($uri, 'mailto:') === 0) {
+			if ($principalPrefix === 'principals/users') {
+				$users = $this->userManager->getByEmail(substr($uri, 7));
+				if (count($users) !== 1) {
+					return null;
 				}
+				$user = $users[0];
+
+				if ($restrictGroups !== false) {
+					$userGroups = $this->groupManager->getUserGroupIds($user);
+					if (count(array_intersect($userGroups, $restrictGroups)) === 0) {
+						return null;
+					}
+				}
+
+				return $this->principalPrefix . '/' . $user->getUID();
 			}
 		}
 
-		return '';
+		return null;
 	}
 
 	/**

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -32,7 +32,7 @@ use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\Connector\Sabre\Principal;
 use OCA\DAV\DAV\GroupPrincipalBackend;
 use OCA\DAV\DAV\SystemPrincipalBackend;
-use Sabre\CalDAV\Principal\Collection;
+use OCA\DAV\CalDAV\Principal\Collection;
 use Sabre\DAV\SimpleCollection;
 
 class RootCollection extends SimpleCollection {

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -43,11 +43,14 @@ class RootCollection extends SimpleCollection {
 		$logger = \OC::$server->getLogger();
 		$userManager = \OC::$server->getUserManager();
 		$groupManager = \OC::$server->getGroupManager();
+		$shareManager = \OC::$server->getShareManager();
 		$db = \OC::$server->getDatabaseConnection();
 		$dispatcher = \OC::$server->getEventDispatcher();
 		$userPrincipalBackend = new Principal(
 			$userManager,
-			$groupManager
+			$groupManager,
+			$shareManager,
+			\OC::$server->getUserSession()
 		);
 		$groupPrincipalBackend = new GroupPrincipalBackend($groupManager);
 		// as soon as debug mode is enabled we allow listing of principals


### PR DESCRIPTION
Currently the FreeBusy Request are answered with a 404 Status. and it is not possible to receive a proper FreeBusy status with e.g. Thunderbird. This is due to a function missing in the NC Principal Backend. Further the ACL for User Principals need to be adjusted to allow propFinds to find the scheduling boxes for principles others than the owner.

I know that especially the ACL fix is not perfect at all and it is just a test get the FreeBusy stuff working. I just saw, that NC subclasses the Calendar to generate a proper ACL based on the sharing options. Maybe subclassing the User class would be a better way. But I'am not sure about the right solution. So this is open for discussion. :)

See: https://help.nextcloud.com/t/future-of-sabre-dav/21739
~~Requires: nextcloud/3rdparty#68~~

PS.: My first NC PR. :see_no_evil: 

cc @georgehrke 