### PR TITLE
Add setup check for pending bigint conversion

### DIFF
--- a/core/Command/Db/ConvertFilecacheBigInt.php
+++ b/core/Command/Db/ConvertFilecacheBigInt.php
@@ -52,6 +52,7 @@ class ConvertFilecacheBigInt extends Command {
 	}
 
 	protected function getColumnsByTable() {
+		// also update in CheckSetupController::hasBigIntConversionPendingColumns()
 		return [
 			'activity' => ['activity_id', 'object_id'],
 			'activity_mq' => ['mail_id'],

--- a/core/Command/Db/ConvertFilecacheBigInt.php
+++ b/core/Command/Db/ConvertFilecacheBigInt.php
@@ -79,7 +79,7 @@ class ConvertFilecacheBigInt extends Command {
 					$column->setType(Type::getType(Type::BIGINT));
 					$column->setOptions(['length' => 20]);
 
-					$updates[] = $tableName . '.' . $columnName;
+					$updates[] = '* ' . $tableName . '.' . $columnName;
 				}
 			}
 		}
@@ -89,6 +89,10 @@ class ConvertFilecacheBigInt extends Command {
 			return 0;
 		}
 
+		$output->writeln('<comment>Following columns will be updated:</comment>');
+		$output->writeln('');
+		$output->writeln($updates);
+		$output->writeln('');
 		$output->writeln('<comment>This can take up to hours, depending on the number of files in your instance!</comment>');
 
 		if ($input->isInteractive()) {

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -337,6 +337,22 @@
 							type: OC.SetupChecks.MESSAGE_TYPE_INFO
 						})
 					}
+					if (data.pendingBigIntConversionColumns.length > 0) {
+						var listOfPendingBigIntConversionColumns = "";
+						data.pendingBigIntConversionColumns.forEach(function(element){
+							listOfPendingBigIntConversionColumns += "<li>" + element + "</li>";
+						});
+						messages.push({
+							msg: t(
+								'core',
+								'Some columns in the database are missing a conversion to big int. Due to the fact that changing column types on big tables could take some time they were not changed automatically. By running \'occ db:convert-filecache-bigint\' those pending changes could be applied manually. This operation needs to be made while the instance is offline. For further details read <a target="_blank" rel="noreferrer noopener" href="{docLink}">the documentation page about this</a>.',
+								{
+									docLink: oc_defaults.docPlaceholderUrl.replace('PLACEHOLDER', 'admin-bigint-conversion'),
+								}
+							) + "<ul>" + listOfPendingBigIntConversionColumns + "</ul>",
+							type: OC.SetupChecks.MESSAGE_TYPE_INFO
+						})
+					}
 					if (data.isSqliteUsed) {
 						messages.push({
 							msg: t(

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -211,7 +211,8 @@ describe('OC.SetupChecks tests', function() {
 					},
 					isMemoryLimitSufficient: true,
 					appDirsWithDifferentOwner: [],
-					recommendedPHPModules: []
+					recommendedPHPModules: [],
+					pendingBigIntConversionColumns: []
 				})
 			);
 
@@ -261,7 +262,8 @@ describe('OC.SetupChecks tests', function() {
 					},
 					isMemoryLimitSufficient: true,
 					appDirsWithDifferentOwner: [],
-					recommendedPHPModules: []
+					recommendedPHPModules: [],
+					pendingBigIntConversionColumns: []
 				})
 			);
 
@@ -312,7 +314,8 @@ describe('OC.SetupChecks tests', function() {
 					},
 					isMemoryLimitSufficient: true,
 					appDirsWithDifferentOwner: [],
-					recommendedPHPModules: []
+					recommendedPHPModules: [],
+					pendingBigIntConversionColumns: []
 				})
 			);
 
@@ -361,7 +364,8 @@ describe('OC.SetupChecks tests', function() {
 					},
 					isMemoryLimitSufficient: true,
 					appDirsWithDifferentOwner: [],
-					recommendedPHPModules: []
+					recommendedPHPModules: [],
+					pendingBigIntConversionColumns: []
 				})
 			);
 
@@ -408,7 +412,8 @@ describe('OC.SetupChecks tests', function() {
 					},
 					isMemoryLimitSufficient: true,
 					appDirsWithDifferentOwner: [],
-					recommendedPHPModules: []
+					recommendedPHPModules: [],
+					pendingBigIntConversionColumns: []
 				})
 			);
 
@@ -457,7 +462,8 @@ describe('OC.SetupChecks tests', function() {
 					appDirsWithDifferentOwner: [
 						'/some/path'
 					],
-					recommendedPHPModules: []
+					recommendedPHPModules: [],
+					pendingBigIntConversionColumns: []
 				})
 			);
 
@@ -504,7 +510,8 @@ describe('OC.SetupChecks tests', function() {
 					},
 					isMemoryLimitSufficient: true,
 					appDirsWithDifferentOwner: [],
-					recommendedPHPModules: []
+					recommendedPHPModules: [],
+					pendingBigIntConversionColumns: []
 				})
 			);
 
@@ -551,7 +558,8 @@ describe('OC.SetupChecks tests', function() {
 					},
 					isMemoryLimitSufficient: true,
 					appDirsWithDifferentOwner: [],
-					recommendedPHPModules: []
+					recommendedPHPModules: [],
+					pendingBigIntConversionColumns: []
 				})
 			);
 
@@ -596,9 +604,10 @@ describe('OC.SetupChecks tests', function() {
 					cronInfo: {
 						diffInSeconds: 0
 					},
+					isMemoryLimitSufficient: false,
 					appDirsWithDifferentOwner: [],
 					recommendedPHPModules: [],
-					isMemoryLimitSufficient: false
+					pendingBigIntConversionColumns: []
 				})
 			);
 
@@ -666,7 +675,8 @@ describe('OC.SetupChecks tests', function() {
 					},
 					isMemoryLimitSufficient: true,
 					appDirsWithDifferentOwner: [],
-					recommendedPHPModules: []
+					recommendedPHPModules: [],
+					pendingBigIntConversionColumns: []
 				})
 			);
 
@@ -714,7 +724,8 @@ describe('OC.SetupChecks tests', function() {
 					},
 					isMemoryLimitSufficient: true,
 					appDirsWithDifferentOwner: [],
-					recommendedPHPModules: []
+					recommendedPHPModules: [],
+					pendingBigIntConversionColumns: []
 				})
 			);
 
@@ -762,7 +773,8 @@ describe('OC.SetupChecks tests', function() {
 					},
 					isMemoryLimitSufficient: true,
 					appDirsWithDifferentOwner: [],
-					recommendedPHPModules: []
+					recommendedPHPModules: [],
+					pendingBigIntConversionColumns: []
 				})
 			);
 
@@ -810,7 +822,8 @@ describe('OC.SetupChecks tests', function() {
 					},
 					isMemoryLimitSufficient: true,
 					appDirsWithDifferentOwner: [],
-					recommendedPHPModules: []
+					recommendedPHPModules: [],
+					pendingBigIntConversionColumns: []
 				})
 			);
 

--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -34,11 +34,13 @@ use bantu\IniGetWrapper\IniGetWrapper;
 use DirectoryIterator;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Types\Type;
 use GuzzleHttp\Exception\ClientException;
 use OC;
 use OC\AppFramework\Http;
 use OC\DB\Connection;
 use OC\DB\MissingIndexInformation;
+use OC\DB\SchemaWrapper;
 use OC\IntegrityCheck\Checker;
 use OC\Lock\NoopLockingProvider;
 use OC\MemoryInfo;
@@ -603,6 +605,39 @@ Raw output
 		return $recommendedPHPModules;
 	}
 
+	protected function hasBigIntConversionPendingColumns(): array {
+		// copy of ConvertFilecacheBigInt::getColumnsByTable()
+		$tables = [
+			'activity' => ['activity_id', 'object_id'],
+			'activity_mq' => ['mail_id'],
+			'filecache' => ['fileid', 'storage', 'parent', 'mimetype', 'mimepart', 'mtime', 'storage_mtime'],
+			'mimetypes' => ['id'],
+			'storages' => ['numeric_id'],
+		];
+
+		$schema = new SchemaWrapper($this->db);
+		$isSqlite = $this->db->getDatabasePlatform() instanceof SqlitePlatform;
+		$pendingColumns = [];
+
+		foreach ($tables as $tableName => $columns) {
+			if (!$schema->hasTable($tableName)) {
+				continue;
+			}
+
+			$table = $schema->getTable($tableName);
+			foreach ($columns as $columnName) {
+				$column = $table->getColumn($columnName);
+				$isAutoIncrement = $column->getAutoincrement();
+				$isAutoIncrementOnSqlite = $isSqlite && $isAutoIncrement;
+				if ($column->getType()->getName() !== Type::BIGINT && !$isAutoIncrementOnSqlite) {
+					$pendingColumns[] = $tableName . '.' . $columnName;
+				}
+			}
+		}
+
+		return $pendingColumns;
+	}
+
 	/**
 	 * @return DataResponse
 	 */
@@ -643,6 +678,7 @@ Raw output
 				'isMemoryLimitSufficient' => $this->memoryInfo->isMemoryLimitSufficient(),
 				'appDirsWithDifferentOwner' => $this->getAppDirsWithDifferentOwner(),
 				'recommendedPHPModules' => $this->hasRecommendedPHPModules(),
+				'pendingBigIntConversionColumns' => $this->hasBigIntConversionPendingColumns(),
 			]
 		);
 	}

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -159,6 +159,7 @@ class CheckSetupControllerTest extends TestCase {
 				'hasOpcacheLoaded',
 				'getAppDirsWithDifferentOwner',
 				'hasRecommendedPHPModules',
+				'hasBigIntConversionPendingColumns',
 			])->getMock();
 	}
 
@@ -493,6 +494,11 @@ class CheckSetupControllerTest extends TestCase {
 			->method('hasRecommendedPHPModules')
 			->willReturn([]);
 
+		$this->checkSetupController
+			->expects($this->once())
+			->method('hasBigIntConversionPendingColumns')
+			->willReturn([]);
+
 		$expected = new DataResponse(
 			[
 				'isGetenvServerWorking' => true,
@@ -536,6 +542,7 @@ class CheckSetupControllerTest extends TestCase {
 				'isMemoryLimitSufficient' => true,
 				'appDirsWithDifferentOwner' => [],
 				'recommendedPHPModules' => [],
+				'pendingBigIntConversionColumns' => [],
 			]
 		);
 		$this->assertEquals($expected, $this->checkSetupController->check());


### PR DESCRIPTION
Requires:

* [x] #12821 (first commit in here will be gone once this is merged)

This contains multiple changes, that are best reviewed on a per commit basis:

* it fixes the problem with SQLite where primary fields can't be bigint and thus a conversion does not work where the warning would be shown all the time - see https://stackoverflow.com/a/18835967/520507
* it lists now the columns that need to be updated on the CLI before one needs to accept to run the command
* it shows the pending columns also in the settings check with a link to the documentation page: https://docs.nextcloud.com/server/15/admin_manual/configuration_database/bigint_identifiers.html
* fixes #12763 

This is how it looks like:

<img width="791" alt="bildschirmfoto 2018-12-04 um 18 46 27" src="https://user-images.githubusercontent.com/245432/49461870-081d8280-f7f5-11e8-8024-958ac6dcafbd.png">

![bildschirmfoto 2018-12-04 um 18 47 10](https://user-images.githubusercontent.com/245432/49461871-081d8280-f7f5-11e8-95f8-ac54db433e85.png)
