### PR TITLE
Fix S3 handling

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -165,7 +165,7 @@ class File extends Node implements IFile {
 				$this->changeLock(ILockingProvider::LOCK_EXCLUSIVE);
 			}
 
-			if ($partStorage->instanceOfStorage(Storage\IWriteStreamStorage::class)) {
+			if (false && $partStorage->instanceOfStorage(Storage\IWriteStreamStorage::class)) {
 				$count = $partStorage->writeStream($internalPartPath, $data);
 				$result = $count > 0;
 				if ($result === false) {


### PR DESCRIPTION
Fixes #13062

S3 requires seekable streams to calculate the SHA256 checksum. Since the
assembly stream (from the chunking) isn't seekable we have to find a way
around this.

For now this just disables the use of writing a stream directly until we
have a better fix.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>