### PR TITLE
Show open graph preview in WhatsApp

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -385,7 +385,18 @@ class ShareController extends Controller {
 			// We just have direct previews for image files
 			if ($share->getNode()->getMimePart() === 'image') {
 				$shareTmpl['previewURL'] = $this->urlGenerator->linkToRouteAbsolute('files_sharing.publicpreview.directLink', ['token' => $token]);
+
 				$ogPreview = $shareTmpl['previewURL'];
+
+				//Whatapp is kind of picky about their size requirements
+				if ($this->request->isUserAgent(['/^WhatsApp/'])) {
+					$ogPreview = $this->urlGenerator->linkToRouteAbsolute('files_sharing.PublicPreview.getPreview', [
+						't' => $token,
+						'x' => 256,
+						'y' => 256,
+						'a' => true,
+					]);
+				}
 			}
 		} else {
 			$shareTmpl['previewImage'] = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'favicon-fb.png'));


### PR DESCRIPTION
Whatsapp is picky about the size of the open graph images.
So we do some special handling.


Now:

![wa](https://user-images.githubusercontent.com/45821/36090773-ea72a2d4-0fe1-11e8-939a-df6d3ce4ec37.png)


Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>