### PR TITLE
Move LDAP settings from tabbed interface to single page

### DIFF
--- a/apps/user_ldap/css/settings.css
+++ b/apps/user_ldap/css/settings.css
@@ -212,6 +212,7 @@ select[multiple=multiple] + button {
 #ldapSettings {
 	background-color: white;
 	padding: 0;
+	border: none;
 }
 
 #ldapSettings > fieldset {

--- a/apps/user_ldap/templates/part.wizard-groupfilter.php
+++ b/apps/user_ldap/templates/part.wizard-groupfilter.php
@@ -1,4 +1,5 @@
-<fieldset id="ldapWizard4">
+<fieldset id="ldapWizard4" class="section">
+	<h2><?php p($l->t('Groups'));?></h2>
 	<div>
 		<p>
 			<?php p($l->t('Groups meeting these criteria are available in %s:', [$theme->getName()]));?>

--- a/apps/user_ldap/templates/part.wizard-loginfilter.php
+++ b/apps/user_ldap/templates/part.wizard-loginfilter.php
@@ -1,4 +1,5 @@
-<fieldset id="ldapWizard3">
+<fieldset id="ldapWizard3" class="section">
+	<h2><?php p($l->t('Login attributes'));?></h2>
 	<div>
 		<p>
 			<?php p($l->t('When logging in, %s will find the user based on the following attributes:', [$theme->getName()]));?>

--- a/apps/user_ldap/templates/part.wizard-server.php
+++ b/apps/user_ldap/templates/part.wizard-server.php
@@ -1,4 +1,5 @@
-<fieldset id="ldapWizard1">
+<fieldset id="ldapWizard1" class="section">
+		<h2><?php p($l->t('LDAP server settings'));?></h2>
 		<p>
 		<select id="ldap_serverconfig_chooser" name="ldap_serverconfig_chooser">
 		<?php

--- a/apps/user_ldap/templates/part.wizard-userfilter.php
+++ b/apps/user_ldap/templates/part.wizard-userfilter.php
@@ -1,4 +1,5 @@
-<fieldset id="ldapWizard2">
+<fieldset id="ldapWizard2" class="section">
+	<h2><?php p($l->t('Users'));?></h2>
 	<div>
 		<p>
 			<?php p($l->t('Listing and searching for users is constrained by these criteria:'));?>

--- a/apps/user_ldap/templates/settings.php
+++ b/apps/user_ldap/templates/settings.php
@@ -54,30 +54,21 @@ style('user_ldap', 'settings');
 
 ?>
 
-<form id="ldap" class="section" action="#" method="post">
-	<h2><?php p($l->t('LDAP / AD integration')); ?></h2>
-
+<form id="ldap" action="#" method="post">
 	<div id="ldapSettings">
-	<ul>
-		<li id="#ldapWizard1"><a href="#ldapWizard1"><?php p($l->t('Server'));?></a></li>
-		<li id="#ldapWizard2"><a href="#ldapWizard2"><?php p($l->t('Users'));?></a></li>
-		<li id="#ldapWizard3"><a href="#ldapWizard3"><?php p($l->t('Login Attributes'));?></a></li>
-		<li id="#ldapWizard4"><a href="#ldapWizard4"><?php p($l->t('Groups'));?></a></li>
-		<li class="ldapSettingsTabs"><a href="#ldapSettings-2"><?php p($l->t('Expert'));?></a></li>
-		<li class="ldapSettingsTabs"><a href="#ldapSettings-1"><?php p($l->t('Advanced'));?></a></li>
-	</ul>
 	<?php
 	if(!function_exists('ldap_connect')) {
-		print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> The PHP LDAP module is not installed, the backend will not work. Please ask your system administrator to install it.').'</p>');
+		print_unescaped('<div class="ldapwarning section">'.$l->t('<h2>PHP LDAP module not installed</h2><p>The LDAP backend will not work without the module. Please ask your system administrator to install it.</p>').'</div>');
 	}
 	?>
 	<?php require_once __DIR__ . '/part.wizard-server.php'; ?>
 	<?php require_once __DIR__ . '/part.wizard-userfilter.php'; ?>
 	<?php require_once __DIR__ . '/part.wizard-loginfilter.php'; ?>
 	<?php require_once __DIR__ . '/part.wizard-groupfilter.php'; ?>
-	<fieldset id="ldapSettings-1">
+	<fieldset id="ldapSettings-1" class="section">
+		<h2><?php p($l->t('Advanced settings'));?></h2>
 		<div id="ldapAdvancedAccordion">
-			<h3><?php p($l->t('Connection Settings'));?></h3>
+			<h3><?php p($l->t('Connection settings'));?></h3>
 			<div>
 				<p><label for="ldap_configuration_active"><?php p($l->t('Configuration Active'));?></label><input type="checkbox" id="ldap_configuration_active" name="ldap_configuration_active" value="1" data-default="<?php p($_['ldap_configuration_active_default']); ?>"  title="<?php p($l->t('When unchecked, this configuration will be skipped.'));?>" /></p>
 				<p><label for="ldap_backup_host"><?php p($l->t('Backup (Replica) Host'));?></label><input type="text" id="ldap_backup_host" name="ldap_backup_host" data-default="<?php p($_['ldap_backup_host_default']); ?>" title="<?php p($l->t('Give an optional backup host. It must be a replica of the main LDAP/AD server.'));?>"></p>
@@ -113,17 +104,18 @@ style('user_ldap', 'settings');
 		</div>
 		<?php print_unescaped($_['settingControls']); ?>
 	</fieldset>
-	<fieldset id="ldapSettings-2">
-		<p><strong><?php p($l->t('Internal Username'));?></strong></p>
-		<p class="ldapIndent"><?php p($l->t('By default the internal username will be created from the UUID attribute. It makes sure that the username is unique and characters do not need to be converted. The internal username has the restriction that only these characters are allowed: [ a-zA-Z0-9_.@- ].  Other characters are replaced with their ASCII correspondence or simply omitted. On collisions a number will be added/increased. The internal username is used to identify a user internally. It is also the default name for the user home folder. It is also a part of remote URLs, for instance for all *DAV services. With this setting, the default behavior can be overridden. Leave it empty for default behavior. Changes will have effect only on newly mapped (added) LDAP users.'));?></p>
-		<p class="ldapIndent"><label for="ldap_expert_username_attr"><?php p($l->t('Internal Username Attribute:'));?></label><input type="text" id="ldap_expert_username_attr" name="ldap_expert_username_attr" data-default="<?php p($_['ldap_expert_username_attr_default']); ?>" /></p>
-		<p><strong><?php p($l->t('Override UUID detection'));?></strong></p>
-		<p class="ldapIndent"><?php p($l->t('By default, the UUID attribute is automatically detected. The UUID attribute is used to doubtlessly identify LDAP users and groups. Also, the internal username will be created based on the UUID, if not specified otherwise above. You can override the setting and pass an attribute of your choice. You must make sure that the attribute of your choice can be fetched for both users and groups and it is unique. Leave it empty for default behavior. Changes will have effect only on newly mapped (added) LDAP users and groups.'));?></p>
-		<p class="ldapIndent"><label for="ldap_expert_uuid_user_attr"><?php p($l->t('UUID Attribute for Users:'));?></label><input type="text" id="ldap_expert_uuid_user_attr" name="ldap_expert_uuid_user_attr" data-default="<?php p($_['ldap_expert_uuid_user_attr_default']); ?>" /></p>
-		<p class="ldapIndent"><label for="ldap_expert_uuid_group_attr"><?php p($l->t('UUID Attribute for Groups:'));?></label><input type="text" id="ldap_expert_uuid_group_attr" name="ldap_expert_uuid_group_attr" data-default="<?php p($_['ldap_expert_uuid_group_attr_default']); ?>" /></p>
-		<p><strong><?php p($l->t('Username-LDAP User Mapping'));?></strong></p>
-		<p class="ldapIndent"><?php p($l->t('Usernames are used to store and assign metadata. In order to precisely identify and recognize users, each LDAP user will have an internal username. This requires a mapping from username to LDAP user. The created username is mapped to the UUID of the LDAP user. Additionally the DN is cached as well to reduce LDAP interaction, but it is not used for identification. If the DN changes, the changes will be found. The internal username is used all over. Clearing the mappings will have leftovers everywhere. Clearing the mappings is not configuration sensitive, it affects all LDAP configurations! Never clear the mappings in a production environment, only in a testing or experimental stage.'));?></p>
-		<p class="ldapIndent"><button type="button" id="ldap_action_clear_user_mappings" name="ldap_action_clear_user_mappings"><?php p($l->t('Clear Username-LDAP User Mapping'));?></button><br/><button type="button" id="ldap_action_clear_group_mappings" name="ldap_action_clear_group_mappings"><?php p($l->t('Clear Groupname-LDAP Group Mapping'));?></button></p>
+	<fieldset id="ldapSettings-2" class="section">
+		<h2><?php p($l->t('Expert settings'));?></h2>
+		<h3><?php p($l->t('Internal Username'));?></h3>
+		<p><?php p($l->t('By default the internal username will be created from the UUID attribute. It makes sure that the username is unique and characters do not need to be converted. The internal username has the restriction that only these characters are allowed: [ a-zA-Z0-9_.@- ].  Other characters are replaced with their ASCII correspondence or simply omitted. On collisions a number will be added/increased. The internal username is used to identify a user internally. It is also the default name for the user home folder. It is also a part of remote URLs, for instance for all *DAV services. With this setting, the default behavior can be overridden. Leave it empty for default behavior. Changes will have effect only on newly mapped (added) LDAP users.'));?></p>
+		<p><label for="ldap_expert_username_attr"><?php p($l->t('Internal Username Attribute:'));?></label><input type="text" id="ldap_expert_username_attr" name="ldap_expert_username_attr" data-default="<?php p($_['ldap_expert_username_attr_default']); ?>" /></p>
+		<h3><?php p($l->t('Override UUID detection'));?></h3>
+		<p><?php p($l->t('By default, the UUID attribute is automatically detected. The UUID attribute is used to doubtlessly identify LDAP users and groups. Also, the internal username will be created based on the UUID, if not specified otherwise above. You can override the setting and pass an attribute of your choice. You must make sure that the attribute of your choice can be fetched for both users and groups and it is unique. Leave it empty for default behavior. Changes will have effect only on newly mapped (added) LDAP users and groups.'));?></p>
+		<p><label for="ldap_expert_uuid_user_attr"><?php p($l->t('UUID Attribute for Users:'));?></label><input type="text" id="ldap_expert_uuid_user_attr" name="ldap_expert_uuid_user_attr" data-default="<?php p($_['ldap_expert_uuid_user_attr_default']); ?>" /></p>
+		<p><label for="ldap_expert_uuid_group_attr"><?php p($l->t('UUID Attribute for Groups:'));?></label><input type="text" id="ldap_expert_uuid_group_attr" name="ldap_expert_uuid_group_attr" data-default="<?php p($_['ldap_expert_uuid_group_attr_default']); ?>" /></p>
+		<h3><?php p($l->t('Username-LDAP User Mapping'));?></h3>
+		<p><?php p($l->t('Usernames are used to store and assign metadata. In order to precisely identify and recognize users, each LDAP user will have an internal username. This requires a mapping from username to LDAP user. The created username is mapped to the UUID of the LDAP user. Additionally the DN is cached as well to reduce LDAP interaction, but it is not used for identification. If the DN changes, the changes will be found. The internal username is used all over. Clearing the mappings will have leftovers everywhere. Clearing the mappings is not configuration sensitive, it affects all LDAP configurations! Never clear the mappings in a production environment, only in a testing or experimental stage.'));?></p>
+		<p><button type="button" id="ldap_action_clear_user_mappings" name="ldap_action_clear_user_mappings"><?php p($l->t('Clear Username-LDAP User Mapping'));?></button><br/><button type="button" id="ldap_action_clear_group_mappings" name="ldap_action_clear_group_mappings"><?php p($l->t('Clear Groupname-LDAP Group Mapping'));?></button></p>
 		<?php print_unescaped($_['settingControls']); ?>
 	</fieldset>
 	</div>


### PR DESCRIPTION
This is only the first step, lots of enhancement needed and help from @nextcloud/ldap:

- [ ] On a new setup, only the "LDAP server settings" section should be displayed as the others are not relevant yet
- [ ] The "Configuration" and "Continue" controls should only be displayed once, and probably sticky at the bottom left of the area.
- [ ] The app needs to use the proper Nextcloud checkboxes https://docs.nextcloud.com/server/stable/developer_manual/design/html.html?highlight=checkbox#checkboxes-and-radios
- [ ] Currently jQuery UI overwrites our styles for e.g. border-radius on buttons. We should only use the aspects we need, which seems accordion. Or we just fully move away from that in favor of the sections?

To properly do this @blizzz and I will have to sit down at the Contributor Week as there’s a lot of moving parts there …

![ldap settings after](https://user-images.githubusercontent.com/925062/53172879-b2cc6280-35e6-11e9-8a10-6fe0c66aa559.png)



What do you think @blizzz @rullzer @MorrisJobke @karlitschek?