### PR TITLE
Mailer: discover sendmail path instead of hardcoding it to /usr/sbin/sendmail

### DIFF
--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -274,7 +274,11 @@ class Mailer implements IMailer {
 				$binaryPath = '/var/qmail/bin/sendmail';
 				break;
 			default:
-				$binaryPath = \OC_Helper::findBinaryPath('sendmail');
+				$sendmail = \OC_Helper::findBinaryPath('sendmail');
+				if ($sendmail === null) {
+					$sendmail = '/usr/sbin/sendmail';
+				}
+				$binaryPath = $sendmail;
 				break;
 		}
 

--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -274,7 +274,7 @@ class Mailer implements IMailer {
 				$binaryPath = '/var/qmail/bin/sendmail';
 				break;
 			default:
-				$binaryPath = '/usr/sbin/sendmail';
+				$binaryPath = \OC_Helper::findBinaryPath('sendmail');
 				break;
 		}
 

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -55,7 +55,13 @@ class MailerTest extends TestCase {
 			->with('mail_smtpmode', 'smtp')
 			->will($this->returnValue('sendmail'));
 
-		$this->assertEquals(new \Swift_SendmailTransport('/usr/sbin/sendmail -bs'), self::invokePrivate($this->mailer, 'getSendMailInstance'));
+		$path = \OC_Helper::findBinaryPath('sendmail');
+		if ($path === null) {
+			$path = '/usr/sbin/sendmail';
+		}
+
+		$expected = new \Swift_SendmailTransport($path . ' -bs');
+		$this->assertEquals($expected, self::invokePrivate($this->mailer, 'getSendMailInstance'));
 	}
 
 	public function testGetSendMailInstanceSendMailQmail() {


### PR DESCRIPTION
`sendmail` can very well be in a path different from
`/usr/sbin/sendmail`.

We already search` $PATH` at `lib/private/Settings/Admin/Mail.php` to
detect whether we want to offer sendmail as a mail transfer method, so
let's be consistent and actually initialize `\Swift_SendmailTransport`
with this path to sendmail, instead of just hardcoding
`/usr/sbin/sendmail`.