### PR TITLE
[stable12] Handle SSL certificate verifications for others than Let's Encrypt

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -63,7 +63,7 @@
   RewriteRule ^\.well-known/caldav /remote.php/dav/ [R=301,L]
   RewriteRule ^remote/(.*) remote.php [QSA,L]
   RewriteRule ^(?:build|tests|config|lib|3rdparty|templates)/.* - [R=404,L]
-  RewriteCond %{REQUEST_URI} !^/.well-known/acme-challenge/.*
+  RewriteCond %{REQUEST_URI} !^/.well-known/(acme-challenge|pki-validation)/.*
   RewriteRule ^(?:\.|autotest|occ|issue|indie|db_|console).* - [R=404,L]
 </IfModule>
 <IfModule mod_mime.c>

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -473,7 +473,7 @@ class Setup {
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/robots.txt";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/updater/";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/ocs-provider/";
-			$content .= "\n  RewriteCond %{REQUEST_URI} !^/.well-known/acme-challenge/.*";
+			$content .= "\n  RewriteCond %{REQUEST_URI} !^/.well-known/(acme-challenge|pki-validation)/.*";
 			$content .= "\n  RewriteRule . index.php [PT,E=PATH_INFO:$1]";
 			$content .= "\n  RewriteBase " . $rewriteBase;
 			$content .= "\n  <IfModule mod_env.c>";


### PR DESCRIPTION
Backport of https://github.com/nextcloud/server/pull/8182

Do no longer (wrongly) rewrite URLs like

  * http://example.net/.well-known/pki-validation/file.txt (Comodo)
  * http://example.net/.well-known/pki-validation/fileauth.txt (DigiCert, Thawte, GeoTrust)
  * http://example.net/.well-known/pki-validation/gsdv.txt (GlobalSign)
  * http://example.net/.well-known/pki-validation/starfield.htm (Starfield, GoDaddy)
  * http://example.net/.well-known/pki-validation/swisssign-check.txt (SwissSign)

for automated SSL certificate verifications. All (common commercial) certificate authorities (CA) except Let's Encrypt (via ACME) seem to use "pki-validation" rather "acme-challenge" for their domain control validation (DCV).

Signed-off-by: Robert Scheck <robert@fedoraproject.org>