### PR TITLE
Use S3Client::upload instead of splitting single/multipart upload ourselves

### DIFF
--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -75,51 +75,10 @@ trait S3ObjectTrait {
 	 * @since 7.0.0
 	 */
 	function writeObject($urn, $stream) {
-		$stat = fstat($stream);
-
-		if ($stat['size'] && $stat['size'] < S3_UPLOAD_PART_SIZE) {
-			$this->singlePartUpload($urn, $stream);
-		} else {
-			$this->multiPartUpload($urn, $stream);
-		}
-
-	}
-
-	protected function singlePartUpload($urn, $stream) {
-		$this->getConnection()->putObject([
-			'Bucket' => $this->bucket,
-			'Key' => $urn,
-			'Body' => $stream
-		]);
-	}
-
-	protected function multiPartUpload($urn, $stream) {
-		$uploader = new MultipartUploader($this->getConnection(), $stream, [
-			'bucket' => $this->bucket,
-			'key' => $urn,
+		$this->getConnection()->upload($this->bucket, $urn, $stream, 'private', [
+			'mup_threshold' => S3_UPLOAD_PART_SIZE,
 			'part_size' => S3_UPLOAD_PART_SIZE
 		]);
-
-		$tries = 0;
-
-		do {
-			try {
-				$result = $uploader->upload();
-			} catch (MultipartUploadException $e) {
-				\OC::$server->getLogger()->logException($e);
-				rewind($stream);
-				$tries++;
-
-				if ($tries < 5) {
-					$uploader = new MultipartUploader($this->getConnection(), $stream, [
-						'state' => $e->getState()
-					]);
-				} else {
-					$this->getConnection()->abortMultipartUpload($e->getState()->getId());
-					throw $e;
-				}
-			}
-		} while (!isset($result) && $tries < 5);
 	}
 
 	/**


### PR DESCRIPTION
It seems to do mostly the same checks but a bit more reliable.

Possible fix for https://github.com/nextcloud/server/issues/7585