### PR TITLE
Fix collapse button in app navigation in IE11

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -358,6 +358,10 @@ kbd {
 			height: 44px;
 			margin: 0;
 			z-index: 110;
+
+			/* Needed for IE11; otherwise the button appears to the right of the
+			 * link. */
+			left: 0;
 		}
 		&:before {
 			position: absolute;


### PR DESCRIPTION
Follow up to #10230

Fixes #11840 (note that the JavaScript error mentioned in the bug is not related even if it seems so ;-) ).

This has been broken since Nextcloud 14, but... how far back this deserves to be backported?

## How to test ##
-Open the Files app in Internet Explorer 11
-Create a new folder
-Add that folder to favorites
-Click twice on the button to the left of _Favorites_ in the app navigation
-Click twice on the button to the left of _Shares_ in the app navigation

### Result with this pull request ###
The favorites and shares sections in the app navigation are expanded and collapsed.

### Result without this pull request ###
The favorites and shares sections in the app navigation are not modified (but they are loaded in the file list).
