### PR TITLE
Introducing user config provisionning api

### DIFF
--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -67,5 +67,9 @@ return [
 		['name' => 'AppConfig#getValue', 'url' => '/api/v1/config/apps/{app}/{key}', 'verb' => 'GET'],
 		['name' => 'AppConfig#setValue', 'url' => '/api/v1/config/apps/{app}/{key}', 'verb' => 'POST'],
 		['name' => 'AppConfig#deleteKey', 'url' => '/api/v1/config/apps/{app}/{key}', 'verb' => 'DELETE'],
+
+		['name' => 'UserConfig#getValue', 'url' => '/api/v1/config/user/{app}/{key}', 'verb' => 'GET'],
+		['name' => 'UserConfig#setValue', 'url' => '/api/v1/config/user/{app}/{key}', 'verb' => 'POST'],
+		['name' => 'UserConfig#deleteKey', 'url' => '/api/v1/config/user/{app}/{key}', 'verb' => 'DELETE'],
 	],
 ];

--- a/apps/provisioning_api/composer/composer/autoload_classmap.php
+++ b/apps/provisioning_api/composer/composer/autoload_classmap.php
@@ -11,6 +11,7 @@ return array(
     'OCA\\Provisioning_API\\Controller\\AppConfigController' => $baseDir . '/../lib/Controller/AppConfigController.php',
     'OCA\\Provisioning_API\\Controller\\AppsController' => $baseDir . '/../lib/Controller/AppsController.php',
     'OCA\\Provisioning_API\\Controller\\GroupsController' => $baseDir . '/../lib/Controller/GroupsController.php',
+    'OCA\\Provisioning_API\\Controller\\UserConfigController' => $baseDir . '/../lib/Controller/UserConfigController.php',
     'OCA\\Provisioning_API\\Controller\\UsersController' => $baseDir . '/../lib/Controller/UsersController.php',
     'OCA\\Provisioning_API\\FederatedFileSharingFactory' => $baseDir . '/../lib/FederatedFileSharingFactory.php',
     'OCA\\Provisioning_API\\Middleware\\Exceptions\\NotSubAdminException' => $baseDir . '/../lib/Middleware/Exceptions/NotSubAdminException.php',

--- a/apps/provisioning_api/composer/composer/autoload_static.php
+++ b/apps/provisioning_api/composer/composer/autoload_static.php
@@ -26,6 +26,7 @@ class ComposerStaticInitProvisioning_API
         'OCA\\Provisioning_API\\Controller\\AppConfigController' => __DIR__ . '/..' . '/../lib/Controller/AppConfigController.php',
         'OCA\\Provisioning_API\\Controller\\AppsController' => __DIR__ . '/..' . '/../lib/Controller/AppsController.php',
         'OCA\\Provisioning_API\\Controller\\GroupsController' => __DIR__ . '/..' . '/../lib/Controller/GroupsController.php',
+        'OCA\\Provisioning_API\\Controller\\UserConfigController' => __DIR__ . '/..' . '/../lib/Controller/UserConfigController.php',
         'OCA\\Provisioning_API\\Controller\\UsersController' => __DIR__ . '/..' . '/../lib/Controller/UsersController.php',
         'OCA\\Provisioning_API\\FederatedFileSharingFactory' => __DIR__ . '/..' . '/../lib/FederatedFileSharingFactory.php',
         'OCA\\Provisioning_API\\Middleware\\Exceptions\\NotSubAdminException' => __DIR__ . '/..' . '/../lib/Middleware/Exceptions/NotSubAdminException.php',

--- a/apps/provisioning_api/lib/Controller/UserConfigController.php
+++ b/apps/provisioning_api/lib/Controller/UserConfigController.php
@@ -1,0 +1,144 @@
+<?php
+declare (strict_types = 1);
+/**
+ * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Provisioning_API\Controller;
+
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
+use OCP\IAppConfig;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+class UserConfigController extends OCSController {
+
+	/** @var IConfig */
+	protected $config;
+
+	/** @var IAppConfig */
+	protected $appConfig;
+
+	/** @var IUserSession */
+	private $userSession;
+
+	/**
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param IConfig $config
+	 * @param IAppConfig $appConfig
+	 * @param IUserSession $userSession
+	 */
+	public function __construct(string $appName,
+								IRequest $request,
+								IConfig $config,
+								IAppConfig $appConfig,
+								IUserSession $userSession) {
+		parent::__construct($appName, $request);
+		$this->config      = $config;
+		$this->appConfig   = $appConfig;
+		$this->userSession = $userSession;
+	}
+
+	/**
+	 * @param string $app
+	 * @param string $key
+	 * @param string $defaultValue
+	 * @return DataResponse
+	 */
+	public function getValue(string $app, string $key, string $defaultValue = ''): DataResponse {
+		try {
+			$this->verifyAppId($app);
+		} catch (\InvalidArgumentException $e) {
+			return new DataResponse(['data' => ['message' => $e->getMessage()]], Http::STATUS_FORBIDDEN);
+		}
+
+		return new DataResponse([
+			'data' => $this->config->getUserValue($this->userSession->getUser()->getUID(), $app, $key, $defaultValue)
+		]);
+	}
+
+	/**
+	 * @PasswordConfirmationRequired
+	 * @param string $app
+	 * @param string $key
+	 * @param string $value
+	 * @return DataResponse
+	 */
+	public function setValue(string $app, string $key, string $value): DataResponse {
+		try {
+			$this->verifyAppId($app);
+			$this->verifyConfigKey($app, $key);
+		} catch (\InvalidArgumentException $e) {
+			return new DataResponse(['data' => ['message' => $e->getMessage()]], Http::STATUS_FORBIDDEN);
+		}
+
+		$this->config->setUserValue($this->userSession->getUser()->getUID(), $app, $key, $value);
+
+		return new DataResponse();
+	}
+
+	/**
+	 * @param string $app
+	 * @param string $key
+	 * @return DataResponse
+	 */
+	public function deleteKey(string $app, string $key): DataResponse {
+		try {
+			$this->verifyAppId($app);
+			$this->verifyConfigKey($app, $key);
+		} catch (\InvalidArgumentException $e) {
+			return new DataResponse(['data' => ['message' => $e->getMessage()]], Http::STATUS_FORBIDDEN);
+		}
+
+		$this->config->deleteUserValue($this->userSession->getUser()->getUID(), $app, $key);
+
+		return new DataResponse();
+	}
+
+	/**
+	 * @param string $app
+	 * @throws \InvalidArgumentException
+	 */
+	protected function verifyAppId(string $app) {
+		if (\OC_App::cleanAppId($app) !== $app) {
+			throw new \InvalidArgumentException('Invalid app id given');
+		}
+	}
+
+	/**
+	 * @param string $app
+	 * @param string $key
+	 * @throws \InvalidArgumentException
+	 */
+	protected function verifyConfigKey(string $app, string $key) {
+		if (in_array($key, ['installed_version', 'enabled', 'types'])) {
+			throw new \InvalidArgumentException('The given key can not be set');
+		}
+
+		if ($app === 'core') {
+			throw new \InvalidArgumentException('The given key can not be set');
+		}
+	}
+}


### PR DESCRIPTION
This is something that we miss but we need to add proper security checks
This is a great addition and can help devs to properly set up ajax edits of their config without creating controllers every time.

What we need to check:
- How do we handle the access:
  - all user should be able to edit their own config
  - but some configs are sensitive and managed by the admin or core (`login/lastLogin`, `settings/email`.... etc)

Please discuss and help :)

