### PR TITLE
Ldap password renewal fixes for NC13

### DIFF
--- a/apps/user_ldap/css/renewPassword.css
+++ b/apps/user_ldap/css/renewPassword.css
@@ -20,108 +20,125 @@
 }
 
 .tooltip {
- position:absolute;
- display:block;
- font-family:'Open Sans', Frutiger, Calibri, 'Myriad Pro', Myriad, sans-serif;
- font-style:normal;
- font-weight:400;
- letter-spacing:normal;
- line-break:auto;
- line-height:1.6;
- text-align:left;
- text-align:start;
- text-decoration:none;
- text-shadow:none;
- text-transform:none;
- white-space:normal;
- word-break:normal;
- word-spacing:normal;
- word-wrap:normal;
- font-size:12px;
- opacity:0;
- z-index:100000;
- filter:drop-shadow(0 1px 10px rgba(77, 77, 77, 0.75));
+	position:absolute;
+	display:block;
+	font-family:'Open Sans', Frutiger, Calibri, 'Myriad Pro', Myriad, sans-serif;
+	font-style:normal;
+	font-weight:400;
+	letter-spacing:normal;
+	line-break:auto;
+	line-height:1.6;
+	text-align:left;
+	text-align:start;
+	text-decoration:none;
+	text-shadow:none;
+	text-transform:none;
+	white-space:normal;
+	word-break:normal;
+	word-spacing:normal;
+	word-wrap:normal;
+	font-size:12px;
+	opacity:0;
+	z-index:100000;
+	filter:drop-shadow(0 1px 10px rgba(77, 77, 77, 0.75));
 }
+
 .tooltip.in {
- opacity:1
+	opacity:1
 }
+
 .tooltip.top {
- margin-top:-3px;
- padding:10px 0
+	margin-top:-3px;
+	padding:10px 0
 }
+
 .tooltip.bottom {
- margin-top:3px;
- padding:10px 0
+	margin-top:3px;
+	padding:10px 0
 }
+
 .tooltip.right {
- margin-left:3px;
- padding:0 10px
+	margin-left:3px;
+	padding:0 10px
 }
+
 .tooltip.right .tooltip-arrow {
- top:50%;
- left:0;
- margin-top:-10px;
- border-width:10px 10px 10px 0;
- border-right-color:#fff
+	top:50%;
+	left:0;
+	margin-top:-10px;
+	border-width:10px 10px 10px 0;
+	border-right-color:#fff
 }
+
 .tooltip.left {
- margin-left:-3px;
- padding:0 5px
+	margin-left:-3px;
+	padding:0 5px
 }
+
 .tooltip.left .tooltip-arrow {
- top:50%;
- right:0;
- margin-top:-10px;
- border-width:10px 0 10px 10px;
- border-left-color:#fff
+	top:50%;
+	right:0;
+	margin-top:-10px;
+	border-width:10px 0 10px 10px;
+	border-left-color:#fff
 }
+
 .tooltip.top .tooltip-arrow,.tooltip.top-left .tooltip-arrow,.tooltip.top-right .tooltip-arrow {
- bottom:0;
- border-width:10px 10px 0;
- border-top-color:#fff
+	bottom:0;
+	border-width:10px 10px 0;
+	border-top-color:#fff
 }
+
 .tooltip.top .tooltip-arrow {
- left:50%;
- margin-left:-10px
+	left:50%;
+	margin-left:-10px
 }
+
 .tooltip.top-left .tooltip-arrow {
- right:10px;
- margin-bottom:-10px
+	right:10px;
+	margin-bottom:-10px
 }
+
 .tooltip.top-right .tooltip-arrow {
- left:10px;
- margin-bottom:-10px
+	left:10px;
+	margin-bottom:-10px
 }
+
 .tooltip.bottom .tooltip-arrow,.tooltip.bottom-left .tooltip-arrow,.tooltip.bottom-right .tooltip-arrow {
- top:0;
- border-width:0 10px 10px;
- border-bottom-color:#fff
+	top:0;
+	border-width:0 10px 10px;
+	border-bottom-color:#fff
 }
+
 .tooltip.bottom .tooltip-arrow {
- left:50%;
- margin-left:-10px
+	left:50%;
+	margin-left:-10px
 }
+
 .tooltip.bottom-left .tooltip-arrow {
- right:10px;
- margin-top:-10px
+	right:10px;
+	margin-top:-10px
 }
+
 .tooltip.bottom-right .tooltip-arrow {
- left:10px;
- margin-top:-10px
+	left:10px;
+	margin-top:-10px
 }
+
 .tooltip-inner {
- max-width:350px;
- padding:5px 8px !important;
- background-color:#fff;
- color:#000 !important;
- text-align:center !important;
- font-weight:normal !important;
- border-radius:3px
+	max-width:350px;
+	padding:5px 8px !important;
+	background-color:#fff;
+	color:#000 !important;
+	text-align:center !important;
+	font-weight:normal !important;
+	border-radius:3px
 }
+
 .tooltip-arrow {
- position:absolute;
- width:0;
- height:0;
- border-color:transparent;
- border-style:solid
+	position:absolute;
+	width:0;
+	height:0;
+	border-color:transparent;
+	border-style:solid
 }

--- a/apps/user_ldap/css/renewPassword.css
+++ b/apps/user_ldap/css/renewPassword.css
@@ -1,6 +1,6 @@
 #personal-show + label {
-	left: 222px !important;
-	margin-top: 3px !important;
+	left: 236px !important;
+	margin-top: 17px !important;
 }
 
 #renewpassword .strengthify-wrapper {
@@ -19,7 +19,109 @@
 	background-color: transparent;
 }
 
-input.primary,
-button.primary {
-	background-color: #00a2e9 !important;
+.tooltip {
+ position:absolute;
+ display:block;
+ font-family:'Open Sans', Frutiger, Calibri, 'Myriad Pro', Myriad, sans-serif;
+ font-style:normal;
+ font-weight:400;
+ letter-spacing:normal;
+ line-break:auto;
+ line-height:1.6;
+ text-align:left;
+ text-align:start;
+ text-decoration:none;
+ text-shadow:none;
+ text-transform:none;
+ white-space:normal;
+ word-break:normal;
+ word-spacing:normal;
+ word-wrap:normal;
+ font-size:12px;
+ opacity:0;
+ z-index:100000;
+ filter:drop-shadow(0 1px 10px rgba(77, 77, 77, 0.75));
+}
+.tooltip.in {
+ opacity:1
+}
+.tooltip.top {
+ margin-top:-3px;
+ padding:10px 0
+}
+.tooltip.bottom {
+ margin-top:3px;
+ padding:10px 0
+}
+.tooltip.right {
+ margin-left:3px;
+ padding:0 10px
+}
+.tooltip.right .tooltip-arrow {
+ top:50%;
+ left:0;
+ margin-top:-10px;
+ border-width:10px 10px 10px 0;
+ border-right-color:#fff
+}
+.tooltip.left {
+ margin-left:-3px;
+ padding:0 5px
+}
+.tooltip.left .tooltip-arrow {
+ top:50%;
+ right:0;
+ margin-top:-10px;
+ border-width:10px 0 10px 10px;
+ border-left-color:#fff
+}
+.tooltip.top .tooltip-arrow,.tooltip.top-left .tooltip-arrow,.tooltip.top-right .tooltip-arrow {
+ bottom:0;
+ border-width:10px 10px 0;
+ border-top-color:#fff
+}
+.tooltip.top .tooltip-arrow {
+ left:50%;
+ margin-left:-10px
+}
+.tooltip.top-left .tooltip-arrow {
+ right:10px;
+ margin-bottom:-10px
+}
+.tooltip.top-right .tooltip-arrow {
+ left:10px;
+ margin-bottom:-10px
+}
+.tooltip.bottom .tooltip-arrow,.tooltip.bottom-left .tooltip-arrow,.tooltip.bottom-right .tooltip-arrow {
+ top:0;
+ border-width:0 10px 10px;
+ border-bottom-color:#fff
+}
+.tooltip.bottom .tooltip-arrow {
+ left:50%;
+ margin-left:-10px
+}
+.tooltip.bottom-left .tooltip-arrow {
+ right:10px;
+ margin-top:-10px
+}
+.tooltip.bottom-right .tooltip-arrow {
+ left:10px;
+ margin-top:-10px
+}
+.tooltip-inner {
+ max-width:350px;
+ padding:5px 8px !important;
+ background-color:#fff;
+ color:#000 !important;
+ text-align:center !important;
+ font-weight:normal !important;
+ border-radius:3px
+}
+.tooltip-arrow {
+ position:absolute;
+ width:0;
+ height:0;
+ border-color:transparent;
+ border-style:solid
 }

--- a/apps/user_ldap/templates/renewpassword.php
+++ b/apps/user_ldap/templates/renewpassword.php
@@ -23,7 +23,7 @@ style('user_ldap', 'renewPassword');
 				<?php p($message); ?><br>
 			</div>
 		<?php endforeach; ?>
-		<?php if (isset($_['internalexception']) && ($_['internalexception'])): ?>
+		<?php if (isset($_['internalexception']) && $_['internalexception']): ?>
 			<div class="warning">
 				<?php p($l->t('An internal error occurred.')); ?><br>
 				<small><?php p($l->t('Please try again or contact your administrator.')); ?></small>

--- a/apps/user_ldap/templates/renewpassword.php
+++ b/apps/user_ldap/templates/renewpassword.php
@@ -23,7 +23,7 @@ style('user_ldap', 'renewPassword');
 				<?php p($message); ?><br>
 			</div>
 		<?php endforeach; ?>
-		<?php if (isset($_['internalexception']) && $_['internalexception']): ?>
+		<?php if (isset($_['internalexception']) && ($_['internalexception'])): ?>
 			<div class="warning">
 				<?php p($l->t('An internal error occurred.')); ?><br>
 				<small><?php p($l->t('Please try again or contact your administrator.')); ?></small>
@@ -53,11 +53,7 @@ style('user_ldap', 'renewPassword');
 		
 		<input type="submit" id="submit" class="login primary icon-confirm-white" title="" value="<?php p($l->t('Renew password')); ?>"/>
 
-		<?php if (!empty($_['invalidpassword']) && !empty($_['canResetPassword'])) { ?>
-		<a id="lost-password" class="warning" href="<?php p($_['resetPasswordLink']); ?>">
-			<?php p($l->t('Wrong password. Reset it?')); ?>
-		</a>
-		<?php } else if (!empty($_['invalidpassword'])) { ?>
+		<?php if (!empty($_['invalidpassword'])) { ?>
 			<p class="warning">
 				<?php p($l->t('Wrong password.')); ?>
 			</p>


### PR DESCRIPTION
Hi,

The "Renew Password" page in user_ldap needed minor adjustments to keep it aligned with NC13 core changes:

- Commit _"adjust css to nc13 core changes"_
Since NC 13 the "Renew Password" page doesn't load the `server.scss` anymore, so tooltip related CSS is copied over to `renewPassword.css` until issue #9251 is solved. The commit also includes a minor adjustment in label position and button background color

- Commit _"remove reset password link"_
The reset password function in core has been heavily revamped, so instead of updating the "Renew Password" page with this now quite complicated function, the reset password link is now removed completely from the "Renew Password" page. This is because such feature isn't needed on the "Renew Password" page anyway, and here's why: 
1) User has to enter the correct password on the Login page before being redirected to the "Renew Password" page, so it's unlikely he suddenly forgets the password after having entered it correctly on the previous page
2) User could click "Cancel" on the "Renew Password" page to return the Login page and perform a password reset there 

