### PR TITLE
Login: Implements the "user disabled" message like the "wrong password" message

### DIFF
--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -2,6 +2,8 @@
 <?php
 vendor_script('jsTimezoneDetect/jstz');
 script('core', 'merged-login');
+
+use OC\Core\Controller\LoginController;
 ?>
 
 <!--[if IE 8]><style>input[type="checkbox"]{padding:0;}</style><![endif]-->
@@ -34,7 +36,7 @@ script('core', 'merged-login');
 			<!-- the following div ensures that the spinner is always inside the #message div -->
 			<div style="clear: both;"></div>
 		</div>
-		<p class="grouptop<?php if (!empty($_['invalidpassword'])) { ?> shake<?php } ?>">
+		<p class="grouptop<?php if (!empty($_[LoginController::LOGIN_MSG_INVALIDPASSWORD])) { ?> shake<?php } ?>">
 			<input type="text" name="user" id="user"
 				placeholder="<?php p($l->t('Username or email')); ?>"
 				aria-label="<?php p($l->t('Username or email')); ?>"
@@ -44,7 +46,7 @@ script('core', 'merged-login');
 			<label for="user" class="infield"><?php p($l->t('Username or email')); ?></label>
 		</p>
 
-		<p class="groupbottom<?php if (!empty($_['invalidpassword'])) { ?> shake<?php } ?>">
+		<p class="groupbottom<?php if (!empty($_[LoginController::LOGIN_MSG_INVALIDPASSWORD])) { ?> shake<?php } ?>">
 			<input type="password" name="password" id="password" value=""
 				placeholder="<?php p($l->t('Password')); ?>"
 				aria-label="<?php p($l->t('Password')); ?>"
@@ -58,9 +60,13 @@ script('core', 'merged-login');
 			<div class="submit-icon icon-confirm-white"></div>
 		</div>
 
-		<?php if (!empty($_['invalidpassword'])) { ?>
+		<?php if (!empty($_[LoginController::LOGIN_MSG_INVALIDPASSWORD])) { ?>
 			<p class="warning wrongPasswordMsg">
 				<?php p($l->t('Wrong password.')); ?>
+			</p>
+		<?php } else if (!empty($_[LoginController::LOGIN_MSG_USERDISABLED])) { ?>
+			<p class="warning userDisabledMsg">
+				<?php p(\OC::$server->getL10N('lib')->t('User disabled')); ?>
 			</p>
 		<?php } ?>
 

--- a/tests/acceptance/features/bootstrap/LoginPageContext.php
+++ b/tests/acceptance/features/bootstrap/LoginPageContext.php
@@ -71,6 +71,14 @@ class LoginPageContext implements Context, ActorAwareInterface {
 	}
 
 	/**
+	 * @return Locator
+	 */
+	public static function userDisabledMessage() {
+		return Locator::forThe()->xpath("//*[@class = 'warning userDisabledMsg' and normalize-space() = 'User disabled']")->
+				describedAs('User disabled message on login page');
+	}
+
+	/**
 	 * @When I log in with user :user and password :password
 	 */
 	public function iLogInWithUserAndPassword($user, $password) {
@@ -94,6 +102,14 @@ class LoginPageContext implements Context, ActorAwareInterface {
 	public function iSeeThatAWrongPasswordMessageIsShown() {
 		PHPUnit_Framework_Assert::assertTrue(
 				$this->actor->find(self::wrongPasswordMessage(), 10)->isVisible());
+	}
+
+	/**
+	 * @Then I see that the disabled user message is shown
+	 */
+	public function iSeeThatTheDisabledUserMessageIsShown() {
+		PHPUnit_Framework_Assert::assertTrue(
+				$this->actor->find(self::userDisabledMessage(), 10)->isVisible());
 	}
 
 	/**

--- a/tests/acceptance/features/login.feature
+++ b/tests/acceptance/features/login.feature
@@ -28,6 +28,12 @@ Feature: login
     Then I see that the current page is the Login page
     And I see that a wrong password message is shown
 
+  Scenario: try to log in as disabled user
+    Given I visit the Home page
+    When I log in with user disabledUser and password 123456acb
+    Then I see that the current page is the Login page
+    And I see that the disabled user message is shown
+
   Scenario: log in with invalid user once fixed by admin
     Given I act as John
     And I can not log in with user unknownUser and password 123456acb

--- a/tests/acceptance/installAndConfigureServer.sh
+++ b/tests/acceptance/installAndConfigureServer.sh
@@ -35,6 +35,8 @@ fi
 php occ maintenance:install --admin-pass=admin
 
 OC_PASS=123456acb php occ user:add --password-from-env user0
+OC_PASS=123456acb php occ user:add --password-from-env disabledUser
+php occ user:disable disabledUser
 
 if [ "$NEXTCLOUD_SERVER_DOMAIN" != "" ]; then
 	# Default first trusted domain is "localhost"; replace it with given domain.


### PR DESCRIPTION
It now looks like the password message:
![image](https://user-images.githubusercontent.com/6216686/43091788-5af1de56-8eab-11e8-8a20-8fc18f8ed4aa.png)

closes #9978 