### PR TITLE
Make sure we have a proper node before parsing

### DIFF
--- a/core/js/files/iedavclient.js
+++ b/core/js/files/iedavclient.js
@@ -82,6 +82,11 @@
 			var parts = name.split(':');
 			var tagName = parts[1];
 			var namespace = resolver(parts[0]);
+			// make sure we can get elements
+			if (typeof node === 'string') {
+				var parser = new DOMParser()
+				node = parser.parseFromString(node, 'text/xml')
+			}
 			if (node.getElementsByTagNameNS) {
 				return node.getElementsByTagNameNS(namespace, tagName);
 			}


### PR DESCRIPTION
Fix viewer compatibility with ie11.
We have a fallback in jquery that do that when doing requests and make sure we return a xml node, but external apps can use other things as jQuery (and they should :stuck_out_tongue_closed_eyes:) But then iedavclient is used for ie11 dav queries and breaking compatibility.

To test: launch ie, open an image in viewer. :framed_picture: 