### PR TITLE
Fix systemtags/list to be compliant

### DIFF
--- a/apps/systemtags/list.php
+++ b/apps/systemtags/list.php
@@ -19,8 +19,24 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+// WARNING: this should be moved to proper AppFramework handling
 // Check if we are a user
-OCP\User::checkLoggedIn();
+if (!\OC::$server->getUserSession()->isLoggedIn()) {
+	header('Location: ' . \OC::$server->getURLGenerator()->linkToRoute(
+			'core.login.showLoginForm',
+			[
+				'redirect_url' => \OC::$server->getRequest()->getRequestUri(),
+			]
+		)
+	);
+	exit();
+}
+// Redirect to 2FA challenge selection if 2FA challenge was not solved yet
+if (\OC::$server->getTwoFactorAuthManager()->needsSecondFactor(\OC::$server->getUserSession()->getUser())) {
+	header('Location: ' . \OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.selectChallenge'));
+	exit();
+}
 
 $tmpl = new OCP\Template('systemtags', 'list', '');
 $tmpl->printPage();


### PR DESCRIPTION
Fixes:

```
Analysing /drone/src/github.com/nextcloud/server/apps/systemtags/list.php
 2 errors
    line   23: OCP\User - Static method of deprecated class must not be called
    line   23: OCP\User::checkLoggedIn - Method of deprecated class must not be called
App is not compliant
```

This is a plain copy of the deprecated method :/