### PR TITLE
Write checksum to filecache table

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -267,7 +267,7 @@ class File extends Node implements IFile {
 				$checksum = trim($this->request->server['HTTP_OC_CHECKSUM']);
 				$this->fileView->putFileInfo($this->path, ['checksum' => $checksum]);
 				$this->refreshInfo();
-			} else if ($this->getChecksum() !== null && $this->getChecksum() !== '') {
+			} else {
 				$this->fileView->putFileInfo($this->path, ['checksum' => '']);
 				$this->refreshInfo();
 			}
@@ -532,7 +532,7 @@ class File extends Node implements IFile {
 				if (isset($this->request->server['HTTP_OC_CHECKSUM'])) {
 					$checksum = trim($this->request->server['HTTP_OC_CHECKSUM']);
 					$this->fileView->putFileInfo($targetPath, ['checksum' => $checksum]);
-				} else if ($info->getChecksum() !== null && $info->getChecksum() !== '') {
+				} else {
 					$this->fileView->putFileInfo($this->path, ['checksum' => '']);
 				}
 

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -65,6 +65,28 @@ use Sabre\DAV\Exception\ServiceUnavailable;
 use Sabre\DAV\IFile;
 use Sabre\DAV\Exception\NotFound;
 
+class md5sum_filter extends \php_user_filter
+{
+	function onCreate () {
+		$this->params->ctx = hash_init('md5');
+		return TRUE;
+	}
+
+	function onClose () {
+		return TRUE;
+	}
+
+	function filter ($in, $out, &$consumed, $closing)
+	{
+		while ($bucket = stream_bucket_make_writeable($in)) {
+			hash_update($this->params->ctx, $bucket->data);
+			$consumed += $bucket->datalen;
+			stream_bucket_append($out, $bucket);
+		}
+		return PSFS_PASS_ON;
+	}
+}
+
 class File extends Node implements IFile {
 
 	protected $request;
@@ -116,6 +138,11 @@ class File extends Node implements IFile {
 	 * @return string|null
 	 */
 	public function put($data) {
+
+		stream_filter_register('md5sum', 'OCA\\DAV\\Connector\\Sabre\\md5sum_filter');
+		$obj = new \stdClass();
+		$md5_filter = stream_filter_append($data, 'md5sum', STREAM_FILTER_READ, $obj);
+
 		try {
 			$exists = $this->fileView->file_exists($this->path);
 			if ($this->info && $exists && !$this->info->isUpdateable()) {
@@ -261,16 +288,14 @@ class File extends Node implements IFile {
 				$this->emitPostHooks($exists);
 			}
 
-			$this->refreshInfo();
-
+			stream_filter_remove($md5_filter);
 			if (isset($this->request->server['HTTP_OC_CHECKSUM'])) {
 				$checksum = trim($this->request->server['HTTP_OC_CHECKSUM']);
-				$this->fileView->putFileInfo($this->path, ['checksum' => $checksum]);
-				$this->refreshInfo();
 			} else {
-				$this->fileView->putFileInfo($this->path, ['checksum' => '']);
-				$this->refreshInfo();
+				$checksum = hash_final($obj->ctx);
 			}
+			$this->fileView->putFileInfo($this->path, ['checksum' => $checksum]);
+			$this->refreshInfo();
 
 		} catch (StorageNotAvailableException $e) {
 			throw new ServiceUnavailable("Failed to check file size: " . $e->getMessage());

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -268,7 +268,7 @@ class File extends Node implements IFile {
 			} else {
 				$checksum = hash_final($contextObject->hashContext);
 			}
-			$this->fileView->putFileInfo($this->path, ['checksum' => $checksum]);
+			$this->fileView->putFileInfo($this->path, ['checksum' => 'md5:' . $checksum]);
 			$this->refreshInfo();
 
 		} catch (StorageNotAvailableException $e) {

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1074,6 +1074,7 @@ return array(
     'OC\\Share\\Helper' => $baseDir . '/lib/private/Share/Helper.php',
     'OC\\Share\\SearchResultSorter' => $baseDir . '/lib/private/Share/SearchResultSorter.php',
     'OC\\Share\\Share' => $baseDir . '/lib/private/Share/Share.php',
+    'OC\\StreamHashFilter' => $baseDir . '/lib/private/StreamHashFilter.php',
     'OC\\Streamer' => $baseDir . '/lib/private/Streamer.php',
     'OC\\SubAdmin' => $baseDir . '/lib/private/SubAdmin.php',
     'OC\\Support\\CrashReport\\Registry' => $baseDir . '/lib/private/Support/CrashReport/Registry.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1104,6 +1104,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Share\\Helper' => __DIR__ . '/../../..' . '/lib/private/Share/Helper.php',
         'OC\\Share\\SearchResultSorter' => __DIR__ . '/../../..' . '/lib/private/Share/SearchResultSorter.php',
         'OC\\Share\\Share' => __DIR__ . '/../../..' . '/lib/private/Share/Share.php',
+        'OC\\StreamHashFilter' => __DIR__ . '/../../..' . '/lib/private/StreamHashFilter.php',
         'OC\\Streamer' => __DIR__ . '/../../..' . '/lib/private/Streamer.php',
         'OC\\SubAdmin' => __DIR__ . '/../../..' . '/lib/private/SubAdmin.php',
         'OC\\Support\\CrashReport\\Registry' => __DIR__ . '/../../..' . '/lib/private/Support/CrashReport/Registry.php',

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -191,7 +191,7 @@ class Scanner extends BasicEmitter implements IScanner {
 						$cacheData = $this->cache->get($file);
 					}
 					if (($reuseExisting & self::RECALCULATE_CHECKSUM_IF_EMPTY) && empty($cacheData['checksum'])) {
-						$data['checksum'] =  $this->storage->hash('md5', $file);
+						$data['checksum'] =  'md5:' . $this->storage->hash('md5', $file);
 					}
 					if ($cacheData and $reuseExisting and isset($cacheData['fileid'])) {
 						// prevent empty etag

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -190,6 +190,9 @@ class Scanner extends BasicEmitter implements IScanner {
 						/** @var CacheEntry $cacheData */
 						$cacheData = $this->cache->get($file);
 					}
+					if (empty($cacheData) || $cacheData['mtime'] != $data['mtime'] || $cacheData['checksum']==='') {
+						$data['checksum'] =  md5_file($this->storage->getLocalFile($file));
+					}
 					if ($cacheData and $reuseExisting and isset($cacheData['fileid'])) {
 						// prevent empty etag
 						if (empty($cacheData['etag'])) {
@@ -216,8 +219,6 @@ class Scanner extends BasicEmitter implements IScanner {
 						$fileId = -1;
 					}
 					if (!empty($newData)) {
-						// Reset the checksum if the data has changed
-						$newData['checksum'] = '';
 						$data['fileid'] = $this->addToCache($file, $newData, $fileId);
 					}
 					if (isset($cacheData['size'])) {

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -190,8 +190,8 @@ class Scanner extends BasicEmitter implements IScanner {
 						/** @var CacheEntry $cacheData */
 						$cacheData = $this->cache->get($file);
 					}
-					if (empty($cacheData) || $cacheData['mtime'] != $data['mtime'] || $cacheData['checksum']==='') {
-						$data['checksum'] =  md5_file($this->storage->getLocalFile($file));
+					if (($reuseExisting & self::RECALCULATE_CHECKSUM_IF_EMPTY) && empty($cacheData['checksum'])) {
+						$data['checksum'] =  $this->storage->hash('md5', $file);
 					}
 					if ($cacheData and $reuseExisting and isset($cacheData['fileid'])) {
 						// prevent empty etag

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -242,7 +242,7 @@ class Scanner extends PublicEmitter {
 			try {
 				$propagator = $storage->getPropagator();
 				$propagator->beginBatch();
-				$scanner->scan($relativePath, $recursive, \OC\Files\Cache\Scanner::REUSE_ETAG | \OC\Files\Cache\Scanner::REUSE_SIZE);
+				$scanner->scan($relativePath, $recursive, \OC\Files\Cache\Scanner::REUSE_ETAG | \OC\Files\Cache\Scanner::REUSE_SIZE | \OC\Files\Cache\Scanner::RECALCULATE_CHECKSUM_IF_EMPTY);
 				$cache = $storage->getCache();
 				if ($cache instanceof Cache) {
 					// only re-calculate for the root folder we scanned, anything below that is taken care of by the scanner

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1552,6 +1552,9 @@ class View {
 		 */
 		list($storage, $internalPath) = Filesystem::resolvePath($path);
 		if ($storage) {
+			if ($data['checksum'] == '') {
+				$data['checksum'] = md5_file($storage->getLocalFile($internalPath));
+			}
 			$cache = $storage->getCache($path);
 
 			if (!$cache->inCache($internalPath)) {

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -672,7 +672,7 @@ class View {
 					list (, $result) = \OC_Helper::streamCopy($data, $target);
 					fclose($target);
 					fclose($data);
-					$this->putFileInfo($path, ['checksum' => hash_final($contextObject->hashContext)]);
+					$this->putFileInfo($path, ['checksum' => 'md5:' . hash_final($contextObject->hashContext)]);
 
 					$this->writeUpdate($storage, $internalPath);
 
@@ -1560,7 +1560,7 @@ class View {
 		list($storage, $internalPath) = Filesystem::resolvePath($path);
 		if ($storage) {
 			if ($data['checksum'] == '') {
-				$data['checksum'] = $storage->hash('md5', $internalPath);
+				$data['checksum'] = 'md5' . $storage->hash('md5', $internalPath);
 			}
 			$cache = $storage->getCache($path);
 

--- a/lib/private/StreamHashFilter.php
+++ b/lib/private/StreamHashFilter.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @copyright Copyright (c) 2019, Tomasz Grobelny <tomasz@grobelny.net>
+ *
+ * @author Tomasz Grobelny <tomasz@grobelny.net>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC;
+
+class StreamHashFilter extends \php_user_filter
+{
+	static function getContextObject($stream) {
+		stream_filter_register('hash.md5', 'OC\\StreamHashFilter');
+		$obj = new \stdClass();
+		$md5_filter = stream_filter_append($stream, 'hash.md5', STREAM_FILTER_ALL, $obj);
+		return $obj;
+	}
+
+	function onCreate () {
+		$this->params->hashContext = hash_init('md5');
+		return TRUE;
+	}
+
+	function onClose () {
+		return TRUE;
+	}
+
+	function filter ($in, $out, &$consumed, $closing)
+	{
+		while ($bucket = stream_bucket_make_writeable($in)) {
+			hash_update($this->params->hashContext, $bucket->data);
+			$consumed += $bucket->datalen;
+			stream_bucket_append($out, $bucket);
+		}
+		return PSFS_PASS_ON;
+	}
+}

--- a/lib/public/Files/Cache/IScanner.php
+++ b/lib/public/Files/Cache/IScanner.php
@@ -35,6 +35,7 @@ interface IScanner {
 	const REUSE_NONE = 0;
 	const REUSE_ETAG = 1;
 	const REUSE_SIZE = 2;
+	const RECALCULATE_CHECKSUM_IF_EMPTY = 4;
 
 	/**
 	 * scan a single file and store it in the cache


### PR DESCRIPTION
Currently the filecache table contains checksum column but it is empty. This pull request updates value in this column during file modification and using occ files:scan.

Information about file checksum can be used eg. for finding duplicate files.