### PR TITLE
dav: Fix handling of chunked WebDAV upload

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -188,7 +188,9 @@ class File extends Node implements IFile {
 				if (isset($_SERVER['CONTENT_LENGTH'])) {
 					$expected = $_SERVER['CONTENT_LENGTH'];
 				}
-				throw new Exception('Error while copying file to target location (copied bytes: ' . $count . ', expected filesize: ' . $expected . ' )');
+				if ($expected !== "0") {
+					throw new Exception('Error while copying file to target location (copied bytes: ' . $count . ', expected filesize: ' . $expected . ' )');
+				}
 			}
 
 			// if content length is sent by client:


### PR DESCRIPTION
When `$data` is null (which can happen when `$request->getBodyAsStream()` returns `null`), the Exceptions says "copied bytes: 0, expected filesize: 0", which sounds more like success... So treat it as such!

This regression (it worked in Nextcloud 14) was probably introduced by commit 93de63777e4a519484ad8f50f7a8ee809697c20a

The setup resulting in this situation was a Canon iR-ADV C5030 uploading its scans via WebDAV to an SFTP external storage. Here is the error that resulted in an HTTP Error 500 being returned:

#### Nextcloud log (data/nextcloud.log)
<details>
<summary>Nextcloud log</summary>

```json
{
  "reqId": "AQ84OEsk9APcLfSPb4tu",
  "level": 4,
  "time": "2019-01-28T12:36:20+00:00",
  "remoteAddr": "<redacted>",
  "user": "<redacted>",
  "app": "webdav",
  "method": "PUT",
  "url": "/remote.php/webdav/<redacted>",
  "message": {
    "Exception": "Sabre\\DAV\\Exception",
    "Message": "Error while copying file to target location (copied bytes: 0, expected filesize: 0 )",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/vhosts/<redacted>/httpdocs/apps/dav/lib/Connector/Sabre/Directory.php",
        "line": 156,
        "function": "put",
        "class": "OCA\\DAV\\Connector\\Sabre\\File",
        "type": "->",
        "args": [
          null
        ]
      },
      {
        "file": "/var/www/vhosts/<redacted>/httpdocs/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 1096,
        "function": "createFile",
        "class": "OCA\\DAV\\Connector\\Sabre\\Directory",
        "type": "->",
        "args": [
          "20190128125733.pdf",
          null
        ]
      },
      {
        "file": "/var/www/vhosts/<redacted>/httpdocs/3rdparty/sabre/dav/lib/DAV/CorePlugin.php",
        "line": 525,
        "function": "createFile",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          "NAS/20190128125733.pdf",
          null,
          null
        ]
      },
      {
        "function": "httpPut",
        "class": "Sabre\\DAV\\CorePlugin",
        "type": "->",
        "args": [
          {
            "absoluteUrl": "https://<redacted>:443/remote.php/webdav/<redacted>",
            "__class__": "Sabre\\HTTP\\Request"
          },
          {
            "__class__": "Sabre\\HTTP\\Response"
          }
        ]
      },
      {
        "file": "/var/www/vhosts/<redacted>/httpdocs/3rdparty/sabre/event/lib/EventEmitterTrait.php",
        "line": 105,
        "function": "call_user_func_array",
        "args": [
          [
            {
              "__class__": "Sabre\\DAV\\CorePlugin"
            },
            "httpPut"
          ],
          [
            {
              "absoluteUrl": "https://<redacted>:443/remote.php/webdav/<redacted>",
              "__class__": "Sabre\\HTTP\\Request"
            },
            {
              "__class__": "Sabre\\HTTP\\Response"
            }
          ]
        ]
      },
      {
        "file": "/var/www/vhosts/<redacted>/httpdocs/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 479,
        "function": "emit",
        "class": "Sabre\\Event\\EventEmitter",
        "type": "->",
        "args": [
          "method:PUT",
          [
            {
              "absoluteUrl": "https://<redacted>:443/remote.php/webdav/<redacted>",
              "__class__": "Sabre\\HTTP\\Request"
            },
            {
              "__class__": "Sabre\\HTTP\\Response"
            }
          ]
        ]
      },
      {
        "file": "/var/www/vhosts/<redacted>/httpdocs/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 254,
        "function": "invokeMethod",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          {
            "absoluteUrl": "https://<redacted>:443/remote.php/webdav/<redacted>",
            "__class__": "Sabre\\HTTP\\Request"
          },
          {
            "__class__": "Sabre\\HTTP\\Response"
          }
        ]
      },
      {
        "file": "/var/www/vhosts/<redacted>/httpdocs/apps/dav/appinfo/v1/webdav.php",
        "line": 80,
        "function": "exec",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/vhosts/<redacted>/httpdocs/remote.php",
        "line": 163,
        "args": [
          "/var/www/vhosts/<redacted>/httpdocs/apps/dav/appinfo/v1/webdav.php"
        ],
        "function": "require_once"
      }
    ],
    "File": "/var/www/vhosts/<redacted>/httpdocs/apps/dav/lib/Connector/Sabre/File.php",
    "Line": 191,
    "CustomMessage": "--"
  },
  "userAgent": "UniversalSend_WebDAV/1.0",
  "version": "15.0.2.0"
}
```
</details>