### PR TITLE
Reduces the footer link padding

### DIFF
--- a/core/css/public.scss
+++ b/core/css/public.scss
@@ -73,8 +73,8 @@ $footer-height: 65px;
 				font-weight: bold;
 				white-space: nowrap;
 				/* increasing clickability to more than the text height */
-				padding: 13px;
-				margin: -13px;
+				padding: 10px;
+				margin: -10px;
 				line-height: 200%;
 			}
 		}


### PR DESCRIPTION
Reduces the footer link padding:
Flexbox doesn't work with paddings... They are in to footer for better click ability.
So I reduced them until the scrollbar disappeard.

Closes #12357