### PR TITLE
Fixes password input being prompted every time.

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1675,13 +1675,16 @@ function initCore() {
 
 OC.PasswordConfirmation = {
 	callback: null,
-
+	pageLoadTime: null,
 	init: function() {
 		$('.password-confirm-required').on('click', _.bind(this.requirePasswordConfirmation, this));
+		this.pageLoadTime = moment.now();
 	},
 
 	requiresPasswordConfirmation: function() {
-		var timeSinceLogin = moment.now() - (nc_lastLogin * 1000);
+		var serverTimeDiff = this.pageLoadTime - (nc_pageLoad * 1000);
+		var timeSinceLogin = moment.now() - (serverTimeDiff + (nc_lastLogin * 1000));
+		
 		// if timeSinceLogin > 30 minutes and user backend allows password confirmation
 		return (backendAllowsPasswordConfirmation && timeSinceLogin > 30 * 60 * 1000);
 	},

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -1539,4 +1539,41 @@ describe('Core base tests', function() {
 			expect(snapperStub.close.calledTwice).toBe(true);
 		});
 	});
+	describe('Requires password confirmation', function () {
+		var stubMomentNow;
+		var stubJsPageLoadTime;
+
+		afterEach(function () {
+			delete window.nc_pageLoad;
+			delete window.nc_lastLogin;
+			delete window.backendAllowsPasswordConfirmation;
+
+			stubMomentNow.restore();
+			stubJsPageLoadTime.restore();
+		});
+
+		it('should not show the password confirmation dialog', function () {
+			// add server variables
+			window.nc_pageLoad = parseInt(new Date(2018, 0, 3, 1, 15, 0).getTime() / 1000);
+			window.nc_lastLogin = parseInt(new Date(2018, 0, 3, 1, 0, 0).getTime() / 1000);
+			window.backendAllowsPasswordConfirmation = true;
+
+			stubJsPageLoadTime = sinon.stub(OC.PasswordConfirmation, 'pageLoadTime').value(new Date(2018, 0, 3, 12, 15, 0).getTime());
+			stubMomentNow = sinon.stub(moment, 'now').returns(new Date(2018, 0, 3, 12, 20, 0).getTime());
+
+			expect(OC.PasswordConfirmation.requiresPasswordConfirmation()).toBeFalsy();
+		});
+
+		it('should show the password confirmation dialog', function () {
+			// add server variables
+			window.nc_pageLoad = parseInt(new Date(2018, 0, 3, 1, 15, 0).getTime() / 1000);
+			window.nc_lastLogin = parseInt(new Date(2018, 0, 3, 1, 0, 0).getTime() / 1000);
+			window.backendAllowsPasswordConfirmation = true;
+
+			stubJsPageLoadTime = sinon.stub(OC.PasswordConfirmation, 'pageLoadTime').value(new Date(2018, 0, 3, 12, 15, 0).getTime());
+			stubMomentNow = sinon.stub(moment, 'now').returns(new Date(2018, 0, 3, 12, 31, 0).getTime());
+
+			expect(OC.PasswordConfirmation.requiresPasswordConfirmation()).toBeTruthy();
+		});
+	});
 });

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -1552,7 +1552,7 @@ describe('Core base tests', function() {
 			stubJsPageLoadTime.restore();
 		});
 
-		it('should not show the password confirmation dialog', function () {
+		it('should not show the password confirmation dialog when server time is earlier than local time', function () {
 			// add server variables
 			window.nc_pageLoad = parseInt(new Date(2018, 0, 3, 1, 15, 0).getTime() / 1000);
 			window.nc_lastLogin = parseInt(new Date(2018, 0, 3, 1, 0, 0).getTime() / 1000);
@@ -1564,10 +1564,34 @@ describe('Core base tests', function() {
 			expect(OC.PasswordConfirmation.requiresPasswordConfirmation()).toBeFalsy();
 		});
 
-		it('should show the password confirmation dialog', function () {
+		it('should show the password confirmation dialog when server time is earlier than local time', function () {
 			// add server variables
 			window.nc_pageLoad = parseInt(new Date(2018, 0, 3, 1, 15, 0).getTime() / 1000);
 			window.nc_lastLogin = parseInt(new Date(2018, 0, 3, 1, 0, 0).getTime() / 1000);
+			window.backendAllowsPasswordConfirmation = true;
+
+			stubJsPageLoadTime = sinon.stub(OC.PasswordConfirmation, 'pageLoadTime').value(new Date(2018, 0, 3, 12, 15, 0).getTime());
+			stubMomentNow = sinon.stub(moment, 'now').returns(new Date(2018, 0, 3, 12, 31, 0).getTime());
+
+			expect(OC.PasswordConfirmation.requiresPasswordConfirmation()).toBeTruthy();
+		});
+
+		it('should not show the password confirmation dialog when server time is later than local time', function () {
+			// add server variables
+			window.nc_pageLoad = parseInt(new Date(2018, 0, 3, 23, 15, 0).getTime() / 1000);
+			window.nc_lastLogin = parseInt(new Date(2018, 0, 3, 23, 0, 0).getTime() / 1000);
+			window.backendAllowsPasswordConfirmation = true;
+
+			stubJsPageLoadTime = sinon.stub(OC.PasswordConfirmation, 'pageLoadTime').value(new Date(2018, 0, 3, 12, 15, 0).getTime());
+			stubMomentNow = sinon.stub(moment, 'now').returns(new Date(2018, 0, 3, 12, 20, 0).getTime());
+
+			expect(OC.PasswordConfirmation.requiresPasswordConfirmation()).toBeFalsy();
+		});
+
+		it('should show the password confirmation dialog when server time is later than local time', function () {
+			// add server variables
+			window.nc_pageLoad = parseInt(new Date(2018, 0, 3, 23, 15, 0).getTime() / 1000);
+			window.nc_lastLogin = parseInt(new Date(2018, 0, 3, 23, 0, 0).getTime() / 1000);
 			window.backendAllowsPasswordConfirmation = true;
 
 			stubJsPageLoadTime = sinon.stub(OC.PasswordConfirmation, 'pageLoadTime').value(new Date(2018, 0, 3, 12, 15, 0).getTime());

--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -155,6 +155,7 @@ class JSConfigHelper {
 			"oc_appswebroots" =>  str_replace('\\/', '/', json_encode($apps_paths)), // Ugly unescape slashes waiting for better solution
 			"datepickerFormatDate" => json_encode($this->l->l('jsdate', null)),
 			'nc_lastLogin' => $lastConfirmTimestamp,
+			'nc_pageLoad' => time(),
 			"dayNames" =>  json_encode([
 				(string)$this->l->t('Sunday'),
 				(string)$this->l->t('Monday'),


### PR DESCRIPTION
@rullzer, @nickvergessen - Want to confirm that we're on the same page on this - 

Take the following scenario.

| Server Time | Last Password Confirm | Local Time |
|-------------|-----------------------|------------|
| 12:00 AM    | 11:45 AM              | 5:00 AM    |

In this case, we are showing the confirm dialog, although the dialog shouldn't be shown until 5:15 AM local time.

I've pushed a potential fix but just want to confirm that you are thinking along the same lines.

Here's what the fix does,

1. Echoing the current server time via a JS variable and storing the current time on page load in JS.
2. Calculating the diff and taking it into account when deciding whether to show the password confirmation.

I'll somehow test this once you guys confirm. Also any ideas how I can add test cases for this?