### PR TITLE
Fix caret icon on installation page

### DIFF
--- a/core/img/actions/caret-white.svg
+++ b/core/img/actions/caret-white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" version="1.1" viewbox="0 0 16 16"><path d="M4 6l4 4 4-3.994z" fill="#fff"/></svg>

--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -57,7 +57,7 @@ script('core', [
 
 	<?php if(!$_['directoryIsSet'] OR !$_['dbIsSet'] OR count($_['errors']) > 0): ?>
 	<fieldset id="advancedHeader">
-		<legend><a id="showAdvanced"><?php p($l->t( 'Storage & database' )); ?> <img src="<?php print_unescaped(image_path('', 'actions/caret.svg')); ?>" /></a></legend>
+		<legend><a id="showAdvanced"><?php p($l->t( 'Storage & database' )); ?> <img src="<?php print_unescaped(image_path('', 'actions/caret-white.svg')); ?>" /></a></legend>
 	</fieldset>
 	<?php endif; ?>
 


### PR DESCRIPTION
Since the icon was moved, there was a black caret icon on the install page. This PR adds the white one again, since the svg endpoint isn't available during install.