### PR TITLE
Make SMB module more fault-tolerant

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -152,7 +152,13 @@ class SMB extends Common implements INotifyStorage {
 				$this->statCache[$path . '/' . $file->getName()] = $file;
 			}
 			return array_filter($files, function (IFileInfo $file) {
-				return !$file->isHidden();
+				try {
+					return !$file->isHidden();
+				} catch (ForbiddenException $e) {
+					return false;
+				} catch (NotFoundException $e) {
+					return false;
+				}
 			});
 		} catch (ConnectException $e) {
 			throw new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
@@ -226,8 +232,12 @@ class SMB extends Common implements INotifyStorage {
 		$highestMTime = 0;
 		$files = $this->share->dir($this->root);
 		foreach ($files as $fileInfo) {
-			if ($fileInfo->getMTime() > $highestMTime) {
-				$highestMTime = $fileInfo->getMTime();
+			try {
+				if ($fileInfo->getMTime() > $highestMTime) {
+					$highestMTime = $fileInfo->getMTime();
+				}
+			} catch (NotFoundException $e) {
+				// Ignore this, can happen on unavailable DFS shares
 			}
 		}
 		return $highestMTime;


### PR DESCRIPTION
Ignore unavailable files when fetching the share's mtime
or reading directory listings. This can happen on servers using a
distributed file system (DFS) with unavailable destinations, for example
when the remote server is offline.