### PR TITLE
Add notification container to public layout template

### DIFF
--- a/core/templates/layout.public.php
+++ b/core/templates/layout.public.php
@@ -27,6 +27,9 @@
 </head>
 <body id="<?php p($_['bodyid']);?>">
 <?php include('layout.noscript.warning.php'); ?>
+	<div id="notification-container">
+		<div id="notification"></div>
+	</div>
 	<header id="header" class="<?php p($_['header-classes']); ?>">
 		<div class="header-left">
 			<span id="nextcloud">


### PR DESCRIPTION
This is needed to show notifications using the standard `OC.Notification.show` function.

Besides removing the need for apps to add the container themselves this also fixes [a regression introduced with PublicTemplateResponse](https://github.com/nextcloud/server/pull/8051/commits/8a13851da8906a4eed3c7b59d01f5a172c90371c#diff-28509333ad5b898bf1af427bd3e64113L10), as a notification is shown in public drop folders [when the name of the file dropped is not valid](https://github.com/nextcloud/server/blob/4d003c812de88c922ff9835d910e5a01b7bb0d28/apps/files_sharing/js/files_drop.js#L44).