### PR TITLE
Construct and register an app only one

### DIFF
--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -365,16 +365,9 @@ class Router implements IRouter {
 	 */
 	private function setupRoutes($routes, $appName) {
 		if (is_array($routes)) {
-			$appNameSpace = App::buildAppNamespace($appName);
+			$appNameSpace = App::buildAppNamespace($appName, '');
 
-			$applicationClassName = $appNameSpace . '\\AppInfo\\Application';
-
-			if (class_exists($applicationClassName)) {
-				$application = new $applicationClassName();
-			} else {
-				$application = new App($appName);
-			}
-
+			$application = \OC::$server->getAppContainer($appName, $appNameSpace);
 			$application->registerRoutes($this, $routes);
 		}
 	}

--- a/lib/private/ServerContainer.php
+++ b/lib/private/ServerContainer.php
@@ -77,7 +77,7 @@ class ServerContainer extends SimpleContainer {
 	 * @return DIContainer
 	 * @throws QueryException
 	 */
-	protected function getAppContainer($namespace, $sensitiveNamespace) {
+	public function getAppContainer($namespace, $sensitiveNamespace) {
 		if (isset($this->appContainers[$namespace])) {
 			return $this->appContainers[$namespace];
 		}


### PR DESCRIPTION
When you construct an app already in app.php the router will hapily
construct a new app.

This fix makes the router just query the server container for the
appcontainer (that is what is needed in the router). If the container
does not yet exist a new one is created.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>