### PR TITLE
Remove unused svg api route

### DIFF
--- a/core/routes.php
+++ b/core/routes.php
@@ -62,7 +62,6 @@ $application->registerRoutes($this, [
 		['name' => 'Preview#getPreviewByFileId', 'url' => '/core/preview', 'verb' => 'GET'],
 		['name' => 'Preview#getPreview', 'url' => '/core/preview.png', 'verb' => 'GET'],
 		['name' => 'Svg#getSvgFromCore', 'url' => '/svg/core/{folder}/{fileName}', 'verb' => 'GET'],
-		['name' => 'Svg#getSvgFromSettings', 'url' => '/svg/settings/{folder}/{fileName}', 'verb' => 'GET'],
 		['name' => 'Svg#getSvgFromApp', 'url' => '/svg/{app}/{fileName}', 'verb' => 'GET'],
 		['name' => 'Css#getCss', 'url' => '/css/{appName}/{fileName}', 'verb' => 'GET'],
 		['name' => 'Js#getJs', 'url' => '/js/{appName}/{fileName}', 'verb' => 'GET'],


### PR DESCRIPTION
Fix #12397

@rso42 

I could not find anywhere where we use this route.
I think this was a start I added in #9984, but did not continued with this path and used the `getSvgFromApp` instead https://github.com/nextcloud/server/commit/29ff7efe9a5be16b133a1ee4e43d6d2155b6a21c#diff-6f74898d9cb1171c9d9a8f925434de55R81 :woman_shrugging: 