### PR TITLE
Deprecate unused, private OC_Helper::linkToPublic

### DIFF
--- a/lib/private/legacy/helper.php
+++ b/lib/private/legacy/helper.php
@@ -52,23 +52,6 @@ class OC_Helper {
 	private static $templateManager;
 
 	/**
-	 * Creates an absolute url for public use
-	 * @param string $service id
-	 * @param bool $add_slash
-	 * @return string the url
-	 *
-	 * Returns a absolute url to the given service.
-	 */
-	public static function linkToPublic($service, $add_slash = false) {
-		if ($service === 'files') {
-			$url = OC::$server->getURLGenerator()->getAbsoluteURL('/s');
-		} else {
-			$url = OC::$server->getURLGenerator()->getAbsoluteURL(OC::$server->getURLGenerator()->linkTo('', 'public.php').'?service='.$service);
-		}
-		return $url . (($add_slash && $service[strlen($service) - 1] != '/') ? '/' : '');
-	}
-
-	/**
 	 * Make a human file size
 	 * @param int $bytes file size in bytes
 	 * @return string a human readable file size

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -230,9 +230,14 @@ class Util {
 	 * @param string $service id
 	 * @return string the url
 	 * @since 4.5.0
+	 * @deprecated 15.0.0 - use OCP\IURLGenerator
 	 */
 	public static function linkToPublic($service) {
-		return \OC_Helper::linkToPublic($service);
+		$urlGenerator = \OC::$server->getURLGenerator();
+		if ($service === 'files') {
+			return $urlGenerator->getAbsoluteURL('/s');
+		}
+		return $urlGenerator->getAbsoluteURL($urlGenerator->linkTo('', 'public.php').'?service='.$service);
 	}
 
 	/**

--- a/tests/lib/LegacyHelperTest.php
+++ b/tests/lib/LegacyHelperTest.php
@@ -222,44 +222,6 @@ class LegacyHelperTest extends \Test\TestCase {
 		);
 	}
 
-	// Url generator methods
-
-	/**
-	 * @small
-	 * test linkToPublic URL construction
-	 */
-	public function testLinkToPublic() {
-		\OC::$WEBROOT = '';
-		$result = \OC_Helper::linkToPublic('files');
-		$this->assertEquals('http://localhost/s', $result);
-		$result = \OC_Helper::linkToPublic('files', false);
-		$this->assertEquals('http://localhost/s', $result);
-		$result = \OC_Helper::linkToPublic('files', true);
-		$this->assertEquals('http://localhost/s/', $result);
-
-		$result = \OC_Helper::linkToPublic('other');
-		$this->assertEquals('http://localhost/public.php?service=other', $result);
-		$result = \OC_Helper::linkToPublic('other', false);
-		$this->assertEquals('http://localhost/public.php?service=other', $result);
-		$result = \OC_Helper::linkToPublic('other', true);
-		$this->assertEquals('http://localhost/public.php?service=other/', $result);
-
-		\OC::$WEBROOT = '/owncloud';
-		$result = \OC_Helper::linkToPublic('files');
-		$this->assertEquals('http://localhost/owncloud/s', $result);
-		$result = \OC_Helper::linkToPublic('files', false);
-		$this->assertEquals('http://localhost/owncloud/s', $result);
-		$result = \OC_Helper::linkToPublic('files', true);
-		$this->assertEquals('http://localhost/owncloud/s/', $result);
-
-		$result = \OC_Helper::linkToPublic('other');
-		$this->assertEquals('http://localhost/owncloud/public.php?service=other', $result);
-		$result = \OC_Helper::linkToPublic('other', false);
-		$this->assertEquals('http://localhost/owncloud/public.php?service=other', $result);
-		$result = \OC_Helper::linkToPublic('other', true);
-		$this->assertEquals('http://localhost/owncloud/public.php?service=other/', $result);
-	}
-
 	/**
 	 * Tests recursive folder deletion with rmdirr()
 	 */


### PR DESCRIPTION
Will add this later to https://github.com/nextcloud/server/issues/11045

Found this while reviewing some code. It is not used at all anymore.