### PR TITLE
Better error message for invalid bucket names

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -90,8 +90,8 @@ trait S3ConnectionTrait {
 		}
 		$this->connection = new S3Client($options);
 
-		if (!S3Client::isBucketDnsCompatible($this->bucket)) {
-			throw new \Exception("The configured bucket name is invalid.");
+		if (!$this->connection->isBucketDnsCompatible($this->bucket)) {
+			throw new \Exception("The configured bucket name is invalid: " . $this->bucket);
 		}
 
 		if (!$this->connection->doesBucketExist($this->bucket)) {


### PR DESCRIPTION
Found in my stashes and was from a debugging session for S3 bucket names. Makes also the code less static. 😉 