### PR TITLE
Add search to users details groups

### DIFF
--- a/apps/provisioning_api/lib/Controller/GroupsController.php
+++ b/apps/provisioning_api/lib/Controller/GroupsController.php
@@ -177,12 +177,13 @@ class GroupsController extends AUserData {
 	 * @NoAdminRequired
 	 *
 	 * @param string $groupId
+	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
 	 * @return DataResponse
 	 * @throws OCSException
 	 */
-	public function getGroupUsersDetails(string $groupId, int $limit = null, int $offset = 0): DataResponse {
+	public function getGroupUsersDetails(string $groupId, string $search = '', int $limit = null, int $offset = 0): DataResponse {
 		$user = $this->userSession->getUser();
 		$isSubadminOfGroup = false;
 
@@ -197,9 +198,9 @@ class GroupsController extends AUserData {
 		// Check subadmin has access to this group
 		if($this->groupManager->isAdmin($user->getUID())
 		   || $isSubadminOfGroup) {
-			$users = $this->groupManager->get($groupId)->getUsers();
+			$users = $this->groupManager->get($groupId)->searchUsers($search, $limit, $offset);
+
 			// Extract required number
-			$users = array_slice($users, $offset, $limit);
 			$users = array_keys($users);
 			$usersDetails = [];
 			foreach ($users as $userId) {

--- a/lib/private/Group/Group.php
+++ b/lib/private/Group/Group.php
@@ -211,10 +211,10 @@ class Group implements IGroup {
 			$userIds = $backend->usersInGroup($this->gid, $search, $limit, $offset);
 			$users += $this->getVerifiedUsers($userIds);
 			if (!is_null($limit) and $limit <= 0) {
-				return array_values($users);
+				return $users;
 			}
 		}
-		return array_values($users);
+		return $users;
 	}
 
 	/**

--- a/tests/lib/Group/GroupTest.php
+++ b/tests/lib/Group/GroupTest.php
@@ -303,7 +303,7 @@ class GroupTest extends \Test\TestCase {
 		$users = $group->searchUsers('2');
 
 		$this->assertEquals(1, count($users));
-		$user2 = $users[0];
+		$user2 = $users['user2'];
 		$this->assertEquals('user2', $user2->getUID());
 	}
 
@@ -329,7 +329,7 @@ class GroupTest extends \Test\TestCase {
 		$users = $group->searchUsers('2');
 
 		$this->assertEquals(1, count($users));
-		$user2 = $users[0];
+		$user2 = $users['user2'];
 		$this->assertEquals('user2', $user2->getUID());
 	}
 
@@ -348,7 +348,7 @@ class GroupTest extends \Test\TestCase {
 		$users = $group->searchUsers('user', 1, 1);
 
 		$this->assertEquals(1, count($users));
-		$user2 = $users[0];
+		$user2 = $users['user2'];
 		$this->assertEquals('user2', $user2->getUID());
 	}
 
@@ -374,8 +374,8 @@ class GroupTest extends \Test\TestCase {
 		$users = $group->searchUsers('user', 2, 1);
 
 		$this->assertEquals(2, count($users));
-		$user2 = $users[0];
-		$user1 = $users[1];
+		$user2 = $users['user2'];
+		$user1 = $users['user1'];
 		$this->assertEquals('user2', $user2->getUID());
 		$this->assertEquals('user1', $user1->getUID());
 	}


### PR DESCRIPTION
- Removed the array_value from `searchUsers` to return the same array and keys (userids) as `getUsers`
- Added search within groups capability