### PR TITLE
prevent lock values from going negative with memcache backend

### DIFF
--- a/tests/lib/Lock/LockingProvider.php
+++ b/tests/lib/Lock/LockingProvider.php
@@ -243,4 +243,16 @@ abstract class LockingProvider extends TestCase {
 		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
 		$this->instance->changeLock('foo', ILockingProvider::LOCK_SHARED);
 	}
+
+	public function testReleaseNonExistingShared() {
+		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance->releaseLock('foo', ILockingProvider::LOCK_SHARED);
+
+		// releasing a lock once to many should not result in a locked state
+		$this->instance->releaseLock('foo', ILockingProvider::LOCK_SHARED);
+
+		$this->instance->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->instance->releaseLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+	}
 }


### PR DESCRIPTION
This can be caused by the code releasing more locks then it acquires,
once the lock value becomes negative it's likely that it will never be able
to change into an exclusive lock again.

Signed-off-by: Robin Appelman <robin@icewind.nl>