### PR TITLE
Fix usage of deprecated OC.webroot

### DIFF
--- a/apps/federatedfilesharing/tests/js/externalSpec.js
+++ b/apps/federatedfilesharing/tests/js/externalSpec.js
@@ -138,7 +138,7 @@ describe('OCA.Sharing external tests', function() {
 			
 			var req = fakeServer.requests[0];
 			expect(req.method).toEqual('GET');
-			expect(req.url).toEqual(OC.webroot + '/index.php/apps/files_sharing/api/externalShares');
+			expect(req.url).toEqual(OC.getRootPath() + '/index.php/apps/files_sharing/api/externalShares');
 
 			req.respond(
 				200,
@@ -178,7 +178,7 @@ describe('OCA.Sharing external tests', function() {
 			expect(request.method).toEqual('POST');
 			expect(query).toEqual({id: '123'});
 			expect(request.url).toEqual(
-				OC.webroot + '/index.php/apps/files_sharing/api/externalShares'
+				OC.getRootPath() + '/index.php/apps/files_sharing/api/externalShares'
 			);
 
 			expect(plugin.filesApp.fileList.reload.notCalled).toEqual(true);
@@ -202,7 +202,7 @@ describe('OCA.Sharing external tests', function() {
 			var request = fakeServer.requests[1];
 			expect(request.method).toEqual('DELETE');
 			expect(request.url).toEqual(
-				OC.webroot + '/index.php/apps/files_sharing/api/externalShares/123'
+				OC.getRootPath() + '/index.php/apps/files_sharing/api/externalShares/123'
 			);
 
 			expect(plugin.filesApp.fileList.reload.notCalled).toEqual(true);

--- a/apps/files/tests/js/favoritesfilelistspec.js
+++ b/apps/files/tests/js/favoritesfilelistspec.js
@@ -90,7 +90,7 @@ describe('OCA.Files.FavoritesFileList tests', function() {
 			expect($tr.attr('data-mime')).toEqual('text/plain');
 			expect($tr.attr('data-mtime')).toEqual('11111000');
 			expect($tr.find('a.name').attr('href')).toEqual(
-				OC.webroot +
+				OC.getRootPath() +
 				'/remote.php/webdav/somedir/test.txt'
 			);
 			expect($tr.find('.nametext').text().trim()).toEqual('test.txt');

--- a/apps/files/tests/js/fileactionsSpec.js
+++ b/apps/files/tests/js/fileactionsSpec.js
@@ -716,7 +716,7 @@ describe('OCA.Files.FileActions tests', function() {
 				expect(busyStub.calledWith('testName.txt', true)).toEqual(true);
 				expect(handleDownloadStub.calledOnce).toEqual(true);
 				expect(handleDownloadStub.getCall(0).args[0]).toEqual(
-					OC.webroot + '/remote.php/webdav/subdir/testName.txt'
+					OC.getRootPath() + '/remote.php/webdav/subdir/testName.txt'
 				);
 				busyStub.reset();
 				handleDownloadStub.yield();

--- a/apps/files/tests/js/fileactionsmenuSpec.js
+++ b/apps/files/tests/js/fileactionsmenuSpec.js
@@ -281,7 +281,7 @@ describe('OCA.Files.FileActionsMenu tests', function() {
 
 			expect(redirectStub.calledOnce).toEqual(true);
 			expect(redirectStub.getCall(0).args[0]).toContain(
-				OC.webroot +
+				OC.getRootPath() +
 				'/remote.php/webdav/subdir/testName.txt'
 			);
 			redirectStub.restore();
@@ -315,7 +315,7 @@ describe('OCA.Files.FileActionsMenu tests', function() {
 
 			expect(redirectStub.calledOnce).toEqual(true);
 			expect(redirectStub.getCall(0).args[0]).toContain(
-				OC.webroot + '/remote.php/webdav/anotherpath/there/testName.txt'
+				OC.getRootPath() + '/remote.php/webdav/anotherpath/there/testName.txt'
 			);
 			redirectStub.restore();
 		});

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -62,8 +62,8 @@ describe('OCA.Files.FileList tests', function() {
 		filesClient = new OC.Files.Client({
 			host: 'localhost',
 			port: 80,
-			// FIXME: uncomment after fixing the test OC.webroot
-			//root: OC.webroot + '/remote.php/webdav',
+			// FIXME: uncomment after fixing the test OC.getRootPath()
+			//root: OC.getRootPath() + '/remote.php/webdav',
 			root: '/remote.php/webdav',
 			useHTTPS: false
 		});
@@ -232,7 +232,7 @@ describe('OCA.Files.FileList tests', function() {
 			expect($tr.attr('data-mtime')).toEqual('123456');
 			expect($tr.attr('data-e2eencrypted')).toEqual('false');
 			expect($tr.find('a.name').attr('href'))
-				.toEqual(OC.webroot + '/remote.php/webdav/subdir/testName.txt');
+				.toEqual(OC.getRootPath() + '/remote.php/webdav/subdir/testName.txt');
 			expect($tr.find('.nametext').text().trim()).toEqual('testName.txt');
 
 			expect($tr.find('.filesize').text()).toEqual('1 KB');
@@ -725,7 +725,7 @@ describe('OCA.Files.FileList tests', function() {
 
 			$tr = fileList.findFileEl('Tu_after_three.txt');
 			expect($tr.find('a.name').attr('href'))
-				.toEqual(OC.webroot + '/remote.php/webdav/some/subdir/Tu_after_three.txt');
+				.toEqual(OC.getRootPath() + '/remote.php/webdav/some/subdir/Tu_after_three.txt');
 		});
 		it('Triggers "fileActionsReady" event after rename', function() {
 			var handler = sinon.stub();
@@ -1412,7 +1412,7 @@ describe('OCA.Files.FileList tests', function() {
 			};
 			var $tr = fileList.add(fileData);
 			var $imgDiv = $tr.find('td.filename .thumbnail');
-			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(OC.webroot + '/core/img/filetypes/file.svg');
+			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(OC.getRootPath() + '/core/img/filetypes/file.svg');
 			// tries to load preview
 			expect(previewLoadStub.calledOnce).toEqual(true);
 		});
@@ -1424,7 +1424,7 @@ describe('OCA.Files.FileList tests', function() {
 
 			var $tr = fileList.add(fileData);
 			var $imgDiv = $tr.find('td.filename .thumbnail');
-			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(OC.webroot + '/core/img/filetypes/folder.svg');
+			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(OC.getRootPath() + '/core/img/filetypes/folder.svg');
 			// no preview since it's a directory
 			expect(previewLoadStub.notCalled).toEqual(true);
 		});
@@ -1432,24 +1432,24 @@ describe('OCA.Files.FileList tests', function() {
 			var fileData = new FileInfo({
 				type: 'file',
 				name: 'test file',
-				icon: OC.webroot + '/core/img/filetypes/application-pdf.svg',
+				icon: OC.getRootPath() + '/core/img/filetypes/application-pdf.svg',
 				mimetype: 'application/pdf'
 			});
 			var $tr = fileList.add(fileData);
 			var $imgDiv = $tr.find('td.filename .thumbnail');
-			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(OC.webroot + '/core/img/filetypes/application-pdf.svg');
+			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(OC.getRootPath() + '/core/img/filetypes/application-pdf.svg');
 			// try loading preview
 			expect(previewLoadStub.calledOnce).toEqual(true);
 		});
 		it('renders provided icon for file when provided', function() {
 			var fileData = new FileInfo({
 				name: 'somefile.pdf',
-				icon: OC.webroot + '/core/img/filetypes/application-pdf.svg'
+				icon: OC.getRootPath() + '/core/img/filetypes/application-pdf.svg'
 			});
 
 			var $tr = fileList.add(fileData);
 			var $imgDiv = $tr.find('td.filename .thumbnail');
-			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(OC.webroot + '/core/img/filetypes/application-pdf.svg');
+			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(OC.getRootPath() + '/core/img/filetypes/application-pdf.svg');
 			// try loading preview
 			expect(previewLoadStub.calledOnce).toEqual(true);
 		});
@@ -1457,12 +1457,12 @@ describe('OCA.Files.FileList tests', function() {
 			var fileData = new FileInfo({
 				name: 'some folder',
 				mimetype: 'httpd/unix-directory',
-				icon: OC.webroot + '/core/img/filetypes/folder-alt.svg'
+				icon: OC.getRootPath() + '/core/img/filetypes/folder-alt.svg'
 			});
 
 			var $tr = fileList.add(fileData);
 			var $imgDiv = $tr.find('td.filename .thumbnail');
-			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(OC.webroot + '/core/img/filetypes/folder-alt.svg');
+			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(OC.getRootPath() + '/core/img/filetypes/folder-alt.svg');
 			// do not load preview for folders
 			expect(previewLoadStub.notCalled).toEqual(true);
 		});
@@ -1474,11 +1474,11 @@ describe('OCA.Files.FileList tests', function() {
 			var $tr = fileList.add(fileData);
 			var $td = $tr.find('td.filename');
 			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail')))
-				.toEqual(OC.webroot + '/core/img/filetypes/file.svg');
+				.toEqual(OC.getRootPath() + '/core/img/filetypes/file.svg');
 			expect(previewLoadStub.calledOnce).toEqual(true);
 			// third argument is callback
-			previewLoadStub.getCall(0).args[0].callback(OC.webroot + '/somepath.png');
-			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(OC.webroot + '/somepath.png');
+			previewLoadStub.getCall(0).args[0].callback(OC.getRootPath() + '/somepath.png');
+			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(OC.getRootPath() + '/somepath.png');
 		});
 		it('does not render preview for directories', function() {
 			var fileData = {
@@ -1488,7 +1488,7 @@ describe('OCA.Files.FileList tests', function() {
 			};
 			var $tr = fileList.add(fileData);
 			var $td = $tr.find('td.filename');
-			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(OC.webroot + '/core/img/filetypes/folder.svg');
+			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(OC.getRootPath() + '/core/img/filetypes/folder.svg');
 			expect(previewLoadStub.notCalled).toEqual(true);
 		});
 		it('render encrypted folder icon for encrypted root', function() {
@@ -1500,7 +1500,7 @@ describe('OCA.Files.FileList tests', function() {
 			};
 			var $tr = fileList.add(fileData);
 			var $td = $tr.find('td.filename');
-			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(OC.webroot + '/core/img/filetypes/folder-encrypted.svg');
+			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(OC.getRootPath() + '/core/img/filetypes/folder-encrypted.svg');
 			expect(previewLoadStub.notCalled).toEqual(true);
 		});
 		it('render encrypted folder icon for encrypted subdir', function() {
@@ -1512,10 +1512,10 @@ describe('OCA.Files.FileList tests', function() {
 			};
 			var $tr = fileList.add(fileData);
 			var $td = $tr.find('td.filename');
-			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(OC.webroot + '/core/img/filetypes/folder-encrypted.svg');
+			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(OC.getRootPath() + '/core/img/filetypes/folder-encrypted.svg');
 			expect(previewLoadStub.notCalled).toEqual(true);
 			// default icon override
-			expect($tr.attr('data-icon')).toEqual(OC.webroot + '/core/img/filetypes/folder-encrypted.svg');
+			expect($tr.attr('data-icon')).toEqual(OC.getRootPath() + '/core/img/filetypes/folder-encrypted.svg');
 		});
 		it('render external storage icon for external storage root', function() {
 			var fileData = {
@@ -1526,7 +1526,7 @@ describe('OCA.Files.FileList tests', function() {
 			};
 			var $tr = fileList.add(fileData);
 			var $td = $tr.find('td.filename');
-			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(OC.webroot + '/core/img/filetypes/folder-external.svg');
+			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(OC.getRootPath() + '/core/img/filetypes/folder-external.svg');
 			expect(previewLoadStub.notCalled).toEqual(true);
 		});
 		it('render external storage icon for external storage subdir', function() {
@@ -1538,10 +1538,10 @@ describe('OCA.Files.FileList tests', function() {
 			};
 			var $tr = fileList.add(fileData);
 			var $td = $tr.find('td.filename');
-			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(OC.webroot + '/core/img/filetypes/folder-external.svg');
+			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(OC.getRootPath() + '/core/img/filetypes/folder-external.svg');
 			expect(previewLoadStub.notCalled).toEqual(true);
 			// default icon override
-			expect($tr.attr('data-icon')).toEqual(OC.webroot + '/core/img/filetypes/folder-external.svg');
+			expect($tr.attr('data-icon')).toEqual(OC.getRootPath() + '/core/img/filetypes/folder-external.svg');
 		});
 
 	});
@@ -1811,20 +1811,20 @@ describe('OCA.Files.FileList tests', function() {
 	describe('Download Url', function() {
 		it('returns correct download URL for single files', function() {
 			expect(fileList.getDownloadUrl('some file.txt'))
-				.toEqual(OC.webroot + '/remote.php/webdav/subdir/some%20file.txt');
+				.toEqual(OC.getRootPath() + '/remote.php/webdav/subdir/some%20file.txt');
 			expect(fileList.getDownloadUrl('some file.txt', '/anotherpath/abc'))
-				.toEqual(OC.webroot + '/remote.php/webdav/anotherpath/abc/some%20file.txt');
+				.toEqual(OC.getRootPath() + '/remote.php/webdav/anotherpath/abc/some%20file.txt');
 			$('#dir').val('/');
 			expect(fileList.getDownloadUrl('some file.txt'))
-				.toEqual(OC.webroot + '/remote.php/webdav/some%20file.txt');
+				.toEqual(OC.getRootPath() + '/remote.php/webdav/some%20file.txt');
 		});
 		it('returns correct download URL for multiple files', function() {
 			expect(fileList.getDownloadUrl(['a b c.txt', 'd e f.txt']))
-				.toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files=%5B%22a%20b%20c.txt%22%2C%22d%20e%20f.txt%22%5D');
+				.toEqual(OC.getRootPath() + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files=%5B%22a%20b%20c.txt%22%2C%22d%20e%20f.txt%22%5D');
 		});
 		it('returns the correct ajax URL', function() {
 			expect(fileList.getAjaxUrl('test', {a:1, b:'x y'}))
-				.toEqual(OC.webroot + '/index.php/apps/files/ajax/test.php?a=1&b=x%20y');
+				.toEqual(OC.getRootPath() + '/index.php/apps/files/ajax/test.php?a=1&b=x%20y');
 		});
 	});
 	describe('File selection', function() {
@@ -2239,7 +2239,7 @@ describe('OCA.Files.FileList tests', function() {
 				it('Opens download URL when clicking "Download"', function() {
 					$('.selectedActions .filesSelectMenu .download').click();
 					expect(redirectStub.calledOnce).toEqual(true);
-					expect(redirectStub.getCall(0).args[0]).toContain(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files=%5B%22One.txt%22%2C%22Three.pdf%22%2C%22somedir%22%5D');
+					expect(redirectStub.getCall(0).args[0]).toContain(OC.getRootPath() + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files=%5B%22One.txt%22%2C%22Three.pdf%22%2C%22somedir%22%5D');
 					redirectStub.restore();
 				});
 				it('Downloads root folder when all selected in root folder', function() {
@@ -2247,13 +2247,13 @@ describe('OCA.Files.FileList tests', function() {
 					$('.select-all').click();
 					$('.selectedActions .filesSelectMenu .download').click();
 					expect(redirectStub.calledOnce).toEqual(true);
-					expect(redirectStub.getCall(0).args[0]).toContain(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2F&files=');
+					expect(redirectStub.getCall(0).args[0]).toContain(OC.getRootPath() + '/index.php/apps/files/ajax/download.php?dir=%2F&files=');
 				});
 				it('Downloads parent folder when all selected in subfolder', function() {
 					$('.select-all').click();
 					$('.selectedActions .filesSelectMenu .download').click();
 					expect(redirectStub.calledOnce).toEqual(true);
-					expect(redirectStub.getCall(0).args[0]).toContain(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2F&files=subdir');
+					expect(redirectStub.getCall(0).args[0]).toContain(OC.getRootPath() + '/index.php/apps/files/ajax/download.php?dir=%2F&files=subdir');
 				});
 
 				afterEach(function() {

--- a/apps/files/tests/js/filesSpec.js
+++ b/apps/files/tests/js/filesSpec.js
@@ -78,15 +78,15 @@ describe('OCA.Files.Files tests', function() {
 	describe('getDownloadUrl', function() {
 		it('returns the ajax download URL when filename and dir specified', function() {
 			var url = Files.getDownloadUrl('test file.txt', '/subdir');
-			expect(url).toEqual(OC.webroot + '/remote.php/webdav/subdir/test%20file.txt');
+			expect(url).toEqual(OC.getRootPath() + '/remote.php/webdav/subdir/test%20file.txt');
 		});
 		it('returns the webdav download URL when filename and root dir specified', function() {
 			var url = Files.getDownloadUrl('test file.txt', '/');
-			expect(url).toEqual(OC.webroot + '/remote.php/webdav/test%20file.txt');
+			expect(url).toEqual(OC.getRootPath() + '/remote.php/webdav/test%20file.txt');
 		});
 		it('returns the ajax download URL when multiple files specified', function() {
 			var url = Files.getDownloadUrl(['test file.txt', 'abc.txt'], '/subdir');
-			expect(url).toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files=%5B%22test%20file.txt%22%2C%22abc.txt%22%5D');
+			expect(url).toEqual(OC.getRootPath() + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files=%5B%22test%20file.txt%22%2C%22abc.txt%22%5D');
 		});
 	});
 	describe('handleDownload', function() {

--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -79,7 +79,7 @@ OCA.External.StatusManager = {
 		} else {
 			defObj = $.ajax({
 				type: 'GET',
-				url: OC.webroot + '/index.php/apps/files_external/' + ((mountData.type === 'personal') ? 'userstorages' : 'userglobalstorages') + '/' + mountData.id,
+				url: OC.getRootPath() + '/index.php/apps/files_external/' + ((mountData.type === 'personal') ? 'userstorages' : 'userglobalstorages') + '/' + mountData.id,
 				data: {'testOnly' : false},
 				success: function (response) {
 					if (response && response.status === 0) {

--- a/apps/files_external/tests/js/mountsfilelistSpec.js
+++ b/apps/files_external/tests/js/mountsfilelistSpec.js
@@ -123,7 +123,7 @@ describe('OCA.External.FileList tests', function() {
 			expect($tr.attr('data-size')).not.toBeDefined();
 			expect($tr.attr('data-permissions')).toEqual('1'); // read only 
 			expect($tr.find('a.name').attr('href')).toEqual(
-				OC.webroot +
+				OC.getRootPath() +
 				'/index.php/apps/files' +
 				'?dir=/another%20mount%20points/sftp%20mount'
 			);
@@ -139,7 +139,7 @@ describe('OCA.External.FileList tests', function() {
 			expect($tr.attr('data-size')).not.toBeDefined();
 			expect($tr.attr('data-permissions')).toEqual('9'); // read and delete
 			expect($tr.find('a.name').attr('href')).toEqual(
-				OC.webroot +
+				OC.getRootPath() +
 				'/index.php/apps/files' +
 				'?dir=/mount%20points/smb%20mount'
 			);

--- a/apps/files_external/tests/js/settingsSpec.js
+++ b/apps/files_external/tests/js/settingsSpec.js
@@ -215,7 +215,7 @@ describe('OCA.External.Settings tests', function() {
 
 				expect(fakeServer.requests.length).toEqual(1);
 				var request = fakeServer.requests[0];
-				expect(request.url).toEqual(OC.webroot + '/index.php/apps/files_external/globalstorages');
+				expect(request.url).toEqual(OC.getRootPath() + '/index.php/apps/files_external/globalstorages');
 				expect(JSON.parse(request.requestBody)).toEqual({
 					backend: '\\OC\\TestBackend',
 					authMechanism: 'mechanism1',

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -343,7 +343,7 @@ OCA.Sharing.PublicApp = {
 	_legacyCreateFederatedShare: function (remote, token, owner, ownerDisplayName, name, isProtected) {
 
 		var self = this;
-		var location = window.location.protocol + '//' + window.location.host + OC.webroot;
+		var location = window.location.protocol + '//' + window.location.host + OC.getRootPath();
 
 		if(remote.substr(-1) !== '/') {
 			remote += '/'

--- a/apps/files_sharing/tests/js/publicAppSpec.js
+++ b/apps/files_sharing/tests/js/publicAppSpec.js
@@ -110,24 +110,24 @@ describe('OCA.Sharing.PublicApp tests', function() {
 
 			it('returns correct download URL for single files', function() {
 				expect(fileList.getDownloadUrl('some file.txt'))
-					.toEqual(OC.webroot + '/index.php/s/sh4tok/download?path=%2Fsubdir&files=some%20file.txt');
+					.toEqual(OC.getRootPath() + '/index.php/s/sh4tok/download?path=%2Fsubdir&files=some%20file.txt');
 				expect(fileList.getDownloadUrl('some file.txt', '/anotherpath/abc'))
-					.toEqual(OC.webroot + '/index.php/s/sh4tok/download?path=%2Fanotherpath%2Fabc&files=some%20file.txt');
+					.toEqual(OC.getRootPath() + '/index.php/s/sh4tok/download?path=%2Fanotherpath%2Fabc&files=some%20file.txt');
 				fileList.changeDirectory('/');
 				expect(fileList.getDownloadUrl('some file.txt'))
-					.toEqual(OC.webroot + '/index.php/s/sh4tok/download?path=%2F&files=some%20file.txt');
+					.toEqual(OC.getRootPath() + '/index.php/s/sh4tok/download?path=%2F&files=some%20file.txt');
 			});
 			it('returns correct download URL for multiple files', function() {
 				expect(fileList.getDownloadUrl(['a b c.txt', 'd e f.txt']))
-					.toEqual(OC.webroot + '/index.php/s/sh4tok/download?path=%2Fsubdir&files=%5B%22a%20b%20c.txt%22%2C%22d%20e%20f.txt%22%5D');
+					.toEqual(OC.getRootPath() + '/index.php/s/sh4tok/download?path=%2Fsubdir&files=%5B%22a%20b%20c.txt%22%2C%22d%20e%20f.txt%22%5D');
 			});
 			it('returns the correct ajax URL', function() {
 				expect(fileList.getAjaxUrl('test', {a:1, b:'x y'}))
-					.toEqual(OC.webroot + '/index.php/apps/files_sharing/ajax/test.php?a=1&b=x%20y&t=sh4tok');
+					.toEqual(OC.getRootPath() + '/index.php/apps/files_sharing/ajax/test.php?a=1&b=x%20y&t=sh4tok');
 			});
 			it('returns correct download URL for downloading everything', function() {
 				expect(fileList.getDownloadUrl())
-					.toEqual(OC.webroot + '/index.php/s/sh4tok/download?path=%2Fsubdir');
+					.toEqual(OC.getRootPath() + '/index.php/s/sh4tok/download?path=%2Fsubdir');
 			});
 		});
 		describe('Upload Url', function() {

--- a/apps/files_sharing/tests/js/sharedfilelistSpec.js
+++ b/apps/files_sharing/tests/js/sharedfilelistSpec.js
@@ -173,7 +173,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-favorite')).toEqual('true');
 			expect($tr.attr('data-tags')).toEqual(OC.TAG_FAVORITE);
 			expect($tr.find('a.name').attr('href')).toEqual(
-				OC.webroot +
+				OC.getRootPath() +
 				'/remote.php/webdav/local%20path/local%20name.txt'
 			);
 			expect($tr.find('.nametext').text().trim()).toEqual('local name.txt');
@@ -193,7 +193,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-favorite')).not.toBeDefined();
 			expect($tr.attr('data-tags')).toEqual('');
 			expect($tr.find('a.name').attr('href')).toEqual(
-				OC.webroot +
+				OC.getRootPath() +
 				'/remote.php/webdav/b.txt'
 			);
 			expect($tr.find('.nametext').text().trim()).toEqual('b.txt');
@@ -251,7 +251,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-favorite')).toEqual('true');
 			expect($tr.attr('data-tags')).toEqual(OC.TAG_FAVORITE);
 			expect($tr.find('a.name').attr('href')).toEqual(
-				OC.webroot +
+				OC.getRootPath() +
 				'/index.php/apps/files' +
 				'?dir=/local%20path/local%20name'
 			);
@@ -272,7 +272,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-favorite')).not.toBeDefined();
 			expect($tr.attr('data-tags')).toEqual('');
 			expect($tr.find('a.name').attr('href')).toEqual(
-				OC.webroot +
+				OC.getRootPath() +
 				'/index.php/apps/files' +
 				'?dir=/b'
 			);
@@ -352,7 +352,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-favorite')).toEqual('true');
 			expect($tr.attr('data-tags')).toEqual(OC.TAG_FAVORITE);
 			expect($tr.find('a.name').attr('href')).toEqual(
-				OC.webroot +
+				OC.getRootPath() +
 				'/remote.php/webdav/local%20path/local%20name.txt'
 			);
 			expect($tr.find('.nametext').text().trim()).toEqual('local name.txt');
@@ -394,7 +394,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-favorite')).toEqual('true');
 			expect($tr.attr('data-tags')).toEqual(OC.TAG_FAVORITE);
 			expect($tr.find('a.name').attr('href')).toEqual(
-				OC.webroot +
+				OC.getRootPath() +
 				'/index.php/apps/files' +
 				'?dir=/local%20path/local%20name'
 			);
@@ -448,7 +448,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-favorite')).toEqual('true');
 			expect($tr.attr('data-tags')).toEqual(OC.TAG_FAVORITE);
 			expect($tr.find('a.name').attr('href')).toEqual(
-				OC.webroot + '/remote.php/webdav/local%20path/local%20name.txt'
+				OC.getRootPath() + '/remote.php/webdav/local%20path/local%20name.txt'
 			);
 
 			expect($tr.find('.nametext').text().trim()).toEqual('local name.txt');
@@ -519,7 +519,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-favorite')).toEqual('true');
 			expect($tr.attr('data-tags')).toEqual(OC.TAG_FAVORITE);
 			expect($tr.find('a.name').attr('href')).toEqual(
-				OC.webroot + '/remote.php/webdav/local%20path/local%20name.txt'
+				OC.getRootPath() + '/remote.php/webdav/local%20path/local%20name.txt'
 			);
 			expect($tr.find('.nametext').text().trim()).toEqual('local name.txt');
 		});
@@ -634,7 +634,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-favorite')).toEqual('true');
 			expect($tr.attr('data-tags')).toEqual(OC.TAG_FAVORITE);
 			expect($tr.find('a.name').attr('href')).toEqual(
-				OC.webroot + '/remote.php/webdav/local%20path/local%20name.txt'
+				OC.getRootPath() + '/remote.php/webdav/local%20path/local%20name.txt'
 			);
 			expect($tr.attr('data-expiration')).toEqual('0');
 			expect($tr.find('td:last-child span').text()).toEqual('');
@@ -687,7 +687,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-favorite')).toEqual('true');
 			expect($tr.attr('data-tags')).toEqual(OC.TAG_FAVORITE);
 			expect($tr.find('a.name').attr('href')).toEqual(
-					OC.webroot +
+					OC.getRootPath() +
 					'/remote.php/webdav/local%20path/local%20name.txt');
 
 			expect($tr.find('.nametext').text().trim()).toEqual('local name.txt');

--- a/apps/files_trashbin/tests/js/filelistSpec.js
+++ b/apps/files_trashbin/tests/js/filelistSpec.js
@@ -158,10 +158,10 @@ describe('OCA.Trashbin.FileList tests', function () {
 			expect($crumbs.length).toEqual(3);
 			expect($crumbs.eq(1).find('a').text()).toEqual('Home');
 			expect($crumbs.eq(1).find('a').attr('href'))
-				.toEqual(OC.webroot + '/index.php/apps/files?view=trashbin&dir=/');
+				.toEqual(OC.getRootPath() + '/index.php/apps/files?view=trashbin&dir=/');
 			expect($crumbs.eq(2).find('a').text()).toEqual('subdir');
 			expect($crumbs.eq(2).find('a').attr('href'))
-				.toEqual(OC.webroot + '/index.php/apps/files?view=trashbin&dir=/subdir');
+				.toEqual(OC.getRootPath() + '/index.php/apps/files?view=trashbin&dir=/subdir');
 		});
 	});
 	describe('Rendering rows', function () {
@@ -326,7 +326,7 @@ describe('OCA.Trashbin.FileList tests', function () {
 				expect(fakeServer.requests.length).toEqual(files.length);
 				for (var i = 0; i < files.length; i++) {
 					request = fakeServer.requests[i];
-					expect(request.url).toEqual(OC.webroot + '/remote.php/dav/trashbin/user/trash/' + files[i]);
+					expect(request.url).toEqual(OC.getRootPath() + '/remote.php/dav/trashbin/user/trash/' + files[i]);
 					request.respond(200);
 				}
 				return promise.then(function () {
@@ -345,7 +345,7 @@ describe('OCA.Trashbin.FileList tests', function () {
 				});
 				expect(fakeServer.requests.length).toEqual(1);
 				request = fakeServer.requests[0];
-				expect(request.url).toEqual(OC.webroot + '/remote.php/dav/trashbin/user/trash');
+				expect(request.url).toEqual(OC.getRootPath() + '/remote.php/dav/trashbin/user/trash');
 				request.respond(200);
 				return promise.then(function () {
 					expect(fileList.isEmpty).toEqual(true);
@@ -363,8 +363,8 @@ describe('OCA.Trashbin.FileList tests', function () {
 				expect(fakeServer.requests.length).toEqual(files.length);
 				for (var i = 0; i < files.length; i++) {
 					request = fakeServer.requests[i];
-					expect(request.url).toEqual(OC.webroot + '/remote.php/dav/trashbin/user/trash/' + files[i]);
-					expect(request.requestHeaders.Destination).toEqual(OC.webroot + '/remote.php/dav/trashbin/user/restore/' + files[i]);
+					expect(request.url).toEqual(OC.getRootPath() + '/remote.php/dav/trashbin/user/trash/' + files[i]);
+					expect(request.requestHeaders.Destination).toEqual(OC.getRootPath() + '/remote.php/dav/trashbin/user/restore/' + files[i]);
 					request.respond(200);
 				}
 				return promise.then(function() {
@@ -385,8 +385,8 @@ describe('OCA.Trashbin.FileList tests', function () {
 				expect(fakeServer.requests.length).toEqual(files.length);
 				for (var i = 0; i < files.length; i++) {
 					request = fakeServer.requests[i];
-					expect(request.url).toEqual(OC.webroot + '/remote.php/dav/trashbin/user/trash/' + files[i]);
-					expect(request.requestHeaders.Destination).toEqual(OC.webroot + '/remote.php/dav/trashbin/user/restore/' + files[i]);
+					expect(request.url).toEqual(OC.getRootPath() + '/remote.php/dav/trashbin/user/trash/' + files[i]);
+					expect(request.requestHeaders.Destination).toEqual(OC.getRootPath() + '/remote.php/dav/trashbin/user/restore/' + files[i]);
 					request.respond(200);
 				}
 				return promise.then(function() {

--- a/core/js/backgroundjobs.js
+++ b/core/js/backgroundjobs.js
@@ -21,7 +21,7 @@
 
 // start worker once page has loaded
 $(document).ready(function(){
-	$.get( OC.webroot+'/cron.php' );
+	$.get( OC.getRootPath()+'/cron.php' );
 
 	$('.section .icon-info').tooltip({
 		placement: 'right'

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -99,7 +99,7 @@ var OCP = {},
 	 * @return {string} the url
 	 */
 	linkToRemoteBase:function(service) {
-		return OC.webroot + '/remote.php/' + service;
+		return OC.getRootPath() + '/remote.php/' + service;
 	},
 
 	/**
@@ -119,7 +119,7 @@ var OCP = {},
 	 */
 	linkToOCS: function(service, version) {
 		version = (version !== 2) ? 1 : 2;
-		return window.location.protocol + '//' + window.location.host + OC.webroot + '/ocs/v' + version + '.php/' + service + '/';
+		return window.location.protocol + '//' + window.location.host + OC.getRootPath() + '/ocs/v' + version + '.php/' + service + '/';
 	},
 
 	/**
@@ -157,10 +157,10 @@ var OCP = {},
 		}
 
 		if(oc_config.modRewriteWorking == true) {
-			return OC.webroot + _build(url, params);
+			return OC.getRootPath() + _build(url, params);
 		}
 
-		return OC.webroot + '/index.php' + _build(url, params);
+		return OC.getRootPath() + '/index.php' + _build(url, params);
 	},
 
 	/**
@@ -172,7 +172,7 @@ var OCP = {},
 	 */
 	filePath:function(app,type,file){
 		var isCore=OC.coreApps.indexOf(app)!==-1,
-			link=OC.webroot;
+			link=OC.getRootPath();
 		if(file.substring(file.length-3) === 'php' && !isCore){
 			link+='/index.php/apps/' + app;
 			if (file != 'index.php') {

--- a/core/js/maintenance-check.js
+++ b/core/js/maintenance-check.js
@@ -3,7 +3,7 @@ window.setInterval(checkStatus, 20000);
 
 function checkStatus() {
 	var request = new XMLHttpRequest();
-	request.open("GET", OC.webroot+'/status.php', true);
+	request.open("GET", OC.getRootPath()+'/status.php', true);
 	request.onreadystatechange = function() {
 		if (request.readyState === 4) {
 			var response = request.responseText;

--- a/core/js/mimetype.js
+++ b/core/js/mimetype.js
@@ -85,7 +85,7 @@ OC.MimeType = {
 		var gotIcon = null;
 		var path = '';
 		if (OC.theme.folder !== '' && $.isArray(OC.MimeTypeList.themes[OC.theme.folder])) {
-			path = OC.webroot + '/themes/' + OC.theme.folder + '/core/img/filetypes/';
+			path = OC.getRootPath() + '/themes/' + OC.theme.folder + '/core/img/filetypes/';
 			var icon = OC.MimeType._getFile(mimeType, OC.MimeTypeList.themes[OC.theme.folder]);
 
 			if (icon !== null) {
@@ -101,7 +101,7 @@ OC.MimeType = {
 
 		// If we do not yet have an icon fall back to the default
 		if (gotIcon === null) {
-			path = OC.webroot + '/core/img/filetypes/';
+			path = OC.getRootPath() + '/core/img/filetypes/';
 			path += OC.MimeType._getFile(mimeType, OC.MimeTypeList.files);
 		}
 

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -31,7 +31,7 @@ describe('Core base tests', function() {
 	});
 	describe('Base values', function() {
 		it('Sets webroots', function() {
-			expect(OC.webroot).toBeDefined();
+			expect(OC.getRootPath()).toBeDefined();
 			expect(OC.appswebroots).toBeDefined();
 		});
 	});
@@ -256,7 +256,7 @@ describe('Core base tests', function() {
 	describe('filePath', function() {
 		beforeEach(function() {
 			OC.webroot = 'http://localhost';
-			OC.appswebroots.files = OC.webroot + '/apps3/files';
+			OC.appswebroots.files = OC.getRootPath() + '/apps3/files';
 		});
 		afterEach(function() {
 			delete OC.appswebroots.files;
@@ -275,7 +275,7 @@ describe('Core base tests', function() {
 	});
 	describe('Link functions', function() {
 		var TESTAPP = 'testapp';
-		var TESTAPP_ROOT = OC.webroot + '/appsx/testapp';
+		var TESTAPP_ROOT = OC.getRootPath() + '/appsx/testapp';
 
 		beforeEach(function() {
 			OC.appswebroots[TESTAPP] = TESTAPP_ROOT;
@@ -285,22 +285,22 @@ describe('Core base tests', function() {
 			delete OC.appswebroots[TESTAPP];
 		});
 		it('Generates correct links for core apps', function() {
-			expect(OC.linkTo('core', 'somefile.php')).toEqual(OC.webroot + '/core/somefile.php');
-			expect(OC.linkTo('admin', 'somefile.php')).toEqual(OC.webroot + '/admin/somefile.php');
+			expect(OC.linkTo('core', 'somefile.php')).toEqual(OC.getRootPath() + '/core/somefile.php');
+			expect(OC.linkTo('admin', 'somefile.php')).toEqual(OC.getRootPath() + '/admin/somefile.php');
 		});
 		it('Generates correct links for regular apps', function() {
-			expect(OC.linkTo(TESTAPP, 'somefile.php')).toEqual(OC.webroot + '/index.php/apps/' + TESTAPP + '/somefile.php');
+			expect(OC.linkTo(TESTAPP, 'somefile.php')).toEqual(OC.getRootPath() + '/index.php/apps/' + TESTAPP + '/somefile.php');
 		});
 		it('Generates correct remote links', function() {
-			expect(OC.linkToRemote('webdav')).toEqual(window.location.protocol + '//' + window.location.host + OC.webroot + '/remote.php/webdav');
+			expect(OC.linkToRemote('webdav')).toEqual(window.location.protocol + '//' + window.location.host + OC.getRootPath() + '/remote.php/webdav');
 		});
 		describe('Images', function() {
 			it('Generates image path with given extension', function() {
-				expect(OC.imagePath('core', 'somefile.jpg')).toEqual(OC.webroot + '/core/img/somefile.jpg');
+				expect(OC.imagePath('core', 'somefile.jpg')).toEqual(OC.getRootPath() + '/core/img/somefile.jpg');
 				expect(OC.imagePath(TESTAPP, 'somefile.jpg')).toEqual(TESTAPP_ROOT + '/img/somefile.jpg');
 			});
 			it('Generates image path with svg extension', function() {
-				expect(OC.imagePath('core', 'somefile')).toEqual(OC.webroot + '/core/img/somefile.svg');
+				expect(OC.imagePath('core', 'somefile')).toEqual(OC.getRootPath() + '/core/img/somefile.svg');
 				expect(OC.imagePath(TESTAPP, 'somefile')).toEqual(TESTAPP_ROOT + '/img/somefile.svg');
 			});
 		});
@@ -502,23 +502,23 @@ describe('Core base tests', function() {
 	});
 	describe('Generate Url', function() {
 		it('returns absolute urls', function() {
-			expect(OC.generateUrl('csrftoken')).toEqual(OC.webroot + '/index.php/csrftoken');
-			expect(OC.generateUrl('/csrftoken')).toEqual(OC.webroot + '/index.php/csrftoken');
+			expect(OC.generateUrl('csrftoken')).toEqual(OC.getRootPath() + '/index.php/csrftoken');
+			expect(OC.generateUrl('/csrftoken')).toEqual(OC.getRootPath() + '/index.php/csrftoken');
 		});
 		it('substitutes parameters which are escaped by default', function() {
-			expect(OC.generateUrl('apps/files/download/{file}', {file: '<">ImAnUnescapedString/!'})).toEqual(OC.webroot + '/index.php/apps/files/download/%3C%22%3EImAnUnescapedString%2F!');
+			expect(OC.generateUrl('apps/files/download/{file}', {file: '<">ImAnUnescapedString/!'})).toEqual(OC.getRootPath() + '/index.php/apps/files/download/%3C%22%3EImAnUnescapedString%2F!');
 		});
 		it('substitutes parameters which can also be unescaped via option flag', function() {
-			expect(OC.generateUrl('apps/files/download/{file}', {file: 'subfolder/Welcome.txt'}, {escape: false})).toEqual(OC.webroot + '/index.php/apps/files/download/subfolder/Welcome.txt');
+			expect(OC.generateUrl('apps/files/download/{file}', {file: 'subfolder/Welcome.txt'}, {escape: false})).toEqual(OC.getRootPath() + '/index.php/apps/files/download/subfolder/Welcome.txt');
 		});
 		it('substitutes multiple parameters which are escaped by default', function() {
-			expect(OC.generateUrl('apps/files/download/{file}/{id}', {file: '<">ImAnUnescapedString/!', id: 5})).toEqual(OC.webroot + '/index.php/apps/files/download/%3C%22%3EImAnUnescapedString%2F!/5');
+			expect(OC.generateUrl('apps/files/download/{file}/{id}', {file: '<">ImAnUnescapedString/!', id: 5})).toEqual(OC.getRootPath() + '/index.php/apps/files/download/%3C%22%3EImAnUnescapedString%2F!/5');
 		});
 		it('substitutes multiple parameters which can also be unescaped via option flag', function() {
-			expect(OC.generateUrl('apps/files/download/{file}/{id}', {file: 'subfolder/Welcome.txt', id: 5}, {escape: false})).toEqual(OC.webroot + '/index.php/apps/files/download/subfolder/Welcome.txt/5');
+			expect(OC.generateUrl('apps/files/download/{file}/{id}', {file: 'subfolder/Welcome.txt', id: 5}, {escape: false})).toEqual(OC.getRootPath() + '/index.php/apps/files/download/subfolder/Welcome.txt/5');
 		});
 		it('doesnt error out with no params provided', function  () {
-			expect(OC.generateUrl('apps/files/download{file}')).toEqual(OC.webroot + '/index.php/apps/files/download%7Bfile%7D');
+			expect(OC.generateUrl('apps/files/download{file}')).toEqual(OC.getRootPath() + '/index.php/apps/files/download%7Bfile%7D');
 		});
 	});
 	describe('Main menu mobile toggle', function() {

--- a/core/js/tests/specs/l10nSpec.js
+++ b/core/js/tests/specs/l10nSpec.js
@@ -12,7 +12,7 @@ describe('OC.L10N tests', function() {
 	var TEST_APP = 'jsunittestapp';
 
 	beforeEach(function() {
-		OC.appswebroots[TEST_APP] = OC.webroot + '/apps3/jsunittestapp';
+		OC.appswebroots[TEST_APP] = OC.getRootPath() + '/apps3/jsunittestapp';
 	});
 	afterEach(function() {
 		delete OC.L10N._bundles[TEST_APP];
@@ -141,7 +141,7 @@ describe('OC.L10N tests', function() {
 			expect(fakeServer.requests.length).toEqual(1);
 			var req = fakeServer.requests[0];
 			expect(req.url).toEqual(
-				OC.webroot + '/apps3/' + TEST_APP + '/l10n/zh_CN.json'
+				OC.getRootPath() + '/apps3/' + TEST_APP + '/l10n/zh_CN.json'
 			);
 			req.respond(
 				200,

--- a/core/js/tests/specs/mimeTypeSpec.js
+++ b/core/js/tests/specs/mimeTypeSpec.js
@@ -100,7 +100,7 @@ describe('MimeType tests', function() {
 
 			it('return the url for the mimetype file', function() {
 				var res = OC.MimeType.getIconUrl('file');
-				expect(res).toEqual(OC.webroot + '/core/img/filetypes/file.svg');
+				expect(res).toEqual(OC.getRootPath() + '/core/img/filetypes/file.svg');
 			});
 
 			it('test if the cache works correctly', function() {
@@ -118,7 +118,7 @@ describe('MimeType tests', function() {
 
 			it('test if alaiases are converted correctly', function() {
 				var res = OC.MimeType.getIconUrl('app/foobar');
-				expect(res).toEqual(OC.webroot + '/core/img/filetypes/foo-bar.svg');
+				expect(res).toEqual(OC.getRootPath() + '/core/img/filetypes/foo-bar.svg');
 				expect(OC.MimeType._mimeTypeIcons['foo/bar']).toEqual(res);
 			});
 		});
@@ -139,12 +139,12 @@ describe('MimeType tests', function() {
 
 			it('test if theme path is used if a theme icon is availble', function() {
 				var res = OC.MimeType.getIconUrl('dir');
-				expect(res).toEqual(OC.webroot + '/themes/abc/core/img/filetypes/folder.svg');
+				expect(res).toEqual(OC.getRootPath() + '/themes/abc/core/img/filetypes/folder.svg');
 			});
 
 			it('test if we fallback to the default theme if no icon is available in the theme', function() {
 				var res = OC.MimeType.getIconUrl('dir-shared');
-				expect(res).toEqual(OC.webroot + '/core/img/filetypes/folder-shared.svg');
+				expect(res).toEqual(OC.getRootPath() + '/core/img/filetypes/folder-shared.svg');
 			});
 		});
 	});

--- a/core/js/update.js
+++ b/core/js/update.js
@@ -41,7 +41,7 @@
 				})
 			);
 
-			var updateEventSource = new OC.EventSource(OC.webroot+'/core/ajax/update.php');
+			var updateEventSource = new OC.EventSource(OC.getRootPath()+'/core/ajax/update.php');
 			updateEventSource.listen('success', function(message) {
 				self.setMessage(message);
 			});

--- a/core/search/js/searchprovider.js
+++ b/core/search/js/searchprovider.js
@@ -417,7 +417,7 @@ $(document).ready(function() {
 	if ($searchResults.length > 0 && $searchBox.length > 0) {
 		$searchResults.addClass('hidden');
 		$searchResults.load(
-			OC.webroot + '/core/search/templates/part.results.html',
+			OC.getRootPath() + '/core/search/templates/part.results.html',
 			function() {
 				OC.Search = new OCA.Search.Core(
 					$searchBox,


### PR DESCRIPTION
Ref https://github.com/nextcloud/server/blob/d07c5db947ebe04666e18294481ff3574314f625/core/js/js.js#L53-L62

This is a big one. I deem it's a bad idea to remove this now (even though from a deprecation time line it would be okay) because it's used so much. However, I search-and-replace'd all usages I could find locally.