### PR TITLE
Fix SetVcardDatabaseUID when using postgresql

### DIFF
--- a/lib/private/Repair/NC15/SetVcardDatabaseUID.php
+++ b/lib/private/Repair/NC15/SetVcardDatabaseUID.php
@@ -112,7 +112,11 @@ class SetVcardDatabaseUID implements IRepairStep {
 		$count   = 0;
 		foreach ($entries as $entry) {
 			$count++;
-			$uid = $this->getUID($entry['carddata']);
+			$cardData = $entry['carddata'];
+			if (is_resource($cardData)) {
+				$cardData = stream_get_contents($cardData);
+			}
+			$uid = $this->getUID($cardData);
 			$this->update($entry['id'], $uid);
 		}
 		$this->connection->commit();


### PR DESCRIPTION
On my postgresql instance the `carddata` column is of the `bytea` type, and when selecting it PDO apparently returns it as a stream instead of an array.