### PR TITLE
Show max warning comment lenth again

### DIFF
--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -512,7 +512,7 @@
 
 		_onTypeComment: function(ev) {
 			var $field = $(ev.target);
-			var len = $field.val().length;
+			var len = $field.text().length;
 			var $submitButton = $field.data('submitButtonEl');
 			if (!$submitButton) {
 				$submitButton = $field.closest('form').find('.submit');

--- a/apps/comments/tests/js/commentstabviewSpec.js
+++ b/apps/comments/tests/js/commentstabviewSpec.js
@@ -411,7 +411,7 @@ describe('OCA.Comments.CommentsTabView tests', function() {
 				expect($message.hasClass('error')).toEqual(false);
 			});
 			it('displays tooltip when limit is almost reached', function() {
-				$message.val(createMessageWithLength(view._commentMaxLength - 2));
+				$message.text(createMessageWithLength(view._commentMaxLength - 2));
 				$message.trigger('change');
 
 				expect(tooltipStub.calledWith('show')).toEqual(true);
@@ -419,7 +419,7 @@ describe('OCA.Comments.CommentsTabView tests', function() {
 				expect($message.hasClass('error')).toEqual(false);
 			});
 			it('displays tooltip and disabled button when limit is exceeded', function() {
-				$message.val(createMessageWithLength(view._commentMaxLength + 2));
+				$message.text(createMessageWithLength(view._commentMaxLength + 2));
 				$message.trigger('change');
 
 				expect(tooltipStub.calledWith('show')).toEqual(true);


### PR DESCRIPTION
Fixes #7414

Since we no longer use an input field we have to use text instead of
val.

I basically just followed the debug session written down by @danxuliu in #7414 :)