### PR TITLE
Add scripts to update server & apps or apps only

### DIFF
--- a/build/update-apps.sh
+++ b/build/update-apps.sh
@@ -11,4 +11,4 @@
 # - removes branches merged into master
 # - … could even do the build steps if they are consistent for the apps (like `make`)
 
-find apps* -maxdepth 2 -name .git -exec sh -c 'cd {}/../ && printf "\n\033[1m${PWD##*/}\033[0m\n" && git checkout master && git pull --quiet -p && git --no-pager log -3 --pretty=format:"%h %Cblue%ar%x09%an %Creset%s" && printf "\n" && git branch --merged master | grep -v "master$" | xargs --no-run-if-empty git branch -d && git fetch --prune --quiet && cd ..' \;
+find apps* -maxdepth 2 -name .git -exec sh -c 'cd {}/../ && printf "\n\033[1m${PWD##*/}\033[0m\n" && git checkout master && git pull --quiet -p && git --no-pager log -3 --pretty=format:"%h %Cblue%ar%x09%an %Creset%s" && printf "\n" && git branch --merged master | grep -v "master$" | xargs --no-run-if-empty git branch -d && cd ..' \;

--- a/build/update-apps.sh
+++ b/build/update-apps.sh
@@ -11,4 +11,4 @@
 # - removes branches merged into master
 # - … could even do the build steps if they are consistent for the apps (like `make`)
 
-find apps* -maxdepth 2 -name .git -exec sh -c 'cd {}/../ && printf "\n\033[1m${PWD##*/}\033[0m\n" && git checkout master && git pull --quiet && git --no-pager log -3 --pretty=format:"%h %Cblue%ar%x09%an %Creset%s" && printf "\n" && git branch --merged master | grep -v "master$" | xargs --no-run-if-empty git branch -d && git fetch --prune --quiet && cd ..' \;
+find apps* -maxdepth 2 -name .git -exec sh -c 'cd {}/../ && printf "\n\033[1m${PWD##*/}\033[0m\n" && git checkout master && git pull --quiet -p && git --no-pager log -3 --pretty=format:"%h %Cblue%ar%x09%an %Creset%s" && printf "\n" && git branch --merged master | grep -v "master$" | xargs --no-run-if-empty git branch -d && git fetch --prune --quiet && cd ..' \;

--- a/build/update-apps.sh
+++ b/build/update-apps.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Update Nextcloud apps from latest git master
+# For local development environment
+# Use from Nextcloud server folder with `./build/update-apps.sh`
+#
+# It automatically:
+# - goes through all apps which are not shipped via server
+# - shows the app name in bold and uses whitespace for separation
+# - changes to master and pulls quietly
+# - shows the 3 most recent commits for context
+# - removes branches merged into master
+# - … could even do the build steps if they are consistent for the apps (like `make`)
+
+find apps* -maxdepth 2 -name .git -exec sh -c 'cd {}/../ && printf "\n\033[1m${PWD##*/}\033[0m\n" && git checkout master && git pull --quiet && git --no-pager log -3 --pretty=format:"%h %Cblue%ar%x09%an %Creset%s" && printf "\n" && git branch --merged master | grep -v "master$" | xargs --no-run-if-empty git branch -d && git fetch --prune --quiet && cd ..' \;

--- a/build/update-apps.sh
+++ b/build/update-apps.sh
@@ -11,4 +11,4 @@
 # - removes branches merged into master
 # - … could even do the build steps if they are consistent for the apps (like `make`)
 
-find apps* -maxdepth 2 -name .git -exec sh -c 'cd {}/../ && printf "\n\033[1m${PWD##*/}\033[0m\n" && git checkout master && git pull --quiet -p && git --no-pager log -3 --pretty=format:"%h %Cblue%ar%x09%an %Creset%s" && printf "\n" && git branch --merged master | grep -v "master$" | xargs --no-run-if-empty git branch -d && cd ..' \;
+find apps* -maxdepth 2 -name .git -exec sh -c 'cd {}/../ && printf "\n\033[1m${PWD##*/}\033[0m\n" && git checkout master && git pull --quiet -p && git --no-pager log -3 --pretty=format:"%h %Cblue%ar%x09%an %Creset%s" && printf "\n" && git branch --merged master | grep -v "master$" | xargs git branch -d && cd ..' \;

--- a/build/update.sh
+++ b/build/update.sh
@@ -10,7 +10,6 @@ git pull --quiet -p
 git --no-pager log -3 --pretty=format:"%h %Cblue%ar%x09%an %Creset%s"
 printf "\n"
 git branch --merged master | grep -v "master$" | xargs --no-run-if-empty git branch -d
-git fetch --prune --quiet
 git submodule update --init
 
 # Update apps

--- a/build/update.sh
+++ b/build/update.sh
@@ -6,7 +6,7 @@
 # Update server
 printf "\n\033[1m${PWD##*/}\033[0m\n"
 git checkout master
-git pull --quiet
+git pull --quiet -p
 git --no-pager log -3 --pretty=format:"%h %Cblue%ar%x09%an %Creset%s"
 printf "\n"
 git branch --merged master | grep -v "master$" | xargs --no-run-if-empty git branch -d

--- a/build/update.sh
+++ b/build/update.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Update Nextcloud server and apps from latest git master
+# For local development environment
+# Use from Nextcloud server folder with `./build/update.sh`
+
+# Update server
+printf "\n\033[1m${PWD##*/}\033[0m\n"
+git checkout master
+git pull --quiet
+git --no-pager log -3 --pretty=format:"%h %Cblue%ar%x09%an %Creset%s"
+printf "\n"
+git branch --merged master | grep -v "master$" | xargs --no-run-if-empty git branch -d
+git fetch --prune --quiet
+git submodule update
+
+# Update apps
+source ./build/update-apps.sh

--- a/build/update.sh
+++ b/build/update.sh
@@ -11,7 +11,7 @@ git --no-pager log -3 --pretty=format:"%h %Cblue%ar%x09%an %Creset%s"
 printf "\n"
 git branch --merged master | grep -v "master$" | xargs --no-run-if-empty git branch -d
 git fetch --prune --quiet
-git submodule update
+git submodule update --init
 
 # Update apps
 source ./build/update-apps.sh

--- a/build/update.sh
+++ b/build/update.sh
@@ -9,7 +9,7 @@ git checkout master
 git pull --quiet -p
 git --no-pager log -3 --pretty=format:"%h %Cblue%ar%x09%an %Creset%s"
 printf "\n"
-git branch --merged master | grep -v "master$" | xargs --no-run-if-empty git branch -d
+git branch --merged master | grep -v "master$" | xargs git branch -d
 git submodule update --init
 
 # Update apps


### PR DESCRIPTION
Ref https://github.com/nextcloud/server/issues/15145#issuecomment-490570313

One script `./build/update.sh` to simply update server and all apps to current master.
And another one `./build/update-apps.sh` to only update the apps.

Please check @MorrisJobke @ChristophWurst @nickvergessen @skjnldsv 

Possible future enhancements:
- The branch could be supplied by an optional argument like `./build/update.sh stable14` but many apps don’t seem to really use these branches.
- If that’s wanted we could have another script for initial setup, including also cloning the repositories of the apps which are shipped, and optionally also "core" apps like Calendar, Contacts, Talk, Mail, etc.