### PR TITLE
Reduce text size of text file preview, fix #13720

### DIFF
--- a/lib/private/Preview/TXT.php
+++ b/lib/private/Preview/TXT.php
@@ -60,8 +60,9 @@ class TXT extends Provider {
 
 		$lines = preg_split("/\r\n|\n|\r/", $content);
 
-		$fontSize = $maxX ? (int) ((5 / 32) * $maxX) : 5; //5px
-		$lineSize = ceil($fontSize * 1.25);
+		// Define text size of text file preview
+		$fontSize = $maxX ? (int) ((2 / 32) * $maxX) : 5; //5px
+		$lineSize = ceil($fontSize * 1.5);
 
 		$image = imagecreate($maxX, $maxY);
 		imagecolorallocate($image, 255, 255, 255);


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/13720 by reducing the size to be maximally the text size as in grid view.

Yes it is now smaller in list view, but the thumbnail is also not to read the lines (which were cut off after a few characters before too and not readable) but to get a general feel for which document it is. Now it looks much more balanced.

## Before in list / grid
![text preview size before grid](https://user-images.githubusercontent.com/925062/51606861-599fdf00-1f13-11e9-8d80-ab52d4535b7a.png)
![txt size preview list before](https://user-images.githubusercontent.com/925062/51606863-599fdf00-1f13-11e9-8134-3eb83e89fc9a.png)

## After in list / grid
![text size new](https://user-images.githubusercontent.com/925062/51606865-5a387580-1f13-11e9-8b35-03d7f06ec3dd.png)
![text size new list](https://user-images.githubusercontent.com/925062/51606864-5a387580-1f13-11e9-9fce-9fcea5c45e33.png)

## Comparison of before state of txt (left) to .odt previews (right)
![text size master](https://user-images.githubusercontent.com/925062/51606866-5a387580-1f13-11e9-9829-2c885a8b3f5f.png)


Please review @nextcloud/designers @karlitschek 
