### PR TITLE
Add an event to edit the CSP

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -373,6 +373,7 @@ return array(
     'OCP\\Search\\PagedProvider' => $baseDir . '/lib/public/Search/PagedProvider.php',
     'OCP\\Search\\Provider' => $baseDir . '/lib/public/Search/Provider.php',
     'OCP\\Search\\Result' => $baseDir . '/lib/public/Search/Result.php',
+    'OCP\\Security\\CSP\\AddContentSecurityPolicyEvent' => $baseDir . '/lib/public/Security/CSP/AddContentSecurityPolicyEvent.php',
     'OCP\\Security\\IContentSecurityPolicyManager' => $baseDir . '/lib/public/Security/IContentSecurityPolicyManager.php',
     'OCP\\Security\\ICredentialsManager' => $baseDir . '/lib/public/Security/ICredentialsManager.php',
     'OCP\\Security\\ICrypto' => $baseDir . '/lib/public/Security/ICrypto.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -407,6 +407,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Search\\PagedProvider' => __DIR__ . '/../../..' . '/lib/public/Search/PagedProvider.php',
         'OCP\\Search\\Provider' => __DIR__ . '/../../..' . '/lib/public/Search/Provider.php',
         'OCP\\Search\\Result' => __DIR__ . '/../../..' . '/lib/public/Search/Result.php',
+        'OCP\\Security\\CSP\\AddContentSecurityPolicyEvent' => __DIR__ . '/../../..' . '/lib/public/Security/CSP/AddContentSecurityPolicyEvent.php',
         'OCP\\Security\\IContentSecurityPolicyManager' => __DIR__ . '/../../..' . '/lib/public/Security/IContentSecurityPolicyManager.php',
         'OCP\\Security\\ICredentialsManager' => __DIR__ . '/../../..' . '/lib/public/Security/ICredentialsManager.php',
         'OCP\\Security\\ICrypto' => __DIR__ . '/../../..' . '/lib/public/Security/ICrypto.php',

--- a/lib/private/Security/CSP/ContentSecurityPolicyManager.php
+++ b/lib/private/Security/CSP/ContentSecurityPolicyManager.php
@@ -25,11 +25,20 @@ namespace OC\Security\CSP;
 
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\EmptyContentSecurityPolicy;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 use OCP\Security\IContentSecurityPolicyManager;
 
 class ContentSecurityPolicyManager implements IContentSecurityPolicyManager {
 	/** @var ContentSecurityPolicy[] */
 	private $policies = [];
+
+	/** @var IEventDispatcher */
+	private $dispatcher;
+
+	public function __construct(IEventDispatcher $dispatcher) {
+		$this->dispatcher = $dispatcher;
+	}
 
 	/** {@inheritdoc} */
 	public function addDefaultPolicy(EmptyContentSecurityPolicy $policy) {
@@ -43,6 +52,9 @@ class ContentSecurityPolicyManager implements IContentSecurityPolicyManager {
 	 * @return ContentSecurityPolicy
 	 */
 	public function getDefaultPolicy(): ContentSecurityPolicy {
+		$event = new AddContentSecurityPolicyEvent($this);
+		$this->dispatcher->dispatch(AddContentSecurityPolicyEvent::class, $event);
+
 		$defaultPolicy = new \OC\Security\CSP\ContentSecurityPolicy();
 		foreach($this->policies as $policy) {
 			$defaultPolicy = $this->mergePolicies($defaultPolicy, $policy);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1029,10 +1029,8 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService(SessionStorage::class, function (Server $c) {
 			return new SessionStorage($c->getSession());
 		});
-		$this->registerService(\OCP\Security\IContentSecurityPolicyManager::class, function (Server $c) {
-			return new ContentSecurityPolicyManager();
-		});
-		$this->registerAlias('ContentSecurityPolicyManager', \OCP\Security\IContentSecurityPolicyManager::class);
+		$this->registerAlias(\OCP\Security\IContentSecurityPolicyManager::class, \OC\Security\CSP\ContentSecurityPolicyManager::class);
+		$this->registerAlias('ContentSecurityPolicyManager', \OC\Security\CSP\ContentSecurityPolicyManager::class);
 
 		$this->registerService('ContentSecurityPolicyNonceManager', function (Server $c) {
 			return new ContentSecurityPolicyNonceManager(

--- a/lib/public/IServerContainer.php
+++ b/lib/public/IServerContainer.php
@@ -534,6 +534,7 @@ interface IServerContainer extends IContainer {
 	/**
 	 * @return IContentSecurityPolicyManager
 	 * @since 9.0.0
+	 * @deprecated 17.0.0 Use the AddContentSecurityPolicyEvent
 	 */
 	public function getContentSecurityPolicyManager();
 

--- a/lib/public/Security/CSP/AddContentSecurityPolicyEvent.php
+++ b/lib/public/Security/CSP/AddContentSecurityPolicyEvent.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Security\CSP;
+
+use OC\Security\CSP\ContentSecurityPolicyManager;
+use OCP\AppFramework\Http\EmptyContentSecurityPolicy;
+use OCP\EventDispatcher\Event;
+
+/**
+ * @since 17.0.0
+ */
+class AddContentSecurityPolicyEvent extends Event {
+
+	/** @var ContentSecurityPolicyManager */
+	private $policyManager;
+
+	/**
+	 * @since 17.0.0
+	 */
+	public function __construct(ContentSecurityPolicyManager $policyManager) {
+		$this->policyManager = $policyManager;
+	}
+
+	/**
+	 * @since 17.0.0
+	 */
+	public function addPolicy(EmptyContentSecurityPolicy $csp): void {
+		$this->policyManager->addDefaultPolicy($csp);
+	}
+}

--- a/lib/public/Security/IContentSecurityPolicyManager.php
+++ b/lib/public/Security/IContentSecurityPolicyManager.php
@@ -28,6 +28,7 @@ use OCP\AppFramework\Http\EmptyContentSecurityPolicy;
  *
  * @package OCP\Security
  * @since 9.0.0
+ * @deprecated 17.0.0 listen to the AddContentSecurityPolicyEvent to add a policy
  */
 interface IContentSecurityPolicyManager {
 	/**
@@ -46,6 +47,7 @@ interface IContentSecurityPolicyManager {
 	 *
 	 * @param EmptyContentSecurityPolicy $policy
 	 * @since 9.0.0
+	 * @deprecated 17.0.0 listen to the AddContentSecurityPolicyEvent to add a policy
 	 */
 	public function addDefaultPolicy(EmptyContentSecurityPolicy $policy);
 }

--- a/tests/lib/Security/CSP/AddContentSecurityPolicyEventTest.php
+++ b/tests/lib/Security/CSP/AddContentSecurityPolicyEventTest.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Test\Security\CSP;
+
+use OC\Security\CSP\ContentSecurityPolicyManager;
+use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\Security\CSP\AddContentSecurityPolicyEvent;
+use Test\TestCase;
+
+class AddContentSecurityPolicyEventTest extends TestCase {
+	public function testAddEvent() {
+		$cspManager = $this->createMock(ContentSecurityPolicyManager::class);
+		$policy = $this->createMock(ContentSecurityPolicy::class);
+		$event = new AddContentSecurityPolicyEvent($cspManager);
+
+		$cspManager->expects($this->once())
+			->method('addDefaultPolicy')
+			->with($policy);
+
+		$event->addPolicy($policy);
+	}
+}

--- a/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
+++ b/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
@@ -23,14 +23,24 @@ namespace Test\Security\CSP;
 
 
 use OC\Security\CSP\ContentSecurityPolicyManager;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Security\CSP\AddContentSecurityPolicyEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Test\TestCase;
 
-class ContentSecurityPolicyManagerTest extends \Test\TestCase {
+class ContentSecurityPolicyManagerTest extends TestCase {
+	/** @var EventDispatcherInterface */
+	private $dispatcher;
+
 	/** @var ContentSecurityPolicyManager */
 	private $contentSecurityPolicyManager;
 
 	public function setUp() {
 		parent::setUp();
-		$this->contentSecurityPolicyManager = new ContentSecurityPolicyManager();
+		$this->dispatcher = \OC::$server->query(IEventDispatcher::class);
+		$this->contentSecurityPolicyManager = new ContentSecurityPolicyManager($this->dispatcher);
 	}
 
 	public function testAddDefaultPolicy() {
@@ -53,6 +63,46 @@ class ContentSecurityPolicyManagerTest extends \Test\TestCase {
 		$policy->addAllowedChildSrcDomain('childdomain');
 		$policy->addAllowedFontDomain('anotherFontDomain');
 		$this->contentSecurityPolicyManager->addDefaultPolicy($policy);
+
+		$expected = new \OC\Security\CSP\ContentSecurityPolicy();
+		$expected->allowInlineScript(true);
+		$expected->allowEvalScript(true);
+		$expected->addAllowedFontDomain('mydomain.com');
+		$expected->addAllowedFontDomain('example.com');
+		$expected->addAllowedFontDomain('anotherFontDomain');
+		$expected->addAllowedImageDomain('anotherdomain.de');
+		$expected->addAllowedImageDomain('example.org');
+		$expected->addAllowedChildSrcDomain('childdomain');
+		$expectedStringPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' 'unsafe-inline' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: anotherdomain.de example.org;font-src 'self' data: mydomain.com example.com anotherFontDomain;connect-src 'self';media-src 'self';child-src childdomain;frame-ancestors 'self'";
+
+		$this->assertEquals($expected, $this->contentSecurityPolicyManager->getDefaultPolicy());
+		$this->assertSame($expectedStringPolicy, $this->contentSecurityPolicyManager->getDefaultPolicy()->buildPolicy());
+	}
+
+	public function testGetDefaultPolicyWithPoliciesViaEvent() {
+		$this->dispatcher->addListener(AddContentSecurityPolicyEvent::class, function(AddContentSecurityPolicyEvent $e) {
+			$policy = new \OCP\AppFramework\Http\ContentSecurityPolicy();
+			$policy->addAllowedFontDomain('mydomain.com');
+			$policy->addAllowedImageDomain('anotherdomain.de');
+
+			$e->addPolicy($policy);
+		});
+
+		$this->dispatcher->addListener(AddContentSecurityPolicyEvent::class, function(AddContentSecurityPolicyEvent $e) {
+			$policy = new \OCP\AppFramework\Http\ContentSecurityPolicy();
+			$policy->addAllowedFontDomain('example.com');
+			$policy->addAllowedImageDomain('example.org');
+			$policy->allowInlineScript(true);
+			$policy->allowEvalScript(true);
+			$e->addPolicy($policy);
+		});
+
+		$this->dispatcher->addListener(AddContentSecurityPolicyEvent::class, function(AddContentSecurityPolicyEvent $e) {
+			$policy = new \OCP\AppFramework\Http\EmptyContentSecurityPolicy();
+			$policy->addAllowedChildSrcDomain('childdomain');
+			$policy->addAllowedFontDomain('anotherFontDomain');
+			$e->addPolicy($policy);
+		});
 
 		$expected = new \OC\Security\CSP\ContentSecurityPolicy();
 		$expected->allowInlineScript(true);


### PR DESCRIPTION
Fixes #14179

This introduces and event that can be listend to when we actually use
the CSP. This means that apps no longer have to always inject their CSP
but only do so when it is required. Yay for being lazy.

Todo:
- [x] Tests
- [ ] Documentation