### PR TITLE
Forward OCSException to initiator

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -317,13 +317,20 @@ class UsersController extends AUserData {
 
 			return new DataResponse();
 
-		} catch (HintException $e ) {
+		} catch (HintException $e) {
 			$this->logger->logException($e, [
 				'message' => 'Failed addUser attempt with hint exception.',
 				'level' => ILogger::WARN,
 				'app' => 'ocs_api',
 			]);
 			throw new OCSException($e->getHint(), 107);
+		} catch (OCSException $e) {
+			$this->logger->logException($e, [
+				'message' => 'Failed addUser attempt with ocs exeption.',
+				'level' => ILogger::ERROR,
+				'app' => 'ocs_api',
+			]);
+			throw $e;
 		} catch (\Exception $e) {
 			$this->logger->logException($e, [
 				'message' => 'Failed addUser attempt with exception.',


### PR DESCRIPTION
Fix #15944 


### Before this patch
```xml
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>failure</status>
  <statuscode>101</statuscode>
  <message>Bad request</message>
  <totalitems></totalitems>
  <itemsperpage></itemsperpage>
 </meta>
 <data/>
</ocs>
```

### After this patch
```xml
<?xml version="1.0"?>
<ocs>
 <meta>
  <statuscode>109</statuscode>
  <message>Unable to send the invitation mail</message>
  <totalitems></totalitems>
  <itemsperpage></itemsperpage>
 </meta>
 <data/>
</ocs>
```