### PR TITLE
Add getExtension() to FileInfo

### DIFF
--- a/apps/files_trashbin/lib/Trash/TrashItem.php
+++ b/apps/files_trashbin/lib/Trash/TrashItem.php
@@ -169,4 +169,8 @@ class TrashItem implements ITrashItem {
 	public function getChecksum() {
 		return $this->fileInfo->getChecksum();
 	}
+
+	public function getExtension(): string {
+		return $this->fileInfo->getExtension();
+	}
 }

--- a/lib/private/Files/FileInfo.php
+++ b/lib/private/Files/FileInfo.php
@@ -390,4 +390,8 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	public function getChecksum() {
 		return $this->data['checksum'];
 	}
+
+	public function getExtension(): string {
+		return pathinfo($this->getName(), PATHINFO_EXTENSION);
+	}
 }

--- a/lib/private/Files/Node/File.php
+++ b/lib/private/Files/Node/File.php
@@ -142,4 +142,8 @@ class File extends Node implements \OCP\Files\File {
 	public function getChecksum() {
 		return $this->getFileInfo()->getChecksum();
 	}
+
+	public function getExtension(): string {
+		return $this->getFileInfo()->getExtension();
+	}
 }

--- a/lib/private/Files/Node/LazyRoot.php
+++ b/lib/private/Files/Node/LazyRoot.php
@@ -344,6 +344,10 @@ class LazyRoot implements IRootFolder {
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
 
+	public function getExtension(): string {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
 	/**
 	 * @inheritDoc
 	 */

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -354,6 +354,10 @@ class Node implements \OCP\Files\Node {
 	public function getChecksum() {
 	}
 
+	public function getExtension(): string {
+		return $this->getFileInfo()->getExtension();
+	}
+
 	/**
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
 	 * @throws \OCP\Lock\LockedException

--- a/lib/public/Files/File.php
+++ b/lib/public/Files/File.php
@@ -96,4 +96,12 @@ interface File extends Node {
 	 * @throws NotFoundException
 	 */
 	public function getChecksum();
+
+	/**
+	 * Get the extension of this file
+	 *
+	 * @return string
+	 * @since 15.0.0
+	 */
+	public function getExtension(): string;
 }

--- a/lib/public/Files/FileInfo.php
+++ b/lib/public/Files/FileInfo.php
@@ -259,4 +259,12 @@ interface FileInfo {
 	 * @since 9.0.0
 	 */
 	public function getChecksum();
+
+	/**
+	 * Get the extension of the file
+	 *
+	 * @return string
+	 * @since 15.0.0
+	 */
+	public function getExtension(): string;
 }


### PR DESCRIPTION
this is a fairly common operation so it makes sense to prevent having
to repeatedly implement it.

Signed-off-by: Robin Appelman <robin@icewind.nl>