### PR TITLE
Fix setup check trusted proxies

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -320,14 +320,18 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 
 		// There's a few headers that seem to end up in the top-level
 		// server array.
-		switch($name) {
+		switch ($name) {
 			case 'CONTENT_TYPE' :
 			case 'CONTENT_LENGTH' :
 				if (isset($this->server[$name])) {
 					return $this->server[$name];
 				}
 				break;
-
+			case 'REMOTE_ADDR' :
+				if (isset($this->server[$name])) {
+					return $this->server[$name];
+				}
+				break;
 		}
 
 		return '';

--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -287,12 +287,11 @@ class CheckSetupController extends Controller {
 	 */
 	private function forwardedForHeadersWorking() {
 		$trustedProxies = $this->config->getSystemValue('trusted_proxies', []);
-		$remoteAddress = $this->request->getRemoteAddress();
+		$remoteAddress = $this->request->getHeader('REMOTE_ADDR');
 
-		if (is_array($trustedProxies) && in_array($remoteAddress, $trustedProxies)) {
-			return false;
+		if (\is_array($trustedProxies) && \in_array($remoteAddress, $trustedProxies)) {
+			return $remoteAddress !== $this->request->getRemoteAddress();
 		}
-
 		// either not enabled or working correctly
 		return true;
 	}


### PR DESCRIPTION
Close #11594 

When validation that remote addr is a trusted proxy its not possible to use `getRemoteAddr` because (if x-forwarded-for is configured properly) the client ip is returned.

@DanielYWoo please have a look :+1: 