### PR TITLE
Store setUserValue as string in cache

### DIFF
--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -233,7 +233,7 @@ class AllConfig implements \OCP\IConfig {
 					->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter($key)));
 				$qb->execute();
 
-				$this->userCache[$userId][$appName][$key] = $value;
+				$this->userCache[$userId][$appName][$key] = (string)$value;
 				return;
 			}
 		}
@@ -258,7 +258,7 @@ class AllConfig implements \OCP\IConfig {
 			if (!isset($this->userCache[$userId][$appName])) {
 				$this->userCache[$userId][$appName] = array();
 			}
-			$this->userCache[$userId][$appName][$key] = $value;
+			$this->userCache[$userId][$appName][$key] = (string)$value;
 		}
 	}
 


### PR DESCRIPTION
We cache the values we set in the setUserValue function.
However since the values are strings in the database we check if a value
is equal with string comparison

Now if the function was called with a $value of int or float. It would
be stored in the DB (and thus converted to string) and in the cache (not
converted thus as int/float).

Now if another call comes in that sets it to the same value (I'm looking
at you LDAP!). The check would fail since we would be comparing
int/float to string which fails by definition.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>