### PR TITLE
verify that l10n option is valid before using

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -1077,7 +1077,7 @@ class OC_App {
 		}
 
 		foreach ($options as $option) {
-			if (is_array($option)) {
+			if (is_array($option) && isset($option['@value'])) {
 				if ($fallback === false) {
 					$fallback = $option['@value'];
 				}


### PR DESCRIPTION
Make sure that the option is what we expect.

Probably caused by a not 100% valid info.xml, not sure which one though, found the issue in the logs of a customer.