### PR TITLE
group existence check works without attribute (like with users)

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -472,6 +472,7 @@ class Access extends LDAPUtility implements IUserTools {
 	 *
 	 * @param string[] $groupDNs
 	 * @return string[]
+	 * @throws ServerNotAvailableException
 	 */
 	public function groupsMatchFilter($groupDNs) {
 		$validGroupDNs = [];
@@ -492,7 +493,7 @@ class Access extends LDAPUtility implements IUserTools {
 				continue;
 			}
 
-			$result = $this->readAttribute($dn, 'cn', $this->connection->ldapGroupFilter);
+			$result = $this->readAttribute($dn, '', $this->connection->ldapGroupFilter);
 			if(is_array($result)) {
 				$this->connection->writeToCache($cacheKey, true);
 				$validGroupDNs[] = $dn;


### PR DESCRIPTION
the hard coded attribute was not necessarily everywhere present. Common among the big players, but we had a case where the group definition did not carry it. As with groups, the pure existence check, that is happening (along the with the group filter to apply restrictions), succeeds with an empty parameter.

One liner essentially.

@nextcloud/ldap 