### PR TITLE
Add HTML5 audio player in public view

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -97,6 +97,12 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 							<source src="<?php p($_['downloadURL']); ?>" type="<?php p($_['mimetype']); ?>" />
 						</video>
 					</div>
+				<?php elseif ($_['previewEnabled'] && substr($_['mimetype'], 0, strpos($_['mimetype'], '/')) == 'audio'): ?>
+					<div id="imgframe">
+						<audio tabindex="0" controls="" preload="none" style="width: 100%; max-width: <?php p($_['previewMaxX']); ?>px; max-height: <?php p($_['previewMaxY']); ?>px">
+							<source src="<?php p($_['downloadURL']); ?>" type="<?php p($_['mimetype']); ?>" />
+						</audio>
+					</div>
 				<?php else: ?>
 					<!-- Preview frame is filled via JS to support SVG images for modern browsers -->
 					<div id="imgframe"></div>


### PR DESCRIPTION
Add `<audio>` element like video. (need backport to 12)

![selection_121](https://user-images.githubusercontent.com/379644/33129163-48357c4a-cf8f-11e7-94f1-54eb3e30ba33.jpg)
