### PR TITLE
Add "password" parameter to the response data of link shares

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -208,8 +208,12 @@ class ShareAPIController extends OCSController {
 			$result['share_with_displayname'] = $group !== null ? $group->getDisplayName() : $share->getSharedWith();
 		} else if ($share->getShareType() === Share::SHARE_TYPE_LINK) {
 
+			// "share_with" and "share_with_displayname" for passwords of link
+			// shares was deprecated in Nextcloud 15, use "password" instead.
 			$result['share_with'] = $share->getPassword();
 			$result['share_with_displayname'] = $share->getPassword();
+
+			$result['password'] = $share->getPassword();
 
 			$result['send_password_by_talk'] = $share->getSendPasswordByTalk();
 

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -428,6 +428,7 @@ class ShareAPIControllerTest extends TestCase {
 		$expected = [
 			'id' => 101,
 			'share_type' => \OCP\Share::SHARE_TYPE_LINK,
+			'password' => 'password',
 			'share_with' => 'password',
 			'share_with_displayname' => 'password',
 			'send_password_by_talk' => false,
@@ -2687,6 +2688,7 @@ class ShareAPIControllerTest extends TestCase {
 				'file_source' => 3,
 				'file_parent' => 1,
 				'file_target' => 'myTarget',
+				'password' => 'mypassword',
 				'share_with' => 'mypassword',
 				'share_with_displayname' => 'mypassword',
 				'send_password_by_talk' => false,
@@ -2736,6 +2738,7 @@ class ShareAPIControllerTest extends TestCase {
 				'file_source' => 3,
 				'file_parent' => 1,
 				'file_target' => 'myTarget',
+				'password' => 'mypassword',
 				'share_with' => 'mypassword',
 				'share_with_displayname' => 'mypassword',
 				'send_password_by_talk' => true,


### PR DESCRIPTION
Due to legacy reasons the password of link shares was returned in the `share_with` and `share_with_displayname` parameters of the response data. Now a proper `password` parameter is returned too.

@camilasan @marinofaggiana @rullzer @tobiasKaminsky No need to hurry updating the clients, the old `share_with` and `share_with_displayname` parameters are kept for now; they will be removed in a future version of Nextcloud, but only once it is safe to do it, of course :-)
