### PR TITLE
use fopen directly when reading objects from s3

### DIFF
--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -49,12 +49,15 @@ trait S3ObjectTrait {
 			'Bucket' => $this->bucket,
 			'Key' => $urn
 		]);
-		$command['@http']['stream'] = true;
-		$result = $client->execute($command);
-		/** @var StreamInterface $body */
-		$body = $result['Body'];
+		$request = \Aws\serialize($command);
+		$opts = [
+			'http' => [
+				'header' => $request->getHeaders()
+			]
+		];
 
-		return $body->detach();
+		$context = stream_context_create($opts);
+		return fopen($request->getUri(), 'r', false, $context);
 	}
 
 	/**


### PR DESCRIPTION
Bypassing curl/guzzle.

This *might* help with errors when dealing with large downloads