### PR TITLE
If for some reason the json can't be decoded it is not cached

### DIFF
--- a/lib/private/Template/JSCombiner.php
+++ b/lib/private/Template/JSCombiner.php
@@ -119,6 +119,10 @@ class JSCombiner {
 
 			$deps = json_decode($deps, true);
 
+			if ($deps === NULL) {
+				return false;
+			}
+
 			foreach ($deps as $file=>$mtime) {
 				if (!file_exists($file) || filemtime($file) > $mtime) {
 					return false;


### PR DESCRIPTION
Should fix #6898

CC: @maxibanki