### PR TITLE
Move 2FA settings above devices & sessions

### DIFF
--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -1239,9 +1239,13 @@ table.grid td.date {
 .icon-info {
 	padding: 11px 20px;
 	vertical-align: super;
+	opacity: .5;
 }
 
-#shareAPI h2, #encryptionAPI h2, #mail_general_settings h2 {
+#two-factor-auth h2,
+#shareAPI h2,
+#encryptionAPI h2,
+#mail_general_settings h2 {
 	display: inline-block;
 }
 

--- a/settings/templates/settings/personal/security.php
+++ b/settings/templates/settings/personal/security.php
@@ -63,6 +63,32 @@ if($_['passwordChangeSupported']) {
 </div>
 <?php } ?>
 
+<div id="two-factor-auth" class="section">
+	<h2><?php p($l->t('Two-Factor Authentication'));?></h2>
+	<ul>
+	<?php foreach ($_['twoFactorProviderData']['providers'] as $data) { ?>
+		<li>
+			<?php
+			/** @var \OCP\Authentication\TwoFactorAuth\IProvidesPersonalSettings $provider */
+			$provider = $data['provider'];
+			if ($provider instanceof \OCP\Authentication\TwoFactorAuth\IProvidesIcons) {
+				$icon = $provider->getDarkIcon();
+			} else {
+				$icon = image_path('core', 'actions/password.svg');
+			}
+			/** @var \OCP\Authentication\TwoFactorAuth\IPersonalProviderSettings $settings */
+			$settings = $data['settings'];
+			?>
+			<h3>
+				<img class="two-factor-provider-settings-icon" src="<?php p($icon) ?>" alt="">
+				<?php p($provider->getDisplayName()) ?>
+			</h3>
+			<?php print_unescaped($settings->getBody()->fetchPage()) ?>
+		</li>
+	<?php } ?>
+	</ul>
+</div>
+
 <div id="security" class="section">
 	<h2><?php p($l->t('Devices & sessions'));?></h2>
 	<p class="settings-hint hidden-when-empty"><?php p($l->t('Web, desktop and mobile clients currently logged in to your account.'));?></p>
@@ -98,30 +124,4 @@ if($_['passwordChangeSupported']) {
 			<button id="app-password-hide" class="button"><?php p($l->t('Done')); ?></button>
 		</div>
 	</div>
-</div>
-
-<div id="two-factor-auth" class="section">
-	<h2><?php p($l->t('Two-Factor Authentication'));?></h2>
-	<ul>
-	<?php foreach ($_['twoFactorProviderData']['providers'] as $data) { ?>
-		<li>
-			<?php
-			/** @var \OCP\Authentication\TwoFactorAuth\IProvidesPersonalSettings $provider */
-			$provider = $data['provider'];
-			if ($provider instanceof \OCP\Authentication\TwoFactorAuth\IProvidesIcons) {
-				$icon = $provider->getDarkIcon();
-			} else {
-				$icon = image_path('core', 'actions/password.svg');
-			}
-			/** @var \OCP\Authentication\TwoFactorAuth\IPersonalProviderSettings $settings */
-			$settings = $data['settings'];
-			?>
-			<h3>
-				<img class="two-factor-provider-settings-icon" src="<?php p($icon) ?>" alt="">
-				<?php p($provider->getDisplayName()) ?>
-			</h3>
-			<?php print_unescaped($settings->getBody()->fetchPage()) ?>
-		</li>
-	<?php } ?>
-	</ul>
 </div>

--- a/settings/templates/settings/personal/security.php
+++ b/settings/templates/settings/personal/security.php
@@ -65,6 +65,10 @@ if($_['passwordChangeSupported']) {
 
 <div id="two-factor-auth" class="section">
 	<h2><?php p($l->t('Two-Factor Authentication'));?></h2>
+	<a target="_blank" rel="noreferrer noopener" class="icon-info"
+	   title="<?php p($l->t('Open documentation'));?>"
+	   href="<?php p(link_to_docs('user-2fa')); ?>"></a>
+	<p class="settings-hint"><?php p($l->t('Use a second factor besides your password to increase security for your account.'));?></p>
 	<ul>
 	<?php foreach ($_['twoFactorProviderData']['providers'] as $data) { ?>
 		<li>


### PR DESCRIPTION
Because the list of devices and sessions can be very long:
![personal security settings](https://user-images.githubusercontent.com/925062/51491202-e466c980-1dad-11e9-86c6-e5feb81561df.png)

Hence it should be at the bottom:
![security personal settings new](https://user-images.githubusercontent.com/925062/51491200-e466c980-1dad-11e9-83d3-4fe2ec546f07.png)

Also added a doc link, needs https://github.com/nextcloud/documentation/pull/1185