### PR TITLE
Fix drag shadow not visible when dragging a file on a narrow screen

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -649,6 +649,7 @@ table tr.summary td {
 
 table.dragshadow {
 	width:auto;
+	z-index: 100;
 }
 table.dragshadow td.filename {
 	padding-left:60px;

--- a/apps/files/css/mobile.scss
+++ b/apps/files/css/mobile.scss
@@ -69,4 +69,9 @@ table td.filename .nametext .innernametext {
 	display: block !important;
 }
 
+/* ensure that it is visible over #app-content */
+table.dragshadow {
+	z-index: 1000;
+}
+
 }

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -383,7 +383,6 @@ var dragOptions={
 	revert: 'invalid',
 	revertDuration: 300,
 	opacity: 0.7,
-	zIndex: 100,
 	appendTo: 'body',
 	cursorAt: { left: 24, top: 18 },
 	helper: createDragShadow,


### PR DESCRIPTION
When a file from the file list is dragged a drag shadow (a copy of the file row that follows the cursor position) is created. The drag shadow element is created as a direct child of the body element, so it needs a higher `z-index` than the one used for the file list to be visible.

In wide screens there is no problem, but [in narrow screens the `#app-content` uses a `z-index` of 1000](https://github.com/nextcloud/server/blob/c80b824a464cb3fb64386be7406f1498ef64766c/core/css/mobile.scss#L58) in order to be visible over the `#navigation-bar` when they overlap, so the `z-index` of the drag shadow must be at least 1000 to be visible over the file list.

Instead of updating the hardcoded `z-index` it was removed and replaced by CSS rules for `.dragshadow` elements to ease theming.

Before:
![files-drag-shadow-before](https://user-images.githubusercontent.com/26858233/34028029-c057fe04-e160-11e7-98b9-d20fb79f582f.png)

After:
![files-drag-shadow-after](https://user-images.githubusercontent.com/26858233/34028031-cac6f2e6-e160-11e7-8cf1-d73017696cf5.png)

If you test this note that there are other issues when dragging files: it is not supported on touch screens, it triggers a slide of the navigation bar on narrow screens and the file could be dragged endlessly to the right. Those issues will be fixed in other pull requests.
