### PR TITLE
Revert "Fix undeclared method warning in phan"

### DIFF
--- a/lib/private/Log/Systemdlog.php
+++ b/lib/private/Log/Systemdlog.php
@@ -68,7 +68,6 @@ class Systemdlog implements IWriter {
 	 * @param string $app
 	 * @param string $message
 	 * @param int $level
-	 * @suppress PhanUndeclaredMethod
 	 */
 	public function write(string $app, $message, int $level) {
 		$journal_level = $this->levels[$level];


### PR DESCRIPTION
This reverts commit f3093b24016f42843d92a1a59cf955692bac57d1.

Phan is supposed to succeed without suppression.