### PR TITLE
Ie11 grid fixes

### DIFF
--- a/apps/files/css/ie.scss
+++ b/apps/files/css/ie.scss
@@ -1,0 +1,48 @@
+@mixin genIEGrid($width, $height) {
+	$nth: 1;
+	@for $y from 1 through $height{ 
+		@for $w from 1 through $width {
+			tr:nth-child(#{$nth}) {
+				-ms-grid-column: $w;
+				-ms-grid-row: $y;
+			}
+			$nth: $nth + 1;
+		}
+	}
+}
+
+// maximum files to compute on those algorithms
+// any folder containing files above won't be displayed properly
+$files: 1000;
+$grid: 160px;
+
+#filestable.view-grid:not(.hidden) tbody {
+	display: -ms-grid;
+}
+
+#filestable.view-grid:not(.hidden) tbody {
+	// MOBILE VIEW < 768px
+	// 4 steps, 160, 320, 480 and 640 (mobile stops at 768)
+	@for $step from 0 to 4 {
+		@media only screen and (min-width: #{$grid + $step*$grid}) {
+			-ms-grid-columns: unquote('(#{$grid})[#{$step + 1}]');
+			@include genIEGrid($step + 1, $files/($step + 1));
+		}
+	}
+
+	// CLASSIC VIEW
+	// 2 columns at 768px
+	@media only screen and (min-width: 768px) {
+		-ms-grid-columns: unquote('(#{$grid})[2]');
+		@include genIEGrid(2, $files/2);
+	}
+	// starts at 780px with 3 columns
+	// 300px + 480px: app-navigation + 3 columns
+	@for $step from 0 to 10 {
+		@media only screen and (min-width: #{780px + $step*$grid}) {
+			-ms-grid-columns: unquote('(#{$grid})[#{$step + 3}]');
+			@include genIEGrid($step + 3, $files/($step + 1));
+		}
+	}
+}
+

--- a/apps/files/css/ie.scss
+++ b/apps/files/css/ie.scss
@@ -1,3 +1,6 @@
+/* MIXIN AND GRID GENERATION FOR IE11 */
+// generate a position for the tr element
+// based on a max columns and max rows
 @mixin genIEGrid($width, $height) {
 	$nth: 1;
 	@for $y from 1 through $height{ 

--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -150,6 +150,9 @@ class ViewController extends Controller {
 
 		// Load the files we need
 		\OCP\Util::addStyle('files', 'merged');
+		if(\OCP\Util::isIE()) {
+			\OC_Util::addStyle('files', 'ie');
+		}
 		\OCP\Util::addScript('files', 'merged-index');
 
 		// mostly for the home storage's free space


### PR DESCRIPTION
Fix #12034 

@nextcloud/designers IE11 does not have a grid auto positionning.
That means we need to pre-compile every case possible for a specific numbers of scenario.
This is what this algorithm do. Nonetheless there is a finite amount of files we can support. I set the limit to 1000 files. Anything above will generate display issues on the grid. But I'm pretty sure anything above will anyway crash internet explorer ^^

Thoughts?

For the record: Not fan of this solution. And flex is not working fine here as well.