### PR TITLE
Request a valid property for DAV opendir

### DIFF
--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -206,7 +206,7 @@ class DAV extends Common {
 		try {
 			$response = $this->client->propFind(
 				$this->encodePath($path),
-				['{DAV:}href'],
+				['{DAV:}getetag'],
 				1
 			);
 			if ($response === false) {


### PR DESCRIPTION
Apperently Sabre and Onedrive (webdav endpoin) are not friends when requesting a single
404 property. I need to dig deeper on why this is. Anyways requesting a
valid property makes it work like a charm.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>