### PR TITLE
Fix email buttons for white theme

### DIFF
--- a/apps/theming/lib/Capabilities.php
+++ b/apps/theming/lib/Capabilities.php
@@ -75,7 +75,7 @@ class Capabilities implements IPublicCapability {
 				'url' => $this->theming->getBaseUrl(),
 				'slogan' => $this->theming->getSlogan(),
 				'color' => $color,
-				'color-text' => $this->util->invertTextColor($color) ? '#000000' : '#FFFFFF',
+				'color-text' => $this->theming->getTextColorPrimary(),
 				'color-element' => $this->util->elementColor($color),
 				'logo' => $this->url->getAbsoluteURL($this->theming->getLogo()),
 				'background' => $backgroundLogo === 'backgroundColor' ?

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -256,13 +256,8 @@ class ThemingDefaults extends \OC_Defaults {
 		$variables['image-login-plain'] = 'false';
 
 		if ($this->config->getAppValue('theming', 'color', null) !== null) {
-			if ($this->util->invertTextColor($this->getColorPrimary())) {
-				$colorPrimaryText = '#000000';
-			} else {
-				$colorPrimaryText = '#ffffff';
-			}
 			$variables['color-primary'] = $this->getColorPrimary();
-			$variables['color-primary-text'] = $colorPrimaryText;
+			$variables['color-primary-text'] = $this->getTextColorPrimary();
 			$variables['color-primary-element'] = $this->util->elementColor($this->getColorPrimary());
 		}
 
@@ -377,5 +372,14 @@ class ThemingDefaults extends \OC_Defaults {
 		}
 
 		return $returnValue;
+	}
+
+	/**
+	 * Color of text in the header and primary buttons
+	 *
+	 * @return string
+	 */
+	public function getTextColorPrimary() {
+		return $this->util->invertTextColor($this->getColorPrimary()) ? '#000000' : '#ffffff';
 	}
 }

--- a/apps/theming/tests/CapabilitiesTest.php
+++ b/apps/theming/tests/CapabilitiesTest.php
@@ -65,7 +65,7 @@ class CapabilitiesTest extends TestCase  {
 
 	public function dataGetCapabilities() {
 		return [
-			['name', 'url', 'slogan', '#FFFFFF', 'logo', 'background', 'http://absolute/', [
+			['name', 'url', 'slogan', '#FFFFFF', '#000000', 'logo', 'background', 'http://absolute/', [
 				'name' => 'name',
 				'url' => 'url',
 				'slogan' => 'slogan',
@@ -75,22 +75,22 @@ class CapabilitiesTest extends TestCase  {
 				'logo' => 'http://absolute/logo',
 				'background' => 'http://absolute/background',
 			]],
-			['name1', 'url2', 'slogan3', '#01e4a0', 'logo5', 'background6', 'http://localhost/', [
+			['name1', 'url2', 'slogan3', '#01e4a0', '#ffffff', 'logo5', 'background6', 'http://localhost/', [
 				'name' => 'name1',
 				'url' => 'url2',
 				'slogan' => 'slogan3',
 				'color' => '#01e4a0',
-				'color-text' => '#FFFFFF',
+				'color-text' => '#ffffff',
 				'color-element' => '#01e4a0',
 				'logo' => 'http://localhost/logo5',
 				'background' => 'http://localhost/background6',
 			]],
-			['name1', 'url2', 'slogan3', '#000000', 'logo5', 'backgroundColor', 'http://localhost/', [
+			['name1', 'url2', 'slogan3', '#000000', '#ffffff', 'logo5', 'backgroundColor', 'http://localhost/', [
 				'name' => 'name1',
 				'url' => 'url2',
 				'slogan' => 'slogan3',
 				'color' => '#000000',
-				'color-text' => '#FFFFFF',
+				'color-text' => '#ffffff',
 				'color-element' => '#000000',
 				'logo' => 'http://localhost/logo5',
 				'background' => '#000000',
@@ -105,11 +105,12 @@ class CapabilitiesTest extends TestCase  {
 	 * @param string $slogan
 	 * @param string $color
 	 * @param string $logo
+	 * @param string $textColor
 	 * @param string $background
 	 * @param string $baseUrl
 	 * @param string[] $expected
 	 */
-	public function testGetCapabilities($name, $url, $slogan, $color, $logo, $background, $baseUrl, array $expected) {
+	public function testGetCapabilities($name, $url, $slogan, $color, $textColor, $logo, $background, $baseUrl, array $expected) {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->willReturn($background);
@@ -128,6 +129,9 @@ class CapabilitiesTest extends TestCase  {
 		$this->theming->expects($this->once())
 			->method('getLogo')
 			->willReturn($logo);
+		$this->theming->expects($this->once())
+			->method('getTextColorPrimary')
+			->willReturn($textColor);
 
 		if($background !== 'backgroundColor') {
 			$this->theming->expects($this->once())

--- a/lib/private/Mail/EMailTemplate.php
+++ b/lib/private/Mail/EMailTemplate.php
@@ -234,7 +234,7 @@ EOF;
 										<table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%%">
 											<tr style="padding:0;text-align:left;vertical-align:top">
 												<td style="-moz-hyphens:auto;-webkit-hyphens:auto;Margin:0;background:%s;border:0 solid %s;border-collapse:collapse!important;color:#fefefe;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:400;hyphens:auto;line-height:1.3;margin:0;padding:0;text-align:left;vertical-align:top;word-wrap:break-word">
-													<a href="%s" style="Margin:0;border:0 solid %s;border-radius:2px;color:#fefefe;display:inline-block;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:regular;line-height:1.3;margin:0;padding:10px 25px 10px 25px;text-align:left;text-decoration:none">%s</a>
+													<a href="%s" style="Margin:0;border:0 solid %s;border-radius:2px;color:%s;display:inline-block;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:regular;line-height:1.3;margin:0;padding:10px 25px 10px 25px;text-align:left;outline:1px solid %s;text-decoration:none">%s</a>
 												</td>
 											</tr>
 										</table>
@@ -287,7 +287,7 @@ EOF;
 										<table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%%">
 											<tr style="padding:0;text-align:left;vertical-align:top">
 												<td style="-moz-hyphens:auto;-webkit-hyphens:auto;Margin:0;background:%s;border:0 solid %s;border-collapse:collapse!important;color:#fefefe;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:400;hyphens:auto;line-height:1.3;margin:0;padding:0;text-align:left;vertical-align:top;word-wrap:break-word">
-													<a href="%s" style="Margin:0;border:0 solid %s;border-radius:2px;color:#fefefe;display:inline-block;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:regular;line-height:1.3;margin:0;padding:10px 25px 10px 25px;text-align:left;text-decoration:none">%s</a>
+													<a href="%s" style="Margin:0;border:0 solid %s;border-radius:2px;color:%s;display:inline-block;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:regular;line-height:1.3;margin:0;padding:10px 25px 10px 25px;text-align:left;outline:1px solid %s;text-decoration:none">%s</a>
 												</td>
 											</tr>
 										</table>
@@ -531,8 +531,9 @@ EOF;
 		$this->ensureBodyListClosed();
 
 		$color = $this->themingDefaults->getColorPrimary();
+		$textColor = $this->themingDefaults->getTextColorPrimary();
 
-		$this->htmlBody .= vsprintf($this->buttonGroup, [$color, $color, $urlLeft, $color, htmlspecialchars($textLeft), $urlRight, htmlspecialchars($textRight)]);
+		$this->htmlBody .= vsprintf($this->buttonGroup, [$color, $color, $urlLeft, $color, $textColor, $textColor, htmlspecialchars($textLeft), $urlRight, htmlspecialchars($textRight)]);
 		$this->plainBody .= $plainTextLeft . ': ' . $urlLeft . PHP_EOL;
 		$this->plainBody .= $plainTextRight . ': ' . $urlRight . PHP_EOL . PHP_EOL;
 
@@ -561,7 +562,8 @@ EOF;
 		}
 
 		$color = $this->themingDefaults->getColorPrimary();
-		$this->htmlBody .= vsprintf($this->button, [$color, $color, $url, $color, htmlspecialchars($text)]);
+		$textColor = $this->themingDefaults->getTextColorPrimary();
+		$this->htmlBody .= vsprintf($this->button, [$color, $color, $url, $color, $textColor, $textColor, htmlspecialchars($text)]);
 
 		if ($plainText !== false) {
 			$this->plainBody .= $plainText . ': ';

--- a/lib/private/legacy/defaults.php
+++ b/lib/private/legacy/defaults.php
@@ -50,6 +50,7 @@ class OC_Defaults {
 	private $defaultDocVersion;
 	private $defaultSlogan;
 	private $defaultColorPrimary;
+	private $defaultTextColorPrimary;
 
 	public function __construct() {
 		$this->l = \OC::$server->getL10N('lib');
@@ -66,6 +67,7 @@ class OC_Defaults {
 		$this->defaultDocVersion = '12'; // used to generate doc links
 		$this->defaultSlogan = $this->l->t('a safe home for all your data');
 		$this->defaultColorPrimary = '#0082c9';
+		$this->defaultTextColorPrimary = '#ffffff';
 
 		$themePath = OC::$SERVERROOT . '/themes/' . OC_Util::getTheme() . '/defaults.php';
 		if (file_exists($themePath)) {
@@ -317,5 +319,12 @@ class OC_Defaults {
 			$logo = \OC::$server->getURLGenerator()->imagePath('core', 'logo.png');
 		}
 	    return $logo . '?v=' . hash('sha1', implode('.', \OCP\Util::getVersion()));
+	}
+
+	public function getTextColorPrimary() {
+		if ($this->themeExist('getTextColorPrimary')) {
+			return $this->theme->getTextColorPrimary();
+		}
+		return $this->defaultTextColorPrimary;
 	}
 }

--- a/lib/public/Defaults.php
+++ b/lib/public/Defaults.php
@@ -213,4 +213,13 @@ class Defaults {
 	public function getTitle() {
 		return $this->defaults->getTitle();
 	}
+
+	/**
+	 * Returns primary color
+	 * @return string
+	 * @since 13.0.0
+	 */
+	public function getTextColorPrimary() {
+		return $this->defaults->getTextColorPrimary();
+	}
 }

--- a/tests/Settings/Mailer/NewUserMailHelperTest.php
+++ b/tests/Settings/Mailer/NewUserMailHelperTest.php
@@ -157,6 +157,10 @@ class NewUserMailHelperTest extends TestCase {
 			->expects($this->any())
 			->method('getName')
 			->willReturn('TestCloud');
+		$this->defaults
+			->expects($this->any())
+			->method('getTextColorPrimary')
+			->willReturn('#ffffff');
 
 		$expectedHtmlBody = <<<EOF
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -281,7 +285,7 @@ class NewUserMailHelperTest extends TestCase {
 										<table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
 											<tr style="padding:0;text-align:left;vertical-align:top">
 												<td style="-moz-hyphens:auto;-webkit-hyphens:auto;Margin:0;background:;border:0 solid ;border-collapse:collapse!important;color:#fefefe;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:400;hyphens:auto;line-height:1.3;margin:0;padding:0;text-align:left;vertical-align:top;word-wrap:break-word">
-													<a href="https://example.com/resetPassword/MySuperLongSecureRandomToken" style="Margin:0;border:0 solid ;border-radius:2px;color:#fefefe;display:inline-block;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:regular;line-height:1.3;margin:0;padding:10px 25px 10px 25px;text-align:left;text-decoration:none">Set your password</a>
+													<a href="https://example.com/resetPassword/MySuperLongSecureRandomToken" style="Margin:0;border:0 solid ;border-radius:2px;color:#ffffff;display:inline-block;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:regular;line-height:1.3;margin:0;padding:10px 25px 10px 25px;text-align:left;outline:1px solid #ffffff;text-decoration:none">Set your password</a>
 												</td>
 											</tr>
 										</table>
@@ -390,6 +394,10 @@ EOF;
 			->expects($this->any())
 			->method('getName')
 			->willReturn('TestCloud');
+		$this->defaults
+			->expects($this->any())
+			->method('getTextColorPrimary')
+			->willReturn('#ffffff');
 
 		$expectedHtmlBody = <<<EOF
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -514,7 +522,7 @@ EOF;
 										<table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
 											<tr style="padding:0;text-align:left;vertical-align:top">
 												<td style="-moz-hyphens:auto;-webkit-hyphens:auto;Margin:0;background:;border:0 solid ;border-collapse:collapse!important;color:#fefefe;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:400;hyphens:auto;line-height:1.3;margin:0;padding:0;text-align:left;vertical-align:top;word-wrap:break-word">
-													<a href="https://example.com/" style="Margin:0;border:0 solid ;border-radius:2px;color:#fefefe;display:inline-block;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:regular;line-height:1.3;margin:0;padding:10px 25px 10px 25px;text-align:left;text-decoration:none">Go to TestCloud</a>
+													<a href="https://example.com/" style="Margin:0;border:0 solid ;border-radius:2px;color:#ffffff;display:inline-block;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:regular;line-height:1.3;margin:0;padding:10px 25px 10px 25px;text-align:left;outline:1px solid #ffffff;text-decoration:none">Go to TestCloud</a>
 												</td>
 											</tr>
 										</table>

--- a/tests/data/emails/new-account-email-custom.html
+++ b/tests/data/emails/new-account-email-custom.html
@@ -120,7 +120,7 @@
 										<table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
 											<tr style="padding:0;text-align:left;vertical-align:top">
 												<td style="-moz-hyphens:auto;-webkit-hyphens:auto;Margin:0;background:#0082c9;border:0 solid #0082c9;border-collapse:collapse!important;color:#fefefe;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:400;hyphens:auto;line-height:1.3;margin:0;padding:0;text-align:left;vertical-align:top;word-wrap:break-word">
-													<a href="https://example.org/resetPassword/123" style="Margin:0;border:0 solid #0082c9;border-radius:2px;color:#fefefe;display:inline-block;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:regular;line-height:1.3;margin:0;padding:10px 25px 10px 25px;text-align:left;text-decoration:none">Set your password</a>
+													<a href="https://example.org/resetPassword/123" style="Margin:0;border:0 solid #0082c9;border-radius:2px;color:#ffffff;display:inline-block;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:regular;line-height:1.3;margin:0;padding:10px 25px 10px 25px;text-align:left;outline:1px solid #ffffff;text-decoration:none">Set your password</a>
 												</td>
 											</tr>
 										</table>

--- a/tests/data/emails/new-account-email-single-button.html
+++ b/tests/data/emails/new-account-email-single-button.html
@@ -120,7 +120,7 @@
 										<table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
 											<tr style="padding:0;text-align:left;vertical-align:top">
 												<td style="-moz-hyphens:auto;-webkit-hyphens:auto;Margin:0;background:#0082c9;border:0 solid #0082c9;border-collapse:collapse!important;color:#fefefe;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:400;hyphens:auto;line-height:1.3;margin:0;padding:0;text-align:left;vertical-align:top;word-wrap:break-word">
-													<a href="https://example.org/resetPassword/123" style="Margin:0;border:0 solid #0082c9;border-radius:2px;color:#fefefe;display:inline-block;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:regular;line-height:1.3;margin:0;padding:10px 25px 10px 25px;text-align:left;text-decoration:none">Set your password</a>
+													<a href="https://example.org/resetPassword/123" style="Margin:0;border:0 solid #0082c9;border-radius:2px;color:#ffffff;display:inline-block;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:regular;line-height:1.3;margin:0;padding:10px 25px 10px 25px;text-align:left;outline:1px solid #ffffff;text-decoration:none">Set your password</a>
 												</td>
 											</tr>
 										</table>

--- a/tests/data/emails/new-account-email.html
+++ b/tests/data/emails/new-account-email.html
@@ -120,7 +120,7 @@
 										<table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
 											<tr style="padding:0;text-align:left;vertical-align:top">
 												<td style="-moz-hyphens:auto;-webkit-hyphens:auto;Margin:0;background:#0082c9;border:0 solid #0082c9;border-collapse:collapse!important;color:#fefefe;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:400;hyphens:auto;line-height:1.3;margin:0;padding:0;text-align:left;vertical-align:top;word-wrap:break-word">
-													<a href="https://example.org/resetPassword/123" style="Margin:0;border:0 solid #0082c9;border-radius:2px;color:#fefefe;display:inline-block;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:regular;line-height:1.3;margin:0;padding:10px 25px 10px 25px;text-align:left;text-decoration:none">Set your password</a>
+													<a href="https://example.org/resetPassword/123" style="Margin:0;border:0 solid #0082c9;border-radius:2px;color:#ffffff;display:inline-block;font-family:Lucida Grande,Geneva,Verdana,sans-serif;font-size:16px;font-weight:regular;line-height:1.3;margin:0;padding:10px 25px 10px 25px;text-align:left;outline:1px solid #ffffff;text-decoration:none">Set your password</a>
 												</td>
 											</tr>
 										</table>

--- a/tests/lib/Mail/EMailTemplateTest.php
+++ b/tests/lib/Mail/EMailTemplateTest.php
@@ -68,6 +68,10 @@ class EMailTemplateTest extends TestCase {
 			->expects($this->any())
 			->method('getName')
 			->willReturn('TestCloud');
+		$this->defaults
+			->expects($this->any())
+			->method('getTextColorPrimary')
+			->willReturn('#ffffff');
 		$this->urlGenerator
 			->expects($this->once())
 			->method('getAbsoluteURL')
@@ -109,6 +113,10 @@ class EMailTemplateTest extends TestCase {
 			->expects($this->any())
 			->method('getLogo')
 			->willReturn('/img/logo-mail-header.png');
+		$this->defaults
+			->expects($this->any())
+			->method('getTextColorPrimary')
+			->willReturn('#ffffff');
 		$this->urlGenerator
 			->expects($this->once())
 			->method('getAbsoluteURL')
@@ -148,6 +156,10 @@ class EMailTemplateTest extends TestCase {
 			->expects($this->any())
 			->method('getLogo')
 			->willReturn('/img/logo-mail-header.png');
+		$this->defaults
+			->expects($this->any())
+			->method('getTextColorPrimary')
+			->willReturn('#ffffff');
 		$this->urlGenerator
 			->expects($this->once())
 			->method('getAbsoluteURL')
@@ -189,6 +201,10 @@ class EMailTemplateTest extends TestCase {
 			->expects($this->any())
 			->method('getLogo')
 			->willReturn('/img/logo-mail-header.png');
+		$this->defaults
+			->expects($this->any())
+			->method('getTextColorPrimary')
+			->willReturn('#ffffff');
 		$this->urlGenerator
 			->expects($this->once())
 			->method('getAbsoluteURL')


### PR DESCRIPTION
If the theming app has set the color set to white the button in the emails where white with white text. This fixes that and introduces the `getTextColorPrimary` to the defaults interface to make the color calculation consistent.

<img width="816" alt="bildschirmfoto 2017-12-08 um 12 11 31" src="https://user-images.githubusercontent.com/245432/33763725-d9be9fc8-dc11-11e7-922b-c576861078a3.png">
<img width="678" alt="bildschirmfoto 2017-12-08 um 12 15 40" src="https://user-images.githubusercontent.com/245432/33763726-d9db54b0-dc11-11e7-8c2d-cd11bd9fb118.png">
