### PR TITLE
Fix popover layout

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -547,46 +547,49 @@ a.action > img {
 	margin-bottom: -1px;
 }
 
-#fileList a.action {
-	display: inline;
-	padding: 17px 8px;
-	line-height: 50px;
-	opacity: 0;
-}
-#fileList a.action.action-share {
-	padding: 17px 14px;
-}
-#fileList a.action.action-share .avatar {
-	display: inline-block;
-	vertical-align: middle;
-}
-
-#fileList a.action.action-menu {
-	padding-top: 17px;
-	padding-bottom: 17px;
-	padding-left: 14px;
-	padding-right: 14px;
-}
-
-#fileList a.action,
-#fileList a.action.no-permission:hover,
-#fileList a.action.no-permission:focus,
-/* also enforce the low opacity for disabled links that are hovered/focused */
-#fileList a.action.disabled:hover,
-#fileList a.action.disabled:focus,
-#fileList a.action.disabled img {
-	opacity: .3;
-}
-
-#fileList a.action.disabled.action-download,
-#fileList a.action.disabled.action-download:hover,
-#fileList a.action.disabled.action-download:focus,
-#fileList a.action:hover,
-#fileList a.action:focus,
-#fileList .fileActionsMenu a.action,
-/* show share action of shared items darker to distinguish from non-shared */
-#fileList a.action.action-share.shared-style {
-	opacity: .7;
+#fileList td a {
+	a.action {
+		display: inline;
+		padding: 17px 8px;
+		line-height: 50px;
+		opacity: .3;
+		&.action-share {
+			padding: 17px 14px;
+			.avatar {
+				display: inline-block;
+				vertical-align: middle;
+			}
+		}
+		&.action-menu {
+			padding-top: 17px;
+			padding-bottom: 17px;
+			padding-left: 14px;
+			padding-right: 14px;
+		}
+		&.no-permission {
+			&:hover, &:focus {
+				opacity: .3;
+			}
+		}
+		&.disabled {
+			&:hover, &:focus,
+			img {
+				opacity: .3;
+			}
+			&.action-download {
+				opacity: .7;
+				&:hover, &:focus {
+					opacity: .7;
+				}
+			}
+		}
+		&:hover, &:focus {
+			opacity: .7;
+		}
+	}
+	.fileActionsMenu a.action, a.action.action-share.shared-style {
+		opacity: .7;
+	}
 }
 
 // Ellipsize long sharer names
@@ -739,7 +742,7 @@ table.dragshadow td.size {
 
 .canDrop,
 #filestable tbody tr.canDrop {
-  background-color: rgba(255, 255, 140, 1);
+	background-color: rgba(255, 255, 140, 1);
 }
 
 

--- a/apps/files_sharing/css/sharetabview.scss
+++ b/apps/files_sharing/css/sharetabview.scss
@@ -79,22 +79,14 @@
 	align-items: center;
 }
 
-#shareWithList .unshare img, #shareWithList .showCruds img {
+#shareWithList .unshare img {
 	vertical-align: text-bottom; /* properly align icons */
 }
 
-#shareWithList .sharingOptionsGroup .icon-more {
+#shareWithList .sharingOptionsGroup > a .icon {
 	padding: 7px;
 	vertical-align: middle;
 	opacity: .5;
-}
-
-#shareWithList .unshare {
-	padding: 1px 6px;
-	vertical-align: text-bottom;
-}
-#shareWithList .unshare .icon {
-	vertical-align: text-top;
 }
 
 #shareWithList .sharingOptionsGroup .popovermenu:after {
@@ -122,7 +114,6 @@
 .shareTabView .icon-loading-small {
 	display: inline-block;
 	z-index: 1;
-	margin-right: 4px;
 	vertical-align: text-top;
 }
 

--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -841,20 +841,23 @@ kbd {
 			/* Override the app-navigation li opacity */
 			opacity: .7 !important;
 			[class^='icon-'],
+			[class*=' icon-'],
+			&[class^='icon-'],
+			&[class*=' icon-'] {
+				min-width: 0; /* Overwrite icons*/
+				min-height: 0;
+				background-position: 10px center;
+				background-size: 16px;
+			}
+			[class^='icon-'],
 			[class*=' icon-'] {
 				/* Keep padding to define the width to
 				 assure correct position of a possible text */
 				padding: 18px 0 18px 36px;
-				min-width: 0; /* Overwrite icons*/
-				min-height: 0;
-				background-position: 10px center;
 			}
 			&[class^='icon-'],
 			&[class*=' icon-'] {
 				padding: 0 10px 0 36px !important;
-				min-width: 0; /* Overwrite icons*/
-				min-height: 0;
-				background-position: 10px center;
 			}
 			&:hover, &:focus, &.active {
 				opacity: 1 !important;

--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -837,8 +837,25 @@ kbd {
 			font-weight: 300;
 			box-shadow: none;
 			width: 100%;
+			color: $color-main-text;
 			/* Override the app-navigation li opacity */
 			opacity: .7 !important;
+			[class^='icon-'],
+			[class*=' icon-'] {
+				/* Keep padding to define the width to
+				 assure correct position of a possible text */
+				padding: 18px 0 18px 36px;
+				min-width: 0; /* Overwrite icons*/
+				min-height: 0;
+				background-position: 10px center;
+			}
+			&[class^='icon-'],
+			&[class*=' icon-'] {
+				padding: 0 10px 0 36px !important;
+				min-width: 0; /* Overwrite icons*/
+				min-height: 0;
+				background-position: 10px center;
+			}
 			&:hover, &:focus, &.active {
 				opacity: 1 !important;
 			}
@@ -857,7 +874,6 @@ kbd {
 			}
 			/* Add padding if contains icon+text */
 			&:not(:empty) {
-				padding: 0 !important;
 				padding-right: 10px !important;
 			}
 			> img {
@@ -871,14 +887,12 @@ kbd {
 				}
 			}
 		}
-		[class^='icon-'],
-		[class*=' icon-']{
-			/* Keep padding to define the width to
-			 assure correct position of a possible text */
-			padding: 18px 0 18px 36px;
-			min-width: 0; /* Overwrite icons*/
-			min-height: 0;
-			background-position: 10px center;
+		> button {
+			padding: 0;
+			span {
+				opacity: 1;
+			}
 		}
+
 	}
 }

--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -889,6 +889,12 @@ kbd {
 					margin: -2px 12px 0;
 				}
 			}
+			> input.radio + label {
+				padding: 0 !important;
+				&::before {
+					margin: -2px 11px 0;
+				}
+			}
 		}
 		> button {
 			padding: 0;

--- a/core/css/share.scss
+++ b/core/css/share.scss
@@ -104,7 +104,6 @@
 		.popovermenu {
 			right: -11px;
 			top: 35px;
-			padding: 3px 6px;
 		}
 	}
 
@@ -112,8 +111,7 @@
 		white-space: nowrap;
 		display: inline-block;
 	}
-	.unshare img,
-	.showCruds img {
+	.unshare img {
 		vertical-align: text-bottom;
 		/* properly align icons */
 	}
@@ -129,22 +127,6 @@
 		overflow: hidden;
 		vertical-align: middle;
 		flex-grow: 5;
-	}
-}
-
-a {
-	&.showCruds {
-		display: inline;
-		opacity: .5;
-	}
-	&.unshare {
-		display: inline-block;
-		opacity: .5;
-		padding: 10px;
-	}
-	&.showCruds:hover,
-	&.unshare:hover {
-		opacity: 1;
 	}
 }
 

--- a/core/js/tests/specs/sharedialogshareelistview.js
+++ b/core/js/tests/specs/sharedialogshareelistview.js
@@ -123,20 +123,6 @@ describe('OC.Share.ShareDialogShareeListView', function () {
 			expect(listView.$el.find("input[name='edit']").is(':checked')).toEqual(true);
 			expect(updateShareStub.calledOnce).toEqual(true);
 		});
-
-		it('shows cruds checkboxes when toggled', function () {
-			shareModel.set('shares', [{
-				id: 100,
-				item_source: 123,
-				permissions: 1,
-				share_type: OC.Share.SHARE_TYPE_USER,
-				share_with: 'user1',
-				share_with_displayname: 'User One'
-			}]);
-			listView.render();
-			listView.$el.find('a.showCruds').click();
-			expect(listView.$el.find('li.cruds').hasClass('hidden')).toEqual(false);
-		});
 	});
 
 });


### PR DESCRIPTION
Somehow the various popover layouts broke appart.
My guess is the cleanup we did on various part of the css which may have influenced this.

I also added support for radio since we also support checkboxes after #6976.

Please tests from various locations. Example:
- Privacy menu in user details
- Session list
- Calendar menu
- ....

| Before | After |
|:---:|:---:|
|![kazam_screenshot_00005](https://user-images.githubusercontent.com/14975046/32406398-f58d4948-c177-11e7-9ca9-3e5982cd94b8.png)|![kazam_screenshot_00004](https://user-images.githubusercontent.com/14975046/32406399-f9e90c2a-c177-11e7-8e3b-36c68a7ffb00.png)|


Test template: [templatetest.tar.gz](https://github.com/nextcloud/server/files/1443188/templatetest.tar.gz)

@nextcloud/designers 