### PR TITLE
allow non integer version ids

### DIFF
--- a/apps/files_versions/lib/Controller/PreviewController.php
+++ b/apps/files_versions/lib/Controller/PreviewController.php
@@ -95,7 +95,7 @@ class PreviewController extends Controller {
 			$user = $this->userSession->getUser();
 			$userFolder = $this->rootFolder->getUserFolder($user->getUID());
 			$file = $userFolder->get($file);
-			$versionFile = $this->versionManager->getVersionFile($user, $file, (int)$version);
+			$versionFile = $this->versionManager->getVersionFile($user, $file, $version);
 			$preview = $this->previewManager->getPreview($versionFile, $x, $y, true, IPreview::MODE_FILL, $versionFile->getMimetype());
 			return new FileDisplayResponse($preview, Http::STATUS_OK, ['Content-Type' => $preview->getMimeType()]);
 		} catch (NotFoundException $e) {

--- a/apps/files_versions/lib/Versions/IVersion.php
+++ b/apps/files_versions/lib/Versions/IVersion.php
@@ -46,10 +46,10 @@ interface IVersion {
 	/**
 	 * Get the id of the revision for the file
 	 *
-	 * @return int
+	 * @return int|string
 	 * @since 15.0.0
 	 */
-	public function getRevisionId(): int;
+	public function getRevisionId();
 
 	/**
 	 * Get the timestamp this version was created

--- a/apps/files_versions/lib/Versions/IVersionBackend.php
+++ b/apps/files_versions/lib/Versions/IVersionBackend.php
@@ -85,9 +85,9 @@ interface IVersionBackend {
 	 *
 	 * @param IUser $user
 	 * @param FileInfo $sourceFile
-	 * @param int $revision
+	 * @param int|string $revision
 	 * @return ISimpleFile
 	 * @since 15.0.0
 	 */
-	public function getVersionFile(IUser $user, FileInfo $sourceFile, int $revision): File;
+	public function getVersionFile(IUser $user, FileInfo $sourceFile, $revision): File;
 }

--- a/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
+++ b/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
@@ -113,7 +113,7 @@ class LegacyVersionsBackend implements IVersionBackend {
 		return $file->fopen('r');
 	}
 
-	public function getVersionFile(IUser $user, FileInfo $sourceFile, int $revision): File {
+	public function getVersionFile(IUser $user, FileInfo $sourceFile, $revision): File {
 		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
 		$versionFolder = $this->getVersionFolder($user);
 		/** @var File $file */

--- a/apps/files_versions/lib/Versions/Version.php
+++ b/apps/files_versions/lib/Versions/Version.php
@@ -29,7 +29,7 @@ class Version implements IVersion {
 	/** @var int */
 	private $timestamp;
 
-	/** @var int */
+	/** @var int|string */
 	private $revisionId;
 
 	/** @var string */
@@ -55,7 +55,7 @@ class Version implements IVersion {
 
 	public function __construct(
 		int $timestamp,
-		int $revisionId,
+		$revisionId,
 		string $name,
 		int $size,
 		string $mimetype,
@@ -83,7 +83,7 @@ class Version implements IVersion {
 		return $this->sourceFileInfo;
 	}
 
-	public function getRevisionId(): int {
+	public function getRevisionId() {
 		return $this->revisionId;
 	}
 

--- a/apps/files_versions/lib/Versions/VersionManager.php
+++ b/apps/files_versions/lib/Versions/VersionManager.php
@@ -98,7 +98,7 @@ class VersionManager implements IVersionManager {
 		return $backend->read($version);
 	}
 
-	public function getVersionFile(IUser $user, FileInfo $sourceFile, int $revision): File {
+	public function getVersionFile(IUser $user, FileInfo $sourceFile, $revision): File {
 		$backend = $this->getBackendForStorage($sourceFile->getStorage());
 		return $backend->getVersionFile($user, $sourceFile, $revision);
 	}


### PR DESCRIPTION
currently version ids are timestamps, but for storage provided versions
this is not always the case and they might be strings

Signed-off-by: Robin Appelman <robin@icewind.nl>