### PR TITLE
Calendar invitation: use system default instead of sender's language as fallback

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -170,7 +170,7 @@ class IMipPlugin extends SabreIMipPlugin {
 		$vevent = $iTipMessage->message->VEVENT;
 
 		$attendee = $this->getCurrentAttendee($iTipMessage);
-		$defaultLang = $this->config->getUserValue($this->userId, 'core', 'lang', $this->l10nFactory->findLanguage());
+		$defaultLang = $this->l10nFactory->findLanguage();
 		$lang = $this->getAttendeeLangOrDefault($defaultLang, $attendee);
 		$l10n = $this->l10nFactory->get('dav', $lang);
 


### PR DESCRIPTION
fixes #11795 

@rullzer This (partly) fixes #11795. It's better to use the instance language as a fallback, rather than the sender's language.

If there is a `LANGUAGE` parameter set for an Attendee in the calendar data, then it will always use that language. So to use the correct language of another user, this needs a modification in the calendar app (that's already planned).