### PR TITLE
Emit write update only once on touch

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1157,7 +1157,7 @@ class View {
 				if ($result && in_array('delete', $hooks) and $result) {
 					$this->removeUpdate($storage, $internalPath);
 				}
-				if ($result && in_array('write', $hooks) and $operation !== 'fopen') {
+				if ($result && in_array('write', $hooks,  true) && $operation !== 'fopen' && $operation !== 'touch') {
 					$this->writeUpdate($storage, $internalPath);
 				}
 				if ($result && in_array('touch', $hooks)) {


### PR DESCRIPTION
When a touch is done (i.e. when creating a new file in the node API)
The hooks contain 'write' and 'touch' (and the operation is touch as
well). This would cause a double write update. Which doesn't make sense.