### PR TITLE
make file cache updates more robust

### DIFF
--- a/apps/encryption/lib/Crypto/Encryption.php
+++ b/apps/encryption/lib/Crypto/Encryption.php
@@ -254,7 +254,6 @@ class Encryption implements IEncryptionModule {
 	public function end($path, $position = 0) {
 		$result = '';
 		if ($this->isWriteOperation) {
-			$this->keyManager->setVersion($path, $this->version + 1, new View());
 			// in case of a part file we remember the new signature versions
 			// the version will be set later on update.
 			// This way we make sure that other apps listening to the pre-hooks

--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -102,6 +102,9 @@ class Encryption extends Wrapper {
 	/** @var array */
 	protected $expectedContextProperties;
 
+	/** @var bool */
+	protected $fileUpdated;
+
 	public function __construct() {
 		$this->expectedContextProperties = array(
 			'source',
@@ -235,6 +238,7 @@ class Encryption extends Wrapper {
 		$this->position = 0;
 		$this->cache = '';
 		$this->writeFlag = false;
+		$this->fileUpdated = false;
 		$this->unencryptedBlockSize = $this->encryptionModule->getUnencryptedBlockSize($this->signed);
 
 		if (
@@ -313,7 +317,6 @@ class Encryption extends Wrapper {
 	}
 
 	public function stream_write($data) {
-
 		$length = 0;
 		// loop over $data to fit it in 6126 sized unencrypted blocks
 		while (isset($data[0])) {
@@ -333,6 +336,7 @@ class Encryption extends Wrapper {
 
 				// switch the writeFlag so flush() will write the block
 				$this->writeFlag = true;
+				$this->fileUpdated = true;
 
 				// determine the relative position in the current block
 				$blockPosition = ($this->position % $this->unencryptedBlockSize);
@@ -414,7 +418,18 @@ class Encryption extends Wrapper {
 			}
 			$this->encryptionStorage->updateUnencryptedSize($this->fullPath, $this->unencryptedSize);
 		}
-		return parent::stream_close();
+		$result = parent::stream_close();
+
+		if ($this->fileUpdated) {
+			$cache = $this->storage->getCache();
+			$cacheEntry = $cache->get($this->internalPath);
+			if ($cacheEntry) {
+				$version = $cacheEntry['encryptedVersion'] + 1;
+				$cache->update($cacheEntry->getId(), ['encrypted' => $version, 'encryptedVersion' => $version]);
+			}
+		}
+
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
Only update the encrypted version after the write operation is finished and the stream is closed

With Amazon S3 as primary storage it happened that we tried to update the "encryption version" before the file was added to the file cache which lead to a wrong version number. By updating the version only after the stream was closed I could solve the issue.

@icewind1991 please have a look if this makes sense. Thanks!

fix https://github.com/nextcloud/server/issues/8299