### PR TITLE
Remove deprecated window.getScrollBarWidth

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -2424,13 +2424,6 @@ jQuery.fn.exists = function(){
 };
 
 /**
- * @deprecated use OC.Util.getScrollBarWidth() instead
- */
-function getScrollBarWidth() {
-	return OC.Util.getScrollBarWidth();
-}
-
-/**
  * jQuery tipsy shim for the bootstrap tooltip
  */
 jQuery.fn.tipsy = function(argument) {


### PR DESCRIPTION
Could not find any usage of this function. It was deprecated three years ago: https://github.com/nextcloud/server/commit/f135128664cae62a831ed46853ac820af6a4812b