### PR TITLE
Deprecated OCP interface to fetch background job type

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -63,7 +63,7 @@ try {
 	$logger = \OC::$server->getLogger();
 	$config = \OC::$server->getConfig();
 
-	// Don't do anything if ownCloud has not been installed
+	// Don't do anything if Nextcloud has not been installed
 	if (!$config->getSystemValue('installed', false)) {
 		exit(0);
 	}
@@ -71,8 +71,8 @@ try {
 	\OC::$server->getTempManager()->cleanOld();
 
 	// Exit if background jobs are disabled!
-	$appMode = \OCP\BackgroundJob::getExecutionType();
-	if ($appMode == 'none') {
+	$appMode = $config->getAppValue('core', 'backgroundjobs_mode', 'ajax');
+	if ($appMode === 'none') {
 		if (OC::$CLI) {
 			echo 'Background Jobs are disabled!' . PHP_EOL;
 		} else {
@@ -101,9 +101,9 @@ try {
 			exit(1);
 		}
 
-		// We call ownCloud from the CLI (aka cron)
-		if ($appMode != 'cron') {
-			\OCP\BackgroundJob::setExecutionType('cron');
+		// We call Nextcloud from the CLI (aka cron)
+		if ($appMode !== 'cron') {
+			$config->setAppValue('core', 'backgroundjobs_mode', 'cron');
 		}
 
 		// Work

--- a/lib/private/App/CodeChecker/DeprecationCheck.php
+++ b/lib/private/App/CodeChecker/DeprecationCheck.php
@@ -45,6 +45,7 @@ class DeprecationCheck extends AbstractCheck implements ICheck {
 			'OCP\Response' => '8.1.0',
 			'OCP\AppFramework\IApi' => '8.0.0',
 			'OCP\User' => '13.0.0',
+			'OCP\BackgroundJob' => '14.0.0',
 		];
 	}
 
@@ -116,6 +117,8 @@ class DeprecationCheck extends AbstractCheck implements ICheck {
 			'OCP\AppFramework\IAppContainer::log' => '8.0.0',
 
 			'OCP\BackgroundJob::registerJob' => '8.1.0',
+			'OCP\BackgroundJob::getExecutionType' => '14.0.0',
+			'OCP\BackgroundJob::setExecutionType' => '14.0.0',
 
 			'OCP\Files::tmpFile' => '8.1.0',
 			'OCP\Files::tmpFolder' => '8.1.0',

--- a/lib/public/BackgroundJob.php
+++ b/lib/public/BackgroundJob.php
@@ -25,67 +25,32 @@
  *
  */
 
-/**
- * Public interface of ownCloud for background jobs.
- */
-
-// use OCP namespace for all classes that are considered public.
-// This means that they should be used by apps instead of the internal ownCloud classes
 namespace OCP;
 
-
 /**
- * This class provides functions to register backgroundjobs in ownCloud
- *
- * To create a new backgroundjob create a new class that inherits from either \OC\BackgroundJob\Job,
- * \OC\BackgroundJob\QueuedJob or \OC\BackgroundJob\TimedJob and register it using
- * \OCP\BackgroundJob->registerJob($job, $argument), $argument will be passed to the run() function
- * of the job when the job is executed.
- *
- * A regular Job will be executed every time cron.php is run, a QueuedJob will only run once and a TimedJob
- * will only run at a specific interval which is to be specified in the constructor of the job by calling
- * $this->setInterval($interval) with $interval in seconds.
  * @since 4.5.0
+ * @deprecated 14.0.0
  */
 class BackgroundJob {
 	/**
-	 * get the execution type of background jobs
-	 *
-	 * @return string
-	 *
-	 * This method returns the type how background jobs are executed. If the user
-	 * did not select something, the type is ajax.
 	 * @since 5.0.0
+	 * @deprecated 14.0.0
 	 */
 	public static function getExecutionType() {
-		return \OC::$server->getConfig()->getAppValue('core', 'backgroundjobs_mode', 'ajax');
+		return '';
 	}
 
 	/**
-	 * sets the background jobs execution type
-	 *
-	 * @param string $type execution type
-	 * @return false|null
-	 *
-	 * This method sets the execution type of the background jobs. Possible types
-	 * are "none", "ajax", "webcron", "cron"
 	 * @since 5.0.0
+	 * @deprecated 14.0.0
 	 */
 	public static function setExecutionType($type) {
-		if( !in_array( $type, array('none', 'ajax', 'webcron', 'cron'))) {
-			return false;
-		}
-		\OC::$server->getConfig()->setAppValue('core', 'backgroundjobs_mode', $type);
 	}
 
 	/**
-	 * @param string $job
-	 * @param mixed $argument
-	 * @deprecated 8.1.0 Use \OC::$server->getJobList()->add() instead
 	 * @since 6.0.0
+	 * @deprecated 8.1.0 Use \OC::$server->getJobList()->add() instead
 	 */
 	public static function registerJob($job, $argument = null) {
-		$jobList = \OC::$server->getJobList();
-		$jobList->add($job, $argument);
 	}
 }

--- a/lib/public/BackgroundJob/IJobList.php
+++ b/lib/public/BackgroundJob/IJobList.php
@@ -29,6 +29,19 @@ namespace OCP\BackgroundJob;
 /**
  * Interface IJobList
  *
+ * This interface provides functions to register background jobs
+ *
+ * To create a new background job create a new class that inherits from either
+ * \OC\BackgroundJob\Job, \OC\BackgroundJob\QueuedJob or
+ * \OC\BackgroundJob\TimedJob and register it using ->add($job, $argument),
+ * $argument will be passed to the run() function of the job when the job is
+ * executed.
+ *
+ * A regular job will be executed every time cron.php is run, a QueuedJob will
+ * only run once and a TimedJob will only run at a specific interval which is to
+ * be specified in the constructor of the job by calling
+ * $this->setInterval($interval) with $interval in seconds.
+ *
  * @package OCP\BackgroundJob
  * @since 7.0.0
  */


### PR DESCRIPTION
* was not used by apps and also is not needed
* migrated the documentation to IJobList