### PR TITLE
Fix cursor for avatar and user names in comments

### DIFF
--- a/apps/comments/css/comments.css
+++ b/apps/comments/css/comments.css
@@ -127,8 +127,8 @@
 	position: relative;
 }
 
-#commentsTabView .comment .message .avatar-name-wrapper,
-#commentsTabView .comment .message .avatar-name-wrapper .avatar,
+#commentsTabView .comment:not(.newCommentRow) .message .avatar-name-wrapper,
+#commentsTabView .comment:not(.newCommentRow) .message .avatar-name-wrapper .avatar,
 #commentsTabView .comment .authorRow .avatar:not(.currentUser),
 #commentsTabView .comment .authorRow .author:not(.currentUser) {
 	cursor: pointer;

--- a/apps/comments/css/comments.css
+++ b/apps/comments/css/comments.css
@@ -125,6 +125,17 @@
 .atwho-view-ul * .avatar-name-wrapper,
 #commentsTabView .comment .authorRow {
 	position: relative;
+}
+
+#commentsTabView .comment .message .avatar-name-wrapper,
+#commentsTabView .comment .message .avatar-name-wrapper .avatar,
+#commentsTabView .comment .authorRow .avatar:not(.currentUser),
+#commentsTabView .comment .authorRow .author:not(.currentUser) {
+	cursor: pointer;
+}
+
+.atwho-view-ul .avatar-name-wrapper,
+.atwho-view-ul .avatar-name-wrapper .avatar {
 	cursor: pointer;
 }
 

--- a/apps/comments/css/comments.css
+++ b/apps/comments/css/comments.css
@@ -127,8 +127,8 @@
 	position: relative;
 }
 
-#commentsTabView .comment:not(.newCommentRow) .message .avatar-name-wrapper,
-#commentsTabView .comment:not(.newCommentRow) .message .avatar-name-wrapper .avatar,
+#commentsTabView .comment:not(.newCommentRow) .message .avatar-name-wrapper:not(.currentUser),
+#commentsTabView .comment:not(.newCommentRow) .message .avatar-name-wrapper:not(.currentUser) .avatar,
 #commentsTabView .comment .authorRow .avatar:not(.currentUser),
 #commentsTabView .comment .authorRow .author:not(.currentUser) {
 	cursor: pointer;

--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -410,7 +410,10 @@
 				var strong = $(this).next();
 				var appendTo = $(this).parent();
 
-				$.merge(avatar, strong).contactsMenu(avatar.data('user'), 0, appendTo);
+				var username = $(this).data('username');
+				if (username !== oc_current_user) {
+					$.merge(avatar, strong).contactsMenu(avatar.data('user'), 0, appendTo);
+				}
 			});
 		},
 
@@ -451,9 +454,11 @@
 				+ ' data-user-display-name="'
 				+ _.escape(displayName) + '"></div>';
 
+			var isCurrentUser = (uid === oc_current_user);
+
 			return ''
 				+ '<span class="atwho-inserted" contenteditable="false">'
-				+ '<span class="avatar-name-wrapper">'
+				+ '<span class="avatar-name-wrapper' + (isCurrentUser ? ' currentUser' : '') + '">'
 				+ avatar + ' <strong>'+ _.escape(displayName)+'</strong>'
 				+ '</span>'
 				+ '</span>';

--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -23,8 +23,8 @@
 	var EDIT_COMMENT_TEMPLATE =
 		'<div class="newCommentRow comment" data-id="{{id}}">' +
 		'    <div class="authorRow">' +
-		'        <div class="avatar" data-username="{{actorId}}"></div>' +
-		'        <div class="author">{{actorDisplayName}}</div>' +
+		'        <div class="avatar currentUser" data-username="{{actorId}}"></div>' +
+		'        <div class="author currentUser">{{actorDisplayName}}</div>' +
 		'{{#if isEditMode}}' +
 		'        <a href="#" class="action delete icon icon-delete has-tooltip" title="{{deleteTooltip}}"></a>' +
 		'{{/if}}' +
@@ -42,8 +42,8 @@
 	var COMMENT_TEMPLATE =
 		'<li class="comment{{#if isUnread}} unread{{/if}}{{#if isLong}} collapsed{{/if}}" data-id="{{id}}">' +
 		'    <div class="authorRow">' +
-		'        <div class="avatar" {{#if actorId}}data-username="{{actorId}}"{{/if}}> </div>' +
-		'        <div class="author">{{actorDisplayName}}</div>' +
+		'        <div class="avatar{{#if isUserAuthor}} currentUser{{/if}}" {{#if actorId}}data-username="{{actorId}}"{{/if}}> </div>' +
+		'        <div class="author{{#if isUserAuthor}} currentUser{{/if}}">{{actorDisplayName}}</div>' +
 		'{{#if isUserAuthor}}' +
 		'        <a href="#" class="action edit icon icon-rename has-tooltip" title="{{editTooltip}}"></a>' +
 		'{{/if}}' +

--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -214,13 +214,15 @@
 				searchKey: "label"
 			});
 			$target.on('inserted.atwho', function (je, $el) {
+				var editionMode = true;
 				s._postRenderItem(
 					// we need to pass the parent of the inserted element
 					// passing the whole comments form would re-apply and request
 					// avatars from the server
 					$(je.target).find(
 						'div[data-username="' + $el.find('[data-username]').data('username') + '"]'
-					).parent()
+					).parent(),
+					editionMode
 				);
 			});
 		},
@@ -377,7 +379,7 @@
 			});
 		},
 
-		_postRenderItem: function($el) {
+		_postRenderItem: function($el, editionMode) {
 			$el.find('.has-tooltip').tooltip();
 			$el.find('.avatar').each(function() {
 				var $this = $(this);
@@ -395,10 +397,14 @@
 				// it is the case when writing a comment and mentioning a person
 				$message = $el;
 			}
-			this._postRenderMessage($message);
+			this._postRenderMessage($message, editionMode);
 		},
 
-		_postRenderMessage: function($el) {
+		_postRenderMessage: function($el, editionMode) {
+			if (editionMode) {
+				return;
+			}
+
 			$el.find('.avatar').each(function() {
 				var avatar = $(this);
 				var strong = $(this).next();
@@ -486,7 +492,8 @@
 				.html(this._formatMessage(commentToEdit.get('message'), commentToEdit.get('mentions')))
 				.find('.avatar')
 				.each(function () { $(this).avatar(); });
-			this._postRenderItem($message);
+			var editionMode = true;
+			this._postRenderItem($message, editionMode);
 
 			// Enable autosize
 			autosize($formRow.find('.message'));

--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -454,7 +454,7 @@
 				+ ' data-user-display-name="'
 				+ _.escape(displayName) + '"></div>';
 
-			var isCurrentUser = (uid === oc_current_user);
+			var isCurrentUser = (uid === OC.getCurrentUser().uid);
 
 			return ''
 				+ '<span class="atwho-inserted" contenteditable="false">'


### PR DESCRIPTION
When it was on an author row the cursor was shown as a pointer, even if clicking on the author row itself does nothing. Also avatars used the default cursor, even if clicking on them shows the contacts menu (if the avatar is for a different user than the current one). Now the cursor is shown as a pointer on avatar and user names of users different than the current one.

There are still some changes pending based on what is decided in #7254 (right now the cursor used for mentions in messages being composed is the default one; changing it to a pointer would require removing `.comment` from `#commentsTabView .comments .message...` and also adding the `currentUser` class to the appropriate mentions through JavaScript).

@jancborchardt  Besides that maybe the contacts menu should be completely disabled for mentions in messages being composed, as it does not provide too much value there (and, moreover, right now it does not appear in the proper position).
