### PR TITLE
Clear login token once apppassword is generated

### DIFF
--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -319,6 +319,9 @@ class ClientFlowLoginController extends Controller {
 			$redirectUri = 'nc://login/server:' . $serverPath . '&user:' . urlencode($loginName) . '&password:' . urlencode($token);
 		}
 
+		// Clear the token from the login here
+		$this->tokenProvider->invalidateToken($sessionId);
+
 		return new Http\RedirectResponse($redirectUri);
 	}
 }


### PR DESCRIPTION
Fixes #7697

When using the new login flow a token will be generated since we login.
However after that we generate yet another token to return (as we
should).

However we should kill the current session token as we are done with it.
And will never use it again.



To test use the android client for example (I don't know if IOS already has this?). Add a new account.

Before:
See 2 identical named sessions in the Security tab of your personal settings

Now:
Just see 1

CC: @tobiasKaminsky