### PR TITLE
Use the real logger in the settings

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -553,7 +553,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 		$this->registerAlias(\OCP\Support\CrashReport\IRegistry::class, \OC\Support\CrashReport\Registry::class);
 
-		$this->registerService(\OCP\ILogger::class, function (Server $c) {
+		$this->registerService(\OC\Log::class, function (Server $c) {
 			$logType = $c->query('AllConfig')->getSystemValue('log_type', 'file');
 			$factory = new LogFactory($c, $this->getSystemConfig());
 			$logger = $factory->get($logType);
@@ -561,7 +561,8 @@ class Server extends ServerContainer implements IServerContainer {
 
 			return new Log($logger, $this->getSystemConfig(), null, $registry);
 		});
-		$this->registerAlias('Logger', \OCP\ILogger::class);
+		$this->registerAlias(\OCP\ILogger::class, \OC\Log::class);
+		$this->registerAlias('Logger', \OC\Log::class);
 
 		$this->registerService(ILogFactory::class, function (Server $c) {
 			return new LogFactory($c, $this->getSystemConfig());

--- a/settings/Controller/LogSettingsController.php
+++ b/settings/Controller/LogSettingsController.php
@@ -29,7 +29,6 @@ namespace OC\Settings\Controller;
 use OC\Log;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\StreamResponse;
-use OCP\ILogger;
 use OCP\IRequest;
 
 /**
@@ -39,10 +38,10 @@ use OCP\IRequest;
  */
 class LogSettingsController extends Controller {
 
-	/** @var ILogger */
+	/** @var Log */
 	private $log;
 
-	public function __construct(string $appName, IRequest $request, ILogger $logger) {
+	public function __construct(string $appName, IRequest $request, Log $logger) {
 		parent::__construct($appName, $request);
 		$this->log = $logger;
 	}


### PR DESCRIPTION
Fixes #13285
The wrapper logger should not be used here. But we need the real logger.
Since this in internal we can just pass that on directly.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>