### PR TITLE
Fix issues when using the public layout without a PublicTemplateResponse

### DIFF
--- a/core/css/public.scss
+++ b/core/css/public.scss
@@ -40,6 +40,11 @@
 		min-height: calc(100vh - 160px);
 	}
 
+	/** don't apply content header padding on the base layout */
+	&.layout-base #content {
+		padding-top: 0;
+	}
+
 	/* force layout to make sure the content element's height matches its contents' height */
 	.ie #content {
 		display: inline-block;

--- a/core/templates/layout.base.php
+++ b/core/templates/layout.base.php
@@ -16,7 +16,7 @@
 		<?php emit_script_loading_tags($_); ?>
 		<?php print_unescaped($_['headers']); ?>
 	</head>
-	<body id="body-public">
+	<body id="body-public" class="layout-base">
 		<?php include 'layout.noscript.warning.php'; ?>
 		<div id="content" class="app-public" role="main">
 			<?php print_unescaped($_['content']); ?>

--- a/core/templates/layout.public.php
+++ b/core/templates/layout.public.php
@@ -30,7 +30,7 @@
 	<div id="notification-container">
 		<div id="notification"></div>
 	</div>
-	<header id="header" class="<?php p($_['header-classes']); ?>">
+	<header id="header">
 		<div class="header-left">
 			<span id="nextcloud">
 				<div class="logo logo-icon svg"></div>

--- a/core/templates/layout.public.php
+++ b/core/templates/layout.public.php
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html class="ng-csp" data-placeholder-focus="false" lang="<?php p($_['language']); ?>" data-locale="<?php p($_['locale']); ?>" >
-<head data-user="<?php p($_['user_uid']); ?>" data-user-displayname="<?php p($_['user_displayname']); ?>" data-requesttoken="<?php p($_['requesttoken']); ?>">
+<head data-requesttoken="<?php p($_['requesttoken']); ?>">
 	<meta charset="utf-8">
 	<title>
 		<?php
@@ -14,7 +14,7 @@
 	<meta name="apple-itunes-app" content="app-id=<?php p($theme->getiTunesAppId()); ?>">
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-status-bar-style" content="black">
-	<meta name="apple-mobile-web-app-title" content="<?php p((!empty($_['application']) && $_['appid']!='files')? $_['application']:$theme->getTitle()); ?>">
+	<meta name="apple-mobile-web-app-title" content="<?php p((!empty($_['application']) && $_['appid']!=='files')? $_['application']:$theme->getTitle()); ?>">
 	<meta name="mobile-web-app-capable" content="yes">
 	<meta name="theme-color" content="<?php p($theme->getColorPrimary()); ?>">
 	<link rel="icon" href="<?php print_unescaped(image_path($_['appid'], 'favicon.ico')); /* IE11+ supports png */ ?>">
@@ -35,17 +35,17 @@
 			<span id="nextcloud">
 				<div class="logo logo-icon svg"></div>
 				<h1 class="header-appname">
-					<?php p($template->getHeaderTitle()); ?>
+					<?php if (isset($template)) { p($template->getHeaderTitle()); } else { p($theme->getName());} ?>
 				</h1>
 				<div class="header-shared-by">
-					<?php p($template->getHeaderDetails()) ?>
+					<?php if (isset($template)) { p($template->getHeaderDetails()); } ?>
 				</div>
 			</span>
 		</div>
 
 		<?php
 		/** @var \OCP\AppFramework\Http\Template\PublicTemplateResponse $template */
-		if($template->getActionCount() !== 0) {
+		if(isset($template) && $template->getActionCount() !== 0) {
 			$primary = $template->getPrimaryAction();
 			$others = $template->getOtherActions();
 			?>
@@ -76,7 +76,7 @@
 	<div id="content" class="app-<?php p($_['appid']) ?>" role="main">
 		<?php print_unescaped($_['content']); ?>
 	</div>
-	<?php if($template->getFooterVisible()) { ?>
+	<?php if(isset($template) && $template->getFooterVisible()) { ?>
 	<footer>
 		<p class="info"><?php print_unescaped($theme->getLongFooter()); ?></p>
 	</footer>


### PR DESCRIPTION
Fixes #10528 

Remove unused parameter access:
- Undefined index: header-classes: /core/templates/layout.public.php@84c46dd#L33 (blame)
- Undefined index: user_displayname /core/templates/layout.public.php@84c46dd#L3 (blame)

Allow using the public layout in a regular TemplateResponse
- "Undefined variable: template"
  Call to a member function getHeaderTitle() on null /core/templates/layout.public.php@84c46dd#L38 (blame)

This still needs a fix for calendar, which is using 'public' instead of 'base' the public calendar embedding, see: https://github.com/nextcloud/calendar/pull/882