### PR TITLE
Give audio-white and audio-off-white shadow via CSS

### DIFF
--- a/core/css/icons.scss
+++ b/core/css/icons.scss
@@ -89,6 +89,10 @@ img, object, video, button, textarea, input, select, div[contenteditable=true] {
 	background-size: 32px !important;
 }
 
+.icon-shadow {
+	filter: drop-shadow(0 1px 3px $color-box-shadow);
+}
+
 /* ICONS -------------------------------------------------------------------- */
 .icon-add {
 	background-image: url('../img/actions/add.svg?v=1');


### PR DESCRIPTION
Fixes regression #7243

audio-white and audio-off-white should be visible in Talk app when video is disabled (thanks to shadow).

This introduces new class `.icon-shadow` that can be use on any icon. Other icons that (still) have SVG shadow filters will be migrated to this solution in a subsequent PR, because only this one is critical.

To be reviewed and merged with https://github.com/nextcloud/spreed/pull/501