### PR TITLE
Fix backup codes column length for Argon2 values

### DIFF
--- a/apps/twofactor_backupcodes/appinfo/info.xml
+++ b/apps/twofactor_backupcodes/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Two factor backup codes</name>
 	<summary>A two-factor auth backup codes provider</summary>
 	<description>A two-factor auth backup codes provider</description>
-	<version>1.3.0</version>
+	<version>1.3.1</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<namespace>TwoFactorBackupCodes</namespace>

--- a/apps/twofactor_backupcodes/composer/composer/autoload_classmap.php
+++ b/apps/twofactor_backupcodes/composer/composer/autoload_classmap.php
@@ -19,6 +19,7 @@ return array(
     'OCA\\TwoFactorBackupCodes\\Migration\\Version1002Date20170607113030' => $baseDir . '/../lib/Migration/Version1002Date20170607113030.php',
     'OCA\\TwoFactorBackupCodes\\Migration\\Version1002Date20170919123342' => $baseDir . '/../lib/Migration/Version1002Date20170919123342.php',
     'OCA\\TwoFactorBackupCodes\\Migration\\Version1002Date20170926101419' => $baseDir . '/../lib/Migration/Version1002Date20170926101419.php',
+    'OCA\\TwoFactorBackupCodes\\Migration\\Version1002Date20180821043638' => $baseDir . '/../lib/Migration/Version1002Date20180821043638.php',
     'OCA\\TwoFactorBackupCodes\\Provider\\BackupCodesProvider' => $baseDir . '/../lib/Provider/BackupCodesProvider.php',
     'OCA\\TwoFactorBackupCodes\\Service\\BackupCodeStorage' => $baseDir . '/../lib/Service/BackupCodeStorage.php',
     'OCA\\TwoFactorBackupCodes\\Settings\\Personal' => $baseDir . '/../lib/Settings/Personal.php',

--- a/apps/twofactor_backupcodes/composer/composer/autoload_static.php
+++ b/apps/twofactor_backupcodes/composer/composer/autoload_static.php
@@ -34,6 +34,7 @@ class ComposerStaticInitTwoFactorBackupCodes
         'OCA\\TwoFactorBackupCodes\\Migration\\Version1002Date20170607113030' => __DIR__ . '/..' . '/../lib/Migration/Version1002Date20170607113030.php',
         'OCA\\TwoFactorBackupCodes\\Migration\\Version1002Date20170919123342' => __DIR__ . '/..' . '/../lib/Migration/Version1002Date20170919123342.php',
         'OCA\\TwoFactorBackupCodes\\Migration\\Version1002Date20170926101419' => __DIR__ . '/..' . '/../lib/Migration/Version1002Date20170926101419.php',
+        'OCA\\TwoFactorBackupCodes\\Migration\\Version1002Date20180821043638' => __DIR__ . '/..' . '/../lib/Migration/Version1002Date20180821043638.php',
         'OCA\\TwoFactorBackupCodes\\Provider\\BackupCodesProvider' => __DIR__ . '/..' . '/../lib/Provider/BackupCodesProvider.php',
         'OCA\\TwoFactorBackupCodes\\Service\\BackupCodeStorage' => __DIR__ . '/..' . '/../lib/Service/BackupCodeStorage.php',
         'OCA\\TwoFactorBackupCodes\\Settings\\Personal' => __DIR__ . '/..' . '/../lib/Settings/Personal.php',

--- a/apps/twofactor_backupcodes/lib/Migration/Version1002Date20180821043638.php
+++ b/apps/twofactor_backupcodes/lib/Migration/Version1002Date20180821043638.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\TwoFactorBackupCodes\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version1002Date20180821043638 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		$table = $schema->getTable('twofactor_backupcodes');
+
+		$table->getColumn('code')->setLength(128);
+
+		return $schema;
+	}
+
+}

--- a/apps/twofactor_backupcodes/tests/Db/BackupCodeMapperTest.php
+++ b/apps/twofactor_backupcodes/tests/Db/BackupCodeMapperTest.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace OCA\TwoFactorBackupCodes\Tests\Integration\Db;
+namespace OCA\TwoFactorBackupCodes\Tests\Db;
 
 use OCA\TwoFactorBackupCodes\Db\BackupCode;
 use OCA\TwoFactorBackupCodes\Db\BackupCodeMapper;

--- a/apps/twofactor_backupcodes/tests/Integration/Db/BackupCodeMapperTest.php
+++ b/apps/twofactor_backupcodes/tests/Integration/Db/BackupCodeMapperTest.php
@@ -109,4 +109,13 @@ class BackupCodeMapperTest extends TestCase {
 		$this->assertCount(0, $this->mapper->getBackupCodes($user));
 	}
 
+	public function testInsertArgonEncryptedCodes() {
+		$code = new BackupCode();
+		$code->setUserId($this->testUID);
+		$code->setCode('2|$argon2i$v=19$m=1024,t=2,p=2$MjJWUjRFWndtMm5BWGxOag$BusVxLeFyiLLWtaVvX/JRFBiPdZcjRrzpQ/rAhn6vqY');
+		$code->setUsed(1);
+
+		$this->mapper->insert($code);
+	}
+
 }

--- a/apps/twofactor_backupcodes/tests/Service/BackupCodeStorageTest.php
+++ b/apps/twofactor_backupcodes/tests/Service/BackupCodeStorageTest.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace OCA\TwoFactorBackupCodes\Tests\Integration\Service;
+namespace OCA\TwoFactorBackupCodes\Tests\Service;
 
 use OCA\TwoFactorBackupCodes\Service\BackupCodeStorage;
 use Test\TestCase;


### PR DESCRIPTION
The new (php7.2) hasher's values are a bit longer than the ones of the old algorithm, hence we have to increase the column length.

- [x] Add a failing test that reproduces the issue
- [x] Fix the issue

Fixes #10766.