### PR TITLE
format self-mentions, but don't offer them

### DIFF
--- a/lib/private/Collaboration/Collaborators/Search.php
+++ b/lib/private/Collaboration/Collaborators/Search.php
@@ -40,6 +40,15 @@ class Search implements ISearch {
 		$this->c = $c;
 	}
 
+	/**
+	 * @param $search
+	 * @param array $shareTypes
+	 * @param $lookup
+	 * @param $limit
+	 * @param $offset
+	 * @return array
+	 * @throws \OCP\AppFramework\QueryException
+	 */
 	public function search($search, array $shareTypes, $lookup, $limit, $offset) {
 		$hasMoreResults = false;
 

--- a/lib/private/Collaboration/Collaborators/Search.php
+++ b/lib/private/Collaboration/Collaborators/Search.php
@@ -41,11 +41,11 @@ class Search implements ISearch {
 	}
 
 	/**
-	 * @param $search
+	 * @param string $search
 	 * @param array $shareTypes
-	 * @param $lookup
-	 * @param $limit
-	 * @param $offset
+	 * @param bool $lookup
+	 * @param int|null $limit
+	 * @param int|null $offset
 	 * @return array
 	 * @throws \OCP\AppFramework\QueryException
 	 */

--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -83,6 +83,8 @@ class UserPlugin implements ISearchPlugin {
 			}
 		}
 
+		$this->takeOutCurrentUser($users);
+
 		if (!$this->shareeEnumeration || sizeof($users) < $limit) {
 			$hasMoreResults = true;
 		}
@@ -145,5 +147,14 @@ class UserPlugin implements ISearchPlugin {
 		$searchResult->addResultSet($type, $result['wide'], $result['exact']);
 
 		return $hasMoreResults;
+	}
+
+	public function takeOutCurrentUser(array &$users) {
+		$currentUser = $this->userSession->getUser();
+		if(!is_null($currentUser)) {
+			if (isset($users[$currentUser->getUID()])) {
+				unset($users[$currentUser->getUID()]);
+			}
+		}
 	}
 }

--- a/lib/private/Comments/Comment.php
+++ b/lib/private/Comments/Comment.php
@@ -232,10 +232,6 @@ class Comment implements IComment {
 		$uids = array_unique($mentions[0]);
 		$result = [];
 		foreach ($uids as $uid) {
-			// exclude author, no self-mentioning
-			if($uid === '@' . $this->getActorId()) {
-				continue;
-			}
 			$result[] = ['type' => 'user', 'id' => substr($uid, 1)];
 		}
 		return $result;

--- a/tests/lib/Collaboration/Collaborators/UserPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/UserPluginTest.php
@@ -442,4 +442,51 @@ class UserPluginTest extends TestCase {
 		$this->assertEquals($expected, $result['users']);
 		$this->assertSame($reachedEnd, $moreResults);
 	}
+
+	public function takeOutCurrentUserProvider() {
+		$inputUsers = [
+			'alice' => 'Alice',
+			'bob' => 'Bob',
+			'carol' => 'Carol'
+		];
+		return [
+			[
+				$inputUsers,
+				['alice', 'carol'],
+				'bob'
+			],
+			[
+				$inputUsers,
+				['alice', 'bob', 'carol'],
+				'dave'
+			],
+			[
+				$inputUsers,
+				['alice', 'bob', 'carol'],
+				null
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider takeOutCurrentUserProvider
+	 * @param array $users
+	 * @param array $expectedUIDs
+	 * @param $currentUserId
+	 */
+	public function testTakeOutCurrentUser(array $users, array $expectedUIDs, $currentUserId) {
+		$this->instantiatePlugin();
+
+		$this->session->expects($this->once())
+			->method('getUser')
+			->willReturnCallback(function() use ($currentUserId) {
+				if($currentUserId !== null) {
+					return $this->getUserMock($currentUserId, $currentUserId);
+				}
+				return null;
+			});
+
+		$this->plugin->takeOutCurrentUser($users);
+		$this->assertSame($expectedUIDs, array_keys($users));
+	}
 }

--- a/tests/lib/Comments/CommentTest.php
+++ b/tests/lib/Comments/CommentTest.php
@@ -8,6 +8,9 @@ use Test\TestCase;
 
 class CommentTest extends TestCase {
 
+	/**
+	 * @throws \OCP\Comments\IllegalIDChangeException
+	 */
 	public function testSettersValidInput() {
 		$comment = new Comment();
 
@@ -58,6 +61,9 @@ class CommentTest extends TestCase {
 		$comment->setId('c17');
 	}
 
+	/**
+	 * @throws \OCP\Comments\IllegalIDChangeException
+	 */
 	public function testResetId() {
 		$comment = new Comment();
 		$comment->setId('c23');
@@ -133,7 +139,7 @@ class CommentTest extends TestCase {
 				'@alice @bob look look, a duplication @alice test @bob!', ['alice', 'bob']
 			],
 			[
-				'@alice is the author, but notify @bob!', ['bob'], 'alice'
+				'@alice is the author, notify @bob, nevertheless mention her!', ['alice', 'bob'], 'alice'
 			],
 			[
 				'@foobar and @barfoo you should know, @foo@bar.com is valid' .
@@ -159,7 +165,6 @@ class CommentTest extends TestCase {
 			$uid = array_shift($expectedUids);
 			$this->assertSame('user', $mention['type']);
 			$this->assertSame($uid, $mention['id']);
-			$this->assertNotSame($author, $mention['id']);
 		}
 		$this->assertEmpty($mentions);
 		$this->assertEmpty($expectedUids);


### PR DESCRIPTION
* When auto-completing (e.g. in comments), a user cannot lookup herself anymore
* When a users manages to mention herself in a comment, it still will be formatted now

fixes #7254 

I guess it makes sense to backport it to 13, it's a papercut.