### PR TITLE
14.0.11 RC 1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(14, 0, 10, 1);
+$OC_Version = array(14, 0, 11, 0);
 
 // The human readable string
-$OC_VersionString = '14.0.10';
+$OC_VersionString = '14.0.11 RC 1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #15007 Reconnect to DB after timeout for Notify command. Fixes #14479
* #15070 3rdparty] Bump sabre to 3.2.3
* #15072 Do not allow invalid users to be created
* #15120 Do not use spaces in generated passwords
* #15140 Backport/15129/stable14
* #15159 Load apps before running repair steps
* #15207 Prefetching blows up if there are a lot of files.
* #15329 [Security] Bump tar from 4.4.1 to 4.4.8 in /apps/updatenotification
* #15330 [Security] Bump tar from 4.4.1 to 4.4.8 in /apps/accessibility
* #15331 [Security] Bump tar from 4.4.1 to 4.4.8 in /apps/oauth2
* #15335 [Security] Bump tar from 4.4.1 to 4.4.8 in /settings
* #15343 Check if the data is in the lookup server
* #15347 Do NOT assume all files are selected if the first checkbox is
* #15391 Fix collapse button in app navigation in IE11
* #15423 Set Edge < 16 as incompatible with css vars
* #15444 Remove setup args from logging
* #15449 Run phan tests only on high memory machines
* #15467 Revert "Run phan tests only on high memory machines"
* #15473 Remove recommendation for opcache on CLI
* #15484 Update file-upload.js
* [3rdparty#266](https://github.com/nextcloud/3rdparty/pull/266) Bump sabre/dav to 3.2.3
* [files_texteditor#152](https://github.com/nextcloud/files_texteditor/pull/152) Use correct CSS URL, remove default marked settings and change to GFM rendering