### PR TITLE
Correctly determinate the owner in case of shared external storages

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1419,10 +1419,12 @@ class Manager implements IManager {
 			return $al;
 		}
 
-		//Get node for the owner
+		//Get node for the owner and correct the owner in case of external storages
 		$userFolder = $this->rootFolder->getUserFolder($owner);
 		if ($path->getId() !== $userFolder->getId() && !$userFolder->isSubNode($path)) {
-			$path = $userFolder->getById($path->getId())[0];
+			$nodes = $userFolder->getById($path->getId());
+			$path = array_shift($nodes);
+			$owner = $path->getOwner()->getUID();
 		}
 
 		$providers = $this->factory->getAllProviders();

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -3427,15 +3427,15 @@ class ManagerTest extends \Test\TestCase {
 		$extraProvider = $this->createMock(IShareProvider::class);
 		$factory->setSecondProvider($extraProvider);
 
-		$owner = $this->createMock(IUser::class);
-		$owner->expects($this->once())
+		$nodeOwner = $this->createMock(IUser::class);
+		$nodeOwner->expects($this->once())
 			->method('getUID')
-			->willReturn('owner');
+			->willReturn('user1');
 
 		$node = $this->createMock(Node::class);
 		$node->expects($this->once())
 			->method('getOwner')
-			->willReturn($owner);
+			->willReturn($nodeOwner);
 		$node->method('getId')
 			->willReturn(42);
 
@@ -3443,10 +3443,17 @@ class ManagerTest extends \Test\TestCase {
 		$file = $this->createMock(File::class);
 		$folder = $this->createMock(Folder::class);
 
+		$owner = $this->createMock(IUser::class);
+		$owner->expects($this->once())
+			->method('getUID')
+			->willReturn('owner');
+
 		$file->method('getParent')
 			->willReturn($folder);
 		$file->method('getPath')
 			->willReturn('/owner/files/folder/file');
+		$file->method('getOwner')
+			->willReturn($owner);
 		$file->method('getId')
 			->willReturn(23);
 		$folder->method('getParent')
@@ -3455,12 +3462,12 @@ class ManagerTest extends \Test\TestCase {
 			->willReturn('/owner/files/folder');
 		$userFolder->method('getById')
 			->with($this->equalTo(42))
-			->willReturn([$file]);
+			->willReturn([12 => $file]);
 		$userFolder->method('getPath')
-			->willReturn('/owner/files');
+			->willReturn('/user1/files');
 
 		$this->userManager->method('userExists')
-			->with($this->equalTo('owner'))
+			->with($this->equalTo('user1'))
 			->willReturn(true);
 
 		$this->defaultProvider->method('getAccessList')
@@ -3494,7 +3501,7 @@ class ManagerTest extends \Test\TestCase {
 			]);
 
 		$this->rootFolder->method('getUserFolder')
-			->with($this->equalTo('owner'))
+			->with($this->equalTo('user1'))
 			->willReturn($userFolder);
 
 		$expected = [
@@ -3536,26 +3543,33 @@ class ManagerTest extends \Test\TestCase {
 		$extraProvider = $this->createMock(IShareProvider::class);
 		$factory->setSecondProvider($extraProvider);
 
-		$owner = $this->createMock(IUser::class);
-		$owner->expects($this->once())
+		$nodeOwner = $this->createMock(IUser::class);
+		$nodeOwner->expects($this->once())
 			->method('getUID')
-			->willReturn('owner');
+			->willReturn('user1');
 
 		$node = $this->createMock(Node::class);
 		$node->expects($this->once())
 			->method('getOwner')
-			->willReturn($owner);
+			->willReturn($nodeOwner);
 		$node->method('getId')
 			->willReturn(42);
 
 		$userFolder = $this->createMock(Folder::class);
 		$file = $this->createMock(File::class);
+
+		$owner = $this->createMock(IUser::class);
+		$owner->expects($this->once())
+			->method('getUID')
+			->willReturn('owner');
 		$folder = $this->createMock(Folder::class);
 
 		$file->method('getParent')
 			->willReturn($folder);
 		$file->method('getPath')
 			->willReturn('/owner/files/folder/file');
+		$file->method('getOwner')
+			->willReturn($owner);
 		$file->method('getId')
 			->willReturn(23);
 		$folder->method('getParent')
@@ -3564,12 +3578,12 @@ class ManagerTest extends \Test\TestCase {
 			->willReturn('/owner/files/folder');
 		$userFolder->method('getById')
 			->with($this->equalTo(42))
-			->willReturn([$file]);
+			->willReturn([42 => $file]);
 		$userFolder->method('getPath')
-			->willReturn('/owner/files');
+			->willReturn('/user1/files');
 
 		$this->userManager->method('userExists')
-			->with($this->equalTo('owner'))
+			->with($this->equalTo('user1'))
 			->willReturn(true);
 
 		$this->defaultProvider->method('getAccessList')
@@ -3605,7 +3619,7 @@ class ManagerTest extends \Test\TestCase {
 			]);
 
 		$this->rootFolder->method('getUserFolder')
-			->with($this->equalTo('owner'))
+			->with($this->equalTo('user1'))
 			->willReturn($userFolder);
 
 		$expected = [


### PR DESCRIPTION
### Steps
1. add an external storage
2. created a file "shared.txt"
    i. user gets notified
3. modified this file
    i. user gets notified
4. shared it with another user (B)
    i. both users are getting notified
5. user B modified this file
    i. only user B gets notified, not the creator