### PR TITLE
Log exceptions as nested array instead of encoded json

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
@@ -24,6 +24,7 @@
 
 namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
+use OC\SystemConfig;
 use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
 use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin as PluginToTest;
 use OC\Log;
@@ -37,13 +38,9 @@ class TestLogger extends Log {
 	public $message;
 	public $level;
 
-	public function __construct($logger = null) {
-		//disable original constructor
-	}
-
-	public function log(int $level, string $message, array $context = array()) {
+	public function writeLog(string $app, $entry, int $level) {
 		$this->level = $level;
-		$this->message = $message;
+		$this->message = $entry;
 	}
 }
 
@@ -59,8 +56,20 @@ class ExceptionLoggerPluginTest extends TestCase {
 	private $logger;
 
 	private function init() {
+		$config = $this->createMock(SystemConfig::class);
+		$config->expects($this->any())
+			->method('getValue')
+			->willReturnCallback(function($key, $default) {
+				switch ($key) {
+					case 'loglevel':
+						return 0;
+					default:
+						return $default;
+				}
+			});
+
 		$this->server = new Server();
-		$this->logger = new TestLogger();
+		$this->logger = new TestLogger(Log\File::class, $config);
 		$this->plugin = new PluginToTest('unit-test', $this->logger);
 		$this->plugin->initialize($this->server);
 	}
@@ -73,7 +82,8 @@ class ExceptionLoggerPluginTest extends TestCase {
 		$this->plugin->logException($exception);
 
 		$this->assertEquals($expectedLogLevel, $this->logger->level);
-		$this->assertStringStartsWith('Exception: {"Exception":' . json_encode(get_class($exception)) . ',"Message":"' . $expectedMessage . '",', $this->logger->message);
+		$this->assertEquals(get_class($exception), $this->logger->message['Exception']);
+		$this->assertEquals($expectedMessage, $this->logger->message['Message']);
 	}
 
 	public function providesExceptions() {

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -265,7 +265,7 @@ class Log implements ILogger {
 		$message = strtr($message, $replace);
 
 		if ($level >= $minLevel) {
-			call_user_func([$this->logger, 'write'], $app, $message, $level);
+			$this->writeLog($app, $message, $level);
 		}
 	}
 
@@ -383,18 +383,25 @@ class Log implements ILogger {
 		array_walk($context, [$this->normalizer, 'format']);
 
 		if ($level >= $minLevel) {
-			if ($this->logger === File::class) {
-				call_user_func([$this->logger, 'write'], $app, $data, $level);
-			} else {
-				$entry = json_encode($data, JSON_PARTIAL_OUTPUT_ON_ERROR);
-				call_user_func([$this->logger, 'write'], $app, $entry, $level);
+			if ($this->logger !== File::class) {
+				$data = json_encode($data, JSON_PARTIAL_OUTPUT_ON_ERROR);
 			}
+			$this->writeLog($app, $data, $level);
 		}
 
 		$context['level'] = $level;
 		if (!is_null($this->crashReporters)) {
 			$this->crashReporters->delegateReport($exception, $context);
 		}
+	}
+
+	/**
+	 * @param string $app
+	 * @param string|array $entry
+	 * @param int $level
+	 */
+	protected function writeLog(string $app, $entry, int $level) {
+		call_user_func([$this->logger, 'write'], $app, $entry, $level);
 	}
 
 	/**

--- a/lib/private/Log/File.php
+++ b/lib/private/Log/File.php
@@ -72,7 +72,7 @@ class File {
 	/**
 	 * write a message in the log
 	 * @param string $app
-	 * @param string $message
+	 * @param string|array $message
 	 * @param int $level
 	 */
 	public static function write($app, $message, $level) {

--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -96,9 +96,12 @@ class LoggerTest extends TestCase {
 
 		$logLines = $this->getLogs();
 		foreach($logLines as $logLine) {
+			if (is_array($logLine)) {
+				$logLine = json_encode($logLine);
+			}
 			$this->assertNotContains($user, $logLine);
 			$this->assertNotContains($password, $logLine);
-			$this->assertContains('login(*** sensitive parameters replaced ***)', $logLine);
+			$this->assertContains('*** sensitive parameters replaced ***', $logLine);
 		}
 	}
 
@@ -115,9 +118,12 @@ class LoggerTest extends TestCase {
 
 		$logLines = $this->getLogs();
 		foreach($logLines as $logLine) {
+			if (is_array($logLine)) {
+				$logLine = json_encode($logLine);
+			}
 			$this->assertNotContains($user, $logLine);
 			$this->assertNotContains($password, $logLine);
-			$this->assertContains('checkPassword(*** sensitive parameters replaced ***)', $logLine);
+			$this->assertContains('*** sensitive parameters replaced ***', $logLine);
 		}
 	}
 
@@ -134,9 +140,12 @@ class LoggerTest extends TestCase {
 
 		$logLines = $this->getLogs();
 		foreach($logLines as $logLine) {
+			if (is_array($logLine)) {
+				$logLine = json_encode($logLine);
+			}
 			$this->assertNotContains($user, $logLine);
 			$this->assertNotContains($password, $logLine);
-			$this->assertContains('validateUserPass(*** sensitive parameters replaced ***)', $logLine);
+			$this->assertContains('*** sensitive parameters replaced ***', $logLine);
 		}
 	}
 
@@ -153,9 +162,12 @@ class LoggerTest extends TestCase {
 
 		$logLines = $this->getLogs();
 		foreach($logLines as $logLine) {
+			if (is_array($logLine)) {
+				$logLine = json_encode($logLine);
+			}
 			$this->assertNotContains($user, $logLine);
 			$this->assertNotContains($password, $logLine);
-			$this->assertContains('tryLogin(*** sensitive parameters replaced ***)', $logLine);
+			$this->assertContains('*** sensitive parameters replaced ***', $logLine);
 		}
 	}
 
@@ -177,13 +189,16 @@ class LoggerTest extends TestCase {
 
 		$logLines = $this->getLogs();
 		foreach($logLines as $logLine) {
+			if (is_array($logLine)) {
+				$logLine = json_encode($logLine);
+			}
 			$log = explode('\n', $logLine);
 			unset($log[1]); // Remove `testDetectclosure(` because we are not testing this here, but the closure on stack trace 0
 			$logLine = implode('\n', $log);
 
 			$this->assertNotContains($user, $logLine);
 			$this->assertNotContains($password, $logLine);
-			$this->assertContains('{closure}(*** sensitive parameters replaced ***)', $logLine);
+			$this->assertContains('*** sensitive parameters replaced ***', $logLine);
 		}
 	}
 


### PR DESCRIPTION
Revived version of #7826

Logreader support: https://github.com/nextcloud/logreader/commit/0f4be889b9603597b7254c7f202a2ce449a7c9fa

I would also like to extend the amount of data we log in a follow up pr (mainly "preview" exception)