### PR TITLE
[LDAP] The WebUI Wizard also should not assign empty config IDs

### DIFF
--- a/apps/user_ldap/lib/Settings/Admin.php
+++ b/apps/user_ldap/lib/Settings/Admin.php
@@ -49,6 +49,14 @@ class Admin implements ISettings {
 	public function getForm() {
 		$helper = new Helper(\OC::$server->getConfig());
 		$prefixes = $helper->getServerConfigurationPrefixes();
+		if(count($prefixes) === 0) {
+			$newPrefix = $helper->getNextServerConfigurationPrefix();
+			$config = new Configuration($newPrefix, false);
+			$config->setConfiguration($config->getDefaults());
+			$config->saveConfiguration();
+			$prefixes[] = $newPrefix;
+		}
+
 		$hosts = $helper->getServerConfigurationHosts();
 
 		$wControls = new Template('user_ldap', 'part.wizardcontrols');
@@ -62,7 +70,9 @@ class Admin implements ISettings {
 		$parameters['wizardControls'] = $wControls;
 
 		// assign default values
-		$config = new Configuration('', false);
+		if(!isset($config)) {
+			$config = new Configuration('', false);
+		}
 		$defaults = $config->getDefaults();
 		foreach($defaults as $key => $default) {
 			$parameters[$key.'_default'] = $default;

--- a/apps/user_ldap/templates/part.wizard-server.php
+++ b/apps/user_ldap/templates/part.wizard-server.php
@@ -1,18 +1,13 @@
 <fieldset id="ldapWizard1">
 		<p>
 		<select id="ldap_serverconfig_chooser" name="ldap_serverconfig_chooser">
-		<?php if(count($_['serverConfigurationPrefixes']) === 0 ) {
+		<?php
+		$i = 1;
+		$sel = ' selected';
+		foreach($_['serverConfigurationPrefixes'] as $prefix) {
 			?>
-				<option value="" selected><?php p($l->t('1. Server'));?></option>');
+			<option value="<?php p($prefix); ?>"<?php p($sel); $sel = ''; ?>><?php p($l->t('%s. Server:', array($i++)));?> <?php p(' '.$_['serverConfigurationHosts'][$prefix]); ?></option>
 			<?php
-		} else {
-			$i = 1;
-			$sel = ' selected';
-			foreach($_['serverConfigurationPrefixes'] as $prefix) {
-				?>
-				<option value="<?php p($prefix); ?>"<?php p($sel); $sel = ''; ?>><?php p($l->t('%s. Server:', array($i++)));?> <?php p(' '.$_['serverConfigurationHosts'][$prefix]); ?></option>
-				<?php
-			}
 		}
 		?>
 		</select>

--- a/apps/user_ldap/tests/Settings/AdminTest.php
+++ b/apps/user_ldap/tests/Settings/AdminTest.php
@@ -56,10 +56,8 @@ class AdminTest extends TestCase {
 	 * @UseDB
 	 */
 	public function testGetForm() {
-
-		$helper = new Helper(\OC::$server->getConfig());
-		$prefixes = $helper->getServerConfigurationPrefixes();
-		$hosts = $helper->getServerConfigurationHosts();
+		$prefixes = ['s01'];
+		$hosts = ['s01' => ''];
 
 		$wControls = new Template('user_ldap', 'part.wizardcontrols');
 		$wControls = $wControls->fetchPage();


### PR DESCRIPTION
With 689df9a the behaviour to assign only non-empty config IDs was introduced. Only, this was only effective for CLI and OCS API.

Related to #3270.

The web UI creates now also a full configuration on first load. This fixes #5094.
