### PR TITLE
Fix mimetype detection for junked uploads

### DIFF
--- a/apps/workflowengine/lib/Check/FileMimeType.php
+++ b/apps/workflowengine/lib/Check/FileMimeType.php
@@ -83,9 +83,13 @@ class FileMimeType extends AbstractStringCheck {
 				return $this->mimeType[$this->storage->getId()][$this->path];
 			}
 
-			if ($this->request->getMethod() === 'PUT') {
-				$path = $this->request->getPathInfo();
-				$this->mimeType[$this->storage->getId()][$this->path] = $this->mimeTypeDetector->detectPath($path);
+			if ($this->request->getMethod() === 'PUT' || $this->request->getMethod() === 'MOVE') {
+				if ($this->request->getMethod() === 'MOVE') {
+					$this->mimeType[$this->storage->getId()][$this->path] = $this->mimeTypeDetector->detectPath($this->path);
+				} else {
+					$path = $this->request->getPathInfo();
+					$this->mimeType[$this->storage->getId()][$this->path] = $this->mimeTypeDetector->detectPath($path);
+				}
 				return $this->mimeType[$this->storage->getId()][$this->path];
 			}
 		} else if ($this->isPublicWebDAVRequest()) {
@@ -171,7 +175,9 @@ class FileMimeType extends AbstractStringCheck {
 			$this->request->getPathInfo() === '/webdav' ||
 			strpos($this->request->getPathInfo(), '/webdav/') === 0 ||
 			$this->request->getPathInfo() === '/dav/files' ||
-			strpos($this->request->getPathInfo(), '/dav/files/') === 0
+			strpos($this->request->getPathInfo(), '/dav/files/') === 0 ||
+			$this->request->getPathInfo() === '/dav/uploads' ||
+			strpos($this->request->getPathInfo(), '/dav/uploads/') === 0
 		);
 	}
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/files_accesscontrol/issues/108

1. Enable Files access control
2. Add rule to block file mimetype is `application/x-ms-dos-executable`
3. Download one from https://download.nextcloud.com/desktop/releases/Windows/
4. Upload it
5. Should be blocked, but still works.