### PR TITLE
Remove check for outdated caches

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -159,18 +159,6 @@
 							type: OC.SetupChecks.MESSAGE_TYPE_INFO
 						});
 					}
-					if (data.outdatedCaches.length > 0) {
-						data.outdatedCaches.forEach(function(element){
-							messages.push({
-								msg: t(
-									'core',
-									'{name} below version {version} is installed, for stability and performance reasons it is recommended to update to a newer {name} version.',
-									element
-								),
-								type: OC.SetupChecks.MESSAGE_TYPE_WARNING
-							})
-						});
-					}
 					if(!data.hasWorkingFileLocking) {
 						messages.push({
 							msg: t('core', 'Transactional file locking is disabled, this might lead to issues with race conditions. Enable "filelocking.enabled" in config.php to avoid these problems. See the <a target="_blank" rel="noreferrer noopener" href="{docLink}">documentation ↗</a> for more information.', {docLink: oc_defaults.docPlaceholderUrl.replace('PLACEHOLDER', 'admin-transactional-locking')}),

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -204,7 +204,6 @@ describe('OC.SetupChecks tests', function() {
 					isSettimelimitAvailable: true,
 					hasFreeTypeSupport: true,
 					missingIndexes: [],
-					outdatedCaches: [],
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
@@ -255,7 +254,6 @@ describe('OC.SetupChecks tests', function() {
 					isSettimelimitAvailable: true,
 					hasFreeTypeSupport: true,
 					missingIndexes: [],
-					outdatedCaches: [],
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
@@ -307,7 +305,6 @@ describe('OC.SetupChecks tests', function() {
 					isSettimelimitAvailable: true,
 					hasFreeTypeSupport: true,
 					missingIndexes: [],
-					outdatedCaches: [],
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
@@ -357,7 +354,6 @@ describe('OC.SetupChecks tests', function() {
 					isSettimelimitAvailable: true,
 					hasFreeTypeSupport: true,
 					missingIndexes: [],
-					outdatedCaches: [],
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
@@ -405,7 +401,6 @@ describe('OC.SetupChecks tests', function() {
 					isSettimelimitAvailable: true,
 					hasFreeTypeSupport: true,
 					missingIndexes: [],
-					outdatedCaches: [],
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
@@ -453,7 +448,6 @@ describe('OC.SetupChecks tests', function() {
 					isSettimelimitAvailable: true,
 					hasFreeTypeSupport: true,
 					missingIndexes: [],
-					outdatedCaches: [],
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
@@ -503,7 +497,6 @@ describe('OC.SetupChecks tests', function() {
 					isSettimelimitAvailable: true,
 					hasFreeTypeSupport: true,
 					missingIndexes: [],
-					outdatedCaches: [],
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
@@ -551,7 +544,6 @@ describe('OC.SetupChecks tests', function() {
 					isSettimelimitAvailable: false,
 					hasFreeTypeSupport: true,
 					missingIndexes: [],
-					outdatedCaches: [],
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
@@ -599,7 +591,6 @@ describe('OC.SetupChecks tests', function() {
 					isSettimelimitAvailable: true,
 					hasFreeTypeSupport: true,
 					missingIndexes: [],
-					outdatedCaches: [],
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
@@ -668,7 +659,6 @@ describe('OC.SetupChecks tests', function() {
 					isSettimelimitAvailable: true,
 					hasFreeTypeSupport: true,
 					missingIndexes: [],
-					outdatedCaches: [],
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
@@ -717,7 +707,6 @@ describe('OC.SetupChecks tests', function() {
 					isSettimelimitAvailable: true,
 					hasFreeTypeSupport: true,
 					missingIndexes: [],
-					outdatedCaches: [],
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
@@ -766,7 +755,6 @@ describe('OC.SetupChecks tests', function() {
 					isSettimelimitAvailable: true,
 					hasFreeTypeSupport: true,
 					missingIndexes: [],
-					outdatedCaches: [],
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0
@@ -815,7 +803,6 @@ describe('OC.SetupChecks tests', function() {
 					isSettimelimitAvailable: true,
 					hasFreeTypeSupport: false,
 					missingIndexes: [],
-					outdatedCaches: [],
 					cronErrors: [],
 					cronInfo: {
 						diffInSeconds: 0

--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -448,25 +448,6 @@ Raw output
 		return $indexInfo->getListOfMissingIndexes();
 	}
 
-	/**
-	 * warn if outdated version of a memcache module is used
-	 */
-	protected function getOutdatedCaches(): array {
-		$caches = [
-			'apcu'	=> ['name' => 'APCu', 'version' => '4.0.6'],
-			'redis'	=> ['name' => 'Redis', 'version' => '2.2.5'],
-		];
-		$outdatedCaches = [];
-		foreach ($caches as $php_module => $data) {
-			$isOutdated = extension_loaded($php_module) && version_compare(phpversion($php_module), $data['version'], '<');
-			if ($isOutdated) {
-				$outdatedCaches[] = $data;
-			}
-		}
-
-		return $outdatedCaches;
-	}
-
 	protected function isSqliteUsed() {
 		return strpos($this->config->getSystemValue('dbtype'), 'sqlite') !== false;
 	}
@@ -647,7 +628,6 @@ Raw output
 				'isGetenvServerWorking' => !empty(getenv('PATH')),
 				'isReadOnlyConfig' => $this->isReadOnlyConfig(),
 				'hasValidTransactionIsolationLevel' => $this->hasValidTransactionIsolationLevel(),
-				'outdatedCaches' => $this->getOutdatedCaches(),
 				'hasFileinfoInstalled' => $this->hasFileinfoInstalled(),
 				'hasWorkingFileLocking' => $this->hasWorkingFileLocking(),
 				'suggestedOverwriteCliURL' => $this->getSuggestedOverwriteCliURL(),

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -148,7 +148,6 @@ class CheckSetupControllerTest extends TestCase {
 				'hasWorkingFileLocking',
 				'getLastCronInfo',
 				'getSuggestedOverwriteCliURL',
-				'getOutdatedCaches',
 				'getCurlVersion',
 				'isPhpOutdated',
 				'isOpcacheProperlySetup',
@@ -435,9 +434,6 @@ class CheckSetupControllerTest extends TestCase {
 			->method('hasMissingIndexes')
 			->willReturn([]);
 		$this->checkSetupController
-			->method('getOutdatedCaches')
-			->willReturn([]);
-		$this->checkSetupController
 			->method('isSqliteUsed')
 			->willReturn(false);
 		$this->checkSetupController
@@ -504,7 +500,6 @@ class CheckSetupControllerTest extends TestCase {
 				'isGetenvServerWorking' => true,
 				'isReadOnlyConfig' => false,
 				'hasValidTransactionIsolationLevel' => true,
-				'outdatedCaches' => [],
 				'hasFileinfoInstalled' => true,
 				'hasWorkingFileLocking' => true,
 				'suggestedOverwriteCliURL' => '',


### PR DESCRIPTION
There is only a little chance that someone could use such an old version of APCu or Redis with PHP 7.0+

APCu 4.0.6: 2014-06-12
Redis 2.2.5: 2014-03-19

