### PR TITLE
[stable12] CSSResourceLocator: handle SCSS in apps outside root

### DIFF
--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -6,6 +6,7 @@
  * @author Joas Schilling <coding@schilljs.com>
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Kyle Fazzari <kyrofa@ubuntu.com>
  *
  * @license AGPL-3.0
  *
@@ -122,45 +123,25 @@ class CSSResourceLocator extends ResourceLocator {
 			parent::append($root, $file, $webRoot, $throw);
 		} else {
 			if (!$webRoot) {
-				$tmpRoot = realpath($root);
-				/*
-				 * traverse the potential web roots upwards in the path
-				 *
-				 * example:
-				 *   - root: /srv/www/apps/myapp
-				 *   - available mappings: ['/srv/www']
-				 *
-				 * First we check if a mapping for /srv/www/apps/myapp is available,
-				 * then /srv/www/apps, /srv/www/apps, /srv/www, ... until we find a
-				 * valid web root
-				 */
-				do {
-					if (isset($this->mapping[$tmpRoot])) {
-						$webRoot = $this->mapping[$tmpRoot];
-						break;
-					}
+				$webRoot = $this->findWebRoot($root);
 
-					if ($tmpRoot === '/') {
-						$webRoot = '';
-						$this->logger->error('ResourceLocator can not find a web root (root: {root}, file: {file}, webRoot: {webRoot}, throw: {throw})', [
-							'app' => 'lib',
-							'root' => $root,
-							'file' => $file,
-							'webRoot' => $webRoot,
-							'throw' => $throw ? 'true' : 'false'
-						]);
-						break;
-					}
-					$tmpRoot = dirname($tmpRoot);
-				} while(true);
+				if ($webRoot === null) {
+					$webRoot = '';
+					$this->logger->error('ResourceLocator can not find a web root (root: {root}, file: {file}, webRoot: {webRoot}, throw: {throw})', [
+						'app' => 'lib',
+						'root' => $root,
+						'file' => $file,
+						'webRoot' => $webRoot,
+						'throw' => $throw ? 'true' : 'false'
+					]);
 
+					if ($throw && $root === '/') {
+						throw new ResourceNotFoundException($file, $webRoot);
+					}
+				}
 			}
 
-			if ($throw && $tmpRoot === '/') {
-				throw new ResourceNotFoundException($file, $webRoot);
-			}
-
-			$this->resources[] = array($tmpRoot, $webRoot, $file);
+			$this->resources[] = array($webRoot? : '/', $webRoot, $file);
 		}
 	}
 }

--- a/lib/private/Template/ResourceLocator.php
+++ b/lib/private/Template/ResourceLocator.php
@@ -7,6 +7,7 @@
  * @author Jörn Friedrich Dreyer <jfd@butonic.de>
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Robin McCorkell <robin@mccorkell.me.uk>
+ * @author Kyle Fazzari <kyrofa@ubuntu.com>
  *
  * @license AGPL-3.0
  *
@@ -107,6 +108,50 @@ abstract class ResourceLocator {
 	}
 
 	/**
+	 * Attempt to find the webRoot
+	 *
+	 * traverse the potential web roots upwards in the path
+	 *
+	 * example:
+	 *   - root: /srv/www/apps/myapp
+	 *   - available mappings: ['/srv/www']
+	 *
+	 * First we check if a mapping for /srv/www/apps/myapp is available,
+	 * then /srv/www/apps, /srv/www/apps, /srv/www, ... until we find a
+	 * valid web root
+	 *
+	 * @param string $root
+	 * @return string|null The web root or null on failure
+	 */
+	protected function findWebRoot($root) {
+		$webRoot = null;
+		$tmpRoot = $root;
+
+		while ($webRoot === null) {
+			if (isset($this->mapping[$tmpRoot])) {
+				$webRoot = $this->mapping[$tmpRoot];
+				break;
+			}
+
+			if ($tmpRoot === '/') {
+				break;
+			}
+
+			$tmpRoot = dirname($tmpRoot);
+                }
+
+		if ($webRoot === null) {
+			$realpath = realpath($root);
+
+			if ($realpath && ($realpath !== $root)) {
+				return $this->findWebRoot($realpath);
+			}
+		}
+
+		return $webRoot;
+	}
+
+	/**
 	 * append the $file resource at $root
 	 *
 	 * @param string $root path to check
@@ -116,7 +161,6 @@ abstract class ResourceLocator {
 	 * @throws ResourceNotFoundException Only thrown when $throw is true and the resource is missing
 	 */
 	protected function append($root, $file, $webRoot = null, $throw = true) {
-
 		if (!is_string($root)) {
 			if ($throw) {
 				throw new ResourceNotFoundException($file, $webRoot);
@@ -125,38 +169,18 @@ abstract class ResourceLocator {
 		}
 
 		if (!$webRoot) {
-			$tmpRoot = realpath($root);
-			/*
-			 * traverse the potential web roots upwards in the path
-			 *
-			 * example:
-			 *   - root: /srv/www/apps/myapp
-			 *   - available mappings: ['/srv/www']
-			 *
-			 * First we check if a mapping for /srv/www/apps/myapp is available,
-			 * then /srv/www/apps, /srv/www/apps, /srv/www, ... until we find a
-			 * valid web root
-			 */
-			do {
-				if (isset($this->mapping[$tmpRoot])) {
-					$webRoot = $this->mapping[$tmpRoot];
-					break;
-				}
+			$webRoot = $this->findWebRoot($root);
 
-				if ($tmpRoot === '/') {
-					$webRoot = '';
-					$this->logger->error('ResourceLocator can not find a web root (root: {root}, file: {file}, webRoot: {webRoot}, throw: {throw})', [
-						'app' => 'lib',
-						'root' => $root,
-						'file' => $file,
-						'webRoot' => $webRoot,
-						'throw' => $throw ? 'true' : 'false'
-					]);
-					break;
-				}
-				$tmpRoot = dirname($tmpRoot);
-			} while(true);
-
+			if ($webRoot === null) {
+				$webRoot = '';
+				$this->logger->error('ResourceLocator can not find a web root (root: {root}, file: {file}, webRoot: {webRoot}, throw: {throw})', [
+					'app' => 'lib',
+					'root' => $root,
+					'file' => $file,
+					'webRoot' => $webRoot,
+					'throw' => $throw ? 'true' : 'false'
+				]);
+			}
 		}
 		$this->resources[] = array($root, $webRoot, $file);
 


### PR DESCRIPTION
Currently static CSS files work fine in apps outside of the root. However, as soon as an app uses SCSS, Nextcloud starts being unable to find the web root.

This PR fixes #5289 by backporting select snippets from master specifically targeting this issue (note that master does not have this issue), and adding a test to ensure it doesn't regress.