### PR TITLE
Breadcrumbs refactor

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -47,14 +47,6 @@
 	top: 44px;
 }
 
-/* make sure there's enough room for the file actions */
-#body-user #filestable {
-	min-width: 688px; /* 768 (mobile break) - 80 (nav width) */
-}
-#body-user #controls {
-	min-width: 688px; /* 768 (mobile break) - 80 (nav width) */
-}
-
 #filestable tbody tr {
 	height: 51px;
 }

--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -732,9 +732,9 @@ table.dragshadow td.size {
 	margin-bottom: 2px;
 }
 
-.canDrop,
+.breadcrumb .canDrop > a,
 #filestable tbody tr.canDrop {
-	background-color: rgba(255, 255, 140, 1);
+	background-color: rgb(179, 230, 255);
 }
 
 

--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -66,12 +66,16 @@
 	background-color: rgb(179, 230, 255)!important;
 }
 
-.app-files #app-content.dir-drop, .file-drag #filestable tbody tr, .file-drag #filestable tbody tr:hover{
-	background-color: rgba(0, 0, 0, 0)!important;
+.app-files #app-content.dir-drop {
+	background-color: $color-main-background !important;
+}
+
+.file-drag #filestable tbody tr, .file-drag #filestable tbody tr:hover{
+	background-color: transparent !important;
 }
 
 .app-files #app-content.dir-drop #filestable tbody tr.dropping-to-dir{
-	background-color: rgb(179, 230, 255)!important;
+	background-color: rgb(179, 230, 255) !important;
 }
 
 /* icons for sidebar */

--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -226,7 +226,8 @@
 		 * Return the number of items to hide
 		 */
 		_toShrink: function() {
-			var maxWidth = this.$el.width();
+			var maxWidth = this.$el.parent().width();
+			console.log('Available width:' +maxWidth);
 			var smallestWidth = 50;
 			// 50px by default for the ellipsis crumb
 			return Math.ceil((this.totalWidth + 50 - maxWidth) / smallestWidth);
@@ -240,7 +241,7 @@
 		 _hideCrumbs: function(toHide) {
 			 var min = Math.round(this.breadcrumbs.length/2 - toHide/2);
 			 var max = Math.round(this.breadcrumbs.length/2 + toHide/2 - 1);
-			 console.log(this.$el.find('.crumb').slice(min, max));
+			 console.log('toShrink: '+toHide);
 			 this.$el.find('.crumb').removeClass('hidden')
 			 	.slice(min, max).addClass('hidden');
 		 },

--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -216,6 +216,7 @@
 			crumbs.push({
 				name: t('core', 'Home'),
 				dir: '/',
+				class: 'crumbhome',
 				linkclass: 'icon-home'
 			});
 			for (var i = 0; i < parts.length; i++) {
@@ -233,7 +234,7 @@
  		 * Hide the middle crumb
  		 */
  		_hideCrumb: function() {
-			var selector = '.crumb:not(.hidden):not(.crumbmenu)';
+			var selector = '.crumb:not(.hidden):not(.crumbhome):not(.crumbmenu)';
 			var length = this.$el.find(selector).length;
 			// Get the middle one floored down
 			var elmt = Math.floor(length / 2 - 0.5);

--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -113,6 +113,9 @@
 		 * Renders the breadcrumb elements
 		 */
 		render: function() {
+			// Hide menu on render
+			OC.hideMenus();
+
 			var parts = this._makeCrumbs(this.dir || '/');
 			var $crumb;
 			var $menuItem;
@@ -156,7 +159,8 @@
 			for (var i = 0; i < parts.length; i++) {
 				var part = parts[i];
 				if(part.dir) {
-					$menuItem = $('<li><a><span></span></a></li>');
+					$menuItem = $('<li class="crumblist"><a><span></span></a></li>');
+					$menuItem.data('dir', part.dir);
 					$menuItem.find('a').attr('href', this.getCrumbUrl(part, i));
 					$menuItem.find('span').text(part.name);
 					this.$menu.children('ul').append($menuItem);

--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -136,7 +136,6 @@
 					$crumb.on('click', this.onClick);
 				}
 			}
-			$crumb.addClass('last');
 
 			_.each(this._detailViews, function(view) {
 				view.render({
@@ -160,8 +159,7 @@
 					hoverClass: 'canDrop'
 				});
 			}
-
-			this._updateTotalWidth();
+			this._resize();
 		},
 
 		/**
@@ -197,54 +195,35 @@
 			return crumbs;
 		},
 
-		/**
-		 * Calculate the total breadcrumb width when
-		 * all crumbs are expanded
-		 */
-		_updateTotalWidth: function () {
-			this.totalWidth = 0;
-			for (var i = 0; i < this.breadcrumbs.length; i++ ) {
-				var $crumb = $(this.breadcrumbs[i]);
-				this.totalWidth += $crumb.width();
-			}
-			this._resize();
-		},
+ 		/**
+ 		 * Hide the middle crumb
+ 		 */
+ 		 _hideCrumb: function() {
+			 var length = this.$el.find('.crumb:not(.hidden)').length;
+			 // Get the middle one floored down
+			 var elmt = Math.floor(length / 2 - 0.5);
+			 this.$el.find('.crumb:not(.hidden):eq('+elmt+')').addClass('hidden');
+ 		 },
 
-		/**
-		 * Show/hide breadcrumbs to fit the given width
-		 *
-		 * @param {int} availableWidth available width
-		 */
-		setMaxWidth: function (availableWidth) {
-			if (this.availableWidth !== availableWidth) {
-				this.availableWidth = availableWidth;
-				this._resize();
-			}
-		},
-
-		/**
-		 * Return the number of items to hide
-		 */
-		_toShrink: function() {
-			var maxWidth = this.$el.parent().width();
-			console.log('Available width:' +maxWidth);
-			var smallestWidth = 50;
-			// 50px by default for the ellipsis crumb
-			return Math.ceil((this.totalWidth + 50 - maxWidth) / smallestWidth);
-		},
-
-		/**
-		 * Hide the desired number of items
-		 *
-		 * @param {int} number to hide
-		 */
-		 _hideCrumbs: function(toHide) {
-			 var min = Math.round(this.breadcrumbs.length/2 - toHide/2);
-			 var max = Math.round(this.breadcrumbs.length/2 + toHide/2 - 1);
-			 console.log('toShrink: '+toHide);
-			 this.$el.find('.crumb').removeClass('hidden')
-			 	.slice(min, max).addClass('hidden');
+ 		/**
+ 		 * Get the crumb to show
+ 		 */
+ 		 _getCrumbElement: function() {
+			 var length = this.$el.find('.crumb.hidden').length;
+			 // Get the outer one with priority to the highest
+			 var elmt = (length % 2) * (length - 1);
+			 return this.$el.find('.crumb.hidden:eq('+elmt+')');
 		 },
+
+ 		/**
+ 		 * Show the middle crumb
+ 		 */
+ 		 _showCrumb: function() {
+			 if(this.$el.find('.crumb.hidden').length === 1) {
+				 this.$el.find('.crumb.hidden').removeClass('hidden');
+			 }
+			 this._getCrumbElement().removeClass('hidden');
+ 		 },
 
 		_resize: function() {
 			var i, $crumb, $ellipsisCrumb;
@@ -256,9 +235,17 @@
 			if (this.breadcrumbs.length <= 1) {
 				return;
 			}
-			this._hideCrumbs(this._toShrink());
 
-
+			// If container is smaller than content
+			while (this.$el.width() > this.$el.parent().width()) {
+				this._hideCrumb();
+			}
+			// If container is bigger than content + element to be shown
+			// AND if there is at least one hidden crumb
+			while (this.$el.find('.crumb.hidden').length > 0
+				&& this.$el.width() + this._getCrumbElement().width() < this.$el.parent().width()) {
+				this._showCrumb();
+			}
 
 		}
 	};

--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -33,7 +33,7 @@
 	 */
 	var BreadCrumb = function(options){
 		this.$el = $('<div class="breadcrumb"></div>');
-		this.$menu = $('<div class="popovermenu menu menu-center"><ul></ul></div>');
+		this.$menu = $('<div class="popovermenu menu-center"><ul></ul></div>');
 		options = options || {};
 		if (options.onClick) {
 			this.onClick = options.onClick;
@@ -84,6 +84,7 @@
 		},
 
 		setDirectoryInfo: function(dirInfo) {
+			console.log(dirInfo);
 			if (dirInfo !== this.dirInfo) {
 				this.dirInfo = dirInfo;
 				this.render();
@@ -144,13 +145,12 @@
 				}
 				this.breadcrumbs.push($crumb);
 				this.$el.append($crumb);
-				if (this.onClick) {
-					$crumb.on('click', this.onClick);
+				// Only add feedback if not menu
+				if (this.onClick && i !== 0) {
+					$link.on('click', this.onClick);
 				}
 			}
 
-				var err = new Error();
-				console.log(err.stack);
 			// Menu creation
 			this._createMenu();
 			for (var i = 0; i < parts.length; i++) {
@@ -165,7 +165,6 @@
 					}
 				}
 			}
-
 			_.each(this._detailViews, function(view) {
 				view.render({
 					dirInfo: this.dirInfo
@@ -188,7 +187,8 @@
 					hoverClass: 'canDrop'
 				});
 			}
-
+			// Menu is destroyed on every change, we need to init it
+			OC.registerMenu($('.crumbmenu'), $('.crumbmenu > .popovermenu'));
 			this._resize();
 		},
 

--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -159,10 +159,10 @@
 			for (var i = 0; i < parts.length; i++) {
 				var part = parts[i];
 				if(part.dir) {
-					$menuItem = $('<li class="crumblist"><a><span></span></a></li>');
+					$menuItem = $('<li class="crumblist"><a><span class="icon-folder"></span><span></span></a></li>');
 					$menuItem.data('dir', part.dir);
 					$menuItem.find('a').attr('href', this.getCrumbUrl(part, i));
-					$menuItem.find('span').text(part.name);
+					$menuItem.find('span:eq(1)').text(part.name);
 					this.$menu.children('ul').append($menuItem);
 					if (this.onClick) {
 						$menuItem.on('click', this.onClick);

--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -333,7 +333,6 @@
 			} else {
 				this.usedWidth = this.availableWidth;
 			}
-			console.log(this.usedWidth, this.getTotalWidth());
 
 			// If container is smaller than content
 			// AND if there are crumbs left to hide

--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -234,6 +234,36 @@
 			return crumbs;
 		},
 
+		/**
+		 * Show/hide breadcrumbs to fit the given width
+		 * Mostly used by tests
+		 *
+		 * @param {int} availableWidth available width
+		 */
+		setMaxWidth: function (availableWidth) {
+			if (this.availableWidth !== availableWidth) {
+				this.availableWidth = availableWidth;
+				this._resize();
+			}
+		},
+
+		/**
+		 * Calculate real width based on individual crumbs
+		 * More accurate and works with tests
+		 *
+		 * @param {boolean} ignoreHidden ignore hidden crumbs
+		 */
+		getTotalWidth: function(ignoreHidden) {
+			var totalWidth = 0;
+			for (var i = 0; i < this.breadcrumbs.length; i++ ) {
+				var $crumb = $(this.breadcrumbs[i]);
+				if(!$crumb.hasClass('hidden') || ignoreHidden) {
+					totalWidth += $crumb.width();
+				}
+			}
+			return totalWidth;
+		},
+
  		/**
  		 * Hide the middle crumb
  		 */
@@ -290,10 +320,11 @@
 		},
 
 		_resize: function() {
-			var i, $crumb, $ellipsisCrumb;
-
+			// Used for testing since this.$el.parent fails
 			if (!this.availableWidth) {
-				this.availableWidth = this.$el.width();
+				this.usedWidth = this.$el.parent().width();
+			} else {
+				this.usedWidth = this.availableWidth;
 			}
 
 			if (this.breadcrumbs.length <= 1) {
@@ -301,13 +332,13 @@
 			}
 
 			// If container is smaller than content
-			while (this.$el.width() > this.$el.parent().width()) {
+			while (this.getTotalWidth() > this.usedWidth) {
 				this._hideCrumb();
 			}
 			// If container is bigger than content + element to be shown
 			// AND if there is at least one hidden crumb
 			while (this.$el.find('.crumb.hidden').length > 0
-				&& this.$el.width() + this._getCrumbElement().width() < this.$el.parent().width()) {
+				&& this.getTotalWidth() + this._getCrumbElement().width() < this.usedWidth) {
 				this._showCrumb();
 			}
 

--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -221,7 +221,7 @@
 			}
 			// menu part
 			crumbs.push({
-				class: 'crumbmenu',
+				class: 'crumbmenu hidden',
 				linkclass: 'icon-more'
 			});
 			// root part
@@ -315,9 +315,9 @@
 		 * Update the popovermenu
 		 */
 		_updateMenu: function() {
-			var menuItems = this.$el.children('.crumb.hidden');
+			var menuItems = this.$el.find('.crumb.hidden');
 			// Hide the crumb menu if no elements
-			this.$el.find('.crumbmenu').toggleClass('hidden', menuItems.length===0)
+			this.$el.find('.crumbmenu').toggleClass('hidden', menuItems.length === 0)
 
 			this.$menu.find('li').addClass('in-breadcrumb');
 			for (var i = 0; i < menuItems.length; i++) {

--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -260,7 +260,7 @@
 			for (var i = 0; i < this.breadcrumbs.length; i++ ) {
 				var $crumb = $(this.breadcrumbs[i]);
 				if(!$crumb.hasClass('hidden') || ignoreHidden === true) {
-					totalWidth += $crumb.width();
+					totalWidth += $crumb.outerWidth();
 				}
 			}
 			return totalWidth;
@@ -329,10 +329,11 @@
 
 			// Used for testing since this.$el.parent fails
 			if (!this.availableWidth) {
-				this.usedWidth = this.$el.parent().width();
+				this.usedWidth = this.$el.parent().width() - this.$el.next('.actions').width();
 			} else {
 				this.usedWidth = this.availableWidth;
 			}
+			console.log(this.usedWidth, this.getTotalWidth());
 
 			// If container is smaller than content
 			// AND if there are crumbs left to hide

--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -249,9 +249,10 @@
  		 * Get the crumb to show
  		 */
  		_getCrumbElement: function() {
-			var length = this.$el.find('.crumb.hidden').length;
+			var hidden = this.$el.find('.crumb.hidden').length;
+			var shown = this.$el.find('.crumb:not(.hidden):not(.crumbhome):not(.crumbmenu)').length;
 			// Get the outer one with priority to the highest
-			var elmt = (length % 2) * (length - 1);
+			var elmt = (1 - shown % 2) * (hidden - 1);
 			return this.$el.find('.crumb.hidden:eq('+elmt+')');
 		},
 

--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -114,8 +114,8 @@
 		 * Renders the breadcrumb elements
 		 */
 		render: function() {
-			// Hide menu on render
-			OC.hideMenus();
+			// Menu is destroyed on every change, we need to init it
+			OC.unregisterMenu($('.crumbmenu'), $('.crumbmenu > .popovermenu'));
 
 			var parts = this._makeCrumbs(this.dir || '/');
 			var $crumb;
@@ -193,8 +193,10 @@
 					greedy: true
 				});
 			}
+
 			// Menu is destroyed on every change, we need to init it
 			OC.registerMenu($('.crumbmenu'), $('.crumbmenu > .popovermenu'));
+
 			this._resize();
 		},
 
@@ -329,7 +331,7 @@
 
 			// Used for testing since this.$el.parent fails
 			if (!this.availableWidth) {
-				this.usedWidth = this.$el.parent().width() - this.$el.next('.actions').width();
+				this.usedWidth = this.$el.parent().width() - (this.$el.parent().find('.button').length + 1) * 44;
 			} else {
 				this.usedWidth = this.availableWidth;
 			}
@@ -337,7 +339,7 @@
 			// If container is smaller than content
 			// AND if there are crumbs left to hide
 			while (this.getTotalWidth() > this.usedWidth
-			&& this.$el.find(this.crumbSelector).length > 0) {
+				&& this.$el.find(this.crumbSelector).length > 0) {
 				this._hideCrumb();
 			}
 			// If container is bigger than content + element to be shown

--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -183,8 +183,15 @@
 
 			// setup drag and drop
 			if (this.onDrop) {
-				this.$el.find('.crumb:not(.last)').droppable({
+				this.$el.find('.crumb:not(:last-child):not(.crumbmenu), .crumblist:not(:last-child)').droppable({
 					drop: this.onDrop,
+					over: this.onOver,
+					out: this.onOut,
+					tolerance: 'pointer',
+					hoverClass: 'canDrop'
+				});
+				// Only toggle class to open the menu
+				this.$el.find('.crumb.crumbmenu').droppable({
 					over: this.onOver,
 					out: this.onOut,
 					tolerance: 'pointer',

--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -157,13 +157,13 @@
 
 			// Menu creation
 			this._createMenu();
-			for (var i = 0; i < parts.length; i++) {
-				var part = parts[i];
-				if(part.dir) {
+			for (var j = 0; j < parts.length; j++) {
+				var menuPart = parts[j];
+				if(menuPart.dir) {
 					$menuItem = $('<li class="crumblist"><a><span class="icon-folder"></span><span></span></a></li>');
-					$menuItem.data('dir', part.dir);
-					$menuItem.find('a').attr('href', this.getCrumbUrl(part, i));
-					$menuItem.find('span:eq(1)').text(part.name);
+					$menuItem.data('dir', menuPart.dir);
+					$menuItem.find('a').attr('href', this.getCrumbUrl(part, j));
+					$menuItem.find('span:eq(1)').text(menuPart.name);
 					this.$menu.children('ul').append($menuItem);
 					if (this.onClick) {
 						$menuItem.on('click', this.onClick);
@@ -311,7 +311,7 @@
 		_updateMenu: function() {
 			var menuItems = this.$el.find('.crumb.hidden');
 			// Hide the crumb menu if no elements
-			this.$el.find('.crumbmenu').toggleClass('hidden', menuItems.length === 0)
+			this.$el.find('.crumbmenu').toggleClass('hidden', menuItems.length === 0);
 
 			this.$menu.find('li').addClass('in-breadcrumb');
 			for (var i = 0; i < menuItems.length; i++) {

--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -34,6 +34,8 @@
 	var BreadCrumb = function(options){
 		this.$el = $('<div class="breadcrumb"></div>');
 		this.$menu = $('<div class="popovermenu menu-center"><ul></ul></div>');
+
+		this.crumbSelector = '.crumb:not(.hidden):not(.crumbhome):not(.crumbmenu)';
 		options = options || {};
 		if (options.onClick) {
 			this.onClick = options.onClick;
@@ -84,7 +86,6 @@
 		},
 
 		setDirectoryInfo: function(dirInfo) {
-			console.log(dirInfo);
 			if (dirInfo !== this.dirInfo) {
 				this.dirInfo = dirInfo;
 				this.render();
@@ -264,7 +265,7 @@
 			var totalWidth = 0;
 			for (var i = 0; i < this.breadcrumbs.length; i++ ) {
 				var $crumb = $(this.breadcrumbs[i]);
-				if(!$crumb.hasClass('hidden') || ignoreHidden) {
+				if(!$crumb.hasClass('hidden') || ignoreHidden === true) {
 					totalWidth += $crumb.width();
 				}
 			}
@@ -275,11 +276,10 @@
  		 * Hide the middle crumb
  		 */
  		_hideCrumb: function() {
-			var selector = '.crumb:not(.hidden):not(.crumbhome):not(.crumbmenu)';
-			var length = this.$el.find(selector).length;
+			var length = this.$el.find(this.crumbSelector).length;
 			// Get the middle one floored down
 			var elmt = Math.floor(length / 2 - 0.5);
-			this.$el.find(selector+':eq('+elmt+')').addClass('hidden');
+			this.$el.find(this.crumbSelector+':eq('+elmt+')').addClass('hidden');
  		},
 
  		/**
@@ -287,7 +287,7 @@
  		 */
  		_getCrumbElement: function() {
 			var hidden = this.$el.find('.crumb.hidden').length;
-			var shown = this.$el.find('.crumb:not(.hidden):not(.crumbhome):not(.crumbmenu)').length;
+			var shown = this.$el.find(this.crumbSelector).length;
 			// Get the outer one with priority to the highest
 			var elmt = (1 - shown % 2) * (hidden - 1);
 			return this.$el.find('.crumb.hidden:eq('+elmt+')');
@@ -327,6 +327,12 @@
 		},
 
 		_resize: function() {
+
+			if (this.breadcrumbs.length <= 2) {
+				// home & menu
+				return;
+			}
+
 			// Used for testing since this.$el.parent fails
 			if (!this.availableWidth) {
 				this.usedWidth = this.$el.parent().width();
@@ -334,12 +340,10 @@
 				this.usedWidth = this.availableWidth;
 			}
 
-			if (this.breadcrumbs.length <= 1) {
-				return;
-			}
-
 			// If container is smaller than content
-			while (this.getTotalWidth() > this.usedWidth) {
+			// AND if there are crumbs left to hide
+			while (this.getTotalWidth() > this.usedWidth
+			&& this.$el.find(this.crumbSelector).length > 0) {
 				this._hideCrumb();
 			}
 			// If container is bigger than content + element to be shown

--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -189,14 +189,8 @@
 					over: this.onOver,
 					out: this.onOut,
 					tolerance: 'pointer',
-					hoverClass: 'canDrop'
-				});
-				// Only toggle class to open the menu
-				this.$el.find('.crumb.crumbmenu').droppable({
-					over: this.onOver,
-					out: this.onOut,
-					tolerance: 'pointer',
-					hoverClass: 'canDrop'
+					hoverClass: 'canDrop',
+					greedy: true
 				});
 			}
 			// Menu is destroyed on every change, we need to init it

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -836,8 +836,8 @@
 		 * Event handler when clicking on a bread crumb
 		 */
 		_onClickBreadCrumb: function(e) {
-			console.log('Clicked breadcrumb ', e);
-			var $el = $(e.target).closest('.crumb'),
+			// Select a crumb or a crumb in the menu
+			var $el = $(e.target).closest('.crumb, .crumblist'),
 				$targetDir = $el.data('dir');
 
 			if ($targetDir !== undefined && e.which === 1) {

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -322,7 +322,7 @@
 
 			this.$el.find('thead th .columntitle').click(_.bind(this._onClickHeader, this));
 
-			this._onResize = _.debounce(_.bind(this._onResize, this), 100);
+			this._onResize = _.debounce(_.bind(this._onResize, this), 250);
 			$('#app-content').on('appresized', this._onResize);
 			$(window).resize(this._onResize);
 
@@ -555,7 +555,7 @@
 			// subtract app navigation toggle when visible
 			containerWidth -= $('#app-navigation-toggle').width();
 
-			this.breadcrumb.setMaxWidth(containerWidth - actionsWidth - 10);
+			this.breadcrumb._resize();
 
 			this.$table.find('>thead').width($('#app-content').width() - OC.Util.getScrollBarWidth());
 		},
@@ -1709,7 +1709,7 @@
 			if (status === 500) {
 				// Go home
 				this.changeDirectory('/');
-				OC.Notification.show(t('files', 'This directory is unavailable, please check the logs or contact the administrator'), 
+				OC.Notification.show(t('files', 'This directory is unavailable, please check the logs or contact the administrator'),
 					{type: 'error'}
 				);
 				return false;
@@ -1720,7 +1720,7 @@
 				if (this.getCurrentDirectory() !== '/') {
 					this.changeDirectory('/');
 					// TODO: read error message from exception
-					OC.Notification.show(t('files', 'Storage is temporarily not available'), 
+					OC.Notification.show(t('files', 'Storage is temporarily not available'),
 						{type: 'error'}
 					);
 				}
@@ -2036,11 +2036,11 @@
 					.fail(function(status) {
 						if (status === 412) {
 							// TODO: some day here we should invoke the conflict dialog
-							OC.Notification.show(t('files', 'Could not move "{file}", target exists', 
+							OC.Notification.show(t('files', 'Could not move "{file}", target exists',
 								{file: fileName}), {type: 'error'}
 							);
 						} else {
-							OC.Notification.show(t('files', 'Could not move "{file}"', 
+							OC.Notification.show(t('files', 'Could not move "{file}"',
 								{file: fileName}), {type: 'error'}
 							);
 						}
@@ -2267,7 +2267,7 @@
 								// TODO: 409 means current folder does not exist, redirect ?
 								if (status === 404) {
 									// source not found, so remove it from the list
-									OC.Notification.show(t('files', 'Could not rename "{fileName}", it does not exist any more', 
+									OC.Notification.show(t('files', 'Could not rename "{fileName}", it does not exist any more',
 										{fileName: oldName}), {timeout: 7, type: 'error'}
 									);
 
@@ -2287,7 +2287,7 @@
 									);
 								} else {
 									// restore the item to its previous state
-									OC.Notification.show(t('files', 'Could not rename "{fileName}"', 
+									OC.Notification.show(t('files', 'Could not rename "{fileName}"',
 										{fileName: oldName}), {type: 'error'}
 									);
 								}
@@ -2372,18 +2372,18 @@
 					self.addAndFetchFileInfo(targetPath, '', {scrollTo: true}).then(function(status, data) {
 						deferred.resolve(status, data);
 					}, function() {
-						OC.Notification.show(t('files', 'Could not create file "{file}"', 
+						OC.Notification.show(t('files', 'Could not create file "{file}"',
 							{file: name}), {type: 'error'}
 						);
 					});
 				})
 				.fail(function(status) {
 					if (status === 412) {
-						OC.Notification.show(t('files', 'Could not create file "{file}" because it already exists', 
+						OC.Notification.show(t('files', 'Could not create file "{file}" because it already exists',
 							{file: name}), {type: 'error'}
 						);
 					} else {
-						OC.Notification.show(t('files', 'Could not create file "{file}"', 
+						OC.Notification.show(t('files', 'Could not create file "{file}"',
 							{file: name}), {type: 'error'}
 						);
 					}
@@ -2422,7 +2422,7 @@
 					self.addAndFetchFileInfo(targetPath, '', {scrollTo:true}).then(function(status, data) {
 						deferred.resolve(status, data);
 					}, function() {
-						OC.Notification.show(t('files', 'Could not create folder "{dir}"', 
+						OC.Notification.show(t('files', 'Could not create folder "{dir}"',
 							{dir: name}), {type: 'error'}
 						);
 					});
@@ -2433,20 +2433,20 @@
 						// add it to the list, for completeness
 						self.addAndFetchFileInfo(targetPath, '', {scrollTo:true})
 							.done(function(status, data) {
-								OC.Notification.show(t('files', 'Could not create folder "{dir}" because it already exists', 
+								OC.Notification.show(t('files', 'Could not create folder "{dir}" because it already exists',
 									{dir: name}), {type: 'error'}
 								);
 								// still consider a failure
 								deferred.reject(createStatus, data);
 							})
 							.fail(function() {
-								OC.Notification.show(t('files', 'Could not create folder "{dir}"', 
+								OC.Notification.show(t('files', 'Could not create folder "{dir}"',
 									{dir: name}), {type: 'error'}
 								);
 								deferred.reject(status);
 							});
 					} else {
-						OC.Notification.show(t('files', 'Could not create folder "{dir}"', 
+						OC.Notification.show(t('files', 'Could not create folder "{dir}"',
 							{dir: name}), {type: 'error'}
 						);
 						deferred.reject(createStatus);
@@ -2503,7 +2503,7 @@
 					deferred.resolve(status, data);
 				})
 				.fail(function(status) {
-					OC.Notification.show(t('files', 'Could not create file "{file}"', 
+					OC.Notification.show(t('files', 'Could not create file "{file}"',
 						{file: name}), {type: 'error'}
 					);
 					deferred.reject(status);
@@ -2612,7 +2612,7 @@
 							removeFromList(file);
 						} else {
 							// only reset the spinner for that one file
-							OC.Notification.show(t('files', 'Error deleting file "{fileName}".', 
+							OC.Notification.show(t('files', 'Error deleting file "{fileName}".',
 								{fileName: file}), {type: 'error'}
 							);
 							var deleteAction = self.findFileEl(file).find('.action.delete');

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -836,11 +836,13 @@
 		 * Event handler when clicking on a bread crumb
 		 */
 		_onClickBreadCrumb: function(e) {
+			console.log('Clicked breadcrumb ', e);
 			var $el = $(e.target).closest('.crumb'),
 				$targetDir = $el.data('dir');
 
 			if ($targetDir !== undefined && e.which === 1) {
 				e.preventDefault();
+				console.log('Triggered dir change');
 				this.changeDirectory($targetDir, true, true);
 				this.updateSearch();
 			}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -842,7 +842,6 @@
 
 			if ($targetDir !== undefined && e.which === 1) {
 				e.preventDefault();
-				console.log('Triggered dir change');
 				this.changeDirectory($targetDir, true, true);
 				this.updateSearch();
 			}
@@ -864,8 +863,8 @@
 		_onDropOnBreadCrumb: function( event, ui ) {
 			var self = this;
 			var $target = $(event.target);
-			if (!$target.is('.crumb')) {
-				$target = $target.closest('.crumb');
+			if (!$target.is('.crumb, .crumblist')) {
+				$target = $target.closest('.crumb, .crumblist');
 			}
 			var targetPath = $(event.target).data('dir');
 			var dir = this.getCurrentDirectory();

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -117,32 +117,32 @@
 				ownerDisplayName = $('#ownerDisplayName').val();
 			if (usedSpacePercent > 98) {
 				if (owner !== oc_current_user) {
-					OC.Notification.show(t('files', 'Storage of {owner} is full, files can not be updated or synced anymore!', 
+					OC.Notification.show(t('files', 'Storage of {owner} is full, files can not be updated or synced anymore!',
 						{owner: ownerDisplayName}), {type: 'error'}
 					);
 					return;
 				}
-				OC.Notification.show(t('files', 
-					'Your storage is full, files can not be updated or synced anymore!'), 
+				OC.Notification.show(t('files',
+					'Your storage is full, files can not be updated or synced anymore!'),
 					{type : 'error'}
 				);
 				return;
 			}
 			if (usedSpacePercent > 90) {
 				if (owner !== oc_current_user) {
-					OC.Notification.show(t('files', 'Storage of {owner} is almost full ({usedSpacePercent}%)', 
+					OC.Notification.show(t('files', 'Storage of {owner} is almost full ({usedSpacePercent}%)',
 						{
-							usedSpacePercent: usedSpacePercent,  
+							usedSpacePercent: usedSpacePercent,
 							owner: ownerDisplayName
 						}),
-						{  
+						{
 							type: 'error'
 						}
 					);
 					return;
 				}
 				OC.Notification.show(t('files', 'Your storage is almost full ({usedSpacePercent}%)',
-					{usedSpacePercent: usedSpacePercent}), 
+					{usedSpacePercent: usedSpacePercent}),
 					{type : 'error'}
 				);
 			}
@@ -396,6 +396,8 @@ var dragOptions={
 		}
 		$selectedFiles.closest('tr').addClass('animate-opacity dragging');
 		$selectedFiles.closest('tr').filter('.ui-droppable').droppable( 'disable' );
+		// Show breadcrumbs menu
+		$('.crumbmenu').addClass('canDropChildren');
 
 	},
 	stop: function(event, ui) {
@@ -411,6 +413,8 @@ var dragOptions={
 		setTimeout(function() {
 			$tr.removeClass('animate-opacity');
 		}, 300);
+		// Hide breadcrumbs menu
+		$('.crumbmenu').removeClass('canDropChildren');
 	},
 	drag: function(event, ui) {
 		var scrollingArea = FileList.$container;

--- a/apps/files/tests/js/breadcrumbSpec.js
+++ b/apps/files/tests/js/breadcrumbSpec.js
@@ -215,6 +215,19 @@ describe('OCA.Files.BreadCrumb tests', function() {
 			$(document).mouseup();
 			expect($popovermenu.is(':visible')).toEqual(false);
 
+			// Change directory and reset elements
+			bc.setDirectory('/one/two/three/four/five/six/seven/eight/nine/ten');
+			$crumbmenuLink = bc.$el.find('.crumbmenu > a');
+			$popovermenu = $crumbmenuLink.next('.popovermenu');
+
+			// Click on menu again
+			$crumbmenuLink.click();
+			expect($popovermenu.is(':visible')).toEqual(true);
+
+			// Click on home again
+			$(document).mouseup();
+			expect($popovermenu.is(':visible')).toEqual(false);
+
 		});
 		it('Shows only items not in the breadcrumb', function() {
 			var hiddenCrumbs = bc.$el.find('.crumb:not(.crumbmenu).hidden');

--- a/apps/files/tests/js/breadcrumbSpec.js
+++ b/apps/files/tests/js/breadcrumbSpec.js
@@ -43,80 +43,93 @@ describe('OCA.Files.BreadCrumb tests', function() {
 			var $crumbs;
 			bc.render();
 			$crumbs = bc.$el.find('.crumb');
-			expect($crumbs.length).toEqual(1);
-			expect($crumbs.eq(0).find('a').attr('href')).toEqual('/#0');
-			expect($crumbs.eq(0).find('img').length).toEqual(1);
-			expect($crumbs.eq(0).attr('data-dir')).toEqual('/');
+			// menu and home
+			expect($crumbs.length).toEqual(2);
+			expect($crumbs.eq(0).find('a').hasClass('icon-more')).toEqual(true);
+			expect($crumbs.eq(0).find('div.popovermenu').length).toEqual(1);
+			expect($crumbs.eq(0).data('dir')).not.toBeDefined();
+			expect($crumbs.eq(1).find('a').attr('href')).toEqual('/#1');
+			expect($crumbs.eq(1).find('a').hasClass('icon-home')).toEqual(true);
+			expect($crumbs.eq(1).data('dir')).toEqual('/');
 		});
 		it('Renders root when switching to root', function() {
 			var $crumbs;
 			bc.setDirectory('/somedir');
 			bc.setDirectory('/');
 			$crumbs = bc.$el.find('.crumb');
-			expect($crumbs.length).toEqual(1);
-			expect($crumbs.eq(0).attr('data-dir')).toEqual('/');
-		});
-		it('Renders last crumb with "last" class', function() {
-			bc.setDirectory('/abc/def');
-			expect(bc.$el.find('.crumb:last').hasClass('last')).toEqual(true);
+			expect($crumbs.length).toEqual(2);
+			expect($crumbs.eq(1).data('dir')).toEqual('/');
 		});
 		it('Renders single path section', function() {
 			var $crumbs;
 			bc.setDirectory('/somedir');
 			$crumbs = bc.$el.find('.crumb');
-			expect($crumbs.length).toEqual(2);
-			expect($crumbs.eq(0).find('a').attr('href')).toEqual('/#0');
-			expect($crumbs.eq(0).find('img').length).toEqual(1);
-			expect($crumbs.eq(0).attr('data-dir')).toEqual('/');
-			expect($crumbs.eq(1).find('a').attr('href')).toEqual('/somedir#1');
-			expect($crumbs.eq(1).find('img').length).toEqual(0);
-			expect($crumbs.eq(1).attr('data-dir')).toEqual('/somedir');
+			expect($crumbs.length).toEqual(3);
+			expect($crumbs.eq(0).find('a').hasClass('icon-more')).toEqual(true);
+			expect($crumbs.eq(0).find('div.popovermenu').length).toEqual(1);
+			expect($crumbs.eq(0).data('dir')).not.toBeDefined();
+
+			expect($crumbs.eq(1).find('a').attr('href')).toEqual('/#1');
+			expect($crumbs.eq(1).find('a').hasClass('icon-home')).toEqual(true);
+			expect($crumbs.eq(1).data('dir')).toEqual('/');
+
+			expect($crumbs.eq(2).find('a').attr('href')).toEqual('/somedir#2');
+			expect($crumbs.eq(2).find('img').length).toEqual(0);
+			expect($crumbs.eq(2).data('dir')).toEqual('/somedir');
 		});
 		it('Renders multiple path sections and special chars', function() {
 			var $crumbs;
 			bc.setDirectory('/somedir/with space/abc');
 			$crumbs = bc.$el.find('.crumb');
-			expect($crumbs.length).toEqual(4);
-			expect($crumbs.eq(0).find('a').attr('href')).toEqual('/#0');
-			expect($crumbs.eq(0).find('img').length).toEqual(1);
-			expect($crumbs.eq(0).attr('data-dir')).toEqual('/');
+			expect($crumbs.length).toEqual(5);
+			expect($crumbs.eq(0).find('a').hasClass('icon-more')).toEqual(true);
+			expect($crumbs.eq(0).find('div.popovermenu').length).toEqual(1);
+			expect($crumbs.eq(0).data('dir')).not.toBeDefined();
 
-			expect($crumbs.eq(1).find('a').attr('href')).toEqual('/somedir#1');
-			expect($crumbs.eq(1).find('img').length).toEqual(0);
-			expect($crumbs.eq(1).attr('data-dir')).toEqual('/somedir');
+			expect($crumbs.eq(1).find('a').attr('href')).toEqual('/#1');
+			expect($crumbs.eq(1).find('a').hasClass('icon-home')).toEqual(true);
+			expect($crumbs.eq(1).data('dir')).toEqual('/');
 
-			expect($crumbs.eq(2).find('a').attr('href')).toEqual('/somedir/with space#2');
+			expect($crumbs.eq(2).find('a').attr('href')).toEqual('/somedir#2');
 			expect($crumbs.eq(2).find('img').length).toEqual(0);
-			expect($crumbs.eq(2).attr('data-dir')).toEqual('/somedir/with space');
+			expect($crumbs.eq(2).data('dir')).toEqual('/somedir');
 
-			expect($crumbs.eq(3).find('a').attr('href')).toEqual('/somedir/with space/abc#3');
+			expect($crumbs.eq(3).find('a').attr('href')).toEqual('/somedir/with space#3');
 			expect($crumbs.eq(3).find('img').length).toEqual(0);
-			expect($crumbs.eq(3).attr('data-dir')).toEqual('/somedir/with space/abc');
+			expect($crumbs.eq(3).data('dir')).toEqual('/somedir/with space');
+
+			expect($crumbs.eq(4).find('a').attr('href')).toEqual('/somedir/with space/abc#4');
+			expect($crumbs.eq(4).find('img').length).toEqual(0);
+			expect($crumbs.eq(4).data('dir')).toEqual('/somedir/with space/abc');
 		});
 		it('Renders backslashes as regular directory separator', function() {
 			var $crumbs;
 			bc.setDirectory('/somedir\\with/mixed\\separators');
 			$crumbs = bc.$el.find('.crumb');
-			expect($crumbs.length).toEqual(5);
-			expect($crumbs.eq(0).find('a').attr('href')).toEqual('/#0');
-			expect($crumbs.eq(0).find('img').length).toEqual(1);
-			expect($crumbs.eq(0).attr('data-dir')).toEqual('/');
+			expect($crumbs.length).toEqual(6);
+			expect($crumbs.eq(0).find('a').hasClass('icon-more')).toEqual(true);
+			expect($crumbs.eq(0).find('div.popovermenu').length).toEqual(1);
+			expect($crumbs.eq(0).data('dir')).not.toBeDefined();
 
-			expect($crumbs.eq(1).find('a').attr('href')).toEqual('/somedir#1');
-			expect($crumbs.eq(1).find('img').length).toEqual(0);
-			expect($crumbs.eq(1).attr('data-dir')).toEqual('/somedir');
+			expect($crumbs.eq(1).find('a').attr('href')).toEqual('/#1');
+			expect($crumbs.eq(1).find('a').hasClass('icon-home')).toEqual(true);
+			expect($crumbs.eq(1).data('dir')).toEqual('/');
 
-			expect($crumbs.eq(2).find('a').attr('href')).toEqual('/somedir/with#2');
+			expect($crumbs.eq(2).find('a').attr('href')).toEqual('/somedir#2');
 			expect($crumbs.eq(2).find('img').length).toEqual(0);
-			expect($crumbs.eq(2).attr('data-dir')).toEqual('/somedir/with');
+			expect($crumbs.eq(2).data('dir')).toEqual('/somedir');
 
-			expect($crumbs.eq(3).find('a').attr('href')).toEqual('/somedir/with/mixed#3');
+			expect($crumbs.eq(3).find('a').attr('href')).toEqual('/somedir/with#3');
 			expect($crumbs.eq(3).find('img').length).toEqual(0);
-			expect($crumbs.eq(3).attr('data-dir')).toEqual('/somedir/with/mixed');
+			expect($crumbs.eq(3).data('dir')).toEqual('/somedir/with');
 
-			expect($crumbs.eq(4).find('a').attr('href')).toEqual('/somedir/with/mixed/separators#4');
+			expect($crumbs.eq(4).find('a').attr('href')).toEqual('/somedir/with/mixed#4');
 			expect($crumbs.eq(4).find('img').length).toEqual(0);
-			expect($crumbs.eq(4).attr('data-dir')).toEqual('/somedir/with/mixed/separators');
+			expect($crumbs.eq(4).data('dir')).toEqual('/somedir/with/mixed');
+
+			expect($crumbs.eq(5).find('a').attr('href')).toEqual('/somedir/with/mixed/separators#5');
+			expect($crumbs.eq(5).find('img').length).toEqual(0);
+			expect($crumbs.eq(5).data('dir')).toEqual('/somedir/with/mixed/separators');
 		});
 	});
 	describe('Events', function() {
@@ -126,14 +139,15 @@ describe('OCA.Files.BreadCrumb tests', function() {
 				onClick: handler
 			});
 			bc.setDirectory('/one/two/three/four');
-			bc.$el.find('.crumb:eq(3)').click();
-			expect(handler.calledOnce).toEqual(true);
-			expect(handler.getCall(0).thisValue).toEqual(bc.$el.find('.crumb').get(3));
+			// Click on crumb does not work, only link
+			bc.$el.find('.crumb:eq(4)').click();
+			expect(handler.calledOnce).toEqual(false);
 
 			handler.reset();
-			bc.$el.find('.crumb:eq(0) a').click();
+			// Click on crumb link works
+			bc.$el.find('.crumb:eq(1) a').click();
 			expect(handler.calledOnce).toEqual(true);
-			expect(handler.getCall(0).thisValue).toEqual(bc.$el.find('.crumb').get(0));
+			expect(handler.getCall(0).thisValue).toEqual(bc.$el.find('.crumb > a').get(1));
 		});
 		it('Calls onDrop handler when dropping on a crumb', function() {
 			var droppableStub = sinon.stub($.fn, 'droppable');
@@ -163,17 +177,12 @@ describe('OCA.Files.BreadCrumb tests', function() {
 
 			// using hard-coded widths (pre-measured) to avoid getting different
 			// results on different browsers due to font engine differences
-			widths = [41, 106, 112, 160, 257, 251, 91];
+			// 51px is default size for menu and home
+			widths = [51, 51, 106, 112, 160, 257, 251, 91];
 
-			oldUpdateTotalWidth = BreadCrumb.prototype._updateTotalWidth;
-			BreadCrumb.prototype._updateTotalWidth = function() {
-				// pre-set a width to simulate consistent measurement
-				$('div.crumb').each(function(index){
-					$(this).css('width', widths[index]);
-				});
-
-				return oldUpdateTotalWidth.apply(this, arguments);
-			};
+			$('div.crumb').each(function(index){
+				$(this).css('width', widths[index]);
+			});
 
 			bc = new BreadCrumb();
 			// append dummy navigation and controls
@@ -184,30 +193,26 @@ describe('OCA.Files.BreadCrumb tests', function() {
 			$('#controls').append(bc.$el);
 		});
 		afterEach(function() {
-			BreadCrumb.prototype._updateTotalWidth = oldUpdateTotalWidth;
 			bc = null;
 		});
 		it('Hides breadcrumbs to fit max allowed width', function() {
 			var $crumbs;
 
 			bc.setMaxWidth(500);
+
 			// triggers resize implicitly
 			bc.setDirectory(dummyDir);
 			$crumbs = bc.$el.find('.crumb');
 
-			// first one is always visible
+			// Menu and home are always visible
 			expect($crumbs.eq(0).hasClass('hidden')).toEqual(false);
-			// second one has ellipsis
 			expect($crumbs.eq(1).hasClass('hidden')).toEqual(false);
-			expect($crumbs.eq(1).find('.ellipsis').length).toEqual(1);
-			// there is only one ellipsis in total
-			expect($crumbs.find('.ellipsis').length).toEqual(1);
-			// subsequent elements are hidden
+
 			expect($crumbs.eq(2).hasClass('hidden')).toEqual(true);
 			expect($crumbs.eq(3).hasClass('hidden')).toEqual(true);
 			expect($crumbs.eq(4).hasClass('hidden')).toEqual(true);
 			expect($crumbs.eq(5).hasClass('hidden')).toEqual(true);
-			expect($crumbs.eq(6).hasClass('hidden')).toEqual(false);
+			expect($crumbs.eq(6).hasClass('hidden')).toEqual(true);
 			expect($crumbs.eq(7).hasClass('hidden')).toEqual(false);
 		});
 		it('Updates the breadcrumbs when reducing max allowed width', function() {
@@ -215,56 +220,27 @@ describe('OCA.Files.BreadCrumb tests', function() {
 
 			// enough space
 			bc.setMaxWidth(1800);
+			$crumbs = bc.$el.find('.crumb');
 
-			expect(bc.$el.find('.ellipsis').length).toEqual(0);
+			// Menu is hidden
+			expect($crumbs.eq(0).hasClass('hidden')).toEqual(false);
 
 			// triggers resize implicitly
 			bc.setDirectory(dummyDir);
 
-			// simulate increase
+			// simulate decrease
 			bc.setMaxWidth(950);
 
-			$crumbs = bc.$el.find('.crumb');
-			// first one is always visible
-			expect($crumbs.eq(0).hasClass('hidden')).toEqual(false);
-			// second one has ellipsis
-			expect($crumbs.eq(1).hasClass('hidden')).toEqual(false);
-			expect($crumbs.eq(1).find('.ellipsis').length).toEqual(1);
-			// there is only one ellipsis in total
-			expect($crumbs.find('.ellipsis').length).toEqual(1);
-			// subsequent elements are hidden
-			expect($crumbs.eq(2).hasClass('hidden')).toEqual(true);
-			expect($crumbs.eq(3).hasClass('hidden')).toEqual(true);
-			// the rest is visible
-			expect($crumbs.eq(4).hasClass('hidden')).toEqual(false);
-			expect($crumbs.eq(5).hasClass('hidden')).toEqual(false);
-			expect($crumbs.eq(6).hasClass('hidden')).toEqual(false);
-		});
-		it('Removes the ellipsis when there is enough space', function() {
-			var $crumbs;
-
-			bc.setMaxWidth(500);
-			// triggers resize implicitly
-			bc.setDirectory(dummyDir);
-			$crumbs = bc.$el.find('.crumb');
-
-			// ellipsis
-			expect(bc.$el.find('.ellipsis').length).toEqual(1);
-
-			// simulate increase
-			bc.setMaxWidth(1800);
-
-			// no ellipsis
-			expect(bc.$el.find('.ellipsis').length).toEqual(0);
-
-			// all are visible
+			// Menu and home are always visible
 			expect($crumbs.eq(0).hasClass('hidden')).toEqual(false);
 			expect($crumbs.eq(1).hasClass('hidden')).toEqual(false);
+
 			expect($crumbs.eq(2).hasClass('hidden')).toEqual(false);
 			expect($crumbs.eq(3).hasClass('hidden')).toEqual(false);
 			expect($crumbs.eq(4).hasClass('hidden')).toEqual(false);
 			expect($crumbs.eq(5).hasClass('hidden')).toEqual(false);
 			expect($crumbs.eq(6).hasClass('hidden')).toEqual(false);
+			expect($crumbs.eq(7).hasClass('hidden')).toEqual(false);
 		});
 	});
 });

--- a/apps/files/tests/js/breadcrumbSpec.js
+++ b/apps/files/tests/js/breadcrumbSpec.js
@@ -208,7 +208,7 @@ describe('OCA.Files.BreadCrumb tests', function() {
 			expect($crumbs.eq(0).hasClass('hidden')).toEqual(false);
 			expect($crumbs.eq(1).hasClass('hidden')).toEqual(false);
 
-			expect($crumbs.eq(2).hasClass('hidden')).toEqual(true);
+			expect($crumbs.eq(2).hasClass('hidden')).toEqual(false);
 			expect($crumbs.eq(3).hasClass('hidden')).toEqual(true);
 			expect($crumbs.eq(4).hasClass('hidden')).toEqual(true);
 			expect($crumbs.eq(5).hasClass('hidden')).toEqual(true);

--- a/apps/files/tests/js/breadcrumbSpec.js
+++ b/apps/files/tests/js/breadcrumbSpec.js
@@ -168,6 +168,60 @@ describe('OCA.Files.BreadCrumb tests', function() {
 			droppableStub.restore();
 		});
 	});
+
+	describe('Menu tests', function() {
+		var bc, dummyDir, $crumbmenuLink, $popovermenu;
+
+		beforeEach(function() {
+			dummyDir = '/one/two/three/four/five'
+
+			$('div.crumb').each(function(index){
+				$(this).css('width', 50);
+			});
+
+			bc = new BreadCrumb();
+			// append dummy navigation and controls
+			// as they are currently used for measurements
+			$('#testArea').append(
+				'<div id="controls"></div>'
+			);
+			$('#controls').append(bc.$el);
+
+			// Shrink to show popovermenu
+			bc.setMaxWidth(300);
+
+			// triggers resize implicitly
+			bc.setDirectory(dummyDir);
+
+			$crumbmenuLink = bc.$el.find('.crumbmenu > a');
+			$popovermenu = $crumbmenuLink.next('.popovermenu');
+		});
+		afterEach(function() {
+			bc = null;
+		});
+
+		it('Opens and closes the menu on click', function() {
+			// Menu exists
+			expect($popovermenu.length).toEqual(1);
+
+			// Disable jQuery delay
+			jQuery.fx.off = true
+
+			// Click on menu
+			$crumbmenuLink.click();
+			expect($popovermenu.is(':visible')).toEqual(true);
+
+			// Click on home
+			$(document).mouseup();
+			expect($popovermenu.is(':visible')).toEqual(false);
+
+		});
+		it('Shows only items not in the breadcrumb', function() {
+			var hiddenCrumbs = bc.$el.find('.crumb:not(.crumbmenu).hidden');
+			expect($popovermenu.find('li:not(.in-breadcrumb)').length).toEqual(hiddenCrumbs.length);
+		});
+	});
+
 	describe('Resizing', function() {
 		var bc, dummyDir, widths;
 

--- a/apps/files/tests/js/breadcrumbSpec.js
+++ b/apps/files/tests/js/breadcrumbSpec.js
@@ -156,7 +156,7 @@ describe('OCA.Files.BreadCrumb tests', function() {
 				onDrop: handler
 			});
 			bc.setDirectory('/one/two/three/four');
-			expect(droppableStub.calledOnce).toEqual(false);
+			expect(droppableStub.calledOnce).toEqual(true);
 
 			expect(droppableStub.getCall(0).args[0].drop).toBeDefined();
 			// simulate drop

--- a/apps/files/tests/js/breadcrumbSpec.js
+++ b/apps/files/tests/js/breadcrumbSpec.js
@@ -156,7 +156,7 @@ describe('OCA.Files.BreadCrumb tests', function() {
 				onDrop: handler
 			});
 			bc.setDirectory('/one/two/three/four');
-			expect(droppableStub.calledOnce).toEqual(true);
+			expect(droppableStub.calledOnce).toEqual(false);
 
 			expect(droppableStub.getCall(0).args[0].drop).toBeDefined();
 			// simulate drop
@@ -169,7 +169,7 @@ describe('OCA.Files.BreadCrumb tests', function() {
 		});
 	});
 	describe('Resizing', function() {
-		var bc, dummyDir, widths, oldUpdateTotalWidth;
+		var bc, dummyDir, widths;
 
 		beforeEach(function() {
 			dummyDir = '/short name/longer name/looooooooooooonger/' +

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1656,7 +1656,7 @@ describe('OCA.Files.FileList tests', function() {
 			fileList.changeDirectory('/subdir/two/three with space/four/five');
 			deferredList.resolve(200, [testRoot].concat(testFiles));
 			var changeDirStub = sinon.stub(fileList, 'changeDirectory');
-			fileList.breadcrumb.$el.find('.crumb:eq(0)').trigger({type: 'click', which: 1});
+			fileList.breadcrumb.$el.find('.crumb:eq(1) > a').trigger({type: 'click', which: 1});
 
 			expect(changeDirStub.calledOnce).toEqual(true);
 			expect(changeDirStub.getCall(0).args[0]).toEqual('/');
@@ -1666,7 +1666,7 @@ describe('OCA.Files.FileList tests', function() {
 			fileList.changeDirectory('/subdir/two/three with space/four/five');
 			deferredList.resolve(200, [testRoot].concat(testFiles));
 			var changeDirStub = sinon.stub(fileList, 'changeDirectory');
-			fileList.breadcrumb.$el.find('.crumb:eq(3)').trigger({type: 'click', which: 1});
+			fileList.breadcrumb.$el.find('.crumb:eq(4) > a').trigger({type: 'click', which: 1});
 
 			expect(changeDirStub.calledOnce).toEqual(true);
 			expect(changeDirStub.getCall(0).args[0]).toEqual('/subdir/two/three with space');
@@ -1677,7 +1677,7 @@ describe('OCA.Files.FileList tests', function() {
 			var moveStub = sinon.stub(filesClient, 'move').returns($.Deferred().promise());
 			fileList.changeDirectory(testDir);
 			deferredList.resolve(200, [testRoot].concat(testFiles));
-			var $crumb = fileList.breadcrumb.$el.find('.crumb:eq(3)');
+			var $crumb = fileList.breadcrumb.$el.find('.crumb:eq(4)');
 			// no idea what this is but is required by the handler
 			var ui = {
 				helper: {
@@ -2990,7 +2990,7 @@ describe('OCA.Files.FileList tests', function() {
 			it('drop on a breadcrumb inside the table triggers upload to target folder', function() {
 				var ev;
 				fileList.changeDirectory('a/b/c/d');
-				ev = dropOn(fileList.$el.find('.crumb:eq(2)'), uploadData);
+				ev = dropOn(fileList.$el.find('.crumb:eq(3)'), uploadData);
 
 				expect(ev).not.toEqual(false);
 				expect(uploadData.targetDir).toEqual('/a/b');

--- a/apps/files_trashbin/tests/js/filelistSpec.js
+++ b/apps/files_trashbin/tests/js/filelistSpec.js
@@ -132,12 +132,12 @@ describe('OCA.Trashbin.FileList tests', function() {
 			fileList.changeDirectory('/subdir', false, true);
 			fakeServer.respond();
 			var $crumbs = fileList.$el.find('#controls .crumb');
-			expect($crumbs.length).toEqual(2);
-			expect($crumbs.eq(0).find('a').text()).toEqual('');
-			expect($crumbs.eq(0).find('a').attr('href'))
-				.toEqual(OC.webroot + '/index.php/apps/files?view=trashbin&dir=/');
-			expect($crumbs.eq(1).find('a').text()).toEqual('subdir');
+			expect($crumbs.length).toEqual(3);
+			expect($crumbs.eq(1).find('a').text()).toEqual('Home');
 			expect($crumbs.eq(1).find('a').attr('href'))
+				.toEqual(OC.webroot + '/index.php/apps/files?view=trashbin&dir=/');
+			expect($crumbs.eq(2).find('a').text()).toEqual('subdir');
+			expect($crumbs.eq(2).find('a').attr('href'))
 				.toEqual(OC.webroot + '/index.php/apps/files?view=trashbin&dir=/subdir');
 		});
 	});

--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -822,6 +822,7 @@ kbd {
 	}
 	li {
 		display: flex;
+		flex: 0 0 auto;
 		> button,
 		> a,
 		> .menuitem {

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -74,7 +74,6 @@
 #header {
 	/* Header menu */
 	.menu {
-		position: relative;
 		top: 45px;
 		background-color: $color-main-background;
 		filter: drop-shadow(0 1px 3px $color-box-shadow);
@@ -82,6 +81,7 @@
 		display: none;
 		box-sizing: border-box;
 		z-index: 2000;
+		position: absolute;
 
 		/* Dropdown arrow */
 		&:after {
@@ -203,7 +203,7 @@ nav {
 	margin-left: -54px;
 }
 
-#navigation,
+.header-left #navigation,
 .ui-datepicker,
 .ui-timepicker.ui-widget {
 	position: relative;

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -22,30 +22,6 @@
 	-ms-user-select: none;
 }
 
-/* Header menu */
-.menu {
-	position: absolute;
-	top: 45px;
-	background-color: $color-main-background;
-	box-shadow: 0 1px 10px $color-box-shadow;
-	border-radius: 0 0 3px 3px;
-	display: none;
-	box-sizing: border-box;
-	z-index: 2000;
-
-	/* Dropdown arrow */
-	&:after {
-		border: 10px solid transparent;
-		border-bottom-color: $color-main-background;
-		bottom: 100%;
-		content: ' ';
-		height: 0;
-		width: 0;
-		position: absolute;
-		pointer-events: none;
-	}
-}
-
 /* removed until content-focusing issue is fixed */
 #skip-to-content a {
 	position: absolute;
@@ -96,6 +72,29 @@
 }
 
 #header {
+	/* Header menu */
+	.menu {
+		position: relative;
+		top: 45px;
+		background-color: $color-main-background;
+		filter: drop-shadow(0 1px 3px $color-box-shadow);
+		border-radius: 0 0 3px 3px;
+		display: none;
+		box-sizing: border-box;
+		z-index: 2000;
+
+		/* Dropdown arrow */
+		&:after {
+			border: 10px solid transparent;
+			border-bottom-color: $color-main-background;
+			bottom: 100%;
+			content: ' ';
+			height: 0;
+			width: 0;
+			position: absolute;
+			pointer-events: none;
+		}
+	}
 	.logo {
 		display: inline-flex;
 		background-image: url($image-logo);
@@ -211,7 +210,7 @@ nav {
 	left: -100%;
 	width: 160px;
 	background-color: $color-main-background;
-	box-shadow: 0 1px 10px $color-box-shadow;
+	filter: drop-shadow(0 1px 3px $color-box-shadow);
 	&:after {
 		/* position of dropdown arrow */
 		left: 47%;

--- a/core/css/mobile.scss
+++ b/core/css/mobile.scss
@@ -81,16 +81,11 @@
 	opacity: 1;
 }
 
-
-/* controls bar for mobile */
-#controls {
-	min-width: initial !important;
-	left: 0 !important;
-	padding-left: 0;
-}
 /* position controls for apps with app-navigation */
 #app-navigation+#app-content #controls {
+	left: 0 !important;
 	padding-left: 44px;
+	width: 100%;
 }
 
 /* .viewer-mode is when text editor, PDF viewer, etc is open */

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1437,7 +1437,6 @@ div.crumb {
 	> a[class^='icon-'] {
 		padding: 0;
 		width: 44px;
-		margin-right: 7px;
 	}
 	&:not(:first-child) a {
 	}

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1411,6 +1411,9 @@ div.crumb {
 		.popovermenu {
 			top: 100%;
 			margin-right: 3px;
+			.in-breadcrumb {
+				display: none;
+			}
 		}
 	}
 	&.hidden {
@@ -1427,6 +1430,10 @@ div.crumb {
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;
+		&.icon-home {
+			// Hide home text
+			text-indent: -9999px;
+		}
 	}
 	> a[class^='icon-'] {
 		padding: 0;

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -228,7 +228,7 @@ body {
 	right: 0;
 	left: 0;
 	height: 44px;
-	width: 100%;
+	width: calc(100% - 250px);
 	padding: 0;
 	margin: 0;
 	background-color: rgba($color-main-background, 0.95);
@@ -1391,7 +1391,6 @@ span.ui-icon {
 /* ---- BREADCRUMB ---- */
 div.breadcrumb {
 	display: inline-flex;
-	overflow: hidden;
 }
 div.crumb {
 	display: inline-flex;
@@ -1400,33 +1399,27 @@ div.crumb {
 	background-position: right center;
 	height: 44px;
 	background-size: auto 24px;
-	flex: 1 2 50px;
-	max-width: 200px;
+	flex: 0 0 auto;
 	&.hidden {
 		display: none;
 	}
-	a, > span {
+	a,
+	> span {
 		position: relative;
-		padding: 14px 24px 14px 17px;
+		padding: 12px 24px 12px 17px;
 		color: nc-lighten($color-main-text, 33%);
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;
 	}
-	&.last a {
-		padding-right: 0;
+	&:not(:first-child) a {
 	}
-	&.last {
+	&:last-child {
 		font-weight: 600;
 		margin-right: 10px;
-	}
-	&.ellipsized {
-		padding: 0 10px 0 5px;
-	}
-	a.ellipsislink {
-		padding: 0 !important;
-		position: relative;
-		top: 8px !important;
+		a {
+			padding-right: 0;
+		}
 	}
 	&:hover, &:focus, a:focus, &:active {
 		opacity: .7;

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1418,7 +1418,9 @@ div.crumb {
 			margin-right: 3px;
 			ul {
 				max-height: 345px;
-				overflow-y: scroll;
+				overflow-y: auto;
+				overflow-x: hidden;
+				padding-right: 5px;
 				li.canDrop span:first-child {
 					background-image: url('../img/filetypes/folder-drag-accept.svg?v=1') !important;
 				}

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1145,9 +1145,6 @@ code {
 #oc-dialog-filepicker-content {
 	.dirtree {
 		width: 92%;
-		float: left;
-		margin-left: 15px;
-		overflow: hidden;
 		div:first-child a {
 			background-image: url('../img/places/home.svg?v=1');
 			background-repeat: no-repeat;
@@ -1182,7 +1179,7 @@ code {
 		display: none;
 	}
 	.filelist {
-		background-color: white;
+		background-color: $color-main-background;
 		width: 100%;
 	}
 	#filestable.filelist {
@@ -1389,7 +1386,7 @@ span.ui-icon {
 }
 
 /* ---- BREADCRUMB ---- */
-div.breadcrumb {
+.breadcrumb {
 	display: inline-flex;
 }
 div.crumb {
@@ -1401,6 +1398,7 @@ div.crumb {
 	background-size: auto 24px;
 	flex: 0 0 auto;
 	order: 1;
+	padding-right: 7px;
 	&.crumbmenu {
 		order: 2;
 		position: relative;
@@ -1425,7 +1423,7 @@ div.crumb {
 	> a,
 	> span {
 		position: relative;
-		padding: 12px 24px 12px 17px;
+		padding: 12px;
 		opacity: 0.5;
 		text-overflow: ellipsis;
 		white-space: nowrap;

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1443,8 +1443,9 @@ div.crumb {
 	&:last-child {
 		font-weight: 600;
 		margin-right: 10px;
-		a {
-			padding-right: 0;
+		// Allow multiple span next to the main 'a'
+		a ~ span {
+			padding-left: 0;
 		}
 	}
 	&:hover, &:focus, a:focus, &:active {

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1410,6 +1410,10 @@ div.crumb {
 		.popovermenu {
 			top: 100%;
 			margin-right: 3px;
+			ul {
+				max-height: 345px;
+				overflow-y: scroll;
+			}
 			.in-breadcrumb {
 				display: none;
 			}

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1406,6 +1406,9 @@ div.crumb {
 		a {
 			opacity: 0.5
 		}
+		&.canDrop .popovermenu {
+			display: block;
+		}
 		// Fix because of the display flex
 		.popovermenu {
 			top: 100%;
@@ -1413,6 +1416,9 @@ div.crumb {
 			ul {
 				max-height: 345px;
 				overflow-y: scroll;
+				li.canDrop span:first-child {
+					background-image: url('../img/filetypes/folder-drag-accept.svg?v=1') !important;
+				}
 			}
 			.in-breadcrumb {
 				display: none;

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1145,6 +1145,7 @@ code {
 #oc-dialog-filepicker-content {
 	.dirtree {
 		width: 92%;
+		flex-wrap: wrap;
 		div:first-child a {
 			background-image: url('../img/places/home.svg?v=1');
 			background-repeat: no-repeat;

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1406,8 +1406,11 @@ div.crumb {
 		a {
 			opacity: 0.5
 		}
-		&.canDrop .popovermenu {
-			display: block;
+		&.canDropChildren,
+		&.canDrop {
+			.popovermenu {
+				display: block;
+			}
 		}
 		// Fix because of the display flex
 		.popovermenu {

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -237,6 +237,7 @@ body {
 	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
+	display: inline-flex;
 }
 
 /* position controls for apps with app-navigation */
@@ -1388,31 +1389,32 @@ span.ui-icon {
 }
 
 /* ---- BREADCRUMB ---- */
-
+div.breadcrumb {
+	display: inline-flex;
+	overflow: hidden;
+}
 div.crumb {
-	float: left;
-	display: block;
+	display: inline-flex;
 	background-image: url('../img/breadcrumb.svg?v=1');
 	background-repeat: no-repeat;
 	background-position: right center;
 	height: 44px;
 	background-size: auto 24px;
+	flex: 1 2 50px;
+	max-width: 200px;
 	&.hidden {
 		display: none;
 	}
 	a, > span {
 		position: relative;
-		top: 12px;
 		padding: 14px 24px 14px 17px;
 		color: nc-lighten($color-main-text, 33%);
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		overflow: hidden;
 	}
 	&.last a {
 		padding-right: 0;
-	}
-	&:first-child a {
-		position: relative;
-		top: 13px;
-		padding-right: 14px;
 	}
 	&.last {
 		font-weight: 600;

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1433,6 +1433,7 @@ div.crumb {
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;
+		flex: 0 0 auto;
 		&.icon-home {
 			// Hide home text
 			text-indent: -9999px;

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1400,17 +1400,38 @@ div.crumb {
 	height: 44px;
 	background-size: auto 24px;
 	flex: 0 0 auto;
+	order: 1;
+	&.crumbmenu {
+		order: 2;
+		position: relative;
+		a {
+			opacity: 0.5
+		}
+		// Fix because of the display flex
+		.popovermenu {
+			top: 100%;
+			margin-right: 3px;
+		}
+	}
 	&.hidden {
 		display: none;
+		~ .crumb {
+			order: 3;
+		}
 	}
-	a,
+	> a,
 	> span {
 		position: relative;
 		padding: 12px 24px 12px 17px;
-		color: nc-lighten($color-main-text, 33%);
+		opacity: 0.5;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;
+	}
+	> a[class^='icon-'] {
+		padding: 0;
+		width: 44px;
+		margin-right: 7px;
 	}
 	&:not(:first-child) a {
 	}
@@ -1422,7 +1443,10 @@ div.crumb {
 		}
 	}
 	&:hover, &:focus, a:focus, &:active {
-		opacity: .7;
+		> a,
+		> span {
+			opacity: .7;
+		}
 	}
 }
 

--- a/core/img/places/home.svg
+++ b/core/img/places/home.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" version="1"><path color="#000" fill="none" d="M-62.897-32.993h163.31v97.986h-163.31z"/><path opacity=".5" d="M8 1.03L0 9h3v6h10V9h3l-3-3.03V2h-3v1.08L8 1.03z" fill-rule="evenodd"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" version="1"><path color="#000" fill="none" d="M-62.897-32.993h163.31v97.986h-163.31z"/><path d="M8 1.03L0 9h3v6h10V9h3l-3-3.03V2h-3v1.08L8 1.03z" fill-rule="evenodd"/></svg>

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1625,39 +1625,6 @@ function initCore() {
 		// initial call
 		toggleSnapperOnSize();
 
-		// adjust controls bar width
-		var adjustControlsWidth = function() {
-			if($('#controls').length) {
-				var controlsWidth;
-				// if there is a scrollbar …
-				if($('#app-content').get(0).scrollHeight > $('#app-content').height()) {
-					if($(window).width() > 768) {
-						controlsWidth = $('#content').width() - $('#app-navigation').width() - getScrollBarWidth();
-						if (!$('#app-sidebar').hasClass('hidden') && !$('#app-sidebar').hasClass('disappear')) {
-							controlsWidth -= $('#app-sidebar').width();
-						}
-					} else {
-						controlsWidth = $('#content').width() - getScrollBarWidth();
-					}
-				} else { // if there is none
-					if($(window).width() > 768) {
-						controlsWidth = $('#content').width() - $('#app-navigation').width();
-						if (!$('#app-sidebar').hasClass('hidden') && !$('#app-sidebar').hasClass('disappear')) {
-							controlsWidth -= $('#app-sidebar').width();
-						}
-					} else {
-						controlsWidth = $('#content').width();
-					}
-				}
-				$('#controls').css('width', controlsWidth);
-				$('#controls').css('min-width', controlsWidth);
-			}
-		};
-
-		$(window).resize(_.debounce(adjustControlsWidth, 250));
-
-		$('body').delegate('#app-content', 'apprendered appresized', _.debounce(adjustControlsWidth, 150));
-
 	}
 
 	// Update live timestamps every 30 seconds

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -929,7 +929,7 @@ var OCdialogs = {
 	*/
 	_handleTreeListSelect:function(event, type) {
 		var self = event.data;
-		var dir = $(event.target).parent().data('dir');
+		var dir = $(event.target).closest('.crumb').data('dir');
 		self._fillFilePicker(dir);
 		var getOcDialog = (event.target).closest('.oc-dialog');
 		var buttonEnableDisable = $('.primary', getOcDialog);


### PR DESCRIPTION
Summary here: https://github.com/nextcloud/server/pull/7051#issuecomment-342940681

Fix #5431, fix #6756 
Closes #5229 

Rebuilding the breadcrumbs design and calculation system for a better result:
- [x] Flexi flexo magic
- [x] Calculate what elements to hide
- [x] Auto hide
- [x] Put hidden elements in a popover
- [x] Mobile style
- [x] Fix click feedback and sidebar opening
- [ ] ~~Animation ?~~
- [x] Fix file picker
- [x] Tests ⚠️ 
- [x] Performance optimisations
  - [ ] ~~There are multiple calls for `BreadCrumb.setDirectoryInfo` & `BreadCrumb.setDirectory` which force re-renders~~
   - [ ] ~~There are at least 3 `BreadCrumb._resize` execution on init, only one is needed~~