### PR TITLE
Disable Oracle enforcement for now until the following issues are sol…

### DIFF
--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -457,7 +457,8 @@ class MigrationService {
 
 		if ($toSchema instanceof SchemaWrapper) {
 			$targetSchema = $toSchema->getWrappedSchema();
-			$this->ensureOracleIdentifierLengthLimit($targetSchema, strlen($this->connection->getPrefix()));
+			// TODO re-enable once stable14 is branched of: https://github.com/nextcloud/server/issues/10518
+			// $this->ensureOracleIdentifierLengthLimit($targetSchema, strlen($this->connection->getPrefix()));
 			$this->connection->migrateToSchema($targetSchema);
 			$toSchema->performDropTableCalls();
 		}

--- a/tests/lib/DB/MigrationsTest.php
+++ b/tests/lib/DB/MigrationsTest.php
@@ -102,12 +102,13 @@ class MigrationsTest extends \Test\TestCase {
 			->method('migrateToSchema');
 
 		$wrappedSchema = $this->createMock(Schema::class);
-		$wrappedSchema->expects($this->once())
+		// TODO re-enable once stable14 is branched of: https://github.com/nextcloud/server/issues/10518
+		/*$wrappedSchema->expects($this->once())
 			->method('getTables')
 			->willReturn([]);
 		$wrappedSchema->expects($this->once())
 			->method('getSequences')
-			->willReturn([]);
+			->willReturn([]);*/
 
 		$schemaResult = $this->createMock(SchemaWrapper::class);
 		$schemaResult->expects($this->once())


### PR DESCRIPTION
…ved:

* Only apps should be checked which say they support oracle
* Only check newly added items, to allow forward migration from an existing database structure

Ref #10518 

Not closing the ticket because we should look into fixing it, instead of commenting out.

I will do that, but maybe not for 14.