### PR TITLE
Preview is active on file sidebar even if preview is set false on config.php #6764

### DIFF
--- a/apps/files/js/sidebarpreviewmanager.js
+++ b/apps/files/js/sidebarpreviewmanager.js
@@ -41,7 +41,7 @@
 		},
 
 		loadPreview: function (model, $thumbnailDiv, $thumbnailContainer) {
-			if (model.get('hasPreview') === false && this.getMimeTypePreviewHandler(model.get('mimetype')) === null) {
+			if (oc_config.previewsEnabled === false ||(model.get('hasPreview') === false && this.getMimeTypePreviewHandler(model.get('mimetype')) === null)) {
 				var mimeIcon = OC.MimeType.getIconUrl(model.get('mimetype'));
 				$thumbnailDiv.removeClass('icon-loading icon-32');
 				$thumbnailContainer.removeClass('image'); //fall back to regular view

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -88,7 +88,7 @@ OCA.Sharing.PublicApp = {
 		mimetypeIcon = mimetypeIcon.substring(0, mimetypeIcon.length - 3);
 		mimetypeIcon = mimetypeIcon + 'svg';
 
-		var previewSupported = $('#previewSupported').val();
+		var previewSupported = $('#previewSupported').val() && oc_config.previewsEnabled;
 
 		if (typeof FileActions !== 'undefined') {
 			// Show file preview if previewer is available, images are already handled by the template

--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -223,6 +223,7 @@ class JSConfigHelper {
 				'sharing.maxAutocompleteResults' => intval($this->config->getSystemValue('sharing.maxAutocompleteResults', 0)),
 				'sharing.minSearchStringLength' => intval($this->config->getSystemValue('sharing.minSearchStringLength', 0)),
 				'blacklist_files_regex' => \OCP\Files\FileInfo::BLACKLIST_FILES_REGEX,
+				'previewsEnabled' => false,
 			]),
 			"oc_appconfig" => json_encode([
 				'core' => [


### PR DESCRIPTION


- Provide the enable_previews value in oc_config in JSConfigHelper.php.
- Take oc_config.enable_previews into account in the condition of SidebarPreviewManager.loadPreview.
- For consistency it take into account too in the public shared file page.