### PR TITLE
Show the repair steps and repair info output in the web for better feedback

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -87,8 +87,10 @@ class FeedBackHandler {
 				$this->eventSource->send('success', (string)$this->l10n->t('[%d / %d]: %s', [$this->progressStateStep, $this->progressStateMax, $this->currentStep]));
 				break;
 			case '\OC\Repair::step':
+				$this->eventSource->send('success', (string)$this->l10n->t('Repair step: ') . $event->getArgument(0));
 				break;
 			case '\OC\Repair::info':
+				$this->eventSource->send('success', (string)$this->l10n->t('Repair info: ') . $event->getArgument(0));
 				break;
 			case '\OC\Repair::warning':
 				$this->eventSource->send('notice', (string)$this->l10n->t('Repair warning: ') . $event->getArgument(0));


### PR DESCRIPTION
I noticed this after a longer running repair step that the web UI showed the output of the previous one. Obviously the steps are only shown shortly, but the can give you an idea what is taking so long.

Should we add this to 15.0.1 because there we introduced the long repair step for the activity table? It's IMO a quite simple fix as well.

Before:
![bildschirmfoto 2019-01-09 um 23 10 09](https://user-images.githubusercontent.com/245432/50931837-16019b80-1464-11e9-989d-bbafd6bd9b17.png)


After:
![bildschirmfoto 2019-01-09 um 23 09 42](https://user-images.githubusercontent.com/245432/50931836-16019b80-1464-11e9-828f-0fad7be62fae.png)