### PR TITLE
Fix app navigation controller to return an array

### DIFF
--- a/core/Controller/NavigationController.php
+++ b/core/Controller/NavigationController.php
@@ -55,7 +55,7 @@ class NavigationController extends OCSController {
 		if ($absolute) {
 			$navigation = $this->rewriteToAbsoluteUrls($navigation);
 		}
-
+		$navigation = array_values($navigation);
 		$etag = $this->generateETag($navigation);
 		if ($this->request->getHeader('If-None-Match') === $etag) {
 			return new DataResponse([], Http::STATUS_NOT_MODIFIED);
@@ -77,6 +77,7 @@ class NavigationController extends OCSController {
 		if ($absolute) {
 			$navigation = $this->rewriteToAbsoluteUrls($navigation);
 		}
+		$navigation = array_values($navigation);
 		$etag = $this->generateETag($navigation);
 		if ($this->request->getHeader('If-None-Match') === $etag) {
 			return new DataResponse([], Http::STATUS_NOT_MODIFIED);

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -6,7 +6,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 			if(response.ocs.meta.status === 'ok') {
 				var addedApps = {};
 				var navEntries = response.ocs.data;
-				var container = $('#navigation #apps');
+				var container = $('#navigation #apps ul');
 
 				// remove disabled apps
 				for (var i = 0; i < navEntries.length; i++) {

--- a/tests/Core/Controller/NavigationControllerTest.php
+++ b/tests/Core/Controller/NavigationControllerTest.php
@@ -69,7 +69,7 @@ class NavigationControllerTest extends TestCase {
 		$this->navigationManager->expects($this->once())
 			->method('getAll')
 			->with('link')
-			->willReturn([ ['id' => 'files', 'href' => '/index.php/apps/files', 'icon' => 'icon' ] ]);
+			->willReturn(['files' => ['id' => 'files', 'href' => '/index.php/apps/files', 'icon' => 'icon' ] ]);
 		if ($absolute) {
 			$this->urlGenerator->expects($this->any())
 				->method('getBaseURL')
@@ -102,7 +102,7 @@ class NavigationControllerTest extends TestCase {
 		$this->navigationManager->expects($this->once())
 			->method('getAll')
 			->with('settings')
-			->willReturn([ ['id' => 'settings', 'href' => '/index.php/settings/user', 'icon' => '/core/img/settings.svg'] ]);
+			->willReturn(['settings' => ['id' => 'settings', 'href' => '/index.php/settings/user', 'icon' => '/core/img/settings.svg'] ]);
 		if ($absolute) {
 			$this->urlGenerator->expects($this->any())
 				->method('getBaseURL')


### PR DESCRIPTION
This is required to not break compatibility with existing consumers of that endpoint like the apps management or the client

The NavigationManager->getAll() method was moved to an associative array here: https://github.com/nextcloud/server/commit/6f45607f57c55550808824ffdeebbf10353a2554#diff-a42705a52a64c13d1977fb3c9e512442L103 That one can't be used since associative arrays are turned to objects when used in JS and the property order is not guaranteed there.

Fixes #10389