### PR TITLE
Add border around previews

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -334,6 +334,12 @@ table td.filename .thumbnail {
 	position: absolute;
 	z-index: 4;
 }
+
+// Show slight border around previews for images, txt, etc.
+table tr[data-has-preview='true'] .thumbnail {
+	border: 1px solid var(--color-border);
+}
+
 table td.filename input.filename {
 	width: 70%;
 	margin-left: 48px;
@@ -835,7 +841,6 @@ table.dragshadow td.size {
 						background-size: contain;
 						margin: 0;
 						border-radius: var(--border-radius);
-						border: 1px solid var(--color-border);
 						background-repeat: no-repeat;
 						background-position: center;
 

--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -835,6 +835,7 @@ table.dragshadow td.size {
 						background-size: contain;
 						margin: 0;
 						border-radius: var(--border-radius);
+						border: 1px solid var(--color-border);
 						background-repeat: no-repeat;
 						background-position: center;
 


### PR DESCRIPTION
@skjnldsv as discussed, so it looks a bit nicer. I think it was suggested by @jospoortvliet 
![grid view border](https://user-images.githubusercontent.com/925062/54190459-278f1000-44b4-11e9-83f0-78f648f30736.png)