### PR TITLE
Allow empty emails provisioning api

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -451,7 +451,7 @@ class UsersController extends OCSController {
 				$this->config->setUserValue($targetUser->getUID(), 'core', 'lang', $value);
 				break;
 			case AccountManager::PROPERTY_EMAIL:
-				if(filter_var($value, FILTER_VALIDATE_EMAIL)) {
+				if(filter_var($value, FILTER_VALIDATE_EMAIL) || $value === '') {
 					$targetUser->setEMailAddress($value);
 				} else {
 					throw new OCSException('', 102);


### PR DESCRIPTION
Handled by the server but not implemented in the api:
https://github.com/nextcloud/server/blob/master/lib/private/User/User.php#L162-L172

Required by #8824 