### PR TITLE
Add acceptance tests for moving and copying files

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -15,6 +15,7 @@ default:
         - DialogContext
         - FeatureContext
         - FileListContext
+        - FilePickerContext
         - FilesAppContext
         - FilesAppSharingContext
         - LoginPageContext
@@ -43,6 +44,7 @@ default:
         - DialogContext
         - FeatureContext
         - FileListContext
+        - FilePickerContext
         - FilesAppContext
         - FilesAppSharingContext
         - LoginPageContext

--- a/tests/acceptance/features/app-files.feature
+++ b/tests/acceptance/features/app-files.feature
@@ -202,6 +202,39 @@ Feature: app-files
     And I see that the file list contains a file named "Folder"
     And I see that the file list contains a file named "Not selected folder"
 
+  Scenario: copy a file in its same folder
+    Given I am logged in
+    When I start the move or copy operation for "welcome.txt"
+    # No folder was explicitly selected, so the last selected folder is the
+    # current folder.
+    And I copy to the last selected folder in the file picker
+    Then I see that the file list contains a file named "welcome.txt"
+    And I see that the file list contains a file named "welcome (copy).txt"
+
+  Scenario: copy a file twice in its same folder
+    Given I am logged in
+    And I start the move or copy operation for "welcome.txt"
+    # No folder was explicitly selected, so the last selected folder is the
+    # current folder.
+    And I copy to the last selected folder in the file picker
+    When I start the move or copy operation for "welcome.txt"
+    And I copy to the last selected folder in the file picker
+    Then I see that the file list contains a file named "welcome.txt"
+    And I see that the file list contains a file named "welcome (copy).txt"
+    And I see that the file list contains a file named "welcome (copy 2).txt"
+
+  Scenario: copy a copy of a file in its same folder
+    Given I am logged in
+    And I start the move or copy operation for "welcome.txt"
+    # No folder was explicitly selected, so the last selected folder is the
+    # current folder.
+    And I copy to the last selected folder in the file picker
+    When I start the move or copy operation for "welcome (copy).txt"
+    And I copy to the last selected folder in the file picker
+    Then I see that the file list contains a file named "welcome.txt"
+    And I see that the file list contains a file named "welcome (copy).txt"
+    And I see that the file list contains a file named "welcome (copy 2).txt"
+
   Scenario: rename a file with the details view open
     Given I am logged in
     And I open the details view for "welcome.txt"

--- a/tests/acceptance/features/app-files.feature
+++ b/tests/acceptance/features/app-files.feature
@@ -150,6 +150,24 @@ Feature: app-files
     And I enter in the folder named "Destination"
     And I see that the file list contains a file named "welcome.txt"
 
+  Scenario: move a selection to another folder
+    Given I am logged in
+    And I create a new folder named "Folder"
+    And I create a new folder named "Not selected folder"
+    And I create a new folder named "Destination"
+    When I select "welcome.txt"
+    And I select "Folder"
+    And I start the move or copy operation for the selected files
+    And I select "Destination" in the file picker
+    And I move to the last selected folder in the file picker
+    Then I see that the file list does not contain a file named "welcome.txt"
+    And I see that the file list does not contain a file named "Folder"
+    And I see that the file list contains a file named "Not selected folder"
+    And I enter in the folder named "Destination"
+    And I see that the file list contains a file named "welcome.txt"
+    And I see that the file list contains a file named "Folder"
+    And I see that the file list does not contain a file named "Not selected folder"
+
   Scenario: copy a file to another folder
     Given I am logged in
     And I create a new folder named "Destination"
@@ -162,6 +180,27 @@ Feature: app-files
     # The Files app is open again to reload the file list in the root folder
     And I open the Files app
     And I see that the file list contains a file named "welcome.txt"
+
+  Scenario: copy a selection to another folder
+    Given I am logged in
+    And I create a new folder named "Folder"
+    And I create a new folder named "Not selected folder"
+    And I create a new folder named "Destination"
+    When I select "welcome.txt"
+    And I select "Folder"
+    And I start the move or copy operation for the selected files
+    And I select "Destination" in the file picker
+    And I copy to the last selected folder in the file picker
+    Then I enter in the folder named "Destination"
+    # The files will appear in the destination once the copy operation finishes
+    And I see that the file list contains a file named "welcome.txt"
+    And I see that the file list contains a file named "Folder"
+    And I see that the file list does not contain a file named "Not selected folder"
+    # The Files app is open again to reload the file list in the root folder
+    And I open the Files app
+    And I see that the file list contains a file named "welcome.txt"
+    And I see that the file list contains a file named "Folder"
+    And I see that the file list contains a file named "Not selected folder"
 
   Scenario: rename a file with the details view open
     Given I am logged in

--- a/tests/acceptance/features/app-files.feature
+++ b/tests/acceptance/features/app-files.feature
@@ -140,6 +140,29 @@ Feature: app-files
     Then I see that the current section is "Deleted files"
     Then I see that the file list contains a file named "welcome.txt"
 
+  Scenario: move a file to another folder
+    Given I am logged in
+    And I create a new folder named "Destination"
+    When I start the move or copy operation for "welcome.txt"
+    And I select "Destination" in the file picker
+    And I move to the last selected folder in the file picker
+    Then I see that the file list does not contain a file named "welcome.txt"
+    And I enter in the folder named "Destination"
+    And I see that the file list contains a file named "welcome.txt"
+
+  Scenario: copy a file to another folder
+    Given I am logged in
+    And I create a new folder named "Destination"
+    When I start the move or copy operation for "welcome.txt"
+    And I select "Destination" in the file picker
+    And I copy to the last selected folder in the file picker
+    Then I enter in the folder named "Destination"
+    # The file will appear in the destination once the copy operation finishes
+    And I see that the file list contains a file named "welcome.txt"
+    # The Files app is open again to reload the file list in the root folder
+    And I open the Files app
+    And I see that the file list contains a file named "welcome.txt"
+
   Scenario: rename a file with the details view open
     Given I am logged in
     And I open the details view for "welcome.txt"

--- a/tests/acceptance/features/bootstrap/FileListContext.php
+++ b/tests/acceptance/features/bootstrap/FileListContext.php
@@ -133,6 +133,48 @@ class FileListContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function fileListHeader($fileListAncestor) {
+		return Locator::forThe()->css("thead")->
+				descendantOf($fileListAncestor)->
+				describedAs("Header in file list");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function selectedFilesActionsMenuButton($fileListAncestor) {
+		return Locator::forThe()->css(".actions-selected")->
+				descendantOf(self::fileListHeader($fileListAncestor))->
+				describedAs("Selected files actions menu button in file list");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function selectedFilesActionsMenu() {
+		return Locator::forThe()->css(".filesSelectMenu")->
+				describedAs("Selected files actions menu in file list");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	private static function selectedFilesActionsMenuItemFor($itemText) {
+		return Locator::forThe()->xpath("//a[normalize-space() = '$itemText']")->
+				descendantOf(self::selectedFilesActionsMenu())->
+				describedAs($itemText . " item in selected files actions menu in file list");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function moveOrCopySelectedFilesMenuItem() {
+		return self::selectedFilesActionsMenuItemFor("Move or copy");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function rowForFile($fileListAncestor, $fileName) {
 		return Locator::forThe()->xpath("//*[@id = 'fileList']//span[contains(concat(' ', normalize-space(@class), ' '), ' nametext ') and normalize-space() = '$fileName']/ancestor::tr")->
 				descendantOf($fileListAncestor)->
@@ -146,6 +188,26 @@ class FileListContext implements Context, ActorAwareInterface {
 		return Locator::forThe()->xpath("//preceding-sibling::tr//span[contains(concat(' ', normalize-space(@class), ' '), ' nametext ') and normalize-space() = '$fileName1']/ancestor::tr")->
 				descendantOf(self::rowForFile($fileListAncestor, $fileName2))->
 				describedAs("Row for file $fileName1 preceding $fileName2 in file list");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function selectionCheckboxForFile($fileListAncestor, $fileName) {
+		// Note that the element that the user interacts with is the label, not
+		// the checbox itself.
+		return Locator::forThe()->css(".selection label")->
+				descendantOf(self::rowForFile($fileListAncestor, $fileName))->
+				describedAs("Selection checkbox for file $fileName in file list");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function selectionCheckboxInputForFile($fileListAncestor, $fileName) {
+		return Locator::forThe()->css(".selection input[type=checkbox]")->
+				descendantOf(self::rowForFile($fileListAncestor, $fileName))->
+				describedAs("Selection checkbox input for file $fileName in file list");
 	}
 
 	/**
@@ -304,6 +366,24 @@ class FileListContext implements Context, ActorAwareInterface {
 	}
 
 	/**
+	 * @Given I select :fileName
+	 */
+	public function iSelect($fileName) {
+		$this->iSeeThatIsNotSelected($fileName);
+
+		$this->actor->find(self::selectionCheckboxForFile($this->fileListAncestor, $fileName), 10)->click();
+	}
+
+	/**
+	 * @Given I start the move or copy operation for the selected files
+	 */
+	public function iStartTheMoveOrCopyOperationForTheSelectedFiles() {
+		$this->actor->find(self::selectedFilesActionsMenuButton($this->fileListAncestor), 10)->click();
+
+		$this->actor->find(self::moveOrCopySelectedFilesMenuItem(), 2)->click();
+	}
+
+	/**
 	 * @Given I open the details view for :fileName
 	 */
 	public function iOpenTheDetailsViewFor($fileName) {
@@ -443,6 +523,13 @@ class FileListContext implements Context, ActorAwareInterface {
 	 */
 	public function iSeeThatPrecedesInTheFileList($fileName1, $fileName2) {
 		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::rowForFilePreceding($this->fileListAncestor, $fileName1, $fileName2), 10));
+	}
+
+	/**
+	 * @Then I see that :fileName is not selected
+	 */
+	public function iSeeThatIsNotSelected($fileName) {
+		PHPUnit_Framework_Assert::assertFalse($this->actor->find(self::selectionCheckboxInputForFile($this->fileListAncestor, $fileName), 10)->isChecked());
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FileListContext.php
+++ b/tests/acceptance/features/bootstrap/FileListContext.php
@@ -268,6 +268,13 @@ class FileListContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function moveOrCopyMenuItem() {
+		return self::fileActionsMenuItemFor("Move or copy");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function viewFileInFolderMenuItem() {
 		return self::fileActionsMenuItemFor("View in folder");
 	}
@@ -323,6 +330,15 @@ class FileListContext implements Context, ActorAwareInterface {
 		// bring the browser window to the foreground when switching to a
 		// different actor.
 		$this->actor->find(self::renameInputForFile($this->fileListAncestor, $fileName1), 10)->setValue($fileName2 . "\r");
+	}
+
+	/**
+	 * @Given I start the move or copy operation for :fileName
+	 */
+	public function iStartTheMoveOrCopyOperationFor($fileName) {
+		$this->actor->find(self::fileActionsMenuButtonForFile($this->fileListAncestor, $fileName), 10)->click();
+
+		$this->actor->find(self::moveOrCopyMenuItem(), 2)->click();
 	}
 
 	/**
@@ -408,6 +424,18 @@ class FileListContext implements Context, ActorAwareInterface {
 	 */
 	public function iSeeThatTheFileListContainsAFileNamed($fileName) {
 		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::rowForFile($this->fileListAncestor, $fileName), 10));
+	}
+
+	/**
+	 * @Then I see that the file list does not contain a file named :fileName
+	 */
+	public function iSeeThatTheFileListDoesNotContainAFileNamed($fileName) {
+		if (!WaitFor::elementToBeEventuallyNotShown(
+				$this->actor,
+				self::rowForFile($this->fileListAncestor, $fileName),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
+			PHPUnit_Framework_Assert::fail("The file list still contains a file named $fileName after $timeout seconds");
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FilePickerContext.php
+++ b/tests/acceptance/features/bootstrap/FilePickerContext.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2018, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use Behat\Behat\Context\Context;
+
+class FilePickerContext implements Context, ActorAwareInterface {
+
+	use ActorAware;
+
+	/**
+	 * @return Locator
+	 */
+	public static function dialog() {
+		return Locator::forThe()->css(".oc-dialog")->
+				describedAs("File picker dialog");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function fileListContainer() {
+		return Locator::forThe()->css("#oc-dialog-filepicker-content")->
+				descendantOf(self::dialog())->
+				describedAs("File list container in the file picker dialog");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function rowForFile($fileName) {
+		return Locator::forThe()->xpath("//*[@id = 'picker-filestable']//*[contains(concat(' ', normalize-space(@class), ' '), ' filename ') and normalize-space() = '$fileName']/ancestor::tr")->
+				descendantOf(self::fileListContainer())->
+				describedAs("Row for file $fileName in the file picker dialog");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function buttonRow() {
+		return Locator::forThe()->css(".oc-dialog-buttonrow")->
+				descendantOf(self::dialog())->
+				describedAs("Button row in the file picker dialog");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	private static function buttonFor($buttonText) {
+		// "Copy" and "Move" buttons text is set to "Copy to XXX" and "Move to
+		// XXX" when a folder is selected.
+		return Locator::forThe()->xpath("//button[starts-with(normalize-space(), '$buttonText')]")->
+				descendantOf(self::buttonRow())->
+				describedAs($buttonText . " button in the file picker dialog");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function copyButton() {
+		return self::buttonFor("Copy");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function moveButton() {
+		return self::buttonFor("Move");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function chooseButton() {
+		return self::buttonFor("Choose");
+	}
+
+	/**
+	 * @When I select :fileName in the file picker
+	 */
+	public function iSelectInTheFilePicker($fileName) {
+		$this->actor->find(self::rowForFile($fileName), 10)->click();
+	}
+
+	/**
+	 * @When I copy to the last selected folder in the file picker
+	 */
+	public function iCopyToTheLastSelectedFolderInTheFilePicker() {
+		$this->actor->find(self::copyButton(), 10)->click();
+	}
+
+	/**
+	 * @When I move to the last selected folder in the file picker
+	 */
+	public function iMoveToTheLastSelectedFolderInTheFilePicker() {
+		$this->actor->find(self::moveButton(), 10)->click();
+	}
+
+	/**
+	 * @When I choose the last selected file in the file picker
+	 */
+	public function iChooseTheLastSelectedFileInTheFilePicker() {
+		$this->actor->find(self::chooseButton(), 10)->click();
+	}
+
+}


### PR DESCRIPTION
I will backport this manually to previous versions (at least _stable15_, as I need _FilePickerContext_ for Talk) as [the commit that tests copying on the same folder is Nextcloud 16 only](https://github.com/nextcloud/server/pull/10825).
