### PR TITLE
Bugfix for issue 10862: Trash-bin ignores trashbin_retention_obligation

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -680,11 +680,10 @@ class Trashbin {
 		// calculate available space for trash bin
 		// subtract size of files and current trash bin size from quota
 		if ($softQuota) {
-			$userFolder = \OC::$server->getUserFolder($user);
-			if(is_null($userFolder)) {
-				return 0;
-			}
-			$free = $quota - $userFolder->getSize(); // remaining free space for user
+			$files_view = new View('/' . $user . '/files');
+			$rootInfo = $files_view->getFileInfo('/', false);
+			$free = $quota - $rootInfo['size']; // remaining free space for user
+
 			if ($free > 0) {
 				$availableSpace = ($free * self::DEFAULTMAXSIZE / 100) - $trashbinSize; // how much space can be used for versions
 			} else {


### PR DESCRIPTION
Fix for https://github.com/nextcloud/server/issues/10862

The method used by Trashbin.php to calculate used space included external storage, while the quota doesn't include external storage. This led to `$free` space always being way too small (or negative), leading trashbin to purge all deleted files.

The calculation for used space, free space and quota was replaced by the version used by the Versions app:
https://github.com/nextcloud/server/blob/4adac445dc57d1ccc7f26e21018e1e731e5b1654/apps/files_versions/lib/Storage.php#L756-L758

@GAS85
@MorrisJobke 
@danielkesselberg 