### PR TITLE
Allow caching of the logout route

### DIFF
--- a/lib/private/legacy/user.php
+++ b/lib/private/legacy/user.php
@@ -269,12 +269,8 @@ class OC_User {
 			return $backend->getLogoutUrl();
 		}
 
-		$logoutUrl = $urlGenerator->linkToRouteAbsolute(
-			'core.login.logout',
-			[
-				'requesttoken' => \OCP\Util::callRegister(),
-			]
-		);
+		$logoutUrl = $urlGenerator->linkToRouteAbsolute('core.login.logout');
+		$logoutUrl .= '?requesttoken=' . \OCP\Util::callRegister();
 
 		return $logoutUrl;
 	}

--- a/tests/lib/NavigationManagerTest.php
+++ b/tests/lib/NavigationManagerTest.php
@@ -221,15 +221,10 @@ class NavigationManagerTest extends TestCase {
 			return '/apps/test/';
 		});
 		$this->urlGenerator
-		     ->expects($this->once())
-		     ->method('linkToRouteAbsolute')
-		     ->with(
-			     'core.login.logout',
-			     [
-				     'requesttoken' => \OCP\Util::callRegister()
-			     ]
-		     )
-		     ->willReturn('https://example.com/logout');
+			->expects($this->once())
+			->method('linkToRouteAbsolute')
+			->with('core.login.logout')
+			->willReturn('https://example.com/logout');
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())->method('getUID')->willReturn('user001');
 		$this->userSession->expects($this->any())->method('getUser')->willReturn($user);
@@ -275,7 +270,7 @@ class NavigationManagerTest extends TestCase {
 			'logout' => [
 				'id'      => 'logout',
 				'order'   => 99999,
-				'href'    => 'https://example.com/logout',
+				'href'    => 'https://example.com/logout?requesttoken='. \OCP\Util::callRegister(),
 				'icon'    => '/apps/core/img/actions/logout.svg',
 				'name'    => 'Log out',
 				'active'  => false,


### PR DESCRIPTION
It is a bit more general. If the only argument is the requesttoken. So a
get request will work with the CSRF protection. The route will be
generated without the parameters and the request token will be added at
the end.

Before the route could not properly be cached as the request token was
always changing. However now it can be cached saving precious cpu
cycles.

Noticed while looking at https://github.com/nextcloud/server/pull/13712. While https://github.com/nextcloud/server/pull/13712 is a general improvement for route generation this fixes the non caching of this specific route.