### PR TITLE
Don't lie about the preview mimetype

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -128,7 +128,7 @@ class Generator {
 
 		// Try to get a cached preview. Else generate (and store) one
 		try {
-			$file = $this->getCachedPreview($previewFolder, $width, $height, $crop);
+			$file = $this->getCachedPreview($previewFolder, $width, $height, $crop, $maxPreview->getMimeType());
 		} catch (NotFoundException $e) {
 			$file = $this->generatePreview($previewFolder, $maxPreview, $width, $height, $crop, $maxWidth, $maxHeight);
 		}
@@ -173,7 +173,8 @@ class Generator {
 					continue;
 				}
 
-				$path = (string)$preview->width() . '-' . (string)$preview->height() . '-max.png';
+				$ext = $this->getExtention($preview->dataMimeType());
+				$path = (string)$preview->width() . '-' . (string)$preview->height() . '-max.' . $ext;
 				try {
 					$file = $previewFolder->newFile($path);
 					$file->putContent($preview->data());
@@ -201,14 +202,17 @@ class Generator {
 	 * @param int $width
 	 * @param int $height
 	 * @param bool $crop
+	 * @param string $mimeType
 	 * @return string
 	 */
-	private function generatePath($width, $height, $crop) {
+	private function generatePath($width, $height, $crop, $mimeType) {
 		$path = (string)$width . '-' . (string)$height;
 		if ($crop) {
 			$path .= '-crop';
 		}
-		$path .= '.png';
+
+		$ext = $this->getExtention($mimeType);
+		$path .= '.' . $ext;
 		return $path;
 	}
 
@@ -340,7 +344,7 @@ class Generator {
 		}
 
 
-		$path = $this->generatePath($width, $height, $crop);
+		$path = $this->generatePath($width, $height, $crop, $preview->dataMimeType());
 		try {
 			$file = $previewFolder->newFile($path);
 			$file->putContent($preview->data());
@@ -356,12 +360,13 @@ class Generator {
 	 * @param int $width
 	 * @param int $height
 	 * @param bool $crop
+	 * @param string $mimeType
 	 * @return ISimpleFile
 	 *
 	 * @throws NotFoundException
 	 */
-	private function getCachedPreview(ISimpleFolder $previewFolder, $width, $height, $crop) {
-		$path = $this->generatePath($width, $height, $crop);
+	private function getCachedPreview(ISimpleFolder $previewFolder, $width, $height, $crop, $mimeType) {
+		$path = $this->generatePath($width, $height, $crop, $mimeType);
 
 		return $previewFolder->getFile($path);
 	}
@@ -380,5 +385,22 @@ class Generator {
 		}
 
 		return $folder;
+	}
+
+	/**
+	 * @param string $mimeType
+	 * @return null|string
+	 */
+	private function getExtention($mimeType) {
+		switch ($mimeType) {
+			case 'image/png':
+				return 'png';
+			case 'image/jpeg':
+				return 'jpg';
+			case 'image/gif':
+				return 'gif';
+			default:
+				return null;
+		}
 	}
 }

--- a/lib/private/legacy/image.php
+++ b/lib/private/legacy/image.php
@@ -305,11 +305,12 @@ class OC_Image implements \OCP\IImage {
 	}
 
 	/**
-	 * @return null|string Returns the mimetype of the data
+	 * @return string Returns the mimetype of the data. Returns the empty string
+	 * if the data is not valid.
 	 */
 	public function dataMimeType() {
 		if (!$this->valid()) {
-			return null;
+			return '';
 		}
 
 		switch ($this->mimeType) {

--- a/lib/private/legacy/image.php
+++ b/lib/private/legacy/image.php
@@ -305,6 +305,24 @@ class OC_Image implements \OCP\IImage {
 	}
 
 	/**
+	 * @return null|string Returns the mimetype of the data
+	 */
+	public function dataMimeType() {
+		if (!$this->valid()) {
+			return null;
+		}
+
+		switch ($this->mimeType) {
+			case 'image/png':
+			case 'image/jpeg':
+			case 'image/gif':
+				return $this->mimeType;
+			default:
+				return 'image/png';
+		}
+	}
+
+	/**
 	 * @return null|string Returns the raw image data.
 	 */
 	public function data() {

--- a/lib/public/IImage.php
+++ b/lib/public/IImage.php
@@ -103,6 +103,12 @@ interface IImage {
 	public function resource();
 
 	/**
+	 * @return string Returns the raw data mimetype
+	 * @since 13.0.0
+	 */
+	public function dataMimeType();
+
+	/**
 	 * @return string Returns the raw image data.
 	 * @since 8.1.0
 	 */

--- a/tests/lib/Preview/GeneratorTest.php
+++ b/tests/lib/Preview/GeneratorTest.php
@@ -93,6 +93,8 @@ class GeneratorTest extends \Test\TestCase {
 		$maxPreview = $this->createMock(ISimpleFile::class);
 		$maxPreview->method('getName')
 			->willReturn('1000-1000-max.png');
+		$maxPreview->method('getMimeType')
+			->willReturn('image/png');
 
 		$previewFolder->method('getDirectoryListing')
 			->willReturn([$maxPreview]);
@@ -170,6 +172,7 @@ class GeneratorTest extends \Test\TestCase {
 		$image->method('width')->willReturn(2048);
 		$image->method('height')->willReturn(2048);
 		$image->method('valid')->willReturn(true);
+		$image->method('dataMimeType')->willReturn('image/png');
 
 		$this->helper->method('getThumbnail')
 			->will($this->returnCallback(function ($provider, $file, $x, $y) use ($invalidProvider, $validProvider, $image) {
@@ -185,6 +188,7 @@ class GeneratorTest extends \Test\TestCase {
 
 		$maxPreview = $this->createMock(ISimpleFile::class);
 		$maxPreview->method('getName')->willReturn('2048-2048-max.png');
+		$maxPreview->method('getMimeType')->willReturn('image/png');
 
 		$previewFile = $this->createMock(ISimpleFile::class);
 
@@ -219,6 +223,7 @@ class GeneratorTest extends \Test\TestCase {
 		$image->method('data')
 			->willReturn('my resized data');
 		$image->method('valid')->willReturn(true);
+		$image->method('dataMimeType')->willReturn('image/png');
 
 		$previewFile->expects($this->once())
 			->method('putContent')
@@ -362,6 +367,8 @@ class GeneratorTest extends \Test\TestCase {
 		$maxPreview = $this->createMock(ISimpleFile::class);
 		$maxPreview->method('getName')
 			->willReturn($maxX . '-' . $maxY . '-max.png');
+		$maxPreview->method('getMimeType')
+			->willReturn('image/png');
 
 		$previewFolder->method('getDirectoryListing')
 			->willReturn([$maxPreview]);
@@ -382,6 +389,7 @@ class GeneratorTest extends \Test\TestCase {
 		$image->method('height')->willReturn($maxY);
 		$image->method('width')->willReturn($maxX);
 		$image->method('valid')->willReturn(true);
+		$image->method('dataMimeType')->willReturn('image/png');
 
 		$preview = $this->createMock(ISimpleFile::class);
 		$previewFolder->method('newFile')


### PR DESCRIPTION
For legacy reasons we stored all the previews with a png extention.
However we did not put png data in them all the time.

This caused the preview endpoints to always report that a preview is a
png file. Which was a lie.

Since we abstract away from the storage etc in the previewmanager. There
is no need anymore to store them as .png files and instead we can use
the actual file extention.