### PR TITLE
Add fopen method to ISimpleFile

### DIFF
--- a/lib/private/Files/SimpleFS/SimpleFile.php
+++ b/lib/private/Files/SimpleFS/SimpleFile.php
@@ -146,4 +146,15 @@ class SimpleFile implements ISimpleFile  {
 	public function getMimeType() {
 		return $this->file->getMimeType();
 	}
+
+	/**
+	 * Open the file as stream, resulting resource can be operated as stream like the result from php's own fopen
+	 *
+	 * @return resource
+	 * @throws \OCP\Files\NotPermittedException
+	 * @since 14.0.0
+	 */
+	public function fopen(string $mode) {
+		return $this->file->fopen($mode);
+	}
 }

--- a/lib/private/Files/SimpleFS/SimpleFile.php
+++ b/lib/private/Files/SimpleFS/SimpleFile.php
@@ -148,13 +148,25 @@ class SimpleFile implements ISimpleFile  {
 	}
 
 	/**
-	 * Open the file as stream, resulting resource can be operated as stream like the result from php's own fopen
+	 * Open the file as stream for reading, resulting resource can be operated as stream like the result from php's own fopen
 	 *
 	 * @return resource
 	 * @throws \OCP\Files\NotPermittedException
 	 * @since 14.0.0
 	 */
-	public function fopen(string $mode) {
-		return $this->file->fopen($mode);
+	public function read() {
+		return $this->file->fopen('r');
 	}
+
+	/**
+	 * Open the file as stream for writing, resulting resource can be operated as stream like the result from php's own fopen
+	 *
+	 * @return resource
+	 * @throws \OCP\Files\NotPermittedException
+	 * @since 14.0.0
+	 */
+	public function write() {
+		return $this->file->fopen('w');
+	}
+
 }

--- a/lib/public/Files/SimpleFS/ISimpleFile.php
+++ b/lib/public/Files/SimpleFS/ISimpleFile.php
@@ -101,11 +101,20 @@ interface ISimpleFile {
 	public function getMimeType();
 
 	/**
-	 * Open the file as stream, resulting resource can be operated as stream like the result from php's own fopen
+	 * Open the file as stream for reading, resulting resource can be operated as stream like the result from php's own fopen
 	 *
 	 * @return resource
 	 * @throws \OCP\Files\NotPermittedException
 	 * @since 14.0.0
 	 */
-	public function fopen(string $mode);
+	public function read();
+
+	/**
+	 * Open the file as stream for writing, resulting resource can be operated as stream like the result from php's own fopen
+	 *
+	 * @return resource
+	 * @throws \OCP\Files\NotPermittedException
+	 * @since 14.0.0
+	 */
+	public function write();
 }

--- a/lib/public/Files/SimpleFS/ISimpleFile.php
+++ b/lib/public/Files/SimpleFS/ISimpleFile.php
@@ -99,4 +99,13 @@ interface ISimpleFile {
 	 * @since 11.0.0
 	 */
 	public function getMimeType();
+
+	/**
+	 * Open the file as stream, resulting resource can be operated as stream like the result from php's own fopen
+	 *
+	 * @return resource
+	 * @throws \OCP\Files\NotPermittedException
+	 * @since 14.0.0
+	 */
+	public function fopen(string $mode);
 }

--- a/tests/lib/Files/SimpleFS/SimpleFileTest.php
+++ b/tests/lib/Files/SimpleFS/SimpleFileTest.php
@@ -123,4 +123,12 @@ class SimpleFileTest extends \Test\TestCase  {
 
 		$this->simpleFile->getContent();
 	}
+
+	public function testFopen() {
+		$this->file->expects($this->once())
+			->method('fopen')
+			->with('r+');
+
+		$this->simpleFile->fopen('r+');
+	}
 }

--- a/tests/lib/Files/SimpleFS/SimpleFileTest.php
+++ b/tests/lib/Files/SimpleFS/SimpleFileTest.php
@@ -124,11 +124,19 @@ class SimpleFileTest extends \Test\TestCase  {
 		$this->simpleFile->getContent();
 	}
 
-	public function testFopen() {
+	public function testRead() {
 		$this->file->expects($this->once())
 			->method('fopen')
-			->with('r+');
+			->with('r');
 
-		$this->simpleFile->fopen('r+');
+		$this->simpleFile->read();
+	}
+
+	public function testWrite() {
+		$this->file->expects($this->once())
+			->method('fopen')
+			->with('w');
+
+		$this->simpleFile->write();
 	}
 }


### PR DESCRIPTION
This allows to also use the AppData for large files where using a FileDisplayResponse will fail, because it is calling getContent and trying to put the whole file in memory.

With this, apps can properly use a StreamResponse.