### PR TITLE
Fixed disabled users query

### DIFF
--- a/lib/private/Group/Backend.php
+++ b/lib/private/Group/Backend.php
@@ -39,6 +39,7 @@ abstract class Backend implements \OCP\GroupInterface {
 		self::ADD_TO_GROUP => 'addToGroup',
 		self::REMOVE_FROM_GOUP => 'removeFromGroup',
 		self::COUNT_USERS => 'countUsersInGroup',
+		self::COUNT_DISABLED => 'countDisabledInGroup',
 		self::GROUP_DETAILS => 'getGroupDetails',
 		self::IS_ADMIN => 'isAdmin',
 	];

--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -359,4 +359,31 @@ class Database extends Backend {
 		return $count;
 	}
 
+	/**
+	 * get the number of disabled users in a group
+	 *
+	 * @param string $search
+	 * @return int|bool
+	 */
+	public function countDisabledInGroup($gid) {
+		$this->fixDI();
+		
+		$query = $this->dbConn->getQueryBuilder();
+		$query->select($queryBuilder->createFunction('COUNT(*)'))
+			->from('preferences')
+			->where($query->expr()->eq('appid', $queryBuilder->createNamedParameter('core')))
+			->andWhere($query->expr()->eq('configkey', $queryBuilder->createNamedParameter('enabled')))
+			->andWhere($query->expr()->eq('configvalue', $queryBuilder->createNamedParameter('false'), IQueryBuilder::PARAM_STR));
+
+		$result = $query->execute();
+		$result = (int)$result->fetchColumn();
+		$query->closeCursor();
+
+
+		if ($count !== false) {
+			$count = (int)$count;
+		}
+		return $count;
+	}
+
 }

--- a/lib/private/Group/Group.php
+++ b/lib/private/Group/Group.php
@@ -237,6 +237,26 @@ class Group implements IGroup {
 	}
 
 	/**
+	 * returns the number of disabled users
+	 *
+	 * @return int|bool
+	 */
+	public function countDisabled() {
+		$users = false;
+		foreach ($this->backends as $backend) {
+			if($backend->implementsActions(\OC\Group\Backend::COUNT_DISABLED)) {
+				if($users === false) {
+					//we could directly add to a bool variable, but this would
+					//be ugly
+					$users = 0;
+				}
+				$users += $backend->countUsersInGroup($this->gid);
+			}
+		}
+		return $users;
+	}
+
+	/**
 	 * search for users in the group by displayname
 	 *
 	 * @param string $search

--- a/lib/private/Group/MetaData.php
+++ b/lib/private/Group/MetaData.php
@@ -29,7 +29,6 @@ namespace OC\Group;
 
 use OCP\IUserSession;
 use OCP\IGroupManager;
-use OCP\IUserManager;
 
 class MetaData {
 	const SORT_NONE = 0;
@@ -44,8 +43,6 @@ class MetaData {
 	protected $metaData = array();
 	/** @var IGroupManager */
 	protected $groupManager;
-	/** @var IUserManager */
-	protected $userManager;
 	/** @var bool */
 	protected $sorting = false;
 	/** @var IUserSession */
@@ -62,13 +59,11 @@ class MetaData {
 			$user,
 			$isAdmin,
 			IGroupManager $groupManager,
-			IUserManager $userManager,
 			IUserSession $userSession
 			) {
 		$this->user = $user;
 		$this->isAdmin = (bool)$isAdmin;
 		$this->groupManager = $groupManager;
-		$this->userManager = $userManager;
 		$this->userSession = $userSession;
 	}
 

--- a/lib/private/Group/MetaData.php
+++ b/lib/private/Group/MetaData.php
@@ -162,14 +162,14 @@ class MetaData {
 	 * creates an array containing the group meta data
 	 * @param \OCP\IGroup $group
 	 * @param string $userSearch
-	 * @return array with the keys 'id', 'name' and 'usercount'
+	 * @return array with the keys 'id', 'name', 'usercount' and 'disabled'
 	 */
 	private function generateGroupMetaData(\OCP\IGroup $group, $userSearch) {
 		return array(
 				'id' => $group->getGID(),
 				'name' => $group->getDisplayName(),
 				'usercount' => $this->sorting === self::SORT_USERCOUNT ? $group->count($userSearch) : 0,
-				'disabled' => $this->userManager->countDisabledUsersOfGroups([$group->getGID()])
+				'disabled' => $group->countDisabled()
 			);
 	}
 

--- a/lib/private/Group/MetaData.php
+++ b/lib/private/Group/MetaData.php
@@ -28,6 +28,8 @@
 namespace OC\Group;
 
 use OCP\IUserSession;
+use OCP\IGroupManager;
+use OCP\IUserManager;
 
 class MetaData {
 	const SORT_NONE = 0;
@@ -40,8 +42,10 @@ class MetaData {
 	protected $isAdmin;
 	/** @var array */
 	protected $metaData = array();
-	/** @var \OCP\IGroupManager */
+	/** @var IGroupManager */
 	protected $groupManager;
+	/** @var IUserManager */
+	protected $userManager;
 	/** @var bool */
 	protected $sorting = false;
 	/** @var IUserSession */
@@ -50,18 +54,21 @@ class MetaData {
 	/**
 	 * @param string $user the uid of the current user
 	 * @param bool $isAdmin whether the current users is an admin
-	 * @param \OCP\IGroupManager $groupManager
+	 * @param IGroupManager $groupManager
+	 * @param IUserManager $userManager
 	 * @param IUserSession $userSession
 	 */
 	public function __construct(
 			$user,
 			$isAdmin,
-			\OCP\IGroupManager $groupManager,
+			IGroupManager $groupManager,
+			IUserManager $userManager,
 			IUserSession $userSession
 			) {
 		$this->user = $user;
 		$this->isAdmin = (bool)$isAdmin;
 		$this->groupManager = $groupManager;
+		$this->userManager = $userManager;
 		$this->userSession = $userSession;
 	}
 
@@ -162,6 +169,7 @@ class MetaData {
 				'id' => $group->getGID(),
 				'name' => $group->getDisplayName(),
 				'usercount' => $this->sorting === self::SORT_USERCOUNT ? $group->count($userSearch) : 0,
+				'disabled' => $this->userManager->countDisabledUsersOfGroups([$group->getGID()])
 			);
 	}
 

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -425,7 +425,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @return int
 	 * @since 12.0.0
 	 */
-	public function countDisabledUsers() {
+	public function countDisabledUsers():int {
 		$queryBuilder = \OC::$server->getDatabaseConnection()->getQueryBuilder();
 		$queryBuilder->select($queryBuilder->createFunction('COUNT(*)'))
 			->from('preferences')
@@ -448,7 +448,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @return int
 	 * @since 14.0.0
 	 */
-	public function countDisabledUsersOfGroups(array $groups) {
+	public function countDisabledUsersOfGroups(array $groups):int {
 		$queryBuilder = \OC::$server->getDatabaseConnection()->getQueryBuilder();
 		$queryBuilder->select($queryBuilder->createFunction('COUNT(Distinct uid)'))
 			->from('preferences', 'p')

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -445,7 +445,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * returns how many users are disabled in the requested groups
 	 *
 	 * @return int
-	 * @since 12.0.0
+	 * @since 14.0.0
 	 */
 	public function countDisabledUsersOfGroups(array $groups) {
 		$queryBuilder = \OC::$server->getDatabaseConnection()->getQueryBuilder();

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -420,7 +420,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	}
 
 	/**
-	 * returns how many users have logged in once
+	 * returns how many users are disabled
 	 *
 	 * @return int
 	 * @since 12.0.0
@@ -432,6 +432,30 @@ class Manager extends PublicEmitter implements IUserManager {
 			->where($queryBuilder->expr()->eq('appid', $queryBuilder->createNamedParameter('core')))
 			->andWhere($queryBuilder->expr()->eq('configkey', $queryBuilder->createNamedParameter('enabled')))
 			->andWhere($queryBuilder->expr()->eq('configvalue', $queryBuilder->createNamedParameter('false'), IQueryBuilder::PARAM_STR));
+
+		$query = $queryBuilder->execute();
+
+		$result = (int)$query->fetchColumn();
+		$query->closeCursor();
+
+		return $result;
+	}
+
+	/**
+	 * returns how many users are disabled in the requested groups
+	 *
+	 * @return int
+	 * @since 12.0.0
+	 */
+	public function countDisabledUsersOfGroups(array $groups) {
+		$queryBuilder = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$queryBuilder->select($queryBuilder->createFunction('COUNT(Distinct uid)'))
+			->from('preferences', 'p')
+			->innerJoin('p', 'group_user', 'g', 'p.userid = g.uid')
+			->where($queryBuilder->expr()->eq('appid', $queryBuilder->createNamedParameter('core')))
+			->andWhere($queryBuilder->expr()->eq('configkey', $queryBuilder->createNamedParameter('enabled')))
+			->andWhere($queryBuilder->expr()->eq('configvalue', $queryBuilder->createNamedParameter('false'), IQueryBuilder::PARAM_STR))
+			->andWhere($queryBuilder->expr()->in('gid', $queryBuilder->createNamedParameter(implode(',', $groups))));
 
 		$query = $queryBuilder->execute();
 

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -420,28 +420,6 @@ class Manager extends PublicEmitter implements IUserManager {
 	}
 
 	/**
-	 * returns how many users are disabled
-	 *
-	 * @return int
-	 * @since 12.0.0
-	 */
-	public function countDisabledUsers():int {
-		$queryBuilder = \OC::$server->getDatabaseConnection()->getQueryBuilder();
-		$queryBuilder->select($queryBuilder->createFunction('COUNT(*)'))
-			->from('preferences')
-			->where($queryBuilder->expr()->eq('appid', $queryBuilder->createNamedParameter('core')))
-			->andWhere($queryBuilder->expr()->eq('configkey', $queryBuilder->createNamedParameter('enabled')))
-			->andWhere($queryBuilder->expr()->eq('configvalue', $queryBuilder->createNamedParameter('false'), IQueryBuilder::PARAM_STR));
-
-		$query = $queryBuilder->execute();
-
-		$result = (int)$query->fetchColumn();
-		$query->closeCursor();
-
-		return $result;
-	}
-
-	/**
 	 * returns how many users are disabled in the requested groups
 	 *
 	 * @param array $groups groupids to search
@@ -456,7 +434,7 @@ class Manager extends PublicEmitter implements IUserManager {
 			->where($queryBuilder->expr()->eq('appid', $queryBuilder->createNamedParameter('core')))
 			->andWhere($queryBuilder->expr()->eq('configkey', $queryBuilder->createNamedParameter('enabled')))
 			->andWhere($queryBuilder->expr()->eq('configvalue', $queryBuilder->createNamedParameter('false'), IQueryBuilder::PARAM_STR))
-			->andWhere($queryBuilder->expr()->in('gid', $queryBuilder->createNamedParameter(implode(',', $groups))));
+			->andWhere($queryBuilder->expr()->in('gid', $queryBuilder->createNamedParameter($groups, IQueryBuilder::PARAM_STR_ARRAY)));
 
 		$query = $queryBuilder->execute();
 

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -444,6 +444,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	/**
 	 * returns how many users are disabled in the requested groups
 	 *
+	 * @param array $groups groupids to search
 	 * @return int
 	 * @since 14.0.0
 	 */

--- a/lib/public/IGroup.php
+++ b/lib/public/IGroup.php
@@ -101,6 +101,13 @@ interface IGroup {
 	public function count($search = '');
 
 	/**
+	 * returns the number of disabled users
+	 *
+	 * @since 14.0.0
+	 */
+	public function countDisabled();
+
+	/**
 	 * search for users in the group by displayname
 	 *
 	 * @param string $search

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -162,23 +162,6 @@ interface IUserManager {
 	public function callForAllUsers(\Closure $callback, $search = '');
 
 	/**
-	 * returns how many users are disabled
-	 *
-	 * @return int
-	 * @since 12.0.0
-	 */
-	public function countDisabledUsers():int;
-
-	/**
-	 * returns how many users are disabled in the requested groups
-	 *
-	 * @param array $groups groupids to search
-	 * @return int
-	 * @since 14.0.0
-	 */
-	public function countDisabledUsersOfGroups(array $groups):int;
-
-	/**
 	 * returns how many users have logged in once
 	 *
 	 * @return int

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -167,7 +167,7 @@ interface IUserManager {
 	 * @return int
 	 * @since 12.0.0
 	 */
-	public function countDisabledUsers();
+	public function countDisabledUsers():int;
 
 	/**
 	 * returns how many users are disabled in the requested groups
@@ -176,7 +176,7 @@ interface IUserManager {
 	 * @return int
 	 * @since 14.0.0
 	 */
-	public function countDisabledUsersOfGroups(array $groups);
+	public function countDisabledUsersOfGroups(array $groups):int;
 
 	/**
 	 * returns how many users have logged in once

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -162,6 +162,14 @@ interface IUserManager {
 	public function callForAllUsers(\Closure $callback, $search = '');
 
 	/**
+	 * returns how many users are disabled
+	 *
+	 * @return int
+	 * @since 12.0.0
+	 */
+	public function countDisabledUsers():int;
+
+	/**
 	 * returns how many users have logged in once
 	 *
 	 * @return int

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -162,12 +162,21 @@ interface IUserManager {
 	public function callForAllUsers(\Closure $callback, $search = '');
 
 	/**
-	 * returns how many users have logged in once
+	 * returns how many users are disabled
 	 *
 	 * @return int
-	 * @since 11.0.0
+	 * @since 12.0.0
 	 */
 	public function countDisabledUsers();
+
+	/**
+	 * returns how many users are disabled in the requested groups
+	 *
+	 * @param array $groups groupids to search
+	 * @return int
+	 * @since 14.0.0
+	 */
+	public function countDisabledUsersOfGroups(array $groups);
 
 	/**
 	 * returns how many users have logged in once

--- a/settings/Controller/GroupsController.php
+++ b/settings/Controller/GroupsController.php
@@ -32,6 +32,7 @@ use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IUserManager;
 use OCP\IUserSession;
 
 /**
@@ -40,6 +41,8 @@ use OCP\IUserSession;
 class GroupsController extends Controller {
 	/** @var IGroupManager */
 	private $groupManager;
+	/** @var IUserManager */
+	private $userManager;
 	/** @var IL10N */
 	private $l10n;
 	/** @var IUserSession */
@@ -58,11 +61,13 @@ class GroupsController extends Controller {
 	public function __construct($appName,
 								IRequest $request,
 								IGroupManager $groupManager,
+								IUserManager $userManager,
 								IUserSession $userSession,
 								$isAdmin,
 								IL10N $l10n) {
 		parent::__construct($appName, $request);
 		$this->groupManager = $groupManager;
+		$this->userManager = $userManager;
 		$this->userSession = $userSession;
 		$this->isAdmin = $isAdmin;
 		$this->l10n = $l10n;
@@ -83,6 +88,7 @@ class GroupsController extends Controller {
 			$this->userSession->getUser()->getUID(),
 			$this->isAdmin,
 			$this->groupManager,
+			$this->userManager,
 			$this->userSession
 		);
 		$groupsInfo->setSorting($sortGroups);

--- a/settings/users.php
+++ b/settings/users.php
@@ -106,7 +106,7 @@ if($isAdmin) {
 	$subAdmins = false;
 }
 
-$disabledUsers = $isLDAPUsed ? 0 : $userManager->countDisabledUsers();
+$disabledUsers = $isLDAPUsed ? 0 : $isAdmin ? $userManager->countDisabledUsers() : $userManager->countDisabledUsersOfGroups($gids);
 $disabledUsersGroup = [
 	'id' => '_disabledUsers',
 	'name' => '_disabledUsers',

--- a/settings/users.php
+++ b/settings/users.php
@@ -75,6 +75,7 @@ $groupsInfo = new \OC\Group\MetaData(
 	$uid,
 	$isAdmin,
 	$groupManager,
+	$userManager,
 	\OC::$server->getUserSession()
 );
 
@@ -84,7 +85,7 @@ list($adminGroup, $groups) = $groupsInfo->get();
 $recoveryAdminEnabled = $appManager->isEnabledForUser('encryption') &&
 					    $config->getAppValue( 'encryption', 'recoveryAdminEnabled', '0');
 
-if($isAdmin) {
+if ($isAdmin) {
 	$subAdmins = \OC::$server->getGroupManager()->getSubAdmin()->getAllSubAdmins();
 	// New class returns IUser[] so convert back
 	$result = [];
@@ -95,7 +96,7 @@ if($isAdmin) {
 		];
 	}
 	$subAdmins = $result;
-}else{
+} else {
 	/* Retrieve group IDs from $groups array, so we can pass that information into OC_Group::displayNamesInGroups() */
 	$gids = array();
 	foreach($groups as $group) {
@@ -106,7 +107,12 @@ if($isAdmin) {
 	$subAdmins = false;
 }
 
-$disabledUsers = $isLDAPUsed ? 0 : $isAdmin ? $userManager->countDisabledUsers() : $userManager->countDisabledUsersOfGroups($gids);
+// remove disabled from total count
+foreach($groups as $key => $group) {
+	$groups[$key]['usercount'] -= $group['disabled'];
+}
+
+$disabledUsers = $isLDAPUsed ? 0 : $isAdmin ? $userManager->countDisabledUsers() : $userManager->countDisabledUsersOfGroups();
 $disabledUsersGroup = [
 	'id' => '_disabledUsers',
 	'name' => '_disabledUsers',

--- a/tests/Settings/Controller/GroupsControllerTest.php
+++ b/tests/Settings/Controller/GroupsControllerTest.php
@@ -19,6 +19,7 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IUserManager;
 use OCP\IUserSession;
 
 /**
@@ -28,6 +29,9 @@ class GroupsControllerTest extends \Test\TestCase {
 
 	/** @var IGroupManager|\PHPUnit_Framework_MockObject_MockObject */
 	private $groupManager;
+
+	/** @var IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	private $userManager;
 
 	/** @var IUserSession|\PHPUnit_Framework_MockObject_MockObject */
 	private $userSession;
@@ -39,6 +43,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		parent::setUp();
 
 		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->userManager = $this->createMock(IUserManager::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$l = $this->createMock(IL10N::class);
 		$l->method('t')
@@ -49,6 +54,7 @@ class GroupsControllerTest extends \Test\TestCase {
 			'settings',
 			$this->createMock(IRequest::class),
 			$this->groupManager,
+			$this->userManager,
 			$this->userSession,
 			true,
 			$l
@@ -112,8 +118,15 @@ class GroupsControllerTest extends \Test\TestCase {
 		$groups[] = $thirdGroup;
 		$groups[] = $fourthGroup;
 
+		// Get disabled count
+		$this->userManager->expects($this->exactly(4))
+			->method('countDisabledUsersOfGroups')
+			->will($this->returnValue(0));
+		
 		$user = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
+		
+		// Get connected user
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -132,7 +145,8 @@ class GroupsControllerTest extends \Test\TestCase {
 					0 => array(
 						'id' => 'admin',
 						'name' => 'Admin',
-						'usercount' => 0,//User count disabled 18,
+						'usercount' => 0, // User count disabled, should be 18,
+						'disabled' => 0
 					)
 				),
 				'groups' =>
@@ -140,17 +154,20 @@ class GroupsControllerTest extends \Test\TestCase {
 						0 => array(
 							'id' => 'firstGroup',
 							'name' => 'First group',
-							'usercount' => 0,//User count disabled 12,
+							'usercount' => 0, // User count disabled, should be 12,
+							'disabled' => 0
 						),
 						1 => array(
 							'id' => 'secondGroup',
 							'name' => 'Second group',
-							'usercount' => 0,//User count disabled 25,
+							'usercount' => 0, // User count disabled, should be 25,
+							'disabled' => 0
 						),
 						2 => array(
 							'id' => 'thirdGroup',
 							'name' => 'Third group',
-							'usercount' => 0,//User count disabled 14,
+							'usercount' => 0, // User count disabled, should be 14,
+							'disabled' => 0
 						),
 					)
 				)
@@ -216,8 +233,15 @@ class GroupsControllerTest extends \Test\TestCase {
 		$groups[] = $thirdGroup;
 		$groups[] = $fourthGroup;
 
+		// Get disabled count
+		$this->userManager->expects($this->exactly(4))
+			->method('countDisabledUsersOfGroups')
+			->will($this->returnValue(0));
+		
 		$user = $this->getMockBuilder(User::class)
 			->disableOriginalConstructor()->getMock();
+		
+		// Get connected user
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -238,6 +262,7 @@ class GroupsControllerTest extends \Test\TestCase {
 						'id' => 'admin',
 						'name' => 'Admin',
 						'usercount' => 18,
+						'disabled' => 0
 					)
 				),
 				'groups' =>
@@ -246,16 +271,19 @@ class GroupsControllerTest extends \Test\TestCase {
 							'id' => 'secondGroup',
 							'name' => 'Second group',
 							'usercount' => 25,
+							'disabled' => 0
 						),
 						1 => array(
 							'id' => 'thirdGroup',
 							'name' => 'Third group',
 							'usercount' => 14,
+							'disabled' => 0
 						),
 						2 => array(
 							'id' => 'firstGroup',
 							'name' => 'First group',
 							'usercount' => 12,
+							'disabled' => 0
 						),
 					)
 				)

--- a/tests/lib/Group/MetaDataTest.php
+++ b/tests/lib/Group/MetaDataTest.php
@@ -27,6 +27,8 @@ use OCP\IUserSession;
 class MetaDataTest extends \Test\TestCase {
 	/** @var \OC\Group\Manager */
 	private $groupManager;
+	/** @var \OC\User\Manager */
+	private $userManager;
 	/** @var \OCP\IUserSession */
 	private $userSession;
 	/** @var \OC\Group\MetaData */
@@ -39,11 +41,15 @@ class MetaDataTest extends \Test\TestCase {
 		$this->groupManager = $this->getMockBuilder('\OC\Group\Manager')
 			->disableOriginalConstructor()
 			->getMock();
+		$this->userManager = $this->getMockBuilder('\OC\user\Manager')
+			->disableOriginalConstructor()
+			->getMock();
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->groupMetadata = new \OC\Group\MetaData(
 			'foo',
 			$this->isAdmin,
 			$this->groupManager,
+			$this->userManager,
 			$this->userSession
 		);
 	}
@@ -53,12 +59,12 @@ class MetaDataTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$group->expects($this->exactly(6))
+		$group->expects($this->exactly(9))
 			->method('getGID')
 			->will($this->onConsecutiveCalls(
-				'admin', 'admin',
-				'g2', 'g2',
-				'g3', 'g3'));
+				'admin', 'admin', 'admin',
+				'g2', 'g2', 'g2',
+				'g3', 'g3', 'g3'));
 
 		$group->expects($this->exactly(3))
 			->method('getDisplayName')
@@ -71,6 +77,10 @@ class MetaDataTest extends \Test\TestCase {
 			->method('count')
 			->with('')
 			->will($this->onConsecutiveCalls(2, 3, 5));
+
+		$this->userManager->expects($this->exactly(3))
+			->method('countDisabledUsersOfGroups')
+			->will($this->onConsecutiveCalls(1, 2, 3));
 
 		return $group;
 	}


### PR DESCRIPTION
Fix #8009 
Fix #8008 
I feel like it's safer to return a different entry instead of directly subtracting the disabled users to the total user count. People might want to get the full data anyway.