### PR TITLE
Properly load permissions in showActions

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1803,7 +1803,7 @@
 		 * @return permission value as integer
 		 */
 		getDirectoryPermissions: function() {
-			return parseInt(this.$el.find('#permissions').val(), 10);
+			return this && this.dirInfo && this.dirInfo.permissions ? this.dirInfo.permissions : parseInt(this.$el.find('#permissions').val(), 10);
 		},
 		/**
 		 * Changes the current directory and reload the file list.


### PR DESCRIPTION
When setViewerMode(false) is called, the permissions should be fetched from the available dirInfo, otherwise creating a file is not possible.

Fixes https://github.com/nextcloud/server/issues/16238

Steps to reproduce:
- Open a pdf file
- Close the pdf file
- Check for the create a new file button