### PR TITLE
Set the filemodel before rending the detailsview

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -576,8 +576,8 @@
 			}
 
 			this._currentFileModel = model;
-			this._detailsView.render();
 			this._detailsView.setFileInfo(model);
+			this._detailsView.render();
 			this._detailsView.$el.scrollTop(0);
 		},
 


### PR DESCRIPTION
fixes #10934

Else it triggers the rendering two times. Resulting is weird state in
for example the comments. Because the comments for OLD_FILEID are
retrieved but then the model is changed to NEW_FILEID. But the old
comments still get in and get parsed.

This of course comes with the usual warnings that if I do javascript it is mostly YOLO