### PR TITLE
remove extra param in cache update call

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -232,7 +232,7 @@ class Cache implements ICache {
 	 */
 	public function put($file, array $data) {
 		if (($id = $this->getId($file)) > -1) {
-			$this->update($id, $data, $file);
+			$this->update($id, $data);
 			return $id;
 		} else {
 			return $this->insert($file, $data);


### PR DESCRIPTION
param was leftover from earlier iterations of the "update event"

Signed-off-by: Robin Appelman <robin@icewind.nl>