### PR TITLE
Allow empty route for navigation entries

### DIFF
--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -289,7 +289,7 @@ class NavigationManager implements INavigationManager {
 				$id = isset($nav['id']) ? $nav['id'] : $app;
 				$order = isset($nav['order']) ? $nav['order'] : 100;
 				$type = isset($nav['type']) ? $nav['type'] : 'link';
-				$route = $this->urlGenerator->linkToRoute($nav['route']);
+				$route = $nav['route'] !== '' ? $this->urlGenerator->linkToRoute($nav['route']) : '';
 				$icon = isset($nav['icon']) ? $nav['icon'] : 'app.svg';
 				foreach ([$icon, "$app.svg"] as $i) {
 					try {


### PR DESCRIPTION
Navigation entries might be handled by javascript, as the about section
from https://github.com/nextcloud/firstrunwizard/pull/64 so we don't
need a route for that.

Fixes the error log message found by @MorrisJobke in https://github.com/nextcloud/firstrunwizard/pull/64#commitcomment-29113955


Requires https://github.com/nextcloud/firstrunwizard/pull/66