### PR TITLE
Fix duplicate inserts in the 2fa provider registry DAO

### DIFF
--- a/tests/lib/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDaoTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDaoTest.php
@@ -93,4 +93,23 @@ class ProviderUserAssignmentDaoTest extends TestCase {
 		$this->assertCount(1, $data);
 	}
 
+	public function testPersistTwice() {
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$this->dao->persist('twofactor_totp', 'user123', 0);
+		$this->dao->persist('twofactor_totp', 'user123', 1);
+
+		$q = $qb
+			->select('*')
+			->from(ProviderUserAssignmentDao::TABLE_NAME)
+			->where($qb->expr()->eq('provider_id', $qb->createNamedParameter('twofactor_totp')))
+			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter('user123')))
+			->andWhere($qb->expr()->eq('enabled', $qb->createNamedParameter(1)));
+		$res = $q->execute();
+		$data = $res->fetchAll();
+		$res->closeCursor();
+
+		$this->assertCount(1, $data);
+	}
+
 }


### PR DESCRIPTION
This fixes the condition of setting the enabled/disabled state of a specific user-provider tuple more than once. I forgot to handle this in #9632.

cc DB pros @nickvergessen @rullzer. Is this the correct way to do an `UPSERT` with our query builder? Does the isolation level of our supported DBs guarantee that this is conflict free now?

Discovered while making the TOTP app ready for Nextcloud 14 https://github.com/nextcloud/twofactor_totp/pull/263.