### PR TITLE
[stable14] Fix a bug with smb notify having leading slash when it should not

### DIFF
--- a/apps/files_external/lib/Command/Notify.php
+++ b/apps/files_external/lib/Command/Notify.php
@@ -155,7 +155,7 @@ class Notify extends Base {
 	}
 
 	private function markParentAsOutdated($mountId, $path) {
-		$parent = dirname($path);
+		$parent = ltrim(dirname($path), '/');
 		if ($parent === '.') {
 			$parent = '';
 		}


### PR DESCRIPTION
Backport of #14456 