### PR TITLE
Fix public page footer link wrap

### DIFF
--- a/core/css/public.scss
+++ b/core/css/public.scss
@@ -73,8 +73,11 @@ $footer-height: 65px;
 			a {
 				color: var(--color-text-lighter);
 				font-weight: 600;
+				white-space: nowrap;
+				/* increasing clickability to more than the text height */
 				padding: 13px;
 				margin: -13px;
+				line-height: 200%;
 			}
 		}
 	}


### PR DESCRIPTION
Small fix to not make the link wrap. Also increasing the line height so the links touch a bit less (with the added clickability area).

Before & after:
![screenshot from 2018-10-01 11-14-59](https://user-images.githubusercontent.com/925062/46280429-2dc7aa80-c56c-11e8-8f8d-4d89405fe8e1.png)
![screenshot from 2018-10-01 11-14-06](https://user-images.githubusercontent.com/925062/46280430-2e604100-c56c-11e8-8c47-69ef2c5a6bda.png)


Please review @nextcloud/designers – maybe worth backporting cause it’s a small fix for smth that just looks off?