### PR TITLE
Make it possible to show admin settings for sub admins

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -379,6 +379,7 @@ return array(
     'OCP\\Settings\\IManager' => $baseDir . '/lib/public/Settings/IManager.php',
     'OCP\\Settings\\ISection' => $baseDir . '/lib/public/Settings/ISection.php',
     'OCP\\Settings\\ISettings' => $baseDir . '/lib/public/Settings/ISettings.php',
+    'OCP\\Settings\\ISubAdminSettings' => $baseDir . '/lib/public/Settings/ISubAdminSettings.php',
     'OCP\\Share' => $baseDir . '/lib/public/Share.php',
     'OCP\\Share\\Exceptions\\GenericShareException' => $baseDir . '/lib/public/Share/Exceptions/GenericShareException.php',
     'OCP\\Share\\Exceptions\\IllegalIDChangeException' => $baseDir . '/lib/public/Share/Exceptions/IllegalIDChangeException.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -409,6 +409,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Settings\\IManager' => __DIR__ . '/../../..' . '/lib/public/Settings/IManager.php',
         'OCP\\Settings\\ISection' => __DIR__ . '/../../..' . '/lib/public/Settings/ISection.php',
         'OCP\\Settings\\ISettings' => __DIR__ . '/../../..' . '/lib/public/Settings/ISettings.php',
+        'OCP\\Settings\\ISubAdminSettings' => __DIR__ . '/../../..' . '/lib/public/Settings/ISubAdminSettings.php',
         'OCP\\Share' => __DIR__ . '/../../..' . '/lib/public/Share.php',
         'OCP\\Share\\Exceptions\\GenericShareException' => __DIR__ . '/../../..' . '/lib/public/Share/Exceptions/GenericShareException.php',
         'OCP\\Share\\Exceptions\\IllegalIDChangeException' => __DIR__ . '/../../..' . '/lib/public/Share/Exceptions/IllegalIDChangeException.php',

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -56,6 +56,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\Folder;
 use OCP\Files\IAppData;
 use OCP\GlobalScale\IConfig;
+use OCP\Group\ISubAdmin;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\INavigationManager;
@@ -218,6 +219,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				$c['AppName'],
 				$server->getUserSession()->isLoggedIn(),
 				$server->getGroupManager()->isAdmin($this->getUserId()),
+				$server->getUserSession()->getUser() !== null && $server->query(ISubAdmin::class)->isSubAdmin($server->getUserSession()->getUser()),
 				$server->getContentSecurityPolicyManager(),
 				$server->getCsrfTokenManager(),
 				$server->getContentSecurityPolicyNonceManager(),

--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -82,6 +82,8 @@ class SecurityMiddleware extends Middleware {
 	private $isLoggedIn;
 	/** @var bool */
 	private $isAdminUser;
+	/** @var bool */
+	private $isSubAdmin;
 	/** @var ContentSecurityPolicyManager */
 	private $contentSecurityPolicyManager;
 	/** @var CsrfTokenManager */
@@ -101,6 +103,7 @@ class SecurityMiddleware extends Middleware {
 								string $appName,
 								bool $isLoggedIn,
 								bool $isAdminUser,
+								bool $isSubAdmin,
 								ContentSecurityPolicyManager $contentSecurityPolicyManager,
 								CsrfTokenManager $csrfTokenManager,
 								ContentSecurityPolicyNonceManager $cspNonceManager,
@@ -115,6 +118,7 @@ class SecurityMiddleware extends Middleware {
 		$this->logger = $logger;
 		$this->isLoggedIn = $isLoggedIn;
 		$this->isAdminUser = $isAdminUser;
+		$this->isSubAdmin = $isSubAdmin;
 		$this->contentSecurityPolicyManager = $contentSecurityPolicyManager;
 		$this->csrfTokenManager = $csrfTokenManager;
 		$this->cspNonceManager = $cspNonceManager;
@@ -143,7 +147,14 @@ class SecurityMiddleware extends Middleware {
 				throw new NotLoggedInException();
 			}
 
-			if(!$this->reflector->hasAnnotation('NoAdminRequired') && !$this->isAdminUser) {
+			if($this->reflector->hasAnnotation('SubAdminRequired')
+				&& !$this->isSubAdmin
+				&& !$this->isAdminUser) {
+				throw new NotAdminException($this->l10n->t('Logged in user must be an admin or sub admin'));
+			}
+			if(!$this->reflector->hasAnnotation('SubAdminRequired')
+				&& !$this->reflector->hasAnnotation('NoAdminRequired')
+				&& !$this->isAdminUser) {
 				throw new NotAdminException($this->l10n->t('Logged in user must be an admin'));
 			}
 		}

--- a/lib/public/Settings/IManager.php
+++ b/lib/public/Settings/IManager.php
@@ -82,10 +82,11 @@ interface IManager {
 	 * returns a list of the admin settings
 	 *
 	 * @param string $section the section id for which to load the settings
+	 * @param bool $subAdminOnly only return settings sub admins are supposed to see (since 17.0.0)
 	 * @return array array of IAdmin[] where key is the priority
 	 * @since 9.1.0
 	 */
-	public function getAdminSettings($section): array;
+	public function getAdminSettings($section, bool $subAdminOnly = false): array;
 
 	/**
 	 * returns a list of the personal  settings

--- a/lib/public/Settings/ISubAdminSettings.php
+++ b/lib/public/Settings/ISubAdminSettings.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCP\Settings;
+
+/**
+ * Tagging interface for settings that should be shown to sub admins
+ *
+ * @since 17.0.0
+ */
+interface ISubAdminSettings extends ISettings {
+
+}

--- a/settings/Controller/PersonalSettingsController.php
+++ b/settings/Controller/PersonalSettingsController.php
@@ -26,8 +26,11 @@ namespace OC\Settings\Controller;
 
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Group\ISubAdmin;
+use OCP\IGroupManager;
 use OCP\INavigationManager;
 use OCP\IRequest;
+use OCP\IUserSession;
 use OCP\Settings\IManager as ISettingsManager;
 use OCP\Template;
 
@@ -38,11 +41,17 @@ class PersonalSettingsController extends Controller {
 		$appName,
 		IRequest $request,
 		INavigationManager $navigationManager,
-		ISettingsManager $settingsManager
+		ISettingsManager $settingsManager,
+		IUserSession $userSession,
+		IGroupManager $groupManager,
+		ISubAdmin $subAdmin
 	) {
 		parent::__construct($appName, $request);
 		$this->navigationManager = $navigationManager;
 		$this->settingsManager = $settingsManager;
+		$this->userSession = $userSession;
+		$this->subAdmin = $subAdmin;
+		$this->groupManager = $groupManager;
 	}
 
 	/**

--- a/tests/lib/Settings/ManagerTest.php
+++ b/tests/lib/Settings/ManagerTest.php
@@ -23,6 +23,7 @@
 
 namespace Tests\Settings;
 
+use function get_class;
 use OC\Settings\Admin\Sharing;
 use OC\Settings\Manager;
 use OC\Settings\Mapper;
@@ -34,6 +35,8 @@ use OCP\ILogger;
 use OCP\IServerContainer;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
+use OCP\Settings\ISettings;
+use OCP\Settings\ISubAdminSettings;
 use Test\TestCase;
 
 class ManagerTest extends TestCase {
@@ -201,6 +204,35 @@ class ManagerTest extends TestCase {
 			->willReturn($section);
 
 		$settings = $this->manager->getAdminSettings('sharing');
+
+		$this->assertEquals([
+			13 => [$section]
+		], $settings);
+	}
+
+	public function testGetAdminSettingsAsSubAdmin() {
+		$section = $this->createMock(Sharing::class);
+		$this->container->expects($this->once())
+			->method('query')
+			->with(Sharing::class)
+			->willReturn($section);
+
+		$settings = $this->manager->getAdminSettings('sharing', true);
+
+		$this->assertEquals([], $settings);
+	}
+
+	public function testGetSubAdminSettingsAsSubAdmin() {
+		$section = $this->createMock(ISubAdminSettings::class);
+		$section->expects($this->once())
+			->method('getPriority')
+			->willReturn(13);
+		$this->container->expects($this->once())
+			->method('query')
+			->with(Sharing::class)
+			->willReturn($section);
+
+		$settings = $this->manager->getAdminSettings('sharing', true);
 
 		$this->assertEquals([
 			13 => [$section]


### PR DESCRIPTION
Todo
- [x] Add tagging interface for sub admin settings
- [x] Add a new annotation to mark controller routes as accessible for admin and sub admins only
- [x] Filter admin settings if the user is not an admin but sub admin
- [x] Adjust all the failing tests

Follow-up (or here, if change is small)
- [x] Do not show empty sections
- [ ] Add `@SubAdminRequired` to the documentation

cc @blizzz for the settings logic
cc @rullzer for the security-related changes

---

On a side note: the `CommonSettingsTrait` should be an abstract base class of the personal and admin settings controllers. That would enforce the private (later protected) properties to be initialized via the constructor. Right now it's fine if you are careful, but IMO the trait is not the best option here.