### PR TITLE
Create Folders when moving files

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -703,7 +703,7 @@ code {
 	.dirtree {
 		flex-wrap: wrap;
 		padding-left: 12px;
-		padding-right: 44px;
+		padding-right: 0px;
 		box-sizing: border-box;
 
 		div:first-child a {
@@ -752,24 +752,25 @@ code {
 		box-sizing: border-box;
 		display: inline-flex;
 		float: none;
-		max-height: 44px;
-		max-width:44px;
+		max-height: 36px;
+		max-width: 36px;
 		background-color: var(--color-background-dark);
 		border: 1px solid var(--color-border-dark);
 		border-radius: var(--border-radius-pill);
 		position: relative;
+		top: -5px;
 		
 		.icon.icon-add{
 			background-image: var(--icon-add-000);
 			background-size: 16px 16px;
-			max-height:44px;
-			width:44px;
+			max-height:36px;
+			width:36px;
 			margin:0px;
 			
 		}
 
 		a {
-			width: 44px;
+			width: 36px;
 			padding: 0px;
 			position: static;
 		}

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -778,6 +778,7 @@ code {
 		.menu {
 			top:100%;
 			margin:10px;
+			margin-left: 0px;
 			form {
 				display:flex;
 				margin:10px;

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -757,8 +757,8 @@ code {
 		background-color: var(--color-background-dark);
 		border: 1px solid var(--color-border-dark);
 		border-radius: var(--border-radius-pill);
-		position: relative;
-		top: -5px;
+		position: absolute;
+		top: 4px;
 		
 		.icon.icon-add{
 			background-image: var(--icon-add-000);

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -753,15 +753,18 @@ code {
 		display: inline-flex;
 		float: none;
 		max-height: 44px;
+		max-width:44px;
 		background-color: var(--color-background-dark);
 		border: 1px solid var(--color-border-dark);
 		border-radius: var(--border-radius-pill);
-		position: static;
+		position: relative;
 		
 		.icon.icon-add{
 			background-image: var(--icon-add-000);
 			background-size: 16px 16px;
 			max-height:44px;
+			width:44px;
+			margin:0px;
 			
 		}
 
@@ -770,6 +773,16 @@ code {
 			padding: 0px;
 			position: static;
 		}
+
+		.menu {
+			top:100%;
+			margin:10px;
+			form {
+				display:flex;
+				margin:10px;
+			}
+		}
+
 	}
 
 	.filelist-container {

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -701,7 +701,6 @@ code {
 	position: relative;
 
 	.dirtree {
-		width: 100%;
 		flex-wrap: wrap;
 		padding-left: 12px;
 		padding-right: 44px;
@@ -745,6 +744,32 @@ code {
 	// keyboard focus
 	#picker-showgridview:focus + #picker-view-toggle {
 		opacity: 1;
+	}
+	
+	.actions.creatable {
+		flex-wrap: wrap;
+		padding: 0px;
+		box-sizing: border-box;
+		display: inline-flex;
+		float: none;
+		max-height: 44px;
+		background-color: var(--color-background-dark);
+		border: 1px solid var(--color-border-dark);
+		border-radius: var(--border-radius-pill);
+		position: static;
+		
+		.icon.icon-add{
+			background-image: var(--icon-add-000);
+			background-size: 16px 16px;
+			max-height:44px;
+			
+		}
+
+		a {
+			width: 44px;
+			padding: 0px;
+			position: static;
+		}
 	}
 
 	.filelist-container {

--- a/core/js/jquery.ocdialog.js
+++ b/core/js/jquery.ocdialog.js
@@ -34,6 +34,8 @@
 				position: 'fixed'
 			});
 
+			this.enterCallback = null;
+
 			$(document).on('keydown keyup', function(event) {
 				if (
 					event.target !== self.$dialog.get(0) &&
@@ -54,6 +56,11 @@
 				// Enter
 				if(event.keyCode === 13) {
 					event.stopImmediatePropagation();
+					if (self.enterCallback != null) {
+						self.enterCallback();
+						event.preventDefault();
+						return false;
+					}
 					if(event.type === 'keyup') {
 						event.preventDefault();
 						return false;
@@ -205,6 +212,12 @@
 		},
 		widget: function() {
 			return this.$dialog;
+		},
+		setEnterCallback: function(callback) {
+			this.enterCallback = callback;
+		},
+		unsetEnterCallback: function() {
+			this.enterCallback = null;
 		},
 		close: function() {
 			this._destroyOverlay();

--- a/core/js/jquery.ocdialog.js
+++ b/core/js/jquery.ocdialog.js
@@ -56,7 +56,7 @@
 				// Enter
 				if(event.keyCode === 13) {
 					event.stopImmediatePropagation();
-					if (self.enterCallback != null) {
+					if (self.enterCallback !== null) {
 						self.enterCallback();
 						event.preventDefault();
 						return false;

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -259,6 +259,17 @@ var OCdialogs = {
 			}
 
 			var newButton = self.$filePicker.find('.actions.creatable .button-add');
+			newButton.on('focus', function() {
+				self.$filePicker.ocdialog('setEnterCallback', function() {
+					event.stopImmediatePropagation();
+					event.preventDefault();
+					newButton.click();
+				});
+			});
+			newButton.on('blur', function() {
+				self.$filePicker.ocdialog('unsetEnterCallback');
+			});
+
 			OC.registerMenu(newButton,self.$filePicker.find('.menu'),function () {
 				$input.focus();
 				self.$filePicker.ocdialog('setEnterCallback', function() {

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -307,7 +307,7 @@ var OCdialogs = {
 					}
 				} catch (error) {
 					$input.attr('title', error);
-					$input.tooltip({placement: 'right', trigger: 'manual', 'container': '.newFileMenu'});
+					$input.tooltip({placement: 'right', trigger: 'manual', 'container': '.newFolderMenu'});
 					$input.tooltip('fixTitle');
 					$input.tooltip('show');
 					$input.addClass('error');

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -331,7 +331,7 @@ var OCdialogs = {
 				}
 			});
 			$input.keypress(function(event) {
-				if (event.keyCode == 13 || event.which == 13) {
+				if (event.keyCode === 13 || event.which === 13) {
 					event.stopImmediatePropagation();
 					event.preventDefault();
 					$form.submit();

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -322,7 +322,7 @@ var OCdialogs = {
 				if (checkInput()) { 
 					var newname = $input.val();
 					self.filepicker.filesClient.createDirectory(self.$filePicker.data('path') + "/" + newname).always(function (status) {
-						self._fillFilePicker(self.$filePicker.data('path') );
+						self._fillFilePicker(self.$filePicker.data('path') + newname );
 					});
 					OC.hideMenus();
 					self.$filePicker.ocdialog('unsetEnterCallback');

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -205,12 +205,15 @@ var OCdialogs = {
 		}
 
 		var emptyText = t('core', 'No files in here');
+		var newText = t('files', 'New folder');
 		if (type === this.FILEPICKER_TYPE_COPY || type === this.FILEPICKER_TYPE_MOVE || type === this.FILEPICKER_TYPE_COPY_MOVE) {
 			emptyText = t('core', 'No more subfolders in here');
 		}
 
 		this.filepicker.loading = true;
 		this.filepicker.filesClient = (OCA.Sharing && OCA.Sharing.PublicApp && OCA.Sharing.PublicApp.fileList)? OCA.Sharing.PublicApp.fileList.filesClient: OC.Files.getClient();
+
+		this.filelist = null;
 
 		$.when(this._getFilePickerTemplate()).then(function($tmpl) {
 			self.filepicker.loading = false;
@@ -229,7 +232,8 @@ var OCdialogs = {
 			self.$filePicker = $tmpl.octemplate({
 				dialog_name: dialogName,
 				title: title,
-				emptytext: emptyText
+				emptytext: emptyText,
+				newtext: newText
 			}).data('path', '').data('multiselect', multiselect).data('mimetype', mimetypeFilter);
 
 			if (modal === undefined) {
@@ -253,6 +257,70 @@ var OCdialogs = {
 			if (!OC.Util.isIE()) {
 				self._getGridSettings();
 			}
+
+			var newButton = self.$filePicker.find('.actions.creatable .button-add');
+			OC.registerMenu(newButton,self.$filePicker.find('.menu'),function () {
+				$input.focus();
+				self.$filePicker.ocdialog('setEnterCallback', function() {
+					self.$form.submit();
+				});
+				var newName = $input.val();
+				lastPos = newName.lastIndexOf('.');
+				if (lastPos === -1) {
+					lastPos = newName.length;
+				}
+				$input.selectRange(0, lastPos);
+			});
+			var $form = self.$filePicker.find('.filenameform');
+			var $input = $form.find('input[type=\'text\']');
+			var $submit = $form.find('input[type=\'submit\']');
+			$submit.on('click',function(event) {
+				event.stopPropagation();
+				event.preventDefault();
+				$form.submit();
+			});
+
+			var checkInput = function () {
+				var filename = $input.val();
+				try {
+					if (!Files.isFileNameValid(filename)) {
+						// Files.isFileNameValid(filename) throws an exception itself
+					} else if (self.filelist.find(function(file){return file.name == this;},filename)) {
+						throw t('files', '{newName} already exists', {newName: filename}, undefined, {
+							escape: false
+						});
+					} else {
+						return true;
+					}
+				} catch (error) {
+					$input.attr('title', error);
+					$input.tooltip({placement: 'right', trigger: 'manual', 'container': '.newFileMenu'});
+					$input.tooltip('fixTitle');
+					$input.tooltip('show');
+					$input.addClass('error');
+				}
+				return false;
+			};
+
+			$form.on('submit', function(event) {
+				event.stopPropagation();
+				event.preventDefault();
+
+				if (checkInput()) { 
+					var newname = $input.val();
+					self.filepicker.filesClient.createDirectory(self.$filePicker.data('path') + "/" + newname).always(function (status) {
+						self._fillFilePicker(self.$filePicker.data('path') );
+					});
+					OC.hideMenus();
+					self.$filePicker.ocdialog('unsetEnterCallback');
+					self.$filePicker.click();
+				}
+			});
+			$input.keypress(function(event) {
+				if (event.keyCode == 13 || event.which == 13) {
+					$form.submit();
+				}
+			});
 
 			self.$filePicker.ready(function() {
 				self.$fileListHeader = self.$filePicker.find('.filelist thead tr');
@@ -912,6 +980,7 @@ var OCdialogs = {
 			self.$fileListHeader.find('[data-sort=' + self.filepicker.sortField + '] .sort-indicator').addClass('icon-triangle-s');
 		}
 		self.filepicker.filesClient.getFolderContents(dir).then(function(status, files) {
+			self.filelist = files;
 			if (filter && filter.length > 0 && filter.indexOf('*') === -1) {
 				files = files.filter(function (file) {
 					return file.type === 'dir' || filter.indexOf(file.mimetype) !== -1;

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -298,7 +298,7 @@ var OCdialogs = {
 				try {
 					if (!Files.isFileNameValid(filename)) {
 						// Files.isFileNameValid(filename) throws an exception itself
-					} else if (self.filelist.find(function(file){return file.name == this;},filename)) {
+					} else if (self.filelist.find(function(file){return file.name === this;},filename)) {
 						throw t('files', '{newName} already exists', {newName: filename}, undefined, {
 							escape: false
 						});

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -262,6 +262,8 @@ var OCdialogs = {
 			OC.registerMenu(newButton,self.$filePicker.find('.menu'),function () {
 				$input.focus();
 				self.$filePicker.ocdialog('setEnterCallback', function() {
+					event.stopImmediatePropagation();
+					event.preventDefault();
 					self.$form.submit();
 				});
 				var newName = $input.val();
@@ -275,7 +277,7 @@ var OCdialogs = {
 			var $input = $form.find('input[type=\'text\']');
 			var $submit = $form.find('input[type=\'submit\']');
 			$submit.on('click',function(event) {
-				event.stopPropagation();
+				event.stopImmediatePropagation();
 				event.preventDefault();
 				$form.submit();
 			});
@@ -314,10 +316,13 @@ var OCdialogs = {
 					OC.hideMenus();
 					self.$filePicker.ocdialog('unsetEnterCallback');
 					self.$filePicker.click();
+					$input.val(newText);
 				}
 			});
 			$input.keypress(function(event) {
 				if (event.keyCode == 13 || event.which == 13) {
+					event.stopImmediatePropagation();
+					event.preventDefault();
 					$form.submit();
 				}
 			});

--- a/core/templates/filepicker.html
+++ b/core/templates/filepicker.html
@@ -1,7 +1,7 @@
 <div id="{dialog_name}" title="{title}">
 	<span class="dirtree breadcrumb"></span>
 	<span class="actions creatable"><a href="#" class="icon icon-add button button-add"></a>
-	<nav class="menu popovermenu bubble menu-center newFileMenu">
+	<nav class="menu popovermenu bubble menu-left newFolderMenu">
 		<ul><li>
 		<form class="filenameform">
 			<input type="text" value={newtext}>

--- a/core/templates/filepicker.html
+++ b/core/templates/filepicker.html
@@ -1,5 +1,6 @@
 <div id="{dialog_name}" title="{title}">
 	<span class="dirtree breadcrumb"></span>
+	<span class="actions creatable"><a href="#" class="icon icon-add button"></a></span>
 	<input type="checkbox" class="hidden-visually" id="picker-showgridview" checked="checked" />
 	<label id="picker-view-toggle" for="picker-showgridview" class="button icon-toggle-filelist"></label>
 	<div class="filelist-container">

--- a/core/templates/filepicker.html
+++ b/core/templates/filepicker.html
@@ -1,6 +1,15 @@
 <div id="{dialog_name}" title="{title}">
 	<span class="dirtree breadcrumb"></span>
-	<span class="actions creatable"><a href="#" class="icon icon-add button"></a></span>
+	<span class="actions creatable"><a href="#" class="icon icon-add button button-add"></a>
+	<nav class="menu popovermenu bubble menu-center newFileMenu">
+		<ul><li>
+		<form class="filenameform">
+			<input type="text" value={newtext}>
+			<input class="icon-confirm" type="submit" value="">
+		</form>
+			</li></ul>
+	</nav>
+	</span>
 	<input type="checkbox" class="hidden-visually" id="picker-showgridview" checked="checked" />
 	<label id="picker-view-toggle" for="picker-showgridview" class="button icon-toggle-filelist"></label>
 	<div class="filelist-container">


### PR DESCRIPTION
This Pull Request intends to solve Issue #7629 .
It adds a button to the file picker next to the breadscrumbs. When clicking on this button it opens a popup that asks for the folders name. After submitting the form, it closes the popup and reloads the file picker's content.
There is one small bug, that I couldn't fix: OC.hideMenus(); prevents the file picker from reacting to keyboard button presses until it is clicked again. So after creating a new folder the enter and escape key will only work again after the user clicked the file picker again.

Please review @MariusBluem @jancborchardt