### PR TITLE
CSP: set nonce for iframes

### DIFF
--- a/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
@@ -468,7 +468,11 @@ class EmptyContentSecurityPolicy {
 		}
 
 		if(!empty($this->allowedFrameDomains)) {
-			$policy .= 'frame-src ' . implode(' ', $this->allowedFrameDomains);
+			$policy .= 'frame-src ';
+			if(is_string($this->useJsNonce)) {
+				$policy .= '\'nonce-' . base64_encode($this->useJsNonce) . '\' ';
+			}
+			$policy .= implode(' ', $this->allowedFrameDomains);
 			$policy .= ';';
 		}
 


### PR DESCRIPTION
This for now uses the jsNonce. That way we can easily backport it.
For 17 I will fix it properly.