### PR TITLE
Fix comment input overlay on empty discussion

### DIFF
--- a/apps/comments/css/comments.scss
+++ b/apps/comments/css/comments.scss
@@ -67,6 +67,7 @@
 	padding: 10px 0px 15px;
 	word-wrap: break-word;
 	overflow-wrap: break-word;
+	overflow: hidden;
 }
 
 #commentsTabView .comments .comment {


### PR DESCRIPTION
Before:
![bildschirmfoto vom 2018-07-18 19-54-51](https://user-images.githubusercontent.com/3404133/42898982-f986cd46-8ac4-11e8-851d-796f2c77f3fd.png)


After:
![bildschirmfoto vom 2018-07-18 19-55-21](https://user-images.githubusercontent.com/3404133/42898929-dd45c754-8ac4-11e8-9582-14ba22333fcb.png)
