### PR TITLE
Fix silent conflicts due to merging #7256 after #7251

### DIFF
--- a/apps/comments/css/comments.css
+++ b/apps/comments/css/comments.css
@@ -140,6 +140,9 @@
 .atwho-view-ul * .avatar-name-wrapper,
 #commentsTabView .comment .authorRow {
 	position: relative;
+	display: inline-flex;
+	align-items: center;
+	width: 100%;
 }
 
 #commentsTabView .comment:not(.newCommentRow) .message .avatar-name-wrapper:not(.currentUser),
@@ -152,9 +155,6 @@
 .atwho-view-ul .avatar-name-wrapper,
 .atwho-view-ul .avatar-name-wrapper .avatar {
 	cursor: pointer;
-	display: inline-flex;
-	align-items: center;
-	width: 100%;
 }
 
 #commentsTabView .comments li .message .atwho-inserted {


### PR DESCRIPTION
Although #7256 was merged cleanly some of the changes really conflicted with those introduced by the last commit of #7251, and this broke the appearance of the author row of comments. This pull request fixes those silent conflicts and restores the appearance of the author row.
