### PR TITLE
[stable12] Allow to skip data dir permission checks by config

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -646,6 +646,18 @@ $CONFIG = array(
 'check_for_working_htaccess' => true,
 
 /**
+ * In rare setups (e.g. on Openshift or docker on windows) the permissions check
+ * might block the installation while the underlying system offers no means to
+ * "correct" the permissions. In this case, set the value to false.
+ *
+ * In regular cases, if issues with permissions are encountered they should be
+ * adjusted accordingly. Changing the flag is discouraged.
+ *
+ * Defaults to ``true``
+ */
+'check_data_directory_permissions' => true,
+
+/**
  * In certain environments it is desired to have a read-only configuration file.
  * When this switch is set to ``true`` Nextcloud will not verify whether the
  * configuration is writable. However, it will not be possible to configure

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -959,8 +959,11 @@ class OC_Util {
 	 * @return array arrays with error messages and hints
 	 */
 	public static function checkDataDirectoryPermissions($dataDirectory) {
+		if(\OC::$server->getConfig()->getSystemValue('check_data_directory_permissions', true) === false) {
+			return  [];
+		}
 		$l = \OC::$server->getL10N('lib');
-		$errors = array();
+		$errors = [];
 		$permissionsModHint = $l->t('Please change the permissions to 0770 so that the directory'
 			. ' cannot be listed by other users.');
 		$perms = substr(decoct(@fileperms($dataDirectory)), -3);


### PR DESCRIPTION
Enables installation on services that don't allow/support permission
changes.

* backport of #7347 


Tested and works 👍 