### PR TITLE
Reduce the min-width of the files table so it works on sharing pages on mobile

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -49,7 +49,7 @@
 #filestable {
 	position: relative;
 	width: 100%;
-	min-width: 500px;
+	min-width: 250px;
 }
 
 /* fit app list view heights */

--- a/apps/files/css/mobile.scss
+++ b/apps/files/css/mobile.scss
@@ -7,9 +7,8 @@
 	background-color: rgba(255, 255, 255, 1)!important;
 }
 
-/* don’t require a minimum width for files table */
 #body-user #filestable {
-	min-width: 300px;
+	min-width: 250px;
 }
 
 table th#headerSize,


### PR DESCRIPTION
This was introduced in https://github.com/nextcloud/server/pull/9982 via https://github.com/nextcloud/server/commit/43ab2082db0db30fd31e9597ed895e0cf3febe47 – cc @skjnldsv was there a specific reason there?

The issue is that for public sharing pages, only the 500px is in effect. There’s not really a reason to limit it either way as far as I can see? Tested when logged in on various widths too.

Probably should be backported cause public shares on mobile are kinda broken due to this?

Before, way too wide when cut off:
![screenshot from 2018-10-01 12-36-22](https://user-images.githubusercontent.com/925062/46284036-a6cbff80-c576-11e8-8d4c-758691066165.png)

After, goes down to reasonable last useful width:
![screenshot from 2018-10-01 12-35-52](https://user-images.githubusercontent.com/925062/46284037-a7649600-c576-11e8-89a5-6d283ecb3f40.png)


Please review @nextcloud/designers 