### PR TITLE
Remove extra margin from warning messages in authenticate page

### DIFF
--- a/core/css/publicshareauth.css
+++ b/core/css/publicshareauth.css
@@ -26,3 +26,8 @@ input[type='submit'].icon-confirm {
 	height: 45px;
 	background-color: transparent !important;
 }
+
+.warning > .warning {
+	/* Do not use a top margin for warning messages in the warning container. */
+	margin-top: 0;
+}


### PR DESCRIPTION
In the public share authentication page the form elements appear inside [a container that uses the `warning` CSS class](https://github.com/nextcloud/server/blob/96108ab8588aa63a242df4a435d26e4ea3aecfdf/core/templates/publicshareauth.php#L9). When the given password is wrong [a warning message is shown inside that container](https://github.com/nextcloud/server/blob/96108ab8588aa63a242df4a435d26e4ea3aecfdf/core/templates/publicshareauth.php#L14); this message uses the `warning` CSS class too, so [the top margin set for `.warning` elements](https://github.com/nextcloud/server/blob/4965f8c7235a11667b79e4f8a3c6210110ee7d03/core/css/guest.css#L594) need to be removed in that case.

The extra margin is there even in Nextcloud 14, but as it is just a style fix I think that backporting just to Nextcloud 16 is enough (but feel free to call backportbot if you disagree ;-) ).

**Before:**
![PublicShareAuth-Warning-Message-Before](https://user-images.githubusercontent.com/26858233/57289177-2c8acd00-70bb-11e9-96b4-659efca56e22.png)

**After:**
![PublicShareAuth-Warning-Message-After](https://user-images.githubusercontent.com/26858233/57289183-2e549080-70bb-11e9-8015-75cd1571b732.png)
