### PR TITLE
Bugfix/2 fa settings icons invert in dark themes #13643

### DIFF
--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -520,6 +520,7 @@ table.nostyle {
 		width: 16px;
 		height: 16px;
 		vertical-align: sub;
+		display: inline-block;
 	}
 }
 

--- a/settings/templates/settings/personal/security.php
+++ b/settings/templates/settings/personal/security.php
@@ -76,15 +76,15 @@ if($_['passwordChangeSupported']) {
 			/** @var \OCP\Authentication\TwoFactorAuth\IProvidesPersonalSettings $provider */
 			$provider = $data['provider'];
 			if ($provider instanceof \OCP\Authentication\TwoFactorAuth\IProvidesIcons) {
-				$icon = $provider->getDarkIcon();
+				$icon = sprintf('icon-twofactor_%s', $provider->getId());
 			} else {
-				$icon = image_path('core', 'actions/password.svg');
+				$icon = 'icon-password';
 			}
 			/** @var \OCP\Authentication\TwoFactorAuth\IPersonalProviderSettings $settings */
 			$settings = $data['settings'];
 			?>
 			<h3>
-				<img class="two-factor-provider-settings-icon" src="<?php p($icon) ?>" alt="">
+				<div class="two-factor-provider-settings-icon <?php p($icon) ?>"></div>
 				<?php p($provider->getDisplayName()) ?>
 			</h3>
 			<?php print_unescaped($settings->getBody()->fetchPage()) ?>


### PR DESCRIPTION
Other two factor auth apps must implement your own `icon-twofactor_$appId` css class based on [this](https://docs.nextcloud.com/server/latest/developer_manual/design/css.html#scss-icon-mixins) mixin functionality.
E.g. totp app:
`.icon-twofactor_totp { @include icon-black-white('icon-name', 'app-name', 1) } `
// result is something like that 
<img width="641" alt="image" src="https://user-images.githubusercontent.com/9904514/52920282-183afd80-3320-11e9-9384-36ed308f934b.png">

But i can't understand how nextcloud theme system, know to change the icons color with svg api based on current theme mode.
Sorry, i know my English grammar is not correct 😬 but i like to contribute.