### PR TITLE
Selecting files inside search results produces wrong download link

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -805,13 +805,9 @@
 			var self = this;
 			var dir = this.getCurrentDirectory();
 
-			if (this.isAllSelected() && this.getSelectedFiles().length > 1) {
-				files = OC.basename(dir);
-				dir = OC.dirname(dir) || '/';
-			}
-			else {
-				files = _.pluck(this.getSelectedFiles(), 'name');
-			}
+			// TODO: condition if a whole directory should be downloaded or a search result
+			// could maybe be set by _onClickSelectAll
+			files = _.pluck(this.getSelectedFiles(), 'name');
 
 			// don't allow a second click on the download action
 			if(this.fileMultiSelectMenu.isDisabled('download')) {


### PR DESCRIPTION
regarding Issues #1274 and #2075

The method isAllSelected() in filelist.js returns true and in consequence a download link for the whole folder is built:
https://test-nc.example.org/index.php/apps/files/ajax/download.php?dir=/Pics/Wallpaper&files=Parrot&downloadStartSecret=xxxxxxxxx

Selecting files outside search results produces a correct download link:
https://test-nc.example.org/index.php/apps/files/ajax/download.php?dir=/Pics/Wallpaper/Parrot&files=["blade.jpg","blocks.jpg"]&downloadStartSecret=xxxxxxxxx
(both link are not URL-encoded due to better representing)

Removing the if-condition enables download from the search results via "select all" checkbox. 
As a side effect, the list of files now is also transferred via GET parameter when explicitly downloading a entire directory. Mayby someone should look at it again.

Signed-off-by: js94x <jan@js94x.de>