### PR TITLE
Correctly handle users with numeric user ids

### DIFF
--- a/core/Command/Base.php
+++ b/core/Command/Base.php
@@ -23,6 +23,7 @@
 
 namespace OC\Core\Command;
 
+use OC\Core\Command\User\ListCommand;
 use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
@@ -76,7 +77,7 @@ class Base extends Command implements CompletionAwareInterface {
 						$this->writeArrayInOutputFormat($input, $output, $item, '  ' . $prefix);
 						continue;
 					}
-					if (!is_int($key)) {
+					if (!is_int($key) || ListCommand::class === get_class($this)) {
 						$value = $this->valueToString($item);
 						if (!is_null($value)) {
 							$output->writeln($prefix . $key . ': ' . $value);


### PR DESCRIPTION
First user is lacking their numeric id:

### Before
```
  - OneTwo
  - admin: admin
  - test1: Seattle Seahawks
  - test2: New Orleans Saints
  - test3: Pittsburgh Steelers
  - test4: Atlanta Falcons
  - test5: Jacksonville Jaguars
```
### After
```
  - 123456: OneTwo
  - admin: admin
  - test1: Seattle Seahawks
  - test2: New Orleans Saints
  - test3: Pittsburgh Steelers
  - test4: Atlanta Falcons
  - test5: Jacksonville Jaguars
```

Fix #10158 