### PR TITLE
Fix unit tests for CalendarManager

### DIFF
--- a/apps/dav/lib/CalDAV/CalendarManager.php
+++ b/apps/dav/lib/CalDAV/CalendarManager.php
@@ -24,6 +24,7 @@
 namespace OCA\DAV\CalDAV;
 
 use OCP\Calendar\IManager;
+use OCP\IConfig;
 use OCP\IL10N;
 
 class CalendarManager {
@@ -34,15 +35,20 @@ class CalendarManager {
 	/** @var IL10N */
 	private $l10n;
 
+	/** @var IConfig */
+	private $config;
+
 	/**
 	 * CalendarManager constructor.
 	 *
 	 * @param CalDavBackend $backend
 	 * @param IL10N $l10n
+	 * @param IConfig $config
 	 */
-	public function __construct(CalDavBackend $backend, IL10N $l10n) {
+	public function __construct(CalDavBackend $backend, IL10N $l10n, IConfig $config) {
 		$this->backend = $backend;
 		$this->l10n = $l10n;
+		$this->config = $config;
 	}
 
 	/**
@@ -60,7 +66,7 @@ class CalendarManager {
 	 */
 	private function register(IManager $cm, array $calendars) {
 		foreach($calendars as $calendarInfo) {
-			$calendar = new Calendar($this->backend, $calendarInfo, $this->l10n);
+			$calendar = new Calendar($this->backend, $calendarInfo, $this->l10n, $this->config);
 			$cm->registerCalendar(new CalendarImpl(
 				$calendar,
 				$calendarInfo,

--- a/apps/dav/tests/unit/CalDAV/CalendarManagerTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarManagerTest.php
@@ -28,6 +28,7 @@ use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CalDAV\CalendarImpl;
 use OCA\DAV\CalDAV\CalendarManager;
 use OCP\Calendar\IManager;
+use OCP\IConfig;
 use OCP\IL10N;
 
 class CalendarManagerTest extends \Test\TestCase {
@@ -38,6 +39,9 @@ class CalendarManagerTest extends \Test\TestCase {
 	/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject */
 	private $l10n;
 
+	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	private $config;
+
 	/** @var CalendarManager */
 	private $manager;
 
@@ -45,8 +49,9 @@ class CalendarManagerTest extends \Test\TestCase {
 		parent::setUp();
 		$this->backend = $this->createMock(CalDavBackend::class);
 		$this->l10n = $this->createMock(IL10N::class);
+		$this->config = $this->createMock(IConfig::class);
 		$this->manager = new CalendarManager($this->backend,
-			$this->l10n);
+			$this->l10n, $this->config);
 	}
 
 	public function testSetupCalendarProvider() {


### PR DESCRIPTION
Beside that:

@georgehrke Where is this actually used? Because I only see that `CalendarManager` is mapped in the server container to `\OC\Calendar\Manager` instead - could it be that this one is not used anymore (or vice versa)?

ref #6840 (where it was introduced) and #6884 (which was merged without a failure and then suddenly master had problems)

