### PR TITLE
Make the new autocomplete endpoint OCS

### DIFF
--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -240,19 +240,22 @@
 				if(!_.isUndefined(this._autoCompleteRequestCall)) {
 					this._autoCompleteRequestCall.abort();
 				}
-				this._autoCompleteRequestCall = $.get(
-					OC.generateUrl('/autocomplete/get'),
-					{
+				this._autoCompleteRequestCall = $.ajax({
+					url: OC.linkToOCS('core', 2) + 'autocomplete/get',
+					data: {
 						search: query,
 						itemType: 'files',
 						itemId: s.model.get('id'),
 						sorter: 'commenters|share-recipients',
 						limit: OC.appConfig.comments.maxAutoCompleteResults
 					},
-					function (data) {
-						callback(data);
+					beforeSend: function (request) {
+						request.setRequestHeader('Accept', 'application/json');
+					},
+					success: function (result) {
+						callback(result.ocs.data);
 					}
-				);
+				});
 			}, 400);
 		},
 

--- a/core/Controller/AutoCompleteController.php
+++ b/core/Controller/AutoCompleteController.php
@@ -23,7 +23,7 @@
 
 namespace OC\Core\Controller;
 
-use OCP\AppFramework\Controller;
+use OCP\AppFramework\OCSController as Controller;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\Collaboration\AutoComplete\IManager;
 use OCP\Collaboration\Collaborators\ISearch;

--- a/core/routes.php
+++ b/core/routes.php
@@ -64,7 +64,6 @@ $application->registerRoutes($this, [
 		['name' => 'Js#getJs', 'url' => '/js/{appName}/{fileName}', 'verb' => 'GET'],
 		['name' => 'contactsMenu#index', 'url' => '/contactsmenu/contacts', 'verb' => 'POST'],
 		['name' => 'contactsMenu#findOne', 'url' => '/contactsmenu/findOne', 'verb' => 'POST'],
-		['name' => 'AutoComplete#get', 'url' => 'autocomplete/get', 'verb' => 'GET'],
 		['name' => 'WalledGarden#get', 'url' => '/204', 'verb' => 'GET'],
 		['name' => 'Search#search', 'url' => '/core/search', 'verb' => 'GET'],
 	],
@@ -75,6 +74,7 @@ $application->registerRoutes($this, [
 		['root' => '/identityproof', 'name' => 'OCS#getIdentityProof', 'url' => '/key/{cloudId}', 'verb' => 'GET'],
 		['root' => '/core', 'name' => 'Navigation#getAppsNavigation', 'url' => '/navigation/apps', 'verb' => 'GET'],
 		['root' => '/core', 'name' => 'Navigation#getSettingsNavigation', 'url' => '/navigation/settings', 'verb' => 'GET'],
+		['root' => '/core', 'name' => 'AutoComplete#get', 'url' => '/autocomplete/get', 'verb' => 'GET'],
 	],
 ]);
 


### PR DESCRIPTION
The new endpoint is much nicer and should be available for apps, so e.g. the android/ios talk app can also autocomplete in the chat in the future....
(The old sharee OCS endpoint does not allow to filter for "participants in a room")