### PR TITLE
13.0.9 RC 1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(13, 0, 8, 2);
+$OC_Version = array(13, 0, 9, 0);
 
 // The human readable string
-$OC_VersionString = '13.0.8';
+$OC_VersionString = '13.0.9 RC 1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Changelog to 13.0.8 (#12585):

* #12595 Load apps that have a dav type set before the dav server plugins
* #12616 Fix typo in original english string and all translations
* #12818 Fix the system address book
* #12827 PHP module is named mbstring
* #12835 Do not update child all child shares on group share update
* #12864 Only execute query in propagateChange once
* #13125 Fix SAML Client login flow on Apple devices
* #13153 Prevent special characters from breaking the file drop remote url
* #13220 Do not forgot to store the second displayname portion
* #13359 Update the CRL
* [files_pdfviewer#116](https://github.com/nextcloud/files_pdfviewer/pull/116) Fix PDF sidebar shown in PDF thumbnails


Pending PRs:

* [x] #13374 Fix loginflow with apptoken enter on iOS

cc @rullzer @skjnldsv @juliushaertl