### PR TITLE
Make sure the relative path is always a string

### DIFF
--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -264,7 +264,6 @@ class ShareByMailProvider implements IShareProvider {
 			$ownerPath = $nodes[0]->getPath();
 			$this->publishActivity(
 				$type === 'share' ? Activity::SUBJECT_SHARED_EMAIL_BY : Activity::SUBJECT_UNSHARED_EMAIL_BY,
-				Activity::SUBJECT_SHARED_EMAIL_BY,
 				[$ownerFolder->getRelativePath($ownerPath), $share->getSharedWith(), $share->getSharedBy()],
 				$share->getShareOwner(),
 				$fileId,

--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -254,7 +254,7 @@ class ShareByMailProvider implements IShareProvider {
 			[$userFolder->getRelativePath($share->getNode()->getPath()), $share->getSharedWith()],
 			$share->getSharedBy(),
 			$share->getNode()->getId(),
-			$userFolder->getRelativePath($share->getNode()->getPath())
+			(string) $userFolder->getRelativePath($share->getNode()->getPath())
 		);
 
 		if ($share->getShareOwner() !== $share->getSharedBy()) {
@@ -268,7 +268,7 @@ class ShareByMailProvider implements IShareProvider {
 				[$ownerFolder->getRelativePath($ownerPath), $share->getSharedWith(), $share->getSharedBy()],
 				$share->getShareOwner(),
 				$fileId,
-				$ownerFolder->getRelativePath($ownerPath)
+				(string) $ownerFolder->getRelativePath($ownerPath)
 			);
 		}
 
@@ -291,7 +291,7 @@ class ShareByMailProvider implements IShareProvider {
 				[$userFolder->getRelativePath($share->getNode()->getPath())],
 				$share->getSharedBy(),
 				$share->getNode()->getId(),
-				$userFolder->getRelativePath($share->getNode()->getPath())
+				(string) $userFolder->getRelativePath($share->getNode()->getPath())
 			);
 		} else {
 			$this->publishActivity(
@@ -299,7 +299,7 @@ class ShareByMailProvider implements IShareProvider {
 				[$userFolder->getRelativePath($share->getNode()->getPath()), $sharedWith],
 				$share->getSharedBy(),
 				$share->getNode()->getId(),
-				$userFolder->getRelativePath($share->getNode()->getPath())
+				(string) $userFolder->getRelativePath($share->getNode()->getPath())
 			);
 		}
 	}
@@ -308,13 +308,13 @@ class ShareByMailProvider implements IShareProvider {
 	/**
 	 * publish activity if a file/folder was shared by mail
 	 *
-	 * @param $subject
-	 * @param $parameters
-	 * @param $affectedUser
-	 * @param $fileId
-	 * @param $filePath
+	 * @param string $subject
+	 * @param array $parameters
+	 * @param string $affectedUser
+	 * @param int $fileId
+	 * @param string $filePath
 	 */
-	protected function publishActivity($subject, $parameters, $affectedUser, $fileId, $filePath) {
+	protected function publishActivity(string $subject, array $parameters, string $affectedUser, int $fileId, string $filePath) {
 		$event = $this->activityManager->generateEvent();
 		$event->setApp('sharebymail')
 			->setType('shared')


### PR DESCRIPTION
Not sure when this is triggered, but it happens:
https://github.com/nextcloud/server/blob/9d9f6903c9e2a94f2a1b230fd35ec586b18b7a77/lib/private/Files/Node/Folder.php#L65-L76


```
Exception

TypeError: Argument 3 passed to OC\Activity\Event::setObject() must be of the type string, null given, called in /var/www/html/apps/sharebymail/lib/ShareByMailProvider.php on line 323
  File "/var/www/html/lib/private/Activity/Event.php", line 377, in setObject
    public function setObject(string $objectType, int $objectId, string $objectName = ''): IEvent {
  File "sharebymail/lib/ShareByMailProvider.php", line 323, in publishActivity
    ->setObject('files', $fileId, $filePath);
  File "sharebymail/lib/ShareByMailProvider.php", line 257, in createShareActivity
    $userFolder->getRelativePath($share->getNode()->getPath())
  File "sharebymail/lib/ShareByMailProvider.php", line 757, in delete
    $this->createShareActivity($share, 'unshare');
  File "/var/www/html/lib/private/Share20/Manager.php", line 979, in deleteShare
    $provider->delete($share);
...
(13 additional frame(s) were not displayed)
```

Fix #14082