### PR TITLE
Change folder detection method for wrapSource() 

### DIFF
--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -195,9 +195,11 @@ class Encryption extends Wrapper {
 	protected static function wrapSource($source, $context, $protocol, $class, $mode = 'r+') {
 		try {
 			stream_wrapper_register($protocol, $class);
-			if (@rewinddir($source) === false) {
+			$meta=stream_get_meta_data($source);
+			if (!$meta['stream_type']=='dir') {
 				$wrapped = fopen($protocol . '://', $mode, false, $context);
 			} else {
+				rewinddir($source);
 				$wrapped = opendir($protocol . '://', $context);
 			}
 		} catch (\BadMethodCallException $e) {


### PR DESCRIPTION
To prevent it from spamming the log file with these:

 rewinddir(): 37 is not a valid Directory resource at /var/www/nextcloud/lib/private/Files/Stream/Encryption.php#198