### PR TITLE
Fix configuration values matched in user searches

### DIFF
--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -203,9 +203,9 @@ class Database extends Backend implements IUserBackend {
 		$query->select('uid', 'displayname')
 			->from('users', 'u')
 			->leftJoin('u', 'preferences', 'p', $query->expr()->andX(
-				$query->expr()->eq('userid', 'uid')),
-				$query->expr()->eq('appid', new Literal('settings')),
-				$query->expr()->eq('configkey', new Literal('email'))
+				$query->expr()->eq('userid', 'uid'),
+				$query->expr()->eq('appid', $query->expr()->literal('settings')),
+				$query->expr()->eq('configkey', $query->expr()->literal('email')))
 			)
 			// sqlite doesn't like re-using a single named parameter here
 			->where($query->expr()->iLike('uid', $query->createPositionalParameter('%' . $connection->escapeLikeParameter($search) . '%')))


### PR DESCRIPTION
This pull request fixes a regression introduced in aad01894e38ff77781934c16b75dac43d49ec74a.

Due to a misplaced closing parenthesis the condition of the left join clause was just `userid = uid`; the other conditions were passed as additional parameters to `leftJoin`, and thus they were ignored. Therefore, the result set contained every preference of each user instead of only the email, so the `WHERE configvalue LIKE XXX` matched any configuration value of the user.

Besides the closing parenthesis this commit also fixes the literal values. Although `Literal` objects represent literal values they must be created through `IExpressionBuilder::literal()` to be properly quoted; otherwise it is just a plain string, which is treated as a column name.

**How to test:**
- Create a user with id and name _aaaaa_ and without e-mail address
- Open the _Sharing_ tab for any file in the details view of the Files app
- Type `true` in the search box of the _Sharing_ tab

**Expected result:**
Only the users with an id, name or e-mail address that contains `true` appear in the dropdown

**Actual result:**
Most users appear in the dropdown, even if their id, name or e-mail address does not contain `true`, like the _aaaaa_ user just created.

They are there because there is at least one row in the _oc_preferences_ table in which the _configvalue_ column has the value `true` for that user. For example, with the `avatar` _appid_ and `generated` _configkey_.
