### PR TITLE
Fix opening search results for comments

### DIFF
--- a/apps/comments/js/search.js
+++ b/apps/comments/js/search.js
@@ -92,7 +92,9 @@
 					.css('background-image', 'url(' + OC.imagePath('core', 'actions/comment') + ')')
 					.css('opacity', '.4');
 				var dir = OC.dirname(result.path);
-				if (dir === '') {
+				// "result.path" does not include a leading "/", so "OC.dirname"
+				// returns the path itself for files or folders in the root.
+				if (dir === result.path) {
 					dir = '/';
 				}
 				$row.find('td.info a').attr('href',

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -20,6 +20,7 @@ default:
         - LoginPageContext
         - NotificationContext
         - PublicShareContext
+        - SearchContext
         - SettingsContext
         - SettingsMenuContext
         - ThemingAppContext
@@ -47,6 +48,7 @@ default:
         - LoginPageContext
         - NotificationContext
         - PublicShareContext
+        - SearchContext
         - SettingsContext
         - SettingsMenuContext
         - ThemingAppContext

--- a/tests/acceptance/features/app-comments.feature
+++ b/tests/acceptance/features/app-comments.feature
@@ -216,3 +216,54 @@ Feature: app-comments
     And I open the unread comments for "Child folder"
     And I see that the details view is open
     And I see a comment with "Hello world" as message
+
+
+
+  Scenario: search a comment
+    Given I am logged in
+    And I open the details view for "welcome.txt"
+    And I open the "Comments" tab in the details view
+    And I create a new comment with "Hello world" as message
+    And I see a comment with "Hello world" as message
+    When I search for "hello"
+    # Search results for comments also include the user that wrote the comment.
+    Then I see that the search result 1 is "user0Hello world"
+    And I see that the search result 1 was found in "welcome.txt"
+
+  Scenario: search a comment in a child folder
+    Given I am logged in
+    And I create a new folder named "Folder"
+    And I enter in the folder named "Folder"
+    And I create a new folder named "Child folder"
+    And I open the details view for "Child folder"
+    And I open the "Comments" tab in the details view
+    And I create a new comment with "Hello world" as message
+    And I see a comment with "Hello world" as message
+    # The Files app is open again to reload the file list
+    And I open the Files app
+    When I search for "hello"
+    # Search results for comments also include the user that wrote the comment.
+    Then I see that the search result 1 is "user0Hello world"
+    And I see that the search result 1 was found in "Folder/Child folder"
+
+  Scenario: search a comment by a another user
+    Given I act as John
+    And I am logged in as the admin
+    And I act as Jane
+    And I am logged in
+    And I act as John
+    And I rename "welcome.txt" to "shared.txt"
+    And I share "shared.txt" with "user0"
+    And I see that the file is shared with "user0"
+    And I act as Jane
+    # The Files app is open again to reload the file list
+    And I open the Files app
+    And I open the details view for "shared.txt"
+    And I open the "Comments" tab in the details view
+    And I create a new comment with "Hello world" as message
+    And I see a comment with "Hello world" as message
+    When I act as John
+    And I search for "hello"
+    # Search results for comments also include the user that wrote the comment.
+    Then I see that the search result 1 is "user0Hello world"
+    And I see that the search result 1 was found in "shared.txt"

--- a/tests/acceptance/features/app-comments.feature
+++ b/tests/acceptance/features/app-comments.feature
@@ -267,3 +267,59 @@ Feature: app-comments
     # Search results for comments also include the user that wrote the comment.
     Then I see that the search result 1 is "user0Hello world"
     And I see that the search result 1 was found in "shared.txt"
+
+  Scenario: open a search result for a comment in a file
+    Given I am logged in
+    And I open the details view for "welcome.txt"
+    And I open the "Comments" tab in the details view
+    And I create a new comment with "Hello world" as message
+    And I see a comment with "Hello world" as message
+    # Force the details view to change to a different file before closing it
+    And I create a new folder named "Folder"
+    And I close the details view
+    When I search for "hello"
+    And I open the search result 1
+    Then I see that the details view is open
+    And I see that the file name shown in the details view is "welcome.txt"
+    And I see a comment with "Hello world" as message
+    And I see that the file list is currently in "Home"
+    And I see that the file list contains a file named "welcome.txt"
+
+  Scenario: open a search result for a comment in a folder named like its child folder
+    Given I am logged in
+    And I create a new folder named "Folder"
+    And I open the details view for "Folder"
+    And I open the "Comments" tab in the details view
+    And I create a new comment with "Hello world" as message
+    And I see a comment with "Hello world" as message
+    And I enter in the folder named "Folder"
+    And I create a new folder named "Folder"
+    # The Files app is open again to reload the file list
+    And I open the Files app
+    When I search for "hello"
+    And I open the search result 1
+    Then I see that the details view is open
+    And I see that the file name shown in the details view is "Folder"
+    And I see a comment with "Hello world" as message
+    And I see that the file list is currently in "Home"
+    And I see that the file list contains a file named "welcome.txt"
+    And I see that the file list contains a file named "Folder"
+
+  Scenario: open a search result for a comment in a child folder
+    Given I am logged in
+    And I create a new folder named "Folder"
+    And I enter in the folder named "Folder"
+    And I create a new folder named "Child folder"
+    And I open the details view for "Child folder"
+    And I open the "Comments" tab in the details view
+    And I create a new comment with "Hello world" as message
+    And I see a comment with "Hello world" as message
+    # The Files app is open again to reload the file list
+    And I open the Files app
+    When I search for "hello"
+    And I open the search result 1
+    Then I see that the details view is open
+    And I see that the file name shown in the details view is "Child folder"
+    And I see a comment with "Hello world" as message
+    And I see that the file list is currently in "Home/Folder"
+    And I see that the file list contains a file named "Child folder"

--- a/tests/acceptance/features/bootstrap/FileListContext.php
+++ b/tests/acceptance/features/bootstrap/FileListContext.php
@@ -90,6 +90,15 @@ class FileListContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function breadcrumbs($fileListAncestor) {
+		return Locator::forThe()->css("#controls .breadcrumb")->
+				descendantOf($fileListAncestor)->
+				describedAs("Breadcrumbs in file list");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function createMenuButton($fileListAncestor) {
 		return Locator::forThe()->css("#controls .button.new")->
 				descendantOf($fileListAncestor)->
@@ -373,6 +382,16 @@ class FileListContext implements Context, ActorAwareInterface {
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
 			PHPUnit_Framework_Assert::fail("The main working icon for the file list is still shown after $timeout seconds");
 		}
+	}
+
+	/**
+	 * @Then I see that the file list is currently in :path
+	 */
+	public function iSeeThatTheFileListIsCurrentlyIn($path) {
+		// The text of the breadcrumbs is the text of all the crumbs separated
+		// by white spaces.
+		PHPUnit_Framework_Assert::assertEquals(
+			str_replace('/', ' ', $path), $this->actor->find(self::breadcrumbs($this->fileListAncestor), 10)->getText());
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/SearchContext.php
+++ b/tests/acceptance/features/bootstrap/SearchContext.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2018, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use Behat\Behat\Context\Context;
+
+class SearchContext implements Context, ActorAwareInterface {
+
+	use ActorAware;
+
+	/**
+	 * @return Locator
+	 */
+	public static function searchBoxInput() {
+		return Locator::forThe()->css("#header .searchbox input")->
+				describedAs("Search box input in the header");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function searchResults() {
+		return Locator::forThe()->css("#searchresults")->
+				describedAs("Search results");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function searchResult($number) {
+		return Locator::forThe()->xpath("//*[contains(concat(' ', normalize-space(@class), ' '), ' result ')][$number]")->
+				descendantOf(self::searchResults())->
+				describedAs("Search result $number");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function searchResultName($number) {
+		return Locator::forThe()->css(".name")->
+				descendantOf(self::searchResult($number))->
+				describedAs("Name for search result $number");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function searchResultPath($number) {
+		// Currently search results for comments misuse the ".path" class to
+		// dim the user name, so "div.path" needs to be used to find the proper
+		// path element.
+		return Locator::forThe()->css("div.path")->
+				descendantOf(self::searchResult($number))->
+				describedAs("Path for search result $number");
+	}
+
+	/**
+	 * @When I search for :query
+	 */
+	public function iSearchFor($query) {
+		$this->actor->find(self::searchBoxInput(), 10)->setValue($query . "\r");
+	}
+
+	/**
+	 * @Then I see that the search result :number is :name
+	 */
+	public function iSeeThatTheSearchResultIs($number, $name) {
+		PHPUnit_Framework_Assert::assertEquals(
+				$name, $this->actor->find(self::searchResultName($number), 10)->getText());
+	}
+
+	/**
+	 * @Then I see that the search result :number was found in :path
+	 */
+	public function iSeeThatTheSearchResultWasFoundIn($number, $path) {
+		PHPUnit_Framework_Assert::assertEquals(
+				$path, $this->actor->find(self::searchResultPath($number), 10)->getText());
+	}
+
+}

--- a/tests/acceptance/features/bootstrap/SearchContext.php
+++ b/tests/acceptance/features/bootstrap/SearchContext.php
@@ -74,10 +74,26 @@ class SearchContext implements Context, ActorAwareInterface {
 	}
 
 	/**
+	 * @return Locator
+	 */
+	public static function searchResultLink($number) {
+		return Locator::forThe()->css(".link")->
+				descendantOf(self::searchResult($number))->
+				describedAs("Link for search result $number");
+	}
+
+	/**
 	 * @When I search for :query
 	 */
 	public function iSearchFor($query) {
 		$this->actor->find(self::searchBoxInput(), 10)->setValue($query . "\r");
+	}
+
+	/**
+	 * @When I open the search result :number
+	 */
+	public function iOpenTheSearchResult($number) {
+		$this->actor->find(self::searchResultLink($number), 10)->click();
 	}
 
 	/**


### PR DESCRIPTION
`OC.dirname` removes everything after the last _/_, so a path without slashes is returned without changes. `result.path` does not include leading nor trailing _/_, so when the path is for a file or folder in the base folder `OC.dirname(result.path)` returns `result.path` instead of an empty string.

To test this just follow the steps in the acceptance tests _open a search result for a comment in a file_ and _open a search result for a comment in a folder named like its child folder_ (or just check the CI results :-P ).

There is another issue with opening search results for comments, though. This pull request fixes the link to the file, but theoretically clicking on a result should be intercepted before the link is opened, and instead of loading the new URL [the file list should be simply updated with the desired file](https://github.com/nextcloud/server/blob/2dd55b0550c42355a6188554c3e217870ce37eb5/apps/comments/js/search.js#L107-L108). However, [`setFileList` is called only on the search provider of files](https://github.com/nextcloud/server/blob/68ad2ae11873933ca2212df5a141e49cafa83c33/apps/files/js/filelist.js#L3063), so there will be no file list set in the search provider for comments and thus the click event will be handled by opening the link.

Fixing that is more a structural change in the search (as the file list should be set for any search provider, it would not be enough to just set it explicitly on the search provider for comments), so that could be fixed for Nextcloud 16 in a different pull request if desired; this one is just a little bug fix (with its corresponding acceptance tests, of course ;-) ) to be backported to previous versions.
