### PR TITLE
dont run invalid path repair step when upgrading from 11.0.5.2 and later

### DIFF
--- a/lib/private/Repair/NC13/RepairInvalidPaths.php
+++ b/lib/private/Repair/NC13/RepairInvalidPaths.php
@@ -172,10 +172,18 @@ class RepairInvalidPaths implements IRepairStep {
 		return $count;
 	}
 
-	public function run(IOutput $output) {
+	private function shouldRun() {
 		$versionFromBeforeUpdate = $this->config->getSystemValue('version', '0.0.0');
-		// was added to 12.0.0.30 and 13.0.0.1
-		if (version_compare($versionFromBeforeUpdate, '12.0.0.30', '<') || version_compare($versionFromBeforeUpdate, '13.0.0.0', '==')) {
+
+		// was added to 11.0.5.2, 12.0.0.30 and 13.0.0.1
+		$shouldRun = version_compare($versionFromBeforeUpdate, '11.0.5.2', '<');
+		$shouldRun |= version_compare($versionFromBeforeUpdate, '12.0.0.0', '>=') && version_compare($versionFromBeforeUpdate, '12.0.0.30', '<');
+		$shouldRun |= version_compare($versionFromBeforeUpdate, '13.0.0.0', '==');
+		return $shouldRun;
+	}
+
+	public function run(IOutput $output) {
+		if ($this->shouldRun()) {
 			$count = $this->repair();
 
 			$output->info('Repaired ' . $count . ' paths');

--- a/tests/lib/Repair/RepairInvalidPathsTest.php
+++ b/tests/lib/Repair/RepairInvalidPathsTest.php
@@ -186,4 +186,34 @@ class RepairInvalidPathsTest extends TestCase {
 		$this->assertEquals($folderId, $this->cache2->get('foo2/bar/asd')['parent']);
 		$this->assertEquals($folderId, $this->cache2->getId('foo2/bar'));
 	}
+
+	public function shouldRunDataProvider() {
+		return [
+			['11.0.0.0', true],
+			['11.0.0.31', true],
+			['11.0.5.2', false],
+			['12.0.0.0', true],
+			['12.0.0.1', true],
+			['12.0.0.31', false],
+			['13.0.0.0', true],
+			['13.0.0.1', false]
+		];
+	}
+
+	/**
+	 * @dataProvider shouldRunDataProvider
+	 *
+	 * @param string $from
+	 * @param boolean $expected
+	 */
+	public function testShouldRun($from, $expected) {
+		$config = $this->createMock(IConfig::class);
+		$config->expects($this->any())
+			->method('getSystemValue')
+			->with('version', '0.0.0')
+			->willReturn($from);
+		$repair = new RepairInvalidPaths(\OC::$server->getDatabaseConnection(), $config);
+
+		$this->assertEquals($expected, $this->invokePrivate($repair, 'shouldRun'));
+	}
 }


### PR DESCRIPTION
With the repair step being backported to stable11 we need to make sure that we don't run the repair step when updating from new stable11 versions