### PR TITLE
Hide summary file actions when a selected file does not match

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2822,8 +2822,28 @@
 				this.$el.find('#headerName a.name>span:first').text(selection);
 				this.$el.find('#modified a>span:first').text('');
 				this.$el.find('table').addClass('multiselect');
+				this.$el.find('.selectedActions .copy-move').toggleClass('hidden', !this.isSelectedCopiableOrMovable());
+				this.$el.find('.selectedActions .download').toggleClass('hidden', !this.isSelectedDownloadable());
 				this.$el.find('.delete-selected').toggleClass('hidden', !this.isSelectedDeletable());
 			}
+		},
+
+		/**
+		 * Check whether all selected files are copiable or movable
+		 */
+		isSelectedCopiableOrMovable: function() {
+			return _.reduce(this.getSelectedFiles(), function(copiableOrMovable, file) {
+				return copiableOrMovable && (file.permissions & OC.PERMISSION_UPDATE);
+			}, true);
+		},
+
+		/**
+		 * Check whether all selected files are downloadable
+		 */
+		isSelectedDownloadable: function() {
+			return _.reduce(this.getSelectedFiles(), function(downloadable, file) {
+				return downloadable && (file.permissions & OC.PERMISSION_READ);
+			}, true);
 		},
 
 		/**

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -94,6 +94,7 @@ describe('OCA.Files.FileList tests', function() {
 			'<input type="checkbox" id="select_all_files" class="select-all checkbox">' +
 			'<a class="name columntitle" data-sort="name"><span>Name</span><span class="sort-indicator"></span></a>' +
 			'<span id="selectedActionsList" class="selectedActions hidden">' +
+			'<a href class="copy-move">Move or copy</a>' +
 			'<a href class="download"><img src="actions/download.svg">Download</a>' +
 			'<a href class="delete-selected">Delete</a></span>' +
 			'</th>' +
@@ -2024,6 +2025,28 @@ describe('OCA.Files.FileList tests', function() {
 			});
 		});
 		describe('Selection overlay', function() {
+			it('show doesnt show the copy/move action if one or more files are not copiable/movable', function () {
+				fileList.setFiles(testFiles);
+				$('#permissions').val(OC.PERMISSION_READ | OC.PERMISSION_UPDATE);
+				$('.select-all').click();
+				expect(fileList.$el.find('.selectedActions .copy-move').hasClass('hidden')).toEqual(false);
+				testFiles[0].permissions = OC.PERMISSION_READ;
+				$('.select-all').click();
+				fileList.setFiles(testFiles);
+				$('.select-all').click();
+				expect(fileList.$el.find('.selectedActions .copy-move').hasClass('hidden')).toEqual(true);
+			});
+			it('show doesnt show the download action if one or more files are not downloadable', function () {
+				fileList.setFiles(testFiles);
+				$('#permissions').val(OC.PERMISSION_READ | OC.PERMISSION_UPDATE);
+				$('.select-all').click();
+				expect(fileList.$el.find('.selectedActions .download').hasClass('hidden')).toEqual(false);
+				testFiles[0].permissions = OC.PERMISSION_UPDATE;
+				$('.select-all').click();
+				fileList.setFiles(testFiles);
+				$('.select-all').click();
+				expect(fileList.$el.find('.selectedActions .download').hasClass('hidden')).toEqual(true);
+			});
 			it('show doesnt show the delete action if one or more files are not deletable', function () {
 				fileList.setFiles(testFiles);
 				$('#permissions').val(OC.PERMISSION_READ | OC.PERMISSION_DELETE);


### PR DESCRIPTION
When several files are selected and one of them can not be deleted the _Delete_ file action is not shown in the summary. This pull request extends that behaviour too to the other file actions in the summary (_Move or copy_ and _Download_), so now an action is shown in the summary only if it can be executed on all the currently selected files.

This is a requisite for proper handling of encrypted folders in #6670.

Hiding the actions may not be the best solution regarding the user experience, as a user may not understand why the actions do not appear if she selects all the files in a folder, or she may expect the actions to always be available and to be performed only on the matching files.

In the future it may be worth considering an alternative approach, like a notification letting the user know on which files the action was not executed, or a dialog informing about that before performing the action, or a visible but disabled action that hints on why it is disabled, or whatever (there are probably much better solutions, those are just examples ;-) ).

But for the time being I am afraid that we will have to live with hidden actions ;-)
