### PR TITLE
get avatar custom status from user config

### DIFF
--- a/lib/private/Avatar.php
+++ b/lib/private/Avatar.php
@@ -125,7 +125,7 @@ class Avatar implements IAvatar {
 	 * @return bool
 	 */
 	public function isCustomAvatar(): bool {
-		return !$this->folder->fileExists('generated');
+		return $this->config->getUserValue($this->user->getUID(), 'avatar', 'generated', 'false') !== 'true';
 	}
 
 	/**


### PR DESCRIPTION
this saves a cache operation because the user config is already cached

Signed-off-by: Robin Appelman <robin@icewind.nl>