### PR TITLE
Remove .css fileending from accessibility user css route

### DIFF
--- a/apps/accessibility/appinfo/routes.php
+++ b/apps/accessibility/appinfo/routes.php
@@ -23,7 +23,7 @@
 
 return [
 	'routes' => [
-		['name' => 'accessibility#getCss', 'url' => '/css/user-{md5}.css', 'verb' => 'GET'],
+		['name' => 'accessibility#getCss', 'url' => '/css/user-{md5}', 'verb' => 'GET'],
 		['name' => 'accessibility#getJavascript', 'url' => '/js/accessibility', 'verb' => 'GET'],
     ],
     'ocs' => [


### PR DESCRIPTION
This PR removes the file ending for the user css of the accessibility app, otherwise this route returns a 404 due to this rewrite condition

https://github.com/nextcloud/server/blob/14f7b2c46633b7a21656872ebf6d809398a342e4/lib/private/Setup.php#L507

when using `'htaccess.RewriteBase' = '/'`

Fixes https://github.com/nextcloud/server/issues/11884