### PR TITLE
Only check whatsnew once per hour

### DIFF
--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -133,7 +133,10 @@
 
 			this._debouncedPersistShowHiddenFilesState = _.debounce(this._persistShowHiddenFilesState, 1200);
 
-			OCP.WhatsNew.query(); // for Nextcloud server
+			if (sessionStorage.getItem('WhatsNewServerCheck') < (Date.now() - 3600*1000)) {
+				OCP.WhatsNew.query(); // for Nextcloud server
+				sessionStorage.setItem('WhatsNewServerCheck', Date.now());
+			}
 		},
 
 		/**


### PR DESCRIPTION
Store the last check in the session storage. (Which gets cleared on
logout). And only check once an hour.
Saves a request to the server on most requests when browsing.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>