### PR TITLE
check userExists later, saves lookups for appData_INSTANCEID userids

### DIFF
--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -237,7 +237,7 @@ class Storage extends Wrapper {
 			return false;
 		}
 
-		if ($this->userManager->userExists($parts[1]) && $parts[2] === 'files') {
+		if ($parts[2] === 'files' && $this->userManager->userExists($parts[1])) {
 			return true;
 		}
 


### PR DESCRIPTION
The easy and cheap check should be preferred. No need to request other user backends unnecessarily. For instance, I observed it was queried for appdata_$INSTANCEID.