### PR TITLE
adjust avatar and its line height to comment message style

### DIFF
--- a/apps/comments/css/comments.css
+++ b/apps/comments/css/comments.css
@@ -80,9 +80,9 @@
 
 #commentsTabView .comment .avatar,
 .atwho-view-ul * .avatar{
-	width: 32px;
-	height: 32px;
-	line-height: 32px;
+	width: 1.6em;
+	height: 1.6em;
+	line-height: 1.6em;
 	margin-right: 5px;
 }
 

--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -56,6 +56,9 @@
 		'{{/if}}' +
 		'</li>';
 
+	var AVATAR_SIZE_TEXT = '16';
+	var AVATAR_SIZE_HEADING = '32';
+
 	/**
 	 * @memberof OCA.Comments
 	 */
@@ -169,7 +172,7 @@
 			this.$el.find('.comments').before(this.editCommentTemplate({}));
 			this.$el.find('.has-tooltip').tooltip();
 			this.$container = this.$el.find('ul.comments');
-			this.$el.find('.avatar').avatar(OC.getCurrentUser().uid, 32);
+			this.$el.find('.avatar').avatar(OC.getCurrentUser().uid, AVATAR_SIZE_HEADING);
 			this.delegateEvents();
 			this.$el.find('.message').on('keydown input change', this._onTypeComment);
 
@@ -191,7 +194,7 @@
 						// misuse the highlighter callback to instead of
 						// highlighting loads the avatars.
 						var $li = $(li);
-						$li.find('.avatar').avatar(undefined, 32);
+						$li.find('.avatar').avatar(undefined, AVATAR_SIZE_TEXT);
 						return $li;
 					},
 					sorter: function (q, items) { return items; }
@@ -374,7 +377,7 @@
 					$message
 						.html(self._formatMessage(model.get('message'), model.get('mentions')))
 						.find('.avatar')
-						.each(function () { $(this).avatar(); });
+						.each(function () { $(this).avatar(undefined, AVATAR_SIZE_HEADING); });
 					self._postRenderItem($message);
 				}
 			});
@@ -384,7 +387,11 @@
 			$el.find('.has-tooltip').tooltip();
 			$el.find('.avatar').each(function() {
 				var $this = $(this);
-				$this.avatar($this.attr('data-username'), 32);
+				var size = AVATAR_SIZE_TEXT;
+				if($this.parents('.authorRow').length) {
+					size = AVATAR_SIZE_HEADING;
+				}
+				$this.avatar($this.attr('data-username'), size);
 			});
 
 			var username = $el.find('.avatar').data('username');
@@ -497,7 +504,7 @@
 			$message
 				.html(this._formatMessage(commentToEdit.get('message'), commentToEdit.get('mentions')))
 				.find('.avatar')
-				.each(function () { $(this).avatar(); });
+				.each(function () { $(this).avatar(undefined, AVATAR_SIZE_TEXT); });
 			var editionMode = true;
 			this._postRenderItem($message, editionMode);
 


### PR DESCRIPTION
@jancborchardt @dan0xii  there is still something odd with line breaks when the message is rendered. It's seems right in the edit mode (content-editable=true), but not in the plain one.

Before:

![screenshot_20171214_132139](https://user-images.githubusercontent.com/2184312/33992124-b9154280-e0d1-11e7-8fe4-5af65e6d2f6e.png)

![screenshot_20171214_132208](https://user-images.githubusercontent.com/2184312/33992152-ca5a84ec-e0d1-11e7-8ec1-61cf8a8e240e.png)

Now:

![screenshot_20171214_132040](https://user-images.githubusercontent.com/2184312/33992095-9583a190-e0d1-11e7-9012-114fe56e6d5a.png)

![screenshot_20171214_132007](https://user-images.githubusercontent.com/2184312/33992078-82114946-e0d1-11e7-86ef-0df0a494ed0c.png)



