### PR TITLE
Make possible for tab views to add CSS classes to their container

### DIFF
--- a/apps/files/js/detailsview.js
+++ b/apps/files/js/detailsview.js
@@ -194,6 +194,9 @@
 			// hide other tabs
 			$tabsContainer.find('.tab').addClass('hidden');
 
+			$tabsContainer.attr('class', 'tabsContainer');
+			$tabsContainer.addClass(tabView.getTabsContainerExtraClasses());
+
 			// tab already rendered ?
 			if (!$tabEl.length) {
 				// render tab

--- a/apps/files/js/detailtabview.js
+++ b/apps/files/js/detailtabview.js
@@ -41,6 +41,21 @@
 		},
 
 		/**
+		 * Returns the extra CSS classes used by the tabs container when this
+		 * tab is the selected one.
+		 *
+		 * In general you should not extend this method, as tabs should not
+		 * modify the classes of its container; this is reserved as a last
+		 * resort for very specific cases in which there is no other way to get
+		 * the proper style or behaviour.
+		 *
+		 * @return {String} space-separated CSS classes
+		 */
+		getTabsContainerExtraClasses: function() {
+			return '';
+		},
+
+		/**
 		 * Returns the tab label
 		 *
 		 * @return {String} label


### PR DESCRIPTION
Required for nextcloud/spreed#1244

In general the style of the tabs container should not change depending on which tab is the currently selected one. However, this could be needed in some very specific cases, so now the tab views can specify the extra CSS classes to be used in their container when they are selected.
