### PR TITLE
Do not use file as template parameter

### DIFF
--- a/core/templates/403.php
+++ b/core/templates/403.php
@@ -12,6 +12,6 @@ if(!isset($_)) {//standalone  page is not supported anymore - redirect to /
 <ul>
 	<li class='error'>
 		<?php p($l->t( 'Access forbidden' )); ?><br>
-		<p class='hint'><?php if(isset($_['file'])) p($_['file'])?></p>
+		<p class='hint'><?php if(isset($_['message'])) p($_['message'])?></p>
 	</li>
 </ul>

--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -249,7 +249,7 @@ class SecurityMiddleware extends Middleware {
 					$url = $this->urlGenerator->linkToRoute('core.login.showLoginForm', $params);
 					$response = new RedirectResponse($url);
 				} else {
-					$response = new TemplateResponse('core', '403', ['file' => $exception->getMessage()], 'guest');
+					$response = new TemplateResponse('core', '403', ['message' => $exception->getMessage()], 'guest');
 					$response->setStatus($exception->getCode());
 				}
 			}

--- a/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
@@ -568,7 +568,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 			'test',
 			$exception
 		);
-		$expected = new TemplateResponse('core', '403', ['file' => $exception->getMessage()], 'guest');
+		$expected = new TemplateResponse('core', '403', ['message' => $exception->getMessage()], 'guest');
 		$expected->setStatus($exception->getCode());
 		$this->assertEquals($expected , $response);
 	}


### PR DESCRIPTION
Using file will overwrite the $file parameter in the template base.
Leading to trying to include a file that is the exception message. Which
will of course fail.

See: https://sentry.rullzer.com/share/issue/5b5ae2d0777e4ac7915de8c846c21098/