### PR TITLE
Put back headings to regular

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -21,7 +21,7 @@
 h2,
 h3,
 h4 {
-	font-weight: 600;
+	font-weight: 400;
 }
 
 h2 {

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -212,7 +212,7 @@
 .header-appname {
 	color: var(--color-primary-text);
 	font-size: 16px;
-	font-weight: 600;
+	font-weight: 400;
 	margin: 0;
 	padding: 0;
 	padding-right: 5px;


### PR DESCRIPTION
Sorry @jancborchardt but this is looking far too agressive with 600 :confused: 
I did not realised it was that much on the previous pr :see_no_evil: 
Regular is better imho, what do you think? @nextcloud/designers 

If you consider that our default is set on light, regular  = semibold and semibold = bold for us ;)

| Before | After |
|:---------:|:------:|
|![dev skjnldsv com_apps_files__dir _ 5](https://user-images.githubusercontent.com/14975046/46483305-9b3b3b80-c7f7-11e8-8a3c-485e0df115aa.png)|![dev skjnldsv com_apps_files__dir _ 4](https://user-images.githubusercontent.com/14975046/46483306-9d04ff00-c7f7-11e8-883b-eb172c80ab23.png)|
|![dev skjnldsv com_s_tb3tzzbhnhws8wg 1](https://user-images.githubusercontent.com/14975046/46483246-79da4f80-c7f7-11e8-946d-a1a34486625c.png)|![dev skjnldsv com_s_tb3tzzbhnhws8wg](https://user-images.githubusercontent.com/14975046/46483245-79da4f80-c7f7-11e8-81b9-d7d31b72a341.png)|


