### PR TITLE
Update "External storages" to current file list layout

### DIFF
--- a/apps/files_external/js/mountsfilelist.js
+++ b/apps/files_external/js/mountsfilelist.js
@@ -30,6 +30,8 @@
 		/** @lends OCA.External.FileList.prototype */ {
 		appName: 'External storages',
 
+		_allowSelection: false,
+
 		/**
 		 * @private
 		 */
@@ -56,7 +58,6 @@
 			$scopeColumn.find('span').text(scopeText);
 			$backendColumn.text(fileData.backend);
 			$tr.find('td.filename').after($scopeColumn).after($backendColumn);
-			$tr.find('td.filename input:checkbox').remove();
 			return $tr;
 		},
 

--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -489,7 +489,7 @@ OCA.External.StatusManager.Utils = {
 			}
 		});
 
-		var icon = trFolder.find('td:first-child div.thumbnail');
+		var icon = trFolder.find('td.filename div.thumbnail');
 		icon.each(function () {
 			var thisElement = $(this);
 			if (thisElement.data('oldImage') === undefined) {
@@ -510,7 +510,7 @@ OCA.External.StatusManager.Utils = {
 			trFolder = $('#fileList tr[data-file=\"' + OCA.External.StatusManager.Utils.jqSelEscape(folder) + '\"]');
 		}
 		trFolder.removeClass('externalErroredRow').removeClass('externalDisabledRow');
-		var tdChilds = trFolder.find("td:first-child div.thumbnail");
+		var tdChilds = trFolder.find("td.filename div.thumbnail");
 		tdChilds.each(function () {
 			var thisElement = $(this);
 			thisElement.css('background-image', thisElement.data('oldImage'));
@@ -529,10 +529,10 @@ OCA.External.StatusManager.Utils = {
 			$.each(filename, function (index) {
 				route = OCA.External.StatusManager.Utils.getIconRoute($(this));
 				$(this).attr("data-icon", route);
-				$(this).find('td:first-child div.thumbnail').css('background-image', "url(" + route + ")").css('display', 'none').css('display', 'inline');
+				$(this).find('td.filename div.thumbnail').css('background-image', "url(" + route + ")").css('display', 'none').css('display', 'inline');
 			});
 		} else {
-			file = $("#fileList tr[data-file=\"" + this.jqSelEscape(filename) + "\"] > td:first-child div.thumbnail");
+			file = $("#fileList tr[data-file=\"" + this.jqSelEscape(filename) + "\"] > td.filename div.thumbnail");
 			var parentTr = file.parents('tr:first');
 			route = OCA.External.StatusManager.Utils.getIconRoute(parentTr);
 			parentTr.attr("data-icon", route);
@@ -573,7 +573,7 @@ OCA.External.StatusManager.Utils = {
 		if (filename instanceof $) {
 			link = filename;
 		} else {
-			link = $("#fileList tr[data-file=\"" + this.jqSelEscape(filename) + "\"] > td:first-child a.name");
+			link = $("#fileList tr[data-file=\"" + this.jqSelEscape(filename) + "\"] > td.filename a.name");
 		}
 		if (active) {
 			link.off('click.connectivity');


### PR DESCRIPTION
When [the checkbox was moved to where the favourite icon was shown before](https://github.com/nextcloud/server/pull/6709) the layout of the file list was modified. The first column is no longer the file name, so neither the thumbnail nor the name link were found. Due to this the thumbnail was not set to the appropriate icon, and the dummy event handler was not removed from the name link, so clicks on the name were basically ignored.

The layout change also caused the checkbox to not be removed on the _External storages_ file list; as the header has no checkbox column but the body rows do the file list looks broken. However, in this case the proper fix is to set `_allowSelection: false` in the file list object instead of explicitly removing the checkbox (it should have been done that way even before the layout change).

Fixes (theoretically; please test ;-) ) #7388 and #7437 

When testing this please note that marking an external storage as a favourite and other actions do not work as expected in the _External storage_ file list (although they do in _All files_). That is a different issue unrelated to the layout and it will be fixed in another pull request.
