### PR TITLE
returning of $tr is expected, otherwise ending up in a JS error

### DIFF
--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -167,6 +167,7 @@
 
 		updateRow: function($tr, fileInfo, options) {
 			// no-op, suppress re-rendering
+			return $tr;
 		},
 
 		reload: function() {


### PR DESCRIPTION
Slipped through in #10700 🙊

in apps/files/js/filelist.js::getModelForFile() it is expected