### PR TITLE
Set "share with" field to the ID of the circle

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -207,8 +207,16 @@ class ShareAPIController extends OCSController {
 			$result['share_with_displayname'] = $this->getDisplayNameFromAddressBook($share->getSharedWith(), 'EMAIL');
 			$result['token'] = $share->getToken();
 		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_CIRCLE) {
-			$result['share_with_displayname'] = $share->getSharedWith();
-			$result['share_with'] = explode(' ', $share->getSharedWith(), 2)[0];
+			// getSharedWith() returns either "name (type, owner)" or
+			// "name (type, owner) [id]", depending on the Circles app version.
+			$hasCircleId = (substr($share->getSharedWith(), -1) === ']');
+
+			$displayNameLength = ($hasCircleId? strrpos($share->getSharedWith(), ' '): strlen($share->getSharedWith()));
+			$result['share_with_displayname'] = substr($share->getSharedWith(), 0, $displayNameLength);
+
+			$shareWithStart = ($hasCircleId? strrpos($share->getSharedWith(), '[') + 1: 0);
+			$shareWithLength = ($hasCircleId? -1: strpos($share->getSharedWith(), ' '));
+			$result['share_with'] = substr($share->getSharedWith(), $shareWithStart, $shareWithLength);
 		}
 
 

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -241,7 +241,7 @@
 				shareWithTitle: shareWithTitle,
 				shareType: shareType,
 				shareId: this.model.get('shares')[shareIndex].id,
-				modSeed: shareType !== OC.Share.SHARE_TYPE_USER,
+				modSeed: shareType !== OC.Share.SHARE_TYPE_USER && shareType !== OC.Share.SHARE_TYPE_CIRCLE,
 				isRemoteShare: shareType === OC.Share.SHARE_TYPE_REMOTE,
 				isMailShare: shareType === OC.Share.SHARE_TYPE_EMAIL,
 				isCircleShare: shareType === OC.Share.SHARE_TYPE_CIRCLE,

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -338,7 +338,7 @@
 			}
 			var insert = $("<div class='share-autocomplete-item'/>");
 			var avatar = $("<div class='avatardiv'></div>").appendTo(insert);
-			if (item.value.shareType === OC.Share.SHARE_TYPE_USER) {
+			if (item.value.shareType === OC.Share.SHARE_TYPE_USER || item.value.shareType === OC.Share.SHARE_TYPE_CIRCLE) {
 				avatar.avatar(item.value.shareWith, 32, undefined, undefined, undefined, item.label);
 			} else {
 				avatar.imageplaceholder(text, undefined, 32);


### PR DESCRIPTION
Server part of nextcloud/circles#182

When a share is shared with a circle the `share_with` field returned by the API endpoint was always set to the name of the circle. However, the name is not enough to identify a circle. The Circles app now provides the ID of the circle in the _shared with_ field of a Share, so this pull request modifies the API endpoint to set the `share_with` field to the ID of the circle when provided by the Circles app.

**How to test**
- Rebase the commit from this pull request on _stable13_ (as Circles app is not compatible yet with current master)
- Install Circles app (at least in commit nextcloud/circles@34327ea1f52d472eb227352f6e3c85e17440bcd9)
- Create a new circle named _Test_
- Open the _Sharing_ tab in the details view of any file in the Files app
- Share the file with the _Test_ circle
- Once shared*, type `Test` in the search box of the Sharing tab

*If it fails with a message like _cURL error 7: Failed to connect to 127.0.0.1 port 8000: Connection refused_ just refresh the page. [It is a problem in the Circles app](https://github.com/nextcloud/circles/issues/183) unrelated to these changes.

**Expected result**
The _Test_ circle is not suggested.

**Actual result**
The _Test_ circle is suggested, even if the file is already shared with that circle. Trying to share with it again fails (as it should).
