### PR TITLE
Do not allow folder creation with quota of 0

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Quota.php
+++ b/lib/private/Files/Storage/Wrapper/Quota.php
@@ -200,4 +200,12 @@ class Quota extends Wrapper {
 			return false;
 		}
 	}
+
+	public function mkdir($path) {
+		if ($this->quota === 0.0) {
+			return false;
+		}
+
+		return parent::mkdir($path);
+	}
 }

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -208,4 +208,9 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$this->assertTrue($this->instance->instanceOfStorage('\OC\Files\Storage\Wrapper\Wrapper'));
 		$this->assertTrue($this->instance->instanceOfStorage('\OC\Files\Storage\Wrapper\Quota'));
 	}
+
+	public function testNoMkdirQuotaZero() {
+		$instance = $this->getLimitedStorage(0.0);
+		$this->assertFalse($instance->mkdir('foobar'));
+	}
 }


### PR DESCRIPTION
Fixes #4577

Users with a quota of 0 are a special case. Since they can't (ever)
create files on their own storage. Therefor it makes no real that they
can create folders (and possible share those etc).


Of course the alternative solution would be to do this in an app. However I feel this behavior makes the most sense...