### PR TITLE
Allow `{lang}` as a placeholder in the skeleton directory

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -242,6 +242,9 @@ $CONFIG = array(
  * The directory where the skeleton files are located. These files will be
  * copied to the data directory of new users. Leave empty to not copy any
  * skeleton files.
+ * ``{lang}`` can be used as a placeholder for the language of the user.
+ * If the directory does not exist, it falls back to non dialect (from ``de_DE``
+ * to ``de``). If that does not exist either, it falls back to ``en``
  *
  * Defaults to ``core/skeleton`` in the Nextcloud directory.
  */

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -244,7 +244,7 @@ $CONFIG = array(
  * skeleton files.
  * ``{lang}`` can be used as a placeholder for the language of the user.
  * If the directory does not exist, it falls back to non dialect (from ``de_DE``
- * to ``de``). If that does not exist either, it falls back to ``en``
+ * to ``de``). If that does not exist either, it falls back to ``default``
  *
  * Defaults to ``core/skeleton`` in the Nextcloud directory.
  */
@@ -865,6 +865,7 @@ $CONFIG = array(
 
 /**
  * custom path for LibreOffice/OpenOffice binary
+ *
  *
  * Defaults to ``''`` (empty string)
  */

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -389,7 +389,10 @@ class OC_Util {
 				$skeletonDirectory = str_replace('{lang}', substr($userLang, 0, $dialectStart), $plainSkeletonDirectory);
 			}
 			if ($dialectStart === false || !file_exists($skeletonDirectory)) {
-				$skeletonDirectory = str_replace('{lang}', 'en', $plainSkeletonDirectory);
+				$skeletonDirectory = str_replace('{lang}', 'default', $plainSkeletonDirectory);
+			}
+			if (!file_exists($skeletonDirectory)) {
+				$skeletonDirectory = '';
 			}
 		}
 

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -379,7 +379,20 @@ class OC_Util {
 	 */
 	public static function copySkeleton($userId, \OCP\Files\Folder $userDirectory) {
 
-		$skeletonDirectory = \OC::$server->getConfig()->getSystemValue('skeletondirectory', \OC::$SERVERROOT . '/core/skeleton');
+		$plainSkeletonDirectory = \OC::$server->getConfig()->getSystemValue('skeletondirectory', \OC::$SERVERROOT . '/core/skeleton');
+		$userLang = \OC::$server->getL10NFactory()->findLanguage();
+		$skeletonDirectory = str_replace('{lang}', $userLang, $plainSkeletonDirectory);
+
+		if (!file_exists($skeletonDirectory)) {
+			$dialectStart = strpos($userLang, '_');
+			if ($dialectStart !== false) {
+				$skeletonDirectory = str_replace('{lang}', substr($userLang, 0, $dialectStart), $plainSkeletonDirectory);
+			}
+			if ($dialectStart === false || !file_exists($skeletonDirectory)) {
+				$skeletonDirectory = str_replace('{lang}', 'en', $plainSkeletonDirectory);
+			}
+		}
+
 		$instanceId = \OC::$server->getConfig()->getSystemValue('instanceid', '');
 
 		if ($instanceId === null) {


### PR DESCRIPTION
Signed-off-by: Joas Schilling <coding@schilljs.com>