### PR TITLE
Fix ellipsis in filename column

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -335,17 +335,20 @@ table td.filename .nametext, .modified, .column-last>span:first-child { float:le
 
 /* TODO fix usability bug (accidental file/folder selection) */
 table {
-	td.filename .nametext {
-		width: 0;
-		flex-grow: 1;
-		display: flex;
-		padding: 0;
-		overflow: hidden;
-		white-space: nowrap;
-		text-overflow: ellipsis;
-		height: 100%;
-		z-index: 10;
-		padding-right: 20px;
+	td.filename {
+		max-width: 0;
+		.nametext {
+			width: 0;
+			flex-grow: 1;
+			display: flex;
+			padding: 0;
+			overflow: hidden;
+			white-space: nowrap;
+			text-overflow: ellipsis;
+			height: 100%;
+			z-index: 10;
+			padding-right: 20px;
+		}
 	}
 
 	.uploadtext {

--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -282,17 +282,19 @@ table td.fileaction {
 	text-align: center;
 }
 table td.filename a.name {
+	display: flex;
 	position:relative; /* Firefox needs to explicitly have this default set … */
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
-	display: block;
 	height: 50px;
 	line-height: 50px;
 	padding: 0;
 }
 table td.filename .thumbnail-wrapper {
-	position: absolute;
-	width: 50px;
+	/* we need this to make sure flex is working inside a table cell */
+	width: 0;
+	min-width: 50px;
+	max-width: 50px;
 	height: 50px;
 }
 table td.filename .thumbnail-wrapper.icon-loading-small {
@@ -332,24 +334,24 @@ table td.filename .nametext, .modified, .column-last>span:first-child { float:le
 }
 
 /* TODO fix usability bug (accidental file/folder selection) */
-table td.filename .nametext {
-	position: absolute;
-	padding: 0;
-	padding-left: 55px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	width: 70%;
-	max-width: 800px;
-	height: 100%;
-	z-index: 10;
-}
-table td.filename .uploadtext {
-	position: absolute;
-	left: 55px;
-}
-/* ellipsis on file names */
-table td.filename .nametext .innernametext {
-	max-width: calc(100% - 100px) !important;
+table {
+	td.filename .nametext {
+		width: 0;
+		flex-grow: 1;
+		display: flex;
+		padding: 0;
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		height: 100%;
+		z-index: 10;
+		padding-right: 20px;
+	}
+
+	.uploadtext {
+		position: absolute;
+		left: 55px;
+	}
 }
 
 .hide-hidden-files #fileList tr.hidden-file,
@@ -371,57 +373,7 @@ table td.filename .nametext .innernametext {
 	text-overflow: ellipsis;
 	overflow: hidden;
 	position: relative;
-	display: inline-block;
 	vertical-align: top;
-}
-
-@media only screen and (min-width: 1500px) {
-	table td.filename .nametext .innernametext {
-		max-width: 790px;
-	}
-	.with-app-sidebar table td.filename .nametext .innernametext {
-		max-width: 390px;
-	}
-}
-@media only screen and (min-width: 1366px) and (max-width: 1500px) {
-	table td.filename .nametext .innernametext {
-		max-width: 660px;
-	}
-	.with-app-sidebar table td.filename .nametext .innernametext {
-		max-width: 290px;
-	}
-}
-@media only screen and (min-width: 1200px) and (max-width: 1366px) {
-	table td.filename .nametext .innernametext {
-		max-width: 500px;
-	}
-	.with-app-sidebar table td.filename .nametext .innernametext {
-		max-width: 230px;
-	}
-}
-@media only screen and (min-width: 1100px) and (max-width: 1200px) {
-	table td.filename .nametext .innernametext {
-		max-width: 400px;
-	}
-	.with-app-sidebar table td.filename .nametext .innernametext {
-		max-width: 230px;
-	}
-}
-@media only screen and (min-width: 1000px) and (max-width: 1100px) {
-	table td.filename .nametext .innernametext {
-		max-width: 310px;
-	}
-	.with-app-sidebar table td.filename .nametext .innernametext {
-		max-width: 230px;
-	}
-}
-@media only screen and (min-width: 768px) and (max-width: 1000px) {
-	table td.filename .nametext .innernametext {
-		max-width: 240px;
-	}
-	.with-app-sidebar table td.filename .nametext .innernametext {
-		max-width: 230px;
-	}
 }
 
 /* for smaller resolutions - see mobile.css */
@@ -490,8 +442,6 @@ table td.selection {
 
 /* File actions */
 .fileactions {
-	position: absolute;
-	right: 0;
 	z-index: 50;
 }
 

--- a/apps/files/css/mobile.scss
+++ b/apps/files/css/mobile.scss
@@ -28,12 +28,7 @@ table td {
 table.multiselect thead {
 	padding-left: 0;
 }
-
-/* restrict length of displayed filename to prevent overflow */
-table td.filename .nametext {
-	width: 100%;
-}
-
+	
 #fileList a.action.action-menu img {
 	padding-left: 0;
 }
@@ -44,11 +39,6 @@ table td.filename .nametext {
 /* hide text of the share action on mobile */
 #fileList a.action-share span:not(.icon) {
 	display: none !important;
-}
-
-/* ellipsis on file names */
-table td.filename .nametext .innernametext {
-	max-width: calc(100% - 175px) !important;
 }
 
 /* show the delete icon in name column in lower resolutions */


### PR DESCRIPTION
This PR moves the sizing of the filename column to a flexbox based layout. There is a small hack needed (defining a width of 0) to make sure that the auto table layout algorithm doesn't use the text width as minimum width for the table cell.

Besides that this approach seems a lot cleaner than before, as we don't need any fixed width rules for different browser sizes, that might break on certain ui changes. It is basically indipendent of the other table cells and the width of the file icon/file actions.

I've tested this on Chrome and Firefox, but my Windows VM doesn't boot right now so I would appreciate if someone could check IE/Edge. 

Fixes https://github.com/nextcloud/server/issues/8940

## files app

![image](https://user-images.githubusercontent.com/3404133/39006597-d501b006-4403-11e8-9a37-b3eb771cd231.png)

![image](https://user-images.githubusercontent.com/3404133/39006613-e505d27a-4403-11e8-8008-b54f8d00ea88.png)


## public shared folder

![image](https://user-images.githubusercontent.com/3404133/39006478-7018bcb6-4403-11e8-8a7c-39d9ac0fef90.png)

![image](https://user-images.githubusercontent.com/3404133/39006494-770019ac-4403-11e8-8739-4165da489aef.png)
