### PR TITLE
Add documentation to config.php for share_folder

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1439,6 +1439,7 @@ $CONFIG = array(
 
 /**
  * Define a default folder for shared files and folders other than root.
+ * Changes to this value will only have effect on new shares.
  *
  * Defaults to ``/``
  */


### PR DESCRIPTION
Fix #9726

From original issue:
> Changes to this value will only have effect on new shares. Existing shares are listed in the share_folder valid at the time of the creation of the share.

I felt like the `Existing shares are listed in the share_folder valid at the time of the creation of the share` part is not very clear, anyone knows what it means?