### PR TITLE
12.0.13 RC 1

### DIFF
--- a/lib/composer/composer/ClassLoader.php
+++ b/lib/composer/composer/ClassLoader.php
@@ -279,7 +279,7 @@ class ClassLoader
      */
     public function setApcuPrefix($apcuPrefix)
     {
-        $this->apcuPrefix = function_exists('apcu_fetch') && ini_get('apc.enabled') ? $apcuPrefix : null;
+        $this->apcuPrefix = function_exists('apcu_fetch') && filter_var(ini_get('apc.enabled'), FILTER_VALIDATE_BOOLEAN) ? $apcuPrefix : null;
     }
 
     /**

--- a/version.php
+++ b/version.php
@@ -26,10 +26,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(12, 0, 12, 2);
+$OC_Version = array(12, 0, 13, 0);
 
 // The human readable string
-$OC_VersionString = '12.0.12';
+$OC_VersionString = '12.0.13 RC 1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Changelog to 12.0.12:

* #11763 Ignore "session_lifetime" if it can not be converted to a number
* #11998 Fix opening a section again in the Files app
* #12059 Actually return the root folder when traversing up the tree
* #12110 Double check for failed cache with a shared storage