### PR TITLE
15.0.2

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(15, 0, 1, 2);
+$OC_Version = array(15, 0, 2, 0);
 
 // The human readable string
-$OC_VersionString = '15.0.1';
+$OC_VersionString = '15.0.2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Changelog to 15.0.1 (#13475):

* #13479 Don't log parameters on user creation in case of error/exception
* #13506 RemoveClassifiedEventActivity: check if calendar still exists
* [3rdparty#196](https://github.com/nextcloud/3rdparty/pull/196) Broker: add timezone to CANCEL messages


We need this due to the "check if calendar still exists", which caused issues during upgrade. 