### PR TITLE
Fix files_external settings layout

### DIFF
--- a/apps/files_external/css/settings.scss
+++ b/apps/files_external/css/settings.scss
@@ -1,7 +1,3 @@
-#global_credentials {
-	padding: 0 30px;
-}
-
 #files_external {
 	margin-bottom: 0px;
 }

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -169,7 +169,6 @@
 		<label for="allowUserMounting"><?php p($l->t('Allow users to mount external storage')); ?></label> <span id="userMountingMsg" class="msg"></span>
 
 		<p id="userMountingBackends"<?php if (!$_['allowUserMounting']): ?> class="hidden"<?php endif; ?>>
-			<?php p($l->t('Allow users to mount the following external storage')); ?><br />
 			<?php
 				$userBackends = array_filter($_['backends'], function($backend) {
 					return $backend->isAllowedVisibleFor(BackendService::VISIBILITY_PERSONAL);
@@ -189,9 +188,10 @@
 </form>
 
 <?php if ($canCreateMounts): ?>
-	<form autocomplete="false" class="section" action="#"
+<div class="followupsection">
+	<form autocomplete="false" action="#"
 		  id="global_credentials">
-		<p><?php p($l->t('Global credentials')); ?></p>
+		<h2><?php p($l->t('Global credentials')); ?></h2>
 		<input type="text" name="username"
 			   autocomplete="false"
 			   value="<?php p($_['globalCredentials']['user']); ?>"
@@ -204,4 +204,5 @@
 			   value="<?php p($_['globalCredentialsUid']); ?>"/>
 		<input type="submit" value="<?php p($l->t('Save')) ?>"/>
 	</form>
+</div>
 <?php endif; ?>


### PR DESCRIPTION
Fix spacing of the global credentials section and remove duplicate text regarding the user allowed external storages

Before:
![image](https://user-images.githubusercontent.com/3404133/41716816-fa780efe-7557-11e8-98d6-cd1d47922540.png)

After:
![image](https://user-images.githubusercontent.com/3404133/41716790-e5d650f0-7557-11e8-9ca2-a5ef266949c4.png)

@nextcloud/designers 
