### PR TITLE
Respect sharing enumeration config in contacts menu

### DIFF
--- a/lib/private/Contacts/ContactsMenu/Manager.php
+++ b/lib/private/Contacts/ContactsMenu/Manager.php
@@ -26,6 +26,7 @@ namespace OC\Contacts\ContactsMenu;
 
 use OCP\App\IAppManager;
 use OCP\Contacts\ContactsMenu\IEntry;
+use OCP\IConfig;
 use OCP\IUser;
 
 class Manager {
@@ -39,15 +40,19 @@ class Manager {
 	/** @var IAppManager */
 	private $appManager;
 
+	/** @var IConfig */
+	private $config;
+
 	/**
 	 * @param ContactsStore $store
 	 * @param ActionProviderStore $actionProviderStore
 	 * @param IAppManager $appManager
 	 */
-	public function __construct(ContactsStore $store, ActionProviderStore $actionProviderStore, IAppManager $appManager) {
+	public function __construct(ContactsStore $store, ActionProviderStore $actionProviderStore, IAppManager $appManager, IConfig $config) {
 		$this->store = $store;
 		$this->actionProviderStore = $actionProviderStore;
 		$this->appManager = $appManager;
+		$this->config = $config;
 	}
 
 	/**
@@ -56,11 +61,16 @@ class Manager {
 	 * @return array
 	 */
 	public function getEntries(IUser $user, $filter) {
-		$entries = $this->store->getContacts($user, $filter);
+		$maxAutocompleteResults = $this->config->getSystemValueInt('sharing.maxAutocompleteResults', 25);
+		$minSearchStringLength = $this->config->getSystemValueInt('sharing.minSearchStringLength', 0);
+		$topEntries = [];
+		if (strlen($filter) >= $minSearchStringLength) {
+			$entries = $this->store->getContacts($user, $filter);
 
-		$sortedEntries = $this->sortEntries($entries);
-		$topEntries = array_slice($sortedEntries, 0, 25);
-		$this->processEntries($topEntries, $user);
+			$sortedEntries = $this->sortEntries($entries);
+			$topEntries = array_slice($sortedEntries, 0, $maxAutocompleteResults);
+			$this->processEntries($topEntries, $user);
+		}
 
 		$contactsEnabled = $this->appManager->isEnabledForUser('contacts', $user);
 		return [

--- a/tests/lib/Contacts/ContactsMenu/ManagerTest.php
+++ b/tests/lib/Contacts/ContactsMenu/ManagerTest.php
@@ -30,6 +30,7 @@ use OC\Contacts\ContactsMenu\Manager;
 use OCP\App\IAppManager;
 use OCP\Contacts\ContactsMenu\IEntry;
 use OCP\Contacts\ContactsMenu\IProvider;
+use OCP\IConfig;
 use OCP\IUser;
 use PHPUnit_Framework_MockObject_MockObject;
 use Test\TestCase;
@@ -41,6 +42,9 @@ class ManagerTest extends TestCase {
 
 	/** @var IAppManager|PHPUnit_Framework_MockObject_MockObject */
 	private $appManager;
+
+	/** @var IConfig|PHPUnit_Framework_MockObject_MockObject */
+	private $config;
 
 	/** @var ActionProviderStore|PHPUnit_Framework_MockObject_MockObject */
 	private $actionProviderStore;
@@ -54,8 +58,9 @@ class ManagerTest extends TestCase {
 		$this->contactsStore = $this->createMock(ContactsStore::class);
 		$this->actionProviderStore = $this->createMock(ActionProviderStore::class);
 		$this->appManager = $this->createMock(IAppManager::class);
+		$this->config = $this->createMock(IConfig::class);
 
-		$this->manager = new Manager($this->contactsStore, $this->actionProviderStore, $this->appManager);
+		$this->manager = new Manager($this->contactsStore, $this->actionProviderStore, $this->appManager, $this->config);
 	}
 
 	private function generateTestEntries() {
@@ -75,6 +80,15 @@ class ManagerTest extends TestCase {
 		$user = $this->createMock(IUser::class);
 		$entries = $this->generateTestEntries();
 		$provider = $this->createMock(IProvider::class);
+
+		$this->config->expects($this->at(0))
+			->method('getSystemValueInt')
+			->with('sharing.maxAutocompleteResults', 25)
+			->willReturn(25);
+		$this->config->expects($this->at(1))
+			->method('getSystemValueInt')
+			->with('sharing.minSearchStringLength', 0)
+			->willReturn(0);
 		$this->contactsStore->expects($this->once())
 			->method('getContacts')
 			->with($user, $filter)
@@ -91,6 +105,71 @@ class ManagerTest extends TestCase {
 			->willReturn(false);
 		$expected = [
 			'contacts' => array_slice($entries, 0, 25),
+			'contactsAppEnabled' => false,
+		];
+
+		$data = $this->manager->getEntries($user, $filter);
+
+		$this->assertEquals($expected, $data);
+	}
+
+	public function testGetFilteredEntriesLimit() {
+		$filter = 'con';
+		$user = $this->createMock(IUser::class);
+		$entries = $this->generateTestEntries();
+		$provider = $this->createMock(IProvider::class);
+
+		$this->config->expects($this->at(0))
+			->method('getSystemValueInt')
+			->with('sharing.maxAutocompleteResults', 25)
+			->willReturn(3);
+		$this->config->expects($this->at(1))
+			->method('getSystemValueInt')
+			->with('sharing.minSearchStringLength', 0)
+			->willReturn(0);
+		$this->contactsStore->expects($this->once())
+			->method('getContacts')
+			->with($user, $filter)
+			->willReturn($entries);
+		$this->actionProviderStore->expects($this->once())
+			->method('getProviders')
+			->with($user)
+			->willReturn([$provider]);
+		$provider->expects($this->exactly(3))
+			->method('process');
+		$this->appManager->expects($this->once())
+			->method('isEnabledForUser')
+			->with($this->equalTo('contacts'), $user)
+			->willReturn(false);
+		$expected = [
+			'contacts' => array_slice($entries, 0, 3),
+			'contactsAppEnabled' => false,
+		];
+
+		$data = $this->manager->getEntries($user, $filter);
+
+		$this->assertEquals($expected, $data);
+	}
+
+	public function testGetFilteredEntriesMinSearchStringLength() {
+		$filter = 'con';
+		$user = $this->createMock(IUser::class);
+		$provider = $this->createMock(IProvider::class);
+
+		$this->config->expects($this->at(0))
+			->method('getSystemValueInt')
+			->with('sharing.maxAutocompleteResults', 25)
+			->willReturn(3);
+		$this->config->expects($this->at(1))
+			->method('getSystemValueInt')
+			->with('sharing.minSearchStringLength', 0)
+			->willReturn(4);
+		$this->appManager->expects($this->once())
+			->method('isEnabledForUser')
+			->with($this->equalTo('contacts'), $user)
+			->willReturn(false);
+		$expected = [
+			'contacts' => [],
 			'contactsAppEnabled' => false,
 		];
 


### PR DESCRIPTION
This makes sure we respect the `sharing.maxAutocompleteResults` and `sharing.minSearchStringLength` config.php parameters when searching for users in the contacts menu.