### PR TITLE
Fix error log on PHP 7.2

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -412,6 +412,10 @@ class OC {
 	}
 
 	public static function initSession() {
+		if(self::$server->getRequest()->getServerProtocol() === 'https') {
+			ini_set('session.cookie_secure', true);
+		}
+
 		// prevents javascript from accessing php session cookies
 		ini_set('session.cookie_httponly', true);
 
@@ -663,9 +667,6 @@ class OC {
 		self::checkInstalled();
 
 		OC_Response::addSecurityHeaders();
-		if(self::$server->getRequest()->getServerProtocol() === 'https') {
-			ini_set('session.cookie_secure', true);
-		}
 
 		self::performSameSiteCookieProtection();
 


### PR DESCRIPTION
Fixes following error in the logs: `ini_set(): A session is active. You cannot change the session module's ini settings at this time`

Basically moves the `ini_set` 5 lines to the top into the method call.

Found while testing the 13.0.0 beta 2 on PHP 7.2