### PR TITLE
changed -bs to -t option to pass to sendmail

### DIFF
--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -282,6 +282,6 @@ class Mailer implements IMailer {
 				break;
 		}
 
-		return new \Swift_SendmailTransport($binaryPath . ' -bs');
+		return new \Swift_SendmailTransport($binaryPath . ' -t');
 	}
 }


### PR DESCRIPTION
from the manpage: "Read message for recipients. To:, Cc:, and Bcc: lines will be scanned for recipient addresses. The Bcc: line will be deleted before transmission."

see issue #11281