### PR TITLE
Remove the need for CSRF check on ocs::getCurrentUser

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -219,6 +219,7 @@ class UsersController extends OCSController {
 
 	/**
 	 * @NoAdminRequired
+	 * @NoCSRFRequired
 	 * @NoSubAdminRequired
 	 *
 	 * gets user info from the currently logged in user


### PR DESCRIPTION
Fixes #5694

I tested on my server, and worked like a charm :)

I think in term of security it is fine to open this route. What do you think?