### PR TITLE
Add report-uri to CSP

### DIFF
--- a/lib/private/Security/CSP/ContentSecurityPolicy.php
+++ b/lib/private/Security/CSP/ContentSecurityPolicy.php
@@ -223,4 +223,12 @@ class ContentSecurityPolicy extends \OCP\AppFramework\Http\ContentSecurityPolicy
 		$this->allowedWorkerSrcDomains = $allowedWorkerSrcDomains;
 	}
 
+	public function getReportTo(): array {
+		return $this->reportTo;
+	}
+
+	public function setReportTo(array $reportTo) {
+		$this->reportTo = $reportTo;
+	}
+
 }

--- a/lib/public/AppFramework/Http/ContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/ContentSecurityPolicy.php
@@ -90,4 +90,7 @@ class ContentSecurityPolicy extends EmptyContentSecurityPolicy {
 
 	/** @var array Domains from which web-workers can be loaded */
 	protected $allowedWorkerSrcDomains = [];
+
+	/** @var array Locations to report violations to */
+	protected $reportTo = [];
 }

--- a/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
@@ -76,6 +76,9 @@ class EmptyContentSecurityPolicy {
 	/** @var array Domains from which web-workers can be loaded */
 	protected $allowedWorkerSrcDomains = null;
 
+	/** @var array Locations to report violations to */
+	protected $reportTo = null;
+
 	/**
 	 * Whether inline JavaScript snippets are allowed or forbidden
 	 * @param bool $state
@@ -384,6 +387,18 @@ class EmptyContentSecurityPolicy {
 	}
 
 	/**
+	 * Add location to report CSP violations to
+	 *
+	 * @param string $location
+	 * @return $this
+	 * @since 15.0.0
+	 */
+	public function addReportTo(string $location) {
+		$this->reportTo[] = $location;
+		return $this;
+	}
+
+	/**
 	 * Get the generated Content-Security-Policy as a string
 	 * @return string
 	 * @since 8.1.0
@@ -469,6 +484,11 @@ class EmptyContentSecurityPolicy {
 
 		if (!empty($this->allowedWorkerSrcDomains)) {
 			$policy .= 'worker-src ' . implode(' ', $this->allowedWorkerSrcDomains);
+			$policy .= ';';
+		}
+
+		if (!empty($this->reportTo)) {
+			$policy .= 'report-uri ' . implode(' ', $this->reportTo);
 			$policy .= ';';
 		}
 

--- a/tests/lib/AppFramework/Http/EmptyContentSecurityPolicyTest.php
+++ b/tests/lib/AppFramework/Http/EmptyContentSecurityPolicyTest.php
@@ -451,4 +451,19 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 		$this->contentSecurityPolicy->addAllowedScriptDomain("'self'");
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
+
+	public function testGetPolicyWithReportUri() {
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';report-uri https://my-report-uri.com";
+
+		$this->contentSecurityPolicy->addReportTo("https://my-report-uri.com");
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
+
+	public function testGetPolicyWithMultipleReportUri() {
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';report-uri https://my-report-uri.com https://my-other-report-uri.com";
+
+		$this->contentSecurityPolicy->addReportTo("https://my-report-uri.com");
+		$this->contentSecurityPolicy->addReportTo("https://my-other-report-uri.com");
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
 }


### PR DESCRIPTION
Allows us to add a report-uri to the CSP header.
This gives browsers a place to report CSP violationg to.

The usage will be a small app where admins can configure where the reports have to be send to.