### PR TITLE
Make sure the arrays are arrays

### DIFF
--- a/apps/dav/lib/HookManager.php
+++ b/apps/dav/lib/HookManager.php
@@ -43,7 +43,7 @@ class HookManager {
 	private $syncService;
 
 	/** @var IUser[] */
-	private $usersToDelete;
+	private $usersToDelete = [];
 
 	/** @var CalDavBackend */
 	private $calDav;
@@ -52,10 +52,10 @@ class HookManager {
 	private $cardDav;
 
 	/** @var array */
-	private $calendarsToDelete;
+	private $calendarsToDelete = [];
 
 	/** @var array */
-	private $addressBooksToDelete;
+	private $addressBooksToDelete = [];
 
 	/** @var EventDispatcher */
 	private $eventDispatcher;


### PR DESCRIPTION
I don't know why, but on the call to preDelete the dav HookManager seems to not be registered yet, and then postDelete failed with foreach and null:
https://travis-ci.org/nextcloud/activity/jobs/328063705#L726

