### PR TITLE
Check if password can be changed for the users backend in OCS api

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -513,6 +513,9 @@ class UsersController extends AUserData {
 				break;
 			case 'password':
 				try {
+					if (!$targetUser->canChangePassword()) {
+						throw new OCSException('Setting the password is not supported by the users backend', 103);
+					}
 					$targetUser->setPassword($value);
 				} catch (HintException $e) { // password policy error
 					throw new OCSException($e->getMessage(), 103);

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -1272,6 +1272,10 @@ class UsersControllerTest extends TestCase {
 			->will($this->returnValue($targetUser));
 		$targetUser
 			->expects($this->once())
+			->method('canChangePassword')
+			->will($this->returnValue(true));
+		$targetUser
+			->expects($this->once())
 			->method('setPassword')
 			->with('NewPassword');
 		$targetUser


### PR DESCRIPTION
Otherwise changing the password via the OCS api will return a success status, even if the password change is not supported by the user backend.