### PR TITLE
Make the token expiration also work for autocasting 0

### DIFF
--- a/lib/private/Authentication/Token/DefaultTokenProvider.php
+++ b/lib/private/Authentication/Token/DefaultTokenProvider.php
@@ -171,7 +171,7 @@ class DefaultTokenProvider implements IProvider {
 			throw new InvalidTokenException();
 		}
 
-		if ($token->getExpires() !== null && $token->getExpires() < $this->time->getTime()) {
+		if ((int)$token->getExpires() !== 0 && $token->getExpires() < $this->time->getTime()) {
 			throw new ExpiredTokenException($token);
 		}
 


### PR DESCRIPTION
Some bad databases don't respect the default null apprently.
Now even if they cast it to 0 it should work just fine.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>