### PR TITLE
Properly cache swift v3 token

### DIFF
--- a/lib/private/Files/ObjectStore/SwiftFactory.php
+++ b/lib/private/Files/ObjectStore/SwiftFactory.php
@@ -60,7 +60,12 @@ class SwiftFactory {
 	}
 
 	private function cacheToken(Token $token, string $cacheKey) {
-		$this->cache->set($cacheKey . '/token', json_encode($token));
+		if ($token instanceof \OpenStack\Identity\v3\Models\Token) {
+			$value = json_encode($token->export());
+		} else {
+			$value = json_encode($token);
+		}
+		$this->cache->set($cacheKey . '/token', $value);
 	}
 
 	/**


### PR DESCRIPTION
The V3 token has an export function. Without this the token is
effectively never cached.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>