### PR TITLE
Forbid eval on legacy responses

### DIFF
--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -84,7 +84,7 @@ class OC_Response {
 		 * @see \OCP\AppFramework\Http\Response::getHeaders
 		 */
 		$policy = 'default-src \'self\'; '
-			. 'script-src \'self\' \'unsafe-eval\' \'nonce-'.\OC::$server->getContentSecurityPolicyNonceManager()->getNonce().'\'; '
+			. 'script-src \'self\' \'nonce-'.\OC::$server->getContentSecurityPolicyNonceManager()->getNonce().'\'; '
 			. 'style-src \'self\' \'unsafe-inline\'; '
 			. 'frame-src *; '
 			. 'img-src * data: blob:; '


### PR DESCRIPTION
Seems I missed this one.
We do not use this response type a lot anymore. But should fix it still.