### PR TITLE
register and show when an LDAP user was detected as unavailable/deleted

### DIFF
--- a/apps/user_ldap/lib/User/DeletedUsersIndex.php
+++ b/apps/user_ldap/lib/User/DeletedUsersIndex.php
@@ -108,7 +108,13 @@ class DeletedUsersIndex {
 	 * @throws \OCP\PreConditionNotMetException
 	 */
 	public function markUser($ocName) {
+		$curValue = $this->config->getUserValue($ocName, 'user_ldap', 'isDeleted', '0');
+		if($curValue === '1') {
+			// the user is already marked, do not write to DB again
+			return;
+		}
 		$this->config->setUserValue($ocName, 'user_ldap', 'isDeleted', '1');
+		$this->config->setUserValue($ocName, 'user_ldap', 'foundDeleted', (string)time());
 		$this->deletedUsers = null;
 	}
 }

--- a/apps/user_ldap/lib/User/DeletedUsersIndex.php
+++ b/apps/user_ldap/lib/User/DeletedUsersIndex.php
@@ -70,7 +70,7 @@ class DeletedUsersIndex {
 		$deletedUsers = $this->config->getUsersForUserValue(
 			'user_ldap', 'isDeleted', '1');
 
-		$userObjects = array();
+		$userObjects = [];
 		foreach($deletedUsers as $user) {
 			$userObjects[] = new OfflineUser($user, $this->config, $this->db, $this->mapping);
 		}
@@ -95,20 +95,20 @@ class DeletedUsersIndex {
 	 * @return bool
 	 */
 	public function hasUsers() {
-		if($this->deletedUsers === false) {
+		if(!is_array($this->deletedUsers)) {
 			$this->fetchDeletedUsers();
 		}
-		if(is_array($this->deletedUsers) && count($this->deletedUsers) > 0) {
-			return true;
-		}
-		return false;
+		return is_array($this->deletedUsers) && (count($this->deletedUsers) > 0);
 	}
 
 	/**
 	 * marks a user as deleted
+	 *
 	 * @param string $ocName
+	 * @throws \OCP\PreConditionNotMetException
 	 */
 	public function markUser($ocName) {
 		$this->config->setUserValue($ocName, 'user_ldap', 'isDeleted', '1');
+		$this->deletedUsers = null;
 	}
 }

--- a/apps/user_ldap/lib/User/OfflineUser.php
+++ b/apps/user_ldap/lib/User/OfflineUser.php
@@ -54,6 +54,10 @@ class OfflineUser {
 	 */
 	protected $lastLogin;
 	/**
+	 * @var string $foundDeleted the timestamp when the user was detected as unavailable
+	 */
+	protected $foundDeleted;
+	/**
 	 * @var string $email
 	 */
 	protected $email;
@@ -92,7 +96,8 @@ class OfflineUser {
 	 * remove the Delete-flag from the user.
 	 */
 	public function unmark() {
-		$this->config->setUserValue($this->ocName, 'user_ldap', 'isDeleted', '0');
+		$this->config->deleteUserValue($this->ocName, 'user_ldap', 'isDeleted');
+		$this->config->deleteUserValue($this->ocName, 'user_ldap', 'foundDeleted');
 	}
 
 	/**
@@ -170,6 +175,14 @@ class OfflineUser {
 	}
 
 	/**
+	 * getter for the detection timestamp
+	 * @return int
+	 */
+	public function getDetectedOn() {
+		return (int)$this->foundDeleted;
+	}
+
+	/**
 	 * getter for having active shares
 	 * @return bool
 	 */
@@ -181,13 +194,14 @@ class OfflineUser {
 	 * reads the user details
 	 */
 	protected function fetchDetails() {
-		$properties = array (
-			'displayName' => 'user_ldap',
-			'uid'         => 'user_ldap',
-			'homePath'    => 'user_ldap',
-			'email'       => 'settings',
-			'lastLogin'   => 'login'
-		);
+		$properties = [
+			'displayName'  => 'user_ldap',
+			'uid'          => 'user_ldap',
+			'homePath'     => 'user_ldap',
+			'foundDeleted' => 'user_ldap',
+			'email'        => 'settings',
+			'lastLogin'    => 'login',
+		];
 		foreach($properties as $property => $app) {
 			$this->$property = $this->config->getUserValue($this->ocName, $app, $property, '');
 		}

--- a/apps/user_ldap/tests/User/DeletedUsersIndexTest.php
+++ b/apps/user_ldap/tests/User/DeletedUsersIndexTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_LDAP\Tests\User;
+
+use OCA\User_LDAP\Mapping\UserMapping;
+use OCA\User_LDAP\User\DeletedUsersIndex;
+use OCP\IConfig;
+use OCP\IDBConnection;
+
+/**
+ * Class DeletedUsersIndexTest
+ *
+ * @group DB
+ *
+ * @package OCA\User_LDAP\Tests\User
+ */
+class DeletedUsersIndexTest extends \Test\TestCase {
+	/** @var DeletedUsersIndex */
+	protected $dui;
+
+	/** @var IConfig */
+	protected $config;
+
+	/** @var IDBConnection */
+	protected $db;
+
+	/** @var UserMapping|\PHPUnit_Framework_MockObject_MockObject */
+	protected $mapping;
+
+	public function setUp() {
+		parent::setUp();
+
+		// no mocks for those as tests go against DB
+		$this->config = \OC::$server->getConfig();
+		$this->db = \OC::$server->getDatabaseConnection();
+
+		$this->mapping = $this->createMock(UserMapping::class);
+
+		$this->dui = new DeletedUsersIndex($this->config, $this->db, $this->mapping);
+	}
+
+	public function tearDown() {
+		$this->config->deleteAppFromAllUsers('user_ldap');
+		return parent::tearDown();
+	}
+
+	public function testMarkAndFetchUser() {
+		$uids = [
+			'cef3775c-71d2-48eb-8984-39a4051b0b95',
+			'8c4bbb40-33ed-42d0-9b14-85b0ab76c1cc',
+		];
+
+		// ensure test works on a pristine state
+		$this->assertFalse($this->dui->hasUsers());
+
+		$this->dui->markUser($uids[0]);
+
+		$this->assertTrue($this->dui->hasUsers());
+
+		$this->dui->markUser($uids[1]);
+
+		$deletedUsers = $this->dui->getUsers();
+		$this->assertSame(2, count($deletedUsers));
+
+		// ensure the different uids were used
+		foreach($deletedUsers as $deletedUser) {
+			$this->assertTrue(in_array($deletedUser->getOCName(), $uids));
+			$i = array_search($deletedUser->getOCName(), $uids);
+			$this->assertNotFalse($i);
+			unset($uids[$i]);
+		}
+		$this->assertEmpty($uids);
+	}
+
+	public function testUnmarkUser() {
+		$uids = [
+			'22a162c7-a9ee-487c-9f33-0563795583fb',
+			'1fb4e0da-4a75-47f3-8fa7-becc7e35c9c5',
+		];
+
+		// we know this works, because of "testMarkAndFetchUser"
+		$this->dui->markUser($uids[0]);
+		// this returns a working instance of OfflineUser
+		$testUser = $this->dui->getUsers()[0];
+		$testUser->unmark();
+
+		// the DUI caches the users, to clear mark someone else
+		$this->dui->markUser($uids[1]);
+
+		$deletedUsers = $this->dui->getUsers();
+		foreach ($deletedUsers as $deletedUser) {
+			$this->assertNotSame($testUser->getOCName(), $deletedUser->getOCName());
+		}
+	}
+
+
+}

--- a/apps/user_ldap/tests/User/DeletedUsersIndexTest.php
+++ b/apps/user_ldap/tests/User/DeletedUsersIndexTest.php
@@ -55,6 +55,9 @@ class DeletedUsersIndexTest extends \Test\TestCase {
 		$this->config = \OC::$server->getConfig();
 		$this->db = \OC::$server->getDatabaseConnection();
 
+		// ensure a clean database
+		$this->config->deleteAppFromAllUsers('user_ldap');
+
 		$this->mapping = $this->createMock(UserMapping::class);
 
 		$this->dui = new DeletedUsersIndex($this->config, $this->db, $this->mapping);


### PR DESCRIPTION
* a background job checks whether known LDAP users are still present. If not they are flagged as "deleted". Which was not recorded, was the date of the detection. This information is now recorded. (As a another db row in the preferences as the IConfig API only allows to request users for a precise value).
* For output a column/field "Detected on" to the `ldap:show-remnants` command was added.
* Also added was a `--short-date` flag to display it in "Y-m-d" format which is easier to consume for scripts that may react on it. For users that were detected earlier, the value "unknown" is shown instead.

How to test?

1. Have LDAP configured
2. Log in with one of the LDAP users.
3. Delete this user in LDAP
4. Manually check the existance of it per  `occ ldap:check-user $uid` (beware caching)
5. Assert `occ ldap:show-remnants` shows  this user as deleted, with a readable long time format
6. Assert `occ ldap:show-remnants --short-date` shows  this user as deleted, with Y-m-d formatted date