### PR TITLE
Dont check Bucket Name in Nextcloud

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -100,12 +100,12 @@ trait S3ConnectionTrait {
 		$this->connection = new S3Client($options);
 
 		if (!$this->connection->isBucketDnsCompatible($this->bucket)) {
-                         $logger = \OC::$server->getLogger();
-                         $logger->warning('Bucket "' . $this->bucket . '" This bucket name is not dns compatible, it may contain invalid characters.',
-                         ['app' => 'objectstore']);
-                }
+			$logger = \OC::$server->getLogger();
+			$logger->warning('Bucket "' . $this->bucket . '" This bucket name is not dns compatible, it may contain invalid characters.',
+					 ['app' => 'objectstore']);
+		}
 
-                if (!$this->connection->doesBucketExist($this->bucket)) {
+		if (!$this->connection->doesBucketExist($this->bucket)) {
 			$logger = \OC::$server->getLogger();
 			try {
 				$logger->info('Bucket "' . $this->bucket . '" does not exist - creating it.', ['app' => 'objectstore']);

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -101,7 +101,7 @@ trait S3ConnectionTrait {
 
 		if (!$this->connection->isBucketDnsCompatible($this->bucket)) {
 			$logger = \OC::$server->getLogger();
-			$logger->warning('Bucket "' . $this->bucket . '" This bucket name is not dns compatible, it may contain invalid characters.',
+			$logger->debug('Bucket "' . $this->bucket . '" This bucket name is not dns compatible, it may contain invalid characters.',
 					 ['app' => 'objectstore']);
 		}
 

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -99,10 +99,6 @@ trait S3ConnectionTrait {
 		}
 		$this->connection = new S3Client($options);
 
-		if (!$this->connection->isBucketDnsCompatible($this->bucket)) {
-			throw new \Exception("The configured bucket name is invalid: " . $this->bucket);
-		}
-
 		if (!$this->connection->doesBucketExist($this->bucket)) {
 			$logger = \OC::$server->getLogger();
 			try {

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -99,13 +99,20 @@ trait S3ConnectionTrait {
 		}
 		$this->connection = new S3Client($options);
 
-		if (!$this->connection->doesBucketExist($this->bucket)) {
+		if (!$this->connection->isBucketDnsCompatible($this->bucket)) {
+                         $logger = \OC::$server->getLogger();
+                         $logger->warning('Bucket "' . $this->bucket . '" This bucket name is not dns compatible, it may contain invalid characters.',
+                         ['app' => 'objectstore']);
+                }
+
+                if (!$this->connection->doesBucketExist($this->bucket)) {
 			$logger = \OC::$server->getLogger();
 			try {
 				$logger->info('Bucket "' . $this->bucket . '" does not exist - creating it.', ['app' => 'objectstore']);
-				$this->connection->createBucket(array(
-					'Bucket' => $this->bucket
-				));
+				if (!$this->connection->isBucketDnsCompatible($this->bucket)) {
+					throw new \Exception("The bucket will not be created because the name is not dns compatible, please correct it: " . $this->bucket);
+				}
+				$this->connection->createBucket(array('Bucket' => $this->bucket));
 				$this->testTimeout();
 			} catch (S3Exception $e) {
 				$logger->logException($e, [


### PR DESCRIPTION
Hi All, 

Ceph S3 storage permit "_" and uppercase in bucket name, it's more permissive that Amazon S3 rules [1].
Actually in Nextcloud, some buckets (created from CEPH) could not be mount due to the check of the bucket name with function "isBucketDnsCompatible" (come from aws sdk).
It could be better not to check bucket name in Nextcloud, it's only necessary when you create a bucket, but that is not the case in Nextcloud.

Thanks,

[1] Look at here : 
https://tracker.ceph.com/issues/36293
http://docs.ceph.com/docs/jewel/radosgw/config-ref/ => search for "rgw relaxed s3 bucket names"
