### PR TITLE
Properly set the mount type for external storages

### DIFF
--- a/apps/files_external/lib/Config/ConfigAdapter.php
+++ b/apps/files_external/lib/Config/ConfigAdapter.php
@@ -168,7 +168,7 @@ class ConfigAdapter implements IMountProvider {
 					$storageConfig->getMountOptions()
 				);
 			} else {
-				return new MountPoint(
+				return new ExternalMountPoint(
 					$storage,
 					'/' . $user->getUID() . '/files' . $storageConfig->getMountPoint(),
 					null,

--- a/apps/files_external/lib/Lib/PersonalMount.php
+++ b/apps/files_external/lib/Lib/PersonalMount.php
@@ -24,14 +24,14 @@
 
 namespace OCA\Files_External\Lib;
 
-use OC\Files\Mount\MountPoint;
 use OC\Files\Mount\MoveableMount;
+use OCA\Files_External\Config\ExternalMountPoint;
 use OCA\Files_External\Service\UserStoragesService;
 
 /**
  * Person mount points can be moved by the user
  */
-class PersonalMount extends MountPoint implements MoveableMount {
+class PersonalMount extends ExternalMountPoint implements MoveableMount {
 	/** @var UserStoragesService */
 	protected $storagesService;
 


### PR DESCRIPTION
@tobiasKaminsky there you go :)

This makes querying the mount-type on webdav actually useful.

to test:

1. Setup external storage
2. do a propfind with `http://nextcloud.org/ns:mount-type`

Beforw it is empty for external storages. Now it is nicely set to 'external'.