### PR TITLE
Fix `this` context for enter-key handler on app tokens

### DIFF
--- a/settings/js/authtoken_view.js
+++ b/settings/js/authtoken_view.js
@@ -245,7 +245,7 @@
 				if (event.which === 13) {
 					this._addAppPassword();
 				}
-			});
+			}.bind(this));
 
 			this._result = $('#app-password-result');
 			this._newAppLoginName = $('#new-app-login-name');


### PR DESCRIPTION
Fixes https://sentry.io/share/issue/e07c5560b6154212832e4cd6598464c7/.

Steps to reproduce:
1. Go to security settings page
2. Focus app tokens input
3. Press enter

## Expected behavior

New token is generated.

## Actual behavior

Nothing.