### PR TITLE
added possibility to disable autocomplete in login form

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1648,4 +1648,14 @@ $CONFIG = array(
  * If this is set to "false" it will not show the link.
  */
 'simpleSignUpLink.shown' => true,
+
+/**
+ * By default autocompletion is enabled for the login form on Nextcloud's login page.
+ * While this is enabled, browsers are allowed to "remember" login names and such.
+ * Some companies require it to be disabled to comply with their security policy.
+ *
+ * Simply set this property to "false", if you want to turn this feature off.
+ */
+
+'login_form_autocomplete' => true,
 );

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -171,6 +171,14 @@ class LoginController extends Controller {
 			$parameters['loginName'] = '';
 			$parameters['user_autofocus'] = true;
 		}
+
+		$autocomplete = $this->config->getSystemValue('login_form_autocomplete', true);
+		if ($autocomplete){
+			$parameters['login_form_autocomplete'] = 'on';
+		} else {
+			$parameters['login_form_autocomplete'] = 'off';
+		}
+
 		if (!empty($redirect_url)) {
 			$parameters['redirect_url'] = $redirect_url;
 		}

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -42,7 +42,7 @@ use OC\Core\Controller\LoginController;
 				aria-label="<?php p($l->t('Username or email')); ?>"
 				value="<?php p($_['loginName']); ?>"
 				<?php p($_['user_autofocus'] ? 'autofocus' : ''); ?>
-				autocomplete="on" autocapitalize="none" autocorrect="off" required>
+				autocomplete="<?php p($_['login_form_autocomplete']); ?>" autocapitalize="none" autocorrect="off" required>
 			<label for="user" class="infield"><?php p($l->t('Username or email')); ?></label>
 		</p>
 
@@ -51,7 +51,7 @@ use OC\Core\Controller\LoginController;
 				placeholder="<?php p($l->t('Password')); ?>"
 				aria-label="<?php p($l->t('Password')); ?>"
 				<?php p($_['user_autofocus'] ? '' : 'autofocus'); ?>
-				autocomplete="on" autocapitalize="off" autocorrect="none" required>
+				autocomplete="<?php p($_['login_form_autocomplete']); ?>" autocapitalize="none" autocorrect="off" required>
 			<label for="password" class="infield"><?php p($l->t('Password')); ?></label>
 		</p>
 

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -199,6 +199,7 @@ class LoginControllerTest extends TestCase {
 				'alt_login' => [],
 				'resetPasswordLink' => null,
 				'throttle_delay' => 1000,
+				'login_form_autocomplete' => 'off',
 			],
 			'guest'
 		);
@@ -223,6 +224,7 @@ class LoginControllerTest extends TestCase {
 				'alt_login' => [],
 				'resetPasswordLink' => null,
 				'throttle_delay' => 1000,
+				'login_form_autocomplete' => 'off',
 			],
 			'guest'
 		);
@@ -255,10 +257,12 @@ class LoginControllerTest extends TestCase {
 			->method('isLoggedIn')
 			->willReturn(false);
 		$this->config
-			->expects($this->once())
+			->expects($this->exactly(2))
 			->method('getSystemValue')
-			->with('lost_password_link')
-			->willReturn(false);
+			->will($this->returnValueMap([
+			['login_form_autocomplete', true, true],
+			['lost_password_link', '', false],
+		]));
 		$user = $this->createMock(IUser::class);
 		$user
 			->expects($this->once())
@@ -281,6 +285,7 @@ class LoginControllerTest extends TestCase {
 				'alt_login' => [],
 				'resetPasswordLink' => false,
 				'throttle_delay' => 1000,
+				'login_form_autocomplete' => 'on',
 			],
 			'guest'
 		);
@@ -338,10 +343,12 @@ class LoginControllerTest extends TestCase {
 			->method('isLoggedIn')
 			->willReturn(false);
 		$this->config
-			->expects($this->once())
+			->expects($this->exactly(2))
 			->method('getSystemValue')
-			->with('lost_password_link')
-			->willReturn(false);
+			->will($this->returnValueMap([
+			['login_form_autocomplete', true, true],
+			['lost_password_link', '', false],
+		]));
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())
 			->method('canChangePassword')
@@ -363,6 +370,7 @@ class LoginControllerTest extends TestCase {
 				'alt_login' => [],
 				'resetPasswordLink' => false,
 				'throttle_delay' => 1000,
+				'login_form_autocomplete' => 'on',
 			],
 			'guest'
 		);


### PR DESCRIPTION
Some companies require `autocomplete="off"` for input forms to comply with their security policy.

Disabling autocomplete is done by simply adding
`'login_form_autocomplete' => false,`
to the config.php file.

In case there is no appropriate entry, auto completion will remain enabled by default.

Signed-off-by: Rayn0r Andre.Weidemann@web.de