### PR TITLE
Double check for failed cache with a shared storage

### DIFF
--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -378,10 +378,12 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 		if (!$storage) {
 			$storage = $this;
 		}
+		$sourceRoot  = $this->getSourceRootInfo();
 		if ($this->storage instanceof FailedStorage) {
 			return new FailedCache();
 		}
-		$this->cache = new \OCA\Files_Sharing\Cache($storage, $this->getSourceRootInfo(), $this->superShare);
+
+		$this->cache = new \OCA\Files_Sharing\Cache($storage, $sourceRoot, $this->superShare);
 		return $this->cache;
 	}
 


### PR DESCRIPTION
When obtaining the SourceRootInfo we can call init. If this fails the
cache is set to a failed cache and the storage to a failed storage.
However we did not check for this. Which means that if the storage was
invalid it would fail later on.

Now we will properly error out.


This should fix warnings on our own instance where I could trigger it.