### PR TITLE
Fix overflow x scroll on app content list

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -1078,10 +1078,10 @@ $popovericon-size: 16px;
 				order: 4;
 				width: 24px;
 				height: 24px;
-				margin: -10px;
+				margin: -7px; // right padding of item
 				padding: 22px;
 				opacity: .3;
-					cursor: pointer;
+				cursor: pointer;
 				&:hover,
 				&:focus {
 					opacity: .7;
@@ -1196,7 +1196,7 @@ $popovericon-size: 16px;
 			opacity: .5;
 			order: 3;
 			flex: 1 0;
-			flex-basis: calc(100% - 24px);
+			flex-basis: calc(100% - 44px);
 		}
 
 		.app-content-list-item-details {


### PR DESCRIPTION
There was a small overflow on the right of the items.
Notice the small white space on the right just next the scrollbar

|Before | After|
|:--:|:--:|
| ![capture d ecran_2018-08-31_12-21-59](https://user-images.githubusercontent.com/14975046/44907536-85c68380-ad18-11e8-8634-bd768e2af902.png)|![capture d ecran_2018-08-31_12-22-18](https://user-images.githubusercontent.com/14975046/44907535-852ded00-ad18-11e8-8bd2-792d8a586281.png) |


