### PR TITLE
Fix contacts menu on mentions

### DIFF
--- a/apps/comments/css/comments.scss
+++ b/apps/comments/css/comments.scss
@@ -251,3 +251,8 @@
 .app-files .action-comment {
 	padding: 16px 14px;
 }
+
+#commentsTabView .comment .message .contactsmenu-popover {
+	left: -6px;
+	top: 24px;
+}

--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -442,14 +442,13 @@
 				return;
 			}
 
-			$el.find('.avatar').each(function() {
-				var avatar = $(this);
-				var strong = $(this).next();
-				var appendTo = $(this).parent();
+			$el.find('.avatar-name-wrapper').each(function() {
+				var $this = $(this);
+				var $avatar = $this.find('.avatar');
 
-				var username = $(this).data('username');
-				if (username !== oc_current_user) {
-					$.merge(avatar, strong).contactsMenu(avatar.data('user'), 0, appendTo);
+				var user = $avatar.data('user');
+				if (user !== OC.getCurrentUser().uid) {
+					$this.contactsMenu(user, 0, $this);
 				}
 			});
 		},


### PR DESCRIPTION
This pull request ensures that the contacts menu will be shown when clicking on any area of the mention, and it also fixes the position of the contacts menu shown on mentions in the comments.

The positioning of the contacts menu is a bit messy right now. There are no default CSS rules for the contacts menu, as its position depends on the context in which it is shown (a different position is needed if the avatar is 16px or 32px, for example). However, there are [some rules set in the share tab which use a broad selector](https://github.com/nextcloud/server/blob/a4e042c7065798a76c6761031f3bebe6938fd460/apps/files_sharing/css/sharetabview.scss#L220) and thus affect the contacts menu in the Comments app. Moreover, the position is also affected by the default rules for other CSS classes used in the contacts menu, [like `.popover-menu.menu-left`](https://github.com/nextcloud/server/blob/0c758dbe5b014715dd5adde625f5d3b4da3528cd/core/css/apps.scss#L868).

The contacts menu is now positioned to show the tip of the arrow horizontally aligned with the center of the avatar *1, and with the top of the menu slightly below the bottom border of the mention *2.

*1: the avatar is 16px and the mention has a left padding of 1px, so the tip of the arrow has to appear at 9px from the left border of the mention to be centered on the avatar; the arrow is 18px (it is created using a [9px bottom border](https://github.com/nextcloud/server/blob/0c758dbe5b014715dd5adde625f5d3b4da3528cd/core/css/apps.scss#L855)), so the tip is at 9px from its left border, and the left border of the arrow is [6px to the left of the contacts menu](https://github.com/nextcloud/server/blob/0c758dbe5b014715dd5adde625f5d3b4da3528cd/core/css/apps.scss#L873), which is left aligned with the mention, so the contacts menu has to be pulled 6px to the left to horizontally center the tip of the arrow on the avatar.

*2: the height of the mention is 20px, so the top of the contacts menu is at 24px to give some space between the mention and the menu while still keeping the tip of the arrow on the avatar.

**Before:**
![comment-mentions-contacts-menu-before](https://user-images.githubusercontent.com/26858233/45609243-57a2ac80-ba57-11e8-974d-6c12247aab58.png)

**After:**
![comment-mentions-contacts-menu-after](https://user-images.githubusercontent.com/26858233/45609245-5a050680-ba57-11e8-96e1-193f9c0b352a.png)

@nextcloud/designers 
