### PR TITLE
Provide a description of the update channels inline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 !/apps/testing
 !/apps/admin_audit
 !/apps/updatenotification
+/apps/updatenotification/build
 /apps/updatenotification/js/merged.js
 /apps/updatenotification/js/merged.js.map
 /apps/updatenotification/js/*.hot-update.*

--- a/apps/updatenotification/css/admin.css
+++ b/apps/updatenotification/css/admin.css
@@ -31,3 +31,12 @@
 #updatenotification .icon-triangle-n {
 	opacity: 0.5;
 }
+
+#updatenotification .channel-description span {
+	color: #aaa;
+}
+
+#updatenotification .channel-description span strong {
+	color: #555;
+	font-weight: normal;
+}

--- a/apps/updatenotification/js-src/components/root.vue
+++ b/apps/updatenotification/js-src/components/root.vue
@@ -55,6 +55,12 @@
 			<em>{{ t('updatenotification', 'Note that after a new release it can take some time before it shows up here. We roll out new versions spread out over time to our users and sometimes skip a version when issues are found.') }}</em>
 		</p>
 
+		<p class="channel-description">
+			<span v-html="productionInfoString"></span><br>
+			<span v-html="stableInfoString"></span><br>
+			<span v-html="betaInfoString"></span>
+		</p>
+
 		<p id="oca_updatenotification_groups">
 			{{ t('updatenotification', 'Notify members of the following groups about available updates:') }}
 			<v-select multiple :value="notifyGroups" :options="availableGroups"></v-select><br />
@@ -174,6 +180,18 @@
 					this.missingAppUpdates.length, {
 						version: this.newVersionString
 					});
+			},
+
+			productionInfoString: function() {
+				return t('updatenotification', '<strong>production</strong> will always provide the latest patch level, but not update to the next major release immediately. That update usually happens with the second minor release (x.0.2).');
+			},
+
+			stableInfoString: function() {
+				return t('updatenotification', '<strong>stable</strong> is the most recent stable version. It is suited for production use and will always update to the latest major version.');
+			},
+
+			betaInfoString: function() {
+				return t('updatenotification', '<strong>beta</strong> is a pre-release version only for testing new features, not for production environments.');
 			}
 		},
 


### PR DESCRIPTION
To make the difference between the update channels more clear and transparent.

Before:
![bildschirmfoto 2018-03-14 um 10 21 59](https://user-images.githubusercontent.com/245432/37393512-90d1aa34-2771-11e8-8083-387fe2880aaf.png)


After:
![bildschirmfoto 2018-03-15 um 07 06 56](https://user-images.githubusercontent.com/245432/37446929-abb6cbe6-281f-11e8-83fa-7618f7010f85.png)

cc @nextcloud/designers for feedback on the style

@blizzz @nickvergessen because we talked about

Also this should make @jospoortvliet and @MariusBluem happy ;)

We should maybe backport the information (because the vue part is new I would create a dedicated PR for stable13 and stable12).