### PR TITLE
[stable12] Fix icon for security settings

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -22,7 +22,7 @@ input#openid, input#webdav {
 }
 
 .nav-icon-security {
-	background-image: url('../img/toggle-filelist.svg?v=1');
+	background-image: url('../img/password.svg?v=1');
 }
 
 .nav-icon-apppasswords {


### PR DESCRIPTION
Fixes #6033 (see that for the image before)

Now looks like this:

<img width="152" alt="bildschirmfoto 2017-11-09 um 09 13 50" src="https://user-images.githubusercontent.com/245432/32594988-65de90e4-c52e-11e7-89ee-064b7ea9ec39.png">
