### PR TITLE
Allow custom text for OC.PasswordConfirmation

### DIFF
--- a/core/css/jquery.ocdialog.scss
+++ b/core/css/jquery.ocdialog.scss
@@ -76,3 +76,17 @@
 .oc-dialog-content {
 	width: 100%;
 }
+
+.oc-dialog.password-confirmation {
+	.oc-dialog-content {
+		width: auto;
+		margin: 12px;
+
+		input[type=password] {
+			width: 100%;
+		}
+		label {
+			display: none;
+		}
+	}
+}

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -122,7 +122,7 @@ var OCdialogs = {
 				type       : 'notice'
 			});
 			var input = $('<input/>');
-			input.attr('type', password ? 'password' : 'text').attr('id', dialogName + '-input');
+			input.attr('type', password ? 'password' : 'text').attr('id', dialogName + '-input').attr('placeholder', name);
 			var label = $('<label/>').attr('for', dialogName + '-input').text(name + ': ');
 			$dlg.append(label);
 			$dlg.append(input);

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -324,7 +324,10 @@ OC.Settings.Apps = OC.Settings.Apps || {
 
 	enableAppBundle:function(bundleId, active, element, groups) {
 		if (OC.PasswordConfirmation.requiresPasswordConfirmation()) {
-			OC.PasswordConfirmation.requirePasswordConfirmation(_.bind(this.enableAppBundle, this, bundleId, active, element, groups));
+			OC.PasswordConfirmation.requirePasswordConfirmation(_.bind(this.enableAppBundle, this, bundleId, active, element, groups), {
+				text: t('settings', 'Installing apps requires you to confirm your password'),
+				confirm: t('settings', 'Install app bundle'),
+			});
 			return;
 		}
 
@@ -348,7 +351,10 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		 */
 	enableApp:function(appId, active, groups) {
 		if (OC.PasswordConfirmation.requiresPasswordConfirmation()) {
-			OC.PasswordConfirmation.requirePasswordConfirmation(_.bind(this.enableApp, this, appId, active, groups));
+			OC.PasswordConfirmation.requirePasswordConfirmation(_.bind(this.enableApp, this, appId, active, groups), {
+				text: ( active ? t('settings', 'Disabling apps requires you to confirm your password') : t('settings', 'Enabling apps requires you to confirm your password') ),
+				confirm: ( active ? t('settings', 'Disable app') : t('settings', 'Enable app') ),
+			});
 			return;
 		}
 
@@ -577,7 +583,10 @@ OC.Settings.Apps = OC.Settings.Apps || {
 
 	uninstallApp:function(appId, element) {
 		if (OC.PasswordConfirmation.requiresPasswordConfirmation()) {
-			OC.PasswordConfirmation.requirePasswordConfirmation(_.bind(this.uninstallApp, this, appId, element));
+			OC.PasswordConfirmation.requirePasswordConfirmation(_.bind(this.uninstallApp, this, appId, element), {
+				text: t('settings', 'Uninstalling apps requires you to confirm your password'),
+				confirm: t('settings', 'Uninstall')
+			});
 			return;
 		}
 


### PR DESCRIPTION
- Add option to specify custom texts for OC.PasswordConfirmation
- Simplify password confirmation dialog
- Show error message inside of the dialog
- Example usage in apps management as described in https://github.com/nextcloud/server/issues/2593

![image](https://user-images.githubusercontent.com/3404133/40484288-5e7e02a4-5f5b-11e8-9da9-864628944855.png)
![image](https://user-images.githubusercontent.com/3404133/40484295-67f61b50-5f5b-11e8-9eb2-2c41327a196c.png)
![image](https://user-images.githubusercontent.com/3404133/40484304-6e576724-5f5b-11e8-893b-70b98b8b38f7.png)

(my screenshot tool seems a bit broken, try to forget the blue overlay across the whole screenshots)

@jancborchardt @nextcloud/designers 