### PR TITLE
Fix app code checker to ignore `build` directory

### DIFF
--- a/lib/private/App/CodeChecker/CodeChecker.php
+++ b/lib/private/App/CodeChecker/CodeChecker.php
@@ -82,7 +82,7 @@ class CodeChecker extends BasicEmitter {
 	public function analyseFolder(string $appId, string $folder): array {
 		$errors = [];
 
-		$excludedDirectories = ['vendor', '3rdparty', '.git', 'l10n', 'tests', 'test'];
+		$excludedDirectories = ['vendor', '3rdparty', '.git', 'l10n', 'tests', 'test', 'build'];
 		if ($appId === 'password_policy') {
 			$excludedDirectories[] = 'lists';
 		}


### PR DESCRIPTION
I think it's safe to assume that the `build` directory does not contain any production code.

Not sure if this shall be seen as bugfix (for nc14) or a (breaking) change for nc15.

cc @nickvergessen @rullzer please assign the milestone ;)