### PR TITLE
Use APCu caching of composer

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -286,7 +286,7 @@ pipeline:
         DB: mysqlmb4
         PHP: 7.2
   integration-capabilities_features:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -295,7 +295,7 @@ pipeline:
       matrix:
         TESTS: integration-capabilities_features
   integration-federation_features:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin
       - cd build/integration
@@ -304,7 +304,7 @@ pipeline:
       matrix:
         TESTS: integration-federation_features
   integration-auth:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -313,7 +313,7 @@ pipeline:
       matrix:
         TESTS: integration-auth
   integration-maintenance-mode:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -322,7 +322,7 @@ pipeline:
       matrix:
         TESTS: integration-maintenance-mode
   integration-ratelimiting:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - ./occ config:system:set redis host --value=cache
@@ -337,7 +337,7 @@ pipeline:
       matrix:
         TESTS: integration-ratelimiting
   integration-carddav:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -346,7 +346,7 @@ pipeline:
       matrix:
         TESTS: integration-carddav
   integration-dav-v2:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -355,7 +355,7 @@ pipeline:
       matrix:
         TESTS: integration-dav-v2
   integration-ocs-v1:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -364,7 +364,7 @@ pipeline:
       matrix:
         TESTS: integration-ocs-v1
   integration-sharing-v1:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -373,7 +373,7 @@ pipeline:
       matrix:
         TESTS: integration-sharing-v1
   integration-sharing-v1-part2:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -382,7 +382,7 @@ pipeline:
       matrix:
         TESTS: integration-sharing-v1-part2
   integration-sharing-v1-part3:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -391,7 +391,7 @@ pipeline:
       matrix:
         TESTS: integration-sharing-v1-part3
   integration-checksums-v1:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -400,7 +400,7 @@ pipeline:
       matrix:
         TESTS: integration-checksums
   integration-external-storage:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -409,7 +409,7 @@ pipeline:
       matrix:
         TESTS: integration-external-storage
   integration-provisioning-v1:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -418,7 +418,7 @@ pipeline:
       matrix:
         TESTS: integration-provisioning-v1
   integration-tags:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -427,7 +427,7 @@ pipeline:
       matrix:
         TESTS: integration-tags
   integration-caldav:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -436,7 +436,7 @@ pipeline:
       matrix:
         TESTS: integration-caldav
   integration-comments:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -445,7 +445,7 @@ pipeline:
       matrix:
         TESTS: integration-comments
   integration-favorites:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -454,7 +454,7 @@ pipeline:
       matrix:
         TESTS: integration-favorites
   integration-provisioning-v2:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -463,7 +463,7 @@ pipeline:
       matrix:
         TESTS: integration-provisioning-v2
   integration-webdav-related:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -472,7 +472,7 @@ pipeline:
       matrix:
         TESTS: integration-webdav-related
   integration-sharees-features:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -481,7 +481,7 @@ pipeline:
       matrix:
         TESTS: integration-sharees-features
   integration-sharees-v2-features:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -490,7 +490,7 @@ pipeline:
       matrix:
         TESTS: integration-sharees-v2-features
   integration-setup-features:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - cd build/integration
       - ./run.sh setup_features/setup.feature
@@ -498,7 +498,7 @@ pipeline:
       matrix:
         TESTS: integration-setup-features
   integration-filesdrop-features:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -507,7 +507,7 @@ pipeline:
       matrix:
         TESTS: integration-filesdrop-features
   integration-transfer-ownership-features:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -516,7 +516,7 @@ pipeline:
       matrix:
         TESTS: integration-transfer-ownership-features
   integration-ldap-features:
-      image: nextcloudci/integration-php7.0:integration-php7.0-6
+      image: nextcloudci/integration-php7.0:integration-php7.0-8
       commands:
         - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
         - ./occ app:enable user_ldap
@@ -526,7 +526,7 @@ pipeline:
         matrix:
           TESTS: integration-ldap-features
   integration-trashbin:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -535,7 +535,7 @@ pipeline:
       matrix:
         TESTS: integration-trashbin
   integration-remote-api:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration
@@ -544,7 +544,7 @@ pipeline:
       matrix:
         TESTS: integration-remote-api
   integration-download:
-    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
       - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
       - cd build/integration

--- a/lib/base.php
+++ b/lib/base.php
@@ -891,6 +891,8 @@ class OC {
 				self::$loader->setMemoryCache($memcacheFactory->createLocal('Autoloader'));
 			} catch (\Exception $ex) {
 			}
+
+			self::$composerAutoloader->setApcuPrefix($instanceId . '-mainComposer');
 		}
 	}
 


### PR DESCRIPTION
Should potentially shave of a few ms when loading classes of apps that
don't ship their own autoloader.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>