### PR TITLE
Raise timeout for Fetcher to work on slow internet connections

### DIFF
--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -95,7 +95,7 @@ abstract class Fetcher {
 		}
 
 		$options = [
-			'timeout' => 10,
+			'timeout' => 30,
 		];
 
 		if ($ETag !== '') {


### PR DESCRIPTION
The timeout in the appstore fetcher is to low. So i raised it to 30 seconds. 

Closes #14926
