### PR TITLE
Fix appid argument for integrity:check-app

### DIFF
--- a/core/Command/Integrity/CheckApp.php
+++ b/core/Command/Integrity/CheckApp.php
@@ -45,7 +45,7 @@ class CheckApp extends Base {
 		parent::__construct();
 		$this->checker = $checker;
 	}
-	
+
 	/**
 	 * {@inheritdoc }
 	 */
@@ -54,7 +54,7 @@ class CheckApp extends Base {
 		$this
 			->setName('integrity:check-app')
 			->setDescription('Check integrity of an app using a signature.')
-			->addArgument('appid', null, InputArgument::REQUIRED, 'Application to check')
+			->addArgument('appid', InputArgument::REQUIRED, 'Application to check')
 			->addOption('path', null, InputOption::VALUE_OPTIONAL, 'Path to application. If none is given it will be guessed.');
 	}
 


### PR DESCRIPTION
Unlike options, arguments don't have a shortcut, so the parameter order is:
`name`, `mode`, `description`, `default`.