### PR TITLE
Fix setupcheck for intl module

### DIFF
--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -574,7 +574,7 @@ Raw output
 	protected function hasRecommendedPHPModules(): array {
 		$recommendedPHPModules = [];
 
-		if (!function_exists('grapheme_strlen')) {
+		if (!extension_loaded('intl')) {
 			$recommendedPHPModules[] = 'intl';
 		}
 


### PR DESCRIPTION
A polyfill for intl is loaded very early (somewhere in base). Polyfill defines grapheme_strlen as function if
intl extension is not loaded. The check here is always true
because there is a function with that name.

https://github.com/nextcloud/server/blob/49829482c898212c1bb4e7461cad7983541cd528/lib/base.php#L630

https://github.com/nextcloud/3rdparty/blob/9e49623fa57786c0874529e66c2ebd0ff2dc5075/patchwork/utf8/src/Patchwork/Utf8/Bootup/intl.php#L26 (here is the function defined)
