### PR TITLE
Update help.php

### DIFF
--- a/settings/templates/help.php
+++ b/settings/templates/help.php
@@ -16,8 +16,8 @@
 	<?php } ?>
 
 		<li>
-			<a href="https://docs.nextcloud.org" target="_blank" rel="noreferrer noopener">
-				<?php p($l->t('Online documentation')); ?> ↗
+			<a href="https://docs.nextcloud.com" target="_blank" rel="noreferrer noopener">
+				<?php p($l->t('Documentation')); ?> ↗
 			</a>
 		</li>
 		<li>
@@ -25,20 +25,6 @@
 				<?php p($l->t('Forum')); ?> ↗
 			</a>
 		</li>
-
-	<?php if($_['admin']) { ?>
-		<li>
-			<a href="https://nextcloud.com/support/" target="_blank" rel="noreferrer noopener">
-				<?php p($l->t('Getting help')); ?> ↗
-			</a>
-		</li>
-	<?php } ?>
-
-	<li>
-		<a href="https://nextcloud.com/enterprise/" target="_blank" rel="noreferrer noopener">
-			<?php p($l->t('Commercial support')); ?> ↗
-		</a>
-	</li>
 </div>
 
 <div id="app-content" class="help-includes">


### PR DESCRIPTION
- docs.nextcloud.**com**
- simplify "Online Documentation" to "Documentation"
- remove Support and Commercial support-link as this is done by "Support" now and end-users are not interested in 😉 

Signed-off-by: Marius Blüm <marius@lineone.io>