### PR TITLE
Fix UniqueConstraintViolationException while insert into oc_file_locks

### DIFF
--- a/lib/private/Lock/DBLockingProvider.php
+++ b/lib/private/Lock/DBLockingProvider.php
@@ -26,6 +26,7 @@
 
 namespace OC\Lock;
 
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use OC\DB\QueryBuilder\Literal;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -133,7 +134,17 @@ class DBLockingProvider extends AbstractLockingProvider {
 
 	protected function initLockField(string $path, int $lock = 0): int {
 		$expire = $this->getExpireTime();
-		return $this->connection->insertIfNotExist('*PREFIX*file_locks', ['key' => $path, 'lock' => $lock, 'ttl' => $expire], ['key']);
+
+		try {
+			$builder = $this->connection->getQueryBuilder();
+			return $builder->insert('file_locks')
+				->setValue('key', $builder->createNamedParameter($path))
+				->setValue('lock', $builder->createNamedParameter($lock))
+				->setValue('ttl', $builder->createNamedParameter($expire))
+				->execute();
+		} catch(UniqueConstraintViolationException $e) {
+			return 0;
+		}
 	}
 
 	/**


### PR DESCRIPTION
* fixes #9305 by not being prone to the race condition in insertIfNotExists
* fixes #6899 by not using a query that can result in a deadlock
* replaces the insertIfNotExists call with an insert which is wrapped into a try-catch block
* followup to #12371

I would back port this one to stable13 and stable14 as well because it is a smaller and not that invasive version of #12371 and it also fixes the deadlocks.