### PR TITLE
[stable15] Fix expire date change eventhandler

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -790,6 +790,17 @@
 			this.model.saveLinkShare({expireDate: expireDate, cid: shareId});
 		},
 
+		onChangeExpirationDate: function(event) {
+			var $element = $(event.target);
+			var expireDate = $element.val();
+			var li = $element.closest('li[data-share-id]');
+			var shareId = li.data('share-id');
+			var expirationDatePicker = '#expirationDatePicker-' + shareId;
+
+			this.setExpirationDate(expireDate, shareId);
+			$(expirationDatePicker).datepicker('hide');
+		},
+
 		/**
 		 * get an array of sharees' share properties
 		 *


### PR DESCRIPTION
Fixes #14307 

There was already an event registered to be triggered on change 
https://github.com/nextcloud/server/blob/d7e05c8de229a7257f852b3457f5cde5e3372672/core/js/sharedialoglinkshareview.js#L70
but the actual implementation was missing.

Backport of #14390 