### PR TITLE
Don't spam the log when we could not properly connect to the appstore

### DIFF
--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -170,7 +170,7 @@ abstract class Fetcher {
 			$file->putContent(json_encode($responseJson));
 			return json_decode($file->getContent(), true)['data'];
 		} catch (ConnectException $e) {
-			$this->logger->logException($e, ['app' => 'appstoreFetcher']);
+			$this->logger->info('Could not connect to appstore', ['app' => 'appstoreFetcher']);
 			return [];
 		} catch (\Exception $e) {
 			return [];


### PR DESCRIPTION
If we can't connect to the appstore for some reason we don't have to log
the exception just an info entry is enough.

Avoids spamming the logs. And avoid spamming sentry.