### PR TITLE
Fix occ files:scan elapsed time

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -289,10 +289,9 @@ class Scan extends Base {
 	 * @return string
 	 */
 	protected function formatExecTime() {
-		list($secs, ) = explode('.', sprintf("%.1f", $this->execTime));
-
-		# if you want to have microseconds add this:   . '.' . $tens;
-		return date('H:i:s', $secs);
+		$secs = round($this->execTime);
+		# convert seconds into HH:MM:SS form
+		return sprintf('%02d:%02d:%02d', ($secs/3600),($secs/60%60), $secs%60);
 	}
 
 	/**

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -291,7 +291,7 @@ class Scan extends Base {
 	protected function formatExecTime() {
 		$secs = round($this->execTime);
 		# convert seconds into HH:MM:SS form
-		return sprintf('%02d:%02d:%02d', ($secs/3600),($secs/60%60), $secs%60);
+		return sprintf('%02d:%02d:%02d', ($secs/3600), ($secs/60%60), $secs%60);
 	}
 
 	/**

--- a/apps/files/lib/Command/ScanAppData.php
+++ b/apps/files/lib/Command/ScanAppData.php
@@ -216,10 +216,9 @@ class ScanAppData extends Base {
 	 * @return string
 	 */
 	protected function formatExecTime() {
-		list($secs, ) = explode('.', sprintf("%.1f", $this->execTime));
-
-		# if you want to have microseconds add this:   . '.' . $tens;
-		return date('H:i:s', $secs);
+		$secs = round($this->execTime);
+		# convert seconds into HH:MM:SS form
+		return sprintf('%02d:%02d:%02d', ($secs/3600), ($secs/60%60), $secs%60);
 	}
 
 	/**


### PR DESCRIPTION
Fix #13911 `occ files:scan` command's elapsed time not displaying correctly when ran for more than 24hrs by formatting the elapsed seconds correctly.
Signed-off-by: Joel S <joel.devbox@protonmail.com>