### PR TITLE
Use numeric placeholders if there are multiple, so that RTL languages…

### DIFF
--- a/apps/admin_audit/lib/Actions/AppManagement.php
+++ b/apps/admin_audit/lib/Actions/AppManagement.php
@@ -41,7 +41,7 @@ class AppManagement extends Action {
 	 * @param string[] $groups
 	 */
 	public function enableAppForGroups(string $appName, array $groups) {
-		$this->log('App "%s" enabled for groups: %s',
+		$this->log('App "%1$s" enabled for groups: %2$s',
 			['app' => $appName, 'groups' => implode(', ', $groups)],
 			['app', 'groups']
 		);

--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -225,7 +225,7 @@ class IMipPlugin extends SabreIMipPlugin {
 		);
 
 		$fromEMail = \OCP\Util::getDefaultEmailAddress('invitations-noreply');
-		$fromName = $l10n->t('%s via %s', [$senderName, $this->defaults->getName()]);
+		$fromName = $l10n->t('%1$s via %2$s', [$senderName, $this->defaults->getName()]);
 
 		$message = $this->mailer->createMessage()
 			->setFrom([$fromEMail => $fromName])
@@ -438,14 +438,14 @@ class IMipPlugin extends SabreIMipPlugin {
 		if ($method === self::METHOD_CANCEL) {
 			$template->setSubject('Cancelled: ' . $summary);
 			$template->addHeading($l10n->t('Invitation canceled'), $l10n->t('Hello %s,', [$attendeeName]));
-			$template->addBodyText($l10n->t('The meeting »%s« with %s was canceled.', [$summary, $inviteeName]));
+			$template->addBodyText($l10n->t('The meeting »%1$s« with %2$s was canceled.', [$summary, $inviteeName]));
 		} else if ($method === self::METHOD_REPLY) {
 			$template->setSubject('Re: ' . $summary);
 			$template->addHeading($l10n->t('Invitation updated'), $l10n->t('Hello %s,', [$attendeeName]));
-			$template->addBodyText($l10n->t('The meeting »%s« with %s was updated.', [$summary, $inviteeName]));
+			$template->addBodyText($l10n->t('The meeting »%1$s« with %2$s was updated.', [$summary, $inviteeName]));
 		} else {
 			$template->setSubject('Invitation: ' . $summary);
-			$template->addHeading($l10n->t('%s invited you to »%s«', [$inviteeName, $summary]), $l10n->t('Hello %s,', [$attendeeName]));
+			$template->addHeading($l10n->t('%1$s invited you to »%2$s«', [$inviteeName, $summary]), $l10n->t('Hello %s,', [$attendeeName]));
 		}
 
 	}

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -184,8 +184,8 @@ class FederatedShareProvider implements IShareProvider {
 		$alreadyShared = $this->getSharedWith($shareWith, \OCP\Share::SHARE_TYPE_REMOTE, $share->getNode(), 1, 0);
 		$alreadySharedGroup = $this->getSharedWith($shareWith, \OCP\Share::SHARE_TYPE_REMOTE_GROUP, $share->getNode(), 1, 0);
 		if (!empty($alreadyShared) || !empty($alreadySharedGroup)) {
-			$message = 'Sharing %s failed, because this item is already shared with %s';
-			$message_t = $this->l->t('Sharing %s failed, because this item is already shared with %s', array($share->getNode()->getName(), $shareWith));
+			$message = 'Sharing %1$s failed, because this item is already shared with %2$s';
+			$message_t = $this->l->t('Sharing %1$s failed, because this item is already shared with %2$s', array($share->getNode()->getName(), $shareWith));
 			$this->logger->debug(sprintf($message, $share->getNode()->getName(), $shareWith), ['app' => 'Federated File Sharing']);
 			throw new \Exception($message_t);
 		}
@@ -298,7 +298,7 @@ class FederatedShareProvider implements IShareProvider {
 
 		if($failure) {
 			$this->removeShareFromTableById($shareId);
-			$message_t = $this->l->t('Sharing %s failed, could not find %s, maybe the server is currently unreachable or uses a self-signed certificate.',
+			$message_t = $this->l->t('Sharing %1$s failed, could not find %2$s, maybe the server is currently unreachable or uses a self-signed certificate.',
 				[$share->getNode()->getName(), $share->getSharedWith()]);
 			throw new \Exception($message_t);
 		}

--- a/apps/files/templates/appnavigation.php
+++ b/apps/files/templates/appnavigation.php
@@ -17,7 +17,7 @@
 			<a href="#" class="icon-quota svg">
 				<p id="quotatext"><?php
 					if ($_['quota'] !== \OCP\Files\FileInfo::SPACE_UNLIMITED) {
-						p($l->t('%s of %s used', [$_['usage'], $_['total_space']]));
+						p($l->t('%1$s of %2$s used', [$_['usage'], $_['total_space']]));
 					} else {
 						p($l->t('%s used', [$_['usage']]));
 					} ?></p>

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -324,7 +324,7 @@ class OC_Mount_Config {
 			case 'ftp':
 				return (string)$l->t('The FTP support in PHP is not enabled or installed. Mounting of %s is not possible. Please ask your system administrator to install it.', [$backend]);
 			default:
-				return (string)$l->t('"%s" is not installed. Mounting of %s is not possible. Please ask your system administrator to install it.', [$module, $backend]);
+				return (string)$l->t('"%1$s" is not installed. Mounting of %2$s is not possible. Please ask your system administrator to install it.', [$module, $backend]);
 		}
 	}
 

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -493,14 +493,14 @@ class ShareAPIController extends OCSController {
 
 		} else if ($shareType === Share::SHARE_TYPE_REMOTE) {
 			if (!$this->shareManager->outgoingServer2ServerSharesAllowed()) {
-				throw new OCSForbiddenException($this->l->t('Sharing %s failed because the back end does not allow shares from type %s', [$path->getPath(), $shareType]));
+				throw new OCSForbiddenException($this->l->t('Sharing %1$s failed because the back end does not allow shares from type %2$s', [$path->getPath(), $shareType]));
 			}
 
 			$share->setSharedWith($shareWith);
 			$share->setPermissions($permissions);
 		}  else if ($shareType === Share::SHARE_TYPE_REMOTE_GROUP) {
 			if (!$this->shareManager->outgoingServer2ServerGroupSharesAllowed()) {
-				throw new OCSForbiddenException($this->l->t('Sharing %s failed because the back end does not allow shares from type %s', [$path->getPath(), $shareType]));
+				throw new OCSForbiddenException($this->l->t('Sharing %1$s failed because the back end does not allow shares from type %2$s', [$path->getPath(), $shareType]));
 			}
 
 			$share->setSharedWith($shareWith);

--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -165,8 +165,8 @@ class ShareByMailProvider implements IShareProvider {
 		 */
 		$alreadyShared = $this->getSharedWith($shareWith, \OCP\Share::SHARE_TYPE_EMAIL, $share->getNode(), 1, 0);
 		if (!empty($alreadyShared)) {
-			$message = 'Sharing %s failed, this item is already shared with %s';
-			$message_t = $this->l->t('Sharing %s failed, this item is already shared with %s', array($share->getNode()->getName(), $shareWith));
+			$message = 'Sharing %1$s failed, this item is already shared with %2$s';
+			$message_t = $this->l->t('Sharing %1$s failed, this item is already shared with %2$s', array($share->getNode()->getName(), $shareWith));
 			$this->logger->debug(sprintf($message, $share->getNode()->getName(), $shareWith), ['app' => 'Federated File Sharing']);
 			throw new \Exception($message_t);
 		}
@@ -400,10 +400,10 @@ class ShareByMailProvider implements IShareProvider {
 			'shareWith' => $shareWith,
 		]);
 
-		$emailTemplate->setSubject($this->l->t('%s shared »%s« with you', array($initiatorDisplayName, $filename)));
+		$emailTemplate->setSubject($this->l->t('%1$s shared »%2$s« with you', array($initiatorDisplayName, $filename)));
 		$emailTemplate->addHeader();
-		$emailTemplate->addHeading($this->l->t('%s shared »%s« with you', [$initiatorDisplayName, $filename]), false);
-		$text = $this->l->t('%s shared »%s« with you.', [$initiatorDisplayName, $filename]);
+		$emailTemplate->addHeading($this->l->t('%1$s shared »%2$s« with you', [$initiatorDisplayName, $filename]), false);
+		$text = $this->l->t('%1$s shared »%2$s« with you.', [$initiatorDisplayName, $filename]);
 
 		$emailTemplate->addBodyText(
 			htmlspecialchars($text . ' ' . $this->l->t('Click the button below to open it.')),
@@ -419,7 +419,7 @@ class ShareByMailProvider implements IShareProvider {
 		// The "From" contains the sharers name
 		$instanceName = $this->defaults->getName();
 		$senderName = $this->l->t(
-			'%s via %s',
+			'%1$s via %2$s',
 			[
 				$initiatorDisplayName,
 				$instanceName
@@ -462,8 +462,8 @@ class ShareByMailProvider implements IShareProvider {
 		$initiatorDisplayName = ($initiatorUser instanceof IUser) ? $initiatorUser->getDisplayName() : $initiator;
 		$initiatorEmailAddress = ($initiatorUser instanceof IUser) ? $initiatorUser->getEMailAddress() : null;
 
-		$plainBodyPart = $this->l->t("%s shared »%s« with you.\nYou should have already received a separate mail with a link to access it.\n", [$initiatorDisplayName, $filename]);
-		$htmlBodyPart = $this->l->t('%s shared »%s« with you. You should have already received a separate mail with a link to access it.', [$initiatorDisplayName, $filename]);
+		$plainBodyPart = $this->l->t("%1\$s shared »%2\$s« with you.\nYou should have already received a separate mail with a link to access it.\n", [$initiatorDisplayName, $filename]);
+		$htmlBodyPart = $this->l->t('%1$s shared »%2$s« with you. You should have already received a separate mail with a link to access it.', [$initiatorDisplayName, $filename]);
 
 		$message = $this->mailer->createMessage();
 
@@ -475,7 +475,7 @@ class ShareByMailProvider implements IShareProvider {
 			'shareWith' => $shareWith,
 		]);
 
-		$emailTemplate->setSubject($this->l->t('Password to access »%s« shared to you by %s', [$filename, $initiatorDisplayName]));
+		$emailTemplate->setSubject($this->l->t('Password to access »%1$s« shared to you by %2$s', [$filename, $initiatorDisplayName]));
 		$emailTemplate->addHeader();
 		$emailTemplate->addHeading($this->l->t('Password to access »%s«', [$filename]), false);
 		$emailTemplate->addBodyText(htmlspecialchars($htmlBodyPart), $plainBodyPart);
@@ -485,7 +485,7 @@ class ShareByMailProvider implements IShareProvider {
 		// The "From" contains the sharers name
 		$instanceName = $this->defaults->getName();
 		$senderName = $this->l->t(
-			'%s via %s',
+			'%1$s via %2$s',
 			[
 				$initiatorDisplayName,
 				$instanceName
@@ -586,7 +586,7 @@ class ShareByMailProvider implements IShareProvider {
 			);
 		}
 
-		$bodyPart = $this->l->t("You just shared »%s« with %s. The share was already send to the recipient. Due to the security policies defined by the administrator of %s each share needs to be protected by password and it is not allowed to send the password directly to the recipient. Therefore you need to forward the password manually to the recipient.", [$filename, $shareWith, $this->defaults->getName()]);
+		$bodyPart = $this->l->t('You just shared »%1$s« with %2$s. The share was already send to the recipient. Due to the security policies defined by the administrator of %3$s each share needs to be protected by password and it is not allowed to send the password directly to the recipient. Therefore you need to forward the password manually to the recipient.', [$filename, $shareWith, $this->defaults->getName()]);
 
 		$message = $this->mailer->createMessage();
 		$emailTemplate = $this->mailer->createEMailTemplate('sharebymail.OwnerPasswordNotification', [
@@ -597,7 +597,7 @@ class ShareByMailProvider implements IShareProvider {
 			'shareWith' => $shareWith,
 		]);
 
-		$emailTemplate->setSubject($this->l->t('Password to access »%s« shared with %s', [$filename, $shareWith]));
+		$emailTemplate->setSubject($this->l->t('Password to access »%1$s« shared with %2$s', [$filename, $shareWith]));
 		$emailTemplate->addHeader();
 		$emailTemplate->addHeading($this->l->t('Password to access »%s«', [$filename]), false);
 		$emailTemplate->addBodyText($bodyPart);

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -187,7 +187,7 @@ if (\OCP\Util::needUpgrade()) {
 		$eventSource->send('success', (string)$l->t('Checked database schema update for apps'));
 	});
 	$updater->listen('\OC\Updater', 'appUpgrade', function ($app, $version) use ($eventSource, $l) {
-		$eventSource->send('success', (string)$l->t('Updated "%s" to %s', array($app, $version)));
+		$eventSource->send('success', (string)$l->t('Updated "%1$s" to %2$s', array($app, $version)));
 	});
 	$updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use (&$incompatibleApps) {
 		$incompatibleApps[]= $app;

--- a/core/templates/loginflow/authpicker.php
+++ b/core/templates/loginflow/authpicker.php
@@ -30,7 +30,7 @@ $urlGenerator = $_['urlGenerator'];
 <div class="picker-window">
 	<h2><?php p($l->t('Connect to your account')) ?></h2>
 	<p class="info">
-		<?php print_unescaped($l->t('Please log in before granting %s access to your %s account.', [
+		<?php print_unescaped($l->t('Please log in before granting %1$s access to your %2$s account.', [
 								'<strong>' . \OCP\Util::sanitizeHTML($_['client']) . '</strong>',
 								\OCP\Util::sanitizeHTML($_['instanceName'])
 							])) ?>

--- a/core/templates/loginflow/grant.php
+++ b/core/templates/loginflow/grant.php
@@ -30,7 +30,7 @@ $urlGenerator = $_['urlGenerator'];
 <div class="picker-window">
 	<h2><?php p($l->t('Account access')) ?></h2>
 	<p class="info">
-		<?php print_unescaped($l->t('You are about to grant %s access to your %s account.', [
+		<?php print_unescaped($l->t('You are about to grant %1$s access to your %2$s account.', [
 								'<strong>' . \OCP\Util::sanitizeHTML($_['client']) . '</strong>',
 								\OCP\Util::sanitizeHTML($_['instanceName'])
 							])) ?>

--- a/core/templates/untrustedDomain.php
+++ b/core/templates/untrustedDomain.php
@@ -8,6 +8,6 @@
 	</p>
 	<br />
 	<p>
-		<?php print_unescaped($l->t('Further information how to configure this can be found in the %sdocumentation%s.', ['<a href="' . $_['docUrl'] . '" target="blank">', '</a>'])); ?>
+		<?php print_unescaped($l->t('Further information how to configure this can be found in the %1$sdocumentation%2$s.', ['<a href="' . $_['docUrl'] . '" target="blank">', '</a>'])); ?>
 	</p>
 </div>

--- a/core/templates/update.admin.php
+++ b/core/templates/update.admin.php
@@ -3,7 +3,7 @@
 		<?php if ($_['isAppsOnlyUpgrade']) { ?>
 		<h2 class="title"><?php p($l->t('App update required')); ?></h2>
 		<?php } else { ?>
-		<h2 class="title"><?php p($l->t('%s will be updated to version %s',
+		<h2 class="title"><?php p($l->t('%1$s will be updated to version %2$s',
 			array($_['productName'], $_['version']))); ?></h2>
 		<?php } ?>
 		<?php if (!empty($_['appsToUpgrade'])) { ?>

--- a/lib/private/App/DependencyAnalyzer.php
+++ b/lib/private/App/DependencyAnalyzer.php
@@ -236,7 +236,7 @@ class DependencyAnalyzer {
 			$libName = $this->getValue($lib);
 			$libVersion = $this->platform->getLibraryVersion($libName);
 			if (is_null($libVersion)) {
-				$missing[] = (string)$this->l->t('The library %s is not available.', [$libName]);
+				$missing[] = $this->l->t('The library %s is not available.', [$libName]);
 				continue;
 			}
 
@@ -244,15 +244,15 @@ class DependencyAnalyzer {
 				if (isset($lib['@attributes']['min-version'])) {
 					$minVersion = $lib['@attributes']['min-version'];
 					if ($this->compareSmaller($libVersion, $minVersion)) {
-						$missing[] = (string)$this->l->t('Library %s with a version higher than %s is required - available version %s.',
-							array($libName, $minVersion, $libVersion));
+						$missing[] = $this->l->t('Library %1$s with a version higher than %2$s is required - available version %3$s.',
+							[$libName, $minVersion, $libVersion]);
 					}
 				}
 				if (isset($lib['@attributes']['max-version'])) {
 					$maxVersion = $lib['@attributes']['max-version'];
 					if ($this->compareBigger($libVersion, $maxVersion)) {
-						$missing[] = (string)$this->l->t('Library %s with a version lower than %s is required - available version %s.',
-							array($libName, $maxVersion, $libVersion));
+						$missing[] = $this->l->t('Library %1$s with a version lower than %2$s is required - available version %3$s.',
+							[$libName, $maxVersion, $libVersion]);
 					}
 				}
 			}

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -413,8 +413,8 @@ class Share extends Constants {
 				throw new \Exception($message_t);
 			}
 			if (!\OC::$server->getUserManager()->userExists($shareWith)) {
-				$message = 'Sharing %s failed, because the user %s does not exist';
-				$message_t = $l->t('Sharing %s failed, because the user %s does not exist', array($itemSourceName, $shareWith));
+				$message = 'Sharing %1$s failed, because the user %2$s does not exist';
+				$message_t = $l->t('Sharing %1$s failed, because the user %2$s does not exist', array($itemSourceName, $shareWith));
 				\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName, $shareWith), ILogger::DEBUG);
 				throw new \Exception($message_t);
 			}
@@ -433,9 +433,9 @@ class Share extends Constants {
 				}
 				$inGroup = array_intersect($groupsOwner, $groupsShareWith);
 				if (empty($inGroup)) {
-					$message = 'Sharing %s failed, because the user '
-						.'%s is not a member of any groups that %s is a member of';
-					$message_t = $l->t('Sharing %s failed, because the user %s is not a member of any groups that %s is a member of', array($itemName, $shareWith, $uidOwner));
+					$message = 'Sharing %1$s failed, because the user '
+						.'%2$s is not a member of any groups that %3$s is a member of';
+					$message_t = $l->t('Sharing %1$s failed, because the user %2$s is not a member of any groups that %3$s is a member of', array($itemName, $shareWith, $uidOwner));
 					\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemName, $shareWith, $uidOwner), ILogger::DEBUG);
 					throw new \Exception($message_t);
 				}
@@ -447,8 +447,8 @@ class Share extends Constants {
 				// owner and is not a user share, this use case is for increasing
 				// permissions for a specific user
 				if ($checkExists['uid_owner'] != $uidOwner || $checkExists['share_type'] == $shareType) {
-					$message = 'Sharing %s failed, because this item is already shared with %s';
-					$message_t = $l->t('Sharing %s failed, because this item is already shared with %s', array($itemSourceName, $shareWith));
+					$message = 'Sharing %1$s failed, because this item is already shared with %2$s';
+					$message_t = $l->t('Sharing %1$s failed, because this item is already shared with %2$s', array($itemSourceName, $shareWith));
 					\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName, $shareWith), ILogger::DEBUG);
 					throw new \Exception($message_t);
 				}
@@ -459,16 +459,16 @@ class Share extends Constants {
 				// owner and is not a user share, this use case is for increasing
 				// permissions for a specific user
 				if ($checkExists['uid_owner'] != $uidOwner || $checkExists['share_type'] == $shareType) {
-					$message = 'Sharing %s failed, because this item is already shared with user %s';
-					$message_t = $l->t('Sharing %s failed, because this item is already shared with user %s', array($itemSourceName, $shareWith));
+					$message = 'Sharing %1$s failed, because this item is already shared with user %2$s';
+					$message_t = $l->t('Sharing %1$s failed, because this item is already shared with user %2$s', array($itemSourceName, $shareWith));
 					\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName, $shareWith), ILogger::ERROR);
 					throw new \Exception($message_t);
 				}
 			}
 		} else if ($shareType === self::SHARE_TYPE_GROUP) {
 			if (!\OC::$server->getGroupManager()->groupExists($shareWith)) {
-				$message = 'Sharing %s failed, because the group %s does not exist';
-				$message_t = $l->t('Sharing %s failed, because the group %s does not exist', array($itemSourceName, $shareWith));
+				$message = 'Sharing %1$s failed, because the group %2$s does not exist';
+				$message_t = $l->t('Sharing %1$s failed, because the group %2$s does not exist', array($itemSourceName, $shareWith));
 				\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName, $shareWith), ILogger::DEBUG);
 				throw new \Exception($message_t);
 			}
@@ -476,9 +476,9 @@ class Share extends Constants {
 				$group = \OC::$server->getGroupManager()->get($shareWith);
 				$user = \OC::$server->getUserManager()->get($uidOwner);
 				if (!$group || !$user || !$group->inGroup($user)) {
-					$message = 'Sharing %s failed, because '
-						. '%s is not a member of the group %s';
-					$message_t = $l->t('Sharing %s failed, because %s is not a member of the group %s', array($itemSourceName, $uidOwner, $shareWith));
+					$message = 'Sharing %1$s failed, because '
+						. '%2$s is not a member of the group %3$s';
+					$message_t = $l->t('Sharing %1$s failed, because %2$s is not a member of the group %3$s', array($itemSourceName, $uidOwner, $shareWith));
 					\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName, $uidOwner, $shareWith), ILogger::DEBUG);
 					throw new \Exception($message_t);
 				}
@@ -489,8 +489,8 @@ class Share extends Constants {
 				null, self::FORMAT_NONE, null, 1, true, true)) {
 
 				if ($checkExists['share_with'] === $shareWith && $checkExists['share_type'] === \OCP\Share::SHARE_TYPE_GROUP) {
-					$message = 'Sharing %s failed, because this item is already shared with %s';
-					$message_t = $l->t('Sharing %s failed, because this item is already shared with %s', array($itemSourceName, $shareWith));
+					$message = 'Sharing %1$s failed, because this item is already shared with %2$s';
+					$message_t = $l->t('Sharing %1$s failed, because this item is already shared with %2$s', array($itemSourceName, $shareWith));
 					\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName, $shareWith), ILogger::DEBUG);
 					throw new \Exception($message_t);
 				}
@@ -595,8 +595,8 @@ class Share extends Constants {
 			 */
 			if ($checkExists = self::getItems($itemType, $itemSource, self::SHARE_TYPE_REMOTE,
 				$shareWith, $uidOwner, self::FORMAT_NONE, null, 1, true, true)) {
-					$message = 'Sharing %s failed, because this item is already shared with %s';
-					$message_t = $l->t('Sharing %s failed, because this item is already shared with %s', array($itemSourceName, $shareWith));
+					$message = 'Sharing %1$s failed, because this item is already shared with %2$s';
+					$message_t = $l->t('Sharing %1$s failed, because this item is already shared with %2$s', array($itemSourceName, $shareWith));
 					\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName, $shareWith), ILogger::DEBUG);
 					throw new \Exception($message_t);
 			}
@@ -626,15 +626,15 @@ class Share extends Constants {
 			if ($send === false) {
 				$currentUser = \OC::$server->getUserSession()->getUser()->getUID();
 				self::unshare($itemType, $itemSource, $shareType, $shareWith, $currentUser);
-				$message_t = $l->t('Sharing %s failed, could not find %s, maybe the server is currently unreachable.', array($itemSourceName, $shareWith));
+				$message_t = $l->t('Sharing %1$s failed, could not find %2$s, maybe the server is currently unreachable.', array($itemSourceName, $shareWith));
 				throw new \Exception($message_t);
 			}
 
 			return $send;
 		} else {
 			// Future share types need to include their own conditions
-			$message = 'Share type %s is not valid for %s';
-			$message_t = $l->t('Share type %s is not valid for %s', array($shareType, $itemSource));
+			$message = 'Share type %1$s is not valid for %2$s';
+			$message_t = $l->t('Share type %1$s is not valid for %2$s', array($shareType, $itemSource));
 			\OCP\Util::writeLog('OCP\Share', sprintf($message, $shareType, $itemSource), ILogger::DEBUG);
 			throw new \Exception($message_t);
 		}
@@ -1666,7 +1666,7 @@ class Share extends Constants {
 		if ($checkReshare) {
 			// Check if attempting to share back to owner
 			if ($checkReshare['uid_owner'] == $shareWith && $shareType == self::SHARE_TYPE_USER) {
-				$message = 'Sharing %s failed, because the user %s is the original sharer';
+				$message = 'Sharing %1$s failed, because the user %2$s is the original sharer';
 				$message_t = $l->t('Sharing failed, because the user %s is the original sharer', [$shareWith]);
 
 				\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName, $shareWith), ILogger::DEBUG);
@@ -1678,8 +1678,8 @@ class Share extends Constants {
 			// Check if share permissions is granted
 			if (self::isResharingAllowed() && (int)$checkReshare['permissions'] & \OCP\Constants::PERMISSION_SHARE) {
 				if (~(int)$checkReshare['permissions'] & $permissions) {
-					$message = 'Sharing %s failed, because the permissions exceed permissions granted to %s';
-					$message_t = $l->t('Sharing %s failed, because the permissions exceed permissions granted to %s', array($itemSourceName, $uidOwner));
+					$message = 'Sharing %1$s failed, because the permissions exceed permissions granted to %2$s';
+					$message_t = $l->t('Sharing %1$s failed, because the permissions exceed permissions granted to %2$s', array($itemSourceName, $uidOwner));
 
 					\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName, $uidOwner), ILogger::DEBUG);
 					throw new \Exception($message_t);
@@ -1723,9 +1723,9 @@ class Share extends Constants {
 			$result['itemSource'] = $itemSource;
 			$result['expirationDate'] = $expirationDate;
 			if (!$backend->isValidSource($itemSource, $uidOwner)) {
-				$message = 'Sharing %s failed, because the sharing backend for '
-					.'%s could not find its source';
-				$message_t = $l->t('Sharing %s failed, because the sharing backend for %s could not find its source', array($itemSource, $itemType));
+				$message = 'Sharing %1$s failed, because the sharing backend for '
+					.'%2$s could not find its source';
+				$message_t = $l->t('Sharing %1$s failed, because the sharing backend for %2$s could not find its source', array($itemSource, $itemType));
 				\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSource, $itemType), ILogger::DEBUG);
 				throw new \Exception($message_t);
 			}

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -735,10 +735,10 @@ class Manager implements IManager {
 			'shareWith' => $shareWith,
 		]);
 
-		$emailTemplate->setSubject($l->t('%s shared »%s« with you', array($initiatorDisplayName, $filename)));
+		$emailTemplate->setSubject($l->t('%1$s shared »%2$s« with you', array($initiatorDisplayName, $filename)));
 		$emailTemplate->addHeader();
-		$emailTemplate->addHeading($l->t('%s shared »%s« with you', [$initiatorDisplayName, $filename]), false);
-		$text = $l->t('%s shared »%s« with you.', [$initiatorDisplayName, $filename]);
+		$emailTemplate->addHeading($l->t('%1$s shared »%2$s« with you', [$initiatorDisplayName, $filename]), false);
+		$text = $l->t('%1$s shared »%2$s« with you.', [$initiatorDisplayName, $filename]);
 
 		$emailTemplate->addBodyText(
 			htmlspecialchars($text . ' ' . $l->t('Click the button below to open it.')),
@@ -754,7 +754,7 @@ class Manager implements IManager {
 		// The "From" contains the sharers name
 		$instanceName = $this->defaults->getName();
 		$senderName = $l->t(
-			'%s via %s',
+			'%1$s via %2$s',
 			[
 				$initiatorDisplayName,
 				$instanceName

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -1096,7 +1096,7 @@ class OC_App {
 		if (!empty($missing)) {
 			$missingMsg = implode(PHP_EOL, $missing);
 			throw new \Exception(
-				$l->t('App "%s" cannot be installed because the following dependencies are not fulfilled: %s',
+				$l->t('App "%1$s" cannot be installed because the following dependencies are not fulfilled: %2$s',
 					[$info['name'], $missingMsg]
 				)
 			);

--- a/lib/public/Federation/Exceptions/ProviderAlreadyExistsException.php
+++ b/lib/public/Federation/Exceptions/ProviderAlreadyExistsException.php
@@ -43,7 +43,7 @@ class ProviderAlreadyExistsException extends HintException {
 	public function __construct($newProviderId, $existingProviderName) {
 		$l = \OC::$server->getL10N('federation');
 		$message = 'ID "' . $newProviderId . '" already used by cloud federation provider "' . $existingProviderName . '"';
-		$hint = $l->t('ID "%s" already used by cloud federation provider "%s"', [$newProviderId, $existingProviderName]);
+		$hint = $l->t('ID "%1$s" already used by cloud federation provider "%2$s"', [$newProviderId, $existingProviderName]);
 		parent::__construct($message, $hint);
 	}
 

--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -235,7 +235,7 @@ class CheckSetupController extends Controller {
 
 			if(($majorVersion === '1.0.1' && ord($patchRelease) < ord('d')) ||
 				($majorVersion === '1.0.2' && ord($patchRelease) < ord('b'))) {
-				return (string) $this->l10n->t('cURL is using an outdated %s version (%s). Please update your operating system or features such as %s will not work reliably.', ['OpenSSL', $versionString, $features]);
+				return $this->l10n->t('cURL is using an outdated %1$s version (%2$s). Please update your operating system or features such as %3$s will not work reliably.', ['OpenSSL', $versionString, $features]);
 			}
 		}
 
@@ -249,7 +249,7 @@ class CheckSetupController extends Controller {
 				$secondClient->get('https://nextcloud.com/');
 			} catch (ClientException $e) {
 				if($e->getResponse()->getStatusCode() === 400) {
-					return (string) $this->l10n->t('cURL is using an outdated %s version (%s). Please update your operating system or features such as %s will not work reliably.', ['NSS', $versionString, $features]);
+					return $this->l10n->t('cURL is using an outdated %1$s version (%2$s). Please update your operating system or features such as %3$s will not work reliably.', ['NSS', $versionString, $features]);
 				}
 			}
 		}

--- a/settings/templates/settings/admin/overview.php
+++ b/settings/templates/settings/admin/overview.php
@@ -50,7 +50,7 @@
 		<ul class="info hidden"></ul>
 	</div>
 	<p id="postsetupchecks-hint" class="hidden">
-		<?php print_unescaped($l->t('Please double check the <a target="_blank" rel="noreferrer noopener" href="%s">installation guides ↗</a>, and check for any errors or warnings in the <a href="%s">log</a>.', [link_to_docs('admin-install'), \OC::$server->getURLGenerator()->linkToRoute('settings.AdminSettings.index', ['section' => 'logging'])] )); ?>
+		<?php print_unescaped($l->t('Please double check the <a target="_blank" rel="noreferrer noopener" href="%1$s">installation guides ↗</a>, and check for any errors or warnings in the <a href="%2$s">log</a>.', [link_to_docs('admin-install'), \OC::$server->getURLGenerator()->linkToRoute('settings.AdminSettings.index', ['section' => 'logging'])] )); ?>
 	</p>
 
 	<p class="extra-top-margin">

--- a/settings/templates/settings/personal/personal.info.php
+++ b/settings/templates/settings/personal/personal.info.php
@@ -89,7 +89,7 @@ vendor_style('jcrop/css/jquery.Jcrop');
 							<?php print_unescaped($l->t('You are using <strong>%s</strong>',
 								[$_['usage']]));?>
 						<?php else: ?>
-							<?php print_unescaped($l->t('You are using <strong>%s</strong> of <strong>%s</strong> (<strong>%s %%</strong>)',
+							<?php print_unescaped($l->t('You are using <strong>%1$s</strong> of <strong>%2$s</strong> (<strong>%3$s %%</strong>)',
 								[$_['usage'], $_['total_space'],  $_['usage_relative']]));?>
 						<?php endif ?>
 					</p>


### PR DESCRIPTION
… can operate better

For now I decided to just fix the strings manually.
Any further work, like automated checking/breaking can be done later.

Background:
Other languages sometimes need to put the arguments into a different order, especially RTL languages.
The translations could use `%1$s` themselves, but it can not be stored, because transifex complains about `%s` placeholder not being used. (See https://www.transifex.com/nextcloud/nextcloud/translate/#he/lib/116186415 ) So we need to make the English version to also do this.