### PR TITLE
Remove jquery ui background image

### DIFF
--- a/core/css/jquery-ui-fixes.scss
+++ b/core/css/jquery-ui-fixes.scss
@@ -11,6 +11,7 @@
 .ui-widget-header {
 	border: none;
 	color: $color-main-text;
+	background-image: none;
 }
 .ui-widget-header a {
 	color: $color-main-text;


### PR DESCRIPTION
Remove leftover jquery ui background image, which was causing a request to a non-existing file:

```
GET http://localhost:8140/core/vendor/jquery-ui/themes/base/images/ui-bg_highlight-soft_75_cccccc_1x100.png 404 (Not Found)
```

Steps to reproduce:
1. Upload a file so that the jquery ui progressbar comes up
2. watch the browser console

@nextcloud/designers
