### PR TITLE
Only lower opacity of the avatar if the checkbox is checked on the content-list

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -1110,20 +1110,25 @@ $popovericon-size: 16px;
 			width: 40px;
 			display: flex;
 			z-index: 50;
-			+ .app-content-list-item-icon {
-				opacity: .7;
-			}
 		}
 
-		.app-content-list-item-checkbox.checkbox + label {
-			top: 14px;
-			left: 7px;
-			&::before {
-				margin: 0;
+		.app-content-list-item-checkbox.checkbox {
+			&:checked {
+				// if checked, lower the opacity of the avatar
+				+ label + .app-content-list-item-icon {
+					opacity: .7;
+				}
 			}
-			/* Hide the star, priority to the checkbox */
-			~ .app-content-list-item-star {
-				display: none;
+			+ label {
+				top: 14px;
+				left: 7px;
+				&::before {
+					margin: 0;
+				}
+				/* Hide the star, priority to the checkbox */
+				~ .app-content-list-item-star {
+					display: none;
+				}
 			}
 		}
 


### PR DESCRIPTION
Before it was always with an opacity of .7 when the checkbox was there.

@nextcloud/designers 

![kazam_screencast_00004](https://user-images.githubusercontent.com/14975046/43479686-3a118662-9501-11e8-8823-1e4eb30b8869.gif)
