### PR TITLE
Fix highlighting of the upload drop zone

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1166,6 +1166,16 @@ OC.Uploader.prototype = _.extend({
 				});
 				fileupload.on('fileuploaddragleave fileuploaddrop', disableDropState);
 
+				// In some browsers the "drop" event can be triggered with no
+				// files even if the "dragover" event seemed to suggest that a
+				// file was being dragged (and thus caused "fileuploaddragover"
+				// to be triggered).
+				fileupload.on('fileuploaddropnofiles', function() {
+					disableDropState();
+
+					OC.Notification.show(t('files', 'Uploading that item is not supported'), {type: 'error'});
+				});
+
 				fileupload.on('fileuploadchunksend', function(e, data) {
 					// modify the request to adjust it to our own chunking
 					var upload = self.getUpload(data);

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1131,23 +1131,8 @@ OC.Uploader.prototype = _.extend({
 					self.log('progress handle fileuploadfail', e, data);
 					self.trigger('fail', e, data);
 				});
-				var disableDropState = function() {
-					$('#app-content').removeClass('file-drag');
-					$('.dropping-to-dir').removeClass('dropping-to-dir');
-					$('.dir-drop').removeClass('dir-drop');
-					$('.icon-filetype-folder-drag-accept').removeClass('icon-filetype-folder-drag-accept');
-				};
-				var disableClassOnFirefox = _.debounce(function() {
-					disableDropState();
-				}, 100);
 				fileupload.on('fileuploaddragover', function(e){
 					$('#app-content').addClass('file-drag');
-					// dropping a folder in firefox doesn't cause a drop event
-					// this is simulated by simply invoke disabling all classes
-					// once no dragover event isn't noticed anymore
-					if (/Firefox/i.test(navigator.userAgent)) {
-						disableClassOnFirefox();
-					}
 					$('#emptycontent .icon-folder').addClass('icon-filetype-folder-drag-accept');
 
 					var filerow = $(e.delegatedEvent.target).closest('tr');
@@ -1164,6 +1149,14 @@ OC.Uploader.prototype = _.extend({
 						filerow.find('.thumbnail').addClass('icon-filetype-folder-drag-accept');
 					}
 				});
+
+				var disableDropState = function() {
+					$('#app-content').removeClass('file-drag');
+					$('.dropping-to-dir').removeClass('dropping-to-dir');
+					$('.dir-drop').removeClass('dir-drop');
+					$('.icon-filetype-folder-drag-accept').removeClass('icon-filetype-folder-drag-accept');
+				};
+
 				fileupload.on('fileuploaddragleave fileuploaddrop', disableDropState);
 
 				// In some browsers the "drop" event can be triggered with no

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1164,12 +1164,7 @@ OC.Uploader.prototype = _.extend({
 						filerow.find('.thumbnail').addClass('icon-filetype-folder-drag-accept');
 					}
 				});
-				fileupload.on('fileuploaddragleave fileuploaddrop', function (){
-					$('#app-content').removeClass('file-drag');
-					$('.dropping-to-dir').removeClass('dropping-to-dir');
-					$('.dir-drop').removeClass('dir-drop');
-					$('.icon-filetype-folder-drag-accept').removeClass('icon-filetype-folder-drag-accept');
-				});
+				fileupload.on('fileuploaddragleave fileuploaddrop', disableDropState);
 
 				fileupload.on('fileuploadchunksend', function(e, data) {
 					// modify the request to adjust it to our own chunking

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1041,6 +1041,8 @@ OC.Uploader.prototype = _.extend({
 				//remaining time
 				var lastUpdate, lastSize, bufferSize, buffer, bufferIndex, bufferIndex2, bufferTotal;
 
+				var dragging = false;
+
 				// add progress handlers
 				fileupload.on('fileuploadadd', function(e, data) {
 					self.log('progress handle fileuploadadd', e, data);
@@ -1148,6 +1150,8 @@ OC.Uploader.prototype = _.extend({
 						filerow.addClass('dropping-to-dir');
 						filerow.find('.thumbnail').addClass('icon-filetype-folder-drag-accept');
 					}
+
+					dragging = true;
 				});
 
 				var disableDropState = function() {
@@ -1155,6 +1159,8 @@ OC.Uploader.prototype = _.extend({
 					$('.dropping-to-dir').removeClass('dropping-to-dir');
 					$('.dir-drop').removeClass('dir-drop');
 					$('.icon-filetype-folder-drag-accept').removeClass('icon-filetype-folder-drag-accept');
+
+					dragging = false;
 				};
 
 				fileupload.on('fileuploaddragleave fileuploaddrop', disableDropState);
@@ -1164,6 +1170,10 @@ OC.Uploader.prototype = _.extend({
 				// file was being dragged (and thus caused "fileuploaddragover"
 				// to be triggered).
 				fileupload.on('fileuploaddropnofiles', function() {
+					if (!dragging) {
+						return;
+					}
+
 					disableDropState();
 
 					OC.Notification.show(t('files', 'Uploading that item is not supported'), {type: 'error'});

--- a/apps/files/js/jquery.fileupload.js
+++ b/apps/files/js/jquery.fileupload.js
@@ -258,6 +258,9 @@
             // Callback for drop events of the dropZone(s):
             // drop: function (e, data) {}, // .bind('fileuploaddrop', func);
 
+            // Callback for drop events of the dropZone(s) when there are no files:
+            // dropnofiles: function (e) {}, // .bind('fileuploaddropnofiles', func);
+
             // Callback for dragover events of the dropZone(s):
             // dragover: function (e) {}, // .bind('fileuploaddragover', func);
 
@@ -1275,6 +1278,15 @@
                         that._onAdd(e, data);
                     }
                 });
+            } else {
+                // "dropnofiles" is triggered to allow proper cleanup of the
+                // drag and drop operation, as some browsers trigger "drop"
+                // events that have no files even if the "DataTransfer.types" of
+                // the "dragover" event included a "Files" item.
+                this._trigger(
+                    'dropnofiles',
+                    $.Event('drop', {delegatedEvent: e})
+                );
             }
         },
 


### PR DESCRIPTION
In the Files app, when a file (or folder) is dragged from the desktop to the browser, the drop zone is highlighted while dragging and restored when the file is dropped or the drag canceled.

This happens only when the browser reports a file drag and a file drop, but in some cases the browser may report a file drag followed by a drop with [no files](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/files). In those cases the drop zone is highlighted, but it is not restored once the drop finishes. In #1406 a workaround was added: remove the highlighting after no `dragover` event was sent for 100 milliseconds.

However, this was done for all Firefox versions, even if it was needed only for Firefox 48 and 49 ([in Firefox 50 folder uploads were properly implemented](https://developer.mozilla.org/en-US/Firefox/Releases/50#Files_and_directories)), and it did not cover other affected browsers, like Internet Explorer 11. Moreover, the description of the problem in that issue is not exact; the `drop` event _is_ triggered, but the jQuery Upload plugin does not trigger any callback for that event. The reason is that the `drop` callback is called only when the `drop` event provides a list of files.

This pull request adds a new callback to the jQuery Upload plugin, `dropnofiles`, which is triggered when the browser triggers a `drop` event that has no files. This callback is used to ensure that the changes made by the `dragover` callback, like the highlighting, are also restored when the browser triggers misbehaved drop events; in those cases an error message is shown to the user too. As it is no longer needed the special handling for Firefox was also removed.

The new callback also handles cases like Firefox < 60 (maybe fixed in some previous version, but not before Firefox 52) on GNU/Linux (tested on KDE/Plasma 5.12) reporting a file drag when text was dragged from KWrite to the browser.

Firefox 60 and Chromium 62 have proper support for dragging text on the browser, and I tried to provide feedback to the user ([using DataTransfer.dropEffect](https://www.w3.org/TR/html/editing.html#dom-datatransfer-dropeffect)) so she knows that dropping text on the file list is not supported. The problem is that currently the handling is too broad, and it overrides more specific handling from child elements (like the text editor), so disabling the drag and drop of text in the uploader also disabled it in the text editor. Thus... something for the future ;-)

There are other quirks, like Firefox < 48 trying to upload the folder but then failing, but there is nothing that can be done in that case (and not worth anyway, as probably there are no users still on those versions).

**How to test**
- Open the Files app with Internet Explorer 11
- Drag a folder from the desktop to the file list

**Expected result**
An error message is shown (as Internet Explorer 11 does not support uploading folders).

**Actual result**
Nothing happens and the drop zone is kept highlighted.
