### PR TITLE
Add fix for IE11 flexbox height bug

### DIFF
--- a/core/css/ie.scss
+++ b/core/css/ie.scss
@@ -4,6 +4,11 @@
 }
 #app-content {
 	width: $navigation-width !important;
+	/**
+	 * set min height so the container will grow in IE11
+	 * https://stackoverflow.com/questions/28627879/flexbox-not-filling-height-in-ie11
+	 */
+	min-height: calc(100vh - 50px);
 }
 #app-sidebar.disappear {
 	right: -$sidebar-max-width !important;


### PR DESCRIPTION
Steps to reproduce:
1. Open a document in the richdocuments app in IE11

Before:
![image](https://user-images.githubusercontent.com/3404133/48153951-be11b180-e2c7-11e8-9185-5028bee82954.png)

After:
![image](https://user-images.githubusercontent.com/3404133/48153788-607d6500-e2c7-11e8-948e-f8c4380176cd.png)


