### PR TITLE
Log mount and storage issues in getFileInfo

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1361,6 +1361,7 @@ class View {
 
 		$mount = Filesystem::getMountManager()->find($path);
 		if (!$mount) {
+			\OC::$server->getLogger()->warning('Mountpoint not found for path: ' . $path);
 			return false;
 		}
 		$storage = $mount->getStorage();
@@ -1392,6 +1393,8 @@ class View {
 			}
 
 			return $info;
+		} else {
+			\OC::$server->getLogger()->warning('Storage not valid for mountpoint: ' . $mount->getMountPoint());
 		}
 
 		return false;


### PR DESCRIPTION
Invalid mounts and storage generally mean something is wrong with the setup, this allows us to hopefully get more clues in such instances