### PR TITLE
Allow redis cluster to use password

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1160,15 +1160,19 @@ $CONFIG = array(
  * which then causes a FileLocked exception.
  *
  * See https://redis.io/topics/cluster-spec for details about the Redis cluster
+ *
+ * Authentication works with phpredis version 4.2.1+. See
+ * https://github.com/phpredis/phpredis/commit/c5994f2a42b8a348af92d3acb4edff1328ad8ce1
  */
 'redis.cluster' => [
 	'seeds' => [ // provide some/all of the cluster servers to bootstrap discovery, port required
 		'localhost:7000',
-		'localhost:7001'
+		'localhost:7001',
 	],
 	'timeout' => 0.0,
 	'read_timeout' => 0.0,
-	'failover_mode' => \RedisCluster::FAILOVER_ERROR
+	'failover_mode' => \RedisCluster::FAILOVER_ERROR,
+	'password' => '', // Optional, if not defined no password will be used.
 ],
 
 

--- a/lib/private/RedisFactory.php
+++ b/lib/private/RedisFactory.php
@@ -56,7 +56,11 @@ class RedisFactory {
 			} else {
 				$readTimeout = null;
 			}
-			$this->instance = new \RedisCluster(null, $config['seeds'], $timeout, $readTimeout);
+			if (isset($config['password']) && $config['password'] !== '') {
+				$this->instance = new \RedisCluster(null, $config['seeds'], $timeout, $readTimeout, false, $config['password']);
+			} else {
+				$this->instance = new \RedisCluster(null, $config['seeds'], $timeout, $readTimeout);
+			}
 
 			if (isset($config['failover_mode'])) {
 				$this->instance->setOption(\RedisCluster::OPT_SLAVE_FAILOVER, $config['failover_mode']);


### PR DESCRIPTION
This allows to specify a password in the same way it already works for normal redis configuration.