### PR TITLE
Fix handlng of concurrent inserts of the 2FA provider registry DAO

### DIFF
--- a/lib/private/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDao.php
+++ b/lib/private/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDao.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 
 namespace OC\Authentication\TwoFactorAuth\Db;
 
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
@@ -72,25 +73,7 @@ class ProviderUserAssignmentDao {
 	public function persist(string $providerId, string $uid, int $enabled) {
 		$qb = $this->conn->getQueryBuilder();
 
-		$this->conn->beginTransaction();
-		// To prevent duplicate primary key, we have to first check if an INSERT
-		// or UPDATE is required
-		$query = $qb->select('*')
-			->from(self::TABLE_NAME)
-			->where($qb->expr()->eq('provider_id', $qb->createNamedParameter($providerId)))
-			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($uid)));
-		$result = $query->execute();
-		$rowCount = count($result->fetchAll());
-		$result->closeCursor();
-
-		if ($rowCount > 0) {
-			// There is an entry -> update it
-			$updateQuery = $qb->update(self::TABLE_NAME)
-				->set('enabled', $qb->createNamedParameter($enabled))
-				->where($qb->expr()->eq('provider_id', $qb->createNamedParameter($providerId)))
-				->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($uid)));
-			$updateQuery->execute();
-		} else {
+		try {
 			// Insert a new entry
 			$insertQuery = $qb->insert(self::TABLE_NAME)->values([
 				'provider_id' => $qb->createNamedParameter($providerId),
@@ -99,8 +82,14 @@ class ProviderUserAssignmentDao {
 			]);
 
 			$insertQuery->execute();
+		} catch (UniqueConstraintViolationException $ex) {
+			// There is already an entry -> update it
+			$updateQuery = $qb->update(self::TABLE_NAME)
+				->set('enabled', $qb->createNamedParameter($enabled))
+				->where($qb->expr()->eq('provider_id', $qb->createNamedParameter($providerId)))
+				->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($uid)));
+			$updateQuery->execute();
 		}
-		$this->conn->commit();
 
 	}
 


### PR DESCRIPTION
This was discovered by Sentry once on my private instance and so far I have not been able to reproduce this. Still, the way I implemented this before is prone to concurrency issues.

The problem originates from https://github.com/nextcloud/server/blob/2a2261587921c80123b5077d16fcbde2a45c1a95/lib/private/Authentication/TwoFactorAuth/Manager.php#L160. In this method, we attempt to insert entries for all providers that weren't known before. So if two or more requests concurrently hit section https://github.com/nextcloud/server/blob/2a2261587921c80123b5077d16fcbde2a45c1a95/lib/private/Authentication/TwoFactorAuth/Manager.php#L225-L228, they all try to persist the provider state.

I was unable to reproduce this with benchmarking tools and high numbers of concurrent requests, so I used the debugger to simulate it.

Steps to reproduce:
* Delete the backup codes entry in the `oc_twofactor_providers` table of your test user
* Set breakpoint at https://github.com/nextcloud/server/blob/2a2261587921c80123b5077d16fcbde2a45c1a95/lib/private/Authentication/TwoFactorAuth/Manager.php#L228
* Wait for your IDE to stop the php execution
* Re-insert the backup codes line deleted above
* Continue php execution

Before this patch: :boom: 

With this patch: exception is caught and update is run instead.

cc @rullzer @MorrisJobke as discussed at the conf.