### PR TITLE
Check if the owner of a share exists

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ObjectTree.php
+++ b/apps/dav/lib/Connector/Sabre/ObjectTree.php
@@ -156,7 +156,7 @@ class ObjectTree extends CachingTree {
 			try {
 				$info = $this->fileView->getFileInfo($path);
 
-				if ($info->getStorage()->instanceOfStorage(FailedStorage::class)) {
+				if ($info instanceof \OCP\Files\FileInfo && $info->getStorage()->instanceOfStorage(FailedStorage::class)) {
 					throw new StorageNotAvailableException();
 				}
 			} catch (StorageNotAvailableException $e) {

--- a/apps/dav/lib/Connector/Sabre/ObjectTree.php
+++ b/apps/dav/lib/Connector/Sabre/ObjectTree.php
@@ -29,6 +29,7 @@
 
 namespace OCA\DAV\Connector\Sabre;
 
+use OC\Files\Storage\FailedStorage;
 use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
 use OCA\DAV\Connector\Sabre\Exception\FileLocked;
@@ -154,6 +155,10 @@ class ObjectTree extends CachingTree {
 			// read from cache
 			try {
 				$info = $this->fileView->getFileInfo($path);
+
+				if ($info->getStorage()->instanceOfStorage(FailedStorage::class)) {
+					throw new StorageNotAvailableException();
+				}
 			} catch (StorageNotAvailableException $e) {
 				throw new \Sabre\DAV\Exception\ServiceUnavailable('Storage is temporarily not available');
 			} catch (StorageInvalidException $e) {

--- a/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
@@ -174,6 +174,8 @@ class ObjectTreeTest extends \Test\TestCase {
 		$fileInfo->expects($this->once())
 			->method('getName')
 			->will($this->returnValue($outputFileName));
+		$fileInfo->method('getStorage')
+			->willReturn($this->createMock(\OC\Files\Storage\Common::class));
 
 		$view->expects($this->once())
 			->method('getFileInfo')


### PR DESCRIPTION
If the owner does not exist we should behave properly.

We can't delete the share at this point as a back end might just be temp
offline.


To test:

1. Setup NC with LDAP
2. Share a folder `test` from user1 to user2
3. Delete user1 from LDAP
  * DO NOT NOTIFY NEXTCLOUD
4. Login as user2
5. navigate to `test`

Before:
* If you enter test you will not see any content and warnings will be thrown
* Weird sync behavior

Now:
* Warning that the storage is temporaly unavailable
* Sync client skips the folder because it is not available