### PR TITLE
SCSS cache buster is a combination of apps/theming/scc_vars

### DIFF
--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -210,7 +210,14 @@ class TemplateLayout extends \OC_Template {
 			if (substr($file, -strlen('print.css')) === 'print.css') {
 				$this->append( 'printcssfiles', $web.'/'.$file . $this->getVersionHashSuffix() );
 			} else {
-				$this->append( 'cssfiles', $web.'/'.$file . $this->getVersionHashSuffix($web, $file)  );
+				$suffix = $this->getVersionHashSuffix($web, $file);
+
+				if (strpos($file, '?v=') == false) {
+					$this->append( 'cssfiles', $web.'/'.$file . $suffix);
+				} else {
+					$this->append( 'cssfiles', $web.'/'.$file . '-' . substr($suffix, 3));
+				}
+
 			}
 		}
 	}


### PR DESCRIPTION
Else on scss files we'd get <file>?v=<hash>?v=<hash2>
This is of course not valid. Now it becomes <file>?v=<hash>-<hash2>

Before: `<server>/css/comments/ca9f-d135-comments.css?v=db81cddf52fdb3c8ca1e4c859e214124?v=ca9f0d77-0`
After: `<server>/css/comments/ca9f-d135-comments.css?v=db81cddf52fdb3c8ca1e4c859e214124-ca9f0d77-0`