### PR TITLE
Show that user search is in progress #10531

### DIFF
--- a/core/js/contactsmenu.js
+++ b/core/js/contactsmenu.js
@@ -303,6 +303,7 @@
 			// resulting in an endless loading loop. To prevent this, we remember
 			// the last search term to savely ignore some events
 			// See https://github.com/nextcloud/server/issues/5281
+			this.$('#contactsmenu-search').val(t('core','Searching contacts…'));
 			if (searchTerm !== this._searchTerm) {
 				this.trigger('search', this.$('#contactsmenu-search').val());
 				this._searchTerm = searchTerm;
@@ -404,6 +405,9 @@
 				contactsAppURL: OC.generateUrl('/apps/contacts')
 			}));
 			this.$('#contactsmenu-contacts').html(list.$el);
+			if (this.$('#contactsmenu-search').val() !== ''){
+				this.$('#contactsmenu-search').val(t('core','Contacts found:'));
+			}
 		},
 
 		/**


### PR DESCRIPTION
- During the processing of the research, there is no indication that the research is being processed.
- For a backend with thousands of users, this can generate doubts to user about the processing.