### PR TITLE
Migrate Scrutinizer to new PHP Analysis

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,13 @@
 before_commands:
   - 'git submodule update --init --recursive'
 
+build:
+    nodes:
+        analysis:
+            tests:
+                override:
+                    - php-scrutinizer-run
+
 checks:
     php:
         excluded_dependencies:


### PR DESCRIPTION
See this article for details:
https://scrutinizer-ci.com/docs/tools/php/php-analyzer/guides/migrate_to_new_php_analysis

Signed-off-by: Stefan Weil <sw@weilnetz.de>