### PR TITLE
Fixed js typehint for showHtml method

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1145,7 +1145,7 @@ OC.Notification={
 	 *
 	 * @param {string} html Message to display
 	 * @param {Object} [options] options
-	 * @param {string] [options.type] notification type
+	 * @param {string} [options.type] notification type
 	 * @param {int} [options.timeout=0] timeout value, defaults to 0 (permanent)
 	 * @return {jQuery} jQuery element for notification row
 	 */


### PR DESCRIPTION
This is a very small pr 😀 Noticed it while reading the [inofficial js docs](http://vincentpetry.net/ocjsdocs/OC.Notification.html) and also GitHub is highlighting it [here](https://github.com/nextcloud/server/blob/master/core/js/js.js#L1148).
  