### PR TITLE
Don't register twofactor_backup settings as "regular" settings

### DIFF
--- a/apps/twofactor_backupcodes/appinfo/info.xml
+++ b/apps/twofactor_backupcodes/appinfo/info.xml
@@ -26,10 +26,6 @@
 		<provider>OCA\TwoFactorBackupCodes\Provider\BackupCodesProvider</provider>
 	</two-factor-providers>
 
-	<settings>
-		<personal>OCA\TwoFactorBackupCodes\Settings\Personal</personal>
-	</settings>
-
 	<activity>
 		<providers>
 			<provider>OCA\TwoFactorBackupCodes\Activity\Provider</provider>

--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -167,7 +167,7 @@ class Manager implements IManager {
 			}
 
 			if (!$setting instanceof ISettings) {
-				$this->log->logException(new \InvalidArgumentException('Invalid settings setting registered'), ['level' => ILogger::INFO]);
+				$this->log->logException(new \InvalidArgumentException('Invalid settings setting registered (' . $class . ')'), ['level' => ILogger::INFO]);
 				continue;
 			}
 


### PR DESCRIPTION
prevents the log from getting spammed with "InvalidArgumentException: Invalid settings setting registered"