### PR TITLE
Publish event for app token create/update/delete

### DIFF
--- a/settings/Activity/Provider.php
+++ b/settings/Activity/Provider.php
@@ -40,6 +40,9 @@ class Provider implements IProvider {
 	const EMAIL_CHANGED_BY = 'email_changed_by';
 	const EMAIL_CHANGED_SELF = 'email_changed_self';
 	const EMAIL_CHANGED = 'email_changed';
+	public const APP_TOKEN_CREATED = 'app_token_created';
+	public const APP_TOKEN_UPDATED = 'app_token_updated';
+	public const APP_TOKEN_DELETED = 'app_token_deleted';
 
 	/** @var IFactory */
 	protected $languageFactory;
@@ -107,6 +110,13 @@ class Provider implements IProvider {
 		} else if ($event->getSubject() === self::EMAIL_CHANGED) {
 			$subject = $this->l->t('Your email address was changed by an administrator');
 
+		} else if ($event->getSubject() === self::APP_TOKEN_CREATED) {
+			$subject = $this->l->t('You created app password "%1$s"', $event->getSubjectParameters());
+		} else if ($event->getSubject() === self::APP_TOKEN_UPDATED) {
+			$subject = $this->l->t('You updated app password "%1$s"', $event->getSubjectParameters());
+		} else if ($event->getSubject() === self::APP_TOKEN_DELETED) {
+			$subject = $this->l->t('You deleted an app token');
+
 		} else {
 			throw new \InvalidArgumentException();
 		}
@@ -131,6 +141,9 @@ class Provider implements IProvider {
 			case self::PASSWORD_RESET:
 			case self::EMAIL_CHANGED_SELF:
 			case self::EMAIL_CHANGED:
+			case self::APP_TOKEN_CREATED:
+			case self::APP_TOKEN_UPDATED:
+			case self::APP_TOKEN_DELETED:
 				return [];
 			case self::PASSWORD_CHANGED_BY:
 			case self::EMAIL_CHANGED_BY:

--- a/settings/Activity/Provider.php
+++ b/settings/Activity/Provider.php
@@ -115,7 +115,7 @@ class Provider implements IProvider {
 		} else if ($event->getSubject() === self::APP_TOKEN_UPDATED) {
 			$subject = $this->l->t('You updated app password "%1$s"', $event->getSubjectParameters());
 		} else if ($event->getSubject() === self::APP_TOKEN_DELETED) {
-			$subject = $this->l->t('You deleted an app token');
+			$subject = $this->l->t('You deleted app password "%1$s"', $event->getSubjectParameters());
 
 		} else {
 			throw new \InvalidArgumentException();

--- a/settings/Activity/Provider.php
+++ b/settings/Activity/Provider.php
@@ -111,11 +111,11 @@ class Provider implements IProvider {
 			$subject = $this->l->t('Your email address was changed by an administrator');
 
 		} else if ($event->getSubject() === self::APP_TOKEN_CREATED) {
-			$subject = $this->l->t('You created app password "%1$s"', $event->getSubjectParameters());
+			$subject = $this->l->t('You created app password "{token}"');
 		} else if ($event->getSubject() === self::APP_TOKEN_UPDATED) {
-			$subject = $this->l->t('You updated app password "%1$s"', $event->getSubjectParameters());
+			$subject = $this->l->t('You updated app password "{token}"');
 		} else if ($event->getSubject() === self::APP_TOKEN_DELETED) {
-			$subject = $this->l->t('You deleted app password "%1$s"', $event->getSubjectParameters());
+			$subject = $this->l->t('You deleted app password "{token}"');
 
 		} else {
 			throw new \InvalidArgumentException();
@@ -141,14 +141,21 @@ class Provider implements IProvider {
 			case self::PASSWORD_RESET:
 			case self::EMAIL_CHANGED_SELF:
 			case self::EMAIL_CHANGED:
-			case self::APP_TOKEN_CREATED:
-			case self::APP_TOKEN_UPDATED:
-			case self::APP_TOKEN_DELETED:
 				return [];
 			case self::PASSWORD_CHANGED_BY:
 			case self::EMAIL_CHANGED_BY:
 				return [
 					'actor' => $this->generateUserParameter($parameters[0]),
+				];
+			case self::APP_TOKEN_CREATED:
+			case self::APP_TOKEN_UPDATED:
+			case self::APP_TOKEN_DELETED:
+				return [
+					'token' => [
+						'type' => 'highlight',
+						'id' => $event->getObjectId(),
+						'name' => $parameters[0],
+					]
 				];
 		}
 

--- a/settings/Activity/Provider.php
+++ b/settings/Activity/Provider.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2017 Joas Schilling <coding@schilljs.com>
  *
@@ -34,12 +35,12 @@ use OCP\L10N\IFactory;
 
 class Provider implements IProvider {
 
-	const PASSWORD_CHANGED_BY = 'password_changed_by';
-	const PASSWORD_CHANGED_SELF = 'password_changed_self';
-	const PASSWORD_RESET = 'password_changed';
-	const EMAIL_CHANGED_BY = 'email_changed_by';
-	const EMAIL_CHANGED_SELF = 'email_changed_self';
-	const EMAIL_CHANGED = 'email_changed';
+	public const PASSWORD_CHANGED_BY = 'password_changed_by';
+	public const PASSWORD_CHANGED_SELF = 'password_changed_self';
+	public const PASSWORD_RESET = 'password_changed';
+	public const EMAIL_CHANGED_BY = 'email_changed_by';
+	public const EMAIL_CHANGED_SELF = 'email_changed_self';
+	public const EMAIL_CHANGED = 'email_changed';
 	public const APP_TOKEN_CREATED = 'app_token_created';
 	public const APP_TOKEN_UPDATED = 'app_token_updated';
 	public const APP_TOKEN_DELETED = 'app_token_deleted';
@@ -62,13 +63,10 @@ class Provider implements IProvider {
 	/** @var string[] cached displayNames - key is the UID and value the displayname */
 	protected $displayNames = [];
 
-	/**
-	 * @param IFactory $languageFactory
-	 * @param IURLGenerator $url
-	 * @param IUserManager $userManager
-	 * @param IManager $activityManager
-	 */
-	public function __construct(IFactory $languageFactory, IURLGenerator $url, IUserManager $userManager, IManager $activityManager) {
+	public function __construct(IFactory $languageFactory,
+								IURLGenerator $url,
+								IUserManager $userManager,
+								IManager $activityManager) {
 		$this->languageFactory = $languageFactory;
 		$this->url = $url;
 		$this->userManager = $userManager;
@@ -83,9 +81,9 @@ class Provider implements IProvider {
 	 * @throws \InvalidArgumentException
 	 * @since 11.0.0
 	 */
-	public function parse($language, IEvent $event, IEvent $previousEvent = null) {
+	public function parse($language, IEvent $event, IEvent $previousEvent = null): IEvent {
 		if ($event->getApp() !== 'settings') {
-			throw new \InvalidArgumentException();
+			throw new \InvalidArgumentException('Unknown app');
 		}
 
 		$this->l = $this->languageFactory->get('settings', $language);
@@ -118,7 +116,7 @@ class Provider implements IProvider {
 			$subject = $this->l->t('You deleted app password "{token}"');
 
 		} else {
-			throw new \InvalidArgumentException();
+			throw new \InvalidArgumentException('Unknown subject');
 		}
 
 		$parsedParameters = $this->getParameters($event);
@@ -132,7 +130,7 @@ class Provider implements IProvider {
 	 * @return array
 	 * @throws \InvalidArgumentException
 	 */
-	protected function getParameters(IEvent $event) {
+	protected function getParameters(IEvent $event): array {
 		$subject = $event->getSubject();
 		$parameters = $event->getSubjectParameters();
 
@@ -159,7 +157,7 @@ class Provider implements IProvider {
 				];
 		}
 
-		throw new \InvalidArgumentException();
+		throw new \InvalidArgumentException('Unknown subject');
 	}
 
 	/**
@@ -168,7 +166,7 @@ class Provider implements IProvider {
 	 * @param array $parameters
 	 * @throws \InvalidArgumentException
 	 */
-	protected function setSubjects(IEvent $event, $subject, array $parameters) {
+	protected function setSubjects(IEvent $event, string $subject, array $parameters): void {
 		$placeholders = $replacements = [];
 		foreach ($parameters as $placeholder => $parameter) {
 			$placeholders[] = '{' . $placeholder . '}';
@@ -179,11 +177,7 @@ class Provider implements IProvider {
 			->setRichSubject($subject, $parameters);
 	}
 
-	/**
-	 * @param string $uid
-	 * @return array
-	 */
-	protected function generateUserParameter($uid) {
+	protected function generateUserParameter(string $uid): array {
 		if (!isset($this->displayNames[$uid])) {
 			$this->displayNames[$uid] = $this->getDisplayName($uid);
 		}
@@ -195,11 +189,7 @@ class Provider implements IProvider {
 		];
 	}
 
-	/**
-	 * @param string $uid
-	 * @return string
-	 */
-	protected function getDisplayName($uid) {
+	protected function getDisplayName(string $uid): string {
 		$user = $this->userManager->get($uid);
 		if ($user instanceof IUser) {
 			return $user->getDisplayName();

--- a/settings/Controller/AuthSettingsController.php
+++ b/settings/Controller/AuthSettingsController.php
@@ -27,16 +27,19 @@
 
 namespace OC\Settings\Controller;
 
+use BadMethodCallException;
 use OC\AppFramework\Http;
 use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
+use OC\Settings\Activity\Provider;
+use OCP\Activity\IManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\ILogger;
 use OCP\IRequest;
 use OCP\ISession;
-use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 
@@ -44,9 +47,6 @@ class AuthSettingsController extends Controller {
 
 	/** @var IProvider */
 	private $tokenProvider;
-
-	/** @var IUserManager */
-	private $userManager;
 
 	/** @var ISession */
 	private $session;
@@ -57,23 +57,37 @@ class AuthSettingsController extends Controller {
 	/** @var ISecureRandom */
 	private $random;
 
+	/** @var IManager */
+	private $activityManager;
+
+	/** @var ILogger */
+	private $logger;
+
 	/**
 	 * @param string $appName
 	 * @param IRequest $request
 	 * @param IProvider $tokenProvider
-	 * @param IUserManager $userManager
 	 * @param ISession $session
 	 * @param ISecureRandom $random
-	 * @param string $userId
+	 * @param string|null $userId
+	 * @param IManager $activityManager
+	 * @param ILogger $logger
 	 */
-	public function __construct($appName, IRequest $request, IProvider $tokenProvider, IUserManager $userManager,
-		ISession $session, ISecureRandom $random, $userId) {
+	public function __construct(string $appName,
+								IRequest $request,
+								IProvider $tokenProvider,
+								ISession $session,
+								ISecureRandom $random,
+								?string $userId,
+								IManager $activityManager,
+								ILogger $logger) {
 		parent::__construct($appName, $request);
 		$this->tokenProvider = $tokenProvider;
-		$this->userManager = $userManager;
 		$this->uid = $userId;
 		$this->session = $session;
 		$this->random = $random;
+		$this->activityManager = $activityManager;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -84,7 +98,7 @@ class AuthSettingsController extends Controller {
 	 */
 	public function index() {
 		$tokens = $this->tokenProvider->getTokenByUser($this->uid);
-		
+
 		try {
 			$sessionId = $this->session->getId();
 		} catch (SessionNotAvailableException $ex) {
@@ -96,7 +110,7 @@ class AuthSettingsController extends Controller {
 			return $this->getServiceNotAvailableResponse();
 		}
 
-		return array_map(function(IToken $token) use ($sessionToken) {
+		return array_map(function (IToken $token) use ($sessionToken) {
 			$data = $token->jsonSerialize();
 			if ($sessionToken->getId() === $token->getId()) {
 				$data['canDelete'] = false;
@@ -140,6 +154,8 @@ class AuthSettingsController extends Controller {
 		$tokenData = $deviceToken->jsonSerialize();
 		$tokenData['canDelete'] = true;
 
+		$this->publishActivity(Provider::APP_TOKEN_CREATED, $deviceToken->getId(), $name);
+
 		return new JSONResponse([
 			'token' => $token,
 			'loginName' => $loginName,
@@ -179,6 +195,7 @@ class AuthSettingsController extends Controller {
 	 */
 	public function destroy($id) {
 		$this->tokenProvider->invalidateTokenById($this->uid, $id);
+		$this->publishActivity(Provider::APP_TOKEN_DELETED, $id);
 		return [];
 	}
 
@@ -204,6 +221,29 @@ class AuthSettingsController extends Controller {
 			'filesystem' => $scope['filesystem']
 		]);
 		$this->tokenProvider->updateToken($token);
+		$this->publishActivity(Provider::APP_TOKEN_UPDATED, $id, $token->getName());
 		return [];
+	}
+
+	/**
+	 * @param string $subject
+	 * @param int $id
+	 * @param string|null $tokenName
+	 */
+	private function publishActivity(string $subject, int $id, ?string $tokenName = null): void {
+		$event = $this->activityManager->generateEvent();
+		$event->setApp('settings')
+			->setType('security')
+			->setAffectedUser($this->uid)
+			->setAuthor($this->uid)
+			->setSubject($subject, [$tokenName])
+			->setObject('app_token', $id, 'App Password');
+
+		try {
+			$this->activityManager->publish($event);
+		} catch (BadMethodCallException $e) {
+			$this->logger->warning('could not publish activity');
+			$this->logger->logException($e);
+		}
 	}
 }

--- a/settings/Controller/AuthSettingsController.php
+++ b/settings/Controller/AuthSettingsController.php
@@ -261,7 +261,7 @@ class AuthSettingsController extends Controller {
 	 * @throws \OC\Authentication\Exceptions\ExpiredTokenException
 	 */
 	private function findTokenByIdAndUser(int $id): IToken {
-		$token = $this->tokenProvider->getTokenById((string)$id);
+		$token = $this->tokenProvider->getTokenById($id);
 		if ($token->getUID() !== $this->uid) {
 			throw new InvalidTokenException('This token does not belong to you!');
 		}

--- a/tests/Settings/Controller/AuthSettingsControllerTest.php
+++ b/tests/Settings/Controller/AuthSettingsControllerTest.php
@@ -28,11 +28,13 @@ use OC\Authentication\Token\DefaultToken;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
 use OC\Settings\Controller\AuthSettingsController;
+use OCP\Activity\IEvent;
+use OCP\Activity\IManager;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\ILogger;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUser;
-use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 use Test\TestCase;
@@ -44,7 +46,6 @@ class AuthSettingsControllerTest extends TestCase {
 	private $request;
 	/** @var IProvider|\PHPUnit_Framework_MockObject_MockObject */
 	private $tokenProvider;
-	private $userManager;
 	private $session;
 	private $secureRandom;
 	private $uid;
@@ -54,13 +55,16 @@ class AuthSettingsControllerTest extends TestCase {
 
 		$this->request = $this->createMock(IRequest::class);
 		$this->tokenProvider = $this->createMock(IProvider::class);
-		$this->userManager = $this->createMock(IUserManager::class);
 		$this->session = $this->createMock(ISession::class);
 		$this->secureRandom = $this->createMock(ISecureRandom::class);
 		$this->uid = 'jane';
-		$this->user = $this->createMock(IUser::class);
 
-		$this->controller = new AuthSettingsController('core', $this->request, $this->tokenProvider, $this->userManager, $this->session, $this->secureRandom, $this->uid);
+		$activityManager = $this->createMock(IManager::class);
+		$activityManager->method('generateEvent')
+			->willReturn($this->createMock(IEvent::class));
+		$logger = $this->createMock(ILogger::class);
+
+		$this->controller = new AuthSettingsController('core', $this->request, $this->tokenProvider, $this->session, $this->secureRandom, $this->uid, $activityManager, $logger);
 	}
 
 	public function testIndex() {

--- a/tests/Settings/Controller/AuthSettingsControllerTest.php
+++ b/tests/Settings/Controller/AuthSettingsControllerTest.php
@@ -34,7 +34,6 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\ILogger;
 use OCP\IRequest;
 use OCP\ISession;
-use OCP\IUser;
 use OCP\Security\ISecureRandom;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 use Test\TestCase;
@@ -43,12 +42,17 @@ class AuthSettingsControllerTest extends TestCase {
 
 	/** @var AuthSettingsController */
 	private $controller;
+	/** @var IRequest|\PHPUnit_Framework_MockObject_MockObject */
 	private $request;
 	/** @var IProvider|\PHPUnit_Framework_MockObject_MockObject */
 	private $tokenProvider;
+	/** @var ISession|\PHPUnit_Framework_MockObject_MockObject */
 	private $session;
+	/** @var ISecureRandom|\PHPUnit_Framework_MockObject_MockObject */
 	private $secureRandom;
-	private $uid;
+	/** @var IManager|\PHPUnit_Framework_MockObject_MockObject */
+	private $activityManager;
+	private $uid = 'jane';
 
 	protected function setUp() {
 		parent::setUp();
@@ -57,14 +61,20 @@ class AuthSettingsControllerTest extends TestCase {
 		$this->tokenProvider = $this->createMock(IProvider::class);
 		$this->session = $this->createMock(ISession::class);
 		$this->secureRandom = $this->createMock(ISecureRandom::class);
-		$this->uid = 'jane';
-
-		$activityManager = $this->createMock(IManager::class);
-		$activityManager->method('generateEvent')
-			->willReturn($this->createMock(IEvent::class));
+		$this->activityManager = $this->createMock(IManager::class);
+		/** @var ILogger|\PHPUnit_Framework_MockObject_MockObject $logger */
 		$logger = $this->createMock(ILogger::class);
 
-		$this->controller = new AuthSettingsController('core', $this->request, $this->tokenProvider, $this->session, $this->secureRandom, $this->uid, $activityManager, $logger);
+		$this->controller = new AuthSettingsController(
+			'core',
+			$this->request,
+			$this->tokenProvider,
+			$this->session,
+			$this->secureRandom,
+			$this->uid,
+			$this->activityManager,
+			$logger
+		);
 	}
 
 	public function testIndex() {
@@ -82,14 +92,14 @@ class AuthSettingsControllerTest extends TestCase {
 		$this->tokenProvider->expects($this->once())
 			->method('getTokenByUser')
 			->with($this->uid)
-			->will($this->returnValue($tokens));
+			->willReturn($tokens);
 		$this->session->expects($this->once())
 			->method('getId')
-			->will($this->returnValue('session123'));
+			->willReturn('session123');
 		$this->tokenProvider->expects($this->once())
 			->method('getToken')
 			->with('session123')
-			->will($this->returnValue($sessionToken));
+			->willReturn($sessionToken);
 
 		$this->assertEquals([
 			[
@@ -120,39 +130,42 @@ class AuthSettingsControllerTest extends TestCase {
 
 		$this->session->expects($this->once())
 			->method('getId')
-			->will($this->returnValue('sessionid'));
+			->willReturn('sessionid');
 		$this->tokenProvider->expects($this->once())
 			->method('getToken')
 			->with('sessionid')
-			->will($this->returnValue($sessionToken));
+			->willReturn($sessionToken);
 		$this->tokenProvider->expects($this->once())
 			->method('getPassword')
 			->with($sessionToken, 'sessionid')
-			->will($this->returnValue($password));
+			->willReturn($password);
 		$sessionToken->expects($this->once())
 			->method('getLoginName')
-			->will($this->returnValue('User13'));
+			->willReturn('User13');
 
 		$this->secureRandom->expects($this->exactly(5))
 			->method('generate')
 			->with(5, ISecureRandom::CHAR_HUMAN_READABLE)
-			->will($this->returnValue('XXXXX'));
+			->willReturn('XXXXX');
 		$newToken = 'XXXXX-XXXXX-XXXXX-XXXXX-XXXXX';
 
 		$this->tokenProvider->expects($this->once())
 			->method('generateToken')
 			->with($newToken, $this->uid, 'User13', $password, $name, IToken::PERMANENT_TOKEN)
-			->will($this->returnValue($deviceToken));
+			->willReturn($deviceToken);
 
 		$deviceToken->expects($this->once())
 			->method('jsonSerialize')
-			->will($this->returnValue(['dummy' => 'dummy', 'canDelete' => true]));
+			->willReturn(['dummy' => 'dummy', 'canDelete' => true]);
+
+		$this->mockActivityManager();
 
 		$expected = [
 			'token' => $newToken,
 			'deviceToken' => ['dummy' => 'dummy', 'canDelete' => true],
 			'loginName' => 'User13',
 		];
+
 		$response = $this->controller->create($name);
 		$this->assertInstanceOf(JSONResponse::class, $response);
 		$this->assertEquals($expected, $response->getData());
@@ -176,7 +189,7 @@ class AuthSettingsControllerTest extends TestCase {
 
 		$this->session->expects($this->once())
 			->method('getId')
-			->will($this->returnValue('sessionid'));
+			->willReturn('sessionid');
 		$this->tokenProvider->expects($this->once())
 			->method('getToken')
 			->with('sessionid')
@@ -189,23 +202,49 @@ class AuthSettingsControllerTest extends TestCase {
 	}
 
 	public function testDestroy() {
-		$id = 123;
-		$user = $this->createMock(IUser::class);
+		$tokenId = 124;
+		$token = $this->createMock(DefaultToken::class);
+
+		$this->mockGetTokenById($tokenId, $token);
+		$this->mockActivityManager();
+
+		$token->expects($this->exactly(2))
+			->method('getId')
+			->willReturn($tokenId);
+
+		$token->expects($this->once())
+			->method('getUID')
+			->willReturn('jane');
 
 		$this->tokenProvider->expects($this->once())
 			->method('invalidateTokenById')
-			->with($this->uid, $id);
+			->with($this->uid, $tokenId);
 
-		$this->assertEquals([], $this->controller->destroy($id));
+		$this->assertEquals([], $this->controller->destroy($tokenId));
 	}
 
-	public function testUpdateToken() {
+	public function testDestroyWrongUser() {
+		$tokenId = 124;
 		$token = $this->createMock(DefaultToken::class);
 
-		$this->tokenProvider->expects($this->once())
-			->method('getTokenById')
-			->with($this->equalTo(42))
-			->willReturn($token);
+		$this->mockGetTokenById($tokenId, $token);
+
+		$token->expects($this->once())
+			->method('getUID')
+			->willReturn('foobar');
+
+		$response = $this->controller->destroy($tokenId);
+		$this->assertSame([], $response->getData());
+		$this->assertSame(\OCP\AppFramework\Http::STATUS_NOT_FOUND, $response->getStatus());
+	}
+
+
+	public function testUpdateToken() {
+		$tokenId = 42;
+		$token = $this->createMock(DefaultToken::class);
+
+		$this->mockGetTokenById($tokenId, $token);
+		$this->mockActivityManager();
 
 		$token->expects($this->once())
 			->method('getUID')
@@ -221,16 +260,14 @@ class AuthSettingsControllerTest extends TestCase {
 			->method('updateToken')
 			->with($this->equalTo($token));
 
-		$this->assertSame([], $this->controller->update(42, ['filesystem' => true]));
+		$this->assertSame([], $this->controller->update($tokenId, ['filesystem' => true]));
 	}
 
 	public function testUpdateTokenWrongUser() {
+		$tokenId = 42;
 		$token = $this->createMock(DefaultToken::class);
 
-		$this->tokenProvider->expects($this->once())
-			->method('getTokenById')
-			->with($this->equalTo(42))
-			->willReturn($token);
+		$this->mockGetTokenById($tokenId, $token);
 
 		$token->expects($this->once())
 			->method('getUID')
@@ -241,7 +278,7 @@ class AuthSettingsControllerTest extends TestCase {
 		$this->tokenProvider->expects($this->never())
 			->method('updateToken');
 
-		$response = $this->controller->update(42, ['filesystem' => true]);
+		$response = $this->controller->update($tokenId, ['filesystem' => true]);
 		$this->assertSame([], $response->getData());
 		$this->assertSame(\OCP\AppFramework\Http::STATUS_NOT_FOUND, $response->getStatus());
 	}
@@ -260,4 +297,22 @@ class AuthSettingsControllerTest extends TestCase {
 		$this->assertSame(\OCP\AppFramework\Http::STATUS_NOT_FOUND, $response->getStatus());
 	}
 
+	private function mockActivityManager(): void {
+		$this->activityManager->expects($this->once())
+			->method('generateEvent')
+			->willReturn($this->createMock(IEvent::class));
+		$this->activityManager->expects($this->once())
+			->method('publish');
+	}
+
+	/**
+	 * @param int $tokenId
+	 * @param $token
+	 */
+	private function mockGetTokenById(int $tokenId, $token): void {
+		$this->tokenProvider->expects($this->once())
+			->method('getTokenById')
+			->with($this->equalTo($tokenId))
+			->willReturn($token);
+	}
 }


### PR DESCRIPTION
Close https://github.com/nextcloud/server/issues/10964

![image](https://user-images.githubusercontent.com/3902676/51428572-6f589000-1c05-11e9-916b-b0ce792afa36.png)

Trigger event for activity app if a user create, update or delete an app token. ~~Unfortunately there is no easy way to inject the app token name.~~

Possible enhancement: Add tokenName as valid definition https://github.com/nextcloud/server/blob/master/lib/public/RichObjectStrings/Definitions.php for subject. (@nickvergessen is there an easier way?)