### PR TITLE
Satisfy @PasswordConfirmationRequired when authenticating with Bearer Authorization header

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -748,6 +748,7 @@ class Session implements IUserSession, Emitter {
 		if(!$this->validateToken($token)) {
 			return false;
 		}
+		$this->session->set('last-password-confirm', $this->timeFactory->getTime());
 		return true;
 	}
 

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -740,6 +740,7 @@ class Session implements IUserSession, Emitter {
 			}
 		} else {
 			$token = substr($authHeader, 7);
+			$loginWithHeader = true;
 		}
 
 		if (!$this->loginWithToken($token)) {
@@ -748,7 +749,10 @@ class Session implements IUserSession, Emitter {
 		if(!$this->validateToken($token)) {
 			return false;
 		}
-		$this->session->set('last-password-confirm', $this->timeFactory->getTime());
+		
+		if($loginWithHeader) {
+			$this->session->set('last-password-confirm', $this->timeFactory->getTime());
+		}
 		return true;
 	}
 


### PR DESCRIPTION
### Issue:
When authenticated with an access token in a Bearer Authorization header in a stateless context, it is impossible to satisfy ```@PasswordConfirmationRequired``` routes.

### Proposed solution:
When authenticating a Bearer Authorization Header, update the 'last-password-confirm' session variable,  in the same way as a Basic Authorization.