### PR TITLE
Fix share link password input

### DIFF
--- a/apps/files_sharing/css/sharetabview.scss
+++ b/apps/files_sharing/css/sharetabview.scss
@@ -48,16 +48,13 @@
 	.shareWithLoading {
 		padding-left: 10px;
 		right: 35px;
-		top: 0px;
+		top: 3px;
 	}
-	.shareWithConfirm,
-	.linkPass .icon-loading-small {
+	.shareWithConfirm {
 		position: absolute;
 		right: 2px;
 		top: 6px;
 		padding: 14px;
-	}
-	.shareWithConfirm {
 		opacity: 0.5;
 	}
 	.shareWithField:focus ~ .shareWithConfirm {
@@ -70,6 +67,21 @@
 		padding: 14px;
 	}
 	.popovermenu {
+		.linkPassMenu {
+			.share-pass-submit {
+				width: auto !important;
+			}
+			.icon-loading-small {
+				background-color: var(--color-main-background);
+				position: absolute;
+				right: 8px;
+				margin: 3px;
+				padding: 10px;
+				width: 32px;
+				height: 32px;
+				z-index: 10;
+			}
+		}
 		.datepicker {
 			margin-left: 35px;
 		}

--- a/core/js/share/sharedialoglinkshareview_popover_menu.handlebars
+++ b/core/js/share/sharedialoglinkshareview_popover_menu.handlebars
@@ -58,6 +58,7 @@
 			<li class="{{#unless isPasswordSet}}hidden{{/unless}} linkPassMenu">
 				<span class="menuitem icon-share-pass">
 					<input id="linkPassText-{{cid}}" class="linkPassText" type="password" placeholder="{{passwordPlaceholder}}" autocomplete="new-password" />
+					<input type="submit" class="icon-confirm share-pass-submit" value="" />
 					<span class="icon icon-loading-small hidden"></span>
 				</span>
 			</li>

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -54,8 +54,8 @@
 			// hide download
 			'change .hideDownloadCheckbox': 'onHideDownloadChange',
 			// password
-			'focusout input.linkPassText': 'onPasswordEntered',
-			'keyup input.linkPassText': 'onPasswordKeyUp',
+			'click input.share-pass-submit': 'onPasswordEntered', 
+			'keyup input.linkPassText': 'onPasswordKeyUp', // check for the enter key
 			'change .showPasswordCheckbox': 'onShowPasswordClick',
 			'change .passwordByTalkCheckbox': 'onPasswordByTalkChange',
 			'change .publicEditingCheckbox': 'onAllowPublicEditingChange',
@@ -381,11 +381,12 @@
 				},
 				error: function(model, msg) {
 					// destroy old tooltips
-					$input.tooltip('destroy');
+					var $container = $input.parent();
+					$container.tooltip('destroy');
 					$input.addClass('error');
-					$input.attr('title', msg);
-					$input.tooltip({placement: 'bottom', trigger: 'manual'});
-					$input.tooltip('show');
+					$container.attr('title', msg);
+					$container.tooltip({placement: 'bottom', trigger: 'manual'});
+					$container.tooltip('show');
 				}
 			});
 		},

--- a/core/js/sharetemplates.js
+++ b/core/js/sharetemplates.js
@@ -154,7 +154,7 @@ templates['sharedialoglinkshareview_popover_menu'] = template({"1":function(cont
     + alias4(((helper = (helper = helpers.cid || (depth0 != null ? depth0.cid : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"cid","hash":{},"data":data}) : helper)))
     + "\" class=\"linkPassText\" type=\"password\" placeholder=\""
     + alias4(((helper = (helper = helpers.passwordPlaceholder || (depth0 != null ? depth0.passwordPlaceholder : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"passwordPlaceholder","hash":{},"data":data}) : helper)))
-    + "\" autocomplete=\"new-password\" />\n					<span class=\"icon icon-loading-small hidden\"></span>\n				</span>\n			</li>\n";
+    + "\" autocomplete=\"new-password\" />\n					<input type=\"submit\" class=\"icon-confirm share-pass-submit\" value=\"\" />\n					<span class=\"icon icon-loading-small hidden\"></span>\n				</span>\n			</li>\n";
 },"9":function(container,depth0,helpers,partials,data) {
     return "disabled=\"disabled\"";
 },"11":function(container,depth0,helpers,partials,data) {

--- a/core/js/tests/specs/sharedialoglinkshareview.js
+++ b/core/js/tests/specs/sharedialoglinkshareview.js
@@ -186,13 +186,11 @@ describe('OC.Share.ShareDialogLinkShareView', function () {
 			});
 			view.render();
 
-			var $passwordDiv = view.$el.find('#linkPass');
 			$passwordText = view.$el.find('.linkPassText');
 			$workingIcon = view.$el.find('.linkPassMenu .icon-loading-small');
 
 			sinon.stub(shareModel, 'saveLinkShare');
 
-			expect($passwordDiv.hasClass('hidden')).toBeFalsy();
 			expect($passwordText.hasClass('hidden')).toBeFalsy();
 			expect($workingIcon.hasClass('hidden')).toBeTruthy();
 

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -127,28 +127,6 @@ describe('OC.Share.ShareDialogView', function() {
 	describe('Share with link', function() {
 		// TODO: test ajax calls
 		// TODO: test password field visibility (whenever enforced or not)
-		it('update password on focus out', function() {
-			$('#allowShareWithLink').val('yes');
-
-			dialog.model.set({
-				linkShares: [{
-					id: 123
-				}]
-			});
-			dialog.render();
-
-			// Enable password, enter password and focusout
-			dialog.$el.find('[name=showPassword]').click();
-			dialog.$el.find('.linkPassText').focus();
-			dialog.$el.find('.linkPassText').val('foo');
-			dialog.$el.find('.linkPassText').focusout();
-
-			expect(saveLinkShareStub.calledOnce).toEqual(true);
-			expect(saveLinkShareStub.firstCall.args[0]).toEqual({
-				cid: 123,
-				password: 'foo'
-			});
-		});
 		it('update password on enter', function() {
 			$('#allowShareWithLink').val('yes');
 
@@ -164,6 +142,28 @@ describe('OC.Share.ShareDialogView', function() {
 			dialog.$el.find('.linkPassText').focus();
 			dialog.$el.find('.linkPassText').val('foo');
 			dialog.$el.find('.linkPassText').trigger(new $.Event('keyup', {keyCode: 13}));
+
+			expect(saveLinkShareStub.calledOnce).toEqual(true);
+			expect(saveLinkShareStub.firstCall.args[0]).toEqual({
+				cid: 123,
+				password: 'foo'
+			});
+		});
+		it('update password on submit', function() {
+			$('#allowShareWithLink').val('yes');
+
+			dialog.model.set({
+				linkShares: [{
+					id: 123
+				}]
+			});
+			dialog.render();
+
+			// Enable password and enter password
+			dialog.$el.find('[name=showPassword]').click();
+			dialog.$el.find('.linkPassText').focus();
+			dialog.$el.find('.linkPassText').val('foo');
+			dialog.$el.find('.linkPassText + .icon-confirm').click();
 
 			expect(saveLinkShareStub.calledOnce).toEqual(true);
 			expect(saveLinkShareStub.firstCall.args[0]).toEqual({


### PR DESCRIPTION
Fix #12308

Better layout, now clicking outside (which is often supposed to be a cancel action) won't do anything now.
Direct validation by enter key or click is what we want.

![peek 16-11-2018 16-18](https://user-images.githubusercontent.com/14975046/48630068-8be50b80-e9bb-11e8-98b4-cbf0cb3dbc0a.gif)

Also fixed the loading on the sharees autocompletion

| Before | After |
|:---------:|:------:|
|![capture d ecran_2018-11-16_15-55-41](https://user-images.githubusercontent.com/14975046/48630083-9a332780-e9bb-11e8-9443-feb520d3115b.png)|![capture d ecran_2018-11-16_15-57-00](https://user-images.githubusercontent.com/14975046/48630084-9a332780-e9bb-11e8-9280-56adc3cd1490.png)|
