### PR TITLE
[stable12] Fix duplicate session token after remembered login

### DIFF
--- a/lib/private/Authentication/Token/DefaultTokenProvider.php
+++ b/lib/private/Authentication/Token/DefaultTokenProvider.php
@@ -195,6 +195,7 @@ class DefaultTokenProvider implements IProvider {
 		$newToken->setRemember($token->getRemember());
 		$newToken->setLastActivity($this->time->getTime());
 		$this->mapper->insert($newToken);
+		$this->mapper->delete($token);
 	}
 
 	/**

--- a/tests/lib/Authentication/Token/DefaultTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/DefaultTokenProviderTest.php
@@ -318,6 +318,10 @@ class DefaultTokenProviderTest extends TestCase {
 			->expects($this->at(1))
 			->method('insert')
 			->with($newToken);
+		$this->mapper
+			->expects($this->at(2))
+			->method('delete')
+			->with($token);
 
 		$this->tokenProvider->renewSessionToken('oldId', 'newId');
 	}
@@ -384,6 +388,10 @@ class DefaultTokenProviderTest extends TestCase {
 			->expects($this->at(1))
 			->method('insert')
 			->with($this->equalTo($newToken));
+		$this->mapper
+			->expects($this->at(2))
+			->method('delete')
+			->with($token);
 
 		$this->tokenProvider->renewSessionToken('oldId', 'newId');
 	}


### PR DESCRIPTION
Backport of https://github.com/nextcloud/server/pull/6544#issuecomment-350847248 as requested by @oparoz / @rullzer 

Original PR description:
```
On a remembered login session, we create a new session token
in the database with the values of the old one. As we actually
don't need the old session token anymore, we can delete it right
away.
```

I found out that one of the two commits I wanted to backport had already been backported and so this is less risky than I originally though. I tested this by logging in with remember-me checked and then deleted the session cookies that would expire when the session ends: On reload, I'm still logged in and there's still only one entry in the list of active browser sessions.