### PR TITLE
Allow apps to provide preview providers

### DIFF
--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -421,5 +421,17 @@ class PreviewManager implements IPreview {
 				$this->registerCoreProvider(Preview\Movie::class, '/video\/.*/');
 			}
 		}
+
+		// Register any preview providers provided by installed apps
+		foreach ($this->getEnabledDefaultProvider() as $provider) {
+			$p = explode('\\', $provider);
+			if (count($p) > 2 && $p[0] == 'OCA') {
+				$i = new $provider();
+				$this->registerProvider($i->getMimeType(), function () use ($provider) {
+					$result = new $provider();
+					return $result;
+				});
+			}
+		}
 	}
 }


### PR DESCRIPTION
They still need to be included in the enabledPreviewProviders array in
config.php. Add code to traverse that array and handle class names
that start with 'OCA\'. Register those as preview providers.

Signed-off-by: Tor Lillqvist <tml@collabora.com>