### PR TITLE
Clear any theming prefixed cache on cache buster increase

### DIFF
--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -320,7 +320,7 @@ class ThemingDefaults extends \OC_Defaults {
 	private function increaseCacheBuster() {
 		$cacheBusterKey = $this->config->getAppValue('theming', 'cachebuster', '0');
 		$this->config->setAppValue('theming', 'cachebuster', (int)$cacheBusterKey+1);
-		$this->cacheFactory->createDistributed('theming-')->clear('getScssVariables');
+		$this->cacheFactory->createDistributed('theming-')->clear();
 	}
 
 	/**

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -276,7 +276,7 @@ class ThemingDefaultsTest extends TestCase {
 		$this->cache
 			->expects($this->once())
 			->method('clear')
-			->with('getScssVariables');
+			->with('');
 		$this->template->set('MySetting', 'MyValue');
 	}
 


### PR DESCRIPTION
Regression from #8716, where the baseUrl was added to the theming cache prefix. When clearing on cache buster increase, the cache was not cleared properly, because it was missing the baseUrl. 

This PR will make sure we clear cached values for any baseUrl prefix.

Fixes #8888 

Also requires to be backported to 13.

