### PR TITLE
Add Updates section to app management

### DIFF
--- a/core/css/icons.scss
+++ b/core/css/icons.scss
@@ -493,14 +493,21 @@ img, object, video, button, textarea, input, select {
 .icon-category-installed {
 	background-image: url('../img/actions/user.svg?v=1');
 }
+
 .icon-category-enabled {
 	background-image: url('../img/actions/checkmark.svg?v=1');
 }
+
 .icon-category-disabled {
 	background-image: url('../img/actions/close.svg?v=1');
 }
+
 .icon-category-app-bundles {
 	background-image: url('../img/categories/bundles.svg?v=1');
+}
+
+.icon-category-updates {
+	background-image: url('../img/actions/download.svg?v=1');
 }
 
 .icon-category-files {

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -768,6 +768,8 @@ class OC_App {
 			}
 		}
 
+		$apps = array_unique($apps);
+
 		return $apps;
 	}
 

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -91,7 +91,6 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		$('#app-category-' + OC.Settings.Apps.State.currentCategory).removeClass('active');
 		$('#app-category-' + categoryId).addClass('active');
 		OC.Settings.Apps.State.currentCategory = categoryId;
-		OC.Settings.Apps.State.availableUpdates = 0;
 
 		this._loadCategoryCall = $.ajax(OC.generateUrl('settings/apps/list?category={categoryId}', {
 			categoryId: categoryId

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -62,11 +62,13 @@ OC.Settings.Apps = OC.Settings.Apps || {
 				var updateCategory = $.grep(jsondata, function(element, index) {
 					return element.ident === 'updates'
 				});
-				if (updateCategory.length === 1) {
-					OC.Settings.Apps.State.availableUpdates = updateCategory[0].counter;
-				}
 				$('#apps-categories').html(html);
 				$('#app-category-' + OC.Settings.Apps.State.currentCategory).addClass('active');
+				if (updateCategory.length === 1) {
+					console.log(updateCategory);
+					OC.Settings.Apps.State.availableUpdates = updateCategory[0].counter;
+					OC.Settings.Apps.refreshUpdateCounter();
+				}
 			},
 			complete: function() {
 				$('#app-navigation').removeClass('icon-loading');
@@ -143,8 +145,13 @@ OC.Settings.Apps = OC.Settings.Apps || {
 						}
 					});
 				} else {
-					$('#apps-list').addClass('hidden');
-					$('#apps-list-empty').removeClass('hidden').find('h2').text(t('settings', 'No apps found for your version'));
+					if (categoryId === 'updates') {
+						OC.Settings.Apps.showEmptyUpdates();
+					} else {
+						$('#apps-list').addClass('hidden');
+						$('#apps-list-empty').removeClass('hidden').find('h2').text(t('settings', 'No apps found for your version'));
+						$('#app-list-empty-icon').addClass('icon-search').removeClass('icon-download');
+					}
 				}
 
 				$('.enable.needs-download').tooltip({
@@ -518,6 +525,12 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		}
 	},
 
+	showEmptyUpdates: function() {
+		$('#apps-list').addClass('hidden');
+		$('#apps-list-empty').removeClass('hidden').find('h2').text(t('settings', 'No app updates available'));
+		$('#app-list-empty-icon').removeClass('icon-search').addClass('icon-download');
+	},
+
 	updateApp:function(appId, element) {
 		var oldButtonText = element.val();
 		element.val(t('settings','Updating....'));
@@ -542,6 +555,13 @@ OC.Settings.Apps = OC.Settings.Apps || {
 
 				OC.Settings.Apps.State.availableUpdates--;
 				OC.Settings.Apps.refreshUpdateCounter();
+
+				if (OC.Settings.Apps.State.currentCategory === 'updates') {
+					$('#app-' + appId).remove();
+					if (OC.Settings.Apps.State.availableUpdates === 0) {
+						OC.Settings.Apps.showEmptyUpdates();
+					}
+				}
 			}
 		},'json');
 	},
@@ -652,7 +672,12 @@ OC.Settings.Apps = OC.Settings.Apps || {
 	},
 
 	refreshUpdateCounter: function() {
-		$('#app-category-updates').find('.app-navigation-entry-utils-counter').html(OC.Settings.Apps.State.availableUpdates);
+		var $updateCount = $('#app-category-updates').find('.app-navigation-entry-utils-counter');
+		if (OC.Settings.Apps.State.availableUpdates > 0) {
+			$updateCount.html(OC.Settings.Apps.State.availableUpdates);
+		} else {
+			$updateCount.empty();
+		}
 	},
 
 	showErrorMessage: function(appId, message) {

--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -19,6 +19,11 @@ script(
 {{#each this}}
 	<li id="app-category-{{ident}}" data-category-id="{{ident}}" tabindex="0">
 		<a href="#" class="icon-category-{{ident}}">{{displayName}}</a>
+		<div class="app-navigation-entry-utils">
+			<ul>
+				<li class="app-navigation-entry-utils-counter">{{ counter }}</li>
+			</ul>
+		</div>
 	</li>
 {{/each}}
 
@@ -65,9 +70,6 @@ script(
 	</div>
 
 	<div class="actions">
-		<div class="app-dependencies update hidden">
-			<p><?php p($l->t('This app has an update available.')); ?></p>
-		</div>
 		<div class="warning hidden"></div>
 		<input class="update hidden" type="submit" value="<?php p($l->t('Update to %s', array('{{update}}'))); ?>" data-appid="{{id}}" />
 		{{#if canUnInstall}}

--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -208,7 +208,7 @@ script(
 	</svg>
 	<div id="apps-list"></div>
 	<div id="apps-list-empty" class="hidden emptycontent emptycontent-search">
-		<div class="icon-search"></div>
+		<div id="app-list-empty-icon" class="icon-search"></div>
 		<h2><?php p($l->t('No apps found for your version')) ?></h2>
 	</div>
 </div>

--- a/tests/Settings/Controller/AppSettingsControllerTest.php
+++ b/tests/Settings/Controller/AppSettingsControllerTest.php
@@ -102,6 +102,12 @@ class AppSettingsControllerTest extends TestCase {
 				'displayName' => 'Your apps',
 			],
 			[
+				'id' => 4,
+				'ident' => 'updates',
+				'displayName' => 'Updates',
+				'counter' => 0,
+			],
+			[
 				'id' => 0,
 				'ident' => 'enabled',
 				'displayName' => 'Enabled apps',


### PR DESCRIPTION
Add updates section to the apps management (fixes #838)

![bildschirmfoto vom 2017-10-03 14-33-08](https://user-images.githubusercontent.com/3404133/31126597-8d7022f2-a84c-11e7-8703-fcad426a30e3.png)

Partly fixes https://github.com/nextcloud/server/issues/301 since it removes the notification in the header and adds a badge with the update count to the sidebar.
