### PR TITLE
Hide favourite icon in details view if favourite action is not available

### DIFF
--- a/apps/files/js/mainfileinfodetailview.js
+++ b/apps/files/js/mainfileinfodetailview.js
@@ -20,9 +20,11 @@
 			'</a>' +
 		'</div>' +
 		'	<div class="file-details ellipsis">' +
+		'		{{#if hasFavoriteAction}}' +
 		'		<a href="#" class="action action-favorite favorite permanent">' +
 		'			<span class="icon {{starClass}}" title="{{starAltText}}"></span>' +
 		'		</a>' +
+		'		{{/if}}' +
 		'		{{#if hasSize}}<span class="size" title="{{altSize}}">{{size}}</span>, {{/if}}<span class="date live-relative-timestamp" data-timestamp="{{timestamp}}" title="{{altDate}}">{{date}}</span>' +
 		'	</div>' +
 		'</div>' +
@@ -175,6 +177,12 @@
 
 			if (this.model) {
 				var isFavorite = (this.model.get('tags') || []).indexOf(OC.TAG_FAVORITE) >= 0;
+				var availableActions = this._fileActions.get(
+					this.model.get('mimetype'),
+					this.model.get('type'),
+					this.model.get('permissions')
+				);
+				var hasFavoriteAction = 'Favorite' in availableActions;
 				this.$el.html(this.template({
 					type: this.model.isImage()? 'image': '',
 					nameLabel: t('files', 'Name'),
@@ -189,6 +197,7 @@
 					altDate: OC.Util.formatDate(this.model.get('mtime')),
 					timestamp: this.model.get('mtime'),
 					date: OC.Util.relativeModifiedDate(this.model.get('mtime')),
+					hasFavoriteAction: hasFavoriteAction,
 					starAltText: isFavorite ? t('files', 'Favorited') : t('files', 'Favorite'),
 					starClass: isFavorite ? 'icon-starred' : 'icon-star',
 					permalink: this._makePermalink(this.model.get('id')),

--- a/apps/files/tests/js/mainfileinfodetailviewSpec.js
+++ b/apps/files/tests/js/mainfileinfodetailviewSpec.js
@@ -68,6 +68,12 @@ describe('OCA.Files.MainFileInfoDetailView tests', function() {
 				.toEqual(OC.getProtocol() + '://' + OC.getHost() + OC.generateUrl('/f/5'));
 		});
 		it('displays favorite icon', function() {
+			fileActions.registerAction({
+				name: 'Favorite',
+				mime: 'all',
+				permissions: OC.PERMISSION_NONE
+			});
+
 			testFileInfo.set('tags', [OC.TAG_FAVORITE]);
 			view.setFileInfo(testFileInfo);
 			expect(view.$el.find('.action-favorite > span').hasClass('icon-starred')).toEqual(true);
@@ -77,6 +83,15 @@ describe('OCA.Files.MainFileInfoDetailView tests', function() {
 			view.setFileInfo(testFileInfo);
 			expect(view.$el.find('.action-favorite > span').hasClass('icon-starred')).toEqual(false);
 			expect(view.$el.find('.action-favorite > span').hasClass('icon-star')).toEqual(true);
+		});
+		it('does not display favorite icon if favorite action is not available', function() {
+			testFileInfo.set('tags', [OC.TAG_FAVORITE]);
+			view.setFileInfo(testFileInfo);
+			expect(view.$el.find('.action-favorite').length).toEqual(0);
+
+			testFileInfo.set('tags', []);
+			view.setFileInfo(testFileInfo);
+			expect(view.$el.find('.action-favorite').length).toEqual(0);
 		});
 		it('displays mime icon', function() {
 			// File
@@ -183,6 +198,13 @@ describe('OCA.Files.MainFileInfoDetailView tests', function() {
 			expect(view.$el.find('.fileName h3').attr('title')).toEqual('hello.txt');
 		});
 		it('rerenders when changes are made on the model', function() {
+			// Show the "Favorite" icon
+			fileActions.registerAction({
+				name: 'Favorite',
+				mime: 'all',
+				permissions: OC.PERMISSION_NONE
+			});
+
 			view.setFileInfo(testFileInfo);
 
 			testFileInfo.set('tags', [OC.TAG_FAVORITE]);
@@ -196,6 +218,13 @@ describe('OCA.Files.MainFileInfoDetailView tests', function() {
 			expect(view.$el.find('.action-favorite > span').hasClass('icon-star')).toEqual(true);
 		});
 		it('unbinds change listener from model', function() {
+			// Show the "Favorite" icon
+			fileActions.registerAction({
+				name: 'Favorite',
+				mime: 'all',
+				permissions: OC.PERMISSION_NONE
+			});
+
 			view.setFileInfo(testFileInfo);
 			view.setFileInfo(new OCA.Files.FileInfoModel({
 				id: 999,


### PR DESCRIPTION
Fixes (in master) #4568

The problem was that [the _Favorite_ file action is added only to some of the file lists](https://github.com/nextcloud/server/blob/c047f32f25a9c1448bf78ef65d5144f5b882b719/apps/files/js/tagsplugin.js#L224-L230), but [the icon in the details view was shown unconditionally](https://github.com/nextcloud/server/blob/599274f5096d04f63b95bd97b521963ef14a4ae1/apps/files/js/mainfileinfodetailview.js#L23-L25) for every file list, so when it was clicked and [the _Favorite_ action was tried to be triggered](https://github.com/nextcloud/server/blob/599274f5096d04f63b95bd97b521963ef14a4ae1/apps/files/js/mainfileinfodetailview.js#L128) it was not found and [the _Download_ action was executed instead](https://github.com/nextcloud/server/blob/c059fbd409b088f65922354149f6d2fd9b5d01b3/apps/files/js/fileactions.js#L481-L483).

Now the favourite icon is hidden if its action is not available.

