### PR TITLE
Use ::class in test mocks

### DIFF
--- a/apps/comments/tests/Unit/Controller/NotificationsTest.php
+++ b/apps/comments/tests/Unit/Controller/NotificationsTest.php
@@ -22,7 +22,17 @@
 namespace OCA\Comments\Tests\Unit\Controller;
 
 use OCA\Comments\Controller\Notifications;
+use OCP\Comments\IComment;
+use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException;
+use OCP\Files\Folder;
+use OCP\Files\Node;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserSession;
+use OCP\Notification\IManager;
+use OCP\Notification\INotification;
 use Test\TestCase;
 
 class NotificationsTest extends TestCase {
@@ -44,24 +54,24 @@ class NotificationsTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->commentsManager = $this->getMockBuilder('\OCP\Comments\ICommentsManager')->getMock();
-		$this->folder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
-		$this->session = $this->getMockBuilder('\OCP\IUserSession')->getMock();
-		$this->notificationManager = $this->getMockBuilder('\OCP\Notification\IManager')->getMock();
+		$this->commentsManager = $this->getMockBuilder(ICommentsManager::class)->getMock();
+		$this->folder = $this->getMockBuilder(Folder::class)->getMock();
+		$this->session = $this->getMockBuilder(IUserSession::class)->getMock();
+		$this->notificationManager = $this->getMockBuilder(IManager::class)->getMock();
 
 		$this->notificationsController = new Notifications(
 			'comments',
-			$this->getMockBuilder('\OCP\IRequest')->getMock(),
+			$this->getMockBuilder(IRequest::class)->getMock(),
 			$this->commentsManager,
 			$this->folder,
-			$this->getMockBuilder('\OCP\IURLGenerator')->getMock(),
+			$this->getMockBuilder(IURLGenerator::class)->getMock(),
 			$this->notificationManager,
 			$this->session
 		);
 	}
 	
 	public function testViewSuccess() {
-		$comment = $this->getMockBuilder('\OCP\Comments\IComment')->getMock();
+		$comment = $this->getMockBuilder(IComment::class)->getMock();
 		$comment->expects($this->any())
 			->method('getObjectType')
 			->will($this->returnValue('files'));
@@ -71,7 +81,7 @@ class NotificationsTest extends TestCase {
 			->with('42')
 			->will($this->returnValue($comment));
 
-		$file = $this->getMockBuilder('\OCP\Files\Node')->getMock();
+		$file = $this->getMockBuilder(Node::class)->getMock();
 
 		$this->folder->expects($this->once())
 			->method('getById')
@@ -79,9 +89,9 @@ class NotificationsTest extends TestCase {
 
 		$this->session->expects($this->once())
 			->method('getUser')
-			->will($this->returnValue($this->getMockBuilder('\OCP\IUser')->getMock()));
+			->will($this->returnValue($this->getMockBuilder(IUser::class)->getMock()));
 
-		$notification = $this->getMockBuilder('\OCP\Notification\INotification')->getMock();
+		$notification = $this->getMockBuilder(INotification::class)->getMock();
 		$notification->expects($this->any())
 			->method($this->anything())
 			->will($this->returnValue($notification));
@@ -119,7 +129,7 @@ class NotificationsTest extends TestCase {
 	}
 
 	public function testViewNoFile() {
-		$comment = $this->getMockBuilder('\OCP\Comments\IComment')->getMock();
+		$comment = $this->getMockBuilder(IComment::class)->getMock();
 		$comment->expects($this->any())
 			->method('getObjectType')
 			->will($this->returnValue('files'));
@@ -135,9 +145,9 @@ class NotificationsTest extends TestCase {
 
 		$this->session->expects($this->once())
 			->method('getUser')
-			->will($this->returnValue($this->getMockBuilder('\OCP\IUser')->getMock()));
+			->will($this->returnValue($this->getMockBuilder(IUser::class)->getMock()));
 
-		$notification = $this->getMockBuilder('\OCP\Notification\INotification')->getMock();
+		$notification = $this->getMockBuilder(INotification::class)->getMock();
 		$notification->expects($this->any())
 			->method($this->anything())
 			->will($this->returnValue($notification));

--- a/apps/comments/tests/Unit/Notification/ListenerTest.php
+++ b/apps/comments/tests/Unit/Notification/ListenerTest.php
@@ -71,7 +71,7 @@ class ListenerTest extends TestCase {
 	 */
 	public function testEvaluate($eventType, $notificationMethod) {
 		/** @var IComment|\PHPUnit_Framework_MockObject_MockObject $comment */
-		$comment = $this->getMockBuilder('\OCP\Comments\IComment')->getMock();
+		$comment = $this->getMockBuilder(IComment::class)->getMock();
 		$comment->expects($this->any())
 			->method('getObjectType')
 			->will($this->returnValue('files'));
@@ -90,7 +90,7 @@ class ListenerTest extends TestCase {
 			]);
 
 		/** @var CommentsEvent|\PHPUnit_Framework_MockObject_MockObject $event */
-		$event = $this->getMockBuilder('\OCP\Comments\CommentsEvent')
+		$event = $this->getMockBuilder(CommentsEvent::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$event->expects($this->once())
@@ -101,7 +101,7 @@ class ListenerTest extends TestCase {
 			->will($this->returnValue($eventType));
 
 		/** @var INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
-		$notification = $this->getMockBuilder('\OCP\Notification\INotification')->getMock();
+		$notification = $this->getMockBuilder(INotification::class)->getMock();
 		$notification->expects($this->any())
 			->method($this->anything())
 			->will($this->returnValue($notification));
@@ -136,7 +136,7 @@ class ListenerTest extends TestCase {
 	 */
 	public function testEvaluateNoMentions($eventType) {
 		/** @var IComment|\PHPUnit_Framework_MockObject_MockObject $comment */
-		$comment = $this->getMockBuilder('\OCP\Comments\IComment')->getMock();
+		$comment = $this->getMockBuilder(IComment::class)->getMock();
 		$comment->expects($this->any())
 			->method('getObjectType')
 			->will($this->returnValue('files'));
@@ -148,7 +148,7 @@ class ListenerTest extends TestCase {
 			->willReturn([]);
 
 		/** @var CommentsEvent|\PHPUnit_Framework_MockObject_MockObject $event */
-		$event = $this->getMockBuilder('\OCP\Comments\CommentsEvent')
+		$event = $this->getMockBuilder(CommentsEvent::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$event->expects($this->once())
@@ -173,7 +173,7 @@ class ListenerTest extends TestCase {
 
 	public function testEvaluateUserDoesNotExist() {
 		/** @var IComment|\PHPUnit_Framework_MockObject_MockObject $comment */
-		$comment = $this->getMockBuilder('\OCP\Comments\IComment')->getMock();
+		$comment = $this->getMockBuilder(IComment::class)->getMock();
 		$comment->expects($this->any())
 			->method('getObjectType')
 			->will($this->returnValue('files'));
@@ -185,7 +185,7 @@ class ListenerTest extends TestCase {
 			->willReturn([[ 'type' => 'user', 'id' => 'foobar']]);
 
 		/** @var CommentsEvent|\PHPUnit_Framework_MockObject_MockObject $event */
-		$event = $this->getMockBuilder('\OCP\Comments\CommentsEvent')
+		$event = $this->getMockBuilder(CommentsEvent::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$event->expects($this->once())
@@ -196,7 +196,7 @@ class ListenerTest extends TestCase {
 			->will($this->returnValue(CommentsEvent::EVENT_ADD));
 
 		/** @var INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
-		$notification = $this->getMockBuilder('\OCP\Notification\INotification')->getMock();
+		$notification = $this->getMockBuilder(INotification::class)->getMock();
 		$notification->expects($this->any())
 			->method($this->anything())
 			->will($this->returnValue($notification));

--- a/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
+++ b/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
@@ -66,7 +66,7 @@ abstract class AbstractCalDavBackend extends TestCase {
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->dispatcher = $this->createMock(EventDispatcherInterface::class);
-		$this->principal = $this->getMockBuilder('OCA\DAV\Connector\Sabre\Principal')
+		$this->principal = $this->getMockBuilder(Principal::class)
 			->disableOriginalConstructor()
 			->setMethods(['getPrincipalByPath', 'getGroupMembership'])
 			->getMock();

--- a/apps/dav/tests/unit/CalDAV/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarTest.php
@@ -38,7 +38,7 @@ class CalendarTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->l10n = $this->getMockBuilder('\OCP\IL10N')
+		$this->l10n = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()->getMock();
 		$this->l10n
 			->expects($this->any())

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
@@ -65,7 +65,7 @@ class PublicCalendarRootTest extends TestCase {
 
 		$this->publicCalendarRoot = new PublicCalendarRoot($this->backend);
 
-		$this->l10n = $this->getMockBuilder('\OCP\IL10N')
+		$this->l10n = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()->getMock();
 	}
 

--- a/apps/dav/tests/unit/CalDAV/Publishing/PublishingTest.php
+++ b/apps/dav/tests/unit/CalDAV/Publishing/PublishingTest.php
@@ -29,14 +29,14 @@ class PluginTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->config = $this->getMockBuilder('\OCP\IConfig')->
+		$this->config = $this->getMockBuilder(IConfig::class)->
 			disableOriginalConstructor()->
 			getMock();
 		$this->config->expects($this->any())->method('getSystemValue')
 			->with($this->equalTo('secret'))
 			->willReturn('mysecret');
 
-		$this->urlGenerator = $this->getMockBuilder('OCP\IURLGenerator')->
+		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)->
 			disableOriginalConstructor()->
 			getMock();
 
@@ -46,7 +46,7 @@ class PluginTest extends TestCase {
 		$root = new SimpleCollection('calendars');
 		$this->server = new Server($root);
 		/** @var SimpleCollection $node */
-		$this->book = $this->getMockBuilder('OCA\DAV\CalDAV\Calendar')->
+		$this->book = $this->getMockBuilder(Calendar::class)->
 			disableOriginalConstructor()->
 			getMock();
 		$this->book->method('getName')->willReturn('cal1');

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
@@ -38,11 +38,11 @@ class IMipPluginTest extends TestCase {
 	public function testDelivery() {
 		$mailMessage = new \OC\Mail\Message(new \Swift_Message());
 		/** @var Mailer | \PHPUnit_Framework_MockObject_MockObject $mailer */
-		$mailer = $this->getMockBuilder('OC\Mail\Mailer')->disableOriginalConstructor()->getMock();
+		$mailer = $this->getMockBuilder(Mailer::class)->disableOriginalConstructor()->getMock();
 		$mailer->method('createMessage')->willReturn($mailMessage);
 		$mailer->expects($this->once())->method('send');
 		/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject $logger */
-		$logger = $this->getMockBuilder('OC\Log')->disableOriginalConstructor()->getMock();
+		$logger = $this->getMockBuilder(ILogger::class)->disableOriginalConstructor()->getMock();
 		$timeFactory = $this->getMockBuilder(ITimeFactory::class)->disableOriginalConstructor()->getMock();
 		$timeFactory->method('getTime')->willReturn(1);
 
@@ -70,11 +70,11 @@ class IMipPluginTest extends TestCase {
 	public function testFailedDelivery() {
 		$mailMessage = new \OC\Mail\Message(new \Swift_Message());
 		/** @var Mailer | \PHPUnit_Framework_MockObject_MockObject $mailer */
-		$mailer = $this->getMockBuilder('OC\Mail\Mailer')->disableOriginalConstructor()->getMock();
+		$mailer = $this->getMockBuilder(Mailer::class)->disableOriginalConstructor()->getMock();
 		$mailer->method('createMessage')->willReturn($mailMessage);
 		$mailer->method('send')->willThrowException(new \Exception());
 		/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject $logger */
-		$logger = $this->getMockBuilder('OC\Log')->disableOriginalConstructor()->getMock();
+		$logger = $this->getMockBuilder(ILogger::class)->disableOriginalConstructor()->getMock();
 		$timeFactory = $this->getMockBuilder(ITimeFactory::class)->disableOriginalConstructor()->getMock();
 		$timeFactory->method('getTime')->willReturn(1);
 
@@ -105,7 +105,7 @@ class IMipPluginTest extends TestCase {
 	public function testNoMessageSendForPastEvents($veventParams, $expectsMail) {
 		$mailMessage = new \OC\Mail\Message(new \Swift_Message());
 		/** @var Mailer | \PHPUnit_Framework_MockObject_MockObject $mailer */
-		$mailer = $this->getMockBuilder('OC\Mail\Mailer')->disableOriginalConstructor()->getMock();
+		$mailer = $this->getMockBuilder(Mailer::class)->disableOriginalConstructor()->getMock();
 		$mailer->method('createMessage')->willReturn($mailMessage);
 		if ($expectsMail) {
 			$mailer->expects($this->once())->method('send');
@@ -113,7 +113,7 @@ class IMipPluginTest extends TestCase {
 			$mailer->expects($this->never())->method('send');
 		}
 		/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject $logger */
-		$logger = $this->getMockBuilder('OC\Log')->disableOriginalConstructor()->getMock();
+		$logger = $this->getMockBuilder(ILogger::class)->disableOriginalConstructor()->getMock();
 		$timeFactory = $this->getMockBuilder(ITimeFactory::class)->disableOriginalConstructor()->getMock();
 		$timeFactory->method('getTime')->willReturn(1496912528);
 

--- a/apps/dav/tests/unit/CardDAV/AddressBookTest.php
+++ b/apps/dav/tests/unit/CardDAV/AddressBookTest.php
@@ -33,7 +33,7 @@ class AddressBookTest extends TestCase {
 
 	public function testDelete() {
 		/** @var \PHPUnit_Framework_MockObject_MockObject | CardDavBackend $backend */
-		$backend = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')->disableOriginalConstructor()->getMock();
+		$backend = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->once())->method('updateShares');
 		$backend->expects($this->any())->method('getShares')->willReturn([
 			['href' => 'principal:user2']
@@ -55,7 +55,7 @@ class AddressBookTest extends TestCase {
 	 */
 	public function testDeleteFromGroup() {
 		/** @var \PHPUnit_Framework_MockObject_MockObject | CardDavBackend $backend */
-		$backend = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')->disableOriginalConstructor()->getMock();
+		$backend = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->never())->method('updateShares');
 		$backend->expects($this->any())->method('getShares')->willReturn([
 			['href' => 'principal:group2']
@@ -77,7 +77,7 @@ class AddressBookTest extends TestCase {
 	 */
 	public function testPropPatch() {
 		/** @var \PHPUnit_Framework_MockObject_MockObject | CardDavBackend $backend */
-		$backend = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')->disableOriginalConstructor()->getMock();
+		$backend = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();
 		$calendarInfo = [
 			'{http://owncloud.org/ns}owner-principal' => 'user1',
 			'{DAV:}displayname' => 'Test address book',
@@ -95,7 +95,7 @@ class AddressBookTest extends TestCase {
 	 */
 	public function testAcl($expectsWrite, $readOnlyValue, $hasOwnerSet) {
 		/** @var \PHPUnit_Framework_MockObject_MockObject | CardDavBackend $backend */
-		$backend = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')->disableOriginalConstructor()->getMock();
+		$backend = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->any())->method('applyShareAcl')->willReturnArgument(1);
 		$calendarInfo = [
 			'{DAV:}displayname' => 'Test address book',

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -85,7 +85,7 @@ class CardDavBackendTest extends TestCase {
 
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
-		$this->principal = $this->getMockBuilder('OCA\DAV\Connector\Sabre\Principal')
+		$this->principal = $this->getMockBuilder(Principal::class)
 			->disableOriginalConstructor()
 			->setMethods(['getPrincipalByPath', 'getGroupMembership'])
 			->getMock();

--- a/apps/dav/tests/unit/CardDAV/ContactsManagerTest.php
+++ b/apps/dav/tests/unit/CardDAV/ContactsManagerTest.php
@@ -28,16 +28,17 @@ use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\CardDAV\ContactsManager;
 use OCP\Contacts\IManager;
 use OCP\IL10N;
+use OCP\IURLGenerator;
 use Test\TestCase;
 
 class ContactsManagerTest extends TestCase {
 	public function test() {
 		/** @var IManager | \PHPUnit_Framework_MockObject_MockObject $cm */
-		$cm = $this->getMockBuilder('OCP\Contacts\IManager')->disableOriginalConstructor()->getMock();
+		$cm = $this->getMockBuilder(IManager::class)->disableOriginalConstructor()->getMock();
 		$cm->expects($this->exactly(2))->method('registerAddressBook');
-		$urlGenerator = $this->getMockBuilder('OCP\IUrlGenerator')->disableOriginalConstructor()->getMock();
+		$urlGenerator = $this->getMockBuilder(IURLGenerator::class)->disableOriginalConstructor()->getMock();
 		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $backEnd */
-		$backEnd = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')->disableOriginalConstructor()->getMock();
+		$backEnd = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backEnd->method('getAddressBooksForUser')->willReturn([
 				['{DAV:}displayname' => 'Test address book', 'uri' => 'default'],
 			]);

--- a/apps/dav/tests/unit/CardDAV/ConverterTest.php
+++ b/apps/dav/tests/unit/CardDAV/ConverterTest.php
@@ -49,12 +49,12 @@ class ConverterTest extends  TestCase {
 		$this->databaseConnection = $this->getMockBuilder('OCP\IDBConnection')->getMock();
 		$this->eventDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
 			->disableOriginalConstructor()->getMock();
-		$this->accountManager = $this->getMockBuilder('OC\Accounts\AccountManager')
+		$this->accountManager = $this->getMockBuilder(AccountManager::class)
 			->disableOriginalConstructor()->getMock();
 	}
 
 	public function getAccountManager(IUser $user) {
-		$accountManager = $this->getMockBuilder('OC\Accounts\AccountManager')
+		$accountManager = $this->getMockBuilder(AccountManager::class)
 			->disableOriginalConstructor()->getMock();
 		$accountManager->expects($this->any())->method('getUser')->willReturn(
 			[

--- a/apps/dav/tests/unit/CardDAV/Sharing/PluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/Sharing/PluginTest.php
@@ -51,7 +51,7 @@ class PluginTest extends TestCase {
 		$authBackend->method('isDavAuthenticated')->willReturn(true);
 
 		/** @var IRequest $request */
-		$request = $this->getMockBuilder('OCP\IRequest')->disableOriginalConstructor()->getMock();
+		$request = $this->getMockBuilder(IRequest::class)->disableOriginalConstructor()->getMock();
 		$this->plugin = new Plugin($authBackend, $request);
 
 		$root = new SimpleCollection('root');

--- a/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
@@ -28,6 +28,7 @@ namespace OCA\DAV\Tests\unit\CardDAV;
 use OC\Accounts\AccountManager;
 use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\CardDAV\SyncService;
+use OCP\ILogger;
 use OCP\IUser;
 use OCP\IUserManager;
 use Test\TestCase;
@@ -75,9 +76,9 @@ class SyncServiceTest extends TestCase {
 		$backend->expects($this->at(1))->method('getAddressBooksByUri')->willReturn([]);
 
 		/** @var IUserManager $userManager */
-		$userManager = $this->getMockBuilder('OCP\IUserManager')->disableOriginalConstructor()->getMock();
-		$logger = $this->getMockBuilder('OCP\ILogger')->disableOriginalConstructor()->getMock();
-		$accountManager = $this->getMockBuilder('OC\Accounts\AccountManager')->disableOriginalConstructor()->getMock();
+		$userManager = $this->getMockBuilder(IUserManager::class)->disableOriginalConstructor()->getMock();
+		$logger = $this->getMockBuilder(ILogger::class)->disableOriginalConstructor()->getMock();
+		$accountManager = $this->getMockBuilder(AccountManager::class)->disableOriginalConstructor()->getMock();
 		$ss = new SyncService($backend, $userManager, $logger, $accountManager);
 		$book = $ss->ensureSystemAddressBookExists('principals/users/adam', 'contacts', []);
 	}
@@ -85,7 +86,7 @@ class SyncServiceTest extends TestCase {
 	public function testUpdateAndDeleteUser() {
 		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $backend */
 		$backend = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();
-		$logger = $this->getMockBuilder('OCP\ILogger')->disableOriginalConstructor()->getMock();
+		$logger = $this->getMockBuilder(ILogger::class)->disableOriginalConstructor()->getMock();
 
 		$backend->expects($this->once())->method('createCard');
 		$backend->expects($this->once())->method('updateCard');
@@ -96,15 +97,15 @@ class SyncServiceTest extends TestCase {
 		]);
 
 		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
-		$userManager = $this->getMockBuilder('OCP\IUserManager')->disableOriginalConstructor()->getMock();
+		$userManager = $this->getMockBuilder(IUserManager::class)->disableOriginalConstructor()->getMock();
 
 		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
-		$user = $this->getMockBuilder('OCP\IUser')->disableOriginalConstructor()->getMock();
+		$user = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$user->method('getBackendClassName')->willReturn('unittest');
 		$user->method('getUID')->willReturn('test-user');
 		$user->method('getCloudId')->willReturn('cloudId');
 		$user->method('getDisplayName')->willReturn('test-user');
-		$accountManager = $this->getMockBuilder('OC\Accounts\AccountManager')->disableOriginalConstructor()->getMock();
+		$accountManager = $this->getMockBuilder(AccountManager::class)->disableOriginalConstructor()->getMock();
 		$accountManager->expects($this->any())->method('getUser')
 			->willReturn([
 					AccountManager::PROPERTY_DISPLAYNAME =>
@@ -174,9 +175,9 @@ class SyncServiceTest extends TestCase {
 	 * @return SyncService|\PHPUnit_Framework_MockObject_MockObject
 	 */
 	private function getSyncServiceMock($backend, $response) {
-		$userManager = $this->getMockBuilder('OCP\IUserManager')->disableOriginalConstructor()->getMock();
-		$logger = $this->getMockBuilder('OCP\ILogger')->disableOriginalConstructor()->getMock();
-		$accountManager = $this->getMockBuilder('OC\Accounts\AccountManager')->disableOriginalConstructor()->getMock();
+		$userManager = $this->getMockBuilder(IUserManager::class)->disableOriginalConstructor()->getMock();
+		$logger = $this->getMockBuilder(ILogger::class)->disableOriginalConstructor()->getMock();
+		$accountManager = $this->getMockBuilder(AccountManager::class)->disableOriginalConstructor()->getMock();
 		/** @var SyncService | \PHPUnit_Framework_MockObject_MockObject $ss */
 		$ss = $this->getMockBuilder(SyncService::class)
 			->setMethods(['ensureSystemAddressBookExists', 'requestSyncReport', 'download', 'getCertPath'])

--- a/apps/dav/tests/unit/Comments/CommentsNodeTest.php
+++ b/apps/dav/tests/unit/Comments/CommentsNodeTest.php
@@ -26,8 +26,13 @@
 namespace OCA\DAV\Tests\unit\Comments;
 
 use OCA\DAV\Comments\CommentNode;
+use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
 use OCP\Comments\MessageTooLongException;
+use OCP\ILogger;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
 
 class CommentsNodeTest extends \Test\TestCase {
 
@@ -43,19 +48,19 @@ class CommentsNodeTest extends \Test\TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->commentsManager = $this->getMockBuilder('\OCP\Comments\ICommentsManager')
+		$this->commentsManager = $this->getMockBuilder(ICommentsManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->comment = $this->getMockBuilder('\OCP\Comments\IComment')
+		$this->comment = $this->getMockBuilder(IComment::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->userManager = $this->getMockBuilder('\OCP\IUserManager')
+		$this->userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->userSession = $this->getMockBuilder('\OCP\IUserSession')
+		$this->userSession = $this->getMockBuilder(IUserSession::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->logger = $this->getMockBuilder('\OCP\ILogger')
+		$this->logger = $this->getMockBuilder(ILogger::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -69,7 +74,7 @@ class CommentsNodeTest extends \Test\TestCase {
 	}
 
 	public function testDelete() {
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -104,7 +109,7 @@ class CommentsNodeTest extends \Test\TestCase {
 	 * @expectedException \Sabre\DAV\Exception\Forbidden
 	 */
 	public function testDeleteForbidden() {
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -156,7 +161,7 @@ class CommentsNodeTest extends \Test\TestCase {
 	public function testUpdateComment() {
 		$msg = 'Hello Earth';
 
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -188,13 +193,13 @@ class CommentsNodeTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException Exception
+	 * @expectedException \Exception
 	 * @expectedExceptionMessage buh!
 	 */
 	public function testUpdateCommentLogException() {
 		$msg = null;
 
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -233,7 +238,7 @@ class CommentsNodeTest extends \Test\TestCase {
 	 * @expectedExceptionMessage Message exceeds allowed character limit of
 	 */
 	public function testUpdateCommentMessageTooLongException() {
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -273,7 +278,7 @@ class CommentsNodeTest extends \Test\TestCase {
 	public function testUpdateForbiddenByUser() {
 		$msg = 'HaXX0r';
 
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -308,7 +313,7 @@ class CommentsNodeTest extends \Test\TestCase {
 	public function testUpdateForbiddenByType() {
 		$msg = 'HaXX0r';
 
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -461,7 +466,7 @@ class CommentsNodeTest extends \Test\TestCase {
 			->method('getObjectId')
 			->will($this->returnValue($expected[$ns . 'objectId']));
 
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->once())
@@ -515,7 +520,7 @@ class CommentsNodeTest extends \Test\TestCase {
 		$this->userSession->expects($this->once())
 			->method('getUser')
 			->will($this->returnValue(
-				$this->getMockBuilder('\OCP\IUser')
+				$this->getMockBuilder(IUser::class)
 					->disableOriginalConstructor()
 					->getMock()
 			));

--- a/apps/dav/tests/unit/Comments/CommentsPluginTest.php
+++ b/apps/dav/tests/unit/Comments/CommentsPluginTest.php
@@ -27,19 +27,27 @@ namespace OCA\DAV\Tests\unit\Comments;
 
 use OC\Comments\Comment;
 use OCA\DAV\Comments\CommentsPlugin as CommentsPluginImplementation;
+use OCA\DAV\Comments\EntityCollection;
 use OCP\Comments\IComment;
+use OCP\Comments\ICommentsManager;
+use OCP\IUser;
+use OCP\IUserSession;
+use Sabre\DAV\INode;
+use Sabre\DAV\Tree;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
 
 class CommentsPluginTest extends \Test\TestCase {
 	/** @var \Sabre\DAV\Server */
 	private $server;
 
-	/** @var \Sabre\DAV\Tree */
+	/** @var Tree */
 	private $tree;
 
-	/** @var \OCP\Comments\ICommentsManager */
+	/** @var ICommentsManager */
 	private $commentsManager;
 
-	/** @var  \OCP\IUserSession */
+	/** @var  IUserSession */
 	private $userSession;
 
 	/** @var CommentsPluginImplementation */
@@ -47,7 +55,7 @@ class CommentsPluginTest extends \Test\TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->tree = $this->getMockBuilder('\Sabre\DAV\Tree')
+		$this->tree = $this->getMockBuilder(Tree::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -56,10 +64,10 @@ class CommentsPluginTest extends \Test\TestCase {
 			->setMethods(['getRequestUri'])
 			->getMock();
 
-		$this->commentsManager = $this->getMockBuilder('\OCP\Comments\ICommentsManager')
+		$this->commentsManager = $this->getMockBuilder(ICommentsManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->userSession = $this->getMockBuilder('\OCP\IUserSession')
+		$this->userSession = $this->getMockBuilder(IUserSession::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -85,14 +93,14 @@ class CommentsPluginTest extends \Test\TestCase {
 
 		$requestData = json_encode($commentData);
 
-		$user = $this->getMockBuilder('OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->once())
 			->method('getUID')
 			->will($this->returnValue('alice'));
 
-		$node = $this->getMockBuilder('\OCA\DAV\Comments\EntityCollection')
+		$node = $this->getMockBuilder(EntityCollection::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->once())
@@ -124,11 +132,11 @@ class CommentsPluginTest extends \Test\TestCase {
 			->with('/' . $path)
 			->will($this->returnValue($node));
 
-		$request = $this->getMockBuilder('Sabre\HTTP\RequestInterface')
+		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$response = $this->getMockBuilder('Sabre\HTTP\ResponseInterface')
+		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -181,13 +189,13 @@ class CommentsPluginTest extends \Test\TestCase {
 
 		$path = 'comments/files/666';
 
-		$user = $this->getMockBuilder('OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->never())
 			->method('getUID');
 
-		$node = $this->getMockBuilder('\OCA\DAV\Comments\EntityCollection')
+		$node = $this->getMockBuilder(EntityCollection::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->never())
@@ -210,11 +218,11 @@ class CommentsPluginTest extends \Test\TestCase {
 			->with('/' . $path)
 			->will($this->throwException(new \Sabre\DAV\Exception\NotFound()));
 
-		$request = $this->getMockBuilder('Sabre\HTTP\RequestInterface')
+		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$response = $this->getMockBuilder('Sabre\HTTP\ResponseInterface')
+		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -265,13 +273,13 @@ class CommentsPluginTest extends \Test\TestCase {
 
 		$requestData = json_encode($commentData);
 
-		$user = $this->getMockBuilder('OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->never())
 			->method('getUID');
 
-		$node = $this->getMockBuilder('\OCA\DAV\Comments\EntityCollection')
+		$node = $this->getMockBuilder(EntityCollection::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->once())
@@ -296,11 +304,11 @@ class CommentsPluginTest extends \Test\TestCase {
 			->with('/' . $path)
 			->will($this->returnValue($node));
 
-		$request = $this->getMockBuilder('Sabre\HTTP\RequestInterface')
+		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$response = $this->getMockBuilder('Sabre\HTTP\ResponseInterface')
+		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -353,13 +361,13 @@ class CommentsPluginTest extends \Test\TestCase {
 
 		$requestData = json_encode($commentData);
 
-		$user = $this->getMockBuilder('OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->never())
 			->method('getUID');
 
-		$node = $this->getMockBuilder('\OCA\DAV\Comments\EntityCollection')
+		$node = $this->getMockBuilder(EntityCollection::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->once())
@@ -384,11 +392,11 @@ class CommentsPluginTest extends \Test\TestCase {
 			->with('/' . $path)
 			->will($this->returnValue($node));
 
-		$request = $this->getMockBuilder('Sabre\HTTP\RequestInterface')
+		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$response = $this->getMockBuilder('Sabre\HTTP\ResponseInterface')
+		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -443,14 +451,14 @@ class CommentsPluginTest extends \Test\TestCase {
 
 		$requestData = json_encode($commentData);
 
-		$user = $this->getMockBuilder('OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->once())
 			->method('getUID')
 			->will($this->returnValue('alice'));
 
-		$node = $this->getMockBuilder('\OCA\DAV\Comments\EntityCollection')
+		$node = $this->getMockBuilder(EntityCollection::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->once())
@@ -478,11 +486,11 @@ class CommentsPluginTest extends \Test\TestCase {
 			->with('/' . $path)
 			->will($this->returnValue($node));
 
-		$request = $this->getMockBuilder('Sabre\HTTP\RequestInterface')
+		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$response = $this->getMockBuilder('Sabre\HTTP\ResponseInterface')
+		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -537,14 +545,14 @@ class CommentsPluginTest extends \Test\TestCase {
 
 		$requestData = json_encode($commentData);
 
-		$user = $this->getMockBuilder('OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->once())
 			->method('getUID')
 			->will($this->returnValue('alice'));
 
-		$node = $this->getMockBuilder('\OCA\DAV\Comments\EntityCollection')
+		$node = $this->getMockBuilder(EntityCollection::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->once())
@@ -575,11 +583,11 @@ class CommentsPluginTest extends \Test\TestCase {
 			->with('/' . $path)
 			->will($this->returnValue($node));
 
-		$request = $this->getMockBuilder('Sabre\HTTP\RequestInterface')
+		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$response = $this->getMockBuilder('Sabre\HTTP\ResponseInterface')
+		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -617,7 +625,7 @@ class CommentsPluginTest extends \Test\TestCase {
 			->method('getNodeForPath')
 			->with('/' . $path)
 			->will($this->returnValue(
-				$this->getMockBuilder('\Sabre\DAV\INode')
+				$this->getMockBuilder(INode::class)
 					->disableOriginalConstructor()
 					->getMock()
 			));
@@ -640,7 +648,7 @@ class CommentsPluginTest extends \Test\TestCase {
 			->method('getNodeForPath')
 			->with('/' . $path)
 			->will($this->returnValue(
-				$this->getMockBuilder('\Sabre\DAV\INode')
+				$this->getMockBuilder(INode::class)
 					->disableOriginalConstructor()
 					->getMock()
 			));
@@ -671,7 +679,7 @@ class CommentsPluginTest extends \Test\TestCase {
 			]
 		];
 
-		$node = $this->getMockBuilder('\OCA\DAV\Comments\EntityCollection')
+		$node = $this->getMockBuilder(EntityCollection::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->once())
@@ -679,7 +687,7 @@ class CommentsPluginTest extends \Test\TestCase {
 			->with(5, 10, null)
 			->will($this->returnValue([]));
 
-		$response = $this->getMockBuilder('Sabre\HTTP\ResponseInterface')
+		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -726,7 +734,7 @@ class CommentsPluginTest extends \Test\TestCase {
 			]
 		];
 
-		$node = $this->getMockBuilder('\OCA\DAV\Comments\EntityCollection')
+		$node = $this->getMockBuilder(EntityCollection::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->once())
@@ -734,7 +742,7 @@ class CommentsPluginTest extends \Test\TestCase {
 			->with(5, 10, new \DateTime($parameters[2]['value']))
 			->will($this->returnValue([]));
 
-		$response = $this->getMockBuilder('Sabre\HTTP\ResponseInterface')
+		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/apps/dav/tests/unit/Comments/EntityCollectionTest.php
+++ b/apps/dav/tests/unit/Comments/EntityCollectionTest.php
@@ -24,32 +24,39 @@
 
 namespace OCA\DAV\Tests\unit\Comments;
 
+use OCA\DAV\Comments\EntityCollection;
+use OCP\Comments\IComment;
+use OCP\Comments\ICommentsManager;
+use OCP\ILogger;
+use OCP\IUserManager;
+use OCP\IUserSession;
+
 class EntityCollectionTest extends \Test\TestCase {
 
 	/** @var \OCP\Comments\ICommentsManager|\PHPUnit_Framework_MockObject_MockObject */
 	protected $commentsManager;
-	/** @var \OCP\IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager|\PHPUnit_Framework_MockObject_MockObject */
 	protected $userManager;
-	/** @var \OCP\ILogger|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger|\PHPUnit_Framework_MockObject_MockObject */
 	protected $logger;
-	/** @var \OCA\DAV\Comments\EntityCollection */
+	/** @var EntityCollection */
 	protected $collection;
-	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserSession|\PHPUnit_Framework_MockObject_MockObject */
 	protected $userSession;
 
 	public function setUp() {
 		parent::setUp();
 
-		$this->commentsManager = $this->getMockBuilder('\OCP\Comments\ICommentsManager')
+		$this->commentsManager = $this->getMockBuilder(ICommentsManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->userManager = $this->getMockBuilder('\OCP\IUserManager')
+		$this->userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->userSession = $this->getMockBuilder('\OCP\IUserSession')
+		$this->userSession = $this->getMockBuilder(IUserSession::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->logger = $this->getMockBuilder('\OCP\ILogger')
+		$this->logger = $this->getMockBuilder(ILogger::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -72,7 +79,7 @@ class EntityCollectionTest extends \Test\TestCase {
 			->method('get')
 			->with('55')
 			->will($this->returnValue(
-				$this->getMockBuilder('\OCP\Comments\IComment')
+				$this->getMockBuilder(IComment::class)
 					->disableOriginalConstructor()
 					->getMock()
 			));
@@ -98,7 +105,7 @@ class EntityCollectionTest extends \Test\TestCase {
 			->method('getForObject')
 			->with('files', '19')
 			->will($this->returnValue([
-				$this->getMockBuilder('\OCP\Comments\IComment')
+				$this->getMockBuilder(IComment::class)
 					->disableOriginalConstructor()
 					->getMock()
 			]));
@@ -115,7 +122,7 @@ class EntityCollectionTest extends \Test\TestCase {
 			->method('getForObject')
 			->with('files', '19', 5, 15, $dt)
 			->will($this->returnValue([
-				$this->getMockBuilder('\OCP\Comments\IComment')
+				$this->getMockBuilder(IComment::class)
 					->disableOriginalConstructor()
 					->getMock()
 			]));

--- a/apps/dav/tests/unit/Comments/EntityTypeCollectionTest.php
+++ b/apps/dav/tests/unit/Comments/EntityTypeCollectionTest.php
@@ -25,10 +25,14 @@
 namespace OCA\DAV\Tests\unit\Comments;
 
 use OCA\DAV\Comments\EntityCollection as EntityCollectionImplemantation;
+use OCP\Comments\ICommentsManager;
+use OCP\ILogger;
+use OCP\IUserManager;
+use OCP\IUserSession;
 
 class EntityTypeCollectionTest extends \Test\TestCase {
 
-	/** @var \OCP\Comments\ICommentsManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var ICommentsManager|\PHPUnit_Framework_MockObject_MockObject */
 	protected $commentsManager;
 	/** @var \OCP\IUserManager|\PHPUnit_Framework_MockObject_MockObject */
 	protected $userManager;
@@ -36,7 +40,7 @@ class EntityTypeCollectionTest extends \Test\TestCase {
 	protected $logger;
 	/** @var \OCA\DAV\Comments\EntityTypeCollection */
 	protected $collection;
-	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserSession|\PHPUnit_Framework_MockObject_MockObject */
 	protected $userSession;
 
 	protected $childMap = [];
@@ -44,16 +48,16 @@ class EntityTypeCollectionTest extends \Test\TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->commentsManager = $this->getMockBuilder('\OCP\Comments\ICommentsManager')
+		$this->commentsManager = $this->getMockBuilder(ICommentsManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->userManager = $this->getMockBuilder('\OCP\IUserManager')
+		$this->userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->userSession = $this->getMockBuilder('\OCP\IUserSession')
+		$this->userSession = $this->getMockBuilder(IUserSession::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->logger = $this->getMockBuilder('\OCP\ILogger')
+		$this->logger = $this->getMockBuilder(ILogger::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/apps/dav/tests/unit/Comments/RootCollectionTest.php
+++ b/apps/dav/tests/unit/Comments/RootCollectionTest.php
@@ -26,6 +26,11 @@ namespace OCA\DAV\Tests\unit\Comments;
 
 use OCA\DAV\Comments\EntityTypeCollection as EntityTypeCollectionImplementation;
 use OCP\Comments\CommentsEntityEvent;
+use OCP\Comments\ICommentsManager;
+use OCP\ILogger;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class RootCollectionTest extends \Test\TestCase {
@@ -48,21 +53,21 @@ class RootCollectionTest extends \Test\TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->user = $this->getMockBuilder('\OCP\IUser')
+		$this->user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->commentsManager = $this->getMockBuilder('\OCP\Comments\ICommentsManager')
+		$this->commentsManager = $this->getMockBuilder(ICommentsManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->userManager = $this->getMockBuilder('\OCP\IUserManager')
+		$this->userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->userSession = $this->getMockBuilder('\OCP\IUserSession')
+		$this->userSession = $this->getMockBuilder(IUserSession::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->dispatcher = new EventDispatcher();
-		$this->logger = $this->getMockBuilder('\OCP\ILogger')
+		$this->logger = $this->getMockBuilder(ILogger::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/apps/dav/tests/unit/Connector/PublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/PublicAuthTest.php
@@ -53,13 +53,13 @@ class PublicAuthTest extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->session = $this->getMockBuilder('\OCP\ISession')
+		$this->session = $this->getMockBuilder(ISession::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->request = $this->getMockBuilder('\OCP\IRequest')
+		$this->request = $this->getMockBuilder(IRequest::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->shareManager = $this->getMockBuilder('\OCP\Share\IManager')
+		$this->shareManager = $this->getMockBuilder(IManager::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
@@ -34,6 +34,7 @@ use OC\User\Session;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUser;
+use Sabre\DAV\Server;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 use Test\TestCase;
@@ -60,16 +61,16 @@ class AuthTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->session = $this->getMockBuilder('\OCP\ISession')
+		$this->session = $this->getMockBuilder(ISession::class)
 			->disableOriginalConstructor()->getMock();
-		$this->userSession = $this->getMockBuilder('\OC\User\Session')
+		$this->userSession = $this->getMockBuilder(Session::class)
 			->disableOriginalConstructor()->getMock();
-		$this->request = $this->getMockBuilder('\OCP\IRequest')
+		$this->request = $this->getMockBuilder(IRequest::class)
 			->disableOriginalConstructor()->getMock();
-		$this->twoFactorManager = $this->getMockBuilder('\OC\Authentication\TwoFactorAuth\Manager')
+		$this->twoFactorManager = $this->getMockBuilder(Manager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->throttler = $this->getMockBuilder('\OC\Security\Bruteforce\Throttler')
+		$this->throttler = $this->getMockBuilder(Throttler::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->auth = new \OCA\DAV\Connector\Sabre\Auth(
@@ -112,7 +113,7 @@ class AuthTest extends TestCase {
 	}
 
 	public function testValidateUserPassOfAlreadyDAVAuthenticatedUser() {
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->exactly(2))
@@ -139,7 +140,7 @@ class AuthTest extends TestCase {
 	}
 
 	public function testValidateUserPassOfInvalidDAVAuthenticatedUser() {
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->once())
@@ -166,7 +167,7 @@ class AuthTest extends TestCase {
 	}
 
 	public function testValidateUserPassOfInvalidDAVAuthenticatedUserWithValidPassword() {
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->exactly(3))
@@ -258,7 +259,7 @@ class AuthTest extends TestCase {
 			->method('get')
 			->with('AUTHENTICATED_TO_DAV_BACKEND')
 			->will($this->returnValue(null));
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->any())
@@ -310,7 +311,7 @@ class AuthTest extends TestCase {
 			->method('get')
 			->with('AUTHENTICATED_TO_DAV_BACKEND')
 			->will($this->returnValue('LoggedInUser'));
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->any())
@@ -360,7 +361,7 @@ class AuthTest extends TestCase {
 			->method('get')
 			->with('AUTHENTICATED_TO_DAV_BACKEND')
 			->will($this->returnValue('LoggedInUser'));
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->any())
@@ -414,7 +415,7 @@ class AuthTest extends TestCase {
 			->method('get')
 			->with('AUTHENTICATED_TO_DAV_BACKEND')
 			->will($this->returnValue('AnotherUser'));
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->any())
@@ -460,7 +461,7 @@ class AuthTest extends TestCase {
 			->method('get')
 			->with('AUTHENTICATED_TO_DAV_BACKEND')
 			->will($this->returnValue(null));
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->any())
@@ -494,7 +495,7 @@ class AuthTest extends TestCase {
 			->method('get')
 			->with('AUTHENTICATED_TO_DAV_BACKEND')
 			->will($this->returnValue(null));
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->any())
@@ -529,7 +530,7 @@ class AuthTest extends TestCase {
 			->method('get')
 			->with('AUTHENTICATED_TO_DAV_BACKEND')
 			->will($this->returnValue(null));
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->any())
@@ -549,7 +550,7 @@ class AuthTest extends TestCase {
 	}
 
 	public function testAuthenticateNoBasicAuthenticateHeadersProvided() {
-		$server = $this->getMockBuilder('\Sabre\DAV\Server')
+		$server = $this->getMockBuilder(Server::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$server->httpRequest = $this->getMockBuilder(RequestInterface::class)
@@ -597,7 +598,7 @@ class AuthTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		/** @var IUser */
-		$user = $this->getMockBuilder('OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->method('getUID')->willReturn('MyTestUser');
@@ -630,7 +631,7 @@ class AuthTest extends TestCase {
 	}
 
 	public function testAuthenticateValidCredentials() {
-		$server = $this->getMockBuilder('\Sabre\DAV\Server')
+		$server = $this->getMockBuilder(Server::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$server->httpRequest = $this->getMockBuilder(RequestInterface::class)
@@ -654,7 +655,7 @@ class AuthTest extends TestCase {
 			->method('logClientIn')
 			->with('username', 'password')
 			->will($this->returnValue(true));
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->exactly(3))
@@ -669,7 +670,7 @@ class AuthTest extends TestCase {
 	}
 
 	public function testAuthenticateInvalidCredentials() {
-		$server = $this->getMockBuilder('\Sabre\DAV\Server')
+		$server = $this->getMockBuilder(Server::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$server->httpRequest = $this->getMockBuilder(RequestInterface::class)

--- a/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
@@ -44,7 +44,7 @@ class BlockLegacyClientPluginTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->config = $this->getMockBuilder('\OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->blockLegacyClientVersionPlugin = new BlockLegacyClientPlugin($this->config);

--- a/apps/dav/tests/unit/Connector/Sabre/CommentsPropertiesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CommentsPropertiesPluginTest.php
@@ -25,6 +25,10 @@
 namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
 use \OCA\DAV\Connector\Sabre\CommentPropertiesPlugin as CommentPropertiesPluginImplementation;
+use OCA\DAV\Connector\Sabre\File;
+use OCP\Comments\ICommentsManager;
+use OCP\IUser;
+use OCP\IUserSession;
 
 class CommentsPropertiesPluginTest extends \Test\TestCase {
 
@@ -37,10 +41,10 @@ class CommentsPropertiesPluginTest extends \Test\TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->commentsManager = $this->getMockBuilder('\OCP\Comments\ICommentsManager')
+		$this->commentsManager = $this->getMockBuilder(ICommentsManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->userSession = $this->getMockBuilder('\OCP\IUserSession')
+		$this->userSession = $this->getMockBuilder(IUserSession::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -103,7 +107,7 @@ class CommentsPropertiesPluginTest extends \Test\TestCase {
 	 * @param $expectedHref
 	 */
 	public function testGetCommentsLink($baseUri, $fid, $expectedHref) {
-		$node = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\File')
+		$node = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->any())
@@ -121,7 +125,7 @@ class CommentsPropertiesPluginTest extends \Test\TestCase {
 	public function userProvider() {
 		return [
 			[
-				$this->getMockBuilder('\OCP\IUser')
+				$this->getMockBuilder(IUser::class)
 					->disableOriginalConstructor()
 					->getMock()
 			],
@@ -134,7 +138,7 @@ class CommentsPropertiesPluginTest extends \Test\TestCase {
 	 * @param $user
 	 */
 	public function testGetUnreadCount($user) {
-		$node = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\File')
+		$node = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->any())

--- a/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
@@ -31,6 +31,10 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre;
  * See the COPYING-README file.
  */
 
+use OCP\IUser;
+use Sabre\DAV\File;
+use Sabre\DAV\Tree;
+
 /**
  * Class CustomPropertiesBackend
  *
@@ -63,13 +67,13 @@ class CustomPropertiesBackendTest extends \Test\TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->server = new \Sabre\DAV\Server();
-		$this->tree = $this->getMockBuilder('\Sabre\DAV\Tree')
+		$this->tree = $this->getMockBuilder(Tree::class)
 			->disableOriginalConstructor()
 			->getMock();
 
 		$userId = $this->getUniqueID('testcustompropertiesuser');
 
-		$this->user = $this->getMockBuilder('\OCP\IUser')
+		$this->user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->user->expects($this->any())
@@ -209,7 +213,7 @@ class CustomPropertiesBackendTest extends \Test\TestCase {
 	public function testGetPropertiesForDirectory() {
 		$rootNode = $this->createTestNode('\OCA\DAV\Connector\Sabre\Directory');
 
-		$nodeSub = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\File')
+		$nodeSub = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$nodeSub->expects($this->any())

--- a/apps/dav/tests/unit/Connector/Sabre/DummyGetResponsePluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DummyGetResponsePluginTest.php
@@ -26,6 +26,7 @@
 namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
 use OCA\DAV\Connector\Sabre\DummyGetResponsePlugin;
+use Sabre\DAV\Server;
 use Test\TestCase;
 
 /**
@@ -44,8 +45,8 @@ class DummyGetResponsePluginTest extends TestCase {
 	}
 
 	public function testInitialize() {
-		/** @var \Sabre\DAV\Server $server */
-		$server = $this->getMockBuilder('\Sabre\DAV\Server')
+		/** @var Server $server */
+		$server = $this->getMockBuilder(Server::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$server

--- a/apps/dav/tests/unit/Connector/Sabre/FakeLockerPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FakeLockerPluginTest.php
@@ -25,6 +25,8 @@
 namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
 use OCA\DAV\Connector\Sabre\FakeLockerPlugin;
+use Sabre\DAV\INode;
+use Sabre\DAV\Server;
 use Sabre\HTTP\Response;
 use Test\TestCase;
 
@@ -43,8 +45,8 @@ class FakeLockerPluginTest extends TestCase {
 	}
 
 	public function testInitialize() {
-		/** @var \Sabre\DAV\Server $server */
-		$server = $this->getMockBuilder('\Sabre\DAV\Server')
+		/** @var Server $server */
+		$server = $this->getMockBuilder(Server::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$server
@@ -86,7 +88,7 @@ class FakeLockerPluginTest extends TestCase {
 		$propFind = $this->getMockBuilder('\Sabre\DAV\PropFind')
 			->disableOriginalConstructor()
 			->getMock();
-		$node = $this->getMockBuilder('\Sabre\DAV\INode')
+		$node = $this->getMockBuilder(INode::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -155,7 +157,7 @@ class FakeLockerPluginTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$response = new Response();
-		$server = $this->getMockBuilder('\Sabre\DAV\Server')
+		$server = $this->getMockBuilder(Server::class)
 			->getMock();
 		$this->fakeLockerPlugin->initialize($server);
 

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -27,7 +27,9 @@
 namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
 use OC\Files\Storage\Local;
+use OC\Files\View;
 use OCP\Files\ForbiddenException;
+use OCP\Files\Storage;
 use Test\HookHelper;
 use OC\Files\Filesystem;
 use OCP\Lock\ILockingProvider;
@@ -70,7 +72,7 @@ class FileTest extends \Test\TestCase {
 	}
 
 	private function getMockStorage() {
-		$storage = $this->getMockBuilder('\OCP\Files\Storage')
+		$storage = $this->getMockBuilder(Storage::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$storage->expects($this->any())
@@ -151,12 +153,12 @@ class FileTest extends \Test\TestCase {
 	 */
 	public function testSimplePutFails($thrownException, $expectedException, $checkPreviousClass = true) {
 		// setup
-		$storage = $this->getMockBuilder('\OC\Files\Storage\Local')
+		$storage = $this->getMockBuilder(Local::class)
 			->setMethods(['fopen'])
 			->setConstructorArgs([['datadir' => \OC::$server->getTempManager()->getTemporaryFolder()]])
 			->getMock();
 		\OC\Files\Filesystem::mount($storage, [], $this->user . '/');
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->setMethods(['getRelativePath', 'resolvePath'])
 			->getMock();
 		$view->expects($this->atLeastOnce())
@@ -210,12 +212,12 @@ class FileTest extends \Test\TestCase {
 	 */
 	public function testChunkedPutFails($thrownException, $expectedException, $checkPreviousClass = false) {
 		// setup
-		$storage = $this->getMockBuilder('\OC\Files\Storage\Local')
+		$storage = $this->getMockBuilder(Local::class)
 			->setMethods(['fopen'])
 			->setConstructorArgs([['datadir' => \OC::$server->getTempManager()->getTemporaryFolder()]])
 			->getMock();
 		\OC\Files\Filesystem::mount($storage, [], $this->user . '/');
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->setMethods(['getRelativePath', 'resolvePath'])
 			->getMock();
 		$view->expects($this->atLeastOnce())
@@ -535,7 +537,7 @@ class FileTest extends \Test\TestCase {
 	 */
 	public function testSimplePutFailsSizeCheck() {
 		// setup
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->setMethods(['rename', 'getRelativePath', 'filesize'])
 			->getMock();
 		$view->expects($this->any())
@@ -653,7 +655,7 @@ class FileTest extends \Test\TestCase {
 	 */
 	public function testSimplePutInvalidChars() {
 		// setup
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->setMethods(['getRelativePath'])
 			->getMock();
 		$view->expects($this->any())
@@ -690,7 +692,7 @@ class FileTest extends \Test\TestCase {
 	 */
 	public function testSetNameInvalidChars() {
 		// setup
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->setMethods(['getRelativePath'])
 			->getMock();
 
@@ -709,7 +711,7 @@ class FileTest extends \Test\TestCase {
 	 */
 	public function testUploadAbort() {
 		// setup
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->setMethods(['rename', 'getRelativePath', 'filesize'])
 			->getMock();
 		$view->expects($this->any())
@@ -755,7 +757,7 @@ class FileTest extends \Test\TestCase {
 	 */
 	public function testDeleteWhenAllowed() {
 		// setup
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->getMock();
 
 		$view->expects($this->once())
@@ -777,7 +779,7 @@ class FileTest extends \Test\TestCase {
 	 */
 	public function testDeleteThrowsWhenDeletionNotAllowed() {
 		// setup
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->getMock();
 
 		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, array(
@@ -795,7 +797,7 @@ class FileTest extends \Test\TestCase {
 	 */
 	public function testDeleteThrowsWhenDeletionFailed() {
 		// setup
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->getMock();
 
 		// but fails
@@ -818,7 +820,7 @@ class FileTest extends \Test\TestCase {
 	 */
 	public function testDeleteThrowsWhenDeletionThrows() {
 		// setup
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->getMock();
 
 		// but fails
@@ -968,7 +970,7 @@ class FileTest extends \Test\TestCase {
 	 * @expectedException \Sabre\DAV\Exception\ServiceUnavailable
 	 */
 	public function testGetFopenFails() {
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->setMethods(['fopen'])
 			->getMock();
 		$view->expects($this->atLeastOnce())
@@ -988,7 +990,7 @@ class FileTest extends \Test\TestCase {
 	 * @expectedException \OCA\DAV\Connector\Sabre\Exception\Forbidden
 	 */
 	public function testGetFopenThrows() {
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->setMethods(['fopen'])
 			->getMock();
 		$view->expects($this->atLeastOnce())
@@ -1008,7 +1010,7 @@ class FileTest extends \Test\TestCase {
 	 * @expectedException \Sabre\DAV\Exception\NotFound
 	 */
 	public function testGetThrowsIfNoPermission() {
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->setMethods(['fopen'])
 			->getMock();
 		$view->expects($this->never())

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -25,10 +25,16 @@
  */
 namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
+use OCA\DAV\Connector\Sabre\File;
 use OCA\DAV\Connector\Sabre\FilesPlugin;
 use OCP\Files\StorageNotAvailableException;
+use OCP\IConfig;
+use OCP\IPreview;
+use OCP\IRequest;
 use Sabre\DAV\PropFind;
 use Sabre\DAV\PropPatch;
+use Sabre\DAV\Server;
+use Sabre\DAV\Tree;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 use Test\TestCase;
@@ -87,20 +93,20 @@ class FilesPluginTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->server = $this->getMockBuilder('\Sabre\DAV\Server')
+		$this->server = $this->getMockBuilder(Server::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->tree = $this->getMockBuilder('\Sabre\DAV\Tree')
+		$this->tree = $this->getMockBuilder(Tree::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->config = $this->createMock('\OCP\IConfig');
+		$this->config = $this->createMock(IConfig::class);
 		$this->config->expects($this->any())->method('getSystemValue')
 			->with($this->equalTo('data-fingerprint'), $this->equalTo(''))
 			->willReturn('my_fingerprint');
-		$this->request = $this->getMockBuilder('\OCP\IRequest')
+		$this->request = $this->getMockBuilder(IRequest::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->previewManager = $this->getMockBuilder('\OCP\IPreview')
+		$this->previewManager = $this->getMockBuilder(IPreview::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -245,7 +251,7 @@ class FilesPluginTest extends TestCase {
 		$this->plugin = new FilesPlugin(
 			$this->tree,
 			$this->config,
-			$this->getMockBuilder('\OCP\IRequest')
+			$this->getMockBuilder(IRequest::class)
 				->disableOriginalConstructor()
 				->getMock(),
 			$this->previewManager,
@@ -311,7 +317,7 @@ class FilesPluginTest extends TestCase {
 
 	public function testGetPropertiesForRootDirectory() {
 		/** @var \OCA\DAV\Connector\Sabre\Directory | \PHPUnit_Framework_MockObject_MockObject $node */
-		$node = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\Directory')
+		$node = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->any())->method('getPath')->willReturn('/');
@@ -347,7 +353,7 @@ class FilesPluginTest extends TestCase {
 		// $this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
 		/** @var \OCA\DAV\Connector\Sabre\Directory|\PHPUnit_Framework_MockObject_MockObject $node */
-		$node = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\Directory')
+		$node = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->any())->method('getPath')->willReturn('/');
@@ -539,7 +545,7 @@ class FilesPluginTest extends TestCase {
 			->method('getPath')
 			->will($this->returnValue('test/somefile.xml'));
 
-		$node = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\File')
+		$node = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node

--- a/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
@@ -24,9 +24,14 @@
 
 namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
+use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\FilesReportPlugin as FilesReportPluginImplementation;
+use OCP\Files\File;
+use OCP\IConfig;
 use OCP\IPreview;
+use OCP\IRequest;
 use OCP\ITagManager;
+use OCP\IUser;
 use OCP\IUserSession;
 use OCP\SystemTag\ISystemTagObjectMapper;
 use OC\Files\View;
@@ -35,6 +40,9 @@ use OCP\IGroupManager;
 use OCP\SystemTag\ISystemTagManager;
 use OCP\ITags;
 use OCP\Files\FileInfo;
+use Sabre\DAV\INode;
+use Sabre\DAV\Tree;
+use Sabre\HTTP\ResponseInterface;
 
 class FilesReportPluginTest extends \Test\TestCase {
 	/** @var \Sabre\DAV\Server|\PHPUnit_Framework_MockObject_MockObject */
@@ -72,11 +80,11 @@ class FilesReportPluginTest extends \Test\TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->tree = $this->getMockBuilder('\Sabre\DAV\Tree')
+		$this->tree = $this->getMockBuilder(Tree::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->view = $this->getMockBuilder('\OC\Files\View')
+		$this->view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -89,15 +97,15 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->method('getBaseUri')
 			->will($this->returnValue('http://example.com/owncloud/remote.php/dav'));
 
-		$this->groupManager = $this->getMockBuilder('\OCP\IGroupManager')
+		$this->groupManager = $this->getMockBuilder(IGroupManager::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->userFolder = $this->getMockBuilder('\OCP\Files\Folder')
+		$this->userFolder = $this->getMockBuilder(Folder::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->previewManager = $this->getMockBuilder('\OCP\IPreview')
+		$this->previewManager = $this->getMockBuilder(IPreview::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -111,7 +119,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->with('files')
 			->will($this->returnValue($this->privateTags));
 
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->any())
@@ -140,7 +148,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->method('getNodeForPath')
 			->with('/' . $path)
 			->will($this->returnValue(
-				$this->getMockBuilder('\Sabre\DAV\INode')
+				$this->getMockBuilder(INode::class)
 					->disableOriginalConstructor()
 					->getMock()
 			));
@@ -160,7 +168,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->method('getNodeForPath')
 			->with('/' . $path)
 			->will($this->returnValue(
-				$this->getMockBuilder('\Sabre\DAV\INode')
+				$this->getMockBuilder(INode::class)
 					->disableOriginalConstructor()
 					->getMock()
 			));
@@ -206,11 +214,11 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->with('456', 'files')
 			->will($this->returnValue(['111', '222', '333']));
 
-		$reportTargetNode = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\Directory')
+		$reportTargetNode = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$response = $this->getMockBuilder('Sabre\HTTP\ResponseInterface')
+		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -230,10 +238,10 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->with('/' . $path)
 			->will($this->returnValue($reportTargetNode));
 
-		$filesNode1 = $this->getMockBuilder('\OCP\Files\Folder')
+		$filesNode1 = $this->getMockBuilder(Folder::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$filesNode2 = $this->getMockBuilder('\OCP\Files\File')
+		$filesNode2 = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -256,21 +264,21 @@ class FilesReportPluginTest extends \Test\TestCase {
 	}
 
 	public function testFindNodesByFileIdsRoot() {
-		$filesNode1 = $this->getMockBuilder('\OCP\Files\Folder')
+		$filesNode1 = $this->getMockBuilder(Folder::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$filesNode1->expects($this->once())
 			->method('getName')
 			->will($this->returnValue('first node'));
 
-		$filesNode2 = $this->getMockBuilder('\OCP\Files\File')
+		$filesNode2 = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$filesNode2->expects($this->once())
 			->method('getName')
 			->will($this->returnValue('second node'));
 
-		$reportTargetNode = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\Directory')
+		$reportTargetNode = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$reportTargetNode->expects($this->any())
@@ -297,21 +305,21 @@ class FilesReportPluginTest extends \Test\TestCase {
 	}
 
 	public function testFindNodesByFileIdsSubDir() {
-		$filesNode1 = $this->getMockBuilder('\OCP\Files\Folder')
+		$filesNode1 = $this->getMockBuilder(Folder::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$filesNode1->expects($this->once())
 			->method('getName')
 			->will($this->returnValue('first node'));
 
-		$filesNode2 = $this->getMockBuilder('\OCP\Files\File')
+		$filesNode2 = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$filesNode2->expects($this->once())
 			->method('getName')
 			->will($this->returnValue('second node'));
 
-		$reportTargetNode = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\Directory')
+		$reportTargetNode = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$reportTargetNode->expects($this->any())
@@ -319,7 +327,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->will($this->returnValue('/sub1/sub2'));
 
 
-		$subNode = $this->getMockBuilder('\OCP\Files\Folder')
+		$subNode = $this->getMockBuilder(Folder::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -353,10 +361,10 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$fileInfo = $this->createMock(FileInfo::class);
 		$fileInfo->method('isReadable')->willReturn(true);
 
-		$node1 = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\Directory')
+		$node1 = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$node2 = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\File')
+		$node2 = $this->getMockBuilder(\OCA\DAV\Connector\Sabre\File::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -378,7 +386,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->will($this->returnValue('/sub/node2'));
 		$node2->method('getFileInfo')->willReturn($fileInfo);
 
-		$config = $this->getMockBuilder('\OCP\IConfig')
+		$config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -386,7 +394,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 			new \OCA\DAV\Connector\Sabre\FilesPlugin(
 				$this->tree,
 				$config,
-				$this->getMockBuilder('\OCP\IRequest')
+				$this->getMockBuilder(IRequest::class)
 					->disableOriginalConstructor()
 					->getMock(),
 				$this->previewManager

--- a/apps/dav/tests/unit/Connector/Sabre/MaintenancePluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/MaintenancePluginTest.php
@@ -42,7 +42,7 @@ class MaintenancePluginTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->config = $this->getMockBuilder('\OCP\IConfig')->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->maintenancePlugin = new MaintenancePlugin($this->config);
 	}
 

--- a/apps/dav/tests/unit/Connector/Sabre/NodeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/NodeTest.php
@@ -25,6 +25,8 @@
  */
 
 namespace OCA\DAV\Tests\unit\Connector\Sabre;
+use OC\Files\View;
+use OCP\Files\Storage;
 
 /**
  * Class NodeTest
@@ -67,7 +69,7 @@ class NodeTest extends \Test\TestCase {
 		$info->expects($this->any())
 			->method('getType')
 			->will($this->returnValue($type));
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -119,7 +121,7 @@ class NodeTest extends \Test\TestCase {
 	 * @dataProvider sharePermissionsProvider
 	 */
 	public function testSharePermissions($type, $user, $permissions, $expected) {
-		$storage = $this->getMockBuilder('\OCP\Files\Storage')
+		$storage = $this->getMockBuilder(Storage::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$storage->method('getPermissions')->willReturn($permissions);
@@ -149,7 +151,7 @@ class NodeTest extends \Test\TestCase {
 		$info->method('getType')->willReturn($type);
 		$info->method('getMountPoint')->willReturn($mountpoint);
 
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
@@ -156,13 +156,13 @@ class ObjectTreeTest extends \Test\TestCase {
 			$_SERVER['HTTP_OC_CHUNKED'] = true;
 		}
 
-		$rootNode = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\Directory')
+		$rootNode = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$mountManager = $this->getMockBuilder('\OC\Files\Mount\Manager')
 			->disableOriginalConstructor()
 			->getMock();
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$fileInfo = $this->getMockBuilder('\OCP\Files\FileInfo')
@@ -275,7 +275,7 @@ class ObjectTreeTest extends \Test\TestCase {
 
 		$storage = new Temporary([]);
 
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->setMethods(['resolvePath'])
 			->getMock();
 		$view->expects($this->once())
@@ -284,7 +284,7 @@ class ObjectTreeTest extends \Test\TestCase {
 			return [$storage, ltrim($path, '/')];
 		}));
 
-		$rootNode = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\Directory')
+		$rootNode = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$mountManager = $this->getMockBuilder('\OC\Files\Mount\Manager')
@@ -302,7 +302,7 @@ class ObjectTreeTest extends \Test\TestCase {
 
 		$storage = new Temporary([]);
 
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->setMethods(['resolvePath'])
 			->getMock();
 		$view->expects($this->any())
@@ -311,7 +311,7 @@ class ObjectTreeTest extends \Test\TestCase {
 				return [$storage, ltrim($path, '/')];
 			}));
 
-		$rootNode = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\Directory')
+		$rootNode = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$mountManager = $this->getMockBuilder('\OC\Files\Mount\Manager')

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/PartFileInRootUploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/PartFileInRootUploadTest.php
@@ -24,6 +24,8 @@
 
 namespace OCA\DAV\Tests\unit\Connector\Sabre\RequestTest;
 
+use OCP\IConfig;
+
 /**
  * Class PartFileInRootUploadTest
  *
@@ -34,7 +36,7 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre\RequestTest;
 class PartFileInRootUploadTest extends UploadTest {
 	protected function setUp() {
 		$config = \OC::$server->getConfig();
-		$mockConfig = $this->getMockBuilder('\OCP\IConfig')
+		$mockConfig = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$mockConfig->expects($this->any())

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTestCase.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTestCase.php
@@ -29,6 +29,7 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre\RequestTest;
 use OCA\DAV\Connector\Sabre\Server;
 use OCA\DAV\Connector\Sabre\ServerFactory;
 use OC\Files\View;
+use OCP\IRequest;
 use Sabre\HTTP\Request;
 use Test\TestCase;
 use Test\Traits\MountProviderTrait;
@@ -62,7 +63,7 @@ abstract class RequestTestCase extends TestCase {
 			\OC::$server->getUserSession(),
 			\OC::$server->getMountManager(),
 			\OC::$server->getTagManager(),
-			$this->getMockBuilder('\OCP\IRequest')
+			$this->getMockBuilder(IRequest::class)
 				->disableOriginalConstructor()
 				->getMock(),
 			\OC::$server->getPreviewManager()

--- a/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
@@ -23,6 +23,14 @@
  */
 namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
+use OCA\DAV\Connector\Sabre\Directory;
+use OCA\DAV\Connector\Sabre\File;
+use OCP\Files\Folder;
+use OCP\IUser;
+use OCP\IUserSession;
+use OCP\Share\IManager;
+use Sabre\DAV\Tree;
+
 class SharesPluginTest extends \Test\TestCase {
 
 	const SHARETYPES_PROPERTYNAME = \OCA\DAV\Connector\Sabre\SharesPlugin::SHARETYPES_PROPERTYNAME;
@@ -55,26 +63,26 @@ class SharesPluginTest extends \Test\TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->server = new \Sabre\DAV\Server();
-		$this->tree = $this->getMockBuilder('\Sabre\DAV\Tree')
+		$this->tree = $this->getMockBuilder(Tree::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->shareManager = $this->getMockBuilder('\OCP\Share\IManager')
+		$this->shareManager = $this->getMockBuilder(IManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$user->expects($this->once())
 			->method('getUID')
 			->will($this->returnValue('user1'));
-		$userSession = $this->getMockBuilder('\OCP\IUserSession')
+		$userSession = $this->getMockBuilder(IUserSession::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$userSession->expects($this->once())
 			->method('getUser')
 			->will($this->returnValue($user));
 
-		$this->userFolder = $this->getMockBuilder('\OCP\Files\Folder')
+		$this->userFolder = $this->getMockBuilder(Folder::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -102,7 +110,7 @@ class SharesPluginTest extends \Test\TestCase {
 			->will($this->returnValue('/subdir'));
 
 		// node API nodes
-		$node = $this->getMockBuilder('\OCP\Files\Folder')
+		$node = $this->getMockBuilder(Folder::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -149,7 +157,7 @@ class SharesPluginTest extends \Test\TestCase {
 	 * @dataProvider sharesGetPropertiesDataProvider
 	 */
 	public function testPreloadThenGetProperties($shareTypes) {
-		$sabreNode1 = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\File')
+		$sabreNode1 = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$sabreNode1->expects($this->any())
@@ -157,7 +165,7 @@ class SharesPluginTest extends \Test\TestCase {
 			->will($this->returnValue(111));
 		$sabreNode1->expects($this->any())
 			->method('getPath');
-		$sabreNode2 = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\File')
+		$sabreNode2 = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$sabreNode2->expects($this->any())
@@ -167,7 +175,7 @@ class SharesPluginTest extends \Test\TestCase {
 			->method('getPath')
 			->will($this->returnValue('/subdir/foo'));
 
-		$sabreNode = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\Directory')
+		$sabreNode = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$sabreNode->expects($this->any())
@@ -181,19 +189,19 @@ class SharesPluginTest extends \Test\TestCase {
 			->will($this->returnValue('/subdir'));
 
 		// node API nodes
-		$node = $this->getMockBuilder('\OCP\Files\Folder')
+		$node = $this->getMockBuilder(Folder::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->any())
 			->method('getId')
 			->will($this->returnValue(123));
-		$node1 = $this->getMockBuilder('\OCP\Files\File')
+		$node1 = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node1->expects($this->any())
 			->method('getId')
 			->will($this->returnValue(111));
-		$node2 = $this->getMockBuilder('\OCP\Files\File')
+		$node2 = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node2->expects($this->any())

--- a/apps/dav/tests/unit/Connector/Sabre/TagsPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/TagsPluginTest.php
@@ -24,6 +24,10 @@
  */
 namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
+use OCA\DAV\Connector\Sabre\Directory;
+use OCA\DAV\Connector\Sabre\File;
+use Sabre\DAV\Tree;
+
 /**
  * Copyright (c) 2014 Vincent Petry <pvince81@owncloud.com>
  * This file is licensed under the Affero General Public License version 3 or
@@ -42,7 +46,7 @@ class TagsPluginTest extends \Test\TestCase {
 	private $server;
 
 	/**
-	 * @var \Sabre\DAV\Tree
+	 * @var Tree
 	 */
 	private $tree;
 
@@ -64,7 +68,7 @@ class TagsPluginTest extends \Test\TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->server = new \Sabre\DAV\Server();
-		$this->tree = $this->getMockBuilder('\Sabre\DAV\Tree')
+		$this->tree = $this->getMockBuilder(Tree::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->tagger = $this->getMockBuilder('\OCP\ITags')
@@ -124,13 +128,13 @@ class TagsPluginTest extends \Test\TestCase {
 	 * @dataProvider tagsGetPropertiesDataProvider
 	 */
 	public function testPreloadThenGetProperties($tags, $requestedProperties, $expectedProperties) {
-		$node1 = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\File')
+		$node1 = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node1->expects($this->any())
 			->method('getId')
 			->will($this->returnValue(111));
-		$node2 = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\File')
+		$node2 = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node2->expects($this->any())
@@ -145,7 +149,7 @@ class TagsPluginTest extends \Test\TestCase {
 			$expectedCallCount = 1;
 		}
 
-		$node = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\Directory')
+		$node = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$node->expects($this->any())

--- a/apps/dav/tests/unit/DAV/Sharing/PluginTest.php
+++ b/apps/dav/tests/unit/DAV/Sharing/PluginTest.php
@@ -51,7 +51,7 @@ class PluginTest extends TestCase {
 		$authBackend->method('isDavAuthenticated')->willReturn(true);
 
 		/** @var IRequest $request */
-		$request = $this->getMockBuilder('OCP\IRequest')->disableOriginalConstructor()->getMock();
+		$request = $this->getMockBuilder(IRequest::class)->disableOriginalConstructor()->getMock();
 		$this->plugin = new Plugin($authBackend, $request);
 
 		$root = new SimpleCollection('root');

--- a/apps/dav/tests/unit/SystemTag/SystemTagMappingNodeTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagMappingNodeTest.php
@@ -25,6 +25,7 @@
 namespace OCA\DAV\Tests\unit\SystemTag;
 
 use OC\SystemTag\SystemTag;
+use OCP\IUser;
 use OCP\SystemTag\TagNotFoundException;
 use OCP\SystemTag\ISystemTag;
 
@@ -52,7 +53,7 @@ class SystemTagMappingNodeTest extends \Test\TestCase {
 			->getMock();
 		$this->tagMapper = $this->getMockBuilder('\OCP\SystemTag\ISystemTagObjectMapper')
 			->getMock();
-		$this->user = $this->getMockBuilder('\OCP\IUser')
+		$this->user = $this->getMockBuilder(IUser::class)
 			->getMock();
 	}
 

--- a/apps/dav/tests/unit/SystemTag/SystemTagNodeTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagNodeTest.php
@@ -26,6 +26,7 @@ namespace OCA\DAV\Tests\unit\SystemTag;
 
 
 use OC\SystemTag\SystemTag;
+use OCP\IUser;
 use OCP\SystemTag\TagNotFoundException;
 use OCP\SystemTag\TagAlreadyExistsException;
 use OCP\SystemTag\ISystemTag;
@@ -48,7 +49,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 
 		$this->tagManager = $this->getMockBuilder('\OCP\SystemTag\ISystemTagManager')
 			->getMock();
-		$this->user = $this->getMockBuilder('\OCP\IUser')
+		$this->user = $this->getMockBuilder(IUser::class)
 			->getMock();
 	}
 

--- a/apps/dav/tests/unit/SystemTag/SystemTagPluginTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagPluginTest.php
@@ -32,6 +32,9 @@ use OCP\IUserSession;
 use OCP\SystemTag\TagAlreadyExistsException;
 use OCP\IUser;
 use OCP\SystemTag\ISystemTag;
+use Sabre\DAV\Tree;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
 
 class SystemTagPluginTest extends \Test\TestCase {
 
@@ -79,7 +82,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->tree = $this->getMockBuilder('\Sabre\DAV\Tree')
+		$this->tree = $this->getMockBuilder(Tree::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -87,11 +90,11 @@ class SystemTagPluginTest extends \Test\TestCase {
 
 		$this->tagManager = $this->getMockBuilder('\OCP\SystemTag\ISystemTagManager')
 			->getMock();
-		$this->groupManager = $this->getMockBuilder('\OCP\IGroupManager')
+		$this->groupManager = $this->getMockBuilder(IGroupManager::class)
 			->getMock();
-		$this->user = $this->getMockBuilder('\OCP\IUser')
+		$this->user = $this->getMockBuilder(IUser::class)
 			->getMock();
-		$this->userSession = $this->getMockBuilder('\OCP\IUserSession')
+		$this->userSession = $this->getMockBuilder(IUserSession::class)
 			->getMock();
 		$this->userSession
 			->expects($this->any())
@@ -413,10 +416,10 @@ class SystemTagPluginTest extends \Test\TestCase {
 			->with('/systemtags')
 			->will($this->returnValue($node));
 
-		$request = $this->getMockBuilder('Sabre\HTTP\RequestInterface')
+		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$response = $this->getMockBuilder('Sabre\HTTP\ResponseInterface')
+		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -458,10 +461,10 @@ class SystemTagPluginTest extends \Test\TestCase {
 			->with('/systemtags')
 			->will($this->returnValue($node));
 
-		$request = $this->getMockBuilder('Sabre\HTTP\RequestInterface')
+		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$response = $this->getMockBuilder('Sabre\HTTP\ResponseInterface')
+		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -545,10 +548,10 @@ class SystemTagPluginTest extends \Test\TestCase {
 			->with('/systemtags')
 			->will($this->returnValue($node));
 
-		$request = $this->getMockBuilder('Sabre\HTTP\RequestInterface')
+		$request = $this->getMockBuilder(RequestInterface::class)
 				->disableOriginalConstructor()
 				->getMock();
-		$response = $this->getMockBuilder('Sabre\HTTP\ResponseInterface')
+		$response = $this->getMockBuilder(ResponseInterface::class)
 				->disableOriginalConstructor()
 				->getMock();
 
@@ -619,10 +622,10 @@ class SystemTagPluginTest extends \Test\TestCase {
 			->method('createFile')
 			->with(1);
 
-		$request = $this->getMockBuilder('Sabre\HTTP\RequestInterface')
+		$request = $this->getMockBuilder(RequestInterface::class)
 				->disableOriginalConstructor()
 				->getMock();
-		$response = $this->getMockBuilder('Sabre\HTTP\ResponseInterface')
+		$response = $this->getMockBuilder(ResponseInterface::class)
 				->disableOriginalConstructor()
 				->getMock();
 
@@ -668,10 +671,10 @@ class SystemTagPluginTest extends \Test\TestCase {
 		$node->expects($this->never())
 			->method('createFile');
 
-		$request = $this->getMockBuilder('Sabre\HTTP\RequestInterface')
+		$request = $this->getMockBuilder(RequestInterface::class)
 				->disableOriginalConstructor()
 				->getMock();
-		$response = $this->getMockBuilder('Sabre\HTTP\ResponseInterface')
+		$response = $this->getMockBuilder(ResponseInterface::class)
 				->disableOriginalConstructor()
 				->getMock();
 
@@ -715,10 +718,10 @@ class SystemTagPluginTest extends \Test\TestCase {
 			->with('/systemtags')
 			->will($this->returnValue($node));
 
-		$request = $this->getMockBuilder('Sabre\HTTP\RequestInterface')
+		$request = $this->getMockBuilder(RequestInterface::class)
 				->disableOriginalConstructor()
 				->getMock();
-		$response = $this->getMockBuilder('Sabre\HTTP\ResponseInterface')
+		$response = $this->getMockBuilder(ResponseInterface::class)
 				->disableOriginalConstructor()
 				->getMock();
 

--- a/apps/dav/tests/unit/SystemTag/SystemTagsByIdCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsByIdCollectionTest.php
@@ -26,6 +26,9 @@ namespace OCA\DAV\Tests\unit\SystemTag;
 
 
 use OC\SystemTag\SystemTag;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserSession;
 use OCP\SystemTag\TagNotFoundException;
 
 class SystemTagsByIdCollectionTest extends \Test\TestCase {
@@ -48,17 +51,17 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 	}
 
 	public function getNode($isAdmin = true) {
-		$this->user = $this->getMockBuilder('\OCP\IUser')
+		$this->user = $this->getMockBuilder(IUser::class)
 			->getMock();
 		$this->user->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('testuser'));
-		$userSession = $this->getMockBuilder('\OCP\IUserSession')
+		$userSession = $this->getMockBuilder(IUserSession::class)
 			->getMock();
 		$userSession->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
-		$groupManager = $this->getMockBuilder('\OCP\IGroupManager')
+		$groupManager = $this->getMockBuilder(IGroupManager::class)
 			->getMock();
 		$groupManager->expects($this->any())
 			->method('isAdmin')

--- a/apps/dav/tests/unit/SystemTag/SystemTagsObjectMappingCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsObjectMappingCollectionTest.php
@@ -26,6 +26,7 @@ namespace OCA\DAV\Tests\unit\SystemTag;
 
 
 use OC\SystemTag\SystemTag;
+use OCP\IUser;
 use OCP\SystemTag\TagNotFoundException;
 
 class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
@@ -53,7 +54,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 		$this->tagMapper = $this->getMockBuilder('\OCP\SystemTag\ISystemTagObjectMapper')
 			->getMock();
 
-		$this->user = $this->getMockBuilder('\OCP\IUser')
+		$this->user = $this->getMockBuilder(IUser::class)
 			->getMock();
 	}
 

--- a/apps/dav/tests/unit/SystemTag/SystemTagsObjectTypeCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsObjectTypeCollectionTest.php
@@ -24,6 +24,11 @@
 
 namespace OCA\DAV\Tests\unit\SystemTag;
 
+use OCP\Files\Folder;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserSession;
+
 class SystemTagsObjectTypeCollectionTest extends \Test\TestCase {
 
 	/**
@@ -54,24 +59,24 @@ class SystemTagsObjectTypeCollectionTest extends \Test\TestCase {
 		$this->tagMapper = $this->getMockBuilder('\OCP\SystemTag\ISystemTagObjectMapper')
 			->getMock();
 
-		$user = $this->getMockBuilder('\OCP\IUser')
+		$user = $this->getMockBuilder(IUser::class)
 			->getMock();
 		$user->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('testuser'));
-		$userSession = $this->getMockBuilder('\OCP\IUserSession')
+		$userSession = $this->getMockBuilder(IUserSession::class)
 			->getMock();
 		$userSession->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($user));
-		$groupManager = $this->getMockBuilder('\OCP\IGroupManager')
+		$groupManager = $this->getMockBuilder(IGroupManager::class)
 			->getMock();
 		$groupManager->expects($this->any())
 			->method('isAdmin')
 			->with('testuser')
 			->will($this->returnValue(true));
 
-		$this->userFolder = $this->getMockBuilder('\OCP\Files\Folder')
+		$this->userFolder = $this->getMockBuilder(Folder::class)
 			->getMock();
 		$userFolder = $this->userFolder;
 

--- a/apps/encryption/tests/Command/TestEnableMasterKey.php
+++ b/apps/encryption/tests/Command/TestEnableMasterKey.php
@@ -27,6 +27,7 @@ namespace OCA\Encryption\Tests\Command;
 
 use OCA\Encryption\Command\EnableMasterKey;
 use OCA\Encryption\Util;
+use OCP\IConfig;
 use Test\TestCase;
 
 class TestEnableMasterKey extends TestCase {
@@ -54,7 +55,7 @@ class TestEnableMasterKey extends TestCase {
 
 		$this->util = $this->getMockBuilder('OCA\Encryption\Util')
 			->disableOriginalConstructor()->getMock();
-		$this->config = $this->getMockBuilder('OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()->getMock();
 		$this->questionHelper = $this->getMockBuilder('Symfony\Component\Console\Helper\QuestionHelper')
 			->disableOriginalConstructor()->getMock();

--- a/apps/encryption/tests/Controller/RecoveryControllerTest.php
+++ b/apps/encryption/tests/Controller/RecoveryControllerTest.php
@@ -27,6 +27,9 @@ namespace OCA\Encryption\Tests\Controller;
 
 use OCA\Encryption\Controller\RecoveryController;
 use OCP\AppFramework\Http;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IRequest;
 use Test\TestCase;
 
 class RecoveryControllerTest extends TestCase {
@@ -151,15 +154,15 @@ class RecoveryControllerTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->requestMock = $this->getMockBuilder('OCP\IRequest')
+		$this->requestMock = $this->getMockBuilder(IRequest::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->configMock = $this->getMockBuilder('OCP\IConfig')
+		$this->configMock = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->l10nMock = $this->getMockBuilder('OCP\IL10N')
+		$this->l10nMock = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/apps/encryption/tests/Controller/SettingsControllerTest.php
+++ b/apps/encryption/tests/Controller/SettingsControllerTest.php
@@ -26,7 +26,9 @@ namespace OCA\Encryption\Tests\Controller;
 use OCA\Encryption\Controller\SettingsController;
 use OCA\Encryption\Session;
 use OCP\AppFramework\Http;
+use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IUserManager;
 use Test\TestCase;
 
 class SettingsControllerTest extends TestCase {
@@ -67,7 +69,7 @@ class SettingsControllerTest extends TestCase {
 
 		$this->requestMock = $this->createMock(IRequest::class);
 
-		$this->l10nMock = $this->getMockBuilder('OCP\IL10N')
+		$this->l10nMock = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()->getMock();
 
 		$this->l10nMock->expects($this->any())
@@ -76,7 +78,7 @@ class SettingsControllerTest extends TestCase {
 				return $message;
 			}));
 
-		$this->userManagerMock = $this->getMockBuilder('OCP\IUserManager')
+		$this->userManagerMock = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()->getMock();
 
 		$this->keyManagerMock = $this->getMockBuilder('OCA\Encryption\KeyManager')

--- a/apps/encryption/tests/Controller/StatusControllerTest.php
+++ b/apps/encryption/tests/Controller/StatusControllerTest.php
@@ -28,6 +28,7 @@ namespace OCA\Encryption\Tests\Controller;
 use OCA\Encryption\Controller\StatusController;
 use OCA\Encryption\Session;
 use OCP\Encryption\IManager;
+use OCP\IL10N;
 use OCP\IRequest;
 use Test\TestCase;
 
@@ -56,7 +57,7 @@ class StatusControllerTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->requestMock = $this->createMock(IRequest::class);
 
-		$this->l10nMock = $this->getMockBuilder('OCP\IL10N')
+		$this->l10nMock = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()->getMock();
 		$this->l10nMock->expects($this->any())
 			->method('t')

--- a/apps/encryption/tests/Crypto/CryptTest.php
+++ b/apps/encryption/tests/Crypto/CryptTest.php
@@ -27,7 +27,9 @@ namespace OCA\Encryption\Tests\Crypto;
 
 
 use OCA\Encryption\Crypto\Crypt;
+use OCP\IConfig;
 use OCP\IL10N;
+use OCP\ILogger;
 use Test\TestCase;
 
 class CryptTest extends TestCase {
@@ -51,7 +53,7 @@ class CryptTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->logger = $this->getMockBuilder('OCP\ILogger')
+		$this->logger = $this->getMockBuilder(ILogger::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->logger->expects($this->any())
@@ -60,7 +62,7 @@ class CryptTest extends TestCase {
 		$this->userSession = $this->getMockBuilder('OCP\IUserSession')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->config = $this->getMockBuilder('OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->l = $this->createMock(IL10N::class);

--- a/apps/encryption/tests/Crypto/EncryptAllTest.php
+++ b/apps/encryption/tests/Crypto/EncryptAllTest.php
@@ -26,6 +26,11 @@ namespace OCA\Encryption\Tests\Crypto;
 
 
 use OCA\Encryption\Crypto\EncryptAll;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IUserManager;
+use OCP\Mail\IMailer;
+use OCP\UserInterface;
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Test\TestCase;
 
@@ -81,15 +86,15 @@ class EncryptAllTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->util = $this->getMockBuilder('OCA\Encryption\Util')
 			->disableOriginalConstructor()->getMock();
-		$this->userManager = $this->getMockBuilder('OCP\IUserManager')
+		$this->userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()->getMock();
 		$this->view = $this->getMockBuilder('OC\Files\View')
 			->disableOriginalConstructor()->getMock();
-		$this->config = $this->getMockBuilder('OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()->getMock();
-		$this->mailer = $this->getMockBuilder('OCP\Mail\IMailer')
+		$this->mailer = $this->getMockBuilder(IMailer::class)
 			->disableOriginalConstructor()->getMock();
-		$this->l = $this->getMockBuilder('OCP\IL10N')
+		$this->l = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()->getMock();
 		$this->questionHelper = $this->getMockBuilder('Symfony\Component\Console\Helper\QuestionHelper')
 			->disableOriginalConstructor()->getMock();
@@ -97,7 +102,7 @@ class EncryptAllTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->outputInterface = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
 			->disableOriginalConstructor()->getMock();
-		$this->userInterface = $this->getMockBuilder('OCP\UserInterface')
+		$this->userInterface = $this->getMockBuilder(UserInterface::class)
 			->disableOriginalConstructor()->getMock();
 
 

--- a/apps/encryption/tests/Crypto/EncryptionTest.php
+++ b/apps/encryption/tests/Crypto/EncryptionTest.php
@@ -24,6 +24,8 @@
 namespace OCA\Encryption\Tests\Crypto;
 
 use OCA\Encryption\Exceptions\PublicKeyMissingException;
+use OCP\IL10N;
+use OCP\ILogger;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
@@ -84,10 +86,10 @@ class EncryptionTest extends TestCase {
 		$this->decryptAllMock = $this->getMockBuilder('OCA\Encryption\Crypto\DecryptAll')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->loggerMock = $this->getMockBuilder('OCP\ILogger')
+		$this->loggerMock = $this->getMockBuilder(ILogger::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->l10nMock = $this->getMockBuilder('OCP\IL10N')
+		$this->l10nMock = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->l10nMock->expects($this->any())

--- a/apps/encryption/tests/Hooks/UserHooksTest.php
+++ b/apps/encryption/tests/Hooks/UserHooksTest.php
@@ -31,6 +31,7 @@ use OCA\Encryption\Crypto\Crypt;
 use OCA\Encryption\Hooks\UserHooks;
 use OCP\ILogger;
 use OCP\IUser;
+use OCP\IUserManager;
 use Test\TestCase;
 
 /**
@@ -327,7 +328,7 @@ class UserHooksTest extends TestCase {
 		$this->keyManagerMock = $this->getMockBuilder('OCA\Encryption\KeyManager')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->userManagerMock = $this->getMockBuilder('OCP\IUserManager')
+		$this->userManagerMock = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->userSetupMock = $this->getMockBuilder('OCA\Encryption\Users\Setup')

--- a/apps/encryption/tests/MigrationTest.php
+++ b/apps/encryption/tests/MigrationTest.php
@@ -25,6 +25,7 @@
 
 namespace OCA\Encryption\Tests;
 
+use OC\Files\View;
 use OCA\Encryption\Migration;
 use OCP\ILogger;
 
@@ -68,7 +69,7 @@ class MigrationTest extends \Test\TestCase {
 
 
 	public function setUp() {
-		$this->logger = $this->getMockBuilder('\OCP\ILogger')->disableOriginalConstructor()->getMock();
+		$this->logger = $this->getMockBuilder(ILogger::class)->disableOriginalConstructor()->getMock();
 		$this->view = new \OC\Files\View();
 		$this->moduleId = \OCA\Encryption\Crypto\Encryption::ID;
 	}
@@ -524,7 +525,7 @@ class MigrationTest extends \Test\TestCase {
 	 */
 	public function testGetTargetDir($user, $keyPath, $filename, $trash, $systemMounts, $expected) {
 
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()->getMock();
 		$view->expects($this->any())->method('file_exists')->willReturn(true);
 

--- a/apps/encryption/tests/Settings/AdminTest.php
+++ b/apps/encryption/tests/Settings/AdminTest.php
@@ -52,12 +52,12 @@ class AdminTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->l = $this->getMockBuilder('\OCP\IL10N')->getMock();
-		$this->logger = $this->getMockBuilder('\OCP\ILogger')->getMock();
-		$this->userSession = $this->getMockBuilder('\OCP\IUserSession')->getMock();
-		$this->config = $this->getMockBuilder('\OCP\IConfig')->getMock();
-		$this->userManager = $this->getMockBuilder('\OCP\IUserManager')->getMock();
-		$this->session = $this->getMockBuilder('\OCP\ISession')->getMock();
+		$this->l = $this->getMockBuilder(IL10N::class)->getMock();
+		$this->logger = $this->getMockBuilder(ILogger::class)->getMock();
+		$this->userSession = $this->getMockBuilder(IUserSession::class)->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
+		$this->userManager = $this->getMockBuilder(IUserManager::class)->getMock();
+		$this->session = $this->getMockBuilder(ISession::class)->getMock();
 
 		$this->admin = new Admin(
 			$this->l,

--- a/apps/federatedfilesharing/tests/AddressHandlerTest.php
+++ b/apps/federatedfilesharing/tests/AddressHandlerTest.php
@@ -47,9 +47,9 @@ class AddressHandlerTest extends \Test\TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->urlGenerator = $this->getMockBuilder('OCP\IURLGenerator')
+		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->getMock();
-		$this->il10n = $this->getMockBuilder('OCP\IL10N')
+		$this->il10n = $this->getMockBuilder(IL10N::class)
 			->getMock();
 
 		$this->cloudIdManager = new CloudIdManager();

--- a/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
@@ -35,6 +35,7 @@ use OCP\Federation\ICloudIdManager;
 use OCP\Files\IRootFolder;
 use OCP\Http\Client\IClientService;
 use OCP\IL10N;
+use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUserManager;
 use OCP\IUserSession;
@@ -85,17 +86,17 @@ class MountPublicLinkControllerTest extends \Test\TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->request = $this->getMockBuilder('OCP\IRequest')->disableOriginalConstructor()->getMock();
+		$this->request = $this->getMockBuilder(IRequest::class)->disableOriginalConstructor()->getMock();
 		$this->federatedShareProvider = $this->getMockBuilder('OCA\FederatedFileSharing\FederatedShareProvider')
 			->disableOriginalConstructor()->getMock();
 		$this->shareManager = $this->getMockBuilder('OCP\Share\IManager')->disableOriginalConstructor()->getMock();
 		$this->addressHandler = $this->getMockBuilder('OCA\FederatedFileSharing\AddressHandler')
 			->disableOriginalConstructor()->getMock();
 		$this->rootFolder = $this->getMockBuilder('OCP\Files\IRootFolder')->disableOriginalConstructor()->getMock();
-		$this->userManager = $this->getMockBuilder('OCP\IUserManager')->disableOriginalConstructor()->getMock();
+		$this->userManager = $this->getMockBuilder(IUserManager::class)->disableOriginalConstructor()->getMock();
 		$this->share = new \OC\Share20\Share($this->rootFolder, $this->userManager);
 		$this->session = $this->getMockBuilder('OCP\ISession')->disableOriginalConstructor()->getMock();
-		$this->l10n = $this->getMockBuilder('OCP\IL10N')->disableOriginalConstructor()->getMock();
+		$this->l10n = $this->getMockBuilder(IL10N::class)->disableOriginalConstructor()->getMock();
 		$this->userSession = $this->getMockBuilder('OCP\IUserSession')->disableOriginalConstructor()->getMock();
 		$this->clientService = $this->getMockBuilder('OCP\Http\Client\IClientService')->disableOriginalConstructor()->getMock();
 		$this->cloudIdManager = new CloudIdManager();

--- a/apps/federatedfilesharing/tests/Controller/RequestHandlerControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/RequestHandlerControllerTest.php
@@ -29,13 +29,13 @@ namespace OCA\FederatedFileSharing\Tests;
 
 use OC\Federation\CloudIdManager;
 use OC\Files\Filesystem;
-use OCA\FederatedFileSharing\DiscoveryManager;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\FederatedFileSharing\Controller\RequestHandlerController;
 use OCP\Federation\ICloudIdManager;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
+use OCP\IConfig;
 use OCP\IUserManager;
 use OCP\Share\IShare;
 
@@ -83,9 +83,9 @@ class RequestHandlerControllerTest extends TestCase {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 		\OC\Share\Share::registerBackend('test', 'Test\Share\Backend');
 
-		$config = $this->getMockBuilder('\OCP\IConfig')
+		$config = $this->getMockBuilder(IConfig::class)
 				->disableOriginalConstructor()->getMock();
-		$clientService = $this->getMockBuilder('\OCP\Http\Client\IClientService')->getMock();
+		$clientService = $this->getMockBuilder(IClientService::class)->getMock();
 		$httpHelperMock = $this->getMockBuilder('\OC\HTTPHelper')
 				->setConstructorArgs([$config, $clientService])
 				->getMock();
@@ -104,7 +104,7 @@ class RequestHandlerControllerTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->addressHandler = $this->getMockBuilder('OCA\FederatedFileSharing\AddressHandler')
 			->disableOriginalConstructor()->getMock();
-		$this->userManager = $this->getMockBuilder('OCP\IUserManager')->getMock();
+		$this->userManager = $this->getMockBuilder(IUserManager::class)->getMock();
 
 		$this->cloudIdManager = new CloudIdManager();
 

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -31,6 +31,7 @@ use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\FederatedFileSharing\Notifications;
 use OCA\FederatedFileSharing\TokenHandler;
 use OCP\Federation\ICloudIdManager;
+use OCP\Files\File;
 use OCP\Files\IRootFolder;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -87,15 +88,15 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$this->tokenHandler = $this->getMockBuilder('OCA\FederatedFileSharing\TokenHandler')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->l = $this->getMockBuilder('OCP\IL10N')->getMock();
+		$this->l = $this->getMockBuilder(IL10N::class)->getMock();
 		$this->l->method('t')
 			->will($this->returnCallback(function($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			}));
-		$this->logger = $this->getMockBuilder('OCP\ILogger')->getMock();
+		$this->logger = $this->getMockBuilder(ILogger::class)->getMock();
 		$this->rootFolder = $this->getMockBuilder('OCP\Files\IRootFolder')->getMock();
-		$this->config = $this->getMockBuilder('OCP\IConfig')->getMock();
-		$this->userManager = $this->getMockBuilder('OCP\IUserManager')->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
+		$this->userManager = $this->getMockBuilder(IUserManager::class)->getMock();
 		//$this->addressHandler = new AddressHandler(\OC::$server->getURLGenerator(), $this->l);
 		$this->addressHandler = $this->getMockBuilder('OCA\FederatedFileSharing\AddressHandler')->disableOriginalConstructor()->getMock();
 		$this->cloudIdManager = new CloudIdManager();
@@ -129,7 +130,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	public function testCreate() {
 		$share = $this->shareManager->newShare();
 
-		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$node = $this->getMockBuilder(File::class)->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
@@ -200,7 +201,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	public function testCreateCouldNotFindServer() {
 		$share = $this->shareManager->newShare();
 
-		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$node = $this->getMockBuilder(File::class)->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
@@ -256,7 +257,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	public function testCreateException() {
 		$share = $this->shareManager->newShare();
 
-		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$node = $this->getMockBuilder(File::class)->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
@@ -312,7 +313,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	public function testCreateShareWithSelf() {
 		$share = $this->shareManager->newShare();
 
-		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$node = $this->getMockBuilder(File::class)->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
@@ -351,7 +352,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	public function testCreateAlreadyShared() {
 		$share = $this->shareManager->newShare();
 
-		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$node = $this->getMockBuilder(File::class)->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
@@ -419,7 +420,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 
 		$share = $this->shareManager->newShare();
 
-		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$node = $this->getMockBuilder(File::class)->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
@@ -476,7 +477,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetSharedBy() {
-		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$node = $this->getMockBuilder(File::class)->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
@@ -517,7 +518,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetSharedByWithNode() {
-		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$node = $this->getMockBuilder(File::class)->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
@@ -536,7 +537,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setNode($node);
 		$this->provider->create($share);
 
-		$node2 = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$node2 = $this->getMockBuilder(File::class)->getMock();
 		$node2->method('getId')->willReturn(43);
 		$node2->method('getName')->willReturn('myOtherFile');
 
@@ -555,7 +556,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetSharedByWithReshares() {
-		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$node = $this->getMockBuilder(File::class)->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
@@ -588,7 +589,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetSharedByWithLimit() {
-		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$node = $this->getMockBuilder(File::class)->getMock();
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -27,6 +27,8 @@ namespace OCA\Files\Tests\Controller;
 
 use OCA\Files\Controller\ViewController;
 use OCP\AppFramework\Http;
+use OCP\Files\File;
+use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\IUser;
 use OCP\Template;
@@ -68,14 +70,14 @@ class ViewControllerTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->request = $this->getMockBuilder('\OCP\IRequest')->getMock();
-		$this->urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')->getMock();
-		$this->l10n = $this->getMockBuilder('\OCP\IL10N')->getMock();
-		$this->config = $this->getMockBuilder('\OCP\IConfig')->getMock();
+		$this->request = $this->getMockBuilder(IRequest::class)->getMock();
+		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)->getMock();
+		$this->l10n = $this->getMockBuilder(IL10N::class)->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->eventDispatcher = $this->getMockBuilder('\Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
-		$this->userSession = $this->getMockBuilder('\OCP\IUserSession')->getMock();
+		$this->userSession = $this->getMockBuilder(IUserSession::class)->getMock();
 		$this->appManager = $this->getMockBuilder('\OCP\App\IAppManager')->getMock();
-		$this->user = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$this->user = $this->getMockBuilder(IUser::class)->getMock();
 		$this->user->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('testuser1'));
@@ -281,12 +283,12 @@ class ViewControllerTest extends TestCase {
 	}
 
 	public function testShowFileRouteWithFolder() {
-		$node = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$node = $this->getMockBuilder(Folder::class)->getMock();
 		$node->expects($this->once())
 			->method('getPath')
 			->will($this->returnValue('/testuser1/files/test/sub'));
 
-		$baseFolder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$baseFolder = $this->getMockBuilder(Folder::class)->getMock();
 
 		$this->rootFolder->expects($this->once())
 			->method('getUserFolder')
@@ -313,19 +315,19 @@ class ViewControllerTest extends TestCase {
 	}
 
 	public function testShowFileRouteWithFile() {
-		$parentNode = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$parentNode = $this->getMockBuilder(Folder::class)->getMock();
 		$parentNode->expects($this->once())
 			->method('getPath')
 			->will($this->returnValue('testuser1/files/test'));
 
-		$baseFolder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$baseFolder = $this->getMockBuilder(Folder::class)->getMock();
 
 		$this->rootFolder->expects($this->once())
 			->method('getUserFolder')
 			->with('testuser1')
 			->will($this->returnValue($baseFolder));
 
-		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$node = $this->getMockBuilder(File::class)->getMock();
 		$node->expects($this->once())
 			->method('getParent')
 			->will($this->returnValue($parentNode));
@@ -353,7 +355,7 @@ class ViewControllerTest extends TestCase {
 	}
 
 	public function testShowFileRouteWithInvalidFileId() {
-		$baseFolder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$baseFolder = $this->getMockBuilder(Folder::class)->getMock();
 		$this->rootFolder->expects($this->once())
 			->method('getUserFolder')
 			->with('testuser1')
@@ -380,13 +382,13 @@ class ViewControllerTest extends TestCase {
 			->with('files_trashbin')
 			->will($this->returnValue(true));
 
-		$parentNode = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$parentNode = $this->getMockBuilder(Folder::class)->getMock();
 		$parentNode->expects($this->once())
 			->method('getPath')
 			->will($this->returnValue('testuser1/files_trashbin/files/test.d1462861890/sub'));
 
-		$baseFolderFiles = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
-		$baseFolderTrash = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$baseFolderFiles = $this->getMockBuilder(Folder::class)->getMock();
+		$baseFolderTrash = $this->getMockBuilder(Folder::class)->getMock();
 
 		$this->rootFolder->expects($this->at(0))
 			->method('getUserFolder')
@@ -402,7 +404,7 @@ class ViewControllerTest extends TestCase {
 			->with(123)
 			->will($this->returnValue([]));
 
-		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$node = $this->getMockBuilder(File::class)->getMock();
 		$node->expects($this->once())
 			->method('getParent')
 			->will($this->returnValue($parentNode));

--- a/apps/files/tests/Settings/AdminTest.php
+++ b/apps/files/tests/Settings/AdminTest.php
@@ -41,7 +41,7 @@ class AdminTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->iniGetWrapper = $this->getMockBuilder('\bantu\IniGetWrapper\IniGetWrapper')->disableOriginalConstructor()->getMock();
-		$this->request = $this->getMockBuilder('\OCP\IRequest')->getMock();
+		$this->request = $this->getMockBuilder(IRequest::class)->getMock();
 		$this->admin = new Admin(
 			$this->iniGetWrapper,
 			$this->request

--- a/apps/files_external/tests/Auth/AuthMechanismTest.php
+++ b/apps/files_external/tests/Auth/AuthMechanismTest.php
@@ -22,10 +22,14 @@
 
 namespace OCA\Files_External\Tests\Auth;
 
+use OCA\Files_External\Lib\Auth\AuthMechanism;
+use OCA\Files_External\Lib\Backend\Backend;
+use OCA\Files_External\Lib\StorageConfig;
+
 class AuthMechanismTest extends \Test\TestCase {
 
 	public function testJsonSerialization() {
-		$mechanism = $this->getMockBuilder('\OCA\Files_External\Lib\Auth\AuthMechanism')
+		$mechanism = $this->getMockBuilder(AuthMechanism::class)
 			->setMethods(['jsonSerializeDefinition'])
 			->getMock();
 		$mechanism->expects($this->once())
@@ -52,7 +56,7 @@ class AuthMechanismTest extends \Test\TestCase {
 	 * @dataProvider validateStorageProvider
 	 */
 	public function testValidateStorage($expectedSuccess, $scheme, $definitionSuccess) {
-		$mechanism = $this->getMockBuilder('\OCA\Files_External\Lib\Auth\AuthMechanism')
+		$mechanism = $this->getMockBuilder(AuthMechanism::class)
 			->setMethods(['validateStorageDefinition'])
 			->getMock();
 		$mechanism->expects($this->atMost(1))
@@ -61,14 +65,14 @@ class AuthMechanismTest extends \Test\TestCase {
 
 		$mechanism->setScheme($scheme);
 
-		$backend = $this->getMockBuilder('\OCA\Files_External\Lib\Backend\Backend')
+		$backend = $this->getMockBuilder(Backend::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$backend->expects($this->once())
 			->method('getAuthSchemes')
 			->willReturn(['scheme' => true, 'foobar' => true]);
 
-		$storageConfig = $this->getMockBuilder('\OCA\Files_External\Lib\StorageConfig')
+		$storageConfig = $this->getMockBuilder(StorageConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$storageConfig->expects($this->once())

--- a/apps/files_external/tests/Backend/BackendTest.php
+++ b/apps/files_external/tests/Backend/BackendTest.php
@@ -23,11 +23,12 @@
 namespace OCA\Files_External\Tests\Backend;
 
 use \OCA\Files_External\Lib\Backend\Backend;
+use OCA\Files_External\Lib\StorageConfig;
 
 class BackendTest extends \Test\TestCase {
 
 	public function testJsonSerialization() {
-		$backend = $this->getMockBuilder('\OCA\Files_External\Lib\Backend\Backend')
+		$backend = $this->getMockBuilder(Backend::class)
 			->setMethods(['jsonSerializeDefinition'])
 			->getMock();
 		$backend->expects($this->once())
@@ -59,14 +60,14 @@ class BackendTest extends \Test\TestCase {
 	 * @dataProvider validateStorageProvider
 	 */
 	public function testValidateStorage($expectedSuccess, $definitionSuccess) {
-		$backend = $this->getMockBuilder('\OCA\Files_External\Lib\Backend\Backend')
+		$backend = $this->getMockBuilder(Backend::class)
 			->setMethods(['validateStorageDefinition'])
 			->getMock();
 		$backend->expects($this->atMost(1))
 			->method('validateStorageDefinition')
 			->willReturn($definitionSuccess);
 
-		$storageConfig = $this->getMockBuilder('\OCA\Files_External\Lib\StorageConfig')
+		$storageConfig = $this->getMockBuilder(StorageConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/apps/files_external/tests/Controller/StoragesControllerTest.php
+++ b/apps/files_external/tests/Controller/StoragesControllerTest.php
@@ -23,6 +23,8 @@
  */
 namespace OCA\Files_External\Tests\Controller;
 
+use OCA\Files_External\Lib\Auth\AuthMechanism;
+use OCA\Files_External\Lib\Backend\Backend;
 use \OCP\AppFramework\Http;
 
 use \OCA\Files_External\Controller\GlobalStoragesController;
@@ -54,7 +56,7 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 	 * @return \OCA\Files_External\Lib\Backend\Backend
 	 */
 	protected function getBackendMock($class = '\OCA\Files_External\Lib\Backend\SMB', $storageClass = '\OCA\Files_External\Lib\Storage\SMB') {
-		$backend = $this->getMockBuilder('\OCA\Files_External\Lib\Backend\Backend')
+		$backend = $this->getMockBuilder(Backend::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$backend->method('getStorageClass')
@@ -68,7 +70,7 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 	 * @return \OCA\Files_External\Lib\Auth\AuthMechanism
 	 */
 	protected function getAuthMechMock($scheme = 'null', $class = '\OCA\Files_External\Lib\Auth\NullMechanism') {
-		$authMech = $this->getMockBuilder('\OCA\Files_External\Lib\Auth\AuthMechanism')
+		$authMech = $this->getMockBuilder(AuthMechanism::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$authMech->method('getScheme')

--- a/apps/files_external/tests/FrontendDefinitionTraitTest.php
+++ b/apps/files_external/tests/FrontendDefinitionTraitTest.php
@@ -23,10 +23,13 @@
 
 namespace OCA\Files_External\Tests;
 
+use OCA\Files_External\Lib\DefinitionParameter;
+use OCA\Files_External\Lib\StorageConfig;
+
 class FrontendDefinitionTraitTest extends \Test\TestCase {
 
 	public function testJsonSerialization() {
-		$param = $this->getMockBuilder('\OCA\Files_External\Lib\DefinitionParameter')
+		$param = $this->getMockBuilder(DefinitionParameter::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$param->method('getName')->willReturn('foo');
@@ -60,7 +63,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 	public function testValidateStorage($expectedSuccess, $params) {
 		$backendParams = [];
 		foreach ($params as $name => $valid) {
-			$param = $this->getMockBuilder('\OCA\Files_External\Lib\DefinitionParameter')
+			$param = $this->getMockBuilder(DefinitionParameter::class)
 				->disableOriginalConstructor()
 				->getMock();
 			$param->method('getName')
@@ -73,7 +76,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 			$backendParams[] = $param;
 		}
 
-		$storageConfig = $this->getMockBuilder('\OCA\Files_External\Lib\StorageConfig')
+		$storageConfig = $this->getMockBuilder(StorageConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$storageConfig->expects($this->any())
@@ -90,7 +93,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 	}
 
 	public function testValidateStorageSet() {
-		$param = $this->getMockBuilder('\OCA\Files_External\Lib\DefinitionParameter')
+		$param = $this->getMockBuilder(DefinitionParameter::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$param->method('getName')
@@ -102,7 +105,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 				return true;
 			}));
 
-		$storageConfig = $this->getMockBuilder('\OCA\Files_External\Lib\StorageConfig')
+		$storageConfig = $this->getMockBuilder(StorageConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$storageConfig->expects($this->once())

--- a/apps/files_external/tests/Service/BackendServiceTest.php
+++ b/apps/files_external/tests/Service/BackendServiceTest.php
@@ -21,6 +21,8 @@
  */
 namespace OCA\Files_External\Tests\Service;
 
+use OCA\Files_External\Lib\Auth\AuthMechanism;
+use OCA\Files_External\Lib\Backend\Backend;
 use OCA\Files_External\Lib\Config\IAuthMechanismProvider;
 use OCA\Files_External\Lib\Config\IBackendProvider;
 use \OCA\Files_External\Service\BackendService;
@@ -46,7 +48,7 @@ class BackendServiceTest extends \Test\TestCase {
 	 * @return \OCA\Files_External\Lib\Backend\Backend
 	 */
 	protected function getBackendMock($class) {
-		$backend = $this->getMockBuilder('\OCA\Files_External\Lib\Backend\Backend')
+		$backend = $this->getMockBuilder(Backend::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$backend->method('getIdentifier')->will($this->returnValue('identifier:'.$class));
@@ -60,7 +62,7 @@ class BackendServiceTest extends \Test\TestCase {
 	 * @return \OCA\Files_External\Lib\Auth\AuthMechanism
 	 */
 	protected function getAuthMechanismMock($class) {
-		$backend = $this->getMockBuilder('\OCA\Files_External\Lib\Auth\AuthMechanism')
+		$backend = $this->getMockBuilder(AuthMechanism::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$backend->method('getIdentifier')->will($this->returnValue('identifier:'.$class));
@@ -73,7 +75,7 @@ class BackendServiceTest extends \Test\TestCase {
 
 		$backend = $this->getBackendMock('\Foo\Bar');
 
-		$backendAlias = $this->getMockBuilder('\OCA\Files_External\Lib\Backend\Backend')
+		$backendAlias = $this->getMockBuilder(Backend::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$backendAlias->method('getIdentifierAliases')
@@ -175,7 +177,7 @@ class BackendServiceTest extends \Test\TestCase {
 			->method('removeVisibility')
 			->with(BackendService::VISIBILITY_PERSONAL);
 
-		$backendAlias = $this->getMockBuilder('\OCA\Files_External\Lib\Backend\Backend')
+		$backendAlias = $this->getMockBuilder(Backend::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$backendAlias->method('getIdentifierAliases')

--- a/apps/files_external/tests/Service/StoragesServiceTest.php
+++ b/apps/files_external/tests/Service/StoragesServiceTest.php
@@ -27,7 +27,9 @@ namespace OCA\Files_External\Tests\Service;
 
 use \OC\Files\Filesystem;
 
+use OCA\Files_External\Lib\Auth\AuthMechanism;
 use OCA\Files_External\Lib\Auth\InvalidAuth;
+use OCA\Files_External\Lib\Backend\Backend;
 use OCA\Files_External\Lib\Backend\InvalidBackend;
 use OCA\Files_External\NotFoundException;
 use OCA\Files_External\Lib\StorageConfig;
@@ -179,7 +181,7 @@ abstract class StoragesServiceTest extends \Test\TestCase {
 	}
 
 	protected function getBackendMock($class = '\OCA\Files_External\Lib\Backend\SMB', $storageClass = '\OCA\Files_External\Lib\Storage\SMB') {
-		$backend = $this->getMockBuilder('\OCA\Files_External\Lib\Backend\Backend')
+		$backend = $this->getMockBuilder(Backend::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$backend->method('getStorageClass')
@@ -190,7 +192,7 @@ abstract class StoragesServiceTest extends \Test\TestCase {
 	}
 
 	protected function getAuthMechMock($scheme = 'null', $class = '\OCA\Files_External\Lib\Auth\NullMechanism') {
-		$authMech = $this->getMockBuilder('\OCA\Files_External\Lib\Auth\AuthMechanism')
+		$authMech = $this->getMockBuilder(AuthMechanism::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$authMech->method('getScheme')
@@ -204,7 +206,7 @@ abstract class StoragesServiceTest extends \Test\TestCase {
 	/**
 	 * Creates a StorageConfig instance based on array data
 	 *
-	 * @param array data
+	 * @param array $data
 	 *
 	 * @return StorageConfig storage config instance
 	 */

--- a/apps/files_external/tests/Settings/SectionTest.php
+++ b/apps/files_external/tests/Settings/SectionTest.php
@@ -38,8 +38,8 @@ class SectionTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')->disableOriginalConstructor()->getMock();
-		$this->l = $this->getMockBuilder('\OCP\IL10N')->disableOriginalConstructor()->getMock();
+		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)->disableOriginalConstructor()->getMock();
+		$this->l = $this->getMockBuilder(IL10N::class)->disableOriginalConstructor()->getMock();
 
 		$this->section = new Section(
 			$this->urlGenerator,

--- a/apps/files_external/tests/StorageConfigTest.php
+++ b/apps/files_external/tests/StorageConfigTest.php
@@ -25,15 +25,18 @@
 
 namespace OCA\Files_External\Tests;
 
+use OCA\Files_External\Lib\Auth\AuthMechanism;
+use OCA\Files_External\Lib\Backend\Backend;
+use OCA\Files_External\Lib\DefinitionParameter;
 use OCA\Files_External\Lib\StorageConfig;
 
 class StorageConfigTest extends \Test\TestCase {
 
 	public function testJsonSerialization() {
-		$backend = $this->getMockBuilder('\OCA\Files_External\Lib\Backend\Backend')
+		$backend = $this->getMockBuilder(Backend::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$parameter = $this->getMockBuilder('\OCA\Files_External\Lib\DefinitionParameter')
+		$parameter = $this->getMockBuilder(DefinitionParameter::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$parameter
@@ -47,7 +50,7 @@ class StorageConfigTest extends \Test\TestCase {
 		$backend->method('getIdentifier')
 			->willReturn('storage::identifier');
 
-		$authMech = $this->getMockBuilder('\OCA\Files_External\Lib\Auth\AuthMechanism')
+		$authMech = $this->getMockBuilder(AuthMechanism::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$authMech->method('getIdentifier')

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -35,6 +35,8 @@ use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
+use OCP\IL10N;
+use OCP\IRequest;
 
 /**
  * Class ApiTest
@@ -96,7 +98,7 @@ class ApiTest extends TestCase {
 	 * @return \OCA\Files_Sharing\Controller\ShareAPIController
 	 */
 	private function createOCS($userId) {
-		$l = $this->getMockBuilder('\OCP\IL10N')->getMock();
+		$l = $this->getMockBuilder(IL10N::class)->getMock();
 		$l->method('t')
 			->will($this->returnCallback(function($text, $parameters = []) {
 				return vsprintf($text, $parameters);
@@ -104,7 +106,7 @@ class ApiTest extends TestCase {
 
 		return new ShareAPIController(
 			self::APP_NAME,
-			$this->getMockBuilder('OCP\IRequest')->getMock(),
+			$this->getMockBuilder(IRequest::class)->getMock(),
 			$this->shareManager,
 			\OC::$server->getGroupManager(),
 			\OC::$server->getUserManager(),

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -24,6 +24,7 @@
 namespace OCA\Files_Sharing\Tests;
 
 use OCA\Files_Sharing\Capabilities;
+use OCP\IConfig;
 
 
 /**
@@ -54,7 +55,7 @@ class CapabilitiesTest extends \Test\TestCase {
 	 * @return string[]
 	 */
 	private function getResults(array $map) {
-		$config = $this->getMockBuilder('\OCP\IConfig')->disableOriginalConstructor()->getMock();
+		$config = $this->getMockBuilder(IConfig::class)->disableOriginalConstructor()->getMock();
 		$config->method('getAppValue')->will($this->returnValueMap($map));
 		$cap = new Capabilities($config);
 		$result = $this->getFilesSharingPart($cap->getCapabilities());

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -25,7 +25,9 @@ namespace OCA\Files_Sharing\Tests\Controller;
 
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSNotFoundException;
+use OCP\Files\File;
 use OCP\Files\Folder;
+use OCP\Files\Storage;
 use OCP\IL10N;
 use OCA\Files_Sharing\Controller\ShareAPIController;
 use OCP\Files\NotFoundException;
@@ -156,7 +158,7 @@ class ShareAPIControllerTest extends TestCase {
 	}
 
 	public function testDeleteShare() {
-		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$node = $this->getMockBuilder(File::class)->getMock();
 
 		$share = $this->newShare();
 		$share->setSharedBy($this->currentUser)
@@ -187,7 +189,7 @@ class ShareAPIControllerTest extends TestCase {
 	 * @expectedExceptionMessage could not delete share
 	 */
 	public function testDeleteShareLocked() {
-		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$node = $this->getMockBuilder(File::class)->getMock();
 
 		$share = $this->newShare();
 		$share->setSharedBy($this->currentUser)
@@ -464,15 +466,15 @@ class ShareAPIControllerTest extends TestCase {
 			->method('linkToRouteAbsolute')
 			->willReturn('url');
 
-		$initiator = $this->getMockBuilder('OCP\IUser')->getMock();
+		$initiator = $this->getMockBuilder(IUser::class)->getMock();
 		$initiator->method('getUID')->willReturn('initiatorId');
 		$initiator->method('getDisplayName')->willReturn('initiatorDisplay');
 
-		$owner = $this->getMockBuilder('OCP\IUser')->getMock();
+		$owner = $this->getMockBuilder(IUser::class)->getMock();
 		$owner->method('getUID')->willReturn('ownerId');
 		$owner->method('getDisplayName')->willReturn('ownerDisplay');
 
-		$user = $this->getMockBuilder('OCP\IUser')->getMock();
+		$user = $this->getMockBuilder(IUser::class)->getMock();
 		$user->method('getUID')->willReturn('userId');
 		$user->method('getDisplayName')->willReturn('userDisplay');
 
@@ -526,7 +528,7 @@ class ShareAPIControllerTest extends TestCase {
 
 		$share = $this->getMockBuilder('OCP\Share\IShare')->getMock();
 		$share->method('getShareType')->willReturn(\OCP\Share::SHARE_TYPE_USER);
-		$share->method('getSharedWith')->willReturn($this->getMockBuilder('OCP\IUser')->getMock());
+		$share->method('getSharedWith')->willReturn($this->getMockBuilder(IUser::class)->getMock());
 		$this->assertFalse($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
 
 		$share = $this->getMockBuilder('OCP\Share\IShare')->getMock();
@@ -579,7 +581,7 @@ class ShareAPIControllerTest extends TestCase {
 	 * @expectedExceptionMessage Wrong path, file/folder doesn't exist
 	 */
 	public function testCreateShareInvalidPath() {
-		$userFolder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
 		$this->rootFolder->expects($this->once())
 			->method('getUserFolder')
 			->with('currentUser')
@@ -601,13 +603,13 @@ class ShareAPIControllerTest extends TestCase {
 		$share = $this->newShare();
 		$this->shareManager->method('newShare')->willReturn($share);
 
-		$userFolder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
 		$this->rootFolder->expects($this->once())
 				->method('getUserFolder')
 				->with('currentUser')
 				->willReturn($userFolder);
 
-		$path = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$path = $this->getMockBuilder(File::class)->getMock();
 		$userFolder->expects($this->once())
 				->method('get')
 				->with('valid-path')
@@ -628,13 +630,13 @@ class ShareAPIControllerTest extends TestCase {
 		$share = $this->newShare();
 		$this->shareManager->method('newShare')->willReturn($share);
 
-		$userFolder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
 		$this->rootFolder->expects($this->once())
 			->method('getUserFolder')
 			->with('currentUser')
 			->willReturn($userFolder);
 
-		$path = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$path = $this->getMockBuilder(File::class)->getMock();
 		$storage = $this->getMockBuilder('OCP\Files\Storage')->getMock();
 		$storage->method('instanceOfStorage')
 			->with('OCA\Files_Sharing\External\Storage')
@@ -660,13 +662,13 @@ class ShareAPIControllerTest extends TestCase {
 		$share = $this->newShare();
 		$this->shareManager->method('newShare')->willReturn($share);
 
-		$userFolder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
 		$this->rootFolder->expects($this->once())
 			->method('getUserFolder')
 			->with('currentUser')
 			->willReturn($userFolder);
 
-		$path = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$path = $this->getMockBuilder(File::class)->getMock();
 		$storage = $this->getMockBuilder('OCP\Files\Storage')->getMock();
 		$storage->method('instanceOfStorage')
 			->with('OCA\Files_Sharing\External\Storage')
@@ -705,13 +707,13 @@ class ShareAPIControllerTest extends TestCase {
 			])->setMethods(['formatShare'])
 			->getMock();
 
-		$userFolder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
 		$this->rootFolder->expects($this->once())
 				->method('getUserFolder')
 				->with('currentUser')
 				->willReturn($userFolder);
 
-		$path = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$path = $this->getMockBuilder(File::class)->getMock();
 		$storage = $this->getMockBuilder('OCP\Files\Storage')->getMock();
 		$storage->method('instanceOfStorage')
 			->with('OCA\Files_Sharing\External\Storage')
@@ -759,13 +761,13 @@ class ShareAPIControllerTest extends TestCase {
 		$this->shareManager->method('createShare')->will($this->returnArgument(0));
 		$this->shareManager->method('allowGroupSharing')->willReturn(true);
 
-		$userFolder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
 		$this->rootFolder->expects($this->once())
 				->method('getUserFolder')
 				->with('currentUser')
 				->willReturn($userFolder);
 
-		$path = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$path = $this->getMockBuilder(File::class)->getMock();
 		$storage = $this->getMockBuilder('OCP\Files\Storage')->getMock();
 		$storage->method('instanceOfStorage')
 			->with('OCA\Files_Sharing\External\Storage')
@@ -811,13 +813,13 @@ class ShareAPIControllerTest extends TestCase {
 				['shareWith', null, 'validGroup'],
 			]));
 
-		$userFolder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
 		$this->rootFolder->expects($this->once())
 			->method('getUserFolder')
 			->with('currentUser')
 			->willReturn($userFolder);
 
-		$path = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$path = $this->getMockBuilder(Folder::class)->getMock();
 		$storage = $this->getMockBuilder('OCP\Files\Storage')->getMock();
 		$storage->method('instanceOfStorage')
 			->with('OCA\Files_Sharing\External\Storage')
@@ -863,13 +865,13 @@ class ShareAPIControllerTest extends TestCase {
 		$share = $this->newShare();
 		$this->shareManager->method('newShare')->willReturn($share);
 
-		$userFolder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
 		$this->rootFolder->expects($this->once())
 			->method('getUserFolder')
 			->with('currentUser')
 			->willReturn($userFolder);
 
-		$path = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$path = $this->getMockBuilder(Folder::class)->getMock();
 		$storage = $this->getMockBuilder('OCP\Files\Storage')->getMock();
 		$storage->method('instanceOfStorage')
 			->with('OCA\Files_Sharing\External\Storage')
@@ -901,7 +903,7 @@ class ShareAPIControllerTest extends TestCase {
 				['shareType', '-1', \OCP\Share::SHARE_TYPE_LINK],
 			]));
 
-		$path = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$path = $this->getMockBuilder(Folder::class)->getMock();
 		$storage = $this->getMockBuilder('OCP\Files\Storage')->getMock();
 		$storage->method('instanceOfStorage')
 			->with('OCA\Files_Sharing\External\Storage')
@@ -920,7 +922,7 @@ class ShareAPIControllerTest extends TestCase {
 	 * @expectedExceptionMessage Public upload disabled by the administrator
 	 */
 	public function testCreateShareLinkNoPublicUpload() {
-		$path = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$path = $this->getMockBuilder(Folder::class)->getMock();
 		$storage = $this->getMockBuilder('OCP\Files\Storage')->getMock();
 		$storage->method('instanceOfStorage')
 			->with('OCA\Files_Sharing\External\Storage')
@@ -940,7 +942,7 @@ class ShareAPIControllerTest extends TestCase {
 	 * @expectedExceptionMessage Public upload is only possible for publicly shared folders
 	 */
 	public function testCreateShareLinkPublicUploadFile() {
-		$path = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$path = $this->getMockBuilder(File::class)->getMock();
 		$storage = $this->getMockBuilder('OCP\Files\Storage')->getMock();
 		$storage->method('instanceOfStorage')
 			->with('OCA\Files_Sharing\External\Storage')
@@ -959,7 +961,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function testCreateShareLinkPublicUploadFolder() {
 		$ocs = $this->mockFormatShare();
 
-		$path = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$path = $this->getMockBuilder(Folder::class)->getMock();
 		$storage = $this->getMockBuilder('OCP\Files\Storage')->getMock();
 		$storage->method('instanceOfStorage')
 			->with('OCA\Files_Sharing\External\Storage')
@@ -993,7 +995,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function testCreateShareLinkPassword() {
 		$ocs = $this->mockFormatShare();
 
-		$path = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$path = $this->getMockBuilder(Folder::class)->getMock();
 		$storage = $this->getMockBuilder('OCP\Files\Storage')->getMock();
 		$storage->method('instanceOfStorage')
 			->with('OCA\Files_Sharing\External\Storage')
@@ -1037,7 +1039,7 @@ class ShareAPIControllerTest extends TestCase {
 				['password', '', ''],
 			]));
 
-		$path = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$path = $this->getMockBuilder(Folder::class)->getMock();
 		$storage = $this->getMockBuilder('OCP\Files\Storage')->getMock();
 		$storage->method('instanceOfStorage')
 			->with('OCA\Files_Sharing\External\Storage')
@@ -1078,7 +1080,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function testCreateShareInvalidExpireDate() {
 		$ocs = $this->mockFormatShare();
 
-		$path = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$path = $this->getMockBuilder(Folder::class)->getMock();
 		$storage = $this->getMockBuilder('OCP\Files\Storage')->getMock();
 		$storage->method('instanceOfStorage')
 			->with('OCA\Files_Sharing\External\Storage')
@@ -1117,13 +1119,13 @@ class ShareAPIControllerTest extends TestCase {
 			])->setMethods(['formatShare'])
 			->getMock();
 
-		$userFolder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
 		$this->rootFolder->expects($this->once())
 			->method('getUserFolder')
 			->with('currentUser')
 			->willReturn($userFolder);
 
-		$path = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$path = $this->getMockBuilder(Folder::class)->getMock();
 		$storage = $this->getMockBuilder('OCP\Files\Storage')->getMock();
 		$storage->method('instanceOfStorage')
 			->with('OCA\Files_Sharing\External\Storage')
@@ -1153,7 +1155,7 @@ class ShareAPIControllerTest extends TestCase {
 	 * @expectedExceptionMessage Wrong share ID, share doesn't exist
 	 */
 	public function testUpdateShareCantAccess() {
-		$node = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$node = $this->getMockBuilder(Folder::class)->getMock();
 		$share = $this->newShare();
 		$share->setNode($node);
 
@@ -1171,7 +1173,7 @@ class ShareAPIControllerTest extends TestCase {
 	 * @expectedExceptionMessage Wrong or no update parameter given
 	 */
 	public function testUpdateNoParametersLink() {
-		$node = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$node = $this->getMockBuilder(Folder::class)->getMock();
 		$share = $this->newShare();
 		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
 			->setSharedBy($this->currentUser)
@@ -1192,7 +1194,7 @@ class ShareAPIControllerTest extends TestCase {
 	 * @expectedExceptionMessage Wrong or no update parameter given
 	 */
 	public function testUpdateNoParametersOther() {
-		$node = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$node = $this->getMockBuilder(Folder::class)->getMock();
 		$share = $this->newShare();
 		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
 			->setSharedBy($this->currentUser)
@@ -1248,7 +1250,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function testUpdateLinkShareSet() {
 		$ocs = $this->mockFormatShare();
 
-		$folder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folder = $this->getMockBuilder(Folder::class)->getMock();
 
 		$share = \OC::$server->getShareManager()->newShare();
 		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
@@ -1286,7 +1288,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function testUpdateLinkShareEnablePublicUpload($permissions, $publicUpload, $expireDate, $password) {
 		$ocs = $this->mockFormatShare();
 
-		$folder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folder = $this->getMockBuilder(Folder::class)->getMock();
 
 		$share = \OC::$server->getShareManager()->newShare();
 		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
@@ -1321,7 +1323,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function testUpdateLinkShareInvalidDate() {
 		$ocs = $this->mockFormatShare();
 
-		$folder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folder = $this->getMockBuilder(Folder::class)->getMock();
 
 		$share = \OC::$server->getShareManager()->newShare();
 		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
@@ -1359,7 +1361,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function testUpdateLinkSharePublicUploadNotAllowed($permissions, $publicUpload, $expireDate, $password) {
 		$ocs = $this->mockFormatShare();
 
-		$folder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folder = $this->getMockBuilder(Folder::class)->getMock();
 
 		$share = \OC::$server->getShareManager()->newShare();
 		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
@@ -1380,7 +1382,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function testUpdateLinkSharePublicUploadOnFile() {
 		$ocs = $this->mockFormatShare();
 
-		$file = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$file = $this->getMockBuilder(File::class)->getMock();
 
 		$share = \OC::$server->getShareManager()->newShare();
 		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
@@ -1400,7 +1402,7 @@ class ShareAPIControllerTest extends TestCase {
 		$date = new \DateTime('2000-01-01');
 		$date->setTime(0,0,0);
 
-		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$node = $this->getMockBuilder(File::class)->getMock();
 		$share = $this->newShare();
 		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
 			->setSharedBy($this->currentUser)
@@ -1434,7 +1436,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function testUpdateLinkShareExpireDateDoesNotChangeOther() {
 		$ocs = $this->mockFormatShare();
 
-		$node = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$node = $this->getMockBuilder(File::class)->getMock();
 		$share = $this->newShare();
 		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
 			->setSharedBy($this->currentUser)
@@ -1473,7 +1475,7 @@ class ShareAPIControllerTest extends TestCase {
 
 		$date = new \DateTime('2000-01-01');
 
-		$folder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folder = $this->getMockBuilder(Folder::class)->getMock();
 
 		$share = \OC::$server->getShareManager()->newShare();
 		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
@@ -1510,7 +1512,7 @@ class ShareAPIControllerTest extends TestCase {
 
 		$date = new \DateTime('2000-01-01');
 
-		$folder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folder = $this->getMockBuilder(Folder::class)->getMock();
 
 		$share = \OC::$server->getShareManager()->newShare();
 		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
@@ -1546,7 +1548,7 @@ class ShareAPIControllerTest extends TestCase {
 
 		$date = new \DateTime('2000-01-01');
 
-		$folder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$folder = $this->getMockBuilder(Folder::class)->getMock();
 
 		$share = \OC::$server->getShareManager()->newShare();
 		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
@@ -1580,7 +1582,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function testUpdateOtherPermissions() {
 		$ocs = $this->mockFormatShare();
 
-		$file = $this->getMockBuilder('\OCP\Files\File')->getMock();
+		$file = $this->getMockBuilder(File::class)->getMock();
 
 		$share = \OC::$server->getShareManager()->newShare();
 		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
@@ -1750,9 +1752,9 @@ class ShareAPIControllerTest extends TestCase {
 	}
 
 	public function dataFormatShare() {
-		$file = $this->getMockBuilder('\OCP\Files\File')->getMock();
-		$folder = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
-		$parent = $this->getMockBuilder('\OCP\Files\Folder')->getMock();
+		$file = $this->getMockBuilder(File::class)->getMock();
+		$folder = $this->getMockBuilder(Folder::class)->getMock();
+		$parent = $this->getMockBuilder(Folder::class)->getMock();
 
 		$file->method('getMimeType')->willReturn('myMimeType');
 		$folder->method('getMimeType')->willReturn('myFolderMimeType');
@@ -1769,18 +1771,18 @@ class ShareAPIControllerTest extends TestCase {
 
 		$cache = $this->getMockBuilder('OCP\Files\Cache\ICache')->getMock();
 		$cache->method('getNumericStorageId')->willReturn(100);
-		$storage = $this->getMockBuilder('\OCP\Files\Storage')->getMock();
+		$storage = $this->getMockBuilder(Storage::class)->getMock();
 		$storage->method('getId')->willReturn('storageId');
 		$storage->method('getCache')->willReturn($cache);
 
 		$file->method('getStorage')->willReturn($storage);
 		$folder->method('getStorage')->willReturn($storage);
 
-		$owner = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$owner = $this->getMockBuilder(IUser::class)->getMock();
 		$owner->method('getDisplayName')->willReturn('ownerDN');
-		$initiator = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$initiator = $this->getMockBuilder(IUser::class)->getMock();
 		$initiator->method('getDisplayName')->willReturn('initiatorDN');
-		$recipient = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$recipient = $this->getMockBuilder(IUser::class)->getMock();
 		$recipient->method('getDisplayName')->willReturn('recipientDN');
 
 		$result = [];

--- a/apps/files_sharing/tests/Controller/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareControllerTest.php
@@ -35,6 +35,12 @@ use OC\Files\Filesystem;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\Files_Sharing\Controller\ShareController;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\ILogger;
+use OCP\IPreview;
+use OCP\IRequest;
+use OCP\IUser;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\AppFramework\Http\NotFoundResponse;
 use OCP\AppFramework\Http\RedirectResponse;
@@ -83,11 +89,11 @@ class ShareControllerTest extends \Test\TestCase {
 		$this->appName = 'files_sharing';
 
 		$this->shareManager = $this->getMockBuilder('\OC\Share20\Manager')->disableOriginalConstructor()->getMock();
-		$this->urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')->getMock();
-		$this->session = $this->getMockBuilder('\OCP\ISession')->getMock();
-		$this->previewManager = $this->getMockBuilder('\OCP\IPreview')->getMock();
-		$this->config = $this->getMockBuilder('\OCP\IConfig')->getMock();
-		$this->userManager = $this->getMockBuilder('\OCP\IUserManager')->getMock();
+		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)->getMock();
+		$this->session = $this->getMockBuilder(ISession::class)->getMock();
+		$this->previewManager = $this->getMockBuilder(IPreview::class)->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
+		$this->userManager = $this->getMockBuilder(IUserManager::class)->getMock();
 		$this->federatedShareProvider = $this->getMockBuilder('OCA\FederatedFileSharing\FederatedShareProvider')
 			->disableOriginalConstructor()->getMock();
 		$this->federatedShareProvider->expects($this->any())
@@ -98,11 +104,11 @@ class ShareControllerTest extends \Test\TestCase {
 
 		$this->shareController = new \OCA\Files_Sharing\Controller\ShareController(
 			$this->appName,
-			$this->getMockBuilder('\OCP\IRequest')->getMock(),
+			$this->getMockBuilder(IRequest::class)->getMock(),
 			$this->config,
 			$this->urlGenerator,
 			$this->userManager,
-			$this->getMockBuilder('\OCP\ILogger')->getMock(),
+			$this->getMockBuilder(ILogger::class)->getMock(),
 			$this->getMockBuilder('\OCP\Activity\IManager')->getMock(),
 			$this->shareManager,
 			$this->session,
@@ -110,7 +116,7 @@ class ShareControllerTest extends \Test\TestCase {
 			$this->getMockBuilder('\OCP\Files\IRootFolder')->getMock(),
 			$this->federatedShareProvider,
 			$this->eventDispatcher,
-			$this->getMockBuilder('\OCP\IL10N')->getMock(),
+			$this->getMockBuilder(IL10N::class)->getMock(),
 			$this->getMockBuilder('\OCP\Defaults')->getMock()
 		);
 
@@ -320,7 +326,7 @@ class ShareControllerTest extends \Test\TestCase {
 
 
 	public function testShowShare() {
-		$owner = $this->getMockBuilder('OCP\IUser')->getMock();
+		$owner = $this->getMockBuilder(IUser::class)->getMock();
 		$owner->method('getDisplayName')->willReturn('ownerDisplay');
 		$owner->method('getUID')->willReturn('ownerUID');
 
@@ -412,7 +418,7 @@ class ShareControllerTest extends \Test\TestCase {
 	 * @expectedException \OCP\Files\NotFoundException
 	 */
 	public function testShowShareInvalid() {
-		$owner = $this->getMockBuilder('OCP\IUser')->getMock();
+		$owner = $this->getMockBuilder(IUser::class)->getMock();
 		$owner->method('getDisplayName')->willReturn('ownerDisplay');
 		$owner->method('getUID')->willReturn('ownerUID');
 

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -27,7 +27,6 @@ namespace OCA\Files_Sharing\Tests\External;
 
 use OC\Federation\CloudIdManager;
 use OC\Files\Storage\StorageFactory;
-use OCA\FederatedFileSharing\DiscoveryManager;
 use OCA\Files_Sharing\External\Manager;
 use OCA\Files_Sharing\External\MountProvider;
 use OCA\Files_Sharing\Tests\TestCase;
@@ -68,7 +67,7 @@ class ManagerTest extends TestCase {
 		$this->createUser($this->uid, '');
 		$this->user = \OC::$server->getUserManager()->get($this->uid);
 		$this->mountManager = new \OC\Files\Mount\Manager();
-		$this->clientService = $this->getMockBuilder('\OCP\Http\Client\IClientService')
+		$this->clientService = $this->getMockBuilder(IClientService::class)
 			->disableOriginalConstructor()->getMock();
 
 		$this->manager = new Manager(

--- a/apps/files_sharing/tests/MountProviderTest.php
+++ b/apps/files_sharing/tests/MountProviderTest.php
@@ -60,11 +60,11 @@ class MountProviderTest extends \Test\TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->config = $this->getMockBuilder('OCP\IConfig')->getMock();
-		$this->user = $this->getMockBuilder('OCP\IUser')->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
+		$this->user = $this->getMockBuilder(IUser::class)->getMock();
 		$this->loader = $this->getMockBuilder('OCP\Files\Storage\IStorageFactory')->getMock();
-		$this->shareManager = $this->getMockBuilder('\OCP\Share\IManager')->getMock();
-		$this->logger = $this->getMockBuilder('\OCP\ILogger')->getMock();
+		$this->shareManager = $this->getMockBuilder(IManager::class)->getMock();
+		$this->logger = $this->getMockBuilder(ILogger::class)->getMock();
 
 		$this->provider = new MountProvider($this->config, $this->shareManager, $this->logger);
 	}

--- a/apps/files_trashbin/tests/ExpirationTest.php
+++ b/apps/files_trashbin/tests/ExpirationTest.php
@@ -23,6 +23,7 @@
 
 use OCA\Files_Trashbin\Expiration;
 use \OCA\Files_Trashbin\Tests;
+use OCP\IConfig;
 
 class ExpirationTest extends \Test\TestCase {
 	const SECONDS_PER_DAY = 86400; //60*60*24
@@ -200,10 +201,10 @@ class ExpirationTest extends \Test\TestCase {
 	/**
 	 *
 	 * @param string $returnValue
-	 * @return \OCP\IConfig
+	 * @return IConfig
 	 */
 	private function getMockedConfig($returnValue){
-		$mockedConfig = $this->getMockBuilder('\OCP\IConfig')
+		$mockedConfig = $this->getMockBuilder(IConfig::class)
 				->disableOriginalConstructor()
 				->setMethods(
 					[

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -37,6 +37,7 @@ use OCP\Files\Cache\ICache;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\ILogger;
+use OCP\IUserManager;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
@@ -535,7 +536,7 @@ class StorageTest extends \Test\TestCase {
 		$tmpStorage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
 			->disableOriginalConstructor()->getMock($cache);
 		$tmpStorage->expects($this->any())->method('getCache')->willReturn($cache);
-		$userManager = $this->getMockBuilder('OCP\IUserManager')
+		$userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()->getMock();
 		$userManager->expects($this->any())
 			->method('userExists')->willReturn($userExists);

--- a/apps/files_versions/tests/ExpirationTest.php
+++ b/apps/files_versions/tests/ExpirationTest.php
@@ -24,6 +24,7 @@
 namespace OCA\Files_Versions\Tests;
 
 use \OCA\Files_Versions\Expiration;
+use OCP\IConfig;
 
 class ExpirationTest extends \Test\TestCase {
 	const SECONDS_PER_DAY = 86400; //60*60*24
@@ -172,7 +173,7 @@ class ExpirationTest extends \Test\TestCase {
 	 * @return \OCP\IConfig
 	 */
 	private function getMockedConfig($returnValue){
-		$mockedConfig = $this->getMockBuilder('\OCP\IConfig')
+		$mockedConfig = $this->getMockBuilder(IConfig::class)
 				->disableOriginalConstructor()
 				->setMethods(
 					[

--- a/apps/provisioning_api/tests/Controller/AppsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/AppsControllerTest.php
@@ -28,10 +28,9 @@
 namespace OCA\Provisioning_API\Tests\Controller;
 
 
-use OC\OCSClient;
 use OCA\Provisioning_API\Controller\AppsController;
-use OCP\API;
 use OCP\App\IAppManager;
+use OCP\IRequest;
 use OCP\IUserSession;
 
 /**
@@ -56,7 +55,7 @@ class AppsControllerTest extends \OCA\Provisioning_API\Tests\TestCase {
 		$this->groupManager = \OC::$server->getGroupManager();
 		$this->userSession = \OC::$server->getUserSession();
 
-		$request = $this->getMockBuilder('OCP\IRequest')
+		$request = $this->getMockBuilder(IRequest::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
@@ -29,6 +29,8 @@ namespace OCA\Provisioning_API\Tests\Controller;
 use OCA\Provisioning_API\Controller\GroupsController;
 use OCP\IGroupManager;
 use OCP\ILogger;
+use OCP\IRequest;
+use OCP\IUser;
 use OCP\IUserSession;
 
 class GroupsControllerTest extends \Test\TestCase {
@@ -59,7 +61,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		$this->userSession = $this->getMockBuilder('OCP\IUserSession')
 			->disableOriginalConstructor()
 			->getMock();
-		$request = $this->getMockBuilder('OCP\IRequest')
+		$request = $this->getMockBuilder(IRequest::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -91,7 +93,7 @@ class GroupsControllerTest extends \Test\TestCase {
 	 * @return \OCP\IUser|\PHPUnit_Framework_MockObject_MockObject
 	 */
 	private function createUser($uid) {
-		$user = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$user = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$user
 			->method('getUID')
 			->willReturn($uid);

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -1128,12 +1128,12 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testEditUserAdminUserSelfEditChangeValidQuota() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('UID'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetUser->expects($this->once())
 			->method('setQuota')
 			->with('2.9 MB');
@@ -1166,12 +1166,12 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionMessage Invalid quota value ABC
 	 */
 	public function testEditUserAdminUserSelfEditChangeInvalidQuota() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('UID'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -1195,12 +1195,12 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testEditUserAdminUserEditChangeValidQuota() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('admin'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetUser->expects($this->once())
 			->method('setQuota')
 			->with('2.9 MB');
@@ -1413,12 +1413,12 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testEditUserSubadminUserAccessible() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetUser->expects($this->once())
 			->method('setQuota')
 			->with('2.9 MB');
@@ -1456,12 +1456,12 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionCode 997
 	 */
 	public function testEditUserSubadminUserInaccessible() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -1496,7 +1496,7 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionCode 101
 	 */
 	public function testDeleteUserNotExistingUser() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
@@ -1519,12 +1519,12 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionCode 101
 	 */
 	public function testDeleteUserSelf() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('UID'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1543,12 +1543,12 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testDeleteSuccessfulUserAsAdmin() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('admin'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1580,12 +1580,12 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionCode 101
 	 */
 	public function testDeleteUnsuccessfulUserAsAdmin() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('admin'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1613,12 +1613,12 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testDeleteSuccessfulUserAsSubadmin() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1661,12 +1661,12 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionCode 101
 	 */
 	public function testDeleteUnsuccessfulUserAsSubadmin() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1709,12 +1709,12 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionCode 997
 	 */
 	public function testDeleteUserAsSubAdminAndUserIsNotAccessible() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1753,7 +1753,7 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionCode 998
 	 */
 	public function testGetUsersGroupsTargetUserNotExisting() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -1763,12 +1763,12 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testGetUsersGroupsSelfTargetted() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
 			->will($this->returnValue('UserToLookup'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1792,12 +1792,12 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testGetUsersGroupsForAdminUser() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->exactly(2))
 			->method('getUID')
 			->will($this->returnValue('admin'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1826,12 +1826,12 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testGetUsersGroupsForSubAdminUserAndUserIsAccessible() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->exactly(2))
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -1890,12 +1890,12 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionCode 997
 	 */
 	public function testGetUsersGroupsForSubAdminUserAndUserIsInaccessible() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->exactly(2))
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -2108,7 +2108,7 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionCode 101
 	 */
 	public function testRemoveFromGroupWithNoTargetGroup() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -2122,7 +2122,7 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionCode 101
 	 */
 	public function testRemoveFromGroupWithEmptyTargetGroup() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -2136,7 +2136,7 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionCode 102
 	 */
 	public function testRemoveFromGroupWithNotExistingTargetGroup() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -2155,7 +2155,7 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionCode 103
 	 */
 	public function testRemoveFromGroupWithNotExistingTargetUser() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
@@ -2180,12 +2180,12 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionCode 104
 	 */
 	public function testRemoveFromGroupWithoutPermission() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->once())
 			->method('getUID')
 			->will($this->returnValue('unauthorizedUser'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
@@ -2222,12 +2222,12 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionMessage Cannot remove yourself from the admin group
 	 */
 	public function testRemoveFromGroupAsAdminFromAdmin() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('admin'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -2272,12 +2272,12 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionMessage Cannot remove yourself from this group as you are a SubAdmin
 	 */
 	public function testRemoveFromGroupAsSubAdminFromSubAdmin() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetUser
 			->expects($this->once())
 			->method('getUID')
@@ -2327,12 +2327,12 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionMessage Cannot remove user from this group as this is the only remaining group you are a SubAdmin of
 	 */
 	public function testRemoveFromGroupAsSubAdminFromLastSubAdminGroup() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$targetGroup
 			->expects($this->any())
@@ -2384,12 +2384,12 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testRemoveFromGroupSuccessful() {
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('admin'));
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
@@ -2446,7 +2446,7 @@ class UsersControllerTest extends TestCase {
 	 */
 	public function testAddSubAdminWithNotExistingTargetGroup() {
 
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -2467,7 +2467,7 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionMessage Cannot create subadmins for admin group
 	 */
 	public function testAddSubAdminToAdminGroup() {
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$targetGroup
 			->expects($this->once())
@@ -2488,7 +2488,7 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testAddSubAdminTwice() {
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
@@ -2516,7 +2516,7 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testAddSubAdminSuccessful() {
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
@@ -2554,7 +2554,7 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionMessage Unknown error occurred
 	 */
 	public function testAddSubAdminUnsuccessful() {
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
@@ -2607,7 +2607,7 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionMessage Group does not exist
 	 */
 	public function testRemoveSubAdminNotExistingTargetGroup() {
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -2629,7 +2629,7 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionMessage User is not a subadmin of this group
 	 */
 	public function testRemoveSubAdminFromNotASubadmin() {
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
@@ -2657,7 +2657,7 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testRemoveSubAdminSuccessful() {
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
@@ -2695,7 +2695,7 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionMessage Unknown error occurred
 	 */
 	public function testRemoveSubAdminUnsuccessful() {
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
@@ -2743,7 +2743,7 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testGetUserSubAdminGroupsWithGroups() {
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
 		$targetGroup
 			->expects($this->once())
@@ -2775,7 +2775,7 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionMessage Unknown error occurred
 	 */
 	public function testGetUserSubAdminGroupsWithoutGroups() {
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -2797,7 +2797,7 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testEnableUser() {
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetUser->expects($this->once())
 			->method('setEnabled')
 			->with(true);
@@ -2806,7 +2806,7 @@ class UsersControllerTest extends TestCase {
 			->method('get')
 			->with('RequestedUser')
 			->will($this->returnValue($targetUser));
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->exactly(2))
 			->method('getUID')
@@ -2824,7 +2824,7 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testDisableUser() {
-		$targetUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$targetUser->expects($this->once())
 			->method('setEnabled')
 			->with(false);
@@ -2833,7 +2833,7 @@ class UsersControllerTest extends TestCase {
 			->method('get')
 			->with('RequestedUser')
 			->will($this->returnValue($targetUser));
-		$loggedInUser = $this->getMockBuilder('\OCP\IUser')->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser
 			->expects($this->exactly(2))
 			->method('getUID')
@@ -2974,14 +2974,14 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionCode 997
 	 */
 	public function testResendWelcomeMessageAsSubAdminAndUserIsNotAccessible() {
-		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+		$loggedInUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$loggedInUser
 			->expects($this->exactly(1))
 			->method('getUID')
 			->will($this->returnValue('subadmin'));
-		$targetUser = $this->getMockBuilder('OCP\IUser')
+		$targetUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->userSession
@@ -3020,10 +3020,10 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionMessage Email address not available
 	 */
 	public function testResendWelcomeMessageNoEmail() {
-		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+		$loggedInUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$targetUser = $this->getMockBuilder('OCP\IUser')
+		$targetUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->userSession
@@ -3061,10 +3061,10 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionMessage Email address not available
 	 */
 	public function testResendWelcomeMessageNullEmail() {
-		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+		$loggedInUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$targetUser = $this->getMockBuilder('OCP\IUser')
+		$targetUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->userSession
@@ -3097,10 +3097,10 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testResendWelcomeMessageSuccess() {
-		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+		$loggedInUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$targetUser = $this->getMockBuilder('OCP\IUser')
+		$targetUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$targetUser
@@ -3167,10 +3167,10 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testResendWelcomeMessageSuccessWithFallbackLanguage() {
-		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+		$loggedInUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$targetUser = $this->getMockBuilder('OCP\IUser')
+		$targetUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$targetUser
@@ -3242,10 +3242,10 @@ class UsersControllerTest extends TestCase {
 	 * @expectedExceptionMessage Sending email failed
 	 */
 	public function testResendWelcomeMessageFailed() {
-		$loggedInUser = $this->getMockBuilder('OCP\IUser')
+		$loggedInUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$targetUser = $this->getMockBuilder('OCP\IUser')
+		$targetUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$targetUser

--- a/apps/sharebymail/tests/ShareByMailProviderTest.php
+++ b/apps/sharebymail/tests/ShareByMailProviderTest.php
@@ -103,17 +103,17 @@ class ShareByMailProviderTest extends TestCase {
 		$this->shareManager = \OC::$server->getShareManager();
 		$this->connection = \OC::$server->getDatabaseConnection();
 
-		$this->l = $this->getMockBuilder('OCP\IL10N')->getMock();
+		$this->l = $this->getMockBuilder(IL10N::class)->getMock();
 		$this->l->method('t')
 			->will($this->returnCallback(function($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			}));
-		$this->logger = $this->getMockBuilder('OCP\ILogger')->getMock();
+		$this->logger = $this->getMockBuilder(ILogger::class)->getMock();
 		$this->rootFolder = $this->getMockBuilder('OCP\Files\IRootFolder')->getMock();
-		$this->userManager = $this->getMockBuilder('OCP\IUserManager')->getMock();
+		$this->userManager = $this->getMockBuilder(IUserManager::class)->getMock();
 		$this->secureRandom = $this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock();
 		$this->mailer = $this->getMockBuilder('\OCP\Mail\IMailer')->getMock();
-		$this->urlGenerator = $this->getMockBuilder('\OCP\IUrlGenerator')->getMock();
+		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)->getMock();
 		$this->share = $this->getMockBuilder('\OCP\Share\IShare')->getMock();
 		$this->activityManager = $this->getMockBuilder('OCP\Activity\IManager')->getMock();
 		$this->settingsManager = $this->getMockBuilder(SettingsManager::class)->disableOriginalConstructor()->getMock();

--- a/apps/theming/tests/Controller/IconControllerTest.php
+++ b/apps/theming/tests/Controller/IconControllerTest.php
@@ -61,7 +61,7 @@ class IconControllerTest extends TestCase {
 	private $imageManager;
 
 	public function setUp() {
-		$this->request = $this->getMockBuilder('OCP\IRequest')->getMock();
+		$this->request = $this->getMockBuilder(IRequest::class)->getMock();
 		$this->themingDefaults = $this->getMockBuilder('OCA\Theming\ThemingDefaults')
 			->disableOriginalConstructor()->getMock();
 		$this->util = $this->getMockBuilder('\OCA\Theming\Util')->disableOriginalConstructor()
@@ -69,7 +69,7 @@ class IconControllerTest extends TestCase {
 		$this->timeFactory = $this->getMockBuilder('OCP\AppFramework\Utility\ITimeFactory')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->config = $this->getMockBuilder('OCP\IConfig')->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->iconBuilder = $this->getMockBuilder('OCA\Theming\IconBuilder')
 			->disableOriginalConstructor()->getMock();
 		$this->imageManager = $this->getMockBuilder('OCA\Theming\ImageManager')->disableOriginalConstructor()->getMock();

--- a/apps/theming/tests/IconBuilderTest.php
+++ b/apps/theming/tests/IconBuilderTest.php
@@ -51,7 +51,7 @@ class IconBuilderTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->config = $this->getMockBuilder('\OCP\IConfig')->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->appData = $this->createMock(IAppData::class);
 		$this->themingDefaults = $this->getMockBuilder('OCA\Theming\ThemingDefaults')
 			->disableOriginalConstructor()->getMock();

--- a/apps/theming/tests/ImageManagerTest.php
+++ b/apps/theming/tests/ImageManagerTest.php
@@ -40,7 +40,7 @@ class ImageManager extends TestCase {
 
 	protected function setUp() {
 		parent::setUp();
-		$this->config = $this->getMockBuilder('\OCP\IConfig')->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->appData = $this->getMockBuilder('OCP\Files\IAppData')->getMock();
 		$this->imageManager = new \OCA\Theming\ImageManager(
 			$this->config,

--- a/apps/theming/tests/Settings/AdminTest.php
+++ b/apps/theming/tests/Settings/AdminTest.php
@@ -45,10 +45,10 @@ class AdminTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->config = $this->getMockBuilder('\OCP\IConfig')->getMock();
-		$this->l10n = $this->getMockBuilder('\OCP\IL10N')->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
+		$this->l10n = $this->getMockBuilder(IL10N::class)->getMock();
 		$this->themingDefaults = $this->getMockBuilder('\OCA\Theming\ThemingDefaults')->disableOriginalConstructor()->getMock();
-		$this->urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')->getMock();
+		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)->getMock();
 
 		$this->admin = new Admin(
 			$this->config,

--- a/apps/user_ldap/tests/Settings/AdminTest.php
+++ b/apps/user_ldap/tests/Settings/AdminTest.php
@@ -43,7 +43,7 @@ class AdminTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->l10n = $this->getMockBuilder('\OCP\IL10N')->getMock();
+		$this->l10n = $this->getMockBuilder(IL10N::class)->getMock();
 
 		$this->admin = new Admin(
 			$this->l10n

--- a/apps/user_ldap/tests/User/UserTest.php
+++ b/apps/user_ldap/tests/User/UserTest.php
@@ -38,6 +38,7 @@ use OCP\Image;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
+use OCP\Notification\INotification;
 
 /**
  * Class UserTest
@@ -134,7 +135,7 @@ class UserTest extends \Test\TestCase {
 		$uid = 'alice';
 		$dn  = 'uid=alice,dc=foo,dc=bar';
 
-		$uuser = $this->getMockBuilder('\OCP\IUser')
+		$uuser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$uuser->expects($this->once())
@@ -1279,7 +1280,7 @@ class UserTest extends \Test\TestCase {
 				return array();
 			}));
 
-		$notification = $this->getMockBuilder('OCP\Notification\INotification')
+		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$notification->expects($this->any())
@@ -1353,7 +1354,7 @@ class UserTest extends \Test\TestCase {
 				return array();
 			}));
 
-		$notification = $this->getMockBuilder('OCP\Notification\INotification')
+		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$notification->expects($this->any())

--- a/apps/workflowengine/tests/Check/AbstractStringCheckTest.php
+++ b/apps/workflowengine/tests/Check/AbstractStringCheckTest.php
@@ -21,11 +21,12 @@
 
 namespace OCA\WorkflowEngine\Tests\Check;
 
+use OCP\IL10N;
 
 class AbstractStringCheckTest extends \Test\TestCase {
 
 	protected function getCheckMock() {
-		$l = $this->getMockBuilder('OCP\IL10N')
+		$l = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$l->expects($this->any())

--- a/apps/workflowengine/tests/Check/RequestRemoteAddressTest.php
+++ b/apps/workflowengine/tests/Check/RequestRemoteAddressTest.php
@@ -21,6 +21,8 @@
 
 namespace OCA\WorkflowEngine\Tests\Check;
 
+use OCP\IL10N;
+use OCP\IRequest;
 
 class RequestRemoteAddressTest extends \Test\TestCase {
 
@@ -31,7 +33,7 @@ class RequestRemoteAddressTest extends \Test\TestCase {
 	 * @return \OCP\IL10N|\PHPUnit_Framework_MockObject_MockObject
 	 */
 	protected function getL10NMock() {
-		$l = $this->getMockBuilder('OCP\IL10N')
+		$l = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$l->expects($this->any())
@@ -45,7 +47,7 @@ class RequestRemoteAddressTest extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->request = $this->getMockBuilder('OCP\IRequest')
+		$this->request = $this->getMockBuilder(IRequest::class)
 			->getMock();
 	}
 

--- a/apps/workflowengine/tests/Check/RequestTimeTest.php
+++ b/apps/workflowengine/tests/Check/RequestTimeTest.php
@@ -21,6 +21,7 @@
 
 namespace OCA\WorkflowEngine\Tests\Check;
 
+use OCP\IL10N;
 
 class RequestTimeTest extends \Test\TestCase {
 
@@ -31,7 +32,7 @@ class RequestTimeTest extends \Test\TestCase {
 	 * @return \OCP\IL10N|\PHPUnit_Framework_MockObject_MockObject
 	 */
 	protected function getL10NMock() {
-		$l = $this->getMockBuilder('OCP\IL10N')
+		$l = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$l->expects($this->any())

--- a/tests/Core/Controller/AvatarControllerTest.php
+++ b/tests/Core/Controller/AvatarControllerTest.php
@@ -85,16 +85,16 @@ class AvatarControllerTest extends \Test\TestCase {
 		$this->avatarManager = $this->getMockBuilder('OCP\IAvatarManager')->getMock();
 		$this->cache = $this->getMockBuilder('OCP\ICache')
 			->disableOriginalConstructor()->getMock();
-		$this->l = $this->getMockBuilder('OCP\IL10N')->getMock();
+		$this->l = $this->getMockBuilder(IL10N::class)->getMock();
 		$this->l->method('t')->will($this->returnArgument(0));
-		$this->userManager = $this->getMockBuilder('OCP\IUserManager')->getMock();
-		$this->request = $this->getMockBuilder('OCP\IRequest')->getMock();
+		$this->userManager = $this->getMockBuilder(IUserManager::class)->getMock();
+		$this->request = $this->getMockBuilder(IRequest::class)->getMock();
 		$this->rootFolder = $this->getMockBuilder('OCP\Files\IRootFolder')->getMock();
-		$this->logger = $this->getMockBuilder('OCP\ILogger')->getMock();
+		$this->logger = $this->getMockBuilder(ILogger::class)->getMock();
 		$this->timeFactory = $this->getMockBuilder('OC\AppFramework\Utility\TimeFactory')->getMock();
 
 		$this->avatarMock = $this->getMockBuilder('OCP\IAvatar')->getMock();
-		$this->userMock = $this->getMockBuilder('OCP\IUser')->getMock();
+		$this->userMock = $this->getMockBuilder(IUser::class)->getMock();
 
 		$this->avatarController = new AvatarController(
 			'core',

--- a/tests/Core/Controller/ChangePasswordControllerTest.php
+++ b/tests/Core/Controller/ChangePasswordControllerTest.php
@@ -29,6 +29,7 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IUser;
 use OCP\IUserManager;
 
 class ChangePasswordControllerTest extends \Test\TestCase {
@@ -91,7 +92,7 @@ class ChangePasswordControllerTest extends \Test\TestCase {
 	}
 
 	public function testChangePersonalPasswordCommonPassword() {
-		$user = $this->getMockBuilder('OCP\IUser')->getMock();
+		$user = $this->getMockBuilder(IUser::class)->getMock();
 		$this->userManager->expects($this->once())
 			->method('checkPassword')
 			->with($this->userId, 'old')
@@ -114,7 +115,7 @@ class ChangePasswordControllerTest extends \Test\TestCase {
 	}
 
 	public function testChangePersonalPasswordNoNewPassword() {
-		$user = $this->getMockBuilder('OCP\IUser')->getMock();
+		$user = $this->getMockBuilder(IUser::class)->getMock();
 		$this->userManager->expects($this->once())
 			->method('checkPassword')
 			->with($this->userId, 'old')
@@ -130,7 +131,7 @@ class ChangePasswordControllerTest extends \Test\TestCase {
 	}
 
 	public function testChangePersonalPasswordCantSetPassword() {
-		$user = $this->getMockBuilder('OCP\IUser')->getMock();
+		$user = $this->getMockBuilder(IUser::class)->getMock();
 		$this->userManager->expects($this->once())
 			->method('checkPassword')
 			->with($this->userId, 'old')
@@ -150,7 +151,7 @@ class ChangePasswordControllerTest extends \Test\TestCase {
 	}
 
 	public function testChangePersonalPassword() {
-		$user = $this->getMockBuilder('OCP\IUser')->getMock();
+		$user = $this->getMockBuilder(IUser::class)->getMock();
 		$this->userManager->expects($this->once())
 			->method('checkPassword')
 			->with($this->userId, 'old')

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -105,9 +105,9 @@ class LostControllerTest extends \Test\TestCase {
 			}));
 		$this->defaults = $this->getMockBuilder('\OCP\Defaults')
 			->disableOriginalConstructor()->getMock();
-		$this->userManager = $this->getMockBuilder('\OCP\IUserManager')
+		$this->userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()->getMock();
-		$this->urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()->getMock();
 		$this->mailer = $this->getMockBuilder('\OCP\Mail\IMailer')
 			->disableOriginalConstructor()->getMock();
@@ -115,7 +115,7 @@ class LostControllerTest extends \Test\TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->timeFactory = $this->getMockBuilder('\OCP\AppFramework\Utility\ITimeFactory')
 			->disableOriginalConstructor()->getMock();
-		$this->request = $this->getMockBuilder('OCP\IRequest')
+		$this->request = $this->getMockBuilder(IRequest::class)
 			->disableOriginalConstructor()->getMock();
 		$this->encryptionManager = $this->getMockBuilder(IManager::class)
 			->disableOriginalConstructor()->getMock();

--- a/tests/Core/Middleware/TwoFactorMiddlewareTest.php
+++ b/tests/Core/Middleware/TwoFactorMiddlewareTest.php
@@ -22,8 +22,10 @@
 
 namespace Test\Core\Middleware;
 
+use OC\Authentication\TwoFactorAuth\Manager;
 use OC\Core\Middleware\TwoFactorMiddleware;
 use OC\AppFramework\Http\Request;
+use OC\User\Session;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Utility\IControllerMethodReflector;
 use OCP\IConfig;
@@ -51,10 +53,10 @@ class TwoFactorMiddlewareTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->twoFactorManager = $this->getMockBuilder('\OC\Authentication\TwoFactorAuth\Manager')
+		$this->twoFactorManager = $this->getMockBuilder(Manager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->userSession = $this->getMockBuilder('\OC\User\Session')
+		$this->userSession = $this->getMockBuilder(Session::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->session = $this->createMock(ISession::class);

--- a/tests/Settings/Controller/AdminSettingsControllerTest.php
+++ b/tests/Settings/Controller/AdminSettingsControllerTest.php
@@ -25,6 +25,7 @@ namespace Tests\Settings\Controller;
 use OC\Settings\Admin\TipsTricks;
 use OC\Settings\Controller\AdminSettingsController;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IConfig;
 use OCP\INavigationManager;
 use OCP\IRequest;
 use OCP\Settings\IManager;
@@ -52,9 +53,9 @@ class AdminSettingsControllerTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->request = $this->getMockBuilder('\OCP\IRequest')->getMock();
-		$this->navigationManager = $this->getMockBuilder('\OCP\INavigationManager')->getMock();
-		$this->settingsManager = $this->getMockBuilder('\OCP\Settings\IManager')->getMock();
+		$this->request = $this->getMockBuilder(IRequest::class)->getMock();
+		$this->navigationManager = $this->getMockBuilder(INavigationManager::class)->getMock();
+		$this->settingsManager = $this->getMockBuilder(IManager::class)->getMock();
 
 		$this->adminSettingsController = new AdminSettingsController(
 			'settings',
@@ -87,7 +88,7 @@ class AdminSettingsControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getAdminSettings')
 			->with('test')
-			->willReturn([5 => new TipsTricks($this->getMockBuilder('\OCP\IConfig')->getMock())]);
+			->willReturn([5 => new TipsTricks($this->getMockBuilder(IConfig::class)->getMock())]);
 
 		$expected = new TemplateResponse('settings', 'settings/frame', ['forms' => ['personal' => [], 'admin' => []], 'content' => '']);
 		$this->assertEquals($expected, $this->adminSettingsController->index('test'));

--- a/tests/Settings/Controller/CertificateControllerTest.php
+++ b/tests/Settings/Controller/CertificateControllerTest.php
@@ -51,10 +51,10 @@ class CertificateControllerTest extends \Test\TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->request = $this->getMockBuilder('\OCP\IRequest')->getMock();
+		$this->request = $this->getMockBuilder(IRequest::class)->getMock();
 		$this->certificateManager = $this->getMockBuilder('\OCP\ICertificateManager')->getMock();
 		$this->systemCertificateManager = $this->getMockBuilder('\OCP\ICertificateManager')->getMock();
-		$this->l10n = $this->getMockBuilder('\OCP\IL10N')->getMock();
+		$this->l10n = $this->getMockBuilder(IL10N::class)->getMock();
 		$this->appManager = $this->getMockBuilder('OCP\App\IAppManager')->getMock();
 
 		$this->certificateController = $this->getMockBuilder('OC\Settings\Controller\CertificateController')

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -64,17 +64,17 @@ class CheckSetupControllerTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->request = $this->getMockBuilder('\OCP\IRequest')
+		$this->request = $this->getMockBuilder(IRequest::class)
 			->disableOriginalConstructor()->getMock();
-		$this->config = $this->getMockBuilder('\OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()->getMock();
-		$this->clientService = $this->getMockBuilder('\OCP\Http\Client\IClientService')
+		$this->clientService = $this->getMockBuilder(IClientService::class)
 			->disableOriginalConstructor()->getMock();
 		$this->util = $this->getMockBuilder('\OC_Util')
 			->disableOriginalConstructor()->getMock();
-		$this->urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()->getMock();
-		$this->l10n = $this->getMockBuilder('\OCP\IL10N')
+		$this->l10n = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()->getMock();
 		$this->l10n->expects($this->any())
 			->method('t')
@@ -83,7 +83,7 @@ class CheckSetupControllerTest extends TestCase {
 			}));
 		$this->checker = $this->getMockBuilder('\OC\IntegrityCheck\Checker')
 				->disableOriginalConstructor()->getMock();
-		$this->logger = $this->getMockBuilder('\OCP\ILogger')->getMock();
+		$this->logger = $this->getMockBuilder(ILogger::class)->getMock();
 		$this->checkSetupController = $this->getMockBuilder('\OC\Settings\Controller\CheckSetupController')
 			->setConstructorArgs([
 				'settings',

--- a/tests/Settings/Controller/EncryptionControllerTest.php
+++ b/tests/Settings/Controller/EncryptionControllerTest.php
@@ -25,11 +25,13 @@ use OC\DB\Connection;
 use OC\Files\View;
 use OC\Settings\Controller\EncryptionController;
 use OCP\App\IAppManager;
+use OCA\Encryption\Migration;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUserManager;
+use OCP\UserInterface;
 use Test\TestCase;
 
 /**
@@ -59,29 +61,29 @@ class EncryptionControllerTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->request = $this->getMockBuilder('\\OCP\\IRequest')
+		$this->request = $this->getMockBuilder(IRequest::class)
 			->disableOriginalConstructor()->getMock();
-		$this->l10n = $this->getMockBuilder('\\OCP\\IL10N')
+		$this->l10n = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()->getMock();
 		$this->l10n->expects($this->any())
 			->method('t')
 			->will($this->returnCallback(function($message, array $replace) {
 				return vsprintf($message, $replace);
 			}));
-		$this->config = $this->getMockBuilder('\\OCP\\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()->getMock();
-		$this->connection = $this->getMockBuilder('\\OC\\DB\\Connection')
+		$this->connection = $this->getMockBuilder(Connection::class)
 			->disableOriginalConstructor()->getMock();
-		$this->userManager = $this->getMockBuilder('\\OCP\\IUserManager')
+		$this->userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()->getMock();
-		$this->view = $this->getMockBuilder('\\OC\\Files\\View')
+		$this->view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()->getMock();
-		$this->logger = $this->getMockBuilder('\\OCP\\ILogger')
+		$this->logger = $this->getMockBuilder(ILogger::class)
 			->disableOriginalConstructor()->getMock();
 		$this->appManager = $this->getMockBuilder('\\OCP\\App\\IAppManager')
 			->disableOriginalConstructor()->getMock();
 
-		$this->encryptionController = $this->getMockBuilder('\\OC\\Settings\\Controller\\EncryptionController')
+		$this->encryptionController = $this->getMockBuilder(EncryptionController::class)
 			->setConstructorArgs([
 				'settings',
 				$this->request,
@@ -101,7 +103,7 @@ class EncryptionControllerTest extends TestCase {
 		// we need to be able to autoload the class we're mocking
 		\OC_App::registerAutoloading('encryption', \OC_App::getAppPath('encryption'));
 
-		$migration = $this->getMockBuilder('\\OCA\\Encryption\\Migration')
+		$migration = $this->getMockBuilder(Migration::class)
 			->disableOriginalConstructor()->getMock();
 		$this->encryptionController
 			->expects($this->once())
@@ -114,7 +116,7 @@ class EncryptionControllerTest extends TestCase {
 		$migration
 			->expects($this->once())
 			->method('updateDB');
-		$backend = $this->getMockBuilder('\OCP\UserInterface')
+		$backend = $this->getMockBuilder(UserInterface::class)
 			->getMock();
 		$this->userManager
 			->expects($this->once())

--- a/tests/Settings/Controller/GroupsControllerTest.php
+++ b/tests/Settings/Controller/GroupsControllerTest.php
@@ -10,6 +10,7 @@
 
 namespace Tests\Settings\Controller;
 
+use OC\Group\Group;
 use OC\Group\MetaData;
 use OC\Settings\Controller\GroupsController;
 use OCP\AppFramework\Http;
@@ -59,7 +60,7 @@ class GroupsControllerTest extends \Test\TestCase {
 	 * to test for subadmins. Thus the test always assumes you have admin permissions...
 	 */
 	public function testIndexSortByName() {
-		$firstGroup = $this->getMockBuilder('\OC\Group\Group')
+		$firstGroup = $this->getMockBuilder(Group::class)
 			->disableOriginalConstructor()->getMock();
 		$firstGroup
 			->method('getGID')
@@ -67,7 +68,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		$firstGroup
 			->method('count')
 			->will($this->returnValue(12));
-		$secondGroup = $this->getMockBuilder('\OC\Group\Group')
+		$secondGroup = $this->getMockBuilder(Group::class)
 			->disableOriginalConstructor()->getMock();
 		$secondGroup
 			->method('getGID')
@@ -75,7 +76,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		$secondGroup
 			->method('count')
 			->will($this->returnValue(25));
-		$thirdGroup = $this->getMockBuilder('\OC\Group\Group')
+		$thirdGroup = $this->getMockBuilder(Group::class)
 			->disableOriginalConstructor()->getMock();
 		$thirdGroup
 			->method('getGID')
@@ -83,7 +84,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		$thirdGroup
 			->method('count')
 			->will($this->returnValue(14));
-		$fourthGroup = $this->getMockBuilder('\OC\Group\Group')
+		$fourthGroup = $this->getMockBuilder(Group::class)
 			->disableOriginalConstructor()->getMock();
 		$fourthGroup
 			->method('getGID')
@@ -151,7 +152,7 @@ class GroupsControllerTest extends \Test\TestCase {
 	 * to test for subadmins. Thus the test always assumes you have admin permissions...
 	 */
 	public function testIndexSortbyCount() {
-		$firstGroup = $this->getMockBuilder('\OC\Group\Group')
+		$firstGroup = $this->getMockBuilder(Group::class)
 			->disableOriginalConstructor()->getMock();
 		$firstGroup
 			->method('getGID')
@@ -159,7 +160,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		$firstGroup
 			->method('count')
 			->will($this->returnValue(12));
-		$secondGroup = $this->getMockBuilder('\OC\Group\Group')
+		$secondGroup = $this->getMockBuilder(Group::class)
 			->disableOriginalConstructor()->getMock();
 		$secondGroup
 			->method('getGID')
@@ -167,7 +168,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		$secondGroup
 			->method('count')
 			->will($this->returnValue(25));
-		$thirdGroup = $this->getMockBuilder('\OC\Group\Group')
+		$thirdGroup = $this->getMockBuilder(Group::class)
 			->disableOriginalConstructor()->getMock();
 		$thirdGroup
 			->method('getGID')
@@ -175,7 +176,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		$thirdGroup
 			->method('count')
 			->will($this->returnValue(14));
-		$fourthGroup = $this->getMockBuilder('\OC\Group\Group')
+		$fourthGroup = $this->getMockBuilder(Group::class)
 			->disableOriginalConstructor()->getMock();
 		$fourthGroup
 			->method('getGID')
@@ -302,7 +303,7 @@ class GroupsControllerTest extends \Test\TestCase {
 	}
 
 	public function testDestroySuccessful() {
-		$group = $this->getMockBuilder('\OC\Group\Group')
+		$group = $this->getMockBuilder(Group::class)
 			->disableOriginalConstructor()->getMock();
 		$this->groupManager
 			->expects($this->once())

--- a/tests/Settings/Controller/UsersControllerTest.php
+++ b/tests/Settings/Controller/UsersControllerTest.php
@@ -11,9 +11,11 @@
 namespace Tests\Settings\Controller;
 
 use OC\Accounts\AccountManager;
+use OC\Group\Group;
 use OC\Group\Manager;
 use OC\Settings\Controller\UsersController;
 use OC\Settings\Mailer\NewUserMailHelper;
+use OC\SubAdmin;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
@@ -326,7 +328,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->with('bar')
 			->will($this->returnValue($bar));
 
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin
@@ -546,19 +548,19 @@ class UsersControllerTest extends \Test\TestCase {
 			->with('admin')
 			->will($this->returnValue($admin));
 
-		$subgroup1 = $this->getMockBuilder('\OCP\IGroup')
+		$subgroup1 = $this->getMockBuilder(IGroup::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subgroup1->expects($this->any())
 			->method('getGID')
 			->will($this->returnValue('SubGroup1'));
-		$subgroup2 = $this->getMockBuilder('\OCP\IGroup')
+		$subgroup2 = $this->getMockBuilder(IGroup::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subgroup2->expects($this->any())
 			->method('getGID')
 			->will($this->returnValue('SubGroup2'));
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin
@@ -746,7 +748,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->method('getUserGroupIds')
 			->will($this->onConsecutiveCalls(array('Users', 'Support'), array('admins', 'Support'), array('External Users')));
 
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->any())
@@ -865,7 +867,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->with('')
 			->will($this->returnValue([$user]));
 
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->once())
@@ -951,7 +953,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->method('createUser')
 			->will($this->onConsecutiveCalls($user));
 
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin
@@ -1006,13 +1008,13 @@ class UsersControllerTest extends \Test\TestCase {
 		$user->expects($this->any())
 			->method('isEnabled')
 			->willReturn(true);
-		$existingGroup = $this->getMockBuilder('\OCP\IGroup')
+		$existingGroup = $this->getMockBuilder(IGroup::class)
 			->disableOriginalConstructor()->getMock();
 		$existingGroup
 			->expects($this->once())
 			->method('addUser')
 			->with($user);
-		$newGroup = $this->getMockBuilder('\OCP\IGroup')
+		$newGroup = $this->getMockBuilder(IGroup::class)
 			->disableOriginalConstructor()->getMock();
 		$newGroup
 			->expects($this->once())
@@ -1038,7 +1040,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->with($user)
 			->will($this->onConsecutiveCalls(array('NewGroup', 'ExistingGroup')));
 
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin
@@ -1358,7 +1360,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->with('UserToDelete')
 			->will($this->returnValue($toDeleteUser));
 
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->once())
@@ -1441,7 +1443,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->with('UserToDelete')
 			->will($this->returnValue($toDeleteUser));
 
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->once())
@@ -1487,7 +1489,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->with('UserToDelete')
 			->will($this->returnValue($toDeleteUser));
 
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->once())
@@ -1571,7 +1573,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('createUser')
 			->will($this->onConsecutiveCalls($user));
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->once())
@@ -1637,7 +1639,7 @@ class UsersControllerTest extends \Test\TestCase {
 
 		list($user, $expectedResult) = $this->mockUser();
 
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->once())
@@ -1684,7 +1686,7 @@ class UsersControllerTest extends \Test\TestCase {
 			)
 			->will($this->returnValue('1'));
 
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->once())
@@ -1722,7 +1724,7 @@ class UsersControllerTest extends \Test\TestCase {
 		// without the master key enabled we use per-user keys -> restore is disabled
 		$expectedResult['isRestoreDisabled'] = !$masterKeyEnabled;
 
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->once())
@@ -1779,7 +1781,7 @@ class UsersControllerTest extends \Test\TestCase {
 
 		$expectedResult['isRestoreDisabled'] = true;
 
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->once())
@@ -1801,7 +1803,7 @@ class UsersControllerTest extends \Test\TestCase {
 
 		list($user, $expectedResult) = $this->mockUser();
 
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->once())
@@ -1853,21 +1855,21 @@ class UsersControllerTest extends \Test\TestCase {
 			->method('getUser')
 			->will($this->returnValue($user));
 
-		$group1 = $this->getMockBuilder('\OC\Group\Group')
+		$group1 = $this->getMockBuilder(Group::class)
 			->disableOriginalConstructor()->getMock();
 		$group1
 			->expects($this->once())
 			->method('getUsers')
 			->will($this->returnValue(['foo' => 'M. Foo', 'admin' => 'S. Admin']));
 
-		$group2 = $this->getMockBuilder('\OC\Group\Group')
+		$group2 = $this->getMockBuilder(Group::class)
 			->disableOriginalConstructor()->getMock();
 		$group2
 			->expects($this->once())
 			->method('getUsers')
 			->will($this->returnValue(['bar' => 'B. Ar']));
 
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin
@@ -1971,7 +1973,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->willReturn($editUser);
 		$this->accountManager->expects($this->any())->method('getUser')->willReturn([]);
 
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin
@@ -2036,7 +2038,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->with($user->getUID())
 			->willReturn($user);
 
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin
@@ -2437,7 +2439,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->method('createUser')
 			->will($this->onConsecutiveCalls($user));
 
-		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
+		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin
@@ -2576,7 +2578,7 @@ class UsersControllerTest extends \Test\TestCase {
 	}
 
 	public function testDisableUserFailsDueSameUser() {
-		$user = $this->getMockBuilder('\OC\User\User')
+		$user = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
 		$user->expects($this->once())
 			->method('getUID')
@@ -2599,7 +2601,7 @@ class UsersControllerTest extends \Test\TestCase {
 	}
 
 	public function testDisableUserFailsDueNoAdminAndNoSubadmin() {
-		$user = $this->getMockBuilder('\OC\User\User')
+		$user = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
 		$user->expects($this->once())
 			->method('getUID')
@@ -2608,7 +2610,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->expects($this->exactly(2))
 			->method('getUser')
 			->will($this->returnValue($user));
-		$user2 = $this->getMockBuilder('\OC\User\User')
+		$user2 = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
 		$user2->expects($this->never())
 			->method('setEnabled');
@@ -2618,7 +2620,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->with('abc')
 			->willReturn($user2);
 
-		$subadmin = $this->createMock('\OC\SubAdmin');
+		$subadmin = $this->createMock(SubAdmin::class);
 		$subadmin->expects($this->once())
 			->method('isUserAccessible')
 			->will($this->returnValue(false));
@@ -2641,7 +2643,7 @@ class UsersControllerTest extends \Test\TestCase {
 	}
 
 	public function testDisableUserFailsDueNoUser() {
-		$user = $this->getMockBuilder('\OC\User\User')
+		$user = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
 		$user->expects($this->once())
 			->method('getUID')
@@ -2674,7 +2676,7 @@ class UsersControllerTest extends \Test\TestCase {
 	}
 
 	public function testDisableUserFailsDueNoUserForSubAdmin() {
-		$user = $this->getMockBuilder('\OC\User\User')
+		$user = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
 		$user->expects($this->once())
 			->method('getUID')
@@ -2707,7 +2709,7 @@ class UsersControllerTest extends \Test\TestCase {
 	}
 
 	public function testDisableUserSuccessForAdmin() {
-		$user = $this->getMockBuilder('\OC\User\User')
+		$user = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
 		$user->expects($this->once())
 			->method('getUID')
@@ -2716,7 +2718,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->expects($this->exactly(1))
 			->method('getUser')
 			->will($this->returnValue($user));
-		$user2 = $this->getMockBuilder('\OC\User\User')
+		$user2 = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
 		$user2->expects($this->once())
 			->method('setEnabled')
@@ -2745,7 +2747,7 @@ class UsersControllerTest extends \Test\TestCase {
 	}
 
 	public function testDisableUserSuccessForSubAdmin() {
-		$user = $this->getMockBuilder('\OC\User\User')
+		$user = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
 		$user->expects($this->once())
 			->method('getUID')
@@ -2754,7 +2756,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->expects($this->exactly(2))
 			->method('getUser')
 			->will($this->returnValue($user));
-		$user2 = $this->getMockBuilder('\OC\User\User')
+		$user2 = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
 		$user2->expects($this->once())
 			->method('setEnabled');
@@ -2764,7 +2766,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->with('abc')
 			->willReturn($user2);
 
-		$subadmin = $this->createMock('\OC\SubAdmin');
+		$subadmin = $this->createMock(SubAdmin::class);
 		$subadmin->expects($this->once())
 			->method('isUserAccessible')
 			->will($this->returnValue(true));
@@ -2787,7 +2789,7 @@ class UsersControllerTest extends \Test\TestCase {
 	}
 
 	public function testEnableUserFailsDueSameUser() {
-		$user = $this->getMockBuilder('\OC\User\User')
+		$user = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
 		$user->expects($this->once())
 			->method('getUID')
@@ -2810,7 +2812,7 @@ class UsersControllerTest extends \Test\TestCase {
 	}
 
 	public function testEnableUserFailsDueNoAdminAndNoSubadmin() {
-		$user = $this->getMockBuilder('\OC\User\User')
+		$user = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
 		$user->expects($this->once())
 			->method('getUID')
@@ -2819,7 +2821,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->expects($this->exactly(2))
 			->method('getUser')
 			->will($this->returnValue($user));
-		$user2 = $this->getMockBuilder('\OC\User\User')
+		$user2 = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
 		$user2->expects($this->never())
 			->method('setEnabled');
@@ -2829,7 +2831,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->with('abc')
 			->willReturn($user2);
 
-		$subadmin = $this->createMock('\OC\SubAdmin');
+		$subadmin = $this->createMock(SubAdmin::class);
 		$subadmin->expects($this->once())
 			->method('isUserAccessible')
 			->will($this->returnValue(false));
@@ -2852,7 +2854,7 @@ class UsersControllerTest extends \Test\TestCase {
 	}
 
 	public function testEnableUserFailsDueNoUser() {
-		$user = $this->getMockBuilder('\OC\User\User')
+		$user = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
 		$user->expects($this->once())
 			->method('getUID')
@@ -2885,7 +2887,7 @@ class UsersControllerTest extends \Test\TestCase {
 	}
 
 	public function testEnableUserFailsDueNoUserForSubAdmin() {
-		$user = $this->getMockBuilder('\OC\User\User')
+		$user = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
 		$user->expects($this->once())
 			->method('getUID')
@@ -2918,7 +2920,7 @@ class UsersControllerTest extends \Test\TestCase {
 	}
 
 	public function testEnableUserSuccessForAdmin() {
-		$user = $this->getMockBuilder('\OC\User\User')
+		$user = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
 		$user->expects($this->once())
 			->method('getUID')
@@ -2927,7 +2929,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->expects($this->exactly(1))
 			->method('getUser')
 			->will($this->returnValue($user));
-		$user2 = $this->getMockBuilder('\OC\User\User')
+		$user2 = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
 		$user2->expects($this->once())
 			->method('setEnabled');
@@ -2955,7 +2957,7 @@ class UsersControllerTest extends \Test\TestCase {
 	}
 
 	public function testEnableUserSuccessForSubAdmin() {
-		$user = $this->getMockBuilder('\OC\User\User')
+		$user = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
 		$user->expects($this->once())
 			->method('getUID')
@@ -2964,7 +2966,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->expects($this->exactly(2))
 			->method('getUser')
 			->will($this->returnValue($user));
-		$user2 = $this->getMockBuilder('\OC\User\User')
+		$user2 = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
 		$user2->expects($this->once())
 			->method('setEnabled')
@@ -2975,7 +2977,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->with('abc')
 			->willReturn($user2);
 
-		$subadmin = $this->createMock('\OC\SubAdmin');
+		$subadmin = $this->createMock(SubAdmin::class);
 		$subadmin->expects($this->once())
 			->method('isUserAccessible')
 			->will($this->returnValue(true));

--- a/tests/Settings/Middleware/SubadminMiddlewareTest.php
+++ b/tests/Settings/Middleware/SubadminMiddlewareTest.php
@@ -34,9 +34,9 @@ class SubadminMiddlewareTest extends \Test\TestCase {
 
 	protected function setUp() {
 		parent::setUp();
-		$this->reflector = $this->getMockBuilder('\OC\AppFramework\Utility\ControllerMethodReflector')
+		$this->reflector = $this->getMockBuilder(ControllerMethodReflector::class)
 			->disableOriginalConstructor()->getMock();
-		$this->controller = $this->getMockBuilder('\OCP\AppFramework\Controller')
+		$this->controller = $this->getMockBuilder(Controller::class)
 			->disableOriginalConstructor()->getMock();
 
 		$this->subadminMiddlewareAsSubAdmin = new SubadminMiddleware($this->reflector, true);

--- a/tests/lib/APITest.php
+++ b/tests/lib/APITest.php
@@ -8,6 +8,8 @@
 
 namespace Test;
 
+use OCP\IRequest;
+
 class APITest extends \Test\TestCase {
 
 	// Helps build a response variable
@@ -71,7 +73,7 @@ class APITest extends \Test\TestCase {
 	 * @param bool $expected
 	 */
 	public function testIsV2($scriptName, $expected) {
-		$request = $this->getMockBuilder('\OCP\IRequest')
+		$request = $this->getMockBuilder(IRequest::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$request

--- a/tests/lib/Accounts/AccountsManagerTest.php
+++ b/tests/lib/Accounts/AccountsManagerTest.php
@@ -71,7 +71,7 @@ class AccountsManagerTest extends TestCase {
 	 * @return \PHPUnit_Framework_MockObject_MockObject | AccountManager
 	 */
 	public function getInstance($mockedMethods = null) {
-		return $this->getMockBuilder('OC\Accounts\AccountManager')
+		return $this->getMockBuilder(AccountManager::class)
 			->setConstructorArgs([$this->connection, $this->eventDispatcher, $this->jobList])
 			->setMethods($mockedMethods)
 			->getMock();
@@ -146,7 +146,7 @@ class AccountsManagerTest extends TestCase {
 	 * @param array $setData
 	 * @param IUser $askUser
 	 * @param array $expectedData
-	 * @param book $userAlreadyExists
+	 * @param bool $userAlreadyExists
 	 */
 	public function testGetUser($setUser, $setData, $askUser, $expectedData, $userAlreadyExists) {
 		$accountManager = $this->getInstance(['buildDefaultUserRecord', 'insertNewUser', 'addMissingDefaultValues']);
@@ -172,9 +172,9 @@ class AccountsManagerTest extends TestCase {
 	}
 
 	public function dataTestGetUser() {
-		$user1 = $this->getMockBuilder('OCP\IUser')->getMock();
+		$user1 = $this->getMockBuilder(IUser::class)->getMock();
 		$user1->expects($this->any())->method('getUID')->willReturn('user1');
-		$user2 = $this->getMockBuilder('OCP\IUser')->getMock();
+		$user2 = $this->getMockBuilder(IUser::class)->getMock();
 		$user2->expects($this->any())->method('getUID')->willReturn('user2');
 		return [
 			['user1', ['key' => 'value'], $user1, ['key' => 'value'], true],
@@ -183,7 +183,7 @@ class AccountsManagerTest extends TestCase {
 	}
 
 	public function testUpdateExistingUser() {
-		$user = $this->getMockBuilder('OCP\IUser')->getMock();
+		$user = $this->getMockBuilder(IUser::class)->getMock();
 		$user->expects($this->once())->method('getUID')->willReturn('uid');
 		$oldData = ['key' => 'value'];
 		$newData = ['newKey' => 'newValue'];
@@ -196,7 +196,7 @@ class AccountsManagerTest extends TestCase {
 	}
 
 	public function testInsertNewUser() {
-		$user = $this->getMockBuilder('OCP\IUser')->getMock();
+		$user = $this->getMockBuilder(IUser::class)->getMock();
 		$uid = 'uid';
 		$data = ['key' => 'value'];
 

--- a/tests/lib/Activity/ManagerTest.php
+++ b/tests/lib/Activity/ManagerTest.php
@@ -12,6 +12,7 @@ namespace Test\Activity;
 
 use OCP\IConfig;
 use OCP\IRequest;
+use OCP\IUser;
 use OCP\IUserSession;
 use OCP\RichObjectStrings\IValidator;
 use Test\TestCase;
@@ -247,7 +248,7 @@ class ManagerTest extends TestCase {
 	}
 
 	protected function mockUserSession($user) {
-		$mockUser = $this->getMockBuilder('\OCP\IUser')
+		$mockUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$mockUser->expects($this->any())
@@ -314,7 +315,7 @@ class ManagerTest extends TestCase {
 	 */
 	public function testPublish($author, $expected) {
 		if ($author !== null) {
-			$authorObject = $this->getMockBuilder('OCP\IUser')
+			$authorObject = $this->getMockBuilder(IUser::class)
 				->disableOriginalConstructor()
 				->getMock();
 			$authorObject->expects($this->once())

--- a/tests/lib/App/DependencyAnalyzerTest.php
+++ b/tests/lib/App/DependencyAnalyzerTest.php
@@ -59,7 +59,7 @@ class DependencyAnalyzerTest extends TestCase {
 			->method('getOcVersion')
 			->will( $this->returnValue('8.0.2'));
 
-		$this->l10nMock = $this->getMockBuilder('\OCP\IL10N')
+		$this->l10nMock = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->l10nMock->expects($this->any())

--- a/tests/lib/AppFramework/Controller/ApiControllerTest.php
+++ b/tests/lib/AppFramework/Controller/ApiControllerTest.php
@@ -26,6 +26,7 @@ namespace Test\AppFramework\Controller;
 
 use OC\AppFramework\Http\Request;
 use OCP\AppFramework\ApiController;
+use OCP\IConfig;
 
 
 class ChildApiController extends ApiController {};
@@ -41,7 +42,7 @@ class ApiControllerTest extends \Test\TestCase {
 			$this->getMockBuilder('\OCP\Security\ISecureRandom')
 				->disableOriginalConstructor()
 				->getMock(),
-			$this->getMockBuilder('\OCP\IConfig')
+			$this->getMockBuilder(IConfig::class)
 				->disableOriginalConstructor()
 				->getMock()
 		);

--- a/tests/lib/AppFramework/Controller/ControllerTest.php
+++ b/tests/lib/AppFramework/Controller/ControllerTest.php
@@ -29,6 +29,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\IConfig;
 
 
 class ChildController extends Controller {
@@ -79,7 +80,7 @@ class ControllerTest extends \Test\TestCase {
 			$this->getMockBuilder('\OCP\Security\ISecureRandom')
 				->disableOriginalConstructor()
 				->getMock(),
-			$this->getMockBuilder('\OCP\IConfig')
+			$this->getMockBuilder(IConfig::class)
 				->disableOriginalConstructor()
 				->getMock()
 		);

--- a/tests/lib/AppFramework/Http/DispatcherTest.php
+++ b/tests/lib/AppFramework/Http/DispatcherTest.php
@@ -31,6 +31,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Controller;
+use OCP\IConfig;
 
 
 class TestController extends Controller {
@@ -301,7 +302,7 @@ class DispatcherTest extends \Test\TestCase {
 			$this->getMockBuilder('\OCP\Security\ISecureRandom')
 				->disableOriginalConstructor()
 				->getMock(),
-			$this->getMockBuilder('\OCP\IConfig')
+			$this->getMockBuilder(IConfig::class)
 				->disableOriginalConstructor()
 				->getMock()
 		);
@@ -332,7 +333,7 @@ class DispatcherTest extends \Test\TestCase {
 			$this->getMockBuilder('\OCP\Security\ISecureRandom')
 				->disableOriginalConstructor()
 				->getMock(),
-			$this->getMockBuilder('\OCP\IConfig')
+			$this->getMockBuilder(IConfig::class)
 				->disableOriginalConstructor()
 				->getMock()
 		);
@@ -366,7 +367,7 @@ class DispatcherTest extends \Test\TestCase {
 			$this->getMockBuilder('\OCP\Security\ISecureRandom')
 				->disableOriginalConstructor()
 				->getMock(),
-			$this->getMockBuilder('\OCP\IConfig')
+			$this->getMockBuilder(IConfig::class)
 				->disableOriginalConstructor()
 				->getMock()
 		);
@@ -399,7 +400,7 @@ class DispatcherTest extends \Test\TestCase {
 			$this->getMockBuilder('\OCP\Security\ISecureRandom')
 				->disableOriginalConstructor()
 				->getMock(),
-			$this->getMockBuilder('\OCP\IConfig')
+			$this->getMockBuilder(IConfig::class)
 				->disableOriginalConstructor()
 				->getMock()
 		);
@@ -433,7 +434,7 @@ class DispatcherTest extends \Test\TestCase {
 			$this->getMockBuilder('\OCP\Security\ISecureRandom')
 				->disableOriginalConstructor()
 				->getMock(),
-			$this->getMockBuilder('\OCP\IConfig')
+			$this->getMockBuilder(IConfig::class)
 				->disableOriginalConstructor()
 				->getMock()
 		);
@@ -469,7 +470,7 @@ class DispatcherTest extends \Test\TestCase {
 			$this->getMockBuilder('\OCP\Security\ISecureRandom')
 				->disableOriginalConstructor()
 				->getMock(),
-			$this->getMockBuilder('\OCP\IConfig')
+			$this->getMockBuilder(IConfig::class)
 				->disableOriginalConstructor()
 				->getMock()
 		);

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -40,7 +40,7 @@ class RequestTest extends \Test\TestCase {
 		stream_wrapper_register('fakeinput', 'Test\AppFramework\Http\RequestStream');
 
 		$this->secureRandom = $this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock();
-		$this->config = $this->getMockBuilder('\OCP\IConfig')->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->csrfTokenManager = $this->getMockBuilder('\OC\Security\CSRF\CsrfTokenManager')
 			->disableOriginalConstructor()->getMock();
 	}

--- a/tests/lib/AppFramework/Middleware/MiddlewareDispatcherTest.php
+++ b/tests/lib/AppFramework/Middleware/MiddlewareDispatcherTest.php
@@ -29,6 +29,7 @@ use OC\AppFramework\Middleware\MiddlewareDispatcher;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Middleware;
 use OCP\AppFramework\Http\Response;
+use OCP\IConfig;
 
 
 // needed to test ordering
@@ -133,7 +134,7 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 				new Request(
 					['method' => 'GET'],
 					$this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock(),
-					$this->getMockBuilder('\OCP\IConfig')->getMock()
+					$this->getMockBuilder(IConfig::class)->getMock()
 				)
 			])->getMock();
 	}

--- a/tests/lib/AppFramework/Middleware/MiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/MiddlewareTest.php
@@ -27,6 +27,7 @@ namespace Test\AppFramework\Middleware;
 use OC\AppFramework\Http\Request;
 use OCP\AppFramework\Middleware;
 use OCP\AppFramework\Http\Response;
+use OCP\IConfig;
 
 class ChildMiddleware extends Middleware {};
 
@@ -59,7 +60,7 @@ class MiddlewareTest extends \Test\TestCase {
 				new Request(
 					[],
 					$this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock(),
-					$this->getMockBuilder('\OCP\IConfig')->getMock()
+					$this->getMockBuilder(IConfig::class)->getMock()
 				)
 			])->getMock();
 		$this->exception = new \Exception();

--- a/tests/lib/AppFramework/Middleware/SessionMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/SessionMiddlewareTest.php
@@ -17,6 +17,7 @@ use OC\AppFramework\Middleware\SessionMiddleware;
 use OC\AppFramework\Utility\ControllerMethodReflector;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Response;
+use OCP\IConfig;
 
 
 class SessionMiddlewareTest extends \Test\TestCase {
@@ -36,7 +37,7 @@ class SessionMiddlewareTest extends \Test\TestCase {
 		$this->request = new Request(
 			[],
 			$this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock(),
-			$this->getMockBuilder('\OCP\IConfig')->getMock()
+			$this->getMockBuilder(IConfig::class)->getMock()
 		);
 		$this->reflector = new ControllerMethodReflector();
 		$this->controller = $this->createMock(Controller::class);

--- a/tests/lib/AppFramework/Routing/RoutingTest.php
+++ b/tests/lib/AppFramework/Routing/RoutingTest.php
@@ -5,6 +5,7 @@ namespace Test\AppFramework\Routing;
 use OC\AppFramework\DependencyInjection\DIContainer;
 use OC\AppFramework\Routing\RouteActionHandler;
 use OC\AppFramework\Routing\RouteConfig;
+use OCP\ILogger;
 
 class RoutingTest extends \Test\TestCase
 {
@@ -130,7 +131,7 @@ class RoutingTest extends \Test\TestCase
 		// router mock
 		$router = $this->getMockBuilder('\OC\Route\Router')
 			->setMethods(['create'])
-			->setConstructorArgs([$this->getMockBuilder('\OCP\ILogger')->getMock()])
+			->setConstructorArgs([$this->getMockBuilder(ILogger::class)->getMock()])
 			->getMock();
 
 		// load route configuration
@@ -151,7 +152,7 @@ class RoutingTest extends \Test\TestCase
 		// router mock
 		$router = $this->getMockBuilder('\OC\Route\Router')
 			->setMethods(['create'])
-			->setConstructorArgs([$this->getMockBuilder('\OCP\ILogger')->getMock()])
+			->setConstructorArgs([$this->getMockBuilder(ILogger::class)->getMock()])
 			->getMock();
 
 		// load route configuration
@@ -212,7 +213,7 @@ class RoutingTest extends \Test\TestCase
 		// router mock
 		$router = $this->getMockBuilder('\OC\Route\Router')
 			->setMethods(['create'])
-			->setConstructorArgs([$this->getMockBuilder('\OCP\ILogger')->getMock()])
+			->setConstructorArgs([$this->getMockBuilder(ILogger::class)->getMock()])
 			->getMock();
 
 		// we expect create to be called once:
@@ -260,7 +261,7 @@ class RoutingTest extends \Test\TestCase
 		// router mock
 		$router = $this->getMockBuilder('\OC\Route\Router')
 			->setMethods(['create'])
-			->setConstructorArgs([$this->getMockBuilder('\OCP\ILogger')->getMock()])
+			->setConstructorArgs([$this->getMockBuilder(ILogger::class)->getMock()])
 			->getMock();
 
 		// we expect create to be called once:
@@ -287,7 +288,7 @@ class RoutingTest extends \Test\TestCase
 		// router mock
 		$router = $this->getMockBuilder('\OC\Route\Router')
 			->setMethods(['create'])
-			->setConstructorArgs([$this->getMockBuilder('\OCP\ILogger')->getMock()])
+			->setConstructorArgs([$this->getMockBuilder(ILogger::class)->getMock()])
 			->getMock();
 
 		// route mocks

--- a/tests/lib/BackgroundJob/JobTest.php
+++ b/tests/lib/BackgroundJob/JobTest.php
@@ -8,6 +8,8 @@
 
 namespace Test\BackgroundJob;
 
+use OCP\ILogger;
+
 class JobTest extends \Test\TestCase {
 	private $run = false;
 
@@ -24,7 +26,7 @@ class JobTest extends \Test\TestCase {
 		});
 		$jobList->add($job);
 
-		$logger = $this->getMockBuilder('OCP\ILogger')
+		$logger = $this->getMockBuilder(ILogger::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$logger->expects($this->once())

--- a/tests/lib/CapabilitiesManagerTest.php
+++ b/tests/lib/CapabilitiesManagerTest.php
@@ -37,7 +37,7 @@ class CapabilitiesManagerTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->logger = $this->getMockBuilder('OCP\ILogger')->getMock();
+		$this->logger = $this->getMockBuilder(ILogger::class)->getMock();
 		$this->manager = new CapabilitiesManager($this->logger);
 	}
 

--- a/tests/lib/Encryption/DecryptAllTest.php
+++ b/tests/lib/Encryption/DecryptAllTest.php
@@ -29,6 +29,7 @@ use OC\Encryption\Manager;
 use OC\Files\FileInfo;
 use OC\Files\View;
 use OCP\IUserManager;
+use OCP\UserInterface;
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Test\TestCase;
 
@@ -65,7 +66,7 @@ class DecryptAllTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->userManager = $this->getMockBuilder('OCP\IUserManager')
+		$this->userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()->getMock();
 		$this->encryptionManager = $this->getMockBuilder('OC\Encryption\Manager')
 			->disableOriginalConstructor()->getMock();
@@ -75,7 +76,7 @@ class DecryptAllTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->outputInterface = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
 			->disableOriginalConstructor()->getMock();
-		$this->userInterface = $this->getMockBuilder('OCP\UserInterface')
+		$this->userInterface = $this->getMockBuilder(UserInterface::class)
 			->disableOriginalConstructor()->getMock();
 
 		$this->outputInterface->expects($this->any())->method('getFormatter')

--- a/tests/lib/Encryption/Keys/StorageTest.php
+++ b/tests/lib/Encryption/Keys/StorageTest.php
@@ -24,6 +24,7 @@
 namespace Test\Encryption\Keys;
 
 use OC\Encryption\Keys\Storage;
+use OCP\IConfig;
 use Test\TestCase;
 
 class StorageTest extends TestCase {
@@ -51,7 +52,7 @@ class StorageTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->config = $this->getMockBuilder('OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/lib/Encryption/UpdateTest.php
+++ b/tests/lib/Encryption/UpdateTest.php
@@ -24,6 +24,7 @@ namespace Test\Encryption;
 
 
 use OC\Encryption\Update;
+use OC\Files\View;
 use Test\TestCase;
 
 class UpdateTest extends TestCase {
@@ -55,7 +56,7 @@ class UpdateTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->view = $this->getMockBuilder('\OC\Files\View')
+		$this->view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()->getMock();
 		$this->util = $this->getMockBuilder('\OC\Encryption\Util')
 			->disableOriginalConstructor()->getMock();

--- a/tests/lib/Encryption/UtilTest.php
+++ b/tests/lib/Encryption/UtilTest.php
@@ -4,6 +4,7 @@ namespace Test\Encryption;
 
 use OC\Encryption\Util;
 use OCP\Encryption\IEncryptionModule;
+use OCP\IConfig;
 use Test\TestCase;
 
 class UtilTest extends TestCase {
@@ -44,7 +45,7 @@ class UtilTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->config = $this->getMockBuilder('OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/lib/Files/Node/NodeTest.php
+++ b/tests/lib/Files/Node/NodeTest.php
@@ -13,7 +13,10 @@ use OC\Files\View;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
+use OCP\Files\Storage;
+use OCP\IConfig;
 use OCP\ILogger;
+use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\Files\NotFoundException;
 
@@ -41,17 +44,18 @@ abstract class NodeTest extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$config = $this->getMockBuilder('\OCP\IConfig')
+		$config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlGenerator = $this->getMockBuilder(IURLGenerator
+		::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->user = new \OC\User\User('', new \Test\Util\User\Dummy, null, $config, $urlGenerator);
 		$this->manager = $this->getMockBuilder('\OC\Files\Mount\Manager')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->view = $this->getMockBuilder('\OC\Files\View')
+		$this->view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->userMountCache = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')
@@ -88,7 +92,7 @@ abstract class NodeTest extends \Test\TestCase {
 	protected abstract function getViewDeleteMethod();
 
 	protected function getMockStorage() {
-		$storage = $this->getMockBuilder('\OCP\Files\Storage')
+		$storage = $this->getMockBuilder(Storage::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$storage->expects($this->any())

--- a/tests/lib/Files/Node/RootTest.php
+++ b/tests/lib/Files/Node/RootTest.php
@@ -13,7 +13,9 @@ use OC\Files\FileInfo;
 use OC\Files\Mount\Manager;
 use OC\Files\Node\Folder;
 use OC\Files\View;
+use OCP\IConfig;
 use OCP\ILogger;
+use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
 
@@ -37,10 +39,10 @@ class RootTest extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$config = $this->getMockBuilder('\OCP\IConfig')
+		$config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$urlgenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlgenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -69,7 +71,7 @@ class RootTest extends \Test\TestCase {
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$root = new \OC\Files\Node\Root(
@@ -105,7 +107,7 @@ class RootTest extends \Test\TestCase {
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$root = new \OC\Files\Node\Root(
@@ -133,7 +135,7 @@ class RootTest extends \Test\TestCase {
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$root = new \OC\Files\Node\Root(
@@ -155,7 +157,7 @@ class RootTest extends \Test\TestCase {
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->getMockBuilder('\OC\Files\View')
+		$view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$root = new \OC\Files\Node\Root(

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -16,6 +16,7 @@ use OCP\Encryption\IFile;
 use OCP\Encryption\Keys\IStorage;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Mount\IMountPoint;
+use OCP\IConfig;
 use OCP\ILogger;
 use Test\Files\Storage\Storage;
 
@@ -120,7 +121,7 @@ class EncryptionTest extends Storage {
 			->willReturn($mockModule);
 
 		$this->arrayCache = $this->createMock(ArrayCache::class);
-		$this->config = $this->getMockBuilder('\OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->groupManager = $this->getMockBuilder('\OC\Group\Manager')

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -185,7 +185,7 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 	}
 
 	public function testSpaceRoot() {
-		$storage = $this->getMockBuilder('\OC\Files\Storage\Local')->disableOriginalConstructor()->getMock();
+		$storage = $this->getMockBuilder(Local::class)->disableOriginalConstructor()->getMock();
 		$cache = $this->getMockBuilder('\OC\Files\Cache\Cache')->disableOriginalConstructor()->getMock();
 		$storage->expects($this->once())
 			->method('getCache')

--- a/tests/lib/Files/Stream/EncryptionTest.php
+++ b/tests/lib/Files/Stream/EncryptionTest.php
@@ -4,6 +4,7 @@ namespace Test\Files\Stream;
 
 use OC\Files\View;
 use OC\Memcache\ArrayCache;
+use OCP\IConfig;
 
 class EncryptionTest extends \Test\TestCase {
 
@@ -29,7 +30,7 @@ class EncryptionTest extends \Test\TestCase {
 			->disableOriginalConstructor()->getMock();
 		$encStorage = $this->getMockBuilder('\OC\Files\Storage\Wrapper\Encryption')
 			->disableOriginalConstructor()->getMock();
-		$config = $this->getMockBuilder('\OCP\IConfig')
+		$config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$arrayCache = $this->createMock(ArrayCache::class);

--- a/tests/lib/Files/Type/DetectionTest.php
+++ b/tests/lib/Files/Type/DetectionTest.php
@@ -21,7 +21,8 @@
 
 namespace Test\Files\Type;
 
-use \OC\Files\Type\Detection;
+use OC\Files\Type\Detection;
+use OCP\IURLGenerator;
 
 class DetectionTest extends \Test\TestCase {
 	/** @var Detection */
@@ -107,7 +108,7 @@ class DetectionTest extends \Test\TestCase {
 		 */
 
 		//Mock UrlGenerator
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -126,7 +127,7 @@ class DetectionTest extends \Test\TestCase {
 		 * Test dir-shareed mimetype
 		 */
 		//Mock UrlGenerator
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -146,7 +147,7 @@ class DetectionTest extends \Test\TestCase {
 		 */
 
 		//Mock UrlGenerator
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -166,7 +167,7 @@ class DetectionTest extends \Test\TestCase {
 		 */
 
 		//Mock UrlGenerator
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -186,7 +187,7 @@ class DetectionTest extends \Test\TestCase {
 		 */
 
 		//Mock UrlGenerator
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -216,7 +217,7 @@ class DetectionTest extends \Test\TestCase {
 		 */
 
 		//Mock UrlGenerator
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -246,7 +247,7 @@ class DetectionTest extends \Test\TestCase {
 		 */
 
 		//Mock UrlGenerator
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -272,7 +273,7 @@ class DetectionTest extends \Test\TestCase {
 		$mimetypealiases_dist->setContent(json_encode(['foo' => 'foobar/baz'], JSON_FORCE_OBJECT));
 
 		//Mock UrlGenerator
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/lib/Group/GroupTest.php
+++ b/tests/lib/Group/GroupTest.php
@@ -10,6 +10,8 @@
 namespace Test\Group;
 
 use OC\User\User;
+use OCP\IConfig;
+use OCP\IURLGenerator;
 
 class GroupTest extends \Test\TestCase {
 
@@ -19,10 +21,10 @@ class GroupTest extends \Test\TestCase {
 	 * @return User
 	 */
 	private function newUser($uid, \OC\User\Backend $backend) {
-		$config = $this->getMockBuilder('\OCP\IConfig')
+		$config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$urlgenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlgenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/lib/HTTPHelperTest.php
+++ b/tests/lib/HTTPHelperTest.php
@@ -9,6 +9,7 @@
 namespace Test;
 
 use OCP\Http\Client\IClientService;
+use OCP\IConfig;
 
 class HTTPHelperTest extends \Test\TestCase {
 
@@ -22,7 +23,7 @@ class HTTPHelperTest extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->config = $this->getMockBuilder('\OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()->getMock();
 		$this->clientService = $this->createMock(IClientService::class);
 		$this->httpHelperMock = $this->getMockBuilder('\OC\HTTPHelper')

--- a/tests/lib/Memcache/FactoryTest.php
+++ b/tests/lib/Memcache/FactoryTest.php
@@ -20,6 +20,8 @@
  */
 namespace Test\Memcache;
 
+use OCP\ILogger;
+
 class Test_Factory_Available_Cache1 {
 	public function __construct($prefix = '') {
 	}
@@ -114,7 +116,7 @@ class FactoryTest extends \Test\TestCase {
 	 */
 	public function testCacheAvailability($localCache, $distributedCache, $lockingCache,
 		$expectedLocalCache, $expectedDistributedCache, $expectedLockingCache) {
-		$logger = $this->getMockBuilder('\OCP\ILogger')->getMock();
+		$logger = $this->getMockBuilder(ILogger::class)->getMock();
 		$factory = new \OC\Memcache\Factory('abc', $logger, $localCache, $distributedCache, $lockingCache);
 		$this->assertTrue(is_a($factory->createLocal(), $expectedLocalCache));
 		$this->assertTrue(is_a($factory->createDistributed(), $expectedDistributedCache));
@@ -126,7 +128,7 @@ class FactoryTest extends \Test\TestCase {
 	 * @expectedException \OC\HintException
 	 */
 	public function testCacheNotAvailableException($localCache, $distributedCache) {
-		$logger = $this->getMockBuilder('\OCP\ILogger')->getMock();
+		$logger = $this->getMockBuilder(ILogger::class)->getMock();
 		new \OC\Memcache\Factory('abc', $logger, $localCache, $distributedCache);
 	}
 }

--- a/tests/lib/Migration/BackgroundRepairTest.php
+++ b/tests/lib/Migration/BackgroundRepairTest.php
@@ -72,7 +72,7 @@ class BackgroundRepairTest extends TestCase {
 		$this->jobList = $this->getMockBuilder('OC\BackgroundJob\JobList')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->logger = $this->getMockBuilder('OCP\ILogger')
+		$this->logger = $this->getMockBuilder(ILogger::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->job = $this->getMockBuilder(BackgroundRepair::class)

--- a/tests/lib/Notification/ManagerTest.php
+++ b/tests/lib/Notification/ManagerTest.php
@@ -22,7 +22,10 @@
 namespace Test\Notification;
 
 use OC\Notification\Manager;
+use OCP\Notification\IApp;
 use OCP\Notification\IManager;
+use OCP\Notification\INotification;
+use OCP\Notification\INotifier;
 use OCP\RichObjectStrings\IValidator;
 use Test\TestCase;
 
@@ -37,7 +40,7 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testRegisterApp() {
-		$app = $this->getMockBuilder('OCP\Notification\IApp')
+		$app = $this->getMockBuilder(IApp::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -61,7 +64,7 @@ class ManagerTest extends TestCase {
 	 * @expectedException \InvalidArgumentException
 	 */
 	public function testRegisterAppInvalid() {
-		$notifier = $this->getMockBuilder('OCP\Notification\INotifier')
+		$notifier = $this->getMockBuilder(INotifier::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -75,7 +78,7 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testRegisterNotifier() {
-		$notifier = $this->getMockBuilder('OCP\Notification\INotifier')
+		$notifier = $this->getMockBuilder(INotifier::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -107,7 +110,7 @@ class ManagerTest extends TestCase {
 	 * @expectedException \InvalidArgumentException
 	 */
 	public function testRegisterNotifierInvalid() {
-		$app = $this->getMockBuilder('OCP\Notification\IApp')
+		$app = $this->getMockBuilder(IApp::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -138,7 +141,7 @@ class ManagerTest extends TestCase {
 	 * @param mixed $data
 	 */
 	public function testRegisterNotifierInfoInvalid($data) {
-		$app = $this->getMockBuilder('OCP\Notification\IApp')
+		$app = $this->getMockBuilder(IApp::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -158,7 +161,7 @@ class ManagerTest extends TestCase {
 	 * @expectedExceptionMessage The given notifier ID test1 is already in use
 	 */
 	public function testRegisterNotifierInfoDuplicate() {
-		$app = $this->getMockBuilder('OCP\Notification\IApp')
+		$app = $this->getMockBuilder(IApp::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -184,7 +187,7 @@ class ManagerTest extends TestCase {
 
 	public function testNotify() {
 		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
-		$notification = $this->getMockBuilder('OCP\Notification\INotification')
+		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$notification->expects($this->once())
@@ -192,7 +195,7 @@ class ManagerTest extends TestCase {
 			->willReturn(true);
 
 		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $app */
-		$app = $this->getMockBuilder('OCP\Notification\IApp')
+		$app = $this->getMockBuilder(IApp::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$app->expects($this->once())
@@ -200,7 +203,7 @@ class ManagerTest extends TestCase {
 			->with($notification);
 
 		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $app2 */
-		$app2 = $this->getMockBuilder('OCP\Notification\IApp')
+		$app2 = $this->getMockBuilder(IApp::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$app2->expects($this->once())
@@ -222,7 +225,7 @@ class ManagerTest extends TestCase {
 	 */
 	public function testNotifyInvalid() {
 		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
-		$notification = $this->getMockBuilder('OCP\Notification\INotification')
+		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$notification->expects($this->once())
@@ -234,14 +237,14 @@ class ManagerTest extends TestCase {
 
 	public function testPrepare() {
 		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
-		$notification = $this->getMockBuilder('OCP\Notification\INotification')
+		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$notification->expects($this->once())
 			->method('isValidParsed')
 			->willReturn(true);
 		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification2 */
-		$notification2 = $this->getMockBuilder('OCP\Notification\INotification')
+		$notification2 = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$notification2->expects($this->exactly(2))
@@ -249,7 +252,7 @@ class ManagerTest extends TestCase {
 			->willReturn(true);
 
 		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $notifier */
-		$notifier = $this->getMockBuilder('OCP\Notification\INotifier')
+		$notifier = $this->getMockBuilder(INotifier::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$notifier->expects($this->once())
@@ -258,7 +261,7 @@ class ManagerTest extends TestCase {
 			->willReturnArgument(0);
 
 		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $notifier2 */
-		$notifier2 = $this->getMockBuilder('OCP\Notification\INotifier')
+		$notifier2 = $this->getMockBuilder(INotifier::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$notifier2->expects($this->once())
@@ -285,7 +288,7 @@ class ManagerTest extends TestCase {
 	 */
 	public function testPrepareInvalid() {
 		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
-		$notification = $this->getMockBuilder('OCP\Notification\INotification')
+		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$notification->expects($this->once())
@@ -293,7 +296,7 @@ class ManagerTest extends TestCase {
 			->willReturn(false);
 
 		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $notifier */
-		$notifier = $this->getMockBuilder('OCP\Notification\INotifier')
+		$notifier = $this->getMockBuilder(INotifier::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$notifier->expects($this->once())
@@ -312,7 +315,7 @@ class ManagerTest extends TestCase {
 
 	public function testPrepareNotifierThrows() {
 		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
-		$notification = $this->getMockBuilder('OCP\Notification\INotification')
+		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$notification->expects($this->once())
@@ -320,7 +323,7 @@ class ManagerTest extends TestCase {
 			->willReturn(true);
 
 		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $notifier */
-		$notifier = $this->getMockBuilder('OCP\Notification\INotifier')
+		$notifier = $this->getMockBuilder(INotifier::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$notifier->expects($this->once())
@@ -342,7 +345,7 @@ class ManagerTest extends TestCase {
 	 */
 	public function testPrepareNoNotifier() {
 		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
-		$notification = $this->getMockBuilder('OCP\Notification\INotification')
+		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$notification->expects($this->once())
@@ -354,12 +357,12 @@ class ManagerTest extends TestCase {
 
 	public function testMarkProcessed() {
 		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
-		$notification = $this->getMockBuilder('OCP\Notification\INotification')
+		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
 
 		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $app */
-		$app = $this->getMockBuilder('OCP\Notification\IApp')
+		$app = $this->getMockBuilder(IApp::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$app->expects($this->once())
@@ -367,7 +370,7 @@ class ManagerTest extends TestCase {
 			->with($notification);
 
 		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $app2 */
-		$app2 = $this->getMockBuilder('OCP\Notification\IApp')
+		$app2 = $this->getMockBuilder(IApp::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$app2->expects($this->once())
@@ -386,12 +389,12 @@ class ManagerTest extends TestCase {
 
 	public function testGetCount() {
 		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
-		$notification = $this->getMockBuilder('OCP\Notification\INotification')
+		$notification = $this->getMockBuilder(INotification::class)
 			->disableOriginalConstructor()
 			->getMock();
 
 		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $app */
-		$app = $this->getMockBuilder('OCP\Notification\IApp')
+		$app = $this->getMockBuilder(IApp::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$app->expects($this->once())
@@ -400,7 +403,7 @@ class ManagerTest extends TestCase {
 			->willReturn(21);
 
 		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $app2 */
-		$app2 = $this->getMockBuilder('OCP\Notification\IApp')
+		$app2 = $this->getMockBuilder(IApp::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$app2->expects($this->once())

--- a/tests/lib/Repair/CleanTagsTest.php
+++ b/tests/lib/Repair/CleanTagsTest.php
@@ -8,6 +8,7 @@
 
 namespace Test\Repair;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IUserManager;
 use OCP\Migration\IOutput;
 
 /**
@@ -41,7 +42,7 @@ class CleanTagsTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->userManager = $this->getMockBuilder('\OCP\IUserManager')
+		$this->userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/lib/Repair/RepairInvalidSharesTest.php
+++ b/tests/lib/Repair/RepairInvalidSharesTest.php
@@ -11,6 +11,7 @@ namespace Test\Repair;
 
 use OC\Repair\RepairInvalidShares;
 use OC\Share\Constants;
+use OCP\IConfig;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use Test\TestCase;
@@ -33,7 +34,7 @@ class RepairInvalidSharesTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$config = $this->getMockBuilder('OCP\IConfig')
+		$config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$config->expects($this->any())

--- a/tests/lib/Repair/RepairMimeTypesTest.php
+++ b/tests/lib/Repair/RepairMimeTypesTest.php
@@ -39,7 +39,7 @@ class RepairMimeTypesTest extends \Test\TestCase {
 		$this->mimetypeLoader = \OC::$server->getMimeTypeLoader();
 
 		/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject $config */
-		$config = $this->getMockBuilder('OCP\IConfig')
+		$config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$config->expects($this->any())

--- a/tests/lib/Security/CSRF/TokenStorage/SessionStorageTest.php
+++ b/tests/lib/Security/CSRF/TokenStorage/SessionStorageTest.php
@@ -31,7 +31,7 @@ class SessionStorageTest extends \Test\TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->session = $this->getMockBuilder('\OCP\ISession')
+		$this->session = $this->getMockBuilder(ISession::class)
 			->disableOriginalConstructor()->getMock();
 		$this->sessionStorage = new \OC\Security\CSRF\TokenStorage\SessionStorage($this->session);
 	}

--- a/tests/lib/Security/HasherTest.php
+++ b/tests/lib/Security/HasherTest.php
@@ -9,6 +9,7 @@
 namespace Test\Security;
 
 use OC\Security\Hasher;
+use OCP\IConfig;
 
 /**
  * Class HasherTest
@@ -75,13 +76,13 @@ class HasherTest extends \Test\TestCase {
 	/** @var Hasher */
 	protected $hasher;
 
-	/** @var \OCP\IConfig */
+	/** @var IConfig */
 	protected $config;
 
 	protected function setUp() {
 		parent::setUp();
 
-		$this->config = $this->getMockBuilder('\OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()->getMock();
 
 		$this->hasher = new Hasher($this->config);

--- a/tests/lib/Security/TrustedDomainHelperTest.php
+++ b/tests/lib/Security/TrustedDomainHelperTest.php
@@ -21,7 +21,7 @@ class TrustedDomainHelperTest extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->config = $this->getMockBuilder('\OCP\IConfig')->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 	}
 
 	/**

--- a/tests/lib/Settings/Admin/AdditionalTest.php
+++ b/tests/lib/Settings/Admin/AdditionalTest.php
@@ -36,7 +36,7 @@ class AdditionalTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->config = $this->getMockBuilder('\OCP\IConfig')->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 
 		$this->admin = new Additional(
 			$this->config

--- a/tests/lib/Settings/Admin/EncryptionTest.php
+++ b/tests/lib/Settings/Admin/EncryptionTest.php
@@ -40,7 +40,7 @@ class EncryptionTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->manager = $this->getMockBuilder('\OC\Encryption\Manager')->disableOriginalConstructor()->getMock();
-		$this->userManager = $this->getMockBuilder('\OCP\IUserManager')->getMock();
+		$this->userManager = $this->getMockBuilder(IUserManager::class)->getMock();
 
 		$this->admin = new Encryption(
 			$this->manager,

--- a/tests/lib/Settings/Admin/ServerTest.php
+++ b/tests/lib/Settings/Admin/ServerTest.php
@@ -49,11 +49,11 @@ class ServerTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->config = $this->getMockBuilder('\OCP\IConfig')->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->request = $this->createMock(IRequest::class);
 		$this->dbConnection = $this->getMockBuilder('\OCP\IDBConnection')->getMock();
 		$this->lockingProvider = $this->getMockBuilder('\OCP\Lock\ILockingProvider')->getMock();
-		$this->l10n = $this->getMockBuilder('\OCP\IL10N')->getMock();
+		$this->l10n = $this->getMockBuilder(IL10N::class)->getMock();
 
 		$this->admin = new Server(
 			$this->dbConnection,

--- a/tests/lib/Settings/Admin/SharingTest.php
+++ b/tests/lib/Settings/Admin/SharingTest.php
@@ -36,7 +36,7 @@ class SharingTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->config = $this->getMockBuilder('\OCP\IConfig')->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 
 		$this->admin = new Sharing(
 			$this->config

--- a/tests/lib/Settings/Admin/TipsTricksTest.php
+++ b/tests/lib/Settings/Admin/TipsTricksTest.php
@@ -36,7 +36,7 @@ class TipsTrickTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->config = $this->getMockBuilder('\OCP\IConfig')->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 
 		$this->admin = new TipsTricks(
 			$this->config

--- a/tests/lib/SystemTag/SystemTagManagerTest.php
+++ b/tests/lib/SystemTag/SystemTagManagerTest.php
@@ -13,6 +13,7 @@ namespace Test\SystemTag;
 use OC\SystemTag\SystemTagManager;
 use OC\SystemTag\SystemTagObjectMapper;
 use OCP\IDBConnection;
+use OCP\IUser;
 use OCP\SystemTag\ISystemTag;
 use OCP\SystemTag\ISystemTagManager;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -56,7 +57,7 @@ class SystemTagManagerTest extends TestCase {
 		$this->dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')
 			->getMock();
 
-		$this->groupManager = $this->getMockBuilder('\OCP\IGroupManager')->getMock();
+		$this->groupManager = $this->getMockBuilder(IGroupManager::class)->getMock();
 
 		$this->tagManager = new SystemTagManager(
 			$this->connection,
@@ -433,7 +434,7 @@ class SystemTagManagerTest extends TestCase {
 	 * @dataProvider visibilityCheckProvider
 	 */
 	public function testVisibilityCheck($userVisible, $userAssignable, $isAdmin, $expectedResult) {
-		$user = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$user = $this->getMockBuilder(IUser::class)->getMock();
 		$user->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('test'));
@@ -480,7 +481,7 @@ class SystemTagManagerTest extends TestCase {
 	 * @dataProvider assignabilityCheckProvider
 	 */
 	public function testAssignabilityCheck($userVisible, $userAssignable, $isAdmin, $expectedResult, $userGroupIds = [], $tagGroupIds = []) {
-		$user = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$user = $this->getMockBuilder(IUser::class)->getMock();
 		$user->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('test'));

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -491,7 +491,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 			->method('getName')
 			->willReturn('Nextcloud');
 		/** @var IL10N|\PHPUnit_Framework_MockObject_MockObject $l10n */
-		$l10n = $this->getMockBuilder('\OCP\IL10N')
+		$l10n = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()->getMock();
 		$l10n
 			->expects($this->any())

--- a/tests/lib/Updater/VersionCheckTest.php
+++ b/tests/lib/Updater/VersionCheckTest.php
@@ -23,6 +23,7 @@
 namespace Test\Updater;
 
 use OC\Updater\VersionCheck;
+use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\Util;
 
@@ -34,10 +35,10 @@ class VersionCheckTest extends \Test\TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->config = $this->getMockBuilder('\OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$clientService = $this->getMockBuilder('\OCP\Http\Client\IClientService')
+		$clientService = $this->getMockBuilder(IClientService::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -615,7 +615,7 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testDeleteUser() {
-		$config = $this->getMockBuilder('OCP\IConfig')
+		$config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$config

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -769,7 +769,7 @@ class SessionTest extends \Test\TestCase {
 
 		$session = new Memory('');
 		$session->set('user_id', 'foo');
-		$userSession = $this->getMockBuilder('\OC\User\Session')
+		$userSession = $this->getMockBuilder(Session::class)
 			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->random, $this->lockdownManager])
 			->setMethods([
 				'validateSession'
@@ -950,7 +950,7 @@ class SessionTest extends \Test\TestCase {
 		$token->setUid('fritz0');
 		$token->setLastCheck(100); // Needs check
 		$user = $this->createMock(IUser::class);
-		$userSession = $this->getMockBuilder('\OC\User\Session')
+		$userSession = $this->getMockBuilder(Session::class)
 			->setMethods(['logout'])
 			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->random, $this->lockdownManager])
 			->getMock();
@@ -980,7 +980,7 @@ class SessionTest extends \Test\TestCase {
 		$session = $this->createMock(ISession::class);
 		$timeFactory = $this->createMock(ITimeFactory::class);
 		$tokenProvider = $this->createMock(IProvider::class);
-		$userSession = $this->getMockBuilder('\OC\User\Session')
+		$userSession = $this->getMockBuilder(Session::class)
 			->setConstructorArgs([$userManager, $session, $timeFactory, $tokenProvider, $this->config, $this->random, $this->lockdownManager])
 			->setMethods(['logout'])
 			->getMock();
@@ -1027,7 +1027,7 @@ class SessionTest extends \Test\TestCase {
 		$session = $this->createMock(ISession::class);
 		$timeFactory = $this->createMock(ITimeFactory::class);
 		$tokenProvider = $this->createMock(IProvider::class);
-		$userSession = $this->getMockBuilder('\OC\User\Session')
+		$userSession = $this->getMockBuilder(Session::class)
 			->setConstructorArgs([$userManager, $session, $timeFactory, $tokenProvider, $this->config, $this->random, $this->lockdownManager])
 			->setMethods(['logout'])
 			->getMock();

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -276,7 +276,7 @@ class UserTest extends TestCase {
 			->method('implementsActions')
 			->will($this->returnValue(false));
 
-		$allConfig = $this->getMockBuilder('\OCP\IConfig')
+		$allConfig = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$allConfig->expects($this->any())

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -10,6 +10,8 @@ namespace Test;
 
 use OC_Util;
 use OCP\App\IAppManager;
+use OCP\IConfig;
+use OCP\IUser;
 
 /**
  * Class UtilTest
@@ -259,9 +261,9 @@ class UtilTest extends \Test\TestCase {
 	 * @param bool $expected expected result
 	 */
 	function testIsSharingDisabledForUser($groups, $membership, $excludedGroups, $expected) {
-		$config = $this->getMockBuilder('OCP\IConfig')->disableOriginalConstructor()->getMock();
+		$config = $this->getMockBuilder(IConfig::class)->disableOriginalConstructor()->getMock();
 		$groupManager = $this->getMockBuilder('OCP\IGroupManager')->disableOriginalConstructor()->getMock();
-		$user = $this->getMockBuilder('OCP\IUser')->disableOriginalConstructor()->getMock();
+		$user = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 
 		$config
 				->expects($this->at(0))


### PR DESCRIPTION
First step towards full usage of `::class` in mocks for better integration into IDE/static code analysis.

Based in search and replace and code analysis of PHPStorm.