### PR TITLE
Add sabre plugin to allow anonymous options requests to the dav root

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -75,6 +75,7 @@ return array(
     'OCA\\DAV\\Comments\\RootCollection' => $baseDir . '/../lib/Comments/RootCollection.php',
     'OCA\\DAV\\Connector\\LegacyDAVACL' => $baseDir . '/../lib/Connector/LegacyDAVACL.php',
     'OCA\\DAV\\Connector\\PublicAuth' => $baseDir . '/../lib/Connector/PublicAuth.php',
+    'OCA\\DAV\\Connector\\Sabre\\AnonymousOptionsPlugin' => $baseDir . '/../lib/Connector/Sabre/AnonymousOptionsPlugin.php',
     'OCA\\DAV\\Connector\\Sabre\\AppEnabledPlugin' => $baseDir . '/../lib/Connector/Sabre/AppEnabledPlugin.php',
     'OCA\\DAV\\Connector\\Sabre\\Auth' => $baseDir . '/../lib/Connector/Sabre/Auth.php',
     'OCA\\DAV\\Connector\\Sabre\\BearerAuth' => $baseDir . '/../lib/Connector/Sabre/BearerAuth.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -90,6 +90,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Comments\\RootCollection' => __DIR__ . '/..' . '/../lib/Comments/RootCollection.php',
         'OCA\\DAV\\Connector\\LegacyDAVACL' => __DIR__ . '/..' . '/../lib/Connector/LegacyDAVACL.php',
         'OCA\\DAV\\Connector\\PublicAuth' => __DIR__ . '/..' . '/../lib/Connector/PublicAuth.php',
+        'OCA\\DAV\\Connector\\Sabre\\AnonymousOptionsPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/AnonymousOptionsPlugin.php',
         'OCA\\DAV\\Connector\\Sabre\\AppEnabledPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/AppEnabledPlugin.php',
         'OCA\\DAV\\Connector\\Sabre\\Auth' => __DIR__ . '/..' . '/../lib/Connector/Sabre/Auth.php',
         'OCA\\DAV\\Connector\\Sabre\\BearerAuth' => __DIR__ . '/..' . '/../lib/Connector/Sabre/BearerAuth.php',

--- a/apps/dav/lib/Connector/Sabre/AnonymousOptionsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/AnonymousOptionsPlugin.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DAV\Connector\Sabre;
+
+use Sabre\DAV\CorePlugin;
+use Sabre\DAV\FS\Directory;
+use Sabre\DAV\ServerPlugin;
+use Sabre\DAV\Tree;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+
+class AnonymousOptionsPlugin extends ServerPlugin {
+
+	/**
+	 * @var \Sabre\DAV\Server
+	 */
+	private $server;
+
+	/**
+	 * @param \Sabre\DAV\Server $server
+	 * @return void
+	 */
+	public function initialize(\Sabre\DAV\Server $server) {
+		$this->server = $server;
+		// before auth
+		$this->server->on('beforeMethod', [$this, 'handleAnonymousOptions'], 9);
+	}
+
+	/**
+	 * @throws \Sabre\DAV\Exception\Forbidden
+	 * @return bool
+	 */
+	public function handleAnonymousOptions(RequestInterface $request, ResponseInterface $response) {
+		if ($request->getMethod() === 'OPTIONS' && $request->getPath() === '') {
+			/** @var CorePlugin $corePlugin */
+			$corePlugin = $this->server->getPlugin('core');
+			// setup a fake tree for anonymous access
+			$this->server->tree = new Tree(new Directory(''));
+			$corePlugin->httpOptions($request, $response);
+			$this->server->sapi->sendResponse($response);
+			return false;
+		}
+	}
+}

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -110,6 +110,7 @@ class ServerFactory {
 		// Load plugins
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\MaintenancePlugin($this->config));
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\BlockLegacyClientPlugin($this->config));
+		$server->addPlugin(new \OCA\DAV\Connector\Sabre\AnonymousOptionsPlugin());
 		$server->addPlugin($authPlugin);
 		// FIXME: The following line is a workaround for legacy components relying on being able to send a GET to /
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\DummyGetResponsePlugin());

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -52,6 +52,7 @@ use OCA\DAV\DAV\PublicAuth;
 use OCA\DAV\DAV\CustomPropertiesBackend;
 use OCA\DAV\Connector\Sabre\QuotaPlugin;
 use OCA\DAV\Files\BrowserErrorPagePlugin;
+use OCA\DAV\Connector\Sabre\AnonymousOptionsPlugin;
 use OCA\DAV\SystemTag\SystemTagPlugin;
 use OCA\DAV\Upload\ChunkingPlugin;
 use OCP\IRequest;
@@ -99,6 +100,7 @@ class Server {
 		$this->server->setBaseUri($this->baseUri);
 
 		$this->server->addPlugin(new BlockLegacyClientPlugin(\OC::$server->getConfig()));
+		$this->server->addPlugin(new AnonymousOptionsPlugin());
 		$authPlugin = new Plugin();
 		$authPlugin->addBackend(new PublicAuth());
 		$this->server->addPlugin($authPlugin);

--- a/apps/dav/tests/unit/DAV/AnonymousOptionsTest.php
+++ b/apps/dav/tests/unit/DAV/AnonymousOptionsTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DAV\tests\unit\DAV;
+
+use OCA\DAV\Connector\Sabre\AnonymousOptionsPlugin;
+use Sabre\DAV\Auth\Backend\BasicCallBack;
+use Sabre\DAV\Auth\Plugin;
+use Sabre\DAV\Server;
+use Sabre\HTTP\ResponseInterface;
+use Sabre\HTTP\Sapi;
+use Test\TestCase;
+
+class AnonymousOptionsTest extends TestCase {
+	private function sendRequest($method, $path) {
+		$server = new Server();
+		$server->addPlugin(new AnonymousOptionsPlugin());
+		$server->addPlugin(new Plugin(new BasicCallBack(function() {
+			return false;
+		})));
+
+		$server->httpRequest->setMethod($method);
+		$server->httpRequest->setUrl($path);
+
+		$server->sapi = new SapiMock();
+		$server->exec();
+		return $server->httpResponse;
+	}
+
+	public function testAnonymousOptionsRoot() {
+		$response = $this->sendRequest('OPTIONS', '');
+
+		$this->assertEquals(200, $response->getStatus());
+	}
+
+	public function testAnonymousOptionsNonRoot() {
+		$response = $this->sendRequest('OPTIONS', 'foo');
+
+		$this->assertEquals(401, $response->getStatus());
+	}
+}
+
+class SapiMock extends Sapi {
+	/**
+	 * Overriding this so nothing is ever echo'd.
+	 *
+	 * @return void
+	 */
+	static function sendResponse(ResponseInterface $response) {
+
+	}
+
+}


### PR DESCRIPTION
Extracted from https://github.com/nextcloud/user_saml/pull/188

Needed to map webdav as drive in windows