### PR TITLE
Updates logo scss to regard default values and updates favicon upload check

### DIFF
--- a/apps/theming/lib/Controller/IconController.php
+++ b/apps/theming/lib/Controller/IconController.php
@@ -115,7 +115,7 @@ class IconController extends Controller {
 		$response = null;
 		$iconFile = null;
 		try {
-			$iconFile = $this->imageManager->getImage('favicon');
+			$iconFile = $this->imageManager->getImage('favicon', false);
 			$response = new FileDisplayResponse($iconFile, Http::STATUS_OK, ['Content-Type' => 'image/x-icon']);
 		} catch (NotFoundException $e) {
 		}

--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -265,7 +265,7 @@ class ThemingController extends Controller {
 		$this->imageManager->delete($key);
 
 		$target = $folder->newFile($key);
-		$supportedFormats = ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml', 'image/svg'];
+		$supportedFormats = $this->getSupportedUploadImageFormats($key);
 		$detectedMimeType = mime_content_type($image['tmp_name']);
 		if (!in_array($image['type'], $supportedFormats) || !in_array($detectedMimeType, $supportedFormats)) {
 			return new DataResponse(
@@ -316,6 +316,24 @@ class ThemingController extends Controller {
 				'status' => 'success'
 			]
 		);
+	}
+
+	/**
+	 * Returns a list of supported mime types for image uploads.
+	 * "favicon" images are only allowed to be SVG when imagemagick with SVG support is available.
+	 *
+	 * @param string $key The image key, e.g. "favicon"
+	 * @return array
+	 */
+	private function getSupportedUploadImageFormats(string $key): array {
+		$supportedFormats = ['image/jpeg', 'image/png', 'image/gif',];
+
+		if ($key !== 'favicon' || $this->imageManager->shouldReplaceIcons() === true) {
+			$supportedFormats[] = 'image/svg+xml';
+			$supportedFormats[] = 'image/svg';
+		}
+
+		return $supportedFormats;
 	}
 
 	/**

--- a/apps/theming/tests/Controller/IconControllerTest.php
+++ b/apps/theming/tests/Controller/IconControllerTest.php
@@ -117,7 +117,7 @@ class IconControllerTest extends TestCase {
 		}
 		$file = $this->iconFileMock('filename', 'filecontent');
 		$this->imageManager->expects($this->once())
-			->method('getImage')
+			->method('getImage', false)
 			->with('favicon')
 			->will($this->throwException(new NotFoundException()));
 		$this->imageManager->expects($this->any())
@@ -142,7 +142,7 @@ class IconControllerTest extends TestCase {
 	public function testGetFaviconFail() {
 		$this->imageManager->expects($this->once())
 			->method('getImage')
-			->with('favicon')
+			->with('favicon', false)
 			->will($this->throwException(new NotFoundException()));
 		$this->imageManager->expects($this->any())
 			->method('shouldReplaceIcons')


### PR DESCRIPTION
**Logo**
With the change from here: https://github.com/nextcloud/server/commit/e8938df1986c4b52fc1f5c9afe4cc4078ea86e4c the scss variables from theming were overwritten by the value in the variables.scss.

This fix adds support for default values to the logo and background scss.

**Favicon**
SVG favicons are not working if they're SVG and imagemagick isn't present. There is already a notice on the theming page, but the user is still able to upload a SVG favicon. I changed this so the upload returns "unsupported image type" for SVG favicons without imagemagick.

Closes  #10957