### PR TITLE
Convert theming app logo to PNG to show it properly in emails

### DIFF
--- a/apps/theming/lib/Controller/IconController.php
+++ b/apps/theming/lib/Controller/IconController.php
@@ -125,7 +125,7 @@ class IconController extends Controller {
 			$response = new FileDisplayResponse($iconFile, Http::STATUS_OK, ['Content-Type' => 'image/x-icon']);
 		} catch (NotFoundException $e) {
 		}
-		if ($iconFile === null && $this->themingDefaults->shouldReplaceIcons()) {
+		if ($iconFile === null && $this->imageManager->shouldReplaceIcons()) {
 			try {
 				$iconFile = $this->imageManager->getCachedImage('favIcon-' . $app);
 			} catch (NotFoundException $exception) {
@@ -161,7 +161,7 @@ class IconController extends Controller {
 			$response = new FileDisplayResponse($iconFile, Http::STATUS_OK, ['Content-Type' => 'image/x-icon']);
 		} catch (NotFoundException $e) {
 		}
-		if ($this->themingDefaults->shouldReplaceIcons()) {
+		if ($this->imageManager->shouldReplaceIcons()) {
 			try {
 				$iconFile = $this->imageManager->getCachedImage('touchIcon-' . $app);
 			} catch (NotFoundException $exception) {

--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -358,12 +358,13 @@ class ThemingController extends Controller {
 	 * @NoCSRFRequired
 	 *
 	 * @param string $key
+	 * @param bool $useSvg
 	 * @return FileDisplayResponse|NotFoundResponse
-	 * @throws \Exception
+	 * @throws NotPermittedException
 	 */
-	public function getImage(string $key, bool $asPng = false) {
+	public function getImage(string $key, bool $useSvg = true) {
 		try {
-			$file = $this->imageManager->getImage($key, $asPng);
+			$file = $this->imageManager->getImage($key, $useSvg);
 		} catch (NotFoundException $e) {
 			return new NotFoundResponse();
 		}
@@ -372,7 +373,7 @@ class ThemingController extends Controller {
 		$response->cacheFor(3600);
 		$response->addHeader('Content-Type', $this->config->getAppValue($this->appName, $key . 'Mime', ''));
 		$response->addHeader('Content-Disposition', 'attachment; filename="' . $key . '"');
-		if ($asPng) {
+		if (!$useSvg) {
 			$response->addHeader('Content-Type', 'image/png');
 		} else {
 			$response->addHeader('Content-Type', $this->config->getAppValue($this->appName, $key . 'Mime', ''));

--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -267,6 +267,8 @@ class ThemingController extends Controller {
 			$folder = $this->appData->newFolder('images');
 		}
 
+		$this->imageManager->delete($key);
+
 		$target = $folder->newFile($key);
 		$supportedFormats = ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml', 'image/svg'];
 		$detectedMimeType = mime_content_type($image['tmp_name']);
@@ -359,9 +361,9 @@ class ThemingController extends Controller {
 	 * @return FileDisplayResponse|NotFoundResponse
 	 * @throws \Exception
 	 */
-	public function getImage(string $key) {
+	public function getImage(string $key, bool $asPng = false) {
 		try {
-			$file = $this->imageManager->getImage($key);
+			$file = $this->imageManager->getImage($key, $asPng);
 		} catch (NotFoundException $e) {
 			return new NotFoundResponse();
 		}
@@ -370,6 +372,11 @@ class ThemingController extends Controller {
 		$response->cacheFor(3600);
 		$response->addHeader('Content-Type', $this->config->getAppValue($this->appName, $key . 'Mime', ''));
 		$response->addHeader('Content-Disposition', 'attachment; filename="' . $key . '"');
+		if ($asPng) {
+			$response->addHeader('Content-Type', 'image/png');
+		} else {
+			$response->addHeader('Content-Type', $this->config->getAppValue($this->appName, $key . 'Mime', ''));
+		}
 		return $response;
 	}
 

--- a/apps/theming/lib/IconBuilder.php
+++ b/apps/theming/lib/IconBuilder.php
@@ -35,19 +35,24 @@ class IconBuilder {
 	private $themingDefaults;
 	/** @var Util */
 	private $util;
+	/** @var ImageManager */
+	private $imageManager;
 
 	/**
 	 * IconBuilder constructor.
 	 *
 	 * @param ThemingDefaults $themingDefaults
 	 * @param Util $util
+	 * @param ImageManager $imageManager
 	 */
 	public function __construct(
 		ThemingDefaults $themingDefaults,
-		Util $util
+		Util $util,
+		ImageManager $imageManager
 	) {
 		$this->themingDefaults = $themingDefaults;
 		$this->util = $util;
+		$this->imageManager = $imageManager;
 	}
 
 	/**
@@ -55,7 +60,7 @@ class IconBuilder {
 	 * @return string|false image blob
 	 */
 	public function getFavicon($app) {
-		if (!$this->themingDefaults->shouldReplaceIcons()) {
+		if (!$this->imageManager->shouldReplaceIcons()) {
 			return false;
 		}
 		try {

--- a/apps/theming/lib/ImageManager.php
+++ b/apps/theming/lib/ImageManager.php
@@ -33,9 +33,6 @@ use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\IURLGenerator;
 
-/**
- * @property IURLGenerator urlGenerator
- */
 class ImageManager {
 
 	/** @var IConfig */
@@ -55,7 +52,7 @@ class ImageManager {
 	 * @param IConfig $config
 	 * @param IAppData $appData
 	 * @param IURLGenerator $urlGenerator
-	 * @param ThemingDefaults $themingDefaults
+	 * @param ICacheFactory $cacheFactory
 	 */
 	public function __construct(IConfig $config,
 								IAppData $appData,
@@ -97,10 +94,10 @@ class ImageManager {
 	 */
 	public function getImage(string $key, bool $useSvg = false): ISimpleFile {
 		$logo = $this->config->getAppValue('theming', $key . 'Mime', false);
-		if ($logo === false) {
+		$folder = $this->appData->getFolder('images');
+		if ($logo === false || !$folder->fileExists($key)) {
 			throw new NotFoundException();
 		}
-		$folder = $this->appData->getFolder('images');
 		if (!$useSvg && $this->shouldReplaceIcons()) {
 			if (!$folder->fileExists($key . '.png')) {
 				try {

--- a/apps/theming/lib/ImageManager.php
+++ b/apps/theming/lib/ImageManager.php
@@ -65,10 +65,10 @@ class ImageManager {
 		$this->cacheFactory = $cacheFactory;
 	}
 
-	public function getImageUrl(string $key): string {
+	public function getImageUrl(string $key, bool $useSvg = true): string {
 		$cacheBusterCounter = $this->config->getAppValue('theming', 'cachebuster', '0');
 		try {
-			$this->getImage($key);
+			$image = $this->getImage($key, $useSvg);
 			return $this->urlGenerator->linkToRoute('theming.Theming.getImage', [ 'key' => $key ]) . '?v=' . $cacheBusterCounter;
 		} catch (NotFoundException $e) {
 		}
@@ -83,16 +83,18 @@ class ImageManager {
 		}
 	}
 
-	public function getImageUrlAbsolute(string $key): string {
-		return $this->urlGenerator->getAbsoluteURL($this->getImageUrl($key));
+	public function getImageUrlAbsolute(string $key, bool $useSvg = true): string {
+		return $this->urlGenerator->getAbsoluteURL($this->getImageUrl($key, $useSvg));
 	}
 
 	/**
-	 * @param $key
+	 * @param string $key
+	 * @param bool $useSvg
 	 * @return ISimpleFile
 	 * @throws NotFoundException
+	 * @throws NotPermittedException
 	 */
-	public function getImage(string $key, bool $useSvg = false): ISimpleFile {
+	public function getImage(string $key, bool $useSvg = true): ISimpleFile {
 		$logo = $this->config->getAppValue('theming', $key . 'Mime', false);
 		$folder = $this->appData->getFolder('images');
 		if ($logo === false || !$folder->fileExists($key)) {

--- a/apps/theming/lib/ImageManager.php
+++ b/apps/theming/lib/ImageManager.php
@@ -181,6 +181,7 @@ class ImageManager {
 	}
 
 	public function delete(string $key) {
+		/* ignore exceptions, since we don't want to fail hard if something goes wrong during cleanup */
 		try {
 			$file = $this->appData->getFolder('images')->getFile($key);
 			$file->delete();

--- a/apps/theming/lib/Settings/Admin.php
+++ b/apps/theming/lib/Settings/Admin.php
@@ -81,7 +81,7 @@ class Admin implements ISettings {
 			'slogan'          => $this->themingDefaults->getSlogan(),
 			'color'           => $this->themingDefaults->getColorPrimary(),
 			'uploadLogoRoute' => $this->urlGenerator->linkToRoute('theming.Theming.uploadImage'),
-			'canThemeIcons'   => $this->themingDefaults->shouldReplaceIcons(),
+			'canThemeIcons'   => $this->imageManager->shouldReplaceIcons(),
 			'iconDocs'        => $this->urlGenerator->linkToDocs('admin-theming-icons'),
 			'images'		  => $this->imageManager->getCustomImages(),
 			'imprintUrl'      => $this->themingDefaults->getImprintUrl(),

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -205,7 +205,7 @@ class ThemingDefaults extends \OC_Defaults {
 
 		$logoExists = true;
 		try {
-			$this->imageManager->getImage('logo');
+			$this->imageManager->getImage('logo', $useSvg);
 		} catch (\Exception $e) {
 			$logoExists = false;
 		}
@@ -221,7 +221,7 @@ class ThemingDefaults extends \OC_Defaults {
 			return $logo . '?v=' . $cacheBusterCounter;
 		}
 
-		return $this->urlGenerator->linkToRoute('theming.Theming.getImage', [ 'key' => 'logo' ]) . '?v=' . $cacheBusterCounter;
+		return $this->urlGenerator->linkToRoute('theming.Theming.getImage', [ 'key' => 'logo', 'useSvg' => $useSvg, 'v' => $cacheBusterCounter ]);
 	}
 
 	/**
@@ -339,23 +339,12 @@ class ThemingDefaults extends \OC_Defaults {
 	 * Check if Imagemagick is enabled and if SVG is supported
 	 * otherwise we can't render custom icons
 	 *
+	 * TODO: move to usage of image manager
+	 *
 	 * @return bool
 	 */
 	public function shouldReplaceIcons() {
-		$cache = $this->cacheFactory->createDistributed('theming-' . $this->urlGenerator->getBaseUrl());
-		if($value = $cache->get('shouldReplaceIcons')) {
-			return (bool)$value;
-		}
-		$value = false;
-		if(extension_loaded('imagick')) {
-			$checkImagick = new \Imagick();
-			if (count($checkImagick->queryFormats('SVG')) >= 1) {
-				$value = true;
-			}
-			$checkImagick->clear();
-		}
-		$cache->set('shouldReplaceIcons', $value);
-		return $value;
+		return $this->imageManager->shouldReplaceIcons();
 	}
 
 	/**

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -317,10 +317,10 @@ class ThemingDefaults extends \OC_Defaults {
 			$customFavicon = null;
 		}
 
-		if ($image === 'favicon.ico' && ($customFavicon !== null || $this->shouldReplaceIcons())) {
+		if ($image === 'favicon.ico' && ($customFavicon !== null || $this->imageManager->shouldReplaceIcons())) {
 			return $this->urlGenerator->linkToRoute('theming.Icon.getFavicon', ['app' => $app]) . '?v=' . $cacheBusterValue;
 		}
-		if ($image === 'favicon-touch.png' && ($customFavicon !== null || $this->shouldReplaceIcons())) {
+		if ($image === 'favicon-touch.png' && ($customFavicon !== null || $this->imageManager->shouldReplaceIcons())) {
 			return $this->urlGenerator->linkToRoute('theming.Icon.getTouchIcon', ['app' => $app]) . '?v=' . $cacheBusterValue;
 		}
 		if ($image === 'manifest.json') {
@@ -334,19 +334,7 @@ class ThemingDefaults extends \OC_Defaults {
 		}
 		return false;
 	}
-
-	/**
-	 * Check if Imagemagick is enabled and if SVG is supported
-	 * otherwise we can't render custom icons
-	 *
-	 * TODO: move to usage of image manager
-	 *
-	 * @return bool
-	 */
-	public function shouldReplaceIcons() {
-		return $this->imageManager->shouldReplaceIcons();
-	}
-
+	
 	/**
 	 * Increases the cache buster key
 	 */

--- a/apps/theming/tests/Controller/IconControllerTest.php
+++ b/apps/theming/tests/Controller/IconControllerTest.php
@@ -118,7 +118,7 @@ class IconControllerTest extends TestCase {
 			->method('getImage')
 			->with('favicon')
 			->will($this->throwException(new NotFoundException()));
-		$this->themingDefaults->expects($this->any())
+		$this->imageManager->expects($this->any())
 			->method('shouldReplaceIcons')
 			->willReturn(true);
 		$this->imageManager->expects($this->once())
@@ -142,7 +142,7 @@ class IconControllerTest extends TestCase {
 			->method('getImage')
 			->with('favicon')
 			->will($this->throwException(new NotFoundException()));
-		$this->themingDefaults->expects($this->any())
+		$this->imageManager->expects($this->any())
 			->method('shouldReplaceIcons')
 			->willReturn(false);
 		$fallbackLogo = \OC::$SERVERROOT . '/core/img/favicon.png';
@@ -163,10 +163,13 @@ class IconControllerTest extends TestCase {
 		if (count($checkImagick->queryFormats('SVG')) < 1) {
 			$this->markTestSkipped('No SVG provider present.');
 		}
-		$this->themingDefaults->expects($this->any())
+
+		$this->imageManager->expects($this->once())
+			->method('getImage')
+			->will($this->throwException(new NotFoundException()));
+		$this->imageManager->expects($this->any())
 			->method('shouldReplaceIcons')
 			->willReturn(true);
-
 		$this->iconBuilder->expects($this->once())
 			->method('getTouchIcon')
 			->with('core')
@@ -189,7 +192,7 @@ class IconControllerTest extends TestCase {
 			->method('getImage')
 			->with('favicon')
 			->will($this->throwException(new NotFoundException()));
-		$this->themingDefaults->expects($this->any())
+		$this->imageManager->expects($this->any())
 			->method('shouldReplaceIcons')
 			->willReturn(false);
 		$fallbackLogo = \OC::$SERVERROOT . '/core/img/favicon-touch.png';

--- a/apps/theming/tests/Controller/ThemingControllerTest.php
+++ b/apps/theming/tests/Controller/ThemingControllerTest.php
@@ -688,7 +688,7 @@ class ThemingControllerTest extends TestCase {
 			->method('getImage')
 			->willReturn($file);
 		$this->config
-			->expects($this->once())
+			->expects($this->any())
 			->method('getAppValue')
 			->with('theming', 'logoMime', '')
 			->willReturn('text/svg');
@@ -716,7 +716,7 @@ class ThemingControllerTest extends TestCase {
 			->willReturn($file);
 
 		$this->config
-			->expects($this->once())
+			->expects($this->any())
 			->method('getAppValue')
 			->with('theming', 'backgroundMime', '')
 			->willReturn('image/png');

--- a/apps/theming/tests/IconBuilderTest.php
+++ b/apps/theming/tests/IconBuilderTest.php
@@ -27,6 +27,7 @@ namespace OCA\Theming\Tests;
 
 use OC\Files\AppData\AppData;
 use OCA\Theming\IconBuilder;
+use OCA\Theming\ImageManager;
 use OCA\Theming\ThemingDefaults;
 use OCA\Theming\Util;
 use OCP\App\IAppManager;
@@ -45,6 +46,8 @@ class IconBuilderTest extends TestCase {
 	protected $themingDefaults;
 	/** @var Util */
 	protected $util;
+	/** @var ImageManager */
+	protected $imageManager;
 	/** @var IconBuilder */
 	protected $iconBuilder;
 	/** @var IAppManager */
@@ -53,13 +56,13 @@ class IconBuilderTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
+		$this->config = $this->createMock(IConfig::class);
 		$this->appData = $this->createMock(AppData::class);
-		$this->themingDefaults = $this->getMockBuilder('OCA\Theming\ThemingDefaults')
-			->disableOriginalConstructor()->getMock();
-		$this->appManager = $this->getMockBuilder('OCP\App\IAppManager')->getMock();
+		$this->themingDefaults = $this->createMock(ThemingDefaults::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->imageManager = $this->createMock(ImageManager::class);
 		$this->util = new Util($this->config, $this->appManager, $this->appData);
-		$this->iconBuilder = new IconBuilder($this->themingDefaults, $this->util);
+		$this->iconBuilder = new IconBuilder($this->themingDefaults, $this->util, $this->imageManager);
 	}
 
 	private function checkImagick() {
@@ -152,7 +155,7 @@ class IconBuilderTest extends TestCase {
 	 */
 	public function testGetFavicon($app, $color, $file) {
 		$this->checkImagick();
-		$this->themingDefaults->expects($this->once())
+		$this->imageManager->expects($this->once())
 			->method('shouldReplaceIcons')
 			->willReturn(true);
 		$this->themingDefaults->expects($this->once())
@@ -183,8 +186,8 @@ class IconBuilderTest extends TestCase {
 		$this->checkImagick();
 		$this->expectException(Warning::class);
 		$util = $this->getMockBuilder(Util::class)->disableOriginalConstructor()->getMock();
-		$iconBuilder = new IconBuilder($this->themingDefaults, $util);
-		$this->themingDefaults->expects($this->once())
+		$iconBuilder = new IconBuilder($this->themingDefaults, $util, $this->imageManager);
+		$this->imageManager->expects($this->once())
 			->method('shouldReplaceIcons')
 			->willReturn(true);
 		$util->expects($this->once())
@@ -197,7 +200,7 @@ class IconBuilderTest extends TestCase {
 		$this->checkImagick();
 		$this->expectException(Warning::class);
 		$util = $this->getMockBuilder(Util::class)->disableOriginalConstructor()->getMock();
-		$iconBuilder = new IconBuilder($this->themingDefaults, $util);
+		$iconBuilder = new IconBuilder($this->themingDefaults, $util, $this->imageManager);
 		$util->expects($this->once())
 			->method('getAppIcon')
 			->willReturn('notexistingfile');
@@ -208,7 +211,7 @@ class IconBuilderTest extends TestCase {
 		$this->checkImagick();
 		$this->expectException(Warning::class);
 		$util = $this->getMockBuilder(Util::class)->disableOriginalConstructor()->getMock();
-		$iconBuilder = new IconBuilder($this->themingDefaults, $util);
+		$iconBuilder = new IconBuilder($this->themingDefaults, $util, $this->imageManager);
 		$util->expects($this->once())
 			->method('getAppImage')
 			->willReturn('notexistingfile');

--- a/apps/theming/tests/ImageManagerTest.php
+++ b/apps/theming/tests/ImageManagerTest.php
@@ -24,6 +24,7 @@
 namespace OCA\Theming\Tests;
 
 use OCA\Theming\ImageManager;
+use OCA\Theming\ThemingDefaults;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\IConfig;
 use OCP\IURLGenerator;

--- a/apps/theming/tests/ImageManagerTest.php
+++ b/apps/theming/tests/ImageManagerTest.php
@@ -126,7 +126,7 @@ class ImageManagerTest extends TestCase {
 		$this->urlGenerator->expects($this->once())
 			->method('linkToRoute')
 			->willReturn('url-to-image');
-		$this->assertEquals('url-to-image?v=0', $this->imageManager->getImageUrl('logo'));
+		$this->assertEquals('url-to-image?v=0', $this->imageManager->getImageUrl('logo', false));
 	}
 
 	public function testGetImageUrlDefault() {
@@ -164,7 +164,7 @@ class ImageManagerTest extends TestCase {
 		$this->urlGenerator->expects($this->at(2))
 			->method('getAbsoluteUrl')
 			->willReturn('url-to-image-absolute?v=0');
-		$this->assertEquals('url-to-image-absolute?v=0', $this->imageManager->getImageUrlAbsolute('logo'));
+		$this->assertEquals('url-to-image-absolute?v=0', $this->imageManager->getImageUrlAbsolute('logo', false));
 
 	}
 
@@ -175,7 +175,7 @@ class ImageManagerTest extends TestCase {
 			->willReturn('png');
 		$file = $this->createMock(ISimpleFile::class);
 		$this->mockGetImage('logo', $file);
-		$this->assertEquals($file, $this->imageManager->getImage('logo'));
+		$this->assertEquals($file, $this->imageManager->getImage('logo', false));
 	}
 
 	/**

--- a/apps/theming/tests/ImageManagerTest.php
+++ b/apps/theming/tests/ImageManagerTest.php
@@ -66,10 +66,10 @@ class ImageManagerTest extends TestCase {
 			$this->markTestSkipped('Imagemagick is required for dynamic icon generation.');
 		}
 		$checkImagick = new \Imagick();
-		if (count($checkImagick->queryFormats('SVG')) < 1) {
+		if (empty($checkImagick->queryFormats('SVG'))) {
 			$this->markTestSkipped('No SVG provider present.');
 		}
-		if (count($checkImagick->queryFormats('PNG')) < 1) {
+		if (empty($checkImagick->queryFormats('PNG'))) {
 			$this->markTestSkipped('No PNG provider present.');
 		}
 	}

--- a/apps/theming/tests/ImageManagerTest.php
+++ b/apps/theming/tests/ImageManagerTest.php
@@ -28,6 +28,7 @@ use OCA\Theming\ThemingDefaults;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\ICacheFactory;
 use OCP\IConfig;
+use OCP\ILogger;
 use OCP\IURLGenerator;
 use Test\TestCase;
 use OCP\Files\SimpleFS\ISimpleFolder;
@@ -46,6 +47,8 @@ class ImageManagerTest extends TestCase {
 	private $urlGenerator;
 	/** @var ICacheFactory|\PHPUnit_Framework_MockObject_MockObject */
 	private $cacheFactory;
+	/** @var ILogger|\PHPUnit_Framework_MockObject_MockObject */
+	private $logger;
 
 	protected function setUp() {
 		parent::setUp();
@@ -53,11 +56,13 @@ class ImageManagerTest extends TestCase {
 		$this->appData = $this->createMock(IAppData::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->logger = $this->createMock(ILogger::class);
 		$this->imageManager = new ImageManager(
 			$this->config,
 			$this->appData,
 			$this->urlGenerator,
-			$this->cacheFactory
+			$this->cacheFactory,
+			$this->logger
 		);
 	}
 

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -604,7 +604,7 @@ class ThemingDefaultsTest extends TestCase {
 		$this->urlGenerator->expects($this->once())
 			->method('linkToRoute')
 			->with('theming.Theming.getImage')
-			->willReturn('custom-logo');
+			->willReturn('custom-logo?v=0');
 		$this->assertEquals('custom-logo' . '?v=0', $this->template->getLogo());
 	}
 

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -954,7 +954,7 @@ class Server extends ServerContainer implements IServerContainer {
 					$c->getURLGenerator(),
 					$c->getMemCacheFactory(),
 					new Util($c->getConfig(), $this->getAppManager(), $c->getAppDataDir('theming')),
-					new ImageManager($c->getConfig(), $c->getAppDataDir('theming'), $c->getURLGenerator(), $this->getMemCacheFactory()),
+					new ImageManager($c->getConfig(), $c->getAppDataDir('theming'), $c->getURLGenerator(), $this->getMemCacheFactory(), $this->getLogger()),
 					$c->getAppManager()
 				);
 			}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -954,7 +954,7 @@ class Server extends ServerContainer implements IServerContainer {
 					$c->getURLGenerator(),
 					$c->getMemCacheFactory(),
 					new Util($c->getConfig(), $this->getAppManager(), $c->getAppDataDir('theming')),
-					new ImageManager($c->getConfig(), $c->getAppDataDir('theming'), $c->getURLGenerator()),
+					new ImageManager($c->getConfig(), $c->getAppDataDir('theming'), $c->getURLGenerator(), $this->getMemCacheFactory()),
 					$c->getAppManager()
 				);
 			}


### PR DESCRIPTION
fixes https://github.com/nextcloud/server/issues/8627

This change will add support for a `$useSvg` parameter to the theming app, so that other parts of the code (like the MailTemplate) can request an image that is not an SVG. This is required for some email clients.

As for the other svg conversion stuff, it requires Imagick with svg support being installed.