### PR TITLE
Fix "allow user mount" checkbox for external storage

### DIFF
--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -169,10 +169,10 @@
 
 	<?php if ($_['visibilityType'] === BackendService::VISIBILITY_ADMIN): ?>
 		<input type="checkbox" name="allowUserMounting" id="allowUserMounting" class="checkbox"
-			value="1" <?php if ($_['allowUserMounting'] === 'yes') print_unescaped(' checked="checked"'); ?> />
+			value="1" <?php if ($_['allowUserMounting']) print_unescaped(' checked="checked"'); ?> />
 		<label for="allowUserMounting"><?php p($l->t('Allow users to mount external storage')); ?></label> <span id="userMountingMsg" class="msg"></span>
 
-		<p id="userMountingBackends"<?php if ($_['allowUserMounting'] !== 'yes'): ?> class="hidden"<?php endif; ?>>
+		<p id="userMountingBackends"<?php if (!$_['allowUserMounting']): ?> class="hidden"<?php endif; ?>>
 			<?php p($l->t('Allow users to mount the following external storage')); ?><br />
 			<?php
 				$userBackends = array_filter($_['backends'], function($backend) {


### PR DESCRIPTION
Currently the checkbox is always shown as disabled, regardless of the actual status