### PR TITLE
13.0.7 RC 1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -313,7 +313,7 @@ pipeline:
     image: nextcloudci/php7.1:php7.1-15
     commands:
       - sleep 10 # gives the database enough time to initialize
-      - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh pgsql
+      - POSTGRES=${POSTGRES} NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh pgsql
     when:
       matrix:
         DB: postgres
@@ -864,6 +864,7 @@ services:
     image: postgres:9
     environment:
       - POSTGRES_USER=oc_autotest
+      - POSTGRES_DB=oc_autotest_dummy
       - POSTGRES_PASSWORD=owncloud
     tmpfs:
       - /var/lib/postgresql/data
@@ -875,6 +876,7 @@ services:
       image: postgres:10
       environment:
         - POSTGRES_USER=oc_autotest
+        - POSTGRES_DB=oc_autotest_dummy
         - POSTGRES_PASSWORD=owncloud
       tmpfs:
         - /var/lib/postgresql/data

--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(13, 0, 6, 1);
+$OC_Version = array(13, 0, 7, 0);
 
 // The human readable string
-$OC_VersionString = '13.0.6';
+$OC_VersionString = '13.0.7 RC 1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Changelog to 13.0.6:

* #10804 Prefer using dir instead of allinfo for getting smb file info
* #10824 [LDAP] The WebUI Wizard also should not assign empty config IDs
* #10829 Fix mimetype detection for junked uploads
* #10884 Improve performance when dealing with large numbers of shares
* #10902 Cast timestamps older than unix epoch to 0
* #10911 Use the same ignored properties list for both CustomerPropertiesBackends
* #11284 Include empty directories in the default state of acceptance tests
* #11400 Do not hide the progress bar while the chunked upload is being assembled
* #11419 Fix "checkWellKnownUrl" not being run
* #11437 AssemblyStream is also eof if we have no more source stream
* #11494 Show auth type "None" in email settings
* #11524 Fixes the move/copy picker buttons
