### PR TITLE
Fix constructor spy in unit test with Sinon 4.1.3

### DIFF
--- a/apps/files_sharing/tests/js/shareSpec.js
+++ b/apps/files_sharing/tests/js/shareSpec.js
@@ -498,7 +498,7 @@ describe('OCA.Sharing.Util tests', function() {
 			var changeHandler = sinon.stub();
 			fileInfoModel.on('change', changeHandler);
 
-			shareTabSpy.getCall(0).thisValue.trigger('sharesChanged', shareModel);
+			shareTabSpy.getCall(0).returnValue.trigger('sharesChanged', shareModel);
 
 			expect(changeHandler.calledOnce).toEqual(true);
 			expect(changeHandler.getCall(0).args[0].changed).toEqual({


### PR DESCRIPTION
**TL;DR;**

When spying on a constructor using Sinon the objects created by the constructor are got using `spy.getCall(XXX).returnValue`.

**All the long and boring details**

[As explained in the MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new#Description), `new Foo(...)` is executed in three steps:
  1. First a new object that inherits from `Foo.prototype` is created.
  2. Then the constructor function `Foo` is called with `this` bound to that new object.
  3. Finally the object returned by the constructor, or the object created in the first step if none is returned, becomes the result of the whole new expression.

When a constructor (or any other function) is spied using Sinon the original constructor is [replaced](https://github.com/ProLoser/sinon/blob/32e451636688c2e98f974b8523fb0df5afa2ccc0/lib/sinon/spy.js#L35) by a [proxy](https://github.com/ProLoser/sinon/blob/32e451636688c2e98f974b8523fb0df5afa2ccc0/lib/sinon/spy.js#L152-L165). When the proxy is called it will record [the arguments it was called with](https://github.com/ProLoser/sinon/blob/32e451636688c2e98f974b8523fb0df5afa2ccc0/lib/sinon/spy.js#L173-L182), call the original constructor, and finally record [the value returned or the exceptions thrown](https://github.com/ProLoser/sinon/blob/32e451636688c2e98f974b8523fb0df5afa2ccc0/lib/sinon/spy.js#L205-L210) by the original constructor.

Before Sinon 4.1.3 when the proxy was called using the `new` operator [the proxy called the original constructor directly](https://github.com/sinonjs/sinon/blob/32e451636688c2e98f974b8523fb0df5afa2ccc0/lib/sinon/spy.js#L193), passing it the `thisValue`, which was the object created in step 1 above. If the original constructor function did not return an object (and note that this is the most common case, as the value returned by a constructor is usually `undefined`; as explained above `new` is the one that returns the created object when the constructor returns no value) then [`returnValue` was set to `thisValue`](https://github.com/sinonjs/sinon/blob/32e451636688c2e98f974b8523fb0df5afa2ccc0/lib/sinon/spy.js#L197); this is the value returned by the proxy to `new`, and thus is the value returned by the whole `new` expression as explained in the step 3. Therefore, before Sinon 4.1.3, `spy.getCall(XXX).thisValue` and `spy.getCall(XXX).returnValue` had (if the constructor returned no value, like in the failing test) the same value.

[This has changed in Sinon 4.1.3](https://github.com/sinonjs/sinon/pull/1626), as now when the proxy is called using the `new` operator [the proxy calls the original constructor using `new` too](https://github.com/sinonjs/sinon/commit/911c498dc14dc4034ba019526bf58f8b24d77da0#diff-339f7c512e23814b998d0ec1e100c70eR199). When `new` is called inside the proxy the three steps outlined above happen again: a new object is created, the original constructor is called with `this` bound to that object, and the object is returned as the result of the whole `new (bind.apply(this.func || func, [thisValue].concat(args)))()` expression; as `returnValue` is an object [it is not replaced by `thisValue`](https://github.com/sinonjs/sinon/pull/1626/files#diff-339f7c512e23814b998d0ec1e100c70eR202) and thus `returnValue` is the value returned by the proxy to the `new` operator that called it.

_Hey, wait a minute, when the original constructor is called inside the proxy it is bound to `thisValue`, so when `new` calls the original constructor in the step 2 it will use `thisValue` instead of the newly created object as `this`, right?_ Nope, [as explained again in the MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind#Parameters) when a function is bound `this` is ignored if the function is called by `new`.

Therefore, in Sinon 4.1.3, `thisValue` contains the object created by `new proxy`, but `returnValue` contains the real object created by `new originalConstructor` inside the proxy and also returned by the outermost `new` expression. That is, `returnValue` is the one you want to use.

Seriously, are you still reading this? Well, thanks :-) It is great that someone else besides me read it; it seems that I did not waste my time after all :-P
