### PR TITLE
only catch QueryException when trying to build class

### DIFF
--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -66,13 +66,7 @@ class SimpleContainer extends Container implements IContainer {
 
 				try {
 					$parameters[] = $this->query($resolveName);
-				} catch (\Exception $e) {
-					if (class_exists('PHPUnit_Framework_AssertionFailedError', false) &&
-						$e instanceof \PHPUnit_Framework_AssertionFailedError) {
-						// Easier debugging of "Your test case is not allowed to access the database."
-						throw $e;
-					}
-
+				} catch (QueryException $e) {
 					// Service not found, use the default value when available
 					if ($parameter->isDefaultValueAvailable()) {
 						$parameters[] = $parameter->getDefaultValue();


### PR DESCRIPTION
This prevents other errors while constructing the class to be hidden as the container falls back to using the parameter name such as in https://github.com/nextcloud/server/issues/11225