### PR TITLE
Use icon classes in personal settings

### DIFF
--- a/settings/js/federationscopemenu.js
+++ b/settings/js/federationscopemenu.js
@@ -16,13 +16,10 @@
 		'{{#each items}}' +
 		'<li>' +
 		'<a href="#" class="menuitem action action-{{name}} permanent {{#if active}}active{{/if}}" data-action="{{name}}">' +
-			'{{#if icon}}<img class="icon" src="{{icon}}"/>' +
-			'{{else}}'+
-				'{{#if iconClass}}' +
-				'<span class="icon {{iconClass}}"></span>' +
-				'{{else}}' +
-				'<span class="no-icon"></span>' +
-				'{{/if}}' +
+			'{{#if iconClass}}' +
+			'<span class="icon {{iconClass}}"></span>' +
+			'{{else}}' +
+			'<span class="no-icon"></span>' +
 			'{{/if}}' +
 			'<p><strong class="menuitem-text">{{displayName}}</strong><br>' +
 			'<span class="menuitem-text-detail">{{tooltip}}</span></p></a>' +
@@ -48,21 +45,21 @@
 					name: 'private',
 					displayName: (this.field === 'avatar' || this.field === 'displayname') ? t('settings', 'Local') : t('settings', 'Private'),
 					tooltip: (this.field === 'avatar' || this.field === 'displayname') ? t('settings', 'Only visible to local users') : t('settings', 'Only visible to you'),
-					icon: OC.imagePath('core', 'actions/password'),
+					iconClass: 'icon-password',
 					active: false
 				},
 				{
 					name: 'contacts',
 					displayName: t('settings', 'Contacts'),
 					tooltip: t('settings', 'Visible to local users and to trusted servers'),
-					icon: OC.imagePath('core', 'places/contacts'),
+					iconClass: 'icon-contacts-dark',
 					active: false
 				},
 				{
 					name: 'public',
 					displayName: t('settings', 'Public'),
 					tooltip: t('settings', 'Will be synced to a global and public address book'),
-					icon: OC.imagePath('core', 'places/link'),
+					iconClass: 'icon-link',
 					active: false
 				}
 			];


### PR DESCRIPTION
Use icon classes for federation visibility popover in personal settings. 

Before:
![screenshot from 2018-08-01 10-07-38](https://user-images.githubusercontent.com/3404133/43509357-c1977008-9572-11e8-9e0a-7c7eec98b82e.png)

After:
![screenshot from 2018-08-01 10-07-00](https://user-images.githubusercontent.com/3404133/43509333-b27785d6-9572-11e8-88b4-804667b13f6a.png)

