### PR TITLE
Don't log parameters on user creation in case of error/exception

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -205,7 +205,7 @@ class UsersController extends AUserData {
 	 * @param string $displayName
 	 * @param string $email
 	 * @param array $groups
-	 * @param array $subadmins
+	 * @param array $subadmin
 	 * @param string $quota
 	 * @param string $language
 	 * @return DataResponse

--- a/lib/private/Log/ExceptionSerializer.php
+++ b/lib/private/Log/ExceptionSerializer.php
@@ -37,6 +37,9 @@ class ExceptionSerializer {
 		'{closure}',
 		'createSessionToken',
 
+		// Provisioning
+		'addUser',
+
 		// TokenProvider
 		'getToken',
 		'isTokenPassword',


### PR DESCRIPTION
Method in question:
https://github.com/nextcloud/server/blob/cf266ee00491bc0e70fbbb7dc9720a9e2f8c3708/apps/provisioning_api/lib/Controller/UsersController.php#L199-L221