### PR TITLE
Fix size of header menus

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -114,7 +114,7 @@
 		#apps > ul,
 		&.settings-menu > ul {
 			max-height: calc(100vh - #{$header-height});
-			overflow: scroll;
+			overflow-y: scroll;
 
 			li {
 				a {

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -87,10 +87,12 @@
 		z-index: 2000;
 		position: absolute;
 		max-width: 350px;
-		max-height: $header-menu-entry-height * 7.5; // half entry
+		min-height: calc(44px * 1.5); // show at least 1.5 entries
+		max-height: calc(100vh - #{$header-height} * 2);
 		right: 5px; // relative to parent
 		top: $header-height;
 		margin: 0;
+		overflow-y: scroll;
 		-webkit-overflow-scrolling: touch;
 
 		&:not(.popovermenu) {
@@ -112,10 +114,7 @@
 
 		/* Use by the apps menu and the settings right menu */
 		#apps > ul,
-		&.settings-menu > ul {
-			max-height: calc(100vh - #{$header-height});
-			overflow-y: scroll;
-
+		&.settings-menu {
 			li {
 				a {
 					display: inline-flex;
@@ -319,13 +318,6 @@ nav[role='navigation'] {
 	.in-header {
 		display: none;
 	}
-}
-
-#apps {
-	max-height: inherit;
-	overflow-x: hidden;
-	overflow-y: auto;
-	-webkit-overflow-scrolling: touch;
 }
 
 /* USER MENU -----------------------------------------------------------------*/

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -113,6 +113,9 @@
 		/* Use by the apps menu and the settings right menu */
 		#apps > ul,
 		&.settings-menu > ul {
+			max-height: calc(100vh - #{$header-height});
+			overflow: scroll;
+
 			li {
 				a {
 					display: inline-flex;


### PR DESCRIPTION
Header menus that are bigger than the screen height will now be scrollable:
![image](https://user-images.githubusercontent.com/3404133/60018048-860a8380-968a-11e9-85ed-10fbc680e693.png)

Fixes https://github.com/nextcloud/external/issues/140

The height is limited here https://github.com/nextcloud/server/blob/da7bed1aeeb8a587e6ee760107e872098f7667c4/core/css/header.scss#L91 but I think we should keep this limit since it avoids having lengthy menu bars.