### PR TITLE
Fix folder path containing leading slash when getting mount root by id

### DIFF
--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -313,7 +313,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 			$internalPath = ltrim($cachedMountInfo->getRootInternalPath() . '/' . $cacheEntry->getPath(), '/');
 			$pathRelativeToMount = substr($internalPath, strlen($cachedMountInfo->getRootInternalPath()));
 			$pathRelativeToMount = ltrim($pathRelativeToMount, '/');
-			$absolutePath = $cachedMountInfo->getMountPoint() . $pathRelativeToMount;
+			$absolutePath = rtrim($cachedMountInfo->getMountPoint() . $pathRelativeToMount, '/');
 			return $this->root->createNode($absolutePath, new \OC\Files\FileInfo(
 				$absolutePath, $mount->getStorage(), $cacheEntry->getPath(), $cacheEntry, $mount,
 				\OC::$server->getUserManager()->get($mount->getStorage()->getOwner($pathRelativeToMount))


### PR DESCRIPTION
This fixes collabora on public link shared groupfolders

Fixes https://github.com/nextcloud/groupfolders/issues/225

Signed-off-by: Robin Appelman <robin@icewind.nl>