### PR TITLE
Emit event when running ./occ db:add-missing-indices

### DIFF
--- a/core/Command/Db/AddMissingIndices.php
+++ b/core/Command/Db/AddMissingIndices.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2017 Bjoern Schiessle <bjoern@schiessle.org>
  *
@@ -27,6 +28,8 @@ use OCP\IDBConnection;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Class AddMissingIndices
@@ -41,12 +44,14 @@ class AddMissingIndices extends Command {
 	/** @var IDBConnection */
 	private $connection;
 
-	/**
-	 * @param IDBConnection $connection
-	 */
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	/** @var EventDispatcherInterface */
+	private $dispatcher;
+
+	public function __construct(IDBConnection $connection, EventDispatcherInterface $dispatcher) {
 		parent::__construct();
+
+		$this->connection = $connection;
+		$this->dispatcher = $dispatcher;
 	}
 
 	protected function configure() {
@@ -58,6 +63,9 @@ class AddMissingIndices extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$this->addShareTableIndicies($output);
 
+		// Dispatch event so apps can also update indexes if needed
+		$event = new GenericEvent($output);
+		$this->dispatcher->dispatch(IDBConnection::ADD_MISSING_INDEXES_EVENT, $event);
 	}
 
 	/**
@@ -73,8 +81,8 @@ class AddMissingIndices extends Command {
 		$schema = new SchemaWrapper($this->connection);
 		$updated = false;
 
-		if ($schema->hasTable("share")) {
-			$table = $schema->getTable("share");
+		if ($schema->hasTable('share')) {
+			$table = $schema->getTable('share');
 			if (!$table->hasIndex('share_with_index')) {
 				$output->writeln('<info>Adding additional index to the share table, this can take some time...</info>');
 				$table->addIndex(['share_with'], 'share_with_index');

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -89,7 +89,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Db\ConvertType(\OC::$server->getConfig(), new \OC\DB\ConnectionFactory(\OC::$server->getSystemConfig())));
 	$application->add(new OC\Core\Command\Db\ConvertMysqlToMB4(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection(), \OC::$server->getURLGenerator(), \OC::$server->getLogger()));
 	$application->add(new OC\Core\Command\Db\ConvertFilecacheBigInt(\OC::$server->getDatabaseConnection()));
-	$application->add(new OC\Core\Command\Db\AddMissingIndices(\OC::$server->getDatabaseConnection()));
+	$application->add(new OC\Core\Command\Db\AddMissingIndices(\OC::$server->getDatabaseConnection(), \OC::$server->getEventDispatcher()));
 	$application->add(new OC\Core\Command\Db\Migrations\StatusCommand(\OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\Db\Migrations\MigrateCommand(\OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\Db\Migrations\GenerateCommand(\OC::$server->getDatabaseConnection(), \OC::$server->getAppManager()));

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -45,6 +45,9 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
  * @since 6.0.0
  */
 interface IDBConnection {
+
+	const ADD_MISSING_INDEXES_EVENT = self::class . '::ADD_MISSING_INDEXES';
+
 	/**
 	 * Gets the QueryBuilder for the connection.
 	 *


### PR DESCRIPTION
This allows apps to listen to this event in order to also update
indecies there.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>