### PR TITLE
Redirect to the right token on public shares

### DIFF
--- a/lib/public/AppFramework/AuthPublicShareController.php
+++ b/lib/public/AppFramework/AuthPublicShareController.php
@@ -185,6 +185,20 @@ abstract class AuthPublicShareController extends PublicShareController {
 				$route = $params['_route'];
 				unset($params['_route']);
 			}
+
+			// If the token doesn't match the rest of the arguments can't be trusted either
+			if (isset($params['token']) && $params['token'] !== $this->getToken()) {
+				$params = [
+					'token' => $this->getToken(),
+				];
+			}
+
+			// We need a token
+			if (!isset($params['token'])) {
+				$params = [
+					'token' => $this->getToken(),
+				];
+			}
 		}
 
 		return new RedirectResponse($this->urlGenerator->linkToRoute($route, $params));


### PR DESCRIPTION
If the token doesn't match (or isn't set) during the redirect. We should
properly set it. Else we might redirect to a later auth display that set
these values.



Steps to test:

1. Create a link `l1` to a file `a` with password `p1`
2. Create a link `l2` to a file `b` with password `p2`
3. Open incognito mode
4. open `l1` in tab
5. open `l2` in other tab
6. switch back to `l1`
7. enter `p1`

Before: redirect to `l2` to authenticate
After: properly logged in to `l1`