### PR TITLE
don't blame randome people for background email updates

### DIFF
--- a/apps/admin_audit/lib/Actions/UserManagement.php
+++ b/apps/admin_audit/lib/Actions/UserManagement.php
@@ -97,14 +97,25 @@ class UserManagement extends Action {
 	 * @param array $params
 	 */
 	public function change(array $params) {
-		if ($params['feature'] === 'enabled') {
-			$this->log(
-				$params['value'] === 'true' ? 'User enabled: "%s"' : 'User disabled: "%s"',
-				['user' => $params['user']->getUID()],
-				[
-					'user',
-				]
-			);
+		switch($params['feature']) {
+			case 'enabled':
+				$this->log(
+					$params['value'] === 'true' ? 'User enabled: "%s"' : 'User disabled: "%s"',
+					['user' => $params['user']->getUID()],
+					[
+						'user',
+					]
+				);
+				break;
+			case 'eMailAddress':
+				$this->log(
+					'Email address changed for user %s',
+					['user' => $params['user']->getUID()],
+					[
+						'user',
+					]
+				);
+				break;
 		}
 	}
 

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -318,11 +318,6 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 		$dn = $user->getDN();
 		//check if user really still exists by reading its entry
 		if(!is_array($this->access->readAttribute($dn, '', $this->access->connection->ldapUserFilter))) {
-			$lcr = $this->access->connection->getConnectionResource();
-			if(is_null($lcr)) {
-				throw new \Exception('No LDAP Connection to server ' . $this->access->connection->ldapHost);
-			}
-
 			try {
 				$uuid = $this->access->getUserMapper()->getUUIDByDN($dn);
 				if (!$uuid) {
@@ -330,7 +325,7 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 				}
 				$newDn = $this->access->getUserDnByUuid($uuid);
 				//check if renamed user is still valid by reapplying the ldap filter
-				if (!is_array($this->access->readAttribute($newDn, '', $this->access->connection->ldapUserFilter))) {
+				if ($newDn === $dn || !is_array($this->access->readAttribute($newDn, '', $this->access->connection->ldapUserFilter))) {
 					return false;
 				}
 				$this->access->getUserMapper()->setDNbyUUID($newDn, $uuid);
@@ -376,9 +371,6 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 
 		$result = $this->userExistsOnLDAP($user);
 		$this->access->connection->writeToCache('userExists'.$uid, $result);
-		if($result === true) {
-			$user->update();
-		}
 		return $result;
 	}
 

--- a/settings/Hooks.php
+++ b/settings/Hooks.php
@@ -165,6 +165,7 @@ class Hooks {
 
 		$actor = $this->userSession->getUser();
 		if ($actor instanceof IUser) {
+			$subject = Provider::EMAIL_CHANGED_SELF;
 			if ($actor->getUID() !== $user->getUID()) {
 				$this->l = $this->languageFactory->get(
 					'settings',
@@ -173,15 +174,11 @@ class Hooks {
 						$this->config->getSystemValue('default_language', 'en')
 					)
 				);
-
-				$text = $this->l->t('%1$s changed your email address on %2$s.', [$actor->getDisplayName(), $instanceUrl]);
-				$event->setAuthor($actor->getUID())
-					->setSubject(Provider::EMAIL_CHANGED_BY, [$actor->getUID()]);
-			} else {
-				$text = $this->l->t('Your email address on %s was changed.', [$instanceUrl]);
-				$event->setAuthor($actor->getUID())
-					->setSubject(Provider::EMAIL_CHANGED_SELF);
+				$subject = Provider::EMAIL_CHANGED;
 			}
+			$text = $this->l->t('Your email address on %s was changed.', [$instanceUrl]);
+			$event->setAuthor($actor->getUID())
+				->setSubject($subject);
 		} else {
 			$text = $this->l->t('Your email address on %s was changed by an administrator.', [$instanceUrl]);
 			$event->setSubject(Provider::EMAIL_CHANGED);


### PR DESCRIPTION
Commit 1)

We have the feature that when, for example, the email address was changed, a notification is sent to the affected user (https://github.com/nextcloud/server/blob/master/settings/Hooks.php#L168-L179). 

Now it is possible that a user record is refreshed from its original source while the user was looked up by other means. Specifically happens on two scenarios in LDAP, and at least one, when ajax as backgroud job mode is used, is not going to change (soon). When this happens, the affected user is notified by "your acquaintance updated your email address", which she didn't herself.

admin_audit now logs email address changes, so this can always be looked up by the admin.

Is there any issue with changing this behaviour? It was reported by a customer and should be backported.

Commit 2)

Latest in 14, we do not need to force a refresh on LDAP user with userExists check, since auth is repeated regularly in the background with the csrf update. IIRC. The Exception check is not necessary anymore as it happens higher in the stack already.