### PR TITLE
Show share owner avatars on all file lists

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -12,6 +12,7 @@
 
 	_.extend(OC.Files.Client, {
 		PROPERTY_SHARE_TYPES:	'{' + OC.Files.Client.NS_OWNCLOUD + '}share-types',
+		PROPERTY_OWNER_ID:	'{' + OC.Files.Client.NS_OWNCLOUD + '}owner-id',
 		PROPERTY_OWNER_DISPLAY_NAME:	'{' + OC.Files.Client.NS_OWNCLOUD + '}owner-display-name'
 	});
 
@@ -66,6 +67,7 @@
 				var fileInfo = oldElementToFile.apply(this, arguments);
 				fileInfo.sharePermissions = $el.attr('data-share-permissions') || undefined;
 				fileInfo.shareOwner = $el.attr('data-share-owner') || undefined;
+				fileInfo.shareOwnerId = $el.attr('data-share-owner-id') || undefined;
 
 				if( $el.attr('data-share-types')){
 					fileInfo.shareTypes = $el.attr('data-share-types').split(',');
@@ -83,6 +85,7 @@
 			var oldGetWebdavProperties = fileList._getWebdavProperties;
 			fileList._getWebdavProperties = function() {
 				var props = oldGetWebdavProperties.apply(this, arguments);
+				props.push(OC.Files.Client.PROPERTY_OWNER_ID);
 				props.push(OC.Files.Client.PROPERTY_OWNER_DISPLAY_NAME);
 				props.push(OC.Files.Client.PROPERTY_SHARE_TYPES);
 				return props;
@@ -95,6 +98,7 @@
 
 				if (permissionsProp && permissionsProp.indexOf('S') >= 0) {
 					data.shareOwner = props[OC.Files.Client.PROPERTY_OWNER_DISPLAY_NAME];
+					data.shareOwnerId = props[OC.Files.Client.PROPERTY_OWNER_ID];
 				}
 
 				var shareTypesProp = props[OC.Files.Client.PROPERTY_SHARE_TYPES];


### PR DESCRIPTION
Follow up on https://github.com/nextcloud/server/pull/6094

This PR shows the avatar of the owner of shared files on every file list not only the sharing views.

Before:
![bildschirmfoto vom 2018-02-09 11-50-39](https://user-images.githubusercontent.com/3404133/36024249-7a302b3a-0d8f-11e8-89c7-6b7a38d636c5.png)

After:
![bildschirmfoto vom 2018-02-09 11-47-36](https://user-images.githubusercontent.com/3404133/36024190-463642b0-0d8f-11e8-8956-b45d4eff8a68.png)
