### PR TITLE
12.0.13

### DIFF
--- a/version.php
+++ b/version.php
@@ -26,10 +26,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(12, 0, 13, 1);
+$OC_Version = array(12, 0, 13, 2);
 
 // The human readable string
-$OC_VersionString = '12.0.13 RC 2';
+$OC_VersionString = '12.0.13';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Changelog since 12.0.12:

* #11763 Ignore "session_lifetime" if it can not be converted to a number
* #11998 Fix opening a section again in the Files app
* #12059 Actually return the root folder when traversing up the tree
* #12110 Double check for failed cache with a shared storage
* #12461 Fixes dav share issue with owner
* #12504 Forward object not found error in swift as dav 404
* #12563 Handle permission in update of share better