### PR TITLE
allow renaming the root of a movable mount even if the parent folder …

### DIFF
--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -28,6 +28,7 @@
 namespace OC\Files\Node;
 
 use OC\Files\Filesystem;
+use OC\Files\Mount\MoveableMount;
 use OCP\Files\FileInfo;
 use OCP\Files\InvalidPathException;
 use OCP\Files\NotFoundException;
@@ -415,7 +416,14 @@ class Node implements \OCP\Files\Node {
 	public function move($targetPath) {
 		$targetPath = $this->normalizePath($targetPath);
 		$parent = $this->root->get(dirname($targetPath));
-		if ($parent instanceof Folder and $this->isValidPath($targetPath) and $parent->isCreatable()) {
+		if (
+			$parent instanceof Folder and
+			$this->isValidPath($targetPath) and
+			(
+				$parent->isCreatable() ||
+				($parent->getInternalPath() === '' && $parent->getMountPoint() instanceof MoveableMount)
+			)
+		) {
 			$nonExisting = $this->createNonExistingNode($targetPath);
 			$this->root->emit('\OC\Files', 'preRename', [$this, $nonExisting]);
 			$this->root->emit('\OC\Files', 'preWrite', [$nonExisting]);


### PR DESCRIPTION
…is readonly

Signed-off-by: Robin Appelman <robin@icewind.nl>