### PR TITLE
Also use default label if share label is null

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -825,7 +825,7 @@
 			return _.extend({}, share, {
 				cid: share.id,
 				shareAllowed: true,
-				linkShareLabel: share.label !== '' ? share.label : t('core', 'Share link'),
+				linkShareLabel: share.label ? share.label : t('core', 'Share link'),
 				popoverMenu: {},
 				shareLinkURL: share.url,
 				newShareTitle: t('core', 'New share link'),


### PR DESCRIPTION
If a share link was there before the multiple share link pr was merged, the label was null and therefore nothing was rendered in the UI.

Fixes #12314 