### PR TITLE
adding .well-known/webfinger

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -59,6 +59,7 @@
   RewriteRule .* - [env=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
   RewriteRule ^\.well-known/host-meta /public.php?service=host-meta [QSA,L]
   RewriteRule ^\.well-known/host-meta\.json /public.php?service=host-meta-json [QSA,L]
+  RewriteRule ^\.well-known/webfinger /public.php?service=webfinger [QSA,L]
   RewriteRule ^\.well-known/carddav /remote.php/dav/ [R=301,L]
   RewriteRule ^\.well-known/caldav /remote.php/dav/ [R=301,L]
   RewriteRule ^remote/(.*) remote.php [QSA,L]

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -52,9 +52,14 @@
 		 * @param url the URL to test
 		 * @param placeholderUrl the placeholder URL - can be found at oc_defaults.docPlaceholderUrl
 		 * @param {boolean} runCheck if this is set to false the check is skipped and no error is returned
+		 * @param {int} expectedStatus the expected HTTP status to be returned by the URL, 207 by default
 		 * @return $.Deferred object resolved with an array of error messages
 		 */
-		checkWellKnownUrl: function(url, placeholderUrl, runCheck) {
+		checkWellKnownUrl: function(url, placeholderUrl, runCheck, expectedStatus) {
+			if (expectedStatus === undefined) {
+				expectedStatus = 207;
+			}
+
 			var deferred = $.Deferred();
 
 			if(runCheck === false) {
@@ -63,7 +68,7 @@
 			}
 			var afterCall = function(xhr) {
 				var messages = [];
-				if (xhr.status !== 207) {
+				if (xhr.status !== expectedStatus) {
 					var docUrl = placeholderUrl.replace('PLACEHOLDER', 'admin-setup-well-known-URL');
 					messages.push({
 						msg: t('core', 'Your web server is not properly set up to resolve "{url}". Further information can be found in the <a target="_blank" rel="noreferrer noopener" href="{docLink}">documentation</a>.', { docLink: docUrl, url: url }),

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -61,8 +61,8 @@ describe('OC.SetupChecks tests', function() {
 	});
 
 	describe('checkWellKnownUrl', function() {
-		it('should fail with another response status code than 207', function(done) {
-			var async = OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav', 'http://example.org/PLACEHOLDER', true);
+		it('should fail with another response status code than the expected one', function(done) {
+			var async = OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav', 'http://example.org/PLACEHOLDER', true, 207);
 
 			suite.server.requests[0].respond(200);
 
@@ -75,7 +75,18 @@ describe('OC.SetupChecks tests', function() {
 			});
 		});
 
-		it('should return no error with a response status code of 207', function(done) {
+		it('should return no error with the expected response status code', function(done) {
+			var async = OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav', 'http://example.org/PLACEHOLDER', true, 207);
+
+			suite.server.requests[0].respond(207);
+
+			async.done(function( data, s, x ){
+				expect(data).toEqual([]);
+				done();
+			});
+		});
+
+		it('should return no error with the default expected response status code', function(done) {
 			var async = OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav', 'http://example.org/PLACEHOLDER', true);
 
 			suite.server.requests[0].respond(207);

--- a/public.php
+++ b/public.php
@@ -54,7 +54,7 @@ try {
 		list($service) = explode('/', $pathInfo);
 	}
 	$file = \OC::$server->getConfig()->getAppValue('core', 'public_' . strip_tags($service));
-	if ($file === null) {
+	if ($file === '') {
 		http_response_code(404);
 		exit;
 	}

--- a/settings/Application.php
+++ b/settings/Application.php
@@ -121,6 +121,8 @@ class Application extends App {
 
 		Util::connectHook('OC_User', 'post_setPassword', $this, 'onChangePassword');
 		Util::connectHook('OC_User', 'changeUser', $this, 'onChangeInfo');
+
+		Util::connectHook('\OCP\Config', 'js', $this, 'extendJsConfig');
 	}
 
 	/**
@@ -151,5 +153,19 @@ class Application extends App {
 		/** @var Hooks $hooks */
 		$hooks = $this->getContainer()->query(Hooks::class);
 		$hooks->onChangeEmail($parameters['user'], $parameters['old_value']);
+	}
+
+	/**
+	 * @param array $settings
+	 */
+	public function extendJsConfig(array $settings) {
+		$appConfig = json_decode($settings['array']['oc_appconfig'], true);
+
+		$publicWebFinger = \OC::$server->getConfig()->getAppValue('core', 'public_webfinger', '');
+		if (!empty($publicWebFinger)) {
+			$appConfig['core']['public_webfinger'] = $publicWebFinger;
+		}
+
+		$settings['array']['oc_appconfig'] = json_encode($appConfig);
 	}
 }

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -248,13 +248,14 @@ $(document).ready(function(){
 	// run setup checks then gather error messages
 	$.when(
 		OC.SetupChecks.checkWebDAV(),
+		OC.SetupChecks.checkWellKnownUrl('/.well-known/webfinger', oc_defaults.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === true && !!oc_appconfig.core.public_webfinger, 200),
 		OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav', oc_defaults.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === true),
 		OC.SetupChecks.checkWellKnownUrl('/.well-known/carddav', oc_defaults.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === true),
 		OC.SetupChecks.checkSetup(),
 		OC.SetupChecks.checkGeneric(),
 		OC.SetupChecks.checkDataProtected()
-	).then(function(check1, check2, check3, check4, check5, check6) {
-		var messages = [].concat(check1, check2, check3, check4, check5, check6);
+	).then(function(check1, check2, check3, check4, check5, check6, check7) {
+		var messages = [].concat(check1, check2, check3, check4, check5, check6, check7);
 		var $el = $('#postsetupchecks');
 		$('#security-warning-state-loading').addClass('hidden');
 

--- a/tests/data/setUploadLimit/htaccess
+++ b/tests/data/setUploadLimit/htaccess
@@ -38,6 +38,7 @@ RewriteEngine on
 RewriteRule .* - [env=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 RewriteRule ^\.well-known/host-meta /public.php?service=host-meta [QSA,L]
 RewriteRule ^\.well-known/host-meta\.json /public.php?service=host-meta-json [QSA,L]
+RewriteRule ^\.well-known/webfinger /public.php?service=webfinger [QSA,L]
 RewriteRule ^\.well-known/carddav /remote.php/carddav/ [R=301,L]
 RewriteRule ^\.well-known/caldav /remote.php/caldav/ [R=301,L]
 RewriteRule ^apps/calendar/caldav\.php remote.php/caldav/ [QSA,L]


### PR DESCRIPTION
.wellknown/webfinger is used by ActivityPub to get local account. This would allow any app to catch requests using 

./occ config:app:set --value path_to_phpfile core public_webfinger

Signed-off-by: Maxence Lange <maxence@artificial-owl.com>