### PR TITLE
[stable12] Replace deprecated sinon reset() call with resetHistory()

### DIFF
--- a/settings/tests/js/users/deleteHandlerSpec.js
+++ b/settings/tests/js/users/deleteHandlerSpec.js
@@ -79,7 +79,7 @@ describe('DeleteHandler tests', function() {
 
 		expect(showNotificationSpy.calledOnce).toEqual(true);
 		expect(showNotificationSpy.getCall(0).args[0]).toEqual('removed some_uid entry');
-		showNotificationSpy.reset();
+		showNotificationSpy.resetHistory();
 
 		handler.mark('some_other_uid');
 


### PR DESCRIPTION
backport of #9348 to fix the failing jsunit tests