### PR TITLE
Consider openssl settings from config.php

### DIFF
--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -287,10 +287,10 @@ class PublicKeyTokenProvider implements IProvider {
 		$dbToken->setUid($uid);
 		$dbToken->setLoginName($loginName);
 
-		$config = [
+		$config = array_merge([
 			'digest_alg' => 'sha512',
 			'private_key_bits' => 2048,
-		];
+		], $this->config->getSystemValue('openssl', []));
 
 		// Generate new key
 		$res = openssl_pkey_new($config);

--- a/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
@@ -67,6 +67,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 				['session_lifetime', 60 * 60 * 24, 150],
 				['remember_login_cookie_lifetime', 60 * 60 * 24 * 15, 300],
 				['secret', '', '1f4h9s'],
+				['openssl', [], []],
 			]));
 		$this->logger = $this->createMock(ILogger::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);


### PR DESCRIPTION
As discussed in #11227 the openssl configuration from config.php is not applied in PublicKeyTokenProvider. 

https://github.com/nextcloud/server/blob/182636b8094c808688bc22a04e07c597f5d6ad3d/config/config.sample.php#L1046-L1053

https://github.com/nextcloud/server/blob/e2974f1133693c022585d3758df142e0f385cb3e/apps/encryption/lib/Crypto/Crypt.php#L156-L168
