### PR TITLE
Don't perform CSRF check on OCS routes with Bearer auth

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -170,10 +170,16 @@ class SecurityMiddleware extends Middleware {
 			 * Only allow the CSRF check to fail on OCS Requests. This kind of
 			 * hacks around that we have no full token auth in place yet and we
 			 * do want to offer CSRF checks for web requests.
+			 *
+			 * Additionally we allow Bearer authenticated requests to pass on OCS routes.
+			 * This allows oauth apps (e.g. moodle) to use the OCS endpoints
 			 */
 			if(!$this->request->passesCSRFCheck() && !(
-					$controller instanceof OCSController &&
-					$this->request->getHeader('OCS-APIREQUEST') === 'true')) {
+					$controller instanceof OCSController && (
+						$this->request->getHeader('OCS-APIREQUEST') === 'true' ||
+						strpos($this->request->getHeader('Authorization'), 'Bearer ') === 0
+					)
+				)) {
 				throw new CrossSiteRequestForgeryException();
 			}
 		}

--- a/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
@@ -387,11 +387,15 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 			->getMock();
 
 		return [
-			[$controller, false, true],
-			[$controller, true,  true],
+			[$controller, false, false, true],
+			[$controller, false,  true, true],
+			[$controller,  true, false, true],
+			[$controller,  true,  true, true],
 
-			[$ocsController, false, true],
-			[$ocsController, true,  false],
+			[$ocsController, false, false,  true],
+			[$ocsController, false,  true, false],
+			[$ocsController,  true, false, false],
+			[$ocsController,  true,  true, false],
 		];
 	}
 
@@ -399,13 +403,21 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	 * @dataProvider dataCsrfOcsController
 	 * @param Controller $controller
 	 * @param bool $hasOcsApiHeader
+	 * @param bool $hasBearerAuth
 	 * @param bool $exception
 	 */
-	public function testCsrfOcsController(Controller $controller, $hasOcsApiHeader, $exception) {
+	public function testCsrfOcsController(Controller $controller, bool $hasOcsApiHeader, bool $hasBearerAuth, bool $exception) {
 		$this->request
 			->method('getHeader')
-			->with('OCS-APIREQUEST')
-			->willReturn($hasOcsApiHeader ? 'true' : null);
+			->will(self::returnCallback(function ($header) use ($hasOcsApiHeader, $hasBearerAuth) {
+				if ($header === 'OCS-APIREQUEST' && $hasOcsApiHeader) {
+					return 'true';
+				}
+				if ($header === 'Authorization' && $hasBearerAuth) {
+					return 'Bearer TOKEN!';
+				}
+				return '';
+			}));
 		$this->request->expects($this->once())
 			->method('passesStrictCookieCheck')
 			->willReturn(true);


### PR DESCRIPTION
Fixes #5694

Todo:
- [x] Validate if this works
  - [x] @daita has it working :balloon: 
  - [x] @pierreozoux has it working too
  - [x] @Dagefoerde has it working as well :)
- [x] Fix tests
- [x] Extend tests

@daita please verify
@Dagefoerde could you also check this out? THNX.