### PR TITLE
Remove replace call which does not replace anything

### DIFF
--- a/apps/theming/js/settings-admin.js
+++ b/apps/theming/js/settings-admin.js
@@ -43,7 +43,7 @@ function preview(setting, value, serverCssUrl) {
 	var reloadStylesheets = function(cssFile) {
 		var queryString = '?reload=' + new Date().getTime();
 		var url = cssFile + queryString;
-		var old = $('link[href*="' + cssFile.replace("/","\/") + '"]');
+		var old = $('link[href*="' + cssFile + '"]');
 		var stylesheet = $("<link/>", {
 			rel: "stylesheet",
 			type: "text/css",


### PR DESCRIPTION
The original code replaced / by /.

Signed-off-by: Stefan Weil <sw@weilnetz.de>