### PR TITLE
Catch the errors related to untrusted self signed certificates for federation

### DIFF
--- a/apps/federation/lib/BackgroundJob/GetSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/GetSharedSecret.php
@@ -32,6 +32,8 @@ namespace OCA\Federation\BackgroundJob;
 
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Ring\Exception\RingException;
 use OC\BackgroundJob\JobList;
 use OC\BackgroundJob\Job;
 use OCA\Federation\DbHandler;
@@ -197,7 +199,10 @@ class GetSharedSecret extends Job {
 			} else {
 				$this->logger->info($target . ' responded with a ' . $status . ' containing: ' . $e->getMessage(), ['app' => 'federation']);
 			}
-		} catch (ConnectException $e) {
+		} catch (RequestException $e) {
+			$status = -1; // There is no status code if we could not connect
+			$this->logger->info('Could not connect to ' . $target, ['app' => 'federation']);
+		} catch (RingException $e) {
 			$status = -1; // There is no status code if we could not connect
 			$this->logger->info('Could not connect to ' . $target, ['app' => 'federation']);
 		} catch (\Exception $e) {

--- a/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
@@ -33,6 +33,8 @@ namespace OCA\Federation\BackgroundJob;
 
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Ring\Exception\RingException;
 use OC\BackgroundJob\JobList;
 use OC\BackgroundJob\Job;
 use OCA\Federation\DbHandler;
@@ -197,7 +199,10 @@ class RequestSharedSecret extends Job {
 			} else {
 				$this->logger->info($target . ' responded with a ' . $status . ' containing: ' . $e->getMessage(), ['app' => 'federation']);
 			}
-		} catch (ConnectException $e) {
+		} catch (RequestException $e) {
+			$status = -1; // There is no status code if we could not connect
+			$this->logger->info('Could not connect to ' . $target, ['app' => 'federation']);
+		} catch (RingException $e) {
 			$status = -1; // There is no status code if we could not connect
 			$this->logger->info('Could not connect to ' . $target, ['app' => 'federation']);
 		} catch (\Exception $e) {

--- a/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
@@ -29,6 +29,7 @@ namespace OCA\Federation\Tests\BackgroundJob;
 
 
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Ring\Exception\RingException;
 use OCA\Federation\BackgroundJob\GetSharedSecret;
 use OCA\Files_Sharing\Tests\TestCase;
 use OCA\Federation\DbHandler;
@@ -307,6 +308,43 @@ class GetSharedSecretTest extends TestCase {
 					'connect_timeout' => 3,
 				]
 			)->willThrowException($this->createMock(ConnectException::class));
+
+		$this->dbHandler->expects($this->never())->method('addToken');
+		$this->trustedServers->expects($this->never())->method('addSharedSecret');
+
+		$this->invokePrivate($this->getSharedSecret, 'run', [$argument]);
+
+		$this->assertTrue($this->invokePrivate($this->getSharedSecret, 'retainJob'));
+	}
+
+	public function testRunRingException() {
+		$target = 'targetURL';
+		$source = 'sourceURL';
+		$token = 'token';
+
+		$argument = ['url' => $target, 'token' => $token];
+
+		$this->timeFactory->method('getTime')
+			->willReturn(42);
+
+		$this->urlGenerator
+			->expects($this->once())
+			->method('getAbsoluteURL')
+			->with('/')
+			->willReturn($source);
+		$this->httpClient->expects($this->once())->method('get')
+			->with(
+				$target . '/ocs/v2.php/apps/federation/api/v1/shared-secret?format=json',
+				[
+					'query' =>
+						[
+							'url' => $source,
+							'token' => $token
+						],
+					'timeout' => 3,
+					'connect_timeout' => 3,
+				]
+			)->willThrowException($this->createMock(RingException::class));
 
 		$this->dbHandler->expects($this->never())->method('addToken');
 		$this->trustedServers->expects($this->never())->method('addSharedSecret');

--- a/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
@@ -28,6 +28,7 @@ namespace OCA\Federation\Tests\BackgroundJob;
 
 
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Ring\Exception\RingException;
 use OCA\Federation\BackgroundJob\RequestSharedSecret;
 use OCA\Federation\DbHandler;
 use OCA\Federation\TrustedServers;
@@ -294,6 +295,43 @@ class RequestSharedSecretTest extends TestCase {
 					'connect_timeout' => 3,
 				]
 			)->willThrowException($this->createMock(ConnectException::class));
+
+		$this->dbHandler->expects($this->never())->method('addToken');
+
+		$this->invokePrivate($this->requestSharedSecret, 'run', [$argument]);
+		$this->assertTrue($this->invokePrivate($this->requestSharedSecret, 'retainJob'));
+	}
+
+	public function testRunRingException() {
+		$target = 'targetURL';
+		$source = 'sourceURL';
+		$token = 'token';
+
+		$argument = ['url' => $target, 'token' => $token];
+
+		$this->timeFactory->method('getTime')->willReturn(42);
+
+		$this->urlGenerator
+			->expects($this->once())
+			->method('getAbsoluteURL')
+			->with('/')
+			->willReturn($source);
+
+		$this->httpClient
+			->expects($this->once())
+			->method('post')
+			->with(
+				$target . '/ocs/v2.php/apps/federation/api/v1/request-shared-secret?format=json',
+				[
+					'body' =>
+						[
+							'url' => $source,
+							'token' => $token
+						],
+					'timeout' => 3,
+					'connect_timeout' => 3,
+				]
+			)->willThrowException($this->createMock(RingException::class));
 
 		$this->dbHandler->expects($this->never())->method('addToken');
 


### PR DESCRIPTION
Found in our sentry setup.

Basically catch more generic exceptions. As well as the ringexceptions. They basically can happen for some weird curl reasons. Just catch them and log. Since the admin can't help what curl is getting back anyway.