### PR TITLE
Set empty CSP by default

### DIFF
--- a/lib/public/AppFramework/Http/DataDisplayResponse.php
+++ b/lib/public/AppFramework/Http/DataDisplayResponse.php
@@ -49,6 +49,8 @@ class DataDisplayResponse extends Response {
 	 */
 	public function __construct($data='', $statusCode=Http::STATUS_OK,
 	                            $headers=[]) {
+		parent::__construct();
+
 		$this->data = $data;
 		$this->setStatus($statusCode);
 		$this->setHeaders(array_merge($this->getHeaders(), $headers));

--- a/lib/public/AppFramework/Http/DataResponse.php
+++ b/lib/public/AppFramework/Http/DataResponse.php
@@ -52,6 +52,8 @@ class DataResponse extends Response {
 	 */
 	public function __construct($data=array(), $statusCode=Http::STATUS_OK,
 	                            array $headers=array()) {
+		parent::__construct();
+
 		$this->data = $data;
 		$this->setStatus($statusCode);
 		$this->setHeaders(array_merge($this->getHeaders(), $headers));

--- a/lib/public/AppFramework/Http/DownloadResponse.php
+++ b/lib/public/AppFramework/Http/DownloadResponse.php
@@ -30,7 +30,7 @@ namespace OCP\AppFramework\Http;
  * Prompts the user to download the a file
  * @since 7.0.0
  */
-class DownloadResponse extends \OCP\AppFramework\Http\Response {
+class DownloadResponse extends Response {
 
 	private $filename;
 	private $contentType;
@@ -42,6 +42,8 @@ class DownloadResponse extends \OCP\AppFramework\Http\Response {
 	 * @since 7.0.0
 	 */
 	public function __construct($filename, $contentType) {
+		parent::__construct();
+
 		$this->filename = $filename;
 		$this->contentType = $contentType;
 

--- a/lib/public/AppFramework/Http/FileDisplayResponse.php
+++ b/lib/public/AppFramework/Http/FileDisplayResponse.php
@@ -45,6 +45,8 @@ class FileDisplayResponse extends Response implements ICallbackResponse {
 	 */
 	public function __construct($file, $statusCode=Http::STATUS_OK,
 								$headers=[]) {
+		parent::__construct();
+
 		$this->file = $file;
 		$this->setStatus($statusCode);
 		$this->setHeaders(array_merge($this->getHeaders(), $headers));

--- a/lib/public/AppFramework/Http/JSONResponse.php
+++ b/lib/public/AppFramework/Http/JSONResponse.php
@@ -53,6 +53,8 @@ class JSONResponse extends Response {
 	 * @since 6.0.0
 	 */
 	public function __construct($data=array(), $statusCode=Http::STATUS_OK) {
+		parent::__construct();
+
 		$this->data = $data;
 		$this->setStatus($statusCode);
 		$this->addHeader('Content-Type', 'application/json; charset=utf-8');

--- a/lib/public/AppFramework/Http/NotFoundResponse.php
+++ b/lib/public/AppFramework/Http/NotFoundResponse.php
@@ -35,6 +35,8 @@ class NotFoundResponse extends Response {
 	 * @since 8.1.0
 	 */
 	public function __construct() {
+		parent::__construct();
+
 		$this->setStatus(404);
 	}
 

--- a/lib/public/AppFramework/Http/OCSResponse.php
+++ b/lib/public/AppFramework/Http/OCSResponse.php
@@ -59,6 +59,8 @@ class OCSResponse extends Response {
 	public function __construct($format, $statuscode, $message,
 								$data=[], $itemscount='',
 								$itemsperpage='') {
+		parent::__construct();
+
 		$this->format = $format;
 		$this->statuscode = $statuscode;
 		$this->message = $message;

--- a/lib/public/AppFramework/Http/RedirectResponse.php
+++ b/lib/public/AppFramework/Http/RedirectResponse.php
@@ -43,6 +43,8 @@ class RedirectResponse extends Response {
 	 * @since 7.0.0
 	 */
 	public function __construct($redirectURL) {
+		parent::__construct();
+
 		$this->redirectURL = $redirectURL;
 		$this->setStatus(Http::STATUS_SEE_OTHER);
 		$this->addHeader('Location', $redirectURL);

--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -90,6 +90,15 @@ class Response {
 	private $throttleMetadata = [];
 
 	/**
+	 * Response constructor.
+	 *
+	 * @since 17.0.0
+	 */
+	public function __construct() {
+		$this->setContentSecurityPolicy(new EmptyContentSecurityPolicy());
+	}
+
+	/**
 	 * Caches the response
 	 * @param int $cacheSeconds the amount of seconds that should be cached
 	 * if 0 then caching will be disabled

--- a/lib/public/AppFramework/Http/StreamResponse.php
+++ b/lib/public/AppFramework/Http/StreamResponse.php
@@ -42,6 +42,8 @@ class StreamResponse extends Response implements ICallbackResponse {
 	 * @since 8.1.0
 	 */
 	public function __construct ($filePath) {
+		parent::__construct();
+
 		$this->filePath = $filePath;
 	}
 

--- a/lib/public/AppFramework/Http/TemplateResponse.php
+++ b/lib/public/AppFramework/Http/TemplateResponse.php
@@ -75,10 +75,14 @@ class TemplateResponse extends Response {
 	 */
 	public function __construct($appName, $templateName, array $params=array(),
 	                            $renderAs='user') {
+		parent::__construct();
+
 		$this->templateName = $templateName;
 		$this->appName = $appName;
 		$this->params = $params;
 		$this->renderAs = $renderAs;
+
+		$this->setContentSecurityPolicy(new ContentSecurityPolicy());
 	}
 
 

--- a/lib/public/AppFramework/Http/ZipResponse.php
+++ b/lib/public/AppFramework/Http/ZipResponse.php
@@ -44,6 +44,8 @@ class ZipResponse extends Response implements ICallbackResponse {
 	 * @since 15.0.0
 	 */
 	public function __construct(IRequest $request, string $name = 'output') {
+		parent::__construct();
+
 		$this->name = $name;
 		$this->request = $request;
 	}

--- a/tests/lib/AppFramework/Controller/ControllerTest.php
+++ b/tests/lib/AppFramework/Controller/ControllerTest.php
@@ -116,7 +116,7 @@ class ControllerTest extends \Test\TestCase {
 			'test' => 'something',
 			'Cache-Control' => 'no-cache, no-store, must-revalidate',
 			'Content-Type' => 'application/json; charset=utf-8',
-			'Content-Security-Policy' => "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self'",
+			'Content-Security-Policy' => "default-src 'none';base-uri 'none';manifest-src 'self'",
 		];
 
 		$response = $this->controller->customDataResponse(array('hi'));

--- a/tests/lib/AppFramework/Http/DataResponseTest.php
+++ b/tests/lib/AppFramework/Http/DataResponseTest.php
@@ -68,7 +68,7 @@ class DataResponseTest extends \Test\TestCase {
 
 		$expectedHeaders = [
 			'Cache-Control' => 'no-cache, no-store, must-revalidate',
-			'Content-Security-Policy' => "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self'",
+			'Content-Security-Policy' => "default-src 'none';base-uri 'none';manifest-src 'self'",
 		];
 		$expectedHeaders = array_merge($expectedHeaders, $headers);
 

--- a/tests/lib/AppFramework/Http/ResponseTest.php
+++ b/tests/lib/AppFramework/Http/ResponseTest.php
@@ -59,7 +59,7 @@ class ResponseTest extends \Test\TestCase {
 
 		$this->childResponse->setHeaders($expected);
 		$headers = $this->childResponse->getHeaders();
-		$expected['Content-Security-Policy'] = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self'";
+		$expected['Content-Security-Policy'] = "default-src 'none';base-uri 'none';manifest-src 'self'";
 
 		$this->assertEquals($expected, $headers);
 	}
@@ -86,7 +86,7 @@ class ResponseTest extends \Test\TestCase {
 	}
 
 	public function testGetCspEmpty() {
-		$this->assertNull($this->childResponse->getContentSecurityPolicy());
+		$this->assertEquals(new Http\EmptyContentSecurityPolicy(), $this->childResponse->getContentSecurityPolicy());
 	}
 
 	public function testAddHeaderValueNullDeletesIt(){


### PR DESCRIPTION
For #14179

By default responses should have the strictest (and simplest) CSP
possible. Only template responses should require an actual CSP.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>