### PR TITLE
Update .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -55,7 +55,8 @@
 <IfModule mod_rewrite.c>
   RewriteEngine on
   RewriteCond %{HTTP_USER_AGENT}  DavClnt
-  RewriteRule ^$         /remote.php/webdav/          [L,R=302]
+  RewriteCond %{REQUEST_METHOD} OPTIONS
+  RewriteRule .* - [R=401,L]
   RewriteRule .* - [env=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
   RewriteRule ^\.well-known/host-meta /public.php?service=host-meta [QSA,L]
   RewriteRule ^\.well-known/host-meta\.json /public.php?service=host-meta-json [QSA,L]


### PR DESCRIPTION
Send 401 on OPTIONS / HTTP/1.1 request coming from windows WebDAV service. Redirection as implemented before did not work and did not start the MS WebClient Service.  
This way the WebClient Service on Windows starts automatically on request. 

 



