### PR TITLE
Fixes the share autocomplete layout

### DIFF
--- a/core/css/jquery-ui-fixes.scss
+++ b/core/css/jquery-ui-fixes.scss
@@ -173,6 +173,7 @@
 		padding: 0;
 		.ui-menu-item a {
 			color: var(--color-text-lighter);
+			display: block;
 			padding: 4px 4px 4px 14px;
 
 			&.ui-state-focus, &.ui-state-active {

--- a/core/css/jquery-ui-fixes.scss
+++ b/core/css/jquery-ui-fixes.scss
@@ -171,6 +171,14 @@
 .ui-autocomplete {
 	&.ui-menu {
 		padding: 0;
+
+		/* scrolling starts from three items,
+		 * so hide overflow and scrollbars for a clean layout */
+		&.item-count-1,
+		&.item-count-2 {
+			overflow-y: hidden;
+		}
+
 		.ui-menu-item a {
 			color: var(--color-text-lighter);
 			display: block;

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -772,7 +772,16 @@
 						event.preventDefault();
 					},
 					source: this.autocompleteHandler,
-					select: this._onSelectRecipient
+					select: this._onSelectRecipient,
+					open: function() {
+						var autocomplete = $(this).autocomplete('widget');
+						var numberOfItems = autocomplete.find('li').size();
+						autocomplete.removeClass('item-count-1');
+						autocomplete.removeClass('item-count-2');
+						if (numberOfItems <= 2) {
+							autocomplete.addClass('item-count-' + numberOfItems);
+						}
+					}
 				}).data('ui-autocomplete')._renderItem = this.autocompleteRenderItem;
 
 				$shareField.on('keydown', null, shareFieldKeydownHandler);


### PR DESCRIPTION
The `a` tag contains block elements, so the `a` tag has to be a block element, too.

I didn't find the ui-autocomplete anywhere else than for the file sharing user selector. There it looks okay now.

**Before:**
![image](https://user-images.githubusercontent.com/6216686/49685791-54fda380-faea-11e8-8f6d-322e8e0a2672.png)

**Fix:**
![image](https://user-images.githubusercontent.com/6216686/49685784-3f887980-faea-11e8-9387-75c307a008c5.png)

Fixes #12832 