### PR TITLE
Show autocompletion as soon as "@" is typed

### DIFF
--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -185,9 +185,6 @@
 		},
 
 		_onAutoComplete: function(query, callback) {
-			if(_.isEmpty(query)) {
-				return;
-			}
 			var s = this;
 			if(!_.isUndefined(this._autoCompleteRequestTimer)) {
 				clearTimeout(this._autoCompleteRequestTimer);


### PR DESCRIPTION
For consistency with Talk, [as suggested by @nickvergessen](https://github.com/nextcloud/spreed/pull/1482#issuecomment-458120667)

In order to show the autocompletion it was needed to type at least another character after "@", so only the mentions that matched that character were shown. Now the autocompletion is shown as soon as "@" is typed, which shows all the possible mentions.
