### PR TITLE
Fix logo URL in SCSS variables

### DIFF
--- a/core/css/variables.scss
+++ b/core/css/variables.scss
@@ -15,7 +15,7 @@ $color-primary-element: $color-primary;
   @return lighten($color, $value);
 }
 
-$image-logo: '../img/logo-icon.svg?v=1';
+$image-logo: '../img/logo.svg?v=1';
 $image-login-background: '../img/background.png?v=2';
 
 $color-loading: #969696;


### PR DESCRIPTION
This is a leftover from #5407, where the logo url is wrong in case the theming app is disabled.

