### PR TITLE
13.0.3 RC 1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(13, 0, 2, 2);
+$OC_Version = array(13, 0, 3, 0);
 
 // The human readable string
-$OC_VersionString = '13.0.2';
+$OC_VersionString = '13.0.3 RC 1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Changelog since 13.0.2:

* #9259 Backport various scss
* #9344 Fix ellipsis in filename column
* #9358 Replace deprecated sinon reset() call with resetHistory()
* #9377 Catch exceptions in SCSSCacher::resetCache()
* #9389 Log lock state on conflict
* #9391 Remove unneeded locks in getCacheEntry
* #9392 Only allow a single concurrent dav write to a file
* #9409 Workflow rules error when changing operation
* #9430 Fix jsunit tests
* #9432 Allow IPv6 database host
* #9433 Add labels for Contacts menu and Settings
* #9436 Get correct version of an app
* #9453 Fix ids of permission checkboxes for shares
* #9454 Fix race condition when preparing upload folder
* #9516 Allow to specify a link to a legal notice
* #9522 Fix for unbound cloned LDAP connections
* #9525 Dont use $info as array when its not an array
* #9540 Improve OAuth
* #9547 Bump theming version for extraordinary release
* #9548 Fix translation bug on lost password page
* #9566 Cleanup locks in scanner on error
* #9573 Bump version for theming again 🙇
* #9579 Make sure force language is reflected in html lang attribute
* #9586 Add privacy link to theming and fix scrollbars
* #9590 Fix settings menu
* #9608 Handle exception while itterating trough smb file listing
* #9610 Send invitations for shared calendars
* #9619 Regenerate session id after public share auth
* #9620 Emit event when running ./occ db:add-missing-indices
* #9621 Add PHP missing message to index.php
* #9622 Delete the previews when a version is restored
* #9629 Limit Sinon version to 5.0.7 at most
* #9647 Prepare another theming release including translations for recently added imprint and privacy policy strings
* #9649 Dont open the file on dav HEAD request
* #9650 Fix AmazonS3:  fix loop $result['Contents'] error
* #9651 Fix undefined variables
* #9652 Add search category icon
* #9654 Fix "Invalid argument supplied for foreach()"
* #9655 Do not load calendar/addressbook plugins if not needed
* #9656  Make LargeFileHelper.php faster by avoiding execs as much as possible
* #9657 Improve error reporting and move format parameter to the options
* #9659 The OAuth endpoint needs to support Basic Auth
* #9661 LDAP password renewal fixes
* #9662 Check user state when fetching to avoid dealing with offline objects
* #9668 Make sure the file is readable before attempting to create a preview
* #9672 Fix drone mysqlmb4 tests
* #9694 Make sure the log doesn't try to read from PUT if it can't
* #9707 Allow admins to disable FreeBusy without modifying ShareAPI capabilities
*  #9712 Fix the unit tests
* [3rdparty#99](https://github.com/nextcloud/3rdparty/pull/99) Don't open the file when handling HEAD requests
* [files_texteditor#101](https://github.com/nextcloud/files_texteditor/pull/101) Do not sanitize markdown output twice