### PR TITLE
explicitly close the streams when doing recursive copy

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -470,7 +470,10 @@ class OC_Util {
 						closedir($dir);
 						return;
 					}
-					stream_copy_to_stream($sourceStream, $child->fopen('w'));
+					$targetStream = $child->fopen('w');
+					stream_copy_to_stream($sourceStream, $targetStream);
+					fclose($targetStream);
+					fclose($sourceStream);
 				}
 			}
 		}


### PR DESCRIPTION
I *think* this fixes some of the "Access to undeclared static property: OC\Files\Filesystem::$normalizedPathCache" errors but ran into some unrelated problems when trying to get a reproduce things properly.