### PR TITLE
Notifications overhaul

### DIFF
--- a/apps/comments/lib/AppInfo/Application.php
+++ b/apps/comments/lib/AppInfo/Application.php
@@ -76,15 +76,7 @@ class Application extends App {
 	}
 
 	protected function registerNotifier() {
-		$this->getContainer()->getServer()->getNotificationManager()->registerNotifier(
-			function() {
-				return $this->getContainer()->query(Notifier::class);
-			},
-			function () {
-				$l = $this->getContainer()->getServer()->getL10NFactory()->get('comments');
-				return ['id' => 'comments', 'name' => $l->t('Comments')];
-			}
-		);
+		$this->getContainer()->getServer()->getNotificationManager()->registerNotifier(Notifier::class);
 	}
 
 	protected function registerCommentsEventHandler() {

--- a/apps/comments/lib/AppInfo/Application.php
+++ b/apps/comments/lib/AppInfo/Application.php
@@ -76,7 +76,7 @@ class Application extends App {
 	}
 
 	protected function registerNotifier() {
-		$this->getContainer()->getServer()->getNotificationManager()->registerNotifier(Notifier::class);
+		$this->getContainer()->getServer()->getNotificationManager()->registerNotifierService(Notifier::class);
 	}
 
 	protected function registerCommentsEventHandler() {

--- a/apps/comments/lib/Notification/Notifier.php
+++ b/apps/comments/lib/Notification/Notifier.php
@@ -32,6 +32,7 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
+use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
 
@@ -67,12 +68,34 @@ class Notifier implements INotifier {
 	}
 
 	/**
+	 * Identifier of the notifier, only use [a-z0-9_]
+	 *
+	 * @return string
+	 * @since 17.0.0
+	 */
+	public function getID(): string {
+		return 'comments';
+	}
+
+	/**
+	 * Human readable name describing the notifier
+	 *
+	 * @return string
+	 * @since 17.0.0
+	 */
+	public function getName(): string {
+		return $this->l10nFactory->get('comments')->t('Comments');
+	}
+
+	/**
 	 * @param INotification $notification
 	 * @param string $languageCode The code of the language that should be used to prepare the notification
 	 * @return INotification
 	 * @throws \InvalidArgumentException When the notification was not prepared by a notifier
+	 * @throws AlreadyProcessedException When the notification is not needed anymore and should be deleted
+	 * @since 9.0.0
 	 */
-	public function prepare(INotification $notification, $languageCode) {
+	public function prepare(INotification $notification, string $languageCode): INotification {
 		if($notification->getApp() !== 'comments') {
 			throw new \InvalidArgumentException();
 		}
@@ -101,7 +124,7 @@ class Notifier implements INotifier {
 				$userFolder = $this->rootFolder->getUserFolder($notification->getUser());
 				$nodes = $userFolder->getById((int)$parameters[1]);
 				if(empty($nodes)) {
-					throw new \InvalidArgumentException('Cannot resolve file ID to node instance');
+					throw new AlreadyProcessedException();
 				}
 				$node = $nodes[0];
 

--- a/apps/comments/tests/Unit/Controller/NotificationsTest.php
+++ b/apps/comments/tests/Unit/Controller/NotificationsTest.php
@@ -117,6 +117,9 @@ class NotificationsTest extends TestCase {
 		$comment->expects($this->any())
 			->method('getObjectType')
 			->willReturn('files');
+		$comment->expects($this->any())
+			->method('getId')
+			->willReturn('1234');
 
 		$this->commentsManager->expects($this->any())
 			->method('get')
@@ -192,6 +195,9 @@ class NotificationsTest extends TestCase {
 		$comment->expects($this->any())
 			->method('getObjectType')
 			->willReturn('files');
+		$comment->expects($this->any())
+			->method('getId')
+			->willReturn('1234');
 
 		$this->commentsManager->expects($this->any())
 			->method('get')

--- a/apps/comments/tests/Unit/Notification/ListenerTest.php
+++ b/apps/comments/tests/Unit/Notification/ListenerTest.php
@@ -91,6 +91,9 @@ class ListenerTest extends TestCase {
 				[ 'type' => 'user', 'id' => '23452-4333-54353-2342'],
 				[ 'type' => 'user', 'id' => 'yolo'],
 			]);
+		$comment->expects($this->atLeastOnce())
+			->method('getId')
+			->willReturn('1234');
 
 		/** @var CommentsEvent|\PHPUnit_Framework_MockObject_MockObject $event */
 		$event = $this->getMockBuilder(CommentsEvent::class)
@@ -186,6 +189,9 @@ class ListenerTest extends TestCase {
 		$comment->expects($this->once())
 			->method('getMentions')
 			->willReturn([[ 'type' => 'user', 'id' => 'foobar']]);
+		$comment->expects($this->atLeastOnce())
+			->method('getId')
+			->willReturn('1234');
 
 		/** @var CommentsEvent|\PHPUnit_Framework_MockObject_MockObject $event */
 		$event = $this->getMockBuilder(CommentsEvent::class)

--- a/apps/comments/tests/Unit/Notification/NotifierTest.php
+++ b/apps/comments/tests/Unit/Notification/NotifierTest.php
@@ -195,6 +195,9 @@ class NotifierTest extends TestCase {
 			->expects($this->any())
 			->method('getMentions')
 			->willReturn([['type' => 'user', 'id' => 'you']]);
+		$this->comment->expects($this->atLeastOnce())
+			->method('getId')
+			->willReturn('1234');
 
 		$this->commentsManager
 			->expects($this->once())
@@ -539,7 +542,7 @@ class NotifierTest extends TestCase {
 	}
 
 	/**
-	 * @expectedException \InvalidArgumentException
+	 * @expectedException \OCP\Notification\AlreadyProcessedException
 	 */
 	public function testPrepareUnresolvableFileID() {
 		$displayName = 'Huraga';

--- a/apps/federatedfilesharing/appinfo/app.php
+++ b/apps/federatedfilesharing/appinfo/app.php
@@ -29,15 +29,7 @@ $app = new \OCA\FederatedFileSharing\AppInfo\Application();
 $eventDispatcher = \OC::$server->getEventDispatcher();
 
 $manager = \OC::$server->getNotificationManager();
-$manager->registerNotifier(function() {
-	return \OC::$server->query(Notifier::class);
-}, function() {
-	$l = \OC::$server->getL10N('files_sharing');
-	return [
-		'id' => 'files_sharing',
-		'name' => $l->t('Federated sharing'),
-	];
-});
+$manager->registerNotifier(Notifier::class);
 
 $federatedShareProvider = $app->getFederatedShareProvider();
 

--- a/apps/federatedfilesharing/appinfo/app.php
+++ b/apps/federatedfilesharing/appinfo/app.php
@@ -29,7 +29,7 @@ $app = new \OCA\FederatedFileSharing\AppInfo\Application();
 $eventDispatcher = \OC::$server->getEventDispatcher();
 
 $manager = \OC::$server->getNotificationManager();
-$manager->registerNotifier(Notifier::class);
+$manager->registerNotifierService(Notifier::class);
 
 $federatedShareProvider = $app->getFederatedShareProvider();
 

--- a/apps/federatedfilesharing/lib/Notifier.php
+++ b/apps/federatedfilesharing/lib/Notifier.php
@@ -60,12 +60,32 @@ class Notifier implements INotifier {
 	}
 
 	/**
+	 * Identifier of the notifier, only use [a-z0-9_]
+	 *
+	 * @return string
+	 * @since 17.0.0
+	 */
+	public function getID(): string {
+		return 'federatedfilesharing';
+	}
+
+	/**
+	 * Human readable name describing the notifier
+	 *
+	 * @return string
+	 * @since 17.0.0
+	 */
+	public function getName(): string {
+		return $this->factory->get('federatedfilesharing')->t('Federated sharing');
+	}
+
+	/**
 	 * @param INotification $notification
 	 * @param string $languageCode The code of the language that should be used to prepare the notification
 	 * @return INotification
 	 * @throws \InvalidArgumentException
 	 */
-	public function prepare(INotification $notification, $languageCode) {
+	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== 'files_sharing') {
 			// Not my app => throw
 			throw new \InvalidArgumentException();

--- a/apps/twofactor_backupcodes/lib/AppInfo/Application.php
+++ b/apps/twofactor_backupcodes/lib/AppInfo/Application.php
@@ -74,7 +74,7 @@ class Application extends App {
 		$container = $this->getContainer();
 		/** @var IManager $manager */
 		$manager = $container->query(IManager::class);
-		$manager->registerNotifier(Notifier::class);
+		$manager->registerNotifierService(Notifier::class);
 	}
 
 	public function deleteUser($params) {

--- a/apps/twofactor_backupcodes/lib/AppInfo/Application.php
+++ b/apps/twofactor_backupcodes/lib/AppInfo/Application.php
@@ -74,15 +74,7 @@ class Application extends App {
 		$container = $this->getContainer();
 		/** @var IManager $manager */
 		$manager = $container->query(IManager::class);
-		$manager->registerNotifier(
-			function() use ($container) {
-				return $container->query(Notifier::class);
-			},
-			function () use ($container) {
-				$l = $container->query(IL10N::class);
-				return ['id' => 'twofactor_backupcodes', 'name' => $l->t('Second-factor backup codes')];
-			}
-		);
+		$manager->registerNotifier(Notifier::class);
 	}
 
 	public function deleteUser($params) {

--- a/apps/twofactor_backupcodes/lib/Notifications/Notifier.php
+++ b/apps/twofactor_backupcodes/lib/Notifications/Notifier.php
@@ -42,7 +42,27 @@ class Notifier implements INotifier {
 		$this->url = $url;
 	}
 
-	public function prepare(INotification $notification, $languageCode) {
+	/**
+	 * Identifier of the notifier, only use [a-z0-9_]
+	 *
+	 * @return string
+	 * @since 17.0.0
+	 */
+	public function getID(): string {
+		return 'twofactor_backupcodes';
+	}
+
+	/**
+	 * Human readable name describing the notifier
+	 *
+	 * @return string
+	 * @since 17.0.0
+	 */
+	public function getName(): string {
+		return $this->factory->get('twofactor_backupcodes')->t('Second-factor backup codes');
+	}
+
+	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== 'twofactor_backupcodes') {
 			// Not my app => throw
 			throw new \InvalidArgumentException();
@@ -67,5 +87,4 @@ class Notifier implements INotifier {
 				throw new \InvalidArgumentException();
 		}
 	}
-
 }

--- a/apps/updatenotification/lib/AppInfo/Application.php
+++ b/apps/updatenotification/lib/AppInfo/Application.php
@@ -71,14 +71,6 @@ class Application extends App {
 
 	public function registerNotifier() {
 		$notificationsManager = $this->getContainer()->getServer()->getNotificationManager();
-		$notificationsManager->registerNotifier(function() {
-			return  $this->getContainer()->query(Notifier::class);
-		}, function() {
-			$l = $this->getContainer()->getServer()->getL10N('updatenotification');
-			return [
-				'id' => 'updatenotification',
-				'name' => $l->t('Update notifications'),
-			];
-		});
+		$notificationsManager->registerNotifier(Notifier::class);
 	}
 }

--- a/apps/updatenotification/lib/AppInfo/Application.php
+++ b/apps/updatenotification/lib/AppInfo/Application.php
@@ -71,6 +71,6 @@ class Application extends App {
 
 	public function registerNotifier() {
 		$notificationsManager = $this->getContainer()->getServer()->getNotificationManager();
-		$notificationsManager->registerNotifier(Notifier::class);
+		$notificationsManager->registerNotifierService(Notifier::class);
 	}
 }

--- a/apps/updatenotification/lib/Notification/Notifier.php
+++ b/apps/updatenotification/lib/Notification/Notifier.php
@@ -31,6 +31,7 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
+use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\IManager;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
@@ -80,13 +81,34 @@ class Notifier implements INotifier {
 	}
 
 	/**
+	 * Identifier of the notifier, only use [a-z0-9_]
+	 *
+	 * @return string
+	 * @since 17.0.0
+	 */
+	public function getID(): string {
+		return 'updatenotification';
+	}
+
+	/**
+	 * Human readable name describing the notifier
+	 *
+	 * @return string
+	 * @since 17.0.0
+	 */
+	public function getName(): string {
+		return $this->l10NFactory->get('updatenotification')->t('Update notifications');
+	}
+
+	/**
 	 * @param INotification $notification
 	 * @param string $languageCode The code of the language that should be used to prepare the notification
 	 * @return INotification
 	 * @throws \InvalidArgumentException When the notification was not prepared by a notifier
+	 * @throws AlreadyProcessedException When the notification is not needed anymore and should be deleted
 	 * @since 9.0.0
 	 */
-	public function prepare(INotification $notification, $languageCode): INotification {
+	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== 'updatenotification') {
 			throw new \InvalidArgumentException('Unknown app id');
 		}
@@ -142,12 +164,11 @@ class Notifier implements INotifier {
 	 *
 	 * @param INotification $notification
 	 * @param string $installedVersion
-	 * @throws \InvalidArgumentException When the update is already installed
+	 * @throws AlreadyProcessedException When the update is already installed
 	 */
 	protected function updateAlreadyInstalledCheck(INotification $notification, $installedVersion) {
 		if (version_compare($notification->getObjectId(), $installedVersion, '<=')) {
-			$this->notificationManager->markProcessed($notification);
-			throw new \InvalidArgumentException('Update already installed');
+			throw new AlreadyProcessedException();
 		}
 	}
 

--- a/apps/updatenotification/tests/Notification/NotifierTest.php
+++ b/apps/updatenotification/tests/Notification/NotifierTest.php
@@ -30,6 +30,7 @@ use OCP\IGroupManager;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
+use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\IManager;
 use OCP\Notification\INotification;
 use Test\TestCase;
@@ -112,21 +113,12 @@ class NotifierTest extends TestCase {
 			->method('getObjectId')
 			->willReturn($versionNotification);
 
-		if ($exception) {
-			$this->notificationManager->expects($this->once())
-				->method('markProcessed')
-				->with($notification);
-		} else {
-			$this->notificationManager->expects($this->never())
-				->method('markProcessed');
-		}
-
 		try {
 			self::invokePrivate($notifier, 'updateAlreadyInstalledCheck', [$notification, $versionInstalled]);
 			$this->assertFalse($exception);
 		} catch (\Exception $e) {
 			$this->assertTrue($exception);
-			$this->assertInstanceOf('InvalidArgumentException', $e);
+			$this->assertInstanceOf(AlreadyProcessedException::class, $e);
 		}
 	}
 }

--- a/apps/user_ldap/appinfo/app.php
+++ b/apps/user_ldap/appinfo/app.php
@@ -42,17 +42,7 @@ if(count($configPrefixes) > 0) {
 	$ldapWrapper = new OCA\User_LDAP\LDAP();
 	$ocConfig = \OC::$server->getConfig();
 	$notificationManager = \OC::$server->getNotificationManager();
-	$notificationManager->registerNotifier(function() {
-		return new \OCA\User_LDAP\Notification\Notifier(
-			\OC::$server->getL10NFactory()
-		);
-	}, function() {
-		$l = \OC::$server->getL10N('user_ldap');
-		return [
-			'id' => 'user_ldap',
-			'name' => $l->t('LDAP user and group backend'),
-		];
-	});
+	$notificationManager->registerNotifier(\OCA\User_LDAP\Notification\Notifier::class);
 	$userSession = \OC::$server->getUserSession();
 
 	$userPluginManager = \OC::$server->query('LDAPUserPluginManager');

--- a/apps/user_ldap/appinfo/app.php
+++ b/apps/user_ldap/appinfo/app.php
@@ -42,7 +42,7 @@ if(count($configPrefixes) > 0) {
 	$ldapWrapper = new OCA\User_LDAP\LDAP();
 	$ocConfig = \OC::$server->getConfig();
 	$notificationManager = \OC::$server->getNotificationManager();
-	$notificationManager->registerNotifier(\OCA\User_LDAP\Notification\Notifier::class);
+	$notificationManager->registerNotifierService(\OCA\User_LDAP\Notification\Notifier::class);
 	$userSession = \OC::$server->getUserSession();
 
 	$userPluginManager = \OC::$server->query('LDAPUserPluginManager');

--- a/apps/user_ldap/lib/Notification/Notifier.php
+++ b/apps/user_ldap/lib/Notification/Notifier.php
@@ -43,12 +43,32 @@ class Notifier implements INotifier {
 	}
 
 	/**
+	 * Identifier of the notifier, only use [a-z0-9_]
+	 *
+	 * @return string
+	 * @since 17.0.0
+	 */
+	public function getID(): string {
+		return 'user_ldap';
+	}
+
+	/**
+	 * Human readable name describing the notifier
+	 *
+	 * @return string
+	 * @since 17.0.0
+	 */
+	public function getName(): string {
+		return $this->l10nFactory->get('user_ldap')->t('LDAP User backend');
+	}
+
+	/**
 	 * @param INotification $notification
 	 * @param string $languageCode The code of the language that should be used to prepare the notification
 	 * @return INotification
 	 * @throws \InvalidArgumentException When the notification was not prepared by a notifier
 	 */
-	public function prepare(INotification $notification, $languageCode) {
+	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== 'user_ldap') {
 			// Not my app => throw
 			throw new \InvalidArgumentException();

--- a/core/Application.php
+++ b/core/Application.php
@@ -65,8 +65,8 @@ class Application extends App {
 		$eventDispatcher = $server->query(IEventDispatcher::class);
 
 		$notificationManager = $server->getNotificationManager();
-		$notificationManager->registerNotifier(RemoveLinkSharesNotifier::class);
-		$notificationManager->registerNotifier(AuthenticationNotifier::class);
+		$notificationManager->registerNotifierService(RemoveLinkSharesNotifier::class);
+		$notificationManager->registerNotifierService(AuthenticationNotifier::class);
 
 		$eventDispatcher->addListener(IDBConnection::CHECK_MISSING_INDEXES_EVENT,
 			function (GenericEvent $event) use ($container) {

--- a/core/Application.php
+++ b/core/Application.php
@@ -65,24 +65,8 @@ class Application extends App {
 		$eventDispatcher = $server->query(IEventDispatcher::class);
 
 		$notificationManager = $server->getNotificationManager();
-		$notificationManager->registerNotifier(function () use ($server) {
-			return new RemoveLinkSharesNotifier(
-				$server->getL10NFactory()
-			);
-		}, function () {
-			return [
-				'id' => 'core',
-				'name' => 'core',
-			];
-		});
-		$notificationManager->registerNotifier(function () use ($server) {
-			return $server->query(AuthenticationNotifier::class);
-		}, function () {
-			return [
-				'id' => 'auth',
-				'name' => 'authentication notifier',
-			];
-		});
+		$notificationManager->registerNotifier(RemoveLinkSharesNotifier::class);
+		$notificationManager->registerNotifier(AuthenticationNotifier::class);
 
 		$eventDispatcher->addListener(IDBConnection::CHECK_MISSING_INDEXES_EVENT,
 			function (GenericEvent $event) use ($container) {

--- a/core/Notification/RemoveLinkSharesNotifier.php
+++ b/core/Notification/RemoveLinkSharesNotifier.php
@@ -36,7 +36,27 @@ class RemoveLinkSharesNotifier implements INotifier {
 		$this->l10nFactory = $factory;
 	}
 
-	public function prepare(INotification $notification, $languageCode): INotification {
+	/**
+	 * Identifier of the notifier, only use [a-z0-9_]
+	 *
+	 * @return string
+	 * @since 17.0.0
+	 */
+	public function getID(): string {
+		return 'core';
+	}
+
+	/**
+	 * Human readable name describing the notifier
+	 *
+	 * @return string
+	 * @since 17.0.0
+	 */
+	public function getName(): string {
+		return $this->l10nFactory->get('core')->t('Nextcloud Server');
+	}
+
+	public function prepare(INotification $notification, string $languageCode): INotification {
 		if($notification->getApp() !== 'core') {
 			throw new \InvalidArgumentException();
 		}
@@ -51,5 +71,4 @@ class RemoveLinkSharesNotifier implements INotifier {
 
 		throw new \InvalidArgumentException('Invalid subject');
 	}
-
 }

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -347,6 +347,7 @@ return array(
     'OCP\\Migration\\IOutput' => $baseDir . '/lib/public/Migration/IOutput.php',
     'OCP\\Migration\\IRepairStep' => $baseDir . '/lib/public/Migration/IRepairStep.php',
     'OCP\\Migration\\SimpleMigrationStep' => $baseDir . '/lib/public/Migration/SimpleMigrationStep.php',
+    'OCP\\Notification\\AlreadyProcessedException' => $baseDir . '/lib/public/Notification/AlreadyProcessedException.php',
     'OCP\\Notification\\IAction' => $baseDir . '/lib/public/Notification/IAction.php',
     'OCP\\Notification\\IApp' => $baseDir . '/lib/public/Notification/IApp.php',
     'OCP\\Notification\\IManager' => $baseDir . '/lib/public/Notification/IManager.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -381,6 +381,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Migration\\IOutput' => __DIR__ . '/../../..' . '/lib/public/Migration/IOutput.php',
         'OCP\\Migration\\IRepairStep' => __DIR__ . '/../../..' . '/lib/public/Migration/IRepairStep.php',
         'OCP\\Migration\\SimpleMigrationStep' => __DIR__ . '/../../..' . '/lib/public/Migration/SimpleMigrationStep.php',
+        'OCP\\Notification\\AlreadyProcessedException' => __DIR__ . '/../../..' . '/lib/public/Notification/AlreadyProcessedException.php',
         'OCP\\Notification\\IAction' => __DIR__ . '/../../..' . '/lib/public/Notification/IAction.php',
         'OCP\\Notification\\IApp' => __DIR__ . '/../../..' . '/lib/public/Notification/IApp.php',
         'OCP\\Notification\\IManager' => __DIR__ . '/../../..' . '/lib/public/Notification/IManager.php',

--- a/lib/private/Authentication/Listeners/RemoteWipeNotificationsListener.php
+++ b/lib/private/Authentication/Listeners/RemoteWipeNotificationsListener.php
@@ -61,7 +61,7 @@ class RemoteWipeNotificationsListener implements IEventListener {
 		$notification->setApp('auth')
 			->setUser($token->getUID())
 			->setDateTime($this->timeFactory->getDateTime())
-			->setObject('token', $token->getId())
+			->setObject('token', (string) $token->getId())
 			->setSubject($event, [
 				'name' => $token->getName(),
 			]);

--- a/lib/private/Authentication/Notifications/Notifier.php
+++ b/lib/private/Authentication/Notifications/Notifier.php
@@ -42,7 +42,7 @@ class Notifier implements INotifier {
 	/**
 	 * @inheritDoc
 	 */
-	public function prepare(INotification $notification, $languageCode) {
+	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== 'auth') {
 			// Not my app => throw
 			throw new InvalidArgumentException();
@@ -74,4 +74,23 @@ class Notifier implements INotifier {
 		}
 	}
 
+	/**
+	 * Identifier of the notifier, only use [a-z0-9_]
+	 *
+	 * @return string
+	 * @since 17.0.0
+	 */
+	public function getID(): string {
+		return 'auth';
+	}
+
+	/**
+	 * Human readable name describing the notifier
+	 *
+	 * @return string
+	 * @since 17.0.0
+	 */
+	public function getName(): string {
+		return $this->factory->get('lib')->t('Authentication');
+	}
 }

--- a/lib/private/Notification/Action.php
+++ b/lib/private/Notification/Action.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -45,9 +46,6 @@ class Action implements IAction {
 	/** @var bool */
 	protected $primary;
 
-	/**
-	 * Constructor
-	 */
 	public function __construct() {
 		$this->label = '';
 		$this->labelParsed = '';
@@ -62,8 +60,8 @@ class Action implements IAction {
 	 * @throws \InvalidArgumentException if the label is invalid
 	 * @since 8.2.0
 	 */
-	public function setLabel($label) {
-		if (!is_string($label) || $label === '' || isset($label[32])) {
+	public function setLabel(string $label): IAction {
+		if ($label === '' || isset($label[32])) {
 			throw new \InvalidArgumentException('The given label is invalid');
 		}
 		$this->label = $label;
@@ -74,7 +72,7 @@ class Action implements IAction {
 	 * @return string
 	 * @since 8.2.0
 	 */
-	public function getLabel() {
+	public function getLabel(): string {
 		return $this->label;
 	}
 
@@ -84,8 +82,8 @@ class Action implements IAction {
 	 * @throws \InvalidArgumentException if the label is invalid
 	 * @since 8.2.0
 	 */
-	public function setParsedLabel($label) {
-		if (!is_string($label) || $label === '') {
+	public function setParsedLabel(string $label): IAction {
+		if ($label === '') {
 			throw new \InvalidArgumentException('The given parsed label is invalid');
 		}
 		$this->labelParsed = $label;
@@ -96,21 +94,16 @@ class Action implements IAction {
 	 * @return string
 	 * @since 8.2.0
 	 */
-	public function getParsedLabel() {
+	public function getParsedLabel(): string {
 		return $this->labelParsed;
 	}
 
 	/**
 	 * @param $primary bool
 	 * @return $this
-	 * @throws \InvalidArgumentException if $primary is invalid
 	 * @since 9.0.0
 	 */
-	public function setPrimary($primary) {
-		if (!is_bool($primary)) {
-			throw new \InvalidArgumentException('The given primary option is invalid');
-		}
-
+	public function setPrimary(bool $primary): IAction {
 		$this->primary = $primary;
 		return $this;
 	}
@@ -119,7 +112,7 @@ class Action implements IAction {
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function isPrimary() {
+	public function isPrimary(): bool {
 		return $this->primary;
 	}
 
@@ -130,11 +123,17 @@ class Action implements IAction {
 	 * @throws \InvalidArgumentException if the link is invalid
 	 * @since 8.2.0
 	 */
-	public function setLink($link, $requestType) {
-		if (!is_string($link) || $link === '' || isset($link[256])) {
+	public function setLink(string $link, string $requestType): IAction {
+		if ($link === '' || isset($link[256])) {
 			throw new \InvalidArgumentException('The given link is invalid');
 		}
-		if (!in_array($requestType, ['GET', 'POST', 'PUT', 'DELETE'], true)) {
+		if (!in_array($requestType, [
+			self::TYPE_GET,
+			self::TYPE_POST,
+			self::TYPE_PUT,
+			self::TYPE_DELETE,
+			self::TYPE_WEB,
+		], true)) {
 			throw new \InvalidArgumentException('The given request type is invalid');
 		}
 		$this->link = $link;
@@ -146,7 +145,7 @@ class Action implements IAction {
 	 * @return string
 	 * @since 8.2.0
 	 */
-	public function getLink() {
+	public function getLink(): string {
 		return $this->link;
 	}
 
@@ -154,21 +153,21 @@ class Action implements IAction {
 	 * @return string
 	 * @since 8.2.0
 	 */
-	public function getRequestType() {
+	public function getRequestType(): string {
 		return $this->requestType;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function isValid() {
+	public function isValid(): bool {
 		return $this->label !== '' && $this->link !== '';
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function isValidParsed() {
+	public function isValidParsed(): bool {
 		return $this->labelParsed !== '' && $this->link !== '';
 	}
 }

--- a/lib/private/Notification/Manager.php
+++ b/lib/private/Notification/Manager.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -56,11 +57,6 @@ class Manager implements IManager {
 	/** @var bool */
 	protected $preparingPushNotification;
 
-	/**
-	 * Manager constructor.
-	 *
-	 * @param IValidator $validator
-	 */
 	public function __construct(IValidator $validator) {
 		$this->validator = $validator;
 		$this->apps = [];
@@ -179,7 +175,7 @@ class Manager implements IManager {
 	 * @param bool $preparingPushNotification
 	 * @since 14.0.0
 	 */
-	public function setPreparingPushNotification($preparingPushNotification) {
+	public function setPreparingPushNotification(bool $preparingPushNotification): void {
 		$this->preparingPushNotification = $preparingPushNotification;
 	}
 
@@ -196,7 +192,7 @@ class Manager implements IManager {
 	 * @throws \InvalidArgumentException When the notification is not valid
 	 * @since 8.2.0
 	 */
-	public function notify(INotification $notification) {
+	public function notify(INotification $notification): void {
 		if (!$notification->isValid()) {
 			throw new \InvalidArgumentException('The given notification is invalid');
 		}
@@ -218,7 +214,7 @@ class Manager implements IManager {
 	 * @throws \InvalidArgumentException When the notification was not prepared by a notifier
 	 * @since 8.2.0
 	 */
-	public function prepare(INotification $notification, $languageCode): INotification {
+	public function prepare(INotification $notification, string $languageCode): INotification {
 		$notifiers = $this->getNotifiers();
 
 		foreach ($notifiers as $notifier) {
@@ -243,7 +239,7 @@ class Manager implements IManager {
 	/**
 	 * @param INotification $notification
 	 */
-	public function markProcessed(INotification $notification) {
+	public function markProcessed(INotification $notification): void {
 		$apps = $this->getApps();
 
 		foreach ($apps as $app) {

--- a/lib/private/Notification/Manager.php
+++ b/lib/private/Notification/Manager.php
@@ -43,21 +43,13 @@ class Manager implements IManager {
 
 	/** @var IApp[] */
 	protected $apps;
-
-	/** @var INotifier[] */
-	protected $notifiers;
-
-	/** @var array[] */
-	protected $notifiersInfo;
-
 	/** @var string[] */
 	protected $appClasses;
 
+	/** @var INotifier[] */
+	protected $notifiers;
 	/** @var string[] */
 	protected $notifierClasses;
-
-	/** @var \Closure[] */
-	protected $notifiersInfoClosures;
 
 	/** @var bool */
 	protected $preparingPushNotification;
@@ -167,7 +159,7 @@ class Manager implements IManager {
 	 * @since 8.2.0
 	 */
 	public function hasNotifiers(): bool {
-		return !empty($this->notifiersClosures);
+		return !empty($this->notifiers) || !empty($this->notifierClasses);
 	}
 
 	/**

--- a/lib/private/Notification/Manager.php
+++ b/lib/private/Notification/Manager.php
@@ -67,7 +67,7 @@ class Manager implements IManager {
 	/**
 	 * @param string $appClass The service must implement IApp, otherwise a
 	 *                          \InvalidArgumentException is thrown later
-	 * @since 9.0.0
+	 * @since 17.0.0
 	 */
 	public function registerApp(string $appClass): void {
 		$this->appClasses[] = $appClass;

--- a/lib/private/Notification/Manager.php
+++ b/lib/private/Notification/Manager.php
@@ -74,12 +74,27 @@ class Manager implements IManager {
 	}
 
 	/**
-	 * @param string $notifierClass The service must implement INotifier, otherwise a
+	 * @param \Closure $service The service must implement INotifier, otherwise a
+	 *                          \InvalidArgumentException is thrown later
+	 * @param \Closure $info    An array with the keys 'id' and 'name' containing
+	 *                          the app id and the app name
+	 * @deprecated 17.0.0 use registerNotifierService instead.
+	 * @since 8.2.0 - Parameter $info was added in 9.0.0
+	 */
+	public function registerNotifier(\Closure $service, \Closure $info) {
+		$infoData = $info();
+		$this->logger->logException(new \InvalidArgumentException(
+			'Notifier ' . $infoData['name'] . ' (id: ' . $infoData['id'] . ') is not considered because it is using the old way to register.'
+		));
+	}
+
+	/**
+	 * @param string $notifierService The service must implement INotifier, otherwise a
 	 *                          \InvalidArgumentException is thrown later
 	 * @since 17.0.0
 	 */
-	public function registerNotifier(string $notifierClass): void {
-		$this->notifierClasses[] = $notifierClass;
+	public function registerNotifierService(string $notifierService): void {
+		$this->notifierClasses[] = $notifierService;
 	}
 
 	/**
@@ -110,6 +125,8 @@ class Manager implements IManager {
 
 			$this->apps[] = $app;
 		}
+
+		$this->appClasses = [];
 
 		return $this->apps;
 	}
@@ -142,6 +159,8 @@ class Manager implements IManager {
 
 			$this->notifiers[] = $notifier;
 		}
+
+		$this->notifierClasses = [];
 
 		return $this->notifiers;
 	}

--- a/lib/private/Notification/Notification.php
+++ b/lib/private/Notification/Notification.php
@@ -1,5 +1,5 @@
 <?php
-declare (strict_types = 1);
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -99,11 +99,6 @@ class Notification implements INotification {
 	/** @var bool */
 	protected $hasPrimaryParsedAction;
 
-	/**
-	 * Constructor
-	 *
-	 * @param IValidator $richValidator
-	 */
 	public function __construct(IValidator $richValidator) {
 		$this->richValidator = $richValidator;
 		$this->app = '';
@@ -134,8 +129,8 @@ class Notification implements INotification {
 	 * @throws \InvalidArgumentException if the app id is invalid
 	 * @since 8.2.0
 	 */
-	public function setApp(string $app) {
-		if (trim($app) === '' || isset($app[32])) {
+	public function setApp(string $app): INotification {
+		if ($app === '' || isset($app[32])) {
 			throw new \InvalidArgumentException('The given app name is invalid');
 		}
 		$this->app = $app;
@@ -146,7 +141,7 @@ class Notification implements INotification {
 	 * @return string
 	 * @since 8.2.0
 	 */
-	public function getApp() {
+	public function getApp(): string {
 		return $this->app;
 	}
 
@@ -156,8 +151,8 @@ class Notification implements INotification {
 	 * @throws \InvalidArgumentException if the user id is invalid
 	 * @since 8.2.0
 	 */
-	public function setUser(string $user) {
-		if (trim($user) === '' || isset($user[64])) {
+	public function setUser(string $user): INotification {
+		if ($user === '' || isset($user[64])) {
 			throw new \InvalidArgumentException('The given user id is invalid');
 		}
 		$this->user = $user;
@@ -168,7 +163,7 @@ class Notification implements INotification {
 	 * @return string
 	 * @since 8.2.0
 	 */
-	public function getUser() {
+	public function getUser(): string {
 		return $this->user;
 	}
 
@@ -178,7 +173,7 @@ class Notification implements INotification {
 	 * @throws \InvalidArgumentException if the $dateTime is invalid
 	 * @since 9.0.0
 	 */
-	public function setDateTime(\DateTime $dateTime) {
+	public function setDateTime(\DateTime $dateTime): INotification {
 		if ($dateTime->getTimestamp() === 0) {
 			throw new \InvalidArgumentException('The given date time is invalid');
 		}
@@ -190,7 +185,7 @@ class Notification implements INotification {
 	 * @return \DateTime
 	 * @since 9.0.0
 	 */
-	public function getDateTime() {
+	public function getDateTime(): \DateTime {
 		return $this->dateTime;
 	}
 
@@ -201,13 +196,13 @@ class Notification implements INotification {
 	 * @throws \InvalidArgumentException if the object type or id is invalid
 	 * @since 8.2.0 - 9.0.0: Type of $id changed to string
 	 */
-	public function setObject(string $type, $id) {
-		if (trim($type) === '' || isset($type[64])) {
+	public function setObject(string $type, string $id): INotification {
+		if ($type === '' || isset($type[64])) {
 			throw new \InvalidArgumentException('The given object type is invalid');
 		}
 		$this->objectType = $type;
 
-		if (!is_int($id) && (!is_string($id) || $id === '' || isset($id[64]))) {
+		if ($id === '' || isset($id[64])) {
 			throw new \InvalidArgumentException('The given object id is invalid');
 		}
 		$this->objectId = (string) $id;
@@ -218,7 +213,7 @@ class Notification implements INotification {
 	 * @return string
 	 * @since 8.2.0
 	 */
-	public function getObjectType() {
+	public function getObjectType(): string {
 		return $this->objectType;
 	}
 
@@ -226,7 +221,7 @@ class Notification implements INotification {
 	 * @return string
 	 * @since 8.2.0 - 9.0.0: Return type changed to string
 	 */
-	public function getObjectId() {
+	public function getObjectId(): string {
 		return $this->objectId;
 	}
 
@@ -237,8 +232,8 @@ class Notification implements INotification {
 	 * @throws \InvalidArgumentException if the subject or parameters are invalid
 	 * @since 8.2.0
 	 */
-	public function setSubject(string $subject, array $parameters = []) {
-		if (trim($subject) === '' || isset($subject[64])) {
+	public function setSubject(string $subject, array $parameters = []): INotification {
+		if ($subject === '' || isset($subject[64])) {
 			throw new \InvalidArgumentException('The given subject is invalid');
 		}
 
@@ -252,15 +247,15 @@ class Notification implements INotification {
 	 * @return string
 	 * @since 8.2.0
 	 */
-	public function getSubject() {
+	public function getSubject(): string {
 		return $this->subject;
 	}
 
 	/**
-	 * @return string[]
+	 * @return array
 	 * @since 8.2.0
 	 */
-	public function getSubjectParameters() {
+	public function getSubjectParameters(): array {
 		return $this->subjectParameters;
 	}
 
@@ -270,8 +265,8 @@ class Notification implements INotification {
 	 * @throws \InvalidArgumentException if the subject is invalid
 	 * @since 8.2.0
 	 */
-	public function setParsedSubject(string $subject) {
-		if (trim($subject) === '') {
+	public function setParsedSubject(string $subject): INotification {
+		if ($subject === '') {
 			throw new \InvalidArgumentException('The given parsed subject is invalid');
 		}
 		$this->subjectParsed = $subject;
@@ -282,7 +277,7 @@ class Notification implements INotification {
 	 * @return string
 	 * @since 8.2.0
 	 */
-	public function getParsedSubject() {
+	public function getParsedSubject(): string {
 		return $this->subjectParsed;
 	}
 
@@ -293,8 +288,8 @@ class Notification implements INotification {
 	 * @throws \InvalidArgumentException if the subject or parameters are invalid
 	 * @since 11.0.0
 	 */
-	public function setRichSubject(string $subject, array $parameters = []) {
-		if (trim($subject) === '') {
+	public function setRichSubject(string $subject, array $parameters = []): INotification {
+		if ($subject === '') {
 			throw new \InvalidArgumentException('The given parsed subject is invalid');
 		}
 
@@ -308,7 +303,7 @@ class Notification implements INotification {
 	 * @return string
 	 * @since 11.0.0
 	 */
-	public function getRichSubject() {
+	public function getRichSubject(): string {
 		return $this->subjectRich;
 	}
 
@@ -316,7 +311,7 @@ class Notification implements INotification {
 	 * @return array[]
 	 * @since 11.0.0
 	 */
-	public function getRichSubjectParameters() {
+	public function getRichSubjectParameters(): array {
 		return $this->subjectRichParameters;
 	}
 
@@ -327,8 +322,8 @@ class Notification implements INotification {
 	 * @throws \InvalidArgumentException if the message or parameters are invalid
 	 * @since 8.2.0
 	 */
-	public function setMessage(string $message, array $parameters = []) {
-		if (trim($message) === '' || isset($message[64])) {
+	public function setMessage(string $message, array $parameters = []): INotification {
+		if ($message === '' || isset($message[64])) {
 			throw new \InvalidArgumentException('The given message is invalid');
 		}
 
@@ -342,15 +337,15 @@ class Notification implements INotification {
 	 * @return string
 	 * @since 8.2.0
 	 */
-	public function getMessage() {
+	public function getMessage(): string {
 		return $this->message;
 	}
 
 	/**
-	 * @return string[]
+	 * @return array
 	 * @since 8.2.0
 	 */
-	public function getMessageParameters() {
+	public function getMessageParameters(): array {
 		return $this->messageParameters;
 	}
 
@@ -360,8 +355,8 @@ class Notification implements INotification {
 	 * @throws \InvalidArgumentException if the message is invalid
 	 * @since 8.2.0
 	 */
-	public function setParsedMessage(string $message) {
-		if (trim($message) === '') {
+	public function setParsedMessage(string $message): INotification {
+		if ($message === '') {
 			throw new \InvalidArgumentException('The given parsed message is invalid');
 		}
 		$this->messageParsed = $message;
@@ -372,7 +367,7 @@ class Notification implements INotification {
 	 * @return string
 	 * @since 8.2.0
 	 */
-	public function getParsedMessage() {
+	public function getParsedMessage(): string {
 		return $this->messageParsed;
 	}
 
@@ -383,8 +378,8 @@ class Notification implements INotification {
 	 * @throws \InvalidArgumentException if the message or parameters are invalid
 	 * @since 11.0.0
 	 */
-	public function setRichMessage(string $message, array $parameters = []) {
-		if (trim($message) === '') {
+	public function setRichMessage(string $message, array $parameters = []): INotification {
+		if ($message === '') {
 			throw new \InvalidArgumentException('The given parsed message is invalid');
 		}
 
@@ -398,7 +393,7 @@ class Notification implements INotification {
 	 * @return string
 	 * @since 11.0.0
 	 */
-	public function getRichMessage() {
+	public function getRichMessage(): string {
 		return $this->messageRich;
 	}
 
@@ -406,7 +401,7 @@ class Notification implements INotification {
 	 * @return array[]
 	 * @since 11.0.0
 	 */
-	public function getRichMessageParameters() {
+	public function getRichMessageParameters(): array {
 		return $this->messageRichParameters;
 	}
 
@@ -416,8 +411,8 @@ class Notification implements INotification {
 	 * @throws \InvalidArgumentException if the link is invalid
 	 * @since 8.2.0
 	 */
-	public function setLink(string $link) {
-		if (trim($link) === '' || isset($link[4000])) {
+	public function setLink(string $link): INotification {
+		if ($link === '' || isset($link[4000])) {
 			throw new \InvalidArgumentException('The given link is invalid');
 		}
 		$this->link = $link;
@@ -428,7 +423,7 @@ class Notification implements INotification {
 	 * @return string
 	 * @since 8.2.0
 	 */
-	public function getLink() {
+	public function getLink(): string {
 		return $this->link;
 	}
 
@@ -438,8 +433,8 @@ class Notification implements INotification {
 	 * @throws \InvalidArgumentException if the icon is invalid
 	 * @since 11.0.0
 	 */
-	public function setIcon(string $icon) {
-		if (trim($icon) === '' || isset($icon[4000])) {
+	public function setIcon(string $icon): INotification {
+		if ($icon === '' || isset($icon[4000])) {
 			throw new \InvalidArgumentException('The given icon is invalid');
 		}
 		$this->icon = $icon;
@@ -450,7 +445,7 @@ class Notification implements INotification {
 	 * @return string
 	 * @since 11.0.0
 	 */
-	public function getIcon() {
+	public function getIcon(): string {
 		return $this->icon;
 	}
 
@@ -458,7 +453,7 @@ class Notification implements INotification {
 	 * @return IAction
 	 * @since 8.2.0
 	 */
-	public function createAction() {
+	public function createAction(): IAction {
 		return new Action();
 	}
 
@@ -468,7 +463,7 @@ class Notification implements INotification {
 	 * @throws \InvalidArgumentException if the action is invalid
 	 * @since 8.2.0
 	 */
-	public function addAction(IAction $action) {
+	public function addAction(IAction $action): INotification {
 		if (!$action->isValid()) {
 			throw new \InvalidArgumentException('The given action is invalid');
 		}
@@ -489,7 +484,7 @@ class Notification implements INotification {
 	 * @return IAction[]
 	 * @since 8.2.0
 	 */
-	public function getActions() {
+	public function getActions(): array {
 		return $this->actions;
 	}
 
@@ -499,7 +494,7 @@ class Notification implements INotification {
 	 * @throws \InvalidArgumentException if the action is invalid
 	 * @since 8.2.0
 	 */
-	public function addParsedAction(IAction $action) {
+	public function addParsedAction(IAction $action): INotification {
 		if (!$action->isValidParsed()) {
 			throw new \InvalidArgumentException('The given parsed action is invalid');
 		}
@@ -524,7 +519,7 @@ class Notification implements INotification {
 	 * @return IAction[]
 	 * @since 8.2.0
 	 */
-	public function getParsedActions() {
+	public function getParsedActions(): array {
 		return $this->actionsParsed;
 	}
 
@@ -532,7 +527,7 @@ class Notification implements INotification {
 	 * @return bool
 	 * @since 8.2.0
 	 */
-	public function isValid() {
+	public function isValid(): bool {
 		return
 			$this->isValidCommon()
 			&&
@@ -544,7 +539,7 @@ class Notification implements INotification {
 	 * @return bool
 	 * @since 8.2.0
 	 */
-	public function isValidParsed() {
+	public function isValidParsed(): bool {
 		if ($this->getRichSubject() !== '' || !empty($this->getRichSubjectParameters())) {
 			try {
 				$this->richValidator->validate($this->getRichSubject(), $this->getRichSubjectParameters());
@@ -568,10 +563,7 @@ class Notification implements INotification {
 		;
 	}
 
-	/**
-	 * @return bool
-	 */
-	protected function isValidCommon() {
+	protected function isValidCommon(): bool {
 		return
 			$this->getApp() !== ''
 			&&

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -899,7 +899,8 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 		$this->registerService(\OCP\Notification\IManager::class, function (Server $c) {
 			return new Manager(
-				$c->query(IValidator::class)
+				$c->query(IValidator::class),
+				$c->getLogger()
 			);
 		});
 		$this->registerAlias('NotificationManager', \OCP\Notification\IManager::class);

--- a/lib/public/Notification/AlreadyProcessedException.php
+++ b/lib/public/Notification/AlreadyProcessedException.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Notification;
+
+
+class AlreadyProcessedException extends \RuntimeException {
+
+	public function __construct() {
+		parent::__construct('Notification is processed already');
+	}
+
+}

--- a/lib/public/Notification/IAction.php
+++ b/lib/public/Notification/IAction.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -29,19 +30,41 @@ namespace OCP\Notification;
  * @since 9.0.0
  */
 interface IAction {
+
+	/**
+	 * @since 17.0.0
+	 */
+	public const TYPE_GET = 'GET';
+	/**
+	 * @since 17.0.0
+	 */
+	public const TYPE_POST = 'POST';
+	/**
+	 * @since 17.0.0
+	 */
+	public const TYPE_PUT = 'PUT';
+	/**
+	 * @since 17.0.0
+	 */
+	public const TYPE_DELETE = 'DELETE';
+	/**
+	 * @since 17.0.0
+	 */
+	public const TYPE_WEB = 'WEB';
+
 	/**
 	 * @param string $label
 	 * @return $this
 	 * @throws \InvalidArgumentException if the label is invalid
 	 * @since 9.0.0
 	 */
-	public function setLabel($label);
+	public function setLabel(string $label): IAction;
 
 	/**
 	 * @return string
 	 * @since 9.0.0
 	 */
-	public function getLabel();
+	public function getLabel(): string;
 
 	/**
 	 * @param string $label
@@ -49,27 +72,27 @@ interface IAction {
 	 * @throws \InvalidArgumentException if the label is invalid
 	 * @since 9.0.0
 	 */
-	public function setParsedLabel($label);
+	public function setParsedLabel(string $label): IAction;
 
 	/**
 	 * @return string
 	 * @since 9.0.0
 	 */
-	public function getParsedLabel();
+	public function getParsedLabel(): string;
 
 	/**
-	 * @param $primary bool
+	 * @param bool $primary
 	 * @return $this
 	 * @throws \InvalidArgumentException if $primary is invalid
 	 * @since 9.0.0
 	 */
-	public function setPrimary($primary);
+	public function setPrimary(bool $primary): IAction;
 
 	/**
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function isPrimary();
+	public function isPrimary(): bool;
 
 	/**
 	 * @param string $link
@@ -78,29 +101,29 @@ interface IAction {
 	 * @throws \InvalidArgumentException if the link is invalid
 	 * @since 9.0.0
 	 */
-	public function setLink($link, $requestType);
+	public function setLink(string $link, string $requestType): IAction;
 
 	/**
 	 * @return string
 	 * @since 9.0.0
 	 */
-	public function getLink();
+	public function getLink(): string;
 
 	/**
 	 * @return string
 	 * @since 9.0.0
 	 */
-	public function getRequestType();
+	public function getRequestType(): string;
 
 	/**
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function isValid();
+	public function isValid(): bool;
 
 	/**
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function isValidParsed();
+	public function isValidParsed(): bool;
 }

--- a/lib/public/Notification/IApp.php
+++ b/lib/public/Notification/IApp.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -34,18 +35,18 @@ interface IApp {
 	 * @throws \InvalidArgumentException When the notification is not valid
 	 * @since 9.0.0
 	 */
-	public function notify(INotification $notification);
+	public function notify(INotification $notification): void;
 
 	/**
 	 * @param INotification $notification
 	 * @since 9.0.0
 	 */
-	public function markProcessed(INotification $notification);
+	public function markProcessed(INotification $notification): void;
 
 	/**
 	 * @param INotification $notification
 	 * @return int
 	 * @since 9.0.0
 	 */
-	public function getCount(INotification $notification);
+	public function getCount(INotification $notification): int;
 }

--- a/lib/public/Notification/IManager.php
+++ b/lib/public/Notification/IManager.php
@@ -31,26 +31,24 @@ namespace OCP\Notification;
  */
 interface IManager extends IApp, INotifier {
 	/**
-	 * @param \Closure $service The service must implement IApp, otherwise a
+	 * @param string $appClass The service must implement IApp, otherwise a
 	 *                          \InvalidArgumentException is thrown later
-	 * @since 9.0.0
+	 * @since 17.0.0
 	 */
-	public function registerApp(\Closure $service);
+	public function registerApp(string $appClass): void;
 
 	/**
-	 * @param \Closure $service The service must implement INotifier, otherwise a
+	 * @param string $notifierClass The service must implement INotifier, otherwise a
 	 *                          \InvalidArgumentException is thrown later
-	 * @param \Closure $info    An array with the keys 'id' and 'name' containing
-	 *                          the app id and the app name
-	 * @since 9.0.0
+	 * @since 17.0.0
 	 */
-	public function registerNotifier(\Closure $service, \Closure $info);
+	public function registerNotifier(string $notifierClass): void;
 
 	/**
-	 * @return array App ID => App Name
+	 * @return INotifier[]
 	 * @since 9.0.0
 	 */
-	public function listNotifiers(): array;
+	public function getNotifiers(): array;
 
 	/**
 	 * @return INotification

--- a/lib/public/Notification/IManager.php
+++ b/lib/public/Notification/IManager.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -49,29 +50,29 @@ interface IManager extends IApp, INotifier {
 	 * @return array App ID => App Name
 	 * @since 9.0.0
 	 */
-	public function listNotifiers();
+	public function listNotifiers(): array;
 
 	/**
 	 * @return INotification
 	 * @since 9.0.0
 	 */
-	public function createNotification();
+	public function createNotification(): INotification;
 
 	/**
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function hasNotifiers();
+	public function hasNotifiers(): bool;
 
 	/**
 	 * @param bool $preparingPushNotification
 	 * @since 14.0.0
 	 */
-	public function setPreparingPushNotification($preparingPushNotification);
+	public function setPreparingPushNotification(bool $preparingPushNotification): void;
 
 	/**
 	 * @return bool
 	 * @since 14.0.0
 	 */
-	public function isPreparingPushNotification();
+	public function isPreparingPushNotification(): bool;
 }

--- a/lib/public/Notification/IManager.php
+++ b/lib/public/Notification/IManager.php
@@ -38,11 +38,21 @@ interface IManager extends IApp, INotifier {
 	public function registerApp(string $appClass): void;
 
 	/**
-	 * @param string $notifierClass The service must implement INotifier, otherwise a
+	 * @param \Closure $service The service must implement INotifier, otherwise a
+	 *                          \InvalidArgumentException is thrown later
+	 * @param \Closure $info    An array with the keys 'id' and 'name' containing
+	 *                          the app id and the app name
+	 * @deprecated 17.0.0 use registerNotifierService instead.
+	 * @since 8.2.0 - Parameter $info was added in 9.0.0
+	 */
+	public function registerNotifier(\Closure $service, \Closure $info);
+
+	/**
+	 * @param string $notifierService The service must implement INotifier, otherwise a
 	 *                          \InvalidArgumentException is thrown later
 	 * @since 17.0.0
 	 */
-	public function registerNotifier(string $notifierClass): void;
+	public function registerNotifierService(string $notifierService): void;
 
 	/**
 	 * @return INotifier[]

--- a/lib/public/Notification/INotification.php
+++ b/lib/public/Notification/INotification.php
@@ -1,5 +1,5 @@
 <?php
-declare (strict_types = 1);
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -37,13 +37,13 @@ interface INotification {
 	 * @throws \InvalidArgumentException if the app id is invalid
 	 * @since 9.0.0
 	 */
-	public function setApp(string $app);
+	public function setApp(string $app): INotification;
 
 	/**
 	 * @return string
 	 * @since 9.0.0
 	 */
-	public function getApp();
+	public function getApp(): string;
 
 	/**
 	 * @param string $user
@@ -51,13 +51,13 @@ interface INotification {
 	 * @throws \InvalidArgumentException if the user id is invalid
 	 * @since 9.0.0
 	 */
-	public function setUser(string $user);
+	public function setUser(string $user): INotification;
 
 	/**
 	 * @return string
 	 * @since 9.0.0
 	 */
-	public function getUser();
+	public function getUser(): string;
 
 	/**
 	 * @param \DateTime $dateTime
@@ -65,13 +65,13 @@ interface INotification {
 	 * @throws \InvalidArgumentException if the $dateTime is invalid
 	 * @since 9.0.0
 	 */
-	public function setDateTime(\DateTime $dateTime);
+	public function setDateTime(\DateTime $dateTime): INotification;
 
 	/**
 	 * @return \DateTime
 	 * @since 9.0.0
 	 */
-	public function getDateTime();
+	public function getDateTime(): \DateTime;
 
 	/**
 	 * @param string $type
@@ -80,19 +80,19 @@ interface INotification {
 	 * @throws \InvalidArgumentException if the object type or id is invalid
 	 * @since 9.0.0
 	 */
-	public function setObject(string $type, $id);
+	public function setObject(string $type, string $id): INotification;
 
 	/**
 	 * @return string
 	 * @since 9.0.0
 	 */
-	public function getObjectType();
+	public function getObjectType(): string;
 
 	/**
 	 * @return string
 	 * @since 9.0.0
 	 */
-	public function getObjectId();
+	public function getObjectId(): string;
 
 	/**
 	 * @param string $subject
@@ -101,19 +101,19 @@ interface INotification {
 	 * @throws \InvalidArgumentException if the subject or parameters are invalid
 	 * @since 9.0.0
 	 */
-	public function setSubject(string $subject, array $parameters = []);
+	public function setSubject(string $subject, array $parameters = []): INotification;
 
 	/**
 	 * @return string
 	 * @since 9.0.0
 	 */
-	public function getSubject();
+	public function getSubject(): string;
 
 	/**
-	 * @return string[]
+	 * @return array
 	 * @since 9.0.0
 	 */
-	public function getSubjectParameters();
+	public function getSubjectParameters(): array;
 
 	/**
 	 * Set a parsed subject
@@ -132,13 +132,13 @@ interface INotification {
 	 * @throws \InvalidArgumentException if the subject is invalid
 	 * @since 9.0.0
 	 */
-	public function setParsedSubject(string $subject);
+	public function setParsedSubject(string $subject): INotification;
 
 	/**
 	 * @return string
 	 * @since 9.0.0
 	 */
-	public function getParsedSubject();
+	public function getParsedSubject(): string;
 
 	/**
 	 * Set a RichObjectString subject
@@ -157,19 +157,19 @@ interface INotification {
 	 * @throws \InvalidArgumentException if the subject or parameters are invalid
 	 * @since 11.0.0
 	 */
-	public function setRichSubject(string $subject, array $parameters = []);
+	public function setRichSubject(string $subject, array $parameters = []): INotification;
 
 	/**
 	 * @return string
 	 * @since 11.0.0
 	 */
-	public function getRichSubject();
+	public function getRichSubject(): string;
 
 	/**
 	 * @return array[]
 	 * @since 11.0.0
 	 */
-	public function getRichSubjectParameters();
+	public function getRichSubjectParameters(): array;
 
 	/**
 	 * @param string $message
@@ -178,19 +178,19 @@ interface INotification {
 	 * @throws \InvalidArgumentException if the message or parameters are invalid
 	 * @since 9.0.0
 	 */
-	public function setMessage(string $message, array $parameters = []);
+	public function setMessage(string $message, array $parameters = []): INotification;
 
 	/**
 	 * @return string
 	 * @since 9.0.0
 	 */
-	public function getMessage();
+	public function getMessage(): string;
 
 	/**
-	 * @return string[]
+	 * @return array
 	 * @since 9.0.0
 	 */
-	public function getMessageParameters();
+	public function getMessageParameters(): array;
 
 	/**
 	 * Set a parsed message
@@ -209,13 +209,13 @@ interface INotification {
 	 * @throws \InvalidArgumentException if the message is invalid
 	 * @since 9.0.0
 	 */
-	public function setParsedMessage(string $message);
+	public function setParsedMessage(string $message): INotification;
 
 	/**
 	 * @return string
 	 * @since 9.0.0
 	 */
-	public function getParsedMessage();
+	public function getParsedMessage(): string;
 
 	/**
 	 * Set a RichObjectString message
@@ -234,19 +234,19 @@ interface INotification {
 	 * @throws \InvalidArgumentException if the message or parameters are invalid
 	 * @since 11.0.0
 	 */
-	public function setRichMessage(string $message, array $parameters = []);
+	public function setRichMessage(string $message, array $parameters = []): INotification;
 
 	/**
 	 * @return string
 	 * @since 11.0.0
 	 */
-	public function getRichMessage();
+	public function getRichMessage(): string;
 
 	/**
 	 * @return array[]
 	 * @since 11.0.0
 	 */
-	public function getRichMessageParameters();
+	public function getRichMessageParameters(): array;
 
 	/**
 	 * @param string $link
@@ -254,13 +254,13 @@ interface INotification {
 	 * @throws \InvalidArgumentException if the link is invalid
 	 * @since 9.0.0
 	 */
-	public function setLink(string $link);
+	public function setLink(string $link): INotification;
 
 	/**
 	 * @return string
 	 * @since 9.0.0
 	 */
-	public function getLink();
+	public function getLink(): string;
 
 	/**
 	 * @param string $icon
@@ -268,19 +268,19 @@ interface INotification {
 	 * @throws \InvalidArgumentException if the icon is invalid
 	 * @since 11.0.0
 	 */
-	public function setIcon(string $icon);
+	public function setIcon(string $icon): INotification;
 
 	/**
 	 * @return string
 	 * @since 11.0.0
 	 */
-	public function getIcon();
+	public function getIcon(): string;
 
 	/**
 	 * @return IAction
 	 * @since 9.0.0
 	 */
-	public function createAction();
+	public function createAction(): IAction;
 
 	/**
 	 * @param IAction $action
@@ -288,13 +288,13 @@ interface INotification {
 	 * @throws \InvalidArgumentException if the action is invalid
 	 * @since 9.0.0
 	 */
-	public function addAction(IAction $action);
+	public function addAction(IAction $action): INotification;
 
 	/**
 	 * @return IAction[]
 	 * @since 9.0.0
 	 */
-	public function getActions();
+	public function getActions(): array;
 
 	/**
 	 * @param IAction $action
@@ -302,23 +302,23 @@ interface INotification {
 	 * @throws \InvalidArgumentException if the action is invalid
 	 * @since 9.0.0
 	 */
-	public function addParsedAction(IAction $action);
+	public function addParsedAction(IAction $action): INotification;
 
 	/**
 	 * @return IAction[]
 	 * @since 9.0.0
 	 */
-	public function getParsedActions();
+	public function getParsedActions(): array;
 
 	/**
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function isValid();
+	public function isValid(): bool;
 
 	/**
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function isValidParsed();
+	public function isValidParsed(): bool;
 }

--- a/lib/public/Notification/INotifier.php
+++ b/lib/public/Notification/INotifier.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -36,5 +37,5 @@ interface INotifier {
 	 * @throws \InvalidArgumentException When the notification was not prepared by a notifier
 	 * @since 9.0.0
 	 */
-	public function prepare(INotification $notification, $languageCode);
+	public function prepare(INotification $notification, string $languageCode): INotification;
 }

--- a/lib/public/Notification/INotifier.php
+++ b/lib/public/Notification/INotifier.php
@@ -30,11 +30,29 @@ namespace OCP\Notification;
  * @since 9.0.0
  */
 interface INotifier {
+
+	/**
+	 * Identifier of the notifier, only use [a-z0-9_]
+	 *
+	 * @return string
+	 * @since 17.0.0
+	 */
+	public function getID(): string;
+
+	/**
+	 * Human readable name describing the notifier
+	 *
+	 * @return string
+	 * @since 17.0.0
+	 */
+	public function getName(): string;
+
 	/**
 	 * @param INotification $notification
 	 * @param string $languageCode The code of the language that should be used to prepare the notification
 	 * @return INotification
 	 * @throws \InvalidArgumentException When the notification was not prepared by a notifier
+	 * @throws AlreadyProcessedException When the notification is not needed anymore and should be deleted
 	 * @since 9.0.0
 	 */
 	public function prepare(INotification $notification, string $languageCode): INotification;

--- a/tests/lib/Authentication/Listeners/RemoteWipeNotificationsListenerTest.php
+++ b/tests/lib/Authentication/Listeners/RemoteWipeNotificationsListenerTest.php
@@ -92,7 +92,7 @@ class RemoteWipeNotificationListenerTests extends TestCase {
 		$token->method('getId')->willReturn(123);
 		$notification->expects($this->once())
 			->method('setObject')
-			->with('token', 123)
+			->with('token', '123')
 			->willReturnSelf();
 		$token->method('getName')->willReturn('Token 1');
 		$notification->expects($this->once())
@@ -132,7 +132,7 @@ class RemoteWipeNotificationListenerTests extends TestCase {
 		$token->method('getId')->willReturn(123);
 		$notification->expects($this->once())
 			->method('setObject')
-			->with('token', 123)
+			->with('token', '123')
 			->willReturnSelf();
 		$token->method('getName')->willReturn('Token 1');
 		$notification->expects($this->once())

--- a/tests/lib/Notification/ActionTest.php
+++ b/tests/lib/Notification/ActionTest.php
@@ -55,14 +55,8 @@ class ActionTest extends TestCase {
 
 	public function dataSetLabelInvalid() {
 		return [
-			[true],
-			[false],
-			[0],
-			[1],
 			[''],
 			[str_repeat('a', 33)],
-			[[]],
-			[[str_repeat('a', 33)]],
 		];
 	}
 
@@ -96,13 +90,7 @@ class ActionTest extends TestCase {
 
 	public function dataSetParsedLabelInvalid() {
 		return [
-			[true],
-			[false],
-			[0],
-			[1],
 			[''],
-			[[]],
-			[[str_repeat('a', 33)]],
 		];
 	}
 
@@ -140,23 +128,11 @@ class ActionTest extends TestCase {
 	public function dataSetLinkInvalid() {
 		return [
 			// Invalid link
-			[true, 'GET'],
-			[false, 'GET'],
-			[0, 'GET'],
-			[1, 'GET'],
 			['', 'GET'],
 			[str_repeat('a', 257), 'GET'],
-			[[], 'GET'],
-			[[str_repeat('a', 257)], 'GET'],
 
 			// Invalid type
 			['url', 'notGET'],
-			['url', true],
-			['url', false],
-			['url', 0],
-			['url', 1],
-			['url', []],
-			['url', ['GET']],
 		];
 	}
 
@@ -186,27 +162,6 @@ class ActionTest extends TestCase {
 		$this->assertSame(false, $this->action->isPrimary());
 		$this->assertSame($this->action, $this->action->setPrimary($primary));
 		$this->assertSame($primary, $this->action->isPrimary());
-	}
-
-	public function dataSetPrimaryInvalid() {
-		return [
-			[0],
-			[1],
-			[''],
-			[str_repeat('a', 257)],
-			[[]],
-			[[str_repeat('a', 257)]],
-		];
-	}
-
-	/**
-	 * @dataProvider dataSetPrimaryInvalid
-	 * @param mixed $primary
-	 *
-	 * @expectedException \InvalidArgumentException
-	 */
-	public function testSetPrimaryInvalid($primary) {
-		$this->action->setPrimary($primary);
 	}
 
 	public function testIsValid() {

--- a/tests/lib/Notification/DummyApp.php
+++ b/tests/lib/Notification/DummyApp.php
@@ -20,19 +20,37 @@ declare(strict_types=1);
  *
  */
 
-namespace OCP\Notification;
+namespace Test\Notification;
 
 
-/**
- * @since 17.0.0
- */
-class AlreadyProcessedException extends \RuntimeException {
+use OCP\Notification\IApp;
+use OCP\Notification\INotification;
+
+class DummyApp implements IApp {
 
 	/**
-	 * @since 17.0.0
+	 * @param INotification $notification
+	 * @throws \InvalidArgumentException When the notification is not valid
+	 * @since 9.0.0
 	 */
-	public function __construct() {
-		parent::__construct('Notification is processed already');
+	public function notify(INotification $notification): void {
+		// TODO: Implement notify() method.
 	}
 
+	/**
+	 * @param INotification $notification
+	 * @since 9.0.0
+	 */
+	public function markProcessed(INotification $notification): void {
+		// TODO: Implement markProcessed() method.
+	}
+
+	/**
+	 * @param INotification $notification
+	 * @return int
+	 * @since 9.0.0
+	 */
+	public function getCount(INotification $notification): int {
+		// TODO: Implement getCount() method.
+	}
 }

--- a/tests/lib/Notification/DummyNotifier.php
+++ b/tests/lib/Notification/DummyNotifier.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Test\Notification;
+
+
+use OCP\Notification\AlreadyProcessedException;
+use OCP\Notification\INotification;
+use OCP\Notification\INotifier;
+
+class DummyNotifier implements INotifier {
+
+	/**
+	 * Identifier of the notifier, only use [a-z0-9_]
+	 *
+	 * @return string
+	 * @since 17.0.0
+	 */
+	public function getID(): string {
+		// TODO: Implement getID() method.
+	}
+
+	/**
+	 * Human readable name describing the notifier
+	 *
+	 * @return string
+	 * @since 17.0.0
+	 */
+	public function getName(): string {
+		// TODO: Implement getName() method.
+	}
+
+	/**
+	 * @param INotification $notification
+	 * @param string $languageCode The code of the language that should be used to prepare the notification
+	 * @return INotification
+	 * @throws \InvalidArgumentException When the notification was not prepared by a notifier
+	 * @throws AlreadyProcessedException When the notification is not needed anymore and should be deleted
+	 * @since 9.0.0
+	 */
+	public function prepare(INotification $notification, string $languageCode): INotification {
+		// TODO: Implement prepare() method.
+	}
+}

--- a/tests/lib/Notification/ManagerTest.php
+++ b/tests/lib/Notification/ManagerTest.php
@@ -22,162 +22,72 @@
 namespace Test\Notification;
 
 use OC\Notification\Manager;
+use OCP\ILogger;
 use OCP\Notification\IApp;
 use OCP\Notification\IManager;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
 use OCP\RichObjectStrings\IValidator;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ManagerTest extends TestCase {
 	/** @var IManager */
 	protected $manager;
 
+	/** @var IValidator|MockObject */
+	protected $validator;
+	/** @var ILogger|MockObject */
+	protected $logger;
+
 	public function setUp() {
 		parent::setUp();
-		$validator = $this->createMock(IValidator::class);
-		$this->manager = new Manager($validator);
+		$this->validator = $this->createMock(IValidator::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->manager = new Manager($this->validator, $this->logger);
 	}
 
 	public function testRegisterApp() {
-		$app = $this->getMockBuilder(IApp::class)
-			->disableOriginalConstructor()
-			->getMock();
 
-		$closure = function() use ($app) {
-			return $app;
-		};
+		$this->assertEquals([], self::invokePrivate($this->manager, 'getApps'));
 
-		$this->assertEquals([], $this->invokePrivate($this->manager, 'getApps'));
+		$this->manager->registerApp(DummyApp::class);
 
-		$this->manager->registerApp($closure);
+		$this->assertCount(1, self::invokePrivate($this->manager, 'getApps'));
+		$this->assertCount(1, self::invokePrivate($this->manager, 'getApps'));
 
-		$this->assertEquals([$app], $this->invokePrivate($this->manager, 'getApps'));
-		$this->assertEquals([$app], $this->invokePrivate($this->manager, 'getApps'));
+		$this->manager->registerApp(DummyApp::class);
 
-		$this->manager->registerApp($closure);
-
-		$this->assertEquals([$app, $app], $this->invokePrivate($this->manager, 'getApps'));
+		$this->assertCount(2, self::invokePrivate($this->manager, 'getApps'));
 	}
 
-	/**
-	 * @expectedException \InvalidArgumentException
-	 */
 	public function testRegisterAppInvalid() {
-		$notifier = $this->getMockBuilder(INotifier::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$this->manager->registerApp(DummyNotifier::class);
 
-		$closure = function() use ($notifier) {
-			return $notifier;
-		};
-
-		$this->manager->registerApp($closure);
-
-		$this->invokePrivate($this->manager, 'getApps');
+		$this->logger->expects($this->once())
+			->method('error');
+		self::invokePrivate($this->manager, 'getApps');
 	}
 
 	public function testRegisterNotifier() {
-		$notifier = $this->getMockBuilder(INotifier::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$this->assertEquals([], self::invokePrivate($this->manager, 'getNotifiers'));
 
-		$closure = function() use ($notifier) {
-			return $notifier;
-		};
+		$this->manager->registerNotifierService(DummyNotifier::class);
 
-		$this->assertEquals([], $this->invokePrivate($this->manager, 'getNotifiers'));
-		$this->assertEquals([], $this->invokePrivate($this->manager, 'listNotifiers'));
+		$this->assertCount(1, self::invokePrivate($this->manager, 'getNotifiers'));
+		$this->assertCount(1, self::invokePrivate($this->manager, 'getNotifiers'));
 
-		$this->manager->registerNotifier($closure, function() {
-			return ['id' => 'test1', 'name' => 'Test One'];
-		});
+		$this->manager->registerNotifierService(DummyNotifier::class);
 
-		$this->assertEquals([$notifier], $this->invokePrivate($this->manager, 'getNotifiers'));
-		$this->assertEquals(['test1' => 'Test One'], $this->invokePrivate($this->manager, 'listNotifiers'));
-		$this->assertEquals([$notifier], $this->invokePrivate($this->manager, 'getNotifiers'));
-		$this->assertEquals(['test1' => 'Test One'], $this->invokePrivate($this->manager, 'listNotifiers'));
-
-		$this->manager->registerNotifier($closure, function() {
-			return ['id' => 'test2', 'name' => 'Test Two'];
-		});
-
-		$this->assertEquals([$notifier, $notifier], $this->invokePrivate($this->manager, 'getNotifiers'));
-		$this->assertEquals(['test1' => 'Test One', 'test2' => 'Test Two'], $this->invokePrivate($this->manager, 'listNotifiers'));
+		$this->assertCount(2, self::invokePrivate($this->manager, 'getNotifiers'));
 	}
 
-	/**
-	 * @expectedException \InvalidArgumentException
-	 */
 	public function testRegisterNotifierInvalid() {
-		$app = $this->getMockBuilder(IApp::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$this->manager->registerNotifierService(DummyApp::class);
 
-		$closure = function() use ($app) {
-			return $app;
-		};
-
-		$this->manager->registerNotifier($closure, function() {
-			return ['id' => 'test1', 'name' => 'Test One'];
-		});
-
-		$this->invokePrivate($this->manager, 'getNotifiers');
-	}
-
-	public function dataRegisterNotifierInfoInvalid() {
-		return [
-			[null],
-			['No array'],
-			[['id' => 'test1', 'name' => 'Test One', 'size' => 'Invalid']],
-			[['no-id' => 'test1', 'name' => 'Test One']],
-			[['id' => 'test1', 'no-name' => 'Test One']],
-		];
-	}
-
-	/**
-	 * @dataProvider dataRegisterNotifierInfoInvalid
-	 * @expectedException \InvalidArgumentException
-	 * @param mixed $data
-	 */
-	public function testRegisterNotifierInfoInvalid($data) {
-		$app = $this->getMockBuilder(IApp::class)
-			->disableOriginalConstructor()
-			->getMock();
-
-		$closure = function() use ($app) {
-			return $app;
-		};
-
-		$this->manager->registerNotifier($closure, function() use ($data) {
-			return $data;
-		});
-
-		$this->manager->listNotifiers();
-	}
-
-	/**
-	 * @expectedException \InvalidArgumentException
-	 * @expectedExceptionMessage The given notifier ID test1 is already in use
-	 */
-	public function testRegisterNotifierInfoDuplicate() {
-		$app = $this->getMockBuilder(IApp::class)
-			->disableOriginalConstructor()
-			->getMock();
-
-		$closure = function() use ($app) {
-			return $app;
-		};
-
-		$this->manager->registerNotifier($closure, function() {
-			return ['id' => 'test1', 'name' => 'Test One'];
-		});
-
-		$this->manager->registerNotifier($closure, function() {
-			return ['id' => 'test1', 'name' => 'Test One'];
-		});
-
-		$this->manager->listNotifiers();
+		$this->logger->expects($this->once())
+			->method('error');
+		self::invokePrivate($this->manager, 'getNotifiers');
 	}
 
 	public function testCreateNotification() {
@@ -194,30 +104,19 @@ class ManagerTest extends TestCase {
 			->method('isValid')
 			->willReturn(true);
 
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $app */
-		$app = $this->getMockBuilder(IApp::class)
-			->disableOriginalConstructor()
+		$manager = $this->getMockBuilder(Manager::class)
+			->setConstructorArgs([
+				$this->validator,
+				$this->logger,
+			])
+			->setMethods(['getApps'])
 			->getMock();
-		$app->expects($this->once())
-			->method('notify')
-			->with($notification);
 
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $app2 */
-		$app2 = $this->getMockBuilder(IApp::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$app2->expects($this->once())
-			->method('notify')
-			->with($notification);
+		$manager->expects($this->once())
+			->method('getApps')
+			->willReturn([]);
 
-		$this->manager->registerApp(function() use ($app) {
-			return $app;
-		});
-		$this->manager->registerApp(function() use ($app2) {
-			return $app2;
-		});
-
-		$this->manager->notify($notification);
+		$manager->notify($notification);
 	}
 
 	/**
@@ -232,127 +131,18 @@ class ManagerTest extends TestCase {
 			->method('isValid')
 			->willReturn(false);
 
-		$this->manager->notify($notification);
-	}
-
-	public function testPrepare() {
-		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
-		$notification = $this->getMockBuilder(INotification::class)
-			->disableOriginalConstructor()
+		$manager = $this->getMockBuilder(Manager::class)
+			->setConstructorArgs([
+				$this->validator,
+				$this->logger,
+			])
+			->setMethods(['getApps'])
 			->getMock();
-		$notification->expects($this->once())
-			->method('isValidParsed')
-			->willReturn(true);
-		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification2 */
-		$notification2 = $this->getMockBuilder(INotification::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$notification2->expects($this->exactly(2))
-			->method('isValidParsed')
-			->willReturn(true);
 
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $notifier */
-		$notifier = $this->getMockBuilder(INotifier::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$notifier->expects($this->once())
-			->method('prepare')
-			->with($notification, 'en')
-			->willReturnArgument(0);
+		$manager->expects($this->never())
+			->method('getApps');
 
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $notifier2 */
-		$notifier2 = $this->getMockBuilder(INotifier::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$notifier2->expects($this->once())
-			->method('prepare')
-			->with($notification, 'en')
-			->willReturn($notification2);
-
-		$this->manager->registerNotifier(function() use ($notifier) {
-			return $notifier;
-		}, function() {
-			return ['id' => 'test1', 'name' => 'Test One'];
-		});
-		$this->manager->registerNotifier(function() use ($notifier2) {
-			return $notifier2;
-		}, function() {
-			return ['id' => 'test2', 'name' => 'Test Two'];
-		});
-
-		$this->assertEquals($notification2, $this->manager->prepare($notification, 'en'));
-	}
-
-	/**
-	 * @expectedException \InvalidArgumentException
-	 */
-	public function testPrepareInvalid() {
-		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
-		$notification = $this->getMockBuilder(INotification::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$notification->expects($this->once())
-			->method('isValidParsed')
-			->willReturn(false);
-
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $notifier */
-		$notifier = $this->getMockBuilder(INotifier::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$notifier->expects($this->once())
-			->method('prepare')
-			->with($notification, 'de')
-			->willReturnArgument(0);
-
-		$this->manager->registerNotifier(function() use ($notifier) {
-			return $notifier;
-		}, function() {
-			return ['id' => 'test1', 'name' => 'Test One'];
-		});
-
-		$this->manager->prepare($notification, 'de');
-	}
-
-	public function testPrepareNotifierThrows() {
-		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
-		$notification = $this->getMockBuilder(INotification::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$notification->expects($this->once())
-			->method('isValidParsed')
-			->willReturn(true);
-
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $notifier */
-		$notifier = $this->getMockBuilder(INotifier::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$notifier->expects($this->once())
-			->method('prepare')
-			->with($notification, 'de')
-			->willThrowException(new \InvalidArgumentException);
-
-		$this->manager->registerNotifier(function() use ($notifier) {
-			return $notifier;
-		}, function() {
-			return ['id' => 'test1', 'name' => 'Test One'];
-		});
-
-		$this->assertEquals($notification, $this->manager->prepare($notification, 'de'));
-	}
-
-	/**
-	 * @expectedException \InvalidArgumentException
-	 */
-	public function testPrepareNoNotifier() {
-		/** @var \OCP\Notification\INotification|\PHPUnit_Framework_MockObject_MockObject $notification */
-		$notification = $this->getMockBuilder(INotification::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$notification->expects($this->once())
-			->method('isValidParsed')
-			->willReturn(false);
-
-		$this->manager->prepare($notification, 'en');
+		$manager->notify($notification);
 	}
 
 	public function testMarkProcessed() {
@@ -361,30 +151,19 @@ class ManagerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $app */
-		$app = $this->getMockBuilder(IApp::class)
-			->disableOriginalConstructor()
+		$manager = $this->getMockBuilder(Manager::class)
+			->setConstructorArgs([
+				$this->validator,
+				$this->logger,
+			])
+			->setMethods(['getApps'])
 			->getMock();
-		$app->expects($this->once())
-			->method('markProcessed')
-			->with($notification);
 
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $app2 */
-		$app2 = $this->getMockBuilder(IApp::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$app2->expects($this->once())
-			->method('markProcessed')
-			->with($notification);
+		$manager->expects($this->once())
+			->method('getApps')
+			->willReturn([]);
 
-		$this->manager->registerApp(function() use ($app) {
-			return $app;
-		});
-		$this->manager->registerApp(function() use ($app2) {
-			return $app2;
-		});
-
-		$this->manager->markProcessed($notification);
+		$manager->markProcessed($notification);
 	}
 
 	public function testGetCount() {
@@ -393,31 +172,18 @@ class ManagerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $app */
-		$app = $this->getMockBuilder(IApp::class)
-			->disableOriginalConstructor()
+		$manager = $this->getMockBuilder(Manager::class)
+			->setConstructorArgs([
+				$this->validator,
+				$this->logger,
+			])
+			->setMethods(['getApps'])
 			->getMock();
-		$app->expects($this->once())
-			->method('getCount')
-			->with($notification)
-			->willReturn(21);
 
-		/** @var \OCP\Notification\IApp|\PHPUnit_Framework_MockObject_MockObject $app2 */
-		$app2 = $this->getMockBuilder(IApp::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$app2->expects($this->once())
-			->method('getCount')
-			->with($notification)
-			->willReturn(42);
+		$manager->expects($this->once())
+			->method('getApps')
+			->willReturn([]);
 
-		$this->manager->registerApp(function() use ($app) {
-			return $app;
-		});
-		$this->manager->registerApp(function() use ($app2) {
-			return $app2;
-		});
-
-		$this->assertSame(63, $this->manager->getCount($notification));
+		$manager->getCount($notification);
 	}
 }

--- a/tests/lib/Notification/NotificationTest.php
+++ b/tests/lib/Notification/NotificationTest.php
@@ -63,29 +63,6 @@ class NotificationTest extends TestCase {
 		return $dataSets;
 	}
 
-	protected function dataInvalidStringType() {
-		return [
-			[true],
-			[false],
-			[16412],
-			[[]],
-			[null],
-		];
-	}
-
-	protected function dataInvalidInt() {
-		return [
-			[true],
-			[false],
-			[''],
-			['a'],
-			[str_repeat('a', 256)],
-			[[]],
-			[['a']],
-			[[str_repeat('a', 256)]],
-		];
-	}
-
 	public function dataSetApp() {
 		return $this->dataValidString(32);
 	}
@@ -104,10 +81,6 @@ class NotificationTest extends TestCase {
 		return $this->dataInvalidString(32);
 	}
 
-	public function dataSetAppInvalidType() {
-		return $this->dataInvalidStringType();
-	}
-
 	/**
 	 * @dataProvider dataSetAppInvalid
 	 * @param mixed $app
@@ -115,16 +88,6 @@ class NotificationTest extends TestCase {
 	 * @expectedException \InvalidArgumentException
 	 */
 	public function testSetAppInvalid($app) {
-		$this->notification->setApp($app);
-	}
-
-	/**
-	 * @dataProvider dataSetAppInvalidType
-	 * @param mixed $app
-	 *
-	 * @expectedException \TypeError
-	 */
-	public function testSetAppInvalidType($app) {
 		$this->notification->setApp($app);
 	}
 
@@ -147,10 +110,6 @@ class NotificationTest extends TestCase {
 		return $this->dataInvalidString(64);
 	}
 
-	public function dataSetUserInvalidType() {
-		return $this->dataInvalidStringType();
-	}
-
 	/**
 	 * @dataProvider dataSetUserInvalid
 	 * @param mixed $user
@@ -158,16 +117,6 @@ class NotificationTest extends TestCase {
 	 * @expectedException \InvalidArgumentException
 	 */
 	public function testSetUserInvalid($user) {
-		$this->notification->setUser($user);
-	}
-
-	/**
-	 * @dataProvider dataSetUserInvalidType
-	 * @param mixed $user
-	 *
-	 * @expectedException \TypeError
-	 */
-	public function testSetUserInvalidType($user) {
 		$this->notification->setUser($user);
 	}
 
@@ -216,48 +165,32 @@ class NotificationTest extends TestCase {
 
 	public function dataSetObject() {
 		return [
-			['a', '21', '21'],
-			[str_repeat('a', 64), 42, '42'],
+			['a', '21'],
+			[str_repeat('a', 64), '42'],
 		];
 	}
 
 	/**
 	 * @dataProvider dataSetObject
 	 * @param string $type
-	 * @param int|string $id
-	 * @param string $exptectedId
+	 * @param string $id
 	 */
-	public function testSetObject($type, $id, $exptectedId) {
+	public function testSetObject($type, $id) {
 		$this->assertSame('', $this->notification->getObjectType());
 		$this->assertSame('', $this->notification->getObjectId());
 		$this->assertSame($this->notification, $this->notification->setObject($type, $id));
 		$this->assertSame($type, $this->notification->getObjectType());
-		$this->assertSame($exptectedId, $this->notification->getObjectId());
+		$this->assertSame($id, $this->notification->getObjectId());
 	}
 
 	public function dataSetObjectTypeInvalid() {
 		return $this->dataInvalidString(64);
 	}
 
-	/**
-	 * @dataProvider dataSetObjectTypeInvalid
-	 * @param mixed $type
-	 *
-	 * @expectedException \InvalidArgumentException
-	 * @expectedMessage 'The given object type is invalid'
-	 */
-	public function testSetObjectTypeInvalid($type) {
-		$this->notification->setObject($type, 1337);
-	}
-
 	public function dataSetObjectIdInvalid() {
 		return [
-			[true],
-			[false],
 			[''],
 			[str_repeat('a', 64 + 1)],
-			[[]],
-			[[str_repeat('a', 64 + 1)]],
 		];
 	}
 


### PR DESCRIPTION
- [x] New "state of the art" registration method for notifiers and apps, this breaks, yes. But it's intentionally to make the devs aware of all the changes. Also I will provide PRs where possible
- [x] Added return types and parameter type hints
- [x] New action type "WEB" to allow to redirect to a given page. E.g. for calls, because you can not start a call on any page (yet)
- [x] Unify the way how notifications are marked "processed" when they should be deleted, also to allow … v
- [x] Silent push notification when one is deleted.
- [x] Notification app adjustments: https://github.com/nextcloud/notifications/pull/318
- [x] Update all shipped notifiers
- [x] Send PRs to all other notifiers

Fix nextcloud/desktop#8697 