### PR TITLE
Server error/hint pages with a 500 error code to avoid it being seen …

### DIFF
--- a/index.php
+++ b/index.php
@@ -48,9 +48,8 @@ try {
 	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
 	OC_Template::printExceptionErrorPage($ex);
 } catch (\OC\HintException $ex) {
-	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
 	try {
-		OC_Template::printErrorPage($ex->getMessage(), $ex->getHint());
+		OC_Template::printErrorPage($ex->getMessage(), $ex->getHint(), OC_Response::STATUS_SERVICE_UNAVAILABLE);
 	} catch (Exception $ex2) {
 		\OC::$server->getLogger()->logException($ex, array('app' => 'index'));
 		\OC::$server->getLogger()->logException($ex2, array('app' => 'index'));
@@ -60,8 +59,7 @@ try {
 		OC_Template::printExceptionErrorPage($ex);
 	}
 } catch (\OC\User\LoginException $ex) {
-	OC_Response::setStatus(OC_Response::STATUS_FORBIDDEN);
-	OC_Template::printErrorPage($ex->getMessage(), $ex->getMessage());
+	OC_Template::printErrorPage($ex->getMessage(), $ex->getMessage(), OC_Response::STATUS_FORBIDDEN);
 } catch (Exception $ex) {
 	\OC::$server->getLogger()->logException($ex, array('app' => 'index'));
 

--- a/index.php
+++ b/index.php
@@ -45,8 +45,7 @@ try {
 	\OC::$server->getLogger()->logException($ex, array('app' => 'index'));
 
 	//show the user a detailed error page
-	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
-	OC_Template::printExceptionErrorPage($ex);
+	OC_Template::printExceptionErrorPage($ex, \OC_Response::STATUS_SERVICE_UNAVAILABLE);
 } catch (\OC\HintException $ex) {
 	try {
 		OC_Template::printErrorPage($ex->getMessage(), $ex->getHint(), OC_Response::STATUS_SERVICE_UNAVAILABLE);
@@ -55,8 +54,7 @@ try {
 		\OC::$server->getLogger()->logException($ex2, array('app' => 'index'));
 
 		//show the user a detailed error page
-		OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
-		OC_Template::printExceptionErrorPage($ex);
+		OC_Template::printExceptionErrorPage($ex, \OC_Response::STATUS_INTERNAL_SERVER_ERROR);
 	}
 } catch (\OC\User\LoginException $ex) {
 	OC_Template::printErrorPage($ex->getMessage(), $ex->getMessage(), OC_Response::STATUS_FORBIDDEN);
@@ -90,6 +88,5 @@ try {
 
 		throw $e;
 	}
-	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
-	OC_Template::printExceptionErrorPage($ex);
+	OC_Template::printExceptionErrorPage($ex, \OC_Response::STATUS_INTERNAL_SERVER_ERROR);
 }

--- a/lib/base.php
+++ b/lib/base.php
@@ -260,7 +260,8 @@ class OC {
 					$l->t('This can usually be fixed by giving the webserver write access to the config directory. See %s',
 					[ $urlGenerator->linkToDocs('admin-dir_permissions') ]) . '. '
 					. $l->t('Or, if you prefer to keep config.php file read only, set the option "config_is_read_only" to true in it. See %s',
-					[ $urlGenerator->linkToDocs('admin-config') ] )
+					[ $urlGenerator->linkToDocs('admin-config') ] ),
+					\OC_Response::STATUS_SERVICE_UNAVAILABLE
 				);
 			}
 		}
@@ -750,11 +751,10 @@ class OC {
 		// Check whether the sample configuration has been copied
 		if($systemConfig->getValue('copied_sample_config', false)) {
 			$l = \OC::$server->getL10N('lib');
-			header('HTTP/1.1 503 Service Temporarily Unavailable');
-			header('Status: 503 Service Temporarily Unavailable');
 			OC_Template::printErrorPage(
 				$l->t('Sample configuration detected'),
-				$l->t('It has been detected that the sample configuration has been copied. This can break your installation and is unsupported. Please read the documentation before performing changes on config.php')
+				$l->t('It has been detected that the sample configuration has been copied. This can break your installation and is unsupported. Please read the documentation before performing changes on config.php'),
+				\OC_Response::STATUS_SERVICE_UNAVAILABLE
 			);
 			return;
 		}

--- a/lib/base.php
+++ b/lib/base.php
@@ -434,8 +434,7 @@ class OC {
 		} catch (Exception $e) {
 			\OC::$server->getLogger()->logException($e, ['app' => 'base']);
 			//show the user a detailed error page
-			OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
-			OC_Template::printExceptionErrorPage($e);
+			OC_Template::printExceptionErrorPage($e, \OC_Response::STATUS_INTERNAL_SERVER_ERROR);
 			die();
 		}
 

--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -198,18 +198,18 @@ class OC_Files {
 			OC::$server->getLogger()->logException($ex);
 			$l = \OC::$server->getL10N('core');
 			$hint = method_exists($ex, 'getHint') ? $ex->getHint() : '';
-			\OC_Template::printErrorPage($l->t('File is currently busy, please try again later'), $hint);
+			\OC_Template::printErrorPage($l->t('File is currently busy, please try again later'), $hint, 200);
 		} catch (\OCP\Files\ForbiddenException $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);
 			$l = \OC::$server->getL10N('core');
-			\OC_Template::printErrorPage($l->t('Can\'t read file'), $ex->getMessage());
+			\OC_Template::printErrorPage($l->t('Can\'t read file'), $ex->getMessage(), 200);
 		} catch (\Exception $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);
 			$l = \OC::$server->getL10N('core');
 			$hint = method_exists($ex, 'getHint') ? $ex->getHint() : '';
-			\OC_Template::printErrorPage($l->t('Can\'t read file'), $hint);
+			\OC_Template::printErrorPage($l->t('Can\'t read file'), $hint, 200);
 		}
 	}
 

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -304,9 +304,10 @@ class OC_Template extends \OC\Template\Base {
 	 * Print a fatal error page and terminates the script
 	 * @param string $error_msg The error message to show
 	 * @param string $hint An optional hint message - needs to be properly escape
+	 * @param int $statusCode
 	 * @suppress PhanAccessMethodInternal
 	 */
-	public static function printErrorPage( $error_msg, $hint = '', $statusCode = \OC_Response::STATUS_INTERNAL_SERVER_ERROR ) {
+	public static function printErrorPage( $error_msg, $hint = '', $statusCode = 500) {
 		if (\OC::$server->getAppManager()->isEnabledForUser('theming') && !\OC_App::isAppLoaded('theming')) {
 			\OC_App::loadApp('theming');
 		}
@@ -337,11 +338,12 @@ class OC_Template extends \OC\Template\Base {
 	/**
 	 * print error page using Exception details
 	 * @param Exception|Throwable $exception
-	 * @param bool $fetchPage
+	 * @param int $statusCode
 	 * @return bool|string
 	 * @suppress PhanAccessMethodInternal
 	 */
-	public static function printExceptionErrorPage($exception, $fetchPage = false) {
+	public static function printExceptionErrorPage($exception, $statusCode = 503) {
+		http_response_code($statusCode);
 		try {
 			$request = \OC::$server->getRequest();
 			$content = new \OC_Template('', 'exception', 'error', false);
@@ -354,16 +356,12 @@ class OC_Template extends \OC\Template\Base {
 			$content->assign('debugMode', \OC::$server->getSystemConfig()->getValue('debug', false));
 			$content->assign('remoteAddr', $request->getRemoteAddress());
 			$content->assign('requestID', $request->getId());
-			if ($fetchPage) {
-				return $content->fetchPage();
-			}
 			$content->printPage();
 		} catch (\Exception $e) {
 			$logger = \OC::$server->getLogger();
 			$logger->logException($exception, ['app' => 'core']);
 			$logger->logException($e, ['app' => 'core']);
 
-			header(self::getHttpProtocol() . ' 500 Internal Server Error');
 			header('Content-Type: text/plain; charset=utf-8');
 			print("Internal Server Error\n\n");
 			print("The server encountered an internal error and was unable to complete your request.\n");
@@ -371,27 +369,5 @@ class OC_Template extends \OC\Template\Base {
 			print("More details can be found in the server log.\n");
 		}
 		die();
-	}
-
-	/**
-	 * This is only here to reduce the dependencies in case of an exception to
-	 * still be able to print a plain error message.
-	 *
-	 * Returns the used HTTP protocol.
-	 *
-	 * @return string HTTP protocol. HTTP/2, HTTP/1.1 or HTTP/1.0.
-	 * @internal Don't use this - use AppFramework\Http\Request->getHttpProtocol instead
-	 */
-	protected static function getHttpProtocol() {
-		$claimedProtocol = strtoupper($_SERVER['SERVER_PROTOCOL']);
-		$validProtocols = [
-			'HTTP/1.0',
-			'HTTP/1.1',
-			'HTTP/2',
-		];
-		if(in_array($claimedProtocol, $validProtocols, true)) {
-			return $claimedProtocol;
-		}
-		return 'HTTP/1.1';
 	}
 }

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -306,7 +306,7 @@ class OC_Template extends \OC\Template\Base {
 	 * @param string $hint An optional hint message - needs to be properly escape
 	 * @suppress PhanAccessMethodInternal
 	 */
-	public static function printErrorPage( $error_msg, $hint = '' ) {
+	public static function printErrorPage( $error_msg, $hint = '', $statusCode = \OC_Response::STATUS_INTERNAL_SERVER_ERROR ) {
 		if (\OC::$server->getAppManager()->isEnabledForUser('theming') && !\OC_App::isAppLoaded('theming')) {
 			\OC_App::loadApp('theming');
 		}
@@ -317,6 +317,7 @@ class OC_Template extends \OC\Template\Base {
 			$hint = '';
 		}
 
+		http_response_code($statusCode);
 		try {
 			$content = new \OC_Template( '', 'error', 'error', false );
 			$errors = array(array('error' => $error_msg, 'hint' => $hint));
@@ -327,7 +328,6 @@ class OC_Template extends \OC\Template\Base {
 			$logger->error("$error_msg $hint", ['app' => 'core']);
 			$logger->logException($e, ['app' => 'core']);
 
-			header(self::getHttpProtocol() . ' 500 Internal Server Error');
 			header('Content-Type: text/plain; charset=utf-8');
 			print("$error_msg $hint");
 		}

--- a/public.php
+++ b/public.php
@@ -79,16 +79,15 @@ try {
 
 } catch (Exception $ex) {
 	if ($ex instanceof \OC\ServiceUnavailableException) {
-		OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
+		$status = OC_Response::STATUS_SERVICE_UNAVAILABLE;
 	} else {
-		OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
+		$status = OC_Response::STATUS_INTERNAL_SERVER_ERROR;
 	}
 	//show the user a detailed error page
 	\OC::$server->getLogger()->logException($ex, ['app' => 'public']);
-	OC_Template::printExceptionErrorPage($ex);
+	OC_Template::printExceptionErrorPage($ex, $status);
 } catch (Error $ex) {
 	//show the user a detailed error page
-	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
 	\OC::$server->getLogger()->logException($ex, ['app' => 'public']);
-	OC_Template::printExceptionErrorPage($ex);
+	OC_Template::printExceptionErrorPage($ex, OC_Response::STATUS_INTERNAL_SERVER_ERROR);
 }

--- a/public.php
+++ b/public.php
@@ -36,8 +36,7 @@ try {
 	if (\OCP\Util::needUpgrade()) {
 		// since the behavior of apps or remotes are unpredictable during
 		// an upgrade, return a 503 directly
-		OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
-		OC_Template::printErrorPage('Service unavailable');
+		OC_Template::printErrorPage('Service unavailable', '', OC_Response::STATUS_SERVICE_UNAVAILABLE);
 		exit;
 	}
 

--- a/remote.php
+++ b/remote.php
@@ -80,8 +80,7 @@ function handleException($e) {
 			OC_Template::printErrorPage($e->getMessage(), '', $e->getCode());
 		} else {
 			\OC::$server->getLogger()->logException($e, ['app' => 'remote']);
-			OC_Response::setStatus($statusCode);
-			OC_Template::printExceptionErrorPage($e);
+			OC_Template::printExceptionErrorPage($e, $statusCode);
 		}
 	}
 }

--- a/remote.php
+++ b/remote.php
@@ -77,8 +77,7 @@ function handleException($e) {
 		}
 		if ($e instanceof RemoteException) {
 			// we shall not log on RemoteException
-			OC_Response::setStatus($e->getCode());
-			OC_Template::printErrorPage($e->getMessage());
+			OC_Template::printErrorPage($e->getMessage(), '', $e->getCode());
 		} else {
 			\OC::$server->getLogger()->logException($e, ['app' => 'remote']);
 			OC_Response::setStatus($statusCode);


### PR DESCRIPTION
…instead of the actual resource

* found while reviewing #7205 
* fixes #6893


Could this solve most of the issues we had in the past with files being overwritten? Because error pages were served with HTTP code 200 :/ 

This should at least avoid problems with clients and the web UI.

Usages:

<img width="686" alt="bildschirmfoto 2018-06-26 um 09 20 00" src="https://user-images.githubusercontent.com/245432/41895358-215d7a72-7922-11e8-895a-72d63291deec.png">
