### PR TITLE
Fix getting the access list on external storage

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1408,7 +1408,13 @@ class Manager implements IManager {
 	 * @return array
 	 */
 	public function getAccessList(\OCP\Files\Node $path, $recursive = true, $currentAccess = false) {
-		$owner = $path->getOwner()->getUID();
+		$owner = $path->getOwner();
+
+		if ($owner === null) {
+			return [];
+		}
+
+		$owner = $owner->getUID();
 
 		if ($currentAccess) {
 			$al = ['users' => [], 'remote' => [], 'public' => false];


### PR DESCRIPTION
If a file is on external storage there is no owner. WHich means we can't
check. So just return an empty array then.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>