### PR TITLE
Use fallback path if data dir is not available for Storage/Local.php

### DIFF
--- a/lib/private/Files/Mount/MountPoint.php
+++ b/lib/private/Files/Mount/MountPoint.php
@@ -152,7 +152,7 @@ class MountPoint implements IMountPoint {
 					// the root storage could not be initialized, show the user!
 					throw new \Exception('The root storage could not be initialized. Please contact your local administrator.', $exception->getCode(), $exception);
 				} else {
-					\OCP\Util::writeLog('core', $exception->getMessage(), \OCP\Util::ERROR);
+					\OC::$server->getLogger()->logException($exception, ['level' => \OCP\Util::ERROR]);
 				}
 				return;
 			}

--- a/lib/private/Files/Storage/Home.php
+++ b/lib/private/Files/Storage/Home.php
@@ -25,6 +25,7 @@
  */
 
 namespace OC\Files\Storage;
+
 use OC\Files\Cache\HomePropagator;
 
 /**
@@ -43,6 +44,7 @@ class Home extends Local implements \OCP\Files\IHomeStorage {
 
 	/**
 	 * Construct a Home storage instance
+	 *
 	 * @param array $arguments array with "user" containing the
 	 * storage owner
 	 */
@@ -51,7 +53,7 @@ class Home extends Local implements \OCP\Files\IHomeStorage {
 		$datadir = $this->user->getHome();
 		$this->id = 'home::' . $this->user->getUID();
 
-		parent::__construct(array('datadir' => $datadir));
+		parent::__construct(['datadir' => $datadir]);
 	}
 
 	public function getId() {
@@ -90,6 +92,7 @@ class Home extends Local implements \OCP\Files\IHomeStorage {
 
 	/**
 	 * Returns the owner of this home storage
+	 *
 	 * @return \OC\User\User owner of this home storage
 	 */
 	public function getUser() {

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -59,12 +59,13 @@ class Local extends \OC\Files\Storage\Common {
 		if (!isset($arguments['datadir']) || !is_string($arguments['datadir'])) {
 			throw new \InvalidArgumentException('No data directory set for local storage');
 		}
-		$this->datadir = $arguments['datadir'];
+		$this->datadir = str_replace('//', '/', $arguments['datadir']);
 		// some crazy code uses a local storage on root...
 		if ($this->datadir === '/') {
 			$this->realDataDir = $this->datadir;
 		} else {
-			$this->realDataDir = rtrim(realpath($this->datadir), '/') . '/';
+			$realPath = realpath($this->datadir) ?: $this->datadir;
+			$this->realDataDir = rtrim($realPath, '/') . '/';
 		}
 		if (substr($this->datadir, -1) !== '/') {
 			$this->datadir .= '/';
@@ -361,14 +362,18 @@ class Local extends \OC\Files\Storage\Common {
 	 */
 	public function getSourcePath($path) {
 		$fullPath = $this->datadir . $path;
-		if ($this->allowSymlinks || $path === '') {
+		$currentPath = $path;
+		if ($this->allowSymlinks || $currentPath === '') {
 			return $fullPath;
 		}
 		$pathToResolve = $fullPath;
 		$realPath = realpath($pathToResolve);
 		while ($realPath === false) { // for non existing files check the parent directory
-			$pathToResolve = dirname($pathToResolve);
-			$realPath = realpath($pathToResolve);
+			$currentPath = dirname($currentPath);
+			if ($currentPath === '' || $currentPath === '.') {
+				return $fullPath;
+			}
+			$realPath = realpath($this->datadir . $currentPath);
 		}
 		if ($realPath) {
 			$realPath = $realPath . '/';


### PR DESCRIPTION
Found while testing strict types for PHP7+. (#7392)

@icewind1991 Does this make sense or should we maybe look into this and fix the case.

See the drone failure while starting phpunit:

```
+ phpenmod xdebug
+ TEST_SELECTION=NODB ./autotest.sh sqlite
Using PHP executable /usr/bin/php
Parsing all files in lib/public for the presence of @since or @deprecated on each method...

Using database oc_autotest
Setup environment for sqlite testing on local storage ...
Installing ....
Nextcloud is not installed - only a limited number of commands are available
creating sqlite db
An unhandled exception has been thrown:
TypeError: rtrim() expects parameter 1 to be string, boolean given in /drone/src/github.com/nextcloud/server/lib/private/Files/Storage/Local.php:68
Stack trace:
#0 /drone/src/github.com/nextcloud/server/lib/private/Files/Storage/Local.php(68): rtrim(false, '/')
#1 /drone/src/github.com/nextcloud/server/lib/private/Files/Storage/Home.php(55): OC\Files\Storage\Local->__construct(Array)
#2 /drone/src/github.com/nextcloud/server/lib/private/Files/Mount/MountPoint.php(147): OC\Files\Storage\Home->__construct(Array)
#3 /drone/src/github.com/nextcloud/server/lib/private/Files/Mount/MountPoint.php(172): OC\Files\Mount\MountPoint->createStorage()
#4 /drone/src/github.com/nextcloud/server/lib/private/Files/Filesystem.php(320): OC\Files\Mount\MountPoint->getStorage()
#5 /drone/src/github.com/nextcloud/server/lib/private/Files/Filesystem.php(442): OC\Files\Filesystem::getStorage('admin')
#6 /drone/src/github.com/nextcloud/server/lib/private/Files/Filesystem.php(375): OC\Files\Filesystem::initMountPoints('admin')
#7 /drone/src/github.com/nextcloud/server/lib/private/legacy/util.php(290): OC\Files\Filesystem::init('admin', '/admin/files')
#8 /drone/src/github.com/nextcloud/server/lib/private/User/Session.php(484): OC_Util::setupFS('admin')
#9 /drone/src/github.com/nextcloud/server/lib/private/User/Session.php(365): OC\User\Session->prepareUserLogin(true, false)
#10 /drone/src/github.com/nextcloud/server/lib/private/User/Session.php(554): OC\User\Session->completeLogin(Object(OC\User\User), Array, false)
#11 /drone/src/github.com/nextcloud/server/lib/private/User/Session.php(330): OC\User\Session->loginWithPassword('admin', 'admin')
#12 /drone/src/github.com/nextcloud/server/lib/private/Setup.php(407): OC\User\Session->login('admin', 'admin')
#13 /drone/src/github.com/nextcloud/server/core/Command/Maintenance/Install.php(102): OC\Setup->install(Array)
#14 /drone/src/github.com/nextcloud/server/3rdparty/symfony/console/Command/Command.php(264): OC\Core\Command\Maintenance\Install->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#15 /drone/src/github.com/nextcloud/server/3rdparty/symfony/console/Application.php(874): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#16 /drone/src/github.com/nextcloud/server/3rdparty/symfony/console/Application.php(228): Symfony\Component\Console\Application->doRunCommand(Object(OC\Core\Command\Maintenance\Install), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#17 /drone/src/github.com/nextcloud/server/3rdparty/symfony/console/Application.php(130): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#18 /drone/src/github.com/nextcloud/server/lib/private/Console/Application.php(174): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#19 /drone/src/github.com/nextcloud/server/console.php(90): OC\Console\Application->run()
#20 /drone/src/github.com/nextcloud/server/occ(11): require_once('/drone/src/gith...')
#21 {main}
```

