### PR TITLE
Full implement group display names

### DIFF
--- a/apps/dav/lib/CalDAV/Activity/Provider/Calendar.php
+++ b/apps/dav/lib/CalDAV/Activity/Provider/Calendar.php
@@ -26,6 +26,7 @@ namespace OCA\DAV\CalDAV\Activity\Provider;
 use OCP\Activity\IEvent;
 use OCP\Activity\IEventMerger;
 use OCP\Activity\IManager;
+use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
@@ -63,10 +64,11 @@ class Calendar extends Base {
 	 * @param IURLGenerator $url
 	 * @param IManager $activityManager
 	 * @param IUserManager $userManager
+	 * @param IGroupManager $groupManager
 	 * @param IEventMerger $eventMerger
 	 */
-	public function __construct(IFactory $languageFactory, IURLGenerator $url, IManager $activityManager, IUserManager $userManager, IEventMerger $eventMerger) {
-		parent::__construct($userManager);
+	public function __construct(IFactory $languageFactory, IURLGenerator $url, IManager $activityManager, IUserManager $userManager, IGroupManager $groupManager, IEventMerger $eventMerger) {
+		parent::__construct($userManager, $groupManager);
 		$this->languageFactory = $languageFactory;
 		$this->url = $url;
 		$this->activityManager = $activityManager;

--- a/apps/dav/lib/CalDAV/Activity/Provider/Event.php
+++ b/apps/dav/lib/CalDAV/Activity/Provider/Event.php
@@ -26,6 +26,7 @@ namespace OCA\DAV\CalDAV\Activity\Provider;
 use OCP\Activity\IEvent;
 use OCP\Activity\IEventMerger;
 use OCP\Activity\IManager;
+use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
@@ -57,10 +58,11 @@ class Event extends Base {
 	 * @param IURLGenerator $url
 	 * @param IManager $activityManager
 	 * @param IUserManager $userManager
+	 * @param IGroupManager $groupManager
 	 * @param IEventMerger $eventMerger
 	 */
-	public function __construct(IFactory $languageFactory, IURLGenerator $url, IManager $activityManager, IUserManager $userManager, IEventMerger $eventMerger) {
-		parent::__construct($userManager);
+	public function __construct(IFactory $languageFactory, IURLGenerator $url, IManager $activityManager, IUserManager $userManager, IGroupManager $groupManager, IEventMerger $eventMerger) {
+		parent::__construct($userManager, $groupManager);
 		$this->languageFactory = $languageFactory;
 		$this->url = $url;
 		$this->activityManager = $activityManager;

--- a/apps/dav/tests/unit/CalDAV/Activity/Provider/BaseTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Provider/BaseTest.php
@@ -29,6 +29,7 @@ use OCP\Activity\IProvider;
 use OCP\IL10N;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\IGroupManager;
 use Test\TestCase;
 
 class BaseTest extends TestCase {
@@ -36,15 +37,20 @@ class BaseTest extends TestCase {
 	/** @var IUserManager|\PHPUnit_Framework_MockObject_MockObject */
 	protected $userManager;
 
+	/** @var IGroupManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $groupManager;
+
 	/** @var IProvider|Base|\PHPUnit_Framework_MockObject_MockObject */
 	protected $provider;
 
 	protected function setUp() {
 		parent::setUp();
 		$this->userManager = $this->createMock(IUserManager::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->provider = $this->getMockBuilder(Base::class)
 			->setConstructorArgs([
-				$this->userManager
+				$this->userManager,
+				$this->groupManager
 			])
 			->setMethods(['parse'])
 			->getMock();

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -790,9 +790,10 @@ class UsersController extends OCSController {
 		}
 
 		// Get the subadmin groups
-		$groups = $this->groupManager->getSubAdmin()->getSubAdminsGroups($user);
-		foreach ($groups as $key => $group) {
-			$groups[$key] = $group->getGID();
+		$subAdminGroups = $this->groupManager->getSubAdmin()->getSubAdminsGroups($user);
+		$groups = [];
+		foreach ($subAdminGroups as $key => $group) {
+			$groups[] = $group->getGID();
 		}
 
 		if(!$groups) {

--- a/apps/workflowengine/js/admin.js
+++ b/apps/workflowengine/js/admin.js
@@ -170,11 +170,11 @@
 				}).done(function(response) {
 					// add admin groups
 					$.each(response.data.adminGroups, function(id, group) {
-						self.groups.push({ id: group.id, displayname: group.name+'FIXME' });
+						self.groups.push({ id: group.id, displayname: group.name });
 					});
 					// add groups
 					$.each(response.data.groups, function(id, group) {
-						self.groups.push({ id: group.id, displayname: group.name+'FIXME' });
+						self.groups.push({ id: group.id, displayname: group.name });
 					});
 					self.render();
 				}).fail(function(response) {

--- a/apps/workflowengine/js/admin.js
+++ b/apps/workflowengine/js/admin.js
@@ -149,6 +149,7 @@
 			message: '',
 			errorMessage: '',
 			saving: false,
+			groups: [],
 			initialize: function() {
 				// this creates a new copy of the object to definitely have a new reference and being able to reset the model
 				this.originalModel = JSON.parse(JSON.stringify(this.model));
@@ -161,6 +162,24 @@
 				if (this.model.get('id') === undefined) {
 					this.hasChanged = true;
 				}
+				var self = this;
+				$.ajax({
+					url: OC.generateUrl('settings/users/groups'),
+					dataType: 'json',
+					quietMillis: 100,
+				}).done(function(response) {
+					// add admin groups
+					$.each(response.data.adminGroups, function(id, group) {
+						self.groups.push({ id: group.id, displayname: group.name+'FIXME' });
+					});
+					// add groups
+					$.each(response.data.groups, function(id, group) {
+						self.groups.push({ id: group.id, displayname: group.name+'FIXME' });
+					});
+					self.render();
+				}).fail(function(response) {
+					console.error('Failure happened', response);
+				});
 			},
 			delete: function() {
 				if (OC.PasswordConfirmation.requiresPasswordConfirmation()) {
@@ -304,10 +323,11 @@
 						id = $element.data('id'),
 						check = checks[id],
 						valueElement = $element.find('.check-value').first();
+						var self = this;
 
 					_.each(OCA.WorkflowEngine.availablePlugins, function(plugin) {
 						if (_.isFunction(plugin.render)) {
-							plugin.render(valueElement, check);
+							plugin.render(valueElement, check, self.groups);
 						}
 					});
 				}, this);

--- a/apps/workflowengine/js/admin.js
+++ b/apps/workflowengine/js/admin.js
@@ -167,7 +167,7 @@
 					url: OC.generateUrl('settings/users/groups'),
 					dataType: 'json',
 					quietMillis: 100,
-				}).done(function(response) {
+				}).success(function(response) {
 					// add admin groups
 					$.each(response.data.adminGroups, function(id, group) {
 						self.groups.push({ id: group.id, displayname: group.name });
@@ -177,8 +177,9 @@
 						self.groups.push({ id: group.id, displayname: group.name });
 					});
 					self.render();
-				}).fail(function(response) {
-					console.error('Failure happened', response);
+				}).error(function(data) {
+					OC.Notification.error(t('workflowengine', 'Unable to retrieve the group list'), {type: 'error'});
+					console.log(data);
 				});
 			},
 			delete: function() {

--- a/apps/workflowengine/js/usergroupmembershipplugin.js
+++ b/apps/workflowengine/js/usergroupmembershipplugin.js
@@ -42,7 +42,7 @@
 			$(element).css('width', '400px');
 
 			$(element).select2({
-				data: groups,
+				data: { results: groups, text: 'displayname' },
 				initSelection: function (element, callback) {
 					var groupId = element.val();
 					if (groupId && groups.length > 0) {

--- a/apps/workflowengine/js/usergroupmembershipplugin.js
+++ b/apps/workflowengine/js/usergroupmembershipplugin.js
@@ -48,7 +48,9 @@
 					if (groupId && groups.length > 0) {
 						callback({
 							id: groupId,
-							displayname: groups.find(group =>group.id === groupId).displayname
+							displayname: groups.find(function (group) {
+								return group.id === groupId;
+							}).displayname
 						});
 					} else if (groupId) {
 						callback({

--- a/apps/workflowengine/js/usergroupmembershipplugin.js
+++ b/apps/workflowengine/js/usergroupmembershipplugin.js
@@ -64,11 +64,11 @@
 
 						// add admin groups
 						$.each(response.data.adminGroups, function(id, group) {
-							results.push({ id: group.id });
+							results.push({ id: group.id, displayname: group.name });
 						});
 						// add groups
 						$.each(response.data.groups, function(id, group) {
-							results.push({ id: group.id });
+							results.push({ id: group.id, displayname: group.name });
 						});
 
 						// TODO once limit and offset is implemented for groups we should paginate the search results
@@ -79,13 +79,21 @@
 					}
 				},
 				initSelection: function (element, callback) {
-					callback({id: element.val()});
+					var groupId = element.val();
+					if (groupId) {
+						callback({
+							id: groupId,
+							displayname: groupId + 'FIXME' // FIXME
+						});
+					} else {
+						callback();
+					}
 				},
 				formatResult: function (element) {
-					return '<span>' + escapeHTML(element.id) + '</span>';
+					return '<span>' + escapeHTML(element.displayname) + '</span>';
 				},
 				formatSelection: function (element) {
-					return '<span title="'+escapeHTML(element.id)+'">'+escapeHTML(element.id)+'</span>';
+					return '<span title="'+escapeHTML(element.id)+'">'+escapeHTML(element.displayname)+'</span>';
 				}
 			});
 		}

--- a/apps/workflowengine/js/usergroupmembershipplugin.js
+++ b/apps/workflowengine/js/usergroupmembershipplugin.js
@@ -34,7 +34,7 @@
 				]
 			};
 		},
-		render: function(element, check) {
+		render: function(element, check, groups) {
 			if (check['class'] !== 'OCA\\WorkflowEngine\\Check\\UserGroupMembership') {
 				return;
 			}
@@ -42,48 +42,18 @@
 			$(element).css('width', '400px');
 
 			$(element).select2({
-				ajax: {
-					url: OC.generateUrl('settings/users/groups'),
-					dataType: 'json',
-					quietMillis: 100,
-					data: function (term) {
-						return {
-							pattern: term, //search term
-							filterGroups: true,
-							sortGroups: 2 // by groupname
-						};
-					},
-					results: function (response) {
-						// TODO improve error case
-						if (response.data === undefined) {
-							console.error('Failure happened', response);
-							return;
-						}
-
-						var results = [];
-
-						// add admin groups
-						$.each(response.data.adminGroups, function(id, group) {
-							results.push({ id: group.id, displayname: group.name });
-						});
-						// add groups
-						$.each(response.data.groups, function(id, group) {
-							results.push({ id: group.id, displayname: group.name });
-						});
-
-						// TODO once limit and offset is implemented for groups we should paginate the search results
-						return {
-							results: results,
-							more: false
-						};
-					}
-				},
+				data: groups,
 				initSelection: function (element, callback) {
 					var groupId = element.val();
-					if (groupId) {
+					if (groupId && groups.length > 0) {
 						callback({
 							id: groupId,
-							displayname: groupId + 'FIXME' // FIXME
+							displayname: groups.find(group =>group.id === groupId).displayname
+						});
+					} else if (groupId) {
+						callback({
+							id: groupId,
+							displayname: groupId
 						});
 					} else {
 						callback();

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -330,6 +330,17 @@ class Manager extends PublicEmitter implements IGroupManager {
 	}
 
 	/**
+	 * get an array of groupid and displayName for a user
+	 * @param IUser $user
+	 * @return array ['displayName' => displayname]
+	 */
+	public function getUserGroupNames(IUser $user) {
+		return array_map(function($group) {
+			return array('displayName' => $group->getDisplayName());
+		}, $this->getUserGroups($user));
+	}
+
+	/**
 	 * get a list of all display names in a group
 	 * @param string $gid
 	 * @param string $search

--- a/lib/private/Group/MetaData.php
+++ b/lib/private/Group/MetaData.php
@@ -160,7 +160,7 @@ class MetaData {
 	private function generateGroupMetaData(\OCP\IGroup $group, $userSearch) {
 		return array(
 				'id' => $group->getGID(),
-				'name' => $group->getGID(),
+				'name' => $group->getDisplayName(),
 				'usercount' => $this->sorting === self::SORT_USERCOUNT ? $group->count($userSearch) : 0,
 			);
 	}

--- a/lib/private/Settings/Personal/PersonalInfo.php
+++ b/lib/private/Settings/Personal/PersonalInfo.php
@@ -174,7 +174,7 @@ class PersonalInfo implements ISettings {
 	private function getGroups(IUser $user) {
 		$groups = array_map(
 			function(IGroup $group) {
-				return $group->getGID();
+				return $group->getDisplayName();
 			},
 			$this->groupManager->getUserGroups($user)
 		);

--- a/lib/private/SubAdmin.php
+++ b/lib/private/SubAdmin.php
@@ -62,7 +62,7 @@ class SubAdmin extends PublicEmitter {
 			$this->post_deleteUser($user);
 		});
 		$this->groupManager->listen('\OC\Group', 'postDelete', function($group) {
-			$this->post_deleteGroup($group);	
+			$this->post_deleteGroup($group);
 		});
 	}
 
@@ -123,12 +123,23 @@ class SubAdmin extends PublicEmitter {
 		while($row = $result->fetch()) {
 			$group = $this->groupManager->get($row['gid']);
 			if(!is_null($group)) {
-				$groups[] = $group;
+				$groups[$group->getGID()] = $group;
 			}
 		}
 		$result->closeCursor();
 
 		return $groups;
+	}
+
+	/**
+	 * get an array of groupid and displayName for a user
+	 * @param IUser $user
+	 * @return array ['displayName' => displayname]
+	 */
+	public function getSubAdminsGroupsName(IUser $user) {
+		return array_map(function($group) {
+			return array('displayName' => $group->getDisplayName());
+		}, $this->getSubAdminsGroups($user));
 	}
 
 	/**
@@ -185,7 +196,7 @@ class SubAdmin extends PublicEmitter {
 
 	/**
 	 * checks if a user is a SubAdmin of a group
-	 * @param IUser $user 
+	 * @param IUser $user
 	 * @param IGroup $group
 	 * @return bool
 	 */
@@ -210,7 +221,7 @@ class SubAdmin extends PublicEmitter {
 
 	/**
 	 * checks if a user is a SubAdmin
-	 * @param IUser $user 
+	 * @param IUser $user
 	 * @return bool
 	 */
 	public function isSubAdmin(IUser $user) {

--- a/settings/Controller/GroupsController.php
+++ b/settings/Controller/GroupsController.php
@@ -28,6 +28,7 @@ use OC\AppFramework\Http;
 use OC\Group\MetaData;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -108,13 +109,9 @@ class GroupsController extends Controller {
 				Http::STATUS_CONFLICT
 			);
 		}
-		if($this->groupManager->createGroup($id)) {
-			return new DataResponse(
-				array(
-					'groupname' => $id
-				),
-				Http::STATUS_CREATED
-			);
+		$group = $this->groupManager->createGroup($id);
+		if($group instanceof IGroup) {
+			return new DataResponse(['groupname' => $group->getDisplayName()], Http::STATUS_CREATED);
 		}
 
 		return new DataResponse(
@@ -140,9 +137,7 @@ class GroupsController extends Controller {
 				return new DataResponse(
 					array(
 						'status' => 'success',
-						'data' => array(
-							'groupname' => $id
-						)
+						'data' => ['groupname' => $group->getDisplayName()]
 					),
 					Http::STATUS_NO_CONTENT
 				);

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -223,10 +223,7 @@ class UsersController extends Controller {
 			$restorePossible = true;
 		}
 
-		$subAdminGroups = $this->groupManager->getSubAdmin()->getSubAdminsGroups($user);
-		foreach ($subAdminGroups as $key => $subAdminGroup) {
-			$subAdminGroups[$key] = $subAdminGroup->getGID();
-		}
+		$subAdminGroups = $this->groupManager->getSubAdmin()->getSubAdminsGroupsName($user);
 
 		$displayName = $user->getEMailAddress();
 		if (is_null($displayName)) {
@@ -243,7 +240,7 @@ class UsersController extends Controller {
 		return [
 			'name' => $user->getUID(),
 			'displayname' => $user->getDisplayName(),
-			'groups' => empty($userGroups) ? $this->groupManager->getUserGroupIds($user) : $userGroups,
+			'groups' => empty($userGroups) ? $this->groupManager->getUserGroupNames($user) : $userGroups,
 			'subadmin' => $subAdminGroups,
 			'quota' => $user->getQuota(),
 			'quota_bytes' => Util::computerFileSize($user->getQuota()),
@@ -344,7 +341,7 @@ class UsersController extends Controller {
 			foreach ($batch as $user) {
 				// Only add the groups, this user is a subadmin of
 				$userGroups = array_values(array_intersect(
-					$this->groupManager->getUserGroupIds($user),
+					$this->groupManager->getUserGroupNames($user),
 					$subAdminOfGroups
 				));
 				if (($gid !== '_disabledUsers' && $user->isEnabled()) ||
@@ -484,7 +481,7 @@ class UsersController extends Controller {
 				}
 			}
 			// fetch users groups
-			$userGroups = $this->groupManager->getUserGroupIds($user);
+			$userGroups = $this->groupManager->getUserGroupNames($user);
 
 			return new DataResponse(
 				$this->formatUserForIndex($user, $userGroups),

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -341,7 +341,7 @@ class UsersController extends Controller {
 			foreach ($batch as $user) {
 				// Only add the groups, this user is a subadmin of
 				$userGroups = array_values(array_intersect(
-					$this->groupManager->getUserGroupNames($user),
+					$this->groupManager->getUserGroupIds($user),
 					$subAdminOfGroups
 				));
 				if (($gid !== '_disabledUsers' && $user->isEnabled()) ||

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -641,14 +641,13 @@ OC.Settings.Apps = OC.Settings.Apps || {
 						$('#navigation li[data-id=' + previousEntry.id + ']').after(li);
 
 						// draw attention to the newly added app entry
-						// by flashing it twice
+						// by flashing twice the more apps menu
 						if(addedApps[entry.id]) {
-							$('#header .menutoggle')
+							$('#header #more-apps')
 								.animate({opacity: 0.5})
 								.animate({opacity: 1})
 								.animate({opacity: 0.5})
-								.animate({opacity: 1})
-								.animate({opacity: 0.75});
+								.animate({opacity: 1});
 						}
 					}
 

--- a/settings/js/settings.js
+++ b/settings/js/settings.js
@@ -73,12 +73,10 @@ OC.Settings = _.extend(OC.Settings, {
 					return element.id;
 				},
 				initSelection: function(element, callback) {
-					var selection =
-						_.map(($(element).val() || []).split('|').sort(),
-							function(groupName) {
+					var selection = _.map(($(element).val() || []).split('|').sort(), function(groupId) {
 						return {
-							id: groupName,
-							displayname: groupName
+							id: groupId,
+							displayname: groupId + 'FIXME' // FIXME
 						};
 					});
 					callback(selection);

--- a/settings/js/settings.js
+++ b/settings/js/settings.js
@@ -40,8 +40,6 @@ OC.Settings = _.extend(OC.Settings, {
 					$.each(data.data.groups, function(i, group) {
 						results.push({id:group.id, displayname:group.name});
 					});
-				},
-				always: function() {
 					// note: settings are saved through a "change" event registered
 					// on all input fields
 					$elements.select2(_.extend({

--- a/settings/js/users/groups.js
+++ b/settings/js/users/groups.js
@@ -18,6 +18,9 @@ GroupList = {
 	filterGroups: false,
 
 	addGroup: function (gid, displayName, usercount) {
+		if (_.isUndefined(displayName)) {
+			displayName = gid;
+		}
 		var $li = $userGroupList.find('.isgroup:last-child').clone();
 		$li
 			.data('gid', gid)
@@ -142,7 +145,7 @@ GroupList = {
 			function (result) {
 				if (result.groupname) {
 					var addedGroup = result.groupname;
-					UserList.availableGroups[result.id] = {displayName: result.groupName};
+					UserList.availableGroups[groupid] = {displayName: result.groupname};
 					GroupList.addGroup(groupid, result.groupname);
 				}
 				GroupList.toggleAddGroup();

--- a/settings/js/users/groups.js
+++ b/settings/js/users/groups.js
@@ -17,11 +17,11 @@ GroupList = {
 	filter: '',
 	filterGroups: false,
 
-	addGroup: function (gid, usercount) {
+	addGroup: function (gid, displayName, usercount) {
 		var $li = $userGroupList.find('.isgroup:last-child').clone();
 		$li
 			.data('gid', gid)
-			.find('.groupname').text(gid);
+			.find('.groupname').text(displayName);
 		GroupList.setUserCount($li, usercount);
 
 		$li.appendTo($userGroupList);
@@ -128,22 +128,22 @@ GroupList = {
 		}
 	},
 
-	createGroup: function (groupname) {
+	createGroup: function (groupid) {
 		if (OC.PasswordConfirmation.requiresPasswordConfirmation()) {
-			OC.PasswordConfirmation.requirePasswordConfirmation(_.bind(this.createGroup, this, groupname));
+			OC.PasswordConfirmation.requirePasswordConfirmation(_.bind(this.createGroup, this, groupid));
 			return;
 		}
 
 		$.post(
 			OC.generateUrl('/settings/users/groups'),
 			{
-				id: groupname
+				id: groupid
 			},
 			function (result) {
 				if (result.groupname) {
 					var addedGroup = result.groupname;
 					UserList.availableGroups = $.unique($.merge(UserList.availableGroups, [addedGroup]));
-					GroupList.addGroup(result.groupname);
+					GroupList.addGroup(groupid, result.groupname);
 				}
 				GroupList.toggleAddGroup();
 			}).fail(function(result) {
@@ -173,7 +173,7 @@ GroupList = {
 								GroupList.setUserCount(GroupList.getGroupLI(group.name).first(), group.usercount);
 							}
 							else {
-								var $li = GroupList.addGroup(group.name, group.usercount);
+								var $li = GroupList.addGroup(group.id, group.name, group.usercount);
 
 								$li.addClass('appear transparent');
 								lis.push($li);

--- a/settings/js/users/groups.js
+++ b/settings/js/users/groups.js
@@ -142,7 +142,7 @@ GroupList = {
 			function (result) {
 				if (result.groupname) {
 					var addedGroup = result.groupname;
-					UserList.availableGroups = $.unique($.merge(UserList.availableGroups, [addedGroup]));
+					UserList.availableGroups[result.id] = {displayName: result.groupName};
 					GroupList.addGroup(groupid, result.groupname);
 				}
 				GroupList.toggleAddGroup();

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -66,7 +66,7 @@ var UserList = {
 	 * 			}
 	 */
 	add: function (user) {
-		if (this.currentGid && this.currentGid !== '_everyone' && this.currentGid !== '_disabledUsers' && _.indexOf(user.groups, this.currentGid) < 0) {
+		if (this.currentGid && this.currentGid !== '_everyone' && this.currentGid !== '_disabledUsers' && Object.keys(user.groups).indexOf(this.currentGid) < 0) {
 			return false;
 		}
 
@@ -454,7 +454,6 @@ var UserList = {
 				if (!OC.isUserAdmin() && checked.length === 1 && checked[0] === group) {
 					return false;
 				}
-
 				if (add && OC.isUserAdmin() && _.isUndefined(UserList.availableGroups[group])) {
 					GroupList.createGroup(group);
 					if (_.isUndefined(UserList.availableGroups[group])) {

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -1071,6 +1071,7 @@ $(document).ready(function () {
 
 		promise.then(function () {
 			var groups = $('#newuser .groups').data('groups') || {};
+			groups = Object.keys(groups);
 			$.post(
 				OC.generateUrl('/settings/users/users'),
 				{

--- a/settings/templates/users/main.php
+++ b/settings/templates/users/main.php
@@ -21,10 +21,10 @@ style('settings', 'settings');
 $userlistParams = array();
 $allGroups=array();
 foreach($_["adminGroup"] as $group) {
-	$allGroups[] = $group['name'];
+	$allGroups[$group['id']] = array('displayName' => $group['name']);
 }
 foreach($_["groups"] as $group) {
-	$allGroups[] = $group['name'];
+	$allGroups[$group['id']] = array('displayName' => $group['name']);
 }
 $userlistParams['subadmingroups'] = $allGroups;
 $userlistParams['allGroups'] = json_encode($allGroups);

--- a/settings/templates/users/part.grouplist.php
+++ b/settings/templates/users/part.grouplist.php
@@ -50,7 +50,7 @@
 
 	<!--List of Groups-->
 	<?php foreach($_["groups"] as $group): ?>
-		<li data-gid="<?php p($group['name']) ?>" data-usercount="<?php p($group['usercount']) ?>" class="isgroup">
+		<li data-gid="<?php p($group['id']) ?>" data-usercount="<?php p($group['usercount']) ?>" class="isgroup">
 			<a href="#" class="dorename">
 				<span class="groupname"><?php p($group['name']); ?></span>
 			</a>

--- a/tests/Settings/Controller/GroupsControllerTest.php
+++ b/tests/Settings/Controller/GroupsControllerTest.php
@@ -67,6 +67,9 @@ class GroupsControllerTest extends \Test\TestCase {
 			->method('getGID')
 			->will($this->returnValue('firstGroup'));
 		$firstGroup
+			->method('getDisplayName')
+			->will($this->returnValue('First group'));
+		$firstGroup
 			->method('count')
 			->will($this->returnValue(12));
 		$secondGroup = $this->getMockBuilder(Group::class)
@@ -74,6 +77,9 @@ class GroupsControllerTest extends \Test\TestCase {
 		$secondGroup
 			->method('getGID')
 			->will($this->returnValue('secondGroup'));
+		$secondGroup
+			->method('getDisplayName')
+			->will($this->returnValue('Second group'));
 		$secondGroup
 			->method('count')
 			->will($this->returnValue(25));
@@ -83,6 +89,9 @@ class GroupsControllerTest extends \Test\TestCase {
 			->method('getGID')
 			->will($this->returnValue('thirdGroup'));
 		$thirdGroup
+			->method('getDisplayName')
+			->will($this->returnValue('Third group'));
+		$thirdGroup
 			->method('count')
 			->will($this->returnValue(14));
 		$fourthGroup = $this->getMockBuilder(Group::class)
@@ -90,6 +99,9 @@ class GroupsControllerTest extends \Test\TestCase {
 		$fourthGroup
 			->method('getGID')
 			->will($this->returnValue('admin'));
+		$fourthGroup
+			->method('getDisplayName')
+			->will($this->returnValue('Admin'));
 		$fourthGroup
 			->method('count')
 			->will($this->returnValue(18));
@@ -119,7 +131,7 @@ class GroupsControllerTest extends \Test\TestCase {
 				'adminGroups' => array(
 					0 => array(
 						'id' => 'admin',
-						'name' => 'admin',
+						'name' => 'Admin',
 						'usercount' => 0,//User count disabled 18,
 					)
 				),
@@ -127,17 +139,17 @@ class GroupsControllerTest extends \Test\TestCase {
 					array(
 						0 => array(
 							'id' => 'firstGroup',
-							'name' => 'firstGroup',
+							'name' => 'First group',
 							'usercount' => 0,//User count disabled 12,
 						),
 						1 => array(
 							'id' => 'secondGroup',
-							'name' => 'secondGroup',
+							'name' => 'Second group',
 							'usercount' => 0,//User count disabled 25,
 						),
 						2 => array(
 							'id' => 'thirdGroup',
-							'name' => 'thirdGroup',
+							'name' => 'Third group',
 							'usercount' => 0,//User count disabled 14,
 						),
 					)
@@ -159,6 +171,9 @@ class GroupsControllerTest extends \Test\TestCase {
 			->method('getGID')
 			->will($this->returnValue('firstGroup'));
 		$firstGroup
+			->method('getDisplayName')
+			->will($this->returnValue('First group'));
+		$firstGroup
 			->method('count')
 			->will($this->returnValue(12));
 		$secondGroup = $this->getMockBuilder(Group::class)
@@ -166,6 +181,9 @@ class GroupsControllerTest extends \Test\TestCase {
 		$secondGroup
 			->method('getGID')
 			->will($this->returnValue('secondGroup'));
+		$secondGroup
+			->method('getDisplayName')
+			->will($this->returnValue('Second group'));
 		$secondGroup
 			->method('count')
 			->will($this->returnValue(25));
@@ -175,6 +193,9 @@ class GroupsControllerTest extends \Test\TestCase {
 			->method('getGID')
 			->will($this->returnValue('thirdGroup'));
 		$thirdGroup
+			->method('getDisplayName')
+			->will($this->returnValue('Third group'));
+		$thirdGroup
 			->method('count')
 			->will($this->returnValue(14));
 		$fourthGroup = $this->getMockBuilder(Group::class)
@@ -182,6 +203,9 @@ class GroupsControllerTest extends \Test\TestCase {
 		$fourthGroup
 			->method('getGID')
 			->will($this->returnValue('admin'));
+		$fourthGroup
+			->method('getDisplayName')
+			->will($this->returnValue('Admin'));
 		$fourthGroup
 			->method('count')
 			->will($this->returnValue(18));
@@ -212,7 +236,7 @@ class GroupsControllerTest extends \Test\TestCase {
 				'adminGroups' => array(
 					0 => array(
 						'id' => 'admin',
-						'name' => 'admin',
+						'name' => 'Admin',
 						'usercount' => 18,
 					)
 				),
@@ -220,17 +244,17 @@ class GroupsControllerTest extends \Test\TestCase {
 					array(
 						0 => array(
 							'id' => 'secondGroup',
-							'name' => 'secondGroup',
+							'name' => 'Second group',
 							'usercount' => 25,
 						),
 						1 => array(
 							'id' => 'thirdGroup',
-							'name' => 'thirdGroup',
+							'name' => 'Third group',
 							'usercount' => 14,
 						),
 						2 => array(
 							'id' => 'firstGroup',
-							'name' => 'firstGroup',
+							'name' => 'First group',
 							'usercount' => 12,
 						),
 					)
@@ -259,6 +283,8 @@ class GroupsControllerTest extends \Test\TestCase {
 	}
 
 	public function testCreateSuccessful() {
+		$group = $this->getMockBuilder(Group::class)
+			->disableOriginalConstructor()->getMock();
 		$this->groupManager
 			->expects($this->once())
 			->method('groupExists')
@@ -268,7 +294,11 @@ class GroupsControllerTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('createGroup')
 			->with('NewGroup')
-			->will($this->returnValue(true));
+			->will($this->returnValue($group));
+		$group
+			->expects($this->once())
+			->method('getDisplayName')
+			->will($this->returnValue('NewGroup'));
 
 		$expectedResponse = new DataResponse(
 			array(
@@ -315,6 +345,9 @@ class GroupsControllerTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('delete')
 			->will($this->returnValue(true));
+		$group
+			->method('getDisplayName')
+			->will($this->returnValue('ExistingGroup'));
 
 		$expectedResponse = new DataResponse(
 			array(

--- a/tests/Settings/Controller/UsersControllerTest.php
+++ b/tests/Settings/Controller/UsersControllerTest.php
@@ -206,7 +206,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$foo
 			->expects($this->exactly(2))
 			->method('getQuota')
-			->will($this->returnValue('1024'));
+			->will($this->returnValue(1024));
 		$foo
 			->method('getLastLogin')
 			->will($this->returnValue(500));
@@ -236,7 +236,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$admin
 			->expects($this->exactly(2))
 			->method('getQuota')
-			->will($this->returnValue('404'));
+			->will($this->returnValue(404));
 		$admin
 			->expects($this->once())
 			->method('getLastLogin')
@@ -268,7 +268,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$bar
 			->expects($this->exactly(2))
 			->method('getQuota')
-			->will($this->returnValue('2323'));
+			->will($this->returnValue(2323));
 		$bar
 			->method('getLastLogin')
 			->will($this->returnValue(3999));
@@ -296,8 +296,20 @@ class UsersControllerTest extends \Test\TestCase {
 			->will($this->returnValue(array('foo' => 'M. Foo', 'admin' => 'S. Admin', 'bar' => 'B. Ar')));
 		$this->groupManager
 			->expects($this->exactly(3))
-			->method('getUserGroupIds')
-			->will($this->onConsecutiveCalls(array('Users', 'Support'), array('admins', 'Support'), array('External Users')));
+			->method('getUserGroupNames')
+			->will($this->onConsecutiveCalls(
+				array(
+					'Users' => array('displayName' => 'Users'),
+					'Support' => array('displayName' => 'Support')
+				),
+				array(
+					'admins' => array('displayName' => 'admins'),
+					'Support' => array('displayName' => 'Support')
+				),
+				array(
+					'External Users' => array('displayName' => 'External Users')
+				)
+			));
 		$this->userManager
 			->expects($this->at(0))
 			->method('get')
@@ -319,17 +331,17 @@ class UsersControllerTest extends \Test\TestCase {
 			->getMock();
 		$subadmin
 			->expects($this->any())
-			->method('getSubAdminsGroups')
+			->method('getSubAdminsGroupsName')
 			->with($foo)
 			->will($this->returnValue([]));
 		$subadmin
 			->expects($this->any())
-			->method('getSubAdminsGroups')
+			->method('getSubAdminsGroupsName')
 			->with($admin)
 			->will($this->returnValue([]));
 		$subadmin
 			->expects($this->any())
-			->method('getSubAdminsGroups')
+			->method('getSubAdminsGroupsName')
 			->with($bar)
 			->will($this->returnValue([]));
 		$this->groupManager
@@ -347,10 +359,13 @@ class UsersControllerTest extends \Test\TestCase {
 				0 => array(
 					'name' => 'foo',
 					'displayname' => 'M. Foo',
-					'groups' => array('Users', 'Support'),
+					'groups' => array(
+						'Users' => array('displayName' => 'Users'),
+						'Support' => array('displayName' => 'Support')
+					),
 					'subadmin' => array(),
 					'quota' => 1024,
-					'quota_bytes' => 1024,
+					'quota_bytes' => 1024.0,
 					'storageLocation' => '/home/foo',
 					'lastLogin' => 500000,
 					'backend' => 'OC_User_Database',
@@ -363,10 +378,13 @@ class UsersControllerTest extends \Test\TestCase {
 				1 => array(
 					'name' => 'admin',
 					'displayname' => 'S. Admin',
-					'groups' => array('admins', 'Support'),
+					'groups' => array(
+						'admins' => array('displayName' => 'admins'),
+						'Support' => array('displayName' => 'Support')
+					),
 					'subadmin' => array(),
 					'quota' => 404,
-					'quota_bytes' => 404,
+					'quota_bytes' => 404.0,
 					'storageLocation' => '/home/admin',
 					'lastLogin' => 12000,
 					'backend' => Dummy::class,
@@ -379,10 +397,12 @@ class UsersControllerTest extends \Test\TestCase {
 				2 => array(
 					'name' => 'bar',
 					'displayname' => 'B. Ar',
-					'groups' => array('External Users'),
+					'groups' => array(
+						'External Users' => array('displayName' => 'External Users')
+					),
 					'subadmin' => array(),
 					'quota' => 2323,
-					'quota_bytes' => 2323,
+					'quota_bytes' => 2323.0,
 					'storageLocation' => '/home/bar',
 					'lastLogin' => 3999000,
 					'backend' => Dummy::class,
@@ -555,6 +575,10 @@ class UsersControllerTest extends \Test\TestCase {
 			->will($this->returnValue([$subgroup1, $subgroup2]));
 		$subadmin
 			->expects($this->any())
+			->method('getSubAdminsGroupsName')
+			->will($this->returnValue([]));
+		$subadmin
+			->expects($this->any())
 			->method('getSubAdminsGroups')
 			->will($this->returnValue([]));
 		$this->groupManager
@@ -574,8 +598,8 @@ class UsersControllerTest extends \Test\TestCase {
 					'displayname' => 'B. Ar',
 					'groups' => ['SubGroup1'],
 					'subadmin' => [],
-					'quota' => 2323,
-					'quota_bytes' => 2323,
+					'quota' => '2323',
+					'quota_bytes' => 2323.0,
 					'storageLocation' => '/home/bar',
 					'lastLogin' => 3999000,
 					'backend' => Dummy::class,
@@ -590,8 +614,8 @@ class UsersControllerTest extends \Test\TestCase {
 					'displayname' => 'M. Foo',
 					'groups' => ['SubGroup2', 'SubGroup1'],
 					'subadmin' => [],
-					'quota' => 1024,
-					'quota_bytes' => 1024,
+					'quota' => '1024',
+					'quota_bytes' => 1024.0,
 					'storageLocation' => '/home/foo',
 					'lastLogin' => 500000,
 					'backend' => 'OC_User_Database',
@@ -606,8 +630,8 @@ class UsersControllerTest extends \Test\TestCase {
 					'displayname' => 'S. Admin',
 					'groups' => ['SubGroup2'],
 					'subadmin' => [],
-					'quota' => 404,
-					'quota_bytes' => 404,
+					'quota' => '404',
+					'quota_bytes' => 404.0,
 					'storageLocation' => '/home/admin',
 					'lastLogin' => 12000,
 					'backend' => Dummy::class,
@@ -731,14 +755,26 @@ class UsersControllerTest extends \Test\TestCase {
 			->will($this->returnValue([$foo, $admin, $bar]));
 		$this->groupManager
 			->expects($this->exactly(3))
-			->method('getUserGroupIds')
-			->will($this->onConsecutiveCalls(array('Users', 'Support'), array('admins', 'Support'), array('External Users')));
+			->method('getUserGroupNames')
+			->will($this->onConsecutiveCalls(
+				array(
+					'Users' => array('displayName' => 'Users'),
+					'Support' => array('displayName' => 'Support')
+				),
+				array(
+					'admins' => array('displayName' => 'admins'),
+					'Support' => array('displayName' => 'Support')
+				),
+				array(
+					'External Users' => array('displayName' => 'External Users')
+				)
+			));
 
 		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->any())
-			->method('getSubAdminsGroups')
+			->method('getSubAdminsGroupsName')
 			->will($this->returnValue([]));
 		$this->groupManager
 			->expects($this->any())
@@ -755,7 +791,10 @@ class UsersControllerTest extends \Test\TestCase {
 				0 => array(
 					'name' => 'foo',
 					'displayname' => 'M. Foo',
-					'groups' => array('Users', 'Support'),
+					'groups' => array(
+						'Users' => array('displayName' => 'Users'),
+						'Support' => array('displayName' => 'Support')
+					),
 					'subadmin' => array(),
 					'quota' => 1024,
 					'quota_bytes' => 1024,
@@ -771,7 +810,10 @@ class UsersControllerTest extends \Test\TestCase {
 				1 => array(
 					'name' => 'admin',
 					'displayname' => 'S. Admin',
-					'groups' => array('admins', 'Support'),
+					'groups' => array(
+						'admins' => array('displayName' => 'admins'),
+						'Support' => array('displayName' => 'Support')
+					),
 					'subadmin' => array(),
 					'quota' => 404,
 					'quota_bytes' => 404,
@@ -787,7 +829,9 @@ class UsersControllerTest extends \Test\TestCase {
 				2 => array(
 					'name' => 'bar',
 					'displayname' => 'B. Ar',
-					'groups' => array('External Users'),
+					'groups' => array(
+						'External Users' => array('displayName' => 'External Users')
+					),
 					'subadmin' => array(),
 					'quota' => 2323,
 					'quota_bytes' => 2323,
@@ -857,7 +901,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->once())
-			->method('getSubAdminsGroups')
+			->method('getSubAdminsGroupsName')
 			->will($this->returnValue([]));
 		$this->groupManager
 			->expects($this->any())
@@ -944,7 +988,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->getMock();
 		$subadmin
 			->expects($this->any())
-			->method('getSubAdminsGroups')
+			->method('getSubAdminsGroupsName')
 			->with($user)
 			->will($this->returnValue([]));
 		$this->groupManager
@@ -1022,16 +1066,21 @@ class UsersControllerTest extends \Test\TestCase {
 			->will($this->onConsecutiveCalls($newGroup));
 		$this->groupManager
 			->expects($this->once())
-			->method('getUserGroupIds')
+			->method('getUserGroupNames')
 			->with($user)
-			->will($this->onConsecutiveCalls(array('NewGroup', 'ExistingGroup')));
+			->will($this->onConsecutiveCalls(
+				array(
+					'NewGroup' => array('displayName' => 'NewGroup'),
+					'ExistingGroup' => array('displayName' => 'ExistingGroup')
+				)
+			));
 
 		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin
 			->expects($this->once())
-			->method('getSubAdminsGroups')
+			->method('getSubAdminsGroupsName')
 			->with($user)
 			->will($this->returnValue([]));
 		$this->groupManager
@@ -1042,7 +1091,10 @@ class UsersControllerTest extends \Test\TestCase {
 		$expectedResponse = new DataResponse(
 			array(
 				'name' => 'foo',
-				'groups' => array('NewGroup', 'ExistingGroup'),
+				'groups' => array(
+					'NewGroup' => array('displayName' => 'NewGroup'),
+					'ExistingGroup' => array('displayName' => 'ExistingGroup')
+				),
 				'storageLocation' => '/home/user',
 				'backend' => 'bar',
 				'lastLogin' => null,
@@ -1100,18 +1152,20 @@ class UsersControllerTest extends \Test\TestCase {
 			->will($this->returnValue($newUser));
 		$this->groupManager
 			->expects($this->once())
-			->method('getUserGroupIds')
+			->method('getUserGroupNames')
 			->with($user)
-			->will($this->onConsecutiveCalls(['SubGroup1']));
+			->will($this->onConsecutiveCalls(array('SubGroup1' =>
+				array('displayName' => 'SubGroup1')
+			)));
 		$this->groupManager
 			->expects($this->once())
-			->method('getUserGroupIds')
+			->method('getUserGroupNames')
 			->with($newUser)
 			->will($this->onConsecutiveCalls(['SubGroup1']));
 
 		$subadmin = $this->createMock(\OC\SubAdmin::class);
 		$subadmin->expects($this->atLeastOnce())
-			->method('getSubAdminsGroups')
+			->method('getSubAdminsGroupsName')
 			->with($user)
 			->willReturnMap([
 				[$user, [$subGroup1]],
@@ -1135,7 +1189,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$expectedResponse = new DataResponse(
 			array(
 				'name' => 'foo',
-				'groups' => ['SubGroup1'],
+				'groups' => array('SubGroup1' => array('displayName' => 'SubGroup1')),
 				'storageLocation' => '/home/user',
 				'backend' => 'bar',
 				'lastLogin' => 0,
@@ -1563,7 +1617,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->once())
-			->method('getSubAdminsGroups')
+			->method('getSubAdminsGroupsName')
 			->with($user)
 			->will($this->returnValue([]));
 		$this->groupManager
@@ -1629,7 +1683,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->once())
-			->method('getSubAdminsGroups')
+			->method('getSubAdminsGroupsName')
 			->with($user)
 			->will($this->returnValue([]));
 		$this->groupManager
@@ -1676,7 +1730,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->once())
-			->method('getSubAdminsGroups')
+			->method('getSubAdminsGroupsName')
 			->with($user)
 			->will($this->returnValue([]));
 		$this->groupManager
@@ -1714,7 +1768,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->once())
-			->method('getSubAdminsGroups')
+			->method('getSubAdminsGroupsName')
 			->with($user)
 			->will($this->returnValue([]));
 		$this->groupManager
@@ -1771,7 +1825,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->once())
-			->method('getSubAdminsGroups')
+			->method('getSubAdminsGroupsName')
 			->with($user)
 			->will($this->returnValue([]));
 		$this->groupManager
@@ -1793,7 +1847,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$subadmin->expects($this->once())
-			->method('getSubAdminsGroups')
+			->method('getSubAdminsGroupsName')
 			->with($user)
 			->will($this->returnValue([]));
 		$this->groupManager
@@ -1858,6 +1912,10 @@ class UsersControllerTest extends \Test\TestCase {
 		$subadmin = $this->getMockBuilder(SubAdmin::class)
 			->disableOriginalConstructor()
 			->getMock();
+		$subadmin
+			->expects($this->at(0))
+			->method('getSubAdminsGroupsName')
+			->will($this->returnValue([$group1, $group2]));
 		$subadmin
 			->expects($this->at(0))
 			->method('getSubAdminsGroups')
@@ -2430,7 +2488,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->getMock();
 		$subadmin
 			->expects($this->any())
-			->method('getSubAdminsGroups')
+			->method('getSubAdminsGroupsName')
 			->with($user)
 			->will($this->returnValue([]));
 		$this->groupManager

--- a/tests/lib/Group/MetaDataTest.php
+++ b/tests/lib/Group/MetaDataTest.php
@@ -56,9 +56,9 @@ class MetaDataTest extends \Test\TestCase {
 		$group->expects($this->exactly(6))
 			->method('getGID')
 			->will($this->onConsecutiveCalls(
-				'admin', 'admin', 'admin',
-				'g2', 'g2', 'g2',
-				'g3', 'g3', 'g3'));
+				'admin', 'admin',
+				'g2', 'g2',
+				'g3', 'g3'));
 
 		$group->expects($this->exactly(3))
 			->method('getDisplayName')

--- a/tests/lib/Group/MetaDataTest.php
+++ b/tests/lib/Group/MetaDataTest.php
@@ -53,12 +53,19 @@ class MetaDataTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$group->expects($this->exactly(9))
+		$group->expects($this->exactly(6))
 			->method('getGID')
 			->will($this->onConsecutiveCalls(
 				'admin', 'admin', 'admin',
 				'g2', 'g2', 'g2',
 				'g3', 'g3', 'g3'));
+
+		$group->expects($this->exactly(3))
+			->method('getDisplayName')
+			->will($this->onConsecutiveCalls(
+				'admin',
+				'g2',
+				'g3'));
 
 		$group->expects($this->exactly($countCallCount))
 			->method('count')


### PR DESCRIPTION
- [x] Personal settings show group id instead of display names in list
- [x] Activities use group id instead of display names
- [x] Select2 in the WorkflowEngine shows the id on load, dropdown and selecting new values works
- [x] Select2 in the OC.Settings.setupGroupsSelect shows the id on load, dropdown and selecting new values works
- [x] User management: user group and subadmin selection is messed up
- [x] Tests

Need someone with better JS/select2 skills to solve this.

### Good patch for testing
```diff
diff --git a/lib/private/Group/Group.php b/lib/private/Group/Group.php
index 6795f0e2f5..24e8a7ad00 100644
--- a/lib/private/Group/Group.php
+++ b/lib/private/Group/Group.php
@@ -87,9 +87,9 @@ class Group implements IGroup {
 
        public function getDisplayName() {
                if (is_null($this->displayName)) {
-                       return $this->gid;
+                       return 'DisplayName{' . $this->gid . '}';
                }
-               return $this->displayName;
+               return 'DisplayName{' . $this->displayName . '}';
        }
 
        /**
```


Fixes #742