### PR TITLE
Fix search related results in OPTIONS requests

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -131,6 +131,7 @@ return array(
     'OCA\\DAV\\Files\\BrowserErrorPagePlugin' => $baseDir . '/../lib/Files/BrowserErrorPagePlugin.php',
     'OCA\\DAV\\Files\\FileSearchBackend' => $baseDir . '/../lib/Files/FileSearchBackend.php',
     'OCA\\DAV\\Files\\FilesHome' => $baseDir . '/../lib/Files/FilesHome.php',
+    'OCA\\DAV\\Files\\LazySearchBackend' => $baseDir . '/../lib/Files/LazySearchBackend.php',
     'OCA\\DAV\\Files\\RootCollection' => $baseDir . '/../lib/Files/RootCollection.php',
     'OCA\\DAV\\Files\\Sharing\\FilesDropPlugin' => $baseDir . '/../lib/Files/Sharing/FilesDropPlugin.php',
     'OCA\\DAV\\Files\\Sharing\\PublicLinkCheckPlugin' => $baseDir . '/../lib/Files/Sharing/PublicLinkCheckPlugin.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -146,6 +146,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Files\\BrowserErrorPagePlugin' => __DIR__ . '/..' . '/../lib/Files/BrowserErrorPagePlugin.php',
         'OCA\\DAV\\Files\\FileSearchBackend' => __DIR__ . '/..' . '/../lib/Files/FileSearchBackend.php',
         'OCA\\DAV\\Files\\FilesHome' => __DIR__ . '/..' . '/../lib/Files/FilesHome.php',
+        'OCA\\DAV\\Files\\LazySearchBackend' => __DIR__ . '/..' . '/../lib/Files/LazySearchBackend.php',
         'OCA\\DAV\\Files\\RootCollection' => __DIR__ . '/..' . '/../lib/Files/RootCollection.php',
         'OCA\\DAV\\Files\\Sharing\\FilesDropPlugin' => __DIR__ . '/..' . '/../lib/Files/Sharing/FilesDropPlugin.php',
         'OCA\\DAV\\Files\\Sharing\\PublicLinkCheckPlugin' => __DIR__ . '/..' . '/../lib/Files/Sharing/PublicLinkCheckPlugin.php',

--- a/apps/dav/lib/Connector/Sabre/AnonymousOptionsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/AnonymousOptionsPlugin.php
@@ -56,6 +56,9 @@ class AnonymousOptionsPlugin extends ServerPlugin {
 			// setup a fake tree for anonymous access
 			$this->server->tree = new Tree(new Directory(''));
 			$corePlugin->httpOptions($request, $response);
+			$this->server->emit('afterMethod', [$request, $response]);
+			$this->server->emit('afterMethod:OPTIONS', [$request, $response]);
+
 			$this->server->sapi->sendResponse($response);
 			return false;
 		}

--- a/apps/dav/lib/Files/LazySearchBackend.php
+++ b/apps/dav/lib/Files/LazySearchBackend.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Robin Appelman <robin@icewind.nl>
+ *
+ * @author Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DAV\Files;
+
+use SearchDAV\Backend\ISearchBackend;
+use SearchDAV\Query\Query;
+
+class LazySearchBackend implements ISearchBackend {
+	/**
+	 * @var ISearchBackend $backend
+	 */
+	private $backend = null;
+
+	public function setBackend(ISearchBackend $backend) {
+		$this->backend = $backend;
+	}
+
+	public function getArbiterPath() {
+		if ($this->backend) {
+			return $this->backend->getArbiterPath();
+		} else {
+			return '';
+		}
+	}
+
+	public function isValidScope($href, $depth, $path) {
+		if ($this->backend) {
+			return $this->backend->getArbiterPath();
+		} else {
+			return false;
+		}
+	}
+
+	public function getPropertyDefinitionsForScope($href, $path) {
+		if ($this->backend) {
+			return $this->backend->getArbiterPath();
+		} else {
+			return [];
+		}
+	}
+
+	public function search(Query $query) {
+		if ($this->backend) {
+			return $this->backend->getArbiterPath();
+		} else {
+			return [];
+		}
+	}
+
+
+}

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -53,6 +53,7 @@ use OCA\DAV\DAV\CustomPropertiesBackend;
 use OCA\DAV\Connector\Sabre\QuotaPlugin;
 use OCA\DAV\Files\BrowserErrorPagePlugin;
 use OCA\DAV\Connector\Sabre\AnonymousOptionsPlugin;
+use OCA\DAV\Files\LazySearchBackend;
 use OCA\DAV\SystemTag\SystemTagPlugin;
 use OCA\DAV\Upload\ChunkingPlugin;
 use OCP\IRequest;
@@ -195,8 +196,11 @@ class Server {
 			$this->server->addPlugin(new BrowserErrorPagePlugin());
 		}
 
+		$lazySearchBackend = new LazySearchBackend();
+		$this->server->addPlugin(new SearchPlugin($lazySearchBackend));
+
 		// wait with registering these until auth is handled and the filesystem is setup
-		$this->server->on('beforeMethod', function () use ($root) {
+		$this->server->on('beforeMethod', function () use ($root, $lazySearchBackend) {
 			// custom properties plugin must be the last one
 			$userSession = \OC::$server->getUserSession();
 			$user = $userSession->getUser();
@@ -255,13 +259,13 @@ class Server {
 						\OC::$server->getGroupManager(),
 						$userFolder
 					));
-					$this->server->addPlugin(new SearchPlugin(new \OCA\DAV\Files\FileSearchBackend(
+					$lazySearchBackend->setBackend(new \OCA\DAV\Files\FileSearchBackend(
 						$this->server->tree,
 						$user,
 						\OC::$server->getRootFolder(),
 						\OC::$server->getShareManager(),
 						$view
-					)));
+					));
 				}
 				$this->server->addPlugin(new \OCA\DAV\CalDAV\BirthdayCalendar\EnablePlugin(
 					\OC::$server->getConfig(),


### PR DESCRIPTION
Fixes #9891

Fixes regression from https://github.com/nextcloud/server/pull/9542 caused by the fact that the search plugin was only registered post-auth