### PR TITLE
Fix "parsing" of email-addresses in comments and chat messages

### DIFF
--- a/core/js/public/comments.js
+++ b/core/js/public/comments.js
@@ -21,7 +21,7 @@
 		 * The downside: anything not ascii is excluded. Not sure how common it is in areas using different
 		 * alphabets… the upside: fake domains with similar looking characters won't be formatted as links
 		 */
-		urlRegex: /(\b(https?:\/\/|([-A-Z0-9+_])*\.([-A-Z])+)[-A-Z0-9+&@#\/%?=~_|!:,.;()]*[-A-Z0-9+&@#\/%=~_|()])/ig,
+		urlRegex: /((\s|^)(https?:\/\/|([-A-Z0-9+_])*\.([-A-Z])+)[-A-Z0-9+&@#\/%?=~_|!:,.;()]*[-A-Z0-9+&@#\/%=~_|()])/ig,
 		protocolRegex: /^https:\/\//,
 
 		plainToRich: function(content) {
@@ -39,7 +39,7 @@
 			return content.replace(this.urlRegex, function(url) {
 				var hasProtocol = (url.indexOf('https://') !== -1) || (url.indexOf('http://') !== -1);
 				if(!hasProtocol) {
-					url = 'https://' + url;
+					url = 'https://' + url.trim();
 				}
 
 				var linkText = url.replace(self.protocolRegex, '');


### PR DESCRIPTION
\\b matches any non-word character, including \@ and \-
In order to not detect urls in the middle of email-addresses,
we need to check for white space characters and beginning of the
message instead.

tested with:
```
github.com
http://github.com
https://github.com
hi github.com
hi http://github.com
hi https://github.com
notifications@github.com
Hi notifications@github.com
Hi <notifications@github.com>
```
and the first 6 correctly parse a URL now, while the last 3 are not changed.


Fix https://github.com/nextcloud/spreed/issues/1007