### PR TITLE
Fix closing menu on second click in sharing page

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -434,10 +434,13 @@ $(document).ready(function () {
 
 
 $(document).mouseup(function(e) {
+	var toggle = $('#share-menutoggle');
 	var container = $('#share-menu');
 
-	// if the target of the click isn't the container nor a descendant of the container
-	if (!container.is(e.target) && container.has(e.target).length === 0) {
+	// if the target of the click isn't the menu toggle, nor a descendant of the
+	// menu toggle, nor the container nor a descendant of the container
+	if (!toggle.is(e.target) && toggle.has(e.target).length === 0 &&
+			!container.is(e.target) && container.has(e.target).length === 0) {
 		container.removeClass('open');
 	}
 });


### PR DESCRIPTION
This pull request addresses (with a big delay, but better late than never :-P ) [a comment in the original pull request that added the menu to the sharing page](https://github.com/nextcloud/server/pull/6652#issuecomment-333167740).

When a `mouseup` event was triggered on any element except on the share menu or its descendants the share menu was closed. The share menu toggle is not a descendant of the share menu, so clicking on it when the share menu was shown closed it by removing its `open` CSS class. However, once
that happened the click event was then handled by the share menu toggle, which toggled the `open` CSS class in the share menu and thus added it again. So, from the user point of view, nothing happened when clicking on the share menu toggle if the share menu was open.

Now a `mouseup` event on the share menu toggle no longer closes the share menu, and thus toggling the `open` CSS class when handling the `click` event works as expected.

@nextcloud/designers 
