### PR TITLE
Allow notifiers to know if we prepare push notifications

### DIFF
--- a/lib/private/Notification/Manager.php
+++ b/lib/private/Notification/Manager.php
@@ -53,6 +53,9 @@ class Manager implements IManager {
 	/** @var \Closure[] */
 	protected $notifiersInfoClosures;
 
+	/** @var bool */
+	protected $preparingPushNotification;
+
 	/**
 	 * Manager constructor.
 	 *
@@ -66,6 +69,7 @@ class Manager implements IManager {
 		$this->appsClosures = [];
 		$this->notifiersClosures = [];
 		$this->notifiersInfoClosures = [];
+		$this->preparingPushNotification = false;
 	}
 
 	/**
@@ -169,6 +173,22 @@ class Manager implements IManager {
 	 */
 	public function hasNotifiers() {
 		return !empty($this->notifiersClosures);
+	}
+
+	/**
+	 * @param bool $preparingPushNotification
+	 * @since 14.0.0
+	 */
+	public function setPreparingPushNotification($preparingPushNotification) {
+		$this->preparingPushNotification = $preparingPushNotification;
+	}
+
+	/**
+	 * @return bool
+	 * @since 14.0.0
+	 */
+	public function isPreparingPushNotification(): bool {
+		return $this->preparingPushNotification;
 	}
 
 	/**

--- a/lib/private/Notification/Manager.php
+++ b/lib/private/Notification/Manager.php
@@ -99,7 +99,7 @@ class Manager implements IManager {
 	/**
 	 * @return IApp[]
 	 */
-	protected function getApps() {
+	protected function getApps(): array {
 		if (!empty($this->apps)) {
 			return $this->apps;
 		}
@@ -119,7 +119,7 @@ class Manager implements IManager {
 	/**
 	 * @return INotifier[]
 	 */
-	protected function getNotifiers() {
+	protected function getNotifiers(): array {
 		if (!empty($this->notifiers)) {
 			return $this->notifiers;
 		}
@@ -139,7 +139,7 @@ class Manager implements IManager {
 	/**
 	 * @return array[]
 	 */
-	public function listNotifiers() {
+	public function listNotifiers(): array {
 		if (!empty($this->notifiersInfo)) {
 			return $this->notifiersInfo;
 		}
@@ -147,7 +147,7 @@ class Manager implements IManager {
 		$this->notifiersInfo = [];
 		foreach ($this->notifiersInfoClosures as $closure) {
 			$notifier = $closure();
-			if (!is_array($notifier) || count($notifier) !== 2 || !isset($notifier['id']) || !isset($notifier['name'])) {
+			if (!\is_array($notifier) || \count($notifier) !== 2 || !isset($notifier['id'], $notifier['name'])) {
 				throw new \InvalidArgumentException('The given notifier information is invalid');
 			}
 			if (isset($this->notifiersInfo[$notifier['id']])) {
@@ -163,7 +163,7 @@ class Manager implements IManager {
 	 * @return INotification
 	 * @since 8.2.0
 	 */
-	public function createNotification() {
+	public function createNotification(): INotification {
 		return new Notification($this->validator);
 	}
 
@@ -171,7 +171,7 @@ class Manager implements IManager {
 	 * @return bool
 	 * @since 8.2.0
 	 */
-	public function hasNotifiers() {
+	public function hasNotifiers(): bool {
 		return !empty($this->notifiersClosures);
 	}
 
@@ -218,7 +218,7 @@ class Manager implements IManager {
 	 * @throws \InvalidArgumentException When the notification was not prepared by a notifier
 	 * @since 8.2.0
 	 */
-	public function prepare(INotification $notification, $languageCode) {
+	public function prepare(INotification $notification, $languageCode): INotification {
 		$notifiers = $this->getNotifiers();
 
 		foreach ($notifiers as $notifier) {
@@ -255,7 +255,7 @@ class Manager implements IManager {
 	 * @param INotification $notification
 	 * @return int
 	 */
-	public function getCount(INotification $notification) {
+	public function getCount(INotification $notification): int {
 		$apps = $this->getApps();
 
 		$count = 0;

--- a/lib/public/Notification/IManager.php
+++ b/lib/public/Notification/IManager.php
@@ -62,4 +62,16 @@ interface IManager extends IApp, INotifier {
 	 * @since 9.0.0
 	 */
 	public function hasNotifiers();
+
+	/**
+	 * @param bool $preparingPushNotification
+	 * @since 14.0.0
+	 */
+	public function setPreparingPushNotification($preparingPushNotification);
+
+	/**
+	 * @return bool
+	 * @since 14.0.0
+	 */
+	public function isPreparingPushNotification();
 }


### PR DESCRIPTION
Push notifications have to be dealt differently with,
because the current user is not the user we are preparing for,
instead they are prepared for another user.
In order to allow notifiers to react accordingly it should be available via an api,
instead of requiring dirty code like:

```php
	protected function isRenderingPushNotifications(): bool {
		$exception = new \Exception();
		$trace = $exception->getTrace();
		foreach ($trace as $step) {
			if (isset($step['class']) && $step['class'] === 'OCA\Notifications\Push' &&
				isset($step['function']) && $step['function'] === 'pushToDevice') {
				return true;
			}
		}
		return false;
	}
```

- [ ] https://github.com/nextcloud/notifications/pull/142 App PR