### PR TITLE
Check if a preview provider is available before using it

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -184,6 +184,10 @@ class Generator {
 					continue;
 				}
 
+				if (!$provider->isAvailable($file)) {
+					continue;
+				}
+
 				$maxWidth = (int)$this->config->getSystemValue('preview_max_x', 4096);
 				$maxHeight = (int)$this->config->getSystemValue('preview_max_y', 4096);
 

--- a/tests/lib/Preview/GeneratorTest.php
+++ b/tests/lib/Preview/GeneratorTest.php
@@ -150,16 +150,24 @@ class GeneratorTest extends \Test\TestCase {
 			}));
 
 		$invalidProvider = $this->createMock(IProvider::class);
+		$invalidProvider->method('isAvailable')
+			->willReturn(true);
+		$unavailableProvider = $this->createMock(IProvider::class);
+		$unavailableProvider->method('isAvailable')
+			->willReturn(false);
 		$validProvider = $this->createMock(IProvider::class);
+		$validProvider->method('isAvailable')
+			->with($file)
+			->willReturn(true);
 
 		$this->previewManager->method('getProviders')
 			->willReturn([
 				'/image\/png/' => ['wrongProvider'],
-				'/myMimeType/' => ['brokenProvider', 'invalidProvider', 'validProvider'],
+				'/myMimeType/' => ['brokenProvider', 'invalidProvider', 'unavailableProvider', 'validProvider'],
 			]);
 
 		$this->helper->method('getProvider')
-			->will($this->returnCallback(function($provider) use ($invalidProvider, $validProvider) {
+			->will($this->returnCallback(function($provider) use ($invalidProvider, $validProvider, $unavailableProvider) {
 				if ($provider === 'wrongProvider') {
 					$this->fail('Wrongprovider should not be constructed!');
 				} else if ($provider === 'brokenProvider') {
@@ -168,6 +176,8 @@ class GeneratorTest extends \Test\TestCase {
 					return $invalidProvider;
 				} else if ($provider === 'validProvider') {
 					return $validProvider;
+				} else if ($provider === 'unavailableProvider') {
+					return $unavailableProvider;
 				}
 				$this->fail('Unexpected provider requested');
 			}));


### PR DESCRIPTION
Else if a preview provider is registerd but not available (for example
missing support in some external lib). It will do :boom:. This way the
providers can at least do the sanity checks required.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>