### PR TITLE
Fix quickaccess active indicator for folders with spaces

### DIFF
--- a/apps/files/js/navigation.js
+++ b/apps/files/js/navigation.js
@@ -92,7 +92,7 @@
 		 * @param array options "silent" to not trigger event
 		 */
 		setActiveItem: function (itemId, options) {
-			var currentItem = this.$el.find('li[data-id=' + itemId + ']');
+			var currentItem = this.$el.find('li[data-id="' + itemId + '"]');
 			var itemDir = currentItem.data('dir');
 			var itemView = currentItem.data('view');
 			var oldItemId = this._activeItem;
@@ -135,7 +135,7 @@
 		 * Returns whether a given item exists
 		 */
 		itemExists: function (itemId) {
-			return this.$el.find('li[data-id=' + itemId + ']').length;
+			return this.$el.find('li[data-id="' + itemId + '"]').length;
 		},
 
 		/**


### PR DESCRIPTION
Fixes a javascript error and missing active indicator on favorite folders with spaces:

> Syntax error, unrecognized expression: li[data-id=-folder with spaces]

Steps to reproduce:
1. Create a folder named "test with spaces"
2. Add the folder to the favorites
3. Unfold the favorites entry in the left navigation
4. Click the "test with spaces" entry

From https://sentry.rullzer.com/sentry/nextcloud/issues/34