### PR TITLE
Cache is not part of the quota

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Quota.php
+++ b/lib/private/Files/Storage/Wrapper/Quota.php
@@ -46,7 +46,7 @@ class Quota extends Wrapper {
 	 * @param array $parameters
 	 */
 	public function __construct($parameters) {
-		$this->storage = $parameters['storage'];
+		parent::__construct($parameters);
 		$this->quota = $parameters['quota'];
 		$this->sizeRoot = isset($parameters['root']) ? $parameters['root'] : '';
 	}
@@ -83,7 +83,7 @@ class Quota extends Wrapper {
 	 * @return int
 	 */
 	public function free_space($path) {
-		if ($this->quota < 0) {
+		if ($this->quota < 0 || strpos($path, 'cache') === 0) {
 			return $this->storage->free_space($path);
 		} else {
 			$used = $this->getSize($this->sizeRoot);
@@ -111,7 +111,7 @@ class Quota extends Wrapper {
 	 * @return bool
 	 */
 	public function file_put_contents($path, $data) {
-		$free = $this->free_space('');
+		$free = $this->free_space($path);
 		if ($free < 0 or strlen($data) < $free) {
 			return $this->storage->file_put_contents($path, $data);
 		} else {
@@ -127,7 +127,7 @@ class Quota extends Wrapper {
 	 * @return bool
 	 */
 	public function copy($source, $target) {
-		$free = $this->free_space('');
+		$free = $this->free_space($target);
 		if ($free < 0 or $this->getSize($source) < $free) {
 			return $this->storage->copy($source, $target);
 		} else {
@@ -147,7 +147,7 @@ class Quota extends Wrapper {
 
 		// don't apply quota for part files
 		if (!$this->isPartFile($path)) {
-			$free = $this->free_space('');
+			$free = $this->free_space($path);
 			if ($source && $free >= 0 && $mode !== 'r' && $mode !== 'rb') {
 				// only apply quota for files, not metadata, trash or others
 				if (strpos(ltrim($path, '/'), 'files/') === 0) {
@@ -178,7 +178,7 @@ class Quota extends Wrapper {
 	 * @return bool
 	 */
 	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
-		$free = $this->free_space('');
+		$free = $this->free_space($targetInternalPath);
 		if ($free < 0 or $this->getSize($sourceInternalPath, $sourceStorage) < $free) {
 			return $this->storage->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		} else {
@@ -193,7 +193,7 @@ class Quota extends Wrapper {
 	 * @return bool
 	 */
 	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
-		$free = $this->free_space('');
+		$free = $this->free_space($targetInternalPath);
 		if ($free < 0 or $this->getSize($sourceInternalPath, $sourceStorage) < $free) {
 			return $this->storage->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		} else {


### PR DESCRIPTION
Fixes #7444

Since the quota is calculated on the files. We should allow apps etc to
store temp stuff in the <user>/cache

Else users can't upload avatars for example.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>