### PR TITLE
Add support for room shares

### DIFF
--- a/apps/admin_audit/lib/Actions/Sharing.php
+++ b/apps/admin_audit/lib/Actions/Sharing.php
@@ -78,6 +78,19 @@ class Sharing extends Action {
 					'id',
 				]
 			);
+		} elseif($params['shareType'] === Share::SHARE_TYPE_ROOM) {
+			$this->log(
+				'The %s "%s" with ID "%s" has been shared to the room "%s" with permissions "%s" (Share ID: %s)',
+				$params,
+				[
+					'itemType',
+					'itemTarget',
+					'itemSource',
+					'shareWith',
+					'permissions',
+					'id',
+				]
+			);
 		}
 	}
 
@@ -113,6 +126,18 @@ class Sharing extends Action {
 		} elseif($params['shareType'] === Share::SHARE_TYPE_GROUP) {
 			$this->log(
 				'The %s "%s" with ID "%s" has been unshared from the group "%s" (Share ID: %s)',
+				$params,
+				[
+					'itemType',
+					'fileTarget',
+					'itemSource',
+					'shareWith',
+					'id',
+				]
+			);
+		} elseif($params['shareType'] === Share::SHARE_TYPE_ROOM) {
+			$this->log(
+				'The %s "%s" with ID "%s" has been unshared from the room "%s" (Share ID: %s)',
 				$params,
 				[
 					'itemType',

--- a/apps/dav/lib/Connector/Sabre/SharesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/SharesPlugin.php
@@ -124,6 +124,7 @@ class SharesPlugin extends \Sabre\DAV\ServerPlugin {
 			\OCP\Share::SHARE_TYPE_LINK,
 			\OCP\Share::SHARE_TYPE_REMOTE,
 			\OCP\Share::SHARE_TYPE_EMAIL,
+			\OCP\Share::SHARE_TYPE_ROOM,
 		];
 		foreach ($requestedShareTypes as $requestedShareType) {
 			// one of each type is enough to find out about the types

--- a/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
@@ -298,6 +298,7 @@ class SharesPluginTest extends \Test\TestCase {
 			[[\OCP\Share::SHARE_TYPE_GROUP]],
 			[[\OCP\Share::SHARE_TYPE_LINK]],
 			[[\OCP\Share::SHARE_TYPE_REMOTE]],
+			[[\OCP\Share::SHARE_TYPE_ROOM]],
 			[[\OCP\Share::SHARE_TYPE_USER, \OCP\Share::SHARE_TYPE_GROUP]],
 			[[\OCP\Share::SHARE_TYPE_USER, \OCP\Share::SHARE_TYPE_GROUP, \OCP\Share::SHARE_TYPE_LINK]],
 			[[\OCP\Share::SHARE_TYPE_USER, \OCP\Share::SHARE_TYPE_LINK]],

--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -217,7 +217,7 @@ class TransferOwnership extends Command {
 		$output->writeln("Collecting all share information for files and folder of $this->sourceUser ...");
 
 		$progress = new ProgressBar($output, count($this->shares));
-		foreach([\OCP\Share::SHARE_TYPE_GROUP, \OCP\Share::SHARE_TYPE_USER, \OCP\Share::SHARE_TYPE_LINK, \OCP\Share::SHARE_TYPE_REMOTE] as $shareType) {
+		foreach([\OCP\Share::SHARE_TYPE_GROUP, \OCP\Share::SHARE_TYPE_USER, \OCP\Share::SHARE_TYPE_LINK, \OCP\Share::SHARE_TYPE_REMOTE, \OCP\Share::SHARE_TYPE_ROOM] as $shareType) {
 		$offset = 0;
 			while (true) {
 				$sharePage = $this->shareManager->getSharesBy($this->sourceUser, $shareType, null, true, 50, $offset);

--- a/apps/files/lib/Controller/ApiController.php
+++ b/apps/files/lib/Controller/ApiController.php
@@ -214,7 +214,8 @@ class ApiController extends Controller {
 			\OCP\Share::SHARE_TYPE_GROUP,
 			\OCP\Share::SHARE_TYPE_LINK,
 			\OCP\Share::SHARE_TYPE_REMOTE,
-			\OCP\Share::SHARE_TYPE_EMAIL
+			\OCP\Share::SHARE_TYPE_EMAIL,
+			\OCP\Share::SHARE_TYPE_ROOM
 		];
 		foreach ($requestedShareTypes as $requestedShareType) {
 			// one of each type is enough to find out about the types

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -144,6 +144,8 @@
 								hasShares = true;
 							} else if (shareType === OC.Share.SHARE_TYPE_CIRCLE) {
 								hasShares = true;
+							} else if (shareType === OC.Share.SHARE_TYPE_ROOM) {
+								hasShares = true;
 							}
 						});
 						OCA.Sharing.Util._updateFileActionIcon($tr, hasShares, hasLink);

--- a/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
@@ -86,6 +86,9 @@ class DeletedShareAPIController extends OCSController {
 		$this->serverContainer = $serverContainer;
 	}
 
+	/**
+	 * @suppress PhanUndeclaredClassMethod
+	 */
 	private function formatShare(IShare $share): array {
 
 		$result = [

--- a/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
@@ -26,14 +26,17 @@ declare(strict_types=1);
 
 namespace OCA\Files_Sharing\Controller;
 
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\AppFramework\OCSController;
+use OCP\AppFramework\QueryException;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IServerContainer;
 use OCP\IUserManager;
 use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\Exceptions\ShareNotFound;
@@ -57,13 +60,21 @@ class DeletedShareAPIController extends OCSController {
 	/** @var IRootFolder */
 	private $rootFolder;
 
+	/** @var IAppManager */
+	private $appManager;
+
+	/** @var IServerContainer */
+	private $serverContainer;
+
 	public function __construct(string $appName,
 								IRequest $request,
 								ShareManager $shareManager,
 								string $UserId,
 								IUserManager $userManager,
 								IGroupManager $groupManager,
-								IRootFolder $rootFolder) {
+								IRootFolder $rootFolder,
+								IAppManager $appManager,
+								IServerContainer $serverContainer) {
 		parent::__construct($appName, $request);
 
 		$this->shareManager = $shareManager;
@@ -71,6 +82,8 @@ class DeletedShareAPIController extends OCSController {
 		$this->userManager = $userManager;
 		$this->groupManager = $groupManager;
 		$this->rootFolder = $rootFolder;
+		$this->appManager = $appManager;
+		$this->serverContainer = $serverContainer;
 	}
 
 	private function formatShare(IShare $share): array {
@@ -120,9 +133,19 @@ class DeletedShareAPIController extends OCSController {
 			$result['expiration'] = $expiration->format('Y-m-d 00:00:00');
 		}
 
-		$group = $this->groupManager->get($share->getSharedWith());
-		$result['share_with'] = $share->getSharedWith();
-		$result['share_with_displayname'] = $group !== null ? $group->getDisplayName() : $share->getSharedWith();
+		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
+			$group = $this->groupManager->get($share->getSharedWith());
+			$result['share_with'] = $share->getSharedWith();
+			$result['share_with_displayname'] = $group !== null ? $group->getDisplayName() : $share->getSharedWith();
+		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_ROOM) {
+			$result['share_with'] = $share->getSharedWith();
+			$result['share_with_displayname'] = '';
+
+			try {
+				$result = array_merge($result, $this->getRoomShareHelper()->formatShare($share));
+			} catch (QueryException $e) {
+			}
+		}
 
 		return $result;
 
@@ -132,7 +155,10 @@ class DeletedShareAPIController extends OCSController {
 	 * @NoAdminRequired
 	 */
 	public function index(): DataResponse {
-		$shares = $this->shareManager->getDeletedSharedWith($this->userId, \OCP\Share::SHARE_TYPE_GROUP, null, -1, 0);
+		$groupShares = $this->shareManager->getDeletedSharedWith($this->userId, \OCP\Share::SHARE_TYPE_GROUP, null, -1, 0);
+		$roomShares = $this->shareManager->getDeletedSharedWith($this->userId, \OCP\Share::SHARE_TYPE_ROOM, null, -1, 0);
+
+		$shares = array_merge($groupShares, $roomShares);
 
 		$shares = array_map(function (IShare $share) {
 			return $this->formatShare($share);
@@ -164,5 +190,22 @@ class DeletedShareAPIController extends OCSController {
 		}
 
 		return new DataResponse([]);
+	}
+
+	/**
+	 * Returns the helper of DeletedShareAPIController for room shares.
+	 *
+	 * If the Talk application is not enabled or the helper is not available
+	 * a QueryException is thrown instead.
+	 *
+	 * @return \OCA\Spreed\Share\Helper\DeletedShareAPIController
+	 * @throws QueryException
+	 */
+	private function getRoomShareHelper() {
+		if (!$this->appManager->isEnabledForUser('spreed')) {
+			throw new QueryException();
+		}
+
+		return $this->serverContainer->query('\OCA\Spreed\Share\Helper\DeletedShareAPIController');
 	}
 }

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -37,6 +37,7 @@ use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\AppFramework\OCSController;
+use OCP\AppFramework\QueryException;
 use OCP\Constants;
 use OCP\Files\Folder;
 use OCP\Files\Node;
@@ -46,6 +47,7 @@ use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IUserManager;
 use OCP\IRequest;
+use OCP\IServerContainer;
 use OCP\IURLGenerator;
 use OCP\Files\IRootFolder;
 use OCP\Lock\LockedException;
@@ -84,6 +86,8 @@ class ShareAPIController extends OCSController {
 	private $config;
 	/** @var IAppManager */
 	private $appManager;
+	/** @var IServerContainer */
+	private $serverContainer;
 
 	/**
 	 * Share20OCS constructor.
@@ -99,6 +103,7 @@ class ShareAPIController extends OCSController {
 	 * @param IL10N $l10n
 	 * @param IConfig $config
 	 * @param IAppManager $appManager
+	 * @param IServerContainer $serverContainer
 	 */
 	public function __construct(
 		string $appName,
@@ -111,7 +116,8 @@ class ShareAPIController extends OCSController {
 		string $userId,
 		IL10N $l10n,
 		IConfig $config,
-		IAppManager $appManager
+		IAppManager $appManager,
+		IServerContainer $serverContainer
 	) {
 		parent::__construct($appName, $request);
 
@@ -125,6 +131,7 @@ class ShareAPIController extends OCSController {
 		$this->l = $l10n;
 		$this->config = $config;
 		$this->appManager = $appManager;
+		$this->serverContainer = $serverContainer;
 	}
 
 	/**
@@ -231,6 +238,14 @@ class ShareAPIController extends OCSController {
 			$shareWithStart = ($hasCircleId? strrpos($share->getSharedWith(), '[') + 1: 0);
 			$shareWithLength = ($hasCircleId? -1: strpos($share->getSharedWith(), ' '));
 			$result['share_with'] = substr($share->getSharedWith(), $shareWithStart, $shareWithLength);
+		} else if ($share->getShareType() === Share::SHARE_TYPE_ROOM) {
+			$result['share_with'] = $share->getSharedWith();
+			$result['share_with_displayname'] = '';
+
+			try {
+				$result = array_merge($result, $this->getRoomShareHelper()->formatShare($share));
+			} catch (QueryException $e) {
+			}
 		}
 
 
@@ -315,7 +330,8 @@ class ShareAPIController extends OCSController {
 			throw new OCSNotFoundException($this->l->t('Could not delete share'));
 		}
 
-		if ($share->getShareType() === Share::SHARE_TYPE_GROUP &&
+		if (($share->getShareType() === Share::SHARE_TYPE_GROUP ||
+				$share->getShareType() === Share::SHARE_TYPE_ROOM) &&
 			$share->getShareOwner() !== $this->currentUser &&
 			$share->getSharedBy() !== $this->currentUser) {
 			$this->shareManager->deleteFromSelf($share, $this->currentUser);
@@ -515,6 +531,12 @@ class ShareAPIController extends OCSController {
 			}
 			$share->setSharedWith($shareWith);
 			$share->setPermissions($permissions);
+		} else if ($shareType === Share::SHARE_TYPE_ROOM) {
+			try {
+				$this->getRoomShareHelper()->createShare($share, $shareWith, $permissions, $expireDate);
+			} catch (QueryException $e) {
+				throw new OCSForbiddenException($this->l->t('Sharing %s failed because the back end does not support room shares', [$path->getPath()]));
+			}
 		} else {
 			throw new OCSBadRequestException($this->l->t('Unknown share type'));
 		}
@@ -546,8 +568,9 @@ class ShareAPIController extends OCSController {
 		$userShares = $this->shareManager->getSharedWith($this->currentUser, Share::SHARE_TYPE_USER, $node, -1, 0);
 		$groupShares = $this->shareManager->getSharedWith($this->currentUser, Share::SHARE_TYPE_GROUP, $node, -1, 0);
 		$circleShares = $this->shareManager->getSharedWith($this->currentUser, Share::SHARE_TYPE_CIRCLE, $node, -1, 0);
+		$roomShares = $this->shareManager->getSharedWith($this->currentUser, Share::SHARE_TYPE_ROOM, $node, -1, 0);
 
-		$shares = array_merge($userShares, $groupShares, $circleShares);
+		$shares = array_merge($userShares, $groupShares, $circleShares, $roomShares);
 
 		$shares = array_filter($shares, function (IShare $share) {
 			return $share->getShareOwner() !== $this->currentUser;
@@ -594,6 +617,7 @@ class ShareAPIController extends OCSController {
 			if ($this->shareManager->outgoingServer2ServerSharesAllowed()) {
 				$shares = array_merge($shares, $this->shareManager->getSharesBy($this->currentUser, Share::SHARE_TYPE_REMOTE, $node, false, -1, 0));
 			}
+			$shares = array_merge($shares, $this->shareManager->getSharesBy($this->currentUser, Share::SHARE_TYPE_ROOM, $node, false, -1, 0));
 		}
 
 		$formatted = [];
@@ -679,8 +703,9 @@ class ShareAPIController extends OCSController {
 		} else {
 			$circleShares = [];
 		}
+		$roomShares = $this->shareManager->getSharesBy($this->currentUser, Share::SHARE_TYPE_ROOM, $path, $reshares, -1, 0);
 
-		$shares = array_merge($userShares, $groupShares, $linkShares, $mailShares, $circleShares);
+		$shares = array_merge($userShares, $groupShares, $linkShares, $mailShares, $circleShares, $roomShares);
 
 		if ($this->shareManager->outgoingServer2ServerSharesAllowed()) {
 			$federatedShares = $this->shareManager->getSharesBy($this->currentUser, Share::SHARE_TYPE_REMOTE, $path, $reshares, -1, 0);
@@ -864,6 +889,7 @@ class ShareAPIController extends OCSController {
 			/* Check if this is an incomming share */
 			$incomingShares = $this->shareManager->getSharedWith($this->currentUser, Share::SHARE_TYPE_USER, $share->getNode(), -1, 0);
 			$incomingShares = array_merge($incomingShares, $this->shareManager->getSharedWith($this->currentUser, Share::SHARE_TYPE_GROUP, $share->getNode(), -1, 0));
+			$incomingShares = array_merge($incomingShares, $this->shareManager->getSharedWith($this->currentUser, Share::SHARE_TYPE_ROOM, $share->getNode(), -1, 0));
 
 			/** @var \OCP\Share\IShare[] $incomingShares */
 			if (!empty($incomingShares)) {
@@ -919,6 +945,14 @@ class ShareAPIController extends OCSController {
 		if ($share->getShareType() === Share::SHARE_TYPE_CIRCLE) {
 			// TODO: have a sanity check like above?
 			return true;
+		}
+
+		if ($share->getShareType() === Share::SHARE_TYPE_ROOM) {
+			try {
+				return $this->getRoomShareHelper()->canAccessShare($share, $this->currentUser);
+			} catch (QueryException $e) {
+				return false;
+			}
 		}
 
 		return false;
@@ -988,6 +1022,13 @@ class ShareAPIController extends OCSController {
 			// Do nothing, just try the other share type
 		}
 
+		try {
+			$share = $this->shareManager->getShareById('ocRoomShare:' . $id, $this->currentUser);
+			return $share;
+		} catch (ShareNotFound $e) {
+			// Do nothing, just try the other share type
+		}
+
 		if (!$this->shareManager->outgoingServer2ServerSharesAllowed()) {
 			throw new ShareNotFound();
 		}
@@ -1015,5 +1056,22 @@ class ShareAPIController extends OCSController {
 		if ($this->lockedNode !== null) {
 			$this->lockedNode->unlock(ILockingProvider::LOCK_SHARED);
 		}
+	}
+
+	/**
+	 * Returns the helper of ShareAPIController for room shares.
+	 *
+	 * If the Talk application is not enabled or the helper is not available
+	 * a QueryException is thrown instead.
+	 *
+	 * @return \OCA\Spreed\Share\Helper\ShareAPIController
+	 * @throws QueryException
+	 */
+	private function getRoomShareHelper() {
+		if (!$this->appManager->isEnabledForUser('spreed')) {
+			throw new QueryException();
+		}
+
+		return $this->serverContainer->query('\OCA\Spreed\Share\Helper\ShareAPIController');
 	}
 }

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -141,6 +141,8 @@ class ShareAPIController extends OCSController {
 	 * @param Node|null $recipientNode
 	 * @return array
 	 * @throws NotFoundException In case the node can't be resolved.
+	 *
+	 * @suppress PhanUndeclaredClassMethod
 	 */
 	protected function formatShare(\OCP\Share\IShare $share, Node $recipientNode = null): array {
 		$sharedBy = $this->userManager->get($share->getSharedBy());
@@ -914,6 +916,9 @@ class ShareAPIController extends OCSController {
 		return new DataResponse($this->formatShare($share));
 	}
 
+	/**
+	 * @suppress PhanUndeclaredClassMethod
+	 */
 	protected function canAccessShare(\OCP\Share\IShare $share, bool $checkGroups = true): bool {
 		// A file with permissions 0 can't be accessed by us. So Don't show it
 		if ($share->getPermissions() === 0) {

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -74,6 +74,7 @@ class MountProvider implements IMountProvider {
 		$shares = $this->shareManager->getSharedWith($user->getUID(), \OCP\Share::SHARE_TYPE_USER, null, -1);
 		$shares = array_merge($shares, $this->shareManager->getSharedWith($user->getUID(), \OCP\Share::SHARE_TYPE_GROUP, null, -1));
 		$shares = array_merge($shares, $this->shareManager->getSharedWith($user->getUID(), \OCP\Share::SHARE_TYPE_CIRCLE, null, -1));
+		$shares = array_merge($shares, $this->shareManager->getSharedWith($user->getUID(), \OCP\Share::SHARE_TYPE_ROOM, null, -1));
 
 		// filter out excluded shares and group shares that includes self
 		$shares = array_filter($shares, function (\OCP\Share\IShare $share) use ($user) {

--- a/apps/files_sharing/lib/Updater.php
+++ b/apps/files_sharing/lib/Updater.php
@@ -59,6 +59,7 @@ class Updater {
 
 		$shares = $shareManager->getSharesBy($userFolder->getOwner()->getUID(), \OCP\Share::SHARE_TYPE_USER, $src, false, -1);
 		$shares = array_merge($shares, $shareManager->getSharesBy($userFolder->getOwner()->getUID(), \OCP\Share::SHARE_TYPE_GROUP, $src, false, -1));
+		$shares = array_merge($shares, $shareManager->getSharesBy($userFolder->getOwner()->getUID(), \OCP\Share::SHARE_TYPE_ROOM, $src, false, -1));
 
 		// If the path we move is not a share we don't care
 		if (empty($shares)) {

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -41,6 +41,7 @@ use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IServerContainer;
 
 /**
  * Class ApiTest
@@ -109,6 +110,7 @@ class ApiTest extends TestCase {
 			}));
 		$config = $this->createMock(IConfig::class);
 		$appManager = $this->createMock(IAppManager::class);
+		$serverContainer = $this->createMock(IServerContainer::class);
 
 		return new ShareAPIController(
 			self::APP_NAME,
@@ -121,7 +123,8 @@ class ApiTest extends TestCase {
 			$userId,
 			$l,
 			$config,
-			$appManager
+			$appManager,
+			$serverContainer
 		);
 	}
 

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -38,6 +38,7 @@ use OCA\Files_Sharing\Controller\ShareAPIController;
 use OCP\Files\NotFoundException;
 use OCP\IGroupManager;
 use OCP\IUserManager;
+use OCP\IServerContainer;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUser;
@@ -92,6 +93,9 @@ class ShareAPIControllerTest extends TestCase {
 	/** @var IAppManager|\PHPUnit_Framework_MockObject_MockObject */
 	private $appManager;
 
+	/** @var IServerContainer|\PHPUnit_Framework_MockObject_MockObject */
+	private $serverContainer;
+
 	protected function setUp() {
 		$this->shareManager = $this->createMock(IManager::class);
 		$this->shareManager
@@ -112,6 +116,7 @@ class ShareAPIControllerTest extends TestCase {
 			}));
 		$this->config = $this->createMock(IConfig::class);
 		$this->appManager = $this->createMock(IAppManager::class);
+		$this->serverContainer = $this->createMock(IServerContainer::class);
 
 		$this->ocs = new ShareAPIController(
 			$this->appName,
@@ -124,7 +129,8 @@ class ShareAPIControllerTest extends TestCase {
 			$this->currentUser,
 			$this->l,
 			$this->config,
-			$this->appManager
+			$this->appManager,
+			$this->serverContainer
 		);
 	}
 
@@ -144,7 +150,8 @@ class ShareAPIControllerTest extends TestCase {
 				$this->currentUser,
 				$this->l,
 				$this->config,
-				$this->appManager
+				$this->appManager,
+				$this->serverContainer
 			])->setMethods(['formatShare'])
 			->getMock();
 	}
@@ -159,10 +166,10 @@ class ShareAPIControllerTest extends TestCase {
 	 */
 	public function testDeleteShareShareNotFound() {
 		$this->shareManager
-			->expects($this->exactly(2))
+			->expects($this->exactly(3))
 			->method('getShareById')
 			->will($this->returnCallback(function($id) {
-				if ($id === 'ocinternal:42' || $id === 'ocFederatedSharing:42') {
+				if ($id === 'ocinternal:42' || $id === 'ocRoomShare:42' || $id === 'ocFederatedSharing:42') {
 					throw new \OCP\Share\Exceptions\ShareNotFound();
 				} else {
 					throw new \Exception();
@@ -461,7 +468,8 @@ class ShareAPIControllerTest extends TestCase {
 					$this->currentUser,
 					$this->l,
 					$this->config,
-					$this->appManager
+					$this->appManager,
+					$this->serverContainer
 				])->setMethods(['canAccessShare'])
 				->getMock();
 
@@ -594,6 +602,65 @@ class ShareAPIControllerTest extends TestCase {
 		$share = $this->createMock(IShare::class);
 		$share->method('getShareType')->willReturn(\OCP\Share::SHARE_TYPE_LINK);
 		$this->assertFalse($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
+	}
+
+	public function dataCanAccessRoomShare() {
+		$result = [];
+
+		$share = $this->createMock(IShare::class);
+		$share->method('getShareType')->willReturn(\OCP\Share::SHARE_TYPE_ROOM);
+		$share->method('getSharedWith')->willReturn('recipientRoom');
+
+		$result[] = [
+			false, $share, false, false
+		];
+
+		$result[] = [
+			false, $share, false, true
+		];
+
+		$result[] = [
+			true, $share, true, true
+		];
+
+		$result[] = [
+			false, $share, true, false
+		];
+
+		return $result;
+	}
+
+	/**
+	 * @dataProvider dataCanAccessRoomShare
+	 *
+	 * @param bool $expects
+	 * @param \OCP\Share\IShare $share
+	 * @param bool helperAvailable
+	 * @param bool canAccessShareByHelper
+	 */
+	public function testCanAccessRoomShare(bool $expected, \OCP\Share\IShare $share, bool $helperAvailable, bool $canAccessShareByHelper) {
+		if (!$helperAvailable) {
+			$this->appManager->method('isEnabledForUser')
+				->with('spreed')
+				->willReturn(false);
+		} else {
+			$this->appManager->method('isEnabledForUser')
+				->with('spreed')
+				->willReturn(true);
+
+			$helper = $this->getMockBuilder('\OCA\Spreed\Share\Helper\ShareAPIController')
+				->setMethods(array('canAccessShare'))
+				->getMock();
+			$helper->method('canAccessShare')
+				->with($share, $this->currentUser)
+				->willReturn($canAccessShareByHelper);
+
+			$this->serverContainer->method('query')
+				->with('\OCA\Spreed\Share\Helper\ShareAPIController')
+				->willReturn($helper);
+		}
+
+		$this->assertEquals($expected, $this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
 	}
 
 	/**
@@ -733,7 +800,8 @@ class ShareAPIControllerTest extends TestCase {
 				$this->currentUser,
 				$this->l,
 				$this->config,
-				$this->appManager
+				$this->appManager,
+				$this->serverContainer
 			])->setMethods(['formatShare'])
 			->getMock();
 
@@ -832,7 +900,8 @@ class ShareAPIControllerTest extends TestCase {
 				$this->currentUser,
 				$this->l,
 				$this->config,
-				$this->appManager
+				$this->appManager,
+				$this->serverContainer
 			])->setMethods(['formatShare'])
 			->getMock();
 
@@ -1128,6 +1197,186 @@ class ShareAPIControllerTest extends TestCase {
 		$ocs->createShare('valid-path', \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK, null, 'false', '', null, 'a1b2d3');
 	}
 
+	public function testCreateShareRoom() {
+		$ocs = $this->mockFormatShare();
+
+		$share = $this->newShare();
+		$this->shareManager->method('newShare')->willReturn($share);
+
+		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
+		$this->rootFolder->expects($this->once())
+				->method('getUserFolder')
+				->with('currentUser')
+				->willReturn($userFolder);
+
+		$path = $this->getMockBuilder(File::class)->getMock();
+		$storage = $this->getMockBuilder(Storage::class)->getMock();
+		$storage->method('instanceOfStorage')
+			->with('OCA\Files_Sharing\External\Storage')
+			->willReturn(false);
+		$path->method('getStorage')->willReturn($storage);
+		$userFolder->expects($this->once())
+				->method('get')
+				->with('valid-path')
+				->willReturn($path);
+
+		$path->expects($this->once())
+			->method('lock')
+			->with(\OCP\Lock\ILockingProvider::LOCK_SHARED);
+
+		$this->appManager->method('isEnabledForUser')
+			->with('spreed')
+			->willReturn(true);
+
+		$helper = $this->getMockBuilder('\OCA\Spreed\Share\Helper\ShareAPIController')
+			->setMethods(array('createShare'))
+			->getMock();
+		$helper->method('createShare')
+			->with(
+				$share,
+				'recipientRoom',
+				\OCP\Constants::PERMISSION_ALL &
+				~\OCP\Constants::PERMISSION_DELETE &
+				~\OCP\Constants::PERMISSION_CREATE,
+				''
+			)->will($this->returnCallback(
+				function ($share) {
+					$share->setSharedWith('recipientRoom');
+					$share->setPermissions(
+						\OCP\Constants::PERMISSION_ALL &
+						~\OCP\Constants::PERMISSION_DELETE &
+						~\OCP\Constants::PERMISSION_CREATE
+					);
+				}
+			));
+
+		$this->serverContainer->method('query')
+			->with('\OCA\Spreed\Share\Helper\ShareAPIController')
+			->willReturn($helper);
+
+		$this->shareManager->method('createShare')
+			->with($this->callback(function (\OCP\Share\IShare $share) use ($path) {
+				return $share->getNode() === $path &&
+					$share->getPermissions() === (
+						\OCP\Constants::PERMISSION_ALL &
+						~\OCP\Constants::PERMISSION_DELETE &
+						~\OCP\Constants::PERMISSION_CREATE
+					) &&
+					$share->getShareType() === \OCP\Share::SHARE_TYPE_ROOM &&
+					$share->getSharedWith() === 'recipientRoom' &&
+					$share->getSharedBy() === 'currentUser';
+			}))
+			->will($this->returnArgument(0));
+
+		$expected = new DataResponse([]);
+		$result = $ocs->createShare('valid-path', \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_ROOM, 'recipientRoom');
+
+		$this->assertInstanceOf(get_class($expected), $result);
+		$this->assertEquals($expected->getData(), $result->getData());
+	}
+
+	/**
+	 * @expectedException \OCP\AppFramework\OCS\OCSForbiddenException
+	 * @expectedExceptionMessage Sharing valid-path failed because the back end does not support room shares
+	 */
+	public function testCreateShareRoomHelperNotAvailable() {
+		$ocs = $this->mockFormatShare();
+
+		$share = $this->newShare();
+		$this->shareManager->method('newShare')->willReturn($share);
+
+		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
+		$this->rootFolder->expects($this->once())
+				->method('getUserFolder')
+				->with('currentUser')
+				->willReturn($userFolder);
+
+		$path = $this->getMockBuilder(File::class)->getMock();
+		$storage = $this->getMockBuilder(Storage::class)->getMock();
+		$storage->method('instanceOfStorage')
+			->with('OCA\Files_Sharing\External\Storage')
+			->willReturn(false);
+		$path->method('getStorage')->willReturn($storage);
+		$path->method('getPath')->willReturn('valid-path');
+		$userFolder->expects($this->once())
+				->method('get')
+				->with('valid-path')
+				->willReturn($path);
+
+		$path->expects($this->once())
+			->method('lock')
+			->with(\OCP\Lock\ILockingProvider::LOCK_SHARED);
+
+		$this->appManager->method('isEnabledForUser')
+			->with('spreed')
+			->willReturn(false);
+
+		$this->shareManager->expects($this->never())->method('createShare');
+
+		$ocs->createShare('valid-path', \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_ROOM, 'recipientRoom');
+	}
+
+	/**
+	 * @expectedException \OCP\AppFramework\OCS\OCSNotFoundException
+	 * @expectedExceptionMessage Exception thrown by the helper
+	 */
+	public function testCreateShareRoomHelperThrowException() {
+		$ocs = $this->mockFormatShare();
+
+		$share = $this->newShare();
+		$this->shareManager->method('newShare')->willReturn($share);
+
+		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
+		$this->rootFolder->expects($this->once())
+				->method('getUserFolder')
+				->with('currentUser')
+				->willReturn($userFolder);
+
+		$path = $this->getMockBuilder(File::class)->getMock();
+		$storage = $this->getMockBuilder(Storage::class)->getMock();
+		$storage->method('instanceOfStorage')
+			->with('OCA\Files_Sharing\External\Storage')
+			->willReturn(false);
+		$path->method('getStorage')->willReturn($storage);
+		$userFolder->expects($this->once())
+				->method('get')
+				->with('valid-path')
+				->willReturn($path);
+
+		$path->expects($this->once())
+			->method('lock')
+			->with(\OCP\Lock\ILockingProvider::LOCK_SHARED);
+
+		$this->appManager->method('isEnabledForUser')
+			->with('spreed')
+			->willReturn(true);
+
+		$helper = $this->getMockBuilder('\OCA\Spreed\Share\Helper\ShareAPIController')
+			->setMethods(array('createShare'))
+			->getMock();
+		$helper->method('createShare')
+			->with(
+				$share,
+				'recipientRoom',
+				\OCP\Constants::PERMISSION_ALL &
+				~\OCP\Constants::PERMISSION_DELETE &
+				~\OCP\Constants::PERMISSION_CREATE,
+				''
+			)->will($this->returnCallback(
+				function ($share) {
+					throw new OCSNotFoundException("Exception thrown by the helper");
+				}
+			));
+
+		$this->serverContainer->method('query')
+			->with('\OCA\Spreed\Share\Helper\ShareAPIController')
+			->willReturn($helper);
+
+		$this->shareManager->expects($this->never())->method('createShare');
+
+		$ocs->createShare('valid-path', \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_ROOM, 'recipientRoom');
+	}
+
 	/**
 	 * Test for https://github.com/owncloud/core/issues/22587
 	 * TODO: Remove once proper solution is in place
@@ -1149,7 +1398,8 @@ class ShareAPIControllerTest extends TestCase {
 				$this->currentUser,
 				$this->l,
 				$this->config,
-				$this->appManager
+				$this->appManager,
+				$this->serverContainer
 			])->setMethods(['formatShare'])
 			->getMock();
 
@@ -1681,7 +1931,8 @@ class ShareAPIControllerTest extends TestCase {
 			->method('getSharedWith')
 			->will($this->returnValueMap([
 				['currentUser', \OCP\Share::SHARE_TYPE_USER, $share->getNode(), -1, 0, []],
-				['currentUser', \OCP\Share::SHARE_TYPE_GROUP, $share->getNode(), -1, 0, [$incomingShare]]
+				['currentUser', \OCP\Share::SHARE_TYPE_GROUP, $share->getNode(), -1, 0, [$incomingShare]],
+				['currentUser', \OCP\Share::SHARE_TYPE_ROOM, $share->getNode(), -1, 0, []]
 			]));
 
 		$this->shareManager->expects($this->never())->method('updateShare');
@@ -1726,7 +1977,8 @@ class ShareAPIControllerTest extends TestCase {
 			->method('getSharedWith')
 			->will($this->returnValueMap([
 				['currentUser', \OCP\Share::SHARE_TYPE_USER, $share->getNode(), -1, 0, [$incomingShare]],
-				['currentUser', \OCP\Share::SHARE_TYPE_GROUP, $share->getNode(), -1, 0, []]
+				['currentUser', \OCP\Share::SHARE_TYPE_GROUP, $share->getNode(), -1, 0, []],
+				['currentUser', \OCP\Share::SHARE_TYPE_ROOM, $share->getNode(), -1, 0, []]
 			]));
 
 		$this->shareManager->expects($this->never())->method('updateShare');
@@ -1734,6 +1986,69 @@ class ShareAPIControllerTest extends TestCase {
 
 		try {
 			$ocs->updateShare(42, null, null, null, 'true');
+			$this->fail();
+		} catch (OCSNotFoundException $e) {
+			$this->assertEquals('Cannot increase permissions', $e->getMessage());
+		}
+	}
+
+	public function testUpdateShareCannotIncreasePermissionsRoomShare() {
+		$ocs = $this->mockFormatShare();
+
+		$folder = $this->createMock(Folder::class);
+
+		$share = \OC::$server->getShareManager()->newShare();
+		$share
+			->setId(42)
+			->setSharedBy($this->currentUser)
+			->setShareOwner('anotheruser')
+			->setShareType(\OCP\Share::SHARE_TYPE_ROOM)
+			->setSharedWith('group1')
+			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setNode($folder);
+
+		// note: updateShare will modify the received instance but getSharedWith will reread from the database,
+		// so their values will be different
+		$incomingShare = \OC::$server->getShareManager()->newShare();
+		$incomingShare
+			->setId(42)
+			->setSharedBy($this->currentUser)
+			->setShareOwner('anotheruser')
+			->setShareType(\OCP\Share::SHARE_TYPE_ROOM)
+			->setSharedWith('group1')
+			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setNode($folder);
+
+		$this->request
+			->method('getParam')
+			->will($this->returnValueMap([
+				['permissions', null, '31'],
+			]));
+
+		$this->shareManager
+			->method('getShareById')
+			->will($this->returnCallback(
+				function ($id) use ($share) {
+					if ($id !== 'ocRoomShare:42') {
+						throw new \OCP\Share\Exceptions\ShareNotFound();
+					}
+
+					return $share;
+				}
+			));
+
+		$this->shareManager->expects($this->any())
+			->method('getSharedWith')
+			->will($this->returnValueMap([
+				['currentUser', \OCP\Share::SHARE_TYPE_USER, $share->getNode(), -1, 0, []],
+				['currentUser', \OCP\Share::SHARE_TYPE_GROUP, $share->getNode(), -1, 0, []],
+				['currentUser', \OCP\Share::SHARE_TYPE_ROOM, $share->getNode(), -1, 0, [$incomingShare]]
+			]));
+
+		$this->shareManager->expects($this->never())->method('updateShare');
+
+		try {
+			$ocs->updateShare(42, 31);
 			$this->fail();
 		} catch (OCSNotFoundException $e) {
 			$this->assertEquals('Cannot increase permissions', $e->getMessage());
@@ -2409,5 +2724,161 @@ class ShareAPIControllerTest extends TestCase {
 		} catch (NotFoundException $e) {
 			$this->assertTrue($exception);
 		}
+	}
+
+	public function dataFormatRoomShare() {
+		$file = $this->getMockBuilder(File::class)->getMock();
+		$parent = $this->getMockBuilder(Folder::class)->getMock();
+
+		$file->method('getMimeType')->willReturn('myMimeType');
+
+		$file->method('getPath')->willReturn('file');
+
+		$parent->method('getId')->willReturn(1);
+		$file->method('getId')->willReturn(3);
+
+		$file->method('getParent')->willReturn($parent);
+
+		$cache = $this->getMockBuilder('OCP\Files\Cache\ICache')->getMock();
+		$cache->method('getNumericStorageId')->willReturn(100);
+		$storage = $this->getMockBuilder(Storage::class)->getMock();
+		$storage->method('getId')->willReturn('storageId');
+		$storage->method('getCache')->willReturn($cache);
+
+		$file->method('getStorage')->willReturn($storage);
+
+		$result = [];
+
+		$share = \OC::$server->getShareManager()->newShare();
+		$share->setShareType(\OCP\Share::SHARE_TYPE_ROOM)
+			->setSharedWith('recipientRoom')
+			->setSharedBy('initiator')
+			->setShareOwner('owner')
+			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setNode($file)
+			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
+			->setTarget('myTarget')
+			->setNote('personal note')
+			->setId(42);
+
+		$result[] = [
+			[
+				'id' => 42,
+				'share_type' => \OCP\Share::SHARE_TYPE_ROOM,
+				'uid_owner' => 'initiator',
+				'displayname_owner' => 'initiator',
+				'permissions' => 1,
+				'stime' => 946684862,
+				'parent' => null,
+				'expiration' => null,
+				'token' => null,
+				'uid_file_owner' => 'owner',
+				'displayname_file_owner' => 'owner',
+				'note' => 'personal note',
+				'path' => 'file',
+				'item_type' => 'file',
+				'storage_id' => 'storageId',
+				'storage' => 100,
+				'item_source' => 3,
+				'file_source' => 3,
+				'file_parent' => 1,
+				'file_target' => 'myTarget',
+				'share_with' => 'recipientRoom',
+				'share_with_displayname' => '',
+				'mail_send' => 0,
+				'mimetype' => 'myMimeType',
+			], $share, false, []
+		];
+
+		$share = \OC::$server->getShareManager()->newShare();
+		$share->setShareType(\OCP\Share::SHARE_TYPE_ROOM)
+			->setSharedWith('recipientRoom')
+			->setSharedBy('initiator')
+			->setShareOwner('owner')
+			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setNode($file)
+			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
+			->setTarget('myTarget')
+			->setNote('personal note')
+			->setId(42);
+
+		$result[] = [
+			[
+				'id' => 42,
+				'share_type' => \OCP\Share::SHARE_TYPE_ROOM,
+				'uid_owner' => 'initiator',
+				'displayname_owner' => 'initiator',
+				'permissions' => 1,
+				'stime' => 946684862,
+				'parent' => null,
+				'expiration' => null,
+				'token' => null,
+				'uid_file_owner' => 'owner',
+				'displayname_file_owner' => 'owner',
+				'note' => 'personal note',
+				'path' => 'file',
+				'item_type' => 'file',
+				'storage_id' => 'storageId',
+				'storage' => 100,
+				'item_source' => 3,
+				'file_source' => 3,
+				'file_parent' => 1,
+				'file_target' => 'myTarget',
+				'share_with' => 'recipientRoom',
+				'share_with_displayname' => 'recipientRoomName',
+				'mail_send' => 0,
+				'mimetype' => 'myMimeType',
+			], $share, true, [
+				'share_with_displayname' => 'recipientRoomName'
+			]
+		];
+
+		return $result;
+	}
+
+	/**
+	 * @dataProvider dataFormatRoomShare
+	 *
+	 * @param array $expects
+	 * @param \OCP\Share\IShare $share
+	 * @param bool $helperAvailable
+	 * @param array $formatShareByHelper
+	 */
+	public function testFormatRoomShare(array $expects, \OCP\Share\IShare $share, bool $helperAvailable, array $formatShareByHelper) {
+		$this->rootFolder->method('getUserFolder')
+			->with($this->currentUser)
+			->will($this->returnSelf());
+
+		$this->rootFolder->method('getById')
+			->with($share->getNodeId())
+			->willReturn([$share->getNode()]);
+
+		$this->rootFolder->method('getRelativePath')
+			->with($share->getNode()->getPath())
+			->will($this->returnArgument(0));
+
+		if (!$helperAvailable) {
+			$this->appManager->method('isEnabledForUser')
+				->with('spreed')
+				->willReturn(false);
+		} else {
+			$this->appManager->method('isEnabledForUser')
+				->with('spreed')
+				->willReturn(true);
+
+			$helper = $this->getMockBuilder('\OCA\Spreed\Share\Helper\ShareAPIController')
+				->setMethods(array('formatShare'))
+				->getMock();
+			$helper->method('formatShare')
+				->with($share)
+				->willReturn($formatShareByHelper);
+
+			$this->serverContainer->method('query')
+				->with('\OCA\Spreed\Share\Helper\ShareAPIController')
+				->willReturn($helper);
+		}
+
+		$result = $this->invokePrivate($this->ocs, 'formatShare', [$share]);
+		$this->assertEquals($expects, $result);
 	}
 }

--- a/apps/files_sharing/tests/MountProviderTest.php
+++ b/apps/files_sharing/tests/MountProviderTest.php
@@ -114,6 +114,12 @@ class MountProviderTest extends \Test\TestCase {
 			$this->makeMockShare(4, 101, 'user2', '/share4', 31), 
 			$this->makeMockShare(5, 100, 'user1', '/share4', 31), 
 		];
+		$roomShares = [
+			$this->makeMockShare(6, 102, 'user2', '/share6', 0),
+			$this->makeMockShare(7, 102, 'user1', '/share6', 31),
+			$this->makeMockShare(8, 102, 'user2', '/share6', 31),
+			$this->makeMockShare(9, 102, 'user2', '/share6', 31),
+		];
 		// tests regarding circles are made in the app itself.
 		$circleShares = [];
 		$this->user->expects($this->any())
@@ -131,15 +137,20 @@ class MountProviderTest extends \Test\TestCase {
 			->method('getSharedWith')
 			->with('user1', \OCP\Share::SHARE_TYPE_CIRCLE, null, -1)
 			->will($this->returnValue($circleShares));
+		$this->shareManager->expects($this->at(3))
+			->method('getSharedWith')
+			->with('user1', \OCP\Share::SHARE_TYPE_ROOM, null, -1)
+			->will($this->returnValue($roomShares));
 		$this->shareManager->expects($this->any())
 			->method('newShare')
 			->will($this->returnCallback(function() use ($rootFolder, $userManager) {
 				return new \OC\Share20\Share($rootFolder, $userManager);
 			}));
 		$mounts = $this->provider->getMountsForUser($this->user, $this->loader);
-		$this->assertCount(2, $mounts);
+		$this->assertCount(3, $mounts);
 		$this->assertInstanceOf('OCA\Files_Sharing\SharedMount', $mounts[0]);
 		$this->assertInstanceOf('OCA\Files_Sharing\SharedMount', $mounts[1]);
+		$this->assertInstanceOf('OCA\Files_Sharing\SharedMount', $mounts[2]);
 		$mountedShare1 = $mounts[0]->getShare();
 		$this->assertEquals('2', $mountedShare1->getId());
 		$this->assertEquals('user2', $mountedShare1->getShareOwner());
@@ -152,6 +163,12 @@ class MountProviderTest extends \Test\TestCase {
 		$this->assertEquals(101, $mountedShare2->getNodeId());
 		$this->assertEquals('/share4', $mountedShare2->getTarget());
 		$this->assertEquals(31, $mountedShare2->getPermissions());
+		$mountedShare3 = $mounts[2]->getShare();
+		$this->assertEquals('8', $mountedShare3->getId());
+		$this->assertEquals('user2', $mountedShare3->getShareOwner());
+		$this->assertEquals(102, $mountedShare3->getNodeId());
+		$this->assertEquals('/share6', $mountedShare3->getTarget());
+		$this->assertEquals(31, $mountedShare3->getPermissions());
 	}
 
 	public function mergeSharesDataProvider() {
@@ -316,6 +333,7 @@ class MountProviderTest extends \Test\TestCase {
 
 		// tests regarding circles are made in the app itself.
 		$circleShares = [];
+		$roomShares = [];
 		$this->shareManager->expects($this->at(0))
 			->method('getSharedWith')
 			->with('user1', \OCP\Share::SHARE_TYPE_USER)
@@ -328,6 +346,10 @@ class MountProviderTest extends \Test\TestCase {
 			->method('getSharedWith')
 			->with('user1', \OCP\Share::SHARE_TYPE_CIRCLE, null, -1)
 			->will($this->returnValue($circleShares));
+		$this->shareManager->expects($this->at(3))
+			->method('getSharedWith')
+			->with('user1', \OCP\Share::SHARE_TYPE_ROOM, null, -1)
+			->will($this->returnValue($roomShares));
 		$this->shareManager->expects($this->any())
 			->method('newShare')
 			->will($this->returnCallback(function() use ($rootFolder, $userManager) {

--- a/apps/files_sharing/tests/js/shareSpec.js
+++ b/apps/files_sharing/tests/js/shareSpec.js
@@ -108,6 +108,26 @@ describe('OCA.Sharing.Util tests', function() {
 			expect($action.find('.icon').hasClass('icon-public')).toEqual(false);
 			expect(OC.basename(getImageUrl($tr.find('.filename .thumbnail')))).toEqual('folder-shared.svg');
 		});
+		it('shows simple share text with share icon when shared to a room', function() {
+			var $action, $tr;
+			fileList.setFiles([{
+				id: 1,
+				type: 'dir',
+				name: 'One',
+				path: '/subdir',
+				mimetype: 'text/plain',
+				size: 12,
+				permissions: OC.PERMISSION_ALL,
+				etag: 'abc',
+				shareTypes: [OC.Share.SHARE_TYPE_ROOM]
+			}]);
+			$tr = fileList.$el.find('tbody tr:first');
+			$action = $tr.find('.action-share');
+			expect($action.find('>span').text().trim()).toEqual('Shared');
+			expect($action.find('.icon').hasClass('icon-shared')).toEqual(true);
+			expect($action.find('.icon').hasClass('icon-public')).toEqual(false);
+			expect(OC.basename(getImageUrl($tr.find('.filename .thumbnail')))).toEqual('folder-shared.svg');
+		});
 		it('shows simple share text with public icon when shared with link', function() {
 			var $action, $tr;
 			OC.Share.statuses = {1: {link: true, path: '/subdir'}};

--- a/build/integration/features/bootstrap/Provisioning.php
+++ b/build/integration/features/bootstrap/Provisioning.php
@@ -680,6 +680,30 @@ trait Provisioning {
 	}
 
 	/**
+	 * @Given /^app "([^"]*)" is not enabled$/
+	 *
+	 * Checks that the app is disabled or not installed.
+	 *
+	 * @param string $app
+	 */
+	public function appIsNotEnabled($app) {
+		$fullUrl = $this->baseUrl . "v2.php/cloud/apps?filter=enabled";
+		$client = new Client();
+		$options = [];
+		if ($this->currentUser === 'admin') {
+			$options['auth'] = $this->adminUser;
+		}
+		$options['headers'] = [
+			'OCS-APIREQUEST' => 'true',
+		];
+
+		$this->response = $client->get($fullUrl, $options);
+		$respondedArray = $this->getArrayOfAppsResponded($this->response);
+		Assert::assertNotContains($app, $respondedArray);
+		Assert::assertEquals(200, $this->response->getStatusCode());
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" is disabled$/
 	 * @param string $user
 	 */

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -43,6 +43,18 @@ Feature: sharing
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
 
+  Scenario: Creating a new room share when Talk is not enabled
+    Given As an "admin"
+    And app "spreed" is not enabled
+    And user "user0" exists
+    And As an "user0"
+    When creating a share with
+      | path | welcome.txt |
+      | shareWith | a-room-token |
+      | shareType | 10 |
+    Then the OCS status code should be "403"
+    And the HTTP status code should be "401"
+
   Scenario: Creating a new public share
     Given user "user0" exists
     And As an "user0"

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -12,6 +12,7 @@ OC.Share = _.extend(OC.Share || {}, {
 	SHARE_TYPE_CIRCLE:7,
 	SHARE_TYPE_GUEST:8,
 	SHARE_TYPE_REMOTE_GROUP:9,
+	SHARE_TYPE_ROOM:10,
 
 	/**
 	 * Regular expression for splitting parts of remote share owners:

--- a/core/js/sharedialogresharerinfoview.js
+++ b/core/js/sharedialogresharerinfoview.js
@@ -99,6 +99,17 @@
 					undefined,
 					{escape: false}
 				);
+			} else if (this.model.getReshareType() === OC.Share.SHARE_TYPE_ROOM) {
+				sharedByText = t(
+					'core',
+					'Shared with you and the conversation {conversation} by {owner}',
+					{
+						conversation: this.model.getReshareWithDisplayName(),
+						owner: ownerDisplayName
+					},
+					undefined,
+					{escape: false}
+				);
 			} else {
 				sharedByText = t(
 					'core',

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -243,6 +243,8 @@
 			} else if (shareType === OC.Share.SHARE_TYPE_EMAIL) {
 				shareWithDisplayName = shareWithDisplayName + " (" + t('core', 'email') + ')';
 			} else if (shareType === OC.Share.SHARE_TYPE_CIRCLE) {
+			} else if (shareType === OC.Share.SHARE_TYPE_ROOM) {
+				shareWithDisplayName = shareWithDisplayName + " (" + t('core', 'conversation') + ')';
 			}
 
 			if (shareType === OC.Share.SHARE_TYPE_GROUP) {
@@ -291,7 +293,7 @@
 				shareWithTitle: shareWithTitle,
 				shareType: shareType,
 				shareId: this.model.get('shares')[shareIndex].id,
-				modSeed: shareType !== OC.Share.SHARE_TYPE_USER && (shareType !== OC.Share.SHARE_TYPE_CIRCLE || shareWithAvatar),
+				modSeed: shareWithAvatar || (shareType !== OC.Share.SHARE_TYPE_USER && shareType !== OC.Share.SHARE_TYPE_CIRCLE && shareType !== OC.Share.SHARE_TYPE_ROOM),
 				isRemoteShare: shareType === OC.Share.SHARE_TYPE_REMOTE,
 				isRemoteGroupShare: shareType === OC.Share.SHARE_TYPE_REMOTE_GROUP,
 				isNoteAvailable: shareType !== OC.Share.SHARE_TYPE_REMOTE && shareType !== OC.Share.SHARE_TYPE_REMOTE_GROUP,

--- a/lib/private/Share/Constants.php
+++ b/lib/private/Share/Constants.php
@@ -38,6 +38,7 @@ class Constants {
 	const SHARE_TYPE_CIRCLE = 7;
 	const SHARE_TYPE_GUEST = 8;
 	const SHARE_TYPE_REMOTE_GROUP = 9;
+	const SHARE_TYPE_ROOM = 10;
 
 	const FORMAT_NONE = -1;
 	const FORMAT_STATUSES = -2;

--- a/lib/private/Share/Constants.php
+++ b/lib/private/Share/Constants.php
@@ -31,6 +31,7 @@ class Constants {
 
 	const SHARE_TYPE_USER = 0;
 	const SHARE_TYPE_GROUP = 1;
+	// const SHARE_TYPE_USERGROUP = 2; // Internal type used by DefaultShareProvider
 	const SHARE_TYPE_LINK = 3;
 	const SHARE_TYPE_EMAIL = 4;
 	const SHARE_TYPE_CONTACT = 5; // ToDo Check if it is still in use otherwise remove it
@@ -39,6 +40,7 @@ class Constants {
 	const SHARE_TYPE_GUEST = 8;
 	const SHARE_TYPE_REMOTE_GROUP = 9;
 	const SHARE_TYPE_ROOM = 10;
+	// const SHARE_TYPE_USERROOM = 11; // Internal type used by RoomShareProvider
 
 	const FORMAT_NONE = -1;
 	const FORMAT_STATUSES = -2;

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -239,6 +239,7 @@ class Manager implements IManager {
 			if ($circle === null) {
 				throw new \InvalidArgumentException('SharedWith is not a valid circle');
 			}
+		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_ROOM) {
 		} else {
 			// We can't handle other types yet
 			throw new \InvalidArgumentException('unknown share type');

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1248,6 +1248,15 @@ class Manager implements IManager {
 			}
 		}
 
+		if ($share === null && $this->shareProviderExists(\OCP\Share::SHARE_TYPE_ROOM)) {
+			try {
+				$provider = $this->factory->getProviderForType(\OCP\Share::SHARE_TYPE_ROOM);
+				$share = $provider->getShareByToken($token);
+			} catch (ProviderException $e) {
+			} catch (ShareNotFound $e) {
+			}
+		}
+
 		if ($share === null) {
 			throw new ShareNotFound($this->l->t('The requested share does not exist anymore'));
 		}

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -60,6 +60,8 @@ class ProviderFactory implements IProviderFactory {
 	private $shareByCircleProvider = null;
 	/** @var bool */
 	private $circlesAreNotAvailable = false;
+	/** @var \OCA\Spreed\Share\RoomShareProvider */
+	private $roomShareProvider = null;
 
 	/**
 	 * IProviderFactory constructor.
@@ -221,6 +223,30 @@ class ProviderFactory implements IProviderFactory {
 		return $this->shareByCircleProvider;
 	}
 
+	/**
+	 * Create the room share provider
+	 *
+	 * @return RoomShareProvider
+	 */
+	protected function getRoomShareProvider() {
+		if ($this->roomShareProvider === null) {
+			/*
+			 * Check if the app is enabled
+			 */
+			$appManager = $this->serverContainer->getAppManager();
+			if (!$appManager->isEnabledForUser('spreed')) {
+				return null;
+			}
+
+			try {
+				$this->roomShareProvider = $this->serverContainer->query('\OCA\Spreed\Share\RoomShareProvider');
+			} catch (\OCP\AppFramework\QueryException $e) {
+				return null;
+			}
+		}
+
+		return $this->roomShareProvider;
+	}
 
 	/**
 	 * @inheritdoc
@@ -235,6 +261,8 @@ class ProviderFactory implements IProviderFactory {
 			$provider = $this->getShareByMailProvider();
 		} else if ($id === 'ocCircleShare') {
 			$provider = $this->getShareByCircleProvider();
+		} else if ($id === 'ocRoomShare') {
+			$provider = $this->getRoomShareProvider();
 		}
 
 		if ($provider === null) {
@@ -261,6 +289,8 @@ class ProviderFactory implements IProviderFactory {
 			$provider = $this->getShareByMailProvider();
 		} else if ($shareType === \OCP\Share::SHARE_TYPE_CIRCLE) {
 			$provider = $this->getShareByCircleProvider();
+		} else if ($shareType === \OCP\Share::SHARE_TYPE_ROOM) {
+			$provider = $this->getRoomShareProvider();
 		}
 
 
@@ -280,6 +310,10 @@ class ProviderFactory implements IProviderFactory {
 		$shareByCircle = $this->getShareByCircleProvider();
 		if ($shareByCircle !== null) {
 			$shares[] = $shareByCircle;
+		}
+		$roomShare = $this->getRoomShareProvider();
+		if ($roomShare !== null) {
+			$shares[] = $roomShare;
 		}
 
 		return $shares;

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -2165,6 +2165,56 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertSame($share, $ret);
 	}
 
+	public function testGetShareByTokenRoom() {
+		$this->config
+			->expects($this->once())
+			->method('getAppValue')
+			->with('core', 'shareapi_allow_links', 'yes')
+			->willReturn('no');
+
+		$factory = $this->createMock(IProviderFactory::class);
+
+		$manager = new Manager(
+			$this->logger,
+			$this->config,
+			$this->secureRandom,
+			$this->hasher,
+			$this->mountManager,
+			$this->groupManager,
+			$this->l,
+			$this->l10nFactory,
+			$factory,
+			$this->userManager,
+			$this->rootFolder,
+			$this->eventDispatcher,
+			$this->mailer,
+			$this->urlGenerator,
+			$this->defaults
+		);
+
+		$share = $this->createMock(IShare::class);
+
+		$roomShareProvider = $this->createMock(IShareProvider::class);
+
+		$factory->expects($this->any())
+			->method('getProviderForType')
+			->will($this->returnCallback(function($shareType) use ($roomShareProvider) {
+				if ($shareType !== \OCP\Share::SHARE_TYPE_ROOM) {
+					throw new Exception\ProviderException();
+				}
+
+				return $roomShareProvider;
+			}));
+
+		$roomShareProvider->expects($this->once())
+			->method('getShareByToken')
+			->with('token')
+			->willReturn($share);
+
+		$ret = $manager->getShareByToken('token');
+		$this->assertSame($share, $ret);
+	}
+
 	public function testGetShareByTokenWithException() {
 		$this->config
 			->expects($this->once())


### PR DESCRIPTION
Server part of nextcloud/spreed#1050

This pull request, with its Talk counterpart, makes possible to share a file or folder into a Talk room.

Due to the current architecture of the sharing system it is not enough to provide an `IShareProvider` to add a new type of share; the controllers for the sharing API also need to be modified to support each type of share. Due to this, and to keep the server isolated from the Talk details (for example, whether a file can be shared with certain type of room or not, or how to generate the display name for a room share), the controllers just delegate those checks or actions to helper classes defined in Talk.

Besides that, each type of share needs to be referenced throughout the server code in order to be taken into account for certain operations, like providing the share type in DAV properties or transferring the ownership of files and shares to a different user.

While implementing this I have found some issues in the existing sharing code (like some types of sharing not being audited, a strange behaviour moving received shares into other received shares, or some shares being wrongly deleted when transferring ownership due to their name); those issues will be fixed in other pull requests.

Also note that this pull request implements room shares, but not search for room collaborators (so even if room shares are implemented you can not test them from the UI); this is implemented in #10256
