### PR TITLE
Fix empty content icons in header on darktheme

### DIFF
--- a/apps/accessibility/css/themedark.scss
+++ b/apps/accessibility/css/themedark.scss
@@ -42,7 +42,8 @@ $color-border-dark: lighten($color-main-background, 14%);
 
 // since svg icons are inverted, revert to white for the header
 .header-right > * {
-	[class^='icon-'], [class*=' icon-'] {
+	>[class^='icon-'],
+	>[class*=' icon-'] {
 		filter: invert(100%);
 	}
 }


### PR DESCRIPTION
### Steps
1. Open notifications dropdown when there are no notifications
2. Open contact search and search for non-existing user

### Before
icons are black/invisible

### After
icons are white/visible