### PR TITLE
Upgrade to swiftmailer-6

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -328,14 +328,9 @@ $CONFIG = array(
 'mail_smtpdebug' => false,
 
 /**
- * Which mode to use for sending mail: ``sendmail``, ``smtp``, ``qmail`` or
- * ``php``.
+ * Which mode to use for sending mail: ``sendmail``, ``smtp`` or ``qmail``.
  *
  * If you are using local or remote SMTP, set this to ``smtp``.
- *
- * If you are using PHP mail you must have an installed and working email system
- * on the server. The program used to send email is defined in the ``php.ini``
- * file.
  *
  * For the ``sendmail`` option you need an installed and working email system on
  * the server, with ``/usr/sbin/sendmail`` installed on your Unix system.
@@ -343,9 +338,9 @@ $CONFIG = array(
  * For ``qmail`` the binary is /var/qmail/bin/sendmail, and it must be installed
  * on your Unix system.
  *
- * Defaults to ``php``
+ * Defaults to ``smtp``
  */
-'mail_smtpmode' => 'php',
+'mail_smtpmode' => 'smtp',
 
 /**
  * This depends on ``mail_smtpmode``. Specify the IP address of your mail

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -293,6 +293,18 @@
 							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 						})
 					}
+					if (data.isPhpMailerUsed) {
+						messages.push({
+							msg: t(
+								'core',
+								'Use of the the built in php mailer is no longer supported. <a target="_blank" rel="noreferrer noopener" href="{docLink}">Please update your email server settings ↗<a/>.',
+								{
+									docLink: data.mailSettingsDocumentation,
+								}
+							),
+							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+						});
+					}
 				} else {
 					messages.push({
 						msg: t('core', 'Error occurred while checking server setup'),

--- a/lib/private/Settings/Admin/Mail.php
+++ b/lib/private/Settings/Admin/Mail.php
@@ -63,6 +63,10 @@ class Mail implements ISettings {
 			$parameters['mail_smtppassword'] = '********';
 		}
 
+		if ($parameters['mail_smtpmode'] === '' || $parameters['mail_smtpmode'] === 'php') {
+			$parameters['mail_smtpmode'] = 'smtp';
+		}
+
 		return new TemplateResponse('settings', 'settings/admin/additional-mail', $parameters, '');
 	}
 

--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -523,6 +523,10 @@ Raw output
 		return [];
 	}
 
+	protected function isPhpMailerUsed(): bool {
+		return $this->config->getSystemValue('mail_smtpmode', 'php') === 'php';
+	}
+
 	/**
 	 * @return DataResponse
 	 */
@@ -557,6 +561,8 @@ Raw output
 				'missingIndexes' => $this->hasMissingIndexes(),
 				'isSqliteUsed' => $this->isSqliteUsed(),
 				'databaseConversionDocumentation' => $this->urlGenerator->linkToDocs('admin-db-conversion'),
+				'isPhpMailerUsed' => $this->isPhpMailerUsed(),
+				'mailSettingsDocumentation' => $this->urlGenerator->getAbsoluteURL('index.php/settings/admin')
 			]
 		);
 	}

--- a/settings/templates/settings/admin/additional-mail.php
+++ b/settings/templates/settings/admin/additional-mail.php
@@ -38,7 +38,6 @@ $mail_smtpsecure = [
 ];
 
 $mail_smtpmode = [
-	['php', 'PHP'],
 	['smtp', 'SMTP'],
 ];
 if ($_['sendmail_is_available']) {

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -119,7 +119,22 @@ class CheckSetupControllerTest extends TestCase {
 				$this->lockingProvider,
 				$this->dateTimeFormatter,
 				])
-			->setMethods(['isReadOnlyConfig', 'hasValidTransactionIsolationLevel', 'hasFileinfoInstalled', 'hasWorkingFileLocking', 'getLastCronInfo', 'getSuggestedOverwriteCliURL', 'getOutdatedCaches', 'getCurlVersion', 'isPhpOutdated', 'isOpcacheProperlySetup', 'hasFreeTypeSupport', 'hasMissingIndexes', 'isSqliteUsed'])->getMock();
+			->setMethods([
+				'isReadOnlyConfig',
+				'hasValidTransactionIsolationLevel',
+				'hasFileinfoInstalled',
+				'hasWorkingFileLocking',
+				'getLastCronInfo',
+				'getSuggestedOverwriteCliURL',
+				'getOutdatedCaches',
+				'getCurlVersion',
+				'isPhpOutdated',
+				'isOpcacheProperlySetup',
+				'hasFreeTypeSupport',
+				'hasMissingIndexes',
+				'isSqliteUsed',
+				'isPhpMailerUsed',
+			])->getMock();
 	}
 
 	public function testIsInternetConnectionWorkingDisabledViaConfig() {
@@ -352,6 +367,10 @@ class CheckSetupControllerTest extends TestCase {
 			->method('linkToDocs')
 			->with('admin-db-conversion')
 			->willReturn('http://docs.example.org/server/go.php?to=admin-db-conversion');
+		$this->urlGenerator->expects($this->at(6))
+			->method('getAbsoluteURL')
+			->with('index.php/settings/admin')
+			->willReturn('https://server/index.php/settings/admin');
 		$this->checkSetupController
 			->method('hasFreeTypeSupport')
 			->willReturn(false);
@@ -392,6 +411,10 @@ class CheckSetupControllerTest extends TestCase {
 				'relativeTime' => '2 hours ago',
 				'backgroundJobsUrl' => 'https://example.org',
 			]);
+		$this->checkSetupController
+			->expects($this->once())
+			->method('isPhpMailerUsed')
+			->willReturn(false);
 		$this->checker
 			->expects($this->once())
 			->method('hasPassedCheck')
@@ -434,6 +457,8 @@ class CheckSetupControllerTest extends TestCase {
 				'isSqliteUsed' => false,
 				'databaseConversionDocumentation' => 'http://docs.example.org/server/go.php?to=admin-db-conversion',
 				'missingIndexes' => [],
+				'isPhpMailerUsed' => false,
+				'mailSettingsDocumentation' => 'https://server/index.php/settings/admin',
 			]
 		);
 		$this->assertEquals($expected, $this->checkSetupController->check());

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -48,50 +48,41 @@ class MailerTest extends TestCase {
 		);
 	}
 
-	public function testGetMailInstance() {
-		$this->assertEquals(\Swift_MailTransport::newInstance(), self::invokePrivate($this->mailer, 'getMailinstance'));
-	}
-
 	public function testGetSendMailInstanceSendMail() {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
-			->with('mail_smtpmode', 'php')
+			->with('mail_smtpmode', 'smtp')
 			->will($this->returnValue('sendmail'));
 
-		$this->assertEquals(\Swift_SendmailTransport::newInstance('/usr/sbin/sendmail -bs'), self::invokePrivate($this->mailer, 'getSendMailInstance'));
+		$this->assertEquals(new \Swift_SendmailTransport('/usr/sbin/sendmail -bs'), self::invokePrivate($this->mailer, 'getSendMailInstance'));
 	}
 
 	public function testGetSendMailInstanceSendMailQmail() {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
-			->with('mail_smtpmode', 'php')
+			->with('mail_smtpmode', 'smtp')
 			->will($this->returnValue('qmail'));
 
-		$this->assertEquals(\Swift_SendmailTransport::newInstance('/var/qmail/bin/sendmail -bs'), self::invokePrivate($this->mailer, 'getSendMailInstance'));
+		$this->assertEquals(new \Swift_SendmailTransport('/var/qmail/bin/sendmail -bs'), self::invokePrivate($this->mailer, 'getSendMailInstance'));
 	}
 
 	public function testGetInstanceDefault() {
-		$this->assertInstanceOf('\Swift_MailTransport', self::invokePrivate($this->mailer, 'getInstance'));
-	}
-
-	public function testGetInstancePhp() {
-		$this->config
-			->expects($this->any())
-			->method('getSystemValue')
-			->will($this->returnValue('php'));
-
-		$this->assertInstanceOf('\Swift_MailTransport', self::invokePrivate($this->mailer, 'getInstance'));
+		$mailer = self::invokePrivate($this->mailer, 'getInstance');
+		$this->assertInstanceOf(\Swift_Mailer::class, $mailer);
+		$this->assertInstanceOf(\Swift_SmtpTransport::class, $mailer->getTransport());
 	}
 
 	public function testGetInstanceSendmail() {
 		$this->config
-			->expects($this->any())
 			->method('getSystemValue')
-			->will($this->returnValue('sendmail'));
+			->with('mail_smtpmode', 'smtp')
+			->willReturn('sendmail');
 
-		$this->assertInstanceOf('\Swift_Mailer', self::invokePrivate($this->mailer, 'getInstance'));
+		$mailer = self::invokePrivate($this->mailer, 'getInstance');
+		$this->assertInstanceOf(\Swift_Mailer::class, $mailer);
+		$this->assertInstanceOf(\Swift_SendmailTransport::class, $mailer->getTransport());
 	}
 
 	public function testCreateMessage() {

--- a/tests/lib/Settings/Admin/MailTest.php
+++ b/tests/lib/Settings/Admin/MailTest.php
@@ -59,7 +59,7 @@ class MailTest extends TestCase {
 			->expects($this->at(2))
 			->method('getSystemValue')
 			->with('mail_smtpmode', '')
-			->willReturn('php');
+			->willReturn('smtp');
 		$this->config
 			->expects($this->at(3))
 			->method('getSystemValue')
@@ -103,7 +103,7 @@ class MailTest extends TestCase {
 				'sendmail_is_available' => (bool) \OC_Helper::findBinaryPath('sendmail'),
 				'mail_domain'           => 'mx.nextcloud.com',
 				'mail_from_address'     => 'no-reply@nextcloud.com',
-				'mail_smtpmode'         => 'php',
+				'mail_smtpmode'         => 'smtp',
 				'mail_smtpsecure'       => true,
 				'mail_smtphost'         => 'smtp.nextcloud.com',
 				'mail_smtpport'         => 25,


### PR DESCRIPTION
Requires:
- [x] https://github.com/nextcloud/3rdparty/pull/115


Todo:
- [x] Remove php mail mode
  * It is removed from swift
  * to unreliable
  * not enough error info returned
  * not properly configured regarding SPF etc 99% of the time
- [x] Move mailer over
- [x] Fix tests
- [x] Add warning to the overview if mail mode is set to php
  * [x] Needs https://github.com/nextcloud/server/pull/9920
- [x] Add docs: https://github.com/nextcloud/documentation/issues/787
- [x] Make sure this is in the release notes