### PR TITLE
Allow attaching plugins to the ShareTabView and trigger event on render

### DIFF
--- a/apps/files_sharing/js/sharetabview.js
+++ b/apps/files_sharing/js/sharetabview.js
@@ -24,6 +24,11 @@
 		id: 'shareTabView',
 		className: 'tab shareTabView',
 
+		initialize: function(name, options) {
+			OCA.Files.DetailTabView.prototype.initialize.call(this, name, options);
+			OC.Plugins.attach('OCA.Sharing.ShareTabView', this);
+		},
+
 		template: function(params) {
 			return 	TEMPLATE;
 		},
@@ -80,6 +85,7 @@
 				this.$el.empty();
 				// TODO: render placeholder text?
 			}
+			this.trigger('rendered');
 		}
 	});
 


### PR DESCRIPTION
This allows apps to register custom plugins and listen to the render event on the share tab view. It can be used for apps like groupfolders to show more advanced data inside of the sharing tab.

Example usage for groupfolders:

```
OCA.Groupfolders = {};
OCA.Groupfolders.ShareTabPlugin = {
	attach: function (shareTabView) {
		shareTabView.on('rendered', function() {
			if (this.model && this.model.get('mountType') === 'group') {
				// Add more info the share tab here
			}
		});
	}
};
OC.Plugins.register('OCA.Sharing.ShareTabView', OCA.Groupfolders.ShareTabPlugin);
```