### PR TITLE
[stable13] allow admins to override FreeBusy capabilities without modifying ShareAPI capabilities

### DIFF
--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -46,6 +46,7 @@ $principalBackend = new Principal(
 	\OC::$server->getGroupManager(),
 	\OC::$server->getShareManager(),
 	\OC::$server->getUserSession(),
+	\OC::$server->getConfig(),
 	'principals/'
 );
 $db = \OC::$server->getDatabaseConnection();

--- a/apps/dav/appinfo/v1/carddav.php
+++ b/apps/dav/appinfo/v1/carddav.php
@@ -47,6 +47,7 @@ $principalBackend = new Principal(
 	\OC::$server->getGroupManager(),
 	\OC::$server->getShareManager(),
 	\OC::$server->getUserSession(),
+	\OC::$server->getConfig(),
 	'principals/'
 );
 $db = \OC::$server->getDatabaseConnection();

--- a/apps/dav/lib/Command/CreateCalendar.php
+++ b/apps/dav/lib/Command/CreateCalendar.php
@@ -77,7 +77,8 @@ class CreateCalendar extends Command {
 			$this->userManager,
 			$this->groupManager,
 			\OC::$server->getShareManager(),
-			\OC::$server->getUserSession()
+			\OC::$server->getUserSession(),
+			\OC::$server->getConfig()
 		);
 		$random = \OC::$server->getSecureRandom();
 		$logger = \OC::$server->getLogger();

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -30,6 +30,7 @@
 
 namespace OCA\DAV\Connector\Sabre;
 
+use OCP\IConfig;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
@@ -55,6 +56,9 @@ class Principal implements BackendInterface {
 	/** @var IUserSession */
 	private $userSession;
 
+	/** @var IConfig */
+	private $config;
+
 	/** @var string */
 	private $principalPrefix;
 
@@ -66,17 +70,20 @@ class Principal implements BackendInterface {
 	 * @param IGroupManager $groupManager
 	 * @param IShareManager $shareManager
 	 * @param IUserSession $userSession
+	 * @param IConfig $config
 	 * @param string $principalPrefix
 	 */
 	public function __construct(IUserManager $userManager,
 								IGroupManager $groupManager,
 								IShareManager $shareManager,
 								IUserSession $userSession,
+								IConfig $config,
 								$principalPrefix = 'principals/users/') {
 		$this->userManager = $userManager;
 		$this->groupManager = $groupManager;
 		$this->shareManager = $shareManager;
 		$this->userSession = $userSession;
+		$this->config = $config;
 		$this->principalPrefix = trim($principalPrefix, '/');
 		$this->hasGroups = ($principalPrefix === 'principals/users/');
 	}
@@ -206,8 +213,10 @@ class Principal implements BackendInterface {
 	protected function searchUserPrincipals(array $searchProperties, $test = 'allof') {
 		$results = [];
 
-		// If sharing is disabled, return the empty array
-		if (!$this->shareManager->shareApiEnabled()) {
+		// If sharing is disabled (or FreeBusy was disabled on purpose), return the empty array
+		$shareAPIEnabled = $this->shareManager->shareApiEnabled();
+		$disableFreeBusy = $this->config->getAppValue('dav', 'disableFreeBusy', $shareAPIEnabled ? 'no' : 'yes');
+		if ($disableFreeBusy === 'yes') {
 			return [];
 		}
 
@@ -290,8 +299,10 @@ class Principal implements BackendInterface {
 	 * @return string
 	 */
 	function findByUri($uri, $principalPrefix) {
-		// If sharing is disabled, return null as in user not found
-		if (!$this->shareManager->shareApiEnabled()) {
+		// If sharing is disabled (or FreeBusy was disabled on purpose), return the empty array
+		$shareAPIEnabled = $this->shareManager->shareApiEnabled();
+		$disableFreeBusy = $this->config->getAppValue('dav', 'disableFreeBusy', $shareAPIEnabled ? 'no' : 'yes');
+		if ($disableFreeBusy === 'yes') {
 			return null;
 		}
 

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -51,7 +51,8 @@ class RootCollection extends SimpleCollection {
 			$userManager,
 			$groupManager,
 			$shareManager,
-			\OC::$server->getUserSession()
+			\OC::$server->getUserSession(),
+			$config
 		);
 		$groupPrincipalBackend = new GroupPrincipalBackend($groupManager);
 		// as soon as debug mode is enabled we allow listing of principals


### PR DESCRIPTION
backport of #9550

before disabling: 
![before](https://user-images.githubusercontent.com/1250540/40796933-e7fe6f36-6506-11e8-8f78-aba16ae3bd82.png)

after disabling:
![after](https://user-images.githubusercontent.com/1250540/40797112-5aa9e8e4-6507-11e8-84c8-4bbdfd0fcfdc.png)
