### PR TITLE
Fix proper permissions for multiple file access

### DIFF
--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -682,7 +682,7 @@ class FolderTest extends NodeTest {
 
 		$fileInfo = new CacheEntry(['path' => 'foo/qwerty', 'mimetype' => 'text/plain'], null);
 
-		$storage->expects($this->once())
+		$storage->expects($this->exactly(2))
 			->method('getCache')
 			->will($this->returnValue($cache));
 


### PR DESCRIPTION
Fixes #8890

In case you have access to a file via multiple ways, for example:
1. the file is shared with you with permission read only
2. the folder containing the file is shared with your read/write

Requesting the getById function on the userFolder would give back two
entries but both with the same permissions. Depending on the node you
picked this is not right.

@icewind1991 please have a look. I realize this is a little less optimized. But it is now correct I think.