### PR TITLE
Fix type in CryptoSessionData

### DIFF
--- a/lib/private/Session/CryptoSessionData.php
+++ b/lib/private/Session/CryptoSessionData.php
@@ -75,7 +75,7 @@ class CryptoSessionData implements \ArrayAccess, ISession {
 	}
 
 	protected function initializeSession() {
-		$encryptedSessionData = $this->session->get(self::encryptedSessionName);
+		$encryptedSessionData = $this->session->get(self::encryptedSessionName) ?: '';
 		try {
 			$this->sessionValues = json_decode(
 				$this->crypto->decrypt($encryptedSessionData, $this->passphrase),


### PR DESCRIPTION
Found while adding strict typing for PHP7+. (#7392)