### PR TITLE
More detailed theming capabilities

### DIFF
--- a/apps/theming/lib/Capabilities.php
+++ b/apps/theming/lib/Capabilities.php
@@ -81,6 +81,8 @@ class Capabilities implements IPublicCapability {
 				'background' => $backgroundLogo === 'backgroundColor' ?
 					$this->theming->getColorPrimary() :
 					$this->url->getAbsoluteURL($this->theming->getBackground()),
+				'background-plain' => $backgroundLogo === 'backgroundColor',
+				'background-default' => !$this->util->isBackgroundThemed(),
 			],
 		];
 	}

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -196,22 +196,13 @@ class ThemingDefaults extends \OC_Defaults {
 	 * @return string
 	 */
 	public function getBackground() {
-		$backgroundLogo = $this->config->getAppValue('theming', 'backgroundMime',false);
-
-		$backgroundExists = true;
-		try {
-			$this->appData->getFolder('images')->getFile('background');
-		} catch (\Exception $e) {
-			$backgroundExists = false;
-		}
-
 		$cacheBusterCounter = $this->config->getAppValue('theming', 'cachebuster', '0');
 
-		if(!$backgroundLogo || !$backgroundExists) {
-			return $this->urlGenerator->imagePath('core','background.png') . '?v=' . $cacheBusterCounter;
+		if($this->util->isBackgroundThemed()) {
+			return $this->urlGenerator->linkToRoute('theming.Theming.getLoginBackground') . '?v=' . $cacheBusterCounter;
 		}
 
-		return $this->urlGenerator->linkToRoute('theming.Theming.getLoginBackground') . '?v=' . $cacheBusterCounter;
+		return $this->urlGenerator->imagePath('core','background.png') . '?v=' . $cacheBusterCounter;
 	}
 
 	/**

--- a/apps/theming/lib/Util.php
+++ b/apps/theming/lib/Util.php
@@ -235,4 +235,16 @@ class Util {
 		return false;
 	}
 
+	public function isBackgroundThemed() {
+		$backgroundLogo = $this->config->getAppValue('theming', 'backgroundMime',false);
+
+		$backgroundExists = true;
+		try {
+			$this->appData->getFolder('images')->getFile('background');
+		} catch (\Exception $e) {
+			$backgroundExists = false;
+		}
+		return $backgroundLogo && $backgroundLogo !== 'backgroundColor' && $backgroundExists;
+	}
+
 }

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -391,24 +391,14 @@ class ThemingDefaultsTest extends TestCase {
 	}
 
 	public function testGetBackgroundDefault() {
-		$this->appData->expects($this->once())
-			->method('getFolder')
-			->willThrowException(new NotFoundException());
 		$this->config
-			->expects($this->at(0))
-			->method('getAppValue')
-			->with('theming', 'backgroundMime')
-			->willReturn('');
-		$this->config
-			->expects($this->at(1))
+			->expects($this->once())
 			->method('getAppValue')
 			->with('theming', 'cachebuster', '0')
 			->willReturn('0');
-		$this->appData
-			->expects($this->once())
-			->method('getFolder')
-			->with('images')
-			->willThrowException(new \Exception());
+		$this->util->expects($this->once())
+			->method('isBackgroundThemed')
+			->willReturn(false);
 		$this->urlGenerator->expects($this->once())
 			->method('imagePath')
 			->with('core', 'background.png')
@@ -417,24 +407,14 @@ class ThemingDefaultsTest extends TestCase {
 	}
 
 	public function testGetBackgroundCustom() {
-		$folder = $this->createMock(ISimpleFolder::class);
-		$file = $this->createMock(ISimpleFile::class);
-		$folder->expects($this->once())
-			->method('getFile')
-			->willReturn($file);
-		$this->appData->expects($this->once())
-			->method('getFolder')
-			->willReturn($folder);
 		$this->config
-			->expects($this->at(0))
-			->method('getAppValue')
-			->with('theming', 'backgroundMime', false)
-			->willReturn('image/svg+xml');
-		$this->config
-			->expects($this->at(1))
+			->expects($this->once())
 			->method('getAppValue')
 			->with('theming', 'cachebuster', '0')
 			->willReturn('0');
+		$this->util->expects($this->once())
+			->method('isBackgroundThemed')
+			->willReturn(true);
 		$this->urlGenerator->expects($this->once())
 			->method('linkToRoute')
 			->with('theming.Theming.getLoginBackground')
@@ -513,12 +493,12 @@ class ThemingDefaultsTest extends TestCase {
 		$this->config->expects($this->at(2))->method('getAppValue')->with('theming', 'backgroundMime', false)->willReturn('jpeg');
 		$this->config->expects($this->at(3))->method('getAppValue')->with('theming', 'logoMime', false)->willReturn('jpeg');
 		$this->config->expects($this->at(4))->method('getAppValue')->with('theming', 'cachebuster', '0')->willReturn('0');
-		$this->config->expects($this->at(5))->method('getAppValue')->with('theming', 'backgroundMime', false)->willReturn('jpeg');
-		$this->config->expects($this->at(6))->method('getAppValue')->with('theming', 'cachebuster', '0')->willReturn('0');
-		$this->config->expects($this->at(7))->method('getAppValue')->with('theming', 'color', null)->willReturn($this->defaults->getColorPrimary());
+		$this->util->expects($this->once())->method('isBackgroundThemed')->willReturn(true);
+		$this->config->expects($this->at(5))->method('getAppValue')->with('theming', 'cachebuster', '0')->willReturn('0');
+		$this->config->expects($this->at(6))->method('getAppValue')->with('theming', 'color', null)->willReturn($this->defaults->getColorPrimary());
+		$this->config->expects($this->at(7))->method('getAppValue')->with('theming', 'color', $this->defaults->getColorPrimary())->willReturn($this->defaults->getColorPrimary());
 		$this->config->expects($this->at(8))->method('getAppValue')->with('theming', 'color', $this->defaults->getColorPrimary())->willReturn($this->defaults->getColorPrimary());
 		$this->config->expects($this->at(9))->method('getAppValue')->with('theming', 'color', $this->defaults->getColorPrimary())->willReturn($this->defaults->getColorPrimary());
-		$this->config->expects($this->at(10))->method('getAppValue')->with('theming', 'color', $this->defaults->getColorPrimary())->willReturn($this->defaults->getColorPrimary());
 
 		$this->util->expects($this->any())->method('invertTextColor')->with($this->defaults->getColorPrimary())->willReturn(false);
 		$this->util->expects($this->any())->method('elementColor')->with($this->defaults->getColorPrimary())->willReturn('#aaaaaa');

--- a/apps/theming/tests/UtilTest.php
+++ b/apps/theming/tests/UtilTest.php
@@ -189,7 +189,6 @@ class UtilTest extends TestCase {
 	}
 
 	public function testIsAlreadyThemedFalse() {
-		$theme = $this->config->getSystemValue('theme', '');
 		$this->config->expects($this->once())
 			->method('getSystemValue')
 			->with('theme', '')
@@ -199,13 +198,43 @@ class UtilTest extends TestCase {
 	}
 
 	public function testIsAlreadyThemedTrue() {
-		$theme = $this->config->getSystemValue('theme', '');
 		$this->config->expects($this->once())
 			->method('getSystemValue')
 			->with('theme', '')
 			->willReturn('example');
 		$actual = $this->util->isAlreadyThemed();
 		$this->assertTrue($actual);
+	}
+
+	public function dataIsBackgroundThemed() {
+		return [
+			[false, false, false],
+			['png', true, true],
+			['backgroundColor', false, false],
+		];
+	}
+	/**
+	 * @dataProvider dataIsBackgroundThemed
+	 */
+	public function testIsBackgroundThemed($backgroundMime, $fileFound, $expected) {
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('theming', 'backgroundMime', false)
+			->willReturn($backgroundMime);
+		$folder = $this->createMock(ISimpleFolder::class);
+		if ($fileFound) {
+			$folder->expects($this->once())
+				->method('getFile')
+				->willReturn($this->createMock(ISimpleFile::class));
+		} else {
+			$folder->expects($this->once())
+				->method('getFile')
+				->willThrowException(new NotFoundException());
+		}
+		$this->appData->expects($this->once())
+			->method('getFolder')
+			->willReturn($folder);
+		$this->assertEquals($expected, $this->util->isBackgroundThemed());
 	}
 
 }


### PR DESCRIPTION
This will allow clients to easily check if a custom background or a plain background color is used.

New entries in the capabilities theming section:

          "background-plain": false,
          "background-default": true

