### PR TITLE
CardDAV convertor check should not be to wide

### DIFF
--- a/apps/dav/lib/CardDAV/Converter.php
+++ b/apps/dav/lib/CardDAV/Converter.php
@@ -61,6 +61,10 @@ class Converter {
 
 		$publish = false;
 
+		if ($image !== null && isset($userData[AccountManager::PROPERTY_AVATAR])) {
+			$userData[AccountManager::PROPERTY_AVATAR]['value'] = true;
+		}
+
 		foreach ($userData as $property => $value) {
 
 			$shareWithTrustedServers =
@@ -68,9 +72,8 @@ class Converter {
 				$value['scope'] === AccountManager::VISIBILITY_PUBLIC;
 
 			$emptyValue = !isset($value['value']) || $value['value'] === '';
-			$noImage = $image === null;
 
-			if ($shareWithTrustedServers && (!$emptyValue || !$noImage)) {
+			if ($shareWithTrustedServers && !$emptyValue) {
 				$publish = true;
 				switch ($property) {
 					case AccountManager::PROPERTY_DISPLAYNAME:


### PR DESCRIPTION
Case: email is set to null, but the avatar is set. In the old case the
email would set $emptyValue but $noImage would still be false. This we
would set the empty string as email.

Found while debugging the tests for https://github.com/nextcloud/server/pull/6876

