### PR TITLE
Fix download link included in public share page with hidden download

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -136,9 +136,11 @@ OCA.Sharing.PublicApp = {
 			scalingup: 0
 		};
 
-		var imgcontainer = $('<a href="' + $('#previewURL').val()
-			+ '" target="_blank"><img class="publicpreview" alt=""></a>');
-		var img = imgcontainer.find('.publicpreview');
+		var imgcontainer = $('<img class="publicpreview" alt="">');
+		if (hideDownload === 'false') {
+			imgcontainer = $('<a href="' + $('#previewURL').val() + '" target="_blank"></a>').append(imgcontainer);
+		}
+		var img = imgcontainer.hasClass('publicpreview')? imgcontainer: imgcontainer.find('.publicpreview');
 		img.css({
 			'max-width': previewWidth,
 			'max-height': previewHeight


### PR DESCRIPTION
The preview element in the public share page was always wrapped with a link to download the file; now that link is included only if the _Hide download_ option of the share is not enabled.

Unfortunately the acceptance tests could not be extended to check this behaviour as text files do not had this issue and it is currently not possible to upload new files to test it, for example, with a zip file.

## How to test
- Upload any file (like a zip) that shows a preview icon in the public share page; an image works too (as it shows the image itself in place of the icon)
- Add a new link share for that file
- Enable _Hide download_ for that link share
- Open the public share page

### Result with this pull request
The preview icon is shown, but clicking on it does nothing.

### Result without this pull request
The preview icon is shown and clicking on it triggers a download of the file.
