### PR TITLE
[stable14] Fix a case where "password_by_talk" was not a boolean 

### DIFF
--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -978,7 +978,7 @@ class ShareByMailProvider implements IShareProvider {
 		$share->setShareTime($shareTime);
 		$share->setSharedWith($data['share_with']);
 		$share->setPassword($data['password']);
-		$share->setSendPasswordByTalk($data['password_by_talk']);
+		$share->setSendPasswordByTalk((bool)$data['password_by_talk']);
 
 		if ($data['uid_initiator'] !== null) {
 			$share->setShareOwner($data['uid_owner']);


### PR DESCRIPTION
(e.g. null or "0") and actively cast it to a boolean

This was the error message that we have seen:

```
Argument 1 passed to OC\\Share20\\Share::setSendPasswordByTalk() must be of the type boolean, null given, called in apps/sharebymail/lib/ShareByMailProvider.php on line 981
```

Backport of #11802