### PR TITLE
Manually instantiate jscolor to avoid csp errors

### DIFF
--- a/apps/theming/js/settings-admin.js
+++ b/apps/theming/js/settings-admin.js
@@ -106,6 +106,10 @@ function hideUndoButton(setting, value) {
 $(document).ready(function () {
 	$('#theming [data-toggle="tooltip"]').tooltip();
 
+	// manually instantiate jscolor to work around new Function call which violates strict CSP
+	var colorElement = $('#theming-color')[0];
+	var jscolor = new window.jscolor(colorElement, {hash: true});
+
 	$('#theming .theme-undo').each(function() {
 		var setting = $(this).data('setting');
 		var value = $('#theming-'+setting).val();

--- a/apps/theming/templates/settings-admin.php
+++ b/apps/theming/templates/settings-admin.php
@@ -62,7 +62,7 @@ style('theming', 'settings-admin');
 	<div>
 		<label>
 			<span><?php p($l->t('Color')) ?></span>
-			<input id="theming-color" type="text" class="jscolor" data-jscolor="{hash:true}" maxlength="7" value="<?php p($_['color']) ?>" />
+			<input id="theming-color" type="text" maxlength="7" value="<?php p($_['color']) ?>" />
 			<div data-setting="color" data-toggle="tooltip" data-original-title="<?php p($l->t('Reset to default')); ?>" class="theme-undo icon icon-history"></div>
 		</label>
 	</div>


### PR DESCRIPTION
Fixes #11031 

When using the data-jscolor attribute, jscolor will call `opts = (new Function ('return (' + optsStr + ')'))();` with the string which is blocked by the strict csp from https://github.com/nextcloud/server/pull/11028. This is a workaround to avoid the call.