### PR TITLE
Temporary fix for project translations

### DIFF
--- a/core/src/OCP/collaboration.js
+++ b/core/src/OCP/collaboration.js
@@ -34,16 +34,21 @@ let types = {};
 
 /**
  * Those translations will be used by the vue component but they should be shipped with the server
- * t('core', 'Add to a project')
- * t('core', 'Show details')
- * t('core', 'Hide details')
- * t('core', 'Rename project')
- * t('core', 'Failed to rename the project')
- * t('core', 'Failed to create a project')
- * t('core', 'Failed to add the item to the project')
- * t('core', 'Connect items to a project to make them easier to find')
- * t('core', 'Type to search for existing projects')
+ * FIXME: Those translations should be added to the library
  */
+const l10nProjects = () => {
+	return [
+		t('core', 'Add to a project'),
+		t('core', 'Show details'),
+		t('core', 'Hide details'),
+		t('core', 'Rename project'),
+		t('core', 'Failed to rename the project'),
+		t('core', 'Failed to create a project'),
+		t('core', 'Failed to add the item to the project'),
+		t('core', 'Connect items to a project to make them easier to find'),
+		t('core', 'Type to search for existing projects')
+	];
+}
 
 export default {
 	/**


### PR DESCRIPTION
This is a temporary fix to let our translation extractor take the project related strings into consideration. 

Ideally the translations should be included in the library (as described in https://github.com/juliushaertl/nextcloud-vue-collections/issues/120) but this requires some deeper work on the l10n handling. Since we need to either make the library use the Nextcloud language to load the matching translations or somehow make the server extract the strings from the library and append it to the existing translations during the webpack build.