### PR TITLE
storage mount handlers: do not attempt to replace anything in password options

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -239,7 +239,11 @@ class OC_Mount_Config {
 		if (self::$skipTest) {
 			return StorageNotAvailableException::STATUS_SUCCESS;
 		}
-		foreach ($options as &$option) {
+		foreach ($options as $key => &$option) {
+			if($key === 'password') {
+				// no replacements in passwords
+				continue;
+			}
 			$option = self::substitutePlaceholdersInConfig($option);
 			if(!self::arePlaceholdersSubstituted($option)) {
 				\OC::$server->getLogger()->error(


### PR DESCRIPTION
The handler (and checker) would look for variable starting with $, e.g. $user (built-in), or $home (LDAP, if configured). The password should be ignored.

It would be nicer to know what sort of $option we handle with instead of just having the name. On the other hand, It is not so common to have $ appearing in keys/secrets. 