### PR TITLE
add an integration test that ensures deletion of LDAP users

### DIFF
--- a/build/integration/ldap_features/openldap-uid-username.feature
+++ b/build/integration/ldap_features/openldap-uid-username.feature
@@ -108,3 +108,13 @@ Feature: LDAP
       | lloyd     |
       | priscilla |
       | shannah   |
+
+  Scenario: Deleting an unavailable LDAP user
+    Given As an "admin"
+    And sending "GET" to "/cloud/users"
+    And modify LDAP configuration
+      | ldapUserFilter | (&(objectclass=inetorgperson)(!(uid=alice))) |
+    And invoking occ with "ldap:check-user alice"
+    And the command output contains the text "Clean up the user's remnants by"
+    And invoking occ with "user:delete alice"
+    Then the command output contains the text "The specified user was deleted"


### PR DESCRIPTION
It sets the user filter to exclude a previously known user, checks for it's availability on LDAP and triggers the deletion process. It's a cumbersome procedure with prone to side effects in case of changes to some parts and thus worth ensuring to not run into regressions.

No production code is touched.