### PR TITLE
Add skip navigation / skip to content links for accessibility

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -564,3 +564,24 @@ nav[role='navigation'] {
 		display: none;
 	}
 }
+
+/* Skip navigation links – show only on keyboard focus */
+.skip-navigation {
+	padding: 11px;
+	position: absolute;
+	overflow: hidden;
+	z-index: 1000;
+	top: -999px;
+	left: 3px;
+	/* Force primary color, otherwise too light focused color */
+	background: var(--color-primary) !important;
+
+	&.skip-content {
+		left: 253px;
+	}
+
+	&:focus,
+	&:active {
+		top: 50px;
+	}
+}

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -27,6 +27,10 @@
 	</head>
 	<body id="<?php p($_['bodyid']);?>">
 	<?php include 'layout.noscript.warning.php'; ?>
+
+	<a href="#app-content" class="button primary skip-navigation skip-content">Skip to main content</a>
+	<a href="#app-navigation" class="button primary skip-navigation">Skip to navigation of app</a>
+
 	<div id="notification-container">
 		<div id="notification"></div>
 	</div>


### PR DESCRIPTION
Add "skip navigation" links according to https://webaim.org/techniques/skipnav/

First tab gets you directly to the main #app-content (skipping both header and left sidebar):
![screenshot from 2018-06-26 12-39-03](https://user-images.githubusercontent.com/925062/41906700-d334268a-793e-11e8-94a7-a98d971a9a27.png)

Second tab gets you to #app-navigation (left sidebar of the app):
![screenshot from 2018-06-26 12-39-13](https://user-images.githubusercontent.com/925062/41906699-d304f6f8-793e-11e8-82f2-c77c1585d62e.png)

After that it continues in the header through the apps as usual.

Please review @nextcloud/accessibility @nextcloud/designers :)