### PR TITLE
Make logfile's mode configurable.

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -729,6 +729,13 @@ $CONFIG = array(
 'logfile' => '/var/log/nextcloud.log',
 
 /**
+ * Log file mode for the Nextcloud loggin type in octal notation.
+ *
+ * Defaults to 0640 (writeable by user, readable by group).
+ */
+'logfilemode' => 0640,
+
+/**
  * Loglevel to start logging at. Valid values are: 0 = Debug, 1 = Info, 2 =
  * Warning, 3 = Error, and 4 = Fatal. The default value is Warning.
  *

--- a/lib/private/Log/File.php
+++ b/lib/private/Log/File.php
@@ -50,6 +50,8 @@ use OCP\ILogger;
 class File implements IWriter, IFileBased {
 	/** @var string */
 	protected $logFile;
+	/** @var int */
+	protected $logFileMode;
 	/** @var SystemConfig */
 	private $config;
 
@@ -67,6 +69,7 @@ class File implements IWriter, IFileBased {
 			}
 		}
 		$this->config = $config;
+		$this->logFileMode = $config->getValue('logfilemode', 0640);
 	}
 
 	/**
@@ -134,8 +137,8 @@ class File implements IWriter, IFileBased {
 		}
 		$entry = json_encode($entry, JSON_PARTIAL_OUTPUT_ON_ERROR);
 		$handle = @fopen($this->logFile, 'a');
-		if ((fileperms($this->logFile) & 0777) != 0640) {
-			@chmod($this->logFile, 0640);
+		if ($this->logFileMode > 0 && (fileperms($this->logFile) & 0777) != $this->logFileMode) {
+			@chmod($this->logFile, $this->logFileMode);
 		}
 		if ($handle) {
 			fwrite($handle, $entry."\n");

--- a/tests/lib/Log/LogFactoryTest.php
+++ b/tests/lib/Log/LogFactoryTest.php
@@ -83,10 +83,10 @@ class LogFactoryTest extends TestCase {
 		$datadir = \OC::$SERVERROOT.'/data';
 		$defaultLog = $datadir . '/nextcloud.log';
 
-		$this->systemConfig->expects($this->exactly(2))
+		$this->systemConfig->expects($this->exactly(3))
 			->method('getValue')
-			->withConsecutive(['datadirectory', $datadir], ['logfile', $defaultLog])
-			->willReturnOnConsecutiveCalls($datadir, $defaultLog);
+			->withConsecutive(['datadirectory', $datadir], ['logfile', $defaultLog], ['logfilemode', 0640])
+			->willReturnOnConsecutiveCalls($datadir, $defaultLog, 0640);
 
 		$log = $this->factory->get($type);
 		$this->assertInstanceOf(File::class, $log);
@@ -113,10 +113,10 @@ class LogFactoryTest extends TestCase {
 		$datadir = \OC::$SERVERROOT.'/data';
 		$defaultLog = $datadir . '/nextcloud.log';
 
-		$this->systemConfig->expects($this->exactly(2))
+		$this->systemConfig->expects($this->exactly(3))
 			->method('getValue')
-			->withConsecutive(['datadirectory', $datadir], ['logfile', $defaultLog])
-			->willReturnOnConsecutiveCalls($datadir, $path);
+			->withConsecutive(['datadirectory', $datadir], ['logfile', $defaultLog], ['logfilemode', 0640])
+			->willReturnOnConsecutiveCalls($datadir, $path, 0640);
 
 		$log = $this->factory->get('file');
 		$this->assertInstanceOf(File::class, $log);


### PR DESCRIPTION
The file logger currently resets the mode of the logfile to 0640.

When the webserver is running as a different user than the cron job
(but both are in the same group) the files mode has to be 0660. The
current implementation breaks logging for the user that is not the
owner of the logfile.

This patch introduces a new config option 'logfilemode' that expects
an octal value (defaults to 0640). Unless the value is lower or equal
than 0 the logfile's mode will be changed to this value.

Signed-off-by: Roland Tapken <roland@bitarbeiter.net>