### PR TITLE
Add guest navigation type

### DIFF
--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -39,6 +39,7 @@ use OCP\Files\NotFoundException;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IL10N;
+use OCP\INavigationManager;
 use OCP\IURLGenerator;
 
 class ThemingDefaults extends \OC_Defaults {
@@ -57,6 +58,9 @@ class ThemingDefaults extends \OC_Defaults {
 	private $util;
 	/** @var IAppManager */
 	private $appManager;
+	/** @var INavigationManager */
+	private $navigationManager;
+
 	/** @var string */
 	private $name;
 	/** @var string */
@@ -94,7 +98,8 @@ class ThemingDefaults extends \OC_Defaults {
 								ICacheFactory $cacheFactory,
 								Util $util,
 								ImageManager $imageManager,
-								IAppManager $appManager
+								IAppManager $appManager,
+								INavigationManager $navigationManager
 	) {
 		parent::__construct();
 		$this->config = $config;
@@ -104,6 +109,7 @@ class ThemingDefaults extends \OC_Defaults {
 		$this->cacheFactory = $cacheFactory;
 		$this->util = $util;
 		$this->appManager = $appManager;
+		$this->navigationManager = $navigationManager;
 
 		$this->name = parent::getName();
 		$this->title = parent::getTitle();
@@ -169,6 +175,15 @@ class ThemingDefaults extends \OC_Defaults {
 				'url' => (string)$this->getPrivacyUrl()
 			],
 		];
+
+		$navigation = $this->navigationManager->getAll(INavigationManager::TYPE_GUEST);
+		$guestNavigation = array_map(function($nav) {
+			return [
+				'text' => $nav['name'],
+				'url' => $nav['href']
+			];
+		}, $navigation);
+		$links = array_merge($links, $guestNavigation);
 
 		$legalLinks = ''; $divider = '';
 		foreach($links as $link) {

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -41,6 +41,7 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IL10N;
+use OCP\INavigationManager;
 use OCP\IURLGenerator;
 use Test\TestCase;
 
@@ -67,6 +68,8 @@ class ThemingDefaultsTest extends TestCase {
 	private $appManager;
 	/** @var ImageManager|\PHPUnit_Framework_MockObject_MockObject */
 	private $imageManager;
+	/** @var INavigationManager|\PHPUnit_Framework_MockObject_MockObject */
+	private $navigationManager;
 
 	public function setUp() {
 		parent::setUp();
@@ -78,6 +81,7 @@ class ThemingDefaultsTest extends TestCase {
 		$this->util = $this->createMock(Util::class);
 		$this->imageManager = $this->createMock(ImageManager::class);
 		$this->appManager = $this->createMock(IAppManager::class);
+		$this->navigationManager = $this->createMock(INavigationManager::class);
 		$this->defaults = new \OC_Defaults();
 		$this->urlGenerator
 			->expects($this->any())
@@ -90,7 +94,8 @@ class ThemingDefaultsTest extends TestCase {
 			$this->cacheFactory,
 			$this->util,
 			$this->imageManager,
-			$this->appManager
+			$this->appManager,
+			$this->navigationManager
 		);
 	}
 
@@ -266,6 +271,7 @@ class ThemingDefaultsTest extends TestCase {
 	}
 
 	public function testGetShortFooterEmptyUrl() {
+		$this->navigationManager->expects($this->once())->method('getAll')->with(INavigationManager::TYPE_GUEST)->willReturn([]);
 		$this->config
 			->expects($this->exactly(5))
 			->method('getAppValue')
@@ -281,6 +287,7 @@ class ThemingDefaultsTest extends TestCase {
 	}
 
 	public function testGetShortFooterEmptySlogan() {
+		$this->navigationManager->expects($this->once())->method('getAll')->with(INavigationManager::TYPE_GUEST)->willReturn([]);
 		$this->config
 			->expects($this->exactly(5))
 			->method('getAppValue')
@@ -296,6 +303,7 @@ class ThemingDefaultsTest extends TestCase {
 	}
 
 	public function testGetShortFooterImprint() {
+		$this->navigationManager->expects($this->once())->method('getAll')->with(INavigationManager::TYPE_GUEST)->willReturn([]);
 		$this->config
 			->expects($this->exactly(5))
 			->method('getAppValue')
@@ -316,6 +324,7 @@ class ThemingDefaultsTest extends TestCase {
 	}
 
 	public function testGetShortFooterPrivacy() {
+		$this->navigationManager->expects($this->once())->method('getAll')->with(INavigationManager::TYPE_GUEST)->willReturn([]);
 		$this->config
 			->expects($this->exactly(5))
 			->method('getAppValue')
@@ -336,6 +345,7 @@ class ThemingDefaultsTest extends TestCase {
 	}
 
 	public function testGetShortFooterAllLegalLinks() {
+		$this->navigationManager->expects($this->once())->method('getAll')->with(INavigationManager::TYPE_GUEST)->willReturn([]);
 		$this->config
 			->expects($this->exactly(5))
 			->method('getAppValue')
@@ -367,6 +377,7 @@ class ThemingDefaultsTest extends TestCase {
 	 * @dataProvider invalidLegalUrlProvider
 	 */
 	public function testGetShortFooterInvalidImprint($invalidImprintUrl) {
+		$this->navigationManager->expects($this->once())->method('getAll')->with(INavigationManager::TYPE_GUEST)->willReturn([]);
 		$this->config
 			->expects($this->exactly(5))
 			->method('getAppValue')
@@ -386,6 +397,7 @@ class ThemingDefaultsTest extends TestCase {
 	 * @dataProvider invalidLegalUrlProvider
 	 */
 	public function testGetShortFooterInvalidPrivacy($invalidPrivacyUrl) {
+		$this->navigationManager->expects($this->once())->method('getAll')->with(INavigationManager::TYPE_GUEST)->willReturn([]);
 		$this->config
 			->expects($this->exactly(5))
 			->method('getAppValue')

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -964,7 +964,8 @@ class Server extends ServerContainer implements IServerContainer {
 					$c->getMemCacheFactory(),
 					new Util($c->getConfig(), $this->getAppManager(), $c->getAppDataDir('theming')),
 					new ImageManager($c->getConfig(), $c->getAppDataDir('theming'), $c->getURLGenerator(), $this->getMemCacheFactory(), $this->getLogger()),
-					$c->getAppManager()
+					$c->getAppManager(),
+					$c->getNavigationManager()
 				);
 			}
 			return new \OC_Defaults();

--- a/lib/public/INavigationManager.php
+++ b/lib/public/INavigationManager.php
@@ -39,6 +39,25 @@ namespace OCP;
  * @since 6.0.0
  */
 interface INavigationManager {
+
+	/**
+	 * Navigation entries of the app navigation
+	 * @since 16.0.0
+	 */
+	const TYPE_APPS = 'link';
+
+	/**
+	 * Navigation entries of the settings navigation
+	 * @since 16.0.0
+	 */
+	const TYPE_SETTINGS = 'settings';
+
+	/**
+	 * Navigation entries for public page footer navigation
+	 * @since 16.0.0
+	 */
+	const TYPE_GUEST = 'guest';
+
 	/**
 	 * Creates a new navigation entry
 	 *
@@ -65,5 +84,5 @@ interface INavigationManager {
 	 * @return array
 	 * @since 14.0.0
 	 */
-	public function getAll(string $type = 'link'): array;
+	public function getAll(string $type = self::TYPE_APPS): array;
 }


### PR DESCRIPTION
This allows apps like https://github.com/nextcloud/external/pull/131 to add links to the public page footer.

![image](https://user-images.githubusercontent.com/3404133/52936874-df217e00-335d-11e9-9c6b-7223b073961d.png)

The existing privacy/imprint links from the theming app will be kept as they are.

Part of implementing https://github.com/nextcloud/external/issues/111