### PR TITLE
Fix click app names

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -482,7 +482,7 @@ nav[role='navigation'] {
 		a.active {
 			opacity: 1;
 		}
-	
+
 		&:hover a + span,
 		a:focus + span,
 		&:hover span,
@@ -504,7 +504,7 @@ nav[role='navigation'] {
 			width: 20px;
 			height: 20px;
 		}
-	
+
 		/* App title */
 		span {
 			opacity: 0;
@@ -516,6 +516,7 @@ nav[role='navigation'] {
 			overflow: hidden;
 			text-overflow: ellipsis;
 			transition: all var(--animation-quick) ease;
+			pointer-events: none;
 		}
 
 		/* Set up transitions for showing app titles on hover */

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -59,10 +59,10 @@
 									</svg>
 								<div class="icon-loading-small-dark"
 									 style="display:none;"></div>
+								<span>
+									<?php p($entry['name']); ?>
+								</span>
 							</a>
-							<span>
-								<?php p($entry['name']); ?>
-							</span>
 						</li>
 					<?php endforeach; ?>
 					<li id="more-apps" class="menutoggle"


### PR DESCRIPTION
* moves the app name `span` into the `a`
* makes the `span` "click through" by setting pointer events to `none`

Once approved, this one should be backported to 15.

Closes #13519