### PR TITLE
Fix LDAP Background Sync does not reset offset

### DIFF
--- a/apps/user_ldap/composer/composer/autoload_classmap.php
+++ b/apps/user_ldap/composer/composer/autoload_classmap.php
@@ -7,6 +7,7 @@ $baseDir = $vendorDir;
 
 return array(
     'OCA\\User_LDAP\\Access' => $baseDir . '/../lib/Access.php',
+    'OCA\\User_LDAP\\AccessFactory' => $baseDir . '/../lib/AccessFactory.php',
     'OCA\\User_LDAP\\AppInfo\\Application' => $baseDir . '/../lib/AppInfo/Application.php',
     'OCA\\User_LDAP\\BackendUtility' => $baseDir . '/../lib/BackendUtility.php',
     'OCA\\User_LDAP\\Command\\CheckUser' => $baseDir . '/../lib/Command/CheckUser.php',
@@ -19,6 +20,7 @@ return array(
     'OCA\\User_LDAP\\Command\\TestConfig' => $baseDir . '/../lib/Command/TestConfig.php',
     'OCA\\User_LDAP\\Configuration' => $baseDir . '/../lib/Configuration.php',
     'OCA\\User_LDAP\\Connection' => $baseDir . '/../lib/Connection.php',
+    'OCA\\User_LDAP\\ConnectionFactory' => $baseDir . '/../lib/ConnectionFactory.php',
     'OCA\\User_LDAP\\Controller\\ConfigAPIController' => $baseDir . '/../lib/Controller/ConfigAPIController.php',
     'OCA\\User_LDAP\\Controller\\RenewPasswordController' => $baseDir . '/../lib/Controller/RenewPasswordController.php',
     'OCA\\User_LDAP\\Exceptions\\ConstraintViolationException' => $baseDir . '/../lib/Exceptions/ConstraintViolationException.php',

--- a/apps/user_ldap/composer/composer/autoload_static.php
+++ b/apps/user_ldap/composer/composer/autoload_static.php
@@ -19,6 +19,7 @@ class ComposerStaticInitUser_LDAP
 
     public static $classMap = array (
         'OCA\\User_LDAP\\Access' => __DIR__ . '/..' . '/../lib/Access.php',
+        'OCA\\User_LDAP\\AccessFactory' => __DIR__ . '/..' . '/../lib/AccessFactory.php',
         'OCA\\User_LDAP\\AppInfo\\Application' => __DIR__ . '/..' . '/../lib/AppInfo/Application.php',
         'OCA\\User_LDAP\\BackendUtility' => __DIR__ . '/..' . '/../lib/BackendUtility.php',
         'OCA\\User_LDAP\\Command\\CheckUser' => __DIR__ . '/..' . '/../lib/Command/CheckUser.php',
@@ -31,6 +32,7 @@ class ComposerStaticInitUser_LDAP
         'OCA\\User_LDAP\\Command\\TestConfig' => __DIR__ . '/..' . '/../lib/Command/TestConfig.php',
         'OCA\\User_LDAP\\Configuration' => __DIR__ . '/..' . '/../lib/Configuration.php',
         'OCA\\User_LDAP\\Connection' => __DIR__ . '/..' . '/../lib/Connection.php',
+        'OCA\\User_LDAP\\ConnectionFactory' => __DIR__ . '/..' . '/../lib/ConnectionFactory.php',
         'OCA\\User_LDAP\\Controller\\ConfigAPIController' => __DIR__ . '/..' . '/../lib/Controller/ConfigAPIController.php',
         'OCA\\User_LDAP\\Controller\\RenewPasswordController' => __DIR__ . '/..' . '/../lib/Controller/RenewPasswordController.php',
         'OCA\\User_LDAP\\Exceptions\\ConstraintViolationException' => __DIR__ . '/..' . '/../lib/Exceptions/ConstraintViolationException.php',

--- a/apps/user_ldap/lib/AccessFactory.php
+++ b/apps/user_ldap/lib/AccessFactory.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_LDAP;
+
+
+use OCA\User_LDAP\User\Manager;
+use OCP\IConfig;
+
+class AccessFactory {
+	/** @var ILDAPWrapper */
+	protected $ldap;
+	/** @var Manager */
+	protected $userManager;
+	/** @var Helper */
+	protected $helper;
+	/** @var IConfig */
+	protected $config;
+
+	public function __construct(
+		ILDAPWrapper $ldap,
+		Manager $userManager,
+		Helper $helper,
+		IConfig $config)
+	{
+		$this->ldap = $ldap;
+		$this->userManager = $userManager;
+		$this->helper = $helper;
+		$this->config = $config;
+	}
+
+	public function get(Connection $connection) {
+		return new Access(
+			$connection,
+			$this->ldap,
+			$this->userManager,
+			$this->helper,
+			$this->config
+		);
+	}
+}

--- a/apps/user_ldap/lib/ConnectionFactory.php
+++ b/apps/user_ldap/lib/ConnectionFactory.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_LDAP;
+
+
+class ConnectionFactory {
+	/** @var ILDAPWrapper */
+	private $ldap;
+
+	public function __construct(ILDAPWrapper $ldap) {
+		$this->ldap = $ldap;
+	}
+
+	public function get($prefix) {
+		return new Connection($this->ldap, $prefix, 'user_ldap');
+	}
+}

--- a/apps/user_ldap/lib/Jobs/Sync.php
+++ b/apps/user_ldap/lib/Jobs/Sync.php
@@ -118,7 +118,7 @@ class Sync extends TimedJob {
 	/**
 	 * @param array $argument
 	 */
-	protected function run($argument) {
+	public function run($argument) {
 		$this->setArgument($argument);
 
 		$isBackgroundJobModeAjax = $this->config
@@ -252,7 +252,7 @@ class Sync extends TimedJob {
 	 * @param $cycleData
 	 * @return bool
 	 */
-	protected function qualifiesToRun($cycleData) {
+	public function qualifiesToRun($cycleData) {
 		$lastChange = $this->config->getAppValue('user_ldap', $cycleData['prefix'] . '_lastChange', 0);
 		if((time() - $lastChange) > 60 * 30) {
 			return true;

--- a/apps/user_ldap/lib/Jobs/Sync.php
+++ b/apps/user_ldap/lib/Jobs/Sync.php
@@ -179,7 +179,7 @@ class Sync extends TimedJob {
 		if($connection->ldapPagingSize === 0) {
 			return true;
 		}
-		return count($results) !== $connection->ldapPagingSize;
+		return count($results) >= $connection->ldapPagingSize;
 	}
 
 	/**

--- a/apps/user_ldap/lib/Jobs/Sync.php
+++ b/apps/user_ldap/lib/Jobs/Sync.php
@@ -26,8 +26,10 @@ namespace OCA\User_LDAP\Jobs;
 use OC\BackgroundJob\TimedJob;
 use OC\ServerNotAvailableException;
 use OCA\User_LDAP\Access;
+use OCA\User_LDAP\AccessFactory;
 use OCA\User_LDAP\Configuration;
 use OCA\User_LDAP\Connection;
+use OCA\User_LDAP\ConnectionFactory;
 use OCA\User_LDAP\FilesystemHelper;
 use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\LDAP;
@@ -62,6 +64,10 @@ class Sync extends TimedJob {
 	protected $ncUserManager;
 	/** @var  IManager */
 	protected $notificationManager;
+	/** @var ConnectionFactory */
+	protected $connectionFactory;
+	/** @var AccessFactory */
+	protected $accessFactory;
 
 	public function __construct() {
 		$this->setInterval(
@@ -153,8 +159,8 @@ class Sync extends TimedJob {
 	 * @return bool whether more results are expected from the same configuration
 	 */
 	public function runCycle($cycleData) {
-		$connection = new Connection($this->ldap, $cycleData['prefix']);
-		$access = new Access($connection, $this->ldap, $this->userManager, $this->ldapHelper, $this->config);
+		$connection = $this->connectionFactory->get($cycleData['prefix']);
+		$access = $this->accessFactory->get($connection);
 		$access->setUserMapper($this->mapper);
 
 		$filter = $access->combineFilterWithAnd(array(
@@ -357,6 +363,23 @@ class Sync extends TimedJob {
 			$this->mapper = $argument['mapper'];
 		} else {
 			$this->mapper = new UserMapping($this->dbc);
+		}
+		
+		if(isset($argument['connectionFactory'])) {
+			$this->connectionFactory = $argument['connectionFactory'];
+		} else {
+			$this->connectionFactory = new ConnectionFactory($this->ldap);
+		}
+
+		if(isset($argument['accessFactory'])) {
+			$this->accessFactory = $argument['accessFactory'];
+		} else {
+			$this->accessFactory = new AccessFactory(
+				$this->ldap,
+				$this->userManager,
+				$this->ldapHelper,
+				$this->config
+			);
 		}
 	}
 }

--- a/apps/user_ldap/lib/Jobs/Sync.php
+++ b/apps/user_ldap/lib/Jobs/Sync.php
@@ -146,11 +146,11 @@ class Sync extends TimedJob {
 			if ($expectMoreResults) {
 				$this->increaseOffset($cycleData);
 			} else {
-				$this->determineNextCycle();
+				$this->determineNextCycle($cycleData);
 			}
 			$this->updateInterval();
 		} catch (ServerNotAvailableException $e) {
-			$this->determineNextCycle();
+			$this->determineNextCycle($cycleData);
 		}
 	}
 

--- a/apps/user_ldap/tests/Jobs/SyncTest.php
+++ b/apps/user_ldap/tests/Jobs/SyncTest.php
@@ -197,11 +197,15 @@ class SyncTest extends TestCase {
 	}
 
 	public function cycleDataProvider() {
-		$cycle1 = ['prefix' => 's01', 'offset' => 1000];
+		$lastCycle = ['prefix' => 's01', 'offset' => 1000];
+		$lastCycle2 = ['prefix' => '', 'offset' => 1000];
 		return [
 			[ null, ['s01'], ['prefix' => 's01', 'offset' => 0] ],
-			[ $cycle1, ['s01', 's02'], ['prefix' => 's02', 'offset' => 0] ],
-			[ $cycle1, [], null ],
+			[ null, [''], ['prefix' => '', 'offset' => 0] ],
+			[ $lastCycle, ['s01', 's02'], ['prefix' => 's02', 'offset' => 0] ],
+			[ $lastCycle, [''], ['prefix' => '', 'offset' => 0] ],
+			[ $lastCycle2, ['', 's01'], ['prefix' => 's01', 'offset' => 0] ],
+			[ $lastCycle, [], null ],
 		];
 	}
 
@@ -235,6 +239,18 @@ class SyncTest extends TestCase {
 			$this->assertSame($expectedCycle['prefix'], $nextCycle['prefix']);
 			$this->assertSame($expectedCycle['offset'], $nextCycle['offset']);
 		}
+	}
+
+	public function testQualifiesToRun() {
+		$cycleData = ['prefix' => 's01'];
+
+		$this->config->expects($this->exactly(2))
+			->method('getAppValue')
+			->willReturnOnConsecutiveCalls(time() - 60*40, time() - 60*20);
+
+		$this->sync->setArgument($this->arguments);
+		$this->assertTrue($this->sync->qualifiesToRun($cycleData));
+		$this->assertFalse($this->sync->qualifiesToRun($cycleData));
 	}
 
 }

--- a/apps/user_ldap/tests/Jobs/SyncTest.php
+++ b/apps/user_ldap/tests/Jobs/SyncTest.php
@@ -265,13 +265,22 @@ class SyncTest extends TestCase {
 				'expectedNextCycle' => ['prefix' => '', 'offset' => '0'],
 				'mappedUsers' => 123,
 			]],
-			#0 - 2 LDAP servers, next prefix
+			#1 - 2 LDAP servers, next prefix
 			[[
 				'prefixes' => ['', 's01'],
 				'scheduledCycle' => ['prefix' => '', 'offset' => '4500'],
 				'pagingSize' => 500,
 				'usersThisCycle' => 0,
 				'expectedNextCycle' => ['prefix' => 's01', 'offset' => '0'],
+				'mappedUsers' => 123,
+			]],
+			#2 - 2 LDAP servers, rotate prefix
+			[[
+				'prefixes' => ['', 's01'],
+				'scheduledCycle' => ['prefix' => 's01', 'offset' => '4500'],
+				'pagingSize' => 500,
+				'usersThisCycle' => 0,
+				'expectedNextCycle' => ['prefix' => '', 'offset' => '0'],
 				'mappedUsers' => 123,
 			]],
 		];


### PR DESCRIPTION
As observed on our instance… issue was that it was reported that more results are expected, while the count was already below the requested limit.