### PR TITLE
Show tha copy share link button properly inline

### DIFF
--- a/apps/files_sharing/css/sharetabview.scss
+++ b/apps/files_sharing/css/sharetabview.scss
@@ -14,7 +14,6 @@
 }
 
 .shareTabView .shareWithRemoteInfo,
-.shareTabView .clipboardButton,
 .shareTabView .linkPass .icon-loading-small {
 	position: absolute;
 	right: -7px;
@@ -38,7 +37,6 @@
 	position: relative;
 	top: initial;
 	right: initial;
-	padding: 18px 0 18px 36px;
 }
 
 .shareTabView label {


### PR DESCRIPTION
Before:

![bildschirmfoto 2017-12-13 um 10 29 33](https://user-images.githubusercontent.com/245432/33931664-f2c01d2a-dff0-11e7-92bf-9a5edb6f1e86.png)

After:

![bildschirmfoto 2017-12-13 um 10 30 54](https://user-images.githubusercontent.com/245432/33931672-f7d9059c-dff0-11e7-9030-c4e3d0540d9f.png)


cc @nextcloud/designers 