### PR TITLE
Log full exception in cron instead of only the message

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -155,7 +155,7 @@ try {
 	exit();
 
 } catch (Exception $ex) {
-	\OCP\Util::writeLog('cron', $ex->getMessage(), \OCP\Util::FATAL);
+	\OC::$server->getLogger()->logException($ex, ['app' => 'cron']);
 } catch (Error $ex) {
-	\OCP\Util::writeLog('cron', $ex->getMessage(), \OCP\Util::FATAL);
+	\OC::$server->getLogger()->logException($ex, ['app' => 'cron']);
 }


### PR DESCRIPTION
Otherwise you get really helpful error messages like this:

```
{"reqId":"gdcGITBVPE638TVLMByv","level":4,"time":"2018-01-12T14:20:22+00:00","remoteAddr":"192.168.99.1","user":"admin","app":"cron","method":"GET","url":"\/server\/cron.php","message":"explode() expects parameter 2 to be string, null given","userAgent":"Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit\/604.4.7 (KHTML, like Gecko) Version\/11.0.2 Safari\/604.4.7","version":"13.0.0.10"}
```