### PR TITLE
Correctly parse the subject parameters for link (un)shares of calendars

### DIFF
--- a/apps/dav/lib/CalDAV/Activity/Provider/Calendar.php
+++ b/apps/dav/lib/CalDAV/Activity/Provider/Calendar.php
@@ -176,6 +176,8 @@ class Calendar extends Base {
 				case self::SUBJECT_DELETE . '_self':
 				case self::SUBJECT_UPDATE:
 				case self::SUBJECT_UPDATE . '_self':
+				case self::SUBJECT_PUBLISH . '_self':
+				case self::SUBJECT_UNPUBLISH . '_self':
 				case self::SUBJECT_SHARE_USER:
 				case self::SUBJECT_UNSHARE_USER:
 				case self::SUBJECT_UNSHARE_USER . '_self':


### PR DESCRIPTION
Fix https://github.com/nextcloud/activity/issues/277

Introduced by https://github.com/nextcloud/server/pull/6590