### PR TITLE
Fixes issue with the large cursor on Safari in the comment section.

### DIFF
--- a/apps/comments/css/comments.scss
+++ b/apps/comments/css/comments.scss
@@ -17,9 +17,12 @@
 }
 
 #commentsTabView .newCommentForm .message {
-	/* width = 100% - (width of submit button (44px) + margin (3px) + inline-block gap) */
-	width: calc(100% - 52px);
-	display: inline-block;
+	/* width = 100% - (width of submit button (44px) + margin (3px) + border (1px)) */
+	width: calc(100% - 48px);
+	/* Need to use float left instead of display inline-block because Safari shows a big cursor */
+	float: left;
+	/* To align it to the button on the side */
+	margin-top: 5px;
 }
 
 #commentsTabView .newCommentForm .submit {


### PR DESCRIPTION
This was being caused due to the `display: inline-block` on the contenteditable div.

Tested the following,

1. Alignments with the close / cancel button
2. Position of the loading symbol when updating / saving a comment.

I've tested this on BrowserStack on Safari 7.1 and it did seem to work, so hoping that it'll work on the newer versions.

Fixes #9150  

cc @nextcloud/designers 

Signed-off-by: Abijeet <abijeetpatro@gmail.com>