### PR TITLE
Fix app menu calculation for random size of the right header

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1562,13 +1562,14 @@ function initCore() {
 
 	var resizeMenu = function() {
 		var appList = $('#appmenu li');
-		var headerWidth = $('.header-left').outerWidth() - $('#nextcloud').outerWidth();
+		var rightHeaderWidth = $('.header-right').outerWidth();
+		var headerWidth = $('header').outerWidth();
 		var usePercentualAppMenuLimit = 0.33;
 		var minAppsDesktop = 8;
-		var availableWidth = headerWidth - $(appList).width();
+		var availableWidth =  headerWidth - $('#nextcloud').outerWidth() - (rightHeaderWidth > 210 ? rightHeaderWidth : 210)
 		var isMobile = $(window).width() < 768;
 		if (!isMobile) {
-			availableWidth = headerWidth * usePercentualAppMenuLimit;
+			availableWidth = availableWidth * usePercentualAppMenuLimit;
 		}
 		var appCount = Math.floor((availableWidth / $(appList).width()));
 		if (isMobile && appCount > minAppsDesktop) {
@@ -1613,7 +1614,7 @@ function initCore() {
 		}
 	};
 	$(window).resize(resizeMenu);
-	resizeMenu();
+	setTimeout(resizeMenu, 0);
 
 	// just add snapper for logged in users
 	if($('#app-navigation').length && !$('html').hasClass('lte9')) {

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -573,6 +573,10 @@ describe('Core base tests', function() {
 		});
 		it('Clicking menu toggle toggles navigation in', function() {
 			window.initCore();
+			// fore show more apps icon since otherwise it would be hidden since no icons are available
+			clock.tick(1 * 1000);
+			$('#more-apps').show();
+			
 			expect($navigation.is(':visible')).toEqual(false);
 			$toggle.click();
 			clock.tick(1 * 1000);


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/10857

This PR will ensure that at least 210px of space is kept available for the right header icons. The issue in #10857 was that the number of icons to show was calculated before all right icons where loaded. This leads to different behaviour when resizing the window/loading an app that doesn't have a search.