### PR TITLE
Dont use find to lookup binaries

### DIFF
--- a/lib/private/legacy/helper.php
+++ b/lib/private/legacy/helper.php
@@ -505,20 +505,7 @@ class OC_Helper {
 		if (self::is_function_enabled('exec')) {
 			$exeSniffer = new ExecutableFinder();
 			// Returns null if nothing is found
-			$result = $exeSniffer->find($program);
-			if (empty($result)) {
-				$paths = getenv('PATH');
-				if (empty($paths)) {
-					$paths = '/usr/local/bin /usr/bin /opt/bin /bin';
-				} else {
-					$paths = str_replace(':',' ',getenv('PATH'));
-				}
-				$command = 'find ' . $paths . ' -name ' . escapeshellarg($program) . ' 2> /dev/null';
-				exec($command, $output, $returnCode);
-				if (count($output) > 0) {
-					$result = escapeshellcmd($output[0]);
-				}
-			}
+			$result = $exeSniffer->find($program, null, ['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin', '/opt/bin']);
 		}
 		// store the value for 5 minutes
 		$memcache->set($program, $result, 300);


### PR DESCRIPTION
Found this one when i was investigating why sendmail is not available. `getenv('PATH')` returns false for me because sendmail binary is in `/usr/sbin/sendmail`. 

I guess it would be enough to add `/usr/sbin/` to `$paths` but there is an additional argument for https://github.com/nextcloud/3rdparty/blob/fbffbe12a754bc92ac2ce22df398da8b132d5d7d/symfony/process/ExecutableFinder.php#L47 that allows to define more directories to search for executables. I think its enough to pass the `$paths` to `$execSniffer->find` (it does basically the same as find with an extra check if the file is executable).