### PR TITLE
Remove "Alternative logins" title on login page

### DIFF
--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -106,7 +106,6 @@ script('core', 'merged-login');
 <?php if (!empty($_['alt_login'])) { ?>
 <form id="alternative-logins">
 	<fieldset>
-		<legend><?php p($l->t('Alternative Logins')) ?></legend>
 		<ul>
 			<?php foreach($_['alt_login'] as $login): ?>
 				<li><a class="button" href="<?php print_unescaped($login['href']); ?>" ><?php p($login['name']); ?></a></li>


### PR DESCRIPTION
Fixes #8813 

Before:
![bildschirmfoto 2018-03-14 um 10 55 33](https://user-images.githubusercontent.com/245432/37397625-596c9260-277c-11e8-8a79-bd191394f2a6.png)

After:
![bildschirmfoto 2018-03-14 um 11 38 40](https://user-images.githubusercontent.com/245432/37397626-59a5c29c-277c-11e8-9ec3-cbeb005b95fe.png)


cc @nextcloud/designers 