### PR TITLE
[stable12] Fix drag shadow not visible when dragging a file on a narrow screen

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -681,6 +681,7 @@ table tr.summary td {
 
 table.dragshadow {
 	width:auto;
+	z-index: 100;
 }
 table.dragshadow td.filename {
 	padding-left:60px;

--- a/apps/files/css/mobile.scss
+++ b/apps/files/css/mobile.scss
@@ -85,4 +85,9 @@ table td.filename .nametext .innernametext {
 	display: block !important;
 }
 
+/* ensure that it is visible over #app-content */
+table.dragshadow {
+	z-index: 1000;
+}
+
 }

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -383,7 +383,6 @@ var dragOptions={
 	revert: 'invalid',
 	revertDuration: 300,
 	opacity: 0.7,
-	zIndex: 100,
 	appendTo: 'body',
 	cursorAt: { left: 24, top: 18 },
 	helper: createDragShadow,


### PR DESCRIPTION
Backport of #7527 