### PR TITLE
Fix 2FA provider registry population on login

### DIFF
--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -104,7 +104,9 @@ class Manager {
 		}
 
 		$providerStates = $this->providerRegistry->getProviderStates($user);
-		$enabled = array_filter($providerStates);
+		$providers = $this->providerLoader->getProviders($user);
+		$fixedStates = $this->fixMissingProviderStates($providerStates, $providers, $user);
+		$enabled = array_filter($fixedStates);
 
 		return $twoFactorEnabled && !empty($enabled);
 	}


### PR DESCRIPTION
If the 2FA provider registry has not been populated yet, we have to make
sure all available providers are loaded and queried on login. Otherwise
previously active 2FA providers aren't detected as enabled.

Supersedes https://github.com/nextcloud/server/pull/10574.

@rullzer good job on finding and debugging this. I cleaned up your patch and added a few more tests :rocket: 