### PR TITLE
Ignore forbidden exception when fetching share mtime on SMB for symlinks

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -302,6 +302,8 @@ class SMB extends Common implements INotifyStorage {
 				}
 			} catch (NotFoundException $e) {
 				// Ignore this, can happen on unavailable DFS shares
+			} catch (ForbiddenException $e) {
+				// Ignore this too - it's a symlink
 			}
 		}
 		return $highestMTime;


### PR DESCRIPTION
See https://github.com/nextcloud/server/pull/7556#issuecomment-499028026


