### PR TITLE
Return the actual UID on client flow login

### DIFF
--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -316,7 +316,7 @@ class ClientFlowLoginController extends Controller {
 			}
 
 			$serverPath = $this->request->getServerProtocol() . "://" . $this->request->getServerHost() . $serverPostfix;
-			$redirectUri = 'nc://login/server:' . $serverPath . '&user:' . urlencode($loginName) . '&password:' . urlencode($token);
+			$redirectUri = 'nc://login/server:' . $serverPath . '&user:' . urlencode($uid) . '&password:' . urlencode($token);
 		}
 
 		return new Http\RedirectResponse($redirectUri);


### PR DESCRIPTION
Fixes #7593

The loginname is stored as the name used to login with. In case of a
username login this is case insensitive. While other parts might depend
upon case sensitive uids.


@blizzz this should also work fine on ldap right?