### PR TITLE
Fix translation bug on lost password page

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -31,6 +31,7 @@
 
 namespace OC\Core\Controller;
 
+use OC\HintException;
 use \OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use \OCP\AppFramework\Http\TemplateResponse;
@@ -275,6 +276,8 @@ class LostController extends Controller {
 
 			$this->config->deleteUserValue($userId, 'core', 'lostpassword');
 			@\OC::$server->getUserSession()->unsetMagicInCookie();
+		} catch (HintException $e){
+			return $this->error($e->getHint());
 		} catch (\Exception $e){
 			return $this->error($e->getMessage());
 		}


### PR DESCRIPTION
During resetting user's password, the controller return the untranslated message (from basic exception) instead of the hint message (translated).

Fix nextcloud/password_policy#26

Signed-off-by: Rémy Jacquin <remy@remyj.fr>