### PR TITLE
allow 'Nextcloud' in the user agent string of Android

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
@@ -303,7 +303,7 @@ class AuthTest extends TestCase {
 			->method('isUserAgent')
 			->with([
 				'/^Mozilla\/5\.0 \([A-Za-z ]+\) (mirall|csyncoC)\/.*$/',
-				'/^Mozilla\/5\.0 \(Android\) ownCloud\-android.*$/',
+				'/^Mozilla\/5\.0 \(Android\) (ownCloud|Nextcloud)\-android.*$/',
 				'/^Mozilla\/5\.0 \(iOS\) (ownCloud|Nextcloud)\-iOS.*$/',
 			])
 			->willReturn(false);
@@ -407,7 +407,7 @@ class AuthTest extends TestCase {
 			->method('isUserAgent')
 			->with([
 				'/^Mozilla\/5\.0 \([A-Za-z ]+\) (mirall|csyncoC)\/.*$/',
-				'/^Mozilla\/5\.0 \(Android\) ownCloud\-android.*$/',
+				'/^Mozilla\/5\.0 \(Android\) (ownCloud|Nextcloud)\-android.*$/',
 				'/^Mozilla\/5\.0 \(iOS\) (ownCloud|Nextcloud)\-iOS.*$/',
 			])
 			->willReturn(false);
@@ -453,7 +453,7 @@ class AuthTest extends TestCase {
 			->method('isUserAgent')
 			->with([
 				'/^Mozilla\/5\.0 \([A-Za-z ]+\) (mirall|csyncoC)\/.*$/',
-				'/^Mozilla\/5\.0 \(Android\) ownCloud\-android.*$/',
+				'/^Mozilla\/5\.0 \(Android\) (ownCloud|Nextcloud)\-android.*$/',
 				'/^Mozilla\/5\.0 \(iOS\) (ownCloud|Nextcloud)\-iOS.*$/',
 			])
 			->willReturn(true);

--- a/lib/public/IRequest.php
+++ b/lib/public/IRequest.php
@@ -67,7 +67,7 @@ interface IRequest {
 	/**
 	 * @since 9.1.0
 	 */
-	const USER_AGENT_CLIENT_ANDROID = '/^Mozilla\/5\.0 \(Android\) ownCloud\-android.*$/';
+	const USER_AGENT_CLIENT_ANDROID = '/^Mozilla\/5\.0 \(Android\) (ownCloud|Nextcloud)\-android.*$/';
 
 	/**
 	 * @since 13.0.0

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -859,6 +859,20 @@ class RequestTest extends \Test\TestCase {
 				],
 				false,
 			],
+			[
+				'Mozilla/5.0 (Android) ownCloud-android/2.0.0',
+				[
+					Request::USER_AGENT_CLIENT_ANDROID
+				],
+				true,
+			],
+			[
+				'Mozilla/5.0 (Android) Nextcloud-android/2.0.0',
+				[
+					Request::USER_AGENT_CLIENT_ANDROID
+				],
+				true,
+			],
 		];
 	}
 


### PR DESCRIPTION
It is already possible for iOS, this PR also enable it for Android. This way we can effectively block all clients which don't support end-to-end encryption. We should backport it so that the new Android client will also work with older Nextcloud releases.

cc @tobiasKaminsky @AndyScherzinger 