### PR TITLE
Fix use of undeclared variable

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -3172,9 +3172,9 @@
 			 * update counter when uploading to sub folder
 			 */
 			uploader.on('done', function(e, upload) {
+				var data = upload.data;
 				self._uploader.log('filelist handle fileuploaddone', e, data);
 
-				var data = upload.data;
 				var status = data.jqXHR.status;
 				if (status < 200 || status >= 300) {
 					// error was handled in OC.Uploads already


### PR DESCRIPTION
This fixes a warning from LGTM:

    Variable 'data' is used before its declaration.

Signed-off-by: Stefan Weil <sw@weilnetz.de>