### PR TITLE
Prepend wildcard to the LDAP search term

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1557,7 +1557,7 @@ class Access extends LDAPUtility {
 		if ($term === '') {
 			$result = '*';
 		} else if ($allowEnum !== 'no') {
-			$result = $term . '*';
+			$result = '*' . $term . '*';
 		}
 		return $result;
 	}


### PR DESCRIPTION
It makes the LDAP user/group search behaves consistently with database backend

See https://github.com/nextcloud/server/blob/3f4941e48aead48bacc7077e2819b492d1394778/lib/private/Group/Database.php#L270-L274