### PR TITLE
[stable14] Revert "Use APCu caching of composer"

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -895,8 +895,6 @@ class OC {
 				self::$loader->setMemoryCache($memcacheFactory->createLocal('Autoloader'));
 			} catch (\Exception $ex) {
 			}
-
-			self::$composerAutoloader->setApcuPrefix($instanceId . '-mainComposer');
 		}
 	}
 


### PR DESCRIPTION
This reverts commit 948ab8a4d06b3821ab94c11a3a04c820e60d6c8a.

For details why see https://github.com/nextcloud/server/issues/11290

Backport of #11292 
