### PR TITLE
Do not logout on auth on public share page

### DIFF
--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -29,6 +29,7 @@
 
 namespace OCA\Files_Sharing\AppInfo;
 
+use OC\Authentication\Token\IProvider;
 use OCA\Files_Sharing\Middleware\OCSShareAPIMiddleware;
 use OCA\Files_Sharing\Middleware\ShareInfoMiddleware;
 use OCA\Files_Sharing\MountProvider;
@@ -72,7 +73,8 @@ class Application extends App {
 				$federatedSharingApp->getFederatedShareProvider(),
 				$server->getEventDispatcher(),
 				$server->getL10N($c->query('AppName')),
-				$server->query(Defaults::class)
+				$server->query(Defaults::class),
+				$server->query(IProvider::class)
 			);
 		});
 		$container->registerService('ExternalSharesController', function (SimpleContainer $c) {

--- a/apps/files_sharing/tests/Controller/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareControllerTest.php
@@ -31,6 +31,7 @@
 
 namespace OCA\Files_Sharing\Tests\Controllers;
 
+use OC\Authentication\Token\IProvider;
 use OC\Files\Filesystem;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\Files_Sharing\Controller\ShareController;
@@ -125,7 +126,8 @@ class ShareControllerTest extends \Test\TestCase {
 			$this->federatedShareProvider,
 			$this->eventDispatcher,
 			$this->l10n,
-			$this->getMockBuilder('\OCP\Defaults')->getMock()
+			$this->getMockBuilder('\OCP\Defaults')->getMock(),
+			$this->createMock(IProvider::class)
 		);
 
 


### PR DESCRIPTION
If the user is authenticated to cloudA. And then visits a password
protected public link where we authenticate. We should rotate the token
to the new session id. Else they have to reauthenticate

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>