### PR TITLE
Use the correct root for shared jail when the source storage is also a jail

### DIFF
--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -30,6 +30,7 @@ namespace OCA\Files_Sharing;
 
 use OC\Files\Cache\FailedCache;
 use OC\Files\Cache\Wrapper\CacheJail;
+use OC\Files\Storage\Wrapper\Jail;
 use OCP\Files\Cache\ICacheEntry;
 
 /**
@@ -62,9 +63,21 @@ class Cache extends CacheJail {
 		$this->storage = $storage;
 		$this->sourceRootInfo = $sourceRootInfo;
 		$this->numericId = $sourceRootInfo->getStorageId();
+
+		$absoluteRoot = $this->sourceRootInfo->getPath();
+
+		// the sourceRootInfo path is the absolute path of the folder in the "real" storage
+		// in the case where a folder is shared from a Jail we need to ensure that the share Jail
+		// has it's root set relative to the source Jail
+		$currentStorage = $storage->getSourceStorage();
+		if ($currentStorage->instanceOfStorage(Jail::class)) {
+			/** @var Jail $currentStorage */
+			$absoluteRoot = $currentStorage->getJailedPath($absoluteRoot);
+		}
+
 		parent::__construct(
 			null,
-			$this->sourceRootInfo->getPath()
+			$absoluteRoot
 		);
 	}
 

--- a/lib/private/Files/Storage/Wrapper/Jail.php
+++ b/lib/private/Files/Storage/Wrapper/Jail.php
@@ -60,6 +60,17 @@ class Jail extends Wrapper {
 		}
 	}
 
+	public function getJailedPath($path) {
+		$root = rtrim($this->rootPath, '/') . '/';
+
+		if (strpos($path, $root) !== 0) {
+			return null;
+		} else {
+			$path = substr($path, strlen($this->rootPath));
+			return trim($path, '/');
+		}
+	}
+
 	public function getId() {
 		return parent::getId();
 	}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/groupfolders/issues/54

to test:

- enable groupfolders
- create a groupfolder `Foo` which can be accessed user `user1`
- as `user1` create a folder `Foo/sub` and share it with `user2`
- as `user2` upload a file in `sub`

Currently the file is uploaded to disk but not correctly added to the cache.

The root cause is sharing being smart an getting it's info efficiently from the db, which leads to some assumptions that were broken by groupfolders.