### PR TITLE
[stable14] Forwarded ExpiredTokenException

### DIFF
--- a/lib/private/Authentication/Token/Manager.php
+++ b/lib/private/Authentication/Token/Manager.php
@@ -138,6 +138,8 @@ class Manager implements IProvider {
 	public function getTokenById(int $tokenId): IToken {
 		try {
 			return $this->publicKeyTokenProvider->getTokenById($tokenId);
+		} catch (ExpiredTokenException $e) {
+			throw $e;
 		} catch (InvalidTokenException $e) {
 			return $this->defaultTokenProvider->getTokenById($tokenId);
 		}

--- a/lib/private/Authentication/Token/Manager.php
+++ b/lib/private/Authentication/Token/Manager.php
@@ -112,7 +112,9 @@ class Manager implements IProvider {
 	public function getToken(string $tokenId): IToken {
 		try {
 			return $this->publicKeyTokenProvider->getToken($tokenId);
-		} catch (InvalidTokenException $e) {
+		} catch (ExpiredTokenException $e) {
+			throw $e;
+		} catch(InvalidTokenException $e) {
 			// No worries we try to convert it to a PublicKey Token
 		}
 
@@ -153,6 +155,8 @@ class Manager implements IProvider {
 	public function renewSessionToken(string $oldSessionId, string $sessionId) {
 		try {
 			$this->publicKeyTokenProvider->renewSessionToken($oldSessionId, $sessionId);
+		} catch (ExpiredTokenException $e) {
+			throw $e;
 		} catch (InvalidTokenException $e) {
 			$this->defaultTokenProvider->renewSessionToken($oldSessionId, $sessionId);
 		}


### PR DESCRIPTION
Backport of #11964 

Nextcloud 15 is released **after** Moodle 3.6, so we definitely need this in Nextcloud 14(.0.4). But there was a `backport-requested` label anyway, so I figured I should just go ahead and backport it :) 

Cheers