### PR TITLE
Add class "settings-hint" to 2FA-text

### DIFF
--- a/settings/src/components/AdminTwoFactor.vue
+++ b/settings/src/components/AdminTwoFactor.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>
-		<p>
+		<p class="settings-hint">
 			{{ t('settings', 'Two-factor authentication can be enforced for all	users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system.') }}
 		</p>
 		<p v-if="loading">


### PR DESCRIPTION
Partly fixes the design issues with #12249 👨‍🎨

**Before:**
![screenshot_2018-11-05 einstellungen - nextcloud 1](https://user-images.githubusercontent.com/19711361/47971327-a13f6900-e090-11e8-8c2a-760def1bb979.png)

**After:**
![screenshot_2018-11-05 einstellungen - nextcloud](https://user-images.githubusercontent.com/19711361/47971330-a4d2f000-e090-11e8-987f-acce5da9300d.png)

@ChristophWurst @schiessle @nextcloud/designers 

Signed-off-by: Marius Blüm <marius@lineone.io