### PR TITLE
Respect limit and order in webdav search

### DIFF
--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -271,7 +271,7 @@ class FileSearchBackend implements ISearchBackend {
 		// TODO offset
 		$limit = $query->limit;
 		$orders = array_map([$this, 'mapSearchOrder'], $query->orderBy);
-		return new SearchQuery($this->transformSearchOperation($query->where), $limit->maxResults, 0, $orders, $this->user);
+		return new SearchQuery($this->transformSearchOperation($query->where), (int)$limit->maxResults, 0, $orders, $this->user);
 	}
 
 	/**

--- a/apps/dav/tests/unit/Files/FileSearchBackendTest.php
+++ b/apps/dav/tests/unit/Files/FileSearchBackendTest.php
@@ -38,6 +38,9 @@ use OCP\Files\IRootFolder;
 use OCP\Files\Search\ISearchComparison;
 use OCP\IUser;
 use OCP\Share\IManager;
+use SearchDAV\Backend\SearchPropertyDefinition;
+use SearchDAV\Query\Limit;
+use SearchDAV\Query\Query;
 use SearchDAV\XML\BasicSearch;
 use SearchDAV\XML\Literal;
 use SearchDAV\XML\Operator;
@@ -132,7 +135,7 @@ class FileSearchBackendTest extends TestCase {
 				new \OC\Files\Node\Folder($this->rootFolder, $this->view, '/test/path')
 			]));
 
-		$query = $this->getBasicQuery(Operator::OPERATION_EQUAL, '{DAV:}displayname', 'foo');
+		$query = $this->getBasicQuery(\SearchDAV\Query\Operator::OPERATION_EQUAL, '{DAV:}displayname', 'foo');
 		$result = $this->search->search($query);
 
 		$this->assertCount(1, $result);
@@ -161,7 +164,7 @@ class FileSearchBackendTest extends TestCase {
 				new \OC\Files\Node\Folder($this->rootFolder, $this->view, '/test/path')
 			]));
 
-		$query = $this->getBasicQuery(Operator::OPERATION_EQUAL, '{DAV:}getcontenttype', 'foo');
+		$query = $this->getBasicQuery(\SearchDAV\Query\Operator::OPERATION_EQUAL, '{DAV:}getcontenttype', 'foo');
 		$result = $this->search->search($query);
 
 		$this->assertCount(1, $result);
@@ -190,7 +193,7 @@ class FileSearchBackendTest extends TestCase {
 				new \OC\Files\Node\Folder($this->rootFolder, $this->view, '/test/path')
 			]));
 
-		$query = $this->getBasicQuery(Operator::OPERATION_GREATER_THAN, FilesPlugin::SIZE_PROPERTYNAME, 10);
+		$query = $this->getBasicQuery(\SearchDAV\Query\Operator::OPERATION_GREATER_THAN, FilesPlugin::SIZE_PROPERTYNAME, 10);
 		$result = $this->search->search($query);
 
 		$this->assertCount(1, $result);
@@ -219,7 +222,7 @@ class FileSearchBackendTest extends TestCase {
 				new \OC\Files\Node\Folder($this->rootFolder, $this->view, '/test/path')
 			]));
 
-		$query = $this->getBasicQuery(Operator::OPERATION_GREATER_THAN, '{DAV:}getlastmodified', 10);
+		$query = $this->getBasicQuery(\SearchDAV\Query\Operator::OPERATION_GREATER_THAN, '{DAV:}getlastmodified', 10);
 		$result = $this->search->search($query);
 
 		$this->assertCount(1, $result);
@@ -248,7 +251,7 @@ class FileSearchBackendTest extends TestCase {
 				new \OC\Files\Node\Folder($this->rootFolder, $this->view, '/test/path')
 			]));
 
-		$query = $this->getBasicQuery(Operator::OPERATION_IS_COLLECTION, 'yes');
+		$query = $this->getBasicQuery(\SearchDAV\Query\Operator::OPERATION_IS_COLLECTION, 'yes');
 		$result = $this->search->search($query);
 
 		$this->assertCount(1, $result);
@@ -266,29 +269,30 @@ class FileSearchBackendTest extends TestCase {
 		$this->searchFolder->expects($this->never())
 			->method('search');
 
-		$query = $this->getBasicQuery(Operator::OPERATION_EQUAL, '{DAV:}getetag', 'foo');
+		$query = $this->getBasicQuery(\SearchDAV\Query\Operator::OPERATION_EQUAL, '{DAV:}getetag', 'foo');
 		$this->search->search($query);
 	}
 
 	private function getBasicQuery($type, $property, $value = null) {
-		$query = new BasicSearch();
-		$scope = new Scope('/', 'infinite');
+		$scope = new \SearchDAV\Query\Scope('/', 'infinite');
 		$scope->path = '/';
-		$query->from = [$scope];
-		$query->orderBy = [];
-		$query->select = [];
+		$from = [$scope];
+		$orderBy = [];
+		$select = [];
 		if (is_null($value)) {
-			$query->where = new Operator(
+			$where = new \SearchDAV\Query\Operator(
 				$type,
-				[new Literal($property)]
+				[new \SearchDAV\Query\Literal($property)]
 			);
 		} else {
-			$query->where = new Operator(
+			$where = new \SearchDAV\Query\Operator(
 				$type,
-				[$property, new Literal($value)]
+				[new SearchPropertyDefinition($property, true, true, true), new \SearchDAV\Query\Literal($value)]
 			);
 		}
-		return $query;
+		$limit = new Limit();
+
+		return new Query($select, $from, $where, $orderBy, $limit);
 	}
 
 	/**
@@ -301,7 +305,7 @@ class FileSearchBackendTest extends TestCase {
 			->method('getNodeForPath')
 			->willReturn($davNode);
 
-		$query = $this->getBasicQuery(Operator::OPERATION_EQUAL, '{DAV:}displayname', 'foo');
+		$query = $this->getBasicQuery(\SearchDAV\Query\Operator::OPERATION_EQUAL, '{DAV:}displayname', 'foo');
 		$this->search->search($query);
 	}
 }

--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -29,6 +29,7 @@
 namespace OC\Files\Cache\Wrapper;
 
 use OC\Files\Cache\Cache;
+use OC\Files\Search\SearchQuery;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Search\ISearchQuery;
 
@@ -236,8 +237,14 @@ class CacheJail extends CacheWrapper {
 	}
 
 	public function searchQuery(ISearchQuery $query) {
-		$results = $this->getCache()->searchQuery($query);
-		return $this->formatSearchResults($results);
+		$simpleQuery = new SearchQuery($query->getSearchOperation(), 0, 0, $query->getOrder(), $query->getUser());
+		$results = $this->getCache()->searchQuery($simpleQuery);
+		$results = $this->formatSearchResults($results);
+
+		$limit = $query->getLimit() === 0 ? NULL : $query->getLimit();
+		$results = array_slice($results, $query->getOffset(), $limit);
+
+		return $results;
 	}
 
 	/**


### PR DESCRIPTION
- [x]  requires https://github.com/nextcloud/3rdparty/pull/80

Very ugly hacky code. But it is a start to start the discussion.

Basically this:
* passes on the limit operator to the search
* sorts the results again (since it can come from multiple storages)
* limits the sorted results again

This should allow mobile clients to do better searching to display for example all images etc.