### PR TITLE
Sidebar fixes, mostly fixing design of tabs

### DIFF
--- a/apps/files/css/detailsView.scss
+++ b/apps/files/css/detailsView.scss
@@ -15,7 +15,13 @@
 
 #app-sidebar .mainFileInfoView .permalink {
 	padding: 6px 10px;
-	vertical-align: text-top;
+	vertical-align: top;
+	opacity: .6;
+
+	&:hover,
+	&:focus {
+		opacity: 1;
+	}
 }
 #app-sidebar .mainFileInfoView .permalink-field>input {
 	clear: both;
@@ -87,7 +93,7 @@
 }
 
 #app-sidebar .fileName h3 {
-	width: calc(100% - 36px); /* 36px is the with of the copy link icon */
+	width: calc(100% - 42px); /* 36px is the with of the copy link icon, but this breaks so we add some more to be sure */
 	display: inline-block;
 	padding: 5px 0;
 	margin: -5px 0;

--- a/apps/files_versions/js/versionstabview.js
+++ b/apps/files_versions/js/versionstabview.js
@@ -38,6 +38,10 @@
 			return t('files_versions', 'Versions');
 		},
 
+		getIcon: function() {
+			return 'icon-history';
+		},
+
 		nextPage: function() {
 			if (this._loading) {
 				return;

--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -781,27 +781,47 @@ kbd {
 
 /* TABS ------------------------------------------------------------ */
 .tabHeaders {
-	display: inline-block;
-	margin: 15px;
+	display: flex;
+	margin-bottom: 16px;
+
 	.tabHeader {
-		float: left;
-		padding: 12px;
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
+		text-align: center;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
 		cursor: pointer;
 		color: var(--color-text-lighter);
 		margin-bottom: 1px;
+		padding: 5px;
+
+		/* Use same amount as sidebar padding */
+		&:first-child {
+			padding-left: 15px;
+		}
+		&:last-child {
+			padding-right: 15px;
+		}
+
 		.icon {
 			display: inline-block;
-			width: 16px;
+			width: 100%;
 			height: 16px;
 			background-size: 16px;
 			vertical-align: middle;
 			margin-top: -2px;
 			margin-right: 3px;
 			opacity: .7;
+			cursor: pointer;
 		}
+
 		a {
 			color: var(--color-text-lighter);
 			margin-bottom: 1px;
+			overflow: hidden;
+			text-overflow: ellipsis;
 		}
 		&.selected {
 			font-weight: bold;


### PR DESCRIPTION
The tabs in the Files sidebar were utterly broken, which is very obvious on any screen which is not 4k resolution, or as soon as the 4th tab shows. This is especially visible now because we added nice icons to all the tabs.

![tabs broken](https://user-images.githubusercontent.com/925062/47830683-473b5c80-dd8d-11e8-83e6-38b4eaaa4cba.gif)

:nauseated_face: 

So here you go with nicer tab layout:
- Flexbox, using the available width
- Icon above text for better look and more space for tabs
- Adjusted whitespace around

![sidebar tabs](https://user-images.githubusercontent.com/925062/47830685-473b5c80-dd8d-11e8-87c3-7f2a235b27ba.png)
--------------

**Even if we add Chat it works – cc** @danxuliu 

![even if we add chat it works](https://user-images.githubusercontent.com/925062/47830687-47d3f300-dd8d-11e8-9788-3061dee1cd8c.png)

---------------
**And even if we really loose our minds 🤯**
![overflow of list](https://user-images.githubusercontent.com/925062/47830688-47d3f300-dd8d-11e8-911d-bf6c7bc77d5d.png)

--------------
Please review @nextcloud/designers, also cc @nickvergessen & @georgehrke for evaluation with Talk and Calendar apps.

Now this is only a stop-gap solution of course. We still need to work towards limiting the amount of tabs in there as per **Sidebar standardization https://github.com/nextcloud/server/issues/10289** and **Sidebar: combine file Activity, Comments and Versions into unified »Activity« timeline tab #658**