### PR TITLE
14.0.6

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(14, 0, 5, 2);
+$OC_Version = array(14, 0, 6, 0);
 
 // The human readable string
-$OC_VersionString = '14.0.5';
+$OC_VersionString = '14.0.6';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Changelog to 14.0.5 (#13476):

* #13480 Don't log parameters on user creation in case of error/exception
* #13507 RemoveClassifiedEventActivity: check if calendar still exists
* [3rdparty#197](https://github.com/nextcloud/3rdparty/pull/197) Broker: add timezone to CANCEL messages

We need this due to the "check if calendar still exists", which caused issues during upgrade.