### PR TITLE
don't show recurring log msg when paged result was turned off

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1095,8 +1095,11 @@ class Access extends LDAPUtility implements IUserTools {
 				$this->pagedSearchedSuccessful = true;
 			}
 		} else {
-			if(!is_null($limit)) {
-				\OCP\Util::writeLog('user_ldap', 'Paged search was not available', \OCP\Util::INFO);
+			if(!is_null($limit) && intval($this->connection->ldapPagingSize) !== 0) {
+				\OC::$server->getLogger()->debug(
+					'Paged search was not available',
+					[ 'app' => 'user_ldap' ]
+				);
 			}
 		}
 		/* ++ Fixing RHDS searches with pages with zero results ++

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -50,7 +50,7 @@ use OC\ServerNotAvailableException;
  * @property boolean turnOnPasswordChange
  * @property boolean hasPagedResultSupport
  * @property string[] ldapBaseUsers
- * @property int|string ldapPagingSize holds an integer
+ * @property int|null ldapPagingSize holds an integer
  * @property bool|mixed|void ldapGroupMemberAssocAttr
  * @property string ldapUuidUserAttribute
  * @property string ldapUuidGroupAttribute


### PR DESCRIPTION
and only as debug level otherwise.

It's a small change. Steps for testing:

1. Have LDAP enabled
2. Set PagingSize to 0 (LDAP settings → advanced → directory settings). This turns of using paged results with the LDAP server.
3. Trigger a search,  for instance in file sharing sidebar
4. check log

Previously:

See "Paged search was not available" for every LDAP search request, info level.

Now: 

The entry does not appear, since it was turned off intentionally.

@nextcloud/ldap 