### PR TITLE
Start fixing 2fa icons in dark theme, ref #13643

### DIFF
--- a/lib/private/Settings/Personal/Security.php
+++ b/lib/private/Settings/Personal/Security.php
@@ -42,6 +42,7 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 use OCP\Settings\ISettings;
+use OCP\IConfig;
 
 class Security implements ISettings {
 
@@ -69,6 +70,10 @@ class Security implements ISettings {
 	 * @var string|null
 	 */
 	private $uid;
+	/**
+	 *@var IConfig
+	 */
+	private $config;
 
 	public function __construct(IUserManager $userManager,
 								TwoFactorManager $providerManager,
@@ -76,6 +81,7 @@ class Security implements ISettings {
 								ProviderLoader $providerLoader,
 								IUserSession $userSession,
 								ISession $session,
+								IConfig $config,
 								IInitialStateService $initialStateService,
 								?string $UserId) {
 		$this->userManager = $userManager;
@@ -86,6 +92,7 @@ class Security implements ISettings {
 		$this->session = $session;
 		$this->initialStateService = $initialStateService;
 		$this->uid = $UserId;
+		$this->config = $config;
 	}
 
 	/**
@@ -108,6 +115,7 @@ class Security implements ISettings {
 		return new TemplateResponse('settings', 'settings/personal/security', [
 			'passwordChangeSupported' => $passwordChangeSupported,
 			'twoFactorProviderData' => $this->getTwoFactorProviderData(),
+			'themedark' => $this->config->getUserValue($this->uid, 'accessibility', 'theme', false)
 		]);
 	}
 

--- a/settings/templates/settings/personal/security.php
+++ b/settings/templates/settings/personal/security.php
@@ -69,12 +69,26 @@ if($_['passwordChangeSupported']) {
 	<?php foreach ($_['twoFactorProviderData']['providers'] as $data) { ?>
 		<li>
 			<?php
+
 			/** @var \OCP\Authentication\TwoFactorAuth\IProvidesPersonalSettings $provider */
 			$provider = $data['provider'];
+			//Handle 2FA provider icons and theme
 			if ($provider instanceof \OCP\Authentication\TwoFactorAuth\IProvidesIcons) {
-				$icon = $provider->getDarkIcon();
+				if ($_['themedark']) {
+					$icon = $provider->getLightIcon();
+				}
+				else {
+					$icon = $provider->getDarkIcon();
+				}
+				//fallback icon if the 2factor provider doesn't provide an icon.
 			} else {
-				$icon = image_path('core', 'actions/password.svg');
+				if ($_['themedark']) {
+					$icon = image_path('core', 'actions/password-white.svg');
+				}
+				else {
+					$icon = image_path('core', 'actions/password.svg');
+				}
+
 			}
 			/** @var \OCP\Authentication\TwoFactorAuth\IPersonalProviderSettings $settings */
 			$settings = $data['settings'];


### PR DESCRIPTION
The <img> tag was changed into div class to make them visible on the dark theme, because the icons inserted via classes are automatically inverted.

What is the best option to go ahead with the next icons, in order to make them visible on the dark theme? Currently I only get the path, but we want to insert it as a class.
Worked with @jancborchardt but we are stuck, any input @ChristophWurst @juliushaertl?