### PR TITLE
Fix header app menu

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -143,7 +143,6 @@
 	#header-left, .header-left {
 		flex: 0 0;
 		flex-grow: 1;
-		overflow: hidden;
 		white-space: nowrap;
 	}
 
@@ -317,6 +316,10 @@ nav {
 	overflow: auto;
 	.in-header {
 		display: none;
+	}
+	ul {
+		display: flex;
+		flex-direction: column;
 	}
 }
 


### PR DESCRIPTION
Fix #7065
Also fixes a previous issue where the link didn't have the full width in the popover menu.

![kazam_screenshot_00003](https://user-images.githubusercontent.com/14975046/32406201-381fb81c-c174-11e7-88d5-e09acd4b9b05.png)


@nextcloud/designers 