### PR TITLE
propagate multipart upload exception when aborting upload

### DIFF
--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -105,6 +105,7 @@ trait S3ObjectTrait {
 					]);
 				} else {
 					$this->getConnection()->abortMultipartUpload($e->getState()->getId());
+					throw $e;
 				}
 			}
 		} while (!isset($result) && $tries < 5);


### PR DESCRIPTION
When we give up on the upload we need to propagate the exception to ensure that the upload is detected as failed.