### PR TITLE
remove cached size from shared calendar objects

### DIFF
--- a/apps/dav/lib/CalDAV/CalendarObject.php
+++ b/apps/dav/lib/CalDAV/CalendarObject.php
@@ -33,6 +33,22 @@ use Sabre\VObject\Reader;
 class CalendarObject extends \Sabre\CalDAV\CalendarObject {
 
 	/**
+	 * CalendarObject constructor.
+	 *
+	 * @param CalDavBackend $caldavBackend
+	 * @param array $calendarInfo
+	 * @param array $objectData
+	 */
+	public function __construct(CalDavBackend $caldavBackend, array $calendarInfo,
+								array $objectData) {
+		parent::__construct($caldavBackend, $calendarInfo, $objectData);
+
+		if ($this->isShared()) {
+			unset($this->objectData['size']);
+		}
+	}
+
+	/**
 	 * @inheritdoc
 	 */
 	function get() {


### PR DESCRIPTION
The object size is cached in the database, but we manipulate the data for shared calendars (remove `VAlarms` and apply `Class` rules, hence the data size is not correct for shared calendars.

If the size is not set, it will simply be calculated by the Sabre CalendarObject.
https://github.com/nextcloud/3rdparty/blob/ec71700daf6aab080502f67ecfca274dcb0bb3d9/sabre/dav/lib/CalDAV/CalendarObject.php#L178