### PR TITLE
Enable sorting in file picker

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -773,6 +773,47 @@ code {
 		margin-bottom: 50px;
 	}
 	.filelist {
+		thead {
+			tr {
+				border-bottom: 1px solid var(--color-border);
+				background-color: var(--color-main-background);
+				th {
+					width: auto;
+					border: none;
+				}
+			}
+		}
+		th .columntitle {
+			display: block;
+			padding: 15px;
+			height: 50px;
+			box-sizing: border-box;
+			-moz-box-sizing: border-box;
+			vertical-align: middle;
+		}
+		th .columntitle.name {
+			padding-left: 5px;
+			margin-left: 50px;
+		}
+
+		th .sort-indicator {
+			width: 10px;
+			height: 8px;
+			margin-left: 5px;
+			display: inline-block;
+			vertical-align: text-bottom;
+			opacity: .3;
+		}
+		.sort-indicator.hidden,
+		th:hover .sort-indicator.hidden,
+		th:focus .sort-indicator.hidden {
+			visibility: hidden;
+		}
+		th:hover .sort-indicator.hidden,
+		th:focus .sort-indicator.hidden {
+			visibility: visible;
+		}
+
 		td {
 			padding: 14px;
 			border-bottom: 1px solid var(--color-border);

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -778,7 +778,7 @@ code {
 				border-bottom: 1px solid var(--color-border);
 				background-color: var(--color-main-background);
 				th {
-					width: auto;
+					width: 80%;
 					border: none;
 				}
 			}

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -905,9 +905,9 @@ var OCdialogs = {
 		self.$fileListHeader.find('.sort-indicator').addClass('hidden').removeClass('icon-triangle-n').removeClass('icon-triangle-s');
 		self.$fileListHeader.find('[data-sort=' + self.filepicker.sortField + '] .sort-indicator').removeClass('hidden');
 		if (self.filepicker.sortOrder === 'asc') {
-			self.$fileListHeader.find('[data-sort=' + self.filepicker.sortField + '] .sort-indicator').addClass('icon-triangle-s');
-		} else {
 			self.$fileListHeader.find('[data-sort=' + self.filepicker.sortField + '] .sort-indicator').addClass('icon-triangle-n');
+		} else {
+			self.$fileListHeader.find('[data-sort=' + self.filepicker.sortField + '] .sort-indicator').addClass('icon-triangle-s');
 		}
 		self.filepicker.filesClient.getFolderContents(dir).then(function(status, files) {
 			if (filter && filter.length > 0 && filter.indexOf('*') === -1) {

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -257,6 +257,7 @@ var OCdialogs = {
 			self.$filePicker.ready(function() {
 				self.$fileListHeader = self.$filePicker.find('.filelist thead tr');
 				self.$filelist = self.$filePicker.find('.filelist tbody');
+				self.$filelistContainer = self.$filePicker.find('.filelist-container');
 				self.$dirTree = self.$filePicker.find('.dirtree');
 				self.$dirTree.on('click', 'div:not(:last-child)', self, function (event) {
 					self._handleTreeListSelect(event, type);
@@ -896,7 +897,9 @@ var OCdialogs = {
 	*/
 	_fillFilePicker:function(dir) {
 		var self = this;
-		this.$filelist.empty().addClass('icon-loading');
+		this.$filelist.empty();
+		this.$filePicker.find('.emptycontent').hide();
+		this.$filelistContainer.addClass('icon-loading');
 		this.$filePicker.data('path', dir);
 		var filter = this.$filePicker.data('mimetype');
 		if (typeof(filter) === "string") {
@@ -952,8 +955,10 @@ var OCdialogs = {
 
 			if (files.length === 0) {
 				self.$filePicker.find('.emptycontent').show();
+				self.$fileListHeader.hide();
 			} else {
 				self.$filePicker.find('.emptycontent').hide();
+				self.$fileListHeader.show();
 			}
 
 			$.each(files, function(idx, entry) {
@@ -993,7 +998,7 @@ var OCdialogs = {
 				self.$filelist.append($row);
 			});
 
-			self.$filelist.removeClass('icon-loading');
+			self.$filelistContainer.removeClass('icon-loading');
 		});
 	},
 	/**

--- a/core/templates/filepicker.html
+++ b/core/templates/filepicker.html
@@ -8,17 +8,39 @@
 			<h2>{emptytext}</h2>
 		</div>
 		<table id="filestable" class="filelist list-container view-grid">
+			<thead>
+				<tr>
+					<th id="headerName" class="column-name">
+						<div id="headerName-container">
+							<a class="name sort columntitle" data-sort="name">
+								<span>Name</span>
+								<span class="sort-indicator hidden icon-triangle-n"></span>
+							</a>
+						</div>
+					</th>
+					<th id="headerSize" class="column-size">
+						<a class="size sort columntitle" data-sort="size">
+							<span>Size</span>
+							<span class="sort-indicator hidden icon-triangle-n"></span></a>
+					</th>
+					<th id="headerDate" class="column-mtime">
+						<a id="modified" class="columntitle" data-sort="mtime">
+							<span>Modified</span>
+							<span class="sort-indicator hidden icon-triangle-n"></span></a>
+					</th>
+				</tr>
+			</thead>
 			<tbody>
-			<tr data-entryname="{filename}" data-type="{type}">
-				<td class="filename"
-					style="background-image:url({icon})">{filename}
-				</td>
-				<td class="filesize"
-					style="color:rgb({sizeColor}, {sizeColor}, {sizeColor})">
-					{size}
-				</td>
-				<td class="date">{date}</td>
-			</tr>
+				<tr data-entryname="{filename}" data-type="{type}">
+					<td class="filename"
+						style="background-image:url({icon})">{filename}
+					</td>
+					<td class="filesize"
+						style="color:rgb({sizeColor}, {sizeColor}, {sizeColor})">
+						{size}
+					</td>
+					<td class="date">{date}</td>
+				</tr>
 			</tbody>
 		</table>
 	</div>


### PR DESCRIPTION
Fixes #645 

This allows sorting the entries in the file picker by name, size or mtime.

List view:
![image](https://user-images.githubusercontent.com/3404133/48198967-eb5b6f80-e35a-11e8-8373-7974f9de8317.png)

Grid view:
![image](https://user-images.githubusercontent.com/3404133/48198993-ff9f6c80-e35a-11e8-98bc-23c9610fa0f1.png)

