### PR TITLE
Fix redirect page design details

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -607,6 +607,7 @@ form #selectDbType label.ui-state-active {
 .warning h2,
 .update h2,
 .error h2 {
+	color: #fff;
 	text-align: center;
 }
 

--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -202,6 +202,7 @@ input[type='submit'],
 input[type='submit'].icon-confirm,
 input[type='button'],
 button,
+a.button,
 .button,
 select {
 	display: inline-block;


### PR DESCRIPTION
When you use the Mail app and click on a link, the redirect page looked a bit off, with unreadable heading and non-pill-style button:
![redirect text color before](https://user-images.githubusercontent.com/925062/48734603-26587f80-ec46-11e8-8c39-6bd924a73f7c.png) ![redirect page after](https://user-images.githubusercontent.com/925062/48734601-26587f80-ec46-11e8-9b66-9cebd1296aa0.png)

Please review @nextcloud/designers :)