### PR TITLE
Fix exception class

### DIFF
--- a/lib/public/Federation/ICloudFederationProviderManager.php
+++ b/lib/public/Federation/ICloudFederationProviderManager.php
@@ -67,7 +67,7 @@ interface ICloudFederationProviderManager {
 	 *
 	 * @param string $resourceType
 	 * @return ICloudFederationProvider
-	 * @throws Exceptions\ProviderDoesNotExistsException;
+	 * @throws Exceptions\ProviderDoesNotExistsException
 	 *
 	 * @since 14.0.0
 	 */


### PR DESCRIPTION
breaks the docs api parsing:

> Unable to parse file "/home/nickv/Nextcloud/Documentation/build/server/lib/public/Federation/ICloudFederationProviderManager.php", "\OCP\Federation\Exceptions\ProviderDoesNotExistsException;" is not a valid Fqsen.
