### PR TITLE
Always replace the app sidebar view when switching from a different file list

### DIFF
--- a/apps/files/js/detailsview.js
+++ b/apps/files/js/detailsview.js
@@ -118,10 +118,13 @@
 		 */
 		render: function() {
 			// remove old instances
-			if ($('#app-sidebar').length === 0) {
+			var $appSidebar = $('#app-sidebar');
+			if ($appSidebar.length === 0) {
 				this.$el.insertAfter($('#app-content'));
 			} else {
-				$('#app-sidebar').replaceWith(this.$el)
+				if ($appSidebar[0] !== this.el) {
+					$appSidebar.replaceWith(this.$el)
+				}
 			}
 			
 			var templateVars = {

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1623,7 +1623,7 @@
 
 			// discard finished uploads list, we'll get it through a regular reload
 			this._uploads = {};
-			this.reload().then(function(success){
+			return this.reload().then(function(success){
 				if (!success) {
 					self.changeDirectory(currentDir, true);
 				}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -564,7 +564,7 @@
 			}
 
 			this._currentFileModel = model;
-
+			this._detailsView.render();
 			this._detailsView.setFileInfo(model);
 			this._detailsView.$el.scrollTop(0);
 		},

--- a/tests/acceptance/features/app-files.feature
+++ b/tests/acceptance/features/app-files.feature
@@ -1,15 +1,23 @@
 Feature: app-files
 
-  Scenario: viewing a favorite file in its folder closes the details view
+  Scenario: viewing a favorite file in its folder shows the correct sidebar view
     Given I am logged in
+    And I create a new folder named "other"
+    And I mark "other" as favorite
     And I mark "welcome.txt" as favorite
+    And I see that "other" is marked as favorite
     And I see that "welcome.txt" is marked as favorite
     And I open the "Favorites" section
-    And I open the details view for "welcome.txt"
+    And I open the details view for "other"
     And I see that the details view is open
+    And I see that the file name shown in the details view is "other"
     When I view "welcome.txt" in folder
     Then I see that the current section is "All files"
-    And I see that the details view is closed
+    And I see that the details view is open
+    And I see that the file name shown in the details view is "welcome.txt"
+    When I open the details view for "other"
+    And I see that the file name shown in the details view is "other"
+
 
   Scenario: viewing a favorite file in its folder does not prevent opening the details view in "All files" section
     Given I am logged in


### PR DESCRIPTION
This should fix #10398. Once you switch to a different file list type like `FavoritesFileList` the detailsview element from the first file list has been removed from the DOM. Because of that it could not be shown when going back to the first file list.

~The underlying reason is that the current files app layout is based on [one DetailsView per file list](https://github.com/nextcloud/server/blob/b7572da4c8d4e0d7e33b31306d3ffd8123860334/apps/files/js/filelist.js#L277), we should change that for 15 maybe, but I would not introduce such a change now, since it might cause even more breakage.~

~Edit: I have a branch that switches to use a single instance at https://github.com/nextcloud/server/commit/01f885e6941bdd768f46e2216d55a8aa74e3854c but as expected this will lead to various issues with the plugins that are registered for each file list.~

Turns out, we simply can run render to make sure that the sidebar view is updated in the dom when updating the details view from the file list. Thanks @skjnldsv :+1: 