### PR TITLE
Deprecate static methods from  \OCP\App

### DIFF
--- a/apps/dav/tests/unit/AppInfo/PluginManagerTest.php
+++ b/apps/dav/tests/unit/AppInfo/PluginManagerTest.php
@@ -72,8 +72,8 @@ class PluginManagerTest extends TestCase {
 
 		$appManager->method('getAppInfo')
 			->will($this->returnValueMap([
-				['adavapp', $appInfo1],
-				['adavapp2', $appInfo2],
+				['adavapp', false, null, $appInfo1],
+				['adavapp2', false, null, $appInfo2],
 			]));
 
 		$pluginManager = new PluginManager($server, $appManager);

--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -268,7 +268,7 @@ class Storage extends Wrapper {
 	 */
 	private function doDelete($path, $method, $ownerOnly = false) {
 		if (self::$disableTrash
-			|| !\OC_App::isEnabled('files_trashbin')
+			|| !\OC::$server->getAppManager()->isEnabledForUser('files_trashbin')
 			|| (pathinfo($path, PATHINFO_EXTENSION) === 'part')
 			|| $this->shouldMoveToTrash($path) === false
 		) {

--- a/lib/private/App/CodeChecker/DeprecationCheck.php
+++ b/lib/private/App/CodeChecker/DeprecationCheck.php
@@ -46,6 +46,7 @@ class DeprecationCheck extends AbstractCheck {
 			'OCP\AppFramework\IApi' => '8.0.0',
 			'OCP\User' => '13.0.0',
 			'OCP\BackgroundJob' => '14.0.0',
+			'OCP\App' => '14.0.0',
 		];
 	}
 
@@ -102,6 +103,13 @@ class DeprecationCheck extends AbstractCheck {
 			'OCP\App::addNavigationEntry' => '8.1.0',
 			'OCP\App::getActiveNavigationEntry' => '8.2.0',
 			'OCP\App::setActiveNavigationEntry' => '8.1.0',
+			'OCP\App::registerPersonal' => '14.0.0',
+			'OCP\App::registerAdmin' => '14.0.0',
+			'OC_App::getAppInfo' => '14.0.0',
+			'OCP\App::getAppInfo' => '14.0.0',
+			'OC_App::getAppVersion' => '14.0.0',
+			'OCP\App::getAppVersion' => '14.0.0',
+			'OCP\App::registerPersonal' => '14.0.0',
 
 			'OCP\AppFramework\Controller::params' => '7.0.0',
 			'OCP\AppFramework\Controller::getParams' => '7.0.0',

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -471,6 +471,9 @@ class Installer {
 	 */
 	public function removeApp($appId) {
 		if($this->isDownloaded( $appId )) {
+			if (\OC::$server->getAppManager()->isShipped($appId)) {
+				return false;
+			}
 			$appDir = OC_App::getInstallPath() . '/' . $appId;
 			OC_Helper::rmdirr($appDir);
 			return true;

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -420,19 +420,6 @@ class OC_App {
 	}
 
 	/**
-	 * @param string $app
-	 * @return bool
-	 */
-	public static function removeApp($app) {
-		if (\OC::$server->getAppManager()->isShipped($app)) {
-			return false;
-		}
-
-		$installer = \OC::$server->query(Installer::class);
-		return $installer->removeApp($app);
-	}
-
-	/**
 	 * This function set an app as disabled in appconfig.
 	 *
 	 * @param string $app app

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -950,63 +950,6 @@ class OC_App {
 	}
 
 	/**
-	 * @param string $app
-	 * @param \OCP\IConfig $config
-	 * @param \OCP\IL10N $l
-	 * @return bool
-	 *
-	 * @throws Exception if app is not compatible with this version of ownCloud
-	 * @throws Exception if no app-name was specified
-	 */
-	public function installApp($app,
-							   \OCP\IConfig $config,
-							   \OCP\IL10N $l) {
-		if ($app !== false) {
-			// check if the app is compatible with this version of ownCloud
-			$info = self::getAppInfo($app);
-			if(!is_array($info)) {
-				throw new \Exception(
-					$l->t('App "%s" cannot be installed because appinfo file cannot be read.',
-						[$info['name']]
-					)
-				);
-			}
-
-			$version = \OCP\Util::getVersion();
-			if (!self::isAppCompatible($version, $info)) {
-				throw new \Exception(
-					$l->t('App "%s" cannot be installed because it is not compatible with this version of the server.',
-						array($info['name'])
-					)
-				);
-			}
-
-			// check for required dependencies
-			self::checkAppDependencies($config, $l, $info);
-
-			$config->setAppValue($app, 'enabled', 'yes');
-			if (isset($appData['id'])) {
-				$config->setAppValue($app, 'ocsid', $appData['id']);
-			}
-
-			if(isset($info['settings']) && is_array($info['settings'])) {
-				$appPath = self::getAppPath($app);
-				self::registerAutoloading($app, $appPath);
-			}
-
-			\OC_Hook::emit('OC_App', 'post_enable', array('app' => $app));
-		} else {
-			if(empty($appName) ) {
-				throw new \Exception($l->t("No app name specified"));
-			} else {
-				throw new \Exception($l->t("App '%s' could not be installed!", $appName));
-			}
-		}
-
-		return $app;
-	}
-
-	/**
 	 * update the database for the app and call the update script
 	 *
 	 * @param string $appId

--- a/lib/public/App.php
+++ b/lib/public/App.php
@@ -40,52 +40,10 @@ namespace OCP;
 /**
  * This class provides functions to manage apps in ownCloud
  * @since 4.0.0
+ * @deprecated 14.0.0
  */
 class App {
 
-	/**
-	 * Adds an entry to the navigation
-	 *
-	 * This function adds a new entry to the navigation visible to users. $data
-	 * is an associative array.
-	 * The following keys are required:
-	 *   - id: unique id for this entry ('addressbook_index')
-	 *   - href: link to the page
-	 *   - name: Human readable name ('Addressbook')
-	 *
-	 * The following keys are optional:
-	 *   - icon: path to the icon of the app
-	 *   - order: integer, that influences the position of your application in
-	 *     the navigation. Lower values come first.
-	 *
-	 * @param array $data containing the data
-	 * @return boolean
-	 *
-	 * @deprecated 8.1.0 Use \OC::$server->getNavigationManager()->add() instead to
-	 * register a closure, this helps to speed up all requests against ownCloud
-	 * @since 4.0.0
-	 */
-	public static function addNavigationEntry($data) {
-		\OC::$server->getNavigationManager()->add($data);
-		return true;
-	}
-
-	/**
-	 * Marks a navigation entry as active
-	 * @param string $id id of the entry
-	 * @return boolean
-	 *
-	 * This function sets a navigation entry as active and removes the 'active'
-	 * property from all other entries. The templates can use this for
-	 * highlighting the current position of the user.
-	 *
-	 * @deprecated 8.1.0 Use \OC::$server->getNavigationManager()->setActiveEntry() instead
-	 * @since 4.0.0
-	 */
-	public static function setActiveNavigationEntry( $id ) {
-		\OC::$server->getNavigationManager()->setActiveEntry($id);
-		return true;
-	}
 
 	/**
 	 * Register a Configuration Screen that should appear in the personal settings section.
@@ -93,6 +51,7 @@ class App {
 	 * @param string $page page to be included
 	 * @return void
 	 * @since 4.0.0
+	 * @deprecated 14.0.0 Use settings section in appinfo.xml to register personal admin sections
 	*/
 	public static function registerPersonal( $app, $page ) {
 		\OC_App::registerPersonal( $app, $page );
@@ -104,6 +63,7 @@ class App {
 	 * @param string $page string page to be included
 	 * @return void
 	 * @since 4.0.0
+	 * @deprecated 14.0.0 Use settings section in appinfo.xml to register admin sections
 	 */
 	public static function registerAdmin( $app, $page ) {
 		\OC_App::registerAdmin( $app, $page );

--- a/lib/public/App.php
+++ b/lib/public/App.php
@@ -114,6 +114,7 @@ class App {
 	 * @param string $app id of the app or the path of the info.xml file
 	 * @param boolean $path (optional)
 	 * @return array|null
+	 * @deprecated 14.0.0 ise \OC::$server->getAppManager()->getAppInfo($appId)
 	 * @since 4.0.0
 	*/
 	public static function getAppInfo( $app, $path=false ) {
@@ -148,8 +149,9 @@ class App {
 	 * @param string $app
 	 * @return string
 	 * @since 4.0.0
+	 * @deprecated 14.0.0 use \OC::$server->getAppManager()->getAppVersion($appId)
 	 */
 	public static function getAppVersion( $app ) {
-		return \OC_App::getAppVersion( $app );
+		return \OC::$server->getAppManager()->getAppVersion($app);
 	}
 }

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -36,6 +36,26 @@ use OCP\IUser;
  * @since 8.0.0
  */
 interface IAppManager {
+
+	/**
+	 * Returns the app information from "appinfo/info.xml".
+	 *
+	 * @param string $appId
+	 * @return mixed
+	 * @since 14.0.0
+	 */
+	public function getAppInfo(string $appId, bool $path = false, $lang = null);
+
+	/**
+	 * Returns the app information from "appinfo/info.xml".
+	 *
+	 * @param string $appId
+	 * @param bool $useCache
+	 * @return mixed
+	 * @since 14.0.0
+	 */
+	public function getAppVersion(string $appId, bool $useCache = true);
+
 	/**
 	 * Check if an app is enabled for user
 	 *

--- a/settings/ajax/uninstallapp.php
+++ b/settings/ajax/uninstallapp.php
@@ -40,7 +40,10 @@ if (!array_key_exists('appid', $_POST)) {
 $appId = (string)$_POST['appid'];
 $appId = OC_App::cleanAppId($appId);
 
-$result = OC_App::removeApp($appId);
+// FIXME: move to controller
+/** @var \OC\Installer $installer */
+$installer = \OC::$server->query(\OC\Installer::class);
+$result = $installer->removeApp($app);
 if($result !== false) {
 	// FIXME: Clear the cache - move that into some sane helper method
 	\OC::$server->getMemCacheFactory()->createDistributed('settings')->remove('listApps-0');

--- a/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
@@ -172,14 +172,14 @@ class ManagerTest extends TestCase {
 			->method('getAppInfo')
 			->will($this->returnValueMap([
 					[
-						'mycustom2faapp',
+						'mycustom2faapp', false, null,
 						['two-factor-providers' => [
 								'\OCA\MyCustom2faApp\FakeProvider',
 							]
 						]
 					],
 					[
-						'twofactor_backupcodes',
+						'twofactor_backupcodes', false, null,
 						['two-factor-providers' => [
 								'\OCA\TwoFactorBackupCodes\Provider\FakeBackupCodesProvider',
 							]


### PR DESCRIPTION
This PR deprecates static methods of \OCP\App and moves getAppInfo and getAppVersion to the AppManager.