### PR TITLE
[stable13] Fix hiding and event propagation issues with the user management popover

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -940,7 +940,7 @@ $(document).ready(function () {
 		UserList._triggerGroupEdit($td, isSubadminSelect);
 	});
 
-	$userListBody.on('click', '.toggleUserActions', function (event) {
+	$userListBody.on('click', '.toggleUserActions > .action', function (event) {
 		event.stopPropagation();
 		var $td = $(this).closest('td');
 		var $tr = $($td).closest('tr');
@@ -963,9 +963,11 @@ $(document).ready(function () {
 		$tr.addClass('active');
 	});
 
-	$(document).on('mouseup', function () {
-		$('#userlist tr.active').removeClass('active');
-		$('#userlist .popovermenu.open').removeClass('open');
+	$(document).on('mouseup', function (event) {
+		if (!$(event.target).closest('.toggleUserActions').length) {
+			$('#userlist tr.active').removeClass('active');
+			$('#userlist .popovermenu.open').removeClass('open');
+		}
 	});
 
 	$userListBody.on('click', '.action-togglestate', function (event) {

--- a/settings/templates/users/part.userlist.php
+++ b/settings/templates/users/part.userlist.php
@@ -67,7 +67,7 @@
 			<td class="userActions">
 				<div class="toggleUserActions">
 					<a class="action"><span class="icon-more"></span></a>
-					<div class="popovermenu bubble menu">
+					<div class="popovermenu">
 						<ul class="userActionsMenu">
 							<li>
 								<a href="#" class="menuitem action-togglestate permanent" data-action="togglestate"></a>


### PR DESCRIPTION
backport of https://github.com/nextcloud/server/pull/8416

This PR fixes the issues from #8401 as well as the popovermenu not being closed when clicking the more icon again.

Removing the additional .menu and .bubble classes takes care that event propagation will not be stopped by the menu handling from core/js/js.js, since the user management has implemented its own code to show/hide popovers.