### PR TITLE
Check proper case for user UID

### DIFF
--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -334,6 +334,12 @@ class Database extends ABackend
 			$result = $qb->execute();
 			$row = $result->fetch();
 			$result->closeCursor();
+			
+			// check proper uid case
+			if((string)$row['uid'] !== $uid) {
+				$this->cache[$uid] = false;
+				return false;
+			}
 
 			$this->cache[$uid] = false;
 

--- a/tests/lib/User/DatabaseTest.php
+++ b/tests/lib/User/DatabaseTest.php
@@ -115,6 +115,13 @@ class DatabaseTest extends Backend {
 		$this->assertTrue($this->backend->userExists($user1));
 	}
 
+	public function testGetUserProperCaseUID() {
+		$user1 = $this->getUniqueID('Test_');
+		$this->backend->createUser($user1, 'pw');
+		$this->assertTrue($this->backend->userExists($user1));
+		$this->assertFalse($this->backend->userExists(strtolower($user1)));
+	}
+
 	public function testSearch() {
 		parent::testSearch();
 


### PR DESCRIPTION
Fix #9532 

Testing:
`$.get('/ocs/v2.php/cloud/users/admin')` 200 
`$.get('/ocs/v2.php/cloud/users/Admin')` 404