### PR TITLE
Change highlight effect of user avatar from opacity to border

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -353,7 +353,9 @@ nav[role='navigation'] {
 			color: var(--color-primary-text);
 
 			img, #expandDisplayName {
-				opacity: .57 !important;
+				border: 2px solid $color-primary-text;
+				margin-top: -2px;
+				margin-left: -2px;
 			}
 		}
 


### PR DESCRIPTION
Before & after:
![screenshot from 2018-09-30 13-07-06](https://user-images.githubusercontent.com/925062/46256910-c9481500-c4b1-11e8-9353-b3c655d713c9.png)
![screenshot from 2018-09-30 13-06-16](https://user-images.githubusercontent.com/925062/46256911-c9e0ab80-c4b1-11e8-826a-106856c09b51.png)

Looks much nicer using the border, and it’s also much more clear, especially when using keyboard to navigate.

Please review @nextcloud/designers, also cc @blackcrack cause this solves the issue you brought up at #11329 in a different way. :)