### PR TITLE
fixes possible override of uniqueMember by autodetection

### DIFF
--- a/apps/user_ldap/js/wizard/wizardDetectorUserGroupAssociation.js
+++ b/apps/user_ldap/js/wizard/wizardDetectorUserGroupAssociation.js
@@ -27,7 +27,7 @@ OCA = OCA || {};
 		run: function(model, configID) {
 			// TODO: might be better with configuration marker as uniqueMember
 			// is a valid value (although probably less common then member and memberUid).
-			if(model.configuration.ldap_group_member_assoc_attribute && model.configuration.ldap_group_member_assoc_attribute !== 'uniqueMember') {
+			if(model.configuration.ldap_group_member_assoc_attribute && model.configuration.ldap_group_member_assoc_attribute !== '') {
 				// a value is already set. Don't overwrite and don't ask LDAP
 				// without reason.
 				return false;

--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -456,7 +456,7 @@ class Configuration {
 			'ldap_quota_def'                    => '',
 			'ldap_quota_attr'                   => '',
 			'ldap_email_attr'                   => '',
-			'ldap_group_member_assoc_attribute' => 'uniqueMember',
+			'ldap_group_member_assoc_attribute' => '',
 			'ldap_cache_ttl'                    => 600,
 			'ldap_uuid_user_attribute'          => 'auto',
 			'ldap_uuid_group_attribute'         => 'auto',

--- a/apps/user_ldap/lib/LDAPProvider.php
+++ b/apps/user_ldap/lib/LDAPProvider.php
@@ -279,7 +279,7 @@ class LDAPProvider implements ILDAPProvider, IDeletionFlagSupport {
 	/**
 	 * Get the LDAP type of association between users and groups
 	 * @param string $gid group id
-	 * @return string the configuration, one of: 'memberUid', 'uniqueMember', 'member', 'gidNumber'
+	 * @return string the configuration, one of: 'memberUid', 'uniqueMember', 'member', 'gidNumber', ''
 	 * @throws \Exception if group id was not found in LDAP
 	 */
 	public function getLDAPGroupMemberAssoc($gid) {

--- a/apps/user_ldap/lib/Wizard.php
+++ b/apps/user_ldap/lib/Wizard.php
@@ -794,7 +794,7 @@ class Wizard extends LDAPUtility {
 	 * @throws \Exception
 	 */
 	private function detectGroupMemberAssoc() {
-		$possibleAttrs = array('uniqueMember', 'memberUid', 'member', 'gidNumber');
+		$possibleAttrs = ['uniqueMember', 'memberUid', 'member', 'gidNumber'];
 		$filter = $this->configuration->ldapGroupFilter;
 		if(empty($filter)) {
 			return false;
@@ -803,7 +803,7 @@ class Wizard extends LDAPUtility {
 		if(!$cr) {
 			throw new \Exception('Could not connect to LDAP');
 		}
-		$base = $this->configuration->ldapBase[0];
+		$base = $this->configuration->ldapBaseGroups[0] ?: $this->configuration->ldapBase[0];
 		$rr = $this->ldap->search($cr, $base, $filter, $possibleAttrs, 0, 1000);
 		if(!$this->ldap->isResource($rr)) {
 			return false;
@@ -812,7 +812,7 @@ class Wizard extends LDAPUtility {
 		while(is_resource($er)) {
 			$this->ldap->getDN($cr, $er);
 			$attrs = $this->ldap->getAttributes($cr, $er);
-			$result = array();
+			$result = [];
 			$possibleAttrsCount = count($possibleAttrs);
 			for($i = 0; $i < $possibleAttrsCount; $i++) {
 				if(isset($attrs[$possibleAttrs[$i]])) {

--- a/build/integration/ldap_features/ldap-openldap.feature
+++ b/build/integration/ldap_features/ldap-openldap.feature
@@ -42,8 +42,9 @@ Feature: LDAP
 
   Scenario: Test group filter with one specific group
     Given modify LDAP configuration
-      | ldapGroupFilter | cn=RedGroup |
-      | ldapBaseGroups  | ou=Groups,ou=Ordinary,dc=nextcloud,dc=ci  |
+      | ldapGroupFilter          | cn=RedGroup |
+      | ldapGroupMemberAssocAttr | member |
+      | ldapBaseGroups           | ou=Groups,ou=Ordinary,dc=nextcloud,dc=ci  |
     And As an "admin"
     And sending "GET" to "/cloud/groups"
     Then the OCS status code should be "200"
@@ -55,8 +56,9 @@ Feature: LDAP
 
   Scenario: Test group filter with two specific groups
     Given modify LDAP configuration
-      | ldapGroupFilter | (\|(cn=RedGroup)(cn=GreenGroup)) |
-      | ldapBaseGroups  | ou=Groups,ou=Ordinary,dc=nextcloud,dc=ci  |
+      | ldapGroupFilter          | (\|(cn=RedGroup)(cn=GreenGroup)) |
+      | ldapGroupMemberAssocAttr | member |
+      | ldapBaseGroups           | ou=Groups,ou=Ordinary,dc=nextcloud,dc=ci |
     And As an "admin"
     And sending "GET" to "/cloud/groups"
     Then the OCS status code should be "200"
@@ -68,8 +70,9 @@ Feature: LDAP
 
   Scenario: Test group filter ruling out a group from a different base
     Given modify LDAP configuration
-      | ldapGroupFilter | (objectClass=groupOfNames) |
-      | ldapBaseGroups  | ou=Groups,ou=Ordinary,dc=nextcloud,dc=ci  |
+      | ldapGroupFilter          | (objectClass=groupOfNames) |
+      | ldapGroupMemberAssocAttr | member |
+      | ldapBaseGroups           | ou=Groups,ou=Ordinary,dc=nextcloud,dc=ci |
     And As an "admin"
     And sending "GET" to "/cloud/groups"
     Then the OCS status code should be "200"

--- a/build/integration/ldap_features/openldap-numerical-id.feature
+++ b/build/integration/ldap_features/openldap-numerical-id.feature
@@ -35,6 +35,7 @@ Scenario: Test LDAP group retrieval with numeric group ids and nesting
   Given modify LDAP configuration
     | ldapBaseGroups                | ou=NumericGroups,dc=nextcloud,dc=ci |
     | ldapGroupFilter               | (objectclass=groupOfNames) |
+    | ldapGroupMemberAssocAttr      | member |
     | ldapNestedGroups              | 1 |
     | useMemberOfToDetectMembership | 1 |
   And As an "admin"

--- a/lib/public/LDAP/ILDAPProvider.php
+++ b/lib/public/LDAP/ILDAPProvider.php
@@ -151,7 +151,7 @@ interface ILDAPProvider {
 	/**
 	 * Get the LDAP attribute name for the type of association betweeen users and groups
 	 * @param string $gid group id
-	 * @return string the configuration, one of: 'memberUid', 'uniqueMember', 'member', 'gidNumber'
+	 * @return string the configuration, one of: 'memberUid', 'uniqueMember', 'member', 'gidNumber', ''
 	 * @throws \Exception if group id was not found in LDAP
 	 * @since 13.0.0
 	 */


### PR DESCRIPTION
* uniqueMember was the default so we did not know whether this setting is
  desired or the initial value
* autodetection of the user-group association attribute runs only when it
  was not set (as far as we knew)
* the default is now empty
* thus LDAPProvider might return this value as well (in exceptional cases)
* if a group base is given (edge case), use this instead of general base
* resolves #12682

It changes behaviour  a bit:
* previously "uniqueMember" was the default and any LDAP config would work OOTB without hitting the test button after configuring groups. `uniqueMember` is not so common, and neither is not hitting "count groups". Imho, only impact for auto-installations were the attribute is not set specifically.
* LDAPProvider can – in edge cases – return '' next to the known attributes

I would say it is still OK to backport… more to the rules is to keep for 17 only though. The impact is small and rather beneficial.

# What's left

*  [x] fix integration tests
