### PR TITLE
Update iOS link to geo-detect & show correct store listing

### DIFF
--- a/lib/private/legacy/defaults.php
+++ b/lib/private/legacy/defaults.php
@@ -60,7 +60,7 @@ class OC_Defaults {
 		$this->defaultTitle = 'Nextcloud'; /* can be a longer name, for titles */
 		$this->defaultBaseUrl = 'https://nextcloud.com';
 		$this->defaultSyncClientUrl = 'https://nextcloud.com/install/#install-clients';
-		$this->defaultiOSClientUrl = 'https://itunes.apple.com/us/app/nextcloud/id1125420102?mt=8';
+		$this->defaultiOSClientUrl = 'https://geo.itunes.apple.com/us/app/nextcloud/id1125420102?mt=8';
 		$this->defaultiTunesAppId = '1125420102';
 		$this->defaultAndroidClientUrl = 'https://play.google.com/store/apps/details?id=com.nextcloud.client';
 		$this->defaultDocBaseUrl = 'https://docs.nextcloud.com';

--- a/themes/example/defaults.php
+++ b/themes/example/defaults.php
@@ -41,7 +41,7 @@ class OC_Theme {
 	 * @return string URL
 	 */
 	public function getiOSClientUrl() {
-		return 'https://itunes.apple.com/us/app/nextcloud/id1125420102?mt=8';
+		return 'https://geo.itunes.apple.com/us/app/nextcloud/id1125420102?mt=8';
 	}
 
 	/**


### PR DESCRIPTION
Adding 'geo.' at beginning of the URL will automatically show users the store listing for their region so it's a better experience.

For example users in Japan will see: https://itunes.apple.com/jp/app/nextcloud/id1125420102?mt=8 which has local customer reviews and certain other information in Japanese.

Signed-off-by: Christian Oliff <christian@christianoliff.com>