### PR TITLE
fix bugs in tests, that occurreds fatal errors

### DIFF
--- a/tests/lib/Traits/EncryptionTrait.php
+++ b/tests/lib/Traits/EncryptionTrait.php
@@ -23,8 +23,8 @@ trait EncryptionTrait {
 	abstract protected function registerStorageWrapper($name, $wrapper);
 
 	// from phpunit
-	abstract protected function markTestSkipped($reason = '');
-	abstract protected function assertTrue($condition, $message = '');
+	abstract protected function markTestSkipped(string $message = '');
+	abstract protected function assertTrue($condition, string $message = '');
 
 	private $encryptionWasEnabled;
 

--- a/tests/startsessionlistener.php
+++ b/tests/startsessionlistener.php
@@ -18,7 +18,7 @@ class StartSessionListener implements TestListener {
 
 	use TestListenerDefaultImplementation;
 
-	public function endTest(Test $test, $time) {
+	public function endTest(Test $test, float $time) :void {
 		// reopen the session - only allowed for memory session
 		if (\OC::$server->getSession() instanceof Memory) {
 			/** @var $session Memory */


### PR DESCRIPTION
When you run tests ./autotest.sh was occurred php fatal errors that says 
`./autotest.sh 
Using PHP executable /bin/php
PHP Warning:  Module 'igbinary' already loaded in Unknown on line 0
PHP Warning:  Module 'igbinary' already loaded in Unknown on line 0
Parsing all files in lib/public for the presence of @since or @deprecated on each method...

Using database oc_autotest
Setup environment for sqlite testing on local storage ...
Installing ....
PHP Warning:  Module 'igbinary' already loaded in Unknown on line 0
Nextcloud was successfully installed
Testing with sqlite ...
PHP Warning:  Module 'igbinary' already loaded in Unknown on line 0
/bin/phpunit --configuration phpunit-autotest.xml --coverage-clover autotest-clover-sqlite.xml --coverage-html coverage-html-sqlite --log-junit autotest-results-sqlite.xml  
PHP Warning:  Module 'igbinary' already loaded in Unknown on line 0
PHP Fatal error:  Declaration of PHPUnit\Framework\Assert::markTestSkipped(string $message = ''): void must be compatible with Test\Traits\EncryptionTrait::markTestSkipped($reason = '') in /srv/http/hacktoberfest/server/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionMasterKeyUploadTest.php on line 35
`

Now all forks fine. Environment:

- Arch Linux (up to date)
- php 7.2.
- phpunit 7.4.3-1
