### PR TITLE
Add optional locale parameter to \OCP\L10N\IFactory

### DIFF
--- a/lib/public/L10N/IFactory.php
+++ b/lib/public/L10N/IFactory.php
@@ -32,10 +32,11 @@ interface IFactory {
 	 *
 	 * @param string $app
 	 * @param string|null $lang
+	 * @param string|null $locale
 	 * @return \OCP\IL10N
 	 * @since 8.2.0
 	 */
-	public function get($app, $lang = null);
+	public function get($app, $lang = null, $locale = null);
 
 	/**
 	 * Find the best language


### PR DESCRIPTION
The additional parameter was added in https://github.com/nextcloud/server/pull/5623 to OC\L10n\Factory but missing on the public interface.