### PR TITLE
fix double slash in search result path when the result is in a submount

### DIFF
--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -258,7 +258,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 			if ($storage) {
 				$cache = $storage->getCache('');
 
-				$relativeMountPoint = substr($mount->getMountPoint(), $rootLength);
+				$relativeMountPoint = ltrim(substr($mount->getMountPoint(), $rootLength), '/');
 				$results = call_user_func_array(array($cache, $method), $args);
 				foreach ($results as $result) {
 					$result['internalPath'] = $result['path'];


### PR DESCRIPTION
requires https://github.com/nextcloud/server/pull/10077 to actually test on master

Fixes https://github.com/nextcloud/server/issues/9892