### PR TITLE
sharebymail: Add linebreak before password

### DIFF
--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -479,7 +479,8 @@ class ShareByMailProvider implements IShareProvider {
 		$emailTemplate->addHeader();
 		$emailTemplate->addHeading($this->l->t('Password to access »%s«', [$filename]), false);
 		$emailTemplate->addBodyText(htmlspecialchars($htmlBodyPart), $plainBodyPart);
-		$emailTemplate->addBodyText($this->l->t('It is protected with the following password: %s', [$password]));
+		$emailTemplate->addBodyText($this->l->t('It is protected with the following password:'));
+		$emailTemplate->addBodyText($password);
 
 		// The "From" contains the sharers name
 		$instanceName = $this->defaults->getName();
@@ -600,7 +601,8 @@ class ShareByMailProvider implements IShareProvider {
 		$emailTemplate->addHeader();
 		$emailTemplate->addHeading($this->l->t('Password to access »%s«', [$filename]), false);
 		$emailTemplate->addBodyText($bodyPart);
-		$emailTemplate->addBodyText($this->l->t('This is the password: %s', [$password]));
+		$emailTemplate->addBodyText($this->l->t('This is the password:'));
+		$emailTemplate->addBodyText($password);
 		$emailTemplate->addBodyText($this->l->t('You can choose a different password at any time in the share dialog.'));
 		$emailTemplate->addFooter();
 


### PR DESCRIPTION
This commit will add a paragraph right before the password, so long passwords, containing hyphen or other breakable characters, do not break the password into two lines any more. The password will be in the next line. in HTML-, as well as in text-only view, (the width of the email depends on the email client)

Problem with long passwords:

![auswahl_019](https://user-images.githubusercontent.com/1591563/46402813-15d55f80-c701-11e8-8695-f6274f385651.png)



---
Signed-off-by: Ruben Barkow <github@r.z11.de>