### PR TITLE
Implement quickaccess removal for delete-action

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2950,6 +2950,7 @@
 			var removeFunction = function(fileName) {
 				var $tr = self.findFileEl(fileName);
 				self.showFileBusyState($tr, true);
+				self.removeFromQuickaccess(dir + fileName);
 				return self.filesClient.remove(dir + '/' + fileName)
 					.done(function() {
 						if (OC.joinPaths(self.getCurrentDirectory(), '/') === OC.joinPaths(dir, '/')) {
@@ -2977,6 +2978,34 @@
 					self.updateStorageStatistics();
 					self.updateStorageQuotas();
 				});
+		},
+
+		/**
+		 * Remove Item from Quickaccesslist
+		 *
+		 * @param {String} appfolder folder to be removed
+		 */
+		removeFromQuickaccess: function(appfolder){
+
+			var quickAccessList = 'sublist-favorites';
+			var listULElements = document.getElementById(quickAccessList);
+			if (!listULElements) {
+				return;
+			}
+
+			var apppath=appfolder;
+			if(appfolder.startsWith("//")){
+				apppath=appfolder.substring(1, appfolder.length);
+			}
+
+			$(listULElements).find('[data-dir="' + apppath + '"]').remove();
+
+			if (listULElements.childElementCount === 0) {
+				var collapsibleButton = $(listULElements).parent().find('button.collapse');
+				collapsibleButton.hide();
+				$("#button-collapse-parent-favorites").removeClass('collapsible');
+			}
+
 		},
 
 		/**

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2981,7 +2981,7 @@
 		},
 
 		/**
-		 * Remove Item from Quickaccesslist
+		 * Remove Item from Quickaccesslist, recursively remove all folders lying beneath the appfolder
 		 *
 		 * @param {String} appfolder folder to be removed
 		 */
@@ -2999,6 +2999,13 @@
 			}
 
 			$(listULElements).find('[data-dir="' + apppath + '"]').remove();
+
+
+			$(listULElements).children().each(function(i) {
+				if($(this).attr('data-dir').match(appfolder+"/[\\s\\S]*")){
+					$(this).remove();
+				}
+			});
 
 			if (listULElements.childElementCount === 0) {
 				var collapsibleButton = $(listULElements).parent().find('button.collapse');


### PR DESCRIPTION
closes #13963 


This removes a folder from the quickaccess navigationbar before it is deleted. 
It also removes every favorited subfolder of that given folder, so that no dead links are left in the sidebar.