### PR TITLE
allow group backends to mark that a group should now be shown in search dialogs

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -266,6 +266,7 @@ return array(
     'OCP\\Group\\Backend\\ICreateGroupBackend' => $baseDir . '/lib/public/Group/Backend/ICreateGroupBackend.php',
     'OCP\\Group\\Backend\\IDeleteGroupBackend' => $baseDir . '/lib/public/Group/Backend/IDeleteGroupBackend.php',
     'OCP\\Group\\Backend\\IGroupDetailsBackend' => $baseDir . '/lib/public/Group/Backend/IGroupDetailsBackend.php',
+    'OCP\\Group\\Backend\\IHideFromCollaborationBackend' => $baseDir . '/lib/public/Group/Backend/IHideFromCollaborationBackend.php',
     'OCP\\Group\\Backend\\IIsAdminBackend' => $baseDir . '/lib/public/Group/Backend/IIsAdminBackend.php',
     'OCP\\Group\\Backend\\IRemoveFromGroupBackend' => $baseDir . '/lib/public/Group/Backend/IRemoveFromGroupBackend.php',
     'OCP\\Group\\ISubAdmin' => $baseDir . '/lib/public/Group/ISubAdmin.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -296,6 +296,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Group\\Backend\\ICreateGroupBackend' => __DIR__ . '/../../..' . '/lib/public/Group/Backend/ICreateGroupBackend.php',
         'OCP\\Group\\Backend\\IDeleteGroupBackend' => __DIR__ . '/../../..' . '/lib/public/Group/Backend/IDeleteGroupBackend.php',
         'OCP\\Group\\Backend\\IGroupDetailsBackend' => __DIR__ . '/../../..' . '/lib/public/Group/Backend/IGroupDetailsBackend.php',
+        'OCP\\Group\\Backend\\IHideFromCollaborationBackend' => __DIR__ . '/../../..' . '/lib/public/Group/Backend/IHideFromCollaborationBackend.php',
         'OCP\\Group\\Backend\\IIsAdminBackend' => __DIR__ . '/../../..' . '/lib/public/Group/Backend/IIsAdminBackend.php',
         'OCP\\Group\\Backend\\IRemoveFromGroupBackend' => __DIR__ . '/../../..' . '/lib/public/Group/Backend/IRemoveFromGroupBackend.php',
         'OCP\\Group\\ISubAdmin' => __DIR__ . '/../../..' . '/lib/public/Group/ISubAdmin.php',

--- a/lib/private/Collaboration/Collaborators/GroupPlugin.php
+++ b/lib/private/Collaboration/Collaborators/GroupPlugin.php
@@ -73,6 +73,10 @@ class GroupPlugin implements ISearchPlugin {
 
 		$lowerSearch = strtolower($search);
 		foreach ($groups as $group) {
+			if ($group->hideFromCollaboration()) {
+				continue;
+			}
+
 			// FIXME: use a more efficient approach
 			$gid = $group->getGID();
 			if (!in_array($gid, $groupIds)) {

--- a/lib/private/Group/Group.php
+++ b/lib/private/Group/Group.php
@@ -30,6 +30,7 @@
 
 namespace OC\Group;
 
+use OCP\Group\Backend\IHideFromCollaborationBackend;
 use OCP\GroupInterface;
 use OCP\IGroup;
 use OCP\IUser;
@@ -349,5 +350,15 @@ class Group implements IGroup {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * @return bool
+	 * @since 16.0.0
+	 */
+	public function hideFromCollaboration(): bool {
+		return array_reduce($this->backends, function(bool $hide, GroupInterface $backend) {
+			return $hide | ($backend instanceof IHideFromCollaborationBackend && $backend->hideGroup($this->gid));
+		}, false);
 	}
 }

--- a/lib/public/Group/Backend/IHideFromCollaborationBackend.php
+++ b/lib/public/Group/Backend/IHideFromCollaborationBackend.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Group\Backend;
+
+/**
+ * @since 16.0.0
+ *
+ * Allow the backend to mark groups to be excluded from being shown in search dialogs
+ */
+interface IHideFromCollaborationBackend {
+	/**
+	 * Check if a group should be hidden from search dialogs
+	 *
+	 * @param string $groupId
+	 * @return bool
+	 * @since 16.0.0
+	 */
+	public function hideGroup(string $groupId): bool;
+}

--- a/lib/public/IGroup.php
+++ b/lib/public/IGroup.php
@@ -138,4 +138,10 @@ interface IGroup {
 	 * @since 14.0.0
 	 */
 	public function canAddUser();
+
+	/**
+	 * @return bool
+	 * @since 16.0.0
+	 */
+	public function hideFromCollaboration(): bool;
 }

--- a/tests/lib/Collaboration/Collaborators/GroupPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/GroupPluginTest.php
@@ -101,9 +101,10 @@ class GroupPluginTest extends TestCase {
 	/**
 	 * @param string $gid
 	 * @param null $displayName
+	 * @param bool $hide
 	 * @return IGroup|\PHPUnit_Framework_MockObject_MockObject
 	 */
-	protected function getGroupMock($gid, $displayName = null) {
+	protected function getGroupMock($gid, $displayName = null, $hide = false) {
 		$group = $this->createMock(IGroup::class);
 
 		$group->expects($this->any())
@@ -118,6 +119,9 @@ class GroupPluginTest extends TestCase {
 		$group->expects($this->any())
 			->method('getDisplayName')
 			->willReturn($displayName);
+
+		$group->method('hideFromCollaboration')
+			->willReturn($hide);
 
 		return $group;
 	}
@@ -413,7 +417,20 @@ class GroupPluginTest extends TestCase {
 				true,
 				$this->getGroupMock('test'),
 			],
+			[
+				'test', false, false,
+				[
+					$this->getGroupMock('test', null, true),
+					$this->getGroupMock('test1'),
+				],
+				[],
+				[],
+				[],
+				true,
+				false,
+			],
 		];
+
 	}
 
 	/**


### PR DESCRIPTION
use case here is hiding the virtual "guests" group from sharing when using the guests app