### PR TITLE
Don't attempt to translate login names to uids when uids are provided

### DIFF
--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -1343,10 +1343,6 @@ class User_LDAPTest extends TestCase {
 					}
 					return true;
 			   }));
-
-		$access->userManager->expects($this->atLeastOnce())
-			->method('get')
-			->willReturn($this->createMock(User::class));
 	}
 
 	/**
@@ -1357,6 +1353,9 @@ class User_LDAPTest extends TestCase {
 		$access = $this->getAccessMock();
 
 		$this->prepareAccessForSetPassword($access);
+		$access->userManager->expects($this->atLeastOnce())
+			->method('get')
+			->willReturn($this->createMock(User::class));
 		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
 		\OC_User::useBackend($backend);
 

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -224,6 +224,12 @@ class LostController extends Controller {
 			return new JSONResponse($this->error($this->l10n->t('Password reset is disabled')));
 		}
 
+		\OCP\Util::emitHook(
+			'\OCA\Files_Sharing\API\Server2Server',
+			'preLoginNameUsedAsUserName',
+			['uid' => &$user]
+		);
+
 		// FIXME: use HTTP error codes
 		try {
 			$this->sendEmail($user);

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -152,16 +152,6 @@ class Manager extends PublicEmitter implements IUserManager {
 			return $this->cachedUsers[$uid];
 		}
 
-		if (method_exists($backend, 'loginName2UserName')) {
-			$loginName = $backend->loginName2UserName($uid);
-			if ($loginName !== false) {
-				$uid = $loginName;
-			}
-			if (isset($this->cachedUsers[$uid])) {
-				return $this->cachedUsers[$uid];
-			}
-		}
-
 		$user = new User($uid, $backend, $this, $this->config);
 		if ($cacheUser) {
 			$this->cachedUsers[$uid] = $user;

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -368,39 +368,6 @@ class FilesystemTest extends \Test\TestCase {
 		$this->assertEquals(2, $thrown);
 	}
 
-	public function testUserNameCasing() {
-		$this->logout();
-		$userId = $this->getUniqueID('user_');
-
-		\OC_User::clearBackends();
-		// needed for loginName2UserName mapping
-		$userBackend = $this->createMock(\OC\User\Database::class);
-		\OC::$server->getUserManager()->registerBackend($userBackend);
-
-		$userBackend->expects($this->once())
-			->method('userExists')
-			->with(strtoupper($userId))
-			->will($this->returnValue(true));
-		$userBackend->expects($this->once())
-			->method('loginName2UserName')
-			->with(strtoupper($userId))
-			->will($this->returnValue($userId));
-
-		$view = new \OC\Files\View();
-		$this->assertFalse($view->file_exists('/' . $userId));
-
-		\OC\Files\Filesystem::initMountPoints(strtoupper($userId));
-
-		list($storage1, $path1) = $view->resolvePath('/' . $userId);
-		list($storage2, $path2) = $view->resolvePath('/' . strtoupper($userId));
-
-		$this->assertTrue($storage1->instanceOfStorage('\OCP\Files\IHomeStorage'));
-		$this->assertEquals('', $path1);
-
-		// not mounted, still on the local root storage
-		$this->assertEquals(strtoupper($userId), $path2);
-	}
-
 	/**
 	 * Tests that the home storage is used for the user's mount point
 	 */

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -185,9 +185,8 @@ class ManagerTest extends TestCase {
 			->method('userExists')
 			->with($this->equalTo('foo'))
 			->will($this->returnValue(true));
-		$backend->expects($this->once())
-			->method('loginName2UserName')
-			->willReturn(false);
+		$backend->expects($this->never())
+			->method('loginName2UserName');
 
 		$manager = new \OC\User\Manager($this->config);
 		$manager->registerBackend($backend);
@@ -211,6 +210,24 @@ class ManagerTest extends TestCase {
 		$this->assertEquals(null, $manager->get('foo'));
 	}
 
+	public function testGetOneBackendDoNotTranslateLoginNames() {
+		/**
+		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend
+		 */
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
+		$backend->expects($this->once())
+			->method('userExists')
+			->with($this->equalTo('bLeNdEr'))
+			->will($this->returnValue(true));
+		$backend->expects($this->never())
+			->method('loginName2UserName');
+
+		$manager = new \OC\User\Manager($this->config);
+		$manager->registerBackend($backend);
+
+		$this->assertEquals('bLeNdEr', $manager->get('bLeNdEr')->getUID());
+	}
+
 	public function testSearchOneBackend() {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend
@@ -220,6 +237,8 @@ class ManagerTest extends TestCase {
 			->method('getUsers')
 			->with($this->equalTo('fo'))
 			->will($this->returnValue(array('foo', 'afoo')));
+		$backend->expects($this->never())
+			->method('loginName2UserName');
 
 		$manager = new \OC\User\Manager($this->config);
 		$manager->registerBackend($backend);
@@ -239,9 +258,8 @@ class ManagerTest extends TestCase {
 			->method('getUsers')
 			->with($this->equalTo('fo'), $this->equalTo(3), $this->equalTo(1))
 			->will($this->returnValue(array('foo1', 'foo2')));
-		$backend1->expects($this->exactly(2))
-			->method('loginName2UserName')
-			->willReturn(false);
+		$backend1->expects($this->never())
+			->method('loginName2UserName');
 
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend2
@@ -251,9 +269,8 @@ class ManagerTest extends TestCase {
 			->method('getUsers')
 			->with($this->equalTo('fo'), $this->equalTo(3), $this->equalTo(1))
 			->will($this->returnValue(array('foo3')));
-		$backend2->expects($this->once())
-			->method('loginName2UserName')
-			->willReturn(false);
+		$backend2->expects($this->never())
+			->method('loginName2UserName');
 
 		$manager = new \OC\User\Manager($this->config);
 		$manager->registerBackend($backend1);
@@ -333,9 +350,8 @@ class ManagerTest extends TestCase {
 			->method('userExists')
 			->with($this->equalTo('foo'))
 			->will($this->returnValue(false));
-		$backend->expects($this->once())
-			->method('loginName2UserName')
-			->willReturn(false);
+		$backend->expects($this->never())
+			->method('loginName2UserName');
 
 		$manager = new \OC\User\Manager($this->config);
 		$manager->registerBackend($backend);

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -185,6 +185,9 @@ class ManagerTest extends TestCase {
 			->method('userExists')
 			->with($this->equalTo('foo'))
 			->will($this->returnValue(true));
+		$backend->expects($this->once())
+			->method('loginName2UserName')
+			->willReturn(false);
 
 		$manager = new \OC\User\Manager($this->config);
 		$manager->registerBackend($backend);
@@ -236,6 +239,9 @@ class ManagerTest extends TestCase {
 			->method('getUsers')
 			->with($this->equalTo('fo'), $this->equalTo(3), $this->equalTo(1))
 			->will($this->returnValue(array('foo1', 'foo2')));
+		$backend1->expects($this->exactly(2))
+			->method('loginName2UserName')
+			->willReturn(false);
 
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit_Framework_MockObject_MockObject $backend2
@@ -245,6 +251,9 @@ class ManagerTest extends TestCase {
 			->method('getUsers')
 			->with($this->equalTo('fo'), $this->equalTo(3), $this->equalTo(1))
 			->will($this->returnValue(array('foo3')));
+		$backend2->expects($this->once())
+			->method('loginName2UserName')
+			->willReturn(false);
 
 		$manager = new \OC\User\Manager($this->config);
 		$manager->registerBackend($backend1);
@@ -324,6 +333,9 @@ class ManagerTest extends TestCase {
 			->method('userExists')
 			->with($this->equalTo('foo'))
 			->will($this->returnValue(false));
+		$backend->expects($this->once())
+			->method('loginName2UserName')
+			->willReturn(false);
 
 		$manager = new \OC\User\Manager($this->config);
 		$manager->registerBackend($backend);

--- a/tests/lib/Util/User/Dummy.php
+++ b/tests/lib/Util/User/Dummy.php
@@ -108,6 +108,13 @@ class Dummy extends Backend implements \OCP\IUserBackend {
 		return false;
 	}
 
+	public function loginName2UserName($loginName) {
+		if(isset($this->users[strtolower($loginName)])) {
+			return strtolower($loginName);
+		}
+		return false;
+	}
+
 	/**
 	 * Get a list of all users
 	 *


### PR DESCRIPTION
It's a legacy of #1142 which was a downstream of a poor fix, that resolved password reset of local users, when the login name provided did not match the user name. The fix in place was to pipe every request to the user manager through the ``loginName2UserName`` even if a user id was provided. With other user backends (*cough* LDAP *cough*) it might not cost a bit of performance, but also may return false positives. Unfortunately this happens, so a backport is necessary.

While resolving login names to user names is not terribly rock solid, back then we introduced this mechanism for federated shares, since end users do not know their user id. This mechanism can be triggered by throwing a hook *on demand*. Which is what is happening now.

fixes #7445 #6986 
  