### PR TITLE
Fix redirect after rescanFailedIntegrityCheck to "Overview" page

### DIFF
--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -334,7 +334,7 @@ class CheckSetupController extends Controller {
 	public function rescanFailedIntegrityCheck() {
 		$this->checker->runInstanceVerification();
 		return new RedirectResponse(
-			$this->urlGenerator->linkToRoute('settings.AdminSettings.index')
+			$this->urlGenerator->linkToRoute('settings.AdminSettings.index', ['section' => 'overview'])
 		);
 	}
 


### PR DESCRIPTION
The link of the rescanFailedIntegrityCheck link is on the settings sub page "Overview". After clicking the link, the user is, however, redirected to the "Basic settings" page.

This PR fixes that (might also be relevant for NC16).