### PR TITLE
Run less phan processes

### DIFF
--- a/build/.phan/config.php
+++ b/build/.phan/config.php
@@ -128,7 +128,7 @@ return [
 
 	// The number of processes to fork off during the analysis
 	// phase.
-	'processes' => 10,
+	'processes' => 5,
 
 	// Backwards Compatibility Checking. This is slow
 	// and expensive, but you should consider running


### PR DESCRIPTION
Hopefully this makes the weaker drone workers not do :boom: as phanis veyr very resource hungy.