### PR TITLE
Apply theme to 2FA button

### DIFF
--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -60,8 +60,10 @@ $invert: luma($color-primary) > 0.6;
 			border: 1px solid nc-lighten($color-primary-text, 50%);
 		}
 		input.primary,
+		button.primary,
 		#alternative-logins li a {
 			background-color: $color-primary;
+			color: $color-primary-text;
 		}
 		a,
 		label,


### PR DESCRIPTION
Fixes #14317

The two factor auth screen uses a button instead of a submit input, so we need to apply the theming rules to that as well.