### PR TITLE
Mock the timefactory in the theming tests

### DIFF
--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -66,8 +66,6 @@ class ThemingController extends Controller {
 	private $themingDefaults;
 	/** @var Util */
 	private $util;
-	/** @var ITimeFactory */
-	private $timeFactory;
 	/** @var IL10N */
 	private $l10n;
 	/** @var IConfig */
@@ -93,7 +91,6 @@ class ThemingController extends Controller {
 	 * @param IConfig $config
 	 * @param ThemingDefaults $themingDefaults
 	 * @param Util $util
-	 * @param ITimeFactory $timeFactory
 	 * @param IL10N $l
 	 * @param ITempManager $tempManager
 	 * @param IAppData $appData
@@ -108,7 +105,6 @@ class ThemingController extends Controller {
 		IConfig $config,
 		ThemingDefaults $themingDefaults,
 		Util $util,
-		ITimeFactory $timeFactory,
 		IL10N $l,
 		ITempManager $tempManager,
 		IAppData $appData,
@@ -121,7 +117,6 @@ class ThemingController extends Controller {
 
 		$this->themingDefaults = $themingDefaults;
 		$this->util = $util;
-		$this->timeFactory = $timeFactory;
 		$this->l10n = $l;
 		$this->config = $config;
 		$this->tempManager = $tempManager;

--- a/apps/theming/tests/Controller/ThemingControllerTest.php
+++ b/apps/theming/tests/Controller/ThemingControllerTest.php
@@ -86,18 +86,21 @@ class ThemingControllerTest extends TestCase {
 		$this->request = $this->createMock(IRequest::class);
 		$this->config = $this->createMock(IConfig::class);
 		$this->themingDefaults = $this->createMock(ThemingDefaults::class);
-		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->l10n = $this->createMock(L10N::class);
 		$this->appData = $this->createMock(IAppData::class);
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->util = new Util($this->config, $this->appManager, $this->appData);
-		$this->timeFactory->expects($this->any())
-			->method('getTime')
-			->willReturn(123);
 		$this->tempManager = \OC::$server->getTempManager();
 		$this->scssCacher = $this->createMock(SCSSCacher::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->imageManager = $this->createMock(ImageManager::class);
+
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->timeFactory->expects($this->any())
+			->method('getTime')
+			->willReturn(123);
+
+		$this->overwriteService(ITimeFactory::class, $this->timeFactory);
 
 		$this->themingController = new ThemingController(
 			'theming',
@@ -105,7 +108,6 @@ class ThemingControllerTest extends TestCase {
 			$this->config,
 			$this->themingDefaults,
 			$this->util,
-			$this->timeFactory,
 			$this->l10n,
 			$this->tempManager,
 			$this->appData,


### PR DESCRIPTION
Now that the cache logic is moved to the theming controller we must
properly overwrite this service. Else it could do :boom: in tests.

else unit tests might sometimes fail..