### PR TITLE
If there is no internet connection don't try to contact appstore

### DIFF
--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -128,8 +128,9 @@ abstract class Fetcher {
 	 */
 	public function get() {
 		$appstoreenabled = $this->config->getSystemValue('appstoreenabled', true);
+		$internetavailable = $this->config->getSystemValue('has_internet_connection', true);
 
-		if (!$appstoreenabled) {
+		if (!$appstoreenabled || !$internetavailable) {
 			return [];
 		}
 

--- a/tests/lib/App/AppStore/Fetcher/AppFetcherTest.php
+++ b/tests/lib/App/AppStore/Fetcher/AppFetcherTest.php
@@ -1945,10 +1945,30 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 
 	public function testAppstoreDisabled() {
 		$this->config
-			->expects($this->once())
 			->method('getSystemValue')
-			->with('appstoreenabled', true)
-			->willReturn(false);
+			->will($this->returnCallback(function($var, $default) {
+				if ($var === 'appstoreenabled') {
+					return false;
+				}
+				return $default;
+			}));
+		$this->appData
+			->expects($this->never())
+			->method('getFolder');
+
+		$this->assertEquals([], $this->fetcher->get());
+	}
+
+
+	public function testNoInternet() {
+		$this->config
+			->method('getSystemValue')
+			->will($this->returnCallback(function($var, $default) {
+				if ($var === 'has_internet_connection') {
+					return false;
+				}
+				return $default;
+			}));
 		$this->appData
 			->expects($this->never())
 			->method('getFolder');

--- a/tests/lib/App/AppStore/Fetcher/CategoryFetcherTest.php
+++ b/tests/lib/App/AppStore/Fetcher/CategoryFetcherTest.php
@@ -40,15 +40,33 @@ class CategoryFetcherTest extends FetcherBase {
 
 	public function testAppstoreDisabled() {
 		$this->config
-			->expects($this->once())
 			->method('getSystemValue')
-			->with('appstoreenabled', true)
-			->willReturn(false);
+			->will($this->returnCallback(function($var, $default) {
+				if ($var === 'appstoreenabled') {
+					return false;
+				}
+				return $default;
+			}));
 		$this->appData
 			->expects($this->never())
 			->method('getFolder');
 
 		$this->assertEquals([], $this->fetcher->get());
+	}
 
+	public function testNoInternet() {
+		$this->config
+			->method('getSystemValue')
+			->will($this->returnCallback(function($var, $default) {
+				if ($var === 'has_internet_connection') {
+					return false;
+				}
+				return $default;
+			}));
+		$this->appData
+			->expects($this->never())
+			->method('getFolder');
+
+		$this->assertEquals([], $this->fetcher->get());
 	}
 }

--- a/tests/lib/App/AppStore/Fetcher/FetcherBase.php
+++ b/tests/lib/App/AppStore/Fetcher/FetcherBase.php
@@ -78,6 +78,11 @@ abstract class FetcherBase extends TestCase {
 		$this->config
 			->expects($this->at(1))
 			->method('getSystemValue')
+			->with('has_internet_connection', true)
+			->willReturn(true);
+		$this->config
+			->expects($this->at(2))
+			->method('getSystemValue')
 			->with(
 				$this->equalTo('version'),
 				$this->anything()
@@ -121,10 +126,15 @@ abstract class FetcherBase extends TestCase {
 		$this->config
 			->expects($this->at(1))
 			->method('getSystemValue')
-			->with('appstoreenabled', true)
+			->with('has_internet_connection', true)
 			->willReturn(true);
 		$this->config
 			->expects($this->at(2))
+			->method('getSystemValue')
+			->with('appstoreenabled', true)
+			->willReturn(true);
+		$this->config
+			->expects($this->at(3))
 			->method('getSystemValue')
 			->with(
 				$this->equalTo('version'),
@@ -277,10 +287,15 @@ abstract class FetcherBase extends TestCase {
 		$this->config
 			->expects($this->at(1))
 			->method('getSystemValue')
-			->with('appstoreenabled', true)
+			->with('has_internet_connection', true)
 			->willReturn(true);
 		$this->config
 			->expects($this->at(2))
+			->method('getSystemValue')
+			->with('appstoreenabled', true)
+			->willReturn(true);
+		$this->config
+			->expects($this->at(3))
 			->method('getSystemValue')
 			->with(
 				$this->equalTo('version'),
@@ -356,10 +371,15 @@ abstract class FetcherBase extends TestCase {
 		$this->config
 			->expects($this->at(1))
 			->method('getSystemValue')
-			->with('appstoreenabled', true)
+			->with('has_internet_connection', true)
 			->willReturn(true);
 		$this->config
 			->expects($this->at(2))
+			->method('getSystemValue')
+			->with('appstoreenabled', true)
+			->willReturn(true);
+		$this->config
+			->expects($this->at(3))
 			->method('getSystemValue')
 			->with(
 				$this->equalTo('version'),


### PR DESCRIPTION
Fixes #7119

If your instance has no internet connection it makes no sense to try to contact the appstore.