### PR TITLE
Fix JavaScript unit tests for "versionmodel.js"

### DIFF
--- a/apps/files_versions/tests/js/versionmodelSpec.js
+++ b/apps/files_versions/tests/js/versionmodelSpec.js
@@ -86,9 +86,17 @@ describe('OCA.Versions.VersionModel', function() {
 			});
 
 			expect(fakeServer.requests.length).toEqual(1);
-			fakeServer.requests[0].respond(404);
+			var responseErrorHeaders = {
+				"Content-Type": "application/xml"
+			};
+			var responseErrorBody =
+				'<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">' +
+				'    <s:exception>Sabre\\DAV\\Exception\\SomeException</s:exception>' +
+				'    <s:message>Some error message</s:message>' +
+				'</d:error>';
+			fakeServer.requests[0].respond(404, responseErrorHeaders, responseErrorBody);
 
-			promise.then(function() {
+			promise.fail(function() {
 				expect(revertEventStub.notCalled).toEqual(true);
 				expect(successStub.notCalled).toEqual(true);
 				expect(errorStub.calledOnce).toEqual(true);

--- a/apps/files_versions/tests/js/versionmodelSpec.js
+++ b/apps/files_versions/tests/js/versionmodelSpec.js
@@ -58,7 +58,7 @@ describe('OCA.Versions.VersionModel', function() {
 			model.on('revert', revertEventStub);
 			model.on('error', errorStub);
 		});
-		it('tells the server to revert when calling the revert method', function() {
+		it('tells the server to revert when calling the revert method', function(done) {
 			var promise = model.revert({
 				success: successStub
 			});
@@ -76,11 +76,11 @@ describe('OCA.Versions.VersionModel', function() {
 				expect(revertEventStub.calledOnce).toEqual(true);
 				expect(successStub.calledOnce).toEqual(true);
 				expect(errorStub.notCalled).toEqual(true);
-			});
 
-			return promise;
+				done();
+			});
 		});
-		it('triggers error event when server returns a failure', function() {
+		it('triggers error event when server returns a failure', function(done) {
 			var promise = model.revert({
 				success: successStub
 			});
@@ -92,6 +92,8 @@ describe('OCA.Versions.VersionModel', function() {
 				expect(revertEventStub.notCalled).toEqual(true);
 				expect(successStub.notCalled).toEqual(true);
 				expect(errorStub.calledOnce).toEqual(true);
+
+				done();
 			});
 		});
 	});


### PR DESCRIPTION
This pull request fixes the failure in the JavaScript tests that started to appear with 530e39b0612b6abaa0a17b7fabb7daefb1201bd6:
```
PhantomJS 2.1.1 (Linux 0.0.0) OCA.Comments.CommentCollection resets page counted when calling reset FAILED
	Expected false to equal true.
	apps/files_versions/tests/js/versionmodelSpec.js:76:47
	core/vendor/jquery/dist/jquery.min.js:2:56437
	j@core/vendor/jquery/dist/jquery.min.js:2:27194
	fireWith@core/vendor/jquery/dist/jquery.min.js:2:54761
	core/vendor/jquery/dist/jquery.min.js:2:56856
	core/js/files/client.js:9:30735
	lib$es6$promise$$internal$$tryCatch@core/vendor/es6-promise/dist/es6-promise.js:331:24
	lib$es6$promise$$internal$$invokeCallback@core/vendor/es6-promise/dist/es6-promise.js:343:52
	lib$es6$promise$$internal$$publish@core/vendor/es6-promise/dist/es6-promise.js:314:52
	lib$es6$promise$asap$$flush@core/vendor/es6-promise/dist/es6-promise.js:125:17
	Expected false to equal true.
	apps/files_versions/tests/js/versionmodelSpec.js:77:43
	core/vendor/jquery/dist/jquery.min.js:2:56437
	j@core/vendor/jquery/dist/jquery.min.js:2:27194
	fireWith@core/vendor/jquery/dist/jquery.min.js:2:54761
	core/vendor/jquery/dist/jquery.min.js:2:56856
	core/js/files/client.js:9:30735
	lib$es6$promise$$internal$$tryCatch@core/vendor/es6-promise/dist/es6-promise.js:331:24
	lib$es6$promise$$internal$$invokeCallback@core/vendor/es6-promise/dist/es6-promise.js:343:52
	lib$es6$promise$$internal$$publish@core/vendor/es6-promise/dist/es6-promise.js:314:52
	lib$es6$promise$asap$$flush@core/vendor/es6-promise/dist/es6-promise.js:125:17
```

The problem comes from not waiting for a promise to be fulfilled before running the next test (as the syntax used was added in Jasmine 2.7, but [the server still uses Jasmine 2.5](https://github.com/nextcloud/server/blob/4367df4e5679a26e502da275215dc6908d4a9de9/build/package.json#L16)), so when the promise is resolved a different test is being run (that is why the error message points to `OCA.Comments.CommentCollection` but the stack trace to `versionmodelSpec.js`).

This could cause no failures, though, but in this specific case the problem is that the stub being checked is not the one set in the model that was reverted; after the successful revert test the failed revert test was run, so all the stubs were created again, and now the variables used inside the `promise.then`checks point to those new stubs.

But, why did it work in #11778 before it was merged? The only explanation I can find is just luck :-P Before the merge the promise was resolved before the failed revert test was run; bisecting and rebasing shows that since 056a74e3230071191fc0c19cfb8c17d2f8c8ab12 the promise started to be resolved after the failed revert test was run, thus causing the problem. However, I can not think of any reason for that commit to cause that difference in behaviour; I guess it is just some (fortunately reproducible and consistent :-P ) coincidence regarding the internal state of the JavaScript interpreter or something like that that causes the promise to take a bit longer to be resolved now.

Besides all that the failed revert test was also fixed (before the checks were never run), as the DAV client expects an error message to be sent by the server (otherwise it "crashes"), and also the checks in that case must be run when the promise fails instead of when it is done.
