### PR TITLE
Make sure all middlewares are only registered once

### DIFF
--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -299,6 +299,9 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 	 * @return boolean|null
 	 */
 	public function registerMiddleWare($middleWare) {
+		if (in_array($middleWare, $this->middleWares, true) !== false) {
+			return false;
+		}
 		$this->middleWares[] = $middleWare;
 	}
 


### PR DESCRIPTION
Not sure where this origins from, but it broke federated shares for me.

1. Do a federated share
2. Gather the token form the database
3. Get Share info: 

With patch:
```json
{
  "data": {
    "id": 165,
    "parentId": 2,
    "mtime": 1557132779,
    "name": "wat",
    "permissions": 31,
    "mimetype": "httpd\/unix-directory",
    "size": 0,
    "type": "dir",
    "etag": "5ccff5eb2c45d",
    "children": [
      
    ]
  },
  "status": "success"
}
```
Without:
```json
{
  "data": {
    "data": {
      "id": 165,
      "parentId": 2,
      "mtime": 1557132779,
      "name": "wat",
      "permissions": 31,
      "mimetype": "httpd\/unix-directory",
      "size": 0,
      "type": "dir",
      "etag": "5ccff5eb2c45d",
      "children": [
        
      ]
    },
    "status": "success"
  },
  "status": "success"
}
```

The double nesting causes broken SQL queries when tryiung to store the cache information for `status` and `data`....