### PR TITLE
Support fileid propfind on trash endpoint

### DIFF
--- a/apps/files_trashbin/lib/Helper.php
+++ b/apps/files_trashbin/lib/Helper.php
@@ -62,7 +62,6 @@ class Helper {
 		$dirContent = $storage->getCache()->getFolderContents($mount->getInternalPath($view->getAbsolutePath($dir)));
 		foreach ($dirContent as $entry) {
 			$entryName = $entry->getName();
-			$id = $entry->getId();
 			$name = $entryName;
 			if ($dir === '' || $dir === '/') {
 				$pathparts = pathinfo($entryName);
@@ -91,7 +90,8 @@ class Helper {
 				'directory' => ($dir === '/') ? '' : $dir,
 				'size' => $entry->getSize(),
 				'etag' => '',
-				'permissions' => Constants::PERMISSION_ALL - Constants::PERMISSION_SHARE
+				'permissions' => Constants::PERMISSION_ALL - Constants::PERMISSION_SHARE,
+				'fileid' => $entry->getId(),
 			);
 			if ($originalPath) {
 				if ($originalPath !== '.') {

--- a/apps/files_trashbin/lib/Sabre/ITrash.php
+++ b/apps/files_trashbin/lib/Sabre/ITrash.php
@@ -33,4 +33,6 @@ interface ITrash {
 	public function getDeletionTime(): int;
 
 	public function getSize();
+
+	public function getFileId(): int;
 }

--- a/apps/files_trashbin/lib/Sabre/PropfindPlugin.php
+++ b/apps/files_trashbin/lib/Sabre/PropfindPlugin.php
@@ -69,6 +69,10 @@ class PropfindPlugin extends ServerPlugin {
 		$propFind->handle(FilesPlugin::SIZE_PROPERTYNAME, function () use ($node) {
 			return $node->getSize();
 		});
+
+		$propFind->handle(FilesPlugin::FILEID_PROPERTYNAME, function () use ($node) {
+			return $node->getFileId();
+		});
 	}
 
 }

--- a/apps/files_trashbin/lib/Sabre/TrashFile.php
+++ b/apps/files_trashbin/lib/Sabre/TrashFile.php
@@ -90,4 +90,10 @@ class TrashFile implements IFile, ITrash {
 	public function getDeletionTime(): int {
 		return $this->getLastModified();
 	}
+
+	public function getFileId(): int {
+		return $this->data->getId();
+	}
+
+
 }

--- a/apps/files_trashbin/lib/Sabre/TrashFolder.php
+++ b/apps/files_trashbin/lib/Sabre/TrashFolder.php
@@ -123,4 +123,8 @@ class TrashFolder implements ICollection, ITrash {
 	public function getSize(): int {
 		return $this->data->getSize();
 	}
+
+	public function getFileId(): int {
+		return $this->data->getId();
+	}
 }

--- a/apps/files_trashbin/lib/Sabre/TrashFolderFile.php
+++ b/apps/files_trashbin/lib/Sabre/TrashFolderFile.php
@@ -101,4 +101,8 @@ class TrashFolderFile implements IFile, ITrash {
 	public function getDeletionTime(): int {
 		return $this->getLastModified();
 	}
+
+	public function getFileId(): int {
+		return $this->data->getId();
+	}
 }

--- a/apps/files_trashbin/lib/Sabre/TrashFolderFolder.php
+++ b/apps/files_trashbin/lib/Sabre/TrashFolderFolder.php
@@ -136,4 +136,8 @@ class TrashFolderFolder implements ICollection, ITrash {
 	public function getSize(): int {
 		return $this->data->getSize();
 	}
+
+	public function getFileId(): int {
+		return $this->data->getId();
+	}
 }


### PR DESCRIPTION
Fixes #9416

In order to support previews on mobile clients they will need the fileid
of files in the trashbin.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>