### PR TITLE
core: hide spinner for initial install

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -624,6 +624,8 @@ p.info {
 .float-spinner {
 	margin-top: -32px;
 	padding-top: 32px;
+	height: 32px;
+	display: none;
 }
 [class^='icon-'], [class*=' icon-'] {
 	background-repeat: no-repeat;


### PR DESCRIPTION
`core/js/setup.js` has logic to show the spinner upon form submission, but ever since v12 was released the spinner was never hidden in the first place.

This PR fixes #5532 by modifying `core/css/guest.css` to hide it, which allows `core/js/setup.js` to do its thing.