### PR TITLE
Better handling of invisible elements in acceptance tests

### DIFF
--- a/tests/acceptance/features/core/ElementWrapper.php
+++ b/tests/acceptance/features/core/ElementWrapper.php
@@ -38,6 +38,14 @@
  * the element is stale it is found again using the same parameters to find it
  * in the first place.
  *
+ * NoSuchElement exceptions are sometimes thrown instead of
+ * StaleElementReference exceptions. This can happen when the Selenium2 driver
+ * for Mink performs an action on an element through the WebDriver session
+ * instead of directly through the WebDriver element. In that case, if the
+ * element with the given ID does not exist, a NoSuchElement exception would be
+ * thrown instead of a StaleElementReference exception, so those cases are
+ * handled like StaleElementReference exceptions.
+ *
  * ElementNotVisible exceptions are thrown when the command requires the element
  * to be visible but the element is not. Finding an element only guarantees that
  * (at that time) the element is attached to the DOM, but it does not provide
@@ -200,8 +208,8 @@ class ElementWrapper {
 	/**
 	 * Executes the given command.
 	 *
-	 * If a StaleElementReference exception is thrown the wrapped element is
-	 * found again and, then, the command is executed again.
+	 * If a StaleElementReference or a NoSuchElement exception is thrown the
+	 * wrapped element is found again and, then, the command is executed again.
 	 *
 	 * @param \Closure $commandCallback the command to execute.
 	 * @param string $errorMessage an error message that describes the failed
@@ -216,6 +224,8 @@ class ElementWrapper {
 			return $commandCallback();
 		} catch (\WebDriver\Exception\StaleElementReference $exception) {
 			$this->printFailedCommandMessage($exception, $errorMessage);
+		} catch (\WebDriver\Exception\NoSuchElement $exception) {
+			$this->printFailedCommandMessage($exception, $errorMessage);
 		}
 
 		$this->element = $this->elementFinder->find();
@@ -226,10 +236,10 @@ class ElementWrapper {
 	/**
 	 * Executes the given command on a visible element.
 	 *
-	 * If a StaleElementReference exception is thrown the wrapped element is
-	 * found again and, then, the command is executed again. If an
-	 * ElementNotVisible or a MoveTargetOutOfBounds exception is thrown it is
-	 * waited for the wrapped element to be visible and, then, the command is
+	 * If a StaleElementReference or a NoSuchElement exception is thrown the
+	 * wrapped element is found again and, then, the command is executed again.
+	 * If an ElementNotVisible or a MoveTargetOutOfBounds exception is thrown it
+	 * is waited for the wrapped element to be visible and, then, the command is
 	 * executed again.
 	 *
 	 * @param \Closure $commandCallback the command to execute.


### PR DESCRIPTION

This pull request adds automatic handling for `MoveTargetOutOfBounds` and `NoSuchElement` exceptions. This does not change the behaviour of current acceptance tests, but it makes them more robust.

`MoveTargetOutOfBounds` and `NoSuchElement` exceptions are sometimes thrown instead of `ElementNotVisible` and `StaleElementReference` exceptions, because the Selenium2 driver for Mink performs some actions on elements through the WebDriver session instead of through the WebDriver element. For example, [when an element is clicked the cursor is first moved on that element using the WebDriver session](https://github.com/minkphp/MinkSelenium2Driver/blob/739b7570f0536bad9b07b511a62c885ee1ec029a/src/Selenium2Driver.php#L770). Therefore, now the exceptions thrown by the WebDriver session are handled like their equivalent exceptions thrown by the WebDriver element.

Note that `MoveTargetOutOfBounds` exceptions are thrown too when the element is visible but "out of reach". The only way to differentiate those cases seems to be through the exception message, as when the element is not visible it says _Offset within element cannot be scrolled into view: (0, 0)_, and when it is visible other values appear instead of _(0, 0)_.

However, although that is true in most cases, that difference is not necessarily always true; [_(0, 0)_ is the offset on the element to move the cursor to](https://github.com/SeleniumHQ/selenium/blob/selenium-2.53.1/javascript/firefox-driver/js/firefoxDriver.js#L1107-L1108), and when an element is invisible it is 0 because [by default the cursor is moved to the centre of the element](https://github.com/SeleniumHQ/selenium/blob/selenium-2.53.1/javascript/firefox-driver/js/events.js#L40-L48), and when the element is invisible its width and height is returned as 0. That does not mean that if the coordinates are _(0, 0)_ the element is invisible, though, as the coordinates could have been explicitly set to that position on a visible element.

Due to all that the `MoveTargetOutOfBounds` exceptions are always handled as `ElementNotVisible` exceptions; that should not be a problem, as if the element was indeed visible the same exception would be thrown once it is verified that the element is visible and the action is automatically performed again.
