### PR TITLE
Show proper default locale

### DIFF
--- a/lib/private/Settings/Personal/PersonalInfo.php
+++ b/lib/private/Settings/Personal/PersonalInfo.php
@@ -227,7 +227,7 @@ class PersonalInfo implements ISettings {
 
 		$uid = $user->getUID();
 
-		$userLocaleString = $this->config->getUserValue($uid, 'core', 'locale', 'en_US');
+		$userLocaleString = $this->config->getUserValue($uid, 'core', 'locale', $this->l10nFactory->findLocale());
 
 		$userLang = $this->config->getUserValue($uid, 'core', 'lang', $this->l10nFactory->findLanguage());
 


### PR DESCRIPTION
* set `'default_locale' => 'sv_SE',` in  `config.php`
* go to personal settings page
* before: `English (US)` is shown in the locale drop down
* after: `Swedish (Sweden)` is shown in the locale drop down