### PR TITLE
Do not fail hard if no appinfo is returned during update

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -358,7 +358,7 @@ class AppManager implements IAppManager {
 	 *
 	 * @param bool $path
 	 * @param null $lang
-	 * @return array app info
+	 * @return array|null app info
 	 */
 	public function getAppInfo(string $appId, bool $path = false, $lang = null) {
 		if ($path) {
@@ -411,7 +411,9 @@ class AppManager implements IAppManager {
 		$incompatibleApps = array();
 		foreach ($apps as $appId) {
 			$info = $this->getAppInfo($appId);
-			if (!\OC_App::isAppCompatible($version, $info)) {
+			if ($info === null) {
+				$incompatibleApps[] = ['id' => $appId];
+			} else if (!\OC_App::isAppCompatible($version, $info)) {
 				$incompatibleApps[] = $info;
 			}
 		}

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -391,7 +391,7 @@ class Updater extends BasicEmitter {
 		foreach ($apps as $app) {
 			// check if the app is compatible with this version of ownCloud
 			$info = OC_App::getAppInfo($app);
-			if(!OC_App::isAppCompatible($version, $info)) {
+			if($info === null || !OC_App::isAppCompatible($version, $info)) {
 				if ($appManager->isShipped($app)) {
 					throw new \UnexpectedValueException('The files of the app "' . $app . '" were not correctly replaced before running the update');
 				}


### PR DESCRIPTION
Fix for https://github.com/nextcloud/server/issues/8964

Before that the updater was failing hard when the appinfo of an enabled app could not been fetched. Now we just disable that app and continue.

Steps to reproduce:
1. Enable some app
2. Delete the appinfo.xml file from the app
3. Increase server version to trigger update
4. Try to update
