### PR TITLE
Check if user is null before getUsername

### DIFF
--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -119,24 +119,26 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 	}
 
 	/**
-	 * returns the username for the given login name, if available
+	 * Return the username for the given login name, if available
 	 *
 	 * @param string $loginName
 	 * @return string|false
+	 * @throws \Exception
 	 */
 	public function loginName2UserName($loginName) {
-		$cacheKey = 'loginName2UserName-'.$loginName;
+		$cacheKey = 'loginName2UserName-' . $loginName;
 		$username = $this->access->connection->getFromCache($cacheKey);
-		if(!is_null($username)) {
+
+		if ($username !== null) {
 			return $username;
 		}
 
 		try {
 			$ldapRecord = $this->getLDAPUserByLoginName($loginName);
 			$user = $this->access->userManager->get($ldapRecord['dn'][0]);
-			if($user instanceof OfflineUser) {
+			if ($user === null || $user instanceof OfflineUser) {
 				// this path is not really possible, however get() is documented
-				// to return User or OfflineUser so we are very defensive here.
+				// to return User, OfflineUser or null so we are very defensive here.
 				$this->access->connection->writeToCache($cacheKey, false);
 				return false;
 			}


### PR DESCRIPTION
Close #8288 

Above issue  only occurs under certain circumstances. I could not reproduce the issue in the wild :see_no_evil: 

https://github.com/nextcloud/server/blob/40bb45225a42a48cd9d090e7540f1a8d3986df63/apps/user_ldap/lib/User_LDAP.php#L136-L142

> however get() is documented 
				// to return User or OfflineUser so we are very defensive here.

https://github.com/nextcloud/server/blob/343036e55c0b41891fc86aafc0cbb3077503ab64/apps/user_ldap/lib/User/Manager.php#L244-L266

Like @blizzz suggested here https://github.com/nextcloud/server/issues/6785#issuecomment-335156343 it should be safe to check for null. UserManager->get could return User, OfflineUser or null so the comment is  wrong.