### PR TITLE
Add DB table to extend filecache with metadata etag, creation  and upload time

### DIFF
--- a/core/Migrations/Version17000Date20190514105811.php
+++ b/core/Migrations/Version17000Date20190514105811.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Morris Jobke <hey@morrisjobke.de>
+ *
+ * @author Morris Jobke <hey@morrisjobke.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OC\Core\Migrations;
+
+use Closure;
+use Doctrine\DBAL\Types\Type;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version17000Date20190514105811 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		if(!$schema->hasTable('filecache_extended')) {
+			$table = $schema->createTable('filecache_extended');
+			$table->addColumn('fileid', Type::INTEGER, [
+				'notnull' => true,
+				'length' => 4,
+				'unsigned' => true,
+			]);
+			$table->addColumn('metadata_etag', Type::STRING, [
+				'notnull' => false,
+				'length' => 40,
+			]);
+			$table->addColumn('creation_time', Type::BIGINT, [
+				'notnull' => true,
+				'length' => 20,
+				'default' => 0,
+			]);
+			$table->addColumn('upload_time', Type::BIGINT, [
+				'notnull' => true,
+				'length' => 20,
+				'default' => 0,
+			]);
+			$table->addUniqueIndex(['fileid'], 'fce_fileid_idx');
+			$table->addIndex(['creation_time'], 'fce_ctime_idx');
+			$table->addIndex(['upload_time'], 'fce_utime_idx');
+		}
+
+		return $schema;
+	}
+}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -757,6 +757,7 @@ return array(
     'OC\\Core\\Migrations\\Version16000Date20190212081545' => $baseDir . '/core/Migrations/Version16000Date20190212081545.php',
     'OC\\Core\\Migrations\\Version16000Date20190427105638' => $baseDir . '/core/Migrations/Version16000Date20190427105638.php',
     'OC\\Core\\Migrations\\Version16000Date20190428150708' => $baseDir . '/core/Migrations/Version16000Date20190428150708.php',
+    'OC\\Core\\Migrations\\Version17000Date20190514105811' => $baseDir . '/core/Migrations/Version17000Date20190514105811.php',
     'OC\\Core\\Notification\\RemoveLinkSharesNotifier' => $baseDir . '/core/Notification/RemoveLinkSharesNotifier.php',
     'OC\\Core\\Service\\LoginFlowV2Service' => $baseDir . '/core/Service/LoginFlowV2Service.php',
     'OC\\DB\\Adapter' => $baseDir . '/lib/private/DB/Adapter.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -791,6 +791,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Core\\Migrations\\Version16000Date20190212081545' => __DIR__ . '/../../..' . '/core/Migrations/Version16000Date20190212081545.php',
         'OC\\Core\\Migrations\\Version16000Date20190427105638' => __DIR__ . '/../../..' . '/core/Migrations/Version16000Date20190427105638.php',
         'OC\\Core\\Migrations\\Version16000Date20190428150708' => __DIR__ . '/../../..' . '/core/Migrations/Version16000Date20190428150708.php',
+        'OC\\Core\\Migrations\\Version17000Date20190514105811' => __DIR__ . '/../../..' . '/core/Migrations/Version17000Date20190514105811.php',
         'OC\\Core\\Notification\\RemoveLinkSharesNotifier' => __DIR__ . '/../../..' . '/core/Notification/RemoveLinkSharesNotifier.php',
         'OC\\Core\\Service\\LoginFlowV2Service' => __DIR__ . '/../../..' . '/core/Service/LoginFlowV2Service.php',
         'OC\\DB\\Adapter' => __DIR__ . '/../../..' . '/lib/private/DB/Adapter.php',


### PR DESCRIPTION
For #8477

Now the big question is: should we try to add more columns to this new table. The idea was to add some generic columns for strings, integer, bools, etc that are by default are just empty and can be used in the future then? The problem we want to solve with this is that the filecache is a big table that is not easily extendable on all possible DBs without a major downtime due to the size of the table. This is especially the case for MySQL/MariaDB where an added column results in the table being created from scratch and then is copied over and thus causing quite some downtime.


cc @rullzer @icewind1991 @karlitschek @nickvergessen @blizzz @kesselb @ChristophWurst 