### PR TITLE
Fixed redirection after password reset

### DIFF
--- a/core/js/lostpassword.js
+++ b/core/js/lostpassword.js
@@ -162,7 +162,7 @@ OC.Lostpassword = {
 		var resetErrorMsg;
 		if (result && result.status === 'success'){
 			$.post(
-					OC.webroot + '/',
+					OC.webroot + '/ocs/v1.php',
 					{
 						user : window.location.href.split('/').pop(),
 						password : $('#password').val()


### PR DESCRIPTION
Fixed error in lostpassword.js, that prevented redirecting after password reset.

I described the error here: https://github.com/nextcloud/server/issues/7218