### PR TITLE
Adjust acceptance tests to changes in public share page menu

### DIFF
--- a/tests/acceptance/features/bootstrap/FilesSharingAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesSharingAppContext.php
@@ -198,7 +198,10 @@ class FilesSharingAppContext implements Context, ActorAwareInterface {
 			PHPUnit_Framework_Assert::fail("The Share menu is not visible yet after $timeout seconds");
 		}
 
-		PHPUnit_Framework_Assert::assertTrue(
+		// The acceptance tests are run in a window wider than 768px, so the
+		// download item should not be shown in the menu (although it will be in
+		// the DOM).
+		PHPUnit_Framework_Assert::assertFalse(
 				$this->actor->find(self::downloadItemInShareMenu())->isVisible());
 		PHPUnit_Framework_Assert::assertTrue(
 				$this->actor->find(self::directLinkItemInShareMenu())->isVisible());


### PR DESCRIPTION
[The _Download_ item in the menu of public share pages is no longer shown in wide (>768px) windows](https://github.com/nextcloud/server/pull/12316); the element is anyway in the DOM, so the acceptance tests now check that the item is there but hidden.
