### PR TITLE
Fix wrong hint about missing indexes

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -183,7 +183,7 @@
 							type: OC.SetupChecks.MESSAGE_TYPE_INFO
 						})
 					}
-					if (data.hasMissingIndexes) {
+					if (data.hasMissingIndexes.length > 0) {
 						var listOfMissingIndexes = "";
 						data.hasMissingIndexes.forEach(function(element){
 							listOfMissingIndexes += "<li>";

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -157,7 +157,8 @@ describe('OC.SetupChecks tests', function() {
 					hasPassedCodeIntegrityCheck: true,
 					isOpcacheProperlySetup: true,
 					isSettimelimitAvailable: true,
-					hasFreeTypeSupport: true
+					hasFreeTypeSupport: true,
+					hasMissingIndexes: []
 				})
 			);
 
@@ -191,7 +192,8 @@ describe('OC.SetupChecks tests', function() {
 					hasPassedCodeIntegrityCheck: true,
 					isOpcacheProperlySetup: true,
 					isSettimelimitAvailable: true,
-					hasFreeTypeSupport: true
+					hasFreeTypeSupport: true,
+					hasMissingIndexes: []
 				})
 			);
 
@@ -226,7 +228,8 @@ describe('OC.SetupChecks tests', function() {
 					hasPassedCodeIntegrityCheck: true,
 					isOpcacheProperlySetup: true,
 					isSettimelimitAvailable: true,
-					hasFreeTypeSupport: true
+					hasFreeTypeSupport: true,
+					hasMissingIndexes: []
 				})
 			);
 
@@ -259,7 +262,8 @@ describe('OC.SetupChecks tests', function() {
 					hasPassedCodeIntegrityCheck: true,
 					isOpcacheProperlySetup: true,
 					isSettimelimitAvailable: true,
-					hasFreeTypeSupport: true
+					hasFreeTypeSupport: true,
+					hasMissingIndexes: []
 				})
 			);
 
@@ -290,7 +294,8 @@ describe('OC.SetupChecks tests', function() {
 					hasPassedCodeIntegrityCheck: true,
 					isOpcacheProperlySetup: true,
 					isSettimelimitAvailable: true,
-					hasFreeTypeSupport: true
+					hasFreeTypeSupport: true,
+					hasMissingIndexes: []
 				})
 			);
 
@@ -321,7 +326,8 @@ describe('OC.SetupChecks tests', function() {
 					hasPassedCodeIntegrityCheck: true,
 					isOpcacheProperlySetup: true,
 					isSettimelimitAvailable: true,
-					hasFreeTypeSupport: true
+					hasFreeTypeSupport: true,
+					hasMissingIndexes: []
 				})
 			);
 
@@ -352,7 +358,8 @@ describe('OC.SetupChecks tests', function() {
 					hasPassedCodeIntegrityCheck: true,
 					isOpcacheProperlySetup: true,
 					isSettimelimitAvailable: false,
-					hasFreeTypeSupport: true
+					hasFreeTypeSupport: true,
+					hasMissingIndexes: []
 				})
 			);
 
@@ -404,7 +411,8 @@ describe('OC.SetupChecks tests', function() {
 					hasPassedCodeIntegrityCheck: true,
 					isOpcacheProperlySetup: true,
 					isSettimelimitAvailable: true,
-					hasFreeTypeSupport: true
+					hasFreeTypeSupport: true,
+					hasMissingIndexes: []
 				})
 			);
 
@@ -436,7 +444,8 @@ describe('OC.SetupChecks tests', function() {
 					isOpcacheProperlySetup: false,
 					phpOpcacheDocumentation: 'https://example.org/link/to/doc',
 					isSettimelimitAvailable: true,
-					hasFreeTypeSupport: true
+					hasFreeTypeSupport: true,
+					hasMissingIndexes: []
 				})
 			);
 
@@ -468,7 +477,8 @@ describe('OC.SetupChecks tests', function() {
 					isOpcacheProperlySetup: true,
 					phpOpcacheDocumentation: 'https://example.org/link/to/doc',
 					isSettimelimitAvailable: true,
-					hasFreeTypeSupport: false
+					hasFreeTypeSupport: false,
+					hasMissingIndexes: []
 				})
 			);
 

--- a/lib/private/DB/MissingIndexInformation.php
+++ b/lib/private/DB/MissingIndexInformation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2018 Morris Jobke <hey@morrisjobke.de>
  *
@@ -21,19 +22,18 @@
 
 namespace OC\DB;
 
-
 class MissingIndexInformation {
 
 	private $listOfMissingIndexes = [];
 
-	public function addHintForMissingSubject($tableName, $indexName) {
+	public function addHintForMissingSubject(string $tableName, string $indexName) {
 		$this->listOfMissingIndexes[] = [
 			'tableName' => $tableName,
 			'indexName' => $indexName
 		];
 	}
 
-	public function getListOfMissingIndexes() {
+	public function getListOfMissingIndexes(): array {
 		return $this->listOfMissingIndexes;
 	}
 }

--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -415,11 +415,7 @@ Raw output
 		return function_exists('imagettfbbox') && function_exists('imagettftext');
 	}
 
-	/**
-	 * Check if the required FreeType functions are present
-	 * @return bool
-	 */
-	protected function hasMissingIndexes() {
+	protected function hasMissingIndexes(): array {
 		$indexInfo = new MissingIndexInformation();
 		// Dispatch event so apps can also hint for pending index updates if needed
 		$event = new GenericEvent($indexInfo);


### PR DESCRIPTION
* before: it always showed the text with "there are missing indexes" in the setup checks section
* after: it only shows it if there are actually missing indexes

Real fix is the JS part. The PHP stuff is basically for cleanup and hardening purposes.