### PR TITLE
Make the L10N loading lazy

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -941,6 +941,7 @@ return array(
     'OC\\L10N\\L10NString' => $baseDir . '/lib/private/L10N/L10NString.php',
     'OC\\L10N\\LanguageIterator' => $baseDir . '/lib/private/L10N/LanguageIterator.php',
     'OC\\L10N\\LanguageNotFoundException' => $baseDir . '/lib/private/L10N/LanguageNotFoundException.php',
+    'OC\\L10N\\LazyL10N' => $baseDir . '/lib/private/L10N/LazyL10N.php',
     'OC\\LargeFileHelper' => $baseDir . '/lib/private/LargeFileHelper.php',
     'OC\\Lock\\AbstractLockingProvider' => $baseDir . '/lib/private/Lock/AbstractLockingProvider.php',
     'OC\\Lock\\DBLockingProvider' => $baseDir . '/lib/private/Lock/DBLockingProvider.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -971,6 +971,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\L10N\\L10NString' => __DIR__ . '/../../..' . '/lib/private/L10N/L10NString.php',
         'OC\\L10N\\LanguageIterator' => __DIR__ . '/../../..' . '/lib/private/L10N/LanguageIterator.php',
         'OC\\L10N\\LanguageNotFoundException' => __DIR__ . '/../../..' . '/lib/private/L10N/LanguageNotFoundException.php',
+        'OC\\L10N\\LazyL10N' => __DIR__ . '/../../..' . '/lib/private/L10N/LazyL10N.php',
         'OC\\LargeFileHelper' => __DIR__ . '/../../..' . '/lib/private/LargeFileHelper.php',
         'OC\\Lock\\AbstractLockingProvider' => __DIR__ . '/../../..' . '/lib/private/Lock/AbstractLockingProvider.php',
         'OC\\Lock\\DBLockingProvider' => __DIR__ . '/../../..' . '/lib/private/Lock/DBLockingProvider.php',

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -108,37 +108,40 @@ class Factory implements IFactory {
 	 * @return \OCP\IL10N
 	 */
 	public function get($app, $lang = null, $locale = null) {
-		$app = \OC_App::cleanAppId($app);
-		if ($lang !== null) {
-			$lang = str_replace(array('\0', '/', '\\', '..'), '', (string) $lang);
-		}
+		return new LazyL10N(function() use ($app, $lang, $locale) {
 
-		$forceLang = $this->config->getSystemValue('force_language', false);
-		if (is_string($forceLang)) {
-			$lang = $forceLang;
-		}
+			$app = \OC_App::cleanAppId($app);
+			if ($lang !== null) {
+				$lang = str_replace(array('\0', '/', '\\', '..'), '', (string)$lang);
+			}
 
-		$forceLocale = $this->config->getSystemValue('force_locale', false);
-		if (is_string($forceLocale)) {
-			$locale = $forceLocale;
-		}
+			$forceLang = $this->config->getSystemValue('force_language', false);
+			if (is_string($forceLang)) {
+				$lang = $forceLang;
+			}
 
-		if ($lang === null || !$this->languageExists($app, $lang)) {
-			$lang = $this->findLanguage($app);
-		}
+			$forceLocale = $this->config->getSystemValue('force_locale', false);
+			if (is_string($forceLocale)) {
+				$locale = $forceLocale;
+			}
 
-		if ($locale === null || !$this->localeExists($locale)) {
-			$locale = $this->findLocale($lang);
-		}
+			if ($lang === null || !$this->languageExists($app, $lang)) {
+				$lang = $this->findLanguage($app);
+			}
 
-		if (!isset($this->instances[$lang][$app])) {
-			$this->instances[$lang][$app] = new L10N(
-				$this, $app, $lang, $locale,
-				$this->getL10nFilesForApp($app, $lang)
-			);
-		}
+			if ($locale === null || !$this->localeExists($locale)) {
+				$locale = $this->findLocale($lang);
+			}
 
-		return $this->instances[$lang][$app];
+			if (!isset($this->instances[$lang][$app])) {
+				$this->instances[$lang][$app] = new L10N(
+					$this, $app, $lang, $locale,
+					$this->getL10nFilesForApp($app, $lang)
+				);
+			}
+
+			return $this->instances[$lang][$app];
+		});
 	}
 
 	/**

--- a/lib/private/L10N/LazyL10N.php
+++ b/lib/private/L10N/LazyL10N.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\L10N;
+
+use OCP\IL10N;
+
+class LazyL10N implements IL10N {
+
+	/** @var IL10N */
+	private $l;
+
+	/** @var \Closure */
+	private $factory;
+
+
+	public function __construct(\Closure $factory) {
+		$this->factory = $factory;
+	}
+
+	private function getL(): IL10N {
+		if ($this->l === null) {
+			$this->l = ($this->factory)();
+		}
+
+		return $this->l;
+	}
+
+	public function t(string $text, $parameters = []): string {
+		return $this->getL()->t($text, $parameters);
+	}
+
+	public function n(string $text_singular, string $text_plural, int $count, array $parameters = []): string {
+		return $this->getL()->n($text_singular, $text_plural, $count, $parameters);
+	}
+
+	public function l(string $type, $data, array $options = []) {
+		return $this->getL()->l($type, $data, $options);
+	}
+
+	public function getLanguageCode(): string {
+		return $this->getL()->getLanguageCode();
+	}
+
+	public function getLocaleCode(): string {
+		return $this->getL()->getLocaleCode();
+	}
+
+}


### PR DESCRIPTION
Fixes #15675
This makes loading of the actual L10N lazy. So we only detect and load
the actual translations when they are used. Instead of trying to load
them all the time just because an app is enabled.


On a clean install doing a fetch to the notifications API reduces the number of actual initializations from 18 to 4. :tada: 