### PR TITLE
Prevent faulty logs from nested setupFS calls

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -204,7 +204,7 @@ class OC_Util {
 
 		\OC\Files\Filesystem::initMountManager();
 
-		\OC\Files\Filesystem::logWarningWhenAddingStorageWrapper(false);
+		$prevLogging = \OC\Files\Filesystem::logWarningWhenAddingStorageWrapper(false);
 		\OC\Files\Filesystem::addStorageWrapper('mount_options', function ($mountPoint, \OCP\Files\Storage $storage, \OCP\Files\Mount\IMountPoint $mount) {
 			if ($storage->instanceOfStorage('\OC\Files\Storage\Common')) {
 				/** @var \OC\Files\Storage\Common $storage */
@@ -279,7 +279,8 @@ class OC_Util {
 		});
 
 		OC_Hook::emit('OC_Filesystem', 'preSetup', array('user' => $user));
-		\OC\Files\Filesystem::logWarningWhenAddingStorageWrapper(true);
+
+		\OC\Files\Filesystem::logWarningWhenAddingStorageWrapper($prevLogging);
 
 		//check if we are using an object storage
 		$objectStore = \OC::$server->getSystemConfig()->getValue('objectstore', null);


### PR DESCRIPTION
Fix https://github.com/nextcloud/ransomware_protection/issues/46

The question is whether nested setupFS calls should even happen, but I cant judge that.

cc @Schmuuu