### PR TITLE
fix remote IP and trusted proxy IPs check in forwardedForHeadersWorking

### DIFF
--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -290,7 +290,7 @@ class CheckSetupController extends Controller {
 		$remoteAddress = $this->request->getRemoteAddress();
 
 		if (is_array($trustedProxies) && in_array($remoteAddress, $trustedProxies)) {
-			return false;
+			return true;
 		}
 
 		// either not enabled or working correctly

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -304,7 +304,7 @@ class CheckSetupControllerTest extends TestCase {
 			->method('getRemoteAddress')
 			->willReturn('1.2.3.4');
 
-		$this->assertFalse(
+		$this->assertTrue(
 			self::invokePrivate(
 				$this->checkSetupController,
 				'forwardedForHeadersWorking'
@@ -321,7 +321,7 @@ class CheckSetupControllerTest extends TestCase {
 			->method('getRemoteAddress')
 			->willReturn('4.3.2.1');
 
-		$this->assertTrue(
+		$this->assertFalse(
 			self::invokePrivate(
 				$this->checkSetupController,
 				'forwardedForHeadersWorking'


### PR DESCRIPTION
For the issue #11594 
If you are using a reverse proxy with trusted_proxies setup, you will always see a warning in the admin console ("https://yourdomain.com/settings/admin"). After this fix, the warning will be gone.
