### PR TITLE
Add Cache-control: immutable

### DIFF
--- a/core/Controller/CssController.php
+++ b/core/Controller/CssController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, John Molakvoæ (skjnldsv@protonmail.com)
  *
@@ -31,11 +32,13 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\NotFoundResponse;
 use OCP\AppFramework\Http\FileDisplayResponse;
+use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
+use OCP\IConfig;
 use OCP\IRequest;
 
 class CssController extends Controller {
@@ -46,13 +49,10 @@ class CssController extends Controller {
 	/** @var ITimeFactory */
 	protected $timeFactory;
 
-	/**
-	 * @param string $appName
-	 * @param IRequest $request
-	 * @param Factory $appDataFactory
-	 * @param ITimeFactory $timeFactory
-	 */
-	public function __construct($appName, IRequest $request, Factory $appDataFactory, ITimeFactory $timeFactory) {
+	public function __construct(string $appName,
+								IRequest $request,
+								Factory $appDataFactory,
+								ITimeFactory $timeFactory) {
 		parent::__construct($appName, $request);
 
 		$this->appData = $appDataFactory->get('css');
@@ -67,7 +67,7 @@ class CssController extends Controller {
 	 * @param string $appName css folder name
 	 * @return FileDisplayResponse|NotFoundResponse
 	 */
-	public function getCss($fileName, $appName) {
+	public function getCss(string $fileName, string $appName): Response {
 		try {
 			$folder = $this->appData->getFolder($appName);
 			$gzip = false;
@@ -80,10 +80,13 @@ class CssController extends Controller {
 		if ($gzip) {
 			$response->addHeader('Content-Encoding', 'gzip');
 		}
-		$response->cacheFor(86400);
+
+		$ttl = 31536000;
+		$response->addHeader('Cache-Control', 'max-age='.$ttl.', immutable');
+
 		$expires = new \DateTime();
 		$expires->setTimestamp($this->timeFactory->getTime());
-		$expires->add(new \DateInterval('PT24H'));
+		$expires->add(new \DateInterval('PT'.$ttl.'S'));
 		$response->addHeader('Expires', $expires->format(\DateTime::RFC1123));
 		$response->addHeader('Pragma', 'cache');
 		return $response;
@@ -94,8 +97,9 @@ class CssController extends Controller {
 	 * @param string $fileName
 	 * @param bool $gzip is set to true if we use the gzip file
 	 * @return ISimpleFile
+	 * @throws NotFoundException
 	 */
-	private function getFile(ISimpleFolder $folder, $fileName, &$gzip) {
+	private function getFile(ISimpleFolder $folder, string $fileName, bool &$gzip): ISimpleFile {
 		$encoding = $this->request->getHeader('Accept-Encoding');
 
 		if (strpos($encoding, 'gzip') !== false) {

--- a/tests/Core/Controller/CssControllerTest.php
+++ b/tests/Core/Controller/CssControllerTest.php
@@ -109,10 +109,10 @@ class CssControllerTest extends TestCase {
 			->willReturn($file);
 
 		$expected = new FileDisplayResponse($file, Http::STATUS_OK, ['Content-Type' => 'text/css']);
-		$expected->cacheFor(86400);
+		$expected->addHeader('Cache-Control', 'max-age=31536000, immutable');
 		$expires = new \DateTime();
 		$expires->setTimestamp(1337);
-		$expires->add(new \DateInterval('PT24H'));
+		$expires->add(new \DateInterval('PT31536000S'));
 		$expected->addHeader('Expires', $expires->format(\DateTime::RFC1123));
 		$expected->addHeader('Pragma', 'cache');
 
@@ -137,10 +137,10 @@ class CssControllerTest extends TestCase {
 
 		$expected = new FileDisplayResponse($gzipFile, Http::STATUS_OK, ['Content-Type' => 'text/css']);
 		$expected->addHeader('Content-Encoding', 'gzip');
-		$expected->cacheFor(86400);
+		$expected->addHeader('Cache-Control', 'max-age=31536000, immutable');
 		$expires = new \DateTime();
 		$expires->setTimestamp(1337);
-		$expires->add(new \DateInterval('PT24H'));
+		$expires->add(new \DateInterval('PT31536000S'));
 		$expected->addHeader('Expires', $expires->format(\DateTime::RFC1123));
 		$expected->addHeader('Pragma', 'cache');
 
@@ -170,10 +170,10 @@ class CssControllerTest extends TestCase {
 			->willReturn('gzip, deflate');
 
 		$expected = new FileDisplayResponse($file, Http::STATUS_OK, ['Content-Type' => 'text/css']);
-		$expected->cacheFor(86400);
+		$expected->addHeader('Cache-Control', 'max-age=31536000, immutable');
 		$expires = new \DateTime();
 		$expires->setTimestamp(1337);
-		$expires->add(new \DateInterval('PT24H'));
+		$expires->add(new \DateInterval('PT31536000S'));
 		$expected->addHeader('Expires', $expires->format(\DateTime::RFC1123));
 		$expected->addHeader('Pragma', 'cache');
 

--- a/tests/Core/Controller/JsControllerTest.php
+++ b/tests/Core/Controller/JsControllerTest.php
@@ -109,10 +109,10 @@ class JsControllerTest extends TestCase {
 			->willReturn($file);
 
 		$expected = new FileDisplayResponse($file, Http::STATUS_OK, ['Content-Type' => 'application/javascript']);
-		$expected->cacheFor(86400);
+		$expected->addHeader('Cache-Control', 'max-age=31536000, immutable');
 		$expires = new \DateTime();
 		$expires->setTimestamp(1337);
-		$expires->add(new \DateInterval('PT24H'));
+		$expires->add(new \DateInterval('PT31536000S'));
 		$expected->addHeader('Expires', $expires->format(\DateTime::RFC1123));
 		$expected->addHeader('Pragma', 'cache');
 
@@ -137,10 +137,10 @@ class JsControllerTest extends TestCase {
 
 		$expected = new FileDisplayResponse($gzipFile, Http::STATUS_OK, ['Content-Type' => 'application/javascript']);
 		$expected->addHeader('Content-Encoding', 'gzip');
-		$expected->cacheFor(86400);
+		$expected->addHeader('Cache-Control', 'max-age=31536000, immutable');
 		$expires = new \DateTime();
 		$expires->setTimestamp(1337);
-		$expires->add(new \DateInterval('PT24H'));
+		$expires->add(new \DateInterval('PT31536000S'));
 		$expected->addHeader('Expires', $expires->format(\DateTime::RFC1123));
 		$expected->addHeader('Pragma', 'cache');
 
@@ -170,10 +170,10 @@ class JsControllerTest extends TestCase {
 			->willReturn('gzip, deflate');
 
 		$expected = new FileDisplayResponse($file, Http::STATUS_OK, ['Content-Type' => 'application/javascript']);
-		$expected->cacheFor(86400);
+		$expected->addHeader('Cache-Control', 'max-age=31536000, immutable');
 		$expires = new \DateTime();
 		$expires->setTimestamp(1337);
-		$expires->add(new \DateInterval('PT24H'));
+		$expires->add(new \DateInterval('PT31536000S'));
 		$expected->addHeader('Expires', $expires->format(\DateTime::RFC1123));
 		$expected->addHeader('Pragma', 'cache');
 


### PR DESCRIPTION
Fixes #7224

If not in debug mode we basically cache the CSS for ever ;) Else we fall back to the default (1 day) in debug mode.

Most modern browsers support this. And on upgrade we have a cache buster. basically it is just telling supported browsers this will not change.

Todo:
- [x] JS endpoint