### PR TITLE
[stable13] fix appinfo parsing when a single localized option is provided

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -1157,6 +1157,11 @@ class OC_App {
 	}
 
 	protected static function findBestL10NOption($options, $lang) {
+		// only a single option
+		if (isset($options['@value'])) {
+			return $options['@value'];
+		}
+
 		$fallback = $similarLangFallback = $englishFallback = false;
 
 		$lang = strtolower($lang);

--- a/tests/data/app/description-multi-lang.xml
+++ b/tests/data/app/description-multi-lang.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<info>
+	<id>files_encryption</id>
+	<name>Server-side Encryption</name>
+	<description lang="en">English</description>
+	<description lang="de">German</description>
+	<licence>AGPL</licence>
+</info>

--- a/tests/data/app/description-single-lang.xml
+++ b/tests/data/app/description-single-lang.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<info>
+	<id>files_encryption</id>
+	<name>Server-side Encryption</name>
+	<description lang="en">English</description>
+	<licence>AGPL</licence>
+</info>

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -9,6 +9,7 @@
 
 namespace Test;
 
+use OC\App\InfoParser;
 use OC\AppConfig;
 use OCP\IAppConfig;
 
@@ -604,6 +605,19 @@ class AppTest extends \Test\TestCase {
 	 */
 	public function testParseAppInfo(array $data, array $expected) {
 		$this->assertSame($expected, \OC_App::parseAppInfo($data));
+	}
+
+	public function testParseAppInfoL10N() {
+		$parser = new InfoParser();
+		$data = $parser->parse(\OC::$SERVERROOT. "/tests/data/app/description-multi-lang.xml");
+		$this->assertEquals('English', \OC_App::parseAppInfo($data, 'en')['description']);
+		$this->assertEquals('German', \OC_App::parseAppInfo($data, 'de')['description']);
+	}
+
+	public function testParseAppInfoL10NSingleLanguage() {
+		$parser = new InfoParser();
+		$data = $parser->parse(\OC::$SERVERROOT. "/tests/data/app/description-single-lang.xml");
+		$this->assertEquals('English', \OC_App::parseAppInfo($data, 'en')['description']);
 	}
 }
 


### PR DESCRIPTION
Backport of #9159 

Tested and works 👍 