### PR TITLE
Better result handling of email search

### DIFF
--- a/lib/private/Collaboration/Collaborators/MailPlugin.php
+++ b/lib/private/Collaboration/Collaborators/MailPlugin.php
@@ -173,6 +173,8 @@ class MailPlugin implements ISearchPlugin {
 
 		if (!$this->shareeEnumeration) {
 			$result['wide'] = [];
+		} else {
+			$result['wide'] = array_slice($result['wide'], $offset, $limit);
 		}
 
 		if (!$searchResult->hasExactIdMatch($emailType) && filter_var($search, FILTER_VALIDATE_EMAIL)) {

--- a/lib/private/Collaboration/Collaborators/RemotePlugin.php
+++ b/lib/private/Collaboration/Collaborators/RemotePlugin.php
@@ -102,6 +102,8 @@ class RemotePlugin implements ISearchPlugin {
 
 		if (!$this->shareeEnumeration) {
 			$result['wide'] = [];
+		} else {
+			$result['wide'] = array_slice($result['wide'], $offset, $limit);
 		}
 
 		if (!$searchResult->hasExactIdMatch($resultType) && $this->cloudIdManager->isValidCloudId($search) && $offset === 0) {

--- a/tests/lib/Collaboration/Collaborators/MailPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/MailPluginTest.php
@@ -103,7 +103,7 @@ class MailPluginTest extends TestCase {
 			->with($searchTerm, ['EMAIL', 'FN'])
 			->willReturn($contacts);
 
-		$moreResults = $this->plugin->search($searchTerm, 0, 0, $this->searchResult);
+		$moreResults = $this->plugin->search($searchTerm, 2, 0, $this->searchResult);
 		$result = $this->searchResult->asArray();
 
 		$this->assertSame($exactIdMatch, $this->searchResult->hasExactIdMatch(new SearchResultType('emails')));
@@ -398,7 +398,7 @@ class MailPluginTest extends TestCase {
 				return in_array($group, $userToGroupMapping[$userId]);
 			});
 
-		$moreResults = $this->plugin->search($searchTerm, 0, 0, $this->searchResult);
+		$moreResults = $this->plugin->search($searchTerm, 2, 0, $this->searchResult);
 		$result = $this->searchResult->asArray();
 
 		$this->assertSame($exactIdMatch, $this->searchResult->hasExactIdMatch(new SearchResultType('emails')));

--- a/tests/lib/Collaboration/Collaborators/RemotePluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/RemotePluginTest.php
@@ -94,7 +94,7 @@ class RemotePluginTest extends TestCase {
 			->with($searchTerm, ['CLOUD', 'FN'])
 			->willReturn($contacts);
 
-		$moreResults = $this->plugin->search($searchTerm, 0, 0, $this->searchResult);
+		$moreResults = $this->plugin->search($searchTerm, 2, 0, $this->searchResult);
 		$result = $this->searchResult->asArray();
 
 		$this->assertSame($exactIdMatch, $this->searchResult->hasExactIdMatch(new SearchResultType('remotes')));


### PR DESCRIPTION
1. Local users should not be returned when searching for empty string
2. The limit of the response should be respected

Master version of #8205 