### PR TITLE
Fix ids of permission checkboxes for shares

### DIFF
--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -383,9 +383,7 @@
 
 			var _this = this;
 			this.getShareeList().forEach(function(sharee) {
-				var checkBoxId = 'canEdit-' + _this.cid + '-' + sharee.shareId;
-				checkBoxId = '#' + checkBoxId.replace( /(:|\.|\[|\]|,|=|@|\/)/g, "\\$1");
-				var $edit = _this.$(checkBoxId);
+				var $edit = _this.$('#canEdit-' + _this.cid + '-' + sharee.shareId);
 				if($edit.length === 1) {
 					$edit.prop('checked', sharee.editPermissionState === 'checked');
 					$edit.prop('indeterminate', sharee.editPermissionState === 'indeterminate');

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -30,8 +30,8 @@
 					'<span class="sharingOptionsGroup">' +
 						'{{#if editPermissionPossible}}' +
 						'<span class="shareOption">' +
-							'<input id="canEdit-{{cid}}-{{shareWith}}" type="checkbox" name="edit" class="permissions checkbox" />' +
-							'<label for="canEdit-{{cid}}-{{shareWith}}">{{canEditLabel}}</label>' +
+							'<input id="canEdit-{{cid}}-{{shareId}}" type="checkbox" name="edit" class="permissions checkbox" />' +
+							'<label for="canEdit-{{cid}}-{{shareId}}">{{canEditLabel}}</label>' +
 						'</span>' +
 						'{{/if}}' +
 						'<a href="#"><span class="icon icon-more"></span></a>' +
@@ -58,8 +58,8 @@
 				'{{#if isResharingAllowed}} {{#if sharePermissionPossible}} {{#unless isMailShare}}' +
 				'<li>' +
 					'<span class="shareOption menuitem">' +
-						'<input id="canShare-{{cid}}-{{shareWith}}" type="checkbox" name="share" class="permissions checkbox" {{#if hasSharePermission}}checked="checked"{{/if}} data-permissions="{{sharePermission}}" />' +
-						'<label for="canShare-{{cid}}-{{shareWith}}">{{canShareLabel}}</label>' +
+						'<input id="canShare-{{cid}}-{{shareId}}" type="checkbox" name="share" class="permissions checkbox" {{#if hasSharePermission}}checked="checked"{{/if}} data-permissions="{{sharePermission}}" />' +
+						'<label for="canShare-{{cid}}-{{shareId}}">{{canShareLabel}}</label>' +
 					'</span>' +
 				'</li>' +
 				'{{/unless}} {{/if}} {{/if}}' +
@@ -67,24 +67,24 @@
 					'{{#if createPermissionPossible}}{{#unless isMailShare}}' +
 					'<li>' +
 						'<span class="shareOption menuitem">' +
-							'<input id="canCreate-{{cid}}-{{shareWith}}" type="checkbox" name="create" class="permissions checkbox" {{#if hasCreatePermission}}checked="checked"{{/if}} data-permissions="{{createPermission}}"/>' +
-							'<label for="canCreate-{{cid}}-{{shareWith}}">{{createPermissionLabel}}</label>' +
+							'<input id="canCreate-{{cid}}-{{shareId}}" type="checkbox" name="create" class="permissions checkbox" {{#if hasCreatePermission}}checked="checked"{{/if}} data-permissions="{{createPermission}}"/>' +
+							'<label for="canCreate-{{cid}}-{{shareId}}">{{createPermissionLabel}}</label>' +
 						'</span>' +
 					'</li>' +
 					'{{/unless}}{{/if}}' +
 					'{{#if updatePermissionPossible}}{{#unless isMailShare}}' +
 					'<li>' +
 						'<span class="shareOption menuitem">' +
-							'<input id="canUpdate-{{cid}}-{{shareWith}}" type="checkbox" name="update" class="permissions checkbox" {{#if hasUpdatePermission}}checked="checked"{{/if}} data-permissions="{{updatePermission}}"/>' +
-							'<label for="canUpdate-{{cid}}-{{shareWith}}">{{updatePermissionLabel}}</label>' +
+							'<input id="canUpdate-{{cid}}-{{shareId}}" type="checkbox" name="update" class="permissions checkbox" {{#if hasUpdatePermission}}checked="checked"{{/if}} data-permissions="{{updatePermission}}"/>' +
+							'<label for="canUpdate-{{cid}}-{{shareId}}">{{updatePermissionLabel}}</label>' +
 						'</span>' +
 					'</li>' +
 					'{{/unless}}{{/if}}' +
 					'{{#if deletePermissionPossible}}{{#unless isMailShare}}' +
 					'<li>' +
 						'<span class="shareOption menuitem">' +
-							'<input id="canDelete-{{cid}}-{{shareWith}}" type="checkbox" name="delete" class="permissions checkbox" {{#if hasDeletePermission}}checked="checked"{{/if}} data-permissions="{{deletePermission}}"/>' +
-							'<label for="canDelete-{{cid}}-{{shareWith}}">{{deletePermissionLabel}}</label>' +
+							'<input id="canDelete-{{cid}}-{{shareId}}" type="checkbox" name="delete" class="permissions checkbox" {{#if hasDeletePermission}}checked="checked"{{/if}} data-permissions="{{deletePermission}}"/>' +
+							'<label for="canDelete-{{cid}}-{{shareId}}">{{deletePermissionLabel}}</label>' +
 						'</span>' +
 					'</li>' +
 					'{{/unless}}{{/if}}' +
@@ -383,7 +383,7 @@
 
 			var _this = this;
 			this.getShareeList().forEach(function(sharee) {
-				var checkBoxId = 'canEdit-' + _this.cid + '-' + sharee.shareWith;
+				var checkBoxId = 'canEdit-' + _this.cid + '-' + sharee.shareId;
 				checkBoxId = '#' + checkBoxId.replace( /(:|\.|\[|\]|,|=|@|\/)/g, "\\$1");
 				var $edit = _this.$(checkBoxId);
 				if($edit.length === 1) {

--- a/core/js/tests/specs/sharedialogshareelistview.js
+++ b/core/js/tests/specs/sharedialogshareelistview.js
@@ -105,6 +105,21 @@ describe('OC.Share.ShareDialogShareeListView', function () {
 			expect(listView.$el.find("input[name='edit']").is(':indeterminate')).toEqual(true);
 		});
 
+		it('marks edit box as indeterminate when only some permissions are given for sharee with special characters', function () {
+			shareModel.set('shares', [{
+				id: 100,
+				item_source: 123,
+				permissions: 1 | OC.PERMISSION_UPDATE,
+				share_type: OC.Share.SHARE_TYPE_USER,
+				share_with: 'user _.@-\'',
+				share_with_displayname: 'User One',
+				itemType: 'folder'
+			}]);
+			shareModel.set('itemType', 'folder');
+			listView.render();
+			expect(listView.$el.find("input[name='edit']").is(':indeterminate')).toEqual(true);
+		});
+
 		it('Checks edit box when all permissions are given', function () {
 			shareModel.set('shares', [{
 				id: 100,
@@ -112,6 +127,21 @@ describe('OC.Share.ShareDialogShareeListView', function () {
 				permissions: 1 | OC.PERMISSION_CREATE | OC.PERMISSION_UPDATE | OC.PERMISSION_DELETE,
 				share_type: OC.Share.SHARE_TYPE_USER,
 				share_with: 'user1',
+				share_with_displayname: 'User One',
+				itemType: 'folder'
+			}]);
+			shareModel.set('itemType', 'folder');
+			listView.render();
+			expect(listView.$el.find("input[name='edit']").is(':checked')).toEqual(true);
+		});
+
+		it('Checks edit box when all permissions are given for sharee with special characters', function () {
+			shareModel.set('shares', [{
+				id: 100,
+				item_source: 123,
+				permissions: 1 | OC.PERMISSION_CREATE | OC.PERMISSION_UPDATE | OC.PERMISSION_DELETE,
+				share_type: OC.Share.SHARE_TYPE_USER,
+				share_with: 'user _.@-\'',
 				share_with_displayname: 'User One',
 				itemType: 'folder'
 			}]);


### PR DESCRIPTION
The ids of permission checkboxes for shares were generated using the `shareWith` field of the share. The `shareWith` field can contain spaces (as spaces are allowed, for example, in user or circle names), so this could cause the id attribute of the HTML element to contain spaces too, [which is forbidden by the HTML specification](https://www.w3.org/TR/html5/dom.html#element-attrdef-global-id).

It is not just a _formal_ issue, though; when the list was rendered, if the id contained a space the selector to get the checkbox element was wrong (as it ended being something like `#canEdit-view1-name with spaces`, which was therefore seen as _the element of type `spaces` that is a descendant of the element of type `with` that is in turn descendant of the element with id `canEdit-view1-name`_) and thus the initial state of the checkbox was not properly set; see first test case below.

Besides that, `shareWith` can contain too single quotes, which would even cause the jQuery selector to abort the search and leave the UI in an invalid state; see second test case below.

Instead of adding more cases to the regular expression to escape special characters and apply it too when the ids are created now the ids of permission checkboxes for shares are based on the `shareId` field instead of on `shareWith`, as `shareId` is expected to always contain compatible characters; due to that it is no longer needed to escape the special characters.

**How to test (1)**
- Create a user with the user name `user name with spaces`
- Open the Sharing tab in the sidebar of the Files app
- Share a file with that user

**Expected result:**
The file is shared and the _Can edit_ checkbox is checked; it is possible to check and uncheck it.

**Actual result:**
The file is shared but the _Can edit_ checkbox is not checked, and it is not possible to check and uncheck it.

**How to test (2)**
- Create a user with the id `user'`
- Open the Sharing tab in the sidebar of the Files app
- Share a file with that user

**Expected result:**
The file is shared and you can keep adding other shares.

**Actual result:**
The file is shared but the input field to search for other sharees is kept disabled. Reloading the page and opening the Sharing tab again does not even show the input field.
