### PR TITLE
Issue 12729 postgresql duplicate key value

### DIFF
--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -127,6 +127,9 @@ class Adapter {
 		}
 	}
 
+	/*
+	 * @suppress SqlInjectionChecker
+	 */
 	public function insertIgnoreConflict($table, $input) : int {
 		try {
 			$builder = $this->conn->getQueryBuilder();

--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -127,7 +127,7 @@ class Adapter {
 		}
 	}
 
-	/*
+	/**
 	 * @suppress SqlInjectionChecker
 	 */
 	public function insertIgnoreConflict(string $table,array $values) : int {

--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -130,11 +130,11 @@ class Adapter {
 	/*
 	 * @suppress SqlInjectionChecker
 	 */
-	public function insertIgnoreConflict($table, $input) : int {
+	public function insertIgnoreConflict(string $table,array $values) : int {
 		try {
 			$builder = $this->conn->getQueryBuilder();
 			$builder->insert($table);
-			foreach($input as $key => $value) {
+			foreach($values as $key => $value) {
 				$builder->setValue($key, $builder->createNamedParameter($value));
 			}
 			return $builder->execute();

--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -126,4 +126,17 @@ class Adapter {
 			return 0;
 		}
 	}
+
+	public function insertIgnoreConflict($table, $input) : int {
+		try {
+			$builder = $this->conn->getQueryBuilder();
+			$builder->insert($table);
+			foreach($input as $key => $value) {
+				$builder->setValue($key, $builder->createNamedParameter($value));
+			}
+			return $builder->execute();
+		} catch(UniqueConstraintViolationException $e) {
+			return 0;
+		}
+	}
 }

--- a/lib/private/DB/AdapterPgSql.php
+++ b/lib/private/DB/AdapterPgSql.php
@@ -35,4 +35,16 @@ class AdapterPgSql extends Adapter {
 		$statement = str_ireplace( 'UNIX_TIMESTAMP()', self::UNIX_TIMESTAMP_REPLACEMENT, $statement );
 		return $statement;
 	}
+
+	public function insertIgnoreConflict($table, $input) : int {
+		$builder = $this->conn->getQueryBuilder();
+		$builder->insert($table)
+			->values($input);
+		foreach($input as $key => $value) {
+			$builder->setValue($key, $builder->createNamedParameter($value));
+		}
+		$queryString = $builder->getSQL() . ' ON CONFLICT DO NOTHING';
+		$inserts = array_values($input);
+		return $this->conn->executeUpdate($queryString, $inserts);
+	}
 }

--- a/lib/private/DB/AdapterPgSql.php
+++ b/lib/private/DB/AdapterPgSql.php
@@ -36,7 +36,7 @@ class AdapterPgSql extends Adapter {
 		return $statement;
 	}
 
-	/*
+	/**
 	 * @suppress SqlInjectionChecker
 	 */
 	public function insertIgnoreConflict(string $table,array $values) : int {

--- a/lib/private/DB/AdapterPgSql.php
+++ b/lib/private/DB/AdapterPgSql.php
@@ -36,6 +36,9 @@ class AdapterPgSql extends Adapter {
 		return $statement;
 	}
 
+	/*
+	 * @suppress SqlInjectionChecker
+	 */
 	public function insertIgnoreConflict($table, $input) : int {
 		$builder = $this->conn->getQueryBuilder();
 		$builder->insert($table)

--- a/lib/private/DB/AdapterPgSql.php
+++ b/lib/private/DB/AdapterPgSql.php
@@ -39,15 +39,13 @@ class AdapterPgSql extends Adapter {
 	/*
 	 * @suppress SqlInjectionChecker
 	 */
-	public function insertIgnoreConflict($table, $input) : int {
+	public function insertIgnoreConflict(string $table,array $values) : int {
 		$builder = $this->conn->getQueryBuilder();
-		$builder->insert($table)
-			->values($input);
-		foreach($input as $key => $value) {
+		$builder->insert($table);
+		foreach($values as $key => $value) {
 			$builder->setValue($key, $builder->createNamedParameter($value));
 		}
 		$queryString = $builder->getSQL() . ' ON CONFLICT DO NOTHING';
-		$inserts = array_values($input);
-		return $this->conn->executeUpdate($queryString, $inserts);
+		return $this->conn->executeUpdate($queryString, $builder->getParameters(), $builder->getParameterTypes());
 	}
 }

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -257,6 +257,10 @@ class Connection extends ReconnectWrapper implements IDBConnection {
 		return $this->adapter->insertIfNotExist($table, $input, $compare);
 	}
 
+	public function insertIgnoreConflict($table, $input) : int {
+		return $this->adapter->insertIgnoreConflict($table, $input);
+	}
+
 	private function getType($value) {
 		if (is_bool($value)) {
 			return IQueryBuilder::PARAM_BOOL;

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -257,8 +257,8 @@ class Connection extends ReconnectWrapper implements IDBConnection {
 		return $this->adapter->insertIfNotExist($table, $input, $compare);
 	}
 
-	public function insertIgnoreConflict($table, $input) : int {
-		return $this->adapter->insertIgnoreConflict($table, $input);
+	public function insertIgnoreConflict(string $table, array $values) : int {
+		return $this->adapter->insertIgnoreConflict($table, $values);
 	}
 
 	private function getType($value) {

--- a/lib/private/Lock/DBLockingProvider.php
+++ b/lib/private/Lock/DBLockingProvider.php
@@ -134,17 +134,7 @@ class DBLockingProvider extends AbstractLockingProvider {
 
 	protected function initLockField(string $path, int $lock = 0): int {
 		$expire = $this->getExpireTime();
-
-		try {
-			$builder = $this->connection->getQueryBuilder();
-			return $builder->insert('file_locks')
-				->setValue('key', $builder->createNamedParameter($path))
-				->setValue('lock', $builder->createNamedParameter($lock))
-				->setValue('ttl', $builder->createNamedParameter($expire))
-				->execute();
-		} catch(UniqueConstraintViolationException $e) {
-			return 0;
-		}
+		return $this->connection->insertIgnoreConflict('file_locks', ['key' => $path, 'lock' => $lock, 'ttl' => $expire]);
 	}
 
 	/**

--- a/lib/private/Lock/DBLockingProvider.php
+++ b/lib/private/Lock/DBLockingProvider.php
@@ -131,10 +131,13 @@ class DBLockingProvider extends AbstractLockingProvider {
 	 * @param int $lock
 	 * @return int number of inserted rows
 	 */
-
 	protected function initLockField(string $path, int $lock = 0): int {
 		$expire = $this->getExpireTime();
-		return $this->connection->insertIgnoreConflict('file_locks', ['key' => $path, 'lock' => $lock, 'ttl' => $expire]);
+		return $this->connection->insertIgnoreConflict('file_locks', [
+			'key' => $path,
+			'lock' => $lock,
+			'ttl' => $expire
+		]);
 	}
 
 	/**

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -120,6 +120,20 @@ interface IDBConnection {
 	 */
 	public function insertIfNotExist($table, $input, array $compare = null);
 
+
+	/**
+	 *
+	 * Insert a row if the row does not exist. Eventual conflicts during insert will be ignored.
+	 *
+	 * Implementation is not fully finished and should not be used!
+	 *
+	 * @param string $table The table name (will replace *PREFIX* with the actual prefix)
+	 * @param array $input data that should be inserted into the table  (column name => value)
+	 * @return int number of inserted rows
+	 * @since 17.0.0
+	 */
+	public function insertIgnoreConflict($table, $input) : int;
+
 	/**
 	 * Insert or update a row value
 	 *

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -128,11 +128,11 @@ interface IDBConnection {
 	 * Implementation is not fully finished and should not be used!
 	 *
 	 * @param string $table The table name (will replace *PREFIX* with the actual prefix)
-	 * @param array $input data that should be inserted into the table  (column name => value)
+	 * @param array $values data that should be inserted into the table  (column name => value)
 	 * @return int number of inserted rows
-	 * @since 17.0.0
+	 * @since 16.0.0
 	 */
-	public function insertIgnoreConflict($table, $input) : int;
+	public function insertIgnoreConflict(string $table,array $values) : int;
 
 	/**
 	 * Insert or update a row value


### PR DESCRIPTION
This should fix the 

`ERROR: duplicate key value violates unique constraint "lock_key_index"`

errors filling up the PostgreSQL log. As described by [Issue 12729](https://github.com/nextcloud/server/issues/12729).

I moved the insert statement from the DBLockingProvider.php to the Adapter.php, so that database specific  inserts are possible.