### PR TITLE
Fix full text search for groupfolders

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1928,7 +1928,7 @@ class View {
 		if ($mount) {
 			try {
 				$storage = $mount->getStorage();
-				if ($storage->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
+				if ($storage && $storage->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
 					$storage->acquireLock(
 						$mount->getInternalPath($absolutePath),
 						$type,
@@ -1969,7 +1969,7 @@ class View {
 		if ($mount) {
 			try {
 				$storage = $mount->getStorage();
-				if ($storage->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
+				if ($storage && $storage->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
 					$storage->changeLock(
 						$mount->getInternalPath($absolutePath),
 						$type,

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1430,6 +1430,9 @@ class Manager implements IManager {
 		if ($path->getId() !== $userFolder->getId() && !$userFolder->isSubNode($path)) {
 			$nodes = $userFolder->getById($path->getId());
 			$path = array_shift($nodes);
+			if ($path->getOwner() === null) {
+				return [];
+			}
 			$owner = $path->getOwner()->getUID();
 		}
 


### PR DESCRIPTION
How to reproduce:

* have a group folder
* enable full text search
* actual: the initial scan works until the group folder is scanned
* expected: initial scan of the full text search works

Fixes following error:

```
An unhandled exception has been thrown:
Error: Call to a member function getUID() on null in /var/www/nextcloud/lib/private/Share20/Manager.php:1433
Stack trace:
#0 /var/www/nextcloud/apps/files_fulltextsearch/lib/Service/LocalFilesService.php(162): OC\Share20\Manager->getAccessList(Object(OC\Files\Node\Folder), true, true)
#1 /var/www/nextcloud/apps/files_fulltextsearch/lib/Service/FilesService.php(667): OCA\Files_FullTextSearch\Service\LocalFilesService->getShareUsersFromFile(Object(OC\Files\Node\Folder), Array)
#2 /var/www/nextcloud/apps/files_fulltextsearch/lib/Service/FilesService.php(596): OCA\Files_FullTextSearch\Service\FilesService->updateShareNames(Object(OCA\Files_FullTextSearch\Model\FilesDocument), Object(OC\Files\Node\Folder))
#3 /var/www/nextcloud/apps/files_fulltextsearch/lib/Service/FilesService.php(570): OCA\Files_FullTextSearch\Service\FilesService->updateDocumentAccess(Object(OCA\Files_FullTextSearch\Model\FilesDocument), Object(OC\Files\Node\Folder))
#4 /var/www/nextcloud/apps/files_fulltextsearch/lib/Service/FilesService.php(551): OCA\Files_FullTextSearch\Service\FilesService->updateFilesDocumentFromFile(Object(OCA\Files_FullTextSearch\Model\FilesDocument), Object(OC\Files\Node\Folder))
#5 /var/www/nextcloud/apps/files_fulltextsearch/lib/Service/FilesService.php(445): OCA\Files_FullTextSearch\Service\FilesService->updateFilesDocument(Object(OCA\Files_FullTextSearch\Model\FilesDocument))
#6 /var/www/nextcloud/apps/files_fulltextsearch/lib/Provider/FilesProvider.php(246): OCA\Files_FullTextSearch\Service\FilesService->generateDocument(Object(OCA\Files_FullTextSearch\Model\FilesDocument))
#7 /var/www/nextcloud/apps/fulltextsearch/lib/Service/IndexService.php(314): OCA\Files_FullTextSearch\Provider\FilesProvider->fillIndexDocument(Object(OCA\Files_FullTextSearch\Model\FilesDocument))
#8 /var/www/nextcloud/apps/fulltextsearch/lib/Service/IndexService.php(194): OCA\FullTextSearch\Service\IndexService->indexDocuments(Object(OCA\FullTextSearch_ElasticSearch\Platform\ElasticSearchPlatform), Object(OCA\Files_FullTextSearch\Provider\FilesProvider), Array, Object(OCA\FullTextSearch\Model\IndexOptions))
#9 /var/www/nextcloud/apps/fulltextsearch/lib/Command/Index.php(408): OCA\FullTextSearch\Service\IndexService->indexProviderContentFromUser(Object(OCA\FullTextSearch_ElasticSearch\Platform\ElasticSearchPlatform), Object(OCA\Files_FullTextSearch\Provider\FilesProvider), 'ABC', Object(OCA\FullTextSearch\Model\IndexOptions))
#10 /var/www/nextcloud/apps/fulltextsearch/lib/Command/Index.php(272): OCA\FullTextSearch\Command\Index->indexProvider(Object(OCA\Files_FullTextSearch\Provider\FilesProvider), Object(OCA\FullTextSearch\Model\IndexOptions))
#11 /var/www/nextcloud/3rdparty/symfony/console/Command/Command.php(255): OCA\FullTextSearch\Command\Index->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 /var/www/nextcloud/core/Command/Base.php(166): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#13 /var/www/nextcloud/3rdparty/symfony/console/Application.php(946): OC\Core\Command\Base->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#14 /var/www/nextcloud/3rdparty/symfony/console/Application.php(248): Symfony\Component\Console\Application->doRunCommand(Object(OCA\FullTextSearch\Command\Index), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#15 /var/www/nextcloud/3rdparty/symfony/console/Application.php(148): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#16 /var/www/nextcloud/lib/private/Console/Application.php(213): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#17 /var/www/nextcloud/console.php(96): OC\Console\Application->run()
#18 /var/www/nextcloud/occ(11): require_once('/var/www/nextcl...')
#19 {main}
```

cc @daita @icewind1991 

Fix #15074 