### PR TITLE
Mount SMB shares readonly

### DIFF
--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -50,6 +50,8 @@ class SMB extends Backend {
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('domain', $l->t('Domain')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+				(new DefinitionParameter('readonly', $l->t('Read only')))
+					->setType(DefinitionParameter::VALUE_BOOLEAN),
 			])
 			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
 			->setLegacyAuthMechanism($legacyAuth)

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -75,6 +75,11 @@ class SMB extends Common implements INotifyStorage {
 	 */
 	protected $statCache;
 
+	/**
+	 * @var boolean
+	 **/
+	protected $readOnly;
+
 	public function __construct($params) {
 		if (isset($params['host']) && isset($params['user']) && isset($params['password']) && isset($params['share'])) {
 			if (Server::NativeAvailable()) {
@@ -87,6 +92,10 @@ class SMB extends Common implements INotifyStorage {
 			$this->root = $params['root'] ?? '/';
 			$this->root = '/' . ltrim($this->root, '/');
 			$this->root = rtrim($this->root, '/') . '/';
+
+			if (isset($params['readonly'])) {
+				$this->readOnly = $params['readonly'];
+			}
 		} else {
 			throw new \Exception('Invalid configuration');
 		}
@@ -102,6 +111,14 @@ class SMB extends Common implements INotifyStorage {
 		// failure to do so will lead to creation of a new storage id and
 		// loss of shares from the storage
 		return 'smb::' . $this->server->getUser() . '@' . $this->server->getHost() . '//' . $this->share->getName() . '/' . $this->root;
+	}
+
+	/**
+	 * Returns true if the 'read only' parameter has been enabled.
+	 * @return bool
+	 **/
+	public function isReadOnly() {
+		return $this->readOnly;
 	}
 
 	/**
@@ -184,7 +201,7 @@ class SMB extends Common implements INotifyStorage {
 	 * @return bool true if the rename is successful, false otherwise
 	 */
 	public function rename($source, $target) {
-		if ($this->isRootDir($source) || $this->isRootDir($target)) {
+		if ($this->isRootDir($source) || $this->isRootDir($target) || $this->isReadOnly()) {
 			return false;
 		}
 
@@ -257,7 +274,7 @@ class SMB extends Common implements INotifyStorage {
 	 * @return bool
 	 */
 	public function unlink($path) {
-		if ($this->isRootDir($path)) {
+		if ($this->isRootDir($path) || $this->isReadOnly()) {
 			return false;
 		}
 
@@ -364,7 +381,7 @@ class SMB extends Common implements INotifyStorage {
 	}
 
 	public function rmdir($path) {
-		if ($this->isRootDir($path)) {
+		if ($this->isRootDir($path) || $this->isReadOnly()) {
 			return false;
 		}
 
@@ -390,6 +407,10 @@ class SMB extends Common implements INotifyStorage {
 	}
 
 	public function touch($path, $time = null) {
+		if ($this->isReadOnly()) {
+			return false;
+		}
+
 		try {
 			if (!$this->file_exists($path)) {
 				$fh = $this->share->write($this->buildPath($path));
@@ -428,6 +449,10 @@ class SMB extends Common implements INotifyStorage {
 	}
 
 	public function mkdir($path) {
+		if ($this->isReadOnly()) {
+			return false;
+		}
+
 		$path = $this->buildPath($path);
 		try {
 			$this->share->mkdir($path);
@@ -468,7 +493,7 @@ class SMB extends Common implements INotifyStorage {
 			$info = $this->getFileInfo($path);
 			// following windows behaviour for read-only folders: they can be written into
 			// (https://support.microsoft.com/en-us/kb/326549 - "cause" section)
-			return !$info->isHidden() && (!$info->isReadOnly() || $this->is_dir($path));
+			return !$this->isReadOnly() && !$info->isHidden() && (!$info->isReadOnly() || $this->is_dir($path));
 		} catch (NotFoundException $e) {
 			return false;
 		} catch (ForbiddenException $e) {
@@ -479,7 +504,7 @@ class SMB extends Common implements INotifyStorage {
 	public function isDeletable($path) {
 		try {
 			$info = $this->getFileInfo($path);
-			return !$info->isHidden() && !$info->isReadOnly();
+			return !$this->isReadOnly() && !$info->isHidden() && !$info->isReadOnly();
 		} catch (NotFoundException $e) {
 			return false;
 		} catch (ForbiddenException $e) {


### PR DESCRIPTION
Add a new parameter to the SMB modules that emulates a read-only mount, although I'm not sure if this is the best approach. My requirement (precisely: that of my employer) is to give access to SMB shares through Nextcloud, but - at least for the moment - it should not be possible to update or delete their contents from within Nextcloud.

**I think a more generic solution where every external storage could be set to "read only" would be a better approach**, but since there is no abstraction between OC\Files\Storage\Common and external storages it would require some very deep changes.

So I leave it here for discussion.