### PR TITLE
Update shipped.json to include privacy and recommendations

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -25,7 +25,9 @@
     "notifications",
     "oauth2",
     "password_policy",
+    "privacy",
     "provisioning_api",
+    "recommendations",
     "serverinfo",
     "sharebymail",
     "support",
@@ -35,6 +37,7 @@
     "twofactor_backupcodes",
     "updatenotification",
     "user_ldap",
+    "viewer",
     "workflowengine"
   ],
   "alwaysEnabled": [


### PR DESCRIPTION
The apps `privacy` and `recommendations` are not part of the `shipped.json`, which causes this error message in the update notifier: 

![Screen Shot 2019-05-16 at 23 13 23](https://user-images.githubusercontent.com/1655601/57884435-4487ec80-7831-11e9-842d-8397709c21d6.png)

Related issues:
https://github.com/nextcloud/privacy/issues/118
https://github.com/nextcloud/recommendations/issues/77