### PR TITLE
cache root cache entry

### DIFF
--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -776,6 +776,15 @@ class CacheTest extends \Test\TestCase {
 		}
 	}
 
+	public function testMutateRootEntry() {
+		$data1 = array('size' => 100, 'mtime' => 50, 'mimetype' => 'foo/folder', 'etag' => 'asd');
+		$this->cache->put('', $data1);
+		$entry = $this->cache->get('');
+		$entry['etag'] = 'foobar';
+		$newEntry = $this->cache->get('');
+		$this->assertNotEquals('foobar', $newEntry->getEtag());
+	}
+
 	protected function tearDown() {
 		if ($this->cache) {
 			$this->cache->clear();


### PR DESCRIPTION
The root entry of a storage is the one that will be queried the most.

This saves 1 query per storage (including shares) for dav requests