### PR TITLE
Use isInstalled of AppManger instead of reimplement it

### DIFF
--- a/core/Command/App/Install.php
+++ b/core/Command/App/Install.php
@@ -58,6 +58,7 @@ class Install extends Command {
 		}
 
 		try {
+			/** @var Installer $installer */
 			$installer = \OC::$server->query(Installer::class);
 			$installer->downloadApp($appId);
 			$result = $installer->installApp($appId);

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -204,7 +204,9 @@ class AppManager implements IAppManager {
 	}
 
 	/**
-	 * Check if an app is installed in the instance
+	 * Check if an app is enabled in the instance
+	 *
+	 * Notice: This actually checks if the app is enabled and not only if it is installed.
 	 *
 	 * @param string $appId
 	 * @return bool

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -383,6 +383,7 @@ class OC_App {
 						   array $groups = []) {
 
 		// Check if app is already downloaded
+		/** @var Installer $installer */
 		$installer = \OC::$server->query(Installer::class);
 		$isDownloaded = $installer->isDownloaded($appId);
 

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -67,7 +67,9 @@ interface IAppManager {
 	public function isEnabledForUser($appId, $user = null);
 
 	/**
-	 * Check if an app is installed in the instance
+	 * Check if an app is enabled in the instance
+	 *
+	 * Notice: This actually checks if the app is enabled and not only if it is installed.
 	 *
 	 * @param string $appId
 	 * @return bool

--- a/tests/lib/InstallerTest.php
+++ b/tests/lib/InstallerTest.php
@@ -103,9 +103,9 @@ class InstallerTest extends TestCase {
 			\OC::$server->getLogger(),
 			\OC::$server->getConfig()
 		);
-		$installer->installApp(self::$appid);
-		$isInstalled = Installer::isInstalled(self::$appid);
-		$this->assertTrue($isInstalled);
+		$this->assertNull(\OC::$server->getConfig()->getAppValue('testapp', 'enabled', null), 'Check that the app is not listed before installation');
+		$this->assertSame('testapp', $installer->installApp(self::$appid));
+		$this->assertSame('no', \OC::$server->getConfig()->getAppValue('testapp', 'enabled', null), 'Check that the app is listed after installation');
 		$this->assertSame('0.9', \OC::$server->getConfig()->getAppValue('testapp', 'installed_version'));
 		$installer->removeApp(self::$appid);
 	}


### PR DESCRIPTION
Found while thinking about #8505 - AppManager and the Installer implemented the same functionality. This removes it and uses one code path.