### PR TITLE
Opt out of IMip CalDAV Plugin

### DIFF
--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>WebDAV endpoint</description>
 	<licence>AGPL</licence>
 	<author>owncloud.org</author>
-	<version>1.4.4</version>
+	<version>1.4.5</version>
 	<default_enable/>
 	<types>
 		<filesystem/>
@@ -52,4 +52,8 @@
 			<provider>OCA\DAV\CalDAV\Activity\Provider\Todo</provider>
 		</providers>
 	</activity>
+
+	<settings>
+		<admin>OCA\DAV\Settings\CalDAVSettings</admin>
+	</settings>
 </info>

--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -52,6 +52,7 @@ $dispatcher = \OC::$server->getEventDispatcher();
 $calDavBackend = new CalDavBackend($db, $principalBackend, $userManager, $random, $dispatcher, true);
 
 $debugging = \OC::$server->getConfig()->getSystemValue('debug', false);
+$sendInvitations = \OC::$server->getConfig()->getAppValue('dav', 'sendInvitations', 'yes') === 'yes';
 
 // Root nodes
 $principalCollection = new \Sabre\CalDAV\Principal\Collection($principalBackend);
@@ -84,7 +85,11 @@ if ($debugging) {
 $server->addPlugin(new \Sabre\DAV\Sync\Plugin());
 $server->addPlugin(new \Sabre\CalDAV\ICSExportPlugin());
 $server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin());
-$server->addPlugin(new \OCA\DAV\CalDAV\Schedule\IMipPlugin( \OC::$server->getMailer(), \OC::$server->getLogger(), new \OC\AppFramework\Utility\TimeFactory()));
+
+if ($sendInvitations) {
+	$server->addPlugin(new \OCA\DAV\CalDAV\Schedule\IMipPlugin( \OC::$server->getMailer(), \OC::$server->getLogger(), new \OC\AppFramework\Utility\TimeFactory()));
+}
+
 $server->addPlugin(new ExceptionLoggerPlugin('caldav', \OC::$server->getLogger()));
 
 // And off we go!

--- a/apps/dav/js/settings-admin-caldav.js
+++ b/apps/dav/js/settings-admin-caldav.js
@@ -1,0 +1,28 @@
+/**
+ * @copyright 2017, Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+"use strict";
+
+$('#caldavSendInvitations').change(function() {
+	var val = $(this)[0].checked;
+
+	OCP.AppConfig.setValue('dav', 'sendInvitations', val ? 'yes' : 'no');
+});

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -76,6 +76,7 @@ class Server {
 		$mailer = \OC::$server->getMailer();
 		$dispatcher = \OC::$server->getEventDispatcher();
 		$timezone = new TimeFactory();
+		$sendInvitations = \OC::$server->getConfig()->getAppValue('dav', 'sendInvitations', 'yes') === 'yes';
 
 		$root = new RootCollection();
 		$this->server = new \OCA\DAV\Connector\Sabre\Server(new CachingTree($root));
@@ -137,7 +138,9 @@ class Server {
 		$this->server->addPlugin(new \OCA\DAV\CalDAV\Plugin());
 		$this->server->addPlugin(new \Sabre\CalDAV\ICSExportPlugin());
 		$this->server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin());
-		$this->server->addPlugin(new IMipPlugin($mailer, $logger, $timezone));
+		if ($sendInvitations) {
+			$this->server->addPlugin(new IMipPlugin($mailer, $logger, $timezone));
+		}
 		$this->server->addPlugin(new \Sabre\CalDAV\Subscriptions\Plugin());
 		$this->server->addPlugin(new \Sabre\CalDAV\Notifications\Plugin());
 		$this->server->addPlugin(new DAV\Sharing\Plugin($authBackend, \OC::$server->getRequest()));

--- a/apps/dav/lib/Settings/CalDAVSettings.php
+++ b/apps/dav/lib/Settings/CalDAVSettings.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @copyright 2017, Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DAV\Settings;
+
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IConfig;
+use OCP\Settings\ISettings;
+
+class CalDAVSettings implements ISettings {
+
+	/** @var IConfig */
+	private $config;
+
+	/**
+	 * CalDAVSettings constructor.
+	 *
+	 * @param IConfig $config
+	 */
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	/**
+	 * @return TemplateResponse
+	 */
+	public function getForm() {
+		$parameters = [
+			'send_invitations' => $this->config->getAppValue('dav', 'sendInvitations', 'yes'),
+		];
+
+		return new TemplateResponse('dav', 'settings-admin-caldav', $parameters);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getSection() {
+		return 'additional';
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getPriority() {
+		return 20;
+	}
+}

--- a/apps/dav/templates/settings-admin-caldav.php
+++ b/apps/dav/templates/settings-admin-caldav.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @copyright 2017, Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+script('dav', [
+	'settings-admin-caldav'
+]);
+
+/** @var \OCP\IL10N $l */
+/** @var array $_ */
+?>
+<form id="CalDAV" class="section">
+	<h2><?php p($l->t('CalDAV server')); ?></h2>
+	<p>
+		<input type="checkbox" name="caldav_send_invitations" id="caldavSendInvitations" class="checkbox"
+			<?php ($_['send_invitations'] === 'yes') ? print_unescaped('checked="checked"') : null ?>/>
+		<label for="caldavSendInvitations"><?php p($l->t('Send invitations to attendees')); ?></label>
+		<br>
+		<em><?php p($l->t('Please make sure to properly setup the email settings above.')); ?></em>
+	</p>
+</form>

--- a/apps/dav/tests/unit/Settings/CalDAVSettingsTest.php
+++ b/apps/dav/tests/unit/Settings/CalDAVSettingsTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @copyright 2017, Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DAV\Tests\Unit\DAV\Settings;
+
+use OCA\DAV\Settings\CalDAVSettings;
+use OCP\IConfig;
+use Test\TestCase;
+
+class CalDAVSettingsTest extends TestCase {
+
+	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	private $config;
+
+	/** @var CalDAVSettings */
+	private $settings;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->settings = new CalDAVSettings($this->config);
+	}
+
+	public function testGetForm() {
+		$result = $this->settings->getForm();
+
+		$this->assertInstanceOf('OCP\AppFramework\Http\TemplateResponse', $result);
+	}
+
+	public function testGetSection() {
+		$this->assertEquals('additional', $this->settings->getSection());
+	}
+
+	public function testGetPriority() {
+		$this->assertEquals(20, $this->settings->getPriority());
+	}
+}


### PR DESCRIPTION
This pull-request makes it possible to opt out of the iMip Plugin for CalDAV. If disabled, the server will no longer send out emails to attendees. This was requested by many people.

I already implemented this earlier in https://github.com/nextcloud/server/pull/5304, but removed it again because of requested changes concerning the implementation.

In contrast to https://github.com/nextcloud/server/pull/5304, this pull-request doesn't use the `config.php`, but stores it in the database.

This pull-request adds a new GUI element:
![c3285bf8-7c80-4ac1-938d-e4129d1a2af1](https://user-images.githubusercontent.com/1250540/31438046-c53effc8-ae87-11e7-80dc-4e33bd1f4b73.jpg)

Config method besides GUI:
```
php occ config:app:set dav sendInvitations --value yes/no
```