### PR TITLE
Use correct L10N files for jsconfig

### DIFF
--- a/core/Controller/OCJSController.php
+++ b/core/Controller/OCJSController.php
@@ -34,11 +34,11 @@ use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IGroupManager;
-use OCP\IL10N;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
+use OCP\L10N\IFactory;
 
 class OCJSController extends Controller {
 
@@ -50,7 +50,7 @@ class OCJSController extends Controller {
 	 *
 	 * @param string $appName
 	 * @param IRequest $request
-	 * @param IL10N $l
+	 * @param IFactory $l10nFactory
 	 * @param Defaults $defaults
 	 * @param IAppManager $appManager
 	 * @param ISession $session
@@ -62,7 +62,7 @@ class OCJSController extends Controller {
 	 */
 	public function __construct($appName,
 								IRequest $request,
-								IL10N $l,
+								IFactory $l10nFactory,
 								Defaults $defaults,
 								IAppManager $appManager,
 								ISession $session,
@@ -74,7 +74,7 @@ class OCJSController extends Controller {
 		parent::__construct($appName, $request);
 
 		$this->helper = new JSConfigHelper(
-			$l,
+			$l10nFactory->get('lib'),
 			$defaults,
 			$appManager,
 			$session,

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -146,7 +146,7 @@ class TemplateLayout extends \OC_Template {
 		if ($this->config->getSystemValue('installed', false) && $renderAs != 'error') {
 			if (\OC::$server->getContentSecurityPolicyNonceManager()->browserSupportsCspV3()) {
 				$jsConfigHelper = new JSConfigHelper(
-					\OC::$server->getL10N('core'),
+					\OC::$server->getL10N('lib'),
 					\OC::$server->query(Defaults::class),
 					\OC::$server->getAppManager(),
 					\OC::$server->getSession(),


### PR DESCRIPTION
To test:

1. set lanugage to other than english
2. open date picket (for example when setting expiration date on a share)

Before: still english
Now: Properly translated