### PR TITLE
Let the admin configure the default share permissions

### DIFF
--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -23,6 +23,7 @@
 namespace OCA\Files_Sharing;
 
 use OCP\Capabilities\ICapability;
+use OCP\Constants;
 use \OCP\IConfig;
 
 /**
@@ -86,6 +87,7 @@ class Capabilities implements ICapability {
 			$res['group'] = [];
 			$res['group']['enabled'] = $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes') === 'yes';
 			$res['group']['expire_date']['enabled'] = true;
+			$res['default_permissions'] = (int)$this->config->getAppValue('core', 'shareapi_default_permissions', Constants::PERMISSION_ALL);
 		}
 
 		//Federated sharing

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -35,8 +35,10 @@ use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\AppFramework\OCSController;
+use OCP\Constants;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
+use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IUserManager;
@@ -75,6 +77,8 @@ class ShareAPIController extends OCSController {
 	private $l;
 	/** @var \OCP\Files\Node */
 	private $lockedNode;
+	/** @var IConfig */
+	private $config;
 
 	/**
 	 * Share20OCS constructor.
@@ -88,6 +92,7 @@ class ShareAPIController extends OCSController {
 	 * @param IURLGenerator $urlGenerator
 	 * @param string $userId
 	 * @param IL10N $l10n
+	 * @param IConfig $config
 	 */
 	public function __construct(
 		$appName,
@@ -98,7 +103,8 @@ class ShareAPIController extends OCSController {
 		IRootFolder $rootFolder,
 		IURLGenerator $urlGenerator,
 		$userId,
-		IL10N $l10n
+		IL10N $l10n,
+		IConfig $config
 	) {
 		parent::__construct($appName, $request);
 
@@ -110,6 +116,7 @@ class ShareAPIController extends OCSController {
 		$this->urlGenerator = $urlGenerator;
 		$this->currentUser = $userId;
 		$this->l = $l10n;
+		$this->config = $config;
 	}
 
 	/**
@@ -318,7 +325,7 @@ class ShareAPIController extends OCSController {
 	 */
 	public function createShare(
 		$path = null,
-		$permissions = \OCP\Constants::PERMISSION_ALL,
+		$permissions = null,
 		$shareType = -1,
 		$shareWith = null,
 		$publicUpload = 'false',
@@ -326,6 +333,10 @@ class ShareAPIController extends OCSController {
 		$expireDate = ''
 	) {
 		$share = $this->shareManager->newShare();
+
+		if ($permissions === null) {
+			$permissions = $this->config->getAppValue('core', 'shareapi_default_permissions', Constants::PERMISSION_ALL);
+		}
 
 		// Verify path
 		if ($path === null) {
@@ -347,17 +358,17 @@ class ShareAPIController extends OCSController {
 			throw new OCSNotFoundException($this->l->t('Could not create share'));
 		}
 
-		if ($permissions < 0 || $permissions > \OCP\Constants::PERMISSION_ALL) {
+		if ($permissions < 0 || $permissions > Constants::PERMISSION_ALL) {
 			throw new OCSNotFoundException($this->l->t('invalid permissions'));
 		}
 
 		// Shares always require read permissions
-		$permissions |= \OCP\Constants::PERMISSION_READ;
+		$permissions |= Constants::PERMISSION_READ;
 
 		if ($path instanceof \OCP\Files\File) {
 			// Single file shares should never have delete or create permissions
-			$permissions &= ~\OCP\Constants::PERMISSION_DELETE;
-			$permissions &= ~\OCP\Constants::PERMISSION_CREATE;
+			$permissions &= ~Constants::PERMISSION_DELETE;
+			$permissions &= ~Constants::PERMISSION_CREATE;
 		}
 
 		/*
@@ -414,13 +425,13 @@ class ShareAPIController extends OCSController {
 				}
 
 				$share->setPermissions(
-					\OCP\Constants::PERMISSION_READ |
-					\OCP\Constants::PERMISSION_CREATE |
-					\OCP\Constants::PERMISSION_UPDATE |
-					\OCP\Constants::PERMISSION_DELETE
+					Constants::PERMISSION_READ |
+					Constants::PERMISSION_CREATE |
+					Constants::PERMISSION_UPDATE |
+					Constants::PERMISSION_DELETE
 				);
 			} else {
-				$share->setPermissions(\OCP\Constants::PERMISSION_READ);
+				$share->setPermissions(Constants::PERMISSION_READ);
 			}
 
 			// Set password
@@ -447,13 +458,9 @@ class ShareAPIController extends OCSController {
 			$share->setPermissions($permissions);
 		} else if ($shareType === \OCP\Share::SHARE_TYPE_EMAIL) {
 			if ($share->getNodeType() === 'file') {
-				$share->setPermissions(\OCP\Constants::PERMISSION_READ);
+				$share->setPermissions(Constants::PERMISSION_READ);
 			} else {
-				$share->setPermissions(
-					\OCP\Constants::PERMISSION_READ |
-					\OCP\Constants::PERMISSION_CREATE |
-					\OCP\Constants::PERMISSION_UPDATE |
-					\OCP\Constants::PERMISSION_DELETE);
+				$share->setPermissions($permissions);
 			}
 			$share->setSharedWith($shareWith);
 		} else if ($shareType === \OCP\Share::SHARE_TYPE_CIRCLE) {
@@ -698,23 +705,23 @@ class ShareAPIController extends OCSController {
 
 			$newPermissions = null;
 			if ($publicUpload === 'true') {
-				$newPermissions = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE;
+				$newPermissions = Constants::PERMISSION_READ | Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE | Constants::PERMISSION_DELETE;
 			} else if ($publicUpload === 'false') {
-				$newPermissions = \OCP\Constants::PERMISSION_READ;
+				$newPermissions = Constants::PERMISSION_READ;
 			}
 
 			if ($permissions !== null) {
 				$newPermissions = (int)$permissions;
-				$newPermissions = $newPermissions & ~\OCP\Constants::PERMISSION_SHARE;
+				$newPermissions = $newPermissions & ~Constants::PERMISSION_SHARE;
 			}
 
 			if ($newPermissions !== null &&
 				!in_array($newPermissions, [
-					\OCP\Constants::PERMISSION_READ,
-					\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE, // legacy
-					\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE, // correct
-					\OCP\Constants::PERMISSION_CREATE, // hidden file list
-					\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE, // allow to edit single files
+					Constants::PERMISSION_READ,
+					Constants::PERMISSION_READ | Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE, // legacy
+					Constants::PERMISSION_READ | Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE | Constants::PERMISSION_DELETE, // correct
+					Constants::PERMISSION_CREATE, // hidden file list
+					Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE, // allow to edit single files
 				])
 			) {
 				throw new OCSBadRequestException($this->l->t('Can\'t change permissions for public share links'));
@@ -722,9 +729,9 @@ class ShareAPIController extends OCSController {
 
 			if (
 				// legacy
-				$newPermissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE) ||
+				$newPermissions === (Constants::PERMISSION_READ | Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE) ||
 				// correct
-				$newPermissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE)
+				$newPermissions === (Constants::PERMISSION_READ | Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE | Constants::PERMISSION_DELETE)
 			) {
 				if (!$this->shareManager->shareApiLinkAllowPublicUpload()) {
 					throw new OCSForbiddenException($this->l->t('Public upload disabled by the administrator'));
@@ -735,7 +742,7 @@ class ShareAPIController extends OCSController {
 				}
 
 				// normalize to correct public upload permissions
-				$newPermissions = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE;
+				$newPermissions = Constants::PERMISSION_READ | Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE | Constants::PERMISSION_DELETE;
 			}
 
 			if ($newPermissions !== null) {

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -37,6 +37,7 @@ use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
+use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 
@@ -105,6 +106,7 @@ class ApiTest extends TestCase {
 			->will($this->returnCallback(function($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			}));
+		$config = $this->createMock(IConfig::class);
 
 		return new ShareAPIController(
 			self::APP_NAME,
@@ -115,7 +117,8 @@ class ApiTest extends TestCase {
 			\OC::$server->getRootFolder(),
 			\OC::$server->getURLGenerator(),
 			$userId,
-			$l
+			$l,
+			$config
 		);
 	}
 

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -31,6 +31,7 @@ use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\Storage;
+use OCP\IConfig;
 use OCP\IL10N;
 use OCA\Files_Sharing\Controller\ShareAPIController;
 use OCP\Files\NotFoundException;
@@ -84,6 +85,9 @@ class ShareAPIControllerTest extends TestCase {
 	/** @var IL10N|\PHPUnit_Framework_MockObject_MockObject */
 	private $l;
 
+	/** @var  IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	private $config;
+
 	protected function setUp() {
 		$this->shareManager = $this->createMock(IManager::class);
 		$this->shareManager
@@ -102,6 +106,7 @@ class ShareAPIControllerTest extends TestCase {
 			->will($this->returnCallback(function($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			}));
+		$this->config = $this->createMock(IConfig::class);
 
 		$this->ocs = new ShareAPIController(
 			$this->appName,
@@ -112,7 +117,8 @@ class ShareAPIControllerTest extends TestCase {
 			$this->rootFolder,
 			$this->urlGenerator,
 			$this->currentUser,
-			$this->l
+			$this->l,
+			$this->config
 		);
 	}
 
@@ -131,6 +137,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->urlGenerator,
 				$this->currentUser,
 				$this->l,
+				$this->config
 			])->setMethods(['formatShare'])
 			->getMock();
 	}
@@ -439,6 +446,7 @@ class ShareAPIControllerTest extends TestCase {
 					$this->urlGenerator,
 					$this->currentUser,
 					$this->l,
+					$this->config
 				])->setMethods(['canAccessShare'])
 				->getMock();
 
@@ -707,6 +715,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->urlGenerator,
 				$this->currentUser,
 				$this->l,
+				$this->config
 			])->setMethods(['formatShare'])
 			->getMock();
 
@@ -804,6 +813,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->urlGenerator,
 				$this->currentUser,
 				$this->l,
+				$this->config
 			])->setMethods(['formatShare'])
 			->getMock();
 
@@ -1119,6 +1129,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->urlGenerator,
 				$this->currentUser,
 				$this->l,
+				$this->config
 			])->setMethods(['formatShare'])
 			->getMock();
 

--- a/core/Controller/OCJSController.php
+++ b/core/Controller/OCJSController.php
@@ -26,6 +26,7 @@
 namespace OC\Core\Controller;
 
 use bantu\IniGetWrapper\IniGetWrapper;
+use OC\CapabilitiesManager;
 use OC\Template\JSConfigHelper;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
@@ -59,6 +60,7 @@ class OCJSController extends Controller {
 	 * @param IGroupManager $groupManager
 	 * @param IniGetWrapper $iniWrapper
 	 * @param IURLGenerator $urlGenerator
+	 * @param CapabilitiesManager $capabilitiesManager
 	 */
 	public function __construct($appName,
 								IRequest $request,
@@ -70,7 +72,8 @@ class OCJSController extends Controller {
 								IConfig $config,
 								IGroupManager $groupManager,
 								IniGetWrapper $iniWrapper,
-								IURLGenerator $urlGenerator) {
+								IURLGenerator $urlGenerator,
+								CapabilitiesManager $capabilitiesManager) {
 		parent::__construct($appName, $request);
 
 		$this->helper = new JSConfigHelper(
@@ -82,7 +85,8 @@ class OCJSController extends Controller {
 			$config,
 			$groupManager,
 			$iniWrapper,
-			$urlGenerator
+			$urlGenerator,
+			$capabilitiesManager
 		);
 	}
 

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -80,6 +80,13 @@ var OCP = {},
 	 */
 	webroot:oc_webroot,
 
+	/**
+	 * Capabilities
+	 *
+	 * @type array
+	 */
+	_capabilities: window.oc_capabilities || null,
+
 	appswebroots:(typeof oc_appswebroots !== 'undefined') ? oc_appswebroots:false,
 	/**
 	 * Currently logged in user or null if none
@@ -306,6 +313,18 @@ var OCP = {},
 	 */
 	getRootPath: function() {
 		return OC.webroot;
+	},
+
+
+	/**
+	 * Returns the capabilities
+	 *
+	 * @return {array} capabilities
+	 *
+	 * @since 13.0
+	 */
+	getCapabilities: function() {
+		return OC._capabilities;
 	},
 
 	/**

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -321,7 +321,7 @@ var OCP = {},
 	 *
 	 * @return {array} capabilities
 	 *
-	 * @since 13.0
+	 * @since 14.0
 	 */
 	getCapabilities: function() {
 		return OC._capabilities;

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -158,23 +158,24 @@
 			var shareType = attributes.shareType;
 			attributes = _.extend({}, attributes);
 
-			// Default permissions are Edit (CRUD) and Share
-			// Check if these permissions are possible
-			var permissions = OC.PERMISSION_READ;
+			// get default permissions
+			var defaultPermissions = OC.getCapabilities()['files_sharing']['default_permissions'] || OC.PERMISSION_ALL;
+			var possiblePermissions = OC.PERMISSION_READ;
+
 			if (this.updatePermissionPossible()) {
-				permissions = permissions | OC.PERMISSION_UPDATE;
+				possiblePermissions = possiblePermissions | OC.PERMISSION_UPDATE;
 			}
 			if (this.createPermissionPossible()) {
-				permissions = permissions | OC.PERMISSION_CREATE;
+				possiblePermissions = possiblePermissions | OC.PERMISSION_CREATE;
 			}
 			if (this.deletePermissionPossible()) {
-				permissions = permissions | OC.PERMISSION_DELETE;
+				possiblePermissions = possiblePermissions | OC.PERMISSION_DELETE;
 			}
 			if (this.configModel.get('isResharingAllowed') && (this.sharePermissionPossible())) {
-				permissions = permissions | OC.PERMISSION_SHARE;
+				possiblePermissions = possiblePermissions | OC.PERMISSION_SHARE;
 			}
 
-			attributes.permissions = permissions;
+			attributes.permissions = defaultPermissions & possiblePermissions;
 			if (_.isUndefined(attributes.path)) {
 				attributes.path = this.fileInfoModel.getFullPath();
 			}

--- a/core/js/tests/specs/shareitemmodelSpec.js
+++ b/core/js/tests/specs/shareitemmodelSpec.js
@@ -25,6 +25,7 @@ describe('OC.Share.ShareItemModel', function() {
 	var fetchSharesDeferred, fetchReshareDeferred;
 	var fileInfoModel, configModel, model;
 	var oldCurrentUser;
+	var capsSpec;
 
 	beforeEach(function() {
 		oldCurrentUser = OC.currentUser;
@@ -56,8 +57,15 @@ describe('OC.Share.ShareItemModel', function() {
 			configModel: configModel,
 			fileInfoModel: fileInfoModel
 		});
+		capsSpec = sinon.stub(OC, 'getCapabilities');
+		capsSpec.returns({
+			'files_sharing': {
+				'default_permissions': OC.PERMISSION_ALL
+			}
+		});
 	});
 	afterEach(function() {
+		capsSpec.restore(); 
 		if (fetchSharesStub) {
 			fetchSharesStub.restore();
 		}
@@ -527,7 +535,22 @@ describe('OC.Share.ShareItemModel', function() {
 				});
 				expect(
 					testWithPermissions(OC.PERMISSION_UPDATE | OC.PERMISSION_SHARE)
-				).toEqual(OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_UPDATE);
+				).toEqual(OC.PERMISSION_READ | OC.PERMISSION_UPDATE);
+			});
+			it('uses default permissions from capabilities', function() {
+				capsSpec.returns({
+					'files_sharing': {
+						'default_permissions': OC.PERMISSION_READ | OC.PERMISSION_CREATE | OC.PERMISSION_SHARE
+					}
+				});
+				configModel.set('isResharingAllowed', true);
+				model.set({
+					reshare: {},
+					shares: []
+				});
+				expect(
+					testWithPermissions(OC.PERMISSION_ALL)
+				).toEqual(OC.PERMISSION_READ | OC.PERMISSION_CREATE | OC.PERMISSION_SHARE);
 			});
 		});
 	});

--- a/lib/private/Settings/Admin/Sharing.php
+++ b/lib/private/Settings/Admin/Sharing.php
@@ -57,7 +57,37 @@ class Sharing implements ISettings {
 		$excludeGroupsList = !is_null(json_decode($excludedGroups))
 			? implode('|', json_decode($excludedGroups, true)) : '';
 
-		$permList = [
+		$parameters = [
+			// Built-In Sharing
+			'allowGroupSharing'                    => $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes'),
+			'allowLinks'                           => $this->config->getAppValue('core', 'shareapi_allow_links', 'yes'),
+			'allowPublicUpload'                    => $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes'),
+			'allowResharing'                       => $this->config->getAppValue('core', 'shareapi_allow_resharing', 'yes'),
+			'allowShareDialogUserEnumeration'      => $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes'),
+			'enforceLinkPassword'                  => Util::isPublicLinkPasswordRequired(),
+			'onlyShareWithGroupMembers'            => Share::shareWithGroupMembersOnly(),
+			'shareAPIEnabled'                      => $this->config->getAppValue('core', 'shareapi_enabled', 'yes'),
+			'shareDefaultExpireDateSet'            => $this->config->getAppValue('core', 'shareapi_default_expire_date', 'no'),
+			'shareExpireAfterNDays'                => $this->config->getAppValue('core', 'shareapi_expire_after_n_days', '7'),
+			'shareEnforceExpireDate'               => $this->config->getAppValue('core', 'shareapi_enforce_expire_date', 'no'),
+			'shareExcludeGroups'                   => $this->config->getAppValue('core', 'shareapi_exclude_groups', 'no') === 'yes',
+			'shareExcludedGroupsList'              => $excludeGroupsList,
+			'publicShareDisclaimerText'            => $this->config->getAppValue('core', 'shareapi_public_link_disclaimertext', null),
+			'enableLinkPasswordByDefault'          => $this->config->getAppValue('core', 'shareapi_enable_link_password_by_default', 'no'),
+			'shareApiDefaultPermissions'           => $this->config->getAppValue('core', 'shareapi_default_permissions', Constants::PERMISSION_ALL),
+			'shareApiDefaultPermissionsCheckboxes' => $this->getSharePermissionList(),
+		];
+
+		return new TemplateResponse('settings', 'settings/admin/sharing', $parameters, '');
+	}
+
+	/**
+	 * get share permission list for template
+	 *
+	 * @return array
+	 */
+	private function getSharePermissionList() {
+		return [
 			[
 				'id' => 'cancreate',
 				'label' => $this->l->t('Create'),
@@ -79,29 +109,6 @@ class Sharing implements ISettings {
 				'value' => Constants::PERMISSION_SHARE
 			],
 		];
-
-		$parameters = [
-			// Built-In Sharing
-			'allowGroupSharing'                    => $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes'),
-			'allowLinks'                           => $this->config->getAppValue('core', 'shareapi_allow_links', 'yes'),
-			'allowPublicUpload'                    => $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes'),
-			'allowResharing'                       => $this->config->getAppValue('core', 'shareapi_allow_resharing', 'yes'),
-			'allowShareDialogUserEnumeration'      => $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes'),
-			'enforceLinkPassword'                  => Util::isPublicLinkPasswordRequired(),
-			'onlyShareWithGroupMembers'            => Share::shareWithGroupMembersOnly(),
-			'shareAPIEnabled'                      => $this->config->getAppValue('core', 'shareapi_enabled', 'yes'),
-			'shareDefaultExpireDateSet'            => $this->config->getAppValue('core', 'shareapi_default_expire_date', 'no'),
-			'shareExpireAfterNDays'                => $this->config->getAppValue('core', 'shareapi_expire_after_n_days', '7'),
-			'shareEnforceExpireDate'               => $this->config->getAppValue('core', 'shareapi_enforce_expire_date', 'no'),
-			'shareExcludeGroups'                   => $this->config->getAppValue('core', 'shareapi_exclude_groups', 'no') === 'yes',
-			'shareExcludedGroupsList'              => $excludeGroupsList,
-			'publicShareDisclaimerText'            => $this->config->getAppValue('core', 'shareapi_public_link_disclaimertext', null),
-			'enableLinkPasswordByDefault'          => $this->config->getAppValue('core', 'shareapi_enable_link_password_by_default', 'no'),
-			'shareApiDefaultPermissions'           => $this->config->getAppValue('core', 'shareapi_default_permissions', Constants::PERMISSION_ALL),
-			'shareApiDefaultPermissionsCheckboxes' => $permList,
-		];
-
-		return new TemplateResponse('settings', 'settings/admin/sharing', $parameters, '');
 	}
 
 	/**

--- a/lib/private/Settings/Admin/Sharing.php
+++ b/lib/private/Settings/Admin/Sharing.php
@@ -28,7 +28,9 @@ namespace OC\Settings\Admin;
 
 use OC\Share\Share;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Constants;
 use OCP\IConfig;
+use OCP\IL10N;
 use OCP\Settings\ISettings;
 use OCP\Util;
 
@@ -36,11 +38,15 @@ class Sharing implements ISettings {
 	/** @var IConfig */
 	private $config;
 
+	/** @var IL10N */
+	private $l;
+
 	/**
 	 * @param IConfig $config
 	 */
-	public function __construct(IConfig $config) {
+	public function __construct(IConfig $config, IL10N $l) {
 		$this->config = $config;
+		$this->l = $l;
 	}
 
 	/**
@@ -51,23 +57,48 @@ class Sharing implements ISettings {
 		$excludeGroupsList = !is_null(json_decode($excludedGroups))
 			? implode('|', json_decode($excludedGroups, true)) : '';
 
+		$permList = [
+			[
+				'id' => 'cancreate',
+				'label' => $this->l->t('Create'),
+				'value' => Constants::PERMISSION_CREATE
+			],
+			[
+				'id' => 'canupdate',
+				'label' => $this->l->t('Change'),
+				'value' => Constants::PERMISSION_UPDATE
+			],
+			[
+				'id' => 'candelete',
+				'label' => $this->l->t('Delete'),
+				'value' => Constants::PERMISSION_DELETE
+			],
+			[
+				'id' => 'canshare',
+				'label' => $this->l->t('Share'),
+				'value' => Constants::PERMISSION_SHARE
+			],
+		];
+
 		$parameters = [
 			// Built-In Sharing
-			'allowGroupSharing'               => $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes'),
-			'allowLinks'                      => $this->config->getAppValue('core', 'shareapi_allow_links', 'yes'),
-			'allowPublicUpload'               => $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes'),
-			'allowResharing'                  => $this->config->getAppValue('core', 'shareapi_allow_resharing', 'yes'),
-			'allowShareDialogUserEnumeration' => $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes'),
-			'enforceLinkPassword'             => Util::isPublicLinkPasswordRequired(),
-			'onlyShareWithGroupMembers'       => Share::shareWithGroupMembersOnly(),
-			'shareAPIEnabled'                 => $this->config->getAppValue('core', 'shareapi_enabled', 'yes'),
-			'shareDefaultExpireDateSet'       => $this->config->getAppValue('core', 'shareapi_default_expire_date', 'no'),
-			'shareExpireAfterNDays'           => $this->config->getAppValue('core', 'shareapi_expire_after_n_days', '7'),
-			'shareEnforceExpireDate'          => $this->config->getAppValue('core', 'shareapi_enforce_expire_date', 'no'),
-			'shareExcludeGroups'              => $this->config->getAppValue('core', 'shareapi_exclude_groups', 'no') === 'yes',
-			'shareExcludedGroupsList'         => $excludeGroupsList,
-			'publicShareDisclaimerText'       => $this->config->getAppValue('core', 'shareapi_public_link_disclaimertext', null),
-			'enableLinkPasswordByDefault'     => $this->config->getAppValue('core', 'shareapi_enable_link_password_by_default', 'no'),
+			'allowGroupSharing'                    => $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes'),
+			'allowLinks'                           => $this->config->getAppValue('core', 'shareapi_allow_links', 'yes'),
+			'allowPublicUpload'                    => $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes'),
+			'allowResharing'                       => $this->config->getAppValue('core', 'shareapi_allow_resharing', 'yes'),
+			'allowShareDialogUserEnumeration'      => $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes'),
+			'enforceLinkPassword'                  => Util::isPublicLinkPasswordRequired(),
+			'onlyShareWithGroupMembers'            => Share::shareWithGroupMembersOnly(),
+			'shareAPIEnabled'                      => $this->config->getAppValue('core', 'shareapi_enabled', 'yes'),
+			'shareDefaultExpireDateSet'            => $this->config->getAppValue('core', 'shareapi_default_expire_date', 'no'),
+			'shareExpireAfterNDays'                => $this->config->getAppValue('core', 'shareapi_expire_after_n_days', '7'),
+			'shareEnforceExpireDate'               => $this->config->getAppValue('core', 'shareapi_enforce_expire_date', 'no'),
+			'shareExcludeGroups'                   => $this->config->getAppValue('core', 'shareapi_exclude_groups', 'no') === 'yes',
+			'shareExcludedGroupsList'              => $excludeGroupsList,
+			'publicShareDisclaimerText'            => $this->config->getAppValue('core', 'shareapi_public_link_disclaimertext', null),
+			'enableLinkPasswordByDefault'          => $this->config->getAppValue('core', 'shareapi_enable_link_password_by_default', 'no'),
+			'shareApiDefaultPermissions'           => $this->config->getAppValue('core', 'shareapi_default_permissions', Constants::PERMISSION_ALL),
+			'shareApiDefaultPermissionsCheckboxes' => $permList,
 		];
 
 		return new TemplateResponse('settings', 'settings/admin/sharing', $parameters, '');

--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -271,7 +271,7 @@ class Manager implements IManager {
 		}
 		if ($section === 'sharing') {
 			/** @var ISettings $form */
-			$form = new Admin\Sharing($this->config);
+			$form = new Admin\Sharing($this->config, $this->l);
 			$forms[$form->getPriority()] = [$form];
 		}
 		if ($section === 'additional') {

--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -28,6 +28,7 @@
 namespace OC\Template;
 
 use bantu\IniGetWrapper\IniGetWrapper;
+use OC\CapabilitiesManager;
 use OCP\App\IAppManager;
 use OCP\Defaults;
 use OCP\IConfig;
@@ -66,6 +67,9 @@ class JSConfigHelper {
 	/** @var IURLGenerator */
 	private $urlGenerator;
 
+	/** @var CapabilitiesManager */
+	private $capabilitiesManager;
+
 	/**
 	 * @param IL10N $l
 	 * @param Defaults $defaults
@@ -76,6 +80,7 @@ class JSConfigHelper {
 	 * @param IGroupManager $groupManager
 	 * @param IniGetWrapper $iniWrapper
 	 * @param IURLGenerator $urlGenerator
+	 * @param CapabilitiesManager $capabilitiesManager
 	 */
 	public function __construct(IL10N $l,
 								Defaults $defaults,
@@ -85,7 +90,8 @@ class JSConfigHelper {
 								IConfig $config,
 								IGroupManager $groupManager,
 								IniGetWrapper $iniWrapper,
-								IURLGenerator $urlGenerator) {
+								IURLGenerator $urlGenerator,
+								CapabilitiesManager $capabilitiesManager) {
 		$this->l = $l;
 		$this->defaults = $defaults;
 		$this->appManager = $appManager;
@@ -95,6 +101,7 @@ class JSConfigHelper {
 		$this->groupManager = $groupManager;
 		$this->iniWrapper = $iniWrapper;
 		$this->urlGenerator = $urlGenerator;
+		$this->capabilitiesManager = $capabilitiesManager;
 	}
 
 	public function getConfig() {
@@ -145,6 +152,8 @@ class JSConfigHelper {
 		} else {
 			$lastConfirmTimestamp = 0;
 		}
+
+		$capabilities = $this->capabilitiesManager->getCapabilities();
 
 		$array = [
 			"oc_debug" => $this->config->getSystemValue('debug', false) ? 'true' : 'false',
@@ -252,6 +261,7 @@ class JSConfigHelper {
 				'longFooter' => $this->defaults->getLongFooter(),
 				'folder' => \OC_Util::getTheme(),
 			]),
+			"oc_capabilities" => json_encode($capabilities),
 		];
 
 		if ($this->currentUser !== null) {

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -156,7 +156,8 @@ class TemplateLayout extends \OC_Template {
 					$this->config,
 					\OC::$server->getGroupManager(),
 					\OC::$server->getIniWrapper(),
-					\OC::$server->getURLGenerator()
+					\OC::$server->getURLGenerator(),
+					\OC::$server->getCapabilitiesManager()
 				);
 				$this->assign('inline_ocjs', $jsConfigHelper->getConfig());
 			} else {

--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -1030,6 +1030,13 @@ table.grid td.date {
 	.double-indent {
 		padding-left: 56px;
 	}
+	.nocheckbox {
+		padding-left: 20px;
+	}
+}
+
+#shareApiDefaultPermissionsSection label {
+	margin-right: 20px;
 }
 
 #fileSharingSettings h3 {

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -121,6 +121,28 @@ $(document).ready(function(){
 		}
 	});
 
+	$('#shareApiDefaultPermissionsSection input').change(function(ev) {
+		var $el = $('#shareApiDefaultPermissions');
+		var $target = $(ev.target);
+
+		var value = $el.val();
+		if ($target.is(':checked')) {
+			value = value | $target.val();
+		} else {
+			value = value & ~$target.val();
+		}
+
+		// always set read permission
+		value |= OC.PERMISSION_READ;
+
+		// this will trigger the field's change event and will save it
+		$el.val(value).change();
+
+		ev.preventDefault();
+
+		return false;
+	});
+
 	var savePublicShareDisclaimerText = _.debounce(function(value) {
 		var options = {
 			success: function() {

--- a/settings/templates/settings/admin/sharing.php
+++ b/settings/templates/settings/admin/sharing.php
@@ -78,18 +78,6 @@
 			   value="1" <?php if ($_['allowGroupSharing'] === 'yes') print_unescaped('checked="checked"'); ?> />
 		<label for="allowGroupSharing"><?php p($l->t('Allow sharing with groups'));?></label><br />
 	</p>
-	<p class="nocheckbox <?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
-		<input type="hidden" name="shareapi_default_permissions" id="shareApiDefaultPermissions" class="checkbox"
-			   value="<?php p($_['shareApiDefaultPermissions']) ?>" />
-		<?php p($l->t('Default user and group share permissions'));?>
-	</p>
-	<p id="shareApiDefaultPermissionsSection" class="indent <?php if ($_['shareAPIEnabled'] === 'no') p('hidden'); ?>">
-		<?php foreach ($_['shareApiDefaultPermissionsCheckboxes'] as $perm): ?>
-			<input type="checkbox" name="shareapi_default_permission_<?php p($perm['id']) ?>" id="shareapi_default_permission_<?php p($perm['id']) ?>"
-				   class="noautosave checkbox" value="<?php p($perm['value']) ?>" <?php if (($_['shareApiDefaultPermissions'] & $perm['value']) !== 0) print_unescaped('checked="checked"'); ?> />
-			<label for="shareapi_default_permission_<?php p($perm['id']) ?>"><?php p($perm['label']);?></label>
-		<?php endforeach ?>
-	</p>
 	<p class="<?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
 		<input type="checkbox" name="shareapi_only_share_with_group_members" id="onlyShareWithGroupMembers" class="checkbox"
 			   value="1" <?php if ($_['onlyShareWithGroupMembers']) print_unescaped('checked="checked"'); ?> />
@@ -117,5 +105,16 @@
 		<span id="publicShareDisclaimerStatus" class="msg" style="display:none"></span>
 		<br/>
 		<textarea placeholder="<?php p($l->t('This text will be shown on the public link upload page when the file list is hidden.')) ?>" id="publicShareDisclaimerText" <?php if ($_['publicShareDisclaimerText'] === null) { print_unescaped('class="hidden"'); } ?>><?php p($_['publicShareDisclaimerText']) ?></textarea>
+	</p>
+
+	<h3><?php p($l->t('Default share permissions'));?></h3>
+	<input type="hidden" name="shareapi_default_permissions" id="shareApiDefaultPermissions" class="checkbox"
+		   value="<?php p($_['shareApiDefaultPermissions']) ?>" />
+	<p id="shareApiDefaultPermissionsSection" class="indent <?php if ($_['shareAPIEnabled'] === 'no') p('hidden'); ?>">
+		<?php foreach ($_['shareApiDefaultPermissionsCheckboxes'] as $perm): ?>
+			<input type="checkbox" name="shareapi_default_permission_<?php p($perm['id']) ?>" id="shareapi_default_permission_<?php p($perm['id']) ?>"
+				   class="noautosave checkbox" value="<?php p($perm['value']) ?>" <?php if (($_['shareApiDefaultPermissions'] & $perm['value']) !== 0) print_unescaped('checked="checked"'); ?> />
+			<label for="shareapi_default_permission_<?php p($perm['id']) ?>"><?php p($perm['label']);?></label>
+		<?php endforeach ?>
 	</p>
 </div>

--- a/settings/templates/settings/admin/sharing.php
+++ b/settings/templates/settings/admin/sharing.php
@@ -78,6 +78,18 @@
 			   value="1" <?php if ($_['allowGroupSharing'] === 'yes') print_unescaped('checked="checked"'); ?> />
 		<label for="allowGroupSharing"><?php p($l->t('Allow sharing with groups'));?></label><br />
 	</p>
+	<p class="nocheckbox <?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
+		<input type="hidden" name="shareapi_default_permissions" id="shareApiDefaultPermissions" class="checkbox"
+			   value="<?php p($_['shareApiDefaultPermissions']) ?>" />
+		<?php p($l->t('Default user and group share permissions'));?>
+	</p>
+	<p id="shareApiDefaultPermissionsSection" class="indent <?php if ($_['shareAPIEnabled'] === 'no') p('hidden'); ?>">
+		<?php foreach ($_['shareApiDefaultPermissionsCheckboxes'] as $perm): ?>
+			<input type="checkbox" name="shareapi_default_permission_<?php p($perm['id']) ?>" id="shareapi_default_permission_<?php p($perm['id']) ?>"
+				   class="noautosave checkbox" value="<?php p($perm['value']) ?>" <?php if (($_['shareApiDefaultPermissions'] & $perm['value']) !== 0) print_unescaped('checked="checked"'); ?> />
+			<label for="shareapi_default_permission_<?php p($perm['id']) ?>"><?php p($perm['label']);?></label>
+		<?php endforeach ?>
+	</p>
 	<p class="<?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
 		<input type="checkbox" name="shareapi_only_share_with_group_members" id="onlyShareWithGroupMembers" class="checkbox"
 			   value="1" <?php if ($_['onlyShareWithGroupMembers']) print_unescaped('checked="checked"'); ?> />

--- a/tests/lib/Settings/Admin/SharingTest.php
+++ b/tests/lib/Settings/Admin/SharingTest.php
@@ -25,6 +25,7 @@ namespace Test\Settings\Admin;
 
 use OC\Settings\Admin\Sharing;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Constants;
 use OCP\IConfig;
 use OCP\IL10N;
 use Test\TestCase;
@@ -114,6 +115,11 @@ class SharingTest extends TestCase {
 			->method('getAppValue')
 			->with('core', 'shareapi_enable_link_password_by_default', 'no')
 			->willReturn('yes');
+		$this->config
+			->expects($this->at(13))
+			->method('getAppValue')
+			->with('core', 'shareapi_default_permissions', Constants::PERMISSION_ALL)
+			->willReturn(Constants::PERMISSION_ALL);
 
 		$expected = new TemplateResponse(
 			'settings',
@@ -133,7 +139,9 @@ class SharingTest extends TestCase {
 				'shareExcludeGroups'              => false,
 				'shareExcludedGroupsList'         => '',
 				'publicShareDisclaimerText'       => 'Lorem ipsum',
-				'enableLinkPasswordByDefault'     => 'yes'
+				'enableLinkPasswordByDefault'     => 'yes',
+				'shareApiDefaultPermissions'      => Constants::PERMISSION_ALL,
+				'shareApiDefaultPermissionsCheckboxes' => $this->invokePrivate($this->admin, 'getSharePermissionList', [])
 			],
 			''
 		);
@@ -207,6 +215,12 @@ class SharingTest extends TestCase {
 			->method('getAppValue')
 			->with('core', 'shareapi_enable_link_password_by_default', 'no')
 			->willReturn('yes');
+		$this->config
+			->expects($this->at(13))
+			->method('getAppValue')
+			->with('core', 'shareapi_default_permissions', Constants::PERMISSION_ALL)
+			->willReturn(Constants::PERMISSION_ALL);
+
 
 		$expected = new TemplateResponse(
 			'settings',
@@ -226,7 +240,9 @@ class SharingTest extends TestCase {
 				'shareExcludeGroups'              => true,
 				'shareExcludedGroupsList'         => 'NoSharers|OtherNoSharers',
 				'publicShareDisclaimerText'       => 'Lorem ipsum',
-				'enableLinkPasswordByDefault'     => 'yes'
+				'enableLinkPasswordByDefault'     => 'yes',
+				'shareApiDefaultPermissions'      => Constants::PERMISSION_ALL,
+				'shareApiDefaultPermissionsCheckboxes' => $this->invokePrivate($this->admin, 'getSharePermissionList', [])
 			],
 			''
 		);

--- a/tests/lib/Settings/Admin/SharingTest.php
+++ b/tests/lib/Settings/Admin/SharingTest.php
@@ -26,6 +26,7 @@ namespace Test\Settings\Admin;
 use OC\Settings\Admin\Sharing;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
+use OCP\IL10N;
 use Test\TestCase;
 
 class SharingTest extends TestCase {
@@ -33,13 +34,17 @@ class SharingTest extends TestCase {
 	private $admin;
 	/** @var IConfig */
 	private $config;
+	/** @var  IL10N|\PHPUnit_Framework_MockObject_MockObject */
+	private $l10n;
 
 	public function setUp() {
 		parent::setUp();
 		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
+		$this->l10n = $this->getMockBuilder(IL10N::class)->getMock();
 
 		$this->admin = new Sharing(
-			$this->config
+			$this->config,
+			$this->l10n
 		);
 	}
 

--- a/tests/lib/Settings/ManagerTest.php
+++ b/tests/lib/Settings/ManagerTest.php
@@ -209,7 +209,7 @@ class ManagerTest extends TestCase {
 
 	public function testGetAdminSettings() {
 		$this->assertEquals([
-			0 => [new Sharing($this->config)],
+			0 => [new Sharing($this->config, $this->l10n)],
 		], $this->manager->getAdminSettings('sharing'));
 	}
 


### PR DESCRIPTION
Let the admin configure the default share permissions

Possible look:

![default-share2](https://user-images.githubusercontent.com/1589737/33483375-d3078006-d69d-11e7-8637-03bf8e0fc917.png)

or (currently implemented)

![default-share1](https://user-images.githubusercontent.com/1589737/33483381-d89426aa-d69d-11e7-9a45-86489bd67fc1.png)

