### PR TITLE
Log path of file that failed to be parsed

### DIFF
--- a/lib/private/Preview/Bitmap.php
+++ b/lib/private/Preview/Bitmap.php
@@ -50,7 +50,7 @@ abstract class Bitmap extends Provider {
 			$bp = $this->getResizedPreview($tmpPath, $maxX, $maxY);
 		} catch (\Exception $e) {
 			\OC::$server->getLogger()->logException($e, [
-				'message' => 'Imagick says:',
+				'message' => 'File: ' . $fileview->getAbsolutePath($path) . ' Imagick says:',
 				'level' => ILogger::ERROR,
 				'app' => 'core',
 			]);


### PR DESCRIPTION
Fixes #9221

Then logs it like this:

```
{
    "reqId": "D61UDTrhsAVbZiiOgGeN",
    "level": 3,
    "time": "2018-06-28T09:10:49+00:00",
    "remoteAddr": "172.20.0.1",
    "user": "admin",
    "app": "core",
    "method": "GET",
    "url": "/index.php/core/preview?fileId=551&c=9ccbb739e0a8aad755280589fbadab88&x=32&y=32&forceIcon=0",
    "message": {
        "Exception": "ImagickException",
        "Message": "Failed to read the file",
        "Code": 1,
        "Trace": [...],
        "File": "/var/www/html/lib/private/Preview/Bitmap.php",
        "Line": 87,
        "CustomMessage": "File: /admin/files/Kuhlschrank.Gebrauchsanleitung.pdf Imagick says:"
    },
    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.1.1 Safari/605.1.15",
    "version": "14.0.0.6"
}
```