### PR TITLE
Fix #4789: Group admins cannot see disabled users

### DIFF
--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -339,7 +339,9 @@ class UsersController extends Controller {
 
 			// Batch all groups the user is subadmin of when a group is specified
 			$batch = [];
-			if ($gid === '') {
+			if ($gid !== '' && $gid !== '_disabledUsers' && $gid !== '_everyone') {
+				$batch = $this->groupManager->displayNamesInGroup($gid, $pattern, $limit, $offset);
+			} else {
 				foreach ($subAdminOfGroups as $group) {
 					$groupUsers = $this->groupManager->displayNamesInGroup($group, $pattern, $limit, $offset);
 
@@ -347,8 +349,6 @@ class UsersController extends Controller {
 						$batch[$uid] = $displayName;
 					}
 				}
-			} else {
-				$batch = $this->groupManager->displayNamesInGroup($gid, $pattern, $limit, $offset);
 			}
 			$batch = $this->getUsersForUID($batch);
 


### PR DESCRIPTION
This is a trivial fix for the issue #4789, pointing out that a sub admin user (not a super user) cannot see the disabled users of their own group.

The problem dwells in `settings/Controller/UsersControllerlines`, in the `index` method, line 342 :

```php
if ($gid === '') {
    // list users of groups the current use is sub admin of
} else {
    // list users of provided group
}
```

This checks only if `$gid` is an empty string. If disabled users are listed, `$gid`'s value is `_disabledUsers` and the `else` branch is executed, where no users are found, since there is not supposed to be a `_disabledUsers` group.

The PR simply mimics the same mechanics used some lines above if the current user is admin by adding to the check if `$gid` is `_disabledUsers` or `_everyone`.

I would like to test this modification, but I couldn't find how.