### PR TITLE
Handle writestream not closing source

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -181,8 +181,12 @@ class File extends Node implements IFile {
 
 				$count = $partStorage->writeStream($internalPartPath, $wrappedData);
 				$result = $count > 0;
+
 				if ($result === false) {
 					$result = $isEOF;
+					if (is_resource($wrappedData)) {
+						$result = feof($wrappedData);
+					}
 				}
 
 			} else {


### PR DESCRIPTION
Fixes #14298

If a storage doesn'tclose the write stream then $isEOF is not yet set.
So we have to fallback.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>