### PR TITLE
+nodeinfo public service

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -47,6 +47,7 @@
   RewriteRule ^\.well-known/host-meta /public.php?service=host-meta [QSA,L]
   RewriteRule ^\.well-known/host-meta\.json /public.php?service=host-meta-json [QSA,L]
   RewriteRule ^\.well-known/webfinger /public.php?service=webfinger [QSA,L]
+  RewriteRule ^\.well-known/nodeinfo /public.php?service=nodeinfo [QSA,L]
   RewriteRule ^\.well-known/carddav /remote.php/dav/ [R=301,L]
   RewriteRule ^\.well-known/caldav /remote.php/dav/ [R=301,L]
   RewriteRule ^remote/(.*) remote.php [QSA,L]

--- a/public.php
+++ b/public.php
@@ -68,7 +68,7 @@ try {
 	OC_App::loadApps(array('filesystem', 'logging'));
 
 	if (!\OC::$server->getAppManager()->isInstalled($app)) {
-		http_response_code(501);
+		http_response_code(404);
 		exit;
 	}
 	OC_App::loadApp($app);

--- a/settings/Application.php
+++ b/settings/Application.php
@@ -220,6 +220,11 @@ class Application extends App {
 			$appConfig['core']['public_webfinger'] = $publicWebFinger;
 		}
 
+		$publicNodeInfo = \OC::$server->getConfig()->getAppValue('core', 'public_nodeinfo', '');
+		if (!empty($publicNodeInfo)) {
+			$appConfig['core']['public_nodeinfo'] = $publicNodeInfo;
+		}
+
 		$settings['array']['oc_appconfig'] = json_encode($appConfig);
 	}
 }

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -248,7 +248,8 @@ $(document).ready(function(){
 		// run setup checks then gather error messages
 		$.when(
 			OC.SetupChecks.checkWebDAV(),
-			OC.SetupChecks.checkWellKnownUrl('/.well-known/webfinger', OC.theme.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === true && !!OC.appConfig.core.public_webfinger, [200, 501]),
+			OC.SetupChecks.checkWellKnownUrl('/.well-known/webfinger', OC.theme.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === true && !!OC.appConfig.core.public_webfinger, [200, 404]),
+			OC.SetupChecks.checkWellKnownUrl('/.well-known/nodeinfo', OC.theme.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === true && !!OC.appConfig.core.public_nodeinfo, [200, 404]),
 			OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav', OC.theme.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === true),
 			OC.SetupChecks.checkWellKnownUrl('/.well-known/carddav', OC.theme.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === true),
 			OC.SetupChecks.checkProviderUrl(OC.getRootPath() + '/ocm-provider/', OC.theme.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === true),
@@ -257,8 +258,8 @@ $(document).ready(function(){
 			OC.SetupChecks.checkGeneric(),
 			OC.SetupChecks.checkWOFF2Loading(OC.filePath('core', '', 'fonts/NotoSans-Regular-latin.woff2'), OC.theme.docPlaceholderUrl),
 			OC.SetupChecks.checkDataProtected()
-		).then(function (check1, check2, check3, check4, check5, check6, check7, check8, check9, check10) {
-			var messages = [].concat(check1, check2, check3, check4, check5, check6, check7, check8, check9, check10);
+		).then(function (check1, check2, check3, check4, check5, check6, check7, check8, check9, check10, check11) {
+			var messages = [].concat(check1, check2, check3, check4, check5, check6, check7, check8, check9, check10, check11);
 			var $el = $('#postsetupchecks');
 			$('#security-warning-state-loading').addClass('hidden');
 


### PR DESCRIPTION
needed by the social app.


> NodeInfo is an effort to create a standardized way of exposing metadata about a server running one of the distributed social networks. The two key goals are being able to get better insights into the user base of distributed social networking and the ability to build tools that allow users to choose the best fitting software and server for their needs.


source: https://github.com/jhass/nodeinfo
