### PR TITLE
update URL for federation

### DIFF
--- a/apps/federatedfilesharing/lib/Settings/Personal.php
+++ b/apps/federatedfilesharing/lib/Settings/Personal.php
@@ -60,7 +60,7 @@ class Personal implements ISettings {
 	 */
 	public function getForm() {
 		$cloudID = $this->userSession->getUser()->getCloudId();
-		$url = 'https://nextcloud.com/federation#' . $cloudID;
+		$url = 'https://nextcloud.com/sharing#' . $cloudID;
 
 		$parameters = [
 			'outgoingServer2serverShareEnabled' => $this->federatedShareProvider->isOutgoingServer2serverShareEnabled(),


### PR DESCRIPTION
We now have this working on our sharing page:

https://nextcloud.com/sharing/#jospoortvliet@josandcamila.com

vs (new):

https://nextcloud.com/federation/#jospoortvliet@josandcamila.com

Backporting is probably a good idea to.