### PR TITLE
replace setcookie value with '' instead of null.

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -441,7 +441,7 @@ class OC {
 		// session timeout
 		if ($session->exists('LAST_ACTIVITY') && (time() - $session->get('LAST_ACTIVITY') > $sessionLifeTime)) {
 			if (isset($_COOKIE[session_name()])) {
-				setcookie(session_name(), null, -1, self::$WEBROOT ? : '/');
+				setcookie(session_name(), '', -1, self::$WEBROOT ? : '/');
 			}
 			\OC::$server->getUserSession()->logout();
 		}

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -54,7 +54,7 @@ class Internal extends Session {
 		try {
 			$this->invoke('session_start');
 		} catch (\Exception $e) {
-			setcookie($this->invoke('session_name'), null, -1, \OC::$WEBROOT ?: '/');
+			setcookie($this->invoke('session_name'), '', -1, \OC::$WEBROOT ?: '/');
 		}
 		restore_error_handler();
 		if (!isset($_SESSION)) {


### PR DESCRIPTION
The php documentation states that an empty string should be used for a cookie when it has no real value.
null leads to the following error: expects parameter 2 to be string, null given

Fixes #11080 