### PR TITLE
Fetch proper translations

### DIFF
--- a/lib/private/Settings/Admin/Sharing.php
+++ b/lib/private/Settings/Admin/Sharing.php
@@ -31,6 +31,7 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Constants;
 use OCP\IConfig;
 use OCP\IL10N;
+use OCP\L10N\IFactory;
 use OCP\Settings\ISettings;
 use OCP\Share\IManager;
 use OCP\Util;
@@ -48,9 +49,9 @@ class Sharing implements ISettings {
 	/**
 	 * @param IConfig $config
 	 */
-	public function __construct(IConfig $config, IL10N $l, IManager $shareManager) {
+	public function __construct(IConfig $config, IFactory $l, IManager $shareManager) {
 		$this->config = $config;
-		$this->l = $l;
+		$this->l = $l->get('lib');
 		$this->shareManager = $shareManager;
 	}
 

--- a/tests/lib/Settings/Admin/SharingTest.php
+++ b/tests/lib/Settings/Admin/SharingTest.php
@@ -28,6 +28,7 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Constants;
 use OCP\IConfig;
 use OCP\IL10N;
+use OCP\L10N\IFactory;
 use OCP\Share\IManager;
 use Test\TestCase;
 
@@ -45,11 +46,16 @@ class SharingTest extends TestCase {
 		parent::setUp();
 		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->l10n = $this->getMockBuilder(IL10N::class)->getMock();
+
+		$l10Factory = $this->createMock(IFactory::class);
+		$l10Factory->method('get')
+			->willReturn($this->l10n);
+
 		$this->shareManager = $this->getMockBuilder(IManager::class)->getMock();
 
 		$this->admin = new Sharing(
 			$this->config,
-			$this->l10n,
+			$l10Factory,
 			$this->shareManager
 		);
 	}


### PR DESCRIPTION
Fixes #14793

This is caused by the mess we have with OC\Settings mapping to settings
and lib/private/Settings.

Anyway this is the quick fix. Moving stuff around for 17 seems better.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>