### PR TITLE
use formal version of German by default

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -157,7 +157,11 @@ $CONFIG = array(
  * language codes such as ``en`` for English, ``de`` for German, and ``fr`` for
  * French. It overrides automatic language detection on public pages like login
  * or shared items. User's language preferences configured under "personal ->
- * language" override this setting after they have logged in.
+ * language" override this setting after they have logged in. Nextcloud has two
+ * distinguished language codes for German, 'de' and 'de_DE'. 'de' is used for
+ * informal German and 'de_DE' for formal German. By setting this value to 'de_DE'
+ * you can enforce the formal version of German unless the user has chosen
+ * something different explicitly.
  *
  * Defaults to ``en``
  */

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -260,7 +260,7 @@ class Factory implements IFactory {
 
 				foreach ($available as $available_language) {
 					if ($preferred_language === strtolower($available_language)) {
-						return $available_language;
+						return $this->respectDefaultLanguage($app, $available_language);
 					}
 				}
 
@@ -274,6 +274,30 @@ class Factory implements IFactory {
 		}
 
 		throw new LanguageNotFoundException();
+	}
+
+	/**
+	 * if default language is set to de_DE (formal German) this should be
+	 * preferred to 'de' (non-formal German) if possible
+	 *
+	 * @param string|null $app
+	 * @param string $lang
+	 * @return string
+	 */
+	protected function respectDefaultLanguage($app, $lang) {
+		$result = $lang;
+		$defaultLanguage = $this->config->getSystemValue('default_language', false);
+
+		// use formal version of german ("Sie" instead of "Du") if the default
+		// language is set to 'de_DE' if possible
+		if (strtolower($lang) === 'de'
+			&& strtolower($defaultLanguage) === 'de_de' &&
+			$this->languageExists($app, 'de_DE')
+		) {
+			$result = 'de_DE';
+		}
+
+		return $result;
 	}
 
 	/**

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -290,8 +290,9 @@ class Factory implements IFactory {
 
 		// use formal version of german ("Sie" instead of "Du") if the default
 		// language is set to 'de_DE' if possible
-		if (strtolower($lang) === 'de'
-			&& strtolower($defaultLanguage) === 'de_de' &&
+		if (is_string($defaultLanguage) &&
+			strtolower($lang) === 'de' &&
+			strtolower($defaultLanguage) === 'de_de' &&
 			$this->languageExists($app, 'de_DE')
 		) {
 			$result = 'de_DE';


### PR DESCRIPTION
Use formal version of German by default, if not explicitly defined differently.

Germans are sometimes a bit old school and prefer the formal "Sie" instead of "Du". 😉  So I think it makes sense to use this version as default if the browser is set to German.
