### PR TITLE
Revert to regular buttons in system tags management

### DIFF
--- a/apps/systemtags/css/settings.css
+++ b/apps/systemtags/css/settings.css
@@ -1,17 +1,15 @@
 .systemtag-input {
 	display: flex;
-	max-width: 500px;
+	flex-wrap: wrap;
 }
 #systemtags .select2-container {
 	width: 100%;
-	max-width: 500px;
+	max-width: 400px;
+}
+#systemtags .select2-container .select2-choice {
+	height: auto;
 }
 #systemtag_name {
-	flex-grow: 1;
-}
-
-#systemtag_delete,
-#systemtag_reset,
-#systemtag_submit {
-	padding: 8px;
+	width: 100%;
+	max-width: 400px;
 }

--- a/apps/systemtags/templates/admin.php
+++ b/apps/systemtags/templates/admin.php
@@ -49,9 +49,9 @@ style('systemtags', 'settings');
 			<option value="0"><?php p($l->t('Invisible')); ?></option>
 		</select>
 
-		<a id="systemtag_delete" class="hidden icon-delete"><span class="hidden-visually"><?php p($l->t('Delete')); ?></span></a>
-		<a id="systemtag_reset" class="icon-close"><span class="hidden-visually"><?php p($l->t('Reset')); ?></span></a>
-		<a id="systemtag_submit" class="icon-confirm"><span class="hidden-visually"><?php p($l->t('Create')); ?></span></a>
+		<a id="systemtag_delete" class="hidden button"><span><?php p($l->t('Delete')); ?></span></a>
+		<a id="systemtag_reset" class="button"><span><?php p($l->t('Reset')); ?></span></a>
+		<a id="systemtag_submit" class="button"><span><?php p($l->t('Create')); ?></span></a>
 	</div>
 
 </form>


### PR DESCRIPTION
Fix #10420

This reverts the button changes from #10028 but keeps the alignment improvements from there.

![screenshot from 2018-07-31 15-36-36](https://user-images.githubusercontent.com/3404133/43463318-976ad5ee-94d8-11e8-8bc3-5bd12e01ddc1.png)
