### PR TITLE
Prefix $path for filename for internal file cache

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -408,7 +408,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		}
 
 		try {
-			if (isset($this->filesCache[$path]) && $this->headObject($path)) {
+			if (isset($this->filesCache[$path]) || $this->headObject($path)) {
 				return 'file';
 			}
 			if ($this->headObject($path . '/')) {

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -309,7 +309,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 						$files[] = $file;
 
 						// store this information for later usage
-						$this->filesCache[$file] = [
+						$this->filesCache[$path . $file] = [
 							'ContentLength' => $object['Size'],
 							'LastModified' => (string)$object['LastModified'],
 						];
@@ -408,7 +408,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		}
 
 		try {
-			if ($this->headObject($path)) {
+			if (isset($this->filesCache[$path]) && $this->headObject($path)) {
 				return 'file';
 			}
 			if ($this->headObject($path . '/')) {


### PR DESCRIPTION
Follow-Up https://github.com/nextcloud/server/pull/11518

- `file1.txt`
- `folder/file1.txt`

If a file with the same name exists in a sub directory (prefix to be precise) `file1.txt` is overwritten (the array key not the file itself) by `folder/file1.txt`. `getContentLength` and `getLastModified` are called with `folder/file1.txt` and the internal cache does not hit.