### PR TITLE
Use new-password as autocomplete on share auth page

### DIFF
--- a/apps/files_sharing/templates/authenticate.php
+++ b/apps/files_sharing/templates/authenticate.php
@@ -17,7 +17,7 @@
 			<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>" />
 			<input type="password" name="password" id="password"
 				placeholder="<?php p($l->t('Password')); ?>" value=""
-				autocomplete="off" autocapitalize="off" autocorrect="off"
+				autocomplete="new-password" autocapitalize="off" autocorrect="off"
 				autofocus />
 			<input type="submit" id="password-submit" 
 				class="svg icon-confirm input-button-inline" value="" disabled="disabled" />


### PR DESCRIPTION
Fixes #6821

This makes sure that (supported) browsers will not prefill the password
field if a user has a password saved for that nextcloud.

CC: @The7thSin