### PR TITLE
indicate users quota when default selected

### DIFF
--- a/apps/provisioning_api/lib/Controller/AUserData.php
+++ b/apps/provisioning_api/lib/Controller/AUserData.php
@@ -176,7 +176,7 @@ abstract class AUserData extends OCSController {
 				throw new OCSException('User does not exist', 101);
 			}
 			$quota = $user->getQuota();
-			if ($quota !== 'none') {
+			if ($quota !== 'none' && $quota !== 'default') {
 				$quota = OC_Helper::computerFileSize($quota);
 			}
 			$data = [

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -375,11 +375,7 @@ class User implements IUser {
 	 * @since 9.0.0
 	 */
 	public function getQuota() {
-		$quota = $this->config->getUserValue($this->uid, 'files', 'quota', 'default');
-		if($quota === 'default') {
-			$quota = $this->config->getAppValue('files', 'default_quota', 'none');
-		}
-		return $quota;
+		return $this->config->getUserValue($this->uid, 'files', 'quota', 'default');
 	}
 
 	/**

--- a/settings/src/components/userList.vue
+++ b/settings/src/components/userList.vue
@@ -143,7 +143,7 @@ import Vue from 'vue';
 
 export default {
 	name: 'userList',
-	props: ['users', 'showConfig', 'selectedGroup', 'externalActions'],
+	props: ['users', 'showConfig', 'selectedGroup', 'externalActions', 'defaultQuotaValue'],
 	components: {
 		userRow,
 		Multiselect,
@@ -195,6 +195,10 @@ export default {
 		 * Register search
 		 */
 		this.userSearch = new OCA.Search(this.search, this.resetSearch);
+
+		this.$nextTick(function () {
+			this.updateDefaultLabel();
+		});
 	},
 	computed: {
 		settings() {
@@ -274,6 +278,9 @@ export default {
 			this.$store.commit('resetUsers');
 			this.$refs.infiniteLoading.$emit('$InfiniteLoading:reset');
 			this.setNewUserDefaultGroup(val);
+		},
+		defaultQuotaValue: function () {
+			this.updateDefaultLabel();
 		}
 	},
 	methods: {
@@ -368,6 +375,17 @@ export default {
 					this.loading.groups = false;
 				});
 			return this.$store.getters.getGroups[this.groups.length];
+		},
+		updateDefaultLabel() {
+			let defaultLabel = undefined;
+
+			if (this.defaultQuotaValue.label === 'Unlimited') {
+				defaultLabel = '∞';
+			} else {
+				defaultLabel = this.defaultQuotaValue.label;
+			}
+
+			this.defaultQuota = {id: 'default', label: defaultLabel + ' (default)'};
 		}
 	}
 }

--- a/settings/src/components/userList/userRow.vue
+++ b/settings/src/components/userList/userRow.vue
@@ -239,8 +239,13 @@ export default {
 				let humanQuota = OC.Util.humanFileSize(this.user.quota.quota);
 				let userQuota = this.quotaOptions.find(quota => quota.id === humanQuota);
 				return userQuota ? userQuota : {id:humanQuota, label:humanQuota};
-			} else if (this.settings.defaultQuota === 'none' || this.user.quota.quota === 'none') {
-				return this.quotaOptions[1]; // unlimited
+			} else if (this.settings.defaultQuota === 'none') { // unlimited
+				if(this.user.quota.quota === 'default') {
+					this.quotaOptions[0]['label'] = '∞ (default)';
+					return this.quotaOptions[0];
+				} else if (this.user.quota.quota === 'none') {
+					return this.quotaOptions[1];
+				}
 			}
 
 			this.quotaOptions[0]['label'] = this.settings.defaultQuota + ' (default)'; // otherwise

--- a/settings/src/components/userList/userRow.vue
+++ b/settings/src/components/userList/userRow.vue
@@ -234,13 +234,13 @@ export default {
 		},
 		// Mapping saved values to objects
 		userQuota() {
-			if (this.user.quota.quota >= 0) {
+			if (this.user.quota.quota > 0) {
 				// if value is valid, let's map the quotaOptions or return custom quota
 				let humanQuota = OC.Util.humanFileSize(this.user.quota.quota);
 				let userQuota = this.quotaOptions.find(quota => quota.id === humanQuota);
 				return userQuota ? userQuota : {id:humanQuota, label:humanQuota};
-			} else if (this.user.quota.quota === 'default') {
-				// default quota is replaced by the proper value on load
+			} else if (this.user.quota.quota === 0 || this.user.quota.quota === 'default') {
+				this.quotaOptions[0]['label'] = this.settings.defaultQuota + ' (default)';
 				return this.quotaOptions[0];
 			}
 			return this.quotaOptions[1]; // unlimited

--- a/settings/src/components/userList/userRow.vue
+++ b/settings/src/components/userList/userRow.vue
@@ -239,17 +239,11 @@ export default {
 				let humanQuota = OC.Util.humanFileSize(this.user.quota.quota);
 				let userQuota = this.quotaOptions.find(quota => quota.id === humanQuota);
 				return userQuota ? userQuota : {id:humanQuota, label:humanQuota};
-			} else if (this.settings.defaultQuota === 'none') { // unlimited
-				if(this.user.quota.quota === 'default') {
-					this.quotaOptions[0]['label'] = '∞ (default)';
-					return this.quotaOptions[0];
-				} else if (this.user.quota.quota === 'none') {
-					return this.quotaOptions[1];
-				}
+			} else if (this.user.quota.quota === 0 || this.user.quota.quota === 'default') {
+				// default quota is replaced by the proper value on load
+				return this.quotaOptions[0];
 			}
-
-			this.quotaOptions[0]['label'] = this.settings.defaultQuota + ' (default)'; // otherwise
-			return this.quotaOptions[0];
+			return this.quotaOptions[1]; // unlimited
 		},
 
 		/* PASSWORD POLICY? */

--- a/settings/src/components/userList/userRow.vue
+++ b/settings/src/components/userList/userRow.vue
@@ -239,11 +239,12 @@ export default {
 				let humanQuota = OC.Util.humanFileSize(this.user.quota.quota);
 				let userQuota = this.quotaOptions.find(quota => quota.id === humanQuota);
 				return userQuota ? userQuota : {id:humanQuota, label:humanQuota};
-			} else if (this.user.quota.quota === 0 || this.user.quota.quota === 'default') {
-				this.quotaOptions[0]['label'] = this.settings.defaultQuota + ' (default)';
-				return this.quotaOptions[0];
+			} else if (this.settings.defaultQuota === 'none' || this.user.quota.quota === 'none') {
+				return this.quotaOptions[1]; // unlimited
 			}
-			return this.quotaOptions[1]; // unlimited
+
+			this.quotaOptions[0]['label'] = this.settings.defaultQuota + ' (default)'; // otherwise
+			return this.quotaOptions[0];
 		},
 
 		/* PASSWORD POLICY? */

--- a/settings/src/views/Users.vue
+++ b/settings/src/views/Users.vue
@@ -52,7 +52,7 @@
 				</div>
 			</template>
 		</app-navigation>
-		<user-list :users="users" :showConfig="showConfig" :selectedGroup="selectedGroup" :externalActions="externalActions" />
+		<user-list :users="users" :showConfig="showConfig" :selectedGroup="selectedGroup" :externalActions="externalActions" :defaultQuotaValue="defaultQuota" />
 	</div>
 </template>
 


### PR DESCRIPTION
Fixes #11393 

Works on custom amounts and changes the default label to that amount.
<img width="189" alt="screen shot 2018-10-31 at 5 08 20 am" src="https://user-images.githubusercontent.com/4040794/47777588-72f60e00-dccb-11e8-814f-8296a2c2da76.png">


Differentiates between the presets and default as default is a respected value on the back-end and not just a label for preset options. For both "Unlimited" and other values.
<img width="191" alt="screen shot 2018-10-31 at 5 04 41 am" src="https://user-images.githubusercontent.com/4040794/47777599-79848580-dccb-11e8-8b20-fdd33e05771c.png">

<img width="192" alt="screen shot 2018-10-31 at 5 13 21 am" src="https://user-images.githubusercontent.com/4040794/47777775-d7b16880-dccb-11e8-8b50-08a4aa646fe8.png">


Signed-off-by: Harold Gray <haroldgray3@gmail.com>