### PR TITLE
Re-enable apps that got automatically disabled while updating

### DIFF
--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -250,6 +250,7 @@ class Updater extends BasicEmitter {
 
 		// upgrade appstore apps
 		$this->upgradeAppStoreApps(\OC::$server->getAppManager()->getInstalledApps());
+		$this->upgradeAppStoreApps(\OC_App::$autoDisabledApps, true);
 
 		// install new shipped apps on upgrade
 		OC_App::loadApps(['authentication']);
@@ -430,9 +431,10 @@ class Updater extends BasicEmitter {
 
 	/**
 	 * @param array $disabledApps
+	 * @param bool $reenable
 	 * @throws \Exception
 	 */
-	private function upgradeAppStoreApps(array $disabledApps) {
+	private function upgradeAppStoreApps(array $disabledApps, $reenable = false) {
 		foreach($disabledApps as $app) {
 			try {
 				$this->emit('\OC\Updater', 'checkAppStoreAppBefore', [$app]);
@@ -441,6 +443,11 @@ class Updater extends BasicEmitter {
 					$this->installer->updateAppstoreApp($app);
 				}
 				$this->emit('\OC\Updater', 'checkAppStoreApp', [$app]);
+
+				if ($reenable) {
+					$ocApp = new \OC_App();
+					$ocApp->enable($app);
+				}
 			} catch (\Exception $ex) {
 				$this->log->logException($ex, ['app' => 'core']);
 			}

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -70,6 +70,7 @@ class OC_App {
 	static private $loadedApps = [];
 	static private $altLogin = [];
 	static private $alreadyRegistered = [];
+	static public $autoDisabledApps = [];
 	const officialApp = 200;
 
 	/**
@@ -156,6 +157,7 @@ class OC_App {
 				if (!\OC::$server->getAppManager()->isShipped($app)) {
 					// Only disable apps which are not shipped
 					\OC::$server->getAppManager()->disableApp($app);
+					self::$autoDisabledApps[] = $app;
 				}
 			}
 			\OC::$server->getEventLogger()->end('load_app_' . $app);


### PR DESCRIPTION
This seems like a quite simple approach to work against https://github.com/nextcloud/server/issues/8293
But maybe I'm overseeing something.

Also I noticed, that automatic disable is already running the uninstall repairsteps. I once had the idea to use the uninstall step to clean up the database of my apps.
But that basically means when the announcement app e.g. gets automatically disabled all announcements and comments would be gone.

Not sure if that sounds intended.