### PR TITLE
Add resource type phpDoc for putContent methods

### DIFF
--- a/lib/private/Files/Node/File.php
+++ b/lib/private/Files/Node/File.php
@@ -56,7 +56,7 @@ class File extends Node implements \OCP\Files\File {
 	}
 
 	/**
-	 * @param string $data
+	 * @param string|resource $data
 	 * @throws \OCP\Files\NotPermittedException
 	 * @throws \OCP\Files\GenericFileException
 	 */

--- a/lib/private/Files/SimpleFS/SimpleFile.php
+++ b/lib/private/Files/SimpleFS/SimpleFile.php
@@ -97,7 +97,7 @@ class SimpleFile implements ISimpleFile  {
 	/**
 	 * Overwrite the file
 	 *
-	 * @param string $data
+	 * @param string|resource $data
 	 * @throws NotPermittedException
 	 */
 	public function putContent($data) {

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -632,7 +632,7 @@ class View {
 
 	/**
 	 * @param string $path
-	 * @param mixed $data
+	 * @param string|resource $data
 	 * @return bool|mixed
 	 * @throws \Exception
 	 */

--- a/lib/public/Files/File.php
+++ b/lib/public/Files/File.php
@@ -51,7 +51,7 @@ interface File extends Node {
 	/**
 	 * Write to the file from string data
 	 *
-	 * @param string $data
+	 * @param string|resource $data
 	 * @throws \OCP\Files\NotPermittedException
 	 * @throws \OCP\Files\GenericFileException
 	 * @since 6.0.0

--- a/lib/public/Files/SimpleFS/ISimpleFile.php
+++ b/lib/public/Files/SimpleFS/ISimpleFile.php
@@ -78,7 +78,7 @@ interface ISimpleFile {
 	/**
 	 * Overwrite the file
 	 *
-	 * @param string $data
+	 * @param string|resource $data
 	 * @throws NotPermittedException
 	 * @since 11.0.0
 	 */


### PR DESCRIPTION
`OC\Files\View::file_put_contents` is capable of [handling streams](https://github.com/nextcloud/server/blob/b1b0362db94fa52a22cee14a92a6aef57de215b3/lib/private/Files/View.php#L640) as well, so we can also just pass a resource to the public API `\OCP\Files\SimpleFS\ISimpleFile::putContent()` or `\OCP\File\File::putContent()`.

This PR only adjusts the phpdoc comments so that app developers are aware of that they can use it in this way.

@icewind1991 Not sure if that really works in all cases like object storage, but since the view is handing over the file interaction to a separate Storage object this should be fine.