### PR TITLE
Remove invalid mail addresses when updating the license header

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -100,6 +100,7 @@ derkostka <sebastian.kostka@gmail.com>
 Diederik de Haas <diederik@cknow.org>
 Dominik Schmidt <dev@dominik-schmidt.de>
 Donald Buczek <buczek@molgen.mpg.de>
+Donquixote <marjunebatac@gmail.com> Donquixote <marjunebatac@gmailcom>
 Doug Neiner <doug@pixelgraphics.us>
 drarko <drarko@users.noreply.github.com>
 dratini0 <dratini0@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,7 +4,7 @@ Nextcloud is written by:
  - Aaron Wood <aaronjwood@gmail.com>
  - Achim Königs <garfonso@tratschtante.de>
  - Adam Williamson <awilliam@redhat.com>
- - Administrator <Administrator@WINDOWS-2012>
+ - Administrator "Administrator@WINDOWS-2012"
  - Aldo "xoen" Giambelluca <xoen@xoen.org>
  - Alex Weirig <alex.weirig@technolink.lu>
  - Alexander Bergolth <leo@strike.wu.ac.at>
@@ -41,7 +41,7 @@ Nextcloud is written by:
  - Christian Jürges <christian@eqipe.ch>
  - Christian Kampka <christian@kampka.net>
  - Christian Weiske <cweiske@cweiske.de>
- - Christoph Schaefer <christophł@wolkesicher.de>
+ - Christoph Schaefer "christophł@wolkesicher.de"
  - Christoph Wickert <cwickert@suse.de>
  - Christoph Wurst <christoph@owncloud.com>
  - Christopher Bartz <bartz@dkrz.de>
@@ -60,7 +60,7 @@ Nextcloud is written by:
  - David Toledo <dtoledo@solidgear.es>
  - Derek <derek.kelly27@gmail.com>
  - Dominik Schmidt <dev@dominik-schmidt.de>
- - Donquixote <marjunebatac@gmailcom>
+ - Donquixote <marjunebatac@gmail.com>
  - Fabian Henze <flyser42@gmx.de>
  - Fabrizio Steiner <fabrizio.steiner@gmail.com>
  - Felix A. Epp <work@felixepp.de>
@@ -279,8 +279,8 @@ Nextcloud is written by:
  - oparoz <owncloud@interfasys.ch>
  - phisch <git@philippschaffrath.de>
  - rakekniven <mark.ziegler@rakekniven.de>
+ - root "root@oc.(none)"
  - root <root@localhost.localdomain>
- - root <root@oc.(none)>
  - scambra <sergio@entrecables.com>
  - scolebrook <scolebrook@mac.com>
  - shkdee <louis.traynard@m4x.org>
@@ -289,8 +289,8 @@ Nextcloud is written by:
  - tbelau666 <thomas.belau@gmx.de>
  - tux-rampage <tux-rampage@users.noreply.github.com>
  - v1r0x <vinzenz.rosenkranz@gmail.com>
- - vkuimov <vkuimov@nextcloud>
- - voxsim <Simon Vocella>
+ - vkuimov "vkuimov@nextcloud"
+ - voxsim "Simon Vocella"
 
 With help from many libraries and frameworks including:
 	Open Collaboration Services

--- a/build/license.php
+++ b/build/license.php
@@ -322,6 +322,7 @@ With help from many libraries and frameworks including:
 		}
 
 		$authors = array_map(function($author){
+			$author = $this->fixInvalidEmail($author);
 			$this->authors[$author] = $author;
 			return " * @author $author";
 		}, $authors);
@@ -345,6 +346,14 @@ With help from many libraries and frameworks including:
 
 		if (isset($this->mailMap[$author])) {
 			return $this->mailMap[$author];
+		}
+		return $author;
+	}
+
+	private function fixInvalidEmail($author) {
+		preg_match('/<(.*)>/', $author, $mailMatch);
+		if (count($mailMatch) === 2 && !filter_var($mailMatch[1], FILTER_VALIDATE_EMAIL)) {
+			$author = str_replace('<'.$mailMatch[1].'>', '"'.$mailMatch[1].'"', $author);
 		}
 		return $author;
 	}

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -4,7 +4,7 @@
  *
  * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
  * @author Bjoern Schiessle <bjoern@schiessle.org>
- * @author Christoph Schaefer <christophł@wolkesicher.de>
+ * @author Christoph Schaefer "christophł@wolkesicher.de"
  * @author Christoph Wurst <christoph@owncloud.com>
  * @author Joas Schilling <coding@schilljs.com>
  * @author Julius Haertl <jus@bitgrid.net>

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -13,7 +13,7 @@
  * @author Robin Appelman <robin@icewind.nl>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Vincent Petry <pvince81@owncloud.com>
- * @author vkuimov <vkuimov@nextcloud>
+ * @author vkuimov "vkuimov@nextcloud"
  *
  * @license AGPL-3.0
  *

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -18,7 +18,7 @@
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Vincent Petry <pvince81@owncloud.com>
  * @author Vinicius Cubas Brand <vinicius@eita.org.br>
- * @author voxsim <Simon Vocella>
+ * @author voxsim "Simon Vocella"
  *
  * @license AGPL-3.0
  *

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -13,7 +13,7 @@
  * @author Lukas Reschke <lukas@statuscode.ch>
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Robin Appelman <robin@icewind.nl>
- * @author root <root@oc.(none)>
+ * @author root "root@oc.(none)"
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Thomas Tanghus <thomas@tanghus.net>
  *

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -2,7 +2,7 @@
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
- * @author Administrator <Administrator@WINDOWS-2012>
+ * @author Administrator "Administrator@WINDOWS-2012"
  * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
  * @author Bart Visscher <bartv@thisnet.nl>
  * @author Bernhard Posselt <dev@bernhard-posselt.com>

--- a/lib/public/AppFramework/Controller.php
+++ b/lib/public/AppFramework/Controller.php
@@ -3,7 +3,7 @@
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
  * @author Bernhard Posselt <dev@bernhard-posselt.com>
- * @author Donquixote <marjunebatac@gmailcom>
+ * @author Donquixote <marjunebatac@gmail.com>
  * @author Lukas Reschke <lukas@statuscode.ch>
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Roeland Jago Douma <roeland@famdouma.nl>

--- a/lib/public/AppFramework/OCSController.php
+++ b/lib/public/AppFramework/OCSController.php
@@ -3,7 +3,7 @@
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
  * @author Bernhard Posselt <dev@bernhard-posselt.com>
- * @author Donquixote <marjunebatac@gmailcom>
+ * @author Donquixote <marjunebatac@gmail.com>
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  * @author Stefan Weil <sw@weilnetz.de>


### PR DESCRIPTION
Follow up of https://github.com/nextcloud/server/pull/6864

This will make sure we only have valid email addresses in the license header, so parsing of the phpdoc block will succeed.

Should i also run the script and commit the changes or is that done only during the release build process?