### PR TITLE
use node API for free space calculation in versions app

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -750,9 +750,11 @@ class Storage {
 			// subtract size of files and current versions size from quota
 			if ($quota >= 0) {
 				if ($softQuota) {
-					$files_view = new View('/' . $uid . '/files');
-					$rootInfo = $files_view->getFileInfo('/', false);
-					$free = $quota - $rootInfo['size']; // remaining free space for user
+					$userFolder = \OC::$server->getUserFolder($uid);
+					if(is_null($userFolder)) {
+						return 0;
+					}
+					$free = $quota - $userFolder->getSize(false); // remaining free space for user
 					if ($free > 0) {
 						$availableSpace = ($free * self::DEFAULTMAXSIZE / 100) - $versionsSize; // how much space can be used for versions
 					} else {

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -752,13 +752,14 @@ class Storage {
 				if ($softQuota) {
 					$userFolder = \OC::$server->getUserFolder($uid);
 					if(is_null($userFolder)) {
-						return 0;
-					}
-					$free = $quota - $userFolder->getSize(false); // remaining free space for user
-					if ($free > 0) {
-						$availableSpace = ($free * self::DEFAULTMAXSIZE / 100) - $versionsSize; // how much space can be used for versions
+						$availableSpace = 0;
 					} else {
-						$availableSpace = $free - $versionsSize;
+						$free = $quota - $userFolder->getSize(false); // remaining free space for user
+						if ($free > 0) {
+							$availableSpace = ($free * self::DEFAULTMAXSIZE / 100) - $versionsSize; // how much space can be used for versions
+						} else {
+							$availableSpace = $free - $versionsSize;
+						}
 					}
 				} else {
 					$availableSpace = $quota;


### PR DESCRIPTION
the node API was extended to allow getting the raw size without mounts: #14412
this method is now used by the trashbin app to calculate free space: #14454
this pull request updates the versions app to use the same method as the trashbin app