### PR TITLE
Remove extra quotes around values passed for clear-site-data header

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -131,7 +131,7 @@ class LoginController extends Controller {
 		$this->userSession->logout();
 
 		$response = new RedirectResponse($this->urlGenerator->linkToRouteAbsolute('core.login.showLoginForm'));
-		$response->addHeader('Clear-Site-Data', '"cache", "storage", "executionContexts"');
+		$response->addHeader('Clear-Site-Data', 'cache, storage, executionContexts');
 		return $response;
 	}
 


### PR DESCRIPTION
Implementation of the patch as suggested by @tfd0207 for issue #12568.
Removing the double quotes from each value set for `Clear-Site-Data` makes Firefox bahave as expected. Also validated in Chrome and Edge. Currently no access to Safari.