### PR TITLE
Remove unused OC._matchMedia helper

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -754,20 +754,6 @@ Object.assign(window.OC, {
 	},
 
 	/**
-	 * Wrapper for matchMedia
-	 *
-	 * This is makes it possible for unit tests to
-	 * stub matchMedia (which doesn't work in PhantomJS)
-	 * @private
-	 */
-	_matchMedia: function(media) {
-		if (window.matchMedia) {
-			return window.matchMedia(media);
-		}
-		return false;
-	},
-
-	/**
 	 * Returns the user's locale as a BCP 47 compliant language tag
 	 *
 	 * @return {String} locale string


### PR DESCRIPTION
This helper is marked as private and I could not find a single reference to it.