### PR TITLE
[stable13] Fix undefined index problem

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -293,9 +293,11 @@ class AppConfig implements IAppConfig {
 	public function getFilteredValues($app) {
 		$values = $this->getValues($app, false);
 
-		foreach ($this->sensitiveValues[$app] as $sensitiveKey) {
-			if (isset($values[$sensitiveKey])) {
-				$values[$sensitiveKey] = IConfig::SENSITIVE_VALUE;
+		if (array_key_exists($app, $this->sensitiveValues)) {
+			foreach ($this->sensitiveValues[$app] as $sensitiveKey) {
+				if (isset($values[$sensitiveKey])) {
+					$values[$sensitiveKey] = IConfig::SENSITIVE_VALUE;
+				}
 			}
 		}
 


### PR DESCRIPTION
Nextcloud 13RC4, error in logfile, triggered by "occ config:list":

Invalid argument supplied for foreach() at lib/private/AppConfig.php#297
PHP	Undefined index: workflowengine at lib/private/AppConfig.php#297

Fix: Check if index exists in array before using it.

Backport of #8173 