### PR TITLE
2FA login notification subject to be shown in HTML e-mail

### DIFF
--- a/settings/Activity/SecurityProvider.php
+++ b/settings/Activity/SecurityProvider.php
@@ -61,6 +61,9 @@ class SecurityProvider implements IProvider {
 				$event->setParsedSubject($l->t('You successfully logged in using two-factor authentication (%1$s)', [
 							$params['provider'],
 					]));
+				$event->setRichSubject(htmlspecialchars($l->t('You successfully logged in using two-factor authentication (%1$s)', [
+							'provider' => $params['provider'],
+					])), []);
 				if ($this->activityManager->getRequirePNG()) {
 					$event->setIcon($this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'actions/password.png')));
 				} else {


### PR DESCRIPTION
Hi,

2FA login message in activity notification e-mail, HTML format, had empty message. Since some e-mail clients like Thunderbird does not show remote images by default, this shows almost no messages. Message is shown if e-mail client is set to text only.

<img width="613" alt="キャプチャ" src="https://user-images.githubusercontent.com/5049333/54937062-14297d80-4f67-11e9-8544-6cf07242d719.PNG">

By this change, message will be shown like text style e-mail notification.

<img width="610" alt="キャプチャ" src="https://user-images.githubusercontent.com/5049333/54937187-489d3980-4f67-11e9-9b2b-d3475f1dab24.PNG">

I'm not sure of coding style here, please comment about it, please comment about it and I will modify according to your comments.

Best regards,
nhirokinet