### PR TITLE
Make it possible to make external storages read only

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -272,7 +272,7 @@ abstract class Node implements \Sabre\DAV\INode {
 				$mountpointpath = substr($mountpointpath, 0, -1);
 			}
 
-			if ($mountpointpath === $this->info->getPath()) {
+			if (!$mountpoint->getOption('readonly', false) && $mountpointpath === $this->info->getPath()) {
 				$permissions |= \OCP\Constants::PERMISSION_DELETE | \OCP\Constants::PERMISSION_UPDATE;
 			}
 		}

--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -48,6 +48,12 @@ var MOUNT_OPTIONS_DROPDOWN_TEMPLATE =
 	'				<label for="mountOptionsEncoding">{{mountOptionsEncodingLabel}}</label>'+
 	'			</span>'+
 	'		</li>'+
+	'		<li class="optionRow">' +
+	'			<span class="menuitem">' +
+	'				<input id="mountOptionsReadOnly" class="checkbox" name="readonly" type="checkbox" value="true"/>' +
+	'				<label for="mountOptionsReadOnly">{{t "files_external" "Read only"}}</label>' +
+	'			</span>' +
+	'		</li>' +
 	'	</ul>'+
 	'</div>';
 
@@ -916,7 +922,8 @@ MountConfigListView.prototype = _.extend({
 				'previews': true,
 				'enable_sharing': false,
 				'filesystem_check_changes': 1,
-				'encoding_compatibility': false
+				'encoding_compatibility': false,
+				'readonly': false,
 			}));
 		}
 
@@ -1303,7 +1310,8 @@ MountConfigListView.prototype = _.extend({
 			'previews',
 			'filesystem_check_changes',
 			'enable_sharing',
-			'encoding_compatibility'
+			'encoding_compatibility',
+			'readonly'
 		];
 		if (this._encryptionEnabled) {
 			visibleOptions.push('encrypt');

--- a/apps/files_external/lib/Command/ListCommand.php
+++ b/apps/files_external/lib/Command/ListCommand.php
@@ -192,7 +192,8 @@ class ListCommand extends Base {
 				'previews' => true,
 				'filesystem_check_changes' => 1,
 				'enable_sharing' => false,
-				'encoding_compatibility' => false
+				'encoding_compatibility' => false,
+				'readonly' => false,
 			];
 			$rows = array_map(function (StorageConfig $config) use ($userId, $defaultMountOptions, $full) {
 				$storageConfig = $config->getBackendOptions();

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -12,6 +12,7 @@
 	$l->t("Check for changes");
 	$l->t("Never");
 	$l->t("Once every direct access");
+	$l->t('Read only');
 
 	script('files_external', 'settings');
 	style('files_external', 'settings');

--- a/apps/files_external/tests/js/settingsSpec.js
+++ b/apps/files_external/tests/js/settingsSpec.js
@@ -376,7 +376,8 @@ describe('OCA.External.Settings tests', function() {
 					previews: true,
 					enable_sharing: false,
 					filesystem_check_changes: 0,
-					encoding_compatibility: false
+					encoding_compatibility: false,
+					readonly: false
 				});
 			});
 		});

--- a/apps/files_sharing/tests/js/sharedfilelistSpec.js
+++ b/apps/files_sharing/tests/js/sharedfilelistSpec.js
@@ -727,7 +727,8 @@ describe('OCA.Sharing.FileList tests', function() {
 				etag: 'abc',
 				shareOwner: 'User One',
 				recipients: 'User Two',
-				mountType: 'external-root'
+				mountType: 'external-root',
+				sharePermissions: OC.PERMISSION_READ,
 			}]);
 			$tr = fileList.$el.find('tr:first');
 
@@ -749,7 +750,8 @@ describe('OCA.Sharing.FileList tests', function() {
 				etag: 'abc',
 				shareOwner: 'User One',
 				recipients: 'User Two',
-				mountType: 'external-root'
+				mountType: 'external-root',
+				sharePermissions: OC.PERMISSION_READ | OC.PERMISSION_SHARE,
 			}]);
 			$tr = fileList.$el.find('tr:first');
 

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -259,6 +259,23 @@ class OC_Util {
 			return $storage;
 		});
 
+		\OC\Files\Filesystem::addStorageWrapper('readonly', function ($mountPoint, \OCP\Files\Storage\IStorage $storage, \OCP\Files\Mount\IMountPoint $mount) {
+			/*
+			 * Do not allow any operations that modify the storage
+			 */
+			if ($mount->getOption('readonly', false)) {
+				return new \OC\Files\Storage\Wrapper\PermissionsMask([
+					'storage' => $storage,
+					'mask' => \OCP\Constants::PERMISSION_ALL & ~(
+						\OCP\Constants::PERMISSION_UPDATE |
+						\OCP\Constants::PERMISSION_CREATE |
+						\OCP\Constants::PERMISSION_DELETE
+					),
+				]);
+			}
+			return $storage;
+		});
+
 		OC_Hook::emit('OC_Filesystem', 'preSetup', array('user' => $user));
 		\OC\Files\Filesystem::logWarningWhenAddingStorageWrapper(true);
 


### PR DESCRIPTION
Repalces https://github.com/nextcloud/server/pull/8315

CC: @Cybso this was the way I suggested. It needs more work but I feel this is way more scaleable and mantainable ;)

Todo:
- [x] Fix tests
- [x] Fix sharing (as if you enable sharing and read only it tries to share with to high permissions currently and thus fails).

------------------

So it became a bit more.

1. Added the Read only option in the files external
2. Added a Read only wrapper
3. Removed share logic from javascript, we already handle this in dav. And there it should be correct as other clients want to use this as well
4. Fix the tests
