### PR TITLE
Remove SAMEORIGIN header from php files.

### DIFF
--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -137,7 +137,7 @@ class OC_Response {
 			. 'object-src \'none\'; '
 			. 'base-uri \'self\'; ';
 		header('Content-Security-Policy:' . $policy);
-		header('X-Frame-Options: SAMEORIGIN'); // Disallow iFraming from other domains
+//		header('X-Frame-Options: SAMEORIGIN'); // Disallow iFraming from other domains
 
 		// Send fallback headers for installations that don't have the possibility to send
 		// custom headers on the webserver side


### PR DESCRIPTION
This is *already* provided by the webserver software config (in my case NGINX). nextcloud server install webGUI gives false positive warnings about X-frame headers when it finds them double(?), like SAMEORIGIN. After commenting it out in this file, I get proper headers from my nextcloud server:

# curl -I https://next.jult.net
HTTP/2 302
server: nginx
date: Wed, 11 Apr 2018 08:13:28 GMT
content-type: text/html; charset=UTF-8
location: https://next.jult.net/login
set-cookie: ock5tdx30nt4=p8gtf93pg8if6uei3pfjs0hj93; path=/; secure; HttpOnly
expires: Thu, 19 Nov 1981 08:52:00 GMT
cache-control: no-store, no-cache, must-revalidate
pragma: no-cache
set-cookie: oc_sessionPassphrase=seE5M%2BV2Qh%2Fvsjf%2FSwFp3M4oO6rV%2ByUbdexlOnuTEAbC7Tdgl8cdHp7xnP7XLi6LJ5G6u8RItWMn%2BcjCcI3IgOtoV2riO08XqZce8RDJPs4Paxi59x9socHNKwh2W982; path=/; secure; HttpOnly
content-security-policy: default-src 'self'; script-src 'self' 'unsafe-eval' 'nonce-YW9WbStyQkU4S1BXa2RUdk1RMmtJVG1nYWF4YnlWN2VBZ3ovazA2UUZaND06THJkV3ZQWUNuL2V5b0p6QWZVeWRZQUR3SnNrRHZDZWZSR0NRd2dEa2RNMD0='; style-src 'self' 'unsafe-inline'; frame-src *; img-src * data: blob:; font-src 'self' data:; media-src *; connect-src *; object-src 'none'; base-uri 'self';
set-cookie: __Host-nc_sameSiteCookielax=true; path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax
set-cookie: __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=strict
strict-transport-security: max-age=31536000; preload
referrer-policy: no-referrer-when-downgrade
content-security-policy: default-src 'self' 'unsafe-inline' 'unsafe-eval'; img-src 'self' data:;
x-frame-options: SAMEORIGIN
x-content-type-options: nosniff
x-xss-protection: 1; mode=block
x-robots-tag: none
x-download-options: noopen
x-permitted-cross-domain-policies: none