### PR TITLE
Apply flex-basis to right header

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -152,6 +152,8 @@
 
 	#header-right, .header-right {
 		justify-content: flex-end;
+		flex-basis: 210px;
+		flex-shrink: 1;
 	}
 
 	/* Right header standard */


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/10452

Steps to reproduce:
1. Enable the notifications app
2. Resize your browser to 360px width
3. Reload the window

This occurs only some times to me, but my guess is that the notifications icon is added after the menu calculation has been done. This PR just adds a flex-basis of 210px (which is the width of the .header-right container with all icons visible) so we have a hint on how big the container will be already before the notification icon was added.

Before:
![image](https://user-images.githubusercontent.com/3404133/43906768-5d6ed674-9bf4-11e8-95cc-54267a100ea7.png)

After:
![image](https://user-images.githubusercontent.com/3404133/43906843-8517fad4-9bf4-11e8-954b-7715de864e59.png)
