### PR TITLE
improve lookup server behaviour

### DIFF
--- a/apps/lookup_server_connector/lib/BackgroundJobs/RetryJob.php
+++ b/apps/lookup_server_connector/lib/BackgroundJobs/RetryJob.php
@@ -36,8 +36,8 @@ class RetryJob extends Job {
 	private $jobList;
 	/** @var string */
 	private $lookupServer;
-	/** @var int how much time should be between two tries (10 minutes) */
-	private $interval = 600;
+	/** @var int how much time should be between two, will be increased for each retry */
+	private $interval = 100;
 
 	/**
 	 * @param IClientService $clientService
@@ -108,7 +108,9 @@ class RetryJob extends Job {
 	 * @return bool
 	 */
 	protected function shouldRun($argument) {
-		return !isset($argument['lastRun']) || ((time() - $argument['lastRun']) > $this->interval);
+		$retryNo = (int)$argument['retryNo'];
+		$delay = $this->interval * 6 ** $retryNo;
+		return !isset($argument['lastRun']) || ((time() - $argument['lastRun']) > $delay);
 	}
 
 	/**

--- a/apps/lookup_server_connector/lib/UpdateLookupServer.php
+++ b/apps/lookup_server_connector/lib/UpdateLookupServer.php
@@ -46,6 +46,8 @@ class UpdateLookupServer {
 	private $jobList;
 	/** @var string URL point to lookup server */
 	private $lookupServer;
+	/** @var bool  */
+	private $lookupServerEnabled;
 
 	/**
 	 * @param AccountManager $accountManager
@@ -68,6 +70,8 @@ class UpdateLookupServer {
 			return;
 		}
 
+		$this->lookupServerEnabled = $this->config->getAppValue('files_sharing', 'lookupServerUploadEnabled', 'yes') === 'yes';
+
 		$this->lookupServer = $config->getSystemValue('lookup_server', 'https://lookup.nextcloud.com');
 		if(!empty($this->lookupServer)) {
 			$this->lookupServer = rtrim($this->lookupServer, '/');
@@ -79,7 +83,8 @@ class UpdateLookupServer {
 	 * @param IUser $user
 	 */
 	public function userUpdated(IUser $user) {
-		if(empty($this->lookupServer)) {
+
+		if (!$this->shouldUpdateLookupServer()) {
 			return;
 		}
 
@@ -150,4 +155,17 @@ class UpdateLookupServer {
 			);
 		}
 	}
+
+	/**
+	 * check if we should update the lookup server, we only do it if
+	 *
+	 * * we have a valid URL
+	 * * the lookup server update was enabled by the admin
+	 *
+	 * @return bool
+	 */
+	private function shouldUpdateLookupServer() {
+		return $this->lookupServerEnabled || !empty($this->lookupServer);
+	}
+
 }


### PR DESCRIPTION
Don't try to connect to the lookup server if the lookup server was disabled
by the admin or an empty lookup server URL was given

fix https://github.com/nextcloud/server/issues/13396

Additionally we should consider to add a background job which clean existing data from the lookup sever once the admin disabled it, see https://github.com/nextcloud/server/issues/13396#issuecomment-451844152