### PR TITLE
Adjust design of maintenance mode page

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -607,6 +607,10 @@ form #selectDbType label.ui-state-active {
 	width: initial;
 }
 
+.body-login-container p:not(:last-child) {
+    margin-bottom: 12px;
+}
+
 .warning.updateAnyways {
 	text-align: center;
 }

--- a/core/templates/update.user.php
+++ b/core/templates/update.user.php
@@ -1,8 +1,6 @@
-<ul>
-	<li class='update'>
-		<?php p($l->t('This %s instance is currently in maintenance mode, which may take a while.', array($theme->getName()))) ?><br><br>
-		<?php p($l->t('This page will refresh itself when the %s instance is available again.', array($theme->getName()))) ?><br><br>
-		<?php p($l->t('Contact your system administrator if this message persists or appeared unexpectedly.')) ?><br><br>
-		<?php p($l->t('Thank you for your patience.')); ?><br><br>
-	</li>
-</ul>
+<div class="body-login-container">
+	<div class="icon-big icon-error-white"></div>
+	<h2><?php p($l->t('Maintenance mode', array($theme->getName()))) ?></h2>
+	<p><?php p($l->t('This %s instance is currently in maintenance mode, which may take a while.', array($theme->getName()))) ?> <?php p($l->t('This page will refresh itself when the instance is available again.')) ?></p>
+	<p><?php p($l->t('Contact your system administrator if this message persists or appeared unexpectedly.')) ?></p>
+</div>


### PR DESCRIPTION
Before:
![maintenance mode](https://user-images.githubusercontent.com/925062/47224843-d83d2b80-d3bc-11e8-9707-3b44c32d3a91.png)

After:
![screenshot from 2018-10-19 16-31-03](https://user-images.githubusercontent.com/925062/47224841-d83d2b80-d3bc-11e8-8556-712d3c469452.png)

Any wording enhancements are welcome. cc @MariusBluem maybe?

Please review @nextcloud/designers 