### PR TITLE
Fix "New" menu shown behind the multiselect header in the file list

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -234,7 +234,7 @@ body {
 	padding: 0;
 	margin: 0;
 	background-color: rgba($color-main-background, 0.95);
-	z-index: 55;
+	z-index: 60;
 	-webkit-user-select: none;
 	-moz-user-select: none;
 	-ms-user-select: none;


### PR DESCRIPTION
This pull request fixes a regression introduced in #7663 

The _New_ menu is a descendant of the controls bar, and the controls bar and the multiselect header belong to the same [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context). As they had the same z-index but the multiselect header appears after the controls bar in the DOM the controls bar and its descendants, including the _New_ menu, were rendered behind the multiselect header.

![files-menu-new-before](https://user-images.githubusercontent.com/26858233/34657930-3b48ebd2-f42b-11e7-96ad-512be97515ea.png)

Now the controls bar has a z-index value higher than the one used for the multiselect header to ensure that the _New_ menu is rendered in front of the multiselect header.

![files-menu-new-after](https://user-images.githubusercontent.com/26858233/34657935-3d4e5390-f42b-11e7-8ce5-95336ea76645.png)

@nextcloud/designers 

  