### PR TITLE
Fix groupExists when a backend provides group details

### DIFF
--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -183,7 +183,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 		foreach ($this->backends as $backend) {
 			if ($backend->implementsActions(\OC\Group\Backend::GROUP_DETAILS)) {
 				$groupData = $backend->getGroupDetails($gid);
-				if (is_array($groupData)) {
+				if (is_array($groupData) && !empty($groupData)) {
 					// take the display name from the first backend that has a non-null one
 					if (is_null($displayName) && isset($groupData['displayName'])) {
 						$displayName = $groupData['displayName'];


### PR DESCRIPTION
With the strict type hints for `getGroupDetails`, returning anything but an array is no longer possible, causing the group manager to always think a group exists if one of the group backends implements the function