### PR TITLE
Fix SCSS variable management with the theming app

### DIFF
--- a/apps/accessibility/lib/Controller/AccessibilityController.php
+++ b/apps/accessibility/lib/Controller/AccessibilityController.php
@@ -149,8 +149,8 @@ class AccessibilityController extends Controller {
 			try {
 				$css .= $scss->compile(
 					$imports .
-					'@import "variables.scss";' .
 					$this->getInjectedVariables() .
+					'@import "variables.scss";' .
 					'@import "css-variables.scss";'
 				);
 			} catch (ParserException $e) {

--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -71,6 +71,11 @@
 			@include icon-color('checkbox-mark', 'actions', $color-white, 1, true);
 		}
 	}
+	#body-user {
+		.primary {
+			border: 1px solid transparent;
+		}
+	}
 } @else {
 	#appmenu:not(.inverted) svg {
 		filter: none;

--- a/apps/theming/lib/Util.php
+++ b/apps/theming/lib/Util.php
@@ -79,7 +79,7 @@ class Util {
 	public function elementColor($color) {
 		$l = $this->calculateLuminance($color);
 		if($l>0.8) {
-			return '#555555';
+			return '#dddddd';
 		}
 		return $color;
 	}

--- a/apps/theming/tests/CapabilitiesTest.php
+++ b/apps/theming/tests/CapabilitiesTest.php
@@ -74,7 +74,7 @@ class CapabilitiesTest extends TestCase  {
 				'slogan' => 'slogan',
 				'color' => '#FFFFFF',
 				'color-text' => '#000000',
-				'color-element' => '#555555',
+				'color-element' => '#dddddd',
 				'logo' => 'http://absolute/logo',
 				'background' => 'http://absolute/background',
 				'background-plain' => false,

--- a/apps/theming/tests/UtilTest.php
+++ b/apps/theming/tests/UtilTest.php
@@ -105,7 +105,7 @@ class UtilTest extends TestCase {
 
 	public function testElementColorOnBrightBackground() {
 		$elementColor = $this->util->elementColor('#ffffff');
-		$this->assertEquals('#555555', $elementColor);
+		$this->assertEquals('#dddddd', $elementColor);
 	}
 
 	public function testGenerateRadioButtonWhite() {

--- a/core/css/variables.scss
+++ b/core/css/variables.scss
@@ -38,8 +38,8 @@ $color-main-background: #fff !default;
 $color-background-dark: nc-darken($color-main-background, 7%) !default;
 $color-background-darker: nc-darken($color-main-background, 14%) !default;
 
-$color-primary: #0082c9;
-$color-primary-text: #ffffff;
+$color-primary: #0082c9 !default;
+$color-primary-text: #ffffff !default;
 // do not use nc-darken/lighten in case of overriding because
 // primary-text is independent of color-main-text
 $color-primary-text-dark: darken($color-primary-text, 7%) !default;

--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -284,9 +284,9 @@ class SCSSCacher {
 		try {
 			$compiledScss = $scss->compile(
 				'$webroot: \'' . $this->getRoutePrefix() . '\';' .
+				$this->getInjectedVariables() .
 				'@import "variables.scss";' .
 				'@import "functions.scss";' .
-				$this->getInjectedVariables() .
 				'@import "' . $fileNameSCSS . '";');
 		} catch (ParserException $e) {
 			$this->logger->error($e, ['app' => 'core']);
@@ -349,7 +349,7 @@ class SCSSCacher {
 		}
 		$variables = '';
 		foreach ($this->defaults->getScssVariables() as $key => $value) {
-			$variables .= '$' . $key . ': ' . $value . ';';
+			$variables .= '$' . $key . ': ' . $value . ' !default;';
 		}
 
 		// check for valid variables / otherwise fall back to defaults


### PR DESCRIPTION
As discussed with @skjnldsv this way we can make sure, that all color calculations in the variables.scss can also use the values from the theming app.

This also fixes https://github.com/nextcloud/server/issues/10901

## Before
Regular
> ![bildschirmfoto von 2018-08-28 16-10-00](https://user-images.githubusercontent.com/213943/44728503-fb461000-aadc-11e8-937f-cdaf16f8f053.png)

Hover
> ![bildschirmfoto von 2018-08-28 16-10-02](https://user-images.githubusercontent.com/213943/44728505-fbdea680-aadc-11e8-878b-ef536acb6adb.png)

## After

Regular:
![image](https://user-images.githubusercontent.com/3404133/44796444-4deefd00-abad-11e8-96be-c7e972c909f5.png)

Hover:
![image](https://user-images.githubusercontent.com/3404133/44796429-462f5880-abad-11e8-9f07-3bede054f9da.png)
