### PR TITLE
ignore non existing users when retrieving details of group members

### DIFF
--- a/apps/provisioning_api/lib/Controller/GroupsController.php
+++ b/apps/provisioning_api/lib/Controller/GroupsController.php
@@ -203,16 +203,20 @@ class GroupsController extends AUserData {
 			// Extract required number
 			$usersDetails = [];
 			foreach ($users as $user) {
-				/** @var IUser $user */
-				$userId = (string) $user->getUID();
-				$userData = $this->getUserData($userId);
-				// Do not insert empty entry
-				if(!empty($userData)) {
-					$usersDetails[$userId] = $userData;
-				} else {
-					// Logged user does not have permissions to see this user
-					// only showing its id
-					$usersDetails[$userId] = ['id' => $userId];
+				try {
+					/** @var IUser $user */
+					$userId = (string)$user->getUID();
+					$userData = $this->getUserData($userId);
+					// Do not insert empty entry
+					if (!empty($userData)) {
+						$usersDetails[$userId] = $userData;
+					} else {
+						// Logged user does not have permissions to see this user
+						// only showing its id
+						$usersDetails[$userId] = ['id' => $userId];
+					}
+				} catch(OCSNotFoundException $e) {
+					// continue if a users ceased to exist.
 				}
 			}
 			return new DataResponse(['users' => $usersDetails]);


### PR DESCRIPTION
Fixes an exception leading to a 404 return of the user details request on the members of a specified group. Please read https://github.com/nextcloud/server/issues/12991#issuecomment-454877366 for detailed reasonings.

To reproduce
1. Have LDAP configured
2. Have a local group "group1"
3. Add an LDAP user to "group1", and another user (local or ldap does not matter, for comparison "stillExistingUser")
4. Delete the user from LDAP (or change the filter to exclude the user) 
5. Use "occ ldap:check-user" to ensure this user is detected as deleted on LDAP (beware caching)
6. Use the curl call against the provisioning API to get the user details (or go to Users page and click on the group)
7. `curl -H "OCS-APIRequest: true" "http://admin:password@my.dev.nc/ocs/v2.php/cloud/groups/group1/users/details"`
Before:

```xml
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>failure</status>
  <statuscode>404</statuscode>
  <message>Invalid query, please check the syntax. API specifications are here: http://www.freedesktop.org/wiki/Specifications/open-collaboration-services.
</message>
 </meta>
 <data/>
</ocs>
```

After:

```xml
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>ok</status>
  <statuscode>200</statuscode>
  <message>OK</message>
 </meta>
 <data>
  <users>
   <stillExistingUser>
    <enabled>1</enabled>
    <storageLocation>/path/to/data/stillExistingUser</storageLocation>
    <id>stillExistingUser</id>
    <lastLogin>1546614345000</lastLogin>
    <backend>Database</backend>
    <!-- ... -->
   </stillExistingUser>
  </users>
 </data>
</ocs>
```
