### PR TITLE
Properly detect if fopen fails for txt previews

### DIFF
--- a/lib/private/Preview/TXT.php
+++ b/lib/private/Preview/TXT.php
@@ -46,6 +46,11 @@ class TXT extends Provider {
 	 */
 	public function getThumbnail($path, $maxX, $maxY, $scalingup, $fileview) {
 		$content = $fileview->fopen($path, 'r');
+
+		if ($content === false) {
+			return false;
+		}
+
 		$content = stream_get_contents($content,3000);
 
 		//don't create previews of empty text files


### PR DESCRIPTION
Our sentry instance found 2 occurrences where apparently the fopen failed, no clue why it failed.. Better not to start throwing exceptions and just return false so we know no preview was generated.

easy one