### PR TITLE
Cleanup the DIContainer

### DIFF
--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -37,6 +37,7 @@ use OC\AppFramework\Utility\SimpleContainer;
 use OCA\Files_Sharing\Controller\ExternalSharesController;
 use OCA\Files_Sharing\Controller\ShareController;
 use OCA\Files_Sharing\Middleware\SharingCheckMiddleware;
+use OCP\AppFramework\Utility\IControllerMethodReflector;
 use OCP\Defaults;
 use OCP\Federation\ICloudIdManager;
 use \OCP\IContainer;
@@ -120,7 +121,7 @@ class Application extends App {
 				$c->query('AppName'),
 				$server->getConfig(),
 				$server->getAppManager(),
-				$c['ControllerMethodReflector'],
+				$server->query(IControllerMethodReflector::class),
 				$server->getShareManager(),
 				$server->getRequest()
 			);

--- a/apps/provisioning_api/lib/AppInfo/Application.php
+++ b/apps/provisioning_api/lib/AppInfo/Application.php
@@ -29,6 +29,7 @@ use OC\AppFramework\Utility\TimeFactory;
 use OC\Settings\Mailer\NewUserMailHelper;
 use OCA\Provisioning_API\Middleware\ProvisioningApiMiddleware;
 use OCP\AppFramework\App;
+use OCP\AppFramework\Utility\IControllerMethodReflector;
 use OCP\Defaults;
 use OCP\Util;
 
@@ -57,7 +58,7 @@ class Application extends App {
 			$isAdmin = $user !== null ? $server->getGroupManager()->isAdmin($user->getUID()) : false;
 			$isSubAdmin = $user !== null ? $server->getGroupManager()->getSubAdmin()->isSubAdmin($user) : false;
 			return new ProvisioningApiMiddleware(
-				$c['ControllerMethodReflector'],
+				$c->query(IControllerMethodReflector::class),
 				$isAdmin,
 				$isSubAdmin
 			);

--- a/lib/private/AppFramework/App.php
+++ b/lib/private/AppFramework/App.php
@@ -84,9 +84,9 @@ class App {
 	 */
 	public static function main(string $controllerName, string $methodName, DIContainer $container, array $urlParams = null) {
 		if (!is_null($urlParams)) {
-			$container[IRequest::class]->setUrlParameters($urlParams);
+			$container->query(IRequest::class)->setUrlParameters($urlParams);
 		} else if (isset($container['urlParams']) && !is_null($container['urlParams'])) {
-			$container[IRequest::class]->setUrlParameters($container['urlParams']);
+			$container->query(IRequest::class)->setUrlParameters($container['urlParams']);
 		}
 		$appName = $container['AppName'];
 

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -152,14 +152,6 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return $c->query(OC\GlobalScale\Config::class);
 		});
 
-		$this->registerService(\OC\Security\IdentityProof\Manager::class, function ($c) {
-			return new \OC\Security\IdentityProof\Manager(
-				$this->getServer()->query(\OC\Files\AppData\Factory::class),
-				$this->getServer()->getCrypto(),
-				$this->getServer()->getConfig()
-			);
-		});
-
 		$this->registerService('Protocol', function($c){
 			/** @var \OC\Server $server */
 			$server = $c->query('ServerContainer');

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -125,9 +125,6 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return new OC\AppFramework\Logger($this->server->query(ILogger::class), $c->query('AppName'));
 		});
 
-		$this->registerAlias(\OCP\AppFramework\Utility\IControllerMethodReflector::class, \OC\AppFramework\Utility\ControllerMethodReflector::class);
-		$this->registerAlias('ControllerMethodReflector', \OCP\AppFramework\Utility\IControllerMethodReflector::class);
-
 		$this->registerService(IRequest::class, function() {
 			return $this->getServer()->query(IRequest::class);
 		});

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -125,8 +125,6 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return new OC\AppFramework\Logger($this->server->query(ILogger::class), $c->query('AppName'));
 		});
 
-		$this->registerAlias(\OC\User\Session::class, \OCP\IUserSession::class);
-
 		$this->registerService(IServerContainer::class, function ($c) {
 			return $this->getServer();
 		});

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -46,7 +46,6 @@ use OC\AppFramework\Middleware\Security\RateLimitingMiddleware;
 use OC\AppFramework\Middleware\Security\SecurityMiddleware;
 use OC\AppFramework\Middleware\SessionMiddleware;
 use OC\AppFramework\Utility\SimpleContainer;
-use OC\Collaboration\Collaborators\SearchResult;
 use OC\Core\Middleware\TwoFactorMiddleware;
 use OC\RichObjectStrings\Validator;
 use OC\ServerContainer;
@@ -54,13 +53,11 @@ use OCP\AppFramework\Http\IOutput;
 use OCP\AppFramework\IAppContainer;
 use OCP\AppFramework\QueryException;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\Collaboration\Collaborators\ISearchResult;
 use OCP\Files\Folder;
 use OCP\Files\IAppData;
 use OCP\GlobalScale\IConfig;
 use OCP\IL10N;
 use OCP\ILogger;
-use OCP\IRequest;
 use OCP\IServerContainer;
 use OCP\ISession;
 use OCP\IUserSession;
@@ -137,8 +134,6 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		$this->registerService(\OCP\AppFramework\IAppContainer::class, function ($c) {
 			return $c;
 		});
-
-		$this->registerAlias(ISearchResult::class, SearchResult::class);
 
 		// commonly used attributes
 		$this->registerService('UserId', function ($c) {

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -152,10 +152,6 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return $c->query(OC\GlobalScale\Config::class);
 		});
 
-		$this->registerService(IValidator::class, function($c) {
-			return $c->query(Validator::class);
-		});
-
 		$this->registerService(\OC\Security\IdentityProof\Manager::class, function ($c) {
 			return new \OC\Security\IdentityProof\Manager(
 				$this->getServer()->query(\OC\Files\AppData\Factory::class),

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -125,9 +125,6 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return new OC\AppFramework\Logger($this->server->query(ILogger::class), $c->query('AppName'));
 		});
 
-		$this->registerAlias(\OCP\AppFramework\Utility\ITimeFactory::class, \OC\AppFramework\Utility\TimeFactory::class);
-		$this->registerAlias('TimeFactory', \OCP\AppFramework\Utility\ITimeFactory::class);
-
 		$this->registerAlias(\OC\User\Session::class, \OCP\IUserSession::class);
 
 		$this->registerService(IServerContainer::class, function ($c) {

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -148,10 +148,6 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return $c->getServer()->getThemingDefaults();
 		});
 
-		$this->registerService(IManager::class, function ($c) {
-			return $this->getServer()->getEncryptionManager();
-		});
-
 		$this->registerService(IConfig::class, function ($c) {
 			return $c->query(OC\GlobalScale\Config::class);
 		});

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -125,11 +125,6 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return new OC\AppFramework\Logger($this->server->query(ILogger::class), $c->query('AppName'));
 		});
 
-		$this->registerService(IRequest::class, function() {
-			return $this->getServer()->query(IRequest::class);
-		});
-		$this->registerAlias('Request', IRequest::class);
-
 		$this->registerAlias(\OCP\AppFramework\Utility\ITimeFactory::class, \OC\AppFramework\Utility\TimeFactory::class);
 		$this->registerAlias('TimeFactory', \OCP\AppFramework\Utility\ITimeFactory::class);
 

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -164,7 +164,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return new Dispatcher(
 				$c['Protocol'],
 				$c['MiddlewareDispatcher'],
-				$c['ControllerMethodReflector'],
+				$c->query(IControllerMethodReflector::class),
 				$c['Request']
 			);
 		});

--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -176,5 +176,4 @@ class SimpleContainer extends Container implements IContainer {
 		}
 		return $name;
 	}
-
 }

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -217,7 +217,7 @@ class Server extends ServerContainer implements IServerContainer {
 			);
 		});
 
-		$this->registerService('EncryptionManager', function (Server $c) {
+		$this->registerService(\OCP\Encryption\IManager::class, function (Server $c) {
 			$view = new View();
 			$util = new Encryption\Util(
 				$view,
@@ -234,6 +234,7 @@ class Server extends ServerContainer implements IServerContainer {
 				new ArrayCache()
 			);
 		});
+		$this->registerAlias('EncryptionManager', \OCP\Encryption\IManager::class);
 
 		$this->registerService('EncryptionFileHelper', function (Server $c) {
 			$util = new Encryption\Util(

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1084,6 +1084,7 @@ class Server extends ServerContainer implements IServerContainer {
 			return $instance;
 		});
 		$this->registerAlias('CollaboratorSearch', \OCP\Collaboration\Collaborators\ISearch::class);
+		$this->registerAlias(\OCP\Collaboration\Collaborators\ISearchResult::class, \OC\Collaboration\Collaborators\SearchResult::class);
 
 		$this->registerAlias(\OCP\Collaboration\AutoComplete\IManager::class, \OC\Collaboration\AutoComplete\Manager::class);
 

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -361,7 +361,7 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 		$this->registerAlias(IProvider::class, Authentication\Token\Manager::class);
 
-		$this->registerService(\OCP\IUserSession::class, function (Server $c) {
+		$this->registerService(\OC\User\Session::class, function (Server $c) {
 			$manager = $c->getUserManager();
 			$session = new \OC\Session\Memory('');
 			$timeFactory = new TimeFactory();
@@ -430,7 +430,8 @@ class Server extends ServerContainer implements IServerContainer {
 			});
 			return $userSession;
 		});
-		$this->registerAlias('UserSession', \OCP\IUserSession::class);
+		$this->registerAlias(\OCP\IUserSession::class, \OC\User\Session::class);
+		$this->registerAlias('UserSession', \OC\User\Session::class);
 
 		$this->registerAlias(\OCP\Authentication\TwoFactorAuth\IRegistry::class, \OC\Authentication\TwoFactorAuth\Registry::class);
 

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1191,6 +1191,14 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerAlias(IDashboardManager::class, DashboardManager::class);
 		$this->registerAlias(IFullTextSearchManager::class, FullTextSearchManager::class);
 
+		$this->registerService(\OC\Security\IdentityProof\Manager::class, function (Server $c) {
+			return new \OC\Security\IdentityProof\Manager(
+				$c->query(\OC\Files\AppData\Factory::class),
+				$c->getCrypto(),
+				$c->getConfig()
+			);
+		});
+
 		$this->connectDispatcher();
 	}
 

--- a/tests/lib/AppFramework/AppTest.php
+++ b/tests/lib/AppFramework/AppTest.php
@@ -25,6 +25,8 @@
 namespace Test\AppFramework;
 
 use OC\AppFramework\App;
+use OC\AppFramework\Http\Dispatcher;
+use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Response;
 
@@ -60,16 +62,9 @@ class AppTest extends \Test\TestCase {
 		parent::setUp();
 
 		$this->container = new \OC\AppFramework\DependencyInjection\DIContainer('test', array());
-		$this->controller = $this->getMockBuilder(
-			'OCP\AppFramework\Controller')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->dispatcher = $this->getMockBuilder(
-			'OC\AppFramework\Http\Dispatcher')
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->io = $this->getMockBuilder('OCP\\AppFramework\\Http\\IOutput')->getMock();
+		$this->controller = $this->createMock(Controller::class);
+		$this->dispatcher = $this->createMock(Dispatcher::class);
+		$this->io = $this->createMock(Http\IOutput::class);
 
 		$this->headers = array('key' => 'value');
 		$this->output = 'hi';

--- a/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
+++ b/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
@@ -40,7 +40,6 @@ class DIContainerTest extends \Test\TestCase {
 
 	/** @var DIContainer|\PHPUnit_Framework_MockObject_MockObject */
 	private $container;
-	private $api;
 
 	protected function setUp(){
 		parent::setUp();
@@ -78,12 +77,8 @@ class DIContainerTest extends \Test\TestCase {
 	public function testMiddlewareDispatcherIncludesSecurityMiddleware(){
 		$this->container['Request'] = new Request(
 			['method' => 'GET'],
-			$this->getMockBuilder(ISecureRandom::class)
-				->disableOriginalConstructor()
-				->getMock(),
-			$this->getMockBuilder(IConfig::class)
-				->disableOriginalConstructor()
-				->getMock()
+			$this->createMock(ISecureRandom::class),
+			$this->createMock(IConfig::class)
 		);
 		$security = $this->container['SecurityMiddleware'];
 		$dispatcher = $this->container['MiddlewareDispatcher'];


### PR DESCRIPTION
There was a lot of stuff registered in every DIContainer while it should just be in the ServerContainer.

This is quite a waste as it:

1. Calls the regsiter functions for each container
2. It avoid sharing of instances
3. It should just be in the right place :wink: 