### PR TITLE
Fix fetching additional search results on scrolling down

### DIFF
--- a/core/search/js/searchprovider.js
+++ b/core/search/js/searchprovider.js
@@ -260,8 +260,8 @@
 				var result = $searchResults.find('tr.result')[currentResult];
 				if (result) {
 					var $result = $(result);
-					var currentOffset = $('#app-content').scrollTop();
-					$('#app-content').animate(
+					var currentOffset = $(window).scrollTop();
+					$(window).animate(
 						{
 							// Scrolling to the top of the new result
 							scrollTop:
@@ -302,16 +302,15 @@
 					lastQuery !== false &&
 					lastResults.length > 0
 				) {
-					var resultsBottom = $searchResults.offset().top + $searchResults.height();
-					var containerBottom = $searchResults.offsetParent().offset().top + $searchResults.offsetParent().height();
-					if (resultsBottom < containerBottom * 1.2) {
-						self.search(lastQuery, lastInApps, lastPage + 1);
+					if ($(window).scrollTop() + $(window).height() > $searchResults.height() - 300) {
+  						self.search(lastQuery, lastInApps, lastPage + 1);
 					}
 					placeStatus();
 				}
 			}
 
-			$('#app-content').on('scroll', _.bind(onScroll, this));
+			$(window).on('scroll', _.bind(onScroll, this)); // For desktop browser
+			$("body").on('scroll', _.bind(onScroll, this)); // For mobile browser
 
 			/**
 			 * scrolls the search results to the top
@@ -319,9 +318,9 @@
 			function scrollToResults() {
 				setTimeout(function() {
 					if (isStatusOffScreen()) {
-						var newScrollTop = $('#app-content').prop('scrollHeight') - $searchResults.height();
+						var newScrollTop = $(window).prop('scrollHeight') - $searchResults.height();
 						console.log('scrolling to ' + newScrollTop);
-						$('#app-content').animate(
+						$(window).animate(
 							{
 								scrollTop: newScrollTop
 							},


### PR DESCRIPTION
When searching for files, the first 30 results are listed. Currently it is not possible to fetch additional results. The code to fetch more results when scrolling down is already there but it seems the scrolling container has changed.
This fix re-enables this feature.

This also fixes https://github.com/nextcloud/server/issues/15088

Tested on Firefox and Nextcloud 16.0.0.