### PR TITLE
Swift v3 requires setting a scope

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1235,10 +1235,18 @@ $CONFIG = array(
 				'name' => 'default',
 			],
 		],
+		'scope' => [
+			'project' => [
+				'name' => 'service',
+				'domain' => [
+					'name' => 'default',
+				],
+			],
+		],
 		'tenantName' => 'service',
 		'serviceName' => 'swift',
 		'region' => 'regionOne',
-		'url' => "http://yourswifthost:5000/v3",
+		'url' => 'http://yourswifthost:5000/v3',
 		'bucket' => 'nextcloud',
 	],
 ],

--- a/lib/private/Files/ObjectStore/SwiftFactory.php
+++ b/lib/private/Files/ObjectStore/SwiftFactory.php
@@ -108,6 +108,10 @@ class SwiftFactory {
 		]);
 
 		if (isset($this->params['user']) && isset($this->params['user']['name'])) {
+			if (!isset($this->params['scope'])) {
+				throw new StorageAuthException('Scope has to be defined for V3 requests');
+			}
+
 			return $this->auth(IdentityV3Service::factory($httpClient), $cacheKey);
 		} else {
 			return $this->auth(IdentityV2Service::factory($httpClient), $cacheKey);


### PR DESCRIPTION
Unscoped auth is not guaranteed to return a catalog. So require the
scope to be set properly.

See https://developer.openstack.org/api-ref/identity/v3/index.html#password-authentication-with-unscoped-authorization

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>