### PR TITLE
Add extendedSupport to Subscription

### DIFF
--- a/core/Controller/OCSController.php
+++ b/core/Controller/OCSController.php
@@ -97,6 +97,7 @@ class OCSController extends \OCP\AppFramework\OCSController {
 			'micro' => $micro,
 			'string' => \OC_Util::getVersionString(),
 			'edition' => '',
+			'extendedSupport' => \OCP\Util::hasExtendedSupport()
 		);
 
 		if($this->userSession->isLoggedIn()) {

--- a/lib/private/Support/Subscription/Registry.php
+++ b/lib/private/Support/Subscription/Registry.php
@@ -72,4 +72,16 @@ class Registry implements IRegistry {
 		}
 		return false;
 	}
+
+	/**
+	 * Indicates if the subscription has extended support
+	 *
+	 * @since 17.0.0
+	 */
+	public function delegateHasExtendedSupport(): bool {
+		if ($this->subscription instanceof ISubscription && method_exists($this->subscription, 'hasExtendedSupport')) {
+			return $this->subscription->hasExtendedSupport();
+		}
+		return false;
+	}
 }

--- a/lib/public/Support/Subscription/IRegistry.php
+++ b/lib/public/Support/Subscription/IRegistry.php
@@ -54,4 +54,11 @@ interface IRegistry {
 	 * @since 17.0.0
 	 */
 	public function delegateHasValidSubscription(): bool;
+
+	/**
+	 * Indicates if the subscription has extended support
+	 *
+	 * @since 17.0.0
+	 */
+	public function delegateHasExtendedSupport(): bool;
 }

--- a/lib/public/Support/Subscription/ISubscription.php
+++ b/lib/public/Support/Subscription/ISubscription.php
@@ -34,4 +34,11 @@ interface ISubscription {
 	 * @since 17.0.0
 	 */
 	public function hasValidSubscription(): bool;
+
+	/**
+	 * Indicates if the subscription has extended support
+	 *
+	 * @since 17.0.0
+	 */
+	public function hasExtendedSupport(): bool;
 }

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -89,7 +89,19 @@ class Util {
 	public static function getVersion() {
 		return \OC_Util::getVersion();
 	}
-	
+
+	/**
+	 * @since 17.0.0
+	 */
+	public static function hasExtendedSupport(): bool {
+		try {
+			/** @var \OCP\Support\Subscription\IRegistry */
+			$subscriptionRegistry = \OC::$server->query(\OCP\Support\Subscription\IRegistry::class);
+			return $subscriptionRegistry->delegateHasExtendedSupport();
+		} catch (AppFramework\QueryException $e) {}
+		return \OC::$server->getConfig()->getSystemValueBool('extendedSupport', false);
+	}
+
 	/**
 	 * Set current update channel
 	 * @param string $channel
@@ -98,7 +110,7 @@ class Util {
 	public static function setChannel($channel) {
 		\OC::$server->getConfig()->setSystemValue('updater.release.channel', $channel);
 	}
-	
+
 	/**
 	 * Get current update channel
 	 * @return string
@@ -501,7 +513,7 @@ class Util {
 	public static function needUpgrade() {
 		if (!isset(self::$needUpgradeCache)) {
 			self::$needUpgradeCache=\OC_Util::needUpgrade(\OC::$server->getSystemConfig());
-		}		
+		}
 		return self::$needUpgradeCache;
 	}
 

--- a/status.php
+++ b/status.php
@@ -42,14 +42,16 @@ try {
 	# see core/lib/private/legacy/defaults.php and core/themes/example/defaults.php
 	# for description and defaults
 	$defaults = new \OCP\Defaults();
-	$values=array(
+	$values = [
 		'installed'=>$installed,
 		'maintenance' => $maintenance,
 		'needsDbUpgrade' => \OCP\Util::needUpgrade(),
 		'version'=>implode('.', \OCP\Util::getVersion()),
 		'versionstring'=>OC_Util::getVersionString(),
 		'edition'=> '',
-		'productname'=>$defaults->getName());
+		'productname'=>$defaults->getName(),
+		'extendedSupport' => \OCP\Util::hasExtendedSupport()
+	];
 	if (OC::$CLI) {
 		print_r($values);
 	} else {

--- a/tests/Core/Controller/OCSControllerTest.php
+++ b/tests/Core/Controller/OCSControllerTest.php
@@ -97,6 +97,7 @@ class OCSControllerTest extends TestCase {
 			'micro' => $micro,
 			'string' => \OC_Util::getVersionString(),
 			'edition' => '',
+			'extendedSupport' => false
 		);
 
 		$capabilities = [
@@ -128,6 +129,7 @@ class OCSControllerTest extends TestCase {
 			'micro' => $micro,
 			'string' => \OC_Util::getVersionString(),
 			'edition' => '',
+			'extendedSupport' => false
 		);
 
 		$capabilities = [

--- a/tests/lib/Support/Subscription/RegistryTest.php
+++ b/tests/lib/Support/Subscription/RegistryTest.php
@@ -74,6 +74,18 @@ class RegistryTest extends TestCase {
 		$this->assertSame(true, $this->registry->delegateHasValidSubscription());
 	}
 
+	public function testDelegateHasExtendedSupport() {
+		/* @var ISubscription|\PHPUnit_Framework_MockObject_MockObject $subscription */
+		$subscription = $this->createMock(ISubscription::class);
+		$subscription->expects($this->once())
+			->method('hasExtendedSupport')
+			->willReturn(true);
+		$this->registry->register($subscription);
+
+		$this->assertSame(true, $this->registry->delegateHasExtendedSupport());
+	}
+
+
 	public function testDelegateGetSupportedApps() {
 		/* @var ISupportedApps|\PHPUnit_Framework_MockObject_MockObject $subscription */
 		$subscription = $this->createMock(ISupportedApps::class);


### PR DESCRIPTION
Adding the option to expose if extended support is contained in the subscription.

This can also be backported without the support-app dependency to just fetch the value from the system config.