### PR TITLE
Fix loading providers of 2FA app with more than one provider

### DIFF
--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -174,6 +174,9 @@ class InfoParser {
 		if (isset($array['commands']['command']) && is_array($array['commands']['command'])) {
 			$array['commands'] = $array['commands']['command'];
 		}
+		if (isset($array['two-factor-providers']['provider']) && is_array($array['two-factor-providers']['provider'])) {
+			$array['two-factor-providers'] = $array['two-factor-providers']['provider'];
+		}
 		if (isset($array['activity']['filters']['filter']) && is_array($array['activity']['filters']['filter'])) {
 			$array['activity']['filters'] = $array['activity']['filters']['filter'];
 		}


### PR DESCRIPTION
Discovered in https://github.com/nextcloud/twofactor_gateway/projects/2:

info.xml with a single provider:
![bildschirmfoto von 2018-08-21 22-19-29](https://user-images.githubusercontent.com/1374172/44428619-30120e80-a595-11e8-847c-9642a471df10.png)

info.xml with multiple providers:
![bildschirmfoto von 2018-08-21 22-20-00](https://user-images.githubusercontent.com/1374172/44428632-386a4980-a595-11e8-97e7-199ab15512af.png)

This fixes the data structure to look the same no matter if one or more providers are specified.