### PR TITLE
Fix reset password button overflow

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -136,8 +136,7 @@ form #datadirField legend {
 						   absolutely positioned descendant icons */
 }
 
-#submit-wrapper .submit-icon,
-#reset-password-wrapper .submit-icon {
+#submit-wrapper .submit-icon {
 	position: absolute;
 	top: 23px;
 	right: 23px;
@@ -145,6 +144,16 @@ form #datadirField legend {
 							 From the user point of view the icon is part of the
 							 button, so the clicks on the icon have to be
 							 applied to the button instead. */
+}
+
+#reset-password-submit {
+	padding: 10px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+#reset-password-wrapper .submit-icon {
+	display: none;
 }
 
 #submit-wrapper .icon-loading-small {


### PR DESCRIPTION
Ref https://github.com/nextcloud/server/pull/7013#issuecomment-342780367
Had to cut the arrow icon from the button because otherwise centering the text and overflowing too is not possible.

Please review @nextcloud/designers 

Before:
![screenshot from 2017-11-14 16-05-03](https://user-images.githubusercontent.com/925062/32786969-ab8a7e66-c955-11e7-9e9a-a6efdbb5c15c.png)

After:
![screenshot from 2017-11-14 16-03-31](https://user-images.githubusercontent.com/925062/32786970-abb6a0fe-c955-11e7-9cd8-27c815e8b6ad.png)
