### PR TITLE
Theming: adjust background image resizing

### DIFF
--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -288,12 +288,10 @@ class ThemingController extends Controller {
 			// Optimize the image since some people may upload images that will be
 			// either to big or are not progressive rendering.
 			$tmpFile = $this->tempManager->getTemporaryFile();
-			if (function_exists('imagescale')) {
-				// FIXME: Once PHP 5.5.0 is a requirement the above check can be removed
-				// Workaround for https://bugs.php.net/bug.php?id=65171
-				$newHeight = imagesy($image) / (imagesx($image) / 1920);
-				$image = imagescale($image, 1920, $newHeight);
-			}
+			$newWidth = imagesx($image) < 4096 ? imagesx($image) : 4096;
+			$newHeight = imagesy($image) / (imagesx($image) / $newWidth);
+			$image = imagescale($image, $newWidth, $newHeight);
+
 			imageinterlace($image, 1);
 			imagejpeg($image, $tmpFile, 75);
 			imagedestroy($image);


### PR DESCRIPTION
Support high resolution login images by resizing only images that are wider than 4096px, otherwise we keep the current size of the image.

This also drops the legacy checek for imagescale which is not needed with PHP>=7.0

fixes #7459

@nextcloud/theming 