### PR TITLE
Fixes the grid toggle for none folder shares

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -46,7 +46,7 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 	</div>
 <?php endif; ?>
 
-<?php if (!$_['isIE']) { ?>
+<?php if ($_['showgridview'] && empty($_['dir']) === false) { ?>
 	<input type="checkbox" class="hidden-visually" id="showgridview"
 		<?php if($_['showgridview']) { ?>checked="checked" <?php } ?>/>
 	<label id="view-toggle" for="showgridview" class="button <?php p($_['showgridview'] ? 'icon-toggle-filelist' : 'icon-toggle-pictures') ?>"


### PR DESCRIPTION
Closes #12356 
`$_['isIE']` was replaced by the show grid view thing - I fixed that too.