### PR TITLE
Fix contacts menu height for Safari

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1340,6 +1340,7 @@ span.ui-icon {
 #contactsmenu-search {
 	width: calc(100% - 16px);
 	margin: 8px;
+	height: 34px;
 }
 
 /* ---- TOOLTIPS ---- */


### PR DESCRIPTION
* fixes #5119
* in Safari the input field was 38px in height and not 34px like in all other browsers

cc @nextcloud/designers 