### PR TITLE
fixed bug: type error on large zip download, argument 2 passed to OC\…

### DIFF
--- a/lib/private/Streamer.php
+++ b/lib/private/Streamer.php
@@ -43,7 +43,7 @@ class Streamer {
 	 * @param int $numberOfFiles The number of files (and directories) that will
 	 *        be included in the streamed file
 	 */
-	public function __construct(IRequest $request, int $size, int $numberOfFiles){
+	public function __construct(IRequest $request, float $size, int $numberOfFiles){
 
 		/**
 		 * zip32 constraints for a basic (without compression, volumes nor


### PR DESCRIPTION
I fixed a smaller bug which raised a type error exception. It had been caused when downloading a large folder using the Streamer. The exception was: "Argument 2 passed to OC\\Streamer::__construct() must be of the type integer, float given"