### PR TITLE
Principal property search for users and groups with {DAV:}display name

### DIFF
--- a/apps/dav/lib/CalDAV/ResourceBooking/AbstractPrincipalBackend.php
+++ b/apps/dav/lib/CalDAV/ResourceBooking/AbstractPrincipalBackend.php
@@ -50,6 +50,9 @@ abstract class AbstractPrincipalBackend implements BackendInterface {
 	/** @var string */
 	private $dbTableName;
 
+	/** @var string */
+	private $cuType;
+
 	/**
 	 * @param IDBConnection $dbConnection
 	 * @param IUserSession $userSession
@@ -57,18 +60,22 @@ abstract class AbstractPrincipalBackend implements BackendInterface {
 	 * @param ILogger $logger
 	 * @param string $principalPrefix
 	 * @param string $dbPrefix
+	 * @param string $cuType
 	 */
 	public function __construct(IDBConnection $dbConnection,
 								IUserSession $userSession,
 								IGroupManager $groupManager,
 								ILogger $logger,
-								$principalPrefix, $dbPrefix) {
+								string $principalPrefix,
+								string $dbPrefix,
+								string $cuType) {
 		$this->db = $dbConnection;
 		$this->userSession = $userSession;
 		$this->groupManager = $groupManager;
 		$this->logger = $logger;
 		$this->principalPrefix = $principalPrefix;
 		$this->dbTableName = 'calendar_' . $dbPrefix;
+		$this->cuType = $cuType;
 	}
 
 	/**
@@ -328,7 +335,8 @@ abstract class AbstractPrincipalBackend implements BackendInterface {
 		return [
 			'uri' => $this->principalPrefix . '/' . $row['backend_id'] . '-' . $row['resource_id'],
 			'{DAV:}displayname' => $row['displayname'],
-			'{http://sabredav.org/ns}email-address' => $row['email']
+			'{http://sabredav.org/ns}email-address' => $row['email'],
+			'{urn:ietf:params:xml:ns:caldav}calendar-user-type' => $this->cuType,
 		];
 	}
 

--- a/apps/dav/lib/CalDAV/ResourceBooking/ResourcePrincipalBackend.php
+++ b/apps/dav/lib/CalDAV/ResourceBooking/ResourcePrincipalBackend.php
@@ -40,6 +40,6 @@ class ResourcePrincipalBackend extends AbstractPrincipalBackend {
 								IGroupManager $groupManager,
 								ILogger $logger) {
 		parent::__construct($dbConnection, $userSession, $groupManager, $logger,
-			'principals/calendar-resources', 'resources');
+			'principals/calendar-resources', 'resources', 'RESOURCE');
 	}
 }

--- a/apps/dav/lib/CalDAV/ResourceBooking/RoomPrincipalBackend.php
+++ b/apps/dav/lib/CalDAV/ResourceBooking/RoomPrincipalBackend.php
@@ -40,6 +40,6 @@ class RoomPrincipalBackend extends AbstractPrincipalBackend {
 								IGroupManager $groupManager,
 								ILogger $logger) {
 		parent::__construct($dbConnection, $userSession, $groupManager, $logger,
-			'principals/calendar-rooms', 'rooms');
+			'principals/calendar-rooms', 'rooms', 'ROOM');
 	}
 }

--- a/apps/dav/lib/CalDAV/Schedule/Plugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/Plugin.php
@@ -50,6 +50,31 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 	}
 
 	/**
+	 * This method handler is invoked during fetching of properties.
+	 *
+	 * We use this event to add calendar-auto-schedule-specific properties.
+	 *
+	 * @param PropFind $propFind
+	 * @param INode $node
+	 * @return void
+	 */
+	function propFind(PropFind $propFind, INode $node) {
+		// overwrite Sabre/Dav's implementation
+		$propFind->handle('{' . self::NS_CALDAV . '}calendar-user-type', function() use ($node) {
+			$calendarUserType = '{' . self::NS_CALDAV . '}calendar-user-type';
+			$props = $node->getProperties([$calendarUserType]);
+
+			if (isset($props[$calendarUserType])) {
+				return $props[$calendarUserType];
+			}
+
+			return 'INDIVIDUAL';
+		});
+
+		parent::propFind($propFind, $node);
+	}
+
+	/**
 	 * Returns a list of addresses that are associated with a principal.
 	 *
 	 * @param string $principal

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -57,7 +57,7 @@ class RootCollection extends SimpleCollection {
 			\OC::$server->getUserSession(),
 			$config
 		);
-		$groupPrincipalBackend = new GroupPrincipalBackend($groupManager);
+		$groupPrincipalBackend = new GroupPrincipalBackend($groupManager, $userSession, $shareManager, $l10n);
 		$calendarResourcePrincipalBackend = new ResourcePrincipalBackend($db, $userSession, $groupManager, $logger);
 		$calendarRoomPrincipalBackend = new RoomPrincipalBackend($db, $userSession, $groupManager, $logger);
 		// as soon as debug mode is enabled we allow listing of principals

--- a/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTest.php
@@ -53,6 +53,9 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 	/** @var string */
 	protected $principalPrefix;
 
+	/** @var string */
+	protected $expectedCUType;
+
 	public function setUp() {
 		parent::setUp();
 
@@ -127,16 +130,19 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 				'uri' => $this->principalPrefix . '/db-123',
 				'{DAV:}displayname' => 'Resource 123',
 				'{http://sabredav.org/ns}email-address' => 'foo@bar.com',
+				'{urn:ietf:params:xml:ns:caldav}calendar-user-type' => $this->expectedCUType,
 			],
 			[
 				'uri' => $this->principalPrefix . '/ldap-123',
 				'{DAV:}displayname' => 'Resource 123 ldap',
 				'{http://sabredav.org/ns}email-address' => 'ldap@bar.com',
+				'{urn:ietf:params:xml:ns:caldav}calendar-user-type' => $this->expectedCUType,
 			],
 			[
 				'uri' => $this->principalPrefix . '/db-456',
 				'{DAV:}displayname' => 'Resource 456',
 				'{http://sabredav.org/ns}email-address' => 'bli@bar.com',
+				'{urn:ietf:params:xml:ns:caldav}calendar-user-type' => $this->expectedCUType,
 			],
 		], $actual);
 
@@ -209,6 +215,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 			'uri' => $this->principalPrefix . '/db-123',
 			'{DAV:}displayname' => 'Resource 123',
 			'{http://sabredav.org/ns}email-address' => 'foo@bar.com',
+			'{urn:ietf:params:xml:ns:caldav}calendar-user-type' => $this->expectedCUType,
 		], $actual);
 	}
 

--- a/apps/dav/tests/unit/CalDAV/ResourceBooking/ResourcePrincipalBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/ResourceBooking/ResourcePrincipalBackendTest.php
@@ -31,5 +31,6 @@ Class ResourcePrincipalBackendTest extends AbstractPrincipalBackendTest {
 			$this->userSession, $this->groupManager, $this->logger);
 		$this->expectedDbTable = 'calendar_resources';
 		$this->principalPrefix = 'principals/calendar-resources';
+		$this->expectedCUType = 'RESOURCE';
 	}
 }

--- a/apps/dav/tests/unit/CalDAV/ResourceBooking/RoomPrincipalBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/ResourceBooking/RoomPrincipalBackendTest.php
@@ -31,5 +31,6 @@ Class RoomPrincipalBackendTest extends AbstractPrincipalBackendTest {
 			$this->userSession, $this->groupManager, $this->logger);
 		$this->expectedDbTable = 'calendar_rooms';
 		$this->principalPrefix = 'principals/calendar-rooms';
+		$this->expectedCUType = 'ROOM';
 	}
 }

--- a/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
@@ -1,12 +1,14 @@
 <?php
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @copyright Copyright (c) 2018, Georg Ehrke
  *
  * @author Joas Schilling <coding@schilljs.com>
  * @author Lukas Reschke <lukas@statuscode.ch>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Vincent Petry <pvince81@owncloud.com>
+ * @author Georg Ehrke <oc.list@georgehrke.com>
  *
  * @license AGPL-3.0
  *
@@ -38,16 +40,22 @@ use OCP\IUserManager;
 use Test\TestCase;
 
 class PrincipalTest extends TestCase {
+
 	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
 	private $userManager;
+
 	/** @var \OCA\DAV\Connector\Sabre\Principal */
 	private $connector;
+
 	/** @var IGroupManager | \PHPUnit_Framework_MockObject_MockObject */
 	private $groupManager;
+
 	/** @var IManager | \PHPUnit_Framework_MockObject_MockObject */
 	private $shareManager;
+
 	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject */
 	private $userSession;
+
 	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject  */
 	private $config;
 
@@ -94,7 +102,7 @@ class PrincipalTest extends TestCase {
 		$barUser
 				->expects($this->exactly(1))
 				->method('getEMailAddress')
-				->will($this->returnValue('bar@owncloud.org'));
+				->will($this->returnValue('bar@nextcloud.com'));
 		$this->userManager
 			->expects($this->once())
 			->method('search')
@@ -104,12 +112,14 @@ class PrincipalTest extends TestCase {
 		$expectedResponse = [
 			0 => [
 				'uri' => 'principals/users/foo',
-				'{DAV:}displayname' => 'Dr. Foo-Bar'
+				'{DAV:}displayname' => 'Dr. Foo-Bar',
+				'{urn:ietf:params:xml:ns:caldav}calendar-user-type' => 'INDIVIDUAL',
 			],
 			1 => [
 				'uri' => 'principals/users/bar',
 				'{DAV:}displayname' => 'bar',
-				'{http://sabredav.org/ns}email-address' => 'bar@owncloud.org'
+				'{urn:ietf:params:xml:ns:caldav}calendar-user-type' => 'INDIVIDUAL',
+				'{http://sabredav.org/ns}email-address' => 'bar@nextcloud.com',
 			]
 		];
 		$response = $this->connector->getPrincipalsByPrefix('principals/users');
@@ -141,7 +151,8 @@ class PrincipalTest extends TestCase {
 
 		$expectedResponse = [
 			'uri' => 'principals/users/foo',
-			'{DAV:}displayname' => 'foo'
+			'{DAV:}displayname' => 'foo',
+			'{urn:ietf:params:xml:ns:caldav}calendar-user-type' => 'INDIVIDUAL',
 		];
 		$response = $this->connector->getPrincipalByPath('principals/users/foo');
 		$this->assertSame($expectedResponse, $response);
@@ -152,7 +163,7 @@ class PrincipalTest extends TestCase {
 		$fooUser
 				->expects($this->exactly(1))
 				->method('getEMailAddress')
-				->will($this->returnValue('foo@owncloud.org'));
+				->will($this->returnValue('foo@nextcloud.com'));
 		$fooUser
 				->expects($this->exactly(1))
 				->method('getUID')
@@ -166,7 +177,8 @@ class PrincipalTest extends TestCase {
 		$expectedResponse = [
 			'uri' => 'principals/users/foo',
 			'{DAV:}displayname' => 'foo',
-			'{http://sabredav.org/ns}email-address' => 'foo@owncloud.org'
+			'{urn:ietf:params:xml:ns:caldav}calendar-user-type' => 'INDIVIDUAL',
+			'{http://sabredav.org/ns}email-address' => 'foo@nextcloud.com',
 		];
 		$response = $this->connector->getPrincipalByPath('principals/users/foo');
 		$this->assertSame($expectedResponse, $response);
@@ -283,7 +295,7 @@ class PrincipalTest extends TestCase {
 	/**
 	 * @dataProvider searchPrincipalsDataProvider
 	 */
-	public function testSearchPrincipals($sharingEnabled, $groupsOnly, $result) {
+	public function testSearchPrincipals($sharingEnabled, $groupsOnly, $test, $result) {
 		$this->shareManager->expects($this->once())
 			->method('shareAPIEnabled')
 			->will($this->returnValue($sharingEnabled));
@@ -302,7 +314,7 @@ class PrincipalTest extends TestCase {
 				$this->groupManager->expects($this->at(0))
 					->method('getUserGroupIds')
 					->with($user)
-					->will($this->returnValue(['group1', 'group2']));
+					->will($this->returnValue(['group1', 'group2', 'group5']));
 			}
 		} else {
 			$this->shareManager->expects($this->never())
@@ -315,15 +327,25 @@ class PrincipalTest extends TestCase {
 		$user2->method('getUID')->will($this->returnValue('user2'));
 		$user3 = $this->createMock(IUser::class);
 		$user3->method('getUID')->will($this->returnValue('user3'));
+		$user4 = $this->createMock(IUser::class);
+		$user4->method('getUID')->will($this->returnValue('user4'));
 
 		if ($sharingEnabled) {
 			$this->userManager->expects($this->at(0))
 				->method('getByEmail')
-				->with('user')
+				->with('user@example.com')
 				->will($this->returnValue([$user2, $user3]));
+
+			$this->userManager->expects($this->at(1))
+				->method('searchDisplayName')
+				->with('User 12')
+				->will($this->returnValue([$user3, $user4]));
 		} else {
 			$this->userManager->expects($this->never())
 				->method('getByEmail');
+
+			$this->userManager->expects($this->never())
+				->method('searchDisplayName');
 		}
 
 		if ($sharingEnabled && $groupsOnly) {
@@ -335,18 +357,30 @@ class PrincipalTest extends TestCase {
 				->method('getUserGroupIds')
 				->with($user3)
 				->will($this->returnValue(['group3', 'group4']));
+			$this->groupManager->expects($this->at(3))
+				->method('getUserGroupIds')
+				->with($user3)
+				->will($this->returnValue(['group3', 'group4']));
+			$this->groupManager->expects($this->at(4))
+				->method('getUserGroupIds')
+				->with($user4)
+				->will($this->returnValue(['group4', 'group5']));
 		}
 
 
 		$this->assertEquals($result, $this->connector->searchPrincipals('principals/users',
-			['{http://sabredav.org/ns}email-address' => 'user']));
+			['{http://sabredav.org/ns}email-address' => 'user@example.com',
+				'{DAV:}displayname' => 'User 12'], $test));
 	}
 
 	public function searchPrincipalsDataProvider() {
 		return [
-			[true, false, ['principals/users/user2', 'principals/users/user3']],
-			[true, true, ['principals/users/user2']],
-			[false, false, []],
+			[true, false, 'allof', ['principals/users/user3']],
+			[true, false, 'anyof', ['principals/users/user2', 'principals/users/user3', 'principals/users/user4']],
+			[true, true, 'allof', []],
+			[true, true, 'anyof', ['principals/users/user2', 'principals/users/user4']],
+			[false, false, 'allof', []],
+			[false, false, 'anyof', []],
 		];
 	}
 


### PR DESCRIPTION
## What does this pull-request introduce:
- proper calendar-user-type reporting for principals
- allow to search for users by their displayname
- allow to search for groups by their display name
- append localised `(group)` to displayname of group. (I can also remove this again if not wanted)

## What do i need this for?
- I need this for implementing a proper `principal-property-search` in the [c-dav library](https://github.com/nextcloud/cdav-library/pull/25/files?utf8=✓&diff=unified#diff-1fdf421c05c1140f6d71444ea2b27638R207)
- I need this for the attendee / resource search in the calendar app
- This will later on allow sharing calendars straight from macOS' calendar with a user's displayname

## Privacy considerations
- All implementations take the sharing API rules into consideration.
  - If sharing API is disabled, principal property search will always return empty list
  - If sharing API is restricted to groups, only groups / users from the same group are returned

=> This change will not provide more information than already provided by the OCS Share API

@MorrisJobke @rullzer @nickvergessen Any opinion on this change? 