### PR TITLE
12.0.8 RC 1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -656,7 +656,7 @@ services:
       matrix:
         DB: postgres
   mysql:
-    image: mysql
+    image: mysql:5.7.22
     environment:
       - MYSQL_ROOT_PASSWORD=owncloud
       - MYSQL_USER=oc_autotest

--- a/version.php
+++ b/version.php
@@ -26,10 +26,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(12, 0, 7, 2);
+$OC_Version = array(12, 0, 8, 0);
 
 // The human readable string
-$OC_VersionString = '12.0.7';
+$OC_VersionString = '12.0.8 RC 1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Changelog since 12.0.7:

* #9359 Replace deprecated sinon reset() call with resetHistory()
* #9431 Fix jsunit tests
* #9493 Allow upgrades from ownCloud 10.0.8
* #9546 Improve OAuth
* #9549 Fix translation bug on lost password page
* #9567 Cleanup locks in scanner on error
* #9580 Make sure force language is reflected in html lang attribute
* #9618 Regenerate session id after public share auth
* #9630 Limit Sinon version to 5.0.7 at most
* #9660 The OAuth endpoint needs to support Basic Auth
* #9669 Make sure the file is readable before attempting to create a preview
* #9671 Fix drone mysqlmb4 tests


Pending PRs:

* [x] #9611 Send invitations for shared calendars
* [x] #9695 Make sure the log doesn't try to read from PUT if it can't
