### PR TITLE
trim filename in webfrontend for windows compatibility

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2471,7 +2471,7 @@
 				}
 
 				try {
-					var newName = input.val();
+					var newName = input.val().trim();
 					input.tooltip('hide');
 					form.remove();
 

--- a/apps/files/js/newfilemenu.js
+++ b/apps/files/js/newfilemenu.js
@@ -167,7 +167,7 @@
 				event.preventDefault();
 
 				if (checkInput()) {
-					var newname = $input.val();
+					var newname = $input.val().trim();
 
 					/* Find the right actionHandler that should be called.
 					 * Actions is retrieved by using `actionSpec.id` */


### PR DESCRIPTION
Added trim function in javascript to ensure compatibility with windows

scenario: I create the file "test.txt " and can't synchronize it with my local file-base. The same issue happens with folders with whitespaces at the begin or end. This feature ensures that a windows-user can't create the same circumstance for himself accidentally.