### PR TITLE
Only create the schema when moving between databases

### DIFF
--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -245,7 +245,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 				$currentMigration = $fromMS->getMigration('current');
 				if ($currentMigration !== '0') {
 					$toMS = new MigrationService($app, $toDB);
-					$toMS->migrate($currentMigration);
+					$toMS->migrate($currentMigration, true);
 				}
 			}
 		}


### PR DESCRIPTION
Fix https://github.com/nextcloud/spreed/issues/714

Steps
1. Install with SQLite
2. Enable Talk
3. Migrate to MySQL
4. :boom: 

The problem is that migrations are given the schema of the new Database, but teh database connection of the old one. It does also not make sense to execute the before/after steps in this case, because there is no data which you should be able to modify. We are just creating the structure at this point and afterwards all content is copied over.