### PR TITLE
When formatting a share node an Empty target is invalid

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -154,7 +154,7 @@ class ShareAPIController extends OCSController {
 			if (empty($nodes)) {
 				// fallback to guessing the path
 				$node = $userFolder->get($share->getTarget());
-				if ($node === null) {
+				if ($node === null || $share->getTarget() === '') {
 					throw new NotFoundException();
 				}
 			} else {


### PR DESCRIPTION
Fixes #9028

For federated shares the share table holds no target information (since
it is on the other server). So when a node is actually invalid and not
found we should not display it anymore in the shared with sections etc
and thus throw the proper exceptions.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>