### PR TITLE
Have streams of files_external in sync

### DIFF
--- a/apps/files_external/3rdparty/composer.json
+++ b/apps/files_external/3rdparty/composer.json
@@ -8,7 +8,7 @@
 		"classmap-authoritative": true
 	},
 	"require": {
-		"icewind/streams": "0.6.1",
+		"icewind/streams": "0.7.1",
 		"icewind/smb": "3.1.1"
 	}
 }

--- a/apps/files_external/3rdparty/composer.lock
+++ b/apps/files_external/3rdparty/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd320be9cd87742d53b4384bf3df9c42",
+    "content-hash": "5639a09feff2318b1b69e11a10a81e7d",
     "packages": [
         {
             "name": "icewind/smb",
@@ -50,16 +50,16 @@
         },
         {
             "name": "icewind/streams",
-            "version": "0.6.1",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/icewind1991/Streams.git",
-                "reference": "0a78597117d8a02937ea05206f219294449fb06e"
+                "reference": "4db3ed6c366e90b958d00e1d4c6360a9b39b2121"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/icewind1991/Streams/zipball/0a78597117d8a02937ea05206f219294449fb06e",
-                "reference": "0a78597117d8a02937ea05206f219294449fb06e",
+                "url": "https://api.github.com/repos/icewind1991/Streams/zipball/4db3ed6c366e90b958d00e1d4c6360a9b39b2121",
+                "reference": "4db3ed6c366e90b958d00e1d4c6360a9b39b2121",
                 "shasum": ""
             },
             "require": {
@@ -87,7 +87,7 @@
                 }
             ],
             "description": "A set of generic stream wrappers",
-            "time": "2018-04-24T09:07:38+00:00"
+            "time": "2019-02-15T12:57:29+00:00"
         }
     ],
     "packages-dev": [],

--- a/apps/files_external/3rdparty/composer/installed.json
+++ b/apps/files_external/3rdparty/composer/installed.json
@@ -45,17 +45,17 @@
     },
     {
         "name": "icewind/streams",
-        "version": "0.6.1",
-        "version_normalized": "0.6.1.0",
+        "version": "v0.7.1",
+        "version_normalized": "0.7.1.0",
         "source": {
             "type": "git",
             "url": "https://github.com/icewind1991/Streams.git",
-            "reference": "0a78597117d8a02937ea05206f219294449fb06e"
+            "reference": "4db3ed6c366e90b958d00e1d4c6360a9b39b2121"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/icewind1991/Streams/zipball/0a78597117d8a02937ea05206f219294449fb06e",
-            "reference": "0a78597117d8a02937ea05206f219294449fb06e",
+            "url": "https://api.github.com/repos/icewind1991/Streams/zipball/4db3ed6c366e90b958d00e1d4c6360a9b39b2121",
+            "reference": "4db3ed6c366e90b958d00e1d4c6360a9b39b2121",
             "shasum": ""
         },
         "require": {
@@ -65,7 +65,7 @@
             "phpunit/phpunit": "^4.8",
             "satooshi/php-coveralls": "v1.0.0"
         },
-        "time": "2018-04-24T09:07:38+00:00",
+        "time": "2019-02-15T12:57:29+00:00",
         "type": "library",
         "installation-source": "dist",
         "autoload": {


### PR DESCRIPTION
Because we ship streams 2 times they have to stay in sync (yay for PHP dependency hell!).

Else uploading 0 byte files fails hard with S3 because the wrong lib is used.