### PR TITLE
Expose navigation entries as API endpoint

### DIFF
--- a/core/Controller/NavigationController.php
+++ b/core/Controller/NavigationController.php
@@ -32,8 +32,8 @@ class NavigationController extends Controller {
 	/** @var INavigationManager */
 	private $navigationManager;
 
-	public function __construct(IRequest $request, INavigationManager $navigationManager) {
-		parent::__construct('core', $request);
+	public function __construct(string $appName, IRequest $request, INavigationManager $navigationManager) {
+		parent::__construct($appName, $request);
 		$this->navigationManager = $navigationManager;
 	}
 

--- a/core/Controller/NavigationController.php
+++ b/core/Controller/NavigationController.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OC\Core\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\INavigationManager;
+use OCP\IRequest;
+
+class NavigationController extends Controller {
+
+	/** @var INavigationManager */
+	private $navigationManager;
+
+	public function __construct(IRequest $request, INavigationManager $navigationManager) {
+		parent::__construct('core', $request);
+		$this->navigationManager = $navigationManager;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * @return JSONResponse
+	 */
+	public function getAppsNavigation($absolute = false) {
+		return new JSONResponse($this->navigationManager->getAll('link', $absolute));
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * @return JSONResponse
+	 */
+	public function getSettingsNavigation($absolute = false) {
+		return new JSONResponse($this->navigationManager->getAll('settings', $absolute));
+	}
+}

--- a/core/Controller/NavigationController.php
+++ b/core/Controller/NavigationController.php
@@ -22,13 +22,13 @@
  */
 namespace OC\Core\Controller;
 
-use OCP\AppFramework\Controller;
-use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
 use OCP\INavigationManager;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 
-class NavigationController extends Controller {
+class NavigationController extends OCSController {
 
 	/** @var INavigationManager */
 	private $navigationManager;
@@ -47,14 +47,14 @@ class NavigationController extends Controller {
 	 * @NoCSRFRequired
 	 *
 	 * @param bool $absolute
-	 * @return JSONResponse
+	 * @return DataResponse
 	 */
-	public function getAppsNavigation(bool $absolute = false) {
-		$navigation = $this->navigationManager->getAll('link');
+	public function getAppsNavigation(bool $absolute = false): DataResponse {
+		$navigation = $this->navigationManager->getAll();
 		if ($absolute) {
-			$this->rewriteToAbsoluteUrls($navigation);
+			$navigation = $this->rewriteToAbsoluteUrls($navigation);
 		}
-		return new JSONResponse($navigation);
+		return new DataResponse($navigation);
 	}
 
 	/**
@@ -62,26 +62,28 @@ class NavigationController extends Controller {
 	 * @NoCSRFRequired
 	 *
 	 * @param bool $absolute
-	 * @return JSONResponse
+	 * @return DataResponse
 	 */
-	public function getSettingsNavigation(bool $absolute = false) {
+	public function getSettingsNavigation(bool $absolute = false): DataResponse {
 		$navigation = $this->navigationManager->getAll('settings');
 		if ($absolute) {
-			$this->rewriteToAbsoluteUrls($navigation);
+			$navigation = $this->rewriteToAbsoluteUrls($navigation);
 		}
-		return new JSONResponse($navigation);
+		return new DataResponse($navigation);
 	}
 
 	/**
 	 * Rewrite href attribute of navigation entries to an absolute URL
 	 *
 	 * @param array $navigation
+	 * @return array
 	 */
-	private function rewriteToAbsoluteUrls(array &$navigation) {
+	private function rewriteToAbsoluteUrls(array $navigation): array {
 		foreach ($navigation as &$entry) {
-			if (substr($entry['href'], 0, strlen($this->urlGenerator->getBaseUrl())) !== $this->urlGenerator->getBaseUrl()) {
+			if (0 !== strpos($entry['href'], $this->urlGenerator->getBaseUrl())) {
 				$entry['href'] = $this->urlGenerator->getAbsoluteURL($entry['href']);
 			}
 		}
+		return $navigation;
 	}
 }

--- a/core/Controller/NavigationController.php
+++ b/core/Controller/NavigationController.php
@@ -83,6 +83,9 @@ class NavigationController extends OCSController {
 			if (0 !== strpos($entry['href'], $this->urlGenerator->getBaseUrl())) {
 				$entry['href'] = $this->urlGenerator->getAbsoluteURL($entry['href']);
 			}
+			if (0 !== strpos($entry['icon'], $this->urlGenerator->getBaseUrl())) {
+				$entry['icon'] = $this->urlGenerator->getAbsoluteURL($entry['icon']);
+			}
 		}
 		return $navigation;
 	}

--- a/core/routes.php
+++ b/core/routes.php
@@ -59,6 +59,8 @@ $application->registerRoutes($this, [
 		['name' => 'OCJS#getConfig', 'url' => '/core/js/oc.js', 'verb' => 'GET'],
 		['name' => 'Preview#getPreviewByFileId', 'url' => '/core/preview', 'verb' => 'GET'],
 		['name' => 'Preview#getPreview', 'url' => '/core/preview.png', 'verb' => 'GET'],
+		['name' => 'Navigation#getAppsNavigation', 'url' => '/core/navigation/apps', 'verb' => 'GET'],
+		['name' => 'Navigation#getSettingsNavigation', 'url' => '/core/navigation/settings', 'verb' => 'GET'],
 		['name' => 'Css#getCss', 'url' => '/css/{appName}/{fileName}', 'verb' => 'GET'],
 		['name' => 'Js#getJs', 'url' => '/js/{appName}/{fileName}', 'verb' => 'GET'],
 		['name' => 'contactsMenu#index', 'url' => '/contactsmenu/contacts', 'verb' => 'POST'],

--- a/core/routes.php
+++ b/core/routes.php
@@ -59,8 +59,6 @@ $application->registerRoutes($this, [
 		['name' => 'OCJS#getConfig', 'url' => '/core/js/oc.js', 'verb' => 'GET'],
 		['name' => 'Preview#getPreviewByFileId', 'url' => '/core/preview', 'verb' => 'GET'],
 		['name' => 'Preview#getPreview', 'url' => '/core/preview.png', 'verb' => 'GET'],
-		['name' => 'Navigation#getAppsNavigation', 'url' => '/core/navigation/apps', 'verb' => 'GET'],
-		['name' => 'Navigation#getSettingsNavigation', 'url' => '/core/navigation/settings', 'verb' => 'GET'],
 		['name' => 'Css#getCss', 'url' => '/css/{appName}/{fileName}', 'verb' => 'GET'],
 		['name' => 'Js#getJs', 'url' => '/js/{appName}/{fileName}', 'verb' => 'GET'],
 		['name' => 'contactsMenu#index', 'url' => '/contactsmenu/contacts', 'verb' => 'POST'],
@@ -73,6 +71,8 @@ $application->registerRoutes($this, [
 		['root' => '', 'name' => 'OCS#getConfig', 'url' => '/config', 'verb' => 'GET'],
 		['root' => '/person', 'name' => 'OCS#personCheck', 'url' => '/check', 'verb' => 'POST'],
 		['root' => '/identityproof', 'name' => 'OCS#getIdentityProof', 'url' => '/key/{cloudId}', 'verb' => 'GET'],
+		['root' => '/core', 'name' => 'Navigation#getAppsNavigation', 'url' => '/navigation/apps', 'verb' => 'GET'],
+		['root' => '/core', 'name' => 'Navigation#getSettingsNavigation', 'url' => '/navigation/settings', 'verb' => 'GET'],
 	],
 ]);
 

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -521,6 +521,7 @@ return array(
     'OC\\Core\\Controller\\JsController' => $baseDir . '/core/Controller/JsController.php',
     'OC\\Core\\Controller\\LoginController' => $baseDir . '/core/Controller/LoginController.php',
     'OC\\Core\\Controller\\LostController' => $baseDir . '/core/Controller/LostController.php',
+    'OC\\Core\\Controller\\NavigationController' => $baseDir . '/core/Controller/NavigationController.php',
     'OC\\Core\\Controller\\OCJSController' => $baseDir . '/core/Controller/OCJSController.php',
     'OC\\Core\\Controller\\OCSController' => $baseDir . '/core/Controller/OCSController.php',
     'OC\\Core\\Controller\\PreviewController' => $baseDir . '/core/Controller/PreviewController.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -551,6 +551,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Core\\Controller\\JsController' => __DIR__ . '/../../..' . '/core/Controller/JsController.php',
         'OC\\Core\\Controller\\LoginController' => __DIR__ . '/../../..' . '/core/Controller/LoginController.php',
         'OC\\Core\\Controller\\LostController' => __DIR__ . '/../../..' . '/core/Controller/LostController.php',
+        'OC\\Core\\Controller\\NavigationController' => __DIR__ . '/../../..' . '/core/Controller/NavigationController.php',
         'OC\\Core\\Controller\\OCJSController' => __DIR__ . '/../../..' . '/core/Controller/OCJSController.php',
         'OC\\Core\\Controller\\OCSController' => __DIR__ . '/../../..' . '/core/Controller/OCSController.php',
         'OC\\Core\\Controller\\PreviewController' => __DIR__ . '/../../..' . '/core/Controller/PreviewController.php',

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -108,7 +108,7 @@ class NavigationManager implements INavigationManager {
 	 * @param string $type
 	 * @return array an array of the added entries
 	 */
-	public function getAll($type = 'link') {
+	public function getAll(string $type = 'link'): array {
 		$this->init();
 		foreach ($this->closureEntries as $c) {
 			$this->add($c());

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -115,14 +115,48 @@ class NavigationManager implements INavigationManager {
 		}
 		$this->closureEntries = array();
 
-		if ($type === 'all') {
-			return $this->entries;
+		$result = $this->entries;
+		if ($type !== 'all') {
+			$result = array_filter($this->entries, function($entry) use ($type) {
+				return $entry['type'] === $type;
+			});
 		}
 
-		return array_filter($this->entries, function($entry) use ($type) {
-			return $entry['type'] === $type;
-		});
+		return $this->proceedNavigation($result);
 	}
+
+	/**
+	 * Sort navigation entries by order, name and set active flag
+	 *
+	 * @param $list
+	 * @return mixed
+	 */
+	private function proceedNavigation($list) {
+		usort($list, function($a, $b) {
+			if (isset($a['order']) && isset($b['order'])) {
+				return ($a['order'] < $b['order']) ? -1 : 1;
+			} else if (isset($a['order']) || isset($b['order'])) {
+				return isset($a['order']) ? -1 : 1;
+			} else {
+				return ($a['name'] < $b['name']) ? -1 : 1;
+			}
+		});
+
+		$activeApp = $this->getActiveEntry();
+		if ($activeApp !== null) {
+			foreach ($list as $index => &$navEntry) {
+				if ($navEntry['id'] == $activeApp) {
+					$navEntry['active'] = true;
+				} else {
+					$navEntry['active'] = false;
+				}
+			}
+			unset($navEntry);
+		}
+
+		return $list;
+	}
+
 
 	/**
 	 * removes all the entries

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -104,9 +104,10 @@ class NavigationManager implements INavigationManager {
 	}
 
 	/**
-	 * returns all the added Menu entries
-	 * @param string $type
-	 * @return array an array of the added entries
+	 * Get a list of navigation entries
+	 *
+	 * @param string $type type of the navigation entries
+	 * @return array
 	 */
 	public function getAll(string $type = 'link'): array {
 		$this->init();
@@ -128,10 +129,10 @@ class NavigationManager implements INavigationManager {
 	/**
 	 * Sort navigation entries by order, name and set active flag
 	 *
-	 * @param $list
-	 * @return mixed
+	 * @param array $list
+	 * @return array
 	 */
-	private function proceedNavigation($list) {
+	private function proceedNavigation(array $list): array {
 		usort($list, function($a, $b) {
 			if (isset($a['order']) && isset($b['order'])) {
 				return ($a['order'] < $b['order']) ? -1 : 1;

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -80,9 +80,9 @@ class TemplateLayout extends \OC_Template {
 			// Add navigation entry
 			$this->assign( 'application', '');
 			$this->assign( 'appid', $appId );
-			$navigation = \OC_App::getNavigation();
+			$navigation = \OC::$server->getNavigationManager()->getAll();
 			$this->assign( 'navigation', $navigation);
-			$settingsNavigation = \OC_App::getSettingsNavigation();
+			$settingsNavigation = \OC::$server->getNavigationManager()->getAll('settings');
 			$this->assign( 'settingsnavigation', $settingsNavigation);
 			foreach($navigation as $entry) {
 				if ($entry['active']) {

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -443,31 +443,6 @@ class OC_App {
 		$appManager->disableApp($app);
 	}
 
-	// This is private as well. It simply works, so don't ask for more details
-	private static function proceedNavigation($list) {
-		usort($list, function($a, $b) {
-			if (isset($a['order']) && isset($b['order'])) {
-				return ($a['order'] < $b['order']) ? -1 : 1;
-			} else if (isset($a['order']) || isset($b['order'])) {
-				return isset($a['order']) ? -1 : 1;
-			} else {
-				return ($a['name'] < $b['name']) ? -1 : 1;
-			}
-		});
-
-		$activeApp = OC::$server->getNavigationManager()->getActiveEntry();
-		foreach ($list as $index => &$navEntry) {
-			if ($navEntry['id'] == $activeApp) {
-				$navEntry['active'] = true;
-			} else {
-				$navEntry['active'] = false;
-			}
-		}
-		unset($navEntry);
-
-		return $list;
-	}
-
 	/**
 	 * Get the path where to install apps
 	 *
@@ -618,8 +593,7 @@ class OC_App {
 	 *   - active: boolean, signals if the user is on this navigation entry
 	 */
 	public static function getNavigation() {
-		$entries = OC::$server->getNavigationManager()->getAll();
-		return self::proceedNavigation($entries);
+		return OC::$server->getNavigationManager()->getAll();
 	}
 
 	/**
@@ -631,8 +605,7 @@ class OC_App {
 	 * entries are sorted by the key 'order' ascending.
 	 */
 	public static function getSettingsNavigation() {
-		$entries = OC::$server->getNavigationManager()->getAll('settings');
-		return self::proceedNavigation($entries);
+		return OC::$server->getNavigationManager()->getAll('settings');
 	}
 
 	/**

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -586,6 +586,7 @@ class OC_App {
 	 * Returns the navigation
 	 *
 	 * @return array
+	 * @deprecated 14.0.0 use \OC::$server->getNavigationManager()->getAll()
 	 *
 	 * This function returns an array containing all entries added. The
 	 * entries are sorted by the key 'order' ascending. Additional to the keys
@@ -600,6 +601,7 @@ class OC_App {
 	 * Returns the Settings Navigation
 	 *
 	 * @return string[]
+	 * @deprecated 14.0.0 use \OC::$server->getNavigationManager()->getAll('settings')
 	 *
 	 * This function returns an array containing all settings pages added. The
 	 * entries are sorted by the key 'order' ascending.

--- a/lib/public/INavigationManager.php
+++ b/lib/public/INavigationManager.php
@@ -57,4 +57,13 @@ interface INavigationManager {
 	 * @since 6.0.0
 	 */
 	public function setActiveEntry($appId);
+
+	/**
+	 * Get a list of navigation entries
+	 *
+	 * @param bool $absolute set to true if links to navigation entries should be converted to absolute urls
+	 * @return array
+	 * @since 14.0.0
+	 */
+	public function getAll(string $type = 'link'): array;
 }

--- a/lib/public/INavigationManager.php
+++ b/lib/public/INavigationManager.php
@@ -61,7 +61,7 @@ interface INavigationManager {
 	/**
 	 * Get a list of navigation entries
 	 *
-	 * @param bool $absolute set to true if links to navigation entries should be converted to absolute urls
+	 * @param string $type type of the navigation entries
 	 * @return array
 	 * @since 14.0.0
 	 */

--- a/settings/ajax/navigationdetect.php
+++ b/settings/ajax/navigationdetect.php
@@ -23,6 +23,6 @@
 OC_Util::checkAdminUser();
 OCP\JSON::callCheck();
 
-$navigation = \OC_App::getNavigation();
+$navigation = \OC::$server->getNavigationManager()->getAll();
 
 OCP\JSON::success(['nav_entries' => $navigation]);

--- a/tests/Core/Controller/NavigationControllerTest.php
+++ b/tests/Core/Controller/NavigationControllerTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace Tests\Core\Controller;
+
+use OC\Core\Controller\NavigationController;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\INavigationManager;
+use OCP\IRequest;
+use Test\TestCase;
+
+class NavigationControllerTest extends TestCase {
+
+	/** @var IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	private $request;
+
+	/** @var INavigationManager|\PHPUnit_Framework_MockObject_MockObject */
+	private $navigationManager;
+
+	/** @var NavigationController */
+	private $controller;
+
+	public function setUp() {
+		parent::setUp();
+
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->navigationManager = $this->createMock(INavigationManager::class);
+
+		$this->controller = new NavigationController(
+			'core',
+			$this->request,
+			$this->navigationManager
+		);
+	}
+
+	public function dataGetNavigation() {
+		return [
+			[false], [true]
+		];
+	}
+	/** @dataProvider dataGetNavigation */
+	public function testGetAppNavigation($absolute) {
+		$this->navigationManager->expects($this->once())
+			->method('getAll')
+			->with('link', $absolute);
+		$this->assertInstanceOf(JSONResponse::class, $this->controller->getAppsNavigation($absolute));
+	}
+
+	/** @dataProvider dataGetNavigation */
+	public function testGetSettingsNavigation($absolute) {
+		$this->navigationManager->expects($this->once())
+			->method('getAll')
+			->with('settings', $absolute);
+		$this->assertInstanceOf(JSONResponse::class, $this->controller->getSettingsNavigation($absolute));
+	}
+
+}

--- a/tests/Core/Controller/NavigationControllerTest.php
+++ b/tests/Core/Controller/NavigationControllerTest.php
@@ -23,7 +23,7 @@
 namespace Tests\Core\Controller;
 
 use OC\Core\Controller\NavigationController;
-use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\DataResponse;
 use OCP\INavigationManager;
 use OCP\IRequest;
 use OCP\IURLGenerator;
@@ -78,11 +78,11 @@ class NavigationControllerTest extends TestCase {
 				->with('/index.php/apps/files')
 				->willReturn('http://localhost/index.php/apps/files');
 			$actual = $this->controller->getAppsNavigation($absolute);
-			$this->assertInstanceOf(JSONResponse::class, $actual);
+			$this->assertInstanceOf(DataResponse::class, $actual);
 			$this->assertEquals('http://localhost/index.php/apps/files', $actual->getData()[0]['href']);
 		} else {
 			$actual = $this->controller->getAppsNavigation($absolute);
-			$this->assertInstanceOf(JSONResponse::class, $actual);
+			$this->assertInstanceOf(DataResponse::class, $actual);
 			$this->assertEquals('/index.php/apps/files', $actual->getData()[0]['href']);
 		}
 	}
@@ -102,11 +102,11 @@ class NavigationControllerTest extends TestCase {
 				->with('/index.php/settings/user')
 				->willReturn('http://localhost/index.php/settings/user');
 			$actual = $this->controller->getSettingsNavigation($absolute);
-			$this->assertInstanceOf(JSONResponse::class, $actual);
+			$this->assertInstanceOf(DataResponse::class, $actual);
 			$this->assertEquals('http://localhost/index.php/settings/user', $actual->getData()[0]['href']);
 		} else {
 			$actual = $this->controller->getSettingsNavigation($absolute);
-			$this->assertInstanceOf(JSONResponse::class, $actual);
+			$this->assertInstanceOf(DataResponse::class, $actual);
 			$this->assertEquals('/index.php/settings/user', $actual->getData()[0]['href']);
 		}
 	}

--- a/tests/Core/Controller/NavigationControllerTest.php
+++ b/tests/Core/Controller/NavigationControllerTest.php
@@ -68,22 +68,31 @@ class NavigationControllerTest extends TestCase {
 		$this->navigationManager->expects($this->once())
 			->method('getAll')
 			->with('link')
-			->willReturn([ ['id' => 'files', 'href' => '/index.php/apps/files'] ]);
+			->willReturn([ ['id' => 'files', 'href' => '/index.php/apps/files', 'icon' => 'icon' ] ]);
 		if ($absolute) {
 			$this->urlGenerator->expects($this->any())
 				->method('getBaseURL')
 				->willReturn('http://localhost/');
-			$this->urlGenerator->expects($this->once())
+			$this->urlGenerator->expects($this->at(1))
 				->method('getAbsoluteURL')
 				->with('/index.php/apps/files')
 				->willReturn('http://localhost/index.php/apps/files');
+			$this->urlGenerator->expects($this->at(3))
+				->method('getAbsoluteURL')
+				->with('icon')
+				->willReturn('http://localhost/icon');
 			$actual = $this->controller->getAppsNavigation($absolute);
 			$this->assertInstanceOf(DataResponse::class, $actual);
 			$this->assertEquals('http://localhost/index.php/apps/files', $actual->getData()[0]['href']);
+			$this->assertEquals('http://localhost/icon', $actual->getData()[0]['icon']);
+
+
 		} else {
 			$actual = $this->controller->getAppsNavigation($absolute);
 			$this->assertInstanceOf(DataResponse::class, $actual);
 			$this->assertEquals('/index.php/apps/files', $actual->getData()[0]['href']);
+			$this->assertEquals('icon', $actual->getData()[0]['icon']);
+
 		}
 	}
 
@@ -92,22 +101,28 @@ class NavigationControllerTest extends TestCase {
 		$this->navigationManager->expects($this->once())
 			->method('getAll')
 			->with('settings')
-			->willReturn([ ['id' => 'settings', 'href' => '/index.php/settings/user'] ]);
+			->willReturn([ ['id' => 'settings', 'href' => '/index.php/settings/user', 'icon' => '/core/img/settings.svg'] ]);
 		if ($absolute) {
 			$this->urlGenerator->expects($this->any())
 				->method('getBaseURL')
 				->willReturn('http://localhost/');
-			$this->urlGenerator->expects($this->once())
+			$this->urlGenerator->expects($this->at(1))
 				->method('getAbsoluteURL')
 				->with('/index.php/settings/user')
 				->willReturn('http://localhost/index.php/settings/user');
+			$this->urlGenerator->expects($this->at(3))
+				->method('getAbsoluteURL')
+				->with('/core/img/settings.svg')
+				->willReturn('http://localhost/core/img/settings.svg');
 			$actual = $this->controller->getSettingsNavigation($absolute);
 			$this->assertInstanceOf(DataResponse::class, $actual);
 			$this->assertEquals('http://localhost/index.php/settings/user', $actual->getData()[0]['href']);
+			$this->assertEquals('http://localhost/core/img/settings.svg', $actual->getData()[0]['icon']);
 		} else {
 			$actual = $this->controller->getSettingsNavigation($absolute);
 			$this->assertInstanceOf(DataResponse::class, $actual);
 			$this->assertEquals('/index.php/settings/user', $actual->getData()[0]['href']);
+			$this->assertEquals('/core/img/settings.svg', $actual->getData()[0]['icon']);
 		}
 	}
 

--- a/tests/lib/NavigationManagerTest.php
+++ b/tests/lib/NavigationManagerTest.php
@@ -284,7 +284,7 @@ class NavigationManagerTest extends TestCase {
 			],
 		];
 		return [
-			'minimalistic' => [array_merge($defaults, [[
+			'minimalistic' => [array_merge([$defaults[0]], [[
 				'id' => 'test',
 				'order' => 100,
 				'href' => '/apps/test/',
@@ -293,8 +293,8 @@ class NavigationManagerTest extends TestCase {
 				'active' => false,
 				'type' => 'link',
 				'classes' => '',
-			]]), ['navigations' => [['route' => 'test.page.index', 'name' => 'Test']]]],
-			'minimalistic-settings' => [array_merge($defaults, [[
+			]], [$defaults[1]]), ['navigations' => [['route' => 'test.page.index', 'name' => 'Test']]]],
+			'minimalistic-settings' => [array_merge([$defaults[0]], [[
 				'id' => 'test',
 				'order' => 100,
 				'href' => '/apps/test/',
@@ -303,8 +303,8 @@ class NavigationManagerTest extends TestCase {
 				'active' => false,
 				'type' => 'settings',
 				'classes' => '',
-			]]), ['navigations' => [['route' => 'test.page.index', 'name' => 'Test', 'type' => 'settings']]]],
-			'admin' => [array_merge($apps, $defaults, [[
+			]], [$defaults[1]]), ['navigations' => [['route' => 'test.page.index', 'name' => 'Test', 'type' => 'settings']]]],
+			'admin' => [array_merge([$defaults[0]], $apps, [[
 				'id' => 'test',
 				'order' => 100,
 				'href' => '/apps/test/',
@@ -313,8 +313,8 @@ class NavigationManagerTest extends TestCase {
 				'active' => false,
 				'type' => 'link',
 				'classes' => '',
-			]]), ['navigations' => [['@attributes' => ['role' => 'admin'], 'route' => 'test.page.index', 'name' => 'Test']]], true],
-			'no name' => [array_merge($apps, $defaults), ['navigations' => [['@attributes' => ['role' => 'admin'], 'route' => 'test.page.index']]], true],
+			]], [$defaults[1]]), ['navigations' => [['@attributes' => ['role' => 'admin'], 'route' => 'test.page.index', 'name' => 'Test']]], true],
+			'no name' => [array_merge([$defaults[0]], $apps, [$defaults[1]]), ['navigations' => [['@attributes' => ['role' => 'admin'], 'route' => 'test.page.index']]], true],
 			'no admin' => [$defaults, ['navigations' => [['@attributes' => ['role' => 'admin'], 'route' => 'test.page.index', 'name' => 'Test']]]]
 		];
 	}


### PR DESCRIPTION
This PR adds new endpoints to get the navigation entries for the app and settings menu, as discussed in #7893. This will make it possible for clients to fetch the list of available "web apps" but also use this in apps management to update the app menu when installing/uninstalling an app. I'll do that in a separate PR once this is merged.

@camilasan 

<details>
<summary>Example request: apps</summary>

```
$ curl http://admin:admin@localhost:8140/index.php/core/navigation/apps 
[
  {
    "id": "files",
    "order": "0",
    "href": "/index.php/apps/files/",
    "icon": "/apps/files/img/app.svg",
    "type": "link",
    "name": "Dateien",
    "active": false,
    "classes": ""
  },
  {
    "id": "activity",
    "order": "1",
    "href": "/index.php/apps/activity/",
    "icon": "/apps/activity/img/activity.svg",
    "type": "link",
    "name": "Aktivität",
    "active": false,
    "classes": ""
  },
  {
    "id": "gallery",
    "order": 2,
    "href": "/index.php/apps/gallery/",
    "icon": "/apps/gallery/img/app.svg",
    "name": "Galerie",
    "active": false,
    "classes": "",
    "type": "link"
  },
  {
    "id": "deck",
    "order": 10,
    "href": "/index.php/apps/deck/",
    "icon": "/apps-extra/deck/img/deck.svg",
    "name": "Deck",
    "active": false,
    "classes": "",
    "type": "link"
  }
]
```
</details>