### PR TITLE
Implemented logging to Graylog server

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -786,7 +786,7 @@ $CONFIG = array(
 /**
  * Your graylog host server name, for example ``localhost``, ``hostname``,
  * ``hostname.example.com``, or the IP address. To specify a port use
- * ``hostname:####``
+ * ``hostname:####``. The default port is 5410
  * Only effective when ``log_type`` set to ``graylog``
  */
 'graylog_host' => '',
@@ -797,7 +797,7 @@ $CONFIG = array(
  *
  * The default value is ``udp``.
  */
-'graylog_method' => 'udp',
+'graylog_proto' => 'udp',
 
 /**
  * Log condition for log level increase based on conditions. Once one of these

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -743,6 +743,8 @@ $CONFIG = array(
  * ``systemd``: the logs are sent to the Systemd journal. This requires a system
  * that runs Systemd and the Systemd journal. The PHP extension ``systemd``
  * must be installed and active.
+ * ``graylog``: the logs are sent to a Graylog server. This requires a running
+ * Graylog service reachable by your Nextcloud instance.
  *
  * Defaults to ``file``
  */
@@ -780,6 +782,22 @@ $CONFIG = array(
  * The default value is ``Nextcloud``.
  */
 'syslog_tag' => 'Nextcloud',
+
+/**
+ * Your graylog host server name, for example ``localhost``, ``hostname``,
+ * ``hostname.example.com``, or the IP address. To specify a port use
+ * ``hostname:####``
+ * Only effective when ``log_type`` set to ``graylog``
+ */
+'graylog_host' => '',
+
+/**
+ * The protocol used for sending logs to the graylog server.
+ * Can be ``udp`` or ``tcp``.
+ *
+ * The default value is ``udp``.
+ */
+'graylog_method' => 'udp',
 
 /**
  * Log condition for log level increase based on conditions. Once one of these

--- a/core/Command/Log/Manage.php
+++ b/core/Command/Log/Manage.php
@@ -56,7 +56,8 @@ class Manage extends Command implements CompletionAwareInterface {
 				'backend',
 				null,
 				InputOption::VALUE_REQUIRED,
-				'set the logging backend [file, syslog, errorlog, systemd]'
+				'set the logging backend [file, syslog, errorlog, systemd,
+				graylog]'
 			)
 			->addOption(
 				'level',

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -922,6 +922,7 @@ return array(
     'OC\\Log\\Errorlog' => $baseDir . '/lib/private/Log/Errorlog.php',
     'OC\\Log\\ExceptionSerializer' => $baseDir . '/lib/private/Log/ExceptionSerializer.php',
     'OC\\Log\\File' => $baseDir . '/lib/private/Log/File.php',
+    'OC\\Log\\Graylog' => $baseDir . '/lib/private/Log/Graylog.php',
     'OC\\Log\\LogFactory' => $baseDir . '/lib/private/Log/LogFactory.php',
     'OC\\Log\\Rotate' => $baseDir . '/lib/private/Log/Rotate.php',
     'OC\\Log\\Syslog' => $baseDir . '/lib/private/Log/Syslog.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -952,6 +952,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Log\\Errorlog' => __DIR__ . '/../../..' . '/lib/private/Log/Errorlog.php',
         'OC\\Log\\ExceptionSerializer' => __DIR__ . '/../../..' . '/lib/private/Log/ExceptionSerializer.php',
         'OC\\Log\\File' => __DIR__ . '/../../..' . '/lib/private/Log/File.php',
+        'OC\\Log\\Graylog' => __DIR__ . '/../../..' . '/lib/private/Log/Graylog.php',
         'OC\\Log\\LogFactory' => __DIR__ . '/../../..' . '/lib/private/Log/LogFactory.php',
         'OC\\Log\\Rotate' => __DIR__ . '/../../..' . '/lib/private/Log/Rotate.php',
         'OC\\Log\\Syslog' => __DIR__ . '/../../..' . '/lib/private/Log/Syslog.php',

--- a/lib/private/Log/Graylog.php
+++ b/lib/private/Log/Graylog.php
@@ -57,7 +57,7 @@ class Graylog implements IWriter {
 	}
 
 	/**
-	 * sena a message to the Graylog server
+	 * send a message to the Graylog server
 	 *
 	 * @param string $app
 	 * @param string $message
@@ -65,11 +65,13 @@ class Graylog implements IWriter {
 	 */
 	public function write(string $app, $message, int $level) {
 		$chunks = [];
-		$msg = '{"version":"' . self::$VERSION . '","host":"' .
-			$this->host . '","short_message":"' .
-			str_replace("\n", '\\n', '{' . $app . '} ' . $message) .
-			'","level":"' . self::$LEVELS[$level] . '","timestamp":' .
-			time() . '}';
+		$msg = json_encode([
+			'version' => self::$VERSION,
+			'host' => $this->host,
+			'short_message' => '{'.$app.'} '.$message,
+			'level' => self::$LEVELS[$level],
+			'timestamp' => time()
+		]);
 		switch ($this->protocol) {
 			case 'udp':
 				$chunks = str_split($msg, 1024);

--- a/lib/private/Log/Graylog.php
+++ b/lib/private/Log/Graylog.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ *
+ * @copyright Copyright (c) <2019>, <Thomas Pulzer> (t.pulzer@thesecretgamer.de)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Log;
+
+
+use OCP\IConfig;
+use OCP\ILogger;
+use OCP\Log\IWriter;
+
+class Graylog implements IWriter {
+
+	private static $VERSION = '1.1';
+	private $host;
+	private $target;
+	private $port;
+	private $protocol;
+
+	protected static $LEVELS = [
+		1 => LOG_ALERT,
+		ILogger::FATAL => LOG_CRIT,
+		ILogger::ERROR => LOG_ERR,
+		ILogger::WARN => LOG_WARNING,
+		5 => LOG_NOTICE,
+		ILogger::INFO => LOG_INFO,
+		ILogger::DEBUG => LOG_DEBUG
+	];
+
+	public function __construct(IConfig $config) {
+		$this->host = gethostname();
+		$this->protocol = $config->getSystemValue('graylog_method', 'udp');
+		$address = $config->getSystemValue('graylog_host', '');
+		if(false !== strpos($address, ':')) {
+			$this->target = explode(':', $address)[0];
+			$this->port = intval(explode(':', $address)[1]);
+		} else {
+			$this->target = $address;
+			$this->port = 514;
+		}
+	}
+
+	/**
+	 * sena a message to the Graylog server
+	 * @param string $app
+	 * @param string $message
+	 * @param int $level
+	 */
+	public function write(string $app, $message, int $level) {
+		$chunks = [];
+		switch ($this->protocol) {
+			case 'udp':
+				$msg = '{"version":"'.self::$VERSION.'","host":"'.
+					$this->host.'","short_message":"'.
+					str_replace("\n", '\\n', '{'.$app.'} '.$message).
+					'","level":"'.self::$LEVELS[$level].'","timestamp":'.
+					time().'}';
+				$chunks = str_split($msg, strlen($msg)/8000);
+				break;
+			case 'tcp':
+				$chunks[0] = '{"version":"'.self::$VERSION.'","host":"'.
+					$this->host.'","short_message":"'.
+					str_replace("\n", '\\n', '{'.$app.'} '.$message).
+					'","level":"'.self::$LEVELS[$level].'","timestamp":'.
+					time().'}';
+				break;
+		}
+		$count = count($chunks);
+		$fp = fsockopen(
+			$this->protocol.'://'.$this->target,
+			$this->port,
+			$timeout = 5
+		);
+		switch ($count > 1) {
+			case true:
+				$id = random_bytes(8);
+				for ($i = 0; $i < $count; $i++) {
+					fwrite($fp, "\x1e\x0f".$id.$i.$count.$chunks[$i]."\0");
+				}
+				break;
+			case false:
+				fwrite($fp, $chunks[0].chr(0));
+				break;
+		}
+		fclose($fp);
+	}
+}

--- a/lib/private/Log/LogFactory.php
+++ b/lib/private/Log/LogFactory.php
@@ -53,6 +53,8 @@ class LogFactory implements ILogFactory {
 				return $this->c->resolve(Syslog::class);
 			case 'systemd':
 				return $this->c->resolve(Systemdlog::class);
+			case 'graylog':
+				return $this->c->resolve(Graylog::class);
 			case 'file':
 				return $this->buildLogFile();
 

--- a/tests/Core/Command/Log/ManageTest.php
+++ b/tests/Core/Command/Log/ManageTest.php
@@ -95,6 +95,13 @@ class ManageTest extends TestCase {
 	}
 
 	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testIsBackendGraylogSet() {
+		self::invokePrivate($this->command, 'isBackendGraylogSet', ['file']);
+	}
+
+	/**
 	 * @expectedException \Exception
 	 */
 	public function testValidateTimezone() {

--- a/tests/lib/Log/GraylogTest.php
+++ b/tests/lib/Log/GraylogTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ *
+ * @copyright Copyright (c) <2019>, <Thomas Pulzer> (t.pulzer@thesecretgamer.de)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\tests\lib\Log;
+
+
+use Test\TestCase;
+
+class GraylogTest extends TestCase {
+
+}

--- a/tests/lib/Log/GraylogTest.php
+++ b/tests/lib/Log/GraylogTest.php
@@ -23,8 +23,92 @@
 namespace OC\tests\lib\Log;
 
 
+use OC\Log\Graylog;
+use OC\SystemConfig;
 use Test\TestCase;
 
 class GraylogTest extends TestCase {
+
+	/** @var string */
+	private $graylog_method_restore;
+	/** @var string */
+	private $graylog_host_restore;
+	/** @var  SystemConfig */
+	private $config;
+	/** @var string */
+	private $buf;
+	/** @var string */
+	private $from;
+	/** @var integer */
+	private $port;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->config = \OC::$server->getSystemConfig();
+		$this->graylog_method_restore = $this->config->getValue('graylog_method');
+		$this->graylog_host_restore = $this->config->getValue('graylog_host');
+		$this->buf = '';
+		$this->from = '';
+		$this->port = 0;
+	}
+
+	public function testUnchunkedUdp() {
+		$this->config->setValue('graylog_method', 'udp');
+		$this->config->setValue('graylog_host', '127.0.0.1:5140');
+
+		// Create a mock server to send a test message to
+		$s = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
+		socket_bind($s, '127.0.0.1', 5140);
+		socket_set_nonblock($s);
+
+		$graylog = new Graylog(\OC::$server->getConfig());
+		$graylog->write('GraylogTest', 'UDP Graylog test < 8kb', 1);
+
+		socket_recvfrom($s, $this->buf, 8000, 0, $this->from, $this->port);
+		socket_close($s);
+
+		// The resulting GELF message has to be 130 characters long
+		$this->assertEquals(130, strlen($this->buf));
+	}
+
+	public function testChunkedUdp() {
+		$this->config->setValue('graylog_method', 'udp');
+		$this->config->setValue('graylog_host', '127.0.0.1:5140');
+
+		// Create a mock server to send a test message to
+		$s = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
+		socket_bind($s, '127.0.0.1', 5140);
+		socket_set_nonblock($s);
+
+		$graylog = new Graylog(\OC::$server->getConfig());
+		$msg = "Very log message filled with garbage to execeed 8kb limit. ";
+		for($i = 0; $i < 8000; $i++) {
+		  $msg .= "A";
+		}
+		$graylog->write('GraylogTest', $msg, 3);
+
+		socket_recvfrom($s, $this->buf, 8000, 0, $this->from, $this->port);
+		socket_close($s);
+
+		// The first response should start with 0x1E 0x0F, has sequence 0
+		// at position 10 and total count 2 at position 11
+		$this->assertEquals(0x1e0f, unpack('n', $this->buf)[1]);
+		$this->assertEquals(0, intval(substr($this->buf, 10, 1)));
+		$this->assertEquals(2, intval(substr($this->buf, 11, 1)));
+	}
+
+	protected function tearDown() {
+		if (isset($this->graylog_method_restore)) {
+			$this->config->setValue('graylog_method', $this->graylog_method_restore);
+		} else {
+			$this->config->deleteValue('graylog_method');
+		}
+		if (isset($this->graylog_host_restore)) {
+			$this->config->setValue('graylog_host', $this->graylog_host_restore);
+		} else {
+			$this->config->deleteValue('graylog_host');
+		}
+		parent::tearDown();
+	}
 
 }

--- a/tests/lib/Log/GraylogTest.php
+++ b/tests/lib/Log/GraylogTest.php
@@ -69,9 +69,9 @@ class GraylogTest extends TestCase {
 		socket_recvfrom($s, $this->buf, 1025, 0, $this->from, $this->port);
 		socket_close($s);
 
-		// The resulting GELF message has a length of 81 + length of host name +
+		// The resulting GELF message has a length of 79 + length of host name +
 		// length of app name + length of log message + 3 formatting characters.
-		$expected = 81 + strlen(gethostname()) + strlen($msg) + strlen($id) + 3;
+		$expected = 79 + strlen(gethostname()) + strlen($msg) + strlen($id) + 3;
 		$this->assertEquals($expected, strlen($this->buf));
 	}
 
@@ -124,9 +124,9 @@ class GraylogTest extends TestCase {
 		socket_close($c);
 		socket_close($s);
 
-		// The resulting GELF message has a length of 81 + length of host name +
+		// The resulting GELF message has a length of 79 + length of host name +
 		// length of app name + length of log message + 3 formatting characters.
-		$expected = 81 + strlen(gethostname()) + strlen($msg) + strlen($id) + 3;
+		$expected = 79 + strlen(gethostname()) + strlen($msg) + strlen($id) + 3;
 		$this->assertEquals($expected, strlen($this->buf));
 	}
 

--- a/tests/lib/Log/LogFactoryTest.php
+++ b/tests/lib/Log/LogFactoryTest.php
@@ -25,6 +25,7 @@
 namespace Test\Log;
 use OC\Log\Errorlog;
 use OC\Log\File;
+use OC\Log\Graylog;
 use OC\Log\LogFactory;
 use OC\Log\Syslog;
 use OC\Log\Systemdlog;
@@ -155,5 +156,18 @@ class LogFactoryTest extends TestCase {
 
 		$log = $this->factory->get('systemd');
 		$this->assertInstanceOf(Systemdlog::class, $log);
+	}
+
+	/**
+	 * @throws \OCP\AppFramework\QueryException
+	 */
+	public function testGraylogLog() {
+		$this->c->expects($this->once())
+			->method('resolve')
+			->with(Graylog::class)
+			->willReturn($this->createMock(Graylog::class));
+
+		$log = $this->factory->get('graylog');
+		$this->assertInstanceOf(Graylog::class, $log);
 	}
 }


### PR DESCRIPTION
# For an old feature request, I implemented logging as GELF to a Graylog server.
## Features
+ Configurable to use tcp or udp in system config
+ Auto-chunking udp messages larger than 1024 bytes
+ Log server and port configurable in host:port notation
## Implementation
Added a new class handling writing the logs to the configured server through a socket connection. If the connection fails, it returns silently.
GELF supports chunking of UDP messages up to 128 chunks. So a log message can be approx. 126kB in size or it is silently discarded.
I also added the ability to configure the logging method through the occ log:manage command scope.

Closes #95