### PR TITLE
Don't encode paths that will be passed to the davclient

### DIFF
--- a/apps/dav/lib/Upload/UploadHome.php
+++ b/apps/dav/lib/Upload/UploadHome.php
@@ -66,7 +66,8 @@ class UploadHome implements ICollection {
 	}
 
 	function getName() {
-		return 'uploads';
+		list(,$name) = \Sabre\Uri\split($this->principalInfo['uri']);
+		return $name;
 	}
 
 	function setName($name) {

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -235,7 +235,7 @@ OC.FileUpload.prototype = {
 		) {
 			data.isChunked = true;
 			chunkFolderPromise = this.uploader.davClient.createDirectory(
-				'uploads/' + encodeURIComponent(OC.getCurrentUser().uid) + '/' + encodeURIComponent(this.getId())
+				'uploads/' + OC.getCurrentUser().uid + '/' + this.getId()
 			);
 			// TODO: if fails, it means same id already existed, need to retry
 		} else {
@@ -272,8 +272,8 @@ OC.FileUpload.prototype = {
 		}
 
 		return this.uploader.davClient.move(
-			'uploads/' + encodeURIComponent(uid) + '/' + encodeURIComponent(this.getId()) + '/.file',
-			'files/' + encodeURIComponent(uid) + '/' + OC.joinPaths(this.getFullPath(), this.getFileName()),
+			'uploads/' + uid + '/' + this.getId() + '/.file',
+			'files/' + uid + '/' + OC.joinPaths(this.getFullPath(), this.getFileName()),
 			true,
 			headers
 		);
@@ -282,7 +282,7 @@ OC.FileUpload.prototype = {
 	_deleteChunkFolder: function() {
 		// delete transfer directory for this upload
 		this.uploader.davClient.remove(
-			'uploads/' + encodeURIComponent(OC.getCurrentUser().uid) + '/' + encodeURIComponent(this.getId())
+			'uploads/' + OC.getCurrentUser().uid + '/' + this.getId()
 		);
 	},
 
@@ -1166,9 +1166,9 @@ OC.Uploader.prototype = _.extend({
 					var chunkId = range.split('/')[0].split('-')[0];
 					data.url = OC.getRootPath() +
 						'/remote.php/dav/uploads' +
-						'/' + encodeURIComponent(OC.getCurrentUser().uid) +
-						'/' + encodeURIComponent(upload.getId()) +
-						'/' + encodeURIComponent(chunkId);
+						'/' + OC.getCurrentUser().uid +
+						'/' + upload.getId() +
+						'/' + chunkId;
 					delete data.contentRange;
 					delete data.headers['Content-Range'];
 				});


### PR DESCRIPTION
Fixes #5574

Those paths will be encoded by the davclient again. So in certain situations this leads to double encoded urls. Which can fail.

To test:

1. Create a user x@y.z
2. Try to upload a large enough file (pick something like 20MB to be safe).

Before: :boom: 
Now: :man_dancing: 
  