### PR TITLE
[stable12] Fix contacts menu for IE11

### DIFF
--- a/core/js/contactsmenu.js
+++ b/core/js/contactsmenu.js
@@ -286,6 +286,9 @@
 		/** @type {undefined|ContactCollection} */
 		_contacts: undefined,
 
+		/** @type {string} */
+		_searchTerm: '',
+
 		events: {
 			'input #contactsmenu-search': '_onSearch'
 		},
@@ -293,8 +296,16 @@
 		/**
 		 * @returns {undefined}
 		 */
-		_onSearch: _.debounce(function() {
-			this.trigger('search', this.$('#contactsmenu-search').val());
+		_onSearch: _.debounce(function(e) {
+			var searchTerm = this.$('#contactsmenu-search').val();
+			// IE11 triggers an 'input' event after the view has been rendered
+			// resulting in an endless loading loop. To prevent this, we remember
+			// the last search term to savely ignore some events
+			// See https://github.com/nextcloud/server/issues/5281
+			if (searchTerm !== this._searchTerm) {
+				this.trigger('search', this.$('#contactsmenu-search').val());
+				this._searchTerm = searchTerm;
+			}
 		}, 700),
 
 		/**


### PR DESCRIPTION
IE11 triggers an 'input' event whenever an input is focussed
or loses focus. Thus this causes an endless loading loop as soon
as the view is re-rendered. To prevent this, this remembers the
previous search term and ignores events where the term has not
changed.

Fixes https://github.com/nextcloud/server/issues/5281
Backport of https://github.com/nextcloud/server/pull/6795