### PR TITLE
Fixes issue with login redirect loop

### DIFF
--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -272,18 +272,22 @@ class Router implements IRouter {
 		try {
 			$parameters = $matcher->match($url);
 		} catch (ResourceNotFoundException $e) {
-			if (substr($url, -1) !== '/') {
-				// We allow links to apps/files? for backwards compatibility reasons
-				// However, since Symfony does not allow empty route names, the route
-				// we need to match is '/', so we need to append the '/' here.
-				try {
-					$parameters = $matcher->match($url . '/');
-				} catch (ResourceNotFoundException $newException) {
-					// If we still didn't match a route, we throw the original exception
+			try {
+				$parameters = $matcher->match(rtrim($url,'/'));
+			} catch (ResourceNotFoundException $newException) {
+				if (substr($url, -1) !== '/') {
+					// We allow links to apps/files? for backwards compatibility reasons
+					// However, since Symfony does not allow empty route names, the route
+					// we need to match is '/', so we need to append the '/' here.
+					try {
+						$parameters = $matcher->match($url . '/');
+					} catch (ResourceNotFoundException $newException) {
+						// If we still didn't match a route, we throw the original exception
+						throw $e;
+					}
+				} else {
 					throw $e;
 				}
-			} else {
-				throw $e;
 			}
 		}
 


### PR DESCRIPTION
When nextcloud is behind a nginx reverse proxy (also reported to have this issue when installed in sub folders via google searches) nextcloud will constantly redirect back and forth between /login/ and /login due to the code in lib/base.php. 
LINE 1034: header('Location: '.\OC::$server->getURLGenerator()->linkToRouteAbsolute('core.login.showLoginForm'));
AND 
LINE 179: header('Location: '.\OC::$WEBROOT.'/');

This is believed to be due to the routes in core/routes.php for the login not having a trailing slash.

This fix makes trailing slash and non-trailing slash urls backwards compatible.