### PR TITLE
fix: change 'sqlite' to 'sqlite3'

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -92,13 +92,13 @@ $CONFIG = array(
  * ``supportedDatabases``
  *
  * Available:
- * 	- sqlite (SQLite3)
+ * 	- sqlite3 (SQLite3)
  * 	- mysql (MySQL/MariaDB)
  * 	- pgsql (PostgreSQL)
  *
- * Defaults to ``sqlite``
+ * Defaults to ``sqlite3``
  */
-'dbtype' => 'sqlite',
+'dbtype' => 'sqlite3',
 
 /**
  * Your host server name, for example ``localhost``, ``hostname``,


### PR DESCRIPTION
@MorrisJobke asked me to open this pull request in the server repo instead of the documentation repo:
https://github.com/nextcloud/documentation/pull/690

Text from the documentation pull request:
On a fresh Nextcloud 13 Installation the default value for dbtype in config.php is 'sqlite3' (and not 'sqlite'). I also noticed that on previous versions.
Despite the fact that Nextcloud 13 also works though, if that value is manually changed to 'sqlite', I would suggest to change that in the documentation to the actually used value created when installing Nextcloud - and that is 'sqlite3'.