### PR TITLE
Improve data directory write checking for NFS mounts

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -43,6 +43,7 @@
  * @author Victor Dubiniuk <dubiniuk@owncloud.com>
  * @author Vincent Petry <pvince81@owncloud.com>
  * @author Volkan Gezer <volkangezer@gmail.com>
+ * @author Robert Dailey <rcdailey@gmail.com>
  *
  * @license AGPL-3.0
  *
@@ -789,13 +790,20 @@ class OC_Util {
 					];
 				}
 			} else if (!is_writable($CONFIG_DATADIRECTORY) or !is_readable($CONFIG_DATADIRECTORY)) {
-				//common hint for all file permissions error messages
-				$permissionsHint = $l->t('Permissions can usually be fixed by giving the webserver write access to the root directory. See %s.',
-					[$urlGenerator->linkToDocs('admin-dir_permissions')]);
-				$errors[] = [
-					'error' => 'Your data directory is not writable',
-					'hint' => $permissionsHint
-				];
+				// is_writable doesn't work for NFS mounts, so try to write a file and check if it exists.
+				$testFile = sprintf('%s/%s.tmp', $CONFIG_DATADIRECTORY, uniqid('data_dir_writability_test_'));
+				$handle = fopen($testFile, 'w');
+				if (!$handle || fwrite($handle, 'Test write operation') === FALSE) {
+					$permissionsHint = $l->t('Permissions can usually be fixed by giving the webserver write access to the root directory. See %s.',
+						[$urlGenerator->linkToDocs('admin-dir_permissions')]);
+					$errors[] = [
+						'error' => 'Your data directory is not writable',
+						'hint' => $permissionsHint
+					];
+				} else {
+					fclose($handle);
+					unlink($testFile);
+				}
 			} else {
 				$errors = array_merge($errors, self::checkDataDirectoryPermissions($CONFIG_DATADIRECTORY));
 			}


### PR DESCRIPTION
If `is_writable()` fails, fall back to logic that attempts to create a file
and then checks if it exists. If this check fails, an error occurs as it
did before.

Discussion on this solution was found here:
https://help.nextcloud.com/t/write-errors-for-nfs-mount/23328

Fixes #7124
