### PR TITLE
don't use deprecated method for requesting memcache

### DIFF
--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -261,7 +261,7 @@ class Storage extends DAV implements ISharedStorage {
 	 * @return bool
 	 */
 	private function testRemoteUrl($url) {
-		$cache = $this->memcacheFactory->create('files_sharing_remote_url');
+		$cache = $this->memcacheFactory->createDistributed('files_sharing_remote_url');
 		if($cache->hasKey($url)) {
 			return (bool)$cache->get($url);
 		}

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -240,7 +240,7 @@ class ThemingDefaults extends \OC_Defaults {
 	 * @return array scss variables to overwrite
 	 */
 	public function getScssVariables() {
-		$cache = $this->cacheFactory->create('theming');
+		$cache = $this->cacheFactory->createDistributed('theming');
 		if ($value = $cache->get('getScssVariables')) {
 			return $value;
 		}
@@ -307,7 +307,7 @@ class ThemingDefaults extends \OC_Defaults {
 	 * @return bool
 	 */
 	public function shouldReplaceIcons() {
-		$cache = $this->cacheFactory->create('theming');
+		$cache = $this->cacheFactory->createDistributed('theming');
 		if($value = $cache->get('shouldReplaceIcons')) {
 			return (bool)$value;
 		}
@@ -329,7 +329,7 @@ class ThemingDefaults extends \OC_Defaults {
 	private function increaseCacheBuster() {
 		$cacheBusterKey = $this->config->getAppValue('theming', 'cachebuster', '0');
 		$this->config->setAppValue('theming', 'cachebuster', (int)$cacheBusterKey+1);
-		$this->cacheFactory->create('theming')->clear('getScssVariables');
+		$this->cacheFactory->createDistributed('theming')->clear('getScssVariables');
 	}
 
 	/**

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -78,7 +78,7 @@ class ThemingDefaultsTest extends TestCase {
 		$this->defaults = new \OC_Defaults();
 		$this->cacheFactory
 			->expects($this->any())
-			->method('create')
+			->method('createDistributed')
 			->with('theming')
 			->willReturn($this->cache);
 		$this->template = new ThemingDefaults(

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -100,7 +100,7 @@ class Connection extends LDAPUtility {
 												 !is_null($configID));
 		$memcache = \OC::$server->getMemCacheFactory();
 		if($memcache->isAvailable()) {
-			$this->cache = $memcache->create();
+			$this->cache = $memcache->createDistributed();
 		}
 		$helper = new Helper(\OC::$server->getConfig());
 		$this->doNotValidate = !in_array($this->configPrefix,

--- a/apps/user_ldap/lib/Proxy.php
+++ b/apps/user_ldap/lib/Proxy.php
@@ -50,7 +50,7 @@ abstract class Proxy {
 		$this->ldap = $ldap;
 		$memcache = \OC::$server->getMemCacheFactory();
 		if($memcache->isAvailable()) {
-			$this->cache = $memcache->create();
+			$this->cache = $memcache->createDistributed();
 		}
 	}
 

--- a/core/Command/Maintenance/UpdateTheme.php
+++ b/core/Command/Maintenance/UpdateTheme.php
@@ -57,7 +57,7 @@ class UpdateTheme extends UpdateJS {
 		parent::execute($input, $output);
 
 		// cleanup image cache
-		$c = $this->cacheFactory->create('imagePath');
+		$c = $this->cacheFactory->createDistributed('imagePath');
 		$c->clear('');
 		$output->writeln('<info>Image cache cleared');
 	}

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -306,7 +306,7 @@ class AppManager implements IAppManager {
 	 * Clear the cached list of apps when enabling/disabling an app
 	 */
 	public function clearAppsCache() {
-		$settingsMemCache = $this->memCacheFactory->create('settings');
+		$settingsMemCache = $this->memCacheFactory->createDistributed('settings');
 		$settingsMemCache->clear('listApps');
 	}
 

--- a/lib/private/Files/ObjectStore/Swift.php
+++ b/lib/private/Files/ObjectStore/Swift.php
@@ -82,7 +82,7 @@ class Swift implements IObjectStore {
 		}
 
 		$cacheFactory = \OC::$server->getMemCacheFactory();
-		$this->memcache = $cacheFactory->create('swift::' . $cacheKey);
+		$this->memcache = $cacheFactory->createDistributed('swift::' . $cacheKey);
 
 		$this->params = $params;
 	}

--- a/lib/private/IntegrityCheck/Checker.php
+++ b/lib/private/IntegrityCheck/Checker.php
@@ -87,7 +87,7 @@ class Checker {
 		$this->fileAccessHelper = $fileAccessHelper;
 		$this->appLocator = $appLocator;
 		$this->config = $config;
-		$this->cache = $cacheFactory->create(self::CACHE_KEY);
+		$this->cache = $cacheFactory->createDistributed(self::CACHE_KEY);
 		$this->appManager = $appManager;
 		$this->tempManager = $tempManager;
 	}

--- a/lib/private/OCS/DiscoveryService.php
+++ b/lib/private/OCS/DiscoveryService.php
@@ -46,7 +46,7 @@ class DiscoveryService implements IDiscoveryService {
 	public function __construct(ICacheFactory $cacheFactory,
 								IClientService $clientService
 	) {
-		$this->cache = $cacheFactory->create('ocs-discovery');
+		$this->cache = $cacheFactory->createDistributed('ocs-discovery');
 		$this->client = $clientService->newClient();
 	}
 

--- a/lib/private/Security/RateLimiting/Backend/MemoryCache.php
+++ b/lib/private/Security/RateLimiting/Backend/MemoryCache.php
@@ -45,7 +45,7 @@ class MemoryCache implements IBackend {
 	 */
 	public function __construct(ICacheFactory $cacheFactory,
 								ITimeFactory $timeFactory) {
-		$this->cache = $cacheFactory->create(__CLASS__);
+		$this->cache = $cacheFactory->createDistributed(__CLASS__);
 		$this->timeFactory = $timeFactory;
 	}
 

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -952,7 +952,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getConfig(),
 				$c->getThemingDefaults(),
 				\OC::$SERVERROOT,
-				$cacheFactory->create('SCSS')
+				$cacheFactory->createDistributed('SCSS')
 			);
 		});
 		$this->registerService(EventDispatcher::class, function () {

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -291,7 +291,7 @@ class TemplateLayout extends \OC_Template {
 			new JSCombiner(
 				\OC::$server->getAppDataDir('js'),
 				\OC::$server->getURLGenerator(),
-				\OC::$server->getMemCacheFactory()->create('JS'),
+				\OC::$server->getMemCacheFactory()->createDistributed('JS'),
 				\OC::$server->getSystemConfig(),
 				\OC::$server->getLogger()
 			)

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -151,7 +151,7 @@ class URLGenerator implements IURLGenerator {
 	 * Returns the path to the image.
 	 */
 	public function imagePath($app, $image) {
-		$cache = $this->cacheFactory->create('imagePath-'.md5($this->getBaseUrl()).'-');
+		$cache = $this->cacheFactory->createDistributed('imagePath-'.md5($this->getBaseUrl()).'-');
 		$cacheKey = $app.'-'.$image;
 		if($key = $cache->get($cacheKey)) {
 			return $key;

--- a/lib/private/legacy/helper.php
+++ b/lib/private/legacy/helper.php
@@ -497,7 +497,7 @@ class OC_Helper {
 	 * @return null|string
 	 */
 	public static function findBinaryPath($program) {
-		$memcache = \OC::$server->getMemCacheFactory()->create('findBinaryPath');
+		$memcache = \OC::$server->getMemCacheFactory()->createDistributed('findBinaryPath');
 		if ($memcache->hasKey($program)) {
 			return $memcache->get($program);
 		}

--- a/settings/ajax/uninstallapp.php
+++ b/settings/ajax/uninstallapp.php
@@ -43,8 +43,8 @@ $appId = OC_App::cleanAppId($appId);
 $result = OC_App::removeApp($appId);
 if($result !== false) {
 	// FIXME: Clear the cache - move that into some sane helper method
-	\OC::$server->getMemCacheFactory()->create('settings')->remove('listApps-0');
-	\OC::$server->getMemCacheFactory()->create('settings')->remove('listApps-1');
+	\OC::$server->getMemCacheFactory()->createDistributed('settings')->remove('listApps-0');
+	\OC::$server->getMemCacheFactory()->createDistributed('settings')->remove('listApps-1');
 	OC_JSON::success(array('data' => array('appid' => $appId)));
 } else {
 	$l = \OC::$server->getL10N('settings');

--- a/tests/Core/Command/Maintenance/UpdateTheme.php
+++ b/tests/Core/Command/Maintenance/UpdateTheme.php
@@ -74,7 +74,7 @@ class UpdateThemeTest extends TestCase {
 			->method('clear')
 			->with('');
 		$this->cacheFactory->expects($this->once())
-			->method('create')
+			->method('createDistributed')
 			->with('imagePath')
 			->willReturn($cache);
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -100,7 +100,7 @@ class AppManagerTest extends TestCase {
 		$this->cache = $this->createMock(ICache::class);
 		$this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 		$this->cacheFactory->expects($this->any())
-			->method('create')
+			->method('createDistributed')
 			->with('settings')
 			->willReturn($this->cache);
 		$this->manager = new AppManager($this->userSession, $this->appConfig, $this->groupManager, $this->cacheFactory, $this->eventDispatcher);

--- a/tests/lib/IntegrityCheck/CheckerTest.php
+++ b/tests/lib/IntegrityCheck/CheckerTest.php
@@ -60,7 +60,7 @@ class CheckerTest extends TestCase {
 
 		$this->cacheFactory
 			->expects($this->any())
-			->method('create')
+			->method('createDistributed')
 			->with('oc.integritycheck.checker')
 			->will($this->returnValue(new NullCache()));
 

--- a/tests/lib/Security/RateLimiting/Backend/MemoryCacheTest.php
+++ b/tests/lib/Security/RateLimiting/Backend/MemoryCacheTest.php
@@ -46,7 +46,7 @@ class MemoryCacheTest extends TestCase {
 
 		$this->cacheFactory
 			->expects($this->once())
-			->method('create')
+			->method('createDistributed')
 			->with('OC\Security\RateLimiting\Backend\MemoryCache')
 			->willReturn($this->cache);
 


### PR DESCRIPTION
Quick and painless, ``create()`` already calls ``createDistributed()``, effectively no change.

