### PR TITLE
Update ca bundle checker

### DIFF
--- a/build/ca-bundle-checker.sh
+++ b/build/ca-bundle-checker.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-echo
-if [[ -n ${DRONE_COMMIT_REFSPEC} &&  ! ${DRONE_COMMIT_REFSPEC} =~ version\/noid\/.+ ]]; then
+printenv
+
+if [[ -n ${DRONE_COMMIT_REFSPEC} &&  ! ${DRONE_COMMIT_REFSPEC} =~ version(\/noid)?\/([0-9.]+) ]]; then
     echo "Skip CA bundle check"
     exit 0
 fi

--- a/build/ca-bundle-checker.sh
+++ b/build/ca-bundle-checker.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
-printenv
-
-if [[ -n ${DRONE_COMMIT_REFSPEC} &&  ! ${DRONE_COMMIT_REFSPEC} =~ version(\/noid)?\/([0-9.]+) ]]; then
+if [[ -n ${DRONE_SOURCE_BRANCH} &&  ! ${DRONE_SOURCE_BRANCH} =~ version(\/noid)?\/([0-9.]+) ]]; then
     echo "Skip CA bundle check"
     exit 0
 fi

--- a/build/ca-bundle-checker.sh
+++ b/build/ca-bundle-checker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [[ -n ${DRONE_SOURCE_BRANCH} &&  ! ${DRONE_SOURCE_BRANCH} =~ version(\/noid)?\/([0-9.]+) ]]; then
+if [[ -n ${DRONE_SOURCE_BRANCH} && ! ${DRONE_SOURCE_BRANCH} =~ version(\/noid)?\/([0-9.]+) ]]; then
     echo "Skip CA bundle check"
     exit 0
 fi


### PR DESCRIPTION
Match `version/noid/14.0.1` and `version/14.0.1`.
Use DRONE_SOURCE_BRANCH because DRONE_COMMIT_REFSPEC is not available anymore.

(build with version/01.01.01 as branch name https://drone.nextcloud.com/nextcloud/server/18626/3/3 and executed check)