### PR TITLE
Could not resolve icon for text/plain

### DIFF
--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -203,7 +203,7 @@ class URLGenerator implements IURLGenerator {
 		} elseif (!file_exists(\OC::$SERVERROOT . "/themes/$theme/core/img/$basename.svg")
 			&& file_exists(\OC::$SERVERROOT . "/themes/$theme/core/img/$basename.png")) {
 			$path =  \OC::$WEBROOT . "/themes/$theme/core/img/$basename.png";
-		} elseif($themingEnabled && $themingImagePath) {
+		} elseif($themingEnabled && $themingImagePath && file_exists(\OC::$SERVERROOT . $themingImagePath)) {
 			$path = $themingImagePath;
 		} elseif ($appPath && file_exists($appPath . "/img/$image")) {
 			$path =  \OC_App::getAppWebPath($app) . "/img/$image";


### PR DESCRIPTION
![Screenshot from 2019-06-24 14-28-58](https://user-images.githubusercontent.com/3902676/60019094-53ae5580-968d-11e9-976d-04575308d98f.png)

```
<div class="activity-previews">
    <a href="https://nextcloud.test/apps/files/?dir=/&amp;scrollto=nextcloud-16.0.1.zip.d1561324636&amp;view=trashbin">
        <img class="preview preview-mimetype-icon" src="https://nextcloud.test/apps/theming/img/core/filetypes/text-plain.svg" alt="Open file">
    </a>
</div>
```

Icon `apps/theming/img/core/filetypes/text-plain.svg` does not exist. There should be a fallback to `plain.svg` but `imagePath` does not check if the icon exists. I'm not sure about this change because this icon resolve logic is rather complex and there might be something broken on my setup ...
