### PR TITLE
Make QueryBuilder varadic

### DIFF
--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php
@@ -71,14 +71,13 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 *     // (u.type = ?) AND (u.role = ?)
 	 *     $expr->andX('u.type = ?', 'u.role = ?'));
 	 *
-	 * @param mixed $x Optional clause. Defaults = null, but requires
+	 * @param mixed ...$x Optional clause. Defaults = null, but requires
 	 *                 at least one defined when converting to string.
 	 *
 	 * @return \OCP\DB\QueryBuilder\ICompositeExpression
 	 */
-	public function andX($x = null) {
-		$arguments = func_get_args();
-		$compositeExpression = call_user_func_array([$this->expressionBuilder, 'andX'], $arguments);
+	public function andX(...$x) {
+		$compositeExpression = call_user_func_array([$this->expressionBuilder, 'andX'], $x);
 		return new CompositeExpression($compositeExpression);
 	}
 
@@ -91,14 +90,13 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 *     // (u.type = ?) OR (u.role = ?)
 	 *     $qb->where($qb->expr()->orX('u.type = ?', 'u.role = ?'));
 	 *
-	 * @param mixed $x Optional clause. Defaults = null, but requires
+	 * @param mixed ...$x Optional clause. Defaults = null, but requires
 	 *                 at least one defined when converting to string.
 	 *
 	 * @return \OCP\DB\QueryBuilder\ICompositeExpression
 	 */
-	public function orX($x = null) {
-		$arguments = func_get_args();
-		$compositeExpression = call_user_func_array([$this->expressionBuilder, 'orX'], $arguments);
+	public function orX(...$x) {
+		$compositeExpression = call_user_func_array([$this->expressionBuilder, 'orX'], $x);
 		return new CompositeExpression($compositeExpression);
 	}
 

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -835,12 +835,14 @@ class QueryBuilder implements IQueryBuilder {
 	 *         ->addGroupBy('u.createdAt')
 	 * </code>
 	 *
-	 * @param mixed $groupBy The grouping expression.
+	 * @param mixed ...$groupBy The grouping expression.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 */
-	public function addGroupBy($groupBy) {
-		$groupBys = is_array($groupBy) ? $groupBy : func_get_args();
+	public function addGroupBy(...$groupBys) {
+		if (count($groupBys) === 1 && is_array($groupBys[0])) {
+			$$groupBys = $groupBys[0];
+		}
 
 		call_user_func_array(
 			[$this->queryBuilder, 'addGroupBy'],

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -931,14 +931,14 @@ class QueryBuilder implements IQueryBuilder {
 	 * Adds a restriction over the groups of the query, forming a logical
 	 * conjunction with any existing having restrictions.
 	 *
-	 * @param mixed $having The restriction to append.
+	 * @param mixed ...$having The restriction to append.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 */
-	public function andHaving($having) {
+	public function andHaving(...$having) {
 		call_user_func_array(
 			[$this->queryBuilder, 'andHaving'],
-			func_get_args()
+			$having
 		);
 
 		return $this;

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -452,12 +452,14 @@ class QueryBuilder implements IQueryBuilder {
 	 *         ->leftJoin('u', 'phonenumbers', 'u.id = p.user_id');
 	 * </code>
 	 *
-	 * @param mixed $select The selection expression.
+	 * @param mixed ...$selects The selection expression.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 */
-	public function addSelect($select = null) {
-		$selects = is_array($select) ? $select : func_get_args();
+	public function addSelect(...$selects) {
+		if (count($selects) === 1 && is_array($selects[0])) {
+			$selects = $selects[0];
+		}
 
 		$this->queryBuilder->addSelect(
 			$this->helper->quoteColumnNames($selects)

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -729,14 +729,14 @@ class QueryBuilder implements IQueryBuilder {
 	 *         ->where($or);
 	 * </code>
 	 *
-	 * @param mixed $predicates The restriction predicates.
+	 * @param mixed ...$predicates The restriction predicates.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 */
-	public function where($predicates) {
+	public function where(...$predicates) {
 		call_user_func_array(
 			[$this->queryBuilder, 'where'],
-			func_get_args()
+			$predicates
 		);
 
 		return $this;

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -807,12 +807,14 @@ class QueryBuilder implements IQueryBuilder {
 	 *         ->groupBy('u.id');
 	 * </code>
 	 *
-	 * @param mixed $groupBy The grouping expression.
+	 * @param mixed ...$groupBys The grouping expression.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 */
-	public function groupBy($groupBy) {
-		$groupBys = is_array($groupBy) ? $groupBy : func_get_args();
+	public function groupBy(...$groupBys) {
+		if (count($groupBys) === 1 && is_array($groupBys[0])) {
+			$$groupBys = $groupBys[0];
+		}
 
 		call_user_func_array(
 			[$this->queryBuilder, 'groupBy'],

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -754,16 +754,16 @@ class QueryBuilder implements IQueryBuilder {
 	 *         ->andWhere('u.is_active = 1');
 	 * </code>
 	 *
-	 * @param mixed $where The query restrictions.
+	 * @param mixed ...$where The query restrictions.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 *
 	 * @see where()
 	 */
-	public function andWhere($where) {
+	public function andWhere(...$where) {
 		call_user_func_array(
 			[$this->queryBuilder, 'andWhere'],
-			func_get_args()
+			$where
 		);
 
 		return $this;

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -781,16 +781,16 @@ class QueryBuilder implements IQueryBuilder {
 	 *         ->orWhere('u.id = 2');
 	 * </code>
 	 *
-	 * @param mixed $where The WHERE statement.
+	 * @param mixed ...$where The WHERE statement.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 *
 	 * @see where()
 	 */
-	public function orWhere($where) {
+	public function orWhere(...$where) {
 		call_user_func_array(
 			[$this->queryBuilder, 'orWhere'],
-			func_get_args()
+			$where
 		);
 
 		return $this;

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -914,14 +914,14 @@ class QueryBuilder implements IQueryBuilder {
 	 * Specifies a restriction over the groups of the query.
 	 * Replaces any previous having restrictions, if any.
 	 *
-	 * @param mixed $having The restriction over the groups.
+	 * @param mixed ...$having The restriction over the groups.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 */
-	public function having($having) {
+	public function having(...$having) {
 		call_user_func_array(
 			[$this->queryBuilder, 'having'],
-			func_get_args()
+			$having
 		);
 
 		return $this;

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -948,14 +948,14 @@ class QueryBuilder implements IQueryBuilder {
 	 * Adds a restriction over the groups of the query, forming a logical
 	 * disjunction with any existing having restrictions.
 	 *
-	 * @param mixed $having The restriction to add.
+	 * @param mixed ...$having The restriction to add.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 */
-	public function orHaving($having) {
+	public function orHaving(...$having) {
 		call_user_func_array(
 			[$this->queryBuilder, 'orHaving'],
-			func_get_args()
+			$having
 		);
 
 		return $this;

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -379,12 +379,14 @@ class QueryBuilder implements IQueryBuilder {
 	 *         ->leftJoin('u', 'phonenumbers', 'p', 'u.id = p.user_id');
 	 * </code>
 	 *
-	 * @param mixed $select The selection expressions.
+	 * @param mixed ...$selects The selection expressions.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 */
-	public function select($select = null) {
-		$selects = is_array($select) ? $select : func_get_args();
+	public function select(...$selects) {
+		if (count($selects) === 1 && is_array($selects[0])) {
+			$selects = $selects[0];
+		}
 
 		$this->queryBuilder->select(
 			$this->helper->quoteColumnNames($selects)

--- a/lib/public/DB/QueryBuilder/IExpressionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IExpressionBuilder.php
@@ -66,13 +66,13 @@ interface IExpressionBuilder {
 	 *     // (u.type = ?) AND (u.role = ?)
 	 *     $expr->andX('u.type = ?', 'u.role = ?'));
 	 *
-	 * @param mixed $x Optional clause. Defaults = null, but requires
+	 * @param mixed ...$x Optional clause. Defaults = null, but requires
 	 *                 at least one defined when converting to string.
 	 *
 	 * @return \OCP\DB\QueryBuilder\ICompositeExpression
 	 * @since 8.2.0
 	 */
-	public function andX($x = null);
+	public function andX(...$x);
 
 	/**
 	 * Creates a disjunction of the given boolean expressions.
@@ -83,13 +83,13 @@ interface IExpressionBuilder {
 	 *     // (u.type = ?) OR (u.role = ?)
 	 *     $qb->where($qb->expr()->orX('u.type = ?', 'u.role = ?'));
 	 *
-	 * @param mixed $x Optional clause. Defaults = null, but requires
+	 * @param mixed ...$x Optional clause. Defaults = null, but requires
 	 *                 at least one defined when converting to string.
 	 *
 	 * @return \OCP\DB\QueryBuilder\ICompositeExpression
 	 * @since 8.2.0
 	 */
-	public function orX($x = null);
+	public function orX(...$x);
 
 	/**
 	 * Creates a comparison expression.

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -704,12 +704,12 @@ interface IQueryBuilder {
 	 * Adds a restriction over the groups of the query, forming a logical
 	 * disjunction with any existing having restrictions.
 	 *
-	 * @param mixed $having The restriction to add.
+	 * @param mixed ...$having The restriction to add.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 * @since 8.2.0
 	 */
-	public function orHaving($having);
+	public function orHaving(...$having);
 
 	/**
 	 * Specifies an ordering for the query results.

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -627,12 +627,12 @@ interface IQueryBuilder {
 	 *         ->addGroupBy('u.createdAt')
 	 * </code>
 	 *
-	 * @param mixed $groupBy The grouping expression.
+	 * @param mixed ...$groupBy The grouping expression.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 * @since 8.2.0
 	 */
-	public function addGroupBy($groupBy);
+	public function addGroupBy(...$groupBy);
 
 	/**
 	 * Sets a value for a column in an insert query.

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -693,12 +693,12 @@ interface IQueryBuilder {
 	 * Adds a restriction over the groups of the query, forming a logical
 	 * conjunction with any existing having restrictions.
 	 *
-	 * @param mixed $having The restriction to append.
+	 * @param mixed ...$having The restriction to append.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 * @since 8.2.0
 	 */
-	public function andHaving($having);
+	public function andHaving(...$having);
 
 	/**
 	 * Adds a restriction over the groups of the query, forming a logical

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -554,7 +554,7 @@ interface IQueryBuilder {
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 * @since 8.2.0
 	 */
-	public function where($predicates);
+	public function where(...$predicates);
 
 	/**
 	 * Adds one or more restrictions to the query results, forming a logical

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -682,12 +682,12 @@ interface IQueryBuilder {
 	 * Specifies a restriction over the groups of the query.
 	 * Replaces any previous having restrictions, if any.
 	 *
-	 * @param mixed $having The restriction over the groups.
+	 * @param mixed ...$having The restriction over the groups.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 * @since 8.2.0
 	 */
-	public function having($having);
+	public function having(...$having);
 
 	/**
 	 * Adds a restriction over the groups of the query, forming a logical

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -568,7 +568,7 @@ interface IQueryBuilder {
 	 *         ->andWhere('u.is_active = 1');
 	 * </code>
 	 *
-	 * @param mixed $where The query restrictions.
+	 * @param mixed ...$where The query restrictions.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 *
@@ -589,14 +589,14 @@ interface IQueryBuilder {
 	 *         ->orWhere('u.id = 2');
 	 * </code>
 	 *
-	 * @param mixed $where The WHERE statement.
+	 * @param mixed ...$where The WHERE statement.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 *
 	 * @see where()
 	 * @since 8.2.0
 	 */
-	public function orWhere($where);
+	public function orWhere(...$where);
 
 	/**
 	 * Specifies a grouping over the results of the query.

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -344,12 +344,12 @@ interface IQueryBuilder {
 	 *         ->leftJoin('u', 'phonenumbers', 'u.id = p.user_id');
 	 * </code>
 	 *
-	 * @param mixed $select The selection expression.
+	 * @param mixed ...$select The selection expression.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 * @since 8.2.0
 	 */
-	public function addSelect($select = null);
+	public function addSelect(...$select);
 
 	/**
 	 * Turns the query being built into a bulk delete query that ranges over

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -575,7 +575,7 @@ interface IQueryBuilder {
 	 * @see where()
 	 * @since 8.2.0
 	 */
-	public function andWhere($where);
+	public function andWhere(...$where);
 
 	/**
 	 * Adds one or more restrictions to the query results, forming a logical

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -609,12 +609,12 @@ interface IQueryBuilder {
 	 *         ->groupBy('u.id');
 	 * </code>
 	 *
-	 * @param mixed $groupBy The grouping expression.
+	 * @param mixed ...$groupBys The grouping expression.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 * @since 8.2.0
 	 */
-	public function groupBy($groupBy);
+	public function groupBy(...$groupBys);
 
 	/**
 	 * Adds a grouping expression to the query.

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -292,12 +292,12 @@ interface IQueryBuilder {
 	 *         ->leftJoin('u', 'phonenumbers', 'p', 'u.id = p.user_id');
 	 * </code>
 	 *
-	 * @param mixed $select The selection expressions.
+	 * @param mixed ...$selects The selection expressions.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder This QueryBuilder instance.
 	 * @since 8.2.0
 	 */
-	public function select($select = null);
+	public function select(...$selects);
 
 	/**
 	 * Specifies an item that is to be returned with a different name in the query result.


### PR DESCRIPTION
See https://github.com/nextcloud/twofactor_totp/pull/239#discussion_r173892949

Note that this not break public API. It just makes it possible to properly typecheck.

Todo:
- [x] select
- [x] All the other functions