### PR TITLE
Fix layout of "i" in admin settings of federated sharing

### DIFF
--- a/apps/federatedfilesharing/css/settings-admin.css
+++ b/apps/federatedfilesharing/css/settings-admin.css
@@ -1,0 +1,3 @@
+#fileSharingSettings h2 {
+	display: inline-block;
+}

--- a/apps/federatedfilesharing/templates/settings-admin.php
+++ b/apps/federatedfilesharing/templates/settings-admin.php
@@ -2,6 +2,7 @@
 /** @var \OCP\IL10N $l */
 /** @var array $_ */
 script('federatedfilesharing', 'settings-admin');
+style('federatedfilesharing', 'settings-admin');
 ?>
 
 <?php if($_['internalOnly'] === false): ?>
@@ -9,10 +10,10 @@ script('federatedfilesharing', 'settings-admin');
 <div id="fileSharingSettings" class="section">
 	<h2>
 		<?php p($l->t('Federated Cloud Sharing'));?>
-		<a target="_blank" rel="noreferrer noopener" class="icon-info svg"
-		   title="<?php p($l->t('Open documentation'));?>"
-		   href="<?php p(link_to_docs('admin-sharing-federated')); ?>"></a>
 	</h2>
+	<a target="_blank" rel="noreferrer noopener" class="icon-info svg"
+	   title="<?php p($l->t('Open documentation'));?>"
+	   href="<?php p(link_to_docs('admin-sharing-federated')); ?>"></a>
 
 	<p class="settings-hint"><?php p($l->t('Adjust how people can share between servers.')); ?></p>
 

--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -1238,7 +1238,7 @@ table.grid td.date {
 
 .icon-info {
 	padding: 11px 20px;
-	vertical-align: text-bottom;
+	vertical-align: super;
 }
 
 #shareAPI h2, #encryptionAPI h2, #mail_general_settings h2 {


### PR DESCRIPTION
This moves the "i" out of the `<h2>` (like all others) and centers it a bit better. 

I did this together with @jancborchardt while do the polishing review (#12694)

cc @nextcloud/designers 

Before and after:

![bildschirmfoto 2018-12-04 um 17 29 35](https://user-images.githubusercontent.com/245432/49457207-b7a12780-f7ea-11e8-8ba4-f49c0a98a29f.png)
![bildschirmfoto 2018-12-04 um 17 31 18](https://user-images.githubusercontent.com/245432/49457208-b7a12780-f7ea-11e8-8a33-1a58c32bbf31.png)
