### PR TITLE
Allow custom HTML in HTML Emails

### DIFF
--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -404,7 +404,7 @@ class ShareByMailProvider implements IShareProvider {
 		$text = $this->l->t('%s shared »%s« with you.', [$initiatorDisplayName, $filename]);
 
 		$emailTemplate->addBodyText(
-			$text . ' ' . $this->l->t('Click the button below to open it.'),
+			htmlspecialchars($text . ' ' . $this->l->t('Click the button below to open it.')),
 			$text
 		);
 		$emailTemplate->addBodyButton(
@@ -476,7 +476,7 @@ class ShareByMailProvider implements IShareProvider {
 		$emailTemplate->setSubject($this->l->t('Password to access »%s« shared to you by %s', [$filename, $initiatorDisplayName]));
 		$emailTemplate->addHeader();
 		$emailTemplate->addHeading($this->l->t('Password to access »%s«', [$filename]), false);
-		$emailTemplate->addBodyText($htmlBodyPart, $plainBodyPart);
+		$emailTemplate->addBodyText(htmlspecialchars($htmlBodyPart), $plainBodyPart);
 		$emailTemplate->addBodyText($this->l->t('It is protected with the following password: %s', [$password]));
 
 		// The "From" contains the sharers name

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -321,12 +321,12 @@ class LostController extends Controller {
 		$emailTemplate->addHeading($this->l10n->t('Password reset'));
 
 		$emailTemplate->addBodyText(
-			$this->l10n->t('Click the following button to reset your password. If you have not requested the password reset, then ignore this email.'),
+			htmlspecialchars($this->l10n->t('Click the following button to reset your password. If you have not requested the password reset, then ignore this email.')),
 			$this->l10n->t('Click the following link to reset your password. If you have not requested the password reset, then ignore this email.')
 		);
 
 		$emailTemplate->addBodyButton(
-			$this->l10n->t('Reset your password'),
+			htmlspecialchars($this->l10n->t('Reset your password')),
 			$link,
 			false
 		);

--- a/lib/private/Mail/EMailTemplate.php
+++ b/lib/private/Mail/EMailTemplate.php
@@ -420,7 +420,7 @@ EOF;
 	/**
 	 * Adds a paragraph to the body of the email
 	 *
-	 * @param string $text
+	 * @param string $text Note: When $plainText falls back to this, HTML is automatically escaped in the HTML email
 	 * @param string|bool $plainText Text that is used in the plain text email
 	 *   if empty the $text is used, if false none will be used
 	 */
@@ -430,11 +430,12 @@ EOF;
 		}
 		if ($plainText === '') {
 			$plainText = $text;
+			$text = htmlspecialchars($text);
 		}
 
 		$this->ensureBodyIsOpened();
 
-		$this->htmlBody .= vsprintf($this->bodyText, [htmlspecialchars($text)]);
+		$this->htmlBody .= vsprintf($this->bodyText, [$text]);
 		if ($plainText !== false) {
 			$this->plainBody .= $plainText . PHP_EOL . PHP_EOL;
 		}
@@ -443,8 +444,8 @@ EOF;
 	/**
 	 * Adds a list item to the body of the email
 	 *
-	 * @param string $text
-	 * @param string $metaInfo
+	 * @param string $text Note: When $plainText falls back to this, HTML is automatically escaped in the HTML email
+	 * @param string $metaInfo Note: When $plainMetaInfo falls back to this, HTML is automatically escaped in the HTML email
 	 * @param string $icon Absolute path, must be 16*16 pixels
 	 * @param string $plainText Text that is used in the plain text email
 	 *   if empty the $text is used, if false none will be used
@@ -457,14 +458,16 @@ EOF;
 
 		if ($plainText === '') {
 			$plainText = $text;
+			$text = htmlspecialchars($text);
 		}
 		if ($plainMetaInfo === '') {
 			$plainMetaInfo = $metaInfo;
+			$metaInfo = htmlspecialchars($metaInfo);
 		}
 
-		$htmlText = htmlspecialchars($text);
+		$htmlText = $text;
 		if ($metaInfo) {
-			$htmlText = '<em style="color:#777;">' . htmlspecialchars($metaInfo) . '</em><br>' . $htmlText;
+			$htmlText = '<em style="color:#777;">' . $metaInfo . '</em><br>' . $htmlText;
 		}
 		if ($icon !== '') {
 			$icon = '<img src="' . htmlspecialchars($icon) . '" alt="&bull;">';
@@ -503,9 +506,9 @@ EOF;
 	/**
 	 * Adds a button group of two buttons to the body of the email
 	 *
-	 * @param string $textLeft Text of left button
+	 * @param string $textLeft Text of left button; Note: When $plainTextLeft falls back to this, HTML is automatically escaped in the HTML email
 	 * @param string $urlLeft URL of left button
-	 * @param string $textRight Text of right button
+	 * @param string $textRight Text of right button; Note: When $plainTextRight falls back to this, HTML is automatically escaped in the HTML email
 	 * @param string $urlRight URL of right button
 	 * @param string $plainTextLeft Text of left button that is used in the plain text version - if unset the $textLeft is used
 	 * @param string $plainTextRight Text of right button that is used in the plain text version - if unset the $textRight is used
@@ -521,10 +524,12 @@ EOF;
 		}
 		if ($plainTextLeft === '') {
 			$plainTextLeft = $textLeft;
+			$textLeft = htmlspecialchars($textLeft);
 		}
 
 		if ($plainTextRight === '') {
 			$plainTextRight = $textRight;
+			$textRight = htmlspecialchars($textRight);
 		}
 
 		$this->ensureBodyIsOpened();
@@ -533,7 +538,7 @@ EOF;
 		$color = $this->themingDefaults->getColorPrimary();
 		$textColor = $this->themingDefaults->getTextColorPrimary();
 
-		$this->htmlBody .= vsprintf($this->buttonGroup, [$color, $color, $urlLeft, $color, $textColor, $textColor, htmlspecialchars($textLeft), $urlRight, htmlspecialchars($textRight)]);
+		$this->htmlBody .= vsprintf($this->buttonGroup, [$color, $color, $urlLeft, $color, $textColor, $textColor, $textLeft, $urlRight, $textRight]);
 		$this->plainBody .= $plainTextLeft . ': ' . $urlLeft . PHP_EOL;
 		$this->plainBody .= $plainTextRight . ': ' . $urlRight . PHP_EOL . PHP_EOL;
 
@@ -542,7 +547,7 @@ EOF;
 	/**
 	 * Adds a button to the body of the email
 	 *
-	 * @param string $text Text of button
+	 * @param string $text Text of button; Note: When $plainText falls back to this, HTML is automatically escaped in the HTML email
 	 * @param string $url URL of button
 	 * @param string $plainText Text of button in plain text version
 	 * 		if empty the $text is used, if false none will be used
@@ -559,11 +564,12 @@ EOF;
 
 		if ($plainText === '') {
 			$plainText = $text;
+			$text = htmlspecialchars($text);
 		}
 
 		$color = $this->themingDefaults->getColorPrimary();
 		$textColor = $this->themingDefaults->getTextColorPrimary();
-		$this->htmlBody .= vsprintf($this->button, [$color, $color, $url, $color, $textColor, $textColor, htmlspecialchars($text)]);
+		$this->htmlBody .= vsprintf($this->button, [$color, $color, $url, $color, $textColor, $textColor, $text]);
 
 		if ($plainText !== false) {
 			$this->plainBody .= $plainText . ': ';

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -735,7 +735,7 @@ class Manager implements IManager {
 		$text = $l->t('%s shared »%s« with you.', [$initiatorDisplayName, $filename]);
 
 		$emailTemplate->addBodyText(
-			$text . ' ' . $l->t('Click the button below to open it.'),
+			htmlspecialchars($text . ' ' . $l->t('Click the button below to open it.')),
 			$text
 		);
 		$emailTemplate->addBodyButton(

--- a/lib/public/Mail/IEMailTemplate.php
+++ b/lib/public/Mail/IEMailTemplate.php
@@ -85,7 +85,7 @@ interface IEMailTemplate {
 	/**
 	 * Adds a paragraph to the body of the email
 	 *
-	 * @param string $text
+	 * @param string $text; Note: When $plainText falls back to this, HTML is automatically escaped in the HTML email
 	 * @param string|bool $plainText Text that is used in the plain text email
 	 *   if empty the $text is used, if false none will be used
 	 *
@@ -96,8 +96,8 @@ interface IEMailTemplate {
 	/**
 	 * Adds a list item to the body of the email
 	 *
-	 * @param string $text
-	 * @param string $metaInfo
+	 * @param string $text; Note: When $plainText falls back to this, HTML is automatically escaped in the HTML email
+	 * @param string $metaInfo; Note: When $plainMetaInfo falls back to this, HTML is automatically escaped in the HTML email
 	 * @param string $icon Absolute path, must be 16*16 pixels
 	 * @param string $plainText Text that is used in the plain text email
 	 *   if empty the $text is used, if false none will be used
@@ -110,9 +110,9 @@ interface IEMailTemplate {
 	/**
 	 * Adds a button group of two buttons to the body of the email
 	 *
-	 * @param string $textLeft Text of left button
+	 * @param string $textLeft Text of left button; Note: When $plainTextLeft falls back to this, HTML is automatically escaped in the HTML email
 	 * @param string $urlLeft URL of left button
-	 * @param string $textRight Text of right button
+	 * @param string $textRight Text of right button; Note: When $plainTextRight falls back to this, HTML is automatically escaped in the HTML email
 	 * @param string $urlRight URL of right button
 	 * @param string $plainTextLeft Text of left button that is used in the plain text version - if empty the $textLeft is used
 	 * @param string $plainTextRight Text of right button that is used in the plain text version - if empty the $textRight is used
@@ -124,7 +124,7 @@ interface IEMailTemplate {
 	/**
 	 * Adds a button to the body of the email
 	 *
-	 * @param string $text Text of button
+	 * @param string $text Text of button; Note: When $plainText falls back to this, HTML is automatically escaped in the HTML email
 	 * @param string $url URL of button
 	 * @param string $plainText Text of button in plain text version
 	 * 		if empty the $text is used, if false none will be used


### PR DESCRIPTION
We need to allow custom HTML, so e.g. the activity app can link file names to the file in the web view.
Currently that is not possible because all HTML is escaped.

The question is if we want to do it the simple way like this, or if we want to add a flag/new method that does not automatically-escape the input.