### PR TITLE
Fix missing login hook wih Apache/SAML login

### DIFF
--- a/lib/private/legacy/user.php
+++ b/lib/private/legacy/user.php
@@ -181,7 +181,15 @@ class OC_User {
 				// completed before we can safely create the users folder.
 				// For example encryption needs to initialize the users keys first
 				// before we can create the user folder with the skeleton files
-				OC_Hook::emit("OC_User", "post_login", array("uid" => $uid, 'password' => ''));
+				OC_Hook::emit(
+					'OC_User',
+					'post_login',
+					[
+						'uid' => $uid,
+						'password' => '',
+						'isTokenLogin' => false,
+					]
+				);
 				//trigger creation of user home and /files folder
 				\OC::$server->getUserFolder($uid);
 			}


### PR DESCRIPTION
Without this patch the hook does not transport the information whether the login is
done with an app password or not. The suspicious login app requires the parameter
to function correctly, hence adding it will make suspicious login detection also possible
with SAML users.

Ref https://github.com/nextcloud/suspicious_login/blob/e1110df7b7cb4cc89357c0e20306c39143950c4b/lib/Listener/LoginListener.php#L64-L66