### PR TITLE
Better readability for text on log in page which is directly on backgrounds

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -389,6 +389,7 @@ form .warning input[type='checkbox']+label {
 	margin: 10px 0;
 	text-align: center;
 	width: 100%;
+	text-shadow: 0 0 2px rgba(0, 0, 0, .4); // better readability on bright background
 }
 #forgot-password {
 	padding: 11px;
@@ -559,6 +560,7 @@ fieldset.update legend + p {
 p.info {
 	margin: 0 auto;
 	padding-top: 20px;
+	text-shadow: 0 0 2px rgba(0, 0, 0, .4); // better readability on bright background
 	-webkit-user-select: none;
 	-moz-user-select: none;
 	-ms-user-select: none;


### PR DESCRIPTION
(Ignore the »Forgot password?« link, it’s from another change. ;) Just note there’s a tiny bit of text-shadow for better readability.)
![screenshot from 2017-10-30 17-59-30](https://user-images.githubusercontent.com/925062/32223682-9f4fd1cc-be3e-11e7-971e-156ff31a05ce.png)

Please review @nextcloud/designers @irgendwie  – it’s especially good t test it with the Unsplash app: https://apps.nextcloud.com/apps/unsplash

Basically same we fixed in Contacts for the header: https://github.com/nextcloud/contacts/pull/338