### PR TITLE
Ellipsize long values in the user management

### DIFF
--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -494,9 +494,10 @@ table.grid {
 td, th {
 	&.name {
 		padding-left: .8em;
-		width: 10em;
-		min-width: 10em;
-		max-width: 10em;
+		min-width: 5em;
+		max-width: 12em;
+		text-overflow: ellipsis;
+		overflow: hidden;
 	}
 	&.password {
 		padding-left: .8em;
@@ -510,10 +511,15 @@ td, th {
 	&.password,
 	&.displayName,
 	&.mailAddress {
-		width: 12em;
-		min-width: 12em;
+		min-width: 5em;
 		max-width: 12em;
 		cursor: pointer;
+		span {
+			width: 90%;
+			display: inline-block;
+			text-overflow: ellipsis;
+			overflow: hidden;
+		}
 	}
 	&.mailAddress {
 		cursor: pointer;


### PR DESCRIPTION
This will properly limit the size of the text for username, displayname and email.

Found when reviewing #8587
Before:
![peek 2018-03-01 17-04](https://user-images.githubusercontent.com/3404133/36854968-addb9468-1d72-11e8-862c-3a374c6481f8.gif)

After:
![peek 2018-03-01 16-59](https://user-images.githubusercontent.com/3404133/36854847-51af1228-1d72-11e8-9440-1ff7ced06cc9.gif)
