### PR TITLE
Allow provider to returns indexeable documents by chunks

### DIFF
--- a/lib/public/FullTextSearch/IFullTextSearchProvider.php
+++ b/lib/public/FullTextSearch/IFullTextSearchProvider.php
@@ -164,6 +164,24 @@ interface IFullTextSearchProvider {
 
 
 	/**
+	 * Allow the provider to generate a list of chunk to split a huge list of
+	 * indexable documents
+	 *
+	 * During the indexing the generateIndexableDocuments method will be called
+	 * for each entry of the returned array.
+	 * If the returned array is empty, the generateIndexableDocuments() will be
+	 * called only once (per user).
+	 *
+	 * @since 16.0.0
+	 * 
+	 * @param string $userId
+	 *
+	 * @return array
+	 */
+	public function generateChunks(string $userId): array;
+
+
+	/**
 	 * Returns all indexable document for a user as an array of IndexDocument.
 	 *
 	 * There is no need to fill each IndexDocument with content; at this point,
@@ -178,13 +196,14 @@ interface IFullTextSearchProvider {
 	 *
 	 * @see IndexDocument
 	 *
-	 * @since 15.0.0
+	 * @since 16.0.0
 	 *
 	 * @param string $userId
+	 * @param string $chunk
 	 *
 	 * @return IndexDocument[]
 	 */
-	public function generateIndexableDocuments(string $userId): array;
+	public function generateIndexableDocuments(string $userId, string $chunk = ''): array;
 
 
 	/**

--- a/lib/public/FullTextSearch/IFullTextSearchProvider.php
+++ b/lib/public/FullTextSearch/IFullTextSearchProvider.php
@@ -176,7 +176,7 @@ interface IFullTextSearchProvider {
 	 *
 	 * @param string $userId
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function generateChunks(string $userId): array;
 
@@ -196,7 +196,8 @@ interface IFullTextSearchProvider {
 	 *
 	 * @see IndexDocument
 	 *
-	 * @since 16.0.0
+	 * @since 15.0.0
+	 *  -> 16.0.0: the parameter "$chunk" was added
 	 *
 	 * @param string $userId
 	 * @param string $chunk

--- a/lib/public/FullTextSearch/IFullTextSearchProvider.php
+++ b/lib/public/FullTextSearch/IFullTextSearchProvider.php
@@ -173,7 +173,7 @@ interface IFullTextSearchProvider {
 	 * called only once (per user).
 	 *
 	 * @since 16.0.0
-	 * 
+	 *
 	 * @param string $userId
 	 *
 	 * @return array
@@ -203,7 +203,7 @@ interface IFullTextSearchProvider {
 	 *
 	 * @return IndexDocument[]
 	 */
-	public function generateIndexableDocuments(string $userId, string $chunk = ''): array;
+	public function generateIndexableDocuments(string $userId, string $chunk): array;
 
 
 	/**


### PR DESCRIPTION
The idea is to give the possibility to a FullTextSearch Content Provider to generate an array that will be used during the indexing process by the FullTextSearch app.

Instead of requesting all document at once (for a user), the FullTextSearch app will request a list of documents for each entry of the 'chunks' array