### PR TITLE
Fixes the apps menu scrollbar

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -329,7 +329,8 @@ nav[role='navigation'] {
 /* Apps management */
 #apps {
 	max-height: inherit;
-	overflow: auto;
+	overflow-x: hidden;
+	overflow-y: auto;
 	-webkit-overflow-scrolling: touch;
 	.in-header {
 		display: none;


### PR DESCRIPTION
Adds overflow x hidden for the apps menu:

Before:
![image](https://user-images.githubusercontent.com/6216686/46500111-452fbd80-c822-11e8-90c9-311569c1658a.png)

After:
![image](https://user-images.githubusercontent.com/6216686/46500114-47921780-c822-11e8-8ea8-4caefdd35b0c.png)

Closes #11468