### PR TITLE
Add index to share_with column in the share table

### DIFF
--- a/core/Command/Db/AddIndexToShareTable.php
+++ b/core/Command/Db/AddIndexToShareTable.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OC\Core\Command\Db;
+
+use OC\DB\SchemaWrapper;
+use OCP\IDBConnection;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class AddIndexToShareTable extends Command {
+
+	/** @var IDBConnection */
+	private $connection;
+
+	/**
+	 * @param IDBConnection $connection
+	 */
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('db:add-index-to-share-table')
+			->setDescription('Add a index to share_with at the share table to increase performance');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+
+		$schema = new SchemaWrapper($this->connection);
+		$updated = false;
+
+		if ($schema->hasTable("share")) {
+			$table = $schema->getTable("share");
+			if (!$table->hasIndex('share_with_index')) {
+				$output->writeln('<info>Adding additional index to the share table, this can take some time...</info>');
+				$table->addIndex(['share_with'], 'share_with_index');
+				$this->connection->migrateToSchema($schema->getWrappedSchema());
+				$updated = true;
+				$output->writeln('<info>Share table updated successfully.</info>');
+			}
+		}
+
+		if (!$updated) {
+			$output->writeln('<info>All index already existed, nothing to do.</info>');
+		}
+
+		return 0;
+
+	}
+}

--- a/core/Command/Db/AddMissingIndices.php
+++ b/core/Command/Db/AddMissingIndices.php
@@ -28,7 +28,15 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class AddIndexToShareTable extends Command {
+/**
+ * Class AddMissingIndices
+ *
+ * if you added any new indices to the database, this is the right place to add
+ * it your update routine for existing instances
+ *
+ * @package OC\Core\Command\Db
+ */
+class AddMissingIndices extends Command {
 
 	/** @var IDBConnection */
 	private $connection;
@@ -43,11 +51,24 @@ class AddIndexToShareTable extends Command {
 
 	protected function configure() {
 		$this
-			->setName('db:add-index-to-share-table')
-			->setDescription('Add a index to share_with at the share table to increase performance');
+			->setName('db:add-missing-indices')
+			->setDescription('Add missing indices to the database tables');
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
+		$this->addShareTableIndicies($output);
+
+	}
+
+	/**
+	 * add missing indices to the share table
+	 *
+	 * @param OutputInterface $output
+	 * @throws \Doctrine\DBAL\Schema\SchemaException
+	 */
+	private function addShareTableIndicies(OutputInterface $output) {
+
+		$output->writeln('<info>Check indices of the share table.</info>');
 
 		$schema = new SchemaWrapper($this->connection);
 		$updated = false;
@@ -64,10 +85,7 @@ class AddIndexToShareTable extends Command {
 		}
 
 		if (!$updated) {
-			$output->writeln('<info>All index already existed, nothing to do.</info>');
+			$output->writeln('<info>Done.</info>');
 		}
-
-		return 0;
-
 	}
 }

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -400,6 +400,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 			$table->addIndex(['item_type', 'share_type'], 'item_share_type_index');
 			$table->addIndex(['file_source'], 'file_source_index');
 			$table->addIndex(['token'], 'token_index');
+			$table->addIndex(['share_with'], 'share_with_index');
 		}
 
 		if (!$schema->hasTable('jobs')) {

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -90,7 +90,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Db\ConvertType(\OC::$server->getConfig(), new \OC\DB\ConnectionFactory(\OC::$server->getSystemConfig())));
 	$application->add(new OC\Core\Command\Db\ConvertMysqlToMB4(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection(), \OC::$server->getURLGenerator(), \OC::$server->getLogger()));
 	$application->add(new OC\Core\Command\Db\ConvertFilecacheBigInt(\OC::$server->getDatabaseConnection()));
-	$application->add(new OC\Core\Command\Db\AddIndexToShareTable(\OC::$server->getDatabaseConnection()));
+	$application->add(new OC\Core\Command\Db\AddMissingIndices(\OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\Db\Migrations\StatusCommand(\OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\Db\Migrations\MigrateCommand(\OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\Db\Migrations\GenerateCommand(\OC::$server->getDatabaseConnection()));

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -90,6 +90,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Db\ConvertType(\OC::$server->getConfig(), new \OC\DB\ConnectionFactory(\OC::$server->getSystemConfig())));
 	$application->add(new OC\Core\Command\Db\ConvertMysqlToMB4(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection(), \OC::$server->getURLGenerator(), \OC::$server->getLogger()));
 	$application->add(new OC\Core\Command\Db\ConvertFilecacheBigInt(\OC::$server->getDatabaseConnection()));
+	$application->add(new OC\Core\Command\Db\AddIndexToShareTable(\OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\Db\Migrations\StatusCommand(\OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\Db\Migrations\MigrateCommand(\OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\Db\Migrations\GenerateCommand(\OC::$server->getDatabaseConnection()));

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -459,6 +459,7 @@ return array(
     'OC\\Core\\Command\\Config\\System\\DeleteConfig' => $baseDir . '/core/Command/Config/System/DeleteConfig.php',
     'OC\\Core\\Command\\Config\\System\\GetConfig' => $baseDir . '/core/Command/Config/System/GetConfig.php',
     'OC\\Core\\Command\\Config\\System\\SetConfig' => $baseDir . '/core/Command/Config/System/SetConfig.php',
+    'OC\\Core\\Command\\Db\\AddMissingIndices' => $baseDir . '/core/Command/Db/AddMissingIndices.php',
     'OC\\Core\\Command\\Db\\ConvertFilecacheBigInt' => $baseDir . '/core/Command/Db/ConvertFilecacheBigInt.php',
     'OC\\Core\\Command\\Db\\ConvertMysqlToMB4' => $baseDir . '/core/Command/Db/ConvertMysqlToMB4.php',
     'OC\\Core\\Command\\Db\\ConvertType' => $baseDir . '/core/Command/Db/ConvertType.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -489,6 +489,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Core\\Command\\Config\\System\\DeleteConfig' => __DIR__ . '/../../..' . '/core/Command/Config/System/DeleteConfig.php',
         'OC\\Core\\Command\\Config\\System\\GetConfig' => __DIR__ . '/../../..' . '/core/Command/Config/System/GetConfig.php',
         'OC\\Core\\Command\\Config\\System\\SetConfig' => __DIR__ . '/../../..' . '/core/Command/Config/System/SetConfig.php',
+        'OC\\Core\\Command\\Db\\AddMissingIndices' => __DIR__ . '/../../..' . '/core/Command/Db/AddMissingIndices.php',
         'OC\\Core\\Command\\Db\\ConvertFilecacheBigInt' => __DIR__ . '/../../..' . '/core/Command/Db/ConvertFilecacheBigInt.php',
         'OC\\Core\\Command\\Db\\ConvertMysqlToMB4' => __DIR__ . '/../../..' . '/core/Command/Db/ConvertMysqlToMB4.php',
         'OC\\Core\\Command\\Db\\ConvertType' => __DIR__ . '/../../..' . '/core/Command/Db/ConvertType.php',


### PR DESCRIPTION
Add a index to share_with. This should improve the performance quite a bit as we need to query all shares with a specific user every time we set up the file system.

For updating existing instances I created a occ script instead of a automated update step because this can take quite some time for large installation.