### PR TITLE
WIP: Make trusted_proxies configuration IPv6 compatible

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "3rdparty"]
 	path = 3rdparty
-	url = https://github.com/nextcloud/3rdparty.git
+	url = https://github.com/johanfleury/3rdparty.git
+	branch = feature/vendor-rlanvin-php-ip


### PR DESCRIPTION
This is based on the 3rdparty library [rlanvin/php-ip](https://github.com/rlanvin/php-ip/). This library
requires installation/activation of the GMP extension.

**Warning: this might break existing installation**.

Requires nextcloud/3rdparty#198.