### PR TITLE
Fix loginflow with apptoken enter on iOS

### DIFF
--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -327,6 +327,18 @@ class ClientFlowLoginController extends Controller {
 		return new Http\RedirectResponse($redirectUri);
 	}
 
+	/**
+	 * @PublicPage
+	 */
+	public function apptokenRedirect(string $stateToken, string $user, string $password) {
+		if (!$this->isValidToken($stateToken)) {
+			return $this->stateTokenForbiddenResponse();
+		}
+
+		$redirectUri = 'nc://login/server:' . $this->getServerPath() . '&user:' . urlencode($user) . '&password:' . urlencode($password);
+		return new Http\RedirectResponse($redirectUri);
+	}
+
 	private function getServerPath(): string {
 		$serverPostfix = '';
 

--- a/core/js/login/authpicker.js
+++ b/core/js/login/authpicker.js
@@ -5,12 +5,4 @@ jQuery(document).ready(function() {
 		$('#redirect-link').addClass('hidden');
 		$('#app-token-login-field').removeClass('hidden');
 	});
-
-	$('#submit-app-token-login').click(function(e) {
-		e.preventDefault();
-		window.location.href = 'nc://login/server:'
-			+ encodeURIComponent($('#serverHost').val())
-			+ "&user:" +  encodeURIComponent($('#user').val())
-			+ "&password:" + encodeURIComponent($('#password').val());
-	});
 });

--- a/core/routes.php
+++ b/core/routes.php
@@ -54,6 +54,7 @@ $application->registerRoutes($this, [
 		['name' => 'ClientFlowLogin#showAuthPickerPage', 'url' => '/login/flow', 'verb' => 'GET'],
 		['name' => 'ClientFlowLogin#generateAppPassword', 'url' => '/login/flow', 'verb' => 'POST'],
 		['name' => 'ClientFlowLogin#grantPage', 'url' => '/login/flow/grant', 'verb' => 'GET'],
+		['name' => 'ClientFlowLogin#apptokenRedirect', 'url' => '/login/flow/apptoken', 'verb' => 'POST'],
 		['name' => 'TwoFactorChallenge#selectChallenge', 'url' => '/login/selectchallenge', 'verb' => 'GET'],
 		['name' => 'TwoFactorChallenge#showChallenge', 'url' => '/login/challenge/{challengeProviderId}', 'verb' => 'GET'],
 		['name' => 'TwoFactorChallenge#solveChallenge', 'url' => '/login/challenge/{challengeProviderId}', 'verb' => 'POST'],

--- a/core/templates/loginflow/authpicker.php
+++ b/core/templates/loginflow/authpicker.php
@@ -44,7 +44,7 @@ $urlGenerator = $_['urlGenerator'];
 		</a>
 	</p>
 
-	<fieldset id="app-token-login-field" class="hidden">
+	<form action="<?php p($urlGenerator->linkToRouteAbsolute('core.ClientFlowLogin.apptokenRedirect')); ?>" method="post" id="app-token-login-field" class="hidden">
 		<p class="grouptop">
 			<input type="text" name="user" id="user" placeholder="<?php p($l->t('Username')) ?>">
 			<label for="user" class="infield"><?php p($l->t('Username')) ?></label>
@@ -53,9 +53,10 @@ $urlGenerator = $_['urlGenerator'];
 			<input type="password" name="password" id="password" placeholder="<?php p($l->t('App token')) ?>">
 			<label for="password" class="infield"><?php p($l->t('Password')) ?></label>
 		</p>
-		<input type="hidden" id="serverHost" value="<?php p($_['serverHost']) ?>" />
+		<input type="hidden" name="stateToken" value="<?php p($_['stateToken']) ?>" />
+		<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>">
 		<input id="submit-app-token-login" type="submit" class="login primary icon-confirm-white" value="<?php p($l->t('Grant access')) ?>">
-	</fieldset>
+	</form>
 </div>
 
 <?php if(empty($_['oauthState'])): ?>


### PR DESCRIPTION
It seems iOS doesn't like us to change the location. So now we submit it
to the server that geneartes the redirect.

So now on iOS devices

1. add your server
2. click on `Alternative log in using app token`
3. enter your username + a generate apptoken
4. click `Grant Access`

Before: Nothing happens
Now: Proper redirect