### PR TITLE
[stable13] Log full exception in cron instead of only the message

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -155,7 +155,7 @@ try {
 	exit();
 
 } catch (Exception $ex) {
-	\OCP\Util::writeLog('cron', $ex->getMessage(), \OCP\Util::FATAL);
+	\OC::$server->getLogger()->logException($ex, ['app' => 'cron']);
 } catch (Error $ex) {
-	\OCP\Util::writeLog('cron', $ex->getMessage(), \OCP\Util::FATAL);
+	\OC::$server->getLogger()->logException($ex, ['app' => 'cron']);
 }


### PR DESCRIPTION
Backport of #7818 (#7820 was somehow against master)

