### PR TITLE
Force breaks on extremely long words in comments

### DIFF
--- a/apps/comments/css/comments.css
+++ b/apps/comments/css/comments.css
@@ -60,6 +60,8 @@
 #commentsTabView .comment {
 	position: relative;
 	margin-bottom: 30px;
+	word-wrap: break-word;
+	overflow-wrap: break-word;
 }
 
 #commentsTabView .comment .avatar,


### PR DESCRIPTION
If not broken extremely long words overflow their container; I have added the break rule to the whole comment, so it will be used too in author names (even if it is highly unlikely that any author name would be long enough to overflow...).

Before:
![before-looong](https://user-images.githubusercontent.com/26858233/32741345-3bc2273c-c8a6-11e7-92aa-37481dafa565.png)

After:
![after-looong](https://user-images.githubusercontent.com/26858233/32741356-4384126e-c8a6-11e7-88ff-4c6e9ea3f75c.png)
