### PR TITLE
HttpClient getHeader can return empty string

### DIFF
--- a/lib/private/Http/Client/Response.php
+++ b/lib/private/Http/Client/Response.php
@@ -71,7 +71,13 @@ class Response implements IResponse {
 	 * @return string
 	 */
 	public function getHeader(string $key): string {
-		return $this->response->getHeader($key)[0];
+		$headers = $this->response->getHeader($key);
+
+		if (count($headers) === 0) {
+			return '';
+		}
+
+		return $headers[0];
 	}
 
 	/**


### PR DESCRIPTION
Fixes #11999

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>