### PR TITLE
Set height for sidebar icons

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -235,6 +235,7 @@ kbd {
 				&:first-child img {
 				    margin-right: 11px;
 				    width: 16px;
+				    height: 16px;
 				    margin-left: -30px;
 				}
 


### PR DESCRIPTION
This makes sure they are properly scaled in IE11

Before:
![bildschirmfoto vom 2018-01-10 09-40-48](https://user-images.githubusercontent.com/3404133/34763694-586ea18a-f5ec-11e7-9fa4-7e37d2947466.png)

After:
![bildschirmfoto vom 2018-01-10 09-44-18](https://user-images.githubusercontent.com/3404133/34763695-588cc624-f5ec-11e7-97ee-56ddb5262b67.png)

The scaling issue of the first entry is addressed in https://github.com/nextcloud/activity/pull/230
