### PR TITLE
The user displayNameResolver is specific to users, not the comments app

### DIFF
--- a/apps/comments/appinfo/app.php
+++ b/apps/comments/appinfo/app.php
@@ -60,14 +60,3 @@ $commentsManager->registerEventHandler(function () {
 	$handler = $application->getContainer()->query(\OCA\Comments\EventHandler::class);
 	return $handler;
 });
-$commentsManager->registerDisplayNameResolver('user', function($id) {
-	$manager = \OC::$server->getUserManager();
-	$user = $manager->get($id);
-	if(is_null($user)) {
-		$l = \OC::$server->getL10N('comments');
-		$displayName = $l->t('Unknown user');
-	} else {
-		$displayName = $user->getDisplayName();
-	}
-	return $displayName;
-});

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -897,7 +897,21 @@ class Server extends ServerContainer implements IServerContainer {
 			$factoryClass = $config->getSystemValue('comments.managerFactory', '\OC\Comments\ManagerFactory');
 			/** @var \OCP\Comments\ICommentsManagerFactory $factory */
 			$factory = new $factoryClass($this);
-			return $factory->getManager();
+			$manager = $factory->getManager();
+
+			$manager->registerDisplayNameResolver('user', function($id) use ($c) {
+				$manager = $c->getUserManager();
+				$user = $manager->get($id);
+				if(is_null($user)) {
+					$l = $c->getL10N('core');
+					$displayName = $l->t('Unknown user');
+				} else {
+					$displayName = $user->getDisplayName();
+				}
+				return $displayName;
+			});
+
+			return $manager;
 		});
 		$this->registerAlias('CommentsManager', \OCP\Comments\ICommentsManager::class);
 


### PR DESCRIPTION
For https://github.com/nextcloud/spreed/pull/517

How to test: write a comment with a mention. If the display name keeps being visible everything continues to work :)

