### PR TITLE
Fix alignment of filelist header

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -199,7 +199,7 @@ table.multiselect th .columntitle {
     display: inline-block;
 }
 table th .columntitle.name {
-	padding-left: 5px;
+	padding-left: 0;
 	margin-left: 50px;
 }
 


### PR DESCRIPTION
Alignment before & after – the header text "Name" was a bit too far to the right. Now left-aligned with the file names.

![alignment before](https://user-images.githubusercontent.com/925062/53170519-988f8600-35e0-11e9-8caf-4f634d7dfdf2.png)

![alignment after](https://user-images.githubusercontent.com/925062/53170518-988f8600-35e0-11e9-9a0b-7a289240e591.png)


Easy review @nextcloud/designers 