### PR TITLE
Fix seeking on object storage

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -447,8 +447,28 @@ class View {
 		@ob_end_clean();
 		$handle = $this->fopen($path, 'rb');
 		if ($handle) {
-			if (fseek($handle, $from) === 0) {
-				$chunkSize = 8192; // 8 kB chunks
+			$chunkSize = 8192; // 8 kB chunks
+			$startReading = true;
+
+			if ($from !== 0 && $from !== '0' && fseek($handle, $from) !== 0) {
+				// forward file handle via chunked fread because fseek seem to have failed
+
+				$end = $from + 1;
+				while (!feof($handle) && ftell($handle) < $end) {
+					$len = $from - ftell($handle);
+					if ($len > $chunkSize) {
+						$len = $chunkSize;
+					}
+					$result = fread($handle, $len);
+
+					if ($result === false) {
+						$startReading = false;
+						break;
+					}
+				}
+			}
+
+			if ($startReading) {
 				$end = $to + 1;
 				while (!feof($handle) && ftell($handle) < $end) {
 					$len = $end - ftell($handle);


### PR DESCRIPTION
Seeking is not needed if the $from is 0, because then the pointer is already at the correct position. Additionally another fallback is added, that if the fseek fails it just uses an fread to skip the beginning of the file until it is at the correct position.
