### PR TITLE
Add human readable description to migration steps

### DIFF
--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -58,7 +58,14 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 
 		$infos = $this->getMigrationsInfos($ms);
 		foreach ($infos as $key => $value) {
-			$output->writeln("    <comment>>></comment> $key: " . str_repeat(' ', 50 - strlen($key)) . $value);
+			if (is_array($value)) {
+				$output->writeln("    <comment>>></comment> $key:");
+				foreach ($value as $subKey => $subValue) {
+					$output->writeln("        <comment>>></comment> $subKey: " . str_repeat(' ', 46 - strlen($subKey)) . $subValue);
+				}
+			} else {
+				$output->writeln("    <comment>>></comment> $key: " . str_repeat(' ', 50 - strlen($key)) . $value);
+			}
 		}
 	}
 
@@ -96,6 +103,7 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 
 		$numExecutedUnavailableMigrations = count($executedUnavailableMigrations);
 		$numNewMigrations = count(array_diff(array_keys($availableMigrations), $executedMigrations));
+		$pending = $ms->describeMigrationStep('lastest');
 
 		$infos = [
 			'App'								=> $ms->getApp(),
@@ -110,6 +118,7 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 			'Executed Unavailable Migrations'	=> $numExecutedUnavailableMigrations,
 			'Available Migrations'				=> count($availableMigrations),
 			'New Migrations'					=> $numNewMigrations,
+			'Pending Migrations'				=> count($pending) ? $pending : 'None'
 		];
 
 		return $infos;

--- a/core/Migrations/Version14000Date20180129121024.php
+++ b/core/Migrations/Version14000Date20180129121024.php
@@ -30,6 +30,13 @@ use OCP\Migration\IOutput;
  * Delete the admin|personal sections and settings tables
  */
 class Version14000Date20180129121024 extends SimpleMigrationStep {
+	public function name(): string {
+		return 'Drop obsolete settings tables';
+	}
+
+	public function description(): string {
+		return 'Drops the following obsolete tables: "admin_sections", "admin_settings", "personal_sections" and "personal_settings"';
+	}
 
 	/**
 	 * @param IOutput $output

--- a/core/Migrations/Version14000Date20180404140050.php
+++ b/core/Migrations/Version14000Date20180404140050.php
@@ -41,6 +41,14 @@ class Version14000Date20180404140050 extends SimpleMigrationStep {
 		$this->connection = $connection;
 	}
 
+	public function name(): string {
+		return 'Add lowercase user id column to users table';
+	}
+
+	public function description(): string {
+		return 'Adds "uid_lower" column to the users table and fills the column to allow indexed case-insensitive searches';
+	}
+
 	/**
 	 * @param IOutput $output
 	 * @param \Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`

--- a/lib/public/Migration/IMigrationStep.php
+++ b/lib/public/Migration/IMigrationStep.php
@@ -29,6 +29,21 @@ use OCP\DB\ISchemaWrapper;
  * @since 13.0.0
  */
 interface IMigrationStep {
+	/**
+	 * Human readable name of the migration step
+	 *
+	 * @return string
+	 * @since 14.0.0
+	 */
+	public function name(): string;
+
+	/**
+	 * Human readable description of the migration steps
+	 *
+	 * @return string
+	 * @since 14.0.0
+	 */
+	public function description(): string;
 
 	/**
 	 * @param IOutput $output

--- a/lib/public/Migration/SimpleMigrationStep.php
+++ b/lib/public/Migration/SimpleMigrationStep.php
@@ -29,6 +29,23 @@ use OCP\DB\ISchemaWrapper;
  * @since 13.0.0
  */
 abstract class SimpleMigrationStep implements IMigrationStep {
+	/**
+	 * Human readable name of the migration step
+	 *
+	 * @return string
+	 */
+	public function name(): string {
+		return '';
+	}
+
+	/**
+	 * Human readable description of the migration step
+	 *
+	 * @return string
+	 */
+	public function description(): string {
+		return '';
+	}
 
 	/**
 	 * @param IOutput $output

--- a/lib/public/Migration/SimpleMigrationStep.php
+++ b/lib/public/Migration/SimpleMigrationStep.php
@@ -33,6 +33,7 @@ abstract class SimpleMigrationStep implements IMigrationStep {
 	 * Human readable name of the migration step
 	 *
 	 * @return string
+	 * @since 14.0.0
 	 */
 	public function name(): string {
 		return '';
@@ -42,6 +43,7 @@ abstract class SimpleMigrationStep implements IMigrationStep {
 	 * Human readable description of the migration step
 	 *
 	 * @return string
+	 * @since 14.0.0
 	 */
 	public function description(): string {
 		return '';


### PR DESCRIPTION
Description is shown in `occ migrations:status` output so admins can get some additional information about what will be done during upgrade when desired.

Example output: 

```
    >> App:                                                core
    >> Version Table Name:                                 oc_migrations
    >> Migrations Namespace:                               OC\Core\Migrations
    >> Migrations Directory:                               /srv/http/cloud/core/Migrations
    >> Previous Version:                                   13000Date20170919121250
    >> Current Version:                                    13000Date20170926101637
    >> Next Version:                                       14000Date20180129121024
    >> Latest Version:                                     14000Date20180404140050
    >> Executed Migrations:                                5
    >> Executed Unavailable Migrations:                    5
    >> Available Migrations:                               7
    >> New Migrations:                                     7
    >> Pending Migrations:
        >> Drop obsolete settings tables:                  Drops the following obsolete tables: "admin_sections", "admin_settings", "personal_sections" and "personal_settings"
        >> Add lowercase user id column to users table:    Adds "uid_lower" column to the users table and fills the column to allow indexed case-insensitive searches
```