### PR TITLE
Use the defined func()->count() instead of manual counting

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -213,7 +213,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	public function getCalendarsForUserCount($principalUri, $excludeBirthday = true) {
 		$principalUri = $this->convertPrincipal($principalUri, true);
 		$query = $this->db->getQueryBuilder();
-		$query->select($query->createFunction('COUNT(*)'))
+		$query->select($query->func()->count('*'))
 			->from('calendars')
 			->where($query->expr()->eq('principaluri', $query->createNamedParameter($principalUri)));
 
@@ -1045,7 +1045,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$extraData = $this->getDenormalizedData($calendarData);
 
 		$q = $this->db->getQueryBuilder();
-		$q->select($q->createFunction('COUNT(*)'))
+		$q->select($q->func()->count('*'))
 			->from('calendarobjects')
 			->where($q->expr()->eq('calendarid', $q->createNamedParameter($calendarId)))
 			->andWhere($q->expr()->eq('uid', $q->createNamedParameter($extraData['uid'])))

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -117,7 +117,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	public function getAddressBooksForUserCount($principalUri) {
 		$principalUri = $this->convertPrincipal($principalUri, true);
 		$query = $this->db->getQueryBuilder();
-		$query->select($query->createFunction('COUNT(*)'))
+		$query->select($query->func()->count('*'))
 			->from('addressbooks')
 			->where($query->expr()->eq('principaluri', $query->createNamedParameter($principalUri)));
 

--- a/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
+++ b/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
@@ -98,7 +98,7 @@ class CleanupRemoteStorages extends Command {
 
 	public function countFiles($numericId, OutputInterface $output) {
 		$queryBuilder = $this->connection->getQueryBuilder();
-		$queryBuilder->select($queryBuilder->createFunction('COUNT(' . $queryBuilder->getColumnName('fileid') . ')'))
+		$queryBuilder->select($queryBuilder->func()->count('fileid'))
 			->from('filecache')
 			->where($queryBuilder->expr()->eq(
 				'storage',

--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -311,7 +311,7 @@ abstract class AbstractMapping {
 	 */
 	public function count() {
 		$qb = $this->dbc->getQueryBuilder();
-		$query = $qb->select($qb->createFunction('COUNT(' . $qb->getColumnName('ldap_dn') . ')'))
+		$query = $qb->select($qb->func()->count('ldap_dn'))
 			->from($this->getTableName());
 		$res = $query->execute();
 		$count = $res->fetchColumn();

--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -301,7 +301,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 
 		$query = $fromDB->getQueryBuilder();
 		$query->automaticTablePrefix(false);
-		$query->selectAlias($query->createFunction('COUNT(*)'), 'num_entries')
+		$query->select($query->func()->count('*', 'num_entries'))
 			->from($table->getName());
 		$result = $query->execute();
 		$count = $result->fetchColumn();

--- a/lib/base.php
+++ b/lib/base.php
@@ -312,7 +312,7 @@ class OC {
 			if ($apps->isInstalled('user_ldap')) {
 				$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
 
-				$result = $qb->selectAlias($qb->createFunction('COUNT(*)'), 'user_count')
+				$result = $qb->select($qb->func()->count('*', 'user_count'))
 					->from('ldap_user_mapping')
 					->execute();
 				$row = $result->fetch();
@@ -323,7 +323,7 @@ class OC {
 			if (!$tooBig && $apps->isInstalled('user_saml')) {
 				$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
 
-				$result = $qb->selectAlias($qb->createFunction('COUNT(*)'), 'user_count')
+				$result = $qb->select($qb->func()->count('*', 'user_count'))
 					->from('user_saml_users')
 					->execute();
 				$row = $result->fetch();

--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -163,7 +163,7 @@ class Manager implements ICommentsManager {
 	 */
 	protected function updateChildrenInformation($id, \DateTime $cDateTime) {
 		$qb = $this->dbConn->getQueryBuilder();
-		$query = $qb->select($qb->createFunction('COUNT(' . $qb->getColumnName('id') . ')'))
+		$query = $qb->select($qb->func()->count('id'))
 			->from('comments')
 			->where($qb->expr()->eq('parent_id', $qb->createParameter('id')))
 			->setParameter('id', $id);
@@ -552,7 +552,7 @@ class Manager implements ICommentsManager {
 	 */
 	public function getNumberOfCommentsForObject($objectType, $objectId, \DateTime $notOlderThan = null, $verb = '') {
 		$qb = $this->dbConn->getQueryBuilder();
-		$query = $qb->select($qb->createFunction('COUNT(' . $qb->getColumnName('id') . ')'))
+		$query = $qb->select($qb->func()->count('id'))
 			->from('comments')
 			->where($qb->expr()->eq('object_type', $qb->createParameter('type')))
 			->andWhere($qb->expr()->eq('object_id', $qb->createParameter('id')))
@@ -585,10 +585,7 @@ class Manager implements ICommentsManager {
 	public function getNumberOfUnreadCommentsForFolder($folderId, IUser $user) {
 		$qb = $this->dbConn->getQueryBuilder();
 		$query = $qb->select('f.fileid')
-			->selectAlias(
-				$qb->createFunction('COUNT(' . $qb->getColumnName('c.id') . ')'),
-				'num_ids'
-			)
+			->addSelect($qb->func()->count('c.id', 'num_ids'))
 			->from('comments', 'c')
 			->innerJoin('c', 'filecache', 'f', $qb->expr()->andX(
 				$qb->expr()->eq('c.object_type', $qb->createNamedParameter('files')),

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
@@ -72,7 +72,8 @@ class FunctionBuilder implements IFunctionBuilder {
 		return new QueryFunction($this->helper->quoteColumnName($x) . ' - ' . $this->helper->quoteColumnName($y));
 	}
 
-	public function count($input) {
-		return new QueryFunction('COUNT(' . $this->helper->quoteColumnName($input) . ')');
+	public function count($count, $alias = '') {
+		$alias = $alias ? (' AS ' . $this->helper->quoteColumnName($alias)) : '';
+		return new QueryFunction('COUNT(' . $this->helper->quoteColumnName($count) . ')' . $alias);
 	}
 }

--- a/lib/private/Files/Cache/Propagator.php
+++ b/lib/private/Files/Cache/Propagator.php
@@ -82,7 +82,7 @@ class Propagator implements IPropagator {
 		}, $parentHashes);
 
 		$builder->update('filecache')
-			->set('mtime', $builder->createFunction('GREATEST(`mtime`, ' . $builder->createNamedParameter((int)$time, IQueryBuilder::PARAM_INT) . ')'))
+			->set('mtime', $builder->createFunction('GREATEST(' . $builder->getColumnName('mtime') . ', ' . $builder->createNamedParameter((int)$time, IQueryBuilder::PARAM_INT) . ')'))
 			->set('etag', $builder->createNamedParameter($etag, IQueryBuilder::PARAM_STR))
 			->where($builder->expr()->eq('storage', $builder->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
 			->andWhere($builder->expr()->in('path_hash', $hashParams));
@@ -93,7 +93,7 @@ class Propagator implements IPropagator {
 			// we need to do size separably so we can ignore entries with uncalculated size
 			$builder = $this->connection->getQueryBuilder();
 			$builder->update('filecache')
-				->set('size', $builder->createFunction('`size` + ' . $builder->createNamedParameter($sizeDifference)))
+				->set('size', $builder->func()->add('size', $builder->createNamedParameter($sizeDifference)))
 				->where($builder->expr()->eq('storage', $builder->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
 				->andWhere($builder->expr()->in('path_hash', $hashParams))
 				->andWhere($builder->expr()->gt('size', $builder->expr()->literal(-1, IQueryBuilder::PARAM_INT)));
@@ -156,14 +156,14 @@ class Propagator implements IPropagator {
 		$storageId = (int)$this->storage->getStorageCache()->getNumericId();
 
 		$query->update('filecache')
-			->set('mtime', $query->createFunction('GREATEST(`mtime`, ' . $query->createParameter('time') . ')'))
+			->set('mtime', $query->createFunction('GREATEST(' . $query->getColumnName('mtime') . ', ' . $query->createParameter('time') . ')'))
 			->set('etag', $query->expr()->literal(uniqid()))
 			->where($query->expr()->eq('storage', $query->expr()->literal($storageId, IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->eq('path_hash', $query->createParameter('hash')));
 
 		$sizeQuery = $this->connection->getQueryBuilder();
 		$sizeQuery->update('filecache')
-			->set('size', $sizeQuery->createFunction('`size` + ' . $sizeQuery->createParameter('size')))
+			->set('size', $sizeQuery->func()->add('size', $sizeQuery->createParameter('size')))
 			->where($query->expr()->eq('storage', $query->expr()->literal($storageId, IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->eq('path_hash', $query->createParameter('hash')))
 			->andWhere($sizeQuery->expr()->gt('size', $sizeQuery->expr()->literal(-1, IQueryBuilder::PARAM_INT)));

--- a/lib/private/Files/Type/Loader.php
+++ b/lib/private/Files/Type/Loader.php
@@ -169,7 +169,7 @@ class Loader implements IMimeTypeLoader {
 				'mimetype', $update->createNamedParameter($folderMimeTypeId)
 			))
 			->andWhere($update->expr()->like(
-				$update->createFunction('LOWER(' . $update->getColumnName('name') . ')'),
+				$update->func()->lower('name'),
 				$update->createNamedParameter('%' . $this->dbConnection->escapeLikeParameter('.' . $ext))
 			));
 		return $update->execute();

--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -354,7 +354,7 @@ class Database extends ABackend
 		$this->fixDI();
 
 		$query = $this->dbConn->getQueryBuilder();
-		$query->selectAlias($query->createFunction('COUNT(*)'), 'num_users')
+		$query->select($query->func()->count('*', 'num_users'))
 			->from('group_user')
 			->where($query->expr()->eq('gid', $query->createNamedParameter($gid)));
 

--- a/lib/private/Lock/DBLockingProvider.php
+++ b/lib/private/Lock/DBLockingProvider.php
@@ -303,7 +303,7 @@ class DBLockingProvider extends AbstractLockingProvider {
 			$builder = $this->connection->getQueryBuilder();
 
 			$query = $builder->update('file_locks')
-				->set('lock', $builder->createFunction('`lock` -1'))
+				->set('lock', $builder->func()->subtract('lock', $builder->expr()->literal(1)))
 				->where($builder->expr()->in('key', $builder->createNamedParameter($chunk, IQueryBuilder::PARAM_STR_ARRAY)))
 				->andWhere($builder->expr()->gt('lock', new Literal(0)));
 

--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -217,7 +217,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 			$query->select('*')
 				->setMaxResults(1);
 		} else {
-			$query->select($query->createFunction('COUNT(1)'));
+			$query->select($query->func()->count($query->expr()->literal(1)));
 		}
 
 		$query->from(self::RELATION_TABLE)

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -446,7 +446,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	 */
 	public function countDisabledUsers(): int {
 		$queryBuilder = \OC::$server->getDatabaseConnection()->getQueryBuilder();
-		$queryBuilder->select($queryBuilder->createFunction('COUNT(*)'))
+		$queryBuilder->select($queryBuilder->func()->count('*'))
 			->from('preferences')
 			->where($queryBuilder->expr()->eq('appid', $queryBuilder->createNamedParameter('core')))
 			->andWhere($queryBuilder->expr()->eq('configkey', $queryBuilder->createNamedParameter('enabled')))
@@ -504,7 +504,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	 */
 	public function countSeenUsers() {
 		$queryBuilder = \OC::$server->getDatabaseConnection()->getQueryBuilder();
-		$queryBuilder->select($queryBuilder->createFunction('COUNT(*)'))
+		$queryBuilder->select($queryBuilder->func()->count('*'))
 			->from('preferences')
 			->where($queryBuilder->expr()->eq('appid', $queryBuilder->createNamedParameter('login')))
 			->andWhere($queryBuilder->expr()->eq('configkey', $queryBuilder->createNamedParameter('lastLogin')))

--- a/lib/public/DB/QueryBuilder/IFunctionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IFunctionBuilder.php
@@ -98,10 +98,11 @@ interface IFunctionBuilder {
 	public function subtract($x, $y);
 
 	/**
-	 * @param mixed $input The input to be counted
+	 * @param mixed $count The input to be counted
+	 * @param string $alias Alias for the counter
 	 *
 	 * @return IQueryFunction
 	 * @since 14.0.0
 	 */
-	public function count($input);
+	public function count($count, $alias = '');
 }

--- a/tests/lib/Authentication/Token/DefaultTokenMapperTest.php
+++ b/tests/lib/Authentication/Token/DefaultTokenMapperTest.php
@@ -93,7 +93,7 @@ class DefaultTokenMapperTest extends TestCase {
 
 	private function getNumberOfTokens() {
 		$qb = $this->dbConnection->getQueryBuilder();
-		$result = $qb->select($qb->createFunction('count(*) as `count`'))
+		$result = $qb->select($qb->func()->count('*', 'count'))
 			->from('authtoken')
 			->execute()
 			->fetch();

--- a/tests/lib/Authentication/Token/PublicKeyTokenMapperTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenMapperTest.php
@@ -117,7 +117,7 @@ class PublicKeyTokenMapperTest extends TestCase {
 
 	private function getNumberOfTokens() {
 		$qb = $this->dbConnection->getQueryBuilder();
-		$result = $qb->select($qb->createFunction('count(*) as `count`'))
+		$result = $qb->select($qb->func()->count('*', 'count'))
 			->from('authtoken')
 			->execute()
 			->fetch();

--- a/tests/lib/DB/QueryBuilder/ExpressionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/ExpressionBuilderTest.php
@@ -400,7 +400,7 @@ class ExpressionBuilderTest extends TestCase {
 		$this->createConfig($appId, 11, 'underscore');
 
 		$query = $this->connection->getQueryBuilder();
-		$query->select($query->createFunction('COUNT(*) AS `count`'))
+		$query->select($query->func()->count('*', 'count'))
 			->from('appconfig')
 			->where($query->expr()->eq('appid', $query->createNamedParameter($appId)))
 			->andWhere(call_user_func([$query->expr(), $function], 'configvalue', $query->createNamedParameter($value, $type), IQueryBuilder::PARAM_STR));

--- a/tests/lib/Repair/CleanTagsTest.php
+++ b/tests/lib/Repair/CleanTagsTest.php
@@ -117,7 +117,7 @@ class CleanTagsTest extends \Test\TestCase {
 	 */
 	protected function assertEntryCount($tableName, $expected, $message = '') {
 		$qb = $this->connection->getQueryBuilder();
-		$result = $qb->select($qb->createFunction('COUNT(*)'))
+		$result = $qb->select($qb->func()->count('*'))
 			->from($tableName)
 			->execute();
 

--- a/tests/lib/Repair/RemoveRootSharesTest.php
+++ b/tests/lib/Repair/RemoveRootSharesTest.php
@@ -180,7 +180,7 @@ class RemoveRootSharesTest extends \Test\TestCase {
 
 		//Verify
 		$qb = $this->connection->getQueryBuilder();
-		$qb->selectAlias($qb->createFunction('COUNT(*)'), 'count')
+		$qb->select($qb->func()->count('*', 'count'))
 			->from('share');
 
 		$cursor = $qb->execute();


### PR DESCRIPTION
Now there are only 2 "functions" left which are both called twice and don't have a wrapper:
* GREATEST
* COUNT(DISTINCT …)

Not sure if it's worth the effort.