### PR TITLE
[stable13] Fix missing clipboard icon in shared links

### DIFF
--- a/apps/files_sharing/css/sharetabview.scss
+++ b/apps/files_sharing/css/sharetabview.scss
@@ -14,6 +14,7 @@
 }
 
 .shareTabView .shareWithRemoteInfo,
+.shareTabView .clipboardButton,
 .shareTabView .linkPass .icon-loading-small {
 	position: absolute;
 	right: -7px;
@@ -37,6 +38,7 @@
 	position: relative;
 	top: initial;
 	right: initial;
+	padding: 0;
 }
 
 .shareTabView label {


### PR DESCRIPTION
The clipboard icon in shared links appears either directly on the link
input field or, if any social sharing app is enabled, in a menu. The
clipboard icon uses the same CSS rules as other icons (like the
information icon) to be posioned on the end of the input field, and
those rules have to be "cancelled" when the icon is shown in the menu.

Fixes #7990

Backport of #8032 