### PR TITLE
cast timestamps older than unix epoch to 0

### DIFF
--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -355,7 +355,7 @@ class FileSearchBackend implements ISearchBackend {
 					return max(0, 0 + $value);
 				}
 				$date = \DateTime::createFromFormat(\DateTime::ATOM, $value);
-				return ($date instanceof \DateTime) ? $date->getTimestamp() : 0;
+				return ($date instanceof \DateTime && $date->getTimestamp() !== false) ? $date->getTimestamp() : 0;
 			default:
 				return $value;
 		}


### PR DESCRIPTION
This change solves issues #10870, which is caused by method castValue of class FileSearchBackend: It casts the timestamps older than the unix epoch to false., see my comment https://github.com/nextcloud/server/pull/10835#discussion_r212806153.