### PR TITLE
Remove duplicate call to decodeURIComponent

### DIFF
--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -281,8 +281,6 @@
 				path = path.substr(0, path.length - 1);
 			}
 
-			path = decodeURIComponent(path);
-
 			if (response.propStat.length === 0 || response.propStat[0].status !== 'HTTP/1.1 200 OK') {
 				return null;
 			}


### PR DESCRIPTION
In this code path the `path` variable got decoded twice which resulted in the bug described in https://github.com/nextcloud/server/issues/11695 because the second call seems to have caused an `URIError`.

I removed the second call to `decodeURIComponent()` which seems to have fixed this bug. I can now open the `all files` view with a file with a `%` in the name and it will show the list of files instead of just the spinning animation.