### PR TITLE
Log a missing setting as INFO not as WARNING

### DIFF
--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -47,6 +47,7 @@ use OCP\Lock\ILockingProvider;
 use OCP\Settings\ISettings;
 use OCP\Settings\IManager;
 use OCP\Settings\ISection;
+use OCP\Util;
 
 class Manager implements IManager {
 	/** @var ILogger */
@@ -344,7 +345,7 @@ class Manager implements IManager {
 		try {
 			return \OC::$server->query($className);
 		} catch (QueryException $e) {
-			$this->log->logException($e);
+			$this->log->logException($e, ['level' => Util::INFO]);
 			throw $e;
 		}
 	}


### PR DESCRIPTION
It can happen for all kinds of reasons that a setting is not available.
(A user removes a folder, a setting got deleted). So don't polute the
log on default settings.

For #7755. We should look into the reason for this happening exactly in #7755 but to me it seems unrelated to this log spamming ;)