### PR TITLE
Don't fail contacts menu on unkown user

### DIFF
--- a/lib/private/Contacts/ContactsMenu/ContactsStore.php
+++ b/lib/private/Contacts/ContactsMenu/ContactsStore.php
@@ -155,7 +155,13 @@ class ContactsStore implements IContactsStore {
 			}
 
 			if ($ownGroupsOnly && $entry->getProperty('isLocalSystemBook') === true) {
-				$contactGroups = $this->groupManager->getUserGroupIds($this->userManager->get($entry->getProperty('UID')));
+				$uid = $this->userManager->get($entry->getProperty('UID'));
+
+				if ($uid === NULL) {
+					return false;
+				}
+
+				$contactGroups = $this->groupManager->getUserGroupIds($uid);
 				if (count(array_intersect($contactGroups, $selfGroups)) === 0) {
 					// no groups in common, so shouldn't see the contact
 					return false;


### PR DESCRIPTION
If for some reason the system addressbook holds a user that is no longer
accessible from the usermanager (so it got somehow out of sync) we
should not fail hard but rather just ignore the entry.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>