### PR TITLE
make the server ready to use global scale with SAML as auth back-end

### DIFF
--- a/lib/private/legacy/user.php
+++ b/lib/private/legacy/user.php
@@ -166,7 +166,7 @@ class OC_User {
 
 		$uid = $backend->getCurrentUserId();
 		$run = true;
-		OC_Hook::emit("OC_User", "pre_login", array("run" => &$run, "uid" => $uid));
+		OC_Hook::emit("OC_User", "pre_login", array("run" => &$run, "uid" => $uid, 'backend' => $backend));
 
 		if ($uid) {
 			if (self::getUser() !== $uid) {


### PR DESCRIPTION
add back-end as parameter to the pre-login hook

This is needed for the Global Scale setup to allow the master
node to perform different operations during login, depending
on the user management. Because in case of SAML, the authentication
at the idp happens at the master node.
