### PR TITLE
Only execute query in propagateChange once

### DIFF
--- a/lib/private/Files/Cache/Propagator.php
+++ b/lib/private/Files/Cache/Propagator.php
@@ -97,9 +97,9 @@ class Propagator implements IPropagator {
 				->where($builder->expr()->eq('storage', $builder->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
 				->andWhere($builder->expr()->in('path_hash', $hashParams))
 				->andWhere($builder->expr()->gt('size', $builder->expr()->literal(-1, IQueryBuilder::PARAM_INT)));
-		}
 
-		$builder->execute();
+			$builder->execute();
+		}
 	}
 
 	protected function getParents($path) {


### PR DESCRIPTION
The second execute statement should be inside the if block. Else it gets
executed twice which makes no sense.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>