### PR TITLE
Allows plus character in username

### DIFF
--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -313,10 +313,10 @@ class Manager extends PublicEmitter implements IUserManager {
 		$l = \OC::$server->getL10N('lib');
 
 		// Check the name for bad characters
-		// Allowed are: "a-z", "A-Z", "0-9" and "_.@-'"
-		if (preg_match('/[^a-zA-Z0-9 _\.@\-\']/', $uid)) {
+		// Allowed are: "a-z", "A-Z", "0-9" and "_.@-'+"
+		if (preg_match('/[^a-zA-Z0-9 _\.@\-\'\+]/', $uid)) {
 			throw new \InvalidArgumentException($l->t('Only the following characters are allowed in a username:'
-				. ' "a-z", "A-Z", "0-9", and "_.@-\'"'));
+				. ' "a-z", "A-Z", "0-9", and "_.@-\'+"'));
 		}
 		// No empty username
 		if (trim($uid) === '') {

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -288,23 +288,23 @@ class ManagerTest extends TestCase {
 	public function dataCreateUserInvalid() {
 		return [
 			['te?st', 'foo', 'Only the following characters are allowed in a username:'
-				. ' "a-z", "A-Z", "0-9", and "_.@-\'"'],
+				. ' "a-z", "A-Z", "0-9", and "_.@-\'+"'],
 			["te\tst", '', 'Only the following characters are allowed in a username:'
-				. ' "a-z", "A-Z", "0-9", and "_.@-\'"'],
+				. ' "a-z", "A-Z", "0-9", and "_.@-\'+"'],
 			["te\nst", '', 'Only the following characters are allowed in a username:'
-				. ' "a-z", "A-Z", "0-9", and "_.@-\'"'],
+				. ' "a-z", "A-Z", "0-9", and "_.@-\'+"'],
 			["te\rst", '', 'Only the following characters are allowed in a username:'
-				. ' "a-z", "A-Z", "0-9", and "_.@-\'"'],
+				. ' "a-z", "A-Z", "0-9", and "_.@-\'+"'],
 			["te\0st", '', 'Only the following characters are allowed in a username:'
-				. ' "a-z", "A-Z", "0-9", and "_.@-\'"'],
+				. ' "a-z", "A-Z", "0-9", and "_.@-\'+"'],
 			["te\x0Bst", '', 'Only the following characters are allowed in a username:'
-				. ' "a-z", "A-Z", "0-9", and "_.@-\'"'],
+				. ' "a-z", "A-Z", "0-9", and "_.@-\'+"'],
 			["te\xe2st", '', 'Only the following characters are allowed in a username:'
-				. ' "a-z", "A-Z", "0-9", and "_.@-\'"'],
+				. ' "a-z", "A-Z", "0-9", and "_.@-\'+"'],
 			["te\x80st", '', 'Only the following characters are allowed in a username:'
-				. ' "a-z", "A-Z", "0-9", and "_.@-\'"'],
+				. ' "a-z", "A-Z", "0-9", and "_.@-\'+"'],
 			["te\x8bst", '', 'Only the following characters are allowed in a username:'
-				. ' "a-z", "A-Z", "0-9", and "_.@-\'"'],
+				. ' "a-z", "A-Z", "0-9", and "_.@-\'+"'],
 			['', 'foo', 'A valid username must be provided'],
 			[' ', 'foo', 'A valid username must be provided'],
 			[' test', 'foo', 'Username contains whitespace at the beginning or at the end'],


### PR DESCRIPTION
Because we want to allow email addresses with common separators like foo+bar@foobar.com as username, we need to add  the plus character to the allowed set of chars. This will resolve #10086