### PR TITLE
[stable13] Fix settings menu 

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -199,7 +199,7 @@
 }
 
 /* NAVIGATION --------------------------------------------------------------- */
-nav {
+#header-left nav {
 	display: inline-block;
 	width: 44px;
 	height: 44px;


### PR DESCRIPTION
This fixes #9514 which was introduced in fc280b2 where the settings menu was moved to a nav element and therefore the css rules scope was to wide.

Doesn't happen on master to me.

Before:
![image](https://user-images.githubusercontent.com/3404133/40493256-9735c44e-5f72-11e8-9bae-d651d4ecfccf.png)

After:
![image](https://user-images.githubusercontent.com/3404133/40493166-6e214e20-5f72-11e8-8278-f6e14d7ef43e.png)

@nextcloud/designers 
