### PR TITLE
Fix upload button visible on read-only folders

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -16,7 +16,6 @@
 .actions .button a:active {
 	color: #333;
 }
-.actions.hidden { display: none; }
 
 .actions.creatable {
 	position: relative;
@@ -25,6 +24,10 @@
 	.button:not(:last-child) {
 		margin-right: 3px;
 	}
+}
+
+.actions.hidden {
+	display: none;
 }
 
 #trash {


### PR DESCRIPTION
Fixes #8343, which is a regression introduced in 7a9e65ceed793604588399d4eaefa7908ad44379

It also fixes #8543, as now the restricted permission notice will be shown in read-only folders in the same place as the upload button in writable folders.

I have written acceptance tests for this, but as they required some refactoring they were sent in a different pull request (#8594).

This fix causes the button to switch to the Gallery app to be hidden on read-only folders; a follow-up pull request for the Gallery app to solve this is in nextcloud/gallery#401.
