### PR TITLE
Don't show 'Personal' header in settings when Admin section is not there

### DIFF
--- a/settings/templates/settings/frame.php
+++ b/settings/templates/settings/frame.php
@@ -30,8 +30,10 @@ script('files', 'jquery.fileupload');
 
 <div id="app-navigation">
 	<ul>
-		<li class="app-navigation-caption"><?php p($l->t('Personal')); ?></li>
+		<?php if(!empty($_['forms']['admin'])) { ?>
+			<li class="app-navigation-caption"><?php p($l->t('Personal')); ?></li>
 		<?php
+		}
 		foreach($_['forms']['personal'] as $form) {
 			if (isset($form['anchor'])) {
 				$anchor = \OC::$server->getURLGenerator()->linkToRoute('settings.PersonalSettings.index', ['section' => $form['anchor']]);

--- a/tests/acceptance/features/access-levels.feature
+++ b/tests/acceptance/features/access-levels.feature
@@ -12,7 +12,8 @@ Feature: access-levels
   Scenario: regular users cannot see admin-level items on the Settings page
     Given I am logged in
     When I visit the settings page
-    Then I see that the "Personal" settings panel is shown
+    Then I see that the "Personal info" entry in the settings panel is shown
+    And I see that the "Personal" settings panel is not shown
     And I see that the "Administration" settings panel is not shown
 
   Scenario: admin users can see admin-level items on the Settings page

--- a/tests/acceptance/features/bootstrap/SettingsMenuContext.php
+++ b/tests/acceptance/features/bootstrap/SettingsMenuContext.php
@@ -94,6 +94,15 @@ class SettingsMenuContext implements Context, ActorAwareInterface {
 	}
 
 	/**
+	 * @param string $itemText
+	 * @return Locator
+	 */
+	private static function settingsPanelEntryFor($itemText) {
+		return Locator::forThe()->xpath("//div[@id = 'app-navigation']//ul//li[normalize-space() = '$itemText']")->
+		describedAs($itemText . " entry in Settings panel");
+	}
+
+	/**
 	 * @return array 
 	 */
 	public function menuItems() {
@@ -185,6 +194,15 @@ class SettingsMenuContext implements Context, ActorAwareInterface {
 	public function iSeeThatTheItemSettingsPanelIsShown($itemText) {
 		PHPUnit_Framework_Assert::assertTrue(
 			$this->actor->find(self::settingsPanelFor($itemText), 10)->isVisible()
+		);
+	}
+
+	/**
+	 * @Then I see that the :itemText entry in the settings panel is shown
+	 */
+	public function iSeeThatTheItemEntryInTheSettingsPanelIsShown($itemText) {
+		PHPUnit_Framework_Assert::assertTrue(
+			$this->actor->find(self::settingsPanelEntryFor($itemText), 10)->isVisible()
 		);
 	}
 


### PR DESCRIPTION
For regular users we don’t need to show the "Personal" heading because there’s no other headings anyway. For admins nothing changes.
![Personal settings before](https://user-images.githubusercontent.com/925062/54311564-2275b200-45d5-11e9-9e75-8ffe2858756e.png) ![settings after](https://user-images.githubusercontent.com/925062/54311565-2275b200-45d5-11e9-9c01-5ad11ce1263a.png)
