### PR TITLE
Implement the size of an assembly stream

### DIFF
--- a/apps/dav/lib/Upload/AssemblyStream.php
+++ b/apps/dav/lib/Upload/AssemblyStream.php
@@ -170,7 +170,9 @@ class AssemblyStream implements \Icewind\Streams\File {
 	 * @return array
 	 */
 	public function stream_stat() {
-		return [];
+		return [
+			'size' => $this->size,
+		];
 	}
 
 	/**


### PR DESCRIPTION
This will make it possible to act propely on moves of future files if we
need to know the size (like for max size virus scanning).

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>