### PR TITLE
Fix a bug with smb notify having leading slash when it should not

### DIFF
--- a/apps/files_external/lib/Command/Notify.php
+++ b/apps/files_external/lib/Command/Notify.php
@@ -155,7 +155,7 @@ class Notify extends Base {
 	}
 
 	private function markParentAsOutdated($mountId, $path) {
-		$parent = dirname($path);
+		$parent = ltrim(dirname($path), '/');
 		if ($parent === '.') {
 			$parent = '';
 		}


### PR DESCRIPTION
@icewind1991 

My SMB server with occ files_external:notify 1 -vvv reported paths like 
```
$ php occ files_external:notify 7 -vvv
modified  /Temp/test/test123.txt
```
The path for the entry in the oc_filecache table had no leading slash ("Temp/test/test123.txt") and its parent too. Which means that the parent never got updated with size = -1. This should fix some (all?) smb notify issues. 
