### PR TITLE
Fix positioning of confirm button in user management fields

### DIFF
--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -1517,12 +1517,20 @@ doesnotexist:-o-prefocus, .strengthify-wrapper {
 				> input:focus, >input:active {
 					+ .icon-confirm {
 						display: block !important;
+						position: absolute;
+						right: 0;
+						border: none;
+						background-color: transparent !important;
 					}
 				}
 				/* inputs like mail, username, password */
 				&:not(.userActions) > input:not([type='submit']) {
 					width: 100%;
 					min-width: 0;
+					&:focus,
+					&:active {
+						padding-right: 30px;
+					}
 				}
 				&.name {
 					word-break: break-all;


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/13651 reported by @nickvergessen 

The icon/button needs to be absolutely positioned on top of the input field (like we do usually) so this doesn’t happen:

> ![bildschirmfoto von 2019-01-17 14-48-18](https://user-images.githubusercontent.com/213943/51322923-12bf6e80-1a67-11e9-9b00-42223cfd04f0.png)

Fixed:
![user management confirm icon fix](https://user-images.githubusercontent.com/925062/51749359-6eb17500-20af-11e9-83fe-db1117e1ae50.png)


Please review @nextcloud/designers  :)