### PR TITLE
Ensure that X-OC-MTime header is an integer with chunked uploads

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -590,7 +590,11 @@ class File extends Node implements IFile {
 	}
 
 	private function sanitizeMtime($mtimeFromRequest) {
-		if (!is_numeric($mtimeFromRequest)) {
+		// In PHP 5.X "is_numeric" returns true for strings in hexadecimal
+		// notation. This is no longer the case in PHP 7.X, so this check
+		// ensures that strings with hexadecimal notations fail too in PHP 5.X.
+		$isHexadecimal = is_string($mtimeFromRequest) && preg_match('/^\s*0[xX]/', $mtimeFromRequest);
+		if ($isHexadecimal || !is_numeric($mtimeFromRequest)) {
 			throw new \InvalidArgumentException('X-OC-MTime header must be an integer (unix timestamp).');
 		}
 

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -36,13 +36,16 @@
 
 namespace OCA\DAV\Connector\Sabre;
 
+use OC\AppFramework\Http\Request;
 use OC\Files\Filesystem;
+use OC\Files\View;
 use OCA\DAV\Connector\Sabre\Exception\EntityTooLarge;
 use OCA\DAV\Connector\Sabre\Exception\FileLocked;
 use OCA\DAV\Connector\Sabre\Exception\Forbidden as DAVForbiddenException;
 use OCA\DAV\Connector\Sabre\Exception\UnsupportedMediaType;
 use OCP\Encryption\Exceptions\GenericEncryptionException;
 use OCP\Files\EntityTooLargeException;
+use OCP\Files\FileInfo;
 use OCP\Files\ForbiddenException;
 use OCP\Files\InvalidContentException;
 use OCP\Files\InvalidPathException;
@@ -51,6 +54,7 @@ use OCP\Files\NotPermittedException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
+use OCP\Share\IManager;
 use Sabre\DAV\Exception;
 use Sabre\DAV\Exception\BadRequest;
 use Sabre\DAV\Exception\Forbidden;
@@ -60,6 +64,26 @@ use Sabre\DAV\IFile;
 use Sabre\DAV\Exception\NotFound;
 
 class File extends Node implements IFile {
+
+	protected $request;
+
+	/**
+	 * Sets up the node, expects a full path name
+	 *
+	 * @param \OC\Files\View $view
+	 * @param \OCP\Files\FileInfo $info
+	 * @param \OCP\Share\IManager $shareManager
+	 * @param \OC\AppFramework\Http\Request $request
+	 */
+	public function __construct(View $view, FileInfo $info, IManager $shareManager = null, Request $request = null) {
+		parent::__construct($view, $info, $shareManager);
+
+		if (isset($request)) {
+			$this->request = $request;
+		} else {
+			$this->request = \OC::$server->getRequest();
+		}
+	}
 
 	/**
 	 * Updates the data
@@ -208,9 +232,8 @@ class File extends Node implements IFile {
 			}
 
 			// allow sync clients to send the mtime along in a header
-			$request = \OC::$server->getRequest();
-			if (isset($request->server['HTTP_X_OC_MTIME'])) {
-				$mtime = $this->sanitizeMtime($request->server['HTTP_X_OC_MTIME']);
+			if (isset($this->request->server['HTTP_X_OC_MTIME'])) {
+				$mtime = $this->sanitizeMtime($this->request->server['HTTP_X_OC_MTIME']);
 				if ($this->fileView->touch($this->path, $mtime)) {
 					header('X-OC-MTime: accepted');
 				}
@@ -222,8 +245,8 @@ class File extends Node implements IFile {
 
 			$this->refreshInfo();
 
-			if (isset($request->server['HTTP_OC_CHECKSUM'])) {
-				$checksum = trim($request->server['HTTP_OC_CHECKSUM']);
+			if (isset($this->request->server['HTTP_OC_CHECKSUM'])) {
+				$checksum = trim($this->request->server['HTTP_OC_CHECKSUM']);
 				$this->fileView->putFileInfo($this->path, ['checksum' => $checksum]);
 				$this->refreshInfo();
 			} else if ($this->getChecksum() !== null && $this->getChecksum() !== '') {
@@ -466,9 +489,8 @@ class File extends Node implements IFile {
 				}
 
 				// allow sync clients to send the mtime along in a header
-				$request = \OC::$server->getRequest();
-				if (isset($request->server['HTTP_X_OC_MTIME'])) {
-					$mtime = $this->sanitizeMtime($request->server['HTTP_X_OC_MTIME']);
+				if (isset($this->request->server['HTTP_X_OC_MTIME'])) {
+					$mtime = $this->sanitizeMtime($this->request->server['HTTP_X_OC_MTIME']);
 					if ($targetStorage->touch($targetInternalPath, $mtime)) {
 						header('X-OC-MTime: accepted');
 					}
@@ -484,8 +506,8 @@ class File extends Node implements IFile {
 				// FIXME: should call refreshInfo but can't because $this->path is not the of the final file
 				$info = $this->fileView->getFileInfo($targetPath);
 
-				if (isset($request->server['HTTP_OC_CHECKSUM'])) {
-					$checksum = trim($request->server['HTTP_OC_CHECKSUM']);
+				if (isset($this->request->server['HTTP_OC_CHECKSUM'])) {
+					$checksum = trim($this->request->server['HTTP_OC_CHECKSUM']);
 					$this->fileView->putFileInfo($targetPath, ['checksum' => $checksum]);
 				} else if ($info->getChecksum() !== null && $info->getChecksum() !== '') {
 					$this->fileView->putFileInfo($this->path, ['checksum' => '']);

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -235,7 +235,7 @@ class File extends Node implements IFile {
 			if (isset($this->request->server['HTTP_X_OC_MTIME'])) {
 				$mtime = $this->sanitizeMtime($this->request->server['HTTP_X_OC_MTIME']);
 				if ($this->fileView->touch($this->path, $mtime)) {
-					header('X-OC-MTime: accepted');
+					$this->header('X-OC-MTime: accepted');
 				}
 			}
 					
@@ -492,7 +492,7 @@ class File extends Node implements IFile {
 				if (isset($this->request->server['HTTP_X_OC_MTIME'])) {
 					$mtime = $this->sanitizeMtime($this->request->server['HTTP_X_OC_MTIME']);
 					if ($targetStorage->touch($targetInternalPath, $mtime)) {
-						header('X-OC-MTime: accepted');
+						$this->header('X-OC-MTime: accepted');
 					}
 				}
 
@@ -604,5 +604,9 @@ class File extends Node implements IFile {
 	 */
 	public function getChecksum() {
 		return $this->info->getChecksum();
+	}
+
+	protected function header($string) {
+		\header($string);
 	}
 }

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -370,7 +370,7 @@ class FileTest extends \Test\TestCase {
 			],
 			"string castable hex int" => [
 					'HTTP_X_OC_MTIME' => "0x45adf",
-					'expected result' => 0
+					'expected result' => null
 			],
 			"string that looks like invalid hex int" => [
 					'HTTP_X_OC_MTIME' => "0x123g",

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -310,7 +310,11 @@ class FileTest extends \Test\TestCase {
 			null
 		);
 
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info, null, $request);
+		/** @var \OCA\DAV\Connector\Sabre\File | \PHPUnit_Framework_MockObject_MockObject $file */
+		$file = $this->getMockBuilder(\OCA\DAV\Connector\Sabre\File::class)
+			->setConstructorArgs([$view, $info, null, $request])
+			->setMethods(['header'])
+			->getMock();
 
 		// beforeMethod locks
 		$view->lockFile($path, ILockingProvider::LOCK_SHARED);
@@ -385,8 +389,6 @@ class FileTest extends \Test\TestCase {
 
 	/**
 	 * Test putting a file with string Mtime
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 * @dataProvider legalMtimeProvider
 	 */
 	public function testPutSingleFileLegalMtime($requestMtime, $resultMtime) {
@@ -411,8 +413,6 @@ class FileTest extends \Test\TestCase {
 
 	/**
 	 * Test putting a file with string Mtime using chunking
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 * @dataProvider legalMtimeProvider
 	 */
 	public function testChunkedPutLegalMtime($requestMtime, $resultMtime) {

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -284,10 +284,11 @@ class FileTest extends \Test\TestCase {
 	 *
 	 * @param string $path path to put the file into
 	 * @param string $viewRoot root to use for the view
+	 * @param null|\OC\AppFramework\Http\Request $request the HTTP request
 	 *
 	 * @return null|string of the PUT operaiton which is usually the etag
 	 */
-	private function doPut($path, $viewRoot = null) {
+	private function doPut($path, $viewRoot = null, \OC\AppFramework\Http\Request $request = null) {
 		$view = \OC\Files\Filesystem::getView();
 		if (!is_null($viewRoot)) {
 			$view = new \OC\Files\View($viewRoot);
@@ -303,7 +304,7 @@ class FileTest extends \Test\TestCase {
 			null
 		);
 
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new \OCA\DAV\Connector\Sabre\File($view, $info, null, $request);
 
 		// beforeMethod locks
 		$view->lockFile($path, ILockingProvider::LOCK_SHARED);


### PR DESCRIPTION
This pull request is a follow up to #3793. That pull request ensured that the `X-OC-MTime` header processed by the server was an integer, but not when chunked uploads were used. This pull request ensures that too for chunked uploads: if the header value can be converted to an integer it will be (so it will not fail if a float is given, it will simply convert it to an integer), and if not an exception will be thrown.

Note, however, that there is a difference in the exceptions thrown for regular uploads and for chunked uploads: if the validation fails on a regular upload an `InvalidArgumentException` is thrown, but if a validation fails on a chunked upload a `Sabre\DAV\Exception` is thrown instead. The reason is that I have not touched the exception handling code, so the behaviour is the same as it was for regular and chunked uploads before this pull request (that is, exceptions in chunked uploads are converted to `Sabre\DAV\Exception` while exceptions in regular uploads are converted only in some specific parts of its code, which looks like something that may need a fix).

Besides that, this pull request also acts as an import of owncloud/core#28066 and owncloud/core#28676.

owncloud/core#28066 is the ownCloud equivalent of #3793; in the case of ownCloud no exception is thrown if the value is invalid, and it is converted to an integer with a different technique. However, the name of the function in which the code that ensures the correct type of `X-OC-MTime` was refactored, `sanitizeMTime`, is based on the one introduced in owncloud/core#28066.

owncloud/core#28066 also provides unit tests to ensure the proper handling of `X-OC-MTime`; those tests (and the changes to the code being tested) were adapted and included in this pull request. Note that in this pull request there is no special handling for negative mtimes in the tests as, if I am not mistaken, currently all the storages used in unit tests have support for negative mtimes.

owncloud/core#28676 is a follow up to owncloud/core#28066 that removes the need of running the unit tests in a separate process. This was needed due to the direct call to `header` in `File`, which caused the _Cannot modify header information - headers already sent by_ error if tests were not run in a separate process. I am not familiar with this code, so in this pull request it was fixed like in the pull request from ownCloud, that is, by wrapping `header` with a protected function and mocking that function in the tests; I am sure that there are better alternatives, so please tell me :-)

owncloud/core#28676 also includes [a totally unrelated change](https://github.com/owncloud/core/pull/28676/commits/de2db6a80b34522597f6f040893fd35c2041109d): remove forcing mtime values to be positive in [the default `filemtime` function of Storages](https://github.com/nextcloud/server/blob/0eebff152a177dd59ed8773df26f1679f8a88e90/lib/private/Files/Storage/Common.php#L182) (apparently it was done just to remove the need of having a special handling for negative mtimes in their tests). I have not included that change in this pull request, but the question is: **should that be added in a different pull request or is the current behaviour in Nextcloud right?**

Finally, this pull request should not conflict with the Web UI, nor the desktop, Android or iOS clients:
  - Some browsers (at least, Chromium) send a float value for `X-OC-MTime` with the current `file-upload.js` file, but it is not a problem due to the conversion to an integer performed in the server (although [the Web UI should not be sending `X-OC-MTime` at all](https://github.com/nextcloud/server/pull/3822); it was introduced when chunked uploads were added to the Web UI and it will be fixed in a different pull request)
  - The desktop client, as far as I know, [always sends an integer `X-OC-MTime` for chunked uploads](https://github.com/nextcloud/client/blob/e10775d34fe4ed2082e9b229bdfea7b9bb686d91/src/libsync/propagateupload.cpp#L587); even if the server is 32 bit and the client 64 bit and it sends a value too large for a 32 bit system the value will simply be truncated by the server to the largest positive or negative value available (depending on the case)
  - If I am not mistaken, the Android client ~~does not use chunked uploads yet~~ [sends](https://github.com/nextcloud/android-library/blob/d082a74caf7b47ed187dc17f0dba62b0dbd2436a/src/com/owncloud/android/lib/resources/files/ChunkedUploadRemoteFileOperation.java#L172) a [signed decimal representation of a long](https://github.com/nextcloud/android/blob/9db47fe559af820d758733a77cf9f925d2d0238b/src/main/java/com/owncloud/android/operations/UploadFileOperation.java#L423); like the desktop client it should work, but please test to be sure :-) @nextcloud/android 
  - I have no idea about the iOS client, so please test to be sure :-) @nextcloud/ios 
