### PR TITLE
SCSS cacher: use realpath on path

### DIFF
--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -94,7 +94,7 @@ class SCSSCacher {
 		$fileNameSCSS = array_pop($path);
 		$fileNameCSS = $this->prependBaseurlPrefix(str_replace('.scss', '.css', $fileNameSCSS));
 
-		$path = implode('/', $path);
+		$path = realpath(implode('/', $path));
 
 		$webDir = substr($path, strlen($this->serverRoot)+1);
 


### PR DESCRIPTION
This PR fixes #6028 more completely by using realpath in the cacher as well. Otherwise, if the server root includes a symlink, the calculated webDir will be incorrect and CSS will break.