### PR TITLE
Fix placement of icon in public share page for audio files

### DIFF
--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -25,6 +25,12 @@
 	max-width: 100% !important;
 }
 
+#imgframe audio {
+	display: block;
+	margin-left: auto;
+	margin-right: auto;
+}
+
 #imgframe .text-preview {
 	display: inline-block;
 	position: relative;

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -136,9 +136,11 @@ OCA.Sharing.PublicApp = {
 			scalingup: 0
 		};
 
-		var imgcontainer = $('<a href="' + $('#previewURL').val()
-			+ '" target="_blank"><img class="publicpreview" alt=""></a>');
-		var img = imgcontainer.find('.publicpreview');
+		var imgcontainer = $('<img class="publicpreview" alt="">');
+		if (hideDownload === 'false') {
+			imgcontainer = $('<a href="' + $('#previewURL').val() + '" target="_blank"></a>').append(imgcontainer);
+		}
+		var img = imgcontainer.hasClass('publicpreview')? imgcontainer: imgcontainer.find('.publicpreview');
 		img.css({
 			'max-width': previewWidth,
 			'max-height': previewHeight

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -177,7 +177,10 @@ OCA.Sharing.PublicApp = {
 		} else if (mimetype.substr(0, mimetype.indexOf('/')) !== 'video') {
 			img.attr('src', mimetypeIcon);
 			img.attr('width', 128);
-			imgcontainer.appendTo('#imgframe');
+			// "#imgframe" is either empty or it contains an audio preview that
+			// the icon should appear before, so the container should be
+			// prepended to the frame.
+			imgcontainer.prependTo('#imgframe');
 		}
 		else if (previewSupported === 'true') {
 			$('#imgframe > video').attr('poster', OC.generateUrl('/apps/files_sharing/publicpreview/' + token + '?' + OC.buildQueryString(params)));


### PR DESCRIPTION
## How to test
- Upload an audio file
- Add link share for that file
- Open the public share page

**Before:**
![Public-Share-Audio-Before](https://user-images.githubusercontent.com/26858233/60264659-07a91e00-98e4-11e9-8436-b5ca9e6e958b.png)

**After:**
![Public-Share-Audio-After](https://user-images.githubusercontent.com/26858233/60264653-0677f100-98e4-11e9-8cc9-9961db43efc9.png)

Is this worth a backport? If yes, up to which version?
