### PR TITLE
Clears the local storage after logout

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -130,7 +130,10 @@ class LoginController extends Controller {
 		}
 		$this->userSession->logout();
 
-		$response = new RedirectResponse($this->urlGenerator->linkToRouteAbsolute('core.login.showLoginForm'));
+		$response = new RedirectResponse($this->urlGenerator->linkToRouteAbsolute(
+			'core.login.showLoginForm',
+			['clear' => true] // this param the the code in login.js may be removed when the "Clear-Site-Data" is working in the browsers
+		));
 		$response->addHeader('Clear-Site-Data', '"cache", "storage", "executionContexts"');
 		return $response;
 	}

--- a/core/js/login.js
+++ b/core/js/login.js
@@ -41,4 +41,10 @@ $(document).ready(function() {
 	$('form[name=login]').submit(OC.Login.onLogin);
 
 	$('#remember_login').click(OC.Login.rememberLogin);
+
+	var clearParamRegex = new RegExp('clear=1');
+	if (clearParamRegex.test(window.location.href)) {
+		window.localStorage.clear();
+		window.sessionStorage.clear();
+	}
 });


### PR DESCRIPTION
The logout controller adds a param to the redirect url. Then the login code checks if it's there and clears the local storage. I also added a note this can be taken out again if the browsers support `Clear-Site-Data` properly.

closes #10859