### PR TITLE
Public API to get user acocunt data

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -7,6 +7,10 @@ $baseDir = dirname(dirname($vendorDir));
 
 return array(
     'OCP\\API' => $baseDir . '/lib/public/API.php',
+    'OCP\\Accounts\\IAccount' => $baseDir . '/lib/public/Accounts/IAccount.php',
+    'OCP\\Accounts\\IAccountManager' => $baseDir . '/lib/public/Accounts/IAccountManager.php',
+    'OCP\\Accounts\\IAccountProperty' => $baseDir . '/lib/public/Accounts/IAccountProperty.php',
+    'OCP\\Accounts\\PropertyDoesNotExistException' => $baseDir . '/lib/public/Accounts/PropertyDoesNotExistException.php',
     'OCP\\Activity\\IConsumer' => $baseDir . '/lib/public/Activity/IConsumer.php',
     'OCP\\Activity\\IEvent' => $baseDir . '/lib/public/Activity/IEvent.php',
     'OCP\\Activity\\IEventMerger' => $baseDir . '/lib/public/Activity/IEventMerger.php',
@@ -363,7 +367,9 @@ return array(
     'OCP\\WorkflowEngine\\ICheck' => $baseDir . '/lib/public/WorkflowEngine/ICheck.php',
     'OCP\\WorkflowEngine\\IManager' => $baseDir . '/lib/public/WorkflowEngine/IManager.php',
     'OCP\\WorkflowEngine\\IOperation' => $baseDir . '/lib/public/WorkflowEngine/IOperation.php',
+    'OC\\Accounts\\Account' => $baseDir . '/lib/private/Accounts/Account.php',
     'OC\\Accounts\\AccountManager' => $baseDir . '/lib/private/Accounts/AccountManager.php',
+    'OC\\Accounts\\AccountProperty' => $baseDir . '/lib/private/Accounts/AccountProperty.php',
     'OC\\Accounts\\Hooks' => $baseDir . '/lib/private/Accounts/Hooks.php',
     'OC\\Activity\\Event' => $baseDir . '/lib/private/Activity/Event.php',
     'OC\\Activity\\EventMerger' => $baseDir . '/lib/private/Activity/EventMerger.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -37,6 +37,10 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
 
     public static $classMap = array (
         'OCP\\API' => __DIR__ . '/../../..' . '/lib/public/API.php',
+        'OCP\\Accounts\\IAccount' => __DIR__ . '/../../..' . '/lib/public/Accounts/IAccount.php',
+        'OCP\\Accounts\\IAccountManager' => __DIR__ . '/../../..' . '/lib/public/Accounts/IAccountManager.php',
+        'OCP\\Accounts\\IAccountProperty' => __DIR__ . '/../../..' . '/lib/public/Accounts/IAccountProperty.php',
+        'OCP\\Accounts\\PropertyDoesNotExistException' => __DIR__ . '/../../..' . '/lib/public/Accounts/PropertyDoesNotExistException.php',
         'OCP\\Activity\\IConsumer' => __DIR__ . '/../../..' . '/lib/public/Activity/IConsumer.php',
         'OCP\\Activity\\IEvent' => __DIR__ . '/../../..' . '/lib/public/Activity/IEvent.php',
         'OCP\\Activity\\IEventMerger' => __DIR__ . '/../../..' . '/lib/public/Activity/IEventMerger.php',
@@ -393,7 +397,9 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\WorkflowEngine\\ICheck' => __DIR__ . '/../../..' . '/lib/public/WorkflowEngine/ICheck.php',
         'OCP\\WorkflowEngine\\IManager' => __DIR__ . '/../../..' . '/lib/public/WorkflowEngine/IManager.php',
         'OCP\\WorkflowEngine\\IOperation' => __DIR__ . '/../../..' . '/lib/public/WorkflowEngine/IOperation.php',
+        'OC\\Accounts\\Account' => __DIR__ . '/../../..' . '/lib/private/Accounts/Account.php',
         'OC\\Accounts\\AccountManager' => __DIR__ . '/../../..' . '/lib/private/Accounts/AccountManager.php',
+        'OC\\Accounts\\AccountProperty' => __DIR__ . '/../../..' . '/lib/private/Accounts/AccountProperty.php',
         'OC\\Accounts\\Hooks' => __DIR__ . '/../../..' . '/lib/private/Accounts/Hooks.php',
         'OC\\Activity\\Event' => __DIR__ . '/../../..' . '/lib/private/Activity/Event.php',
         'OC\\Activity\\EventMerger' => __DIR__ . '/../../..' . '/lib/private/Activity/EventMerger.php',

--- a/lib/private/Accounts/Account.php
+++ b/lib/private/Accounts/Account.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Accounts;
+
+use OCP\Accounts\IAccount;
+use OCP\Accounts\IAccountProperty;
+use OCP\Accounts\PropertyDoesNotExistException;
+use OCP\IUser;
+
+class Account implements IAccount {
+
+	/** @var IAccountProperty[] */
+	private $properties = [];
+
+	/** @var IUser */
+	private $user;
+
+	public function __construct(IUser $user) {
+		$this->user = $user;
+	}
+
+	public function setProperty(string $property, string $value, string $scope, string $verified): IAccount {
+		$this->properties[$property] = new AccountProperty($property, $value, $scope, $verified);
+		return $this;
+	}
+
+	public function getProperty(string $property): IAccountProperty {
+		if (!array_key_exists($property, $this->properties)) {
+			throw new PropertyDoesNotExistException($property);
+		}
+		return $this->properties[$property];
+	}
+
+	public function getProperties(): array {
+		return $this->properties;
+	}
+
+	public function getFilteredProperties(string $scope = null, string $verified = null): array {
+		return \array_filter($this->properties, function(IAccountProperty $obj) use ($scope, $verified){
+			if ($scope !== null && $scope !== $obj->getScope()) {
+				return false;
+			}
+			if ($verified !== null && $verified !== $obj->getVerified()) {
+				return false;
+			}
+			return true;
+		});
+	}
+
+	public function jsonSerialize() {
+		return $this->properties;
+	}
+
+	public function getUser(): IUser {
+		return $this->user;
+	}
+}

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -26,6 +26,8 @@
 
 namespace OC\Accounts;
 
+use OCP\Accounts\IAccount;
+use OCP\Accounts\IAccountManager;
 use OCP\BackgroundJob\IJobList;
 use OCP\IDBConnection;
 use OCP\IUser;
@@ -41,26 +43,7 @@ use OC\Settings\BackgroundJobs\VerifyUserData;
  * @group DB
  * @package OC\Accounts
  */
-class AccountManager {
-
-	/** nobody can see my account details */
-	const VISIBILITY_PRIVATE = 'private';
-	/** only contacts, especially trusted servers can see my contact details */
-	const VISIBILITY_CONTACTS_ONLY = 'contacts';
-	/** every body ca see my contact detail, will be published to the lookup server */
-	const VISIBILITY_PUBLIC = 'public';
-
-	const PROPERTY_AVATAR = 'avatar';
-	const PROPERTY_DISPLAYNAME = 'displayname';
-	const PROPERTY_PHONE = 'phone';
-	const PROPERTY_EMAIL = 'email';
-	const PROPERTY_WEBSITE = 'website';
-	const PROPERTY_ADDRESS = 'address';
-	const PROPERTY_TWITTER = 'twitter';
-
-	const NOT_VERIFIED = '0';
-	const VERIFICATION_IN_PROGRESS = '1';
-	const VERIFIED = '2';
+class AccountManager implements IAccountManager {
 
 	/** @var  IDBConnection database connection */
 	private $connection;
@@ -342,6 +325,18 @@ class AccountManager {
 					'verified' => self::NOT_VERIFIED,
 				],
 		];
+	}
+
+	private function parseAccountData(IUser $user, $data): Account {
+		$account = new Account($user);
+		foreach($data as $property => $accountData) {
+			$account->setProperty($property, $accountData['value'], $accountData['scope'], $accountData['verified']);
+		}
+		return $account;
+	}
+
+	public function getAccount(IUser $user): IAccount {
+		return $this->parseAccountData($user, $this->getUser($user));
 	}
 
 }

--- a/lib/private/Accounts/AccountProperty.php
+++ b/lib/private/Accounts/AccountProperty.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Accounts;
+
+use OCP\Accounts\IAccountProperty;
+
+class AccountProperty implements IAccountProperty {
+
+	/** @var string */
+	private $name;
+	/** @var string */
+	private $value;
+	/** @var string */
+	private $scope;
+	/** @var string */
+	private $verified;
+
+	public function __construct(string $name, string $value, string $scope, string $verified) {
+		$this->name = $name;
+		$this->value = $value;
+		$this->scope = $scope;
+		$this->verified = $verified;
+	}
+
+	public function jsonSerialize() {
+		return [
+			'name' => $this->getName(),
+			'value' => $this->getValue(),
+			'scope' => $this->getScope(),
+			'verified' => $this->getVerified()
+		];
+	}
+
+	/**
+	 * Set the value of a property
+	 *
+	 * @since 15.0.0
+	 *
+	 * @param string $value
+	 * @return IAccountProperty
+	 */
+	public function setValue(string $value): IAccountProperty {
+		$this->value = $value;
+		return $this;
+	}
+
+	/**
+	 * Set the scope of a property
+	 *
+	 * @since 15.0.0
+	 *
+	 * @param string $scope
+	 * @return IAccountProperty
+	 */
+	public function setScope(string $scope): IAccountProperty {
+		$this->scope = $scope;
+		return $this;
+	}
+
+	/**
+	 * Set the verification status of a property
+	 *
+	 * @since 15.0.0
+	 *
+	 * @param string $verified
+	 * @return IAccountProperty
+	 */
+	public function setVerified(string $verified): IAccountProperty {
+		$this->verified = $verified;
+		return $this;
+	}
+
+	/**
+	 * Get the name of a property
+	 *
+	 * @since 15.0.0
+	 *
+	 * @return string
+	 */
+	public function getName(): string {
+		return $this->name;
+	}
+
+	/**
+	 * Get the value of a property
+	 *
+	 * @since 15.0.0
+	 *
+	 * @return string
+	 */
+	public function getValue(): string {
+		return $this->value;
+	}
+
+	/**
+	 * Get the scope of a property
+	 *
+	 * @since 15.0.0
+	 *
+	 * @return string
+	 */
+	public function getScope(): string {
+		return $this->scope;
+	}
+
+	/**
+	 * Get the verification status of a property
+	 *
+	 * @since 15.0.0
+	 *
+	 * @return string
+	 */
+	public function getVerified(): string {
+		return $this->verified;
+	}
+}

--- a/lib/public/Accounts/IAccount.php
+++ b/lib/public/Accounts/IAccount.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Accounts;
+
+use OCP\IUser;
+
+/**
+ * Interface IAccount
+ *
+ * @since 15.0.0
+ * @package OCP\Accounts
+ */
+interface IAccount extends \JsonSerializable {
+
+	/**
+	 * Set a property with data
+	 *
+	 * @since 15.0.0
+	 *
+	 * @param string $property  Must be one of the PROPERTY_ prefixed constants of \OCP\Accounts\IAccountManager
+	 * @param string $value
+	 * @param string $scope Must be one of the VISIBILITY_ prefixed constants of \OCP\Accounts\IAccountManager
+	 * @param string $verified \OCP\Accounts\IAccountManager::NOT_VERIFIED | \OCP\Accounts\IAccountManager::VERIFICATION_IN_PROGRESS | \OCP\Accounts\IAccountManager::VERIFIED
+	 * @return IAccount
+	 */
+	public function setProperty(string $property, string $value, string $scope, string $verified): IAccount;
+
+	/**
+	 * Get a property by its key
+	 *
+	 * @since 15.0.0
+	 *
+	 * @param string $property Must be one of the PROPERTY_ prefixed constants of \OCP\Accounts\IAccountManager
+	 * @return IAccountProperty
+	 * @throws PropertyDoesNotExistException
+	 */
+	public function getProperty(string $property): IAccountProperty;
+
+	/**
+	 * Get all properties of an account
+	 *
+	 * @since 15.0.0
+	 *
+	 * @return IAccountProperty[]
+	 */
+	public function getProperties(): array;
+
+	/**
+	 * Get all properties that match the provided filters for scope and verification status
+	 *
+	 * @since 15.0.0
+	 *
+	 * @param string $scope Must be one of the VISIBILITY_ prefixed constants of \OCP\Accounts\IAccountManager
+	 * @param string $verified \OCP\Accounts\IAccountManager::NOT_VERIFIED | \OCP\Accounts\IAccountManager::VERIFICATION_IN_PROGRESS | \OCP\Accounts\IAccountManager::VERIFIED
+	 * @return IAccountProperty[]
+	 */
+	public function getFilteredProperties(string $scope, string $verified): array;
+
+	/**
+	 * Get the related user for the account data
+	 *
+	 * @since 15.0.0
+	 *
+	 * @return IUser
+	 */
+	public function getUser(): IUser;
+
+}

--- a/lib/public/Accounts/IAccountManager.php
+++ b/lib/public/Accounts/IAccountManager.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Accounts;
+
+use OCP\IUser;
+
+/**
+ * Access user profile information
+ *
+ * @since 15.0.0
+ *
+ * @package OCP\Accounts
+ */
+interface IAccountManager {
+
+	/** nobody can see my account details */
+	const VISIBILITY_PRIVATE = 'private';
+	/** only contacts, especially trusted servers can see my contact details */
+	const VISIBILITY_CONTACTS_ONLY = 'contacts';
+	/** every body ca see my contact detail, will be published to the lookup server */
+	const VISIBILITY_PUBLIC = 'public';
+
+	const PROPERTY_AVATAR = 'avatar';
+	const PROPERTY_DISPLAYNAME = 'displayname';
+	const PROPERTY_PHONE = 'phone';
+	const PROPERTY_EMAIL = 'email';
+	const PROPERTY_WEBSITE = 'website';
+	const PROPERTY_ADDRESS = 'address';
+	const PROPERTY_TWITTER = 'twitter';
+
+	const NOT_VERIFIED = '0';
+	const VERIFICATION_IN_PROGRESS = '1';
+	const VERIFIED = '2';
+
+	/**
+	 * Get the account data for a given user
+	 *
+	 * @since 15.0.0
+	 *
+	 * @param IUser $user
+	 * @return IAccount
+	 */
+	public function getAccount(IUser $user): IAccount;
+
+}

--- a/lib/public/Accounts/IAccountProperty.php
+++ b/lib/public/Accounts/IAccountProperty.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Accounts;
+
+/**
+ * Interface IAccountProperty
+ *
+ * @package OCP\Account
+ * @since 15.0.0
+ */
+interface IAccountProperty extends \JsonSerializable {
+
+	/**
+	 * Set the value of a property
+	 *
+	 * @since 15.0.0
+	 *
+	 * @param string $value
+	 * @return IAccountProperty
+	 */
+	public function setValue(string $value): IAccountProperty;
+
+	/**
+	 * Set the scope of a property
+	 *
+	 * @since 15.0.0
+	 *
+	 * @param string $scope
+	 * @return IAccountProperty
+	 */
+	public function setScope(string $scope): IAccountProperty;
+
+	/**
+	 * Set the verification status of a property
+	 *
+	 * @since 15.0.0
+	 *
+	 * @param string $verified
+	 * @return IAccountProperty
+	 */
+	public function setVerified(string $verified): IAccountProperty;
+
+	/**
+	 * Get the name of a property
+	 *
+	 * @since 15.0.0
+	 *
+	 * @return string
+	 */
+	public function getName(): string;
+
+	/**
+	 * Get the value of a property
+	 *
+	 * @since 15.0.0
+	 *
+	 * @return string
+	 */
+	public function getValue(): string;
+
+	/**
+	 * Get the scope of a property
+	 *
+	 * @since 15.0.0
+	 *
+	 * @return string
+	 */
+	public function getScope(): string;
+
+	/**
+	 * Get the verification status of a property
+	 *
+	 * @since 15.0.0
+	 *
+	 * @return string
+	 */
+	public function getVerified(): string;
+
+}
+
+

--- a/lib/public/Accounts/PropertyDoesNotExistException.php
+++ b/lib/public/Accounts/PropertyDoesNotExistException.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Accounts;
+
+/**
+ * Class PropertyDoesNotExistException
+ *
+ * @since 15.0.0
+ *
+ * @package OCP\Accounts
+ */
+class PropertyDoesNotExistException extends \Exception {
+
+	/**
+	 * Constructor
+	 * @param string $msg the error message
+	 * @since 15.0.0
+	 */
+	public function __construct($property){
+		parent::__construct('Property ' . $property . ' does not exist.');
+	}
+
+}

--- a/tests/lib/Accounts/AccountPropertyTest.php
+++ b/tests/lib/Accounts/AccountPropertyTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Test\Accounts;
+
+use OC\Accounts\Account;
+use OC\Accounts\AccountManager;
+use OC\Accounts\AccountProperty;
+
+use Test\TestCase;
+
+/**
+ * Class AccountPropertyTest
+ *
+ * @package Test\Accounts
+ */
+class AccountPropertyTest extends TestCase {
+
+	public function testConstructor() {
+		$accountProperty = new AccountProperty(
+			AccountManager::PROPERTY_WEBSITE,
+			'https://example.com',
+			AccountManager::VISIBILITY_PUBLIC,
+			AccountManager::VERIFIED
+		);
+		$this->assertEquals(AccountManager::PROPERTY_WEBSITE, $accountProperty->getName());
+		$this->assertEquals('https://example.com', $accountProperty->getValue());
+		$this->assertEquals(AccountManager::VISIBILITY_PUBLIC, $accountProperty->getScope());
+		$this->assertEquals(AccountManager::VERIFIED, $accountProperty->getVerified());
+	}
+
+	public function testSetValue() {
+		$accountProperty = new AccountProperty(
+			AccountManager::PROPERTY_WEBSITE,
+			'https://example.com',
+			AccountManager::VISIBILITY_PUBLIC,
+			AccountManager::VERIFIED
+		);
+		$actualReturn = $accountProperty->setValue('https://example.org');
+		$this->assertEquals('https://example.org', $accountProperty->getValue());
+		$this->assertEquals('https://example.org', $actualReturn->getValue());
+	}
+
+	public function testSetScope() {
+		$accountProperty = new AccountProperty(
+			AccountManager::PROPERTY_WEBSITE,
+			'https://example.com',
+			AccountManager::VISIBILITY_PUBLIC,
+			AccountManager::VERIFIED
+		);
+		$actualReturn = $accountProperty->setScope(AccountManager::VISIBILITY_PRIVATE);
+		$this->assertEquals(AccountManager::VISIBILITY_PRIVATE, $accountProperty->getScope());
+		$this->assertEquals(AccountManager::VISIBILITY_PRIVATE, $actualReturn->getScope());
+	}
+
+	public function testSetVerified() {
+		$accountProperty = new AccountProperty(
+			AccountManager::PROPERTY_WEBSITE,
+			'https://example.com',
+			AccountManager::VISIBILITY_PUBLIC,
+			AccountManager::VERIFIED
+		);
+		$actualReturn = $accountProperty->setVerified(AccountManager::NOT_VERIFIED);
+		$this->assertEquals(AccountManager::NOT_VERIFIED, $accountProperty->getVerified());
+		$this->assertEquals(AccountManager::NOT_VERIFIED, $actualReturn->getVerified());
+	}
+
+	public function testJsonSerialize() {
+		$accountProperty = new AccountProperty(
+			AccountManager::PROPERTY_WEBSITE,
+			'https://example.com',
+			AccountManager::VISIBILITY_PUBLIC,
+			AccountManager::VERIFIED
+		);
+		$this->assertEquals([
+			'name' => AccountManager::PROPERTY_WEBSITE,
+			'value' => 'https://example.com',
+			'scope' => AccountManager::VISIBILITY_PUBLIC,
+			'verified' => AccountManager::VERIFIED
+		], $accountProperty->jsonSerialize());
+	}
+
+
+}

--- a/tests/lib/Accounts/AccountPropertyTest.php
+++ b/tests/lib/Accounts/AccountPropertyTest.php
@@ -23,10 +23,8 @@
 
 namespace Test\Accounts;
 
-use OC\Accounts\Account;
-use OC\Accounts\AccountManager;
 use OC\Accounts\AccountProperty;
-
+use OCP\Accounts\IAccountManager;
 use Test\TestCase;
 
 /**
@@ -38,23 +36,23 @@ class AccountPropertyTest extends TestCase {
 
 	public function testConstructor() {
 		$accountProperty = new AccountProperty(
-			AccountManager::PROPERTY_WEBSITE,
+			IAccountManager::PROPERTY_WEBSITE,
 			'https://example.com',
-			AccountManager::VISIBILITY_PUBLIC,
-			AccountManager::VERIFIED
+			IAccountManager::VISIBILITY_PUBLIC,
+			IAccountManager::VERIFIED
 		);
-		$this->assertEquals(AccountManager::PROPERTY_WEBSITE, $accountProperty->getName());
+		$this->assertEquals(IAccountManager::PROPERTY_WEBSITE, $accountProperty->getName());
 		$this->assertEquals('https://example.com', $accountProperty->getValue());
-		$this->assertEquals(AccountManager::VISIBILITY_PUBLIC, $accountProperty->getScope());
-		$this->assertEquals(AccountManager::VERIFIED, $accountProperty->getVerified());
+		$this->assertEquals(IAccountManager::VISIBILITY_PUBLIC, $accountProperty->getScope());
+		$this->assertEquals(IAccountManager::VERIFIED, $accountProperty->getVerified());
 	}
 
 	public function testSetValue() {
 		$accountProperty = new AccountProperty(
-			AccountManager::PROPERTY_WEBSITE,
+			IAccountManager::PROPERTY_WEBSITE,
 			'https://example.com',
-			AccountManager::VISIBILITY_PUBLIC,
-			AccountManager::VERIFIED
+			IAccountManager::VISIBILITY_PUBLIC,
+			IAccountManager::VERIFIED
 		);
 		$actualReturn = $accountProperty->setValue('https://example.org');
 		$this->assertEquals('https://example.org', $accountProperty->getValue());
@@ -63,40 +61,40 @@ class AccountPropertyTest extends TestCase {
 
 	public function testSetScope() {
 		$accountProperty = new AccountProperty(
-			AccountManager::PROPERTY_WEBSITE,
+			IAccountManager::PROPERTY_WEBSITE,
 			'https://example.com',
-			AccountManager::VISIBILITY_PUBLIC,
-			AccountManager::VERIFIED
+			IAccountManager::VISIBILITY_PUBLIC,
+			IAccountManager::VERIFIED
 		);
-		$actualReturn = $accountProperty->setScope(AccountManager::VISIBILITY_PRIVATE);
-		$this->assertEquals(AccountManager::VISIBILITY_PRIVATE, $accountProperty->getScope());
-		$this->assertEquals(AccountManager::VISIBILITY_PRIVATE, $actualReturn->getScope());
+		$actualReturn = $accountProperty->setScope(IAccountManager::VISIBILITY_PRIVATE);
+		$this->assertEquals(IAccountManager::VISIBILITY_PRIVATE, $accountProperty->getScope());
+		$this->assertEquals(IAccountManager::VISIBILITY_PRIVATE, $actualReturn->getScope());
 	}
 
 	public function testSetVerified() {
 		$accountProperty = new AccountProperty(
-			AccountManager::PROPERTY_WEBSITE,
+			IAccountManager::PROPERTY_WEBSITE,
 			'https://example.com',
-			AccountManager::VISIBILITY_PUBLIC,
-			AccountManager::VERIFIED
+			IAccountManager::VISIBILITY_PUBLIC,
+			IAccountManager::VERIFIED
 		);
-		$actualReturn = $accountProperty->setVerified(AccountManager::NOT_VERIFIED);
-		$this->assertEquals(AccountManager::NOT_VERIFIED, $accountProperty->getVerified());
-		$this->assertEquals(AccountManager::NOT_VERIFIED, $actualReturn->getVerified());
+		$actualReturn = $accountProperty->setVerified(IAccountManager::NOT_VERIFIED);
+		$this->assertEquals(IAccountManager::NOT_VERIFIED, $accountProperty->getVerified());
+		$this->assertEquals(IAccountManager::NOT_VERIFIED, $actualReturn->getVerified());
 	}
 
 	public function testJsonSerialize() {
 		$accountProperty = new AccountProperty(
-			AccountManager::PROPERTY_WEBSITE,
+			IAccountManager::PROPERTY_WEBSITE,
 			'https://example.com',
-			AccountManager::VISIBILITY_PUBLIC,
-			AccountManager::VERIFIED
+			IAccountManager::VISIBILITY_PUBLIC,
+			IAccountManager::VERIFIED
 		);
 		$this->assertEquals([
-			'name' => AccountManager::PROPERTY_WEBSITE,
+			'name' => IAccountManager::PROPERTY_WEBSITE,
 			'value' => 'https://example.com',
-			'scope' => AccountManager::VISIBILITY_PUBLIC,
-			'verified' => AccountManager::VERIFIED
+			'scope' => IAccountManager::VISIBILITY_PUBLIC,
+			'verified' => IAccountManager::VERIFIED
 		], $accountProperty->jsonSerialize());
 	}
 

--- a/tests/lib/Accounts/AccountTest.php
+++ b/tests/lib/Accounts/AccountTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Test\Accounts;
+
+use OC\Accounts\Account;
+use OC\Accounts\AccountManager;
+use OC\Accounts\AccountProperty;
+use OCP\IUser;
+use Test\TestCase;
+
+/**
+ * Class AccountTest
+ *
+ * @package Test\Accounts
+ */
+class AccountTest extends TestCase {
+
+	public function testConstructor() {
+		$user = $this->createMock(IUser::class);
+		$account = new Account($user);
+		$this->assertEquals($user, $account->getUser());
+	}
+
+	public function testSetProperty() {
+		$user = $this->createMock(IUser::class);
+		$property = new AccountProperty(AccountManager::PROPERTY_WEBSITE, 'https://example.com', AccountManager::VISIBILITY_PUBLIC, AccountManager::NOT_VERIFIED);
+		$account = new Account($user);
+		$account->setProperty(AccountManager::PROPERTY_WEBSITE, 'https://example.com', AccountManager::VISIBILITY_PUBLIC, AccountManager::NOT_VERIFIED);
+		$this->assertEquals($property, $account->getProperty(AccountManager::PROPERTY_WEBSITE));
+	}
+
+	public function testGetProperties() {
+		$user = $this->createMock(IUser::class);
+		$properties = [
+			AccountManager::PROPERTY_WEBSITE => new AccountProperty(AccountManager::PROPERTY_WEBSITE, 'https://example.com', AccountManager::VISIBILITY_PUBLIC, AccountManager::NOT_VERIFIED),
+			AccountManager::PROPERTY_EMAIL => new AccountProperty(AccountManager::PROPERTY_EMAIL, 'user@example.com', AccountManager::VISIBILITY_PRIVATE, AccountManager::VERIFIED)
+		];
+		$account = new Account($user);
+		$account->setProperty(AccountManager::PROPERTY_WEBSITE, 'https://example.com', AccountManager::VISIBILITY_PUBLIC, AccountManager::NOT_VERIFIED);
+		$account->setProperty(AccountManager::PROPERTY_EMAIL, 'user@example.com', AccountManager::VISIBILITY_PRIVATE, AccountManager::VERIFIED);
+
+		$this->assertEquals($properties, $account->getProperties());
+	}
+
+	public function testGetFilteredProperties() {
+		$user = $this->createMock(IUser::class);
+		$properties = [
+			AccountManager::PROPERTY_WEBSITE => new AccountProperty(AccountManager::PROPERTY_WEBSITE, 'https://example.com', AccountManager::VISIBILITY_PUBLIC, AccountManager::NOT_VERIFIED),
+			AccountManager::PROPERTY_EMAIL => new AccountProperty(AccountManager::PROPERTY_EMAIL, 'user@example.com', AccountManager::VISIBILITY_PRIVATE, AccountManager::VERIFIED),
+			AccountManager::PROPERTY_PHONE => new AccountProperty(AccountManager::PROPERTY_PHONE, '123456', AccountManager::VISIBILITY_PUBLIC, AccountManager::VERIFIED),
+		];
+		$account = new Account($user);
+		$account->setProperty(AccountManager::PROPERTY_WEBSITE, 'https://example.com', AccountManager::VISIBILITY_PUBLIC, AccountManager::NOT_VERIFIED);
+		$account->setProperty(AccountManager::PROPERTY_EMAIL, 'user@example.com', AccountManager::VISIBILITY_PRIVATE, AccountManager::VERIFIED);
+		$account->setProperty(AccountManager::PROPERTY_PHONE, '123456', AccountManager::VISIBILITY_PUBLIC, AccountManager::VERIFIED);
+
+
+		$this->assertEquals(
+			[
+				AccountManager::PROPERTY_WEBSITE => $properties[AccountManager::PROPERTY_WEBSITE],
+				AccountManager::PROPERTY_PHONE => $properties[AccountManager::PROPERTY_PHONE],
+			],
+			$account->getFilteredProperties(AccountManager::VISIBILITY_PUBLIC)
+		);
+		$this->assertEquals(
+			[
+				AccountManager::PROPERTY_EMAIL => $properties[AccountManager::PROPERTY_EMAIL],
+				AccountManager::PROPERTY_PHONE => $properties[AccountManager::PROPERTY_PHONE],
+			],
+			$account->getFilteredProperties(null, AccountManager::VERIFIED)
+		);
+		$this->assertEquals(
+			[AccountManager::PROPERTY_PHONE => $properties[AccountManager::PROPERTY_PHONE]],
+			$account->getFilteredProperties(AccountManager::VISIBILITY_PUBLIC, AccountManager::VERIFIED)
+		);
+	}
+
+	public function testJsonSerialize() {
+		$user = $this->createMock(IUser::class);
+		$properties = [
+			AccountManager::PROPERTY_WEBSITE => new AccountProperty(AccountManager::PROPERTY_WEBSITE, 'https://example.com', AccountManager::VISIBILITY_PUBLIC, AccountManager::NOT_VERIFIED),
+			AccountManager::PROPERTY_EMAIL => new AccountProperty(AccountManager::PROPERTY_EMAIL, 'user@example.com', AccountManager::VISIBILITY_PRIVATE, AccountManager::VERIFIED)
+		];
+		$account = new Account($user);
+		$account->setProperty(AccountManager::PROPERTY_WEBSITE, 'https://example.com', AccountManager::VISIBILITY_PUBLIC, AccountManager::NOT_VERIFIED);
+		$account->setProperty(AccountManager::PROPERTY_EMAIL, 'user@example.com', AccountManager::VISIBILITY_PRIVATE, AccountManager::VERIFIED);
+
+		$this->assertEquals($properties, $account->jsonSerialize());
+	}
+
+}

--- a/tests/lib/Accounts/AccountTest.php
+++ b/tests/lib/Accounts/AccountTest.php
@@ -24,8 +24,8 @@
 namespace Test\Accounts;
 
 use OC\Accounts\Account;
-use OC\Accounts\AccountManager;
 use OC\Accounts\AccountProperty;
+use OCP\Accounts\IAccountManager;
 use OCP\IUser;
 use Test\TestCase;
 
@@ -44,21 +44,21 @@ class AccountTest extends TestCase {
 
 	public function testSetProperty() {
 		$user = $this->createMock(IUser::class);
-		$property = new AccountProperty(AccountManager::PROPERTY_WEBSITE, 'https://example.com', AccountManager::VISIBILITY_PUBLIC, AccountManager::NOT_VERIFIED);
+		$property = new AccountProperty(IAccountManager::PROPERTY_WEBSITE, 'https://example.com', IAccountManager::VISIBILITY_PUBLIC, IAccountManager::NOT_VERIFIED);
 		$account = new Account($user);
-		$account->setProperty(AccountManager::PROPERTY_WEBSITE, 'https://example.com', AccountManager::VISIBILITY_PUBLIC, AccountManager::NOT_VERIFIED);
-		$this->assertEquals($property, $account->getProperty(AccountManager::PROPERTY_WEBSITE));
+		$account->setProperty(IAccountManager::PROPERTY_WEBSITE, 'https://example.com', IAccountManager::VISIBILITY_PUBLIC, IAccountManager::NOT_VERIFIED);
+		$this->assertEquals($property, $account->getProperty(IAccountManager::PROPERTY_WEBSITE));
 	}
 
 	public function testGetProperties() {
 		$user = $this->createMock(IUser::class);
 		$properties = [
-			AccountManager::PROPERTY_WEBSITE => new AccountProperty(AccountManager::PROPERTY_WEBSITE, 'https://example.com', AccountManager::VISIBILITY_PUBLIC, AccountManager::NOT_VERIFIED),
-			AccountManager::PROPERTY_EMAIL => new AccountProperty(AccountManager::PROPERTY_EMAIL, 'user@example.com', AccountManager::VISIBILITY_PRIVATE, AccountManager::VERIFIED)
+			IAccountManager::PROPERTY_WEBSITE => new AccountProperty(IAccountManager::PROPERTY_WEBSITE, 'https://example.com', IAccountManager::VISIBILITY_PUBLIC, IAccountManager::NOT_VERIFIED),
+			IAccountManager::PROPERTY_EMAIL => new AccountProperty(IAccountManager::PROPERTY_EMAIL, 'user@example.com', IAccountManager::VISIBILITY_PRIVATE, IAccountManager::VERIFIED)
 		];
 		$account = new Account($user);
-		$account->setProperty(AccountManager::PROPERTY_WEBSITE, 'https://example.com', AccountManager::VISIBILITY_PUBLIC, AccountManager::NOT_VERIFIED);
-		$account->setProperty(AccountManager::PROPERTY_EMAIL, 'user@example.com', AccountManager::VISIBILITY_PRIVATE, AccountManager::VERIFIED);
+		$account->setProperty(IAccountManager::PROPERTY_WEBSITE, 'https://example.com', IAccountManager::VISIBILITY_PUBLIC, IAccountManager::NOT_VERIFIED);
+		$account->setProperty(IAccountManager::PROPERTY_EMAIL, 'user@example.com', IAccountManager::VISIBILITY_PRIVATE, IAccountManager::VERIFIED);
 
 		$this->assertEquals($properties, $account->getProperties());
 	}
@@ -66,45 +66,45 @@ class AccountTest extends TestCase {
 	public function testGetFilteredProperties() {
 		$user = $this->createMock(IUser::class);
 		$properties = [
-			AccountManager::PROPERTY_WEBSITE => new AccountProperty(AccountManager::PROPERTY_WEBSITE, 'https://example.com', AccountManager::VISIBILITY_PUBLIC, AccountManager::NOT_VERIFIED),
-			AccountManager::PROPERTY_EMAIL => new AccountProperty(AccountManager::PROPERTY_EMAIL, 'user@example.com', AccountManager::VISIBILITY_PRIVATE, AccountManager::VERIFIED),
-			AccountManager::PROPERTY_PHONE => new AccountProperty(AccountManager::PROPERTY_PHONE, '123456', AccountManager::VISIBILITY_PUBLIC, AccountManager::VERIFIED),
+			IAccountManager::PROPERTY_WEBSITE => new AccountProperty(IAccountManager::PROPERTY_WEBSITE, 'https://example.com', IAccountManager::VISIBILITY_PUBLIC, IAccountManager::NOT_VERIFIED),
+			IAccountManager::PROPERTY_EMAIL => new AccountProperty(IAccountManager::PROPERTY_EMAIL, 'user@example.com', IAccountManager::VISIBILITY_PRIVATE, IAccountManager::VERIFIED),
+			IAccountManager::PROPERTY_PHONE => new AccountProperty(IAccountManager::PROPERTY_PHONE, '123456', IAccountManager::VISIBILITY_PUBLIC, IAccountManager::VERIFIED),
 		];
 		$account = new Account($user);
-		$account->setProperty(AccountManager::PROPERTY_WEBSITE, 'https://example.com', AccountManager::VISIBILITY_PUBLIC, AccountManager::NOT_VERIFIED);
-		$account->setProperty(AccountManager::PROPERTY_EMAIL, 'user@example.com', AccountManager::VISIBILITY_PRIVATE, AccountManager::VERIFIED);
-		$account->setProperty(AccountManager::PROPERTY_PHONE, '123456', AccountManager::VISIBILITY_PUBLIC, AccountManager::VERIFIED);
+		$account->setProperty(IAccountManager::PROPERTY_WEBSITE, 'https://example.com', IAccountManager::VISIBILITY_PUBLIC, IAccountManager::NOT_VERIFIED);
+		$account->setProperty(IAccountManager::PROPERTY_EMAIL, 'user@example.com', IAccountManager::VISIBILITY_PRIVATE, IAccountManager::VERIFIED);
+		$account->setProperty(IAccountManager::PROPERTY_PHONE, '123456', IAccountManager::VISIBILITY_PUBLIC, IAccountManager::VERIFIED);
 
 
 		$this->assertEquals(
 			[
-				AccountManager::PROPERTY_WEBSITE => $properties[AccountManager::PROPERTY_WEBSITE],
-				AccountManager::PROPERTY_PHONE => $properties[AccountManager::PROPERTY_PHONE],
+				IAccountManager::PROPERTY_WEBSITE => $properties[IAccountManager::PROPERTY_WEBSITE],
+				IAccountManager::PROPERTY_PHONE => $properties[IAccountManager::PROPERTY_PHONE],
 			],
-			$account->getFilteredProperties(AccountManager::VISIBILITY_PUBLIC)
+			$account->getFilteredProperties(IAccountManager::VISIBILITY_PUBLIC)
 		);
 		$this->assertEquals(
 			[
-				AccountManager::PROPERTY_EMAIL => $properties[AccountManager::PROPERTY_EMAIL],
-				AccountManager::PROPERTY_PHONE => $properties[AccountManager::PROPERTY_PHONE],
+				IAccountManager::PROPERTY_EMAIL => $properties[IAccountManager::PROPERTY_EMAIL],
+				IAccountManager::PROPERTY_PHONE => $properties[IAccountManager::PROPERTY_PHONE],
 			],
-			$account->getFilteredProperties(null, AccountManager::VERIFIED)
+			$account->getFilteredProperties(null, IAccountManager::VERIFIED)
 		);
 		$this->assertEquals(
-			[AccountManager::PROPERTY_PHONE => $properties[AccountManager::PROPERTY_PHONE]],
-			$account->getFilteredProperties(AccountManager::VISIBILITY_PUBLIC, AccountManager::VERIFIED)
+			[IAccountManager::PROPERTY_PHONE => $properties[IAccountManager::PROPERTY_PHONE]],
+			$account->getFilteredProperties(IAccountManager::VISIBILITY_PUBLIC, IAccountManager::VERIFIED)
 		);
 	}
 
 	public function testJsonSerialize() {
 		$user = $this->createMock(IUser::class);
 		$properties = [
-			AccountManager::PROPERTY_WEBSITE => new AccountProperty(AccountManager::PROPERTY_WEBSITE, 'https://example.com', AccountManager::VISIBILITY_PUBLIC, AccountManager::NOT_VERIFIED),
-			AccountManager::PROPERTY_EMAIL => new AccountProperty(AccountManager::PROPERTY_EMAIL, 'user@example.com', AccountManager::VISIBILITY_PRIVATE, AccountManager::VERIFIED)
+			IAccountManager::PROPERTY_WEBSITE => new AccountProperty(IAccountManager::PROPERTY_WEBSITE, 'https://example.com', IAccountManager::VISIBILITY_PUBLIC, IAccountManager::NOT_VERIFIED),
+			IAccountManager::PROPERTY_EMAIL => new AccountProperty(IAccountManager::PROPERTY_EMAIL, 'user@example.com', IAccountManager::VISIBILITY_PRIVATE, IAccountManager::VERIFIED)
 		];
 		$account = new Account($user);
-		$account->setProperty(AccountManager::PROPERTY_WEBSITE, 'https://example.com', AccountManager::VISIBILITY_PUBLIC, AccountManager::NOT_VERIFIED);
-		$account->setProperty(AccountManager::PROPERTY_EMAIL, 'user@example.com', AccountManager::VISIBILITY_PRIVATE, AccountManager::VERIFIED);
+		$account->setProperty(IAccountManager::PROPERTY_WEBSITE, 'https://example.com', IAccountManager::VISIBILITY_PUBLIC, IAccountManager::NOT_VERIFIED);
+		$account->setProperty(IAccountManager::PROPERTY_EMAIL, 'user@example.com', IAccountManager::VISIBILITY_PRIVATE, IAccountManager::VERIFIED);
 
 		$this->assertEquals($properties, $account->jsonSerialize());
 	}

--- a/tests/lib/Accounts/AccountsManagerTest.php
+++ b/tests/lib/Accounts/AccountsManagerTest.php
@@ -23,6 +23,7 @@
 namespace Test\Accounts;
 
 
+use OC\Accounts\Account;
 use OC\Accounts\AccountManager;
 use OCP\BackgroundJob\IJobList;
 use OCP\IUser;
@@ -252,6 +253,42 @@ class AccountsManagerTest extends TestCase {
 		if (!empty($result)) {
 			return json_decode($result[0]['data'], true);
 		}
+	}
+
+	public function testGetAccount() {
+		$accountManager = $this->getInstance(['getUser']);
+		/** @var IUser $user */
+		$user = $this->createMock(IUser::class);
+
+		$data = [
+			AccountManager::PROPERTY_TWITTER =>
+				[
+					'value' => '@twitterhandle',
+					'scope' => AccountManager::VISIBILITY_PRIVATE,
+					'verified' => AccountManager::NOT_VERIFIED,
+				],
+			AccountManager::PROPERTY_EMAIL =>
+				[
+					'value' => 'test@example.com',
+					'scope' => AccountManager::VISIBILITY_PUBLIC,
+					'verified' => AccountManager::VERIFICATION_IN_PROGRESS,
+				],
+			AccountManager::PROPERTY_WEBSITE =>
+				[
+					'value' => 'https://example.com',
+					'scope' => AccountManager::VISIBILITY_CONTACTS_ONLY,
+					'verified' => AccountManager::VERIFIED,
+				],
+		];
+		$expected = new Account($user);
+		$expected->setProperty(AccountManager::PROPERTY_TWITTER, '@twitterhandle', AccountManager::VISIBILITY_PRIVATE, AccountManager::NOT_VERIFIED);
+		$expected->setProperty(AccountManager::PROPERTY_EMAIL, 'test@example.com', AccountManager::VISIBILITY_PUBLIC, AccountManager::VERIFICATION_IN_PROGRESS);
+		$expected->setProperty(AccountManager::PROPERTY_WEBSITE, 'https://example.com', AccountManager::VISIBILITY_CONTACTS_ONLY, AccountManager::VERIFIED);
+
+		$accountManager->expects($this->once())
+			->method('getUser')
+			->willReturn($data);
+		$this->assertEquals($expected, $accountManager->getAccount($user));
 	}
 
 }

--- a/tests/lib/Accounts/AccountsManagerTest.php
+++ b/tests/lib/Accounts/AccountsManagerTest.php
@@ -25,6 +25,7 @@ namespace Test\Accounts;
 
 use OC\Accounts\Account;
 use OC\Accounts\AccountManager;
+use OCP\Accounts\IAccountManager;
 use OCP\BackgroundJob\IJobList;
 use OCP\IUser;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -261,29 +262,29 @@ class AccountsManagerTest extends TestCase {
 		$user = $this->createMock(IUser::class);
 
 		$data = [
-			AccountManager::PROPERTY_TWITTER =>
+			IAccountManager::PROPERTY_TWITTER =>
 				[
 					'value' => '@twitterhandle',
-					'scope' => AccountManager::VISIBILITY_PRIVATE,
-					'verified' => AccountManager::NOT_VERIFIED,
+					'scope' => IAccountManager::VISIBILITY_PRIVATE,
+					'verified' => IAccountManager::NOT_VERIFIED,
 				],
-			AccountManager::PROPERTY_EMAIL =>
+			IAccountManager::PROPERTY_EMAIL =>
 				[
 					'value' => 'test@example.com',
-					'scope' => AccountManager::VISIBILITY_PUBLIC,
-					'verified' => AccountManager::VERIFICATION_IN_PROGRESS,
+					'scope' => IAccountManager::VISIBILITY_PUBLIC,
+					'verified' => IAccountManager::VERIFICATION_IN_PROGRESS,
 				],
-			AccountManager::PROPERTY_WEBSITE =>
+			IAccountManager::PROPERTY_WEBSITE =>
 				[
 					'value' => 'https://example.com',
-					'scope' => AccountManager::VISIBILITY_CONTACTS_ONLY,
-					'verified' => AccountManager::VERIFIED,
+					'scope' => IAccountManager::VISIBILITY_CONTACTS_ONLY,
+					'verified' => IAccountManager::VERIFIED,
 				],
 		];
 		$expected = new Account($user);
-		$expected->setProperty(AccountManager::PROPERTY_TWITTER, '@twitterhandle', AccountManager::VISIBILITY_PRIVATE, AccountManager::NOT_VERIFIED);
-		$expected->setProperty(AccountManager::PROPERTY_EMAIL, 'test@example.com', AccountManager::VISIBILITY_PUBLIC, AccountManager::VERIFICATION_IN_PROGRESS);
-		$expected->setProperty(AccountManager::PROPERTY_WEBSITE, 'https://example.com', AccountManager::VISIBILITY_CONTACTS_ONLY, AccountManager::VERIFIED);
+		$expected->setProperty(IAccountManager::PROPERTY_TWITTER, '@twitterhandle', IAccountManager::VISIBILITY_PRIVATE, IAccountManager::NOT_VERIFIED);
+		$expected->setProperty(IAccountManager::PROPERTY_EMAIL, 'test@example.com', IAccountManager::VISIBILITY_PUBLIC, IAccountManager::VERIFICATION_IN_PROGRESS);
+		$expected->setProperty(IAccountManager::PROPERTY_WEBSITE, 'https://example.com', IAccountManager::VISIBILITY_CONTACTS_ONLY, IAccountManager::VERIFIED);
 
 		$accountManager->expects($this->once())
 			->method('getUser')


### PR DESCRIPTION
This adds a readonly API to public namespace to allow apps to access the user account data.

Todo:

- [x] Add tests