### PR TITLE
Improve startup speed of acceptance tests

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -147,7 +147,18 @@ function prepareDocker() {
 	# "docker cp" does not take them into account (the extracted files are set
 	# to root).
 	echo "Copying local Git working directory of Nextcloud to the container"
-	tar --create --file="$NEXTCLOUD_LOCAL_TAR" --exclude=".git" --exclude="./build" --exclude="./config/config.php" --exclude="./data" --exclude="./data-autotest" --exclude="./tests" --exclude="./apps-extra" --exclude="apps-writable" --directory=../../ .
+	tar --create --file="$NEXTCLOUD_LOCAL_TAR" \
+		--exclude=".git" \
+		--exclude="./build" \
+		--exclude="./config/config.php" \
+		--exclude="./data" \
+		--exclude="./data-autotest" \
+		--exclude="./tests" \
+		--exclude="./apps-extra" \
+		--exclude="./apps-writable" \
+		--exclude="node_modules" \
+		--directory=../../ \
+		.
 	tar --append --file="$NEXTCLOUD_LOCAL_TAR" --directory=../../ tests/acceptance/
 
 	docker exec $NEXTCLOUD_LOCAL_CONTAINER mkdir /nextcloud


### PR DESCRIPTION
Actual change is to add `--exclude="node_modules"`
Then I added line breaks for readability and better adding new entries locally.