### PR TITLE
cache the displayname after an LDAP plugin set it

### DIFF
--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -506,7 +506,9 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 	 */
 	public function setDisplayName($uid, $displayName) {
 		if ($this->userPluginManager->implementsActions(Backend::SET_DISPLAYNAME)) {
-			return $this->userPluginManager->setDisplayName($uid, $displayName);
+			$this->userPluginManager->setDisplayName($uid, $displayName);
+			$this->access->cacheUserDisplayName($uid, $displayName);
+			return $displayName;
 		}
 		return false;
 	}


### PR DESCRIPTION
When you have an LDAP plugin that would write the displayname, in the current state the cache would not be updated. Thus, a refresh will still show the old name, this is confusing. That's solved now.