### PR TITLE
Safe default behaviour when no users are specified on trashbin:cleanup

### DIFF
--- a/apps/files_trashbin/lib/Command/CleanUp.php
+++ b/apps/files_trashbin/lib/Command/CleanUp.php
@@ -29,6 +29,7 @@ use OCP\IUserBackend;
 use OCP\IUserManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -62,13 +63,22 @@ class CleanUp extends Command {
 			->addArgument(
 				'user_id',
 				InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
-				'remove deleted files of the given user(s), if no user is given all deleted files will be removed'
+				'remove deleted files of the given user(s)'
+			)
+			->addOption(
+				'all-users',
+				null,
+				InputOption::VALUE_NONE,
+				'run action on all users'
 			);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$users = $input->getArgument('user_id');
 		if (!empty($users)) {
+			if ($input->getOption('all-users')) {
+				$output->writeln('Option --all-users supplied along with users, restricting to supplied users');
+			}
 			foreach ($users as $user) {
 				if ($this->userManager->userExists($user)) {
 					$output->writeln("Remove deleted files of   <info>$user</info>");
@@ -77,8 +87,8 @@ class CleanUp extends Command {
 					$output->writeln("<error>Unknown user $user</error>");
 				}
 			}
-		} else {
-			$output->writeln('Remove all deleted files');
+		} elseif ($input->getOption('all-users')) {
+			$output->writeln('Remove deleted files for all users');
 			foreach ($this->userManager->getBackends() as $backend) {
 				$name = get_class($backend);
 				if ($backend instanceof IUserBackend) {

--- a/apps/files_trashbin/lib/Command/CleanUp.php
+++ b/apps/files_trashbin/lib/Command/CleanUp.php
@@ -32,6 +32,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Exception\InvalidOptionException;
 
 class CleanUp extends Command {
 
@@ -75,10 +76,9 @@ class CleanUp extends Command {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$users = $input->getArgument('user_id');
-		if (!empty($users)) {
-			if ($input->getOption('all-users')) {
-				$output->writeln('Option --all-users supplied along with users, restricting to supplied users');
-			}
+		if ((!empty($users)) and ($input->getOption('all-users'))) {
+			throw new InvalidOptionException('Either specify a user_id or --all-users');
+		} elseif (!empty($users)) {
 			foreach ($users as $user) {
 				if ($this->userManager->userExists($user)) {
 					$output->writeln("Remove deleted files of   <info>$user</info>");
@@ -106,6 +106,8 @@ class CleanUp extends Command {
 					$offset += $limit;
 				} while (count($users) >= $limit);
 			}
+		} else {
+			throw new InvalidOptionException('Either specify a user_id or --all-users');
 		}
 	}
 


### PR DESCRIPTION
* Add option --all-users to explicitly clean all trashbins
* Reject no users on commandline and no --all-users
* Warn when --all-users and userids are specified
#10001 

Signed-off-by: Liam Dennehy <liam@wiemax.net>