### PR TITLE
Fix for unbound cloned LDAP connections

### DIFF
--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -126,6 +126,9 @@ class Connection extends LDAPUtility {
 	public function __clone() {
 		$this->configuration = new Configuration($this->configPrefix,
 												 !is_null($this->configID));
+		if(count($this->bindResult) !== 0 && $this->bindResult['result'] === true) {
+			$this->bindResult = [];
+		}
 		$this->ldapConnectionRes = null;
 		$this->dontDestruct = true;
 	}


### PR DESCRIPTION
Hi,

This is a fix for cloned LDAP connections which happen to be unbound since the ["track the state of the bind result" change](https://github.com/nextcloud/server/commit/9bc75307e788d99277ee7130a52ccae1b913cc6d#diff-eebdc050887fcec1851e13e3424827d7). 