### PR TITLE
[stable12] Fix loading icon position in the app menu

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -475,6 +475,8 @@ nav {
 	}
 	.app-loading .icon-loading-small-dark {
 		top:12px;
+		width: 20px;
+		height: 20px;
 	}
 
 


### PR DESCRIPTION
Backport of https://github.com/nextcloud/server/pull/7271

Before:

![peek 2017-11-23 21-13](https://user-images.githubusercontent.com/3404133/33187643-7c8964a2-d093-11e7-8b0f-f826d944486f.gif)

After:

![peek 2017-11-23 21-14](https://user-images.githubusercontent.com/3404133/33187640-7a3b33e2-d093-11e7-983c-ea6a9bbb14ec.gif)
