### PR TITLE
Use a more widely available method to test s3 settings

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -566,13 +566,10 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 	}
 
 	public function test() {
-		$test = $this->getConnection()->getBucketAcl(array(
-			'Bucket' => $this->bucket,
-		));
-		if (isset($test) && !is_null($test->getPath('Owner/ID'))) {
-			return true;
-		}
-		return false;
+		$this->getConnection()->headBucket([
+			'Bucket' => $this->bucket
+		]);
+		return true;
 	}
 
 	public function getId() {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/8120

Bucket ACL's are not supported on minio making the test method always fail