### PR TITLE
Allow hidden smb shares

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -292,7 +292,7 @@ class OC_Mount_Config {
 				}
 			}
 		} else if (is_string($option)) {
-			if (strpos($option, '$') !== false) {
+			if (strpos(rtrim($option, '$'), '$') !== false) {
 				$result = false;
 			}
 		}

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -287,7 +287,7 @@ class OC_Mount_Config {
 		$result = true;
 		if(is_array($option)) {
 			foreach ($option as $optionItem) {
-					$result = $result && self::arePlaceholdersSubstituted($optionItem);
+				$result = $result && self::arePlaceholdersSubstituted($optionItem);
 			}
 		} else if (is_string($option)) {
 			if (strpos(rtrim($option, '$'), '$') !== false) {

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -287,9 +287,7 @@ class OC_Mount_Config {
 		$result = true;
 		if(is_array($option)) {
 			foreach ($option as $optionItem) {
-				if(is_array($optionItem)) {
-					$result = $result && self::arePlaceholdersSubstituted($option);
-				}
+					$result = $result && self::arePlaceholdersSubstituted($optionItem);
 			}
 		} else if (is_string($option)) {
 			if (strpos(rtrim($option, '$'), '$') !== false) {

--- a/apps/files_external/tests/Config/PlaceholderSubstituteTest.php
+++ b/apps/files_external/tests/Config/PlaceholderSubstituteTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @copyright Copyright (c) 2019 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @author Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\files_external\tests\Config;
+
+use OC_Mount_Config;
+use Test\TestCase;
+
+class PlaceholderSubstituteTest extends TestCase {
+
+	public function dataArePlaceholdersSubstituted(): array {
+		return [
+			['smb_$user', false],
+			['hidden_share$', true],
+		];
+	}
+
+	/**
+	 * @dataProvider dataArePlaceholdersSubstituted
+	 * @param string|array $option
+	 * @param bool $expected
+	 */
+	public function testArePlaceholdersSubstituted($option, $expected): void {
+		$this->assertSame($expected, OC_Mount_Config::arePlaceholdersSubstituted($option));
+	}
+
+}

--- a/apps/files_external/tests/Config/PlaceholderSubstituteTest.php
+++ b/apps/files_external/tests/Config/PlaceholderSubstituteTest.php
@@ -32,6 +32,8 @@ class PlaceholderSubstituteTest extends TestCase {
 		return [
 			['smb_$user', false],
 			['hidden_share$', true],
+			[['smb_$user', 'hidden_share$'], false],
+			[['smb_hello', 'hidden_share$'], true]
 		];
 	}
 


### PR DESCRIPTION
Fix #15567 

A hidden smb share ends with $. This patch changes the placeholder
detection to allow shares with $ at the end.