### PR TITLE
Only return link to themed icon if file exists

### DIFF
--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -349,7 +349,7 @@ class ThemingDefaults extends \OC_Defaults {
 			} catch (AppPathNotFoundException $e) {}
 			return $this->urlGenerator->linkToRoute('theming.Theming.getManifest') . '?v=' . $cacheBusterValue;
 		}
-		if (strpos($image, 'filetypes/') === 0) {
+		if (strpos($image, 'filetypes/') === 0 && file_exists(\OC::$SERVERROOT . '/core/img/' . $image )) {
 			return $this->urlGenerator->linkToRoute('theming.Icon.getThemedIcon', ['app' => $app, 'image' => $image]);
 		}
 		return false;


### PR DESCRIPTION
Close https://github.com/nextcloud/server/pull/16058

This makes sure we only return an URL to the imagePath method if the file exists. 

Fixes issue mentioned in https://github.com/nextcloud/server/issues/16076
> .mp4 filetype uses non-existing "video-mp4.svg" as mimetype icon, but we only have "video.svg" and should use that