### PR TITLE
Remove divider in app content list (Mail, Contacts, …)

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -1122,7 +1122,6 @@ $outter-margin: ($popoveritem-height - $popovericon-size) / 2;
 	.app-content-list-item {
 		position: relative;
 		height: 68px;
-		border-top: 1px solid var(--color-border);
 		cursor: pointer;
 		padding: 10px 7px;
 		display: flex;


### PR DESCRIPTION
Can be tested in the Contacts app (list of Contacts) and the Mail app (list of Mails).

Current on the left, and then without divider lines on the right – much simpler and the whitespace is enough to divide (just like we also don’t use divider lines in the app-navigation for example):
![contact list current](https://user-images.githubusercontent.com/925062/58188142-64e3fb00-7cb8-11e9-8aab-f6e61447343c.png) ![contact list no lines](https://user-images.githubusercontent.com/925062/58188141-64e3fb00-7cb8-11e9-9e68-c48035c41308.png)

Ref as commented in https://github.com/nextcloud/nextcloud-vue/pull/398#issuecomment-494857345

For this to look good in the Mail app, this needs a fix for the 3-dot menu because currently the second line of text (mail subject) is pushed too far down from the first line (mail sender). See https://github.com/nextcloud/nextcloud-vue/pull/382