### PR TITLE
Pass old value to user triggerChange hook & do not update unchanged attributes

### DIFF
--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -436,7 +436,7 @@ class User {
 			if (!empty($oldName) && $user instanceof \OC\User\User) {
 				// if it was empty, it would be a new record, not a change emitting the trigger could
 				// potentially cause a UniqueConstraintViolationException, depending on some factors.
-				$user->triggerChange('displayName', $displayName);
+				$user->triggerChange('displayName', $displayName, $oldName);
 			}
 		}
 		return $displayName;

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -158,12 +158,12 @@ class User implements IUser {
 	 */
 	public function setEMailAddress($mailAddress) {
 		$oldMailAddress = $this->getEMailAddress();
-		if($mailAddress === '') {
-			$this->config->deleteUserValue($this->uid, 'settings', 'email');
-		} else {
-			$this->config->setUserValue($this->uid, 'settings', 'email', $mailAddress);
-		}
 		if($oldMailAddress !== $mailAddress) {
+			if($mailAddress === '') {
+				$this->config->deleteUserValue($this->uid, 'settings', 'email');
+			} else {
+				$this->config->setUserValue($this->uid, 'settings', 'email', $mailAddress);
+			}
 			$this->triggerChange('eMailAddress', $mailAddress, $oldMailAddress);
 		}
 	}
@@ -407,8 +407,8 @@ class User implements IUser {
 			$quota = OC_Helper::computerFileSize($quota);
 			$quota = OC_Helper::humanFileSize($quota);
 		}
-		$this->config->setUserValue($this->uid, 'files', 'quota', $quota);
 		if($quota !== $oldQuota) {
+			$this->config->setUserValue($this->uid, 'files', 'quota', $quota);
 			$this->triggerChange('quota', $quota, $oldQuota);
 		}
 	}

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -145,9 +145,8 @@ class User implements IUser {
 				$this->triggerChange('displayName', $displayName);
 			}
 			return $result !== false;
-		} else {
-			return false;
 		}
+		return false;
 	}
 
 	/**
@@ -365,7 +364,8 @@ class User implements IUser {
 		$oldStatus = $this->isEnabled();
 		$this->enabled = $enabled;
 		if ($oldStatus !== $this->enabled) {
-			$this->triggerChange('enabled', $enabled);
+			// TODO: First change the value, then trigger the event as done for all other properties.
+			$this->triggerChange('enabled', $enabled, $oldStatus);
 			$this->config->setUserValue($this->uid, 'core', 'enabled', $enabled ? 'true' : 'false');
 		}
 	}
@@ -409,7 +409,7 @@ class User implements IUser {
 		}
 		$this->config->setUserValue($this->uid, 'files', 'quota', $quota);
 		if($quota !== $oldQuota) {
-			$this->triggerChange('quota', $quota);
+			$this->triggerChange('quota', $quota, $oldQuota);
 		}
 	}
 

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -676,14 +676,8 @@ class UserTest extends TestCase {
 		$config->expects($this->any())
 			->method('getUserValue')
 			->willReturn('foo@bar.com');
-		$config->expects($this->once())
-			->method('setUserValue')
-			->with(
-				'foo',
-				'settings',
-				'email',
-				'foo@bar.com'
-			);
+		$config->expects($this->never())
+			->method('setUserValue');
 
 		$user = new User('foo', $backend, $this->dispatcher, $emitter, $config);
 		$user->setEMailAddress('foo@bar.com');
@@ -741,14 +735,8 @@ class UserTest extends TestCase {
 		$config->expects($this->any())
 			->method('getUserValue')
 			->willReturn('23 TB');
-		$config->expects($this->once())
-			->method('setUserValue')
-			->with(
-				'foo',
-				'files',
-				'quota',
-				'23 TB'
-			);
+		$config->expects($this->never())
+			->method('setUserValue');
 
 		$user = new User('foo', $backend, $this->dispatcher, $emitter, $config);
 		$user->setQuota('23 TB');


### PR DESCRIPTION
Part of #14967 and #14566 that only passes the additional value for the old value of the attribute.

Also includes that some attributes should not be updated if their value hasn't changed.