### PR TITLE
Menu entry clickability

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -890,6 +890,7 @@ $popovericon-size: 16px;
 			align-items: flex-start;
 			height: auto;
 			margin: 0;
+			padding: 3px 20px 3px 3px !important; /* for nice visual balance */
 			font-weight: 300;
 			box-shadow: none;
 			width: 100%;
@@ -930,10 +931,6 @@ $popovericon-size: 16px;
 			&.active {
 				opacity: 1 !important;
 			}
-			/* prevent .action class to break the design */
-			&.action {
-				padding: inherit !important;
-			}
 			> span {
 				cursor: pointer;
 				white-space: nowrap;
@@ -946,10 +943,6 @@ $popovericon-size: 16px;
 			> select {
 				margin: 0;
 				margin-left: 6px;
-			}
-			/* Add padding if contains icon+text */
-			&:not(:empty) {
-				padding-right: 10px !important;
 			}
 			/* DEPRECATED! old img in popover fallback
 			 * TODO: to remove */

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -269,8 +269,9 @@ nav[role='navigation'] {
 	a {
 		position: relative;
 		display: inline-flex;
-		padding: 10px 12px;
-		height: 40px;
+		height: 44px;
+		width: 100%;
+		padding: 12px;
 		align-items: center;
 		span {
 			display: inline-block;
@@ -412,7 +413,8 @@ nav[role='navigation'] {
 	a {
 		display: inline-flex;
 		align-items: center;
-		height: 40px;
+		height: 44px;
+		width: 100%;
 		color: var(--color-main-text);
 		padding: 12px;
 		box-sizing: border-box;

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -271,7 +271,7 @@ nav[role='navigation'] {
 		display: inline-flex;
 		height: 44px;
 		width: 100%;
-		padding: 12px;
+		padding: 12px 20px 12px 14px; /* for nice visual balance */
 		align-items: center;
 		span {
 			display: inline-block;
@@ -415,8 +415,8 @@ nav[role='navigation'] {
 		align-items: center;
 		height: 44px;
 		width: 100%;
+		padding: 12px 20px 12px 14px; /* for nice visual balance */
 		color: var(--color-main-text);
-		padding: 12px;
 		box-sizing: border-box;
 		opacity: .7;
 		white-space: nowrap;


### PR DESCRIPTION
Adjust to proper minimum 44px size (we need to take care that all elements have this minimum clickable size), please review @nextcloud/designers 
Also has more breathing space and looks less cramped now. :)

Before:
![before](https://user-images.githubusercontent.com/925062/40973930-459969c6-68c6-11e8-998a-2f7b873cdf26.png)

After:

![after](https://user-images.githubusercontent.com/925062/40973931-45cb0c7e-68c6-11e8-90eb-46052e486673.png)
