### PR TITLE
handle mail send error gracefully

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -714,7 +714,7 @@ class Manager implements IManager {
 	 * @param string $initiator user ID of share sender
 	 * @param string $shareWith email address of share receiver
 	 * @param \DateTime|null $expiration
-	 * @throws \Exception If mail couldn't be sent
+	 * @return bool
 	 */
 	protected function sendMailNotification(IL10N $l,
 											$filename,
@@ -773,7 +773,18 @@ class Manager implements IManager {
 		}
 
 		$message->useTemplate($emailTemplate);
-		$this->mailer->send($message);
+		try {
+			$failedRecipients = $this->mailer->send($message);
+			if(!empty($failedRecipients)) {
+				$this->logger->error('Share notification mail could not be send to: ' . implode(', ', $failedRecipients));
+				return false;
+			}
+		} catch (\Exception $e) {
+			$this->logger->error('Share notification mail could not be send: ' . $e->getMessage());
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -776,11 +776,11 @@ class Manager implements IManager {
 		try {
 			$failedRecipients = $this->mailer->send($message);
 			if(!empty($failedRecipients)) {
-				$this->logger->error('Share notification mail could not be send to: ' . implode(', ', $failedRecipients));
+				$this->logger->error('Share notification mail could not be sent to: ' . implode(', ', $failedRecipients));
 				return false;
 			}
 		} catch (\Exception $e) {
-			$this->logger->logException($e, ['message' => 'Share notification mail could not be send']);
+			$this->logger->logException($e, ['message' => 'Share notification mail could not be sent']);
 			return false;
 		}
 

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -780,7 +780,7 @@ class Manager implements IManager {
 				return false;
 			}
 		} catch (\Exception $e) {
-			$this->logger->error('Share notification mail could not be send: ' . $e->getMessage());
+			$this->logger->logException($e, ['message' => 'Share notification mail could not be send']);
 			return false;
 		}
 

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -692,15 +692,15 @@ class Manager implements IManager {
 							$emailAddress,
 							$share->getExpirationDate()
 						);
-						$this->logger->debug('Send share notification to ' . $emailAddress . ' for share with ID ' . $share->getId(), ['app' => 'share']);
+						$this->logger->debug('Sent share notification to ' . $emailAddress . ' for share with ID ' . $share->getId(), ['app' => 'share']);
 					} else {
-						$this->logger->debug('Share notification not send to ' . $share->getSharedWith() . ' because email address is not set.', ['app' => 'share']);
+						$this->logger->debug('Share notification not sent to ' . $share->getSharedWith() . ' because email address is not set.', ['app' => 'share']);
 					}
 				} else {
-					$this->logger->debug('Share notification not send to ' . $share->getSharedWith() . ' because user could not be found.', ['app' => 'share']);
+					$this->logger->debug('Share notification not sent to ' . $share->getSharedWith() . ' because user could not be found.', ['app' => 'share']);
 				}
 			} else {
-				$this->logger->debug('Share notification not send because mailsend is false.', ['app' => 'share']);
+				$this->logger->debug('Share notification not sent because mailsend is false.', ['app' => 'share']);
 			}
 		}
 
@@ -708,13 +708,16 @@ class Manager implements IManager {
 	}
 
 	/**
+	 * Send mail notifications
+	 *
+	 * This method will catch and log mail transmission errors
+	 *
 	 * @param IL10N $l Language of the recipient
 	 * @param string $filename file/folder name
 	 * @param string $link link to the file/folder
 	 * @param string $initiator user ID of share sender
 	 * @param string $shareWith email address of share receiver
 	 * @param \DateTime|null $expiration
-	 * @return bool
 	 */
 	protected function sendMailNotification(IL10N $l,
 											$filename,
@@ -777,14 +780,11 @@ class Manager implements IManager {
 			$failedRecipients = $this->mailer->send($message);
 			if(!empty($failedRecipients)) {
 				$this->logger->error('Share notification mail could not be sent to: ' . implode(', ', $failedRecipients));
-				return false;
+				return;
 			}
 		} catch (\Exception $e) {
 			$this->logger->logException($e, ['message' => 'Share notification mail could not be sent']);
-			return false;
 		}
-
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
log the error in case a notification mail of a new share couldn't
be send to the recipient and finish the share operation successfully

I would suggest to backport it at least to stable15 and stable14

fix https://github.com/nextcloud/server/issues/12597