### PR TITLE
Fix for high contrast theme

### DIFF
--- a/apps/accessibility/css/themehighcontrast.scss
+++ b/apps/accessibility/css/themehighcontrast.scss
@@ -18,6 +18,8 @@ $color-border: darken($color-main-background, 50%);
 $color-border-dark: darken($color-main-background, 50%);
 
 [class^='icon-'], [class*=' icon-'],
-.action {
+.action,
+#appmenu li a,
+.menutoggle {
 	opacity: 1 !important;
 }

--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -941,9 +941,9 @@ span.version {
 
 .section {
 	margin-bottom: 0;
-	/* use 2nd child since app-navigation-toggle is the first */
-	&:not(:nth-child(2)) {
-		border-top: 1px solid var(--color-border);
+	/* section divider lines, none needed for last one */
+	&:not(:last-child) {
+		border-bottom: 1px solid var(--color-border);
 	}
 
 	/* correctly display help icons next to headings */


### PR DESCRIPTION
High contrast theme before. Note:
- The header icons are not full opacity, only the contacts menu icon.
- There is a dark line visible below the triangle of the user menu (top right), just a cosmetic issue but now fixed.

![high contrast theme before](https://user-images.githubusercontent.com/925062/51699683-a962d100-200d-11e9-87fa-629fb8e33152.png)

After:
![high contrast theme after](https://user-images.githubusercontent.com/925062/51699684-a962d100-200d-11e9-8c9c-2873fcced32b.png)


Please check @nextcloud/designers @nextcloud/accessibility :heart: 