### PR TITLE
AppData hardening

### DIFF
--- a/lib/public/Files/SimpleFS/ISimpleFile.php
+++ b/lib/public/Files/SimpleFS/ISimpleFile.php
@@ -22,6 +22,7 @@
  */
 namespace OCP\Files\SimpleFS;
 
+use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 
 /**
@@ -67,6 +68,8 @@ interface ISimpleFile {
 	/**
 	 * Get the content
 	 *
+	 * @throws NotPermittedException
+	 * @throws NotFoundException
 	 * @return string
 	 * @since 11.0.0
 	 */

--- a/tests/lib/Files/SimpleFS/SimpleFileTest.php
+++ b/tests/lib/Files/SimpleFS/SimpleFileTest.php
@@ -24,6 +24,9 @@ namespace Test\File\SimpleFS;
 
 use OC\Files\SimpleFS\SimpleFile;
 use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
 
 class SimpleFileTest extends \Test\TestCase  {
 	/** @var File|\PHPUnit_Framework_MockObject_MockObject */
@@ -100,5 +103,24 @@ class SimpleFileTest extends \Test\TestCase  {
 			->willReturn('app/awesome');
 
 		$this->assertEquals('app/awesome', $this->simpleFile->getMimeType());
+	}
+
+	public function testGetContentInvalidAppData() {
+		$this->file->method('getContent')
+			->willReturn(false);
+		$this->file->method('stat')->willReturn(false);
+
+		$parent = $this->createMock(Folder::class);
+		$parent->method('stat')->willReturn(false);
+
+		$root = $this->createMock(Folder::class);
+		$root->method('stat')->willReturn([]);
+
+		$this->file->method('getParent')->willReturn($parent);
+		$parent->method('getParent')->willReturn($root);
+
+		$this->expectException(NotFoundException::class);
+
+		$this->simpleFile->getContent();
 	}
 }


### PR DESCRIPTION
Since people sometimes do weird stuff with their appdata folders. Make them a bit more robust. basically we can check fs actions. And if they fail we do "stuff"

- [x] SimpleFile getContents
- [x] Update tests

@juliushaertl @icewind1991 does this make sense?


Testing:

1. Load a page
2. now delete `appdata_*/js`
3. Force Reload
4. See it :boom:
5. Go to 3

Now it will still do :boom: at step 3. But reloading again should fix it all. You can do this removing of code in various ways.