### PR TITLE
Do not calculate folder size for parent that also needs proper scan, fixes #3524

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -532,7 +532,7 @@ class Scanner extends BasicEmitter implements IScanner {
 			$callback();
 			\OC_Hook::emit('Scanner', 'correctFolderSize', array('path' => $path));
 			if ($this->cacheActive && $this->cache instanceof Cache) {
-				$this->cache->correctFolderSize($path);
+				$this->cache->correctFolderSize($path, null, true);
 			}
 		} catch (\OCP\Files\StorageInvalidException $e) {
 			// skip unavailable storages

--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -265,9 +265,9 @@ class CacheJail extends CacheWrapper {
 	 * @param string|boolean $path
 	 * @param array $data (optional) meta data of the folder
 	 */
-	public function correctFolderSize($path, $data = null) {
+	public function correctFolderSize($path, $data = null, $isBackgroundSize = false) {
 		if ($this->getCache() instanceof Cache) {
-			$this->getCache()->correctFolderSize($this->getSourcePath($path), $data);
+			$this->getCache()->correctFolderSize($this->getSourcePath($path), $data, $isBackgroundSize);
 		}
 	}
 

--- a/lib/private/Files/Cache/Wrapper/CacheWrapper.php
+++ b/lib/private/Files/Cache/Wrapper/CacheWrapper.php
@@ -258,9 +258,9 @@ class CacheWrapper extends Cache {
 	 * @param string|boolean $path
 	 * @param array $data (optional) meta data of the folder
 	 */
-	public function correctFolderSize($path, $data = null) {
+	public function correctFolderSize($path, $data = null, $isBackgroundScan = false) {
 		if ($this->getCache() instanceof Cache) {
-			$this->getCache()->correctFolderSize($path, $data);
+			$this->getCache()->correctFolderSize($path, $data, $isBackgroundScan);
 		}
 	}
 


### PR DESCRIPTION
As discussed in https://github.com/nextcloud/server/issues/3524
This small patch avoids a weird edge case when multiple incomplete folders shares some of their tree and fileid is higher on the lowest folder.

Example:
testfile1.txt and testfile2.txt gets modified and occ files_external:notify registers it by setting size -1 on subfolder1 and subfolder2.
Tree:
subfolder1/testfile1.txt
subfolder1/subfolder2/testfile2.txt

If subfolder2 has higher fileid, **only** testfile1.txt would be properly scanned when doing a backgroundScan. subfolder1 would just get its old cached size back and not properly scan 

Any thoughts? @MorrisJobke @icewind1991 
Any chance this could be backported to 15? It seems to be it should be a quite a top priority bug.