### PR TITLE
Fix popover and styling in user management

### DIFF
--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -347,7 +347,7 @@ table.nostyle {
 	}
 	.token-list {
 		td > a.icon {
-			opacity: 0;
+
 			transition: opacity 0.5s;
 		}
 		a.icon {
@@ -563,34 +563,24 @@ tr:hover > td {
 }
 
 td.userActions {
-	width: 25px;
-	text-align: center;
-	position: relative;
-	.action {
-		position: relative;
-		top: 3px;
-	}
+	width: 44px;
 	.toggleUserActions {
-		border: none;
-		background-color: rgba(0, 0, 0, 0);
-		width: 34px;
-		height: 34px;
-		margin: 0;
-		opacity: 0.5;
-		&:hover,
-		&:focus {
-			background-color: transparent;
-			opacity: 1;
+		width: 44px;
+		height: 44px;
+		position: relative;
+		.action {
+			display: block;
+			padding: 14px;
+			opacity: 0.5;
+			.icon-more {
+				display: inline-block;
+			}
+			&:hover,
+			&:focus {
+				opacity: 1;
+			}
 		}
 	}
-}
-
-tr.active td.userActions .action {
-	opacity: 1;
-}
-
-td.userActions .action:hover {
-	cursor: pointer;
 }
 
 div.recoveryPassword {

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -101,16 +101,9 @@ var UserList = {
 		$tdSubadmins.find('.action').tooltip({placement: 'top'});
 
 		/**
-		 * user actions menu
+		 * hide user actions menu for current user
 		 */
-		if ($tr.find('td.userActions > span > img').length === 0 && OC.currentUser !== user.name) {
-			var menuImage = $('<img class="svg action">').attr({
-				src: OC.imagePath('core', 'actions/more')
-			});
-			var menuLink = $('<span class="toggleUserActions"></span>')
-				.append(menuImage);
-			$tr.find('td.userActions > span').replaceWith(menuLink);
-		} else if (OC.currentUser === user.name) {
+		if (OC.currentUser === user.name) {
 			$tr.find('td.userActions').empty();
 		}
 

--- a/settings/templates/users/part.userlist.php
+++ b/settings/templates/users/part.userlist.php
@@ -1,4 +1,4 @@
-<table id="userlist" class="hascontrols grid" data-groups="<?php p($_['allGroups']);?>">
+<table id="userlist" class="grid" data-groups="<?php p($_['allGroups']);?>">
 	<thead>
 		<tr>
 			<th id="headerAvatar" scope="col"></th>
@@ -64,19 +64,22 @@
 			<td class="storageLocation"></td>
 			<td class="userBackend"></td>
 			<td class="lastLogin"></td>
-			<td class="userActions"><span></span>
-				<div class="popovermenu bubble menu">
-					<ul class="userActionsMenu">
-						<li>
-							<a href="#" class="menuitem action-togglestate permanent" data-action="togglestate"></a>
-						</li>
-						<li>
-							<a href="#" class="menuitem action-remove permanent" data-action="remove">
-								<span class="icon icon-delete"></span>
-								<span><?php p($l->t('Delete')); ?></span>
-							</a>
-						</li>
-					</ul>
+			<td class="userActions">
+				<div class="toggleUserActions">
+					<a class="action"><span class="icon-more"></span></a>
+					<div class="popovermenu bubble menu">
+						<ul class="userActionsMenu">
+							<li>
+								<a href="#" class="menuitem action-togglestate permanent" data-action="togglestate"></a>
+							</li>
+							<li>
+								<a href="#" class="menuitem action-remove permanent" data-action="remove">
+									<span class="icon icon-delete"></span>
+									<span><?php p($l->t('Delete')); ?></span>
+								</a>
+							</li>
+						</ul>
+					</div>
 				</div>
 			</td>
 		</tr>


### PR DESCRIPTION
- Fix popover positioning 
- Always show the 3-dots icon
- Remove margin between new user form and table

Before:
![bildschirmfoto vom 2018-01-11 12-15-39](https://user-images.githubusercontent.com/3404133/34823024-3aa4c2a0-f6c9-11e7-9461-4addc5795c15.png)

After:
![bildschirmfoto vom 2018-01-11 12-15-15](https://user-images.githubusercontent.com/3404133/34823031-40887680-f6c9-11e7-9877-2ef1ea4cf1ff.png)

@nextcloud/designers 