### PR TITLE
fix exception on LDAP mapping during login

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -629,6 +629,11 @@ pipeline:
       image: nextcloudci/integration-php7.0:integration-php7.0-6
       commands:
         - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
+        - ./occ config:system:set redis host --value=cache
+        - ./occ config:system:set redis port --value=6379 --type=integer
+        - ./occ config:system:set redis timeout --value=0 --type=integer
+        - ./occ config:system:set --type string --value "\\OC\\Memcache\\Redis" memcache.local
+        - ./occ config:system:set --type string --value "\\OC\\Memcache\\Redis" memcache.distributed
         - ./occ app:enable user_ldap
         - cd build/integration
         - ./run.sh ldap_features/ldap-openldap.feature
@@ -639,6 +644,11 @@ pipeline:
         image: nextcloudci/integration-php7.0:integration-php7.0-6
         commands:
           - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
+          - ./occ config:system:set redis host --value=cache
+          - ./occ config:system:set redis port --value=6379 --type=integer
+          - ./occ config:system:set redis timeout --value=0 --type=integer
+          - ./occ config:system:set --type string --value "\\OC\\Memcache\\Redis" memcache.local
+          - ./occ config:system:set --type string --value "\\OC\\Memcache\\Redis" memcache.distributed
           - ./occ app:enable user_ldap
           - cd build/integration
           - ./run.sh ldap_features/openldap-uid-username.feature
@@ -649,6 +659,11 @@ pipeline:
     image: nextcloudci/integration-php7.0:integration-php7.0-6
     commands:
     - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
+    - ./occ config:system:set redis host --value=cache
+    - ./occ config:system:set redis port --value=6379 --type=integer
+    - ./occ config:system:set redis timeout --value=0 --type=integer
+    - ./occ config:system:set --type string --value "\\OC\\Memcache\\Redis" memcache.local
+    - ./occ config:system:set --type string --value "\\OC\\Memcache\\Redis" memcache.distributed
     - ./occ app:enable user_ldap
     - cd build/integration
     - ./run.sh ldap_features/openldap-numerical-id.feature
@@ -958,10 +973,13 @@ matrix:
     - TESTS: integration-ldap-features
     - TESTS: integration-ldap-openldap-features
       ENABLE_OPENLDAP: true
+      ENABLE_REDIS: true
     - TESTS: integration-ldap-openldap-uid-features
       ENABLE_OPENLDAP: true
+      ENABLE_REDIS: true
     - TESTS: integration-ldap-openldap-numerical-id-features
       ENABLE_OPENLDAP: true
+      ENABLE_REDIS: true
     - TESTS: integration-trashbin
     - TESTS: integration-remote-api
     - TESTS: integration-download

--- a/apps/dav/lib/CardDAV/SyncService.php
+++ b/apps/dav/lib/CardDAV/SyncService.php
@@ -261,7 +261,7 @@ class SyncService {
 	/**
 	 * @param IUser $user
 	 */
-	public function updateUser($user) {
+	public function updateUser(IUser $user) {
 		$systemAddressBook = $this->getLocalSystemAddressBook();
 		$addressBookId = $systemAddressBook['id'];
 		$converter = new Converter($this->accountManager);

--- a/apps/dav/lib/HookManager.php
+++ b/apps/dav/lib/HookManager.php
@@ -101,7 +101,9 @@ class HookManager {
 
 	public function postCreateUser($params) {
 		$user = $this->userManager->get($params['uid']);
-		$this->syncService->updateUser($user);
+		if ($user instanceof IUser) {
+			$this->syncService->updateUser($user);
+		}
 	}
 
 	public function preDeleteUser($params) {

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -609,30 +609,46 @@ class Access extends LDAPUtility {
 		// outside of core user management will still cache the user as non-existing.
 		$originalTTL = $this->connection->ldapCacheTTL;
 		$this->connection->setConfiguration(['ldapCacheTTL' => 0]);
-		if(($isUser && $intName !== '' && !$this->ncUserManager->userExists($intName))
-			|| (!$isUser && !\OC::$server->getGroupManager()->groupExists($intName))) {
-			if($mapper->map($fdn, $intName, $uuid)) {
-				$this->connection->setConfiguration(['ldapCacheTTL' => $originalTTL]);
-				if($this->ncUserManager instanceof PublicEmitter && $isUser) {
-					$this->ncUserManager->emit('\OC\User', 'assignedUserId', [$intName]);
-				}
-				$newlyMapped = true;
+		if( $intName !== ''
+			&& (($isUser && !$this->ncUserManager->userExists($intName))
+				|| (!$isUser && !\OC::$server->getGroupManager()->groupExists($intName))
+			)
+		) {
+			$this->connection->setConfiguration(['ldapCacheTTL' => $originalTTL]);
+			$newlyMapped = $this->mapAndAnnounceIfApplicable($mapper, $fdn, $intName, $uuid, $isUser);
+			if($newlyMapped) {
 				return $intName;
 			}
 		}
-		$this->connection->setConfiguration(['ldapCacheTTL' => $originalTTL]);
 
+		$this->connection->setConfiguration(['ldapCacheTTL' => $originalTTL]);
 		$altName = $this->createAltInternalOwnCloudName($intName, $isUser);
-		if (is_string($altName) && $mapper->map($fdn, $altName, $uuid)) {
-			if ($this->ncUserManager instanceof PublicEmitter && $isUser) {
-				$this->ncUserManager->emit('\OC\User', 'assignedUserId', [$altName]);
+		if (is_string($altName)) {
+			if($this->mapAndAnnounceIfApplicable($mapper, $fdn, $altName, $uuid, $isUser)) {
+				$newlyMapped = true;
+				return $altName;
 			}
-			$newlyMapped = true;
-			return $altName;
 		}
 
 		//if everything else did not help..
 		\OCP\Util::writeLog('user_ldap', 'Could not create unique name for '.$fdn.'.', ILogger::INFO);
+		return false;
+	}
+
+	protected function mapAndAnnounceIfApplicable(
+		AbstractMapping $mapper,
+		string $fdn,
+		string $name,
+		string $uuid,
+		bool $isUser
+	) :bool {
+		if($mapper->map($fdn, $name, $uuid)) {
+			if ($this->ncUserManager instanceof PublicEmitter && $isUser) {
+				$this->cacheUserExists($name);
+				$this->ncUserManager->emit('\OC\User', 'assignedUserId', [$name]);
+			}
+			return true;
+		}
 		return false;
 	}
 

--- a/apps/user_ldap/lib/AppInfo/Application.php
+++ b/apps/user_ldap/lib/AppInfo/Application.php
@@ -24,6 +24,8 @@
 namespace OCA\User_LDAP\AppInfo;
 
 use OCA\User_LDAP\Controller\RenewPasswordController;
+use OCA\User_LDAP\ILDAPWrapper;
+use OCA\User_LDAP\LDAP;
 use OCP\AppFramework\App;
 use OCP\AppFramework\IAppContainer;
 use OCP\IL10N;
@@ -49,6 +51,10 @@ class Application extends App {
 				$c->query('Session'),
 				$server->getURLGenerator()
 			);
+		});
+
+		$container->registerService(ILDAPWrapper::class, function () {
+			return new LDAP();
 		});
 	}
 }

--- a/apps/user_ldap/lib/Command/SetConfig.php
+++ b/apps/user_ldap/lib/Command/SetConfig.php
@@ -26,6 +26,8 @@
 
 namespace OCA\User_LDAP\Command;
 
+use OCA\User_LDAP\ConnectionFactory;
+use OCA\User_LDAP\LDAP;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -83,5 +85,8 @@ class SetConfig extends Command {
 		$configHolder = new Configuration($configID);
 		$configHolder->$key = $value;
 		$configHolder->saveConfiguration();
+
+		$connectionFactory = new ConnectionFactory(new LDAP());
+		$connectionFactory->get($configID)->clearCache();
 	}
 }

--- a/apps/user_ldap/lib/Controller/ConfigAPIController.php
+++ b/apps/user_ldap/lib/Controller/ConfigAPIController.php
@@ -27,6 +27,7 @@ use OC\CapabilitiesManager;
 use OC\Core\Controller\OCSController;
 use OC\Security\IdentityProof\Manager;
 use OCA\User_LDAP\Configuration;
+use OCA\User_LDAP\ConnectionFactory;
 use OCA\User_LDAP\Helper;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSBadRequestException;
@@ -45,6 +46,9 @@ class ConfigAPIController extends OCSController {
 	/** @var ILogger */
 	private $logger;
 
+	/** @var ConnectionFactory */
+	private $connectionFactory;
+
 	public function __construct(
 		$appName,
 		IRequest $request,
@@ -53,7 +57,8 @@ class ConfigAPIController extends OCSController {
 		IUserManager $userManager,
 		Manager $keyManager,
 		Helper $ldapHelper,
-		ILogger $logger
+		ILogger $logger,
+		ConnectionFactory $connectionFactory
 	) {
 		parent::__construct(
 			$appName,
@@ -67,6 +72,7 @@ class ConfigAPIController extends OCSController {
 
 		$this->ldapHelper = $ldapHelper;
 		$this->logger = $logger;
+		$this->connectionFactory = $connectionFactory;
 	}
 
 	/**
@@ -198,6 +204,7 @@ class ConfigAPIController extends OCSController {
 			}
 
 			$configuration->saveConfiguration();
+			$this->connectionFactory->get($configID)->clearCache();
 		} catch(OCSException $e) {
 			throw $e;
 		} catch (\Exception $e) {


### PR DESCRIPTION
fixes #11474 

It seems the issue was introduced with https://github.com/nextcloud/server/commit/c92d7429d7ff9a76a6dd62607e55ef680a43a679, but I cannot (and will not :D) blame @weeman1337 for it. It is a side effect of how the LDAP Backend detects name collisions when creating a mapping, and caching. 

A user object is fetched before matching, the yet non-existing user is found as non-existing and cached accordingly. The mapping follows later, is successful, but when a hook to announce this user is thrown a different listener wants to pull and fetch the brand new user object, but get's a null instead (and does not check for it).

The fix is essentially to cache the user after mapping. I removed some duplication as it is stupid to maintain and had a copy-paste issue in the past.