### PR TITLE
Properly name privacy settings for display name and avatar

### DIFF
--- a/settings/js/federationscopemenu.js
+++ b/settings/js/federationscopemenu.js
@@ -27,8 +27,8 @@
 			this._scopes = [
 				{
 					name: 'private',
-					displayName: (this.field === 'avatar' || this.field === 'displayname') ? t('settings', 'Local') : t('settings', 'Private'),
-					tooltip: (this.field === 'avatar' || this.field === 'displayname') ? t('settings', 'Only visible to local users') : t('settings', 'Only visible to you'),
+					displayName: t('settings', 'Private'),
+					tooltip: t('settings', 'Only visible to you'),
 					iconClass: 'icon-password',
 					active: false
 				},


### PR DESCRIPTION
This setting was introduced with f489fd99c352be3dfa65c1955573e44c13732e30 in #1946. I could not find any hint that this was ever working local only. Thus this should be changed to "private" to properly reflect what it is doing.

Background is that the properties aren't synced to the system address book if the setting is "private".

Fixes #10317
