### PR TITLE
Align file menu below '+' button, fix #5595

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -8,7 +8,12 @@
 }
 
 /* FILE MENU */
-.actions { padding:5px; height:32px; display: inline-block; float: left; }
+.actions {
+	padding: 5px;
+	height: 100%;
+	display: inline-block;
+	float: left;
+}
 .actions input, .actions button, .actions .button { margin:0; float:left; }
 .actions .button a { color: #555; }
 .actions .button a:hover,
@@ -658,8 +663,14 @@ table.dragshadow td.size {
 	top: 100%;
 	margin-top: 4px;
 	min-width: 100px;
-	margin-left: 7px;
+	margin-left: 22px; /* Align left edge below center of + button … */
+	transform: translateX(-50%); /* … then center it below button */
 	z-index: 1001;
+
+	/* Center triangle */
+	&::after {
+		left: calc(50% - 8px) !important;
+	}
 }
 
 #filestable .filename .action .icon,


### PR DESCRIPTION
Not only makes it look much better and consistent with the rest of our popups, but also fixes https://github.com/nextcloud/server/issues/5595 cc @pixelipo :)

Before & after:
![screenshot from 2018-10-31 11-21-59](https://user-images.githubusercontent.com/925062/47781923-3f34db80-dcff-11e8-84c7-6616d164fffb.png) ![file menu aligned](https://user-images.githubusercontent.com/925062/47781927-3fcd7200-dcff-11e8-8714-ed16e119fb14.png)

When on the right edge, before & after:
![screenshot from 2018-10-31 11-21-39](https://user-images.githubusercontent.com/925062/47781924-3f34db80-dcff-11e8-826b-cd87d7c875a0.png) ![screenshot from 2018-10-31 11-21-02](https://user-images.githubusercontent.com/925062/47781926-3f34db80-dcff-11e8-879a-7eb31e104eab.png)


Please review @nextcloud/designers :tada: 