### PR TITLE
[stable13] When formatting a share node an Empty target is invalid

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -147,7 +147,7 @@ class ShareAPIController extends OCSController {
 			if (empty($nodes)) {
 				// fallback to guessing the path
 				$node = $userFolder->get($share->getTarget());
-				if ($node === null) {
+				if ($node === null || $share->getTarget() === '') {
 					throw new NotFoundException();
 				}
 			} else {


### PR DESCRIPTION
Backport of #9070 