### PR TITLE
Make access column a real boolean

### DIFF
--- a/core/Migrations/Version16000Date20190427105638.php
+++ b/core/Migrations/Version16000Date20190427105638.php
@@ -65,9 +65,8 @@ class Version16000Date20190427105638 extends SimpleMigrationStep {
 		if ($schema->hasTable('collres_accesscache')) {
 			$table = $schema->getTable('collres_accesscache');
 
-			$table->dropColumn('access');
-
-			$table->addColumn('access', Type::BOOLEAN, [
+			$table->changeColumn('access', [
+				'type' => Type::BOOLEAN,
 				'notnull' => true,
 				'default' => false,
 			]);

--- a/core/Migrations/Version16000Date20190427105638.php
+++ b/core/Migrations/Version16000Date20190427105638.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Core\Migrations;
+
+use Closure;
+use Doctrine\DBAL\Types\Type;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+
+class Version16000Date20190427105638 extends SimpleMigrationStep {
+
+	/** @var IDBConnection */
+	private $connection;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+		$this->connection
+			->getQueryBuilder()
+			->delete('collres_accesscache')
+			->execute();
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 * @throws \Doctrine\DBAL\Schema\SchemaException
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('collres_accesscache')) {
+			$table = $schema->getTable('collres_accesscache');
+
+			$table->dropColumn('access');
+
+			$table->addColumn('access', Type::BOOLEAN, [
+				'notnull' => true,
+				'default' => false,
+			]);
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+	}
+}

--- a/core/Migrations/Version16000Date20190427105638.php
+++ b/core/Migrations/Version16000Date20190427105638.php
@@ -69,12 +69,4 @@ class Version16000Date20190427105638 extends SimpleMigrationStep {
 
 		return $schema;
 	}
-
-	/**
-	 * @param IOutput $output
-	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
-	 * @param array $options
-	 */
-	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
-	}
 }

--- a/core/Migrations/Version16000Date20190427105638.php
+++ b/core/Migrations/Version16000Date20190427105638.php
@@ -57,6 +57,7 @@ class Version16000Date20190427105638 extends SimpleMigrationStep {
 	 * @param array $options
 	 * @return null|ISchemaWrapper
 	 * @throws \Doctrine\DBAL\Schema\SchemaException
+	 * @throws \Doctrine\DBAL\DBALException
 	 */
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
 		/** @var ISchemaWrapper $schema */
@@ -66,7 +67,7 @@ class Version16000Date20190427105638 extends SimpleMigrationStep {
 			$table = $schema->getTable('collres_accesscache');
 
 			$table->changeColumn('access', [
-				'type' => Type::BOOLEAN,
+				'type' => Type::getType(Type::BOOLEAN),
 				'notnull' => true,
 				'default' => false,
 			]);

--- a/core/Migrations/Version16000Date20190428150708.php
+++ b/core/Migrations/Version16000Date20190428150708.php
@@ -23,20 +23,15 @@ declare(strict_types=1);
 namespace OC\Core\Migrations;
 
 use Closure;
+use Doctrine\DBAL\Types\Type;
 use OCP\DB\ISchemaWrapper;
-use OCP\IDBConnection;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
-
-class Version16000Date20190427105638 extends SimpleMigrationStep {
-
-	/** @var IDBConnection */
-	private $connection;
-
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
-	}
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version16000Date20190428150708 extends SimpleMigrationStep {
 
 	/**
 	 * @param IOutput $output
@@ -44,10 +39,6 @@ class Version16000Date20190427105638 extends SimpleMigrationStep {
 	 * @param array $options
 	 */
 	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
-		$this->connection
-			->getQueryBuilder()
-			->delete('collres_accesscache')
-			->execute();
 	}
 
 	/**
@@ -56,7 +47,6 @@ class Version16000Date20190427105638 extends SimpleMigrationStep {
 	 * @param array $options
 	 * @return null|ISchemaWrapper
 	 * @throws \Doctrine\DBAL\Schema\SchemaException
-	 * @throws \Doctrine\DBAL\DBALException
 	 */
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
 		/** @var ISchemaWrapper $schema */
@@ -64,7 +54,10 @@ class Version16000Date20190427105638 extends SimpleMigrationStep {
 
 		if ($schema->hasTable('collres_accesscache')) {
 			$table = $schema->getTable('collres_accesscache');
-			$table->dropColumn('access');
+			$table->addColumn('access', Type::BOOLEAN, [
+				'notnull' => true,
+				'default' => false
+			]);
 		}
 
 		return $schema;

--- a/core/Migrations/Version16000Date20190428150708.php
+++ b/core/Migrations/Version16000Date20190428150708.php
@@ -28,18 +28,7 @@ use OCP\DB\ISchemaWrapper;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
-/**
- * Auto-generated migration step: Please modify to your needs!
- */
 class Version16000Date20190428150708 extends SimpleMigrationStep {
-
-	/**
-	 * @param IOutput $output
-	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
-	 * @param array $options
-	 */
-	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
-	}
 
 	/**
 	 * @param IOutput $output
@@ -61,13 +50,5 @@ class Version16000Date20190428150708 extends SimpleMigrationStep {
 		}
 
 		return $schema;
-	}
-
-	/**
-	 * @param IOutput $output
-	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
-	 * @param array $options
-	 */
-	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
 	}
 }

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -712,6 +712,7 @@ return array(
     'OC\\Core\\Migrations\\Version16000Date20190207141427' => $baseDir . '/core/Migrations/Version16000Date20190207141427.php',
     'OC\\Core\\Migrations\\Version16000Date20190212081545' => $baseDir . '/core/Migrations/Version16000Date20190212081545.php',
     'OC\\Core\\Migrations\\Version16000Date20190427105638' => $baseDir . '/core/Migrations/Version16000Date20190427105638.php',
+    'OC\\Core\\Migrations\\Version16000Date20190428150708' => $baseDir . '/core/Migrations/Version16000Date20190428150708.php',
     'OC\\Core\\Notification\\RemoveLinkSharesNotifier' => $baseDir . '/core/Notification/RemoveLinkSharesNotifier.php',
     'OC\\Core\\Service\\LoginFlowV2Service' => $baseDir . '/core/Service/LoginFlowV2Service.php',
     'OC\\DB\\Adapter' => $baseDir . '/lib/private/DB/Adapter.php',

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -711,6 +711,7 @@ return array(
     'OC\\Core\\Migrations\\Version15000Date20181029084625' => $baseDir . '/core/Migrations/Version15000Date20181029084625.php',
     'OC\\Core\\Migrations\\Version16000Date20190207141427' => $baseDir . '/core/Migrations/Version16000Date20190207141427.php',
     'OC\\Core\\Migrations\\Version16000Date20190212081545' => $baseDir . '/core/Migrations/Version16000Date20190212081545.php',
+    'OC\\Core\\Migrations\\Version16000Date20190427105638' => $baseDir . '/core/Migrations/Version16000Date20190427105638.php',
     'OC\\Core\\Notification\\RemoveLinkSharesNotifier' => $baseDir . '/core/Notification/RemoveLinkSharesNotifier.php',
     'OC\\Core\\Service\\LoginFlowV2Service' => $baseDir . '/core/Service/LoginFlowV2Service.php',
     'OC\\DB\\Adapter' => $baseDir . '/lib/private/DB/Adapter.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -741,6 +741,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Core\\Migrations\\Version15000Date20181029084625' => __DIR__ . '/../../..' . '/core/Migrations/Version15000Date20181029084625.php',
         'OC\\Core\\Migrations\\Version16000Date20190207141427' => __DIR__ . '/../../..' . '/core/Migrations/Version16000Date20190207141427.php',
         'OC\\Core\\Migrations\\Version16000Date20190212081545' => __DIR__ . '/../../..' . '/core/Migrations/Version16000Date20190212081545.php',
+        'OC\\Core\\Migrations\\Version16000Date20190427105638' => __DIR__ . '/../../..' . '/core/Migrations/Version16000Date20190427105638.php',
         'OC\\Core\\Notification\\RemoveLinkSharesNotifier' => __DIR__ . '/../../..' . '/core/Notification/RemoveLinkSharesNotifier.php',
         'OC\\Core\\Service\\LoginFlowV2Service' => __DIR__ . '/../../..' . '/core/Service/LoginFlowV2Service.php',
         'OC\\DB\\Adapter' => __DIR__ . '/../../..' . '/lib/private/DB/Adapter.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -742,6 +742,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Core\\Migrations\\Version16000Date20190207141427' => __DIR__ . '/../../..' . '/core/Migrations/Version16000Date20190207141427.php',
         'OC\\Core\\Migrations\\Version16000Date20190212081545' => __DIR__ . '/../../..' . '/core/Migrations/Version16000Date20190212081545.php',
         'OC\\Core\\Migrations\\Version16000Date20190427105638' => __DIR__ . '/../../..' . '/core/Migrations/Version16000Date20190427105638.php',
+        'OC\\Core\\Migrations\\Version16000Date20190428150708' => __DIR__ . '/../../..' . '/core/Migrations/Version16000Date20190428150708.php',
         'OC\\Core\\Notification\\RemoveLinkSharesNotifier' => __DIR__ . '/../../..' . '/core/Notification/RemoveLinkSharesNotifier.php',
         'OC\\Core\\Service\\LoginFlowV2Service' => __DIR__ . '/../../..' . '/core/Service/LoginFlowV2Service.php',
         'OC\\DB\\Adapter' => __DIR__ . '/../../..' . '/lib/private/DB/Adapter.php',

--- a/lib/private/Collaboration/Resources/Manager.php
+++ b/lib/private/Collaboration/Resources/Manager.php
@@ -431,7 +431,7 @@ class Manager implements IManager {
 			->values([
 				'user_id' => $query->createNamedParameter($userId),
 				'collection_id' => $query->createNamedParameter($collection->getId()),
-				'access' => $query->createNamedParameter($access),
+				'access' => $query->createNamedParameter($access, IQueryBuilder::PARAM_BOOL),
 			]);
 		try {
 			$query->execute();


### PR DESCRIPTION
Close #15256 

`Type::SMALLINT` should be `Type::BOOLEAN`.

MySQL uses a tinyint(1) to store a boolean value where PostgresSql has a dedicated type boolean for booleans. If we create a column with type smallint and try to save a boolean postgresql :boom: 

https://github.com/doctrine/dbal/blob/e4978c2299d4d8e4f39da94f4d567e698e9bdbeb/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php#L944
https://github.com/doctrine/dbal/blob/e4978c2299d4d8e4f39da94f4d567e698e9bdbeb/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php#L299

Tested these changes only on mysql (smallint to tinyint there). Tried multiple ways to do it with one migration but doctrine is smart enough to merge dropColumn and addColumn to changeColumn which fails on pqsql because for a integer to boolean conversion we need additional instructions for pqsql which is not supported by doctrine yet (e.g. https://drone.nextcloud.com/nextcloud/server/18043/21/5)
