### PR TITLE
[stable12] Fix translation bug on lost password page

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -30,6 +30,7 @@
 
 namespace OC\Core\Controller;
 
+use OC\HintException;
 use \OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use \OCP\AppFramework\Http\TemplateResponse;
@@ -274,6 +275,8 @@ class LostController extends Controller {
 
 			$this->config->deleteUserValue($userId, 'core', 'lostpassword');
 			@\OC_User::unsetMagicInCookie();
+		} catch (HintException $e){
+			return $this->error($e->getHint());
 		} catch (\Exception $e){
 			return $this->error($e->getMessage());
 		}


### PR DESCRIPTION
During resetting user's password, the controller return the untranslated message (from basic exception) instead of the hint message (translated).

Fix nextcloud/password_policy#26

Signed-off-by: Rémy Jacquin <remy@remyj.fr>