### PR TITLE
Add default values when parsing account data

### DIFF
--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -330,7 +330,7 @@ class AccountManager implements IAccountManager {
 	private function parseAccountData(IUser $user, $data): Account {
 		$account = new Account($user);
 		foreach($data as $property => $accountData) {
-			$account->setProperty($property, $accountData['value'] ?? '', $accountData['scope'], $accountData['verified']);
+			$account->setProperty($property, $accountData['value'] ?? '', $accountData['scope'] ?? self::VISIBILITY_PRIVATE, $accountData['verified'] ?? self::NOT_VERIFIED);
 		}
 		return $account;
 	}


### PR DESCRIPTION
Add default values for property scope and verified status, since it might be null if the visibility hasn't been set.

Found in https://github.com/nextcloud/social/issues/229