### PR TITLE
Also cache invalid DiscoveryService response

### DIFF
--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -280,7 +280,7 @@ class Storage extends DAV implements ISharedStorage {
 			$returnValue = false;
 		}
 
-		$cache->set($url, $returnValue);
+		$cache->set($url, $returnValue, 60*60*24);
 		return $returnValue;
 	}
 

--- a/lib/private/OCS/DiscoveryService.php
+++ b/lib/private/OCS/DiscoveryService.php
@@ -81,11 +81,10 @@ class DiscoveryService implements IDiscoveryService {
 			}
 		} catch (\Exception $e) {
 			// if we couldn't discover the service or any end-points we return a empty array
-			return [];
 		}
 
 		// Write into cache
-		$this->cache->set($remote . '#' . $service, json_encode($discoveredServices));
+		$this->cache->set($remote . '#' . $service, json_encode($discoveredServices), 60*60*24);
 		return $discoveredServices;
 	}
 


### PR DESCRIPTION
Fixes #7001 
Or at least it should help. Also adds caching (of a day) to the Discovery call we make for each invalid federated share every time.

Also sets a 24h timeout on the status.php check. So we will check that one as well at some point again.