### PR TITLE
user_ldap: Filter groups after nested groups

### DIFF
--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -263,7 +263,6 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface, IGroupLD
 		if (!is_array($groups)) {
 			return array();
 		}
-		$groups = $this->access->groupsMatchFilter($groups);
 		$allGroups =  $groups;
 		$nestedGroups = $this->access->connection->ldapNestedGroups;
 		if ((int)$nestedGroups === 1) {
@@ -272,7 +271,7 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface, IGroupLD
 				$allGroups = array_merge($allGroups, $subGroups);
 			}
 		}
-		return $allGroups;
+		return $this->access->groupsMatchFilter($allGroups);
 	}
 
 	/**

--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -250,28 +250,33 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface, IGroupLD
 	 * @param array|null &$seen
 	 * @return array
 	 */
-	private function _getGroupDNsFromMemberOf($DN, &$seen = null) {
-		if ($seen === null) {
-			$seen = array();
-		}
-		if (array_key_exists($DN, $seen)) {
-			// avoid loops
-			return array();
-		}
-		$seen[$DN] = 1;
+	private function _getGroupDNsFromMemberOf($DN) {
 		$groups = $this->access->readAttribute($DN, 'memberOf');
 		if (!is_array($groups)) {
 			return array();
 		}
-		$allGroups =  $groups;
 		$nestedGroups = $this->access->connection->ldapNestedGroups;
 		if ((int)$nestedGroups === 1) {
-			foreach ($groups as $group) {
-				$subGroups = $this->_getGroupDNsFromMemberOf($group, $seen);
-				$allGroups = array_merge($allGroups, $subGroups);
+			$seen = array();
+			while ($group = array_pop($groups)) {
+				if ($group === $DN || array_key_exists($group, $seen)) {
+					// Prevent loops
+					continue;
+				}
+				$seen[$group] = 1;
+
+				// Resolve nested groups
+				$nestedGroups = $this->access->readAttribute($group, 'memberOf');
+				if (is_array($nestedGroups)) {
+					foreach ($nestedGroups as $nestedGroup) {
+						array_push($groups, $nestedGroup);
+					}
+				}
 			}
+			// Get unique group DN's from those we have visited in the loop
+			$groups = array_keys($seen);
 		}
-		return $this->access->groupsMatchFilter($allGroups);
+		return $this->access->groupsMatchFilter($groups);
 	}
 
 	/**

--- a/apps/user_ldap/tests/Group_LDAPTest.php
+++ b/apps/user_ldap/tests/Group_LDAPTest.php
@@ -624,7 +624,7 @@ class Group_LDAPTest extends \Test\TestCase {
 			->method('dn2groupname')
 			->will($this->returnArgument(0));
 
-		$access->expects($this->exactly(3))
+		$access->expects($this->exactly(1))
 			->method('groupsMatchFilter')
 			->will($this->returnArgument(0));
 


### PR DESCRIPTION
Currently groupsMatchFilter is called before nested groups are resolved.
This basicly breaks this feature since it is not possible to inherit
membership in a group from another group.

Minimal example:


```
  Group filter: (&(objectClass=group),(cn=nextcloud))
  Nested groups: enabled

  cn=nextcloud,ou=Nextcloud,ou=groups,dn=company,dn=local
    objectClass: group

  cn=IT,ou=groups,dn=company,dn=local
    objectClass: group
    memberOf: cn=nextcloud,ou=Nextcloud,ou=groups,dn=company,dn=local

  cn=John Doe,ou=users,dn=company,dn=local
    objectClass: person
    memberOf: cn=IT,ou=groups,dn=company,dn=local
```

Since 'cn=IT,ou=groups,dn=company,dn=local' doesn't match the group
filter, John wouldn't be a member of group 'nextcloud'.

This patch fixes this by filtering the groups after all nested groups
have been collected. If nested groups is disabled the result will be the
same as without this patch.

Signed-off-by: Roland Tapken <roland@bitarbeiter.net>