### PR TITLE
Use correct SVG icon on share view

### DIFF
--- a/core/css/variables.scss
+++ b/core/css/variables.scss
@@ -15,7 +15,7 @@ $color-primary-element: $color-primary;
   @return lighten($color, $value);
 }
 
-$image-logo: '../img/logo-icon.svg?v=1';
+$image-logo: '../img/logo.svg?v=1';
 $image-login-background: '../img/background.png?v=2';
 
 $color-loading: #969696;


### PR DESCRIPTION
Discovered while testing #7575 - it seems that $image-logo SCSS variable was pointing to a deprecated SVG image.
Before:
![image](https://user-images.githubusercontent.com/4129927/34165205-ee1350c2-e4db-11e7-81f0-b703dcf67a30.png)
![image](https://user-images.githubusercontent.com/4129927/34165181-dd84f954-e4db-11e7-94f9-44544d5b7436.png)


After:
![image](https://user-images.githubusercontent.com/4129927/34165254-0c5194a4-e4dc-11e7-9f3f-f106f80deed1.png)
![image](https://user-images.githubusercontent.com/4129927/34165132-b810eef8-e4db-11e7-9962-f3b03637d7fa.png)
