### PR TITLE
Do not invalidate main token on OAuth

### DIFF
--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -366,10 +366,10 @@ class ClientFlowLoginController extends Controller {
 
 			$serverPath = $protocol . "://" . $this->request->getServerHost() . $serverPostfix;
 			$redirectUri = 'nc://login/server:' . $serverPath . '&user:' . urlencode($loginName) . '&password:' . urlencode($token);
-		}
 
-		// Clear the token from the login here
-		$this->tokenProvider->invalidateToken($sessionId);
+			// Clear the token from the login here
+			$this->tokenProvider->invalidateToken($sessionId);
+		}
 
 		return new Http\RedirectResponse($redirectUri);
 	}


### PR DESCRIPTION
Fixes #10584

We deleted the main token when using the login flow else mutliple tokens
would show up for a single user.

However in the case of OAuth this is perfectly fine as the
authentication happens really in your browser:

1. You are already logged in, no need to log you out
2. You are not logged in yet, but since you log in into the exact same
browser the expected behavior is to stay logged in.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>