### PR TITLE
Use phpunit's directory feature

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -380,17 +380,9 @@ function execute_tests {
 		echo "No coverage"
 	fi
 
-	if [ -d "$2" ]; then
-	    for f in $(find "$2" -name '*Test.php'); do
-			echo "${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" / "$f" "$3"
-			"${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$f" "$3"
-			RESULT=$?
-	    done;
-	else
-	    echo "${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
-	    "${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
-		RESULT=$?
-	fi
+	echo "${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
+	"${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
+	RESULT=$?
 
 	if [ "$PRIMARY_STORAGE_CONFIG" == "swift" ] ; then
 		cd ..


### PR DESCRIPTION
* Runs all tests instead of stopping at the first failed one
* Supported by phpunit now, because we require 6.5+
* Run `./autotest.sh sqlite tests/lib/Collaboration/Collaborators/`

### After
```
No coverage
/home/nickv/Tools/vendor/bin/phpunit --configuration phpunit-autotest.xml --log-junit autotest-results-sqlite.xml ../tests/lib/Collaboration/Collaborators/ 
PHPUnit 6.5.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.14-1+ubuntu17.10.1+deb.sury.org+1 with Xdebug 2.6.0
Configuration: /home/nickv/Nextcloud/14/server/tests/phpunit-autotest.xml

...............................................................  63 / 325 ( 19%)
............................................................... 126 / 325 ( 38%)
............................................................... 189 / 325 ( 58%)
............................................................... 252 / 325 ( 77%)
............................................................... 315 / 325 ( 96%)
..........                                                      325 / 325 (100%)

Time: 724 ms, Memory: 22.00MB

OK (325 tests, 775 assertions)
```

### Before
```
No coverage
/home/nickv/Tools/vendor/bin/phpunit --configuration phpunit-autotest.xml --log-junit autotest-results-sqlite.xml ../tests/lib/Collaboration/Collaborators/ / ../tests/lib/Collaboration/Collaborators/RemotePluginTest.php 
PHPUnit 6.5.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.14-1+ubuntu17.10.1+deb.sury.org+1 with Xdebug 2.6.0
Configuration: /home/nickv/Nextcloud/14/server/tests/phpunit-autotest.xml

...............................................................  63 / 236 ( 26%)
............................................................... 126 / 236 ( 53%)
............................................................... 189 / 236 ( 80%)
...............................................                 236 / 236 (100%)

Time: 468 ms, Memory: 20.00MB

OK (236 tests, 476 assertions)
/home/nickv/Tools/vendor/bin/phpunit --configuration phpunit-autotest.xml --log-junit autotest-results-sqlite.xml ../tests/lib/Collaboration/Collaborators/ / ../tests/lib/Collaboration/Collaborators/UserPluginTest.php 
PHPUnit 6.5.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.14-1+ubuntu17.10.1+deb.sury.org+1 with Xdebug 2.6.0
Configuration: /home/nickv/Nextcloud/14/server/tests/phpunit-autotest.xml

.........................                                         25 / 25 (100%)

Time: 305 ms, Memory: 20.00MB

OK (25 tests, 98 assertions)
/home/nickv/Tools/vendor/bin/phpunit --configuration phpunit-autotest.xml --log-junit autotest-results-sqlite.xml ../tests/lib/Collaboration/Collaborators/ / ../tests/lib/Collaboration/Collaborators/SearchResultTest.php 
PHPUnit 6.5.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.14-1+ubuntu17.10.1+deb.sury.org+1 with Xdebug 2.6.0
Configuration: /home/nickv/Nextcloud/14/server/tests/phpunit-autotest.xml

...........                                                       11 / 11 (100%)

Time: 231 ms, Memory: 20.00MB

OK (11 tests, 11 assertions)
/home/nickv/Tools/vendor/bin/phpunit --configuration phpunit-autotest.xml --log-junit autotest-results-sqlite.xml ../tests/lib/Collaboration/Collaborators/ / ../tests/lib/Collaboration/Collaborators/SearchTest.php 
PHPUnit 6.5.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.14-1+ubuntu17.10.1+deb.sury.org+1 with Xdebug 2.6.0
Configuration: /home/nickv/Nextcloud/14/server/tests/phpunit-autotest.xml

......                                                              6 / 6 (100%)

Time: 224 ms, Memory: 20.00MB

OK (6 tests, 12 assertions)
/home/nickv/Tools/vendor/bin/phpunit --configuration phpunit-autotest.xml --log-junit autotest-results-sqlite.xml ../tests/lib/Collaboration/Collaborators/ / ../tests/lib/Collaboration/Collaborators/MailPluginTest.php 
PHPUnit 6.5.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.14-1+ubuntu17.10.1+deb.sury.org+1 with Xdebug 2.6.0
Configuration: /home/nickv/Nextcloud/14/server/tests/phpunit-autotest.xml

.................                                                 17 / 17 (100%)

Time: 257 ms, Memory: 20.00MB

OK (17 tests, 51 assertions)
/home/nickv/Tools/vendor/bin/phpunit --configuration phpunit-autotest.xml --log-junit autotest-results-sqlite.xml ../tests/lib/Collaboration/Collaborators/ / ../tests/lib/Collaboration/Collaborators/GroupPluginTest.php 
PHPUnit 6.5.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.14-1+ubuntu17.10.1+deb.sury.org+1 with Xdebug 2.6.0
Configuration: /home/nickv/Nextcloud/14/server/tests/phpunit-autotest.xml

...........................                                       27 / 27 (100%)

Time: 343 ms, Memory: 20.00MB

OK (27 tests, 108 assertions)
/home/nickv/Tools/vendor/bin/phpunit --configuration phpunit-autotest.xml --log-junit autotest-results-sqlite.xml ../tests/lib/Collaboration/Collaborators/ / ../tests/lib/Collaboration/Collaborators/LookupPluginTest.php 
PHPUnit 6.5.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.14-1+ubuntu17.10.1+deb.sury.org+1 with Xdebug 2.6.0
Configuration: /home/nickv/Nextcloud/14/server/tests/phpunit-autotest.xml

...                                                                 3 / 3 (100%)

Time: 240 ms, Memory: 20.00MB
```