### PR TITLE
Style of navigation links in header is too catchy

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -112,7 +112,7 @@
 		}
 
 		/* Use by the apps menu and the settings right menu */
-		ul {
+		&.settings-menu > ul {
 			li {
 				a {
 					display: inline-flex;

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -112,6 +112,7 @@
 		}
 
 		/* Use by the apps menu and the settings right menu */
+		#apps > ul,
 		&.settings-menu > ul {
 			li {
 				a {

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -131,7 +131,7 @@
 						</div>
 						<div id="expandDisplayName" class="icon-settings-white"></div>
 					</div>
-					<nav id="expanddiv" style="display:none;"
+					<nav class="settings-menu" id="expanddiv" style="display:none;"
 						aria-label="<?php p($l->t('Settings menu'));?>">
 					<ul>
 					<?php foreach($_['settingsnavigation'] as $entry):?>


### PR DESCRIPTION
* Have a notification which has a link (e.g. app update notification)
* Layout is totally broken

Styling `.header-right > div > .menu ul li a` is too bold an dalso breaks links in notifications etc.

Or did you have another fix in mind @skjnldsv 