### PR TITLE
Provide translated error message for permission error

### DIFF
--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -219,7 +219,8 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				$server->getContentSecurityPolicyManager(),
 				$server->getCsrfTokenManager(),
 				$server->getContentSecurityPolicyNonceManager(),
-				$server->getAppManager()
+				$server->getAppManager(),
+				$server->getL10N('lib')
 			);
 		});
 

--- a/lib/private/AppFramework/Middleware/Security/Exceptions/NotAdminException.php
+++ b/lib/private/AppFramework/Middleware/Security/Exceptions/NotAdminException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -35,7 +36,7 @@ use OCP\AppFramework\Http;
  * @package OC\AppFramework\Middleware\Security\Exceptions
  */
 class NotAdminException extends SecurityException {
-	public function __construct($message = 'Logged in user must be an admin') {
+	public function __construct(string $message) {
 		parent::__construct($message, Http::STATUS_FORBIDDEN);
 	}
 }

--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -48,6 +48,7 @@ use OCP\AppFramework\Middleware;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\OCSController;
+use OCP\IL10N;
 use OCP\INavigationManager;
 use OCP\IURLGenerator;
 use OCP\IRequest;
@@ -87,6 +88,8 @@ class SecurityMiddleware extends Middleware {
 	private $cspNonceManager;
 	/** @var IAppManager */
 	private $appManager;
+	/** @var IL10N */
+	private $l10n;
 
 	/**
 	 * @param IRequest $request
@@ -101,6 +104,7 @@ class SecurityMiddleware extends Middleware {
 	 * @param CSRFTokenManager $csrfTokenManager
 	 * @param ContentSecurityPolicyNonceManager $cspNonceManager
 	 * @param IAppManager $appManager
+	 * @param IL10N $l10n
 	 */
 	public function __construct(IRequest $request,
 								ControllerMethodReflector $reflector,
@@ -113,7 +117,8 @@ class SecurityMiddleware extends Middleware {
 								ContentSecurityPolicyManager $contentSecurityPolicyManager,
 								CsrfTokenManager $csrfTokenManager,
 								ContentSecurityPolicyNonceManager $cspNonceManager,
-								IAppManager $appManager
+								IAppManager $appManager,
+								IL10N $l10n
 	) {
 		$this->navigationManager = $navigationManager;
 		$this->request = $request;
@@ -127,6 +132,7 @@ class SecurityMiddleware extends Middleware {
 		$this->csrfTokenManager = $csrfTokenManager;
 		$this->cspNonceManager = $cspNonceManager;
 		$this->appManager = $appManager;
+		$this->l10n = $l10n;
 	}
 
 	/**
@@ -152,7 +158,7 @@ class SecurityMiddleware extends Middleware {
 
 			if(!$this->reflector->hasAnnotation('NoAdminRequired')) {
 				if(!$this->isAdminUser) {
-					throw new NotAdminException();
+					throw new NotAdminException($this->l10n->t('Logged in user must be an admin'));
 				}
 			}
 		}

--- a/settings/Middleware/SubadminMiddleware.php
+++ b/settings/Middleware/SubadminMiddleware.php
@@ -30,6 +30,7 @@ use OC\AppFramework\Utility\ControllerMethodReflector;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Middleware;
+use OCP\IL10N;
 
 /**
  * Verifies whether an user has at least subadmin rights.
@@ -42,15 +43,20 @@ class SubadminMiddleware extends Middleware {
 	protected $isSubAdmin;
 	/** @var ControllerMethodReflector */
 	protected $reflector;
+	/** @var IL10N */
+	private $l10n;
 
 	/**
 	 * @param ControllerMethodReflector $reflector
 	 * @param bool $isSubAdmin
+	 * @param IL10N $l10n
 	 */
 	public function __construct(ControllerMethodReflector $reflector,
-								$isSubAdmin) {
+								$isSubAdmin,
+								IL10N $l10n) {
 		$this->reflector = $reflector;
 		$this->isSubAdmin = $isSubAdmin;
+		$this->l10n = $l10n;
 	}
 
 	/**
@@ -62,7 +68,7 @@ class SubadminMiddleware extends Middleware {
 	public function beforeController($controller, $methodName) {
 		if(!$this->reflector->hasAnnotation('NoSubadminRequired')) {
 			if(!$this->isSubAdmin) {
-				throw new NotAdminException('Logged in user must be a subadmin');
+				throw new NotAdminException($this->l10n->t('Logged in user must be a subadmin'));
 			}
 		}
 	}

--- a/tests/Settings/Middleware/SubadminMiddlewareTest.php
+++ b/tests/Settings/Middleware/SubadminMiddlewareTest.php
@@ -15,6 +15,7 @@ use OC\AppFramework\Utility\ControllerMethodReflector;
 use OC\Settings\Middleware\SubadminMiddleware;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IL10N;
 
 /**
  * Verifies whether an user has at least subadmin rights.
@@ -31,6 +32,8 @@ class SubadminMiddlewareTest extends \Test\TestCase {
 	private $reflector;
 	/** @var Controller */
 	private $controller;
+	/** @var IL10N */
+	private $l10n;
 
 	protected function setUp() {
 		parent::setUp();
@@ -38,9 +41,10 @@ class SubadminMiddlewareTest extends \Test\TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->controller = $this->getMockBuilder(Controller::class)
 			->disableOriginalConstructor()->getMock();
+		$this->l10n = $this->createMock(IL10N::class);
 
-		$this->subadminMiddlewareAsSubAdmin = new SubadminMiddleware($this->reflector, true);
-		$this->subadminMiddleware = new SubadminMiddleware($this->reflector, false);
+		$this->subadminMiddlewareAsSubAdmin = new SubadminMiddleware($this->reflector, true, $this->l10n);
+		$this->subadminMiddleware = new SubadminMiddleware($this->reflector, false, $this->l10n);
 	}
 
 	/**
@@ -86,7 +90,7 @@ class SubadminMiddlewareTest extends \Test\TestCase {
 	public function testAfterNotAdminException() {
 		$expectedResponse = new TemplateResponse('core', '403', array(), 'guest');
 		$expectedResponse->setStatus(403);
-		$this->assertEquals($expectedResponse, $this->subadminMiddleware->afterException($this->controller, 'foo', new NotAdminException()));
+		$this->assertEquals($expectedResponse, $this->subadminMiddleware->afterException($this->controller, 'foo', new NotAdminException('')));
 	}
 
 	/**

--- a/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
@@ -45,13 +45,11 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
+use OCP\IL10N;
 use OCP\ILogger;
 use OCP\INavigationManager;
 use OCP\IRequest;
-use OCP\ISession;
 use OCP\IURLGenerator;
-use OCP\IUser;
-use OCP\IUserSession;
 use OCP\Security\ISecureRandom;
 
 class SecurityMiddlewareTest extends \Test\TestCase {
@@ -82,8 +80,8 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	private $cspNonceManager;
 	/** @var IAppManager|\PHPUnit_Framework_MockObject_MockObject */
 	private $appManager;
-	/** @var IUserSession|\PHPUnit_Framework_MockObject_MockObject */
-	private $userSession;
+	/** @var IL10N|\PHPUnit_Framework_MockObject_MockObject */
+	private $l10n;
 
 	protected function setUp() {
 		parent::setUp();
@@ -98,6 +96,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->csrfTokenManager = $this->createMock(CsrfTokenManager::class);
 		$this->cspNonceManager = $this->createMock(ContentSecurityPolicyNonceManager::class);
 		$this->appManager = $this->createMock(IAppManager::class);
+		$this->l10n = $this->createMock(IL10N::class);
 		$this->appManager->expects($this->any())
 			->method('isEnabledForUser')
 			->willReturn(true);
@@ -124,7 +123,8 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 			$this->contentSecurityPolicyManager,
 			$this->csrfTokenManager,
 			$this->cspNonceManager,
-			$this->appManager
+			$this->appManager,
+			$this->l10n
 		);
 	}
 
@@ -541,7 +541,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 				new CrossSiteRequestForgeryException(),
 			],
 			[
-				new NotAdminException(),
+				new NotAdminException(''),
 			],
 		];
 	}


### PR DESCRIPTION
Found while reviewing #8511 

Just go to http://example.org/settings/admin/externalstorages as normal user and check the error message

![bildschirmfoto 2018-02-26 um 15 32 48](https://user-images.githubusercontent.com/245432/36675945-9d6f458a-1b0a-11e8-977f-88f9102bf125.png)

This text is now properly localised. 