### PR TITLE
Make sure the log doesn't try to read from PUT if it can't

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -233,8 +233,16 @@ class Log implements ILogger {
 				if (isset($logCondition['shared_secret'])) {
 					$request = \OC::$server->getRequest();
 
+					if ($request->getMethod() === 'PUT' &&
+						strpos($request->getHeader('Content-Type'), 'application/x-www-form-urlencoded') === false &&
+						strpos($request->getHeader('Content-Type'), 'application/json') === false) {
+						$logSecretRequest = '';
+					} else {
+						$logSecretRequest = $request->getParam('log_secret', '');
+					}
+
 					// if token is found in the request change set the log condition to satisfied
-					if ($request && hash_equals($logCondition['shared_secret'], $request->getParam('log_secret', ''))) {
+					if ($request && hash_equals($logCondition['shared_secret'], $logSecretRequest)) {
 						$this->logConditionSatisfied = true;
 					}
 				}


### PR DESCRIPTION
If a PUT request comes in that is not JSON or from encoded. Then we can
only read it (exactly) once. If that is the case we must assume no
shared secret is set.

If we don't then we either are the first to read it, thus causing the
real read of the data to fail.

Or we are later and then it throws an exception (also failing the
request).


To trigger you need quite a few conditions.

1. configure are `shared_secret` logcondition in your config.php
2. Have an app installed that on PUT somewhere logs to debug
3. Upload a file to a public share (was the easiest to trigger).


On our instance this was the files_antivirus app.

This write to debug will try to read the log_secret from the request. But this will fail hard. Causing the request to fail.