### PR TITLE
Fix SCSS processing when undoing theming values

### DIFF
--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -324,7 +324,7 @@ class ThemingController extends Controller {
 	public function undo($setting) {
 		$value = $this->themingDefaults->undo($setting);
 		// reprocess server scss for preview
-		$cssCached = $this->scssCacher->process(\OC::$SERVERROOT, '/core/css/server.scss', 'core');
+		$cssCached = $this->scssCacher->process(\OC::$SERVERROOT, 'core/css/server.scss', 'core');
 
 		if($setting === 'logoMime') {
 			try {


### PR DESCRIPTION
As discussed with @skjnldsv on IRC, rebasing of urls in SCSS doesn't work when resetting values in the theming app. This PR fixes that behaviour as well.

Signed-off-by: Julius Härtl <jus@bitgrid.net>

Follow-up pr of #7710 

probably fixes #7721 as well

@nextcloud/theming 