### PR TITLE
Make TestCase->overwriteService() work with App classes

### DIFF
--- a/lib/private/ServerContainer.php
+++ b/lib/private/ServerContainer.php
@@ -107,6 +107,10 @@ class ServerContainer extends SimpleContainer {
 	public function query($name) {
 		$name = $this->sanitizeName($name);
 
+		if (isset($this[$name])) {
+			return $this[$name];
+		}
+
 		// In case the service starts with OCA\ we try to find the service in
 		// the apps container first.
 		if (strpos($name, 'OCA\\') === 0 && substr_count($name, '\\') >= 2) {


### PR DESCRIPTION
https://github.com/nextcloud/server/blob/eded07f28fade99bdb7d832bf9294cbd609e2802/tests/lib/TestCase.php#L46-L94 does not work for apps atm, because `OCA` classes are overwritten to the ServerContainer, but inside `query()` we directly pipe the request to the App Container :see_no_evil: 