### PR TITLE
Fix dropping a folder on a folder row

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -523,7 +523,9 @@ OC.Uploader.prototype = _.extend({
 				self.filesClient.createDirectory(fullPath).always(function(status) {
 					// 405 is expected if the folder already exists
 					if ((status >= 200 && status < 300) || status === 405) {
-						self.trigger('createdfolder', fullPath);
+						if (status !== 405) {
+							self.trigger('createdfolder', fullPath);
+						}
 						deferred.resolve();
 						return;
 					}


### PR DESCRIPTION
Fixes #11180

When the uploaded files have a relative path (that is, when a folder is uploaded) [it is first ensured that all the parent folders exist](https://github.com/nextcloud/server/blob/f99ce0d546c8332bb46807eed21fcdf7d5d0ab71/apps/files/js/file-upload.js#L197-L200), which is done by [trying to create them](https://github.com/nextcloud/server/blob/f99ce0d546c8332bb46807eed21fcdf7d5d0ab71/apps/files/js/file-upload.js#L523). When a folder is created in the currently opened folder [the file list is updated and a row for the new folder is added](https://github.com/nextcloud/server/blob/5742ec79ab28d618e54fece89f8659a4f574eee8/apps/files/js/filelist.js#L3361). However, this was done too when the folder already existed, which caused [the previous row to be removed and a new one added to replace it](https://github.com/nextcloud/server/blob/5742ec79ab28d618e54fece89f8659a4f574eee8/apps/files/js/filelist.js#L2788-L2789).

For security reasons, some special headers need to be set in requests; this is done automatically for jQuery [by handling the `ajaxSend` event in the document](https://github.com/nextcloud/server/blob/cd90685af13d3fa14b3bd15aa5e6d4ddeee84eb3/core/js/oc-requesttoken.js#L1). In the case of DAV requests, [if the headers are not set the server rejects the request with "CSRF check not passed"](https://github.com/nextcloud/server/blob/0efd29f41f924f2b48ef4dc87b8420401db49746/apps/dav/lib/Connector/Sabre/Auth.php#L221).

When a file or folder is dropped on a folder row the jQuery upload events are chained from the initial drop event, which has the row as its target. In order to upload the file jQuery performs a request, which triggers the `ajaxSend` event in the row; this event then bubbles up to the document, which is then handled by adding the special headers to the request (hopefully you do not mind that I have spared you the links to jQuery's guts; I have been there, it behaves as I have explained :-P ).

However, when a folder was dropped on a folder row that folder row was removed when ensuring that the folder exists. The jQuery upload events were still triggered on the row, but as it had been removed it had no parent nodes, and thus the events did not bubble up. Due to this the `ajaxSend` event never reached the document when triggered on the removed row, the headers were not set, and the upload failed.

All this is _simply_ fixed by not removing the folder row when trying to create it if it existed already.

I have also noticed some issues with the _Uploading N files_ text shown in a folder row, but that is something for another pull request.
