### PR TITLE
Fix: Check if `$this->params['user']` is an array

### DIFF
--- a/lib/private/Files/ObjectStore/SwiftFactory.php
+++ b/lib/private/Files/ObjectStore/SwiftFactory.php
@@ -122,7 +122,7 @@ class SwiftFactory {
 			'handler' => HandlerStack::create()
 		]);
 
-		if (isset($this->params['user']) && isset($this->params['user']['name'])) {
+		if (isset($this->params['user']) && is_array($this->params['user']) && isset($this->params['user']['name'])) {
 			if (!isset($this->params['scope'])) {
 				throw new StorageAuthException('Scope has to be defined for V3 requests');
 			}


### PR DESCRIPTION
Since upgrade from 13 to 14, i have a exception in my Swift setup (primary storage). I keep my configuration format.

I don't know why but in my setup `params['user']` is instance of `OC\User\User` and `isset($this->params['user']['name'])` raise a exception.

Maybe a more deeper bug ...
