### PR TITLE
implement federated group sharing

### DIFF
--- a/apps/cloud_federation_api/lib/Config.php
+++ b/apps/cloud_federation_api/lib/Config.php
@@ -47,11 +47,14 @@ class Config {
 	 *
 	 * @param string $resourceType
 	 * @return array
-	 * @throws \OCP\Federation\Exceptions\ProviderDoesNotExistsException
 	 */
 	public function getSupportedShareTypes($resourceType) {
-		$provider = $this->cloudFederationProviderManager->getCloudFederationProvider($resourceType);
-		return $provider->getSupportedShareTypes();
+		try {
+			$provider = $this->cloudFederationProviderManager->getCloudFederationProvider($resourceType);
+			return $provider->getSupportedShareTypes();
+		} catch (\Exception $e) {
+			return [];
+		}
 	}
 
 }

--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -35,6 +35,7 @@ use OCP\Federation\ICloudFederationFactory;
 use OCP\Federation\ICloudFederationProviderManager;
 use OCP\Federation\Exceptions\ProviderDoesNotExistsException;
 use OCP\Federation\ICloudIdManager;
+use OCP\IGroupManager;
 use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IURLGenerator;
@@ -57,6 +58,9 @@ class RequestHandlerController extends Controller {
 	/** @var IUserManager */
 	private $userManager;
 
+	/** @var IGroupManager */
+	private $groupManager;
+
 	/** @var IURLGenerator */
 	private $urlGenerator;
 
@@ -76,6 +80,7 @@ class RequestHandlerController extends Controller {
 								IRequest $request,
 								ILogger $logger,
 								IUserManager $userManager,
+								IGroupManager $groupManager,
 								IURLGenerator $urlGenerator,
 								ICloudFederationProviderManager $cloudFederationProviderManager,
 								Config $config,
@@ -86,6 +91,7 @@ class RequestHandlerController extends Controller {
 
 		$this->logger = $logger;
 		$this->userManager = $userManager;
+		$this->groupManager = $groupManager;
 		$this->urlGenerator = $urlGenerator;
 		$this->cloudFederationProviderManager = $cloudFederationProviderManager;
 		$this->config = $config;
@@ -136,15 +142,35 @@ class RequestHandlerController extends Controller {
 			);
 		}
 
-		$cloudId = $this->cloudIdManager->resolveCloudId($shareWith);
-		$shareWithLocalId = $cloudId->getUser();
-		$shareWith = $this->mapUid($shareWithLocalId);
-
-		if (!$this->userManager->userExists($shareWith)) {
+		$supportedShareTypes = $this->config->getSupportedShareTypes($resourceType);
+		if (!in_array($shareType, $supportedShareTypes)) {
 			return new JSONResponse(
-				['message' => 'User "' . $shareWith . '" does not exists at ' . $this->urlGenerator->getBaseUrl()],
-				Http::STATUS_BAD_REQUEST
+				['message' => 'Share type "' . $shareType . '" not implemented'],
+				Http::STATUS_NOT_IMPLEMENTED
 			);
+		}
+
+		$cloudId = $this->cloudIdManager->resolveCloudId($shareWith);
+		$shareWith = $cloudId->getUser();
+
+		if ($shareType === 'user') {
+			$shareWith = $this->mapUid($shareWith);
+
+			if (!$this->userManager->userExists($shareWith)) {
+				return new JSONResponse(
+					['message' => 'User "' . $shareWith . '" does not exists at ' . $this->urlGenerator->getBaseUrl()],
+					Http::STATUS_BAD_REQUEST
+				);
+			}
+		}
+
+		if ($shareType === 'group') {
+			if(!$this->groupManager->groupExists($shareWith)) {
+				return new JSONResponse(
+					['message' => 'Group "' . $shareWith . '" does not exists at ' . $this->urlGenerator->getBaseUrl()],
+					Http::STATUS_BAD_REQUEST
+				);
+			}
 		}
 
 		// if no explicit display name is given, we use the uid as display name
@@ -161,7 +187,7 @@ class RequestHandlerController extends Controller {
 			$provider = $this->cloudFederationProviderManager->getCloudFederationProvider($resourceType);
 			$share = $this->factory->getCloudFederationShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, '', $shareType, $resourceType);
 			$share->setProtocol($protocol);
-			$id = $provider->shareReceived($share);
+			$provider->shareReceived($share);
 		} catch (ProviderDoesNotExistsException $e) {
 			return new JSONResponse(
 				['message' => $e->getMessage()],
@@ -179,7 +205,7 @@ class RequestHandlerController extends Controller {
 			);
 		}
 
-		$user = $this->userManager->get($shareWithLocalId);
+		$user = $this->userManager->get($shareWith);
 		$recipientDisplayName = '';
 		if($user) {
 			$recipientDisplayName = $user->getDisplayName();
@@ -259,7 +285,6 @@ class RequestHandlerController extends Controller {
 	 * @return string mixed
 	 */
 	private function mapUid($uid) {
-		\OC::$server->getURLGenerator()->linkToDocs('key');
 		// FIXME this should be a method in the user management instead
 		$this->logger->debug('shareWith before, ' . $uid, ['app' => $this->appName]);
 		\OCP\Util::emitHook(

--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -65,7 +65,8 @@ class Application extends App {
 					$server->getURLGenerator(),
 					$server->getCloudFederationFactory(),
 					$server->getCloudFederationProviderManager(),
-					$server->getDatabaseConnection()
+					$server->getDatabaseConnection(),
+					$server->getGroupManager()
 				);
 			});
 
@@ -145,7 +146,9 @@ class Application extends App {
 			\OC::$server->getConfig(),
 			\OC::$server->getUserManager(),
 			\OC::$server->getCloudIdManager(),
-			$c->query(IConfig::class)
+			$c->query(IConfig::class),
+			\OC::$server->getCloudFederationProviderManager()
+
 		);
 	}
 

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -30,6 +30,7 @@
 namespace OCA\FederatedFileSharing;
 
 use OC\Share20\Share;
+use OCP\Federation\ICloudFederationProviderManager;
 use OCP\Federation\ICloudIdManager;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Folder;
@@ -92,6 +93,9 @@ class FederatedShareProvider implements IShareProvider {
 	/** @var \OCP\GlobalScale\IConfig */
 	private $gsConfig;
 
+	/** @var ICloudFederationProviderManager */
+	private $cloudFederationProviderManager;
+
 	/**
 	 * DefaultShareProvider constructor.
 	 *
@@ -106,6 +110,7 @@ class FederatedShareProvider implements IShareProvider {
 	 * @param IUserManager $userManager
 	 * @param ICloudIdManager $cloudIdManager
 	 * @param \OCP\GlobalScale\IConfig $globalScaleConfig
+	 * @param ICloudFederationProviderManager $cloudFederationProviderManager
 	 */
 	public function __construct(
 			IDBConnection $connection,
@@ -118,7 +123,8 @@ class FederatedShareProvider implements IShareProvider {
 			IConfig $config,
 			IUserManager $userManager,
 			ICloudIdManager $cloudIdManager,
-			\OCP\GlobalScale\IConfig $globalScaleConfig
+			\OCP\GlobalScale\IConfig $globalScaleConfig,
+			ICloudFederationProviderManager $cloudFederationProviderManager
 	) {
 		$this->dbConnection = $connection;
 		$this->addressHandler = $addressHandler;
@@ -131,6 +137,7 @@ class FederatedShareProvider implements IShareProvider {
 		$this->userManager = $userManager;
 		$this->cloudIdManager = $cloudIdManager;
 		$this->gsConfig = $globalScaleConfig;
+		$this->cloudFederationProviderManager = $cloudFederationProviderManager;
 	}
 
 	/**
@@ -965,6 +972,42 @@ class FederatedShareProvider implements IShareProvider {
 		}
 		$result = $this->config->getAppValue('files_sharing', 'incoming_server2server_share_enabled', 'yes');
 		return ($result === 'yes');
+	}
+
+
+	/**
+	 * check if users from other Nextcloud instances are allowed to send federated group shares
+	 *
+	 * @return bool
+	 */
+	public function isOutgoingServer2serverGroupShareEnabled() {
+		if ($this->gsConfig->onlyInternalFederation()) {
+			return false;
+		}
+		$result = $this->config->getAppValue('files_sharing', 'outgoing_server2server_group_share_enabled', 'no');
+		return ($result === 'yes');
+	}
+
+	/**
+	 * check if users are allowed to receive federated group shares
+	 *
+	 * @return bool
+	 */
+	public function isIncomingServer2serverGroupShareEnabled() {
+		if ($this->gsConfig->onlyInternalFederation()) {
+			return false;
+		}
+		$result = $this->config->getAppValue('files_sharing', 'incoming_server2server_group_share_enabled', 'no');
+		return ($result === 'yes');
+	}
+
+	/**
+	 * check if federated group sharing is supported, therefore the OCM API need to be enabled
+	 *
+	 * @return bool
+	 */
+	public function isFederatedGroupSharingSupported() {
+		return $this->cloudFederationProviderManager->isReady();
 	}
 
 	/**

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -88,11 +88,12 @@ class Notifications {
 	 * @param string $ownerFederatedId
 	 * @param string $sharedBy
 	 * @param string $sharedByFederatedId
+	 * @param int $shareType (can be a remote user or group share)
 	 * @return bool
 	 * @throws \OC\HintException
 	 * @throws \OC\ServerNotAvailableException
 	 */
-	public function sendRemoteShare($token, $shareWith, $name, $remote_id, $owner, $ownerFederatedId, $sharedBy, $sharedByFederatedId) {
+	public function sendRemoteShare($token, $shareWith, $name, $remote_id, $owner, $ownerFederatedId, $sharedBy, $sharedByFederatedId, $shareType) {
 
 		list($user, $remote) = $this->addressHandler->splitUserRemote($shareWith);
 
@@ -109,6 +110,7 @@ class Notifications {
 				'sharedBy' => $sharedBy,
 				'sharedByFederatedId' => $sharedByFederatedId,
 				'remote' => $local,
+				'shareType' => $shareType
 			);
 
 			$result = $this->tryHttpPostToShareEndpoint($remote, '', $fields);
@@ -392,7 +394,7 @@ class Notifications {
 					$fields['sharedByFederatedId'],
 					$fields['sharedBy'],
 					$fields['token'],
-					'user',
+					$fields['shareType'],
 					'file'
 				);
 				return $this->federationProviderManager->sendShare($share);
@@ -406,6 +408,7 @@ class Notifications {
 						'sharedSecret' => $fields['token'],
 						'shareWith' => $fields['shareWith'],
 						'senderId' => $fields['localId'],
+						'shareType' => $fields['shareType'],
 						'message' => 'Ask owner to reshare the file'
 					]
 				);

--- a/apps/federatedfilesharing/lib/Settings/Admin.php
+++ b/apps/federatedfilesharing/lib/Settings/Admin.php
@@ -58,6 +58,9 @@ class Admin implements ISettings {
 			'internalOnly' => $this->gsConfig->onlyInternalFederation(),
 			'outgoingServer2serverShareEnabled' => $this->fedShareProvider->isOutgoingServer2serverShareEnabled(),
 			'incomingServer2serverShareEnabled' => $this->fedShareProvider->isIncomingServer2serverShareEnabled(),
+			'federatedGroupSharingSupported' => $this->fedShareProvider->isFederatedGroupSharingSupported(),
+			'outgoingServer2serverGroupShareEnabled' => $this->fedShareProvider->isOutgoingServer2serverGroupShareEnabled(),
+			'incomingServer2serverGroupShareEnabled' => $this->fedShareProvider->isIncomingServer2serverGroupShareEnabled(),
 			'lookupServerEnabled' => $this->fedShareProvider->isLookupServerQueriesEnabled(),
 			'lookupServerUploadEnabled' => $this->fedShareProvider->isLookupServerUploadEnabled(),
 		];

--- a/apps/federatedfilesharing/lib/ocm/CloudFederationProviderFiles.php
+++ b/apps/federatedfilesharing/lib/ocm/CloudFederationProviderFiles.php
@@ -228,6 +228,8 @@ class CloudFederationProviderFiles implements ICloudFederationProvider {
 				\OC::$server->query(\OCP\OCS\IDiscoveryService::class),
 				\OC::$server->getCloudFederationProviderManager(),
 				\OC::$server->getCloudFederationFactory(),
+				\OC::$server->getGroupManager(),
+				\OC::$server->getUserManager(),
 				$shareWith
 			);
 

--- a/apps/federatedfilesharing/templates/settings-admin.php
+++ b/apps/federatedfilesharing/templates/settings-admin.php
@@ -23,7 +23,6 @@ script('federatedfilesharing', 'settings-admin');
 			<?php p($l->t('Allow users on this server to send shares to other servers'));?>
 		</label>
 	</p>
-
 	<p>
 		<input type="checkbox" name="incoming_server2server_share_enabled" id="incomingServer2serverShareEnabled" class="checkbox"
 			   value="1" <?php if ($_['incomingServer2serverShareEnabled']) print_unescaped('checked="checked"'); ?> />
@@ -31,6 +30,22 @@ script('federatedfilesharing', 'settings-admin');
 			<?php p($l->t('Allow users on this server to receive shares from other servers'));?>
 		</label><br/>
 	</p>
+	<?php if($_['federatedGroupSharingSupported']): ?>
+	<p>
+		<input type="checkbox" name="outgoing_server2server_group_share_enabled" id="outgoingServer2serverGroupShareEnabled" class="checkbox"
+			   value="1" <?php if ($_['outgoingServer2serverGroupShareEnabled']) print_unescaped('checked="checked"'); ?> />
+		<label for="outgoingServer2serverGroupShareEnabled">
+			<?php p($l->t('Allow users on this server to send shares to groups on other servers'));?>
+		</label>
+	</p>
+	<p>
+		<input type="checkbox" name="incoming_server2server_group_share_enabled" id="incomingServer2serverGroupShareEnabled" class="checkbox"
+			   value="1" <?php if ($_['incomingServer2serverGroupShareEnabled']) print_unescaped('checked="checked"'); ?> />
+		<label for="incomingServer2serverGroupShareEnabled">
+			<?php p($l->t('Allow users on this server to receive group shares from other servers'));?>
+		</label><br/>
+	</p>
+	<?php endif; ?>
 	<p>
 		<input type="checkbox" name="lookupServerEnabled" id="lookupServerEnabled" class="checkbox"
 			   value="1" <?php if ($_['lookupServerEnabled']) print_unescaped('checked="checked"'); ?> />

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -33,6 +33,7 @@ use OCA\FederatedFileSharing\AddressHandler;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\FederatedFileSharing\Notifications;
 use OCA\FederatedFileSharing\TokenHandler;
+use OCP\Federation\ICloudFederationProviderManager;
 use OCP\Federation\ICloudIdManager;
 use OCP\Files\File;
 use OCP\Files\IRootFolder;
@@ -80,6 +81,8 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	/** @var  ICloudIdManager */
 	private $cloudIdManager;
 
+	/** @var \PHPUnit_Framework_MockObject_MockObject|ICloudFederationProviderManager */
+	private $cloudFederationProviderManager;
 
 	public function setUp() {
 		parent::setUp();
@@ -107,6 +110,8 @@ class FederatedShareProviderTest extends \Test\TestCase {
 
 		$this->userManager->expects($this->any())->method('userExists')->willReturn(true);
 
+		$this->cloudFederationProviderManager = $this->createMock(ICloudFederationProviderManager::class);
+
 		$this->provider = new FederatedShareProvider(
 			$this->connection,
 			$this->addressHandler,
@@ -118,7 +123,8 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			$this->config,
 			$this->userManager,
 			$this->cloudIdManager,
-			$this->gsConfig
+			$this->gsConfig,
+			$this->cloudFederationProviderManager
 		);
 
 		$this->shareManager = \OC::$server->getShareManager();
@@ -141,6 +147,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setSharedBy('sharedBy')
 			->setShareOwner('shareOwner')
 			->setPermissions(19)
+			->setShareType(\OCP\Share::SHARE_TYPE_REMOTE)
 			->setNode($node);
 
 		$this->tokenHandler->method('generateToken')->willReturn('token');
@@ -212,6 +219,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setSharedBy('sharedBy')
 			->setShareOwner('shareOwner')
 			->setPermissions(19)
+			->setShareType(\OCP\Share::SHARE_TYPE_REMOTE)
 			->setNode($node);
 
 		$this->tokenHandler->method('generateToken')->willReturn('token');
@@ -268,6 +276,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setSharedBy('sharedBy')
 			->setShareOwner('shareOwner')
 			->setPermissions(19)
+			->setShareType(\OCP\Share::SHARE_TYPE_REMOTE)
 			->setNode($node);
 
 		$this->tokenHandler->method('generateToken')->willReturn('token');
@@ -367,6 +376,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setSharedBy('sharedBy')
 			->setShareOwner('shareOwner')
 			->setPermissions(19)
+			->setShareType(\OCP\Share::SHARE_TYPE_REMOTE)
 			->setNode($node);
 
 		$this->tokenHandler->method('generateToken')->willReturn('token');
@@ -417,7 +427,8 @@ class FederatedShareProviderTest extends \Test\TestCase {
 					$this->config,
 					$this->userManager,
 					$this->cloudIdManager,
-					$this->gsConfig
+					$this->gsConfig,
+					$this->cloudFederationProviderManager
 				]
 			)->setMethods(['sendPermissionUpdate'])->getMock();
 
@@ -435,6 +446,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setSharedBy($sharedBy)
 			->setShareOwner($owner)
 			->setPermissions(19)
+			->setShareType(\OCP\Share::SHARE_TYPE_REMOTE)
 			->setNode($node);
 
 		$this->tokenHandler->method('generateToken')->willReturn('token');
@@ -505,6 +517,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setSharedBy('sharedBy')
 			->setShareOwner('shareOwner')
 			->setPermissions(19)
+			->setShareType(\OCP\Share::SHARE_TYPE_REMOTE)
 			->setNode($node);
 		$this->provider->create($share);
 
@@ -513,6 +526,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setSharedBy('sharedBy2')
 			->setShareOwner('shareOwner')
 			->setPermissions(19)
+			->setShareType(\OCP\Share::SHARE_TYPE_REMOTE)
 			->setNode($node);
 		$this->provider->create($share2);
 
@@ -543,6 +557,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setSharedBy('sharedBy')
 			->setShareOwner('shareOwner')
 			->setPermissions(19)
+			->setShareType(\OCP\Share::SHARE_TYPE_REMOTE)
 			->setNode($node);
 		$this->provider->create($share);
 
@@ -555,6 +570,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setSharedBy('sharedBy')
 			->setShareOwner('shareOwner')
 			->setPermissions(19)
+			->setShareType(\OCP\Share::SHARE_TYPE_REMOTE)
 			->setNode($node2);
 		$this->provider->create($share2);
 
@@ -584,6 +600,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setSharedBy('shareOwner')
 			->setShareOwner('shareOwner')
 			->setPermissions(19)
+			->setShareType(\OCP\Share::SHARE_TYPE_REMOTE)
 			->setNode($node);
 		$this->provider->create($share);
 
@@ -592,6 +609,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setSharedBy('sharedBy')
 			->setShareOwner('shareOwner')
 			->setPermissions(19)
+			->setShareType(\OCP\Share::SHARE_TYPE_REMOTE)
 			->setNode($node);
 		$this->provider->create($share2);
 
@@ -628,6 +646,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setSharedBy('sharedBy')
 			->setShareOwner('shareOwner')
 			->setPermissions(19)
+			->setShareType(\OCP\Share::SHARE_TYPE_REMOTE)
 			->setNode($node);
 		$this->provider->create($share);
 
@@ -636,6 +655,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setSharedBy('sharedBy')
 			->setShareOwner('shareOwner')
 			->setPermissions(19)
+			->setShareType(\OCP\Share::SHARE_TYPE_REMOTE)
 			->setNode($node);
 		$this->provider->create($share2);
 
@@ -826,6 +846,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setSharedBy($u1->getUID())
 			->setShareOwner($u1->getUID())
 			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setShareType(\OCP\Share::SHARE_TYPE_REMOTE)
 			->setNode($file1);
 		$this->provider->create($share1);
 
@@ -834,6 +855,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setSharedBy($u2->getUID())
 			->setShareOwner($u1->getUID())
 			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setShareType(\OCP\Share::SHARE_TYPE_REMOTE)
 			->setNode($file2);
 		$this->provider->create($share2);
 
@@ -880,6 +902,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setSharedBy($u1->getUID())
 			->setShareOwner($u1->getUID())
 			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setShareType(\OCP\Share::SHARE_TYPE_REMOTE)
 			->setNode($file1);
 		$this->provider->create($share1);
 
@@ -888,6 +911,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setSharedBy($u1->getUID())
 			->setShareOwner($u1->getUID())
 			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setShareType(\OCP\Share::SHARE_TYPE_REMOTE)
 			->setNode($file1);
 		$this->provider->create($share2);
 

--- a/apps/federatedfilesharing/tests/Settings/AdminTest.php
+++ b/apps/federatedfilesharing/tests/Settings/AdminTest.php
@@ -74,11 +74,27 @@ class AdminTest extends TestCase {
 			->willReturn($state);
 		$this->federatedShareProvider
 			->expects($this->once())
+			->method('isIncomingServer2serverShareEnabled')
+			->willReturn($state);
+		$this->federatedShareProvider
+			->expects($this->once())
 			->method('isLookupServerQueriesEnabled')
 			->willReturn($state);
 		$this->federatedShareProvider
 			->expects($this->once())
 			->method('isLookupServerUploadEnabled')
+			->willReturn($state);
+		$this->federatedShareProvider
+			->expects($this->once())
+			->method('isFederatedGroupSharingSupported')
+			->willReturn($state);
+		$this->federatedShareProvider
+			->expects($this->once())
+			->method('isOutgoingServer2serverGroupShareEnabled')
+			->willReturn($state);
+		$this->federatedShareProvider
+			->expects($this->once())
+			->method('isIncomingServer2serverGroupShareEnabled')
 			->willReturn($state);
 		$this->gsConfig->expects($this->once())->method('onlyInternalFederation')
 			->willReturn($state);
@@ -88,7 +104,10 @@ class AdminTest extends TestCase {
 			'outgoingServer2serverShareEnabled' => $state,
 			'incomingServer2serverShareEnabled' => $state,
 			'lookupServerEnabled' => $state,
-			'lookupServerUploadEnabled' => $state
+			'lookupServerUploadEnabled' => $state,
+			'federatedGroupSharingSupported' => $state,
+			'outgoingServer2serverGroupShareEnabled' => $state,
+			'incomingServer2serverGroupShareEnabled' => $state,
 		];
 		$expected = new TemplateResponse('federatedfilesharing', 'settings-admin', $params, '');
 		$this->assertEquals($expected, $this->admin->getForm());

--- a/apps/files_sharing/appinfo/database.xml
+++ b/apps/files_sharing/appinfo/database.xml
@@ -16,6 +16,17 @@
 				<length>4</length>
 			</field>
 			<field>
+				<name>parent</name>
+				<type>integer</type>
+				<default>-1</default>
+				<length>4</length>
+			</field>
+			<field>
+				<name>share_type</name>
+				<type>integer</type>
+				<length>4</length>
+			</field>
+			<field>
 				<name>remote</name>
 				<type>text</type>
 				<notnull>true</notnull>

--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -9,7 +9,7 @@
 Turning the feature off removes shared files and folders on the server for all share recipients, and also on the sync clients and mobile apps. More information is available in the Nextcloud Documentation.
 
 	</description>
-	<version>1.6.1</version>
+	<version>1.6.2</version>
 	<licence>agpl</licence>
 	<author>Michael Gapczynski</author>
 	<author>Bjoern Schiessle</author>

--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -105,6 +105,8 @@ class Application extends App {
 				$server->query(\OCP\OCS\IDiscoveryService::class),
 				$server->getCloudFederationProviderManager(),
 				$server->getCloudFederationFactory(),
+				$server->getGroupManager(),
+				$server->getUserManager(),
 				$uid
 			);
 		});

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -48,6 +48,7 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\Files\IRootFolder;
 use OCP\Lock\LockedException;
+use OCP\Share;
 use OCP\Share\IManager;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\Exceptions\GenericShareException;
@@ -181,15 +182,15 @@ class ShareAPIController extends OCSController {
 			$result['expiration'] = $expiration->format('Y-m-d 00:00:00');
 		}
 
-		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER) {
+		if ($share->getShareType() === Share::SHARE_TYPE_USER) {
 			$sharedWith = $this->userManager->get($share->getSharedWith());
 			$result['share_with'] = $share->getSharedWith();
 			$result['share_with_displayname'] = $sharedWith !== null ? $sharedWith->getDisplayName() : $share->getSharedWith();
-		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
+		} else if ($share->getShareType() === Share::SHARE_TYPE_GROUP) {
 			$group = $this->groupManager->get($share->getSharedWith());
 			$result['share_with'] = $share->getSharedWith();
 			$result['share_with_displayname'] = $group !== null ? $group->getDisplayName() : $share->getSharedWith();
-		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
+		} else if ($share->getShareType() === Share::SHARE_TYPE_LINK) {
 
 			$result['share_with'] = $share->getPassword();
 			$result['share_with_displayname'] = $share->getPassword();
@@ -197,16 +198,16 @@ class ShareAPIController extends OCSController {
 			$result['token'] = $share->getToken();
 			$result['url'] = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.showShare', ['token' => $share->getToken()]);
 
-		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_REMOTE) {
+		} else if ($share->getShareType() === Share::SHARE_TYPE_REMOTE || $share->getShareType() || Share::SHARE_TYPE_REMOTE_GROUP) {
 			$result['share_with'] = $share->getSharedWith();
 			$result['share_with_displayname'] = $this->getDisplayNameFromAddressBook($share->getSharedWith(), 'CLOUD');
 			$result['token'] = $share->getToken();
-		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_EMAIL) {
+		} else if ($share->getShareType() === Share::SHARE_TYPE_EMAIL) {
 			$result['share_with'] = $share->getSharedWith();
 			$result['password'] = $share->getPassword();
 			$result['share_with_displayname'] = $this->getDisplayNameFromAddressBook($share->getSharedWith(), 'EMAIL');
 			$result['token'] = $share->getToken();
-		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_CIRCLE) {
+		} else if ($share->getShareType() === Share::SHARE_TYPE_CIRCLE) {
 			// getSharedWith() returns either "name (type, owner)" or
 			// "name (type, owner) [id]", depending on the Circles app version.
 			$hasCircleId = (substr($share->getSharedWith(), -1) === ']');
@@ -301,7 +302,7 @@ class ShareAPIController extends OCSController {
 			throw new OCSNotFoundException($this->l->t('Could not delete share'));
 		}
 
-		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP &&
+		if ($share->getShareType() === Share::SHARE_TYPE_GROUP &&
 			$share->getShareOwner() !== $this->currentUser &&
 			$share->getSharedBy() !== $this->currentUser) {
 			$this->shareManager->deleteFromSelf($share, $this->currentUser);
@@ -388,14 +389,14 @@ class ShareAPIController extends OCSController {
 			$permissions &= ~($permissions & ~$path->getPermissions());
 		}
 
-		if ($shareType === \OCP\Share::SHARE_TYPE_USER) {
+		if ($shareType === Share::SHARE_TYPE_USER) {
 			// Valid user is required to share
 			if ($shareWith === null || !$this->userManager->userExists($shareWith)) {
 				throw new OCSNotFoundException($this->l->t('Please specify a valid user'));
 			}
 			$share->setSharedWith($shareWith);
 			$share->setPermissions($permissions);
-		} else if ($shareType === \OCP\Share::SHARE_TYPE_GROUP) {
+		} else if ($shareType === Share::SHARE_TYPE_GROUP) {
 			if (!$this->shareManager->allowGroupSharing()) {
 				throw new OCSNotFoundException($this->l->t('Group sharing is disabled by the administrator'));
 			}
@@ -406,7 +407,7 @@ class ShareAPIController extends OCSController {
 			}
 			$share->setSharedWith($shareWith);
 			$share->setPermissions($permissions);
-		} else if ($shareType === \OCP\Share::SHARE_TYPE_LINK) {
+		} else if ($shareType === Share::SHARE_TYPE_LINK) {
 			//Can we even share links?
 			if (!$this->shareManager->shareApiAllowLinks()) {
 				throw new OCSNotFoundException($this->l->t('Public link sharing is disabled by the administrator'));
@@ -416,7 +417,7 @@ class ShareAPIController extends OCSController {
 			 * For now we only allow 1 link share.
 			 * Return the existing link share if this is a duplicate
 			 */
-			$existingShares = $this->shareManager->getSharesBy($this->currentUser, \OCP\Share::SHARE_TYPE_LINK, $path, false, 1, 0);
+			$existingShares = $this->shareManager->getSharesBy($this->currentUser, Share::SHARE_TYPE_LINK, $path, false, 1, 0);
 			if (!empty($existingShares)) {
 				return new DataResponse($this->formatShare($existingShares[0]));
 			}
@@ -457,21 +458,28 @@ class ShareAPIController extends OCSController {
 				}
 			}
 
-		} else if ($shareType === \OCP\Share::SHARE_TYPE_REMOTE) {
+		} else if ($shareType === Share::SHARE_TYPE_REMOTE) {
 			if (!$this->shareManager->outgoingServer2ServerSharesAllowed()) {
 				throw new OCSForbiddenException($this->l->t('Sharing %s failed because the back end does not allow shares from type %s', [$path->getPath(), $shareType]));
 			}
 
 			$share->setSharedWith($shareWith);
 			$share->setPermissions($permissions);
-		} else if ($shareType === \OCP\Share::SHARE_TYPE_EMAIL) {
+		}  else if ($shareType === Share::SHARE_TYPE_REMOTE_GROUP) {
+			if (!$this->shareManager->outgoingServer2ServerGroupSharesAllowed()) {
+				throw new OCSForbiddenException($this->l->t('Sharing %s failed because the back end does not allow shares from type %s', [$path->getPath(), $shareType]));
+			}
+
+			$share->setSharedWith($shareWith);
+			$share->setPermissions($permissions);
+		} else if ($shareType === Share::SHARE_TYPE_EMAIL) {
 			if ($share->getNodeType() === 'file') {
 				$share->setPermissions(Constants::PERMISSION_READ);
 			} else {
 				$share->setPermissions($permissions);
 			}
 			$share->setSharedWith($shareWith);
-		} else if ($shareType === \OCP\Share::SHARE_TYPE_CIRCLE) {
+		} else if ($shareType === Share::SHARE_TYPE_CIRCLE) {
 			if (!\OC::$server->getAppManager()->isEnabledForUser('circles') || !class_exists('\OCA\Circles\ShareByCircleProvider')) {
 				throw new OCSNotFoundException($this->l->t('You cannot share to a Circle if the app is not enabled'));
 			}
@@ -512,9 +520,9 @@ class ShareAPIController extends OCSController {
 	 */
 	private function getSharedWithMe($node = null, bool $includeTags): DataResponse {
 
-		$userShares = $this->shareManager->getSharedWith($this->currentUser, \OCP\Share::SHARE_TYPE_USER, $node, -1, 0);
-		$groupShares = $this->shareManager->getSharedWith($this->currentUser, \OCP\Share::SHARE_TYPE_GROUP, $node, -1, 0);
-		$circleShares = $this->shareManager->getSharedWith($this->currentUser, \OCP\Share::SHARE_TYPE_CIRCLE, $node, -1, 0);
+		$userShares = $this->shareManager->getSharedWith($this->currentUser, Share::SHARE_TYPE_USER, $node, -1, 0);
+		$groupShares = $this->shareManager->getSharedWith($this->currentUser, Share::SHARE_TYPE_GROUP, $node, -1, 0);
+		$circleShares = $this->shareManager->getSharedWith($this->currentUser, Share::SHARE_TYPE_CIRCLE, $node, -1, 0);
 
 		$shares = array_merge($userShares, $groupShares, $circleShares);
 
@@ -554,14 +562,14 @@ class ShareAPIController extends OCSController {
 		/** @var \OCP\Share\IShare[] $shares */
 		$shares = [];
 		foreach ($nodes as $node) {
-			$shares = array_merge($shares, $this->shareManager->getSharesBy($this->currentUser, \OCP\Share::SHARE_TYPE_USER, $node, false, -1, 0));
-			$shares = array_merge($shares, $this->shareManager->getSharesBy($this->currentUser, \OCP\Share::SHARE_TYPE_GROUP, $node, false, -1, 0));
-			$shares = array_merge($shares, $this->shareManager->getSharesBy($this->currentUser, \OCP\Share::SHARE_TYPE_LINK, $node, false, -1, 0));
-			if($this->shareManager->shareProviderExists(\OCP\Share::SHARE_TYPE_EMAIL)) {
-				$shares = array_merge($shares, $this->shareManager->getSharesBy($this->currentUser, \OCP\Share::SHARE_TYPE_EMAIL, $node, false, -1, 0));
+			$shares = array_merge($shares, $this->shareManager->getSharesBy($this->currentUser, Share::SHARE_TYPE_USER, $node, false, -1, 0));
+			$shares = array_merge($shares, $this->shareManager->getSharesBy($this->currentUser, Share::SHARE_TYPE_GROUP, $node, false, -1, 0));
+			$shares = array_merge($shares, $this->shareManager->getSharesBy($this->currentUser, Share::SHARE_TYPE_LINK, $node, false, -1, 0));
+			if($this->shareManager->shareProviderExists(Share::SHARE_TYPE_EMAIL)) {
+				$shares = array_merge($shares, $this->shareManager->getSharesBy($this->currentUser, Share::SHARE_TYPE_EMAIL, $node, false, -1, 0));
 			}
 			if ($this->shareManager->outgoingServer2ServerSharesAllowed()) {
-				$shares = array_merge($shares, $this->shareManager->getSharesBy($this->currentUser, \OCP\Share::SHARE_TYPE_REMOTE, $node, false, -1, 0));
+				$shares = array_merge($shares, $this->shareManager->getSharesBy($this->currentUser, Share::SHARE_TYPE_REMOTE, $node, false, -1, 0));
 			}
 		}
 
@@ -635,16 +643,16 @@ class ShareAPIController extends OCSController {
 		}
 
 		// Get all shares
-		$userShares = $this->shareManager->getSharesBy($this->currentUser, \OCP\Share::SHARE_TYPE_USER, $path, $reshares, -1, 0);
-		$groupShares = $this->shareManager->getSharesBy($this->currentUser, \OCP\Share::SHARE_TYPE_GROUP, $path, $reshares, -1, 0);
-		$linkShares = $this->shareManager->getSharesBy($this->currentUser, \OCP\Share::SHARE_TYPE_LINK, $path, $reshares, -1, 0);
-		if ($this->shareManager->shareProviderExists(\OCP\Share::SHARE_TYPE_EMAIL)) {
-			$mailShares = $this->shareManager->getSharesBy($this->currentUser, \OCP\Share::SHARE_TYPE_EMAIL, $path, $reshares, -1, 0);
+		$userShares = $this->shareManager->getSharesBy($this->currentUser, Share::SHARE_TYPE_USER, $path, $reshares, -1, 0);
+		$groupShares = $this->shareManager->getSharesBy($this->currentUser, Share::SHARE_TYPE_GROUP, $path, $reshares, -1, 0);
+		$linkShares = $this->shareManager->getSharesBy($this->currentUser, Share::SHARE_TYPE_LINK, $path, $reshares, -1, 0);
+		if ($this->shareManager->shareProviderExists(Share::SHARE_TYPE_EMAIL)) {
+			$mailShares = $this->shareManager->getSharesBy($this->currentUser, Share::SHARE_TYPE_EMAIL, $path, $reshares, -1, 0);
 		} else {
 			$mailShares = [];
 		}
-		if ($this->shareManager->shareProviderExists(\OCP\Share::SHARE_TYPE_CIRCLE)) {
-			$circleShares = $this->shareManager->getSharesBy($this->currentUser, \OCP\Share::SHARE_TYPE_CIRCLE, $path, $reshares, -1, 0);
+		if ($this->shareManager->shareProviderExists(Share::SHARE_TYPE_CIRCLE)) {
+			$circleShares = $this->shareManager->getSharesBy($this->currentUser, Share::SHARE_TYPE_CIRCLE, $path, $reshares, -1, 0);
 		} else {
 			$circleShares = [];
 		}
@@ -652,7 +660,12 @@ class ShareAPIController extends OCSController {
 		$shares = array_merge($userShares, $groupShares, $linkShares, $mailShares, $circleShares);
 
 		if ($this->shareManager->outgoingServer2ServerSharesAllowed()) {
-			$federatedShares = $this->shareManager->getSharesBy($this->currentUser, \OCP\Share::SHARE_TYPE_REMOTE, $path, $reshares, -1, 0);
+			$federatedShares = $this->shareManager->getSharesBy($this->currentUser, Share::SHARE_TYPE_REMOTE, $path, $reshares, -1, 0);
+			$shares = array_merge($shares, $federatedShares);
+		}
+
+		if ($this->shareManager->outgoingServer2ServerGroupSharesAllowed()) {
+			$federatedShares = $this->shareManager->getSharesBy($this->currentUser, Share::SHARE_TYPE_REMOTE_GROUP, $path, $reshares, -1, 0);
 			$shares = array_merge($shares, $federatedShares);
 		}
 
@@ -711,7 +724,7 @@ class ShareAPIController extends OCSController {
 		/*
 		 * expirationdate, password and publicUpload only make sense for link shares
 		 */
-		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
+		if ($share->getShareType() === Share::SHARE_TYPE_LINK) {
 
 			$newPermissions = null;
 			if ($publicUpload === 'true') {
@@ -783,7 +796,7 @@ class ShareAPIController extends OCSController {
 				$share->setPermissions($permissions);
 			}
 
-			if ($share->getShareType() === \OCP\Share::SHARE_TYPE_EMAIL) {
+			if ($share->getShareType() === Share::SHARE_TYPE_EMAIL) {
 				if ($password === '') {
 					$share->setPassword(null);
 				} else if ($password !== null) {
@@ -806,8 +819,8 @@ class ShareAPIController extends OCSController {
 
 		if ($permissions !== null && $share->getShareOwner() !== $this->currentUser) {
 			/* Check if this is an incomming share */
-			$incomingShares = $this->shareManager->getSharedWith($this->currentUser, \OCP\Share::SHARE_TYPE_USER, $share->getNode(), -1, 0);
-			$incomingShares = array_merge($incomingShares, $this->shareManager->getSharedWith($this->currentUser, \OCP\Share::SHARE_TYPE_GROUP, $share->getNode(), -1, 0));
+			$incomingShares = $this->shareManager->getSharedWith($this->currentUser, Share::SHARE_TYPE_USER, $share->getNode(), -1, 0);
+			$incomingShares = array_merge($incomingShares, $this->shareManager->getSharedWith($this->currentUser, Share::SHARE_TYPE_GROUP, $share->getNode(), -1, 0));
 
 			/** @var \OCP\Share\IShare[] $incomingShares */
 			if (!empty($incomingShares)) {
@@ -846,13 +859,13 @@ class ShareAPIController extends OCSController {
 		}
 
 		// If the share is shared with you (or a group you are a member of)
-		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER &&
+		if ($share->getShareType() === Share::SHARE_TYPE_USER &&
 			$share->getSharedWith() === $this->currentUser
 		) {
 			return true;
 		}
 
-		if ($checkGroups && $share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
+		if ($checkGroups && $share->getShareType() === Share::SHARE_TYPE_GROUP) {
 			$sharedWith = $this->groupManager->get($share->getSharedWith());
 			$user = $this->userManager->get($this->currentUser);
 			if ($user !== null && $sharedWith !== null && $sharedWith->inGroup($user)) {
@@ -860,7 +873,7 @@ class ShareAPIController extends OCSController {
 			}
 		}
 
-		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_CIRCLE) {
+		if ($share->getShareType() === Share::SHARE_TYPE_CIRCLE) {
 			// TODO: have a sanity check like above?
 			return true;
 		}
@@ -915,7 +928,7 @@ class ShareAPIController extends OCSController {
 
 
 		try {
-			if ($this->shareManager->shareProviderExists(\OCP\Share::SHARE_TYPE_CIRCLE)) {
+			if ($this->shareManager->shareProviderExists(Share::SHARE_TYPE_CIRCLE)) {
 				$share = $this->shareManager->getShareById('ocCircleShare:' . $id, $this->currentUser);
 				return $share;
 			}
@@ -924,7 +937,7 @@ class ShareAPIController extends OCSController {
 		}
 
 		try {
-			if ($this->shareManager->shareProviderExists(\OCP\Share::SHARE_TYPE_EMAIL)) {
+			if ($this->shareManager->shareProviderExists(Share::SHARE_TYPE_EMAIL)) {
 				$share = $this->shareManager->getShareById('ocMailShare:' . $id, $this->currentUser);
 				return $share;
 			}

--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -223,7 +223,13 @@ class ShareesAPIController extends OCSController {
 	}
 
 	protected function isRemoteGroupSharingAllowed(string $itemType): bool {
-		return true;
+		try {
+			// FIXME: static foo makes unit testing unnecessarily difficult
+			$backend = \OC\Share\Share::getBackend($itemType);
+			return $backend->isShareTypeAllowed(Share::SHARE_TYPE_REMOTE_GROUP);
+		} catch (\Exception $e) {
+			return false;
+		}
 	}
 
 

--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -67,12 +67,14 @@ class ShareesAPIController extends OCSController {
 			'users' => [],
 			'groups' => [],
 			'remotes' => [],
+			'remote_groups' => [],
 			'emails' => [],
 			'circles' => [],
 		],
 		'users' => [],
 		'groups' => [],
 		'remotes' => [],
+		'remote_groups' => [],
 		'emails' => [],
 		'lookup' => [],
 		'circles' => [],
@@ -153,6 +155,10 @@ class ShareesAPIController extends OCSController {
 				$shareTypes[] = Share::SHARE_TYPE_REMOTE;
 			}
 
+			if ($this->isRemoteGroupSharingAllowed($itemType)) {
+				$shareTypes[] = Share::SHARE_TYPE_REMOTE_GROUP;
+			}
+
 			if ($this->shareManager->shareProviderExists(Share::SHARE_TYPE_EMAIL)) {
 				$shareTypes[] = Share::SHARE_TYPE_EMAIL;
 			}
@@ -214,6 +220,10 @@ class ShareesAPIController extends OCSController {
 		} catch (\Exception $e) {
 			return false;
 		}
+	}
+
+	protected function isRemoteGroupSharingAllowed(string $itemType): bool {
+		return true;
 	}
 
 

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -636,7 +636,7 @@ class Manager {
 
 		$query = 'SELECT `id`, `remote`, `remote_id`, `share_token`, `name`, `owner`, `user`, `mountpoint`, `accepted`
 		          FROM `*PREFIX*share_external` 
-				  WHERE `user` = ? OR `user` IN (?)';
+				  WHERE (`user` = ? OR `user` IN (?))';
 		$parameters = [$this->uid, implode(',',$userGroups)];
 		if (!is_null($accepted)) {
 			$query .= ' AND `accepted` = ?';

--- a/apps/files_sharing/lib/Hooks.php
+++ b/apps/files_sharing/lib/Hooks.php
@@ -42,6 +42,8 @@ class Hooks {
 			\OC::$server->query(\OCP\OCS\IDiscoveryService::class),
 			\OC::$server->getCloudFederationProviderManager(),
 			\OC::$server->getCloudFederationFactory(),
+			\OC::$server->getGroupManager(),
+			\OC::$server->getUserManager(),
 			$params['uid']);
 
 		$manager->removeUserShares($params['uid']);

--- a/apps/files_sharing/lib/ShareBackend/File.php
+++ b/apps/files_sharing/lib/ShareBackend/File.php
@@ -195,6 +195,10 @@ class File implements \OCP\Share_Backend_File_Dependent {
 			return $this->federatedShareProvider->isOutgoingServer2serverShareEnabled();
 		}
 
+		if ($shareType === \OCP\Share::SHARE_TYPE_REMOTE_GROUP) {
+			return $this->federatedShareProvider->isOutgoingServer2serverGroupShareEnabled();
+		}
+
 		return true;
 	}
 

--- a/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
@@ -85,120 +85,125 @@ class ShareesAPIControllerTest extends TestCase {
 
 	public function dataSearch() {
 		$noRemote = [Share::SHARE_TYPE_USER, Share::SHARE_TYPE_GROUP, Share::SHARE_TYPE_EMAIL];
-		$allTypes = [Share::SHARE_TYPE_USER, Share::SHARE_TYPE_GROUP, Share::SHARE_TYPE_REMOTE, Share::SHARE_TYPE_EMAIL];
+		$allTypes = [Share::SHARE_TYPE_USER, Share::SHARE_TYPE_GROUP, Share::SHARE_TYPE_REMOTE, Share::SHARE_TYPE_REMOTE_GROUP, Share::SHARE_TYPE_EMAIL];
 
 		return [
-			[[], '', 'yes', true, true, $noRemote, false, true, true],
+			[[], '', 'yes', true, true, true, $noRemote, false, true, true],
 
 			// Test itemType
 			[[
 				'search' => '',
-			], '', 'yes', true, true, $noRemote, false, true, true],
+			], '', 'yes', true, true, true, $noRemote, false, true, true],
 			[[
 				'search' => 'foobar',
-			], '', 'yes', true, true, $noRemote, false, true, true],
+			], '', 'yes', true, true, true, $noRemote, false, true, true],
 			[[
 				'search' => 0,
-			], '', 'yes', true, true, $noRemote, false, true, true],
+			], '', 'yes', true, true, true, $noRemote, false, true, true],
 
 			// Test itemType
 			[[
 				'itemType' => '',
-			], '', 'yes', true, true, $noRemote, false, true, true],
+			], '', 'yes', true, true, true, $noRemote, false, true, true],
 			[[
 				'itemType' => 'folder',
-			], '', 'yes', true, true, $allTypes, false, true, true],
+			], '', 'yes', true, true, true, $allTypes, false, true, true],
 			[[
 				'itemType' => 0,
-			], '', 'yes', true, true, $noRemote, false, true, true],
-
+			], '', 'yes', true, true , true, $noRemote, false, true, true],
 			// Test shareType
 			[[
 				'itemType' => 'call',
-			], '', 'yes', true, true, $noRemote, false, true, true],
+			], '', 'yes', true, true, true, $noRemote, false, true, true],
 			[[
 				'itemType' => 'folder',
-			], '', 'yes', true, true, $allTypes, false, true, true],
+			], '', 'yes', true, true, true, $allTypes, false, true, true],
 			[[
 				'itemType' => 'folder',
 				'shareType' => 0,
-			], '', 'yes', true, false, [0], false, true, true],
+			], '', 'yes', true, true, false, [0], false, true, true],
 			[[
 				'itemType' => 'folder',
 				'shareType' => '0',
-			], '', 'yes', true, false, [0], false, true, true],
+			], '', 'yes', true, true, false, [0], false, true, true],
 			[[
 				'itemType' => 'folder',
 				'shareType' => 1,
-			], '', 'yes', true, false, [1], false, true, true],
+			], '', 'yes', true, true, false, [1], false, true, true],
 			[[
 				'itemType' => 'folder',
 				'shareType' => 12,
-			], '', 'yes', true, false, [], false, true, true],
+			], '', 'yes', true, true, false, [], false, true, true],
 			[[
 				'itemType' => 'folder',
 				'shareType' => 'foobar',
-			], '', 'yes', true, true, $allTypes, false, true, true],
+			], '', 'yes', true, true, true, $allTypes, false, true, true],
+
 			[[
 				'itemType' => 'folder',
 				'shareType' => [0, 1, 2],
-			], '', 'yes', false, false, [0, 1], false, true, true],
+			], '', 'yes', false, false, false, [0, 1], false, true, true],
 			[[
 				'itemType' => 'folder',
 				'shareType' => [0, 1],
-			], '', 'yes', false, false, [0, 1], false, true, true],
+			], '', 'yes', false, false, false, [0, 1], false, true, true],
 			[[
 				'itemType' => 'folder',
 				'shareType' => $allTypes,
-			], '', 'yes', true, true, $allTypes, false, true, true],
+			], '', 'yes', true, true, true, $allTypes, false, true, true],
 			[[
 				'itemType' => 'folder',
 				'shareType' => $allTypes,
-			], '', 'yes', false, false, [0, 1], false, true, true],
+			], '', 'yes', false, false, false, [0, 1], false, true, true],
 			[[
 				'itemType' => 'folder',
 				'shareType' => $allTypes,
-			], '', 'yes', true, false, [0, 6], false, true, false],
+			], '', 'yes', true, false, false, [0, 6], false, true, false],
 			[[
 				'itemType' => 'folder',
 				'shareType' => $allTypes,
-			], '', 'yes', false, true, [0, 4], false, true, false],
+			], '', 'yes', false, false, true, [0, 4], false, true, false],
+			[[
+				'itemType' => 'folder',
+				'shareType' => $allTypes,
+			], '', 'yes', true, true, false, [0, 6, 9], false, true, false],
 
 			// Test pagination
 			[[
 				'itemType' => 'folder',
 				'page' => 1,
-			], '', 'yes', true, true, $allTypes, false, true, true],
+			], '', 'yes', true, true, true, $allTypes, false, true, true],
 			[[
 				'itemType' => 'folder',
 				'page' => 10,
-			], '', 'yes', true, true, $allTypes, false, true, true],
+			], '', 'yes', true, true, true, $allTypes, false, true, true],
 
 			// Test perPage
 			[[
 				'itemType' => 'folder',
 				'perPage' => 1,
-			], '', 'yes', true, true, $allTypes, false, true, true],
+			], '', 'yes', true, true, true, $allTypes, false, true, true],
 			[[
 				'itemType' => 'folder',
 				'perPage' => 10,
-			], '', 'yes', true, true, $allTypes, false, true, true],
+			], '', 'yes', true, true, true, $allTypes, false, true, true],
 
 			// Test $shareWithGroupOnly setting
 			[[
 				'itemType' => 'folder',
-			], 'no', 'yes',  true, true, $allTypes, false, true, true],
+			], 'no', 'yes',  true, true, true, $allTypes, false, true, true],
 			[[
 				'itemType' => 'folder',
-			], 'yes', 'yes', true, true, $allTypes, true, true, true],
+			], 'yes', 'yes', true, true, true, $allTypes, true, true, true],
 
 			// Test $shareeEnumeration setting
 			[[
 				'itemType' => 'folder',
-			], 'no', 'yes',  true, true, $allTypes, false, true, true],
+			], 'no', 'yes',  true, true, true, $allTypes, false, true, true],
 			[[
 				'itemType' => 'folder',
-			], 'no', 'no', true, true, $allTypes, false, false, true],
+			], 'no', 'no', true, true, true, $allTypes, false, false, true],
+
 		];
 	}
 
@@ -209,13 +214,15 @@ class ShareesAPIControllerTest extends TestCase {
 	 * @param string $apiSetting
 	 * @param string $enumSetting
 	 * @param bool $remoteSharingEnabled
+	 * @param bool $isRemoteGroupSharingEnabled
 	 * @param bool $emailSharingEnabled
 	 * @param array $shareTypes
 	 * @param bool $shareWithGroupOnly
 	 * @param bool $shareeEnumeration
 	 * @param bool $allowGroupSharing
+	 * @throws OCSBadRequestException
 	 */
-	public function testSearch($getData, $apiSetting, $enumSetting, $remoteSharingEnabled, $emailSharingEnabled, $shareTypes, $shareWithGroupOnly, $shareeEnumeration, $allowGroupSharing) {
+	public function testSearch($getData, $apiSetting, $enumSetting, $remoteSharingEnabled, $isRemoteGroupSharingEnabled, $emailSharingEnabled, $shareTypes, $shareWithGroupOnly, $shareeEnumeration, $allowGroupSharing) {
 		$search = isset($getData['search']) ? $getData['search'] : '';
 		$itemType = isset($getData['itemType']) ? $getData['itemType'] : 'irrelevant';
 		$page = isset($getData['page']) ? $getData['page'] : 1;
@@ -251,7 +258,7 @@ class ShareesAPIControllerTest extends TestCase {
 				$this->shareManager,
 				$this->collaboratorSearch
 			])
-			->setMethods(['isRemoteSharingAllowed', 'shareProviderExists'])
+			->setMethods(['isRemoteSharingAllowed', 'shareProviderExists', 'isRemoteGroupSharingAllowed'])
 			->getMock();
 
 		$this->collaboratorSearch->expects($this->once())
@@ -263,6 +270,13 @@ class ShareesAPIControllerTest extends TestCase {
 			->method('isRemoteSharingAllowed')
 			->with($itemType)
 			->willReturn($remoteSharingEnabled);
+
+
+		$sharees->expects($this->any())
+			->method('isRemoteGroupSharingAllowed')
+			->with($itemType)
+			->willReturn($isRemoteGroupSharingEnabled);
+
 
 		$this->shareManager->expects($this->any())
 			->method('shareProviderExists')

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -35,6 +35,8 @@ use OCA\Files_Sharing\Tests\TestCase;
 use OCP\Federation\ICloudFederationFactory;
 use OCP\Federation\ICloudFederationProviderManager;
 use OCP\Http\Client\IClientService;
+use OCP\IGroupManager;
+use OCP\IUserManager;
 use Test\Traits\UserTrait;
 
 /**
@@ -62,6 +64,12 @@ class ManagerTest extends TestCase {
 	/** @var ICloudFederationFactory|\PHPUnit_Framework_MockObject_MockObject */
 	private $cloudFederationFactory;
 
+	/** @var \PHPUnit_Framework_MockObject_MockObject|IGroupManager */
+	private $groupManager;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject|IUserManager */
+	private $userManager;
+
 	private $uid;
 
 	/**
@@ -81,6 +89,8 @@ class ManagerTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->cloudFederationProviderManager = $this->createMock(ICloudFederationProviderManager::class);
 		$this->cloudFederationFactory = $this->createMock(ICloudFederationFactory::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->userManager = $this->createMock(IUserManager::class);
 
 		$this->manager = $this->getMockBuilder(Manager::class)
 			->setConstructorArgs(
@@ -93,6 +103,8 @@ class ManagerTest extends TestCase {
 					\OC::$server->query(\OCP\OCS\IDiscoveryService::class),
 					$this->cloudFederationProviderManager,
 					$this->cloudFederationFactory,
+					$this->groupManager,
+					$this->userManager,
 					$this->uid
 				]
 			)->setMethods(['tryOCMEndPoint'])->getMock();
@@ -117,6 +129,7 @@ class ManagerTest extends TestCase {
 			'password' => '',
 			'name' => '/SharedFolder',
 			'owner' => 'foobar',
+			'shareType' => \OCP\Share::SHARE_TYPE_USER,
 			'accepted' => false,
 			'user' => $this->uid,
 		];

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -138,6 +138,9 @@ class ManagerTest extends TestCase {
 		$shareData3 = $shareData1;
 		$shareData3['token'] = 'token3';
 
+		$this->userManager->expects($this->any())->method('get')->willReturn($this->user);
+		$this->groupManager->expects($this->any())->method(('getUserGroups'))->willReturn([]);
+
 		$this->manager->expects($this->at(0))->method('tryOCMEndPoint')->with('http://localhost', 'token1', -1, 'accept')->willReturn(false);
 		$this->manager->expects($this->at(1))->method('tryOCMEndPoint')->with('http://localhost', 'token3', -1, 'decline')->willReturn(false);
 

--- a/build/integration/features/bootstrap/FederationContext.php
+++ b/build/integration/features/bootstrap/FederationContext.php
@@ -35,6 +35,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 class FederationContext implements Context, SnippetAcceptingContext {
 
 	use WebDav;
+	use AppConfiguration;
 
 	/**
 	 * @Given /^User "([^"]*)" from server "(LOCAL|REMOTE)" shares "([^"]*)" with user "([^"]*)" from server "(LOCAL|REMOTE)"$/
@@ -56,6 +57,27 @@ class FederationContext implements Context, SnippetAcceptingContext {
 		$this->usingServer($previous);
 	}
 
+
+	/**
+	 * @Given /^User "([^"]*)" from server "(LOCAL|REMOTE)" shares "([^"]*)" with group "([^"]*)" from server "(LOCAL|REMOTE)"$/
+	 *
+	 * @param string $sharerUser
+	 * @param string $sharerServer "LOCAL" or "REMOTE"
+	 * @param string $sharerPath
+	 * @param string $shareeUser
+	 * @param string $shareeServer "LOCAL" or "REMOTE"
+	 */
+	public function federateGroupSharing($sharerUser, $sharerServer, $sharerPath, $shareeGroup, $shareeServer){
+		if ($shareeServer == "REMOTE"){
+			$shareWith = "$shareeGroup@" . substr($this->remoteBaseUrl, 0, -4);
+		} else {
+			$shareWith = "$shareeGroup@" . substr($this->localBaseUrl, 0, -4);
+		}
+		$previous = $this->usingServer($sharerServer);
+		$this->createShare($sharerUser, $sharerPath, 9, $shareWith, null, null, null);
+		$this->usingServer($previous);
+	}
+
 	/**
 	 * @When /^User "([^"]*)" from server "(LOCAL|REMOTE)" accepts last pending share$/
 	 * @param string $user
@@ -72,5 +94,10 @@ class FederationContext implements Context, SnippetAcceptingContext {
 		$this->theHTTPStatusCodeShouldBe('200');
 		$this->theOCSStatusCodeShouldBe('100');
 		$this->usingServer($previous);
+	}
+
+	protected function resetAppConfigs() {
+		$this->modifyServerConfig('files_sharing', 'incoming_server2server_group_share_enabled', 'no');
+		$this->modifyServerConfig('files_sharing', 'outgoing_server2server_group_share_enabled', 'no');
 	}
 }

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -11,6 +11,7 @@ OC.Share = _.extend(OC.Share || {}, {
 	SHARE_TYPE_REMOTE:6,
 	SHARE_TYPE_CIRCLE:7,
 	SHARE_TYPE_GUEST:8,
+	SHARE_TYPE_REMOTE_GROUP:9,
 
 	/**
 	 * Regular expression for splitting parts of remote share owners:

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -198,6 +198,8 @@
 				shareWithDisplayName = shareWithDisplayName + " (" + t('core', 'group') + ')';
 			} else if (shareType === OC.Share.SHARE_TYPE_REMOTE) {
 				shareWithDisplayName = shareWithDisplayName + " (" + t('core', 'remote') + ')';
+			} else if (shareType === OC.Share.SHARE_TYPE_REMOTE_GROUP) {
+				shareWithDisplayName = shareWithDisplayName + " (" + t('core', 'remote group') + ')';
 			} else if (shareType === OC.Share.SHARE_TYPE_EMAIL) {
 				shareWithDisplayName = shareWithDisplayName + " (" + t('core', 'email') + ')';
 			} else if (shareType === OC.Share.SHARE_TYPE_CIRCLE) {
@@ -207,7 +209,10 @@
 				shareWithTitle = shareWith + " (" + t('core', 'group') + ')';
 			} else if (shareType === OC.Share.SHARE_TYPE_REMOTE) {
 				shareWithTitle = shareWith + " (" + t('core', 'remote') + ')';
-			} else if (shareType === OC.Share.SHARE_TYPE_EMAIL) {
+			} else if (shareType === OC.Share.SHARE_TYPE_REMOTE_GROUP) {
+				shareWithTitle = shareWith + " (" + t('core', 'remote group') + ')';
+			}
+			else if (shareType === OC.Share.SHARE_TYPE_EMAIL) {
 				shareWithTitle = shareWith + " (" + t('core', 'email') + ')';
 			} else if (shareType === OC.Share.SHARE_TYPE_CIRCLE) {
 				shareWithTitle = shareWith;
@@ -243,6 +248,7 @@
 				shareId: this.model.get('shares')[shareIndex].id,
 				modSeed: shareType !== OC.Share.SHARE_TYPE_USER && shareType !== OC.Share.SHARE_TYPE_CIRCLE,
 				isRemoteShare: shareType === OC.Share.SHARE_TYPE_REMOTE,
+				isRemoteGroupShare: shareType === OC.Share.SHARE_TYPE_REMOTE_GROUP,
 				isMailShare: shareType === OC.Share.SHARE_TYPE_EMAIL,
 				isCircleShare: shareType === OC.Share.SHARE_TYPE_CIRCLE,
 				isFileSharedByMail: shareType === OC.Share.SHARE_TYPE_EMAIL && !this.model.isFolder(),

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -93,6 +93,9 @@
 			this.configModel.on('change:isRemoteShareAllowed', function() {
 				view.render();
 			});
+			this.configModel.on('change:isRemoteGroupShareAllowed', function() {
+				view.render();
+			});
 			this.model.on('change:permissions', function() {
 				view.render();
 			});
@@ -161,7 +164,7 @@
 				},
 				function (result) {
 					if (result.ocs.meta.statuscode === 100) {
-						var filter = function(users, groups, remotes, emails, circles) {
+						var filter = function(users, groups, remotes, remote_groups, emails, circles) {
 							if (typeof(emails) === 'undefined') {
 								emails = [];
 							}
@@ -172,6 +175,7 @@
 							var usersLength;
 							var groupsLength;
 							var remotesLength;
+							var remoteGroupsLength;
 							var emailsLength;
 							var circlesLength;
 
@@ -228,6 +232,14 @@
 											break;
 										}
 									}
+								} else if (share.share_type === OC.Share.SHARE_TYPE_REMOTE_GROUP) {
+									remoteGroupsLength = remote_groups.length;
+									for (j = 0; j < remoteGroupsLength; j++) {
+										if (remote_groups[j].value.shareWith === share.share_with) {
+											remote_groups.splice(j, 1);
+											break;
+										}
+									}
 								} else if (share.share_type === OC.Share.SHARE_TYPE_EMAIL) {
 									emailsLength = emails.length;
 									for (j = 0; j < emailsLength; j++) {
@@ -252,6 +264,7 @@
 							result.ocs.data.exact.users,
 							result.ocs.data.exact.groups,
 							result.ocs.data.exact.remotes,
+							result.ocs.data.exact.remote_groups,
 							result.ocs.data.exact.emails,
 							result.ocs.data.exact.circles
 						);
@@ -259,6 +272,7 @@
 						var exactUsers   = result.ocs.data.exact.users;
 						var exactGroups  = result.ocs.data.exact.groups;
 						var exactRemotes = result.ocs.data.exact.remotes;
+						var exactRemoteGroups = result.ocs.data.exact.remote_groups;
 						var exactEmails = [];
 						if (typeof(result.ocs.data.emails) !== 'undefined') {
 							exactEmails = result.ocs.data.exact.emails;
@@ -268,12 +282,13 @@
 							exactCircles = result.ocs.data.exact.circles;
 						}
 
-						var exactMatches = exactUsers.concat(exactGroups).concat(exactRemotes).concat(exactEmails).concat(exactCircles);
+						var exactMatches = exactUsers.concat(exactGroups).concat(exactRemotes).concat(exactRemoteGroups).concat(exactEmails).concat(exactCircles);
 
 						filter(
 							result.ocs.data.users,
 							result.ocs.data.groups,
 							result.ocs.data.remotes,
+							result.ocs.data.remote_groups,
 							result.ocs.data.emails,
 							result.ocs.data.circles
 						);
@@ -281,6 +296,7 @@
 						var users   = result.ocs.data.users;
 						var groups  = result.ocs.data.groups;
 						var remotes = result.ocs.data.remotes;
+						var remoteGroups = result.ocs.data.remote_groups;
 						var lookup = result.ocs.data.lookup;
 						var emails = [];
 						if (typeof(result.ocs.data.emails) !== 'undefined') {
@@ -291,7 +307,7 @@
 							circles = result.ocs.data.circles;
 						}
 
-						var suggestions = exactMatches.concat(users).concat(groups).concat(remotes).concat(emails).concat(circles).concat(lookup);
+						var suggestions = exactMatches.concat(users).concat(groups).concat(remotes).concat(remoteGroups).concat(emails).concat(circles).concat(lookup);
 
 						deferred.resolve(suggestions, exactMatches);
 					} else {
@@ -414,7 +430,9 @@
 			if (item.value.shareType === OC.Share.SHARE_TYPE_GROUP) {
 				text = t('core', '{sharee} (group)', { sharee: text }, undefined, { escape: false });
 			} else if (item.value.shareType === OC.Share.SHARE_TYPE_REMOTE) {
-				text = t('core', '{sharee} (remote)', { sharee: text }, undefined, { escape: false });
+				text = t('core', '{sharee} (remote)', {sharee: text}, undefined, {escape: false});
+			} else if (item.value.shareType === OC.Share.SHARE_TYPE_REMOTE_GROUP) {
+				text = t('core', '{sharee} (remote group)', { sharee: text }, undefined, { escape: false });
 			} else if (item.value.shareType === OC.Share.SHARE_TYPE_EMAIL) {
 				text = t('core', '{sharee} (email)', { sharee: text }, undefined, { escape: false });
 			} else if (item.value.shareType === OC.Share.SHARE_TYPE_CIRCLE) {

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -489,11 +489,13 @@ describe('OC.Share.ShareDialogView', function() {
 						'exact': {
 							'users': [],
 							'groups': [],
-							'remotes': []
+							'remotes': [],
+							'remote_groups': [],
 						},
 						'users': [],
 						'groups': [],
 						'remotes': [],
+						'remote_groups': [],
 						'lookup': []
 					}
 				}
@@ -529,7 +531,8 @@ describe('OC.Share.ShareDialogView', function() {
 						'exact': {
 							'users': [],
 							'groups': [],
-							'remotes': []
+							'remotes': [],
+							'remote_groups': [],
 						},
 						'users': [
 							{
@@ -542,6 +545,7 @@ describe('OC.Share.ShareDialogView', function() {
 						],
 						'groups': [],
 						'remotes': [],
+						'remote_groups': [],
 						'lookup': []
 					}
 				}
@@ -589,11 +593,13 @@ describe('OC.Share.ShareDialogView', function() {
 								}
 							],
 							'groups': [],
-							'remotes': []
+							'remotes': [],
+							'remote_groups': [],
 						},
 						'users': [],
 						'groups': [],
 						'remotes': [],
+						'remote_groups': [],
 						'lookup': []
 					}
 				}
@@ -651,7 +657,8 @@ describe('OC.Share.ShareDialogView', function() {
 									}
 								}
 							],
-							'remotes': []
+							'remotes': [],
+							'remote_groups': [],
 						},
 						'users': [
 							{
@@ -679,6 +686,7 @@ describe('OC.Share.ShareDialogView', function() {
 							}
 						],
 						'remotes': [],
+						'remote_groups': [],
 						'lookup': []
 					}
 				}
@@ -744,11 +752,13 @@ describe('OC.Share.ShareDialogView', function() {
 								}
 							],
 							'groups': [],
-							'remotes': []
+							'remotes': [],
+							'remote_groups': [],
 						},
 						'users': [],
 						'groups': [],
 						'remotes': [],
+						'remote_groups': [],
 						'lookup': []
 					}
 				}
@@ -817,11 +827,13 @@ describe('OC.Share.ShareDialogView', function() {
 								}
 							],
 							'groups': [],
-							'remotes': []
+							'remotes': [],
+							'remote_groups': [],
 						},
 						'users': [],
 						'groups': [],
 						'remotes': [],
+						'remote_groups': [],
 						'lookup': []
 					}
 				}
@@ -928,7 +940,8 @@ describe('OC.Share.ShareDialogView', function() {
 									}
 								],
 								'groups': [],
-								'remotes': []
+								'remotes': [],
+								'remote_groups': [],
 							},
 							'users': [
 								{
@@ -941,6 +954,7 @@ describe('OC.Share.ShareDialogView', function() {
 							],
 							'groups': [],
 							'remotes': [],
+							'remote_groups': [],
 							'lookup': []
 						}
 					}
@@ -983,7 +997,8 @@ describe('OC.Share.ShareDialogView', function() {
 										}
 									}
 								],
-								'remotes': []
+								'remotes': [],
+								'remote_groups': [],
 							},
 							'users': [],
 							'groups': [
@@ -996,6 +1011,7 @@ describe('OC.Share.ShareDialogView', function() {
 								}
 							],
 							'remotes': [],
+							'remote_groups': [],
 							'lookup': []
 						}
 					}
@@ -1038,7 +1054,8 @@ describe('OC.Share.ShareDialogView', function() {
 											'shareWith': 'foo@bar.com/baz'
 										}
 									}
-								]
+								],
+								'remote_groups': [],
 							},
 							'users': [],
 							'groups': [],
@@ -1051,6 +1068,7 @@ describe('OC.Share.ShareDialogView', function() {
 									}
 								}
 							],
+							'remote_groups': [],
 							'lookup': []
 						}
 					}
@@ -1086,6 +1104,7 @@ describe('OC.Share.ShareDialogView', function() {
 								'users': [],
 								'groups': [],
 								'remotes': [],
+								'remote_groups': [],
 								'emails': [
 									{
 										'label': 'foo@bar.com',
@@ -1099,6 +1118,7 @@ describe('OC.Share.ShareDialogView', function() {
 							'users': [],
 							'groups': [],
 							'remotes': [],
+							'remote_groups': [],
 							'lookup': [],
 							'emails': [
 								{
@@ -1143,6 +1163,7 @@ describe('OC.Share.ShareDialogView', function() {
 								'users': [],
 								'groups': [],
 								'remotes': [],
+								'remote_groups': [],
 								'circles': [
 									{
 										'label': 'CircleName (type, owner)',
@@ -1163,6 +1184,7 @@ describe('OC.Share.ShareDialogView', function() {
 							'users': [],
 							'groups': [],
 							'remotes': [],
+							'remote_groups': [],
 							'lookup': [],
 							'circles': [
 								{
@@ -1211,7 +1233,8 @@ describe('OC.Share.ShareDialogView', function() {
 							'exact': {
 								'users': [],
 								'groups': [],
-								'remotes': []
+								'remotes': [],
+								'remote_groups': [],
 							},
 							'users': [
 								{
@@ -1231,6 +1254,7 @@ describe('OC.Share.ShareDialogView', function() {
 							],
 							'groups': [],
 							'remotes': [],
+							'remote_groups': [],
 							'lookup': []
 						}
 					}
@@ -1270,7 +1294,8 @@ describe('OC.Share.ShareDialogView', function() {
 							'exact': {
 								'users': [],
 								'groups': [],
-								'remotes': []
+								'remotes': [],
+								'remote_groups': [],
 							},
 							'users': [
 								{
@@ -1290,6 +1315,7 @@ describe('OC.Share.ShareDialogView', function() {
 							],
 							'groups': [],
 							'remotes': [],
+							'remote_groups': [],
 							'lookup': []
 						}
 					}
@@ -1364,7 +1390,8 @@ describe('OC.Share.ShareDialogView', function() {
 								'exact': {
 									'users': [],
 									'groups': [],
-									'remotes': []
+									'remotes': [],
+									'remote_groups': [],
 								},
 								'users': [
 									{
@@ -1384,6 +1411,7 @@ describe('OC.Share.ShareDialogView', function() {
 								],
 								'groups': [],
 								'remotes': [],
+								'remote_groups': [],
 								'lookup': []
 							}
 						}
@@ -1423,7 +1451,8 @@ describe('OC.Share.ShareDialogView', function() {
 										}
 									],
 									'groups': [],
-									'remotes': []
+									'remotes': [],
+									'remote_groups': [],
 								},
 								'users': [
 									{
@@ -1436,6 +1465,7 @@ describe('OC.Share.ShareDialogView', function() {
 								],
 								'groups': [],
 								'remotes': [],
+								'remote_groups': [],
 								'lookup': []
 							}
 						}
@@ -1467,7 +1497,8 @@ describe('OC.Share.ShareDialogView', function() {
 								'exact': {
 									'users': [],
 									'groups': [],
-									'remotes': []
+									'remotes': [],
+									'remote_groups': [],
 								},
 								'users': [],
 								'groups': [
@@ -1487,6 +1518,7 @@ describe('OC.Share.ShareDialogView', function() {
 									}
 								],
 								'remotes': [],
+								'remote_groups': [],
 								'lookup': []
 							}
 						}
@@ -1526,7 +1558,8 @@ describe('OC.Share.ShareDialogView', function() {
 											}
 										}
 									],
-									'remotes': []
+									'remotes': [],
+									'remote_groups': [],
 								},
 								'users': [],
 								'groups': [
@@ -1539,6 +1572,7 @@ describe('OC.Share.ShareDialogView', function() {
 									}
 								],
 								'remotes': [],
+								'remote_groups': [],
 								'lookup': []
 							}
 						}
@@ -1570,7 +1604,8 @@ describe('OC.Share.ShareDialogView', function() {
 								'exact': {
 									'users': [],
 									'groups': [],
-									'remotes': []
+									'remotes': [],
+									'remote_groups': [],
 								},
 								'users': [],
 								'groups': [],
@@ -1590,6 +1625,7 @@ describe('OC.Share.ShareDialogView', function() {
 										}
 									}
 								],
+								'remote_groups': [],
 								'lookup': []
 							}
 						}
@@ -1629,7 +1665,8 @@ describe('OC.Share.ShareDialogView', function() {
 												'shareWith': 'foo@bar.com/baz'
 											}
 										}
-									]
+									],
+									'remote_groups': [],
 								},
 								'users': [],
 								'groups': [],
@@ -1642,6 +1679,7 @@ describe('OC.Share.ShareDialogView', function() {
 										}
 									}
 								],
+								'remote_groups': [],
 								'lookup': []
 							}
 						}
@@ -1674,12 +1712,14 @@ describe('OC.Share.ShareDialogView', function() {
 									'users': [],
 									'groups': [],
 									'remotes': [],
+									'remote_groups': [],
 									'emails': []
 								},
 								'users': [],
 								'groups': [],
 								'remotes': [],
 								'lookup': [],
+								'remote_groups': [],
 								'emails': [
 									{
 										'label': 'foo@bar.com',
@@ -1727,6 +1767,7 @@ describe('OC.Share.ShareDialogView', function() {
 									'users': [],
 									'groups': [],
 									'remotes': [],
+									'remote_groups': [],
 									'emails': [
 										{
 											'label': 'foo@bar.com',
@@ -1740,6 +1781,7 @@ describe('OC.Share.ShareDialogView', function() {
 								'users': [],
 								'groups': [],
 								'remotes': [],
+								'remote_groups': [],
 								'lookup': [],
 								'emails': [
 									{
@@ -1781,11 +1823,13 @@ describe('OC.Share.ShareDialogView', function() {
 									'users': [],
 									'groups': [],
 									'remotes': [],
+									'remote_groups': [],
 									'circles': []
 								},
 								'users': [],
 								'groups': [],
 								'remotes': [],
+								'remote_groups': [],
 								'lookup': [],
 								'circles': [
 									{
@@ -1834,6 +1878,7 @@ describe('OC.Share.ShareDialogView', function() {
 									'users': [],
 									'groups': [],
 									'remotes': [],
+									'remote_groups': [],
 									'circles': [
 										{
 											'label': 'CircleName (type, owner)',
@@ -1854,6 +1899,7 @@ describe('OC.Share.ShareDialogView', function() {
 								'users': [],
 								'groups': [],
 								'remotes': [],
+								'remote_groups': [],
 								'lookup': [],
 								'circles': [
 									{
@@ -2031,11 +2077,13 @@ describe('OC.Share.ShareDialogView', function() {
 						'exact': {
 							'users': [],
 							'groups': [],
-							'remotes': []
+							'remotes': [],
+							'remote_groups': [],
 						},
 						'users': [],
 						'groups': [],
 						'remotes': [],
+						'remote_groups': [],
 						'lookup': []
 					}
 				}
@@ -2126,11 +2174,13 @@ describe('OC.Share.ShareDialogView', function() {
 								}
 							],
 							'groups': [],
-							'remotes': []
+							'remotes': [],
+							'remote_groups': [],
 						},
 						'users': [],
 						'groups': [],
 						'remotes': [],
+						'remote_groups': [],
 						'lookup': []
 					}
 				}
@@ -2191,11 +2241,13 @@ describe('OC.Share.ShareDialogView', function() {
 								}
 							],
 							'groups': [],
-							'remotes': []
+							'remotes': [],
+							'remote_groups': [],
 						},
 						'users': [],
 						'groups': [],
 						'remotes': [],
+						'remote_groups': [],
 						'lookup': []
 					}
 				}
@@ -2248,12 +2300,14 @@ describe('OC.Share.ShareDialogView', function() {
 						'exact': {
 							'users': [],
 							'groups': [],
-							'remotes': []
+							'remotes': [],
+							'remote_groups': [],
 						},
 						'users': [],
 						'groups': [],
 						'remotes': [],
-						'lookup': []
+						'lookup': [],
+						'remote_groups': [],
 					}
 				}
 			});
@@ -2292,7 +2346,8 @@ describe('OC.Share.ShareDialogView', function() {
 						'exact': {
 							'users': [],
 							'groups': [],
-							'remotes': []
+							'remotes': [],
+							'remote_groups': [],
 						},
 						'users': [
 							{
@@ -2305,6 +2360,7 @@ describe('OC.Share.ShareDialogView', function() {
 						],
 						'groups': [],
 						'remotes': [],
+						'remote_groups': [],
 						'lookup': []
 					}
 				}
@@ -2356,11 +2412,13 @@ describe('OC.Share.ShareDialogView', function() {
 									}
 								}
 							],
-							'remotes': []
+							'remotes': [],
+							'remote_groups': [],
 						},
 						'users': [],
 						'groups': [],
 						'remotes': [],
+						'remote_groups': [],
 						'lookup': []
 					}
 				}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -471,6 +471,7 @@ return array(
     'OC\\Collaboration\\Collaborators\\GroupPlugin' => $baseDir . '/lib/private/Collaboration/Collaborators/GroupPlugin.php',
     'OC\\Collaboration\\Collaborators\\LookupPlugin' => $baseDir . '/lib/private/Collaboration/Collaborators/LookupPlugin.php',
     'OC\\Collaboration\\Collaborators\\MailPlugin' => $baseDir . '/lib/private/Collaboration/Collaborators/MailPlugin.php',
+    'OC\\Collaboration\\Collaborators\\RemoteGroupPlugin' => $baseDir . '/lib/private/Collaboration/Collaborators/RemoteGroupPlugin.php',
     'OC\\Collaboration\\Collaborators\\RemotePlugin' => $baseDir . '/lib/private/Collaboration/Collaborators/RemotePlugin.php',
     'OC\\Collaboration\\Collaborators\\Search' => $baseDir . '/lib/private/Collaboration/Collaborators/Search.php',
     'OC\\Collaboration\\Collaborators\\SearchResult' => $baseDir . '/lib/private/Collaboration/Collaborators/SearchResult.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -501,6 +501,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Collaboration\\Collaborators\\GroupPlugin' => __DIR__ . '/../../..' . '/lib/private/Collaboration/Collaborators/GroupPlugin.php',
         'OC\\Collaboration\\Collaborators\\LookupPlugin' => __DIR__ . '/../../..' . '/lib/private/Collaboration/Collaborators/LookupPlugin.php',
         'OC\\Collaboration\\Collaborators\\MailPlugin' => __DIR__ . '/../../..' . '/lib/private/Collaboration/Collaborators/MailPlugin.php',
+        'OC\\Collaboration\\Collaborators\\RemoteGroupPlugin' => __DIR__ . '/../../..' . '/lib/private/Collaboration/Collaborators/RemoteGroupPlugin.php',
         'OC\\Collaboration\\Collaborators\\RemotePlugin' => __DIR__ . '/../../..' . '/lib/private/Collaboration/Collaborators/RemotePlugin.php',
         'OC\\Collaboration\\Collaborators\\Search' => __DIR__ . '/../../..' . '/lib/private/Collaboration/Collaborators/Search.php',
         'OC\\Collaboration\\Collaborators\\SearchResult' => __DIR__ . '/../../..' . '/lib/private/Collaboration/Collaborators/SearchResult.php',

--- a/lib/private/Collaboration/Collaborators/RemoteGroupPlugin.php
+++ b/lib/private/Collaboration/Collaborators/RemoteGroupPlugin.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Collaboration\Collaborators;
+
+
+use OCP\Collaboration\Collaborators\ISearchPlugin;
+use OCP\Collaboration\Collaborators\ISearchResult;
+use OCP\Collaboration\Collaborators\SearchResultType;
+use OCP\Contacts\IManager;
+use OCP\Federation\ICloudFederationProviderManager;
+use OCP\Federation\ICloudIdManager;
+use OCP\IConfig;
+use OCP\Share;
+
+class RemoteGroupPlugin implements ISearchPlugin {
+	protected $shareeEnumeration;
+
+	/** @var ICloudIdManager */
+	private $cloudIdManager;
+	/** @var IConfig */
+	private $config;
+	/** @var bool */
+	private $enabled = false;
+
+	public function __construct(ICloudFederationProviderManager $cloudFederationProviderManager, ICloudIdManager $cloudIdManager) {
+		try {
+			$fileSharingProvider = $cloudFederationProviderManager->getCloudFederationProvider('file');
+			$supportedShareTypes = $fileSharingProvider->getSupportedShareTypes();
+			if (in_array('group', $supportedShareTypes)) {
+				$this->enabled = true;
+			}
+		} catch (\Exception $e) {
+			// do nothing, just don't enable federated group shares
+		}
+		$this->cloudIdManager = $cloudIdManager;
+	}
+
+	public function search($search, $limit, $offset, ISearchResult $searchResult) {
+		$result = ['wide' => [], 'exact' => []];
+		$resultType = new SearchResultType('remote_groups');
+
+		if ($this->enabled && $this->cloudIdManager->isValidCloudId($search) && $offset === 0) {
+			$result['exact'][] = [
+				'label' => $search,
+				'value' => [
+					'shareType' => Share::SHARE_TYPE_REMOTE_GROUP,
+					'shareWith' => $search,
+				],
+			];
+		}
+
+		$searchResult->addResultSet($resultType, $result['wide'], $result['exact']);
+
+		return true;
+	}
+
+}

--- a/lib/private/Federation/CloudFederationProviderManager.php
+++ b/lib/private/Federation/CloudFederationProviderManager.php
@@ -157,6 +157,7 @@ class CloudFederationProviderManager implements ICloudFederationProviderManager 
 			// we re-throw the exception and fall back to the old behaviour.
 			// (flat re-shares has been introduced in Nextcloud 9.1)
 			if ($e->getCode() === Http::STATUS_INTERNAL_SERVER_ERROR) {
+				$this->logger->debug($e->getMessage());
 				throw $e;
 			}
 		}

--- a/lib/private/Federation/CloudFederationShare.php
+++ b/lib/private/Federation/CloudFederationShare.php
@@ -204,7 +204,11 @@ class CloudFederationShare implements ICloudFederationShare {
 	 * @since 14.0.0
 	 */
 	public function setShareType($shareType) {
-		$this->share['shareType'] = $shareType;
+		if ($shareType === 'group' || $shareType === \OCP\Share::SHARE_TYPE_REMOTE_GROUP) {
+			$this->share['shareType'] = 'group';
+		} else {
+			$this->share['shareType'] = 'user';
+		}
 	}
 
 	/**

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -60,6 +60,7 @@ use OC\Authentication\LoginCredentials\Store;
 use OC\Authentication\Token\IProvider;
 use OC\Collaboration\Collaborators\GroupPlugin;
 use OC\Collaboration\Collaborators\MailPlugin;
+use OC\Collaboration\Collaborators\RemoteGroupPlugin;
 use OC\Collaboration\Collaborators\RemotePlugin;
 use OC\Collaboration\Collaborators\UserPlugin;
 use OC\Command\CronBus;
@@ -1066,6 +1067,7 @@ class Server extends ServerContainer implements IServerContainer {
 			$instance->registerPlugin(['shareType' => 'SHARE_TYPE_GROUP', 'class' => GroupPlugin::class]);
 			$instance->registerPlugin(['shareType' => 'SHARE_TYPE_EMAIL', 'class' => MailPlugin::class]);
 			$instance->registerPlugin(['shareType' => 'SHARE_TYPE_REMOTE', 'class' => RemotePlugin::class]);
+			$instance->registerPlugin(['shareType' => 'SHARE_TYPE_REMOTE_GROUP', 'class' => RemoteGroupPlugin::class]);
 
 			return $instance;
 		});

--- a/lib/private/Share/Constants.php
+++ b/lib/private/Share/Constants.php
@@ -37,6 +37,7 @@ class Constants {
 	const SHARE_TYPE_REMOTE = 6;
 	const SHARE_TYPE_CIRCLE = 7;
 	const SHARE_TYPE_GUEST = 8;
+	const SHARE_TYPE_REMOTE_GROUP = 9;
 
 	const FORMAT_NONE = -1;
 	const FORMAT_STATUSES = -2;

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -226,6 +226,10 @@ class Manager implements IManager {
 			if ($share->getSharedWith() === null) {
 				throw new \InvalidArgumentException('SharedWith should not be empty');
 			}
+		}  else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_REMOTE_GROUP) {
+			if ($share->getSharedWith() === null) {
+				throw new \InvalidArgumentException('SharedWith should not be empty');
+			}
 		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_EMAIL) {
 			if ($share->getSharedWith() === null) {
 				throw new \InvalidArgumentException('SharedWith should not be empty');
@@ -1577,6 +1581,13 @@ class Manager implements IManager {
 	 */
 	public function outgoingServer2ServerSharesAllowed() {
 		return $this->config->getAppValue('files_sharing', 'outgoing_server2server_share_enabled', 'yes') === 'yes';
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function outgoingServer2ServerGroupSharesAllowed() {
+		return $this->config->getAppValue('files_sharing', 'outgoing_server2server_group_share_enabled', 'no') === 'yes';
 	}
 
 	/**

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -135,7 +135,8 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->getConfig(),
 				$this->serverContainer->getUserManager(),
 				$this->serverContainer->getCloudIdManager(),
-				$this->serverContainer->getGlobalScaleConfig()
+				$this->serverContainer->getGlobalScaleConfig(),
+				$this->serverContainer->getCloudFederationProviderManager()
 			);
 		}
 
@@ -250,7 +251,7 @@ class ProviderFactory implements IProviderFactory {
 			$shareType === \OCP\Share::SHARE_TYPE_LINK
 		) {
 			$provider = $this->defaultShareProvider();
-		} else if ($shareType === \OCP\Share::SHARE_TYPE_REMOTE) {
+		} else if ($shareType === \OCP\Share::SHARE_TYPE_REMOTE || \OCP\Share::SHARE_TYPE_REMOTE_GROUP) {
 			$provider = $this->federatedShareProvider();
 		} else if ($shareType === \OCP\Share::SHARE_TYPE_EMAIL) {
 			$provider = $this->getShareByMailProvider();

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -370,6 +370,14 @@ interface IManager {
 	public function outgoingServer2ServerSharesAllowed();
 
 	/**
+	 * Check if outgoing server2server shares are allowed
+	 * @return bool
+	 * @since 14.0.0
+	 */
+	public function outgoingServer2ServerGroupSharesAllowed();
+
+
+	/**
 	 * Check if a given share provider exists
 	 * @param int $shareType
 	 * @return bool


### PR DESCRIPTION
Allows you to share a file/folder with a group on a different server. The group is addressed similiar to a individual user: `<groupname>@<server>`. By default incoming and outgoing federated group shares are disabled in the admin settings.

- [x]  send federated group share
- [x] individual user can accept share
- [x] individual user can decline share
- [x] individual user can unshare from self
- [x] handle unshare notification from owner correctly
- [x] handle permission change from owner correctly
- [x] UI to create federated group share

Fixes #4252