### PR TITLE
allow shallow (non-recursive) scan when scanning file storage

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -97,6 +97,11 @@ class Scan extends Base {
 				null,
 				InputOption::VALUE_NONE,
 				'only scan files which are marked as not fully scanned'
+			)->addOption(
+				'shallow',
+				null,
+				InputOption::VALUE_NONE,
+				'do not scan folders recursively'
 			);
 	}
 
@@ -109,7 +114,7 @@ class Scan extends Base {
 		}
 	}
 
-	protected function scanFiles($user, $path, $verbose, OutputInterface $output, $backgroundScan = false) {
+	protected function scanFiles($user, $path, $verbose, OutputInterface $output, $backgroundScan = false, $recursive = true) {
 		$connection = $this->reconnectToDatabase($output);
 		$scanner = new \OC\Files\Utils\Scanner($user, $connection, \OC::$server->getLogger());
 		# check on each file/folder if there was a user interrupt (ctrl-c) and throw an exception
@@ -158,7 +163,7 @@ class Scan extends Base {
 			if ($backgroundScan) {
 				$scanner->backgroundScan($path);
 			} else {
-				$scanner->scan($path);
+				$scanner->scan($path, $recursive);
 			}
 		} catch (ForbiddenException $e) {
 			$output->writeln("<error>Home storage for user $user not writable</error>");
@@ -231,7 +236,7 @@ class Scan extends Base {
 				}
 				$output->writeln("Starting scan for user $user_count out of $users_total ($user)");
 				# full: printout data if $verbose was set
-				$this->scanFiles($user, $path, $verbose, $output, $input->getOption('unscanned'));
+				$this->scanFiles($user, $path, $verbose, $output, $input->getOption('unscanned'), ! $input->getOption('shallow'));
 			} else {
 				$output->writeln("<error>Unknown user $user_count $user</error>");
 			}

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -185,7 +185,7 @@ class Scanner extends PublicEmitter {
 	 * @throws \OC\ForbiddenException
 	 * @throws \OCP\Files\NotFoundException
 	 */
-	public function scan($dir = '') {
+	public function scan($dir = '', $recursive = \OC\Files\Cache\Scanner::SCAN_RECURSIVE) {
 		if (!Filesystem::isValidPath($dir)) {
 			throw new \InvalidArgumentException('Invalid path to scan');
 		}
@@ -242,7 +242,7 @@ class Scanner extends PublicEmitter {
 			try {
 				$propagator = $storage->getPropagator();
 				$propagator->beginBatch();
-				$scanner->scan($relativePath, \OC\Files\Cache\Scanner::SCAN_RECURSIVE, \OC\Files\Cache\Scanner::REUSE_ETAG | \OC\Files\Cache\Scanner::REUSE_SIZE);
+				$scanner->scan($relativePath, $recursive, \OC\Files\Cache\Scanner::REUSE_ETAG | \OC\Files\Cache\Scanner::REUSE_SIZE);
 				$cache = $storage->getCache();
 				if ($cache instanceof Cache) {
 					// only re-calculate for the root folder we scanned, anything below that is taken care of by the scanner


### PR DESCRIPTION
When user files are deleted externally on the filesystem, current version of `occ files:scan` recursively scans the whole folder, which is not necessary. This patch adds a new argument, i.e., `occ files:scan --shallow`, to allow shallow scan on a certain folder.