### PR TITLE
Fix Typo in Original English String and All Translations

### DIFF
--- a/settings/js/settings/personalInfo.js
+++ b/settings/js/settings/personalInfo.js
@@ -229,7 +229,7 @@ $(document).ready(function () {
 				location.reload();
 			},
 			fail: function() {
-				OC.Notification.showTemporary(t('settings', 'An error occured while changing your language. Please reload the page and try again.'));
+				OC.Notification.showTemporary(t('settings', 'An error occurred while changing your language. Please reload the page and try again.'));
 			}
 		});
 	};
@@ -255,7 +255,7 @@ $(document).ready(function () {
 				moment.locale(selectedLocale);
 			},
 			fail: function() {
-				OC.Notification.showTemporary(t('settings', 'An error occured while changing your locale. Please reload the page and try again.'));
+				OC.Notification.showTemporary(t('settings', 'An error occurred while changing your locale. Please reload the page and try again.'));
 			}
 		});
 	};


### PR DESCRIPTION
There is a small typo in the word "occured", which misses an additional "r". It has to be "occurred". The string is used as a key for the translations as well, so I replaced all occurrences ;)