### PR TITLE
Fix writable public folder share

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -433,6 +433,7 @@ class ShareController extends AuthPublicShareController {
 			\OCP\Util::addScript('files', 'filemultiselectmenu');
 			\OCP\Util::addScript('files', 'filelist');
 			\OCP\Util::addScript('files', 'keyboardshortcuts');
+			\OCP\Util::addScript('files', 'operationprogressbar');
 		}
 
 		// OpenGraph Support: http://ogp.me/


### PR DESCRIPTION
This PR fixes public shared folders not working when there are write permissions, due to the missing js file from https://github.com/nextcloud/server/pull/12652

Steps to reproduce:
- Share a folder with write permissions via a link
- Open the link

Found by failing acceptance test: https://drone.nextcloud.com/nextcloud/server/16010/245