### PR TITLE
On login trigger 2FA provider migration

### DIFF
--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -103,6 +103,9 @@ class Manager {
 			return false;
 		}
 
+		// Trigger provider registering
+		$this->getProviderSet($user);
+
 		$providerStates = $this->providerRegistry->getProviderStates($user);
 		$enabled = array_filter($providerStates);
 


### PR DESCRIPTION
Without this the providers are never migrated resulting in no 2FA unless
explictly enabled again.

It is not the optimal way. But it works for now.
@ChristophWurst is you have a more elegant way feel free to adjust.