### PR TITLE
Syntactic sugar for hasBeenInterrupted

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -129,12 +129,12 @@ class Scan extends Base {
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function ($path) use ($output) {
 				$output->writeln("\tFile   <info>$path</info>");
 				$this->filesCounter += 1;
-				$this->hasBeenInterrupted();
+				$this->abortIfInterrupted();
 			});
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function ($path) use ($output) {
 				$output->writeln("\tFolder <info>$path</info>");
 				$this->foldersCounter += 1;
-				$this->hasBeenInterrupted();
+				$this->abortIfInterrupted();
 			});
 			$scanner->listen('\OC\Files\Utils\Scanner', 'StorageNotAvailable', function (StorageNotAvailableException $e) use ($output) {
 				$output->writeln('Error while scanning, storage not available (' . $e->getMessage() . ')');
@@ -143,11 +143,11 @@ class Scan extends Base {
 		} else {
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function () use ($output) {
 				$this->filesCounter += 1;
-				$this->hasBeenInterrupted();
+				$this->abortIfInterrupted();
 			});
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function () use ($output) {
 				$this->foldersCounter += 1;
-				$this->hasBeenInterrupted();
+				$this->abortIfInterrupted();
 			});
 		}
 		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function ($path) use ($output) {
@@ -244,7 +244,7 @@ class Scan extends Base {
 			}
 
 			try {
-				$this->hasBeenInterrupted();
+				$this->abortIfInterrupted();
 			} catch(InterruptedException $e) {
 				break;
 			}

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -129,33 +129,25 @@ class Scan extends Base {
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function ($path) use ($output) {
 				$output->writeln("\tFile   <info>$path</info>");
 				$this->filesCounter += 1;
-				if ($this->hasBeenInterrupted()) {
-					throw new InterruptedException();
-				}
+				$this->hasBeenInterrupted();
 			});
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function ($path) use ($output) {
 				$output->writeln("\tFolder <info>$path</info>");
 				$this->foldersCounter += 1;
-				if ($this->hasBeenInterrupted()) {
-					throw new InterruptedException();
-				}
+				$this->hasBeenInterrupted();
 			});
 			$scanner->listen('\OC\Files\Utils\Scanner', 'StorageNotAvailable', function (StorageNotAvailableException $e) use ($output) {
-				$output->writeln("Error while scanning, storage not available (" . $e->getMessage() . ")");
+				$output->writeln('Error while scanning, storage not available (' . $e->getMessage() . ')');
 			});
 			# count only
 		} else {
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function () use ($output) {
 				$this->filesCounter += 1;
-				if ($this->hasBeenInterrupted()) {
-					throw new InterruptedException();
-				}
+				$this->hasBeenInterrupted();
 			});
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function () use ($output) {
 				$this->foldersCounter += 1;
-				if ($this->hasBeenInterrupted()) {
-					throw new InterruptedException();
-				}
+				$this->hasBeenInterrupted();
 			});
 		}
 		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function ($path) use ($output) {
@@ -173,7 +165,7 @@ class Scan extends Base {
 			}
 		} catch (ForbiddenException $e) {
 			$output->writeln("<error>Home storage for user $user not writable</error>");
-			$output->writeln("Make sure you're running the scan command only as the user the web server runs as");
+			$output->writeln('Make sure you\'re running the scan command only as the user the web server runs as');
 		} catch (InterruptedException $e) {
 			# exit the function if ctrl-c has been pressed
 			$output->writeln('Interrupted by user');
@@ -250,8 +242,10 @@ class Scan extends Base {
 			} else {
 				$output->writeln("<error>Unknown user $user_count $user</error>");
 			}
-			# check on each user if there was a user interrupt (ctrl-c) and exit foreach
-			if ($this->hasBeenInterrupted()) {
+
+			try {
+				$this->hasBeenInterrupted();
+			} catch(InterruptedException $e) {
 				break;
 			}
 		}

--- a/apps/files/lib/Command/ScanAppData.php
+++ b/apps/files/lib/Command/ScanAppData.php
@@ -102,12 +102,12 @@ class ScanAppData extends Base {
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function ($path) use ($output) {
 				$output->writeln("\tFile   <info>$path</info>");
 				$this->filesCounter += 1;
-				$this->hasBeenInterrupted();
+				$this->abortIfInterrupted();
 			});
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function ($path) use ($output) {
 				$output->writeln("\tFolder <info>$path</info>");
 				$this->foldersCounter += 1;
-				$this->hasBeenInterrupted();
+				$this->abortIfInterrupted();
 			});
 			$scanner->listen('\OC\Files\Utils\Scanner', 'StorageNotAvailable', function (StorageNotAvailableException $e) use ($output) {
 				$output->writeln('Error while scanning, storage not available (' . $e->getMessage() . ')');
@@ -116,11 +116,11 @@ class ScanAppData extends Base {
 		} else {
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function () use ($output) {
 				$this->filesCounter += 1;
-				$this->hasBeenInterrupted();
+				$this->abortIfInterrupted();
 			});
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function () use ($output) {
 				$this->foldersCounter += 1;
-				$this->hasBeenInterrupted();
+				$this->abortIfInterrupted();
 			});
 		}
 		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function($path) use ($output) {

--- a/apps/files/lib/Command/ScanAppData.php
+++ b/apps/files/lib/Command/ScanAppData.php
@@ -102,33 +102,25 @@ class ScanAppData extends Base {
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function ($path) use ($output) {
 				$output->writeln("\tFile   <info>$path</info>");
 				$this->filesCounter += 1;
-				if ($this->hasBeenInterrupted()) {
-					throw new InterruptedException();
-				}
+				$this->hasBeenInterrupted();
 			});
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function ($path) use ($output) {
 				$output->writeln("\tFolder <info>$path</info>");
 				$this->foldersCounter += 1;
-				if ($this->hasBeenInterrupted()) {
-					throw new InterruptedException();
-				}
+				$this->hasBeenInterrupted();
 			});
 			$scanner->listen('\OC\Files\Utils\Scanner', 'StorageNotAvailable', function (StorageNotAvailableException $e) use ($output) {
-				$output->writeln("Error while scanning, storage not available (" . $e->getMessage() . ")");
+				$output->writeln('Error while scanning, storage not available (' . $e->getMessage() . ')');
 			});
 			# count only
 		} else {
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function () use ($output) {
 				$this->filesCounter += 1;
-				if ($this->hasBeenInterrupted()) {
-					throw new InterruptedException();
-				}
+				$this->hasBeenInterrupted();
 			});
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function () use ($output) {
 				$this->foldersCounter += 1;
-				if ($this->hasBeenInterrupted()) {
-					throw new InterruptedException();
-				}
+				$this->hasBeenInterrupted();
 			});
 		}
 		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function($path) use ($output) {
@@ -142,7 +134,7 @@ class ScanAppData extends Base {
 			$scanner->scan($appData->getPath());
 		} catch (ForbiddenException $e) {
 			$output->writeln("<error>Storage not writable</error>");
-			$output->writeln("Make sure you're running the scan command only as the user the web server runs as");
+			$output->writeln('Make sure you\'re running the scan command only as the user the web server runs as');
 		} catch (InterruptedException $e) {
 			# exit the function if ctrl-c has been pressed
 			$output->writeln('Interrupted by user');

--- a/core/Command/Base.php
+++ b/core/Command/Base.php
@@ -129,15 +129,19 @@ class Base extends Command implements CompletionAwareInterface {
 	}
 
 	/**
-	 * @return bool
+	 * Throw InterruptedException when interrupted by user
+	 *
+	 * @throws InterruptedException
 	 */
 	protected function hasBeenInterrupted() {
-		// return always false if pcntl_signal functions are not accessible
-		if ($this->php_pcntl_signal) {
-			pcntl_signal_dispatch();
-			return $this->interrupted;
-		} else {
-			return false;
+		if ($this->php_pcntl_signal === false) {
+			return;
+		}
+
+		pcntl_signal_dispatch();
+
+		if ($this->interrupted === true) {
+			throw new InterruptedException('Command interrupted by user');
 		}
 	}
 

--- a/core/Command/Base.php
+++ b/core/Command/Base.php
@@ -133,7 +133,7 @@ class Base extends Command implements CompletionAwareInterface {
 	 *
 	 * @throws InterruptedException
 	 */
-	protected function hasBeenInterrupted() {
+	protected function abortIfInterrupted() {
 		if ($this->php_pcntl_signal === false) {
 			return;
 		}


### PR DESCRIPTION
Some syntactic sugar for hasBeenInterrupted. In 8 out of 9 occurrences the method is used like below:

```
if ($this->hasBeenInterrupted()) {
    throw new InterruptedException();
}
```
Changed the method to throw an exception when current command has been interrupted. I guess the method is only used in nextcloud/server and nextcloud/fulltextsearch (@daita)