### PR TITLE
Hides the header actions for file drops

### DIFF
--- a/apps/files_sharing/css/mobile.scss
+++ b/apps/files_sharing/css/mobile.scss
@@ -51,4 +51,13 @@ table td.filename .nametext {
     background-position: center;
 }
 
+	.disclaimer,
+	.note {
+		padding: 0 20px;
+	}
+
+	#emptycontent {
+		margin-top: 10vh;
+	}
+
 }

--- a/apps/files_sharing/css/mobile.scss
+++ b/apps/files_sharing/css/mobile.scss
@@ -50,8 +50,6 @@ table td.filename .nametext {
     padding-right: 14px;
     background-position: center;
 }
-
-	.disclaimer,
 	.note {
 		padding: 0 20px;
 	}
@@ -59,5 +57,4 @@ table td.filename .nametext {
 	#emptycontent {
 		margin-top: 10vh;
 	}
-
 }

--- a/apps/files_sharing/css/mobile.scss
+++ b/apps/files_sharing/css/mobile.scss
@@ -50,11 +50,11 @@ table td.filename .nametext {
     padding-right: 14px;
     background-position: center;
 }
-	.note {
-		padding: 0 20px;
-	}
+.note {
+	padding: 0 20px;
+}
 
-	#emptycontent {
-		margin-top: 10vh;
-	}
+#emptycontent {
+	margin-top: 10vh;
+}
 }

--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -92,8 +92,15 @@ thead {
 	margin: 0 auto;
 }
 
-#emptycontent.has-disclaimer {
-	margin-top: 10vh;
+#emptycontent {
+	&.has-disclaimer,
+	&.has-note {
+		margin-top: 10vh;
+	}
+
+	&.has-disclaimer.has-note {
+		margin-top: 5vh;
+	}
 }
 
 #public-upload #emptycontent h2 {
@@ -152,8 +159,9 @@ thead {
 	margin-right: 7px;
 }
 
-.disclaimer {
-	margin: -20px auto 30px;
+.disclaimer,
+.note {
+	margin: 0 auto 30px;
 	max-width: 400px;
 	text-align: left;
 }

--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -93,12 +93,7 @@ thead {
 }
 
 #emptycontent {
-	&.has-disclaimer,
 	&.has-note {
-		margin-top: 10vh;
-	}
-
-	&.has-disclaimer.has-note {
 		margin-top: 5vh;
 	}
 }
@@ -190,6 +185,10 @@ thead {
 		overflow: auto;
 		max-height: 200px;
 	}
+}
+
+#show-terms-dialog {
+	cursor: pointer;
 }
 
 // hide the primary on public share on mobile

--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -189,6 +189,7 @@ thead {
 
 #show-terms-dialog {
 	cursor: pointer;
+	font-weight: bold;
 }
 
 // hide the primary on public share on mobile

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -89,7 +89,7 @@ OCA.Sharing.PublicApp = {
 								displayName: t('files', 'Delete'),
 								iconClass: 'icon-delete',
 						}
-					] 
+					]
 				}
 			);
 			this.files = OCA.Files.Files;
@@ -297,8 +297,22 @@ OCA.Sharing.PublicApp = {
 			}
 		});
 
+		self._bindShowTermsAction();
+
 		// legacy
 		window.FileList = this.fileList;
+	},
+
+	/**
+	 * Binds the click action for the "terms of service" action.
+	 * Shows an OC info dialog on click.
+	 *
+	 * @private
+	 */
+	_bindShowTermsAction: function() {
+		$('#show-terms-dialog').on('click', function() {
+			OC.dialogs.info($('#disclaimerText').val(), t('files_sharing', 'Terms of service'));
+		});
 	},
 
 	_showTextPreview: function (data, previewHeight) {

--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -409,6 +409,7 @@ class ShareController extends AuthPublicShareController {
 		\OCP\Util::addScript('files', 'file-upload');
 		\OCP\Util::addStyle('files_sharing', 'publicView');
 		\OCP\Util::addScript('files_sharing', 'public');
+		\OCP\Util::addScript('files_sharing', 'templates');
 		\OCP\Util::addScript('files', 'fileactions');
 		\OCP\Util::addScript('files', 'fileactionsmenu');
 		\OCP\Util::addScript('files', 'jquery.fileupload');

--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -327,7 +327,7 @@ class ShareController extends AuthPublicShareController {
 
 		$hideFileList = false;
 
-		if ($share->getNode() instanceof \OCP\Files\Folder) {
+		if ($shareNode instanceof \OCP\Files\Folder) {
 
 			$shareIsFolder = true;
 

--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -409,8 +409,6 @@ class ShareController extends AuthPublicShareController {
 		\OCP\Util::addScript('files', 'file-upload');
 		\OCP\Util::addStyle('files_sharing', 'publicView');
 		\OCP\Util::addScript('files_sharing', 'public');
-		\OCP\Util::addScript('files_sharing', 'templates');
-		\OCP\Util::addScript('files_sharing', 'public_note');
 		\OCP\Util::addScript('files', 'fileactions');
 		\OCP\Util::addScript('files', 'fileactionsmenu');
 		\OCP\Util::addScript('files', 'jquery.fileupload');
@@ -447,6 +445,7 @@ class ShareController extends AuthPublicShareController {
 		$response->setHeaderTitle($shareTmpl['filename']);
 		$response->setHeaderDetails($this->l10n->t('shared by %s', [$shareTmpl['displayName']]));
 		if (!$share->getHideDownload()) {
+			\OCP\Util::addScript('files_sharing', 'public_note');
 			$response->setHeaderActions([
 				new SimpleMenuAction('download', $this->l10n->t('Download'), 'icon-download-white', $shareTmpl['downloadURL'], 0),
 				new SimpleMenuAction('download', $this->l10n->t('Download'), 'icon-download', $shareTmpl['downloadURL'], 10, $shareTmpl['fileSize']),

--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -61,7 +61,6 @@ use OCA\Files_Sharing\Activity\Providers\Downloads;
 use OCP\Files\NotFoundException;
 use OCP\Files\IRootFolder;
 use OCP\Share\Exceptions\ShareNotFound;
-use OCP\Util;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use OCP\Share\IManager as ShareManager;

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -82,13 +82,20 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 <?php } else { ?>
 	<input type="hidden" id="upload-only-interface" value="1"/>
 	<div id="public-upload">
-		<div id="emptycontent" class="<?php if (!empty($_['disclaimer'])) { ?>has-disclaimer<?php } ?>">
+		<div
+				id="emptycontent"
+				class="<?php if (!empty($_['disclaimer'])) { ?>has-disclaimer<?php } ?> <?php if (!empty($_['note'])) { ?>has-note<?php } ?>">
 			<div id="displayavatar"><div class="avatardiv"></div></div>
 			<h2><?php p($l->t('Upload files to %s', [$_['shareOwner']])) ?></h2>
 			<p><span class="icon-folder"></span> <?php p($_['filename']) ?></p>
+
 			<?php if (!empty($_['disclaimer'])) { ?>
 				<p class="disclaimer"><?php p($_['disclaimer']); ?></p>
 			<?php } ?>
+			<?php if (empty($_['note']) === false) { ?>
+				<p class="note"><?php p($_['note']); ?></p>
+			<?php } ?>
+
 			<input type="file" name="files[]" class="hidden" multiple>
 
 			<a href="#" class="button icon-upload"><?php p($l->t('Select or drop files')) ?></a>

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -21,6 +21,7 @@
 <input type="hidden" name="previewSupported" value="<?php p($_['previewSupported'] ? 'true' : 'false'); ?>" id="previewSupported">
 <input type="hidden" name="mimetypeIcon" value="<?php p(\OC::$server->getMimeTypeDetector()->mimeTypeIcon($_['mimetype'])); ?>" id="mimetypeIcon">
 <input type="hidden" name="hideDownload" value="<?php p($_['hideDownload'] ? 'true' : 'false'); ?>" id="hideDownload">
+<input type="hidden" id="disclaimerText" value="<?php p($_['disclaimer']) ?>">
 <?php
 $upload_max_filesize = OC::$server->getIniWrapper()->getBytes('upload_max_filesize');
 $post_max_size = OC::$server->getIniWrapper()->getBytes('post_max_size');
@@ -84,15 +85,13 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 	<div id="public-upload">
 		<div
 				id="emptycontent"
-				class="<?php if (!empty($_['disclaimer'])) { ?>has-disclaimer<?php } ?> <?php if (!empty($_['note'])) { ?>has-note<?php } ?>">
+				class="<?php if (!empty($_['note'])) { ?>has-note<?php } ?>">
 			<div id="displayavatar"><div class="avatardiv"></div></div>
 			<h2><?php p($l->t('Upload files to %s', [$_['shareOwner']])) ?></h2>
 			<p><span class="icon-folder"></span> <?php p($_['filename']) ?></p>
 
-			<?php if (!empty($_['disclaimer'])) { ?>
-				<p class="disclaimer"><?php p($_['disclaimer']); ?></p>
-			<?php } ?>
 			<?php if (empty($_['note']) === false) { ?>
+				<h3><?php p($l->t('Note')); ?></h3>
 				<p class="note"><?php p($_['note']); ?></p>
 			<?php } ?>
 
@@ -101,8 +100,16 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 			<a href="#" class="button icon-upload"><?php p($l->t('Select or drop files')) ?></a>
 			<div id="drop-upload-progress-indicator" style="padding-top: 25px;" class="hidden"><?php p($l->t('Uploading files…')) ?></div>
 			<div id="drop-upload-done-indicator" style="padding-top: 25px;" class="hidden"><?php p($l->t('Uploaded files:')) ?></div>
-			<ul>
-			</ul>
+
+			<?php if (!empty($_['disclaimer'])) { ?>
+				<div>
+					<?php
+						echo $l->t('By uploading files, you agree to the %s.', [
+								'<b id="show-terms-dialog">' . $l->t('terms of service') . '</b>'
+						]);
+					?>
+				</div>
+			<?php } ?>
 		</div>
 	</div>
 <?php } ?>

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -104,8 +104,8 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 			<?php if (!empty($_['disclaimer'])) { ?>
 				<div>
 					<?php
-						echo $l->t('By uploading files, you agree to the %s.', [
-								'<b id="show-terms-dialog">' . $l->t('terms of service') . '</b>'
+						echo $l->t('By uploading files, you agree to the %1$sterms of service%2$s.', [
+								'<span id="show-terms-dialog">', '</span>'
 						]);
 					?>
 				</div>

--- a/apps/files_sharing/tests/Controller/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareControllerTest.php
@@ -507,7 +507,8 @@ class ShareControllerTest extends \Test\TestCase {
 			'shareUrl' => '',
 			'previewImage' => '',
 			'previewURL' => '',
-			'note' => ''
+			'note' => '',
+			'hideDownload' => false
 		);
 
 		$csp = new \OCP\AppFramework\Http\ContentSecurityPolicy();

--- a/apps/files_sharing/tests/Controller/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareControllerTest.php
@@ -508,7 +508,8 @@ class ShareControllerTest extends \Test\TestCase {
 			'previewImage' => '',
 			'previewURL' => '',
 			'note' => '',
-			'hideDownload' => false
+			'hideDownload' => false,
+			'showgridview' => true
 		);
 
 		$csp = new \OCP\AppFramework\Http\ContentSecurityPolicy();


### PR DESCRIPTION
As discussed in the ticket the header actions (like download) don't make sense for file drops.

Closes #11514 
Fixes #11513