### PR TITLE
Allow apps to store longer messages in the comments API

### DIFF
--- a/lib/private/Comments/Comment.php
+++ b/lib/private/Comments/Comment.php
@@ -188,17 +188,18 @@ class Comment implements IComment {
 	 * sets the message of the comment and returns itself
 	 *
 	 * @param string $message
+	 * @param int $maxLength
 	 * @return IComment
 	 * @throws MessageTooLongException
 	 * @since 9.0.0
 	 */
-	public function setMessage($message) {
+	public function setMessage($message, $maxLength = self::MAX_MESSAGE_LENGTH) {
 		if(!is_string($message)) {
 			throw new \InvalidArgumentException('String expected.');
 		}
 		$message = trim($message);
-		if(mb_strlen($message, 'UTF-8') > IComment::MAX_MESSAGE_LENGTH) {
-			throw new MessageTooLongException('Comment message must not exceed ' . IComment::MAX_MESSAGE_LENGTH . ' characters');
+		if ($maxLength && mb_strlen($message, 'UTF-8') > $maxLength) {
+			throw new MessageTooLongException('Comment message must not exceed ' . $maxLength. ' characters');
 		}
 		$this->data['message'] = $message;
 		return $this;

--- a/lib/public/Comments/IComment.php
+++ b/lib/public/Comments/IComment.php
@@ -127,11 +127,12 @@ interface IComment {
 	 * MessageTooLongException shall be thrown.
 	 *
 	 * @param string $message
+	 * @param int $maxLength
 	 * @return IComment
 	 * @throws MessageTooLongException
-	 * @since 9.0.0
+	 * @since 9.0.0 - $maxLength added in 16.0.2
 	 */
-	public function setMessage($message);
+	public function setMessage($message, $maxLength = self::MAX_MESSAGE_LENGTH);
 
 	/**
 	 * returns an array containing mentions that are included in the comment


### PR DESCRIPTION
No database changes required, because the database is already `longtext` (65+k chars depending on your database, MySQL is 4GB :see_no_evil: )

This allows the talk app to evade the 1000 chars, which is very narrow with commands and other non-plain text messages