### PR TITLE
[stable14] Make sure to always load the latest icons-vars.css file

### DIFF
--- a/tests/lib/Template/IconsCacherTest.php
+++ b/tests/lib/Template/IconsCacherTest.php
@@ -28,6 +28,7 @@ use OC\Files\AppData\AppData;
 use OC\Files\AppData\Factory;
 use OC\Template\IconsCacher;
 use OCA\Theming\ThemingDefaults;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
@@ -46,10 +47,13 @@ class IconsCacherTest extends \Test\TestCase {
 	protected $appData;
 	/** @var IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
 	protected $urlGenerator;
+	/** @var ITimeFactory|\PHPUnit_Framework_MockObject_MockObject */
+	private $timeFactory;
 
 	protected function setUp() {
 		$this->logger = $this->createMock(ILogger::class);
 		$this->appData = $this->createMock(AppData::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 
 		/** @var Factory|\PHPUnit_Framework_MockObject_MockObject $factory */
 		$factory = $this->createMock(Factory::class);
@@ -63,7 +67,8 @@ class IconsCacherTest extends \Test\TestCase {
 		$this->iconsCacher = new IconsCacher(
 			$this->logger,
 			$factory,
-			$this->urlGenerator
+			$this->urlGenerator,
+			$this->timeFactory
 		);
 	}
 


### PR DESCRIPTION
Backport of  #12408

The icons-vars.css file was taken from browser cache even it was changed.

Steps to reproduce:

1. run occ maintenance:repair to clear the css cache
2. Load the files app
3. Load a different app that uses the scss icons methods (like deck on master)