### PR TITLE
Show original path in trashbin

### DIFF
--- a/apps/files_trashbin/js/filelist.js
+++ b/apps/files_trashbin/js/filelist.js
@@ -11,6 +11,7 @@
 	var DELETED_REGEXP = new RegExp(/^(.+)\.d[0-9]+$/);
 	var FILENAME_PROP = '{http://nextcloud.org/ns}trashbin-filename';
 	var DELETION_TIME_PROP = '{http://nextcloud.org/ns}trashbin-deletion-time';
+	var TRASHBIN_ORIGINAL_LOCATION = '{http://nextcloud.org/ns}trashbin-original-location';
 
 	/**
 	 * Convert a file name in the format filename.d12345 to the real file name.
@@ -54,11 +55,13 @@
 		initialize: function() {
 			this.client.addFileInfoParser(function(response, data) {
 				var props = response.propStat[0].properties;
+				var path = props[TRASHBIN_ORIGINAL_LOCATION];
 				return {
 					displayName: props[FILENAME_PROP],
 					mtime: parseInt(props[DELETION_TIME_PROP], 10) * 1000,
 					hasPreview: true,
-					path: data.path.substr(6), // remove leading /trash
+					path: path,
+					extraData: path
 				}
 			});
 
@@ -248,7 +251,7 @@
 		 * Returns list of webdav properties to request
 		 */
 		_getWebdavProperties: function() {
-			return [FILENAME_PROP, DELETION_TIME_PROP].concat(this.filesClient.getPropfindProperties());
+			return [FILENAME_PROP, DELETION_TIME_PROP, TRASHBIN_ORIGINAL_LOCATION].concat(this.filesClient.getPropfindProperties());
 		},
 
 		/**


### PR DESCRIPTION
* delete a file from a subfolder
* go to trashbin
* hover over file
* expected: a tooltip with the previous path will be shown
* actual: the tooltip is not shown

Regression from #11037

I managed to fetch the needed attribute and also set it to the `path` variable, because it was not used before. Now I struggle with how to trigger or fill the tooltip.

@skjnldsv @icewind1991 @juliushaertl Any idea?