### PR TITLE
Fix accesslist when a user has an ID only containting 0-9

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1390,7 +1390,7 @@ class Manager implements IManager {
 			foreach ($tmp as $k => $v) {
 				if (isset($al[$k])) {
 					if (is_array($al[$k])) {
-						$al[$k] = array_merge($al[$k], $v);
+						$al[$k] += $v;
 					} else {
 						$al[$k] = $al[$k] || $v;
 					}


### PR DESCRIPTION
Basically we should check all array-merges ... and make sure they dont merge by user id...

Fix #6580 