### PR TITLE
Adds type hinting for scalar types in ICrypto->decrypt

### DIFF
--- a/lib/private/Security/Crypto.php
+++ b/lib/private/Security/Crypto.php
@@ -108,7 +108,7 @@ class Crypto implements ICrypto {
 	 * @return string plaintext
 	 * @throws \Exception If the HMAC does not match
 	 */
-	public function decrypt($authenticatedCiphertext, $password = '') {
+	public function decrypt(string $authenticatedCiphertext, string $password = ''): string {
 		if($password === '') {
 			$password = $this->config->getSystemValue('secret');
 		}

--- a/lib/public/Security/ICrypto.php
+++ b/lib/public/Security/ICrypto.php
@@ -61,5 +61,5 @@ interface ICrypto {
 	 * @throws \Exception If the HMAC does not match
 	 * @since 8.0.0
 	 */
-	public function decrypt($authenticatedCiphertext, $password = '');
+	public function decrypt(string $authenticatedCiphertext, string $password = ''): string;
 }

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -653,14 +653,14 @@ class LostControllerTest extends \Test\TestCase {
 	public function testIsSetPasswordWithoutTokenFailing() {
 		$this->config->method('getUserValue')
 			->with('ValidTokenUser', 'core', 'lostpassword', null)
-			->will($this->returnValue(null));
+			->willReturn('aValidtoken');
 		$this->userManager->method('get')
 			->with('ValidTokenUser')
 			->willReturn($this->existingUser);
 
 		$this->crypto->method('decrypt')
 			->with(
-				$this->equalTo(''),
+				$this->equalTo('aValidtoken'),
 				$this->equalTo('test@example.comSECRET')
 			)->willThrowException(new \Exception());
 


### PR DESCRIPTION
A side effect of this is that failures could now happen regarding the type of a parameter even if the other file does not use strict typing. But it would make the original error of #7824 a lot more clear:

It now would cause something like this (which immediately points out the root of the issue):

```
{
    "Code": 0,
    "Exception": "TypeError",
    "File": "lib/private/Security/Crypto.php",
    "Line": 112,
    "Message": "Argument 1 passed to OC\\Security\\Crypto::decrypt() must be of the type string, null given, called in lib/private/Session/CryptoSessionData.php on line 82",
    "Trace": "
        #0 lib/private/Session/CryptoSessionData.php(82): OC\\Security\\Crypto->decrypt(*** sensitive parameters replaced ***)
        #1 lib/private/Session/CryptoSessionData.php(63): OC\\Session\\CryptoSessionData->initializeSession()
        #2 lib/private/Session/CryptoWrapper.php(101): OC\\Session\\CryptoSessionData->__construct(Object(OC\\Session\\Memory), Object(OC\\Security\\Crypto), '7tkRtGTgI79Dtd7...')
        #3 cron.php(60): OC\\Session\\CryptoWrapper->wrapSession(Object(OC\\Session\\Memory))
        #4 {main}
    "
}
```

instead of this:

```
{
    "Code": 0,
    "Exception": "TypeError",
    "File": "lib/private/Security/Crypto.php",
    "Line": 118,
    "Message": "explode() expects parameter 2 to be string, null given",
    "Trace": "
        #0 lib/private/Security/Crypto.php(118): explode('|', NULL)
        #1 lib/private/Session/CryptoSessionData.php(82): OC\\Security\\Crypto->decrypt(*** sensitive parameters replaced ***)
        #2 lib/private/Session/CryptoSessionData.php(63): OC\\Session\\CryptoSessionData->initializeSession()
        #3 lib/private/Session\\/CryptoWrapper.php(101): OC\\Session\\CryptoSessionData->__construct(Object(OC\\Session\\Memory), Object(OC\\Security\\Crypto), '7tkRtGTgI79Dtd7...')
        #4 cron.php(60): OC\\Session\\CryptoWrapper->wrapSession(Object(OC\\Session\\Memory))
        #5 {main}
    "
}
```


@schiessle @blizzz @skjnldsv @juliushaertl @LukasReschke @irgendwie @Henni @pixelipo @rullzer @nickvergessen @daita @oparoz @karlitschek Does this makes sense for you? I guess it helps us a lot, but will also cause quite a lot of (valid) issues in the existing code.
