### PR TITLE
Do not show tab headers marked as hidden

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -805,6 +805,10 @@ $min-content-width: $breakpoint-mobile - $navigation-width - $list-min-width;
 		margin-bottom: 1px;
 		padding: 5px;
 
+		&.hidden {
+			display: none;
+		}
+
 		/* Use same amount as sidebar padding */
 		&:first-child {
 			padding-left: 15px;


### PR DESCRIPTION
This pull request fixes a regression introduced in #12180 

[Tab headers that should not be shown are marked with the `hidden` CSS class](https://github.com/nextcloud/server/blob/838105877c7b426f5c0e75699df096a80198d39c/apps/files/js/detailsview.js#L174-L175). The CSS rules set `display: none` for `.hidden` elements, but as the rules for `.tabHeaders .tabHeader` are more specific than rules for `.hidden` [the `display` property is overriden and ends being `flex`](https://github.com/nextcloud/server/blob/e7d565178131510c5081fe7a54c92d59d4ea13c3/core/css/apps.scss#L796). Therefore, it is necessary to explicitly set a rule for `.tabHeaders .tabHeader.hidden` elements.

**Before:**
![sidebar-hidden-tab-before](https://user-images.githubusercontent.com/26858233/48848596-9846db00-eda4-11e8-9414-a2a1385369b9.png)

**After:**
![sidebar-hidden-tab-after](https://user-images.githubusercontent.com/26858233/48848600-9b41cb80-eda4-11e8-90bc-d27f8e8a6770.png)

@nextcloud/designers
