### PR TITLE
Make acceptance tests for comments more robust

### DIFF
--- a/tests/acceptance/features/app-comments.feature
+++ b/tests/acceptance/features/app-comments.feature
@@ -24,6 +24,7 @@ Feature: app-comments
     And I open the details view for "Folder"
     And I open the "Comments" tab in the details view
     And I create a new comment with "Comment in Folder" as message
+    And I see a comment with "Comment in Folder" as message
     And I open the details view for "welcome.txt"
     # The "Comments" tab should already be opened
     When I create a new comment with "Comment in welcome.txt" as message

--- a/tests/acceptance/features/bootstrap/CommentsAppContext.php
+++ b/tests/acceptance/features/bootstrap/CommentsAppContext.php
@@ -83,8 +83,12 @@ class CommentsAppContext implements Context, ActorAwareInterface {
 	 * @Then /^I see that there are no comments$/
 	 */
 	public function iSeeThatThereAreNoComments() {
-		PHPUnit_Framework_Assert::assertTrue(
-				$this->actor->find(self::emptyContent(), 10)->isVisible());
+		if (!WaitFor::elementToBeEventuallyShown(
+				$this->actor,
+				self::emptyContent(),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
+			PHPUnit_Framework_Assert::fail("The no comments message is not visible yet after $timeout seconds");
+		}
 	}
 
 	/**


### PR DESCRIPTION
**How to test:**
- Make fetching comments a bit slower by adding `sleep(2)` to [the beginning of `getChild()` in _apps/dav/lib/Comments/RootCollection.php_](https://github.com/nextcloud/server/blob/813f0a0f40dd42b28cd35d91616f3f87ef400861/apps/dav/lib/Comments/RootCollection.php#L146)
- Run the acceptance tests for comments

**Result with this pull request:**
All tests pass

**Previous result:**
_open the comments for a different file_ failed due to the empty content message not having being shown yet when looking for it and not waiting for it to be shown, _write a comment in a file right after writing a comment in another file_ failed due to _Comment in Folder_ being shown in _welcome.txt_.

This last failure is actually [a bug in the comments](https://github.com/nextcloud/server/issues/12648), but one that can not be reliably tested with the acceptance tests due to depending on how fast the server creates the new comment. Therefore, the scenario now waits for the comment to be added to the first file before continuing; this still verifies that changing to a different file does not cause the comments from the previous file to be shown in the current file ([this was a different bug already fixed](https://github.com/nextcloud/server/issues/10934) and due to which this test was added in the first place), although it no longer verifies that changing to a different file while the comment is being sent does not cause the comment from the previous file to be shown in the current file (subtle difference, but needed for the reliability of the tests ;-) ).
