### PR TITLE
Use proper lanugage in langauge code

### DIFF
--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -128,7 +128,9 @@ class TemplateLayout extends \OC_Template {
 
 		}
 		// Send the language to our layouts
-		$this->assign('language', \OC::$server->getL10NFactory()->findLanguage());
+		$lang = \OC::$server->getL10NFactory()->findLanguage();
+		$lang = str_replace('_', '-', $lang);
+		$this->assign('language', $lang);
 
 		if(\OC::$server->getSystemConfig()->getValue('installed', false)) {
 			if (empty(self::$versionHash)) {


### PR DESCRIPTION
Fixes #8180

The _ is not valid in language codes use - instead.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>