### PR TITLE
Prepare 14.0.1 release

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(14, 0, 0, 19);
+$OC_Version = array(14, 0, 1, 0);
 
 // The human readable string
-$OC_VersionString = '14.0.0';
+$OC_VersionString = '14.0.1 RC 1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
:no_entry: **Do NOT merge** :no_entry: 

## Changelog

* #11039 Fixes the upload progress bar layout - 14 backport
* #11077 [stable14] Fix markup and style of mentions in comments
* #11090 [stable14] Do not invalidate main token on OAuth
* #11103 [stable14] Expire tokens hardening
* #11152 [14] fix js files client for user names with spaces
* #11186 [stable14] Fix user and group listing with users that have an integer user id
* #11187 [stable14] Fix exception class
* #11191 [14] Remove posix_getpwuid and compare only userid
* #11201 [stable14]  fix check for more users in sharing dialogue
* #11237 [stable14] Remove filter_var flags due to PHP 7.3 deprecation, fixes #10894
* #11276 [stable14] Fix size of icons in menus inside apps when shown as images
* #11277 [stable14] Prevent comment being composed from overlapping the submit button
* #11280 [stable14] replace setcookie value with '' instead of null.
* #11282 [stable14] Fix the link and anchor for the update notifications
* #11283 [stable14] Include empty directories in the default state of acceptance tests
* #11287 [stable14] Get permission of storage for shares
* #11288 [stable14] Shared by info for room shares without names
* #11291 [stable14] Fix icons cacher regex for compressed output
* #11293 [stable14] Revert "Use APCu caching of composer"
* #11294 [stable14] Use user locale as default in the template
* #11302 [stable14] Fix expiration code of tokens
* [activity#295](https://github.com/nextcloud/activity/pull/295) 14 scroll fix
* [files_texteditor#111](https://github.com/nextcloud/files_texteditor/pull/111) Update stable14 target versions
* [firstrunwizard#80](https://github.com/nextcloud/firstrunwizard/pull/80) Update stable14 target versions
* [gallery#467](https://github.com/nextcloud/gallery/pull/467) Update stable14 target versions
* [nextcloud_announcements#32](https://github.com/nextcloud/nextcloud_announcements/pull/32) Update stable14 target versions
* [notifications#158](https://github.com/nextcloud/notifications/pull/158) Update stable14 target versions
* [notifications#161](https://github.com/nextcloud/notifications/pull/161) [stable14] Update config and babel for ie11
