### PR TITLE
Fix window scroll container

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -3523,9 +3523,9 @@
 			var _this = this;
 			var $scrollContainer = this.$container;
 			if ($scrollContainer[0] === window) {
-				// need to use "body" to animate scrolling
+				// need to use "html" to animate scrolling
 				// when the scroll container is the window
-				$scrollContainer = $('body');
+				$scrollContainer = $('html');
 			}
 			$scrollContainer.animate({
 				// Scrolling to the top of the new element


### PR DESCRIPTION
Fix scrolling to the file in the list if it is out of view.

To test:
- Have a file that is hidden and requires scrolling to reveal
- Click that in the recommendations list or call `OCA.Files.App.fileList.scrollTo('todo.md')` in the console