### PR TITLE
Missing svg filter mixin for apps management

### DIFF
--- a/settings/src/components/svgFilterMixin.vue
+++ b/settings/src/components/svgFilterMixin.vue
@@ -1,0 +1,40 @@
+<!--
+  - @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
+  -
+  - @author Julius Härtl <jus@bitgrid.net>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<script>
+	export default {
+		name: 'svgFilterMixin',
+		mounted() {
+			this.filterId = 'invertIconApps' + Math.floor((Math.random() * 100 )) + new Date().getSeconds() + new Date().getMilliseconds();
+		},
+		computed: {
+			filterUrl () {
+				return `url(#${this.filterId})`;
+			},
+		},
+		data() {
+			return {
+				filterId: '',
+			};
+		},
+	}
+</script>


### PR DESCRIPTION
Forgot to commit the source file. The bundled source was working since I had that file locally while building. :see_no_evil: 

Follow up to #9565 