### PR TITLE
extend integration tests with users with numerical IDs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -589,6 +589,16 @@ pipeline:
         when:
           matrix:
             TESTS: integration-ldap-openldap-uid-features
+  integration-ldap-openldap-numerical-id-features:
+    image: nextcloudci/integration-php7.0:integration-php7.0-6
+    commands:
+    - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
+    - ./occ app:enable user_ldap
+    - cd build/integration
+    - ./run.sh ldap_features/openldap-numerical-id.feature
+    when:
+      matrix:
+        TESTS: integration-ldap-openldap-numerical-id-features
   integration-trashbin:
     image: nextcloudci/integration-php7.0:integration-php7.0-8
     commands:
@@ -860,6 +870,8 @@ matrix:
       ENABLE_OPENLDAP: true
     - TESTS: integration-ldap-openldap-uid-features
       ENABLE_OPENLDAP: true
+    - TESTS: integration-ldap-openldap-numerical-id-features
+      ENABLE_OPENLDAP: true
     - TESTS: integration-trashbin
     - TESTS: integration-remote-api
     - TESTS: integration-download
@@ -1042,7 +1054,7 @@ services:
       matrix:
         TESTS: acceptance
   openldap:
-    image: nextcloudci/openldap:openldap-4
+    image: nextcloudci/openldap:openldap-5
     environment:
       - SLAPD_DOMAIN=nextcloud.ci
       - SLAPD_ORGANIZATION=Nextcloud

--- a/build/integration/ldap_features/openldap-numerical-id.feature
+++ b/build/integration/ldap_features/openldap-numerical-id.feature
@@ -1,0 +1,31 @@
+Feature: LDAP
+  Background:
+    Given using api version "2"
+    And having a valid LDAP configuration
+    And modify LDAP configuration
+      | ldapExpertUsernameAttr | employeeNumber |
+      | ldapLoginFilter        | (&(objectclass=inetorgperson)(employeeNumber=%uid)) |
+
+# Those tests are dedicated to ensure Nc is working when it is provided with
+# users having numerical IDs
+
+Scenario: Look for a expected LDAP users
+  Given As an "admin"
+  And sending "GET" to "/cloud/users"
+  Then the OCS status code should be "200"
+  And the "users" result should match
+    | 92379 | 1 |
+    | 50194 | 1 |
+
+Scenario: check default home of an LDAP user
+  Given As an "admin"
+  And sending "GET" to "/cloud/users/92379"
+  Then the OCS status code should be "200"
+  And the record's fields should match
+    | storageLocation | /dev/shm/nc_int/92379 |
+
+Scenario: Test by logging in
+  Given cookies are reset
+  And Logging in using web as "92379"
+  And Sending a "GET" to "/remote.php/webdav/welcome.txt" with requesttoken
+  Then the HTTP status code should be "200"


### PR DESCRIPTION
Not sure we'd catch everything, but it's a start. If it works with LDAP, it'll work with locals, too.

Depends on https://github.com/nextcloud/docker-ci/pull/108