### PR TITLE
Fix avatar sizing for comments

### DIFF
--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -386,7 +386,11 @@
 
 		_postRenderItem: function($el, editionMode) {
 			$el.find('.has-tooltip').tooltip();
-			$el.find('.avatar').each(function () {
+			var inlineAvatars = $el.find('.message .avatar');
+			if ($($el.context).hasClass('message')) {
+				inlineAvatars = $el.find('.avatar');
+			}
+			inlineAvatars.each(function () {
 				var $this = $(this);
 				$this.avatar($this.attr('data-username'), 16);
 			});

--- a/core/js/jquery.avatar.js
+++ b/core/js/jquery.avatar.js
@@ -133,7 +133,11 @@
 			}
 		};
 
-		$div.addClass('icon-loading');
+		if (size < 32) {
+			$div.addClass('icon-loading-small');
+		} else {
+			$div.addClass('icon-loading');
+		}
 		img.width = size;
 		img.height = size;
 		img.src = url;

--- a/core/js/placeholder.js
+++ b/core/js/placeholder.js
@@ -169,5 +169,6 @@
 		this.css('font-size', '');
 		this.html('');
 		this.removeClass('icon-loading');
+		this.removeClass('icon-loading-small');
 	};
 }(jQuery));


### PR DESCRIPTION
- Limit small avatar rendering only to inline mentions
- Use small loading indicator for avatars smaller than 32px

The overlay in the loading preview is only caused by the browser when stopping the execution to make a screenshot. :wink: 
Before:
![image](https://user-images.githubusercontent.com/3404133/43200846-1c0242d6-9017-11e8-8f14-3eed4eb745a7.png)
![image](https://user-images.githubusercontent.com/3404133/43200857-292e5b0c-9017-11e8-9247-adaafd447027.png)

After:
![image](https://user-images.githubusercontent.com/3404133/43200771-d7a0f8e4-9016-11e8-9868-65fa93335751.png)
![image](https://user-images.githubusercontent.com/3404133/43200781-e5826902-9016-11e8-85fd-4eebb320cead.png)

Fixes #10381 