### PR TITLE
Actually return the root folder when traversing up the tree

### DIFF
--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -266,7 +266,11 @@ class Node implements \OCP\Files\Node {
 	 * @return Node
 	 */
 	public function getParent() {
-		return $this->root->get(dirname($this->path));
+		$newPath = dirname($this->path);
+		if ($newPath === '' || $newPath === '.' || $newPath === '/') {
+			return $this->root;
+		}
+		return $this->root->get($newPath);
 	}
 
 	/**


### PR DESCRIPTION
Cherry pick from 235e3480e651790feb63b904945db2dd352a4bde
This commit fixes an infinite loop in ShareHelper:getPathsForUsers() for certain shares as NotFoundException is otherwise never thrown in `while (!empty($byId))`. 

This can be reproduced in latest v12 (tested in 12.0.12) as well as latest v13 (tested in 13.0.7) 

---

If you now keep calling $node->getParent() you will at some point get
the RootFolder back. This is a nice termination check and will prevent
endless loops if an exit condition is slightly off.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>