### PR TITLE
Check if TTY is invalid in encryption:encrypt-all and encryption:decrypt-all

### DIFF
--- a/core/Command/Encryption/DecryptAll.php
+++ b/core/Command/Encryption/DecryptAll.php
@@ -123,6 +123,14 @@ class DecryptAll extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
+		if ( !$input->isInteractive() ) {
+			$output->writeln('Invalid TTY.');
+			$output->writeln('If you are trying to execute the command in a Docker ');
+			$output->writeln("container, do not forget to execute 'docker exec' with");
+			$output->writeln("the '-i' and '-t' options.");
+			$output->writeln('');
+			return;
+		}
 
 		try {
 			if ($this->encryptionManager->isEnabled() === true) {

--- a/core/Command/Encryption/EncryptAll.php
+++ b/core/Command/Encryption/EncryptAll.php
@@ -105,6 +105,14 @@ class EncryptAll extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
+		if ( !$input->isInteractive() ) {
+			$output->writeln('Invalid TTY.');
+			$output->writeln('If you are trying to execute the command in a Docker ');
+			$output->writeln("container, do not forget to execute 'docker exec' with");
+			$output->writeln("the '-i' and '-t' options.");
+			$output->writeln('');
+			return;
+		}
 
 		if ($this->encryptionManager->isEnabled() === false) {
 			throw new \Exception('Server side encryption is not enabled');

--- a/tests/Core/Command/Encryption/DecryptAllTest.php
+++ b/tests/Core/Command/Encryption/DecryptAllTest.php
@@ -73,6 +73,9 @@ class DecryptAllTest extends TestCase {
 		$this->decryptAll = $this->getMockBuilder(\OC\Encryption\DecryptAll::class)
 			->disableOriginalConstructor()->getMock();
 		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleInput->expects($this->any())
+			->method('isInteractive')
+			->willReturn(true);
 		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 		$this->config->expects($this->any())

--- a/tests/Core/Command/Encryption/EncryptAllTest.php
+++ b/tests/Core/Command/Encryption/EncryptAllTest.php
@@ -78,6 +78,9 @@ class EncryptAllTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->consoleInput->expects($this->any())
+			->method('isInteractive')
+			->willReturn(true);
 		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
 	}


### PR DESCRIPTION
Inspired by https://github.com/nextcloud/server/issues/9894.
The commands `occ encryption:decrypt-all` and `occ encryption:encrypt-all` transform into interactive processes since they both use `ConfirmationQuestion`. It's not possible to execute the commands in a container via `docker exec` without the `-i` and `-t` options. However, it becomes not obvious from a user point of view _why_ since the result of both commands in this case is `aborted`. This PR tries to solve the problem.
Fixes #9894.

Signed-off-by: Evgeny Golyshev <eugulixes@gmail.com>