### PR TITLE
Throw exception if upload folder can't be created

### DIFF
--- a/apps/dav/lib/Upload/UploadHome.php
+++ b/apps/dav/lib/Upload/UploadHome.php
@@ -86,7 +86,10 @@ class UploadHome implements ICollection {
 		$user = \OC::$server->getUserSession()->getUser();
 		Filesystem::initMountPoints($user->getUID());
 		if (!$rootView->file_exists('/' . $user->getUID() . '/uploads')) {
-			$rootView->mkdir('/' . $user->getUID() . '/uploads');
+			$result = $rootView->mkdir('/' . $user->getUID() . '/uploads');
+			if (!$result) {
+				throw new \Exception('Could not create folder "uploads" for user "' . $user->getUID() . '"');
+			}
 		}
 		$view = new View('/' . $user->getUID() . '/uploads');
 		$rootInfo = $view->getFileInfo('');


### PR DESCRIPTION
This basically makes #11485 a bit more clear and does not error with 

```
Argument 2 passed to OCA\\DAV\\Connector\\Sabre\\Directory::__construct() must implement interface OCP\\Files\\FileInfo, boolean given, called in /var/www/html/apps/dav/lib/Upload/UploadHome.php on line 93
```

How to reproduce:

* create a user "test1" without a quota and a user "test2" with a quota of 0
* share a folder from "test1" to "test2"
* as user "test2" try to upload a file bigger than 10 MB to this folder
* expected: upload is fine as long as user "test1" has enough storage space left
* actual: fails with the above error

@icewind1991 Shouldn't the upload folder be excluded from the quota wrapper?