### PR TITLE
[stable14] Fix the warning appearing in the admin section when mail_smtpmode is not configured 

### DIFF
--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -529,7 +529,7 @@ Raw output
 	}
 
 	protected function isPhpMailerUsed(): bool {
-		return $this->config->getSystemValue('mail_smtpmode') === 'php';
+		return $this->config->getSystemValue('mail_smtpmode', 'smtp') === 'php';
 	}
 
 	protected function hasOpcacheLoaded(): bool {

--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -529,7 +529,7 @@ Raw output
 	}
 
 	protected function isPhpMailerUsed(): bool {
-		return $this->config->getSystemValue('mail_smtpmode', 'php') === 'php';
+		return $this->config->getSystemValue('mail_smtpmode') === 'php';
 	}
 
 	protected function hasOpcacheLoaded(): bool {

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -511,6 +511,39 @@ class CheckSetupControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->checkSetupController->check());
 	}
 
+	public function testIsPhpMailerUsed() {
+		$checkSetupController = $this->getMockBuilder('\OC\Settings\Controller\CheckSetupController')
+			->setConstructorArgs([
+				'settings',
+				$this->request,
+				$this->config,
+				$this->clientService,
+				$this->urlGenerator,
+				$this->util,
+				$this->l10n,
+				$this->checker,
+				$this->logger,
+				$this->dispatcher,
+				$this->db,
+				$this->lockingProvider,
+				$this->dateTimeFormatter,
+				$this->memoryInfo,
+			])
+			->setMethods(null)->getMock();
+
+		$this->config->expects($this->at(0))
+			->method('getSystemValue')
+			->with('mail_smtpmode', null)
+			->will($this->returnValue('php'));
+		$this->config->expects($this->at(1))
+			->method('getSystemValue')
+			->with('mail_smtpmode', null)
+			->will($this->returnValue('not-php'));
+
+		$this->assertTrue($this->invokePrivate($checkSetupController, 'isPhpMailerUsed'));
+		$this->assertFalse($this->invokePrivate($checkSetupController, 'isPhpMailerUsed'));
+	}
+
 	public function testGetCurlVersion() {
 		$checkSetupController = $this->getMockBuilder('\OC\Settings\Controller\CheckSetupController')
 			->setConstructorArgs([

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -533,11 +533,11 @@ class CheckSetupControllerTest extends TestCase {
 
 		$this->config->expects($this->at(0))
 			->method('getSystemValue')
-			->with('mail_smtpmode', null)
+			->with('mail_smtpmode', 'smtp')
 			->will($this->returnValue('php'));
 		$this->config->expects($this->at(1))
 			->method('getSystemValue')
-			->with('mail_smtpmode', null)
+			->with('mail_smtpmode', 'smtp')
 			->will($this->returnValue('not-php'));
 
 		$this->assertTrue($this->invokePrivate($checkSetupController, 'isPhpMailerUsed'));


### PR DESCRIPTION
Backport of #12401 

I would port this to 14.0.4 (as we need an RC 2 for #12502 anyways) and because this blocks that stable14 is shipped via snap by @kyrofa. Also this is a change of one default attribute in the setup check and has little impact on the overall instance. 
