### PR TITLE
Use normal header() calls instead of private method calls

### DIFF
--- a/apps/files/download.php
+++ b/apps/files/download.php
@@ -41,7 +41,9 @@ $ftype=\OC::$server->getMimeTypeDetector()->getSecureMimeType(\OC\Files\Filesyst
 
 header('Content-Type:'.$ftype);
 OCP\Response::setContentDispositionHeader(basename($filename), 'attachment');
-OCP\Response::disableCaching();
+header('Pragma: public');// enable caching in IE
+header('Expires: 0');
+header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
 OCP\Response::setContentLengthHeader(\OC\Files\Filesystem::filesize($filename));
 
 OC_Util::obEnd();

--- a/apps/files_versions/download.php
+++ b/apps/files_versions/download.php
@@ -49,7 +49,9 @@ $ftype = \OC::$server->getMimeTypeDetector()->getSecureMimeType($view->getMimeTy
 
 header('Content-Type:'.$ftype);
 OCP\Response::setContentDispositionHeader(basename($filename), 'attachment');
-OCP\Response::disableCaching();
+header('Pragma: public');// enable caching in IE
+header('Expires: 0');
+header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
 OCP\Response::setContentLengthHeader($view->filesize($versionName));
 
 OC_Util::obEnd();

--- a/lib/private/App/CodeChecker/DeprecationCheck.php
+++ b/lib/private/App/CodeChecker/DeprecationCheck.php
@@ -146,6 +146,8 @@ class DeprecationCheck extends AbstractCheck {
 			'OCP\IServerContainer::getDb' => '8.1.0',
 			'OCP\IServerContainer::getHTTPHelper' => '8.1.0',
 
+			'OCP\Response::disableCaching' => '14.0.0',
+
 			'OCP\User::getUser' => '8.0.0',
 			'OCP\User::getUsers' => '8.1.0',
 			'OCP\User::getDisplayName' => '8.1.0',

--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -75,7 +75,9 @@ class OC_Files {
 	private static function sendHeaders($filename, $name, array $rangeArray) {
 		OC_Response::setContentDispositionHeader($name, 'attachment');
 		header('Content-Transfer-Encoding: binary', true);
-		OC_Response::disableCaching();
+		header('Pragma: public');// enable caching in IE
+		header('Expires: 0');
+		header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
 		$fileSize = \OC\Files\Filesystem::filesize($filename);
 		$type = \OC::$server->getMimeTypeDetector()->getSecureMimeType(\OC\Files\Filesystem::getMimeType($filename));
 		if ($fileSize > -1) {

--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -55,7 +55,7 @@ class OC_Response {
 				header('Cache-Control: max-age='.$cache_time.', must-revalidate');
 			}
 			else {
-				self::setExpiresHeader(0);
+				header('Expires: 0');
 				header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
 			}
 		}
@@ -64,14 +64,6 @@ class OC_Response {
 			header('Pragma: cache');
 		}
 
-	}
-
-	/**
-	* disable browser caching
-	* @see enableCaching with cache_time = 0
-	*/
-	static public function disableCaching() {
-		self::enableCaching(0);
 	}
 
 	/**

--- a/lib/public/Response.php
+++ b/lib/public/Response.php
@@ -89,9 +89,12 @@ class Response {
 	 * Disable browser caching
 	 * @see enableCaching with cache_time = 0
 	 * @since 4.0.0
+	 * @deprecated 14.0.0 just set the headers
 	 */
 	static public function disableCaching() {
-		\OC_Response::disableCaching();
+		header('Pragma: public');// enable caching in IE
+		header('Expires: 0');
+		header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
 	}
 
 	/**


### PR DESCRIPTION
Just some cleanup of files that will be replaced by proper AppFramework implementations sooner or later (or by proper webdav URLs).