### PR TITLE
Fix lookup server connector background jobs problem

### DIFF
--- a/apps/lookup_server_connector/appinfo/app.php
+++ b/apps/lookup_server_connector/appinfo/app.php
@@ -19,13 +19,5 @@
  *
  */
 
-$dispatcher = \OC::$server->getEventDispatcher();
-
-$dispatcher->addListener('OC\AccountManager::userUpdated', function(\Symfony\Component\EventDispatcher\GenericEvent $event) {
-	/** @var \OCP\IUser $user */
-	$user = $event->getSubject();
-
-	/** @var \OCA\LookupServerConnector\UpdateLookupServer $updateLookupServer */
-	$updateLookupServer = \OC::$server->query(\OCA\LookupServerConnector\UpdateLookupServer::class);
-	$updateLookupServer->userUpdated($user);
-});
+$app = new \OCA\LookupServerConnector\AppInfo\Application();
+$app->register();

--- a/apps/lookup_server_connector/composer/composer/autoload_classmap.php
+++ b/apps/lookup_server_connector/composer/composer/autoload_classmap.php
@@ -6,6 +6,7 @@ $vendorDir = dirname(dirname(__FILE__));
 $baseDir = $vendorDir;
 
 return array(
+    'OCA\\LookupServerConnector\\AppInfo\\Application' => $baseDir . '/../lib/AppInfo/Application.php',
     'OCA\\LookupServerConnector\\BackgroundJobs\\RetryJob' => $baseDir . '/../lib/BackgroundJobs/RetryJob.php',
     'OCA\\LookupServerConnector\\UpdateLookupServer' => $baseDir . '/../lib/UpdateLookupServer.php',
 );

--- a/apps/lookup_server_connector/composer/composer/autoload_static.php
+++ b/apps/lookup_server_connector/composer/composer/autoload_static.php
@@ -21,6 +21,7 @@ class ComposerStaticInitLookupServerConnector
     );
 
     public static $classMap = array (
+        'OCA\\LookupServerConnector\\AppInfo\\Application' => __DIR__ . '/..' . '/../lib/AppInfo/Application.php',
         'OCA\\LookupServerConnector\\BackgroundJobs\\RetryJob' => __DIR__ . '/..' . '/../lib/BackgroundJobs/RetryJob.php',
         'OCA\\LookupServerConnector\\UpdateLookupServer' => __DIR__ . '/..' . '/../lib/UpdateLookupServer.php',
     );

--- a/apps/lookup_server_connector/lib/AppInfo/Application.php
+++ b/apps/lookup_server_connector/lib/AppInfo/Application.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\LookupServerConnector\AppInfo;
+
+use OCA\LookupServerConnector\UpdateLookupServer;
+use OCP\AppFramework\App;
+use OCP\IUser;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class Application extends App {
+	public function __construct () {
+		parent::__construct('lookup_server_connector');
+	}
+
+	/**
+	 * Register the different app parts
+	 */
+	public function register(): void {
+		$this->registerHooksAndEvents();
+	}
+
+	/**
+	 * Register the hooks and events
+	 */
+	public function registerHooksAndEvents(): void {
+		$dispatcher = $this->getContainer()->getServer()->getEventDispatcher();
+		$dispatcher->addListener('OC\AccountManager::userUpdated', static function(GenericEvent $event) {
+			/** @var IUser $user */
+			$user = $event->getSubject();
+
+			/** @var UpdateLookupServer $updateLookupServer */
+			$updateLookupServer = \OC::$server->query(UpdateLookupServer::class);
+			$updateLookupServer->userUpdated($user);
+		});
+
+	}
+}

--- a/apps/lookup_server_connector/lib/BackgroundJobs/RetryJob.php
+++ b/apps/lookup_server_connector/lib/BackgroundJobs/RetryJob.php
@@ -85,13 +85,23 @@ class RetryJob extends Job {
 		$client = $this->clientService->newClient();
 
 		try {
-			$client->post($this->lookupServer,
-				[
-					'body' => json_encode($argument['dataArray']),
-					'timeout' => 10,
-					'connect_timeout' => 3,
-				]
-			);
+			if (count($argument['dataArray']) === 1) {
+				$client->delete($this->lookupServer,
+					[
+						'body' => json_encode($argument['dataArray']),
+						'timeout' => 10,
+						'connect_timeout' => 3,
+					]
+				);
+			} else {
+				$client->post($this->lookupServer,
+					[
+						'body' => json_encode($argument['dataArray']),
+						'timeout' => 10,
+						'connect_timeout' => 3,
+					]
+				);
+			}
 		} catch (\Exception $e) {
 			$this->jobList->add(RetryJob::class,
 				[

--- a/apps/lookup_server_connector/lib/BackgroundJobs/RetryJob.php
+++ b/apps/lookup_server_connector/lib/BackgroundJobs/RetryJob.php
@@ -1,6 +1,8 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016 Bjoern Schiessle <bjoern@schiessle.org>
+ * @copyright Copyright (c) 2019 Joas Schilling <coding@schilljs.com>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -22,43 +24,55 @@
 namespace OCA\LookupServerConnector\BackgroundJobs;
 
 
+use OC\Security\IdentityProof\Signer;
+use OCP\Accounts\IAccountManager;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\Job;
 use OCP\BackgroundJob\IJobList;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\ILogger;
+use OCP\IUser;
+use OCP\IUserManager;
 
 class RetryJob extends Job {
 	/** @var IClientService */
 	private $clientService;
-	/** @var IJobList */
-	private $jobList;
 	/** @var string */
 	private $lookupServer;
-	/** @var int how much time should be between two, will be increased for each retry */
-	private $interval = 100;
 	/** @var IConfig */
 	private $config;
+	/** @var IUserManager */
+	private $userManager;
+	/** @var IAccountManager */
+	private $accountManager;
+	/** @var Signer */
+	private $signer;
+	/** @var int */
+	protected $retries = 0;
+	/** @var bool */
+	protected $retainJob = false;
 
 	/**
 	 * @param ITimeFactory $time
 	 * @param IClientService $clientService
-	 * @param IJobList $jobList
 	 * @param IConfig $config
+	 * @param IUserManager $userManager
+	 * @param IAccountManager $accountManager
+	 * @param Signer $signer
 	 */
 	public function __construct(ITimeFactory $time,
 								IClientService $clientService,
-								IJobList $jobList,
-								IConfig $config) {
+								IConfig $config,
+								IUserManager $userManager,
+								IAccountManager $accountManager,
+								Signer $signer) {
 		parent::__construct($time);
 		$this->clientService = $clientService;
-		$this->jobList = $jobList;
 		$this->config = $config;
-
-		if ($config->getSystemValue('has_internet_connection', true) === false) {
-			return;
-		}
+		$this->userManager = $userManager;
+		$this->accountManager = $accountManager;
+		$this->signer = $signer;
 
 		$this->lookupServer = $config->getSystemValue('lookup_server', 'https://lookup.nextcloud.com');
 		if (!empty($this->lookupServer)) {
@@ -74,24 +88,66 @@ class RetryJob extends Job {
 	 * @param ILogger|null $logger
 	 */
 	public function execute($jobList, ILogger $logger = null): void {
-		if ($this->shouldRun($this->argument)) {
-			parent::execute($jobList, $logger);
+		if (!isset($this->argument['userId'])) {
+			// Old background job without user id, just drop it.
 			$jobList->remove($this, $this->argument);
-		}
-	}
-
-	protected function run($argument): void {
-		if ($this->killBackgroundJob((int)$argument['retryNo'])) {
 			return;
 		}
 
+		$this->retries = (int) $this->config->getUserValue($this->argument['userId'], 'lookup_server_connector', 'update_retries', 0);
+
+		if ($this->shouldRemoveBackgroundJob()) {
+			$jobList->remove($this, $this->argument);
+			return;
+		}
+
+		if ($this->shouldRun()) {
+			parent::execute($jobList, $logger);
+			if (!$this->retainJob) {
+				$jobList->remove($this, $this->argument);
+			}
+		}
+	}
+
+	/**
+	 * Check if we should kill the background job:
+	 *
+	 * - internet connection is disabled
+	 * - no valid lookup server URL given
+	 * - lookup server was disabled by the admin
+	 * - max retries are reached (set to 5)
+	 *
+	 * @return bool
+	 */
+	protected function shouldRemoveBackgroundJob(): bool {
+		return $this->config->getSystemValueBool('has_internet_connection', true) === false ||
+			$this->config->getSystemValueString('lookup_server', 'https://lookup.nextcloud.com') === '' ||
+			$this->config->getAppValue('files_sharing', 'lookupServerUploadEnabled', 'yes') !== 'yes' ||
+			$this->retries >= 5;
+	}
+
+	protected function shouldRun(): bool {
+		$delay = 100 * 6 ** $this->retries;
+		return ($this->time->getTime() - $this->lastRun) > $delay;
+	}
+
+	protected function run($argument): void {
+		$user = $this->userManager->get($this->argument['userId']);
+		if (!$user instanceof IUser) {
+			// User does not exist anymore
+			return;
+		}
+
+		$data = $this->getUserAccountData($user);
+		$signedData = $this->signer->sign('lookupserver', $data, $user);
 		$client = $this->clientService->newClient();
 
 		try {
-			if (count($argument['dataArray']) === 1) {
+			if (count($data) === 1) {
+				// No public data, just the federation Id
 				$client->delete($this->lookupServer,
 					[
-						'body' => json_encode($argument['dataArray']),
+						'body' => json_encode($signedData),
 						'timeout' => 10,
 						'connect_timeout' => 3,
 					]
@@ -99,52 +155,58 @@ class RetryJob extends Job {
 			} else {
 				$client->post($this->lookupServer,
 					[
-						'body' => json_encode($argument['dataArray']),
+						'body' => json_encode($signedData),
 						'timeout' => 10,
 						'connect_timeout' => 3,
 					]
 				);
 			}
-		} catch (\Exception $e) {
-			$this->jobList->add(self::class,
-				[
-					'dataArray' => $argument['dataArray'],
-					'retryNo' => $argument['retryNo'] + 1,
-					'lastRun' => $this->time->getTime(),
-				]
+
+			// Reset retry counter
+			$this->config->deleteUserValue(
+				$user->getUID(),
+				'lookup_server_connector',
+				'update_retries'
 			);
 
+		} catch (\Exception $e) {
+			// An error occurred, retry later
+			$this->retainJob = true;
+			$this->config->setUserValue(
+				$user->getUID(),
+				'lookup_server_connector',
+				'update_retries',
+				$this->retries + 1
+			);
 		}
 	}
 
-	/**
-	 * test if it is time for the next run
-	 *
-	 * @param array $argument
-	 * @return bool
-	 */
-	protected function shouldRun(array $argument): bool {
-		$retryNo = (int)$argument['retryNo'];
-		$delay = $this->interval * 6 ** $retryNo;
-		return !isset($argument['lastRun']) || (($this->time->getTime() - $argument['lastRun']) > $delay);
-	}
+	protected function getUserAccountData(IUser $user): array {
+		$account = $this->accountManager->getAccount($user);
 
-	/**
-	 * check if we should kill the background job
-	 *
-	 * The lookup server should no longer be contacted if:
-	 *
-	 * - max retries are reached (set to 5)
-	 * - lookup server was disabled by the admin
-	 * - no valid lookup server URL given
-	 *
-	 * @param int $retryCount
-	 * @return bool
-	 */
-	protected function killBackgroundJob(int $retryCount): bool {
-		$maxTriesReached = $retryCount >= 5;
-		$lookupServerDisabled = $this->config->getAppValue('files_sharing', 'lookupServerUploadEnabled', 'yes') !== 'yes';
+		$publicData = [];
+		foreach ($account->getProperties() as $property) {
+			if ($property->getScope() === IAccountManager::VISIBILITY_PUBLIC) {
+				$publicData[$property->getName()] = $property->getValue();
+			}
+		}
 
-		return $maxTriesReached || $lookupServerDisabled || empty($this->lookupServer);
+		$data = ['federationId' => $user->getCloudId()];
+		if (!empty($publicData)) {
+			$data['name'] = $publicData[IAccountManager::PROPERTY_DISPLAYNAME]['value'] ?? '';
+			$data['email'] = $publicData[IAccountManager::PROPERTY_EMAIL]['value'] ?? '';
+			$data['address'] = $publicData[IAccountManager::PROPERTY_ADDRESS]['value'] ?? '';
+			$data['website'] = $publicData[IAccountManager::PROPERTY_WEBSITE]['value'] ?? '';
+			$data['twitter'] = $publicData[IAccountManager::PROPERTY_TWITTER]['value'] ?? '';
+			$data['phone'] = $publicData[IAccountManager::PROPERTY_PHONE]['value'] ?? '';
+			$data['twitter_signature'] = $publicData[IAccountManager::PROPERTY_TWITTER]['signature'] ?? '';
+			$data['website_signature'] = $publicData[IAccountManager::PROPERTY_WEBSITE]['signature'] ?? '';
+			$data['verificationStatus'] = [
+				IAccountManager::PROPERTY_WEBSITE => $publicData[IAccountManager::PROPERTY_WEBSITE]['verified'] ?? '',
+				IAccountManager::PROPERTY_TWITTER => $publicData[IAccountManager::PROPERTY_TWITTER]['verified'] ?? '',
+			];
+		}
+
+		return $data;
 	}
 }

--- a/apps/lookup_server_connector/lib/UpdateLookupServer.php
+++ b/apps/lookup_server_connector/lib/UpdateLookupServer.php
@@ -106,19 +106,18 @@ class UpdateLookupServer {
 		$dataArray = ['federationId' => $user->getCloudId()];
 
 		if (!empty($publicData)) {
-			$dataArray['name'] = isset($publicData[AccountManager::PROPERTY_DISPLAYNAME]) ? $publicData[AccountManager::PROPERTY_DISPLAYNAME]['value'] : '';
-			$dataArray['email'] = isset($publicData[AccountManager::PROPERTY_EMAIL]) ? $publicData[AccountManager::PROPERTY_EMAIL]['value'] : '';
-			$dataArray['address'] = isset($publicData[AccountManager::PROPERTY_ADDRESS]) ? $publicData[AccountManager::PROPERTY_ADDRESS]['value'] : '';
-			$dataArray['website'] = isset($publicData[AccountManager::PROPERTY_WEBSITE]) ? $publicData[AccountManager::PROPERTY_WEBSITE]['value'] : '';
-			$dataArray['twitter'] = isset($publicData[AccountManager::PROPERTY_TWITTER]) ? $publicData[AccountManager::PROPERTY_TWITTER]['value'] : '';
-			$dataArray['phone'] = isset($publicData[AccountManager::PROPERTY_PHONE]) ? $publicData[AccountManager::PROPERTY_PHONE]['value'] : '';
-			$dataArray['twitter_signature'] = isset($publicData[AccountManager::PROPERTY_TWITTER]['signature']) ? $publicData[AccountManager::PROPERTY_TWITTER]['signature'] : '';
-			$dataArray['website_signature'] = isset($publicData[AccountManager::PROPERTY_WEBSITE]['signature']) ? $publicData[AccountManager::PROPERTY_WEBSITE]['signature'] : '';
-			$dataArray['verificationStatus'] =
-				[
-					AccountManager::PROPERTY_WEBSITE => isset($publicData[AccountManager::PROPERTY_WEBSITE]) ? $publicData[AccountManager::PROPERTY_WEBSITE]['verified'] : '',
-					AccountManager::PROPERTY_TWITTER => isset($publicData[AccountManager::PROPERTY_TWITTER]) ? $publicData[AccountManager::PROPERTY_TWITTER]['verified'] : '',
-				];
+			$dataArray['name'] = $publicData[AccountManager::PROPERTY_DISPLAYNAME]['value'] ?? '';
+			$dataArray['email'] = $publicData[AccountManager::PROPERTY_EMAIL]['value'] ?? '';
+			$dataArray['address'] = $publicData[AccountManager::PROPERTY_ADDRESS]['value'] ?? '';
+			$dataArray['website'] = $publicData[AccountManager::PROPERTY_WEBSITE]['value'] ?? '';
+			$dataArray['twitter'] = $publicData[AccountManager::PROPERTY_TWITTER]['value'] ?? '';
+			$dataArray['phone'] = $publicData[AccountManager::PROPERTY_PHONE]['value'] ?? '';
+			$dataArray['twitter_signature'] = $publicData[AccountManager::PROPERTY_TWITTER]['signature'] ?? '';
+			$dataArray['website_signature'] = $publicData[AccountManager::PROPERTY_WEBSITE]['signature'] ?? '';
+			$dataArray['verificationStatus'] = [
+				AccountManager::PROPERTY_WEBSITE => $publicData[AccountManager::PROPERTY_WEBSITE]['verified'] ?? '',
+				AccountManager::PROPERTY_TWITTER => $publicData[AccountManager::PROPERTY_TWITTER]['verified'] ?? '',
+			];
 		}
 
 		$dataArray = $this->signer->sign('lookupserver', $dataArray, $user);


### PR DESCRIPTION
Some 50 user instances have 400k pending jobs for lookup updates
The first problem is that the job was scheduled too often with #15020 
The second one is that each time any value changed, a new job was scheduled (because at least the retry count and the last execution was different).
So you ended up with 6 jobs per change on user data.

As LDAP seems to set the user name/email some more times, it basically added the 6 jobs on each login?

So now the app got a little update and in the end can only have 1 background job per user.
Existing update requests are killed when  the userId is not set in the arguments, so the table should clean up on the next few cron runs after the update.