### PR TITLE
Adjust border-radius-large to fit with padding of modals

### DIFF
--- a/core/css/variables.scss
+++ b/core/css/variables.scss
@@ -73,7 +73,7 @@ $color-border: nc-darken($color-main-background, 7%) !default;
 // darker border like inputs or very visible elements
 $color-border-dark: nc-darken($color-main-background, 14%) !default;
 $border-radius: 3px !default;
-$border-radius-large: 20px;
+$border-radius-large: 10px;
 
 $font-face: 'Open Sans', Frutiger, Calibri, 'Myriad Pro', Myriad, sans-serif !default;
 


### PR DESCRIPTION
So the border-radius doesn’t have to be chosen just willy-nilly, but we have an anchor point and that are the buttons on the bottom (or generally elements inside):

This is how it looks in this pull request: 15px border-radius, to fit the [15px padding of .oc-dialog](https://github.com/nextcloud/server/blob/master/core/css/jquery.ocdialog.scss#L6):
![screenshot from 2018-10-02 10-10-55](https://user-images.githubusercontent.com/925062/46336799-1ea83180-c62c-11e8-8068-69788244ebc8.png)

This is how it was after my pull request – yes that’s too big (but also accounted for the margin of the buttons):
![screenshot from 2018-10-02 10-09-40](https://user-images.githubusercontent.com/925062/46336802-1ea83180-c62c-11e8-9ede-30f811367f65.png)

This is 10px (would also happen with less), creating a bump → for reference see this [admittedly quite old article, cause it’s an old issue](http://www.artofadambetts.com/weblog/2006/08/graphic-tip-rounded-rectangle-borders/):
![screenshot from 2018-10-02 10-10-32](https://user-images.githubusercontent.com/925062/46336800-1ea83180-c62c-11e8-8be7-b22f6f476d27.png)

