### PR TITLE
Fix case when overwrite URL is empty during setup

### DIFF
--- a/core/Command/Maintenance/UpdateHtaccess.php
+++ b/core/Command/Maintenance/UpdateHtaccess.php
@@ -43,7 +43,7 @@ class UpdateHtaccess extends Command {
 			$output->writeln('.htaccess has been updated');
 			return 0;
 		} else {
-			$output->writeln('<error>Error updating .htaccess file, not enough permissions?</error>');
+			$output->writeln('<error>Error updating .htaccess file, not enough permissions or "overwrite.cli.url" set to an invalid URL?</error>');
 			return 1;
 		}
 	}

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -437,6 +437,9 @@ class Setup {
 				return false;
 			}
 			$webRoot = parse_url($webRoot, PHP_URL_PATH);
+			if ($webRoot === null) {
+				return false;
+			}
 			$webRoot = rtrim($webRoot, '/');
 		} else {
 			$webRoot = !empty(\OC::$WEBROOT) ? \OC::$WEBROOT : '/';


### PR DESCRIPTION
Found while testing strict typing for PHP 7+.(#7392)