### PR TITLE
13.0.2 RC 1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(13, 0, 1, 1);
+$OC_Version = array(13, 0, 2, 0);
 
 // The human readable string
-$OC_VersionString = '13.0.1';
+$OC_VersionString = '13.0.2 RC 1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Changelog (since 13.0.1):

* #8779 Show group display names
* #8849 Group existence check works without attribute (like with users)
* #8900 The FN is optional, carrying the displayname if present
* #8905 Set "share with" field to the ID of the circle
* #9015 Use app version to generate scss filename
* #9017 Update icewind/smb to 2.0.5
* #9019 Fix search text overlapping close button
* #9020 Clear any theming prefixed cache on cache buster increase
* #9064 Reset encryptionVersion to '1' if a file was stream copied
* #9071 Do not treat is-encrypted as custom property
* #9072 Fix proper permissions for multiple file access
* #9073 When formatting a share node an Empty target is invalid
* #9077 Move on with the next user if we found the user on one user back-end
* #9089 Allow usage of Windows 10 WebDav Netdrive
* #9094 Add more logging for the object storage during creation of the buckets
* #9095 Do not convert email addresses with idn_to_ascii if…
* #9124 Fix progress bar hidden before the upload ends
* #9213 Update CRL to include old quicknotes cert
* [activity#262](https://github.com/nextcloud/activity/pulls/262) Don't update personal settings for admins
* [files_pdfviewer#64](https://github.com/nextcloud/files_pdfviewer/pulls/64) Bump version 13
* [files_pdfviewer#66](https://github.com/nextcloud/files_pdfviewer/pulls/66) Fix info.xml
* [files_pdfviewer#67](https://github.com/nextcloud/files_pdfviewer/pulls/67) No default enable
* [gallery#418](https://github.com/nextcloud/gallery/pulls/418) Fix position of icons in "Share with" input field
* [gallery#419](https://github.com/nextcloud/gallery/pulls/419) Fix "No results found" tooltip
* [gallery#420](https://github.com/nextcloud/gallery/pulls/420) Fix UI while a share is being added
* [gallery#424](https://github.com/nextcloud/gallery/pulls/424) Hide "No results found" tooltip on autocompletion
* [gallery#430](https://github.com/nextcloud/gallery/pulls/430) Fix error while clicking on the share link checkbox


Pending PRs:

* [x] #8986 Show EOL warning in the update section
* [x] #9230 Fix user selectable text for public links for text files
* [x] #9231 Provide an option to disable HTML emails
* [x] #9233 Fix appinfo parsing when a single localized option is provided
* [x] #9234 Use multibyte substring
* [x] #9236 Fix webdav support for OneNote clients
* [x] #9238 Fixed files copy/move when in favorites or recent section
* [x] nextcloud/activity#265 Skip parameters which are not there instead of failing out

Pending backports:

* none

Nice-to-have but non-blockers:

* [ ] #8777 Various css fixes
* [ ] #8565 Make the Outlook and Thunderbird addons identifyable
* [ ] #9225 Allow IPv6 database hosts