### PR TITLE
Wait for cron to finish before running upgrade command

### DIFF
--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -99,7 +99,8 @@ class Upgrade extends Command {
 					$this->config,
 					\OC::$server->getIntegrityCodeChecker(),
 					$this->logger,
-					$this->installer
+					$this->installer,
+					\OC::$server->getJobList()
 			);
 
 			$dispatcher = \OC::$server->getEventDispatcher();
@@ -190,6 +191,9 @@ class Upgrade extends Command {
 			});
 			$updater->listen('\OC\Updater', 'maintenanceActive', function () use($output) {
 				$output->writeln('<info>Maintenance mode is kept active</info>');
+			});
+			$updater->listen('\OC\Updater', 'waitForCronToFinish', function () use($output) {
+				$output->writeln('<info>Waiting for cron to finish (checks again in 5 seconds)...</info>');
 			});
 			$updater->listen('\OC\Updater', 'updateEnd',
 				function ($success) use($output, $self) {

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -119,7 +119,8 @@ if (\OCP\Util::needUpgrade()) {
 			$config,
 			\OC::$server->getIntegrityCodeChecker(),
 			$logger,
-			\OC::$server->query(\OC\Installer::class)
+			\OC::$server->query(\OC\Installer::class),
+			\OC::$server->getJobList()
 	);
 	$incompatibleApps = [];
 
@@ -151,6 +152,9 @@ if (\OCP\Util::needUpgrade()) {
 	});
 	$updater->listen('\OC\Updater', 'maintenanceActive', function () use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Maintenance mode is kept active'));
+	});
+	$updater->listen('\OC\Updater', 'waitForCronToFinish', function () use ($eventSource, $l) {
+		$eventSource->send('success', (string)$l->t('Waiting for cron to finish (checks again in 5 seconds)...'));
 	});
 	$updater->listen('\OC\Updater', 'dbUpgradeBefore', function () use($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Updating database schema'));

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -48,6 +48,9 @@ class JobList implements IJobList {
 	/**@var ITimeFactory */
 	protected $timeFactory;
 
+	/** @var int - 12 hours * 3600 seconds*/
+	private $jobTimeOut = 43200;
+
 	/**
 	 * @param IDBConnection $connection
 	 * @param IConfig $config
@@ -182,7 +185,7 @@ class JobList implements IJobList {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')
 			->from('jobs')
-			->where($query->expr()->lte('reserved_at', $query->createNamedParameter($this->timeFactory->getTime() - 12 * 3600, IQueryBuilder::PARAM_INT)))
+			->where($query->expr()->lte('reserved_at', $query->createNamedParameter($this->timeFactory->getTime() - $this->jobTimeOut, IQueryBuilder::PARAM_INT)))
 			->orderBy('last_checked', 'ASC')
 			->setMaxResults(1);
 
@@ -332,5 +335,40 @@ class JobList implements IJobList {
 			->set('execution_duration', $query->createNamedParameter($timeTaken, IQueryBuilder::PARAM_INT))
 			->where($query->expr()->eq('id', $query->createNamedParameter($job->getId(), IQueryBuilder::PARAM_INT)));
 		$query->execute();
+	}
+
+	/**
+	 * checks if a job is still running (reserved_at time is smaller than 12 hours ago)
+	 *
+	 * Background information:
+	 *
+	 * The 12 hours is the same timeout that is also used to re-schedule an non-terminated
+	 * job (see getNext()). The idea here is to give a job enough time to run very
+	 * long but still be able to recognize that it maybe crashed and re-schedule it
+	 * after the timeout. It's more likely to be crashed at that time than it ran
+	 * that long.
+	 *
+	 * In theory it could lead to an nearly endless loop (as in - at most 12 hours).
+	 * The cron command will not start new jobs when maintenance mode is active and
+	 * this method is only executed in maintenance mode (see where it is called in
+	 * the upgrader class. So this means in the worst case we wait 12 hours when a
+	 * job has crashed. On the other hand: then the instance should be fixed anyways.
+	 *
+	 * @return bool
+	 */
+	public function isAnyJobRunning(): bool {
+		$query = $this->connection->getQueryBuilder();
+		$query->select('*')
+			->from('jobs')
+			->where($query->expr()->gt('reserved_at', $query->createNamedParameter($this->timeFactory->getTime() - $this->jobTimeOut, IQueryBuilder::PARAM_INT)))
+			->setMaxResults(1);
+		$result = $query->execute();
+		$row = $result->fetch();
+		$result->closeCursor();
+
+		if ($row) {
+			return true;
+		}
+		return false;
 	}
 }

--- a/tests/lib/UpdaterTest.php
+++ b/tests/lib/UpdaterTest.php
@@ -24,6 +24,7 @@ namespace Test;
 
 use OC\Installer;
 use OC\Updater;
+use OCP\BackgroundJob\IJobList;
 use OCP\IConfig;
 use OCP\ILogger;
 use OC\IntegrityCheck\Checker;
@@ -39,6 +40,8 @@ class UpdaterTest extends TestCase {
 	private $checker;
 	/** @var Installer|\PHPUnit_Framework_MockObject_MockObject */
 	private $installer;
+	/** @var IJobList|\PHPUnit_Framework_MockObject_MockObject */
+	private $jobList;
 
 	public function setUp() {
 		parent::setUp();
@@ -54,12 +57,16 @@ class UpdaterTest extends TestCase {
 		$this->installer = $this->getMockBuilder(Installer::class)
 			->disableOriginalConstructor()
 			->getMock();
+		$this->jobList = $this->getMockBuilder(IJobList::class)
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->updater = new Updater(
 			$this->config,
 			$this->checker,
 			$this->logger,
-			$this->installer
+			$this->installer,
+			$this->jobList
 		);
 	}
 


### PR DESCRIPTION
* fixes #9562


To test this, add this:

```patch
diff --git a/lib/private/Authentication/Token/DefaultTokenProvider.php b/lib/private/Authentication/Token/DefaultTokenProvider.php
index 7a43dbb23e..fb2b33f564 100644
--- a/lib/private/Authentication/Token/DefaultTokenProvider.php
+++ b/lib/private/Authentication/Token/DefaultTokenProvider.php
@@ -281,9 +281,11 @@ class DefaultTokenProvider implements IProvider {
 	public function invalidateOldTokens() {
 		$olderThan = $this->time->getTime() - (int) $this->config->getSystemValue('session_lifetime', 60 * 60 * 24);
 		$this->logger->debug('Invalidating session tokens older than ' . date('c', $olderThan), ['app' => 'cron']);
+		sleep(15);
 		$this->mapper->invalidateOld($olderThan, IToken::DO_NOT_REMEMBER);
 		$rememberThreshold = $this->time->getTime() - (int) $this->config->getSystemValue('remember_login_cookie_lifetime', 60 * 60 * 24 * 15);
 		$this->logger->debug('Invalidating remembered session tokens older than ' . date('c', $rememberThreshold), ['app' => 'cron']);
+		sleep(15);
 		$this->mapper->invalidateOld($rememberThreshold, IToken::REMEMBER);
 	}
```

Then start a cron job `cron.php`, raise the version number in `version.php` or lower it in `config/config.php` and then trigger the upgrade by calling `occ upgrade`.

It then looks like this:

```
$ occ upgrade
Nextcloud or one of the apps require upgrade - only a limited number of commands are available
You may use your browser or the occ upgrade command to do the upgrade
Set log level to debug
Turned on maintenance mode
Waiting for cron to finish (checks again in 5 seconds)...
Waiting for cron to finish (checks again in 5 seconds)...
Waiting for cron to finish (checks again in 5 seconds)...
Waiting for cron to finish (checks again in 5 seconds)...
Updating database schema
Updated database
Checking for update of app activity in appstore
Checked for update of app "activity" in appstore 
Checking for update of app bruteforcesettings in appstore
Checked for update of app "bruteforcesettings" in appstore 
Checking for update of app comments in appstore
Checked for update of app "comments" in appstore 
...
```

When no cron job runs, then it looks like this:

```
$ occ upgrade
Nextcloud or one of the apps require upgrade - only a limited number of commands are available
You may use your browser or the occ upgrade command to do the upgrade
Set log level to debug
Turned on maintenance mode
Updating database schema
Updated database
Checking for update of app activity in appstore
Checked for update of app "activity" in appstore 
Checking for update of app bruteforcesettings in appstore
Checked for update of app "bruteforcesettings" in appstore 
Checking for update of app comments in appstore
Checked for update of app "comments" in appstore 
...
```

