### PR TITLE
Add function to generate urls for OCS routes

### DIFF
--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -91,6 +91,19 @@ class URLGenerator implements IURLGenerator {
 		return $this->getAbsoluteURL($this->linkToRoute($routeName, $arguments));
 	}
 
+	public function linkToOCSRouteAbsolute(string $routeName, array $arguments = []): string {
+		$route = \OC::$server->getRouter()->generate('ocs.'.$routeName, $arguments, false);
+
+		if (strpos($route, '/index.php') === 0) {
+			$route = substr($route, 10);
+		}
+
+		$route = substr($route, 7);
+		$route = '/ocs/v2.php' . $route;
+
+		return $this->getAbsoluteURL($route);
+	}
+
 	/**
 	 * Creates an url
 	 * @param string $app app

--- a/lib/public/IURLGenerator.php
+++ b/lib/public/IURLGenerator.php
@@ -51,6 +51,14 @@ interface IURLGenerator {
 	public function linkToRouteAbsolute(string $routeName, array $arguments = array()): string;
 
 	/**
+	 * @param string $routeName
+	 * @param array $arguments
+	 * @return string
+	 * @since 15.0.0
+	 */
+	public function linkToOCSRouteAbsolute(string $routeName, array $arguments = []): string;
+
+	/**
 	 * Returns an URL for an image or file
 	 * @param string $appName the name of the app
 	 * @param string $file the name of the file

--- a/tests/lib/UrlGeneratorTest.php
+++ b/tests/lib/UrlGeneratorTest.php
@@ -162,4 +162,22 @@ class UrlGeneratorTest extends \Test\TestCase {
 		$this->assertEquals($expected, $actual);
 	}
 
+	/**
+	 * @dataProvider provideOCSRoutes
+	 */
+	public function testLinkToOCSRouteAbsolute(string $route, string $expected) {
+		$this->mockBaseUrl();
+		\OC::$WEBROOT = '/nextcloud';
+		$result = $this->urlGenerator->linkToOCSRouteAbsolute($route);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function provideOCSRoutes() {
+		return [
+			['core.OCS.getCapabilities', 'http://localhost/nextcloud/ocs/v2.php/cloud/capabilities'],
+			['core.WhatsNew.dismiss', 'http://localhost/nextcloud/ocs/v2.php/core/whatsnew'],
+		];
+	}
+
+
 }


### PR DESCRIPTION
fixes #11617

The OCS routes are only absolute for now as they are often exposed to
the outside anyway and are on a different endpoint than index.php in
anyway.

TODO;
- [x] tests