### PR TITLE
A failing federation sync job is not an error

### DIFF
--- a/apps/federation/lib/SyncJob.php
+++ b/apps/federation/lib/SyncJob.php
@@ -50,7 +50,7 @@ class SyncJob extends TimedJob {
 			if ($ex instanceof \Exception) {
 				$this->logger->logException($ex, [
 					'message' => "Error while syncing $url.",
-					'level' => ILogger::ERROR,
+					'level' => ILogger::INFO,
 					'app' => 'fed-sync',
 				]);
 			}


### PR DESCRIPTION
This is an INFO warning at best. Else it spams the logs continuously