### PR TITLE
Make sure to always use an array as parameter

### DIFF
--- a/apps/workflowengine/lib/Controller/FlowOperations.php
+++ b/apps/workflowengine/lib/Controller/FlowOperations.php
@@ -111,7 +111,7 @@ class FlowOperations extends Controller {
 	 * @return array
 	 */
 	protected function prepareOperation(array $operation) {
-		$checkIds = json_decode($operation['checks']);
+		$checkIds = json_decode($operation['checks'], true);
 		$checks = $this->manager->getChecks($checkIds);
 
 		$operation['checks'] = [];


### PR DESCRIPTION
Fix https://github.com/nextcloud/files_accesscontrol/issues/104

Not sure why this is a problem all of a sudden, https://3v4l.org/WmUOn
works for `Output for 5.2.0 - 5.6.30, hhvm-3.10.1 - 3.22.0, 7.0.0 - 7.3.0alpha1`

User with teh problem runs 7.0

Anyway patch is simple and logical enough