### PR TITLE
Don't require Same Site Cookies on accessibility app assets

### DIFF
--- a/apps/accessibility/lib/Controller/AccessibilityController.php
+++ b/apps/accessibility/lib/Controller/AccessibilityController.php
@@ -121,6 +121,7 @@ class AccessibilityController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @NoSameSiteCookieRequired
 	 *
 	 * @return DataDisplayResponse
 	 */
@@ -191,6 +192,7 @@ class AccessibilityController extends Controller {
 	/**
 	 * @NoCSRFRequired
 	 * @PublicPage
+	 * @NoSameSiteCookieRequired
 	 *
 	 * @return DataDownloadResponse
 	 */


### PR DESCRIPTION
Follows https://github.com/nextcloud/server/pull/11878

(EDIT : Github web Editor is handy for tiny editions, but DCO doesn't like it of course.)