### PR TITLE
Fix typo in info log for autoconfig

### DIFF
--- a/core/Controller/SetupController.php
+++ b/core/Controller/SetupController.php
@@ -106,7 +106,7 @@ class SetupController {
 
 	public function loadAutoConfig($post) {
 		if( file_exists($this->autoConfigFile)) {
-			\OCP\Util::writeLog('core', 'Autoconfig file found, setting up ownCloud…', ILogger::INFO);
+			\OCP\Util::writeLog('core', 'Autoconfig file found, setting up Nextcloud…', ILogger::INFO);
 			$AUTOCONFIG = array();
 			include $this->autoConfigFile;
 			$post = array_merge ($post, $AUTOCONFIG);


### PR DESCRIPTION
Found while looking at logs from @skjnldsv 😉 