### PR TITLE
Rename sync clients section to mobile & desktop

### DIFF
--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -350,7 +350,7 @@ class Manager implements IManager {
 		$sections = [
 			0 => [new Section('personal-info', $this->l->t('Personal info'), 0, $this->url->imagePath('core', 'actions/info.svg'))],
 			5 => [new Section('security', $this->l->t('Security'), 0, $this->url->imagePath('settings', 'password.svg'))],
-			15 => [new Section('sync-clients', $this->l->t('Sync clients'), 0, $this->url->imagePath('settings', 'change.svg'))],
+			15 => [new Section('sync-clients', $this->l->t('Mobile & desktop'), 0, $this->url->imagePath('core', 'clients/phone.svg'))],
 		];
 
 		$legacyForms = \OC_App::getForms('personal');

--- a/tests/lib/Settings/ManagerTest.php
+++ b/tests/lib/Settings/ManagerTest.php
@@ -199,13 +199,13 @@ class ManagerTest extends TestCase {
 			->willReturnMap([
 				['core', 'actions/info.svg', '1'],
 				['settings', 'password.svg', '2'],
-				['settings', 'change.svg', '3'],
+				['core', 'clients/phone.svg', '3'],
 			]);
 
 		$this->assertArraySubset([
 			0 => [new Section('personal-info', 'Personal info', 0, '1')],
 			5 => [new Section('security', 'Security', 0, '2')],
-			15 => [new Section('sync-clients', 'Sync clients', 0, '3')],
+			15 => [new Section('sync-clients', 'Mobile & desktop', 0, '3')],
 		], $this->manager->getPersonalSections());
 	}
 

--- a/tests/lib/Settings/ManagerTest.php
+++ b/tests/lib/Settings/ManagerTest.php
@@ -150,13 +150,13 @@ class ManagerTest extends TestCase {
 			->willReturnMap([
 				['core', 'actions/info.svg', '1'],
 				['settings', 'password.svg', '2'],
-				['settings', 'change.svg', '3'],
+				['core', 'clients/phone.svg', '3'],
 			]);
 
 		$this->assertEquals([
 			0 => [new Section('personal-info', 'Personal info', 0, '1')],
 			5 => [new Section('security', 'Security', 0, '2')],
-			15 => [new Section('sync-clients', 'Sync clients', 0, '3')],
+			15 => [new Section('sync-clients', 'Mobile & desktop', 0, '3')],
 			55 => [\OC::$server->query(\OCA\WorkflowEngine\Settings\Section::class)],
 		], $this->manager->getPersonalSections());
 	}


### PR DESCRIPTION
Rename the sync clients section in personal settings to "Mobile & desktop" as proposed by @jancborchardt in https://github.com/nextcloud/spreed/pull/913

![image](https://user-images.githubusercontent.com/3404133/40487364-3ca99ec8-5f64-11e8-89ca-96a41ac49eb7.png)
