### PR TITLE
getAppInfo has to return array

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -351,7 +351,7 @@ class AppManager implements IAppManager {
 	 * @param null $lang
 	 * @return array app info
 	 */
-	public function getAppInfo(string $appId, bool $path = false, $lang = null) {
+	public function getAppInfo(string $appId, bool $path = false, $lang = null): array {
 		if ($path) {
 			$file = $appId;
 		} else {
@@ -361,7 +361,7 @@ class AppManager implements IAppManager {
 			try {
 				$appPath = $this->getAppPath($appId);
 			} catch (AppPathNotFoundException $e) {
-				return null;
+				return [];
 			}
 			$file = $appPath . '/appinfo/info.xml';
 		}


### PR DESCRIPTION
null causes exceptions down the road (e.g. when you uncleanly remove an app only from the file system) in AppManager::getIncompatibleApps()::405, the call to ``isAppCompatible`` which expects the second parameter to be an array. Restores the same behaviour as before. Without this, you are greeted with an unstyled error page.

