### PR TITLE
Remove filter_var flags due to PHP 7.3 deprecation, fixes #10894

### DIFF
--- a/apps/oauth2/lib/Controller/SettingsController.php
+++ b/apps/oauth2/lib/Controller/SettingsController.php
@@ -74,7 +74,7 @@ class SettingsController extends Controller {
 	public function addClient(string $name,
 							  string $redirectUri): JSONResponse {
 
-		if (filter_var($redirectUri, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED|FILTER_FLAG_HOST_REQUIRED) === false) {
+		if (filter_var($redirectUri, FILTER_VALIDATE_URL) === false) {
 			return new JSONResponse(['message' => $this->l->t('Your redirect URL needs to be a full URL for example: https://yourdomain.com/path')], Http::STATUS_BAD_REQUEST);
 		}
 

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -174,9 +174,7 @@ class ThemingDefaults extends \OC_Defaults {
 		$legalLinks = ''; $divider = '';
 		foreach($links as $link) {
 			if($link['url'] !== ''
-				&& filter_var($link['url'], FILTER_VALIDATE_URL, [
-					'flags' => FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED
-				])
+				&& filter_var($link['url'], FILTER_VALIDATE_URL)
 			) {
 				$legalLinks .= $divider . '<a href="' . $link['url'] . '" class="legal" target="_blank"' .
 					' rel="noreferrer noopener">' . $link['text'] . '</a>';
@@ -339,7 +337,7 @@ class ThemingDefaults extends \OC_Defaults {
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Increases the cache buster key
 	 */


### PR DESCRIPTION
This PR should address PHP 7.3 deprecation errors of specific `filter_var` flags, see more in issue #10894.