### PR TITLE
[share by mail] set "from" header to the owner of the share if possible

### DIFF
--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -427,15 +427,16 @@ class ShareByMailProvider implements IShareProvider {
 				$instanceName
 			]
 		);
-		$message->setFrom([\OCP\Util::getDefaultEmailAddress($instanceName) => $senderName]);
 
-		// The "Reply-To" is set to the sharer if an mail address is configured
+
+		// The "From" is set to the sharer if an mail address is configured
 		// also the default footer contains a "Do not reply" which needs to be adjusted.
 		$initiatorEmail = $initiatorUser->getEMailAddress();
 		if($initiatorEmail !== null) {
-			$message->setReplyTo([$initiatorEmail => $initiatorDisplayName]);
+			$message->setFrom([$initiatorEmail => $initiatorDisplayName]);
 			$emailTemplate->addFooter($instanceName . ($this->defaults->getSlogan() !== '' ? ' - ' . $this->defaults->getSlogan() : ''));
 		} else {
+			$message->setFrom([\OCP\Util::getDefaultEmailAddress($instanceName) => $senderName]);
 			$emailTemplate->addFooter();
 		}
 


### PR DESCRIPTION
this way the person who creates the share will get the error
message from the mail server, e.g. if there was a typo in the
recipient mail address. Which allows them to correct the address.