### PR TITLE
Use the path_hash instead of the path to query the filecache

### DIFF
--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -375,7 +375,7 @@ class UserMountCache implements IUserMountCache {
 			->innerJoin('m', 'filecache', 'f',
 				$builder->expr()->andX(
 					$builder->expr()->eq('m.storage_id', 'f.storage'),
-					$builder->expr()->eq('f.path', $builder->createNamedParameter('files'))
+					$builder->expr()->eq('f.path_hash', $builder->createNamedParameter(md5('files')))
 				))
 			->where($builder->expr()->eq('m.mount_point', $mountPoint))
 			->andWhere($builder->expr()->in('m.user_id', $builder->createNamedParameter($userIds, IQueryBuilder::PARAM_STR_ARRAY)));


### PR DESCRIPTION
Fixes #7974

This API is not used anymore in 14. Should be back ported to stable13 anyways. 