### PR TITLE
Deprecate theme sync clients

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -782,7 +782,8 @@ $CONFIG = array(
  * Defaults to
  * * Desktop client: ``https://nextcloud.com/install/#install-clients``
  * * Android client: ``https://play.google.com/store/apps/details?id=com.nextcloud.client``
- * * iOS client    : ``https://itunes.apple.com/us/app/nextcloud/id1125420102?mt=8``
+ * * iOS client: ``https://itunes.apple.com/us/app/nextcloud/id1125420102?mt=8``
+ *  *iOS client app id: ``1125420102``
  */
 'customclient_desktop' =>
 	'https://nextcloud.com/install/#install-clients',
@@ -790,7 +791,8 @@ $CONFIG = array(
 	'https://play.google.com/store/apps/details?id=com.nextcloud.client',
 'customclient_ios' =>
 	'https://itunes.apple.com/us/app/nextcloud/id1125420102?mt=8',
-
+'customclient_ios_appid' =>
+		'1125420102',
 /**
  * Apps
  *

--- a/lib/private/legacy/defaults.php
+++ b/lib/private/legacy/defaults.php
@@ -54,15 +54,16 @@ class OC_Defaults {
 
 	public function __construct() {
 		$this->l = \OC::$server->getL10N('lib');
+		$config = \OC::$server->getConfig();
 
 		$this->defaultEntity = 'Nextcloud'; /* e.g. company name, used for footers and copyright notices */
 		$this->defaultName = 'Nextcloud'; /* short name, used when referring to the software */
 		$this->defaultTitle = 'Nextcloud'; /* can be a longer name, for titles */
 		$this->defaultBaseUrl = 'https://nextcloud.com';
-		$this->defaultSyncClientUrl = 'https://nextcloud.com/install/#install-clients';
-		$this->defaultiOSClientUrl = 'https://geo.itunes.apple.com/us/app/nextcloud/id1125420102?mt=8';
-		$this->defaultiTunesAppId = '1125420102';
-		$this->defaultAndroidClientUrl = 'https://play.google.com/store/apps/details?id=com.nextcloud.client';
+		$this->defaultSyncClientUrl = $config->getSystemValue('customclient_desktop', 'https://nextcloud.com/install/#install-clients');
+		$this->defaultiOSClientUrl = $config->getSystemValue('customclient_ios', 'https://geo.itunes.apple.com/us/app/nextcloud/id1125420102?mt=8');
+		$this->defaultiTunesAppId = $config->getSystemValue('customclient_ios_appid', '1125420102');
+		$this->defaultAndroidClientUrl = $config->getSystemValue('customclient_android', 'https://play.google.com/store/apps/details?id=com.nextcloud.client');
 		$this->defaultDocBaseUrl = 'https://docs.nextcloud.com';
 		$this->defaultDocVersion = '14'; // used to generate doc links
 		$this->defaultSlogan = $this->l->t('a safe home for all your data');

--- a/themes/example/defaults.php
+++ b/themes/example/defaults.php
@@ -29,38 +29,6 @@ class OC_Theme {
 	}
 
 	/**
-	 * Returns the URL where the sync clients are listed
-	 * @return string URL
-	 */
-	public function getSyncClientUrl() {
-		return 'https://nextcloud.com/install/#install-clients';
-	}
-
-	/**
-	 * Returns the URL to the App Store for the iOS Client
-	 * @return string URL
-	 */
-	public function getiOSClientUrl() {
-		return 'https://geo.itunes.apple.com/us/app/nextcloud/id1125420102?mt=8';
-	}
-
-	/**
-	 * Returns the AppId for the App Store for the iOS Client
-	 * @return string AppId
-	 */
-	public function getiTunesAppId() {
-		return '1125420102';
-	}
-
-	/**
-	 * Returns the URL to Google Play for the Android Client
-	 * @return string URL
-	 */
-	public function getAndroidClientUrl() {
-		return 'https://play.google.com/store/apps/details?id=com.nextcloud.client';
-	}
-
-	/**
 	 * Returns the documentation URL
 	 * @return string URL
 	 */


### PR DESCRIPTION
Right now there were two options to configure links to custom clients, using a config.php parameter and in a custom theme. This PR will use the customclient_* parameters of config.php by default if set and deprecate the ability to overwriting those in custom themes. 