### PR TITLE
Honor remember_login_cookie_lifetime

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -225,8 +225,8 @@ $CONFIG = array(
 'allow_user_to_change_display_name' => true,
 
 /**
- * Lifetime of the remember login cookie, which is set when the user clicks
- * the ``remember`` checkbox on the login screen.
+ * Lifetime of the remember login cookie. This should be larger than the
+ * session_lifetime. If it is set to 0 remember me is disabled.
  *
  * Defaults to ``60*60*24*15`` seconds (15 days)
  */

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -329,7 +329,14 @@ class LoginController extends Controller {
 		// TODO: remove password checks from above and let the user session handle failures
 		// requires https://github.com/owncloud/core/pull/24616
 		$this->userSession->completeLogin($loginResult, ['loginName' => $user, 'password' => $password]);
-		$this->userSession->createSessionToken($this->request, $loginResult->getUID(), $user, $password, IToken::REMEMBER);
+
+		$tokenType = IToken::REMEMBER;
+		if ((int)$this->config->getSystemValue('remember_login_cookie_lifetime', 60*60*24*15) === 0) {
+			$remember_login = false;
+			$tokenType = IToken::DO_NOT_REMEMBER;
+		}
+
+		$this->userSession->createSessionToken($this->request, $loginResult->getUID(), $user, $password, $tokenType);
 		$this->userSession->updateTokens($loginResult->getUID(), $password);
 
 		// User has successfully logged in, now remove the password reset link, when it is available

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -449,6 +449,10 @@ class LoginControllerTest extends TestCase {
 		$this->config->expects($this->once())
 			->method('setUserValue')
 			->with('uid', 'core', 'timezone', 'Europe/Berlin');
+		$this->config
+			->method('getSystemValue')
+			->with('remember_login_cookie_lifetime')
+			->willReturn(1234);
 		$this->userSession->expects($this->never())
 			->method('createRememberMeToken');
 
@@ -493,6 +497,10 @@ class LoginControllerTest extends TestCase {
 		$this->config->expects($this->once())
 			->method('deleteUserValue')
 			->with('uid', 'core', 'lostpassword');
+		$this->config
+			->method('getSystemValue')
+			->with('remember_login_cookie_lifetime')
+			->willReturn(1234);
 		$this->userSession->expects($this->once())
 			->method('createRememberMeToken')
 			->with($user);
@@ -553,6 +561,10 @@ class LoginControllerTest extends TestCase {
 			->method('deleteUserValue');
 		$this->userSession->expects($this->never())
 			->method('createRememberMeToken');
+		$this->config
+			->method('getSystemValue')
+			->with('remember_login_cookie_lifetime')
+			->willReturn(1234);
 
 		$expected = new \OCP\AppFramework\Http\RedirectResponse($redirectUrl);
 		$this->assertEquals($expected, $this->loginController->tryLogin('Jane', $password, $originalUrl));
@@ -590,6 +602,10 @@ class LoginControllerTest extends TestCase {
 		$this->config->expects($this->once())
 			->method('deleteUserValue')
 			->with('jane', 'core', 'lostpassword');
+		$this->config
+			->method('getSystemValue')
+			->with('remember_login_cookie_lifetime')
+			->willReturn(1234);
 
 		$expected = new \OCP\AppFramework\Http\RedirectResponse(urldecode($redirectUrl));
 		$this->assertEquals($expected, $this->loginController->tryLogin('Jane', $password, $originalUrl));
@@ -642,6 +658,10 @@ class LoginControllerTest extends TestCase {
 		$this->config->expects($this->once())
 			->method('deleteUserValue')
 			->with('john', 'core', 'lostpassword');
+		$this->config
+			->method('getSystemValue')
+			->with('remember_login_cookie_lifetime')
+			->willReturn(1234);
 		$this->userSession->expects($this->never())
 			->method('createRememberMeToken');
 
@@ -694,6 +714,10 @@ class LoginControllerTest extends TestCase {
 		$this->config->expects($this->once())
 			->method('deleteUserValue')
 			->with('john', 'core', 'lostpassword');
+		$this->config
+			->method('getSystemValue')
+			->with('remember_login_cookie_lifetime')
+			->willReturn(1234);
 		$this->userSession->expects($this->never())
 			->method('createRememberMeToken');
 


### PR DESCRIPTION
If the remember_login_cookie_lifetime is set to 0 this means we do not
want to use remember me at all. In that case we should also not create
a remember me cookie and should create a proper temp token.

Further this specifies that is not 0 the remember me time should always
be larger than the session timeout. Because else the behavior is not
really defined.