### PR TITLE
Don't notify admins if no potentially over exposing links found

### DIFF
--- a/lib/private/Repair/RemoveLinkShares.php
+++ b/lib/private/Repair/RemoveLinkShares.php
@@ -201,8 +201,7 @@ class RemoveLinkShares implements IRepairStep {
 		}
 	}
 
-	private function repair(IOutput $output): void {
-		$total = $this->getTotal();
+	private function repair(IOutput $output, int $total): void {
 		$output->startProgress($total);
 
 		$shareCursor = $this->getShares();
@@ -225,12 +224,13 @@ class RemoveLinkShares implements IRepairStep {
 	}
 
 	public function run(IOutput $output): void {
-		if ($this->shouldRun()) {
-			$output->info('Removing potentially over exposing link shares');
-			$this->repair($output);
-			$output->info('Removed potentially over exposing link shares');
-		} else {
+		if ($this->shouldRun() === false || ($total = $this->getTotal()) === 0) {
 			$output->info('No need to remove link shares.');
+			return;
 		}
+
+		$output->info('Removing potentially over exposing link shares');
+		$this->repair($output, $total);
+		$output->info('Removed potentially over exposing link shares');
 	}
 }


### PR DESCRIPTION
> The getTotal() function seems to use the same SQL query to get the total number of dodgy shares but it is only used for reporting purposes. The repair function then continues to delete 'zero' shares and reports that it has deleted any 'potential' dodgy ones.

https://github.com/nextcloud/server/issues/15643#issuecomment-495983415

I'm not sure how many instances not upgraded yet but we should notify admins only if there are links removed.

cc @garyhowell