### PR TITLE
Allow options to be passed to `FileList.createFile`

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -670,7 +670,7 @@
 			this.$showGridView.next('#view-toggle')
 				.removeClass('icon-toggle-filelist icon-toggle-pictures')
 				.addClass(show ? 'icon-toggle-filelist' : 'icon-toggle-pictures')
-				
+
 			$('.list-container').toggleClass('view-grid', show);
 			if (show) {
 				// If switching into grid view from list view, too few files might be displayed
@@ -2743,7 +2743,7 @@
 		 *
 		 * @since 8.2
 		 */
-		createFile: function(name) {
+		createFile: function(name, options) {
 			var self = this;
 			var deferred = $.Deferred();
 			var promise = deferred.promise();
@@ -2767,7 +2767,8 @@
 				)
 				.done(function() {
 					// TODO: error handling / conflicts
-					self.addAndFetchFileInfo(targetPath, '', {scrollTo: true}).then(function(status, data) {
+					options = _.extend({scrollTo: true}, options || {});
+					self.addAndFetchFileInfo(targetPath, '', options).then(function(status, data) {
 						deferred.resolve(status, data);
 					}, function() {
 						OC.Notification.show(t('files', 'Could not create file "{file}"',


### PR DESCRIPTION
Addresses: https://github.com/nextcloud/server/issues/12989

Summary: Allow options to be passed to `FileList.createFile`, so that `scrollTo` can be overridden.

This could be a fix to allow apps using the `createFile` method to disable `scrollTo` behavior and by that disabling opening of the `detailsView` overlay. 

I don't like it very much, because `scrollTo` for me doesn't imply that another view will be opened. But since I have no idea what others expect from this method, this is my safest bet, right now. Any help is of course appreciated 😊 