### PR TITLE
Skip check if CONSTANT on real object is used

### DIFF
--- a/lib/private/App/CodeChecker/NodeVisitor.php
+++ b/lib/private/App/CodeChecker/NodeVisitor.php
@@ -162,7 +162,7 @@ class NodeVisitor extends NodeVisitorAbstract {
 				if ($node->class instanceof Name) {
 					$this->checkBlackList($node->class->toString(), CodeChecker::CLASS_CONST_FETCH_NOT_ALLOWED, $node);
 				}
-				if ($node->class instanceof Node\Expr\Variable) {
+				if ($node->class instanceof Node\Expr\Variable || $node->class instanceof Node\Expr\PropertyFetch) {
 					/**
 					 * TODO: find a way to detect something like this:
 					 *       $c = "OC_API";


### PR DESCRIPTION
Close #14824

Not really a fix. We just skip the check in case.