### PR TITLE
Change wording of 'Copy URL' to more understandable 'Copy link'

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -406,7 +406,7 @@
 				permissions: permissions
 			});
 		},
-		
+
 		showNoteForm: function(event) {
 			event.preventDefault();
 			event.stopPropagation();
@@ -431,9 +431,9 @@
 			var shareId = $li.data('share-id');
 			var $menu = $element.closest('li');
 			var $form = $menu.next('li.share-note-form');
-	
+
 			$form.find('.share-note').val('');
-			
+
 			$form.addClass('hidden');
 			$menu.find('.share-note-delete').hide();
 
@@ -600,7 +600,7 @@
 
 			var popover = this.popoverMenuTemplate({
 				cid: this.model.get('linkShare').id,
-				copyLabel: t('core', 'Copy URL'),
+				copyLabel: t('core', 'Copy link'),
 				social: social,
 
 				shareLinkURL: this.model.get('linkShare').link,
@@ -745,7 +745,7 @@
 			var datePicker = $(expirationDatePicker);
 			var state = $element.prop('checked');
 			datePicker.toggleClass('hidden', !state);
-			
+
 			if (!state) {
 				// disabled, let's hide the input and
 				// set the expireDate to nothing

--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -227,9 +227,9 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function copyUrlMenuItem() {
-		return Locator::forThe()->xpath("//a[normalize-space() = 'Copy URL']")->
+		return Locator::forThe()->xpath("//a[normalize-space() = 'Copy link']")->
 				descendantOf(self::shareLinkMenu())->
-				describedAs("Copy URL menu item in the share link menu in the details view in Files app");
+				describedAs("Copy link menu item in the share link menu in the details view in Files app");
 	}
 
 	/**


### PR DESCRIPTION
Quick review @nextcloud/designers :)

It’s in the files sidebar, in the dropdown for the share link:
![screenshot from 2018-10-01 11-04-20](https://user-images.githubusercontent.com/925062/46279591-c6a8f680-c569-11e8-9aa0-2b5a8f659363.png)
