### PR TITLE
fix wrong return value of filtered whats new info

### DIFF
--- a/apps/updatenotification/lib/Settings/Admin.php
+++ b/apps/updatenotification/lib/Settings/Admin.php
@@ -127,7 +127,8 @@ class Admin implements ISettings {
 		do {
 			$lang = $iterator->current();
 			if(isset($changes['whatsNew'][$lang])) {
-				return $filtered['whatsNew'][$lang];
+				$filtered['whatsNew'] = $changes['whatsNew'][$lang];
+				return $filtered;
 			}
 			$iterator->next();
 		} while($lang !== 'en' && $iterator->valid());

--- a/apps/updatenotification/lib/Settings/Admin.php
+++ b/apps/updatenotification/lib/Settings/Admin.php
@@ -114,7 +114,7 @@ class Admin implements ISettings {
 		return new TemplateResponse('updatenotification', 'admin', $params, '');
 	}
 
-	protected function filterChanges(array $changes) {
+	protected function filterChanges(array $changes): array {
 		$filtered = [];
 		if(isset($changes['changelogURL'])) {
 			$filtered['changelogURL'] = $changes['changelogURL'];

--- a/core/css/whatsnew.scss
+++ b/core/css/whatsnew.scss
@@ -9,6 +9,7 @@
   bottom: 35px !important;
   left: 15px !important;
   width: 270px;
+  z-index: 700;
 }
 
 .whatsNewPopover p {


### PR DESCRIPTION
The current state would return null, and present nothing. Comes with unit tests.

How to test:
* be on beta 3
* have an update server with https://github.com/nextcloud/updater_server/pull/138 merged (e.g. internal one)
* go to admin settings overview. Next to the "open updater" button you will now see a "What's new" info

(to avoid cache hits, add a `false && ` to the if-check in lib/private/Updater/VersionCheck.php::check() )

![screenshot_20180816_130345](https://user-images.githubusercontent.com/2184312/44204905-cf2da500-a154-11e8-95a8-5c877102512a.png)
