### PR TITLE
Fix NULL users?

### DIFF
--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -323,7 +323,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @param IUser $user
 	 * @return array with group ids
 	 */
-	public function getUserGroupIds(IUser $user) {
+	public function getUserGroupIds(IUser $user = null) {
 		return array_map(function($value) {
 			return (string) $value;
 		}, array_keys($this->getUserGroups($user)));


### PR DESCRIPTION
When the following options are enabled in Nextcloud 13.0.0 the ContactsMenu fails to load.
```
Restrict users to only share with users in their groups
Allow username autocompletion in share dialog. If this is disabled the full username or email address needs to be entered.
```

The issue is traced back to:
### /lib/private/Contacts/ContactsMenu/ContactsStore.php
```PHP
$contactGroups = $this->groupManager->getUserGroupIds($this->userManager->get($entry->getProperty('UID')));
```

You'll get the error:
```
TypeError: Argument 1 passed to OC\Group\Manager::getUserGroupIds() must implement interface OCP\IUser, null given, called in /nextcloud/lib/private/Contacts/ContactsMenu/ContactsStore.php on line 161
```