### PR TITLE
[stable12] Set height for sidebar icons 

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -154,6 +154,7 @@ kbd {
 	    margin-bottom: -3px;
 	    margin-right: 11px;
 	    width: 16px;
+	    height: 16px;
 	    margin-left: 2px;
 	}
 	.collapse {


### PR DESCRIPTION
This makes sure they are properly scaled in IE11

backport of #7769

Signed-off-by: Julius Härtl <jus@bitgrid.net>