### PR TITLE
fix LDAP Wizard forgetting groups on select with search

### DIFF
--- a/apps/user_ldap/js/wizard/wizardFilterOnType.js
+++ b/apps/user_ldap/js/wizard/wizardFilterOnType.js
@@ -21,7 +21,6 @@ OCA = OCA || {};
 		init: function($select, $textInput) {
 			this.$select = $select;
 			this.$textInput = $textInput;
-			this.updateOptions();
 			this.lastSearch = '';
 
 			var fity = this;
@@ -36,22 +35,6 @@ OCA = OCA || {};
 		},
 
 		/**
-		 * the options will be read in again. Should be called after a
-		 * configuration switch.
-		 */
-		updateOptions: function() {
-			var options = [];
-			this.$select.find('option').each(function() {
-				options.push({
-						value: $(this).val(),
-						normalized: $(this).val().toLowerCase()
-					}
-				);
-			});
-			this._options = options;
-		},
-
-		/**
 		 * the actual search or filter method
 		 *
 		 * @param {FilterOnType} fity
@@ -62,10 +45,12 @@ OCA = OCA || {};
 				return;
 			}
 			fity.lastSearch = filterVal;
-			fity.$select.empty();
-			$.each(fity._options, function() {
-				if(!filterVal || this.normalized.indexOf(filterVal) > -1) {
-					fity.$select.append($('<option>').val(this.value).text(this.value));
+
+			fity.$select.find('option').each(function() {
+				if(!filterVal || $(this).val().toLowerCase().indexOf(filterVal) > -1) {
+					$(this).removeAttr('hidden')
+				} else {
+					$(this).attr('hidden', 'hidden');
 				}
 			});
 			delete(fity.runID);

--- a/apps/user_ldap/js/wizard/wizardTabGeneric.js
+++ b/apps/user_ldap/js/wizard/wizardTabGeneric.js
@@ -228,10 +228,12 @@ OCA = OCA || {};
 		 * @param {Array} options
 		 */
 		equipMultiSelect: function($element, options) {
-			$element.empty();
-			for (var i in options) {
-				var name = options[i];
-				$element.append($('<option>').val(name).text(name).attr('title', name));
+			if($element.find('option').length === 0) {
+				$element.empty();
+				for (var i in options) {
+					var name = options[i];
+					$element.append($('<option>').val(name).text(name).attr('title', name));
+				}
 			}
 			if(!$element.hasClass('ldapGroupList')) {
 				$element.multiselect('refresh');


### PR DESCRIPTION
When you have more than 40 groups, the LDAP wizard shows a different group selection utility to better cope with long lists. It can be searched too. Sadly, when a filtered selection was done and added, the previously selected groups were forgotten. See following recordings

The bug:

https://cloud.nextcloud.com/s/555t9EkAe9j9G2y

(You also notice that the left box is not properly populated again)


And resolved:

https://cloud.nextcloud.com/s/aKXxZHwdybypBN9


What I love about the fix is that it works much better with less LOCs :)








