### PR TITLE
Ensure filename is possibly centered below file icons in grid view

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -852,19 +852,27 @@ table.dragshadow td.size {
 					.nametext {
 						display: flex;
 						height: 44px;
-						overflow: hidden;
-						text-overflow: ellipsis;
-						white-space: nowrap;
 						margin-top: $grid-size - $grid-pad;
-						padding-right: 0;
-						text-align: right;
+						text-align: center;
 						line-height: 44px;
-						padding-left: $grid-pad; // same as action icon right padding
+						padding: 0;
 
 						.innernametext {
 							display: inline-block;
-							width: 100%;
-							max-width: 80px;
+							text-align: center;
+							overflow: hidden;
+							text-overflow: ellipsis;
+							white-space: nowrap;
+						}
+						&:before {
+							content: '';
+							flex: 1;
+							min-width: 14px;
+						}
+						&:after {
+							content: '';
+							flex: 1;
+							min-width: 44px;
 						}
 
 						/* No space for extension in grid view */
@@ -878,6 +886,8 @@ table.dragshadow td.size {
 						margin-top: $grid-size - $grid-pad;
 						display: flex;
 						align-items: center;
+						position: absolute;
+						right: 0;
 
 						.action {
 							padding: $grid-pad;
@@ -887,17 +897,8 @@ table.dragshadow td.size {
 							align-items: center;
 							justify-content: center;
 
-							&.action-share.permanent.shared-style span {
-								/* Do not show "Shared" text next to icon as there is no space */
-								&:not(.icon) {
-									display: none;
-								}
-
-								/* If an avatar is present, show that instead of the icon */
-								&.avatar {
-									display: inline-block;
-									position: absolute;
-								}
+							&.action.action-share.permanent {
+								display: none;
 							}
 
 							/* In "Deleted files", do not show "Restore" text next to icon as there is no space */

--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -863,6 +863,7 @@ table.dragshadow td.size {
 
 						.innernametext {
 							display: inline-block;
+							width: 100%;
 							max-width: 80px;
 						}
 


### PR DESCRIPTION
This was already intended in the pull request, not sure where this got lost. We do use the text-align: right; for the text already, but the element of the text didn’t take full width so stayed on the left. :wink: 

This is also to make it in line with what we do in the file picker #12154 

Currently left-aligned, looks strange and the names float _away_ from the preview/icon and actions:
![file names current left aligned](https://user-images.githubusercontent.com/925062/47803759-7cb35c00-dd33-11e8-918b-9489aec31f30.png)

Now _really_ right-aligned, sticking to the actions and the preview:
![file names centered in grid view](https://user-images.githubusercontent.com/925062/47803760-7d4bf280-dd33-11e8-92da-a0c1bb47a14f.png)

Please review @nextcloud/designers 