### PR TITLE
Make OCP\Http strict

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -25,6 +26,7 @@ namespace OC\Http\Client;
 
 use GuzzleHttp\Client as GuzzleClient;
 use OCP\Http\Client\IClient;
+use OCP\Http\Client\IResponse;
 use OCP\ICertificateManager;
 use OCP\IConfig;
 
@@ -89,7 +91,7 @@ class Client implements IClient {
 	 *
 	 * @return string
 	 */
-	private function getProxyUri() {
+	private function getProxyUri(): string {
 		$proxyHost = $this->config->getSystemValue('proxy', null);
 		$proxyUserPwd = $this->config->getSystemValue('proxyuserpwd', null);
 		$proxyUri = '';
@@ -130,10 +132,10 @@ class Client implements IClient {
 	 *              'verify' => true, // bool or string to CA file
 	 *              'debug' => true,
 	 *              'timeout' => 5,
-	 * @return Response
+	 * @return IResponse
 	 * @throws \Exception If the request could not get completed
 	 */
-	public function get($uri, array $options = []) {
+	public function get(string $uri, array $options = []): IResponse {
 		$this->setDefaultOptions();
 		$response = $this->client->get($uri, $options);
 		$isStream = isset($options['stream']) && $options['stream'];
@@ -161,10 +163,10 @@ class Client implements IClient {
 	 *              'verify' => true, // bool or string to CA file
 	 *              'debug' => true,
 	 *              'timeout' => 5,
-	 * @return Response
+	 * @return IResponse
 	 * @throws \Exception If the request could not get completed
 	 */
-	public function head($uri, $options = []) {
+	public function head(string $uri, array $options = []): IResponse {
 		$this->setDefaultOptions();
 		$response = $this->client->head($uri, $options);
 		return new Response($response);
@@ -196,10 +198,10 @@ class Client implements IClient {
 	 *              'verify' => true, // bool or string to CA file
 	 *              'debug' => true,
 	 *              'timeout' => 5,
-	 * @return Response
+	 * @return IResponse
 	 * @throws \Exception If the request could not get completed
 	 */
-	public function post($uri, array $options = []) {
+	public function post(string $uri, array $options = []): IResponse {
 		$this->setDefaultOptions();
 		$response = $this->client->post($uri, $options);
 		return new Response($response);
@@ -231,10 +233,10 @@ class Client implements IClient {
 	 *              'verify' => true, // bool or string to CA file
 	 *              'debug' => true,
 	 *              'timeout' => 5,
-	 * @return Response
+	 * @return IResponse
 	 * @throws \Exception If the request could not get completed
 	 */
-	public function put($uri, array $options = []) {
+	public function put(string $uri, array $options = []): IResponse {
 		$this->setDefaultOptions();
 		$response = $this->client->put($uri, $options);
 		return new Response($response);
@@ -266,10 +268,10 @@ class Client implements IClient {
 	 *              'verify' => true, // bool or string to CA file
 	 *              'debug' => true,
 	 *              'timeout' => 5,
-	 * @return Response
+	 * @return IResponse
 	 * @throws \Exception If the request could not get completed
 	 */
-	public function delete($uri, array $options = []) {
+	public function delete(string $uri, array $options = []): IResponse {
 		$this->setDefaultOptions();
 		$response = $this->client->delete($uri, $options);
 		return new Response($response);
@@ -302,10 +304,10 @@ class Client implements IClient {
 	 *              'verify' => true, // bool or string to CA file
 	 *              'debug' => true,
 	 *              'timeout' => 5,
-	 * @return Response
+	 * @return IResponse
 	 * @throws \Exception If the request could not get completed
 	 */
-	public function options($uri, array $options = []) {
+	public function options(string $uri, array $options = []): IResponse {
 		$this->setDefaultOptions();
 		$response = $this->client->options($uri, $options);
 		return new Response($response);

--- a/lib/private/Http/Client/ClientService.php
+++ b/lib/private/Http/Client/ClientService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -23,6 +24,7 @@
 namespace OC\Http\Client;
 
 use GuzzleHttp\Client as GuzzleClient;
+use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\ICertificateManager;
 use OCP\IConfig;
@@ -51,7 +53,7 @@ class ClientService implements IClientService {
 	/**
 	 * @return Client
 	 */
-	public function newClient() {
+	public function newClient(): IClient {
 		return new Client($this->config, $this->certificateManager, new GuzzleClient());
 	}
 }

--- a/lib/private/Http/Client/Response.php
+++ b/lib/private/Http/Client/Response.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -24,7 +25,7 @@
 namespace OC\Http\Client;
 
 use OCP\Http\Client\IResponse;
-use GuzzleHttp\Message\Response as GuzzleResponse;
+use GuzzleHttp\Message\ResponseInterface as GuzzleResponse;
 
 /**
  * Class Response
@@ -61,22 +62,22 @@ class Response implements IResponse {
 	/**
 	 * @return int
 	 */
-	public function getStatusCode() {
+	public function getStatusCode(): int {
 		return $this->response->getStatusCode();
 	}
 
 	/**
-	 * @param $key
+	 * @param string $key
 	 * @return string
 	 */
-	public function getHeader($key) {
+	public function getHeader(string $key): string {
 		return $this->response->getHeader($key);
 	}
 
 	/**
 	 * @return array
 	 */
-	public function getHeaders() {
+	public function getHeaders(): array {
 		return $this->response->getHeaders();
 	}
 }

--- a/lib/public/Http/Client/IClient.php
+++ b/lib/public/Http/Client/IClient.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -59,7 +60,7 @@ interface IClient {
 	 * @throws \Exception If the request could not get completed
 	 * @since 8.1.0
 	 */
-	public function get($uri, array $options = []);
+	public function get(string $uri, array $options = []): IResponse;
 
 	/**
 	 * Sends a HEAD request
@@ -84,7 +85,7 @@ interface IClient {
 	 * @throws \Exception If the request could not get completed
 	 * @since 8.1.0
 	 */
-	public function head($uri, $options = []);
+	public function head(string $uri, array $options = []): IResponse;
 
 	/**
 	 * Sends a POST request
@@ -114,7 +115,7 @@ interface IClient {
 	 * @throws \Exception If the request could not get completed
 	 * @since 8.1.0
 	 */
-	public function post($uri, array $options = []);
+	public function post(string $uri, array $options = []): IResponse;
 
 	/**
 	 * Sends a PUT request
@@ -144,7 +145,7 @@ interface IClient {
 	 * @throws \Exception If the request could not get completed
 	 * @since 8.1.0
 	 */
-	public function put($uri, array $options = []);
+	public function put(string $uri, array $options = []): IResponse;
 
 	/**
 	 * Sends a DELETE request
@@ -174,7 +175,7 @@ interface IClient {
 	 * @throws \Exception If the request could not get completed
 	 * @since 8.1.0
 	 */
-	public function delete($uri, array $options = []);
+	public function delete(string $uri, array $options = []): IResponse;
 
 	/**
 	 * Sends a options request
@@ -204,5 +205,5 @@ interface IClient {
 	 * @throws \Exception If the request could not get completed
 	 * @since 8.1.0
 	 */
-	public function options($uri, array $options = []);
+	public function options(string $uri, array $options = []): IResponse;
 }

--- a/lib/public/Http/Client/IClientService.php
+++ b/lib/public/Http/Client/IClientService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -34,5 +35,5 @@ interface IClientService {
 	 * @return IClient
 	 * @since 8.1.0
 	 */
-	public function newClient();
+	public function newClient(): IClient;
 }

--- a/lib/public/Http/Client/IResponse.php
+++ b/lib/public/Http/Client/IResponse.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -41,18 +42,18 @@ interface IResponse {
 	 * @return int
 	 * @since 8.1.0
 	 */
-	public function getStatusCode();
+	public function getStatusCode(): int;
 
 	/**
-	 * @param $key
+	 * @param string $key
 	 * @return string
 	 * @since 8.1.0
 	 */
-	public function getHeader($key);
+	public function getHeader(string $key): string;
 
 	/**
 	 * @return array
 	 * @since 8.1.0
 	 */
-	public function getHeaders();
+	public function getHeaders(): array;
 }


### PR DESCRIPTION
* Handle private files
* Add return types
* Add scalar typehints
* Made strict
* Fixed requiring proper guzzle message interface that is passed around

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>