### PR TITLE
Wait for the link share menu to open in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -320,6 +320,14 @@ class FilesAppContext implements Context, ActorAwareInterface {
 		$this->actor->find(FileListContext::shareActionForFile(self::currentSectionMainView(), $fileName), 10)->click();
 
 		$this->actor->find(self::shareLinkAddNewButton(), 5)->click();
+
+		// Wait until the menu was opened after the share creation to continue.
+		if (!WaitFor::elementToBeEventuallyShown(
+				$this->actor,
+				self::shareLinkMenu(),
+				$timeout = 5 * $this->actor->getFindTimeoutMultiplier())) {
+			PHPUnit_Framework_Assert::fail("The share link menu is not open yet after $timeout seconds");
+		}
 	}
 
 	/**


### PR DESCRIPTION
In the acceptance tests [the link share menu is automatically opened if needed](https://github.com/nextcloud/server/blob/b23289da1a9c7a6be87d2e421a44199fc64a986c/tests/acceptance/features/bootstrap/FilesAppContext.php#L550) before interacting with an item in the menu; if the menu is not open it is opened by clicking on its toggle.

However, since [a recent change](https://github.com/nextcloud/server/commit/0a70544cd93c02e0ec5c2571400b5d00ed97c456#diff-da7df34db49581af77bd59e4f269dc36R206) the link share menu is automatically opened by the regular UI after the link share is created. This causes that, sometimes, after the creation of a link share the acceptance tests check whether the menu is shown or not before the menu was automatically opened; as the menu is not open then the acceptance tests proceed to click on the toggle, but in the meantime the link share was created and the menu opened, so clicking on the toggle now closes it. As the menu is closed it is not possible to interact with its items and the test fails.

To prevent that now the acceptance tests wait for the link share menu to open after a link share is created before continuing with the other steps.
