### PR TITLE
Show hint that PHP 5.6 will not be supported in Nextcloud 14 anymore

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -122,6 +122,12 @@
 							type: OC.SetupChecks.MESSAGE_TYPE_INFO
 						});
 					}
+					if(data.phpSupported && data.phpSupported.version.substr(0, 3) === '5.6') {
+						messages.push({
+							msg: t('core', 'You are currently running PHP 5.6. The current major version of Nextcloud is the last that is supported on PHP 5.6. It is recommended to upgrade the PHP version to 7.0+ to be able to upgrade to Nextcloud 14.'),
+							type: OC.SetupChecks.MESSAGE_TYPE_INFO
+						});
+					}
 					if(!data.forwardedForHeadersWorking) {
 						messages.push({
 							msg: t('core', 'The reverse proxy header configuration is incorrect, or you are accessing Nextcloud from a trusted proxy. If not, this is a security issue and can allow an attacker to spoof their IP address as visible to the Nextcloud. Further information can be found in the <a target="_blank" rel="noreferrer noopener" href="{docLink}">documentation</a>.', {docLink: data.reverseProxyDocs}),

--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -238,7 +238,7 @@ class CheckSetupController extends Controller {
 	 * @return bool
 	 */
 	protected function isPhpOutdated() {
-		if (version_compare(PHP_VERSION, '5.5.0') === -1) {
+		if (version_compare(PHP_VERSION, '7.0.0', '<')) {
 			return true;
 		}
 


### PR DESCRIPTION
Looks then like this:

![bildschirmfoto 2017-12-04 um 22 51 42](https://user-images.githubusercontent.com/245432/33578156-cb55d420-d945-11e7-80c8-7fd084882776.png)

Fixes #7386 

* Feedback on the wording is very welcome.
* Should it be red or black (warning vs info)?
* Should it be combined with the other version info that is already present or is this too little?