### PR TITLE
Fix float/integer handling in image API

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -345,9 +345,9 @@ class Generator {
 					$scaleH = $maxHeight / $widthR;
 					$scaleW = $width;
 				}
-				$preview->preciseResize(round($scaleW), round($scaleH));
+				$preview->preciseResize((int)round($scaleW), (int)round($scaleH));
 			}
-			$cropX = floor(abs($width - $preview->width()) * 0.5);
+			$cropX = (int)floor(abs($width - $preview->width()) * 0.5);
 			$cropY = 0;
 			$preview->crop($cropX, $cropY, $width, $height);
 		} else {

--- a/lib/private/Preview/GeneratorHelper.php
+++ b/lib/private/Preview/GeneratorHelper.php
@@ -27,7 +27,7 @@ use OCP\Files\File;
 use OCP\Files\IRootFolder;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\IImage;
-use OCP\Image as img;
+use OCP\Image as OCPImage;
 use OCP\Preview\IProvider;
 
 /**
@@ -79,7 +79,9 @@ class GeneratorHelper {
 	 * @return IImage
 	 */
 	public function getImage(ISimpleFile $maxPreview) {
-		return new img($maxPreview->getContent());
+		$image = new OCPImage();
+		$image->loadFromData($maxPreview->getContent());
+		return $image;
 	}
 
 	/**

--- a/lib/private/legacy/image.php
+++ b/lib/private/legacy/image.php
@@ -550,6 +550,16 @@ class OC_Image implements \OCP\IImage {
 	 * @return bool|resource An image resource or false on error
 	 */
 	public function loadFromFile($imagePath = false) {
+		try {
+			// detect if it is a path or maybe the images as string
+			// needed because the constructor iterates over all load* methods
+			$result = @realpath($imagePath);
+			if ($result === false) {
+				return false;
+			}
+		} catch (Error $e) {
+			return false;
+		}
 		// exif_imagetype throws "read error!" if file is less than 12 byte
 		if (!@is_file($imagePath) || !file_exists($imagePath) || filesize($imagePath) < 12 || !is_readable($imagePath)) {
 			return false;
@@ -873,7 +883,7 @@ class OC_Image implements \OCP\IImage {
 			$newHeight = $maxSize;
 		}
 
-		$this->preciseResize(round($newWidth), round($newHeight));
+		$this->preciseResize((int)round($newWidth), (int)round($newHeight));
 		return true;
 	}
 
@@ -882,7 +892,7 @@ class OC_Image implements \OCP\IImage {
 	 * @param int $height
 	 * @return bool
 	 */
-	public function preciseResize($width, $height) {
+	public function preciseResize(int $width, int $height): bool {
 		if (!$this->valid()) {
 			$this->logger->error(__METHOD__ . '(): No image loaded', array('app' => 'core'));
 			return false;
@@ -982,7 +992,7 @@ class OC_Image implements \OCP\IImage {
 	 * @param int $h Height
 	 * @return bool for success or failure
 	 */
-	public function crop($x, $y, $w, $h) {
+	public function crop(int $x, int $y, int $w, int $h): bool {
 		if (!$this->valid()) {
 			$this->logger->error(__METHOD__ . '(): No image loaded', array('app' => 'core'));
 			return false;
@@ -1033,7 +1043,7 @@ class OC_Image implements \OCP\IImage {
 		$newWidth = min($maxWidth, $ratio * $maxHeight);
 		$newHeight = min($maxHeight, $maxWidth / $ratio);
 
-		$this->preciseResize(round($newWidth), round($newHeight));
+		$this->preciseResize((int)round($newWidth), (int)round($newHeight));
 		return true;
 	}
 

--- a/lib/public/IImage.php
+++ b/lib/public/IImage.php
@@ -147,7 +147,7 @@ interface IImage {
 	 * @return bool
 	 * @since 8.1.0
 	 */
-	public function preciseResize($width, $height);
+	public function preciseResize(int $width, int $height): bool;
 
 	/**
 	 * Crops the image to the middle square. If the image is already square it just returns.
@@ -168,7 +168,7 @@ interface IImage {
 	 * @return bool for success or failure
 	 * @since 8.1.0
 	 */
-	public function crop($x, $y, $w, $h);
+	public function crop(int $x, int $y, int $w, int $h): bool;
 
 	/**
 	 * Resizes the image to fit within a boundary while preserving ratio.


### PR DESCRIPTION
* IImage::crop/preciseResize now have type hinting for integers
* found while testing strict typing for PHP 7+(#7392)