### PR TITLE
Bugfix/noid/fix too many event triggers

### DIFF
--- a/apps/lookup_server_connector/lib/UpdateLookupServer.php
+++ b/apps/lookup_server_connector/lib/UpdateLookupServer.php
@@ -165,7 +165,7 @@ class UpdateLookupServer {
 	 * @return bool
 	 */
 	private function shouldUpdateLookupServer() {
-		return $this->lookupServerEnabled || !empty($this->lookupServer);
+		return $this->lookupServerEnabled && !empty($this->lookupServer);
 	}
 
 }

--- a/lib/private/Avatar/UserAvatar.php
+++ b/lib/private/Avatar/UserAvatar.php
@@ -312,11 +312,6 @@ class UserAvatar extends Avatar {
 	 * @throws \OCP\PreConditionNotMetException
 	 */
 	public function userChanged($feature, $oldValue, $newValue) {
-		// We only change the avatar on display name changes
-		if ($feature !== 'displayName') {
-			return;
-		}
-
 		// If the avatar is not generated (so an uploaded image) we skip this
 		if (!$this->folder->fileExists('generated')) {
 			return;

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1257,6 +1257,11 @@ class Server extends ServerContainer implements IServerContainer {
 			$oldValue = $e->getArgument('oldValue');
 			$value = $e->getArgument('value');
 
+			// We only change the avatar on display name changes
+			if ($feature !== 'displayName') {
+				return;
+			}
+
 			try {
 				$avatar = $manager->getAvatar($user->getUID());
 				$avatar->userChanged($feature, $oldValue, $value);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -426,10 +426,9 @@ class Server extends ServerContainer implements IServerContainer {
 			$userSession->listen('\OC\User', 'logout', function () {
 				\OC_Hook::emit('OC_User', 'logout', array());
 			});
-			$userSession->listen('\OC\User', 'changeUser', function ($user, $feature, $value, $oldValue) use ($dispatcher) {
+			$userSession->listen('\OC\User', 'changeUser', function ($user, $feature, $value, $oldValue) {
 				/** @var $user \OC\User\User */
 				\OC_Hook::emit('OC_User', 'changeUser', array('run' => true, 'user' => $user, 'feature' => $feature, 'value' => $value, 'old_value' => $oldValue));
-				$dispatcher->dispatch('OCP\IUser::changeUser', new GenericEvent($user, ['feature' => $feature, 'oldValue' => $oldValue, 'value' => $value]));
 			});
 			return $userSession;
 		});


### PR DESCRIPTION
Add a break point at https://github.com/nextcloud/server/blob/3f9cdeeb5fe9aee97e410ec59bbdd1c9cf3c33d5/lib/private/Server.php#L1261
And create a user via console

Before: called **6** times
After: called **1** time

The event was already in place before:
https://github.com/nextcloud/server/blame/ec4b1584fe46df81e3eda1ff374f575d153a966f/lib/private/Server.php#L432
So when I added it in:
https://github.com/nextcloud/server/blame/01b4db62fbc4230cff953a2385d305b149744b86/lib/private/User/User.php#L468

It got actually called twices everytime.

And then the avatar manager listened to it's own event making some extra loops :see_no_evil: 

