### PR TITLE
[PoC] Make cookies lax cookies

### DIFF
--- a/lib/private/Session/CryptoWrapper.php
+++ b/lib/private/Session/CryptoWrapper.php
@@ -86,7 +86,19 @@ class CryptoWrapper {
 				if($webRoot === '') {
 					$webRoot = '/';
 				}
-				setcookie(self::COOKIE_NAME, $this->passphrase, 0, $webRoot, '', $secureCookie, true);
+				$header = sprintf(
+					'Set-Cookie: %s=%s; path=%s',
+					self::COOKIE_NAME,
+					$this->passphrase,
+					$webRoot
+				);
+				if ($secureCookie) {
+					$header .= '; Secure';
+				}
+				$header .= '; HttpOnly';
+				$header .= '; SameSite=Lax';
+				header($header);
+				//setcookie(self::COOKIE_NAME, $this->passphrase, 0, $webRoot, '', $secureCookie, true);
 			}
 		}
 	}

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -53,6 +53,26 @@ class Internal extends Session {
 		$this->invoke('session_name', [$name]);
 		try {
 			$this->invoke('session_start');
+
+			$id = $this->getId();
+
+			$secure = \OC::$server->getRequest()->getServerProtocol() === 'https';
+			$webRoot = \OC::$WEBROOT;
+			if($webRoot === '') {
+				$webRoot = '/';
+			}
+			$header = sprintf(
+				'Set-Cookie: %s=%s; path=%s',
+				$name,
+				$id,
+				$webRoot
+			);
+			if ($secure) {
+				$header .= '; Secure';
+			}
+			$header .= '; HttpOnly';
+			$header .= '; SameSite=Lax';
+			header($header, true);
 		} catch (\Exception $e) {
 			setcookie($this->invoke('session_name'), null, -1, \OC::$WEBROOT ?: '/');
 		}


### PR DESCRIPTION
:construction: 

Make the cookies lax cookies.

So if a 3rdparty website does a:
* FORM posts
* IFRAME
* AJAX
* IMAGE

it will not send the cookies. just like it does not send the strict and lax cookies we set for that purpose.

This would make https://github.com/nextcloud/calendar/issues/169#issuecomment-413976379 for example work

As the embedded iframe would not send any cookies then. So it is treated for everybody like a pure public page.

Todo:
- [ ] cookies set by the appframework controllers
- [ ] maybe others
- [ ] cleanup -> static helper function to do this would be best I think

I need to think a bit more about possible complications. But this seems like a step in the right direction.