### PR TITLE
Fix anchor change when clicking on sharing page menu

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -50,7 +50,7 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 
 		<div class="header-right">
 			<?php if (!isset($_['hideFileList']) || (isset($_['hideFileList']) && $_['hideFileList'] === false)) { ?>
-			<a href="#" id="share-menutoggle" class="menutoggle icon-more-white"><span class="share-menutoggle-text"><?php p($l->t('Download')) ?></span></a>
+			<a id="share-menutoggle" class="menutoggle icon-more-white"><span class="share-menutoggle-text"><?php p($l->t('Download')) ?></span></a>
 			<div id="share-menu" class="popovermenu menu">
 				<ul>
 					<li>
@@ -60,7 +60,7 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 						</a>
 					</li>
 					<li>
-						<a href="#" id="directLink-container">
+						<a id="directLink-container">
 							<span class="icon icon-public"></span>
 							<label for="directLink"><?php p($l->t('Direct link')) ?></label>
 							<input id="directLink" type="text" readonly value="<?php p($_['previewURL']); ?>">
@@ -68,7 +68,7 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 					</li>
 					<?php if ($_['server2serversharing']) { ?>
 					<li>
-						<a href="#" id="save" data-protected="<?php p($_['protected']) ?>"
+						<a id="save" data-protected="<?php p($_['protected']) ?>"
 							  data-owner-display-name="<?php p($_['displayName']) ?>" data-owner="<?php p($_['owner']) ?>" data-name="<?php p($_['filename']) ?>">
 							<span class="icon icon-external"></span>
 							<span id="save-button"><?php p($l->t('Add to your Nextcloud')) ?></span>


### PR DESCRIPTION
Fixes the PDF viewer related part of #7509.

The share menu toggle and some share menu items included an `href="#"` attribute, so they were handled as internal links by the browser, which changed the current anchor when they were clicked. However, there was no real need to change the anchor in those cases, and it could interfere with other apps (for example, [the PDF viewer sets the current anchor to "#pdfviewer" when it is shown and it hides itself when that anchor is modified](https://github.com/nextcloud/files_pdfviewer/blob/154556cd37cc12fdef9224e2f990437bb5068b36/js/previewplugin.js#L95-L103)). According to the HTML 5 spec (which I guess is our target spec, but I do not really know :-) ) [the `href` attribute is not mandatory for `a` elements](https://www.w3.org/TR/html53/links.html#element-attrdef-a-href), so they were removed.

Other options would have been to change the elements from `a` to `div` or something like that, but [that would have required changes to the CSS rules too](https://github.com/nextcloud/server/blob/bb04e106514f51c056f030ceef2c34cff355ef4b/core/css/apps.scss#L827), or to prevent the default event handling for those elements through JavaScript, which would have been a workaround instead of the proper solution.

@nextcloud/designers 
