### PR TITLE
Prefix icon variables with app name to avoid conflicts

### DIFF
--- a/core/css/functions.scss
+++ b/core/css/functions.scss
@@ -66,7 +66,11 @@
  */
 @mixin icon-color($icon, $dir, $color, $version: 1, $core: false) {
 	$color: remove-hash-from-color($color);
-	$varName: "--icon-#{$icon}-#{$color}";
+	/* $dir is the app name, so we add this to the icon var to avoid conflicts between apps */
+	$varName: "--icon-#{$dir}-#{$icon}-#{$color}";
+	@if $core {
+		$varName: "--icon-#{$icon}-#{$color}";
+	}
 	#{$varName}: url(icon-color-path($icon, $dir, $color, $version, $core));
 	background-image: var(#{$varName});
 }


### PR DESCRIPTION
Otherwise apps with the same icon name will overwrite each other.

## Example:

deck uses: `@include icon-color('app', 'deck', $color-black);`
calendar uses: `@include icon-color('app', 'calendar', $color-black);`

### Before:
Both icon variables have the same name `--icon-app-000`

### Before:
deck uses `--icon-deck-app-000`
calendar uses `--icon-calendar-app-000`