### PR TITLE
prevent recursion when moving a file to the trashbin

### DIFF
--- a/apps/files_trashbin/lib/Trash/TrashManager.php
+++ b/apps/files_trashbin/lib/Trash/TrashManager.php
@@ -99,7 +99,10 @@ class TrashManager implements ITrashManager {
 		}
 		try {
 			$backend = $this->getBackendForStorage($storage);
-			return $backend->moveToTrash($storage, $internalPath);
+			$this->trashPaused = true;
+			$result = $backend->moveToTrash($storage, $internalPath);
+			$this->trashPaused = false;
+			return $result;
 		} catch (BackendNotFoundException $e) {
 			return false;
 		}


### PR DESCRIPTION
Depending on how the backend performs the "move to trash", the trashbin might get triggered again, by pausing the trash while performing the move we prevent a possible infinite loop.