### PR TITLE
Run phan tests only on high memory machines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -133,6 +133,9 @@ trigger:
     - pull_request
     - push
 
+node:
+  memory: high
+
 ---
 kind: pipeline
 name: litmus


### PR DESCRIPTION
This should fix the out of memory issues we are seeing with this job.

Currently only one of our servers has this, but it should be enough for this test here.

Let's see if it is scheduled correctly.