### PR TITLE
Also allow dragging below the file list

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -3350,6 +3350,7 @@
 					&& !self.$el.is(dropTarget) // dropped on list directly
 					&& !self.$el.has(dropTarget).length // dropped inside list
 					&& !dropTarget.is(self.$container) // dropped on main container
+					&& !self.$el.parent().is(dropTarget) // drop on the parent container (#app-content) since the main container might not have the full height
 					) {
 					e.preventDefault();
 					return false;


### PR DESCRIPTION
This PR fixes file upload by dragging files to the browser when there is empty space below the file list. The file list is not stretched to 100% height, as possible search results need to be displayed right below the list. Therefore we should not cancel the drop action if the dropTarget is the main `#app-content` container.

To reproduce, drag a file below the `#app-content-files` container:
![image](https://user-images.githubusercontent.com/3404133/58415885-236c9a80-8080-11e9-8055-9187b83455de.png)
