### PR TITLE
Update login filter when user filter was newly generated

### DIFF
--- a/apps/user_ldap/js/wizard/wizardTabLoginFilter.js
+++ b/apps/user_ldap/js/wizard/wizardTabLoginFilter.js
@@ -85,6 +85,7 @@ OCA = OCA || {};
 		setModel: function(configModel) {
 			this._super(configModel);
 			this.configModel.on('configLoaded', this.onConfigSwitch, this);
+			this.configModel.on('configUpdated', this.onConfigUpdated, this);
 			this.configModel.on('receivedLdapFeature', this.onFeatureReceived, this);
 		},
 
@@ -202,6 +203,22 @@ OCA = OCA || {};
 			view.managedItems.ldap_loginfilter_attributes.$element.find('option').remove();
 
 			view.onConfigLoaded(view, configuration);
+		},
+
+		/**
+		 * @param {WizardTabLoginFilter} view
+		 * @param {Object} configuration
+		 */
+		onConfigUpdated: function(view, configuration) {
+			// When the user list filter is updated in assisted mode, also
+			// update the login filter automatically.
+			if(
+				!_.isUndefined(configuration.ldap_userlist_filter)
+				&& view.parsedFilterMode === view.configModel.FILTER_MODE_ASSISTED
+				&& _.toArray(configuration).length === 1
+			) {
+				view.configModel.requestWizard('ldap_login_filter');
+			}
 		},
 
 		/**


### PR DESCRIPTION
When the Login filter operates in assisted mode, changes to the user filter should also always trigger its update, because it utilizes it. It happens that admins forget to revisit the login filter which would trigger the update otherwise.

In manual mode, the login filter is not touched.