### PR TITLE
[stable15] Use slient option to switch for regular file actions as well

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -662,7 +662,7 @@
 			this.register('dir', 'Open', OC.PERMISSION_READ, '', function (filename, context) {
 				var dir = context.$file.attr('data-path') || context.fileList.getCurrentDirectory();
 				if (OCA.Files.App && OCA.Files.App.getActiveView() !== 'files') {
-					OCA.Files.App.setActiveView('files');
+					OCA.Files.App.setActiveView('files', {silent: true});
 					OCA.Files.App.fileList.changeDirectory(OC.joinPaths(dir, filename), true, true);
 				} else {
 					context.fileList.changeDirectory(OC.joinPaths(dir, filename), true, false, parseInt(context.$file.attr('data-id'), 10));


### PR DESCRIPTION
Backport of https://github.com/nextcloud/server/pull/15057

When opening folders from the favorites quick access, the default file list is used instead of the `OCA.Files.FavoritesFileList`, therefore we also need to call OCA.Files.App.setActiveView` with the silent option to avoid events being triggered, that may lead to a race condition, where the filelist switches to the root folder after opening.

This is another fix for https://github.com/nextcloud/server/issues/13028 that was not catched by https://github.com/nextcloud/server/pull/14886

Note: Try testing without an open browser console, which seems to trigger the race condition more often. :see_no_evil: 

Steps to reproduce:
- Create folder 1 with subfolder 11
- favorite folder 1
- Unfold the favorites navigation
- Click on Folder 1
![image](https://user-images.githubusercontent.com/3404133/55960350-da49be00-5c6c-11e9-9944-6007498da615.png)
- Click on Folder 11 in the main file list
