### PR TITLE
Add ico as avatar

### DIFF
--- a/apps/dav/lib/CardDAV/PhotoCache.php
+++ b/apps/dav/lib/CardDAV/PhotoCache.php
@@ -40,7 +40,7 @@ class PhotoCache {
 		'image/png' => 'png',
 		'image/jpeg' => 'jpg',
 		'image/gif' => 'gif',
-		'application/octet-stream' => 'ico',
+		'image/vnd.microsoft.icon' => 'ico',
 	];
 
 	/** @var IAppData */


### PR DESCRIPTION
Add ico as avatar

> This error is logged for all contacts that have a photo stored that is neither a png nor jpeg nor a gif. Only those 3 types are handled in PhotoCache.php, for other file types the variable ext is not set.

https://github.com/nextcloud/server/issues/11852#issuecomment-457676042

I have noticed that for every contact a file `photo.` is created if not `png|jpeg|gif`. Do you think we need some repair step to find and delete these files `photo.`?

Introduced a single point of truth for `init`, `getExtension` and `getPhoto`. They use `ALLOWED_CONTENT_TYPES` to check if type is allowed and which extension is expected. If content type not allowed a `nophoto` file is created (before: `photo.`)

cc @m-i-k-e-y