### PR TITLE
add carddav-search (vCard2Array) option for X-ADDRESSBOOKSERVER-MEMBER

### DIFF
--- a/apps/dav/lib/CardDAV/AddressBookImpl.php
+++ b/apps/dav/lib/CardDAV/AddressBookImpl.php
@@ -269,7 +269,7 @@ class AddressBookImpl implements IAddressBook {
 				}
 
 			// The following properties can be set multiple times
-			} else if (in_array($property->name, ['CLOUD', 'EMAIL', 'IMPP', 'TEL', 'URL'])) {
+			} else if (in_array($property->name, ['CLOUD', 'EMAIL', 'IMPP', 'TEL', 'URL', 'X-ADDRESSBOOKSERVER-MEMBER'])) {
 				if (!isset($result[$property->name])) {
 					$result[$property->name] = [];
 				}


### PR DESCRIPTION
Hi,
First PR, sorry if I don't get all the ways just now. Bit of a training. But I'm happy to learn.

Adding said field,
which in reverse can be used to relate persons back to groups (macos behaviour), based on CardDAV only.

- groups are cards with field X-ADDRESSBOOKSERVER-KIND == 'group'
- and all members' UUID/URI in the X-ADDRESSBOOKSERVER-MEMBER "array" of that group-card.

Based on NC 15.0 from the official beta channel

Cheers
Manu


BTW:
I'm very glad the vCard2Array 'types' option was introduced upstream. Thanks a lot!
