### PR TITLE
LDAP Sync fixes: revert recursion resolution, fixed handling of pagingsize of 0

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1914,11 +1914,8 @@ class Access extends LDAPUtility implements IUserTools {
 					// no cookie known from a potential previous search. We need
 					// to start from 0 to come to the desired page. cookie value
 					// of '0' is valid, because 389ds
-					$reOffset = 0;
-					while($reOffset < $offset) {
-						$this->search($filter, array($base), $attr, $limit, $reOffset, true);
-						$reOffset += $limit;
-					}
+					$reOffset = ($offset - $limit) < 0 ? 0 : $offset - $limit;
+					$this->search($filter, array($base), $attr, $limit, $reOffset, true);
 					$cookie = $this->getPagedResultCookie($base, $filter, $limit, $offset);
 					//still no cookie? obviously, the server does not like us. Let's skip paging efforts.
 					// '0' is valid, because 389ds

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -52,6 +52,7 @@ use OCA\User_LDAP\Mapping\AbstractMapping;
 
 use OC\ServerNotAvailableException;
 use OCP\IConfig;
+use OCP\Util;
 
 /**
  * Class Access
@@ -1937,9 +1938,8 @@ class Access extends LDAPUtility implements IUserTools {
 					}
 					\OCP\Util::writeLog('user_ldap', 'Ready for a paged search', \OCP\Util::DEBUG);
 				} else {
-					\OCP\Util::writeLog('user_ldap',
-						'No paged search for us, Cpt., Limit '.$limit.' Offset '.$offset,
-						\OCP\Util::INFO);
+					$e = new \Exception('No paged search possible, Limit '.$limit.' Offset '.$offset);
+					\OC::$server->getLogger()->logException($e, ['level' => Util::DEBUG]);
 				}
 
 			}

--- a/apps/user_ldap/lib/Jobs/Sync.php
+++ b/apps/user_ldap/lib/Jobs/Sync.php
@@ -176,10 +176,10 @@ class Sync extends TimedJob {
 			true
 		);
 
-		if($connection->ldapPagingSize === 0) {
+		if((int)$connection->ldapPagingSize === 0) {
 			return false;
 		}
-		return count($results) >= $connection->ldapPagingSize;
+		return count($results) >= (int)$connection->ldapPagingSize;
 	}
 
 	/**

--- a/apps/user_ldap/lib/Jobs/Sync.php
+++ b/apps/user_ldap/lib/Jobs/Sync.php
@@ -177,7 +177,7 @@ class Sync extends TimedJob {
 		);
 
 		if($connection->ldapPagingSize === 0) {
-			return true;
+			return false;
 		}
 		return count($results) >= $connection->ldapPagingSize;
 	}

--- a/apps/user_ldap/tests/Jobs/SyncTest.php
+++ b/apps/user_ldap/tests/Jobs/SyncTest.php
@@ -159,7 +159,8 @@ class SyncTest extends TestCase {
 			[ 3, 3, true ],
 			[ 3, 5, true ],
 			[ 3, 2, false],
-			[ 0, 4, false]
+			[ 0, 4, false],
+			[ null, 4, false]
 		];
 	}
 

--- a/apps/user_ldap/tests/Jobs/SyncTest.php
+++ b/apps/user_ldap/tests/Jobs/SyncTest.php
@@ -158,7 +158,8 @@ class SyncTest extends TestCase {
 		return [
 			[ 3, 3, true ],
 			[ 3, 5, true ],
-			[ 3, 2, false]
+			[ 3, 2, false],
+			[ 0, 4, false]
 		];
 	}
 


### PR DESCRIPTION
So, we still encountered to see a lot of log messages on our instances, and with some more debug output I could trace it  back. The main issue here is that resolving a recursion during LDAP  search (happens with an initial offset > 0) didn't work out as expected, due to some internal state issues. It was not obvious with low offset, but  it can pile up unnicely.

Additionally to it comes some by catch with tests.