### PR TITLE
Only bind to ldap if configuration for the first server is set

### DIFF
--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -576,8 +576,8 @@ class Connection extends LDAPUtility {
 				if (!$isOverrideMainServer) {
 					$this->doConnect($this->configuration->ldapHost,
 						$this->configuration->ldapPort);
+					return $this->bind();
 				}
-				return $this->bind();
 			} catch (ServerNotAvailableException $e) {
 				if(!$isBackupHost) {
 					throw $e;

--- a/apps/user_ldap/tests/ConnectionTest.php
+++ b/apps/user_ldap/tests/ConnectionTest.php
@@ -110,7 +110,7 @@ class ConnectionTest extends \Test\TestCase {
 			->method('setOption')
 			->will($this->returnValue(true));
 
-		$this->ldap->expects($this->exactly(2))
+		$this->ldap->expects($this->exactly(3))
 			->method('connect')
 			->will($this->returnValue('ldapResource'));
 
@@ -119,7 +119,7 @@ class ConnectionTest extends \Test\TestCase {
 			->will($this->returnValue(0));
 
 		// Not called often enough? Then, the fallback to the backup server is broken.
-		$this->connection->expects($this->exactly(3))
+		$this->connection->expects($this->exactly(4))
 			->method('getFromCache')
 			->with('overrideMainServer')
 			->will($this->onConsecutiveCalls(false, false, true, true));


### PR DESCRIPTION
This fixes an infinite loop in setups with an backup ldap server as reported in https://github.com/nextcloud/server/issues/10160

We should only try to bind to ldap for the main server if we have a configuration set with doConnect at this point, otherwise there will be no resource for the connection set and establishConnection() will be called over and over again.