### PR TITLE
Fix security settings if password change is disabled

### DIFF
--- a/settings/templates/settings/personal/security.php
+++ b/settings/templates/settings/personal/security.php
@@ -22,7 +22,6 @@
  */
 
 script('settings', [
-	'security_password',
 	'authtoken',
 	'authtoken_collection',
 	'authtoken_view',
@@ -30,18 +29,18 @@ script('settings', [
 ]);
 
 if($_['passwordChangeSupported']) {
+	script('settings', 'security_password');
 	script('jquery-showpassword');
 	vendor_script('strengthify/jquery.strengthify');
 	vendor_style('strengthify/strengthify');
 }
 
 ?>
-
+<?php if($_['passwordChangeSupported']) { ?>
 <div id="security-password" class="section">
 	<h2 class="inlineblock"><?php p($l->t('Password'));?></h2>
 	<span id="password-error-msg" class="msg success hidden">Saved</span>
 	<div class="personal-settings-setting-box personal-settings-password-box">
-		<?php if($_['passwordChangeSupported']) { ?>
 			<form id="passwordform">
 				<label for="pass1" class="hidden-visually"><?php p($l->t('Current password')); ?>: </label>
 				<input type="password" id="pass1" name="oldpassword"
@@ -60,12 +59,10 @@ if($_['passwordChangeSupported']) {
 				<input id="passwordbutton" type="submit" value="<?php p($l->t('Change password')); ?>" />
 
 			</form>
-			<?php
-		}
-		?>
 	</div>
 	<span class="msg"></span>
 </div>
+<?php } ?>
 
 <div id="security" class="section">
 	<h2><?php p($l->t('Devices & sessions'));?></h2>


### PR DESCRIPTION
Fix for #10464 

This will make sure the password change javascript is only included if it is needed as well as hide the whole password section when changing passwords is disabled.

Apply this patch to test:
```
--- a/lib/private/Settings/Personal/Security.php
+++ b/lib/private/Settings/Personal/Security.php
@@ -46,7 +46,7 @@ class Security implements ISettings {
                $user = $this->userManager->get(\OC_User::getUser());
                $passwordChangeSupported = false;
                if ($user !== null) {
-                       $passwordChangeSupported = $user->canChangePassword();
+                       $passwordChangeSupported = false;
                }
 
                return new TemplateResponse('settings', 'settings/personal/security', [
```