### PR TITLE
in 14 the click action gets lost in the Backbone view.

### DIFF
--- a/apps/systemtags/js/filesplugin.js
+++ b/apps/systemtags/js/filesplugin.js
@@ -49,10 +49,10 @@
 						systemTagsInfoViewToggleView.$el.detach();
 					});
 					systemTagsInfoViewToggleView.listenTo(detailView, 'post-render', function() {
+						var clicker = _.bind(systemTagsInfoViewToggleView.click, systemTagsInfoViewToggleView);
+						systemTagsInfoViewToggleView.$el.click(clicker);
 						detailView.$el.find('.file-details').append(systemTagsInfoViewToggleView.$el);
 					});
-
-					return;
 				}
 			});
 		}

--- a/apps/systemtags/js/systemtagsinfoviewtoggleview.js
+++ b/apps/systemtags/js/systemtagsinfoviewtoggleview.js
@@ -62,7 +62,6 @@
 		 * references the SystemTagsInfoView to associate to this toggle view.
 		 */
 		initialize: function(options) {
-			var self = this;
 			options = options || {};
 
 			this._systemTagsInfoView = options.systemTagsInfoView;


### PR DESCRIPTION
fixes #10774 – tagging a file does not work with the second time you open the sidebar

I am not sure this is the best way to fix it, but it works. For this at least. There should be some reason why the click action gets unbound in 14, I don't know why though and don't know where to look. Thus, not sure whether this can be a problem for other FilePlugins.