### PR TITLE
Load apps/APP/l10n/*.js and themes/THEME/apps/APP/l10n/*.js

### DIFF
--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -55,6 +55,7 @@ class JSResourceLocator extends ResourceLocator {
 			$found += $this->appendIfExist($this->serverroot, $theme_dir.'core/'.$script.'.js');
 			$found += $this->appendIfExist($this->serverroot, $script.'.js');
 			$found += $this->appendIfExist($this->serverroot, $theme_dir.$script.'.js');
+			$found += $this->appendIfExist($this->serverroot, 'apps/'.$script.'.js');
 			$found += $this->appendIfExist($this->serverroot, $theme_dir.'apps/'.$script.'.js');
 
 			if ($found) {


### PR DESCRIPTION
Before it quit right after finding the theme version of the l10n file which results in a not translated part of the UI.


How to reproduce:

* create `themes/test/apps/files/l10n/de.js` with this:

```js
OC.L10N.register(
	"files",
	{
		"Download" : "Herunterladen2"
	},
	"nplurals=2; plural=(n != 1);"
);
```


* create `themes/test/apps/files/l10n/de.json` with this:

```json
{
  "translations": {
    "Download" : "Herunterladen2"
  },
  "pluralForm" :"nplurals=2; plural=(n != 1);"
}
```

* configure the theme `test` in `config.php`
* configure the user to have `Deutsch (Persönlich: Du)" as language
* before: in the files app -> 3 dots menu is not properly translated:

![bildschirmfoto 2018-10-22 um 11 06 19](https://user-images.githubusercontent.com/245432/47285252-85e15200-d5ea-11e8-8ad8-1e895b63b945.png)


* after: in the files app -> 3 dots menu is properly translated: 

![bildschirmfoto 2018-10-22 um 11 06 03](https://user-images.githubusercontent.com/245432/47285236-7d891700-d5ea-11e8-8017-d882cd13eaf7.png)


I would like to backport this to 13, because it was reported there.