### PR TITLE
Fix explode() call in legacy/helper.php to have correct types

### DIFF
--- a/lib/private/legacy/helper.php
+++ b/lib/private/legacy/helper.php
@@ -477,12 +477,12 @@ class OC_Helper {
 			return false;
 		}
 		$ini = \OC::$server->getIniWrapper();
-		$disabled = explode(',', $ini->get('disable_functions'));
+		$disabled = explode(',', $ini->get('disable_functions') ?: '');
 		$disabled = array_map('trim', $disabled);
 		if (in_array($function_name, $disabled)) {
 			return false;
 		}
-		$disabled = explode(',', $ini->get('suhosin.executor.func.blacklist'));
+		$disabled = explode(',', $ini->get('suhosin.executor.func.blacklist') ?: '');
 		$disabled = array_map('trim', $disabled);
 		if (in_array($function_name, $disabled)) {
 			return false;


### PR DESCRIPTION
Found while enabling strict_typing for PHP7+. (#7392)