### PR TITLE
 Only in case of $currentAccess the array uses the user id as index

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1395,7 +1395,13 @@ class Manager implements IManager {
 			foreach ($tmp as $k => $v) {
 				if (isset($al[$k])) {
 					if (is_array($al[$k])) {
-						$al[$k] += $v;
+						if ($currentAccess) {
+							$al[$k] += $v;
+						} else {
+							$al[$k] = array_merge($al[$k], $v);
+							$al[$k] = array_unique($al[$k]);
+							$al[$k] = array_values($al[$k]);
+						}
 					} else {
 						$al[$k] = $al[$k] || $v;
 					}


### PR DESCRIPTION
Regression from 3820d68

Before 3820d68 the method worked for `!$currentAccess`, afterwards for `$currentAccess`, now it works for both and I added the relevant unit tests before.

Fix #7325 