### PR TITLE
Use mb_* string methods to extract first character for generated avatars

### DIFF
--- a/lib/private/Avatar.php
+++ b/lib/private/Avatar.php
@@ -263,7 +263,7 @@ class Avatar implements IAvatar {
 	 * @return string
 	 */
 	private function generateAvatar($userDisplayName, $size) {
-		$text = strtoupper($userDisplayName[0]);
+		$text = mb_strtoupper(mb_substr($userDisplayName, 0, 1), 'UTF-8');
 		$backgroundColor = $this->avatarBackgroundColor($userDisplayName);
 
 		$im = imagecreatetruecolor($size, $size);


### PR DESCRIPTION
This fixes #8451 where the first character is a non-ASCII character. The `$string[0]` notation only extracted one byte and thus resulting in an invalid code. The `mb_strtoupper` method also allows to convert characters independently from the current locale on the server.

See also http://php.net/manual/en/function.mb-strtoupper.php

I would also backport this to 13 and 12 to prevent further reports on this.