### PR TITLE
Fix multiselect bar overlapping recommendations

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -263,6 +263,7 @@ table th.column-last, table td.column-last {
 
 /* Multiselect bar */
 table.multiselect thead {
+	position: -webkit-sticky; // Safari support
 	position: sticky;
 	top: 94px;
 	z-index: 55;

--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -262,11 +262,8 @@ table th.column-last, table td.column-last {
 }
 
 /* Multiselect bar */
-#filestable.multiselect {
-	top: 51px;
-}
 table.multiselect thead {
-	position: fixed;
+	position: sticky;
 	top: 94px;
 	z-index: 55;
 	-moz-box-sizing: border-box;
@@ -275,7 +272,7 @@ table.multiselect thead {
 }
 
 table.multiselect thead th {
-	background-color: var(--color-main-background);
+	background-color: var(--color-main-background-translucent);
 	font-weight: bold;
 	border-bottom: 0;
 }
@@ -783,7 +780,7 @@ table.dragshadow td.size {
 		tr {
 			display: block;
 			border-bottom: 1px solid var(--color-border);
-			background-color: var(--color-main-background);
+			background-color: var(--color-main-background-translucent);
 			th {
 				width: auto;
 				border: none;

--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -263,8 +263,7 @@ table th.column-last, table td.column-last {
 
 /* Multiselect bar */
 table.multiselect thead {
-	position: -webkit-sticky; // Safari support
-	position: sticky;
+	@include position('sticky');
 	top: 94px;
 	z-index: 55;
 	-moz-box-sizing: border-box;


### PR DESCRIPTION
Fix https://github.com/nextcloud/recommendations/issues/29 please review @MorrisJobke @ChristophWurst @nextcloud/designers 

Before:
![multiselect before](https://user-images.githubusercontent.com/925062/56373356-0af79d80-6201-11e9-8916-68d740f28476.png)

After:
![multiselect bar after](https://user-images.githubusercontent.com/925062/56373353-0af79d80-6201-11e9-920c-c9c903b0d007.png)

And even sticky when scrolling:
![multiselect bar sticky](https://user-images.githubusercontent.com/925062/56373352-0af79d80-6201-11e9-9674-b4f5f03f1ddb.png)