### PR TITLE
Add QBMapper::insertOrUpdate()

### DIFF
--- a/lib/public/AppFramework/Db/QBMapper.php
+++ b/lib/public/AppFramework/Db/QBMapper.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace OCP\AppFramework\Db;
 
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
@@ -123,7 +124,23 @@ abstract class QBMapper {
 		return $entity;
 	}
 
-
+	/**
+	 * Tries to creates a new entry in the db from an entity and
+	 * updates an existing entry if duplicate keys are detected
+	 * by the database
+	 *
+	 * @param Entity $entity the entity that should be created/updated
+	 * @return Entity the saved entity with the (new) id
+	 * @since 15.0.0
+	 * @suppress SqlInjectionChecker
+	 */
+	public function insertOrUpdate(Entity $entity): Entity {
+		try {
+			return $this->insert($entity);
+		} catch (UniqueConstraintViolationException $ex) {
+			return $this->update($entity);
+		}
+	}
 
 	/**
 	 * Updates an entry in the db from an entity

--- a/lib/public/AppFramework/Db/QBMapper.php
+++ b/lib/public/AppFramework/Db/QBMapper.php
@@ -131,6 +131,7 @@ abstract class QBMapper {
 	 *
 	 * @param Entity $entity the entity that should be created/updated
 	 * @return Entity the saved entity with the (new) id
+	 * @throws \InvalidArgumentException if entity has no id
 	 * @since 15.0.0
 	 * @suppress SqlInjectionChecker
 	 */


### PR DESCRIPTION
This allows elegant upserts where the entity ID is provided (e.g. by an
external system) and when that data is fed into our database multiple
times.

I've stumbled over this while working on a small side-projects where I sync data from an external API into an app's tables and figured it would be nice to have this for all apps.