### PR TITLE
Remove leftover input that causes undefined index errors

### DIFF
--- a/settings/templates/settings/admin/security.php
+++ b/settings/templates/settings/admin/security.php
@@ -30,7 +30,6 @@ script('settings', 'vue-settings-admin-security');
 
 <div id="two-factor-auth" class="section">
 	<h2><?php p($l->t('Two-Factor Authentication'));?></h2>
-	<input type="hidden" id="two-factor-auth-settings-initial-state" value="<?php p(base64_encode(json_encode($_['mandatory2FAState']))); ?>">
 	<div id="two-factor-auth-settings"></div>
 </div>
 


### PR DESCRIPTION
A left over from https://github.com/nextcloud/server/pull/13489, when I switched from the manually added input to the new initial state API.