### PR TITLE
Fix search in user managent when no group is selected

### DIFF
--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -290,6 +290,8 @@ class Database extends Backend implements IUserBackend {
 		if ($search !== '') {
 			$parameters[] = '%' . \OC::$server->getDatabaseConnection()->escapeLikeParameter($search) . '%';
 			$searchLike = ' WHERE LOWER(`uid`) LIKE LOWER(?)';
+			$parameters[] = '%' . \OC::$server->getDatabaseConnection()->escapeLikeParameter($search) . '%';
+			$searchLike .= ' OR LOWER(`displayname`) LIKE LOWER(?)';
 		}
 
 		$query = \OC_DB::prepare('SELECT `uid` FROM `*PREFIX*users`' . $searchLike . ' ORDER BY LOWER(`uid`) ASC', $limit, $offset);

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -308,7 +308,7 @@ class UsersController extends Controller {
 		$userObjects = [];
 		$users = [];
 		if ($this->isAdmin) {
-			if ($gid !== '' && $gid !== '_disabledUsers') {
+			if ($gid !== '' && $gid !== '_disabledUsers' && $gid !== '_everyone') {
 				$batch = $this->getUsersForUID($this->groupManager->displayNamesInGroup($gid, $pattern, $limit, $offset));
 			} else {
 				$batch = $this->userManager->search($pattern, $limit, $offset);


### PR DESCRIPTION
* also allows to search by displayname (partially what #2660)

Before: search in the "all group" did not work (for DB users)
After: search for username & displayname works

cc @LukasReschke 


Fixes #1749 