### PR TITLE
Make sure we always know for sure if an avatar is generated or not

### DIFF
--- a/lib/private/Avatar.php
+++ b/lib/private/Avatar.php
@@ -234,6 +234,11 @@ class Avatar implements IAvatar {
 
 		}
 
+		if($this->config->getUserValue($this->user->getUID(), 'avatar', 'generated', null) === null) {
+			$generated = $this->folder->fileExists('generated') ? 'true' : 'false';
+			$this->config->setUserValue($this->user->getUID(), 'avatar', 'generated', $generated);
+		}
+
 		return $file;
 	}
 


### PR DESCRIPTION
When the user had an avatar set before upgrading from NC12 to  NC13+ the uservalue for generated avatars will not be set. This PR makes sure we update it to the correct value if it doesn't exist.

Fixes #8019