### PR TITLE
occ app update command

### DIFF
--- a/core/Command/App/Update.php
+++ b/core/Command/App/Update.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018, michag86 (michag86@arcor.de)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Core\Command\App;
+
+use OCP\App\IAppManager;
+use OC\Installer;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Update extends Command {
+
+	/** @var IAppManager */
+	protected $manager;
+	/** @var Installer */
+	private $installer;
+	/**
+	 * @param IAppManager $manager
+	 * @param Installer $installer
+	 */
+	public function __construct(IAppManager $manager, Installer $installer) {
+		parent::__construct();
+		$this->manager = $manager;
+		$this->installer = $installer;
+	}
+
+	protected function configure() {
+		$this
+			->setName('app:update')
+			->setDescription('update an app or all apps')
+			->addArgument(
+				'app-id',
+				InputArgument::OPTIONAL,
+				'update the specified app'
+			)
+			->addOption(
+				'all',
+				null,
+				InputOption::VALUE_NONE,
+				'update all updatable apps'
+			)
+			->addOption(
+				'showonly',
+				null,
+				InputOption::VALUE_NONE,
+				'show update(s) without updating'
+			)
+
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$singleAppId = $input->getArgument('app-id');
+
+		if ($singleAppId) {
+			$apps = array($singleAppId);
+			try {
+				$this->manager->getAppPath($singleAppId);
+			} catch (\OCP\App\AppPathNotFoundException $e) {
+				$output->writeln($singleAppId . ' not installed');
+				return 1;
+			}
+
+		} else if ($input->getOption('all') || $input->getOption('showonly')) {
+			$apps = \OC_App::getAllApps();
+		} else {
+			$output->writeln("<error>Please specify an app to update or \"--all\" to update all updatable apps\"</error>");
+			return 1;
+		}
+
+		$return = 0;
+		foreach ($apps as $appId) {
+			$newVersion = $this->installer->isUpdateAvailable($appId);
+			if ($newVersion) {
+				$output->writeln($appId . ' new version available: ' . $newVersion);
+
+				if (!$input->getOption('showonly')) {
+					try {
+						$result = $this->installer->updateAppstoreApp($appId);
+					} catch(\Exception $e) {
+						$output->writeln('Error: ' . $e->getMessage());
+						$return = 1;
+					}
+
+					if ($result === false) {
+						$output->writeln($appId . ' couldn\'t be updated');
+						$return = 1;
+					} else if($result === true) {
+						$output->writeln($appId . ' updated');
+					}
+				}
+			}
+		}
+
+		return $return;
+	}
+}
+

--- a/core/Command/App/Update.php
+++ b/core/Command/App/Update.php
@@ -23,6 +23,7 @@ namespace OC\Core\Command\App;
 
 use OCP\App\IAppManager;
 use OC\Installer;
+use OCP\ILogger;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -35,14 +36,18 @@ class Update extends Command {
 	protected $manager;
 	/** @var Installer */
 	private $installer;
+	/** @var ILogger */
+	private $logger;
+
 	/**
 	 * @param IAppManager $manager
 	 * @param Installer $installer
 	 */
-	public function __construct(IAppManager $manager, Installer $installer) {
+	public function __construct(IAppManager $manager, Installer $installer, ILogger $logger) {
 		parent::__construct();
 		$this->manager = $manager;
 		$this->installer = $installer;
+		$this->logger = $logger;
 	}
 
 	protected function configure() {
@@ -99,6 +104,7 @@ class Update extends Command {
 					try {
 						$result = $this->installer->updateAppstoreApp($appId);
 					} catch(\Exception $e) {
+						$this->logger->logException($e, ['message' => 'Failure during update of app "' . $appId . '"','app' => 'app:update']);
 						$output->writeln('Error: ' . $e->getMessage());
 						$return = 1;
 					}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -66,6 +66,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\App\GetPath());
 	$application->add(new OC\Core\Command\App\ListApps(\OC::$server->getAppManager()));
 	$application->add(new OC\Core\Command\App\Remove(\OC::$server->getAppManager(), \OC::$server->query(\OC\Installer::class), \OC::$server->getLogger()));
+	$application->add(\OC::$server->query(\OC\Core\Command\App\Update::class));
 
 	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Cleanup::class));
 	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Enforce::class));

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -558,6 +558,7 @@ return array(
     'OC\\Core\\Command\\App\\Install' => $baseDir . '/core/Command/App/Install.php',
     'OC\\Core\\Command\\App\\ListApps' => $baseDir . '/core/Command/App/ListApps.php',
     'OC\\Core\\Command\\App\\Remove' => $baseDir . '/core/Command/App/Remove.php',
+    'OC\\Core\\Command\\App\\Update' => $baseDir . '/core/Command/App/Update.php',
     'OC\\Core\\Command\\Background\\Ajax' => $baseDir . '/core/Command/Background/Ajax.php',
     'OC\\Core\\Command\\Background\\Base' => $baseDir . '/core/Command/Background/Base.php',
     'OC\\Core\\Command\\Background\\Cron' => $baseDir . '/core/Command/Background/Cron.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -588,6 +588,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Core\\Command\\App\\Install' => __DIR__ . '/../../..' . '/core/Command/App/Install.php',
         'OC\\Core\\Command\\App\\ListApps' => __DIR__ . '/../../..' . '/core/Command/App/ListApps.php',
         'OC\\Core\\Command\\App\\Remove' => __DIR__ . '/../../..' . '/core/Command/App/Remove.php',
+        'OC\\Core\\Command\\App\\Update' => __DIR__ . '/../../..' . '/core/Command/App/Update.php',
         'OC\\Core\\Command\\Background\\Ajax' => __DIR__ . '/../../..' . '/core/Command/Background/Ajax.php',
         'OC\\Core\\Command\\Background\\Base' => __DIR__ . '/../../..' . '/core/Command/Background/Base.php',
         'OC\\Core\\Command\\Background\\Cron' => __DIR__ . '/../../..' . '/core/Command/Background/Cron.php',


### PR DESCRIPTION
partial fix for #7002

This new command has two parameters/options:
appid as parameter updates a single app
--all updates all updatable apps

output looks like this:
```
calendar new version available: 1.6.1
calendar updated
contacts new version available: 2.1.6
contacts updated
```

If no update is available, no output is written.

@MorrisJobke @exploide @enoch85 