### PR TITLE
Use proper scroll container when dragging files

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -455,21 +455,20 @@ var dragOptions={
 		$('.crumbmenu').removeClass('canDropChildren');
 	},
 	drag: function(event, ui) {
-		var scrollingArea = FileList.$container;
+		var scrollingArea = window;
 		var currentScrollTop = $(scrollingArea).scrollTop();
 		var scrollArea = Math.min(Math.floor($(window).innerHeight() / 2), 100);
 
 		var bottom = $(window).innerHeight() - scrollArea;
 		var top = $(window).scrollTop() + scrollArea;
 		if (event.pageY < top) {
-			$('html, body').animate({
-
-				scrollTop: $(scrollingArea).scrollTop(currentScrollTop - 10)
+			$(scrollingArea).animate({
+				scrollTop: currentScrollTop - 10
 			}, 400);
 
 		} else if (event.pageY > bottom) {
-			$('html, body').animate({
-				scrollTop: $(scrollingArea).scrollTop(currentScrollTop + 10)
+			$(scrollingArea).animate({
+				scrollTop: currentScrollTop + 10
 			}, 400);
 		}
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/12844

Steps to reproduce:
- Have a long file list
- Start dragging a file to the bottom
- The view should scroll