### PR TITLE
Disable the injected snapper logic when apps want to ship their own

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1192,7 +1192,9 @@ function initCore() {
 	setTimeout(resizeMenu, 0);
 
 	// just add snapper for logged in users
-	if($('#app-navigation').length && !$('html').hasClass('lte9')) {
+	// and if the app doesn't handle the nav slider itself
+	if($('#app-navigation').length && !$('html').hasClass('lte9')
+	    && !$('#app-content').hasClass('no-snapper')) {
 
 		// App sidebar on mobile
 		var snapper = new Snap({


### PR DESCRIPTION
This allows apps to ship their own, as in some cases the #app-content
element does not exist on page load and therefore the injection fails
and the icon is missing afterwards.

With https://github.com/nextcloud/nextcloud-vue/pull/339 we'll ship our own Vue-specific logic to handle the sliding.

Fixes https://github.com/nextcloud/server/issues/14956