### PR TITLE
Add isTokenLogin argument to post login hook/event

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -413,9 +413,9 @@ class Server extends ServerContainer implements IServerContainer {
 			$userSession->listen('\OC\User', 'preLogin', function ($uid, $password) {
 				\OC_Hook::emit('OC_User', 'pre_login', array('run' => true, 'uid' => $uid, 'password' => $password));
 			});
-			$userSession->listen('\OC\User', 'postLogin', function ($user, $password) {
+			$userSession->listen('\OC\User', 'postLogin', function ($user, $password, $isTokenLogin) {
 				/** @var $user \OC\User\User */
-				\OC_Hook::emit('OC_User', 'post_login', array('run' => true, 'uid' => $user->getUID(), 'password' => $password));
+				\OC_Hook::emit('OC_User', 'post_login', array('run' => true, 'uid' => $user->getUID(), 'password' => $password, 'isTokenLogin' => $isTokenLogin));
 			});
 			$userSession->listen('\OC\User', 'postRememberedLogin', function ($user, $password) {
 				/** @var $user \OC\User\User */

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -360,7 +360,8 @@ class Session implements IUserSession, Emitter {
 		$this->setUser($user);
 		$this->setLoginName($loginDetails['loginName']);
 
-		if(isset($loginDetails['token']) && $loginDetails['token'] instanceof IToken) {
+		$isToken = isset($loginDetails['token']) && $loginDetails['token'] instanceof IToken;
+		if ($isToken) {
 			$this->setToken($loginDetails['token']->getId());
 			$this->lockdownManager->setToken($loginDetails['token']);
 			$firstTimeLogin = false;
@@ -368,7 +369,11 @@ class Session implements IUserSession, Emitter {
 			$this->setToken(null);
 			$firstTimeLogin = $user->updateLastLoginTimestamp();
 		}
-		$this->manager->emit('\OC\User', 'postLogin', [$user, $loginDetails['password']]);
+		$this->manager->emit('\OC\User', 'postLogin', [
+			$user,
+			$loginDetails['password'],
+			$isToken,
+		]);
 		if($this->isLoggedIn()) {
 			$this->prepareUserLogin($firstTimeLogin, $regenerateSessionId);
 			return true;


### PR DESCRIPTION
Otherwise it's impossible to know if the event was triggered by a password or token login. Some apps would like to distinguish that and this makes it possible.

This is an additional parameter that should not break any existing listeners.