### PR TITLE
[stable13] Make acceptance tests for comments more consistent with the others

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -615,6 +615,13 @@ pipeline:
       when:
         matrix:
           TESTS-ACCEPTANCE: access-levels
+  acceptance-app-comments:
+      image: nextcloudci/integration-php7.0:integration-php7.0-6
+      commands:
+        - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-app-comments --selenium-server selenium:4444 allow-git-repository-modifications features/app-comments.feature
+      when:
+        matrix:
+          TESTS-ACCEPTANCE: app-comments
   acceptance-app-files:
       image: nextcloudci/integration-php7.0:integration-php7.0-6
       commands:
@@ -813,6 +820,8 @@ matrix:
     - TESTS: integration-remote-api
     - TESTS: acceptance
       TESTS-ACCEPTANCE: access-levels
+    - TESTS: acceptance
+      TESTS-ACCEPTANCE: app-comments
     - TESTS: acceptance
       TESTS-ACCEPTANCE: app-files
     - TESTS: acceptance

--- a/tests/acceptance/features/app-comments.feature
+++ b/tests/acceptance/features/app-comments.feature
@@ -5,4 +5,4 @@ Feature: app-comments
     And I open the details view for "welcome.txt"
     And I open the "Comments" tab in the details view
     When I create a new comment with "Hello world" as message
-    Then I see that a comment was added
+    Then I see a comment with "Hello world" as message

--- a/tests/acceptance/features/bootstrap/CommentsAppContext.php
+++ b/tests/acceptance/features/bootstrap/CommentsAppContext.php
@@ -26,6 +26,32 @@ use Behat\Behat\Context\Context;
 class CommentsAppContext implements Context, ActorAwareInterface {
 	use ActorAware;
 
+	/**
+	 * @return Locator
+	 */
+	public static function newCommentField() {
+		return Locator::forThe()->css("div.newCommentRow .message")->
+				descendantOf(FilesAppContext::currentSectionDetailsView())->
+				describedAs("New comment field in current section details view in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function submitNewCommentButton() {
+		return Locator::forThe()->css("div.newCommentRow .submit")->
+				descendantOf(FilesAppContext::currentSectionDetailsView())->
+				describedAs("Submit new comment button in current section details view in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function commentFields() {
+		return Locator::forThe()->css(".comments .comment .message")->
+				descendantOf(FilesAppContext::currentSectionDetailsView())->
+				describedAs("Comment fields in current section details view in Files app");
+	}
 
 	/**
 	 * @When /^I create a new comment with "([^"]*)" as message$/
@@ -57,26 +83,5 @@ class CommentsAppContext implements Context, ActorAwareInterface {
 			return false;
 		}
 		return true;
-	}
-
-	/**
-	 * @return Locator
-	 */
-	public static function newCommentField() {
-		return Locator::forThe()->css("div.newCommentRow .message")->descendantOf(FilesAppContext::currentSectionDetailsView())->
-		describedAs("New comment field in the details view in Files app");
-	}
-
-	public static function commentFields() {
-		return Locator::forThe()->css(".comments .comment .message")->descendantOf(FilesAppContext::currentSectionDetailsView())->
-		describedAs("Comment fields in the details view in Files app");
-	}
-
-	/**
-	 * @return Locator
-	 */
-	public static function submitNewCommentButton() {
-		return Locator::forThe()->css("div.newCommentRow .submit")->descendantOf(FilesAppContext::currentSectionDetailsView())->
-		describedAs("Submit new comment button in the details view in Files app");
 	}
 }

--- a/tests/acceptance/features/bootstrap/CommentsAppContext.php
+++ b/tests/acceptance/features/bootstrap/CommentsAppContext.php
@@ -57,8 +57,8 @@ class CommentsAppContext implements Context, ActorAwareInterface {
 	 * @When /^I create a new comment with "([^"]*)" as message$/
 	 */
 	public function iCreateANewCommentWithAsMessage($commentText) {
-		$this->actor->find(self::newCommentField(), 2)->setValue($commentText);
-		$this->actor->find(self::submitNewCommentButton(), 2)->click();
+		$this->actor->find(self::newCommentField(), 10)->setValue($commentText);
+		$this->actor->find(self::submitNewCommentButton())->click();
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/CommentsAppContext.php
+++ b/tests/acceptance/features/bootstrap/CommentsAppContext.php
@@ -47,10 +47,19 @@ class CommentsAppContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
-	public static function commentFields() {
-		return Locator::forThe()->css(".comments .comment .message")->
+	public static function commentList() {
+		return Locator::forThe()->css("ul.comments")->
 				descendantOf(FilesAppContext::currentSectionDetailsView())->
-				describedAs("Comment fields in current section details view in Files app");
+				describedAs("Comment list in current section details view in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function commentWithText($text) {
+		return Locator::forThe()->xpath("//div[normalize-space() = '$text']/ancestor::li")->
+				descendantOf(self::commentList())->
+				describedAs("Comment with text \"$text\" in current section details view in Files app");
 	}
 
 	/**
@@ -62,26 +71,10 @@ class CommentsAppContext implements Context, ActorAwareInterface {
 	}
 
 	/**
-	 * @Then /^I see that a comment was added$/
+	 * @Then /^I see a comment with "([^"]*)" as message$/
 	 */
-	public function iSeeThatACommentWasAdded() {
-		$self = $this;
-
-		$result = Utils::waitFor(function () use ($self) {
-			return $self->isCommentAdded();
-		}, 5, 0.5);
-
-		PHPUnit_Framework_Assert::assertTrue($result);
-	}
-
-	public function isCommentAdded() {
-		try {
-				$locator = self::commentFields();
-			$comments = $this->actor->getSession()->getPage()->findAll($locator->getSelector(), $locator->getLocator());
-			PHPUnit_Framework_Assert::assertSame(1, count($comments));
-		} catch (PHPUnit_Framework_ExpectationFailedException $e) {
-			return false;
-		}
-		return true;
+	public function iSeeACommentWithAsMessage($commentText) {
+		PHPUnit_Framework_Assert::assertTrue(
+				$this->actor->find(self::commentWithText($commentText), 10)->isVisible());
 	}
 }


### PR DESCRIPTION
Backport of #8382 

The typo in _.drone.yml_ in the original pull request is already fixed in this backport.
