### PR TITLE
fix user creation using LDAP Plugin

### DIFF
--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -1139,6 +1139,7 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface, IGroupLD
 		if ($this->groupPluginManager->implementsActions(GroupInterface::ADD_TO_GROUP)) {
 			if ($ret = $this->groupPluginManager->addToGroup($uid, $gid)) {
 				$this->access->connection->clearCache();
+				unset($this->cachedGroupMembers[$gid]);
 			}
 			return $ret;
 		}
@@ -1156,6 +1157,7 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface, IGroupLD
 		if ($this->groupPluginManager->implementsActions(GroupInterface::REMOVE_FROM_GROUP)) {
 			if ($ret = $this->groupPluginManager->removeFromGroup($uid, $gid)) {
 				$this->access->connection->clearCache();
+				unset($this->cachedGroupMembers[$gid]);
 			}
 			return $ret;
 		}

--- a/apps/user_ldap/lib/UserPluginManager.php
+++ b/apps/user_ldap/lib/UserPluginManager.php
@@ -84,7 +84,7 @@ class UserPluginManager {
 	 *
 	 * @param string $username The username of the user to create
 	 * @param string $password The password of the new user
-	 * @return bool
+	 * @return string | false The user DN if user creation was successful.
 	 * @throws \Exception
 	 */
 	public function createUser($username, $password) {

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -615,11 +615,19 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 	 * create new user
 	 * @param string $username username of the new user
 	 * @param string $password password of the new user
-	 * @return bool was the user created?
+	 * @return bool
 	 */
 	public function createUser($username, $password) {
 		if ($this->userPluginManager->implementsActions(Backend::CREATE_USER)) {
-			return $this->userPluginManager->createUser($username, $password);
+			if ($dn = $this->userPluginManager->createUser($username, $password)) {
+				if (is_string($dn)) {
+					//updates user mapping
+					$this->access->dn2ocname($dn, $username, true);
+				} else {
+					throw new \Exception("LDAP Plugin: Method createUser changed to return the user DN instead of boolean.");
+				}
+			}
+			return (bool) $dn;
 		}
 		return false;
 	}

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -615,6 +615,7 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 	 * create new user
 	 * @param string $username username of the new user
 	 * @param string $password password of the new user
+	 * @throws \UnexpectedValueException
 	 * @return bool
 	 */
 	public function createUser($username, $password) {
@@ -624,7 +625,7 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 					//updates user mapping
 					$this->access->dn2ocname($dn, $username, true);
 				} else {
-					throw new \Exception("LDAP Plugin: Method createUser changed to return the user DN instead of boolean.");
+					throw new \UnexpectedValueException("LDAP Plugin: Method createUser changed to return the user DN instead of boolean.");
 				}
 			}
 			return (bool) $dn;

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -1422,7 +1422,7 @@ class User_LDAPTest extends TestCase {
 			->with('uid','password')
 			->willReturn('result');
 
-		$this->assertEquals($this->backend->createUser('uid', 'password'),'result');
+		$this->assertEquals($this->backend->createUser('uid', 'password'),true);
 	}
 
 	public function testCreateUserFailing() {


### PR DESCRIPTION
When upgrading our installation to nextcloud14 we could not anymore create users in LDAP.

These are changes in user_ldap app that needed to be made to the createUser in the plugin work again. 

We needed to change the createUser function in our plugin also, now it returns the user DN in LDAP, instead of returning a boolean. Other developers who created a plugin for LDAP will need to change this also. 

Their code will break anyway when they try to upgrade to nc14, so we are now throwing an exception when the custom createUser function returns true.

Here is our plugin code:
https://gitlab.com/eita/rios/user_ldap_extended/tree/nc14

