### PR TITLE
Do not switch to root folder if filelist is already shown

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -653,8 +653,13 @@
 		 */
 		_onShow: function(e) {
 			if (this.shown) {
-				this._setCurrentDir('/', false);
-				this.reload();
+				if (e.itemId === this.id) {
+					this._setCurrentDir('/', false);
+				}
+				// Only reload if we don't navigate to a different directory
+				if (typeof e.dir === 'undefined' || e.dir === this.getCurrentDirectory()) {
+					this.reload();
+				}
 			}
 			this.shown = true;
 		},

--- a/apps/files/js/navigation.js
+++ b/apps/files/js/navigation.js
@@ -154,7 +154,12 @@
 			this.$currentContent = $('#app-content-' + (typeof itemView === 'string' && itemView !== '' ? itemView : itemId));
 			this.$currentContent.removeClass('hidden');
 			if (!options || !options.silent) {
-				this.$currentContent.trigger(jQuery.Event('show'));
+				this.$currentContent.trigger(jQuery.Event('show', {
+					itemId: itemId,
+					previousItemId: oldItemId,
+					dir: itemDir,
+					view: itemView
+				}));
 				this.$el.trigger(
 					new $.Event('itemChanged', {
 						itemId: itemId,


### PR DESCRIPTION
Navigating to the root folder is already handled by [OCA.Files.Navigation.setActiveItem](https://github.com/nextcloud/server/blob/df7e016104f284c29f9c8571d548b64008f1a626/apps/files/js/navigation.js#L134-L146) in case the view doesn't change.

Fixes https://github.com/nextcloud/server/issues/12493 since there was a race condition between the root folder loading for falling back when clicking the All files sidebar entry and the actual view that should be loaded.