### PR TITLE
suppress wrong audit log messages about failed login attempts

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -228,11 +228,12 @@ class Auth extends AbstractBasic {
 			if($this->twoFactorManager->needsSecondFactor($this->userSession->getUser())) {
 				throw new \Sabre\DAV\Exception\NotAuthenticated('2FA challenge not passed.');
 			}
-			if (\OC_User::handleApacheAuth() ||
+			if (
 				//Fix for broken webdav clients
 				($this->userSession->isLoggedIn() && is_null($this->session->get(self::DAV_AUTHENTICATED))) ||
 				//Well behaved clients that only send the cookie are allowed
-				($this->userSession->isLoggedIn() && $this->session->get(self::DAV_AUTHENTICATED) === $this->userSession->getUser()->getUID() && $request->getHeader('Authorization') === null)
+				($this->userSession->isLoggedIn() && $this->session->get(self::DAV_AUTHENTICATED) === $this->userSession->getUser()->getUID() && $request->getHeader('Authorization') === null) ||
+				\OC_User::handleApacheAuth()
 			) {
 				$user = $this->userSession->getUser()->getUID();
 				\OC_Util::setupFS($user);


### PR DESCRIPTION
first check if the user is already logged in and then try to authenticate via apache, this way we suppress wrong audit log messages about failed login attempts

followup on https://github.com/nextcloud/user_saml/pull/254 to suppress the last remaining message

fix https://github.com/nextcloud/server/issues/11269

