### PR TITLE
AssemblyStream is also eof if we have no more source stream

### DIFF
--- a/apps/dav/lib/Upload/AssemblyStream.php
+++ b/apps/dav/lib/Upload/AssemblyStream.php
@@ -182,7 +182,7 @@ class AssemblyStream implements \Icewind\Streams\File {
 	 * @return bool
 	 */
 	public function stream_eof() {
-		return $this->pos >= $this->size;
+		return $this->pos >= $this->size || $this->currentStream === null;
 	}
 
 	/**


### PR DESCRIPTION
Prevents infinite loops when for some reason we can't read a source node fully.