### PR TITLE
Revert "Temp disable bundle tests"

### DIFF
--- a/tests/acceptance/features/apps.feature
+++ b/tests/acceptance/features/apps.feature
@@ -40,14 +40,14 @@ Feature: apps
     And I see the app bundles
     And I see that the "Enterprise bundle" is disabled
 
-#  Scenario: Enable an app bundle
-#    Given I act as Jane
-#    And I am logged in as the admin
-#    And I open the Apps management
-#    And I open the "App bundles" section
-#    When I enable all apps from the "Enterprise bundle"
-#    Then I see that the "Auditing / Logging" app has been enabled
-#    And I see that the "LDAP user and group backend" app has been enabled
+  Scenario: Enable an app bundle
+    Given I act as Jane
+    And I am logged in as the admin
+    And I open the Apps management
+    And I open the "App bundles" section
+    When I enable all apps from the "Enterprise bundle"
+    Then I see that the "Auditing / Logging" app has been enabled
+    And I see that the "LDAP user and group backend" app has been enabled
 
   Scenario: View app details
     Given I act as Jane


### PR DESCRIPTION
Once all apps have a 16 version (of the enterprise bundle) the test should work again.