### PR TITLE
Allow public page access to apps with group restrictions

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -111,9 +112,9 @@ class SecurityMiddleware extends Middleware {
 								INavigationManager $navigationManager,
 								IURLGenerator $urlGenerator,
 								ILogger $logger,
-								$appName,
-								$isLoggedIn,
-								$isAdminUser,
+								string $appName,
+								bool $isLoggedIn,
+								bool $isAdminUser,
 								ContentSecurityPolicyManager $contentSecurityPolicyManager,
 								CsrfTokenManager $csrfTokenManager,
 								ContentSecurityPolicyNonceManager $cspNonceManager,
@@ -156,10 +157,8 @@ class SecurityMiddleware extends Middleware {
 				throw new NotLoggedInException();
 			}
 
-			if(!$this->reflector->hasAnnotation('NoAdminRequired')) {
-				if(!$this->isAdminUser) {
-					throw new NotAdminException($this->l10n->t('Logged in user must be an admin'));
-				}
+			if(!$this->reflector->hasAnnotation('NoAdminRequired') && !$this->isAdminUser) {
+				throw new NotAdminException($this->l10n->t('Logged in user must be an admin'));
 			}
 		}
 
@@ -212,7 +211,7 @@ class SecurityMiddleware extends Middleware {
 	 * @param Response $response
 	 * @return Response
 	 */
-	public function afterController($controller, $methodName, Response $response) {
+	public function afterController($controller, $methodName, Response $response): Response {
 		$policy = !is_null($response->getContentSecurityPolicy()) ? $response->getContentSecurityPolicy() : new ContentSecurityPolicy();
 
 		if (get_class($policy) === EmptyContentSecurityPolicy::class) {
@@ -241,14 +240,14 @@ class SecurityMiddleware extends Middleware {
 	 * @throws \Exception the passed in exception if it can't handle it
 	 * @return Response a Response object or null in case that the exception could not be handled
 	 */
-	public function afterException($controller, $methodName, \Exception $exception) {
+	public function afterException($controller, $methodName, \Exception $exception): Response {
 		if($exception instanceof SecurityException) {
 			if($exception instanceof StrictCookieMissingException) {
 				return new RedirectResponse(\OC::$WEBROOT);
  			}
 			if (stripos($this->request->getHeader('Accept'),'html') === false) {
 				$response = new JSONResponse(
-					array('message' => $exception->getMessage()),
+					['message' => $exception->getMessage()],
 					$exception->getCode()
 				);
 			} else {

--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -195,8 +195,9 @@ class SecurityMiddleware extends Middleware {
 		 * Checks if app is enabled (also includes a check whether user is allowed to access the resource)
 		 * The getAppPath() check is here since components such as settings also use the AppFramework and
 		 * therefore won't pass this check.
+		 * If page is public, app does not need to be enabled for current user/visitor
 		 */
-		if(\OC_App::getAppPath($this->appName) !== false && !$this->appManager->isEnabledForUser($this->appName)) {
+		if(\OC_App::getAppPath($this->appName) !== false && !$isPublicPage && !$this->appManager->isEnabledForUser($this->appName)) {
 			throw new AppNotEnabledException();
 		}
 


### PR DESCRIPTION
This PR is related to #6962, #5309, nextcloud/polls#225 and [phonetrack-oc/#78](https://gitlab.com/eneiluj/phonetrack-oc/issues/78).

It allows non-logged user to access public pages of applications restricted to a group.

It does **not** fix the following problem : Logged-in users who are not in the authorized group cannot access public pages of an app. They are redirected to "Files" app.

I ran unit tests with autotest.sh and there were two unrelated errors : 
```
There were 2 failures:                                                                
                                                                                      
1) Test\LargeFileHelperGetFileSizeTest::testGetFileSizeViaCurl with data set #0 ('/var/www/html/ncdev/tests/dat...em.txt', 446)
Failed asserting that null is identical to 446.                                                                      
                                                                                                                                                                             
/var/www/html/ncdev/tests/lib/LargeFileHelperGetFileSizeTest.php:53                                                      
                                                                                                                                                         
2) Test\LargeFileHelperGetFileSizeTest::testGetFileSizeViaCurl with data set #1 ('/var/www/html/ncdev/tests/dat...2).txt', 446)
Failed asserting that null is identical to 446.                                       
                                                                                                                                                                             
/var/www/html/ncdev/tests/lib/LargeFileHelperGetFileSizeTest.php:53
```
