### PR TITLE
Call proper function when fetching link shares in the breadcrumb view

### DIFF
--- a/apps/files_sharing/js/sharebreadcrumbview.js
+++ b/apps/files_sharing/js/sharebreadcrumbview.js
@@ -84,7 +84,7 @@
 					}
 				}
 
-				if (shareModel.hasLinkShare()) {
+				if (shareModel.hasLinkShares()) {
 					shareTypes.push(OC.Share.SHARE_TYPE_LINK);
 				}
 

--- a/apps/files_sharing/tests/js/sharedbreadcrumviewSpec.js
+++ b/apps/files_sharing/tests/js/sharedbreadcrumviewSpec.js
@@ -194,7 +194,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 
 			var model = sinon.createStubInstance(OC.Share.ShareItemModel);
 			model.getSharesWithCurrentItem = function() { return [] };
-			model.hasLinkShare = function() { return false; };
+			model.hasLinkShares = function() { return false; };
 
 			shareTab.trigger('sharesChanged', model);
 
@@ -227,7 +227,7 @@ describe('OCA.Sharing.ShareBreadCrumbView tests', function() {
 			model.getSharesWithCurrentItem = function() { return [
 				{share_type: OC.Share.SHARE_TYPE_USER}
 			] };
-			model.hasLinkShare = function() { return true; };
+			model.hasLinkShares = function() { return true; };
 
 			shareTab.trigger('sharesChanged', model);
 


### PR DESCRIPTION
Fixes call to undefined method.

> TypeError
> shareModel.hasLinkShare is not a function

Steps to reproduce:
1. Create a folder
2. Go into the folder
3. Click on the share icon in the breadcrumbs

Fixes #13056