### PR TITLE
Use basename() instead of self implementation

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -259,7 +259,7 @@ class Cache implements ICache {
 
 		$data['path'] = $file;
 		$data['parent'] = $this->getParentId($file);
-		$data['name'] = \OC_Util::basename($file);
+		$data['name'] = basename($file);
 
 		list($queryParts, $params) = $this->buildParts($data);
 		$queryParts[] = '`storage`';
@@ -551,7 +551,7 @@ class Cache implements ICache {
 			}
 
 			$sql = 'UPDATE `*PREFIX*filecache` SET `storage` = ?, `path` = ?, `path_hash` = ?, `name` = ?, `parent` = ? WHERE `fileid` = ?';
-			$this->connection->executeQuery($sql, array($targetStorageId, $targetPath, md5($targetPath), \OC_Util::basename($targetPath), $newParentId, $sourceId));
+			$this->connection->executeQuery($sql, array($targetStorageId, $targetPath, md5($targetPath), basename($targetPath), $newParentId, $sourceId));
 			$this->connection->commit();
 		} else {
 			$this->moveFromCacheFallback($sourceCache, $sourcePath, $targetPath);

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1408,16 +1408,6 @@ class OC_Util {
 	}
 
 	/**
-	 * @param boolean|string $file
-	 * @return string
-	 */
-	public static function basename($file) {
-		$file = rtrim($file, '/');
-		$t = explode('/', $file);
-		return array_pop($t);
-	}
-
-	/**
 	 * A human readable string is generated based on version and build number
 	 *
 	 * @return string

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -178,24 +178,6 @@ class UtilTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider baseNameProvider
-	 */
-	public function testBaseName($expected, $file) {
-		$base = \OC_Util::basename($file);
-		$this->assertEquals($expected, $base);
-	}
-
-	public function baseNameProvider() {
-		return array(
-			array('public_html', '/home/user/public_html/'),
-			array('public_html', '/home/user/public_html'),
-			array('', '/'),
-			array('public_html', 'public_html'),
-			array('442aa682de2a64db1e010f50e60fd9c9', 'local::C:\Users\ADMINI~1\AppData\Local\Temp\2/442aa682de2a64db1e010f50e60fd9c9/')
-		);
-	}
-
-	/**
 	 * @dataProvider filenameValidationProvider
 	 */
 	public function testFilenameValidation($file, $valid) {


### PR DESCRIPTION
I tried this by keeping the unit tests and they still succeed if I would just use the native `basename()` method.

@icewind1991 Does that make sense?