### PR TITLE
Use a case insensitive search for email

### DIFF
--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -459,6 +459,38 @@ class AllConfig implements \OCP\IConfig {
 		return $userIDs;
 	}
 
+	/**
+	 * Determines the users that have the given value set for a specific app-key-pair
+	 *
+	 * @param string $appName the app to get the user for
+	 * @param string $key the key to get the user for
+	 * @param string $value the value to get the user for
+	 * @return array of user IDs
+	 */
+	public function getUsersForUserValueCaseInsensitive($appName, $key, $value) {
+		// TODO - FIXME
+		$this->fixDIInit();
+
+		$sql  = 'SELECT `userid` FROM `*PREFIX*preferences` ' .
+			'WHERE `appid` = ? AND `configkey` = ? ';
+
+		if($this->getSystemValue('dbtype', 'sqlite') === 'oci') {
+			//oracle hack: need to explicitly cast CLOB to CHAR for comparison
+			$sql .= 'AND LOWER(to_char(`configvalue`)) = LOWER(?)';
+		} else {
+			$sql .= 'AND LOWER(`configvalue`) = LOWER(?)';
+		}
+
+		$result = $this->connection->executeQuery($sql, array($appName, $key, $value));
+
+		$userIDs = array();
+		while ($row = $result->fetch()) {
+			$userIDs[] = $row['userid'];
+		}
+
+		return $userIDs;
+	}
+
 	public function getSystemConfig() {
 		return $this->systemConfig;
 	}

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -589,7 +589,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @since 9.1.0
 	 */
 	public function getByEmail($email) {
-		$userIds = $this->config->getUsersForUserValue('settings', 'email', $email);
+		$userIds = $this->config->getUsersForUserValueCaseInsensitive('settings', 'email', $email);
 
 		$users = array_map(function($uid) {
 			return $this->get($uid);

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -8,6 +8,7 @@
  */
 
 namespace Test\User;
+use OC\AllConfig;
 use OC\User\Database;
 use OC\User\Manager;
 use OCP\IConfig;
@@ -670,12 +671,12 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testGetByEmail() {
-		$config = $this->getMockBuilder(IConfig::class)
+		$config = $this->getMockBuilder(AllConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$config
 			->expects($this->at(0))
-			->method('getUsersForUserValue')
+			->method('getUsersForUserValueCaseInsensitive')
 			->with('settings', 'email', 'test@example.com')
 			->will($this->returnValue(['uid1', 'uid99', 'uid2']));
 


### PR DESCRIPTION
Fixes #7084
Now entering wrongly cased email (roeland@ instead of Roeland@) for
password reset etc. Will also work.

Propably good to backport at least to 15, even 14 maybe.