### PR TITLE
Guest flex instead of absolute

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -4,7 +4,7 @@
 
 /* Default and reset */
 html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, code, del, dfn, em, img, q, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, dialog, figure, footer, header, hgroup, nav, section { margin:0; padding:0; border:0; outline:0; font-weight:inherit; font-size:100%; font-family:inherit; vertical-align:baseline; cursor:default; }
-html, body { height:100%; }
+html { height:100%; }
 article, aside, dialog, figure, footer, header, hgroup, nav, section { display:block; }
 body { line-height:1.5; }
 table { border-collapse:separate; border-spacing:0; white-space:nowrap; }
@@ -28,7 +28,8 @@ body {
 	background-repeat: no-repeat;
 	background-size: cover;
 	background-attachment: fixed; /* fix background gradient */
-	height: 100%; /* fix sticky footer */
+	min-height: 100%; /* fix sticky footer */
+	height: auto;
 }
 
 /* Various fonts settings */

--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -86,7 +86,7 @@ body {
 }
 .wrapper {
 	width: 300px;
-	margin-top: auto;
+	margin-top: 10%;
 }
 
 /* Default FORM */

--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -60,6 +60,13 @@ h3 {
 }
 
 /* Global content */
+body {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+}
+
 #header .logo {
 	background-image: url('../img/logo.svg?v=1');
 	background-repeat: no-repeat;
@@ -77,15 +84,8 @@ h3 {
 	max-height: 200px;
 }
 .wrapper {
-	min-height: 100%;
-	margin: 0 auto -70px;
 	width: 300px;
-}
-.v-align {
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, -50%);
+	margin-top: auto;
 }
 
 /* Default FORM */
@@ -723,6 +723,7 @@ img.icon-loading-small-dark, object.icon-loading-small-dark, video.icon-loading-
 footer,
 .push {
 	height: 70px;
+	margin-top: auto;
 }
 
 footer .info a {


### PR DESCRIPTION
This allows the browser to automatically compute the full content.
Everything is center except the footer as long as the window as enough space to display everything.
The fallback in case of big content or small screen is the reducing of the blank space between the man content and the top and the main content and the footer. After that, the total height is expanded by a scroll.

Examples with various sizes: 
![dev0](https://user-images.githubusercontent.com/14975046/33133256-809fe414-cf9c-11e7-9f41-abf16777f8bb.jpg)![dev1](https://user-images.githubusercontent.com/14975046/33133257-80bee74c-cf9c-11e7-81af-c176a407a770.jpg)![dev2](https://user-images.githubusercontent.com/14975046/33133258-80dd554c-cf9c-11e7-9e7d-1063b215ab65.jpg)



[Update example (very big picture)](https://user-images.githubusercontent.com/14975046/33133074-ecb4029e-cf9b-11e7-8247-dfaee99af1c6.png)
