### PR TITLE
Reduce settings manager complexity by loading sections via DI

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1081,7 +1081,6 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('SettingsManager', function (Server $c) {
 			$manager = new \OC\Settings\Manager(
 				$c->getLogger(),
-				$c->getDatabaseConnection(),
 				$c->getL10N('lib'),
 				$c->getURLGenerator(),
 				$c

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1083,16 +1083,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getLogger(),
 				$c->getDatabaseConnection(),
 				$c->getL10N('lib'),
-				$c->getConfig(),
-				$c->getEncryptionManager(),
-				$c->getUserManager(),
-				$c->getLockingProvider(),
-				$c->getRequest(),
 				$c->getURLGenerator(),
-				$c->query(AccountManager::class),
-				$c->getGroupManager(),
-				$c->getL10NFactory(),
-				$c->getAppManager()
+				$c
 			);
 			return $manager;
 		});

--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -30,7 +30,6 @@
 namespace OC\Settings;
 
 use OCP\AppFramework\QueryException;
-use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IServerContainer;
@@ -44,9 +43,6 @@ class Manager implements IManager {
 	/** @var ILogger */
 	private $log;
 
-	/** @var IDBConnection */
-	private $dbc;
-
 	/** @var IL10N */
 	private $l;
 
@@ -58,13 +54,11 @@ class Manager implements IManager {
 
 	public function __construct(
 		ILogger $log,
-		IDBConnection $dbc,
 		IL10N $l10n,
 		IURLGenerator $url,
 		IServerContainer $container
 	) {
 		$this->log = $log;
-		$this->dbc = $dbc;
 		$this->l = $l10n;
 		$this->url = $url;
 		$this->container = $container;

--- a/tests/lib/Settings/ManagerTest.php
+++ b/tests/lib/Settings/ManagerTest.php
@@ -42,8 +42,6 @@ class ManagerTest extends TestCase {
 	/** @var ILogger|\PHPUnit_Framework_MockObject_MockObject */
 	private $logger;
 	/** @var IDBConnection|\PHPUnit_Framework_MockObject_MockObject */
-	private $dbConnection;
-	/** @var IL10N|\PHPUnit_Framework_MockObject_MockObject */
 	private $l10n;
 	/** @var IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
 	private $url;
@@ -54,14 +52,12 @@ class ManagerTest extends TestCase {
 		parent::setUp();
 
 		$this->logger = $this->createMock(ILogger::class);
-		$this->dbConnection = $this->createMock(IDBConnection::class);
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->url = $this->createMock(IURLGenerator::class);
 		$this->container = $this->createMock(IServerContainer::class);
 
 		$this->manager = new Manager(
 			$this->logger,
-			$this->dbConnection,
 			$this->l10n,
 			$this->url,
 			$this->container


### PR DESCRIPTION
For https://github.com/nextcloud/server/issues/11381 I need to add some more section to the server's default settings sections and therefore I stumbled over this massively overcomplicated class that build the settings sections for both personal and admin settings.

IMO it's a lot easier and cleaner to load these external classes via the DI container. This way changes to them don't have to be reflected in the settings manager (and they shouldn't -> single responsibility principle).