### PR TITLE
[stable13] Only handle encrypted property on folders

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -339,11 +339,6 @@ class FilesPlugin extends ServerPlugin {
 				}
 			});
 
-			$propFind->handle(self::IS_ENCRYPTED_PROPERTYNAME, function() use ($node) {
-				$result = $node->getFileInfo()->isEncrypted() ? '1' : '0';
-				return $result;
-			});
-
 			$propFind->handle(self::HAS_PREVIEW_PROPERTYNAME, function () use ($node) {
 				return json_encode($this->previewManager->isAvailable($node->getFileInfo()));
 			});
@@ -391,6 +386,10 @@ class FilesPlugin extends ServerPlugin {
 		if ($node instanceof \OCA\DAV\Connector\Sabre\Directory) {
 			$propFind->handle(self::SIZE_PROPERTYNAME, function() use ($node) {
 				return $node->getSize();
+			});
+
+			$propFind->handle(self::IS_ENCRYPTED_PROPERTYNAME, function() use ($node) {
+				return $node->getFileInfo()->isEncrypted() ? '1' : '0';
 			});
 		}
 	}


### PR DESCRIPTION
Backport of #8111 

Exposing the encrypted property is required for E2E. However, there is
no need to expose this on files as then it is server side encryption
(which the clients don't care about).

Better to not confuse the output.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>