### PR TITLE
[stable14] add global site selector as user back-end which doesn't support password confirmation

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
@@ -39,6 +39,8 @@ class PasswordConfirmationMiddleware extends Middleware {
 	private $userSession;
 	/** @var ITimeFactory */
 	private $timeFactory;
+	/** @var array */
+	private $excludedUserBackEnds = ['user_saml' => true, 'user_globalsiteselector' => true];
 
 	/**
 	 * PasswordConfirmationMiddleware constructor.
@@ -73,7 +75,7 @@ class PasswordConfirmationMiddleware extends Middleware {
 
 			$lastConfirm = (int) $this->session->get('last-password-confirm');
 			// we can't check the password against a SAML backend, so skip password confirmation in this case
-			if ($backendClassName !== 'user_saml' && $lastConfirm < ($this->timeFactory->getTime() - (30 * 60 + 15))) { // allow 15 seconds delay
+			if (!isset($this->excludedUserBackEnds[$backendClassName]) && $lastConfirm < ($this->timeFactory->getTime() - (30 * 60 + 15))) { // allow 15 seconds delay
 				throw new NotConfirmedException();
 			}
 		}

--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -70,6 +70,9 @@ class JSConfigHelper {
 	/** @var CapabilitiesManager */
 	private $capabilitiesManager;
 
+	/** @var array user back-ends excluded from password verification */
+	private $excludedUserBackEnds = ['user_saml' => true, 'user_globalsiteselector' => true];
+
 	/**
 	 * @param IL10N $l
 	 * @param Defaults $defaults
@@ -158,7 +161,7 @@ class JSConfigHelper {
 		$array = [
 			"oc_debug" => $this->config->getSystemValue('debug', false) ? 'true' : 'false',
 			"oc_isadmin" => $this->groupManager->isAdmin($uid) ? 'true' : 'false',
-			"backendAllowsPasswordConfirmation" => $userBackend === 'user_saml'? 'false' : 'true',
+			"backendAllowsPasswordConfirmation" => !isset($this->excludedUserBackEnds[$userBackend]) ? 'true' : 'false',
 			"oc_dataURL" => is_string($dataLocation) ? "\"".$dataLocation."\"" : 'false',
 			"oc_webroot" => "\"".\OC::$WEBROOT."\"",
 			"oc_appswebroots" =>  str_replace('\\/', '/', json_encode($apps_paths)), // Ugly unescape slashes waiting for better solution


### PR DESCRIPTION
beside user_saml, also the user management implemented in the global site selector doesn't support password verification.

backport of https://github.com/nextcloud/server/pull/12085