### PR TITLE
Restrict default permission to READ for sharebymail.

### DIFF
--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -335,7 +335,7 @@ class ShareByMailProvider implements IShareProvider {
 			$share->getSharedWith(),
 			$share->getSharedBy(),
 			$share->getShareOwner(),
-			$share->getPermissions(),
+			$share->getPermissions() & 1,
 			$share->getToken(),
 			$share->getPassword()
 		);


### PR DESCRIPTION
See issue #8186: giving EDIT permissions by default to email shares can be dangerous

Signed-off-by: Roland Tapken <roland@bitarbeiter.net>