### PR TITLE
Remove cookies from Clear-Site-Data Header

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -131,7 +131,7 @@ class LoginController extends Controller {
 		$this->userSession->logout();
 
 		$response = new RedirectResponse($this->urlGenerator->linkToRouteAbsolute('core.login.showLoginForm'));
-		$response->addHeader('Clear-Site-Data', '"cache", "cookies", "storage", "executionContexts"');
+		$response->addHeader('Clear-Site-Data', '"cache", "storage", "executionContexts"');
 		return $response;
 	}
 

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -117,7 +117,7 @@ class LoginControllerTest extends TestCase {
 			->willReturn('/login');
 
 		$expected = new RedirectResponse('/login');
-		$expected->addHeader('Clear-Site-Data', '"cache", "cookies", "storage", "executionContexts"');
+		$expected->addHeader('Clear-Site-Data', '"cache", "storage", "executionContexts"');
 		$this->assertEquals($expected, $this->loginController->logout());
 	}
 
@@ -147,7 +147,7 @@ class LoginControllerTest extends TestCase {
 			->willReturn('/login');
 
 		$expected = new RedirectResponse('/login');
-		$expected->addHeader('Clear-Site-Data', '"cache", "cookies", "storage", "executionContexts"');
+		$expected->addHeader('Clear-Site-Data', '"cache", "storage", "executionContexts"');
 		$this->assertEquals($expected, $this->loginController->logout());
 	}
 


### PR DESCRIPTION
In https://github.com/nextcloud/server/commit/2f87fb6b456fd109c90a5093c31b7a3f62a32040 this header was introduced. The referenced documentation says:

> When delivered with a response from https://example.com/clear, the following header will cause cookies associated with the origin https://example.com to be cleared, as well as cookies on any origin in the same registered domain (e.g. https://www.example.com/ and https://more.subdomains.example.com/).

This also applies if `https://nextcloud.example.com/` sends the `Clear-Site-Data: "cookies"` header.
This is not the behavior we want at this point!

So I removed the deletion of cookies from the header. This has no effect on the logout process as this header is supported only recently and the logout works in old browsers as well.

---
Fix #9010 