### PR TITLE
Allow clients to delete their own apptoken

### DIFF
--- a/core/routes.php
+++ b/core/routes.php
@@ -102,6 +102,7 @@ $application->registerRoutes($this, [
 		['root' => '/core', 'name' => 'WhatsNew#get', 'url' => '/whatsnew', 'verb' => 'GET'],
 		['root' => '/core', 'name' => 'WhatsNew#dismiss', 'url' => '/whatsnew', 'verb' => 'POST'],
 		['root' => '/core', 'name' => 'AppPassword#getAppPassword', 'url' => '/getapppassword', 'verb' => 'GET'],
+		['root' => '/core', 'name' => 'AppPassword#deleteAppPassword', 'url' => '/apppassword', 'verb' => 'DELETE'],
 
 		['root' => '/collaboration', 'name' => 'CollaborationResources#searchCollections', 'url' => '/resources/collections/search/{filter}', 'verb' => 'GET'],
 		['root' => '/collaboration', 'name' => 'CollaborationResources#listCollection', 'url' => '/resources/collections/{collectionId}', 'verb' => 'GET'],


### PR DESCRIPTION
Fixes #15480

Adds and OCS endpoint that clients can call to delete their own apptoken.
Could also be useful for the clients if they remove an account: @tobiasKaminsky 

Todo:
- [x] Add docs https://github.com/nextcloud/documentation/pull/1456