### PR TITLE
Also check for empty content length

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -406,6 +406,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		if ($this->method === 'PUT'
 			&& $this->getHeader('Content-Length') !== 0
 			&& $this->getHeader('Content-Length') !== null
+			&& $this->getHeader('Content-Length') !== ''
 			&& strpos($this->getHeader('Content-Type'), 'application/x-www-form-urlencoded') === false
 			&& strpos($this->getHeader('Content-Type'), 'application/json') === false
 		) {


### PR DESCRIPTION
My guess it this is caused by php 7.2

I was debugging the client with the https://github.com/nextcloud/end_to_end_encryption app. To encrypt a folder a PUT request is send to 

```<server>/ocs/v2.php/apps/end_to_end_encryption/api/v1/encrypted/<fileid>```

Without this patch this will fail. Because we don't correctly get the id from the urlparameters.