### PR TITLE
Show UI when using a custom theme

### DIFF
--- a/apps/theming/lib/Settings/Admin.php
+++ b/apps/theming/lib/Settings/Admin.php
@@ -67,7 +67,7 @@ class Admin implements ISettings {
 		$theme = $this->config->getSystemValue('theme', '');
 		if ($theme !== '') {
 			$themable = false;
-			$errorMessage = $this->l->t('You are already using a custom theme');
+			$errorMessage = $this->l->t('You are already using a custom theme. Theming app settings might be overwritten by that.');
 		}
 
 		$parameters = [

--- a/apps/theming/templates/settings-admin.php
+++ b/apps/theming/templates/settings-admin.php
@@ -37,7 +37,7 @@ style('theming', 'settings-admin');
 	<p>
 		<?php p($_['errorMessage']) ?>
 	</p>
-	<?php } else { ?>
+	<?php } ?>
 	<div>
 		<label>
 			<span><?php p($l->t('Name')) ?></span>
@@ -99,5 +99,4 @@ style('theming', 'settings-admin');
 			</p>
 		<?php } ?>
 	</div>
-	<?php } ?>
 </div>

--- a/apps/theming/tests/Settings/AdminTest.php
+++ b/apps/theming/tests/Settings/AdminTest.php
@@ -118,8 +118,8 @@ class AdminTest extends TestCase {
 		$this->l10n
 			->expects($this->once())
 			->method('t')
-			->with('You are already using a custom theme')
-			->willReturn('You are already using a custom theme');
+			->with('You are already using a custom theme. Theming app settings might be overwritten by that.')
+			->willReturn('You are already using a custom theme. Theming app settings might be overwritten by that.');
 		$this->themingDefaults
 			->expects($this->once())
 			->method('getEntity')
@@ -143,7 +143,7 @@ class AdminTest extends TestCase {
 			->willReturn('/my/route');
 		$params = [
 			'themable' => false,
-			'errorMessage' => 'You are already using a custom theme',
+			'errorMessage' => 'You are already using a custom theme. Theming app settings might be overwritten by that.',
 			'name' => 'MyEntity',
 			'url' => 'https://example.com',
 			'slogan' => 'MySlogan',


### PR DESCRIPTION
Do not hide the theming app UI when using a custom theme besides it, but warn the users about some settings being overwritten by that.