### PR TITLE
unbundle user_external to release it via appstore

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -34,7 +34,6 @@
     "theming",
     "twofactor_backupcodes",
     "updatenotification",
-    "user_external",
     "user_ldap",
     "workflowengine"
   ],


### PR DESCRIPTION
as for nextcloud/user_external#22 we want to remove user_external from the build script and update it independently via appstore. As it's broken for 15.0.0 anyway (#12506) we want to increase the min-version to 15 and publish it via appstore. So it should not generate any problem (if shipped and available via appstore).
I only found the `shipped.json`. Are there other things to change or does the build script only take the list from `shipped.json`? @MorrisJobke 

cc @nextcloud/user_external @jancborchardt 

Signed-off-by: Jonas Sulzer <jonas@violoncello.ch>