### PR TITLE
Shared contacts in dropdown menu, for issue #5097

### DIFF
--- a/lib/private/Contacts/ContactsMenu/ContactsStore.php
+++ b/lib/private/Contacts/ContactsMenu/ContactsStore.php
@@ -76,9 +76,25 @@ class ContactsStore implements IContactsStore {
 			'EMAIL'
 		]);
 
+		$sharedContacts = [];
+		
+		$conn = \OC::$server->getDatabaseConnection();
+		
+        	// Retrieving shared contacts/users from database
+		$sharedWith = $conn->executeQuery('SELECT DISTINCT * FROM oc_share');
+		
+		// Matching who shared with current user
+		while ($row = $sharedWith->fetch()) {
+		    for ($i = 0; $i < count($allContacts); $i++) {
+			if ($row['share_with'] == $allContacts[$i]['UID']) {
+			    $sharedContacts[] = $allContacts[$i];
+			}
+		    }
+		}
+		
 		$entries = array_map(function(array $contact) {
 			return $this->contactArrayToEntry($contact);
-		}, $allContacts);
+		}, $sharedContacts);
 		return $this->filterContacts(
 			$user,
 			$entries,


### PR DESCRIPTION
Retrieving contacts/users from database to dropdown menu who shared with current user.
When you shared something with someone, then it appears on dropdown menu. In dropdown menu just shared users appear and search operation just find in shared users, not all users.

Signed-off-by: Sanani Rajabov <sananirajabov@gmail.com>