### PR TITLE
Fix filenames in sharing integration tests

### DIFF
--- a/build/integration/features/sharing-v1-part2.feature
+++ b/build/integration/features/sharing-v1-part2.feature
@@ -69,7 +69,7 @@ Feature: sharing
     And group "group1" exists
     And user "user1" belongs to group "group1"
     And file "textfile0.txt" of user "user0" is shared with group "group1"
-    And User "user1" moved file "/textfile0.txt" to "/FOLDER/textfile0.txt"
+    And User "user1" moved file "/textfile0 (2).txt" to "/FOLDER/textfile0.txt"
     And As an "user0"
     When Updating last share with
       | permissions | 1 |
@@ -240,7 +240,7 @@ Feature: sharing
     And User "user1" moved file "/textfile0.txt" to "/common/textfile0.txt"
     And User "user1" moved file "/common/textfile0.txt" to "/common/sub/textfile0.txt"
     And As an "user2"
-    When Downloading file "/textfile0.txt" with range "bytes=10-18"
+    When Downloading file "/textfile0 (2).txt" with range "bytes=10-18"
     Then Downloaded content should be "test text"
     And user "user2" should see following elements
       | /common/sub/textfile0.txt |
@@ -252,7 +252,7 @@ Feature: sharing
     And group "group1" exists
     And user "user1" belongs to group "group1"
     And file "textfile0.txt" of user "user0" is shared with group "group1"
-    And User "user1" moved file "/textfile0.txt" to "/FOLDER/textfile0.txt"
+    And User "user1" moved file "/textfile0 (2).txt" to "/FOLDER/textfile0.txt"
     And As an "user0"
     And Deleting last share
     And As an "user1"

--- a/build/integration/features/sharing-v1-part2.feature
+++ b/build/integration/features/sharing-v1-part2.feature
@@ -199,8 +199,14 @@ Feature: sharing
     Then user "user1" should see following elements
       | /FOLDER/ |
       | /PARENT/ |
-      | /CHILD/ |
+      | /PARENT/CHILD/ |
       | /PARENT/parent.txt |
+      | /PARENT/CHILD/child.txt |
+      | /PARENT%20(2)/ |
+      | /PARENT%20(2)/CHILD/ |
+      | /PARENT%20(2)/parent.txt |
+      | /PARENT%20(2)/CHILD/child.txt |
+      | /CHILD/ |
       | /CHILD/child.txt |
     And the HTTP status code should be "200"
 


### PR DESCRIPTION
When a file is shared and the receiver of the share already has a file with the same name that file is left untouched, and ["(2)" is appended to the name of the shared file](https://github.com/nextcloud/server/blob/dd34cb75404fb806da7e780bc5804fc958a75456/apps/files_sharing/lib/SharedMount.php#L150).

As [_textfile0.txt_ is included in the user folder skeleton](https://github.com/nextcloud/server/blob/49d0f0c49901c291e26e4f02f52060bae25a11ed/build/integration/features/bootstrap/BasicStructure.php#L442) all the users in the integration test have that file, so when it is shared the receiver sees the share as _/textfile0 (2).txt_, and her own file as _/textfile0.txt_; some tests that were using _/textfile0.txt_ were fixed to use the shared file instead.

In a similar way, a shared folder and its subfolders were also added to the list of files that should be seen by a user in a test, as before only her own folder was checked.
