### PR TITLE
Check if HTTP_USER_AGENT is set before using it

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1535,6 +1535,10 @@ class OC_Util {
 	 * @return boolean
 	 */
 	public static function isIe() {
+		if (!isset($_SERVER['HTTP_USER_AGENT'])) {
+			return false;
+		}
+
 		return preg_match(Request::USER_AGENT_IE, $_SERVER['HTTP_USER_AGENT']) === 1;
 	}
 


### PR DESCRIPTION
Sentry reported some errors regarding this. Apparently not everybody
sets a user agent. If it is not set we assume this is not IE ;)

https://sentry.rullzer.com/share/issue/14e12547168e4155a9e45c6a9bfb450b/