### PR TITLE
Design details in file picker

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -316,6 +316,7 @@ table td.filename .thumbnail {
 	background-size: 32px;
 	margin-left: 9px;
 	margin-top: 9px;
+	border-radius: var(--border-radius);
 	cursor: pointer;
 	position: absolute;
 	z-index: 4;

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -798,7 +798,7 @@ code {
 		&.view-grid {
 			$grid-size: 120px;
 			$grid-pad: 10px;
-			$name-height: 20px;
+			$name-height: 30px;
 			display: flex;
 			flex-direction: column;
 
@@ -821,17 +821,17 @@ code {
 					td {
 						border: none;
 						padding: 0;
+						text-align: center;
 
 						&.filename {
 							padding: #{$grid-size - 2 * $grid-pad} 0 0 0;
 							background-position: center top;
 							background-size: contain;
 							line-height: $name-height;
-							height: $name-height;
 						}
 						&.filesize {
-							line-height: $name-height;
-							text-align: left;
+							line-height: $name-height / 3;
+							width: 100%;
 						}
 						&.date {
 							display: none;

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -818,10 +818,12 @@ code {
 					flex-direction: column;
 					width: $grid-size - 2 * $grid-pad;
 
+
 					td {
 						border: none;
 						padding: 0;
 						text-align: center;
+						border-radius: var(--border-radius);
 
 						&.filename {
 							padding: #{$grid-size - 2 * $grid-pad} 0 0 0;


### PR DESCRIPTION
- Filepicker: center text in grid view, improve spacing 
- slightly round off thumbnails in list view too

The centering of text because it’s centered in the Files view too – check with short names. :) And the filename was too closely stuck below the thumbnail.
And the rounding off of thumbnails does _not_ work in the file picker as of now unfortunately because we use background-image there for the thumbnail. (We should change this when we do a rewrite.)

Before and after of file picker grid view:
![file picker grid view before](https://user-images.githubusercontent.com/925062/47756297-c94e5700-dca1-11e8-9955-9325e1029635.png)

![file picker grid view after](https://user-images.githubusercontent.com/925062/47756298-c9e6ed80-dca1-11e8-9f99-15bd020b835d.png)

Please review @nextcloud/designers :heart: 