### PR TITLE
Fix user selectable text for public links for text files

### DIFF
--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -35,12 +35,6 @@
 	height: auto;
 	min-height: 200px;
 	max-height: 800px;
-	-webkit-touch-callout: none;
-	-webkit-user-select: none;
-	-khtml-user-select: none;
-	-moz-user-select: none;
-	-ms-user-select: none;
-	user-select: none;
 }
 
 #imgframe .ellipsis {


### PR DESCRIPTION
Makes public link share text files selectable.

Was added in https://github.com/owncloud/core/pull/15652

As discussed with @jancborchardt - cc @nextcloud/designers 

Found while reviewing https://github.com/nextcloud/files_texteditor/pull/71/files