### PR TITLE
Reconnect to DB after timeout for Notify command. Fixes #14479

### DIFF
--- a/apps/files_external/lib/Command/Notify.php
+++ b/apps/files_external/lib/Command/Notify.php
@@ -51,7 +51,7 @@ class Notify extends Base {
 	/** @var \OCP\DB\QueryBuilder\IQueryBuilder */
 	private $updateQuery;
 	/** @var ILogger */
-	private $log;
+	private $logger;
 
 	function __construct(GlobalStoragesService $globalService, IDBConnection $connection, ILogger $logger) {
 		parent::__construct();


### PR DESCRIPTION
Fix #14479 

Every 8th hour I got a "2006 Mysql server has gone away". It was due to a 8 hour wait_time.
Since the Notify command should be running 24/7 increasing wait_time won't help much. Change events that triggers this never get registered and filecache will be wrong/out of sync.

This PR makes it reconnect in case of timeout. I borrowed the reconnect logic from: https://github.com/nextcloud/server/blob/1cfa870821c92bdd6854171c8c073ed16529b6df/apps/files/lib/Command/Scan.php#L300

I also needed to move updateQuery to a method due to it being a prepared statement from a dead connection and it needed to be remade after reconnect.

