### PR TITLE
No need to propogate changes in appdata

### DIFF
--- a/lib/private/Files/Cache/Propagator.php
+++ b/lib/private/Files/Cache/Propagator.php
@@ -46,12 +46,14 @@ class Propagator implements IPropagator {
 	private $connection;
 
 	/**
-	 * @param \OC\Files\Storage\Storage $storage
-	 * @param IDBConnection $connection
+	 * @var array
 	 */
-	public function __construct(\OC\Files\Storage\Storage $storage, IDBConnection $connection) {
+	private $ignore = [];
+
+	public function __construct(\OC\Files\Storage\Storage $storage, IDBConnection $connection, array $ignore = []) {
 		$this->storage = $storage;
 		$this->connection = $connection;
+		$this->ignore = $ignore;
 	}
 
 
@@ -62,6 +64,13 @@ class Propagator implements IPropagator {
 	 * @suppress SqlInjectionChecker
 	 */
 	public function propagateChange($internalPath, $time, $sizeDifference = 0) {
+		// Do not propogate changes in ignored paths
+		foreach ($this->ignore as $ignore) {
+			if (strpos($internalPath, $ignore) === 0) {
+				return;
+			}
+		}
+
 		$storageId = (int)$this->storage->getStorageCache()->getNumericId();
 
 		$parents = $this->getParents($internalPath);

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -368,7 +368,8 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 			$storage = $this;
 		}
 		if (!isset($storage->propagator)) {
-			$storage->propagator = new Propagator($storage, \OC::$server->getDatabaseConnection());
+			$config = \OC::$server->getSystemConfig();
+			$storage->propagator = new Propagator($storage, \OC::$server->getDatabaseConnection(), ['appdata_' . $config->getValue('instanceid')]);
 		}
 		return $storage->propagator;
 	}


### PR DESCRIPTION
Right now we propogate a lof of changes in appdata. So for example we
propogate each and every preview that is added to the system. This has
no real added value as far as I can tell.

@icewind1991 what do you think?