### PR TITLE
Nextcloud 12 is not compatible with newer than php 7.1

### DIFF
--- a/console.php
+++ b/console.php
@@ -25,27 +25,13 @@
  *
  */
 
+require_once __DIR__ . '/lib/versioncheck.php';
+
 use OC\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 define('OC_CONSOLE', 1);
-
-// Show warning if a PHP version below 5.6.0 is used, this has to happen here
-// because base.php will already use 5.6 syntax.
-if (version_compare(PHP_VERSION, '5.6.0') === -1) {
-	echo 'This version of Nextcloud requires at least PHP 5.6.0'.PHP_EOL;
-	echo 'You are currently running ' . PHP_VERSION . '. Please update your PHP version.'.PHP_EOL;
-	return;
-}
-
-// Show warning if PHP 7.2 is used as Nextcloud is not compatible with PHP 7.2 for now
-// @see https://github.com/nextcloud/server/pull/5791
-if (version_compare(PHP_VERSION, '7.2.0') !== -1) {
-	echo 'This version of Nextcloud is not compatible with PHP 7.2.<br/>';
-	echo 'You are currently running ' . PHP_VERSION . '.';
-	return;
-}
 
 function exceptionHandler($exception) {
 	echo "An unhandled exception has been thrown:" . PHP_EOL;

--- a/cron.php
+++ b/cron.php
@@ -30,12 +30,7 @@
  *
  */
 
-// Show warning if a PHP version below 5.6.0 is used
-if (version_compare(PHP_VERSION, '5.6.0') === -1) {
-	echo 'This version of Nextcloud requires at least PHP 5.6.0<br/>';
-	echo 'You are currently running ' . PHP_VERSION . '. Please update your PHP version.';
-	return;
-}
+require_once __DIR__ . '/lib/versioncheck.php';
 
 try {
 

--- a/index.php
+++ b/index.php
@@ -25,13 +25,7 @@
  *
  */
 
-// Show warning if a PHP version below 5.6.0 is used, this has to happen here
-// because base.php will already use 5.6 syntax.
-if (version_compare(PHP_VERSION, '5.6.0') === -1) {
-	echo 'This version of Nextcloud requires at least PHP 5.6.0<br/>';
-	echo 'You are currently running ' . PHP_VERSION . '. Please update your PHP version.';
-	return;
-}
+require_once __DIR__ . '/lib/versioncheck.php';
 
 // Show warning if PHP 7.2 is used as Nextcloud is not compatible with PHP 7.2 for now
 // @see https://github.com/nextcloud/server/pull/5791

--- a/lib/versioncheck.php
+++ b/lib/versioncheck.php
@@ -1,0 +1,18 @@
+<?php
+
+// Show warning if a PHP version below 5.6.0 is used, this has to happen here
+// because base.php will already use 5.6 syntax.
+if (version_compare(PHP_VERSION, '5.6.0', '<')) {
+	http_response_code(500);
+	echo 'This version of Nextcloud requires at least PHP 5.6.0<br/>';
+	echo 'You are currently running ' . PHP_VERSION . '. Please update your PHP version.';
+	exit(-1);
+}
+
+// Show warning if > PHP 7.1 is used as Nextcloud 12 is not compatible with > PHP 7.1
+if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+	http_response_code(500);
+	echo 'This version of Nextcloud is not compatible with > PHP 7.2.<br/>';
+	echo 'You are currently running ' . PHP_VERSION . '.';
+	exit(-1);
+}

--- a/ocs/providers.php
+++ b/ocs/providers.php
@@ -23,6 +23,7 @@
  *
  */
 
+require_once __DIR__ . '/../lib/versioncheck.php';
 require_once __DIR__ . '/../lib/base.php';
 
 header('Content-type: application/xml');

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -29,6 +29,7 @@
  *
  */
 
+require_once __DIR__ . '/../lib/versioncheck.php';
 require_once __DIR__ . '/../lib/base.php';
 
 if (\OCP\Util::needUpgrade()

--- a/public.php
+++ b/public.php
@@ -27,6 +27,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+require_once __DIR__ . '/lib/versioncheck.php';
+
 try {
 
 	require_once __DIR__ . '/lib/base.php';

--- a/remote.php
+++ b/remote.php
@@ -28,6 +28,8 @@
  *
  */
 
+require_once __DIR__ . '/lib/versioncheck.php';
+
 use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin;
 use Sabre\DAV\Exception\ServiceUnavailable;
 use Sabre\DAV\Server;

--- a/status.php
+++ b/status.php
@@ -27,6 +27,8 @@
  *
  */
 
+require_once __DIR__ . '/lib/versioncheck.php';
+
 try {
 
 	require_once __DIR__ . '/lib/base.php';


### PR DESCRIPTION
Backport of #6830

Fixes https://github.com/nextcloud/server/issues/7415

Just to avoid users from trying this with a to new (untested) php version

* Moved the check logic to 1 place
* All directly callable scripts just require this on top
* exit hard (-1) so we know scripts won't continue
* Return status 500 so no sync clients will try fancy stuff

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>