### PR TITLE
Expose Swift Mailer streaming options in config, fixes #12702

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -422,6 +422,13 @@ $CONFIG = array(
 'mail_send_plaintext_only' => false,
 
 /**
+ * This depends on ``mail_smtpmode``. Array of additional streams options that
+ * will be passed to underlying Swift mailer implementation.
+ * Defaults to an empty array.
+ */
+'mail_smtpstreamoptions' => array(),
+
+/**
  * Which mode is used for sendmail/qmail: ``smtp`` or ``pipe``.
  *
  * For ``smtp`` the sendmail binary is started with the parameter ``-bs``:

--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -259,6 +259,10 @@ class Mailer implements IMailer {
 		if (!empty($smtpSecurity)) {
 			$transport->setEncryption($smtpSecurity);
 		}
+		$streamingOptions = $this->config->getSystemValue('mail_smtpstreamoptions', array());
+		if (is_array($streamingOptions) && count($streamingOptions) > 0) {
+			$transport->setStreamOptions($streamingOptions);
+		}
 
 		return $transport;
 	}

--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -259,7 +259,7 @@ class Mailer implements IMailer {
 		if (!empty($smtpSecurity)) {
 			$transport->setEncryption($smtpSecurity);
 		}
-		$streamingOptions = $this->config->getSystemValue('mail_smtpstreamoptions', array());
+		$streamingOptions = $this->config->getSystemValue('mail_smtpstreamoptions', []);
 		if (is_array($streamingOptions) && !empty($streamingOptions)) {
 			$transport->setStreamOptions($streamingOptions);
 		}

--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -260,7 +260,7 @@ class Mailer implements IMailer {
 			$transport->setEncryption($smtpSecurity);
 		}
 		$streamingOptions = $this->config->getSystemValue('mail_smtpstreamoptions', array());
-		if (is_array($streamingOptions) && count($streamingOptions) > 0) {
+		if (is_array($streamingOptions) && !empty($streamingOptions)) {
 			$transport->setStreamOptions($streamingOptions);
 		}
 

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -172,7 +172,7 @@ class MailerTest extends TestCase {
 		$this->config->method('getSystemValue')
 			->will($this->returnValueMap([
 				['mail_smtpmode', 'smtp', 'smtp'],
-				['mail_smtpstreamoptions', array(), array('foo' => 1)]
+				['mail_smtpstreamoptions', [], ['foo' => 1]]
 			]));
 		$mailer = self::invokePrivate($this->mailer, 'getInstance');
 		$this->assertEquals(1, count($mailer->getTransport()->getStreamOptions()));
@@ -184,7 +184,7 @@ class MailerTest extends TestCase {
 		$this->config->method('getSystemValue')
 			->will($this->returnValueMap([
 				['mail_smtpmode', 'smtp', 'smtp'],
-				['mail_smtpstreamoptions', array(), 'bar']
+				['mail_smtpstreamoptions', [], 'bar']
 			]));
 		$mailer = self::invokePrivate($this->mailer, 'getInstance');
 		$this->assertEquals(0, count($mailer->getTransport()->getStreamOptions()));

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -167,4 +167,26 @@ class MailerTest extends TestCase {
 
 		$this->assertSame(EMailTemplate::class, get_class($this->mailer->createEMailTemplate('tests.MailerTest')));
 	}
+
+	public function testStreamingOptions() {
+		$this->config->method('getSystemValue')
+			->will($this->returnValueMap([
+				['mail_smtpmode', 'smtp', 'smtp'],
+				['mail_smtpstreamoptions', array(), array('foo' => 1)]
+			]));
+		$mailer = self::invokePrivate($this->mailer, 'getInstance');
+		$this->assertEquals(1, count($mailer->getTransport()->getStreamOptions()));
+		$this->assertTrue(isset($mailer->getTransport()->getStreamOptions()['foo']));
+
+	}
+
+	public function testStreamingOptionsWrongType() {
+		$this->config->method('getSystemValue')
+			->will($this->returnValueMap([
+				['mail_smtpmode', 'smtp', 'smtp'],
+				['mail_smtpstreamoptions', array(), 'bar']
+			]));
+		$mailer = self::invokePrivate($this->mailer, 'getInstance');
+		$this->assertEquals(0, count($mailer->getTransport()->getStreamOptions()));
+	}
 }


### PR DESCRIPTION
Backward compatible addition to expose streaming options, so user can define them in their repsective configs.

Swift Mailer added streaming options 3 years ago in [this commit](https://github.com/swiftmailer/swiftmailer/commit/d791ebe2266d5f997a6f712fa8892620395b0c0e). Seems Nextcloud is having proper version.

Fixes #12702 