### PR TITLE
Comment mentions with spaces

### DIFF
--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -416,15 +416,22 @@
 					return;
 				}
 				var mention = '@' + mentions[i].mentionId;
+				if (mentions[i].mentionId.indexOf(' ') !== -1) {
+					mention = _.escape('@"' + mentions[i].mentionId + '"');
+				}
 
 				// escape possible regex characters in the name
 				mention = mention.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+				var regex = new RegExp("(^|\\s)(" + mention + ")\\b", 'g');
+				if (mentions[i].mentionId.indexOf(' ') !== -1) {
+					regex = new RegExp("(^|\\s)(" + mention + ")", 'g');
+				}
 
 				var displayName = this._composeHTMLMention(mentions[i].mentionId, mentions[i].mentionDisplayName);
 
 				// replace every mention either at the start of the input or after a whitespace
 				// followed by a non-word character.
-				message = message.replace(new RegExp("(^|\\s)(" + mention + ")\\b", 'g'),
+				message = message.replace(regex,
 					function(match, p1) {
 						// to  get number of whitespaces (0 vs 1) right
 						return p1+displayName;
@@ -602,9 +609,14 @@
 			var $comment = $el.clone();
 
 			$comment.find('.avatar-name-wrapper').each(function () {
-				var $this = $(this);
-				var $inserted = $this.parent();
-				$inserted.html('@' + $this.find('.avatar').data('username'));
+				var $this = $(this),
+					$inserted = $this.parent(),
+					userId = $this.find('.avatar').data('username');
+				if (userId.indexOf(' ') !== -1) {
+					$inserted.html('@"' + userId + '"');
+				} else {
+					$inserted.html('@' + userId);
+				}
 			});
 
 			$comment.html(OCP.Comments.richToPlain($comment.html()));

--- a/apps/comments/lib/Activity/Provider.php
+++ b/apps/comments/lib/Activity/Provider.php
@@ -213,8 +213,13 @@ class Provider implements IProvider {
 					continue;
 				}
 
+				$pattern = '/(^|\s)(' . '@' . $mention['id'] . ')(\b)/';
+				if (strpos($mention['id'], ' ') !== false) {
+					$pattern = '/(^|\s)(' . '@"' . $mention['id'] . '"' . ')(\b)?/';
+				}
+
 				$message = preg_replace(
-					'/(^|\s)(' . '@' . $mention['id'] . ')(\b)/',
+					$pattern,
 					//'${1}' . $this->regexSafeUser($mention['id'], $displayName) . '${3}',
 					'${1}' . '{mention' . $mentionCount . '}' . '${3}',
 					$message

--- a/lib/private/Comments/Comment.php
+++ b/lib/private/Comments/Comment.php
@@ -225,14 +225,14 @@ class Comment implements IComment {
 	 *
 	 */
 	public function getMentions() {
-		$ok = preg_match_all("/\B(?<![^a-z0-9_\-@\.\'\s])@[a-z0-9_\-@\.\']+/i", $this->getMessage(), $mentions);
+		$ok = preg_match_all("/\B(?<![^a-z0-9_\-@\.\'\s])@(\"[a-z0-9_\-@\.\' ]+\"|[a-z0-9_\-@\.\']+)/i", $this->getMessage(), $mentions);
 		if(!$ok || !isset($mentions[0]) || !is_array($mentions[0])) {
 			return [];
 		}
 		$uids = array_unique($mentions[0]);
 		$result = [];
 		foreach ($uids as $uid) {
-			$result[] = ['type' => 'user', 'id' => substr($uid, 1)];
+			$result[] = ['type' => 'user', 'id' => trim(substr($uid, 1), '"')];
 		}
 		return $result;
 	}

--- a/tests/lib/Comments/CommentTest.php
+++ b/tests/lib/Comments/CommentTest.php
@@ -150,8 +150,11 @@ class CommentTest extends TestCase {
 				['foobar', 'barfoo', 'foo@bar.com', 'bar@foo.org@foobar.io', '23452-4333-54353-2342', 'yolo']
 			],
 			[
-			'@@chef is also a valid mention, no matter how strange it looks', ['@chef']
-			]
+				'@@chef is also a valid mention, no matter how strange it looks', ['@chef']
+			],
+			[
+				'Also @"user with spaces" are now supported', ['user with spaces']
+			],
 		];
 	}
 


### PR DESCRIPTION
1. Create a user with a space in the user id: `foo bar`
2. Share a file with the user
3. Mention the user using autocompletion
4. Look at the message

Before: `Hi {{@Unknown user}} bar test`
After: `Hi {{@User with space in ID}} test`

Fix #2443 