### PR TITLE
[stable14] in 14 the click action gets lost in the Backbone view.

### DIFF
--- a/apps/systemtags/js/filesplugin.js
+++ b/apps/systemtags/js/filesplugin.js
@@ -49,10 +49,10 @@
 						systemTagsInfoViewToggleView.$el.detach();
 					});
 					systemTagsInfoViewToggleView.listenTo(detailView, 'post-render', function() {
+						var clicker = _.bind(systemTagsInfoViewToggleView.click, systemTagsInfoViewToggleView);
+						systemTagsInfoViewToggleView.$el.click(clicker);
 						detailView.$el.find('.file-details').append(systemTagsInfoViewToggleView.$el);
 					});
-
-					return;
 				}
 			});
 		}

--- a/apps/systemtags/js/systemtagsinfoviewtoggleview.js
+++ b/apps/systemtags/js/systemtagsinfoviewtoggleview.js
@@ -62,7 +62,6 @@
 		 * references the SystemTagsInfoView to associate to this toggle view.
 		 */
 		initialize: function(options) {
-			var self = this;
 			options = options || {};
 
 			this._systemTagsInfoView = options.systemTagsInfoView;


### PR DESCRIPTION
backport of #10782 

@MorrisJobke since there were some thoughts about a second rc, i put it to the 14.0.2 milestone. can be moved otherwise.