### PR TITLE
Load apps that have a dav type set before the dav server plugins

### DIFF
--- a/apps/dav/appinfo/app.php
+++ b/apps/dav/appinfo/app.php
@@ -27,6 +27,8 @@ use OCA\DAV\AppInfo\Application;
 use OCA\DAV\CardDAV\CardDavBackend;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
+\OC_App::loadApps(['dav']);
+
 $app = new Application();
 $app->registerHooks();
 

--- a/apps/dav/lib/AppInfo/PluginManager.php
+++ b/apps/dav/lib/AppInfo/PluginManager.php
@@ -103,9 +103,6 @@ class PluginManager {
 			if (!isset($info['types']) || !in_array('dav', $info['types'], true)) {
 				continue;
 			}
-			// FIXME: switch to public API once available
-			// load app to make sure its classes are available
-			\OC_App::loadApp($app);
 			$this->loadSabrePluginsFromInfoXml($this->extractPluginList($info));
 			$this->loadSabreCollectionsFromInfoXml($this->extractCollectionList($info));
 		}


### PR DESCRIPTION
To implement comments support for an app, it is required to register a comments entity:

```
$this->eventDispatcher->addListener(CommentsEntityEvent::EVENT_ENTITY, function(CommentsEntityEvent $event) {
			$event->addEntityCollection('deckCard', function($name) {});
});
```

This is usually done in the app.php. When using the comments dav endpoint, the app is only loaded if either one of the types logging/authentication/filesystem is set in the info.xml, but this will remove the ability to enable the app just for a specific group. See
- https://github.com/nextcloud/announcementcenter/blob/master/appinfo/info.xml#L22
- https://github.com/nextcloud/deck/blob/master/appinfo/info.xml#L25

We already have a type 'dav' that is used for loading dav plugins, so this PR will make sure we load app apps with a type 'dav' set in info.xml before registering plugins in the DAV Server class.

cc @nickvergessen @blizzz 
