### PR TITLE
check for empty string

### DIFF
--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -457,6 +457,10 @@ class Crypt {
 	 * @throws DecryptionFailedException
 	 */
 	public function symmetricDecryptFileContent($keyFileContents, $passPhrase, $cipher = self::DEFAULT_CIPHER, $version = 0, $position = 0) {
+		if ($keyFileContents == '') {
+			return '';
+		}
+
 		$catFile = $this->splitMetaData($keyFileContents, $cipher);
 
 		if ($catFile['signature'] !== false) {


### PR DESCRIPTION
Adding a check to see if keyFileContents is empty:

* this fixes a download error and an exception if the data content for encryption is empty
* #3958: for recovering encrypted files with a damaged signature this is necessary in addition to turning the signature check off

Signed-off-by: Stefan Weiberg <sweiberg@suse.com>