### PR TITLE
Use the new direct endpoint for the OpenGraph image

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -373,15 +373,20 @@ class ShareController extends Controller {
 		$shareTmpl['previewMaxY'] = $this->config->getSystemValue('preview_max_y', 1024);
 		$shareTmpl['disclaimer'] = $this->config->getAppValue('core', 'shareapi_public_link_disclaimertext', null);
 		$shareTmpl['previewURL'] = $shareTmpl['downloadURL'];
+		$ogPreview = '';
 		if ($shareTmpl['previewSupported']) {
 			$shareTmpl['previewImage'] = $this->urlGenerator->linkToRouteAbsolute( 'files_sharing.PublicPreview.getPreview',
 				['x' => 200, 'y' => 200, 'file' => $shareTmpl['directory_path'], 't' => $shareTmpl['dirToken']]);
+			$ogPreview = $shareTmpl['previewImage'];
+
 			// We just have direct previews for image files
 			if ($share->getNode()->getMimePart() === 'image') {
 				$shareTmpl['previewURL'] = $this->urlGenerator->linkToRouteAbsolute('files_sharing.publicpreview.directLink', ['token' => $token]);
+				$ogPreview = $shareTmpl['previewURL'];
 			}
 		} else {
 			$shareTmpl['previewImage'] = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'favicon-fb.png'));
+			$ogPreview = $shareTmpl['previewImage'];
 		}
 
 		// Load files we need
@@ -411,7 +416,7 @@ class ShareController extends Controller {
 		\OCP\Util::addHeader('meta', ['property' => "og:site_name", 'content' => $this->defaults->getName()]);
 		\OCP\Util::addHeader('meta', ['property' => "og:url", 'content' => $shareTmpl['shareUrl']]);
 		\OCP\Util::addHeader('meta', ['property' => "og:type", 'content' => "object"]);
-		\OCP\Util::addHeader('meta', ['property' => "og:image", 'content' => $shareTmpl['previewImage']]);
+		\OCP\Util::addHeader('meta', ['property' => "og:image", 'content' => $ogPreview]);
 
 		$this->eventDispatcher->dispatch('OCA\Files_Sharing::loadAdditionalScripts');
 


### PR DESCRIPTION
Fixes #5149 

Some providers had issues when using the preview link (since it was double encoded).

Now we actually serve the max size preview so it looks better

The image isn't cropped anymore so supporting platforms can just embed
the whole image.

Basically share single image. And then post it to FB, twitter or whatever. If should look fancier now.