### PR TITLE
Fix settings section whitespace

### DIFF
--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -787,8 +787,11 @@ span.version {
 		display: block;
 		margin: 8px 0;
 	}
-	padding: 10px 30px;
 	margin-bottom: 0;
+}
+
+.personal-settings-setting-box .section {
+	padding: 10px 30px;
 }
 
 .followupsection {


### PR DESCRIPTION
Whitespace between settings sections was non-existent cause it was overwritten:
![screenshot from 2017-11-02 11-03-45](https://user-images.githubusercontent.com/925062/32320311-99d41ac0-bfbd-11e7-8a3d-3ea0c8512a5c.png)

Fixed:
![screenshot from 2017-11-02 11-02-37](https://user-images.githubusercontent.com/925062/32320312-99fc5fee-bfbd-11e7-8114-be41178e8848.png)

Please review @nextcloud/designers @blizzz