### PR TITLE
Throttle getstoragestats.php calls and allow simultaneous uploads

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -845,7 +845,8 @@ OC.Uploader.prototype = _.extend({
 				type: 'PUT',
 				dropZone: options.dropZone, // restrict dropZone to content div
 				autoUpload: false,
-				sequentialUploads: true,
+				sequentialUploads: false,
+				limitConcurrentUploads: 10,
 				//singleFileUploads is on by default, so the data.files array will always have length 1
 				/**
 				 * on first add of every selection

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -33,6 +33,9 @@
 		},
 		// update quota
 		updateStorageQuotas: function() {
+			Files._updateStorageQuotasThrottled();
+		},
+		_updateStorageQuotas: function() {
 			var state = Files.updateStorageQuotas;
 			state.call = $.getJSON(OC.filePath('files','ajax','getstoragestats.php'),function(response) {
 				Files.updateQuota(response);
@@ -356,6 +359,7 @@
 	};
 
 	Files._updateStorageStatisticsDebounced = _.debounce(Files._updateStorageStatistics, 250);
+	Files._updateStorageQuotasThrottled = _.throttle(Files._updateStorageQuotas, 30000);
 	OCA.Files.Files = Files;
 })();
 


### PR DESCRIPTION
Improves speed on https://github.com/nextcloud/server/issues/13854 and https://github.com/nextcloud/server/issues/13696. Does not address reliability in any way.