### PR TITLE
Fix public pages conflicting

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -77,6 +77,8 @@ body {
 	min-height: 128px;
 	max-height: 200px;
 	margin: 0 auto;
+	position: relative;
+	left: unset;
 }
 
 #header .logo img {


### PR DESCRIPTION
@nextcloud/designers 

Since we allowed scss on public pages there was conflicting css properties with the guest.css file

![capture d ecran_2018-08-25_14-27-38](https://user-images.githubusercontent.com/14975046/44626418-161d5680-a91c-11e8-9b98-ff3cefd8e6a9.png)
