### PR TITLE
[stable15] Fix opening folders from different file lists

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -661,7 +661,12 @@
 
 			this.register('dir', 'Open', OC.PERMISSION_READ, '', function (filename, context) {
 				var dir = context.$file.attr('data-path') || context.fileList.getCurrentDirectory();
-				context.fileList.changeDirectory(OC.joinPaths(dir, filename), true, false, parseInt(context.$file.attr('data-id'), 10));
+				if (OCA.Files.App.getActiveView() !== 'files') {
+					OCA.Files.App.setActiveView('files');
+					OCA.Files.App.fileList.changeDirectory(OC.joinPaths(dir, filename), true, true);
+				} else {
+					context.fileList.changeDirectory(OC.joinPaths(dir, filename), true, false, parseInt(context.$file.attr('data-id'), 10));
+				}
 			});
 
 			this.registerAction({


### PR DESCRIPTION
This PR fixes navigating to folders from file lists which are not the default one. To achieve proper navigation we need to switch to the default file list before trying to navigate to the actual directory.

Steps to reproduce:
1. Share a folder
2. Go to shares overview
3. Click on the shared folder
4. The folder gets opened

Fixes https://github.com/nextcloud/server/issues/13028

Backport of https://github.com/nextcloud/server/pull/14886