### PR TITLE
Files list not rendering if user has favorites navigation unfolded

### DIFF
--- a/apps/files/js/navigation.js
+++ b/apps/files/js/navigation.js
@@ -283,8 +283,11 @@
 		 * This method allows easy swapping of elements.
 		 */
 		swap: function (list, j, i) {
-			list[i].before(list[j]);
-			list[j].before(list[i]);
+			var before = function(node, insertNode) {
+				node.parentNode.insertBefore(insertNode, node);
+			}
+			before(list[i], list[j]);
+			before(list[j], list[i]);
 		}
 
 	};


### PR DESCRIPTION
This replaces ChildNode.before() with a simple custom helper, because it is not available on all browsers we support.

### Steps to reproduce:

In a modern browser:
- Mark some folders as favorite
- Unfold the favorites section in the left navigation

Afterwards in IE11:
- Open the files app
- :boom: 

