### PR TITLE
Let DI handle the background job

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1093,16 +1093,6 @@ class Server extends ServerContainer implements IServerContainer {
 			return new CloudIdManager();
 		});
 
-		/* To trick DI since we don't extend the DIContainer here */
-		$this->registerService(CleanPreviewsBackgroundJob::class, function (Server $c) {
-			return new CleanPreviewsBackgroundJob(
-				$c->getRootFolder(),
-				$c->getLogger(),
-				$c->getJobList(),
-				new TimeFactory()
-			);
-		});
-
 		$this->registerAlias(\OCP\AppFramework\Utility\IControllerMethodReflector::class, \OC\AppFramework\Utility\ControllerMethodReflector::class);
 		$this->registerAlias('ControllerMethodReflector', \OCP\AppFramework\Utility\IControllerMethodReflector::class);
 


### PR DESCRIPTION
Fixes #7548

The DI can now do the magic itself. It could not before so we tricked it in Server.php. However then we failed to update the call to the constructor.

Long story short. Let the DI do the magic.