### PR TITLE
[stable12] Set primary action button color to same as theming color

### DIFF
--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -86,7 +86,7 @@
 
 input.primary {
 	background-color: $color-primary-element;
-	border: 1px solid $color-primary;
+	border: 1px solid $color-primary-text;
 	color: $color-primary-text;
 }
 

--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -191,8 +191,8 @@ input.update-continue {
 }
 input.primary,
 button.primary {
-	border: 1px solid #0082c9;
-	background-color: #00a2e9;
+	border: 1px solid #fff;
+	background-color: #0082c9;
 	color: #fff;
 }
 

--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -67,7 +67,7 @@ textarea,
 	/* Primary action button, use sparingly */
 	&.primary {
 		border: 1px solid $color-primary-text;
-		background-color: $color-primary-element;
+		background-color: $color-primary;
 		color: $color-primary-text;
 		cursor: pointer;
 		&:not(:disabled) {


### PR DESCRIPTION
Partial backport of #6303 (only the change of the border color)

Fixes #6857 

Now it looks like this:

![bildschirmfoto 2017-11-28 um 13 50 34](https://user-images.githubusercontent.com/245432/33320675-562d2466-d443-11e7-9206-08a09ca7ac7f.png)
![bildschirmfoto 2017-11-28 um 13 50 42](https://user-images.githubusercontent.com/245432/33320676-5649bfe0-d443-11e7-94e9-8dfdc4725ef4.png)
![bildschirmfoto 2017-11-28 um 13 50 48](https://user-images.githubusercontent.com/245432/33320677-56628a7a-d443-11e7-9803-702a2d88465c.png)
