### PR TITLE
15.0.9 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(15, 0, 8, 1);
+$OC_Version = array(15, 0, 9, 0);
 
 // The human readable string
-$OC_VersionString = '15.0.8';
+$OC_VersionString = '15.0.9 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #15555 Update ca bundle checker
* #15572 Update ca bundle
* #15576 User management/subadmin: rephrase ambiguous error message
* #15629 Update CRL due to revoked cookbook.crt
* #15650 Only show sharing section if it has content
* #15687 Allow redis cluster to use password
* #15725 Check the actual status code for 204 and 304
* #15726 [Security] Bump tar from 2.2.1 to 2.2.2 in /settings
* #15727 [Security] Bump tar from 2.2.1 to 2.2.2 in /build
* #15755 Also allow dragging below the file list
* #15771 Check for free space on touch
* #15800 Search files by id in shared storages last
* #15818 [Security] Bump axios from 0.18.0 to 0.19.0 in /apps/accessibility
* #15855 Hide newFile menu if quota is set to 0B
* #15861 Don't notify admins if no potentially over exposing links found
* #15927 Show share settings only if incoming federated shares are allowed
* #15985 Add LDAP integr. test for receiving share candidates with group limitation
* #16030 Prevent faulty logs from nested setupFS calls
* #16052 Fix LDAP Wizard forgetting groups on select with search
* #16081 Fix appid argument for integrity:check-app
* #16083 Fix full text search for groupfolders
* #16090 Fall back to black for non-color values
* #16092 Check if uploading to lookup server is enabled before verifying
* #16110 LDAP) API: return one base properly when multiple are configured
* #16113 Invalidates user when plugin reported deletion success
* #16126 Fix download link included in public share page with hidden download
* #16129 Verify that paths are valid for recursive local move
* #16134 Don't allow to disable encryption via the API
* [activity#381](https://github.com/nextcloud/activity/pull/381) Fix "unshare group share from self" activity
* [gallery#530](https://github.com/nextcloud/gallery/pull/530) Correctly show errors when setting the password


Pending PRs:

* [x] #16142 Better check reshare permissions