### PR TITLE
Add support for sending the password for a link share by Nextcloud Talk

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -212,6 +212,8 @@ class ShareAPIController extends OCSController {
 			$result['share_with'] = $share->getPassword();
 			$result['share_with_displayname'] = $share->getPassword();
 
+			$result['send_password_by_talk'] = $share->getSendPasswordByTalk();
+
 			$result['token'] = $share->getToken();
 			$result['url'] = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.showShare', ['token' => $share->getToken()]);
 
@@ -477,8 +479,17 @@ class ShareAPIController extends OCSController {
 				$share->setPassword($password);
 			}
 
+
 			if (!empty($label)) {
 				$share->setLabel($label);
+			}
+
+			if ($sendPasswordByTalk === 'true') {
+				if (!$this->appManager->isEnabledForUser('spreed')) {
+					throw new OCSForbiddenException($this->l->t('Sharing %s sending the password by Nextcloud Talk failed because Nextcloud Talk is not enabled', [$path->getPath()]));
+				}
+
+				$share->setSendPasswordByTalk(true);
 			}
 
 			//Expire date
@@ -873,6 +884,15 @@ class ShareAPIController extends OCSController {
 				$share->setLabel($label);
 			}
 
+			if ($sendPasswordByTalk === 'true') {
+				if (!$this->appManager->isEnabledForUser('spreed')) {
+					throw new OCSForbiddenException($this->l->t('Sharing sending the password by Nextcloud Talk failed because Nextcloud Talk is not enabled'));
+				}
+
+				$share->setSendPasswordByTalk(true);
+			} else if ($sendPasswordByTalk !== null) {
+				$share->setSendPasswordByTalk(false);
+			}
 		} else {
 			if ($permissions !== null) {
 				$permissions = (int)$permissions;

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -1512,6 +1512,9 @@ class ShareAPIControllerTest extends TestCase {
 			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
 			->setPassword('password')
 			->setExpirationDate(new \DateTime())
+			->setNote('note')
+			->setLabel('label')
+			->setHideDownload(true)
 			->setPermissions(\OCP\Constants::PERMISSION_ALL)
 			->setNode($node);
 
@@ -1525,7 +1528,12 @@ class ShareAPIControllerTest extends TestCase {
 			$this->callback(function (\OCP\Share\IShare $share) {
 				return $share->getPermissions() === \OCP\Constants::PERMISSION_READ &&
 				$share->getPassword() === null &&
-				$share->getExpirationDate() === null;
+				$share->getExpirationDate() === null &&
+				// Once set a note or a label are never back to null, only to an
+				// empty string.
+				$share->getNote() === '' &&
+				$share->getLabel() === '' &&
+				$share->getHideDownload() === false;
 			})
 		)->will($this->returnArgument(0));
 
@@ -1533,7 +1541,7 @@ class ShareAPIControllerTest extends TestCase {
 			->willReturn([]);
 
 		$expected = new DataResponse([]);
-		$result = $ocs->updateShare(42, null, '', null, 'false', '');
+		$result = $ocs->updateShare(42, null, '', null, 'false', '', '', '', 'false');
 
 		$this->assertInstanceOf(get_class($expected), $result);
 		$this->assertEquals($expected->getData(), $result->getData());
@@ -1560,7 +1568,10 @@ class ShareAPIControllerTest extends TestCase {
 
 				return $share->getPermissions() === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE) &&
 				$share->getPassword() === 'password' &&
-				$share->getExpirationDate() == $date;
+				$share->getExpirationDate() == $date &&
+				$share->getNote() === 'note' &&
+				$share->getLabel() === 'label' &&
+				$share->getHideDownload() === true;
 			})
 		)->will($this->returnArgument(0));
 
@@ -1568,7 +1579,7 @@ class ShareAPIControllerTest extends TestCase {
 			->willReturn([]);
 
 		$expected = new DataResponse([]);
-		$result = $ocs->updateShare(42, null, 'password', null, 'true', '2000-01-01');
+		$result = $ocs->updateShare(42, null, 'password', null, 'true', '2000-01-01', 'note', 'label', 'true');
 
 		$this->assertInstanceOf(get_class($expected), $result);
 		$this->assertEquals($expected->getData(), $result->getData());
@@ -1701,6 +1712,9 @@ class ShareAPIControllerTest extends TestCase {
 			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
 			->setPassword('password')
 			->setExpirationDate($date)
+			->setNote('note')
+			->setLabel('label')
+			->setHideDownload(true)
 			->setPermissions(\OCP\Constants::PERMISSION_ALL)
 			->setNode($node);
 
@@ -1714,12 +1728,15 @@ class ShareAPIControllerTest extends TestCase {
 			$this->callback(function (\OCP\Share\IShare $share) use ($date) {
 				return $share->getPermissions() === \OCP\Constants::PERMISSION_ALL &&
 				$share->getPassword() === 'newpassword' &&
-				$share->getExpirationDate() === $date;
+				$share->getExpirationDate() === $date &&
+				$share->getNote() === 'note' &&
+				$share->getLabel() === 'label' &&
+				$share->getHideDownload() === true;
 			})
 		)->will($this->returnArgument(0));
 
 		$expected = new DataResponse([]);
-		$result = $ocs->updateShare(42, null, 'newpassword', null, null, null);
+		$result = $ocs->updateShare(42, null, 'newpassword', null, null, null, null, null, null);
 
 		$this->assertInstanceOf(get_class($expected), $result);
 		$this->assertEquals($expected->getData(), $result->getData());
@@ -1735,6 +1752,9 @@ class ShareAPIControllerTest extends TestCase {
 			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
 			->setPassword('password')
 			->setExpirationDate(new \DateTime())
+			->setNote('note')
+			->setLabel('label')
+			->setHideDownload(true)
 			->setPermissions(\OCP\Constants::PERMISSION_ALL)
 			->setNode($node);
 
@@ -1751,12 +1771,15 @@ class ShareAPIControllerTest extends TestCase {
 
 				return $share->getPermissions() === \OCP\Constants::PERMISSION_ALL &&
 				$share->getPassword() === 'password' &&
-				$share->getExpirationDate() == $date;
+				$share->getExpirationDate() == $date &&
+				$share->getNote() === 'note' &&
+				$share->getLabel() === 'label' &&
+				$share->getHideDownload() === true;
 			})
 		)->will($this->returnArgument(0));
 
 		$expected = new DataResponse([]);
-		$result = $ocs->updateShare(42, null, null, null, null, '2010-12-23');
+		$result = $ocs->updateShare(42, null, null, null, null, '2010-12-23', null, null, null);
 
 		$this->assertInstanceOf(get_class($expected), $result);
 		$this->assertEquals($expected->getData(), $result->getData());
@@ -1775,6 +1798,9 @@ class ShareAPIControllerTest extends TestCase {
 			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
 			->setPassword('password')
 			->setExpirationDate($date)
+			->setNote('note')
+			->setLabel('label')
+			->setHideDownload(true)
 			->setPermissions(\OCP\Constants::PERMISSION_ALL)
 			->setNode($folder);
 
@@ -1785,7 +1811,10 @@ class ShareAPIControllerTest extends TestCase {
 			$this->callback(function (\OCP\Share\IShare $share) use ($date) {
 				return $share->getPermissions() === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE) &&
 				$share->getPassword() === 'password' &&
-				$share->getExpirationDate() === $date;
+				$share->getExpirationDate() === $date &&
+				$share->getNote() === 'note' &&
+				$share->getLabel() === 'label' &&
+				$share->getHideDownload() === true;
 			})
 		)->will($this->returnArgument(0));
 
@@ -1793,7 +1822,7 @@ class ShareAPIControllerTest extends TestCase {
 			->willReturn([]);
 
 		$expected = new DataResponse([]);
-		$result = $ocs->updateShare(42, null, null, null, 'true', null);
+		$result = $ocs->updateShare(42, null, null, null, 'true', null, null, null, null);
 
 		$this->assertInstanceOf(get_class($expected), $result);
 		$this->assertEquals($expected->getData(), $result->getData());
@@ -1812,6 +1841,9 @@ class ShareAPIControllerTest extends TestCase {
 			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
 			->setPassword('password')
 			->setExpirationDate($date)
+			->setNote('note')
+			->setLabel('label')
+			->setHideDownload(true)
 			->setPermissions(\OCP\Constants::PERMISSION_ALL)
 			->setNode($folder);
 
@@ -1822,14 +1854,17 @@ class ShareAPIControllerTest extends TestCase {
 			$this->callback(function (\OCP\Share\IShare $share) use ($date) {
 				return $share->getPermissions() === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE) &&
 				$share->getPassword() === 'password' &&
-				$share->getExpirationDate() === $date;
+				$share->getExpirationDate() === $date &&
+				$share->getNote() === 'note' &&
+				$share->getLabel() === 'label' &&
+				$share->getHideDownload() === true;
 			})
 		)->will($this->returnArgument(0));
 
 		$this->shareManager->method('getSharedWith')->willReturn([]);
 
 		$expected = new DataResponse([]);
-		$result = $ocs->updateShare(42, 7, null, null, null, null);
+		$result = $ocs->updateShare(42, 7, null, null, null, null, null, null, null);
 
 		$this->assertInstanceOf(get_class($expected), $result);
 		$this->assertEquals($expected->getData(), $result->getData());
@@ -1848,6 +1883,9 @@ class ShareAPIControllerTest extends TestCase {
 			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
 			->setPassword('password')
 			->setExpirationDate($date)
+			->setNote('note')
+			->setLabel('label')
+			->setHideDownload(true)
 			->setPermissions(\OCP\Constants::PERMISSION_READ)
 			->setNode($folder);
 
@@ -1858,14 +1896,17 @@ class ShareAPIControllerTest extends TestCase {
 			$this->callback(function (\OCP\Share\IShare $share) use ($date) {
 				return $share->getPermissions() === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE) &&
 					$share->getPassword() === 'password' &&
-					$share->getExpirationDate() === $date;
+					$share->getExpirationDate() === $date &&
+					$share->getNote() === 'note' &&
+					$share->getLabel() === 'label' &&
+					$share->getHideDownload() === true;
 			})
 		)->will($this->returnArgument(0));
 
 		$this->shareManager->method('getSharedWith')->willReturn([]);
 
 		$expected = new DataResponse([]);
-		$result = $ocs->updateShare(42, 31, null, null, null, null);
+		$result = $ocs->updateShare(42, 31, null, null, null, null, null, null, null);
 
 		$this->assertInstanceOf(get_class($expected), $result);
 		$this->assertEquals($expected->getData(), $result->getData());

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -430,6 +430,7 @@ class ShareAPIControllerTest extends TestCase {
 			'share_type' => \OCP\Share::SHARE_TYPE_LINK,
 			'share_with' => 'password',
 			'share_with_displayname' => 'password',
+			'send_password_by_talk' => false,
 			'uid_owner' => 'initiatorId',
 			'displayname_owner' => 'initiatorDisplay',
 			'item_type' => 'folder',
@@ -1135,6 +1136,71 @@ class ShareAPIControllerTest extends TestCase {
 		$this->assertEquals($expected->getData(), $result->getData());
 	}
 
+	public function testCreateShareLinkSendPasswordByTalk() {
+		$ocs = $this->mockFormatShare();
+
+		$path = $this->getMockBuilder(Folder::class)->getMock();
+		$storage = $this->getMockBuilder(Storage::class)->getMock();
+		$storage->method('instanceOfStorage')
+			->with('OCA\Files_Sharing\External\Storage')
+			->willReturn(false);
+		$path->method('getStorage')->willReturn($storage);
+		$this->rootFolder->method('getUserFolder')->with($this->currentUser)->will($this->returnSelf());
+		$this->rootFolder->method('get')->with('valid-path')->willReturn($path);
+
+		$this->shareManager->method('newShare')->willReturn(\OC::$server->getShareManager()->newShare());
+		$this->shareManager->method('shareApiAllowLinks')->willReturn(true);
+		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
+
+		$this->appManager->method('isEnabledForUser')->with('spreed')->willReturn(true);
+
+		$this->shareManager->expects($this->once())->method('createShare')->with(
+			$this->callback(function (\OCP\Share\IShare $share) use ($path) {
+				return $share->getNode() === $path &&
+				$share->getShareType() === \OCP\Share::SHARE_TYPE_LINK &&
+				$share->getPermissions() === \OCP\Constants::PERMISSION_READ &&
+				$share->getSharedBy() === 'currentUser' &&
+				$share->getPassword() === 'password' &&
+				$share->getSendPasswordByTalk() === true &&
+				$share->getExpirationDate() === null;
+			})
+		)->will($this->returnArgument(0));
+
+		$expected = new DataResponse([]);
+		$result = $ocs->createShare('valid-path', \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK, null, 'false', 'password', 'true', '');
+
+		$this->assertInstanceOf(get_class($expected), $result);
+		$this->assertEquals($expected->getData(), $result->getData());
+	}
+
+	/**
+	 * @expectedException \OCP\AppFramework\OCS\OCSForbiddenException
+	 * @expectedExceptionMessage Sharing valid-path sending the password by Nextcloud Talk failed because Nextcloud Talk is not enabled
+     */
+	public function testCreateShareLinkSendPasswordByTalkWithTalkDisabled() {
+		$ocs = $this->mockFormatShare();
+
+		$path = $this->getMockBuilder(Folder::class)->getMock();
+		$storage = $this->getMockBuilder(Storage::class)->getMock();
+		$storage->method('instanceOfStorage')
+			->with('OCA\Files_Sharing\External\Storage')
+			->willReturn(false);
+		$path->method('getStorage')->willReturn($storage);
+		$path->method('getPath')->willReturn('valid-path');
+		$this->rootFolder->method('getUserFolder')->with($this->currentUser)->will($this->returnSelf());
+		$this->rootFolder->method('get')->with('valid-path')->willReturn($path);
+
+		$this->shareManager->method('newShare')->willReturn(\OC::$server->getShareManager()->newShare());
+		$this->shareManager->method('shareApiAllowLinks')->willReturn(true);
+		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
+
+		$this->appManager->method('isEnabledForUser')->with('spreed')->willReturn(false);
+
+		$this->shareManager->expects($this->never())->method('createShare');
+
+		$ocs->createShare('valid-path', \OCP\Constants::PERMISSION_ALL, \OCP\Share::SHARE_TYPE_LINK, null, 'false', 'password', 'true', '');
+	}
+
 	public function testCreateShareValidExpireDate() {
 		$ocs = $this->mockFormatShare();
 
@@ -1711,6 +1777,7 @@ class ShareAPIControllerTest extends TestCase {
 			->setSharedBy($this->currentUser)
 			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
 			->setPassword('password')
+			->setSendPasswordByTalk(true)
 			->setExpirationDate($date)
 			->setNote('note')
 			->setLabel('label')
@@ -1728,6 +1795,7 @@ class ShareAPIControllerTest extends TestCase {
 			$this->callback(function (\OCP\Share\IShare $share) use ($date) {
 				return $share->getPermissions() === \OCP\Constants::PERMISSION_ALL &&
 				$share->getPassword() === 'newpassword' &&
+				$share->getSendPasswordByTalk() === true &&
 				$share->getExpirationDate() === $date &&
 				$share->getNote() === 'note' &&
 				$share->getLabel() === 'label' &&
@@ -1742,6 +1810,184 @@ class ShareAPIControllerTest extends TestCase {
 		$this->assertEquals($expected->getData(), $result->getData());
 	}
 
+	public function testUpdateLinkShareSendPasswordByTalkDoesNotChangeOther() {
+		$ocs = $this->mockFormatShare();
+
+		$date = new \DateTime('2000-01-01');
+		$date->setTime(0,0,0);
+
+		$node = $this->getMockBuilder(File::class)->getMock();
+		$share = $this->newShare();
+		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
+			->setSharedBy($this->currentUser)
+			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setPassword('password')
+			->setSendPasswordByTalk(false)
+			->setExpirationDate($date)
+			->setNote('note')
+			->setLabel('label')
+			->setHideDownload(true)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL)
+			->setNode($node);
+
+		$node->expects($this->once())
+			->method('lock')
+			->with(\OCP\Lock\ILockingProvider::LOCK_SHARED);
+
+		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
+
+		$this->appManager->method('isEnabledForUser')->with('spreed')->willReturn(true);
+
+		$this->shareManager->expects($this->once())->method('updateShare')->with(
+			$this->callback(function (\OCP\Share\IShare $share) use ($date) {
+				return $share->getPermissions() === \OCP\Constants::PERMISSION_ALL &&
+				$share->getPassword() === 'password' &&
+				$share->getSendPasswordByTalk() === true &&
+				$share->getExpirationDate() === $date &&
+				$share->getNote() === 'note' &&
+				$share->getLabel() === 'label' &&
+				$share->getHideDownload() === true;
+			})
+		)->will($this->returnArgument(0));
+
+		$expected = new DataResponse([]);
+		$result = $ocs->updateShare(42, null, null, 'true', null, null, null, null, null);
+
+		$this->assertInstanceOf(get_class($expected), $result);
+		$this->assertEquals($expected->getData(), $result->getData());
+	}
+
+	/**
+	 * @expectedException \OCP\AppFramework\OCS\OCSForbiddenException
+	 * @expectedExceptionMessage Sharing sending the password by Nextcloud Talk failed because Nextcloud Talk is not enabled
+     */
+	public function testUpdateLinkShareSendPasswordByTalkWithTalkDisabledDoesNotChangeOther() {
+		$ocs = $this->mockFormatShare();
+
+		$date = new \DateTime('2000-01-01');
+		$date->setTime(0,0,0);
+
+		$node = $this->getMockBuilder(File::class)->getMock();
+		$share = $this->newShare();
+		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
+			->setSharedBy($this->currentUser)
+			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setPassword('password')
+			->setSendPasswordByTalk(false)
+			->setExpirationDate($date)
+			->setNote('note')
+			->setLabel('label')
+			->setHideDownload(true)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL)
+			->setNode($node);
+
+		$node->expects($this->once())
+			->method('lock')
+			->with(\OCP\Lock\ILockingProvider::LOCK_SHARED);
+
+		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
+
+		$this->appManager->method('isEnabledForUser')->with('spreed')->willReturn(false);
+
+		$this->shareManager->expects($this->never())->method('updateShare');
+
+		$ocs->updateShare(42, null, null, 'true', null, null, null, null, null);
+	}
+
+	public function testUpdateLinkShareDoNotSendPasswordByTalkDoesNotChangeOther() {
+		$ocs = $this->mockFormatShare();
+
+		$date = new \DateTime('2000-01-01');
+		$date->setTime(0,0,0);
+
+		$node = $this->getMockBuilder(File::class)->getMock();
+		$share = $this->newShare();
+		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
+			->setSharedBy($this->currentUser)
+			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setPassword('password')
+			->setSendPasswordByTalk(true)
+			->setExpirationDate($date)
+			->setNote('note')
+			->setLabel('label')
+			->setHideDownload(true)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL)
+			->setNode($node);
+
+		$node->expects($this->once())
+			->method('lock')
+			->with(\OCP\Lock\ILockingProvider::LOCK_SHARED);
+
+		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
+
+		$this->appManager->method('isEnabledForUser')->with('spreed')->willReturn(true);
+
+		$this->shareManager->expects($this->once())->method('updateShare')->with(
+			$this->callback(function (\OCP\Share\IShare $share) use ($date) {
+				return $share->getPermissions() === \OCP\Constants::PERMISSION_ALL &&
+				$share->getPassword() === 'password' &&
+				$share->getSendPasswordByTalk() === false &&
+				$share->getExpirationDate() === $date &&
+				$share->getNote() === 'note' &&
+				$share->getLabel() === 'label' &&
+				$share->getHideDownload() === true;
+			})
+		)->will($this->returnArgument(0));
+
+		$expected = new DataResponse([]);
+		$result = $ocs->updateShare(42, null, null, 'false', null, null, null, null, null);
+
+		$this->assertInstanceOf(get_class($expected), $result);
+		$this->assertEquals($expected->getData(), $result->getData());
+	}
+
+	public function testUpdateLinkShareDoNotSendPasswordByTalkWithTalkDisabledDoesNotChangeOther() {
+		$ocs = $this->mockFormatShare();
+
+		$date = new \DateTime('2000-01-01');
+		$date->setTime(0,0,0);
+
+		$node = $this->getMockBuilder(File::class)->getMock();
+		$share = $this->newShare();
+		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
+			->setSharedBy($this->currentUser)
+			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setPassword('password')
+			->setSendPasswordByTalk(true)
+			->setExpirationDate($date)
+			->setNote('note')
+			->setLabel('label')
+			->setHideDownload(true)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL)
+			->setNode($node);
+
+		$node->expects($this->once())
+			->method('lock')
+			->with(\OCP\Lock\ILockingProvider::LOCK_SHARED);
+
+		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
+
+		$this->appManager->method('isEnabledForUser')->with('spreed')->willReturn(false);
+
+		$this->shareManager->expects($this->once())->method('updateShare')->with(
+			$this->callback(function (\OCP\Share\IShare $share) use ($date) {
+				return $share->getPermissions() === \OCP\Constants::PERMISSION_ALL &&
+				$share->getPassword() === 'password' &&
+				$share->getSendPasswordByTalk() === false &&
+				$share->getExpirationDate() === $date &&
+				$share->getNote() === 'note' &&
+				$share->getLabel() === 'label' &&
+				$share->getHideDownload() === true;
+			})
+		)->will($this->returnArgument(0));
+
+		$expected = new DataResponse([]);
+		$result = $ocs->updateShare(42, null, null, 'false', null, null, null, null, null);
+
+		$this->assertInstanceOf(get_class($expected), $result);
+		$this->assertEquals($expected->getData(), $result->getData());
+	}
+
 	public function testUpdateLinkShareExpireDateDoesNotChangeOther() {
 		$ocs = $this->mockFormatShare();
 
@@ -1751,6 +1997,7 @@ class ShareAPIControllerTest extends TestCase {
 			->setSharedBy($this->currentUser)
 			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
 			->setPassword('password')
+			->setSendPasswordByTalk(true)
 			->setExpirationDate(new \DateTime())
 			->setNote('note')
 			->setLabel('label')
@@ -1771,6 +2018,7 @@ class ShareAPIControllerTest extends TestCase {
 
 				return $share->getPermissions() === \OCP\Constants::PERMISSION_ALL &&
 				$share->getPassword() === 'password' &&
+				$share->getSendPasswordByTalk() === true &&
 				$share->getExpirationDate() == $date &&
 				$share->getNote() === 'note' &&
 				$share->getLabel() === 'label' &&
@@ -1797,6 +2045,7 @@ class ShareAPIControllerTest extends TestCase {
 			->setSharedBy($this->currentUser)
 			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
 			->setPassword('password')
+			->setSendPasswordByTalk(true)
 			->setExpirationDate($date)
 			->setNote('note')
 			->setLabel('label')
@@ -1811,6 +2060,7 @@ class ShareAPIControllerTest extends TestCase {
 			$this->callback(function (\OCP\Share\IShare $share) use ($date) {
 				return $share->getPermissions() === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE) &&
 				$share->getPassword() === 'password' &&
+				$share->getSendPasswordByTalk() === true &&
 				$share->getExpirationDate() === $date &&
 				$share->getNote() === 'note' &&
 				$share->getLabel() === 'label' &&
@@ -1840,6 +2090,7 @@ class ShareAPIControllerTest extends TestCase {
 			->setSharedBy($this->currentUser)
 			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
 			->setPassword('password')
+			->setSendPasswordByTalk(true)
 			->setExpirationDate($date)
 			->setNote('note')
 			->setLabel('label')
@@ -1854,6 +2105,7 @@ class ShareAPIControllerTest extends TestCase {
 			$this->callback(function (\OCP\Share\IShare $share) use ($date) {
 				return $share->getPermissions() === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE) &&
 				$share->getPassword() === 'password' &&
+				$share->getSendPasswordByTalk() === true &&
 				$share->getExpirationDate() === $date &&
 				$share->getNote() === 'note' &&
 				$share->getLabel() === 'label' &&
@@ -1882,6 +2134,7 @@ class ShareAPIControllerTest extends TestCase {
 			->setSharedBy($this->currentUser)
 			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
 			->setPassword('password')
+			->setSendPasswordByTalk(true)
 			->setExpirationDate($date)
 			->setNote('note')
 			->setLabel('label')
@@ -1896,6 +2149,7 @@ class ShareAPIControllerTest extends TestCase {
 			$this->callback(function (\OCP\Share\IShare $share) use ($date) {
 				return $share->getPermissions() === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE) &&
 					$share->getPassword() === 'password' &&
+					$share->getSendPasswordByTalk() === true &&
 					$share->getExpirationDate() === $date &&
 					$share->getNote() === 'note' &&
 					$share->getLabel() === 'label' &&
@@ -2435,6 +2689,56 @@ class ShareAPIControllerTest extends TestCase {
 				'file_target' => 'myTarget',
 				'share_with' => 'mypassword',
 				'share_with_displayname' => 'mypassword',
+				'send_password_by_talk' => false,
+				'mail_send' => 0,
+				'url' => 'myLink',
+				'mimetype' => 'myMimeType',
+				'hide_download' => 0,
+			], $share, [], false
+		];
+
+		$share = \OC::$server->getShareManager()->newShare();
+		$share->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setSharedBy('initiator')
+			->setShareOwner('owner')
+			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setNode($file)
+			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
+			->setTarget('myTarget')
+			->setPassword('mypassword')
+			->setSendPasswordByTalk(true)
+			->setExpirationDate(new \DateTime('2001-01-02T00:00:00'))
+			->setToken('myToken')
+			->setNote('personal note')
+			->setLabel('new link share')
+			->setId(42);
+
+		$result[] = [
+			[
+				'id' => 42,
+				'share_type' => \OCP\Share::SHARE_TYPE_LINK,
+				'uid_owner' => 'initiator',
+				'displayname_owner' => 'initiator',
+				'permissions' => 1,
+				'stime' => 946684862,
+				'parent' => null,
+				'expiration' => '2001-01-02 00:00:00',
+				'token' => 'myToken',
+				'uid_file_owner' => 'owner',
+				'displayname_file_owner' => 'owner',
+				'note' => 'personal note',
+				'label' => 'new link share',
+				'path' => 'file',
+				'item_type' => 'file',
+				'storage_id' => 'storageId',
+				'storage' => 100,
+				'item_source' => 3,
+				'file_source' => 3,
+				'file_parent' => 1,
+				'file_target' => 'myTarget',
+				'share_with' => 'mypassword',
+				'share_with_displayname' => 'mypassword',
+				'send_password_by_talk' => true,
 				'mail_send' => 0,
 				'url' => 'myLink',
 				'mimetype' => 'myMimeType',

--- a/core/js/share/sharedialoglinkshareview_popover_menu.handlebars
+++ b/core/js/share/sharedialoglinkshareview_popover_menu.handlebars
@@ -62,6 +62,16 @@
 				</span>
 			</li>
 		{{/if}}
+		{{#if showPasswordByTalkCheckBox}}
+			<li>
+				<span class="shareOption menuitem">
+					<span class="icon-loading-small hidden"></span>
+					<input type="checkbox" name="passwordByTalk" id="passwordByTalk-{{cid}}" class="checkbox passwordByTalkCheckbox"
+					{{#if isPasswordByTalkSet}}checked="checked"{{/if}} />
+					<label for="passwordByTalk-{{cid}}">{{passwordByTalkLabel}}</label>
+				</span>
+			</li>
+		{{/if}}
 		<li>
 			<span class="menuitem">
 				<input id="expireDate-{{cid}}" type="checkbox" name="expirationDate" class="expireDate checkbox"

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -19,6 +19,7 @@
 	 * @property {string} token
 	 * @property {bool} hideDownload
 	 * @property {string|null} password
+	 * @property {bool} sendPasswordByTalk
 	 * @property {number} permissions
 	 * @property {Date} expiration
 	 * @property {number} stime share time
@@ -141,6 +142,7 @@
 					hideDownload: false,
 					password: '',
 					passwordChanged: false,
+					sendPasswordByTalk: false,
 					permissions: OC.PERMISSION_READ,
 					expireDate: this.configModel.getDefaultExpirationDateString(),
 					shareType: OC.Share.SHARE_TYPE_LINK
@@ -873,7 +875,8 @@
 							// hide_download is returned as an int, so force it
 							// to a boolean
 							hideDownload: !!share.hide_download,
-							password: share.share_with
+							password: share.share_with,
+							sendPasswordByTalk: share.send_password_by_talk
 						}));
 
 						return share;

--- a/core/js/sharetemplates.js
+++ b/core/js/sharetemplates.js
@@ -158,18 +158,30 @@ templates['sharedialoglinkshareview_popover_menu'] = template({"1":function(cont
 },"11":function(container,depth0,helpers,partials,data) {
     return "hidden";
 },"13":function(container,depth0,helpers,partials,data) {
-    return "datepicker";
-},"15":function(container,depth0,helpers,partials,data) {
-    var helper;
+    var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
-  return container.escapeExpression(((helper = (helper = helpers.expireDate || (depth0 != null ? depth0.expireDate : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"expireDate","hash":{},"data":data}) : helper)));
+  return "			<li>\n				<span class=\"shareOption menuitem\">\n					<span class=\"icon-loading-small hidden\"></span>\n					<input type=\"checkbox\" name=\"passwordByTalk\" id=\"passwordByTalk-"
+    + alias4(((helper = (helper = helpers.cid || (depth0 != null ? depth0.cid : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"cid","hash":{},"data":data}) : helper)))
+    + "\" class=\"checkbox passwordByTalkCheckbox\"\n					"
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isPasswordByTalkSet : depth0),{"name":"if","hash":{},"fn":container.program(6, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + " />\n					<label for=\"passwordByTalk-"
+    + alias4(((helper = (helper = helpers.cid || (depth0 != null ? depth0.cid : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"cid","hash":{},"data":data}) : helper)))
+    + "\">"
+    + alias4(((helper = (helper = helpers.passwordByTalkLabel || (depth0 != null ? depth0.passwordByTalkLabel : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"passwordByTalkLabel","hash":{},"data":data}) : helper)))
+    + "</label>\n				</span>\n			</li>\n";
+},"15":function(container,depth0,helpers,partials,data) {
+    return "datepicker";
 },"17":function(container,depth0,helpers,partials,data) {
     var helper;
 
-  return container.escapeExpression(((helper = (helper = helpers.defaultExpireDate || (depth0 != null ? depth0.defaultExpireDate : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"defaultExpireDate","hash":{},"data":data}) : helper)));
+  return container.escapeExpression(((helper = (helper = helpers.expireDate || (depth0 != null ? depth0.expireDate : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"expireDate","hash":{},"data":data}) : helper)));
 },"19":function(container,depth0,helpers,partials,data) {
-    return "readonly";
+    var helper;
+
+  return container.escapeExpression(((helper = (helper = helpers.defaultExpireDate || (depth0 != null ? depth0.defaultExpireDate : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"defaultExpireDate","hash":{},"data":data}) : helper)));
 },"21":function(container,depth0,helpers,partials,data) {
+    return "readonly";
+},"23":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "			<li>\n				<a href=\"#\" class=\"menuitem pop-up\" data-url=\""
@@ -193,6 +205,7 @@ templates['sharedialoglinkshareview_popover_menu'] = template({"1":function(cont
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.publicEditing : depth0),{"name":"if","hash":{},"fn":container.program(3, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.showHideDownloadCheckbox : depth0),{"name":"if","hash":{},"fn":container.program(5, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.showPasswordCheckBox : depth0),{"name":"if","hash":{},"fn":container.program(8, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.showPasswordByTalkCheckBox : depth0),{"name":"if","hash":{},"fn":container.program(13, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "		<li>\n			<span class=\"menuitem\">\n				<input id=\"expireDate-"
     + alias4(((helper = (helper = helpers.cid || (depth0 != null ? depth0.cid : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"cid","hash":{},"data":data}) : helper)))
     + "\" type=\"checkbox\" name=\"expirationDate\" class=\"expireDate checkbox\"\n				"
@@ -216,15 +229,15 @@ templates['sharedialoglinkshareview_popover_menu'] = template({"1":function(cont
     + "</label>\n				<!-- do not use the datepicker if enforced -->\n				<input id=\"expirationDatePicker-"
     + alias4(((helper = (helper = helpers.cid || (depth0 != null ? depth0.cid : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"cid","hash":{},"data":data}) : helper)))
     + "\" class=\""
-    + ((stack1 = helpers.unless.call(alias1,(depth0 != null ? depth0.isExpirationEnforced : depth0),{"name":"unless","hash":{},"fn":container.program(13, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.unless.call(alias1,(depth0 != null ? depth0.isExpirationEnforced : depth0),{"name":"unless","hash":{},"fn":container.program(15, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\" type=\"text\"\n					placeholder=\""
     + alias4(((helper = (helper = helpers.expirationDatePlaceholder || (depth0 != null ? depth0.expirationDatePlaceholder : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"expirationDatePlaceholder","hash":{},"data":data}) : helper)))
     + "\" value=\""
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.hasExpireDate : depth0),{"name":"if","hash":{},"fn":container.program(15, data, 0),"inverse":container.program(17, data, 0),"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.hasExpireDate : depth0),{"name":"if","hash":{},"fn":container.program(17, data, 0),"inverse":container.program(19, data, 0),"data":data})) != null ? stack1 : "")
     + "\"\n					data-max-date=\""
     + alias4(((helper = (helper = helpers.maxDate || (depth0 != null ? depth0.maxDate : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"maxDate","hash":{},"data":data}) : helper)))
     + "\" "
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isExpirationEnforced : depth0),{"name":"if","hash":{},"fn":container.program(19, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isExpirationEnforced : depth0),{"name":"if","hash":{},"fn":container.program(21, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + " />\n			</span>\n			</li>\n		<li>\n			<a href=\"#\" class=\"share-add\">\n				<span class=\"icon-loading-small hidden\"></span>\n				<span class=\"icon icon-edit\"></span>\n				<span>"
     + alias4(((helper = (helper = helpers.addNoteLabel || (depth0 != null ? depth0.addNoteLabel : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"addNoteLabel","hash":{},"data":data}) : helper)))
     + "</span>\n				<input type=\"button\" class=\"share-note-delete icon-delete "
@@ -236,7 +249,7 @@ templates['sharedialoglinkshareview_popover_menu'] = template({"1":function(cont
     + "</textarea>\n				<input type=\"submit\" class=\"icon-confirm share-note-submit\" value=\"\" id=\"add-note-"
     + alias4(((helper = (helper = helpers.shareId || (depth0 != null ? depth0.shareId : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"shareId","hash":{},"data":data}) : helper)))
     + "\" />\n			</span>\n		</li>\n"
-    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.social : depth0),{"name":"each","hash":{},"fn":container.program(21, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.social : depth0),{"name":"each","hash":{},"fn":container.program(23, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "		<li>\n			<a href=\"#\" class=\"unshare\"><span class=\"icon-loading-small hidden\"></span><span class=\"icon icon-delete\"></span><span>"
     + alias4(((helper = (helper = helpers.unshareLinkLabel || (depth0 != null ? depth0.unshareLinkLabel : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"unshareLinkLabel","hash":{},"data":data}) : helper)))
     + "</span></a>\n		</li>\n		<li>\n			<a href=\"#\" class=\"new-share\">\n				<span class=\"icon-loading-small hidden\"></span>\n				<span class=\"icon icon-add\"></span>\n				<span>"

--- a/core/js/tests/specs/sharedialoglinkshareview.js
+++ b/core/js/tests/specs/sharedialoglinkshareview.js
@@ -235,4 +235,117 @@ describe('OC.Share.ShareDialogLinkShareView', function () {
 
 	});
 
+	describe('protect password by Talk', function () {
+
+		var $passwordByTalkCheckbox;
+		var $workingIcon;
+
+		beforeEach(function () {
+			// Needed to render the view
+			configModel.isShareWithLinkAllowed.returns(true);
+
+			// "Enable" Talk
+			window.oc_appswebroots['spreed'] = window.oc_webroot + '/apps/files/';
+
+			shareModel.set({
+				linkShares: [{
+					id: 123,
+					password: 'password'
+				}]
+			});
+			view.render();
+
+			$passwordByTalkCheckbox = view.$el.find('.passwordByTalkCheckbox');
+			$workingIcon = $passwordByTalkCheckbox.prev('.icon-loading-small');
+
+			sinon.stub(shareModel, 'saveLinkShare');
+
+			expect($workingIcon.hasClass('hidden')).toBeTruthy();
+		});
+
+		afterEach(function () {
+			shareModel.saveLinkShare.restore();
+		});
+
+		it('is shown if Talk is enabled and there is a password set', function() {
+			expect($passwordByTalkCheckbox.length).toBeTruthy();
+		});
+
+		it('is not shown if Talk is enabled but there is no password set', function() {
+			// Changing the password value also triggers the rendering
+			shareModel.set({
+				linkShares: [{
+					id: 123
+				}]
+			});
+
+			$passwordByTalkCheckbox = view.$el.find('.passwordByTalkCheckbox');
+
+			expect($passwordByTalkCheckbox.length).toBeFalsy();
+		});
+
+		it('is not shown if there is a password set but Talk is not enabled', function() {
+			// "Disable" Talk
+			delete window.oc_appswebroots['spreed'];
+
+			view.render();
+
+			$passwordByTalkCheckbox = view.$el.find('.passwordByTalkCheckbox');
+
+			expect($passwordByTalkCheckbox.length).toBeFalsy();
+		});
+
+		it('checkbox is checked when the setting is enabled', function () {
+			shareModel.set({
+				linkShares: [{
+					id: 123,
+					password: 'password',
+					sendPasswordByTalk: true
+				}]
+			});
+			view.render();
+
+			$passwordByTalkCheckbox = view.$el.find('.passwordByTalkCheckbox');
+
+			expect($passwordByTalkCheckbox.is(':checked')).toEqual(true);
+		});
+
+		it('checkbox is not checked when the setting is disabled', function () {
+			expect($passwordByTalkCheckbox.is(':checked')).toEqual(false);
+		});
+
+		it('enables the setting if clicked when unchecked', function () {
+			// Simulate the click by checking the checkbox and then triggering
+			// the "change" event.
+			$passwordByTalkCheckbox.prop('checked', true);
+			$passwordByTalkCheckbox.change();
+
+			expect($workingIcon.hasClass('hidden')).toBeFalsy();
+			expect(shareModel.saveLinkShare.withArgs({ sendPasswordByTalk: true, cid: 123 }).calledOnce).toBeTruthy();
+		});
+
+		it('disables the setting if clicked when checked', function () {
+			shareModel.set({
+				linkShares: [{
+					id: 123,
+					password: 'password',
+					sendPasswordByTalk: true
+				}]
+			});
+			view.render();
+
+			$passwordByTalkCheckbox = view.$el.find('.passwordByTalkCheckbox');
+			$workingIcon = $passwordByTalkCheckbox.prev('.icon-loading-small');
+
+			// Simulate the click by unchecking the checkbox and then triggering
+			// the "change" event.
+			$passwordByTalkCheckbox.prop('checked', false);
+			$passwordByTalkCheckbox.change();
+
+			expect($workingIcon.hasClass('hidden')).toBeFalsy();
+			expect(shareModel.saveLinkShare.withArgs({ sendPasswordByTalk: false, cid: 123 }).calledOnce).toBeTruthy();
+		});
+
+	});
+
 });

--- a/core/js/tests/specs/shareitemmodelSpec.js
+++ b/core/js/tests/specs/shareitemmodelSpec.js
@@ -169,7 +169,8 @@ describe('OC.Share.ShareItemModel', function() {
 					storage: 1,
 					token: 'tehtoken',
 					uid_owner: 'root',
-					hide_download: 1
+					hide_download: 1,
+					send_password_by_talk: true
 				}
 			]));
 
@@ -189,6 +190,7 @@ describe('OC.Share.ShareItemModel', function() {
 			expect(linkShares.length).toEqual(1);
 			var linkShare = linkShares[0];
 			expect(linkShare.hideDownload).toEqual(true);
+			expect(linkShare.sendPasswordByTalk).toEqual(true);
 
 			// TODO: check more attributes
 		});
@@ -293,7 +295,8 @@ describe('OC.Share.ShareItemModel', function() {
 					storage: 1,
 					token: 'tehtoken',
 					uid_owner: 'root',
-					hide_download: 0
+					hide_download: 0,
+					send_password_by_talk: false
 				}, {
 					displayname_owner: 'root',
 					expiration: '2015-10-15 00:00:00',
@@ -312,7 +315,8 @@ describe('OC.Share.ShareItemModel', function() {
 					storage: 1,
 					token: 'anothertoken',
 					uid_owner: 'root',
-					hide_download: 1
+					hide_download: 1,
+					send_password_by_talk: true
 				}]
 			));
 			OC.currentUser = 'root';
@@ -327,6 +331,7 @@ describe('OC.Share.ShareItemModel', function() {
 			var linkShare = linkShares[0];
 			expect(linkShare.token).toEqual('tehtoken');
 			expect(linkShare.hideDownload).toEqual(false);
+			expect(linkShare.sendPasswordByTalk).toEqual(false);
 
 			// TODO: check child too
 		});
@@ -588,6 +593,7 @@ describe('OC.Share.ShareItemModel', function() {
 				hideDownload: false,
 				password: '',
 				passwordChanged: false,
+				sendPasswordByTalk: false,
 				permissions: OC.PERMISSION_READ,
 				expireDate: '',
 				shareType: OC.Share.SHARE_TYPE_LINK
@@ -612,6 +618,7 @@ describe('OC.Share.ShareItemModel', function() {
 				hideDownload: false,
 				password: '',
 				passwordChanged: false,
+				sendPasswordByTalk: false,
 				permissions: OC.PERMISSION_READ,
 			expireDate: '2015-07-24 00:00:00',
 			shareType: OC.Share.SHARE_TYPE_LINK

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -156,6 +156,8 @@ class DefaultShareProvider implements IShareProvider {
 				$qb->setValue('password', $qb->createNamedParameter($share->getPassword()));
 			}
 
+			$qb->setValue('password_by_talk', $qb->createNamedParameter($share->getSendPasswordByTalk(), IQueryBuilder::PARAM_BOOL));
+
 			//If an expiration date is set store it
 			if ($share->getExpirationDate() !== null) {
 				$qb->setValue('expiration', $qb->createNamedParameter($share->getExpirationDate(), 'datetime'));
@@ -293,6 +295,7 @@ class DefaultShareProvider implements IShareProvider {
 			$qb->update('share')
 				->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())))
 				->set('password', $qb->createNamedParameter($share->getPassword()))
+				->set('password_by_talk', $qb->createNamedParameter($share->getSendPasswordByTalk(), IQueryBuilder::PARAM_BOOL))
 				->set('uid_owner', $qb->createNamedParameter($share->getShareOwner()))
 				->set('uid_initiator', $qb->createNamedParameter($share->getSharedBy()))
 				->set('permissions', $qb->createNamedParameter($share->getPermissions()))
@@ -938,6 +941,7 @@ class DefaultShareProvider implements IShareProvider {
 			$share->setSharedWith($data['share_with']);
 		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
 			$share->setPassword($data['password']);
+			$share->setSendPasswordByTalk((bool)$data['password_by_talk']);
 			$share->setToken($data['token']);
 		}
 

--- a/tests/acceptance/features/app-files.feature
+++ b/tests/acceptance/features/app-files.feature
@@ -218,6 +218,10 @@ Feature: app-files
     When I protect the shared link with the password "abcdef"
     Then I see that the working icon for password protect is shown
     And I see that the working icon for password protect is eventually not shown
+    And I see that the link share is password protected
+    # As Talk is not enabled in the acceptance tests of the server the checkbox
+    # is never shown.
+    And I see that the checkbox to protect the password of the link share by Talk is not shown
 
   Scenario: access a shared link protected by password with a valid password
     Given I act as John

--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -279,6 +279,15 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function passwordProtectCheckboxInput() {
+		return Locator::forThe()->checkbox("Password protect")->
+				descendantOf(self::shareLinkMenu())->
+				describedAs("Password protect checkbox input in the details view in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function passwordProtectField() {
 		return Locator::forThe()->css(".linkPassText")->descendantOf(self::shareLinkMenu())->
 				describedAs("Password protect field in the details view in Files app");
@@ -290,6 +299,18 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	public static function passwordProtectWorkingIcon() {
 		return Locator::forThe()->css(".linkPassMenu .icon-loading-small")->descendantOf(self::shareLinkMenu())->
 				describedAs("Password protect working icon in the details view in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function passwordProtectByTalkCheckbox() {
+		// forThe()->checkbox("Password protect by Talk") can not be used here;
+		// that would return the checkbox itself, but the element that the user
+		// interacts with is the label.
+		return Locator::forThe()->xpath("//label[normalize-space() = 'Password protect by Talk']")->
+				descendantOf(self::shareLinkMenu())->
+				describedAs("Password protect by Talk checkbox in the details view in Files app");
 	}
 
 	/**
@@ -534,6 +555,29 @@ class FilesAppContext implements Context, ActorAwareInterface {
 				self::passwordProtectWorkingIcon(),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
 			PHPUnit_Framework_Assert::fail("The working icon for password protect is still shown after $timeout seconds");
+		}
+	}
+
+	/**
+	 * @Then I see that the link share is password protected
+	 */
+	public function iSeeThatTheLinkShareIsPasswordProtected() {
+		$this->showShareLinkMenuIfNeeded();
+
+		PHPUnit_Framework_Assert::assertTrue($this->actor->find(self::passwordProtectCheckboxInput(), 10)->isChecked(), "Password protect checkbox is checked");
+		PHPUnit_Framework_Assert::assertTrue($this->actor->find(self::passwordProtectField(), 10)->isVisible(), "Password protect field is visible");
+	}
+
+	/**
+	 * @Then I see that the checkbox to protect the password of the link share by Talk is not shown
+	 */
+	public function iSeeThatTheCheckboxToProtectThePasswordOfTheLinkShareByTalkIsNotShown() {
+		$this->showShareLinkMenuIfNeeded();
+
+		try {
+			PHPUnit_Framework_Assert::assertFalse(
+					$this->actor->find(self::passwordProtectByTalkCheckbox())->isVisible());
+		} catch (NoSuchElementException $exception) {
 		}
 	}
 

--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -314,6 +314,15 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	}
 
 	/**
+	 * @return Locator
+	 */
+	public static function passwordProtectByTalkCheckboxInput() {
+		return Locator::forThe()->checkbox("Password protect by Talk")->
+				descendantOf(self::shareLinkMenu())->
+				describedAs("Password protect by Talk checkbox input in the details view in Files app");
+	}
+
+	/**
 	 * @Given I close the details view
 	 */
 	public function iCloseTheDetailsView() {
@@ -413,6 +422,28 @@ class FilesAppContext implements Context, ActorAwareInterface {
 		$this->actor->find(self::passwordProtectCheckbox(), 2)->click();
 
 		$this->actor->find(self::passwordProtectField(), 2)->setValue($password . "\r");
+	}
+
+	/**
+	 * @When I set the password of the shared link as protected by Talk
+	 */
+	public function iSetThePasswordOfTheSharedLinkAsProtectedByTalk() {
+		$this->showShareLinkMenuIfNeeded();
+
+		$this->iSeeThatThePasswordOfTheLinkShareIsNotProtectedByTalk();
+
+		$this->actor->find(self::passwordProtectByTalkCheckbox(), 2)->click();
+	}
+
+	/**
+	 * @When I set the password of the shared link as not protected by Talk
+	 */
+	public function iSetThePasswordOfTheSharedLinkAsNotProtectedByTalk() {
+		$this->showShareLinkMenuIfNeeded();
+
+		$this->iSeeThatThePasswordOfTheLinkShareIsProtectedByTalk();
+
+		$this->actor->find(self::passwordProtectByTalkCheckbox(), 2)->click();
 	}
 
 	/**
@@ -566,6 +597,24 @@ class FilesAppContext implements Context, ActorAwareInterface {
 
 		PHPUnit_Framework_Assert::assertTrue($this->actor->find(self::passwordProtectCheckboxInput(), 10)->isChecked(), "Password protect checkbox is checked");
 		PHPUnit_Framework_Assert::assertTrue($this->actor->find(self::passwordProtectField(), 10)->isVisible(), "Password protect field is visible");
+	}
+
+	/**
+	 * @Then I see that the password of the link share is protected by Talk
+	 */
+	public function iSeeThatThePasswordOfTheLinkShareIsProtectedByTalk() {
+		$this->showShareLinkMenuIfNeeded();
+
+		PHPUnit_Framework_Assert::assertTrue($this->actor->find(self::passwordProtectByTalkCheckboxInput(), 10)->isChecked());
+	}
+
+	/**
+	 * @Then I see that the password of the link share is not protected by Talk
+	 */
+	public function iSeeThatThePasswordOfTheLinkShareIsNotProtectedByTalk() {
+		$this->showShareLinkMenuIfNeeded();
+
+		PHPUnit_Framework_Assert::assertFalse($this->actor->find(self::passwordProtectByTalkCheckboxInput(), 10)->isChecked());
 	}
 
 	/**

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -1788,6 +1788,14 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->assertSame('user4', $share2->getSharedBy());
 		$this->assertSame('user5', $share2->getShareOwner());
 		$this->assertSame(1, $share2->getPermissions());
+
+		$share2 = $this->provider->getShareById($id);
+
+		$this->assertEquals($id, $share2->getId());
+		$this->assertSame('user3', $share2->getSharedWith());
+		$this->assertSame('user4', $share2->getSharedBy());
+		$this->assertSame('user5', $share2->getShareOwner());
+		$this->assertSame(1, $share2->getPermissions());
 	}
 
 	public function testUpdateLink() {
@@ -1833,7 +1841,15 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$share2 = $this->provider->update($share);
 
 		$this->assertEquals($id, $share2->getId());
-		$this->assertEquals('password', $share->getPassword());
+		$this->assertEquals('password', $share2->getPassword());
+		$this->assertSame('user4', $share2->getSharedBy());
+		$this->assertSame('user5', $share2->getShareOwner());
+		$this->assertSame(1, $share2->getPermissions());
+
+		$share2 = $this->provider->getShareById($id);
+
+		$this->assertEquals($id, $share2->getId());
+		$this->assertEquals('password', $share2->getPassword());
 		$this->assertSame('user4', $share2->getSharedBy());
 		$this->assertSame('user5', $share2->getShareOwner());
 		$this->assertSame(1, $share2->getPermissions());
@@ -1842,6 +1858,12 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	public function testUpdateLinkRemovePassword() {
 		$id = $this->addShareToDB(\OCP\Share::SHARE_TYPE_LINK, 'foo', 'user1', 'user2',
 			'file', 42, 'target', 31, null, null);
+
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->update('share');
+		$qb->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
+		$qb->set('password', $qb->createNamedParameter('password'));
+		$this->assertEquals(1, $qb->execute());
 
 		$users = [];
 		for($i = 0; $i < 6; $i++) {
@@ -1882,7 +1904,15 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$share2 = $this->provider->update($share);
 
 		$this->assertEquals($id, $share2->getId());
-		$this->assertEquals(null, $share->getPassword());
+		$this->assertEquals(null, $share2->getPassword());
+		$this->assertSame('user4', $share2->getSharedBy());
+		$this->assertSame('user5', $share2->getShareOwner());
+		$this->assertSame(1, $share2->getPermissions());
+
+		$share2 = $this->provider->getShareById($id);
+
+		$this->assertEquals($id, $share2->getId());
+		$this->assertEquals(null, $share2->getPassword());
 		$this->assertSame('user4', $share2->getSharedBy());
 		$this->assertSame('user5', $share2->getShareOwner());
 		$this->assertSame(1, $share2->getPermissions());
@@ -1942,6 +1972,15 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$share->setPermissions(1);
 
 		$share2 = $this->provider->update($share);
+
+		$this->assertEquals($id, $share2->getId());
+		// Group shares do not allow updating the recipient
+		$this->assertSame('group0', $share2->getSharedWith());
+		$this->assertSame('user4', $share2->getSharedBy());
+		$this->assertSame('user5', $share2->getShareOwner());
+		$this->assertSame(1, $share2->getPermissions());
+
+		$share2 = $this->provider->getShareById($id);
 
 		$this->assertEquals($id, $share2->getId());
 		// Group shares do not allow updating the recipient
@@ -2011,6 +2050,15 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$share->setPermissions(1);
 
 		$share2 = $this->provider->update($share);
+
+		$this->assertEquals($id, $share2->getId());
+		// Group shares do not allow updating the recipient
+		$this->assertSame('group0', $share2->getSharedWith());
+		$this->assertSame('user4', $share2->getSharedBy());
+		$this->assertSame('user5', $share2->getShareOwner());
+		$this->assertSame(1, $share2->getPermissions());
+
+		$share2 = $this->provider->getShareById($id);
 
 		$this->assertEquals($id, $share2->getId());
 		// Group shares do not allow updating the recipient

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -363,6 +363,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->values([
 				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_LINK),
 				'password' => $qb->expr()->literal('password'),
+				'password_by_talk' => $qb->expr()->literal(true),
 				'uid_owner' => $qb->expr()->literal('shareOwner'),
 				'uid_initiator' => $qb->expr()->literal('sharedBy'),
 				'item_type'   => $qb->expr()->literal('file'),
@@ -392,6 +393,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_LINK, $share->getShareType());
 		$this->assertNull($share->getSharedWith());
 		$this->assertEquals('password', $share->getPassword());
+		$this->assertEquals(true, $share->getSendPasswordByTalk());
 		$this->assertEquals('sharedBy', $share->getSharedBy());
 		$this->assertEquals('shareOwner', $share->getShareOwner());
 		$this->assertEquals($ownerPath, $share->getNode());
@@ -775,6 +777,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$share->setNode($path);
 		$share->setPermissions(1);
 		$share->setPassword('password');
+		$share->setSendPasswordByTalk(true);
 		$share->setToken('token');
 		$expireDate = new \DateTime();
 		$share->setExpirationDate($expireDate);
@@ -792,6 +795,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->assertLessThanOrEqual(new \DateTime(), $share2->getShareTime());
 		$this->assertSame($path, $share2->getNode());
 		$this->assertSame('password', $share2->getPassword());
+		$this->assertSame(true, $share2->getSendPasswordByTalk());
 		$this->assertSame('token', $share2->getToken());
 		$this->assertEquals($expireDate->getTimestamp(), $share2->getExpirationDate()->getTimestamp());
 	}
@@ -803,6 +807,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->values([
 				'share_type'    => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_LINK),
 				'password'    => $qb->expr()->literal('password'),
+				'password_by_talk' => $qb->expr()->literal(true),
 				'uid_owner'     => $qb->expr()->literal('shareOwner'),
 				'uid_initiator' => $qb->expr()->literal('sharedBy'),
 				'item_type'     => $qb->expr()->literal('file'),
@@ -825,6 +830,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->assertSame('sharedBy', $share->getSharedBy());
 		$this->assertSame('secrettoken', $share->getToken());
 		$this->assertSame('password', $share->getPassword());
+		$this->assertSame(true, $share->getSendPasswordByTalk());
 		$this->assertSame(null, $share->getSharedWith());
 	}
 
@@ -1833,6 +1839,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$share = $this->provider->getShareById($id);
 
 		$share->setPassword('password');
+		$share->setSendPasswordByTalk(true);
 		$share->setSharedBy('user4');
 		$share->setShareOwner('user5');
 		$share->setNode($file2);
@@ -1842,6 +1849,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$this->assertEquals($id, $share2->getId());
 		$this->assertEquals('password', $share2->getPassword());
+		$this->assertSame(true, $share2->getSendPasswordByTalk());
 		$this->assertSame('user4', $share2->getSharedBy());
 		$this->assertSame('user5', $share2->getShareOwner());
 		$this->assertSame(1, $share2->getPermissions());
@@ -1850,6 +1858,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$this->assertEquals($id, $share2->getId());
 		$this->assertEquals('password', $share2->getPassword());
+		$this->assertSame(true, $share2->getSendPasswordByTalk());
 		$this->assertSame('user4', $share2->getSharedBy());
 		$this->assertSame('user5', $share2->getShareOwner());
 		$this->assertSame(1, $share2->getPermissions());


### PR DESCRIPTION
Requires nextcloud/spreed#1273

Sending the password by Nextcloud Talk for a link share behaves slightly different than [when doing it for an e-mail share](https://github.com/nextcloud/server/pull/10238). When an e-mail share is protected with a password an e-mail is sent with the password. Due to this, when the password is protected by Talk a new password must be always set; otherwise the recipient would already have the password, and thus she would not need to request it to the sharer and protecting it by Talk would be pointless.

However, in the case of link shares, just setting the password does not disclose it to anyone; the sharer must explicitly send it to someone to be known. Therefore, when protecting the password of a link share by Talk it is not mandatory to set a different password than the one set before; protecting the password by Talk in this case is an additional step to protecting the share with a password. Due to this the checkbox to protect the password by Talk is shown only when there is a password set for the link share.

![share-link-menu-no-password](https://user-images.githubusercontent.com/26858233/47579961-cd9b0d00-d94d-11e8-8af3-6a9c83d6f5f5.png)
![share-link-menu-password](https://user-images.githubusercontent.com/26858233/47579962-cf64d080-d94d-11e8-8e36-db70593c340c.png)


**Reviewers:** Although the Talk counterpart is still in development state the server part is ready for review and can be merged now even if the Talk part is not ready yet; the missing parts in Talk are just better naming of rooms and a more useful text in the notifications, but besides that it just works (or, at least, it should :-) ).
