### PR TITLE
Properly quote column name in "createFunction" call

### DIFF
--- a/apps/dav/lib/Migration/BuildCalendarSearchIndex.php
+++ b/apps/dav/lib/Migration/BuildCalendarSearchIndex.php
@@ -70,7 +70,7 @@ class BuildCalendarSearchIndex implements IRepairStep {
 		}
 
 		$query = $this->db->getQueryBuilder();
-		$query->select($query->createFunction('MAX(id)'))
+		$query->select($query->createFunction('MAX(' . $query->getColumnName('id') . ')'))
 			->from('calendarobjects');
 		$maxId = (int)$query->execute()->fetchColumn();
 

--- a/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
+++ b/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
@@ -98,7 +98,7 @@ class CleanupRemoteStorages extends Command {
 
 	public function countFiles($numericId, OutputInterface $output) {
 		$queryBuilder = $this->connection->getQueryBuilder();
-		$queryBuilder->select($queryBuilder->createFunction('count(fileid)'))
+		$queryBuilder->select($queryBuilder->createFunction('COUNT(' . $queryBuilder->getColumnName('fileid') . ')'))
 			->from('filecache')
 			->where($queryBuilder->expr()->eq(
 				'storage',

--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -311,7 +311,7 @@ abstract class AbstractMapping {
 	 */
 	public function count() {
 		$qb = $this->dbc->getQueryBuilder();
-		$query = $qb->select($qb->createFunction('COUNT(`ldap_dn`)'))
+		$query = $qb->select($qb->createFunction('COUNT(' . $qb->getColumnName('ldap_dn') . ')'))
 			->from($this->getTableName());
 		$res = $query->execute();
 		$count = $res->fetchColumn();

--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -163,7 +163,7 @@ class Manager implements ICommentsManager {
 	 */
 	protected function updateChildrenInformation($id, \DateTime $cDateTime) {
 		$qb = $this->dbConn->getQueryBuilder();
-		$query = $qb->select($qb->createFunction('COUNT(`id`)'))
+		$query = $qb->select($qb->createFunction('COUNT(' . $qb->getColumnName('id') . ')'))
 			->from('comments')
 			->where($qb->expr()->eq('parent_id', $qb->createParameter('id')))
 			->setParameter('id', $id);

--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -387,9 +387,9 @@ class Database extends ABackend
 		$this->fixDI();
 		
 		$query = $this->dbConn->getQueryBuilder();
-		$query->select($query->createFunction('COUNT(Distinct uid)'))
+		$query->select($query->createFunction('COUNT(DISTINCT ' . $query->getColumnName('uid') . ')'))
 			->from('preferences', 'p')
-			->innerJoin('p', 'group_user', 'g', 'p.userid = g.uid')
+			->innerJoin('p', 'group_user', 'g', $query->expr()->eq('p.userid', 'g.uid'))
 			->where($query->expr()->eq('appid', $query->createNamedParameter('core')))
 			->andWhere($query->expr()->eq('configkey', $query->createNamedParameter('enabled')))
 			->andWhere($query->expr()->eq('configvalue', $query->createNamedParameter('false'), IQueryBuilder::PARAM_STR))

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -475,9 +475,9 @@ class Manager extends PublicEmitter implements IUserManager {
 	 */
 	public function countDisabledUsersOfGroups(array $groups): int {
 		$queryBuilder = \OC::$server->getDatabaseConnection()->getQueryBuilder();
-		$queryBuilder->select($queryBuilder->createFunction('COUNT(Distinct uid)'))
+		$queryBuilder->select($queryBuilder->createFunction('COUNT(DISTINCT ' . $queryBuilder->getColumnName('uid') . ')'))
 			->from('preferences', 'p')
-			->innerJoin('p', 'group_user', 'g', 'p.userid = g.uid')
+			->innerJoin('p', 'group_user', 'g', $queryBuilder->expr()->eq('p.userid', 'g.uid'))
 			->where($queryBuilder->expr()->eq('appid', $queryBuilder->createNamedParameter('core')))
 			->andWhere($queryBuilder->expr()->eq('configkey', $queryBuilder->createNamedParameter('enabled')))
 			->andWhere($queryBuilder->expr()->eq('configvalue', $queryBuilder->createNamedParameter('false'), IQueryBuilder::PARAM_STR))


### PR DESCRIPTION
On Oracle the unquoted identifiers are upper cased:

```
Doctrine\DBAL\Exception\InvalidFieldNameException: An exception occurred while executing 'SELECT MAX(id) FROM "oc_calendarobjects"':

ORA-00904: "ID": ungültige ID
```
