### PR TITLE
Improve the upload progress bar layout

### DIFF
--- a/apps/files/css/upload.scss
+++ b/apps/files/css/upload.scss
@@ -38,6 +38,9 @@
 	margin-left: 3px;
 }
 #uploadprogressbar {
+	border-color: var(--color-border-dark);
+	border-radius: 18px 0 0 18px;
+	border-right: 0;
 	position:relative;
 	float: left;
 	width: 200px;
@@ -50,15 +53,15 @@
 	}
 }
 #uploadprogressbar .ui-progressbar-value.ui-widget-header.ui-corner-left {
-	height: 100%;
-	top: 0px;
-	left: 0px;
+	height: calc(100% + 2px);
+	top: -1px;
+	left: -1px;
 	position: absolute;
 	overflow: hidden;
 	background-color: var(--color-primary);
 }
 #uploadprogressbar .label {
-	top: 6px;
+	top: 8px;
 	opacity: 1;
 	overflow: hidden;
 	white-space: nowrap;
@@ -81,8 +84,9 @@
 	display: none;
 }
 
-#uploadprogressbar + stop {
-	font-size: 13px;
+#uploadprogressbar + .stop {
+	border-top-left-radius: 0;
+	border-bottom-left-radius: 0;
 }
 
 .oc-dialog .fileexists {


### PR DESCRIPTION
The upload progress bar looked kind of ? unfinished to me:  
![upload-before](https://user-images.githubusercontent.com/6216686/51092838-6480a400-179c-11e9-9433-18581b046d0e.png)

Everything now has the cool round layout. So I updated the progress bar to match that:  
![upload-after](https://user-images.githubusercontent.com/6216686/51092853-94c84280-179c-11e9-90bc-03336795076e.png)

@nextcloud/designers 