### PR TITLE
Polishing of various modal dialogs

### DIFF
--- a/core/css/jquery.ocdialog.scss
+++ b/core/css/jquery.ocdialog.scss
@@ -17,7 +17,6 @@
 }
 .oc-dialog-title {
 	background: var(--color-main-background);
-	margin-left: 12px;
 }
 .oc-dialog-buttonrow {
 	position: relative;
@@ -30,12 +29,10 @@
 	box-sizing: border-box;
 	width: 100%;
 	background-image: linear-gradient(rgba(255, 255, 255, 0.0), var(--color-main-background));
-	border-bottom-left-radius: 3px;
-	border-bottom-right-radius: 3px;
 
 	&.twobuttons {
-		justify-content: space-between;
-	}
+        justify-content: space-between;
+    }
 
 	&.onebutton,
 	&.twobuttons.aside {
@@ -66,11 +63,13 @@
 
 .oc-dialog-dim {
 	background-color: #000;
-	opacity: .20;
+	opacity: .2;
 	z-index: 9999;
 	position: fixed;
-	top: 0; left: 0;
-	width: 100%; height: 100%;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
 }
 
 .oc-dialog-content {
@@ -80,7 +79,6 @@
 .oc-dialog.password-confirmation {
 	.oc-dialog-content {
 		width: auto;
-		margin: 12px;
 
 		input[type=password] {
 			width: 100%;

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1790,6 +1790,7 @@ OC.PasswordConfirmation = {
 					var $error = $('<p></p>').addClass('msg warning').text(config.error);
 				}
 				$dialog.find('.oc-dialog-content').append($error);
+				$dialog.find('.oc-dialog-buttonrow').addClass('aside');
 
 				var $buttons = $dialog.find('button');
 				$buttons.eq(0).hide();

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -239,7 +239,7 @@ var OCdialogs = {
 				multiselect = false;
 			}
 
-			// No grid for IE! 
+			// No grid for IE!
 			if (OC.Util.isIE()) {
 				self.$filePicker.find('#picker-view-toggle').remove();
 				self.$filePicker.find('#picker-filestable').removeClass('view-grid');
@@ -826,7 +826,6 @@ var OCdialogs = {
 		this.$showGridView.next('#picker-view-toggle')
 			.removeClass('icon-toggle-filelist icon-toggle-pictures')
 			.addClass(show ? 'icon-toggle-filelist' : 'icon-toggle-pictures')
-			
 		$('.list-container').toggleClass('view-grid', show);
 	},
 	_getFilePickerTemplate: function() {

--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -78,12 +78,15 @@ input {
 		transform: translate(-50%, -50%);
 		background: #fff;
 		color: #333;
-		border-radius: var(--border-radius);
-		box-shadow: 0 0 7px #888;
+		border-radius: var(--border-radius-large);
+		box-shadow: 0 0 10px var(--color-box-shadow);
 		padding: 15px;
-		.jcrop-holder {
-			box-shadow: 0 0 7px #888;
+		.jcrop-holder,
+		.jcrop-holder img,
+		img.jcrop-preview  {
+			border-radius: var(--border-radius);
 		}
+
 		.button {
 			margin-top: 15px;
 		}


### PR DESCRIPTION
Dialogs to test with:
- Authentication dialog e.g. when installing apps: Button to right, margins fixed.
![authentication dialog](https://user-images.githubusercontent.com/925062/49301628-5a913300-f4c5-11e8-99ff-2f28faa5161c.png)
- File picker / Move or copy dialog: Fade on bottom right not fully overlapping scrollbar (cause of border-radius) fixed.
![copymove border radius](https://user-images.githubusercontent.com/925062/49301626-59f89c80-f4c5-11e8-9114-088acb1d6a70.png)
- Avatar cropper in personal settings: Adjusted border-radii and drop-shadows to standard.
![avatar cropper](https://user-images.githubusercontent.com/925062/49301627-5a913300-f4c5-11e8-9c54-ad652733018f.png)
- File conflict dialog in files: No change.