### PR TITLE
Fix progress bar hidden before the upload ends

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -958,7 +958,6 @@ OC.Uploader.prototype = _.extend({
 						status = upload.getResponseStatus();
 					}
 					self.log('fail', e, upload);
-					self._hideProgressBar();
 
 					if (data.textStatus === 'abort') {
 						self.showUploadCancelMessage();
@@ -1109,14 +1108,11 @@ OC.Uploader.prototype = _.extend({
 					self.log('progress handle fileuploadstop', e, data);
 
 					self.clear();
+					self._hideProgressBar();
 					self.trigger('stop', e, data);
 				});
 				fileupload.on('fileuploadfail', function(e, data) {
 					self.log('progress handle fileuploadfail', e, data);
-					//if user pressed cancel hide upload progress bar and cancel button
-					if (data.errorThrown === 'abort') {
-						self._hideProgressBar();
-					}
 					self.trigger('fail', e, data);
 				});
 				var disableDropState = function() {
@@ -1175,11 +1171,9 @@ OC.Uploader.prototype = _.extend({
 				fileupload.on('fileuploaddone', function(e, data) {
 					var upload = self.getUpload(data);
 					upload.done().then(function() {
-						self._hideProgressBar();
 						self.trigger('done', e, upload);
 					}).fail(function(status, response) {
 						var message = response.message;
-						self._hideProgressBar();
 						if (status === 507) {
 							// not enough space
 							OC.Notification.show(message || t('files', 'Not enough free space'), {type: 'error'});


### PR DESCRIPTION
Follow-up to #7056
Fixes issue mentioned in https://github.com/nextcloud/server/pull/6079#discussion_r139920814 and https://github.com/nextcloud/server/pull/6079#discussion_r139921731
Fixes #8106

[The jQuery File Upload plugin triggers the `stop` event once there are no more files being uploaded](https://github.com/nextcloud/server/blob/937d21ed29f29f424aaed7abb643a210ccb2453b/apps/files/js/jquery.fileupload.js#L933-L937) (even if some of them were added when another upload was already in progress). Therefore, the progress bar should be hidden in the `fileuploadstop` callback.

In some cases the `stop` event is not triggered and thus the progress bar is not hidden once no more files are being uploaded. This is caused by a race condition and it is fixed in #9245; except in buggy cases like that one (that need to be fixed anyway) it is safe to hide the progress bar in the `fileuploadstop` callback.

In any case, note that the callbacks in `fileuploaddone` may be called after the `stop` event was triggered and handled when using chunked uploads. In that case [once all the chunks are uploaded the assembled file is moved to its final destination](https://github.com/nextcloud/server/blob/d4f163b2300b5190366f38b51d4e7a80fde6d235/apps/files/js/file-upload.js#L274), so its promise could be resolved after the `stop` event was triggered. Therefore a different approach would be needed to keep the progress bar visible until the chunked upload is truly finished, but for the time being the current one is good enough.

Before this pull request the progress bar was being hidden when the first upload finished, either successfully or with an error, no matter if there were other files being uploaded too.

The progress bar was being explicitly hidden also when the upload was cancelled. When an upload is cancelled all the single uploads are aborted, which triggers a `fail` event for each of them. However, the `stop` event is always triggered when no more files are being uploaded, so it is triggered too once all the single uploads were aborted. As [all the single uploads are immediately aborted in a loop when the general upload is cancelled](https://github.com/nextcloud/server/blob/d4f163b2300b5190366f38b51d4e7a80fde6d235/apps/files/js/file-upload.js#L570-L572) it makes no difference to hide the progress bar when the first single upload is aborted or when all the single uploads were aborted, so the progress bar is no longer explicitly hidden in the former case.
