### PR TITLE
disallow negative mtime in dav search

### DIFF
--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -352,7 +352,7 @@ class FileSearchBackend implements ISearchBackend {
 				return 0 + $value;
 			case SearchPropertyDefinition::DATATYPE_DATETIME:
 				if (is_numeric($value)) {
-					return 0 + $value;
+					return max(0, 0 + $value);
 				}
 				$date = \DateTime::createFromFormat(\DateTime::ATOM, $value);
 				return ($date instanceof \DateTime) ? $date->getTimestamp() : 0;


### PR DESCRIPTION
Prevents potential errors from the database when a client provides an invalid mtime