### PR TITLE
Avoid to leak a user ID that is not a string to reach a user backend

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -142,6 +142,10 @@ class LoginController extends Controller {
 	 * @return TemplateResponse|RedirectResponse
 	 */
 	public function showLoginForm($user, $redirect_url) {
+		if (!is_string($user)) {
+			throw new \InvalidArgumentException('User needs to be string');
+		}
+
 		if ($this->userSession->isLoggedIn()) {
 			return new RedirectResponse(OC_Util::getDefaultPageUrl());
 		}

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -141,10 +141,7 @@ class LoginController extends Controller {
 	 *
 	 * @return TemplateResponse|RedirectResponse
 	 */
-	public function showLoginForm($user, $redirect_url) {
-		if (!is_string($user)) {
-			throw new \InvalidArgumentException('User needs to be string');
-		}
+	public function showLoginForm(string $user = null, string $redirect_url = null): Http\Response {
 
 		if ($this->userSession->isLoggedIn()) {
 			return new RedirectResponse(OC_Util::getDefaultPageUrl());


### PR DESCRIPTION
Found in the logs:

![ohne titel](https://user-images.githubusercontent.com/245432/37700531-323d6c26-2cec-11e8-8551-40dba9cec094.png)


When calling `http://localhost:8000/index.php/login?user[]=1<img%20src=x%20onerror=alert(1)>` then the user backend is queried with an array instead of a string and causing weird things.

Before:

```
{"reqId":"AKYU62KVi6LyzLvjvkPN","level":3,"time":"2018-03-21T08:37:54+00:00","remoteAddr":"172.20.0.1","user":"--","app":"PHP","method":"GET","url":"\/index.php\/login?user[]=1%3Cimg%20src=x%20onerror=alert(1)%3E","message":"Array to string conversion at \/var\/www\/html\/lib\/private\/legacy\/template\/functions.php#39","userAgent":"Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit\/604.5.6 (KHTML, like Gecko) Version\/11.0.3 Safari\/604.5.6","version":"14.0.0.1"}
```


After:

```
{
    "reqId": "8rI9pwMsOP80OeBlitpx",
    "level": 3,
    "time": "2018-03-21T08:31:39+00:00",
    "remoteAddr": "172.20.0.1",
    "user": "--",
    "app": "index",
    "method": "GET",
    "url": "/index.php/login?user[]=1%3Cimg%20src=x%20onerror=alert(1)%3E",
    "message": {
        "Exception": "InvalidArgumentException",
        "Message": "User needs to be string",
        "Code": 0,
        "Trace": "
            #0 lib/private/AppFramework/Http/Dispatcher.php(166): OC\Core\Controller\LoginController->showLoginForm(Array, NULL, NULL)
            #1 lib/private/AppFramework/Http/Dispatcher.php(99): OC\AppFramework\Http\Dispatcher->executeController(Object(OC\Core\Controller\LoginController), 'showLoginForm')
            #2 lib/private/AppFramework/App.php(118): OC\AppFramework\Http\Dispatcher->dispatch(Object(OC\Core\Controller\LoginController), 'showLoginForm')
            #3 lib/private/AppFramework/Routing/RouteActionHandler.php(47): OC\AppFramework\App::main('OC\\Core\\Control...', 'showLoginForm', Object(OC\AppFramework\DependencyInjection\DIContainer), Array)
            #4 [internal function]: OC\AppFramework\Routing\RouteActionHandler->__invoke(Array)
            #5 lib/private/Route/Router.php(297): call_user_func(Object(OC\AppFramework\Routing\RouteActionHandler), Array)
            #6 lib/base.php(981): OC\Route\Router->match('/login')
            #7 index.php(37): OC::handleRequest()
            #8 {main}
        ",
        "File": "core/Controller/LoginController.php",
        "Line": 146
    },
    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/604.5.6 (KHTML, like Gecko) Version/11.0.3 Safari/604.5.6",
    "version": "14.0.0.1"
}
```

Alternative would be to do scalar type hinting and then the error would be something like this:

```
{
    "reqId": "Oa03JU68a8Ubn7wfLYZe",
    "level": 3,
    "time": "2018-03-21T08:35:24+00:00",
    "remoteAddr": "172.20.0.1",
    "user": "--",
    "app": "index",
    "method": "GET",
    "url": "/index.php/login?user[]=1%3Cimg%20src=x%20onerror=alert(1)%3E",
    "message": {
        "Exception": "TypeError",
        "Message": "Argument 1 passed to OC\Core\Controller\LoginController::showLoginForm() must be of the type string, array given, called in lib/private/AppFramework/Http/Dispatcher.php on line 166",
        "Code": 0,
        "Trace": "
            #0 lib/private/AppFramework/Http/Dispatcher.php(166): OC\Core\Controller\LoginController->showLoginForm(Array, NULL, NULL)
            #1 lib/private/AppFramework/Http/Dispatcher.php(99): OC\AppFramework\Http\Dispatcher->executeController(Object(OC\Core\Controller\LoginController), 'showLoginForm')
            #2 lib/private/AppFramework/App.php(118): OC\AppFramework\Http\Dispatcher->dispatch(Object(OC\Core\Controller\LoginController), 'showLoginForm')
            #3 lib/private/AppFramework/Routing/RouteActionHandler.php(47): OC\AppFramework\App::main('OC\\Core\\Control...', 'showLoginForm', Object(OC\AppFramework\DependencyInjection\DIContainer), Array)
            #4 [internal function]: OC\AppFramework\Routing\RouteActionHandler->__invoke(Array)
            #5 lib/private/Route/Router.php(297): call_user_func(Object(OC\AppFramework\Routing\RouteActionHandler), Array)
            #6 lib/base.php(981): OC\Route\Router->match('/login')
            #7 index.php(37): OC::handleRequest()
            #8 {main}",
        "File": "core/Controller/LoginController.php",
        "Line": 144
    },
    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/604.5.6 (KHTML, like Gecko) Version/11.0.3 Safari/604.5.6",
    "version": "14.0.0.1"
}
```

Or should we cast `string` as well in the `HTTP\Dispatcher`: https://github.com/nextcloud/server/blob/ca9f364fd4746093a38cdcaf2456f5f86aebb89f/lib/private/AppFramework/Http/Dispatcher.php#L138 ?

The problem I see with the current handling: we would spam the log with useless exceptions (the cast in `Dispatcher` would make this go and simply cast it to `Array` 🙈 