### PR TITLE
Fix updating an app

### DIFF
--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -385,7 +385,7 @@ class Updater extends BasicEmitter {
 	private function checkAppsRequirements() {
 		$isCoreUpgrade = $this->isCodeUpgrade();
 		$apps = OC_App::getEnabledApps();
-		$version = Util::getVersion();
+		$version = implode('.', Util::getVersion());
 		$disabledApps = [];
 		$appManager = \OC::$server->getAppManager();
 		foreach ($apps as $app) {

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -915,7 +915,7 @@ class OC_App {
 	 * @param string $appId
 	 * @return bool
 	 */
-	public static function updateApp(sstring $appId): bool {
+	public static function updateApp(string $appId): bool {
 		$appPath = self::getAppPath($appId);
 		if($appPath === false) {
 			return false;


### PR DESCRIPTION
OC_App has been made strict recently and the updater code was not
compatible to this. This adds the array to string conversion of the
Nextcloud version and fixes a typo in OC_App (sstring -> string)

```
php ../../occ upgrade                                                                                                        
Nextcloud or one of the apps require upgrade - only a limited number of commands are available
You may use your browser or the occ upgrade command to do the upgrade
Set log level to debug
Turned on maintenance mode
Updating database schema
Updated database
An unhandled exception has been thrown:
TypeError: Argument 1 passed to OC_App::isAppCompatible() must be of the type string, array given, called in /home/christoph/workspace/nextcloud/lib/private/Updater.php on line 394 and defined in /home/christoph/workspace/nextcloud/lib/private/legacy/app.php:862
Stack trace:
#0 /home/christoph/workspace/nextcloud/lib/private/Updater.php(394): OC_App::isAppCompatible(Array, Array)
#1 /home/christoph/workspace/nextcloud/lib/private/Updater.php(243): OC\Updater->checkAppsRequirements()
#2 /home/christoph/workspace/nextcloud/lib/private/Updater.php(120): OC\Updater->doUpgrade('14.0.0.1', '14.0.0.1')
#3 /home/christoph/workspace/nextcloud/core/Command/Upgrade.php(258): OC\Updater->upgrade()
#4 /home/christoph/workspace/nextcloud/3rdparty/symfony/console/Command/Command.php(264): OC\Core\Command\Upgrade->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#5 /home/christoph/workspace/nextcloud/3rdparty/symfony/console/Application.php(874): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 /home/christoph/workspace/nextcloud/3rdparty/symfony/console/Application.php(228): Symfony\Component\Console\Application->doRunCommand(Object(OC\Core\Command\Upgrade), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /home/christoph/workspace/nextcloud/3rdparty/symfony/console/Application.php(130): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /home/christoph/workspace/nextcloud/lib/private/Console/Application.php(173): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#9 /home/christoph/workspace/nextcloud/console.php(90): OC\Console\Application->run()
#10 /home/christoph/workspace/nextcloud/occ(11): require_once('/home/christoph...')
```

Regression of https://github.com/nextcloud/server/pull/8411