### PR TITLE
(LDAP) API: return one base properly when multiple are configured

### DIFF
--- a/apps/user_ldap/lib/ILDAPUserPlugin.php
+++ b/apps/user_ldap/lib/ILDAPUserPlugin.php
@@ -40,7 +40,7 @@ interface ILDAPUserPlugin {
 	 *
 	 * @param string $uid The UID of the user to create
 	 * @param string $password The password of the new user
-	 * @return bool
+	 * @return bool|string
 	 */
 	public function createUser($uid, $password);
 


### PR DESCRIPTION
* reading the config directly will return the value with line breaks
* using the proper accessor gives us all bases in an array
* returns the first matching one
* having user id provided for the group base is strange and does not let
  us operate like this. here we return the first one. might change in
  future, a backportable fix won't have an API change however.