### PR TITLE
Fix linear gradient from black to white in dialogs in Safari

### DIFF
--- a/core/css/jquery.ocdialog.scss
+++ b/core/css/jquery.ocdialog.scss
@@ -29,7 +29,7 @@
 	padding-bottom: 0;
 	box-sizing: border-box;
 	width: 100%;
-	background-image: linear-gradient(transparent, $color-main-background);
+	background-image: linear-gradient(rgba(255, 255, 255, 0.0), $color-main-background);
 	border-bottom-left-radius: 3px;
 	border-bottom-right-radius: 3px;
 }


### PR DESCRIPTION
On Safari transparent seems to be `rgba(0, 0, 0, 0.0)` and this creating a gradient from black to white, which causes this:

<img width="610" alt="bildschirmfoto 2017-11-14 um 23 55 29" src="https://user-images.githubusercontent.com/245432/32809633-ced2f4ba-c997-11e7-8b4f-93bada5c8888.png">

With this patch it looks like this (as in all other browsers):

<img width="611" alt="bildschirmfoto 2017-11-14 um 23 55 12" src="https://user-images.githubusercontent.com/245432/32809636-d549b626-c997-11e7-892a-0f9461c247e3.png">


cc @nextcloud/designers 