### PR TITLE
Make possible to run acceptance tests on Apache

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -543,42 +543,42 @@ pipeline:
       matrix:
         TESTS: integration-remote-api
   acceptance-access-levels:
-      image: nextcloudci/integration-php7.0:integration-php7.0-6
+      image: nextcloudci/acceptance-php7.1:acceptance-php7.1-2
       commands:
         - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-access-levels --selenium-server selenium:4444 allow-git-repository-modifications features/access-levels.feature
       when:
         matrix:
           TESTS-ACCEPTANCE: access-levels
   acceptance-app-comments:
-      image: nextcloudci/integration-php7.0:integration-php7.0-6
+      image: nextcloudci/acceptance-php7.1:acceptance-php7.1-2
       commands:
         - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-app-comments --selenium-server selenium:4444 allow-git-repository-modifications features/app-comments.feature
       when:
         matrix:
           TESTS-ACCEPTANCE: app-comments
   acceptance-app-files:
-      image: nextcloudci/integration-php7.0:integration-php7.0-6
+      image: nextcloudci/acceptance-php7.1:acceptance-php7.1-2
       commands:
         - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-app-files --selenium-server selenium:4444 allow-git-repository-modifications features/app-files.feature
       when:
         matrix:
           TESTS-ACCEPTANCE: app-files
   acceptance-app-theming:
-      image: nextcloudci/integration-php7.0:integration-php7.0-6
+      image: nextcloudci/acceptance-php7.1:acceptance-php7.1-2
       commands:
         - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-app-theming --selenium-server selenium:4444 allow-git-repository-modifications features/app-theming.feature
       when:
         matrix:
           TESTS-ACCEPTANCE: app-theming
   acceptance-header:
-      image: nextcloudci/integration-php7.0:integration-php7.0-6
+      image: nextcloudci/acceptance-php7.1:acceptance-php7.1-2
       commands:
         - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-header --selenium-server selenium:4444 allow-git-repository-modifications features/header.feature
       when:
         matrix:
           TESTS-ACCEPTANCE: header
   acceptance-login:
-      image: nextcloudci/integration-php7.0:integration-php7.0-6
+      image: nextcloudci/acceptance-php7.1:acceptance-php7.1-2
       commands:
         - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-login --selenium-server selenium:4444 allow-git-repository-modifications features/login.feature
       when:

--- a/tests/acceptance/features/core/NextcloudTestServerContext.php
+++ b/tests/acceptance/features/core/NextcloudTestServerContext.php
@@ -40,12 +40,12 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
  *
  * The Nextcloud server is provided by an instance of NextcloudTestServerHelper;
  * its class must be specified when this context is created. By default,
- * "NextcloudTestServerLocalHelper" is used, although that can be customized
- * using the "nextcloudTestServerHelper" parameter in "behat.yml". In the same
- * way, the parameters to be passed to the helper when it is created can be
- * customized using the "nextcloudTestServerHelperParameters" parameter, which
- * is an array (without keys) with the value of the parameters in the same order
- * as in the constructor of the helper class (by default, [ ]).
+ * "NextcloudTestServerLocalBuiltInHelper" is used, although that can be
+ * customized using the "nextcloudTestServerHelper" parameter in "behat.yml". In
+ * the same way, the parameters to be passed to the helper when it is created
+ * can be customized using the "nextcloudTestServerHelperParameters" parameter,
+ * which is an array (without keys) with the value of the parameters in the same
+ * order as in the constructor of the helper class (by default, [ ]).
  *
  * Example of custom parameters in "behat.yml":
  * default:
@@ -73,7 +73,7 @@ class NextcloudTestServerContext implements Context {
 	 * @param array $nextcloudTestServerHelperParameters the parameters for the
 	 *        constructor of the $nextcloudTestServerHelper class.
 	 */
-	public function __construct($nextcloudTestServerHelper = "NextcloudTestServerLocalHelper",
+	public function __construct($nextcloudTestServerHelper = "NextcloudTestServerLocalBuiltInHelper",
 								$nextcloudTestServerHelperParameters = [ ]) {
 		$nextcloudTestServerHelperClass = new ReflectionClass($nextcloudTestServerHelper);
 

--- a/tests/acceptance/features/core/NextcloudTestServerLocalApacheHelper.php
+++ b/tests/acceptance/features/core/NextcloudTestServerLocalApacheHelper.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2018, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Helper to manage a Nextcloud test server started directly by the acceptance
+ * tests themselves using the Apache web server.
+ *
+ * The Nextcloud test server is executed using the Apache web server; the
+ * default Apache directory is expected to have been set to the root directory
+ * of the Nextcloud server (for example, by linking "var/www/html" to it); in
+ * any case, note that the acceptance tests must be run from the acceptance
+ * tests directory. The "setUp" method resets the Nextcloud server to its
+ * initial state and starts it, while the "cleanUp" method stops it. To be able
+ * to reset the Nextcloud server to its initial state a Git repository must be
+ * provided in the root directory of the Nextcloud server; the last commit in
+ * that Git repository must provide the initial state for the Nextcloud server
+ * expected by the acceptance tests. When the Nextcloud server is reset the
+ * owner of "apps", "config" and "data" must be set to the user that Apache
+ * server is run as; it is assumed that Apache is run as "www-data".
+ *
+ * The Nextcloud server is available at "$nextcloudServerDomain", which can be
+ * optionally specified when the NextcloudTestServerLocalApacheHelper is
+ * created; if no value is given "127.0.0.1" is used by default. In any case,
+ * the value of "$nextcloudServerDomain" must be seen as a trusted domain by the
+ * Nextcloud server (which would be the case for "127.0.0.1" if it was installed
+ * by running "occ maintenance:install"). The base URL to access the Nextcloud
+ * server can be got from "getBaseUrl".
+ */
+class NextcloudTestServerLocalApacheHelper implements NextcloudTestServerHelper {
+
+	/**
+	 * @var string
+	 */
+	private $nextcloudServerDomain;
+
+	/**
+	 * Creates a new NextcloudTestServerLocalApacheHelper.
+	 */
+	public function __construct($nextcloudServerDomain = "127.0.0.1") {
+		$this->nextcloudServerDomain = $nextcloudServerDomain;
+	}
+
+	/**
+	 * Sets up the Nextcloud test server.
+	 *
+	 * It resets the Nextcloud test server restoring its last saved Git state
+	 * and then waits for the Nextcloud test server to start again; if the
+	 * server can not be reset or if it does not start again after some time an
+	 * exception is thrown (as it is just a warning for the test runner and
+	 * nothing to be explicitly catched a plain base Exception is used).
+	 *
+	 * @throws \Exception if the Nextcloud test server can not be reset or
+	 *         started again.
+	 */
+	public function setUp() {
+		// Ensure that previous Apache server is not running (as cleanUp may not
+		// have been called).
+		$this->stopApacheServer();
+
+		$this->execOrException("cd ../../ && git reset --hard HEAD");
+		$this->execOrException("cd ../../ && git clean -d --force");
+		$this->execOrException("cd ../../ && chown -R www-data:www-data apps config data");
+
+		$this->execOrException("service apache2 start");
+
+		$timeout = 60;
+		if (!Utils::waitForServer($this->getBaseUrl(), $timeout)) {
+			throw new Exception("Nextcloud test server could not be started");
+		}
+	}
+
+	/**
+	 * Cleans up the Nextcloud test server.
+	 *
+	 * It stops the running Nextcloud test server, if any.
+	 */
+	public function cleanUp() {
+		$this->stopApacheServer();
+	}
+
+	/**
+	 * Returns the base URL of the Nextcloud test server.
+	 *
+	 * @return string the base URL of the Nextcloud test server.
+	 */
+	public function getBaseUrl() {
+		return "http://" . $this->nextcloudServerDomain . "/index.php";
+	}
+
+	/**
+	 * Executes the given command, throwing an Exception if it fails.
+	 *
+	 * @param string $command the command to execute.
+	 * @throws \Exception if the command fails to execute.
+	 */
+	private function execOrException($command) {
+		exec($command . " 2>&1", $output, $returnValue);
+		if ($returnValue != 0) {
+			throw new Exception("'$command' could not be executed: " . implode("\n", $output));
+		}
+	}
+
+	/**
+	 * Stops the Apache server started in setUp, if any.
+	 */
+	private function stopApacheServer() {
+		$this->execOrException("service apache2 stop");
+	}
+
+}

--- a/tests/acceptance/features/core/NextcloudTestServerLocalBuiltInHelper.php
+++ b/tests/acceptance/features/core/NextcloudTestServerLocalBuiltInHelper.php
@@ -36,14 +36,14 @@
  * initial state for the Nextcloud server expected by the acceptance tests.
  *
  * The Nextcloud server is available at "$nextcloudServerDomain", which can be
- * optionally specified when the NextcloudTestServerLocalHelper is created; if
- * no value is given "127.0.0.1" is used by default. In any case, the value of
- * "$nextcloudServerDomain" must be seen as a trusted domain by the Nextcloud
- * server (which would be the case for "127.0.0.1" if it was installed by
- * running "occ maintenance:install"). The base URL to access the Nextcloud
+ * optionally specified when the NextcloudTestServerLocalBuiltInHelper is
+ * created; if no value is given "127.0.0.1" is used by default. In any case,
+ * the value of "$nextcloudServerDomain" must be seen as a trusted domain by the
+ * Nextcloud server (which would be the case for "127.0.0.1" if it was installed
+ * by running "occ maintenance:install"). The base URL to access the Nextcloud
  * server can be got from "getBaseUrl".
  */
-class NextcloudTestServerLocalHelper implements NextcloudTestServerHelper {
+class NextcloudTestServerLocalBuiltInHelper implements NextcloudTestServerHelper {
 
 	/**
 	 * @var string
@@ -56,7 +56,7 @@ class NextcloudTestServerLocalHelper implements NextcloudTestServerHelper {
 	private $phpServerPid;
 
 	/**
-	 * Creates a new NextcloudTestServerLocalHelper.
+	 * Creates a new NextcloudTestServerLocalBuiltInHelper.
 	 */
 	public function __construct($nextcloudServerDomain = "127.0.0.1") {
 		$this->nextcloudServerDomain = $nextcloudServerDomain;

--- a/tests/acceptance/run-local.sh
+++ b/tests/acceptance/run-local.sh
@@ -192,7 +192,14 @@ if [ "$NEXTCLOUD_SERVER_DOMAIN" != "$DEFAULT_NEXTCLOUD_SERVER_DOMAIN" ]; then
 fi
 
 echo "Installing and configuring Nextcloud server"
-$ACCEPTANCE_TESTS_DIR/installAndConfigureServer.sh $INSTALL_AND_CONFIGURE_SERVER_PARAMETERS
+# The server is installed and configured using the www-data user as it is the
+# user that Apache sub-processes will be run as; the PHP built-in web server is
+# run as the root user, and in that case the permissions of apps, config and
+# data dirs makes no difference, so this is valid for both cases.
+mkdir data
+chown -R www-data:www-data apps config data
+NEXTCLOUD_DIR=`pwd`
+su --shell /bin/bash --login www-data --command "cd $NEXTCLOUD_DIR && $ACCEPTANCE_TESTS_DIR/installAndConfigureServer.sh $INSTALL_AND_CONFIGURE_SERVER_PARAMETERS"
 
 echo "Saving the default state so acceptance tests can reset to it"
 find . -name ".gitignore" -exec rm --force {} \;

--- a/tests/acceptance/run-local.sh
+++ b/tests/acceptance/run-local.sh
@@ -144,8 +144,12 @@ if [ "$NEXTCLOUD_SERVER_DOMAIN" != "$DEFAULT_NEXTCLOUD_SERVER_DOMAIN" ]; then
 	# https://github.com/Behat/Behat/issues/983). Thus, the default "behat.yml"
 	# configuration file has to be adjusted to provide the appropriate
 	# parameters for NextcloudTestServerContext.
+	#
+	# Note that the substitution below is only valid if no parameters for
+	# the helper are set in behat.yml, although it is valid if a specific
+	# helper is.
 	ORIGINAL="\
-        - NextcloudTestServerContext"
+        - NextcloudTestServerContext:\?"
 	REPLACEMENT="\
         - NextcloudTestServerContext:\n\
             nextcloudTestServerHelperParameters:\n\

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -138,7 +138,7 @@ function prepareDocker() {
 	# Selenium server.
 	# The container exits immediately if no command is given, so a Bash session
 	# is created to prevent that.
-	docker run --detach --name=$NEXTCLOUD_LOCAL_CONTAINER --network=container:$SELENIUM_CONTAINER --interactive --tty nextcloudci/php7.1:php7.1-15 bash
+	docker run --detach --name=$NEXTCLOUD_LOCAL_CONTAINER --network=container:$SELENIUM_CONTAINER --interactive --tty nextcloudci/acceptance-php7.1:acceptance-php7.1-2 bash
 
 	# Use the $TMPDIR or, if not set, fall back to /tmp.
 	NEXTCLOUD_LOCAL_TAR="$($MKTEMP --tmpdir="${TMPDIR:-/tmp}" --suffix=.tar nextcloud-local-XXXXXXXXXX)"
@@ -152,6 +152,10 @@ function prepareDocker() {
 
 	docker exec $NEXTCLOUD_LOCAL_CONTAINER mkdir /nextcloud
 	docker cp - $NEXTCLOUD_LOCAL_CONTAINER:/nextcloud/ < "$NEXTCLOUD_LOCAL_TAR"
+
+	# Link the default Apache directory to the root directory of the Nextcloud
+	# server to make possible to run the Nextcloud server on Apache if needed.
+	docker exec $NEXTCLOUD_LOCAL_CONTAINER ln --symbolic /nextcloud /var/www/html
 
 	# run-local.sh expects a Git repository to be available in the root of the
 	# Nextcloud server, but it was excluded when the Git working directory was


### PR DESCRIPTION
Until now the acceptance tests were always run on the PHP built-in web server. This pull request makes possible to optionally run them on an Apache web server too.

Acceptance tests for the Nextcloud server run fine on the PHP built-in web server; this is meant to be used for the acceptance tests of those apps that require a multi-threaded web server (for example, Talk, as it uses long polling).

To run the acceptance tests on an Apache web server it is simply necessary to set the `nextcloudTestServerHelper` parameter of the `NextcloudTestServerContext` to `NextcloudTestServerLocalApacheHelper` in the Behat configuration of the acceptance tests for the app, and also link the server directory to _/var/www/html/_ in Drone (when the acceptance tests are run through _run.sh_ the link is done automatically, it is only needed for Drone).

The above description can be seen more clearly in https://github.com/nextcloud/spreed/pull/768/commits/07b6b10f93f78153e4b7b6dd0c2d7cbfc9253fe0 and https://github.com/nextcloud/spreed/pull/768/commits/137e7c67273b9e99e277a2cbe33c55fd5adb0d15#diff-3216dfff0ed3e301453e6799e8c367e2R161, which are part of [the pull request to add acceptance tests for Nextcloud Talk](https://github.com/nextcloud/spreed/pull/768).
