### PR TITLE
disable password confirmation with SSO

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1647,7 +1647,8 @@ OC.PasswordConfirmation = {
 
 	requiresPasswordConfirmation: function() {
 		var timeSinceLogin = moment.now() - (nc_lastLogin * 1000);
-		return timeSinceLogin > 30 * 60 * 1000; // 30 minutes
+		// if timeSinceLogin > 30 minutes and user backend allows password confirmation
+		return (backendAllowsPasswordConfirmation && timeSinceLogin > 30 * 60 * 1000);
 	},
 
 	/**

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -335,6 +335,7 @@ return array(
     'OC\\AppFramework\\Middleware\\Security\\Exceptions\\NotLoggedInException' => $baseDir . '/lib/private/AppFramework/Middleware/Security/Exceptions/NotLoggedInException.php',
     'OC\\AppFramework\\Middleware\\Security\\Exceptions\\SecurityException' => $baseDir . '/lib/private/AppFramework/Middleware/Security/Exceptions/SecurityException.php',
     'OC\\AppFramework\\Middleware\\Security\\Exceptions\\StrictCookieMissingException' => $baseDir . '/lib/private/AppFramework/Middleware/Security/Exceptions/StrictCookieMissingException.php',
+    'OC\\AppFramework\\Middleware\\Security\\PasswordConfirmationMiddleware' => $baseDir . '/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php',
     'OC\\AppFramework\\Middleware\\Security\\RateLimitingMiddleware' => $baseDir . '/lib/private/AppFramework/Middleware/Security/RateLimitingMiddleware.php',
     'OC\\AppFramework\\Middleware\\Security\\SameSiteCookieMiddleware' => $baseDir . '/lib/private/AppFramework/Middleware/Security/SameSiteCookieMiddleware.php',
     'OC\\AppFramework\\Middleware\\Security\\SecurityMiddleware' => $baseDir . '/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -365,6 +365,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\AppFramework\\Middleware\\Security\\Exceptions\\NotLoggedInException' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Middleware/Security/Exceptions/NotLoggedInException.php',
         'OC\\AppFramework\\Middleware\\Security\\Exceptions\\SecurityException' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Middleware/Security/Exceptions/SecurityException.php',
         'OC\\AppFramework\\Middleware\\Security\\Exceptions\\StrictCookieMissingException' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Middleware/Security/Exceptions/StrictCookieMissingException.php',
+        'OC\\AppFramework\\Middleware\\Security\\PasswordConfirmationMiddleware' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php',
         'OC\\AppFramework\\Middleware\\Security\\RateLimitingMiddleware' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Middleware/Security/RateLimitingMiddleware.php',
         'OC\\AppFramework\\Middleware\\Security\\SameSiteCookieMiddleware' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Middleware/Security/SameSiteCookieMiddleware.php',
         'OC\\AppFramework\\Middleware\\Security\\SecurityMiddleware' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php',

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -234,7 +234,8 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				$server->getContentSecurityPolicyManager(),
 				$server->getCsrfTokenManager(),
 				$server->getContentSecurityPolicyNonceManager(),
-				$server->getAppManager()
+				$server->getAppManager(),
+				$server->getUserSession()
 			);
 
 		});

--- a/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * @copyright 2018, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OC\AppFramework\Middleware\Security;
+
+use OC\AppFramework\Middleware\Security\Exceptions\NotConfirmedException;
+use OC\AppFramework\Utility\ControllerMethodReflector;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Middleware;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\ISession;
+use OCP\IUserSession;
+
+class PasswordConfirmationMiddleware extends Middleware {
+	/** @var ControllerMethodReflector */
+	private $reflector;
+	/** @var ISession */
+	private $session;
+	/** @var IUserSession */
+	private $userSession;
+	/** @var ITimeFactory */
+	private $timeFactory;
+
+	/**
+	 * PasswordConfirmationMiddleware constructor.
+	 *
+	 * @param ControllerMethodReflector $reflector
+	 * @param ISession $session
+	 * @param IUserSession $userSession
+	 * @param ITimeFactory $timeFactory
+	 */
+	public function __construct(ControllerMethodReflector $reflector,
+								ISession $session,
+								IUserSession $userSession,
+								ITimeFactory $timeFactory) {
+		$this->reflector = $reflector;
+		$this->session = $session;
+		$this->userSession = $userSession;
+		$this->timeFactory = $timeFactory;
+	}
+
+	/**
+	 * @param Controller $controller
+	 * @param string $methodName
+	 * @throws NotConfirmedException
+	 */
+	public function beforeController($controller, $methodName) {
+		if ($this->reflector->hasAnnotation('PasswordConfirmationRequired')) {
+			$user = $this->userSession->getUser();
+			$backendClassName = '';
+			if ($user !== null) {
+				$backendClassName = $user->getBackendClassName();
+			}
+
+			$lastConfirm = (int) $this->session->get('last-password-confirm');
+			// we can't check the password against a SAML backend, so skip password confirmation in this case
+			if ($backendClassName !== 'user_saml' && $lastConfirm < ($this->timeFactory->getTime() - (30 * 60 + 15))) { // allow 15 seconds delay
+				throw new NotConfirmedException();
+			}
+		}
+	}
+}

--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -101,8 +101,10 @@ class JSConfigHelper {
 
 		if ($this->currentUser !== null) {
 			$uid = $this->currentUser->getUID();
+			$userBackend = $this->currentUser->getBackendClassName();
 		} else {
 			$uid = null;
+			$userBackend = '';
 		}
 
 		// Get the config
@@ -147,6 +149,7 @@ class JSConfigHelper {
 		$array = [
 			"oc_debug" => $this->config->getSystemValue('debug', false) ? 'true' : 'false',
 			"oc_isadmin" => $this->groupManager->isAdmin($uid) ? 'true' : 'false',
+			"backendAllowsPasswordConfirmation" => $userBackend === 'user_saml'? 'false' : 'true',
 			"oc_dataURL" => is_string($dataLocation) ? "\"".$dataLocation."\"" : 'false',
 			"oc_webroot" => "\"".\OC::$WEBROOT."\"",
 			"oc_appswebroots" =>  str_replace('\\/', '/', json_encode($apps_paths)), // Ugly unescape slashes waiting for better solution

--- a/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * @copyright 2018, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace Test\AppFramework\Middleware\Security;
+
+use OC\AppFramework\Middleware\Security\Exceptions\NotConfirmedException;
+use OC\AppFramework\Middleware\Security\PasswordConfirmationMiddleware;
+use OC\AppFramework\Utility\ControllerMethodReflector;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\ISession;
+use OCP\IUser;
+use OCP\IUserSession;
+use Test\TestCase;
+
+class PasswordConfirmationMiddlewareTest extends TestCase {
+	/** @var ControllerMethodReflector */
+	private $reflector;
+	/** @var ISession|\PHPUnit_Framework_MockObject_MockObject */
+	private $session;
+	/** @var IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	private $userSession;
+	/** @var IUser|\PHPUnit_Framework_MockObject_MockObject */
+	private $user;
+	/** @var PasswordConfirmationMiddleware */
+	private $middleware;
+	/** @var Controller */
+	private $contoller;
+	/** @var ITimeFactory|\PHPUnit_Framework_MockObject_MockObject */
+	private $timeFactory;
+
+	protected function setUp() {
+		$this->reflector = new ControllerMethodReflector();
+		$this->session = $this->createMock(ISession::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->user = $this->createMock(IUser::class);
+		$this->contoller = $this->createMock(Controller::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+
+		$this->middleware = new PasswordConfirmationMiddleware(
+			$this->reflector,
+			$this->session,
+			$this->userSession,
+			$this->timeFactory
+		);
+	}
+
+	public function testNoAnnotation() {
+		$this->reflector->reflect(__CLASS__, __FUNCTION__);
+		$this->session->expects($this->never())
+			->method($this->anything());
+		$this->userSession->expects($this->never())
+			->method($this->anything());
+
+		$this->middleware->beforeController($this->contoller, __FUNCTION__);
+	}
+
+	/**
+	 * @TestAnnotation
+	 */
+	public function testDifferentAnnotation() {
+		$this->reflector->reflect(__CLASS__, __FUNCTION__);
+		$this->session->expects($this->never())
+			->method($this->anything());
+		$this->userSession->expects($this->never())
+			->method($this->anything());
+
+		$this->middleware->beforeController($this->contoller, __FUNCTION__);
+	}
+
+	/**
+	 * @PasswordConfirmationRequired
+	 * @dataProvider testProvider
+	 */
+	public function testAnnotation($backend, $lastConfirm, $currentTime, $exception) {
+		$this->reflector->reflect(__CLASS__, __FUNCTION__);
+
+		$this->user->method('getBackendClassName')
+			->willReturn($backend);
+		$this->userSession->method('getUser')
+			->willReturn($this->user);
+
+		$this->session->method('get')
+			->with('last-password-confirm')
+			->willReturn($lastConfirm);
+
+		$this->timeFactory->method('getTime')
+			->willReturn($currentTime);
+
+		$thrown = false;
+		try {
+			$this->middleware->beforeController($this->contoller, __FUNCTION__);
+		} catch (NotConfirmedException $e) {
+			$thrown = true;
+		}
+
+		$this->assertSame($exception, $thrown);
+	}
+
+	public function testProvider() {
+		return [
+			['foo', 2000, 4000, true],
+			['foo', 2000, 3000, false],
+			['user_saml', 2000, 4000, false],
+			['user_saml', 2000, 3000, false],
+			['foo', 2000, 3815, false],
+			['foo', 2000, 3816, true],
+		];
+	}
+}

--- a/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
@@ -50,6 +50,8 @@ use OCP\INavigationManager;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserSession;
 use OCP\Security\ISecureRandom;
 
 class SecurityMiddlewareTest extends \Test\TestCase {
@@ -82,6 +84,8 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	private $cspNonceManager;
 	/** @var IAppManager|\PHPUnit_Framework_MockObject_MockObject */
 	private $appManager;
+	/** @var IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	private $userSession;
 
 	protected function setUp() {
 		parent::setUp();
@@ -100,6 +104,10 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->appManager->expects($this->any())
 			->method('isEnabledForUser')
 			->willReturn(true);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$user = $this->createMock(IUser::class);
+		$user->expects($this->any())->method('getBackendClassName')->willReturn('user_ldap');
+		$this->userSession->expects($this->any())->method('getUser')->willReturn($user);
 		$this->middleware = $this->getMiddleware(true, true);
 		$this->secException = new SecurityException('hey', false);
 		$this->secAjaxException = new SecurityException('hey', true);
@@ -124,7 +132,8 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 			$this->contentSecurityPolicyManager,
 			$this->csrfTokenManager,
 			$this->cspNonceManager,
-			$this->appManager
+			$this->appManager,
+			$this->userSession
 		);
 	}
 

--- a/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
@@ -64,8 +64,6 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	private $secException;
 	/** @var SecurityException */
 	private $secAjaxException;
-	/** @var ISession|\PHPUnit_Framework_MockObject_MockObject */
-	private $session;
 	/** @var IRequest|\PHPUnit_Framework_MockObject_MockObject */
 	private $request;
 	/** @var ControllerMethodReflector */
@@ -95,7 +93,6 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->logger = $this->createMock(ILogger::class);
 		$this->navigationManager = $this->createMock(INavigationManager::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
-		$this->session = $this->createMock(ISession::class);
 		$this->request = $this->createMock(IRequest::class);
 		$this->contentSecurityPolicyManager = $this->createMock(ContentSecurityPolicyManager::class);
 		$this->csrfTokenManager = $this->createMock(CsrfTokenManager::class);
@@ -104,10 +101,6 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->appManager->expects($this->any())
 			->method('isEnabledForUser')
 			->willReturn(true);
-		$this->userSession = $this->createMock(IUserSession::class);
-		$user = $this->createMock(IUser::class);
-		$user->expects($this->any())->method('getBackendClassName')->willReturn('user_ldap');
-		$this->userSession->expects($this->any())->method('getUser')->willReturn($user);
 		$this->middleware = $this->getMiddleware(true, true);
 		$this->secException = new SecurityException('hey', false);
 		$this->secAjaxException = new SecurityException('hey', true);
@@ -125,15 +118,13 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 			$this->navigationManager,
 			$this->urlGenerator,
 			$this->logger,
-			$this->session,
 			'files',
 			$isLoggedIn,
 			$isAdminUser,
 			$this->contentSecurityPolicyManager,
 			$this->csrfTokenManager,
 			$this->cspNonceManager,
-			$this->appManager,
-			$this->userSession
+			$this->appManager
 		);
 	}
 


### PR DESCRIPTION
Disable password confirmation in case of single-sign-on.
In case of SSO password confirmation doesn't work because Nextcloud can't check the users password.