### PR TITLE
Remove deprecated SVG helpers for old IEs

### DIFF
--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -178,11 +178,6 @@
 				$crumb.append(view.$el);
 			}, this);
 
-			// in case svg is not supported by the browser we need to execute the fallback mechanism
-			if (!OC.Util.hasSVGSupport()) {
-				OC.Util.replaceSVG(this.$el);
-			}
-
 			// setup drag and drop
 			if (this.onDrop) {
 				this.$el.find('.crumb:not(:last-child):not(.crumbmenu), .crumblist:not(:last-child)').droppable({

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -168,7 +168,7 @@ OCA.Sharing.PublicApp = {
 			img.attr('src', OC.generateUrl('/apps/files_sharing/publicpreview/' + token + '?' + OC.buildQueryString(params)));
 			imgcontainer.appendTo('#imgframe');
 		} else if (mimetype.substr(0, mimetype.indexOf('/')) !== 'video') {
-			img.attr('src', OC.Util.replaceSVGIcon(mimetypeIcon));
+			img.attr('src', mimetypeIcon);
 			img.attr('width', 128);
 			imgcontainer.appendTo('#imgframe');
 		}

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1981,33 +1981,6 @@ OC.Util = {
 		}
 		return moment(timestamp).fromNow();
 	},
-	/**
-	 * Returns whether the browser supports SVG
-	 * @deprecated SVG is always supported (since 9.0)
-	 * @return {boolean} true if the browser supports SVG, false otherwise
-	 */
-	hasSVGSupport: function(){
-		return true;
-	},
-	/**
-	 * If SVG is not supported, replaces the given icon's extension
-	 * from ".svg" to ".png".
-	 * If SVG is supported, return the image path as is.
-	 * @param {string} file image path with svg extension
-	 * @deprecated SVG is always supported (since 9.0)
-	 * @return {string} fixed image path with png extension if SVG is not supported
-	 */
-	replaceSVGIcon: function(file) {
-		return file;
-	},
-	/**
-	 * Replace SVG images in all elements that have the "svg" class set
-	 * with PNG images.
-	 *
-	 * @param $el root element from which to search, defaults to $('body')
-	 * @deprecated SVG is always supported (since 9.0)
-	 */
-	replaceSVG: function($el) {},
 
 	/**
 	 * Fix image scaling for IE8, since background-size is not supported.


### PR DESCRIPTION
Removed long deprecated APIs and fixed usage (noops).

@MorrisJobke please double-check for any usage in 3rd party apps. Thanks!