### PR TITLE
Add SFTP auth mechanism to use a password and private key for SFTP

### DIFF
--- a/apps/files_external/js/public_key.js
+++ b/apps/files_external/js/public_key.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
 
 	OCA.External.Settings.mountConfig.whenSelectAuthMechanism(function($tr, authMechanism, scheme, onCompletion) {
-		if (scheme === 'publickey') {
+		if (scheme === 'publickey' && authMechanism === 'publickey::rsa') {
 			var config = $tr.find('.configuration');
 			if ($(config).find('[name="public_key_generate"]').length === 0) {
 				setupTableRow($tr, config);

--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -29,6 +29,7 @@
 
 namespace OCA\Files_External\AppInfo;
 
+use OCA\Files_External\Lib\Auth\PublicKey\RSAPrivateKey;
 use \OCP\AppFramework\App;
 use OCP\AppFramework\IAppContainer;
 use \OCA\Files_External\Service\BackendService;
@@ -138,6 +139,7 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 
 			// AuthMechanism::SCHEME_PUBLICKEY mechanisms
 			$container->query(RSA::class),
+			$container->query(RSAPrivateKey::class),
 
 			// AuthMechanism::SCHEME_OPENSTACK mechanisms
 			$container->query(OpenStackV2::class),

--- a/apps/files_external/lib/Lib/Auth/PublicKey/RSAPrivateKey.php
+++ b/apps/files_external/lib/Lib/Auth/PublicKey/RSAPrivateKey.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @copyright 2018, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Files_External\Lib\Auth\PublicKey;
+
+use \OCP\IL10N;
+use \OCA\Files_External\Lib\DefinitionParameter;
+use \OCA\Files_External\Lib\Auth\AuthMechanism;
+use \OCA\Files_External\Lib\StorageConfig;
+use \OCP\IConfig;
+use OCP\IUser;
+use \phpseclib\Crypt\RSA as RSACrypt;
+
+/**
+ * RSA public key authentication
+ */
+class RSAPrivateKey extends AuthMechanism {
+
+	/** @var IConfig */
+	private $config;
+
+	public function __construct(IL10N $l, IConfig $config) {
+		$this->config = $config;
+
+		$this
+			->setIdentifier('publickey::rsa_private')
+			->setScheme(self::SCHEME_PUBLICKEY)
+			->setText($l->t('RSA private key'))
+			->addParameters([
+				new DefinitionParameter('user', $l->t('Username')),
+				(new DefinitionParameter('password', $l->t('Password')))
+					->setFlag(DefinitionParameter::FLAG_OPTIONAL)
+					->setType(DefinitionParameter::VALUE_PASSWORD),
+				new DefinitionParameter('private_key', $l->t('Private key')),
+			]);
+	}
+
+	public function manipulateStorageConfig(StorageConfig &$storage, IUser $user = null) {
+		$auth = new RSACrypt();
+		$auth->setPassword($this->config->getSystemValue('secret', ''));
+		if (!$auth->loadKey($storage->getBackendOption('private_key'))) {
+			throw new \RuntimeException('unable to load private key');
+		}
+		$storage->setBackendOption('public_key_auth', $auth);
+	}
+}


### PR DESCRIPTION
This adds a new auth mechanism to the SFTP backend

- You can specifiy your own private key (in case somebody else generates your keypair somewhere)
- You can also specify a password. This password is not used to decrypt the private key. It is used to also authenticate (so you send both a key and a password).