### PR TITLE
Force multiselect max-height to 5.5 items

### DIFF
--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -761,7 +761,7 @@ input {
 		border: 1px solid var(--color-border-dark);
 		background: var(--color-main-background);
 		z-index: 50;
-		max-height: 250px;
+		max-height: 175px !important; // 5 items and a half
 		overflow-y: auto;
 		.multiselect__content {
 			width: 100%;


### PR DESCRIPTION
@nextcloud/designers 
![capture d ecran_2018-10-03_08-32-50](https://user-images.githubusercontent.com/14975046/46393859-41e3e700-c6e7-11e8-82fd-732d85bce89c.png)
Fix #11543