### PR TITLE
Fix typo in build matrix of ".drone.yml"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -734,7 +734,7 @@ matrix:
     - TESTS: acceptance
       TESTS-ACCEPTANCE: access-levels
     - TESTS: acceptance
-      TESTS-ACCEPTANCE: access-comments
+      TESTS-ACCEPTANCE: app-comments
     - TESTS: acceptance
       TESTS-ACCEPTANCE: app-files
     - TESTS: acceptance


### PR DESCRIPTION
Follow up for #8382 
