### PR TITLE
Fix the behat version to 3.3.*

### DIFF
--- a/build/integration/composer.json
+++ b/build/integration/composer.json
@@ -1,7 +1,7 @@
 {
   "require-dev": {
     "phpunit/phpunit": "~6.5",
-    "behat/behat": "^3.0",
+    "behat/behat": "~3.3.0",
     "guzzlehttp/guzzle": "6.3.3",
     "jarnaiz/behat-junit-formatter": "^1.3",
     "sabre/dav": "3.2.2"


### PR DESCRIPTION
Otherwise the tests fail with:
```
In Inline.php line 299:
                                                                                                                                                   
  The reserved indicator "%" cannot start a plain scalar; you need to quote the scalar at line 3 (near "'': %paths.base%/../features/bootstrap"). 
```

because of symfony4 which is the deps of behat 3.4