### PR TITLE
Fix/improve collapsible nav bullet hover

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -393,7 +393,7 @@ kbd {
 			&:before {
 				opacity: 1;
 			}
-			.app-navigation-entry-bullet {
+			> .app-navigation-entry-bullet {
 				background: transparent !important;
 			}
 		}


### PR DESCRIPTION
I made the selector more specific. The transparent should only apply to bullets following a collapsible directly.

Before:
![hover-before](https://user-images.githubusercontent.com/6216686/50741869-b2793300-1203-11e9-9fcb-3c6e36018500.gif)

After:
![hover-after](https://user-images.githubusercontent.com/6216686/50741871-b60cba00-1203-11e9-8786-f27a5097dfea.gif)

closes https://github.com/nextcloud/nextcloud-vue/issues/179