### PR TITLE
Do not run getRepairSteps in register_commands

### DIFF
--- a/core/Command/Maintenance/Repair.php
+++ b/core/Command/Maintenance/Repair.php
@@ -77,11 +77,14 @@ class Repair extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$includeExpensive = $input->getOption('include-expensive');
-		if ($includeExpensive) {
-			foreach ($this->repair->getExpensiveRepairSteps() as $step) {
-				$this->repair->addStep($step);
-			}
+		$repairSteps = $this->repair::getRepairSteps();
+
+		if ($input->getOption('include-expensive')) {
+			$repairSteps = array_merge($repairSteps, $this->repair::getExpensiveRepairSteps());
+		}
+
+		foreach ($repairSteps as $step) {
+			$this->repair->addStep($step);
 		}
 
 		$apps = $this->appManager->getInstalledApps();

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -140,8 +140,11 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 
 	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig(), \OC::$server->getLogger(), \OC::$server->query(\OC\Installer::class)));
 	$application->add(new OC\Core\Command\Maintenance\Repair(
-		new \OC\Repair(\OC\Repair::getRepairSteps(), \OC::$server->getEventDispatcher()), \OC::$server->getConfig(),
-		\OC::$server->getEventDispatcher(), \OC::$server->getAppManager()));
+		new \OC\Repair([], \OC::$server->getEventDispatcher()),
+		\OC::$server->getConfig(),
+		\OC::$server->getEventDispatcher(),
+		\OC::$server->getAppManager()
+	));
 
 	$application->add(new OC\Core\Command\User\Add(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\User\Delete(\OC::$server->getUserManager()));

--- a/lib/private/Migration/BackgroundRepair.php
+++ b/lib/private/Migration/BackgroundRepair.php
@@ -29,7 +29,7 @@ use OC\Repair;
 use OC_App;
 use OCP\BackgroundJob\IJobList;
 use OCP\ILogger;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Class BackgroundRepair
@@ -44,12 +44,16 @@ class BackgroundRepair extends TimedJob {
 	/** @var ILogger */
 	private $logger;
 
-	/** @var EventDispatcher */
+	/** @var EventDispatcherInterface */
 	private $dispatcher;
 
-	public function setDispatcher(EventDispatcher $dispatcher) {
+	/**
+	 * @param EventDispatcherInterface $dispatcher
+	 */
+	public function setDispatcher(EventDispatcherInterface $dispatcher): void {
 		$this->dispatcher = $dispatcher;
 	}
+
 	/**
 	 * run the job, then remove it from the job list
 	 *

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -76,7 +76,7 @@ class Repair implements IOutput {
 	 * @param IRepairStep[] $repairSteps array of RepairStep instances
 	 * @param EventDispatcherInterface $dispatcher
 	 */
-	public function __construct($repairSteps = [], EventDispatcherInterface $dispatcher = null) {
+	public function __construct(array $repairSteps, EventDispatcherInterface $dispatcher) {
 		$this->repairSteps = $repairSteps;
 		$this->dispatcher  = $dispatcher;
 	}

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -56,7 +56,7 @@ use OC\Template\SCSSCacher;
 use OCP\AppFramework\QueryException;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 class Repair implements IOutput {
@@ -64,7 +64,7 @@ class Repair implements IOutput {
 	/** @var IRepairStep[] */
 	private $repairSteps;
 
-	/** @var EventDispatcher */
+	/** @var EventDispatcherInterface */
 	private $dispatcher;
 
 	/** @var string */
@@ -74,9 +74,9 @@ class Repair implements IOutput {
 	 * Creates a new repair step runner
 	 *
 	 * @param IRepairStep[] $repairSteps array of RepairStep instances
-	 * @param EventDispatcher $dispatcher
+	 * @param EventDispatcherInterface $dispatcher
 	 */
-	public function __construct($repairSteps = [], EventDispatcher $dispatcher = null) {
+	public function __construct($repairSteps = [], EventDispatcherInterface $dispatcher = null) {
 		$this->repairSteps = $repairSteps;
 		$this->dispatcher  = $dispatcher;
 	}


### PR DESCRIPTION
`getRepairSteps` is quite expensive (because every repair step is initialized and their dependencies are injected).

![screenshot from 2019-02-02 18-39-51](https://user-images.githubusercontent.com/3902676/52167343-094a2d80-271a-11e9-87e0-ae82f86a4aea.png)

How to reproduce:

1. Monkey patch [Repair.php](https://github.com/nextcloud/server/blob/ecc8068e66abe77785cccffa0e4da1b5c209ebca/lib/private/Repair.php#L135) and add `echo 'getRepairSteps has been called' . PHP_EOL;`

2. Run `occ app:list`

3. You see "getRepairSteps has been called"