### PR TITLE
do not create empty userid when attribute does not have allowed chars

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -579,7 +579,19 @@ class Access extends LDAPUtility implements IUserTools {
 			} else {
 				$username = $uuid;
 			}
-			$intName = $this->sanitizeUsername($username);
+			try {
+				$intName = $this->sanitizeUsername($username);
+			} catch (\InvalidArgumentException $e) {
+				\OC::$server->getLogger()->logException($e, [
+					'app' => 'user_ldap',
+					'level' => Util::WARN,
+				]);
+				// we don't attempt to set a username here. We can go for
+				// for an alternativ 4 digit random number as we would append
+				// otherwise, however it's likely not enough space in bigger
+				// setups, and most importantly: this is not intended.
+				return false;
+			}
 		} else {
 			$intName = $ldapName;
 		}
@@ -1291,7 +1303,7 @@ class Access extends LDAPUtility implements IUserTools {
 
 	/**
 	 * @param string $name
-	 * @return bool|mixed|string
+	 * @return string
 	 */
 	public function sanitizeUsername($name) {
 		if($this->connection->ldapIgnoreNamingRules) {
@@ -1300,13 +1312,17 @@ class Access extends LDAPUtility implements IUserTools {
 
 		// Transliteration
 		// latin characters to ASCII
-		$name = iconv('UTF-8', 'ASCII//TRANSLIT', $name);
+		$name = iconv('UTF-8', 'ASCII//TRANSLIT', trim($name));
 
 		// Replacements
 		$name = str_replace(' ', '_', $name);
 
 		// Every remaining disallowed characters will be removed
 		$name = preg_replace('/[^a-zA-Z0-9_.@-]/u', '', $name);
+
+		if($name === '') {
+			throw new \InvalidArgumentException('provided name template for username does not contain any allowed characters');
+		}
 
 		return $name;
 	}

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1307,13 +1307,18 @@ class Access extends LDAPUtility implements IUserTools {
 	 * @throws \InvalidArgumentException
 	 */
 	public function sanitizeUsername($name) {
+		$name = trim($name);
+
 		if($this->connection->ldapIgnoreNamingRules) {
-			return trim($name);
+			return $name;
 		}
 
-		// Transliteration
-		// latin characters to ASCII
-		$name = iconv('UTF-8', 'ASCII//TRANSLIT', trim($name));
+		// Transliteration to ASCII
+		$transliterated = @iconv('UTF-8', 'ASCII//TRANSLIT', $name);
+		if($transliterated !== false) {
+			// depending on system config iconv can work or not
+			$name = $transliterated;
+		}
 
 		// Replacements
 		$name = str_replace(' ', '_', $name);

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -587,7 +587,7 @@ class Access extends LDAPUtility implements IUserTools {
 					'level' => Util::WARN,
 				]);
 				// we don't attempt to set a username here. We can go for
-				// for an alternativ 4 digit random number as we would append
+				// for an alternative 4 digit random number as we would append
 				// otherwise, however it's likely not enough space in bigger
 				// setups, and most importantly: this is not intended.
 				return false;
@@ -1304,6 +1304,7 @@ class Access extends LDAPUtility implements IUserTools {
 	/**
 	 * @param string $name
 	 * @return string
+	 * @throws \InvalidArgumentException
 	 */
 	public function sanitizeUsername($name) {
 		if($this->connection->ldapIgnoreNamingRules) {

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -633,13 +633,16 @@ class AccessTest extends TestCase {
 	}
 
 	public function intUsernameProvider() {
+		// system dependent :-/
+		$translitExpected = @iconv('UTF-8', 'ASCII//TRANSLIT', 'fränk') ? 'frank' : 'frnk';
+
 		return [
 			['alice', 'alice'],
 			['b/ob', 'bob'],
 			['charly🐬', 'charly'],
 			['debo rah', 'debo_rah'],
 			['epost@poste.test', 'epost@poste.test'],
-			['fränk', 'frank'],
+			['fränk', $translitExpected],
 			[' gerda ', 'gerda'],
 			['🕱🐵🐘🐑', null]
 		];

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -632,5 +632,33 @@ class AccessTest extends TestCase {
 		$this->assertSame($expected, $list);
 	}
 
+	public function intUsernameProvider() {
+		return [
+			['alice', 'alice'],
+			['b/ob', 'bob'],
+			['charly🐬', 'charly'],
+			['debo rah', 'debo_rah'],
+			['epost@poste.test', 'epost@poste.test'],
+			['fränk', 'frank'],
+			[' gerda ', 'gerda'],
+			['🕱🐵🐘🐑', null]
+		];
+	}
+
+	/**
+	 * @dataProvider intUsernameProvider
+	 *
+	 * @param $name
+	 * @param $expected
+	 */
+	public function testSanitizeUsername($name, $expected) {
+		if($expected === null) {
+			$this->expectException(\InvalidArgumentException::class);
+		}
+		$sanitizedName = $this->access->sanitizeUsername($name);
+		$this->assertSame($expected, $sanitizedName);
+	}
+
+
 
 }


### PR DESCRIPTION
If some funny attribute contains only characters that are not allowed for user ids, one empty userid would have been generated. Comes with unit test.