### PR TITLE
Allow crash reporters to catpture any message

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -389,6 +389,7 @@ return array(
     'OCP\\Share_Backend_Collection' => $baseDir . '/lib/public/Share_Backend_Collection.php',
     'OCP\\Share_Backend_File_Dependent' => $baseDir . '/lib/public/Share_Backend_File_Dependent.php',
     'OCP\\Support\\CrashReport\\ICollectBreadcrumbs' => $baseDir . '/lib/public/Support/CrashReport/ICollectBreadcrumbs.php',
+    'OCP\\Support\\CrashReport\\IMessageReporter' => $baseDir . '/lib/public/Support/CrashReport/IMessageReporter.php',
     'OCP\\Support\\CrashReport\\IRegistry' => $baseDir . '/lib/public/Support/CrashReport/IRegistry.php',
     'OCP\\Support\\CrashReport\\IReporter' => $baseDir . '/lib/public/Support/CrashReport/IReporter.php',
     'OCP\\SystemTag\\ISystemTag' => $baseDir . '/lib/public/SystemTag/ISystemTag.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -419,6 +419,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Share_Backend_Collection' => __DIR__ . '/../../..' . '/lib/public/Share_Backend_Collection.php',
         'OCP\\Share_Backend_File_Dependent' => __DIR__ . '/../../..' . '/lib/public/Share_Backend_File_Dependent.php',
         'OCP\\Support\\CrashReport\\ICollectBreadcrumbs' => __DIR__ . '/../../..' . '/lib/public/Support/CrashReport/ICollectBreadcrumbs.php',
+        'OCP\\Support\\CrashReport\\IMessageReporter' => __DIR__ . '/../../..' . '/lib/public/Support/CrashReport/IMessageReporter.php',
         'OCP\\Support\\CrashReport\\IRegistry' => __DIR__ . '/../../..' . '/lib/public/Support/CrashReport/IRegistry.php',
         'OCP\\Support\\CrashReport\\IReporter' => __DIR__ . '/../../..' . '/lib/public/Support/CrashReport/IReporter.php',
         'OCP\\SystemTag\\ISystemTag' => __DIR__ . '/../../..' . '/lib/public/SystemTag/ISystemTag.php',

--- a/lib/private/Support/CrashReport/Registry.php
+++ b/lib/private/Support/CrashReport/Registry.php
@@ -24,6 +24,7 @@ namespace OC\Support\CrashReport;
 
 use Exception;
 use OCP\Support\CrashReport\ICollectBreadcrumbs;
+use OCP\Support\CrashReport\IMessageReporter;
 use OCP\Support\CrashReport\IRegistry;
 use OCP\Support\CrashReport\IReporter;
 use Throwable;
@@ -38,7 +39,7 @@ class Registry implements IRegistry {
 	 *
 	 * @param IReporter $reporter
 	 */
-	public function register(IReporter $reporter) {
+	public function register(IReporter $reporter): void {
 		$this->reporters[] = $reporter;
 	}
 
@@ -51,7 +52,7 @@ class Registry implements IRegistry {
 	 *
 	 * @since 15.0.0
 	 */
-	public function delegateBreadcrumb(string $message, string $category, array $context = []) {
+	public function delegateBreadcrumb(string $message, string $category, array $context = []): void {
 		foreach ($this->reporters as $reporter) {
 			if ($reporter instanceof ICollectBreadcrumbs) {
 				$reporter->collect($message, $category, $context);
@@ -65,10 +66,26 @@ class Registry implements IRegistry {
 	 * @param Exception|Throwable $exception
 	 * @param array $context
 	 */
-	public function delegateReport($exception, array $context = []) {
+	public function delegateReport($exception, array $context = []): void {
 		/** @var IReporter $reporter */
 		foreach ($this->reporters as $reporter) {
 			$reporter->report($exception, $context);
+		}
+	}
+
+	/**
+	 * Delegate a message to all reporters that implement IMessageReporter
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 */
+	public function delegateMessage(string $message, array $context = []): void {
+		foreach ($this->reporters as $reporter) {
+			if ($reporter instanceof IMessageReporter) {
+				$reporter->reportMessage($message, $context);
+			}
 		}
 	}
 

--- a/lib/public/Support/CrashReport/IMessageReporter.php
+++ b/lib/public/Support/CrashReport/IMessageReporter.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCP\Support\CrashReport;
+
+/**
+ * @since 17.0.0
+ */
+interface IMessageReporter extends IReporter {
+
+	/**
+	 * Report a (error) message
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @since 17.0.0
+	 */
+	public function reportMessage(string $message, array $context = []): void;
+
+}

--- a/lib/public/Support/CrashReport/IRegistry.php
+++ b/lib/public/Support/CrashReport/IRegistry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  *
@@ -33,10 +35,11 @@ interface IRegistry {
 	/**
 	 * Register a reporter instance
 	 *
-	 * @since 13.0.0
 	 * @param IReporter $reporter
+	 *
+	 * @since 13.0.0
 	 */
-	public function register(IReporter $reporter);
+	public function register(IReporter $reporter): void;
 
 	/**
 	 * Delegate breadcrumb collection to all registered reporters
@@ -47,14 +50,27 @@ interface IRegistry {
 	 *
 	 * @since 15.0.0
 	 */
-	public function delegateBreadcrumb(string $message, string $category, array $context = []);
+	public function delegateBreadcrumb(string $message, string $category, array $context = []): void;
 
 	/**
 	 * Delegate crash reporting to all registered reporters
 	 *
-	 * @since 13.0.0
 	 * @param Exception|Throwable $exception
 	 * @param array $context
+	 *
+	 * @since 13.0.0
 	 */
 	public function delegateReport($exception, array $context = []);
+
+	/**
+	 * Delegate a message to all reporters that implement IMessageReporter
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 *
+	 * @since 17.0.0
+	 */
+	public function delegateMessage(string $message, array $context = []): void;
 }

--- a/tests/lib/Support/CrashReport/RegistryTest.php
+++ b/tests/lib/Support/CrashReport/RegistryTest.php
@@ -27,6 +27,7 @@ namespace Test\Support\CrashReport;
 use Exception;
 use OC\Support\CrashReport\Registry;
 use OCP\Support\CrashReport\ICollectBreadcrumbs;
+use OCP\Support\CrashReport\IMessageReporter;
 use OCP\Support\CrashReport\IReporter;
 use Test\TestCase;
 
@@ -79,6 +80,19 @@ class RegistryTest extends TestCase {
 		$this->registry->register($reporter1);
 		$this->registry->register($reporter2);
 		$this->registry->delegateReport($exception);
+	}
+
+	public function testDelegateMessage() {
+		$reporter1 = $this->createMock(IReporter::class);
+		$reporter2 = $this->createMock(IMessageReporter::class);
+		$message = 'hello';
+		$reporter2->expects($this->once())
+			->method('reportMessage')
+			->with($message, []);
+
+		$this->registry->register($reporter1);
+		$this->registry->register($reporter2);
+		$this->registry->delegateMessage($message);
 	}
 
 }


### PR DESCRIPTION
@rullzer found out we only capture exceptions and their breadcrumbs, but no simple warning/error/critical log messages. This can change now :)