### PR TITLE
Adds a permission check for app directories

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -316,6 +316,23 @@
 							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 						});
 					}
+
+					if(data.appDirsWithDifferentOwner.length > 0) {
+						var appDirsWithDifferentOwner = data.appDirsWithDifferentOwner.reduce(
+							function(appDirsWithDifferentOwner, directory) {
+								return appDirsWithDifferentOwner + '<li>' + directory + '</li>';
+							},
+							''
+						);
+						messages.push({
+							msg: t('core', 'Some app directories are owned by a different user than the web server one. ' +
+									'This may be the case if apps have been installed manually. ' +
+									'Check the permissions of the following app directories:')
+									+ '<ul>' + appDirsWithDifferentOwner + '</ul>',
+							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+						});
+					}
+
 				} else {
 					messages.push({
 						msg: t('core', 'Error occurred while checking server setup'),

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -170,7 +170,8 @@ describe('OC.SetupChecks tests', function() {
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
-					}
+					},
+					appDirsWithDifferentOwner: []
 				})
 			);
 
@@ -217,7 +218,8 @@ describe('OC.SetupChecks tests', function() {
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
-					}
+					},
+					appDirsWithDifferentOwner: []
 				})
 			);
 
@@ -265,7 +267,8 @@ describe('OC.SetupChecks tests', function() {
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
-					}
+					},
+					appDirsWithDifferentOwner: []
 				})
 			);
 
@@ -311,7 +314,8 @@ describe('OC.SetupChecks tests', function() {
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
-					}
+					},
+					appDirsWithDifferentOwner: []
 				})
 			);
 
@@ -355,13 +359,61 @@ describe('OC.SetupChecks tests', function() {
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
-					}
+					},
+					appDirsWithDifferentOwner: []
 				})
 			);
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([{
 					msg: 'Memcached is configured as distributed cache, but the wrong PHP module "memcache" is installed. \\OC\\Memcache\\Memcached only supports "memcached" and not "memcache". See the <a href="https://code.google.com/p/memcached/wiki/PHPClientComparison" rel="noreferrer noopener">memcached wiki about both modules</a>.',
+					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+				}]);
+				done();
+			});
+		});
+
+		it('should return a warning if there are app directories with wrong permissions', function(done) {
+			var async = OC.SetupChecks.checkSetup();
+
+			suite.server.requests[0].respond(
+				200,
+				{
+					'Content-Type': 'application/json',
+				},
+				JSON.stringify({
+					hasFileinfoInstalled: true,
+					isGetenvServerWorking: true,
+					isReadOnlyConfig: false,
+					hasWorkingFileLocking: true,
+					hasValidTransactionIsolationLevel: true,
+					suggestedOverwriteCliURL: '',
+					isUrandomAvailable: true,
+					securityDocs: 'https://docs.owncloud.org/myDocs.html',
+					serverHasInternetConnection: true,
+					isMemcacheConfigured: true,
+					forwardedForHeadersWorking: true,
+					isCorrectMemcachedPHPModuleInstalled: true,
+					hasPassedCodeIntegrityCheck: true,
+					isOpcacheProperlySetup: true,
+					hasOpcacheLoaded: true,
+					isSettimelimitAvailable: true,
+					hasFreeTypeSupport: true,
+					missingIndexes: [],
+					outdatedCaches: [],
+					cronErrors: [],
+					cronInfo: {
+						diffInSeconds: 0
+					},
+					appDirsWithDifferentOwner: [
+						'/some/path'
+					]
+				})
+			);
+
+			async.done(function( data, s, x ){
+				expect(data).toEqual([{
+					msg: 'Some app directories are owned by a different user than the web server one. This may be the case if apps have been installed manually. Check the permissions of the following app directories:<ul><li>/some/path</li></ul>',
 					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 				}]);
 				done();
@@ -399,7 +451,8 @@ describe('OC.SetupChecks tests', function() {
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
-					}
+					},
+					appDirsWithDifferentOwner: []
 				})
 			);
 
@@ -443,7 +496,8 @@ describe('OC.SetupChecks tests', function() {
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
-					}
+					},
+					appDirsWithDifferentOwner: []
 				})
 			);
 
@@ -508,7 +562,8 @@ describe('OC.SetupChecks tests', function() {
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
-					}
+					},
+					appDirsWithDifferentOwner: []
 				})
 			);
 
@@ -553,7 +608,8 @@ describe('OC.SetupChecks tests', function() {
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
-					}
+					},
+					appDirsWithDifferentOwner: []
 				})
 			);
 
@@ -598,7 +654,8 @@ describe('OC.SetupChecks tests', function() {
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
-					}
+					},
+					appDirsWithDifferentOwner: []
 				})
 			);
 
@@ -643,7 +700,8 @@ describe('OC.SetupChecks tests', function() {
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
-					}
+					},
+					appDirsWithDifferentOwner: []
 				})
 			);
 

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -629,6 +629,27 @@ class CheckSetupControllerTest extends TestCase {
 		);
 	}
 
+	/**
+	 * Calls the check for a none existing app root that is marked as not writable.
+	 * It's expected that no error happens since the check shouldn't apply.
+	 *
+	 * @return void
+	 */
+	public function testAppDirectoryOwnersNotWritable() {
+		$tempDir = tempnam(sys_get_temp_dir(), 'apps') . 'dir';
+		OC::$APPSROOTS = [
+			[
+				'path' => $tempDir,
+				'url' => '/apps',
+				'writable' => false,
+			],
+		];
+		$this->assertSame(
+			[],
+			$this->invokePrivate($this->checkSetupController, 'getAppDirsWithDifferentOwner')
+		);
+	}
+
 	public function testIsBuggyNss400() {
 		$this->config->expects($this->any())
 			->method('getSystemValue')


### PR DESCRIPTION
This PR adds a setup check for the permissions of the app root directories.

There is a test for the case the permissions are fine. It's hard to add a test for the wrong permissions, because an ordinary user can't do a chown.

Replaces #10538

Closes #10154