### PR TITLE
[stable13] Fix a misleading setup check for .well-known/caldav & carddav

### DIFF
--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -62,13 +62,13 @@ describe('OC.SetupChecks tests', function() {
 
 	describe('checkWellKnownUrl', function() {
 		it('should fail with another response status code than 207', function(done) {
-			var async = OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav/', 'http://example.org/PLACEHOLDER', true);
+			var async = OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav', 'http://example.org/PLACEHOLDER', true);
 
 			suite.server.requests[0].respond(200);
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([{
-					msg: 'Your web server is not properly set up to resolve "/.well-known/caldav/". Further information can be found in the <a href="http://example.org/admin-setup-well-known-URL" rel="noreferrer noopener">documentation</a>.',
+					msg: 'Your web server is not properly set up to resolve "/.well-known/caldav". Further information can be found in the <a href="http://example.org/admin-setup-well-known-URL" rel="noreferrer noopener">documentation</a>.',
 					type: OC.SetupChecks.MESSAGE_TYPE_INFO
 				}]);
 				done();
@@ -76,7 +76,7 @@ describe('OC.SetupChecks tests', function() {
 		});
 
 		it('should return no error with a response status code of 207', function(done) {
-			var async = OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav/', 'http://example.org/PLACEHOLDER', true);
+			var async = OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav', 'http://example.org/PLACEHOLDER', true);
 
 			suite.server.requests[0].respond(207);
 
@@ -87,7 +87,7 @@ describe('OC.SetupChecks tests', function() {
 		});
 
 		it('should return no error when no check should be run', function(done) {
-			var async = OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav/', 'http://example.org/PLACEHOLDER', false);
+			var async = OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav', 'http://example.org/PLACEHOLDER', false);
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([]);

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -251,8 +251,8 @@ $(document).ready(function(){
 	// run setup checks then gather error messages
 	$.when(
 		OC.SetupChecks.checkWebDAV(),
-		OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav/', oc_defaults.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === true),
-		OC.SetupChecks.checkWellKnownUrl('/.well-known/carddav/', oc_defaults.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === true),
+		OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav', oc_defaults.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === true),
+		OC.SetupChecks.checkWellKnownUrl('/.well-known/carddav', oc_defaults.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === true),
 		OC.SetupChecks.checkSetup(),
 		OC.SetupChecks.checkGeneric(),
 		OC.SetupChecks.checkDataProtected()


### PR DESCRIPTION
The problem is that the version without the slash is the correct one.

Backport of #11733