### PR TITLE
remove user_external example from config.sample.php

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -278,18 +278,6 @@ $CONFIG = array(
 'skeletondirectory' => '/path/to/nextcloud/core/skeleton',
 
 /**
- * The ``user_backends`` app (which needs to be enabled first) allows you to
- * configure alternate authentication backends. Supported backends are:
- * IMAP (OC_User_IMAP), SMB (OC_User_SMB), and FTP (OC_User_FTP).
- */
-'user_backends' => array(
-	array(
-		'class' => 'OC_User_IMAP',
-		'arguments' => array('{imap.gmail.com:993/imap/ssl}INBOX')
-	)
-),
-
-/**
  * If your user backend does not allow password resets (e.g. when it's a
  * read-only user backend like LDAP), you can specify a custom link, where the
  * user is redirected to, when clicking the "reset password" link after a failed


### PR DESCRIPTION
because the APP isn't shipped any more any ways
detailed and up to date documentation of the app can found in https://github.com/nextcloud/user_external#readme