### PR TITLE
[stable13] Do not try to get the jailed path if we can't find the id

### DIFF
--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -312,6 +312,10 @@ class CacheJail extends CacheWrapper {
 	 */
 	public function getPathById($id) {
 		$path = $this->getCache()->getPathById($id);
+		if ($path === null) {
+			return null;
+		}
+
 		return $this->getJailedPath($path);
 	}
 


### PR DESCRIPTION
Backport of #8160 

Fixes #8047 

If we can't find the file by id there we should just return null instead
of trying to get the jailed path of null.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>