### PR TITLE
hide new folder button in choose type filepicker

### DIFF
--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -264,6 +264,9 @@ var OCdialogs = {
 			}
 
 			var newButton = self.$filePicker.find('.actions.creatable .button-add');
+			if (type === self.FILEPICKER_TYPE_CHOOSE) {
+				newButton.hide();
+			}
 			newButton.on('focus', function() {
 				self.$filePicker.ocdialog('setEnterCallback', function() {
 					event.stopImmediatePropagation();


### PR DESCRIPTION
This pull requests aims to solve issue #14834
It hides the button to create a new folder in the filepicker if the type is choose.
I think that in this case it wouldn't make sense to create a new folder anyway.

Please review @MorrisJobke @jancborchardt @nextcloud/designers 