### PR TITLE
Fix opening the menu in a share page

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -78,10 +78,13 @@
 		background-color: $color-main-background;
 		filter: drop-shadow(0 1px 3px $color-box-shadow);
 		border-radius: 0 0 3px 3px;
-		display: none;
 		box-sizing: border-box;
 		z-index: 2000;
 		position: absolute;
+
+		&:not(.popovermenu) {
+			display: none;
+		}
 
 		/* Dropdown arrow */
 		&:after {

--- a/tests/acceptance/features/app-files.feature
+++ b/tests/acceptance/features/app-files.feature
@@ -23,6 +23,17 @@ Feature: app-files
     When I open the details view for "welcome.txt"
     Then I see that the details view for "All files" section is open
 
+  Scenario: open the menu in a public shared link
+    Given I act as John
+    And I am logged in
+    And I share the link for "welcome.txt"
+    And I write down the shared link
+    When I act as Jane
+    And I visit the shared link I wrote down
+    And I see that the current page is the shared link I wrote down
+    And I open the Share menu
+    Then I see that the Share menu is shown
+
   Scenario: set a password to a shared link
     Given I am logged in
     And I share the link for "welcome.txt"


### PR DESCRIPTION
This pull request fixes a regression introduced in commit 2348d14e48d2482343bcc111347efcdd53c0faf8. Since that commit the menu of a Shared file page (in the Files app, open the right sidebar and the _Sharing_ tab for a file, enable _Share link_ and open that link) is no longer opened when clicking on the top right area of the header.

`.popovermenu` elements are visible or not depending on whether they also have the `open` CSS class or not. `#header .menu` elements were always hidden, so when both rules applied to the same element, like in the menu of a Share page, the element was always hidden due to `#header .menu` being more specific than `.popovermenu` and thus overriding its rules. Now, `#header .menu` elements are hidden only if they are not a `.popovermenu` too.
