### PR TITLE
Fix popover menu not closing in user settings

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -970,7 +970,7 @@ $(document).ready(function () {
 		$tr.addClass('active');
 	});
 
-	$(document.body).click(function () {
+	$(document).on('mouseup', function () {
 		$('#userlist tr.active').removeClass('active');
 		$('#userlist .popovermenu.open').removeClass('open');
 	});

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -972,6 +972,7 @@ $(document).ready(function () {
 
 	$(document.body).click(function () {
 		$('#userlist tr.active').removeClass('active');
+		$('#userlist .popovermenu.open').removeClass('open');
 	});
 
 	$userListBody.on('click', '.action-togglestate', function (event) {


### PR DESCRIPTION
Fixes (partially; the position part is not covered here) #7617

This pull request fixes a regression introduced in commit https://github.com/nextcloud/server/pull/6669/commits/7fb329294958beab28a2cbd8370d5733de8ec4d0

Before that commit the popover menu in user settings was shown or not based on whether the popover menu element was descendant of an active row or not. The `active` CSS class was added to the row when clicking on the menu toggle and removed when clicking again on the menu toggle or on the body, either directly or through event propagation.

The aforementioned commit unified its behaviour with the guidelines, which is showing it when the popover menu element has the `open` CSS class. However, the `open` CSS class was removed only when clicking again on the menu toggle and not when clicking on the body, so once open it was not closed until the menu toggle was clicked again. This is fixed by removing the `open` CSS class too when clicking on the body.

~~Note that this pull request restores the same technique used to close the menu when it was based on the active row, and that technique has the same problems described in #7613 (for example, if clicking on the button to edit the user name the popover menu is not closed, because the event propagation is stopped and it never reaches the body element).~~
This pull request restores the same technique used to close the menu when it was based on the active row, although now `mouseup` is used instead of `click` (like for [other menus in the server](https://github.com/nextcloud/server/blob/de4028336aca79ab243fc0d1ad3a904d4cc72299/core/js/js.js#L1384-L1392)). Although the technique has the same problems described in #7613 the propagation of `mouseup` events is not stopped in the user settings elements, so the problems in this case are just theoretical and do not appear in practice.
