### PR TITLE
13.0.10

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(13, 0, 9, 2);
+$OC_Version = array(13, 0, 10, 0);
 
 // The human readable string
-$OC_VersionString = '13.0.9';
+$OC_VersionString = '13.0.10';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Changelog to 13.0.9 (#13477):

* #13508 RemoveClassifiedEventActivity: check if calendar still exists

We need this due to the "check if calendar still exists", which caused issues during upgrade.