### PR TITLE
Do not contain failed mounts in the view

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -47,6 +47,7 @@ namespace OC\Files;
 
 use Icewind\Streams\CallbackWrapper;
 use OC\Files\Mount\MoveableMount;
+use OC\Files\Storage\FailedStorage;
 use OC\Files\Storage\Storage;
 use OC\User\User;
 use OCP\Constants;
@@ -1455,6 +1456,9 @@ class View {
 			foreach ($mounts as $mount) {
 				$mountPoint = $mount->getMountPoint();
 				$subStorage = $mount->getStorage();
+				if ($subStorage->instanceOfStorage(FailedStorage::class)) {
+					continue;
+				}
 				if ($subStorage) {
 					$subCache = $subStorage->getCache('');
 


### PR DESCRIPTION
A shared failed shared storage (for whatever reason) should not still
show up in the view. Else this can lead to user still wanting to access
this.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>