### PR TITLE
Add support for files with no permissions

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -299,6 +299,9 @@ abstract class Node implements \Sabre\DAV\INode {
 		if ($this->info->isMounted()) {
 			$p .= 'M';
 		}
+		if ($this->info->isReadable()) {
+			$p .= 'G';
+		}
 		if ($this->info->isDeletable()) {
 			$p .= 'D';
 		}

--- a/apps/dav/tests/unit/Connector/Sabre/NodeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/NodeTest.php
@@ -41,15 +41,17 @@ use OCP\Share\IShare;
 class NodeTest extends \Test\TestCase {
 	public function davPermissionsProvider() {
 		return array(
-			array(\OCP\Constants::PERMISSION_ALL, 'file', false, false, 'RDNVW'),
-			array(\OCP\Constants::PERMISSION_ALL, 'dir', false, false, 'RDNVCK'),
-			array(\OCP\Constants::PERMISSION_ALL, 'file', true, false, 'SRDNVW'),
-			array(\OCP\Constants::PERMISSION_ALL, 'file', true, true, 'SRMDNVW'),
-			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_SHARE, 'file', true, false, 'SDNVW'),
-			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_UPDATE, 'file', false, false, 'RD'),
-			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_DELETE, 'file', false, false, 'RNVW'),
-			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_CREATE, 'file', false, false, 'RDNVW'),
-			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_CREATE, 'dir', false, false, 'RDNV'),
+			array(\OCP\Constants::PERMISSION_ALL, 'file', false, false, 'RGDNVW'),
+			array(\OCP\Constants::PERMISSION_ALL, 'dir', false, false, 'RGDNVCK'),
+			array(\OCP\Constants::PERMISSION_ALL, 'file', true, false, 'SRGDNVW'),
+			array(\OCP\Constants::PERMISSION_ALL, 'file', true, true, 'SRMGDNVW'),
+			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_SHARE, 'file', true, false, 'SGDNVW'),
+			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_UPDATE, 'file', false, false, 'RGD'),
+			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_DELETE, 'file', false, false, 'RGNVW'),
+			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_CREATE, 'file', false, false, 'RGDNVW'),
+			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_READ, 'file', false, false, 'RDNVW'),
+			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_CREATE, 'dir', false, false, 'RGDNV'),
+			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_READ, 'dir', false, false, 'RDNVCK'),
 		);
 	}
 

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -235,7 +235,7 @@
 			}
 			var filteredActions = {};
 			$.each(actions, function (name, action) {
-				if (action.permissions & permissions) {
+				if ((action.permissions === OC.PERMISSION_NONE) || (action.permissions & permissions)) {
 					filteredActions[name] = action;
 				}
 			});

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -407,7 +407,7 @@
 					mime: 'all',
 					order: -50,
 					iconClass: 'icon-details',
-					permissions: OC.PERMISSION_READ,
+					permissions: OC.PERMISSION_NONE,
 					actionHandler: function(fileName, context) {
 						self._updateDetailsView(fileName);
 					}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1159,6 +1159,11 @@
 				}
 			}
 
+			var permissions = fileData.permissions;
+			if (permissions === undefined || permissions === null) {
+				permissions = this.getDirectoryPermissions();
+			}
+
 			//containing tr
 			var tr = $('<tr></tr>').attr({
 				"data-id" : fileData.id,
@@ -1168,7 +1173,7 @@
 				"data-mime": mime,
 				"data-mtime": mtime,
 				"data-etag": fileData.etag,
-				"data-permissions": fileData.permissions || this.getDirectoryPermissions(),
+				"data-permissions": permissions,
 				"data-has-preview": fileData.hasPreview !== false
 			});
 

--- a/apps/files/js/tagsplugin.js
+++ b/apps/files/js/tagsplugin.js
@@ -104,7 +104,7 @@
 				},
 				mime: 'all',
 				order: -100,
-				permissions: OC.PERMISSION_READ,
+				permissions: OC.PERMISSION_NONE,
 				iconClass: function(fileName, context) {
 					var $file = context.$file;
 					var isFavorite = $file.data('favorite') === true;

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -296,6 +296,15 @@ describe('OCA.Files.FileList tests', function() {
 			expect($tr.find('.filesize').text()).toEqual('Pending');
 			expect($tr.find('.date').text()).not.toEqual('?');
 		});
+		it('generates file element with no permissions when permissions are explicitly none', function() {
+			var fileData = {
+				type: 'dir',
+				name: 'testFolder',
+				permissions: OC.PERMISSION_NONE
+			};
+			var $tr = fileList.add(fileData);
+			expect($tr.attr('data-permissions')).toEqual('0');
+		});
 		it('generates file element with zero size when size is explicitly zero', function() {
 			var fileData = {
 				type: 'dir',

--- a/build/integration/features/sharing-v1-part3.feature
+++ b/build/integration/features/sharing-v1-part3.feature
@@ -167,7 +167,7 @@ Feature: sharing
     And folder "/merge-test-outside-perms" of user "user0" is shared with user "user1" with permissions 31
     Then as "user1" gets properties of folder "/merge-test-outside-perms" with
       |{http://owncloud.org/ns}permissions|
-    And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRGDNVCK"
     And as "user1" the folder "/merge-test-outside-perms (2)" does not exist
 
   Scenario: Merging shares for recipient when shared from outside with two groups
@@ -197,7 +197,7 @@ Feature: sharing
     And folder "/merge-test-outside-twogroups-perms" of user "user0" is shared with group "group2" with permissions 31
     Then as "user1" gets properties of folder "/merge-test-outside-twogroups-perms" with
       |{http://owncloud.org/ns}permissions|
-    And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRGDNVCK"
     And as "user1" the folder "/merge-test-outside-twogroups-perms (2)" does not exist
 
   Scenario: Merging shares for recipient when shared from outside with two groups and member
@@ -214,7 +214,7 @@ Feature: sharing
     And folder "/merge-test-outside-twogroups-member-perms" of user "user0" is shared with user "user1" with permissions 1
     Then as "user1" gets properties of folder "/merge-test-outside-twogroups-member-perms" with
       |{http://owncloud.org/ns}permissions|
-    And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRGDNVCK"
     And as "user1" the folder "/merge-test-outside-twogroups-member-perms (2)" does not exist
 
   Scenario: Merging shares for recipient when shared from inside with group
@@ -253,7 +253,7 @@ Feature: sharing
     And folder "/merge-test-inside-twogroups-perms" of user "user0" is shared with group "group2"
     Then as "user0" gets properties of folder "/merge-test-inside-twogroups-perms" with
       |{http://owncloud.org/ns}permissions|
-    And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "RDNVCK"
+    And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "RGDNVCK"
     And as "user0" the folder "/merge-test-inside-twogroups-perms (2)" does not exist
     And as "user0" the folder "/merge-test-inside-twogroups-perms (3)" does not exist
 
@@ -270,7 +270,7 @@ Feature: sharing
     And folder "/merge-test-outside-groups-renamebeforesecondshare" of user "user0" is shared with user "user1"
     Then as "user1" gets properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" with
       |{http://owncloud.org/ns}permissions|
-    And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRGDNVCK"
     And as "user1" the folder "/merge-test-outside-groups-renamebeforesecondshare" does not exist
 
   Scenario: Merging shares for recipient when shared from outside with user then group and recipient renames in between
@@ -287,7 +287,7 @@ Feature: sharing
     And folder "/merge-test-outside-groups-renamebeforesecondshare" of user "user0" is shared with group "group1"
     Then as "user1" gets properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" with
       |{http://owncloud.org/ns}permissions|
-    And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+    And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRGDNVCK"
     And as "user1" the folder "/merge-test-outside-groups-renamebeforesecondshare" does not exist
 
   Scenario: Empting trashbin

--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -319,7 +319,7 @@
 				}
 			}
 
-			data.permissions = OC.PERMISSION_READ;
+			data.permissions = OC.PERMISSION_NONE;
 			var permissionProp = props[Client.PROPERTY_PERMISSIONS];
 			if (!_.isUndefined(permissionProp)) {
 				var permString = permissionProp || '';
@@ -331,6 +331,9 @@
 						case 'C':
 						case 'K':
 							data.permissions |= OC.PERMISSION_CREATE;
+							break;
+						case 'G':
+							data.permissions |= OC.PERMISSION_READ;
 							break;
 						case 'W':
 						case 'N':

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -60,6 +60,7 @@ function fileDownloadPath(dir, file) {
 /** @namespace */
 var OCP = {},
 	OC = {
+	PERMISSION_NONE:0,
 	PERMISSION_CREATE:4,
 	PERMISSION_READ:1,
 	PERMISSION_UPDATE:2,

--- a/core/js/tests/specs/files/clientSpec.js
+++ b/core/js/tests/specs/files/clientSpec.js
@@ -658,26 +658,11 @@ describe('OC.Files.Client tests', function() {
 				['', true, OC.PERMISSION_READ],
 				['C', true, OC.PERMISSION_READ | OC.PERMISSION_CREATE],
 				['K', true, OC.PERMISSION_READ | OC.PERMISSION_CREATE],
-				['W', true, OC.PERMISSION_READ | OC.PERMISSION_CREATE | OC.PERMISSION_UPDATE],
+				['W', true, OC.PERMISSION_READ | OC.PERMISSION_UPDATE],
 				['D', true, OC.PERMISSION_READ | OC.PERMISSION_DELETE],
 				['R', true, OC.PERMISSION_READ | OC.PERMISSION_SHARE],
 				['CKWDR', true, OC.PERMISSION_ALL]
 			];
-			_.each(testCases, function(testCase) {
-				return testPermission.apply(this, testCase);
-			});
-		});
-		it('properly parses folder permissions', function() {
-			var testCases = [
-				['', false, OC.PERMISSION_READ],
-				['C', false, OC.PERMISSION_READ | OC.PERMISSION_CREATE | OC.PERMISSION_UPDATE],
-				['K', false, OC.PERMISSION_READ | OC.PERMISSION_CREATE | OC.PERMISSION_UPDATE],
-				['W', false, OC.PERMISSION_READ | OC.PERMISSION_UPDATE],
-				['D', false, OC.PERMISSION_READ | OC.PERMISSION_DELETE],
-				['R', false, OC.PERMISSION_READ | OC.PERMISSION_SHARE],
-				['CKWDR', false, OC.PERMISSION_ALL]
-			];
-
 			_.each(testCases, function(testCase) {
 				return testPermission.apply(this, testCase);
 			});

--- a/core/js/tests/specs/files/clientSpec.js
+++ b/core/js/tests/specs/files/clientSpec.js
@@ -640,14 +640,14 @@ describe('OC.Files.Client tests', function() {
 
 		function testPermission(permission, isFile, expectedPermissions) {
 			var promise = getFileInfoWithPermission(permission, isFile);
-			promise.then(function(result) {
+			promise.then(function(status, result) {
 				expect(result.permissions).toEqual(expectedPermissions);
 			});
 		}
 
 		function testMountType(permission, isFile, expectedMountType) {
 			var promise = getFileInfoWithPermission(permission, isFile);
-			promise.then(function(result) {
+			promise.then(function(status, result) {
 				expect(result.mountType).toEqual(expectedMountType);
 			});
 		}
@@ -664,7 +664,7 @@ describe('OC.Files.Client tests', function() {
 				['CKWDR', true, OC.PERMISSION_ALL]
 			];
 			_.each(testCases, function(testCase) {
-				return testPermission.apply(testCase);
+				return testPermission.apply(this, testCase);
 			});
 		});
 		it('properly parses folder permissions', function() {
@@ -679,7 +679,7 @@ describe('OC.Files.Client tests', function() {
 			];
 
 			_.each(testCases, function(testCase) {
-				return testPermission.apply(testCase);
+				return testPermission.apply(this, testCase);
 			});
 		});
 		it('properly parses mount types', function() {
@@ -691,7 +691,7 @@ describe('OC.Files.Client tests', function() {
 			];
 
 			_.each(testCases, function(testCase) {
-				return testMountType.apply(testCase);
+				return testMountType.apply(this, testCase);
 			});
 		});
 	});

--- a/core/js/tests/specs/files/clientSpec.js
+++ b/core/js/tests/specs/files/clientSpec.js
@@ -164,7 +164,7 @@ describe('OC.Files.Client tests', function() {
 				'd:resourcetype': '<d:collection/>',
 				'oc:id': '00000011oc2d13a6a068',
 				'oc:fileid': '11',
-				'oc:permissions': 'RDNVCK',
+				'oc:permissions': 'GRDNVCK',
 				'oc:size': '120'
 			},
 			[
@@ -196,7 +196,7 @@ describe('OC.Files.Client tests', function() {
 				'd:resourcetype': '<d:collection/>',
 				'oc:id': '00000015oc2d13a6a068',
 				'oc:fileid': '15',
-				'oc:permissions': 'RDNVCK',
+				'oc:permissions': 'GRDNVCK',
 				'oc:size': '100'
 			},
 			[
@@ -257,7 +257,7 @@ describe('OC.Files.Client tests', function() {
 				expect(info.id).toEqual(51);
 				expect(info.path).toEqual('/path/to space/文件夹');
 				expect(info.name).toEqual('One.txt');
-				expect(info.permissions).toEqual(27);
+				expect(info.permissions).toEqual(26);
 				expect(info.size).toEqual(250);
 				expect(info.mtime).toEqual(1436535485000);
 				expect(info.mimetype).toEqual('text/plain');
@@ -482,7 +482,7 @@ describe('OC.Files.Client tests', function() {
 				'd:resourcetype': '<d:collection/>',
 				'oc:id': '00000011oc2d13a6a068',
 				'oc:fileid': '11',
-				'oc:permissions': 'RDNVCK',
+				'oc:permissions': 'GRDNVCK',
 				'oc:size': '120'
 			},
 			[
@@ -549,7 +549,7 @@ describe('OC.Files.Client tests', function() {
 					'd:resourcetype': '<d:collection/>',
 					'oc:id': '00000011oc2d13a6a068',
 					'oc:fileid': '11',
-					'oc:permissions': 'RDNVCK',
+					'oc:permissions': 'GRDNVCK',
 					'oc:size': '120'
 				},
 				[
@@ -655,13 +655,14 @@ describe('OC.Files.Client tests', function() {
 		it('properly parses file permissions', function() {
 			// permission, isFile, expectedPermissions
 			var testCases = [
-				['', true, OC.PERMISSION_READ],
-				['C', true, OC.PERMISSION_READ | OC.PERMISSION_CREATE],
-				['K', true, OC.PERMISSION_READ | OC.PERMISSION_CREATE],
-				['W', true, OC.PERMISSION_READ | OC.PERMISSION_UPDATE],
-				['D', true, OC.PERMISSION_READ | OC.PERMISSION_DELETE],
-				['R', true, OC.PERMISSION_READ | OC.PERMISSION_SHARE],
-				['CKWDR', true, OC.PERMISSION_ALL]
+				['', true, OC.PERMISSION_NONE],
+				['C', true, OC.PERMISSION_CREATE],
+				['K', true, OC.PERMISSION_CREATE],
+				['G', true, OC.PERMISSION_READ],
+				['W', true, OC.PERMISSION_UPDATE],
+				['D', true, OC.PERMISSION_DELETE],
+				['R', true, OC.PERMISSION_SHARE],
+				['CKGWDR', true, OC.PERMISSION_ALL]
 			];
 			_.each(testCases, function(testCase) {
 				return testPermission.apply(this, testCase);
@@ -669,7 +670,7 @@ describe('OC.Files.Client tests', function() {
 		});
 		it('properly parses mount types', function() {
 			var testCases = [
-				['CKWDR', false, null],
+				['CKGWDR', false, null],
 				['M', false, 'external'],
 				['S', false, 'shared'],
 				['SM', false, 'shared']


### PR DESCRIPTION
Until now it was safe to assume that every file was readable by its owner, but with the introduction of end to end encryption that is no longer the case. Therefore, the server now must explicitly return whether a file is readable or not, and the web UI has to be prepared to handle files with no permissions (which is simply a matter of fixing some code that assumed that the file would always have at least the read permission).

This is a requisite for proper handling of encrypted folders in #6670.
