### PR TITLE
Fix various theming issues on bright colors

### DIFF
--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -68,7 +68,8 @@ $invert: luma($color-primary) > 0.6;
 		a,
 		label,
 		p,
-		#alternative-logins legend {
+		#alternative-logins legend,
+		.lost-password-container #lost-password {
 			color: $color-primary-text;
 		}
 		input[type='checkbox'].checkbox--white + label:before {
@@ -175,8 +176,26 @@ input.primary,
 }
 
 @if ($invert) {
-	#body-login #submit-wrapper .icon-confirm-white {
-		background-image: url('../../../core/img/actions/confirm.svg');
+	#body-login {
+		.body-login-container {
+			background-color: $color-main-background;
+		}
+		#submit-wrapper .icon-confirm-white {
+			background-image: url('../../../core/img/actions/confirm.svg');
+		}
+		.body-login-container {
+			h2 {
+				color: $color-main-text;
+			}
+			.icon-search.icon-white {
+				// CSS variable is not used here since it is on the public page layout,
+				// where the dark theme doesn't apply at the moment
+				background-image: url('../../../core/img/actions/search.svg');
+			}
+		}
+	}
+	#body-public #header .icon-more-white {
+		background-image: var(--icon-more-000);
 	}
 }
 

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -445,7 +445,7 @@ nav[role='navigation'] {
 			text-overflow: initial;
 			width: auto;
 			overflow: hidden;
-			background-color: var(--color-primary-element);
+			background-color: var(--color-primary);
 			padding: 0 5px;
 			z-index: 2;
 		}


### PR DESCRIPTION
Theming fixes from https://github.com/nextcloud/server/issues/14639

- [x] Light theming color:
    - [x] On error pages like "File not found"
    - [x] "Forgot password?" on log in is light, should be dark
    - [x] App name in header has boxy background
    - [x] 3 dot icon in share link header is white, should be black
    - First run wizard "next" icon should be dark because the primary color is light -> https://github.com/nextcloud/firstrunwizard/pull/182
- [x] Dark theme: "File not found" screen has dark icon, should be white
- [x] Basically all the content of the `.body-login-container` should always be white because the container background is dark (`#body-login p` rule for footer overwrites this, should be more specific)

