### PR TITLE
Implementation for #12885

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -244,12 +244,23 @@ class IMipPlugin extends SabreIMipPlugin {
 		$template->addFooter();
 		$message->useTemplate($template);
 
+		# We choose to work like google calendar, i.e. creating a base64 attachment with the event.ics,
+		# but also including a plain text text/calendar object. This last one is needed for 
+		# Microsoft Outlook versions <=2010 to work.
+		# The attachment base64 text/calendar part
 		$attachment = $this->mailer->createAttachment(
 			$iTipMessage->message->serialize(),
 			'event.ics',// TODO(leon): Make file name unique, e.g. add event id
 			'text/calendar; method=' . $iTipMessage->method
 		);
 		$message->attach($attachment);
+		
+		# The plain text text/calendar part
+		$message->addPart(
+                        $iTipMessage->message->serialize(),
+                        'text/calendar; method=' . $iTipMessage->method,
+                        'UTF-8'
+                );
 
 		try {
 			$failed = $this->mailer->send($message);

--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -255,7 +255,7 @@ class IMipPlugin extends SabreIMipPlugin {
 		);
 		$message->attach($attachment);
 		
-		# The plain text text/calendar part
+		# The plain text text/calendar part 
 		$message->addPart(
                         $iTipMessage->message->serialize(),
                         'text/calendar; method=' . $iTipMessage->method,

--- a/apps/oauth2/lib/Controller/LoginRedirectorController.php
+++ b/apps/oauth2/lib/Controller/LoginRedirectorController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2017 Lukas Reschke <lukas@statuscode.ch>
  *
@@ -50,7 +51,7 @@ class LoginRedirectorController extends Controller {
 	 * @param ISession $session
 	 * @param IL10N $l
 	 */
-	public function __construct($appName,
+	public function __construct(string $appName,
 								IRequest $request,
 								IURLGenerator $urlGenerator,
 								ClientMapper $clientMapper,
@@ -75,7 +76,7 @@ class LoginRedirectorController extends Controller {
 	 */
 	public function authorize($client_id,
 							  $state,
-							  $response_type) {
+							  $response_type): Response {
 		try {
 			$client = $this->clientMapper->getByIdentifier($client_id);
 		} catch (ClientNotFoundException $e) {

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2017 Lukas Reschke <lukas@statuscode.ch>
  *
@@ -53,18 +54,7 @@ class OauthApiController extends Controller {
 	/** @var Throttler */
 	private $throttler;
 
-	/**
-	 * @param string $appName
-	 * @param IRequest $request
-	 * @param ICrypto $crypto
-	 * @param AccessTokenMapper $accessTokenMapper
-	 * @param ClientMapper $clientMapper
-	 * @param TokenProvider $tokenProvider
-	 * @param ISecureRandom $secureRandom
-	 * @param ITimeFactory $time
-	 * @param Throttler $throttler
-	 */
-	public function __construct($appName,
+	public function __construct(string $appName,
 								IRequest $request,
 								ICrypto $crypto,
 								AccessTokenMapper $accessTokenMapper,
@@ -94,7 +84,7 @@ class OauthApiController extends Controller {
 	 * @param string $client_secret
 	 * @return JSONResponse
 	 */
-	public function getToken($grant_type, $code, $refresh_token, $client_id, $client_secret) {
+	public function getToken($grant_type, $code, $refresh_token, $client_id, $client_secret): JSONResponse {
 
 		// We only handle two types
 		if ($grant_type !== 'authorization_code' && $grant_type !== 'refresh_token') {

--- a/apps/oauth2/lib/Exceptions/AccessTokenNotFoundException.php
+++ b/apps/oauth2/lib/Exceptions/AccessTokenNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2017 Lukas Reschke <lukas@statuscode.ch>
  *

--- a/apps/oauth2/lib/Exceptions/ClientNotFoundException.php
+++ b/apps/oauth2/lib/Exceptions/ClientNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2017 Lukas Reschke <lukas@statuscode.ch>
  *

--- a/apps/oauth2/lib/Migration/SetTokenExpiration.php
+++ b/apps/oauth2/lib/Migration/SetTokenExpiration.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright 2018, Roeland Jago Douma <roeland@famdouma.nl>
  *
@@ -50,7 +51,7 @@ class SetTokenExpiration implements IRepairStep {
 		$this->tokenProvider = $tokenProvider;
 	}
 
-	public function getName() {
+	public function getName(): string {
 		return 'Update OAuth token expiration times';
 	}
 

--- a/lib/private/Mail/Message.php
+++ b/lib/private/Mail/Message.php
@@ -57,6 +57,18 @@ class Message implements IMessage {
 		$this->swiftMessage->attach($attachment->getSwiftAttachment());
 		return $this;
 	}
+	
+	/**
+	 * @param $body:  body of the mime part
+	 * @param $content-type = null: Mime Content-Type (e.g. text/plain or text/calendar)
+	 * @param $charset = null: Character Set (e.g. UTF-8)
+	 * @return $this
+	 * @since 14.0.4
+	 */
+	public function addPart($data, $content_type = null, $charset = null): IMessage {
+               $this->swiftMessage->addPart($data, $content_type, $charset);
+               return $this;
+        }
 
 	/**
 	 * SwiftMailer does currently not work with IDN domains, this function therefore converts the domains

--- a/lib/private/Mail/Message.php
+++ b/lib/private/Mail/Message.php
@@ -66,7 +66,15 @@ class Message implements IMessage {
 	 * @since 14.0.4
 	 */
 	public function addPart($data, $content_type = null, $charset = null): IMessage {
+	       # To be sure this works with iCalendar messages, we encode with 8bit instead of 
+	       # quoted-printable encoding. We save the current encoder, replace the current
+	       # encoder with an 8bit encoder and after we've finished, we reset the encoder
+	       # to the previous one.
+               $encoder = $this->swiftMessage->getEncoder();
+               $eightbit_encoder = new \Swift_Mime_ContentEncoder_PlainContentEncoder("8bit");
+               $this->swiftMessage->setEncoder($eightbit_encoder);
                $this->swiftMessage->addPart($data, $content_type, $charset);
+               $this->swiftMessage->setEncoder($encoder);
                return $this;
         }
 

--- a/lib/public/Mail/IMessage.php
+++ b/lib/public/Mail/IMessage.php
@@ -38,7 +38,16 @@ interface IMessage {
 	 * @since 13.0.0
 	 */
 	public function attach(IAttachment $attachment): IMessage;
-
+	
+	/**
+	 * @param $body:  body of the mime part
+	 * @param $content-type = null: Mime Content-Type (e.g. text/plain or text/calendar)
+	 * @param $charset = null: Character Set (e.g. UTF-8)
+	 * @return IMessage
+	 * @since 14.0.4
+	 */
+	public function addPart($body, $content_type = null, $charset = null): IMessage;
+	
 	/**
 	 * Set the from address of this message.
 	 *


### PR DESCRIPTION
I deviated a little from the implementation in #12885. There was an other problem with outlook integration, that is also solved by this patch. The cancellation messages did not parse in Outlook 2010 and 2016. 
The messages are analogue to Thunderbird Lightning now and as far as I can see work fine. 

