### PR TITLE
Clean pending 2FA authentication on password reset

### DIFF
--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -31,6 +31,7 @@ use function array_diff;
 use function array_filter;
 use BadMethodCallException;
 use Exception;
+use OC\Authentication\Exceptions\ExpiredTokenException;
 use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\IProvider as TokenProvider;
 use OCP\Activity\IManager;
@@ -362,6 +363,14 @@ class Manager {
 		$id = $this->session->getId();
 		$token = $this->tokenProvider->getToken($id);
 		$this->config->setUserValue($user->getUID(), 'login_token_2fa', $token->getId(), $this->timeFactory->getTime());
+	}
+
+	public function clearTwoFactorPending(string $userId) {
+		$tokensNeeding2FA = $this->config->getUserKeys($userId, 'login_token_2fa');
+
+		foreach ($tokensNeeding2FA as $tokenId) {
+			$this->tokenProvider->invalidateTokenById($userId, $tokenId);
+		}
 	}
 
 }

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -21,6 +21,7 @@
 
 namespace Tests\Core\Controller;
 
+use OC\Authentication\TwoFactorAuth\Manager;
 use OC\Core\Controller\LostController;
 use OC\Mail\Message;
 use OCP\AppFramework\Http\JSONResponse;
@@ -77,6 +78,8 @@ class LostControllerTest extends \Test\TestCase {
 	private $crypto;
 	/** @var ILogger|\PHPUnit_Framework_MockObject_MockObject */
 	private $logger;
+	/** @var Manager|\PHPUnit_Framework_MockObject_MockObject */
+	private $twofactorManager;
 
 	protected function setUp() {
 		parent::setUp();
@@ -128,6 +131,7 @@ class LostControllerTest extends \Test\TestCase {
 			->willReturn(true);
 		$this->crypto = $this->createMock(ICrypto::class);
 		$this->logger = $this->createMock(ILogger::class);
+		$this->twofactorManager = $this->createMock(Manager::class);
 		$this->lostController = new LostController(
 			'Core',
 			$this->request,
@@ -142,7 +146,8 @@ class LostControllerTest extends \Test\TestCase {
 			$this->mailer,
 			$this->timeFactory,
 			$this->crypto,
-			$this->logger
+			$this->logger,
+			$this->twofactorManager
 		);
 	}
 


### PR DESCRIPTION
When a password is reste we should make sure that all users are properly
logged in. Pending states should be cleared. For example a session where
the 2FA code is not entered yet should be cleared.

The token is now removed so the session will be killed the next time
this is checked (within 5 minutes).

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>