### PR TITLE
Fix depracted jQuery.bind call

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -3432,7 +3432,7 @@
 $(document).ready(function() {
 	// FIXME: unused ?
 	OCA.Files.FileList.useUndo = (window.onbeforeunload)?true:false;
-	$(window).bind('beforeunload', function () {
+	$(window).on('beforeunload', function () {
 		if (OCA.Files.FileList.lastAction) {
 			OCA.Files.FileList.lastAction();
 		}


### PR DESCRIPTION
Fixes

```
JQMIGRATE: jQuery.fn.bind() is deprecated jquery-migrate.js:62:4
console.trace() jquery-migrate.js:64:5
migrateWarn
https://localhost/core/vendor/jquery-migrate/jquery-migrate.js:64:5
bind
https://localhost/core/vendor/jquery-migrate/jquery-migrate.js:419:3
<anonymous>
https://localhost/apps/files/js/filelist.js:3435:2
j
https://localhost/core/vendor/jquery/dist/jquery.min.js:2:26920
fireWith
https://localhost/core/vendor/jquery/dist/jquery.min.js:2:27738
ready
https://localhost/core/vendor/jquery/dist/jquery.min.js:2:29530
I
https://localhost/core/vendor/jquery/dist/jquery.min.js:2:29721

```