### PR TITLE
Replaced website address for internet checking

### DIFF
--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -131,7 +131,7 @@ class CheckSetupController extends Controller {
 		}
 
 		$siteArray = ['www.nextcloud.com',
-						'www.startpage.com',
+						'www.amazon.com',
 						'www.eff.org',
 						'www.edri.org',
 			];


### PR DESCRIPTION
starpage.com is not available in mainland china, replaced it with amazon.com