### PR TITLE
Move login page more to the top

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -60,9 +60,6 @@ h3 {
 }
 
 /* Global content */
-#header {
-	padding-top: 100px;
-}
 #header .logo {
 	background-image: url('../img/logo.svg?v=1');
 	background-repeat: no-repeat;
@@ -85,7 +82,10 @@ h3 {
 	width: 300px;
 }
 .v-align {
-	width: inherit;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
 }
 
 /* Default FORM */


### PR DESCRIPTION
on iPhone SE the login button is not shown when the AppInfo is displayed. This change move the page more to the top. The login button is now displayed on small cellphones like iPhone SE

Before:
![before](https://user-images.githubusercontent.com/1473674/31114476-8cab7426-a81e-11e7-89ce-9c6ad5b32fe9.jpg)


After:
![after](https://user-images.githubusercontent.com/1473674/31114513-c1a003f4-a81e-11e7-95a6-90ae43ece746.jpg)
