### PR TITLE
Fix contactsmenu for mentioned users in comments

### DIFF
--- a/apps/comments/css/comments.scss
+++ b/apps/comments/css/comments.scss
@@ -198,7 +198,6 @@
 	padding-left: 40px;
 	word-wrap: break-word;
 	overflow-wrap: break-word;
-	overflow: hidden;
 }
 
 #commentsTabView .comment .action {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/3404133/44620439-86809500-a894-11e8-8c51-32261ffe531b.png)

After:
![image](https://user-images.githubusercontent.com/3404133/44620437-79fc3c80-a894-11e8-8ed4-c213994918f2.png)
