### PR TITLE
Respect the disabled setting for lost_password_link

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -232,7 +232,9 @@ class LoginController extends Controller {
 		$parameters['resetPasswordLink'] = $this->config
 			->getSystemValue('lost_password_link', '');
 
-		if (!$parameters['resetPasswordLink'] && $userObj !== null) {
+		if ($parameters['resetPasswordLink'] === 'disabled') {
+			$parameters['canResetPassword'] = false;
+		} else if (!$parameters['resetPasswordLink'] && $userObj !== null) {
 			$parameters['canResetPassword'] = $userObj->canChangePassword();
 		} else if ($userObj !== null && $userObj->isEnabled() === false) {
 			$parameters['canResetPassword'] = false;


### PR DESCRIPTION
Fixes #11146
As documented when it is set to disabled the user can't request a lost
password.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>