### PR TITLE
Fix rendering of the sidebar in Files app

### DIFF
--- a/apps/files/js/detailsview.js
+++ b/apps/files/js/detailsview.js
@@ -96,16 +96,6 @@
 		 * Renders this details view
 		 */
 		render: function() {
-			// remove old instances
-			var $appSidebar = $('#app-sidebar');
-			if ($appSidebar.length === 0) {
-				this.$el.insertAfter($('#app-content'));
-			} else {
-				if ($appSidebar[0] !== this.el) {
-					$appSidebar.replaceWith(this.$el);
-				}
-			}
-			
 			var templateVars = {
 				closeLabel: t('files', 'Close')
 			};

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -584,9 +584,33 @@
 			}
 
 			this._currentFileModel = model;
+
+			this._replaceDetailsViewElementIfNeeded();
+
 			this._detailsView.setFileInfo(model);
-			this._detailsView.render();
 			this._detailsView.$el.scrollTop(0);
+		},
+
+		/**
+		 * Replaces the current details view element with the details view
+		 * element of this file list.
+		 *
+		 * Each file list has its own DetailsView object, and each one has its
+		 * own root element, but there can be just one details view/sidebar
+		 * element in the document. This helper method replaces the current
+		 * details view/sidebar element in the document with the element from
+		 * the DetailsView object of this file list.
+		 */
+		_replaceDetailsViewElementIfNeeded: function() {
+			var $appSidebar = $('#app-sidebar');
+			if ($appSidebar.length === 0) {
+				this._detailsView.$el.insertAfter($('#app-content'));
+			} else if ($appSidebar[0] !== this._detailsView.el) {
+				// "replaceWith()" can not be used here, as it removes the old
+				// element instead of just detaching it.
+				this._detailsView.$el.insertBefore($appSidebar);
+				$appSidebar.detach();
+			}
 		},
 
 		/**

--- a/tests/acceptance/features/app-comments.feature
+++ b/tests/acceptance/features/app-comments.feature
@@ -6,3 +6,26 @@ Feature: app-comments
     And I open the "Comments" tab in the details view
     When I create a new comment with "Hello world" as message
     Then I see a comment with "Hello world" as message
+
+  Scenario: open the comments for a different file
+    Given I am logged in
+    And I create a new folder named "Folder"
+    And I open the details view for "welcome.txt"
+    And I open the "Comments" tab in the details view
+    And I create a new comment with "Hello world" as message
+    And I see a comment with "Hello world" as message
+    When I open the details view for "Folder"
+    # The "Comments" tab should already be opened
+    Then I see that there are no comments
+
+  Scenario: write a comment in a file right after writing a comment in another file
+    Given I am logged in
+    And I create a new folder named "Folder"
+    And I open the details view for "Folder"
+    And I open the "Comments" tab in the details view
+    And I create a new comment with "Comment in Folder" as message
+    And I open the details view for "welcome.txt"
+    # The "Comments" tab should already be opened
+    When I create a new comment with "Comment in welcome.txt" as message
+    Then I see a comment with "Comment in welcome.txt" as message
+    And I see that there is no comment with "Comment in Folder" as message

--- a/tests/acceptance/features/app-files-tags.feature
+++ b/tests/acceptance/features/app-files-tags.feature
@@ -8,6 +8,17 @@ Feature: app-files-tags
     When I open the input field for tags in the details view
     Then I see that the input field for tags in the details view is shown
 
+  Scenario: show the input field for tags in the details view after closing and opening the details view again
+    Given I am logged in
+    And I open the details view for "welcome.txt"
+    And I see that the details view is open
+    And I close the details view
+    And I see that the details view is closed
+    And I open the details view for "welcome.txt"
+    And I see that the details view is open
+    When I open the input field for tags in the details view
+    Then I see that the input field for tags in the details view is shown
+
   Scenario: show the input field for tags in the details view after the sharing tab has loaded
     Given I am logged in
     And I open the details view for "welcome.txt"

--- a/tests/acceptance/features/app-files.feature
+++ b/tests/acceptance/features/app-files.feature
@@ -1,5 +1,42 @@
 Feature: app-files
 
+  Scenario: open and close the details view
+    Given I am logged in
+    When I open the details view for "welcome.txt"
+    And I see that the details view is open
+    And I close the details view
+    Then I see that the details view is closed
+
+  Scenario: open and close the details view twice
+    Given I am logged in
+    And I open the details view for "welcome.txt"
+    And I see that the details view is open
+    And I close the details view
+    And I see that the details view is closed
+    When I open the details view for "welcome.txt"
+    And I see that the details view is open
+    And I close the details view
+    Then I see that the details view is closed
+
+  Scenario: open and close the details view again after coming back from a different section
+    Given I am logged in
+    And I open the details view for "welcome.txt"
+    And I see that the details view is open
+    And I close the details view
+    And I see that the details view is closed
+    And I open the "Recent" section
+    And I see that the current section is "Recent"
+    And I open the details view for "welcome.txt"
+    And I see that the details view is open
+    And I close the details view
+    And I see that the details view is closed
+    When I open the "All files" section
+    And I see that the current section is "All files"
+    And I open the details view for "welcome.txt"
+    And I see that the details view is open
+    And I close the details view
+    Then I see that the details view is closed
+
   Scenario: viewing a favorite file in its folder shows the correct sidebar view
     Given I am logged in
     And I create a new folder named "other"

--- a/tests/acceptance/features/app-files.feature
+++ b/tests/acceptance/features/app-files.feature
@@ -292,3 +292,22 @@ Feature: app-files
     When I unmark "welcome.txt" as favorite
     Then I see that "welcome.txt" is not marked as favorite
     And I see that "A name alphabetically lower than welcome.txt" precedes "welcome.txt" in the file list
+
+  Scenario: mark a file as favorite in the details view
+    Given I am logged in
+    And I open the details view for "welcome.txt"
+    And I see that the details view is open
+    When I mark the file as favorite in the details view
+    Then I see that "welcome.txt" is marked as favorite
+    And I see that the file is marked as favorite in the details view
+
+  Scenario: unmark a file as favorite in the details view
+    Given I am logged in
+    And I open the details view for "welcome.txt"
+    And I see that the details view is open
+    And I mark the file as favorite in the details view
+    And I see that "welcome.txt" is marked as favorite
+    And I see that the file is marked as favorite in the details view
+    When I unmark the file as favorite in the details view
+    Then I see that "welcome.txt" is not marked as favorite
+    And I see that the file is not marked as favorite in the details view

--- a/tests/acceptance/features/bootstrap/CommentsAppContext.php
+++ b/tests/acceptance/features/bootstrap/CommentsAppContext.php
@@ -63,6 +63,15 @@ class CommentsAppContext implements Context, ActorAwareInterface {
 	}
 
 	/**
+	 * @return Locator
+	 */
+	public static function emptyContent() {
+		return Locator::forThe()->css(".emptycontent")->
+				descendantOf(FilesAppContext::detailsView())->
+				describedAs("Empty content in details view in Files app");
+	}
+
+	/**
 	 * @When /^I create a new comment with "([^"]*)" as message$/
 	 */
 	public function iCreateANewCommentWithAsMessage($commentText) {
@@ -71,10 +80,29 @@ class CommentsAppContext implements Context, ActorAwareInterface {
 	}
 
 	/**
+	 * @Then /^I see that there are no comments$/
+	 */
+	public function iSeeThatThereAreNoComments() {
+		PHPUnit_Framework_Assert::assertTrue(
+				$this->actor->find(self::emptyContent(), 10)->isVisible());
+	}
+
+	/**
 	 * @Then /^I see a comment with "([^"]*)" as message$/
 	 */
 	public function iSeeACommentWithAsMessage($commentText) {
 		PHPUnit_Framework_Assert::assertTrue(
 				$this->actor->find(self::commentWithText($commentText), 10)->isVisible());
+	}
+
+	/**
+	 * @Then /^I see that there is no comment with "([^"]*)" as message$/
+	 */
+	public function iSeeThatThereIsNoCommentWithAsMessage($commentText) {
+		try {
+			PHPUnit_Framework_Assert::assertFalse(
+					$this->actor->find(self::commentWithText($commentText))->isVisible());
+		} catch (NoSuchElementException $exception) {
+		}
 	}
 }

--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -89,6 +89,33 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function favoriteActionInFileDetailsInDetailsView() {
+		return Locator::forThe()->css(".action-favorite")->
+				descendantOf(self::fileDetailsInDetailsView())->
+				describedAs("Favorite action in file details in details view in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function notFavoritedStateIconInFileDetailsInDetailsView() {
+		return Locator::forThe()->css(".icon-star")->
+				descendantOf(self::favoriteActionInFileDetailsInDetailsView())->
+				describedAs("Not favorited state icon in file details in details view in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function favoritedStateIconInFileDetailsInDetailsView() {
+		return Locator::forThe()->css(".icon-starred")->
+				descendantOf(self::favoriteActionInFileDetailsInDetailsView())->
+				describedAs("Favorited state icon in file details in details view in Files app");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function fileDetailsInDetailsViewWithText($fileDetailsText) {
 		return Locator::forThe()->xpath("//span[normalize-space() = '$fileDetailsText']")->
 				descendantOf(self::fileDetailsInDetailsView())->
@@ -373,6 +400,24 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	}
 
 	/**
+	 * @When I mark the file as favorite in the details view
+	 */
+	public function iMarkTheFileAsFavoriteInTheDetailsView() {
+		$this->iSeeThatTheFileIsNotMarkedAsFavoriteInTheDetailsView();
+
+		$this->actor->find(self::favoriteActionInFileDetailsInDetailsView(), 10)->click();
+	}
+
+	/**
+	 * @When I unmark the file as favorite in the details view
+	 */
+	public function iUnmarkTheFileAsFavoriteInTheDetailsView() {
+		$this->iSeeThatTheFileIsMarkedAsFavoriteInTheDetailsView();
+
+		$this->actor->find(self::favoriteActionInFileDetailsInDetailsView(), 10)->click();
+	}
+
+	/**
 	 * @When I check the tag :tag in the dropdown for tags in the details view
 	 */
 	public function iCheckTheTagInTheDropdownForTagsInTheDetailsView($tag) {
@@ -498,6 +543,22 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	public function iSeeThatTheFileNameShownInTheDetailsViewIs($fileName) {
 		PHPUnit_Framework_Assert::assertEquals(
 				$this->actor->find(self::fileNameInDetailsView(), 10)->getText(), $fileName);
+	}
+
+	/**
+	 * @Then I see that the file is marked as favorite in the details view
+	 */
+	public function iSeeThatTheFileIsMarkedAsFavoriteInTheDetailsView() {
+		PHPUnit_Framework_Assert::assertNotNull(
+				$this->actor->find(self::favoritedStateIconInFileDetailsInDetailsView(), 10));
+	}
+
+	/**
+	 * @Then I see that the file is not marked as favorite in the details view
+	 */
+	public function iSeeThatTheFileIsNotMarkedAsFavoriteInTheDetailsView() {
+		PHPUnit_Framework_Assert::assertNotNull(
+				$this->actor->find(self::notFavoritedStateIconInFileDetailsInDetailsView(), 10));
 	}
 
 	/**


### PR DESCRIPTION
Fixes #12320

This pull request fixes the regressions regarding the sidebar introduced in #12231 and #10509 (which, in turn, fixed the regression of the sidebar introduced in #9982).

When a view is rendered it should not be concerned with where it is going to be placed in the document; in general this should be a responsibility of the object using the view.

Moreover, when the details view is rendered it should simply prepare a skeleton that includes the root elements provided by the plugins; those elements will be updated by the plugins as needed when a file or a tab is selected.

Finally, the details view should not be explicitly rendered. The rendering removes the previous elements, but that is needed only when the details view is in a dirty state, that is, when new plugins were added since the last time that it was rendered. However, that dirty state is internally handled, and the view is automatically rendered again if needed when a file info is set.

Due to all that the details view is no longer explicitly rendered when updating it with a different file. Also, as each file list has its own details view, and each details view has its own element, but there can be only one details view/sidebar element in the document, when the file list updates the details view it also replaces the current one in the document with its own details view if needed (that is, if it is not the current one already).

Besides that, when the element of a details view is replaced with the element of a different details view the old one should be detached from the document, but never removed. Otherwise the event handlers would not work when that element is attached again later (when changing to a different section in the Files app and then going back to the previous one).

Essentially the problems with buttons not working come from this last point (which was also increased by rendering the details view after setting the file info). Excuse me for not giving more details, but it is quite late ;-) (yes, late, not early; for me it is still yesterday :-P ).

Nevertheless, for reference here is the explanation of what was the problem with comments: it did not come from rendering the view twice, but from setting the file info for one file and then setting the file info for a different file almost immediately; rendering the details view after setting the file info fixed the problem only because the same file info was set twice ;-)

[`CommentsTabView.setFileInfo` resets the collection and then fetches the next page](https://github.com/nextcloud/server/blob/master/apps/comments/js/commentstabview.js#L104-L105), which [triggers a sync request](https://github.com/nextcloud/server/blob/master/apps/comments/js/commentcollection.js#L132). However, `reset` does not abort current pending requests (see pull 1325 in https://github.com/jashkenas/backbone (I am not linking it directly to prevent the reference from polluting that thread)). Thus, if `setFileInfo` is called with two different models once the second one is setup the response for the first one will be received, and [the comments in that response will be included in the second model](https://github.com/nextcloud/server/blob/master/apps/comments/js/commentcollection.js#L122).

Due to all that it may be possible that [further bugs](https://github.com/nextcloud/server/issues/12648) with the comments are lurking in the shadows, but in most cases it should work fine ;-)

I have added acceptance tests for the issue that was fixed by #12231 (comments), issues caused by #12231 (favoriting from the details view), and issues caused (or, at least, not yet fixed) by #10509 (tags and opening and closing the details view). Note, however, that the tests for tags still fail sometimes due to a race condition; this is another issue to be fixed in a different pull request.
