### PR TITLE
Do not load bundled jstimezonedetect

### DIFF
--- a/apps/workflowengine/lib/AppInfo/Application.php
+++ b/apps/workflowengine/lib/AppInfo/Application.php
@@ -59,8 +59,6 @@ class Application extends \OCP\AppFramework\App {
 					'systemtags/systemtagscollection',
 				]);
 
-				vendor_script('jsTimezoneDetect/jstz');
-
 				script('workflowengine', [
 					'admin',
 					'templates',

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -1,6 +1,5 @@
 <?php /** @var $l \OCP\IL10N */ ?>
 <?php
-vendor_script('jsTimezoneDetect/jstz');
 script('core', 'merged-login');
 
 use OC\Core\Controller\LoginController;


### PR DESCRIPTION
No need to load this as it is bundled.
Removes some warnings from the logs.