### PR TITLE
Replace deprecated sinon reset() call with resetHistory()

### DIFF
--- a/settings/tests/js/users/deleteHandlerSpec.js
+++ b/settings/tests/js/users/deleteHandlerSpec.js
@@ -79,7 +79,7 @@ describe('DeleteHandler tests', function() {
 
 		expect(showNotificationSpy.calledOnce).toEqual(true);
 		expect(showNotificationSpy.getCall(0).args[0]).toEqual('removed some_uid entry');
-		showNotificationSpy.reset();
+		showNotificationSpy.resetHistory();
 
 		handler.mark('some_other_uid');
 


### PR DESCRIPTION
This fixes the jsunit CI error that came when it was run with sinon>5.0.0 which was release 3 days ago:

```
FAILED
	TypeError: undefined is not a function (evaluating 'showNotificationSpy.reset()') in settings/tests/js/users/deleteHandlerSpec.js (line 82)
	settings/tests/js/users/deleteHandlerSpec.js:82:28
```

See https://github.com/sinonjs/sinon/commit/88e6e5f7caed575a79f135ead6ecc3a17b704929
