### PR TITLE
Emit event to load additionalscripts

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -419,6 +419,7 @@ return array(
     'OC\\AppFramework\\Http\\Output' => $baseDir . '/lib/private/AppFramework/Http/Output.php',
     'OC\\AppFramework\\Http\\Request' => $baseDir . '/lib/private/AppFramework/Http/Request.php',
     'OC\\AppFramework\\Logger' => $baseDir . '/lib/private/AppFramework/Logger.php',
+    'OC\\AppFramework\\Middleware\\AdditionalScriptsMiddleware' => $baseDir . '/lib/private/AppFramework/Middleware/AdditionalScriptsMiddleware.php',
     'OC\\AppFramework\\Middleware\\MiddlewareDispatcher' => $baseDir . '/lib/private/AppFramework/Middleware/MiddlewareDispatcher.php',
     'OC\\AppFramework\\Middleware\\OCSMiddleware' => $baseDir . '/lib/private/AppFramework/Middleware/OCSMiddleware.php',
     'OC\\AppFramework\\Middleware\\PublicShare\\Exceptions\\NeedAuthenticationException' => $baseDir . '/lib/private/AppFramework/Middleware/PublicShare/Exceptions/NeedAuthenticationException.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -449,6 +449,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\AppFramework\\Http\\Output' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Http/Output.php',
         'OC\\AppFramework\\Http\\Request' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Http/Request.php',
         'OC\\AppFramework\\Logger' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Logger.php',
+        'OC\\AppFramework\\Middleware\\AdditionalScriptsMiddleware' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Middleware/AdditionalScriptsMiddleware.php',
         'OC\\AppFramework\\Middleware\\MiddlewareDispatcher' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Middleware/MiddlewareDispatcher.php',
         'OC\\AppFramework\\Middleware\\OCSMiddleware' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Middleware/OCSMiddleware.php',
         'OC\\AppFramework\\Middleware\\PublicShare\\Exceptions\\NeedAuthenticationException' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Middleware/PublicShare/Exceptions/NeedAuthenticationException.php',

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -261,6 +261,9 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 					$c->query(\OCP\IConfig::class)
 				)
 			);
+			$dispatcher->registerMiddleware(
+				$c->query(\OC\AppFramework\Middleware\AdditionalScriptsMiddleware::class)
+			);
 
 			foreach($this->middleWares as $middleWare) {
 				$dispatcher->registerMiddleware($c[$middleWare]);

--- a/lib/private/AppFramework/Middleware/AdditionalScriptsMiddleware.php
+++ b/lib/private/AppFramework/Middleware/AdditionalScriptsMiddleware.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\AppFramework\Middleware;
+
+use OCP\AppFramework\Http\Response;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Middleware;
+use OCP\IUserSession;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class AdditionalScriptsMiddleware extends Middleware {
+	/** @var EventDispatcherInterface */
+	private $dispatcher;
+	/** @var IUserSession */
+	private $userSession;
+
+	public function __construct(EventDispatcherInterface $dispatcher, IUserSession $userSession) {
+		$this->dispatcher = $dispatcher;
+		$this->userSession = $userSession;
+	}
+
+	public function afterController($controller, $methodName, Response $response): Response {
+		if ($response instanceof TemplateResponse) {
+			$this->dispatcher->dispatch(TemplateResponse::EVENT_LOAD_ADDITIONAL_SCRIPTS);
+
+			if ($this->userSession->isLoggedIn()) {
+				$this->dispatcher->dispatch(TemplateResponse::EVENT_LOAD_ADDITIONAL_SCRIPTS_LOGGEDIN);
+			}
+		}
+
+		return $response;
+	}
+
+}

--- a/lib/public/AppFramework/Http/TemplateResponse.php
+++ b/lib/public/AppFramework/Http/TemplateResponse.php
@@ -37,6 +37,9 @@ namespace OCP\AppFramework\Http;
  */
 class TemplateResponse extends Response {
 
+	const EVENT_LOAD_ADDITIONAL_SCRIPTS = self::class . '::loadAdditionalScripts';
+	const EVENT_LOAD_ADDITIONAL_SCRIPTS_LOGGEDIN = self::class . '::loadAdditionalScriptsLoggedIn';
+
 	/**
 	 * name of the template
 	 * @var string

--- a/tests/lib/AppFramework/Middleware/AdditionalScriptsMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/AdditionalScriptsMiddlewareTest.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Test\AppFramework\Middleware;
+
+use OC\AppFramework\Middleware\AdditionalScriptsMiddleware;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Response;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class AdditionalScriptsMiddlewareTest extends \Test\TestCase {
+
+	/** @var EventDispatcherInterface|MockObject */
+	private $dispatcher;
+	/** @var IUserSession|MockObject */
+	private $userSession;
+
+	/** @var Controller */
+	private $controller;
+
+	/** @var AdditionalScriptsMiddleware */
+	private $middleWare;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->dispatcher = $this->createMock(EventDispatcherInterface::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->middleWare = new AdditionalScriptsMiddleware(
+			$this->dispatcher,
+			$this->userSession
+		);
+
+		$this->controller = $this->createMock(Controller::class);
+	}
+
+	public function testNoTemplateResponse() {
+		$this->dispatcher->expects($this->never())
+			->method($this->anything());
+		$this->userSession->expects($this->never())
+			->method($this->anything());
+
+		$this->middleWare->afterController($this->controller, 'myMethod', $this->createMock(Response::class));
+	}
+
+	public function testTemplateResponseNotLoggedIn() {
+		$this->dispatcher->expects($this->once())
+			->method('dispatch')
+			->willReturnCallback(function($eventName) {
+				if ($eventName === TemplateResponse::EVENT_LOAD_ADDITIONAL_SCRIPTS) {
+					return;
+				}
+
+				$this->fail('Wrong event dispatched');
+			});
+		$this->userSession->method('isLoggedIn')
+			->willReturn(false);
+
+		$this->middleWare->afterController($this->controller, 'myMethod', $this->createMock(TemplateResponse::class));
+	}
+
+	public function testTemplateResponseLoggedIn() {
+		$events = [];
+
+		$this->dispatcher->expects($this->exactly(2))
+			->method('dispatch')
+			->willReturnCallback(function($eventName) use (&$events) {
+				if ($eventName === TemplateResponse::EVENT_LOAD_ADDITIONAL_SCRIPTS ||
+					$eventName === TemplateResponse::EVENT_LOAD_ADDITIONAL_SCRIPTS_LOGGEDIN) {
+					$events[] = $eventName;
+					return;
+				}
+
+				$this->fail('Wrong event dispatched');
+			});
+		$this->userSession->method('isLoggedIn')
+			->willReturn(true);
+
+		$this->middleWare->afterController($this->controller, 'myMethod', $this->createMock(TemplateResponse::class));
+
+		$this->assertContains(TemplateResponse::EVENT_LOAD_ADDITIONAL_SCRIPTS, $events);
+		$this->assertContains(TemplateResponse::EVENT_LOAD_ADDITIONAL_SCRIPTS_LOGGEDIN, $events);
+	}
+}


### PR DESCRIPTION
Fixes #13662

This will fire of an event after a Template Response has been returned.
There is an event for the generic loading and one when logged in. So
apps can chose to load only on loged in pages.

This is a more generic approach than the files app event. As some things
we might want to load on other pages as well besides the files app.

Todo:
- [x] Tests
- [x] Docs https://github.com/nextcloud/documentation

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>