### PR TITLE
Do not set indeterminate state for file shares

### DIFF
--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -314,7 +314,9 @@
 				var $edit = _this.$('#canEdit-' + _this.cid + '-' + sharee.shareId);
 				if($edit.length === 1) {
 					$edit.prop('checked', sharee.editPermissionState === 'checked');
-					$edit.prop('indeterminate', sharee.editPermissionState === 'indeterminate');
+					if (sharee.isFolder) {
+						$edit.prop('indeterminate', sharee.editPermissionState === 'indeterminate');
+					}
 				}
 			});
 			this.$('.popovermenu').on('afterHide', function() {

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -616,6 +616,12 @@
 			var hcp = this.hasCreatePermission(shareIndex);
 			var hup = this.hasUpdatePermission(shareIndex);
 			var hdp = this.hasDeletePermission(shareIndex);
+			if (this.isFile()) {
+				if (hcp || hup || hdp) {
+					return 'checked';
+				}
+				return '';
+			}
 			if (!hcp && !hup && !hdp) {
 				return '';
 			}

--- a/core/js/tests/specs/sharedialogshareelistview.js
+++ b/core/js/tests/specs/sharedialogshareelistview.js
@@ -90,6 +90,37 @@ describe('OC.Share.ShareDialogShareeListView', function () {
 	});
 
 	describe('Sets correct initial checkbox state', function () {
+
+		it('marks edit box as unchecked for file shares without edit permissions', function () {
+			shareModel.set('shares', [{
+				id: 100,
+				item_source: 123,
+				permissions: 1,
+				share_type: OC.Share.SHARE_TYPE_USER,
+				share_with: 'user1',
+				share_with_displayname: 'User One',
+				uid_owner: oc_current_user,
+				itemType: 'file'
+			}]);
+			listView.render();
+			expect(listView.$el.find("input[name='edit']").is(':not(:checked)')).toEqual(true);
+		});
+
+		it('marks edit box as checked for file shares', function () {
+			shareModel.set('shares', [{
+				id: 100,
+				item_source: 123,
+				permissions: 1 | OC.PERMISSION_UPDATE,
+				share_type: OC.Share.SHARE_TYPE_USER,
+				share_with: 'user1',
+				share_with_displayname: 'User One',
+				uid_owner: oc_current_user,
+				itemType: 'file'
+			}]);
+			listView.render();
+			expect(listView.$el.find("input[name='edit']").is(':checked')).toEqual(true);
+		});
+
 		it('marks edit box as indeterminate when only some permissions are given', function () {
 			shareModel.set('shares', [{
 				id: 100,


### PR DESCRIPTION
Files just have one edit permission checkbox, so having an indeterminate state there doesn't make sense and actually broke updating the edit permission on file shares. Found this while checking the failing tests in #12105. 

Fixes https://github.com/nextcloud/server/issues/11730

@nextcloud/javascript 