### PR TITLE
Run federated discoverjob in cron

### DIFF
--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -9,7 +9,7 @@
 Turning the feature off removes shared files and folders on the server for all share recipients, and also on the sync clients and mobile apps. More information is available in the Nextcloud Documentation.
 
 	</description>
-	<version>1.6.0</version>
+	<version>1.6.1</version>
 	<licence>agpl</licence>
 	<author>Michael Gapczynski</author>
 	<author>Bjoern Schiessle</author>
@@ -29,6 +29,7 @@ Turning the feature off removes shared files and folders on the server for all s
 	<background-jobs>
 		<job>OCA\Files_Sharing\DeleteOrphanedSharesJob</job>
 		<job>OCA\Files_Sharing\ExpireSharesJob</job>
+		<job>OCA\Files_Sharing\BackgroundJob\FederatedSharesDiscoverJob</job>
 	</background-jobs>
 
 	<repair-steps>

--- a/apps/files_sharing/composer/composer/autoload_classmap.php
+++ b/apps/files_sharing/composer/composer/autoload_classmap.php
@@ -17,6 +17,7 @@ return array(
     'OCA\\Files_Sharing\\Activity\\Settings\\RemoteShare' => $baseDir . '/../lib/Activity/Settings/RemoteShare.php',
     'OCA\\Files_Sharing\\Activity\\Settings\\Shared' => $baseDir . '/../lib/Activity/Settings/Shared.php',
     'OCA\\Files_Sharing\\AppInfo\\Application' => $baseDir . '/../lib/AppInfo/Application.php',
+    'OCA\\Files_Sharing\\BackgroundJob\\FederatedSharesDiscoverJob' => $baseDir . '/../lib/BackgroundJob/FederatedSharesDiscoverJob.php',
     'OCA\\Files_Sharing\\Cache' => $baseDir . '/../lib/Cache.php',
     'OCA\\Files_Sharing\\Capabilities' => $baseDir . '/../lib/Capabilities.php',
     'OCA\\Files_Sharing\\Collaboration\\ShareRecipientSorter' => $baseDir . '/../lib/Collaboration/ShareRecipientSorter.php',

--- a/apps/files_sharing/composer/composer/autoload_static.php
+++ b/apps/files_sharing/composer/composer/autoload_static.php
@@ -32,6 +32,7 @@ class ComposerStaticInitFiles_Sharing
         'OCA\\Files_Sharing\\Activity\\Settings\\RemoteShare' => __DIR__ . '/..' . '/../lib/Activity/Settings/RemoteShare.php',
         'OCA\\Files_Sharing\\Activity\\Settings\\Shared' => __DIR__ . '/..' . '/../lib/Activity/Settings/Shared.php',
         'OCA\\Files_Sharing\\AppInfo\\Application' => __DIR__ . '/..' . '/../lib/AppInfo/Application.php',
+        'OCA\\Files_Sharing\\BackgroundJob\\FederatedSharesDiscoverJob' => __DIR__ . '/..' . '/../lib/BackgroundJob/FederatedSharesDiscoverJob.php',
         'OCA\\Files_Sharing\\Cache' => __DIR__ . '/..' . '/../lib/Cache.php',
         'OCA\\Files_Sharing\\Capabilities' => __DIR__ . '/..' . '/../lib/Capabilities.php',
         'OCA\\Files_Sharing\\Collaboration\\ShareRecipientSorter' => __DIR__ . '/..' . '/../lib/Collaboration/ShareRecipientSorter.php',

--- a/apps/files_sharing/lib/BackgroundJob/FederatedSharesDiscoverJob.php
+++ b/apps/files_sharing/lib/BackgroundJob/FederatedSharesDiscoverJob.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright 2018, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Files_Sharing\BackgroundJob;
+
+use OC\BackgroundJob\TimedJob;
+use OCP\IDBConnection;
+use OCP\OCS\IDiscoveryService;
+
+class FederatedSharesDiscoverJob extends TimedJob {
+	/** @var IDBConnection */
+	private $connection;
+	/** @var IDiscoveryService */
+	private $discoveryService;
+
+	public function __construct(IDBConnection $connection,
+								IDiscoveryService $discoveryService) {
+		$this->connection = $connection;
+		$this->discoveryService = $discoveryService;
+
+		$this->setInterval(86400);
+	}
+
+	public function run($argument) {
+		$qb = $this->connection->getQueryBuilder();
+
+		$qb->selectDistinct('remote')
+			->from('share_external');
+
+		$result = $qb->execute();
+		while($row = $result->fetch()) {
+			$this->discoveryService->discover($row['remote'], 'FEDERATED_SHARING', true);
+		}
+		$result->closeCursor();
+	}
+}

--- a/lib/private/OCS/DiscoveryService.php
+++ b/lib/private/OCS/DiscoveryService.php
@@ -59,15 +59,18 @@ class DiscoveryService implements IDiscoveryService {
 	 *
 	 * @param string $remote
 	 * @param string $service the service you want to discover
+	 * @param bool $skipCache We won't check if the data is in the cache. This is usefull if a background job is updating the status
 	 * @return array
 	 */
-	public function discover(string $remote, string $service): array {
+	public function discover(string $remote, string $service, bool $skipCache = false): array {
 		// Check the cache first
-		$cacheData = $this->cache->get($remote . '#' . $service);
-		if($cacheData) {
-			$data = json_decode($cacheData, true);
-			if (\is_array($data)) {
-				return $data;
+		if ($skipCache === false) {
+			$cacheData = $this->cache->get($remote . '#' . $service);
+			if ($cacheData) {
+				$data = json_decode($cacheData, true);
+				if (\is_array($data)) {
+					return $data;
+				}
 			}
 		}
 

--- a/lib/public/OCS/IDiscoveryService.php
+++ b/lib/public/OCS/IDiscoveryService.php
@@ -44,8 +44,9 @@ interface IDiscoveryService {
 	 *
 	 * @param string $remote
 	 * @param string $service the service you want to discover
+	 * @param bool $skipCache We won't check if the data is in the cache. This is usefull if a background job is updating the status
 	 * @return array
 	 */
-	public function discover(string $remote, string $service): array;
+	public function discover(string $remote, string $service, bool $skipCache = false): array;
 
 }

--- a/lib/public/OCS/IDiscoveryService.php
+++ b/lib/public/OCS/IDiscoveryService.php
@@ -44,7 +44,7 @@ interface IDiscoveryService {
 	 *
 	 * @param string $remote
 	 * @param string $service the service you want to discover
-	 * @param bool $skipCache We won't check if the data is in the cache. This is usefull if a background job is updating the status
+	 * @param bool $skipCache We won't check if the data is in the cache. This is useful if a background job is updating the status - Added in 14.0.0
 	 * @return array
 	 */
 	public function discover(string $remote, string $service, bool $skipCache = false): array;


### PR DESCRIPTION
Instead of doing this on demand.

Once a day loop over all federated hosts to obtain their discovery information.

This should make federated shares a bit faster again.