### PR TITLE
Temp disable bundle tests

### DIFF
--- a/tests/acceptance/features/apps.feature
+++ b/tests/acceptance/features/apps.feature
@@ -40,14 +40,14 @@ Feature: apps
     And I see the app bundles
     And I see that the "Enterprise bundle" is disabled
 
-  Scenario: Enable an app bundle
-    Given I act as Jane
-    And I am logged in as the admin
-    And I open the Apps management
-    And I open the "App bundles" section
-    When I enable all apps from the "Enterprise bundle"
-    Then I see that the "Auditing / Logging" app has been enabled
-    And I see that the "LDAP user and group backend" app has been enabled
+#  Scenario: Enable an app bundle
+#    Given I act as Jane
+#    And I am logged in as the admin
+#    And I open the Apps management
+#    And I open the "App bundles" section
+#    When I enable all apps from the "Enterprise bundle"
+#    Then I see that the "Auditing / Logging" app has been enabled
+#    And I see that the "LDAP user and group backend" app has been enabled
 
   Scenario: View app details
     Given I act as Jane


### PR DESCRIPTION
The bundle acceptance tests fails after #14578 sometimes. This is
because of a race condition. not all apps have compatible 16 versions
yet. So trying to enable them results in those apps doing :boom:.

Because of #14578 we do show them now. So we try to enable them. However
depending on which requests finishes first the disable button for the
audit app either shows up or now.

I'll create a PR to revert this right away. So that we can have the tests back when we have releases for all the apps.