### PR TITLE
Remove "DEBUG OUTPUT:" from failing OCS API requests

### DIFF
--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -81,7 +81,7 @@ try {
 
 	$format = \OC::$server->getRequest()->getParam('format', 'xml');
 	$txt='Invalid query, please check the syntax. API specifications are here:'
-		.' http://www.freedesktop.org/wiki/Specifications/open-collaboration-services. DEBUG OUTPUT:'."\n";
+		.' http://www.freedesktop.org/wiki/Specifications/open-collaboration-services.'."\n";
 	OC_API::respond(new \OC\OCS\Result(null, \OCP\API::RESPOND_NOT_FOUND, $txt), $format);
 } catch (MethodNotAllowedException $e) {
 	OC_API::setContentType();
@@ -96,7 +96,7 @@ try {
 
 	$format = \OC::$server->getRequest()->getParam('format', 'xml');
 	$txt='Invalid query, please check the syntax. API specifications are here:'
-		.' http://www.freedesktop.org/wiki/Specifications/open-collaboration-services. DEBUG OUTPUT:'."\n";
+		.' http://www.freedesktop.org/wiki/Specifications/open-collaboration-services.'."\n";
 	OC_API::respond(new \OC\OCS\Result(null, \OCP\API::RESPOND_NOT_FOUND, $txt), $format);
 }
 


### PR DESCRIPTION
Just some cleanup. There was never (at least not since I'm involved) an output behind this phrase. Also the code doesn't show anything.