### PR TITLE
UTF-8 encode the logging

### DIFF
--- a/lib/private/Log/File.php
+++ b/lib/private/Log/File.php
@@ -117,6 +117,9 @@ class File {
 			'userAgent',
 			'version'
 		);
+		foreach($entry as $key => $value) {
+			$entry[$key] = utf8_encode($value);
+		}
 		$entry = json_encode($entry);
 		$handle = @fopen(self::$logFile, 'a');
 		if ((fileperms(self::$logFile) & 0777) != 0640) {


### PR DESCRIPTION
I found this branch while looking through stale branches.

@nickvergessen @icewind1991 @rullzer Does that make sense? I would say so to unify the output.