### PR TITLE
13.0.8

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(13, 0, 8, 1);
+$OC_Version = array(13, 0, 8, 2);
 
 // The human readable string
-$OC_VersionString = '13.0.8 RC 2';
+$OC_VersionString = '13.0.8';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Changelog since 13.0.7:

* #11762 Ignore "session_lifetime" if it can not be converted to a number
* #11857 Change password expiration time from 12h to 7d
* #11962 Do not emit preHooks twice on non-part-storage
* #11978 Filter null values for UserManager::getByEmail
* #11982 Allow local delivery of schedule message while prohibiting FreeBusy requests
* #11992 Load apps/APP/l10n/*.js and themes/THEME/apps/APP/l10n/*.js
* #11996 Fix opening a section again in the Files app
* #11997 Lazy open first source stream in assemblystream
* #12006 Remove cookies from Clear-Site-Data Header
* #12060 Actually return the root folder when traversing up the tree
* #12109 Double check for failed cache with a shared storage
* #12112 Implement the size of an assembly stream
* #12123 Remove unneeded empty search attribute values, fixes #12086
* #12142 LDAP: announce display name changes so that addressbook picks it up
* #12208 Reset bruteforce on token refresh OAuth
* #12212 Expired tokens should not trigger bruteforce protection
* #12298 A folder should get a folder mimetype
* #12376 Properly search the root of a shared external storage
* #12434 Unique contraint and deadlock fixes for filecache and file_locks
* #12460 Fixes dav share issue with owner
* #12503 Forward object not found error in swift as dav 404
* #12546 Bearer tokens are app token
* #12562 Handle permission in update of share better
* [activity#313](https://github.com/nextcloud/activity/pull/313) Correctly restrict affected users when using command to send emails