### PR TITLE
Fixes the upload progress bar layout

### DIFF
--- a/apps/files/css/upload.scss
+++ b/apps/files/css/upload.scss
@@ -44,6 +44,10 @@
 	height: 36px;
 	display:inline-block;
 	text-align: center;
+
+	.ui-progressbar-value {
+		margin: 0;
+	}
 }
 #uploadprogressbar .ui-progressbar-value.ui-widget-header.ui-corner-left {
 	height: 100%;


### PR DESCRIPTION
jQuery CSS adds one pixel negative margin to the upload box:
![image](https://user-images.githubusercontent.com/6216686/44958691-0a193200-aee4-11e8-8c3f-6ed7bd9a5c54.png)

With that there is a small gap and the text doesn't align.

This removes the jQuery negative margin, so everything looks okay.

Closes #10968 