### PR TITLE
Allow div instead of forms on editable nav entries

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -423,7 +423,8 @@ kbd {
 		position: absolute;
 		background-color: $color-main-background;
 		z-index: -1;
-		form {
+		form,
+		div {
 			display: inline-flex;
 			width: 100%;
 		}


### PR DESCRIPTION
If someone wishes to create an editable nav entry and handle everything in js, he should be able to NOT use a form :)

@nextcloud/designers 