### PR TITLE
Use default favicon on sharing pages

### DIFF
--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -308,7 +308,7 @@ class ThemingDefaults extends \OC_Defaults {
 	 * @return bool|string false if image should not replaced, otherwise the location of the image
 	 */
 	public function replaceImagePath($app, $image) {
-		if($app==='') {
+		if ($app === '' || $app === 'files_sharing') {
 			$app = 'core';
 		}
 		$cacheBusterValue = $this->config->getAppValue('theming', 'cachebuster', '0');


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/11504

Make sure the default favicon is used on sharing pages instead of the auto-generated one.


Before:
![favicon-files_sharinh](https://user-images.githubusercontent.com/3404133/46796966-2f545800-cd4e-11e8-9a45-19ae11846120.png)

After:
![favicon-core](https://user-images.githubusercontent.com/3404133/46796971-33807580-cd4e-11e8-8eef-5f910a3104c5.png)


@nextcloud/theming 