### PR TITLE
Better swift V3 token handling

### DIFF
--- a/lib/private/Files/ObjectStore/SwiftFactory.php
+++ b/lib/private/Files/ObjectStore/SwiftFactory.php
@@ -131,9 +131,9 @@ class SwiftFactory {
 
 		$cachedToken = $this->params['cachedToken'];
 		$hasValidCachedToken = false;
-		if (is_array($cachedToken)) {
+		if (\is_array($cachedToken) && ($authService instanceof IdentityV3Service)) {
 			$token = $authService->generateTokenFromCache($cachedToken);
-			if (is_null($token->catalog)) {
+			if (\is_null($token->catalog)) {
 				$this->logger->warning('Invalid cached token for swift, no catalog set: ' . json_encode($cachedToken));
 			} else if ($token->hasExpired()) {
 				$this->logger->debug('Cached token for swift expired');

--- a/lib/private/Files/ObjectStore/SwiftFactory.php
+++ b/lib/private/Files/ObjectStore/SwiftFactory.php
@@ -56,7 +56,7 @@ class SwiftFactory {
 	private function getCachedToken(string $cacheKey) {
 		$cachedTokenString = $this->cache->get($cacheKey . '/token');
 		if ($cachedTokenString) {
-			return json_decode($cachedTokenString);
+			return json_decode($cachedTokenString, true);
 		} else {
 			return null;
 		}


### PR DESCRIPTION
* The cached token is expected to be an associative array
* The generateTokenFromCache is only present on the V3 service