### PR TITLE
304 responses should not have a body also not on v1.php

### DIFF
--- a/lib/private/AppFramework/OCS/BaseResponse.php
+++ b/lib/private/AppFramework/OCS/BaseResponse.php
@@ -87,7 +87,7 @@ abstract class BaseResponse extends Response   {
 	 * @return string
 	 */
 	protected function renderResult(array $meta): string {
-		$status = $this->getStatus();
+		$status = $this->getHttpStatus();
 		if ($status === Http::STATUS_NO_CONTENT ||
 			$status === Http::STATUS_NOT_MODIFIED ||
 			($status >= 100 && $status <= 199)) {
@@ -143,6 +143,10 @@ abstract class BaseResponse extends Response   {
 	}
 
 	public function getOCSStatus() {
+		return parent::getStatus();
+	}
+
+	protected function getHttpStatus() {
 		return parent::getStatus();
 	}
 }


### PR DESCRIPTION
Because of the OCS Status code magic the 204/304 check always was false.
This adds a helper method to get the actual status to check.

To test:
1. query the activity endpoint and get the etag:
  * curl -H 'OCS-APIREQUEST: true'  http://server/ocs/v1.php/apps/activity/api/v2/activity -u USER:PASS -v
2. query the activity endpoint again but with the etag:
  * curl -H 'OCS-APIREQUEST: true'  http://server/ocs/v1.php/apps/activity/api/v2/activity -u USER:PASS -v -H 'IF-NONE-MATCH: ETAG'

Before: 304 status with body, this is not RFC compliant
Now: 304 status without body