### PR TITLE
allow to disable encryption

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -412,9 +412,13 @@ class Encryption extends Wrapper {
 					|| $mode === 'wb'
 					|| $mode === 'wb+'
 				) {
-					// don't overwrite encrypted files if encryption is not enabled
+					// if we update a encrypted file with a un-encrypted one we change the db flag
 					if ($targetIsEncrypted && $encryptionEnabled === false) {
-						throw new GenericEncryptionException('Tried to access encrypted file but encryption is not enabled');
+						$cache = $this->storage->getCache();
+						if ($cache) {
+							$entry = $cache->get($path);
+							$cache->update($entry->getId(), ['encrypted' => 0]);
+						}
 					}
 					if ($encryptionEnabled) {
 						// if $encryptionModuleId is empty, the default module will be used


### PR DESCRIPTION
it should be possible to disable encryption and continue to read/write/update files.

Test:

1. Enable encryption
2. Upload a file to generate a encrypted file on the server
3. disable encryption `occ encryption:disable` but keep the "Default Encryption Module" app enabled so that old files can still be read
4. check if you can upload new (unencrypted) files, read old (encrypted) files, edit old (encrypted) files and replace the file with a unencrypted version.