### PR TITLE
allow admins to disable FreeBusy without modifying ShareAPI capabilities

### DIFF
--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -46,6 +46,7 @@ $principalBackend = new Principal(
 	\OC::$server->getGroupManager(),
 	\OC::$server->getShareManager(),
 	\OC::$server->getUserSession(),
+	\OC::$server->getConfig(),
 	'principals/'
 );
 $db = \OC::$server->getDatabaseConnection();

--- a/apps/dav/appinfo/v1/carddav.php
+++ b/apps/dav/appinfo/v1/carddav.php
@@ -47,6 +47,7 @@ $principalBackend = new Principal(
 	\OC::$server->getGroupManager(),
 	\OC::$server->getShareManager(),
 	\OC::$server->getUserSession(),
+	\OC::$server->getConfig(),
 	'principals/'
 );
 $db = \OC::$server->getDatabaseConnection();

--- a/apps/dav/lib/Command/CreateCalendar.php
+++ b/apps/dav/lib/Command/CreateCalendar.php
@@ -77,7 +77,8 @@ class CreateCalendar extends Command {
 			$this->userManager,
 			$this->groupManager,
 			\OC::$server->getShareManager(),
-			\OC::$server->getUserSession()
+			\OC::$server->getUserSession(),
+			\OC::$server->getConfig()
 		);
 		$random = \OC::$server->getSecureRandom();
 		$logger = \OC::$server->getLogger();

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -51,7 +51,8 @@ class RootCollection extends SimpleCollection {
 			$userManager,
 			$groupManager,
 			$shareManager,
-			\OC::$server->getUserSession()
+			\OC::$server->getUserSession(),
+			$config
 		);
 		$groupPrincipalBackend = new GroupPrincipalBackend($groupManager);
 		// as soon as debug mode is enabled we allow listing of principals

--- a/apps/files_trashbin/lib/AppInfo/Application.php
+++ b/apps/files_trashbin/lib/AppInfo/Application.php
@@ -57,7 +57,8 @@ class Application extends App {
 				\OC::$server->getUserManager(),
 				\OC::$server->getGroupManager(),
 				\OC::$server->getShareManager(),
-				\OC::$server->getUserSession()
+				\OC::$server->getUserSession(),
+				\OC::$server->getConfig()
 			);
 		});
 	}

--- a/apps/files_versions/lib/AppInfo/Application.php
+++ b/apps/files_versions/lib/AppInfo/Application.php
@@ -48,7 +48,8 @@ class Application extends App {
 				\OC::$server->getUserManager(),
 				\OC::$server->getGroupManager(),
 				\OC::$server->getShareManager(),
-				\OC::$server->getUserSession()
+				\OC::$server->getUserSession(),
+				\OC::$server->getConfig()
 			);
 		});
 	}


### PR DESCRIPTION
@MorrisJobke @rullzer As discussed last week

Sorry for not providing a proper testing description in the beginning. 
To test this you need an external client like thunderbird, because the Nextcloud Calendar web app does not support Free/Busy yet.

Before setting the property: 
![before](https://user-images.githubusercontent.com/1250540/40795241-b493d208-6501-11e8-8c72-ceddb48dbb46.png)

After executing: `php occ config:app:set dav disableFreeBusy --value=yes`
![after](https://user-images.githubusercontent.com/1250540/40795295-e7951b76-6501-11e8-9368-8345bc8eca71.png)

You can get back to the first behavior by executing: `php occ config:app:delete dav disableFreeBusy`