### PR TITLE
remove unneeded empty LDAP search attribute values

### DIFF
--- a/apps/user_ldap/lib/User/Manager.php
+++ b/apps/user_ldap/lib/User/Manager.php
@@ -197,6 +197,13 @@ class Manager {
 			);
 		}
 
+		// remove possible empty attributes
+		$attributes = array_values(
+			array_filter($attributes, function ($attributeName) {
+				return !empty($attributeName);
+			})
+		);
+
 		return $attributes;
 	}
 

--- a/apps/user_ldap/tests/User/ManagerTest.php
+++ b/apps/user_ldap/tests/User/ManagerTest.php
@@ -256,12 +256,17 @@ class ManagerTest extends \Test\TestCase {
 		$manager->setLdapAccess($access);
 
 		$connection = $access->getConnection();
-		$connection->setConfiguration(['ldapEmailAttribute' => 'mail', 'ldapUserAvatarRule' => 'default']);
+		$connection->setConfiguration([
+			'ldapEmailAttribute' => 'mail',
+			'ldapUserAvatarRule' => 'default',
+			'ldapQuotaAttribute' => '',
+		]);
 
 		$attributes = $manager->getAttributes($minimal);
 
 		$this->assertTrue(in_array('dn', $attributes));
 		$this->assertTrue(in_array($access->getConnection()->ldapEmailAttribute, $attributes));
+		$this->assertFalse(in_array('', $attributes));
 		$this->assertSame(!$minimal, in_array('jpegphoto', $attributes));
 		$this->assertSame(!$minimal, in_array('thumbnailphoto', $attributes));
 	}


### PR DESCRIPTION
fixes #12086

@jlehtoranta @MrManor @PaulLebmann this should fix the issue as you described it. Would be great if you can test and confirm it is working again.