### PR TITLE
Show hint in OCS API for user creation

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -31,6 +31,7 @@
 namespace OCA\Provisioning_API\Controller;
 
 use OC\Accounts\AccountManager;
+use OC\HintException;
 use OC\Settings\Mailer\NewUserMailHelper;
 use OC_Helper;
 use OCA\Provisioning_API\FederatedFileSharingFactory;
@@ -193,15 +194,22 @@ class UsersController extends OCSController {
 
 		try {
 			$newUser = $this->userManager->createUser($userid, $password);
-			$this->logger->info('Successful addUser call with userid: '.$userid, ['app' => 'ocs_api']);
+			$this->logger->info('Successful addUser call with userid: ' . $userid, ['app' => 'ocs_api']);
 
 			if (is_array($groups)) {
 				foreach ($groups as $group) {
 					$this->groupManager->get($group)->addUser($newUser);
-					$this->logger->info('Added userid '.$userid.' to group '.$group, ['app' => 'ocs_api']);
+					$this->logger->info('Added userid ' . $userid . ' to group ' . $group, ['app' => 'ocs_api']);
 				}
 			}
 			return new DataResponse();
+		} catch (HintException $e ) {
+			$this->logger->logException($e, [
+				'message' => 'Failed addUser attempt with hint exception.',
+				'level' => \OCP\Util::WARN,
+				'app' => 'ocs_api',
+			]);
+			throw new OCSException($e->getHint(), 107);
 		} catch (\Exception $e) {
 			$this->logger->logException($e, [
 				'message' => 'Failed addUser attempt with exception.',


### PR DESCRIPTION
* adds a 107 error code together with the hint of the exception
* logs the exception as warning
* fixes #7946


```xml
<?xml version="1.0"?>
<ocs>
	<meta>
		<status>failure</status>
		<statuscode>107</statuscode>
		<message>Password is among the 1,000,000 most common ones. Please make it unique.</message>
	</meta>
	<data/>
</ocs>
```

* [x] update documentation