### PR TITLE
Display the proper language strings in setttings

### DIFF
--- a/lib/private/Settings/Personal/PersonalInfo.php
+++ b/lib/private/Settings/Personal/PersonalInfo.php
@@ -205,7 +205,7 @@ class PersonalInfo implements ISettings {
 		$languages = [];
 
 		foreach($languageCodes as $lang) {
-			$l = \OC::$server->getL10N('settings', $lang);
+			$l = \OC::$server->getL10N('lib', $lang);
 			// TRANSLATORS this is the language name for the language switcher in the personal settings and should be the localized version
 			$potentialName = (string) $l->t('__language_name__');
 			if($l->getLanguageCode() === $lang && $potentialName[0] !== '_') {//first check if the language name is in the translation file


### PR DESCRIPTION
Since this was moved to lib, we have to the lib language files.

To verify:

1. Open personal settings
2. Check the languages


* [x] external app also uses this and maybe should get an update as well (see https://github.com/nextcloud/external/pull/78)