### PR TITLE
Limit Sinon version to 5.0.7 at most

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -25,7 +25,7 @@
     "karma-viewport": "^0.4.2",
     "phantomjs-prebuilt": "*",
     "node-sass": "~4.1.1",
-    "sinon": "*"
+    "sinon": "<= 5.0.7"
   },
   "engine": "node >= 6.9"
 }


### PR DESCRIPTION
This pull request adds a workaround for recent JavaScript unit test failures in Drone.

When using fake servers with Sinon.JS, the JavaScript test framework, the XHR objects are also fake. Both the fake XHR and server come from nise, which is a dependency and subproject from Sinon. In nise 1.3.3, which [is used by Sinon.JS since 5.0.8](https://github.com/sinonjs/sinon/commit/082f8e8ab3f8b5d6332550dd05c5b3c6fed82d91#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R47), [`setRequestHeader` of XMLHttpRequest was modified to normalize the header values](https://github.com/sinonjs/nise/commit/d0032f741ac995ed33b80a06a04e9b7ecf2ee00d) (as requested [by the spec](https://xhr.spec.whatwg.org/#the-setrequestheader()-method)), but since then only string values are accepted; null or integer values can no longer be passed to `setRequestHeader`, as [it expects the `replace` function to be available in the object](https://github.com/sinonjs/nise/commit/d0032f741ac995ed33b80a06a04e9b7ecf2ee00d#diff-03bee40ee9cedcff60e39b08d9f066b3R130). However, in the tests null and integer values are passed to `setRequestHeader`, which causes them to fail.

Null values are passed due to `oc_requesttoken` being null. [`oc_requesttoken` is set to the `data-requesttoken` attribute of the `head` element when _js.js_ is loaded](https://github.com/nextcloud/server/blob/33b65faba020804e5fbe54d281eeb2dd384854f2/core/js/js.js#L15). However, in the unit tests, that attribute is not set anywhere, so `oc_requesttoken` ends being null  (and, in turn, `OC.requestToken` too, [as it is set based on `os_requesttoken` also when _js.js_ is loaded](https://github.com/nextcloud/server/blob/33b65faba020804e5fbe54d281eeb2dd384854f2/core/js/js.js#L102)).

[`oc_requesttoken` is passed as the value of the _requesttoken_ header for every AJAX call that is not cross domain](https://github.com/nextcloud/server/blob/cd90685af13d3fa14b3bd15aa5e6d4ddeee84eb3/core/js/oc-requesttoken.js#L3). In the unit tests some AJAX calls are seen as cross domain and others are not (if not explicitly given in the options of the call, whether an AJAX call is cross domain or not [is automatically set by jQuery based on the URL](https://github.com/nextcloud/server/blob/cd90685af13d3fa14b3bd15aa5e6d4ddeee84eb3/core/vendor/jquery/jquery.js#L8009-L8017); it seems that some of the URLs used in the tests are wrong, but that is a different issue); those tests that use an AJAX call that is not cross domain fail, as `normalizeHeaderValue` in the fake XMLHttpRequest tries to call `replace` on a null object.

Fixing that by initializing `oc_requesttoken` in _specHelper.js_ to an empty string [before every test is run](https://github.com/nextcloud/server/blob/ac1aff7d9249523cc66a7cd890f95f0760f1016a/core/js/tests/specHelper.js#L143) is not enough, though, as there are other places in the code in which non-string values are passed as the header value to `setRequestHeader`.

In the `propFind` function of _davclient.js_, which is an external dependency, the value of the _Depth_ header is passed as an integer to `setRequestHeader`. The depth is a parameter of the `propFind` function, so it could be passed as an integer to that function... but then it would not properly handle a depth of 0, as [it makes an strict comparison against an integer](https://github.com/nextcloud/server/blob/6d2bff46c95615a774e9701c02da0cd4fc3561b5/core/vendor/davclient.js/lib/client.js#L91).

Both Firefox and Chromium accept passing non-string values to their `setRequestHeader` implementation, and [there is currently a pull request in nise to allow again non-string values to be passed to `setRequestHeader`](https://github.com/sinonjs/nise/pull/48). It is not clear yet whether nise got too restrictive or the code calling `setRequestHeader` was too loose. Given that _davclient.js_ is an external dependency, as a temporary measure Sinon version is forced to be 5.0.7 at most until either Sinon or _davclient.js_ are updated.

@nextcloud/javascript 
