### PR TITLE
Remove ellipsis below public text file shares

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -132,6 +132,10 @@ OCA.Sharing.PublicApp = {
 			img.attr('src', $('#downloadURL').val());
 			imgcontainer.appendTo('#imgframe');
 		} else if (mimetype.substr(0, mimetype.indexOf('/')) === 'text' && window.btoa) {
+			if (oc_appswebroots['files_texteditor'] !== undefined) {
+				// the text editor handles the previewing
+				return;
+			}
 			// Undocumented Url to public WebDAV endpoint
 			var url = parent.location.protocol + '//' + location.host + OC.linkTo('', 'public.php/webdav');
 			$.ajax({


### PR DESCRIPTION
The text editor also does a preview which is usually a lot better and thus it should not preview twice. Thus the sharing app should not preview if text editor is loaded. Also removes one request on publicly shared text files.

