### PR TITLE
Allow usage of Windows 10 WebDav Netdrive

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -525,6 +525,7 @@ class OC {
 		$incompatibleUserAgents = [
 			// OS X Finder
 			'/^WebDAVFS/',
+			'/^Microsoft-WebDAV-MiniRedir/',
 		];
 		if($request->isUserAgent($incompatibleUserAgents)) {
 			return;


### PR DESCRIPTION
Fixes #3523

As long as we don't have #8123 lets not leave our Window10 netdrive
users hanging.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>