### PR TITLE
return correct mount type for federated shares

### DIFF
--- a/apps/files_sharing/lib/External/Mount.php
+++ b/apps/files_sharing/lib/External/Mount.php
@@ -68,4 +68,14 @@ class Mount extends MountPoint implements MoveableMount {
 	public function removeMount() {
 		return $this->manager->removeShare($this->mountPoint);
 	}
+
+	/**
+	 * Get the type of mount point, used to distinguish things like shares and external storages
+	 * in the web interface
+	 *
+	 * @return string
+	 */
+	public function getMountType() {
+		return 'shared';
+	}
 }


### PR DESCRIPTION
return the correct mount type for federated share.

fix https://github.com/nextcloud/server/issues/6584