### PR TITLE
Show auth type "None" in email settings

### DIFF
--- a/settings/templates/settings/admin/additional-mail.php
+++ b/settings/templates/settings/admin/additional-mail.php
@@ -96,7 +96,7 @@ if ($_['mail_smtpmode'] === 'qmail') {
 
 		<p id="setting_smtpauth" <?php if ($_['mail_smtpmode'] !== 'smtp') print_unescaped(' class="hidden"'); ?>>
 			<label for="mail_smtpauthtype"><?php p($l->t('Authentication method')); ?></label>
-			<select name="mail_smtpauthtype" id="mail_smtpauthtype'>
+			<select name="mail_smtpauthtype" id="mail_smtpauthtype">
 				<?php foreach ($mail_smtpauthtype as $authtype => $name):
 					$selected = '';
 					if ($authtype == $_['mail_smtpauthtype']):


### PR DESCRIPTION
Fixes #11218 
Fixes #6304 

Before: "None" is not available in email auth settings
After: it is available

Regression from #4372