### PR TITLE
Cleanup middleware registering

### DIFF
--- a/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
+++ b/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
@@ -29,6 +29,7 @@ namespace Test\AppFramework\DependencyInjection;
 
 use OC\AppFramework\DependencyInjection\DIContainer;
 use \OC\AppFramework\Http\Request;
+use OC\AppFramework\Middleware\Security\SecurityMiddleware;
 use OCP\AppFramework\QueryException;
 use OCP\IConfig;
 use OCP\Security\ISecureRandom;
@@ -54,16 +55,9 @@ class DIContainerTest extends \Test\TestCase {
 		$this->assertTrue(isset($this->container['Request']));
 	}
 
-
-	public function testProvidesSecurityMiddleware(){
-		$this->assertTrue(isset($this->container['SecurityMiddleware']));
-	}
-
-
 	public function testProvidesMiddlewareDispatcher(){
 		$this->assertTrue(isset($this->container['MiddlewareDispatcher']));
 	}
-
 
 	public function testProvidesAppName(){
 		$this->assertTrue(isset($this->container['AppName']));
@@ -80,10 +74,17 @@ class DIContainerTest extends \Test\TestCase {
 			$this->createMock(ISecureRandom::class),
 			$this->createMock(IConfig::class)
 		);
-		$security = $this->container['SecurityMiddleware'];
 		$dispatcher = $this->container['MiddlewareDispatcher'];
+		$middlewares = $dispatcher->getMiddlewares();
 
-		$this->assertContains($security, $dispatcher->getMiddlewares());
+		$found = false;
+		foreach ($middlewares as $middleware) {
+			if ($middleware instanceof SecurityMiddleware) {
+				$found = true;
+			}
+		}
+
+		$this->assertTrue($found);
 	}
 
 	public function testInvalidAppClass() {


### PR DESCRIPTION
Fixes #12224

Since we only use the middleware at 1 location it makes no sense to
register them in each and every container.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>