### PR TITLE
#6307 fix page title not changed (stable12)

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1635,6 +1635,7 @@
 				// close sidebar
 				this._updateDetailsView(null);
 			}
+			this._setCurrentDir(this.getCurrentDirectory(), false);
 			var callBack = this.reloadCallback.bind(this);
 			return this._reloadCall.then(callBack, callBack);
 		},

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1523,7 +1523,9 @@ describe('OCA.Files.FileList tests', function() {
 			var setDirSpy = sinon.spy(fileList.breadcrumb, 'setDirectory');
 			fileList.changeDirectory('/anothersubdir');
 			deferredList.resolve(200, [testRoot].concat(testFiles));
-			expect(fileList.breadcrumb.setDirectory.calledOnce).toEqual(true);
+			// twice because setDirectory gets called by _setCurrentDir which
+			// gets called directly by changeDirectory and via reload()
+			expect(fileList.breadcrumb.setDirectory.calledTwice).toEqual(true);
 			expect(fileList.breadcrumb.setDirectory.calledWith('/anothersubdir')).toEqual(true);
 			setDirSpy.restore();
 			getFolderContentsStub.restore();

--- a/apps/systemtags/js/systemtagsfilelist.js
+++ b/apps/systemtags/js/systemtagsfilelist.js
@@ -234,6 +234,9 @@
 		},
 
 		reload: function() {
+			// there is only root
+			this._setCurrentDir('/', false);
+
 			if (!this._systemTagIds.length) {
 				// don't reload
 				this.updateEmptyContent();


### PR DESCRIPTION
Fixes #6307

Backport of #6869 

With this changes the page title gets set when switching to file list and tag list.

@danxuliu here is the pull request to bring the bugfix also to _stable12_.