### PR TITLE
Apply border to primary button if on log in page (and not in a dark container) or if in header

### DIFF
--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -82,10 +82,9 @@ $invert: luma($color-primary) > 0.6;
 			@include icon-color('checkbox-mark', 'actions', $color-white, 1, true);
 		}
 	}
-	#body-user {
-		.primary {
-			border: 1px solid transparent;
-		}
+	/* Always give primary button a border for light primary colors */
+	.primary {
+		border-color: var(--color-border) !important;
 	}
 } @else {
 	#appmenu:not(.inverted) svg {

--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -90,7 +90,7 @@ div[contenteditable=true],
 		cursor: pointer;
 
 		/* Apply border to primary button if on log in page (and not in a dark container) or if in header */
-		#body-login :not(body-login-container) &,
+		#body-login :not(.body-login-container) &,
 		#header & {
 			border-color: var(--color-primary-text);
 		}

--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -85,14 +85,22 @@ div[contenteditable=true],
 	/* Primary action button, use sparingly */
 	&.primary {
 		background-color: var(--color-primary-element);
-		border: 1px solid var(--color-primary-text);
+		border-color: var(--color-primary-element);
 		color: var(--color-primary-text);
 		cursor: pointer;
+
+		/* Apply border to primary button if on log in page (and not in a dark container) or if in header */
+		#body-login :not(body-login-container) &,
+		#header & {
+			border-color: var(--color-primary-text);
+		}
+
 		&:not(:disabled) {
 			&:hover,
 			&:focus,
-			&:active  {
-				background-color: var(--color-primary-element-light)
+			&:active {
+				background-color: var(--color-primary-element-light);
+				border-color: var(--color-primary-element-light);
 			}
 			&:active {
 				color: var(--color-primary-text-dark);


### PR DESCRIPTION
fix #12294, please review @nextcloud/designers @schiessle 

For buttons on dark background, like in the header of the share page, there still is white border:
![primary button on dark background](https://user-images.githubusercontent.com/925062/48785993-25772a80-ece6-11e8-919d-3aa5e85dc522.png)

For buttons elsewhere in the main content, where they are on white background, the border color is the same as the background color:
![primary button on white background](https://user-images.githubusercontent.com/925062/48785994-260fc100-ece6-11e8-9ed1-f4babaf6d155.png)

We could also go with `border:none;` which looks even better, but then also need an exception for theming:
![primary button border none](https://user-images.githubusercontent.com/925062/48786220-ac2c0780-ece6-11e8-9b12-833612bb14f3.png)

In general we still need something for light theming colors … as usual. @juliushaertl @skjnldsv any idea? Maybe again cap the color at a specific lightness and then use the standard border color?


I am not sure whether this is something for 15 in any case as this has a bunch of potential for regressions and looking strange too.
