### PR TITLE
Fix changeDirectory event propagation when the URL does not change

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1850,16 +1850,15 @@
 			// legacy stuff
 			this.$el.find('#dir').val(targetDir);
 
-			if (changeUrl !== false) {
-				var params = {
-					dir: targetDir,
-					previousDir: previousDir
-				};
-				if (fileId) {
-					params.fileId = fileId;
-				}
-				this.$el.trigger(jQuery.Event('changeDirectory', params));
+			var params = {
+				dir: targetDir,
+				previousDir: previousDir
+			};
+			if (fileId) {
+				params.fileId = fileId;
 			}
+			this.$el.trigger(jQuery.Event('changeDirectory', params));
+
 			this.breadcrumb.setDirectory(this.getCurrentDirectory());
 		},
 		/**


### PR DESCRIPTION
Fixes https://github.com/nextcloud/recommendations/issues/38

The recommendations app queries the filelist for the current directory on page load. Then it uses an event to stay in sync. However, when the file list is rendered for the first time, it returns `/` as current directory. Because the URL does not change when it set the actual directory path, there was no event emitted before this patch and recommendations is unable to detect whether it's in the root directory or not.

I'm unsure if this could break anything unrelated, but on a little smoke test nothing seemed to be broken.