### PR TITLE
Use correct update server

### DIFF
--- a/apps/updatenotification/lib/Settings/Admin.php
+++ b/apps/updatenotification/lib/Settings/Admin.php
@@ -77,7 +77,7 @@ class Admin implements ISettings {
 
 		$notifyGroups = json_decode($this->config->getAppValue('updatenotification', 'notify_groups', '["admin"]'), true);
 
-		$defaultUpdateServerURL = 'https://updates.nextcloud.com/server/';
+		$defaultUpdateServerURL = 'https://updates.nextcloud.com/updater_server/';
 		$updateServerURL = $this->config->getSystemValue('updater.server.url', $defaultUpdateServerURL);
 
 		$params = [

--- a/apps/updatenotification/tests/Settings/AdminTest.php
+++ b/apps/updatenotification/tests/Settings/AdminTest.php
@@ -81,8 +81,8 @@ class AdminTest extends TestCase {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
-			->with('updater.server.url', 'https://updates.nextcloud.com/server/')
-			->willReturn('https://updates.nextcloud.com/server/');
+			->with('updater.server.url', 'https://updates.nextcloud.com/updater_server/')
+			->willReturn('https://updates.nextcloud.com/updater_server/');
 		$this->dateTimeFormatter
 			->expects($this->once())
 			->method('formatDateTime')
@@ -108,7 +108,7 @@ class AdminTest extends TestCase {
 			'downloadLink' => 'https://downloads.nextcloud.org/server',
 			'updaterEnabled' => true,
 			'isDefaultUpdateServerURL' => true,
-			'updateServerURL' => 'https://updates.nextcloud.com/server/',
+			'updateServerURL' => 'https://updates.nextcloud.com/updater_server/',
 			'notify_groups' => 'admin',
 		];
 


### PR DESCRIPTION
Found here: https://help.nextcloud.com/t/call-for-testing-nextcloud-13-0-0-rc4/25435/77?u=morrisjobke

When the config.php has the update server set to the default one:

```
	'updater.server.url' => 'https://updates.nextcloud.com/updater_server/',
```

Then the warning that the non-default update server is in use was wrongly shown. 

See https://github.com/nextcloud/server/blob/1beffa058a493a0c9f36a0280fb9e5e354e0d066/lib/private/Updater/VersionCheck.php#L62