### PR TITLE
Do not autoload built in types

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -192,7 +192,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 								ISecureRandom $random,
 								ILogger $logger,
 								EventDispatcherInterface $dispatcher,
-								$legacyEndpoint = false) {
+								bool $legacyEndpoint = false) {
 		$this->db = $db;
 		$this->principalBackend = $principalBackend;
 		$this->userManager = $userManager;

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -91,7 +91,7 @@ class Principal implements BackendInterface {
 								IUserSession $userSession,
 								IConfig $config,
 								IAppManager $appManager,
-								$principalPrefix = 'principals/users/') {
+								string $principalPrefix = 'principals/users/') {
 		$this->userManager = $userManager;
 		$this->groupManager = $groupManager;
 		$this->shareManager = $shareManager;

--- a/apps/dav/tests/unit/AppInfo/PluginManagerTest.php
+++ b/apps/dav/tests/unit/AppInfo/PluginManagerTest.php
@@ -80,12 +80,12 @@ class PluginManagerTest extends TestCase {
 
 		$server->method('query')
 			->will($this->returnValueMap([
-				['\OCA\DAV\ADavApp\PluginOne', 'dummyplugin1'],
-				['\OCA\DAV\ADavApp\PluginTwo', 'dummyplugin2'],
-				['\OCA\DAV\ADavApp\CollectionOne', 'dummycollection1'],
-				['\OCA\DAV\ADavApp\CollectionTwo', 'dummycollection2'],
-				['\OCA\DAV\ADavApp2\PluginOne', 'dummy2plugin1'],
-				['\OCA\DAV\ADavApp2\CollectionOne', 'dummy2collection1'],
+				['\OCA\DAV\ADavApp\PluginOne', true, 'dummyplugin1'],
+				['\OCA\DAV\ADavApp\PluginTwo', true, 'dummyplugin2'],
+				['\OCA\DAV\ADavApp\CollectionOne', true, 'dummycollection1'],
+				['\OCA\DAV\ADavApp\CollectionTwo', true, 'dummycollection2'],
+				['\OCA\DAV\ADavApp2\PluginOne', true, 'dummy2plugin1'],
+				['\OCA\DAV\ADavApp2\CollectionOne', true, 'dummy2collection1'],
 			]));
 
 		$expectedPlugins = [

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -374,17 +374,12 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		});
 	}
 
-	/**
-	 * @param string $name
-	 * @return mixed
-	 * @throws QueryException if the query could not be resolved
-	 */
-	public function query($name) {
+	public function query(string $name, bool $autoload = true) {
 		try {
 			return $this->queryNoFallback($name);
 		} catch (QueryException $firstException) {
 			try {
-				return $this->getServer()->query($name);
+				return $this->getServer()->query($name, $autoload);
 			} catch (QueryException $secondException) {
 				if ($firstException->getCode() === 1) {
 					throw $secondException;

--- a/lib/private/ServerContainer.php
+++ b/lib/private/ServerContainer.php
@@ -113,12 +113,7 @@ class ServerContainer extends SimpleContainer {
 		throw new QueryException();
 	}
 
-	/**
-	 * @param string $name name of the service to query for
-	 * @return mixed registered service for the given $name
-	 * @throws QueryException if the query could not be resolved
-	 */
-	public function query($name) {
+	public function query(string $name, bool $autoload = true) {
 		$name = $this->sanitizeName($name);
 
 		if (isset($this[$name])) {
@@ -147,6 +142,6 @@ class ServerContainer extends SimpleContainer {
 			}
 		}
 
-		return parent::query($name);
+		return parent::query($name, $autoload);
 	}
 }

--- a/lib/public/IContainer.php
+++ b/lib/public/IContainer.php
@@ -61,11 +61,12 @@ interface IContainer {
 	 * Look up a service for a given name in the container.
 	 *
 	 * @param string $name
+	 * @param bool $autoload Should we try to autoload the service. If we are trying to resolve built in types this makes no sense for example
 	 * @return mixed
 	 * @throws QueryException if the query could not be resolved
 	 * @since 6.0.0
 	 */
-	public function query($name);
+	public function query(string $name, bool $autoload = true);
 
 	/**
 	 * A value is stored in the container with it's corresponding name

--- a/tests/lib/Contacts/ContactsMenu/ActionProviderStoreTest.php
+++ b/tests/lib/Contacts/ContactsMenu/ActionProviderStoreTest.php
@@ -81,8 +81,8 @@ class ActionProviderStoreTest extends TestCase {
 		$this->serverContainer->expects($this->exactly(2))
 			->method('query')
 			->will($this->returnValueMap([
-					[EMailProvider::class, $provider1],
-					['OCA\Contacts\Provider1', $provider2]
+					[EMailProvider::class, true, $provider1],
+					['OCA\Contacts\Provider1', true, $provider2]
 		]));
 
 		$providers = $this->actionProviderStore->getProviders($user);
@@ -106,7 +106,7 @@ class ActionProviderStoreTest extends TestCase {
 		$this->serverContainer->expects($this->once())
 			->method('query')
 			->will($this->returnValueMap([
-					[EMailProvider::class, $provider1],
+					[EMailProvider::class, true, $provider1],
 		]));
 
 		$providers = $this->actionProviderStore->getProviders($user);


### PR DESCRIPTION
While doing some debugging I noticed that we were trying to autoload several weird things like 'principalPrefix'.

This is just an (optional) string. When properly type hinted we can skip the step of actually resolving the type and trying to autoload it.

Especially since we have quite some autoloaders listed. This shaves of some function calls