### PR TITLE
switches the oc dialog button row to flex

### DIFF
--- a/core/css/jquery.ocdialog.scss
+++ b/core/css/jquery.ocdialog.scss
@@ -21,7 +21,7 @@
 }
 .oc-dialog-buttonrow {
 	position: relative;
-	display: block;
+	display: flex;
 	background: transparent;
 	right: 0;
 	bottom: 0;
@@ -32,24 +32,15 @@
 	background-image: linear-gradient(rgba(255, 255, 255, 0.0), var(--color-main-background));
 	border-bottom-left-radius: 3px;
 	border-bottom-right-radius: 3px;
-	clear: both;
-	button {
-		display: inline-block;
-	}
-}
-/* align primary button to right, other buttons to left */
-.oc-dialog-buttonrow.twobuttons button:nth-child(1) {
-	float: left;
-}
-.oc-dialog-buttonrow.twobuttons.aside button:nth-child(1) {
-	float: none;
-}
-.oc-dialog-buttonrow.twobuttons button:nth-child(2) {
-	float: right;
-}
 
-.oc-dialog-buttonrow.onebutton button {
-	float: right;
+	&.twobuttons {
+		justify-content: space-between;
+	}
+
+	&.onebutton,
+	&.twobuttons.aside {
+		justify-content: flex-end;
+	}
 }
 
 .oc-dialog-close {


### PR DESCRIPTION
I found that https://github.com/nextcloud/server/pull/10274/commits/c90d7c15e98b35ae98c6a08bc92271348c3db72e fixed the button layout for safari, but broke it for others.

As a possible solution I switched the button row layout to flex. It now fits in Chrome, Firefox and Safari.

For visual tests I found three possible button configurations:
- [single button](https://user-images.githubusercontent.com/6216686/44054738-b753c4f4-9f43-11e8-9ff2-0b74d5d9fa33.png)
- [dual button](https://user-images.githubusercontent.com/6216686/44054777-cff3df30-9f43-11e8-9810-10f82d0d92a6.png)
- [dual button side by side](https://user-images.githubusercontent.com/6216686/44054807-db987f30-9f43-11e8-9940-c0b5d2543577.png)

closes #10667 