### PR TITLE
Catch Request exception in testRemoteUrl

### DIFF
--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -32,6 +32,7 @@ namespace OCA\Files_Sharing\External;
 
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use OC\Files\Storage\DAV;
 use OC\ForbiddenException;
 use OCA\Files_Sharing\ISharedStorage;
@@ -279,6 +280,8 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage {
 		} catch (ConnectException $e) {
 			$returnValue = false;
 		} catch (ClientException $e) {
+			$returnValue = false;
+		} catch (RequestException $e) {
 			$returnValue = false;
 		}
 


### PR DESCRIPTION
Else the background job fails hard if the remote has for example an invalid certificate.

Basically it is to solve: https://github.com/nextcloud/server/blob/0e72d38747b12913c7524e07f8f9adc11f75f407/apps/files_sharing/lib/External/Storage.php#L298 that path
