### PR TITLE
do not forgot to store the second displayname portion

### DIFF
--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -202,7 +202,7 @@ class User {
 			$displayName2 = (string)$ldapEntry[$attr][0];
 		}
 		if ($displayName !== '') {
-			$this->composeAndStoreDisplayName($displayName);
+			$this->composeAndStoreDisplayName($displayName, $displayName2);
 			$this->access->cacheUserDisplayName(
 				$this->getUsername(),
 				$displayName,


### PR DESCRIPTION
Given your LDAP configuration defined a "Second displayname" attribute (e.g.) that is show behind the main one in brackets, then user listings and logins will create a cascade of system addressbook updated, because in one code path we missed to consider the second attribute when storing the displayname in the database. This fixes it. A final update will happen to end up with the correct value.