### PR TITLE
Hide newFile menu if quota is set to 0B

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2036,7 +2036,7 @@
 			this.breadcrumb.setDirectoryInfo(this.dirInfo);
 
 			if (this.dirInfo.permissions) {
-				this.setDirectoryPermissions(this.dirInfo.permissions);
+				this._updateDirectoryPermissions();
 			}
 
 			result.sort(this._sortComparator);
@@ -2187,11 +2187,8 @@
 			img.src = previewURL;
 		},
 
-		/**
-		 * @deprecated
-		 */
-		setDirectoryPermissions: function(permissions) {
-			var isCreatable = (permissions & OC.PERMISSION_CREATE) !== 0;
+		_updateDirectoryPermissions: function() {
+			var isCreatable = (this.dirInfo.permissions & OC.PERMISSION_CREATE) !== 0 && this.$el.find('#free_space').val() !== '0';
 			this.$el.find('#permissions').val(permissions);
 			this.$el.find('.creatable').toggleClass('hidden', !isCreatable);
 			this.$el.find('.notCreatable').toggleClass('hidden', isCreatable);

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -75,6 +75,7 @@
 				$('#owner').val(response.data.owner);
 				$('#ownerDisplayName').val(response.data.ownerDisplayName);
 				Files.displayStorageWarnings();
+				OCA.Files.App.fileList._updateDirectoryPermissions();
 			}
 			if (response[0] === undefined) {
 				return;


### PR DESCRIPTION
Hide the add new file button if 0B quota is configured for a user.  

The button will be shown again, once the user enters a folder that has a different quota on the mount, e.g. inside of shared folders with write permissions.

![image](https://user-images.githubusercontent.com/3404133/58473831-e240bd00-8149-11e9-881e-62c0c2112232.png)