### PR TITLE
Apply ldapUserFilter on members of group

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -538,9 +538,11 @@ class Access extends LDAPUtility implements IUserTools {
 		if($isUser) {
 			$mapper = $this->getUserMapper();
 			$nameAttribute = $this->connection->ldapUserDisplayName;
+			$filter = $this->connection->ldapUserFilter;
 		} else {
 			$mapper = $this->getGroupMapper();
 			$nameAttribute = $this->connection->ldapGroupDisplayName;
+			$filter = $this->connection->ldapGroupFilter;
 		}
 
 		//let's try to retrieve the Nextcloud name from the mappings table
@@ -564,13 +566,9 @@ class Access extends LDAPUtility implements IUserTools {
 		}
 
 		if(is_null($ldapName)) {
-			if ($isUser) {
-				$ldapName = $this->readAttribute($fdn, $nameAttribute, $this->connection->ldapUserFilter);
-			} else {
-				$ldapName = $this->readAttribute($fdn, $nameAttribute);
-			}
+			$ldapName = $this->readAttribute($fdn, $nameAttribute, $filter);
 			if(!isset($ldapName[0]) && empty($ldapName[0])) {
-				\OCP\Util::writeLog('user_ldap', 'No or empty name for '.$fdn.'.', \OCP\Util::INFO);
+				\OCP\Util::writeLog('user_ldap', 'No or empty name for '.$fdn.' with filter '.$filter.'.', \OCP\Util::INFO);
 				return false;
 			}
 			$ldapName = $ldapName[0];

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -564,7 +564,11 @@ class Access extends LDAPUtility implements IUserTools {
 		}
 
 		if(is_null($ldapName)) {
-			$ldapName = $this->readAttribute($fdn, $nameAttribute);
+			if ($isUser) {
+				$ldapName = $this->readAttribute($fdn, $nameAttribute, $this->connection->ldapUserFilter);
+			} else {
+				$ldapName = $this->readAttribute($fdn, $nameAttribute);
+			}
 			if(!isset($ldapName[0]) && empty($ldapName[0])) {
 				\OCP\Util::writeLog('user_ldap', 'No or empty name for '.$fdn.'.', \OCP\Util::INFO);
 				return false;


### PR DESCRIPTION
Refers to issue #8220

user_ldap configured with custom filters for active directory access
(group-member-association is "member"). Then it can happen that the
a group contain members that don't belong to the users
available in Nextcloud (the most trivial reason is that the user filter
contains "(!(UserAccountControl:1.2.840.113556.1.4.803:=2))" to exclude
disabled users from being imported).

This can be fixed by applying the ldapUserFilter when resolving the UID
for a DN fetched from the group's member list.

Signed-off-by: Roland Tapken <roland@bitarbeiter.net>