### PR TITLE
Check app path for enableAppForGroups

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -254,15 +254,16 @@ class AppManager implements IAppManager {
 	 *
 	 * @param string $appId
 	 * @param \OCP\IGroup[] $groups
-	 * @throws \Exception if app can't be enabled for groups
+	 * @throws \InvalidArgumentException if app can't be enabled for groups
+	 * @throws AppPathNotFoundException
 	 */
 	public function enableAppForGroups($appId, $groups) {
+		// Check if app exists
+		$this->getAppPath($appId);
+
 		$info = $this->getAppInfo($appId);
-		if (!empty($info['types'])) {
-			$protectedTypes = array_intersect($this->protectedAppTypes, $info['types']);
-			if (!empty($protectedTypes)) {
-				throw new \Exception("$appId can't be enabled for groups.");
-			}
+		if (!empty($info['types']) && $this->hasProtectedAppType($info['types'])) {
+			throw new \InvalidArgumentException("$appId can't be enabled for groups.");
 		}
 
 		$groupIds = array_map(function ($group) {

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -149,7 +149,23 @@ class AppManagerTest extends TestCase {
 			new Group('group2', array(), null)
 		);
 		$this->expectClearCache();
-		$this->manager->enableAppForGroups('test', $groups);
+
+		/** @var AppManager|\PHPUnit_Framework_MockObject_MockObject $manager */
+		$manager = $this->getMockBuilder(AppManager::class)
+			->setConstructorArgs([
+				$this->userSession, $this->appConfig, $this->groupManager, $this->cacheFactory, $this->eventDispatcher
+			])
+			->setMethods([
+				'getAppPath',
+			])
+			->getMock();
+
+		$manager->expects($this->exactly(2))
+			->method('getAppPath')
+			->with('test')
+			->willReturn('apps/test');
+
+		$manager->enableAppForGroups('test', $groups);
 		$this->assertEquals('["group1","group2"]', $this->appConfig->getValue('test', 'enabled', 'no'));
 	}
 
@@ -183,9 +199,15 @@ class AppManagerTest extends TestCase {
 				$this->userSession, $this->appConfig, $this->groupManager, $this->cacheFactory, $this->eventDispatcher
 			])
 			->setMethods([
-				'getAppInfo'
+				'getAppPath',
+				'getAppInfo',
 			])
 			->getMock();
+
+		$manager->expects($this->once())
+			->method('getAppPath')
+			->with('test')
+			->willReturn(null);
 
 		$manager->expects($this->once())
 			->method('getAppInfo')
@@ -226,9 +248,15 @@ class AppManagerTest extends TestCase {
 				$this->userSession, $this->appConfig, $this->groupManager, $this->cacheFactory, $this->eventDispatcher
 			])
 			->setMethods([
-				'getAppInfo'
+				'getAppPath',
+				'getAppInfo',
 			])
 			->getMock();
+
+		$manager->expects($this->once())
+			->method('getAppPath')
+			->with('test')
+			->willReturn(null);
 
 		$manager->expects($this->once())
 			->method('getAppInfo')


### PR DESCRIPTION
https://github.com/nextcloud/server/blob/c09ddf6c78cfd29de739d7b639700dab8b15707e/lib/private/App/AppManager.php#L225-L227

If you call `enableApp` there is a check if the app exist (e.g. a folder with that name is there).
For `enableAppForGroups` there is no such check.

Replace the check if app can enabled for groups with `hasProtectedAppType` (afaics it does the same).