### PR TITLE
Allow to disable the signature check

### DIFF
--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -482,9 +482,15 @@ class Crypt {
 	 * @throws GenericEncryptionException
 	 */
 	private function checkSignature($data, $passPhrase, $expectedSignature) {
+		$skipSignatureCheck = $this->config->getSystemValue('encryption_skip_signature_check', false);
+
 		$signature = $this->createSignature($data, $passPhrase);
-		if (!hash_equals($expectedSignature, $signature)) {
+		$hash = hash_equals($expectedSignature, $signature);
+
+		if (!$hash && $skipSignatureCheck === false) {
 			throw new GenericEncryptionException('Bad Signature', $this->l->t('Bad Signature'));
+		} else if (!$hash && $skipSignatureCheck) {
+			$this->logger->info("Signature check skipped", ['app' => 'encryption']);
 		}
 	}
 

--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -563,11 +563,13 @@ class Crypt {
 	 * @throws GenericEncryptionException
 	 */
 	private function hasSignature($catFile, $cipher) {
+		$skipSignatureCheck = $this->config->getSystemValue('encryption_skip_signature_check', false);
+
 		$meta = substr($catFile, -93);
 		$signaturePosition = strpos($meta, '00sig00');
 
 		// enforce signature for the new 'CTR' ciphers
-		if ($signaturePosition === false && stripos($cipher, 'ctr') !== false) {
+		if (!$skipSignatureCheck && $signaturePosition === false && stripos($cipher, 'ctr') !== false) {
 			throw new GenericEncryptionException('Missing Signature', $this->l->t('Missing Signature'));
 		}
 

--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -482,14 +482,14 @@ class Crypt {
 	 * @throws GenericEncryptionException
 	 */
 	private function checkSignature($data, $passPhrase, $expectedSignature) {
-		$skipSignatureCheck = $this->config->getSystemValue('encryption_skip_signature_check', false);
+		$enforceSignature = !$this->config->getSystemValue('encryption_skip_signature_check', false);
 
 		$signature = $this->createSignature($data, $passPhrase);
-		$hash = hash_equals($expectedSignature, $signature);
+		$isCorrectHash = hash_equals($expectedSignature, $signature);
 
-		if (!$hash && $skipSignatureCheck === false) {
+		if (!$isCorrectHash && $enforceSignature) {
 			throw new GenericEncryptionException('Bad Signature', $this->l->t('Bad Signature'));
-		} else if (!$hash && $skipSignatureCheck) {
+		} else if (!$isCorrectHash && !$enforceSignature) {
 			$this->logger->info("Signature check skipped", ['app' => 'encryption']);
 		}
 	}


### PR DESCRIPTION
This allows you to recover encryption files even if the signature is broken

Steps to test:

1. Enable server side encryption
2. Create a encrypted file
3. changed "encrypted" in the oc_filecache table for the file to a different value
4. Try to open the file

By default you will get a "bad signature error", if you disable the signature check in the config.php with `'encryption_skip_signature_check' => true` you should be able to open the file again.