### PR TITLE
Fix typos in config.sample.php

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -817,7 +817,6 @@ $CONFIG = array(
  * @see appcodechecker
  */
 
-
 /**
  * Previews
  *
@@ -1094,8 +1093,8 @@ $CONFIG = array(
  *
  * WARNING: FAILOVER_DISTRIBUTE is a not recommended setting and we strongly
  * suggest to not use it if you use Redis for file locking. Due to the way Redis
- * is synchronised it could happen, that the read for an existing lock is
- * scheduled to a slave that is not fully synchronised with the connected master
+ * is synchronized it could happen, that the read for an existing lock is
+ * scheduled to a slave that is not fully synchronized with the connected master
  * which then causes a FileLocked exception.
  *
  * See https://redis.io/topics/cluster-spec for details about the Redis cluster


### PR DESCRIPTION
Originally added in https://github.com/nextcloud/documentation/commit/f7af8893300ef3d9cef9e125d25d4d3b36a0e4d7#diff-cc42d41e3199bfcefb0487b5b9e8872a

