### PR TITLE
No user enumeration on DAV if disabled

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -73,6 +73,7 @@ return array(
     'OCA\\DAV\\CardDAV\\PhotoCache' => $baseDir . '/../lib/CardDAV/PhotoCache.php',
     'OCA\\DAV\\CardDAV\\Plugin' => $baseDir . '/../lib/CardDAV/Plugin.php',
     'OCA\\DAV\\CardDAV\\SyncService' => $baseDir . '/../lib/CardDAV/SyncService.php',
+    'OCA\\DAV\\CardDAV\\SystemAddressbook' => $baseDir . '/../lib/CardDAV/SystemAddressbook.php',
     'OCA\\DAV\\CardDAV\\UserAddressBooks' => $baseDir . '/../lib/CardDAV/UserAddressBooks.php',
     'OCA\\DAV\\CardDAV\\Xml\\Groups' => $baseDir . '/../lib/CardDAV/Xml/Groups.php',
     'OCA\\DAV\\Command\\CreateAddressBook' => $baseDir . '/../lib/Command/CreateAddressBook.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -88,6 +88,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\CardDAV\\PhotoCache' => __DIR__ . '/..' . '/../lib/CardDAV/PhotoCache.php',
         'OCA\\DAV\\CardDAV\\Plugin' => __DIR__ . '/..' . '/../lib/CardDAV/Plugin.php',
         'OCA\\DAV\\CardDAV\\SyncService' => __DIR__ . '/..' . '/../lib/CardDAV/SyncService.php',
+        'OCA\\DAV\\CardDAV\\SystemAddressbook' => __DIR__ . '/..' . '/../lib/CardDAV/SystemAddressbook.php',
         'OCA\\DAV\\CardDAV\\UserAddressBooks' => __DIR__ . '/..' . '/../lib/CardDAV/UserAddressBooks.php',
         'OCA\\DAV\\CardDAV\\Xml\\Groups' => __DIR__ . '/..' . '/../lib/CardDAV/Xml/Groups.php',
         'OCA\\DAV\\Command\\CreateAddressBook' => __DIR__ . '/..' . '/../lib/Command/CreateAddressBook.php',

--- a/apps/dav/lib/CardDAV/SystemAddressbook.php
+++ b/apps/dav/lib/CardDAV/SystemAddressbook.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2018, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DAV\CardDAV;
+
+use OCP\IConfig;
+use OCP\IL10N;
+use Sabre\CardDAV\Backend\BackendInterface;
+
+class SystemAddressbook extends AddressBook {
+	/** @var IConfig */
+	private $config;
+
+	public function __construct(BackendInterface $carddavBackend, array $addressBookInfo, IL10N $l10n, IConfig $config) {
+		parent::__construct($carddavBackend, $addressBookInfo, $l10n);
+		$this->config = $config;
+	}
+
+	public function getChildren() {
+		if ($this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') !== 'yes') {
+			return [];
+		}
+
+		return parent::getChildren();
+	}
+}

--- a/apps/dav/lib/CardDAV/UserAddressBooks.php
+++ b/apps/dav/lib/CardDAV/UserAddressBooks.php
@@ -22,12 +22,16 @@
  */
 namespace OCA\DAV\CardDAV;
 
+use OCP\IConfig;
 use OCP\IL10N;
 
 class UserAddressBooks extends \Sabre\CardDAV\AddressBookHome {
 
 	/** @var IL10N */
 	protected $l10n;
+
+	/** @var IConfig */
+	protected $config;
 
 	/**
 	 * Returns a list of addressbooks
@@ -38,11 +42,18 @@ class UserAddressBooks extends \Sabre\CardDAV\AddressBookHome {
 		if ($this->l10n === null) {
 			$this->l10n = \OC::$server->getL10N('dav');
 		}
+		if ($this->config === null) {
+			$this->config = \OC::$server->getConfig();
+		}
 
 		$addressBooks = $this->carddavBackend->getAddressBooksForUser($this->principalUri);
 		$objects = [];
 		foreach($addressBooks as $addressBook) {
-			$objects[] = new AddressBook($this->carddavBackend, $addressBook, $this->l10n);
+			if ($addressBook['principaluri'] === 'principals/system/system') {
+				$objects[] = new SystemAddressbook($this->carddavBackend, $addressBook, $this->l10n, $this->config);
+			} else {
+				$objects[] = new AddressBook($this->carddavBackend, $addressBook, $this->l10n);
+			}
 		}
 		return $objects;
 


### PR DESCRIPTION
If you disable the `Allow username autocompletion in share dialog. If this is disabled the full username or email address needs to be entered.` (share options)

Then we should also not allow enumeration on this endpoint.

Fixes #9058

Depends on:
- [x] https://github.com/nextcloud/server/pull/12813