### PR TITLE
Fix styling issues of guest pages

### DIFF
--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -91,14 +91,14 @@
 }
 
 /* override styles for login screen in guest.css */
-@if variable_exists('theming-logo-mime') {
+@if variable_exists('theming-logo-mime') and $theming-logo-mime != '' {
 	#header .logo {
 		background-image: url(#{$image-logo});
 		background-size: contain;
 	}
 }
 
-@if variable_exists('theming-background-mime') {
+@if variable_exists('theming-background-mime') and $theming-background-mime != ''  {
 	#body-login,
 	#firstrunwizard .firstrunwizard-header,
 	#theming-preview {

--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -96,6 +96,9 @@
 		background-image: url(#{$image-logo});
 		background-size: contain;
 	}
+	#body-login #header .logo {
+		margin-bottom: 22px;
+	}
 }
 
 @if variable_exists('theming-background-mime') and $theming-background-mime != ''  {

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -178,7 +178,9 @@ class TemplateLayout extends \OC_Template {
 		if(\OC::$server->getSystemConfig()->getValue('installed', false)
 			&& !\OCP\Util::needUpgrade()
 			&& $pathInfo !== ''
-			&& !preg_match('/^\/login/', $pathInfo)) {
+			&& !preg_match('/^\/login/', $pathInfo)
+			&& $renderAs !== 'error' && $renderAs !== 'guest'
+		) {
 			$cssFiles = self::findStylesheetFiles(\OC_Util::$styles);
 		} else {
 			// If we ignore the scss compiler,


### PR DESCRIPTION
This PR makes sure we use the guest.css file on all guest-template based pages that use the guest or error layout. Also fixes the regression from https://github.com/nextcloud/server/issues/8035


Before:
![bildschirmfoto vom 2018-02-02 12-53-07](https://user-images.githubusercontent.com/3404133/35732263-140c3a4a-0819-11e8-9720-75edb40e02e3.png)
![bildschirmfoto vom 2018-02-02 12-53-23](https://user-images.githubusercontent.com/3404133/35732265-1650587c-0819-11e8-85df-d94cb42391d8.png)
![bildschirmfoto vom 2018-02-02 12-54-09](https://user-images.githubusercontent.com/3404133/35732271-1a635892-0819-11e8-97b0-6768fa68954f.png)

After:
![bildschirmfoto vom 2018-02-02 12-58-37](https://user-images.githubusercontent.com/3404133/35732277-1d76d310-0819-11e8-81de-0d5d2796f59a.png)
![bildschirmfoto vom 2018-02-02 12-58-22](https://user-images.githubusercontent.com/3404133/35732285-21ee6d36-0819-11e8-858b-baa35c73d16b.png)
![bildschirmfoto vom 2018-02-02 12-58-01](https://user-images.githubusercontent.com/3404133/35732288-23fc8c52-0819-11e8-9b55-45bd230fd8c4.png)

@nextcloud/theming 
