### PR TITLE
Repair step to remove "photo." files created by photocache

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -981,6 +981,7 @@ return array(
     'OC\\Repair\\NC14\\AddPreviewBackgroundCleanupJob' => $baseDir . '/lib/private/Repair/NC14/AddPreviewBackgroundCleanupJob.php',
     'OC\\Repair\\NC14\\RepairPendingCronJobs' => $baseDir . '/lib/private/Repair/NC14/RepairPendingCronJobs.php',
     'OC\\Repair\\NC15\\SetVcardDatabaseUID' => $baseDir . '/lib/private/Repair/NC15/SetVcardDatabaseUID.php',
+    'OC\\Repair\\NC16\\CleanupCardDAVPhotoCache' => $baseDir . '/lib/private/Repair/NC16/CleanupCardDAVPhotoCache.php',
     'OC\\Repair\\OldGroupMembershipShares' => $baseDir . '/lib/private/Repair/OldGroupMembershipShares.php',
     'OC\\Repair\\Owncloud\\DropAccountTermsTable' => $baseDir . '/lib/private/Repair/Owncloud/DropAccountTermsTable.php',
     'OC\\Repair\\Owncloud\\SaveAccountsTableData' => $baseDir . '/lib/private/Repair/Owncloud/SaveAccountsTableData.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1011,6 +1011,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Repair\\NC14\\AddPreviewBackgroundCleanupJob' => __DIR__ . '/../../..' . '/lib/private/Repair/NC14/AddPreviewBackgroundCleanupJob.php',
         'OC\\Repair\\NC14\\RepairPendingCronJobs' => __DIR__ . '/../../..' . '/lib/private/Repair/NC14/RepairPendingCronJobs.php',
         'OC\\Repair\\NC15\\SetVcardDatabaseUID' => __DIR__ . '/../../..' . '/lib/private/Repair/NC15/SetVcardDatabaseUID.php',
+        'OC\\Repair\\NC16\\CleanupCardDAVPhotoCache' => __DIR__ . '/../../..' . '/lib/private/Repair/NC16/CleanupCardDAVPhotoCache.php',
         'OC\\Repair\\OldGroupMembershipShares' => __DIR__ . '/../../..' . '/lib/private/Repair/OldGroupMembershipShares.php',
         'OC\\Repair\\Owncloud\\DropAccountTermsTable' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/DropAccountTermsTable.php',
         'OC\\Repair\\Owncloud\\SaveAccountsTableData' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/SaveAccountsTableData.php',

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -30,14 +30,11 @@
 
 namespace OC;
 
-use OCP\AppFramework\QueryException;
-use OCP\Migration\IOutput;
-use OCP\Migration\IRepairStep;
 use OC\Avatar\AvatarManager;
 use OC\Repair\AddCleanupUpdaterBackupsJob;
 use OC\Repair\CleanTags;
-use OC\Repair\ClearGeneratedAvatarCache;
 use OC\Repair\ClearFrontendCaches;
+use OC\Repair\ClearGeneratedAvatarCache;
 use OC\Repair\Collation;
 use OC\Repair\MoveUpdaterStepFile;
 use OC\Repair\NC11\FixMountStorages;
@@ -46,6 +43,7 @@ use OC\Repair\NC13\RepairInvalidPaths;
 use OC\Repair\NC14\AddPreviewBackgroundCleanupJob;
 use OC\Repair\NC14\RepairPendingCronJobs;
 use OC\Repair\NC15\SetVcardDatabaseUID;
+use OC\Repair\NC16\CleanupCardDAVPhotoCache;
 use OC\Repair\OldGroupMembershipShares;
 use OC\Repair\Owncloud\DropAccountTermsTable;
 use OC\Repair\Owncloud\SaveAccountsTableData;
@@ -55,6 +53,9 @@ use OC\Repair\RepairMimeTypes;
 use OC\Repair\SqliteAutoincrement;
 use OC\Template\JSCombiner;
 use OC\Template\SCSSCacher;
+use OCP\AppFramework\QueryException;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -147,7 +148,8 @@ class Repair implements IOutput {
 			new AddPreviewBackgroundCleanupJob(\OC::$server->getJobList()),
 			new AddCleanupUpdaterBackupsJob(\OC::$server->getJobList()),
 			new RepairPendingCronJobs(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig()),
-			new SetVcardDatabaseUID(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig(), \OC::$server->getLogger())
+			new SetVcardDatabaseUID(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig(), \OC::$server->getLogger()),
+			new CleanupCardDAVPhotoCache(\OC::$server->getConfig(), \OC::$server->getAppDataDir('dav-photocache')),
 		];
 	}
 

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -149,7 +149,7 @@ class Repair implements IOutput {
 			new AddCleanupUpdaterBackupsJob(\OC::$server->getJobList()),
 			new RepairPendingCronJobs(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig()),
 			new SetVcardDatabaseUID(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig(), \OC::$server->getLogger()),
-			new CleanupCardDAVPhotoCache(\OC::$server->getConfig(), \OC::$server->getAppDataDir('dav-photocache')),
+			new CleanupCardDAVPhotoCache(\OC::$server->getConfig(), \OC::$server->getAppDataDir('dav-photocache'), \OC::$server->getLogger()),
 		];
 	}
 

--- a/lib/private/Repair/NC16/CleanupCardDAVPhotoCache.php
+++ b/lib/private/Repair/NC16/CleanupCardDAVPhotoCache.php
@@ -22,11 +22,11 @@ declare(strict_types=1);
 
 namespace OC\Repair\NC16;
 
-use OC\Files\AppData\AppData;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\IConfig;
+use OCP\ILogger;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
@@ -44,12 +44,16 @@ class CleanupCardDAVPhotoCache implements IRepairStep {
 	/** @var IConfig */
 	private $config;
 
-	/** @var AppData */
+	/** @var IAppData */
 	private $appData;
 
-	public function __construct(IConfig $config, IAppData $appData) {
+	/** @var ILogger */
+	private $logger;
+
+	public function __construct(IConfig $config, IAppData $appData, ILogger $logger) {
 		$this->config = $config;
 		$this->appData = $appData;
+		$this->logger = $logger;
 	}
 
 	public function getName(): string {
@@ -78,7 +82,8 @@ class CleanupCardDAVPhotoCache implements IRepairStep {
 				/** @var ISimpleFolder $folder */
 				$folder->getFile('photo.')->delete();
 			} catch (\Exception $e) {
-				$output->warning('Could not delete "photo." file in dav-photocache/' . $folder->getName());
+				$this->logger->logException($e);
+				$output->warning('Could not delete file "dav-photocache/' . $folder->getName() . '/photo."');
 			}
 		}
 	}

--- a/lib/private/Repair/NC16/CleanupCardDAVPhotoCache.php
+++ b/lib/private/Repair/NC16/CleanupCardDAVPhotoCache.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019, Daniel Kesselberg (mail@danielkesselberg.de)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Repair\NC16;
+
+use OC\Files\AppData\AppData;
+use OCP\Files\IAppData;
+use OCP\Files\NotFoundException;
+use OCP\Files\SimpleFS\ISimpleFolder;
+use OCP\IConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+/**
+ * Class CleanupCardDAVPhotoCache
+ *
+ * This repair step removes "photo." files created by photocache
+ *
+ * Before https://github.com/nextcloud/server/pull/13843 a "photo." file could be created
+ * for unsupported image formats by photocache. Because a file is present but not jpg, png or gif no
+ * photo could be returned for this vcard. These invalid files are removed by this migration step.
+ */
+class CleanupCardDAVPhotoCache implements IRepairStep {
+
+	/** @var IConfig */
+	private $config;
+
+	/** @var AppData */
+	private $appData;
+
+	public function __construct(IConfig $config, IAppData $appData) {
+		$this->config = $config;
+		$this->appData = $appData;
+	}
+
+	public function getName(): string {
+		return 'Cleanup invalid photocache files for carddav';
+	}
+
+	private function repair(IOutput $output): void {
+		try {
+			$folders = $this->appData->getDirectoryListing();
+		} catch (NotFoundException $e) {
+			return;
+		}
+
+		$folders = array_filter($folders, function (ISimpleFolder $folder) {
+			return $folder->fileExists('photo.');
+		});
+
+		if (empty($folders)) {
+			return;
+		}
+
+		$output->info('Delete ' . count($folders) . ' "photo." files');
+
+		foreach ($folders as $folder) {
+			try {
+				/** @var ISimpleFolder $folder */
+				$folder->getFile('photo.')->delete();
+			} catch (\Exception $e) {
+				$output->warning('Could not delete "photo." file in dav-photocache/' . $folder->getName());
+			}
+		}
+	}
+
+	private function shouldRun(): bool {
+		return version_compare(
+			$this->config->getSystemValue('version', '0.0.0.0'),
+			'16.0.0.0',
+			'<='
+		);
+	}
+
+	public function run(IOutput $output): void {
+		if ($this->shouldRun()) {
+			$this->repair($output);
+		}
+	}
+}


### PR DESCRIPTION
Before https://github.com/nextcloud/server/pull/13843 a "photo." file could be created for unsupported image formats by photocache. Because a file is present but not jpg, png or gif no photo could be returned for this vcard. These invalid files are removed by this repair step. There is only little chance that "photo." files created again. Should be safe to remove this repair step in near future again.

How to test:

1. Create or Import one or more contacts
2. Upload a avatar for every contact
3. Open your terminal and goto `appdata_xxxxx/dav-photocache` 
4. Pick any folder and rename `photo.xxx` to `photo.` (without the extension)
5. Run `occ maintenance:repair` 

Exepected result:

There are no more `photo.` files. If you look at the contacts a new file is created.

