### PR TITLE
Fix missing dot before class name

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -553,8 +553,10 @@ nav[role='navigation'] {
 		li {
 			/* Move up app icon */
 			svg,
-			.icon-more, icon-more-white,
-			.icon-loading-small, .icon-loading-small-dark {
+			.icon-more,
+			.icon-more-white,
+			.icon-loading-small,
+			.icon-loading-small-dark {
 				transform: translateY(-7px);
 			}
 
@@ -583,8 +585,10 @@ nav[role='navigation'] {
 	li a:focus {
 		/* Move up app icon */
 		svg,
-		.icon-more, icon-more-white,
-		.icon-loading-small, .icon-loading-small-dark {
+		.icon-more,
+		.icon-more-white,
+		.icon-loading-small,
+		.icon-loading-small-dark {
 			transform: translateY(-7px);
 		}
 


### PR DESCRIPTION
Fixed the issue that the 3-dot-more icon did not move up with the other app navigation items. Follow-up to https://github.com/nextcloud/server/pull/12216

Simple fix, please review @juliushaertl @nextcloud/designers :) (Also, this seems to be one reason why having only one selector per line is good. :D )