### PR TITLE
#8629 use a global unique identifier for each event sequence type 

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -427,7 +427,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 		return $this->userDisplayNames[$uid];
 	}
-	
+
 	/**
 	 * @return array
 	 */
@@ -976,7 +976,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$q->select($q->createFunction('COUNT(*)'))
 			->from('calendarobjects')
 			->where($q->expr()->eq('calendarid', $q->createNamedParameter($calendarId)))
-			->andWhere($q->expr()->eq('uid', $q->createNamedParameter($extraData['uid'])));
+			->andWhere($q->expr()->eq('uid', $q->createNamedParameter($objectUri)));
 
 		$result = $q->execute();
 		$count = (int) $result->fetchColumn();
@@ -999,7 +999,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 				'firstoccurence' => $query->createNamedParameter($extraData['firstOccurence']),
 				'lastoccurence' => $query->createNamedParameter($extraData['lastOccurence']),
 				'classification' => $query->createNamedParameter($extraData['classification']),
-				'uid' => $query->createNamedParameter($extraData['uid']),
+				'uid' => $query->createNamedParameter($objectUri),
 			])
 			->execute();
 


### PR DESCRIPTION
Solves #8629.

Use a global unique identifier for each event sequence type (birthday, anniversary, date of death) instead of one shared contact URI.

Using the unique event ObjectUri/DateUri as event UID solved that issue for me.

Maybe someone could add some unit tests. (I could not find an existing unit test for that. So unit tests are not changed.)

Maybe someone could add a migration script to fix existing data in database.

Instructions to fix corrupt data:
Migration for existing corrupt VCALENDAR datasets can be healed with:

- truncate table
- re-creation of birthday calendar

`docker exec --user www-data nextcloudapp php occ dav:sync-birthday-calendar christian`