### PR TITLE
Revert "Only allow colons in db host for IPv6 addresses"

### DIFF
--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -295,10 +295,6 @@ class Setup {
 			$error[] = $l->t("Can't create or write into the data directory %s", array($dataDir));
 		}
 
-		if (!$this->validateDatabaseHost($options['dbhost'])) {
-			$error[] = $l->t('Given database host is invalid and must not contain the port: %s', [$options['dbhost']]);
-		}
-
 		if (!empty($error)) {
 			return $error;
 		}
@@ -414,18 +410,6 @@ class Setup {
 		}
 
 		return $error;
-	}
-
-	/**
-	 * @param string $host
-	 * @return bool
-	 */
-	protected function validateDatabaseHost($host) {
-		if (strpos($host, ':') === false) {
-			return true;
-		}
-
-		return filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
 	}
 
 	public static function installBackgroundJobs() {


### PR DESCRIPTION
This reverts commit 1287d6ddb303fc9b088b8a6837490042a1540dc6.

Same as #7102 for master.

Fixes #7058 for master