### PR TITLE
Get correct version of an app

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -464,7 +464,7 @@ class OC_App {
 		} else {
 			$versionToLoad = [];
 			foreach ($possibleApps as $possibleApp) {
-				$version = self::getAppVersionByPath($possibleApp['path']);
+				$version = self::getAppVersionByPath($possibleApp['path'] . '/' . $appId);
 				if (empty($versionToLoad) || version_compare($version, $versionToLoad['version'], '>')) {
 					$versionToLoad = array(
 						'dir' => $possibleApp,


### PR DESCRIPTION
Related to #8929

We should get the version of the app. Not of the appfolder. Else there
is no way to properly compare the versions.

Now note that installing in 1 go will still fail. But at least on the
next page load the new version will be properly detected.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>