### PR TITLE
Use the proper server for the apptoken flow login

### DIFF
--- a/tests/Core/Controller/ClientFlowLoginControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginControllerTest.php
@@ -162,6 +162,9 @@ class ClientFlowLoginControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getServerHost')
 			->willReturn('example.com');
+		$this->request
+			->method('getServerProtocol')
+			->willReturn('https');
 
 		$expected = new TemplateResponse(
 			'core',
@@ -172,7 +175,7 @@ class ClientFlowLoginControllerTest extends TestCase {
 				'instanceName' => 'ExampleCloud',
 				'urlGenerator' => $this->urlGenerator,
 				'stateToken' => 'StateToken',
-				'serverHost' => 'example.com',
+				'serverHost' => 'https://example.com',
 				'oauthState' => 'OauthStateToken',
 			],
 			'guest'
@@ -218,6 +221,9 @@ class ClientFlowLoginControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getServerHost')
 			->willReturn('example.com');
+		$this->request
+			->method('getServerProtocol')
+			->willReturn('https');
 
 		$expected = new TemplateResponse(
 			'core',
@@ -228,7 +234,7 @@ class ClientFlowLoginControllerTest extends TestCase {
 				'instanceName' => 'ExampleCloud',
 				'urlGenerator' => $this->urlGenerator,
 				'stateToken' => 'StateToken',
-				'serverHost' => 'example.com',
+				'serverHost' => 'https://example.com',
 				'oauthState' => 'OauthStateToken',
 			],
 			'guest'


### PR DESCRIPTION
If a user can't authenticate normally (because they have 2FA that is not
available on their devices for example). The redirect that is generated
should be of the proper format.

This means

1. Include the protocol
2. Include the possible subfolder

Discovered while debugging https://github.com/nextcloud/desktop/issues/596