### PR TITLE
Add mtime and storage_mtime to db:convert-filecache-bigint

### DIFF
--- a/core/Command/Db/ConvertFilecacheBigInt.php
+++ b/core/Command/Db/ConvertFilecacheBigInt.php
@@ -54,7 +54,7 @@ class ConvertFilecacheBigInt extends Command {
 		return [
 			'activity' => ['activity_id', 'object_id'],
 			'activity_mq' => ['mail_id'],
-			'filecache' => ['fileid', 'storage', 'parent', 'mimetype', 'mimepart'],
+			'filecache' => ['fileid', 'storage', 'parent', 'mimetype', 'mimepart', 'mtime', 'storage_mtime'],
 			'mimetypes' => ['id'],
 			'storages' => ['numeric_id'],
 		];


### PR DESCRIPTION
Adding some columns that were left out of the bigint conversion for the filecache.

See #7637 