### PR TITLE
16.0.0 RC 1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(16, 0, 0, 5);
+$OC_Version = array(16, 0, 0, 6);
 
 // The human readable string
-$OC_VersionString = '16.0.0 Beta 3';
+$OC_VersionString = '16.0.0 RC 1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Changes since beta3:

* #14958 Adjust drone config to drone 1.0.0
* #14983 Do not try to compile templates that are not there
* #14985 Check if OCA.Files.App is available before calling
* #14989 Harden appdata putcontent
* #15016 Forbid eval on legacy responses
* #15022 Respect the setting if the lookup server is disabled
* [activity#361](https://github.com/nextcloud/activity/pull/361) Fix missing translation for "Home folder"
* [firstrunwizard#176](https://github.com/nextcloud/firstrunwizard/pull/176) Show server url to connect. Not everyone know that this can be copied…
* [firstrunwizard#183](https://github.com/nextcloud/firstrunwizard/pull/183) Fix drone
* [notifications#310](https://github.com/nextcloud/notifications/pull/310) Bump @babel/preset-env from 7.4.1 to 7.4.2
* [recommendations#66](https://github.com/nextcloud/recommendations/pull/66) Ignore compressed javascript


Pending PRs:

* [ ] #14784 Fix language vs. locale
* [x] #14965 Prevent a reinstall
* [x] #14967 Do not issue update command if nothing has changed in user values
* [x] #14972 Disable the injected snapper logic when apps want to ship their own
* [x] #14987 Add acceptance test for public folder navigation
* [x] #14990 Rename collections to projects
* [x] #14994 Enable pre-releases for beta and daily channel
* [x] #15020 Bugfix/noid/fix too many event triggers
* [x] #15027 Run less phan processes
* [x] #15030 Remove a debug log from the 2FA admin settings
* [x] #15035 [nc16] Add a bool check isAvailable() to FullTextSearchManager
* [x] #15049 Do not allow JavaScript "eval" in the public share auth page with Talk
* [x] #15052 Pass old value to user triggerChange hook & do not update unchanged attributes