### PR TITLE
Don't use double quotes in MySQL queries

### DIFF
--- a/lib/private/Repair/Collation.php
+++ b/lib/private/Repair/Collation.php
@@ -6,6 +6,7 @@
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Robin Appelman <robin@icewind.nl>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Robin Müller <robin.mueller@1und1.de>
  *
  * @license AGPL-3.0
  *
@@ -124,7 +125,7 @@ class Collation implements IRepairStep {
 			"	FROM INFORMATION_SCHEMA . COLUMNS" .
 			"	WHERE TABLE_SCHEMA = ?" .
 			"	AND (COLLATION_NAME <> '" . $characterSet . "_bin' OR CHARACTER_SET_NAME <> '" . $characterSet . "')" .
-			"	AND TABLE_NAME LIKE \"*PREFIX*%\"",
+			"	AND TABLE_NAME LIKE '*PREFIX*%'",
 			array($dbName)
 		);
 		$rows = $statement->fetchAll();
@@ -139,7 +140,7 @@ class Collation implements IRepairStep {
 			"	FROM INFORMATION_SCHEMA . TABLES" .
 			"	WHERE TABLE_SCHEMA = ?" .
 			"	AND TABLE_COLLATION <> '" . $characterSet . "_bin'" .
-			"	AND TABLE_NAME LIKE \"*PREFIX*%\"",
+			"	AND TABLE_NAME LIKE '*PREFIX*%'",
 			[$dbName]
 		);
 		$rows = $statement->fetchAll();


### PR DESCRIPTION
MySQL databases with the [ANSI_QUOTES](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_ansi_quotes) mode enabled treat `"` as an identifier quote. So for such databases the 'occ upgrade' fails with an error message like this:
... unknown column 'oc_*' in where clause.

This fix replaces the doulbe quotes with single quotes that should be always used in MySQL queries to quote literal strings.