### PR TITLE
Do scan the root storage in background scan

### DIFF
--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -151,11 +151,6 @@ class Scanner extends PublicEmitter {
 				continue;
 			}
 
-			// don't scan the root storage
-			if ($storage->instanceOfStorage('\OC\Files\Storage\Local') && $mount->getMountPoint() === '/') {
-				continue;
-			}
-
 			// don't scan received local shares, these can be scanned when scanning the owner's storage
 			if ($storage->instanceOfStorage(SharedStorage::class)) {
 				continue;


### PR DESCRIPTION
Otherwise we can run into a situation where part of the root storage will never be scanned fully, which causes a "shallow scan" every time a it's accessed.