### PR TITLE
Fix opening a section again in the Files app

### DIFF
--- a/apps/files/js/favoritesfilelist.js
+++ b/apps/files/js/favoritesfilelist.js
@@ -94,12 +94,6 @@ $(document).ready(function() {
 
 				return OCA.Files.FileList.prototype.reloadCallback.call(this, status, result);
 			},
-
-			_onUrlChanged: function (e) {
-				if (e && _.isString(e.dir)) {
-					this.changeDirectory(e.dir, false, true);
-				}
-			}
 		});
 
 		OCA.Files.FavoritesFileList = FavoritesFileList;

--- a/apps/files/js/favoritesplugin.js
+++ b/apps/files/js/favoritesplugin.js
@@ -67,6 +67,11 @@
 			return new OCA.Files.FavoritesFileList(
 				$el, {
 					fileActions: fileActions,
+					// The file list is created when a "show" event is handled,
+					// so it should be marked as "shown" like it would have been
+					// done if handling the event with the file list already
+					// created.
+					shown: true
 				}
 			);
 		},

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -221,6 +221,10 @@
 				return;
 			}
 
+			if (options.shown) {
+				this.shown = options.shown;
+			}
+
 			if (options.config) {
 				this._filesConfig = options.config;
 			} else if (!_.isUndefined(OCA.Files) && !_.isUndefined(OCA.Files.App)) {

--- a/apps/files/js/recentplugin.js
+++ b/apps/files/js/recentplugin.js
@@ -67,6 +67,11 @@
 			return new OCA.Files.RecentFileList(
 				$el, {
 					fileActions: fileActions,
+					// The file list is created when a "show" event is handled,
+					// so it should be marked as "shown" like it would have been
+					// done if handling the event with the file list already
+					// created.
+					shown: true
 				}
 			);
 		},

--- a/apps/files_sharing/js/app.js
+++ b/apps/files_sharing/js/app.js
@@ -34,7 +34,11 @@ OCA.Sharing.App = {
 				id: 'shares.self',
 				sharedWithUser: true,
 				fileActions: this._createFileActions(),
-				config: OCA.Files.App.getFilesConfig()
+				config: OCA.Files.App.getFilesConfig(),
+				// The file list is created when a "show" event is handled, so
+				// it should be marked as "shown" like it would have been done
+				// if handling the event with the file list already created.
+				shown: true
 			}
 		);
 
@@ -56,7 +60,11 @@ OCA.Sharing.App = {
 				id: 'shares.others',
 				sharedWithUser: false,
 				fileActions: this._createFileActions(),
-				config: OCA.Files.App.getFilesConfig()
+				config: OCA.Files.App.getFilesConfig(),
+				// The file list is created when a "show" event is handled, so
+				// it should be marked as "shown" like it would have been done
+				// if handling the event with the file list already created.
+				shown: true
 			}
 		);
 
@@ -78,7 +86,11 @@ OCA.Sharing.App = {
 				id: 'shares.link',
 				linksOnly: true,
 				fileActions: this._createFileActions(),
-				config: OCA.Files.App.getFilesConfig()
+				config: OCA.Files.App.getFilesConfig(),
+				// The file list is created when a "show" event is handled, so
+				// it should be marked as "shown" like it would have been done
+				// if handling the event with the file list already created.
+				shown: true
 			}
 		);
 
@@ -101,7 +113,11 @@ OCA.Sharing.App = {
 				showDeleted: true,
 				sharedWithUser: true,
 				fileActions: this._restoreShareAction(),
-				config: OCA.Files.App.getFilesConfig()
+				config: OCA.Files.App.getFilesConfig(),
+				// The file list is created when a "show" event is handled, so
+				// it should be marked as "shown" like it would have been done
+				// if handling the event with the file list already created.
+				shown: true
 			}
 		);
 
@@ -122,7 +138,11 @@ OCA.Sharing.App = {
 			{
 				id: 'shares.overview',
 				config: OCA.Files.App.getFilesConfig(),
-				isOverview: true
+				isOverview: true,
+				// The file list is created when a "show" event is handled, so
+				// it should be marked as "shown" like it would have been done
+				// if handling the event with the file list already created.
+				shown: true
 			}
 		);
 

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -444,12 +444,6 @@
 			// Sort by expected sort comparator
 			return files.sort(this._sortComparator);
 		},
-
-		_onUrlChanged: function(e) {
-			if (e && _.isString(e.dir)) {
-				this.changeDirectory(e.dir, false, true);
-			}
-		}
 	});
 
 	/**

--- a/apps/files_trashbin/js/app.js
+++ b/apps/files_trashbin/js/app.js
@@ -51,7 +51,11 @@ OCA.Trashbin.App = {
 						iconClass: 'icon-delete',
 					}
 				],
-				client: this.client
+				client: this.client,
+				// The file list is created when a "show" event is handled, so
+				// it should be marked as "shown" like it would have been done
+				// if handling the event with the file list already created.
+				shown: true
 			}
 		);
 	},

--- a/apps/systemtags/js/app.js
+++ b/apps/systemtags/js/app.js
@@ -28,7 +28,12 @@
 				{
 					id: 'systemtags',
 					fileActions: this._createFileActions(),
-					config: OCA.Files.App.getFilesConfig()
+					config: OCA.Files.App.getFilesConfig(),
+					// The file list is created when a "show" event is handled,
+					// so it should be marked as "shown" like it would have been
+					// done if handling the event with the file list already
+					// created.
+					shown: true
 				}
 			);
 

--- a/tests/acceptance/features/app-files.feature
+++ b/tests/acceptance/features/app-files.feature
@@ -31,6 +31,78 @@ Feature: app-files
     When I open the details view for "welcome.txt"
     Then I see that the details view is open
 
+  Scenario: show recent files
+    Given I am logged in
+    And I create a new folder named "Folder just created"
+    When I open the "Recent" section
+    Then I see that the current section is "Recent"
+    Then I see that the file list contains a file named "Folder just created"
+
+  Scenario: show recent files for a second time
+    Given I am logged in
+    And I open the "Recent" section
+    And I see that the current section is "Recent"
+    And I open the "All files" section
+    And I see that the current section is "All files"
+    And I create a new folder named "Folder just created"
+    When I open the "Recent" section
+    Then I see that the current section is "Recent"
+    Then I see that the file list contains a file named "Folder just created"
+
+  Scenario: show favorites
+    Given I am logged in
+    And I mark "welcome.txt" as favorite
+    When I open the "Favorites" section
+    Then I see that the current section is "Favorites"
+    Then I see that the file list contains a file named "welcome.txt"
+
+  Scenario: show favorites for a second time
+    Given I am logged in
+    And I open the "Favorites" section
+    And I see that the current section is "Favorites"
+    And I open the "All files" section
+    And I see that the current section is "All files"
+    And I mark "welcome.txt" as favorite
+    When I open the "Favorites" section
+    Then I see that the current section is "Favorites"
+    Then I see that the file list contains a file named "welcome.txt"
+
+  Scenario: show shares
+    Given I am logged in
+    And I share the link for "welcome.txt"
+    When I open the "Shares" section
+    Then I see that the current section is "Shares"
+    Then I see that the file list contains a file named "welcome.txt"
+
+  Scenario: show shares for a second time
+    Given I am logged in
+    And I open the "Shares" section
+    And I see that the current section is "Shares"
+    And I open the "All files" section
+    And I see that the current section is "All files"
+    And I share the link for "welcome.txt"
+    When I open the "Shares" section
+    Then I see that the current section is "Shares"
+    Then I see that the file list contains a file named "welcome.txt"
+
+  Scenario: show deleted files
+    Given I am logged in
+    And I delete "welcome.txt"
+    When I open the "Deleted files" section
+    Then I see that the current section is "Deleted files"
+    Then I see that the file list contains a file named "welcome.txt"
+
+  Scenario: show deleted files for a second time
+    Given I am logged in
+    And I open the "Deleted files" section
+    And I see that the current section is "Deleted files"
+    And I open the "All files" section
+    And I see that the current section is "All files"
+    And I delete "welcome.txt"
+    When I open the "Deleted files" section
+    Then I see that the current section is "Deleted files"
+    Then I see that the file list contains a file named "welcome.txt"
+
   Scenario: rename a file with the details view open
     Given I am logged in
     And I open the details view for "welcome.txt"

--- a/tests/acceptance/features/bootstrap/FileListContext.php
+++ b/tests/acceptance/features/bootstrap/FileListContext.php
@@ -255,6 +255,13 @@ class FileListContext implements Context, ActorAwareInterface {
 	}
 
 	/**
+	 * @return Locator
+	 */
+	public static function deleteMenuItem() {
+		return self::fileActionsMenuItemFor("Delete");
+	}
+
+	/**
 	 * @Given I create a new folder named :folderName
 	 */
 	public function iCreateANewFolderNamed($folderName) {
@@ -320,6 +327,15 @@ class FileListContext implements Context, ActorAwareInterface {
 		$this->actor->find(self::fileActionsMenuButtonForFile($this->fileListAncestor, $fileName), 10)->click();
 
 		$this->actor->find(self::viewFileInFolderMenuItem(), 2)->click();
+	}
+
+	/**
+	 * @When I delete :fileName
+	 */
+	public function iDelete($fileName) {
+		$this->actor->find(self::fileActionsMenuButtonForFile($this->fileListAncestor, $fileName), 10)->click();
+
+		$this->actor->find(self::deleteMenuItem(), 2)->click();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #11907

When a section is open in the Files app [a `show` event is triggered](https://github.com/nextcloud/server/blob/df7e016104f284c29f9c8571d548b64008f1a626/apps/files/js/navigation.js#L157). File list objects handle that event by reloading themselves, but [only if the file list was shown at least once](https://github.com/nextcloud/server/blob/6a979a0ba0d59ceda2a117cc4fe5efee4b048b4b/apps/files/js/filelist.js#L594-L597). This is needed [to prevent a race condition when the _Files_ app is initially loaded](https://github.com/nextcloud/server/pull/4693), as in that case the file list could be reloaded twice, one time due to the `show` event and another time due to a directory change when parsing the URL.

However, [the file list objects of plugins are created when the `show` event is triggered for the first time for their section](https://github.com/nextcloud/server/blob/440b5c944f1d5bb759da1f90ad7fb17ba0e2b302/apps/files/js/recentplugin.js#L47); as the file list objects register their handler for the `show` event when they are created they never handle the first triggered `show` event, as the handler is set while that event is being already handled. Therefore, from the point of view of the handler, the second time that a `show` event was triggered it was seen as if the file list was shown for the first time, and thus it was not reloaded. Now the `shown` property is explicitly set for those file lists that are created while handling a `show` event, which causes them to be reloaded as expected when opening their section again.

"_But, wait, before this fix the file list for favorites and shares did not have the `shown` property set, yet they were reloaded without problems the second time that their section was opened, why?_". Because they overrode the `onUrlChanged` method to change the directory; as the URL changes when a different section is opened (due to the trailing _view=XXX_ part) the file list always got reloaded, although not necessarily due to the `show` event. The method was overrode for both [favorites](https://github.com/nextcloud/server/pull/4423) and [shares](https://github.com/nextcloud/server/pull/4293) to fix the file list not being reloaded when showing it again, so this pull request removes them as now that the `shown` property is explicitly set that fix is no longer needed.

In the case of the file list for system tags, however, [the `_onUrlChanged` method](https://github.com/nextcloud/server/blob/844db3c891c10d575728742eef69945c807c9472/apps/systemtags/js/systemtagsfilelist.js#L183-L190) was not removed as it was overrode for a different purpose (parsing the tags to search for from the URL). Note that opening again that section clears the tags to search for previously set, but that is a different issue than the one fixed here (and it is not too bad either, as searching for the tags again works without problems).
