### PR TITLE
Fix download entry shown on public share menu when not in mobile

### DIFF
--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -195,7 +195,7 @@ thead {
 
 // hide the download entry on the menu
 // on public share when NOT on mobile
-@media only screen and (min-width: $mobile_breakpoint + 1) {
+@media only screen and (min-width: $breakpoint-mobile + 1) {
 	#body-public {
 		.header-right {
 			#header-actions-menu {

--- a/tests/acceptance/features/bootstrap/PublicShareContext.php
+++ b/tests/acceptance/features/bootstrap/PublicShareContext.php
@@ -202,11 +202,14 @@ class PublicShareContext implements Context, ActorAwareInterface {
 		// download item should not be shown in the menu (although it will be in
 		// the DOM).
 		PHPUnit_Framework_Assert::assertFalse(
-				$this->actor->find(self::downloadItemInShareMenu())->isVisible());
+				$this->actor->find(self::downloadItemInShareMenu())->isVisible(),
+				"Download item in share menu is visible");
 		PHPUnit_Framework_Assert::assertTrue(
-				$this->actor->find(self::directLinkItemInShareMenu())->isVisible());
+				$this->actor->find(self::directLinkItemInShareMenu())->isVisible(),
+				"Direct link item in share menu is not visible");
 		PHPUnit_Framework_Assert::assertTrue(
-				$this->actor->find(self::saveItemInShareMenu())->isVisible());
+				$this->actor->find(self::saveItemInShareMenu())->isVisible(),
+				"Save item in share menu is not visible");
 	}
 
 	/**


### PR DESCRIPTION
This fixes a regression introduced in #15199 due to a typo in the variable name.

I have also added messages to `assertFalse/assertTrue` in the related acceptance tests (as [thanks to them](https://drone.nextcloud.com/nextcloud/server/19021/69/4) is how I found the issue ;-) ) to make the failures more descriptive.
