### PR TITLE
Reduce length of md5 in scss caching

### DIFF
--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -285,7 +285,7 @@ class SCSSCacher {
 		$re = '/url\([\'"]([\.\w?=\/-]*)[\'"]\)/x';
 		// OC\Route\Router:75
 		if(($this->config->getSystemValue('htaccess.IgnoreFrontController', false) === true || getenv('front_controller_active') === 'true')) {
-			$subst = 'url(\'../../'.$webDir.'/$1\')';	
+			$subst = 'url(\'../../'.$webDir.'/$1\')';
 		} else {
 			$subst = 'url(\'../../../'.$webDir.'/$1\')';
 		}
@@ -313,6 +313,6 @@ class SCSSCacher {
 	 */
 	private function prependBaseurlPrefix($cssFile) {
 		$frontendController = ($this->config->getSystemValue('htaccess.IgnoreFrontController', false) === true || getenv('front_controller_active') === 'true');
-		return md5($this->urlGenerator->getBaseUrl() . $frontendController) . '-' . $cssFile;
+		return substr(md5($this->urlGenerator->getBaseUrl() . $frontendController), 0, 8) . '-' . $cssFile;
 	}
 }

--- a/tests/lib/Template/SCSSCacherTest.php
+++ b/tests/lib/Template/SCSSCacherTest.php
@@ -185,7 +185,7 @@ class SCSSCacherTest extends \Test\TestCase {
 		$fileDeps->expects($this->any())->method('getSize')->willReturn(1);
 
 		$gzFile = $this->createMock(ISimpleFile::class);
-		$filePrefix = md5('http://localhost/nextcloud') . '-';
+		$filePrefix = substr(md5('http://localhost/nextcloud'), 0, 8) . '-';
 		$folder->method('getFile')
 			->will($this->returnCallback(function($name) use ($file, $fileDeps, $gzFile, $filePrefix) {
 				if ($name === $filePrefix.'styles.css') {
@@ -385,7 +385,7 @@ class SCSSCacherTest extends \Test\TestCase {
 		$this->urlGenerator->expects($this->once())
 			->method('linkToRoute')
 			->with('core.Css.getCss', [
-				'fileName' => md5('http://localhost/nextcloud') . '-styles.css',
+				'fileName' => substr(md5('http://localhost/nextcloud'), 0, 8) . '-styles.css',
 				'appName' => $appName
 			])
 			->willReturn(\OC::$WEBROOT . $result);

--- a/tests/lib/Template/SCSSCacherTest.php
+++ b/tests/lib/Template/SCSSCacherTest.php
@@ -88,7 +88,7 @@ class SCSSCacherTest extends \Test\TestCase {
 
 		$fileDeps = $this->createMock(ISimpleFile::class);
 		$gzfile = $this->createMock(ISimpleFile::class);
-		$filePrefix = md5('http://localhost/nextcloud') . '-';
+		$filePrefix = substr(md5('http://localhost/nextcloud'), 0, 8) . '-';
 
 		$folder->method('getFile')
 			->will($this->returnCallback(function($path) use ($file, $gzfile, $filePrefix) {
@@ -122,7 +122,7 @@ class SCSSCacherTest extends \Test\TestCase {
 		$file->expects($this->any())->method('getSize')->willReturn(1);
 		$fileDeps = $this->createMock(ISimpleFile::class);
 		$gzfile = $this->createMock(ISimpleFile::class);
-		$filePrefix = md5('http://localhost/nextcloud') . '-';
+		$filePrefix = substr(md5('http://localhost/nextcloud'), 0, 8) . '-';
 
 		$folder->method('getFile')
 			->will($this->returnCallback(function($path) use ($file, $gzfile, $filePrefix) {
@@ -152,7 +152,7 @@ class SCSSCacherTest extends \Test\TestCase {
 		$fileDeps = $this->createMock(ISimpleFile::class);
 		$fileDeps->expects($this->any())->method('getSize')->willReturn(1);
 		$gzFile = $this->createMock(ISimpleFile::class);
-		$filePrefix = md5('http://localhost/nextcloud') . '-';
+		$filePrefix = substr(md5('http://localhost/nextcloud'), 0, 8) . '-';
 
 		$folder->method('getFile')
 			->will($this->returnCallback(function($name) use ($file, $fileDeps, $gzFile, $filePrefix) {


### PR DESCRIPTION
Easier to debug.

|Before|After|
|:--:|:--:|
|![kazam_screenshot_00011](https://user-images.githubusercontent.com/14975046/33981241-51af0556-e0ac-11e7-9ab2-c4802b0a7382.png)|![kazam_screenshot_00010](https://user-images.githubusercontent.com/14975046/33981240-5197b5ea-e0ac-11e7-806e-24dc49d5d2a3.png)|

