### PR TITLE
Fix strpos if needle is not found

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -671,7 +671,7 @@ class OC_App {
 	public static function getCurrentApp() {
 		$request = \OC::$server->getRequest();
 		$script = substr($request->getScriptName(), strlen(OC::$WEBROOT) + 1);
-		$topFolder = substr($script, 0, strpos($script, '/'));
+		$topFolder = substr($script, 0, strpos($script, '/') ?: 0);
 		if (empty($topFolder)) {
 			$path_info = $request->getPathInfo();
 			if ($path_info) {


### PR DESCRIPTION
Found while testing strict_typing for PHP 7+ (#7392). If `$script` does not contain a `/` then it should extract a string of the length 0.
