### PR TITLE
Improve performance when dealing with large numbers of shares

### DIFF
--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -65,6 +65,10 @@ class Helper {
 		return $path;
 	}
 
+	public static function isUsingShareFolder() {
+		return \OC::$server->getConfig()->getSystemValue('share_folder', '/') !== '/';
+	}
+
 	/**
 	 * get default share folder
 	 *

--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -65,10 +65,6 @@ class Helper {
 		return $path;
 	}
 
-	public static function isUsingShareFolder() {
-		return \OC::$server->getConfig()->getSystemValue('share_folder', '/') !== '/';
-	}
-
 	/**
 	 * get default share folder
 	 *

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -86,7 +86,7 @@ class MountProvider implements IMountProvider {
 		$mounts = [];
 		foreach ($superShares as $share) {
 			try {
-				$mounts[] = new SharedMount(
+				$mount = new SharedMount(
 					'\OCA\Files_Sharing\SharedStorage',
 					$mounts,
 					[
@@ -98,6 +98,7 @@ class MountProvider implements IMountProvider {
 					],
 					$storageFactory
 				);
+				$mounts[$mount->getMountPoint()] = $mount;
 			} catch (\Exception $e) {
 				$this->logger->logException($e);
 				$this->logger->error('Error while trying to create shared mount');
@@ -105,7 +106,7 @@ class MountProvider implements IMountProvider {
 		}
 
 		// array_filter removes the null values from the array
-		return array_filter($mounts);
+		return array_values(array_filter($mounts));
 	}
 
 	/**

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -27,6 +27,7 @@
 
 namespace OCA\Files_Sharing;
 
+use OC\Files\View;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\IConfig;
@@ -84,19 +85,29 @@ class MountProvider implements IMountProvider {
 		$superShares = $this->buildSuperShares($shares, $user);
 
 		$mounts = [];
+		$view = new View('/' . $user->getUID() . '/files');
+		$ownerViews = [];
 		foreach ($superShares as $share) {
 			try {
+				/** @var \OCP\Share\IShare $parentShare */
+				$parentShare = $share[0];
+				$owner = $parentShare->getShareOwner();
+				if (!isset($ownerViews[$owner])) {
+					$ownerViews[$owner] = new View('/' . $parentShare->getShareOwner() . '/files');
+				}
 				$mount = new SharedMount(
 					'\OCA\Files_Sharing\SharedStorage',
 					$mounts,
 					[
 						'user' => $user->getUID(),
 						// parent share
-						'superShare' => $share[0],
+						'superShare' => $parentShare,
 						// children/component of the superShare
 						'groupedShares' => $share[1],
+						'ownerView' => $ownerViews[$owner]
 					],
-					$storageFactory
+					$storageFactory,
+					$view
 				);
 				$mounts[$mount->getMountPoint()] = $mount;
 			} catch (\Exception $e) {

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -87,6 +87,7 @@ class MountProvider implements IMountProvider {
 		$mounts = [];
 		$view = new View('/' . $user->getUID() . '/files');
 		$ownerViews = [];
+		$sharingDisabledForUser = $this->shareManager->sharingDisabledForUser($user->getUID());
 		foreach ($superShares as $share) {
 			try {
 				/** @var \OCP\Share\IShare $parentShare */
@@ -104,7 +105,8 @@ class MountProvider implements IMountProvider {
 						'superShare' => $parentShare,
 						// children/component of the superShare
 						'groupedShares' => $share[1],
-						'ownerView' => $ownerViews[$owner]
+						'ownerView' => $ownerViews[$owner],
+						'sharingDisabledForUser' => $sharingDisabledForUser
 					],
 					$storageFactory,
 					$view

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -27,6 +27,7 @@
 
 namespace OCA\Files_Sharing;
 
+use OC\Cache\CappedMemoryCache;
 use OC\Files\View;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Storage\IStorageFactory;
@@ -88,6 +89,7 @@ class MountProvider implements IMountProvider {
 		$view = new View('/' . $user->getUID() . '/files');
 		$ownerViews = [];
 		$sharingDisabledForUser = $this->shareManager->sharingDisabledForUser($user->getUID());
+		$foldersExistCache = new CappedMemoryCache();
 		foreach ($superShares as $share) {
 			try {
 				/** @var \OCP\Share\IShare $parentShare */
@@ -109,7 +111,8 @@ class MountProvider implements IMountProvider {
 						'sharingDisabledForUser' => $sharingDisabledForUser
 					],
 					$storageFactory,
-					$view
+					$view,
+					$foldersExistCache
 				);
 				$mounts[$mount->getMountPoint()] = $mount;
 			} catch (\Exception $e) {

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -135,20 +135,16 @@ class SharedMount extends MountPoint implements MoveableMount {
 		$name = $pathinfo['filename'];
 		$dir = $pathinfo['dirname'];
 
-		// Helper function to find existing mount points
-		$mountpointExists = function ($path) use ($mountpoints) {
-			foreach ($mountpoints as $mountpoint) {
-				if ($mountpoint->getShare()->getTarget() === $path) {
-					return true;
-				}
-			}
-			return false;
-		};
-
 		$i = 2;
-		while ($view->file_exists($path) || $mountpointExists($path)) {
+		$absolutePath = $this->recipientView->getAbsolutePath($path) . '/';
+		while ($view->file_exists($path) || isset($mountpoints[$absolutePath])) {
 			$path = Filesystem::normalizePath($dir . '/' . $name . ' (' . $i . ')' . $ext);
+			$absolutePath = $this->recipientView->getAbsolutePath($path) . '/';
+			var_dump($absolutePath);
 			$i++;
+			if ($i > 10) {
+				return $path;
+			}
 		}
 
 		return $path;

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -89,7 +89,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 		$mountPoint = basename($share->getTarget());
 		$parent = dirname($share->getTarget());
 
-		if (!$this->recipientView->is_dir($parent)) {
+		if (Helper::isUsingShareFolder() && !$this->recipientView->is_dir($parent)) {
 			$parent = Helper::getShareFolder($this->recipientView);
 		}
 

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -28,10 +28,12 @@
 
 namespace OCA\Files_Sharing;
 
+use OC\Cache\CappedMemoryCache;
 use OC\Files\Filesystem;
 use OC\Files\Mount\MountPoint;
 use OC\Files\Mount\MoveableMount;
 use OC\Files\View;
+use OCP\Files\Storage\IStorageFactory;
 
 /**
  * Shared mount points can be moved by the user
@@ -62,17 +64,17 @@ class SharedMount extends MountPoint implements MoveableMount {
 	 * @param string $storage
 	 * @param SharedMount[] $mountpoints
 	 * @param array $arguments
-	 * @param \OCP\Files\Storage\IStorageFactory $loader
+	 * @param IStorageFactory $loader
 	 * @param View $recipientView
 	 */
-	public function __construct($storage, array $mountpoints, $arguments, $loader, $recipientView) {
+	public function __construct($storage, array $mountpoints, $arguments, IStorageFactory $loader, View $recipientView, CappedMemoryCache $folderExistCache) {
 		$this->user = $arguments['user'];
 		$this->recipientView = $recipientView;
 
 		$this->superShare = $arguments['superShare'];
 		$this->groupedShares = $arguments['groupedShares'];
 
-		$newMountPoint = $this->verifyMountPoint($this->superShare, $mountpoints);
+		$newMountPoint = $this->verifyMountPoint($this->superShare, $mountpoints, $folderExistCache);
 		$absMountPoint = '/' . $this->user . '/files' . $newMountPoint;
 		parent::__construct($storage, $absMountPoint, $arguments, $loader);
 	}
@@ -84,12 +86,18 @@ class SharedMount extends MountPoint implements MoveableMount {
 	 * @param SharedMount[] $mountpoints
 	 * @return string
 	 */
-	private function verifyMountPoint(\OCP\Share\IShare $share, array $mountpoints) {
+	private function verifyMountPoint(\OCP\Share\IShare $share, array $mountpoints, CappedMemoryCache $folderExistCache) {
 
 		$mountPoint = basename($share->getTarget());
 		$parent = dirname($share->getTarget());
 
-		if (Helper::isUsingShareFolder() && !$this->recipientView->is_dir($parent)) {
+		if ($folderExistCache->hasKey($parent)) {
+			$parentExists = $folderExistCache->get($parent);
+		} else {
+			$parentExists = $this->recipientView->is_dir($parent);
+			$folderExistCache->set($parent, $parentExists);
+		}
+		if (!$parentExists) {
 			$parent = Helper::getShareFolder($this->recipientView);
 		}
 

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -140,11 +140,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 		while ($view->file_exists($path) || isset($mountpoints[$absolutePath])) {
 			$path = Filesystem::normalizePath($dir . '/' . $name . ' (' . $i . ')' . $ext);
 			$absolutePath = $this->recipientView->getAbsolutePath($path) . '/';
-			var_dump($absolutePath);
 			$i++;
-			if ($i > 10) {
-				return $path;
-			}
 		}
 
 		return $path;

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -61,19 +61,19 @@ class SharedMount extends MountPoint implements MoveableMount {
 	/**
 	 * @param string $storage
 	 * @param SharedMount[] $mountpoints
-	 * @param array|null $arguments
+	 * @param array $arguments
 	 * @param \OCP\Files\Storage\IStorageFactory $loader
+	 * @param View $recipientView
 	 */
-	public function __construct($storage, array $mountpoints, $arguments = null, $loader = null) {
+	public function __construct($storage, array $mountpoints, $arguments, $loader, $recipientView) {
 		$this->user = $arguments['user'];
-		$this->recipientView = new View('/' . $this->user . '/files');
+		$this->recipientView = $recipientView;
 
 		$this->superShare = $arguments['superShare'];
 		$this->groupedShares = $arguments['groupedShares'];
 
 		$newMountPoint = $this->verifyMountPoint($this->superShare, $mountpoints);
 		$absMountPoint = '/' . $this->user . '/files' . $newMountPoint;
-		$arguments['ownerView'] = new View('/' . $this->superShare->getShareOwner() . '/files');
 		parent::__construct($storage, $absMountPoint, $arguments, $loader);
 	}
 

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -79,6 +79,9 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 
 	private $options;
 
+	/** @var boolean */
+	private $sharingDisabledForUser;
+
 	public function __construct($arguments) {
 		$this->ownerView = $arguments['ownerView'];
 		$this->logger = \OC::$server->getLogger();
@@ -87,6 +90,11 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 		$this->groupedShares = $arguments['groupedShares'];
 
 		$this->user = $arguments['user'];
+		if (isset($arguments['sharingDisabledForUser'])) {
+			$this->sharingDisabledForUser = $arguments['sharingDisabledForUser'];
+		} else {
+			$this->sharingDisabledForUser = false;
+		}
 
 		parent::__construct([
 			'storage' => null,
@@ -193,7 +201,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 			$permissions |= \OCP\Constants::PERMISSION_DELETE;
 		}
 
-		if (\OCP\Util::isSharingDisabledForUser()) {
+		if ($this->sharingDisabledForUser) {
 			$permissions &= ~\OCP\Constants::PERMISSION_SHARE;
 		}
 

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -135,16 +135,19 @@ class UserMountCache implements IUserMountCache {
 	 * @return ICachedMountInfo[]
 	 */
 	private function findChangedMounts(array $newMounts, array $cachedMounts) {
+		$new = [];
+		foreach ($newMounts as $mount) {
+			$new[$mount->getRootId()] = $mount;
+		}
 		$changed = [];
-		foreach ($newMounts as $newMount) {
-			foreach ($cachedMounts as $cachedMount) {
+		foreach ($cachedMounts as $cachedMount) {
+			$rootId = $cachedMount->getRootId();
+			if (isset($new[$rootId])) {
+				$newMount = $new[$rootId];
 				if (
-					$newMount->getRootId() === $cachedMount->getRootId() &&
-					(
-						$newMount->getMountPoint() !== $cachedMount->getMountPoint() ||
-						$newMount->getStorageId() !== $cachedMount->getStorageId() ||
-						$newMount->getMountId() !== $cachedMount->getMountId()
-					)
+					$newMount->getMountPoint() !== $cachedMount->getMountPoint() ||
+					$newMount->getStorageId() !== $cachedMount->getStorageId() ||
+					$newMount->getMountId() !== $cachedMount->getMountId()
 				) {
 					$changed[] = $newMount;
 				}
@@ -197,7 +200,7 @@ class UserMountCache implements IUserMountCache {
 		}
 		$mount_id = $row['mount_id'];
 		if (!is_null($mount_id)) {
-			$mount_id = (int) $mount_id;
+			$mount_id = (int)$mount_id;
 		}
 		return new CachedMountInfo($user, (int)$row['storage_id'], (int)$row['root_id'], $row['mount_point'], $mount_id, isset($row['path']) ? $row['path'] : '');
 	}

--- a/lib/private/Files/Mount/Manager.php
+++ b/lib/private/Files/Mount/Manager.php
@@ -38,8 +38,12 @@ class Manager implements IMountManager {
 	/** @var CappedMemoryCache */
 	private $pathCache;
 
+	/** @var CappedMemoryCache */
+	private $inPathCache;
+
 	public function __construct() {
 		$this->pathCache = new CappedMemoryCache();
+		$this->inPathCache = new CappedMemoryCache();
 	}
 
 	/**
@@ -48,6 +52,7 @@ class Manager implements IMountManager {
 	public function addMount(IMountPoint $mount) {
 		$this->mounts[$mount->getMountPoint()] = $mount;
 		$this->pathCache->clear();
+		$this->inPathCache->clear();
 	}
 
 	/**
@@ -60,16 +65,18 @@ class Manager implements IMountManager {
 		}
 		unset($this->mounts[$mountPoint]);
 		$this->pathCache->clear();
+		$this->inPathCache->clear();
 	}
 
 	/**
 	 * @param string $mountPoint
 	 * @param string $target
 	 */
-	public function moveMount(string $mountPoint, string $target){
+	public function moveMount(string $mountPoint, string $target) {
 		$this->mounts[$target] = $this->mounts[$mountPoint];
 		unset($this->mounts[$mountPoint]);
 		$this->pathCache->clear();
+		$this->inPathCache->clear();
 	}
 
 	/**
@@ -87,7 +94,7 @@ class Manager implements IMountManager {
 		}
 
 		$current = $path;
-		while(true) {
+		while (true) {
 			$mountPoint = $current . '/';
 			if (isset($this->mounts[$mountPoint])) {
 				$this->pathCache[$path] = $this->mounts[$mountPoint];
@@ -114,6 +121,11 @@ class Manager implements IMountManager {
 	public function findIn(string $path): array {
 		\OC_Util::setupFS();
 		$path = $this->formatPath($path);
+
+		if (isset($this->inPathCache[$path])) {
+			return $this->inPathCache[$path];
+		}
+
 		$result = [];
 		$pathLength = \strlen($path);
 		$mountPoints = array_keys($this->mounts);
@@ -122,12 +134,15 @@ class Manager implements IMountManager {
 				$result[] = $this->mounts[$mountPoint];
 			}
 		}
+
+		$this->inPathCache[$path] = $result;
 		return $result;
 	}
 
 	public function clear() {
 		$this->mounts = [];
 		$this->pathCache->clear();
+		$this->inPathCache->clear();
 	}
 
 	/**

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1208,6 +1208,10 @@ class Manager implements IManager {
 	 * @throws ShareNotFound
 	 */
 	public function getShareByToken($token) {
+		// tokens can't be valid local user names
+		if ($this->userManager->userExists($token)) {
+			throw new ShareNotFound();
+		}
 		$share = null;
 		try {
 			if($this->shareApiAllowLinks()) {


### PR DESCRIPTION
Removes a number of loops.

Comparisons with 2k shares as the receiver:

Listing root folder with the shares in a subfolder: https://blackfire.io/profiles/compare/e0ff76bc-8d96-4842-9b34-37acaf446294/graph
Listing the folder containing all the shares: https://blackfire.io/profiles/compare/f6054929-f61e-43bb-8241-55550ecd5204/graph