### PR TITLE
14.0.13 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(14, 0, 12, 0);
+$OC_Version = array(14, 0, 13, 0);
 
 // The human readable string
-$OC_VersionString = '14.0.12';
+$OC_VersionString = '14.0.13 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #15630 Update CRL due to revoked cookbook.crt
* #15756 Also allow dragging below the file list
* #15862 Don't notify admins if no potentially over exposing links found
* #16031 Prevent faulty logs from nested setupFS calls
* #16094 Check if uploading to lookup server is enabled before verifying
* #16096 Fall back to black for non-color values
* #16130 Verify that paths are valid for recursive local move
* #16135 Don't allow to disable encryption via the API
* [gallery#531](https://github.com/nextcloud/gallery/pull/531) Correctly show errors when setting the password


Pending PRs:

* [x] #16143 [stabel 14] Better check reshare permissions
* [x] [files_pdfviewer#143](https://github.com/nextcloud/files_pdfviewer/pull/143) Fix load of character maps