### PR TITLE
Fix tooltip placement in Shared files list

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1285,7 +1285,7 @@
 					fileData.extraData = fileData.extraData.substr(1);
 				}
 				nameSpan.addClass('extra-data').attr('title', fileData.extraData);
-				nameSpan.tooltip({placement: 'right'});
+				nameSpan.tooltip({placement: 'top'});
 			}
 			// dirs can show the number of uploaded files
 			if (mime === 'httpd/unix-directory') {


### PR DESCRIPTION
The tooltip was placed to the right which looks strange and actually makes it almost not visible. It’s also pretty nonstandard as we use top almost everywhere else.
![screenshot from 2017-11-14 11-57-17](https://user-images.githubusercontent.com/925062/32776546-32675936-c933-11e7-992c-8c99519cfb7c.png)

Fixed it to placement above:
![screenshot from 2017-11-14 11-54-19](https://user-images.githubusercontent.com/925062/32776545-31ec400c-c933-11e7-89ae-324d0f2044e3.png)

Please review @nextcloud/designers 

(It would be even nicer of course to have the tooltip aligned to the left but it seems like that’s not easily possible through the tooltip API. Maybe @nextcloud/javascript have an idea.)