### PR TITLE
Fix size of icons in menus inside apps when shown as images

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -1043,6 +1043,27 @@ $popovericon-size: 16px;
 	}
 }
 
+/* "app-*" descendants use border-box sizing, so the height of the icon must be
+ * set to the height of the item (as well as its width to make it squared). */
+#content[class*='app-'] {
+	.bubble,
+	.app-navigation-entry-menu,
+	.popovermenu {
+		li {
+			> button,
+			> a,
+			> .menuitem {
+				/* DEPRECATED! old img in popover fallback
+				* TODO: to remove */
+				> img {
+					width: $popoveritem-height;
+					height: $popoveritem-height;
+				}
+			}
+		}
+	}
+}
+
 /* CONTENT LIST ------------------------------------------------------------ */
 .app-content-list {
 	width: 300px;


### PR DESCRIPTION
This pull request fixes the icons in the contacts menu popover for Files app, although it can potentially fix other menus too.

In our beloved #9982 :-P [the descendants of `.app-*` elements were set to use `border-box` sizing](https://github.com/nextcloud/server/commit/d6b718584e8aff74a0e76f77d2c1c5689f78cc78#diff-bf0066932907b556b49ffe55b209a501R70). This caused the descendants of the Files app (like the comments and the sharing tab in its sidebar) to use `border-box` sizing (before they used `content-box` because there was no ancestor `#app` element).

[The main CSS rules for images in popover menus assume that `content-box` sizing is used](https://github.com/nextcloud/server/blob/27f14cf91bdebf22abc4b27acb37dc08c8117af0/core/css/apps.scss#L975-L978), so when they were shown using `border-box` they were not properly shown. Now both the width and height of the image is set to the item height in that case, which causes the visible size of the icon to be the item height minus the padding (the same as when `content-box` sizing is used).

Before:
![contactsmenupopover-icons-before](https://user-images.githubusercontent.com/26858233/45056703-f3194200-b093-11e8-95b6-d69e46041967.png)

After:
![contactsmenupopover-icons-after](https://user-images.githubusercontent.com/26858233/45056707-f4e30580-b093-11e8-80ed-2e556c2d368c.png)

@nextcloud/designers 
