### PR TITLE
added possibility to disable autocomplete in login form

### DIFF
--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -4,6 +4,8 @@ vendor_script('jsTimezoneDetect/jstz');
 script('core', 'merged-login');
 
 use OC\Core\Controller\LoginController;
+$config = \OC::$server->getConfig();
+$autocomplete = $config->getSystemValue('login_form_autocomplete', true);
 ?>
 
 <!--[if IE 8]><style>input[type="checkbox"]{padding:0;}</style><![endif]-->
@@ -42,7 +44,8 @@ use OC\Core\Controller\LoginController;
 				aria-label="<?php p($l->t('Username or email')); ?>"
 				value="<?php p($_['loginName']); ?>"
 				<?php p($_['user_autofocus'] ? 'autofocus' : ''); ?>
-				autocomplete="on" autocapitalize="none" autocorrect="off" required>
+				autocomplete="<?php p($autocomplete ? 'on' : 'off'); ?>"
+				autocapitalize="none" autocorrect="off" required>
 			<label for="user" class="infield"><?php p($l->t('Username or email')); ?></label>
 		</p>
 
@@ -51,7 +54,8 @@ use OC\Core\Controller\LoginController;
 				placeholder="<?php p($l->t('Password')); ?>"
 				aria-label="<?php p($l->t('Password')); ?>"
 				<?php p($_['user_autofocus'] ? '' : 'autofocus'); ?>
-				autocomplete="on" autocapitalize="off" autocorrect="none" required>
+				autocomplete="<?php p($autocomplete ? 'on' : 'off'); ?>"
+				autocapitalize="off" autocorrect="none" required>
 			<label for="password" class="infield"><?php p($l->t('Password')); ?></label>
 		</p>
 


### PR DESCRIPTION
Some companies require `autocomplete="off"` for input forms to comply with their security policy.

Disabling autocomplete is done by simply adding
` 'login_form_autocomplete' => false, `
to the config.php file.

In case there is no appropriate entry, auto completion will remain enabled by default.

