### PR TITLE
Set false as default for requirePNG

### DIFF
--- a/lib/private/Activity/Manager.php
+++ b/lib/private/Activity/Manager.php
@@ -58,7 +58,7 @@ class Manager implements IManager {
 	protected $formattingObjectId;
 
 	/** @var bool */
-	protected $requirePNG;
+	protected $requirePNG = false;
 
 	/** @var string */
 	protected $currentUserId;


### PR DESCRIPTION
Exception if an activity created for app "core". Does not happen if "settings" is used as app :thinking: 

`{"reqId":"ZRBJc0pB1nEnzqjy2eDX","level":3,"time":"2019-02-17T22:27:47+00:00","remoteAddr":"192.168.10.1","user":"admin","app":"PHP","method":"GET","url":"\/ocs\/v2.php\/cloud\/activity?start=0&count=100&format=json","message":"TypeError: Return value of OC\\Activity\\Manager::getRequirePNG() must be of the type boolean, null returned at \/home\/vagrant\/code\/nextcloud\/lib\/private\/Activity\/Manager.php#328","userAgent":"Mozilla\/5.0 (Linux) mirall\/2.5.1git (Nextcloud)","version":"16.0.0.0"}
`

`INSERT INTO nextcloud.oc_activity (activity_id, timestamp, priority, type, user, affecteduser, app, subject, subjectparams, message, messageparams, file, link, object_type, object_id) VALUES (45, 1550442423, 30, 'security', 'admin', 'admin', 'core', 'app_token_created', '{"name":"Mozilla\\/5.0 (Linux) mirall\\/2.5.1git (Nextcloud)"}', '', '[]', 'App Password', '', 'app_token', 107);`
