### PR TITLE
Remove too restrict check for background image/color

### DIFF
--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -101,13 +101,11 @@
 	}
 }
 
-@if variable_exists('theming-background-mime') and $theming-background-mime != ''  {
-	#body-login,
-	#firstrunwizard .firstrunwizard-header,
-	#theming-preview {
-		background-image: url(#{$image-login-background});
-		background-color: $color-primary;
-	}
+#body-login,
+#firstrunwizard .firstrunwizard-header,
+#theming-preview {
+	background-image: url(#{$image-login-background});
+	background-color: $color-primary;
 }
 
 input.primary,


### PR DESCRIPTION
Fix for #8599 

The background styles need to be applied always, since the login page doesn't use any SCSS based styling.

Needs a backport to stable13