### PR TITLE
Fix file checkbox margin causing layout issues in file list

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -441,6 +441,7 @@ table td.selection {
 /* File checkboxes */
 #fileList tr td.selection>.selectCheckBox + label:before {
 	opacity: 0.3;
+	margin-right: 0;
 }
 
 /* Show checkbox with full opacity when hovering, checked, or selected */


### PR DESCRIPTION
Actually it wasn’t the recommendations entries being too far left, it was the files in the list being pushed too far to the right.

Before:
![checkbox files before](https://user-images.githubusercontent.com/925062/60138877-30c69300-97ac-11e9-93cd-06fee6a83e04.png)

After:
![checkbox after](https://user-images.githubusercontent.com/925062/60138878-30c69300-97ac-11e9-9c4e-f6a8896ffcfe.png)

