### PR TITLE
Add catch for RuntimeException

### DIFF
--- a/lib/private/Repair/NC16/CleanupCardDAVPhotoCache.php
+++ b/lib/private/Repair/NC16/CleanupCardDAVPhotoCache.php
@@ -64,7 +64,10 @@ class CleanupCardDAVPhotoCache implements IRepairStep {
 	private function repair(IOutput $output): void {
 		try {
 			$folders = $this->appData->getDirectoryListing();
-		} catch (NotFoundException|RuntimeException $e) {
+		} catch (NotFoundException $e) {
+			return;
+		} catch (RuntimeException $e) {
+			$this->logger->logException($e, ['message' => 'Failed to fetch directory listing in CleanupCardDAVPhotoCache']);
 			return;
 		}
 

--- a/lib/private/Repair/NC16/CleanupCardDAVPhotoCache.php
+++ b/lib/private/Repair/NC16/CleanupCardDAVPhotoCache.php
@@ -29,6 +29,7 @@ use OCP\IConfig;
 use OCP\ILogger;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
+use RuntimeException;
 
 /**
  * Class CleanupCardDAVPhotoCache
@@ -63,7 +64,7 @@ class CleanupCardDAVPhotoCache implements IRepairStep {
 	private function repair(IOutput $output): void {
 		try {
 			$folders = $this->appData->getDirectoryListing();
-		} catch (NotFoundException $e) {
+		} catch (NotFoundException|RuntimeException $e) {
 			return;
 		}
 


### PR DESCRIPTION
Fix #15605

getDirectoryListing can throw a NotFoundException or a RuntimeException.
The repair step should be skipped if the cache directory is missing so
a catch for both exceptions is required.

How to reproduce:

1) Change permission of appdata_xxx to root:root, delete dav-photocache and run  `occ files:scan-app-data`
2) Run the repair step