### PR TITLE
Always query lookup server in GS mode

### DIFF
--- a/lib/private/Collaboration/Collaborators/LookupPlugin.php
+++ b/lib/private/Collaboration/Collaborators/LookupPlugin.php
@@ -66,7 +66,7 @@ class LookupPlugin implements ISearchPlugin {
 		$hasInternetConnection = (bool)$this->config->getSystemValue('has_internet_connection', true);
 
 		// if case of Global Scale we always search the lookup server
-		if ((!$isLookupServerEnabled && !$isGlobalScaleEnabled) || !$hasInternetConnection) {
+		if (!$isGlobalScaleEnabled && (!$isLookupServerEnabled || !$hasInternetConnection)) {
 			return false;
 		}
 


### PR DESCRIPTION
Without the lookupserver GS is kind of useless.
If the admin places their lookup sever outside of the reachable network
that is not something we can help.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>