### PR TITLE
Use warning background color & primary text color for setting warnings

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -322,6 +322,8 @@ label.infield {
 	margin-top: 8px;
 	padding: 5px;
 	border-radius: var(--border-radius);
+	color: var(--color-primary-text);
+	background-color: var(--color-warning);
 }
 
 .warning {


### PR DESCRIPTION
Found in https://github.com/nextcloud/user_saml/pull/298

Looks like this:

![bildschirmfoto 2019-01-18 um 12 05 42](https://user-images.githubusercontent.com/245432/51383486-d7ca4300-1b19-11e9-8f54-2486acee803c.png)

The link was not visible by default so I adjusted the warning box to look like in the screenshots. I will open a server PR soon.

@nextcloud/designers I guess we should add such stuff to the dev docs, right?

I would also backport it to stable14 and 15.