### PR TITLE
Log the previous exception during hard failure

### DIFF
--- a/index.php
+++ b/index.php
@@ -78,7 +78,7 @@ try {
 		print("Please contact the server administrator if this error reappears multiple times, please include the technical details below in your report.\n");
 		print("More details can be found in the webserver log.\n");
 
-		throw $e;
+		throw $ex;
 	}
 	OC_Template::printExceptionErrorPage($ex, 500);
 }


### PR DESCRIPTION
* otherwise the exception that was caused by the template is logged


I noticed this while trying to access Nextcloud while the config/ directory itself was not readable or writable (didn't remind that well anymore).