### PR TITLE
Fix opening folders from different file lists

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -671,7 +671,12 @@
 				icon: '',
 				actionHandler: function (filename, context) {
 					var dir = context.$file.attr('data-path') || context.fileList.getCurrentDirectory();
-					context.fileList.changeDirectory(OC.joinPaths(dir, filename), true, false, parseInt(context.$file.attr('data-id'), 10));
+					if (OCA.Files.App.getActiveView() !== 'files') {
+						OCA.Files.App.setActiveView('files');
+						OCA.Files.App.fileList.changeDirectory(OC.joinPaths(dir, filename), true, true);
+					} else {
+						context.fileList.changeDirectory(OC.joinPaths(dir, filename), true, false, parseInt(context.$file.attr('data-id'), 10));
+					}
 				},
 				displayName: t('files', 'Open')
 			});


### PR DESCRIPTION
This PR fixes navigating to folders from file lists which are not the default one. To achieve proper navigation we need to switch to the default file list before trying to navigate to the actual directory.

Steps to reproduce:
1. Share a folder
2. Go to shares overview
3. Click on the shared folder
4. The folder gets opened

Fixes https://github.com/nextcloud/server/issues/13028