### PR TITLE
Remove unreliable 2FA state message on personal 2FA settings page

### DIFF
--- a/lib/private/Settings/Personal/Security.php
+++ b/lib/private/Settings/Personal/Security.php
@@ -106,7 +106,6 @@ class Security implements ISettings {
 		}
 
 		return [
-			'isEnabled' => $this->twoFactorManager->isTwoFactorAuthenticated($user),
 			'providers' => array_map(function (IProvidesPersonalSettings $provider) use ($user) {
 				return [
 					'provider' => $provider,

--- a/settings/templates/settings/personal/security.php
+++ b/settings/templates/settings/personal/security.php
@@ -104,15 +104,6 @@ if($_['passwordChangeSupported']) {
 
 <div id="two-factor-auth" class="section">
 	<h2><?php p($l->t('Two-Factor Authentication'));?></h2>
-	<p class="settings-hint">
-		<?php
-		if ($_['twoFactorProviderData']['enabled']) {
-			p($l->t('Two-factor authentication is enabled on your account.'));
-		} else {
-			p($l->t('Two-factor authentication is disabled on your account.'));
-		}
-		?>
-	</p>
 	<ul>
 	<?php foreach ($_['twoFactorProviderData']['providers'] as $data) { ?>
 		<li>


### PR DESCRIPTION
Regardless of the bug that the template should read the array key `isEnabled`, we should remove this message as it currently isn't reactive to changes of provider states, hence giving a wrong impression that enabling/disabling a provider wouldn't update the 2FA state.

This message was added when I started the consolidated personal 2FA settings and I forgot to remove it afterwards.