### PR TITLE
Prefetching blows up if there are a lot of files.

### DIFF
--- a/apps/dav/lib/Connector/Sabre/CustomPropertiesBackend.php
+++ b/apps/dav/lib/Connector/Sabre/CustomPropertiesBackend.php
@@ -129,13 +129,6 @@ class CustomPropertiesBackend implements BackendInterface {
 			return;
 		}
 
-		if ($node instanceof Directory
-			&& $propFind->getDepth() !== 0
-		) {
-			// note: pre-fetching only supported for depth <= 1
-			$this->loadChildrenProperties($node, $requestedProps);
-		}
-
 		$props = $this->getProperties($node, $requestedProps);
 		foreach ($props as $propName => $propValue) {
 			$propFind->set($propName, $propValue);

--- a/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
@@ -226,10 +226,6 @@ class CustomPropertiesBackendTest extends \Test\TestCase {
 			->method('getPath')
 			->will($this->returnValue('/dummypath/test.txt'));
 
-		$rootNode->expects($this->once())
-			->method('getChildren')
-			->will($this->returnValue(array($nodeSub)));
-
 		$this->tree->expects($this->at(0))
 			->method('getNodeForPath')
 			->with('/dummypath')


### PR DESCRIPTION
I saw instances where people had a lot of files (each with custom
properties) and all this prefetching blew up and started to consume an
insane amount of RAM resulting in the process getting killed.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>