### PR TITLE
Add min-version/max-version to fulltextsearch provider element

### DIFF
--- a/resources/app-info.xsd
+++ b/resources/app-info.xsd
@@ -659,11 +659,20 @@
         </xs:sequence>
     </xs:complexType>
 
+    <xs:complexType name="fulltextsearch-provider">
+        <xs:simpleContent>
+            <xs:extension base="php-class">
+                <xs:attribute name="min-version" type="version" use="optional"/>
+                <xs:attribute name="max-version" type="version" use="optional"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
     <xs:complexType name="fulltextsearch">
         <xs:sequence>
             <xs:element name="platform" type="php-class" minOccurs="0"
                         maxOccurs="unbounded"/>
-            <xs:element name="provider" type="php-class" minOccurs="0"
+            <xs:element name="provider" type="fulltextsearch-provider" minOccurs="0"
                         maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>


### PR DESCRIPTION
@daita In https://github.com/nextcloud/server/pull/14302#issuecomment-465680038 you mentioned a version parameter but in deck you actually used min-version. Can you clarify what is actually used, since I couldn't find where this is checked.