### PR TITLE
Refactor method to check if update is needed

### DIFF
--- a/apps/dav/lib/Connector/Sabre/MaintenancePlugin.php
+++ b/apps/dav/lib/Connector/Sabre/MaintenancePlugin.php
@@ -27,6 +27,7 @@
 namespace OCA\DAV\Connector\Sabre;
 
 use OCP\IConfig;
+use OCP\Util;
 use Sabre\DAV\Exception\ServiceUnavailable;
 use Sabre\DAV\ServerPlugin;
 
@@ -80,7 +81,7 @@ class MaintenancePlugin extends ServerPlugin {
 		if ($this->config->getSystemValue('maintenance', false)) {
 			throw new ServiceUnavailable('System in maintenance mode.');
 		}
-		if (\OC::checkUpgrade(false)) {
+		if (Util::needUpgrade()) {
 			throw new ServiceUnavailable('Upgrade needed');
 		}
 

--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -39,6 +39,7 @@ use OC\Installer;
 use OC\Updater;
 use OCP\IConfig;
 use OCP\ILogger;
+use OCP\Util;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -93,7 +94,7 @@ class Upgrade extends Command {
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
 
-		if(\OC::checkUpgrade(false)) {
+		if(Util::needUpgrade()) {
 			if (OutputInterface::VERBOSITY_NORMAL < $output->getVerbosity()) {
 				// Prepend each line with a little timestamp
 				$timestampFormatter = new TimestampFormatter($this->config, $output->getFormatter());

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -98,7 +98,7 @@ class FeedBackHandler {
 	}
 }
 
-if (OC::checkUpgrade(false)) {
+if (\OCP\Util::needUpgrade()) {
 
 	$config = \OC::$server->getSystemConfig();
 	if ($config->getValue('upgrade.disable-web', false)) {

--- a/lib/base.php
+++ b/lib/base.php
@@ -291,15 +291,14 @@ class OC {
 
 	/**
 	 * Prints the upgrade page
+	 *
+	 * @param \OC\SystemConfig $systemConfig
 	 */
-	private static function printUpgradePage() {
-		$systemConfig = \OC::$server->getSystemConfig();
-
+	private static function printUpgradePage(\OC\SystemConfig $systemConfig) {
 		$disableWebUpdater = $systemConfig->getValue('upgrade.disable-web', false);
 		$tooBig = false;
 		if (!$disableWebUpdater) {
 			$apps = \OC::$server->getAppManager();
-			$tooBig = false;
 			if ($apps->isInstalled('user_ldap')) {
 				$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
 
@@ -903,7 +902,7 @@ class OC {
 		if (!$systemConfig->getValue('installed', false)) {
 			\OC::$server->getSession()->clear();
 			$setupHelper = new OC\Setup(
-				\OC::$server->getSystemConfig(),
+				$systemConfig,
 				\OC::$server->getIniWrapper(),
 				\OC::$server->getL10N('lib'),
 				\OC::$server->query(\OCP\Defaults::class),
@@ -929,7 +928,7 @@ class OC {
 					opcache_reset();
 				}
 				if (!$systemConfig->getValue('maintenance', false)) {
-					self::printUpgradePage();
+					self::printUpgradePage($systemConfig);
 					exit();
 				}
 			}


### PR DESCRIPTION
There was only one call, that actually needed the parameter to be set to true. So this change moved the print of the page to that location and replaces all other occurences with a direct call to the underlying OCP API.

Also added an additional commit to remove unneeded/unused variables in that code parts.