### PR TITLE
handle storage exceptions when trying to set mtime

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -566,7 +566,12 @@ class View {
 			$hooks[] = 'create';
 			$hooks[] = 'write';
 		}
-		$result = $this->basicOperation('touch', $path, $hooks, $mtime);
+		try {
+			$result = $this->basicOperation('touch', $path, $hooks, $mtime);
+		} catch (\Exception $e) {
+			$this->logger->logException($e, ['level' => ILogger::INFO, 'message' => 'Error while setting modified time']);
+			$result = false;
+		}
 		if (!$result) {
 			// If create file fails because of permissions on external storage like SMB folders,
 			// check file exists and return false if not.

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -1962,6 +1962,9 @@ class ViewTest extends \Test\TestCase {
 		$operationArgs,
 		$path
 	) {
+		if ($operation === 'touch') {
+			$this->markTestSkipped("touch handles storage exceptions internally");
+		}
 		$view = new View('/' . $this->user . '/files/');
 
 		/** @var Temporary|\PHPUnit_Framework_MockObject_MockObject $storage */


### PR DESCRIPTION
not all storage backends can handle setting the mtime and they might
not always handle that error correctly.

Signed-off-by: Robin Appelman <robin@icewind.nl>