### PR TITLE
Replace "wd_host" directly in "behat.yml" instead of through "BEHAT_PARAMS"

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -27,14 +27,18 @@ default:
     Behat\MinkExtension:
       sessions:
         default:
-          selenium2: ~
+          selenium2:
+            wd_host: %selenium.server%
         John:
-          selenium2: ~
+          selenium2:
+            wd_host: %selenium.server%
         Jane:
-          selenium2: ~
+          selenium2:
+            wd_host: %selenium.server%
         Rubeus:
           # Rubeus uses a browser that has CSS grid support.
           selenium2:
+            wd_host: %selenium.server%
             capabilities:
               firefox:
                 profile: %paths.base%/firefox-profiles/css-grid-enabled.zip

--- a/tests/acceptance/run-local.sh
+++ b/tests/acceptance/run-local.sh
@@ -160,9 +160,9 @@ if [ "$NEXTCLOUD_SERVER_DOMAIN" != "$DEFAULT_NEXTCLOUD_SERVER_DOMAIN" ]; then
 fi
 
 # Due to a bug in the Mink Extension for Behat it is not possible to use the
-# "paths.base" parameter in the path to the custom Firefox profile. Thus, the
+# "paths.base" variable in the path to the custom Firefox profile. Thus, the
 # default "behat.yml" configuration file has to be adjusted to replace the
-# parameter by its value before the configuration file is parsed by Behat.
+# variable by its value before the configuration file is parsed by Behat.
 ORIGINAL="profile: %paths.base%"
 REPLACEMENT="profile: $ACCEPTANCE_TESTS_CONFIG_DIR"
 # As the substitution does not involve regular expressions or multilines it can

--- a/tests/acceptance/run-local.sh
+++ b/tests/acceptance/run-local.sh
@@ -172,32 +172,19 @@ FILE_CONTENTS=$(<$ACCEPTANCE_TESTS_CONFIG_DIR/behat.yml)
 echo "${FILE_CONTENTS//$ORIGINAL/$REPLACEMENT}" > $ACCEPTANCE_TESTS_CONFIG_DIR/behat.yml
 
 if [ "$SELENIUM_SERVER" != "$DEFAULT_SELENIUM_SERVER" ]; then
-	# Set the Selenium server to be used by Mink; this extends the default
-	# configuration from "config/behat.yml".
-	export BEHAT_PARAMS='
-{
-    "extensions": {
-        "Behat\\MinkExtension": {
-            "sessions": {
-                "default": {
-                    "selenium2": {
-                        "wd_host": "http://'"$SELENIUM_SERVER"'/wd/hub"
-                    }
-                },
-                "John": {
-                    "selenium2": {
-                        "wd_host": "http://'"$SELENIUM_SERVER"'/wd/hub"
-                    }
-                },
-                "Jane": {
-                    "selenium2": {
-                        "wd_host": "http://'"$SELENIUM_SERVER"'/wd/hub"
-                    }
-                }
-            }
-        }
-    }
-}'
+	# Set the Selenium server to be used by Mink. Although Mink sessions can be
+	# extended through BEHAT_PARAMS this would require adding here too each new
+	# session added to "behat.yml", including those added in the acceptance
+	# tests of apps. Instead, the default "behat.yml" configuration file is
+	# adjusted to replace the simulated "selenium.server" variable by its value
+	# before the configuration file is parsed by Behat.
+	ORIGINAL="wd_host: %selenium.server%"
+	REPLACEMENT="wd_host: http://$SELENIUM_SERVER/wd/hub"
+	# As the substitution does not involve regular expressions or multilines it
+	# can be done just with Bash. Moreover, this does not require escaping the
+	# regular expression characters that may appear in the URL, like "/".
+	FILE_CONTENTS=$(<$ACCEPTANCE_TESTS_CONFIG_DIR/behat.yml)
+	echo "${FILE_CONTENTS//$ORIGINAL/$REPLACEMENT}" > $ACCEPTANCE_TESTS_CONFIG_DIR/behat.yml
 fi
 
 composer install


### PR DESCRIPTION
This pull request makes possible to use custom Selenium2 sessions in the acceptance tests for apps.

The `wd_host` parameter of Selenium2 sessions specify the URL used by the Selenium driver to connect with the Selenium server. Thus, when the Selenium server is at a different host or port than the default one (for example, when run on Drone) the `wd_host` parameter must be set for each of the Selenium2 sessions defined in _behat.yml_.

The `BEHAT_PARAMS` environment variable, which extends the _behat.yml_ configuration file, was used for that. However, this required adding to the `BEHAT_PARAMS` in _run-local.sh_ each new session added to _behat.yml_, including those added in the acceptance tests of apps.

To address that limitation, this pull request introduces a simulated variable, `selenium.server`; just before the acceptance tests are run the `selenium.server` variable in the `wd_host` parameter is replaced in the _behat.yml_ file used by the acceptance tests. Note that the file that is modified is the one inside the Docker container used to run the acceptance tests, so the original file is not touched.
