### PR TITLE
Show thumbnail on rename

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -153,6 +153,7 @@
 #filestable tbody tr.highlighted .name:focus,
 #filestable tbody tr.selected,
 #filestable tbody tr.searchresult,
+#filestable tbody tr:hover .filename form,
 table tr.mouseOver td {
 	transition: background-color 0.3s ease;
 	background-color: var(--color-background-dark);
@@ -332,9 +333,13 @@ table td.filename .thumbnail {
 }
 table td.filename input.filename {
 	width: 70%;
-	margin-top: 9px;
 	margin-left: 48px;
 	cursor: text;
+}
+table td.filename form {
+	margin-top: -40px;
+	position: relative;
+	top: -6px;
 }
 
 table td.filename a, table td.login, table td.logout, table td.download, table td.upload, table td.create, table td.delete { padding:3px 8px 8px 3px; }
@@ -906,6 +911,16 @@ table.dragshadow td.size {
 								display: none;
 							}
 						}
+					}
+				}
+
+				form {
+					padding: 3px 14px;
+					border-radius: var(--border-radius);
+
+					input.filename {
+						width: 100%;
+						margin-left: 0;
 					}
 				}
 			}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2390,7 +2390,7 @@
 			input = $('<input type="text" class="filename"/>').val(oldName);
 			form = $('<form></form>');
 			form.append(input);
-			td.children('a.name').hide();
+			td.children('a.name').children(':not(.thumbnail-wrapper)').hide();
 			td.append(form);
 			input.focus();
 			//preselect input
@@ -2418,7 +2418,7 @@
 				input.tooltip('hide');
 				tr.data('renaming',false);
 				form.remove();
-				td.children('a.name').show();
+				td.children('a.name').children(':not(.thumbnail-wrapper)').show();
 			}
 
 			function updateInList(fileInfo) {
@@ -2449,7 +2449,7 @@
 							basename = newName.substr(0, newName.lastIndexOf('.'));
 						}
 						td.find('a.name span.nametext').text(basename);
-						td.children('a.name').show();
+						td.children('a.name').children(':not(.thumbnail-wrapper)').show();
 
 						var path = tr.attr('data-path') || self.getCurrentDirectory();
 						self.filesClient.move(OC.joinPaths(path, oldName), OC.joinPaths(path, newName))

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -777,7 +777,8 @@ describe('OCA.Files.FileList tests', function() {
 			// trigger rename prompt
 			fileList.rename('One.txt');
 
-			expect($tr.find('a.name').css('display')).toEqual('none');
+			expect($tr.find('a.name .thumbnail-wrapper').css('display')).not.toEqual('none');
+			expect($tr.find('a.name .nametext').css('display')).toEqual('none');
 
 			$input = fileList.$fileList.find('input.filename');
 			$input.val('Two.jpg');


### PR DESCRIPTION
* does not hide thumbnail when rename is shown
* fixes layout for grid and list view
* fixes #11901

Before:

![bildschirmfoto 2018-11-15 um 12 18 52](https://user-images.githubusercontent.com/245432/48549642-a55d5900-e8d0-11e8-8bb0-d5bb7e7cd9a7.png)
![bildschirmfoto 2018-11-15 um 12 18 58](https://user-images.githubusercontent.com/245432/48549643-a5f5ef80-e8d0-11e8-9234-4592e61e6c07.png)

-----

After:

![bildschirmfoto 2018-11-15 um 12 18 00](https://user-images.githubusercontent.com/245432/48549609-89f24e00-e8d0-11e8-8d3d-f5c5dd3c88aa.png)


![bildschirmfoto 2018-11-15 um 12 15 05](https://user-images.githubusercontent.com/245432/48549472-29631100-e8d0-11e8-84d7-c915cd337ed1.png)

Hovered:
![bildschirmfoto 2018-11-15 um 12 15 09](https://user-images.githubusercontent.com/245432/48549473-29fba780-e8d0-11e8-9659-7caedd87e21f.png)


@nextcloud/designers Have a look. I know it involves a lot of CSS fiddling, but I don't want to completely reorder the DOM structure as of now.