### PR TITLE
Avoid fruitless login attempts

### DIFF
--- a/apps/user_ldap/tests/ConnectionTest.php
+++ b/apps/user_ldap/tests/ConnectionTest.php
@@ -174,7 +174,7 @@ class ConnectionTest extends \Test\TestCase {
 			->method('connect')
 			->will($this->returnValue('ldapResource'));
 
-		$this->ldap->expects($this->exactly(2))
+		$this->ldap->expects($this->once())
 			->method('bind')
 			->will($this->returnValue(false));
 

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -264,13 +264,15 @@ class LoginController extends Controller {
 			$users = $this->userManager->getByEmail($user);
 			// we only allow login by email if unique
 			if (count($users) === 1) {
+				$previousUser = $user;
 				$user = $users[0]->getUID();
-				$loginResult = $this->userManager->checkPassword($user, $password);
-			} else {
-				$this->logger->warning('Login failed: \''. $user .'\' (Remote IP: \''. $this->request->getRemoteAddress(). '\')', ['app' => 'core']);
+				if($user !== $previousUser) {
+					$loginResult = $this->userManager->checkPassword($user, $password);
+				}
 			}
 		}
 		if ($loginResult === false) {
+			$this->logger->warning('Login failed: \''. $user .'\' (Remote IP: \''. $this->request->getRemoteAddress(). '\')', ['app' => 'core']);
 			// Read current user and append if possible - we need to return the unmodified user otherwise we will leak the login name
 			$args = !is_null($user) ? ['user' => $originalUser] : [];
 			if (!is_null($redirect_url)) {


### PR DESCRIPTION
* LDAP: don't attempt to bind with last, active bind credentials
* User Manager: don't try to login user with email ids twice if it failed (this should be move to the backend, but I need something backportable)