### PR TITLE
Remove vertical whitespace between entries in Personal settings

### DIFF
--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -106,7 +106,7 @@ input {
 .profile-settings-container {
 	display: inline-grid;
 	grid-template-columns: 1fr;
-	grid-template-rows: 1fr 1fr 1fr;
+	grid-template-rows: 1fr 2fr 1fr;
 }
 
 .personal-show-container {
@@ -211,7 +211,7 @@ select {
 .personal-settings-container {
 	display: inline-grid;
 	grid-template-columns: 1fr 1fr;
-	grid-template-rows: 1fr 1fr 1fr;
+	grid-template-rows: 1fr 1fr 2fr;
 	&:after {
 		clear: both;
 	}


### PR DESCRIPTION
Ref #16076 
I fixed the padding between boxes, and the vertical whitespace.
Before
![before](https://user-images.githubusercontent.com/12728974/60982035-b5321d80-a337-11e9-8c24-f2660e424e80.png)
After
![after](https://user-images.githubusercontent.com/12728974/60982036-b5321d80-a337-11e9-8c2d-1494fa295111.png)


What do you think @ChristophWurst @skjnldsv @rullzer ?