### PR TITLE
prefer using dir instead of allinfo for getting smb file info

### DIFF
--- a/apps/files_external/3rdparty/icewind/smb/src/TimeZoneProvider.php
+++ b/apps/files_external/3rdparty/icewind/smb/src/TimeZoneProvider.php
@@ -35,7 +35,8 @@ class TimeZoneProvider {
 	public function get() {
 		if (!$this->timeZone) {
 			$net = $this->system->getNetPath();
-			if ($net) {
+			// for local domain names we can assume same timezone
+			if ($net && strpos($this->host, '.') !== false) {
 				$command = sprintf('%s time zone -S %s',
 					$net,
 					escapeshellarg($this->host)

--- a/apps/files_external/3rdparty/icewind/smb/src/TimeZoneProvider.php
+++ b/apps/files_external/3rdparty/icewind/smb/src/TimeZoneProvider.php
@@ -41,7 +41,10 @@ class TimeZoneProvider {
 					escapeshellarg($this->host)
 				);
 				$this->timeZone = exec($command);
-			} else { // fallback to server timezone
+			}
+
+			if ($this->timeZone) {
+				// fallback to server timezone
 				$this->timeZone = date_default_timezone_get();
 			}
 		}

--- a/apps/files_external/3rdparty/icewind/smb/src/Wrapped/Share.php
+++ b/apps/files_external/3rdparty/icewind/smb/src/Wrapped/Share.php
@@ -13,6 +13,7 @@ use Icewind\SMB\Exception\DependencyException;
 use Icewind\SMB\Exception\FileInUseException;
 use Icewind\SMB\Exception\InvalidTypeException;
 use Icewind\SMB\Exception\NotFoundException;
+use Icewind\SMB\IFileInfo;
 use Icewind\SMB\INotifyHandler;
 use Icewind\SMB\IServer;
 use Icewind\SMB\System;

--- a/apps/files_external/3rdparty/icewind/smb/src/Wrapped/Share.php
+++ b/apps/files_external/3rdparty/icewind/smb/src/Wrapped/Share.php
@@ -153,6 +153,18 @@ class Share extends AbstractShare {
 	 * @return \Icewind\SMB\IFileInfo
 	 */
 	public function stat($path) {
+		// some windows server setups don't seem to like the allinfo command
+		// use the dir command instead to get the file info where possible
+		if ($path !== "" && $path !== "/") {
+			$parent = dirname($path);
+			$dir = $this->dir($parent);
+			$file = array_values(array_filter($dir, function(IFileInfo $info) use ($path) {
+				return $info->getPath() === $path;
+			}));
+			if ($file) {
+				return $file[0];
+			}
+		}
 		$escapedPath = $this->escapePath($path);
 		$output = $this->execute('allinfo ' . $escapedPath);
 		// Windows and non Windows Fileserver may respond different


### PR DESCRIPTION
some windows server setups don't seem to like the allinfo command use the dir command instead to get the file info where possible.

Also includes some improvements for the timezone detection to properly handle cases where the command errors out.