### PR TITLE
Allow userId to be null

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -113,7 +113,7 @@ class ShareAPIController extends OCSController {
 		IUserManager $userManager,
 		IRootFolder $rootFolder,
 		IURLGenerator $urlGenerator,
-		string $userId,
+		string $userId = null,
 		IL10N $l10n,
 		IConfig $config,
 		IAppManager $appManager,


### PR DESCRIPTION
Fixes #10852

A quick hack. Still ensures some type safety however now also accepts
null. Else we'd need to add a whole new layer of middlewares.

This can only happen when a guest user wants to access a controller that
requries the user_id.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>