### PR TITLE
Change login error message to "wrong username or password"

### DIFF
--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -61,7 +61,7 @@ use OC\Core\Controller\LoginController;
 
 		<?php if (!empty($_[LoginController::LOGIN_MSG_INVALIDPASSWORD])) { ?>
 			<p class="warning wrongPasswordMsg">
-				<?php p($l->t('Wrong password.')); ?>
+				<?php p($l->t('Wrong username or password.')); ?>
 			</p>
 		<?php } else if (!empty($_[LoginController::LOGIN_MSG_USERDISABLED])) { ?>
 			<p class="warning userDisabledMsg">


### PR DESCRIPTION
After a failed login, Nextcloud currently shows the error "wrong password". That message can be misleading, so this PR changes it to "wrong username or password". See #14460 for details.

I already tested that it works as expected. However, I am not sure what I should do with the translation strings. Should I rename the keys and keep the old values? Or delete the affected strings entirely?