### PR TITLE
Fix race condition when preparing upload folder

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -576,7 +576,6 @@ OC.Uploader.prototype = _.extend({
 	 * Clear uploads
 	 */
 	clear: function() {
-		this._uploads = {};
 		this._knownDirs = {};
 	},
 	/**
@@ -593,6 +592,19 @@ OC.Uploader.prototype = _.extend({
 			return this._uploads[data.uploadId];
 		}
 		return null;
+	},
+
+	/**
+	 * Removes an upload from the list of known uploads.
+	 *
+	 * @param {OC.FileUpload} upload the upload to remove.
+	 */
+	removeUpload: function(upload) {
+		if (!upload || !upload.data || !upload.data.uploadId) {
+			return;
+		}
+
+		delete this._uploads[upload.data.uploadId];
 	},
 
 	showUploadCancelMessage: _.debounce(function() {
@@ -959,6 +971,8 @@ OC.Uploader.prototype = _.extend({
 					}
 					self.log('fail', e, upload);
 
+					self.removeUpload(upload);
+
 					if (data.textStatus === 'abort') {
 						self.showUploadCancelMessage();
 					} else if (status === 412) {
@@ -995,6 +1009,8 @@ OC.Uploader.prototype = _.extend({
 					var upload = self.getUpload(data);
 					var that = $(this);
 					self.log('done', e, upload);
+
+					self.removeUpload(upload);
 
 					var status = upload.getResponseStatus();
 					if (status < 200 || status >= 300) {


### PR DESCRIPTION
Before any upload is submitted [the upload is registered in a list of known uploads](https://github.com/nextcloud/server/blob/bcfe8431b4c1a475a0fa8b1a003c378d91cc89e3/apps/files/js/file-upload.js#L535); this is needed to retrieve the upload object at several points of the upload process. When a chunked upload is submitted [first a directory to upload all the chunks is created](https://github.com/nextcloud/server/blob/bcfe8431b4c1a475a0fa8b1a003c378d91cc89e3/apps/files/js/file-upload.js#L237) and, [once that is done, the chunks are sent](https://github.com/nextcloud/server/blob/bcfe8431b4c1a475a0fa8b1a003c378d91cc89e3/apps/files/js/file-upload.js#L247); in order to send a chunk [the upload object needs to be retrieved from the list of known uploads](https://github.com/nextcloud/server/blob/bcfe8431b4c1a475a0fa8b1a003c378d91cc89e3/apps/files/js/file-upload.js#L1160).

When all the active uploads were finished the list of known uploads was cleared. However, an upload is not active until it actually starts sending the data, so while waiting for the upload directory to be created the upload is already in the list of known uploads yet not active. Due to all this, if the active uploads finished while another pending upload was waiting for the upload directory to be created that pending upload would be removed from the list of known uploads too, and once the directory was created and thus the chunks were sent [a field of a null upload object would be accessed](https://github.com/nextcloud/server/blob/bcfe8431b4c1a475a0fa8b1a003c378d91cc89e3/apps/files/js/file-upload.js#L1166) thus causing a failure.

Instead of removing all the known uploads at once when the active uploads finish now each upload is explicitly removed when it finishes.

**How to test**
Being a race condition sometimes this happens and sometimes it does not; it is necessary to add a `sleep(10)` to [`createDirectory` in DAV](https://github.com/nextcloud/server/blob/9d6d23d1f7f4cd8255e61c190afc507f1fe1bac6/apps/dav/lib/Connector/Sabre/Directory.php#L172) to be able to test this consistently. The instructions below assume that this hack was added.

- Open the _Files_ app
- Upload a file larger than 10MiB (so chunked uploads are used)
- Upload another file larger than 10MiB before the first one has finished (there is no need to wait for the first upload to actually start)

**Expected results**
The files are uploaded successfully (note that the progress bar is shown once the uploads actually start, so it will not be shown while waiting for the upload directory to be created).

**Actual result**
The first file is uploaded successfully; the second is not, and its progress bar is never hidden.

@nextcloud/javascript 
