### PR TITLE
make sure force language is reflected in html lang attribute

### DIFF
--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -126,14 +126,13 @@ class Factory implements IFactory {
 	 * @return string language If nothing works it returns 'en'
 	 */
 	public function findLanguage($app = null) {
-		if ($this->requestLanguage !== '' && $this->languageExists($app, $this->requestLanguage)) {
-			return $this->requestLanguage;
+		$forceLang = $this->config->getSystemValue('force_language', false);
+		if (is_string($forceLang)) {
+			$this->requestLanguage = $forceLang;
 		}
 
-		$forceLang = $this->config->getSystemValue('force_language', false);
-		if (is_string($forceLang) && $this->languageExists($app, $forceLang)) {
-			$this->requestLanguage = $forceLang;
-			return $forceLang;
+		if ($this->requestLanguage !== '' && $this->languageExists($app, $this->requestLanguage)) {
+			return $this->requestLanguage;
 		}
 
 		/**

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -130,6 +130,12 @@ class Factory implements IFactory {
 			return $this->requestLanguage;
 		}
 
+		$forceLang = $this->config->getSystemValue('force_language', false);
+		if (is_string($forceLang) && $this->languageExists($app, $forceLang)) {
+			$this->requestLanguage = $forceLang;
+			return $forceLang;
+		}
+
 		/**
 		 * At this point Nextcloud might not yet be installed and thus the lookup
 		 * in the preferences table might fail. For this reason we need to check

--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -117,7 +117,12 @@ class FactoryTest extends TestCase {
 				->with('MyApp', 'de')
 				->willReturn(false);
 		$this->config
-			->expects($this->once())
+			->expects($this->at(0))
+			->method('getSystemValue')
+			->with('force_language', false)
+			->willReturn(false);
+		$this->config
+			->expects($this->at(1))
 			->method('getSystemValue')
 			->with('installed', false)
 			->willReturn(true);
@@ -151,7 +156,12 @@ class FactoryTest extends TestCase {
 				->with('MyApp', 'de')
 				->willReturn(false);
 		$this->config
-				->expects($this->at(0))
+			->expects($this->at(0))
+			->method('getSystemValue')
+			->with('force_language', false)
+			->willReturn(false);
+		$this->config
+				->expects($this->at(1))
 				->method('getSystemValue')
 				->with('installed', false)
 				->willReturn(true);
@@ -174,7 +184,7 @@ class FactoryTest extends TestCase {
 				->with('MyApp', 'jp')
 				->willReturn(false);
 		$this->config
-				->expects($this->at(2))
+				->expects($this->at(3))
 				->method('getSystemValue')
 				->with('default_language', false)
 				->willReturn('es');
@@ -194,7 +204,12 @@ class FactoryTest extends TestCase {
 				->with('MyApp', 'de')
 				->willReturn(false);
 		$this->config
-				->expects($this->at(0))
+			->expects($this->at(0))
+			->method('getSystemValue')
+			->with('force_language', false)
+			->willReturn(false);
+		$this->config
+				->expects($this->at(1))
 				->method('getSystemValue')
 				->with('installed', false)
 				->willReturn(true);
@@ -217,7 +232,7 @@ class FactoryTest extends TestCase {
 				->with('MyApp', 'jp')
 				->willReturn(false);
 		$this->config
-				->expects($this->at(2))
+				->expects($this->at(3))
 				->method('getSystemValue')
 				->with('default_language', false)
 				->willReturn('es');
@@ -240,7 +255,12 @@ class FactoryTest extends TestCase {
 				->with('MyApp', 'de')
 				->willReturn(false);
 		$this->config
-				->expects($this->at(0))
+			->expects($this->at(0))
+			->method('getSystemValue')
+			->with('force_language', false)
+			->willReturn(false);
+		$this->config
+				->expects($this->at(1))
 				->method('getSystemValue')
 				->with('installed', false)
 				->willReturn(true);
@@ -263,7 +283,7 @@ class FactoryTest extends TestCase {
 				->with('MyApp', 'jp')
 				->willReturn(false);
 		$this->config
-				->expects($this->at(2))
+				->expects($this->at(3))
 				->method('getSystemValue')
 				->with('default_language', false)
 				->willReturn('es');
@@ -278,6 +298,22 @@ class FactoryTest extends TestCase {
 
 
 		$this->assertSame('en', $factory->findLanguage('MyApp'));
+	}
+
+	public function testFindLanguageWithForcedLanguage() {
+		$factory = $this->getFactory(['languageExists']);
+		$this->config
+			->expects($this->at(0))
+			->method('getSystemValue')
+			->with('force_language', false)
+			->willReturn('de');
+
+		$factory->expects($this->once())
+			->method('languageExists')
+			->with('MyApp', 'de')
+			->willReturn(true);
+
+		$this->assertSame('de', $factory->findLanguage('MyApp'));
 	}
 
 	/**


### PR DESCRIPTION
Steps to reproduce:
- set `force_language` in config.php (e.g. to `de`)
- everything that's translated in javascript will still be english, because force language is not properly reflected in the `lang` attribute of the `html` element.

before:
![before](https://user-images.githubusercontent.com/1250540/39809338-c8787e5e-5381-11e8-97ee-0250ddb69d78.jpg)


after:
![after](https://user-images.githubusercontent.com/1250540/39809324-c020afc4-5381-11e8-9cf0-e7502c115ad1.jpg)

Ref: https://help.nextcloud.com/t/spracheinstellung-im-kalender/30969/16