### PR TITLE
Settings design polishing

### DIFF
--- a/apps/dav/templates/settings-admin-caldav.php
+++ b/apps/dav/templates/settings-admin-caldav.php
@@ -29,7 +29,7 @@ script('dav', [
 /** @var array $_ */
 ?>
 <form id="CalDAV" class="section">
-	<h2><?php p($l->t('CalDAV server')); ?></h2>
+	<h2><?php p($l->t('Calendar server')); ?></h2>
 	<p>
 		<input type="checkbox" name="caldav_send_invitations" id="caldavSendInvitations" class="checkbox"
 			<?php ($_['send_invitations'] === 'yes') ? print_unescaped('checked="checked"') : null ?>/>

--- a/apps/encryption/lib/Settings/Admin.php
+++ b/apps/encryption/lib/Settings/Admin.php
@@ -110,7 +110,7 @@ class Admin implements ISettings {
 	 * @return string the section ID, e.g. 'sharing'
 	 */
 	public function getSection() {
-		return 'encryption';
+		return 'security';
 	}
 
 	/**
@@ -121,7 +121,7 @@ class Admin implements ISettings {
 	 * E.g.: 70
 	 */
 	public function getPriority() {
-		return 5;
+		return 11;
 	}
 
 }

--- a/apps/encryption/tests/Settings/AdminTest.php
+++ b/apps/encryption/tests/Settings/AdminTest.php
@@ -92,10 +92,10 @@ class AdminTest extends TestCase {
 	}
 
 	public function testGetSection() {
-		$this->assertSame('encryption', $this->admin->getSection());
+		$this->assertSame('security', $this->admin->getSection());
 	}
 
 	public function testGetPriority() {
-		$this->assertSame(5, $this->admin->getPriority());
+		$this->assertSame(11, $this->admin->getPriority());
 	}
 }

--- a/apps/files_external/css/settings.scss
+++ b/apps/files_external/css/settings.scss
@@ -6,6 +6,12 @@
 	margin: 15px 0 20px 0;
 }
 
+#externalStorage td {
+	& > input, & > select {
+		width: 100%;
+	}
+}
+
 #externalStorage td.status {
 	/* overwrite conflicting core styles */
 	display: table-cell;
@@ -20,8 +26,12 @@
 	border-radius: 50%;
 	cursor: pointer;
 }
-
-td.mountPoint, td.backend { width:160px; }
+#externalStorage {
+	td.mountPoint, td.backend, td.authentication, td.configuration {
+		min-width: 160px;
+		width: 15%;
+	}
+}
 #externalStorage td>img { padding-top:7px; opacity: 0.5; }
 #externalStorage td>img:hover { padding-top:7px; cursor:pointer; opacity: 1; }
 #addMountPoint>td { border:none; }
@@ -84,6 +94,10 @@ td.mountPoint, td.backend { width:160px; }
 #externalStorage td.applicable div.chzn-container {
 	position: relative;
 	top: 3px;
+}
+
+#externalStorage .select2-container.applicableUsers {
+	width: 100% !important;
 }
 
 #userMountingBackends {

--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -54,6 +54,11 @@ var MOUNT_OPTIONS_DROPDOWN_TEMPLATE =
 	'				<label for="mountOptionsReadOnly">{{t "files_external" "Read only"}}</label>' +
 	'			</span>' +
 	'		</li>' +
+	'		<li class="optionRow persistent">' +
+	'			<a href="#" class="menuitem remove icon-delete">' +
+	'				<span>{{t "files_external" "Delete"}}</span>' +
+	'			</a>' +
+	'		</li>' +
 	'	</ul>'+
 	'</div>';
 
@@ -584,7 +589,7 @@ MountOptionsDropdown.prototype = {
 		$el.find('.optionRow').each(function(i, row){
 			var $row = $(row);
 			var optionId = $row.find('input, select').attr('name');
-			if (visibleOptions.indexOf(optionId) === -1) {
+			if (visibleOptions.indexOf(optionId) === -1 && !$row.hasClass('persistent')) {
 				$row.hide();
 			} else {
 				$row.show();
@@ -734,7 +739,7 @@ MountConfigListView.prototype = _.extend({
 			self.recheckStorageConfig($(this).closest('tr'));
 		});
 
-		this.$el.on('click', 'td.remove>.icon-delete', function() {
+		this.$el.on('click', 'td.mountOptionsToggle .icon-delete', function() {
 			self.deleteStorageConfig($(this).closest('tr'));
 		});
 
@@ -742,7 +747,7 @@ MountConfigListView.prototype = _.extend({
 			self.saveStorageConfig($(this).closest('tr'));
 		});
 
-		this.$el.on('click', 'td.mountOptionsToggle>.icon-settings-dark', function() {
+		this.$el.on('click', 'td.mountOptionsToggle>.icon-more', function() {
 			self._showMountOptionsDropdown($(this).closest('tr'));
 		});
 
@@ -1311,7 +1316,8 @@ MountConfigListView.prototype = _.extend({
 			'filesystem_check_changes',
 			'enable_sharing',
 			'encoding_compatibility',
-			'readonly'
+			'readonly',
+			'delete'
 		];
 		if (this._encryptionEnabled) {
 			visibleOptions.push('encrypt');

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -150,11 +150,8 @@
 					</td>
 				<?php endif; ?>
 				<td class="mountOptionsToggle hidden">
-					<div class="icon-settings-dark" title="<?php p($l->t('Advanced settings')); ?>"></div>
+					<div class="icon-more" title="<?php p($l->t('Advanced settings')); ?>"></div>
 					<input type="hidden" class="mountOptions" value="" />
-				</td>
-				<td class="remove hidden">
-					<div class="icon-delete" title="<?php p($l->t('Delete')); ?>"></div>
 				</td>
 				<td class="save hidden">
 					<div class="icon-checkmark" title="<?php p($l->t('Save')); ?>"></div>

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -95,6 +95,7 @@
 
 <form data-can-create="<?php echo $canCreateMounts?'true':'false' ?>" id="files_external" class="section" data-encryption-enabled="<?php echo $_['encryptionEnabled']?'true': 'false'; ?>">
 	<h2 data-anchor-name="external-storage"><?php p($l->t('External storages')); ?></h2>
+	<p class="settings-hint"><?php p($l->t('External storage enables you to mount external storage services and devices as secondary Nextcloud storage devices. You may also allow users to mount their own external storage services.')); ?></p>
 	<?php if (isset($_['dependencies']) and ($_['dependencies'] !== '') and $canCreateMounts) print_unescaped(''.$_['dependencies'].''); ?>
 	<table id="externalStorage" class="grid" data-admin='<?php print_unescaped(json_encode($_['visibilityType'] === BackendService::VISIBILITY_ADMIN)); ?>'>
 		<thead>
@@ -189,6 +190,7 @@
 	<form autocomplete="false" action="#"
 		  id="global_credentials">
 		<h2><?php p($l->t('Global credentials')); ?></h2>
+		<p class="settings-hint"><?php p($l->t('Global credentials can be used to authenticate with multiple external storages that have the same credentials.')); ?></p>
 		<input type="text" name="username"
 			   autocomplete="false"
 			   value="<?php p($_['globalCredentials']['user']); ?>"

--- a/apps/files_external/tests/js/settingsSpec.js
+++ b/apps/files_external/tests/js/settingsSpec.js
@@ -46,11 +46,8 @@ describe('OCA.External.Settings tests', function() {
 			'<input type="hidden" class="applicableUsers">' +
 			'</td>' +
 			'<td class="mountOptionsToggle">'+
-			'<div class="icon-settings-dark" title="Advanced settings" deluminate_imagetype="unknown"></div>'+
+			'<div class="icon-more" title="Advanced settings" deluminate_imagetype="unknown"></div>'+
 			'<input type="hidden" class="mountOptions"/>'+
-			'</td>'+
-			'<td class="remove">'+
-			'<div class="icon-delete" title="Delete" deluminate_imagetype="unknown"></div>'+
 			'</td>'+
 			'<td class="save">'+
 			'<div class="icon-checkmark" title="Save" deluminate_imagetype="unknown"></div>'+
@@ -239,7 +236,7 @@ describe('OCA.External.Settings tests', function() {
 				// TODO: respond and check data-id
 			});
 			it('saves storage after closing mount options popovermenu', function() {
-				$tr.find('.mountOptionsToggle .icon-settings-dark').click();
+				$tr.find('.mountOptionsToggle .icon-more').click();
 				$tr.find('[name=previews]').trigger(new $.Event('keyup', {keyCode: 97}));
 				$tr.find('input[data-parameter=field1]').val('test');
 
@@ -331,7 +328,7 @@ describe('OCA.External.Settings tests', function() {
 			});
 
 			it('shows popovermenu when clicking on toggle button, hides when clicking outside', function() {
-				$td.find('.icon-settings-dark').click();
+				$td.find('.icon-more').click();
 
 				expect($td.find('.popovermenu.open').length).toEqual(1);
 
@@ -342,7 +339,7 @@ describe('OCA.External.Settings tests', function() {
 
 			it('doesnt show the encryption option when encryption is disabled', function () {
 				view._encryptionEnabled = false;
-				$td.find('.icon-settings-dark').click();
+				$td.find('.icon-more').click();
 
 				expect($td.find('.popovermenu [name=encrypt]:visible').length).toEqual(0);
 
@@ -354,17 +351,17 @@ describe('OCA.External.Settings tests', function() {
 			it('reads config from mountOptions field', function() {
 				$tr.find('input.mountOptions').val(JSON.stringify({previews:false}));
 
-				$td.find('.icon-settings-dark').click();
+				$td.find('.icon-more').click();
 				expect($td.find('.popovermenu [name=previews]').prop('checked')).toEqual(false);
 				$('body').mouseup();
 
 				$tr.find('input.mountOptions').val(JSON.stringify({previews:true}));
-				$td.find('.icon-settings-dark').click();
+				$td.find('.icon-more').click();
 				expect($td.find('.popovermenu [name=previews]').prop('checked')).toEqual(true);
 			});
 
 			it('writes config into mountOptions field', function() {
-				$td.find('.icon-settings-dark').click();
+				$td.find('.icon-more').click();
 				// defaults to true
 				var $field = $td.find('.popovermenu [name=previews]');
 				expect($field.prop('checked')).toEqual(true);

--- a/apps/systemtags/js/admin.js
+++ b/apps/systemtags/js/admin.js
@@ -40,6 +40,12 @@
 				}
 			});
 
+			var self = this;
+			$('#systemtag_name').on('keyup', function(e) {
+				if (e.which === 13) {
+					_.bind(self._onClickSubmit, self)();
+				}
+			});
 			$('#systemtag_submit').on('click', _.bind(this._onClickSubmit, this));
 			$('#systemtag_delete').on('click', _.bind(this._onClickDelete, this));
 			$('#systemtag_reset').on('click', _.bind(this._onClickReset, this));

--- a/lib/private/Settings/Admin/Encryption.php
+++ b/lib/private/Settings/Admin/Encryption.php
@@ -77,7 +77,7 @@ class Encryption implements ISettings {
 	 * @return string the section ID, e.g. 'sharing'
 	 */
 	public function getSection() {
-		return 'encryption';
+		return 'security';
 	}
 
 	/**
@@ -88,6 +88,6 @@ class Encryption implements ISettings {
 	 * E.g.: 70
 	 */
 	public function getPriority() {
-		return 0;
+		return 10;
 	}
 }

--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -230,7 +230,6 @@ class Manager implements IManager {
 			1 => [new Section('server', $this->l->t('Basic settings'), 0, $this->url->imagePath('core', 'actions/settings-dark.svg'))],
 			5 => [new Section('sharing', $this->l->t('Sharing'), 0, $this->url->imagePath('core', 'actions/share.svg'))],
 			10 => [new Section('security', $this->l->t('Security'), 0, $this->url->imagePath('core', 'actions/password.svg'))],
-			45 => [new Section('encryption', $this->l->t('Encryption'), 0, $this->url->imagePath('core', 'actions/password.svg'))],
 			50 => [new Section('groupware', $this->l->t('Groupware'), 0, $this->url->imagePath('core', 'places/contacts.svg'))],
 			98 => [new Section('additional', $this->l->t('Additional settings'), 0, $this->url->imagePath('core', 'actions/settings-dark.svg'))],
 		];
@@ -270,7 +269,7 @@ class Manager implements IManager {
 			$form = new Admin\Mail($this->config);
 			$forms[$form->getPriority()] = [$form];
 		}
-		if ($section === 'encryption') {
+		if ($section === 'security') {
 			/** @var ISettings $form */
 			$form = new Admin\Encryption($this->encryptionManager, $this->userManager);
 			$forms[$form->getPriority()] = [$form];

--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -1473,7 +1473,7 @@ doesnotexist:-o-prefocus, .strengthify-wrapper {
 				top: $grid-row-height;
 			}
 			&#grid-header {
-				color: var(--color-text-light);
+				color: var(--color-text-maxcontrast);
 				z-index: 60; /* above new-user */
 			}
 			&:hover {

--- a/settings/templates/settings/personal/personal.info.php
+++ b/settings/templates/settings/personal/personal.info.php
@@ -367,8 +367,9 @@ vendor_style('jcrop/css/jquery.Jcrop');
 						<?php endforeach;?>
 					</select>
 					<div id="localeexample" class="personal-info icon-timezone">
-						<p id="localeexample-time"></p>
-						<p id="localeexample-date"></p>
+						<p>
+							<span id="localeexample-date"></span> <span id="localeexample-time"></span>
+						</p>
 						<p id="localeexample-fdow"></p>
 					</div>
 				</form>

--- a/tests/lib/Settings/Admin/EncryptionTest.php
+++ b/tests/lib/Settings/Admin/EncryptionTest.php
@@ -129,10 +129,10 @@ class EncryptionTest extends TestCase {
 	}
 
 	public function testGetSection() {
-		$this->assertSame('encryption', $this->admin->getSection());
+		$this->assertSame('security', $this->admin->getSection());
 	}
 
 	public function testGetPriority() {
-		$this->assertSame(0, $this->admin->getPriority());
+		$this->assertSame(10, $this->admin->getPriority());
 	}
 }

--- a/tests/lib/Settings/ManagerTest.php
+++ b/tests/lib/Settings/ManagerTest.php
@@ -115,7 +115,7 @@ class ManagerTest extends TestCase {
 
 		$this->manager->registerSection('admin', \OCA\WorkflowEngine\Settings\Section::class);
 
-		$this->url->expects($this->exactly(7))
+		$this->url->expects($this->exactly(6))
 			->method('imagePath')
 			->willReturnMap([
 				['settings', 'admin.svg', '0'],
@@ -131,7 +131,6 @@ class ManagerTest extends TestCase {
 			1 => [new Section('server', 'Basic settings', 0, '1')],
 			5 => [new Section('sharing', 'Sharing', 0, '2')],
 			10 => [new Section('security', 'Security', 0, '3')],
-			45 => [new Section('encryption', 'Encryption', 0, '3')],
 			50 => [new Section('groupware', 'Groupware', 0, '5')],
 			55 => [\OC::$server->query(\OCA\WorkflowEngine\Settings\Section::class)],
 			98 => [new Section('additional', 'Additional settings', 0, '1')],
@@ -168,7 +167,7 @@ class ManagerTest extends TestCase {
 			->method('t')
 			->will($this->returnArgument(0));
 
-		$this->url->expects($this->exactly(7))
+		$this->url->expects($this->exactly(6))
 			->method('imagePath')
 			->willReturnMap([
 				['settings', 'admin.svg', '0'],
@@ -184,7 +183,6 @@ class ManagerTest extends TestCase {
 			1 => [new Section('server', 'Basic settings', 0, '1')],
 			5 => [new Section('sharing', 'Sharing', 0, '2')],
 			10 => [new Section('security', 'Security', 0, '3')],
-			45 => [new Section('encryption', 'Encryption', 0, '3')],
 			50 => [new Section('groupware', 'Groupware', 0, '5')],
 			98 => [new Section('additional', 'Additional settings', 0, '1')],
 		], $this->manager->getAdminSections());


### PR DESCRIPTION
From https://github.com/nextcloud/server/issues/10094

- [x] User management: Table headers should be lighter font color than the rest of the text
- [x] External storages: Could use a settings-hint text like "You can mount different storage services as folders into your Nextcloud." Global credentials also needs explanation
- [x] External storages: Settings menu should use 3-dot-icon, and delete action should go in there too (as last entry)
- [x] Personal info: Vertical whitespace is a bit much. If it's cause of the region format, put time and date on one row.
- [x] Merge Server-side encryption into "Security" section?
- [x] Groupware: "Calendar settings" instead of "CalDAV server", and more whitespace between settings.
- [x] Workflow: Create a new tag input field should also create the tag on pressing enter