### PR TITLE
Group display name support (service level + ldap)

### DIFF
--- a/apps/files_external/ajax/applicable.php
+++ b/apps/files_external/ajax/applicable.php
@@ -41,7 +41,7 @@ if (isset($_GET['offset'])) {
 
 $groups = [];
 foreach (\OC::$server->getGroupManager()->search($pattern, $limit, $offset) as $group) {
-	$groups[$group->getGID()] = $group->getGID();
+	$groups[$group->getGID()] = $group->getDisplayName();
 }
 
 $users = [];

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -712,6 +712,8 @@ class Access extends LDAPUtility {
 					$sndName = isset($ldapObject[$sndAttribute][0])
 						? $ldapObject[$sndAttribute][0] : '';
 					$this->cacheUserDisplayName($ncName, $nameByLDAP, $sndName);
+				} else if($nameByLDAP !== null) {
+					$this->cacheGroupDisplayName($ncName, $nameByLDAP);
 				}
 			}
 		}
@@ -763,6 +765,11 @@ class Access extends LDAPUtility {
 		$displayName = $user->composeAndStoreDisplayName($displayName, $displayName2);
 		$cacheKeyTrunk = 'getDisplayName';
 		$this->connection->writeToCache($cacheKeyTrunk.$ocName, $displayName);
+	}
+
+	public function cacheGroupDisplayName(string $ncName, string $displayName): void {
+		$cacheKey = 'group_getDisplayName' . $ncName;
+		$this->connection->writeToCache($cacheKey, $displayName);
 	}
 
 	/**

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -65,6 +65,7 @@ use OCP\ILogger;
  * @property bool|string ldapNestedGroups
  * @property string[] ldapBaseGroups
  * @property string ldapGroupFilter
+ * @property string ldapGroupDisplayName
  */
 class Connection extends LDAPUtility {
 	private $ldapConnectionRes = null;

--- a/apps/user_ldap/lib/Group_Proxy.php
+++ b/apps/user_ldap/lib/Group_Proxy.php
@@ -27,7 +27,9 @@
 
 namespace OCA\User_LDAP;
 
-class Group_Proxy extends Proxy implements \OCP\GroupInterface, IGroupLDAP {
+use OCP\Group\Backend\IGetDisplayNameBackend;
+
+class Group_Proxy extends Proxy implements \OCP\GroupInterface, IGroupLDAP, IGetDisplayNameBackend {
 	private $backends = array();
 	private $refBackend = null;
 
@@ -272,4 +274,7 @@ class Group_Proxy extends Proxy implements \OCP\GroupInterface, IGroupLDAP {
 		return $this->handleRequest($gid, 'getNewLDAPConnection', array($gid));
 	}
 
+	public function getDisplayName(string $gid): string {
+		return $this->handleRequest($gid, 'getDisplayName', [$gid]);
+	}
 }

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -276,6 +276,7 @@ return array(
     'OCP\\Group\\Backend\\ICountUsersBackend' => $baseDir . '/lib/public/Group/Backend/ICountUsersBackend.php',
     'OCP\\Group\\Backend\\ICreateGroupBackend' => $baseDir . '/lib/public/Group/Backend/ICreateGroupBackend.php',
     'OCP\\Group\\Backend\\IDeleteGroupBackend' => $baseDir . '/lib/public/Group/Backend/IDeleteGroupBackend.php',
+    'OCP\\Group\\Backend\\IGetDisplayNameBackend' => $baseDir . '/lib/public/Group/Backend/IGetDisplayNameBackend.php',
     'OCP\\Group\\Backend\\IGroupDetailsBackend' => $baseDir . '/lib/public/Group/Backend/IGroupDetailsBackend.php',
     'OCP\\Group\\Backend\\IHideFromCollaborationBackend' => $baseDir . '/lib/public/Group/Backend/IHideFromCollaborationBackend.php',
     'OCP\\Group\\Backend\\IIsAdminBackend' => $baseDir . '/lib/public/Group/Backend/IIsAdminBackend.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -306,6 +306,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Group\\Backend\\ICountUsersBackend' => __DIR__ . '/../../..' . '/lib/public/Group/Backend/ICountUsersBackend.php',
         'OCP\\Group\\Backend\\ICreateGroupBackend' => __DIR__ . '/../../..' . '/lib/public/Group/Backend/ICreateGroupBackend.php',
         'OCP\\Group\\Backend\\IDeleteGroupBackend' => __DIR__ . '/../../..' . '/lib/public/Group/Backend/IDeleteGroupBackend.php',
+        'OCP\\Group\\Backend\\IGetDisplayNameBackend' => __DIR__ . '/../../..' . '/lib/public/Group/Backend/IGetDisplayNameBackend.php',
         'OCP\\Group\\Backend\\IGroupDetailsBackend' => __DIR__ . '/../../..' . '/lib/public/Group/Backend/IGroupDetailsBackend.php',
         'OCP\\Group\\Backend\\IHideFromCollaborationBackend' => __DIR__ . '/../../..' . '/lib/public/Group/Backend/IHideFromCollaborationBackend.php',
         'OCP\\Group\\Backend\\IIsAdminBackend' => __DIR__ . '/../../..' . '/lib/public/Group/Backend/IIsAdminBackend.php',

--- a/lib/private/Group/Group.php
+++ b/lib/private/Group/Group.php
@@ -30,6 +30,7 @@
 
 namespace OC\Group;
 
+use OCP\Group\Backend\IGetDisplayNameBackend;
 use OCP\Group\Backend\IHideFromCollaborationBackend;
 use OC\Hooks\PublicEmitter;
 use OCP\GroupInterface;
@@ -86,6 +87,15 @@ class Group implements IGroup {
 
 	public function getDisplayName() {
 		if (is_null($this->displayName)) {
+			foreach ($this->backends as $backend) {
+				if ($backend instanceof IGetDisplayNameBackend) {
+					$displayName = $backend->getDisplayName($this->gid);
+					if (trim($displayName) !== '') {
+						$this->displayName = $displayName;
+						return $this->displayName;
+					}
+				}
+			}
 			return $this->gid;
 		}
 		return $this->displayName;

--- a/lib/public/Group/Backend/IGetDisplayNameBackend.php
+++ b/lib/public/Group/Backend/IGetDisplayNameBackend.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Group\Backend;
+
+/**
+ * @since 17.0.0
+ */
+interface IGetDisplayNameBackend {
+	/**
+	 * @since 17.0.0
+	 */
+	public function getDisplayName(string $gid): string;
+
+}


### PR DESCRIPTION
* an interface for Group backends is added
* LDAP group backend incorporates it

How to test?

1. Have LDAP with groups configured
2. Go to the users page, see the group listed
3. Change the group name in LDAP (default displayname attribute for groups is `cn`)
4. Beware caching (if memcache is configured, 10min by default, you can flush redis or change ldap config slightly - or have the TTL low for development).
5. Refresh users page, group should be shown with new name
6. click in the group → the new URL carries the ID (== old name)

The new group name should be visisble in the personal settings (if you're member of such a group), sharing, external storage config, etc.

Nothing needed for local groups, as their ID equals their name and they cannot be renamed.

Solves #7267 
