### PR TITLE
throw a proper error if rename fails in dav

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -138,7 +138,9 @@ abstract class Node implements \Sabre\DAV\INode {
 
 		$newPath = $parentPath . '/' . $newName;
 
-		$this->fileView->rename($this->path, $newPath);
+		if (!$this->fileView->rename($this->path, $newPath)) {
+			throw new \Sabre\DAV\Exception('Failed to rename '. $this->path . ' to ' . $newPath);
+		}
 
 		$this->path = $newPath;
 


### PR DESCRIPTION
instead of failing with a cryptic error message when we cant find the file later