### PR TITLE
[stable13] Fix ids of permission checkboxes for shares

### DIFF
--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -380,9 +380,7 @@
 				var $li = this.$('li[data-share-id=' + permissionChangeShareId + ']');
 				$li.find('.sharingOptionsGroup .popovermenu').replaceWith(this.popoverMenuTemplate(sharee));
 
-				var checkBoxId = 'canEdit-' + this.cid + '-' + sharee.shareId;
-				checkBoxId = '#' + checkBoxId.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1");
-				var $edit = $li.parent().find(checkBoxId);
+				var $edit = $li.parent().find('#canEdit-' + this.cid + '-' + sharee.shareId);
 				if($edit.length === 1) {
 					$edit.prop('checked', sharee.hasEditPermission);
 				}

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -30,8 +30,8 @@
 					'<span class="sharingOptionsGroup">' +
 						'{{#if editPermissionPossible}}' +
 						'<span class="shareOption">' +
-							'<input id="canEdit-{{cid}}-{{shareWith}}" type="checkbox" name="edit" class="permissions checkbox" {{#if hasEditPermission}}checked="checked"{{/if}} />' +
-							'<label for="canEdit-{{cid}}-{{shareWith}}">{{canEditLabel}}</label>' +
+							'<input id="canEdit-{{cid}}-{{shareId}}" type="checkbox" name="edit" class="permissions checkbox" {{#if hasEditPermission}}checked="checked"{{/if}} />' +
+							'<label for="canEdit-{{cid}}-{{shareId}}">{{canEditLabel}}</label>' +
 						'</span>' +
 						'{{/if}}' +
 						'<a href="#"><span class="icon icon-more"></span></a>' +
@@ -58,8 +58,8 @@
 				'{{#if isResharingAllowed}} {{#if sharePermissionPossible}} {{#unless isMailShare}}' +
 				'<li>' +
 					'<span class="shareOption menuitem">' +
-						'<input id="canShare-{{cid}}-{{shareWith}}" type="checkbox" name="share" class="permissions checkbox" {{#if hasSharePermission}}checked="checked"{{/if}} data-permissions="{{sharePermission}}" />' +
-						'<label for="canShare-{{cid}}-{{shareWith}}">{{canShareLabel}}</label>' +
+						'<input id="canShare-{{cid}}-{{shareId}}" type="checkbox" name="share" class="permissions checkbox" {{#if hasSharePermission}}checked="checked"{{/if}} data-permissions="{{sharePermission}}" />' +
+						'<label for="canShare-{{cid}}-{{shareId}}">{{canShareLabel}}</label>' +
 					'</span>' +
 				'</li>' +
 				'{{/unless}} {{/if}} {{/if}}' +
@@ -67,24 +67,24 @@
 					'{{#if createPermissionPossible}}{{#unless isMailShare}}' +
 					'<li>' +
 						'<span class="shareOption menuitem">' +
-							'<input id="canCreate-{{cid}}-{{shareWith}}" type="checkbox" name="create" class="permissions checkbox" {{#if hasCreatePermission}}checked="checked"{{/if}} data-permissions="{{createPermission}}"/>' +
-							'<label for="canCreate-{{cid}}-{{shareWith}}">{{createPermissionLabel}}</label>' +
+							'<input id="canCreate-{{cid}}-{{shareId}}" type="checkbox" name="create" class="permissions checkbox" {{#if hasCreatePermission}}checked="checked"{{/if}} data-permissions="{{createPermission}}"/>' +
+							'<label for="canCreate-{{cid}}-{{shareId}}">{{createPermissionLabel}}</label>' +
 						'</span>' +
 					'</li>' +
 					'{{/unless}}{{/if}}' +
 					'{{#if updatePermissionPossible}}{{#unless isMailShare}}' +
 					'<li>' +
 						'<span class="shareOption menuitem">' +
-							'<input id="canUpdate-{{cid}}-{{shareWith}}" type="checkbox" name="update" class="permissions checkbox" {{#if hasUpdatePermission}}checked="checked"{{/if}} data-permissions="{{updatePermission}}"/>' +
-							'<label for="canUpdate-{{cid}}-{{shareWith}}">{{updatePermissionLabel}}</label>' +
+							'<input id="canUpdate-{{cid}}-{{shareId}}" type="checkbox" name="update" class="permissions checkbox" {{#if hasUpdatePermission}}checked="checked"{{/if}} data-permissions="{{updatePermission}}"/>' +
+							'<label for="canUpdate-{{cid}}-{{shareId}}">{{updatePermissionLabel}}</label>' +
 						'</span>' +
 					'</li>' +
 					'{{/unless}}{{/if}}' +
 					'{{#if deletePermissionPossible}}{{#unless isMailShare}}' +
 					'<li>' +
 						'<span class="shareOption menuitem">' +
-							'<input id="canDelete-{{cid}}-{{shareWith}}" type="checkbox" name="delete" class="permissions checkbox" {{#if hasDeletePermission}}checked="checked"{{/if}} data-permissions="{{deletePermission}}"/>' +
-							'<label for="canDelete-{{cid}}-{{shareWith}}">{{deletePermissionLabel}}</label>' +
+							'<input id="canDelete-{{cid}}-{{shareId}}" type="checkbox" name="delete" class="permissions checkbox" {{#if hasDeletePermission}}checked="checked"{{/if}} data-permissions="{{deletePermission}}"/>' +
+							'<label for="canDelete-{{cid}}-{{shareId}}">{{deletePermissionLabel}}</label>' +
 						'</span>' +
 					'</li>' +
 					'{{/unless}}{{/if}}' +
@@ -380,7 +380,7 @@
 				var $li = this.$('li[data-share-id=' + permissionChangeShareId + ']');
 				$li.find('.sharingOptionsGroup .popovermenu').replaceWith(this.popoverMenuTemplate(sharee));
 
-				var checkBoxId = 'canEdit-' + this.cid + '-' + sharee.shareWith;
+				var checkBoxId = 'canEdit-' + this.cid + '-' + sharee.shareId;
 				checkBoxId = '#' + checkBoxId.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1");
 				var $edit = $li.parent().find(checkBoxId);
 				if($edit.length === 1) {

--- a/core/js/tests/specs/sharedialogshareelistview.js
+++ b/core/js/tests/specs/sharedialogshareelistview.js
@@ -122,6 +122,56 @@ describe('OC.Share.ShareDialogShareeListView', function () {
 			expect(listView.$el.find("input[name='edit']").is(':checked')).toEqual(true);
 			expect(updateShareStub.calledOnce).toEqual(true);
 		});
+
+		it('Checks edit box when clicking on it', function () {
+			updateShareStub.callsFake(function (shareId, attributes) {
+				// Update the permissions to get the new value when rendering
+				// again.
+				var shareIndex = this.findShareWithIndex(shareId);
+				this.get('shares')[shareIndex].permissions = attributes.permissions;
+			});
+
+			shareModel.set('shares', [{
+				id: 100,
+				item_source: 123,
+				permissions: 0,
+				share_type: OC.Share.SHARE_TYPE_USER,
+				share_with: 'user1',
+				share_with_displayname: 'User One'
+			}]);
+			shareModel.set('itemType', 'folder');
+			listView.render();
+			expect(listView.$el.find("input[name='edit']").is(':checked')).toEqual(false);
+			listView.$el.find("input[name='edit']").click();
+			listView.render();
+			expect(listView.$el.find("input[name='edit']").is(':checked')).toEqual(true);
+			expect(updateShareStub.calledOnce).toEqual(true);
+		});
+
+		it('Checks edit box when clicking on it for sharee with special characters', function () {
+			updateShareStub.callsFake(function (shareId, attributes) {
+				// Update the permissions to get the new value when rendering
+				// again.
+				var shareIndex = this.findShareWithIndex(shareId);
+				this.get('shares')[shareIndex].permissions = attributes.permissions;
+			});
+
+			shareModel.set('shares', [{
+				id: 100,
+				item_source: 123,
+				permissions: 0,
+				share_type: OC.Share.SHARE_TYPE_USER,
+				share_with: 'user _.@-\'',
+				share_with_displayname: 'User One'
+			}]);
+			shareModel.set('itemType', 'folder');
+			listView.render();
+			expect(listView.$el.find("input[name='edit']").is(':checked')).toEqual(false);
+			listView.$el.find("input[name='edit']").click();
+			listView.render();
+			expect(listView.$el.find("input[name='edit']").is(':checked')).toEqual(true);
+			expect(updateShareStub.calledOnce).toEqual(true);
+		});
 	});
 
 });


### PR DESCRIPTION
Backport of #9237

Note that as #8390 was not backported the issues in _stable13_ are not exactly the same as the ones described in #9237; in _master_ the problems appear as soon as the shares list is rendered, while in _stable13_ they appear only when the share permissions are updated, for example, when clicking on the _Can edit_ checkbox.