### PR TITLE
Forwarded ExpiredTokenException

### DIFF
--- a/lib/private/Authentication/Token/Manager.php
+++ b/lib/private/Authentication/Token/Manager.php
@@ -138,6 +138,8 @@ class Manager implements IProvider {
 	public function getTokenById(int $tokenId): IToken {
 		try {
 			return $this->publicKeyTokenProvider->getTokenById($tokenId);
+		} catch (ExpiredTokenException $e) {
+			throw $e;
 		} catch (InvalidTokenException $e) {
 			return $this->defaultTokenProvider->getTokenById($tokenId);
 		}

--- a/lib/private/Authentication/Token/Manager.php
+++ b/lib/private/Authentication/Token/Manager.php
@@ -112,7 +112,9 @@ class Manager implements IProvider {
 	public function getToken(string $tokenId): IToken {
 		try {
 			return $this->publicKeyTokenProvider->getToken($tokenId);
-		} catch (InvalidTokenException $e) {
+		} catch (ExpiredTokenException $e) {
+			throw $e;
+		} catch(InvalidTokenException $e) {
 			// No worries we try to convert it to a PublicKey Token
 		}
 
@@ -153,6 +155,8 @@ class Manager implements IProvider {
 	public function renewSessionToken(string $oldSessionId, string $sessionId) {
 		try {
 			$this->publicKeyTokenProvider->renewSessionToken($oldSessionId, $sessionId);
+		} catch (ExpiredTokenException $e) {
+			throw $e;
 		} catch (InvalidTokenException $e) {
 			$this->defaultTokenProvider->renewSessionToken($oldSessionId, $sessionId);
 		}


### PR DESCRIPTION
Fixes #11919 

This fixes an issue when the oauth part requests a token that is expired. Because of the migration path it woudl just return the InvalidTokenException instead of the ExpiredTokenException resulting in not renewing the token properly.

This was working all properly when introduced. But it got broken by the move to the PublicKey Tokens.

Guess this means time for integration and acceptance tests on the OAuth endpoint. I just need to think how to make the tokens directly expire then ;)

CC: @Dagefoerde