### PR TITLE
LDAP: announce display name changes so that addressbook picks it up

### DIFF
--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -414,14 +414,21 @@ class User {
 	 *
 	 * @param string $displayName
 	 * @param string $displayName2
-	 * @returns string the effective display name
+	 * @return string the effective display name
 	 */
 	public function composeAndStoreDisplayName($displayName, $displayName2 = '') {
 		$displayName2 = (string)$displayName2;
 		if($displayName2 !== '') {
 			$displayName .= ' (' . $displayName2 . ')';
 		}
-		$this->store('displayName', $displayName);
+		$oldName = $this->config->getUserValue($this->uid, 'user_ldap', 'displayName', '');
+		if ($oldName !== $displayName) {
+			$this->store('displayName', $displayName);
+			$user = $this->userManager->get($this->getUsername());
+			if ($user instanceof \OC\User\User) {
+				$user->triggerChange('displayName', $displayName);
+			}
+		}
 		return $displayName;
 	}
 

--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -421,11 +421,13 @@ class User {
 		if($displayName2 !== '') {
 			$displayName .= ' (' . $displayName2 . ')';
 		}
-		$oldName = $this->config->getUserValue($this->uid, 'user_ldap', 'displayName', '');
-		if ($oldName !== $displayName) {
+		$oldName = $this->config->getUserValue($this->uid, 'user_ldap', 'displayName', null);
+		if ($oldName !== $displayName)  {
 			$this->store('displayName', $displayName);
 			$user = $this->userManager->get($this->getUsername());
-			if ($user instanceof \OC\User\User) {
+			if (!empty($oldName) && $user instanceof \OC\User\User) {
+				// if it was empty, it would be a new record, not a change emitting the trigger could
+				// potentially cause a UniqueConstraintViolationException, depending on some factors.
 				$user->triggerChange('displayName', $displayName);
 			}
 		}

--- a/apps/user_ldap/tests/User/UserTest.php
+++ b/apps/user_ldap/tests/User/UserTest.php
@@ -1010,9 +1010,34 @@ class UserTest extends \Test\TestCase {
 	public function testComposeAndStoreDisplayName($part1, $part2, $expected) {
 		$this->config->expects($this->once())
 			->method('setUserValue');
+		$this->config->expects($this->once())
+			->method('getUserValue');
+
+		$ncUserObj = $this->createMock(\OC\User\User::class);
+		$ncUserObj->expects($this->once())
+			->method('triggerChange')
+			->with('displayName', $expected);
+		$this->userManager->expects($this->once())
+			->method('get')
+			->willReturn($ncUserObj);
 
 		$displayName = $this->user->composeAndStoreDisplayName($part1, $part2);
 		$this->assertSame($expected, $displayName);
+	}
+
+	public function testComposeAndStoreDisplayNameNoOverwrite() {
+		$displayName = 'Randall Flagg';
+		$this->config->expects($this->never())
+			->method('setUserValue');
+		$this->config->expects($this->once())
+			->method('getUserValue')
+			->willReturn($displayName);
+
+		$this->userManager->expects($this->never())
+			->method('get'); // Implicit: no triggerChange can be called
+
+		$composedDisplayName = $this->user->composeAndStoreDisplayName($displayName);
+		$this->assertSame($composedDisplayName, $displayName);
 	}
 
 	public function testHandlePasswordExpiryWarningDefaultPolicy() {


### PR DESCRIPTION
fixes #9112 (and refs #5212)

Test is: 
1. Have LDAP enabled and configured
2. Ensure User A and B show up on users page
3. As User A (or admin, does not matter), look up User B in the contacts menu on the upper right
4. Change the displayName of User B in LDAP
5. Log in as User B to ensure the displayname is fetched from LDAP and updated
6. Again as User A look up User B again. 

Now the new displayname should be presented, previously it did not.

@nextcloud/ldap 