### PR TITLE
Fix variable not replaced in "behat.yml" when default value was used

### DIFF
--- a/tests/acceptance/run-local.sh
+++ b/tests/acceptance/run-local.sh
@@ -171,21 +171,19 @@ REPLACEMENT="profile: $ACCEPTANCE_TESTS_CONFIG_DIR"
 FILE_CONTENTS=$(<$ACCEPTANCE_TESTS_CONFIG_DIR/behat.yml)
 echo "${FILE_CONTENTS//$ORIGINAL/$REPLACEMENT}" > $ACCEPTANCE_TESTS_CONFIG_DIR/behat.yml
 
-if [ "$SELENIUM_SERVER" != "$DEFAULT_SELENIUM_SERVER" ]; then
-	# Set the Selenium server to be used by Mink. Although Mink sessions can be
-	# extended through BEHAT_PARAMS this would require adding here too each new
-	# session added to "behat.yml", including those added in the acceptance
-	# tests of apps. Instead, the default "behat.yml" configuration file is
-	# adjusted to replace the simulated "selenium.server" variable by its value
-	# before the configuration file is parsed by Behat.
-	ORIGINAL="wd_host: %selenium.server%"
-	REPLACEMENT="wd_host: http://$SELENIUM_SERVER/wd/hub"
-	# As the substitution does not involve regular expressions or multilines it
-	# can be done just with Bash. Moreover, this does not require escaping the
-	# regular expression characters that may appear in the URL, like "/".
-	FILE_CONTENTS=$(<$ACCEPTANCE_TESTS_CONFIG_DIR/behat.yml)
-	echo "${FILE_CONTENTS//$ORIGINAL/$REPLACEMENT}" > $ACCEPTANCE_TESTS_CONFIG_DIR/behat.yml
-fi
+# Set the Selenium server to be used by Mink. Although Mink sessions can be
+# extended through BEHAT_PARAMS this would require adding here too each new
+# session added to "behat.yml", including those added in the acceptance
+# tests of apps. Instead, the default "behat.yml" configuration file is
+# adjusted to replace the simulated "selenium.server" variable by its value
+# before the configuration file is parsed by Behat.
+ORIGINAL="wd_host: %selenium.server%"
+REPLACEMENT="wd_host: http://$SELENIUM_SERVER/wd/hub"
+# As the substitution does not involve regular expressions or multilines it
+# can be done just with Bash. Moreover, this does not require escaping the
+# regular expression characters that may appear in the URL, like "/".
+FILE_CONTENTS=$(<$ACCEPTANCE_TESTS_CONFIG_DIR/behat.yml)
+echo "${FILE_CONTENTS//$ORIGINAL/$REPLACEMENT}" > $ACCEPTANCE_TESTS_CONFIG_DIR/behat.yml
 
 composer install
 


### PR DESCRIPTION
Follow up to #9967 

As _selenium.server_ is a simulated variable it is not recognized by Mink, so it must be always replaced by its value in _behat.yml_ before the file is parsed by Behat. Otherwise, Behat complains that
>   The service "mink" has a dependency on a non-existent parameter "selenium.server"

This happened when running the acceptance test using _run.sh_, as in that case `$SELENIUM_SERVER` had the default value and the replacement was not performed; now the variable is unconditionally replaced by its value.
