### PR TITLE
Update UsersController.php

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -177,7 +177,7 @@ class UsersController extends AUserData {
 		$users = array_keys($users);
 		$usersDetails = [];
 		foreach ($users as $key => $userId) {
-			$userData = $this->getUserData($userId);
+			$userData = $this->getUserData((string)$userId);
 			// Do not insert empty entry
 			if (!empty($userData)) {
 				$usersDetails[$userId] = $userData;


### PR DESCRIPTION
Using the mobile number as the username will report the following error.
TypeError: Argument 1 passed to OCA\Provisioning_API\Controller\AUserData::getUserData() must be of the type string, integer given, called in /var/www/html/apps/provisioning_api/lib/Controller/UsersController.php on line 180 at /var/www/html/apps/provisioning_api/lib/Controller/AUserData.php#81