### PR TITLE
LDAP user should be able to set avatar if directory provides incompatible image

### DIFF
--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -93,8 +93,10 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 
 	/**
 	 * checks whether the user is allowed to change his avatar in Nextcloud
+	 *
 	 * @param string $uid the Nextcloud user name
 	 * @return boolean either the user can or cannot
+	 * @throws \Exception
 	 */
 	public function canChangeAvatar($uid) {
 		if ($this->userPluginManager->implementsActions(Backend::PROVIDE_AVATAR)) {
@@ -105,11 +107,11 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 		if(!$user instanceof User) {
 			return false;
 		}
-		if($user->getAvatarImage() === false) {
+		$imageData = $user->getAvatarImage();
+		if($imageData === false) {
 			return true;
 		}
-
-		return false;
+		return !$user->updateAvatar(true);
 	}
 
 	/**

--- a/apps/user_ldap/tests/User/UserTest.php
+++ b/apps/user_ldap/tests/User/UserTest.php
@@ -33,7 +33,6 @@ use OCA\User_LDAP\Access;
 use OCA\User_LDAP\Connection;
 use OCA\User_LDAP\FilesystemHelper;
 use OCA\User_LDAP\LogWrapper;
-use OCA\User_LDAP\User\IUserTools;
 use OCA\User_LDAP\User\User;
 use OCP\IAvatar;
 use OCP\IAvatarManager;
@@ -56,51 +55,66 @@ class UserTest extends \Test\TestCase {
 	protected $access;
 	/** @var  Connection|\PHPUnit_Framework_MockObject_MockObject */
 	protected $connection;
+	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	protected $config;
+	/** @var FilesystemHelper|\PHPUnit_Framework_MockObject_MockObject */
+	protected $filesystemhelper;
+	/** @var INotificationManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $notificationManager;
+	/** @var IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $userManager;
+	/** @var Image|\PHPUnit_Framework_MockObject_MockObject */
+	protected $image;
+	/** @var IAvatarManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $avatarManager;
+	/** @var LogWrapper|\PHPUnit_Framework_MockObject_MockObject */
+	protected $log;
+	/** @var string */
+	protected $uid = 'alice';
+	/** @var string */
+	protected $dn  = 'uid=alice,dc=foo,dc=bar';
+	/** @var User */
+	protected $user;
 
 	public function setUp() {
-		/** @var Access|\PHPUnit_Framework_MockObject_MockObject access */
-		$this->access = $this->createMock(Access::class);
+		parent::setUp();
+
 		$this->connection = $this->createMock(Connection::class);
 
+		$this->access = $this->createMock(Access::class);
 		$this->access->connection = $this->connection;
 		$this->access->expects($this->any())
 			->method('getConnection')
 			->willReturn($this->connection);
 
-		parent::setUp();
-	}
+		$this->config = $this->createMock(IConfig::class);
+		$this->filesystemhelper = $this->createMock(FilesystemHelper::class);
+		$this->log = $this->createMock(LogWrapper::class);
+		$this->avatarManager = $this->createMock(IAvatarManager::class);
+		$this->image = $this->createMock(Image::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->notificationManager = $this->createMock(INotificationManager::class);
 
-	private function getTestInstances() {
-		$access  = $this->createMock(IUserTools::class);
-		$config  = $this->createMock(IConfig::class);
-		$filesys = $this->createMock(FilesystemHelper::class);
-		$log     = $this->createMock(LogWrapper::class);
-		$avaMgr  = $this->createMock(IAvatarManager::class);
-		$image   = $this->createMock(Image::class);
-		$userMgr  = $this->createMock(IUserManager::class);
-		$notiMgr  = $this->createMock(INotificationManager::class);
-
-		return array($access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
+		$this->user = new User(
+			$this->uid,
+			$this->dn,
+			$this->access,
+			$this->config,
+			$this->filesystemhelper,
+			$this->image,
+			$this->log,
+			$this->avatarManager,
+			$this->userManager,
+			$this->notificationManager
+		);
 	}
 
 	public function testGetDNandUsername() {
-		list($access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$this->assertSame($dn, $user->getDN());
-		$this->assertSame($uid, $user->getUsername());
+		$this->assertSame($this->dn, $this->user->getDN());
+		$this->assertSame($this->uid, $this->user->getUsername());
 	}
 
 	public function testUpdateEmailProvided() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->connection->expects($this->once())
 			->method('__get')
 			->with($this->equalTo('ldapEmailAttribute'))
@@ -108,59 +122,43 @@ class UserTest extends \Test\TestCase {
 
 		$this->access->expects($this->once())
 			->method('readAttribute')
-			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+			->with($this->equalTo($this->dn),
 				$this->equalTo('email'))
-			->will($this->returnValue(array('alice@foo.bar')));
+			->will($this->returnValue(['alice@foo.bar']));
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$uuser = $this->getMockBuilder(IUser::class)
+		$coreUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$uuser->expects($this->once())
+		$coreUser->expects($this->once())
 			->method('setEMailAddress')
 			->with('alice@foo.bar');
-		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userMgr */
-		$userMgr->expects($this->any())
-			->method('get')
-			->willReturn($uuser);
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
 
-		$user->updateEmail();
+		$this->userManager->expects($this->any())
+			->method('get')
+			->willReturn($coreUser);
+
+		$this->user->updateEmail();
 	}
 
 	public function testUpdateEmailNotProvided() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->connection->expects($this->once())
 			->method('__get')
 			->with($this->equalTo('ldapEmailAttribute'))
 			->will($this->returnValue('email'));
+
 		$this->access->expects($this->once())
 			->method('readAttribute')
-			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+			->with($this->equalTo($this->dn),
 				$this->equalTo('email'))
 			->will($this->returnValue(false));
 
-		$config->expects($this->never())
+		$this->config->expects($this->never())
 			->method('setUserValue');
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->updateEmail();
+		$this->user->updateEmail();
 	}
 
 	public function testUpdateEmailNotConfigured() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->connection->expects($this->once())
 			->method('__get')
 			->with($this->equalTo('ldapEmailAttribute'))
@@ -169,22 +167,13 @@ class UserTest extends \Test\TestCase {
 		$this->access->expects($this->never())
 			->method('readAttribute');
 
-		$config->expects($this->never())
+		$this->config->expects($this->never())
 			->method('setUserValue');
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->updateEmail();
+		$this->user->updateEmail();
 	}
 
 	public function testUpdateQuotaAllProvided() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->connection->expects($this->exactly(2))
 			->method('__get')
 			->willReturnMap([
@@ -194,33 +183,24 @@ class UserTest extends \Test\TestCase {
 
 		$this->access->expects($this->once())
 			->method('readAttribute')
-			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+			->with($this->equalTo($this->dn),
 				$this->equalTo('myquota'))
-			->will($this->returnValue(array('42 GB')));
+			->will($this->returnValue(['42 GB']));
 
-		$user = $this->createMock(IUser::class);
-		$user->expects($this->once())
+		$coreUser = $this->createMock(IUser::class);
+		$coreUser->expects($this->once())
 			->method('setQuota')
 			->with('42 GB');
 
-		$userMgr->expects($this->atLeastOnce())
+		$this->userManager->expects($this->atLeastOnce())
 			->method('get')
-			->with('alice')
-			->will($this->returnValue($user));
+			->with($this->uid)
+			->will($this->returnValue($coreUser));
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->updateQuota();
+		$this->user->updateQuota();
 	}
 
 	public function testUpdateQuotaToDefaultAllProvided() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->connection->expects($this->exactly(2))
 			->method('__get')
 			->willReturnMap([
@@ -230,33 +210,24 @@ class UserTest extends \Test\TestCase {
 
 		$this->access->expects($this->once())
 			->method('readAttribute')
-			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+			->with($this->equalTo($this->dn),
 				$this->equalTo('myquota'))
-			->will($this->returnValue(array('default')));
+			->will($this->returnValue(['default']));
 
-		$user = $this->createMock('\OCP\IUser');
-		$user->expects($this->once())
+		$coreUser = $this->createMock(IUser::class);
+		$coreUser->expects($this->once())
 			->method('setQuota')
 			->with('default');
 
-		$userMgr->expects($this->once())
+		$this->userManager->expects($this->once())
 			->method('get')
-			->with('alice')
-			->will($this->returnValue($user));
+			->with($this->uid)
+			->will($this->returnValue($coreUser));
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->updateQuota();
+		$this->user->updateQuota();
 	}
 
 	public function testUpdateQuotaToNoneAllProvided() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->connection->expects($this->exactly(2))
 			->method('__get')
 			->willReturnMap([
@@ -266,33 +237,24 @@ class UserTest extends \Test\TestCase {
 
 		$this->access->expects($this->once())
 			->method('readAttribute')
-			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+			->with($this->equalTo($this->dn),
 				$this->equalTo('myquota'))
-			->will($this->returnValue(array('none')));
+			->will($this->returnValue(['none']));
 
-		$user = $this->createMock('\OCP\IUser');
-		$user->expects($this->once())
+		$coreUser = $this->createMock(IUser::class);
+		$coreUser->expects($this->once())
 			->method('setQuota')
 			->with('none');
 
-		$userMgr->expects($this->once())
+		$this->userManager->expects($this->once())
 			->method('get')
-			->with('alice')
-			->will($this->returnValue($user));
+			->with($this->uid)
+			->will($this->returnValue($coreUser));
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->updateQuota();
+		$this->user->updateQuota();
 	}
 
 	public function testUpdateQuotaDefaultProvided() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->connection->expects($this->at(0))
 			->method('__get')
 			->with($this->equalTo('ldapQuotaAttribute'))
@@ -306,33 +268,24 @@ class UserTest extends \Test\TestCase {
 
 		$this->access->expects($this->once())
 			->method('readAttribute')
-			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+			->with($this->equalTo($this->dn),
 				$this->equalTo('myquota'))
 			->will($this->returnValue(false));
 
-		$user = $this->createMock(IUser::class);
-		$user->expects($this->once())
+		$coreUser = $this->createMock(IUser::class);
+		$coreUser->expects($this->once())
 			->method('setQuota')
 			->with('25 GB');
 
-		$userMgr->expects($this->once())
+		$this->userManager->expects($this->once())
 			->method('get')
-			->with('alice')
-			->will($this->returnValue($user));
+			->with($this->uid)
+			->will($this->returnValue($coreUser));
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->updateQuota();
+		$this->user->updateQuota();
 	}
 
 	public function testUpdateQuotaIndividualProvided() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->connection->expects($this->exactly(2))
 			->method('__get')
 			->willReturnMap([
@@ -342,33 +295,24 @@ class UserTest extends \Test\TestCase {
 
 		$this->access->expects($this->once())
 			->method('readAttribute')
-			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+			->with($this->equalTo($this->dn),
 				$this->equalTo('myquota'))
-			->will($this->returnValue(array('27 GB')));
+			->will($this->returnValue(['27 GB']));
 
-		$user = $this->createMock(IUser::class);
-		$user->expects($this->once())
+		$coreUser = $this->createMock(IUser::class);
+		$coreUser->expects($this->once())
 			->method('setQuota')
 			->with('27 GB');
 
-		$userMgr->expects($this->once())
+		$this->userManager->expects($this->once())
 			->method('get')
-			->with('alice')
-			->will($this->returnValue($user));
+			->with($this->uid)
+			->will($this->returnValue($coreUser));
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->updateQuota();
+		$this->user->updateQuota();
 	}
 
 	public function testUpdateQuotaNoneProvided() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->connection->expects($this->exactly(2))
 			->method('__get')
 			->willReturnMap([
@@ -378,34 +322,25 @@ class UserTest extends \Test\TestCase {
 
 		$this->access->expects($this->once())
 			->method('readAttribute')
-			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+			->with($this->equalTo($this->dn),
 				$this->equalTo('myquota'))
 			->will($this->returnValue(false));
 
-		$user = $this->createMock('\OCP\IUser');
-		$user->expects($this->never())
+		$coreUser = $this->createMock(IUser::class);
+		$coreUser->expects($this->never())
 			->method('setQuota');
 
-		$userMgr->expects($this->never())
+		$this->userManager->expects($this->never())
 			->method('get')
-			->with('alice');
+			->with($this->uid);
 
-		$config->expects($this->never())
+		$this->config->expects($this->never())
 			->method('setUserValue');
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->updateQuota();
+		$this->user->updateQuota();
 	}
 
 	public function testUpdateQuotaNoneConfigured() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->connection->expects($this->exactly(2))
 			->method('__get')
 			->willReturnMap([
@@ -413,32 +348,23 @@ class UserTest extends \Test\TestCase {
 				['ldapQuotaDefault', '']
 			]);
 
-		$user = $this->createMock('\OCP\IUser');
-		$user->expects($this->never())
+		$coreUser = $this->createMock(IUser::class);
+		$coreUser->expects($this->never())
 			->method('setQuota');
 
-		$userMgr->expects($this->never())
+		$this->userManager->expects($this->never())
 			->method('get');
 
 		$this->access->expects($this->never())
 			->method('readAttribute');
 
-		$config->expects($this->never())
+		$this->config->expects($this->never())
 			->method('setUserValue');
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->updateQuota();
+		$this->user->updateQuota();
 	}
 
 	public function testUpdateQuotaFromValue() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$readQuota = '19 GB';
 
 		$this->connection->expects($this->exactly(2))
@@ -456,27 +382,18 @@ class UserTest extends \Test\TestCase {
 			->method('setQuota')
 			->with($readQuota);
 
-		$userMgr->expects($this->once())
+		$this->userManager->expects($this->once())
 			->method('get')
-			->with('alice')
+			->with($this->uid)
 			->will($this->returnValue($user));
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->updateQuota($readQuota);
+		$this->user->updateQuota($readQuota);
 	}
 
 	/**
 	 * Unparseable quota will fallback to use the LDAP default
 	 */
 	public function testUpdateWrongQuotaAllProvided() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->connection->expects($this->exactly(2))
 			->method('__get')
 			->willReturnMap([
@@ -486,36 +403,27 @@ class UserTest extends \Test\TestCase {
 
 		$this->access->expects($this->once())
 			->method('readAttribute')
-			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+			->with($this->equalTo($this->dn),
 				$this->equalTo('myquota'))
-			->will($this->returnValue(array('42 GBwos')));
+			->will($this->returnValue(['42 GBwos']));
 
-		$user = $this->createMock('\OCP\IUser');
-		$user->expects($this->once())
+		$coreUser = $this->createMock(IUser::class);
+		$coreUser->expects($this->once())
 			->method('setQuota')
 			->with('23 GB');
 
-		$userMgr->expects($this->once())
+		$this->userManager->expects($this->once())
 			->method('get')
-			->with('alice')
-			->will($this->returnValue($user));
+			->with($this->uid)
+			->will($this->returnValue($coreUser));
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->updateQuota();
+		$this->user->updateQuota();
 	}
 
 	/**
 	 * No user quota and wrong default will set 'default' as quota
 	 */
 	public function testUpdateWrongDefaultQuotaProvided() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->connection->expects($this->exactly(2))
 			->method('__get')
 			->willReturnMap([
@@ -525,33 +433,24 @@ class UserTest extends \Test\TestCase {
 
 		$this->access->expects($this->once())
 			->method('readAttribute')
-			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+			->with($this->equalTo($this->dn),
 				$this->equalTo('myquota'))
 			->will($this->returnValue(false));
 
-		$user = $this->createMock('\OCP\IUser');
-		$user->expects($this->never())
+		$coreUser = $this->createMock(IUser::class);
+		$coreUser->expects($this->never())
 			->method('setQuota');
 
-		$userMgr->expects($this->never())
+		$this->userManager->expects($this->never())
 			->method('get');
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->updateQuota();
+		$this->user->updateQuota();
 	}
 
 	/**
 	 * Wrong user quota and wrong default will set 'default' as quota
 	 */
 	public function testUpdateWrongQuotaAndDefaultAllProvided() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->connection->expects($this->exactly(2))
 			->method('__get')
 			->willReturnMap([
@@ -561,33 +460,24 @@ class UserTest extends \Test\TestCase {
 
 		$this->access->expects($this->once())
 			->method('readAttribute')
-			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+			->with($this->equalTo($this->dn),
 				$this->equalTo('myquota'))
-			->will($this->returnValue(array('23 flush')));
+			->will($this->returnValue(['23 flush']));
 
-		$user = $this->createMock('\OCP\IUser');
-		$user->expects($this->never())
+		$coreUser = $this->createMock(IUser::class);
+		$coreUser->expects($this->never())
 			->method('setQuota');
 
-		$userMgr->expects($this->never())
+		$this->userManager->expects($this->never())
 			->method('get');
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->updateQuota();
+		$this->user->updateQuota();
 	}
 
 	/**
 	 * No quota attribute set and wrong default will set 'default' as quota
 	 */
 	public function testUpdateWrongDefaultQuotaNotProvided() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->connection->expects($this->exactly(2))
 			->method('__get')
 			->willReturnMap([
@@ -598,81 +488,63 @@ class UserTest extends \Test\TestCase {
 		$this->access->expects($this->never())
 			->method('readAttribute');
 
-		$user = $this->createMock('\OCP\IUser');
-		$user->expects($this->never())
+		$coreUser = $this->createMock(IUser::class);
+		$coreUser->expects($this->never())
 			->method('setQuota');
 
-		$userMgr->expects($this->never())
+		$this->userManager->expects($this->never())
 			->method('get');
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->updateQuota();
+		$this->user->updateQuota();
 	}
 
 	//the testUpdateAvatar series also implicitely tests getAvatarImage
 	public function testUpdateAvatarJpegPhotoProvided() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->access->expects($this->once())
 			->method('readAttribute')
-			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+			->with($this->equalTo($this->dn),
 				$this->equalTo('jpegPhoto'))
-			->will($this->returnValue(array('this is a photo')));
+			->will($this->returnValue(['this is a photo']));
 
-		$image->expects($this->once())
+		$this->image->expects($this->once())
 			->method('valid')
 			->will($this->returnValue(true));
-		$image->expects($this->once())
+		$this->image->expects($this->once())
 			->method('width')
 			->will($this->returnValue(128));
-		$image->expects($this->once())
+		$this->image->expects($this->once())
 			->method('height')
 			->will($this->returnValue(128));
-		$image->expects($this->once())
+		$this->image->expects($this->once())
 			->method('centerCrop')
 			->will($this->returnValue(true));
 
-		$filesys->expects($this->once())
+		$this->filesystemhelper->expects($this->once())
 			->method('isLoaded')
 			->will($this->returnValue(true));
 
 		$avatar = $this->createMock(IAvatar::class);
 		$avatar->expects($this->once())
 			->method('set')
-			->with($this->isInstanceOf($image));
+			->with($this->isInstanceOf($this->image));
 
-		$avaMgr->expects($this->once())
+		$this->avatarManager->expects($this->once())
 			->method('getAvatar')
-			->with($this->equalTo('alice'))
+			->with($this->equalTo($this->uid))
 			->will($this->returnValue($avatar));
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->updateAvatar();
+		$this->user->updateAvatar();
 	}
 
 	public function testUpdateAvatarThumbnailPhotoProvided() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->access->expects($this->any())
 			->method('readAttribute')
 			->willReturnCallback(function($dn, $attr) {
-				if($dn === 'uid=alice,dc=foo,dc=bar'
+				if($dn === $this->dn
 					&& $attr === 'jpegPhoto')
 				{
 					return false;
-				} elseif($dn === 'uid=alice,dc=foo,dc=bar'
+				} elseif($dn === $this->dn
 					&& $attr === 'thumbnailPhoto')
 				{
 					return ['this is a photo'];
@@ -680,54 +552,45 @@ class UserTest extends \Test\TestCase {
 				return null;
 			});
 
-		$image->expects($this->once())
+		$this->image->expects($this->once())
 			->method('valid')
 			->will($this->returnValue(true));
-		$image->expects($this->once())
+		$this->image->expects($this->once())
 			->method('width')
 			->will($this->returnValue(128));
-		$image->expects($this->once())
+		$this->image->expects($this->once())
 			->method('height')
 			->will($this->returnValue(128));
-		$image->expects($this->once())
+		$this->image->expects($this->once())
 			->method('centerCrop')
 			->will($this->returnValue(true));
 
-		$filesys->expects($this->once())
+		$this->filesystemhelper->expects($this->once())
 			->method('isLoaded')
 			->will($this->returnValue(true));
 
 		$avatar = $this->createMock(IAvatar::class);
 		$avatar->expects($this->once())
 			->method('set')
-			->with($this->isInstanceOf($image));
+			->with($this->isInstanceOf($this->image));
 
-		$avaMgr->expects($this->once())
+		$this->avatarManager->expects($this->once())
 			->method('getAvatar')
-			->with($this->equalTo('alice'))
+			->with($this->equalTo($this->uid))
 			->will($this->returnValue($avatar));
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->updateAvatar();
+		$this->user->updateAvatar();
 	}
 
 	public function testUpdateAvatarNotProvided() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->access->expects($this->any())
 			->method('readAttribute')
 			->willReturnCallback(function($dn, $attr) {
-				if($dn === 'uid=alice,dc=foo,dc=bar'
+				if($dn === $this->dn
 					&& $attr === 'jpegPhoto')
 				{
 					return false;
-				} elseif($dn === 'uid=alice,dc=foo,dc=bar'
+				} elseif($dn === $this->dn
 					&& $attr === 'thumbnailPhoto')
 				{
 					return false;
@@ -735,182 +598,124 @@ class UserTest extends \Test\TestCase {
 				return null;
 			});
 
-		$image->expects($this->never())
+		$this->image->expects($this->never())
 			->method('valid');
-		$image->expects($this->never())
+		$this->image->expects($this->never())
 			->method('width');
-		$image->expects($this->never())
+		$this->image->expects($this->never())
 			->method('height');
-		$image->expects($this->never())
+		$this->image->expects($this->never())
 			->method('centerCrop');
 
-		$filesys->expects($this->never())
+		$this->filesystemhelper->expects($this->never())
 			->method('isLoaded');
 
-		$avaMgr->expects($this->never())
+		$this->avatarManager->expects($this->never())
 			->method('getAvatar');
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->updateAvatar();
+		$this->user->updateAvatar();
 	}
 
 	public function testUpdateBeforeFirstLogin() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
-		$config->expects($this->at(0))
+		$this->config->expects($this->at(0))
 			->method('getUserValue')
-			->with($this->equalTo('alice'), $this->equalTo('user_ldap'),
+			->with($this->equalTo($this->uid), $this->equalTo('user_ldap'),
 				$this->equalTo(User::USER_PREFKEY_FIRSTLOGIN),
 				$this->equalTo(0))
 			->will($this->returnValue(0));
-		$config->expects($this->at(1))
+		$this->config->expects($this->at(1))
 			->method('getUserValue')
-			->with($this->equalTo('alice'), $this->equalTo('user_ldap'),
+			->with($this->equalTo($this->uid), $this->equalTo('user_ldap'),
 				$this->equalTo(User::USER_PREFKEY_LASTREFRESH),
 				$this->equalTo(0))
 			->will($this->returnValue(0));
-		$config->expects($this->exactly(2))
+		$this->config->expects($this->exactly(2))
 			->method('getUserValue');
-		$config->expects($this->never())
+		$this->config->expects($this->never())
 			->method('setUserValue');
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->update();
+		$this->user->update();
 	}
 
 	public function testUpdateAfterFirstLogin() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
-		$config->expects($this->at(0))
+		$this->config->expects($this->at(0))
 			->method('getUserValue')
-			->with($this->equalTo('alice'), $this->equalTo('user_ldap'),
+			->with($this->equalTo($this->uid), $this->equalTo('user_ldap'),
 				$this->equalTo(User::USER_PREFKEY_FIRSTLOGIN),
 				$this->equalTo(0))
 			->will($this->returnValue(1));
-		$config->expects($this->at(1))
+		$this->config->expects($this->at(1))
 			->method('getUserValue')
-			->with($this->equalTo('alice'), $this->equalTo('user_ldap'),
+			->with($this->equalTo($this->uid), $this->equalTo('user_ldap'),
 				$this->equalTo(User::USER_PREFKEY_LASTREFRESH),
 				$this->equalTo(0))
 			->will($this->returnValue(0));
-		$config->expects($this->exactly(2))
+		$this->config->expects($this->exactly(2))
 			->method('getUserValue');
-		$config->expects($this->once())
+		$this->config->expects($this->once())
 			->method('setUserValue')
-			->with($this->equalTo('alice'), $this->equalTo('user_ldap'),
+			->with($this->equalTo($this->uid), $this->equalTo('user_ldap'),
 				$this->equalTo(User::USER_PREFKEY_LASTREFRESH),
 				$this->anything())
 			->will($this->returnValue(true));
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->update();
+		$this->user->update();
 	}
 
 	public function testUpdateNoRefresh() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
-		$config->expects($this->at(0))
+		$this->config->expects($this->at(0))
 			->method('getUserValue')
-			->with($this->equalTo('alice'), $this->equalTo('user_ldap'),
+			->with($this->equalTo($this->uid), $this->equalTo('user_ldap'),
 				$this->equalTo(User::USER_PREFKEY_FIRSTLOGIN),
 				$this->equalTo(0))
 			->will($this->returnValue(1));
-		$config->expects($this->at(1))
+		$this->config->expects($this->at(1))
 			->method('getUserValue')
-			->with($this->equalTo('alice'), $this->equalTo('user_ldap'),
+			->with($this->equalTo($this->uid), $this->equalTo('user_ldap'),
 				$this->equalTo(User::USER_PREFKEY_LASTREFRESH),
 				$this->equalTo(0))
 			->will($this->returnValue(time() - 10));
-
-		$config->expects($this->once())
+		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with($this->equalTo('user_ldap'),
 				$this->equalTo('updateAttributesInterval'),
 				$this->anything())
 			->will($this->returnValue(1800));
-		$config->expects($this->exactly(2))
+		$this->config->expects($this->exactly(2))
 			->method('getUserValue');
-		$config->expects($this->never())
+		$this->config->expects($this->never())
 			->method('setUserValue');
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->update();
+		$this->user->update();
 	}
 
 	public function testMarkLogin() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
-		$config->expects($this->once())
+		$this->config->expects($this->once())
 			->method('setUserValue')
-			->with($this->equalTo('alice'),
+			->with($this->equalTo($this->uid),
 				$this->equalTo('user_ldap'),
 				$this->equalTo(User::USER_PREFKEY_FIRSTLOGIN),
 				$this->equalTo(1))
 			->will($this->returnValue(true));
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->markLogin();
+		$this->user->markLogin();
 	}
 
 	public function testGetAvatarImageProvided() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->access->expects($this->once())
 			->method('readAttribute')
-			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+			->with($this->equalTo($this->dn),
 				$this->equalTo('jpegPhoto'))
-			->will($this->returnValue(array('this is a photo')));
+			->will($this->returnValue(['this is a photo']));
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$photo = $user->getAvatarImage();
+		$photo = $this->user->getAvatarImage();
 		$this->assertSame('this is a photo', $photo);
 		//make sure readAttribute is not called again but the already fetched
 		//photo is returned
-		$photo = $user->getAvatarImage();
+		$this->user->getAvatarImage();
 	}
 
 	public function testProcessAttributes() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
-		$uid = 'alice';
-		$dn = 'uid=alice';
-
 		$requiredMethods = array(
 			'markRefreshTime',
 			'updateQuota',
@@ -923,7 +728,18 @@ class UserTest extends \Test\TestCase {
 
 		/** @var User|\PHPUnit_Framework_MockObject_MockObject $userMock */
 		$userMock = $this->getMockBuilder(User::class)
-			->setConstructorArgs(array($uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr))
+			->setConstructorArgs([
+				$this->uid,
+				$this->dn,
+				$this->access,
+				$this->config,
+				$this->filesystemhelper,
+				$this->image,
+				$this->log,
+				$this->avatarManager,
+				$this->userManager,
+				$this->notificationManager
+			])
 			->setMethods($requiredMethods)
 			->getMock();
 
@@ -932,7 +748,6 @@ class UserTest extends \Test\TestCase {
 		));
 		$this->connection->expects($this->any())
 			->method('__get')
-			//->will($this->returnArgument(0));
 			->will($this->returnCallback(function($name) {
 				if($name === 'homeFolderNamingRule') {
 					return 'attr:homeDirectory';
@@ -944,7 +759,7 @@ class UserTest extends \Test\TestCase {
 			strtolower($this->connection->ldapQuotaAttribute) => array('4096'),
 			strtolower($this->connection->ldapEmailAttribute) => array('alice@wonderland.org'),
 			strtolower($this->connection->ldapUserDisplayName) => array('Aaaaalice'),
-			'uid' => array($uid),
+			'uid' => [$this->uid],
 			'homedirectory' => array('Alice\'s Folder'),
 			'memberof' => array('cn=groupOne', 'cn=groupTwo'),
 			'jpegphoto' => array('here be an image')
@@ -956,13 +771,14 @@ class UserTest extends \Test\TestCase {
 		}
 		\OC_Hook::clear();//disconnect irrelevant hooks 
 		$userMock->processAttributes($record);
-		\OC_Hook::emit('OC_User', 'post_login', array('uid' => $uid));
+		/** @noinspection PhpUnhandledExceptionInspection */
+		\OC_Hook::emit('OC_User', 'post_login', ['uid' => $this->uid]);
 	}
 
 	public function emptyHomeFolderAttributeValueProvider() {
 		return array(
-			'empty' => array(''),
-			'prefixOnly' => array('attr:'),
+			'empty' => [''],
+			'prefixOnly' => ['attr:'],
 		);
 	}
 
@@ -970,9 +786,6 @@ class UserTest extends \Test\TestCase {
 	 * @dataProvider emptyHomeFolderAttributeValueProvider
 	 */
 	public function testGetHomePathNotConfigured($attributeValue) {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->connection->expects($this->any())
 			->method('__get')
 			->with($this->equalTo('homeFolderNamingRule'))
@@ -981,23 +794,14 @@ class UserTest extends \Test\TestCase {
 		$this->access->expects($this->never())
 			->method('readAttribute');
 
-		$config->expects($this->never())
+		$this->config->expects($this->never())
 			->method('getAppValue');
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$path = $user->getHomePath();
-		$this->assertSame($path, false);
+		/** @noinspection PhpUnhandledExceptionInspection */
+		$this->assertFalse($this->user->getHomePath());
 	}
 
 	public function testGetHomePathConfiguredNotAvailableAllowed() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->connection->expects($this->any())
 			->method('__get')
 			->with($this->equalTo('homeFolderNamingRule'))
@@ -1008,28 +812,18 @@ class UserTest extends \Test\TestCase {
 			->will($this->returnValue(false));
 
 		// asks for "enforce_home_folder_naming_rule"
-		$config->expects($this->once())
+		$this->config->expects($this->once())
 			->method('getAppValue')
 			->will($this->returnValue(false));
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$path = $user->getHomePath();
-
-		$this->assertSame($path, false);
+		/** @noinspection PhpUnhandledExceptionInspection */
+		$this->assertFalse($this->user->getHomePath());
 	}
 
 	/**
 	 * @expectedException \Exception
 	 */
 	public function testGetHomePathConfiguredNotAvailableNotAllowed() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
 		$this->connection->expects($this->any())
 			->method('__get')
 			->with($this->equalTo('homeFolderNamingRule'))
@@ -1040,17 +834,11 @@ class UserTest extends \Test\TestCase {
 			->will($this->returnValue(false));
 
 		// asks for "enforce_home_folder_naming_rule"
-		$config->expects($this->once())
+		$this->config->expects($this->once())
 			->method('getAppValue')
 			->will($this->returnValue(true));
 
-		$uid = 'alice';
-		$dn  = 'uid=alice,dc=foo,dc=bar';
-
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$user->getHomePath();
+		$this->user->getHomePath();
 	}
 
 	public function displayNameProvider() {
@@ -1065,26 +853,14 @@ class UserTest extends \Test\TestCase {
 	 * @dataProvider displayNameProvider
 	 */
 	public function testComposeAndStoreDisplayName($part1, $part2, $expected) {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
-		$config->expects($this->once())
+		$this->config->expects($this->once())
 			->method('setUserValue');
 
-		$user = new User(
-			'user', 'cn=user', $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		$displayName = $user->composeAndStoreDisplayName($part1, $part2);
+		$displayName = $this->user->composeAndStoreDisplayName($part1, $part2);
 		$this->assertSame($expected, $displayName);
 	}
 
 	public function testHandlePasswordExpiryWarningDefaultPolicy() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
-		$uid = 'alice';
-		$dn = 'uid=alice';
-
 		$this->connection->expects($this->any())
 			->method('__get')
 			->will($this->returnCallback(function($name) {
@@ -1100,23 +876,23 @@ class UserTest extends \Test\TestCase {
 		$this->access->expects($this->any())
 			->method('search')
 			->will($this->returnCallback(function($filter, $base) {
-				if($base === array('uid=alice')) {
-					return array(
-						array(
-							'pwdchangedtime' => array((new \DateTime())->sub(new \DateInterval('P28D'))->format('Ymdhis').'Z'),
+				if($base === [$this->dn]) {
+					return [
+						[
+							'pwdchangedtime' => [(new \DateTime())->sub(new \DateInterval('P28D'))->format('Ymdhis').'Z'],
 							'pwdgraceusetime' => [],
-						),
-					);
+						],
+					];
 				}
-				if($base === array('cn=default,ou=policies,dc=foo,dc=bar')) {
-					return array(
-						array(
-							'pwdmaxage' => array('2592000'),
-							'pwdexpirewarning' => array('2591999'),
-						),
-					);
+				if($base === ['cn=default,ou=policies,dc=foo,dc=bar']) {
+					return [
+						[
+							'pwdmaxage' => ['2592000'],
+							'pwdexpirewarning' => ['2591999'],
+						],
+					];
 				}
-				return array();
+				return [];
 			}));
 
 		$notification = $this->getMockBuilder(INotification::class)
@@ -1134,27 +910,20 @@ class UserTest extends \Test\TestCase {
 		$notification->expects($this->any())
 			->method('setDateTime')
 			->will($this->returnValue($notification));
-		$notiMgr->expects($this->exactly(2))
+
+		$this->notificationManager->expects($this->exactly(2))
 			->method('createNotification')
 			->will($this->returnValue($notification));
-		$notiMgr->expects($this->exactly(1))
+		$this->notificationManager->expects($this->exactly(1))
 			->method('notify');
 
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
 		\OC_Hook::clear();//disconnect irrelevant hooks
-		\OCP\Util::connectHook('OC_User', 'post_login', $user, 'handlePasswordExpiry');
-		\OC_Hook::emit('OC_User', 'post_login', array('uid' => $uid));
+		\OCP\Util::connectHook('OC_User', 'post_login', $this->user, 'handlePasswordExpiry');
+		/** @noinspection PhpUnhandledExceptionInspection */
+		\OC_Hook::emit('OC_User', 'post_login', ['uid' => $this->uid]);
 	}
 
 	public function testHandlePasswordExpiryWarningCustomPolicy() {
-		list(, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
-		$uid = 'alice';
-		$dn = 'uid=alice';
-
 		$this->connection->expects($this->any())
 			->method('__get')
 			->will($this->returnCallback(function($name) {
@@ -1170,24 +939,24 @@ class UserTest extends \Test\TestCase {
 		$this->access->expects($this->any())
 			->method('search')
 			->will($this->returnCallback(function($filter, $base) {
-				if($base === array('uid=alice')) {
-					return array(
-						array(
-							'pwdpolicysubentry' => array('cn=custom,ou=policies,dc=foo,dc=bar'),
-							'pwdchangedtime' => array((new \DateTime())->sub(new \DateInterval('P28D'))->format('Ymdhis').'Z'),
+				if($base === [$this->dn]) {
+					return [
+						[
+							'pwdpolicysubentry' => ['cn=custom,ou=policies,dc=foo,dc=bar'],
+							'pwdchangedtime' => [(new \DateTime())->sub(new \DateInterval('P28D'))->format('Ymdhis').'Z'],
 							'pwdgraceusetime' => [],
-						)
-					);
+						]
+					];
 				}
-				if($base === array('cn=custom,ou=policies,dc=foo,dc=bar')) {
-					return array(
-						array(
-							'pwdmaxage' => array('2592000'),
-							'pwdexpirewarning' => array('2591999'),
-						)
-					);
+				if($base === ['cn=custom,ou=policies,dc=foo,dc=bar']) {
+					return [
+						[
+							'pwdmaxage' => ['2592000'],
+							'pwdexpirewarning' => ['2591999'],
+						]
+					];
 				}
-				return array();
+				return [];
 			}));
 
 		$notification = $this->getMockBuilder(INotification::class)
@@ -1205,17 +974,16 @@ class UserTest extends \Test\TestCase {
 		$notification->expects($this->any())
 			->method('setDateTime')
 			->will($this->returnValue($notification));
-		$notiMgr->expects($this->exactly(2))
+
+		$this->notificationManager->expects($this->exactly(2))
 			->method('createNotification')
 			->will($this->returnValue($notification));
-		$notiMgr->expects($this->exactly(1))
+		$this->notificationManager->expects($this->exactly(1))
 			->method('notify');
 
-		$user = new User(
-			$uid, $dn, $this->access, $config, $filesys, $image, $log, $avaMgr, $userMgr, $notiMgr);
-
-		\OC_Hook::clear();//disconnect irrelevant hooks 
-		\OCP\Util::connectHook('OC_User', 'post_login', $user, 'handlePasswordExpiry');
-		\OC_Hook::emit('OC_User', 'post_login', array('uid' => $uid));
+		\OC_Hook::clear();//disconnect irrelevant hooks
+		\OCP\Util::connectHook('OC_User', 'post_login', $this->user, 'handlePasswordExpiry');
+		/** @noinspection PhpUnhandledExceptionInspection */
+		\OC_Hook::emit('OC_User', 'post_login', ['uid' => $this->uid]);
 	}
 }

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -1312,6 +1312,34 @@ class User_LDAPTest extends TestCase {
 		$this->assertEquals($this->backend->setPassword('uid', 'password'),'result');
 	}
 
+	public function avatarDataProvider() {
+		return [
+			[ 'validImageData', false ],
+			[ 'corruptImageData', true ],
+			[ false, true]
+		];
+	}
+
+	/** @dataProvider avatarDataProvider */
+	public function testCanChangeAvatar($imageData, $expected) {
+		$isValidImage  = strpos((string)$imageData, 'valid') === 0;
+
+		$user = $this->createMock(User::class);
+		$user->expects($this->once())
+			->method('getAvatarImage')
+			->willReturn($imageData);
+		$user->expects($this->atMost(1))
+			->method('updateAvatar')
+			->willReturn($isValidImage);
+
+		$this->userManager->expects($this->atLeastOnce())
+			->method('get')
+			->willReturn($user);
+
+		/** @noinspection PhpUnhandledExceptionInspection */
+		$this->assertSame($expected, $this->backend->canChangeAvatar('uid'));
+	}
+
 	public function testCanChangeAvatarWithPlugin() {
 		$this->pluginManager->expects($this->once())
 			->method('implementsActions')

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -35,10 +35,6 @@ use OC\User\Backend;
 use OC\User\Session;
 use OCA\User_LDAP\Access;
 use OCA\User_LDAP\Connection;
-use OCA\User_LDAP\FilesystemHelper;
-use OCA\User_LDAP\Helper;
-use OCA\User_LDAP\ILDAPWrapper;
-use OCA\User_LDAP\LogWrapper;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User\Manager;
 use OCA\User_LDAP\User\OfflineUser;
@@ -46,12 +42,9 @@ use OC\HintException;
 use OCA\User_LDAP\User\User;
 use OCA\User_LDAP\User_LDAP as UserLDAP;
 use OCA\User_LDAP\User_LDAP;
-use OCP\IAvatarManager;
+use OCA\User_LDAP\UserPluginManager;
 use OCP\IConfig;
-use OCP\IDBConnection;
-use OCP\Image;
 use OCP\IUser;
-use OCP\IUserManager;
 use Test\TestCase;
 use OCP\Notification\IManager as INotificationManager;
 
@@ -63,63 +56,55 @@ use OCP\Notification\IManager as INotificationManager;
  * @package OCA\User_LDAP\Tests
  */
 class User_LDAPTest extends TestCase {
+	/** @var User_LDAP */
 	protected $backend;
+	/** @var Access|\PHPUnit_Framework_MockObject_MockObject */
 	protected $access;
-	/** @var  IConfig|\PHPUnit_Framework_MockObject_MockObject */
-	protected $configMock;
 	/** @var  OfflineUser|\PHPUnit_Framework_MockObject_MockObject */
 	protected $offlineUser;
+	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	protected $config;
+	/** @var INotificationManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $notificationManager;
+	/** @var Session|\PHPUnit_Framework_MockObject_MockObject */
+	protected $session;
+	/** @var UserPluginManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $pluginManager;
+	/** @var Connection|\PHPUnit_Framework_MockObject_MockObject */
+	protected $connection;
+	/** @var Manager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $userManager;
 
 	protected function setUp() {
 		parent::setUp();
 
 		\OC_User::clearBackends();
 		\OC::$server->getGroupManager()->clearBackends();
+
+		$this->connection = $this->createMock(Connection::class);
+		$this->userManager = $this->createMock(Manager::class);
+
+		$this->access = $this->createMock(Access::class);
+		$this->access->connection = $this->connection;
+		$this->access->userManager = $this->userManager;
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->notificationManager = $this->createMock(INotificationManager::class);
+		// Cannot use IUserSession because of private listen() methods
+		$this->session = $this->createMock(Session::class);
+		$this->pluginManager = $this->createMock(UserPluginManager::class);
+
+		$this->backend = new User_LDAP(
+			$this->access,
+			$this->config,
+			$this->notificationManager,
+			$this->session,
+			$this->pluginManager
+		);
 	}
 
-	/**
-	 * @return \PHPUnit_Framework_MockObject_MockObject|Access
-	 */
-	private function getAccessMock() {
-		$this->configMock = $this->createMock(IConfig::class);
-
-		$this->offlineUser = $this->createMock(OfflineUser::class);
-
-		/** @var Manager|\PHPUnit_Framework_MockObject_MockObject $um */
-		$um = $this->getMockBuilder(Manager::class)
-			->setMethods(['getDeletedUser'])
-			->setConstructorArgs([
-				$this->configMock,
-				$this->createMock(FilesystemHelper::class),
-				$this->createMock(LogWrapper::class),
-				$this->createMock(IAvatarManager::class),
-				$this->createMock(Image::class),
-				$this->createMock(IDBConnection::class),
-				$this->createMock(IUserManager::class),
-				$this->createMock(INotificationManager::class)
-			  ])
-			->getMock();
-
-		/** @var Connection|\PHPUnit_Framework_MockObject_MockObject $connection */
-		$connection = $this->createMock(Connection::class);
-
-		/** @var Manager|\PHPUnit_Framework_MockObject_MockObject $userManager */
-		$userManager = $this->createMock(Manager::class);
-
-		/** @var Access|\PHPUnit_Framework_MockObject_MockObject $access */
-		$access = $this->createMock(Access::class);
-		$access->connection = $connection;
-		$access->userManager = $userManager;
-
-		return $access;
-	}
-
-	private function getDefaultPluginManagerMock() {
-		return $this->getMockBuilder('\OCA\User_LDAP\UserPluginManager')->getMock();
-	}
-
-	private function prepareMockForUserExists(&$access) {
-		$access->expects($this->any())
+	private function prepareMockForUserExists() {
+		$this->access->expects($this->any())
 			   ->method('username2dn')
 			   ->will($this->returnCallback(function($uid) {
 					switch ($uid) {
@@ -140,18 +125,17 @@ class User_LDAPTest extends TestCase {
 					}
 			   }));
 
-		$access->method('fetchUsersByLoginName')
+		$this->access->method('fetchUsersByLoginName')
 			->willReturn([]);
 	}
 
 	/**
 	 * Prepares the Access mock for checkPassword tests
-	 * @param Access|\PHPUnit_Framework_MockObject_MockObject $access mock
 	 * @param bool $noDisplayName
 	 * @return void
 	 */
-	private function prepareAccessForCheckPassword(&$access, $noDisplayName = false) {
-		$access->connection->expects($this->any())
+	private function prepareAccessForCheckPassword($noDisplayName = false) {
+		$this->connection->expects($this->any())
 			   ->method('__get')
 			   ->will($this->returnCallback(function($name) {
 					if($name === 'ldapLoginFilter') {
@@ -160,7 +144,7 @@ class User_LDAPTest extends TestCase {
 					return null;
 			   }));
 
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			   ->method('fetchListOfUsers')
 			   ->will($this->returnCallback(function($filter) {
 					if($filter === 'roland') {
@@ -168,8 +152,7 @@ class User_LDAPTest extends TestCase {
 					}
 					return array();
 			   }));
-
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('fetchUsersByLoginName')
 			->will($this->returnCallback(function($uid) {
 				if($uid === 'roland') {
@@ -182,17 +165,15 @@ class User_LDAPTest extends TestCase {
 		if($noDisplayName === true) {
 			$retVal = false;
 		}
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			   ->method('dn2username')
 			   ->with($this->equalTo('dnOfRoland,dc=test'))
 			   ->will($this->returnValue($retVal));
-
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			   ->method('stringResemblesDN')
 			   ->with($this->equalTo('dnOfRoland,dc=test'))
 			   ->will($this->returnValue(true));
-
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			   ->method('areCredentialsValid')
 			   ->will($this->returnCallback(function($dn, $pwd) {
 					if($pwd === 'dt19') {
@@ -208,13 +189,12 @@ class User_LDAPTest extends TestCase {
 			->method('getUsername')
 			->willReturn('gunslinger');
 
-		$access = $this->getAccessMock();
-		$this->prepareAccessForCheckPassword($access);
-		$access->userManager->expects($this->any())
+		$this->prepareAccessForCheckPassword();
+		$this->userManager->expects($this->any())
 			->method('get')
 			->willReturn($user);
 
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 
 		\OC_User::useBackend($backend);
 
@@ -223,10 +203,8 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testCheckPasswordWrongPassword() {
-		$access = $this->getAccessMock();
-
-		$this->prepareAccessForCheckPassword($access);
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$this->prepareAccessForCheckPassword();
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 		\OC_User::useBackend($backend);
 
 		$result = $backend->checkPassword('roland', 'wrong');
@@ -234,10 +212,8 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testCheckPasswordWrongUser() {
-		$access = $this->getAccessMock();
-
-		$this->prepareAccessForCheckPassword($access);
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$this->prepareAccessForCheckPassword();
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 		\OC_User::useBackend($backend);
 
 		$result = $backend->checkPassword('mallory', 'evil');
@@ -245,15 +221,14 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testCheckPasswordNoDisplayName() {
-		$access = $this->getAccessMock();
-		$this->prepareAccessForCheckPassword($access, true);
+		$this->prepareAccessForCheckPassword(true);
 
-		$this->prepareAccessForCheckPassword($access);
-		$access->userManager->expects($this->atLeastOnce())
+		$this->prepareAccessForCheckPassword();
+		$this->userManager->expects($this->atLeastOnce())
 			->method('get')
 			->willReturn(null);
 
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 		\OC_User::useBackend($backend);
 
 		$result = $backend->checkPassword('roland', 'dt19');
@@ -266,13 +241,12 @@ class User_LDAPTest extends TestCase {
 			->method('getUsername')
 			->willReturn('gunslinger');
 
-		$access = $this->getAccessMock();
-		$this->prepareAccessForCheckPassword($access);
-		$access->userManager->expects($this->any())
+		$this->prepareAccessForCheckPassword();
+		$this->userManager->expects($this->any())
 			->method('get')
 			->willReturn($user);
 
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 		\OC_User::useBackend($backend);
 
 		$user = \OC::$server->getUserManager()->checkPassword('roland', 'dt19');
@@ -284,9 +258,8 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testCheckPasswordPublicAPIWrongPassword() {
-		$access = $this->getAccessMock();
-		$this->prepareAccessForCheckPassword($access);
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$this->prepareAccessForCheckPassword();
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 		\OC_User::useBackend($backend);
 
 		$user = \OC::$server->getUserManager()->checkPassword('roland', 'wrong');
@@ -298,9 +271,8 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testCheckPasswordPublicAPIWrongUser() {
-		$access = $this->getAccessMock();
-		$this->prepareAccessForCheckPassword($access);
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$this->prepareAccessForCheckPassword();
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 		\OC_User::useBackend($backend);
 
 		$user = \OC::$server->getUserManager()->checkPassword('mallory', 'evil');
@@ -312,8 +284,7 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testDeleteUserCancel() {
-		$access = $this->getAccessMock();
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 		$result = $backend->deleteUser('notme');
 		$this->assertFalse($result);
 	}
@@ -322,35 +293,36 @@ class User_LDAPTest extends TestCase {
 		$uid = 'jeremy';
 		$home = '/var/vhome/jdings/';
 
-		$access = $this->getAccessMock();
 		$mapping = $this->createMock(UserMapping::class);
 		$mapping->expects($this->once())
 			->method('unmap')
 			->will($this->returnValue(true));
-		$access->expects($this->once())
+		$this->access->expects($this->once())
 			->method('getUserMapper')
 			->will($this->returnValue($mapping));
-		$access->connection->expects($this->any())
+		$this->connection->expects($this->any())
 			->method('getConnectionResource')
 			->willReturn('this is an ldap link');
 
-		$this->configMock->expects($this->any())
+		$this->config->expects($this->any())
 			->method('getUserValue')
 			->with($uid, 'user_ldap', 'isDeleted')
 			->willReturn('1');
 
-		$this->offlineUser->expects($this->once())
+		$offlineUser = $this->createMock(OfflineUser::class);
+		$offlineUser->expects($this->once())
 			->method('getHomePath')
 			->willReturn($home);
-		$this->offlineUser->expects($this->once())
+		$offlineUser->expects($this->once())
 			->method('getOCName')
 			->willReturn($uid);
-		$access->userManager->expects($this->atLeastOnce())
+		$this->userManager->expects($this->atLeastOnce())
 			->method('get')
-			->willReturn($this->offlineUser);
+			->willReturn($offlineUser);
 
-		$backend = new UserLDAP($access, $this->configMock, $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 
+		/** @var IUser|\PHPUnit_Framework_MockObject_MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())
 			->method('getUID')
@@ -359,64 +331,42 @@ class User_LDAPTest extends TestCase {
 		$backend->preDeleteUser($user);
 		$result = $backend->deleteUser($uid);
 		$this->assertTrue($result);
+		/** @noinspection PhpUnhandledExceptionInspection */
 		$this->assertSame($backend->getHome($uid), $home);
 	}
 
 	public function testDeleteUserWithPlugin() {
-		$pluginManager = $this->getMockBuilder('\OCA\User_LDAP\UserPluginManager')
-			->setMethods(['canDeleteUser','deleteUser'])
-			->getMock();
-
-		$pluginManager->expects($this->once())
+		$this->pluginManager->expects($this->once())
 			->method('canDeleteUser')
 			->willReturn(true);
-
-		$pluginManager->expects($this->once())
+		$this->pluginManager->expects($this->once())
 			->method('deleteUser')
 			->with('uid')
 			->willReturn('result');
 
-		$access = $this->createMock(Access::class);
-		$config = $this->createMock(IConfig::class);
-		$noti = $this->createMock(INotificationManager::class);
-		$session = $this->createMock(Session::class);
-
-		$ldap = new User_LDAP(
-			$access,
-			$config,
-			$noti,
-			$session,
-			$pluginManager
-		);
-
-		$this->assertEquals($ldap->deleteUser('uid'),'result');
+		$this->assertEquals($this->backend->deleteUser('uid'),'result');
 	}
 
 	/**
 	 * Prepares the Access mock for getUsers tests
-	 * @param Access $access mock
-	 * @return void
 	 */
-	private function prepareAccessForGetUsers(&$access) {
-		$access->expects($this->once())
+	private function prepareAccessForGetUsers() {
+		$this->access->expects($this->once())
 			   ->method('escapeFilterPart')
 			   ->will($this->returnCallback(function($search) {
 				   return $search;
 			   }));
-
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			   ->method('getFilterPartForUserSearch')
 			   ->will($this->returnCallback(function($search) {
 					return $search;
 			   }));
-
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			   ->method('combineFilterWithAnd')
 			   ->will($this->returnCallback(function($param) {
 					return $param[2];
 			   }));
-
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			   ->method('fetchListOfUsers')
 			   ->will($this->returnCallback(function($search, $a, $l, $o) {
 					$users = array('gunslinger', 'newyorker', 'ladyofshadows');
@@ -435,55 +385,48 @@ class User_LDAPTest extends TestCase {
 					}
 					return $result;
 			   }));
-
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			   ->method('nextcloudUserNames')
 			   ->will($this->returnArgument(0));
-
-		$access->method('fetchUsersByLoginName')
+		$this->access->method('fetchUsersByLoginName')
 			->willReturn([]);
 	}
 
 	public function testGetUsersNoParam() {
-		$access = $this->getAccessMock();
-		$this->prepareAccessForGetUsers($access);
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$this->prepareAccessForGetUsers();
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 
 		$result = $backend->getUsers();
 		$this->assertEquals(3, count($result));
 	}
 
 	public function testGetUsersLimitOffset() {
-		$access = $this->getAccessMock();
-		$this->prepareAccessForGetUsers($access);
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$this->prepareAccessForGetUsers();
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 
 		$result = $backend->getUsers('', 1, 2);
 		$this->assertEquals(1, count($result));
 	}
 
 	public function testGetUsersLimitOffset2() {
-		$access = $this->getAccessMock();
-		$this->prepareAccessForGetUsers($access);
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$this->prepareAccessForGetUsers();
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 
 		$result = $backend->getUsers('', 2, 1);
 		$this->assertEquals(2, count($result));
 	}
 
 	public function testGetUsersSearchWithResult() {
-		$access = $this->getAccessMock();
-		$this->prepareAccessForGetUsers($access);
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$this->prepareAccessForGetUsers();
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 
 		$result = $backend->getUsers('yo');
 		$this->assertEquals(2, count($result));
 	}
 
 	public function testGetUsersSearchEmptyResult() {
-		$access = $this->getAccessMock();
-		$this->prepareAccessForGetUsers($access);
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$this->prepareAccessForGetUsers();
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 
 		$result = $backend->getUsers('nix');
 		$this->assertEquals(0, count($result));
@@ -498,9 +441,8 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testGetUsersViaAPINoParam() {
-		$access = $this->getAccessMock();
-		$this->prepareAccessForGetUsers($access);
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$this->prepareAccessForGetUsers();
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 		\OC_User::useBackend($backend);
 
 		$result = $this->getUsers();
@@ -508,9 +450,8 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testGetUsersViaAPILimitOffset() {
-		$access = $this->getAccessMock();
-		$this->prepareAccessForGetUsers($access);
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$this->prepareAccessForGetUsers();
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 		\OC_User::useBackend($backend);
 
 		$result = $this->getUsers('', 1, 2);
@@ -518,9 +459,8 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testGetUsersViaAPILimitOffset2() {
-		$access = $this->getAccessMock();
-		$this->prepareAccessForGetUsers($access);
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$this->prepareAccessForGetUsers();
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 		\OC_User::useBackend($backend);
 
 		$result = $this->getUsers('', 2, 1);
@@ -528,9 +468,8 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testGetUsersViaAPISearchWithResult() {
-		$access = $this->getAccessMock();
-		$this->prepareAccessForGetUsers($access);
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$this->prepareAccessForGetUsers();
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 		\OC_User::useBackend($backend);
 
 		$result = $this->getUsers('yo');
@@ -538,9 +477,8 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testGetUsersViaAPISearchEmptyResult() {
-		$access = $this->getAccessMock();
-		$this->prepareAccessForGetUsers($access);
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$this->prepareAccessForGetUsers();
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 		\OC_User::useBackend($backend);
 
 		$result = $this->getUsers('nix');
@@ -548,16 +486,15 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testUserExists() {
-		$access = $this->getAccessMock();
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
-		$this->prepareMockForUserExists($access);
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
+		$this->prepareMockForUserExists();
 
 		$user = $this->createMock(User::class);
 		$user->expects($this->any())
 			->method('getDN')
 			->willReturn('dnOfRoland,dc=test');
 
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('readAttribute')
 			->will($this->returnCallback(function($dn) {
 				if($dn === 'dnOfRoland,dc=test') {
@@ -565,14 +502,15 @@ class User_LDAPTest extends TestCase {
 				}
 				return false;
 			}));
-		$access->userManager->expects($this->atLeastOnce())
+		$this->userManager->expects($this->atLeastOnce())
 			->method('get')
 			->willReturn($user);
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('getUserMapper')
 			->willReturn($this->createMock(UserMapping::class));
 
 		//test for existing user
+		/** @noinspection PhpUnhandledExceptionInspection */
 		$result = $backend->userExists('gunslinger');
 		$this->assertTrue($result);
 	}
@@ -581,11 +519,10 @@ class User_LDAPTest extends TestCase {
 	 * @expectedException \Exception
 	 */
 	public function testUserExistsForDeleted() {
-		$access = $this->getAccessMock();
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
-		$this->prepareMockForUserExists($access);
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
+		$this->prepareMockForUserExists();
 
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('readAttribute')
 			->will($this->returnCallback(function($dn) {
 				if($dn === 'dnOfRoland,dc=test') {
@@ -594,8 +531,7 @@ class User_LDAPTest extends TestCase {
 				return false;
 			}));
 
-		$access->userManager = $this->createMock(Manager::class);
-		$access->userManager->expects($this->atLeastOnce())
+		$this->userManager->expects($this->atLeastOnce())
 			->method('get')
 			->willReturn($this->createMock(User::class));
 
@@ -604,11 +540,10 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testUserExistsForNeverExisting() {
-		$access = $this->getAccessMock();
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
-		$this->prepareMockForUserExists($access);
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
+		$this->prepareMockForUserExists();
 
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('readAttribute')
 			->will($this->returnCallback(function($dn) {
 				if($dn === 'dnOfRoland,dc=test') {
@@ -618,14 +553,14 @@ class User_LDAPTest extends TestCase {
 			}));
 
 		//test for never-existing user
+		/** @noinspection PhpUnhandledExceptionInspection */
 		$result = $backend->userExists('mallory');
 		$this->assertFalse($result);
 	}
 
 	public function testUserExistsPublicAPI() {
-		$access = $this->getAccessMock();
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
-		$this->prepareMockForUserExists($access);
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
+		$this->prepareMockForUserExists();
 		\OC_User::useBackend($backend);
 
 		$user = $this->createMock(User::class);
@@ -633,7 +568,7 @@ class User_LDAPTest extends TestCase {
 			->method('getDN')
 			->willReturn('dnOfRoland,dc=test');
 
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('readAttribute')
 			->will($this->returnCallback(function($dn) {
 				if($dn === 'dnOfRoland,dc=test') {
@@ -641,10 +576,10 @@ class User_LDAPTest extends TestCase {
 				}
 				return false;
 			}));
-		$access->userManager->expects($this->atLeastOnce())
+		$this->userManager->expects($this->atLeastOnce())
 			->method('get')
 			->willReturn($user);
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('getUserMapper')
 			->willReturn($this->createMock(UserMapping::class));
 
@@ -657,12 +592,11 @@ class User_LDAPTest extends TestCase {
 	 * @expectedException \Exception
 	 */
 	public function testUserExistsPublicAPIForDeleted() {
-		$access = $this->getAccessMock();
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
-		$this->prepareMockForUserExists($access);
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
+		$this->prepareMockForUserExists();
 		\OC_User::useBackend($backend);
 
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('readAttribute')
 			->will($this->returnCallback(function($dn) {
 				if($dn === 'dnOfRoland,dc=test') {
@@ -670,8 +604,7 @@ class User_LDAPTest extends TestCase {
 				}
 				return false;
 			}));
-		$access->userManager = $this->createMock(Manager::class);
-		$access->userManager->expects($this->atLeastOnce())
+		$this->userManager->expects($this->atLeastOnce())
 			->method('get')
 			->willReturn($this->createMock(User::class));
 
@@ -680,12 +613,11 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testUserExistsPublicAPIForNeverExisting() {
-		$access = $this->getAccessMock();
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
-		$this->prepareMockForUserExists($access);
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
+		$this->prepareMockForUserExists();
 		\OC_User::useBackend($backend);
 
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('readAttribute')
 			->will($this->returnCallback(function($dn) {
 				if($dn === 'dnOfRoland,dc=test') {
@@ -700,8 +632,7 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testDeleteUserExisting() {
-		$access = $this->getAccessMock();
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 
 		//we do not support deleting existing users at all
 		$result = $backend->deleteUser('gunslinger');
@@ -709,13 +640,10 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testGetHomeAbsolutePath() {
-		$access = $this->getAccessMock();
-		$config = $this->createMock(IConfig::class);
-		$noti = $this->createMock(INotificationManager::class);
-		$backend = new UserLDAP($access, $config, $noti, $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
-		$this->prepareMockForUserExists($access);
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
+		$this->prepareMockForUserExists();
 
-		$access->connection->expects($this->any())
+		$this->connection->expects($this->any())
 			->method('__get')
 			->will($this->returnCallback(function($name) {
 				if($name === 'homeFolderNamingRule') {
@@ -724,7 +652,7 @@ class User_LDAPTest extends TestCase {
 				return null;
 			}));
 
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('readAttribute')
 			->will($this->returnCallback(function($dn, $attr) {
 				switch ($dn) {
@@ -750,26 +678,24 @@ class User_LDAPTest extends TestCase {
 			->method('getHomePath')
 			->willReturn('/tmp/rolandshome/');
 
-		$access->userManager->expects($this->atLeastOnce())
+		$this->userManager->expects($this->atLeastOnce())
 			->method('get')
 			->willReturn($user);
 
 		//absolute path
+		/** @noinspection PhpUnhandledExceptionInspection */
 		$result = $backend->getHome('gunslinger');
 		$this->assertEquals('/tmp/rolandshome/', $result);
 	}
 
 	public function testGetHomeRelative() {
-		$access = $this->getAccessMock();
-		$config = $this->createMock(IConfig::class);
-		$noti = $this->createMock(INotificationManager::class);
-		$backend = new UserLDAP($access, $config, $noti, $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
-		$this->prepareMockForUserExists($access);
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
+		$this->prepareMockForUserExists();
 
 		$dataDir = \OC::$server->getConfig()->getSystemValue(
 			'datadirectory', \OC::$SERVERROOT.'/data');
 
-		$access->connection->expects($this->any())
+		$this->connection->expects($this->any())
 			->method('__get')
 			->will($this->returnCallback(function($name) {
 				if($name === 'homeFolderNamingRule') {
@@ -778,7 +704,7 @@ class User_LDAPTest extends TestCase {
 				return null;
 			}));
 
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('readAttribute')
 			->will($this->returnCallback(function($dn, $attr) {
 				switch ($dn) {
@@ -804,10 +730,11 @@ class User_LDAPTest extends TestCase {
 			->method('getHomePath')
 			->willReturn($dataDir.'/susannah/');
 
-		$access->userManager->expects($this->atLeastOnce())
+		$this->userManager->expects($this->atLeastOnce())
 			->method('get')
 			->willReturn($user);
 
+		/** @noinspection PhpUnhandledExceptionInspection */
 		$result = $backend->getHome('ladyofshadows');
 		$this->assertEquals($dataDir.'/susannah/', $result);
 	}
@@ -816,11 +743,10 @@ class User_LDAPTest extends TestCase {
 	 * @expectedException \Exception
 	 */
 	public function testGetHomeNoPath() {
-		$access = $this->getAccessMock();
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
-		$this->prepareMockForUserExists($access);
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
+		$this->prepareMockForUserExists();
 
-		$access->connection->expects($this->any())
+		$this->connection->expects($this->any())
 			->method('__get')
 			->will($this->returnCallback(function($name) {
 				if($name === 'homeFolderNamingRule') {
@@ -828,8 +754,7 @@ class User_LDAPTest extends TestCase {
 				}
 				return null;
 			}));
-
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('readAttribute')
 			->will($this->returnCallback(function($dn, $attr) {
 				switch ($dn) {
@@ -846,7 +771,7 @@ class User_LDAPTest extends TestCase {
 			->method('getHomePath')
 			->willThrowException(new \Exception());
 
-		$access->userManager->expects($this->atLeastOnce())
+		$this->userManager->expects($this->atLeastOnce())
 			->method('get')
 			->willReturn($user);
 
@@ -861,11 +786,10 @@ class User_LDAPTest extends TestCase {
 	public function testGetHomeDeletedUser() {
 		$uid = 'newyorker';
 
-		$access = $this->getAccessMock();
-		$backend = new UserLDAP($access, $this->configMock, $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
-		$this->prepareMockForUserExists($access);
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
+		$this->prepareMockForUserExists();
 
-		$access->connection->expects($this->any())
+		$this->connection->expects($this->any())
 				->method('__get')
 				->will($this->returnCallback(function($name) {
 					if($name === 'homeFolderNamingRule') {
@@ -874,69 +798,53 @@ class User_LDAPTest extends TestCase {
 					return null;
 				}));
 
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 				->method('readAttribute')
 				->will($this->returnValue([]));
 
 		$userMapper = $this->createMock(UserMapping::class);
 
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 				->method('getUserMapper')
 				->will($this->returnValue($userMapper));
 
-		$this->configMock->expects($this->any())
+		$this->config->expects($this->any())
 			->method('getUserValue')
 			->will($this->returnValue(true));
 
-		$this->offlineUser->expects($this->never())
+		$offlineUser = $this->createMock(OfflineUser::class);
+		$offlineUser->expects($this->never())
 			->method('getHomePath');
 
-		$access->userManager->expects($this->atLeastOnce())
+		$this->userManager->expects($this->atLeastOnce())
 			->method('get')
-			->willReturn($this->offlineUser);
+			->willReturn($offlineUser);
 
 		$backend->getHome($uid);
 	}
 
 	public function testGetHomeWithPlugin() {
-		$pluginManager = $this->getMockBuilder('\OCA\User_LDAP\UserPluginManager')
-			->setMethods(['implementsActions','getHome'])
-			->getMock();
-
-		$pluginManager->expects($this->once())
+		$this->pluginManager->expects($this->once())
 			->method('implementsActions')
 			->with(Backend::GET_HOME)
 			->willReturn(true);
-
-		$pluginManager->expects($this->once())
+		$this->pluginManager->expects($this->once())
 			->method('getHome')
 			->with('uid')
 			->willReturn('result');
 
-		$access = $this->getAccessMock();
-		$config = $this->createMock(IConfig::class);
-		$noti = $this->createMock(INotificationManager::class);
-		$session = $this->createMock(Session::class);
-
-		$access->connection->expects($this->any())
+		$this->connection->expects($this->any())
 			->method('getFromCache')
 			->will($this->returnCallback(function($uid) {
 				return true;
 			}));
 
-		$ldap = new User_LDAP(
-			$access,
-			$config,
-			$noti,
-			$session,
-			$pluginManager
-		);
-
-		$this->assertEquals($ldap->getHome('uid'),'result');
+		/** @noinspection PhpUnhandledExceptionInspection */
+		$this->assertEquals($this->backend->getHome('uid'),'result');
 	}
 
-	private function prepareAccessForGetDisplayName(&$access) {
-		$access->connection->expects($this->any())
+	private function prepareAccessForGetDisplayName() {
+		$this->connection->expects($this->any())
 			   ->method('__get')
 			   ->will($this->returnCallback(function($name) {
 					if($name === 'ldapUserDisplayName') {
@@ -945,7 +853,7 @@ class User_LDAPTest extends TestCase {
 					return null;
 			   }));
 
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			   ->method('readAttribute')
 			   ->will($this->returnCallback(function($dn, $attr) {
 					switch ($dn) {
@@ -960,18 +868,16 @@ class User_LDAPTest extends TestCase {
 							return false;
 				   }
 			   }));
-
-		$access->method('fetchUsersByLoginName')
+		$this->access->method('fetchUsersByLoginName')
 			->willReturn([]);
 	}
 
 	public function testGetDisplayName() {
-		$access = $this->getAccessMock();
-		$this->prepareAccessForGetDisplayName($access);
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
-		$this->prepareMockForUserExists($access);
+		$this->prepareAccessForGetDisplayName();
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
+		$this->prepareMockForUserExists();
 
-		$access->connection->expects($this->any())
+		$this->connection->expects($this->any())
 			->method('getConnectionResource')
 			->will($this->returnCallback(function() {
 				return true;
@@ -997,7 +903,7 @@ class User_LDAPTest extends TestCase {
 			->method('getUUIDByDN')
 			->willReturnCallback(function($dn) { return $dn; });
 
-		$access->userManager->expects($this->any())
+		$this->userManager->expects($this->any())
 			->method('get')
 			->willReturnCallback(function($uid) use ($user1, $user2) {
 				if($uid === 'gunslinger') {
@@ -1005,11 +911,12 @@ class User_LDAPTest extends TestCase {
 				} else if($uid === 'newyorker') {
 					return $user2;
 				}
+				return null;
 			});
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('getUserMapper')
 			->willReturn($mapper);
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('getUserDnByUuid')
 			->willReturnCallback(function($uuid) { return $uuid . '1'; });
 
@@ -1023,8 +930,7 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testGetDisplayNamePublicAPI() {
-		$access = $this->getAccessMock();
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('username2dn')
 			->will($this->returnCallback(function($uid) {
 				switch ($uid) {
@@ -1044,11 +950,11 @@ class User_LDAPTest extends TestCase {
 						return false;
 				}
 			}));
-		$this->prepareAccessForGetDisplayName($access);
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
-		$this->prepareMockForUserExists($access);
+		$this->prepareAccessForGetDisplayName();
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
+		$this->prepareMockForUserExists();
 
-		$access->connection->expects($this->any())
+		$this->connection->expects($this->any())
 			->method('getConnectionResource')
 			->will($this->returnCallback(function() {
 				return true;
@@ -1076,7 +982,7 @@ class User_LDAPTest extends TestCase {
 			->method('getUUIDByDN')
 			->willReturnCallback(function($dn) { return $dn; });
 
-		$access->userManager->expects($this->any())
+		$this->userManager->expects($this->any())
 			->method('get')
 			->willReturnCallback(function($uid) use ($user1, $user2) {
 				if($uid === 'gunslinger') {
@@ -1084,11 +990,12 @@ class User_LDAPTest extends TestCase {
 				} else if($uid === 'newyorker') {
 					return $user2;
 				}
+				return null;
 			});
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('getUserMapper')
 			->willReturn($mapper);
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('getUserDnByUuid')
 			->willReturnCallback(function($uuid) { return $uuid . '1'; });
 
@@ -1102,93 +1009,53 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testGetDisplayNameWithPlugin() {
-		$pluginManager = $this->getMockBuilder('\OCA\User_LDAP\UserPluginManager')
-			->setMethods(['implementsActions','getDisplayName'])
-			->getMock();
-
-		$pluginManager->expects($this->once())
+		$this->pluginManager->expects($this->once())
 			->method('implementsActions')
 			->with(Backend::GET_DISPLAYNAME)
 			->willReturn(true);
-
-		$pluginManager->expects($this->once())
+		$this->pluginManager->expects($this->once())
 			->method('getDisplayName')
 			->with('uid')
 			->willReturn('result');
 
-		$access = $this->createMock(Access::class);
-		$config = $this->createMock(IConfig::class);
-		$noti = $this->createMock(INotificationManager::class);
-		$session = $this->createMock(Session::class);
-
-		$ldap = new User_LDAP(
-			$access,
-			$config,
-			$noti,
-			$session,
-			$pluginManager
-		);
-
-		$this->assertEquals($ldap->getDisplayName('uid'),'result');
+		$this->assertEquals($this->backend->getDisplayName('uid'),'result');
 	}
 
 	//no test for getDisplayNames, because it just invokes getUsers and
 	//getDisplayName
 
 	public function testCountUsers() {
-		$access = $this->getAccessMock();
-
-		$access->expects($this->once())
+		$this->access->expects($this->once())
 			   ->method('countUsers')
 			   ->will($this->returnValue(5));
 
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 
 		$result = $backend->countUsers();
 		$this->assertEquals(5, $result);
 	}
 
 	public function testCountUsersFailing() {
-		$access = $this->getAccessMock();
-
-		$access->expects($this->once())
+		$this->access->expects($this->once())
 			   ->method('countUsers')
 			   ->will($this->returnValue(false));
 
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 
 		$result = $backend->countUsers();
 		$this->assertFalse($result);
 	}
 
 	public function testCountUsersWithPlugin() {
-		$pluginManager = $this->getMockBuilder('\OCA\User_LDAP\UserPluginManager')
-			->setMethods(['implementsActions','countUsers'])
-			->getMock();
-
-		$pluginManager->expects($this->once())
+		$this->pluginManager->expects($this->once())
 			->method('implementsActions')
 			->with(Backend::COUNT_USERS)
 			->willReturn(true);
-
-		$pluginManager->expects($this->once())
+		$this->pluginManager->expects($this->once())
 			->method('countUsers')
 			->willReturn(42);
 
-		$access = $this->createMock(Access::class);
-		$config = $this->createMock(IConfig::class);
-		$noti = $this->createMock(INotificationManager::class);
-		$session = $this->createMock(Session::class);
-
-		$ldap = new User_LDAP(
-			$access,
-			$config,
-			$noti,
-			$session,
-			$pluginManager
-		);
-
-		$this->assertEquals($ldap->countUsers(),42);
+		$this->assertEquals($this->backend->countUsers(),42);
 	}	
 
 	public function testLoginName2UserNameSuccess() {
@@ -1196,35 +1063,34 @@ class User_LDAPTest extends TestCase {
 		$username  = 'alice';
 		$dn        = 'uid=alice,dc=what,dc=ever';
 
-		$access = $this->getAccessMock();
-		$access->expects($this->once())
+		$this->access->expects($this->once())
 			->method('fetchUsersByLoginName')
 			->with($this->equalTo($loginName))
 			->willReturn([['dn' => [$dn]]]);
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('stringResemblesDN')
 			->with($this->equalTo($dn))
 			->willReturn(true);
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('dn2username')
 			->with($this->equalTo($dn))
 			->willReturn($username);
 
-		$access->connection->expects($this->exactly(2))
+		$this->connection->expects($this->exactly(2))
 			->method('getFromCache')
 			->with($this->equalTo('loginName2UserName-'.$loginName))
 			->willReturnOnConsecutiveCalls(null, $username);
-		$access->connection->expects($this->once())
+		$this->connection->expects($this->once())
 			->method('writeToCache')
 			->with($this->equalTo('loginName2UserName-'.$loginName), $this->equalTo($username));
 
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 		$user = $this->createMock(User::class);
 		$user->expects($this->any())
 			->method('getUsername')
 			->willReturn('alice');
 
-		$access->userManager->expects($this->atLeastOnce())
+		$this->userManager->expects($this->atLeastOnce())
 			->method('get')
 			->with($dn)
 			->willReturn($user);
@@ -1239,25 +1105,24 @@ class User_LDAPTest extends TestCase {
 	public function testLoginName2UserNameNoUsersOnLDAP() {
 		$loginName = 'Loki';
 
-		$access = $this->getAccessMock();
-		$access->expects($this->once())
+		$this->access->expects($this->once())
 			->method('fetchUsersByLoginName')
 			->with($this->equalTo($loginName))
 			->willReturn([]);
-		$access->expects($this->never())
+		$this->access->expects($this->never())
 			->method('stringResemblesDN');
-		$access->expects($this->never())
+		$this->access->expects($this->never())
 			->method('dn2username');
 
-		$access->connection->expects($this->exactly(2))
+		$this->connection->expects($this->exactly(2))
 			->method('getFromCache')
 			->with($this->equalTo('loginName2UserName-'.$loginName))
 			->willReturnOnConsecutiveCalls(null, false);
-		$access->connection->expects($this->once())
+		$this->connection->expects($this->once())
 			->method('writeToCache')
 			->with($this->equalTo('loginName2UserName-'.$loginName), false);
 
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 		$name = $backend->loginName2UserName($loginName);
 		$this->assertSame(false, $name);
 
@@ -1273,40 +1138,39 @@ class User_LDAPTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$access = $this->getAccessMock();
-		$access->expects($this->once())
+		$this->access->expects($this->once())
 			->method('fetchUsersByLoginName')
 			->with($this->equalTo($loginName))
 			->willReturn([['dn' => [$dn]]]);
 
-		$access->connection->expects($this->exactly(2))
+		$this->connection->expects($this->exactly(2))
 			->method('getFromCache')
 			->with($this->equalTo('loginName2UserName-'.$loginName))
 			->willReturnOnConsecutiveCalls(null, false);
-		$access->connection->expects($this->once())
+		$this->connection->expects($this->once())
 			->method('writeToCache')
 			->with($this->equalTo('loginName2UserName-'.$loginName), $this->equalTo(false));
 
-		$access->userManager->expects($this->any())
+		$this->userManager->expects($this->any())
 			->method('get')
 			->with($dn)
 			->willReturn($offlineUser);
 
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 		$name = $backend->loginName2UserName($loginName);
 		$this->assertSame(false, $name);
 
 		// and once again to verify that caching works
 		$backend->loginName2UserName($loginName);
 	}
-	
+
 	/**
 	 * Prepares the Access mock for setPassword tests
-	 * @param \OCA\User_LDAP\Access|\PHPUnit_Framework_MockObject_MockObject $access mock
-	 * @return void
+	 *
+	 * @param bool $enablePasswordChange
 	 */
-	private function prepareAccessForSetPassword(&$access, $enablePasswordChange = true) {
-		$access->connection->expects($this->any())
+	private function prepareAccessForSetPassword($enablePasswordChange = true) {
+		$this->connection->expects($this->any())
 			   ->method('__get')
 			   ->will($this->returnCallback(function($name) use (&$enablePasswordChange) {
 					if($name === 'ldapLoginFilter') {
@@ -1317,8 +1181,7 @@ class User_LDAPTest extends TestCase {
 					}
 					return null;
 			   }));
-
-		$access->connection->expects($this->any())
+		$this->connection->expects($this->any())
 			   ->method('getFromCache')
 			   ->will($this->returnCallback(function($uid) {
 					if($uid === 'userExists'.'roland') {
@@ -1327,7 +1190,7 @@ class User_LDAPTest extends TestCase {
 					return null;
 			   }));
 
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			   ->method('fetchListOfUsers')
 			   ->will($this->returnCallback(function($filter) {
 					if($filter === 'roland') {
@@ -1335,8 +1198,7 @@ class User_LDAPTest extends TestCase {
 					}
 					return array();
 			   }));
-
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			->method('fetchUsersByLoginName')
 			->will($this->returnCallback(function($uid) {
 				if($uid === 'roland') {
@@ -1344,18 +1206,15 @@ class User_LDAPTest extends TestCase {
 				}
 				return array();
 			}));
-
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			   ->method('dn2username')
 			   ->with($this->equalTo('dnOfRoland,dc=test'))
 			   ->will($this->returnValue('roland'));
-
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			   ->method('stringResemblesDN')
 			   ->with($this->equalTo('dnOfRoland,dc=test'))
 			   ->will($this->returnValue(true));
-			   
-		$access->expects($this->any())
+		$this->access->expects($this->any())
 			   ->method('setPassword')
 			   ->will($this->returnCallback(function($uid, $password) {
 					if(strlen($password) <= 5) {
@@ -1370,29 +1229,25 @@ class User_LDAPTest extends TestCase {
 	 * @expectedExceptionMessage Password fails quality checking policy
 	 */
 	public function testSetPasswordInvalid() {
-		$access = $this->getAccessMock();
-
-		$this->prepareAccessForSetPassword($access);
-		$access->userManager->expects($this->atLeastOnce())
+		$this->prepareAccessForSetPassword($this->access);
+		$this->userManager->expects($this->atLeastOnce())
 			->method('get')
 			->willReturn($this->createMock(User::class));
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 		\OC_User::useBackend($backend);
 
 		$this->assertTrue(\OC_User::setPassword('roland', 'dt'));
 	}
 	
 	public function testSetPasswordValid() {
-		$access = $this->getAccessMock();
+		$this->prepareAccessForSetPassword($this->access);
 
-		$this->prepareAccessForSetPassword($access);
-
-		$access->userManager->expects($this->any())
+		$this->userManager->expects($this->any())
 			->method('get')
 			->willReturn($this->createMock(User::class));
 
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
-		$access->userManager->expects($this->any())
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
+		$this->userManager->expects($this->any())
 			->method('get')
 			->willReturn($this->createMock(User::class));
 
@@ -1402,13 +1257,12 @@ class User_LDAPTest extends TestCase {
 	}
 
 	public function testSetPasswordValidDisabled() {
-		$access = $this->getAccessMock();
-		$access->userManager->expects($this->any())
+		$this->userManager->expects($this->any())
 			->method('get')
 			->willReturn($this->createMock(User::class));
 
-		$this->prepareAccessForSetPassword($access, false);
-		$backend = new UserLDAP($access, $this->createMock(IConfig::class), $this->createMock(INotificationManager::class), $this->createMock(Session::class), $this->getDefaultPluginManagerMock());
+		$this->prepareAccessForSetPassword(false);
+		$backend = new UserLDAP($this->access, $this->config, $this->notificationManager, $this->session, $this->pluginManager);
 		\OC_User::useBackend($backend);
 
 		$this->assertFalse(\OC_User::setPassword('roland', 'dt12234$'));
@@ -1419,24 +1273,13 @@ class User_LDAPTest extends TestCase {
 	 * @expectedExceptionMessage LDAP setPassword: Could not get user object for uid NotExistingUser. Maybe the LDAP entry has no set display name attribute?
 	 */
 	public function testSetPasswordWithInvalidUser() {
-		$access = $this->createMock(Access::class);
-		$access->userManager = $this->createMock(IUserManager::class);
-		$access->userManager
+		$this->userManager
 			->expects($this->once())
 			->method('get')
 			->with('NotExistingUser')
 			->willReturn(null);
-		$config = $this->createMock(IConfig::class);
-		$noti = $this->createMock(INotificationManager::class);
-		$userSession = $this->createMock(Session::class);
-		$ldap = new User_LDAP(
-			$access,
-			$config,
-			$noti,
-			$userSession,
-			$this->getDefaultPluginManagerMock()
-		);
-		$ldap->setPassword('NotExistingUser', 'Password');
+
+		$this->backend->setPassword('NotExistingUser', 'Password');
 	}
 
 	public function testSetPasswordWithUsernameFalse() {
@@ -1445,199 +1288,84 @@ class User_LDAPTest extends TestCase {
 			->expects($this->once())
 			->method('getUsername')
 			->willReturn(false);
-		$access = $this->createMock(Access::class);
-		$access->userManager = $this->createMock(IUserManager::class);
-		$access->userManager
+		$this->userManager
 			->expects($this->once())
 			->method('get')
 			->with('NotExistingUser')
 			->willReturn($user);
-		$config = $this->createMock(IConfig::class);
-		$noti = $this->createMock(INotificationManager::class);
-		$userSession = $this->createMock(Session::class);
-		$ldap = new User_LDAP(
-			$access,
-			$config,
-			$noti,
-			$userSession,
-			$this->getDefaultPluginManagerMock()
-		);
-		$this->assertFalse($ldap->setPassword('NotExistingUser', 'Password'));
+
+		/** @noinspection PhpUnhandledExceptionInspection */
+		$this->assertFalse($this->backend->setPassword('NotExistingUser', 'Password'));
 	}
 
 	public function testSetPasswordWithPlugin() {
-		$pluginManager = $this->getMockBuilder('\OCA\User_LDAP\UserPluginManager')
-			->setMethods(['implementsActions','setPassword'])
-			->getMock();
-
-		$pluginManager->expects($this->once())
+		$this->pluginManager->expects($this->once())
 			->method('implementsActions')
 			->with(Backend::SET_PASSWORD)
 			->willReturn(true);
-
-		$pluginManager->expects($this->once())
+		$this->pluginManager->expects($this->once())
 			->method('setPassword')
 			->with('uid','password')
 			->willReturn('result');
 
-		$access = $this->createMock(Access::class);
-		$config = $this->createMock(IConfig::class);
-		$noti = $this->createMock(INotificationManager::class);
-		$session = $this->createMock(Session::class);
-
-		$ldap = new User_LDAP(
-			$access,
-			$config,
-			$noti,
-			$session,
-			$pluginManager
-		);
-
-		$this->assertEquals($ldap->setPassword('uid', 'password'),'result');
-	}	
+		/** @noinspection PhpUnhandledExceptionInspection */
+		$this->assertEquals($this->backend->setPassword('uid', 'password'),'result');
+	}
 
 	public function testCanChangeAvatarWithPlugin() {
-		$pluginManager = $this->getMockBuilder('\OCA\User_LDAP\UserPluginManager')
-			->setMethods(['implementsActions','canChangeAvatar'])
-			->getMock();
-
-		$pluginManager->expects($this->once())
+		$this->pluginManager->expects($this->once())
 			->method('implementsActions')
 			->with(Backend::PROVIDE_AVATAR)
 			->willReturn(true);
-
-		$pluginManager->expects($this->once())
+		$this->pluginManager->expects($this->once())
 			->method('canChangeAvatar')
 			->with('uid')
 			->willReturn('result');
 
-		$access = $this->createMock(Access::class);
-		$config = $this->createMock(IConfig::class);
-		$noti = $this->createMock(INotificationManager::class);
-		$session = $this->createMock(Session::class);
-
-		$ldap = new User_LDAP(
-			$access,
-			$config,
-			$noti,
-			$session,
-			$pluginManager
-		);
-
-		$this->assertEquals($ldap->canChangeAvatar('uid'),'result');
+		$this->assertEquals($this->backend->canChangeAvatar('uid'),'result');
 	}
 
 	public function testSetDisplayNameWithPlugin() {
-		$pluginManager = $this->getMockBuilder('\OCA\User_LDAP\UserPluginManager')
-			->setMethods(['implementsActions','setDisplayName'])
-			->getMock();
-
-		$pluginManager->expects($this->once())
+		$this->pluginManager->expects($this->once())
 			->method('implementsActions')
 			->with(Backend::SET_DISPLAYNAME)
 			->willReturn(true);
-
-		$pluginManager->expects($this->once())
+		$this->pluginManager->expects($this->once())
 			->method('setDisplayName')
 			->with('uid','displayName')
 			->willReturn('result');
 
-		$access = $this->createMock(Access::class);
-		$config = $this->createMock(IConfig::class);
-		$noti = $this->createMock(INotificationManager::class);
-		$session = $this->createMock(Session::class);
-
-		$ldap = new User_LDAP(
-			$access,
-			$config,
-			$noti,
-			$session,
-			$pluginManager
-		);
-
-		$this->assertEquals($ldap->setDisplayName('uid', 'displayName'),'result');
+		$this->assertEquals($this->backend->setDisplayName('uid', 'displayName'),'result');
 	}
 
 	public function testSetDisplayNameFailing() {
-		$pluginManager = $this->getMockBuilder('\OCA\User_LDAP\UserPluginManager')
-			->setMethods(['implementsActions','setDisplayName'])
-			->getMock();
-
-		$pluginManager->expects($this->once())
+		$this->pluginManager->expects($this->once())
 			->method('implementsActions')
 			->with(Backend::SET_DISPLAYNAME)
 			->willReturn(false);
 
-		$access = $this->createMock(Access::class);
-		$config = $this->createMock(IConfig::class);
-		$noti = $this->createMock(INotificationManager::class);
-		$session = $this->createMock(Session::class);
-
-		$ldap = new User_LDAP(
-			$access,
-			$config,
-			$noti,
-			$session,
-			$pluginManager
-		);
-
-		$this->assertFalse($ldap->setDisplayName('uid', 'displayName'));
+		$this->assertFalse($this->backend->setDisplayName('uid', 'displayName'));
 	}
 
 	public function testCreateUserWithPlugin() {
-		$pluginManager = $this->getMockBuilder('\OCA\User_LDAP\UserPluginManager')
-			->setMethods(['implementsActions','createUser'])
-			->getMock();
-
-		$pluginManager->expects($this->once())
+		$this->pluginManager->expects($this->once())
 			->method('implementsActions')
 			->with(Backend::CREATE_USER)
 			->willReturn(true);
-
-		$pluginManager->expects($this->once())
+		$this->pluginManager->expects($this->once())
 			->method('createUser')
 			->with('uid','password')
 			->willReturn('result');
 
-		$access = $this->createMock(Access::class);
-		$config = $this->createMock(IConfig::class);
-		$noti = $this->createMock(INotificationManager::class);
-		$session = $this->createMock(Session::class);
-
-		$ldap = new User_LDAP(
-			$access,
-			$config,
-			$noti,
-			$session,
-			$pluginManager
-		);
-
-		$this->assertEquals($ldap->createUser('uid', 'password'),'result');
+		$this->assertEquals($this->backend->createUser('uid', 'password'),'result');
 	}
 
 	public function testCreateUserFailing() {
-		$pluginManager = $this->getMockBuilder('\OCA\User_LDAP\UserPluginManager')
-			->setMethods(['implementsActions', 'createUser'])
-			->getMock();
-
-		$pluginManager->expects($this->once())
+		$this->pluginManager->expects($this->once())
 			->method('implementsActions')
 			->with(Backend::CREATE_USER)
 			->willReturn(false);
 
-		$access = $this->createMock(Access::class);
-		$config = $this->createMock(IConfig::class);
-		$noti = $this->createMock(INotificationManager::class);
-		$session = $this->createMock(Session::class);
-
-		$ldap = new User_LDAP(
-			$access,
-			$config,
-			$noti,
-			$session,
-			$pluginManager
-		);
-
-		$this->assertFalse($ldap->createUser('uid', 'password'));
+		$this->assertFalse($this->backend->createUser('uid', 'password'));
 	}
 }


### PR DESCRIPTION
The general behaviour is that LDAP users can set their avatar within Nextcloud, as long as LDAP does not provide an image. What was not taken into account was when an unsupported (Avatar API accepts PNG and JPG only) or corrupt image was supplied. For instance a BMP. In that case, the generic placeholder was shown and the hint that the avatar was provided the by user backend. Expected was that users can set an avatar in that case.

(the first commit only cleans up unit tests without effective code changes, but makes the diff look big. don't be scared.)