### PR TITLE
Fix small issues with IAccountManager API

### DIFF
--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -330,7 +330,7 @@ class AccountManager implements IAccountManager {
 	private function parseAccountData(IUser $user, $data): Account {
 		$account = new Account($user);
 		foreach($data as $property => $accountData) {
-			$account->setProperty($property, $accountData['value'], $accountData['scope'], $accountData['verified']);
+			$account->setProperty($property, $accountData['value'] ?? '', $accountData['scope'], $accountData['verified']);
 		}
 		return $account;
 	}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -124,6 +124,7 @@ use OC\Dashboard\DashboardManager;
 use OCA\Theming\ImageManager;
 use OCA\Theming\ThemingDefaults;
 
+use OCP\Accounts\IAccountManager;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Collaboration\AutoComplete\IManager;
@@ -1175,6 +1176,7 @@ class Server extends ServerContainer implements IServerContainer {
 			);
 		});
 		$this->registerAlias(IContactsStore::class, ContactsStore::class);
+		$this->registerAlias(IAccountManager::class, AccountManager::class);
 
 		$this->registerService(IStorageFactory::class, function() {
 			return new StorageFactory();

--- a/lib/public/Accounts/IAccount.php
+++ b/lib/public/Accounts/IAccount.php
@@ -78,7 +78,7 @@ interface IAccount extends \JsonSerializable {
 	 * @param string $verified \OCP\Accounts\IAccountManager::NOT_VERIFIED | \OCP\Accounts\IAccountManager::VERIFICATION_IN_PROGRESS | \OCP\Accounts\IAccountManager::VERIFIED
 	 * @return IAccountProperty[]
 	 */
-	public function getFilteredProperties(string $scope, string $verified): array;
+	public function getFilteredProperties(string $scope = null, string $verified = null): array;
 
 	/**
 	 * Get the related user for the account data


### PR DESCRIPTION
- Use empty string as a default for null values
- Register IAccountManager as a service
- Allow filter properties to be null

