### PR TITLE
Properly search the root of a shared external storage

### DIFF
--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -94,7 +94,7 @@ class CacheJail extends CacheWrapper {
 
 	protected function filterCacheEntry($entry) {
 		$rootLength = strlen($this->getRoot()) + 1;
-		return ($entry['path'] === $this->getRoot()) or (substr($entry['path'], 0, $rootLength) === $this->getRoot() . '/');
+		return $rootLength === 1 || ($entry['path'] === $this->getRoot()) || (substr($entry['path'], 0, $rootLength) === $this->getRoot() . '/');
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1020

When an external storage is shared with you in full the root is ''
(empty). This adds an extra check for an empty jail basically.

Because if the jail is on the empty string. It matches all paths.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>