### PR TITLE
Allow clients to request an apppassword if they still use the real password

### DIFF
--- a/core/Controller/AppPasswordController.php
+++ b/core/Controller/AppPasswordController.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2018, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Core\Controller;
+
+use OC\Authentication\Token\IProvider;
+use OC\Authentication\Token\IToken;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\Authentication\Exceptions\CredentialsUnavailableException;
+use OCP\Authentication\Exceptions\PasswordUnavailableException;
+use OCP\Authentication\LoginCredentials\IStore;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\Security\ISecureRandom;
+
+class AppPasswordController extends \OCP\AppFramework\OCSController {
+
+	/** @var ISession */
+	private $session;
+
+	/** @var ISecureRandom */
+	private $random;
+
+	/** @var IProvider */
+	private $tokenProvider;
+
+	/** @var IStore */
+	private $credentialStore;
+
+	public function __construct(string $appName,
+								IRequest $request,
+								ISession $session,
+								ISecureRandom $random,
+								IProvider $tokenProvider,
+								IStore $credentialStore) {
+		parent::__construct($appName, $request);
+
+		$this->session = $session;
+		$this->random = $random;
+		$this->tokenProvider = $tokenProvider;
+		$this->credentialStore = $credentialStore;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @return DataResponse
+	 * @throws OCSForbiddenException
+	 */
+	public function getAppPassword(): DataResponse {
+		// We do not allow the creation of new tokens if this is an app password
+		if ($this->session->exists('app_password')) {
+			throw new OCSForbiddenException('You cannot request an new apppassword with an apppassword');
+		}
+
+		try {
+			$credentials = $this->credentialStore->getLoginCredentials();
+		} catch (CredentialsUnavailableException $e) {
+			throw new OCSForbiddenException();
+		}
+
+		try {
+			$password = $credentials->getPassword();
+		} catch (PasswordUnavailableException $e) {
+			$password = null;
+		}
+
+		$userAgent = $this->request->getHeader('USER_AGENT');
+
+		$token = $this->random->generate(72, ISecureRandom::CHAR_UPPER.ISecureRandom::CHAR_LOWER.ISecureRandom::CHAR_DIGITS);
+
+		$this->tokenProvider->generateToken(
+			$token,
+			$credentials->getUID(),
+			$credentials->getLoginName(),
+			$password,
+			$userAgent,
+			IToken::PERMANENT_TOKEN,
+			IToken::DO_NOT_REMEMBER
+		);
+
+		return new DataResponse([
+			'apppassword' => $token
+		]);
+	}
+}

--- a/core/routes.php
+++ b/core/routes.php
@@ -81,6 +81,7 @@ $application->registerRoutes($this, [
 		['root' => '/core', 'name' => 'AutoComplete#get', 'url' => '/autocomplete/get', 'verb' => 'GET'],
 		['root' => '/core', 'name' => 'WhatsNew#get', 'url' => '/whatsnew', 'verb' => 'GET'],
 		['root' => '/core', 'name' => 'WhatsNew#dismiss', 'url' => '/whatsnew', 'verb' => 'POST'],
+		['root' => '/core', 'name' => 'AppPassword#getAppPassword', 'url' => '/getapppassword', 'verb' => 'GET'],
 	],
 ]);
 

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -595,6 +595,7 @@ return array(
     'OC\\Core\\Command\\User\\Report' => $baseDir . '/core/Command/User/Report.php',
     'OC\\Core\\Command\\User\\ResetPassword' => $baseDir . '/core/Command/User/ResetPassword.php',
     'OC\\Core\\Command\\User\\Setting' => $baseDir . '/core/Command/User/Setting.php',
+    'OC\\Core\\Controller\\AppPasswordController' => $baseDir . '/core/Controller/AppPasswordController.php',
     'OC\\Core\\Controller\\AutoCompleteController' => $baseDir . '/core/Controller/AutoCompleteController.php',
     'OC\\Core\\Controller\\AvatarController' => $baseDir . '/core/Controller/AvatarController.php',
     'OC\\Core\\Controller\\CSRFTokenController' => $baseDir . '/core/Controller/CSRFTokenController.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -625,6 +625,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Core\\Command\\User\\Report' => __DIR__ . '/../../..' . '/core/Command/User/Report.php',
         'OC\\Core\\Command\\User\\ResetPassword' => __DIR__ . '/../../..' . '/core/Command/User/ResetPassword.php',
         'OC\\Core\\Command\\User\\Setting' => __DIR__ . '/../../..' . '/core/Command/User/Setting.php',
+        'OC\\Core\\Controller\\AppPasswordController' => __DIR__ . '/../../..' . '/core/Controller/AppPasswordController.php',
         'OC\\Core\\Controller\\AutoCompleteController' => __DIR__ . '/../../..' . '/core/Controller/AutoCompleteController.php',
         'OC\\Core\\Controller\\AvatarController' => __DIR__ . '/../../..' . '/core/Controller/AvatarController.php',
         'OC\\Core\\Controller\\CSRFTokenController' => __DIR__ . '/../../..' . '/core/Controller/CSRFTokenController.php',

--- a/tests/Core/Controller/AppPasswordControllerTest.php
+++ b/tests/Core/Controller/AppPasswordControllerTest.php
@@ -1,0 +1,179 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2018, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Tests\Core\Controller;
+
+use OC\Authentication\Token\IProvider;
+use OC\Authentication\Token\IToken;
+use OC\Core\Controller\AppPasswordController;
+use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\Authentication\Exceptions\CredentialsUnavailableException;
+use OCP\Authentication\Exceptions\PasswordUnavailableException;
+use OCP\Authentication\LoginCredentials\ICredentials;
+use OCP\Authentication\LoginCredentials\IStore;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class AppPasswordControllerTest extends TestCase {
+
+	/** @var ISession|MockObject */
+	private $session;
+
+	/** @var ISecureRandom|MockObject */
+	private $random;
+
+	/** @var IProvider|MockObject */
+	private $tokenProvider;
+
+	/** @var IStore|MockObject */
+	private $credentialStore;
+
+	/** @var IRequest|MockObject */
+	private $request;
+
+	/** @var AppPasswordController */
+	private $controller;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->session = $this->createMock(ISession::class);
+		$this->random = $this->createMock(ISecureRandom::class);
+		$this->tokenProvider = $this->createMock(IProvider::class);
+		$this->credentialStore = $this->createMock(IStore::class);
+		$this->request = $this->createMock(IRequest::class);
+
+		$this->controller = new AppPasswordController(
+			'core',
+			$this->request,
+			$this->session,
+			$this->random,
+			$this->tokenProvider,
+			$this->credentialStore
+		);
+	}
+
+	public function testGetAppPasswordWithAppPassword() {
+		$this->session->method('exists')
+			->with('app_password')
+			->willReturn(true);
+
+		$this->expectException(OCSForbiddenException::class);
+
+		$this->controller->getAppPassword();
+	}
+
+	public function testGetAppPasswordNoLoginCreds() {
+		$this->session->method('exists')
+			->with('app_password')
+			->willReturn(false);
+		$this->credentialStore->method('getLoginCredentials')
+			->willThrowException(new CredentialsUnavailableException());
+
+		$this->expectException(OCSForbiddenException::class);
+
+		$this->controller->getAppPassword();
+	}
+
+	public function testGetAppPassword() {
+		$credentials = $this->createMock(ICredentials::class);
+
+		$this->session->method('exists')
+			->with('app_password')
+			->willReturn(false);
+		$this->credentialStore->method('getLoginCredentials')
+			->willReturn($credentials);
+		$credentials->method('getUid')
+			->willReturn('myUID');
+		$credentials->method('getPassword')
+			->willReturn('myPassword');
+		$credentials->method('getLoginName')
+			->willReturn('myLoginName');
+		$this->request->method('getHeader')
+			->with('USER_AGENT')
+			->willReturn('myUA');
+		$this->random->method('generate')
+			->with(
+				72,
+				ISecureRandom::CHAR_UPPER.ISecureRandom::CHAR_LOWER.ISecureRandom::CHAR_DIGITS
+			)->willReturn('myToken');
+
+		$this->tokenProvider->expects($this->once())
+			->method('generateToken')
+			->with(
+				'myToken',
+				'myUID',
+				'myLoginName',
+				'myPassword',
+				'myUA',
+				IToken::PERMANENT_TOKEN,
+				IToken::DO_NOT_REMEMBER
+			);
+
+		$this->controller->getAppPassword();
+	}
+
+	public function testGetAppPasswordNoPassword() {
+		$credentials = $this->createMock(ICredentials::class);
+
+		$this->session->method('exists')
+			->with('app_password')
+			->willReturn(false);
+		$this->credentialStore->method('getLoginCredentials')
+			->willReturn($credentials);
+		$credentials->method('getUid')
+			->willReturn('myUID');
+		$credentials->method('getPassword')
+			->willThrowException(new PasswordUnavailableException());
+		$credentials->method('getLoginName')
+			->willReturn('myLoginName');
+		$this->request->method('getHeader')
+			->with('USER_AGENT')
+			->willReturn('myUA');
+		$this->random->method('generate')
+			->with(
+				72,
+				ISecureRandom::CHAR_UPPER.ISecureRandom::CHAR_LOWER.ISecureRandom::CHAR_DIGITS
+			)->willReturn('myToken');
+
+		$this->tokenProvider->expects($this->once())
+			->method('generateToken')
+			->with(
+				'myToken',
+				'myUID',
+				'myLoginName',
+				null,
+				'myUA',
+				IToken::PERMANENT_TOKEN,
+				IToken::DO_NOT_REMEMBER
+			);
+
+		$this->controller->getAppPassword();
+	}
+
+
+}


### PR DESCRIPTION
Now that we can enforce 2FA it is good if we can have client automatically switch from the real password to apppasswords.