### PR TITLE
Add missing semicolons

### DIFF
--- a/apps/files/js/detailsview.js
+++ b/apps/files/js/detailsview.js
@@ -102,7 +102,7 @@
 				this.$el.insertAfter($('#app-content'));
 			} else {
 				if ($appSidebar[0] !== this.el) {
-					$appSidebar.replaceWith(this.$el)
+					$appSidebar.replaceWith(this.$el);
 				}
 			}
 			

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -310,10 +310,10 @@
 				breadcrumbOptions.onDrop = _.bind(this._onDropOnBreadCrumb, this);
 				breadcrumbOptions.onOver = function() {
 					self.$el.find('td.filename.ui-droppable').droppable('disable');
-				}
+				};
 				breadcrumbOptions.onOut = function() {
 					self.$el.find('td.filename.ui-droppable').droppable('enable');
-				}
+				};
 			}
 			this.breadcrumb = new OCA.Files.BreadCrumb(breadcrumbOptions);
 

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -232,7 +232,7 @@
 					promises.push($.ajax(remoteShares));
 				}
 				if (this._isOverview) {
-					shares.data.shared_with_me = !shares.data.shared_with_me
+					shares.data.shared_with_me = !shares.data.shared_with_me;
 					promises.push($.ajax(shares));
 				}
 			}

--- a/apps/user_ldap/js/wizard/wizardTabAbstractFilter.js
+++ b/apps/user_ldap/js/wizard/wizardTabAbstractFilter.js
@@ -302,7 +302,7 @@ OCA = OCA || {};
 				if(    !view.getFilterItem().$element.val()
 					&& view.parsedFilterMode === view.configModel.FILTER_MODE_ASSISTED
 				) {
-					view.configModel.requestWizard(view.getFilterItem().keyName)
+					view.configModel.requestWizard(view.getFilterItem().keyName);
 				}
 			} else if (payload.feature === view.getGroupsItem().featureName) {
 				if(view.manyGroupsSupport && payload.data.length > view._groupElementSwitchThreshold) {

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -114,7 +114,7 @@
 			});
 			clipboard.on('error', function (e) {
 				var $menu = $(e.trigger);
-				var $linkTextMenu = $menu.parent().next('li.linkTextMenu')
+				var $linkTextMenu = $menu.parent().next('li.linkTextMenu');
 				var $input = $linkTextMenu.find('.linkText');
 
 				var actionMsg = '';
@@ -393,8 +393,8 @@
 
 			var isLinkShare = this.model.get('linkShare').isLinkShare;
 			var isPasswordSet = !!this.model.get('linkShare').password;
-			var isPasswordEnforced = this.configModel.get('enforcePasswordForPublicLink')
-			var isPasswordEnabledByDefault = this.configModel.get('enableLinkPasswordByDefault') === true
+			var isPasswordEnforced = this.configModel.get('enforcePasswordForPublicLink');
+			var isPasswordEnabledByDefault = this.configModel.get('enableLinkPasswordByDefault') === true;
 			var showPasswordCheckBox = isLinkShare
 				&& (   !this.configModel.get('enforcePasswordForPublicLink')
 					|| !this.model.get('linkShare').password);


### PR DESCRIPTION
This fixes some recommendations from LGTM:

    Avoid automated semicolon insertion (90% of all statements
    in the enclosing function have an explicit semicolon).

Signed-off-by: Stefan Weil <sw@weilnetz.de>