### PR TITLE
Make sure to always load the latest icons-vars.css file

### DIFF
--- a/lib/private/Template/IconsCacher.php
+++ b/lib/private/Template/IconsCacher.php
@@ -24,6 +24,7 @@ declare (strict_types = 1);
 
 namespace OC\Template;
 
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFolder;
@@ -46,6 +47,9 @@ class IconsCacher {
 	/** @var IURLGenerator */
 	protected $urlGenerator;
 
+	/** @var ITimeFactory */
+	protected $timeFactory;
+
 	/** @var string */
 	private $iconVarRE = '/--(icon-[a-zA-Z0-9-]+):\s?url\(["\']?([a-zA-Z0-9-_\~\/\.\?\&\=\:\;\+\,]+)[^;]+;/m';
 
@@ -58,14 +62,17 @@ class IconsCacher {
 	 * @param ILogger $logger
 	 * @param Factory $appDataFactory
 	 * @param IURLGenerator $urlGenerator
+	 * @param ITimeFactory $timeFactory
 	 * @throws \OCP\Files\NotPermittedException
 	 */
 	public function __construct(ILogger $logger,
 								Factory $appDataFactory,
-								IURLGenerator $urlGenerator) {
+								IURLGenerator $urlGenerator,
+								ITimeFactory $timeFactory) {
 		$this->logger       = $logger;
 		$this->appData      = $appDataFactory->get('css');
 		$this->urlGenerator = $urlGenerator;
+		$this->timeFactory  = $timeFactory;
 
 		try {
 			$this->folder = $this->appData->getFolder('icons');
@@ -216,6 +223,11 @@ class IconsCacher {
 	}
 
 	public function injectCss() {
+		$mtime = $this->timeFactory->getTime();
+		$file = $this->getCachedList();
+		if ($file) {
+			$mtime = $file->getMTime();
+		}
 		// Only inject once
 		foreach (\OC_Util::$headers as $header) {
 			if (
@@ -225,7 +237,7 @@ class IconsCacher {
 				return;
 			}
 		}
-		$linkToCSS = $this->urlGenerator->linkToRoute('core.Css.getCss', ['appName' => 'icons', 'fileName' => $this->fileName]);
+		$linkToCSS = $this->urlGenerator->linkToRoute('core.Css.getCss', ['appName' => 'icons', 'fileName' => $this->fileName, 'v' => $mtime]);
 		\OC_Util::addHeader('link', ['rel' => 'stylesheet', 'href' => $linkToCSS], null, true);
 	}
 

--- a/tests/lib/Template/IconsCacherTest.php
+++ b/tests/lib/Template/IconsCacherTest.php
@@ -28,6 +28,7 @@ use OC\Files\AppData\AppData;
 use OC\Files\AppData\Factory;
 use OC\Template\IconsCacher;
 use OCA\Theming\ThemingDefaults;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
@@ -46,10 +47,13 @@ class IconsCacherTest extends \Test\TestCase {
 	protected $appData;
 	/** @var IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
 	protected $urlGenerator;
+	/** @var ITimeFactory|\PHPUnit_Framework_MockObject_MockObject */
+	private $timeFactory;
 
 	protected function setUp() {
 		$this->logger = $this->createMock(ILogger::class);
 		$this->appData = $this->createMock(AppData::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 
 		/** @var Factory|\PHPUnit_Framework_MockObject_MockObject $factory */
 		$factory = $this->createMock(Factory::class);
@@ -63,7 +67,8 @@ class IconsCacherTest extends \Test\TestCase {
 		$this->iconsCacher = new IconsCacher(
 			$this->logger,
 			$factory,
-			$this->urlGenerator
+			$this->urlGenerator,
+			$this->timeFactory
 		);
 	}
 


### PR DESCRIPTION
The icons-vars.css file was taken from browser cache even it was changed.

Steps to reproduce:
1. run occ maintenance:repair to clear the css cache
2. Load the files app
3. Load a different app that uses the scss icons methods (like deck on master)
