### PR TITLE
Fix file list visible behind the multiselect header

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -247,7 +247,7 @@ table th.column-last, table td.column-last {
 table.multiselect thead {
 	position: fixed;
 	top: 89px;
-	z-index: 10;
+	z-index: 55;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 	left: 250px; /* sidebar */


### PR DESCRIPTION
Fixes #7540

When the file list is scrolled vertically its contents are visible behind the file list multiselect header. As mentioned by @jancborchardt [they are intended to be slightly visible](https://github.com/nextcloud/server/issues/7540#issuecomment-352109156), but currently some parts (the name and the file actions) are fully visible.

The problem comes from the z-index used for the header and those parts of the row; the z-index for `.nametext` was set to 50 in 22da869fb8460daf4b36d2519e6de2ba4251827a and the z-index for `.fileactions` was set to 50 in 5e02cedef3af7d96daee643a465b68131fe253bf Both values are needed for the right behaviour of the file list, so this has to be fixed by setting an even higher z-index value for the header.

When the original issue was filled the problem happened too in the controls bar (breadcrumbs and add button), but it was fixed in https://github.com/nextcloud/server/pull/7478/commits/3105a2780b8eaf5528e8025f7681d0291cf35778 For consistency with that the z-index value of the header was set too to 55.

@nextcloud/designers 
