### PR TITLE
Do not pass '.' along as path

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Jail.php
+++ b/lib/private/Files/Storage/Wrapper/Jail.php
@@ -27,6 +27,7 @@ namespace OC\Files\Storage\Wrapper;
 
 use OC\Files\Cache\Wrapper\CacheJail;
 use OC\Files\Cache\Wrapper\JailPropagator;
+use OC\Files\Filesystem;
 use OCP\Files\Storage\IStorage;
 use OCP\Lock\ILockingProvider;
 
@@ -56,7 +57,7 @@ class Jail extends Wrapper {
 		if ($path === '') {
 			return $this->rootPath;
 		} else {
-			return $this->rootPath . '/' . $path;
+			return Filesystem::normalizePath($this->rootPath . '/' . $path);
 		}
 	}
 


### PR DESCRIPTION
Fixes #11637

When writing a file to the root of a shared storage we have to obtain
creatable information on the root of the share. However getting the
dirname of the path then results in `.`. Passing this along potentially
breaks.

For example objectstores do not have the same hierachy as a normal fs.
So the file `.` doesn't mean anything in that context.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>