### PR TITLE
16.0.0 Beta 2

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(16, 0, 0, 3);
+$OC_Version = array(16, 0, 0, 4);
 
 // The human readable string
-$OC_VersionString = '16.0.0 Beta 1';
+$OC_VersionString = '16.0.0 Beta 2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Changelog since beta 1 (https://github.com/nextcloud/server/pull/14573)

* #14798 Allow string to be translated
* #14801 Fetch proper translations
* #14802 Use monospaced font when printing twofactor backup codes.
* #14804 Make all filepicker strings translatable
* #14805 Properly inject EventDispatched in BackgroundRepair
* #14806 Fix filepicker's add button design
* #14808 Fix personal settings fed scope tabindex
* #14809 Fix selecting an accessibility theme with the keyboard
* #14810 Select the username input after creating a user successfully
* #14812 Force boolean type for access parameter
* #14813 Check if elements are set in installer
* #14816 Bump handlebars from 4.1.0 to 4.1.1 in /build
* #14825 Set parameter type in QBMapper
* #14829 Use name from theme when downloading/printing twofactor backup codes.
* #14833 Bump strenghify to v0.5.8
* #14838 Fix placeholder in disable message
* #14852 Exclude compiled assets of files_sharing for transifex
* #14853 Make regions translatable
* #14876 Always show full previews
* #14878 Make sure all tables have named indexes
* #14880 Fix settings translation sync
* #14883 Fix light theme form elements
* #14886 Fix opening folders from different file lists
* [firstrunwizard#172](https://github.com/nextcloud/firstrunwizard/pull/172) Bump vue and vue-template-compiler
* [firstrunwizard#181](https://github.com/nextcloud/firstrunwizard/pull/181) Only load apps page for admins
* [firstrunwizard#182](https://github.com/nextcloud/firstrunwizard/pull/182) Fix next arrow on light theming colors
* [notifications#311](https://github.com/nextcloud/notifications/pull/311) Fix lodash replacing the global underscore
* [notifications#312](https://github.com/nextcloud/notifications/pull/312) Make the richObjectStringParser a real ES module
* [viewer#49](https://github.com/nextcloud/viewer/pull/49) Allow registering aliases without components
* [viewer#52](https://github.com/nextcloud/viewer/pull/52) Bump nextcloud-vue from 0.9.3 to 0.9.4


Pending PRs:

* [ ] #13137 Fix redundant urldecode()
* [ ] #14566 Lib/private/User: always pass old value to 'triggerChange' in User class, do not change user properties if value has not changed
* [ ] #14605 Returns reshares in API
* [ ] #14775 Revert "Temp disable bundle tests"
* [ ] #14784 Fix language vs. locale
* [ ] #14845 Prepend wildcard to the LDAP search term
* [x] #14885 Fix various theming issues on bright colors
* [ ] [3rdparty#193](https://github.com/nextcloud/3rdparty/pull/193) Repairing BASE64 encoded vCard version 3
* [ ] [privacy#77](https://github.com/nextcloud/privacy/pull/77) Fix adding additional admins
