### PR TITLE
Allows adding of hex color to the theme-color

### DIFF
--- a/apps/theming/js/settings-admin.js
+++ b/apps/theming/js/settings-admin.js
@@ -206,7 +206,11 @@ $(document).ready(function () {
 	});
 
 	$('#theming-color').change(function (e) {
-		setThemingValue('color', '#' + $(this).val());
+		var color = $(this).val();
+		if (color.indexOf('#') !== 0) {
+			color = '#' + color;
+		}
+		setThemingValue('color', color);
 	});
 
 	$('.theme-undo').click(function (e) {

--- a/apps/theming/templates/settings-admin.php
+++ b/apps/theming/templates/settings-admin.php
@@ -62,7 +62,7 @@ style('theming', 'settings-admin');
 	<div>
 		<label>
 			<span><?php p($l->t('Color')) ?></span>
-			<input id="theming-color" type="text" class="jscolor" maxlength="6" value="<?php p($_['color']) ?>" />
+			<input id="theming-color" type="text" class="jscolor" data-jscolor="{hash:true}" maxlength="7" value="<?php p($_['color']) ?>" />
 			<div data-setting="color" data-toggle="tooltip" data-original-title="<?php p($l->t('Reset to default')); ?>" class="theme-undo icon icon-history"></div>
 		</label>
 	</div>

--- a/tests/acceptance/features/app-theming.feature
+++ b/tests/acceptance/features/app-theming.feature
@@ -5,19 +5,19 @@ Feature: app-theming
     And I visit the settings page
     And I open the "Theming" section
     And I see that the color selector in the Theming app has loaded
-    And I see that the header color is "0082C9"
-    When I set the "Color" parameter in the Theming app to "C9C9C9"
+    And I see that the header color is "#0082C9"
+    When I set the "Color" parameter in the Theming app to "#C9C9C9"
     Then I see that the parameters in the Theming app are eventually saved
-    And I see that the header color is "C9C9C9"
+    And I see that the header color is "#C9C9C9"
 
   Scenario: resetting the color updates the header color
     Given I am logged in as the admin
     And I visit the settings page
     And I open the "Theming" section
     And I see that the color selector in the Theming app has loaded
-    And I set the "Color" parameter in the Theming app to "C9C9C9"
+    And I set the "Color" parameter in the Theming app to "#C9C9C9"
     And I see that the parameters in the Theming app are eventually saved
-    And I see that the header color is "C9C9C9"
+    And I see that the header color is "#C9C9C9"
     When I reset the "Color" parameter in the Theming app to its default value
     Then I see that the parameters in the Theming app are eventually saved
-    And I see that the header color is "0082C9"
+    And I see that the header color is "#0082C9"


### PR DESCRIPTION
Squashed version of #7371 - fixes #7158

Thanks to @abijeet

I tested it and it works 👍 


---


I've done the following,

1. Increased max length to allow for 7 characters.
2. Checking and adding # if not already present on the `change` event.
3. Added `jscolor {hash:true}` class so that user does not enter a 7 character colour by mistake.

