### PR TITLE
Properly provide local memcache check to ICacheFactory

### DIFF
--- a/lib/private/Memcache/Factory.php
+++ b/lib/private/Memcache/Factory.php
@@ -185,11 +185,11 @@ class Factory implements ICacheFactory {
 	}
 
 	/**
-	 * check local memcache availability
+	 * Check if a local memory cache backend is available
 	 *
 	 * @return bool
 	 */
-	public function isAvailableLowLatency(): bool {
+	public function isLocalCacheAvailable(): bool {
 		return ($this->localCacheClass !== self::NULL_CACHE);
 	}
 }

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -567,7 +567,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService(\OCP\Route\IRouter::class, function (Server $c) {
 			$cacheFactory = $c->getMemCacheFactory();
 			$logger = $c->getLogger();
-			if ($cacheFactory->isAvailableLowLatency()) {
+			if ($cacheFactory->isLocalCacheAvailable()) {
 				$router = new \OC\Route\CachingRouter($cacheFactory->createLocal('route'), $logger);
 			} else {
 				$router = new \OC\Route\Router($logger);
@@ -581,7 +581,7 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 		$this->registerAlias('Search', \OCP\ISearch::class);
 
-		$this->registerService(\OC\Security\RateLimiting\Limiter::class, function ($c) {
+		$this->registerService(\OC\Security\RateLimiting\Limiter::class, function (Server $c) {
 			return new \OC\Security\RateLimiting\Limiter(
 				$this->getUserSession(),
 				$this->getRequest(),

--- a/lib/public/ICacheFactory.php
+++ b/lib/public/ICacheFactory.php
@@ -52,6 +52,14 @@ interface ICacheFactory{
 	public function isAvailable(): bool;
 
 	/**
+	 * Check if a local memory cache backend is available
+	 *
+	 * @return bool
+	 * @since 14.0.0
+	 */
+	public function isLocalCacheAvailable(): bool;
+
+	/**
 	 * create a cache instance for storing locks
 	 *
 	 * @param string $prefix


### PR DESCRIPTION
Ref #8375 

We used this method in one place only but this makes the check for local cache available in the public interface (as the one for distributed cache was already). Should also make Phan more happy, because now the method is properly defined.