### PR TITLE
Delete the previews when a version is restored

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -337,6 +337,9 @@ class Storage {
 			return false;
 		}
 
+		// Fetch the userfolder to trigger view hooks
+		$userFolder = \OC::$server->getUserFolder($uid);
+
 		$users_view = new View('/'.$uid);
 		$files_view = new View('/'. User::getUser().'/files');
 
@@ -375,9 +378,14 @@ class Storage {
 		if (self::copyFileContents($users_view, $fileToRestore, 'files' . $filename)) {
 			$files_view->touch($file, $revision);
 			Storage::scheduleExpire($uid, $file);
+
+			$node = $userFolder->get($file);
+
+			// TODO: move away from those legacy hooks!
 			\OC_Hook::emit('\OCP\Versions', 'rollback', array(
 				'path' => $filename,
 				'revision' => $revision,
+				'node' => $node,
 			));
 			return true;
 		} else if ($versionCreated) {

--- a/lib/private/Preview/Watcher.php
+++ b/lib/private/Preview/Watcher.php
@@ -49,6 +49,10 @@ class Watcher {
 	}
 
 	public function postWrite(Node $node) {
+		$this->deleteNode($node);
+	}
+
+	protected function deleteNode(Node $node) {
 		// We only handle files
 		if ($node instanceof Folder) {
 			return;
@@ -59,6 +63,12 @@ class Watcher {
 			$folder->delete();
 		} catch (NotFoundException $e) {
 			//Nothing to do
+		}
+	}
+
+	public function versionRollback(array $data) {
+		if (isset($data['node'])) {
+			$this->deleteNode($data['node']);
 		}
 	}
 }

--- a/lib/private/Preview/WatcherConnector.php
+++ b/lib/private/Preview/WatcherConnector.php
@@ -60,6 +60,8 @@ class WatcherConnector {
 			$this->root->listen('\OC\Files', 'postWrite', function (Node $node) {
 				$this->getWatcher()->postWrite($node);
 			});
+
+			\OC_Hook::connect('\OCP\Versions', 'rollback', $this->getWatcher(), 'versionRollback');
 		}
 	}
 }


### PR DESCRIPTION
Fixes #9469

When a version of a file is restored the previews are no longer valid.
Thus we should remove them so they are regenerated.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>