### PR TITLE
Add note for Docker users running console

### DIFF
--- a/console.php
+++ b/console.php
@@ -68,6 +68,7 @@ try {
 		echo "Current user: " . $user['name'] . PHP_EOL;
 		echo "Owner of config.php: " . $configUser['name'] . PHP_EOL;
 		echo "Try adding 'sudo -u " . $configUser['name'] . " ' to the beginning of the command (without the single quotes)" . PHP_EOL;
+		echo "If running with 'docker exec' try adding the option '-u " . $configUser['name'] . "' to the docker command (without the single quotes)" . PHP_EOL;
 		exit(1);
 	}
 


### PR DESCRIPTION
The official Docker container doesn't ship with sudo so the advice given when an admin tries to run the console  with `docker exec -ti nextcloud occ` is difficult to put into action. This note lets them know how to perform an equivalent action.