### PR TITLE
Fix findTemplate for core app

### DIFF
--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -148,7 +148,7 @@ class OC_Template extends \OC\Template\Base {
 	 */
 	protected function findTemplate($theme, $app, $name) {
 		// Check if it is a app template or not.
-		if( $app !== '' ) {
+		if( $app !== '' && $app !== 'core' ) {
 			$dirs = $this->getAppTemplateDirs($theme, $app, OC::$SERVERROOT, OC_App::getAppPath($app));
 		} else {
 			$dirs = $this->getCoreTemplateDirs($theme, OC::$SERVERROOT);


### PR DESCRIPTION
$app can be "core", this results in an error: https://paste.ee/p/ZBkqw
When app == core, we need to call getCoreTemplateDirs, not getAppTemplateDirs.