### PR TITLE
Allow --database-name and --database-table-prefix for sqlite from occ

### DIFF
--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -38,6 +38,12 @@ use OC\SystemConfig;
  * Takes care of creating and configuring Doctrine connections.
  */
 class ConnectionFactory {
+	/** @var string default database name */
+	const DEFAULT_DBNAME = 'owncloud';
+
+	/** @var string default database table prefix */
+	const DEFAULT_DBTABLEPREFIX = 'oc_';
+
 	/**
 	 * @var array
 	 *
@@ -186,7 +192,7 @@ class ConnectionFactory {
 			'user' => $this->config->getValue('dbuser', ''),
 			'password' => $this->config->getValue('dbpassword', ''),
 		];
-		$name = $this->config->getValue('dbname', 'owncloud');
+		$name = $this->config->getValue('dbname', self::DEFAULT_DBNAME);
 
 		if ($this->normalizeType($type) === 'sqlite3') {
 			$dataDir = $this->config->getValue("datadirectory", \OC::$SERVERROOT . '/data');
@@ -197,7 +203,7 @@ class ConnectionFactory {
 			$connectionParams['dbname'] = $name;
 		}
 
-		$connectionParams['tablePrefix'] = $this->config->getValue('dbtableprefix', 'oc_');
+		$connectionParams['tablePrefix'] = $this->config->getValue('dbtableprefix', self::DEFAULT_DBTABLEPREFIX);
 		$connectionParams['sqlite.journal_mode'] = $this->config->getValue('sqlite.journal_mode', 'WAL');
 
 		//additional driver options, eg. for mysql ssl

--- a/lib/private/Setup/Sqlite.php
+++ b/lib/private/Setup/Sqlite.php
@@ -44,8 +44,13 @@ class Sqlite extends AbstractDatabase {
 		 * in connection factory configuration is obtained from config.php.
 		 */
 
-		$this->dbName = $config['dbname'] ?? ConnectionFactory::DEFAULT_DBNAME;
-		$this->tablePrefix = $config['dbtableprefix'] ?? ConnectionFactory::DEFAULT_DBTABLEPREFIX;
+		$this->dbName = empty($config['dbname'])
+			? ConnectionFactory::DEFAULT_DBNAME
+			: $config['dbname'];
+
+		$this->tablePrefix = empty($config['dbtableprefix'])
+			? ConnectionFactory::DEFAULT_DBTABLEPREFIX
+			: $config['dbtableprefix'];
 
 		if ($this->dbName !== ConnectionFactory::DEFAULT_DBNAME) {
 			$this->config->setValue('dbname', $this->dbName);

--- a/lib/private/Setup/Sqlite.php
+++ b/lib/private/Setup/Sqlite.php
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace OC\Setup;
 
 class Sqlite extends AbstractDatabase {
@@ -29,14 +30,11 @@ class Sqlite extends AbstractDatabase {
 		return array();
 	}
 
-	public function initialize($config) {
-	}
-
 	public function setupDatabase($username) {
 		$datadir = $this->config->getValue('datadirectory', \OC::$SERVERROOT . '/data');
 
 		//delete the old sqlite database first, might cause infinte loops otherwise
-		if(file_exists("$datadir/owncloud.db")) {
+		if (file_exists("$datadir/owncloud.db")) {
 			unlink("$datadir/owncloud.db");
 		}
 		//in case of sqlite, we can always fill the database


### PR DESCRIPTION
Close #3342 

Option --database-name and --database-table-prefix are ignored when passed to occ maintenance:install.
 
https://github.com/nextcloud/server/blob/2e36069e24406455ad3f3998aa25e2a949d1402a/lib/private/Setup/Sqlite.php#L32-L33
They are ignored because `initialize` is overwritten without any logic.
https://github.com/nextcloud/server/blob/2e36069e24406455ad3f3998aa25e2a949d1402a/lib/private/Setup/AbstractDatabase.php#L91-L96
In the parent implementation all parameters are written to config.php.

https://github.com/nextcloud/server/blob/2e36069e24406455ad3f3998aa25e2a949d1402a/lib/private/DB/ConnectionFactory.php#L189
The ConnectionFactory obtains the connection parameters only from config.php. When you pass parameters to occ but they never written to config.php they will not be used.

This behaviour has existed for at least 6 years. I tried to keep the current logic when possible. When you call maintenance:install (or use the web installer) without --database-name or --database-table-prefix the generated config.php looks like before.  They are written to config.php if passed as arguments.