### PR TITLE
Hide quota bar if unlimited quota

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -227,7 +227,7 @@ class ViewController extends Controller {
 
 		$nav->assign('navigationItems', $navItems);
 
-		$nav->assign('usage', \OC_Helper::humanFileSize($storageInfo['used']));
+		$nav->assign('usage', \OC_Helper::humanFileSize(ceil($storageInfo['used'] / 102400) * 102400));
 		if ($storageInfo['quota'] === \OCP\Files\FileInfo::SPACE_UNLIMITED) {
 			$totalSpace = $this->l10n->t('Unlimited');
 		} else {

--- a/apps/files/templates/appnavigation.php
+++ b/apps/files/templates/appnavigation.php
@@ -17,9 +17,9 @@
 			</li>
 		<?php else: ?>
 			<li id="quota" class="has-tooltip pinned <?php p($pinned === 0 ? 'first-pinned ' : '') ?>"
-				title="<?php p($_['usage_relative'] . '%, '); p($l->t('%s of %s used', [$_['usage'], $_['total_space']])); ?>">
+				title="<?php p($l->t('%s (%s%%) of %s used', [$_['usage'], $_['usage_relative'], $_['total_space']])); ?>">
 				<a href="#" class="icon-quota svg">
-					<p id="quotatext"><?php p($l->t('%1$s%% of %2$s used', [round($_['usage_relative'], 1), $_['total_space']])); ?></p>
+					<p id="quotatext"><?php p($l->t('%1$s of %2$s used', [$_['usage'], $_['total_space']])); ?></p>
 					<div class="quota-container">
 						<progress value="<?php p($_['usage_relative']); ?>" max="100" class="<?= ($_['usage_relative'] > 80) ? 'warn' : '' ?>"></progress>
 					</div>

--- a/apps/files/templates/appnavigation.php
+++ b/apps/files/templates/appnavigation.php
@@ -9,26 +9,23 @@
 		}
 		?>
 
-		<li id="quota"
-			class="pinned <?php p($pinned === 0 ? 'first-pinned ' : '') ?><?php
-			if ($_['quota'] !== \OCP\Files\FileInfo::SPACE_UNLIMITED) {
-			?>has-tooltip" title="<?php p($_['usage_relative'] . '%, ');
-			p($l->t('%s of %s used', [$_['usage'], $_['total_space']]));
-		} ?>">
-			<a href="#" class="icon-quota svg">
-				<p id="quotatext"><?php
-					if ($_['quota'] !== \OCP\Files\FileInfo::SPACE_UNLIMITED) {
-						p($l->t('%1$s%% of %2$s used', [round($_['usage_relative'], 1), $_['total_space']]));
-					} else {
-						p($l->t('%s used', [$_['usage']]));
-					} ?></p>
-				<div class="quota-container">
-					<progress value="<?php p($_['usage_relative']); ?>"
-							  max="100"
-						<?php if ($_['usage_relative'] > 80): ?> class="warn" <?php endif; ?>></progress>
-				</div>
-			</a>
-		</li>
+		<?php if($_['quota'] === \OCP\Files\FileInfo::SPACE_UNLIMITED): ?>
+			<li id="quota" class="pinned <?php p($pinned === 0 ? 'first-pinned ' : '') ?>">
+				<a href="#" class="icon-quota svg">
+					<p><?php p($l->t('%s used', [$_['usage']])); ?></p>
+				</a>
+			</li>
+		<?php else: ?>
+			<li id="quota" class="has-tooltip pinned <?php p($pinned === 0 ? 'first-pinned ' : '') ?>"
+				title="<?php p($_['usage_relative'] . '%, '); p($l->t('%s of %s used', [$_['usage'], $_['total_space']])); ?>">
+				<a href="#" class="icon-quota svg">
+					<p id="quotatext"><?php p($l->t('%1$s%% of %2$s used', [round($_['usage_relative'], 1), $_['total_space']])); ?></p>
+					<div class="quota-container">
+						<progress value="<?php p($_['usage_relative']); ?>" max="100" class="<?= ($_['usage_relative'] > 80) ? 'warn' : '' ?>"></progress>
+					</div>
+				</a>
+			</li>
+		<?php endif; ?>
 	</ul>
 	<div id="app-settings">
 		<div id="app-settings-header">

--- a/apps/files/templates/appnavigation.php
+++ b/apps/files/templates/appnavigation.php
@@ -17,7 +17,7 @@
 			</li>
 		<?php else: ?>
 			<li id="quota" class="has-tooltip pinned <?php p($pinned === 0 ? 'first-pinned ' : '') ?>"
-				title="<?php p($l->t('%s (%s%%) of %s used', [$_['usage'], $_['usage_relative'], $_['total_space']])); ?>">
+				title="<?php p($l->t('%s%% of %s used', [$_['usage_relative'], $_['total_space']])); ?>">
 				<a href="#" class="icon-quota svg">
 					<p id="quotatext"><?php p($l->t('%1$s of %2$s used', [$_['usage'], $_['total_space']])); ?></p>
 					<div class="quota-container">


### PR DESCRIPTION
**Quota**
![image](https://user-images.githubusercontent.com/3902676/60045319-e5858500-96c4-11e9-8375-80f029b8b4df.png)


**Unlimited Quota**
![image](https://user-images.githubusercontent.com/3902676/60045373-077f0780-96c5-11e9-9013-6af1cee14eb7.png)


I would like to propose two further changes:

- ~Remove the progress bar because it looks much cleaner without.~
- ~Change 3,3% of 5 GB to 169,9 MB of 5 GB used because its much easier to understand~