### PR TITLE
Fix missing clipboard icon in shared links

### DIFF
--- a/apps/files_sharing/css/sharetabview.scss
+++ b/apps/files_sharing/css/sharetabview.scss
@@ -14,6 +14,7 @@
 }
 
 .shareTabView .shareWithRemoteInfo,
+.shareTabView .clipboardButton,
 .shareTabView .linkPass .icon-loading-small {
 	position: absolute;
 	right: -7px;
@@ -37,6 +38,7 @@
 	position: relative;
 	top: initial;
 	right: initial;
+	padding: 0;
 }
 
 .shareTabView label {


### PR DESCRIPTION
This pull request fixes [a regression](https://github.com/nextcloud/server/issues/7990) introduced in #7476 when fixing a regression introduced in #7064 (_Inception_ is a great movie, by the way :-P ).

In #7064 [a padding of 0 was removed from menu items](https://github.com/nextcloud/server/pull/7064/commits/c152f80b93ff6d1443ca375197112cb496e77bdc#diff-bf0066932907b556b49ffe55b209a501L860); as the padding of the _Copy_ menu item was no longer forced to 0 it ended with a large padding.

This was fixed in #7476 by removing all the padding from the clipboard icon, but as [the padding (and other CSS rules) were removed also when the clipboard icon was not in the menu](https://github.com/nextcloud/server/pull/7476/files#diff-beb0f4dcc04979e80858de2c3efcc54eL17) it was no longer properly shown in the link input field.

This pull request restores the CSS rules when the clipboard icon is shown in the link input field and also forces the padding to 0 when it is in the menu, which causes the icon to be shown as expected in both cases (and I hope that I have not inadvertently introduced yet another regression :-P ).

@nextcloud/designers 
