### PR TITLE
Fix integer overflow in ChunkingPlugin

### DIFF
--- a/apps/dav/lib/Upload/ChunkingPlugin.php
+++ b/apps/dav/lib/Upload/ChunkingPlugin.php
@@ -97,7 +97,10 @@ class ChunkingPlugin extends ServerPlugin {
 			return;
 		}
 		$actualSize = $this->sourceNode->getSize();
-		if ((int)$expectedSize !== $actualSize) {
+
+		// casted to string because cast to float cause equality for non equal numbers
+		// and integer has the problem of limited size on 32 bit systems
+		if ((string)$expectedSize !== (string)$actualSize) {
 			throw new BadRequest("Chunks on server do not sum up to $expectedSize but to $actualSize bytes");
 		}
 	}


### PR DESCRIPTION
Avoids errors when the size exceeds MAX_INT because of the cast to int. Better cast it to float to avoid this.

Fix #7948 and https://github.com/nextcloud/server/pull/8109#issuecomment-361565581


@nariox @pasxalisk Could you check if this fixes the issue for you?