### PR TITLE
Adjust acceptance tests to notifications based on toastify

### DIFF
--- a/tests/acceptance/features/bootstrap/NotificationContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationContext.php
@@ -31,7 +31,7 @@ class NotificationContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function notificationMessage($message) {
-		return Locator::forThe()->xpath("//*[@class = 'row' and normalize-space() = '$message']")->
+		return Locator::forThe()->xpath("//*[contains(concat(' ', normalize-space(@class), ' '), ' toastify ') and normalize-space(text()) = '$message']")->
 				descendantOf(self::notificationContainer())->
 				describedAs("$message notification");
 	}
@@ -40,7 +40,7 @@ class NotificationContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	private static function notificationContainer() {
-		return Locator::forThe()->id("notification-container")->
+		return Locator::forThe()->id("content")->
 				describedAs("Notification container");
 	}
 


### PR DESCRIPTION
Follow up to #15124

Note that notifications are not checked in any of the acceptance tests of the server, although [they are in Talk](https://github.com/nextcloud/spreed/blob/afc9a54633887301b8f00b3b8c8e7c0fb1f1831b/tests/acceptance/features/conversation.feature#L106). The failure in the acceptance tests in Drone is unrelated to this change and [it is fixed in a different pull request](https://github.com/nextcloud/server/pull/15937).

