### PR TITLE
ensure attribute names are lower cased

### DIFF
--- a/apps/user_ldap/lib/User/Manager.php
+++ b/apps/user_ldap/lib/User/Manager.php
@@ -169,19 +169,14 @@ class Manager {
 	 * @return string[]
 	 */
 	public function getAttributes($minimal = false) {
-		$attributes = array_merge(Access::UUID_ATTRIBUTES, ['dn', 'uid', 'samaccountname', 'memberof']);
-		$possible = array(
+		$baseAttributes = array_merge(Access::UUID_ATTRIBUTES, ['dn', 'uid', 'samaccountname', 'memberof']);
+		$attributes = [
 			$this->access->getConnection()->ldapExpertUUIDUserAttr,
 			$this->access->getConnection()->ldapQuotaAttribute,
 			$this->access->getConnection()->ldapEmailAttribute,
 			$this->access->getConnection()->ldapUserDisplayName,
 			$this->access->getConnection()->ldapUserDisplayName2,
-		);
-		foreach($possible as $attr) {
-			if(!is_null($attr)) {
-				$attributes[] = $attr;
-			}
-		}
+		];
 
 		$homeRule = $this->access->getConnection()->homeFolderNamingRule;
 		if(strpos($homeRule, 'attr:') === 0) {
@@ -197,11 +192,16 @@ class Manager {
 			);
 		}
 
-		// remove possible empty attributes
-		$attributes = array_values(
-			array_filter($attributes, function ($attributeName) {
-				return !empty($attributeName);
-			})
+		$attributes = array_reduce($attributes,
+			function($list, $attribute) {
+				$attribute = strtolower(trim((string)$attribute));
+				if(!empty($attribute) && !in_array($attribute, $list)) {
+					$list[] = $attribute;
+				}
+
+				return $list;
+			},
+			$baseAttributes // hard-coded, lower-case, non-empty attributes
 		);
 
 		return $attributes;

--- a/apps/user_ldap/tests/User/ManagerTest.php
+++ b/apps/user_ldap/tests/User/ManagerTest.php
@@ -233,18 +233,22 @@ class ManagerTest extends \Test\TestCase {
 	 */
 	public function testGetAttributes($minimal) {
 		$this->connection->setConfiguration([
-			'ldapEmailAttribute' => 'mail',
+			'ldapEmailAttribute' => 'MAIL',
 			'ldapUserAvatarRule' => 'default',
 			'ldapQuotaAttribute' => '',
+			'ldapUserDisplayName2' => 'Mail',
 		]);
 
 		$attributes = $this->manager->getAttributes($minimal);
 
 		$this->assertTrue(in_array('dn', $attributes));
-		$this->assertTrue(in_array($this->access->getConnection()->ldapEmailAttribute, $attributes));
+		$this->assertTrue(in_array(strtolower($this->access->getConnection()->ldapEmailAttribute), $attributes));
+		$this->assertTrue(!in_array($this->access->getConnection()->ldapEmailAttribute, $attributes)); #cases check
 		$this->assertFalse(in_array('', $attributes));
 		$this->assertSame(!$minimal, in_array('jpegphoto', $attributes));
 		$this->assertSame(!$minimal, in_array('thumbnailphoto', $attributes));
+		$valueCounts = array_count_values($attributes);
+		$this->assertSame(1, $valueCounts['mail']);
 	}
 
 }


### PR DESCRIPTION
otherwise they will be skipped when the results is being formatted and the
lower-cased result keys do not match.
