### PR TITLE
Fix working icon position when sending or deleting a comment

### DIFF
--- a/apps/comments/css/comments.css
+++ b/apps/comments/css/comments.css
@@ -177,7 +177,8 @@
 	opacity: 1;
 }
 
-#commentsTabView .comment .action.delete {
+#commentsTabView .comment .action.delete,
+#commentsTabView .comment .deleteLoading {
 	position: absolute;
 	right: 0;
 }

--- a/apps/comments/css/comments.css
+++ b/apps/comments/css/comments.css
@@ -42,6 +42,20 @@
 
 #commentsTabView .newCommentForm .submitLoading {
 	background-position: left;
+
+	/* Match rules for '#commentsTabView .newCommentForm .submit' to place the
+	   loading icon at the same position as the confirm icon */
+	position: absolute;
+	bottom: 0px;
+	right: 8px;
+	width: 30px;
+	margin: 0;
+	padding: 7px 9px;
+
+	/* Match rules for 'input[type="submit"]' to place the loading icon at the
+	   same position as the confirm icon */
+	min-height: 34px;
+	box-sizing: border-box;
 }
 
 #commentsTabView .newCommentForm .cancel {

--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -27,6 +27,7 @@
 		'        <div class="author">{{actorDisplayName}}</div>' +
 		'{{#if isEditMode}}' +
 		'        <a href="#" class="action delete icon icon-delete has-tooltip" title="{{deleteTooltip}}"></a>' +
+		'        <div class="deleteLoading icon-loading-small hidden"></div>'+
 		'{{/if}}' +
 		'    </div>' +
 		'    <form class="newCommentForm">' +
@@ -543,7 +544,7 @@
 			ev.preventDefault();
 			var $comment = $(ev.target).closest('.comment');
 			var commentId = $comment.data('id');
-			var $loading = $comment.find('.submitLoading');
+			var $loading = $comment.find('.deleteLoading');
 			var $commentField = $comment.find('.message');
 			var $submit = $comment.find('.submit');
 			var $cancel = $comment.find('.cancel');


### PR DESCRIPTION
Fix working icon position when sending or deleting a comment


The working/loading icon is now placed at the same position as the confirm and delete "buttons" while a comment is being sent or deleted.

To place the working icon at the same position as the confirm button I have just copied the CSS rules used by the absolutely positioned input element of the confirm button. It looks like a terribly brittle approach, so @nextcloud/designers feel free to improve it ;-)

Also please ignore the input field not being disabled in the screenshots below; that is a different issue ;-) (#7266)

Send, before:
![comment-icon-send-before](https://user-images.githubusercontent.com/26858233/33217807-f549c32c-d139-11e7-9d8c-9523730892f3.png)

Send, after:
![comment-icon-send-after](https://user-images.githubusercontent.com/26858233/33217809-f777fb46-d139-11e7-9603-a1f258877e76.png)

Delete, before:
![comment-icon-delete-before](https://user-images.githubusercontent.com/26858233/33217817-feb3be72-d139-11e7-88b1-e17b7337dd1f.png)

Delete, after:
![comment-icon-delete-after](https://user-images.githubusercontent.com/26858233/33217820-037b5bd6-d13a-11e7-97d6-67cba2d721a7.png)
