### PR TITLE
Log NotImplementedException on DAV in debug level

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
@@ -32,6 +32,7 @@ use OCP\ILogger;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotAuthenticated;
 use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\Exception\NotImplemented;
 use Sabre\DAV\Exception\PreconditionFailed;
 use Sabre\DAV\Exception\ServiceUnavailable;
 
@@ -54,6 +55,9 @@ class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
 		// Happens when an external storage or federated share is temporarily
 		// not available
 		StorageNotAvailableException::class => true,
+		// happens if some a client uses the wrong method for a given URL
+		// the error message itself is visible on the client side anyways
+		NotImplemented::class => true,
 	];
 
 	/** @var string */


### PR DESCRIPTION
Happens when a `POST` request is for example send to a calendar URL - like here:

```
curl -X POST -u admin:password http://192.168.99.100/server/remote.php/dav/calendars/admin/personal/
```

In this case it was send by the macOS calendar for one user.

Maybe @georgehrke can also look into it.