### PR TITLE
Do not show "Not installed warning" during occ install

### DIFF
--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -127,7 +127,7 @@ class Application {
 						}
 					}
 				}
-			} else if ($input->getArgument('command') !== '_completion') {
+			} else if ($input->getArgument('command') !== '_completion' && $input->getArgument('command') !== 'maintenance:install') {
 				$output->writeln("Nextcloud is not installed - only a limited number of commands are available");
 			}
 		} catch(NeedsUpdateException $e) {


### PR DESCRIPTION
Now looks like this:

```
$ occ maintenance:install ...
Nextcloud was successfully installed
```

Before:
```
$ occ maintenance:install ...
Nextcloud is not installed - only a limited number of commands are available
Nextcloud was successfully installed
```