### PR TITLE
Previews on for all trashbin files

### DIFF
--- a/apps/files_trashbin/appinfo/routes.php
+++ b/apps/files_trashbin/appinfo/routes.php
@@ -29,7 +29,7 @@ $application->registerRoutes($this, [
 	'routes' => [
 		[
 			'name' => 'Preview#getPreview',
-			'url' => '/ajax/preview.php',
+			'url' => '/preview',
 			'verb' => 'GET',
 		],
 	],

--- a/apps/files_trashbin/js/filelist.js
+++ b/apps/files_trashbin/js/filelist.js
@@ -260,7 +260,7 @@
 		},
 
 		generatePreviewUrl: function(urlSpec) {
-			return OC.generateUrl('/apps/files_trashbin/ajax/preview.php?') + $.param(urlSpec);
+			return OC.generateUrl('/apps/files_trashbin/preview?') + $.param(urlSpec);
 		},
 
 		getDownloadUrl: function() {

--- a/apps/files_trashbin/lib/Helper.php
+++ b/apps/files_trashbin/lib/Helper.php
@@ -116,10 +116,9 @@ class Helper {
 	 */
 	public static function formatFileInfos($fileInfos) {
 		$files = array();
-		$id = 0;
 		foreach ($fileInfos as $i) {
 			$entry = \OCA\Files\Helper::formatFileInfo($i);
-			$entry['id'] = $id++;
+			$entry['id'] = $i->getId();
 			$entry['etag'] = $entry['mtime']; // add fake etag, it is only needed to identify the preview image
 			$entry['permissions'] = \OCP\Constants::PERMISSION_READ;
 			$files[] = $entry;


### PR DESCRIPTION
Fixes #9489 

* Previews possible for all files in the trashbin
* Set caching
* Use the fileid to find the file
* Move js to new endpoint

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>