### PR TITLE
cache isCached state for scss resources

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -965,7 +965,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getThemingDefaults(),
 				\OC::$SERVERROOT,
 				$this->getMemCacheFactory(),
-				$c->query(IconsCacher::class)
+				$c->query(IconsCacher::class),
+				new TimeFactory()
 			);
 		});
 		$this->registerService(JSCombiner::class, function (Server $c) {

--- a/tests/lib/Template/CSSResourceLocatorTest.php
+++ b/tests/lib/Template/CSSResourceLocatorTest.php
@@ -25,6 +25,7 @@ namespace Test\Template;
 
 use OC\Files\AppData\AppData;
 use OC\Files\AppData\Factory;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\IAppData;
 use OCP\ICacheFactory;
 use OCP\ILogger;
@@ -50,6 +51,8 @@ class CSSResourceLocatorTest extends \Test\TestCase {
 	protected $logger;
 	/** @var IconsCacher|\PHPUnit_Framework_MockObject_MockObject */
 	protected $iconsCacher;
+	/** @var ITimeFactory|\PHPUnit_Framework_MockObject_MockObject */
+	private $timeFactory;
 
 	protected function setUp() {
 		parent::setUp();
@@ -61,6 +64,7 @@ class CSSResourceLocatorTest extends \Test\TestCase {
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
 		$this->themingDefaults = $this->createMock(ThemingDefaults::class);
 		$this->iconsCacher = $this->createMock(IconsCacher::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 	}
 
 	private function cssResourceLocator() {
@@ -75,7 +79,8 @@ class CSSResourceLocatorTest extends \Test\TestCase {
 			$this->themingDefaults,
 			\OC::$SERVERROOT,
 			$this->cacheFactory,
-			$this->iconsCacher
+			$this->iconsCacher,
+			$this->timeFactory
 		);
 		return new CSSResourceLocator(
 			$this->logger,

--- a/tests/lib/Template/SCSSCacherTest.php
+++ b/tests/lib/Template/SCSSCacherTest.php
@@ -28,6 +28,7 @@ use OC\Files\AppData\Factory;
 use OC\Template\SCSSCacher;
 use OC\Template\IconsCacher;
 use OCA\Theming\ThemingDefaults;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
@@ -58,12 +59,15 @@ class SCSSCacherTest extends \Test\TestCase {
 	protected $cacheFactory;
 	/** @var IconsCacher|\PHPUnit_Framework_MockObject_MockObject */
 	protected $iconsCacher;
+	/** @var ITimeFactory|\PHPUnit_Framework_MockObject_MockObject */
+	protected $timeFactory;
 
 	protected function setUp() {
 		parent::setUp();
 		$this->logger = $this->createMock(ILogger::class);
 		$this->appData = $this->createMock(AppData::class);
 		$this->iconsCacher = $this->createMock(IconsCacher::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 
 		/** @var Factory|\PHPUnit_Framework_MockObject_MockObject $factory */
 		$factory = $this->createMock(Factory::class);
@@ -97,7 +101,8 @@ class SCSSCacherTest extends \Test\TestCase {
 			$this->themingDefaults,
 			\OC::$SERVERROOT,
 			$this->cacheFactory,
-			$this->iconsCacher
+			$this->iconsCacher,
+			$this->timeFactory
 		);
 	}
 

--- a/tests/lib/Template/SCSSCacherTest.php
+++ b/tests/lib/Template/SCSSCacherTest.php
@@ -259,7 +259,10 @@ class SCSSCacherTest extends \Test\TestCase {
 		$folder = $this->createMock(ISimpleFolder::class);
 
 		$folder->expects($this->at(0))->method('getFile')->with($fileNameCSS)->willThrowException(new NotFoundException());
-		$actual = self::invokePrivate($this->scssCacher, 'isCached', [$fileNameCSS, $folder]);
+		$this->appData->expects($this->any())
+			->method('getFolder')
+			->willReturn($folder);
+		$actual = self::invokePrivate($this->scssCacher, 'isCached', [$fileNameCSS, 'core']);
 		$this->assertFalse($actual);
 	}
 
@@ -280,7 +283,10 @@ class SCSSCacherTest extends \Test\TestCase {
 				}
 			}));
 
-		$actual = self::invokePrivate($this->scssCacher, 'isCached', [$fileNameCSS, $folder]);
+		$this->appData->expects($this->any())
+			->method('getFolder')
+			->willReturn($folder);
+		$actual = self::invokePrivate($this->scssCacher, 'isCached', [$fileNameCSS, 'core']);
 		$this->assertFalse($actual);
 	}
 	public function testCacheNoFile() {


### PR DESCRIPTION
This saves a significant amount of filecache operations when loading a page.

This extra caching layer is disabled when debug mode is enabled to ensure it doesn't get in the way of development