### PR TITLE
Enable pre-releases for beta and daily channel

### DIFF
--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -83,14 +83,17 @@ class AppFetcher extends Fetcher {
 		/** @var mixed[] $response */
 		$response = parent::fetch($ETag, $content);
 
+		$allowPreReleases = $this->getChannel() === 'beta' || $this->getChannel() === 'daily';
+		$allowNightly = $this->getChannel() === 'daily';
+
 		foreach($response['data'] as $dataKey => $app) {
 			$releases = [];
 
 			// Filter all compatible releases
 			foreach($app['releases'] as $release) {
-				// Exclude all nightly and pre-releases
-				if($release['isNightly'] === false
-					&& strpos($release['version'], '-') === false) {
+				// Exclude all nightly and pre-releases if required
+				if (($allowNightly || $release['isNightly'] === false)
+					&& ($allowPreReleases || strpos($release['version'], '-') === false)) {
 					// Exclude all versions not compatible with the current version
 					try {
 						$versionParser = new VersionParser();

--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -57,6 +57,8 @@ abstract class Fetcher {
 	protected $endpointUrl;
 	/** @var string */
 	protected $version;
+	/** @var string */
+	protected $channel;
 
 	/**
 	 * @param Factory $appDataFactory
@@ -196,5 +198,24 @@ abstract class Fetcher {
 	 */
 	public function setVersion(string $version) {
 		$this->version = $version;
+	}
+
+	/**
+	 * Get the currently Nextcloud update channel
+	 * @return string
+	 */
+	protected function getChannel() {
+		if ($this->channel === null) {
+			$this->channel = \OC_Util::getChannel();
+		}
+		return $this->channel;
+	}
+
+	/**
+	 * Set the current Nextcloud update channel
+	 * @param string $channel
+	 */
+	public function setChannel(string $channel) {
+		$this->channel = $channel;
 	}
 }


### PR DESCRIPTION
For easier testing apply:
```diff
diff --git a/lib/private/App/AppStore/Fetcher/Fetcher.php b/lib/private/App/AppStore/Fetcher/Fetcher.php
index db8c38ac68..e665ae8e47 100644
--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -98,11 +98,11 @@ abstract class Fetcher {
                        'timeout' => 10,
                ];
 
-               if ($ETag !== '') {
-                       $options['headers'] = [
-                               'If-None-Match' => $ETag,
-                       ];
-               }
+//             if ($ETag !== '') {
+//                     $options['headers'] = [
+//                             'If-None-Match' => $ETag,
+//                     ];
+//             }
 
                $client = $this->clientService->newClient();
                $response = $client->get($this->endpointUrl, $options);
@@ -151,15 +151,15 @@ abstract class Fetcher {
                                // No caching when the version has been updated
                                if (isset($jsonBlob['ncversion']) && $jsonBlob['ncversion'] === $this->getVersion()) {
 
-                                       // If the timestamp is older than 300 seconds request the files new
-                                       if ((int)$jsonBlob['timestamp'] > ($this->timeFactory->getTime() - self::INVALIDATE_AFTER_SECONDS)) {
-                                               return $jsonBlob['data'];
-                                       }
-
-                                       if (isset($jsonBlob['ETag'])) {
-                                               $ETag = $jsonBlob['ETag'];
-                                               $content = json_encode($jsonBlob['data']);
-                                       }
+//                                     // If the timestamp is older than 300 seconds request the files new
+//                                     if ((int)$jsonBlob['timestamp'] > ($this->timeFactory->getTime() - self::INVALIDATE_AFTER_SECONDS)) {
+//                                             return $jsonBlob['data'];
+//                                     }
+//
+//                                     if (isset($jsonBlob['ETag'])) {
+//                                             $ETag = $jsonBlob['ETag'];
+//                                             $content = json_encode($jsonBlob['data']);
+//                                     }
                                }
                        }
                } catch (NotFoundException $e) {
diff --git a/lib/private/Installer.php b/lib/private/Installer.php
index a410c6a011..69f81ef668 100644
--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -420,7 +420,7 @@ class Installer {
                        return false;
                }
                $basedir = $app['path'].'/'.$appId;
-               return file_exists($basedir.'/.git/');
+               return false;//file_exists($basedir.'/.git/');
        }
 
        /**

```