### PR TITLE
Can not change encryption directory

### DIFF
--- a/core/Command/Encryption/ChangeKeyStorageRoot.php
+++ b/core/Command/Encryption/ChangeKeyStorageRoot.php
@@ -146,7 +146,7 @@ class ChangeKeyStorageRoot extends Command {
 			'ownCloud will detect this folder as key storage root only if this file exists'
 		);
 
-		if ($result === false) {
+		if ($result !== true) {
 			throw new \Exception("Can't write to new root folder. Please check the permissions and try again");
 		}
 

--- a/core/Command/Encryption/ChangeKeyStorageRoot.php
+++ b/core/Command/Encryption/ChangeKeyStorageRoot.php
@@ -146,8 +146,8 @@ class ChangeKeyStorageRoot extends Command {
 			'ownCloud will detect this folder as key storage root only if this file exists'
 		);
 
-		if ($result !== true) {
-			throw new \Exception("Can't write to new root folder. Please check the permissions and try again");
+		if (!$result) {
+			throw new \Exception("Can't access the new root folder. Please check the permissions and make sure that the folder is in your data folder");
 		}
 
 	}

--- a/core/Command/Encryption/ChangeKeyStorageRoot.php
+++ b/core/Command/Encryption/ChangeKeyStorageRoot.php
@@ -143,7 +143,7 @@ class ChangeKeyStorageRoot extends Command {
 
 		$result = $this->rootView->file_put_contents(
 			$newRoot . '/' . Storage::KEY_STORAGE_MARKER,
-			'ownCloud will detect this folder as key storage root only if this file exists'
+			'Nextcloud will detect this folder as key storage root only if this file exists'
 		);
 
 		if (!$result) {

--- a/tests/Core/Command/Encryption/ChangeKeyStorageRootTest.php
+++ b/tests/Core/Command/Encryption/ChangeKeyStorageRootTest.php
@@ -175,7 +175,7 @@ class ChangeKeyStorageRootTest extends TestCase {
 
 		$this->view->expects($this->once())->method('file_put_contents')
 			->with('newRoot/' . \OC\Encryption\Keys\Storage::KEY_STORAGE_MARKER,
-				'ownCloud will detect this folder as key storage root only if this file exists');
+				'Nextcloud will detect this folder as key storage root only if this file exists')->willReturn(true);
 
 		$this->invokePrivate($this->changeKeyStorageRoot, 'prepareNewRoot', ['newRoot']);
 	}
@@ -198,6 +198,7 @@ class ChangeKeyStorageRootTest extends TestCase {
 	public function dataTestPrepareNewRootException() {
 		return [
 			[true, false],
+			[true, null],
 			[false, true]
 		];
 	}


### PR DESCRIPTION
Fix #6769 

@schiessle there is an issue here
1. You require a path relative to the root storage
2. You use the view
3. The view does not allow `/../` in paths

Therefor you can only change the root inside your data directory, but not move it out of it.
If that is intended, we should have this commit here and display a better error message