### PR TITLE
Add data-id to settings navigation

### DIFF
--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -131,7 +131,7 @@
 						aria-label="<?php p($l->t('Settings menu'));?>">
 					<ul>
 					<?php foreach($_['settingsnavigation'] as $entry):?>
-						<li>
+						<li data-id="<?php p($entry['id']); ?>">
 							<a href="<?php print_unescaped($entry['href']); ?>"
 								<?php if( $entry["active"] ): ?> class="active"<?php endif; ?>>
 								<img alt="" src="<?php print_unescaped($entry['icon'] . '?v=' . $_['versionHash']); ?>">


### PR DESCRIPTION
Add id of navigation entries as data attribute to the settings navigation.

We already have this for the main app navigation. 

Required for https://github.com/nextcloud/firstrunwizard/pull/64