### PR TITLE
Only use width and opacity for transition

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -691,8 +691,7 @@ nav[role='navigation'] {
 		height: 34px;
 		width: 0;
 		cursor: pointer;
-		-webkit-transition: all 100ms;
-		transition: all 100ms;
+		transition: width 100ms, opacity 100ms;
 		opacity: .6;
 		&:focus, &:active, &:valid {
 			background-position-x: 6px;


### PR DESCRIPTION
This probably fixes #11179 

I tried to debug this a bit using browserstack, and it seems to fix the continuous rerendering, which was caused by the transition: all 100ms; rule. 

@MorrisJobke Would be great if you could give this a try on a real Safari.