### PR TITLE
still trigger conflict resolution for existing entries when the curre…

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1249,23 +1249,24 @@
 			var nameSpan=$('<span></span>').addClass('nametext');
 			var innernameSpan = $('<span></span>').addClass('innernametext').text(basename);
 
-			if (path && path !== '/') {
-				var conflictingItems = this.$fileList.find('tr[data-file="' + this._jqSelEscape(name) + '"]');
-				if (conflictingItems.length !== 0) {
-					if (conflictingItems.length === 1) {
-						// Update the path on the first conflicting item
-						var $firstConflict = $(conflictingItems[0]),
-							firstConflictPath = $firstConflict.attr('data-path') + '/';
-						if (firstConflictPath.charAt(0) === '/') {
-							firstConflictPath = firstConflictPath.substr(1);
-						}
-						$firstConflict.find('td.filename span.innernametext').prepend($('<span></span>').addClass('conflict-path').text(firstConflictPath));
-					}
 
-					var conflictPath = path + '/';
-					if (conflictPath.charAt(0) === '/') {
-						conflictPath = conflictPath.substr(1);
+			var conflictingItems = this.$fileList.find('tr[data-file="' + this._jqSelEscape(name) + '"]');
+			if (conflictingItems.length !== 0) {
+				if (conflictingItems.length === 1) {
+					// Update the path on the first conflicting item
+					var $firstConflict = $(conflictingItems[0]),
+						firstConflictPath = $firstConflict.attr('data-path') + '/';
+					if (firstConflictPath.charAt(0) === '/') {
+						firstConflictPath = firstConflictPath.substr(1);
 					}
+					$firstConflict.find('td.filename span.innernametext').prepend($('<span></span>').addClass('conflict-path').text(firstConflictPath));
+				}
+
+				var conflictPath = path + '/';
+				if (conflictPath.charAt(0) === '/') {
+					conflictPath = conflictPath.substr(1);
+				}
+				if (path && path !== '/') {
 					nameSpan.append($('<span></span>').addClass('conflict-path').text(conflictPath));
 				}
 			}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1259,7 +1259,9 @@
 					if (firstConflictPath.charAt(0) === '/') {
 						firstConflictPath = firstConflictPath.substr(1);
 					}
-					$firstConflict.find('td.filename span.innernametext').prepend($('<span></span>').addClass('conflict-path').text(firstConflictPath));
+					if (firstConflictPath && firstConflictPath !== '/') {
+						$firstConflict.find('td.filename span.innernametext').prepend($('<span></span>').addClass('conflict-path').text(firstConflictPath));
+					}
 				}
 
 				var conflictPath = path + '/';


### PR DESCRIPTION
…nt entry doesn't need it

Currently if a filelist (such as favorites) contain `'a/foo.txt'`, `'/foo.txt'` and `'b/foo.txt'` in that order the [conflict resolution](https://user-images.githubusercontent.com/1283854/31616742-cdb6cef6-b28d-11e7-934f-ddb4f03620fa.png) doesn't trigger for the first item, since while adding the 2nd item (when adding conflict resolution to the first item should be triggered) the conflict resolution code is never triggered.

By always checking for conflict resolution we ensure that this case is properly handled

(not sure if there is a reliable way to reproduce the issue since it relies on the favorite listing being reported in a specific order, tested this myself by editing the js code on an instance that had the issue)