### PR TITLE
Allow ldap_dynamic_group_member_url to be a filter

### DIFF
--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -179,9 +179,9 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface, IGroupLD
 
 		$dynamicMembers = array();
 		if (strpos($dynamicGroupMemberURL, '(') === 0) {
-			// This is the filter URL itself. Replace %gid with the group's DN
+			// This is the filter URL itself. Replace %gdn with the group's DN
 			$memberURLs = array(
-				preg_replace('/%gid(?=\b)/', $dnGroup, $dynamicGroupMemberURL)
+				preg_replace('/%gdn(?=\b)/', $dnGroup, $dynamicGroupMemberURL)
 			);
 		} else {
 			// This is an LDAP attribute where the URL can be found in
@@ -641,7 +641,7 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface, IGroupLD
 		if (!empty($dynamicGroupMemberURL)) {
 			// look through dynamic groups to add them to the result array if needed
 			if (strpos($dynamicGroupMemberURL, '(') === 0) {
-				// This is a query filter. '%gid' will be replaced by the group's DN
+				// This is a query filter. '%gdn' will be replaced by the group's DN
 				$urlIsFilter = true;
 				$groupsToMatch = $this->access->fetchListOfGroups(
 					$this->access->connection->ldapGroupFilter, array('dn'));
@@ -653,13 +653,13 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface, IGroupLD
 			}
 			foreach($groupsToMatch as $dynamicGroup) {
 				if ($urlIsFilter) {
-					// Replace '%gid' with the group's DN
+					// Replace '%gdn' with the group's DN
 					if (is_string($dynamicGroup)) {
 						// fetchListOfGroups returns an array of strings when called
 						// with a single attribute to fetch. Make this compatible.
 						$dynamicGroup = array('dn' => array($dynamicGroup));
 					}
-					$memberUrlFilter = preg_replace('/%gid(?=\b)/', $dynamicGroup['dn'][0], $dynamicGroupMemberURL);
+					$memberUrlFilter = preg_replace('/%gdn(?=\b)/', $dynamicGroup['dn'][0], $dynamicGroupMemberURL);
 				} else {
 					// Resolve filter from given attribute
 					if (!array_key_exists($dynamicGroupMemberURL, $dynamicGroup)) {

--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -654,6 +654,11 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface, IGroupLD
 			foreach($groupsToMatch as $dynamicGroup) {
 				if ($urlIsFilter) {
 					// Replace '%gid' with the group's DN
+					if (is_string($dynamicGroup)) {
+						// fetchListOfGroups returns an array of strings when called
+						// with a single attribute to fetch. Make this compatible.
+						$dynamicGroup = array('dn' => array($dynamicGroup));
+					}
 					$memberUrlFilter = preg_replace('/%gid(?=\b)/', $dynamicGroup['dn'][0], $dynamicGroupMemberURL);
 				} else {
 					// Resolve filter from given attribute


### PR DESCRIPTION
This change allows dynamic_group_member_url of the user_ldap module to
be the filter itself instead of an attribute where the filter can
be read from. The value is assumed to be a filter when it starts with
a round bracket. The substring '%gid' will be replaced by the group's
DN.

This allows group members to be resolved by LDAP_MATCHING_RULE_IN_CHAIN
on Active Directory servers. Example:

```
  (&(objectClass=person)(memberOf:1.2.840.113556.1.4.1941:=%gid))
```

Returns all persons that are either direct members of %gid or members
of another group that is member of %gid.

An alternative implementation would be to implement this as a dedicated settings field, but this "simple" solution _works for me_ ;-)

Signed-off-by: Roland Tapken <roland@bitarbeiter.net>