### PR TITLE
Repair step to clear frontend related caches

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -802,6 +802,7 @@ return array(
     'OC\\Repair' => $baseDir . '/lib/private/Repair.php',
     'OC\\RepairException' => $baseDir . '/lib/private/RepairException.php',
     'OC\\Repair\\CleanTags' => $baseDir . '/lib/private/Repair/CleanTags.php',
+    'OC\\Repair\\ClearFrontendCaches' => $baseDir . '/lib/private/Repair/ClearFrontendCaches.php',
     'OC\\Repair\\Collation' => $baseDir . '/lib/private/Repair/Collation.php',
     'OC\\Repair\\MoveUpdaterStepFile' => $baseDir . '/lib/private/Repair/MoveUpdaterStepFile.php',
     'OC\\Repair\\NC11\\FixMountStorages' => $baseDir . '/lib/private/Repair/NC11/FixMountStorages.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -832,6 +832,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Repair' => __DIR__ . '/../../..' . '/lib/private/Repair.php',
         'OC\\RepairException' => __DIR__ . '/../../..' . '/lib/private/RepairException.php',
         'OC\\Repair\\CleanTags' => __DIR__ . '/../../..' . '/lib/private/Repair/CleanTags.php',
+        'OC\\Repair\\ClearFrontendCaches' => __DIR__ . '/../../..' . '/lib/private/Repair/ClearFrontendCaches.php',
         'OC\\Repair\\Collation' => __DIR__ . '/../../..' . '/lib/private/Repair/Collation.php',
         'OC\\Repair\\MoveUpdaterStepFile' => __DIR__ . '/../../..' . '/lib/private/Repair/MoveUpdaterStepFile.php',
         'OC\\Repair\\NC11\\FixMountStorages' => __DIR__ . '/../../..' . '/lib/private/Repair/NC11/FixMountStorages.php',

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -33,6 +33,7 @@ namespace OC;
 use OC\App\AppStore\Bundles\BundleFetcher;
 use OC\Files\AppData\Factory;
 use OC\Repair\CleanTags;
+use OC\Repair\ClearFrontendCaches;
 use OC\Repair\Collation;
 use OC\Repair\MoveUpdaterStepFile;
 use OC\Repair\NC11\FixMountStorages;
@@ -45,6 +46,8 @@ use OC\Repair\NC13\RepairInvalidPaths;
 use OC\Repair\SqliteAutoincrement;
 use OC\Repair\RepairMimeTypes;
 use OC\Repair\RepairInvalidShares;
+use OC\Template\JSCombiner;
+use OC\Template\SCSSCacher;
 use OCP\AppFramework\QueryException;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -131,6 +134,7 @@ class Repair implements IOutput{
 			new FixMountStorages(\OC::$server->getDatabaseConnection()),
 			new RepairInvalidPaths(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig()),
 			new AddLogRotateJob(\OC::$server->getJobList()),
+			new ClearFrontendCaches(\OC::$server->getMemCacheFactory(), \OC::$server->query(SCSSCacher::class), \OC::$server->query(JSCombiner::class))
 		];
 	}
 

--- a/lib/private/Repair/ClearFrontendCaches.php
+++ b/lib/private/Repair/ClearFrontendCaches.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Repair;
+
+use OC\Core\Command\Maintenance\ClearCacheJSCSS;
+use OC\Template\JSCombiner;
+use OC\Template\SCSSCacher;
+use OCP\AppFramework\QueryException;
+use OCP\ICacheFactory;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class ClearFrontendCaches implements IRepairStep {
+
+	/** @var ICacheFactory */
+	protected $cacheFactory;
+
+	/** @var SCSSCacher */
+	protected $scssCacher;
+
+	/** @var JSCombiner */
+	protected $jsCombiner;
+
+	public function __construct(ICacheFactory $cacheFactory,
+								SCSSCacher $SCSSCacher,
+								JSCombiner $JSCombiner) {
+		$this->cacheFactory = $cacheFactory;
+		$this->scssCacher = $SCSSCacher;
+		$this->jsCombiner = $JSCombiner;
+	}
+
+	public function getName() {
+		return 'Clear frontend caches';
+	}
+
+	public function run(IOutput $output) {
+		try {
+			$c = $this->cacheFactory->createDistributed('imagePath');
+			$c->clear('');
+			$output->info('Image cache cleared');
+
+			$this->scssCacher->resetCache();
+			$c = $this->cacheFactory->createDistributed('SCSS');
+			$c->clear('');
+			$output->info('SCSS cache cleared');
+
+			$this->jsCombiner->resetCache();
+			$c = $this->cacheFactory->createDistributed('JS');
+			$c->clear('');
+			$output->info('JS cache cleared');
+		} catch (\Exception $e) {
+			$output->warning('Unable to clear the frontend cache');
+		}
+	}
+}

--- a/lib/private/Repair/ClearFrontendCaches.php
+++ b/lib/private/Repair/ClearFrontendCaches.php
@@ -23,15 +23,11 @@
 
 namespace OC\Repair;
 
-use OC\Core\Command\Maintenance\ClearCacheJSCSS;
 use OC\Template\JSCombiner;
 use OC\Template\SCSSCacher;
-use OCP\AppFramework\QueryException;
 use OCP\ICacheFactory;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
-use Symfony\Component\Console\Input\StringInput;
-use Symfony\Component\Console\Output\BufferedOutput;
 
 class ClearFrontendCaches implements IRepairStep {
 
@@ -59,17 +55,13 @@ class ClearFrontendCaches implements IRepairStep {
 	public function run(IOutput $output) {
 		try {
 			$c = $this->cacheFactory->createDistributed('imagePath');
-			$c->clear('');
+			$c->clear();
 			$output->info('Image cache cleared');
 
 			$this->scssCacher->resetCache();
-			$c = $this->cacheFactory->createDistributed('SCSS');
-			$c->clear('');
 			$output->info('SCSS cache cleared');
 
 			$this->jsCombiner->resetCache();
-			$c = $this->cacheFactory->createDistributed('JS');
-			$c->clear('');
 			$output->info('JS cache cleared');
 		} catch (\Exception $e) {
 			$output->warning('Unable to clear the frontend cache');

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -112,6 +112,7 @@ use OC\Share20\ProviderFactory;
 use OC\Share20\ShareHelper;
 use OC\SystemTag\ManagerFactory as SystemTagManagerFactory;
 use OC\Tagging\TagMapper;
+use OC\Template\JSCombiner;
 use OC\Template\SCSSCacher;
 use OCA\Theming\ThemingDefaults;
 
@@ -965,6 +966,17 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getThemingDefaults(),
 				\OC::$SERVERROOT,
 				$cacheFactory->createDistributed('SCSS')
+			);
+		});
+		$this->registerService(JSCombiner::class, function (Server $c) {
+			/** @var Factory $cacheFactory */
+			$cacheFactory = $c->query(Factory::class);
+			return new JSCombiner(
+				$c->getAppDataDir('js'),
+				$c->getURLGenerator(),
+				$cacheFactory->createDistributed('JS'),
+				$c->getSystemConfig(),
+				$c->getLogger()
 			);
 		});
 		$this->registerService(EventDispatcher::class, function () {

--- a/lib/private/Template/JSCombiner.php
+++ b/lib/private/Template/JSCombiner.php
@@ -184,9 +184,10 @@ class JSCombiner {
 			$depFile->putContent($deps);
 			$this->depsCache->set($folder->getName() . '-' . $depFileName, $deps);
 			$gzipFile->putContent(gzencode($res, 9));
-
+			$this->logger->debug('JSCombiner: successfully cached: ' . $fileName);
 			return true;
 		} catch (NotPermittedException $e) {
+			$this->logger->error('JSCombiner: unable to cache: ' . $fileName);
 			return false;
 		}
 	}
@@ -226,5 +227,23 @@ class JSCombiner {
 		}
 
 		return $result;
+	}
+
+
+	/**
+	 * Clear cache with combined javascript files
+	 *
+	 * @throws NotFoundException
+	 */
+	public function resetCache() {
+		$appDirectory = $this->appData->getDirectoryListing();
+		if(empty($appDirectory)){
+			return;
+		}
+		foreach ($appDirectory as $folder) {
+			foreach ($folder->getDirectoryListing() as $file) {
+				$file->delete();
+			}
+		}
 	}
 }

--- a/lib/private/Template/JSCombiner.php
+++ b/lib/private/Template/JSCombiner.php
@@ -236,10 +236,8 @@ class JSCombiner {
 	 * @throws NotFoundException
 	 */
 	public function resetCache() {
+		$this->depsCache->clear();
 		$appDirectory = $this->appData->getDirectoryListing();
-		if(empty($appDirectory)){
-			return;
-		}
 		foreach ($appDirectory as $folder) {
 			foreach ($folder->getDirectoryListing() as $file) {
 				$file->delete();

--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -249,9 +249,10 @@ class SCSSCacher {
 			$depFile->putContent($deps);
 			$this->depsCache->set($folder->getName() . '-' . $depFileName, $deps);
 			$gzipFile->putContent(gzencode($data, 9));
-			$this->logger->debug($webDir.'/'.$fileNameSCSS.' compiled and successfully cached', ['app' => 'core']);
+			$this->logger->debug('SCSSCacher: '.$webDir.'/'.$fileNameSCSS.' compiled and successfully cached', ['app' => 'core']);
 			return true;
 		} catch(NotPermittedException $e) {
+			$this->logger->error('SCSSCacher: unable to cache: ' . $fileNameSCSS);
 			return false;
 		}
 	}
@@ -260,7 +261,7 @@ class SCSSCacher {
 	 * Reset scss cache by deleting all generated css files
 	 * We need to regenerate all files when variables change
 	 */
-	private function resetCache() {
+	public function resetCache() {
 		$this->injectedVariables = null;
 		$appDirectory = $this->appData->getDirectoryListing();
 		if(empty($appDirectory)){
@@ -268,9 +269,7 @@ class SCSSCacher {
 		}
 		foreach ($appDirectory as $folder) {
 			foreach ($folder->getDirectoryListing() as $file) {
-				if (substr($file->getName(), -3) === 'css' || substr($file->getName(), -4) === 'deps') {
-					$file->delete();
-				}
+				$file->delete();
 			}
 		}
 	}

--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -263,10 +263,8 @@ class SCSSCacher {
 	 */
 	public function resetCache() {
 		$this->injectedVariables = null;
+		$this->depsCache->clear();
 		$appDirectory = $this->appData->getDirectoryListing();
-		if(empty($appDirectory)){
-			return;
-		}
 		foreach ($appDirectory as $folder) {
 			foreach ($folder->getDirectoryListing() as $file) {
 				$file->delete();

--- a/tests/lib/Repair/ClearFrontendCachesTest.php
+++ b/tests/lib/Repair/ClearFrontendCachesTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Test\Repair;
+use OC\Template\JSCombiner;
+use OC\Template\SCSSCacher;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\Migration\IOutput;
+
+class ClearFrontendCachesTest extends \Test\TestCase {
+
+	/** @var ICacheFactory */
+	private $cacheFactory;
+
+	/** @var SCSSCacher */
+	private $scssCacher;
+
+	/** @var JSCombiner */
+	private $jsCombiner;
+
+	/** @var \OC\Repair\ClearFrontendCaches */
+	protected $repair;
+
+	/** @var IOutput */
+	private $outputMock;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->outputMock = $this->createMock(IOutput::class);
+
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->scssCacher = $this->createMock(SCSSCacher::class);
+		$this->jsCombiner = $this->createMock(JSCombiner::class);
+
+		$this->repair = new \OC\Repair\ClearFrontendCaches($this->cacheFactory, $this->scssCacher, $this->jsCombiner);
+	}
+
+
+	public function testRun() {
+		$imagePathCache = $this->createMock(ICache::class);
+		$imagePathCache->expects($this->once())
+			->method('clear')
+			->with('');
+		$jsCache = $this->createMock(ICache::class);
+		$jsCache->expects($this->once())
+			->method('clear')
+			->with('');
+		$cssCache = $this->createMock(ICache::class);
+		$cssCache->expects($this->once())
+			->method('clear')
+			->with('');
+		$this->jsCombiner->expects($this->once())
+			->method('resetCache');
+		$this->scssCacher->expects($this->once())
+			->method('resetCache');
+		$this->cacheFactory->expects($this->at(0))
+			->method('createDistributed')
+			->with('imagePath')
+			->willReturn($imagePathCache);
+		$this->cacheFactory->expects($this->at(1))
+			->method('createDistributed')
+			->with('SCSS')
+			->willReturn($cssCache);
+		$this->cacheFactory->expects($this->at(2))
+			->method('createDistributed')
+			->with('JS')
+			->willReturn($jsCache);
+
+		$this->repair->run($this->outputMock);
+		$this->assertTrue(true);
+	}
+}

--- a/tests/lib/Repair/ClearFrontendCachesTest.php
+++ b/tests/lib/Repair/ClearFrontendCachesTest.php
@@ -63,14 +63,6 @@ class ClearFrontendCachesTest extends \Test\TestCase {
 		$imagePathCache->expects($this->once())
 			->method('clear')
 			->with('');
-		$jsCache = $this->createMock(ICache::class);
-		$jsCache->expects($this->once())
-			->method('clear')
-			->with('');
-		$cssCache = $this->createMock(ICache::class);
-		$cssCache->expects($this->once())
-			->method('clear')
-			->with('');
 		$this->jsCombiner->expects($this->once())
 			->method('resetCache');
 		$this->scssCacher->expects($this->once())
@@ -79,14 +71,6 @@ class ClearFrontendCachesTest extends \Test\TestCase {
 			->method('createDistributed')
 			->with('imagePath')
 			->willReturn($imagePathCache);
-		$this->cacheFactory->expects($this->at(1))
-			->method('createDistributed')
-			->with('SCSS')
-			->willReturn($cssCache);
-		$this->cacheFactory->expects($this->at(2))
-			->method('createDistributed')
-			->with('JS')
-			->willReturn($jsCache);
 
 		$this->repair->run($this->outputMock);
 		$this->assertTrue(true);

--- a/tests/lib/Template/JSCombinerTest.php
+++ b/tests/lib/Template/JSCombinerTest.php
@@ -511,4 +511,25 @@ var b = \'world\';
 		$expected = [];
 		$this->assertEquals($expected, $this->jsCombiner->getContent($pathInfo['dirname'], $pathInfo['basename']));
 	}
+
+	public function testResetCache() {
+		$file = $this->createMock(ISimpleFile::class);
+		$file->expects($this->once())
+			->method('delete');
+
+		$folder = $this->createMock(ISimpleFolder::class);
+		$folder->expects($this->once())
+			->method('getDirectoryListing')
+			->willReturn([$file]);
+
+		$this->depsCache->expects($this->once())
+			->method('clear')
+			->with('');
+		$this->appData->expects($this->once())
+			->method('getDirectoryListing')
+			->willReturn([$folder]);
+
+		$this->jsCombiner->resetCache();
+	}
+
 }

--- a/tests/lib/Template/SCSSCacherTest.php
+++ b/tests/lib/Template/SCSSCacherTest.php
@@ -85,6 +85,7 @@ class SCSSCacherTest extends \Test\TestCase {
 
 		$this->appData->expects($this->once())->method('getFolder')->with('core')->willThrowException(new NotFoundException());
 		$this->appData->expects($this->once())->method('newFolder')->with('core')->willReturn($folder);
+		$this->appData->method('getDirectoryListing')->willReturn([]);
 
 		$fileDeps = $this->createMock(ISimpleFile::class);
 		$gzfile = $this->createMock(ISimpleFile::class);
@@ -118,6 +119,7 @@ class SCSSCacherTest extends \Test\TestCase {
 	public function testProcessUncachedFile() {
 		$folder = $this->createMock(ISimpleFolder::class);
 		$this->appData->expects($this->once())->method('getFolder')->with('core')->willReturn($folder);
+		$this->appData->method('getDirectoryListing')->willReturn([]);
 		$file = $this->createMock(ISimpleFile::class);
 		$file->expects($this->any())->method('getSize')->willReturn(1);
 		$fileDeps = $this->createMock(ISimpleFile::class);
@@ -148,6 +150,7 @@ class SCSSCacherTest extends \Test\TestCase {
 	public function testProcessCachedFile() {
 		$folder = $this->createMock(ISimpleFolder::class);
 		$this->appData->expects($this->once())->method('getFolder')->with('core')->willReturn($folder);
+		$this->appData->method('getDirectoryListing')->willReturn([]);
 		$file = $this->createMock(ISimpleFile::class);
 		$fileDeps = $this->createMock(ISimpleFile::class);
 		$fileDeps->expects($this->any())->method('getSize')->willReturn(1);
@@ -178,6 +181,7 @@ class SCSSCacherTest extends \Test\TestCase {
 			->willReturn($folder);
 		$folder->method('getName')
 			->willReturn('core');
+		$this->appData->method('getDirectoryListing')->willReturn([]);
 
 		$file = $this->createMock(ISimpleFile::class);
 

--- a/tests/lib/Template/SCSSCacherTest.php
+++ b/tests/lib/Template/SCSSCacherTest.php
@@ -445,4 +445,25 @@ class SCSSCacherTest extends \Test\TestCase {
 		$this->rrmdir($tmpDir.$path);
 	}
 
+	public function testResetCache() {
+		$file = $this->createMock(ISimpleFile::class);
+		$file->expects($this->once())
+			->method('delete');
+
+		$folder = $this->createMock(ISimpleFolder::class);
+		$folder->expects($this->once())
+			->method('getDirectoryListing')
+			->willReturn([$file]);
+
+		$this->depsCache->expects($this->once())
+			->method('clear')
+			->with('');
+		$this->appData->expects($this->once())
+			->method('getDirectoryListing')
+			->willReturn([$folder]);
+
+		$this->scssCacher->resetCache();
+	}
+
+
 }


### PR DESCRIPTION
This PR adds a repair step that will be executed during update and when calling occ maintenance:repair, that will remove any frontend related caches that caused issues in the past, as:
- SCSS cache
- combined JS files
- imagePath cache

I also added some further logging to the SCSSCacher and the JSCombiner, so at least logs can tell if something was wrong there.

The initial idea was from https://github.com/nextcloud/server/issues/7984 to pregenerate files, but that would be a lot more logic to be implemented, since the list of js/css files is built dynamically on every request. Clearing those files from appdata should be enough there.