### PR TITLE
Send a proper response for status.php on trusted domain error

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -779,8 +779,16 @@ class OC {
 				$isScssRequest = true;
 			}
 
+			if(substr($request->getRequestUri(), -11) === '/status.php') {
+				OC_Response::setStatus(\OC_Response::STATUS_BAD_REQUEST);
+				header('Status: 400 Bad Request');
+				header('Content-Type: application/json');
+				echo '{"error": "Trusted domain error.", "code": 15}';
+				exit();
+			}
+
 			if (!$isScssRequest) {
-				header('HTTP/1.1 400 Bad Request');
+				OC_Response::setStatus(\OC_Response::STATUS_BAD_REQUEST);
 				header('Status: 400 Bad Request');
 
 				\OC::$server->getLogger()->warning(


### PR DESCRIPTION
* fixes #7732

Maybe good to backport to stable12 and stable13 to make it easier for apps to detect the real problem.