### PR TITLE
Convert value of timestamp metadata key in swift files_external

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Swift.php
+++ b/apps/files_external/lib/Lib/Storage/Swift.php
@@ -451,7 +451,7 @@ class Swift extends \OC\Files\Storage\Common {
 		if (is_null($mtime)) {
 			$mtime = time();
 		}
-		$metadata = ['timestamp' => $mtime];
+		$metadata = ['timestamp' => (string)$mtime];
 		if ($this->file_exists($path)) {
 			if ($this->is_dir($path) && $path !== '.') {
 				$path .= '/';


### PR DESCRIPTION
Fixes #13448 
The error reported in the logs mentions it is expecting a string, but an int was provided 

```
The key provided \"\" has the wrong value type. You provided 1550708014 (integer) but was expecting string
```
Before this change file uploads were failing when using Swift as external storage. I verified uploading several files and comparing with md5sum.