### PR TITLE
fix paged search with multiple bases (LDAP)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1087,7 +1087,7 @@ services:
       matrix:
         TESTS: acceptance
   openldap:
-    image: nextcloudci/openldap:openldap-5
+    image: nextcloudci/openldap:openldap-6
     environment:
       - SLAPD_DOMAIN=nextcloud.ci
       - SLAPD_ORGANIZATION=Nextcloud

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -975,7 +975,11 @@ class Access extends LDAPUtility {
 	 * Executes an LDAP search
 	 */
 	public function searchUsers($filter, $attr = null, $limit = null, $offset = null) {
-		return $this->search($filter, $this->connection->ldapBaseUsers, $attr, $limit, $offset);
+		$result = [];
+		foreach($this->connection->ldapBaseUsers as $base) {
+			$result = array_merge($result, $this->search($filter, [$base], $attr, $limit, $offset));
+		}
+		return $result;
 	}
 
 	/**
@@ -986,7 +990,12 @@ class Access extends LDAPUtility {
 	 * @return false|int
 	 */
 	public function countUsers($filter, $attr = array('dn'), $limit = null, $offset = null) {
-		return $this->count($filter, $this->connection->ldapBaseUsers, $attr, $limit, $offset);
+		$result = false;
+		foreach($this->connection->ldapBaseUsers as $base) {
+			$count = $this->count($filter, [$base], $attr, $limit, $offset);
+			$result = is_int($count) ? (int)$result + $count : $result;
+		}
+		return $result;
 	}
 
 	/**
@@ -1000,7 +1009,11 @@ class Access extends LDAPUtility {
 	 * Executes an LDAP search
 	 */
 	public function searchGroups($filter, $attr = null, $limit = null, $offset = null) {
-		return $this->search($filter, $this->connection->ldapBaseGroups, $attr, $limit, $offset);
+		$result = [];
+		foreach($this->connection->ldapBaseGroups as $base) {
+			$result = array_merge($result, $this->search($filter, [$base], $attr, $limit, $offset));
+		}
+		return $result;
 	}
 
 	/**
@@ -1012,7 +1025,12 @@ class Access extends LDAPUtility {
 	 * @return int|bool
 	 */
 	public function countGroups($filter, $attr = array('dn'), $limit = null, $offset = null) {
-		return $this->count($filter, $this->connection->ldapBaseGroups, $attr, $limit, $offset);
+		$result = false;
+		foreach($this->connection->ldapBaseGroups as $base) {
+			$count = $this->count($filter, [$base], $attr, $limit, $offset);
+			$result = is_int($count) ? (int)$result + $count : $result;
+		}
+		return $result;
 	}
 
 	/**
@@ -1023,7 +1041,12 @@ class Access extends LDAPUtility {
 	 * @return int|bool
 	 */
 	public function countObjects($limit = null, $offset = null) {
-		return $this->count('objectclass=*', $this->connection->ldapBase, array('dn'), $limit, $offset);
+		$result = false;
+		foreach($this->connection->ldapBase as $base) {
+			$count = $this->count('objectclass=*', [$base], ['dn'], $limit, $offset);
+			$result = is_int($count) ? (int)$result + $count : $result;
+		}
+		return $result;
 	}
 
 	/**

--- a/build/integration/ldap_features/ldap-openldap.feature
+++ b/build/integration/ldap_features/ldap-openldap.feature
@@ -24,7 +24,7 @@ Feature: LDAP
     And Sending a "GET" to "/remote.php/webdav/welcome.txt" with requesttoken
     Then the HTTP status code should be "200"
 
-  Scenario: Test valid configuration with LDAP protoccol and port by logging in
+  Scenario: Test valid configuration with LDAP protocol and port by logging in
     Given modify LDAP configuration
       | ldapHost | ldap://openldap:389 |
     And cookies are reset

--- a/build/integration/ldap_features/openldap-uid-username.feature
+++ b/build/integration/ldap_features/openldap-uid-username.feature
@@ -86,3 +86,25 @@ Feature: LDAP
       | juliana |
       | leo     |
       | stigur  |
+
+  Scenario: Fetch from second batch of all users, invoking pagination with two bases
+    Given modify LDAP configuration
+      | ldapBaseUsers  | ou=PagingTest,dc=nextcloud,dc=ci;ou=PagingTestSecondBase,dc=nextcloud,dc=ci |
+      | ldapPagingSize | 2                                |
+    And As an "admin"
+    And sending "GET" to "/cloud/users?limit=10&offset=2"
+    Then the OCS status code should be "200"
+    And the "users" result should contain "5" of
+      | ebba    |
+      | eindis  |
+      | fjolnir |
+      | gunna   |
+      | juliana |
+      | leo     |
+      | stigur  |
+    And the "users" result should contain "3" of
+      | allisha   |
+      | dogukan   |
+      | lloyd     |
+      | priscilla |
+      | shannah   |


### PR DESCRIPTION
* [x] Integration test
* [x] actual fix
* [ ] ~~refactor (not to backport)~~ will do as seperate PR, less mess

There are a couple concepts in LDAP around the search. On is that parallel searches in multiple bases are allowed. The other one are paged searches, that allows to browse through the directory. Alas, they are incompatible to each other. Since we do paged results by default (if present, which in 99% is), we leave the parallel search asside. This PR goes the quick way with so it is easy to backport. A follow up PR will follow to refactor functions for 16.

Included is an integration test (commit 2) that establishes the failing scenario, commit 3 contains the simple, backportable fix.
