### PR TITLE
Fix call to logger

### DIFF
--- a/apps/theming/lib/ImageManager.php
+++ b/apps/theming/lib/ImageManager.php
@@ -117,7 +117,7 @@ class ImageManager {
 					$pngFile = $folder->newFile($key . '.png');
 					$pngFile->putContent($finalIconFile->getImageBlob());
 				} catch (\ImagickException $e) {
-					$this->logger->info('The image was requested to be no SVG file, but converting it to PNG failed.', $e->getMessage());
+					$this->logger->info('The image was requested to be no SVG file, but converting it to PNG failed.', [$e->getMessage()]);
 					$pngFile = null;
 				}
 			} else {

--- a/apps/theming/lib/ImageManager.php
+++ b/apps/theming/lib/ImageManager.php
@@ -117,7 +117,7 @@ class ImageManager {
 					$pngFile = $folder->newFile($key . '.png');
 					$pngFile->putContent($finalIconFile->getImageBlob());
 				} catch (\ImagickException $e) {
-					$this->logger->info('The image was requested to be no SVG file, but converting it to PNG failed.', [$e->getMessage()]);
+					$this->logger->info('The image was requested to be no SVG file, but converting it to PNG failed: ' . $e->getMessage());
 					$pngFile = null;
 				}
 			} else {


### PR DESCRIPTION
`Argument 2 passed to OC\\Log::info() must be of the type array, string given, called in \/var\/www\/html\/nextcloud\/apps\/theming\/lib\/ImageManager.php on line 120`

https://github.com/nextcloud/server/blob/38a90130ce425d531a804dff591df4a883de3154/lib/public/ILogger.php#L129