### PR TITLE
Better debugging for "Your test case is not allowed to access the dat…

### DIFF
--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -46,6 +46,7 @@ class SimpleContainer extends Container implements IContainer {
 	/**
 	 * @param ReflectionClass $class the class to instantiate
 	 * @return \stdClass the created class
+	 * @suppress PhanUndeclaredClassInstanceof
 	 */
 	private function buildClass(ReflectionClass $class) {
 		$constructor = $class->getConstructor();

--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -66,6 +66,12 @@ class SimpleContainer extends Container implements IContainer {
 				try {
 					$parameters[] = $this->query($resolveName);
 				} catch (\Exception $e) {
+					if (class_exists("PHPUnit_Framework_AssertionFailedError") &&
+						$e instanceof \PHPUnit_Framework_AssertionFailedError) {
+						// Easier debugging of "Your test case is not allowed to access the database."
+						throw $e;
+					}
+
 					// Service not found, use the default value when available
 					if ($parameter->isDefaultValueAvailable()) {
 						$parameters[] = $parameter->getDefaultValue();

--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -66,7 +66,7 @@ class SimpleContainer extends Container implements IContainer {
 				try {
 					$parameters[] = $this->query($resolveName);
 				} catch (\Exception $e) {
-					if (class_exists("PHPUnit_Framework_AssertionFailedError") &&
+					if (class_exists("PHPUnit_Framework_AssertionFailedError", false) &&
 						$e instanceof \PHPUnit_Framework_AssertionFailedError) {
 						// Easier debugging of "Your test case is not allowed to access the database."
 						throw $e;

--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -67,7 +67,7 @@ class SimpleContainer extends Container implements IContainer {
 				try {
 					$parameters[] = $this->query($resolveName);
 				} catch (\Exception $e) {
-					if (class_exists("PHPUnit_Framework_AssertionFailedError", false) &&
+					if (class_exists('PHPUnit_Framework_AssertionFailedError', false) &&
 						$e instanceof \PHPUnit_Framework_AssertionFailedError) {
 						// Easier debugging of "Your test case is not allowed to access the database."
 						throw $e;


### PR DESCRIPTION
…abase."

Ref https://help.nextcloud.com/t/integration-test-failure/28383

### before
```
There was 1 error:

1) OCA\FocusFrog\Tests\Integration\Controller\TaskIntegrationTest::testUpdate
OCP\AppFramework\QueryException: Could not resolve service! Class service does not exist

/home/nickv/Nextcloud/13/server/lib/private/AppFramework/Utility/SimpleContainer.php:108
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/Utility/SimpleContainer.php:123
/home/nickv/Nextcloud/13/server/lib/private/ServerContainer.php:132
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/DependencyInjection/DIContainer.php:441
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/Utility/SimpleContainer.php:79
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/Utility/SimpleContainer.php:102
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/Utility/SimpleContainer.php:123
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/DependencyInjection/DIContainer.php:467
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/DependencyInjection/DIContainer.php:438
/home/nickv/Nextcloud/13/server/appstank/focusfrog/tests/Integration/Controller/TaskIntegrationTest.php:30

ERRORS!
Tests: 2, Assertions: 1, Errors: 1.
```

### before
```
There was 1 failure:

1) OCA\FocusFrog\Tests\Integration\Controller\TaskIntegrationTest::testUpdate
Your test case is not allowed to access the database.

/home/nickv/Nextcloud/13/server/tests/lib/TestCase.php:142
/home/nickv/Nextcloud/13/server/3rdparty/pimple/pimple/src/Pimple/Container.php:113
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/Utility/SimpleContainer.php:123
/home/nickv/Nextcloud/13/server/lib/private/ServerContainer.php:132
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/DependencyInjection/DIContainer.php:441
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/Utility/SimpleContainer.php:68
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/Utility/SimpleContainer.php:104
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/Utility/SimpleContainer.php:125
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/DependencyInjection/DIContainer.php:467
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/DependencyInjection/DIContainer.php:438
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/Utility/SimpleContainer.php:68
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/Utility/SimpleContainer.php:104
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/Utility/SimpleContainer.php:125
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/DependencyInjection/DIContainer.php:467
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/DependencyInjection/DIContainer.php:438
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/Utility/SimpleContainer.php:68
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/Utility/SimpleContainer.php:104
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/Utility/SimpleContainer.php:125
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/DependencyInjection/DIContainer.php:467
/home/nickv/Nextcloud/13/server/lib/private/AppFramework/DependencyInjection/DIContainer.php:438
/home/nickv/Nextcloud/13/server/appstank/focusfrog/tests/Integration/Controller/TaskIntegrationTest.php:30

FAILURES!
Tests: 2, Assertions: 1, Failures: 1.

```