### PR TITLE
ensure we always return an array from `Request::getParams`

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -358,7 +358,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 * @return array the array with all parameters
 	 */
 	public function getParams(): array {
-		return $this->parameters;
+		return is_array($this->parameters) ? $this->parameters : [];
 	}
 
 	/**


### PR DESCRIPTION
It seems to for (some?) PUT requests, the `params` property gets set to a resource instead of an array.

Since an array is what is expected here by apps (it has been always documented like that iirc), instead of changing the return type to `array|resource` we just return an empty array if it isn't an array already.