### PR TITLE
Make active navigation indicator more obvious

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -152,7 +152,7 @@ kbd {
 				&,
 				> a {
 					opacity: 1;
-					box-shadow: inset 2px 0 $color-primary;
+					box-shadow: inset 4px 0 $color-primary;
 				}
 			}
 
@@ -177,7 +177,6 @@ kbd {
 			/* Second level nesting for lists */
 			> ul {
 				flex: 0 1 auto;
-				padding-left: 44px;
 				width: 100%;
 				transition: max-height 2000ms ease-in-out,
 							opacity 250ms ease-in-out;
@@ -187,6 +186,7 @@ kbd {
 				> li {
 					display: inline-flex;
 					flex-wrap: wrap;
+					padding-left: 44px;
 					&:focus,
 					&:hover,
 					&.active,
@@ -197,9 +197,20 @@ kbd {
 						}
 					}
 
+					&.active {
+						box-shadow: inset 4px 0 $color-primary;
+					}
+
 					/* align loader */
 					&.icon-loading-small:after {
 						left: 22px; /* 44px / 2 */
+					}
+
+					> .app-navigation-entry-deleted,
+					> .app-navigation-entry-edit {
+						/* margin to keep active indicator visible */
+						margin-left: 4px;
+						padding-left: 84px;
 					}
 				}
 			}

--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -206,11 +206,18 @@ kbd {
 						left: 22px; /* 44px / 2 */
 					}
 
-					> .app-navigation-entry-deleted,
-					> .app-navigation-entry-edit {
+					> .app-navigation-entry-deleted {
 						/* margin to keep active indicator visible */
 						margin-left: 4px;
 						padding-left: 84px;
+					}
+
+					> .app-navigation-entry-edit {
+						/* margin to keep active indicator visible */
+						margin-left: 4px;
+						/* align the input correctly with the link text
+						44px+44px-4px-6px padding for the input */
+						padding-left: 78px !important;
 					}
 				}
 			}


### PR DESCRIPTION
Increase the width of the active navigation item to 5px and also use it for entries in the second hierarchy level.

Fixes https://github.com/nextcloud/server/issues/4627

![bildschirmfoto vom 2018-03-19 17-04-03](https://user-images.githubusercontent.com/3404133/37607295-f39669c8-2b97-11e8-977f-48de3a18c6e0.png)

@nextcloud/designers 