### PR TITLE
Multi vcf download plugin

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -65,6 +65,7 @@ return array(
     'OCA\\DAV\\CardDAV\\ContactsManager' => $baseDir . '/../lib/CardDAV/ContactsManager.php',
     'OCA\\DAV\\CardDAV\\Converter' => $baseDir . '/../lib/CardDAV/Converter.php',
     'OCA\\DAV\\CardDAV\\ImageExportPlugin' => $baseDir . '/../lib/CardDAV/ImageExportPlugin.php',
+    'OCA\\DAV\\CardDAV\\MultiGetExportPlugin' => $baseDir . '/../lib/CardDAV/MultiGetExportPlugin.php',
     'OCA\\DAV\\CardDAV\\PhotoCache' => $baseDir . '/../lib/CardDAV/PhotoCache.php',
     'OCA\\DAV\\CardDAV\\Plugin' => $baseDir . '/../lib/CardDAV/Plugin.php',
     'OCA\\DAV\\CardDAV\\SyncService' => $baseDir . '/../lib/CardDAV/SyncService.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -80,6 +80,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\CardDAV\\ContactsManager' => __DIR__ . '/..' . '/../lib/CardDAV/ContactsManager.php',
         'OCA\\DAV\\CardDAV\\Converter' => __DIR__ . '/..' . '/../lib/CardDAV/Converter.php',
         'OCA\\DAV\\CardDAV\\ImageExportPlugin' => __DIR__ . '/..' . '/../lib/CardDAV/ImageExportPlugin.php',
+        'OCA\\DAV\\CardDAV\\MultiGetExportPlugin' => __DIR__ . '/..' . '/../lib/CardDAV/MultiGetExportPlugin.php',
         'OCA\\DAV\\CardDAV\\PhotoCache' => __DIR__ . '/..' . '/../lib/CardDAV/PhotoCache.php',
         'OCA\\DAV\\CardDAV\\Plugin' => __DIR__ . '/..' . '/../lib/CardDAV/Plugin.php',
         'OCA\\DAV\\CardDAV\\SyncService' => __DIR__ . '/..' . '/../lib/CardDAV/SyncService.php',

--- a/apps/dav/lib/CardDAV/MultiGetExportPlugin.php
+++ b/apps/dav/lib/CardDAV/MultiGetExportPlugin.php
@@ -1,0 +1,122 @@
+<?php
+declare (strict_types = 1);
+/**
+ * @copyright Copyright (c) 2018 John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @author John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DAV\CardDAV;
+
+use Sabre\DAV;
+use Sabre\DAV\Server;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+
+class MultiGetExportPlugin extends DAV\ServerPlugin {
+
+	/** @var Server */
+	protected $server;
+
+	/**
+	 * Initializes the plugin and registers event handlers
+	 *
+	 * @param Server $server
+	 * @return void
+	 */
+	public function initialize(Server $server) {
+		$this->server = $server;
+		$this->server->on('afterMethod:REPORT', [$this, 'httpReport'], 90);
+	}
+
+	/**
+	 * Intercepts REPORT requests
+	 *
+	 * @param RequestInterface $request
+	 * @param ResponseInterface $response
+	 * @return bool
+	 */
+	public function httpReport(RequestInterface $request, ResponseInterface $response) {
+
+		$queryParams = $request->getQueryParameters();
+		if (!array_key_exists('export', $queryParams)) {
+			return;
+		}
+
+		// Only handling xml
+		$contentType = $response->getHeader('Content-Type');
+		if (strpos($contentType, 'application/xml') === false && strpos($contentType, 'text/xml') === false) {
+			return;
+		}
+
+		$this->server->transactionType = 'vcf-multi-get-intercept-and-export';
+
+		// Get the xml response
+		$responseBody = $response->getBodyAsString();
+		$responseXml  = $this->server->xml->parse($responseBody);
+
+		// Reduce the vcards into one string
+		$output = array_reduce($responseXml->getResponses(), function ($vcf, $card) {
+			$vcf .= $card->getResponseProperties()[200]['{urn:ietf:params:xml:ns:carddav}address-data'];
+			return $vcf;
+		}, '');
+
+		// Build and override the response
+		$filename = 'vcfexport-' . date('Y-m-d') . '.vcf';
+		$response->setHeader('Content-Disposition', 'attachment; filename="' . $filename . '"');
+		$response->setHeader('Content-Type', 'text/vcard');
+
+		$response->setStatus(200);
+		$response->setBody($output);
+
+		return true;
+	}
+
+	/**
+	 * Returns a plugin name.
+	 *
+	 * Using this name other plugins will be able to access other plugins
+	 * using \Sabre\DAV\Server::getPlugin
+	 *
+	 * @return string
+	 */
+	public function getPluginName() {
+		return 'vcf-multi-get-intercept-and-export';
+	}
+
+	/**
+	 * Returns a bunch of meta-data about the plugin.
+	 *
+	 * Providing this information is optional, and is mainly displayed by the
+	 * Browser plugin.
+	 *
+	 * The description key in the returned array may contain html and will not
+	 * be sanitized.
+	 *
+	 * @return array
+	 */
+	public function getPluginInfo() {
+		return [
+			'name'        => $this->getPluginName(),
+			'description' => 'Intercept a multi-get request and return a single vcf file instead.'
+		];
+
+	}
+
+}

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -34,6 +34,7 @@ namespace OCA\DAV;
 
 use OCA\DAV\CalDAV\BirthdayService;
 use OCA\DAV\CardDAV\ImageExportPlugin;
+use OCA\DAV\CardDAV\MultiGetExportPlugin;
 use OCA\DAV\CardDAV\PhotoCache;
 use OCA\DAV\Comments\CommentsPlugin;
 use OCA\DAV\Connector\Sabre\Auth;
@@ -162,6 +163,7 @@ class Server {
 			$this->server->addPlugin(new DAV\Sharing\Plugin($authBackend, \OC::$server->getRequest()));
 			$this->server->addPlugin(new \OCA\DAV\CardDAV\Plugin());
 			$this->server->addPlugin(new VCFExportPlugin());
+			$this->server->addPlugin(new MultiGetExportPlugin());
 			$this->server->addPlugin(new ImageExportPlugin(new PhotoCache(\OC::$server->getAppDataDir('dav-photocache'))));
 		}
 


### PR DESCRIPTION
@charismatic-claire @brjhaverkamp

This plugin allow us to ~~POST~~GET a list of vcards as a multi dimensional array and retrieve everything as a single vcf file. Needed for https://github.com/nextcloud/contacts/issues/39

To discuss:
1. ~~shall we go with a GET instead?~~ DONE
2. ~~shall we use a simple array instead of a multi dimensional one?~~ DONE

``` bash
curl 'https://dev.skjnldsv.com/remote.php/dav/addressbooks/users/admin/contacts/?export' \
	-X REPORT  --user 'admin:admin' \
	--data-binary '<x1:addressbook-multiget xmlns:x1="urn:ietf:params:xml:ns:carddav"><x0:prop xmlns:x0="DAV:"><x0:getcontenttype/><x0:getetag/><x0:resourcetype/><x0:displayname/><x0:owner/><x0:resourcetype/><x0:sync-token/><x0:current-user-privilege-set/><x0:getcontenttype/><x0:getetag/><x0:resourcetype/><x1:address-data/></x0:prop><x0:href xmlns:x0="DAV:">83F18885-8FF6-4839-9D10-C997D5BD9B96.vcf</x0:href><x0:href xmlns:x0="DAV:">470623A2-0FCB-4BA0-A6D2-6C25F4113C02.vcf</x0:href></x1:addressbook-multiget>'
```