### PR TITLE
Do not cut full color on accessibility svg color invert

### DIFF
--- a/apps/accessibility/lib/Controller/AccessibilityController.php
+++ b/apps/accessibility/lib/Controller/AccessibilityController.php
@@ -260,7 +260,15 @@ class AccessibilityController extends Controller {
 	 * @return string
 	 */
 	private function invertSvgIconsColor(string $css) {
-		return str_replace(['color=000', 'color=fff', 'color=***'], ['color=***', 'color=000', 'color=fff'], $css);
+		return str_replace(
+			['color=000&', 'color=fff&', 'color=***&'],
+			['color=***&', 'color=000&', 'color=fff&'],
+			str_replace(
+				['color=000000&', 'color=ffffff&', 'color=******&'],
+				['color=******&', 'color=000000&', 'color=ffffff&'],
+				$css
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
Using something like `@include icon-color('delete', 'contacts', '#fffffe', 1);` was failing because the css invert was only taking the first three letters into account.

Since we always prepend the version key param, we can safely check for the full colour only.