### PR TITLE
Increase width of other active navigation indicators to 4px

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -696,7 +696,7 @@ kbd {
 	&:hover {
 		background-color: $color-main-background;
 		opacity: 1;
-		box-shadow: inset 2px 0 $color-primary;
+		box-shadow: inset 4px 0 $color-primary;
 	}
 }
 

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -434,7 +434,7 @@ nav[role='navigation'] {
 		&:active,
 		&.active {
 			opacity: 1;
-			box-shadow: inset 2px 0 $color-primary;
+			box-shadow: inset 4px 0 $color-primary;
 		}
 	}
 }


### PR DESCRIPTION
Follow up of https://github.com/nextcloud/server/pull/8886

Before:
![image](https://user-images.githubusercontent.com/3404133/40347142-6fcb0452-5d9f-11e8-9c65-9aaafd7daf52.png)

![image](https://user-images.githubusercontent.com/3404133/40347128-622cea0e-5d9f-11e8-962b-0c4be40cc313.png)

After:
![image](https://user-images.githubusercontent.com/3404133/40347074-382a6a88-5d9f-11e8-9b95-c282f9260f2c.png)
![image](https://user-images.githubusercontent.com/3404133/40347110-4f52331c-5d9f-11e8-8c7b-9486eff6e460.png)

@nextcloud/designers 
