### PR TITLE
Remove arrow function for ie compatibility

### DIFF
--- a/settings/js/settings.js
+++ b/settings/js/settings.js
@@ -55,7 +55,9 @@ OC.Settings = _.extend(OC.Settings, {
                                     selection = _.map((groups || []).split('|').sort(), function(groupId) {
                                         return {
                                             id: groupId,
-                                            displayname: results.find(group => group.id === groupId).displayname
+                                            displayname: results.find(function (group) {
+                                                return group.id === groupId;
+                                            }).displayname
                                         };
                                     });
                                 } else if (groups) {


### PR DESCRIPTION
Fix ie11 throwing error on settings and script not working
![capture d ecran_2018-11-07_17-50-45](https://user-images.githubusercontent.com/14975046/48146655-c52fc400-e2b5-11e8-972d-67e2bafa410e.png)
