### PR TITLE
Add caching headers for public previews

### DIFF
--- a/apps/files_sharing/lib/Controller/PublicPreviewController.php
+++ b/apps/files_sharing/lib/Controller/PublicPreviewController.php
@@ -119,7 +119,9 @@ class PublicPreviewController extends PublicShareController {
 			}
 
 			$f = $this->previewManager->getPreview($file, $x, $y, !$a);
-			return new FileDisplayResponse($f, Http::STATUS_OK, ['Content-Type' => $f->getMimeType()]);
+			$response = new FileDisplayResponse($f, Http::STATUS_OK, ['Content-Type' => $f->getMimeType()]);
+			$response->cacheFor(3600 * 24);
+			return $response;
 		} catch (NotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		} catch (\InvalidArgumentException $e) {
@@ -166,7 +168,9 @@ class PublicPreviewController extends PublicShareController {
 			}
 
 			$f = $this->previewManager->getPreview($node, -1, -1, false);
-			return new FileDisplayResponse($f, Http::STATUS_OK, ['Content-Type' => $f->getMimeType()]);
+			$response = new FileDisplayResponse($f, Http::STATUS_OK, ['Content-Type' => $f->getMimeType()]);
+			$response->cacheFor(3600 * 24);
+			return $response;
 		} catch (NotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		} catch (\InvalidArgumentException $e) {

--- a/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
+++ b/apps/files_sharing/tests/Controller/PublicPreviewControllerTest.php
@@ -136,6 +136,7 @@ class PublicPreviewControllerTest extends TestCase {
 
 		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
 		$expected = new FileDisplayResponse($preview, Http::STATUS_OK, ['Content-Type' => 'myMime']);
+		$expected->cacheFor(3600 * 24);
 		$this->assertEquals($expected, $res);
 	}
 
@@ -190,6 +191,7 @@ class PublicPreviewControllerTest extends TestCase {
 
 		$res = $this->controller->getPreview('token', 'file', 10, 10, true);
 		$expected = new FileDisplayResponse($preview, Http::STATUS_OK, ['Content-Type' => 'myMime']);
+		$expected->cacheFor(3600 * 24);
 		$this->assertEquals($expected, $res);
 	}
 }


### PR DESCRIPTION
This adds proper caching headers to public image previews.

Fixes #13290 
