### PR TITLE
Remove memory and upload PHP settings

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -31,9 +31,6 @@
   </FilesMatch>
 </IfModule>
 <IfModule mod_php5.c>
-  php_value upload_max_filesize 511M
-  php_value post_max_size 511M
-  php_value memory_limit 512M
   php_value mbstring.func_overload 0
   php_value always_populate_raw_post_data -1
   php_value default_charset 'UTF-8'
@@ -43,9 +40,6 @@
   </IfModule>
 </IfModule>
 <IfModule mod_php7.c>
-  php_value upload_max_filesize 511M
-  php_value post_max_size 511M
-  php_value memory_limit 512M
   php_value mbstring.func_overload 0
   php_value default_charset 'UTF-8'
   php_value output_buffering 0

--- a/.user.ini
+++ b/.user.ini
@@ -1,6 +1,3 @@
-upload_max_filesize=511M
-post_max_size=511M
-memory_limit=512M
 mbstring.func_overload=0
 always_populate_raw_post_data=-1
 default_charset='UTF-8'


### PR DESCRIPTION
Because memory & file size limitation settings are specified in the local configs, they override any
values in the global `php.ini` on the system. Because of this, it's impossible to, for example,
increase the memory limit of Nextcloud without touching its own configuration/source files.

These settings are removed in favor of the `php.ini` settings. The justification for not having
these settings specified strictly by Nextcloud is that they are variant. In other words, their
values are environment-dependent, and especially dependent on the content hosted by Nextcloud
itself. For example, hosting lots of images and thumbnails frequently causes memory issues.