### PR TITLE
16.0.2 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(16, 0, 1, 1);
+$OC_Version = array(16, 0, 2, 0);
 
 // The human readable string
-$OC_VersionString = '16.0.1';
+$OC_VersionString = '16.0.2 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #15553 Update ca bundle
* #15554 Update ca bundle checker
* #15575 User management/subadmin: rephrase ambiguous error message
* #15592 Update shipped.json to include privacy and recommendations
* #15593 Show supported apps in app management
* #15628 Update CRL due to revoked cookbook.crt
* #15649 Only show sharing section if it has content
* #15666 Remove quota feedback if no link set
* #15686 Allow redis cluster to use password
* #15718 Don't run repair step for every individual user, outsource that to background job
* #15724 Check the actual status code for 204 and 304
* #15728 [Security] Bump tar from 2.2.1 to 2.2.2
* #15745 Don't notify admins if no potentially over exposing links found
* #15754 Also allow dragging below the file list
* #15768 Change text color in search box in darktheme, ref #15598
* #15772 Check for free space on touch
* #15799 Search files by id in shared storages last
* #15856 Hide newFile menu if quota is set to 0B
* #15948 Add core/js/dist/ to l10nignore
* #15984 Add LDAP integr. test for receiving share candidates with group limitation
* #16010 Remove auto focus of share input field on dialog open, fix #15261
* #16015 LDAP) API: return one base properly when multiple are configured
* #16038 Handle storage exceptions when trying to set mtime
* #16051 Fix LDAP Wizard forgetting groups on select with search
* #16068 Revert "Fix userid casting in notifications"
* #16080 Fix appid argument for integrity:check-app
* #16082 Fix full text search for groupfolders
* #16089 Fall back to black for non-color values
* #16091 Check if uploading to lookup server is enabled before verifying
* #16105 Allow apps to store longer messages in the comments API
* #16112 Invalidates user when plugin reported deletion success
* #16125 Fix download link included in public share page with hidden download
* #16127 Better check reshare permissions
* #16128 Verify that paths are valid for recursive local move
* #16133 Don't allow to disable encryption via the API
* [activity#380](https://github.com/nextcloud/activity/pull/380) Fix "unshare group share from self" activity
* [gallery#529](https://github.com/nextcloud/gallery/pull/529) Correctly show errors when setting the password
* [notifications#359](https://github.com/nextcloud/notifications/pull/359) Update dependabot deps in stable16
* [privacy#133](https://github.com/nextcloud/privacy/pull/133) Add app description to readme and appinfo
* [recommendations#79](https://github.com/nextcloud/recommendations/pull/79) Catch and filter share that can't be found
* [recommendations#92](https://github.com/nextcloud/recommendations/pull/92) [Security] Bump axios from 0.18.0 to 0.18.1
* [viewer#113](https://github.com/nextcloud/viewer/pull/113) [Security] Bump tar from 2.2.1 to 2.2.2
* [viewer#117](https://github.com/nextcloud/viewer/pull/117) [Security] Bump axios from 0.18.0 to 0.19.0


Pending PRs:

* [ ] #14784 Fix language vs. locale
* [ ] #15187 Bugfix: user is not allowed
* [x] #16146 Do not show a internet connectivity warning if internet access is dis…
* [x] [files_pdfviewer#141](https://github.com/nextcloud/files_pdfviewer/pull/141) Fix load of character maps
* [x] [gallery#533](https://github.com/nextcloud/gallery/pull/533) Blacklist using .noimage