### PR TITLE
Add wrapper Logger in DIContainer

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -370,6 +370,7 @@ return array(
     'OC\\AppFramework\\Http\\Dispatcher' => $baseDir . '/lib/private/AppFramework/Http/Dispatcher.php',
     'OC\\AppFramework\\Http\\Output' => $baseDir . '/lib/private/AppFramework/Http/Output.php',
     'OC\\AppFramework\\Http\\Request' => $baseDir . '/lib/private/AppFramework/Http/Request.php',
+    'OC\\AppFramework\\Logger' => $baseDir . '/lib/private/AppFramework/Logger.php',
     'OC\\AppFramework\\Middleware\\MiddlewareDispatcher' => $baseDir . '/lib/private/AppFramework/Middleware/MiddlewareDispatcher.php',
     'OC\\AppFramework\\Middleware\\OCSMiddleware' => $baseDir . '/lib/private/AppFramework/Middleware/OCSMiddleware.php',
     'OC\\AppFramework\\Middleware\\PublicShare\\Exceptions\\NeedAuthenticationException' => $baseDir . '/lib/private/AppFramework/Middleware/PublicShare/Exceptions/NeedAuthenticationException.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -400,6 +400,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\AppFramework\\Http\\Dispatcher' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Http/Dispatcher.php',
         'OC\\AppFramework\\Http\\Output' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Http/Output.php',
         'OC\\AppFramework\\Http\\Request' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Http/Request.php',
+        'OC\\AppFramework\\Logger' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Logger.php',
         'OC\\AppFramework\\Middleware\\MiddlewareDispatcher' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Middleware/MiddlewareDispatcher.php',
         'OC\\AppFramework\\Middleware\\OCSMiddleware' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Middleware/OCSMiddleware.php',
         'OC\\AppFramework\\Middleware\\PublicShare\\Exceptions\\NeedAuthenticationException' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Middleware/PublicShare/Exceptions/NeedAuthenticationException.php',

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -120,6 +120,11 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return $this->getServer()->getL10N($c->query('AppName'));
 		});
 
+		// Log wrapper
+		$this->registerService(ILogger::class, function ($c) {
+			return new OC\AppFramework\Logger($this->server->query(ILogger::class), $c->query('AppName'));
+		});
+
 		$this->registerAlias(\OCP\AppFramework\Utility\IControllerMethodReflector::class, \OC\AppFramework\Utility\ControllerMethodReflector::class);
 		$this->registerAlias('ControllerMethodReflector', \OCP\AppFramework\Utility\IControllerMethodReflector::class);
 

--- a/lib/private/AppFramework/Logger.php
+++ b/lib/private/AppFramework/Logger.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2018, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\AppFramework;
+
+use OCP\ILogger;
+
+class Logger implements ILogger {
+
+	/** @var ILogger */
+	private $logger;
+
+	/** @var string */
+	private $appName;
+
+	public function __construct(ILogger $logger, string $appName) {
+		$this->logger = $logger;
+		$this->appName = $appName;
+	}
+
+	private function extendContext(array $context): array {
+		if (!isset($context['app'])) {
+			$context['app'] = $this->appName;
+		}
+
+		return $context;
+	}
+
+	public function emergency(string $message, array $context = []) {
+		$this->logger->emergency($message, $this->extendContext($context));
+	}
+
+	public function alert(string $message, array $context = []) {
+		$this->logger->alert($message, $this->extendContext($context));
+	}
+
+	public function critical(string $message, array $context = []) {
+		$this->logger->critical($message, $this->extendContext($context));
+	}
+
+	public function error(string $message, array $context = []) {
+		$this->logger->emergency($message, $this->extendContext($context));
+	}
+
+	public function warning(string $message, array $context = []) {
+		$this->logger->warning($message, $this->extendContext($context));
+	}
+
+	public function notice(string $message, array $context = []) {
+		$this->logger->notice($message, $this->extendContext($context));
+	}
+
+	public function info(string $message, array $context = []) {
+		$this->logger->info($message, $this->extendContext($context));
+	}
+
+	public function debug(string $message, array $context = []) {
+		$this->logger->debug($message, $this->extendContext($context));
+	}
+
+	public function log(int $level, string $message, array $context = []) {
+		$this->logger->log($level, $message, $this->extendContext($context));
+	}
+
+	public function logException(\Throwable $exception, array $context = []) {
+		$this->logger->logException($exception, $this->extendContext($context));
+	}
+}


### PR DESCRIPTION
Fixes #10725 

This makes sure that for example app for the context is always set.
We can in the future extend this to include more info.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>