### PR TITLE
Fix loader colours for better visibility

### DIFF
--- a/core/css/variables.scss
+++ b/core/css/variables.scss
@@ -65,7 +65,7 @@ $image-logo: url('../img/logo.svg?v=1') !default;
 $image-login-background: url('../img/background.png?v=2') !default;
 
 $color-loading-light: #ccc !default;
-$color-loading-dark: #777 !default;
+$color-loading-dark: #444 !default;
 
 $color-box-shadow: rgba(nc-darken($color-main-background, 70%), 0.5) !default;
 


### PR DESCRIPTION
Fix #12091 

| Before |
|:---------:|
|![capture d ecran_2018-11-16_13-39-37](https://user-images.githubusercontent.com/14975046/48621858-3271e200-e9a5-11e8-8d61-9ebc169a3e8b.png)|
| After |
![capture d ecran_2018-11-16_13-39-06](https://user-images.githubusercontent.com/14975046/48621857-31d94b80-e9a5-11e8-9344-c4776e43065d.png)|
@nextcloud/designers 