### PR TITLE
Improve timepicker design, align to datepicker

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -224,7 +224,7 @@ nav {
 		position: absolute;
 		pointer-events: none;
 		border-color: rgba(0, 0, 0, 0);
-		border-bottom-color: rgba(255, 255, 255, .97);
+		border-bottom-color: $color-main-background;
 		border-width: 9px;
 		margin-left: -9px;
 	}

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -206,7 +206,8 @@ nav {
 }
 
 #navigation,
-.ui-datepicker {
+.ui-datepicker,
+.ui-timepicker.ui-widget {
 	position: relative;
 	left: -100%;
 	width: 160px;

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1070,6 +1070,72 @@ code {
 	background: $color-main-background;
 }
 
+
+/* ---- jQuery UI timepicker ---- */
+.ui-widget.ui-timepicker {
+	margin-top: 10px !important;
+	width: auto !important;
+	border-radius: $border-radius;
+
+	.ui-widget-content {
+		border: none !important;
+	}
+
+	.ui-state-default,
+	.ui-widget-content .ui-state-default,
+	.ui-widget-header .ui-state-default {
+		border: 1px solid transparent;
+		background: inherit;
+	}
+	.ui-widget-header {
+		padding: 7px;
+		font-size: 13px;
+		border:	none;
+		background-color: $color-main-background;
+		color: $color-main-text;
+
+		.ui-timepicker-title {
+			line-height: 1;
+			font-weight: 300;
+		}
+	}
+	.ui-timepicker-table {
+		th {
+			font-weight: normal;
+			color: nc-lighten($color-main-text, 33%);
+			opacity: .8;
+		}
+		tr:hover {
+			background-color: inherit;
+		}
+		td {
+			> * {
+				border-radius: 50%;
+				text-align: center;
+				font-weight: normal;
+				color: $color-main-text;
+				padding: 8px 7px;
+				font-size: .9em;
+				line-height: 12px;
+			}
+
+			&.ui-timepicker-hour-cell a.ui-state-active,
+			&.ui-timepicker-minute-cell a.ui-state-active,
+			.ui-state-hover,
+			.ui-state-focus {
+				background-color: $color-primary;
+				color: $color-primary-text;
+				font-weight: bold;
+			}
+
+			&.ui-timepicker-minutes:not(.ui-state-hover) {
+				color: nc-lighten($color-main-text, 33%);
+				opacity: .8;
+			}
+		}
+	}
+}
+
 /* ---- DIALOGS ---- */
 
 #oc-dialog-filepicker-content {

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1132,6 +1132,10 @@ code {
 				color: nc-lighten($color-main-text, 33%);
 				opacity: .8;
 			}
+
+			&.ui-timepicker-hours {
+				border-right: 1px solid $color-border;
+			}
 		}
 	}
 }

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1130,7 +1130,6 @@ code {
 
 			&.ui-timepicker-minutes:not(.ui-state-hover) {
 				color: nc-lighten($color-main-text, 33%);
-				opacity: .8;
 			}
 
 			&.ui-timepicker-hours {


### PR DESCRIPTION
Basically the equivalent of Redesign jQuery UI datepicker #5713 :), also ref "Include a timepicker into server" #6348.

Please review @nextcloud/designers @georgehrke @raimund-schluessler 

I didn’t mess with any layout for now to not make it too big – but ideally we also improve that. This is mainly a quick fix for Nextcloud 13 because the timepicker is one of the only ugly jQuery UI parts left.

You can test in the Calendar app (positioning needs to be fixed there @georgehrke):

Before:
![screenshot from 2017-11-03 15-02-54](https://user-images.githubusercontent.com/925062/32377475-18720cda-c0a8-11e7-82ab-454449909456.png)

After:
![screenshot from 2017-11-03 14-58-00](https://user-images.githubusercontent.com/925062/32377476-1894c54a-c0a8-11e7-9c99-16a8b13853b8.png)
