### PR TITLE
Disable codecov status and comment

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,7 +8,8 @@ coverage:
   precision: 2
   round: down
   range: "70...100"
+  status:
+    project: off
+    patch: off
 
-comment:
-  layout: "header, diff, changes, uncovered, tree"
-  behavior: default
+comment: off


### PR DESCRIPTION
It still reports it to codecov, but doesn't log in the PR anymore. Background: it is too unreliable due to the parallel push of stats from drone.

See https://codecov.io/gh/nextcloud/server/pulls

As discussed on IRC.