### PR TITLE
Fix drag shadow in Files app

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -612,7 +612,7 @@ table tr.summary td {
 
 table.dragshadow {
 	width:auto;
-	z-index: 100;
+	z-index: 2000;
 }
 table.dragshadow td.filename {
 	padding-left:60px;

--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -618,6 +618,9 @@ table.dragshadow td.filename {
 	padding-left:60px;
 	padding-right:16px;
 	height: 36px;
+
+	/* Override "max-width: 0" to prevent file name and size from overlapping */
+	max-width: unset;
 }
 table.dragshadow td.size {
 	padding-right:8px;


### PR DESCRIPTION
[Due to the increased 'z-index` in the content children](https://github.com/nextcloud/server/commit/248b786bd0e9fdb01af8aa43af5f763d029d5c2e) the drag shadow was no longer visible.

Besides that, once the drag shadow was made visible again the file size overlapped the file name. This was caused by `max-width: 0` set for file names, which was introduced in https://github.com/nextcloud/server/commit/cbdaa8b7ce041ddb7768fa374c1b65e2515f9b2e; as it is necessary for the general file list that limit is removed only for file names in drag shadows.

**How to test:**
-Open the Files app
-Drag a file (press down with the mouse on the file and move it) anywhere

**Expected result:**
The file name and its size follow the cursor when it is moved

**Actual result:**
No element follows the cursor while the file is being dragged
