### PR TITLE
Fix dark text in body-login box on light theming colors

### DIFF
--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -67,7 +67,7 @@ $invert: luma($color-primary) > 0.6;
 		}
 		a,
 		label,
-		p,
+		footer p,
 		#alternative-logins legend,
 		.lost-password-container #lost-password {
 			color: $color-primary-text;


### PR DESCRIPTION
Please check @juliushaertl @nickvergessen @nextcloud/theming 