### PR TITLE
The max_scale_factor is not used anymore.

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -859,15 +859,6 @@ $CONFIG = array(
  * Defaults to ``2048``
  */
 'preview_max_y' => 2048,
-/**
- * If a lot of small pictures are stored on the Nextcloud instance and the
- * preview system generates blurry previews, you might want to consider setting
- * a maximum scale factor. By default, pictures are upscaled to 10 times the
- * original size. A value of ``1`` or ``null`` disables scaling.
- *
- * Defaults to ``2``
- */
-'preview_max_scale_factor' => 10,
 
 /**
  * max file size for generating image previews with imagegd (default behavior)


### PR DESCRIPTION
We never generate previews larger than the original. So the config
setting can be removed.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>