### PR TITLE
13.0.0 RC2

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(13, 0, 0, 10);
+$OC_Version = array(13, 0, 0, 11);
 
 // The human readable string
-$OC_VersionString = '13.0.0 RC 1';
+$OC_VersionString = '13.0.0 RC 2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Diff to RC1 (#7764):

* #7806 Fix bug with proxies
* #7878 Deprecated checkLoggedIn and other old ways to access control
* #7883 Support arbitrary number of arguments for d:or and d:and in search queries
* #7886 Add OCP\User deprecations to app code checker
* #7887 Keep all shipped apps enabled because they should be okay
* #7903 Fix systemtags/list to be compliant
* #7915 Fix the type hints of migrations and correctly inject the wrapped schema into migrations
* #7932 Format self-mentions, but don't offer them

Pending backports:

* [x] #7943 Make sure the arrays are arrays
* [x] #7944 Correctly drop the ownCloud migrations table
* [x]  #7942 remove hardcoded sharepoint icon path