### PR TITLE
Make update notification open the new update view from apps management

### DIFF
--- a/apps/updatenotification/lib/Notification/Notifier.php
+++ b/apps/updatenotification/lib/Notification/Notifier.php
@@ -126,7 +126,7 @@ class Notifier implements INotifier {
 				]);
 
 			if ($this->isAdmin()) {
-				$notification->setLink($this->url->linkToRouteAbsolute('settings.AppSettings.viewApps') . '#app-' . $notification->getObjectType());
+				$notification->setLink($this->url->linkToRouteAbsolute('settings.AppSettings.viewApps', ['category' => 'updates']) . '#app-' . $notification->getObjectType());
 			}
 		}
 


### PR DESCRIPTION
Open the updates section instead of your apps when clicking an update notification. That way it is easier to find the app that requires an update.