### PR TITLE
Always use a temp file for swift writes

### DIFF
--- a/lib/private/Files/ObjectStore/Swift.php
+++ b/lib/private/Files/ObjectStore/Swift.php
@@ -76,14 +76,9 @@ class Swift implements IObjectStore {
 	 * @throws \Exception from openstack lib when something goes wrong
 	 */
 	public function writeObject($urn, $stream) {
-		$handle = $stream;
-
-		$meta = stream_get_meta_data($stream);
-		if (!(isset($meta['seekable']) && $meta['seekable'] === true)) {
-			$tmpFile = \OC::$server->getTempManager()->getTemporaryFile('swiftwrite');
-			file_put_contents($tmpFile, $stream);
-			$handle = fopen($tmpFile, 'rb');
-		}
+		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile('swiftwrite');
+		file_put_contents($tmpFile, $stream);
+		$handle = fopen($tmpFile, 'rb');
 
 		$this->getContainer()->createObject([
 			'name' => $urn,


### PR DESCRIPTION
Fixes #13554 (again)

Apparently the if statement doesn't work in all cases (even if I could
not reproduce it). So for the time being we will just not directly
stream to swift.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>