### PR TITLE
[stable15] Make external storages browsable again in the web UI

### DIFF
--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -288,6 +288,17 @@ OCA.Files_External.StatusManager = {
 					};
 					ajaxQueue.push(queueElement);
 				});
+
+				var rolQueue = new OCA.Files_External.StatusManager.RollingQueue(ajaxQueue, 4, function () {
+					if (!self.notificationHasShown) {
+						$.each(self.mountStatus, function (key, value) {
+							if (value.status === 1) {
+								self.notificationHasShown = true;
+							}
+						});
+					}
+				});
+				rolQueue.runQueue();
 			}
 		});
 	},


### PR DESCRIPTION
Fixes #14022

basically reverts #13891 and removes the notification (the original goal of that PR).


This is directly against stable15 to be able to just release another point release right afterwards.