### PR TITLE
Fix box shadow of header elements

### DIFF
--- a/core/css/fixes.scss
+++ b/core/css/fixes.scss
@@ -16,3 +16,10 @@ select {
 	visibility: hidden;
 }
 
+.ie #header .menu,
+.ie .header-left #navigation,
+.ie .ui-datepicker,
+.ie .ui-timepicker.ui-widget,
+.ie #appmenu li span {
+	box-shadow: 0 1px 10px $color-box-shadow;
+}

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -76,7 +76,7 @@
 	.menu {
 		top: 45px;
 		background-color: $color-main-background;
-		filter: drop-shadow(0 1px 3px $color-box-shadow);
+		filter: drop-shadow(0 1px 10px $color-box-shadow);
 		border-radius: 0 0 3px 3px;
 		display: none;
 		box-sizing: border-box;
@@ -210,7 +210,7 @@ nav {
 	left: -100%;
 	width: 160px;
 	background-color: $color-main-background;
-	filter: drop-shadow(0 1px 3px $color-box-shadow);
+	filter: drop-shadow(0 1px 10px $color-box-shadow);
 	&:after {
 		/* position of dropdown arrow */
 		left: 47%;
@@ -408,7 +408,6 @@ nav {
 #expanddiv {
 	right: 13px;
 	background: $color-main-background;
-	box-shadow: 0 1px 10px $color-box-shadow;
 	&:after {
 		/* position of dropdown arrow */
 		right: 13px;
@@ -483,7 +482,7 @@ nav {
 		display: none;
 		position: absolute;
 		overflow: visible;
-		background-color: rgba($color-main-background, .97);
+		background-color: $color-main-background;
 		white-space: nowrap;
 		border: none;
 		border-radius: $border-radius;
@@ -496,7 +495,7 @@ nav {
 		top: 45px;
 		transform: translateX(-50%);
 		padding: 4px 10px;
-		box-shadow: 0 1px 10px $color-box-shadow;
+		filter: drop-shadow(0 1px 10px $color-box-shadow);
 	}
 
 	li:hover span {


### PR DESCRIPTION
* unify shadow blur from 3px to 10px
* remove opacity of background of app labels
* for IE: use box-shadow as fallback (because the filter: drop-shadow is not supported)



Found while reviewing https://github.com/nextcloud/notifications/pull/89

cc @nextcloud/designers 

Before (opacity, ~~bigger blur, no shadow on notifications in Safari~~):

![bildschirmfoto 2017-12-19 um 12 10 16](https://user-images.githubusercontent.com/245432/34154499-fc075032-e4b5-11e7-963b-a0f8864a3a51.png)

After:

![bildschirmfoto 2017-12-19 um 12 09 56](https://user-images.githubusercontent.com/245432/34154525-11442574-e4b6-11e7-9a2a-ea92bdeecca1.png)
