### PR TITLE
Make navigation responsive and fix IE rendering

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -75,7 +75,7 @@ kbd {
 #app-navigation {
 	width: $navigation-width;
 	min-width: $navigation-width-min;
-	max-width: 300px;
+	max-width: $navigation-width-max;
 	position: fixed; /* IE11 fallback for sticky */
 	position: sticky;
 	top: $header-height;

--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -85,7 +85,7 @@ kbd {
 	overflow-x: hidden;
 	// Do not use vh because of mobile headers
 	// are included in the calculation
-	height: calc(100% - #{$header-height});
+	height: calc(100vh - #{$header-height});
 	box-sizing: border-box;
 	background-color: var(--color-main-background);
 	-webkit-user-select: none;
@@ -835,6 +835,10 @@ $popovericon-size: 16px;
 	/* add margin, since IE11 uses fixed positioning instead of sticky */
 	#app-navigation + #app-content {
 		margin-left: $navigation-width-min;
+	}
+	#app-sidebar {
+		position: fixed;
+		width: $sidebar-max-width;
 	}
 }
 

--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -74,7 +74,10 @@ kbd {
 /* Navigation: folder like structure */
 #app-navigation {
 	width: $navigation-width;
-	position: fixed;
+	min-width: $navigation-width-min;
+	max-width: 300px;
+	position: fixed; /* IE11 fallback for sticky */
+	position: sticky;
 	top: $header-height;
 	left: 0;
 	z-index: 500;
@@ -116,7 +119,6 @@ kbd {
 	> ul {
 		position: relative;
 		height: 100%;
-		width: inherit;
 		overflow-x: hidden;
 		overflow-y: auto;
 		box-sizing: border-box;
@@ -606,10 +608,7 @@ kbd {
 	position: relative;
 	min-height: 100%;
 	flex-basis: 100vw;
-	/* margin if navigation element is here */
-	#app-navigation  + & {
-		margin-left: $navigation-width;
-	}
+
 	/* no top border for first settings item */
 	> .section:first-child {
 		border-top: none;
@@ -829,6 +828,13 @@ $popovericon-size: 16px;
 	#app-navigation .app-navigation-entry-menu,
 	#app-navigation .app-navigation-entry-menu:after {
 		border: 1px solid var(--color-border);
+	}
+	#app-navigation {
+		width: $navigation-width-min;
+	}
+	/* add margin, since IE11 uses fixed positioning instead of sticky */
+	#app-navigation + #app-content {
+		margin-left: $navigation-width-min;
 	}
 }
 

--- a/core/css/mobile.scss
+++ b/core/css/mobile.scss
@@ -33,6 +33,19 @@
 		margin-left: 0;
 	}
 
+	/* add margin, since IE11 uses fixed positioning instead of sticky */
+	.ie {
+		#app-navigation + #app-content {
+			margin-left: 0;
+		}
+		.snapjs-left #app-navigation + #app-content {
+			margin-right: $sidebar-min-width;
+		}
+		#app-sidebar {
+			position: fixed;
+			width: $sidebar-min-width;
+		}
+	}
 
 	/* full width for message list on mobile */
 	.app-content-list {

--- a/core/css/mobile.scss
+++ b/core/css/mobile.scss
@@ -20,7 +20,8 @@
 
 	/* APP SIDEBAR TOGGLE and SWIPE ----------------------------------------------*/
 	#app-navigation {
-		transform: translateX(-#{$navigation-width});
+		transform: translateX(-#{$navigation-width-min});
+		position: fixed;
 	}
 	.snapjs-left {
 		#app-navigation {

--- a/core/css/variables.scss
+++ b/core/css/variables.scss
@@ -79,6 +79,7 @@ $font-face: 'Open Sans', Frutiger, Calibri, 'Myriad Pro', Myriad, sans-serif !de
 
 // various structure data
 $header-height: 50px;
-$navigation-width: 300px;
+$navigation-width: 23vw;
+$navigation-width-min: 250px;
 $sidebar-min-width: 300px;
 $sidebar-max-width: 500px;

--- a/core/css/variables.scss
+++ b/core/css/variables.scss
@@ -79,7 +79,8 @@ $font-face: 'Open Sans', Frutiger, Calibri, 'Myriad Pro', Myriad, sans-serif !de
 
 // various structure data
 $header-height: 50px;
-$navigation-width: 23vw;
-$navigation-width-min: 250px;
+$navigation-width: 17vw;
+$navigation-width-min: 220px;
+$navigation-width-max: 300px;
 $sidebar-min-width: 300px;
 $sidebar-max-width: 500px;

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1626,7 +1626,7 @@ function initCore() {
 		var snapper = new Snap({
 			element: document.getElementById('app-content'),
 			disable: 'right',
-			maxPosition: 300, // $navigation-width
+			maxPosition: 250, // $navigation-width-min
 			minDragDistance: 100
 		});
 


### PR DESCRIPTION
Make app navigation responsive instead of a hardcoded 300px width

Before:
![peek 2018-07-27 12-41](https://user-images.githubusercontent.com/3404133/43317069-bacb8c26-919b-11e8-9d83-d3bfcafe5450.gif)

After:
![peek 2018-07-27 12-42](https://user-images.githubusercontent.com/3404133/43317070-baf3e716-919b-11e8-90a3-c71b4f2c0c86.gif)

