### PR TITLE
Split move and copy operations

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -625,12 +625,23 @@
 
 			this.registerAction({
 				name: 'MoveCopy',
-				displayName: t('files', 'Move or copy'),
+				displayName: function(context) {
+					var permissions = context.fileInfoModel.attributes.permissions;
+					if (permissions & OC.PERMISSION_UPDATE) {
+						return t('files', 'Move or copy');
+					}
+					return t('files', 'Copy');
+				},
 				mime: 'all',
 				order: -25,
-				permissions: OC.PERMISSION_UPDATE,
+				permissions: $('#isPublic').val() ? OC.PERMISSION_UPDATE : OC.PERMISSION_READ,
 				iconClass: 'icon-external',
 				actionHandler: function (filename, context) {
+					var permissions = context.fileInfoModel.attributes.permissions;
+					var actions = OC.dialogs.FILEPICKER_TYPE_COPY;
+					if (permissions & OC.PERMISSION_UPDATE) {
+						actions = OC.dialogs.FILEPICKER_TYPE_COPY_MOVE;
+					}
 					OC.dialogs.filepicker(t('files', 'Target folder'), function(targetPath, type) {
 						if (type === OC.dialogs.FILEPICKER_TYPE_COPY) {
 							context.fileList.copy(filename, targetPath);
@@ -638,7 +649,7 @@
 						if (type === OC.dialogs.FILEPICKER_TYPE_MOVE) {
 							context.fileList.move(filename, targetPath);
 						}
-					}, false, "httpd/unix-directory", true, OC.dialogs.FILEPICKER_TYPE_COPY_MOVE);
+					}, false, "httpd/unix-directory", true, actions);
 				}
 			});
 

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -798,6 +798,7 @@
 				OCA.Files.FileActions.updateFileActionSpinner(moveFileAction, false);
 			};
 
+			var actions = this.isSelectedMovable() ? OC.dialogs.FILEPICKER_TYPE_COPY_MOVE : OC.dialogs.FILEPICKER_TYPE_COPY;
 			OC.dialogs.filepicker(t('files', 'Target folder'), function(targetPath, type) {
 				if (type === OC.dialogs.FILEPICKER_TYPE_COPY) {
 					self.copy(files, targetPath, disableLoadingState);
@@ -805,7 +806,7 @@
 				if (type === OC.dialogs.FILEPICKER_TYPE_MOVE) {
 					self.move(files, targetPath, disableLoadingState);
 				}
-			}, false, "httpd/unix-directory", true, OC.dialogs.FILEPICKER_TYPE_COPY_MOVE);
+			}, false, "httpd/unix-directory", true, actions);
 			return false;
 		},
 
@@ -2871,18 +2872,39 @@
 				this.$el.find('#headerName a.name>span:first').text(selection);
 				this.$el.find('#modified a>span:first').text('');
 				this.$el.find('table').addClass('multiselect');
-				this.$el.find('.selectedActions .copy-move').toggleClass('hidden', !this.isSelectedCopiableOrMovable());
 				this.$el.find('.selectedActions .download').toggleClass('hidden', !this.isSelectedDownloadable());
 				this.$el.find('.delete-selected').toggleClass('hidden', !this.isSelectedDeletable());
+
+				var $copyMove = this.$el.find('.selectedActions .copy-move');
+				if (this.isSelectedCopiable()) {
+					$copyMove.toggleClass('hidden', false);
+					if (this.isSelectedMovable()) {
+						$copyMove.find('.label').text(t('files', 'Move or copy'));
+					} else {
+						$copyMove.find('.label').text(t('files', 'Copy'));
+					}
+				} else {
+					$copyMove.toggleClass('hidden', true);
+				}
 			}
 		},
 
 		/**
-		 * Check whether all selected files are copiable or movable
+		 * Check whether all selected files are copiable
 		 */
-		isSelectedCopiableOrMovable: function() {
-			return _.reduce(this.getSelectedFiles(), function(copiableOrMovable, file) {
-				return copiableOrMovable && (file.permissions & OC.PERMISSION_UPDATE);
+		isSelectedCopiable: function() {
+			return _.reduce(this.getSelectedFiles(), function(copiable, file) {
+				var requiredPermission = $('#isPublic').val() ? OC.PERMISSION_UPDATE : OC.PERMISSION_READ;
+				return copiable && (file.permissions & requiredPermission);
+			}, true);
+		},
+
+		/**
+		 * Check whether all selected files are movable
+		 */
+		isSelectedMovable: function() {
+			return _.reduce(this.getSelectedFiles(), function(movable, file) {
+				return movable && (file.permissions & OC.PERMISSION_UPDATE);
 			}, true);
 		},
 

--- a/apps/files/templates/list.php
+++ b/apps/files/templates/list.php
@@ -53,7 +53,7 @@
 					<span id="selectedActionsList" class="selectedActions">
 						<a href="" class="copy-move">
 							<span class="icon icon-external"></span>
-							<span><?php p($l->t('Move or copy'))?></span>
+							<span class="label"><?php p($l->t('Move or copy'))?></span>
 						</a>
 						<a href="" class="download">
 							<span class="icon icon-download"></span>

--- a/apps/files/tests/js/fileactionsmenuSpec.js
+++ b/apps/files/tests/js/fileactionsmenuSpec.js
@@ -271,6 +271,7 @@ describe('OCA.Files.FileActionsMenu tests', function() {
 				$file: $tr,
 				fileList: fileList,
 				fileActions: fileActions,
+				fileInfoModel: new OCA.Files.FileInfoModel(fileData),
 				dir: fileList.getCurrentDirectory()
 			};
 			menu = new OCA.Files.FileActionsMenu();
@@ -304,6 +305,7 @@ describe('OCA.Files.FileActionsMenu tests', function() {
 				$file: $tr,
 				fileList: fileList,
 				fileActions: fileActions,
+				fileInfoModel: new OCA.Files.FileInfoModel(fileData),
 				dir: '/anotherpath/there'
 			};
 			menu = new OCA.Files.FileActionsMenu();
@@ -336,6 +338,7 @@ describe('OCA.Files.FileActionsMenu tests', function() {
 				$file: $tr,
 				fileList: fileList,
 				fileActions: fileActions,
+				fileInfoModel: new OCA.Files.FileInfoModel(fileData),
 				dir: '/somepath/dir'
 			};
 			menu = new OCA.Files.FileActionsMenu();

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -94,7 +94,7 @@ describe('OCA.Files.FileList tests', function() {
 			'<input type="checkbox" id="select_all_files" class="select-all checkbox">' +
 			'<a class="name columntitle" data-sort="name"><span>Name</span><span class="sort-indicator"></span></a>' +
 			'<span id="selectedActionsList" class="selectedActions hidden">' +
-			'<a href class="copy-move">Move or copy</a>' +
+			'<a href class="copy-move"><span class="label">Move or copy</span></a>' +
 			'<a href class="download"><img src="actions/download.svg">Download</a>' +
 			'<a href class="delete-selected">Delete</a></span>' +
 			'</th>' +
@@ -2101,7 +2101,14 @@ describe('OCA.Files.FileList tests', function() {
 				$('#permissions').val(OC.PERMISSION_READ | OC.PERMISSION_UPDATE);
 				$('.select-all').click();
 				expect(fileList.$el.find('.selectedActions .copy-move').hasClass('hidden')).toEqual(false);
+				expect(fileList.$el.find('.selectedActions .copy-move .label').text()).toEqual('Move or copy');
 				testFiles[0].permissions = OC.PERMISSION_READ;
+				$('.select-all').click();
+				fileList.setFiles(testFiles);
+				$('.select-all').click();
+				expect(fileList.$el.find('.selectedActions .copy-move').hasClass('hidden')).toEqual(false);
+				expect(fileList.$el.find('.selectedActions .copy-move .label').text()).toEqual('Copy');
+				testFiles[0].permissions = OC.PERMISSION_NONE;
 				$('.select-all').click();
 				fileList.setFiles(testFiles);
 				$('.select-all').click();


### PR DESCRIPTION
As a follow up to #6014: this pull requests splits 'Move or copy' actions into a 'Move' action that requires UPDATE and a 'Copy' action that only demands READ permission (except when viewed as a public share).  

This allows users to copy shared files into their own home directory and modify them afterwards.