### PR TITLE
take out support for parallel search

### DIFF
--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -36,6 +36,11 @@ namespace OCA\User_LDAP;
 /**
  * @property int ldapPagingSize holds an integer
  * @property string ldapUserAvatarRule
+ * @property string ldapEmailAttribute
+ * @property string ldapUserDisplayName
+ * @property string ldapUserFilter
+ * @property string ldapGroupFilter
+ * @property string[] ldapBase
  */
 class Configuration {
 	const AVATAR_PREFIX_DEFAULT = 'default';

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -45,12 +45,18 @@ use OCP\ILogger;
  *
  * @property string ldapHost
  * @property string ldapPort holds the port number
+ * @property string ldapLoginFilter
  * @property string ldapUserFilter
  * @property string ldapUserDisplayName
  * @property string ldapUserDisplayName2
  * @property string ldapUserAvatarRule
+ * @property string ldapGroupFilter
+ * @property string ldapGidNumber
+ * @property string ldapDynamicGroupMemberURL
  * @property boolean turnOnPasswordChange
+ * @property string[] ldapBase
  * @property string[] ldapBaseUsers
+ * @property string[] ldapBaseGroups
  * @property int|null ldapPagingSize holds an integer
  * @property bool|mixed|void ldapGroupMemberAssocAttr
  * @property string ldapUuidUserAttribute
@@ -60,6 +66,7 @@ use OCP\ILogger;
  * @property string ldapQuotaAttribute
  * @property string ldapQuotaDefault
  * @property string ldapEmailAttribute
+ * @property string ldapDefaultPPolicyDN
  */
 class Connection extends LDAPUtility {
 	private $ldapConnectionRes = null;

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -309,7 +309,7 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 	 * @throws \Exception
 	 * @throws \OC\ServerNotAvailableException
 	 */
-	public function userExistsOnLDAP($user) {
+	public function userExistsOnLDAP($user): bool {
 		if(is_string($user)) {
 			$user = $this->access->userManager->get($user);
 		}
@@ -319,7 +319,7 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 
 		$dn = $user->getDN();
 		//check if user really still exists by reading its entry
-		if(!is_array($this->access->readAttribute($dn, '', $this->access->connection->ldapUserFilter))) {
+		if(!$this->access->isRecordOnLDAP($dn, $this->access->connection->ldapUserFilter)) {
 			try {
 				$uuid = $this->access->getUserMapper()->getUUIDByDN($dn);
 				if (!$uuid) {
@@ -327,7 +327,7 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 				}
 				$newDn = $this->access->getUserDnByUuid($uuid);
 				//check if renamed user is still valid by reapplying the ldap filter
-				if ($newDn === $dn || !is_array($this->access->readAttribute($newDn, '', $this->access->connection->ldapUserFilter))) {
+				if ($newDn === $dn || !$this->access->isRecordOnLDAP($newDn, $this->access->connection->ldapUserFilter)) {
 					return false;
 				}
 				$this->access->getUserMapper()->setDNbyUUID($newDn, $uuid);

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -559,7 +559,7 @@ class AccessTest extends TestCase {
 			->method('search')
 			->willReturn([$fakeSearchResultResource]);
 		$this->ldap
-			->expects($this->exactly(count($base)))
+			->expects($this->exactly(1))
 			->method('getEntries')
 			->willReturn($fakeLdapEntries);
 
@@ -571,7 +571,7 @@ class AccessTest extends TestCase {
 	public function testSearchNoPagedSearch() {
 		// scenario: no pages search, 1 search base
 		$filter = 'objectClass=nextcloudUser';
-		$base = ['ou=zombies,dc=foobar,dc=nextcloud,dc=com'];
+		$base = 'ou=zombies,dc=foobar,dc=nextcloud,dc=com';
 
 		$fakeConnection = new \stdClass();
 		$fakeSearchResultResource = new \stdClass();

--- a/apps/user_ldap/tests/User/UserTest.php
+++ b/apps/user_ldap/tests/User/UserTest.php
@@ -545,7 +545,7 @@ class UserTest extends \Test\TestCase {
 	}
 
 	public function testUpdateAvatarThumbnailPhotoProvided() {
-		$this->access->expects($this->any())
+		$this->access->expects($this->atLeastOnce())
 			->method('readAttribute')
 			->willReturnCallback(function($dn, $attr) {
 				if($dn === $this->dn
@@ -599,7 +599,7 @@ class UserTest extends \Test\TestCase {
 	}
 
 	public function testUpdateAvatarCorruptPhotoProvided() {
-		$this->access->expects($this->any())
+		$this->access->expects($this->atLeastOnce())
 			->method('readAttribute')
 			->willReturnCallback(function($dn, $attr) {
 				if($dn === $this->dn
@@ -645,7 +645,7 @@ class UserTest extends \Test\TestCase {
 	}
 
 	public function testUpdateAvatarUnsupportedThumbnailPhotoProvided() {
-		$this->access->expects($this->any())
+		$this->access->expects($this->atLeastOnce())
 			->method('readAttribute')
 			->willReturnCallback(function($dn, $attr) {
 				if($dn === $this->dn
@@ -700,7 +700,7 @@ class UserTest extends \Test\TestCase {
 	}
 
 	public function testUpdateAvatarNotProvided() {
-		$this->access->expects($this->any())
+		$this->access->expects($this->atLeastOnce())
 			->method('readAttribute')
 			->willReturnCallback(function($dn, $attr) {
 				if($dn === $this->dn
@@ -962,7 +962,7 @@ class UserTest extends \Test\TestCase {
 			->with($this->equalTo('homeFolderNamingRule'))
 			->will($this->returnValue('attr:foobar'));
 
-		$this->access->expects($this->once())
+		$this->access->expects($this->atLeastOnce())
 			->method('readAttribute')
 			->will($this->returnValue(false));
 
@@ -984,7 +984,7 @@ class UserTest extends \Test\TestCase {
 			->with($this->equalTo('homeFolderNamingRule'))
 			->will($this->returnValue('attr:foobar'));
 
-		$this->access->expects($this->once())
+		$this->access->expects($this->atLeastOnce())
 			->method('readAttribute')
 			->will($this->returnValue(false));
 
@@ -1066,7 +1066,7 @@ class UserTest extends \Test\TestCase {
 		$this->access->expects($this->any())
 			->method('search')
 			->will($this->returnCallback(function($filter, $base) {
-				if($base === [$this->dn]) {
+				if($base === $this->dn) {
 					return [
 						[
 							'pwdchangedtime' => [(new \DateTime())->sub(new \DateInterval('P28D'))->format('Ymdhis').'Z'],
@@ -1074,7 +1074,7 @@ class UserTest extends \Test\TestCase {
 						],
 					];
 				}
-				if($base === ['cn=default,ou=policies,dc=foo,dc=bar']) {
+				if($base === 'cn=default,ou=policies,dc=foo,dc=bar') {
 					return [
 						[
 							'pwdmaxage' => ['2592000'],
@@ -1129,7 +1129,7 @@ class UserTest extends \Test\TestCase {
 		$this->access->expects($this->any())
 			->method('search')
 			->will($this->returnCallback(function($filter, $base) {
-				if($base === [$this->dn]) {
+				if($base === $this->dn) {
 					return [
 						[
 							'pwdpolicysubentry' => ['cn=custom,ou=policies,dc=foo,dc=bar'],
@@ -1138,7 +1138,7 @@ class UserTest extends \Test\TestCase {
 						]
 					];
 				}
-				if($base === ['cn=custom,ou=policies,dc=foo,dc=bar']) {
+				if($base === 'cn=custom,ou=policies,dc=foo,dc=bar') {
 					return [
 						[
 							'pwdmaxage' => ['2592000'],


### PR DESCRIPTION
follow up to #13865 

_(still pondering whether it might make sense to keep it in place, but use it when paged search is turned off. could be useful for edge cases, e.g. certain LDAP directories + multiple bases. performance testing could be useful here, too)._