### PR TITLE
Expose isCLI to DI

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -164,6 +164,9 @@ class Server extends ServerContainer implements IServerContainer {
 		parent::__construct();
 		$this->webRoot = $webRoot;
 
+		// To find out if we are running from CLI or not
+		$this->registerParameter('isCLI', \OC::$CLI);
+
 		$this->registerService(\OCP\IServerContainer::class, function (IServerContainer $c) {
 			return $c;
 		});


### PR DESCRIPTION
This allows apps/backgroundjobs to find out if they are run from the CLI
or not. Some apps/backgroundjobs might do more if they are not at risk
of timing out.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>