### PR TITLE
Fix OC.addStyle and OC.addScript

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -863,8 +863,6 @@ Object.assign(window.OC, {
 	}
 });
 
-/**
-
 OC.addStyle.loaded=[];
 OC.addScript.loaded=[];
 


### PR DESCRIPTION
With the move to the bundles a comment tag was not removed. So the
loaded array was undefined.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>