### PR TITLE
check anonymous OPTIONS requests file in root (not in subdir)

### DIFF
--- a/apps/dav/lib/Connector/Sabre/AnonymousOptionsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/AnonymousOptionsPlugin.php
@@ -46,11 +46,18 @@ class AnonymousOptionsPlugin extends ServerPlugin {
 	}
 
 	/**
+	 * @return bool
+	 */
+	public function isRequestInRoot($path) {
+		return $path === '' || (is_string($path) && strpos($path, '/') === FALSE);
+	}
+
+	/**
 	 * @throws \Sabre\DAV\Exception\Forbidden
 	 * @return bool
 	 */
 	public function handleAnonymousOptions(RequestInterface $request, ResponseInterface $response) {
-		if ($request->getHeader('Authorization') === null && $request->getMethod() === 'OPTIONS') {
+		if ($request->getHeader('Authorization') === null && $request->getMethod() === 'OPTIONS' && $this->isRequestInRoot($request->getPath())) {
 			/** @var CorePlugin $corePlugin */
 			$corePlugin = $this->server->getPlugin('core');
 			// setup a fake tree for anonymous access

--- a/apps/dav/tests/unit/DAV/AnonymousOptionsTest.php
+++ b/apps/dav/tests/unit/DAV/AnonymousOptionsTest.php
@@ -56,6 +56,12 @@ class AnonymousOptionsTest extends TestCase {
 
 		$this->assertEquals(200, $response->getStatus());
 	}
+
+	public function testAnonymousOptionsNonRootSubDir() {
+		$response = $this->sendRequest('OPTIONS', 'foo/bar');
+
+		$this->assertEquals(401, $response->getStatus());
+	}
 }
 
 class SapiMock extends Sapi {


### PR DESCRIPTION
Don't allow anonymous OPTIONS to sub directories, so we won't send 404's when client is expecting 401 before authenticate.