### PR TITLE
handle long etags from dav external storage

### DIFF
--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -726,7 +726,11 @@ class DAV extends Common {
 			return null;
 		}
 		if (isset($response['{DAV:}getetag'])) {
-			return trim($response['{DAV:}getetag'], '"');
+			$etag = trim($response['{DAV:}getetag'], '"');
+			if (strlen($etag) > 40) {
+				$etag = md5($etag);
+			}
+			return $etag;
 		}
 		return parent::getEtag($path);
 	}


### PR DESCRIPTION
we can only store etags up to 40 characters long in the database, so when we get an etag that's longer we simply hash it to bring down the length

Signed-off-by: Robin Appelman <robin@icewind.nl>