### PR TITLE
Fix call to clearstatcache to actually use the file path

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -180,7 +180,7 @@ class Local extends \OC\Files\Storage\Common {
 
 	public function filemtime($path) {
 		$fullPath = $this->getSourcePath($path);
-		clearstatcache($fullPath);
+		clearstatcache(true, $fullPath);
 		if (!$this->file_exists($path)) {
 			return false;
 		}


### PR DESCRIPTION
* found while adding the strict_typing for PHP 7+ migration (#7392)
* first argument is a boolean - second one is the path
* see http://php.net/manual/en/function.clearstatcache.php
