### PR TITLE
Fix webdav support for OneNote clients

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -119,7 +119,7 @@ class ServerFactory {
 		// we do not provide locking we emulate it using a fake locking plugin.
 		if($this->request->isUserAgent([
 				'/WebDAVFS/',
-				'/Microsoft Office OneNote 2013/',
+				'/OneNote/',
 				'/Microsoft-WebDAV-MiniRedir/',
 		])) {
 			$server->addPlugin(new \OCA\DAV\Connector\Sabre\FakeLockerPlugin());

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -179,7 +179,7 @@ class Server {
 		// we do not provide locking we emulate it using a fake locking plugin.
 		if($request->isUserAgent([
 			'/WebDAVFS/',
-			'/Microsoft Office OneNote 2013/',
+			'/OneNote/',
 			'/^Microsoft-WebDAV/',// Microsoft-WebDAV-MiniRedir/6.1.7601
 		])) {
 			$this->server->addPlugin(new FakeLockerPlugin());


### PR DESCRIPTION
Microsoft OneNote WebDAV Client requires some special handling on the server side that is enabled by User Agent detection.  This PR updates the User Agent detection string to be compatible with all versions of OneNote.