### PR TITLE
16.0.0 Beta 3

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(16, 0, 0, 4);
+$OC_Version = array(16, 0, 0, 5);
 
 // The human readable string
-$OC_VersionString = '16.0.0 Beta 2';
+$OC_VersionString = '16.0.0 Beta 3';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Changelog to 16.0.0 beta 2 #14872:

* #14605 Returns reshares in API
* #14775 Revert "Temp disable bundle tests"
* #14892 Bugfix/noid/collections
* #14900 Hide new folder button in choose type filepicker
* #14902 Indeces, columns and sequences don't have the table prefix
* #14905 Add min-version/max-version to fulltextsearch provider element
* #14912 Truncate filename in the middle on filepicker
* #14914 Fix hidden file display in grid view
* #14925 Skip check if CONSTANT on real object is used
* #14931 Show comments and restore in popover menu
* #14934 Fix mobile menu on users management
* #14935 Fix/settings/use components multiselect
* #14936 Set the loglevel in context, save the condition
* #14937 Storage mount handlers: do not attempt to replace anything in password options
* #14938 Move appstore details warnings above buttons
* #14946 Fix markup of file names in file picker
* #14947 Adjust acceptance tests to changes of file names in file picker
* [activity#357](https://github.com/nextcloud/activity/pull/357) Fallback to plaintext subject if no rich subject is set
* [notifications#313](https://github.com/nextcloud/notifications/pull/313) Readme: correct link for comments app
* [privacy#77](https://github.com/nextcloud/privacy/pull/77) Fix adding additional admins
* [privacy#78](https://github.com/nextcloud/privacy/pull/78) Bump phpunit/phpunit from 7.5.7 to 7.5.8
* [privacy#80](https://github.com/nextcloud/privacy/pull/80) Bump nextcloud-vue from 0.9.3 to 0.9.5
* [privacy#81](https://github.com/nextcloud/privacy/pull/81) Bump eslint from 5.15.3 to 5.16.0
* [privacy#83](https://github.com/nextcloud/privacy/pull/83) Bump babel-jest from 24.5.0 to 24.6.0
* [privacy#84](https://github.com/nextcloud/privacy/pull/84) Bump eslint-plugin-promise from 4.0.1 to 4.1.1
* [privacy#86](https://github.com/nextcloud/privacy/pull/86) Bump @babel/preset-env from 7.4.2 to 7.4.3
* [privacy#87](https://github.com/nextcloud/privacy/pull/87) Bump @babel/polyfill from 7.4.0 to 7.4.3
* [privacy#88](https://github.com/nextcloud/privacy/pull/88) Bump @babel/core from 7.4.0 to 7.4.3
* [privacy#89](https://github.com/nextcloud/privacy/pull/89) Show encryption status, fixes #68
* [privacy#90](https://github.com/nextcloud/privacy/pull/90) Don't list disabled admins, fixes #82
* [privacy#91](https://github.com/nextcloud/privacy/pull/91) Bump jest from 24.5.0 to 24.7.0
* [viewer#53](https://github.com/nextcloud/viewer/pull/53) Bump nextcloud-vue from 0.9.4 to 0.9.5
* [viewer#55](https://github.com/nextcloud/viewer/pull/55) Fix display of tiny images
* [viewer#56](https://github.com/nextcloud/viewer/pull/56) Add drone webpack build check
* [viewer#58](https://github.com/nextcloud/viewer/pull/58) Update the view on sidebar show & hide
* [viewer#59](https://github.com/nextcloud/viewer/pull/59) Bump eslint from 5.15.3 to 5.16.0
* [viewer#60](https://github.com/nextcloud/viewer/pull/60) Bump eslint-plugin-promise from 4.0.1 to 4.1.1
* [viewer#62](https://github.com/nextcloud/viewer/pull/62) Bump @babel/core from 7.4.0 to 7.4.3
* [viewer#63](https://github.com/nextcloud/viewer/pull/63) Bump @babel/preset-env from 7.4.2 to 7.4.3


Pending PRs:

* [ ] #14566 Lib/private/User: always pass old value to 'triggerChange' in User class, do not change user properties if value has not changed
* [ ] #14784 Fix language vs. locale