### PR TITLE
Workaround for interrupting expired files deletion

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -790,8 +790,15 @@ class Trashbin {
 			$timestamp = $file['mtime'];
 			$filename = $file['name'];
 			if ($expiration->isExpired($timestamp)) {
-				$count++;
-				$size += self::delete($filename, $user, $timestamp);
+				try {
+					$size += self::delete($filename, $user, $timestamp);
+					$count++;
+				} catch (\OCP\Files\NotPermittedException $e) {
+					\OC::$server->getLogger()->warning(
+						'Removing "' . $filename . '" from trashbin failed (OCP\\Files\\NotPermittedException).',
+						['app' => 'files_trashbin']
+					);
+				}
 				\OC::$server->getLogger()->info(
 					'Remove "' . $filename . '" from trashbin because it exceeds max retention obligation term.',
 					['app' => 'files_trashbin']

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -794,10 +794,7 @@ class Trashbin {
 					$size += self::delete($filename, $user, $timestamp);
 					$count++;
 				} catch (\OCP\Files\NotPermittedException $e) {
-					\OC::$server->getLogger()->warning(
-						'Removing "' . $filename . '" from trashbin failed (OCP\\Files\\NotPermittedException).',
-						['app' => 'files_trashbin']
-					);
+					\OC::$server->getLogger()->logException($e, ['app' => 'files_trashbin', 'level' => \OCP\ILogger::WARN, 'message' => 'Removing "' . $filename . '" from trashbin failed.']);
 				}
 				\OC::$server->getLogger()->info(
 					'Remove "' . $filename . '" from trashbin because it exceeds max retention obligation term.',


### PR DESCRIPTION
Our nextcloud system threw some "Error while running background job (class: OCA\Files_Trashbin\BackgroundJob\ExpireTrash, arguments: ): {"Exception":"OCP\\Files\\NotPermittedException","Message":"","Code":0,"Trace":"#0 \/var\/www\/cloud\/apps\/files_trashbin\/lib\/Trashbin.php(590): OC\\Files\\Node\\File->delete() [...]" exceptions in logs during the last weeks.

Even though the root problem at our system needs to be solved, stopping deleting expired files from trash isn't the best idea for us. Therefore here's a small patch to handle that situation.