### PR TITLE
Directly show "Forgot password?" link, fix #6808

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -384,12 +384,21 @@ form .warning input[type='checkbox']+label {
 #remember_login {
 	margin: 18px 5px 0 16px !important;
 }
-.remember-login-container {
+.remember-login-container,
+.lost-password-container {
 	display: inline-block;
 	margin: 10px 0;
 	text-align: center;
 	width: 100%;
 	text-shadow: 0 0 2px rgba(0, 0, 0, .4); // better readability on bright background
+}
+.lost-password-container {
+	margin: 0;
+}
+.lost-password-container #lost-password {
+	color: #fff;
+	padding: 10px;
+	opacity: .7;
 }
 #forgot-password {
 	padding: 11px;

--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -393,9 +393,6 @@ form .warning input[type='checkbox']+label {
 	width: 100%;
 	text-shadow: 0 0 2px rgba(0, 0, 0, .4); // better readability on bright background
 }
-.lost-password-container {
-	margin: 0;
-}
 .lost-password-container #lost-password,
 .lost-password-container #lost-password-back {
 	display: inline-block;

--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -130,26 +130,27 @@ form #datadirField legend {
 }
 
 /* Buttons and input */
-#submit-wrapper {
+#submit-wrapper,
+#reset-password-wrapper {
 	position: relative; /* Make the wrapper the containing block of its
 						   absolutely positioned descendant icons */
 }
-#submit-wrapper .icon-confirm-white {
+
+#submit-wrapper .submit-icon,
+#reset-password-wrapper .submit-icon {
 	position: absolute;
 	top: 23px;
 	right: 23px;
-}
-#submit-wrapper .icon-loading-small {
-	position: absolute;
-	top: 22px;
-	right: 24px;
-}
-
-#submit-wrapper #submit-icon {
 	pointer-events: none; /* The submit icon is positioned on the submit button.
 							 From the user point of view the icon is part of the
 							 button, so the clicks on the icon have to be
 							 applied to the button instead. */
+}
+
+#submit-wrapper .icon-loading-small {
+	position: absolute;
+	top: 22px;
+	right: 24px;
 }
 
 input, textarea, select, button, div[contenteditable=true] {
@@ -395,9 +396,12 @@ form .warning input[type='checkbox']+label {
 .lost-password-container {
 	margin: 0;
 }
-.lost-password-container #lost-password {
+.lost-password-container #lost-password,
+.lost-password-container #lost-password-back {
+	display: inline-block;
+	padding: 12px;
+	margin-top: -6px;
 	color: #fff;
-	padding: 10px;
 	opacity: .7;
 }
 #forgot-password {

--- a/core/js/login.js
+++ b/core/js/login.js
@@ -12,7 +12,7 @@
  */
 OC.Login = _.extend(OC.Login || {}, {
 	onLogin: function () {
-		$('#submit-icon')
+		$('#submit-wrapper .submit-icon')
 			.removeClass('icon-confirm-white')
 			.addClass('icon-loading-small');
 		$('#submit')

--- a/core/js/login.js
+++ b/core/js/login.js
@@ -12,12 +12,17 @@
  */
 OC.Login = _.extend(OC.Login || {}, {
 	onLogin: function () {
-		$('#submit-wrapper .submit-icon')
-			.removeClass('icon-confirm-white')
-			.addClass('icon-loading-small');
-		$('#submit')
-			.attr('value', t('core', 'Logging in …'));
-		return true;
+		// Only if password reset form is not active
+		if($('form[name=login][action]').length === 0) {
+			$('#submit-wrapper .submit-icon')
+				.removeClass('icon-confirm-white')
+				.addClass('icon-loading-small-dark');
+			$('#submit')
+				.attr('value', t('core', 'Logging in …'));
+			$('.login-additional').fadeOut();
+			return true;
+		}
+		return false;
 	},
 
 	rememberLogin: function(){

--- a/core/js/lostpassword.js
+++ b/core/js/lostpassword.js
@@ -14,11 +14,33 @@ OC.Lostpassword = {
 
 	init : function() {
 		$('#lost-password').click(OC.Lostpassword.resetLink);
-		$('#reset-password #submit').click(OC.Lostpassword.resetPassword);
+		$('#reset-password-submit').click(OC.Lostpassword.resetPassword);
+		$('#lost-password-back').click(OC.Lostpassword.backToLogin);
+	},
+
+	backToLogin : function(event){
+		event.preventDefault();
+
+		$('#reset-password-wrapper').slideUp().fadeOut();
+		$('#lost-password').slideDown().fadeIn();
+		$('.remember-login-container').slideDown().fadeIn();
+		$('#submit-wrapper').slideDown().fadeIn();
+		$('.groupbottom').slideDown().fadeIn();
+		$('#user').parent().addClass('grouptop');
+		$('#user').focus();
 	},
 
 	resetLink : function(event){
 		event.preventDefault();
+
+		$('#lost-password').slideUp().fadeOut();
+		$('.remember-login-container').slideUp().fadeOut();
+		$('#submit-wrapper').slideUp().fadeOut();
+		$('.groupbottom').slideUp().fadeOut();
+		$('#user').parent().removeClass('grouptop');
+		$('#reset-password-wrapper').slideDown().fadeIn();
+		$('#user').focus();
+
 		if (!$('#user').val().length){
 			$('#submit').trigger('click');
 		} else {

--- a/core/js/lostpassword.js
+++ b/core/js/lostpassword.js
@@ -16,6 +16,11 @@ OC.Lostpassword = {
 		$('#lost-password').click(OC.Lostpassword.resetLink);
 		$('#reset-password-submit').click(OC.Lostpassword.resetPassword);
 		$('#lost-password-back').click(OC.Lostpassword.backToLogin);
+		$('#reset-password-wrapper .submit-icon')
+			.addClass('icon-confirm-white')
+			.removeClass('icon-loading-small');
+		$('#reset-password-submit')
+			.attr('value', t('core', 'Reset password'));
 	},
 
 	backToLogin : function(event){
@@ -41,7 +46,8 @@ OC.Lostpassword = {
 		$('#reset-password-wrapper').slideDown().fadeIn();
 		$('#user').focus();
 
-		if (!$('#user').val().length){
+		// Generate a browser warning if field empty
+		if ($('#user').val().length === 0) {
 			$('#submit').trigger('click');
 		} else {
 			if (OC.config.lost_password_link === 'disabled') {
@@ -49,6 +55,7 @@ OC.Lostpassword = {
 			} else if (OC.config.lost_password_link) {
 				window.location = OC.config.lost_password_link;
 			} else {
+				OC.Lostpassword.onSendLink();
 				$.post(
 					OC.generateUrl('/lostpassword/email'),
 					{
@@ -60,6 +67,15 @@ OC.Lostpassword = {
 				});
 			}
 		}
+	},
+
+	onSendLink: function () {
+		$('.submit-icon')
+			.removeClass('icon-confirm-white')
+			.addClass('icon-loading-small');
+		$('#reset-password-submit')
+			.attr('value', t('core', 'Sending email …'));
+		return true;
 	},
 
 	sendLinkDone : function(result){

--- a/core/js/lostpassword.js
+++ b/core/js/lostpassword.js
@@ -35,6 +35,7 @@ OC.Lostpassword = {
 
 		$('#reset-password-wrapper').slideUp().fadeOut();
 		$('#lost-password').slideDown().fadeIn();
+		$('#lost-password-back').hide();
 		$('.remember-login-container').slideDown().fadeIn();
 		$('#submit-wrapper').slideDown().fadeIn();
 		$('.groupbottom').slideDown().fadeIn();
@@ -47,7 +48,8 @@ OC.Lostpassword = {
 	resetLink : function(event){
 		event.preventDefault();
 
-		$('#lost-password').slideUp().fadeOut();
+		$('#lost-password').hide();
+		$('#lost-password-back').slideDown().fadeIn();
 		$('.remember-login-container').slideUp().fadeOut();
 		$('#submit-wrapper').slideUp().fadeOut();
 		$('.groupbottom').slideUp().fadeOut(function(){
@@ -118,6 +120,7 @@ OC.Lostpassword = {
 		// update is the better success message styling
 		node.addClass('update').css({width:'auto'});
 		node.html(OC.Lostpassword.sendSuccessMsg);
+		OC.Lostpassword.resetButtons();
 	},
 
 	sendLinkError : function(msg){

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -75,6 +75,13 @@ script('core', 'merged-login');
 				<?php } ?>
 				<label for="remember_login"><?php p($l->t('Stay logged in')); ?></label>
 			</div>
+			<?php if (!empty($_['canResetPassword'])) { ?>
+			<div class="lost-password-container">
+				<a id="lost-password" href="<?php p($_['resetPasswordLink']); ?>">
+					<?php p($l->t('Forgot password?')); ?>
+				</a>
+			</div>
+			<?php } ?>
 		</div>
 
 		<input type="hidden" name="timezone_offset" id="timezone_offset"/>

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -51,7 +51,7 @@ script('core', 'merged-login');
 			<label for="password" class="infield"><?php p($l->t('Password')); ?></label>
 		</p>
 
-		<?php if (!empty($_['invalidpassword']) && !empty($_['canResetPlost-passwordassword'])) { ?>
+		<?php if (!empty($_['invalidpassword']) && !empty($_['canResetPassword'])) { ?>
 		<a id="lost-password" class="warning" href="<?php p($_['resetPasswordLink']); ?>">
 			<?php p($l->t('Wrong password. Reset it?')); ?>
 		</a>

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -51,7 +51,7 @@ script('core', 'merged-login');
 			<label for="password" class="infield"><?php p($l->t('Password')); ?></label>
 		</p>
 
-		<?php if (!empty($_['invalidpassword']) && !empty($_['canResetPassword'])) { ?>
+		<?php if (!empty($_['invalidpassword']) && !empty($_['canResetPlost-passwordassword'])) { ?>
 		<a id="lost-password" class="warning" href="<?php p($_['resetPasswordLink']); ?>">
 			<?php p($l->t('Wrong password. Reset it?')); ?>
 		</a>
@@ -63,7 +63,7 @@ script('core', 'merged-login');
 
 		<div id="submit-wrapper">
 			<input type="submit" id="submit" class="login primary" title="" value="<?php p($l->t('Log in')); ?>" disabled="disabled" />
-			<div id="submit-icon" class="icon-confirm-white"></div>
+			<div class="submit-icon icon-confirm-white"></div>
 		</div>
 
 		<div class="login-additional">
@@ -80,6 +80,13 @@ script('core', 'merged-login');
 				<a id="lost-password" href="<?php p($_['resetPasswordLink']); ?>">
 					<?php p($l->t('Forgot password?')); ?>
 				</a>
+				<div id="reset-password-wrapper" style="display: none;">
+					<input type="submit" id="reset-password-submit" class="login primary" title="" value="<?php p($l->t('Reset password')); ?>" disabled="disabled" />
+					<div class="submit-icon icon-confirm-white"></div>
+					<a id="lost-password-back" href="">
+						<?php p($l->t('Back to log in')); ?>
+					</a>
+				</div>
 			</div>
 			<?php } ?>
 		</div>

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -51,11 +51,7 @@ script('core', 'merged-login');
 			<label for="password" class="infield"><?php p($l->t('Password')); ?></label>
 		</p>
 
-		<?php if (!empty($_['invalidpassword']) && !empty($_['canResetPassword'])) { ?>
-		<a id="lost-password" class="warning" href="<?php p($_['resetPasswordLink']); ?>">
-			<?php p($l->t('Wrong password. Reset it?')); ?>
-		</a>
-		<?php } else if (!empty($_['invalidpassword'])) { ?>
+		<?php if (!empty($_['invalidpassword'])) { ?>
 			<p class="warning">
 				<?php p($l->t('Wrong password.')); ?>
 			</p>
@@ -65,6 +61,13 @@ script('core', 'merged-login');
 			<input type="submit" id="submit" class="login primary" title="" value="<?php p($l->t('Log in')); ?>" disabled="disabled" />
 			<div class="submit-icon icon-confirm-white"></div>
 		</div>
+
+		<?php if (!empty($_['canResetPassword'])) { ?>
+		<div id="reset-password-wrapper" style="display: none;">
+			<input type="submit" id="reset-password-submit" class="login primary" title="" value="<?php p($l->t('Reset password')); ?>" disabled="disabled" />
+			<div class="submit-icon icon-confirm-white"></div>
+		</div>
+		<?php } ?>
 
 		<div class="login-additional">
 			<div class="remember-login-container">
@@ -80,13 +83,9 @@ script('core', 'merged-login');
 				<a id="lost-password" href="<?php p($_['resetPasswordLink']); ?>">
 					<?php p($l->t('Forgot password?')); ?>
 				</a>
-				<div id="reset-password-wrapper" style="display: none;">
-					<input type="submit" id="reset-password-submit" class="login primary" title="" value="<?php p($l->t('Reset password')); ?>" disabled="disabled" />
-					<div class="submit-icon icon-confirm-white"></div>
-					<a id="lost-password-back" href="">
-						<?php p($l->t('Back to log in')); ?>
-					</a>
-				</div>
+				<a id="lost-password-back" href="" style="display:none;">
+					<?php p($l->t('Back to log in')); ?>
+				</a>
 			</div>
 			<?php } ?>
 		</div>

--- a/tests/acceptance/features/bootstrap/LoginPageContext.php
+++ b/tests/acceptance/features/bootstrap/LoginPageContext.php
@@ -66,7 +66,7 @@ class LoginPageContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function wrongPasswordMessage() {
-		return Locator::forThe()->xpath("//*[@class = 'warning' and normalize-space() = 'Wrong password. Reset it?']")->
+		return Locator::forThe()->xpath("//*[@class = 'warning' and normalize-space() = 'Wrong password.']")->
 				describedAs("Wrong password message in Login page");
 	}
 


### PR DESCRIPTION
We still need some JS so that when you click »Forgot password?«:

- [x] The password field is hidden
- [x] The log in button text is changed to »Reset password«
- [x] After the password is reset, the view is morphed back

Ref #6808 cc @ccoenen @nextcloud/javascript 