### PR TITLE
Revert important rule for hidden class and inline button style

### DIFF
--- a/core/css/global.scss
+++ b/core/css/global.scss
@@ -25,12 +25,12 @@
 }
 
 .hidden {
-	display: none !important; /* Hiding should take precedence */
+	display: none;
 }
 
 .hidden-visually {
 	position: absolute;
-	left: -10000px;
+	left:-10000px;
 	top: auto;
 	width: 1px;
 	height: 1px;

--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -163,7 +163,6 @@ input[type='reset'] {
 	padding: 6px 12px;
 	width: auto;
 	min-height: 34px;
-	display: inline-block;
 	cursor: pointer;
 	box-sizing: border-box;
 	background-color: var(--color-background-dark);


### PR DESCRIPTION
Unfortunately the `display: none !important;` will break every point where we use a hidden class and try to show it with jQuery functions like `show` or `slideDown`, because jQuery will set an inline css rule of `display: block;` which doesn't have any effect then.

This is for example:
- any popovermenu that uses OC.registerMenu, like the sharing settings popover
- app token settings

Because of that this PR reverts #12138 and #12167

For https://github.com/nextcloud/server/issues/3752 i would propose to just apply the inline-block only to the twofactor buttons. 

cc @jancborchardt @violoncelloch 