### PR TITLE
Make sure error_log() always receives a string

### DIFF
--- a/lib/private/Log/File.php
+++ b/lib/private/Log/File.php
@@ -145,6 +145,9 @@ class File implements IWriter, IFileBased {
 			error_log($entry);
 		}
 		if (php_sapi_name() === 'cli-server') {
+			if (!\is_string($message)) {
+				$message = json_encode($message);
+			}
 			error_log($message, 4);
 		}
 	}


### PR DESCRIPTION
Talk integration tests were failing with, because the log was not writable and an "array" was logged:
```
[Mon Jul 23 16:26:36 2018] error_log() expects parameter 1 to be string, array given at /home/nickv/Nextcloud/14/server/lib/private/Log/File.php#148
```