### PR TITLE
Add appdata_path option to store appdata locally outside primary storage.

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -642,6 +642,7 @@ return array(
     'OC\\Files\\FileInfo' => $baseDir . '/lib/private/Files/FileInfo.php',
     'OC\\Files\\Filesystem' => $baseDir . '/lib/private/Files/Filesystem.php',
     'OC\\Files\\Mount\\CacheMountProvider' => $baseDir . '/lib/private/Files/Mount/CacheMountProvider.php',
+    'OC\\Files\\Mount\\AppdataMountProvider' => $baseDir . '/lib/private/Files/Mount/AppdataMountProvider.php',
     'OC\\Files\\Mount\\LocalHomeMountProvider' => $baseDir . '/lib/private/Files/Mount/LocalHomeMountProvider.php',
     'OC\\Files\\Mount\\Manager' => $baseDir . '/lib/private/Files/Mount/Manager.php',
     'OC\\Files\\Mount\\MountPoint' => $baseDir . '/lib/private/Files/Mount/MountPoint.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -672,6 +672,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Files\\FileInfo' => __DIR__ . '/../../..' . '/lib/private/Files/FileInfo.php',
         'OC\\Files\\Filesystem' => __DIR__ . '/../../..' . '/lib/private/Files/Filesystem.php',
         'OC\\Files\\Mount\\CacheMountProvider' => __DIR__ . '/../../..' . '/lib/private/Files/Mount/CacheMountProvider.php',
+        'OC\\Files\\Mount\\AppdataMountProvider' => __DIR__ . '/../../..' . '/lib/private/Files/Mount/AppdataMountProvider.php',
         'OC\\Files\\Mount\\LocalHomeMountProvider' => __DIR__ . '/../../..' . '/lib/private/Files/Mount/LocalHomeMountProvider.php',
         'OC\\Files\\Mount\\Manager' => __DIR__ . '/../../..' . '/lib/private/Files/Mount/Manager.php',
         'OC\\Files\\Mount\\MountPoint' => __DIR__ . '/../../..' . '/lib/private/Files/Mount/MountPoint.php',

--- a/lib/private/Files/AppData/AppData.php
+++ b/lib/private/Files/AppData/AppData.php
@@ -73,7 +73,12 @@ class AppData implements IAppData {
 				throw new \RuntimeException('no instance id!');
 			}
 
-			$name = 'appdata_' . $instanceId;
+			$appdataPath = $this->config->getValue('appdata_path', '');
+			if ($appdataPath !== '') {
+				$name = '/appdata.local/appdata_' . $instanceId;
+			} else {
+				$name = 'appdata_' . $instanceId;
+			}
 
 			try {
 				$appDataFolder = $this->rootFolder->get($name);

--- a/lib/private/Files/Mount/AppdataMountProvider.php
+++ b/lib/private/Files/Mount/AppdataMountProvider.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @copyright Copyright (c) <2018>, <Patrik Novotný> (<patrik.novotny@gmx.com>)
+ *
+ * @author Patrik Novotný <patrik.novotny@gmx.com>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Files\Mount;
+
+use OCP\Files\Config\IMountProvider;
+use OCP\Files\Storage\IStorageFactory;
+use OCP\IConfig;
+use OCP\IUser;
+
+/**
+ * Mount provider for custom appdata storages
+ */
+class AppdataMountProvider implements IMountProvider {
+    /**
+     * @var IConfig
+     */
+    private $config;
+
+    /**
+     * AppdataMountProvider constructor.
+     *
+     * @param IConfig $config
+     */
+    public function __construct(IConfig $config) {
+        $this->config = $config;
+    }
+
+    /**
+     * Get the appdata mount for a user
+     *
+     * @param IUser $user
+     * @param IStorageFactory $loader
+     * @return \OCP\Files\Mount\IMountPoint[]
+     */
+    public function getMountsForUser(IUser $user, IStorageFactory $loader) {
+        $appdataPath = $this->config->getSystemValue('appdata_path', '');
+        if ($appdataPath !== '') {
+            return [new MountPoint('\OC\Files\Storage\Local', '/appdata.local', ['datadir' => $appdataPath])];
+        } else {
+            return [];
+        }
+    }
+}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -722,6 +722,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 			$config = $c->getConfig();
 			$manager->registerProvider(new CacheMountProvider($config));
+			$manager->registerProvider(new AppdataMountProvider($config));
 			$manager->registerHomeProvider(new LocalHomeMountProvider());
 			$manager->registerHomeProvider(new ObjectHomeMountProvider($config));
 


### PR DESCRIPTION
Problem: Appdata are stored in primary storage. That means that (mostly even partial) unavailability of object storage (ex. S3) as primary storage causes Nextcloud web client to be unavailable as well.

Solution: Local directory is mounted to /appdata.local when 'appdata_path' is set in the configuration file.

Signed-off-by: Patrik Novotný patrik.novotny@gmx.com