### PR TITLE
Fix for crashing occ files:scan

### DIFF
--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -522,7 +522,7 @@ class Manager {
 
 		$share = $getShare->fetch();
 		$getShare->closeCursor();
-		if ($result && (int)$share['share_type'] === Share::SHARE_TYPE_USER) {
+		if ($result && (bool)$share !== false && (int)$share['share_type'] === Share::SHARE_TYPE_USER) {
 			try {
 				$this->sendFeedbackToRemote($share['remote'], $share['share_token'], $share['remote_id'], 'decline');
 			} catch (\Exception $e) {


### PR DESCRIPTION
when $share === false then (int)$share['share_type'] will always be equal to (int)0

which results in following crash:

[root@server nextcloud]# sudo -u apache php occ files:scan someuser
The current PHP memory limit is below the recommended value of 512MB.
Starting scan for user 1 out of 1 (someuser)
An unhandled exception has been thrown:
TypeError: Argument 1 passed to OC\OCS\DiscoveryService::discover() must be of the type string, null given, called in /var/www/html/nextcloud/apps/files_sharing/lib/External/Manager.php on line 382 and defined in /var/www/html/nextcloud/lib/private/OCS/DiscoveryService.php:65
Stack trace:
#0 /var/www/html/nextcloud/apps/files_sharing/lib/External/Manager.php(382): OC\OCS\DiscoveryService->discover(NULL, 'FEDERATED_SHARI...')
#1 /var/www/html/nextcloud/apps/files_sharing/lib/External/Manager.php(527): OCA\Files_Sharing\External\Manager->sendFeedbackToRemote(NULL, NULL, NULL, 'decline')
#2 /var/www/html/nextcloud/apps/files_sharing/lib/External/Storage.php(216): OCA\Files_Sharing\External\Manager->removeShare('files/Someth...')
#3 [internal function]: OCA\Files_Sharing\External\Storage->checkStorageAvailability()
#4 /var/www/html/nextcloud/lib/private/Files/Storage/Wrapper/Wrapper.php(505): call_user_func_array(Array, Array)
#5 [internal function]: OC\Files\Storage\Wrapper\Wrapper->__call('checkStorageAva...', Array)
#6 /var/www/html/nextcloud/lib/private/Files/Storage/Wrapper/Wrapper.php(505): call_user_func_array(Array, Array)
#7 /var/www/html/nextcloud/apps/files_sharing/lib/External/Scanner.php(89): OC\Files\Storage\Wrapper\Wrapper->__call('checkStorageAva...', Array)
#8 /var/www/html/nextcloud/apps/files_sharing/lib/External/Scanner.php(44): OCA\Files_Sharing\External\Scanner->scanAll()
#9 /var/www/html/nextcloud/lib/private/Files/Utils/Scanner.php(245): OCA\Files_Sharing\External\Scanner->scan('', true, 3)
#10 /var/www/html/nextcloud/apps/files/lib/Command/Scan.php(172): OC\Files\Utils\Scanner->scan('/someuser', true, NULL)
#11 /var/www/html/nextcloud/apps/files/lib/Command/Scan.php(249): OCA\Files\Command\Scan->scanFiles('someuser', '/someuser', false, Object(Symfony\Component\Console\Output\ConsoleOutput), false, true, false)
#12 /var/www/html/nextcloud/3rdparty/symfony/console/Command/Command.php(251): OCA\Files\Command\Scan->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#13 /var/www/html/nextcloud/core/Command/Base.php(162): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#14 /var/www/html/nextcloud/3rdparty/symfony/console/Application.php(946): OC\Core\Command\Base->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#15 /var/www/html/nextcloud/3rdparty/symfony/console/Application.php(248): Symfony\Component\Console\Application->doRunCommand(Object(OCA\Files\Command\Scan), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#16 /var/www/html/nextcloud/3rdparty/symfony/console/Application.php(148): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#17 /var/www/html/nextcloud/lib/private/Console/Application.php(213): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#18 /var/www/html/nextcloud/console.php(96): OC\Console\Application->run()
#19 /var/www/html/nextcloud/occ(11): require_once('/var/www/html/n...')
#20 {main}[root@server nextcloud]#