### PR TITLE
[stable12] Fix #4789: Group admins cannot see disabled users

### DIFF
--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -302,7 +302,9 @@ class UsersController extends Controller {
 
 			// Batch all groups the user is subadmin of when a group is specified
 			$batch = [];
-			if($gid === '') {
+			if ($gid !== '' && $gid !== '_disabledUsers' && $gid !== '_everyone') {
+				$batch = $this->groupManager->displayNamesInGroup($gid, $pattern, $limit, $offset);
+			} else {
 				foreach($subAdminOfGroups as $group) {
 					$groupUsers = $this->groupManager->displayNamesInGroup($group, $pattern, $limit, $offset);
 
@@ -310,8 +312,6 @@ class UsersController extends Controller {
 						$batch[$uid] = $displayName;
 					}
 				}
-			} else {
-				$batch = $this->groupManager->displayNamesInGroup($gid, $pattern, $limit, $offset);
 			}
 			$batch = $this->getUsersForUID($batch);
 


### PR DESCRIPTION
Backport of #7292 

I place it to 12.0.6 since .5 is almost out of the door. 