### PR TITLE
fixes an Exception on the background job because the config was not set

### DIFF
--- a/settings/BackgroundJobs/VerifyUserData.php
+++ b/settings/BackgroundJobs/VerifyUserData.php
@@ -63,6 +63,9 @@ class VerifyUserData extends Job {
 	/** @var string */
 	private $lookupServerUrl;
 
+	/** @var IConfig */
+	private $config;
+
 	/**
 	 * VerifyUserData constructor.
 	 *
@@ -85,6 +88,7 @@ class VerifyUserData extends Job {
 
 		$lookupServerUrl = $config->getSystemValue('lookup_server', 'https://lookup.nextcloud.com');
 		$this->lookupServerUrl = rtrim($lookupServerUrl, '/');
+		$this->config = $config;
 	}
 
 	/**


### PR DESCRIPTION
Fixes a 

```
{"Exception":"Error","Message":"Call to a member function getSystemValue() on null","Code":0,"Trace":[{"file":"//srv//http//nextcloud//master//settings//BackgroundJobs//VerifyUserData.php","line":120,"function":"verifyViaLookupServer","class":"OC\Settings\BackgroundJobs\VerifyUserData","type":"->","args":[{"verificationCode":"","data":"person_3@example.org","type":"email","uid":"04f784d9-0e90-4a90-94df-8210a27f33b1","try":1,"lastRun":1540569262},"email"]},{"file":"//srv//http//nextcloud//master//lib//private//BackgroundJob//Job.php","line":61,"function":"run","class":"OC\Settings\BackgroundJobs\VerifyUserData","type":"->","args":[{"verificationCode":"","data":"person_3@example.org","type":"email","uid":"04f784d9-0e90-4a90-94df-8210a27f33b1","try":1,"lastRun":1540569262}]},{"file":"//srv//http//nextcloud//master//settings//BackgroundJobs//VerifyUserData.php","line":99,"function":"execute","class":"OC\BackgroundJob\Job","type":"->","args":[{"__class__":"OC\BackgroundJob\JobList"},{"__class__":"OC\Log"}]},{"file":"//srv//http//nextcloud//master//cron.php","line":123,"function":"execute","class":"OC\Settings\BackgroundJobs\VerifyUserData","type":"->","args":[{"__class__":"OC\BackgroundJob\JobList"},{"__class__":"OC\Log"}]}],"File":"//srv//http//nextcloud//master//settings//BackgroundJobs//VerifyUserData.php","Line":185,"CustomMessage":"--"}
```

in `verifyViaLookupServer()` because `$this->config` was not set…