### PR TITLE
Fix proper overwrite URL on CLI install

### DIFF
--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -325,15 +325,20 @@ class Setup {
 		$secret = $this->random->generate(48);
 
 		//write the config file
-		$this->config->setValues([
+		$newConfigValues = [
 			'passwordsalt'		=> $salt,
 			'secret'			=> $secret,
 			'trusted_domains'	=> $trustedDomains,
 			'datadirectory'		=> $dataDir,
-			'overwrite.cli.url'	=> $request->getServerProtocol() . '://' . $request->getInsecureServerHost() . \OC::$WEBROOT,
 			'dbtype'			=> $dbType,
 			'version'			=> implode('.', \OCP\Util::getVersion()),
-		]);
+		];
+
+		if ($this->config->getValue('overwrite.cli.url', null) === null) {
+			$newConfigValues['overwrite.cli.url'] = $request->getServerProtocol() . '://' . $request->getInsecureServerHost() . \OC::$WEBROOT;
+		}
+
+		$this->config->setValues($newConfigValues);
 
 		try {
 			$dbSetup->initialize($options);


### PR DESCRIPTION
* regression from #7835
* only sets `overwrite.cli.url` if it isn't already set

Steps

* having a my.config.php with a proper `overwrite.cli.url` and `htaccess.RewriteBase` set
* install with this
* before: short URLs where broken and you need to call `occ maintenance:update:htaccess` additionally to fix this
* after: occ install results in a proper htaccess like on stable13