### PR TITLE
Use the existing info from the share root to get source storage and path 

### DIFF
--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -124,8 +124,9 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 		$this->initialized = true;
 		try {
 			Filesystem::initMountPoints($this->superShare->getShareOwner());
-			$sourcePath = $this->ownerView->getPath($this->superShare->getNodeId());
-			list($this->nonMaskedStorage, $this->rootPath) = $this->ownerView->resolvePath($sourcePath);
+			$this->rootPath = $this->getSourceRootInfo()->getPath();
+			$mounts = $this->ownerView->getMountByNumericId($this->getSourceRootInfo()->getStorageId());
+			$this->nonMaskedStorage = $mounts[0]->getStorage();
 			$this->storage = new PermissionsMask([
 				'storage' => $this->nonMaskedStorage,
 				'mask' => $this->superShare->getPermissions()

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -126,11 +126,17 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 			Filesystem::initMountPoints($this->superShare->getShareOwner());
 			$this->rootPath = $this->getSourceRootInfo()->getPath();
 			$mounts = $this->ownerView->getMountByNumericId($this->getSourceRootInfo()->getStorageId());
-			$this->nonMaskedStorage = $mounts[0]->getStorage();
-			$this->storage = new PermissionsMask([
-				'storage' => $this->nonMaskedStorage,
-				'mask' => $this->superShare->getPermissions()
-			]);
+			if(!$mounts) {
+				$this->storage = new FailedStorage(['exception' => new \Exception('Mount for source storage not found')]);
+				$this->cache = new FailedCache();
+				$this->rootPath = '';
+			} else {
+				$this->nonMaskedStorage = $mounts[0]->getStorage();
+				$this->storage = new PermissionsMask([
+					'storage' => $this->nonMaskedStorage,
+					'mask' => $this->superShare->getPermissions()
+				]);
+			}
 		} catch (NotFoundException $e) {
 			// original file not accessible or deleted, set FailedStorage
 			$this->storage = new FailedStorage(['exception' => $e]);

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -214,6 +214,17 @@ class View {
 	}
 
 	/**
+	 * @param int $id
+	 * @return IMountPoint[]
+	 */
+	public function getMountByNumericId($id) {
+		$mounts = Filesystem::getMountByNumericId($id);
+		return array_values(array_filter($mounts, function(IMountPoint $mountPoint) {
+			return $this->getRelativePath($mountPoint->getMountPoint()) || $mountPoint->getInternalPath($this->fakeRoot);
+		}));
+	}
+
+	/**
 	 * resolve a path to a storage and internal path
 	 *
 	 * @param string $path


### PR DESCRIPTION
Also includes an improvement for `getMountByNumericId` to ensure we don't lose all the improvements we've gained there.

Saves 1 query per incoming share.