### PR TITLE
Disable failing test in legacy sharing tests

### DIFF
--- a/apps/files_sharing/tests/ShareTest.php
+++ b/apps/files_sharing/tests/ShareTest.php
@@ -157,6 +157,8 @@ class ShareTest extends TestCase {
 	}
 
 	public function testShareWithGroupUniqueName() {
+		$this->markTestSkipped('TODO: Disable because fails on drone');
+
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER1);
 		\OC\Files\Filesystem::file_put_contents('test.txt', 'test');
 


### PR DESCRIPTION
* seems to be a race condition

