### PR TITLE
Remove deprecated and noop APIs from OC.AppConfig

### DIFF
--- a/core/js/config.js
+++ b/core/js/config.js
@@ -58,23 +58,9 @@ OC.AppConfig={
 	},
 
 	/**
-	 * @deprecated
-	 */
-	hasKey:function(app,key,callback){
-		console.error('OC.AppConfig.hasKey is not supported anymore. Use OCP.AppConfig.getValue instead.');
-	},
-
-	/**
 	 * @deprecated Use OCP.AppConfig.deleteKey() instead
 	 */
 	deleteKey:function(app,key){
 		OCP.AppConfig.deleteKey(app, key);
-	},
-
-	/**
-	 * @deprecated
-	 */
-	deleteApp:function(app){
-		console.error('OC.AppConfig.deleteApp is not supported anymore.');
 	}
 };


### PR DESCRIPTION
APIs are practically dead and couldn't find any usage.