### PR TITLE
Use specific privileges when creating admin

### DIFF
--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -79,7 +79,7 @@ class MySQL extends AbstractDatabase {
 
 		try {
 			//this query will fail if there aren't the right permissions, ignore the error
-			$query="GRANT ALL PRIVILEGES ON `$name` . * TO '$user'";
+			$query="GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER ON `$name` . * TO '$user'";
 			$connection->executeUpdate($query);
 		} catch (\Exception $ex) {
 			$this->logger->logException($ex, [


### PR DESCRIPTION
Using the ALL shorthand can cause problems when not all privileges are available to the user.
For example, AWS RDS MariaDB/MySQL will not grant the initial user account on an instance the SUPER privilege.
While the user account is still valid for pretty much any task on the DB instance, it can not use the ALL shorthand when granting privileges to new users.
By supplying a specific set of privileges, we work around this limitation without sacrificing functionality.

Closes #16139