### PR TITLE
fix appinfo parsing when a single localized option is provided

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -1004,6 +1004,11 @@ class OC_App {
 	}
 
 	protected static function findBestL10NOption(array $options, string $lang): string {
+		// only a single option
+		if (isset($options['@value'])) {
+			return $options['@value'];
+		}
+
 		$fallback = $similarLangFallback = $englishFallback = false;
 
 		$lang = strtolower($lang);

--- a/tests/data/app/description-multi-lang.xml
+++ b/tests/data/app/description-multi-lang.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<info>
+	<id>files_encryption</id>
+	<name>Server-side Encryption</name>
+	<description lang="en">English</description>
+	<description lang="de">German</description>
+	<licence>AGPL</licence>
+</info>

--- a/tests/data/app/description-single-lang.xml
+++ b/tests/data/app/description-single-lang.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<info>
+	<id>files_encryption</id>
+	<name>Server-side Encryption</name>
+	<description lang="en">English</description>
+	<licence>AGPL</licence>
+</info>

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -9,6 +9,7 @@
 
 namespace Test;
 
+use OC\App\InfoParser;
 use OC\AppConfig;
 use OCP\IAppConfig;
 
@@ -591,6 +592,19 @@ class AppTest extends \Test\TestCase {
 	 */
 	public function testParseAppInfo(array $data, array $expected) {
 		$this->assertSame($expected, \OC_App::parseAppInfo($data));
+	}
+
+	public function testParseAppInfoL10N() {
+		$parser = new InfoParser();
+		$data = $parser->parse(\OC::$SERVERROOT. "/tests/data/app/description-multi-lang.xml");
+		$this->assertEquals('English', \OC_App::parseAppInfo($data, 'en')['description']);
+		$this->assertEquals('German', \OC_App::parseAppInfo($data, 'de')['description']);
+	}
+
+	public function testParseAppInfoL10NSingleLanguage() {
+		$parser = new InfoParser();
+		$data = $parser->parse(\OC::$SERVERROOT. "/tests/data/app/description-single-lang.xml");
+		$this->assertEquals('English', \OC_App::parseAppInfo($data, 'en')['description']);
 	}
 }
 


### PR DESCRIPTION
See https://github.com/nextcloud/server/pull/8223