### PR TITLE
Remove unneeded check if app is enabled

### DIFF
--- a/apps/encryption/lib/Hooks/UserHooks.php
+++ b/apps/encryption/lib/Hooks/UserHooks.php
@@ -170,11 +170,6 @@ class UserHooks implements IHook {
 	 * @return boolean|null
 	 */
 	public function login($params) {
-
-		if (!App::isEnabled('encryption')) {
-			return true;
-		}
-
 		// ensure filesystem is loaded
 		if (!\OC\Files\Filesystem::$loaded) {
 			$this->setupFS($params['uid']);
@@ -200,10 +195,7 @@ class UserHooks implements IHook {
 	 * @param array $params
 	 */
 	public function postCreateUser($params) {
-
-		if (App::isEnabled('encryption')) {
-			$this->userSetup->setupUser($params['uid'], $params['password']);
-		}
+		$this->userSetup->setupUser($params['uid'], $params['password']);
 	}
 
 	/**
@@ -213,17 +205,12 @@ class UserHooks implements IHook {
 	 * @note This method should never be called for users using client side encryption
 	 */
 	public function postDeleteUser($params) {
-
-		if (App::isEnabled('encryption')) {
-			$this->keyManager->deletePublicKey($params['uid']);
-		}
+		$this->keyManager->deletePublicKey($params['uid']);
 	}
 
 	public function prePasswordReset($params) {
-		if (App::isEnabled('encryption')) {
-			$user = $params['uid'];
-			self::$passwordResetUsers[$user] = true;
-		}
+		$user = $params['uid'];
+		self::$passwordResetUsers[$user] = true;
 	}
 
 	public function postPasswordReset($params) {

--- a/apps/files_trashbin/lib/Hooks.php
+++ b/apps/files_trashbin/lib/Hooks.php
@@ -39,10 +39,8 @@ class Hooks {
 	 * to remove the used space for the trash bin stored in the database
 	 */
 	public static function deleteUser_hook($params) {
-		if( \OCP\App::isEnabled('files_trashbin') ) {
-			$uid = $params['uid'];
-			Trashbin::deleteUser($uid);
-		}
+		$uid = $params['uid'];
+		Trashbin::deleteUser($uid);
 	}
 
 	public static function post_write_hook($params) {


### PR DESCRIPTION
App code will not be executable if the app is not enabled, because the autoloader refuses to load that class.


@rullzer Correct me if I'm wrong.