### PR TITLE
Better primary visual on public pages

### DIFF
--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -192,6 +192,20 @@ thead {
 	font-weight: bold;
 }
 
+// hide the download entry on the menu
+// on public share when NOT on mobile
+@media only screen and (min-width: 769px) {
+	#body-public {
+		.header-right {
+			#header-actions-menu {
+				> ul > li#download {
+					display: none;
+				}
+			}
+		}
+	}
+}
+
 // hide the primary on public share on mobile
 @media only screen and (max-width: 768px) {
 	#body-public {

--- a/core/templates/layout.public.php
+++ b/core/templates/layout.public.php
@@ -51,18 +51,18 @@
 			?>
 		<div class="header-right">
 			<span id="header-primary-action" class="<?php if($template->getActionCount() === 1) {  p($primary->getIcon()); } ?>">
-				<a href="<?php p($primary->getLink()); ?>">
+				<a href="<?php p($primary->getLink()); ?>" class="primary button">
 					<span><?php p($primary->getLabel()) ?></span>
 				</a>
 			</span>
-			<?php if($template->getActionCount()>1) { ?>
+			<?php if($template->getActionCount() > 1) { ?>
 			<div id="header-secondary-action">
 				<span id="header-actions-toggle" class="menutoggle icon-more-white"></span>
 				<div id="header-actions-menu" class="popovermenu menu">
 					<ul>
 						<?php
 							/** @var \OCP\AppFramework\Http\Template\IMenuAction $action */
-							foreach($template->getOtherActions() as $action) {
+							foreach($others as $action) {
 								print_unescaped($action->render());
 							}
 						?>


### PR DESCRIPTION
- better visual for the primary button
- hide the download button when the primary is shown

fix #9933
@nextcloud/designers 

@juliushaertl should we always display the primary in the menu and only show it when mobile?
I mean, not only the download? :thinking: 
@nextcloud/designers any thoughts?