### PR TITLE
Check if realpath() returns false

### DIFF
--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -186,7 +186,7 @@ class MigrationService {
 
 	protected function findMigrations() {
 		$directory = realpath($this->migrationsPath);
-		if (!file_exists($directory) || !is_dir($directory)) {
+		if ($directory === false || !file_exists($directory) || !is_dir($directory)) {
 			return [];
 		}
 


### PR DESCRIPTION
realpath() returns false in case the directory does not exist. Found it while preparing strict_typing for PHP7+. (#7392)
