### PR TITLE
Fix acceptance tests as app title changed

### DIFF
--- a/tests/acceptance/features/apps.feature
+++ b/tests/acceptance/features/apps.feature
@@ -76,7 +76,7 @@ Feature: apps
     And I am logged in as the admin
     And I open the Apps management
     And I open the "Tools" section
-    When I click on the "Antivirus App for files" app
+    When I click on the "Antivirus for files" app
     Then I see that the app details are shown
 
   Scenario: Install an app from the app store


### PR DESCRIPTION
The redundant app was removed. So we need to update the tests to make it
green.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>