### PR TITLE
Provide an option to disable HTML emails

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -390,6 +390,18 @@ $CONFIG = array(
  */
 'mail_smtppassword' => '',
 
+/**
+ * Replaces the default mail template layout. This can be utilized if the
+ * options to modify the mail texts with the theming app is not enough.
+ * The class must extend  ``\OC\Mail\EMailTemplate``
+ */
+'mail_template_class' => '\OC\Mail\EMailTemplate',
+
+/**
+ * Email will be send by default with an HTML and a plain text body. This option
+ * allows to only send plain text emails.
+ */
+'mail_send_plaintext_only' => false,
 
 /**
  * Proxy Configurations
@@ -984,13 +996,6 @@ $CONFIG = array(
  * Defaults to ``\OC\SystemTag\ManagerFactory``
  */
 'systemtags.managerFactory' => '\OC\SystemTag\ManagerFactory',
-
-/**
- * Replaces the default mail template layout. This can be utilized if the
- * options to modify the mail texts with the theming app is not enough.
- * The class must extend  ``\OC\Mail\EMailTemplate``
- */
-'mail_template_class' => '\OC\Mail\EMailTemplate',
 
 /**
  * Maintenance

--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -93,7 +93,8 @@ class Mailer implements IMailer {
 	 * @return IMessage
 	 */
 	public function createMessage(): IMessage {
-		return new Message(new \Swift_Message());
+		$plainTextOnly = $this->config->getSystemValue('mail_send_plaintext_only', false);
+		return new Message(new \Swift_Message(), $plainTextOnly);
 	}
 
 	/**

--- a/lib/private/Mail/Message.php
+++ b/lib/private/Mail/Message.php
@@ -39,12 +39,12 @@ use Swift_Message;
 class Message implements IMessage {
 	/** @var Swift_Message */
 	private $swiftMessage;
+	/** @var bool */
+	private $plainTextOnly;
 
-	/**
-	 * @param Swift_Message $swiftMessage
-	 */
-	public function __construct(Swift_Message $swiftMessage) {
+	public function __construct(Swift_Message $swiftMessage, bool $plainTextOnly) {
 		$this->swiftMessage = $swiftMessage;
+		$this->plainTextOnly = $plainTextOnly;
 	}
 
 	/**
@@ -246,7 +246,9 @@ class Message implements IMessage {
 	 * @return $this
 	 */
 	public function setHtmlBody($body) {
-		$this->swiftMessage->addPart($body, 'text/html');
+		if (!$this->plainTextOnly) {
+			$this->swiftMessage->addPart($body, 'text/html');
+		}
 		return $this;
 	}
 
@@ -264,7 +266,9 @@ class Message implements IMessage {
 	 * @return $this
 	 */
 	public function setBody($body, $contentType) {
-		$this->swiftMessage->setBody($body, $contentType);
+		if (!$this->plainTextOnly || $contentType !== 'text/html') {
+			$this->swiftMessage->setBody($body, $contentType);
+		}
 		return $this;
 	}
 
@@ -275,7 +279,9 @@ class Message implements IMessage {
 	public function useTemplate(IEMailTemplate $emailTemplate): IMessage {
 		$this->setSubject($emailTemplate->renderSubject());
 		$this->setPlainBody($emailTemplate->renderText());
-		$this->setHtmlBody($emailTemplate->renderHtml());
+		if (!$this->plainTextOnly) {
+			$this->setHtmlBody($emailTemplate->renderHtml());
+		}
 		return $this;
 	}
 }

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -95,6 +95,11 @@ class MailerTest extends TestCase {
 	}
 
 	public function testCreateMessage() {
+		$this->config
+			->expects($this->any())
+			->method('getSystemValue')
+			->with('mail_send_plaintext_only', false)
+			->will($this->returnValue(false));
 		$this->assertInstanceOf('\OC\Mail\Message', $this->mailer->createMessage());
 	}
 

--- a/tests/lib/Mail/MessageTest.php
+++ b/tests/lib/Mail/MessageTest.php
@@ -9,6 +9,7 @@
 namespace Test\Mail;
 
 use OC\Mail\Message;
+use OCP\Mail\IEMailTemplate;
 use Swift_Message;
 use Test\TestCase;
 
@@ -36,7 +37,7 @@ class MessageTest extends TestCase {
 		$this->swiftMessage = $this->getMockBuilder('\Swift_Message')
 			->disableOriginalConstructor()->getMock();
 
-		$this->message = new Message($this->swiftMessage);
+		$this->message = new Message($this->swiftMessage, false);
 	}
 
 	/**
@@ -178,6 +179,52 @@ class MessageTest extends TestCase {
 			->with('<blink>Fancy Body</blink>', 'text/html');
 
 		$this->message->setHtmlBody('<blink>Fancy Body</blink>');
+	}
+
+	public function testPlainTextRenderOption() {
+		/** @var \PHPUnit_Framework_MockObject_MockObject|Swift_Message $swiftMessage */
+		$swiftMessage = $this->getMockBuilder('\Swift_Message')
+			->disableOriginalConstructor()->getMock();
+		/** @var \PHPUnit_Framework_MockObject_MockObject|IEMailTemplate $template */
+		$template = $this->getMockBuilder('\OCP\Mail\IEMailTemplate')
+			->disableOriginalConstructor()->getMock();
+
+		$message = new Message($swiftMessage, true);
+
+		$template
+			->expects($this->never())
+			->method('renderHTML');
+		$template
+			->expects($this->once())
+			->method('renderText');
+		$template
+			->expects($this->once())
+			->method('renderSubject');
+
+		$message->useTemplate($template);
+	}
+
+	public function testBothRenderingOptions() {
+		/** @var \PHPUnit_Framework_MockObject_MockObject|Swift_Message $swiftMessage */
+		$swiftMessage = $this->getMockBuilder('\Swift_Message')
+			->disableOriginalConstructor()->getMock();
+		/** @var \PHPUnit_Framework_MockObject_MockObject|IEMailTemplate $template */
+		$template = $this->getMockBuilder('\OCP\Mail\IEMailTemplate')
+			->disableOriginalConstructor()->getMock();
+
+		$message = new Message($swiftMessage, false);
+
+		$template
+			->expects($this->once())
+			->method('renderHTML');
+		$template
+			->expects($this->once())
+			->method('renderText');
+		$template
+			->expects($this->once())
+			->method('renderSubject');
+
+		$message->useTemplate($template);
 	}
 
 }


### PR DESCRIPTION
Needs to be back ported to stable12 to fix an issue with IBM notes (see #9102).

Unit tests are included.

Fixes #9031 