### PR TITLE
always query the lookup server in a global scale setup 

### DIFF
--- a/lib/private/Collaboration/Collaborators/LookupPlugin.php
+++ b/lib/private/Collaboration/Collaborators/LookupPlugin.php
@@ -27,8 +27,10 @@ namespace OC\Collaboration\Collaborators;
 use OCP\Collaboration\Collaborators\ISearchPlugin;
 use OCP\Collaboration\Collaborators\ISearchResult;
 use OCP\Collaboration\Collaborators\SearchResultType;
+use OCP\Federation\ICloudIdManager;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
+use OCP\IUserSession;
 use OCP\Share;
 
 class LookupPlugin implements ISearchPlugin {
@@ -37,14 +39,27 @@ class LookupPlugin implements ISearchPlugin {
 	private $config;
 	/** @var IClientService */
 	private $clientService;
+	/** @var string remote part of the current user's cloud id */
+	private $currentUserRemote;
+	/** @var ICloudIdManager */
+	private $cloudIdManager;
 
-	public function __construct(IConfig $config, IClientService $clientService) {
+	public function __construct(IConfig $config,
+								IClientService $clientService,
+								IUserSession $userSession,
+								ICloudIdManager $cloudIdManager) {
 		$this->config = $config;
 		$this->clientService = $clientService;
+		$this->cloudIdManager = $cloudIdManager;
+		$currentUserCloudId = $userSession->getUser()->getCloudId();
+		$this->currentUserRemote = $cloudIdManager->resolveCloudId($currentUserCloudId)->getRemote();
 	}
 
 	public function search($search, $limit, $offset, ISearchResult $searchResult) {
-		if ($this->config->getAppValue('files_sharing', 'lookupServerEnabled', 'no') !== 'yes') {
+		$isGlobalScaleEnabled = $this->config->getSystemValue('gs.enabled', false);
+		$isLookupServerEnabled = $this->config->getAppValue('files_sharing', 'lookupServerEnabled', 'no');
+		// if case of Global Scale we always search the lookup server
+		if ($isLookupServerEnabled !== 'yes' && !$isGlobalScaleEnabled) {
 			return false;
 		}
 
@@ -65,8 +80,12 @@ class LookupPlugin implements ISearchPlugin {
 			$body = json_decode($response->getBody(), true);
 
 			foreach ($body as $lookup) {
+				$remote = $this->cloudIdManager->resolveCloudId($lookup['federationId'])->getRemote();
+				if ($this->currentUserRemote === $remote) continue;
+				$name = $lookup['name']['value'];
+				$label = empty($name) ? $lookup['federationId'] : $name . ' (' . $lookup['federationId'] . ')';
 				$result[] = [
-					'label' => $lookup['federationId'],
+					'label' => $label,
 					'value' => [
 						'shareType' => Share::SHARE_TYPE_REMOTE,
 						'shareWith' => $lookup['federationId'],

--- a/lib/private/Collaboration/Collaborators/LookupPlugin.php
+++ b/lib/private/Collaboration/Collaborators/LookupPlugin.php
@@ -82,7 +82,7 @@ class LookupPlugin implements ISearchPlugin {
 			foreach ($body as $lookup) {
 				$remote = $this->cloudIdManager->resolveCloudId($lookup['federationId'])->getRemote();
 				if ($this->currentUserRemote === $remote) continue;
-				$name = $lookup['name']['value'];
+				$name = isset($lookup['name']['value']) ? $lookup['name']['value'] : '';
 				$label = empty($name) ? $lookup['federationId'] : $name . ' (' . $lookup['federationId'] . ')';
 				$result[] = [
 					'label' => $label,

--- a/tests/lib/Collaboration/Collaborators/LookupPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/LookupPluginTest.php
@@ -25,12 +25,17 @@ namespace Test\Collaboration\Collaborators;
 
 
 use OC\Collaboration\Collaborators\LookupPlugin;
+use OC\Federation\CloudId;
 use OCP\Collaboration\Collaborators\ISearchResult;
 use OCP\Collaboration\Collaborators\SearchResultType;
+use OCP\Federation\ICloudId;
+use OCP\Federation\ICloudIdManager;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
 use OCP\IConfig;
+use OCP\IUser;
+use OCP\IUserSession;
 use OCP\Share;
 use Test\TestCase;
 
@@ -40,16 +45,36 @@ class LookupPluginTest extends TestCase {
 	protected $config;
 	/** @var  IClientService|\PHPUnit_Framework_MockObject_MockObject */
 	protected $clientService;
+	/** @var IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	protected $userSession;
+	/** @var ICloudIdManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $cloudIdManager;
 	/** @var  LookupPlugin */
 	protected $plugin;
 
 	public function setUp() {
 		parent::setUp();
 
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->cloudIdManager = $this->createMock(ICloudIdManager::class);
 		$this->config = $this->createMock(IConfig::class);
 		$this->clientService = $this->createMock(IClientService::class);
+		$cloudId = $this->createMock(ICloudId::class);
+		$cloudId->expects($this->any())->method('getRemote')->willReturn('myNextcloud.net');
+		$user = $this->createMock(IUser::class);
+		$user->expects($this->any())->method('getCloudId')->willReturn('user@myNextcloud.net');
+		$this->userSession->expects($this->any())->method('getUser')
+			->willReturn($user);
+		$this->cloudIdManager->expects($this->any())->method('resolveCloudId')
+			->willReturnCallback(function($cloudId) {
+				if ($cloudId === 'user@myNextcloud.net') {
+					return new CloudId('user@myNextcloud.net', 'user', 'myNextcloud.net');
+				}
+				return new CloudId('user@someNextcloud.net', 'user', 'someNextcloud.net');
+			});
 
-		$this->plugin = new LookupPlugin($this->config, $this->clientService);
+
+		$this->plugin = new LookupPlugin($this->config, $this->clientService, $this->userSession, $this->cloudIdManager);
 	}
 
 	/**
@@ -69,7 +94,11 @@ class LookupPluginTest extends TestCase {
 			->method('getAppValue')
 			->with('files_sharing', 'lookupServerEnabled', 'no')
 			->willReturn('yes');
-		$this->config->expects($this->once())
+		$this->config->expects($this->at(0))
+			->method('getSystemValue')
+			->with('gs.enabled', false)
+			->willReturn(false);
+		$this->config->expects($this->at(2))
 			->method('getSystemValue')
 			->with('lookup_server', 'https://lookup.nextcloud.com')
 			->willReturn($searchParams['server']);

--- a/tests/lib/Collaboration/Collaborators/LookupPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/LookupPluginTest.php
@@ -34,6 +34,7 @@ use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
 use OCP\IConfig;
+use OCP\ILogger;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Share;
@@ -51,6 +52,8 @@ class LookupPluginTest extends TestCase {
 	protected $cloudIdManager;
 	/** @var  LookupPlugin */
 	protected $plugin;
+	/** @var ILogger|\PHPUnit_Framework_MockObject_MockObject */
+	protected $logger;
 
 	public function setUp() {
 		parent::setUp();
@@ -58,6 +61,7 @@ class LookupPluginTest extends TestCase {
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->cloudIdManager = $this->createMock(ICloudIdManager::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->logger = $this->createMock(ILogger::class);
 		$this->clientService = $this->createMock(IClientService::class);
 		$cloudId = $this->createMock(ICloudId::class);
 		$cloudId->expects($this->any())->method('getRemote')->willReturn('myNextcloud.net');
@@ -74,7 +78,13 @@ class LookupPluginTest extends TestCase {
 			});
 
 
-		$this->plugin = new LookupPlugin($this->config, $this->clientService, $this->userSession, $this->cloudIdManager);
+		$this->plugin = new LookupPlugin(
+			$this->config,
+			$this->clientService,
+			$this->userSession,
+			$this->cloudIdManager,
+			$this->logger
+		);
 	}
 
 	/**


### PR DESCRIPTION
Check if global scale is enabled, in this case we should always query the lookup server. Further I improved the label of the result to look like `User Name (uid@nextcloudserver)`