### PR TITLE
Pass the exception context to the crash reporter

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -352,7 +352,7 @@ class Log implements ILogger {
 		$msg .= ': ' . json_encode($data);
 		$this->log($level, $msg, $context);
 		if (!is_null($this->crashReporters)) {
-			$this->crashReporters->delegateReport($exception);
+			$this->crashReporters->delegateReport($exception, $context);
 		}
 	}
 

--- a/lib/private/Support/CrashReport/Registry.php
+++ b/lib/private/Support/CrashReport/Registry.php
@@ -45,10 +45,11 @@ class Registry implements IRegistry {
 	 * Delegate crash reporting to all registered reporters
 	 *
 	 * @param Exception|Throwable $exception
+	 * @param array $context
 	 */
-	public function delegateReport($exception) {
+	public function delegateReport($exception, array $context = []) {
 		foreach ($this->reporters as $reporter) {
-			$reporter->report($exception);
+			$reporter->report($exception, $context);
 		}
 	}
 

--- a/lib/private/Support/CrashReport/Registry.php
+++ b/lib/private/Support/CrashReport/Registry.php
@@ -48,6 +48,7 @@ class Registry implements IRegistry {
 	 * @param array $context
 	 */
 	public function delegateReport($exception, array $context = []) {
+		/** @var IReporter $reporter */
 		foreach ($this->reporters as $reporter) {
 			$reporter->report($exception, $context);
 		}

--- a/lib/public/Support/CrashReport/IRegistry.php
+++ b/lib/public/Support/CrashReport/IRegistry.php
@@ -43,6 +43,7 @@ interface IRegistry {
 	 *
 	 * @since 13.0.0
 	 * @param Exception|Throwable $exception
+	 * @param array $context
 	 */
-	public function delegateReport($exception);
+	public function delegateReport($exception, array $context = []);
 }

--- a/lib/public/Support/CrashReport/IReporter.php
+++ b/lib/public/Support/CrashReport/IReporter.php
@@ -35,6 +35,7 @@ interface IReporter {
 	 *
 	 * @since 13.0.0
 	 * @param Exception|Throwable $exception
+	 * @param array $context
 	 */
-	public function report($exception);
+	public function report($exception, array $context = []);
 }

--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -90,7 +90,7 @@ class LoggerTest extends TestCase {
 		$e = new \Exception('test');
 		$this->registry->expects($this->once())
 			->method('delegateReport')
-			->with($e);
+			->with($e, []);
 
 		$this->logger->logException($e);
 
@@ -109,7 +109,7 @@ class LoggerTest extends TestCase {
 		$e = new \Exception('test');
 		$this->registry->expects($this->once())
 			->method('delegateReport')
-			->with($e);
+			->with($e, []);
 
 		$this->logger->logException($e);
 
@@ -128,7 +128,7 @@ class LoggerTest extends TestCase {
 		$e = new \Exception('test');
 		$this->registry->expects($this->once())
 			->method('delegateReport')
-			->with($e);
+			->with($e, []);
 
 		$this->logger->logException($e);
 
@@ -147,7 +147,7 @@ class LoggerTest extends TestCase {
 		$e = new \Exception('test');
 		$this->registry->expects($this->once())
 			->method('delegateReport')
-			->with($e);
+			->with($e, []);
 
 		$this->logger->logException($e);
 


### PR DESCRIPTION
This should allow better reports as often the app id is passed
as context. While this is not used right now, I'd like to have this
for NC13 as adding it later will break the interface for existing apps

This is a follow-up for #7151. Sorry that I'm submitting this after feature freeze.