### PR TITLE
Don't call apc_delete_file and apc_clear_cache anymore

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -265,10 +265,8 @@ class Config {
 		flock($filePointer, LOCK_UN);
 		fclose($filePointer);
 
-		// Try invalidating the opcache just for the file we wrote...
-		if (!\OC_Util::deleteFromOpcodeCache($this->configFilePath)) {
-			// But if that doesn't work, clear the whole cache.
-			\OC_Util::clearOpcodeCache();
+		if (function_exists('opcache_invalidate')) {
+			@opcache_invalidate($this->configFilePath, true);
 		}
 	}
 }

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1334,19 +1334,11 @@ class OC_Util {
 	 * @param string $path the path of the file to clear from the cache
 	 * @return bool true if underlying function returns true, otherwise false
 	 */
-	public static function deleteFromOpcodeCache($path) {
-		$ret = false;
-		if ($path) {
-			// APC >= 3.1.1
-			if (function_exists('apc_delete_file')) {
-				$ret = @apc_delete_file($path);
-			}
-			// Zend OpCache >= 7.0.0, PHP >= 5.5.0
-			if (function_exists('opcache_invalidate')) {
-				$ret = @opcache_invalidate($path);
-			}
+	public static function deleteFromOpcodeCache($path): bool {
+		if (!empty($path) && function_exists('opcache_invalidate')) {
+			return @opcache_invalidate($path); // Zend OpCache >= 7.0.0, PHP >= 5.5.0
 		}
-		return $ret;
+		return false;
 	}
 
 	/**
@@ -1355,21 +1347,10 @@ class OC_Util {
 	 * in case the opcode cache does not re-validate files
 	 *
 	 * @return void
-	 * @suppress PhanDeprecatedFunction
-	 * @suppress PhanUndeclaredConstant
 	 */
-	public static function clearOpcodeCache() {
-		// APC
-		if (function_exists('apc_clear_cache')) {
-			apc_clear_cache();
-		}
-		// Zend Opcache
-		if (function_exists('accelerator_reset')) {
-			accelerator_reset();
-		}
-		// Opcache (PHP >= 5.5)
+	public static function clearOpcodeCache(): void {
 		if (function_exists('opcache_reset')) {
-			@opcache_reset();
+			@opcache_reset(); // Opcache (PHP >= 5.5)
 		}
 	}
 

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1324,37 +1324,6 @@ class OC_Util {
 	}
 
 	/**
-	 * Clear a single file from the opcode cache
-	 * This is useful for writing to the config file
-	 * in case the opcode cache does not re-validate files
-	 * Returns true if successful, false if unsuccessful:
-	 * caller should fall back on clearing the entire cache
-	 * with clearOpcodeCache() if unsuccessful
-	 *
-	 * @param string $path the path of the file to clear from the cache
-	 * @return bool true if underlying function returns true, otherwise false
-	 */
-	public static function deleteFromOpcodeCache($path): bool {
-		if (!empty($path) && function_exists('opcache_invalidate')) {
-			return @opcache_invalidate($path); // Zend OpCache >= 7.0.0, PHP >= 5.5.0
-		}
-		return false;
-	}
-
-	/**
-	 * Clear the opcode cache if one exists
-	 * This is necessary for writing to the config file
-	 * in case the opcode cache does not re-validate files
-	 *
-	 * @return void
-	 */
-	public static function clearOpcodeCache(): void {
-		if (function_exists('opcache_reset')) {
-			@opcache_reset(); // Opcache (PHP >= 5.5)
-		}
-	}
-
-	/**
 	 * Normalize a unicode string
 	 *
 	 * @param string $value a not normalized string


### PR DESCRIPTION
There is no apc for PHP7+ so there is no need to check if exist.
accelerator_reset looks even more ancient.

https://en.wikipedia.org/wiki/List_of_PHP_accelerators#Compatibility_chart

Only used by `writeData` (e.g. some config value changed). There is no need to backport it.