### PR TITLE
Only show sharing section if it has content

### DIFF
--- a/apps/federatedfilesharing/lib/Settings/Personal.php
+++ b/apps/federatedfilesharing/lib/Settings/Personal.php
@@ -80,6 +80,9 @@ class Personal implements ISettings {
 	 * @since 9.1
 	 */
 	public function getSection() {
+		if (!$this->federatedShareProvider->isOutgoingServer2serverShareEnabled()) {
+			return null;
+		}
 		return 'sharing';
 	}
 

--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -171,6 +171,10 @@ class Manager implements IManager {
 				continue;
 			}
 
+			if ($setting->getSection() === null) {
+				continue;
+			}
+
 			if (!isset($this->settings[$settingsType][$setting->getSection()])) {
 				$this->settings[$settingsType][$setting->getSection()] = [];
 			}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/7965

This makes sure that the personal sharing settings section will be hidden, if there are no federated sharing settings available.