### PR TITLE
12.0.7 RC 1

### DIFF
--- a/version.php
+++ b/version.php
@@ -26,10 +26,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(12, 0, 6, 1);
+$OC_Version = array(12, 0, 7, 0);
 
 // The human readable string
-$OC_VersionString = '12.0.6';
+$OC_VersionString = '12.0.7 RC 1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #8850 Group existence check works without attribute (like with users)
* #8893 Fix undefined index problem
* #9016 Update icewind/smb to 2.0.5
* #9078 Set new-password as autocomplete on the link password
* #9088 Allow usage of Windows 10 WebDav Netdrive
* #9214  Update CRL to include old quicknotes cert
* [files_pdfviewer#65](https://github.com/nextcloud/files_pdfviewer/pulls/65) Bump version 12
* [files_pdfviewer#68](https://github.com/nextcloud/files_pdfviewer/pulls/68) Fix info.xml
* [files_pdfviewer#69](https://github.com/nextcloud/files_pdfviewer/pulls/69) Remove default enable


Pending PRs:

* [x] #8987 Show EOL warning in the update section
* [x] #9232 Provide an option to disable HTML emails
* [x] #9235 Use multibyte substring