### PR TITLE
Show apps with available updates first

### DIFF
--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -113,9 +113,11 @@ OC.Settings.Apps = OC.Settings.Apps || {
 						appList.sort(function (a, b) {
 							if (a.active !== b.active) {
 								return (a.active ? -1 : 1)
-							} else {
-							    	return OC.Util.naturalSortCompare(a.name, b.name);
 							}
+							if (a.update !== b.update) {
+								return (a.update ? -1 : 1)
+							}
+							return OC.Util.naturalSortCompare(a.name, b.name);
 						});
 					}
 


### PR DESCRIPTION
fix for #1236

The order is:
- Enabled with Updates
- Enabled without Updates
- Disabled with Updates
- Disabled without Updates

Inside those they are sorted alphabetically

![bildschirmfoto vom 2017-10-03 15-05-03](https://user-images.githubusercontent.com/3404133/31126854-57367b4a-a84d-11e7-83b0-98ac2f41a591.png)
