### PR TITLE
take return of mkdir into consideration; photocache to not create a folder for deletion

### DIFF
--- a/apps/dav/lib/CardDAV/PhotoCache.php
+++ b/apps/dav/lib/CardDAV/PhotoCache.php
@@ -167,16 +167,19 @@ class PhotoCache {
 	}
 
 	/**
-	 * @param int $addressBookId
-	 * @param string $cardUri
-	 * @return ISimpleFolder
+	 * @throws NotFoundException
+	 * @throws NotPermittedException
 	 */
-	private function getFolder($addressBookId, $cardUri) {
+	private function getFolder(int $addressBookId, string $cardUri, bool $createIfNotExists = true): ISimpleFolder {
 		$hash = md5($addressBookId . ' ' . $cardUri);
 		try {
 			return $this->appData->getFolder($hash);
 		} catch (NotFoundException $e) {
-			return $this->appData->newFolder($hash);
+			if($createIfNotExists) {
+				return $this->appData->newFolder($hash);
+			} else {
+				throw $e;
+			}
 		}
 	}
 
@@ -271,9 +274,14 @@ class PhotoCache {
 	/**
 	 * @param int $addressBookId
 	 * @param string $cardUri
+	 * @throws NotPermittedException
 	 */
 	public function delete($addressBookId, $cardUri) {
-		$folder = $this->getFolder($addressBookId, $cardUri);
-		$folder->delete();
+		try {
+			$folder = $this->getFolder($addressBookId, $cardUri, false);
+			$folder->delete();
+		} catch (NotFoundException $e) {
+			// that's OK, nothing to do
+		}
 	}
 }

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -158,7 +158,9 @@ class Folder extends Node implements \OCP\Files\Folder {
 			$nonExisting = new NonExistingFolder($this->root, $this->view, $fullPath);
 			$this->root->emit('\OC\Files', 'preWrite', array($nonExisting));
 			$this->root->emit('\OC\Files', 'preCreate', array($nonExisting));
-			$this->view->mkdir($fullPath);
+			if(!$this->view->mkdir($fullPath)) {
+				throw new NotPermittedException('Could not create folder');
+			}
 			$node = new Folder($this->root, $this->view, $fullPath);
 			$this->root->emit('\OC\Files', 'postWrite', array($node));
 			$this->root->emit('\OC\Files', 'postCreate', array($node));


### PR DESCRIPTION
Resolves #8635 

I am not deep into the Node/filessystem things… i  hope the additional exception does not kill stuff. What is still unknown is why the folder could not have been created in the first place, because `mkdir` on the local storage was silenced previously. **update** and still is as it causes tests to fail :-/ **/update**