### PR TITLE
Warning if x-forwarded-host present but trusted_proxies empty

### DIFF
--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -289,9 +289,14 @@ class CheckSetupController extends Controller {
 		$trustedProxies = $this->config->getSystemValue('trusted_proxies', []);
 		$remoteAddress = $this->request->getHeader('REMOTE_ADDR');
 
-		if (\is_array($trustedProxies) && \in_array($remoteAddress, $trustedProxies)) {
+		if (empty($trustedProxies) && $this->request->getHeader('X-Forwarded-Host')) {
+			return false;
+		}
+
+		if (\is_array($trustedProxies) && \in_array($remoteAddress, $trustedProxies, true)) {
 			return $remoteAddress !== $this->request->getRemoteAddress();
 		}
+
 		// either not enabled or working correctly
 		return true;
 	}


### PR DESCRIPTION
If you run nextcloud behind a reverse proxy then usually X-Forwarded-Host is present:

- apache2.4: https://httpd.apache.org/docs/current/mod/mod_proxy.html#x-headers
- nginx: https://www.nginx.com/resources/wiki/start/topics/examples/forwarded/

I've decided against X-Forwarded-For because this will cause a false positive on plesk hosting (nginx in front of apache: https://docs.plesk.com/en-US/onyx/administrator-guide/web-servers/apache-and-nginx-web-servers-linux/apache-with-nginx.70837/)

cc @J0WI will show a warning to docker users with an invalid setup (empty trusted proxies). 

