### PR TITLE
Inject public IGroupManager instead of private GroupManager

### DIFF
--- a/settings/Controller/ChangePasswordController.php
+++ b/settings/Controller/ChangePasswordController.php
@@ -1,5 +1,7 @@
 <?php
-declare(strict_types=1);
+// FIXME: disabled for now to be able to inject IGroupManager and also use
+// getSubAdmin()
+//declare(strict_types=1);
 /**
  *
  *
@@ -27,12 +29,12 @@ declare(strict_types=1);
  */
 namespace OC\Settings\Controller;
 
-use OC\Group\Manager as GroupManager;
 use OC\HintException;
 use OC\User\Session;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
@@ -50,7 +52,7 @@ class ChangePasswordController extends Controller {
 	/** @var IL10N */
 	private $l;
 
-	/** @var GroupManager */
+	/** @var IGroupManager */
 	private $groupManager;
 
 	/** @var Session */
@@ -64,7 +66,7 @@ class ChangePasswordController extends Controller {
 								string $userId,
 								IUserManager $userManager,
 								IUserSession $userSession,
-								GroupManager $groupManager,
+								IGroupManager $groupManager,
 								IAppManager $appManager,
 								IL10N $l) {
 		parent::__construct($appName, $request);

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -1,5 +1,7 @@
 <?php
-declare(strict_types=1);
+// FIXME: disabled for now to be able to inject IGroupManager and also use
+// getSubAdmin()
+//declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -40,7 +42,6 @@ namespace OC\Settings\Controller;
 use OC\Accounts\AccountManager;
 use OC\AppFramework\Http;
 use OC\ForbiddenException;
-use OC\Group\Manager as GroupManager;
 use OC\HintException;
 use OC\Settings\Mailer\NewUserMailHelper;
 use OC\Security\IdentityProof\Manager;
@@ -52,6 +53,7 @@ use OCP\Files\Config\IUserMountCache;
 use OCP\Encryption\IEncryptionModule;
 use OCP\Encryption\IManager;
 use OCP\IConfig;
+use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IRequest;
@@ -77,7 +79,7 @@ class UsersController extends Controller {
 	private $isAdmin;
 	/** @var IUserManager */
 	private $userManager;
-	/** @var GroupManager */
+	/** @var IGroupManager */
 	private $groupManager;
 	/** @var IConfig */
 	private $config;
@@ -113,7 +115,7 @@ class UsersController extends Controller {
 	public function __construct(string $appName,
 								IRequest $request,
 								IUserManager $userManager,
-								GroupManager $groupManager,
+								IGroupManager $groupManager,
 								IUserSession $userSession,
 								IConfig $config,
 								bool $isAdmin,


### PR DESCRIPTION
This pull request fixes a regression introduced in #8743 

[The public `IGroupManager` service](https://github.com/nextcloud/server/blob/f5c5c5181f66e15ff3ccc30fa32e84e20a863182/lib/private/Server.php#L295) returned by the dependency injection system [is automatically initialized with an `OC\Group\Database` backend](https://github.com/nextcloud/server/blob/044d01d0e13330120753077ba2ab3869da11e082/lib/base.php#L700). However, no backend is automatically set in private `GroupManager` instances. Therefore, a private `GroupManager` instance does not work as expected when initialized through the dependency injection system.

For example, an admin can no longer change the password of another user, and creating another user in the admin group does not fully work; although the user is created an error is returned anyway by the server.

Due to that this pull request reverts the changes from #8743 to replace the public "IGroupManager" with a private "GroupManager" instance. It seems that using again the public "IGroupManager" does not cause any problem regarding the strict types, so maybe something else was changed in the meantime that made that previous change no longer needed.
