### PR TITLE
Fix the warning appearing in the admin section when mail_smtpmode is not configured

### DIFF
--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -530,7 +530,7 @@ Raw output
 	}
 
 	protected function isPhpMailerUsed(): bool {
-		return $this->config->getSystemValue('mail_smtpmode') === 'php';
+		return $this->config->getSystemValue('mail_smtpmode', 'smtp') === 'php';
 	}
 
 	protected function hasOpcacheLoaded(): bool {

--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -530,7 +530,7 @@ Raw output
 	}
 
 	protected function isPhpMailerUsed(): bool {
-		return $this->config->getSystemValue('mail_smtpmode', 'php') === 'php';
+		return $this->config->getSystemValue('mail_smtpmode') === 'php';
 	}
 
 	protected function hasOpcacheLoaded(): bool {

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -520,6 +520,40 @@ class CheckSetupControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->checkSetupController->check());
 	}
 
+	public function testIsPhpMailerUsed() {
+		$checkSetupController = $this->getMockBuilder('\OC\Settings\Controller\CheckSetupController')
+			->setConstructorArgs([
+				'settings',
+				$this->request,
+				$this->config,
+				$this->clientService,
+				$this->urlGenerator,
+				$this->util,
+				$this->l10n,
+				$this->checker,
+				$this->logger,
+				$this->dispatcher,
+				$this->db,
+				$this->lockingProvider,
+				$this->dateTimeFormatter,
+				$this->memoryInfo,
+				$this->secureRandom,
+			])
+			->setMethods(null)->getMock();
+
+		$this->config->expects($this->at(0))
+			->method('getSystemValue')
+			->with('mail_smtpmode', null)
+			->will($this->returnValue('php'));
+		$this->config->expects($this->at(1))
+			->method('getSystemValue')
+			->with('mail_smtpmode', null)
+			->will($this->returnValue('not-php'));
+
+		$this->assertTrue($this->invokePrivate($checkSetupController, 'isPhpMailerUsed'));
+		$this->assertFalse($this->invokePrivate($checkSetupController, 'isPhpMailerUsed'));
+	}
+
 	public function testGetCurlVersion() {
 		$checkSetupController = $this->getMockBuilder('\OC\Settings\Controller\CheckSetupController')
 			->setConstructorArgs([

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -543,11 +543,11 @@ class CheckSetupControllerTest extends TestCase {
 
 		$this->config->expects($this->at(0))
 			->method('getSystemValue')
-			->with('mail_smtpmode', null)
+			->with('mail_smtpmode', 'smtp')
 			->will($this->returnValue('php'));
 		$this->config->expects($this->at(1))
 			->method('getSystemValue')
-			->with('mail_smtpmode', null)
+			->with('mail_smtpmode', 'smtp')
 			->will($this->returnValue('not-php'));
 
 		$this->assertTrue($this->invokePrivate($checkSetupController, 'isPhpMailerUsed'));


### PR DESCRIPTION
Closes #11107

The bug is preventing the snap stable channel to jump to 14:
* https://github.com/nextcloud/nextcloud-snap/issues/707
* https://github.com/nextcloud/nextcloud-snap/issues/706

So if this is OK it should be backported to 14.