### PR TITLE
Cache fetched apps in update check

### DIFF
--- a/apps/updatenotification/lib/Notification/BackgroundJob.php
+++ b/apps/updatenotification/lib/Notification/BackgroundJob.php
@@ -53,6 +53,9 @@ class BackgroundJob extends TimedJob {
 	/** @var IClientService */
 	protected $client;
 
+	/** @var Installer */
+	protected $installer;
+
 	/** @var string[] */
 	protected $users;
 
@@ -64,8 +67,9 @@ class BackgroundJob extends TimedJob {
 	 * @param IGroupManager $groupManager
 	 * @param IAppManager $appManager
 	 * @param IClientService $client
+	 * @param Installer $installer
 	 */
-	public function __construct(IConfig $config, IManager $notificationManager, IGroupManager $groupManager, IAppManager $appManager, IClientService $client) {
+	public function __construct(IConfig $config, IManager $notificationManager, IGroupManager $groupManager, IAppManager $appManager, IClientService $client, Installer $installer) {
 		// Run once a day
 		$this->setInterval(60 * 60 * 24);
 
@@ -74,6 +78,7 @@ class BackgroundJob extends TimedJob {
 		$this->groupManager = $groupManager;
 		$this->appManager = $appManager;
 		$this->client = $client;
+		$this->installer = $installer;
 	}
 
 	protected function run($argument) {
@@ -257,6 +262,6 @@ class BackgroundJob extends TimedJob {
 	 * @return string|false
 	 */
 	protected function isUpdateAvailable($app) {
-		return Installer::isUpdateAvailable($app, \OC::$server->getAppFetcher());
+		return $this->installer->isUpdateAvailable($app);
 	}
 }

--- a/apps/updatenotification/tests/Notification/BackgroundJobTest.php
+++ b/apps/updatenotification/tests/Notification/BackgroundJobTest.php
@@ -23,6 +23,7 @@
 namespace OCA\UpdateNotification\Tests\Notification;
 
 
+use OC\Installer;
 use OCA\UpdateNotification\Notification\BackgroundJob;
 use OCP\App\IAppManager;
 use OCP\Http\Client\IClientService;
@@ -47,6 +48,8 @@ class BackgroundJobTest extends TestCase {
 	protected $appManager;
 	/** @var IClientService|\PHPUnit_Framework_MockObject_MockObject */
 	protected $client;
+	/** @var Installer|\PHPUnit_Framework_MockObject_MockObject */
+	protected $installer;
 
 	public function setUp() {
 		parent::setUp();
@@ -56,6 +59,7 @@ class BackgroundJobTest extends TestCase {
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->client = $this->createMock(IClientService::class);
+		$this->installer = $this->createMock(Installer::class);
 	}
 
 	/**
@@ -69,7 +73,8 @@ class BackgroundJobTest extends TestCase {
 				$this->notificationManager,
 				$this->groupManager,
 				$this->appManager,
-				$this->client
+				$this->client,
+				$this->installer
 			);
 		} {
 			return $this->getMockBuilder(BackgroundJob::class)
@@ -79,6 +84,7 @@ class BackgroundJobTest extends TestCase {
 					$this->groupManager,
 					$this->appManager,
 					$this->client,
+					$this->installer,
 				])
 				->setMethods($methods)
 				->getMock();

--- a/core/Command/App/Install.php
+++ b/core/Command/App/Install.php
@@ -51,13 +51,7 @@ class Install extends Command {
 		}
 
 		try {
-			$installer = new Installer(
-				\OC::$server->getAppFetcher(),
-				\OC::$server->getHTTPClientService(),
-				\OC::$server->getTempManager(),
-				\OC::$server->getLogger(),
-				\OC::$server->getConfig()
-			);
+			$installer = \OC::$server->query(Installer::class);
 			$installer->downloadApp($appId);
 			$result = $installer->installApp($appId);
 		} catch(\Exception $e) {

--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -30,6 +30,7 @@
 namespace OC\Core\Command\Maintenance;
 
 use InvalidArgumentException;
+use OC\Installer;
 use OC\Setup;
 use OC\SystemConfig;
 use OCP\Defaults;
@@ -73,9 +74,15 @@ class Install extends Command {
 
 		// validate the environment
 		$server = \OC::$server;
-		$setupHelper = new Setup($this->config, $server->getIniWrapper(),
-			$server->getL10N('lib'), $server->query(Defaults::class), $server->getLogger(),
-			$server->getSecureRandom());
+		$setupHelper = new Setup(
+			$this->config,
+			$server->getIniWrapper(),
+			$server->getL10N('lib'),
+			$server->query(Defaults::class),
+			$server->getLogger(),
+			$server->getSecureRandom(),
+			\OC::$server->query(Installer::class)
+		);
 		$sysInfo = $setupHelper->getSystemInfo(true);
 		$errors = $sysInfo['errors'];
 		if (count($errors) > 0) {

--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -35,6 +35,7 @@
 namespace OC\Core\Command;
 
 use OC\Console\TimestampFormatter;
+use OC\Installer;
 use OC\Updater;
 use OCP\IConfig;
 use OCP\ILogger;
@@ -63,11 +64,13 @@ class Upgrade extends Command {
 	/**
 	 * @param IConfig $config
 	 * @param ILogger $logger
+	 * @param Installer $installer
 	 */
-	public function __construct(IConfig $config, ILogger $logger) {
+	public function __construct(IConfig $config, ILogger $logger, Installer $installer) {
 		parent::__construct();
 		$this->config = $config;
 		$this->logger = $logger;
+		$this->installer = $installer;
 	}
 
 	protected function configure() {
@@ -101,7 +104,8 @@ class Upgrade extends Command {
 			$updater = new Updater(
 					$this->config,
 					\OC::$server->getIntegrityCodeChecker(),
-					$this->logger
+					$this->logger,
+					$this->installer
 			);
 
 			if ($input->getOption('no-app-disable')) {

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -116,7 +116,8 @@ if (OC::checkUpgrade(false)) {
 	$updater = new \OC\Updater(
 			$config,
 			\OC::$server->getIntegrityCodeChecker(),
-			$logger
+			$logger,
+			\OC::$server->query(\OC\Installer::class)
 	);
 	$incompatibleApps = [];
 	$disabledThirdPartyApps = [];

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -137,7 +137,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Maintenance\UpdateHtaccess());
 	$application->add(new OC\Core\Command\Maintenance\UpdateTheme(\OC::$server->getMimeTypeDetector(), \OC::$server->getMemCacheFactory()));
 
-	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig(), \OC::$server->getLogger()));
+	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig(), \OC::$server->getLogger(), \OC::$server->query(\OC\Installer::class)));
 	$application->add(new OC\Core\Command\Maintenance\Repair(
 		new \OC\Repair(\OC\Repair::getRepairSteps(), \OC::$server->getEventDispatcher()), \OC::$server->getConfig(),
 		\OC::$server->getEventDispatcher(), \OC::$server->getAppManager()));

--- a/lib/base.php
+++ b/lib/base.php
@@ -915,9 +915,15 @@ class OC {
 		// Check if Nextcloud is installed or in maintenance (update) mode
 		if (!$systemConfig->getValue('installed', false)) {
 			\OC::$server->getSession()->clear();
-			$setupHelper = new OC\Setup(\OC::$server->getSystemConfig(), \OC::$server->getIniWrapper(),
-				\OC::$server->getL10N('lib'), \OC::$server->query(\OCP\Defaults::class), \OC::$server->getLogger(),
-				\OC::$server->getSecureRandom());
+			$setupHelper = new OC\Setup(
+				\OC::$server->getSystemConfig(),
+				\OC::$server->getIniWrapper(),
+				\OC::$server->getL10N('lib'),
+				\OC::$server->query(\OCP\Defaults::class),
+				\OC::$server->getLogger(),
+				\OC::$server->getSecureRandom(),
+				\OC::$server->query(\OC\Installer::class)
+			);
 			$controller = new OC\Core\Controller\SetupController($setupHelper);
 			$controller->run($_POST);
 			exit();

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -395,7 +395,11 @@ class Installer {
 			return false;
 		}
 
-		$apps = $appFetcher->get();
+		static $apps = null;
+		if ($apps === null) {
+			$apps = $appFetcher->get();
+		}
+
 		foreach($apps as $app) {
 			if($app['id'] === $appId) {
 				$currentVersion = OC_App::getAppVersion($appId);

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -67,6 +67,10 @@ class Installer {
 	private $logger;
 	/** @var IConfig */
 	private $config;
+	/** @var array - for caching the result of app fetcher */
+	private $apps = null;
+	/** @var bool|null - for caching the result of the ready status */
+	private $isInstanceReadyForUpdates = null;
 
 	/**
 	 * @param AppFetcher $appFetcher
@@ -187,7 +191,7 @@ class Installer {
 	 * @return bool
 	 */
 	public function updateAppstoreApp($appId) {
-		if(self::isUpdateAvailable($appId, $this->appFetcher)) {
+		if($this->isUpdateAvailable($appId)) {
 			try {
 				$this->downloadApp($appId);
 			} catch (\Exception $e) {
@@ -375,29 +379,24 @@ class Installer {
 	 * Check if an update for the app is available
 	 *
 	 * @param string $appId
-	 * @param AppFetcher $appFetcher
 	 * @return string|false false or the version number of the update
 	 */
-	public static function isUpdateAvailable($appId,
-									  AppFetcher $appFetcher) {
-		static $isInstanceReadyForUpdates = null;
-
-		if ($isInstanceReadyForUpdates === null) {
+	public function isUpdateAvailable($appId) {
+		if ($this->isInstanceReadyForUpdates === null) {
 			$installPath = OC_App::getInstallPath();
 			if ($installPath === false || $installPath === null) {
-				$isInstanceReadyForUpdates = false;
+				$this->isInstanceReadyForUpdates = false;
 			} else {
-				$isInstanceReadyForUpdates = true;
+				$this->isInstanceReadyForUpdates = true;
 			}
 		}
 
-		if ($isInstanceReadyForUpdates === false) {
+		if ($this->isInstanceReadyForUpdates === false) {
 			return false;
 		}
 
-		static $apps = null;
-		if ($apps === null) {
-			$apps = $appFetcher->get();
+		if ($this->apps === null) {
+			$apps = $this->appFetcher->get();
 		}
 
 		foreach($apps as $app) {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1099,6 +1099,16 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->query(\OCP\Share\IManager::class)
 			);
 		});
+
+		$this->registerService(Installer::class, function(Server $c) {
+			return new Installer(
+				$c->getAppFetcher(),
+				$c->getHTTPClientService(),
+				$c->getTempManager(),
+				$c->getLogger(),
+				$c->getConfig()
+			);
+		});
 	}
 
 	/**

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -63,6 +63,9 @@ class Updater extends BasicEmitter {
 	/** @var Checker */
 	private $checker;
 
+	/** @var Installer */
+	private $installer;
+
 	/** @var bool */
 	private $skip3rdPartyAppsDisable;
 
@@ -78,13 +81,16 @@ class Updater extends BasicEmitter {
 	 * @param IConfig $config
 	 * @param Checker $checker
 	 * @param ILogger $log
+	 * @param Installer $installer
 	 */
 	public function __construct(IConfig $config,
 								Checker $checker,
-								ILogger $log = null) {
+								ILogger $log = null,
+								Installer $installer) {
 		$this->log = $log;
 		$this->config = $config;
 		$this->checker = $checker;
+		$this->installer = $installer;
 
 		// If at least PHP 7.0.0 is used we don't need to disable apps as we catch
 		// fatal errors and exceptions and disable the app just instead.
@@ -461,17 +467,10 @@ class Updater extends BasicEmitter {
 	private function upgradeAppStoreApps(array $disabledApps) {
 		foreach($disabledApps as $app) {
 			try {
-				$installer = new Installer(
-					\OC::$server->getAppFetcher(),
-					\OC::$server->getHTTPClientService(),
-					\OC::$server->getTempManager(),
-					$this->log,
-					\OC::$server->getConfig()
-				);
 				$this->emit('\OC\Updater', 'checkAppStoreAppBefore', [$app]);
 				if (Installer::isUpdateAvailable($app, \OC::$server->getAppFetcher())) {
 					$this->emit('\OC\Updater', 'upgradeAppStoreApp', [$app]);
-					$installer->updateAppstoreApp($app);
+					$this->installer->updateAppstoreApp($app);
 				}
 				$this->emit('\OC\Updater', 'checkAppStoreApp', [$app]);
 			} catch (\Exception $ex) {

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -468,7 +468,7 @@ class Updater extends BasicEmitter {
 		foreach($disabledApps as $app) {
 			try {
 				$this->emit('\OC\Updater', 'checkAppStoreAppBefore', [$app]);
-				if (Installer::isUpdateAvailable($app, \OC::$server->getAppFetcher())) {
+				if ($this->installer->isUpdateAvailable($app)) {
 					$this->emit('\OC\Updater', 'upgradeAppStoreApp', [$app]);
 					$this->installer->updateAppstoreApp($app);
 				}

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -375,13 +375,7 @@ class OC_App {
 		self::$enabledAppsCache = []; // flush
 
 		// Check if app is already downloaded
-		$installer = new Installer(
-			\OC::$server->getAppFetcher(),
-			\OC::$server->getHTTPClientService(),
-			\OC::$server->getTempManager(),
-			\OC::$server->getLogger(),
-			\OC::$server->getConfig()
-		);
+		$installer = \OC::$server->query(Installer::class);
 		$isDownloaded = $installer->isDownloaded($appId);
 
 		if(!$isDownloaded) {
@@ -415,13 +409,7 @@ class OC_App {
 			return false;
 		}
 
-		$installer = new Installer(
-			\OC::$server->getAppFetcher(),
-			\OC::$server->getHTTPClientService(),
-			\OC::$server->getTempManager(),
-			\OC::$server->getLogger(),
-			\OC::$server->getConfig()
-		);
+		$installer = \OC::$server->query(Installer::class);
 		return $installer->removeApp($app);
 	}
 

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -708,8 +708,15 @@ class OC_Util {
 		}
 
 		$webServerRestart = false;
-		$setup = new \OC\Setup($config, \OC::$server->getIniWrapper(), \OC::$server->getL10N('lib'),
-			\OC::$server->query(\OCP\Defaults::class), \OC::$server->getLogger(), \OC::$server->getSecureRandom());
+		$setup = new \OC\Setup(
+			$config,
+			\OC::$server->getIniWrapper(),
+			\OC::$server->getL10N('lib'),
+			\OC::$server->query(\OCP\Defaults::class),
+			\OC::$server->getLogger(),
+			\OC::$server->getSecureRandom(),
+			\OC::$server->query(\OC\Installer::class)
+		);
 
 		$urlGenerator = \OC::$server->getURLGenerator();
 

--- a/settings/Controller/AppSettingsController.php
+++ b/settings/Controller/AppSettingsController.php
@@ -37,6 +37,7 @@ use OC\App\AppStore\Fetcher\CategoryFetcher;
 use OC\App\AppStore\Version\VersionParser;
 use OC\App\DependencyAnalyzer;
 use OC\App\Platform;
+use OC\Installer;
 use OCP\App\IAppManager;
 use \OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
@@ -74,6 +75,8 @@ class AppSettingsController extends Controller {
 	private $l10nFactory;
 	/** @var BundleFetcher */
 	private $bundleFetcher;
+	/** @var Installer */
+	private $installer;
 
 	/**
 	 * @param string $appName
@@ -86,6 +89,7 @@ class AppSettingsController extends Controller {
 	 * @param AppFetcher $appFetcher
 	 * @param IFactory $l10nFactory
 	 * @param BundleFetcher $bundleFetcher
+	 * @param Installer $installer
 	 */
 	public function __construct($appName,
 								IRequest $request,
@@ -96,7 +100,8 @@ class AppSettingsController extends Controller {
 								CategoryFetcher $categoryFetcher,
 								AppFetcher $appFetcher,
 								IFactory $l10nFactory,
-								BundleFetcher $bundleFetcher) {
+								BundleFetcher $bundleFetcher,
+								Installer $installer) {
 		parent::__construct($appName, $request);
 		$this->l10n = $l10n;
 		$this->config = $config;
@@ -106,6 +111,7 @@ class AppSettingsController extends Controller {
 		$this->appFetcher = $appFetcher;
 		$this->l10nFactory = $l10nFactory;
 		$this->bundleFetcher = $bundleFetcher;
+		$this->installer = $installer;
 	}
 
 	/**
@@ -270,8 +276,7 @@ class AppSettingsController extends Controller {
 			];
 
 
-			$appFetcher = \OC::$server->getAppFetcher();
-			$newVersion = \OC\Installer::isUpdateAvailable($app['id'], $appFetcher);
+			$newVersion = $this->installer->isUpdateAvailable($app['id']);
 			if($newVersion && $this->appManager->isInstalled($app['id'])) {
 				$formattedApps[count($formattedApps)-1]['update'] = $newVersion;
 			}
@@ -284,7 +289,7 @@ class AppSettingsController extends Controller {
 		$appClass = new \OC_App();
 		$apps = $appClass->listAllApps();
 		foreach($apps as $key => $app) {
-			$newVersion = \OC\Installer::isUpdateAvailable($app['id'], $this->appFetcher);
+			$newVersion = $this->installer->isUpdateAvailable($app['id']);
 			if($newVersion !== false) {
 				$apps[$key]['update'] = $newVersion;
 			} else {
@@ -317,7 +322,7 @@ class AppSettingsController extends Controller {
 				$apps = $appClass->listAllApps();
 
 				foreach($apps as $key => $app) {
-					$newVersion = \OC\Installer::isUpdateAvailable($app['id'], $this->appFetcher);
+					$newVersion = $this->installer->isUpdateAvailable($app['id']);
 					$apps[$key]['update'] = $newVersion;
 				}
 
@@ -342,7 +347,7 @@ class AppSettingsController extends Controller {
 				});
 
 				foreach($apps as $key => $app) {
-					$newVersion = \OC\Installer::isUpdateAvailable($app['id'], $this->appFetcher);
+					$newVersion = $this->installer->isUpdateAvailable($app['id']);
 					$apps[$key]['update'] = $newVersion;
 				}
 
@@ -363,7 +368,7 @@ class AppSettingsController extends Controller {
 				});
 
 				$apps = array_map(function ($app) {
-					$newVersion = \OC\Installer::isUpdateAvailable($app['id'], $this->appFetcher);
+					$newVersion = $this->installer->isUpdateAvailable($app['id']);
 					if ($newVersion !== false) {
 						$app['update'] = $newVersion;
 					}

--- a/settings/ajax/updateapp.php
+++ b/settings/ajax/updateapp.php
@@ -41,13 +41,7 @@ $appId = OC_App::cleanAppId($appId);
 $config = \OC::$server->getConfig();
 $config->setSystemValue('maintenance', true);
 try {
-	$installer = new \OC\Installer(
-		\OC::$server->getAppFetcher(),
-		\OC::$server->getHTTPClientService(),
-		\OC::$server->getTempManager(),
-		\OC::$server->getLogger(),
-		\OC::$server->getConfig()
-	);
+	$installer = \OC::$server->query(\OC\Installer::class);
 	$result = $installer->updateAppstoreApp($appId);
 	$config->setSystemValue('maintenance', false);
 } catch(Exception $ex) {

--- a/tests/Settings/Controller/AppSettingsControllerTest.php
+++ b/tests/Settings/Controller/AppSettingsControllerTest.php
@@ -25,6 +25,7 @@ namespace Tests\Settings\Controller;
 use OC\App\AppStore\Bundles\BundleFetcher;
 use OC\App\AppStore\Fetcher\AppFetcher;
 use OC\App\AppStore\Fetcher\CategoryFetcher;
+use OC\Installer;
 use OC\Settings\Controller\AppSettingsController;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\JSONResponse;
@@ -63,6 +64,8 @@ class AppSettingsControllerTest extends TestCase {
 	private $l10nFactory;
 	/** @var BundleFetcher|\PHPUnit_Framework_MockObject_MockObject */
 	private $bundleFetcher;
+	/** @var Installer|\PHPUnit_Framework_MockObject_MockObject */
+	private $installer;
 
 	public function setUp() {
 		parent::setUp();
@@ -79,6 +82,7 @@ class AppSettingsControllerTest extends TestCase {
 		$this->appFetcher = $this->createMock(AppFetcher::class);
 		$this->l10nFactory = $this->createMock(IFactory::class);
 		$this->bundleFetcher = $this->createMock(BundleFetcher::class);
+		$this->installer = $this->createMock(Installer::class);
 
 		$this->appSettingsController = new AppSettingsController(
 			'settings',
@@ -90,11 +94,15 @@ class AppSettingsControllerTest extends TestCase {
 			$this->categoryFetcher,
 			$this->appFetcher,
 			$this->l10nFactory,
-			$this->bundleFetcher
+			$this->bundleFetcher,
+			$this->installer
 		);
 	}
 
 	public function testListCategories() {
+		$this->installer->expects($this->any())
+			->method('isUpdateAvailable')
+			->willReturn(false);
 		$expected = new JSONResponse([
 			[
 				'id' => 2,

--- a/tests/lib/InstallerTest.php
+++ b/tests/lib/InstallerTest.php
@@ -154,7 +154,8 @@ class InstallerTest extends TestCase {
 			->method('get')
 			->willReturn($appArray);
 
-		$this->assertSame($updateAvailable, Installer::isUpdateAvailable('files', $this->appFetcher));
+		$installer = $this->getInstaller();
+		$this->assertSame($updateAvailable, $installer->isUpdateAvailable('files'));
 	}
 
 	/**

--- a/tests/lib/InstallerTest.php
+++ b/tests/lib/InstallerTest.php
@@ -40,9 +40,6 @@ class InstallerTest extends TestCase {
 	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
 	private $config;
 
-	/** @var Installer */
-	private $installer;
-
 	protected function setUp() {
 		parent::setUp();
 
@@ -51,13 +48,6 @@ class InstallerTest extends TestCase {
 		$this->tempManager = $this->createMock(ITempManager::class);
 		$this->logger = $this->createMock(ILogger::class);
 		$this->config = $this->createMock(IConfig::class);
-		$this->installer = new Installer(
-			$this->appFetcher,
-			$this->clientService,
-			$this->tempManager,
-			$this->logger,
-			$this->config
-		);
 
 		$config = \OC::$server->getConfig();
 		$this->appstore = $config->setSystemValue('appstoreenabled', true);
@@ -70,6 +60,16 @@ class InstallerTest extends TestCase {
 			$config
 		);
 		$installer->removeApp(self::$appid);
+	}
+
+	protected function getInstaller() {
+		return new Installer(
+			$this->appFetcher,
+			$this->clientService,
+			$this->tempManager,
+			$this->logger,
+			$this->config
+		);
 	}
 
 	protected function tearDown() {
@@ -197,7 +197,8 @@ gLgK8d8sKL60JMmKHN3boHrsThKBVA==
 			->willReturn($appArray);
 
 
-		$this->installer->downloadApp('news');
+		$installer = $this->getInstaller();
+		$installer->downloadApp('news');
 	}
 
 	/**
@@ -239,7 +240,8 @@ YSu356M=
 			->method('get')
 			->willReturn($appArray);
 
-		$this->installer->downloadApp('news');
+		$installer = $this->getInstaller();
+		$installer->downloadApp('news');
 	}
 
 	/**
@@ -281,7 +283,8 @@ cR92p/PYCFXkAKP3OO0RPlf6dXNKTw==
 			->method('get')
 			->willReturn($appArray);
 
-		$this->installer->downloadApp('news');
+		$installer = $this->getInstaller();
+		$installer->downloadApp('news');
 	}
 
 	/**
@@ -348,7 +351,8 @@ cR92p/PYCFXkAKP3OO0RPlf6dXNKTw==
 			->method('newClient')
 			->willReturn($client);
 
-		$this->installer->downloadApp('passman');
+		$installer = $this->getInstaller();
+		$installer->downloadApp('passman');
 	}
 
 	/**
@@ -431,7 +435,8 @@ YwDVP+QmNRzx72jtqAN/Kc3CvQ9nkgYhU65B95aX0xA=',
 			->method('newClient')
 			->willReturn($client);
 
-		$this->installer->downloadApp('testapp');
+		$installer = $this->getInstaller();
+		$installer->downloadApp('testapp');
 	}
 
 	/**
@@ -513,7 +518,8 @@ YwDVP+QmNRzx72jtqAN/Kc3CvQ9nkgYhU65B95aX0xA=',
 			->method('newClient')
 			->willReturn($client);
 
-		$this->installer->downloadApp('testapp');
+		$installer = $this->getInstaller();
+		$installer->downloadApp('testapp');
 	}
 
 	public function testDownloadAppSuccessful() {
@@ -591,7 +597,8 @@ MPLX6f5V9tCJtlH6ztmEcDROfvuVc0U3rEhqx2hphoyo+MZrPFpdcJL8KkIdMKbY
 			->method('newClient')
 			->willReturn($client);
 
-		$this->installer->downloadApp('testapp');
+		$installer = $this->getInstaller();
+		$installer->downloadApp('testapp');
 
 		$this->assertTrue(file_exists(__DIR__ . '/../../apps/testapp/appinfo/info.xml'));
 		$this->assertEquals('0.9', \OC_App::getAppVersionByPath(__DIR__ . '/../../apps/testapp/'));
@@ -679,7 +686,8 @@ JXhrdaWDZ8fzpUjugrtC3qslsqL0dzgU37anS3HwrT8=',
 		$this->assertTrue(file_exists(__DIR__ . '/../../apps/testapp/appinfo/info.xml'));
 		$this->assertEquals('0.9', \OC_App::getAppVersionByPath(__DIR__ . '/../../apps/testapp/'));
 
-		$this->installer->downloadApp('testapp');
+		$installer = $this->getInstaller();
+		$installer->downloadApp('testapp');
 		$this->assertTrue(file_exists(__DIR__ . '/../../apps/testapp/appinfo/info.xml'));
 		$this->assertEquals('0.8', \OC_App::getAppVersionByPath(__DIR__ . '/../../apps/testapp/'));
 	}

--- a/tests/lib/SetupTest.php
+++ b/tests/lib/SetupTest.php
@@ -9,6 +9,7 @@
 namespace Test;
 
 use bantu\IniGetWrapper\IniGetWrapper;
+use OC\Installer;
 use OC\SystemConfig;
 use OCP\Defaults;
 use OCP\IL10N;
@@ -31,6 +32,8 @@ class SetupTest extends \Test\TestCase {
 	protected $logger;
 	/** @var \OCP\Security\ISecureRandom|\PHPUnit_Framework_MockObject_MockObject */
 	protected $random;
+	/** @var Installer|\PHPUnit_Framework_MockObject_MockObject */
+	protected $installer;
 
 	protected function setUp() {
 		parent::setUp();
@@ -41,9 +44,10 @@ class SetupTest extends \Test\TestCase {
 		$this->defaults = $this->createMock(Defaults::class);
 		$this->logger = $this->createMock(ILogger::class);
 		$this->random = $this->createMock(ISecureRandom::class);
+		$this->installer = $this->createMock(Installer::class);
 		$this->setupClass = $this->getMockBuilder('\OC\Setup')
 			->setMethods(['class_exists', 'is_callable', 'getAvailableDbDriversForPdo'])
-			->setConstructorArgs([$this->config, $this->iniWrapper, $this->l10n, $this->defaults, $this->logger, $this->random])
+			->setConstructorArgs([$this->config, $this->iniWrapper, $this->l10n, $this->defaults, $this->logger, $this->random, $this->installer])
 			->getMock();
 	}
 

--- a/tests/lib/UpdaterTest.php
+++ b/tests/lib/UpdaterTest.php
@@ -22,6 +22,7 @@
 
 namespace Test;
 
+use OC\Installer;
 use OC\Updater;
 use OCP\IConfig;
 use OCP\ILogger;
@@ -36,6 +37,8 @@ class UpdaterTest extends TestCase {
 	private $updater;
 	/** @var Checker | \PHPUnit_Framework_MockObject_MockObject */
 	private $checker;
+	/** @var Installer|\PHPUnit_Framework_MockObject_MockObject */
+	private $installer;
 
 	public function setUp() {
 		parent::setUp();
@@ -46,13 +49,17 @@ class UpdaterTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$this->checker = $this->getMockBuilder(Checker::class)
-				->disableOriginalConstructor()
-				->getMock();
+			->disableOriginalConstructor()
+			->getMock();
+		$this->installer = $this->getMockBuilder(Installer::class)
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->updater = new Updater(
 			$this->config,
 			$this->checker,
-			$this->logger
+			$this->logger,
+			$this->installer
 		);
 	}
 


### PR DESCRIPTION
The code tried to find the apps with updates and thus was called for every available app. This caused to get the full appstore content as often as apps are available. The appstore request itself was cached nevertheless in an appdata dir, but with an object storage this is still a lot of round trips to read this cached result. Thus the instantiated list is now cached in a static variable (because it's a static method call).

Fixes #7235 

Diff of the before and after code base: https://blackfire.io/profiles/compare/0b59e81d-4ea4-4a22-ba14-640cf091d487/graph