### PR TITLE
Do not allow JavaScript "eval" in the public share auth page with Talk

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -164,7 +164,6 @@ class ShareController extends AuthPublicShareController {
 			$csp = new ContentSecurityPolicy();
 			$csp->addAllowedConnectDomain('*');
 			$csp->addAllowedMediaDomain('blob:');
-			$csp->allowEvalScript(true);
 			$response->setContentSecurityPolicy($csp);
 		}
 
@@ -185,7 +184,6 @@ class ShareController extends AuthPublicShareController {
 			$csp = new ContentSecurityPolicy();
 			$csp->addAllowedConnectDomain('*');
 			$csp->addAllowedMediaDomain('blob:');
-			$csp->allowEvalScript(true);
 			$response->setContentSecurityPolicy($csp);
 		}
 


### PR DESCRIPTION
[Talk no longer uses JavaScript `eval`](https://github.com/nextcloud/spreed/pull/1706) (well, right now it still does, but it will not once the linked pull request is merged), so the Content Security Policy can now be configured to prevent its use in the public share authentication page when the password is protected by Talk.
