### PR TITLE
Trashbin propfind respond to oc:size

### DIFF
--- a/apps/files_trashbin/lib/Sabre/ITrash.php
+++ b/apps/files_trashbin/lib/Sabre/ITrash.php
@@ -31,4 +31,6 @@ interface ITrash {
 	public function getOriginalLocation(): string;
 
 	public function getDeletionTime(): int;
+
+	public function getSize();
 }

--- a/apps/files_trashbin/lib/Sabre/PropfindPlugin.php
+++ b/apps/files_trashbin/lib/Sabre/PropfindPlugin.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace OCA\Files_Trashbin\Sabre;
 
+use OCA\DAV\Connector\Sabre\FilesPlugin;
 use Sabre\DAV\INode;
 use Sabre\DAV\PropFind;
 use Sabre\DAV\Server;
@@ -63,6 +64,10 @@ class PropfindPlugin extends ServerPlugin {
 
 		$propFind->handle(self::TRASHBIN_DELETION_TIME, function () use ($node) {
 			return $node->getDeletionTime();
+		});
+
+		$propFind->handle(FilesPlugin::SIZE_PROPERTYNAME, function () use ($node) {
+			return $node->getSize();
 		});
 	}
 

--- a/apps/files_trashbin/lib/Sabre/TrashFolder.php
+++ b/apps/files_trashbin/lib/Sabre/TrashFolder.php
@@ -120,4 +120,7 @@ class TrashFolder implements ICollection, ITrash {
 		return $this->getLastModified();
 	}
 
+	public function getSize(): int {
+		return $this->data->getSize();
+	}
 }

--- a/apps/files_trashbin/lib/Sabre/TrashFolderFolder.php
+++ b/apps/files_trashbin/lib/Sabre/TrashFolderFolder.php
@@ -132,4 +132,8 @@ class TrashFolderFolder implements ICollection, ITrash {
 	public function getDeletionTime(): int {
 		return $this->getLastModified();
 	}
+
+	public function getSize(): int {
+		return $this->data->getSize();
+	}
 }


### PR DESCRIPTION
In order to display the total size of folders also in the clients (and
web) we should return the oc:size.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>