### PR TITLE
Block referrer information with "no-referrer"

### DIFF
--- a/core/templates/layout.base.php
+++ b/core/templates/layout.base.php
@@ -6,7 +6,7 @@
 		<?php p($theme->getTitle()); ?>
 		</title>
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
-		<meta name="referrer" content="never">
+		<meta name="referrer" content="no-referrer">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0">
 		<meta name="theme-color" content="<?php p($theme->getColorPrimary()); ?>">
 		<link rel="icon" href="<?php print_unescaped(image_path('', 'favicon.ico')); /* IE11+ supports png */ ?>">

--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -6,7 +6,7 @@
 		<?php p($theme->getTitle()); ?>
 		</title>
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
-		<meta name="referrer" content="never">
+		<meta name="referrer" content="no-referrer">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0">
 		<meta name="apple-itunes-app" content="app-id=<?php p($theme->getiTunesAppId()); ?>">
 		<meta name="theme-color" content="<?php p($theme->getColorPrimary()); ?>">

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -9,7 +9,7 @@
 			?>
 		</title>
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
-		<meta name="referrer" content="never">
+		<meta name="referrer" content="no-referrer">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0">
 		<meta name="apple-itunes-app" content="app-id=<?php p($theme->getiTunesAppId()); ?>">
 		<meta name="apple-mobile-web-app-capable" content="yes">


### PR DESCRIPTION
Blocking referrer information should be done with `no-referrer` and not `never`. See
[here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) and [here](https://www.w3.org/TR/referrer-policy/#referrer-policy-no-referrer).