### PR TITLE
Fix custom share expiry date datepicker location

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -210,7 +210,7 @@ nav {
 .ui-datepicker,
 .ui-timepicker.ui-widget {
 	position: relative;
-	left: -100%;
+	left: -44px;
 	width: 160px;
 	background-color: $color-main-background;
 	filter: drop-shadow(0 1px 10px $color-box-shadow);

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -525,7 +525,7 @@
 					}
 			});
 
-			$(expirationDatePicker).addClass('hidden-visually');
+			// $(expirationDatePicker).addClass('hidden-visually');
 		},
 
 		setExpirationDate: function(shareId, expireDate) {


### PR DESCRIPTION
Fixes #7007 

This is still a work-in-progress. I have changed the `left` to a magical `44px` that seems to do the trick for this particular problem (without causing a break anywhere else).

I've also disabled hiding the datepicker input field when datepicker calendar is shown, because that didn't seem right. The problem is, now it shows "Invalid date" - instead, it should probably just show default "placeholder" (which is not set for this field).

TODO:

- [ ] remove "Invalid date" input value
- [ ] add a default placeholder to the input
- [ ] make sure datepicker popover doesn't change parent popover's width

I could use some help and/or advice, @nextcloud/designers @nextcloud/javascript 