### PR TITLE
Use default cursor for disabled primary buttons

### DIFF
--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -110,6 +110,7 @@ div[contenteditable=true],
 			// opacity is already defined to .5 if disabled
 			background-color: var(--color-primary-element);
 			color: var(--color-primary-text-dark);
+			cursor: default;
 		}
 	}
 }


### PR DESCRIPTION
[Disabled buttons use the default cursor](https://github.com/nextcloud/server/blob/f80a0234319ce1206892259b65e63f5277b2ecb9/core/css/inputs.scss#L75), but as [the cursor property for primary buttons](https://github.com/nextcloud/server/blob/f80a0234319ce1206892259b65e63f5277b2ecb9/core/css/inputs.scss#L90) is set after the cursor property for disabled buttons the latter is always overridden, even if the primary button is also
disabled. Due to this it is necessary to explicitly set the default cursor for disabled primary buttons.

@nextcloud/designers 

Before:
![button-disabled-cursor-before](https://user-images.githubusercontent.com/26858233/49797090-b6b64b80-fd3e-11e8-8ef3-c9c3509fa235.png)

After:
![button-disabled-cursor-after](https://user-images.githubusercontent.com/26858233/49797091-b918a580-fd3e-11e8-8328-bceb1cc67209.png)

I would backport this at least to _stable15_.
