### PR TITLE
Fix the thorrtler whitelist bitmask

### DIFF
--- a/lib/private/Security/Bruteforce/Throttler.php
+++ b/lib/private/Security/Bruteforce/Throttler.php
@@ -177,8 +177,10 @@ class Throttler {
 				$part = ord($addr[(int)($i/8)]);
 				$orig = ord($ip[(int)($i/8)]);
 
-				$part = $part & (15 << (1 - ($i % 2)));
-				$orig = $orig & (15 << (1 - ($i % 2)));
+				$bitmask = 1 << (7 - ($i % 8));
+
+				$part = $part & $bitmask;
+				$orig = $orig & $bitmask;
 
 				if ($part !== $orig) {
 					$valid = false;

--- a/tests/lib/Security/Bruteforce/ThrottlerTest.php
+++ b/tests/lib/Security/Bruteforce/ThrottlerTest.php
@@ -101,6 +101,27 @@ class ThrottlerTest extends TestCase {
 				true,
 			],
 			[
+				'10.10.10.10',
+				[
+					'whitelist_0' => '10.10.10.11/31',
+				],
+				true,
+			],
+			[
+				'10.10.10.10',
+				[
+					'whitelist_0' => '10.10.10.9/31',
+				],
+				false,
+			],
+			[
+				'10.10.10.10',
+				[
+					'whitelist_0' => '10.10.10.15/29',
+				],
+				true,
+			],
+			[
 				'dead:beef:cafe::1',
 				[
 					'whitelist_0' => '192.168.0.0/16',
@@ -124,6 +145,14 @@ class ThrottlerTest extends TestCase {
 					'whitelist_0' => '192.168.0.0/16',
 					'whitelist_1' => '10.10.10.0/24',
 					'whitelist_2' => 'deaf:cafe::/8'
+				],
+				true,
+			],
+			[
+				'dead:beef:cafe::1111',
+				[
+					'whitelist_0' => 'dead:beef:cafe::1100/123',
+					
 				],
 				true,
 			],


### PR DESCRIPTION
Before we actually didn't check each bit of the bitmask. Now we do.

Testing is easy. Just try to run the added testcases without this patch.