### PR TITLE
Fix appmenu svg double invert

### DIFF
--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -20,9 +20,11 @@
 }
 
 @if (luma($color-primary) > 0.6) {
-	#appmenu img,
-	#appmenu image {
+	#appmenu:not(.inverted) svg {
 		filter: invert(1);
+	}
+	#appmenu.inverted svg {
+		filter: none;
 	}
 	.searchbox input[type="search"] {
 		background: transparent url('../../../core/img/actions/search.svg') no-repeat 6px center;
@@ -67,10 +69,12 @@
 		}
 	}
 } @else {
-	  #appmenu img,
-	  #appmenu image {
-		  filter: none;
-	  }
+	#appmenu:not(.inverted) svg {
+		filter: none;
+	}
+	#appmenu.inverted svg {
+		filter: invert(1);
+	}
 }
 
 /* Colorized svg images */

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -41,19 +41,17 @@
 					</div>
 				</a>
 
-				<ul id="appmenu">
+				<ul id="appmenu" <?php if ($_['themingInvertMenu']) { ?>class="inverted"<?php } ?>>
 					<?php foreach ($_['navigation'] as $entry): ?>
 						<li data-id="<?php p($entry['id']); ?>" class="hidden">
 							<a href="<?php print_unescaped($entry['href']); ?>"
 								<?php if ($entry['active']): ?> class="active"<?php endif; ?>>
-								<?php if ($_['themingInvertMenu']) { ?>
 									<svg width="20" height="20" viewBox="0 0 20 20">
-									<defs><filter id="invertMenuMain-<?php p($entry['id']); ?>"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0" /></filter></defs>
-									<image x="0" y="0" width="20" height="20" preserveAspectRatio="xMinYMin meet" filter="url(#invertMenuMain-<?php p($entry['id']); ?>)" xlink:href="<?php print_unescaped($entry['icon'] . '?v=' . $_['versionHash']); ?>"  class="app-icon" /></svg>
-								<?php } else { ?>
-									<img src="<?php print_unescaped($entry['icon'] . '?v=' . $_['versionHash']); ?>"
-										 class="app-icon" alt="<?php p($entry['name']); ?>" />
-								<?php } ?>
+										<?php if ($_['themingInvertMenu']) { ?>
+										<defs><filter id="invertMenuMain-<?php p($entry['id']); ?>"><feColorMatrix in="SourceGraphic" type="matrix" values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0" /></filter></defs>
+										<?php } ?>
+										<image x="0" y="0" width="20" height="20" preserveAspectRatio="xMinYMin meet"<?php if ($_['themingInvertMenu']) { ?> filter="url(#invertMenuMain-<?php p($entry['id']); ?>)"<?php } ?> xlink:href="<?php print_unescaped($entry['icon'] . '?v=' . $_['versionHash']); ?>"  class="app-icon" />
+									</svg>
 								<div class="icon-loading-small-dark"
 									 style="display:none;"></div>
 							</a>


### PR DESCRIPTION
This fixes a regression caused by 9b668d0, where the css filters to
preview color inversion of the app menu was applied by default. This
commit makes the css filters sensitive on what the current state of the
app menu is.

As described in https://github.com/nextcloud/server/issues/7401#issuecomment-356513518

Steps to reproduce:
- Set theming color to #ffffff
- Go to the files app
- App icons are white

Not sure why this didn't happen during testing - maybe some odd caching.

@nextcloud/theming 
  