### PR TITLE
Use a tmp file for swift writes

### DIFF
--- a/lib/private/Files/ObjectStore/Swift.php
+++ b/lib/private/Files/ObjectStore/Swift.php
@@ -76,9 +76,18 @@ class Swift implements IObjectStore {
 	 * @throws \Exception from openstack lib when something goes wrong
 	 */
 	public function writeObject($urn, $stream) {
+		$handle = $stream;
+
+		$meta = stream_get_meta_data($stream);
+		if (!(isset($meta['seekable']) && $meta['seekable'] === true)) {
+			$tmpFile = \OC::$server->getTempManager()->getTemporaryFile('swiftwrite');
+			file_put_contents($tmpFile, $stream);
+			$handle = fopen($tmpFile, 'rb');
+		}
+
 		$this->getContainer()->createObject([
 			'name' => $urn,
-			'stream' => stream_for($stream)
+			'stream' => stream_for($handle)
 		]);
 	}
 


### PR DESCRIPTION
Fixes #13554 
Else this leads to a seekable stream error with chunked uploads

@icewind1991 I know this is not the ideal solution. but this is at least trivial to backport to 15.
