### PR TITLE
Improve performance of UserMountCache with external storage folders

### DIFF
--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -194,7 +194,11 @@ class UserMountCache implements IUserMountCache {
 		if (is_null($user)) {
 			return null;
 		}
-		return new CachedMountInfo($user, (int)$row['storage_id'], (int)$row['root_id'], $row['mount_point'], $row['mount_id'], isset($row['path']) ? $row['path'] : '');
+		$mount_id = $row['mount_id'];
+		if (!is_null($mount_id)) {
+			$mount_id = (int) $mount_id;
+		}
+		return new CachedMountInfo($user, (int)$row['storage_id'], (int)$row['root_id'], $row['mount_point'], $mount_id, isset($row['path']) ? $row['path'] : '');
 	}
 
 	/**


### PR DESCRIPTION
I use Nextcloud (stable - currently 12.0.3) primarily to share photos with my family and friends. Since generating image previews feels a bit slow, I have started looking for potential causes of the slowness.

I have noticed that during each request a few records are updated in the '**oc_mounts**' table. After some more investigation I have found out that these are related to the external storage folders that I have configured in my installation.

The problem seems to be that within **UserMountCache::findChangedMounts** method the types of the mount IDs do not match between **$newMounts** and **$cachedMounts**. The mount ID in **$cachedMounts** is a **string** while the one in **$newMounts** is an **integer**. The strict comparison (!==) fails and the cached mounts always get updated.

Since I have a few external folders configured, in my configuration this caused an additional ~100ms delay on each request.

The proposed change seems to fix this issue.