### PR TITLE
Add workaround for parameter not available in Mink Extension

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -36,4 +36,4 @@ default:
           selenium2:
             capabilities:
               firefox:
-                profile: config/firefox-profiles/css-grid-enabled.zip
+                profile: %paths.base%/firefox-profiles/css-grid-enabled.zip

--- a/tests/acceptance/run-local.sh
+++ b/tests/acceptance/run-local.sh
@@ -159,6 +159,18 @@ if [ "$NEXTCLOUD_SERVER_DOMAIN" != "$DEFAULT_NEXTCLOUD_SERVER_DOMAIN" ]; then
 	sed --in-place "s/$ORIGINAL/$REPLACEMENT/" $ACCEPTANCE_TESTS_CONFIG_DIR/behat.yml
 fi
 
+# Due to a bug in the Mink Extension for Behat it is not possible to use the
+# "paths.base" parameter in the path to the custom Firefox profile. Thus, the
+# default "behat.yml" configuration file has to be adjusted to replace the
+# parameter by its value before the configuration file is parsed by Behat.
+ORIGINAL="profile: %paths.base%"
+REPLACEMENT="profile: $ACCEPTANCE_TESTS_CONFIG_DIR"
+# As the substitution does not involve regular expressions or multilines it can
+# be done just with Bash. Moreover, this does not require escaping the regular
+# expression characters that may appear in the path, like "/".
+FILE_CONTENTS=$(<$ACCEPTANCE_TESTS_CONFIG_DIR/behat.yml)
+echo "${FILE_CONTENTS//$ORIGINAL/$REPLACEMENT}" > $ACCEPTANCE_TESTS_CONFIG_DIR/behat.yml
+
 if [ "$SELENIUM_SERVER" != "$DEFAULT_SELENIUM_SERVER" ]; then
 	# Set the Selenium server to be used by Mink; this extends the default
 	# configuration from "config/behat.yml".

--- a/tests/acceptance/run-local.sh
+++ b/tests/acceptance/run-local.sh
@@ -63,6 +63,8 @@ if [ "$1" = "--acceptance-tests-dir" ]; then
 	shift 2
 fi
 
+ACCEPTANCE_TESTS_CONFIG_DIR="../../$ACCEPTANCE_TESTS_DIR/config"
+
 # "--timeout-multiplier N" option can be provided to set the timeout multiplier
 # to be used in ActorContext.
 TIMEOUT_MULTIPLIER=""
@@ -133,7 +135,7 @@ if [ "$TIMEOUT_MULTIPLIER" != "" ]; then
 	REPLACEMENT="\
         - ActorContext:\n\
             actorTimeoutMultiplier: $TIMEOUT_MULTIPLIER"
-	sed --in-place "s/$ORIGINAL/$REPLACEMENT/" ../../$ACCEPTANCE_TESTS_DIR/config/behat.yml
+	sed --in-place "s/$ORIGINAL/$REPLACEMENT/" $ACCEPTANCE_TESTS_CONFIG_DIR/behat.yml
 fi
 
 if [ "$NEXTCLOUD_SERVER_DOMAIN" != "$DEFAULT_NEXTCLOUD_SERVER_DOMAIN" ]; then
@@ -154,7 +156,7 @@ if [ "$NEXTCLOUD_SERVER_DOMAIN" != "$DEFAULT_NEXTCLOUD_SERVER_DOMAIN" ]; then
         - NextcloudTestServerContext:\n\
             nextcloudTestServerHelperParameters:\n\
               - $NEXTCLOUD_SERVER_DOMAIN"
-	sed --in-place "s/$ORIGINAL/$REPLACEMENT/" ../../$ACCEPTANCE_TESTS_DIR/config/behat.yml
+	sed --in-place "s/$ORIGINAL/$REPLACEMENT/" $ACCEPTANCE_TESTS_CONFIG_DIR/behat.yml
 fi
 
 if [ "$SELENIUM_SERVER" != "$DEFAULT_SELENIUM_SERVER" ]; then
@@ -215,4 +217,4 @@ cd tests/acceptance
 echo "Waiting for Selenium"
 timeout 60s bash -c "while ! curl $SELENIUM_SERVER >/dev/null 2>&1; do sleep 1; done"
 
-vendor/bin/behat --config=../../$ACCEPTANCE_TESTS_DIR/config/behat.yml $SCENARIO_TO_RUN
+vendor/bin/behat --config=$ACCEPTANCE_TESTS_CONFIG_DIR/behat.yml $SCENARIO_TO_RUN


### PR DESCRIPTION
This pull request adds a workaround for a bug in the Mink Extension for Behat used in the acceptance tests.

When the Selenium2 driver is configured in the Mink Extension [an `InvalidConfigurationException` is thrown if the file for the custom Firefox profile does not exist](https://github.com/Behat/MinkExtension/blob/4b6d5f1ea50590d0a075eec89a2d1ce8813fe2a7/src/Behat/MinkExtension/ServiceContainer/Driver/Selenium2Factory.php#L131-L143). However, at that point the parameters have not been replaced yet by their value, so the path that is verified is the raw value specified in the _behat.yml_ file. Thus, when a paramater is used in that path the path is always seen as invalid, even if it would be valid once the parameter was replaced by its value.

Due to that bug it is not possible to use the `paths.base` parameter in the path to the custom Firefox profile in _behat.yml_. `paths.base` is a special parameter in the Behat configuration that refers to the directory in which _behat.yml_ is stored. This comes in very handy to set the path to custom Firefox profiles in the acceptance tests for apps, as even if the _behat.yml_ file belongs to an app its paths are relative to the directory in which the tests are run, that is, the _tests/acceptance_ directory of the server.

Until the bug is fixed, just before the acceptance tests are run the `paths.base` parameter in the path to the custom Firefox profile is replaced by its value in the _behat.yml_ file used by the acceptance tests. Note that the file that is modified is the one inside the Docker container used to run the acceptance tests, so the original file is not touched.
