### PR TITLE
Basic CSP no longer deprecated

### DIFF
--- a/lib/public/AppFramework/Http/ContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/ContentSecurityPolicy.php
@@ -39,7 +39,6 @@ namespace OCP\AppFramework\Http;
  *
  * @package OCP\AppFramework\Http
  * @since 8.1.0
- * @deprecated 14.0.0 Use one of our stricter CSP policies
  */
 class ContentSecurityPolicy extends EmptyContentSecurityPolicy {
 	/** @var bool Whether inline JS snippets are allowed */


### PR DESCRIPTION
Since we chose to just tighten our default CSP it makes no sense to still have it deprecated.
The vision I had with this in 14 turned out not to entirely work out. So lets remove the deprecation and just continue with tightening the basic CSP.