### PR TITLE
Fixed migration type hint

### DIFF
--- a/core/Command/Db/Migrations/GenerateCommand.php
+++ b/core/Command/Db/Migrations/GenerateCommand.php
@@ -39,7 +39,7 @@ class GenerateCommand extends Command {
 		'<?php
 namespace {{namespace}};
 
-use Doctrine\DBAL\Schema\Schema;
+use OC\DB\SchemaWrapper;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
@@ -50,7 +50,7 @@ class {{classname}} extends SimpleMigrationStep {
 
 	/**
 	 * @param IOutput $output
-	 * @param \Closure $schemaClosure The `\Closure` returns a `Schema`
+	 * @param \Closure $schemaClosure The `\Closure` returns a `SchemaWrapper`
 	 * @param array $options
 	 * @since 13.0.0
 	 */
@@ -59,9 +59,9 @@ class {{classname}} extends SimpleMigrationStep {
 
 	/**
 	 * @param IOutput $output
-	 * @param \Closure $schemaClosure The `\Closure` returns a `Schema`
+	 * @param \Closure $schemaClosure The `\Closure` returns a `SchemaWrapper`
 	 * @param array $options
-	 * @return null|Schema
+	 * @return null|SchemaWrapper
 	 * @since 13.0.0
 	 */
 	public function changeSchema(IOutput $output, \Closure $schemaClosure, array $options) {
@@ -70,7 +70,7 @@ class {{classname}} extends SimpleMigrationStep {
 
 	/**
 	 * @param IOutput $output
-	 * @param \Closure $schemaClosure The `\Closure` returns a `Schema`
+	 * @param \Closure $schemaClosure The `\Closure` returns a `SchemaWrapper`
 	 * @param array $options
 	 * @since 13.0.0
 	 */

--- a/core/Command/Db/Migrations/GenerateFromSchemaFileCommand.php
+++ b/core/Command/Db/Migrations/GenerateFromSchemaFileCommand.php
@@ -91,7 +91,7 @@ class GenerateFromSchemaFileCommand extends GenerateCommand {
 	 */
 	protected function schemaToMigration(Schema $schema) {
 		$content = <<<'EOT'
-		/** @var Schema $schema */
+		/** @var SchemaWrapper $schema */
 		$schema = $schemaClosure();
 
 EOT;


### PR DESCRIPTION
The type hint seems to be wrong. It´s an instance of the Nc SchemaWrapper and not the Doctrine Schema. The SchemaWrapper has some differences and PHP 7 complains about the wrong type once type hint is added.

See: https://github.com/nextcloud/server/blob/master/lib/private/DB/MigrationService.php#L397

All in all the migrations are really nice 💪