### PR TITLE
Improve encrypted registration flow

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -131,10 +131,11 @@ class LostController extends Controller {
 	 *
 	 * @param string $token
 	 * @param string $userId
+	 * @param boolean $register
 	 * @return TemplateResponse
 	 */
-	public function resetform($token, $userId) {
-		if ($this->config->getSystemValue('lost_password_link', '') !== '') {
+	public function resetform($token, $userId, $register = false) {
+		if ($register === false && $this->config->getSystemValue('lost_password_link', '') !== '') {
 			return new TemplateResponse('core', 'error', [
 					'errors' => [['error' => $this->l10n->t('Password reset is disabled')]]
 				],
@@ -157,7 +158,11 @@ class LostController extends Controller {
 			'core',
 			'lostpassword/resetpassword',
 			array(
-				'link' => $this->urlGenerator->linkToRouteAbsolute('core.lost.setPassword', array('userId' => $userId, 'token' => $token)),
+				'link' => $this->urlGenerator->linkToRouteAbsolute(
+					'core.lost.setPassword', 
+					array('userId' => $userId, 'token' => $token, 'register' => $register)
+				),
+				'register' => $register
 			),
 			'guest'
 		);
@@ -253,14 +258,15 @@ class LostController extends Controller {
 	 * @param string $userId
 	 * @param string $password
 	 * @param boolean $proceed
+	 * @param boolean $register
 	 * @return array
 	 */
-	public function setPassword($token, $userId, $password, $proceed) {
-		if ($this->config->getSystemValue('lost_password_link', '') !== '') {
+	public function setPassword($token, $userId, $password, $proceed, $register = false) {
+		if ($register === false&& $this->config->getSystemValue('lost_password_link', '') !== '') {
 			return $this->error($this->l10n->t('Password reset is disabled'));
 		}
 
-		if ($this->encryptionManager->isEnabled() && !$proceed) {
+		if ($register === false && $this->encryptionManager->isEnabled() && !$proceed) {
 			$encryptionModules = $this->encryptionManager->getEncryptionModules();
 			foreach ($encryptionModules as $module) {
 				/** @var IEncryptionModule $instance */

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -262,7 +262,7 @@ class LostController extends Controller {
 	 * @return array
 	 */
 	public function setPassword($token, $userId, $password, $proceed, $register = false) {
-		if ($register === false&& $this->config->getSystemValue('lost_password_link', '') !== '') {
+		if ($register === false && $this->config->getSystemValue('lost_password_link', '') !== '') {
 			return $this->error($this->l10n->t('Password reset is disabled'));
 		}
 

--- a/core/js/lostpassword.js
+++ b/core/js/lostpassword.js
@@ -5,7 +5,7 @@ OC.Lostpassword = {
 	sendSuccessMsg : t('core', 'The link to reset your password has been sent to your email. If you do not receive it within a reasonable amount of time, check your spam/junk folders.<br>If it is not there ask your local administrator.'),
 
 	encryptedMsg : t('core', "Your files are encrypted. There will be no way to get your data back after your password is reset.<br />If you are not sure what to do, please contact your administrator before you continue. <br />Do you really want to continue?")
-			+ ('<br /><input type="checkbox" id="encrypted-continue" value="Yes" />')
+			+ ('<br /><input type="checkbox" id="encrypted-continue" value="Yes" class="checkbox checkbox--white" />')
 			+ '<label for="encrypted-continue">'
 			+ t('core', 'I know what I\'m doing')
 			+ '</label><br />',
@@ -141,18 +141,24 @@ OC.Lostpassword = {
 		return $('#lost-password');
 	},
 
-	resetPassword : function(event){
-		event.preventDefault();
-		if ($('#password').val()){
-			$.post(
-					$('#password').parents('form').attr('action'),
-					{
-						password : $('#password').val(),
-						proceed: $('#encrypted-continue').is(':checked') ? 'true' : 'false'
-					},
-					OC.Lostpassword.resetDone
-			);
+	resetPassword : function(event) {
+		// trigger html5 validation popup on required field but dont do anything else
+		if (!$('#password').val()) {
+			return true;
+		} else {
+			// otherwise preventDefault to not submit form twice (causing csrf issue)
+			event.preventDefault();
 		}
+
+		$.post(
+			$('#password').parents('form').attr('action'),
+			{
+				password : $('#password').val(),
+				proceed: $('#encrypted-continue').is(':checked') ? 'true' : 'false'
+			},
+			OC.Lostpassword.resetDone
+		);
+
 		if($('#encrypted-continue').is(':checked')) {
 			$('#reset-password #submit').hide();
 			$('#reset-password #float-spinner').removeClass('hidden');

--- a/core/templates/lostpassword/resetpassword.php
+++ b/core/templates/lostpassword/resetpassword.php
@@ -32,7 +32,7 @@ script('core', 'lostpassword');
 			<label for="password" class="infield"><?php p($l->t('New password')); ?></label>
 			<input type="password" name="password" id="password" value="" placeholder="<?php p($l->t('New Password')); ?>" required />
 		</p>
-		<input class="primary" type="submit" id="submit" value="<?php p($l->t('Reset password')); ?>" />
+		<input class="primary" type="submit" id="submit" value="<?php ($_['register']) ? p($l->t('Set password')) : p($l->t('Reset password')); ?>" />
 		<p class="text-center">
 			<img class="hidden" id="float-spinner" src="<?php p(image_path('core', 'loading-dark.gif'));?>"/>
 		</p>

--- a/settings/Activity/Provider.php
+++ b/settings/Activity/Provider.php
@@ -98,7 +98,7 @@ class Provider implements IProvider {
 		} else if ($event->getSubject() === self::PASSWORD_CHANGED_SELF) {
 			$subject = $this->l->t('You changed your password');
 		} else if ($event->getSubject() === self::PASSWORD_RESET) {
-			$subject = $this->l->t('Your password was reset by an administrator');
+			$subject = $this->l->t('Your password was reset');
 
 		} else if ($event->getSubject() === self::EMAIL_CHANGED_BY) {
 			$subject = $this->l->t('{actor} changed your email address');

--- a/settings/Hooks.php
+++ b/settings/Hooks.php
@@ -114,7 +114,7 @@ class Hooks {
 					->setSubject(Provider::PASSWORD_CHANGED_SELF);
 			}
 		} else {
-			$text = $this->l->t('Your password on %s was reset by an administrator.', [$instanceUrl]);
+			$text = $this->l->t('Your password on %s was reset.', [$instanceUrl]);
 			$event->setSubject(Provider::PASSWORD_RESET);
 		}
 

--- a/settings/Mailer/NewUserMailHelper.php
+++ b/settings/Mailer/NewUserMailHelper.php
@@ -114,7 +114,7 @@ class NewUserMailHelper {
 			$mailAddress = (null !== $user->getEMailAddress()) ? $user->getEMailAddress() : '';
 			$encryptedValue = $this->crypto->encrypt($tokenValue, $mailAddress . $this->config->getSystemValue('secret'));
 			$this->config->setUserValue($user->getUID(), 'core', 'lostpassword', $encryptedValue);
-			$link = $this->urlGenerator->linkToRouteAbsolute('core.lost.resetform', ['userId' => $user->getUID(), 'token' => $token]);
+			$link = $this->urlGenerator->linkToRouteAbsolute('core.lost.resetform', ['userId' => $user->getUID(), 'token' => $token, 'register' => true]);
 		} else {
 			$link = $this->urlGenerator->getAbsoluteURL('/');
 		}

--- a/tests/Settings/Mailer/NewUserMailHelperTest.php
+++ b/tests/Settings/Mailer/NewUserMailHelperTest.php
@@ -145,7 +145,8 @@ class NewUserMailHelperTest extends TestCase {
 		$this->urlGenerator
 			->expects($this->at(0))
 			->method('linkToRouteAbsolute')
-			->with('core.lost.resetform', ['userId' => 'john', 'token' => 'MySuperLongSecureRandomToken'])
+			->with('core.lost.resetform', ['userId' => 'john', 'token' => 'MySuperLongSecureRandomToken', 'register' => true])
+
 			->willReturn('https://example.com/resetPassword/MySuperLongSecureRandomToken');
 		$user
 			->expects($this->at(4))


### PR DESCRIPTION
Improves registration flow in general and especially when the home files are encrypted. It removes the warning (which is still there when you request a passwort reset via the normal means) and changes some wordings when the user is being informed via email that his account as created.

https://github.com/nextcloud/server/issues/9311

A backport to 13.0.x would be very appreciated, if approved.