### PR TITLE
Do not add sharePermission logic in JS

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -254,20 +254,7 @@
 		 * @returns {String}
 		 */
 		getSharePermissions: function(fileData) {
-			var sharePermissions = fileData.permissions;
-			if (fileData.mountType && fileData.mountType === "external-root"){
-				// for external storages we can't use the permissions of the mountpoint
-				// instead we show all permissions and only use the share permissions from the mountpoint to handle resharing
-				sharePermissions = sharePermissions | (OC.PERMISSION_ALL & ~OC.PERMISSION_SHARE);
-			}
-			if (fileData.type === 'file') {
-				// files can't be shared with delete permissions
-				sharePermissions = sharePermissions & ~OC.PERMISSION_DELETE;
-
-				// create permissions don't mean anything for files
-				sharePermissions = sharePermissions & ~OC.PERMISSION_CREATE;
-			}
-			return sharePermissions;
+			return fileData.sharePermissions;
 		}
 	};
 })();

--- a/apps/files_sharing/tests/js/sharedfilelistSpec.js
+++ b/apps/files_sharing/tests/js/sharedfilelistSpec.js
@@ -723,6 +723,7 @@ describe('OCA.Sharing.FileList tests', function() {
 				mimetype: 'text/plain',
 				size: 12,
 				permissions: OC.PERMISSION_READ,
+				sharePermissions: OC.PERMISSION_READ,
 				etag: 'abc',
 				shareOwner: 'User One',
 				recipients: 'User Two',
@@ -730,7 +731,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			}]);
 			$tr = fileList.$el.find('tr:first');
 
-			expect(parseInt($tr.attr('data-share-permissions'), 10)).toEqual(OC.PERMISSION_ALL - OC.PERMISSION_SHARE);
+			expect(parseInt($tr.attr('data-share-permissions'), 10)).toEqual(OC.PERMISSION_READ);
 		});
 
 		it('external storage root folder reshare', function () {
@@ -744,6 +745,7 @@ describe('OCA.Sharing.FileList tests', function() {
 				mimetype: 'text/plain',
 				size: 12,
 				permissions: OC.PERMISSION_READ + OC.PERMISSION_SHARE,
+				sharePermissions: OC.PERMISSION_READ + OC.PERMISSION_SHARE,
 				etag: 'abc',
 				shareOwner: 'User One',
 				recipients: 'User Two',
@@ -751,7 +753,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			}]);
 			$tr = fileList.$el.find('tr:first');
 
-			expect(parseInt($tr.attr('data-share-permissions'), 10)).toEqual(OC.PERMISSION_ALL);
+			expect(parseInt($tr.attr('data-share-permissions'), 10)).toEqual(OC.PERMISSION_READ + OC.PERMISSION_SHARE);
 		});
 
 		it('external storage root folder file', function () {
@@ -765,6 +767,7 @@ describe('OCA.Sharing.FileList tests', function() {
 				mimetype: 'text/plain',
 				size: 12,
 				permissions: OC.PERMISSION_READ,
+				sharePermissions: OC.PERMISSION_READ,
 				etag: 'abc',
 				shareOwner: 'User One',
 				recipients: 'User Two',
@@ -773,7 +776,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			$tr = fileList.$el.find('tr:first');
 
 			expect(parseInt($tr.attr('data-share-permissions'), 10))
-				.toEqual(OC.PERMISSION_ALL - OC.PERMISSION_SHARE - OC.PERMISSION_DELETE - OC.PERMISSION_CREATE);
+				.toEqual(OC.PERMISSION_READ);
 		});
 	});
 });

--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -49,7 +49,8 @@
 			xmlNamespaces: {
 				'DAV:': 'd',
 				'http://owncloud.org/ns': 'oc',
-				'http://nextcloud.org/ns': 'nc'
+				'http://nextcloud.org/ns': 'nc',
+				'http://open-collaboration-services.org/ns': 'ocs'
 			}
 		};
 		if (options.userName) {
@@ -65,6 +66,7 @@
 	Client.NS_OWNCLOUD = 'http://owncloud.org/ns';
 	Client.NS_NEXTCLOUD = 'http://nextcloud.org/ns';
 	Client.NS_DAV = 'DAV:';
+	Client.NS_OCS = 'http://open-collaboration-services.org/ns';
 
 	Client.PROPERTY_GETLASTMODIFIED	= '{' + Client.NS_DAV + '}getlastmodified';
 	Client.PROPERTY_GETETAG	= '{' + Client.NS_DAV + '}getetag';
@@ -75,6 +77,7 @@
 	Client.PROPERTY_SIZE	= '{' + Client.NS_OWNCLOUD + '}size';
 	Client.PROPERTY_GETCONTENTLENGTH	= '{' + Client.NS_DAV + '}getcontentlength';
 	Client.PROPERTY_ISENCRYPTED	= '{' + Client.NS_DAV + '}is-encrypted';
+	Client.PROPERTY_SHARE_PERMISSIONS	= '{' + Client.NS_OCS + '}share-permissions';
 
 	Client.PROTOCOL_HTTP	= 'http';
 	Client.PROTOCOL_HTTPS	= 'https';
@@ -125,6 +128,10 @@
 		 * Encryption state
 		 */
 		[Client.NS_NEXTCLOUD, 'is-encrypted'],
+		/**
+		 * Share permissions
+		 */
+		[Client.NS_OCS, 'share-permissions']
 	];
 
 	/**
@@ -371,6 +378,11 @@
 							break;
 					}
 				}
+			}
+
+			var sharePermissionsProp = props[Client.PROPERTY_SHARE_PERMISSIONS];
+			if (!_.isUndefined(sharePermissionsProp)) {
+				data.sharePermissions = parseInt(sharePermissionsProp);
 			}
 
 			var mounTypeProp = props['{' + Client.NS_NEXTCLOUD + '}mount-type'];

--- a/core/js/files/fileinfo.js
+++ b/core/js/files/fileinfo.js
@@ -132,7 +132,12 @@
 		/**
 		 * @type boolean
 		 */
-		hasPreview: true
+		hasPreview: true,
+
+		/**
+		 * @type int
+		 */
+		sharePermissions: null
 	};
 
 	if (!OC.Files) {


### PR DESCRIPTION
We have a dedicated dav property. We should do all the magic in 1 place.
Not several.

Extracted from: https://github.com/nextcloud/server/pull/8564 as this is unrelated to that PR.
