### PR TITLE
Use main text color for editable divs and text areas

### DIFF
--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -192,7 +192,7 @@ button, .button {
 }
 
 textarea, div[contenteditable=true] {
-	color: var(--color-text-lighter);
+	color: var(--color-main-text);
 	cursor: text;
 	font-family: inherit;
 	height: auto;


### PR DESCRIPTION
As discussed with @jancborchardt; no idea of what to do with other types of text areas like one-line input fields.

Before:
![editable-div-color-before](https://user-images.githubusercontent.com/26858233/44798706-7deccf00-abb2-11e8-8f23-27955bed6af8.png)

After:
![editable-div-color-after](https://user-images.githubusercontent.com/26858233/44798711-804f2900-abb2-11e8-8d20-927f8e05f7fe.png)

@nextcloud/designers 