### PR TITLE
Make displayname selectable

### DIFF
--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -113,7 +113,7 @@ class FileSearchBackend implements ISearchBackend {
 		//todo dynamically load all propfind properties that are supported
 		return [
 			// queryable properties
-			new SearchPropertyDefinition('{DAV:}displayname', true, false, true),
+			new SearchPropertyDefinition('{DAV:}displayname', true, true, true),
 			new SearchPropertyDefinition('{DAV:}getcontenttype', true, true, true),
 			new SearchPropertyDefinition('{DAV:}getlastmodified', true, true, true, SearchPropertyDefinition::DATATYPE_DATETIME),
 			new SearchPropertyDefinition(FilesPlugin::SIZE_PROPERTYNAME, true, true, true, SearchPropertyDefinition::DATATYPE_NONNEGATIVE_INTEGER),


### PR DESCRIPTION
It is dav. so if it is not properly set we just return a 404 anyway.

Else the current android client does :boom: with the current server.