### PR TITLE
Migrate groups fetch to ocs api

### DIFF
--- a/apps/workflowengine/js/admin.js
+++ b/apps/workflowengine/js/admin.js
@@ -19,372 +19,376 @@
  */
 
 (function() {
-	Handlebars.registerHelper('selectItem', function(currentValue, itemValue) {
-		if(currentValue === itemValue) {
-			return 'selected="selected"';
-		}
+    Handlebars.registerHelper('selectItem', function(currentValue, itemValue) {
+        if (currentValue === itemValue) {
+            return 'selected="selected"';
+        }
 
-		return "";
-	});
+        return "";
+    });
 
-	Handlebars.registerHelper('getOperators', function(classname) {
-		var check = OCA.WorkflowEngine.getCheckByClass(classname);
-		if (!_.isUndefined(check)) {
-			return check['operators'];
-		}
-		return [];
-	});
+    Handlebars.registerHelper('getOperators', function(classname) {
+        var check = OCA.WorkflowEngine.getCheckByClass(classname);
+        if (!_.isUndefined(check)) {
+            return check['operators'];
+        }
+        return [];
+    });
 
-	OCA.WorkflowEngine = _.extend(OCA.WorkflowEngine || {}, {
-			availablePlugins: [],
-			availableChecks: [],
+    OCA.WorkflowEngine = _.extend(OCA.WorkflowEngine || {}, {
+        availablePlugins: [],
+        availableChecks: [],
 
-			getCheckByClass: function(className) {
-				var length = OCA.WorkflowEngine.availableChecks.length;
-				for (var i = 0; i < length; i++) {
-					if (OCA.WorkflowEngine.availableChecks[i]['class'] === className) {
-						return OCA.WorkflowEngine.availableChecks[i];
-					}
-				}
-				return undefined;
-			}
-	});
+        getCheckByClass: function(className) {
+            var length = OCA.WorkflowEngine.availableChecks.length;
+            for (var i = 0; i < length; i++) {
+                if (OCA.WorkflowEngine.availableChecks[i]['class'] === className) {
+                    return OCA.WorkflowEngine.availableChecks[i];
+                }
+            }
+            return undefined;
+        }
+    });
 
-	/**
-	 * 888b     d888               888          888
-	 * 8888b   d8888               888          888
-	 * 88888b.d88888               888          888
-	 * 888Y88888P888  .d88b.   .d88888  .d88b.  888 .d8888b
-	 * 888 Y888P 888 d88""88b d88" 888 d8P  Y8b 888 88K
-	 * 888  Y8P  888 888  888 888  888 88888888 888 "Y8888b.
-	 * 888   "   888 Y88..88P Y88b 888 Y8b.     888      X88
-	 * 888       888  "Y88P"   "Y88888  "Y8888  888  88888P'
-	 */
+    /**
+     * 888b     d888               888          888
+     * 8888b   d8888               888          888
+     * 88888b.d88888               888          888
+     * 888Y88888P888  .d88b.   .d88888  .d88b.  888 .d8888b
+     * 888 Y888P 888 d88""88b d88" 888 d8P  Y8b 888 88K
+     * 888  Y8P  888 888  888 888  888 88888888 888 "Y8888b.
+     * 888   "   888 Y88..88P Y88b 888 Y8b.     888      X88
+     * 888       888  "Y88P"   "Y88888  "Y8888  888  88888P'
+     */
 
-	/**
-	 * @class OCA.WorkflowEngine.Operation
-	 */
-	OCA.WorkflowEngine.Operation =
-		OC.Backbone.Model.extend({
-			defaults: {
-				'class': 'OCA\\WorkflowEngine\\Operation',
-				'name': '',
-				'checks': [],
-				'operation': ''
-			}
-		});
+    /**
+     * @class OCA.WorkflowEngine.Operation
+     */
+    OCA.WorkflowEngine.Operation =
+        OC.Backbone.Model.extend({
+            defaults: {
+                'class': 'OCA\\WorkflowEngine\\Operation',
+                'name': '',
+                'checks': [],
+                'operation': ''
+            }
+        });
 
-	/**
-	 *  .d8888b.           888 888                   888    d8b
-	 * d88P  Y88b          888 888                   888    Y8P
-	 * 888    888          888 888                   888
-	 * 888         .d88b.  888 888  .d88b.   .d8888b 888888 888  .d88b.  88888b.  .d8888b
-	 * 888        d88""88b 888 888 d8P  Y8b d88P"    888    888 d88""88b 888 "88b 88K
-	 * 888    888 888  888 888 888 88888888 888      888    888 888  888 888  888 "Y8888b.
-	 * Y88b  d88P Y88..88P 888 888 Y8b.     Y88b.    Y88b.  888 Y88..88P 888  888      X88
-	 *  "Y8888P"   "Y88P"  888 888  "Y8888   "Y8888P  "Y888 888  "Y88P"  888  888  88888P'
-	 */
+    /**
+     *  .d8888b.           888 888                   888    d8b
+     * d88P  Y88b          888 888                   888    Y8P
+     * 888    888          888 888                   888
+     * 888         .d88b.  888 888  .d88b.   .d8888b 888888 888  .d88b.  88888b.  .d8888b
+     * 888        d88""88b 888 888 d8P  Y8b d88P"    888    888 d88""88b 888 "88b 88K
+     * 888    888 888  888 888 888 88888888 888      888    888 888  888 888  888 "Y8888b.
+     * Y88b  d88P Y88..88P 888 888 Y8b.     Y88b.    Y88b.  888 Y88..88P 888  888      X88
+     *  "Y8888P"   "Y88P"  888 888  "Y8888   "Y8888P  "Y888 888  "Y88P"  888  888  88888P'
+     */
 
-	/**
-	 * @class OCA.WorkflowEngine.OperationsCollection
-	 *
-	 * collection for all configurated operations
-	 */
-	OCA.WorkflowEngine.OperationsCollection =
-		OC.Backbone.Collection.extend({
-			model: OCA.WorkflowEngine.Operation,
-			url: OC.generateUrl('apps/workflowengine/operations')
-		});
+    /**
+     * @class OCA.WorkflowEngine.OperationsCollection
+     *
+     * collection for all configurated operations
+     */
+    OCA.WorkflowEngine.OperationsCollection =
+        OC.Backbone.Collection.extend({
+            model: OCA.WorkflowEngine.Operation,
+            url: OC.generateUrl('apps/workflowengine/operations')
+        });
 
-	/**
-	 * 888     888 d8b
-	 * 888     888 Y8P
-	 * 888     888
-	 * Y88b   d88P 888  .d88b.  888  888  888 .d8888b
-	 *  Y88b d88P  888 d8P  Y8b 888  888  888 88K
-	 *   Y88o88P   888 88888888 888  888  888 "Y8888b.
-	 *    Y888P    888 Y8b.     Y88b 888 d88P      X88
-	 *     Y8P     888  "Y8888   "Y8888888P"   88888P'
-	 */
+    /**
+     * 888     888 d8b
+     * 888     888 Y8P
+     * 888     888
+     * Y88b   d88P 888  .d88b.  888  888  888 .d8888b
+     *  Y88b d88P  888 d8P  Y8b 888  888  888 88K
+     *   Y88o88P   888 88888888 888  888  888 "Y8888b.
+     *    Y888P    888 Y8b.     Y88b 888 d88P      X88
+     *     Y8P     888  "Y8888   "Y8888888P"   88888P'
+     */
 
-	/**
-	 * @class OCA.WorkflowEngine.TemplateView
-	 *
-	 * a generic template that handles the Handlebars template compile step
-	 * in a method called "template()"
-	 */
-	OCA.WorkflowEngine.TemplateView =
-		OC.Backbone.View.extend({
-			_template: null,
-			template: function(vars) {
-				if (!this._template) {
-					this._template = Handlebars.compile($(this.templateId).html());
-				}
-				return this._template(vars);
-			}
-		});
+    /**
+     * @class OCA.WorkflowEngine.TemplateView
+     *
+     * a generic template that handles the Handlebars template compile step
+     * in a method called "template()"
+     */
+    OCA.WorkflowEngine.TemplateView =
+        OC.Backbone.View.extend({
+            _template: null,
+            template: function(vars) {
+                if (!this._template) {
+                    this._template = Handlebars.compile($(this.templateId).html());
+                }
+                return this._template(vars);
+            }
+        });
 
-	/**
-	 * @class OCA.WorkflowEngine.OperationView
-	 *
-	 * this creates the view for a single operation
-	 */
-	OCA.WorkflowEngine.OperationView =
-		OCA.WorkflowEngine.TemplateView.extend({
-			templateId: '#operation-template',
-			events: {
-				'change .check-class': 'checkChanged',
-				'change .check-operator': 'checkChanged',
-				'change .check-value': 'checkChanged',
-				'change .operation-name': 'operationChanged',
-				'change .operation-operation': 'operationChanged',
-				'click .button-reset': 'reset',
-				'click .button-save': 'save',
-				'click .button-add': 'add',
-				'click .button-delete': 'delete',
-				'click .button-delete-check': 'deleteCheck'
-			},
-			originalModel: null,
-			hasChanged: false,
-			message: '',
-			errorMessage: '',
-			saving: false,
-			groups: [],
-			initialize: function() {
-				// this creates a new copy of the object to definitely have a new reference and being able to reset the model
-				this.originalModel = JSON.parse(JSON.stringify(this.model));
-				this.model.on('change', function(){
-					console.log('model changed');
-					this.hasChanged = true;
-					this.render();
-				}, this);
+    /**
+     * @class OCA.WorkflowEngine.OperationView
+     *
+     * this creates the view for a single operation
+     */
+    OCA.WorkflowEngine.OperationView =
+        OCA.WorkflowEngine.TemplateView.extend({
+            templateId: '#operation-template',
+            events: {
+                'change .check-class': 'checkChanged',
+                'change .check-operator': 'checkChanged',
+                'change .check-value': 'checkChanged',
+                'change .operation-name': 'operationChanged',
+                'change .operation-operation': 'operationChanged',
+                'click .button-reset': 'reset',
+                'click .button-save': 'save',
+                'click .button-add': 'add',
+                'click .button-delete': 'delete',
+                'click .button-delete-check': 'deleteCheck'
+            },
+            originalModel: null,
+            hasChanged: false,
+            message: '',
+            errorMessage: '',
+            saving: false,
+            groups: [],
+            initialize: function() {
+                // this creates a new copy of the object to definitely have a new reference and being able to reset the model
+                this.originalModel = JSON.parse(JSON.stringify(this.model));
+                this.model.on('change', function() {
+                    console.log('model changed');
+                    this.hasChanged = true;
+                    this.render();
+                }, this);
 
-				if (this.model.get('id') === undefined) {
-					this.hasChanged = true;
-				}
-				var self = this;
-				$.ajax({
-					url: OC.generateUrl('settings/users/groups'),
-					dataType: 'json',
-					quietMillis: 100,
-				}).success(function(response) {
-					// add admin groups
-					$.each(response.data.adminGroups, function(id, group) {
-						self.groups.push({ id: group.id, displayname: group.name });
-					});
-					// add groups
-					$.each(response.data.groups, function(id, group) {
-						self.groups.push({ id: group.id, displayname: group.name });
-					});
-					self.render();
-				}).error(function(data) {
-					OC.Notification.error(t('workflowengine', 'Unable to retrieve the group list'), {type: 'error'});
-					console.log(data);
-				});
-			},
-			delete: function() {
-				if (OC.PasswordConfirmation.requiresPasswordConfirmation()) {
-					OC.PasswordConfirmation.requirePasswordConfirmation(_.bind(this.delete, this));
-					return;
-				}
+                if (this.model.get('id') === undefined) {
+                    this.hasChanged = true;
+                }
+                var self = this;
+                $.ajax({
+                    url: OC.linkToOCS('cloud/groups', 2) + 'details',
+                    dataType: 'json',
+                    quietMillis: 100,
+                }).success(function(response) {
+                    if (data.ocs.data.groups && data.ocs.data.groups.length > 0) {
 
-				this.model.destroy();
-				this.remove();
-			},
-			reset: function() {
-				this.hasChanged = false;
-				// silent is need to not trigger the change event which resets the hasChanged attribute
-				this.model.set(this.originalModel, {silent: true});
-				this.render();
-			},
-			save: function() {
-				if (OC.PasswordConfirmation.requiresPasswordConfirmation()) {
-					OC.PasswordConfirmation.requirePasswordConfirmation(_.bind(this.save, this));
-					return;
-				}
+                        data.ocs.data.groups.forEach(function(group) {
+                            self.groups.push({ id: group.id, displayname: group.displayname });
+                        })
+                        self.render();
 
-				var success = function(model, response, options) {
-					this.saving = false;
-					this.originalModel = JSON.parse(JSON.stringify(this.model));
+                    } else {
+                        OC.Notification.error(t('workflowengine', 'Group list is empty'), { type: 'error' });
+                        console.log(data);
+                    }
+                }).error(function(data) {
+                    OC.Notification.error(t('workflowengine', 'Unable to retrieve the group list'), { type: 'error' });
+                    console.log(data);
+                });
+            },
+            delete: function() {
+                if (OC.PasswordConfirmation.requiresPasswordConfirmation()) {
+                    OC.PasswordConfirmation.requirePasswordConfirmation(_.bind(this.delete, this));
+                    return;
+                }
 
-					this.message = t('workflowengine', 'Saved');
-					this.errorMessage = '';
-					this.render();
-				};
-				var error = function(model, response, options) {
-					this.saving = false;
-					this.hasChanged = true;
+                this.model.destroy();
+                this.remove();
+            },
+            reset: function() {
+                this.hasChanged = false;
+                // silent is need to not trigger the change event which resets the hasChanged attribute
+                this.model.set(this.originalModel, { silent: true });
+                this.render();
+            },
+            save: function() {
+                if (OC.PasswordConfirmation.requiresPasswordConfirmation()) {
+                    OC.PasswordConfirmation.requirePasswordConfirmation(_.bind(this.save, this));
+                    return;
+                }
 
-					this.message = t('workflowengine', 'Saving failed:');
-					this.errorMessage = response.responseText;
-					this.render();
-				};
-				this.hasChanged = false;
-				this.saving = true;
-				this.render();
-				this.model.save(null, {success: success, error: error, context: this});
-			},
-			add: function() {
-				var checks = _.clone(this.model.get('checks')),
-					classname = OCA.WorkflowEngine.availableChecks[0]['class'],
-					operators = OCA.WorkflowEngine.availableChecks[0]['operators'];
+                var success = function(model, response, options) {
+                    this.saving = false;
+                    this.originalModel = JSON.parse(JSON.stringify(this.model));
 
-				checks.push({
-					'class': classname,
-					'operator': operators[0]['operator'],
-					'value': ''
-				});
-				this.model.set({'checks': checks});
-			},
-			checkChanged: function(event) {
-				var value = event.target.value,
-					id = $(event.target.parentElement).data('id'),
-					// this creates a new copy of the object to definitely have a new reference
-					checks = JSON.parse(JSON.stringify(this.model.get('checks'))),
-					key = null;
+                    this.message = t('workflowengine', 'Saved');
+                    this.errorMessage = '';
+                    this.render();
+                };
+                var error = function(model, response, options) {
+                    this.saving = false;
+                    this.hasChanged = true;
 
-				for (var i = 0; i < event.target.classList.length; i++) {
-					var className = event.target.classList[i];
-					if (className.substr(0, 'check-'.length) === 'check-') {
-						key = className.substr('check-'.length);
-						break;
-					}
-				}
+                    this.message = t('workflowengine', 'Saving failed:');
+                    this.errorMessage = response.responseText;
+                    this.render();
+                };
+                this.hasChanged = false;
+                this.saving = true;
+                this.render();
+                this.model.save(null, { success: success, error: error, context: this });
+            },
+            add: function() {
+                var checks = _.clone(this.model.get('checks')),
+                    classname = OCA.WorkflowEngine.availableChecks[0]['class'],
+                    operators = OCA.WorkflowEngine.availableChecks[0]['operators'];
 
-				if (key === null) {
-					console.warn('checkChanged triggered but element doesn\'t have any "check-" class');
-					return;
-				}
+                checks.push({
+                    'class': classname,
+                    'operator': operators[0]['operator'],
+                    'value': ''
+                });
+                this.model.set({ 'checks': checks });
+            },
+            checkChanged: function(event) {
+                var value = event.target.value,
+                    id = $(event.target.parentElement).data('id'),
+                    // this creates a new copy of the object to definitely have a new reference
+                    checks = JSON.parse(JSON.stringify(this.model.get('checks'))),
+                    key = null;
 
-				if (!_.has(checks[id], key)) {
-					console.warn('key "' + key + '" is not available in check', check);
-					return;
-				}
+                for (var i = 0; i < event.target.classList.length; i++) {
+                    var className = event.target.classList[i];
+                    if (className.substr(0, 'check-'.length) === 'check-') {
+                        key = className.substr('check-'.length);
+                        break;
+                    }
+                }
 
-				checks[id][key] = value;
-				// if the class is changed most likely also the operators have changed
-				// with this we set the operator to the first possible operator
-				if (key === 'class') {
-					var check = OCA.WorkflowEngine.getCheckByClass(value);
-					if (!_.isUndefined(check)) {
-						checks[id]['operator'] = check['operators'][0]['operator'];
-					}
-				}
-				// model change will trigger render
-				this.model.set({'checks': checks});
-			},
-			deleteCheck: function(event) {
-				console.log(arguments);
-				var id = $(event.target.parentElement).data('id'),
-					checks = JSON.parse(JSON.stringify(this.model.get('checks')));
+                if (key === null) {
+                    console.warn('checkChanged triggered but element doesn\'t have any "check-" class');
+                    return;
+                }
 
-				// splice removes 1 element at index `id`
-				checks.splice(id, 1);
-				// model change will trigger render
-				this.model.set({'checks': checks});
-			},
-			operationChanged: function(event) {
-				var value = event.target.value,
-					key = null;
+                if (!_.has(checks[id], key)) {
+                    console.warn('key "' + key + '" is not available in check', check);
+                    return;
+                }
 
-				for (var i = 0; i < event.target.classList.length; i++) {
-					var className = event.target.classList[i];
-					if (className.substr(0, 'operation-'.length) === 'operation-') {
-						key = className.substr('operation-'.length);
-						break;
-					}
-				}
+                checks[id][key] = value;
+                // if the class is changed most likely also the operators have changed
+                // with this we set the operator to the first possible operator
+                if (key === 'class') {
+                    var check = OCA.WorkflowEngine.getCheckByClass(value);
+                    if (!_.isUndefined(check)) {
+                        checks[id]['operator'] = check['operators'][0]['operator'];
+                    }
+                }
+                // model change will trigger render
+                this.model.set({ 'checks': checks });
+            },
+            deleteCheck: function(event) {
+                console.log(arguments);
+                var id = $(event.target.parentElement).data('id'),
+                    checks = JSON.parse(JSON.stringify(this.model.get('checks')));
 
-				if (key === null) {
-					console.warn('operationChanged triggered but element doesn\'t have any "operation-" class');
-					return;
-				}
+                // splice removes 1 element at index `id`
+                checks.splice(id, 1);
+                // model change will trigger render
+                this.model.set({ 'checks': checks });
+            },
+            operationChanged: function(event) {
+                var value = event.target.value,
+                    key = null;
 
-				if (key !== 'name' && key !== 'operation') {
-					console.warn('key "' + key + '" is no valid attribute');
-					return;
-				}
+                for (var i = 0; i < event.target.classList.length; i++) {
+                    var className = event.target.classList[i];
+                    if (className.substr(0, 'operation-'.length) === 'operation-') {
+                        key = className.substr('operation-'.length);
+                        break;
+                    }
+                }
 
-				// model change will trigger render
-				this.model.set(key, value);
-			},
-			render: function() {
-				this.$el.html(this.template({
-					operation: this.model.toJSON(),
-					classes: OCA.WorkflowEngine.availableChecks,
-					hasChanged: this.hasChanged,
-					message: this.message,
-					errorMessage: this.errorMessage,
-					saving: this.saving
-				}));
+                if (key === null) {
+                    console.warn('operationChanged triggered but element doesn\'t have any "operation-" class');
+                    return;
+                }
 
-				var checks = this.model.get('checks');
-				_.each(this.$el.find('.check'), function(element){
-					var $element = $(element),
-						id = $element.data('id'),
-						check = checks[id],
-						valueElement = $element.find('.check-value').first();
-						var self = this;
+                if (key !== 'name' && key !== 'operation') {
+                    console.warn('key "' + key + '" is no valid attribute');
+                    return;
+                }
 
-					_.each(OCA.WorkflowEngine.availablePlugins, function(plugin) {
-						if (_.isFunction(plugin.render)) {
-							plugin.render(valueElement, check, self.groups);
-						}
-					});
-				}, this);
+                // model change will trigger render
+                this.model.set(key, value);
+            },
+            render: function() {
+                this.$el.html(this.template({
+                    operation: this.model.toJSON(),
+                    classes: OCA.WorkflowEngine.availableChecks,
+                    hasChanged: this.hasChanged,
+                    message: this.message,
+                    errorMessage: this.errorMessage,
+                    saving: this.saving
+                }));
 
-				if (this.message !== '') {
-					// hide success messages after some time
-					_.delay(function(elements){
-						$(elements).css('opacity', 0);
-					}, 7000, this.$el.find('.msg.success'));
-					this.message = '';
-				}
+                var checks = this.model.get('checks');
+                _.each(this.$el.find('.check'), function(element) {
+                    var $element = $(element),
+                        id = $element.data('id'),
+                        check = checks[id],
+                        valueElement = $element.find('.check-value').first();
+                    var self = this;
 
-				return this.$el;
-			}
-		});
+                    _.each(OCA.WorkflowEngine.availablePlugins, function(plugin) {
+                        if (_.isFunction(plugin.render)) {
+                            plugin.render(valueElement, check, self.groups);
+                        }
+                    });
+                }, this);
 
-	/**
-	 * @class OCA.WorkflowEngine.OperationsView
-	 *
-	 * this creates the view for configured operations
-	 */
-	OCA.WorkflowEngine.OperationsView =
-		OCA.WorkflowEngine.TemplateView.extend({
-			templateId: '#operations-template',
-			collection: null,
-			$el: null,
-			events: {
-				'click .button-add-operation': 'add'
-			},
-			initialize: function(classname) {
-				if (!OCA.WorkflowEngine.availablePlugins.length) {
-					OCA.WorkflowEngine.availablePlugins = OC.Plugins.getPlugins('OCA.WorkflowEngine.CheckPlugins');
-					_.each(OCA.WorkflowEngine.availablePlugins, function(plugin) {
-						if (_.isFunction(plugin.getCheck)) {
-							OCA.WorkflowEngine.availableChecks.push(plugin.getCheck(classname));
-						}
-					});
-				}
+                if (this.message !== '') {
+                    // hide success messages after some time
+                    _.delay(function(elements) {
+                        $(elements).css('opacity', 0);
+                    }, 7000, this.$el.find('.msg.success'));
+                    this.message = '';
+                }
 
-				this.collection.fetch({data: {
-					'class': classname
-				}});
-				this.collection.once('sync', this.render, this);
-			},
-			add: function() {
-				var operation = this.collection.create();
-				this.renderOperation(operation);
-			},
-			renderOperation: function(subView){
-				var operationsElement = this.$el.find('.operations');
-				operationsElement.append(subView.$el);
-				subView.render();
-			},
-			render: function() {
-				this.$el.html(this.template());
-				this.collection.each(this.renderOperation, this);
-			}
-		});
+                return this.$el;
+            }
+        });
+
+    /**
+     * @class OCA.WorkflowEngine.OperationsView
+     *
+     * this creates the view for configured operations
+     */
+    OCA.WorkflowEngine.OperationsView =
+        OCA.WorkflowEngine.TemplateView.extend({
+            templateId: '#operations-template',
+            collection: null,
+            $el: null,
+            events: {
+                'click .button-add-operation': 'add'
+            },
+            initialize: function(classname) {
+                if (!OCA.WorkflowEngine.availablePlugins.length) {
+                    OCA.WorkflowEngine.availablePlugins = OC.Plugins.getPlugins('OCA.WorkflowEngine.CheckPlugins');
+                    _.each(OCA.WorkflowEngine.availablePlugins, function(plugin) {
+                        if (_.isFunction(plugin.getCheck)) {
+                            OCA.WorkflowEngine.availableChecks.push(plugin.getCheck(classname));
+                        }
+                    });
+                }
+
+                this.collection.fetch({
+                    data: {
+                        'class': classname
+                    }
+                });
+                this.collection.once('sync', this.render, this);
+            },
+            add: function() {
+                var operation = this.collection.create();
+                this.renderOperation(operation);
+            },
+            renderOperation: function(subView) {
+                var operationsElement = this.$el.find('.operations');
+                operationsElement.append(subView.$el);
+                subView.render();
+            },
+            render: function() {
+                this.$el.html(this.template());
+                this.collection.each(this.renderOperation, this);
+            }
+        });
 })();

--- a/settings/js/settings.js
+++ b/settings/js/settings.js
@@ -6,86 +6,89 @@
 OC.Settings = OC.Settings || {};
 OC.Settings = _.extend(OC.Settings, {
 
-	_cachedGroups: null,
+    _cachedGroups: null,
 
-	/**
-	 * Setup selection box for group selection.
-	 *
-	 * Values need to be separated by a pipe "|" character.
-	 * (mostly because a comma is more likely to be used
-	 * for groups)
-	 *
-	 * @param $elements jQuery element (hidden input) to setup select2 on
-	 * @param {Array} [extraOptions] extra options hash to pass to select2
-	 * @param {Array} [options] extra options
-	 * @param {Array} [options.excludeAdmins=false] flag whether to exclude admin groups
-	 */
-	setupGroupsSelect: function($elements, extraOptions, options) {
-		var self = this;
-		options = options || {};
-		if ($elements.length > 0) {
-			// Let's load the data and THEN init our select
-			$.ajax({
-				url: OC.generateUrl('/settings/users/groups'),
-				dataType: 'json',
-				success: function(data) {
-					var results = [];
+    /**
+     * Setup selection box for group selection.
+     *
+     * Values need to be separated by a pipe "|" character.
+     * (mostly because a comma is more likely to be used
+     * for groups)
+     *
+     * @param $elements jQuery element (hidden input) to setup select2 on
+     * @param {Array} [extraOptions] extra options hash to pass to select2
+     * @param {Array} [options] extra options
+     * @param {Array} [options.excludeAdmins=false] flag whether to exclude admin groups
+     */
+    setupGroupsSelect: function($elements, extraOptions, options) {
+        var self = this;
+        options = options || {};
+        if ($elements.length > 0) {
+            // Let's load the data and THEN init our select
+            $.ajax({
+                url: OC.linkToOCS('cloud/groups', 2) + 'details',
+                dataType: 'json',
+                success: function(data) {
+                    var results = [];
 
-					// add groups
-					if (!options.excludeAdmins) {
-						$.each(data.data.adminGroups, function(i, group) {
-							results.push({id:group.id, displayname:group.name});
-						});
-					}
-					$.each(data.data.groups, function(i, group) {
-						results.push({id:group.id, displayname:group.name});
-					});
-					// note: settings are saved through a "change" event registered
-					// on all input fields
-					$elements.select2(_.extend({
-						placeholder: t('core', 'Groups'),
-						allowClear: true,
-						multiple: true,
-						toggleSelect: true,
-						separator: '|',
-						data: { results: results, text: 'displayname' },
-						initSelection: function(element, callback) {
-							var groups = $(element).val();
-							var selection;
-							if (groups && results.length > 0) {
-								selection = _.map((groups || []).split('|').sort(), function(groupId) {
-									return {
-										id: groupId,
-										displayname: results.find(group =>group.id === groupId).displayname
-									};
-								});
-							} else if (groups) {
-								selection = _.map((groups || []).split('|').sort(), function(groupId) {
-									return {
-										id: groupId,
-										displayname: groupId
-									};
-								});
-							}
-							callback(selection);
-						},
-						formatResult: function (element) {
-							return escapeHTML(element.displayname);
-						},
-						formatSelection: function (element) {
-							return escapeHTML(element.displayname);
-						},
-						escapeMarkup: function(m) {
-							// prevent double markup escape
-							return m;
-						}
-					}, extraOptions || {}));
-				},
-				error : function(data) {
-					OC.Notification.show(t('settings', 'Unable to retrieve the group list'), {type: 'error'});
-					console.log(data);
-				}
-			});
-		}
-	}
+                    if (data.ocs.data.groups && data.ocs.data.groups.length > 0) {
+
+                        data.ocs.data.groups.forEach(function(group) {
+                            if (!options.excludeAdmins || group.id !== 'admin') {
+                                results.push({ id: group.id, displayname: group.displayname });
+                            }
+                        })
+
+                        // note: settings are saved through a "change" event registered
+                        // on all input fields
+                        $elements.select2(_.extend({
+                            placeholder: t('core', 'Groups'),
+                            allowClear: true,
+                            multiple: true,
+                            toggleSelect: true,
+                            separator: '|',
+                            data: { results: results, text: 'displayname' },
+                            initSelection: function(element, callback) {
+                                var groups = $(element).val();
+                                var selection;
+                                if (groups && results.length > 0) {
+                                    selection = _.map((groups || []).split('|').sort(), function(groupId) {
+                                        return {
+                                            id: groupId,
+                                            displayname: results.find(group => group.id === groupId).displayname
+                                        };
+                                    });
+                                } else if (groups) {
+                                    selection = _.map((groups || []).split('|').sort(), function(groupId) {
+                                        return {
+                                            id: groupId,
+                                            displayname: groupId
+                                        };
+                                    });
+                                }
+                                callback(selection);
+                            },
+                            formatResult: function(element) {
+                                return escapeHTML(element.displayname);
+                            },
+                            formatSelection: function(element) {
+                                return escapeHTML(element.displayname);
+                            },
+                            escapeMarkup: function(m) {
+                                // prevent double markup escape
+                                return m;
+                            }
+                        }, extraOptions || {}));
+                    } else {
+                        OC.Notification.show(t('settings', 'Group list is empty'), { type: 'error' });
+                        console.log(data);
+                    }
+                },
+                error: function(data) {
+                    OC.Notification.show(t('settings', 'Unable to retrieve the group list'), { type: 'error' });
+                    console.log(data);
+                }
+            });
+        }
+    }
 });


### PR DESCRIPTION
Use our ocs api instead of old group controller legacy in settings

I reformatted the files:
the only real change is:
https://github.com/nextcloud/server/pull/9296/files?w=1

``` js
            $.ajax({
                url: OC.linkToOCS('cloud/groups', 2) + 'details',
                dataType: 'json',
                success: function(data) {
                    var results = [];

                    if (data.ocs.data.groups && data.ocs.data.groups.length > 0) {

                        data.ocs.data.groups.forEach(function(group) {
                            if (!options.excludeAdmins || group.id !== 'admin') {
                                results.push({ id: group.id, displayname: group.displayname });
                            }
                        })
```