### PR TITLE
Fix max length requirements for the throttler metadata

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -382,7 +382,7 @@ class LoginController extends Controller {
 		$response = new RedirectResponse(
 			$this->urlGenerator->linkToRoute('core.login.showLoginForm', $args)
 		);
-		$response->throttle(['user' => $user]);
+		$response->throttle(['user' => substr($user, 0, 64)]);
 		$this->session->set('loginMessages', [
 			[$loginMessage], []
 		]);


### PR DESCRIPTION
If a failed login is logged, we save the username as metadata
in the bruteforce throttler. To prevent database error due to
very long strings, this truncates the username at 64 bytes in
the assumption that no real username is longer than that.