### PR TITLE
[PoC] Allow apps to add their own collection to the calendar-home-set

### DIFF
--- a/apps/dav/lib/CalDAV/ICalendarHomePlugin.php
+++ b/apps/dav/lib/CalDAV/ICalendarHomePlugin.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DAV\CalDAV;
+
+/**
+ * Interface that allows a SabreDAV plugin to register a calendar home to be
+ * returned as calendar-home-set
+ */
+interface ICalendarHomePlugin {
+
+	/**
+	 * Returns the path to a principal's calendar home.
+	 *
+	 * The return url must not end with a slash.
+	 * This function should return null in case a principal did not have
+	 * a calendar home.
+	 *
+	 * @param string $principalUrl
+	 * @return string|null
+	 */
+	public function getCalendarHomeForPrincipal($principalUrl);
+
+}

--- a/apps/dav/lib/CalDAV/Plugin.php
+++ b/apps/dav/lib/CalDAV/Plugin.php
@@ -36,8 +36,8 @@ class Plugin extends \Sabre\CalDAV\Plugin implements ICalendarHomePlugin {
 	 * @return void
 	 */
 	public function initialize(Server $server) {
-		parent::initialize($server);
-		$server->on('propFind', [$this, 'propFind']);
+		$this->server = $server;
+		$server->on('propFind', [$this, 'propFind'], 90);
 	}
 
 	/**
@@ -52,7 +52,6 @@ class Plugin extends \Sabre\CalDAV\Plugin implements ICalendarHomePlugin {
 	 * @return void
 	 */
 	public function propFind(DAV\PropFind $propFind, DAV\INode $node) {
-		parent::propFind($propFind, $node);
 		if ($node instanceof IPrincipal) {
 			$principalUrl = $node->getPrincipalUrl();
 			$propFind->handle('{' . self::NS_CALDAV . '}calendar-home-set', function () use ($principalUrl) {

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -135,6 +135,7 @@ class Server {
 		$this->server->addPlugin($acl);
 
 		// calendar plugins
+		$this->server->addPlugin(new \Sabre\CalDAV\Plugin());
 		$this->server->addPlugin(new \OCA\DAV\CalDAV\Plugin());
 		$this->server->addPlugin(new \Sabre\CalDAV\ICSExportPlugin());
 		$this->server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin());


### PR DESCRIPTION
This way apps providing a CalDAV collection can be found by clients
looking for the calendar-home-set. Since some client implementations
only check for the first entry in that set, we need to make sure that
the calendars collection is at index 0.

This is as it is specified in RFC 4791 https://tools.ietf.org/html/rfc4791#section-6.2.1

## Use case

With #6835 apps can register custom dav collections. For the https://github.com/nextcloud/deck I plan to implement an additional CalDAV endpoint, that exposes each board as a calendar. In order to let apps like davdroid detect existing calendars using the calendar-home-set, it should be possible for apps to extend this.

## Client implementations

Clients that can handle multiple entries:
- davdroid
- Outlook CalDAV synchronizer aluxnimm/outlookcaldavsynchronizer#139

Clients that use only the first entry:
- Nextcloud calendar app
- Nextcloud tasks app
- Evolution
- gnome-online-accounts (gnome-calendar/gnome-todo)
- macOS
- iOS (untested)

Clients that break:
- Fantastical

I'm not sure if there are clients that will have problems with this implementation, but in general they should be fine, since the first entry will always be the Nextcloud default calendar set.

cc @nextcloud/calendar @nextcloud/tasks