### PR TITLE
Properly theme folder icons that are accessed though imagePath

### DIFF
--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -349,6 +349,9 @@ class ThemingDefaults extends \OC_Defaults {
 			} catch (AppPathNotFoundException $e) {}
 			return $this->urlGenerator->linkToRoute('theming.Theming.getManifest') . '?v=' . $cacheBusterValue;
 		}
+		if (strpos($image, 'filetypes/') === 0) {
+			return $this->urlGenerator->linkToRoute('theming.Icon.getThemedIcon', ['app' => $app, 'image' => $image]);
+		}
 		return false;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/activity/issues/296

The activity app is using the IMimeTypeDetector, so to make sure folder icons from there are themed as well, this PR adds a rule to replace imagePath calls matching `filetypes/folder` in the image path.

