### PR TITLE
A folder should get a folder mimetype

### DIFF
--- a/apps/workflowengine/lib/Check/FileMimeType.php
+++ b/apps/workflowengine/lib/Check/FileMimeType.php
@@ -76,6 +76,11 @@ class FileMimeType extends AbstractStringCheck {
 			return $this->mimeType[$this->storage->getId()][$this->path];
 		}
 
+		if ($this->storage->is_dir($this->path)) {
+			$this->mimeType[$this->storage->getId()][$this->path] = 'httpd/unix-directory';
+			return $this->mimeType[$this->storage->getId()][$this->path];
+		}
+
 		if ($this->isWebDAVRequest()) {
 			// Creating a folder
 			if ($this->request->getMethod() === 'MKCOL') {


### PR DESCRIPTION
If doing achunked upload the mimetype of the folder would otherwise be
guessed from the path. Which always returned application/octet-stream.

If an access control rule to block that is in place this means that all
chunked uploads fail hard in directories as the isCreatable on the
directory always fails.

Actually fixes: https://github.com/nextcloud/files_accesscontrol/issues/115