### PR TITLE
Fix #11873 by making default font weight "normal"

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -84,7 +84,7 @@ ul {
 
 body {
 	background-color: var(--color-main-background);
-	font-weight: 300;
+	font-weight: 400;
 	font-size: .8em;
 	line-height: 1.6em;
 	font-family: var(--font-face);


### PR DESCRIPTION
It's a small change, but it greatly improves readability (and I don't have any accessibility or tech issues, so I can only imagine it is worse for others)