### PR TITLE
Avoid scrolling to the hidden input when toggling grid/list view

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -1079,6 +1079,10 @@ table.dragshadow td.size {
 		opacity: 1;
 	}
 }
+/* Make sure the hidden input is not rendered at all to avoid scrolling to top */
+#showgridview {
+	display: none;
+}
 
 /* Adjustments for link share page */
 #body-public {


### PR DESCRIPTION
Steps to reproduce:
- Have a folder with many files
- Scroll to the bottom
- Switch between grid/list view

Expected behavior:
- The scroll position remains

Actual behavior:
- The browser scrolls back to the top

Fixes #16002