### PR TITLE
Fix avatar display to not overwrite display style

### DIFF
--- a/core/js/jquery.avatar.js
+++ b/core/js/jquery.avatar.js
@@ -110,9 +110,8 @@
 
 		// If the new image loads successfully set it.
 		img.onload = function() {
-			$div.text('');
-			$div.append(img);
 			$div.clearimageplaceholder();
+			$div.append(img);
 
 			if(typeof callback === 'function') {
 				callback();
@@ -127,7 +126,6 @@
 				$div.imageplaceholder(user, displayname);
 			} else {
 				setAvatarForUnknownUser($div);
-				$div.removeClass('icon-loading');
 			}
 
 			if(typeof callback === 'function') {
@@ -136,7 +134,6 @@
 		};
 
 		$div.addClass('icon-loading');
-		$div.show();
 		img.width = size;
 		img.height = size;
 		img.src = url;

--- a/core/js/placeholder.js
+++ b/core/js/placeholder.js
@@ -156,6 +156,7 @@
 		this.css('text-align', '');
 		this.css('line-height', '');
 		this.css('font-size', '');
+		this.html('');
 		this.removeClass('icon-loading');
 	};
 }(jQuery));

--- a/core/js/tests/specs/jquery.avatarSpec.js
+++ b/core/js/tests/specs/jquery.avatarSpec.js
@@ -202,8 +202,6 @@ describe('jquery.avatar tests', function() {
 			expect(window.Image().height).toEqual(32);
 			expect(window.Image().width).toEqual(32);
 			expect(window.Image().src).toEqual('http://localhost/index.php/avatar/foo/32');
-
-			expect($div.css('display')).toEqual('block');
 		});
 
 		it('callback called', function() {


### PR DESCRIPTION
We always show the avatar container, so we don't need the show() call. The image is added after successful loading. This was caused by #7498 since we reduced the two code paths to one.

Fix for https://github.com/nextcloud/spreed/issues/539