### PR TITLE
Multiselect line-height fix

### DIFF
--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -723,6 +723,7 @@ input {
 			z-index: 1; /* above input */
 			background-color: var(--color-main-background);
 			cursor: pointer;
+			line-height: 17px;
 		}
 		/* displayed text if tag limit reached */
 		.multiselect__strong,


### PR DESCRIPTION
There is no small pull requests :grin: 
Look at the line height :mag: 

|Before|After|
|:--:|:--:|
|![capture d ecran_2018-09-24_22-54-43](https://user-images.githubusercontent.com/14975046/45978563-f11c2080-c04c-11e8-9821-4d3c31ab610d.png)|![capture d ecran_2018-09-24_22-54-37](https://user-images.githubusercontent.com/14975046/45978569-f2e5e400-c04c-11e8-89e0-16b1314526b7.png)|


@nextcloud/designers 