### PR TITLE
Add breadcrumb support to crash reporters

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -328,6 +328,7 @@ return array(
     'OCP\\Share_Backend' => $baseDir . '/lib/public/Share_Backend.php',
     'OCP\\Share_Backend_Collection' => $baseDir . '/lib/public/Share_Backend_Collection.php',
     'OCP\\Share_Backend_File_Dependent' => $baseDir . '/lib/public/Share_Backend_File_Dependent.php',
+    'OCP\\Support\\CrashReport\\ICollectBreadcrumbs' => $baseDir . '/lib/public/Support/CrashReport/ICollectBreadcrumbs.php',
     'OCP\\Support\\CrashReport\\IRegistry' => $baseDir . '/lib/public/Support/CrashReport/IRegistry.php',
     'OCP\\Support\\CrashReport\\IReporter' => $baseDir . '/lib/public/Support/CrashReport/IReporter.php',
     'OCP\\SystemTag\\ISystemTag' => $baseDir . '/lib/public/SystemTag/ISystemTag.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -358,6 +358,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Share_Backend' => __DIR__ . '/../../..' . '/lib/public/Share_Backend.php',
         'OCP\\Share_Backend_Collection' => __DIR__ . '/../../..' . '/lib/public/Share_Backend_Collection.php',
         'OCP\\Share_Backend_File_Dependent' => __DIR__ . '/../../..' . '/lib/public/Share_Backend_File_Dependent.php',
+        'OCP\\Support\\CrashReport\\ICollectBreadcrumbs' => __DIR__ . '/../../..' . '/lib/public/Support/CrashReport/ICollectBreadcrumbs.php',
         'OCP\\Support\\CrashReport\\IRegistry' => __DIR__ . '/../../..' . '/lib/public/Support/CrashReport/IRegistry.php',
         'OCP\\Support\\CrashReport\\IReporter' => __DIR__ . '/../../..' . '/lib/public/Support/CrashReport/IReporter.php',
         'OCP\\SystemTag\\ISystemTag' => __DIR__ . '/../../..' . '/lib/public/SystemTag/ISystemTag.php',

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -217,6 +217,10 @@ class Log implements ILogger {
 		if ($level >= $minLevel) {
 			$this->writeLog($app, $message, $level);
 		}
+
+		if (!is_null($this->crashReporters)) {
+			$this->crashReporters->delegateBreadcrumb($message, 'log', $context);
+		}
 	}
 
 	private function getLogLevel($context) {

--- a/lib/private/Support/CrashReport/Registry.php
+++ b/lib/private/Support/CrashReport/Registry.php
@@ -23,6 +23,7 @@
 namespace OC\Support\CrashReport;
 
 use Exception;
+use OCP\Support\CrashReport\ICollectBreadcrumbs;
 use OCP\Support\CrashReport\IRegistry;
 use OCP\Support\CrashReport\IReporter;
 use Throwable;
@@ -39,6 +40,23 @@ class Registry implements IRegistry {
 	 */
 	public function register(IReporter $reporter) {
 		$this->reporters[] = $reporter;
+	}
+
+	/**
+	 * Delegate breadcrumb collection to all registered reporters
+	 *
+	 * @param string $message
+	 * @param string $category
+	 * @param array $context
+	 *
+	 * @since 13.0.0
+	 */
+	public function delegateBreadcrumb(string $message, string $category, array $context = []) {
+		foreach ($this->reporters as $reporter) {
+			if ($reporter instanceof ICollectBreadcrumbs) {
+				$reporter->collect($message, $category, $context);
+			}
+		}
 	}
 
 	/**

--- a/lib/private/Support/CrashReport/Registry.php
+++ b/lib/private/Support/CrashReport/Registry.php
@@ -49,7 +49,7 @@ class Registry implements IRegistry {
 	 * @param string $category
 	 * @param array $context
 	 *
-	 * @since 13.0.0
+	 * @since 15.0.0
 	 */
 	public function delegateBreadcrumb(string $message, string $category, array $context = []) {
 		foreach ($this->reporters as $reporter) {

--- a/lib/public/Support/CrashReport/ICollectBreadcrumbs.php
+++ b/lib/public/Support/CrashReport/ICollectBreadcrumbs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  *
@@ -22,39 +24,20 @@
 
 namespace OCP\Support\CrashReport;
 
-use Exception;
-use Throwable;
-
 /**
- * @since 13.0.0
+ * @since 15.0.0
  */
-interface IRegistry {
+interface ICollectBreadcrumbs extends IReporter {
 
 	/**
-	 * Register a reporter instance
-	 *
-	 * @since 13.0.0
-	 * @param IReporter $reporter
-	 */
-	public function register(IReporter $reporter);
-
-	/**
-	 * Delegate breadcrumb collection to all registered reporters
+	 * Collect breadcrumbs for crash reports
 	 *
 	 * @param string $message
 	 * @param string $category
 	 * @param array $context
 	 *
-	 * @since 13.0.0
+	 * @since 15.0.0
 	 */
-	public function delegateBreadcrumb(string $message, string $category, array $context = []);
+	public function collect(string $message, string $category, array $context = []);
 
-	/**
-	 * Delegate crash reporting to all registered reporters
-	 *
-	 * @since 13.0.0
-	 * @param Exception|Throwable $exception
-	 * @param array $context
-	 */
-	public function delegateReport($exception, array $context = []);
 }

--- a/lib/public/Support/CrashReport/IRegistry.php
+++ b/lib/public/Support/CrashReport/IRegistry.php
@@ -45,7 +45,7 @@ interface IRegistry {
 	 * @param string $category
 	 * @param array $context
 	 *
-	 * @since 13.0.0
+	 * @since 15.0.0
 	 */
 	public function delegateBreadcrumb(string $message, string $category, array $context = []);
 

--- a/tests/lib/Support/CrashReport/RegistryTest.php
+++ b/tests/lib/Support/CrashReport/RegistryTest.php
@@ -26,6 +26,7 @@ namespace Test\Support\CrashReport;
 
 use Exception;
 use OC\Support\CrashReport\Registry;
+use OCP\Support\CrashReport\ICollectBreadcrumbs;
 use OCP\Support\CrashReport\IReporter;
 use Test\TestCase;
 
@@ -48,6 +49,20 @@ class RegistryTest extends TestCase {
 
 		$this->registry->delegateReport($exception);
 		$this->addToAssertionCount(1);
+	}
+
+	public function testDelegateBreadcrumbCollection() {
+		$reporter1 = $this->createMock(IReporter::class);
+		$reporter2 = $this->createMock(ICollectBreadcrumbs::class);
+		$message = 'hello';
+		$category = 'log';
+		$reporter2->expects($this->once())
+			->method('collect')
+			->with($message, $category);
+
+		$this->registry->register($reporter1);
+		$this->registry->register($reporter2);
+		$this->registry->delegateBreadcrumb($message, $category);
 	}
 
 	public function testDelegateToAll() {


### PR DESCRIPTION
Ref https://github.com/ChristophWurst/nextcloud_sentry/issues/37.

This just adds basic support for breadcrumbs to our public API. For future enhancements, we could integrate our diagnostics services (query and event logger).