### PR TITLE
Fix "checkWellKnownUrl" not being run

### DIFF
--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -248,8 +248,8 @@ $(document).ready(function(){
 	// run setup checks then gather error messages
 	$.when(
 		OC.SetupChecks.checkWebDAV(),
-		OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav/', oc_defaults.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === 'true'),
-		OC.SetupChecks.checkWellKnownUrl('/.well-known/carddav/', oc_defaults.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === 'true'),
+		OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav/', oc_defaults.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === true),
+		OC.SetupChecks.checkWellKnownUrl('/.well-known/carddav/', oc_defaults.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === true),
 		OC.SetupChecks.checkSetup(),
 		OC.SetupChecks.checkGeneric(),
 		OC.SetupChecks.checkDataProtected()


### PR DESCRIPTION
[The check is run only if its last parameter is `true`](https://github.com/nextcloud/server/blob/006e150c879312264db10009792c7035be9562dc/core/js/setupchecks.js#L54); [`data()` tries to convert the HTML attribute string to an actual JavaScript value](https://api.jquery.com/data/#data-html5), so [`"true"`](https://github.com/nextcloud/server/blob/57ef1d307bec09c61b813ca6bafe261e8fe4df22/settings/templates/settings/admin/overview.php#L47) is returned as an actual boolean instead of an string; as a strict comparison against `"true"` was used the result was `false` and thus the checks were not run.

**Vue experts**, I just run `make` on the _settings_ directory to update the _settings-vue.js_ and _settings-vue.js.map_ files, but they seem to have quite a lot more changed lines than I would expected for a two contiguous line change in the source. I do not know if I did something wrong :-)

**How to test:**
- Run Nextcloud on Apache
- Remove or comment [the rewrite rules for CardDAV and CalDAV from _.htaccess_](https://github.com/nextcloud/server/blob/de56915605ed1b714b7d9e6320e22c71da5379fd/.htaccess#L62-L63)
- Open the _Overview_ section in the Administration settings
- Wait for the checks to finish

**Expected result:**
Error messages saying _Your web server is not properly set up to resolve..._ for CardDAV and CalDAV. If the lines are restored in the _.htaccess_ obviously the errors go away. 

**Actual result:**
No _Your web server is not properly set up to resolve..._  error messages are shown.
