### PR TITLE
Fix regex for icon urls

### DIFF
--- a/core/img/actions/star-dark.svg
+++ b/core/img/actions/star-dark.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16"><path d="m8 0.5 2.2 5.3 5.8 0.45-4.5 3.75 1.5 5.5-5-3.1-5 3.1 1.5-5.5-4.5-3.75 5.8-0.45z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 16 16" width="16" height="16"><path d="m8 0.5 2.2 5.3 5.8 0.45-4.5 3.75 1.5 5.5-5-3.1-5 3.1 1.5-5.5-4.5-3.75 5.8-0.45z" fill="#000"/></svg>

--- a/lib/private/Template/IconsCacher.php
+++ b/lib/private/Template/IconsCacher.php
@@ -47,7 +47,7 @@ class IconsCacher {
 	protected $urlGenerator;
 
 	/** @var string */
-	private $iconVarRE = '/--(icon-[a-zA-Z0-9-]+): url\(["\']([a-z0-9-_\~\/\.]+)[^;]+;/m';
+	private $iconVarRE = '/--(icon-[a-zA-Z0-9-]+): url\(["\']([a-zA-Z0-9-_\~\/\.\?\=]+)[^;]+;/m';
 
 	/** @var string */
 	private $fileName = 'icons-vars.css';
@@ -101,7 +101,7 @@ class IconsCacher {
 
 		$data = '';
 		foreach ($icons as $icon => $url) {
-			$data .= "--$icon: url('$url?v=1');";
+			$data .= "--$icon: url('$url');";
 		}
 
 		if (strlen($data) > 0) {

--- a/tests/lib/Template/IconsCacherTest.php
+++ b/tests/lib/Template/IconsCacherTest.php
@@ -86,7 +86,7 @@ class IconsCacherTest extends \Test\TestCase {
 		";
 		$actual = self::invokePrivate($this->iconsCacher, 'getIconsFromCss', [$css]);
 		$expected = array(
-			'icon-test' => '/svg/core/actions/add/000'
+			'icon-test' => '/svg/core/actions/add/000?v=1'
 		);
 		$this->assertEquals($expected, $actual);
 	}


### PR DESCRIPTION
Use the version from the url rather than hardcoding v=1. Also allow uppercase chars in the url, so that uppercase
hex color values will also be included.

This caused a missing icon for favorites in my dev setup:

![screenshot from 2018-07-26 21-33-43](https://user-images.githubusercontent.com/3404133/43285911-c1983124-9120-11e8-86e6-23121410e973.png)
