### PR TITLE
Add a hint that some indexes are not added yet

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -28,8 +28,12 @@
 
 namespace OC\Core;
 
+use OC\DB\MissingIndexInformation;
+use OC\DB\SchemaWrapper;
 use OCP\AppFramework\App;
+use OCP\IDBConnection;
 use OCP\Util;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Class Application
@@ -46,5 +50,28 @@ class Application extends App {
 		$container->registerService('defaultMailAddress', function () {
 			return Util::getDefaultEmailAddress('lostpassword-noreply');
 		});
+
+		$server = $container->getServer();
+		$eventDispatcher = $server->getEventDispatcher();
+
+		$eventDispatcher->addListener(IDBConnection::CHECK_MISSING_INDEXES_EVENT,
+			function(GenericEvent $event) use ($container) {
+				/** @var MissingIndexInformation $subject */
+				$subject = $event->getSubject();
+
+				$schema = new SchemaWrapper($container->query(IDBConnection::class));
+
+				if ($schema->hasTable('share')) {
+					$table = $schema->getTable('share');
+
+					if (!$table->hasIndex('share_with_index')) {
+						$subject->addHintForMissingSubject($table->getName(), 'share_with_index');
+					}
+					if (!$table->hasIndex('parent_index')) {
+						$subject->addHintForMissingSubject($table->getName(), 'parent_index');
+					}
+				}
+			}
+		);
 	}
 }

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -183,6 +183,21 @@
 							type: OC.SetupChecks.MESSAGE_TYPE_INFO
 						})
 					}
+					if (data.hasMissingIndexes) {
+						var listOfMissingIndexes = "";
+						data.hasMissingIndexes.forEach(function(element){
+							listOfMissingIndexes += "<li>";
+							listOfMissingIndexes += t('core', 'Missing index "{indexName}" in table "{tableName}".', element);
+							listOfMissingIndexes += "</li>";
+						});
+						messages.push({
+							msg: t(
+								'core',
+								'The database is missing some indexes. Due to the fact that adding indexes on big tables could take some time they were not added automatically. By running "occ db:add-missing-indices" those missing indexes could be added manually while the instance keeps running. Once the indexes are added queries to those tables are usually much faster.'
+							) + "<ul>" + listOfMissingIndexes + "</ul>",
+							type: OC.SetupChecks.MESSAGE_TYPE_INFO
+						})
+					}
 				} else {
 					messages.push({
 						msg: t('core', 'Error occurred while checking server setup'),

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -579,6 +579,7 @@ return array(
     'OC\\DB\\MigrationException' => $baseDir . '/lib/private/DB/MigrationException.php',
     'OC\\DB\\MigrationService' => $baseDir . '/lib/private/DB/MigrationService.php',
     'OC\\DB\\Migrator' => $baseDir . '/lib/private/DB/Migrator.php',
+    'OC\\DB\\MissingIndexInformation' => $baseDir . '/lib/private/DB/MissingIndexInformation.php',
     'OC\\DB\\MySQLMigrator' => $baseDir . '/lib/private/DB/MySQLMigrator.php',
     'OC\\DB\\MySqlTools' => $baseDir . '/lib/private/DB/MySqlTools.php',
     'OC\\DB\\OCSqlitePlatform' => $baseDir . '/lib/private/DB/OCSqlitePlatform.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -609,6 +609,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\DB\\MigrationException' => __DIR__ . '/../../..' . '/lib/private/DB/MigrationException.php',
         'OC\\DB\\MigrationService' => __DIR__ . '/../../..' . '/lib/private/DB/MigrationService.php',
         'OC\\DB\\Migrator' => __DIR__ . '/../../..' . '/lib/private/DB/Migrator.php',
+        'OC\\DB\\MissingIndexInformation' => __DIR__ . '/../../..' . '/lib/private/DB/MissingIndexInformation.php',
         'OC\\DB\\MySQLMigrator' => __DIR__ . '/../../..' . '/lib/private/DB/MySQLMigrator.php',
         'OC\\DB\\MySqlTools' => __DIR__ . '/../../..' . '/lib/private/DB/MySqlTools.php',
         'OC\\DB\\OCSqlitePlatform' => __DIR__ . '/../../..' . '/lib/private/DB/OCSqlitePlatform.php',

--- a/lib/private/DB/MissingIndexInformation.php
+++ b/lib/private/DB/MissingIndexInformation.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Morris Jobke <hey@morrisjobke.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\DB;
+
+
+class MissingIndexInformation {
+
+	private $listOfMissingIndexes = [];
+
+	public function addHintForMissingSubject($tableName, $indexName) {
+		$this->listOfMissingIndexes[] = [
+			'tableName' => $tableName,
+			'indexName' => $indexName
+		];
+	}
+
+	public function getListOfMissingIndexes() {
+		return $this->listOfMissingIndexes;
+	}
+}

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -47,6 +47,7 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 interface IDBConnection {
 
 	const ADD_MISSING_INDEXES_EVENT = self::class . '::ADD_MISSING_INDEXES';
+	const CHECK_MISSING_INDEXES_EVENT = self::class . '::CHECK_MISSING_INDEXES';
 
 	/**
 	 * Gets the QueryBuilder for the connection.

--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -1038,12 +1038,6 @@ table.grid td.date {
 	margin-top: 20px;
 }
 
-#security-warning li {
-	list-style: initial;
-	margin: 10px 0;
-	list-style-position: inside;
-}
-
 #security-warning-state span {
 	padding-left: 25px;
 	background-position: 5px center;
@@ -1198,6 +1192,18 @@ doesnotexist:-o-prefocus, .strengthify-wrapper {
 }
 
 #postsetupchecks {
+	ul {
+		margin-left: 44px;
+		list-style: disc;
+
+		li {
+			margin: 10px 0;
+		}
+
+		ul {
+			list-style: circle;
+		}
+	}
 	.loading {
 		height: 50px;
 		background-position: left center;
@@ -1207,6 +1213,10 @@ doesnotexist:-o-prefocus, .strengthify-wrapper {
 	}
 	.warnings, .warnings a {
 		color: $color-warning;
+	}
+
+	.hint {
+		margin: 20px 0;
 	}
 }
 


### PR DESCRIPTION
* gives the admin a chance to discover the missing indexes and improve the performance of the instance without digging through the manual
* nicely integrated in the setup checks where this kind of hints belong to
* also adds an option to integrate this from an app based on events


![bildschirmfoto 2018-06-04 um 16 19 43](https://user-images.githubusercontent.com/245432/40922800-6a3868a8-6813-11e8-8934-a4803f97d867.png)


cc @nextcloud/designers for hints about how to show them.

I found this helpful after reviewing #9327.

Should we make a `OCP\DB\IMissingIndexInformation` with only the method to add information to the object?