### PR TITLE
Switch around syntax of scour command for SVG image optimization

### DIFF
--- a/build/image-optimization.sh
+++ b/build/image-optimization.sh
@@ -7,7 +7,7 @@ jpegoptim --strip-all *.jpg;
 for svg in `ls *.svg`;
 do
     mv $svg $svg.opttmp;
-    scour -i $svg.opttmp -o $svg --create-groups --enable-id-stripping --enable-comment-stripping --shorten-ids --remove-metadata --strip-xml-prolog --no-line-breaks;
+    scour --create-groups --enable-id-stripping --enable-comment-stripping --shorten-ids --remove-metadata --strip-xml-prolog --no-line-breaks  -i $svg.opttmp -o $svg;
 done;
 rm *.opttmp
 for dir in `ls -d */`;


### PR DESCRIPTION
Just a very small adjustment. But I find myself copying this line of the file a lot of times to minify individual SVG files. And that’s much easier with the part that gets changed (the filenames) at the end, as otherwise you have to move the cursor all the way to the beginning with the arrow keys. :)

Please review @nextcloud/designers 