### PR TITLE
[stable13] Fix check if theming defaults instance is available

### DIFF
--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -35,6 +35,7 @@
 namespace OC;
 
 
+use OCA\Theming\ThemingDefaults;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IRequest;
@@ -170,7 +171,10 @@ class URLGenerator implements IURLGenerator {
 		$themingEnabled = $this->config->getSystemValue('installed', false) && \OCP\App::isEnabled('theming') && \OC_App::isAppLoaded('theming');
 		$themingImagePath = false;
 		if($themingEnabled) {
-			$themingImagePath = \OC::$server->getThemingDefaults()->replaceImagePath($app, $image);
+			$themingDefaults = \OC::$server->getThemingDefaults();
+			if ($themingDefaults instanceof ThemingDefaults) {
+				$themingImagePath = $themingDefaults->replaceImagePath($app, $image);
+			}
 		}
 
 		if (file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$image")) {


### PR DESCRIPTION
The check in URLGenerator.php#169 and Server.php#945 are different and thus the DI container could return a \OC_Defaults object which does not provide the wanted method caising a PHP error.

Fixes #8420

Backport of #8557