### PR TITLE
theming: handle not being in the serverroot

### DIFF
--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -110,7 +110,7 @@ class ThemingController extends Controller {
 		IAppData $appData,
 		SCSSCacher $scssCacher,
 		IURLGenerator $urlGenerator,
-		IAppManager $appManager = NULL
+		IAppManager $appManager
 	) {
 		parent::__construct($appName, $request);
 
@@ -123,12 +123,7 @@ class ThemingController extends Controller {
 		$this->appData = $appData;
 		$this->scssCacher = $scssCacher;
 		$this->urlGenerator = $urlGenerator;
-
-		if (!is_null($appManager)) {
-			$this->appManager = $appManager;
-		} else {
-			$this->appManager = \OC::$server->getAppManager();
-		}
+		$this->appManager = $appManager;
 	}
 
 	/**

--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -51,6 +51,7 @@ use OCP\IRequest;
 use OCA\Theming\Util;
 use OCP\ITempManager;
 use OCP\IURLGenerator;
+use OCP\App\IAppManager;
 
 /**
  * Class ThemingController
@@ -78,6 +79,8 @@ class ThemingController extends Controller {
 	private $scssCacher;
 	/** @var IURLGenerator */
 	private $urlGenerator;
+	/** @var IAppManager */
+	private $appManager;
 
 	/**
 	 * ThemingController constructor.
@@ -93,6 +96,7 @@ class ThemingController extends Controller {
 	 * @param IAppData $appData
 	 * @param SCSSCacher $scssCacher
 	 * @param IURLGenerator $urlGenerator
+	 * @param IAppManager $appManager
 	 */
 	public function __construct(
 		$appName,
@@ -105,7 +109,8 @@ class ThemingController extends Controller {
 		ITempManager $tempManager,
 		IAppData $appData,
 		SCSSCacher $scssCacher,
-		IURLGenerator $urlGenerator
+		IURLGenerator $urlGenerator,
+		IAppManager $appManager = NULL
 	) {
 		parent::__construct($appName, $request);
 
@@ -118,6 +123,12 @@ class ThemingController extends Controller {
 		$this->appData = $appData;
 		$this->scssCacher = $scssCacher;
 		$this->urlGenerator = $urlGenerator;
+
+		if (!is_null($appManager)) {
+			$this->appManager = $appManager;
+		} else {
+			$this->appManager = \OC::$server->getAppManager();
+		}
 	}
 
 	/**
@@ -409,12 +420,13 @@ class ThemingController extends Controller {
 	 * @return FileDisplayResponse|NotFoundResponse
 	 */
 	public function getStylesheet() {
-		$appPath = substr(\OC::$server->getAppManager()->getAppPath('theming'), strlen(\OC::$SERVERROOT) + 1);
+		$appPath = $this->appManager->getAppPath('theming');
+
 		/* SCSSCacher is required here
 		 * We cannot rely on automatic caching done by \OC_Util::addStyle,
 		 * since we need to add the cacheBuster value to the url
 		 */
-		$cssCached = $this->scssCacher->process(\OC::$SERVERROOT, $appPath . '/css/theming.scss', 'theming');
+		$cssCached = $this->scssCacher->process($appPath, 'css/theming.scss', 'theming');
 		if(!$cssCached) {
 			return new NotFoundResponse();
 		}

--- a/apps/theming/tests/Controller/ThemingControllerTest.php
+++ b/apps/theming/tests/Controller/ThemingControllerTest.php
@@ -106,7 +106,8 @@ class ThemingControllerTest extends TestCase {
 			$this->tempManager,
 			$this->appData,
 			$this->scssCacher,
-			$this->urlGenerator
+			$this->urlGenerator,
+			$this->appManager
 		);
 
 		return parent::setUp();
@@ -798,7 +799,7 @@ class ThemingControllerTest extends TestCase {
 
 
 	public function testGetStylesheet() {
-
+		$this->appManager->expects($this->once())->method('getAppPath')->with('theming')->willReturn(\OC::$SERVERROOT . '/theming');
 		$file = $this->createMock(ISimpleFile::class);
 		$file->expects($this->any())->method('getName')->willReturn('theming.css');
 		$file->expects($this->any())->method('getContent')->willReturn('compiled');
@@ -818,6 +819,7 @@ class ThemingControllerTest extends TestCase {
 	}
 
 	public function testGetStylesheetFails() {
+		$this->appManager->expects($this->once())->method('getAppPath')->with('theming')->willReturn(\OC::$SERVERROOT . '/theming');
 		$file = $this->createMock(ISimpleFile::class);
 		$file->expects($this->any())->method('getName')->willReturn('theming.css');
 		$file->expects($this->any())->method('getContent')->willReturn('compiled');
@@ -830,20 +832,6 @@ class ThemingControllerTest extends TestCase {
 	}
 
 	public function testGetStylesheetOutsideServerroot() {
-		$this->themingController = new ThemingController(
-			'theming',
-			$this->request,
-			$this->config,
-			$this->themingDefaults,
-			$this->util,
-			$this->timeFactory,
-			$this->l10n,
-			$this->tempManager,
-			$this->appData,
-			$this->scssCacher,
-			$this->urlGenerator,
-			$this->appManager
-		);
 		$this->appManager->expects($this->once())->method('getAppPath')->with('theming')->willReturn('/outside/serverroot/theming');
 		$file = $this->createMock(ISimpleFile::class);
 		$file->expects($this->any())->method('getName')->willReturn('theming.css');


### PR DESCRIPTION
Currently, the theming app assumes it's in the serverroot. However, with Nextcloud's flexibility regarding configurable app paths, this is not a safe assumption to make. If it happens to be an incorrect assumption, the theming app fails to work.

Instead of relying on the serverroot, this PR fixes #8462 by simply using the app path from the AppManager and utilizing relative paths for assets from there. Note that, in order to make this testable, the ability to inject an `IAppManager` to the `ThemingController` was added.

As this has been broken since v12, a backport to both stable13 and stable12 would be great (happy to do the legwork if given the okay).