### PR TITLE
Unify the HTML encoding handling with other ROS apps

### DIFF
--- a/apps/comments/lib/Activity/Provider.php
+++ b/apps/comments/lib/Activity/Provider.php
@@ -204,7 +204,6 @@ class Provider implements IProvider {
 		try {
 			$comment = $this->commentsManager->get((string) $commentId);
 			$message = $comment->getMessage();
-			$message = str_replace(['<', '>', "\n"], ['&lt;', '&gt;', '<br />'], $message);
 
 			$mentionCount = 1;
 			$mentions = [];

--- a/lib/public/Activity/IEvent.php
+++ b/lib/public/Activity/IEvent.php
@@ -100,6 +100,17 @@ interface IEvent {
 	public function setSubject(string $subject, array $parameters = []): self;
 
 	/**
+	 * Set a parsed subject
+	 *
+	 * HTML is not allowed in the parsed subject and will be escaped
+	 * automatically by the clients. You can use the RichObjectString system
+	 * provided by the Nextcloud server to highlight important parameters via
+	 * the setRichSubject method, but make sure, that a plain text message is
+	 * always set via setParsedSubject, to support clients which can not handle
+	 * rich strings.
+	 *
+	 * See https://github.com/nextcloud/server/issues/1706 for more information.
+	 *
 	 * @param string $subject
 	 * @return $this
 	 * @throws \InvalidArgumentException if the subject is invalid
@@ -114,6 +125,16 @@ interface IEvent {
 	public function getParsedSubject(): string;
 
 	/**
+	 * Set a RichObjectString subject
+	 *
+	 * HTML is not allowed in the rich subject and will be escaped automatically
+	 * by the clients, but you can use the RichObjectString system provided by
+	 * the Nextcloud server to highlight important parameters.
+	 * Also make sure, that a plain text subject is always set via
+	 * setParsedSubject, to support clients which can not handle rich strings.
+	 *
+	 * See https://github.com/nextcloud/server/issues/1706 for more information.
+	 *
 	 * @param string $subject
 	 * @param array $parameters
 	 * @return $this
@@ -146,6 +167,17 @@ interface IEvent {
 	public function setMessage(string $message, array $parameters = []): self;
 
 	/**
+	 * Set a parsed message
+	 *
+	 * HTML is not allowed in the parsed message and will be escaped
+	 * automatically by the clients. You can use the RichObjectString system
+	 * provided by the Nextcloud server to highlight important parameters via
+	 * the setRichMessage method, but make sure, that a plain text message is
+	 * always set via setParsedMessage, to support clients which can not handle
+	 * rich strings.
+	 *
+	 * See https://github.com/nextcloud/server/issues/1706 for more information.
+	 *
 	 * @param string $message
 	 * @return $this
 	 * @throws \InvalidArgumentException if the message is invalid
@@ -160,6 +192,16 @@ interface IEvent {
 	public function getParsedMessage(): string;
 
 	/**
+	 * Set a RichObjectString message
+	 *
+	 * HTML is not allowed in the rich message and will be escaped automatically
+	 * by the clients, but you can use the RichObjectString system provided by
+	 * the Nextcloud server to highlight important parameters.
+	 * Also make sure, that a plain text message is always set via
+	 * setParsedMessage, to support clients which can not handle rich strings.
+	 *
+	 * See https://github.com/nextcloud/server/issues/1706 for more information.
+	 *
 	 * @param string $message
 	 * @param array $parameters
 	 * @return $this

--- a/lib/public/Notification/INotification.php
+++ b/lib/public/Notification/INotification.php
@@ -115,6 +115,17 @@ interface INotification {
 	public function getSubjectParameters();
 
 	/**
+	 * Set a parsed subject
+	 *
+	 * HTML is not allowed in the parsed subject and will be escaped
+	 * automatically by the clients. You can use the RichObjectString system
+	 * provided by the Nextcloud server to highlight important parameters via
+	 * the setRichSubject method, but make sure, that a plain text message is
+	 * always set via setParsedSubject, to support clients which can not handle
+	 * rich strings.
+	 *
+	 * See https://github.com/nextcloud/server/issues/1706 for more information.
+	 *
 	 * @param string $subject
 	 * @return $this
 	 * @throws \InvalidArgumentException if the subject is invalid
@@ -129,6 +140,16 @@ interface INotification {
 	public function getParsedSubject();
 
 	/**
+	 * Set a RichObjectString subject
+	 *
+	 * HTML is not allowed in the rich subject and will be escaped automatically
+	 * by the clients, but you can use the RichObjectString system provided by
+	 * the Nextcloud server to highlight important parameters.
+	 * Also make sure, that a plain text subject is always set via
+	 * setParsedSubject, to support clients which can not handle rich strings.
+	 *
+	 * See https://github.com/nextcloud/server/issues/1706 for more information.
+	 *
 	 * @param string $subject
 	 * @param array $parameters
 	 * @return $this
@@ -171,6 +192,17 @@ interface INotification {
 	public function getMessageParameters();
 
 	/**
+	 * Set a parsed message
+	 *
+	 * HTML is not allowed in the parsed message and will be escaped
+	 * automatically by the clients. You can use the RichObjectString system
+	 * provided by the Nextcloud server to highlight important parameters via
+	 * the setRichMessage method, but make sure, that a plain text message is
+	 * always set via setParsedMessage, to support clients which can not handle
+	 * rich strings.
+	 *
+	 * See https://github.com/nextcloud/server/issues/1706 for more information.
+	 *
 	 * @param string $message
 	 * @return $this
 	 * @throws \InvalidArgumentException if the message is invalid
@@ -185,6 +217,16 @@ interface INotification {
 	public function getParsedMessage();
 
 	/**
+	 * Set a RichObjectString message
+	 *
+	 * HTML is not allowed in the rich message and will be escaped automatically
+	 * by the clients, but you can use the RichObjectString system provided by
+	 * the Nextcloud server to highlight important parameters.
+	 * Also make sure, that a plain text message is always set via
+	 * setParsedMessage, to support clients which can not handle rich strings.
+	 *
+	 * See https://github.com/nextcloud/server/issues/1706 for more information.
+	 *
 	 * @param string $message
 	 * @param array $parameters
 	 * @return $this


### PR DESCRIPTION
While looking into https://github.com/nextcloud/android/issues/3487 I noticed, that the apps which use the most famous RichObjectStrings (Activity and Notifications) have an inconsistent handling in terms of HTML encoding. Or to phrase it better, neither cared and it worked for most, because the providing app happened to escape the HTML (sometimes).

So now we simply define, that ROS should not be HTML escaped, similar to their plain-text variants. Instead the viewing part is responsible to escape the HTML properly, which was provided before the ROS rendering happens.

### :warning: The rendering PRs below need to be merged/backported before, otherwise we create a stored XSS in the comments app. :warning: 

- [x] https://github.com/nextcloud/notifications/pull/261
- [x] https://github.com/nextcloud/activity/pull/343

I checked all apps, and I only could find HTML handling in comments (for activities only, notifications are fine) and announcementcenter (both fixed for upcoming)

---

Client devs please confirm that this works as intended on your side then:
- [x] Desktop: @camilasan 
- [x] Android: @tobiasKaminsky @AndyScherzinger 
- [x] iOS: @marinofaggiana 

You can test this, by mentioning your user `@test1` in a comment:
```
@test1 <strong>this should not be bold</strong>
This is on a new line

<em>And this is two lines away and NOT italic</em>
```