### PR TITLE
Add OCS endpoint for search

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -445,6 +445,15 @@ pipeline:
     when:
       matrix:
         TESTS: integration-comments
+  integration-comments-ocs-search:
+    image: nextcloudci/integration-php7.1:1
+    commands:
+      - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
+      - cd build/integration
+      - ./run.sh features/comments-ocs-search.feature
+    when:
+      matrix:
+        TESTS: integration-comments-ocs-search
   integration-comments-search:
     image: nextcloudci/integration-php7.1:1
     commands:
@@ -845,6 +854,7 @@ matrix:
     - TESTS: integration-tags
     - TESTS: integration-caldav
     - TESTS: integration-comments
+    - TESTS: integration-comments-ocs-search
     - TESTS: integration-comments-search
     - TESTS: integration-favorites
     - TESTS: integration-provisioning-v2

--- a/build/integration/features/bootstrap/FeatureContext.php
+++ b/build/integration/features/bootstrap/FeatureContext.php
@@ -32,6 +32,7 @@ require __DIR__ . '/../../vendor/autoload.php';
  * Features context.
  */
 class FeatureContext implements Context, SnippetAcceptingContext {
+	use OCSSearch;
 	use Search;
 	use WebDav;
 }

--- a/build/integration/features/bootstrap/OCSSearch.php
+++ b/build/integration/features/bootstrap/OCSSearch.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2019, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
+
+trait OCSSearch {
+
+	// BasicStructure trait is expected to be used in the class that uses this
+	// trait.
+
+	/**
+	 * @When /^user "([^"]*)" OCS searches for "([^"]*)" in app "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $query
+	 * @param string $app
+	 */
+	public function userOcsSearchesForInApp(string $user, string $query, string $app) {
+		$this->currentUser = $user;
+
+		$url = '/core/search';
+
+		$parameters[] = 'query=' . $query;
+		$parameters[] = 'inApps[]=' . $app;
+
+		$url .= '?' . implode('&', $parameters);
+
+		$this->sendingTo('GET', $url);
+	}
+
+	/**
+	 * @Then /^the list of OCS search results has "(\d+)" results$/
+	 */
+	public function theListOfOcsSearchResultsHasResults(int $count) {
+		$this->theHTTPStatusCodeShouldBe('200');
+		$this->theOCSStatusCodeShouldBe('100');
+
+		$searchResults = simplexml_load_string($this->response->getBody())->data[0];
+
+		Assert::assertEquals($count, count($searchResults->element));
+	}
+
+	/**
+	 * @Then /^OCS search result "(\d+)" contains$/
+	 *
+	 * @param int $number
+	 * @param TableNode $body
+	 */
+	public function ocsSearchResultXContains(int $number, TableNode $body) {
+		if (!($body instanceof TableNode)) {
+			return;
+		}
+
+		$searchResults = simplexml_load_string($this->response->getBody())->data[0];
+		$searchResult = $searchResults->element[$number];
+
+		foreach ($body->getRowsHash() as $expectedField => $expectedValue) {
+			if (!array_key_exists($expectedField, $searchResult)) {
+				Assert::fail("$expectedField was not found in response");
+			}
+
+			Assert::assertEquals($expectedValue, (string)$searchResult->$expectedField, "Field '$expectedField' does not match (" . $searchResult->$expectedField . ")");
+		}
+	}
+
+}

--- a/build/integration/features/bootstrap/Search.php
+++ b/build/integration/features/bootstrap/Search.php
@@ -30,14 +30,6 @@ trait Search {
 	// trait.
 
 	/**
-	 * @When /^searching for "([^"]*)"$/
-	 * @param string $query
-	 */
-	public function searchingFor(string $query) {
-		$this->searchForInApp($query, '');
-	}
-
-	/**
 	 * @When /^searching for "([^"]*)" in app "([^"]*)"$/
 	 * @param string $query
 	 * @param string $app

--- a/build/integration/features/comments-ocs-search.feature
+++ b/build/integration/features/comments-ocs-search.feature
@@ -1,0 +1,255 @@
+Feature: comments-ocs-search
+
+  Scenario: Search my own comment on a file belonging to myself
+    Given user "user0" exists
+    And User "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
+    And "user0" posts a comment with content "My first comment" on the file named "/myFileToComment.txt" it should return "201"
+    When user "user0" OCS searches for "first" in app "files"
+    Then the list of OCS search results has "1" results
+    And OCS search result "0" contains
+      | type | comment |
+      | comment | My first comment |
+      | authorId | user0 |
+      | authorName | user0 |
+      | path | myFileToComment.txt |
+      | fileName | myFileToComment.txt |
+      | name | My first comment |
+
+  Scenario: Search my own comment on a file shared by someone with me
+    Given user "user0" exists
+    And user "user1" exists
+    And User "user1" uploads file "data/textfile.txt" to "/sharedFileToComment.txt"
+    And As "user1" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+      | path | sharedFileToComment.txt |
+      | shareWith | user0 |
+      | shareType | 0 |
+    And "user0" posts a comment with content "My first comment" on the file named "/sharedFileToComment.txt" it should return "201"
+    When user "user0" OCS searches for "first" in app "files"
+    Then the list of OCS search results has "1" results
+    And OCS search result "0" contains
+      | type | comment |
+      | comment | My first comment |
+      | authorId | user0 |
+      | authorName | user0 |
+      | path | sharedFileToComment.txt |
+      | fileName | sharedFileToComment.txt |
+      | name | My first comment |
+
+  Scenario: Search other user's comment on a file shared by me
+    Given user "user0" exists
+    And user "user1" exists
+    And User "user0" uploads file "data/textfile.txt" to "/mySharedFileToComment.txt"
+    And As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+      | path | mySharedFileToComment.txt |
+      | shareWith | user1 |
+      | shareType | 0 |
+    And "user1" posts a comment with content "Other's first comment" on the file named "/mySharedFileToComment.txt" it should return "201"
+    When user "user0" OCS searches for "first" in app "files"
+    Then the list of OCS search results has "1" results
+    And OCS search result "0" contains
+      | type | comment |
+      | comment | Other's first comment |
+      | authorId | user1 |
+      | authorName | user1 |
+      | path | mySharedFileToComment.txt |
+      | fileName | mySharedFileToComment.txt |
+      | name | Other's first comment |
+
+  Scenario: Search other user's comment on a file shared by someone with me
+    Given user "user0" exists
+    And user "user1" exists
+    And User "user1" uploads file "data/textfile.txt" to "/sharedFileToComment.txt"
+    And As "user1" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+      | path | sharedFileToComment.txt |
+      | shareWith | user0 |
+      | shareType | 0 |
+    And "user1" posts a comment with content "Other's first comment" on the file named "/sharedFileToComment.txt" it should return "201"
+    When user "user0" OCS searches for "first" in app "files"
+    Then the list of OCS search results has "1" results
+    And OCS search result "0" contains
+      | type | comment |
+      | comment | Other's first comment |
+      | authorId | user1 |
+      | authorName | user1 |
+      | path | sharedFileToComment.txt |
+      | fileName | sharedFileToComment.txt |
+      | name | Other's first comment |
+
+  Scenario: Search several comments on a file belonging to myself
+    Given user "user0" exists
+    And User "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
+    And "user0" posts a comment with content "My first comment to be found" on the file named "/myFileToComment.txt" it should return "201"
+    And "user0" posts a comment with content "The second comment should not be found" on the file named "/myFileToComment.txt" it should return "201"
+    And "user0" posts a comment with content "My third comment to be found" on the file named "/myFileToComment.txt" it should return "201"
+    When user "user0" OCS searches for "comment to be found" in app "files"
+    Then the list of OCS search results has "2" results
+    And OCS search result "0" contains
+      | type | comment |
+      | comment | My third comment to be found |
+      | authorId | user0 |
+      | authorName | user0 |
+      | path | myFileToComment.txt |
+      | fileName | myFileToComment.txt |
+      | name | My third comment to be found |
+    And OCS search result "1" contains
+      | type | comment |
+      | comment | My first comment to be found |
+      | authorId | user0 |
+      | authorName | user0 |
+      | path | myFileToComment.txt |
+      | fileName | myFileToComment.txt |
+      | name | My first comment to be found |
+
+  Scenario: Search comment with a large message ellipsized on the right
+    Given user "user0" exists
+    And User "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
+    And "user0" posts a comment with content "A very verbose message that is meant to be used to test the ellipsized message returned when searching for long comments" on the file named "/myFileToComment.txt" it should return "201"
+    When user "user0" OCS searches for "verbose" in app "files"
+    Then the list of OCS search results has "1" results
+    And OCS search result "0" contains
+      | type | comment |
+      | comment | A very verbose message that is meant to… |
+      | authorId | user0 |
+      | authorName | user0 |
+      | path | myFileToComment.txt |
+      | fileName | myFileToComment.txt |
+      | name | A very verbose message that is meant to be used to test the ellipsized message returned when searching for long comments |
+
+  Scenario: Search comment with a large message ellipsized on the left
+    Given user "user0" exists
+    And User "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
+    And "user0" posts a comment with content "A very verbose message that is meant to be used to test the ellipsized message returned when searching for long comments" on the file named "/myFileToComment.txt" it should return "201"
+    When user "user0" OCS searches for "searching" in app "files"
+    Then the list of OCS search results has "1" results
+    And OCS search result "0" contains
+      | type | comment |
+      | comment | …ed message returned when searching for long comments |
+      | authorId | user0 |
+      | authorName | user0 |
+      | path | myFileToComment.txt |
+      | fileName | myFileToComment.txt |
+      | name | A very verbose message that is meant to be used to test the ellipsized message returned when searching for long comments |
+
+  Scenario: Search comment with a large message ellipsized on both ends
+    Given user "user0" exists
+    And User "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
+    And "user0" posts a comment with content "A very verbose message that is meant to be used to test the ellipsized message returned when searching for long comments" on the file named "/myFileToComment.txt" it should return "201"
+    When user "user0" OCS searches for "ellipsized" in app "files"
+    Then the list of OCS search results has "1" results
+    And OCS search result "0" contains
+      | type | comment |
+      | comment | …t to be used to test the ellipsized message returned when se… |
+      | authorId | user0 |
+      | authorName | user0 |
+      | path | myFileToComment.txt |
+      | fileName | myFileToComment.txt |
+      | name | A very verbose message that is meant to be used to test the ellipsized message returned when searching for long comments |
+
+  Scenario: Search comment on a file in a subfolder
+    Given user "user0" exists
+    And user "user0" created a folder "/subfolder"
+    And User "user0" uploads file "data/textfile.txt" to "/subfolder/myFileToComment.txt"
+    And "user0" posts a comment with content "My first comment" on the file named "/subfolder/myFileToComment.txt" it should return "201"
+    When user "user0" OCS searches for "first" in app "files"
+    Then the list of OCS search results has "1" results
+    And OCS search result "0" contains
+      | type | comment |
+      | comment | My first comment |
+      | authorId | user0 |
+      | authorName | user0 |
+      | path | subfolder/myFileToComment.txt |
+      | fileName | myFileToComment.txt |
+      | name | My first comment |
+
+  Scenario: Search several comments
+    Given user "user0" exists
+    And user "user1" exists
+    And User "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
+    And User "user0" uploads file "data/textfile.txt" to "/mySharedFileToComment.txt"
+    And As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+      | path | mySharedFileToComment.txt |
+      | shareWith | user1 |
+      | shareType | 0 |
+    And User "user1" uploads file "data/textfile.txt" to "/sharedFileToComment.txt"
+    And As "user1" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+      | path | sharedFileToComment.txt |
+      | shareWith | user0 |
+      | shareType | 0 |
+    And "user0" posts a comment with content "My first comment to be found" on the file named "/myFileToComment.txt" it should return "201"
+    And "user0" posts a comment with content "The second comment should not be found" on the file named "/myFileToComment.txt" it should return "201"
+    And "user0" posts a comment with content "My first comment to be found" on the file named "/mySharedFileToComment.txt" it should return "201"
+    And "user1" posts a comment with content "Other's first comment that should not be found" on the file named "/mySharedFileToComment.txt" it should return "201"
+    And "user1" posts a comment with content "Other's second comment to be found" on the file named "/mySharedFileToComment.txt" it should return "201"
+    And "user0" posts a comment with content "My first comment that should not be found" on the file named "/sharedFileToComment.txt" it should return "201"
+    And "user1" posts a comment with content "Other's first comment to be found" on the file named "/sharedFileToComment.txt" it should return "201"
+    And "user0" posts a comment with content "My second comment to be found that happens to be more verbose than the others and thus should be ellipsized" on the file named "/sharedFileToComment.txt" it should return "201"
+    And "user0" posts a comment with content "My third comment to be found" on the file named "/myFileToComment.txt" it should return "201"
+    When user "user0" OCS searches for "comment to be found" in app "files"
+    Then the list of OCS search results has "6" results
+    And OCS search result "0" contains
+      | type | comment |
+      | comment | My third comment to be found |
+      | authorId | user0 |
+      | authorName | user0 |
+      | path | myFileToComment.txt |
+      | fileName | myFileToComment.txt |
+      | name | My third comment to be found |
+    And OCS search result "1" contains
+      | type | comment |
+      | comment | My second comment to be found that happens to be more … |
+      | authorId | user0 |
+      | authorName | user0 |
+      | path | sharedFileToComment.txt |
+      | fileName | sharedFileToComment.txt |
+      | name | My second comment to be found that happens to be more verbose than the others and thus should be ellipsized |
+    And OCS search result "2" contains
+      | type | comment |
+      | comment | Other's first comment to be found |
+      | authorId | user1 |
+      | authorName | user1 |
+      | path | sharedFileToComment.txt |
+      | fileName | sharedFileToComment.txt |
+      | name | Other's first comment to be found |
+    And OCS search result "3" contains
+      | type | comment |
+      | comment | Other's second comment to be found |
+      | authorId | user1 |
+      | authorName | user1 |
+      | path | mySharedFileToComment.txt |
+      | fileName | mySharedFileToComment.txt |
+      | name | Other's second comment to be found |
+    And OCS search result "4" contains
+      | type | comment |
+      | comment | My first comment to be found |
+      | authorId | user0 |
+      | authorName | user0 |
+      | path | mySharedFileToComment.txt |
+      | fileName | mySharedFileToComment.txt |
+      | name | My first comment to be found |
+    And OCS search result "5" contains
+      | type | comment |
+      | comment | My first comment to be found |
+      | authorId | user0 |
+      | authorName | user0 |
+      | path | myFileToComment.txt |
+      | fileName | myFileToComment.txt |
+      | name | My first comment to be found |
+
+  Scenario: Search comment with a query that also matches a file name
+    Given user "user0" exists
+    And User "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
+    And "user0" posts a comment with content "A comment in myFileToComment.txt" on the file named "/myFileToComment.txt" it should return "201"
+    When user "user0" OCS searches for "myFileToComment" in app "files"
+    Then the list of OCS search results has "2" results
+    And OCS search result "0" contains
+      | type | file |
+      | path | /myFileToComment.txt |
+      | name | myFileToComment.txt |
+    And OCS search result "1" contains
+      | type | comment |
+      | comment | A comment in myFileToComment.txt |
+      | authorId | user0 |
+      | authorName | user0 |
+      | path | myFileToComment.txt |
+      | fileName | myFileToComment.txt |
+      | name | A comment in myFileToComment.txt |

--- a/core/Controller/OCSSearchController.php
+++ b/core/Controller/OCSSearchController.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Core\Controller;
+
+use OCP\AppFramework\OCSController;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\IRequest;
+use OCP\ISearch;
+
+class OCSSearchController extends OCSController {
+
+	/** @var ISearch */
+	private $searcher;
+
+	public function __construct(string $appName,
+								IRequest $request,
+								ISearch $search) {
+		parent::__construct($appName, $request);
+
+		$this->searcher = $search;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 */
+	public function search(string $query, array $inApps = [], int $page = 1, int $size = 30): DataResponse {
+		$results = $this->searcher->searchPaged($query, $inApps, $page, $size);
+
+		// Convert from an array of objects to an array of arrays.
+		$preparedResults = [];
+		foreach ($results as $result) {
+			$preparedResults[] = (array)$result;
+		}
+
+		return new DataResponse($preparedResults);
+	}
+}

--- a/core/routes.php
+++ b/core/routes.php
@@ -82,6 +82,7 @@ $application->registerRoutes($this, [
 		['root' => '/core', 'name' => 'WhatsNew#get', 'url' => '/whatsnew', 'verb' => 'GET'],
 		['root' => '/core', 'name' => 'WhatsNew#dismiss', 'url' => '/whatsnew', 'verb' => 'POST'],
 		['root' => '/core', 'name' => 'AppPassword#getAppPassword', 'url' => '/getapppassword', 'verb' => 'GET'],
+		['root' => '/core', 'name' => 'OCSSearch#search', 'url' => '/search', 'verb' => 'GET'],
 	],
 ]);
 


### PR DESCRIPTION
This would make possible to use the search endpoint from mobile apps (for example, [in Talk](https://github.com/nextcloud/spreed/pull/1270)); even if it ends not being used for Talk I would say that having an OCS endpoint for search makes sense anyway.

The current non-OCS endpoint is kept as is for backwards compatibility; I do not really know if it is used directly by any app (outside of the [default search provider](https://github.com/nextcloud/server/blob/c1e839961eb99df24742a605a5dfc1b10ed14d00/core/search/js/searchprovider.js#L150), which I have not changed either), but just in case.
