### PR TITLE
Fix unsafe array access 

### DIFF
--- a/apps/admin_audit/lib/Actions/Console.php
+++ b/apps/admin_audit/lib/Actions/Console.php
@@ -30,7 +30,7 @@ class Console extends Action {
 	 * @param $arguments
 	 */
 	public function runCommand(array $arguments) {
-		if ($arguments[1] === '_completion') {
+		if (!isset($arguments[1]) || $arguments[1] === '_completion') {
 			// Don't log autocompletion
 			return;
 		}


### PR DESCRIPTION
Close #13098 

I see this on my instance but cannot reproduce :see_no_evil: 