### PR TITLE
Actually return the root folder when traversing up the tree

### DIFF
--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -265,7 +265,11 @@ class Node implements \OCP\Files\Node {
 	 * @return Node
 	 */
 	public function getParent() {
-		return $this->root->get(dirname($this->path));
+		$newPath = dirname($this->path);
+		if ($newPath === '' || $newPath === '.' || $newPath === '/') {
+			return $this->root;
+		}
+		return $this->root->get($newPath);
 	}
 
 	/**


### PR DESCRIPTION
If you now keep calling $node->getParent() you will at some point get
the RootFolder back. This is a nice termination check and will prevent
endless loops if an exit condition is slightly off.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>