### PR TITLE
use the same ignored properties list for both CustomerPropertiesBackends

### DIFF
--- a/apps/dav/lib/Connector/Sabre/CustomPropertiesBackend.php
+++ b/apps/dav/lib/Connector/Sabre/CustomPropertiesBackend.php
@@ -47,7 +47,6 @@ class CustomPropertiesBackend implements BackendInterface {
 		'{DAV:}getetag',
 		'{DAV:}quota-used-bytes',
 		'{DAV:}quota-available-bytes',
-		'{DAV:}quota-available-bytes',
 		'{http://owncloud.org/ns}permissions',
 		'{http://owncloud.org/ns}downloadURL',
 		'{http://owncloud.org/ns}dDC',

--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -49,6 +49,7 @@ class CustomPropertiesBackend implements BackendInterface {
 		'{http://owncloud.org/ns}downloadURL',
 		'{http://owncloud.org/ns}dDC',
 		'{http://owncloud.org/ns}size',
+		'{http://nextcloud.org/ns}is-encrypted',
 	);
 
 	/**


### PR DESCRIPTION
Why we have 2 `CustomerPropertiesBackend`s, the world might never know, but at least this saves a DB request per file if the e2ee app is disabled.