### PR TITLE
Return proper boolean and do not save enabled state in db

### DIFF
--- a/apps/provisioning_api/lib/Controller/AUserData.php
+++ b/apps/provisioning_api/lib/Controller/AUserData.php
@@ -92,7 +92,7 @@ abstract class AUserData extends OCSController {
 		// Should be at least Admin Or SubAdmin!
 		if( $this->groupManager->isAdmin($currentLoggedInUser->getUID())
 			|| $this->groupManager->getSubAdmin()->isUserAccessible($currentLoggedInUser, $targetUserObject)) {
-				$data['enabled'] = $this->config->getUserValue($targetUserObject->getUID(), 'core', 'enabled', 'true');
+				$data['enabled'] = $this->config->getUserValue($targetUserObject->getUID(), 'core', 'enabled', 'true') === 'true';
 		} else {
 			// Check they are looking up themselves
 			if($currentLoggedInUser->getUID() !== $targetUserObject->getUID()) {

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -766,7 +766,7 @@ class UsersControllerTest extends TestCase {
 
 		$expected = [
 			'id' => 'UID',
-			'enabled' => 'true',
+			'enabled' => true,
 			'storageLocation' => '/var/www/newtcloud/data/UID',
 			'lastLogin' => 1521191471000,
 			'backend' => 'Database',
@@ -881,7 +881,7 @@ class UsersControllerTest extends TestCase {
 
 		$expected = [
 			'id' => 'UID',
-			'enabled' => 'true',
+			'enabled' => true,
 			'storageLocation' => '/var/www/newtcloud/data/UID',
 			'lastLogin' => 1521191471000,
 			'backend' => 'Database',

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -349,13 +349,12 @@ class User implements IUser {
 	 *
 	 * @param bool $enabled
 	 */
-	public function setEnabled($enabled) {
+	public function setEnabled(bool $enabled = true) {
 		$oldStatus = $this->isEnabled();
 		$this->enabled = $enabled;
-		$enabled = $enabled ? 'true' : 'false';
 		if ($oldStatus !== $this->enabled) {
 			$this->triggerChange('enabled', $enabled);
-			$this->config->setUserValue($this->uid, 'core', 'enabled', $enabled);
+			$this->config->setUserValue($this->uid, 'core', 'enabled', $enabled ? 'true' : 'false');
 		}
 	}
 

--- a/lib/public/IUser.php
+++ b/lib/public/IUser.php
@@ -146,7 +146,7 @@ interface IUser {
 	 * @param bool $enabled
 	 * @since 8.0.0
 	 */
-	public function setEnabled($enabled);
+	public function setEnabled(bool $enabled = true);
 
 	/**
 	 * get the users email address

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -816,7 +816,7 @@ class UserTest extends TestCase {
 			->method('triggerChange')
 			->with(
 				'enabled',
-				'false'
+				false
 			);
 
 		$user->setEnabled(false);


### PR DESCRIPTION
Since we store booleans as string in the db, let's check agains it so we also return a boolean in the json and not a string like "true".

Also, I introduced the removal of the "enabled" key when we enable a user since no config = true.