### PR TITLE
Access needs UserManager, missed to add in #8833

### DIFF
--- a/apps/user_ldap/ajax/wizard.php
+++ b/apps/user_ldap/ajax/wizard.php
@@ -69,7 +69,8 @@ $access = new \OCA\User_LDAP\Access(
 	$ldapWrapper,
 	$userManager,
 	new \OCA\User_LDAP\Helper(\OC::$server->getConfig()),
-	\OC::$server->getConfig()
+	\OC::$server->getConfig(),
+	\OC::$server->getUserManager()
 );
 
 $wizard = new \OCA\User_LDAP\Wizard($configuration, $ldapWrapper, $access);

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -50,7 +50,6 @@ use OCA\User_LDAP\User\IUserTools;
 use OCA\User_LDAP\User\Manager;
 use OCA\User_LDAP\User\OfflineUser;
 use OCA\User_LDAP\Mapping\AbstractMapping;
-
 use OC\ServerNotAvailableException;
 use OCP\IConfig;
 use OCP\IUserManager;


### PR DESCRIPTION
Effect: LDAP settings don't work. Now they do again.