### PR TITLE
Check the permission of the underlying storage

### DIFF
--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -142,7 +142,7 @@ class Cache extends CacheJail {
 		} else {
 			$entry['path'] = $path;
 		}
-		$sharePermissions = $this->storage->getPermissions($path);
+		$sharePermissions = $this->storage->getPermissions($entry['path']);
 		if (isset($entry['permissions'])) {
 			$entry['permissions'] &= $sharePermissions;
 		} else {

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -258,11 +258,17 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 				case 'xb':
 				case 'a':
 				case 'ab':
-					$creatable = $this->isCreatable($path);
+					$creatable = $this->isCreatable(dirname($path));
 					$updatable = $this->isUpdatable($path);
 					// if neither permissions given, no need to continue
 					if (!$creatable && !$updatable) {
-						return false;
+						if (pathinfo($path, PATHINFO_EXTENSION) === 'part') {
+							$updatable = $this->isUpdatable(dirname($path));
+						}
+
+						if (!$updatable) {
+							return false;
+						}
 					}
 
 					$exists = $this->file_exists($path);

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -195,7 +195,8 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 		if (!$this->isValid()) {
 			return 0;
 		}
-		$permissions = $this->superShare->getPermissions();
+		$permissions = parent::getPermissions($target) & $this->superShare->getPermissions();
+
 		// part files and the mount point always have delete permissions
 		if ($target === '' || pathinfo($target, PATHINFO_EXTENSION) === 'part') {
 			$permissions |= \OCP\Constants::PERMISSION_DELETE;

--- a/apps/files_sharing/tests/PermissionsTest.php
+++ b/apps/files_sharing/tests/PermissionsTest.php
@@ -134,14 +134,14 @@ class PermissionsTest extends TestCase {
 	 * Test that the permissions of shared directory are returned correctly
 	 */
 	function testGetPermissions() {
-		$sharedDirPerms = $this->sharedStorage->getPermissions('shareddir');
+		$sharedDirPerms = $this->sharedStorage->getPermissions('');
 		$this->assertEquals(31, $sharedDirPerms);
-		$sharedDirPerms = $this->sharedStorage->getPermissions('shareddir/textfile.txt');
-		$this->assertEquals(31, $sharedDirPerms);
-		$sharedDirRestrictedPerms = $this->sharedStorageRestrictedShare->getPermissions('shareddirrestricted');
-		$this->assertEquals(7, $sharedDirRestrictedPerms);
-		$sharedDirRestrictedPerms = $this->sharedStorageRestrictedShare->getPermissions('shareddirrestricted/textfile.txt');
-		$this->assertEquals(7, $sharedDirRestrictedPerms);
+		$sharedDirPerms = $this->sharedStorage->getPermissions('textfile.txt');
+		$this->assertEquals(27, $sharedDirPerms);
+		$sharedDirRestrictedPerms = $this->sharedStorageRestrictedShare->getPermissions('');
+		$this->assertEquals(15, $sharedDirRestrictedPerms);
+		$sharedDirRestrictedPerms = $this->sharedStorageRestrictedShare->getPermissions('textfile1.txt');
+		$this->assertEquals(3, $sharedDirRestrictedPerms);
 	}
 
 	/**


### PR DESCRIPTION
Else shares might expose more permissions than the storage actually
providers.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>