### PR TITLE
Support arbitrary number of arguments for d:or and d:and in search queries

### DIFF
--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -83,6 +83,16 @@ class QuerySearchHelper {
 		return false;
 	}
 
+	/**
+	 * @param IQueryBuilder $builder
+	 * @param ISearchOperator $operator
+	 */
+	public function searchOperatorArrayToDBExprArray(IQueryBuilder $builder, array $operators) {
+		return array_map(function ($operator) use ($builder) {
+			return $this->searchOperatorToDBExpr($builder, $operator);
+		}, $operators);
+	}
+
 	public function searchOperatorToDBExpr(IQueryBuilder $builder, ISearchOperator $operator) {
 		$expr = $builder->expr();
 		if ($operator instanceof ISearchBinaryOperator) {
@@ -95,9 +105,9 @@ class QuerySearchHelper {
 						throw new \InvalidArgumentException('Binary operators inside "not" is not supported');
 					}
 				case ISearchBinaryOperator::OPERATOR_AND:
-					return $expr->andX($this->searchOperatorToDBExpr($builder, $operator->getArguments()[0]), $this->searchOperatorToDBExpr($builder, $operator->getArguments()[1]));
+					return call_user_func_array([$expr, 'andX'], $this->searchOperatorArrayToDBExprArray($builder, $operator->getArguments()));
 				case ISearchBinaryOperator::OPERATOR_OR:
-					return $expr->orX($this->searchOperatorToDBExpr($builder, $operator->getArguments()[0]), $this->searchOperatorToDBExpr($builder, $operator->getArguments()[1]));
+					return call_user_func_array([$expr, 'orX'], $this->searchOperatorArrayToDBExprArray($builder, $operator->getArguments()));
 				default:
 					throw new \InvalidArgumentException('Invalid operator type: ' . $operator->getType());
 			}

--- a/tests/lib/Files/Cache/QuerySearchHelperTest.php
+++ b/tests/lib/Files/Cache/QuerySearchHelperTest.php
@@ -151,8 +151,13 @@ class QuerySearchHelperTest extends TestCase {
 			[new SearchComparison(ISearchComparison::COMPARE_LIKE, 'mimetype', 'image/%'), [0, 1]],
 			[new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
 				new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'size', 50),
-				new SearchComparison(ISearchComparison::COMPARE_LESS_THAN, 'mtime', 125), [0]
+				new SearchComparison(ISearchComparison::COMPARE_LESS_THAN, 'mtime', 125)
 			]), [0]],
+			[new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+				new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'size', 50),
+				new SearchComparison(ISearchComparison::COMPARE_LESS_THAN, 'mtime', 125),
+				new SearchComparison(ISearchComparison::COMPARE_LIKE, 'mimetype', 'text/%')
+			]), []],
 			[new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR, [
 				new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'mtime', 100),
 				new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'mtime', 150),


### PR DESCRIPTION
The sabredav plugin already handles this case, just have to properly transform it to the db query

See https://github.com/nextcloud/server/pull/3360#issuecomment-357682769