### PR TITLE
Ignore "session_lifetime" if it can not be converted to a number

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1383,10 +1383,12 @@ function initCore() {
 	 */
 	function initSessionHeartBeat() {
 		// interval in seconds
-		var interval = 900;
+		var interval = NaN;
 		if (oc_config.session_lifetime) {
 			interval = Math.floor(oc_config.session_lifetime / 2);
 		}
+		interval = isNaN(interval)? 900: interval;
+
 		// minimum one minute
 		interval = Math.max(60, interval);
 		// max interval in seconds set to 24 hours


### PR DESCRIPTION
When `session_lifetime` can not be converted to a number the interval becomes a NaN due to dividing it by 2. This NaN was _dragged_ over all the other mathematical operations and caused the csrftoken to be got again and again due to an infinite loop with no pauses in `setInterval`. Now, the interval is set to the default value instead if the `session_lifetime` can not be converted to a number.
