### PR TITLE
S3 reuse information from listObject and skip headObject

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -61,10 +61,14 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 	/** @var CappedMemoryCache|Result[] */
 	private $objectCache;
 
+	/** @var CappedMemoryCache|array */
+	private $filesCache;
+
 	public function __construct($parameters) {
 		parent::__construct($parameters);
 		$this->parseParams($parameters);
 		$this->objectCache = new CappedMemoryCache();
+		$this->filesCache = new CappedMemoryCache();
 	}
 
 	/**
@@ -302,10 +306,11 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 						);
 						$files[] = $file;
 
-						$this->objectCache->set($file, [
+						// store this information for later usage
+						$this->filesCache[$file] = [
 							'ContentLength' => $object['Size'],
 							'LastModified' => (string)$object['LastModified'],
-						]);
+						];
 					}
 				}
 			}
@@ -321,20 +326,14 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		$path = $this->normalizePath($path);
 
 		try {
-			$stat = array();
+			$stat = [];
 			if ($this->is_dir($path)) {
 				//folders don't really exist
 				$stat['size'] = -1; //unknown
 				$stat['mtime'] = time() - $this->rescanDelay * 1000;
 			} else {
-				$result = $this->headObject($path);
-
-				$stat['size'] = $result['ContentLength'] ? $result['ContentLength'] : 0;
-				if (isset($result['Metadata']['lastmodified'])) {
-					$stat['mtime'] = strtotime($result['Metadata']['lastmodified']);
-				} else {
-					$stat['mtime'] = strtotime($result['LastModified']);
-				}
+				$stat['size'] = $this->getContentLength($path);
+				$stat['mtime'] = strtotime($this->getLastModified($path));
 			}
 			$stat['atime'] = time();
 
@@ -343,6 +342,50 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			\OC::$server->getLogger()->logException($e, ['app' => 'files_external']);
 			return false;
 		}
+	}
+
+	/**
+	 * Return content length for object
+	 *
+	 * When the information is already present (e.g. opendir has been called before)
+	 * this value is return. Otherwise a headObject is emitted.
+	 *
+	 * @param $path
+	 * @return int|mixed
+	 */
+	private function getContentLength($path) {
+		if (isset($this->filesCache[$path])) {
+			return $this->filesCache[$path]['ContentLength'];
+		}
+
+		$result = $this->headObject($path);
+		if (isset($result['ContentLength'])) {
+			return $result['ContentLength'];
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Return last modified for object
+	 *
+	 * When the information is already present (e.g. opendir has been called before)
+	 * this value is return. Otherwise a headObject is emitted.
+	 *
+	 * @param $path
+	 * @return mixed|string
+	 */
+	private function getLastModified($path) {
+		if (isset($this->filesCache[$path])) {
+			return $this->filesCache[$path]['LastModified'];
+		}
+
+		$result = $this->headObject($path);
+		if (isset($result['LastModified'])) {
+			return $result['LastModified'];
+		}
+
+		return 'now';
 	}
 
 	public function is_dir($path) {

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -301,6 +301,11 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 							isset($object['Key']) ? $object['Key'] : $object['Prefix']
 						);
 						$files[] = $file;
+
+						$this->objectCache->set($file, [
+							'ContentLength' => $object['Size'],
+							'LastModified' => (string)$object['LastModified'],
+						]);
 					}
 				}
 			}

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -98,6 +98,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 
 	private function clearCache() {
 		$this->objectCache = new CappedMemoryCache();
+		$this->filesCache = new CappedMemoryCache();
 	}
 
 	private function invalidateCache($key) {
@@ -109,6 +110,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 				unset($this->objectCache[$existingKey]);
 			}
 		}
+		unset($this->filesCache[$key]);
 	}
 
 	/**


### PR DESCRIPTION
I've noticed when looking into https://github.com/nextcloud/server/issues/6954 that there are many unneccessary headObject requests.

According to https://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html#v2-RESTBucketGET-responses-examples Size, LastModified and Etag returned with listObjects.

![image](https://user-images.githubusercontent.com/3902676/46308140-2bd80880-c5b9-11e8-8fba-03cc2ee71d1f.png)

When calling `stat` for a file the required information are size and last modified. Reusing this information from listObjects may save some api calls.