### PR TITLE
add option to show hidden files in SMB shares

### DIFF
--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -50,6 +50,9 @@ class SMB extends Backend {
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('domain', $l->t('Domain')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+				(new DefinitionParameter('show_hidden', $l->t('Show hidden files')))
+					->setType(DefinitionParameter::VALUE_BOOLEAN)
+					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 			])
 			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
 			->addAuthScheme(AuthMechanism::SCHEME_SMB)


### PR DESCRIPTION
Note hidden files can mean different things in smb and the option the the files web ui,
the webui only counts files starting with '.' as hidden, while smb files
can be marked as hidden regardless, any files that are marked as hidden
on smb will thus be shown in the webui regardless of the setting in the files app.

Fixes #15644

Signed-off-by: Robin Appelman <robin@icewind.nl>