### PR TITLE
16.0.0 RC2

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(16, 0, 0, 7);
+$OC_Version = array(16, 0, 0, 8);
 
 // The human readable string
-$OC_VersionString = '16.0.0 RC 1';
+$OC_VersionString = '16.0.0 RC 2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #15101 Pass proper TEST_SELECTION to drone objectstore
* #15108 Use slient option to switch for regular file actions as well
* #15109 Add animation-slow var
* #15111 Make sure we have a proper node before parsing
* #15118 Do not use spaces in generated passwords
* #15127 Improve the share link password error feedback with a red border
* #15138 Backport/15129/stable16
* [activity#364](https://github.com/nextcloud/activity/pull/364) Update stable16 target versions
* [files_pdfviewer#127](https://github.com/nextcloud/files_pdfviewer/pull/127) Update stable16 target versions
* [files_texteditor#147](https://github.com/nextcloud/files_texteditor/pull/147) Update stable16 target versions
* [firstrunwizard#185](https://github.com/nextcloud/firstrunwizard/pull/185) Update stable16 target versions
* [gallery#509](https://github.com/nextcloud/gallery/pull/509) Update stable16 target versions
* [gallery#510](https://github.com/nextcloud/gallery/pull/510) Typo fix
* [gallery#511](https://github.com/nextcloud/gallery/pull/511) Update master php testing versions
* [nextcloud_announcements#39](https://github.com/nextcloud/nextcloud_announcements/pull/39) Update stable16 target versions
* [notifications#320](https://github.com/nextcloud/notifications/pull/320) Update stable16 target versions
* [password_policy#81](https://github.com/nextcloud/password_policy/pull/81) Update stable16 target versions
* [privacy#96](https://github.com/nextcloud/privacy/pull/96) Update stable16 target versions
* [recommendations#68](https://github.com/nextcloud/recommendations/pull/68) Update stable16 target versions
* [serverinfo#148](https://github.com/nextcloud/serverinfo/pull/148) Update stable16 target versions
* [survey_client#91](https://github.com/nextcloud/survey_client/pull/91) Update stable16 target versions


Pending PRs:

* [ ] #14784 Fix language vs. locale