### PR TITLE
Add blue bar as highlight to active menu entry

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -424,6 +424,7 @@ nav {
 		&:active,
 		&.active {
 			opacity: 1;
+			box-shadow: inset 2px 0 $color-primary;
 		}
 	}
 }

--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -248,6 +248,8 @@ input {
 				opacity: .75;
 			}
 			&.active {
+				box-shadow: inset 2px 0 $color-primary;
+
 				.menuitem-text {
 					font-weight: 600;
 				}


### PR DESCRIPTION
Like in the .app-navigation as well to improve highlight of the current entry. Please review @nextcloud/designers:
![screenshot from 2017-10-26 14-31-18](https://user-images.githubusercontent.com/925062/32053143-b13cddfe-ba5a-11e7-97af-68e2d349e7a4.png)
![screenshot from 2017-10-26 14-32-00](https://user-images.githubusercontent.com/925062/32053141-b10dfde0-ba5a-11e7-8741-3d535a3e9398.png)
