### PR TITLE
Add job to check users for backup code reminders

### DIFF
--- a/apps/twofactor_backupcodes/appinfo/info.xml
+++ b/apps/twofactor_backupcodes/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Two factor backup codes</name>
 	<summary>A two-factor auth backup codes provider</summary>
 	<description>A two-factor auth backup codes provider</description>
-	<version>1.4.0</version>
+	<version>1.4.1</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<namespace>TwoFactorBackupCodes</namespace>
@@ -15,6 +15,12 @@
 	<dependencies>
 		<nextcloud min-version="15" max-version="15" />
 	</dependencies>
+
+	<repair-steps>
+		<post-migration>
+			<step>OCA\TwoFactorBackupCodes\Migration\CheckBackupCodes</step>
+		</post-migration>
+	</repair-steps>
 
 	<two-factor-providers>
 		<provider>OCA\TwoFactorBackupCodes\Provider\BackupCodesProvider</provider>

--- a/apps/twofactor_backupcodes/composer/composer/autoload_classmap.php
+++ b/apps/twofactor_backupcodes/composer/composer/autoload_classmap.php
@@ -8,6 +8,7 @@ $baseDir = $vendorDir;
 return array(
     'OCA\\TwoFactorBackupCodes\\Activity\\Provider' => $baseDir . '/../lib/Activity/Provider.php',
     'OCA\\TwoFactorBackupCodes\\AppInfo\\Application' => $baseDir . '/../lib/AppInfo/Application.php',
+    'OCA\\TwoFactorBackupCodes\\BackgroundJob\\CheckBackupCodes' => $baseDir . '/../lib/BackgroundJob/CheckBackupCodes.php',
     'OCA\\TwoFactorBackupCodes\\BackgroundJob\\RememberBackupCodesJob' => $baseDir . '/../lib/BackgroundJob/RememberBackupCodesJob.php',
     'OCA\\TwoFactorBackupCodes\\Controller\\SettingsController' => $baseDir . '/../lib/Controller/SettingsController.php',
     'OCA\\TwoFactorBackupCodes\\Db\\BackupCode' => $baseDir . '/../lib/Db/BackupCode.php',
@@ -18,6 +19,7 @@ return array(
     'OCA\\TwoFactorBackupCodes\\Listener\\IListener' => $baseDir . '/../lib/Listener/IListener.php',
     'OCA\\TwoFactorBackupCodes\\Listener\\ProviderEnabled' => $baseDir . '/../lib/Listener/ProviderEnabled.php',
     'OCA\\TwoFactorBackupCodes\\Listener\\RegistryUpdater' => $baseDir . '/../lib/Listener/RegistryUpdater.php',
+    'OCA\\TwoFactorBackupCodes\\Migration\\CheckBackupCodes' => $baseDir . '/../lib/Migration/CheckBackupCodes.php',
     'OCA\\TwoFactorBackupCodes\\Migration\\Version1002Date20170607104347' => $baseDir . '/../lib/Migration/Version1002Date20170607104347.php',
     'OCA\\TwoFactorBackupCodes\\Migration\\Version1002Date20170607113030' => $baseDir . '/../lib/Migration/Version1002Date20170607113030.php',
     'OCA\\TwoFactorBackupCodes\\Migration\\Version1002Date20170919123342' => $baseDir . '/../lib/Migration/Version1002Date20170919123342.php',

--- a/apps/twofactor_backupcodes/composer/composer/autoload_static.php
+++ b/apps/twofactor_backupcodes/composer/composer/autoload_static.php
@@ -23,6 +23,7 @@ class ComposerStaticInitTwoFactorBackupCodes
     public static $classMap = array (
         'OCA\\TwoFactorBackupCodes\\Activity\\Provider' => __DIR__ . '/..' . '/../lib/Activity/Provider.php',
         'OCA\\TwoFactorBackupCodes\\AppInfo\\Application' => __DIR__ . '/..' . '/../lib/AppInfo/Application.php',
+        'OCA\\TwoFactorBackupCodes\\BackgroundJob\\CheckBackupCodes' => __DIR__ . '/..' . '/../lib/BackgroundJob/CheckBackupCodes.php',
         'OCA\\TwoFactorBackupCodes\\BackgroundJob\\RememberBackupCodesJob' => __DIR__ . '/..' . '/../lib/BackgroundJob/RememberBackupCodesJob.php',
         'OCA\\TwoFactorBackupCodes\\Controller\\SettingsController' => __DIR__ . '/..' . '/../lib/Controller/SettingsController.php',
         'OCA\\TwoFactorBackupCodes\\Db\\BackupCode' => __DIR__ . '/..' . '/../lib/Db/BackupCode.php',
@@ -33,6 +34,7 @@ class ComposerStaticInitTwoFactorBackupCodes
         'OCA\\TwoFactorBackupCodes\\Listener\\IListener' => __DIR__ . '/..' . '/../lib/Listener/IListener.php',
         'OCA\\TwoFactorBackupCodes\\Listener\\ProviderEnabled' => __DIR__ . '/..' . '/../lib/Listener/ProviderEnabled.php',
         'OCA\\TwoFactorBackupCodes\\Listener\\RegistryUpdater' => __DIR__ . '/..' . '/../lib/Listener/RegistryUpdater.php',
+        'OCA\\TwoFactorBackupCodes\\Migration\\CheckBackupCodes' => __DIR__ . '/..' . '/../lib/Migration/CheckBackupCodes.php',
         'OCA\\TwoFactorBackupCodes\\Migration\\Version1002Date20170607104347' => __DIR__ . '/..' . '/../lib/Migration/Version1002Date20170607104347.php',
         'OCA\\TwoFactorBackupCodes\\Migration\\Version1002Date20170607113030' => __DIR__ . '/..' . '/../lib/Migration/Version1002Date20170607113030.php',
         'OCA\\TwoFactorBackupCodes\\Migration\\Version1002Date20170919123342' => __DIR__ . '/..' . '/../lib/Migration/Version1002Date20170919123342.php',

--- a/apps/twofactor_backupcodes/lib/BackgroundJob/CheckBackupCodes.php
+++ b/apps/twofactor_backupcodes/lib/BackgroundJob/CheckBackupCodes.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2018, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\TwoFactorBackupCodes\BackgroundJob;
+
+use OC\Authentication\TwoFactorAuth\Manager;
+use OC\BackgroundJob\QueuedJob;
+use OCP\Authentication\TwoFactorAuth\IRegistry;
+use OCP\BackgroundJob\IJobList;
+use OCP\IUser;
+use OCP\IUserManager;
+
+class CheckBackupCodes extends QueuedJob {
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var IJobList */
+	private $jobList;
+
+	/** @var Manager */
+	private $registry;
+
+	/** @var Manager */
+	private $twofactorManager;
+
+	public function __construct(IUserManager $userManager, IJobList $jobList, Manager $twofactorManager, IRegistry $registry) {
+		$this->userManager = $userManager;
+		$this->jobList = $jobList;
+		$this->twofactorManager = $twofactorManager;
+		$this->registry = $registry;
+	}
+
+	protected function run($argument) {
+		$this->userManager->callForSeenUsers(function(IUser $user) {
+			$providers = $this->registry->getProviderStates($user);
+			$isTwoFactorAuthenticated = $this->twofactorManager->isTwoFactorAuthenticated($user);
+
+			if ($isTwoFactorAuthenticated && isset($providers['backup_codes']) && $providers['backup_codes'] === false) {
+				$this->jobList->add(RememberBackupCodesJob::class, ['uid' => $user->getUID()]);
+			}
+		});
+	}
+
+}

--- a/apps/twofactor_backupcodes/lib/Migration/CheckBackupCodes.php
+++ b/apps/twofactor_backupcodes/lib/Migration/CheckBackupCodes.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2018, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\TwoFactorBackupCodes\Migration;
+
+use OCP\BackgroundJob\IJobList;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class CheckBackupCodes implements IRepairStep {
+
+	/** @var IJobList */
+	private $jobList;
+
+	public function __construct(IJobList $jobList) {
+		$this->jobList = $jobList;
+	}
+
+	public function getName(): string {
+		return 'Add background job to check for backup codes';
+	}
+
+	public function run(IOutput $output) {
+		$this->jobList->add(\OCA\TwoFactorBackupCodes\BackgroundJob\CheckBackupCodes::class);
+	}
+
+}

--- a/apps/twofactor_backupcodes/tests/Unit/BackgroundJob/CheckBackupCodeTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/BackgroundJob/CheckBackupCodeTest.php
@@ -1,0 +1,133 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2018, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\TwoFactorBackupCodes\Tests\Unit\BackgroundJob;
+
+use OC\Authentication\TwoFactorAuth\Manager;
+use OCA\TwoFactorBackupCodes\BackgroundJob\CheckBackupCodes;
+use OCA\TwoFactorBackupCodes\BackgroundJob\RememberBackupCodesJob;
+use OCP\Authentication\TwoFactorAuth\IRegistry;
+use OCP\BackgroundJob\IJobList;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class CheckBackupCodeTest extends TestCase {
+
+	/** @var IUserManager|MockObject */
+	private $userManager;
+
+	/** @var IJobList|MockObject */
+	private $jobList;
+
+	/** @var IRegistry|MockObject */
+	private $registry;
+
+	/** @var Manager|MockObject */
+	private $manager;
+
+	/** @var IUser|MockObject */
+	private $user;
+
+	/** @var CheckBackupCodes */
+	private $checkBackupCodes;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->jobList = $this->createMock(IJobList::class);
+		$this->registry = $this->createMock(IRegistry::class);
+		$this->manager = $this->createMock(Manager::class);
+
+		$this->user = $this->createMock(IUser::class);
+
+		$this->userManager->method('callForSeenUsers')
+			->will($this->returnCallback(function(\Closure $e) {
+				$e($this->user);
+			}));
+
+		$this->checkBackupCodes = new CheckBackupCodes(
+			$this->userManager,
+			$this->jobList,
+			$this->manager,
+			$this->registry
+		);
+	}
+
+	public function testRunAlreadyGenerated() {
+		$this->registry->method('getProviderStates')
+			->with($this->user)
+			->willReturn(['backup_codes' => true]);
+		$this->manager->method('isTwoFactorAuthenticated')
+			->with($this->user)
+			->willReturn(true);
+		$this->jobList->expects($this->never())
+			->method($this->anything());
+
+		$this->invokePrivate($this->checkBackupCodes, 'run', [[]]);
+	}
+
+	public function testRun() {
+		$this->user->method('getUID')
+			->willReturn('myUID');
+
+		$this->registry->expects($this->once())
+			->method('getProviderStates')
+			->with($this->user)
+			->willReturn([
+				'backup_codes' => false,
+			]);
+		$this->jobList->expects($this->once())
+			->method('add')
+			->with(
+				$this->equalTo(RememberBackupCodesJob::class),
+				['uid' => 'myUID']
+			);
+		$this->manager->method('isTwoFactorAuthenticated')
+			->with($this->user)
+			->willReturn(true);
+
+		$this->invokePrivate($this->checkBackupCodes, 'run', [[]]);
+	}
+
+	public function testRunNoProviders() {
+		$this->registry->expects($this->once())
+			->method('getProviderStates')
+			->with($this->user)
+			->willReturn([
+				'backup_codes' => false,
+			]);
+		$this->jobList->expects($this->never())
+			->method($this->anything());
+		$this->manager->method('isTwoFactorAuthenticated')
+			->with($this->user)
+			->willReturn(false);
+
+		$this->invokePrivate($this->checkBackupCodes, 'run', [[]]);
+	}
+
+
+}

--- a/apps/twofactor_backupcodes/tests/Unit/Migration/CheckBackupCodeTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Migration/CheckBackupCodeTest.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\TwoFactorBackupCodes\Tests\Unit\Migration;
+
+use OCA\TwoFactorBackupCodes\Event\CodesGenerated;
+use OCA\TwoFactorBackupCodes\Listener\RegistryUpdater;
+use OCA\TwoFactorBackupCodes\Migration\CheckBackupCodes;
+use OCA\TwoFactorBackupCodes\Provider\BackupCodesProvider;
+use OCP\Authentication\TwoFactorAuth\IRegistry;
+use OCP\BackgroundJob\IJobList;
+use OCP\IUser;
+use OCP\Migration\IOutput;
+use Symfony\Component\EventDispatcher\Event;
+use Test\TestCase;
+
+class CheckBackupCodeTest extends TestCase {
+
+	/** @var IJobList|\PHPunit\Framework\MockObject\MockObject */
+	private $jobList;
+
+	/** @var CheckBackupCodes */
+	private $checkBackupsCodes;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->jobList = $this->createMock(IJobList::class);
+		$this->checkBackupsCodes = new CheckBackupCodes($this->jobList);
+	}
+
+	public function testGetName() {
+		$this->assertSame('Add background job to check for backup codes', $this->checkBackupsCodes->getName());
+	}
+
+	public function testRun() {
+		$this->jobList->expects($this->once())
+			->method('add')
+			->with(
+				$this->equalTo(\OCA\TwoFactorBackupCodes\BackgroundJob\CheckBackupCodes::class)
+			);
+
+		$this->checkBackupsCodes->run($this->createMock(IOutput::class));
+	}
+}


### PR DESCRIPTION
Now that we can enforce 2FA we also should notify users that have
enabled 2FA but do not yet have backup codes generated.

This adds a repair step that inserts a background job to do this.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>