### PR TITLE
Prevent special characters from breaking the file drop remote url

### DIFF
--- a/apps/files_sharing/js/files_drop.js
+++ b/apps/files_sharing/js/files_drop.js
@@ -28,7 +28,11 @@
 				useHTTPS: OC.getProtocol() === 'https'
 			});
 			
+			// We only process one file at a time 🤷‍♀️
 			var name = data.files[0].name;
+			// removing unwanted characters
+			name = name.replace(/["'#%`]/gm, '');
+
 			try {
 				// FIXME: not so elegant... need to refactor that method to return a value
 				Files.isFileNameValid(name);


### PR DESCRIPTION
1. create a share file drop
2. upload the following file
3. see that empty files are being uploaded 
![capture d ecran_2018-12-18_09-20-04](https://user-images.githubusercontent.com/14975046/50140781-22039e80-02a6-11e9-85af-abf2d3594f59.png)

Broken file test: 
[#Test.txt](https://github.com/nextcloud/server/files/2689545/Test.txt)

