### PR TITLE
Wait for the shared link to be set in the acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -640,7 +640,7 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	private function waitForElementToBeEventuallyNotShown($elementLocator, $timeout = 10, $timeoutStep = 1) {
 		$actor = $this->actor;
 
-		$elementNotFoundCallback = function() use ($actor, $elementLocator) {
+		$elementNotShownCallback = function() use ($actor, $elementLocator) {
 			try {
 				return !$actor->find($elementLocator)->isVisible();
 			} catch (NoSuchElementException $exception) {
@@ -648,6 +648,6 @@ class FilesAppContext implements Context, ActorAwareInterface {
 			}
 		};
 
-		return Utils::waitFor($elementNotFoundCallback, $timeout, $timeoutStep);
+		return Utils::waitFor($elementNotShownCallback, $timeout, $timeoutStep);
 	}
 }

--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -606,7 +606,9 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @When I see that the :tabName tab in the details view is eventually loaded
 	 */
 	public function iSeeThatTheTabInTheDetailsViewIsEventuallyLoaded($tabName) {
-		if (!$this->waitForElementToBeEventuallyNotShown(self::loadingIconForTabInCurrentSectionDetailsViewNamed($tabName), $timeout = 10)) {
+		if (!$this->waitForElementToBeEventuallyNotShown(
+				self::loadingIconForTabInCurrentSectionDetailsViewNamed($tabName),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
 			PHPUnit_Framework_Assert::fail("The $tabName tab in the details view has not been loaded after $timeout seconds");
 		}
 	}
@@ -622,7 +624,9 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @Then I see that the working icon for password protect is eventually not shown
 	 */
 	public function iSeeThatTheWorkingIconForPasswordProtectIsEventuallyNotShown() {
-		if (!$this->waitForElementToBeEventuallyNotShown(self::passwordProtectWorkingIcon(), $timeout = 10)) {
+		if (!$this->waitForElementToBeEventuallyNotShown(
+				self::passwordProtectWorkingIcon(),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
 			PHPUnit_Framework_Assert::fail("The working icon for password protect is still shown after $timeout seconds");
 		}
 	}


### PR DESCRIPTION
When clicking on _Share link_ in the _Sharing_ tab of the Files app an input field with the link appears. That input field already exists in the DOM, although empty, before clicking on _Share link_, and when that is done the proper value is set and then the input field is shown.

In the acceptance tests `getValue()` can return the value of hidden elements too, so as long as an element exists its value is returned without waiting for the field to be visible. Due to this if the test code runs too fast the _I write down the shared link_ step could be executed before the proper value was set, so the shared link got in that case would be an empty value. Then, when the link was tried to be visited no web page would load, and the acceptance test failed with a message like:
```
And I see that the current page is the shared link I wrote down # FilesSharingAppContext::iSeeThatTheCurrentPageIsTheSharedLinkIWroteDown()
      Failed asserting that two strings are equal.
      --- Expected
      +++ Actual
      @@ @@
      -''
      +'about:blank'
```

This pull request should prevent those failures from appearing again. Once it is "_confirmed_" that it works (that is, the failures have not been seen in a while, as unfortunately they are not deterministic :-( ) it should be backported to _stable12_ too.
