### PR TITLE
Retrieving shared contacts/users from database to dropdown menu

### DIFF
--- a/lib/private/Contacts/ContactsMenu/ContactsStore.php
+++ b/lib/private/Contacts/ContactsMenu/ContactsStore.php
@@ -76,9 +76,24 @@ class ContactsStore implements IContactsStore {
 			'EMAIL'
 		]);
 
+		$sharedContacts = [];
+
+		$conn = \OC::$server->getDatabaseConnection();
+		$sharedWith = $conn->executeQuery('SELECT DISTINCT * FROM oc_share');
+
+		// Matching who shared with current user
+		while ($row = $sharedWith->fetch()) {
+			for ($i = 0; $i < count($allContacts); $i++) {
+				if ($row['share_with'] == $allContacts[$i]['UID']) {
+					$sharedContacts[] = $allContacts[$i];
+				}
+			}
+		}
+
 		$entries = array_map(function(array $contact) {
 			return $this->contactArrayToEntry($contact);
-		}, $allContacts);
+		}, $sharedContacts);
+
 		return $this->filterContacts(
 			$user,
 			$entries,


### PR DESCRIPTION
The problem is when you click users dropdown menu, first 25 users appear, to fix this problem I implemented code when you share something with user, this user then appear in dropdown menu, and there is no limit how many users will appear.

fix #5097

Signed-off-by: Sanani Rajabov [sananirajabov@gmail.com](mailto:sananirajabov@gmail.com)