### PR TITLE
Fixed English grammatical error on Settings page.

### DIFF
--- a/settings/l10n/af.js
+++ b/settings/l10n/af.js
@@ -28,7 +28,7 @@ OC.L10N.register(
     "png or jpg, max. 20 MB" : "png of jpg, maks. 20 MB",
     "Cancel" : "Kanselleer",
     "Choose as profile picture" : "Kies as profielprent",
-    "You are member of the following groups:" : "U is ’n lid van die volgende groepe:",
+    "You are a member of the following groups:" : "U is ’n lid van die volgende groepe:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "U gebruik <strong>%s</strong> van <strong>%s</strong> (<strong>%s %%</strong>)",
     "Your email address" : "U e-posadres",
     "No email address set" : "Geen e-posadres ingestel",

--- a/settings/l10n/af.json
+++ b/settings/l10n/af.json
@@ -26,7 +26,7 @@
     "png or jpg, max. 20 MB" : "png of jpg, maks. 20 MB",
     "Cancel" : "Kanselleer",
     "Choose as profile picture" : "Kies as profielprent",
-    "You are member of the following groups:" : "U is ’n lid van die volgende groepe:",
+    "You are a member of the following groups:" : "U is ’n lid van die volgende groepe:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "U gebruik <strong>%s</strong> van <strong>%s</strong> (<strong>%s %%</strong>)",
     "Your email address" : "U e-posadres",
     "No email address set" : "Geen e-posadres ingestel",

--- a/settings/l10n/ast.js
+++ b/settings/l10n/ast.js
@@ -95,7 +95,7 @@ OC.L10N.register(
     "png or jpg, max. 20 MB" : "png o jpg, máximu 20 MB",
     "Picture provided by original account" : "Semeya fornida pola cuenta orixinal",
     "Cancel" : "Encaboxar",
-    "You are member of the following groups:" : "Yes miembru de los grupos de darréu:",
+    "You are a member of the following groups:" : "Yes miembru de los grupos de darréu:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Tas usando <strong>%s</strong> de <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Nun s'afitó'l nome p'amosar",
     "Your email address" : "Direición de corréu-e",

--- a/settings/l10n/ast.json
+++ b/settings/l10n/ast.json
@@ -93,7 +93,7 @@
     "png or jpg, max. 20 MB" : "png o jpg, máximu 20 MB",
     "Picture provided by original account" : "Semeya fornida pola cuenta orixinal",
     "Cancel" : "Encaboxar",
-    "You are member of the following groups:" : "Yes miembru de los grupos de darréu:",
+    "You are a member of the following groups:" : "Yes miembru de los grupos de darréu:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Tas usando <strong>%s</strong> de <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Nun s'afitó'l nome p'amosar",
     "Your email address" : "Direición de corréu-e",

--- a/settings/l10n/az.js
+++ b/settings/l10n/az.js
@@ -56,7 +56,7 @@ OC.L10N.register(
     "Upload new" : "Yenisini yüklə",
     "Remove image" : "Şəkili sil",
     "Cancel" : "Dayandır",
-    "You are member of the following groups:" : "Siz göstərilən qrupların üzvüsünüz:",
+    "You are a member of the following groups:" : "Siz göstərilən qrupların üzvüsünüz:",
     "No display name set" : "Ekranda adı dəsti yoxdur",
     "Your email address" : "Sizin email ünvanı",
     "No email address set" : "Email ünvanı dəsti yoxdur",

--- a/settings/l10n/az.json
+++ b/settings/l10n/az.json
@@ -54,7 +54,7 @@
     "Upload new" : "Yenisini yüklə",
     "Remove image" : "Şəkili sil",
     "Cancel" : "Dayandır",
-    "You are member of the following groups:" : "Siz göstərilən qrupların üzvüsünüz:",
+    "You are a member of the following groups:" : "Siz göstərilən qrupların üzvüsünüz:",
     "No display name set" : "Ekranda adı dəsti yoxdur",
     "Your email address" : "Sizin email ünvanı",
     "No email address set" : "Email ünvanı dəsti yoxdur",

--- a/settings/l10n/bg.js
+++ b/settings/l10n/bg.js
@@ -67,7 +67,7 @@ OC.L10N.register(
     "Remove image" : "Премахни изображението",
     "png or jpg, max. 20 MB" : "png или jpg, макс. 20 MB",
     "Cancel" : "Отказ",
-    "You are member of the following groups:" : "Член сте на следните групи:",
+    "You are a member of the following groups:" : "Член сте на следните групи:",
     "No display name set" : "Няма настроено екранно име",
     "Your email address" : "Вашият имейл адрес",
     "No email address set" : "Няма настроен адрес на електронна поща",

--- a/settings/l10n/bg.json
+++ b/settings/l10n/bg.json
@@ -65,7 +65,7 @@
     "Remove image" : "Премахни изображението",
     "png or jpg, max. 20 MB" : "png или jpg, макс. 20 MB",
     "Cancel" : "Отказ",
-    "You are member of the following groups:" : "Член сте на следните групи:",
+    "You are a member of the following groups:" : "Член сте на следните групи:",
     "No display name set" : "Няма настроено екранно име",
     "Your email address" : "Вашият имейл адрес",
     "No email address set" : "Няма настроен адрес на електронна поща",

--- a/settings/l10n/ca.js
+++ b/settings/l10n/ca.js
@@ -101,7 +101,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Imatge proveïda per compte original",
     "Cancel" : "Cancel·la",
     "Choose as profile picture" : "Elegeix una imatge de perfil",
-    "You are member of the following groups:" : "Vostè és membre dels següents grups:",
+    "You are a member of the following groups:" : "Vostè és membre dels següents grups:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estàs fent servir <strong>%s</strong> de <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "No s'ha establert cap nom para mostrar",
     "Your email address" : "Correu electrònic",

--- a/settings/l10n/ca.json
+++ b/settings/l10n/ca.json
@@ -99,7 +99,7 @@
     "Picture provided by original account" : "Imatge proveïda per compte original",
     "Cancel" : "Cancel·la",
     "Choose as profile picture" : "Elegeix una imatge de perfil",
-    "You are member of the following groups:" : "Vostè és membre dels següents grups:",
+    "You are a member of the following groups:" : "Vostè és membre dels següents grups:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estàs fent servir <strong>%s</strong> de <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "No s'ha establert cap nom para mostrar",
     "Your email address" : "Correu electrònic",

--- a/settings/l10n/cs.js
+++ b/settings/l10n/cs.js
@@ -139,7 +139,7 @@ OC.L10N.register(
     "Cancel" : "Zrušit",
     "Choose as profile picture" : "Vybrat jako profilový obrázek",
     "Details" : "Podrobnosti",
-    "You are member of the following groups:" : "Patříte do následujících skupin:",
+    "You are a member of the following groups:" : "Patříte do následujících skupin:",
     "You are using <strong>%s</strong>" : "Používáte <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Používáte <strong>%s</strong> z <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Jméno pro zobrazení nenastaveno",

--- a/settings/l10n/cs.json
+++ b/settings/l10n/cs.json
@@ -137,7 +137,7 @@
     "Cancel" : "Zrušit",
     "Choose as profile picture" : "Vybrat jako profilový obrázek",
     "Details" : "Podrobnosti",
-    "You are member of the following groups:" : "Patříte do následujících skupin:",
+    "You are a member of the following groups:" : "Patříte do následujících skupin:",
     "You are using <strong>%s</strong>" : "Používáte <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Používáte <strong>%s</strong> z <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Jméno pro zobrazení nenastaveno",

--- a/settings/l10n/da.js
+++ b/settings/l10n/da.js
@@ -94,7 +94,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Billede leveret af den oprindelige konto",
     "Cancel" : "Annuller",
     "Choose as profile picture" : "Vælg et profilbillede",
-    "You are member of the following groups:" : "Du er medlem af følgende grupper:",
+    "You are a member of the following groups:" : "Du er medlem af følgende grupper:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Du bruger <strong>%s</strong> af <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Der er ikke angivet skærmnavn",
     "Your email address" : "Din e-mailadresse",

--- a/settings/l10n/da.json
+++ b/settings/l10n/da.json
@@ -92,7 +92,7 @@
     "Picture provided by original account" : "Billede leveret af den oprindelige konto",
     "Cancel" : "Annuller",
     "Choose as profile picture" : "Vælg et profilbillede",
-    "You are member of the following groups:" : "Du er medlem af følgende grupper:",
+    "You are a member of the following groups:" : "Du er medlem af følgende grupper:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Du bruger <strong>%s</strong> af <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Der er ikke angivet skærmnavn",
     "Your email address" : "Din e-mailadresse",

--- a/settings/l10n/de.js
+++ b/settings/l10n/de.js
@@ -150,7 +150,7 @@ OC.L10N.register(
     "Cancel" : "Abbrechen",
     "Choose as profile picture" : "Als Profilbild auswählen",
     "Details" : "Details",
-    "You are member of the following groups:" : "Du bist Mitglied folgender Gruppen:",
+    "You are a member of the following groups:" : "Du bist Mitglied folgender Gruppen:",
     "You are using <strong>%s</strong>" : "Sie benutzen <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Du benutzt <strong>%s</strong> von <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Kein Anzeigename angegeben",

--- a/settings/l10n/de.json
+++ b/settings/l10n/de.json
@@ -148,7 +148,7 @@
     "Cancel" : "Abbrechen",
     "Choose as profile picture" : "Als Profilbild auswählen",
     "Details" : "Details",
-    "You are member of the following groups:" : "Du bist Mitglied folgender Gruppen:",
+    "You are a member of the following groups:" : "Du bist Mitglied folgender Gruppen:",
     "You are using <strong>%s</strong>" : "Sie benutzen <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Du benutzt <strong>%s</strong> von <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Kein Anzeigename angegeben",

--- a/settings/l10n/de_DE.js
+++ b/settings/l10n/de_DE.js
@@ -148,7 +148,7 @@ OC.L10N.register(
     "Cancel" : "Abbrechen",
     "Choose as profile picture" : "Als Profilbild auswählen",
     "Details" : "Details",
-    "You are member of the following groups:" : "Sie sind Mitglied folgender Gruppen:",
+    "You are a member of the following groups:" : "Sie sind Mitglied folgender Gruppen:",
     "You are using <strong>%s</strong>" : "Sie benutzen <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Sie verwenden <strong>%s</strong> von <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Kein Anzeigename angegeben",

--- a/settings/l10n/de_DE.json
+++ b/settings/l10n/de_DE.json
@@ -146,7 +146,7 @@
     "Cancel" : "Abbrechen",
     "Choose as profile picture" : "Als Profilbild auswählen",
     "Details" : "Details",
-    "You are member of the following groups:" : "Sie sind Mitglied folgender Gruppen:",
+    "You are a member of the following groups:" : "Sie sind Mitglied folgender Gruppen:",
     "You are using <strong>%s</strong>" : "Sie benutzen <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Sie verwenden <strong>%s</strong> von <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Kein Anzeigename angegeben",

--- a/settings/l10n/el.js
+++ b/settings/l10n/el.js
@@ -109,7 +109,7 @@ OC.L10N.register(
     "Cancel" : "Άκυρο",
     "Choose as profile picture" : "Επιλέξτε εικόνα προφίλ",
     "Details" : "Λεπτομέρειες",
-    "You are member of the following groups:" : "Είστε μέλος των ακόλουθων ομάδων:",
+    "You are a member of the following groups:" : "Είστε μέλος των ακόλουθων ομάδων:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Χρησιμοποιείτε <strong>%s</strong> του <strong>%s</strong>(<strong>%s%%</strong>)",
     "No display name set" : "Δεν ορίστηκε όνομα",
     "Your email address" : "Η διεύθυνση ηλ. ταχυδρομείου σας",

--- a/settings/l10n/el.json
+++ b/settings/l10n/el.json
@@ -107,7 +107,7 @@
     "Cancel" : "Άκυρο",
     "Choose as profile picture" : "Επιλέξτε εικόνα προφίλ",
     "Details" : "Λεπτομέρειες",
-    "You are member of the following groups:" : "Είστε μέλος των ακόλουθων ομάδων:",
+    "You are a member of the following groups:" : "Είστε μέλος των ακόλουθων ομάδων:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Χρησιμοποιείτε <strong>%s</strong> του <strong>%s</strong>(<strong>%s%%</strong>)",
     "No display name set" : "Δεν ορίστηκε όνομα",
     "Your email address" : "Η διεύθυνση ηλ. ταχυδρομείου σας",

--- a/settings/l10n/en_GB.js
+++ b/settings/l10n/en_GB.js
@@ -148,7 +148,7 @@ OC.L10N.register(
     "Cancel" : "Cancel",
     "Choose as profile picture" : "Choose as profile picture",
     "Details" : "Details",
-    "You are member of the following groups:" : "You are member of the following groups:",
+    "You are a member of the following groups:" : "You are a member of the following groups:",
     "You are using <strong>%s</strong>" : "You are using <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "No display name set",

--- a/settings/l10n/en_GB.json
+++ b/settings/l10n/en_GB.json
@@ -146,7 +146,7 @@
     "Cancel" : "Cancel",
     "Choose as profile picture" : "Choose as profile picture",
     "Details" : "Details",
-    "You are member of the following groups:" : "You are member of the following groups:",
+    "You are a member of the following groups:" : "You are a member of the following groups:",
     "You are using <strong>%s</strong>" : "You are using <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "No display name set",

--- a/settings/l10n/es.js
+++ b/settings/l10n/es.js
@@ -150,7 +150,7 @@ OC.L10N.register(
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como imagen de perfil",
     "Details" : "Detalles",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong>" : "Estás usando <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Está usando <strong>%s</strong> de <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "No se ha establecido ningún nombre para mostrar",

--- a/settings/l10n/es.json
+++ b/settings/l10n/es.json
@@ -148,7 +148,7 @@
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como imagen de perfil",
     "Details" : "Detalles",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong>" : "Estás usando <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Está usando <strong>%s</strong> de <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "No se ha establecido ningún nombre para mostrar",

--- a/settings/l10n/es_419.js
+++ b/settings/l10n/es_419.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Imagen proporcionada por la cuenta original ",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",
     "Your email address" : "Tu dirección de correo electrónico",

--- a/settings/l10n/es_419.json
+++ b/settings/l10n/es_419.json
@@ -116,7 +116,7 @@
     "Picture provided by original account" : "Imagen proporcionada por la cuenta original ",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",
     "Your email address" : "Tu dirección de correo electrónico",

--- a/settings/l10n/es_AR.js
+++ b/settings/l10n/es_AR.js
@@ -110,7 +110,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Imagen proporcionadoa por la cuenta original ",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
-    "You are member of the following groups:" : "Usted es un miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Usted es un miembro de los siguientes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Usted está usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",
     "Your email address" : "Su dirección de correo electrónico",

--- a/settings/l10n/es_AR.json
+++ b/settings/l10n/es_AR.json
@@ -108,7 +108,7 @@
     "Picture provided by original account" : "Imagen proporcionadoa por la cuenta original ",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
-    "You are member of the following groups:" : "Usted es un miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Usted es un miembro de los siguientes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Usted está usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",
     "Your email address" : "Su dirección de correo electrónico",

--- a/settings/l10n/es_CL.js
+++ b/settings/l10n/es_CL.js
@@ -122,7 +122,7 @@ OC.L10N.register(
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
     "Details" : "Detalles",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong>" : "Estás usando<strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",

--- a/settings/l10n/es_CL.json
+++ b/settings/l10n/es_CL.json
@@ -120,7 +120,7 @@
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
     "Details" : "Detalles",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong>" : "Estás usando<strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",

--- a/settings/l10n/es_CO.js
+++ b/settings/l10n/es_CO.js
@@ -122,7 +122,7 @@ OC.L10N.register(
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
     "Details" : "Detalles",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong>" : "Estás usando<strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",

--- a/settings/l10n/es_CO.json
+++ b/settings/l10n/es_CO.json
@@ -120,7 +120,7 @@
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
     "Details" : "Detalles",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong>" : "Estás usando<strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",

--- a/settings/l10n/es_CR.js
+++ b/settings/l10n/es_CR.js
@@ -122,7 +122,7 @@ OC.L10N.register(
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
     "Details" : "Detalles",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong>" : "Estás usando<strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",

--- a/settings/l10n/es_CR.json
+++ b/settings/l10n/es_CR.json
@@ -120,7 +120,7 @@
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
     "Details" : "Detalles",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong>" : "Estás usando<strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",

--- a/settings/l10n/es_DO.js
+++ b/settings/l10n/es_DO.js
@@ -122,7 +122,7 @@ OC.L10N.register(
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
     "Details" : "Detalles",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong>" : "Estás usando<strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",

--- a/settings/l10n/es_DO.json
+++ b/settings/l10n/es_DO.json
@@ -120,7 +120,7 @@
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
     "Details" : "Detalles",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong>" : "Estás usando<strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",

--- a/settings/l10n/es_EC.js
+++ b/settings/l10n/es_EC.js
@@ -122,7 +122,7 @@ OC.L10N.register(
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
     "Details" : "Detalles",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong>" : "Estás usando<strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",

--- a/settings/l10n/es_EC.json
+++ b/settings/l10n/es_EC.json
@@ -120,7 +120,7 @@
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
     "Details" : "Detalles",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong>" : "Estás usando<strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",

--- a/settings/l10n/es_GT.js
+++ b/settings/l10n/es_GT.js
@@ -122,7 +122,7 @@ OC.L10N.register(
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
     "Details" : "Detalles",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong>" : "Estás usando<strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",

--- a/settings/l10n/es_GT.json
+++ b/settings/l10n/es_GT.json
@@ -120,7 +120,7 @@
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
     "Details" : "Detalles",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong>" : "Estás usando<strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",

--- a/settings/l10n/es_HN.js
+++ b/settings/l10n/es_HN.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Imagen proporcionada por la cuenta original ",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",
     "Your email address" : "Tu dirección de correo electrónico",

--- a/settings/l10n/es_HN.json
+++ b/settings/l10n/es_HN.json
@@ -116,7 +116,7 @@
     "Picture provided by original account" : "Imagen proporcionada por la cuenta original ",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",
     "Your email address" : "Tu dirección de correo electrónico",

--- a/settings/l10n/es_MX.js
+++ b/settings/l10n/es_MX.js
@@ -141,7 +141,7 @@ OC.L10N.register(
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
     "Details" : "Detalles",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong>" : "Estás usando<strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",

--- a/settings/l10n/es_MX.json
+++ b/settings/l10n/es_MX.json
@@ -139,7 +139,7 @@
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
     "Details" : "Detalles",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong>" : "Estás usando<strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",

--- a/settings/l10n/es_NI.js
+++ b/settings/l10n/es_NI.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Imagen proporcionada por la cuenta original ",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",
     "Your email address" : "Tu dirección de correo electrónico",

--- a/settings/l10n/es_NI.json
+++ b/settings/l10n/es_NI.json
@@ -116,7 +116,7 @@
     "Picture provided by original account" : "Imagen proporcionada por la cuenta original ",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",
     "Your email address" : "Tu dirección de correo electrónico",

--- a/settings/l10n/es_PA.js
+++ b/settings/l10n/es_PA.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Imagen proporcionada por la cuenta original ",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",
     "Your email address" : "Tu dirección de correo electrónico",

--- a/settings/l10n/es_PA.json
+++ b/settings/l10n/es_PA.json
@@ -116,7 +116,7 @@
     "Picture provided by original account" : "Imagen proporcionada por la cuenta original ",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",
     "Your email address" : "Tu dirección de correo electrónico",

--- a/settings/l10n/es_PE.js
+++ b/settings/l10n/es_PE.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Imagen proporcionada por la cuenta original ",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",
     "Your email address" : "Tu dirección de correo electrónico",

--- a/settings/l10n/es_PE.json
+++ b/settings/l10n/es_PE.json
@@ -116,7 +116,7 @@
     "Picture provided by original account" : "Imagen proporcionada por la cuenta original ",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",
     "Your email address" : "Tu dirección de correo electrónico",

--- a/settings/l10n/es_PR.js
+++ b/settings/l10n/es_PR.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Imagen proporcionada por la cuenta original ",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",
     "Your email address" : "Tu dirección de correo electrónico",

--- a/settings/l10n/es_PR.json
+++ b/settings/l10n/es_PR.json
@@ -116,7 +116,7 @@
     "Picture provided by original account" : "Imagen proporcionada por la cuenta original ",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",
     "Your email address" : "Tu dirección de correo electrónico",

--- a/settings/l10n/es_PY.js
+++ b/settings/l10n/es_PY.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Imagen proporcionada por la cuenta original ",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",
     "Your email address" : "Tu dirección de correo electrónico",

--- a/settings/l10n/es_PY.json
+++ b/settings/l10n/es_PY.json
@@ -116,7 +116,7 @@
     "Picture provided by original account" : "Imagen proporcionada por la cuenta original ",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",
     "Your email address" : "Tu dirección de correo electrónico",

--- a/settings/l10n/es_SV.js
+++ b/settings/l10n/es_SV.js
@@ -122,7 +122,7 @@ OC.L10N.register(
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
     "Details" : "Detalles",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong>" : "Estás usando<strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",

--- a/settings/l10n/es_SV.json
+++ b/settings/l10n/es_SV.json
@@ -120,7 +120,7 @@
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
     "Details" : "Detalles",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong>" : "Estás usando<strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",

--- a/settings/l10n/es_UY.js
+++ b/settings/l10n/es_UY.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Imagen proporcionada por la cuenta original ",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",
     "Your email address" : "Tu dirección de correo electrónico",

--- a/settings/l10n/es_UY.json
+++ b/settings/l10n/es_UY.json
@@ -116,7 +116,7 @@
     "Picture provided by original account" : "Imagen proporcionada por la cuenta original ",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Seleccionar como foto del perfil",
-    "You are member of the following groups:" : "Eres miembro de los siguientes grupos:",
+    "You are a member of the following groups:" : "Eres miembro de los siguientes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Estás usando <strong>%s</strong> de <strong>%s</strong> (<strong> %s %%</strong>)",
     "No display name set" : "No se ha establecido el nombre a desplegar",
     "Your email address" : "Tu dirección de correo electrónico",

--- a/settings/l10n/et_EE.js
+++ b/settings/l10n/et_EE.js
@@ -92,7 +92,7 @@ OC.L10N.register(
     "png or jpg, max. 20 MB" : "png või jpg, max. 20 MB",
     "Cancel" : "Loobu",
     "Choose as profile picture" : "Vali kui profiili pilt",
-    "You are member of the following groups:" : "Sa oled nende gruppide liige:",
+    "You are a member of the following groups:" : "Sa oled nende gruppide liige:",
     "No display name set" : "Näidatavat nime pole veel määratud",
     "Your email address" : "Sinu e-posti aadress",
     "No email address set" : "E-posti aadressi pole veel määratud",

--- a/settings/l10n/et_EE.json
+++ b/settings/l10n/et_EE.json
@@ -90,7 +90,7 @@
     "png or jpg, max. 20 MB" : "png või jpg, max. 20 MB",
     "Cancel" : "Loobu",
     "Choose as profile picture" : "Vali kui profiili pilt",
-    "You are member of the following groups:" : "Sa oled nende gruppide liige:",
+    "You are a member of the following groups:" : "Sa oled nende gruppide liige:",
     "No display name set" : "Näidatavat nime pole veel määratud",
     "Your email address" : "Sinu e-posti aadress",
     "No email address set" : "E-posti aadressi pole veel määratud",

--- a/settings/l10n/eu.js
+++ b/settings/l10n/eu.js
@@ -113,7 +113,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Irudia jatorrizko kontutik hartuta",
     "Cancel" : "Ezeztatu",
     "Choose as profile picture" : "Aukeratu profil irudi gisa",
-    "You are member of the following groups:" : "Zuk honako talde kide zara:",
+    "You are a member of the following groups:" : "Zuk honako talde kide zara:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "<strong>%s</strong> erabiltzen ari zara,<strong>%s</strong>-koa (<strong>%s %%</strong>)",
     "No display name set" : "Ez da bistaratze izena ezarri",
     "Your email address" : "Zure e-posta",

--- a/settings/l10n/eu.json
+++ b/settings/l10n/eu.json
@@ -111,7 +111,7 @@
     "Picture provided by original account" : "Irudia jatorrizko kontutik hartuta",
     "Cancel" : "Ezeztatu",
     "Choose as profile picture" : "Aukeratu profil irudi gisa",
-    "You are member of the following groups:" : "Zuk honako talde kide zara:",
+    "You are a member of the following groups:" : "Zuk honako talde kide zara:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "<strong>%s</strong> erabiltzen ari zara,<strong>%s</strong>-koa (<strong>%s %%</strong>)",
     "No display name set" : "Ez da bistaratze izena ezarri",
     "Your email address" : "Zure e-posta",

--- a/settings/l10n/fa.js
+++ b/settings/l10n/fa.js
@@ -69,7 +69,7 @@ OC.L10N.register(
     "Upload new" : "بارگذاری جدید",
     "Remove image" : "تصویر پاک شود",
     "Cancel" : "منصرف شدن",
-    "You are member of the following groups:" : "شما عضو این گروه‌ها هستید:",
+    "You are a member of the following groups:" : "شما عضو این گروه‌ها هستید:",
     "No display name set" : "هیچ نام نمایشی تعیین نشده است",
     "Your email address" : "پست الکترونیکی شما",
     "No email address set" : "آدرس‌ایمیلی تنظیم نشده است",

--- a/settings/l10n/fa.json
+++ b/settings/l10n/fa.json
@@ -67,7 +67,7 @@
     "Upload new" : "بارگذاری جدید",
     "Remove image" : "تصویر پاک شود",
     "Cancel" : "منصرف شدن",
-    "You are member of the following groups:" : "شما عضو این گروه‌ها هستید:",
+    "You are a member of the following groups:" : "شما عضو این گروه‌ها هستید:",
     "No display name set" : "هیچ نام نمایشی تعیین نشده است",
     "Your email address" : "پست الکترونیکی شما",
     "No email address set" : "آدرس‌ایمیلی تنظیم نشده است",

--- a/settings/l10n/fi.js
+++ b/settings/l10n/fi.js
@@ -137,7 +137,7 @@ OC.L10N.register(
     "Cancel" : "Peru",
     "Choose as profile picture" : "Valitse profiilikuvaksi",
     "Details" : "Yksityiskohdat",
-    "You are member of the following groups:" : "Olet jäsenenä seuraavissa ryhmissä:",
+    "You are a member of the following groups:" : "Olet jäsenenä seuraavissa ryhmissä:",
     "You are using <strong>%s</strong>" : "Käytössäsi on <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Käytössäsi on <strong>%s</strong>/<strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Näyttönimeä ei ole asetettu",

--- a/settings/l10n/fi.json
+++ b/settings/l10n/fi.json
@@ -135,7 +135,7 @@
     "Cancel" : "Peru",
     "Choose as profile picture" : "Valitse profiilikuvaksi",
     "Details" : "Yksityiskohdat",
-    "You are member of the following groups:" : "Olet jäsenenä seuraavissa ryhmissä:",
+    "You are a member of the following groups:" : "Olet jäsenenä seuraavissa ryhmissä:",
     "You are using <strong>%s</strong>" : "Käytössäsi on <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Käytössäsi on <strong>%s</strong>/<strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Näyttönimeä ei ole asetettu",

--- a/settings/l10n/fr.js
+++ b/settings/l10n/fr.js
@@ -140,7 +140,7 @@ OC.L10N.register(
     "Cancel" : "Annuler",
     "Choose as profile picture" : "Définir comme image de profil",
     "Details" : "Détails",
-    "You are member of the following groups:" : "Vous êtes membre des groupes suivants :",
+    "You are a member of the following groups:" : "Vous êtes membre des groupes suivants :",
     "You are using <strong>%s</strong>" : "Vous utilisez <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Vous utilisez <strong>%s</strong> sur <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Aucun nom d'affichage configuré",

--- a/settings/l10n/fr.json
+++ b/settings/l10n/fr.json
@@ -138,7 +138,7 @@
     "Cancel" : "Annuler",
     "Choose as profile picture" : "Définir comme image de profil",
     "Details" : "Détails",
-    "You are member of the following groups:" : "Vous êtes membre des groupes suivants :",
+    "You are a member of the following groups:" : "Vous êtes membre des groupes suivants :",
     "You are using <strong>%s</strong>" : "Vous utilisez <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Vous utilisez <strong>%s</strong> sur <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Aucun nom d'affichage configuré",

--- a/settings/l10n/he.js
+++ b/settings/l10n/he.js
@@ -137,7 +137,7 @@ OC.L10N.register(
     "Cancel" : "ביטול",
     "Choose as profile picture" : "יש לבחור כתמונת פרופיל",
     "Details" : "פרטים",
-    "You are member of the following groups:" : "הקבוצות הבאות כוללות אותך:",
+    "You are a member of the following groups:" : "הקבוצות הבאות כוללות אותך:",
     "You are using <strong>%s</strong>" : "הניצולת שלך היא <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "הניצולת שלך היא <strong>%s</strong> מתוך <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "לא נקבע שם תצוגה",

--- a/settings/l10n/he.json
+++ b/settings/l10n/he.json
@@ -135,7 +135,7 @@
     "Cancel" : "ביטול",
     "Choose as profile picture" : "יש לבחור כתמונת פרופיל",
     "Details" : "פרטים",
-    "You are member of the following groups:" : "הקבוצות הבאות כוללות אותך:",
+    "You are a member of the following groups:" : "הקבוצות הבאות כוללות אותך:",
     "You are using <strong>%s</strong>" : "הניצולת שלך היא <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "הניצולת שלך היא <strong>%s</strong> מתוך <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "לא נקבע שם תצוגה",

--- a/settings/l10n/hu.js
+++ b/settings/l10n/hu.js
@@ -121,7 +121,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Az eredeti fiók által biztosított kép.",
     "Cancel" : "Mégsem",
     "Choose as profile picture" : "Kiválasztás profil képként",
-    "You are member of the following groups:" : "Tagja vagy a következő csoport(ok)nak:",
+    "You are a member of the following groups:" : "Tagja vagy a következő csoport(ok)nak:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Jelenleg használt: <strong>%s</strong>, ebből: <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Nincs megjelenítési név beállítva",
     "Your email address" : "Az Ön e-mail címe",

--- a/settings/l10n/hu.json
+++ b/settings/l10n/hu.json
@@ -119,7 +119,7 @@
     "Picture provided by original account" : "Az eredeti fiók által biztosított kép.",
     "Cancel" : "Mégsem",
     "Choose as profile picture" : "Kiválasztás profil képként",
-    "You are member of the following groups:" : "Tagja vagy a következő csoport(ok)nak:",
+    "You are a member of the following groups:" : "Tagja vagy a következő csoport(ok)nak:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Jelenleg használt: <strong>%s</strong>, ebből: <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Nincs megjelenítési név beállítva",
     "Your email address" : "Az Ön e-mail címe",

--- a/settings/l10n/ia.js
+++ b/settings/l10n/ia.js
@@ -63,7 +63,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Pictura fornite per conto original",
     "Cancel" : "Cancellar",
     "Choose as profile picture" : "Selectiona como pictura de profilo",
-    "You are member of the following groups:" : "Tu es membro del sequente gruppos:",
+    "You are a member of the following groups:" : "Tu es membro del sequente gruppos:",
     "Your email address" : "Tu adresse de e-posta",
     "No email address set" : "Nulle adresse de e-posta definite",
     "For password reset and notifications" : "Pro reinitialisation de contrasigno e invio de notificationes",

--- a/settings/l10n/ia.json
+++ b/settings/l10n/ia.json
@@ -61,7 +61,7 @@
     "Picture provided by original account" : "Pictura fornite per conto original",
     "Cancel" : "Cancellar",
     "Choose as profile picture" : "Selectiona como pictura de profilo",
-    "You are member of the following groups:" : "Tu es membro del sequente gruppos:",
+    "You are a member of the following groups:" : "Tu es membro del sequente gruppos:",
     "Your email address" : "Tu adresse de e-posta",
     "No email address set" : "Nulle adresse de e-posta definite",
     "For password reset and notifications" : "Pro reinitialisation de contrasigno e invio de notificationes",

--- a/settings/l10n/id.js
+++ b/settings/l10n/id.js
@@ -93,7 +93,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Gambar disediakan oleh akun asli",
     "Cancel" : "Batal",
     "Choose as profile picture" : "Pilih sebagai gambar profil",
-    "You are member of the following groups:" : "Anda adalah anggota dari grup berikut:",
+    "You are a member of the following groups:" : "Anda adalah anggota dari grup berikut:",
     "No display name set" : "Nama tampilan tidak diatur",
     "Your email address" : "Alamat surel Anda",
     "No email address set" : "Alamat surel tidak diatur",

--- a/settings/l10n/id.json
+++ b/settings/l10n/id.json
@@ -91,7 +91,7 @@
     "Picture provided by original account" : "Gambar disediakan oleh akun asli",
     "Cancel" : "Batal",
     "Choose as profile picture" : "Pilih sebagai gambar profil",
-    "You are member of the following groups:" : "Anda adalah anggota dari grup berikut:",
+    "You are a member of the following groups:" : "Anda adalah anggota dari grup berikut:",
     "No display name set" : "Nama tampilan tidak diatur",
     "Your email address" : "Alamat surel Anda",
     "No email address set" : "Alamat surel tidak diatur",

--- a/settings/l10n/is.js
+++ b/settings/l10n/is.js
@@ -135,7 +135,7 @@ OC.L10N.register(
     "Cancel" : "Hætta við",
     "Choose as profile picture" : "Veldu sem einkennismynd",
     "Details" : "Nánar",
-    "You are member of the following groups:" : "Þú ert meðlimur eftirfarandi hópa:",
+    "You are a member of the following groups:" : "Þú ert meðlimur eftirfarandi hópa:",
     "You are using <strong>%s</strong>" : "Þú ert að nota <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "You are using <strong>%s</strong> af <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Ekkert birtingarnafn sett",

--- a/settings/l10n/is.json
+++ b/settings/l10n/is.json
@@ -133,7 +133,7 @@
     "Cancel" : "Hætta við",
     "Choose as profile picture" : "Veldu sem einkennismynd",
     "Details" : "Nánar",
-    "You are member of the following groups:" : "Þú ert meðlimur eftirfarandi hópa:",
+    "You are a member of the following groups:" : "Þú ert meðlimur eftirfarandi hópa:",
     "You are using <strong>%s</strong>" : "Þú ert að nota <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "You are using <strong>%s</strong> af <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Ekkert birtingarnafn sett",

--- a/settings/l10n/it.js
+++ b/settings/l10n/it.js
@@ -150,7 +150,7 @@ OC.L10N.register(
     "Cancel" : "Annulla",
     "Choose as profile picture" : "Scegli come immagine del profilo",
     "Details" : "Dettagli",
-    "You are member of the following groups:" : "Sei membro dei seguenti gruppi:",
+    "You are a member of the following groups:" : "Sei membro dei seguenti gruppi:",
     "You are using <strong>%s</strong>" : "Stai utilizzando <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Stai utilizzando <strong>%s</strong> di <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Nome visualizzato non impostato",

--- a/settings/l10n/it.json
+++ b/settings/l10n/it.json
@@ -148,7 +148,7 @@
     "Cancel" : "Annulla",
     "Choose as profile picture" : "Scegli come immagine del profilo",
     "Details" : "Dettagli",
-    "You are member of the following groups:" : "Sei membro dei seguenti gruppi:",
+    "You are a member of the following groups:" : "Sei membro dei seguenti gruppi:",
     "You are using <strong>%s</strong>" : "Stai utilizzando <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Stai utilizzando <strong>%s</strong> di <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Nome visualizzato non impostato",

--- a/settings/l10n/ja.js
+++ b/settings/l10n/ja.js
@@ -117,7 +117,7 @@ OC.L10N.register(
     "Picture provided by original account" : "オリジナルのアカウントで提供されている写真",
     "Cancel" : "キャンセル",
     "Choose as profile picture" : "プロファイル画像として選択",
-    "You are member of the following groups:" : "次のグループのメンバー:",
+    "You are a member of the following groups:" : "次のグループのメンバー:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "<strong>%s</strong> / <strong>%s</strong> (<strong>%s %%</strong>) 使用中",
     "No display name set" : "表示名が未設定",
     "Your email address" : "あなたのメールアドレス",

--- a/settings/l10n/ja.json
+++ b/settings/l10n/ja.json
@@ -115,7 +115,7 @@
     "Picture provided by original account" : "オリジナルのアカウントで提供されている写真",
     "Cancel" : "キャンセル",
     "Choose as profile picture" : "プロファイル画像として選択",
-    "You are member of the following groups:" : "次のグループのメンバー:",
+    "You are a member of the following groups:" : "次のグループのメンバー:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "<strong>%s</strong> / <strong>%s</strong> (<strong>%s %%</strong>) 使用中",
     "No display name set" : "表示名が未設定",
     "Your email address" : "あなたのメールアドレス",

--- a/settings/l10n/ka_GE.js
+++ b/settings/l10n/ka_GE.js
@@ -121,7 +121,7 @@ OC.L10N.register(
     "Picture provided by original account" : "სურათი ორიგინალი ანგარიშიდან",
     "Cancel" : "უარყოფა",
     "Choose as profile picture" : "აირჩიეთ პროფილის სურათად",
-    "You are member of the following groups:" : "თქვენ ხართ შემდეგი ჯგუფების წევრი:",
+    "You are a member of the following groups:" : "თქვენ ხართ შემდეგი ჯგუფების წევრი:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "თქვენ იყენებთ <strong>%s</strong> სულ <strong>%s</strong>-დან (<strong>%s%%</strong>)",
     "No display name set" : "დისპლეი სახელი არაა დაყენებული",
     "Your email address" : "თქვენი ელ-ფოსტის მისამართი",

--- a/settings/l10n/ka_GE.json
+++ b/settings/l10n/ka_GE.json
@@ -119,7 +119,7 @@
     "Picture provided by original account" : "სურათი ორიგინალი ანგარიშიდან",
     "Cancel" : "უარყოფა",
     "Choose as profile picture" : "აირჩიეთ პროფილის სურათად",
-    "You are member of the following groups:" : "თქვენ ხართ შემდეგი ჯგუფების წევრი:",
+    "You are a member of the following groups:" : "თქვენ ხართ შემდეგი ჯგუფების წევრი:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "თქვენ იყენებთ <strong>%s</strong> სულ <strong>%s</strong>-დან (<strong>%s%%</strong>)",
     "No display name set" : "დისპლეი სახელი არაა დაყენებული",
     "Your email address" : "თქვენი ელ-ფოსტის მისამართი",

--- a/settings/l10n/ko.js
+++ b/settings/l10n/ko.js
@@ -120,7 +120,7 @@ OC.L10N.register(
     "Picture provided by original account" : "원래 계정에서 제공하는 사진",
     "Cancel" : "취소",
     "Choose as profile picture" : "프로필 사진으로 선택",
-    "You are member of the following groups:" : "다음 그룹의 구성원입니다:",
+    "You are a member of the following groups:" : "다음 그룹의 구성원입니다:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "현재 <strong>%s</strong>/<strong>%s</strong>(<strong>%s%%</strong>)를 사용하고 있습니다",
     "No display name set" : "표시 이름이 설정되지 않음",
     "Your email address" : "이메일 주소",

--- a/settings/l10n/ko.json
+++ b/settings/l10n/ko.json
@@ -118,7 +118,7 @@
     "Picture provided by original account" : "원래 계정에서 제공하는 사진",
     "Cancel" : "취소",
     "Choose as profile picture" : "프로필 사진으로 선택",
-    "You are member of the following groups:" : "다음 그룹의 구성원입니다:",
+    "You are a member of the following groups:" : "다음 그룹의 구성원입니다:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "현재 <strong>%s</strong>/<strong>%s</strong>(<strong>%s%%</strong>)를 사용하고 있습니다",
     "No display name set" : "표시 이름이 설정되지 않음",
     "Your email address" : "이메일 주소",

--- a/settings/l10n/lt_LT.js
+++ b/settings/l10n/lt_LT.js
@@ -55,7 +55,7 @@ OC.L10N.register(
     "Remove image" : "Šalinti paveikslą",
     "png or jpg, max. 20 MB" : "png arba jpg, daugiausiai 20 MB",
     "Cancel" : "Atsisakyti",
-    "You are member of the following groups:" : "Jūs esate šių grupių narys:",
+    "You are a member of the following groups:" : "Jūs esate šių grupių narys:",
     "You are using <strong>%s</strong>" : "Jūs naudojate <strong>%s</strong>",
     "Your email address" : "Jūsų el. pašto adresas",
     "No email address set" : "Nenustatytas joks el. pašto adresas",

--- a/settings/l10n/lt_LT.json
+++ b/settings/l10n/lt_LT.json
@@ -53,7 +53,7 @@
     "Remove image" : "Šalinti paveikslą",
     "png or jpg, max. 20 MB" : "png arba jpg, daugiausiai 20 MB",
     "Cancel" : "Atsisakyti",
-    "You are member of the following groups:" : "Jūs esate šių grupių narys:",
+    "You are a member of the following groups:" : "Jūs esate šių grupių narys:",
     "You are using <strong>%s</strong>" : "Jūs naudojate <strong>%s</strong>",
     "Your email address" : "Jūsų el. pašto adresas",
     "No email address set" : "Nenustatytas joks el. pašto adresas",

--- a/settings/l10n/lv.js
+++ b/settings/l10n/lv.js
@@ -81,7 +81,7 @@ OC.L10N.register(
     "png or jpg, max. 20 MB" : "png vai jpg, max. 20 MB",
     "Cancel" : "Atcelt",
     "Choose as profile picture" : "Izvēlēties kā profila attēlu",
-    "You are member of the following groups:" : "Jūs esat šādu grupu biedrs:",
+    "You are a member of the following groups:" : "Jūs esat šādu grupu biedrs:",
     "No display name set" : "Nav norādīts ekrāna vārds",
     "Your email address" : "Jūsu e-pasta adrese",
     "No email address set" : "Nav norādīts e-pasts",

--- a/settings/l10n/lv.json
+++ b/settings/l10n/lv.json
@@ -79,7 +79,7 @@
     "png or jpg, max. 20 MB" : "png vai jpg, max. 20 MB",
     "Cancel" : "Atcelt",
     "Choose as profile picture" : "Izvēlēties kā profila attēlu",
-    "You are member of the following groups:" : "Jūs esat šādu grupu biedrs:",
+    "You are a member of the following groups:" : "Jūs esat šādu grupu biedrs:",
     "No display name set" : "Nav norādīts ekrāna vārds",
     "Your email address" : "Jūsu e-pasta adrese",
     "No email address set" : "Nav norādīts e-pasts",

--- a/settings/l10n/mn.js
+++ b/settings/l10n/mn.js
@@ -27,7 +27,7 @@ OC.L10N.register(
     "Remove image" : "Зургийг хасах",
     "Cancel" : "Цуцлах",
     "Choose as profile picture" : "Профайл зургаа сонгоно уу",
-    "You are member of the following groups:" : "Та дараах бүлгүүдийн гишүүн:",
+    "You are a member of the following groups:" : "Та дараах бүлгүүдийн гишүүн:",
     "Phone number" : "Утасны дугаар",
     "Your phone number" : "Таны утасны дугаар",
     "Address" : "Хаяг",

--- a/settings/l10n/mn.json
+++ b/settings/l10n/mn.json
@@ -25,7 +25,7 @@
     "Remove image" : "Зургийг хасах",
     "Cancel" : "Цуцлах",
     "Choose as profile picture" : "Профайл зургаа сонгоно уу",
-    "You are member of the following groups:" : "Та дараах бүлгүүдийн гишүүн:",
+    "You are a member of the following groups:" : "Та дараах бүлгүүдийн гишүүн:",
     "Phone number" : "Утасны дугаар",
     "Your phone number" : "Таны утасны дугаар",
     "Address" : "Хаяг",

--- a/settings/l10n/nb.js
+++ b/settings/l10n/nb.js
@@ -121,7 +121,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Bilde kommer fra opprinnelig konto",
     "Cancel" : "Avbryt",
     "Choose as profile picture" : "Velg som profilbilde",
-    "You are member of the following groups:" : "Du er medlem av følgende grupper:",
+    "You are a member of the following groups:" : "Du er medlem av følgende grupper:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Du bruker <strong>%s</strong> av <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Visningsnavn ikke satt",
     "Your email address" : "Din e-postadresse",

--- a/settings/l10n/nb.json
+++ b/settings/l10n/nb.json
@@ -119,7 +119,7 @@
     "Picture provided by original account" : "Bilde kommer fra opprinnelig konto",
     "Cancel" : "Avbryt",
     "Choose as profile picture" : "Velg som profilbilde",
-    "You are member of the following groups:" : "Du er medlem av følgende grupper:",
+    "You are a member of the following groups:" : "Du er medlem av følgende grupper:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Du bruker <strong>%s</strong> av <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Visningsnavn ikke satt",
     "Your email address" : "Din e-postadresse",

--- a/settings/l10n/nl.js
+++ b/settings/l10n/nl.js
@@ -125,7 +125,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Afbeelding is verstrekt door originele account.",
     "Cancel" : "Annuleren",
     "Choose as profile picture" : "Kies als profielafbeelding",
-    "You are member of the following groups:" : "Je bent lid van de volgende groepen:",
+    "You are a member of the following groups:" : "Je bent lid van de volgende groepen:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Je gebruikt <strong>%s</strong> van <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Nog geen weergavenaam ingesteld",
     "Your email address" : "Je e-mailadres",

--- a/settings/l10n/nl.json
+++ b/settings/l10n/nl.json
@@ -123,7 +123,7 @@
     "Picture provided by original account" : "Afbeelding is verstrekt door originele account.",
     "Cancel" : "Annuleren",
     "Choose as profile picture" : "Kies als profielafbeelding",
-    "You are member of the following groups:" : "Je bent lid van de volgende groepen:",
+    "You are a member of the following groups:" : "Je bent lid van de volgende groepen:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Je gebruikt <strong>%s</strong> van <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Nog geen weergavenaam ingesteld",
     "Your email address" : "Je e-mailadres",

--- a/settings/l10n/pl.js
+++ b/settings/l10n/pl.js
@@ -121,7 +121,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Zdjęcie dostarczone przez oryginalne konto",
     "Cancel" : "Anuluj",
     "Choose as profile picture" : "Wybierz zdjęcie profilowe",
-    "You are member of the following groups:" : "Należysz do następujących grup:",
+    "You are a member of the following groups:" : "Należysz do następujących grup:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Używasz <strong>%s</strong> z <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Brak nazwa wyświetlanej",
     "Your email address" : "Twój adres e-mail",

--- a/settings/l10n/pl.json
+++ b/settings/l10n/pl.json
@@ -119,7 +119,7 @@
     "Picture provided by original account" : "Zdjęcie dostarczone przez oryginalne konto",
     "Cancel" : "Anuluj",
     "Choose as profile picture" : "Wybierz zdjęcie profilowe",
-    "You are member of the following groups:" : "Należysz do następujących grup:",
+    "You are a member of the following groups:" : "Należysz do następujących grup:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Używasz <strong>%s</strong> z <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Brak nazwa wyświetlanej",
     "Your email address" : "Twój adres e-mail",

--- a/settings/l10n/pt_BR.js
+++ b/settings/l10n/pt_BR.js
@@ -150,7 +150,7 @@ OC.L10N.register(
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Escolha como imagem de perfil",
     "Details" : "Detalhes",
-    "You are member of the following groups:" : "Você é membro dos seguintes grupos:",
+    "You are a member of the following groups:" : "Você é membro dos seguintes grupos:",
     "You are using <strong>%s</strong>" : "Você está usando <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Você está usando <strong>%s</strong> de <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Nenhum nome de exibição definido",

--- a/settings/l10n/pt_BR.json
+++ b/settings/l10n/pt_BR.json
@@ -148,7 +148,7 @@
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Escolha como imagem de perfil",
     "Details" : "Detalhes",
-    "You are member of the following groups:" : "Você é membro dos seguintes grupos:",
+    "You are a member of the following groups:" : "Você é membro dos seguintes grupos:",
     "You are using <strong>%s</strong>" : "Você está usando <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Você está usando <strong>%s</strong> de <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Nenhum nome de exibição definido",

--- a/settings/l10n/pt_PT.js
+++ b/settings/l10n/pt_PT.js
@@ -119,7 +119,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Imagem fornecida pela conta original",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Escolher como fotografia de perfil",
-    "You are member of the following groups:" : "Você é membro dos seguintes grupos:",
+    "You are a member of the following groups:" : "Você é membro dos seguintes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Está a usar <strong>%s</strong> de <strong>%s</strong> (<strong>%s%%</strong>)",
     "No display name set" : "Nenhum nome display estabelecido",
     "Your email address" : "O seu endereço de email",

--- a/settings/l10n/pt_PT.json
+++ b/settings/l10n/pt_PT.json
@@ -117,7 +117,7 @@
     "Picture provided by original account" : "Imagem fornecida pela conta original",
     "Cancel" : "Cancelar",
     "Choose as profile picture" : "Escolher como fotografia de perfil",
-    "You are member of the following groups:" : "Você é membro dos seguintes grupos:",
+    "You are a member of the following groups:" : "Você é membro dos seguintes grupos:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Está a usar <strong>%s</strong> de <strong>%s</strong> (<strong>%s%%</strong>)",
     "No display name set" : "Nenhum nome display estabelecido",
     "Your email address" : "O seu endereço de email",

--- a/settings/l10n/ru.js
+++ b/settings/l10n/ru.js
@@ -150,7 +150,7 @@ OC.L10N.register(
     "Cancel" : "Отмена",
     "Choose as profile picture" : "Выбрать в качестве картинки профиля",
     "Details" : "Подробности",
-    "You are member of the following groups:" : "Вы являетесь членом следующих групп:",
+    "You are a member of the following groups:" : "Вы являетесь членом следующих групп:",
     "You are using <strong>%s</strong>" : "Вы используете <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Вы используете <strong>%s</strong> из <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Отображаемое имя не указано",

--- a/settings/l10n/ru.json
+++ b/settings/l10n/ru.json
@@ -148,7 +148,7 @@
     "Cancel" : "Отмена",
     "Choose as profile picture" : "Выбрать в качестве картинки профиля",
     "Details" : "Подробности",
-    "You are member of the following groups:" : "Вы являетесь членом следующих групп:",
+    "You are a member of the following groups:" : "Вы являетесь членом следующих групп:",
     "You are using <strong>%s</strong>" : "Вы используете <strong>%s</strong>",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Вы используете <strong>%s</strong> из <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Отображаемое имя не указано",

--- a/settings/l10n/sk.js
+++ b/settings/l10n/sk.js
@@ -114,7 +114,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Obrázok poskytnutý originálnym účtom",
     "Cancel" : "Zrušiť",
     "Choose as profile picture" : "Použiť ako obrázok avatara",
-    "You are member of the following groups:" : "Ste členom nasledovných skupín:",
+    "You are a member of the following groups:" : "Ste členom nasledovných skupín:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Využívate <strong>%s</strong> z <strong>%s</strong>(<strong>%s%%</strong>)",
     "No display name set" : "Zobrazované meno nie je nastavené",
     "Your email address" : "Vaša emailová adresa",

--- a/settings/l10n/sk.json
+++ b/settings/l10n/sk.json
@@ -112,7 +112,7 @@
     "Picture provided by original account" : "Obrázok poskytnutý originálnym účtom",
     "Cancel" : "Zrušiť",
     "Choose as profile picture" : "Použiť ako obrázok avatara",
-    "You are member of the following groups:" : "Ste členom nasledovných skupín:",
+    "You are a member of the following groups:" : "Ste členom nasledovných skupín:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Využívate <strong>%s</strong> z <strong>%s</strong>(<strong>%s%%</strong>)",
     "No display name set" : "Zobrazované meno nie je nastavené",
     "Your email address" : "Vaša emailová adresa",

--- a/settings/l10n/sl.js
+++ b/settings/l10n/sl.js
@@ -81,7 +81,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Slika iz originalnega računa",
     "Cancel" : "Prekliči",
     "Choose as profile picture" : "Izberi kot sliko profila",
-    "You are member of the following groups:" : "Ste član naslednjih skupin:",
+    "You are a member of the following groups:" : "Ste član naslednjih skupin:",
     "No display name set" : "Prikazno ime ni nastavljeno",
     "Your email address" : "Osebni elektronski naslov",
     "No email address set" : "Poštni naslov ni nastavljen",

--- a/settings/l10n/sl.json
+++ b/settings/l10n/sl.json
@@ -79,7 +79,7 @@
     "Picture provided by original account" : "Slika iz originalnega računa",
     "Cancel" : "Prekliči",
     "Choose as profile picture" : "Izberi kot sliko profila",
-    "You are member of the following groups:" : "Ste član naslednjih skupin:",
+    "You are a member of the following groups:" : "Ste član naslednjih skupin:",
     "No display name set" : "Prikazno ime ni nastavljeno",
     "Your email address" : "Osebni elektronski naslov",
     "No email address set" : "Poštni naslov ni nastavljen",

--- a/settings/l10n/sq.js
+++ b/settings/l10n/sq.js
@@ -113,7 +113,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Foto e prurë nga llogaria origjinale",
     "Cancel" : "Anuloje",
     "Choose as profile picture" : "Zgjidhni një foto profili",
-    "You are member of the following groups:" : "Jeni anëtar i grupeve vijuese:",
+    "You are a member of the following groups:" : "Jeni anëtar i grupeve vijuese:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Ju po përdorni <strong>%s</strong> të <strong>%s</strong> (<strong>%s%%</strong>)",
     "No display name set" : "S’është caktuar emër për në ekran",
     "Your email address" : "Adresa juaj email",

--- a/settings/l10n/sq.json
+++ b/settings/l10n/sq.json
@@ -111,7 +111,7 @@
     "Picture provided by original account" : "Foto e prurë nga llogaria origjinale",
     "Cancel" : "Anuloje",
     "Choose as profile picture" : "Zgjidhni një foto profili",
-    "You are member of the following groups:" : "Jeni anëtar i grupeve vijuese:",
+    "You are a member of the following groups:" : "Jeni anëtar i grupeve vijuese:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Ju po përdorni <strong>%s</strong> të <strong>%s</strong> (<strong>%s%%</strong>)",
     "No display name set" : "S’është caktuar emër për në ekran",
     "Your email address" : "Adresa juaj email",

--- a/settings/l10n/sr.js
+++ b/settings/l10n/sr.js
@@ -148,7 +148,7 @@ OC.L10N.register(
     "Cancel" : "Одустани",
     "Choose as profile picture" : "Одаберите слику профила",
     "Details" : "Детаљи",
-    "You are member of the following groups:" : "Члан сте следећих група:",
+    "You are a member of the following groups:" : "Члан сте следећих група:",
     "You are using <strong>%s</strong>" : "Користите <strong>%s</strong>.",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Користите <strong>%s</strong> од <strong>%s</strong> (<strong>%s%%</strong>)",
     "No display name set" : "Није постављено име за приказ",

--- a/settings/l10n/sr.json
+++ b/settings/l10n/sr.json
@@ -146,7 +146,7 @@
     "Cancel" : "Одустани",
     "Choose as profile picture" : "Одаберите слику профила",
     "Details" : "Детаљи",
-    "You are member of the following groups:" : "Члан сте следећих група:",
+    "You are a member of the following groups:" : "Члан сте следећих група:",
     "You are using <strong>%s</strong>" : "Користите <strong>%s</strong>.",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Користите <strong>%s</strong> од <strong>%s</strong> (<strong>%s%%</strong>)",
     "No display name set" : "Није постављено име за приказ",

--- a/settings/l10n/sv.js
+++ b/settings/l10n/sv.js
@@ -117,7 +117,7 @@ OC.L10N.register(
     "Picture provided by original account" : "Bild gjordes tillgänglig av orginalkonto",
     "Cancel" : "Avbryt",
     "Choose as profile picture" : "Välj som profilbild",
-    "You are member of the following groups:" : "Du är medlem i följande grupper:",
+    "You are a member of the following groups:" : "Du är medlem i följande grupper:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Du använder <strong>%s</strong> av <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Inget visningsnamn angivet",
     "Your email address" : "Din e-postadress",

--- a/settings/l10n/sv.json
+++ b/settings/l10n/sv.json
@@ -115,7 +115,7 @@
     "Picture provided by original account" : "Bild gjordes tillgänglig av orginalkonto",
     "Cancel" : "Avbryt",
     "Choose as profile picture" : "Välj som profilbild",
-    "You are member of the following groups:" : "Du är medlem i följande grupper:",
+    "You are a member of the following groups:" : "Du är medlem i följande grupper:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Du använder <strong>%s</strong> av <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Inget visningsnamn angivet",
     "Your email address" : "Din e-postadress",

--- a/settings/l10n/th.js
+++ b/settings/l10n/th.js
@@ -83,7 +83,7 @@ OC.L10N.register(
     "Picture provided by original account" : "ใช้รูปภาพจากบัญชีเดิม",
     "Cancel" : "ยกเลิก",
     "Choose as profile picture" : "เลือกรูปภาพโปรไฟล์",
-    "You are member of the following groups:" : "คุณเป็นสมาชิกของกลุ่มต่อไปนี้:",
+    "You are a member of the following groups:" : "คุณเป็นสมาชิกของกลุ่มต่อไปนี้:",
     "No display name set" : "ไม่มีชื่อที่แสดง",
     "Your email address" : "ที่อยู่อีเมล์ของคุณ",
     "No email address set" : "ไม่ได้ตั้งค่าที่อยู่อีเมล",

--- a/settings/l10n/th.json
+++ b/settings/l10n/th.json
@@ -81,7 +81,7 @@
     "Picture provided by original account" : "ใช้รูปภาพจากบัญชีเดิม",
     "Cancel" : "ยกเลิก",
     "Choose as profile picture" : "เลือกรูปภาพโปรไฟล์",
-    "You are member of the following groups:" : "คุณเป็นสมาชิกของกลุ่มต่อไปนี้:",
+    "You are a member of the following groups:" : "คุณเป็นสมาชิกของกลุ่มต่อไปนี้:",
     "No display name set" : "ไม่มีชื่อที่แสดง",
     "Your email address" : "ที่อยู่อีเมล์ของคุณ",
     "No email address set" : "ไม่ได้ตั้งค่าที่อยู่อีเมล",

--- a/settings/l10n/tr.js
+++ b/settings/l10n/tr.js
@@ -150,7 +150,7 @@ OC.L10N.register(
     "Cancel" : "İptal",
     "Choose as profile picture" : "Profil görseli olarak seç",
     "Details" : "Ayrıntılar",
-    "You are member of the following groups:" : "Şu gruplara üyesiniz:",
+    "You are a member of the following groups:" : "Şu gruplara üyesiniz:",
     "You are using <strong>%s</strong>" : "<strong>%s</strong> kullanıyorsunuz",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Kullandığınız: <strong>%s</strong> Kullanabileceğiniz: <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Görüntülenecek ad belirtilmemiş",

--- a/settings/l10n/tr.json
+++ b/settings/l10n/tr.json
@@ -148,7 +148,7 @@
     "Cancel" : "İptal",
     "Choose as profile picture" : "Profil görseli olarak seç",
     "Details" : "Ayrıntılar",
-    "You are member of the following groups:" : "Şu gruplara üyesiniz:",
+    "You are a member of the following groups:" : "Şu gruplara üyesiniz:",
     "You are using <strong>%s</strong>" : "<strong>%s</strong> kullanıyorsunuz",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "Kullandığınız: <strong>%s</strong> Kullanabileceğiniz: <strong>%s</strong> (<strong>%s %%</strong>)",
     "No display name set" : "Görüntülenecek ad belirtilmemiş",

--- a/settings/l10n/uk.js
+++ b/settings/l10n/uk.js
@@ -70,7 +70,7 @@ OC.L10N.register(
     "Remove image" : "Видалити зображення",
     "Cancel" : "Відмінити",
     "Choose as profile picture" : "Обрати як зображення для профілю",
-    "You are member of the following groups:" : "Ви є членом наступних груп:",
+    "You are a member of the following groups:" : "Ви є членом наступних груп:",
     "No display name set" : "Коротке ім'я не вказано",
     "Your email address" : "Ваша адреса електронної пошти",
     "No email address set" : "E-mail не вказано",

--- a/settings/l10n/uk.json
+++ b/settings/l10n/uk.json
@@ -68,7 +68,7 @@
     "Remove image" : "Видалити зображення",
     "Cancel" : "Відмінити",
     "Choose as profile picture" : "Обрати як зображення для профілю",
-    "You are member of the following groups:" : "Ви є членом наступних груп:",
+    "You are a member of the following groups:" : "Ви є членом наступних груп:",
     "No display name set" : "Коротке ім'я не вказано",
     "Your email address" : "Ваша адреса електронної пошти",
     "No email address set" : "E-mail не вказано",

--- a/settings/l10n/zh_CN.js
+++ b/settings/l10n/zh_CN.js
@@ -119,7 +119,7 @@ OC.L10N.register(
     "Picture provided by original account" : "原始账户图片",
     "Cancel" : "取消",
     "Choose as profile picture" : "选择个人头像",
-    "You are member of the following groups:" : "您是以下组的成员:",
+    "You are a member of the following groups:" : "您是以下组的成员:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "你使用了<strong>%s</strong>的<strong>%s</strong>(<strong>%s %%</strong>)",
     "No display name set" : "不显示名称设置",
     "Your email address" : "您的电子邮件",

--- a/settings/l10n/zh_CN.json
+++ b/settings/l10n/zh_CN.json
@@ -117,7 +117,7 @@
     "Picture provided by original account" : "原始账户图片",
     "Cancel" : "取消",
     "Choose as profile picture" : "选择个人头像",
-    "You are member of the following groups:" : "您是以下组的成员:",
+    "You are a member of the following groups:" : "您是以下组的成员:",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "你使用了<strong>%s</strong>的<strong>%s</strong>(<strong>%s %%</strong>)",
     "No display name set" : "不显示名称设置",
     "Your email address" : "您的电子邮件",

--- a/settings/l10n/zh_TW.js
+++ b/settings/l10n/zh_TW.js
@@ -116,7 +116,7 @@ OC.L10N.register(
     "Picture provided by original account" : "原本的帳戶提供的圖片",
     "Cancel" : "取消",
     "Choose as profile picture" : "設定為大頭貼照",
-    "You are member of the following groups:" : "您的帳號屬於這些群組：",
+    "You are a member of the following groups:" : "您的帳號屬於這些群組：",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "您正在使用 <strong>%s</strong> ，共有 <strong>%s</strong>（<strong>%s %%</strong>）",
     "No display name set" : "未設定顯示名稱",
     "Your email address" : "您的電子郵件信箱",

--- a/settings/l10n/zh_TW.json
+++ b/settings/l10n/zh_TW.json
@@ -114,7 +114,7 @@
     "Picture provided by original account" : "原本的帳戶提供的圖片",
     "Cancel" : "取消",
     "Choose as profile picture" : "設定為大頭貼照",
-    "You are member of the following groups:" : "您的帳號屬於這些群組：",
+    "You are a member of the following groups:" : "您的帳號屬於這些群組：",
     "You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)" : "您正在使用 <strong>%s</strong> ，共有 <strong>%s</strong>（<strong>%s %%</strong>）",
     "No display name set" : "未設定顯示名稱",
     "Your email address" : "您的電子郵件信箱",

--- a/settings/templates/settings/personal/personal.info.php
+++ b/settings/templates/settings/personal/personal.info.php
@@ -78,7 +78,7 @@ vendor_style('jcrop/css/jquery.Jcrop');
 		<div class="personal-settings-setting-box personal-settings-group-box section">
 			<h2><?php p($l->t('Details')); ?></h2>
 			<div id="groups" class="personal-info icon-user">
-				<p class="icon-groups"><?php p($l->t('You are member of the following groups:')); ?></p>
+				<p class="icon-groups"><?php p($l->t('You are a member of the following groups:')); ?></p>
 				<p id="groups-groups">
 					<strong><?php p(implode(', ', $_['groups'])); ?></strong>
 				</p>


### PR DESCRIPTION

Original:
`You are member of the following groups:`
Updated:
`You are a member of the following groups:`

Grammatical error appears on `https://domain.com/settings/user` page