### PR TITLE
Improve shadow of tooltips

### DIFF
--- a/core/css/fixes.scss
+++ b/core/css/fixes.scss
@@ -20,6 +20,7 @@ select {
 .ie .header-left #navigation,
 .ie .ui-datepicker,
 .ie .ui-timepicker.ui-widget,
-.ie #appmenu li span {
+.ie #appmenu li span,
+.ie .tooltip-inner {
 	box-shadow: 0 1px 10px $color-box-shadow;
 }

--- a/core/css/tooltip.scss
+++ b/core/css/tooltip.scss
@@ -31,6 +31,7 @@
 	font-size: 12px;
 	opacity: 0;
 	z-index: 100000;
+	filter: drop-shadow(0 1px 10px $color-box-shadow);
 	&.in {
 		opacity: 1;
 	}
@@ -115,7 +116,6 @@
 	padding: 5px 8px;
 	background-color: $color-main-background;
 	color: $color-main-text;
-	box-shadow: 0 1px 10px $color-box-shadow;
 	text-align: center;
 	border-radius: $border-radius;
 }


### PR DESCRIPTION
Tooltips now have the same drop shadow that includes the arrow as the other popover elements.

Before / IE fallback:
![bildschirmfoto vom 2018-01-08 10-04-50](https://user-images.githubusercontent.com/3404133/34664627-19cba63e-f45d-11e7-858b-37aaad53693b.png)

After:
![bildschirmfoto vom 2018-01-08 10-04-32](https://user-images.githubusercontent.com/3404133/34664655-37b45fba-f45d-11e7-949f-81e656f1263b.png)

@nextcloud/designers 