### PR TITLE
add "askForPassword" on capabilities for sharing

### DIFF
--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -62,6 +62,12 @@ class Capabilities implements ICapability {
 				$public['password'] = [];
 				$public['password']['enforced'] = ($this->config->getAppValue('core', 'shareapi_enforce_links_password', 'no') === 'yes');
 
+				if ($public['password']['enforced']) {
+					$public['password']['askForOptionalPassword'] = false;
+				} else {
+					$public['password']['askForOptionalPassword'] = ($this->config->getAppValue('core', 'shareapi_enable_link_password_by_default', 'no') === 'yes');
+				}
+
 				$public['expire_date'] = [];
 				$public['multiple_links'] = true;
 				$public['expire_date']['enabled'] = $this->config->getAppValue('core', 'shareapi_default_expire_date', 'no') === 'yes';


### PR DESCRIPTION
Needed for https://github.com/nextcloud/server/issues/15459

This exposes "askForPassword" capability on file_sharing:
If password is enforced, askForPassword will be false.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>