### PR TITLE
Fix empty details view after renaming a file

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2266,7 +2266,7 @@
 
 			function updateInList(fileInfo) {
 				self.updateRow(tr, fileInfo);
-				self._updateDetailsView(fileInfo, false);
+				self._updateDetailsView(fileInfo.name, false);
 			}
 
 			// TODO: too many nested blocks, move parts into functions

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -674,6 +674,36 @@ describe('OCA.Files.FileList tests', function() {
 
 			expect(notificationStub.calledOnce).toEqual(true);
 		});
+		it('Shows renamed file details if rename ajax call suceeded', function() {
+			fileList.showDetailsView('One.txt');
+
+			expect($('#app-sidebar').hasClass('disappear')).toEqual(false);
+			expect(fileList._detailsView.getFileInfo().get('id')).toEqual(1);
+			expect(fileList._detailsView.getFileInfo().get('name')).toEqual('One.txt');
+
+			doRename();
+
+			deferredRename.resolve(201);
+
+			expect($('#app-sidebar').hasClass('disappear')).toEqual(false);
+			expect(fileList._detailsView.getFileInfo().get('id')).toEqual(1);
+			expect(fileList._detailsView.getFileInfo().get('name')).toEqual('Tu_after_three.txt');
+		});
+		it('Shows again file details if rename ajax call failed', function() {
+			fileList.showDetailsView('One.txt');
+
+			expect($('#app-sidebar').hasClass('disappear')).toEqual(false);
+			expect(fileList._detailsView.getFileInfo().get('id')).toEqual(1);
+			expect(fileList._detailsView.getFileInfo().get('name')).toEqual('One.txt');
+
+			doRename();
+
+			deferredRename.reject(403);
+
+			expect($('#app-sidebar').hasClass('disappear')).toEqual(false);
+			expect(fileList._detailsView.getFileInfo().get('id')).toEqual(1);
+			expect(fileList._detailsView.getFileInfo().get('name')).toEqual('One.txt');
+		});
 		it('Correctly updates file link after rename', function() {
 			var $tr;
 			doRename();

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -612,6 +612,12 @@ describe('OCA.Files.FileList tests', function() {
 		beforeEach(function() {
 			deferredRename = $.Deferred();
 			renameStub = sinon.stub(filesClient, 'move').returns(deferredRename.promise());
+
+			for (var i = 0; i < testFiles.length; i++) {
+				var file = testFiles[i];
+				file.path = '/some/subdir';
+				fileList.add(file, {silent: true});
+			}
 		});
 		afterEach(function() {
 			renameStub.restore();
@@ -619,9 +625,6 @@ describe('OCA.Files.FileList tests', function() {
 
 		function doCancelRename() {
 			var $input;
-			for (var i = 0; i < testFiles.length; i++) {
-				fileList.add(testFiles[i]);
-			}
 
 			// trigger rename prompt
 			fileList.rename('One.txt');
@@ -635,12 +638,6 @@ describe('OCA.Files.FileList tests', function() {
 		}
 		function doRename() {
 			var $input;
-
-			for (var i = 0; i < testFiles.length; i++) {
-				var file = testFiles[i];
-				file.path = '/some/subdir';
-				fileList.add(file, {silent: true});
-			}
 
 			// trigger rename prompt
 			fileList.rename('One.txt');
@@ -730,10 +727,6 @@ describe('OCA.Files.FileList tests', function() {
 		});
 		it('Validates the file name', function() {
 			var $input, $tr;
-
-			for (var i = 0; i < testFiles.length; i++) {
-				fileList.add(testFiles[i], {silent: true});
-			}
 
 			$tr = fileList.findFileEl('One.txt');
 			expect($tr.find('a.name').css('display')).not.toEqual('none');

--- a/tests/acceptance/features/app-files.feature
+++ b/tests/acceptance/features/app-files.feature
@@ -23,6 +23,13 @@ Feature: app-files
     When I open the details view for "welcome.txt"
     Then I see that the details view for "All files" section is open
 
+  Scenario: rename a file with the details view open
+    Given I am logged in
+    And I open the details view for "welcome.txt"
+    When I rename "welcome.txt" to "farewell.txt"
+    Then I see that the file list contains a file named "farewell.txt"
+    And I see that the file name shown in the details view is "farewell.txt"
+
   Scenario: open the menu in a public shared link
     Given I act as John
     And I am logged in

--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -89,6 +89,15 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function fileNameInCurrentSectionDetailsView() {
+		return Locator::forThe()->css(".fileName")->
+				descendantOf(self::currentSectionDetailsView())->
+				describedAs("File name in current section details view in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function fileDetailsInCurrentSectionDetailsViewWithText($fileDetailsText) {
 		return Locator::forThe()->xpath("//span[normalize-space() = '$fileDetailsText']")->
 				descendantOf(self::fileDetailsInCurrentSectionDetailsView())->
@@ -319,6 +328,14 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function renameInputForFile($fileName) {
+		return Locator::forThe()->css("input.filename")->descendantOf(self::rowForFile($fileName))->
+				describedAs("Rename input for file $fileName in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function shareActionForFile($fileName) {
 		return Locator::forThe()->css(".action-share")->descendantOf(self::rowForFile($fileName))->
 				describedAs("Share action for file $fileName in Files app");
@@ -345,6 +362,13 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 */
 	public static function detailsMenuItem() {
 		return self::fileActionsMenuItemFor("Details");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function renameMenuItem() {
+		return self::fileActionsMenuItemFor("Rename");
 	}
 
 	/**
@@ -415,6 +439,17 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 */
 	public function iOpenTheTabInTheDetailsView($tabName) {
 		$this->actor->find(self::tabHeaderInCurrentSectionDetailsViewNamed($tabName), 10)->click();
+	}
+
+	/**
+	 * @Given I rename :fileName1 to :fileName2
+	 */
+	public function iRenameTo($fileName1, $fileName2) {
+		$this->actor->find(self::fileActionsMenuButtonForFile($fileName1), 10)->click();
+
+		$this->actor->find(self::renameMenuItem(), 2)->click();
+
+		$this->actor->find(self::renameInputForFile($fileName1), 10)->setValue($fileName2 . "\r");
 	}
 
 	/**
@@ -543,6 +578,13 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	}
 
 	/**
+	 * @Then I see that the file list contains a file named :fileName
+	 */
+	public function iSeeThatTheFileListContainsAFileNamed($fileName) {
+		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::rowForFile($fileName), 10));
+	}
+
+	/**
 	 * @Then I see that :fileName1 precedes :fileName2 in the file list
 	 */
 	public function iSeeThatPrecedesInTheFileList($fileName1, $fileName2) {
@@ -561,6 +603,14 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 */
 	public function iSeeThatIsNotMarkedAsFavorite($fileName) {
 		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::notFavoritedStateIconForFile($fileName), 10));
+	}
+
+	/**
+	 * @Then I see that the file name shown in the details view is :fileName
+	 */
+	public function iSeeThatTheFileNameShownInTheDetailsViewIs($fileName) {
+		PHPUnit_Framework_Assert::assertEquals(
+				$this->actor->find(self::fileNameInCurrentSectionDetailsView(), 10)->getText(), $fileName);
 	}
 
 	/**


### PR DESCRIPTION
`FileList._updateDetailsView` [expects either a file name (as a string) or a file model (as an `OCA.File.FileInfoModel`)](https://github.com/nextcloud/server/blob/ab1985b62b56699061f2206b15404f7f881797c5/apps/files/js/filelist.js#L501), but when called through `updateInList` [an `OC.Files.FileInfo` object was given instead](https://github.com/nextcloud/server/blob/ab1985b62b56699061f2206b15404f7f881797c5/apps/files/js/filelist.js#L2269). As the given attribute was not a model `_updateDetailsView` treated it as a file name and [tried to get the model for that file](https://github.com/nextcloud/server/blob/ab1985b62b56699061f2206b15404f7f881797c5/apps/files/js/filelist.js#L535-L536), which failed and caused the details view to be emptied.
