### PR TITLE
Avoid error messages for restricted opcache API

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1374,7 +1374,7 @@ class OC_Util {
 			}
 			// Zend OpCache >= 7.0.0, PHP >= 5.5.0
 			if (function_exists('opcache_invalidate')) {
-				$ret = opcache_invalidate($path);
+				$ret = @opcache_invalidate($path);
 			}
 		}
 		return $ret;
@@ -1408,7 +1408,7 @@ class OC_Util {
 		}
 		// Opcache (PHP >= 5.5)
 		if (function_exists('opcache_reset')) {
-			opcache_reset();
+			@opcache_reset();
 		}
 	}
 


### PR DESCRIPTION
As mentioned in #3602 the server log gets filled with messages like this, when `opcache_invalidate()` or `opcache_reset()` can not be called due to a restricted API:

`Zend OPcache can't be temporary enabled (it may be only disabled till the end of request) at Unknown#0`

It makes to report errors in the log for these calls as the cause for it usually can not be changed easily. Also note that other cache calls for APC etc. are also used with a preceding @ sign to avoid error messages.

Having dozens or hundreds of error messages without indicating the reason for the error does not help - a better approach to deal with this and to let the administrator know that there may be a problem would be to check the call in the security admin tests and show the result there with a message like "it seems, opcache can not be cleared if needed - please be aware, that changes in the configuration might not take place immediately".