### PR TITLE
Remove wrong entry in admin_settings that causes 500

### DIFF
--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -32,6 +32,7 @@ namespace OC\Settings;
 use OC\Accounts\AccountManager;
 use OCP\App\IAppManager;
 use OCP\AppFramework\QueryException;
+use OCP\AutoloadNotAllowedException;
 use OCP\Encryption\IManager as EncryptionManager;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -471,6 +472,10 @@ class Manager implements IManager {
 				$settings[$row['priority']][] = $this->query($row['class']);
 			} catch (QueryException $e) {
 				// skip
+			} catch (AutoloadNotAllowedException $e) {
+				// skip error and remove remnant of disabled app
+				$this->log->warning('Orphan setting entry will be removed from admin_settings: ' . json_encode($row));
+				$this->mapper->remove(Mapper::TABLE_ADMIN_SETTINGS, $row['class']);
 			}
 		}
 


### PR DESCRIPTION
* having a stale entry like this in the oc_admin_settings table:

```sql
INSERT INTO oc_admin_settings(class, section, priority)
VALUES ('OCA\\OnlyOffice\\AdminSettings', 'server', 1);
```

* also have the only office app code in your apps directory but disable the app
* open the admin settings
* actual: 500 internal server error like in #5313
* expected: load the admin settings

This PR cleans up those stale entries and avoids the 500.

Should we maybe backport this to 12?

Fixes #5313
Fixes #5067