### PR TITLE
Fix mismatch method signature in Nextcloud 11

### DIFF
--- a/lib/private/Files/Storage/FailedStorage.php
+++ b/lib/private/Files/Storage/FailedStorage.php
@@ -183,7 +183,7 @@ class FailedStorage extends Common {
 		return true;
 	}
 
-	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false) {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -419,7 +419,7 @@ class Local extends \OC\Files\Storage\Common {
 	 * @param string $targetInternalPath
 	 * @return bool
 	 */
-	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false) {
 		if ($sourceStorage->instanceOfStorage('\OC\Files\Storage\Local')) {
 			/**
 			 * @var \OC\Files\Storage\Local $sourceStorage

--- a/lib/private/Lockdown/Filesystem/NullStorage.php
+++ b/lib/private/Lockdown/Filesystem/NullStorage.php
@@ -156,7 +156,7 @@ class NullStorage extends Common {
 		return false;
 	}
 
-	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false) {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -26,8 +26,8 @@ class TemporaryNoTouch extends \OC\Files\Storage\Temporary {
 }
 
 class TemporaryNoCross extends \OC\Files\Storage\Temporary {
-	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
-		return Common::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false) {
+		return Common::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime);
 	}
 
 	public function moveFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {


### PR DESCRIPTION
Refer to issue #6991, I included fixes for other child class related to \OC\Files\Storage\Common also.