### PR TITLE
[stable13] Include empty directories in the default state of acceptance tests

### DIFF
--- a/tests/acceptance/run-local.sh
+++ b/tests/acceptance/run-local.sh
@@ -160,6 +160,8 @@ tests/acceptance/installAndConfigureServer.sh $INSTALL_AND_CONFIGURE_SERVER_PARA
 
 echo "Saving the default state so acceptance tests can reset to it"
 find . -name ".gitignore" -exec rm --force {} \;
+# Create dummy files in empty directories to force Git to save the directories.
+find . -not -path "*.git*" -type d -empty -exec touch {}/.keep \;
 git add --all && echo 'Default state' | git -c user.name='John Doe' -c user.email='john@doe.org' commit --quiet --file=-
 
 cd tests/acceptance


### PR DESCRIPTION
Backport of #11268