### PR TITLE
Mark files_rightclick as shipped so it's marked as official

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -12,6 +12,7 @@
     "files",
     "files_external",
     "files_pdfviewer",
+    "files_rightclick",
     "files_sharing",
     "files_texteditor",
     "files_trashbin",


### PR DESCRIPTION
For https://github.com/nextcloud/server/issues/16076

> Right-click app needs an "Official" label

![Bildschirmfoto von 2019-06-28 10-45-52](https://user-images.githubusercontent.com/1374172/60330080-f880a980-9991-11e9-8d7b-832d648bdfd7.png)


Ref https://github.com/nextcloud/server/blob/361836675cc9d37a5cf74c5f99c3739c5eb271c9/lib/private/legacy/app.php#L741