### PR TITLE
Change password expiration time from 12h to 7d

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -187,7 +187,7 @@ class LostController extends Controller {
 			throw new \Exception($this->l10n->t('Couldn\'t reset password because the token is invalid'));
 		}
 
-		if ($splittedToken[0] < ($this->timeFactory->getTime() - 60*60*12) ||
+		if ($splittedToken[0] < ($this->timeFactory->getTime() - 60*60*24*7) ||
 			$user->getLastLogin() > $splittedToken[0]) {
 			throw new \Exception($this->l10n->t('Couldn\'t reset password because the token is expired'));
 		}

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -584,7 +584,7 @@ class LostControllerTest extends \Test\TestCase {
 			->with('ValidTokenUser')
 			->willReturn($this->existingUser);
 		$this->timeFactory->method('getTime')
-			->willReturn(55546);
+			->willReturn(617146);
 
 		$this->crypto->method('decrypt')
 			->with(


### PR DESCRIPTION
We use the same logic for creating accounts without a password and there the 12h is a bit short. Users don't expect that the signup link needs to be clicked within 12h - 7d should be a more expected behavior.

See #10776 

Additionally there should be a button to request a new token.