### PR TITLE
Add autocomplete to migration commands

### DIFF
--- a/core/Command/Db/Migrations/ExecuteCommand.php
+++ b/core/Command/Db/Migrations/ExecuteCommand.php
@@ -26,27 +26,35 @@ namespace OC\Core\Command\Db\Migrations;
 
 use OC\DB\MigrationService;
 use OC\Migration\ConsoleOutput;
+use OCP\App\IAppManager;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ExecuteCommand extends Command {
+class ExecuteCommand extends Command implements CompletionAwareInterface {
 
 	/** @var IDBConnection */
 	private $connection;
+
 	/** @var IConfig */
 	private $config;
+
+	/** @var IAppManager */
+	protected $appManager;
 
 	/**
 	 * ExecuteCommand constructor.
 	 *
 	 * @param IDBConnection $connection
 	 * @param IConfig $config
+	 * @param IAppManager $appManager
 	 */
-	public function __construct(IDBConnection $connection, IConfig $config) {
+	public function __construct(IDBConnection $connection, IAppManager $appManager, IConfig $config) {
 		$this->connection = $connection;
 		$this->config = $config;
 
@@ -86,6 +94,39 @@ class ExecuteCommand extends Command {
 
 		$ms->executeStep($version);
 		return 0;
+	}
+
+	/**
+	 * @param string $optionName
+	 * @param CompletionContext $context
+	 * @return string[]
+	 */
+	public function completeOptionValues($optionName, CompletionContext $context) {
+		return [];
+	}
+
+	/**
+	 * @param string $argumentName
+	 * @param CompletionContext $context
+	 * @return string[]
+	 */
+	public function completeArgumentValues($argumentName, CompletionContext $context) {
+		if ($argumentName === 'app') {
+			$allApps = \OC_App::getAllApps();
+			return array_diff($allApps, \OC_App::getEnabledApps(true, true));
+		}
+
+		if ($argumentName === 'version') {
+			$appName = $context->getWordAtIndex($context->getWordIndex() - 1);
+
+			$ms = new MigrationService($appName, $this->connection);
+			$migrations = $ms->getAvailableVersions();
+
+			array_unshift($migrations, 'next', 'latest');
+			return $migrations;
+		}
+
+		return [];
 	}
 
 }

--- a/core/Command/Db/Migrations/GenerateCommand.php
+++ b/core/Command/Db/Migrations/GenerateCommand.php
@@ -26,14 +26,17 @@ namespace OC\Core\Command\Db\Migrations;
 
 use OC\DB\MigrationService;
 use OC\Migration\ConsoleOutput;
+use OCP\App\IAppManager;
 use OCP\IDBConnection;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class GenerateCommand extends Command {
+class GenerateCommand extends Command implements CompletionAwareInterface {
 
 	protected static $_templateSimple =
 		'<?php
@@ -82,11 +85,16 @@ class {{classname}} extends SimpleMigrationStep {
 	/** @var IDBConnection */
 	protected $connection;
 
+	/** @var IAppManager */
+	protected $appManager;
+
 	/**
 	 * @param IDBConnection $connection
+	 * @param IAppManager $appManager
 	 */
-	public function __construct(IDBConnection $connection) {
+	public function __construct(IDBConnection $connection, IAppManager $appManager) {
 		$this->connection = $connection;
+		$this->appManager = $appManager;
 
 		parent::__construct();
 	}
@@ -117,6 +125,36 @@ class {{classname}} extends SimpleMigrationStep {
 
 		$output->writeln("New migration class has been generated to <info>$path</info>");
 		return 0;
+	}
+
+	/**
+	 * @param string $optionName
+	 * @param CompletionContext $context
+	 * @return string[]
+	 */
+	public function completeOptionValues($optionName, CompletionContext $context) {
+		return [];
+	}
+
+	/**
+	 * @param string $argumentName
+	 * @param CompletionContext $context
+	 * @return string[]
+	 */
+	public function completeArgumentValues($argumentName, CompletionContext $context) {
+		if ($argumentName === 'app') {
+			$allApps = \OC_App::getAllApps();
+			return array_diff($allApps, \OC_App::getEnabledApps(true, true));
+		}
+
+		if ($argumentName === 'version') {
+			$appName = $context->getWordAtIndex($context->getWordIndex() - 1);
+
+			$version = explode('.', $this->appManager->getAppVersion($appName));
+			return [$version[0] . sprintf('%1$03d', $version[1])];
+		}
+
+		return [];
 	}
 
 	/**

--- a/core/Command/Db/Migrations/GenerateFromSchemaFileCommand.php
+++ b/core/Command/Db/Migrations/GenerateFromSchemaFileCommand.php
@@ -39,13 +39,9 @@ class GenerateFromSchemaFileCommand extends GenerateCommand {
 	/** @var IConfig */
 	protected $config;
 
-	/** @var IAppManager */
-	protected $appManager;
-
 	public function __construct(IConfig $config, IAppManager $appManager, IDBConnection $connection) {
-		parent::__construct($connection);
+		parent::__construct($connection, $appManager);
 		$this->config = $config;
-		$this->appManager = $appManager;
 	}
 
 

--- a/core/Command/Db/Migrations/MigrateCommand.php
+++ b/core/Command/Db/Migrations/MigrateCommand.php
@@ -26,12 +26,14 @@ namespace OC\Core\Command\Db\Migrations;
 use OC\DB\MigrationService;
 use OC\Migration\ConsoleOutput;
 use OCP\IDBConnection;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class MigrateCommand extends Command {
+class MigrateCommand extends Command implements CompletionAwareInterface {
 
 	/** @var IDBConnection */
 	private $connection;
@@ -60,6 +62,39 @@ class MigrateCommand extends Command {
 		$version = $input->getArgument('version');
 
 		$ms->migrate($version);
+	}
+
+	/**
+	 * @param string $optionName
+	 * @param CompletionContext $context
+	 * @return string[]
+	 */
+	public function completeOptionValues($optionName, CompletionContext $context) {
+		return [];
+	}
+
+	/**
+	 * @param string $argumentName
+	 * @param CompletionContext $context
+	 * @return string[]
+	 */
+	public function completeArgumentValues($argumentName, CompletionContext $context) {
+		if ($argumentName === 'app') {
+			$allApps = \OC_App::getAllApps();
+			return array_diff($allApps, \OC_App::getEnabledApps(true, true));
+		}
+
+		if ($argumentName === 'version') {
+			$appName = $context->getWordAtIndex($context->getWordIndex() - 1);
+
+			$ms = new MigrationService($appName, $this->connection);
+			$migrations = $ms->getAvailableVersions();
+
+			array_unshift($migrations, 'next', 'latest');
+			return $migrations;
+		}
+
+		return [];
 	}
 
 }

--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -25,12 +25,14 @@ namespace OC\Core\Command\Db\Migrations;
 use OC\DB\MigrationService;
 use OC\Migration\ConsoleOutput;
 use OCP\IDBConnection;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class StatusCommand extends Command {
+class StatusCommand extends Command implements CompletionAwareInterface {
 
 	/** @var IDBConnection */
 	private $connection;
@@ -58,6 +60,28 @@ class StatusCommand extends Command {
 		foreach ($infos as $key => $value) {
 			$output->writeln("    <comment>>></comment> $key: " . str_repeat(' ', 50 - strlen($key)) . $value);
 		}
+	}
+
+	/**
+	 * @param string $optionName
+	 * @param CompletionContext $context
+	 * @return string[]
+	 */
+	public function completeOptionValues($optionName, CompletionContext $context) {
+		return [];
+	}
+
+	/**
+	 * @param string $argumentName
+	 * @param CompletionContext $context
+	 * @return string[]
+	 */
+	public function completeArgumentValues($argumentName, CompletionContext $context) {
+		if ($argumentName === 'app') {
+			$allApps = \OC_App::getAllApps();
+			return array_diff($allApps, \OC_App::getEnabledApps(true, true));
+		}
+		return [];
 	}
 
 	/**

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -92,9 +92,9 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Db\AddMissingIndices(\OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\Db\Migrations\StatusCommand(\OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\Db\Migrations\MigrateCommand(\OC::$server->getDatabaseConnection()));
-	$application->add(new OC\Core\Command\Db\Migrations\GenerateCommand(\OC::$server->getDatabaseConnection()));
+	$application->add(new OC\Core\Command\Db\Migrations\GenerateCommand(\OC::$server->getDatabaseConnection(), \OC::$server->getAppManager()));
 	$application->add(new OC\Core\Command\Db\Migrations\GenerateFromSchemaFileCommand(\OC::$server->getConfig(), \OC::$server->getAppManager(), \OC::$server->getDatabaseConnection()));
-	$application->add(new OC\Core\Command\Db\Migrations\ExecuteCommand(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\Db\Migrations\ExecuteCommand(\OC::$server->getDatabaseConnection(), \OC::$server->getAppManager(), \OC::$server->getConfig()));
 
 	$application->add(new OC\Core\Command\Encryption\Disable(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Encryption\Enable(\OC::$server->getConfig(), \OC::$server->getEncryptionManager()));


### PR DESCRIPTION
Start typing `occ migration:generate <forget your appid>` 
Now with `tab` you can autocomplete it just fine.

Also works for the version suggestion and for the other commands it suggestions the available migrations