### PR TITLE
fix reading the ldapIgnoreNamingRule config value

### DIFF
--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -531,6 +531,7 @@ class Configuration {
 			'ldap_experienced_admin'            => 'ldapExperiencedAdmin',
 			'ldap_dynamic_group_member_url'     => 'ldapDynamicGroupMemberURL',
 			'ldap_default_ppolicy_dn'           => 'ldapDefaultPPolicyDN',
+			'ldapIgnoreNamingRules'             => 'ldapIgnoreNamingRules',	// syconfig
 		);
 		return $array;
 	}

--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -531,7 +531,7 @@ class Configuration {
 			'ldap_experienced_admin'            => 'ldapExperiencedAdmin',
 			'ldap_dynamic_group_member_url'     => 'ldapDynamicGroupMemberURL',
 			'ldap_default_ppolicy_dn'           => 'ldapDefaultPPolicyDN',
-			'ldapIgnoreNamingRules'             => 'ldapIgnoreNamingRules',	// syconfig
+			'ldapIgnoreNamingRules'             => 'ldapIgnoreNamingRules',	// sysconfig
 		);
 		return $array;
 	}


### PR DESCRIPTION
fixes #6851 

How to test: with 'ldapIgnoreNamingRules' set to true in config.php new LDAP user names ignore constraints (e.g. conversion to ascii or replacing anything but letters, numbers and some chars).