### PR TITLE
Headings standard

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -17,19 +17,9 @@
  */
 
 /* BASE STYLING ------------------------------------------------------------ */
-h1,
+// no h1 allowed since h1 = logo
 h2 {
 	font-weight: bold;
-}
-
-h1 {
-	font-size: 26px;
-	margin-bottom: 12px;
-	line-height: 40px;
-	color: var(--color-text-lighter);
-}
-
-h2 {
 	font-size: 20px;
 	margin-bottom: 12px;
 	line-height: 30px;

--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -17,22 +17,33 @@
  */
 
 /* BASE STYLING ------------------------------------------------------------ */
-
-h2,
-h3,
-h4 {
+h1,
+h2 {
 	font-weight: bold;
+}
+
+h1 {
+	font-size: 26px;
+	margin-bottom: 12px;
+	line-height: 40px;
+	color: var(--color-text-lighter);
 }
 
 h2 {
 	font-size: 20px;
 	margin-bottom: 12px;
-	line-height: 140%;
+	line-height: 30px;
+	color: var(--color-text-light);
 }
 
 h3 {
-	font-size: 15px;
+	font-size: 16px;
 	margin: 12px 0;
+	color: var(--color-text-light);
+}
+
+h4 {
+	font-size: 14px;
 }
 
 /* do not use italic typeface style, instead lighter color */

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -221,7 +221,6 @@ body {
 	}
 	h2 {
 		margin-bottom: 10px;
-		line-height: 150%;
 	}
 	[class^='icon-'],
 	[class*='icon-'] {

--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -224,7 +224,6 @@ select {
 			flex-wrap: nowrap;
 			justify-content: flex-start;
 			width: 100%;
-			font-weight: 300;
 
 			> label {
 				white-space: nowrap;

--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -104,11 +104,6 @@ input {
 	display: inline-grid;
 	grid-template-columns: 1fr;
 	grid-template-rows: 1fr 1fr 1fr;
-
-	/* Same font-weight exception as for .personal-settings-container */
-	> div h3 {
-		font-weight: 300;
-	}
 }
 
 .personal-show-container {
@@ -318,7 +313,7 @@ select {
 		top: 44px;
 		&.popovermenu {
 			.menuitem {
-				// override h2 heading font size
+				// override h3 heading font size
 				font-size: 12.8px;
 				line-height: 1.6em;
 				.menuitem-text-detail {


### PR DESCRIPTION
This is the introduction to proper headings.
H1 **->** main page titles, theoretically only one by page on nextcloud
H2 **->** secondary section headers (settings section headings, etc etc)
H3 **->** multiple sub-section headers (personal settings, grouped divs)
*H4 **->** rarely used, but just in case, sub-sub entries*

## Example
![capture d ecran_2018-10-23_15-57-57](https://user-images.githubusercontent.com/14975046/47365714-6de9fb00-d6dc-11e8-93b0-33c6f7d0135a.png)


## Contacts
Before
![capture d ecran_2018-10-23_15-45-25](https://user-images.githubusercontent.com/14975046/47365159-3fb7eb80-d6db-11e8-94e7-f00677f4e199.png)
After
![capture d ecran_2018-10-23_15-46-02](https://user-images.githubusercontent.com/14975046/47365169-45153600-d6db-11e8-9dc0-d961267ab836.png)

## Personal settings 
Before
![capture d ecran_2018-10-23_15-44-52](https://user-images.githubusercontent.com/14975046/47365194-53635200-d6db-11e8-80e5-5e633b55f9d4.png)
After
![capture d ecran_2018-10-23_15-42-51](https://user-images.githubusercontent.com/14975046/47365213-5c542380-d6db-11e8-90c6-3ec409e7fef5.png)

## Settings section
Before
![capture d ecran_2018-10-23_15-44-08](https://user-images.githubusercontent.com/14975046/47365460-e7cdb480-d6db-11e8-809f-7db96238241f.png)
After
![capture d ecran_2018-10-23_15-43-32](https://user-images.githubusercontent.com/14975046/47365470-ebf9d200-d6db-11e8-840a-b1f8cfe10d7f.png)

Fix #11947 
Fix #5822 

## TODO (partially pulled from #5822)
- [x] Base styling
- [ ] Decide on the opacity/color of h1, I'm not really fond of (@jancborchardt pls help :hugs: )
- [ ] `<h1>`  is used twice (it [shouldn't be](http://w3c.github.io/html/sections.html#rank)): once in the NC logo `<h1 class="hidden-visually">Nextcloud</h1>` and once in the `header-appname-container menutoggle` (app name). Possible solutions are changing the tag of the first one or removing the whole link from the Nextcloud logo (it's a weird link anyway, since it targets default app (Files), not Nextcloud itself)
- [ ] because of the :arrow_up: , `<h1>` should never be used in apps - e.g. @nextcloud/news and @nextcloud/deck are breaking this "rule"
- [x] we have a default (core) style rules for `<h2>` and `<h3>`, but `<h4>` might be useful as well
- [ ] ~~`<h3>` should be used in right sidebar (I guess?) - in which case, we should come up with a good default rule for `#app-sidebar h3`; on a related note, should it actually be an input field, like in @nextcloud/calendar ?~~ Unfortunately we cannot use h3 inside ul. Leaving the style to `app-navigation-caption`

@nextcloud/designers 