### PR TITLE
Move the webui over to the new dav endpoint

### DIFF
--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -932,7 +932,7 @@
 		var client = new OC.Files.Client({
 			host: OC.getHost(),
 			port: OC.getPort(),
-			root: OC.linkToRemoteBase('webdav'),
+			root: OC.linkToRemoteBase('dav') + '/files/' + OC.getCurrentUser().uid,
 			useHTTPS: OC.getProtocol() === 'https'
 		});
 		OC.Files._defaultClient = client;


### PR DESCRIPTION
We should use the new dav endpoint everywhere now.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>