### PR TITLE
Add logrote as a default background job

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -730,7 +730,6 @@ class OC {
 		self::registerCacheHooks();
 		self::registerFilesystemHooks();
 		self::registerShareHooks();
-		self::registerLogRotate();
 		self::registerEncryptionWrapper();
 		self::registerEncryptionHooks();
 		self::registerAccountHooks();
@@ -860,18 +859,6 @@ class OC {
 	private static function registerAccountHooks() {
 		$hookHandler = new \OC\Accounts\Hooks(\OC::$server->getLogger());
 		\OCP\Util::connectHook('OC_User', 'changeUser', $hookHandler, 'changeUserHook');
-	}
-
-	/**
-	 * register hooks for the cache
-	 */
-	public static function registerLogRotate() {
-		$systemConfig = \OC::$server->getSystemConfig();
-		if ($systemConfig->getValue('installed', false) && $systemConfig->getValue('log_rotate_size', false) && !self::checkUpgrade(false)) {
-			//don't try to do this before we are properly setup
-			//use custom logfile path if defined, otherwise use default of nextcloud.log in data directory
-			\OC::$server->getJobList()->add('OC\Log\Rotate');
-		}
 	}
 
 	/**

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -780,6 +780,7 @@ return array(
     'OC\\Repair\\NC12\\InstallCoreBundle' => $baseDir . '/lib/private/Repair/NC12/InstallCoreBundle.php',
     'OC\\Repair\\NC12\\RepairIdentityProofKeyFolders' => $baseDir . '/lib/private/Repair/NC12/RepairIdentityProofKeyFolders.php',
     'OC\\Repair\\NC12\\UpdateLanguageCodes' => $baseDir . '/lib/private/Repair/NC12/UpdateLanguageCodes.php',
+    'OC\\Repair\\NC13\\AddLogRotateJob' => $baseDir . '/lib/private/Repair/NC13/AddLogRotateJob.php',
     'OC\\Repair\\NC13\\RepairInvalidPaths' => $baseDir . '/lib/private/Repair/NC13/RepairInvalidPaths.php',
     'OC\\Repair\\OldGroupMembershipShares' => $baseDir . '/lib/private/Repair/OldGroupMembershipShares.php',
     'OC\\Repair\\Owncloud\\DropAccountTermsTable' => $baseDir . '/lib/private/Repair/Owncloud/DropAccountTermsTable.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -810,6 +810,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Repair\\NC12\\InstallCoreBundle' => __DIR__ . '/../../..' . '/lib/private/Repair/NC12/InstallCoreBundle.php',
         'OC\\Repair\\NC12\\RepairIdentityProofKeyFolders' => __DIR__ . '/../../..' . '/lib/private/Repair/NC12/RepairIdentityProofKeyFolders.php',
         'OC\\Repair\\NC12\\UpdateLanguageCodes' => __DIR__ . '/../../..' . '/lib/private/Repair/NC12/UpdateLanguageCodes.php',
+        'OC\\Repair\\NC13\\AddLogRotateJob' => __DIR__ . '/../../..' . '/lib/private/Repair/NC13/AddLogRotateJob.php',
         'OC\\Repair\\NC13\\RepairInvalidPaths' => __DIR__ . '/../../..' . '/lib/private/Repair/NC13/RepairInvalidPaths.php',
         'OC\\Repair\\OldGroupMembershipShares' => __DIR__ . '/../../..' . '/lib/private/Repair/OldGroupMembershipShares.php',
         'OC\\Repair\\Owncloud\\DropAccountTermsTable' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/DropAccountTermsTable.php',

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -41,6 +41,7 @@ use OC\Repair\NC11\MoveAvatars;
 use OC\Repair\NC12\InstallCoreBundle;
 use OC\Repair\NC12\UpdateLanguageCodes;
 use OC\Repair\NC12\RepairIdentityProofKeyFolders;
+use OC\Repair\NC13\AddLogRotateJob;
 use OC\Repair\OldGroupMembershipShares;
 use OC\Repair\Owncloud\DropAccountTermsTable;
 use OC\Repair\Owncloud\SaveAccountsTableData;
@@ -150,6 +151,7 @@ class Repair implements IOutput{
 			),
 			new RepairInvalidPaths(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig()),
 			new RepairIdentityProofKeyFolders(\OC::$server->getConfig(), \OC::$server->query(Factory::class), \OC::$server->getRootFolder()),
+			new AddLogRotateJob(\OC::$server->getJobList()),
 		];
 	}
 

--- a/lib/private/Repair/NC13/AddLogRotateJob.php
+++ b/lib/private/Repair/NC13/AddLogRotateJob.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @copyright 2017, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OC\Repair\NC13;
+
+use OC\Log\Rotate;
+use OCP\BackgroundJob\IJobList;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class AddLogRotateJob implements IRepairStep {
+
+	/** @var IJobList */
+	private $jobList;
+
+	public function __construct(IJobList $jobList) {
+		$this->jobList = $jobList;
+	}
+
+	public function getName() {
+		return 'Add log rotate job';
+	}
+
+	public function run(IOutput $output) {
+		$this->jobList->add(Rotate::class);
+	}
+
+}

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -44,6 +44,7 @@ use Exception;
 use OC\App\AppStore\Bundles\BundleFetcher;
 use OC\Authentication\Token\DefaultTokenCleanupJob;
 use OC\Authentication\Token\DefaultTokenProvider;
+use OC\Log\Rotate;
 use OCP\Defaults;
 use OCP\IL10N;
 use OCP\ILogger;
@@ -426,7 +427,9 @@ class Setup {
 	}
 
 	public static function installBackgroundJobs() {
-		\OC::$server->getJobList()->add(DefaultTokenCleanupJob::class);
+		$jobList = \OC::$server->getJobList();
+		$jobList->add(DefaultTokenCleanupJob::class);
+		$jobList->add(Rotate::class);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #6909

Just adds a background job by default to rotate the logs. This way we do less checks on each request.

Of course if you don't rotate there will be an extra background job. But that should almost finish instantly. So no real resources lost there.