### PR TITLE
remove unneeded is_dir from file cache gc

### DIFF
--- a/lib/private/Cache/File.php
+++ b/lib/private/Cache/File.php
@@ -174,7 +174,7 @@ class File implements ICache {
 	 */
 	public function gc() {
 		$storage = $this->getStorage();
-		if ($storage and $storage->is_dir('/')) {
+		if ($storage) {
 			// extra hour safety, in case of stray part chunks that take longer to write,
 			// because touch() is only called after the chunk was finished
 			$now = time() - 3600;


### PR DESCRIPTION
The error handling of `opendir` already handles it correctly if the directory doesn't exist so there is no need for an extra storage call here