### PR TITLE
Add occ app:remove CLI command

### DIFF
--- a/core/Command/App/Remove.php
+++ b/core/Command/App/Remove.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018, Patrik Kernstock <info@pkern.at>
+ *
+ * @author Patrik Kernstock <info@pkern.at>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\App;
+
+use OC\Installer;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Remove extends Command implements CompletionAwareInterface {
+
+	protected function configure() {
+		$this
+			->setName('app:remove')
+			->setDescription('remove an app')
+			->addArgument(
+				'app-id',
+				InputArgument::REQUIRED,
+				'remove the specified app'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$appId = $input->getArgument('app-id');
+
+		if (!\OC_App::getAppPath($appId)) {
+			$output->writeln($appId . ' is not installed');
+			return 1;
+		}
+
+		try {
+			/** @var Installer $installer */
+			$installer = \OC::$server->query(Installer::class);
+			$result = $installer->removeApp($appId);
+		} catch(\Exception $e) {
+			$output->writeln('Error: ' . $e->getMessage());
+			return 1;
+		}
+
+		if($result === false) {
+			$output->writeln($appId . ' could not be removed');
+			return 1;
+		}
+
+		$output->writeln($appId . ' removed');
+
+		return 0;
+	}
+
+	/**
+	 * @param string $optionName
+	 * @param CompletionContext $context
+	 * @return string[]
+	 */
+	public function completeOptionValues($optionName, CompletionContext $context) {
+		return [];
+	}
+
+	/**
+	 * @param string $argumentName
+	 * @param CompletionContext $context
+	 * @return string[]
+	 */
+	public function completeArgumentValues($argumentName, CompletionContext $context) {
+		if ($argumentName === 'app-id') {
+			return \OC_App::getAllApps();
+		}
+		return [];
+	}
+}

--- a/core/Command/App/Remove.php
+++ b/core/Command/App/Remove.php
@@ -27,6 +27,7 @@ use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareI
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -40,6 +41,12 @@ class Remove extends Command implements CompletionAwareInterface {
 				'app-id',
 				InputArgument::REQUIRED,
 				'remove the specified app'
+			)
+			->addOption(
+				'keep-data',
+				null,
+				InputOption::VALUE_NONE,
+				'keep app data and do not remove them'
 			);
 	}
 
@@ -49,6 +56,18 @@ class Remove extends Command implements CompletionAwareInterface {
 		if (!\OC_App::getAppPath($appId)) {
 			$output->writeln($appId . ' is not installed');
 			return 1;
+		}
+
+		if (!$input->getOption('keep-data')) {
+			try {
+				/** @var IAppManager $appManager*/
+				$appManager = \OC::$server->getAppManager();
+				$appManager->disableApp($appId);
+				$output->writeln($appId . ' disabled');
+			} catch(\Exception $e) {
+				$output->writeln('Error: ' . $e->getMessage());
+				return 1;
+			}
 		}
 
 		try {

--- a/core/Command/App/Remove.php
+++ b/core/Command/App/Remove.php
@@ -24,6 +24,7 @@ namespace OC\Core\Command\App;
 
 use OC\Installer;
 use OCP\App\IAppManager;
+use OCP\ILogger;
 use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
@@ -38,15 +39,19 @@ class Remove extends Command implements CompletionAwareInterface {
 	protected $manager;
 	/** @var Installer */
 	private $installer;
+	/** @var ILogger */
+	private $logger;
 
 	/**
 	 * @param IAppManager $manager
 	 * @param Installer $installer
+	 * @param ILogger $logger
 	 */
-	public function __construct(IAppManager $manager, Installer $installer) {
+	public function __construct(IAppManager $manager, Installer $installer, ILogger $logger) {
 		parent::__construct();
 		$this->manager = $manager;
 		$this->installer = $installer;
+		$this->logger = $logger;
 	}
 
 	protected function configure() {
@@ -90,6 +95,10 @@ class Remove extends Command implements CompletionAwareInterface {
 				$output->writeln($appId . ' disabled');
 			} catch(\Exception $e) {
 				$output->writeln('Error: ' . $e->getMessage());
+				$this->logger->logException($e, [
+					'app' => 'CLI',
+					'level' => ILogger::ERROR
+				]);
 				return 1;
 			}
 		}
@@ -99,6 +108,10 @@ class Remove extends Command implements CompletionAwareInterface {
 			$result = $this->installer->removeApp($appId);
 		} catch(\Exception $e) {
 			$output->writeln('Error: ' . $e->getMessage());
+			$this->logger->logException($e, [
+				'app' => 'CLI',
+				'level' => ILogger::ERROR
+			]);
 			return 1;
 		}
 

--- a/core/Command/App/Remove.php
+++ b/core/Command/App/Remove.php
@@ -95,7 +95,7 @@ class Remove extends Command implements CompletionAwareInterface {
 				$this->manager->disableApp($appId);
 				$output->writeln($appId . ' disabled');
 			} catch(Throwable $e) {
-				$output->writeln('Error: ' . $e->getMessage());
+				$output->writeln('<error>Error: ' . $e->getMessage() . '</error>');
 				$this->logger->logException($e, [
 					'app' => 'CLI',
 					'level' => ILogger::ERROR
@@ -108,7 +108,7 @@ class Remove extends Command implements CompletionAwareInterface {
 		try {
 			$result = $this->installer->removeApp($appId);
 		} catch(Throwable $e) {
-			$output->writeln('Error: ' . $e->getMessage());
+			$output->writeln('<error>Error: ' . $e->getMessage() . '</error>');
 			$this->logger->logException($e, [
 				'app' => 'CLI',
 				'level' => ILogger::ERROR

--- a/core/Command/App/Remove.php
+++ b/core/Command/App/Remove.php
@@ -22,6 +22,7 @@
 
 namespace OC\Core\Command\App;
 
+use Throwable;
 use OC\Installer;
 use OCP\App\IAppManager;
 use OCP\ILogger;
@@ -93,7 +94,7 @@ class Remove extends Command implements CompletionAwareInterface {
 			try {
 				$this->manager->disableApp($appId);
 				$output->writeln($appId . ' disabled');
-			} catch(\Exception $e) {
+			} catch(Throwable $e) {
 				$output->writeln('Error: ' . $e->getMessage());
 				$this->logger->logException($e, [
 					'app' => 'CLI',
@@ -106,7 +107,7 @@ class Remove extends Command implements CompletionAwareInterface {
 		// Let's try to remove the app...
 		try {
 			$result = $this->installer->removeApp($appId);
-		} catch(\Exception $e) {
+		} catch(Throwable $e) {
 			$output->writeln('Error: ' . $e->getMessage());
 			$this->logger->logException($e, [
 				'app' => 'CLI',

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -65,6 +65,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\App\Install());
 	$application->add(new OC\Core\Command\App\GetPath());
 	$application->add(new OC\Core\Command\App\ListApps(\OC::$server->getAppManager()));
+	$application->add(new OC\Core\Command\App\Remove());
 
 	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Cleanup::class));
 	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Enforce::class));

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -65,7 +65,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\App\Install());
 	$application->add(new OC\Core\Command\App\GetPath());
 	$application->add(new OC\Core\Command\App\ListApps(\OC::$server->getAppManager()));
-	$application->add(new OC\Core\Command\App\Remove(\OC::$server->getAppManager(), \OC::$server->query(\OC\Installer::class)));
+	$application->add(new OC\Core\Command\App\Remove(\OC::$server->getAppManager(), \OC::$server->query(\OC\Installer::class), \OC::$server->getLogger()));
 
 	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Cleanup::class));
 	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Enforce::class));

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -65,7 +65,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\App\Install());
 	$application->add(new OC\Core\Command\App\GetPath());
 	$application->add(new OC\Core\Command\App\ListApps(\OC::$server->getAppManager()));
-	$application->add(new OC\Core\Command\App\Remove());
+	$application->add(new OC\Core\Command\App\Remove(\OC::$server->getAppManager(), \OC::$server->query(\OC\Installer::class)));
 
 	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Cleanup::class));
 	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Enforce::class));

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -519,6 +519,7 @@ return array(
     'OC\\Core\\Command\\App\\GetPath' => $baseDir . '/core/Command/App/GetPath.php',
     'OC\\Core\\Command\\App\\Install' => $baseDir . '/core/Command/App/Install.php',
     'OC\\Core\\Command\\App\\ListApps' => $baseDir . '/core/Command/App/ListApps.php',
+	'OC\\Core\\Command\\App\\Remove' => $baseDir . '/core/Command/App/Remove.php',
     'OC\\Core\\Command\\Background\\Ajax' => $baseDir . '/core/Command/Background/Ajax.php',
     'OC\\Core\\Command\\Background\\Base' => $baseDir . '/core/Command/Background/Base.php',
     'OC\\Core\\Command\\Background\\Cron' => $baseDir . '/core/Command/Background/Cron.php',

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -519,7 +519,7 @@ return array(
     'OC\\Core\\Command\\App\\GetPath' => $baseDir . '/core/Command/App/GetPath.php',
     'OC\\Core\\Command\\App\\Install' => $baseDir . '/core/Command/App/Install.php',
     'OC\\Core\\Command\\App\\ListApps' => $baseDir . '/core/Command/App/ListApps.php',
-	'OC\\Core\\Command\\App\\Remove' => $baseDir . '/core/Command/App/Remove.php',
+    'OC\\Core\\Command\\App\\Remove' => $baseDir . '/core/Command/App/Remove.php',
     'OC\\Core\\Command\\Background\\Ajax' => $baseDir . '/core/Command/Background/Ajax.php',
     'OC\\Core\\Command\\Background\\Base' => $baseDir . '/core/Command/Background/Base.php',
     'OC\\Core\\Command\\Background\\Cron' => $baseDir . '/core/Command/Background/Cron.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -549,6 +549,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Core\\Command\\App\\GetPath' => __DIR__ . '/../../..' . '/core/Command/App/GetPath.php',
         'OC\\Core\\Command\\App\\Install' => __DIR__ . '/../../..' . '/core/Command/App/Install.php',
         'OC\\Core\\Command\\App\\ListApps' => __DIR__ . '/../../..' . '/core/Command/App/ListApps.php',
+		'OC\\Core\\Command\\App\\Remove' => __DIR__ . '/../../..' . '/core/Command/App/Remove.php',
         'OC\\Core\\Command\\Background\\Ajax' => __DIR__ . '/../../..' . '/core/Command/Background/Ajax.php',
         'OC\\Core\\Command\\Background\\Base' => __DIR__ . '/../../..' . '/core/Command/Background/Base.php',
         'OC\\Core\\Command\\Background\\Cron' => __DIR__ . '/../../..' . '/core/Command/Background/Cron.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -549,7 +549,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Core\\Command\\App\\GetPath' => __DIR__ . '/../../..' . '/core/Command/App/GetPath.php',
         'OC\\Core\\Command\\App\\Install' => __DIR__ . '/../../..' . '/core/Command/App/Install.php',
         'OC\\Core\\Command\\App\\ListApps' => __DIR__ . '/../../..' . '/core/Command/App/ListApps.php',
-		'OC\\Core\\Command\\App\\Remove' => __DIR__ . '/../../..' . '/core/Command/App/Remove.php',
+        'OC\\Core\\Command\\App\\Remove' => __DIR__ . '/../../..' . '/core/Command/App/Remove.php',
         'OC\\Core\\Command\\Background\\Ajax' => __DIR__ . '/../../..' . '/core/Command/Background/Ajax.php',
         'OC\\Core\\Command\\Background\\Base' => __DIR__ . '/../../..' . '/core/Command/Background/Base.php',
         'OC\\Core\\Command\\Background\\Cron' => __DIR__ . '/../../..' . '/core/Command/Background/Cron.php',


### PR DESCRIPTION
While PR #11053 recently added the possibility for updating apps and PR #5644 to install apps, basically just removing apps is missing... This PR adds the command to be able to remove apps using CLI.

I've decided to use the term `remove` because of two reasons:
1. In `OC\Installer` the function is also called `removeApp()`
2. To prevent any confusion when using term `uninstall` with command `install`

Usage is simple as that:
```
# sudo -u www-data php occ app:install news
news installed
news enabled
# sudo -u www-data php occ app:remove news
news removed
# sudo -u www-data php occ app:remove news
news is not installed
```

Now we have all important CLI commands to be able to manage apps using the command line, perfectly for automation tasks.