### PR TITLE
don't close input stream when writing in encrypted file

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -1033,7 +1033,6 @@ class Encryption extends Wrapper {
 		// always fall back to fopen
 		$target = $this->fopen($path, 'w');
 		list($count, $result) = \OC_Helper::streamCopy($stream, $target);
-		fclose($stream);
 		fclose($target);
 		return $count;
 	}


### PR DESCRIPTION
This addresses issue #13276. Since Sabre checks if the end of the stream has been reached, when the created file is empty, closing the stream creates an error in that case.
```				$count = $partStorage->writeStream($internalPartPath, $data);
				$result = $count > 0;
				if ($result === false) {
					$result = feof($data);
				}
```
I also don't see, why it would make sense to close that stream that writeStream gets as an parameter, but please tell me if I am missing something.
Please review @nextcloud/encryption 