### PR TITLE
don't show an empty settings page if federated sharing is disabled

### DIFF
--- a/apps/federatedfilesharing/lib/Settings/Personal.php
+++ b/apps/federatedfilesharing/lib/Settings/Personal.php
@@ -25,7 +25,6 @@
 namespace OCA\FederatedFileSharing\Settings;
 
 
-use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IL10N;
 use OCP\IUserSession;
@@ -33,8 +32,6 @@ use OCP\Settings\ISettings;
 
 class Personal implements ISettings {
 
-	/** @var FederatedShareProvider */
-	private $federatedShareProvider;
 	/** @var IUserSession */
 	private $userSession;
 	/** @var IL10N */
@@ -43,12 +40,10 @@ class Personal implements ISettings {
 	private $defaults;
 
 	public function __construct(
-		FederatedShareProvider $federatedShareProvider, #
 		IUserSession $userSession,
 		IL10N $l,
 		\OC_Defaults $defaults
 	) {
-		$this->federatedShareProvider = $federatedShareProvider;
 		$this->userSession = $userSession;
 		$this->l = $l;
 		$this->defaults = $defaults;
@@ -63,7 +58,6 @@ class Personal implements ISettings {
 		$url = 'https://nextcloud.com/sharing#' . $cloudID;
 
 		$parameters = [
-			'outgoingServer2serverShareEnabled' => $this->federatedShareProvider->isOutgoingServer2serverShareEnabled(),
 			'message_with_URL' => $this->l->t('Share with me through my #Nextcloud Federated Cloud ID, see %s', [$url]),
 			'message_without_URL' => $this->l->t('Share with me through my #Nextcloud Federated Cloud ID', [$cloudID]),
 			'logoPath' => $this->defaults->getLogo(),

--- a/apps/federatedfilesharing/lib/Settings/PersonalSection.php
+++ b/apps/federatedfilesharing/lib/Settings/PersonalSection.php
@@ -24,6 +24,7 @@
 namespace OCA\FederatedFileSharing\Settings;
 
 
+use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\Settings\IIconSection;
@@ -33,10 +34,13 @@ class PersonalSection implements IIconSection {
 	private $urlGenerator;
 	/** @var IL10N */
 	private $l;
+	/** @var FederatedShareProvider */
+	private $federatedShareProvider;
 
-	public function __construct(IURLGenerator $urlGenerator, IL10N $l) {
+	public function __construct(IURLGenerator $urlGenerator, IL10N $l, FederatedShareProvider $federatedShareProvider) {
 		$this->urlGenerator = $urlGenerator;
 		$this->l = $l;
+		$this->federatedShareProvider = $federatedShareProvider;
 	}
 
 	/**
@@ -58,7 +62,14 @@ class PersonalSection implements IIconSection {
 	 * @since 9.1
 	 */
 	public function getID() {
-		return 'sharing';
+		if (
+			$this->federatedShareProvider->isIncomingServer2serverShareEnabled() ||
+			$this->federatedShareProvider->isIncomingServer2serverGroupShareEnabled()
+		) {
+			return 'sharing';
+		}
+
+		return '';
 	}
 
 	/**

--- a/apps/federatedfilesharing/templates/settings-personal.php
+++ b/apps/federatedfilesharing/templates/settings-personal.php
@@ -5,7 +5,6 @@ script('federatedfilesharing', 'settings-personal');
 style('federatedfilesharing', 'settings-personal');
 ?>
 
-<?php if ($_['outgoingServer2serverShareEnabled']): ?>
 	<div id="fileSharingSettings" class="section">
 		<h2 data-anchor-name="federated-cloud"><?php p($l->t('Federated Cloud')); ?></h2>
 		<a target="_blank" rel="noreferrer noopener" class="icon-info svg"
@@ -58,4 +57,4 @@ style('federatedfilesharing', 'settings-personal');
 		</div>
 
 	</div>
-<?php endif; ?>
+


### PR DESCRIPTION
fix https://github.com/nextcloud/server/issues/15802

If incoming federated shares are disabled by the admin we hide the whole personal share settings instead showing an empty settings page