### PR TITLE
Allow access to addressbook unique uri

### DIFF
--- a/apps/dav/lib/CardDAV/AddressBookImpl.php
+++ b/apps/dav/lib/CardDAV/AddressBookImpl.php
@@ -76,6 +76,15 @@ class AddressBookImpl implements IAddressBook {
 	}
 
 	/**
+	 * @return string defining the unique uri
+	 * @since 16.0.0
+	 * @return string
+	 */
+	public function getUri(): string {
+		return $this->addressBookInfo['uri'];
+	}
+
+	/**
 	 * In comparison to getKey() this function returns a human readable (maybe translated) name
 	 *
 	 * @return mixed

--- a/lib/private/ContactsManager.php
+++ b/lib/private/ContactsManager.php
@@ -119,7 +119,12 @@ namespace OC {
 		}
 
 		/**
+		 * Return a list of the user's addressbooks display names
+		 * ! The addressBook displayName are not unique, please use getUserAddressBooks
+		 * 
 		 * @return array
+		 * @since 6.0.0
+		 * @deprecated 16.0.0 - Use `$this->getUserAddressBooks()` instead
 		 */
 		public function getAddressBooks() {
 			$this->loadAddressBooks();
@@ -129,6 +134,17 @@ namespace OC {
 			}
 
 			return $result;
+		}
+
+		/**
+		 * Return a list of the user's addressbooks
+		 * 
+		 * @return IAddressBook[]
+		 * @since 16.0.0
+		 */
+		public function getUserAddressBooks(): Array {
+			$this->loadAddressBooks();
+			return $this->addressBooks;
 		}
 
 		/**

--- a/lib/public/Contacts/IManager.php
+++ b/lib/public/Contacts/IManager.php
@@ -154,13 +154,25 @@ interface IManager {
 	public function register(\Closure $callable);
 
 	/**
+	 * Return a list of the user's addressbooks display names
+	 * 
 	 * @return array
 	 * @since 6.0.0
+	 * @deprecated 16.0.0 - Use `$this->getUserAddressBooks()` instead
 	 */
 	public function getAddressBooks();
 
 	/**
+	 * Return a list of the user's addressbooks
+	 * 
+	 * @return IAddressBook[]
+	 * @since 16.0.0
+	 */
+	public function getUserAddressBooks();
+
+	/**
 	 * removes all registered address book instances
+	 * 
 	 * @return void
 	 * @since 6.0.0
 	 */

--- a/lib/public/IAddressBook.php
+++ b/lib/public/IAddressBook.php
@@ -46,6 +46,13 @@ namespace OCP {
 		public function getKey();
 
 		/**
+		 * @return string defining the unique uri
+		 * @since 16.0.0
+		 * @return string
+		 */
+		public function getUri(): string;
+
+		/**
 		 * In comparison to getKey() this function returns a human readable (maybe translated) name
 		 * @return mixed
 		 * @since 5.0.0


### PR DESCRIPTION
Because you can have the same contact UID spread accross different addressbooks, we cannot ensure the direct link to a contact (from the contactsmenu) lead to the correct contact. We need to use the uri for that.

This is a first step towards bringing back the direct link to contact feature to a usable state. Next step is on the contacts app.