### PR TITLE
Show share link header text always in 2 rows

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -62,7 +62,6 @@
 	height: 100%;
 	box-sizing: border-box;
 	opacity: 1;
-	display: flex;
 	align-items: center;
 	flex-wrap: wrap;
 	overflow: hidden;


### PR DESCRIPTION
For more consistent display of share link header text, now we never show it in only 1 row:

Before, wide and narrow:
![Share link header wide before](https://user-images.githubusercontent.com/925062/60166111-c8ee6780-9800-11e9-8b94-22e8f466365e.png)
![Share link header mobile](https://user-images.githubusercontent.com/925062/60166108-c855d100-9800-11e9-9158-358d43fda672.png)

After, wide and narrow, more consistent:
![Share link header wide after](https://user-images.githubusercontent.com/925062/60166109-c855d100-9800-11e9-8c1e-0544f14fd88a.png)
![Menu bar new](https://user-images.githubusercontent.com/925062/60166105-c855d100-9800-11e9-9781-244aa42203f9.png)


Please review @nextcloud/designers 