### PR TITLE
[stable13] Make sure error_log() always receives a string

### DIFF
--- a/lib/private/Log/File.php
+++ b/lib/private/Log/File.php
@@ -144,6 +144,9 @@ class File {
 			error_log($entry);
 		}
 		if (php_sapi_name() === 'cli-server') {
+			if (!\is_string($message)) {
+				$message = json_encode($message);
+			}
 			error_log($message, 4);
 		}
 	}


### PR DESCRIPTION
Backport of #10355 