### PR TITLE
Fix integer background job id type error

### DIFF
--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -273,7 +273,7 @@ class JobList implements IJobList {
 				}
 			}
 
-			$job->setId($row['id']);
+			$job->setId((int) $row['id']);
 			$job->setLastRun($row['last_run']);
 			$job->setArgument(json_decode($row['argument'], true));
 			return $job;


### PR DESCRIPTION
Fixes
```
{"reqId":"EHhZ5rL76Y4IGKW5rV51","level":3,"time":"2019-01-15T13:35:17+00:00","remoteAddr":"","user":"--","app":"cron","method":"","url":"--","message":{"Exception":"TypeError","Message":"Return value of OCP\\BackgroundJob\\Job::getId() must be of the type int, string returned","Code":0,"Trace":[{"file":"\/home\/christoph\/workspace\/nextcloud\/cron.php","line":118,"function":"getId","class":"OCP\\BackgroundJob\\Job","type":"->","args":[]}],"File":"\/home\/christoph\/workspace\/nextcloud\/lib\/public\/BackgroundJob\/Job.php","Line":117,"CustomMessage":"--"},"userAgent":"--","version":"16.0.0.0"}
```

That fails because of https://github.com/nextcloud/server/blob/99dea46e25bc7ebfb0a739f5599fd4eec9284c6b/lib/public/BackgroundJob/Job.php#L116. I now just assumed they are always int, hence the type cast.
