### PR TITLE
fix searching all users in repair regenerate birthday cal reparir job 

### DIFF
--- a/apps/dav/lib/CardDAV/SyncService.php
+++ b/apps/dav/lib/CardDAV/SyncService.php
@@ -319,7 +319,7 @@ class SyncService {
 
 	public function syncInstance(\Closure $progressCallback = null) {
 		$systemAddressBook = $this->getLocalSystemAddressBook();
-		$this->userManager->callForAllUsers(function($user) use ($systemAddressBook, $progressCallback) {
+		$this->userManager->callForSeenUsers(function($user) use ($systemAddressBook, $progressCallback) {
 			$this->updateUser($user);
 			if (!is_null($progressCallback)) {
 				$progressCallback();

--- a/apps/dav/lib/Command/SyncBirthdayCalendar.php
+++ b/apps/dav/lib/Command/SyncBirthdayCalendar.php
@@ -92,7 +92,7 @@ class SyncBirthdayCalendar extends Command {
 		$output->writeln("Start birthday calendar sync for all users ...");
 		$p = new ProgressBar($output);
 		$p->start();
-		$this->userManager->callForAllUsers(function($user) use ($p)  {
+		$this->userManager->callForSeenUsers(function($user) use ($p)  {
 			$p->advance();
 
 			$userId = $user->getUID();

--- a/apps/dav/lib/Controller/BirthdayCalendarController.php
+++ b/apps/dav/lib/Controller/BirthdayCalendarController.php
@@ -93,7 +93,7 @@ class BirthdayCalendarController extends Controller {
 		$this->config->setAppValue($this->appName, 'generateBirthdayCalendar', 'yes');
 
 		// add background job for each user
-		$this->userManager->callForAllUsers(function(IUser $user) {
+		$this->userManager->callForSeenUsers(function(IUser $user) {
 			$this->jobList->add(GenerateBirthdayCalendarBackgroundJob::class, [
 				'userId' => $user->getUID(),
 			]);

--- a/apps/dav/lib/Migration/RegenerateBirthdayCalendars.php
+++ b/apps/dav/lib/Migration/RegenerateBirthdayCalendars.php
@@ -72,7 +72,7 @@ class RegenerateBirthdayCalendars implements IRepairStep {
 		}
 
 		$output->info('Adding background jobs to regenerate birthday calendar');
-		$this->userManager->callForAllUsers(function(IUser $user) {
+		$this->userManager->callForSeenUsers(function(IUser $user) {
 			$this->jobList->add(GenerateBirthdayCalendarBackgroundJob::class, [
 				'userId' => $user->getUID(),
 				'purgeBeforeGenerating' => true

--- a/apps/dav/tests/unit/Controller/BirthdayCalendarControllerTest.php
+++ b/apps/dav/tests/unit/Controller/BirthdayCalendarControllerTest.php
@@ -78,7 +78,7 @@ class BirthdayCalendarControllerTest extends TestCase {
 			->with('dav', 'generateBirthdayCalendar', 'yes');
 
 		$this->userManager->expects($this->once())
-			->method('callForAllUsers')
+			->method('callForSeenUsers')
 			->will($this->returnCallback(function($closure) {
 				$user1 = $this->createMock(IUser::class);
 				$user1->method('getUID')->will($this->returnValue('uid1'));

--- a/apps/dav/tests/unit/Migration/RegenerateBirthdayCalendarsTest.php
+++ b/apps/dav/tests/unit/Migration/RegenerateBirthdayCalendarsTest.php
@@ -76,7 +76,7 @@ class RegenerateBirthdayCalendarsTest extends TestCase {
 			->with('Adding background jobs to regenerate birthday calendar');
 
 		$this->userManager->expects($this->once())
-			->method('callForAllUsers')
+			->method('callForSeenUsers')
 			->will($this->returnCallback(function($closure) {
 				$user1 = $this->createMock(IUser::class);
 				$user1->method('getUID')->will($this->returnValue('uid1'));
@@ -128,7 +128,7 @@ class RegenerateBirthdayCalendarsTest extends TestCase {
 			->with('Repair step already executed');
 
 		$this->userManager->expects($this->never())
-			->method('callForAllUsers');
+			->method('callForSeenUsers');
 
 		$this->migration->run($output);
 	}

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -59,7 +59,6 @@ namespace OC\User;
 
 use OC\Cache\CappedMemoryCache;
 use OCP\IDBConnection;
-use OCP\ILogger;
 use OCP\User\Backend\ABackend;
 use OCP\User\Backend\ICheckPasswordBackend;
 use OCP\User\Backend\ICountUsersBackend;
@@ -68,7 +67,6 @@ use OCP\User\Backend\IGetDisplayNameBackend;
 use OCP\User\Backend\IGetHomeBackend;
 use OCP\User\Backend\ISetDisplayNameBackend;
 use OCP\User\Backend\ISetPasswordBackend;
-use OCP\Util;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
 


### PR DESCRIPTION
The problem: my dev system on upgrade is working on that for almost an hour now…

* this avoids searches across all users on all backends
* most, if not all, are known anyhow
* for those that aren't there is no reason to act upon
* with only known users it will be tremendeously faster… but it would still be best if this could be done in a background job instead and not blocking upgrade