### PR TITLE
Load theming app css as well if legacy theme is enabled

### DIFF
--- a/apps/theming/appinfo/app.php
+++ b/apps/theming/appinfo/app.php
@@ -26,38 +26,32 @@
  */
 
 $app = new \OCP\AppFramework\App('theming');
-/** @var \OCA\Theming\Util $util */
-$util = $app->getContainer()->query(\OCA\Theming\Util::class);
-if(!$util->isAlreadyThemed()) {
+$app->getContainer()->registerCapability(\OCA\Theming\Capabilities::class);
 
-	$app->getContainer()->registerCapability(\OCA\Theming\Capabilities::class);
+$linkToCSS = \OC::$server->getURLGenerator()->linkToRoute(
+	'theming.Theming.getStylesheet',
+	[
+		'v' => \OC::$server->getConfig()->getAppValue('theming', 'cachebuster', '0'),
+	]
+);
+\OCP\Util::addHeader(
+	'link',
+	[
+		'rel' => 'stylesheet',
+		'href' => $linkToCSS,
+	]
+);
 
-	$linkToCSS = \OC::$server->getURLGenerator()->linkToRoute(
-		'theming.Theming.getStylesheet',
-		[
-			'v' => \OC::$server->getConfig()->getAppValue('theming', 'cachebuster', '0'),
-		]
-	);
-	\OCP\Util::addHeader(
-		'link',
-		[
-			'rel' => 'stylesheet',
-			'href' => $linkToCSS,
-		]
-	);
-
-	$linkToJs = \OC::$server->getURLGenerator()->linkToRoute(
-		'theming.Theming.getJavascript',
-		[
-			'v' => \OC::$server->getConfig()->getAppValue('theming', 'cachebuster', '0'),
-		]
-	);
-	\OCP\Util::addHeader(
-		'script',
-		[
-			'src' => $linkToJs,
-			'nonce' => \OC::$server->getContentSecurityPolicyNonceManager()->getNonce()
-		], ''
-	);
-
-}
+$linkToJs = \OC::$server->getURLGenerator()->linkToRoute(
+	'theming.Theming.getJavascript',
+	[
+		'v' => \OC::$server->getConfig()->getAppValue('theming', 'cachebuster', '0'),
+	]
+);
+\OCP\Util::addHeader(
+	'script',
+	[
+		'src' => $linkToJs,
+		'nonce' => \OC::$server->getContentSecurityPolicyNonceManager()->getNonce()
+	], ''
+);


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/server/pull/8993 

This will make sure we also load the theming app css when a custom theme is enabled.

Signed-off-by: Julius Härtl <jus@bitgrid.net>