### PR TITLE
13.0.0 beta3

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(13, 0, 0, 7);
+$OC_Version = array(13, 0, 0, 8);
 
 // The human readable string
-$OC_VersionString = '13.0.0 Beta 2';
+$OC_VersionString = '13.0.0 Beta 3';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Includes:

* Fix error log on PHP 7.2 #7466 <- that is the main reason for the beta 3 to not have issues with users, that test it on PHP 7.2
* The user displayNameResolver is specific to users, not the comments app #7472
* Fixed firefox guest header height #7470
* Fix filename typo #7465
* allow 'Nextcloud' in the user agent string of Android #7462
* Show tha copy share link button properly inline #7476 
* Fixes hex2bin() in LDAP #7479
