### PR TITLE
fix(EMailTemplate): malformed HTML in some cases

### DIFF
--- a/lib/private/Mail/EMailTemplate.php
+++ b/lib/private/Mail/EMailTemplate.php
@@ -436,6 +436,7 @@ EOF;
 		}
 
 		$this->ensureBodyIsOpened();
+		$this->ensureBodyListClosed();
 
 		$this->htmlBody .= vsprintf($this->bodyText, [$text]);
 		if ($plainText !== false) {

--- a/lib/private/Mail/EMailTemplate.php
+++ b/lib/private/Mail/EMailTemplate.php
@@ -435,8 +435,8 @@ EOF;
 			$text = htmlspecialchars($text);
 		}
 
-		$this->ensureBodyIsOpened();
 		$this->ensureBodyListClosed();
+		$this->ensureBodyIsOpened();
 
 		$this->htmlBody .= vsprintf($this->bodyText, [$text]);
 		if ($plainText !== false) {


### PR DESCRIPTION
when an addBodyListItem() is not directly followed by addBodyButton(), resulting HTML is broken