### PR TITLE
Remove not needed 3rdparty app disabling during upgrade for PHP 5.x

### DIFF
--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -76,13 +76,7 @@ class Upgrade extends Command {
 	protected function configure() {
 		$this
 			->setName('upgrade')
-			->setDescription('run upgrade routines after installation of a new release. The release has to be installed before.')
-			->addOption(
-				'--no-app-disable',
-				null,
-				InputOption::VALUE_NONE,
-				'skips the disable of third party apps'
-			);
+			->setDescription('run upgrade routines after installation of a new release. The release has to be installed before.');
 	}
 
 	/**
@@ -108,9 +102,6 @@ class Upgrade extends Command {
 					$this->installer
 			);
 
-			if ($input->getOption('no-app-disable')) {
-				$updater->setSkip3rdPartyAppsDisable(true);
-			}
 			$dispatcher = \OC::$server->getEventDispatcher();
 			$progress = new ProgressBar($output);
 			$progress->setFormat(" %message%\n %current%/%max% [%bar%] %percent:3s%%");
@@ -223,9 +214,6 @@ class Upgrade extends Command {
 			});
 			$updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use($output) {
 				$output->writeln('<comment>Disabled incompatible app: ' . $app . '</comment>');
-			});
-			$updater->listen('\OC\Updater', 'thirdPartyAppDisabled', function ($app) use ($output) {
-				$output->writeln('<comment>Disabled 3rd-party app: ' . $app . '</comment>');
 			});
 			$updater->listen('\OC\Updater', 'checkAppStoreAppBefore', function ($app) use($output) {
 				$output->writeln('<info>Checking for update of app ' . $app . ' in appstore</info>');

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -120,7 +120,6 @@ if (OC::checkUpgrade(false)) {
 			\OC::$server->query(\OC\Installer::class)
 	);
 	$incompatibleApps = [];
-	$disabledThirdPartyApps = [];
 
 	$dispatcher = \OC::$server->getEventDispatcher();
 	$dispatcher->addListener('\OC\DB\Migrator::executeSql', function($event) use ($eventSource, $l) {
@@ -187,9 +186,6 @@ if (OC::checkUpgrade(false)) {
 	$updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use (&$incompatibleApps) {
 		$incompatibleApps[]= $app;
 	});
-	$updater->listen('\OC\Updater', 'thirdPartyAppDisabled', function ($app) use (&$disabledThirdPartyApps) {
-		$disabledThirdPartyApps[]= $app;
-	});
 	$updater->listen('\OC\Updater', 'failure', function ($message) use ($eventSource, $config) {
 		$eventSource->send('failure', $message);
 		$eventSource->close();
@@ -217,9 +213,6 @@ if (OC::checkUpgrade(false)) {
 	}
 
 	$disabledApps = [];
-	foreach ($disabledThirdPartyApps as $app) {
-		$disabledApps[$app] = (string) $l->t('%s (3rdparty)', [$app]);
-	}
 	foreach ($incompatibleApps as $app) {
 		$disabledApps[$app] = (string) $l->t('%s (incompatible)', [$app]);
 	}

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -66,9 +66,6 @@ class Updater extends BasicEmitter {
 	/** @var Installer */
 	private $installer;
 
-	/** @var bool */
-	private $skip3rdPartyAppsDisable;
-
 	private $logLevelNames = [
 		0 => 'Debug',
 		1 => 'Info',
@@ -91,22 +88,6 @@ class Updater extends BasicEmitter {
 		$this->config = $config;
 		$this->checker = $checker;
 		$this->installer = $installer;
-
-		// If at least PHP 7.0.0 is used we don't need to disable apps as we catch
-		// fatal errors and exceptions and disable the app just instead.
-		if(version_compare(phpversion(), '7.0.0', '>=')) {
-			$this->skip3rdPartyAppsDisable = true;
-		}
-	}
-
-	/**
-	 * Sets whether the update disables 3rd party apps.
-	 * This can be set to true to skip the disable.
-	 *
-	 * @param bool $flag false to not disable, true otherwise
-	 */
-	public function setSkip3rdPartyAppsDisable($flag) {
-		$this->skip3rdPartyAppsDisable = $flag;
 	}
 
 	/**
@@ -437,13 +418,6 @@ class Updater extends BasicEmitter {
 			if (OC_App::isType($app, ['session', 'authentication'])) {
 				continue;
 			}
-
-			// disable any other 3rd party apps if not overriden
-			if(!$this->skip3rdPartyAppsDisable) {
-				\OC_App::disable($app);
-				$disabledApps[]= $app;
-				$this->emit('\OC\Updater', 'thirdPartyAppDisabled', array($app));
-			};
 		}
 		return $disabledApps;
 	}
@@ -596,9 +570,6 @@ class Updater extends BasicEmitter {
 		});
 		$this->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use($log) {
 			$log->info('\OC\Updater::incompatibleAppDisabled: Disabled incompatible app: ' . $app, ['app' => 'updater']);
-		});
-		$this->listen('\OC\Updater', 'thirdPartyAppDisabled', function ($app) use ($log) {
-			$log->info('\OC\Updater::thirdPartyAppDisabled: Disabled 3rd-party app: ' . $app, ['app' => 'updater']);
 		});
 		$this->listen('\OC\Updater', 'checkAppStoreAppBefore', function ($app) use($log) {
 			$log->info('\OC\Updater::checkAppStoreAppBefore: Checking for update of app "' . $app . '" in appstore', ['app' => 'updater']);

--- a/tests/lib/AppFramework/Http/JSONResponseTest.php
+++ b/tests/lib/AppFramework/Http/JSONResponseTest.php
@@ -93,7 +93,6 @@ class JSONResponseTest extends \Test\TestCase {
 	/**
 	 * @expectedException \Exception
 	 * @expectedExceptionMessage Could not json_encode due to invalid non UTF-8 characters in the array: array (
-	 * @requires PHP 5.5
 	 */
 	public function testRenderWithNonUtf8Encoding() {
 		$params = ['test' => hex2bin('e9')];

--- a/tests/lib/UpdaterTest.php
+++ b/tests/lib/UpdaterTest.php
@@ -115,11 +115,4 @@ class UpdaterTest extends TestCase {
 		$this->assertSame($result, $this->updater->isUpgradePossible($oldVersion, $newVersion, $allowedVersions));
 	}
 
-	public function testSetSkip3rdPartyAppsDisable() {
-		$this->updater->setSkip3rdPartyAppsDisable(true);
-		$this->assertSame(true, $this->invokePrivate($this->updater, 'skip3rdPartyAppsDisable'));
-		$this->updater->setSkip3rdPartyAppsDisable(false);
-		$this->assertSame(false, $this->invokePrivate($this->updater, 'skip3rdPartyAppsDisable'));
-	}
-
 }


### PR DESCRIPTION
Not needed anymore because PHP 7+ is now required on master and this is then default anyways.

Added to #7827