### PR TITLE
Remove negation for swift tmp file

### DIFF
--- a/lib/private/Files/ObjectStore/Swift.php
+++ b/lib/private/Files/ObjectStore/Swift.php
@@ -79,7 +79,7 @@ class Swift implements IObjectStore {
 		$handle = $stream;
 
 		$meta = stream_get_meta_data($stream);
-		if (!(isset($meta['seekable']) && $meta['seekable'] === true)) {
+		if (isset($meta['seekable']) && $meta['seekable'] === true) {
 			$tmpFile = \OC::$server->getTempManager()->getTemporaryFile('swiftwrite');
 			file_put_contents($tmpFile, $stream);
 			$handle = fopen($tmpFile, 'rb');


### PR DESCRIPTION
After testing PR #14570 in NC15 and Master, I couldn't write files bigger than 10MB with the negation on the verification. After removing the negation it worked just fine. 

See issue #13554 