### PR TITLE
[stable13] Only bind to ldap if configuration for the first server is set

### DIFF
--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -564,8 +564,8 @@ class Connection extends LDAPUtility {
 				if (!$isOverrideMainServer) {
 					$this->doConnect($this->configuration->ldapHost,
 						$this->configuration->ldapPort);
+					return $this->bind();
 				}
-				return $this->bind();
 			} catch (ServerNotAvailableException $e) {
 				if(!$isBackupHost) {
 					throw $e;

--- a/apps/user_ldap/tests/ConnectionTest.php
+++ b/apps/user_ldap/tests/ConnectionTest.php
@@ -110,7 +110,7 @@ class ConnectionTest extends \Test\TestCase {
 			->method('setOption')
 			->will($this->returnValue(true));
 
-		$this->ldap->expects($this->exactly(2))
+		$this->ldap->expects($this->exactly(3))
 			->method('connect')
 			->will($this->returnValue('ldapResource'));
 
@@ -119,7 +119,7 @@ class ConnectionTest extends \Test\TestCase {
 			->will($this->returnValue(0));
 
 		// Not called often enough? Then, the fallback to the backup server is broken.
-		$this->connection->expects($this->exactly(3))
+		$this->connection->expects($this->exactly(4))
 			->method('getFromCache')
 			->with('overrideMainServer')
 			->will($this->onConsecutiveCalls(false, false, true, true));


### PR DESCRIPTION
Backport of #10227 

Let get this in and build an RC2 of 13.0.5 to fix this bug in the back ported #10031