### PR TITLE
Fix getting the information of a group share as a sharee

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -908,7 +908,7 @@ class ShareAPIController extends OCSController {
 
 		// First check if it is an internal share.
 		try {
-			$share = $this->shareManager->getShareById('ocinternal:' . $id);
+			$share = $this->shareManager->getShareById('ocinternal:' . $id, $this->currentUser);
 			return $share;
 		} catch (ShareNotFound $e) {
 			// Do nothing, just try the other share type
@@ -917,7 +917,7 @@ class ShareAPIController extends OCSController {
 
 		try {
 			if ($this->shareManager->shareProviderExists(\OCP\Share::SHARE_TYPE_CIRCLE)) {
-				$share = $this->shareManager->getShareById('ocCircleShare:' . $id);
+				$share = $this->shareManager->getShareById('ocCircleShare:' . $id, $this->currentUser);
 				return $share;
 			}
 		} catch (ShareNotFound $e) {
@@ -926,7 +926,7 @@ class ShareAPIController extends OCSController {
 
 		try {
 			if ($this->shareManager->shareProviderExists(\OCP\Share::SHARE_TYPE_EMAIL)) {
-				$share = $this->shareManager->getShareById('ocMailShare:' . $id);
+				$share = $this->shareManager->getShareById('ocMailShare:' . $id, $this->currentUser);
 				return $share;
 			}
 		} catch (ShareNotFound $e) {
@@ -936,7 +936,7 @@ class ShareAPIController extends OCSController {
 		if (!$this->shareManager->outgoingServer2ServerSharesAllowed()) {
 			throw new ShareNotFound();
 		}
-		$share = $this->shareManager->getShareById('ocFederatedSharing:' . $id);
+		$share = $this->shareManager->getShareById('ocFederatedSharing:' . $id, $this->currentUser);
 
 		return $share;
 	}

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -229,7 +229,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->shareManager
 			->expects($this->once())
 			->method('getShareById')
-			->with('ocinternal:42')
+			->with('ocinternal:42', 'currentUser')
 			->will($this->throwException(new \OC\Share20\Exception\ShareNotFound()));
 
 		$expected = new \OC\OCS\Result(null, 404, 'wrong share ID, share doesn\'t exist.');
@@ -457,7 +457,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->shareManager
 			->expects($this->once())
 			->method('getShareById')
-			->with($share->getFullId())
+			->with($share->getFullId(), 'currentUser')
 			->willReturn($share);
 
 		$userFolder = $this->getMockBuilder('OCP\Files\Folder')->getMock();
@@ -517,7 +517,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->shareManager
 			->expects($this->once())
 			->method('getShareById')
-			->with('ocinternal:42')
+			->with('ocinternal:42', 'currentUser')
 			->willReturn($share);
 
 		$this->ocs->getShare(42);

--- a/build/integration/features/sharing-v1-part2.feature
+++ b/build/integration/features/sharing-v1-part2.feature
@@ -62,6 +62,59 @@ Feature: sharing
       | displayname_owner | user0 |
       | mimetype          | text/plain |
 
+  Scenario: getting share info of a group share
+    Given user "user0" exists
+    And user "user1" exists
+    And group "group1" exists
+    And user "user1" belongs to group "group1"
+    And file "textfile0.txt" of user "user0" is shared with group "group1"
+    And As an "user0"
+    When Getting info of last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And Share fields of last share match with
+      | id | A_NUMBER |
+      | item_type | file |
+      | item_source | A_NUMBER |
+      | share_type | 1 |
+      | share_with | group1 |
+      | file_source | A_NUMBER |
+      | file_target | /textfile0.txt |
+      | path | /textfile0.txt |
+      | permissions | 19 |
+      | stime | A_NUMBER |
+      | storage | A_NUMBER |
+      | mail_send | 0 |
+      | uid_owner | user0 |
+      | storage_id | home::user0 |
+      | file_parent | A_NUMBER |
+      | share_with_displayname | group1 |
+      | displayname_owner | user0 |
+      | mimetype          | text/plain |
+    And As an "user1"
+    And Getting info of last share
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And Share fields of last share match with
+      | id | A_NUMBER |
+      | item_type | file |
+      | item_source | A_NUMBER |
+      | share_type | 1 |
+      | share_with | group1 |
+      | file_source | A_NUMBER |
+      | file_target | /textfile0 (2).txt |
+      | path | /textfile0 (2).txt |
+      | permissions | 19 |
+      | stime | A_NUMBER |
+      | storage | A_NUMBER |
+      | mail_send | 0 |
+      | uid_owner | user0 |
+      | storage_id | shared::/textfile0 (2).txt |
+      | file_parent | A_NUMBER |
+      | share_with_displayname | group1 |
+      | displayname_owner | user0 |
+      | mimetype          | text/plain |
+
   Scenario: keep group permissions in sync
     Given As an "admin"
     Given user "user0" exists
@@ -89,6 +142,26 @@ Feature: sharing
       | mail_send | 0 |
       | uid_owner | user0 |
       | storage_id | home::user0 |
+      | file_parent | A_NUMBER |
+      | displayname_owner | user0 |
+      | mimetype          | text/plain |
+    And As an "user1"
+    And Getting info of last share
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And Share fields of last share match with
+      | id | A_NUMBER |
+      | item_type | file |
+      | item_source | A_NUMBER |
+      | share_type | 1 |
+      | file_source | A_NUMBER |
+      | file_target | /FOLDER/textfile0.txt |
+      | permissions | 1 |
+      | stime | A_NUMBER |
+      | storage | A_NUMBER |
+      | mail_send | 0 |
+      | uid_owner | user0 |
+      | storage_id | shared::/FOLDER/textfile0.txt |
       | file_parent | A_NUMBER |
       | displayname_owner | user0 |
       | mimetype          | text/plain |


### PR DESCRIPTION
When the receiver of a group share modifies it (for example, by moving it to a different folder) the original share is not modified, but [a "ghost" share that keeps track of the changes made by that specific user is used instead](https://github.com/nextcloud/server/blob/d3d045dd5c5af5f29268727afe63f3c53d22af6c/lib/private/Share20/DefaultShareProvider.php#L447-L460).

By default, the method `getShareById` in the share provider returns the share from the point of view of the sharer, but it can be used too to get [the share from the point of view of a sharee by providing the `recipient` parameter](https://github.com/nextcloud/server/blob/d3d045dd5c5af5f29268727afe63f3c53d22af6c/lib/private/Share20/DefaultShareProvider.php#L606-L608) (and [if the sharee is not found then the share is returned from the point of view of the sharer](https://github.com/nextcloud/server/blob/d3d045dd5c5af5f29268727afe63f3c53d22af6c/lib/private/Share20/DefaultShareProvider.php#L884)).

The `ShareAPIController` always [formats the share from the point of view of the current user](https://github.com/nextcloud/server/blob/4d5a2cce8df12537e3006e8e5976eb8dd24783a7/apps/files_sharing/lib/Controller/ShareAPIController.php#L149), but when getting the information of a specific share the `recipient` parameter was not given, so it was always returned from the point of view of the sharer, even if the current user was a sharee. Now the `recipient` parameter is set to the current user, and thus the information of the share is returned from the point of view of the current user, be it the sharer or a sharee.

All this can be seen in the integration tests added also in this pull request; without the fix, when getting the information of a group share as a sharee, the returned `file_target` is _/textfile0.txt_ instead of _/textfile0 (2).txt_ (because it is returned by `getShareById`), but the returned `path` is _/textfile0 (2).txt_ with and without the fix (because [it is got from the node as the current user when the share is formatted](https://github.com/nextcloud/server/blob/4d5a2cce8df12537e3006e8e5976eb8dd24783a7/apps/files_sharing/lib/Controller/ShareAPIController.php#L149-L166)).

Note that this special behaviour of `getShareById` happens only with group shares; with other types of shares the share is the same for the sharer and the sharee, and thus the parameter is ignored ([`DefaultShareProvider`](https://github.com/nextcloud/server/blob/d3d045dd5c5af5f29268727afe63f3c53d22af6c/lib/private/Share20/DefaultShareProvider.php#L570), [`ShareByCircleProvider`](https://github.com/nextcloud/circles/blob/235fe7d81287e86b81541c9884291b335be3d168/lib/ShareByCircleProvider.php#L398), [`ShareByMailProvider`](https://github.com/nextcloud/server/blob/38a90130ce425d531a804dff591df4a883de3154/apps/sharebymail/lib/ShareByMailProvider.php#L754) and [`FederatedShareProvider`](https://github.com/nextcloud/server/blob/38a90130ce425d531a804dff591df4a883de3154/apps/federatedfilesharing/lib/FederatedShareProvider.php#L698)); it was added for them too just for consistency.
