### PR TITLE
30 issues per run on stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -27,7 +27,7 @@ markComment: >
   for your contributions.
 
 # Limit the number of actions per hour, from 1-30. Default is 30
-limitPerRun: 1
+limitPerRun: 30
 
 # Limit to only `issues` or `pulls`
 only: issues


### PR DESCRIPTION
Now that we use a fixed branch for the bot, and since I removed all the untagged stale issues we can go back to full thrust

https://github.com/nextcloud/server/issues?page=1&q=is%3Aissue+sort%3Aupdated-desc+is%3Aopen+label%3Astale+-label%3A%22needs+info%22+-label%3A%220.+Needs+triage%22+-label%3A%221.+to+develop%22+-label%3A%223.+to+review%22&utf8=%E2%9C%93

