### PR TITLE
Include empty directories in the default state of acceptance tests

### DIFF
--- a/tests/acceptance/run-local.sh
+++ b/tests/acceptance/run-local.sh
@@ -206,6 +206,8 @@ su --shell /bin/bash --login www-data --command "cd $NEXTCLOUD_DIR && $ACCEPTANC
 
 echo "Saving the default state so acceptance tests can reset to it"
 find . -name ".gitignore" -exec rm --force {} \;
+# Create dummy files in empty directories to force Git to save the directories.
+find . -not -path "*.git*" -type d -empty -exec touch {}/.keep \;
 git add --all && echo 'Default state' | git -c user.name='John Doe' -c user.email='john@doe.org' commit --quiet --file=-
 
 cd tests/acceptance


### PR DESCRIPTION
Before each scenario of the acceptance tests is run the Nextcloud server is reset to a default state. To do this the full directory of the Nextcloud server is commited to a local Git repository and then reset to that commit when needed.

Unfortunately, Git does not support including empty directories in a commit. Due to this, when the default state was restored, it could happen that the file cache listed an empty directory that did not exist because it was not properly restored (for example, `data/appdata_*/css/icons`), and that in turn could lead to an error when the directory was used.

[Currently the only way to force Git to include an empty directory is to add a dummy file to the directory](https://git.wiki.kernel.org/index.php/Git_FAQ#Can_I_add_empty_directories.3F) (so it will no longer be empty, but that should not be a problem in the affected directories, even if the dummy file is not included in the file cache); although Git FAQ suggests using a _.gitignore_ file a _.keep_ file was used instead, as it conveys better its purpose.
