### PR TITLE
Revert "Run phan tests only on high memory machines"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -133,9 +133,6 @@ trigger:
     - pull_request
     - push
 
-node:
-  memory: high
-
 ---
 kind: pipeline
 name: litmus


### PR DESCRIPTION
Reverts nextcloud/server#15446

It was not the solution for the problem - we should go for more generic workers that have enough memory, because otherwise we have workers that ONLY execute those tasks.

https://readme.drone.io/reference/agent/drone-runner-labels/

cc @tobiasKaminsky 