### PR TITLE
Read openssl error and log

### DIFF
--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -295,6 +295,10 @@ class PublicKeyTokenProvider implements IProvider {
 
 		// Generate new key
 		$res = openssl_pkey_new($config);
+		if ($res === false) {
+			$this->logOpensslError();
+		}
+
 		openssl_pkey_export($res, $privateKey);
 
 		// Extract the public key from $res to $pubKey
@@ -343,5 +347,11 @@ class PublicKeyTokenProvider implements IProvider {
 		}
 	}
 
-
+	private function logOpensslError() {
+		$errors = [];
+		while ($error = openssl_error_string()) {
+			$errors[] = $error;
+		}
+		$this->logger->critical('Something is wrong with your openssl setup: ' . implode(', ', $errors));
+	}
 }


### PR DESCRIPTION
Ref https://github.com/nextcloud/server/issues/12890 https://github.com/nextcloud/server/issues/11227

Some people are running into issues with their openssl setup. The logged information are confusing. With this pr `openssl_error_string` is written to log. 

If you wonder about the way calling `openssl_error_string` (i do :roll_eyes:) this is the recommended way http://php.net/manual/en/function.openssl-error-string.php.

Example:

> Something is wrong with your openssl setup: error:02001002:system library:fopen:No such file or directory, error:2006D080:BIO routines:BIO_new_file:no such file, error:0E064002:configuration file routines:CONF_load:system lib

Without while:

> Something is wrong with your openssl setup: error:02001002:system library:fopen:No such file or directory