### PR TITLE
Expose password confirmation capabilities in the user backend

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -391,6 +391,7 @@ return array(
     'OCP\\User\\Backend\\ICreateUserBackend' => $baseDir . '/lib/public/User/Backend/ICreateUserBackend.php',
     'OCP\\User\\Backend\\IGetDisplayNameBackend' => $baseDir . '/lib/public/User/Backend/IGetDisplayNameBackend.php',
     'OCP\\User\\Backend\\IGetHomeBackend' => $baseDir . '/lib/public/User/Backend/IGetHomeBackend.php',
+    'OCP\\User\\Backend\\IPasswordConfirmationBackend' => $baseDir . '/lib/public/User/Backend/IPasswordConfirmationBackend.php',
     'OCP\\User\\Backend\\IProvideAvatarBackend' => $baseDir . '/lib/public/User/Backend/IProvideAvatarBackend.php',
     'OCP\\User\\Backend\\ISetDisplayNameBackend' => $baseDir . '/lib/public/User/Backend/ISetDisplayNameBackend.php',
     'OCP\\User\\Backend\\ISetPasswordBackend' => $baseDir . '/lib/public/User/Backend/ISetPasswordBackend.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -421,6 +421,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\User\\Backend\\ICreateUserBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/ICreateUserBackend.php',
         'OCP\\User\\Backend\\IGetDisplayNameBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IGetDisplayNameBackend.php',
         'OCP\\User\\Backend\\IGetHomeBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IGetHomeBackend.php',
+        'OCP\\User\\Backend\\IPasswordConfirmationBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IPasswordConfirmationBackend.php',
         'OCP\\User\\Backend\\IProvideAvatarBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IProvideAvatarBackend.php',
         'OCP\\User\\Backend\\ISetDisplayNameBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/ISetDisplayNameBackend.php',
         'OCP\\User\\Backend\\ISetPasswordBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/ISetPasswordBackend.php',

--- a/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
@@ -29,6 +29,7 @@ use OCP\AppFramework\Middleware;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\ISession;
 use OCP\IUserSession;
+use OCP\User\Backend\IPasswordConfirmationBackend;
 
 class PasswordConfirmationMiddleware extends Middleware {
 	/** @var ControllerMethodReflector */
@@ -70,6 +71,13 @@ class PasswordConfirmationMiddleware extends Middleware {
 			$user = $this->userSession->getUser();
 			$backendClassName = '';
 			if ($user !== null) {
+				$backend = $user->getBackend();
+				if ($backend instanceof IPasswordConfirmationBackend) {
+					if (!$backend->canConfirmPassword($user->getUID())) {
+						return;
+					}
+				}
+
 				$backendClassName = $user->getBackendClassName();
 			}
 

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -302,6 +302,10 @@ class User implements IUser {
 		return get_class($this->backend);
 	}
 
+	public function getBackend() {
+		return $this->backend;
+	}
+
 	/**
 	 * check if the backend allows the user to change his avatar on Personal page
 	 *

--- a/lib/public/IUser.php
+++ b/lib/public/IUser.php
@@ -109,6 +109,13 @@ interface IUser {
 	public function getBackendClassName();
 
 	/**
+	 * Get the backend for the current user object
+	 *
+	 * @since 15.0.0
+	 */
+	public function getBackend();
+
+	/**
 	 * check if the backend allows the user to change his avatar on Personal page
 	 *
 	 * @return bool

--- a/lib/public/User/Backend/IPasswordConfirmationBackend.php
+++ b/lib/public/User/Backend/IPasswordConfirmationBackend.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2018, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend;
+
+/**
+ * @since 15.0.0
+ */
+interface IPasswordConfirmationBackend {
+
+	/**
+	 * @since 15.0.0
+	 */
+	public function canConfirmPassword(string $uid): bool;
+}


### PR DESCRIPTION
This will allow user backends to expose if a users password can be validated. This can be useful in several places and allows us to proper do instanceof checks instead of magic string comparisons.

@blizzz as discussed.

* [ ] once this is in we should implement #12085 with this approach here