### PR TITLE
Fix login redirection if only one 2FA provider is active

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -334,7 +334,7 @@ class LoginController extends Controller {
 		if ($this->twoFactorManager->isTwoFactorAuthenticated($loginResult)) {
 			$this->twoFactorManager->prepareTwoFactorLogin($loginResult, $remember_login);
 
-			$providers = $this->twoFactorManager->getProviderSet($loginResult)->get3rdPartyProviders();
+			$providers = $this->twoFactorManager->getProviderSet($loginResult)->getPrimaryProviders();
 			if (count($providers) === 1) {
 				// Single provider, hence we can redirect to that provider's challenge page directly
 				/* @var $provider IProvider */

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -334,7 +334,7 @@ class LoginController extends Controller {
 		if ($this->twoFactorManager->isTwoFactorAuthenticated($loginResult)) {
 			$this->twoFactorManager->prepareTwoFactorLogin($loginResult, $remember_login);
 
-			$providers = $this->twoFactorManager->getProviderSet($loginResult)->getProviders();
+			$providers = $this->twoFactorManager->getProviderSet($loginResult)->get3rdPartyProviders();
 			if (count($providers) === 1) {
 				// Single provider, hence we can redirect to that provider's challenge page directly
 				/* @var $provider IProvider */

--- a/lib/private/Authentication/TwoFactorAuth/ProviderSet.php
+++ b/lib/private/Authentication/TwoFactorAuth/ProviderSet.php
@@ -70,7 +70,7 @@ class ProviderSet {
 	/**
 	 * @return IProvider[]
 	 */
-	public function get3rdPartyProviders(): array {
+	public function getPrimaryProviders(): array {
 		return array_filter($this->providers, function(IProvider $provider) {
 			return !($provider instanceof BackupCodesProvider);
 		});

--- a/lib/private/Authentication/TwoFactorAuth/ProviderSet.php
+++ b/lib/private/Authentication/TwoFactorAuth/ProviderSet.php
@@ -25,6 +25,8 @@ declare(strict_types=1);
 
 namespace OC\Authentication\TwoFactorAuth;
 
+use function array_filter;
+use OCA\TwoFactorBackupCodes\Provider\BackupCodesProvider;
 use OCP\Authentication\TwoFactorAuth\IProvider;
 
 /**
@@ -63,6 +65,15 @@ class ProviderSet {
 	 */
 	public function getProviders(): array {
 		return $this->providers;
+	}
+
+	/**
+	 * @return IProvider[]
+	 */
+	public function get3rdPartyProviders(): array {
+		return array_filter($this->providers, function(IProvider $provider) {
+			return !($provider instanceof BackupCodesProvider);
+		});
 	}
 
 	public function isProviderMissing(): bool {

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -27,6 +27,7 @@ use OC\Authentication\TwoFactorAuth\ProviderSet;
 use OC\Core\Controller\LoginController;
 use OC\Security\Bruteforce\Throttler;
 use OC\User\Session;
+use OCA\TwoFactorBackupCodes\Provider\BackupCodesProvider;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Authentication\TwoFactorAuth\IProvider;
@@ -594,7 +595,10 @@ class LoginControllerTest extends TestCase {
 			->will($this->returnValue('john'));
 		$password = 'secret';
 		$challengeUrl = 'challenge/url';
-		$provider = $this->createMock(IProvider::class);
+		$provider1 = $this->createMock(IProvider::class);
+		$provider1->method('getId')->willReturn('u2f');
+		$provider2 = $this->createMock(BackupCodesProvider::class);
+		$provider2->method('getId')->willReturn('backup');
 
 		$this->request
 			->expects($this->once())
@@ -616,14 +620,11 @@ class LoginControllerTest extends TestCase {
 		$this->twoFactorManager->expects($this->once())
 			->method('prepareTwoFactorLogin')
 			->with($user);
-		$providerSet = new ProviderSet([$provider], false);
+		$providerSet = new ProviderSet([$provider1, $provider2], false);
 		$this->twoFactorManager->expects($this->once())
 			->method('getProviderSet')
 			->with($user)
 			->willReturn($providerSet);
-		$provider->expects($this->once())
-			->method('getId')
-			->will($this->returnValue('u2f'));
 		$this->urlGenerator->expects($this->once())
 			->method('linkToRoute')
 			->with('core.TwoFactorChallenge.showChallenge', [

--- a/tests/lib/Authentication/TwoFactorAuth/ProviderSetTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/ProviderSetTest.php
@@ -64,7 +64,7 @@ class ProviderSetTest extends TestCase {
 
 		$set = new ProviderSet([$p2, $p1], false);
 
-		$this->assertEquals($expected, $set->get3rdPartyProviders());
+		$this->assertEquals($expected, $set->getPrimaryProviders());
 	}
 
 	public function testGetProvider() {

--- a/tests/lib/Authentication/TwoFactorAuth/ProviderSetTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/ProviderSetTest.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace Test\Authentication\TwoFactorAuth;
 
 use OC\Authentication\TwoFactorAuth\ProviderSet;
+use OCA\TwoFactorBackupCodes\Provider\BackupCodesProvider;
 use OCP\Authentication\TwoFactorAuth\IProvider;
 use Test\TestCase;
 
@@ -47,6 +48,23 @@ class ProviderSetTest extends TestCase {
 		$set = new ProviderSet([$p2, $p1], false);
 
 		$this->assertEquals($expected, $set->getProviders());
+	}
+
+	public function testGet3rdPartyProviders() {
+		$p1 = $this->createMock(IProvider::class);
+		$p1->method('getId')->willReturn('p1');
+		$p2 = $this->createMock(IProvider::class);
+		$p2->method('getId')->willReturn('p2');
+		$p3 = $this->createMock(BackupCodesProvider::class);
+		$p3->method('getId')->willReturn('p3');
+		$expected = [
+			'p1' => $p1,
+			'p2' => $p2,
+		];
+
+		$set = new ProviderSet([$p2, $p1], false);
+
+		$this->assertEquals($expected, $set->get3rdPartyProviders());
 	}
 
 	public function testGetProvider() {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/10500.

`get3rdPartyProviders` isn't a particularly beautiful method name, but `getProvidersButNotTheBackupCodesProviderPlease` was a bit too long. Suggestions welcome :wink: 