### PR TITLE
Fix share header text on small widths

### DIFF
--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -165,6 +165,8 @@ thead {
 	font-weight: 300;
 	font-size: 11px;
 	opacity: .57;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 #note-content {

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -65,6 +65,8 @@
 	display: flex;
 	align-items: center;
 	flex-wrap: wrap;
+	overflow: hidden;
+
 	&:focus {
 		opacity: .75;
 	}
@@ -151,6 +153,7 @@
 		flex: 0 0;
 		flex-grow: 1;
 		white-space: nowrap;
+		overflow: hidden;
 	}
 
 	#header-right, .header-right {
@@ -206,7 +209,7 @@
 	}
 }
 
-/* show appname next to logo */
+/* only used for public share pages now as we have the app icons when logged in */
 .header-appname {
 	color: var(--color-primary-text);
 	font-size: 16px;
@@ -214,6 +217,8 @@
 	margin: 0;
 	padding: 0;
 	padding-right: 5px;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 /* do not show menu toggle on public share links as there is no menu */

--- a/core/css/public.scss
+++ b/core/css/public.scss
@@ -8,8 +8,6 @@ $footer-height: 65px;
 		}
 
 		#header-secondary-action {
-			margin-right: 13px;
-
 			ul li {
 				min-width: 270px;
 			}


### PR DESCRIPTION
Before:
![Animation of header before, text does not get ellipsized](https://user-images.githubusercontent.com/925062/46282007-b1839600-c570-11e8-8af5-4049f7ae16c1.gif)

After:
![Animation of header after, text gets ellipsized](https://user-images.githubusercontent.com/925062/46282008-b1839600-c570-11e8-88a9-1f87a21b80ee.gif)

Please review @nextcloud/designers – we should also backport this since it limits the usability of the share page on mobile.