### PR TITLE
Change text color in search box in darktheme, ref #15598

### DIFF
--- a/apps/accessibility/css/themedark.scss
+++ b/apps/accessibility/css/themedark.scss
@@ -42,8 +42,7 @@ $color-border-dark: lighten($color-main-background, 14%);
 
 // since svg icons are inverted, revert to white for the header
 .header-right > * {
-	>[class^='icon-'],
-	>[class*=' icon-'] {
+	>[class^='icon-'] {
 		filter: invert(100%);
 	}
 }

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -631,7 +631,7 @@ nav[role='navigation'] {
 			width: 155px;
 			cursor: text;
 			background-color: transparent !important;
-			border: 1px solid var(--color-border) !important;
+			border: 1px solid var(--color-primary-text) !important;
 		}
 		&:hover, &:focus, &:active {
 			opacity: 1;
@@ -655,6 +655,9 @@ nav[role='navigation'] {
 		&::-webkit-search-cancel-button {
 			-webkit-appearance: none;
 		}
+	}
+	.icon-search-force-white {
+		@include icon-color('search', 'actions', '#fffffe', 1, true);
 	}
 }
 

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -105,7 +105,7 @@
 						<?php p($l->t('Search'));?>
 					</label>
 					<input id="searchbox" type="search" name="query"
-						value="" required class="hidden icon-search-white"
+						value="" required class="hidden icon-search-white icon-search-force-white"
 						autocomplete="off">
 					<button class="icon-close-white" type="reset"><span class="hidden-visually"><?php p($l->t('Reset search'));?></span></button>
 				</form>


### PR DESCRIPTION
I need to fix the color-primary-text variable so it is inverted when the primary-colour is too bright as suggested by skjnldsv here: https://github.com/nextcloud/server/commit/7c10ef6298eb88a2f4ae422950150d9eeb344c75. Another patch will follow.

Fixes #15598