### PR TITLE
Add X-Frame-Options header to .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -11,13 +11,13 @@
 
   <IfModule mod_env.c>
     # Add security and privacy related headers
-    Header set X-Content-Type-Options "nosniff"
-    Header set X-XSS-Protection "1; mode=block"
-    Header set X-Robots-Tag "none"
-    Header set X-Download-Options "noopen"
-    Header set X-Permitted-Cross-Domain-Policies "none"
     Header set Referrer-Policy "no-referrer"
+    Header set X-Content-Type-Options "nosniff"
+    Header set X-Download-Options "noopen"
     Header set X-Frame-Options "SAMEORIGIN"
+    Header set X-Permitted-Cross-Domain-Policies "none"
+    Header set X-Robots-Tag "none"
+    Header set X-XSS-Protection "1; mode=block"
     SetEnv modHeadersAvailable true
   </IfModule>
 

--- a/.htaccess
+++ b/.htaccess
@@ -11,13 +11,13 @@
 
   <IfModule mod_env.c>
     # Add security and privacy related headers
-    Header set Referrer-Policy "no-referrer"
-    Header set X-Content-Type-Options "nosniff"
-    Header set X-Download-Options "noopen"
-    Header set X-Frame-Options "SAMEORIGIN"
-    Header set X-Permitted-Cross-Domain-Policies "none"
-    Header set X-Robots-Tag "none"
-    Header set X-XSS-Protection "1; mode=block"
+    Header always set Referrer-Policy "no-referrer"
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set X-Download-Options "noopen"
+    Header always set X-Frame-Options "SAMEORIGIN"
+    Header always set X-Permitted-Cross-Domain-Policies "none"
+    Header always set X-Robots-Tag "none"
+    Header always set X-XSS-Protection "1; mode=block"
     SetEnv modHeadersAvailable true
   </IfModule>
 

--- a/.htaccess
+++ b/.htaccess
@@ -17,6 +17,7 @@
     Header set X-Download-Options "noopen"
     Header set X-Permitted-Cross-Domain-Policies "none"
     Header set Referrer-Policy "no-referrer"
+    Header set X-Frame-Options "SAMEORIGIN"
     SetEnv modHeadersAvailable true
   </IfModule>
 

--- a/.htaccess
+++ b/.htaccess
@@ -41,8 +41,8 @@
 </IfModule>
 <IfModule mod_rewrite.c>
   RewriteEngine on
-  RewriteCond %{HTTP_USER_AGENT}  DavClnt
-  RewriteRule ^$         /remote.php/webdav/          [L,R=302]
+  RewriteCond %{HTTP_USER_AGENT} DavClnt
+  RewriteRule ^$ /remote.php/webdav/ [L,R=302]
   RewriteRule .* - [env=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
   RewriteRule ^\.well-known/host-meta /public.php?service=host-meta [QSA,L]
   RewriteRule ^\.well-known/host-meta\.json /public.php?service=host-meta-json [QSA,L]

--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -89,7 +89,7 @@ class OC_Response {
 			. 'frame-src *; '
 			. 'img-src * data: blob:; '
 			. 'font-src \'self\' data:; '
-			. 'media-src *; ' 
+			. 'media-src *; '
 			. 'connect-src *; '
 			. 'object-src \'none\'; '
 			. 'base-uri \'self\'; ';

--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -98,13 +98,13 @@ class OC_Response {
 		// Send fallback headers for installations that don't have the possibility to send
 		// custom headers on the webserver side
 		if(getenv('modHeadersAvailable') !== 'true') {
-			header('X-XSS-Protection: 1; mode=block'); // Enforce browser based XSS filters
-			header('X-Content-Type-Options: nosniff'); // Disable sniffing the content type for IE
-			header('X-Robots-Tag: none'); // https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag
-			header('X-Download-Options: noopen'); // https://msdn.microsoft.com/en-us/library/jj542450(v=vs.85).aspx
-			header('X-Permitted-Cross-Domain-Policies: none'); // https://www.adobe.com/devnet/adobe-media-server/articles/cross-domain-xml-for-streaming.html
 			header('Referrer-Policy: no-referrer'); // https://www.w3.org/TR/referrer-policy/
+			header('X-Content-Type-Options: nosniff'); // Disable sniffing the content type for IE
+			header('X-Download-Options: noopen'); // https://msdn.microsoft.com/en-us/library/jj542450(v=vs.85).aspx
 			header('X-Frame-Options: SAMEORIGIN'); // Disallow iFraming from other domains
+			header('X-Permitted-Cross-Domain-Policies: none'); // https://www.adobe.com/devnet/adobe-media-server/articles/cross-domain-xml-for-streaming.html
+			header('X-Robots-Tag: none'); // https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag
+			header('X-XSS-Protection: 1; mode=block'); // Enforce browser based XSS filters
 		}
 	}
 

--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -94,7 +94,6 @@ class OC_Response {
 			. 'object-src \'none\'; '
 			. 'base-uri \'self\'; ';
 		header('Content-Security-Policy:' . $policy);
-		header('X-Frame-Options: SAMEORIGIN'); // Disallow iFraming from other domains
 
 		// Send fallback headers for installations that don't have the possibility to send
 		// custom headers on the webserver side
@@ -105,6 +104,7 @@ class OC_Response {
 			header('X-Download-Options: noopen'); // https://msdn.microsoft.com/en-us/library/jj542450(v=vs.85).aspx
 			header('X-Permitted-Cross-Domain-Policies: none'); // https://www.adobe.com/devnet/adobe-media-server/articles/cross-domain-xml-for-streaming.html
 			header('Referrer-Policy: no-referrer'); // https://www.w3.org/TR/referrer-policy/
+			header('X-Frame-Options: SAMEORIGIN'); // Disallow iFraming from other domains
 		}
 	}
 


### PR DESCRIPTION
This addresses the some major points of #8207.

This should not change the behavior of a normal request to NextCloud. But it changes the following:

<table>
<tr>
<th>Before</th><th>After</th>
</tr>
<tr>
<td><code>X-Frame-Options</code> is only sent by PHP responses</td><td><code>X-Frame-Options</code> is sent on all responses</td>
</tr>
<tr>
<td>security headers are only sent on 2xx responses</td><td>security headers (except dynamically generated CSP) are sent on all responses</td>
</tr>
<tr>
<td>If the <code>X-Frame-Options</code> header is added to the <a href="https://github.com/nextcloud/documentation/blob/master/admin_manual/installation/nginx.rst#nextcloud-in-the-webroot-of-nginx">nginx example</a>, it's sent twice for PHP responses</td><td>The <code>X-Frame-Options</code> header should be added to the <a href="https://github.com/nextcloud/documentation/blob/master/admin_manual/installation/nginx.rst#nextcloud-in-the-webroot-of-nginx">nginx example</a></td>
</tr>
</table>

This should not affect installations without `modHeadersAvailable`.