### PR TITLE
Return value immediately instead of assigning to a one-time variable

### DIFF
--- a/apps/dav/lib/CardDAV/Converter.php
+++ b/apps/dav/lib/CardDAV/Converter.php
@@ -143,8 +143,7 @@ class Converter {
 	 */
 	private function getAvatarImage(IUser $user) {
 		try {
-			$image = $user->getAvatarImage(-1);
-			return $image;
+			return $user->getAvatarImage(-1);
 		} catch (\Exception $ex) {
 			return null;
 		}

--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -340,8 +340,7 @@ class FilesPlugin extends ServerPlugin {
 			});
 
 			$propFind->handle(self::IS_ENCRYPTED_PROPERTYNAME, function() use ($node) {
-				$result = $node->getFileInfo()->isEncrypted() ? '1' : '0';
-				return $result;
+				return $node->getFileInfo()->isEncrypted() ? '1' : '0';
 			});
 
 			$propFind->handle(self::HAS_PREVIEW_PROPERTYNAME, function () use ($node) {

--- a/apps/encryption/lib/Util.php
+++ b/apps/encryption/lib/Util.php
@@ -196,8 +196,7 @@ class Util {
 	 * @return \OC\Files\Storage\Storage
 	 */
 	public function getStorage($path) {
-		$storage = $this->files->getMount($path)->getStorage();
-		return $storage;
+		return $this->files->getMount($path)->getStorage();
 	}
 
 }

--- a/apps/federatedfilesharing/lib/AddressHandler.php
+++ b/apps/federatedfilesharing/lib/AddressHandler.php
@@ -84,8 +84,7 @@ class AddressHandler {
 	 * @return string url of the current server
 	 */
 	public function generateRemoteURL() {
-		$url = $this->urlGenerator->getAbsoluteURL('/');
-		return $url;
+		return $this->urlGenerator->getAbsoluteURL('/');
 	}
 
 	/**

--- a/apps/files_external/3rdparty/icewind/smb/src/Share.php
+++ b/apps/files_external/3rdparty/icewind/smb/src/Share.php
@@ -370,8 +370,7 @@ class Share extends AbstractShare {
 	protected function execute($command) {
 		$this->connect();
 		$this->connection->write($command . PHP_EOL);
-		$output = $this->connection->read();
-		return $output;
+		return $this->connection->read();
 	}
 
 	/**

--- a/apps/files_external/lib/Service/UserStoragesService.php
+++ b/apps/files_external/lib/Service/UserStoragesService.php
@@ -112,8 +112,7 @@ class UserStoragesService extends StoragesService {
 	 */
 	public function addStorage(StorageConfig $newStorage) {
 		$newStorage->setApplicableUsers([$this->getUser()->getUID()]);
-		$config = parent::addStorage($newStorage);
-		return $config;
+		return parent::addStorage($newStorage);
 	}
 
 	/**

--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -230,9 +230,7 @@ class ShareesAPIController extends OCSController {
 			$url = $this->urlGenerator->getAbsoluteURL('/ocs/v1.php/apps/files_sharing/api/v1/sharees') . '?';
 		}
 		$params['page'] = $page + 1;
-		$link = '<' . $url . http_build_query($params) . '>; rel="next"';
-
-		return $link;
+		return '<' . $url . http_build_query($params) . '>; rel="next"';
 	}
 
 	/**

--- a/apps/files_sharing/lib/ShareBackend/Folder.php
+++ b/apps/files_sharing/lib/ShareBackend/Folder.php
@@ -73,9 +73,7 @@ class Folder extends File implements \OCP\Share_Backend_Collection {
 		$query = \OCP\DB::prepare('SELECT `parent` FROM `*PREFIX*filecache` WHERE `fileid` = ?');
 		$result = $query->execute(array($child));
 		$row = $result->fetchRow();
-		$parent = $row ? $row['parent'] : null;
-
-		return $parent;
+		return $row ? $row['parent'] : null;
 	}
 
 	public function getChildren($itemSource) {

--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -254,8 +254,7 @@ class Storage extends Wrapper {
 	 * @return MoveToTrashEvent
 	 */
 	protected function createMoveToTrashEvent(Node $node) {
-		$event = new MoveToTrashEvent($node);
-		return $event;
+		return new MoveToTrashEvent($node);
 	}
 
 	/**

--- a/apps/twofactor_backupcodes/lib/Provider/BackupCodesProvider.php
+++ b/apps/twofactor_backupcodes/lib/Provider/BackupCodesProvider.php
@@ -90,8 +90,7 @@ class BackupCodesProvider implements IProvider {
 	 * @return Template
 	 */
 	public function getTemplate(IUser $user) {
-		$tmpl = new Template('twofactor_backupcodes', 'challenge');
-		return $tmpl;
+		return new Template('twofactor_backupcodes', 'challenge');
 	}
 
 	/**

--- a/apps/user_ldap/lib/Helper.php
+++ b/apps/user_ldap/lib/Helper.php
@@ -123,8 +123,7 @@ class Helper {
 		sort($serverConnections);
 		$lastKey = array_pop($serverConnections);
 		$lastNumber = intval(str_replace('s', '', $lastKey));
-		$nextPrefix = 's' . str_pad($lastNumber + 1, 2, '0', STR_PAD_LEFT);
-		return $nextPrefix;
+		return 's' . str_pad($lastNumber + 1, 2, '0', STR_PAD_LEFT);
 	}
 
 	private function getServersConfig($value) {

--- a/core/Command/Config/Import.php
+++ b/core/Command/Config/Import.php
@@ -113,8 +113,7 @@ class Import extends Command implements CompletionAwareInterface  {
 	 * @return string
 	 */
 	protected function getArrayFromFile($importFile) {
-		$content = file_get_contents($importFile);
-		return $content;
+		return file_get_contents($importFile);
 	}
 
 	/**

--- a/lib/private/App/Platform.php
+++ b/lib/private/App/Platform.php
@@ -94,7 +94,6 @@ class Platform {
 
 	public function getLibraryVersion($name) {
 		$repo = new PlatformRepository();
-		$lib = $repo->findLibrary($name);
-		return $lib;
+		return $repo->findLibrary($name);
 	}
 }

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -426,8 +426,7 @@ class View {
 				flush();
 			}
 			fclose($handle);
-			$size = $this->filesize($path);
-			return $size;
+			return $this->filesize($path);
 		}
 		return false;
 	}
@@ -476,8 +475,7 @@ class View {
 					echo fread($handle, $len);
 					flush();
 				}
-				$size = ftell($handle) - $from;
-				return $size;
+				return ftell($handle) - $from;
 			}
 
 			throw new \OCP\Files\UnseekableException('fseek error');
@@ -1083,8 +1081,7 @@ class View {
 			}
 			list($storage, $internalPath) = Filesystem::resolvePath($absolutePath . $postFix);
 			if ($storage) {
-				$result = $storage->hash($type, $internalPath, $raw);
-				return $result;
+				return $storage->hash($type, $internalPath, $raw);
 			}
 		}
 		return null;

--- a/lib/private/Security/CertificateManager.php
+++ b/lib/private/Security/CertificateManager.php
@@ -249,9 +249,7 @@ class CertificateManager implements ICertificateManager {
 		if ($uid === '') {
 			$uid = $this->uid;
 		}
-		$path = is_null($uid) ? '/files_external/' : '/' . $uid . '/files_external/';
-
-		return $path;
+		return is_null($uid) ? '/files_external/' : '/' . $uid . '/files_external/';
 	}
 
 	/**

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -243,9 +243,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('SystemTagManagerFactory', function (Server $c) {
 			$config = $c->getConfig();
 			$factoryClass = $config->getSystemValue('systemtags.managerFactory', '\OC\SystemTag\ManagerFactory');
-			/** @var \OC\SystemTag\ManagerFactory $factory */
-			$factory = new $factoryClass($this);
-			return $factory;
+			return new $factoryClass($this);
 		});
 		$this->registerService(\OCP\SystemTag\ISystemTagManager::class, function (Server $c) {
 			return $c->query('SystemTagManagerFactory')->getManager();

--- a/lib/private/legacy/db.php
+++ b/lib/private/legacy/db.php
@@ -170,8 +170,7 @@ class OC_DB {
 	 */
 	public static function createDbFromStructure( $file ) {
 		$schemaManager = self::getMDB2SchemaManager();
-		$result = $schemaManager->createDbFromStructure($file);
-		return $result;
+		return $schemaManager->createDbFromStructure($file);
 	}
 
 	/**

--- a/lib/private/legacy/db/statementwrapper.php
+++ b/lib/private/legacy/db/statementwrapper.php
@@ -77,8 +77,7 @@ class OC_DB_StatementWrapper {
 			return false;
 		}
 		if ($this->isManipulation) {
-			$count = $this->statement->rowCount();
-			return $count;
+			return $this->statement->rowCount();
 		} else {
 			return $this;
 		}

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -723,9 +723,7 @@ class UsersController extends Controller {
 	protected function signMessage(IUser $user, $message) {
 		$privateKey = $this->keyManager->getKey($user)->getPrivate();
 		openssl_sign(json_encode($message), $signature, $privateKey, OPENSSL_ALGO_SHA512);
-		$signatureBase64 = base64_encode($signature);
-
-		return $signatureBase64;
+		return base64_encode($signature);
 	}
 
 	/**


### PR DESCRIPTION
There is no need to assign it to a variable and then immediately return that value.