### PR TITLE
Move on with the next user if we found the user on one user back-end

### DIFF
--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -478,6 +478,7 @@ class Manager extends PublicEmitter implements IUserManager {
 						if ($return === false) {
 							return;
 						}
+						break;
 					}
 				}
 			}
@@ -488,7 +489,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * Getting all userIds that have a listLogin value requires checking the
 	 * value in php because on oracle you cannot use a clob in a where clause,
 	 * preventing us from doing a not null or length(value) > 0 check.
-	 * 
+	 *
 	 * @param int $limit
 	 * @param int $offset
 	 * @return string[] with user ids


### PR DESCRIPTION
If a user back-end is used which returns always "true" for `userExists($uid)` like the user_saml back-end we will call each callback twice for every user which also exists on any other back-end (database, ldap,...). This becomes especially critical since the last update of the saml app where we started to allow multiple back-ends in parallel.

This changes make sure that we move on to the next user if we found the user on one user back-end and executed the callback successfully.

Steps to test:

Enable the user_saml app. You don't even have to configure it and run a command which uses this function, e.g. `sudo -u www-data ./occ trashbin:expire`. If you have N local users, you will notice that the expire operation will be triggered 2*N times. With this patch it will be only executed N times.