### PR TITLE
[stable13] Send a proper response for status.php on trusted domain error

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -779,8 +779,16 @@ class OC {
 				$isScssRequest = true;
 			}
 
+			if(substr($request->getRequestUri(), -11) === '/status.php') {
+				OC_Response::setStatus(\OC_Response::STATUS_BAD_REQUEST);
+				header('Status: 400 Bad Request');
+				header('Content-Type: application/json');
+				echo '{"error": "Trusted domain error.", "code": 15}';
+				exit();
+			}
+
 			if (!$isScssRequest) {
-				header('HTTP/1.1 400 Bad Request');
+				OC_Response::setStatus(\OC_Response::STATUS_BAD_REQUEST);
 				header('Status: 400 Bad Request');
 
 				\OC::$server->getLogger()->warning(


### PR DESCRIPTION
* fixes #7732
* backport of #7991 

I would like to get this in 13. Usually it happens anyways only during installation time and thus backporting to stable12 makes not much sense in my opinion.


@rullzer @nickvergessen Are you fine with 13.0.0 or should it go into 13.0.1?