### PR TITLE
Use DI for IAppManager to encryption migration

### DIFF
--- a/apps/encryption/lib/Migration.php
+++ b/apps/encryption/lib/Migration.php
@@ -26,6 +26,7 @@ namespace OCA\Encryption;
 
 
 use OC\Files\View;
+use OCP\App\IAppManager;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\ILogger;
@@ -43,6 +44,8 @@ class Migration {
 	private $logger;
 	/** @var string*/
 	protected $installedVersion;
+	/** @var IAppManager */
+	protected $appManager;
 
 	/**
 	 * @param IConfig $config
@@ -50,7 +53,7 @@ class Migration {
 	 * @param IDBConnection $connection
 	 * @param ILogger $logger
 	 */
-	public function __construct(IConfig $config, View $view, IDBConnection $connection, ILogger $logger) {
+	public function __construct(IConfig $config, View $view, IDBConnection $connection, ILogger $logger, IAppManager $appManager) {
 		$this->view = $view;
 		$this->view->disableCacheUpdate();
 		$this->connection = $connection;
@@ -58,6 +61,7 @@ class Migration {
 		$this->config = $config;
 		$this->logger = $logger;
 		$this->installedVersion = $this->config->getAppValue('files_encryption', 'installed_version', '-1');
+		$this->appManager = $appManager;
 	}
 
 	public function finalCleanUp() {
@@ -137,7 +141,7 @@ class Migration {
 			$path = '/files_encryption/keys';
 			$this->renameFileKeys($user, $path);
 			$trashPath = '/files_trashbin/keys';
-			if (\OC_App::isEnabled('files_trashbin') && $this->view->is_dir($user . '/' . $trashPath)) {
+			if ($this->appManager->isEnabledForUser('files_trashbin') && $this->view->is_dir($user . '/' . $trashPath)) {
 				$this->renameFileKeys($user, $trashPath, true);
 				$this->view->deleteAll($trashPath);
 			}

--- a/apps/encryption/tests/MigrationTest.php
+++ b/apps/encryption/tests/MigrationTest.php
@@ -203,13 +203,14 @@ class MigrationTest extends \Test\TestCase {
 		$this->createDummySystemWideKeys();
 
 		/** @var \PHPUnit_Framework_MockObject_MockObject|\OCA\Encryption\Migration $m */
-		$m = $this->getMockBuilder('OCA\Encryption\Migration')
+		$m = $this->getMockBuilder(Migration::class)
 			->setConstructorArgs(
 				[
 					\OC::$server->getConfig(),
 					new \OC\Files\View(),
 					\OC::$server->getDatabaseConnection(),
-					$this->logger
+					$this->logger,
+					\OC::$server->getAppManager()
 				]
 			)->setMethods(['getSystemMountPoints'])->getMock();
 
@@ -366,7 +367,7 @@ class MigrationTest extends \Test\TestCase {
 	public function testUpdateDB() {
 		$this->prepareDB();
 
-		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection(), $this->logger);
+		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection(), $this->logger, \OC::$server->getAppManager());
 		$this->invokePrivate($m, 'installedVersion', ['0.7']);
 		$m->updateDB();
 
@@ -386,7 +387,7 @@ class MigrationTest extends \Test\TestCase {
 		$config->setAppValue('encryption', 'publicShareKeyId', 'wrong_share_id');
 		$config->setUserValue(self::TEST_ENCRYPTION_MIGRATION_USER1, 'encryption', 'recoverKeyEnabled', '9');
 
-		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection(), $this->logger);
+		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection(), $this->logger, \OC::$server->getAppManager());
 		$this->invokePrivate($m, 'installedVersion', ['0.7']);
 		$m->updateDB();
 
@@ -455,7 +456,7 @@ class MigrationTest extends \Test\TestCase {
 	 */
 	public function testUpdateFileCache() {
 		$this->prepareFileCache();
-		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection(), $this->logger);
+		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection(), $this->logger, \OC::$server->getAppManager());
 		$this->invokePrivate($m, 'installedVersion', ['0.7']);
 		self::invokePrivate($m, 'updateFileCache');
 
@@ -527,13 +528,14 @@ class MigrationTest extends \Test\TestCase {
 			->disableOriginalConstructor()->getMock();
 		$view->expects($this->any())->method('file_exists')->willReturn(true);
 
-		$m = $this->getMockBuilder('OCA\Encryption\Migration')
+		$m = $this->getMockBuilder(Migration::class)
 			->setConstructorArgs(
 				[
 					\OC::$server->getConfig(),
 					$view,
 					\OC::$server->getDatabaseConnection(),
-					$this->logger
+					$this->logger,
+					\OC::$server->getAppManager()
 				]
 			)->setMethods(['getSystemMountPoints'])->getMock();
 

--- a/settings/Controller/EncryptionController.php
+++ b/settings/Controller/EncryptionController.php
@@ -26,6 +26,7 @@ namespace OC\Settings\Controller;
 
 use OC\Files\View;
 use OCA\Encryption\Migration;
+use OCP\App\IAppManager;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\AppFramework\Controller;
@@ -57,6 +58,9 @@ class EncryptionController extends Controller {
 	/** @var ILogger */
 	private $logger;
 
+	/** @var IAppManager */
+	private $appManager;
+
 	/**
 	 * @param string $appName
 	 * @param IRequest $request
@@ -66,6 +70,7 @@ class EncryptionController extends Controller {
 	 * @param IUserManager $userManager
 	 * @param View $view
 	 * @param ILogger $logger
+	 * @param IAppManager $appManager
 	 */
 	public function __construct($appName,
 								IRequest $request,
@@ -74,7 +79,8 @@ class EncryptionController extends Controller {
 								IDBConnection $connection,
 								IUserManager $userManager,
 								View $view,
-								ILogger  $logger) {
+								ILogger $logger,
+								IAppManager $appManager) {
 		parent::__construct($appName, $request);
 		$this->l10n = $l10n;
 		$this->config = $config;
@@ -82,6 +88,7 @@ class EncryptionController extends Controller {
 		$this->view = $view;
 		$this->userManager = $userManager;
 		$this->logger = $logger;
+		$this->appManager = $appManager;
 	}
 
 	/**
@@ -89,13 +96,15 @@ class EncryptionController extends Controller {
 	 * @param View $view
 	 * @param IDBConnection $connection
 	 * @param ILogger $logger
+	 * @param IAppManager $appManager
 	 * @return Migration
 	 */
 	protected function getMigration(IConfig $config,
 								 View $view,
 								 IDBConnection $connection,
-								 ILogger $logger) {
-		return new Migration($config, $view, $connection, $logger);
+								 ILogger $logger,
+								 IAppManager $appManager) {
+		return new Migration($config, $view, $connection, $logger, $appManager);
 	}
 
 	/**
@@ -111,7 +120,7 @@ class EncryptionController extends Controller {
 
 		try {
 
-			$migration = $this->getMigration($this->config, $this->view, $this->connection, $this->logger);
+			$migration = $this->getMigration($this->config, $this->view, $this->connection, $this->logger, $this->appManager);
 			$migration->reorganizeSystemFolderStructure();
 			$migration->updateDB();
 

--- a/tests/Settings/Controller/EncryptionControllerTest.php
+++ b/tests/Settings/Controller/EncryptionControllerTest.php
@@ -24,6 +24,7 @@ namespace Tests\Settings\Controller;
 use OC\DB\Connection;
 use OC\Files\View;
 use OC\Settings\Controller\EncryptionController;
+use OCP\App\IAppManager;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\ILogger;
@@ -51,6 +52,8 @@ class EncryptionControllerTest extends TestCase {
 	private $view;
 	/** @var ILogger */
 	private $logger;
+	/** @var IAppManager */
+	private $appManager;
 	/** @var EncryptionController */
 	private $encryptionController;
 
@@ -75,6 +78,8 @@ class EncryptionControllerTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->logger = $this->getMockBuilder('\\OCP\\ILogger')
 			->disableOriginalConstructor()->getMock();
+		$this->appManager = $this->getMockBuilder('\\OCP\\App\\IAppManager')
+			->disableOriginalConstructor()->getMock();
 
 		$this->encryptionController = $this->getMockBuilder('\\OC\\Settings\\Controller\\EncryptionController')
 			->setConstructorArgs([
@@ -86,6 +91,7 @@ class EncryptionControllerTest extends TestCase {
 				$this->userManager,
 				$this->view,
 				$this->logger,
+				$this->appManager,
 			])
 			->setMethods(['getMigration'])
 			->getMock();


### PR DESCRIPTION
One step towards removing `\OC_App::isEnabled`