### PR TITLE
No need to check 2fa state on apptoken logins

### DIFF
--- a/core/Middleware/TwoFactorMiddleware.php
+++ b/core/Middleware/TwoFactorMiddleware.php
@@ -95,7 +95,8 @@ class TwoFactorMiddleware extends Middleware {
 		if ($this->userSession->isLoggedIn()) {
 			$user = $this->userSession->getUser();
 
-			if ($this->twoFactorManager->isTwoFactorAuthenticated($user)) {
+
+			if ($this->session->exists('app_password') || $this->twoFactorManager->isTwoFactorAuthenticated($user)) {
 				$this->checkTwoFactor($controller, $methodName, $user);
 			} else if ($controller instanceof TwoFactorChallengeController) {
 				// Allow access to the two-factor controllers only if two-factor authentication


### PR DESCRIPTION
If you login with an apptoken there is no need to check 2FA state as
this does not apply to apptokens. Not checking saves us a query on each
request made from a client.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>