### PR TITLE
Fix multiSelectMenu for public shares #10536

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -72,7 +72,24 @@ OCA.Sharing.PublicApp = {
 					fileActions: fileActions,
 					detailsViewEnabled: false,
 					filesClient: filesClient,
-					enableUpload: true
+					enableUpload: true,
+					multiSelectMenu: [
+						{
+								name: 'copyMove',
+								displayName:  t('files', 'Move or copy'),
+								iconClass: 'icon-external',
+						},
+						{
+								name: 'download',
+								displayName:  t('files', 'Download'),
+								iconClass: 'icon-download',
+						},
+						{
+								name: 'delete',
+								displayName: t('files', 'Delete'),
+								iconClass: 'icon-delete',
+						}
+					] 
 				}
 			);
 			this.files = OCA.Files.Files;

--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -399,6 +399,7 @@ class ShareController extends AuthPublicShareController {
 			\OCP\Util::addScript('files', 'fileinfomodel');
 			\OCP\Util::addScript('files', 'newfilemenu');
 			\OCP\Util::addScript('files', 'files');
+			\OCP\Util::addScript('files', 'filemultiselectmenu');
 			\OCP\Util::addScript('files', 'filelist');
 			\OCP\Util::addScript('files', 'keyboardshortcuts');
 		}


### PR DESCRIPTION
This should fix the issue reported in #10536

**RW-share**
![image](https://user-images.githubusercontent.com/4820905/43678331-e920caf6-9811-11e8-96d9-2c696ec50601.png)

**Read-only share**
![image](https://user-images.githubusercontent.com/4820905/43678336-f0555f76-9811-11e8-89d2-6b7e9801a278.png)


Signed-off-by: MartB <mart.b@outlook.de>