### PR TITLE
Fix the system address book

### DIFF
--- a/apps/dav/lib/CardDAV/AddressBook.php
+++ b/apps/dav/lib/CardDAV/AddressBook.php
@@ -112,6 +112,14 @@ class AddressBook extends \Sabre\CardDAV\AddressBook implements IShareable {
 			]
 		];
 
+		if ($this->getOwner() === 'principals/system/system') {
+			$acl[] = [
+				'privilege' => '{DAV:}read',
+				'principal' => '{DAV:}authenticated',
+				'protected' => true,
+			];
+		}
+
 		if (!$this->isShared()) {
 			return $acl;
 		}
@@ -129,13 +137,6 @@ class AddressBook extends \Sabre\CardDAV\AddressBook implements IShareable {
 					'protected' => true,
 				];
 			}
-		}
-		if ($this->getOwner() === 'principals/system/system') {
-			$acl[] = [
-					'privilege' => '{DAV:}read',
-					'principal' => '{DAV:}authenticated',
-					'protected' => true,
-			];
 		}
 
 		$acl = $this->carddavBackend->applyShareAcl($this->getResourceId(), $acl);


### PR DESCRIPTION
c23a66cda46d9a1f0ce8dc60a6c160809c87d9f6 broke the system address book.
We now move the ACL rules for this special case up and all is good in
the world again.

To test.

1. Create a new user
2. Navigate to `<server>/remote.php/dav/addressbooks/system/system/system/`

Before: :boom: 
Now: :beer: 