### PR TITLE
Customize presentation of accept/decline buttons in iMip mail

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -144,11 +144,11 @@ class IMipPlugin extends SabreIMipPlugin {
 
 		$summary = $iTipMessage->message->VEVENT->SUMMARY;
 
-		if (strcasecmp(parse_url($iTipMessage->sender, PHP_URL_SCHEME), 'mailto') !== 0) {
+		if (parse_url($iTipMessage->sender, PHP_URL_SCHEME) !== 'mailto') {
 			return;
 		}
 
-		if (strcasecmp(parse_url($iTipMessage->recipient, PHP_URL_SCHEME), 'mailto') !== 0) {
+		if (parse_url($iTipMessage->recipient, PHP_URL_SCHEME) !== 'mailto') {
 			return;
 		}
 

--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -242,7 +242,7 @@ class IMipPlugin extends SabreIMipPlugin {
 
 
 		// Only add response buttons to invitation requests: Fix Issue #11230
-		if ($method == self::METHOD_REQUEST) {
+		if (($method == self::METHOD_REQUEST) && $this->getAttendeeRSVP($attendee)) {
 
 			/*
 			** Only offer invitation accept/reject buttons, which link back to the
@@ -378,6 +378,21 @@ class IMipPlugin extends SabreIMipPlugin {
 			}
 		}
 		return $default;
+	}
+
+	/**
+	 * @param Property|null $attendee
+	 * @return bool
+	 */
+	private function getAttendeeRSVP(Property $attendee = null) {
+		if ($attendee !== null) {
+			$rsvp = $attendee->offsetGet('RSVP');
+			if (($rsvp instanceof Parameter) && (strcasecmp($rsvp->getValue(), 'TRUE') === 0)) {
+				return true;
+			}
+		}
+		// RFC 5545 3.2.17: default RSVP is false
+		return false;
 	}
 
 	/**
@@ -538,7 +553,7 @@ class IMipPlugin extends SabreIMipPlugin {
 			$moreOptionsURL, $l10n->t('More options …')
 		]);
 		$text = $l10n->t('More options at %s', [$moreOptionsURL]);
-		
+
 		$template->addBodyText($html, $text);
 	}
 

--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -249,28 +249,26 @@ class IMipPlugin extends SabreIMipPlugin {
 			** nextcloud server, to recipients who can access the nextcloud server via
 			** their internet/intranet.  Issue #12156
 			**
+			** The app setting is stored in the appconfig database table.
+			**
 			** For nextcloud servers accessible to the public internet, the default
-			** "dav.invitation_link_recipients" value "true" (all recipients) is appropriate.
+			** "invitation_link_recipients" value "yes" (all recipients) is appropriate.
 			**
 			** When the nextcloud server is restricted behind a firewall, accessible
 			** only via an internal network or via vpn, you can set "dav.invitation_link_recipients"
-			** to the email address or email domain, or array of addresses or domains,
+			** to the email address or email domain, or comma separated list of addresses or domains,
 			** of recipients who can access the server.
 			**
-			** To deliver URL's always, set invitation_link_recipients to boolean "true".
-			** To suppress URL's entirely, set invitation_link_recipients to boolean "false".
+			** To always deliver URLs, set invitation_link_recipients to "yes".
+			** To suppress URLs entirely, set invitation_link_recipients to boolean "no".
 			*/
 
 			$recipientDomain = substr(strrchr($recipient, "@"), 1);
-			$invitationLinkRecipients = $this->config->getSystemValue('dav.invitation_link_recipients', true);
-			if (is_array($invitationLinkRecipients)) {
-				$invitationLinkRecipients = array_map('strtolower', $invitationLinkRecipients); // for case insensitive in_array
-			}
-			if ($invitationLinkRecipients === true
-				 || (is_string($invitationLinkRecipients) && strcasecmp($recipient, $invitationLinkRecipients) === 0)
-				 || (is_string($invitationLinkRecipients) && strcasecmp($recipientDomain, $invitationLinkRecipients) === 0)
-				 || (is_array($invitationLinkRecipients) && in_array(strtolower($recipient), $invitationLinkRecipients))
-				 || (is_array($invitationLinkRecipients) && in_array(strtolower($recipientDomain), $invitationLinkRecipients))) {
+			$invitationLinkRecipients = explode(',', preg_replace('/\s+/', '', strtolower($this->config->getAppValue('dav', 'invitation_link_recipients', 'yes'))));
+
+			if (strcmp('yes', $invitationLinkRecipients[0]) === 0
+				 || in_array(strtolower($recipient), $invitationLinkRecipients)
+				 || in_array(strtolower($recipientDomain), $invitationLinkRecipients)) {
 				$this->addResponseButtons($template, $l10n, $iTipMessage, $lastOccurrence);
 			}
 		}

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
@@ -48,179 +48,76 @@ use Test\TestCase;
 
 class IMipPluginTest extends TestCase {
 
-	public function testDelivery() {
-		$mailMessage = $this->createMock(IMessage::class);
-		$mailMessage->method('setFrom')->willReturn($mailMessage);
-		$mailMessage->method('setReplyTo')->willReturn($mailMessage);
-		$mailMessage->method('setTo')->willReturn($mailMessage);
-		/** @var Mailer | \PHPUnit_Framework_MockObject_MockObject $mailer */
-		$mailer = $this->getMockBuilder(IMailer::class)->disableOriginalConstructor()->getMock();
-		$emailTemplate = $this->createMock(IEMailTemplate::class);
-		$emailAttachment = $this->createMock(IAttachment::class);
-		$mailer->method('createEMailTemplate')->willReturn($emailTemplate);
-		$mailer->method('createMessage')->willReturn($mailMessage);
-		$mailer->method('createAttachment')->willReturn($emailAttachment);
-		$mailer->expects($this->once())->method('send');
-		/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject $logger */
+        public function setUp() {
+		$this->mailMessage = $this->createMock(IMessage::class);
+		$this->mailMessage->method('setFrom')->willReturn($this->mailMessage);
+		$this->mailMessage->method('setReplyTo')->willReturn($this->mailMessage);
+		$this->mailMessage->method('setTo')->willReturn($this->mailMessage);
+
+		$this->mailer = $this->getMockBuilder(IMailer::class)->disableOriginalConstructor()->getMock();
+		$this->mailer->method('createMessage')->willReturn($this->mailMessage);
+
+		$this->emailTemplate = $this->createMock(IEMailTemplate::class);
+		$this->mailer->method('createEMailTemplate')->willReturn($this->emailTemplate);
+
+		$this->emailAttachment = $this->createMock(IAttachment::class);
+		$this->mailer->method('createAttachment')->willReturn($this->emailAttachment);
+
 		$logger = $this->getMockBuilder(ILogger::class)->disableOriginalConstructor()->getMock();
-		$timeFactory = $this->getMockBuilder(ITimeFactory::class)->disableOriginalConstructor()->getMock();
-		$timeFactory->method('getTime')->willReturn(1);
-		/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject $config */
-		$config = $this->createMock(IConfig::class);
-		$config->method('getSystemValue')
-			->with('dav.invitation_link_recipients', true)
-			->willReturn(true);
+
+		$this->timeFactory = $this->getMockBuilder(ITimeFactory::class)->disableOriginalConstructor()->getMock();
+		$this->timeFactory->method('getTime')->willReturn(1496912528); // 2017-01-01
+
+		$this->config = $this->createMock(IConfig::class);
+
 		$l10n = $this->createMock(IL10N::class);
-		/** @var IFactory | \PHPUnit_Framework_MockObject_MockObject $l10nFactory */
 		$l10nFactory = $this->createMock(IFactory::class);
 		$l10nFactory->method('get')->willReturn($l10n);
-		/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject $urlGenerator */
-		$urlGenerator = $this->createMock(IURLGenerator::class);
-		/** @var IDBConnection | \PHPUnit_Framework_MockObject_MockObject $db */
-		$db = $this->createMock(IDBConnection::class);
-		/** @var ISecureRandom | \PHPUnit_Framework_MockObject_MockObject $random */
-		$random = $this->createMock(ISecureRandom::class);
-		/** @var Defaults | \PHPUnit_Framework_MockObject_MockObject $defaults */
-		$defaults = $this->createMock(Defaults::class);
-		$defaults->expects($this->once())
-			->method('getName')
-			->will($this->returnValue('Instance Name 123'));
 
-		$random->expects($this->once())
-			->method('generate')
+		$urlGenerator = $this->createMock(IURLGenerator::class);
+
+		$this->queryBuilder = $this->createMock(IQueryBuilder::class);
+		$db = $this->createMock(IDBConnection::class);
+		$db->method('getQueryBuilder')
+			->with()
+			->will($this->returnValue($this->queryBuilder));
+
+		$random = $this->createMock(ISecureRandom::class);
+		$random->method('generate')
 			->with(60, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789')
 			->will($this->returnValue('random_token'));
 
-		$queryBuilder = $this->createMock(IQueryBuilder::class);
+		$defaults = $this->createMock(Defaults::class);
+		$defaults->method('getName')
+			->will($this->returnValue('Instance Name 123'));
 
-		$db->expects($this->once())
-			->method('getQueryBuilder')
-			->with()
-			->will($this->returnValue($queryBuilder));
-		$queryBuilder->expects($this->at(0))
-			->method('insert')
-			->with('calendar_invitations')
-			->will($this->returnValue($queryBuilder));
-		$queryBuilder->expects($this->at(8))
-			->method('values')
-			->will($this->returnValue($queryBuilder));
-		$queryBuilder->expects($this->at(9))
-			->method('execute');
+		$this->plugin = new IMipPlugin($this->config, $this->mailer, $logger, $this->timeFactory, $l10nFactory, $urlGenerator, $defaults, $random, $db, 'user123');
+	}
 
-		$plugin = new IMipPlugin($config, $mailer, $logger, $timeFactory, $l10nFactory, $urlGenerator, $defaults, $random, $db, 'user123');
-		$message = new Message();
-		$message->method = 'REQUEST';
-		$message->message = new VCalendar();
-		$message->message->add('VEVENT', [
-			'UID' => $message->uid,
-			'SEQUENCE' => $message->sequence,
-			'SUMMARY' => 'Fellowship meeting',
-			'DTSTART' => new \DateTime('2017-01-01 00:00:00') // 1483228800
-		]);
+	public function testDelivery() {
+		$this->config
+			->method('getSystemValue')
+			->with('dav.invitation_link_recipients', true)
+			->willReturn(true);
 
-		$message->message->VEVENT->add( 'ORGANIZER', 'mailto:gandalf@wiz.ard' );
-		$message->message->VEVENT->add( 'ATTENDEE', 'mailto:frodo@hobb.it', [ 'RSVP' => 'TRUE' ] );
-
-		$message->sender = 'mailto:gandalf@wiz.ard';
-		$message->recipient = 'mailto:frodo@hobb.it';
-
-		$emailTemplate->expects($this->once())
-			->method('setSubject')
-			->with('Invitation: Fellowship meeting');
-		$mailMessage->expects($this->once())
-			->method('setTo')
-			->with(['frodo@hobb.it' => null]);
-		$mailMessage->expects($this->once())
-			->method('setReplyTo')
-			->with(['gandalf@wiz.ard' => null]);
-
-		$plugin->schedule($message);
+		$message = $this->_testMessage();
+		$this->_expectSend();
+		$this->plugin->schedule($message);
 		$this->assertEquals('1.1', $message->getScheduleStatus());
 	}
 
 	public function testFailedDelivery() {
-		$mailMessage = $this->createMock(IMessage::class);
-		$mailMessage->method('setFrom')->willReturn($mailMessage);
-		$mailMessage->method('setReplyTo')->willReturn($mailMessage);
-		$mailMessage->method('setTo')->willReturn($mailMessage);
-		/** @var Mailer | \PHPUnit_Framework_MockObject_MockObject $mailer */
-		$mailer = $this->getMockBuilder(IMailer::class)->disableOriginalConstructor()->getMock();
-		$emailTemplate = $this->createMock(IEMailTemplate::class);
-		$emailAttachment = $this->createMock(IAttachment::class);
-		$mailer->method('createEMailTemplate')->willReturn($emailTemplate);
-		$mailer->method('createMessage')->willReturn($mailMessage);
-		$mailer->method('createAttachment')->willReturn($emailAttachment);
-		$mailer->method('send')->willThrowException(new \Exception());
-		/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject $logger */
-		$logger = $this->getMockBuilder(ILogger::class)->disableOriginalConstructor()->getMock();
-		$timeFactory = $this->getMockBuilder(ITimeFactory::class)->disableOriginalConstructor()->getMock();
-		$timeFactory->method('getTime')->willReturn(1);
-		/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject $config */
-		$config = $this->createMock(IConfig::class);
-		$config->method('getSystemValue')
+		$this->config
+			->method('getSystemValue')
 			->with('dav.invitation_link_recipients', true)
 			->willReturn(true);
 
-		$l10n = $this->createMock(IL10N::class);
-		/** @var IFactory | \PHPUnit_Framework_MockObject_MockObject $l10nFactory */
-		$l10nFactory = $this->createMock(IFactory::class);
-		$l10nFactory->method('get')->willReturn($l10n);
-		/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject $urlGenerator */
-		$urlGenerator = $this->createMock(IURLGenerator::class);
-		/** @var IDBConnection | \PHPUnit_Framework_MockObject_MockObject $db */
-		$db = $this->createMock(IDBConnection::class);
-		/** @var ISecureRandom | \PHPUnit_Framework_MockObject_MockObject $random */
-		$random = $this->createMock(ISecureRandom::class);
-		/** @var Defaults | \PHPUnit_Framework_MockObject_MockObject $defaults */
-		$defaults = $this->createMock(Defaults::class);
-
-		$random->expects($this->once())
-			->method('generate')
-			->with(60, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789')
-			->will($this->returnValue('random_token'));
-
-		$queryBuilder = $this->createMock(IQueryBuilder::class);
-
-		$db->expects($this->once())
-			->method('getQueryBuilder')
-			->with()
-			->will($this->returnValue($queryBuilder));
-		$queryBuilder->expects($this->at(0))
-			->method('insert')
-			->with('calendar_invitations')
-			->will($this->returnValue($queryBuilder));
-		$queryBuilder->expects($this->at(8))
-			->method('values')
-			->will($this->returnValue($queryBuilder));
-		$queryBuilder->expects($this->at(9))
-			->method('execute');
-
-		$plugin = new IMipPlugin($config, $mailer, $logger, $timeFactory, $l10nFactory, $urlGenerator, $defaults, $random, $db, 'user123');
-		$message = new Message();
-		$message->method = 'REQUEST';
-		$message->message = new VCalendar();
-		$message->message->add('VEVENT', [
-			'UID' => $message->uid,
-			'SEQUENCE' => $message->sequence,
-			'SUMMARY' => 'Fellowship meeting',
-			'DTSTART' => new \DateTime('2017-01-01 00:00:00') // 1483228800
-		]);
-		$message->message->VEVENT->add( 'ORGANIZER', 'mailto:gandalf@wiz.ard' );
-		$message->message->VEVENT->add( 'ATTENDEE', 'mailto:frodo@hobb.it', [ 'RSVP' => 'TRUE' ] );
-		$message->sender = 'mailto:gandalf@wiz.ard';
-		$message->recipient = 'mailto:frodo@hobb.it';
-
-		$emailTemplate->expects($this->once())
-			->method('setSubject')
-			->with('Invitation: Fellowship meeting');
-		$mailMessage->expects($this->once())
-			->method('setTo')
-			->with(['frodo@hobb.it' => null]);
-		$mailMessage->expects($this->once())
-			->method('setReplyTo')
-			->with(['gandalf@wiz.ard' => null]);
-
-		$plugin->schedule($message);
+		$message = $this->_testMessage();
+		$this->mailer
+			->method('send')
+			->willThrowException(new \Exception());
+		$this->_expectSend();
+		$this->plugin->schedule($message);
 		$this->assertEquals('5.0', $message->getScheduleStatus());
 	}
 
@@ -228,82 +125,17 @@ class IMipPluginTest extends TestCase {
 	 * @dataProvider dataNoMessageSendForPastEvents
 	 */
 	public function testNoMessageSendForPastEvents($veventParams, $expectsMail) {
-		$mailMessage = $this->createMock(IMessage::class);
-		$mailMessage->method('setFrom')->willReturn($mailMessage);
-		$mailMessage->method('setReplyTo')->willReturn($mailMessage);
-		$mailMessage->method('setTo')->willReturn($mailMessage);
-		/** @var Mailer | \PHPUnit_Framework_MockObject_MockObject $mailer */
-		$mailer = $this->getMockBuilder(IMailer::class)->disableOriginalConstructor()->getMock();
-		$emailTemplate = $this->createMock(IEMailTemplate::class);
-		$emailAttachment = $this->createMock(IAttachment::class);
-		$mailer->method('createEMailTemplate')->willReturn($emailTemplate);
-		$mailer->method('createMessage')->willReturn($mailMessage);
-		$mailer->method('createAttachment')->willReturn($emailAttachment);
-		if ($expectsMail) {
-			$mailer->expects($this->once())->method('send');
-		} else {
-			$mailer->expects($this->never())->method('send');
-		}
-		/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject $logger */
-		$logger = $this->getMockBuilder(ILogger::class)->disableOriginalConstructor()->getMock();
-		$timeFactory = $this->getMockBuilder(ITimeFactory::class)->disableOriginalConstructor()->getMock();
-		$timeFactory->method('getTime')->willReturn(1496912528);
-		/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject $config */
-		$config = $this->createMock(IConfig::class);
-		$config->method('getSystemValue')
+
+		$this->config
+			->method('getSystemValue')
 			->with('dav.invitation_link_recipients', true)
 			->willReturn(true);
-		$l10n = $this->createMock(IL10N::class);
-		/** @var IFactory | \PHPUnit_Framework_MockObject_MockObject $l10nFactory */
-		$l10nFactory = $this->createMock(IFactory::class);
-		$l10nFactory->method('get')->willReturn($l10n);
-		/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject $urlGenerator */
-		$urlGenerator = $this->createMock(IURLGenerator::class);
-		/** @var IDBConnection | \PHPUnit_Framework_MockObject_MockObject $db */
-		$db = $this->createMock(IDBConnection::class);
-		/** @var ISecureRandom | \PHPUnit_Framework_MockObject_MockObject $random */
-		$random = $this->createMock(ISecureRandom::class);
-		/** @var Defaults | \PHPUnit_Framework_MockObject_MockObject $defaults */
-		$defaults = $this->createMock(Defaults::class);
 
-		if ($expectsMail) {
-			$random->expects($this->once())
-				->method('generate')
-				->with(60, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789')
-				->will($this->returnValue('random_token'));
+		$message = $this->_testMessage( $veventParams );
 
-			$queryBuilder = $this->createMock(IQueryBuilder::class);
+		$this->_expectSend('frodo@hobb.it', $expectsMail, $expectsMail);
 
-			$db->expects($this->once())
-				->method('getQueryBuilder')
-				->with()
-				->will($this->returnValue($queryBuilder));
-			$queryBuilder->expects($this->at(0))
-				->method('insert')
-				->with('calendar_invitations')
-				->will($this->returnValue($queryBuilder));
-			$queryBuilder->expects($this->at(8))
-				->method('values')
-				->will($this->returnValue($queryBuilder));
-			$queryBuilder->expects($this->at(9))
-				->method('execute');
-		}
-
-		$plugin = new IMipPlugin($config, $mailer, $logger, $timeFactory, $l10nFactory, $urlGenerator, $defaults, $random, $db, 'user123');
-		$message = new Message();
-		$message->method = 'REQUEST';
-		$message->message = new VCalendar();
-		$message->message->add('VEVENT', array_merge([
-			'UID' => 'uid1337',
-			'SEQUENCE' => 42,
-			'SUMMARY' => 'Fellowship meeting',
-		], $veventParams));
-		$message->message->VEVENT->add( 'ORGANIZER', 'mailto:gandalf@wiz.ard' );
-		$message->message->VEVENT->add( 'ATTENDEE', 'mailto:frodo@hobb.it', [ 'RSVP' => 'TRUE' ] );
-		$message->sender = 'mailto:gandalf@wiz.ard';
-		$message->recipient = 'mailto:frodo@hobb.it';
-
-		$plugin->schedule($message);
+		$this->plugin->schedule($message);
 
 		if ($expectsMail) {
 			$this->assertEquals('1.1', $message->getScheduleStatus());
@@ -331,100 +163,15 @@ class IMipPluginTest extends TestCase {
 	* @dataProvider dataIncludeResponseButtons
 	*/
 	public function testIncludeResponseButtons( $config_setting, $recipient, $has_buttons ) {
-		$mailMessage = $this->createMock(IMessage::class);
-		$mailMessage->method('setFrom')->willReturn($mailMessage);
-		$mailMessage->method('setReplyTo')->willReturn($mailMessage);
-		$mailMessage->method('setTo')->willReturn($mailMessage);
-		/** @var Mailer | \PHPUnit_Framework_MockObject_MockObject $mailer */
-		$mailer = $this->getMockBuilder(IMailer::class)->disableOriginalConstructor()->getMock();
-		$emailTemplate = $this->createMock(IEMailTemplate::class);
-		$emailAttachment = $this->createMock(IAttachment::class);
-		$mailer->method('createEMailTemplate')->willReturn($emailTemplate);
-		$mailer->method('createMessage')->willReturn($mailMessage);
-		$mailer->method('createAttachment')->willReturn($emailAttachment);
-		$mailer->expects($this->once())->method('send');
-		/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject $logger */
-		$logger = $this->getMockBuilder(ILogger::class)->disableOriginalConstructor()->getMock();
-		$timeFactory = $this->getMockBuilder(ITimeFactory::class)->disableOriginalConstructor()->getMock();
-		$timeFactory->method('getTime')->willReturn(1);
-		/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject $config */
-		$config = $this->createMock(IConfig::class);
-		$config->method('getSystemValue')
+		$message = $this->_testMessage([],$recipient);
+
+		$this->_expectSend($recipient, true, $has_buttons);
+		$this->config
+			->method('getSystemValue')
 			->with('dav.invitation_link_recipients', true)
 			->willReturn($config_setting);
-		$l10n = $this->createMock(IL10N::class);
-		/** @var IFactory | \PHPUnit_Framework_MockObject_MockObject $l10nFactory */
-		$l10nFactory = $this->createMock(IFactory::class);
-		$l10nFactory->method('get')->willReturn($l10n);
-		/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject $urlGenerator */
-		$urlGenerator = $this->createMock(IURLGenerator::class);
-		/** @var IDBConnection | \PHPUnit_Framework_MockObject_MockObject $db */
-		$db = $this->createMock(IDBConnection::class);
-		/** @var ISecureRandom | \PHPUnit_Framework_MockObject_MockObject $random */
-		$random = $this->createMock(ISecureRandom::class);
-		/** @var Defaults | \PHPUnit_Framework_MockObject_MockObject $defaults */
-		$defaults = $this->createMock(Defaults::class);
-		$defaults->expects($this->once())
-			->method('getName')
-			->will($this->returnValue('Instance Name 123'));
 
-		if ($has_buttons) {
-		$random->expects($this->once())
-			->method('generate')
-			->with(60, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789')
-			->will($this->returnValue('random_token'));
-		}
-
-		$queryBuilder = $this->createMock(IQueryBuilder::class);
-
-		if ($has_buttons) {
-			$db->expects($this->once())
-				->method('getQueryBuilder')
-				->with()
-				->will($this->returnValue($queryBuilder));
-			$queryBuilder->expects($this->at(0))
-				->method('insert')
-				->with('calendar_invitations')
-				->will($this->returnValue($queryBuilder));
-			$queryBuilder->expects($this->at(8))
-				->method('values')
-				->will($this->returnValue($queryBuilder));
-			$queryBuilder->expects($this->at(9))
-				->method('execute');
-		} else {
-			$queryBuilder->expects($this->never())
-				->method('insert')
-				->with('calendar_invitations');
-		}
-
-		$plugin = new IMipPlugin($config, $mailer, $logger, $timeFactory, $l10nFactory, $urlGenerator, $defaults, $random, $db, 'user123');
-		$message = new Message();
-		$message->method = 'REQUEST';
-		$message->message = new VCalendar();
-		$message->message->add('VEVENT', [
-			'UID' => $message->uid,
-			'SEQUENCE' => $message->sequence,
-			'SUMMARY' => 'Fellowship meeting',
-			'DTSTART' => new \DateTime('2017-01-01 00:00:00') // 1483228800
-		]);
-
-		$message->message->VEVENT->add( 'ORGANIZER', 'mailto:gandalf@wiz.ard' );
-		$message->message->VEVENT->add( 'ATTENDEE', 'mailto:'.$recipient, [ 'RSVP' => 'TRUE' ] );
-
-		$message->sender = 'mailto:gandalf@wiz.ard';
-		$message->recipient = 'mailto:'.$recipient;
-
-		$emailTemplate->expects($this->once())
-			->method('setSubject')
-			->with('Invitation: Fellowship meeting');
-		$mailMessage->expects($this->once())
-			->method('setTo')
-			->with([$recipient => null]);
-		$mailMessage->expects($this->once())
-			->method('setReplyTo')
-			->with(['gandalf@wiz.ard' => null]);
-
-		$plugin->schedule($message);
+		$this->plugin->schedule($message);
 		$this->assertEquals('1.1', $message->getScheduleStatus());
 	}
 
@@ -439,5 +186,64 @@ class IMipPluginTest extends TestCase {
 			[ 'internal.com', 'joe@external.com', false],
 			[ ['jane@otherinternal.com', 'internal.com'], 'joe@otherinternal.com', false],
 		];
+	}
+
+	private function _testMessage($attrs = [], $recipient = 'frodo@hobb.it' ) {
+		$message = new Message();
+		$message->method = 'REQUEST';
+		$message->message = new VCalendar();
+		$message->message->add('VEVENT', array_merge([
+			'UID' => 'uid-1234',
+			'SEQUENCE' => 0,
+			'SUMMARY' => 'Fellowship meeting',
+			'DTSTART' => new \DateTime('2018-01-01 00:00:00')
+		], $attrs));
+		$message->message->VEVENT->add( 'ORGANIZER', 'mailto:gandalf@wiz.ard' );
+		$message->message->VEVENT->add( 'ATTENDEE', 'mailto:'.$recipient, [ 'RSVP' => 'TRUE' ] );
+		$message->sender = 'mailto:gandalf@wiz.ard';
+		$message->recipient = 'mailto:'.$recipient;
+		return $message;
+	}
+
+
+        private function _expectSend( $recipient = 'frodo@hobb.it', $expectSend = true, $expectButtons = true ) {
+
+		// if the event is in the past, we skip out
+		if (!$expectSend) {
+			$this->mailer
+				->expects($this->never())
+				->method('send');
+			return;
+		}
+
+		$this->emailTemplate->expects($this->once())
+			->method('setSubject')
+			->with('Invitation: Fellowship meeting');
+		$this->mailMessage->expects($this->once())
+			->method('setTo')
+			->with([$recipient => null]);
+		$this->mailMessage->expects($this->once())
+			->method('setReplyTo')
+			->with(['gandalf@wiz.ard' => null]);
+		$this->mailer
+			->expects($this->once())
+			->method('send');
+
+		if ($expectButtons) {
+			$this->queryBuilder->expects($this->at(0))
+				->method('insert')
+				->with('calendar_invitations')
+				->will($this->returnValue($this->queryBuilder));
+			$this->queryBuilder->expects($this->at(8))
+				->method('values')
+				->will($this->returnValue($this->queryBuilder));
+			$this->queryBuilder->expects($this->at(9))
+				->method('execute');
+		}
+		else {
+			$this->queryBuilder->expects($this->never())
+				->method('insert')
+				->with('calendar_invitations');
+		}
 	}
 }

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
@@ -96,9 +96,9 @@ class IMipPluginTest extends TestCase {
 
 	public function testDelivery() {
 		$this->config
-			->method('getSystemValue')
-			->with('dav.invitation_link_recipients', true)
-			->willReturn(true);
+			->method('getAppValue')
+			->with('dav', 'invitation_link_recipients', 'yes')
+			->willReturn('yes');
 
 		$message = $this->_testMessage();
 		$this->_expectSend();
@@ -108,9 +108,9 @@ class IMipPluginTest extends TestCase {
 
 	public function testFailedDelivery() {
 		$this->config
-			->method('getSystemValue')
-			->with('dav.invitation_link_recipients', true)
-			->willReturn(true);
+			->method('getAppValue')
+			->with('dav', 'invitation_link_recipients', 'yes')
+			->willReturn('yes');
 
 		$message = $this->_testMessage();
 		$this->mailer
@@ -127,9 +127,9 @@ class IMipPluginTest extends TestCase {
 	public function testNoMessageSendForPastEvents($veventParams, $expectsMail) {
 
 		$this->config
-			->method('getSystemValue')
-			->with('dav.invitation_link_recipients', true)
-			->willReturn(true);
+			->method('getAppValue')
+			->with('dav', 'invitation_link_recipients', 'yes')
+			->willReturn('yes');
 
 		$message = $this->_testMessage( $veventParams );
 
@@ -167,8 +167,8 @@ class IMipPluginTest extends TestCase {
 
 		$this->_expectSend($recipient, true, $has_buttons);
 		$this->config
-			->method('getSystemValue')
-			->with('dav.invitation_link_recipients', true)
+			->method('getAppValue')
+			->with('dav', 'invitation_link_recipients', 'yes')
 			->willReturn($config_setting);
 
 		$this->plugin->schedule($message);
@@ -178,13 +178,13 @@ class IMipPluginTest extends TestCase {
 	public function dataIncludeResponseButtons() {
 		return [
 			// dav.invitation_link_recipients, recipient, $has_buttons
-			[ true, 'joe@internal.com', true],
+			[ 'yes', 'joe@internal.com', true],
 			[ 'joe@internal.com', 'joe@internal.com', true],
 			[ 'internal.com', 'joe@internal.com', true],
-			[ ['pete@otherinternal.com', 'internal.com'], 'joe@internal.com', true],
-			[ false, 'joe@internal.com', false],
+			[ 'pete@otherinternal.com,internal.com', 'joe@internal.com', true],
+			[ 'no', 'joe@internal.com', false],
 			[ 'internal.com', 'joe@external.com', false],
-			[ ['jane@otherinternal.com', 'internal.com'], 'joe@otherinternal.com', false],
+			[ 'jane@otherinternal.com,internal.com', 'joe@otherinternal.com', false],
 		];
 	}
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1721,7 +1721,7 @@ $CONFIG = array(
 *   'dav.invitation_link_recipients' => false,
 *
 */
-'dav.invitation_link_recipients' => '*', // always include accept/reject server links in iMip emails
+'dav.invitation_link_recipients' => true, // always include accept/reject server links in iMip emails
 
 /**
  * By default there is on public pages a link shown that allows users to

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1697,6 +1697,33 @@ $CONFIG = array(
 ),
 
 /**
+* The caldav server sends invitation emails to invitees, attaching the ICS
+* file for the invitation.  It also may include, in the body of the e-mail,
+* invitation accept/reject web links referencing URL's that point to the nextcloud server.
+*
+* Although any recipient can read and reply to the ICS file via the iMip protocol,
+* we must only present the web links to recipients who can access the nextcloud
+* web server via their internet/intranet.
+*
+* When your nextcloud server is restricted behind a firewall, accessible
+* only via an internal network or via vpn, you can set "dav.invitation_link_recipients"
+* to the email address or email domain, or array of addresses or domains,
+* of recipients who can access the server. Only those recipients will get web links. External
+* users can accept/reject invitations by emailing back ICS files containing appropriate
+* messages, using the iMip protocol. Many mail clients support this functionality.
+*
+* To suppress iMip web links entirely, set dav.invitation_link_recipients to false.
+* To deliver iMip web links always, set dav.invitation_link_recipients to true.
+*
+* Examples:
+*   'dav.invitation_link_recipients' => 'internal.example.com',
+*   'dav.invitation_link_recipients' => array( 'internal.example.com', 'pat@roadwarrior.example.com' ),
+*   'dav.invitation_link_recipients' => false,
+*
+*/
+'dav.invitation_link_recipients' => '*', // always include accept/reject server links in iMip emails
+
+/**
  * By default there is on public pages a link shown that allows users to
  * learn about the "simple sign up" - see https://nextcloud.com/signup/
  *

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1697,33 +1697,6 @@ $CONFIG = array(
 ),
 
 /**
-* The caldav server sends invitation emails to invitees, attaching the ICS
-* file for the invitation.  It also may include, in the body of the e-mail,
-* invitation accept/reject web links referencing URL's that point to the nextcloud server.
-*
-* Although any recipient can read and reply to the ICS file via the iMip protocol,
-* we must only present the web links to recipients who can access the nextcloud
-* web server via their internet/intranet.
-*
-* When your nextcloud server is restricted behind a firewall, accessible
-* only via an internal network or via vpn, you can set "dav.invitation_link_recipients"
-* to the email address or email domain, or array of addresses or domains,
-* of recipients who can access the server. Only those recipients will get web links. External
-* users can accept/reject invitations by emailing back ICS files containing appropriate
-* messages, using the iMip protocol. Many mail clients support this functionality.
-*
-* To suppress iMip web links entirely, set dav.invitation_link_recipients to false.
-* To deliver iMip web links always, set dav.invitation_link_recipients to true.
-*
-* Examples:
-*   'dav.invitation_link_recipients' => 'internal.example.com',
-*   'dav.invitation_link_recipients' => array( 'internal.example.com', 'pat@roadwarrior.example.com' ),
-*   'dav.invitation_link_recipients' => false,
-*
-*/
-'dav.invitation_link_recipients' => true, // always include accept/reject server links in iMip emails
-
-/**
  * By default there is on public pages a link shown that allows users to
  * learn about the "simple sign up" - see https://nextcloud.com/signup/
  *


### PR DESCRIPTION
- Fix Issue #11230
Only present accept/decline button links in iMip mail for REQUEST, not CANCEL or others.

- Fix Issue #12156
Implement config setting "dav.invitation_link_recipients", to control
which invitation recipients see accept/decline button links.  The
default, for public internet facing servers, is to always include
them.  For a server on a private intranet, this setting can be set
to the email addresses or email domains of users whose browsers can
access the nextcloud server referenced by those accept/decline
button links. It can also be set to "false" to exclude the links
from all requests.

Signed-off-by: Brad Rubenstein <brad@wbr.tech>