### PR TITLE
Remove deprecated and unused legacy ShareConfigModel.areAvatarsEnabled()

### DIFF
--- a/core/js/shareconfigmodel.js
+++ b/core/js/shareconfigmodel.js
@@ -35,14 +35,6 @@
 
 		/**
 		 * @returns {boolean}
-		 * @deprecated here for legacy reasons - will always return true
-		 */
-		areAvatarsEnabled: function() {
-			return true;
-		},
-
-		/**
-		 * @returns {boolean}
 		 */
 		isPublicUploadEnabled: function() {
 			var publicUploadEnabled = $('#filestable').data('allow-public-upload');


### PR DESCRIPTION
No usage found. @MorrisJobke wouldn't hurt to double-check with your apps dir.