### PR TITLE
Fix alignment issues in admin settings

### DIFF
--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -365,7 +365,7 @@ input {
 			// Detail description below label of checkbox or radio button
 			& + label ~ em {
 				display: inline-block;
-				margin-left: 18px;
+				margin-left: 25px;
 			}
 			& + label ~ em:last-of-type {
 				margin-bottom: $checkbox-radio-size;

--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -1169,7 +1169,7 @@ table.grid td.date {
 
 .icon-info {
 	padding: 11px 20px;
-	vertical-align: super;
+	vertical-align: text-bottom;
 	opacity: .5;
 }
 


### PR DESCRIPTION
For #16076 

- [x] Overview: Version info i icon not vertically aligned correctly
- [x] Basic settings: Cron settings alignment issues: info i not correctly vertically aligned, detail text of radio buttons should be flush with first line
- [x] Groupware: Also text alignment issues, indent the subline to be flush with first line

EDIT: Forgot to put the last one in the list.