### PR TITLE
[stable14] Fix missing quickaccess favorite folder on add

### DIFF
--- a/apps/files/appinfo/routes.php
+++ b/apps/files/appinfo/routes.php
@@ -81,6 +81,11 @@ $application->registerRoutes(
 				'url' => '/api/v1/toggleShowFolder/{key}',
 				'verb' => 'POST'
 			],
+			[
+				'name' => 'API#getNodeType',
+				'url' => '/api/v1/quickaccess/get/NodeType',
+				'verb' => 'GET',
+			],
 		]
 	]
 );

--- a/apps/files/lib/Controller/ApiController.php
+++ b/apps/files/lib/Controller/ApiController.php
@@ -292,5 +292,17 @@ class ApiController extends Controller {
 		return $response;
 	}
 
+	/**
+	 * Get sorting-order for custom sorting
+	 *
+	 * @NoAdminRequired
+	 *
+	 * @param String
+	 * @return String
+	 */
+	public function getNodeType($folderpath) {
+		$node = $this->userFolder->get($folderpath);
+		return $node->getType();
+	}
 
 }

--- a/apps/files/lib/Controller/ApiController.php
+++ b/apps/files/lib/Controller/ApiController.php
@@ -297,8 +297,9 @@ class ApiController extends Controller {
 	 *
 	 * @NoAdminRequired
 	 *
-	 * @param String
-	 * @return String
+	 * @param string
+	 * @return string
+	 * @throws \OCP\Files\NotFoundException
 	 */
 	public function getNodeType($folderpath) {
 		$node = $this->userFolder->get($folderpath);


### PR DESCRIPTION
Backport to NC14 of #10888


When you mark a folder as favorite, it should be added to the quickaccessbar. This is not the case, because the route for checking if the newly marked element is a folder or a directory is missing. This PR readds the missing route.