### PR TITLE
Add funding.yml with Bountysource info

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# You can add one username per supported platform and one custom link
+custom: https://www.bountysource.com/teams/nextcloud


### PR DESCRIPTION
As per announcement at Github conf today, this FUNDING.yml will display donation info in the repository. :)
More info in their post at https://github.blog/2019-05-23-announcing-github-sponsors-a-new-way-to-contribute-to-open-source/

Please review @rullzer @MorrisJobke @jospoortvliet 