### PR TITLE
Cache final result of update check

### DIFF
--- a/lib/private/Updater/VersionCheck.php
+++ b/lib/private/Updater/VersionCheck.php
@@ -101,12 +101,10 @@ class VersionCheck {
 			} else {
 				libxml_clear_errors();
 			}
-		} else {
-			$data = [];
 		}
 
 		// Cache the result
-		$this->config->setAppValue('core', 'lastupdateResult', json_encode($data));
+		$this->config->setAppValue('core', 'lastupdateResult', json_encode($tmp));
 		return $tmp;
 	}
 


### PR DESCRIPTION
If the parsed data is not a valid response we should not cache it and only cache the preprocessed result set.

Fixes #7442


This method is called in https://github.com/nextcloud/server/blob/0eebff152a177dd59ed8773df26f1679f8a88e90/apps/updatenotification/lib/UpdateChecker.php#L44

If the `$data` instead of `$tmp` is cached, then the returned value in the first call and the second call could be different, because a different object is cached causing the array access error in #7442. 

I also added a unit test to verify that a missing attribute still results in a proper result with all keys.