### PR TITLE
use hash algo that's robust against collisions

### DIFF
--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -218,7 +218,7 @@ class Connection extends LDAPUtility {
 		if(is_null($key)) {
 			return $prefix;
 		}
-		return $prefix.md5($key);
+		return $prefix.hash('sha256', $key);
 	}
 
 	/**

--- a/apps/user_ldap/lib/Proxy.php
+++ b/apps/user_ldap/lib/Proxy.php
@@ -163,7 +163,7 @@ abstract class Proxy {
 		if($key === null) {
 			return $prefix;
 		}
-		return $prefix.md5($key);
+		return $prefix.hash('sha256', $key);
 	}
 
 	/**


### PR DESCRIPTION
I've had a strange scenario and did not found another explanation (and way to trigger) that a hash collision. md5 is fragile to it… memcached has a key length limit of 250 byte which still won't be hurt. 

We use md5 in several other places, also on permanent basis.  Perhaps I am only paranoid. For now just those changes, that can also go back easily.