### PR TITLE
Issue #9318: catch exceptions in SCSSCacher::resetCache()

### DIFF
--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -273,7 +273,11 @@ class SCSSCacher {
 		$appDirectory = $this->appData->getDirectoryListing();
 		foreach ($appDirectory as $folder) {
 			foreach ($folder->getDirectoryListing() as $file) {
-				$file->delete();
+				try {
+					$file->delete();
+				} catch(NotPermittedException $e) {
+					$this->logger->logException($e, ['message' => 'SCSSCacher: unable to delete file: ' . $file->getName()]);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes hard fails when SCSSCacher::resetCache() is not able to delete a cached file, as described in issue #9318 after an upgrade from Nextcloud 13.0.0.0 to 13.0.0.2.