### PR TITLE
Exclude avatar from Same-Site Cookie requirement

### DIFF
--- a/core/Controller/AvatarController.php
+++ b/core/Controller/AvatarController.php
@@ -115,6 +115,7 @@ class AvatarController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @NoSameSiteCookieRequired
 	 * @PublicPage
 	 *
 	 * @param string $userId


### PR DESCRIPTION
Required to work with the upcoming Collabora avatar integration.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>