### PR TITLE
remove LogicException, because it's also triggered with legitimate parameters

### DIFF
--- a/apps/dav/lib/CalDAV/Plugin.php
+++ b/apps/dav/lib/CalDAV/Plugin.php
@@ -28,10 +28,16 @@ class Plugin extends \Sabre\CalDAV\Plugin {
 	const SYSTEM_CALENDAR_ROOT = 'system-calendars';
 
 	/**
-	 * @inheritdoc
+	 * Returns the path to a principal's calendar home.
+	 *
+	 * The return url must not end with a slash.
+	 * This function should return null in case a principal did not have
+	 * a calendar home.
+	 *
+	 * @param string $principalUrl
+	 * @return string|null
 	 */
-	function getCalendarHomeForPrincipal($principalUrl):string {
-
+	function getCalendarHomeForPrincipal($principalUrl) {
 		if (strrpos($principalUrl, 'principals/users', -strlen($principalUrl)) !== false) {
 			list(, $principalId) = \Sabre\Uri\split($principalUrl);
 			return self::CALENDAR_ROOT . '/' . $principalId;
@@ -44,8 +50,6 @@ class Plugin extends \Sabre\CalDAV\Plugin {
 			list(, $principalId) = \Sabre\Uri\split($principalUrl);
 			return self::SYSTEM_CALENDAR_ROOT . '/calendar-rooms/' . $principalId;
 		}
-
-		throw new \LogicException('This is not supposed to happen');
 	}
 
 }

--- a/apps/dav/lib/CardDAV/Plugin.php
+++ b/apps/dav/lib/CardDAV/Plugin.php
@@ -39,10 +39,9 @@ class Plugin extends \Sabre\CardDAV\Plugin {
 	 * Returns the addressbook home for a given principal
 	 *
 	 * @param string $principal
-	 * @return string
+	 * @return string|null
 	 */
 	protected function getAddressbookHomeForPrincipal($principal) {
-
 		if (strrpos($principal, 'principals/users', -strlen($principal)) !== false) {
 			list(, $principalId) = \Sabre\Uri\split($principal);
 			return self::ADDRESSBOOK_ROOT . '/users/' . $principalId;
@@ -55,8 +54,6 @@ class Plugin extends \Sabre\CardDAV\Plugin {
 			list(, $principalId) = \Sabre\Uri\split($principal);
 			return self::ADDRESSBOOK_ROOT . '/system/' . $principalId;
 		}
-
-		throw new \LogicException('This is not supposed to happen');
 	}
 
 	/**

--- a/apps/dav/tests/unit/CalDAV/PluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/PluginTest.php
@@ -63,11 +63,7 @@ class PluginTest extends TestCase  {
 		$this->assertSame($expected, $this->plugin->getCalendarHomeForPrincipal($input));
 	}
 
-	/**
-	 * @expectedException        \LogicException
-	 * @expectedExceptionMessage This is not supposed to happen
-	 */
 	public function testGetCalendarHomeForUnknownPrincipal() {
-		$this->plugin->getCalendarHomeForPrincipal('FOO/BAR/BLUB');
+		$this->assertNull($this->plugin->getCalendarHomeForPrincipal('FOO/BAR/BLUB'));
 	}
 }


### PR DESCRIPTION
fixes #10727 

Removes the LogicException, that was introduced by https://github.com/nextcloud/server/commit/2da510af0b537e3bef7d0563eff828bade51fcbd?diff=split#diff-1aec04ba25037067a4d2c1fc323ed253

removed in `getCalendarHomeForPrincipal`, because it doesn't provide calendar-homes for:
- `principals/groups/...`
- `principals/system/...`

removed in `getAddressbookHomeForPrincipal`, because it doesn't provide addressBook-homes for:
- `principals/calendar-resources/...`
- `principals/calendar-rooms/...`