### PR TITLE
Fix for issue #13319: load oc-backbone-webdav before loading versions app

### DIFF
--- a/apps/files_versions/lib/Hooks.php
+++ b/apps/files_versions/lib/Hooks.php
@@ -149,6 +149,7 @@ class Hooks {
 	 * Load additional scripts when the files app is visible
 	 */
 	public static function onLoadFilesAppScripts() {
+		\OCP\Util::addScript('oc-backbone-webdav');
 		\OCP\Util::addScript('files_versions', 'merged');
 	}
 }


### PR DESCRIPTION
See issue #13319 