### PR TITLE
Add groupware settings section

### DIFF
--- a/apps/dav/lib/Settings/CalDAVSettings.php
+++ b/apps/dav/lib/Settings/CalDAVSettings.php
@@ -57,13 +57,13 @@ class CalDAVSettings implements ISettings {
 	 * @return string
 	 */
 	public function getSection() {
-		return 'server';
+		return 'groupware';
 	}
 
 	/**
 	 * @return int
 	 */
 	public function getPriority() {
-		return 20;
+		return 10;
 	}
 }

--- a/apps/dav/tests/unit/Settings/CalDAVSettingsTest.php
+++ b/apps/dav/tests/unit/Settings/CalDAVSettingsTest.php
@@ -49,10 +49,10 @@ class CalDAVSettingsTest extends TestCase {
 	}
 
 	public function testGetSection() {
-		$this->assertEquals('server', $this->settings->getSection());
+		$this->assertEquals('groupware', $this->settings->getSection());
 	}
 
 	public function testGetPriority() {
-		$this->assertEquals(20, $this->settings->getPriority());
+		$this->assertEquals(10, $this->settings->getPriority());
 	}
 }

--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -231,6 +231,7 @@ class Manager implements IManager {
 			5 => [new Section('sharing', $this->l->t('Sharing'), 0, $this->url->imagePath('core', 'actions/share.svg'))],
 			10 => [new Section('security', $this->l->t('Security'), 0, $this->url->imagePath('core', 'actions/password.svg'))],
 			45 => [new Section('encryption', $this->l->t('Encryption'), 0, $this->url->imagePath('core', 'actions/password.svg'))],
+			50 => [new Section('groupware', $this->l->t('Groupware'), 0, $this->url->imagePath('core', 'places/contacts-dark.svg'))],
 			98 => [new Section('additional', $this->l->t('Additional settings'), 0, $this->url->imagePath('core', 'actions/settings-dark.svg'))],
 		];
 

--- a/tests/lib/Settings/ManagerTest.php
+++ b/tests/lib/Settings/ManagerTest.php
@@ -115,13 +115,14 @@ class ManagerTest extends TestCase {
 
 		$this->manager->registerSection('admin', \OCA\WorkflowEngine\Settings\Section::class);
 
-		$this->url->expects($this->exactly(6))
+		$this->url->expects($this->exactly(7))
 			->method('imagePath')
 			->willReturnMap([
 				['settings', 'admin.svg', '0'],
 				['core', 'actions/settings-dark.svg', '1'],
 				['core', 'actions/share.svg', '2'],
 				['core', 'actions/password.svg', '3'],
+				['core', 'places/contacts-dark.svg', '5'],
 				['settings', 'help.svg', '4'],
 			]);
 
@@ -131,6 +132,7 @@ class ManagerTest extends TestCase {
 			5 => [new Section('sharing', 'Sharing', 0, '2')],
 			10 => [new Section('security', 'Security', 0, '3')],
 			45 => [new Section('encryption', 'Encryption', 0, '3')],
+			50 => [new Section('groupware', 'Groupware', 0, '5')],
 			55 => [\OC::$server->query(\OCA\WorkflowEngine\Settings\Section::class)],
 			98 => [new Section('additional', 'Additional settings', 0, '1')],
 		], $this->manager->getAdminSections());
@@ -166,13 +168,14 @@ class ManagerTest extends TestCase {
 			->method('t')
 			->will($this->returnArgument(0));
 
-		$this->url->expects($this->exactly(6))
+		$this->url->expects($this->exactly(7))
 			->method('imagePath')
 			->willReturnMap([
 				['settings', 'admin.svg', '0'],
 				['core', 'actions/settings-dark.svg', '1'],
 				['core', 'actions/share.svg', '2'],
 				['core', 'actions/password.svg', '3'],
+				['core', 'places/contacts-dark.svg', '5'],
 				['settings', 'help.svg', '4'],
 			]);
 
@@ -182,6 +185,7 @@ class ManagerTest extends TestCase {
 			5 => [new Section('sharing', 'Sharing', 0, '2')],
 			10 => [new Section('security', 'Security', 0, '3')],
 			45 => [new Section('encryption', 'Encryption', 0, '3')],
+			50 => [new Section('groupware', 'Groupware', 0, '5')],
 			98 => [new Section('additional', 'Additional settings', 0, '1')],
 		], $this->manager->getAdminSections());
 	}


### PR DESCRIPTION
This PR adds a separate Groupware section to the settings. They contain just the CalDAV- Server settings for now but after #9773 is in, we can also add the resource booking ui from https://github.com/georgehrke/admin_resource_booking_database to it.

@nextcloud/designers 

![image](https://user-images.githubusercontent.com/3404133/41989216-d1ad4156-7a3e-11e8-9336-6ca52c2c662e.png)

