### PR TITLE
implement principal property search for calendar user address set property

### DIFF
--- a/apps/dav/lib/CalDAV/ResourceBooking/AbstractPrincipalBackend.php
+++ b/apps/dav/lib/CalDAV/ResourceBooking/AbstractPrincipalBackend.php
@@ -244,6 +244,14 @@ abstract class AbstractPrincipalBackend implements BackendInterface {
 					$stmt->closeCursor();
 					break;
 
+				case '{urn:ietf:params:xml:ns:caldav}calendar-user-address-set':
+					// If you add support for more search properties that qualify as a user-address,
+					// please also add them to the array below
+					$results[] = $this->searchPrincipals($this->principalPrefix, [
+						'{http://sabredav.org/ns}email-address' => $value,
+					], 'anyof');
+					break;
+
 				default:
 					$results[] = [];
 					break;

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -287,6 +287,16 @@ class Principal implements BackendInterface {
 					}, []);
 					break;
 
+				case '{urn:ietf:params:xml:ns:caldav}calendar-user-address-set':
+					// If you add support for more search properties that qualify as a user-address,
+					// please also add them to the array below
+					$results[] = $this->searchUserPrincipals([
+						// In theory this should also search for principal:principals/users/...
+						// but that's used internally only anyway and i don't know of any client querying that
+						'{http://sabredav.org/ns}email-address' => $value,
+					], 'anyof');
+					break;
+
 				default:
 					$results[] = [];
 					break;

--- a/apps/dav/lib/DAV/GroupPrincipalBackend.php
+++ b/apps/dav/lib/DAV/GroupPrincipalBackend.php
@@ -222,6 +222,13 @@ class GroupPrincipalBackend implements BackendInterface {
 					}, []);
 					break;
 
+				case '{urn:ietf:params:xml:ns:caldav}calendar-user-address-set':
+					// If you add support for more search properties that qualify as a user-address,
+					// please also add them to the array below
+					$results[] = $this->searchPrincipals(self::PRINCIPAL_PREFIX, [
+					], 'anyof');
+					break;
+
 				default:
 					$results[] = [];
 					break;

--- a/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
@@ -391,6 +391,32 @@ class PrincipalTest extends TestCase {
 		];
 	}
 
+	public function testSearchPrincipalByCalendarUserAddressSet() {
+		$this->shareManager->expects($this->exactly(2))
+			->method('shareAPIEnabled')
+			->will($this->returnValue(true));
+
+		$this->shareManager->expects($this->exactly(2))
+			->method('shareWithGroupMembersOnly')
+			->will($this->returnValue(false));
+
+		$user2 = $this->createMock(IUser::class);
+		$user2->method('getUID')->will($this->returnValue('user2'));
+		$user3 = $this->createMock(IUser::class);
+		$user3->method('getUID')->will($this->returnValue('user3'));
+
+		$this->userManager->expects($this->at(0))
+			->method('getByEmail')
+			->with('user@example.com')
+			->will($this->returnValue([$user2, $user3]));
+
+		$this->assertEquals([
+				'principals/users/user2',
+				'principals/users/user3',
+			], $this->connector->searchPrincipals('principals/users',
+			['{urn:ietf:params:xml:ns:caldav}calendar-user-address-set' => 'user@example.com']));
+	}
+
 	public function testFindByUriSharingApiDisabled() {
 		$this->shareManager->expects($this->once())
 			->method('shareApiEnabled')


### PR DESCRIPTION
fixes #12033

This will extend FreeBusy support for KDE-PIM and Evolution.

Before:
```
curl -XREPORT -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Depth:0" -d '<principal-property-search xmlns="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">     curl -XREPORT -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Depth:0" -d '<principal-property-search xmlns="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
  <apply-to-principal-collection-set />
  <property-search>
    <prop>
      <c:calendar-user-address-set />
    </prop>
    <match>foo3@ehrke.email</match>
  </property-search>
  <prop>
    <displayname />
  </prop>
</principal-property-search>' 'http://nextcloud.local/remote.php/dav/calendars/admin/personal'

<?xml version="1.0"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:cal="urn:ietf:params:xml:ns:caldav" xmlns:cs="http://calendarserver.org/ns/" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"/>%
```

after:
```
curl -XREPORT -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Depth:0" -d '<principal-property-search xmlns="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
  <apply-to-principal-collection-set />
  <property-search>
    <prop>
      <c:calendar-user-address-set />
    </prop>
    <match>foo3@ehrke.email</match>
  </property-search>
  <prop>
    <displayname />
  </prop>
</principal-property-search>' 'http://nextcloud.local/remote.php/dav/calendars/admin/personal'

<?xml version="1.0"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:cal="urn:ietf:params:xml:ns:caldav" xmlns:cs="http://calendarserver.org/ns/" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns">
<d:response>
    <d:href>/remote.php/dav/principals/users/user2/</d:href>
    <d:propstat>
        <d:prop>
            <d:displayname>Umberto</d:displayname>
        </d:prop>
        <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
</d:response>
</d:multistatus>%
```

@schiessle 
