### PR TITLE
Respect sharing options when searching for Sharees

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -614,6 +614,22 @@ class ShareesAPIController extends OCSController {
 					$exactEmailMatch = strtolower($emailAddress) === $lowerSearch;
 
 					if (isset($contact['isLocalSystemBook'])) {
+						if ($this->shareWithGroupOnly) {
+							/*
+							 * Check if the user may share with the user associated with the e-mail of the just found contact
+							 */
+							$userGroups = $this->groupManager->getUserGroupIds($this->userSession->getUser());
+							$found = false;
+							foreach ($userGroups as $userGroup) {
+								if ($this->groupManager->isInGroup($contact['UID'], $userGroup)) {
+									$found = true;
+									break;
+								}
+							}
+							if (!$found) {
+								continue;
+							}
+						}
 						if ($exactEmailMatch) {
 							try {
 								$cloud = $this->cloudIdManager->resolveCloudId($contact['CLOUD'][0]);


### PR DESCRIPTION
Backport of #7490 

I didn't backported the tests because some results are returned in the method and some are set using `sharees->result`.