### PR TITLE
allow local delivery of schedule message while prohibiting FreeBusy requests

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -35,6 +35,7 @@ return array(
     'OCA\\DAV\\CalDAV\\CalendarObject' => $baseDir . '/../lib/CalDAV/CalendarObject.php',
     'OCA\\DAV\\CalDAV\\CalendarRoot' => $baseDir . '/../lib/CalDAV/CalendarRoot.php',
     'OCA\\DAV\\CalDAV\\InvitationResponse\\InvitationResponseServer' => $baseDir . '/../lib/CalDAV/InvitationResponse/InvitationResponseServer.php',
+    'OCA\\DAV\\CalDAV\\Outbox' => $baseDir . '/../lib/CalDAV/Outbox.php',
     'OCA\\DAV\\CalDAV\\Plugin' => $baseDir . '/../lib/CalDAV/Plugin.php',
     'OCA\\DAV\\CalDAV\\Principal\\Collection' => $baseDir . '/../lib/CalDAV/Principal/Collection.php',
     'OCA\\DAV\\CalDAV\\Principal\\User' => $baseDir . '/../lib/CalDAV/Principal/User.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -50,6 +50,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\CalDAV\\CalendarObject' => __DIR__ . '/..' . '/../lib/CalDAV/CalendarObject.php',
         'OCA\\DAV\\CalDAV\\CalendarRoot' => __DIR__ . '/..' . '/../lib/CalDAV/CalendarRoot.php',
         'OCA\\DAV\\CalDAV\\InvitationResponse\\InvitationResponseServer' => __DIR__ . '/..' . '/../lib/CalDAV/InvitationResponse/InvitationResponseServer.php',
+        'OCA\\DAV\\CalDAV\\Outbox' => __DIR__ . '/..' . '/../lib/CalDAV/Outbox.php',
         'OCA\\DAV\\CalDAV\\Plugin' => __DIR__ . '/..' . '/../lib/CalDAV/Plugin.php',
         'OCA\\DAV\\CalDAV\\Principal\\Collection' => __DIR__ . '/..' . '/../lib/CalDAV/Principal/Collection.php',
         'OCA\\DAV\\CalDAV\\Principal\\User' => __DIR__ . '/..' . '/../lib/CalDAV/Principal/User.php',

--- a/apps/dav/lib/CalDAV/CalendarHome.php
+++ b/apps/dav/lib/CalDAV/CalendarHome.php
@@ -29,7 +29,6 @@ use Sabre\CalDAV\Backend\NotificationSupport;
 use Sabre\CalDAV\Backend\SchedulingSupport;
 use Sabre\CalDAV\Backend\SubscriptionSupport;
 use Sabre\CalDAV\Schedule\Inbox;
-use Sabre\CalDAV\Schedule\Outbox;
 use Sabre\CalDAV\Subscriptions\Subscription;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\Exception\MethodNotAllowed;
@@ -81,7 +80,7 @@ class CalendarHome extends \Sabre\CalDAV\CalendarHome {
 
 		if ($this->caldavBackend instanceof SchedulingSupport) {
 			$objects[] = new Inbox($this->caldavBackend, $this->principalInfo['uri']);
-			$objects[] = new Outbox($this->principalInfo['uri']);
+			$objects[] = new Outbox($this->config, $this->principalInfo['uri']);
 		}
 
 		// We're adding a notifications node, if it's supported by the backend.
@@ -108,7 +107,7 @@ class CalendarHome extends \Sabre\CalDAV\CalendarHome {
 			return new Inbox($this->caldavBackend, $this->principalInfo['uri']);
 		}
 		if ($name === 'outbox' && $this->caldavBackend instanceof SchedulingSupport) {
-			return new Outbox($this->principalInfo['uri']);
+			return new Outbox($this->config, $this->principalInfo['uri']);
 		}
 		if ($name === 'notifications' && $this->caldavBackend instanceof NotificationSupport) {
 			return new \Sabre\CalDAv\Notifications\Collection($this->caldavBackend, $this->principalInfo['uri']);

--- a/apps/dav/lib/CalDAV/Outbox.php
+++ b/apps/dav/lib/CalDAV/Outbox.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018, Georg Ehrke
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\CalDAV;
+
+use OCP\IConfig;
+use Sabre\CalDAV\Plugin as CalDAVPlugin;
+
+/**
+ * Class Outbox
+ *
+ * @package OCA\DAV\CalDAV
+ */
+class Outbox extends \Sabre\CalDAV\Schedule\Outbox {
+
+	/** @var IConfig */
+	private $config;
+
+	/** @var null|bool */
+	private $disableFreeBusy = null;
+
+	/**
+	 * Outbox constructor.
+	 *
+	 * @param IConfig $config
+	 * @param string $principalUri
+	 */
+	public function __construct(IConfig $config, string $principalUri) {
+		parent::__construct($principalUri);
+		$this->config = $config;
+	}
+
+	/**
+	 * Returns a list of ACE's for this node.
+	 *
+	 * Each ACE has the following properties:
+	 *   * 'privilege', a string such as {DAV:}read or {DAV:}write. These are
+	 *     currently the only supported privileges
+	 *   * 'principal', a url to the principal who owns the node
+	 *   * 'protected' (optional), indicating that this ACE is not allowed to
+	 *      be updated.
+	 *
+	 * @return array
+	 */
+	function getACL() {
+		// getACL is called so frequently that we cache the config result
+		if ($this->disableFreeBusy === null) {
+			$this->disableFreeBusy = ($this->config->getAppValue('dav', 'disableFreeBusy', 'no') === 'yes');
+		}
+
+		$commonAcl = [
+			[
+				'privilege' => '{DAV:}read',
+				'principal' => $this->getOwner(),
+				'protected' => true,
+			],
+			[
+				'privilege' => '{DAV:}read',
+				'principal' => $this->getOwner() . '/calendar-proxy-read',
+				'protected' => true,
+			],
+			[
+				'privilege' => '{DAV:}read',
+				'principal' => $this->getOwner() . '/calendar-proxy-write',
+				'protected' => true,
+			],
+		];
+
+		// schedule-send is an aggregate privilege for:
+		// - schedule-send-invite
+		// - schedule-send-reply
+		// - schedule-send-freebusy
+		//
+		// If FreeBusy is disabled, we have to remove the latter privilege
+
+		if ($this->disableFreeBusy) {
+			return array_merge($commonAcl, [
+				[
+					'privilege' => '{' . CalDAVPlugin::NS_CALDAV . '}schedule-send-invite',
+					'principal' => $this->getOwner(),
+					'protected' => true,
+				],
+				[
+					'privilege' => '{' . CalDAVPlugin::NS_CALDAV . '}schedule-send-invite',
+					'principal' => $this->getOwner() . '/calendar-proxy-write',
+					'protected' => true,
+				],
+				[
+					'privilege' => '{' . CalDAVPlugin::NS_CALDAV . '}schedule-send-reply',
+					'principal' => $this->getOwner(),
+					'protected' => true,
+				],
+				[
+					'privilege' => '{' . CalDAVPlugin::NS_CALDAV . '}schedule-send-reply',
+					'principal' => $this->getOwner() . '/calendar-proxy-write',
+					'protected' => true,
+				],
+			]);
+		}
+
+		return array_merge($commonAcl, [
+			[
+				'privilege' => '{' . CalDAVPlugin::NS_CALDAV . '}schedule-send',
+				'principal' => $this->getOwner(),
+				'protected' => true,
+			],
+			[
+				'privilege' => '{' . CalDAVPlugin::NS_CALDAV . '}schedule-send',
+				'principal' => $this->getOwner() . '/calendar-proxy-write',
+				'protected' => true,
+			],
+		]);
+	}
+}

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -212,10 +212,9 @@ class Principal implements BackendInterface {
 	protected function searchUserPrincipals(array $searchProperties, $test = 'allof') {
 		$results = [];
 
-		// If sharing is disabled (or FreeBusy was disabled on purpose), return the empty array
+		// If sharing is disabled, return the empty array
 		$shareAPIEnabled = $this->shareManager->shareApiEnabled();
-		$disableFreeBusy = $this->config->getAppValue('dav', 'disableFreeBusy', $shareAPIEnabled ? 'no' : 'yes');
-		if ($disableFreeBusy === 'yes') {
+		if (!$shareAPIEnabled) {
 			return [];
 		}
 
@@ -298,10 +297,9 @@ class Principal implements BackendInterface {
 	 * @return string
 	 */
 	function findByUri($uri, $principalPrefix) {
-		// If sharing is disabled (or FreeBusy was disabled on purpose), return the empty array
+		// If sharing is disabled, return the empty array
 		$shareAPIEnabled = $this->shareManager->shareApiEnabled();
-		$disableFreeBusy = $this->config->getAppValue('dav', 'disableFreeBusy', $shareAPIEnabled ? 'no' : 'yes');
-		if ($disableFreeBusy === 'yes') {
+		if (!$shareAPIEnabled) {
 			return null;
 		}
 

--- a/apps/dav/tests/unit/CalDAV/OutboxTest.php
+++ b/apps/dav/tests/unit/CalDAV/OutboxTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018, Georg Ehrke
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\unit\CalDAV;
+
+use OCA\DAV\CalDAV\Outbox;
+use OCP\IConfig;
+use Test\TestCase;
+
+class OutboxTest extends TestCase {
+
+	/** @var IConfig */
+	private $config;
+
+	/** @var Outbox */
+	private $outbox;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->outbox = new Outbox($this->config, 'user-principal-123');
+	}
+
+	public function testGetACLFreeBusyEnabled() {
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('dav', 'disableFreeBusy', 'no')
+			->will($this->returnValue('no'));
+
+		$this->assertEquals([
+			[
+				'privilege' => '{DAV:}read',
+				'principal' => 'user-principal-123',
+				'protected' => true,
+			],
+			[
+				'privilege' => '{DAV:}read',
+				'principal' => 'user-principal-123/calendar-proxy-read',
+				'protected' => true,
+			],
+			[
+				'privilege' => '{DAV:}read',
+				'principal' => 'user-principal-123/calendar-proxy-write',
+				'protected' => true,
+			],
+			[
+				'privilege' => '{urn:ietf:params:xml:ns:caldav}schedule-send',
+				'principal' => 'user-principal-123',
+				'protected' => true,
+			],
+			[
+				'privilege' => '{urn:ietf:params:xml:ns:caldav}schedule-send',
+				'principal' => 'user-principal-123/calendar-proxy-write',
+				'protected' => true,
+			],
+		], $this->outbox->getACL());
+	}
+
+	public function testGetACLFreeBusyDisabled() {
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('dav', 'disableFreeBusy', 'no')
+			->will($this->returnValue('yes'));
+
+		$this->assertEquals([
+			[
+				'privilege' => '{DAV:}read',
+				'principal' => 'user-principal-123',
+				'protected' => true,
+			],
+			[
+				'privilege' => '{DAV:}read',
+				'principal' => 'user-principal-123/calendar-proxy-read',
+				'protected' => true,
+			],
+			[
+				'privilege' => '{DAV:}read',
+				'principal' => 'user-principal-123/calendar-proxy-write',
+				'protected' => true,
+			],
+			[
+				'privilege' => '{urn:ietf:params:xml:ns:caldav}schedule-send-invite',
+				'principal' => 'user-principal-123',
+				'protected' => true,
+			],
+			[
+				'privilege' => '{urn:ietf:params:xml:ns:caldav}schedule-send-invite',
+				'principal' => 'user-principal-123/calendar-proxy-write',
+				'protected' => true,
+			],
+			[
+				'privilege' => '{urn:ietf:params:xml:ns:caldav}schedule-send-reply',
+				'principal' => 'user-principal-123',
+				'protected' => true,
+			],
+			[
+				'privilege' => '{urn:ietf:params:xml:ns:caldav}schedule-send-reply',
+				'principal' => 'user-principal-123/calendar-proxy-write',
+				'protected' => true,
+			],
+		], $this->outbox->getACL());
+	}
+}


### PR DESCRIPTION
To test this you need a copy of thunderbird.

With `php occ config:app:set dav disableFreeBusy --value=no` (or option not set):
- [x] FreeBusy is allowed
![freebusy_setting_disabled](https://user-images.githubusercontent.com/1250540/47037146-768f7e00-d17e-11e8-8b21-462b39cfbeef.png)
- [x] Invitations are delivered locally
![delivered_setting_disabled](https://user-images.githubusercontent.com/1250540/47037151-7a230500-d17e-11e8-8b69-2de8e654d78b.png)

With `php occ config:app:set dav disableFreeBusy --value=yes`
- [x] FreeBusy is prohibited
![freebusy_option_enabled](https://user-images.githubusercontent.com/1250540/47037179-8f982f00-d17e-11e8-9b23-3871d5530a97.png)
- [x] but local delivery is still working
![d0182040-b5c3-4b24-b7f1-157ef8715b85](https://user-images.githubusercontent.com/1250540/47037194-99219700-d17e-11e8-80d6-25fb71f59d42.jpg)

With current master, enabling `disableFreeBusy` also breaks local delivery.