### PR TITLE
Revert "send invitations for shared calendars"

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/Plugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/Plugin.php
@@ -31,10 +31,6 @@ use Sabre\DAV\PropFind;
 use Sabre\DAV\Server;
 use Sabre\DAV\Xml\Property\LocalHref;
 use Sabre\DAVACL\IPrincipal;
-use Sabre\HTTP\RequestInterface;
-use Sabre\HTTP\ResponseInterface;
-use Sabre\VObject\Component\VCalendar;
-use Sabre\VObject\Reader;
 
 class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 
@@ -138,68 +134,5 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 				return new LocalHref($result[0]['href']);
 			});
 		}
-	}
-
-	/**
-	 * This method is triggered whenever there was a calendar object gets
-	 * created or updated.
-	 *
-	 * Basically just a copy of parent::calendarObjectChange, with the change
-	 * from:
-	 * $addresses = $this->getAddressesForPrincipal($calendarNode->getOwner());
-	 * to:
-	 * $addresses = $this->getAddressesForPrincipal($calendarNode->getPrincipalURI());
-	 *
-	 * @param RequestInterface $request HTTP request
-	 * @param ResponseInterface $response HTTP Response
-	 * @param VCalendar $vCal Parsed iCalendar object
-	 * @param mixed $calendarPath Path to calendar collection
-	 * @param mixed $modified The iCalendar object has been touched.
-	 * @param mixed $isNew Whether this was a new item or we're updating one
-	 * @return void
-	 */
-	function calendarObjectChange(RequestInterface $request, ResponseInterface $response, VCalendar $vCal, $calendarPath, &$modified, $isNew) {
-
-		if (!$this->scheduleReply($this->server->httpRequest)) {
-			return;
-		}
-
-		$calendarNode = $this->server->tree->getNodeForPath($calendarPath);
-
-		$addresses = $this->getAddressesForPrincipal(
-			$calendarNode->getPrincipalURI()
-		);
-
-		if (!$isNew) {
-			$node = $this->server->tree->getNodeForPath($request->getPath());
-			$oldObj = Reader::read($node->get());
-		} else {
-			$oldObj = null;
-		}
-
-		$this->processICalendarChange($oldObj, $vCal, $addresses, [], $modified);
-
-		if ($oldObj) {
-			// Destroy circular references so PHP will GC the object.
-			$oldObj->destroy();
-		}
-
-	}
-
-	/**
-	 * This method checks the 'Schedule-Reply' header
-	 * and returns false if it's 'F', otherwise true.
-	 *
-	 * Copied from Sabre/DAV's Schedule plugin, because it's
-	 * private for whatever reason
-	 *
-	 * @param RequestInterface $request
-	 * @return bool
-	 */
-	private function scheduleReply(RequestInterface $request) {
-
-		$scheduleReply = $request->getHeader('Schedule-Reply');
-		return $scheduleReply !== 'F';
-
 	}
 }


### PR DESCRIPTION
This reverts commit a9c313ce451c701a2e065e34022659cf17523963.

The problem in https://github.com/nextcloud/server/issues/12501 basically comes down to the following:
- Sabre/DAV tries to find the event in all calendars of a user (it uses getUsersOwnCalendars)
- the event is obviously not in there, because it’s in  a shared calendar
- Sabre/DAV doesn’t find the invitation and report that it can’t be delivered.

Allowing sharees to send invitation in shared calendars was a mistake back then, there are many unresolved topics, especially if the sharee is also an attendee of the event:
- when editing, does the sharee edit for themselves or on behalf of the calendar owner?
- when deleting, is the sharee declining the event for themselves or cancelling it for everyone?
- ...

The CalDAV standard does not have answers to these problems yet. Until then, we should not allow sharees to send invitations in shared calendars.

Since this is a breaking behaviour, we should not back port it.