### PR TITLE
 Replace $verbose with VERBOSITY_VERBOSE

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -77,18 +77,6 @@ class Scan extends Base {
 				'limit rescan to this path, eg. --path="/alice/files/Music", the user_id is determined by the path and the user_id parameter and --all are ignored'
 			)
 			->addOption(
-				'quiet',
-				'q',
-				InputOption::VALUE_NONE,
-				'suppress any output'
-			)
-			->addOption(
-				'verbose',
-				'-v|vv|vvv',
-				InputOption::VALUE_NONE,
-				'verbose the output'
-			)
-			->addOption(
 				'all',
 				null,
 				InputOption::VALUE_NONE,
@@ -123,8 +111,8 @@ class Scan extends Base {
 	protected function scanFiles($user, $path, OutputInterface $output, $backgroundScan = false, $recursive = true, $homeOnly = false) {
 		$connection = $this->reconnectToDatabase($output);
 		$scanner = new \OC\Files\Utils\Scanner($user, $connection, \OC::$server->getLogger());
+
 		# check on each file/folder if there was a user interrupt (ctrl-c) and throw an exception
-		# printout and count
 
 		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function ($path) use ($output) {
 			$output->writeln("\tFile\t<info>$path</info>", OutputInterface::VERBOSITY_VERBOSE);

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -120,39 +120,32 @@ class Scan extends Base {
 		}
 	}
 
-	protected function scanFiles($user, $path, $verbose, OutputInterface $output, $backgroundScan = false, $recursive = true, $homeOnly = false) {
+	protected function scanFiles($user, $path, OutputInterface $output, $backgroundScan = false, $recursive = true, $homeOnly = false) {
 		$connection = $this->reconnectToDatabase($output);
 		$scanner = new \OC\Files\Utils\Scanner($user, $connection, \OC::$server->getLogger());
 		# check on each file/folder if there was a user interrupt (ctrl-c) and throw an exception
 		# printout and count
-		if ($verbose) {
-			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function ($path) use ($output) {
-				$output->writeln("\tFile   <info>$path</info>");
-				$this->filesCounter += 1;
-				$this->abortIfInterrupted();
-			});
-			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function ($path) use ($output) {
-				$output->writeln("\tFolder <info>$path</info>");
-				$this->foldersCounter += 1;
-				$this->abortIfInterrupted();
-			});
-			$scanner->listen('\OC\Files\Utils\Scanner', 'StorageNotAvailable', function (StorageNotAvailableException $e) use ($output) {
-				$output->writeln('Error while scanning, storage not available (' . $e->getMessage() . ')');
-			});
-			# count only
-		} else {
-			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function () use ($output) {
-				$this->filesCounter += 1;
-				$this->abortIfInterrupted();
-			});
-			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function () use ($output) {
-				$this->foldersCounter += 1;
-				$this->abortIfInterrupted();
-			});
-		}
+
+		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function ($path) use ($output) {
+			$output->writeln("\tFile\t<info>$path</info>", OutputInterface::VERBOSITY_VERBOSE);
+			++$this->filesCounter;
+			$this->abortIfInterrupted();
+		});
+
+		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function ($path) use ($output) {
+			$output->writeln("\tFolder\t<info>$path</info>", OutputInterface::VERBOSITY_VERBOSE);
+			++$this->foldersCounter;
+			$this->abortIfInterrupted();
+		});
+
+		$scanner->listen('\OC\Files\Utils\Scanner', 'StorageNotAvailable', function (StorageNotAvailableException $e) use ($output) {
+			$output->writeln('Error while scanning, storage not available (' . $e->getMessage() . ')', OutputInterface::VERBOSITY_VERBOSE);
+		});
+
 		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function ($path) use ($output) {
 			$this->checkScanWarning($path, $output);
 		});
+
 		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function ($path) use ($output) {
 			$this->checkScanWarning($path, $output);
 		});
@@ -194,32 +187,16 @@ class Scan extends Base {
 			$users = $input->getArgument('user_id');
 		}
 
-		# no messaging level option means: no full printout but statistics
-		# $quiet   means no print at all
-		# $verbose means full printout including statistics
-		# -q	-v	full	stat
-		#  0	 0	no	yes
-		#  0	 1	yes	yes
-		#  1	--	no	no  (quiet overrules verbose)
-		$verbose = $input->getOption('verbose');
-		$quiet = $input->getOption('quiet');
 		# restrict the verbosity level to VERBOSITY_VERBOSE
 		if ($output->getVerbosity() > OutputInterface::VERBOSITY_VERBOSE) {
 			$output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
-		}
-		if ($quiet) {
-			$verbose = false;
 		}
 
 		# check quantity of users to be process and show it on the command line
 		$users_total = count($users);
 		if ($users_total === 0) {
-			$output->writeln("<error>Please specify the user id to scan, \"--all\" to scan for all users or \"--path=...\"</error>");
+			$output->writeln('<error>Please specify the user id to scan, --all to scan for all users or --path=...</error>');
 			return;
-		} else {
-			if ($users_total > 1) {
-				$output->writeln("\nScanning files for $users_total users");
-			}
 		}
 
 		$this->initTools();
@@ -230,30 +207,24 @@ class Scan extends Base {
 				$user = $user->getUID();
 			}
 			$path = $inputPath ? $inputPath : '/' . $user;
-			$user_count += 1;
+			++$user_count;
 			if ($this->userManager->userExists($user)) {
-				# add an extra line when verbose is set to optical separate users
-				if ($verbose) {
-					$output->writeln("");
-				}
 				$output->writeln("Starting scan for user $user_count out of $users_total ($user)");
-				# full: printout data if $verbose was set
-				$this->scanFiles($user, $path, $verbose, $output, $input->getOption('unscanned'), ! $input->getOption('shallow'), $input->getOption('home-only'));
+				$this->scanFiles($user, $path, $output, $input->getOption('unscanned'), !$input->getOption('shallow'), $input->getOption('home-only'));
+				$output->writeln('', OutputInterface::VERBOSITY_VERBOSE);
 			} else {
 				$output->writeln("<error>Unknown user $user_count $user</error>");
+				$output->writeln('', OutputInterface::VERBOSITY_VERBOSE);
 			}
 
 			try {
 				$this->abortIfInterrupted();
-			} catch(InterruptedException $e) {
+			} catch (InterruptedException $e) {
 				break;
 			}
 		}
 
-		# stat: printout statistics if $quiet was not set
-		if (!$quiet) {
-			$this->presentStats($output);
-		}
+		$this->presentStats($output);
 	}
 
 	/**
@@ -292,7 +263,6 @@ class Scan extends Base {
 	protected function presentStats(OutputInterface $output) {
 		// Stop the timer
 		$this->execTime += microtime(true);
-		$output->writeln("");
 
 		$headers = [
 			'Folders', 'Files', 'Elapsed time'


### PR DESCRIPTION
`--verbose` and `--quiet` works out of the box for commands. When you are fine with the default behaviour there is no need to redefine these options within an command.

https://github.com/nextcloud/3rdparty/blob/f48c7e29b8001dff95ac00c16338becef1f175dd/symfony/console/Application.php#L865-L868

This pr replace `if ($verbose)` with `OutputInterface::VERBOSITY_VERBOSE`