### PR TITLE
Require PHPUnit 6.5 or higher 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,14 +15,14 @@ pipeline:
       matrix:
         TESTS: jsunit
   checkers:
-    image: nextcloudci/php7.0:php7.0-16
+    image: nextcloudci/php7.0:php7.0-19
     commands:
       - ./autotest-checkers.sh
     when:
       matrix:
         TESTS: checkers
   syntax-php7.0:
-    image: nextcloudci/php7.0:php7.0-16
+    image: nextcloudci/php7.0:php7.0-19
     commands:
       - composer install
       - ./lib/composer/bin/parallel-lint --exclude lib/composer/jakub-onderka/ --exclude 3rdparty/symfony/polyfill-php70/Resources/stubs/ --exclude 3rdparty/patchwork/utf8/src/Patchwork/Utf8/Bootup/ --exclude 3rdparty/paragonie/random_compat/lib/ --exclude lib/composer/composer/autoload_static.php --exclude 3rdparty/composer/autoload_static.php .
@@ -30,7 +30,7 @@ pipeline:
       matrix:
         TESTS: syntax-php7.0
   syntax-php7.1:
-    image: nextcloudci/php7.1:php7.1-15
+    image: nextcloudci/php7.1:php7.1-16
     commands:
       - composer install
       - ./lib/composer/bin/parallel-lint --exclude lib/composer/jakub-onderka/ --exclude 3rdparty/symfony/polyfill-php70/Resources/stubs/ --exclude 3rdparty/patchwork/utf8/src/Patchwork/Utf8/Bootup/ --exclude 3rdparty/paragonie/random_compat/lib/ --exclude lib/composer/composer/autoload_static.php --exclude 3rdparty/composer/autoload_static.php .
@@ -38,7 +38,7 @@ pipeline:
       matrix:
         TESTS: syntax-php7.1
   phan:
-    image: nextcloudci/php7.1:php7.1-15
+    image: nextcloudci/php7.1:php7.1-16
     commands:
       - composer install
       - composer require --dev "phan/phan:dev-master"
@@ -139,7 +139,7 @@ pipeline:
       matrix:
         TESTS: sqlite-php7.0-webdav-apache
   nodb-php7.0:
-    image: nextcloudci/php7.0:php7.0-16
+    image: nextcloudci/php7.0:php7.0-19
     commands:
       - NOCOVERAGE=true TEST_SELECTION=NODB ./autotest.sh sqlite
     when:
@@ -147,7 +147,7 @@ pipeline:
         DB: NODB
         PHP: "7.0"
   nodb-php7.1:
-    image: nextcloudci/php7.1:php7.1-15
+    image: nextcloudci/php7.1:php7.1-16
     commands:
       - NOCOVERAGE=true TEST_SELECTION=NODB ./autotest.sh sqlite
     when:
@@ -155,7 +155,7 @@ pipeline:
         DB: NODB
         PHP: 7.1
   nodb-php7.2:
-    image: nextcloudci/php7.2:php7.2-9
+    image: nextcloudci/php7.2:php7.2-10
     commands:
       - NOCOVERAGE=true TEST_SELECTION=NODB ./autotest.sh sqlite
     when:
@@ -163,7 +163,7 @@ pipeline:
         DB: NODB
         PHP: 7.2
   sqlite-php7.0:
-    image: nextcloudci/php7.0:php7.0-16
+    image: nextcloudci/php7.0:php7.0-19
     commands:
       - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh sqlite
     when:
@@ -171,7 +171,7 @@ pipeline:
         DB: sqlite
         PHP: "7.0"
   sqlite-php7.1:
-    image: nextcloudci/php7.1:php7.1-15
+    image: nextcloudci/php7.1:php7.1-16
     commands:
       - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh sqlite
     when:
@@ -179,7 +179,7 @@ pipeline:
         DB: sqlite
         PHP: 7.1
   sqlite-php7.2:
-    image: nextcloudci/php7.2:php7.2-9
+    image: nextcloudci/php7.2:php7.2-10
     commands:
       - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh sqlite
     when:
@@ -187,7 +187,7 @@ pipeline:
         DB: sqlite
         PHP: 7.2
   mysql-php7.0:
-    image: nextcloudci/php7.0:php7.0-16
+    image: nextcloudci/php7.0:php7.0-19
     commands:
       - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh mysql
     when:
@@ -195,7 +195,7 @@ pipeline:
         DB: mysql
         PHP: "7.0"
   mysql-php7.1:
-    image: nextcloudci/php7.1:php7.1-15
+    image: nextcloudci/php7.1:php7.1-16
     commands:
       - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh mysql
     when:
@@ -203,7 +203,7 @@ pipeline:
         DB: mysql
         PHP: 7.1
   mysql-php7.2:
-    image: nextcloudci/php7.2:php7.2-9
+    image: nextcloudci/php7.2:php7.2-10
     commands:
       - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh mysql
     when:
@@ -211,7 +211,7 @@ pipeline:
         DB: mysql
         PHP: 7.2
   mysql5.6-php7.0:
-    image: nextcloudci/php7.0:php7.0-16
+    image: nextcloudci/php7.0:php7.0-19
     commands:
       - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh mysql
     when:
@@ -219,7 +219,7 @@ pipeline:
         DB: mysql5.6
         PHP: "7.0"
   mysql5.6-php7.1:
-    image: nextcloudci/php7.1:php7.1-15
+    image: nextcloudci/php7.1:php7.1-16
     commands:
       - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh mysql
     when:
@@ -227,7 +227,7 @@ pipeline:
         DB: mysql5.6
         PHP: 7.1
   mysql5.5-php7.0:
-    image: nextcloudci/php7.0:php7.0-16
+    image: nextcloudci/php7.0:php7.0-19
     commands:
       - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh mysql
     when:
@@ -235,7 +235,7 @@ pipeline:
         DB: mysql5.5
         PHP: "7.0"
   mysql5.5-php7.1:
-    image: nextcloudci/php7.1:php7.1-15
+    image: nextcloudci/php7.1:php7.1-16
     commands:
       - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh mysql
     when:
@@ -243,7 +243,7 @@ pipeline:
         DB: mysql5.5
         PHP: 7.1
   postgres-php7.0:
-    image: nextcloudci/php7.0:php7.0-16
+    image: nextcloudci/php7.0:php7.0-19
     commands:
       - sleep 10 # gives the database enough time to initialize
       - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh pgsql
@@ -252,7 +252,7 @@ pipeline:
         DB: postgres
         PHP: "7.0"
   postgres-php7.1:
-    image: nextcloudci/php7.1:php7.1-15
+    image: nextcloudci/php7.1:php7.1-16
     commands:
       - sleep 10 # gives the database enough time to initialize
       - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh pgsql
@@ -261,7 +261,7 @@ pipeline:
         DB: postgres
         PHP: 7.1
   mysqlmb4-php7.0:
-    image: nextcloudci/php7.0:php7.0-16
+    image: nextcloudci/php7.0:php7.0-19
     commands:
       - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh mysqlmb4
     when:
@@ -269,7 +269,7 @@ pipeline:
         DB: mysqlmb4
         PHP: "7.0"
   mysqlmb4-php7.1:
-    image: nextcloudci/php7.1:php7.1-15
+    image: nextcloudci/php7.1:php7.1-16
     commands:
       - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh mysqlmb4
     when:
@@ -277,7 +277,7 @@ pipeline:
         DB: mysqlmb4
         PHP: 7.1
   mysqlmb4-php7.2:
-    image: nextcloudci/php7.2:php7.2-9
+    image: nextcloudci/php7.2:php7.2-10
     commands:
       - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh mysqlmb4
     when:
@@ -571,7 +571,7 @@ pipeline:
         matrix:
           TESTS-ACCEPTANCE: login
   nodb-codecov:
-    image: nextcloudci/php7.0:php7.0-16
+    image: nextcloudci/php7.0:php7.0-19
     commands:
       - phpenmod xdebug
       - TEST_SELECTION=NODB ./autotest.sh sqlite
@@ -582,7 +582,7 @@ pipeline:
       matrix:
         TESTS: nodb-codecov
   db-codecov:
-    image: nextcloudci/php7.0:php7.0-16
+    image: nextcloudci/php7.0:php7.0-19
     commands:
       - phpenmod xdebug
       - TEST_SELECTION=QUICKDB ./autotest.sh sqlite
@@ -593,7 +593,7 @@ pipeline:
       matrix:
         TESTS: db-codecov
   object-store:
-      image: nextcloudci/php7.0:php7.0-16
+      image: nextcloudci/php7.0:php7.0-19
       commands:
         - phpenmod xdebug
         - TEST_SELECTION=PRIMARY-${OBJECT_STORE} ./autotest.sh sqlite
@@ -616,7 +616,7 @@ pipeline:
       matrix:
         TEST: memcache-memcached
   memcache-redis-cluster:
-    image: nextcloudci/php7.0:php7.0-17
+    image: nextcloudci/php7.0:php7.0-19
     commands:
       - phpenmod xdebug
       - sleep 20

--- a/.drone.yml
+++ b/.drone.yml
@@ -604,7 +604,7 @@ pipeline:
         matrix:
           TESTS: object-store
   memcache-memcached:
-    image: nextcloudci/php7.0-memcached:php7.0-memcached-8
+    image: nextcloudci/php7.0-memcached:php7.0-memcached-9
     commands:
       - phpenmod xdebug
       - service memcached restart

--- a/apps/dav/tests/unit/AppInfo/ApplicationTest.php
+++ b/apps/dav/tests/unit/AppInfo/ApplicationTest.php
@@ -61,6 +61,6 @@ class ApplicationTest extends TestCase {
 		/** @var IManager|\PHPUnit_Framework_MockObject_MockObject $cm */
 		$cm = $this->createMock(IManager::class);
 		$app->setupContactsProvider($cm, 'xxx');
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 }

--- a/apps/dav/tests/unit/AppInfo/PluginManagerTest.php
+++ b/apps/dav/tests/unit/AppInfo/PluginManagerTest.php
@@ -22,8 +22,8 @@
 
 namespace OCA\DAV\Tests\unit\AppInfo;
 
+use OC\App\AppManager;
 use Test\TestCase;
-use OCP\App\IAppManager;
 use OC\ServerContainer;
 use OCA\DAV\AppInfo\PluginManager;
 
@@ -37,7 +37,7 @@ class PluginManagerTest extends TestCase {
 		$server = $this->createMock(ServerContainer::class);
 
 
-		$appManager = $this->createMock(IAppManager::class);
+		$appManager = $this->createMock(AppManager::class);
 		$appManager->method('getInstalledApps')
 			->willReturn(['adavapp', 'adavapp2']);
 

--- a/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
+++ b/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
@@ -176,7 +176,7 @@ EOD;
 	protected function assertAcl($principal, $privilege, $acl) {
 		foreach($acl as $a) {
 			if ($a['principal'] === $principal && $a['privilege'] === $privilege) {
-				$this->assertTrue(true);
+				$this->addToAssertionCount(1);
 				return;
 			}
 		}
@@ -190,7 +190,7 @@ EOD;
 				return;
 			}
 		}
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	protected function assertAccess($shouldHaveAcl, $principal, $privilege, $acl) {

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -36,6 +36,7 @@ use OCP\IL10N;
 use Sabre\DAV\PropPatch;
 use Sabre\DAV\Xml\Property\Href;
 use Sabre\DAVACL\IACL;
+use Sabre\DAV\Exception\NotFound;
 
 /**
  * Class CalDavBackendTest
@@ -526,7 +527,7 @@ EOD;
 		$calendar->setPublishStatus(false);
 		$this->assertEquals(false, $calendar->getPublishStatus());
 
-		$this->setExpectedException('Sabre\DAV\Exception\NotFound');
+		$this->expectException(NotFound::class);
 		$this->backend->getPublicCalendar($publicCalendarURI);
 	}
 

--- a/apps/dav/tests/unit/CalDAV/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarTest.php
@@ -183,7 +183,7 @@ class CalendarTest extends TestCase {
 				->with(666, $propPatch);
 		}
 		$c->propPatch($propPatch);
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	/**

--- a/apps/dav/tests/unit/CalDAV/Publishing/PublisherTest.php
+++ b/apps/dav/tests/unit/CalDAV/Publishing/PublisherTest.php
@@ -25,8 +25,9 @@ namespace OCA\DAV\Tests\unit\CalDAV\Publishing;
 
 use OCA\DAV\CalDAV\Publishing\Xml\Publisher;
 use Sabre\Xml\Writer;
+use Test\TestCase;
 
-class PublisherTest extends \PHPUnit_Framework_TestCase {
+class PublisherTest extends TestCase {
 
 	const NS_CALENDARSERVER = 'http://calendarserver.org/ns/';
 

--- a/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
@@ -174,7 +174,7 @@ class CustomPropertiesBackendTest extends \Test\TestCase {
 		);
 
 		// no exception, soft fail
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	/**

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -345,7 +345,7 @@ class DirectoryTest extends \Test\TestCase {
 	 */
 	public function testMoveSuccess($source, $destination, $updatables, $deletables) {
 		$this->moveTest($source, $destination, $updatables, $deletables);
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	/**

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -29,6 +29,7 @@
 namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
 use OC\User\User;
+use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\File;
 use OCA\DAV\Connector\Sabre\FilesPlugin;
 use OCA\DAV\Connector\Sabre\Node;
@@ -319,7 +320,7 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testGetPropertiesForRootDirectory() {
-		/** @var \OCA\DAV\Connector\Sabre\Directory | \PHPUnit_Framework_MockObject_MockObject $node */
+		/** @var \OCA\DAV\Connector\Sabre\Directory|\PHPUnit_Framework_MockObject_MockObject $node */
 		$node = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -383,6 +383,8 @@ class FilesPluginTest extends TestCase {
 			$propFind,
 			$node
 		);
+
+		$this->addToAssertionCount(1);
 	}
 
 	public function testUpdateProps() {

--- a/apps/dav/tests/unit/SystemTag/SystemTagNodeTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagNodeTest.php
@@ -251,7 +251,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 			->method('deleteTags')
 			->with('1');
 		if (!$isAdmin) {
-			$this->setExpectedException(Forbidden::class);
+			$this->expectException(Forbidden::class);
 		}
 		$this->getTagNode($isAdmin, $tag)->delete();
 	}
@@ -282,7 +282,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 		$this->tagManager->expects($this->never())
 			->method('deleteTags');
 
-		$this->setExpectedException($expectedException);
+		$this->expectException($expectedException);
 		$this->getTagNode(false, $tag)->delete();
 	}
 

--- a/apps/dav/tests/unit/bootstrap.php
+++ b/apps/dav/tests/unit/bootstrap.php
@@ -26,10 +26,6 @@ if (!defined('PHPUNIT_RUN')) {
 
 require_once __DIR__.'/../../../../lib/base.php';
 
-if(!class_exists('PHPUnit_Framework_TestCase')) {
-	require_once('PHPUnit/Autoload.php');
-}
-
 \OC::$composerAutoloader->addPsr4('Test\\', OC::$SERVERROOT . '/tests/lib/', true);
 
 \OC_App::loadApp('dav');

--- a/apps/encryption/tests/Crypto/EncryptAllTest.php
+++ b/apps/encryption/tests/Crypto/EncryptAllTest.php
@@ -335,8 +335,10 @@ class EncryptAllTest extends TestCase {
 		$encryptAll->expects($this->at(1))->method('encryptFile')->with('/user1/files/bar');
 		$encryptAll->expects($this->at(2))->method('encryptFile')->with('/user1/files/foo/subfile');
 
-		$progressBar = $this->getMockBuilder(ProgressBar::class)
-			->disableOriginalConstructor()->getMock();
+		$this->outputInterface->expects($this->any())
+			->method('getFormatter')
+			->willReturn($this->createMock(OutputFormatterInterface::class));
+		$progressBar = new ProgressBar($this->outputInterface);
 
 		$this->invokePrivate($encryptAll, 'encryptUsersFiles', ['user1', $progressBar, '']);
 

--- a/apps/encryption/tests/Hooks/UserHooksTest.php
+++ b/apps/encryption/tests/Hooks/UserHooksTest.php
@@ -110,7 +110,7 @@ class UserHooksTest extends TestCase {
 		$this->sessionMock->expects($this->once())
 			->method('clear');
 		$this->instance->logout();
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testPostCreateUser() {
@@ -118,7 +118,7 @@ class UserHooksTest extends TestCase {
 			->method('setupUser');
 
 		$this->instance->postCreateUser($this->params);
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testPostDeleteUser() {
@@ -127,7 +127,7 @@ class UserHooksTest extends TestCase {
 			->with('testUser');
 
 		$this->instance->postDeleteUser($this->params);
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testPrePasswordReset() {

--- a/apps/encryption/tests/RecoveryTest.php
+++ b/apps/encryption/tests/RecoveryTest.php
@@ -213,7 +213,7 @@ class RecoveryTest extends TestCase {
 		$this->cryptMock->expects($this->once())
 			->method('decryptPrivateKey');
 		$this->instance->recoverUsersFiles('password', 'admin');
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testRecoverFile() {

--- a/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
@@ -304,66 +304,66 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 
 	public function testGetStoragesBackendNotVisible() {
 		// we don't test this here
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testGetStoragesAuthMechanismNotVisible() {
 		// we don't test this here
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testHooksAddStorage($a = null, $b = null, $c = null) {
 		// we don't test this here
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testHooksUpdateStorage($a = null, $b = null, $c = null, $d = null, $e = null) {
 		// we don't test this here
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testHooksRenameMountPoint() {
 		// we don't test this here
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testHooksDeleteStorage($a = null, $b = null, $c = null) {
 		// we don't test this here
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testLegacyConfigConversionApplicableAll() {
 		// we don't test this here
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testLegacyConfigConversionApplicableUserAndGroup() {
 		// we don't test this here
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testReadLegacyConfigAndGenerateConfigId() {
 		// we don't test this here
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testReadLegacyConfigNoAuthMechanism() {
 		// we don't test this here
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testReadLegacyConfigClass() {
 		// we don't test this here
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testReadEmptyMountPoint() {
 		// we don't test this here
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testUpdateStorageMountPoint() {
 		// we don't test this here
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 }

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -236,7 +236,7 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 	}
 
-	function testEnfoceLinkPassword() {
+	function testEnforceLinkPassword() {
 
 		$password = md5(time());
 		$config = \OC::$server->getConfig();
@@ -288,6 +288,7 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 
 		$config->setAppValue('core', 'shareapi_enforce_links_password', 'no');
+		$this->addToAssertionCount(1);
 	}
 
 	/**
@@ -336,6 +337,8 @@ class ApiTest extends TestCase {
 		// cleanup
 		\OC::$server->getConfig()->setAppValue('core', 'shareapi_exclude_groups', 'no');
 		\OC::$server->getConfig()->setAppValue('core', 'shareapi_exclude_groups_list', '');
+
+		$this->addToAssertionCount(1);
 	}
 
 
@@ -1102,6 +1105,7 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 
 		$this->shareManager->deleteShare($share1);
+		$this->addToAssertionCount(1);
 	}
 
 	/**

--- a/apps/files_sharing/tests/External/ScannerTest.php
+++ b/apps/files_sharing/tests/External/ScannerTest.php
@@ -58,7 +58,7 @@ class ScannerTest extends TestCase {
 		// Declaration of OCA\Files_Sharing\External\Scanner::*() should be
 		// compatible with OC\Files\Cache\Scanner::*()
 		$this->scanner->scanAll();
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testScan() {
@@ -70,7 +70,7 @@ class ScannerTest extends TestCase {
 		// Declaration of OCA\Files_Sharing\External\Scanner::*() should be
 		// compatible with OC\Files\Cache\Scanner::*()
 		$this->scanner->scan('test', Scanner::SCAN_RECURSIVE);
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testScanFile() {
@@ -78,6 +78,6 @@ class ScannerTest extends TestCase {
 		// Declaration of OCA\Files_Sharing\External\Scanner::*() should be
 		// compatible with OC\Files\Cache\Scanner::*()
 		$this->scanner->scanFile('test', Scanner::SCAN_RECURSIVE);
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 }

--- a/apps/files_sharing/tests/LockingTest.php
+++ b/apps/files_sharing/tests/LockingTest.php
@@ -111,6 +111,6 @@ class LockingTest extends TestCase {
 		$recipientView->changeLock('bar.txt', ILockingProvider::LOCK_EXCLUSIVE);
 		$recipientView->unlockFile('bar.txt', ILockingProvider::LOCK_EXCLUSIVE);
 
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 }

--- a/apps/files_sharing/tests/Middleware/OCSShareAPIMiddlewareTest.php
+++ b/apps/files_sharing/tests/Middleware/OCSShareAPIMiddlewareTest.php
@@ -136,5 +136,6 @@ class OCSShareAPIMiddlewareTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$this->middleware->afterController($controller, 'foo', $response);
+		$this->addToAssertionCount(1);
 	}
 }

--- a/apps/files_trashbin/tests/BackgroundJob/ExpireTrashTest.php
+++ b/apps/files_trashbin/tests/BackgroundJob/ExpireTrashTest.php
@@ -39,6 +39,6 @@ class ExpireTrashTest extends \Test\TestCase {
 
 		/** @var \OC\BackgroundJob\JobList $jobList */
 		$backgroundJob->execute($jobList);
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 }

--- a/apps/files_trashbin/tests/Command/ExpireTest.php
+++ b/apps/files_trashbin/tests/Command/ExpireTest.php
@@ -39,6 +39,6 @@ class ExpireTest extends TestCase {
 		$command = new Expire('test');
 		$command->handle();
 
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 }

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -593,6 +593,7 @@ class StorageTest extends \Test\TestCase {
 			$this->markTestSkipped('Skipping since the current home storage backend requires the user to logged in');
 		} else {
 			$this->userView->unlink('test.txt');
+			$this->addToAssertionCount(1);
 		}
 	}
 }

--- a/apps/files_versions/tests/Command/ExpireTest.php
+++ b/apps/files_versions/tests/Command/ExpireTest.php
@@ -39,6 +39,6 @@ class ExpireTest extends TestCase {
 		$command = new Expire($this->getUniqueID('test'), '');
 		$command->handle();
 
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 }

--- a/apps/provisioning_api/tests/Controller/AppConfigControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/AppConfigControllerTest.php
@@ -318,7 +318,7 @@ class AppConfigControllerTest extends TestCase {
 	public function testVerifyAppId() {
 		$api = $this->getInstance();
 		$this->invokePrivate($api, 'verifyAppId', ['activity']);
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function dataVerifyAppIdThrows() {
@@ -356,7 +356,7 @@ class AppConfigControllerTest extends TestCase {
 	public function testVerifyConfigKey($app, $key) {
 		$api = $this->getInstance();
 		$this->invokePrivate($api, 'verifyConfigKey', [$app, $key]);
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function dataVerifyConfigKeyThrows() {

--- a/apps/theming/tests/IconBuilderTest.php
+++ b/apps/theming/tests/IconBuilderTest.php
@@ -34,6 +34,7 @@ use OCP\Files\IAppData;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\IConfig;
+use PHPUnit\Framework\Error\Warning;
 use Test\TestCase;
 
 class IconBuilderTest extends TestCase {
@@ -172,11 +173,9 @@ class IconBuilderTest extends TestCase {
 		// cloud be something like $expectedIcon->compareImages($icon, Imagick::METRIC_MEANABSOLUTEERROR)[1])
 	}
 
-	/**
-	 * @expectedException \PHPUnit_Framework_Error_Warning
-	 */
 	public function testGetFaviconNotFound() {
 		$this->checkImagick();
+		$this->expectException(Warning::class);
 		$util = $this->getMockBuilder(Util::class)->disableOriginalConstructor()->getMock();
 		$iconBuilder = new IconBuilder($this->themingDefaults, $util);
 		$this->themingDefaults->expects($this->once())
@@ -188,11 +187,9 @@ class IconBuilderTest extends TestCase {
 		$this->assertFalse($iconBuilder->getFavicon('noapp'));
 	}
 
-	/**
-	 * @expectedException \PHPUnit_Framework_Error_Warning
-	 */
 	public function testGetTouchIconNotFound() {
 		$this->checkImagick();
+		$this->expectException(Warning::class);
 		$util = $this->getMockBuilder(Util::class)->disableOriginalConstructor()->getMock();
 		$iconBuilder = new IconBuilder($this->themingDefaults, $util);
 		$util->expects($this->once())
@@ -201,11 +198,9 @@ class IconBuilderTest extends TestCase {
 		$this->assertFalse($iconBuilder->getTouchIcon('noapp'));
 	}
 
-	/**
-	 * @expectedException \PHPUnit_Framework_Error_Warning
-	 */
 	public function testColorSvgNotFound() {
 		$this->checkImagick();
+		$this->expectException(Warning::class);
 		$util = $this->getMockBuilder(Util::class)->disableOriginalConstructor()->getMock();
 		$iconBuilder = new IconBuilder($this->themingDefaults, $util);
 		$util->expects($this->once())

--- a/apps/twofactor_backupcodes/tests/Unit/Activity/ProviderTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Activity/ProviderTest.php
@@ -62,7 +62,7 @@ class ProviderTest extends TestCase {
 		$event->expects($this->once())
 			->method('getApp')
 			->willReturn('comments');
-		$this->setExpectedException(InvalidArgumentException::class);
+		$this->expectException(InvalidArgumentException::class);
 
 		$this->provider->parse($lang, $event);
 	}

--- a/apps/user_ldap/tests/LDAPProviderTest.php
+++ b/apps/user_ldap/tests/LDAPProviderTest.php
@@ -429,7 +429,7 @@ class LDAPProviderTest extends \Test\TestCase {
 			
 		$ldapProvider = $this->getLDAPProvider($server);
 		$ldapProvider->clearCache('existing_user');
-		$this->assertTrue(TRUE);
+		$this->addToAssertionCount(1);
 	}
 
 	/**
@@ -474,7 +474,7 @@ class LDAPProviderTest extends \Test\TestCase {
 
 		$ldapProvider = $this->getLDAPProvider($server);
 		$ldapProvider->clearGroupCache('existing_group');
-		$this->assertTrue(TRUE);
+		$this->addToAssertionCount(1);
 	}
 	
 	public function testDnExists() {
@@ -502,7 +502,7 @@ class LDAPProviderTest extends \Test\TestCase {
 			
 		$ldapProvider = $this->getLDAPProvider($server);
 		$ldapProvider->flagRecord('existing_user');
-		$this->assertTrue(TRUE);
+		$this->addToAssertionCount(1);
 	}
 	
 	public function testUnflagRecord() {
@@ -515,7 +515,7 @@ class LDAPProviderTest extends \Test\TestCase {
 			
 		$ldapProvider = $this->getLDAPProvider($server);
 		$ldapProvider->unflagRecord('existing_user');
-		$this->assertTrue(TRUE);
+		$this->addToAssertionCount(1);
 	}
 
 	/**

--- a/apps/workflowengine/tests/Check/AbstractStringCheckTest.php
+++ b/apps/workflowengine/tests/Check/AbstractStringCheckTest.php
@@ -96,6 +96,8 @@ class AbstractStringCheckTest extends \Test\TestCase {
 
 		/** @var \OCA\WorkflowEngine\Check\AbstractStringCheck $check */
 		$check->validateCheck($operator, $value);
+
+		$this->addToAssertionCount(1);
 	}
 
 	public function dataValidateCheckInvalid() {

--- a/apps/workflowengine/tests/Check/RequestTimeTest.php
+++ b/apps/workflowengine/tests/Check/RequestTimeTest.php
@@ -129,6 +129,7 @@ class RequestTimeTest extends \Test\TestCase {
 	public function testValidateCheck($operator, $value) {
 		$check = new \OCA\WorkflowEngine\Check\RequestTime($this->getL10NMock(), $this->timeFactory);
 		$check->validateCheck($operator, $value);
+		$this->addToAssertionCount(1);
 	}
 
 	public function dataValidateCheckInvalid() {

--- a/autotest.sh
+++ b/autotest.sh
@@ -53,7 +53,7 @@ else
 fi
 
 if ! [ -x "$PHPUNIT" ]; then
-	echo "phpunit executable not found, please install phpunit version >= 4.8" >&2
+	echo "phpunit executable not found, please install phpunit version >= 6.5" >&2
 	exit 3
 fi
 
@@ -68,8 +68,8 @@ PHPUNIT_VERSION=$($PHPUNIT --version | cut -d" " -f2)
 PHPUNIT_MAJOR_VERSION=$(echo "$PHPUNIT_VERSION" | cut -d"." -f1)
 PHPUNIT_MINOR_VERSION=$(echo "$PHPUNIT_VERSION" | cut -d"." -f2)
 
-if ! [ "$PHPUNIT_MAJOR_VERSION" -gt 4 -o \( "$PHPUNIT_MAJOR_VERSION" -eq 4 -a "$PHPUNIT_MINOR_VERSION" -ge 8 \) ]; then
-	echo "phpunit version >= 4.8 required. Version found: $PHPUNIT_VERSION" >&2
+if ! [ "$PHPUNIT_MAJOR_VERSION" -gt 6 -o \( "$PHPUNIT_MAJOR_VERSION" -eq 6 -a "$PHPUNIT_MINOR_VERSION" -ge 5 \) ]; then
+	echo "phpunit version >= 6.5 required. Version found: $PHPUNIT_VERSION" >&2
 	exit 4
 fi
 

--- a/tests/Settings/Activity/SecurityProviderTest.php
+++ b/tests/Settings/Activity/SecurityProviderTest.php
@@ -62,7 +62,7 @@ class SecurityProviderTest extends TestCase {
 		$event->expects($this->once())
 			->method('getType')
 			->willReturn('comments');
-		$this->setExpectedException(InvalidArgumentException::class);
+		$this->expectException(InvalidArgumentException::class);
 
 		$this->provider->parse($lang, $event);
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,10 +14,6 @@ require_once __DIR__ . '/../lib/base.php';
 // load all enabled apps
 \OC_App::loadApps();
 
-if (!class_exists('PHPUnit_Framework_TestCase')) {
-	require_once('PHPUnit/Autoload.php');
-}
-
 OC_Hook::clear();
 
 set_include_path(get_include_path() . PATH_SEPARATOR . '/usr/share/php');

--- a/tests/lib/AppFramework/Db/EntityTest.php
+++ b/tests/lib/AppFramework/Db/EntityTest.php
@@ -46,7 +46,7 @@ class TestEntity extends Entity {
 	protected $preName;
 
 	public function __construct($name=null){
-		$this->addType('testId', 'integer');		
+		$this->addType('testId', 'integer');
 		$this->name = $name;
 	}
 };
@@ -119,23 +119,26 @@ class EntityTest extends \Test\TestCase {
 	}
 
 
+	/**
+	 * @expectedException \BadFunctionCallException
+	 */
 	public function testCallShouldOnlyWorkForGetterSetter(){
-		$this->setExpectedException('\BadFunctionCallException');
-
 		$this->entity->something();
 	}
 
 
+	/**
+	 * @expectedException \BadFunctionCallException
+	 */
 	public function testGetterShouldFailIfAttributeNotDefined(){
-		$this->setExpectedException('\BadFunctionCallException');
-
 		$this->entity->getTest();
 	}
 
+	/**
+	 * @expectedException \BadFunctionCallException
+	 */
 
 	public function testSetterShouldFailIfAttributeNotDefined(){
-		$this->setExpectedException('\BadFunctionCallException');
-
 		$this->entity->setTest();
 	}
 

--- a/tests/lib/AppFramework/Db/MapperTest.php
+++ b/tests/lib/AppFramework/Db/MapperTest.php
@@ -24,6 +24,8 @@
 
 namespace Test\AppFramework\Db;
 
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use \OCP\IDBConnection;
 use \OCP\AppFramework\Db\Entity;
 use \OCP\AppFramework\Db\Mapper;
@@ -95,8 +97,7 @@ class MapperTest extends MapperTestUtility {
 		$params = array('jo');
 		$rows = array();
 		$this->setMapperResult($sql, $params, $rows);
-		$this->setExpectedException(
-			'\OCP\AppFramework\Db\DoesNotExistException');
+		$this->expectException(DoesNotExistException::class);
 		$this->mapper->find($sql, $params);
 	}
 
@@ -105,8 +106,7 @@ class MapperTest extends MapperTestUtility {
 		$params = array('jo');
 		$rows = array();
 		$this->setMapperResult($sql, $params, $rows, null, null, true);
-		$this->setExpectedException(
-			'\OCP\AppFramework\Db\DoesNotExistException');
+		$this->expectException(DoesNotExistException::class);
 		$this->mapper->findOneEntity($sql, $params);
 	}
 
@@ -117,8 +117,7 @@ class MapperTest extends MapperTestUtility {
 			array('jo'), array('ho')
 		);
 		$this->setMapperResult($sql, $params, $rows, null, null, true);
-		$this->setExpectedException(
-			'\OCP\AppFramework\Db\MultipleObjectsReturnedException');
+		$this->expectException(MultipleObjectsReturnedException::class);
 		$this->mapper->find($sql, $params);
 	}
 
@@ -129,8 +128,7 @@ class MapperTest extends MapperTestUtility {
 			array('jo'), array('ho')
 		);
 		$this->setMapperResult($sql, $params, $rows, null, null, true);
-		$this->setExpectedException(
-			'\OCP\AppFramework\Db\MultipleObjectsReturnedException');
+		$this->expectException(MultipleObjectsReturnedException::class);
 		$this->mapper->findOneEntity($sql, $params);
 	}
 
@@ -223,7 +221,7 @@ class MapperTest extends MapperTestUtility {
 		$entity->setPreName($params[0]);
 		$entity->setEmail($params[1]);
 
-		$this->setExpectedException('InvalidArgumentException');
+		$this->expectException(\InvalidArgumentException::class);
 
 		$this->mapper->update($entity);
 	}

--- a/tests/lib/AppFramework/Http/DispatcherTest.php
+++ b/tests/lib/AppFramework/Http/DispatcherTest.php
@@ -267,7 +267,7 @@ class DispatcherTest extends \Test\TestCase {
 		$responseHeaders = array('hell' => 'yeah');
 		$this->setMiddlewareExpectations($out, $httpHeaders, $responseHeaders, true, false);
 
-		$this->setExpectedException('\Exception');
+		$this->expectException(\Exception::class);
 		$response = $this->dispatcher->dispatch($this->controller,
 			$this->controllerMethod);
 

--- a/tests/lib/AppFramework/Middleware/MiddlewareDispatcherTest.php
+++ b/tests/lib/AppFramework/Middleware/MiddlewareDispatcherTest.php
@@ -177,7 +177,7 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 		$this->dispatcher->registerMiddleware($m1);
 		$this->dispatcher->registerMiddleware($m2);
 
-		$this->setExpectedException('\Exception');
+		$this->expectException(\Exception::class);
 		$this->dispatcher->beforeController($this->controller, $this->method);
 		$this->dispatcher->afterException($this->controller, $this->method, $this->exception);
 	}
@@ -206,7 +206,7 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 	public function testAfterExceptionCorrectArguments(){
 		$m1 = $this->getMiddleware();
 
-		$this->setExpectedException('\Exception');
+		$this->expectException(\Exception::class);
 
 		$this->dispatcher->beforeController($this->controller, $this->method);
 		$this->dispatcher->afterException($this->controller, $this->method, $this->exception);
@@ -253,7 +253,7 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 		$m1 = $this->getMiddleware();
 		$m2 = $this->getMiddleware();
 
-		$this->setExpectedException('\Exception');
+		$this->expectException(\Exception::class);
 		$this->dispatcher->beforeController($this->controller, $this->method);
 		$this->dispatcher->afterException($this->controller, $this->method, $this->exception);
 

--- a/tests/lib/AppFramework/Middleware/MiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/MiddlewareTest.php
@@ -75,8 +75,8 @@ class MiddlewareTest extends \Test\TestCase {
 
 
 	public function testAfterExceptionRaiseAgainWhenUnhandled() {
-		$this->setExpectedException('Exception');
-		$afterEx = $this->middleware->afterException($this->controller, null, $this->exception);
+		$this->expectException(\Exception::class);
+		$this->middleware->afterException($this->controller, null, $this->exception);
 	}
 
 

--- a/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
@@ -89,7 +89,7 @@ class PasswordConfirmationMiddlewareTest extends TestCase {
 
 	/**
 	 * @PasswordConfirmationRequired
-	 * @dataProvider testProvider
+	 * @dataProvider dataProvider
 	 */
 	public function testAnnotation($backend, $lastConfirm, $currentTime, $exception) {
 		$this->reflector->reflect(__CLASS__, __FUNCTION__);
@@ -116,7 +116,7 @@ class PasswordConfirmationMiddlewareTest extends TestCase {
 		$this->assertSame($exception, $thrown);
 	}
 
-	public function testProvider() {
+	public function dataProvider() {
 		return [
 			['foo', 2000, 4000, true],
 			['foo', 2000, 3000, false],

--- a/tests/lib/AppFramework/Middleware/Security/SameSiteCookieMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SameSiteCookieMiddlewareTest.php
@@ -55,6 +55,7 @@ class SameSiteCookieMiddlewareTest extends TestCase {
 			->willReturn('/ocs/v2.php');
 
 		$this->middleware->beforeController($this->createMock(Controller::class), 'foo');
+		$this->addToAssertionCount(1);
 	}
 
 	public function testBeforeControllerIndexHasAnnotation() {
@@ -66,6 +67,7 @@ class SameSiteCookieMiddlewareTest extends TestCase {
 			->willReturn(true);
 
 		$this->middleware->beforeController($this->createMock(Controller::class), 'foo');
+		$this->addToAssertionCount(1);
 	}
 
 	public function testBeforeControllerIndexNoAnnotationPassingCheck() {
@@ -80,6 +82,7 @@ class SameSiteCookieMiddlewareTest extends TestCase {
 			->willReturn(true);
 
 		$this->middleware->beforeController($this->createMock(Controller::class), 'foo');
+		$this->addToAssertionCount(1);
 	}
 
 	public function testBeforeControllerIndexNoAnnotationFailingCheck() {

--- a/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
@@ -263,7 +263,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$sec = $this->getMiddleware($isLoggedIn, $isAdminUser);
 
 		if($shouldFail) {
-			$this->setExpectedException('\OC\AppFramework\Middleware\Security\Exceptions\SecurityException');
+			$this->expectException(SecurityException::class);
 		} else {
 			$this->assertTrue(true);
 		}
@@ -454,7 +454,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 
 	public function testAfterExceptionNotCaughtThrowsItAgain(){
 		$ex = new \Exception();
-		$this->setExpectedException('\Exception');
+		$this->expectException(\Exception::class);
 		$this->middleware->afterException($this->controller, 'test', $ex);
 	}
 

--- a/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
@@ -168,7 +168,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		// add assertion if everything should work fine otherwise phpunit will
 		// complain
 		if ($status === 0) {
-			$this->assertTrue(true);
+			$this->addToAssertionCount(1);
 		}
 	}
 
@@ -265,7 +265,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		if($shouldFail) {
 			$this->expectException(SecurityException::class);
 		} else {
-			$this->assertTrue(true);
+			$this->addToAssertionCount(1);
 		}
 
 		$this->reader->reflect(__CLASS__, $method);

--- a/tests/lib/Authentication/LoginCredentials/StoreTest.php
+++ b/tests/lib/Authentication/LoginCredentials/StoreTest.php
@@ -79,6 +79,7 @@ class StoreTest extends TestCase {
 		$session = $this->createMock(ISession::class);
 
 		$this->store->setSession($session);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testGetLoginCredentialsNoTokenProvider() {

--- a/tests/lib/Contacts/ContactsMenu/EntryTest.php
+++ b/tests/lib/Contacts/ContactsMenu/EntryTest.php
@@ -26,10 +26,9 @@ namespace Tests\Contacts\ContactsMenu;
 
 use OC\Contacts\ContactsMenu\Actions\LinkAction;
 use OC\Contacts\ContactsMenu\Entry;
-use OCP\Contacts\ContactsMenu\IAction;
 use Test\TestCase;
 
-class EntryTest extends \PHPUnit_Framework_TestCase {
+class EntryTest extends TestCase {
 
 	/** @var Entry */
 	private $entry;

--- a/tests/lib/Contacts/ContactsMenu/EntryTest.php
+++ b/tests/lib/Contacts/ContactsMenu/EntryTest.php
@@ -41,6 +41,7 @@ class EntryTest extends TestCase {
 
 	public function testSetId() {
 		$this->entry->setId(123);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testSetGetFullName() {

--- a/tests/lib/DB/ConnectionTest.php
+++ b/tests/lib/DB/ConnectionTest.php
@@ -58,7 +58,7 @@ class ConnectionTest extends \Test\TestCase {
 	public function assertTableExist($table) {
 		if ($this->connection->getDatabasePlatform() instanceof SqlitePlatform) {
 			// sqlite removes the tables after closing the DB
-			$this->assertTrue(true);
+			$this->addToAssertionCount(1);
 		} else {
 			$this->assertTrue($this->connection->tableExists($table), 'Table ' . $table . ' exists.');
 		}
@@ -70,7 +70,7 @@ class ConnectionTest extends \Test\TestCase {
 	public function assertTableNotExist($table) {
 		if ($this->connection->getDatabasePlatform() instanceof SqlitePlatform) {
 			// sqlite removes the tables after closing the DB
-			$this->assertTrue(true);
+			$this->addToAssertionCount(1);
 		} else {
 			$this->assertFalse($this->connection->tableExists($table), 'Table ' . $table . " doesn't exist.");
 		}
@@ -195,5 +195,7 @@ class ConnectionTest extends \Test\TestCase {
 		], [
 			'textfield' => 'foo'
 		]);
+
+		$this->addToAssertionCount(1);
 	}
 }

--- a/tests/lib/DB/DBSchemaTest.php
+++ b/tests/lib/DB/DBSchemaTest.php
@@ -107,7 +107,7 @@ class DBSchemaTest extends TestCase {
 		$platform = \OC::$server->getDatabaseConnection()->getDatabasePlatform();
 		if ($platform instanceof SqlitePlatform) {
 			// sqlite removes the tables after closing the DB
-			$this->assertTrue(true);
+			$this->addToAssertionCount(1);
 		} else {
 			$this->assertFalse(OC_DB::tableExists($table), 'Table ' . $table . ' exists.');
 		}

--- a/tests/lib/DB/MDB2SchemaManagerTest.php
+++ b/tests/lib/DB/MDB2SchemaManagerTest.php
@@ -46,7 +46,7 @@ class MDB2SchemaManagerTest extends \Test\TestCase {
 		$connection->executeUpdate('insert into `*PREFIX*table` values (?)', array('123'));
 		$manager->updateDbFromStructure(__DIR__ . '/ts-autoincrement-after.xml');
 
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 }

--- a/tests/lib/DB/MigratorTest.php
+++ b/tests/lib/DB/MigratorTest.php
@@ -132,7 +132,7 @@ class MigratorTest extends \Test\TestCase {
 
 		$migrator->checkMigrate($endSchema);
 		$migrator->migrate($endSchema);
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testUpgradeDifferentPrefix() {
@@ -151,7 +151,7 @@ class MigratorTest extends \Test\TestCase {
 
 		$migrator->checkMigrate($endSchema);
 		$migrator->migrate($endSchema);
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 
 		$this->config->setSystemValue('dbtableprefix', $oldTablePrefix);
 	}
@@ -169,7 +169,7 @@ class MigratorTest extends \Test\TestCase {
 			$this->connection->insert($this->tableName, array('id' => 2, 'name' => 'qwerty'));
 			$this->fail('Expected duplicate key insert to fail');
 		} catch (DBALException $e) {
-			$this->assertTrue(true);
+			$this->addToAssertionCount(1);
 		}
 	}
 
@@ -191,7 +191,7 @@ class MigratorTest extends \Test\TestCase {
 		$migrator->checkMigrate($endSchema);
 		$migrator->migrate($endSchema);
 
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testReservedKeywords() {
@@ -213,7 +213,7 @@ class MigratorTest extends \Test\TestCase {
 		$migrator->checkMigrate($endSchema);
 		$migrator->migrate($endSchema);
 
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testAddingForeignKey() {

--- a/tests/lib/DB/MySqlMigrationTest.php
+++ b/tests/lib/DB/MySqlMigrationTest.php
@@ -43,7 +43,7 @@ class MySqlMigrationTest extends \Test\TestCase {
 		$manager = new \OC\DB\MDB2SchemaManager($this->connection);
 		$manager->updateDbFromStructure(__DIR__ . '/testschema.xml');
 
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 }

--- a/tests/lib/DB/QueryBuilder/QueryBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/QueryBuilderTest.php
@@ -1137,7 +1137,7 @@ class QueryBuilderTest extends \Test\TestCase {
 			$qB->getLastInsertId();
 			$this->fail('getLastInsertId() should throw an exception, when being called before insert()');
 		} catch (\BadMethodCallException $e) {
-			$this->assertTrue(true);
+			$this->addToAssertionCount(1);
 		}
 
 		$qB->insert('properties')
@@ -1163,7 +1163,7 @@ class QueryBuilderTest extends \Test\TestCase {
 			$qB->getLastInsertId();
 			$this->fail('getLastInsertId() should throw an exception, when being called after delete()');
 		} catch (\BadMethodCallException $e) {
-			$this->assertTrue(true);
+			$this->addToAssertionCount(1);
 		}
 	}
 

--- a/tests/lib/DB/SqliteMigrationTest.php
+++ b/tests/lib/DB/SqliteMigrationTest.php
@@ -43,7 +43,7 @@ class SqliteMigrationTest extends \Test\TestCase {
 		$manager = new \OC\DB\MDB2SchemaManager($this->connection);
 		$manager->updateDbFromStructure(__DIR__ . '/testschema.xml');
 
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 }

--- a/tests/lib/Encryption/DecryptAllTest.php
+++ b/tests/lib/Encryption/DecryptAllTest.php
@@ -301,8 +301,11 @@ class DecryptAllTest extends TestCase {
 			->method('decryptFile')
 			->with('/user1/files/foo/subfile');
 
-		$progressBar = $this->getMockBuilder(ProgressBar::class)
-			->disableOriginalConstructor()->getMock();
+		$output = $this->createMock(OutputInterface::class);
+		$output->expects($this->any())
+			->method('getFormatter')
+			->willReturn($this->createMock(OutputFormatterInterface::class));
+		$progressBar = new ProgressBar($output);
 
 		$this->invokePrivate($instance, 'decryptUsersFiles', ['user1', $progressBar, '']);
 

--- a/tests/lib/Encryption/DecryptAllTest.php
+++ b/tests/lib/Encryption/DecryptAllTest.php
@@ -34,6 +34,7 @@ use OCP\UserInterface;
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 

--- a/tests/lib/Federation/CloudIdTest.php
+++ b/tests/lib/Federation/CloudIdTest.php
@@ -25,7 +25,7 @@ use OC\Federation\CloudId;
 use Test\TestCase;
 
 class CloudIdTest extends TestCase {
-	public function testGetDisplayCloudIdProvider() {
+	public function dataGetDisplayCloudId() {
 		return [
 			['test@example.com', 'test@example.com'],
 			['test@http://example.com', 'test@example.com'],
@@ -34,7 +34,7 @@ class CloudIdTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider testGetDisplayCloudIdProvider
+	 * @dataProvider dataGetDisplayCloudId
 	 *
 	 * @param string $id
 	 * @param string $display

--- a/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
+++ b/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
@@ -79,7 +79,7 @@ class CacheJailTest extends CacheTest {
 
 	function testGetIncomplete() {
 		//not supported
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	function testMoveFromJail() {

--- a/tests/lib/Files/PathVerificationTest.php
+++ b/tests/lib/Files/PathVerificationTest.php
@@ -87,6 +87,8 @@ class PathVerificationTest extends \Test\TestCase {
 		if (!$connection->supports4ByteText()) {
 			$this->expectException(InvalidPathException::class);
 			$this->expectExceptionMessage('File name contains at least one invalid character');
+		} else {
+			$this->addToAssertionCount(1);
 		}
 
 		$this->view->verifyPath('', $fileName);
@@ -161,7 +163,7 @@ class PathVerificationTest extends \Test\TestCase {
 
 		self::invokePrivate($storage, 'verifyPosixPath', [$fileName]);
 		// nothing thrown
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function providesValidPosixPaths() {

--- a/tests/lib/Files/Storage/LocalTest.php
+++ b/tests/lib/Files/Storage/LocalTest.php
@@ -106,6 +106,7 @@ class LocalTest extends Storage {
 		$storage = new \OC\Files\Storage\Local(['datadir' => $subDir1]);
 
 		$storage->file_put_contents('sym/foo', 'bar');
+		$this->addToAssertionCount(1);
 	}
 }
 

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -719,9 +719,7 @@ class EncryptionTest extends Storage {
 	}
 
 	public function testCopyBetweenStorageMinimumEncryptedVersion() {
-		$storage2 = $this->getMockBuilder(Storage::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$storage2 = $this->createMock(\OC\Files\Storage\Storage::class);
 
 		$sourceInternalPath = $targetInternalPath = 'file.txt';
 		$preserveMtime = $isRename = false;
@@ -768,9 +766,7 @@ class EncryptionTest extends Storage {
 	 * @param bool $expectedEncrypted
 	 */
 	public function testCopyBetweenStorage($encryptionEnabled, $mountPointEncryptionEnabled, $expectedEncrypted) {
-		$storage2 = $this->getMockBuilder(Storage::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$storage2 = $this->createMock(\OC\Files\Storage\Storage::class);
 
 		$sourceInternalPath = $targetInternalPath = 'file.txt';
 		$preserveMtime = $isRename = false;
@@ -830,13 +826,9 @@ class EncryptionTest extends Storage {
 	 */
 	public function  testCopyBetweenStorageVersions($sourceInternalPath, $targetInternalPath, $copyResult, $encrypted) {
 
-		$sourceStorage = $this->getMockBuilder(Storage::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$sourceStorage = $this->createMock(\OC\Files\Storage\Storage::class);
 
-		$targetStorage = $this->getMockBuilder(Storage::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$targetStorage = $this->createMock(\OC\Files\Storage\Storage::class);
 
 		$cache = $this->getMockBuilder('\OC\Files\Cache\Cache')
 			->disableOriginalConstructor()->getMock();

--- a/tests/lib/Group/Backend.php
+++ b/tests/lib/Group/Backend.php
@@ -157,5 +157,7 @@ abstract class Backend extends \Test\TestCase {
 
 		$this->backend->createGroup($group);
 		$this->backend->createGroup($group);
+
+		$this->addToAssertionCount(1);
 	}
 }

--- a/tests/lib/Hooks/BasicEmitterTest.php
+++ b/tests/lib/Hooks/BasicEmitterTest.php
@@ -157,7 +157,7 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->removeListener('Test', 'test', $listener);
 		$this->emitter->emitEvent('Test', 'test');
 
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testRemoveWildcardListener() {
@@ -172,7 +172,7 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->removeListener('Test', 'test');
 		$this->emitter->emitEvent('Test', 'test');
 
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testRemoveWildcardMethod() {
@@ -185,7 +185,7 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->emitEvent('Test', 'test');
 		$this->emitter->emitEvent('Test', 'foo');
 
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testRemoveWildcardScope() {
@@ -198,7 +198,7 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->emitEvent('Test', 'test');
 		$this->emitter->emitEvent('Bar', 'test');
 
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testRemoveWildcardScopeAndMethod() {
@@ -213,7 +213,7 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->emitEvent('Test', 'foo');
 		$this->emitter->emitEvent('Bar', 'foo');
 
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	/**
@@ -231,7 +231,7 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->removeListener('Test', 'test', $listener1);
 		$this->emitter->emitEvent('Test', 'test');
 
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	/**
@@ -246,7 +246,7 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->removeListener('Test', 'foo', $listener);
 		$this->emitter->emitEvent('Test', 'test');
 
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	/**
@@ -261,7 +261,7 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->removeListener('Bar', 'test', $listener);
 		$this->emitter->emitEvent('Test', 'test');
 
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 
 	/**
@@ -275,6 +275,6 @@ class BasicEmitterTest extends \Test\TestCase {
 		$this->emitter->removeListener('Bar', 'test', $listener);
 		$this->emitter->emitEvent('Test', 'test');
 
-		$this->assertTrue(true);
+		$this->addToAssertionCount(1);
 	}
 }

--- a/tests/lib/InfoXmlTest.php
+++ b/tests/lib/InfoXmlTest.php
@@ -67,8 +67,10 @@ class InfoXmlTest extends TestCase {
 		$applicationClassName = \OCP\AppFramework\App::buildAppNamespace($app) . '\\AppInfo\\Application';
 		if (class_exists($applicationClassName)) {
 			$application = new $applicationClassName();
+			$this->addToAssertionCount(1);
 		} else {
 			$application = new \OCP\AppFramework\App($app);
+			$this->addToAssertionCount(1);
 		}
 
 		if (isset($appInfo['background-jobs'])) {

--- a/tests/lib/IntegrityCheck/Helpers/FileAccessHelperTest.php
+++ b/tests/lib/IntegrityCheck/Helpers/FileAccessHelperTest.php
@@ -64,5 +64,6 @@ class FileAccessHelperTest extends TestCase {
 
 	public function testAssertDirectoryExists() {
 		$this->fileAccessHelper->assertDirectoryExists(\OC::$server->getTempManager()->getTemporaryFolder('/testfolder/'));
+		$this->addToAssertionCount(1);
 	}
 }

--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -392,7 +392,7 @@ class FactoryTest extends TestCase {
 			->willReturn($header);
 
 		if ($expected instanceof LanguageNotFoundException) {
-			$this->setExpectedException(LanguageNotFoundException::class);
+			$this->expectException(LanguageNotFoundException::class);
 			self::invokePrivate($factory, 'getLanguageFromRequest', [$app]);
 		} else {
 			$this->assertSame($expected, self::invokePrivate($factory, 'getLanguageFromRequest', [$app]), 'Asserting returned language');

--- a/tests/lib/Notification/NotificationTest.php
+++ b/tests/lib/Notification/NotificationTest.php
@@ -466,7 +466,7 @@ class NotificationTest extends TestCase {
 
 		$this->assertSame($this->notification, $this->notification->addAction($action));
 
-		$this->setExpectedException('\InvalidArgumentException');
+		$this->expectException(\InvalidArgumentException::class);
 		$this->notification->addAction($action);
 	}
 
@@ -512,7 +512,7 @@ class NotificationTest extends TestCase {
 
 		$this->assertSame($this->notification, $this->notification->addParsedAction($action));
 
-		$this->setExpectedException('\InvalidArgumentException');
+		$this->expectException(\InvalidArgumentException::class);
 		$this->notification->addParsedAction($action);
 	}
 

--- a/tests/lib/RichObjectStrings/ValidatorTest.php
+++ b/tests/lib/RichObjectStrings/ValidatorTest.php
@@ -49,6 +49,7 @@ class ValidatorTest extends TestCase {
 				'path' => 'path/to/test.txt',
 			],
 		]);
+		$this->addToAssertionCount(2);
 	}
 
 }

--- a/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
+++ b/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
@@ -35,6 +35,7 @@ class ContentSecurityPolicyManagerTest extends \Test\TestCase {
 
 	public function testAddDefaultPolicy() {
 		$this->contentSecurityPolicyManager->addDefaultPolicy(new \OCP\AppFramework\Http\ContentSecurityPolicy());
+		$this->addToAssertionCount(1);
 	}
 
 	public function testGetDefaultPolicyWithPolicies() {

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -779,6 +779,7 @@ class ManagerTest extends \Test\TestCase {
 
 		try {
 			self::invokePrivate($this->manager, 'validateExpirationDate', [$share]);
+			$this->addToAssertionCount(1);
 		} catch (\OCP\Share\Exceptions\GenericShareException $e) {
 			$this->assertEquals('Cannot set expiration date more than 3 days in the future', $e->getMessage());
 			$this->assertEquals('Cannot set expiration date more than 3 days in the future', $e->getHint());
@@ -1008,6 +1009,7 @@ class ManagerTest extends \Test\TestCase {
 			->willReturn([]);
 
 		self::invokePrivate($this->manager, 'userCreateChecks', [$share]);
+		$this->addToAssertionCount(1);
 	}
 
 	/**
@@ -1143,6 +1145,7 @@ class ManagerTest extends \Test\TestCase {
 			->willReturn([$share2]);
 
 		self::invokePrivate($this->manager, 'userCreateChecks', [$share]);
+		$this->addToAssertionCount(1);
 	}
 
 	/**
@@ -1237,6 +1240,7 @@ class ManagerTest extends \Test\TestCase {
 			]));
 
 		self::invokePrivate($this->manager, 'groupCreateChecks', [$share]);
+		$this->addToAssertionCount(1);
 	}
 
 	/**
@@ -1292,6 +1296,7 @@ class ManagerTest extends \Test\TestCase {
 			]));
 
 		self::invokePrivate($this->manager, 'groupCreateChecks', [$share]);
+		$this->addToAssertionCount(1);
 	}
 
 	/**
@@ -1360,6 +1365,7 @@ class ManagerTest extends \Test\TestCase {
 			]));
 
 		self::invokePrivate($this->manager, 'linkCreateChecks', [$share]);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testLinkCreateChecksReadOnly() {
@@ -1375,6 +1381,7 @@ class ManagerTest extends \Test\TestCase {
 			]));
 
 		self::invokePrivate($this->manager, 'linkCreateChecks', [$share]);
+		$this->addToAssertionCount(1);
 	}
 
 	/**
@@ -1407,12 +1414,14 @@ class ManagerTest extends \Test\TestCase {
 		$this->mountManager->method('findIn')->with('path')->willReturn([$mount]);
 
 		self::invokePrivate($this->manager, 'pathCreateChecks', [$path]);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testPathCreateChecksContainsNoFolder() {
 		$path = $this->createMock(File::class);
 
 		self::invokePrivate($this->manager, 'pathCreateChecks', [$path]);
+		$this->addToAssertionCount(1);
 	}
 
 	public function dataIsSharingDisabledForUser() {
@@ -2744,6 +2753,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->defaultProvider->method('move')->with($share, 'recipient')->will($this->returnArgument(0));
 
 		$this->manager->moveShare($share, 'recipient');
+		$this->addToAssertionCount(1);
 	}
 
 	/**
@@ -2801,6 +2811,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->defaultProvider->method('move')->with($share, 'recipient')->will($this->returnArgument(0));
 
 		$this->manager->moveShare($share, 'recipient');
+		$this->addToAssertionCount(1);
 	}
 
 	/**

--- a/tests/lib/Support/CrashReport/RegistryTest.php
+++ b/tests/lib/Support/CrashReport/RegistryTest.php
@@ -47,6 +47,7 @@ class RegistryTest extends TestCase {
 		$exception = new Exception('test');
 
 		$this->registry->delegateReport($exception);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testDelegateToAll() {

--- a/tests/lib/Template/CSSResourceLocatorTest.php
+++ b/tests/lib/Template/CSSResourceLocatorTest.php
@@ -24,6 +24,7 @@
 namespace Test\Template;
 
 use OC\Files\AppData\Factory;
+use OCP\Files\IAppData;
 use OCP\ILogger;
 use OCP\IURLGenerator;
 use OCP\IConfig;
@@ -37,7 +38,7 @@ class CSSResourceLocatorTest extends \Test\TestCase {
 	protected $appData;
 	/** @var IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
 	protected $urlGenerator;
-	/** @var SystemConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
 	protected $config;
 	/** @var ThemingDefaults|\PHPUnit_Framework_MockObject_MockObject */
 	protected $themingDefaults;

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -33,7 +33,7 @@ use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\Security\ISecureRandom;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase {
+abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	/** @var \OC\Command\QueueBus */
 	private $commandBus;
 
@@ -45,24 +45,6 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 
 	/** @var array */
 	protected $services = [];
-
-	/**
-	 * Wrapper to be forward compatible to phpunit 5.4+
-	 *
-	 * @param string $originalClassName
-	 * @return \PHPUnit_Framework_MockObject_MockObject
-	 */
-	protected function createMock($originalClassName) {
-		if (is_callable('parent::createMock')) {
-			return parent::createMock($originalClassName);
-		}
-
-		return $this->getMockBuilder($originalClassName)
-			->disableOriginalConstructor()
-			->disableOriginalClone()
-			->disableArgumentCloning()
-			->getMock();
-	}
 
 	/**
 	 * @param string $name
@@ -152,7 +134,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		}
 	}
 
-	protected function onNotSuccessfulTest($e) {
+	protected function onNotSuccessfulTest(\Throwable $t) {
 		$this->restoreAllServices();
 
 		// restore database connection
@@ -162,7 +144,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 			});
 		}
 
-		parent::onNotSuccessfulTest($e);
+		parent::onNotSuccessfulTest($t);
 	}
 
 	protected function tearDown() {

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -329,7 +329,7 @@ class ManagerTest extends TestCase {
 		$manager = new \OC\User\Manager($this->config);
 		$manager->registerBackend($backend);
 
-		$this->setExpectedException(\InvalidArgumentException::class, $exception);
+		$this->expectException(\InvalidArgumentException::class, $exception);
 		$manager->createUser($uid, $password);
 	}
 

--- a/tests/startsessionlistener.php
+++ b/tests/startsessionlistener.php
@@ -6,45 +6,25 @@
  * See the COPYING-README file.
  */
 
+use OC\Session\Memory;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestListenerDefaultImplementation;
+
 /**
  * Starts a new session before each test execution
  */
-class StartSessionListener implements PHPUnit_Framework_TestListener {
+class StartSessionListener implements TestListener {
 
-	public function addError(PHPUnit_Framework_Test $test, Exception $e, $time) {
-	}
+	use TestListenerDefaultImplementation;
 
-	public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time) {
-	}
-
-	public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
-	}
-
-	public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
-	}
-
-	public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
-	}
-
-	public function startTest(PHPUnit_Framework_Test $test) {
-	}
-
-	public function endTest(PHPUnit_Framework_Test $test, $time) {
+	public function endTest(Test $test, $time) {
 		// reopen the session - only allowed for memory session
-		if (\OC::$server->getSession() instanceof \OC\Session\Memory) {
-			/** @var $session \OC\Session\Memory */
+		if (\OC::$server->getSession() instanceof Memory) {
+			/** @var $session Memory */
 			$session = \OC::$server->getSession();
 			$session->reopen();
 		}
-	}
-
-	public function startTestSuite(PHPUnit_Framework_TestSuite $suite) {
-	}
-
-	public function endTestSuite(PHPUnit_Framework_TestSuite $suite) {
-	}
-
-	public function addWarning(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_Warning $e, $time) {
 	}
 
 }


### PR DESCRIPTION
`\PHPUnit_Framework_MockObject_MockObject` is still available and not deprecated, so we can keep that for now and have an easy diff on the transition.

Only "problem" for apps should be that `setExpectedException` is now `expectException`