### PR TITLE
Use guest css on sharing authentication page

### DIFF
--- a/apps/files_sharing/css/authenticate.css
+++ b/apps/files_sharing/css/authenticate.css
@@ -8,6 +8,7 @@ form fieldset {
 	border-top-right-radius: 0;
 	border-bottom-right-radius: 0;
 	height: 45px;
+	box-sizing: border-box;
 	flex: 1 1 auto;
 	width: 100% !important;
 	min-width: 0; /* FF hack for to override default value */

--- a/apps/files_sharing/templates/authenticate.php
+++ b/apps/files_sharing/templates/authenticate.php
@@ -1,6 +1,7 @@
 <?php
 	/** @var $_ array */
 	/** @var $l \OCP\IL10N */
+	style('core', 'guest');
 	style('files_sharing', 'authenticate');
 	script('files_sharing', 'authenticate'); 
 ?>


### PR DESCRIPTION
This PR makes the files_sharing authentication page use the guest.css styles so we have a proper styling of the logo there.

Fixes #7575 as well as the wrong sizing of the default logo as described here. https://github.com/nextcloud/server/pull/7580#pullrequestreview-84529396