### PR TITLE
Setting ZipStreaner zip64 = true

### DIFF
--- a/lib/private/Streamer.php
+++ b/lib/private/Streamer.php
@@ -68,7 +68,7 @@ class Streamer {
 		 * larger than 4GiB), but it should not happen in the real world.
 		 */
 		if ($size < 4 * 1000 * 1000 * 1000 && $numberOfFiles < 65536) {
-			$this->streamerInstance = new ZipStreamer(['zip64' => false]);
+			$this->streamerInstance = new ZipStreamer(['zip64' => true]);
 		} else if ($request->isUserAgent($this->preferTarFor)) {
 			$this->streamerInstance = new TarStreamer();
 		} else {


### PR DESCRIPTION
Downloaded zip files larger than 4GB are corrupted.  In my case setting  "new ZipStreamer(['zip64' => true])" fixed the issue and I believe that this should be the default now since the zip64 issues on older nextcloud versions have been fixed.