### PR TITLE
Remove posix_getpwuid and compare only userid

### DIFF
--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -565,7 +565,7 @@ Raw output
 	 * @param array $appRoot The app root config
 	 * @return string[] The none writable directory paths inside the app root
 	 */
-	private function getAppDirsWithDifferentOwnerForAppRoot($currentUser, array $appRoot): array {
+	private function getAppDirsWithDifferentOwnerForAppRoot(int $currentUser, array $appRoot): array {
 		$appDirsWithDifferentOwner = [];
 		$appsPath = $appRoot['path'];
 		$appsDir = new DirectoryIterator($appRoot['path']);

--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -543,7 +543,7 @@ Raw output
 	 * @return array
 	 */
 	protected function getAppDirsWithDifferentOwner(): array {
-		$currentUser = posix_getpwuid(posix_getuid());
+		$currentUser = posix_getuid();
 		$appDirsWithDifferentOwner = [[]];
 
 		foreach (OC::$APPSROOTS as $appRoot) {
@@ -561,11 +561,11 @@ Raw output
 	/**
 	 * Tests if the directories for one apps directory are writable by the current user.
 	 *
-	 * @param array $currentUser The current user
+	 * @param int $currentUser The current user
 	 * @param array $appRoot The app root config
 	 * @return string[] The none writable directory paths inside the app root
 	 */
-	private function getAppDirsWithDifferentOwnerForAppRoot(array $currentUser, array $appRoot): array {
+	private function getAppDirsWithDifferentOwnerForAppRoot($currentUser, array $appRoot): array {
 		$appDirsWithDifferentOwner = [];
 		$appsPath = $appRoot['path'];
 		$appsDir = new DirectoryIterator($appRoot['path']);
@@ -573,7 +573,7 @@ Raw output
 		foreach ($appsDir as $fileInfo) {
 			if ($fileInfo->isDir() && !$fileInfo->isDot()) {
 				$absAppPath = $appsPath . DIRECTORY_SEPARATOR . $fileInfo->getFilename();
-				$appDirUser = posix_getpwuid(fileowner($absAppPath));
+				$appDirUser = fileowner($absAppPath);
 				if ($appDirUser !== $currentUser) {
 					$appDirsWithDifferentOwner[] = $absAppPath;
 				}


### PR DESCRIPTION
Close #11088 
Close #11089 

posix_getpwuid returns an array with information about user/group/etc. for current user. These information is not available when /etc/passwd is not readable (see https://secure.php.net/manual/en/function.posix-getpwuid.php#45994).

@weeman1337 @rullzer is it enough to compare the user id? i guess we could check the group id as well.


