### PR TITLE
Fix inline avatar display for mentions in comments

### DIFF
--- a/apps/comments/css/comments.scss
+++ b/apps/comments/css/comments.scss
@@ -155,8 +155,27 @@
 	cursor: pointer;
 }
 
-#commentsTabView .comments li .message .atwho-inserted {
-	margin-left: 5px;
+#commentsTabView .comments li .message .atwho-inserted,
+#commentsTabView .newCommentForm .atwho-inserted {
+	.avatar-name-wrapper {
+		display: inline;
+		vertical-align: top;
+		background-color: var(--color-background-dark);
+		border-radius: 50vh;
+		padding: 1px 7px 1px 1px;
+		.avatar {
+			img {
+				vertical-align: top;
+			}
+			height: 16px;
+			width: 16px;
+			vertical-align: middle;
+			padding: 1px;
+			margin-top: -3px;
+			margin-left: 0;
+			margin-right: 2px;
+		}
+	}
 }
 
 .atwho-view-ul * .avatar-name-wrapper {

--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -383,7 +383,11 @@
 
 		_postRenderItem: function($el, editionMode) {
 			$el.find('.has-tooltip').tooltip();
-			$el.find('.avatar').each(function() {
+			$el.find('.avatar').each(function () {
+				var $this = $(this);
+				$this.avatar($this.attr('data-username'), 16);
+			});
+			$el.find('.authorRow .avatar').each(function () {
 				var $this = $(this);
 				$this.avatar($this.attr('data-username'), 32);
 			});


### PR DESCRIPTION
This adjusts the avatar display in files comments to show them nicely inline, similar to the way riot is displaying them inside chat conversations. See https://github.com/nextcloud/server/issues/9273

I think it is way nicer to have those properly inline and even if they are quite small at 16px they still help to recognize the mentioned person instead of going with just the name. And it is way nicer than before. :see_no_evil:

## Before
![image](https://user-images.githubusercontent.com/3404133/42900599-9d0636b0-8ac9-11e8-83f2-038458ed1ded.png)

## After
When writing:
![image](https://user-images.githubusercontent.com/3404133/42900446-3debfef8-8ac9-11e8-93ac-9a08ef5e1b4f.png)

Inside some text:
![image](https://user-images.githubusercontent.com/3404133/42900422-28d3c064-8ac9-11e8-9b63-13414f122115.png)

@nextcloud/designers 
