### PR TITLE
disable part files for object stores

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -144,6 +144,8 @@ class File extends Node implements IFile {
 		} else {
 			// upload file directly as the final path
 			$partFilePath = $this->path;
+
+			$this->emitPreHooks($exists);
 		}
 
 		// the part file and target file might be on a different storage in case of a single file storage (e.g. single file share)
@@ -188,11 +190,7 @@ class File extends Node implements IFile {
 
 		try {
 			$view = \OC\Files\Filesystem::getView();
-			if ($view) {
-				$run = $this->emitPreHooks($exists);
-			} else {
-				$run = true;
-			}
+			$run = ($view && $needsPartFile) ? $this->emitPreHooks($exists) : true;
 
 			try {
 				$this->changeLock(ILockingProvider::LOCK_EXCLUSIVE);

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -423,4 +423,8 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 	public function hasUpdated($path, $time) {
 		return false;
 	}
+
+	public function needsPartFile() {
+		return false;
+	}
 }


### PR DESCRIPTION
Renaming the part file to the target file while preserving fileids can't be done for object stores without issues.

To test

- upload a new file to s3 object store
- check the fileid
- overwrite the file with dav upload
- check the fileid again