### PR TITLE
No need to explicitly load bundle dependencies

### DIFF
--- a/apps/comments/lib/AppInfo/Application.php
+++ b/apps/comments/lib/AppInfo/Application.php
@@ -61,7 +61,6 @@ class Application extends App {
 		$dispatcher->addListener(
 			'OCA\Files::loadAdditionalScripts',
 			function() {
-				Util::addScript('oc-backbone-webdav');
 				Util::addScript('comments', 'merged');
 				Util::addStyle('comments', 'autocomplete');
 				Util::addStyle('comments', 'comments');

--- a/apps/systemtags/appinfo/app.php
+++ b/apps/systemtags/appinfo/app.php
@@ -33,7 +33,6 @@ $eventDispatcher->addListener(
 	'OCA\Files::loadAdditionalScripts',
 	function() {
 		// FIXME: no public API for these ?
-		\OCP\Util::addScript('oc-backbone-webdav');
 		\OCP\Util::addScript('systemtags/merged');
 		\OCP\Util::addScript('systemtags', 'merged');
 		\OCP\Util::addStyle('systemtags');

--- a/apps/systemtags/templates/admin.php
+++ b/apps/systemtags/templates/admin.php
@@ -20,7 +20,6 @@
  */
 
 script('core', [
-	'oc-backbone-webdav',
 	'systemtags/systemtags',
 	'systemtags/systemtagmodel',
 	'systemtags/systemtagscollection',

--- a/apps/workflowengine/lib/AppInfo/Application.php
+++ b/apps/workflowengine/lib/AppInfo/Application.php
@@ -54,7 +54,6 @@ class Application extends \OCP\AppFramework\App {
 				script('core', [
 					'files/fileinfo',
 					'files/client',
-					'oc-backbone-webdav',
 					'systemtags/systemtags',
 					'systemtags/systemtagmodel',
 					'systemtags/systemtagscollection',


### PR DESCRIPTION
oc-webdav-backbone is in the main bundle (which is always loaded).

Removes some warnings from the logs.