### PR TITLE
Use theme colors for text selection

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -159,6 +159,14 @@ body {
 	border-radius: var(--border-radius);
 }
 
+/* SELECTION */
+
+::selection {
+	background-color: var(--color-primary-element);
+	color: var(--color-primary-text);
+}
+
+
 /* CONTENT ------------------------------------------------------------------ */
 
 #controls {


### PR DESCRIPTION
Currently the text selection is just the default browser color, which is kinda similar to the Nextcloud blue so that’s why it never looked off. ;)
![theming current](https://user-images.githubusercontent.com/925062/59930427-28382a80-9443-11e9-87c3-29a77da520ae.png)


Now it looks much better when themed too. This is especially the case for text-heavy apps like Mail or Notes. :)

![selection themed](https://user-images.githubusercontent.com/925062/59930426-28382a80-9443-11e9-9fe1-737e08abc99e.png)

![selection themed 2](https://user-images.githubusercontent.com/925062/59930425-28382a80-9443-11e9-95ac-3b058f1b4c4a.png)

(Note that the selection color is not 100% the same color but it’s made a bit lighter by the browser for some reason. Just in case you check via color picker. ;)

Please review @juliushaertl @skjnldsv @korelstar 