### PR TITLE
[stable15] groupname like username - allow share with both

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -438,7 +438,7 @@ class Manager implements IManager {
 			}
 
 			// Identical share already existst
-            if ($existingShare->getSharedWith() === $share->getSharedWith() && ($existingShare->getShareType() === $share->getShareType())) {
+			if ($existingShare->getSharedWith() === $share->getSharedWith() && $existingShare->getShareType() === $share->getShareType()) {
 				throw new \Exception('Path is already shared with this user');
 			}
 

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -438,7 +438,7 @@ class Manager implements IManager {
 			}
 
 			// Identical share already existst
-			if ($existingShare->getSharedWith() === $share->getSharedWith()) {
+            if ($existingShare->getSharedWith() === $share->getSharedWith() && ($existingShare->getShareType() === $share->getShareType())) {
 				throw new \Exception('Path is already shared with this user');
 			}
 
@@ -493,7 +493,7 @@ class Manager implements IManager {
 				//It is a new share so just continue
 			}
 
-			if ($existingShare->getSharedWith() === $share->getSharedWith()) {
+            if ($existingShare->getSharedWith() === $share->getSharedWith() && ($existingShare->getShareType() === $share->getShareType())) {
 				throw new \Exception('Path is already shared with this group');
 			}
 		}

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -493,7 +493,7 @@ class Manager implements IManager {
 				//It is a new share so just continue
 			}
 
-            if ($existingShare->getSharedWith() === $share->getSharedWith() && ($existingShare->getShareType() === $share->getShareType())) {
+			if ($existingShare->getSharedWith() === $share->getSharedWith() && $existingShare->getShareType() === $share->getShareType()) {
 				throw new \Exception('Path is already shared with this group');
 			}
 		}


### PR DESCRIPTION
It happens that users and groups have the same name in big organizations, the nextcloud standard behaviour is like this: I can only share with the user or the group.
With this small extension it's possible to share files with the group "test" and the user "test" at the same time.

I added this feature, because it makes no sense to me to disallow the sharing because of the same name of a group and an user.