### PR TITLE
Fix password displayed as username in Firefox password manager dialog

### DIFF
--- a/apps/user_ldap/js/renewPassword.js
+++ b/apps/user_ldap/js/renewPassword.js
@@ -46,5 +46,6 @@ $(document).ready(function() {
 			t('core', 'Strong password')
 		],
 		drawTitles: true,
+		$addAfter: $('input[name="newPassword-clone"]'),
 	});
 });

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "select2": "~3.4.8",
     "zxcvbn": "*",
     "snapjs": "~2.0.0-rc1",
-    "strengthify": "^0.5.2",
+    "strengthify": "^0.5.3",
     "underscore": "~1.8.0",
     "bootstrap": "~3.3.6",
     "backbone": "~1.2.3",

--- a/core/js/jquery-showpassword.js
+++ b/core/js/jquery-showpassword.js
@@ -74,7 +74,7 @@
             	
             	// Create clone
 				var $clone = cloneElement($input);
-					$clone.insertBefore($input);
+					$clone.insertAfter($input);
 				
 				// Set callback arguments
             	if(callback.fn){	

--- a/core/vendor/strengthify/.bower.json
+++ b/core/vendor/strengthify/.bower.json
@@ -1,6 +1,6 @@
 {
   "name": "strengthify",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "homepage": "https://github.com/MorrisJobke/strengthify",
   "authors": [
     "Eve Ragins <eve.ragins@eve-corp.com",
@@ -9,13 +9,13 @@
   "description": "Combine jQuery and zxcvbn to create a password strength meter.",
   "main": "jquery.strengthify.js",
   "license": "MIT",
-  "_release": "0.5.2",
+  "_release": "0.5.3",
   "_resolution": {
     "type": "version",
-    "tag": "0.5.2",
-    "commit": "82d63c39de1b7b60ae38d24d0f866cba325904b5"
+    "tag": "0.5.3",
+    "commit": "a97e861762ccb17ce5f51d5c608b5d9e42732ae3"
   },
   "_source": "https://github.com/MorrisJobke/strengthify.git",
-  "_target": "^0.5.2",
+  "_target": "^0.5.3",
   "_originalSource": "strengthify"
 }

--- a/core/vendor/strengthify/jquery.strengthify.js
+++ b/core/vendor/strengthify/jquery.strengthify.js
@@ -51,7 +51,8 @@
             },
             drawTitles: false,
             drawMessage: false,
-            drawBars: true
+            drawBars: true,
+            $addAfter: null
         };
 
         return this.each(function() {
@@ -175,8 +176,13 @@
                     elemId = $elem.attr('id');
                 var drawSelf = drawStrengthify.bind(this);
 
+                var $addAfter = options.$addAfter;
+                if (!$addAfter) {
+                    $addAfter = $elem;
+                }
+
                 // add elements
-                $elem.after('<div class="strengthify-wrapper" data-strengthifyFor="' + $elem.attr('id') + '"></div>');
+                $addAfter.after('<div class="strengthify-wrapper" data-strengthifyFor="' + $elem.attr('id') + '"></div>');
 
                 if (options.drawBars) {
                     getWrapperFor(elemId)

--- a/settings/js/settings/personalInfo.js
+++ b/settings/js/settings/personalInfo.js
@@ -395,6 +395,7 @@ $(document).ready(function () {
 			t('settings', 'Strong password')
 		],
 		drawTitles: true,
+		$addAfter: $('input[name="newpassword-clone"]'),
 	});
 
 	// Load the big avatar


### PR DESCRIPTION
Fixes (in master) #7031

The problem was (besides the [password manager ignoring `autocomplete="off"`](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#The_autocomplete_attribute_and_login_fields)) that the password input element (in the HTML form) is cloned in a text input element, which is used to show the password in plain text when clicking on the _Show password_ button. As it was a text input immediately followed by a password input Firefox seemed to assume that it had to be the username and ignored the real username field, no matter the value set for the `autocomplete` attribute (`autocomplete="off"` for the whole form, `autocomplete="street-name"` (because it is a [supported `autocomplete` value](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autocomplete) that has nothing to do with login) or `autocomplete="new-password"` for the cloned text input, `autocomplete="name/username/email"` for the username text input, nor combinations of those).

Now the cloned text input is added after the password input, so Firefox no longer thinks that the cloned text input is the username field and the password manager dialog shows the proper username instead.

Chromium was not affected by the original issue (it also offers to save the credentials, but its password manager dialog showed the proper username), and it still works as before after the change.
