### PR TITLE
add occ command to recover encrypted files in case of password lost

### DIFF
--- a/apps/encryption/appinfo/info.xml
+++ b/apps/encryption/appinfo/info.xml
@@ -14,7 +14,7 @@
 		Please read the documentation to know all implications before you decide
 		to enable server-side encryption.
 	</description>
-	<version>2.1.0</version>
+	<version>2.2.0</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>
 	<author>Clark Tomlinson</author>
@@ -43,6 +43,7 @@
 	<commands>
 		<command>OCA\Encryption\Command\EnableMasterKey</command>
 		<command>OCA\Encryption\Command\DisableMasterKey</command>
+		<command>OCA\Encryption\Command\RecoverUser</command>
 	</commands>
 
 	<settings>

--- a/apps/encryption/composer/composer/autoload_classmap.php
+++ b/apps/encryption/composer/composer/autoload_classmap.php
@@ -9,6 +9,7 @@ return array(
     'OCA\\Encryption\\AppInfo\\Application' => $baseDir . '/../lib/AppInfo/Application.php',
     'OCA\\Encryption\\Command\\DisableMasterKey' => $baseDir . '/../lib/Command/DisableMasterKey.php',
     'OCA\\Encryption\\Command\\EnableMasterKey' => $baseDir . '/../lib/Command/EnableMasterKey.php',
+    'OCA\\Encryption\\Command\\RecoverUser' => $baseDir . '/../lib/Command/RecoverUser.php',
     'OCA\\Encryption\\Controller\\RecoveryController' => $baseDir . '/../lib/Controller/RecoveryController.php',
     'OCA\\Encryption\\Controller\\SettingsController' => $baseDir . '/../lib/Controller/SettingsController.php',
     'OCA\\Encryption\\Controller\\StatusController' => $baseDir . '/../lib/Controller/StatusController.php',

--- a/apps/encryption/composer/composer/autoload_static.php
+++ b/apps/encryption/composer/composer/autoload_static.php
@@ -24,6 +24,7 @@ class ComposerStaticInitEncryption
         'OCA\\Encryption\\AppInfo\\Application' => __DIR__ . '/..' . '/../lib/AppInfo/Application.php',
         'OCA\\Encryption\\Command\\DisableMasterKey' => __DIR__ . '/..' . '/../lib/Command/DisableMasterKey.php',
         'OCA\\Encryption\\Command\\EnableMasterKey' => __DIR__ . '/..' . '/../lib/Command/EnableMasterKey.php',
+        'OCA\\Encryption\\Command\\RecoverUser' => __DIR__ . '/..' . '/../lib/Command/RecoverUser.php',
         'OCA\\Encryption\\Controller\\RecoveryController' => __DIR__ . '/..' . '/../lib/Controller/RecoveryController.php',
         'OCA\\Encryption\\Controller\\SettingsController' => __DIR__ . '/..' . '/../lib/Controller/SettingsController.php',
         'OCA\\Encryption\\Controller\\StatusController' => __DIR__ . '/..' . '/../lib/Controller/StatusController.php',

--- a/apps/encryption/lib/Command/RecoverUser.php
+++ b/apps/encryption/lib/Command/RecoverUser.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Encryption\Command;
+
+
+use OC\Files\Filesystem;
+use OC\User\NoUserException;
+use OCA\Encryption\Crypto\Crypt;
+use OCA\Encryption\KeyManager;
+use OCA\Encryption\Recovery;
+use OCA\Encryption\Util;
+use OCP\IConfig;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+class RecoverUser extends Command {
+
+	/** @var Util */
+	protected $util;
+
+	/** @var IUserManager */
+	protected $userManager;
+
+	/** @var  QuestionHelper */
+	protected $questionHelper;
+
+	/**
+	 * @param Util $util
+	 * @param IConfig $config
+	 * @param IUserManager $userManager
+	 * @param QuestionHelper $questionHelper
+	 */
+	public function __construct(Util $util,
+								IConfig $config,
+								IUserManager $userManager,
+								QuestionHelper $questionHelper) {
+
+		$this->util = $util;
+		$this->questionHelper = $questionHelper;
+		$this->userManager = $userManager;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('encryption:recover-user')
+			->setDescription('Recover user data in case of password lost. This only works if the user enabled the recovery key.');
+
+		$this->addArgument(
+			'user',
+			InputArgument::REQUIRED,
+			'user which should be recovered'
+		);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+
+		$isMasterKeyEnabled = $this->util->isMasterKeyEnabled();
+
+		if($isMasterKeyEnabled) {
+			$output->writeln('You use the master key, no individual user recovery needed.');
+			return;
+		}
+
+		$uid = $input->getArgument('user');
+		$userExists = $this->userManager->userExists($uid);
+		if ($userExists === false) {
+			$output->writeln('User "' . $uid . '" unknown.');
+			return;
+		}
+
+		$recoveryKeyEnabled = $this->util->isRecoveryEnabledForUser($uid);
+		if($recoveryKeyEnabled === false) {
+			$output->writeln('Recovery key is not enabled for: ' . $uid);
+			return;
+		}
+
+		$question = new Question('Please enter the recovery key password: ');
+		$question->setHidden(true);
+		$question->setHiddenFallback(false);
+		$recoveryPassword = $this->questionHelper->ask($input, $output, $question);
+
+		$question = new Question('Please enter the new login password for the user: ');
+		$question->setHidden(true);
+		$question->setHiddenFallback(false);
+		$newLoginPassword = $this->questionHelper->ask($input, $output, $question);
+
+		$output->write('Start to recover users files... This can take some time...');
+		$this->userManager->get($uid)->setPassword($newLoginPassword, $recoveryPassword);
+		$output->writeln('Done.');
+
+	}
+
+}

--- a/apps/encryption/tests/Hooks/UserHooksTest.php
+++ b/apps/encryption/tests/Hooks/UserHooksTest.php
@@ -210,9 +210,9 @@ class UserHooksTest extends TestCase {
 	}
 
 	public function testSetPassphrase() {
-		$this->sessionMock->expects($this->exactly(4))
+		$this->sessionMock->expects($this->once())
 			->method('getPrivateKey')
-			->willReturnOnConsecutiveCalls(true, false);
+			->willReturn(true);
 
 		$this->cryptMock->expects($this->exactly(4))
 			->method('encryptPrivateKey')
@@ -236,7 +236,7 @@ class UserHooksTest extends TestCase {
 
 		$this->recoveryMock->expects($this->exactly(3))
 			->method('isRecoveryEnabledForUser')
-			->with('testUser')
+			->with('testUser1')
 			->willReturnOnConsecutiveCalls(true, false);
 
 
@@ -257,13 +257,15 @@ class UserHooksTest extends TestCase {
 
 		$this->instance->expects($this->exactly(3))->method('initMountPoints');
 
+		$this->params['uid'] = 'testUser1';
+
 		// Test first if statement
 		$this->assertNull($this->instance->setPassphrase($this->params));
 
 		// Test Second if conditional
 		$this->keyManagerMock->expects($this->exactly(2))
 			->method('userHasKeys')
-			->with('testUser')
+			->with('testUser1')
 			->willReturn(true);
 
 		$this->assertNull($this->instance->setPassphrase($this->params));
@@ -271,7 +273,7 @@ class UserHooksTest extends TestCase {
 		// Test third and final if condition
 		$this->utilMock->expects($this->once())
 			->method('userHasFiles')
-			->with('testUser')
+			->with('testUser1')
 			->willReturn(false);
 
 		$this->cryptMock->expects($this->once())
@@ -282,7 +284,7 @@ class UserHooksTest extends TestCase {
 
 		$this->recoveryMock->expects($this->once())
 			->method('recoverUsersFiles')
-			->with('password', 'testUser');
+			->with('password', 'testUser1');
 
 		$this->assertNull($this->instance->setPassphrase($this->params));
 	}
@@ -297,9 +299,6 @@ class UserHooksTest extends TestCase {
 	}
 
 	public function testSetPasswordNoUser() {
-		$this->sessionMock->expects($this->once())
-			->method('getPrivateKey')
-			->willReturn(true);
 
 		$userSessionMock = $this->getMockBuilder(IUserSession::class)
 			->disableOriginalConstructor()


### PR DESCRIPTION
For Nextcloud 14 we removed the recovery option for encrypted files from the user management because this can easily run into timeouts for large user accounts.

This PR brings the functionality back as a occ command.