### PR TITLE
Use apps versions to generate suffix when possible

### DIFF
--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -90,7 +90,7 @@ class TemplateLayout extends \OC_Template {
 					break;
 				}
 			}
-			
+
 			foreach($settingsNavigation as $entry) {
 				if ($entry['active']) {
 					$this->assign( 'application', $entry['name'] );
@@ -125,7 +125,7 @@ class TemplateLayout extends \OC_Template {
 			if (empty(self::$versionHash)) {
 				$v = \OC_App::getAppVersions();
 				$v['core'] = implode('.', \OCP\Util::getVersion());
-				self::$versionHash = md5(implode(',', $v));
+				self::$versionHash = substr(md5(implode(',', $v)), 0, 8);
 			}
 		} else {
 			self::$versionHash = md5('not installed');
@@ -188,16 +188,25 @@ class TemplateLayout extends \OC_Template {
 			if (substr($file, -strlen('print.css')) === 'print.css') {
 				$this->append( 'printcssfiles', $web.'/'.$file . $this->getVersionHashSuffix() );
 			} else {
-				$this->append( 'cssfiles', $web.'/'.$file . $this->getVersionHashSuffix()  );
+				$this->append( 'cssfiles', $web.'/'.$file . $this->getVersionHashSuffix($web)  );
 			}
 		}
 	}
 
-	protected function getVersionHashSuffix() {
-		if(\OC::$server->getConfig()->getSystemValue('debug', false)) {
+	protected function getVersionHashSuffix($app=false) {
+		if (\OC::$server->getConfig()->getSystemValue('debug', false)) {
 			// allows chrome workspace mapping in debug mode
 			return "";
 		}
+		if ($app !== false && $app !== '') {
+			$v = \OC_App::getAppVersions();
+			$appName = end(explode('/', $app));
+			if(array_key_exists($appName, $v)) {
+				$appVersion = $v[$appName];
+				return '?v=' . substr(md5(implode(',', $appVersion)), 0, 8) . '-' . $this->config->getAppValue('theming', 'cachebuster', '0');
+			}
+		}
+
 		if ($this->config->getSystemValue('installed', false) && \OC::$server->getAppManager()->isInstalled('theming')) {
 			return '?v=' . self::$versionHash . '-' . $this->config->getAppValue('theming', 'cachebuster', '0');
 		}

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -188,22 +188,32 @@ class TemplateLayout extends \OC_Template {
 			if (substr($file, -strlen('print.css')) === 'print.css') {
 				$this->append( 'printcssfiles', $web.'/'.$file . $this->getVersionHashSuffix() );
 			} else {
-				$this->append( 'cssfiles', $web.'/'.$file . $this->getVersionHashSuffix($web)  );
+				$this->append( 'cssfiles', $web.'/'.$file . $this->getVersionHashSuffix($web, $file)  );
 			}
 		}
 	}
 
-	protected function getVersionHashSuffix($app=false) {
+	protected function getVersionHashSuffix($path = false, $file = false) {
 		if (\OC::$server->getConfig()->getSystemValue('debug', false)) {
 			// allows chrome workspace mapping in debug mode
 			return "";
 		}
-		if ($app !== false && $app !== '') {
-			$v = \OC_App::getAppVersions();
-			$appName = end(explode('/', $app));
+		$v = \OC_App::getAppVersions();
+
+		// Try the webroot path for a match
+		if ($path !== false && $path !== '') {
+			$appName = $this->getAppNamefromPath($path);
 			if(array_key_exists($appName, $v)) {
 				$appVersion = $v[$appName];
-				return '?v=' . substr(md5(implode(',', $appVersion)), 0, 8) . '-' . $this->config->getAppValue('theming', 'cachebuster', '0');
+				return '?v=' . substr(md5($appVersion), 0, 8) . '-' . $this->config->getAppValue('theming', 'cachebuster', '0');
+			}
+		}
+		// fallback to the file path instead
+		if ($file !== false && $file !== '') {
+			$appName = $this->getAppNamefromPath($file);
+			if(array_key_exists($appName, $v)) {
+				$appVersion = $v[$appName];
+				return '?v=' . substr(md5($appVersion), 0, 8) . '-' . $this->config->getAppValue('theming', 'cachebuster', '0');
 			}
 		}
 
@@ -236,6 +246,22 @@ class TemplateLayout extends \OC_Template {
 		);
 		$locator->find($styles);
 		return $locator->getResources();
+	}
+
+	/**
+	 * @param string $path
+	 * @return string
+	 */
+	static public function getAppNamefromPath($path) {
+		if ($path !== '' && is_string($path)) {
+			$pathParts = explode('/', $path);
+			if ($pathParts[0] === 'css') {
+				// This is a scss request
+				return $pathParts[1];
+			}
+			return end($pathParts);
+		}
+
 	}
 
 	/**

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -193,6 +193,11 @@ class TemplateLayout extends \OC_Template {
 		}
 	}
 
+	/**
+	 * @param string $path
+ 	 * @param string $file
+	 * @return string
+	 */
 	protected function getVersionHashSuffix($path = false, $file = false) {
 		if (\OC::$server->getConfig()->getSystemValue('debug', false)) {
 			// allows chrome workspace mapping in debug mode
@@ -250,9 +255,9 @@ class TemplateLayout extends \OC_Template {
 
 	/**
 	 * @param string $path
-	 * @return string
+	 * @return string|boolean
 	 */
-	static public function getAppNamefromPath($path) {
+	public function getAppNamefromPath($path) {
 		if ($path !== '' && is_string($path)) {
 			$pathParts = explode('/', $path);
 			if ($pathParts[0] === 'css') {
@@ -261,6 +266,7 @@ class TemplateLayout extends \OC_Template {
 			}
 			return end($pathParts);
 		}
+		return false
 
 	}
 

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -266,7 +266,7 @@ class TemplateLayout extends \OC_Template {
 			}
 			return end($pathParts);
 		}
-		return false
+		return false;
 
 	}
 


### PR DESCRIPTION
- Reduce the hash to 8 chars (readability) 
- Generate hash based on apps versions if possible and not nextcloud version

This will force css cache update on the user's browser side on app update. And avoid many errors like calendar or contacts had in the past.