### PR TITLE
filter null values for UserManager::getByEmail

### DIFF
--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -591,8 +591,12 @@ class Manager extends PublicEmitter implements IUserManager {
 	public function getByEmail($email) {
 		$userIds = $this->config->getUsersForUserValue('settings', 'email', $email);
 
-		return array_map(function($uid) {
+		$users = array_map(function($uid) {
 			return $this->get($uid);
 		}, $userIds);
+
+		return array_values(array_filter($users, function($u) {
+			return ($u instanceof IUser);
+		}));
 	}
 }

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -668,4 +668,37 @@ class ManagerTest extends TestCase {
 		$manager->get('foo')->delete();
 		$this->assertFalse($manager->userExists('foo'));
 	}
+
+	public function testGetByEmail() {
+		$config = $this->getMockBuilder(IConfig::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$config
+			->expects($this->at(0))
+			->method('getUsersForUserValue')
+			->with('settings', 'email', 'test@example.com')
+			->will($this->returnValue(['uid1', 'uid99', 'uid2']));
+
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
+		$backend->expects($this->at(0))
+			->method('userExists')
+			->with($this->equalTo('uid1'))
+			->will($this->returnValue(true));
+		$backend->expects($this->at(1))
+			->method('userExists')
+			->with($this->equalTo('uid99'))
+			->will($this->returnValue(false));
+		$backend->expects($this->at(2))
+			->method('userExists')
+			->with($this->equalTo('uid2'))
+			->will($this->returnValue(true));
+
+		$manager = new \OC\User\Manager($config);
+		$manager->registerBackend($backend);
+
+		$users = $manager->getByEmail('test@example.com');
+		$this->assertCount(2, $users);
+		$this->assertEquals('uid1', $users[0]->getUID());
+		$this->assertEquals('uid2', $users[1]->getUID());
+	}
 }


### PR DESCRIPTION
I wasn't able to reproduce #9326, but it seems to be related to non-local user-backends. (Reporter is using ldap)

It seems that some user backends don't clean up `oc_preferences` properly after a user was deleted in the backend. To be on the safe side we should filter null values.