### PR TITLE
Bearer tokens are app token

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -783,6 +783,10 @@ class Session implements IUserSession, Emitter {
 		if(!$this->validateToken($token)) {
 			return false;
 		}
+
+		// Set the session variable so we know this is an app password
+		$this->session->set('app_password', $token);
+
 		return true;
 	}
 


### PR DESCRIPTION
Fixes #12498

This means that we set that it is a proper app token once it is
validated. This will allow the 2FA middleware to just run the same
check.