### PR TITLE
Add Mailer events

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -372,6 +372,7 @@ return array(
     'OCP\\Log\\ILogFactory' => $baseDir . '/lib/public/Log/ILogFactory.php',
     'OCP\\Log\\IWriter' => $baseDir . '/lib/public/Log/IWriter.php',
     'OCP\\Log\\RotationTrait' => $baseDir . '/lib/public/Log/RotationTrait.php',
+    'OCP\\Mail\\Events\\BeforeMessageSent' => $baseDir . '/lib/public/Mail/Events/BeforeMessageSent.php',
     'OCP\\Mail\\IAttachment' => $baseDir . '/lib/public/Mail/IAttachment.php',
     'OCP\\Mail\\IEMailTemplate' => $baseDir . '/lib/public/Mail/IEMailTemplate.php',
     'OCP\\Mail\\IMailer' => $baseDir . '/lib/public/Mail/IMailer.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -401,6 +401,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Log\\ILogFactory' => __DIR__ . '/../../..' . '/lib/public/Log/ILogFactory.php',
         'OCP\\Log\\IWriter' => __DIR__ . '/../../..' . '/lib/public/Log/IWriter.php',
         'OCP\\Log\\RotationTrait' => __DIR__ . '/../../..' . '/lib/public/Log/RotationTrait.php',
+        'OCP\\Mail\\Events\\BeforeMessageSent' => __DIR__ . '/../../..' . '/lib/public/Mail/Events/BeforeMessageSent.php',
         'OCP\\Mail\\IAttachment' => __DIR__ . '/../../..' . '/lib/public/Mail/IAttachment.php',
         'OCP\\Mail\\IEMailTemplate' => __DIR__ . '/../../..' . '/lib/public/Mail/IEMailTemplate.php',
         'OCP\\Mail\\IMailer' => __DIR__ . '/../../..' . '/lib/public/Mail/IMailer.php',

--- a/lib/private/Mail/Message.php
+++ b/lib/private/Mail/Message.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Arne Hamann <github@arne.email>
  *
  * @license AGPL-3.0
  *
@@ -112,7 +113,7 @@ class Message implements IMessage {
 	 * @return array
 	 */
 	public function getFrom(): array {
-		return $this->swiftMessage->getFrom();
+		return $this->swiftMessage->getFrom() ?? [];
 	}
 
 	/**
@@ -156,7 +157,7 @@ class Message implements IMessage {
 	 * @return array
 	 */
 	public function getTo(): array {
-		return $this->swiftMessage->getTo();
+		return $this->swiftMessage->getTo() ?? [];
 	}
 
 	/**
@@ -178,7 +179,7 @@ class Message implements IMessage {
 	 * @return array
 	 */
 	public function getCc(): array {
-		return $this->swiftMessage->getCc();
+		return $this->swiftMessage->getCc() ?? [];
 	}
 
 	/**
@@ -200,7 +201,7 @@ class Message implements IMessage {
 	 * @return array
 	 */
 	public function getBcc(): array {
-		return $this->swiftMessage->getBcc();
+		return $this->swiftMessage->getBcc() ?? [];
 	}
 
 	/**
@@ -254,6 +255,14 @@ class Message implements IMessage {
 			$this->swiftMessage->addPart($body, 'text/html');
 		}
 		return $this;
+	}
+
+	/**
+	 * Get's the underlying SwiftMessage
+	 * @param Swift_Message $swiftMessage
+	 */
+	public function setSwiftMessage(Swift_Message $swiftMessage): void {
+		$this->swiftMessage = $swiftMessage;
 	}
 
 	/**

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -988,7 +988,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getLogger(),
 				$c->query(Defaults::class),
 				$c->getURLGenerator(),
-				$c->getL10N('lib')
+				$c->getL10N('lib'),
+				$c->query(IEventDispatcher::class)
 			);
 		});
 		$this->registerDeprecatedAlias('Mailer', IMailer::class);

--- a/lib/public/Mail/Events/BeforeMessageSent.php
+++ b/lib/public/Mail/Events/BeforeMessageSent.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Arne Hamann <github@arne.email>
+ *
+ * @author Arne Hamann <github@arne.email>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Mail\Events;
+
+use OCP\EventDispatcher\Event;
+use OCP\Mail\IMessage;
+
+/**
+ * @since 19.0.0
+ */
+class BeforeMessageSent extends Event {
+
+	/** @var IMessage */
+	private $message;
+
+	/**
+	 * @param IMessage $message
+	 * @since 19.0.0
+	 */
+	public function __construct(IMessage $message) {
+		parent::__construct();
+		$this->message = $message;
+	}
+
+	/**
+	 * @return IMessage
+	 * @since 19.0.0
+	 */
+	public function getMessage(): IMessage {
+		return $this->message;
+	}
+
+}

--- a/tests/lib/Mail/MessageTest.php
+++ b/tests/lib/Mail/MessageTest.php
@@ -27,7 +27,17 @@ class MessageTest extends TestCase {
 			array(array('lukas@owncloud.com' => 'Lukas Reschke'), array('lukas@owncloud.com' => 'Lukas Reschke')),
 			array(array('lukas@owncloud.com' => 'Lukas Reschke', 'lukas@öwnclöüd.com', 'lukäs@owncloud.örg' => 'Lükäs Réschke'),
 				array('lukas@owncloud.com' => 'Lukas Reschke', 'lukas@xn--wncld-iuae2c.com', 'lukäs@owncloud.xn--rg-eka' => 'Lükäs Réschke')),
-			array(array('lukas@öwnclöüd.com'), array('lukas@xn--wncld-iuae2c.com'))
+			array(array('lukas@öwnclöüd.com'), array('lukas@xn--wncld-iuae2c.com')),
+		);
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getMailAddressProvider() {
+		return array(
+			array(NULL, array()),
+			array(array('lukas@owncloud.com' => 'Lukas Reschke'), array('lukas@owncloud.com' => 'Lukas Reschke')),
 		);
 	}
 
@@ -59,13 +69,20 @@ class MessageTest extends TestCase {
 		$this->message->setFrom(array('lukas@owncloud.com'));
 	}
 
-	public function testGetFrom() {
+
+	/**
+	 * @dataProvider getMailAddressProvider
+	 *
+	 * @param $swiftresult
+	 * @param $return
+	 */
+	public function testGetFrom($swiftresult, $return) {
 		$this->swiftMessage
 			->expects($this->once())
 			->method('getFrom')
-			->will($this->returnValue(array('lukas@owncloud.com')));
+			->will($this->returnValue($swiftresult));
 
-		$this->assertSame(array('lukas@owncloud.com'), $this->message->getFrom());
+		$this->assertSame($return, $this->message->getFrom());
 	}
 
 	public function testSetReplyTo() {
@@ -93,13 +110,16 @@ class MessageTest extends TestCase {
 		$this->message->setTo(array('lukas@owncloud.com'));
 	}
 
-	public function testGetTo() {
+	/**
+	 * @dataProvider  getMailAddressProvider
+	 */
+	public function testGetTo($swiftresult,$return) {
 		$this->swiftMessage
 			->expects($this->once())
 			->method('getTo')
-			->will($this->returnValue(array('lukas@owncloud.com')));
+			->will($this->returnValue($swiftresult));
 
-		$this->assertSame(array('lukas@owncloud.com'), $this->message->getTo());
+		$this->assertSame($return, $this->message->getTo());
 	}
 
 	public function testSetCc() {
@@ -110,13 +130,16 @@ class MessageTest extends TestCase {
 		$this->message->setCc(array('lukas@owncloud.com'));
 	}
 
-	public function testGetCc() {
+	/**
+	 * @dataProvider  getMailAddressProvider
+	 */
+	public function testGetCc($swiftresult,$return) {
 		$this->swiftMessage
 			->expects($this->once())
 			->method('getCc')
-			->will($this->returnValue(array('lukas@owncloud.com')));
+			->will($this->returnValue($swiftresult));
 
-		$this->assertSame(array('lukas@owncloud.com'), $this->message->getCc());
+		$this->assertSame($return, $this->message->getCc());
 	}
 
 	public function testSetBcc() {
@@ -127,13 +150,16 @@ class MessageTest extends TestCase {
 		$this->message->setBcc(array('lukas@owncloud.com'));
 	}
 
-	public function testGetBcc() {
+	/**
+	 * @dataProvider  getMailAddressProvider
+	 */
+	public function testGetBcc($swiftresult,$return) {
 		$this->swiftMessage
 			->expects($this->once())
 			->method('getBcc')
-			->will($this->returnValue(array('lukas@owncloud.com')));
+			->will($this->returnValue($swiftresult));
 
-		$this->assertSame(array('lukas@owncloud.com'), $this->message->getBcc());
+		$this->assertSame($return, $this->message->getBcc());
 	}
 
 	public function testSetSubject() {


### PR DESCRIPTION
I'm working on an APP implementing the ability to send encrypted emails to registered users #7310.
Therefor a two small modifications are needed.

- An Hook in scope \OC\Mail    preSendMessage(IMessage $message)
- And the function  OC\Mail\Massage::setSwiftMessage, to replace unencrypted swiftmessage with the encrypted one.

The rest is fixing a bug if swiftMessage->getX() is returning NULL
