### PR TITLE
Fetch lastInsertId only when id null

### DIFF
--- a/lib/public/AppFramework/Db/QBMapper.php
+++ b/lib/public/AppFramework/Db/QBMapper.php
@@ -119,7 +119,7 @@ abstract class QBMapper {
 
 		$qb->execute();
 
-		if($entity->getId() === null) {
+		if($entity->id === null) {
 			$entity->setId((int)$qb->getLastInsertId());
 		}
 

--- a/lib/public/AppFramework/Db/QBMapper.php
+++ b/lib/public/AppFramework/Db/QBMapper.php
@@ -119,7 +119,9 @@ abstract class QBMapper {
 
 		$qb->execute();
 
-		$entity->setId((int) $qb->getLastInsertId());
+		if($entity->getId() === null) {
+			$entity->setId((int)$qb->getLastInsertId());
+		}
 
 		return $entity;
 	}


### PR DESCRIPTION
When id column has no autoincrement flag query for lastInsertId fails
on postgres because no value has been generated. Call lastInsertId only
if id is null.

Could you consider a backport? Social App does not work on postgres without this like reported here https://github.com/nextcloud/server/issues/12465#issuecomment-446492467. Not sure how "safe" it is to backport it.