### PR TITLE
Redirect to the same page after an update

### DIFF
--- a/core/js/update.js
+++ b/core/js/update.js
@@ -107,7 +107,7 @@
 					}
 
 					setTimeout(function () {
-						OC.redirect(OC.webroot + '/');
+						OC.redirect(window.location.href);
 					}, 3000);
 				}
 			});


### PR DESCRIPTION
This PR makes sure we redirect to the requested page after an update instead of just redirecting to the files app.

fixes #4550
