### PR TITLE
allow admin to disable fetching of avatars as well as a specific attribute

### DIFF
--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -568,7 +568,7 @@ class Configuration {
 			if($attribute === '') {
 				return $defaultAttributes;
 			}
-			return [$attribute];
+			return [strtolower($attribute)];
 		}
 		if($value !== self::AVATAR_PREFIX_DEFAULT) {
 			\OC::$server->getLogger()->warning('Invalid config value to ldapUserAvatarRule; falling back to default.');

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -48,6 +48,7 @@ use OCP\ILogger;
  * @property string ldapUserFilter
  * @property string ldapUserDisplayName
  * @property string ldapUserDisplayName2
+ * @property string ldapUserAvatarRule
  * @property boolean turnOnPasswordChange
  * @property boolean hasPagedResultSupport
  * @property string[] ldapBaseUsers
@@ -167,6 +168,15 @@ class Connection extends LDAPUtility {
 			}
 			$this->validateConfiguration();
 		}
+	}
+
+	/**
+	 * @param string $rule
+	 * @return array
+	 * @throws \RuntimeException
+	 */
+	public function resolveRule($rule) {
+		return $this->configuration->resolveRule($rule);
 	}
 
 	/**

--- a/apps/user_ldap/lib/User/Manager.php
+++ b/apps/user_ldap/lib/User/Manager.php
@@ -163,6 +163,7 @@ class Manager {
 	/**
 	 * returns a list of attributes that will be processed further, e.g. quota,
 	 * email, displayname, or others.
+	 *
 	 * @param bool $minimal - optional, set to true to skip attributes with big
 	 * payload
 	 * @return string[]
@@ -190,10 +191,10 @@ class Manager {
 		if(!$minimal) {
 			// attributes that are not really important but may come with big
 			// payload.
-			$attributes = array_merge($attributes, array(
-				'jpegphoto',
-				'thumbnailphoto'
-			));
+			$attributes = array_merge(
+				$attributes,
+				$this->access->getConnection()->resolveRule('avatar')
+			);
 		}
 
 		return $attributes;

--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -245,10 +245,12 @@ class User {
 		$this->connection->writeToCache($cacheKey, $groups);
 
 		//Avatar
-		$attrs = array('jpegphoto', 'thumbnailphoto');
-		foreach ($attrs as $attr)  {
-			if(isset($ldapEntry[$attr])) {
-				$this->avatarImage = $ldapEntry[$attr][0];
+		/** @var Connection $connection */
+		$connection = $this->access->getConnection();
+		$attributes = $connection->resolveRule('avatar');
+		foreach ($attributes as $attribute)  {
+			if(isset($ldapEntry[$attribute])) {
+				$this->avatarImage = $ldapEntry[$attribute][0];
 				// the call to the method that saves the avatar in the file
 				// system must be postponed after the login. It is to ensure
 				// external mounts are mounted properly (e.g. with login
@@ -348,7 +350,9 @@ class User {
 		}
 
 		$this->avatarImage = false;
-		$attributes = array('jpegPhoto', 'thumbnailPhoto');
+		/** @var Connection $connection */
+		$connection = $this->access->getConnection();
+		$attributes = $connection->resolveRule('avatar');
 		foreach($attributes as $attribute) {
 			$result = $this->access->readAttribute($this->dn, $attribute);
 			if($result !== false && is_array($result) && isset($result[0])) {
@@ -575,7 +579,7 @@ class User {
 	 */
 	private function setOwnCloudAvatar() {
 		if(!$this->image->valid()) {
-			$this->log->log('jpegPhoto data invalid for '.$this->dn, ILogger::ERROR);
+			$this->log->log('avatar image data from LDAP invalid for '.$this->dn, ILogger::ERROR);
 			return false;
 		}
 		//make sure it is a square and not bigger than 128x128

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -103,6 +103,10 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 			return $this->userPluginManager->canChangeAvatar($uid);
 		}
 
+		if(!$this->implementsActions(Backend::PROVIDE_AVATAR)) {
+			return true;
+		}
+
 		$user = $this->access->userManager->get($uid);
 		if(!$user instanceof User) {
 			return false;
@@ -550,7 +554,7 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 		return (bool)((Backend::CHECK_PASSWORD
 			| Backend::GET_HOME
 			| Backend::GET_DISPLAYNAME
-			| Backend::PROVIDE_AVATAR
+			| (($this->access->connection->ldapUserAvatarRule !== 'none') ? Backend::PROVIDE_AVATAR : 0)
 			| Backend::COUNT_USERS
 			| (((int)$this->access->connection->turnOnPasswordChange === 1)? Backend::SET_PASSWORD :0)
 			| $this->userPluginManager->getImplementedActions())

--- a/apps/user_ldap/tests/ConfigurationTest.php
+++ b/apps/user_ldap/tests/ConfigurationTest.php
@@ -112,6 +112,7 @@ class ConfigurationTest extends \Test\TestCase {
 		return [
 			['none', []],
 			['data:selfie', ['selfie']],
+			['data:sELFie', ['selfie']],
 			['data:', ['jpegphoto', 'thumbnailphoto']],
 			['default', ['jpegphoto', 'thumbnailphoto']],
 			['invalid#', ['jpegphoto', 'thumbnailphoto']],

--- a/apps/user_ldap/tests/User/ManagerTest.php
+++ b/apps/user_ldap/tests/User/ManagerTest.php
@@ -238,7 +238,17 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertNull($user);
 	}
 
-	public function testGetAttributesAll() {
+	public function attributeRequestProvider() {
+		return [
+			[ false ],
+			[ true ],
+		];
+	}
+
+	/**
+	 * @dataProvider attributeRequestProvider
+	 */
+	public function testGetAttributes($minimal) {
 		list($access, $config, $filesys, $image, $log, $avaMgr, $dbc, $userMgr, $notiMgr) =
 			$this->getTestInstances();
 
@@ -246,28 +256,14 @@ class ManagerTest extends \Test\TestCase {
 		$manager->setLdapAccess($access);
 
 		$connection = $access->getConnection();
-		$connection->setConfiguration(array('ldapEmailAttribute' => 'mail'));
+		$connection->setConfiguration(['ldapEmailAttribute' => 'mail', 'ldapUserAvatarRule' => 'default']);
 
-		$attributes = $manager->getAttributes();
+		$attributes = $manager->getAttributes($minimal);
 
 		$this->assertTrue(in_array('dn', $attributes));
 		$this->assertTrue(in_array($access->getConnection()->ldapEmailAttribute, $attributes));
-		$this->assertTrue(in_array('jpegphoto', $attributes));
-		$this->assertTrue(in_array('thumbnailphoto', $attributes));
-	}
-
-	public function testGetAttributesMinimal() {
-		list($access, $config, $filesys, $image, $log, $avaMgr, $dbc, $userMgr, $notiMgr) =
-			$this->getTestInstances();
-
-		$manager = new Manager($config, $filesys, $log, $avaMgr, $image, $dbc, $userMgr, $notiMgr);
-		$manager->setLdapAccess($access);
-
-		$attributes = $manager->getAttributes(true);
-
-		$this->assertTrue(in_array('dn', $attributes));
-		$this->assertTrue(!in_array('jpegphoto', $attributes));
-		$this->assertTrue(!in_array('thumbnailphoto', $attributes));
+		$this->assertSame(!$minimal, in_array('jpegphoto', $attributes));
+		$this->assertSame(!$minimal, in_array('thumbnailphoto', $attributes));
 	}
 
 }

--- a/apps/user_ldap/tests/User/UserTest.php
+++ b/apps/user_ldap/tests/User/UserTest.php
@@ -503,7 +503,7 @@ class UserTest extends \Test\TestCase {
 		$this->access->expects($this->once())
 			->method('readAttribute')
 			->with($this->equalTo($this->dn),
-				$this->equalTo('jpegPhoto'))
+				$this->equalTo('jpegphoto'))
 			->will($this->returnValue(['this is a photo']));
 
 		$this->image->expects($this->once())
@@ -536,6 +536,11 @@ class UserTest extends \Test\TestCase {
 			->with($this->equalTo($this->uid))
 			->will($this->returnValue($avatar));
 
+		$this->connection->expects($this->any())
+			->method('resolveRule')
+			->with('avatar')
+			->willReturn(['jpegphoto', 'thumbnailphoto']);
+
 		$this->user->updateAvatar();
 	}
 
@@ -544,11 +549,11 @@ class UserTest extends \Test\TestCase {
 			->method('readAttribute')
 			->willReturnCallback(function($dn, $attr) {
 				if($dn === $this->dn
-					&& $attr === 'jpegPhoto')
+					&& $attr === 'jpegphoto')
 				{
 					return false;
 				} elseif($dn === $this->dn
-					&& $attr === 'thumbnailPhoto')
+					&& $attr === 'thumbnailphoto')
 				{
 					return ['this is a photo'];
 				}
@@ -585,6 +590,11 @@ class UserTest extends \Test\TestCase {
 			->with($this->equalTo($this->uid))
 			->will($this->returnValue($avatar));
 
+		$this->connection->expects($this->any())
+			->method('resolveRule')
+			->with('avatar')
+			->willReturn(['jpegphoto', 'thumbnailphoto']);
+
 		$this->user->updateAvatar();
 	}
 
@@ -593,11 +603,11 @@ class UserTest extends \Test\TestCase {
 			->method('readAttribute')
 			->willReturnCallback(function($dn, $attr) {
 				if($dn === $this->dn
-					&& $attr === 'jpegPhoto')
+					&& $attr === 'jpegphoto')
 				{
 					return false;
 				} elseif($dn === $this->dn
-					&& $attr === 'thumbnailPhoto')
+					&& $attr === 'thumbnailphoto')
 				{
 					return ['this is a photo'];
 				}
@@ -626,6 +636,11 @@ class UserTest extends \Test\TestCase {
 		$this->avatarManager->expects($this->never())
 			->method('getAvatar');
 
+		$this->connection->expects($this->any())
+			->method('resolveRule')
+			->with('avatar')
+			->willReturn(['jpegphoto', 'thumbnailphoto']);
+
 		$this->user->updateAvatar();
 	}
 
@@ -634,11 +649,11 @@ class UserTest extends \Test\TestCase {
 			->method('readAttribute')
 			->willReturnCallback(function($dn, $attr) {
 				if($dn === $this->dn
-					&& $attr === 'jpegPhoto')
+					&& $attr === 'jpegphoto')
 				{
 					return false;
 				} elseif($dn === $this->dn
-					&& $attr === 'thumbnailPhoto')
+					&& $attr === 'thumbnailphoto')
 				{
 					return ['this is a photo'];
 				}
@@ -676,6 +691,11 @@ class UserTest extends \Test\TestCase {
 			->with($this->equalTo($this->uid))
 			->will($this->returnValue($avatar));
 
+		$this->connection->expects($this->any())
+			->method('resolveRule')
+			->with('avatar')
+			->willReturn(['jpegphoto', 'thumbnailphoto']);
+
 		$this->assertFalse($this->user->updateAvatar());
 	}
 
@@ -709,6 +729,11 @@ class UserTest extends \Test\TestCase {
 
 		$this->avatarManager->expects($this->never())
 			->method('getAvatar');
+
+		$this->connection->expects($this->any())
+			->method('resolveRule')
+			->with('avatar')
+			->willReturn(['jpegphoto', 'thumbnailphoto']);
 
 		$this->user->updateAvatar();
 	}
@@ -756,6 +781,11 @@ class UserTest extends \Test\TestCase {
 				$this->anything())
 			->will($this->returnValue(true));
 
+		$this->connection->expects($this->any())
+			->method('resolveRule')
+			->with('avatar')
+			->willReturn(['jpegphoto', 'thumbnailphoto']);
+
 		$this->user->update();
 	}
 
@@ -802,14 +832,30 @@ class UserTest extends \Test\TestCase {
 		$this->access->expects($this->once())
 			->method('readAttribute')
 			->with($this->equalTo($this->dn),
-				$this->equalTo('jpegPhoto'))
+				$this->equalTo('jpegphoto'))
 			->will($this->returnValue(['this is a photo']));
+		$this->connection->expects($this->any())
+			->method('resolveRule')
+			->with('avatar')
+			->willReturn(['jpegphoto', 'thumbnailphoto']);
 
 		$photo = $this->user->getAvatarImage();
 		$this->assertSame('this is a photo', $photo);
 		//make sure readAttribute is not called again but the already fetched
 		//photo is returned
 		$this->user->getAvatarImage();
+	}
+
+	public function testGetAvatarImageDisabled() {
+		$this->access->expects($this->never())
+			->method('readAttribute')
+			->with($this->equalTo($this->dn), $this->anything());
+		$this->connection->expects($this->any())
+			->method('resolveRule')
+			->with('avatar')
+			->willReturn([]);
+
+		$this->assertFalse($this->user->getAvatarImage());
 	}
 
 	public function imageDataProvider() {
@@ -859,16 +905,20 @@ class UserTest extends \Test\TestCase {
 				}
 				return $name;
 			}));
+		$this->connection->expects($this->any())
+			->method('resolveRule')
+			->with('avatar')
+			->willReturn(['jpegphoto', 'thumbnailphoto']);
 
-		$record = array(
-			strtolower($this->connection->ldapQuotaAttribute) => array('4096'),
-			strtolower($this->connection->ldapEmailAttribute) => array('alice@wonderland.org'),
-			strtolower($this->connection->ldapUserDisplayName) => array('Aaaaalice'),
+		$record = [
+			strtolower($this->connection->ldapQuotaAttribute) => ['4096'],
+			strtolower($this->connection->ldapEmailAttribute) => ['alice@wonderland.org'],
+			strtolower($this->connection->ldapUserDisplayName) => ['Aaaaalice'],
 			'uid' => [$this->uid],
-			'homedirectory' => array('Alice\'s Folder'),
-			'memberof' => array('cn=groupOne', 'cn=groupTwo'),
-			'jpegphoto' => array('here be an image')
-		);
+			'homedirectory' => ['Alice\'s Folder'],
+			'memberof' => ['cn=groupOne', 'cn=groupTwo'],
+			'jpegphoto' => ['here be an image']
+		];
 
 		foreach($requiredMethods as $method) {
 			$userMock->expects($this->once())

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -1396,4 +1396,31 @@ class User_LDAPTest extends TestCase {
 
 		$this->assertFalse($this->backend->createUser('uid', 'password'));
 	}
+
+	public function actionProvider() {
+		return [
+			[ 'ldapUserAvatarRule', 'default', Backend::PROVIDE_AVATAR, true]	,
+			[ 'ldapUserAvatarRule', 'data:selfiePhoto', Backend::PROVIDE_AVATAR, true],
+			[ 'ldapUserAvatarRule', 'none', Backend::PROVIDE_AVATAR, false],
+			[ 'turnOnPasswordChange', 0, Backend::SET_PASSWORD, false],
+			[ 'turnOnPasswordChange', 1, Backend::SET_PASSWORD, true],
+		];
+	}
+
+	/**
+	 * @dataProvider actionProvider
+	 */
+	public function testImplementsAction($configurable, $value, $actionCode, $expected) {
+		$this->pluginManager->expects($this->once())
+			->method('getImplementedActions')
+			->willReturn(0);
+
+		$this->connection->expects($this->any())
+			->method('__get')
+			->willReturnMap([
+				[$configurable, $value],
+			]);
+
+		$this->assertSame($expected, $this->backend->implementsActions($actionCode));
+	}
 }


### PR DESCRIPTION
Allows to override the default behaviour when looking for user images in LDAP. This is controlled by the ldapUserAvatarRule configuration option, available on CLI only.

The default is (as before) to take both "jpegPhoto" and "thumbnailPhoto" into consideration:

``occ ldap:set-config "s01" "ldapUserAvatarRule" "default"``

Instead, a single specific attribute that carries the image data (like jpegPhoto and thumbnailPhoto do) can be set instead:

``occ ldap:set-config "s01" "ldapUserAvatarRule" "data:selfiePhoto"``

Or, fetching the avatar image from LDAP can be disable at all:

``occ ldap:set-config "s01" "ldapUserAvatarRule" "none"``

~~Waiting for #10083 before writing unit tests for User_LDAP and User/User.~~

documentation in https://github.com/nextcloud/documentation/pull/803