### PR TITLE
Fix OC.getCurrentUser() on guest pages

### DIFF
--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html class="ng-csp" data-placeholder-focus="false" lang="<?php p($_['language']); ?>" data-locale="<?php p($_['locale']); ?>" >
-	<head data-requesttoken="<?php p($_['requesttoken']); ?>">
+	<head
+<?php if ($_['user_uid']) { ?>
+	data-user="<?php p($_['user_uid']); ?>" data-user-displayname="<?php p($_['user_displayname']); ?>"
+<?php } ?>
+ data-requesttoken="<?php p($_['requesttoken']); ?>">
 		<meta charset="utf-8">
 		<title>
 		<?php p($theme->getTitle()); ?>

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -122,6 +122,10 @@ class TemplateLayout extends \OC_Template {
 			parent::__construct('core', 'layout.guest');
 			\OC_Util::addStyle('guest');
 			$this->assign('bodyid', 'body-login');
+
+			$userDisplayName = \OC_User::getDisplayName();
+			$this->assign('user_displayname', $userDisplayName);
+			$this->assign('user_uid', \OC_User::getUser());
 		} else if ($renderAs == 'public') {
 			parent::__construct('core', 'layout.public');
 			$this->assign( 'appid', $appId );


### PR DESCRIPTION
There is an inconsistency between the state an app can get in the UI and what all requests to the backend do.

See: https://github.com/nextcloud/spreed/issues/1537
The signaling ticket contained the user, because the OCS request is authenticated, but the UI does not provide the user, so signaling continues without the user, and the signaling ticket is invalid on the external signaling server, because it is not for the current user.

As discussed @rullzer 