### PR TITLE
Fix jsunit tests

### DIFF
--- a/apps/files/tests/js/fileUploadSpec.js
+++ b/apps/files/tests/js/fileUploadSpec.js
@@ -66,7 +66,7 @@ describe('OC.Upload tests', function() {
 				originalFiles: files,
 				files: [file],
 				jqXHR: jqXHR,
-				response: sinon.stub.returns(jqXHR),
+				response: sinon.stub().returns(jqXHR),
 				submit: sinon.stub()
 			};
 			if (uploader.fileUploadParam.add.call(


### PR DESCRIPTION
Seems like the behaviour changed somewhere between sinon version 5.0.1 and the current 5.0.5, but I could not find any reference in the changes.

Anyhow this fixes the jsunit tests in drone again. We should also backport this back to stable13/stable12, as it is broken there as well.

Please review @nextcloud/javascript 