### PR TITLE
Fix transfering ownership of a share to user with same id as receiver

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -263,7 +263,8 @@ class TransferOwnership extends Command {
 
 		foreach($this->shares as $share) {
 			try {
-				if ($share->getSharedWith() === $this->destinationUser) {
+				if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER &&
+						$share->getSharedWith() === $this->destinationUser) {
 					// Unmount the shares before deleting, so we don't try to get the storage later on.
 					$shareMountPoint = $this->mountManager->find('/' . $this->destinationUser . '/files' . $share->getTarget());
 					if ($shareMountPoint) {

--- a/build/integration/features/transfer-ownership.feature
+++ b/build/integration/features/transfer-ownership.feature
@@ -72,6 +72,19 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	Scenario: transfering ownership of file shares to user with the same id as the group
+		Given user "user0" exists
+		And user "test" exists
+		And user "user2" exists
+		And group "test" exists
+		And user "user2" belongs to group "test"
+		And User "user0" uploads file "data/textfile.txt" to "/somefile.txt"
+		And file "/somefile.txt" of user "user0" is shared with group "test"
+		When transfering ownership from "user0" to "test"
+		And the command was successful
+		And As an "user2"
+		Then Downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
+
 	Scenario: transfering ownership does not transfer received shares
 		Given user "user0" exists
 		And user "user1" exists


### PR DESCRIPTION
When the ownership of a user share is transfered to the receiver the share is removed, as the receiver now owns the original file. However, due to a missing condition, [any share with a group, link or remote](https://github.com/nextcloud/server/blob/0eebff152a177dd59ed8773df26f1679f8a88e90/apps/files/lib/Command/TransferOwnership.php#L220) with the same id as the user was removed, not only the user shares.
