### PR TITLE
Prevent comment being composed from overlapping the submit button

### DIFF
--- a/apps/comments/css/comments.scss
+++ b/apps/comments/css/comments.scss
@@ -22,6 +22,9 @@
 	padding: 10px;
 	min-height: 44px;
 	margin: 0;
+
+	/* Prevent the text from overlapping with the submit button. */
+	padding-right: 30px;
 }
 
 #commentsTabView .newCommentForm {


### PR DESCRIPTION
**Before:**
![comment-compose-overlap-before](https://user-images.githubusercontent.com/26858233/45609189-190cf200-ba57-11e8-8666-825b7da65206.png)

**After:**
![comment-compose-overlap-after](https://user-images.githubusercontent.com/26858233/45609192-1ad6b580-ba57-11e8-8047-52400e873bcb.png)
