### PR TITLE
Use javascript to send the actual password reset

### DIFF
--- a/core/js/lostpassword.js
+++ b/core/js/lostpassword.js
@@ -16,6 +16,7 @@ OC.Lostpassword = {
 		$('#lost-password').click(OC.Lostpassword.resetLink);
 		$('#lost-password-back').click(OC.Lostpassword.backToLogin);
 		$('form[name=login]').submit(OC.Lostpassword.onSendLink);
+		$('#reset-password #submit').click(OC.Lostpassword.resetPassword);
 		OC.Lostpassword.resetButtons();
 	},
 


### PR DESCRIPTION
Fixes #7574

During some refactoring the event linked to password reset got removed.
This ment that we just submitted a normal POST but without the CSRF
token. And none of the js magic to redirect afterwards.


To test:

1. Click forgot password so you get an e-mail with a reset link
2. Open link
3. Fill in new password

Before:
:boom: 

Now:
Proper redirect to the login page again.