### PR TITLE
Fix SAML Client login flow on Apple devices

### DIFF
--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -207,6 +207,7 @@ class ClientFlowLoginController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @NoSameSiteCookieRequired
 	 * @UseSession
 	 *
 	 * @param string $stateToken


### PR DESCRIPTION
Because the redirect from the SAML/SSO endpoint is a POST the lax/strict
cookies are not properly send.

Note that it is not strictly requried on this endpoint as we do not need
the remember me data. Only the real session info is enough. The endpoint
is also already protected by a state token.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>