### PR TITLE
Fix possible test timing issues in IconController

### DIFF
--- a/apps/theming/lib/Controller/IconController.php
+++ b/apps/theming/lib/Controller/IconController.php
@@ -34,15 +34,12 @@ use OCP\AppFramework\Http\NotFoundResponse;
 use OCP\AppFramework\Http\FileDisplayResponse;
 use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\Response;
-use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\NotFoundException;
 use OCP\IRequest;
 
 class IconController extends Controller {
 	/** @var ThemingDefaults */
 	private $themingDefaults;
-	/** @var ITimeFactory */
-	private $timeFactory;
 	/** @var IconBuilder */
 	private $iconBuilder;
 	/** @var ImageManager */
@@ -56,7 +53,6 @@ class IconController extends Controller {
 	 * @param string $appName
 	 * @param IRequest $request
 	 * @param ThemingDefaults $themingDefaults
-	 * @param ITimeFactory $timeFactory
 	 * @param IconBuilder $iconBuilder
 	 * @param ImageManager $imageManager
 	 * @param FileAccessHelper $fileAccessHelper
@@ -65,7 +61,6 @@ class IconController extends Controller {
 		$appName,
 		IRequest $request,
 		ThemingDefaults $themingDefaults,
-		ITimeFactory $timeFactory,
 		IconBuilder $iconBuilder,
 		ImageManager $imageManager,
 		FileAccessHelper $fileAccessHelper
@@ -73,7 +68,6 @@ class IconController extends Controller {
 		parent::__construct($appName, $request);
 
 		$this->themingDefaults = $themingDefaults;
-		$this->timeFactory = $timeFactory;
 		$this->iconBuilder = $iconBuilder;
 		$this->imageManager = $imageManager;
 		$this->fileAccessHelper = $fileAccessHelper;

--- a/apps/theming/tests/Controller/IconControllerTest.php
+++ b/apps/theming/tests/Controller/IconControllerTest.php
@@ -64,19 +64,21 @@ class IconControllerTest extends TestCase {
 	public function setUp() {
 		$this->request = $this->createMock(IRequest::class);
 		$this->themingDefaults = $this->createMock(ThemingDefaults::class);
-		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->iconBuilder = $this->createMock(IconBuilder::class);
 		$this->imageManager = $this->createMock(ImageManager::class);
 		$this->fileAccessHelper = $this->createMock(FileAccessHelper::class);
+
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->timeFactory->expects($this->any())
 			->method('getTime')
 			->willReturn(123);
+
+		$this->overwriteService(ITimeFactory::class, $this->timeFactory);
 
 		$this->iconController = new IconController(
 			'theming',
 			$this->request,
 			$this->themingDefaults,
-			$this->timeFactory,
 			$this->iconBuilder,
 			$this->imageManager,
 			$this->fileAccessHelper


### PR DESCRIPTION
Since the response now handles the caching. We need to provide a default
ITimeFactory mock. Else you might have failing tests.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>