### PR TITLE
Add test that unique constraint is working

### DIFF
--- a/tests/lib/DB/ConnectionTest.php
+++ b/tests/lib/DB/ConnectionTest.php
@@ -336,4 +336,17 @@ class ConnectionTest extends \Test\TestCase {
 		$this->assertEquals(0, $result);
 	}
 
+	/**
+	 * @expectedException \Doctrine\DBAL\Exception\UniqueConstraintViolationException
+	 */
+	public function testUniqueConstraintViolating() {
+		$this->makeTestTable();
+
+		$testQuery = 'INSERT INTO `*PREFIX*table` (`integerfield`, `textfield`) VALUES(?, ?)';
+		$testParams = [1, 'hello'];
+
+		$this->connection->executeUpdate($testQuery, $testParams);
+		$this->connection->executeUpdate($testQuery, $testParams);
+	}
+
 }


### PR DESCRIPTION
A small test to validate the insert with unique constraint works the same for `mysql`, `pqsql`, `oracle` and `sqlite`. I noticed too late that you are testing this already within another test :disappointed: but before I throw it away. 