### PR TITLE
Fix "fileActions.currentFile" not set before using it

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -683,11 +683,14 @@
 					// the details to be shown.
 					event.preventDefault();
 					var filename = $tr.attr('data-file');
+					this.fileActions.currentFile = $tr.find('td');
 					var mime = this.fileActions.getCurrentMimeType();
 					var type = this.fileActions.getCurrentType();
 					var permissions = this.fileActions.getCurrentPermissions();
 					var action = this.fileActions.get(mime, type, permissions)['Details'];
 					if (action) {
+						// also set on global object for legacy apps
+						window.FileActions.currentFile = this.fileActions.currentFile;
 						action(filename, {
 							$file: $tr,
 							fileList: this,

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2489,6 +2489,30 @@ describe('OCA.Files.FileList tests', function() {
 			expect(context.fileActions).toBeDefined();
 			expect(context.dir).toEqual('/subdir');
 		});
+		it('Clicking on an empty space of the file row will trigger the "Details" action', function() {
+			var detailsActionStub = sinon.stub();
+			fileList.setFiles(testFiles);
+			// Override the "Details" action set internally by the FileList for
+			// easier testing.
+			fileList.fileActions.registerAction({
+				mime: 'all',
+				name: 'Details',
+				permissions: OC.PERMISSION_NONE,
+				actionHandler: detailsActionStub
+			});
+			// Ensure that the action works even if fileActions.currentFile is
+			// not set.
+			fileList.fileActions.currentFile = null;
+			var $tr = fileList.findFileEl('One.txt');
+			$tr.find('td.filename a.name').click();
+			expect(detailsActionStub.calledOnce).toEqual(true);
+			expect(detailsActionStub.getCall(0).args[0]).toEqual('One.txt');
+			var context = detailsActionStub.getCall(0).args[1];
+			expect(context.$file.is($tr)).toEqual(true);
+			expect(context.fileList).toBe(fileList);
+			expect(context.fileActions).toBe(fileList.fileActions);
+			expect(context.dir).toEqual('/subdir');
+		});
 		it('redisplays actions when new actions have been registered', function() {
 			var actionStub = sinon.stub();
 			var readyHandler = sinon.stub();


### PR DESCRIPTION
Follow-up fix for [the second commit](https://github.com/nextcloud/server/pull/7591/commits/96ed73343eadb8723ca3bc404259d054f42b181d) of #7591

When an empty area of a file row was clicked and the _Details_ action was executed `fileActions.currentFile` was not guaranteed to be set to the appropriate object (it depended on the previous actions of the user), so when it was used by `getCurrentMimeType()` and other FileActions functions they may not work as expected. Now it is explicitly set to the appropriate value before its use.
