### PR TITLE
External storage test: log exceptions

### DIFF
--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -449,8 +449,11 @@ abstract class Common implements Storage, ILockingStorage {
 			if ($this->stat('')) {
 				return true;
 			}
+			\OC::$server->getLogger()->info("External storage not available: stat() failed");
 			return false;
 		} catch (\Exception $e) {
+			\OC::$server->getLogger()->info("External storage not available: " . $e->getMessage());
+			\OC::$server->getLogger()->logException($e, ['level' => \OCP\Util::DEBUG]);
 			return false;
 		}
 	}


### PR DESCRIPTION
If an external storage test fails the exception's message is now written
into the logfile (level INFO). This helps to resolve the reason for a
failing connection.

Signed-off-by: Roland Tapken <roland@bitarbeiter.net>