### PR TITLE
Fix l10n for SettingsManager by injecting the l10n factory

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1093,7 +1093,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('SettingsManager', function (Server $c) {
 			$manager = new \OC\Settings\Manager(
 				$c->getLogger(),
-				$c->getL10N('lib'),
+				$c->getL10NFactory(),
 				$c->getURLGenerator(),
 				$c
 			);

--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -34,6 +34,7 @@ use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IServerContainer;
 use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
 use OCP\Settings\ISettings;
 use OCP\Settings\IManager;
 use OCP\Settings\ISection;
@@ -46,6 +47,9 @@ class Manager implements IManager {
 	/** @var IL10N */
 	private $l;
 
+	/** @var IFactory */
+	private $l10nFactory;
+
 	/** @var IURLGenerator */
 	private $url;
 
@@ -54,12 +58,12 @@ class Manager implements IManager {
 
 	public function __construct(
 		ILogger $log,
-		IL10N $l10n,
+		IFactory $l10nFactory,
 		IURLGenerator $url,
 		IServerContainer $container
 	) {
 		$this->log = $log;
-		$this->l = $l10n;
+		$this->l10nFactory = $l10nFactory;
 		$this->url = $url;
 		$this->container = $container;
 	}
@@ -190,6 +194,10 @@ class Manager implements IManager {
 	 * @inheritdoc
 	 */
 	public function getAdminSections(): array {
+		if ($this->l === null) {
+			$this->l = $this->l10nFactory->get('lib');
+		}
+
 		// built-in sections
 		$sections = [
 			0 => [new Section('overview', $this->l->t('Overview'), 0, $this->url->imagePath('settings', 'admin.svg'))],
@@ -301,6 +309,10 @@ class Manager implements IManager {
 	 * @inheritdoc
 	 */
 	public function getPersonalSections(): array {
+		if ($this->l === null) {
+			$this->l = $this->l10nFactory->get('lib');
+		}
+
 		$sections = [
 			0 => [new Section('personal-info', $this->l->t('Personal info'), 0, $this->url->imagePath('core', 'actions/info.svg'))],
 			5 => [new Section('security', $this->l->t('Security'), 0, $this->url->imagePath('settings', 'password.svg'))],

--- a/tests/lib/Settings/ManagerTest.php
+++ b/tests/lib/Settings/ManagerTest.php
@@ -33,6 +33,7 @@ use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IServerContainer;
 use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
 use Test\TestCase;
 
 class ManagerTest extends TestCase {
@@ -43,6 +44,8 @@ class ManagerTest extends TestCase {
 	private $logger;
 	/** @var IDBConnection|\PHPUnit_Framework_MockObject_MockObject */
 	private $l10n;
+	/** @var IFactory|\PHPUnit_Framework_MockObject_MockObject */
+	private $l10nFactory;
 	/** @var IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
 	private $url;
 	/** @var IServerContainer|\PHPUnit_Framework_MockObject_MockObject */
@@ -53,18 +56,24 @@ class ManagerTest extends TestCase {
 
 		$this->logger = $this->createMock(ILogger::class);
 		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10nFactory = $this->createMock(IFactory::class);
 		$this->url = $this->createMock(IURLGenerator::class);
 		$this->container = $this->createMock(IServerContainer::class);
 
 		$this->manager = new Manager(
 			$this->logger,
-			$this->l10n,
+			$this->l10nFactory,
 			$this->url,
 			$this->container
 		);
 	}
 
 	public function testGetAdminSections() {
+		$this->l10nFactory
+			->expects($this->once())
+			->method('get')
+			->with('lib')
+			->willReturn($this->l10n);
 		$this->l10n
 			->expects($this->any())
 			->method('t')
@@ -95,6 +104,11 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testGetPersonalSections() {
+		$this->l10nFactory
+			->expects($this->once())
+			->method('get')
+			->with('lib')
+			->willReturn($this->l10n);
 		$this->l10n
 			->expects($this->any())
 			->method('t')
@@ -119,6 +133,11 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testGetAdminSectionsEmptySection() {
+		$this->l10nFactory
+			->expects($this->once())
+			->method('get')
+			->with('lib')
+			->willReturn($this->l10n);
 		$this->l10n
 			->expects($this->any())
 			->method('t')
@@ -146,6 +165,11 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testGetPersonalSectionsEmptySection() {
+		$this->l10nFactory
+			->expects($this->once())
+			->method('get')
+			->with('lib')
+			->willReturn($this->l10n);
 		$this->l10n
 			->expects($this->any())
 			->method('t')
@@ -201,6 +225,11 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testSameSectionAsPersonalAndAdmin() {
+		$this->l10nFactory
+			->expects($this->once())
+			->method('get')
+			->with('lib')
+			->willReturn($this->l10n);
 		$this->l10n
 			->expects($this->any())
 			->method('t')


### PR DESCRIPTION
Fixes #10832 

Background: The federation app uses `SettingsManager` as dependency and is marked as an authentication app. Thus it's loaded quite early and before the `user_ldap` app. In this case the language fetcher can't use the user information and injects the language that is guessed from the browser. Thus the SettingsManager always has the browser language for LDAP users and the correct language for DB user, because the normal DB user backend is hardcoded before that.