### PR TITLE
Max preview size to 4096x4096

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -849,16 +849,16 @@ $CONFIG = array(
  * The maximum width, in pixels, of a preview. A value of ``null`` means there
  * is no limit.
  *
- * Defaults to ``2048``
+ * Defaults to ``4096``
  */
-'preview_max_x' => 2048,
+'preview_max_x' => 4096,
 /**
  * The maximum height, in pixels, of a preview. A value of ``null`` means there
  * is no limit.
  *
- * Defaults to ``2048``
+ * Defaults to ``4096``
  */
-'preview_max_y' => 2048,
+'preview_max_y' => 4096,
 
 /**
  * max file size for generating image previews with imagegd (default behavior)

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -164,8 +164,8 @@ class Generator {
 					continue;
 				}
 
-				$maxWidth = (int)$this->config->getSystemValue('preview_max_x', 2048);
-				$maxHeight = (int)$this->config->getSystemValue('preview_max_y', 2048);
+				$maxWidth = (int)$this->config->getSystemValue('preview_max_x', 4096);
+				$maxHeight = (int)$this->config->getSystemValue('preview_max_y', 4096);
 
 				$preview = $this->helper->getThumbnail($provider, $file, $maxWidth, $maxHeight);
 


### PR DESCRIPTION
With HiDPI screens. And even normal HD screens you want more detail from
your pictures. Or the ability to somewhat zoom on you previews. For this
we need somewhat larger previews.

Moving the default to 4096x4096 is a step up. Users that want the old
behavior can still set the values in config.php



We should mention this in the release notes... @jospoortvliet 