### PR TITLE
Use proper authorative-autoloader for app autoloaders

### DIFF
--- a/apps/admin_audit/composer/composer.json
+++ b/apps/admin_audit/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "AdminAudit"
     },
     "autoload" : {

--- a/apps/admin_audit/composer/composer/autoload_real.php
+++ b/apps/admin_audit/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitAdminAudit
 
             call_user_func(\Composer\Autoload\ComposerStaticInitAdminAudit::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;

--- a/apps/comments/composer/composer.json
+++ b/apps/comments/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "Comments"
     },
     "autoload" : {

--- a/apps/comments/composer/composer/autoload_real.php
+++ b/apps/comments/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitComments
 
             call_user_func(\Composer\Autoload\ComposerStaticInitComments::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;

--- a/apps/dav/composer/composer.json
+++ b/apps/dav/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "DAV"
     },
     "autoload" : {

--- a/apps/dav/composer/composer/autoload_real.php
+++ b/apps/dav/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitDAV
 
             call_user_func(\Composer\Autoload\ComposerStaticInitDAV::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;

--- a/apps/encryption/composer/composer.json
+++ b/apps/encryption/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "Encryption"
     },
     "autoload" : {

--- a/apps/encryption/composer/composer/autoload_real.php
+++ b/apps/encryption/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitEncryption
 
             call_user_func(\Composer\Autoload\ComposerStaticInitEncryption::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;

--- a/apps/federatedfilesharing/composer/composer.json
+++ b/apps/federatedfilesharing/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "FederatedFileSharing"
     },
     "autoload" : {

--- a/apps/federatedfilesharing/composer/composer/autoload_real.php
+++ b/apps/federatedfilesharing/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitFederatedFileSharing
 
             call_user_func(\Composer\Autoload\ComposerStaticInitFederatedFileSharing::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;

--- a/apps/federation/composer/composer.json
+++ b/apps/federation/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "Federation"
     },
     "autoload" : {

--- a/apps/federation/composer/composer/autoload_real.php
+++ b/apps/federation/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitFederation
 
             call_user_func(\Composer\Autoload\ComposerStaticInitFederation::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;

--- a/apps/files/composer/composer.json
+++ b/apps/files/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "Files"
     },
     "autoload" : {

--- a/apps/files/composer/composer/autoload_real.php
+++ b/apps/files/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitFiles
 
             call_user_func(\Composer\Autoload\ComposerStaticInitFiles::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;

--- a/apps/files_sharing/composer/composer.json
+++ b/apps/files_sharing/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "Files_Sharing"
     },
     "autoload" : {

--- a/apps/files_sharing/composer/composer/autoload_real.php
+++ b/apps/files_sharing/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitFiles_Sharing
 
             call_user_func(\Composer\Autoload\ComposerStaticInitFiles_Sharing::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;

--- a/apps/files_trashbin/composer/composer.json
+++ b/apps/files_trashbin/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "Files_Trashbin"
     },
     "autoload" : {

--- a/apps/files_trashbin/composer/composer/autoload_real.php
+++ b/apps/files_trashbin/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitFiles_Trashbin
 
             call_user_func(\Composer\Autoload\ComposerStaticInitFiles_Trashbin::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;

--- a/apps/files_versions/composer/composer.json
+++ b/apps/files_versions/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "Files_Versions"
     },
     "autoload" : {

--- a/apps/files_versions/composer/composer/autoload_real.php
+++ b/apps/files_versions/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitFiles_Versions
 
             call_user_func(\Composer\Autoload\ComposerStaticInitFiles_Versions::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;

--- a/apps/lookup_server_connector/composer/composer.json
+++ b/apps/lookup_server_connector/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "LookupServerConnector"
     },
     "autoload" : {

--- a/apps/lookup_server_connector/composer/composer/autoload_real.php
+++ b/apps/lookup_server_connector/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitLookupServerConnector
 
             call_user_func(\Composer\Autoload\ComposerStaticInitLookupServerConnector::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;

--- a/apps/oauth2/composer/composer.json
+++ b/apps/oauth2/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "OAuth2"
     },
     "autoload" : {

--- a/apps/oauth2/composer/composer/autoload_real.php
+++ b/apps/oauth2/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitOAuth2
 
             call_user_func(\Composer\Autoload\ComposerStaticInitOAuth2::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;

--- a/apps/provisioning_api/composer/composer.json
+++ b/apps/provisioning_api/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "Provisioning_API"
     },
     "autoload" : {

--- a/apps/provisioning_api/composer/composer/autoload_real.php
+++ b/apps/provisioning_api/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitProvisioning_API
 
             call_user_func(\Composer\Autoload\ComposerStaticInitProvisioning_API::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;

--- a/apps/sharebymail/composer/composer.json
+++ b/apps/sharebymail/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "ShareByMail"
     },
     "autoload" : {

--- a/apps/sharebymail/composer/composer/autoload_real.php
+++ b/apps/sharebymail/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitShareByMail
 
             call_user_func(\Composer\Autoload\ComposerStaticInitShareByMail::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;

--- a/apps/systemtags/composer/composer.json
+++ b/apps/systemtags/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "SystemTags"
     },
     "autoload" : {

--- a/apps/systemtags/composer/composer/autoload_real.php
+++ b/apps/systemtags/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitSystemTags
 
             call_user_func(\Composer\Autoload\ComposerStaticInitSystemTags::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;

--- a/apps/testing/composer/composer.json
+++ b/apps/testing/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "Testing"
     },
     "autoload" : {

--- a/apps/testing/composer/composer/autoload_real.php
+++ b/apps/testing/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitTesting
 
             call_user_func(\Composer\Autoload\ComposerStaticInitTesting::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;

--- a/apps/twofactor_backupcodes/composer/composer.json
+++ b/apps/twofactor_backupcodes/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "TwoFactorBackupCodes"
     },
     "autoload" : {

--- a/apps/twofactor_backupcodes/composer/composer/autoload_real.php
+++ b/apps/twofactor_backupcodes/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitTwoFactorBackupCodes
 
             call_user_func(\Composer\Autoload\ComposerStaticInitTwoFactorBackupCodes::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;

--- a/apps/updatenotification/composer/composer.json
+++ b/apps/updatenotification/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "UpdateNotification"
     },
     "autoload" : {

--- a/apps/updatenotification/composer/composer/autoload_real.php
+++ b/apps/updatenotification/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitUpdateNotification
 
             call_user_func(\Composer\Autoload\ComposerStaticInitUpdateNotification::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;

--- a/apps/user_ldap/composer/composer.json
+++ b/apps/user_ldap/composer/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "vendor-dir": ".",
         "optimize-autoloader": true,
-        "authorative-autoloader": true,
+        "classmap-authoritative": true,
         "autoloader-suffix": "User_LDAP"
     },
     "autoload" : {

--- a/apps/user_ldap/composer/composer/autoload_real.php
+++ b/apps/user_ldap/composer/composer/autoload_real.php
@@ -29,22 +29,13 @@ class ComposerAutoloaderInitUser_LDAP
 
             call_user_func(\Composer\Autoload\ComposerStaticInitUser_LDAP::getInitializer($loader));
         } else {
-            $map = require __DIR__ . '/autoload_namespaces.php';
-            foreach ($map as $namespace => $path) {
-                $loader->set($namespace, $path);
-            }
-
-            $map = require __DIR__ . '/autoload_psr4.php';
-            foreach ($map as $namespace => $path) {
-                $loader->setPsr4($namespace, $path);
-            }
-
             $classMap = require __DIR__ . '/autoload_classmap.php';
             if ($classMap) {
                 $loader->addClassMap($classMap);
             }
         }
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;


### PR DESCRIPTION
Because I'm an idiot I used some non existing keyword to try to set an authoritative classmap.

I noticed we were spending an insane amount of time in findFileWithExtention. This should make that a lot better.