### PR TITLE
Fix timepicker z-index to be above the sidebar

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -601,6 +601,7 @@ code {
 	margin-top: 10px !important;
 	width: auto !important;
 	border-radius: var(--border-radius);
+	z-index: 1600 !important;
 
 	.ui-widget-content {
 		border: none !important;


### PR DESCRIPTION
This fixes the timepicker being hidden under the app sidebar.