### PR TITLE
[master]New Password Welcome form : Activate and choose initial password for new provisioned user

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -261,7 +261,8 @@ class LostController extends Controller {
 		}
 		
 		$parameters = $this->setPasswordResetParameters($userObj, $parameters);
-		$parameters['administrator_email'] = $this->config->getSystemValue('administrator_email');
+		// the administrator_email value, if set in confif.php makes possible mailto:// and customized messages in front pages
+		$parameters['administrator_email'] = $this->config->getSystemValue('administrator_email',null);
 		$parameters['login_form_autocomplete'] = 'on';
 		$parameters['throttle_delay'] = $this->throttler->getDelay($this->request->getRemoteAddress());
 

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -32,8 +32,10 @@
 namespace OC\Core\Controller;
 
 use OC\Authentication\TwoFactorAuth\Manager;
+use OC\Security\Bruteforce\Throttler;
 use OC\HintException;
 use \OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use \OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -47,9 +49,14 @@ use \OCP\IL10N;
 use \OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\ISession;
+use OCP\Util;
 use OCP\Mail\IMailer;
 use OCP\Security\ICrypto;
 use OCP\Security\ISecureRandom;
+use function array_filter;
+use function count;
+use function reset;
 
 /**
  * Class LostController
@@ -73,6 +80,8 @@ class LostController extends Controller {
 	protected $encryptionManager;
 	/** @var IConfig */
 	protected $config;
+	/** @var ISession */
+	protected $session;
 	/** @var ISecureRandom */
 	protected $secureRandom;
 	/** @var IMailer */
@@ -85,6 +94,9 @@ class LostController extends Controller {
 	private $logger;
 	/** @var Manager */
 	private $twoFactorManager;
+	/** @var Throttler */
+	private $throttler;
+
 
 	/**
 	 * @param string $appName
@@ -94,6 +106,7 @@ class LostController extends Controller {
 	 * @param Defaults $defaults
 	 * @param IL10N $l10n
 	 * @param IConfig $config
+ 	 * @param ISession $session
 	 * @param ISecureRandom $secureRandom
 	 * @param string $defaultMailAddress
 	 * @param IManager $encryptionManager
@@ -108,6 +121,7 @@ class LostController extends Controller {
 								Defaults $defaults,
 								IL10N $l10n,
 								IConfig $config,
+								ISession $session,								
 								ISecureRandom $secureRandom,
 								$defaultMailAddress,
 								IManager $encryptionManager,
@@ -115,7 +129,8 @@ class LostController extends Controller {
 								ITimeFactory $timeFactory,
 								ICrypto $crypto,
 								ILogger $logger,
-								Manager $twoFactorManager) {
+								Manager $twoFactorManager,
+								Throttler $throttler) {
 		parent::__construct($appName, $request);
 		$this->urlGenerator = $urlGenerator;
 		$this->userManager = $userManager;
@@ -125,11 +140,13 @@ class LostController extends Controller {
 		$this->from = $defaultMailAddress;
 		$this->encryptionManager = $encryptionManager;
 		$this->config = $config;
+		$this->session = $session;
 		$this->mailer = $mailer;
 		$this->timeFactory = $timeFactory;
 		$this->crypto = $crypto;
 		$this->logger = $logger;
 		$this->twoFactorManager = $twoFactorManager;
+		$this->throttler = $throttler;
 	}
 
 	/**
@@ -169,6 +186,95 @@ class LostController extends Controller {
 				'link' => $this->urlGenerator->linkToRouteAbsolute('core.lost.setPassword', array('userId' => $userId, 'token' => $token)),
 			),
 			'guest'
+		);
+	}
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 * @BruteForceProtection(action=passwordResetEmail)
+	 * @AnonRateThrottle(limit=10, period=300)
+	 * @UseSession
+	 *
+	 * @param string $userId
+	 *
+	 * @return TemplateResponse
+	 */
+	public function showPasswordEmailForm($userId) : Http\Response {
+		return $this->showNewPasswordForm($userId);
+	}		
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 * @BruteForceProtection(action=passwordResetEmail)
+	 * @AnonRateThrottle(limit=10, period=300)
+	 * @UseSession
+	 *
+	 * @param string $user
+	 *
+	 * @return TemplateResponse
+	 */
+	public function showNewPasswordForm($user = null) : Http\Response {
+
+		$parameters = [];
+		$errors = [];
+		$messages = [];
+
+		$renewPasswordMessages = $this->session->get('loginMessages');
+		if (is_array($renewPasswordMessages)) {
+			[$errors, $messages] = $renewPasswordMessages;
+		}
+		$this->session->remove('loginMessages');
+		foreach ($errors as $value) {
+			$parameters[$value] = true;
+		}
+		$parameters['messages'] = $messages;
+
+		$parameters['resetPasswordLink'] = $this->config
+		->getSystemValue('lost_password_link', '');
+
+		// disable the form if setting 'password reset' is disabled
+		if ($parameters['resetPasswordLink'] !== '') {
+			return new TemplateResponse('core', 'error', [
+					'errors' => [['error' => $this->l10n->t('Password reset is disabled')]]
+				],
+				'guest'
+			);
+		}
+		
+		$userObj = null;
+		if ($user !== null && $user !== '') {
+			try {
+				$userObj = $this->findUserByIdOrMail($user);
+				$parameters['displayName'] = $userObj->getDisplayName();
+				$parameters['loginName'] = $userObj->getEMailAddress();
+				//the timestamp of the user's last login or 0 if the user did never
+				$parameters['last_login'] = $userObj->getLastLogin();
+				$parameters['user_autofocus'] = false;
+			} catch(\InvalidArgumentException $exception){
+				// $user parameter is unknown or desactivated				
+				$parameters['messages'][] =  $user . ' :' . $this->l10n->t('unknown text');
+				$parameters['loginName'] = null;
+				$parameters['displayName'] = null;
+				$parameters['last_login'] = null;
+				$parameters['user_autofocus'] = true;
+			}
+		}
+		
+		$parameters = $this->setPasswordResetParameters($userObj, $parameters);
+		$parameters['administrator_email'] = $this->config->getSystemValue('administrator_email');
+		$parameters['login_form_autocomplete'] = 'on';
+		$parameters['throttle_delay'] = $this->throttler->getDelay($this->request->getRemoteAddress());
+
+		// OpenGraph Support: http://ogp.me/
+		Util::addHeader('meta', ['property' => 'og:title', 'content' => Util::sanitizeHTML($this->defaults->getName())]);
+		Util::addHeader('meta', ['property' => 'og:description', 'content' => Util::sanitizeHTML($this->defaults->getSlogan())]);
+		Util::addHeader('meta', ['property' => 'og:site_name', 'content' => Util::sanitizeHTML($this->defaults->getName())]);
+		Util::addHeader('meta', ['property' => 'og:url', 'content' => $this->urlGenerator->getAbsoluteURL('/')]);
+		Util::addHeader('meta', ['property' => 'og:type', 'content' => 'website']);
+		Util::addHeader('meta', ['property' => 'og:image', 'content' => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'favicon-touch.png'))]);
+
+		return new TemplateResponse(
+			$this->appName, 'lostpassword/newpassword', $parameters, 'guest'
 		);
 	}
 
@@ -229,9 +335,10 @@ class LostController extends Controller {
 	 * @AnonRateThrottle(limit=10, period=300)
 	 *
 	 * @param string $user
+	 * @param string $action optional
 	 * @return JSONResponse
 	 */
-	public function email($user){
+	public function email($user, string $action = null){
 		if ($this->config->getSystemValue('lost_password_link', '') !== '') {
 			return new JSONResponse($this->error($this->l10n->t('Password reset is disabled')));
 		}
@@ -244,7 +351,7 @@ class LostController extends Controller {
 
 		// FIXME: use HTTP error codes
 		try {
-			$this->sendEmail($user);
+			$this->sendEmail($user, $action);
 		} catch (\Exception $e) {
 			// Ignore the error since we do not want to leak this info
 			$this->logger->logException($e, [
@@ -309,9 +416,10 @@ class LostController extends Controller {
 
 	/**
 	 * @param string $input
+	 * @param string $action
 	 * @throws \Exception
 	 */
-	protected function sendEmail($input) {
+	protected function sendEmail($input, string $action = null) {
 		$user = $this->findUserByIdOrMail($input);
 		$email = $user->getEMailAddress();
 
@@ -341,22 +449,44 @@ class LostController extends Controller {
 			'link' => $link,
 		]);
 
-		$emailTemplate->setSubject($this->l10n->t('%s password reset', [$this->defaults->getName()]));
-		$emailTemplate->addHeader();
-		$emailTemplate->addHeading($this->l10n->t('Password reset'));
+		if(empty($action) || $action === 'RESET') {
+			$emailTemplate->setSubject($this->l10n->t('%s password reset', [$this->defaults->getName()]));
+			$emailTemplate->addHeader();
+			$emailTemplate->addHeading($this->l10n->t('Password reset'));
 
-		$emailTemplate->addBodyText(
-			htmlspecialchars($this->l10n->t('Click the following button to reset your password. If you have not requested the password reset, then ignore this email.')),
-			$this->l10n->t('Click the following link to reset your password. If you have not requested the password reset, then ignore this email.')
-		);
+			$emailTemplate->addBodyText(
+				htmlspecialchars($this->l10n->t('Click the following button to reset your password. If you have not requested the password reset, then ignore this email.')),
+				$this->l10n->t('Click the following link to reset your password. If you have not requested the password reset, then ignore this email.')
+			);
 
-		$emailTemplate->addBodyButton(
-			htmlspecialchars($this->l10n->t('Reset your password')),
-			$link,
-			false
-		);
-		$emailTemplate->addFooter();
+			$emailTemplate->addBodyButton(
+				htmlspecialchars($this->l10n->t('Reset your password')),
+				$link,
+				false
+			);
+		} else if($action === 'NEW'){
+			$emailTemplate->setSubject($this->l10n->t('%s activate and choose a password', [$this->defaults->getName()]));
+			$emailTemplate->addHeader();
+			$emailTemplate->addHeading($this->l10n->t('Activate and choose a password'));
 
+			$emailTemplate->addBodyText(
+				htmlspecialchars($this->l10n->t('Click the following button to activate and choose a new password. If you have not requested the new password, then ignore this email.')),
+				$this->l10n->t('Click the following link to activate and choose a new password. If you have not requested the new password, then ignore this email.')
+			);
+
+			$emailTemplate->addBodyButton(
+				htmlspecialchars($this->l10n->t('Activate and choose your new password')),
+				$link,
+				false
+			);
+
+		} else {
+			throw new \Exception($this->l10n->t(
+				'Couldn\'t send reset email. Please contact your administrator.'
+			));
+		}
+
+			$emailTemplate->addFooter();
 		try {
 			$message = $this->mailer->createMessage();
 			$message->setTo([$email => $user->getUID()]);
@@ -389,14 +519,42 @@ class LostController extends Controller {
 			return $user;
 		}
 
-		$users = \array_filter($this->userManager->getByEmail($input), function (IUser $user) {
+		$users = array_filter($this->userManager->getByEmail($input), function (IUser $user) {
 			return $user->isEnabled();
 		});
 
-		if (\count($users) === 1) {
-			return $users[0];
+		if (count($users) === 1) {
+			return reset($users);
 		}
 
 		throw $userNotFound;
+	}
+
+	/**
+	 * Sets the password reset params.
+	 *
+	 * Users may not change their passwords if:
+	 * - The account is disabled
+	 * - The backend doesn't support password resets
+	 * - The password reset function is disabled
+	 *
+	 * @param IUser $userObj
+	 * @param array $parameters
+	 * @return array
+	 */
+	protected function setPasswordResetParameters(
+		IUser $userObj = null, array $parameters): array {
+
+		if ($parameters['resetPasswordLink'] === 'disabled') {
+			$parameters['canResetPassword'] = false;
+		} else if (!$parameters['resetPasswordLink'] && $userObj !== null) {
+			$parameters['canResetPassword'] = $userObj->canChangePassword();
+		} else if ($userObj !== null && $userObj->isEnabled() === false) {
+			$parameters['canResetPassword'] = false;
+		} else {
+			$parameters['canResetPassword'] = true;
+		}
+
+		return $parameters;
 	}
 }

--- a/core/js/lostpassword/newpassword.js
+++ b/core/js/lostpassword/newpassword.js
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2019
+ *  Guillaume Compagnon gcompagnon@outlook.com
+ * This file is licensed under the Affero General Public License version 3 or later.
+ * See the COPYING-README file.
+ */
+OC.Newpassword = {
+
+	sendErrorMsg : t('core', 'Couldn\'t send reset email. Please contact your administrator.'),
+
+	sendSuccessResetPasswordMsg : t('core', 'We have send a password reset e-mail to the e-mail address known to us for this account. If you do not receive it within a reasonable amount of time, check your spam/junk folders.<br>If it is not there ask your local administrator.'),
+	
+	sendSuccessNewPasswordMsg : t('core', 'We have send a password create e-mail to the e-mail address known to us for this account. If you do not receive it within a reasonable amount of time, check your spam/junk folders.<br>If it is not there ask your local administrator.'),
+
+	resetErrorMsg : t('core', 'Password can not be changed. Please contact your administrator.'),
+
+	init : function() {
+		$('form[name=email]').submit(OC.Newpassword.onSendLink);
+		$('#new-password-close').click(OC.Newpassword.closeWindows);
+		$('#new-password-submit').click(OC.Newpassword.resetPassword);
+		OC.Newpassword.resetButtons();
+	},
+
+	resetButtons : function() {		
+		$('#submit-wrapper .submit-icon')
+			.addClass('icon-confirm-white')
+			.removeClass('icon-loading-small-dark');
+		if( $('#action').val() == 'NEW') {
+			$('#new-password-submit')
+			.attr('value', t('core', 'First connection'))
+			.prop('disabled', false);
+			$('#user').prop('disabled', true);
+		} else if( $('#action').val() == 'RESET') {
+			$('#new-password-submit')
+			.attr('value', t('core', 'Reset password'))
+			.prop('disabled', false);
+			$('#user').prop('disabled', false);
+		}		
+		$('.login-additional').fadeIn();
+		//$('.new-password-wrapper').fadeIn();
+		$('form[name=email]').attr('action', 'lostpassword/email');
+	},
+
+	onSendLink: function (event) {
+		// Only if password reset form is active
+		if($('form[name=email][action]').length === 1) {
+			if (event) {
+				event.preventDefault();
+			}
+			$('#submit-wrapper .submit-icon')
+				.removeClass('icon-confirm-white')
+				.addClass('icon-loading-small-dark');
+			$('#new-password-submit')
+				.attr('value', t('core', 'Sending email …'))
+				.prop('disabled', true);
+			$('#user').prop('disabled', true);
+
+			$('.login-additional').fadeOut();
+			$('.new-password-wrapper').slideDown().fadeOut();
+			
+			$.post(
+			OC.generateUrl('/lostpassword/email'),
+			{
+				user : $('#user').val(),
+				action : $('#action').val()
+			},
+			OC.Newpassword.sendLinkDone
+		).fail(function() {
+			OC.Newpassword.sendLinkError(OC.Newpassword.sendErrorMsg);
+		});
+	}
+	},
+
+	sendLinkDone : function(result){
+		var sendErrorMsg;		
+		if (result && result.status === 'success'){
+			OC.Newpassword.sendLinkSuccess();
+		} else {
+			if (result && result.msg){
+				sendErrorMsg = result.msg;
+			} else {
+				sendErrorMsg = OC.Newpassword.sendErrorMsg;
+			}
+			OC.Newpassword.sendLinkError(sendErrorMsg);
+		}
+	},
+
+	sendLinkSuccess : function(msg){
+		var node = OC.Newpassword.getSendStatusNode();
+		// update is the better success message styling
+		node.addClass('update').css({width:'auto'});
+		if( $('#action').val() == 'NEW') {
+			node.html(OC.Newpassword.sendSuccessNewPasswordMsg);
+			$('#action').val('RESET');
+		} else if ( $('#action').val() == 'RESET') {
+			node.html(OC.Newpassword.sendSuccessResetPasswordMsg);
+		}
+		$('#new-password-close').slideDown().fadeIn();
+		OC.Newpassword.resetButtons();
+	},
+
+	sendLinkError : function(msg){
+		var node = OC.Newpassword.getSendStatusNode();
+		node.addClass('warning');
+		node.html(msg);
+		$('#new-password-close').slideDown().fadeIn();
+		$('#new-password-admin').slideDown().fadeIn();
+		OC.Newpassword.resetButtons();
+	},
+
+	getSendStatusNode : function(){
+		if (!$('#new-password').length){
+			$('<p id="#new-password"></p>').insertBefore($('#new-password-close'));
+		} else {
+			$('#new-password').replaceWith($('<p id="new-password"></p>'));
+		}
+		return $('#new-password');
+	},
+
+	resetPassword : function(event){
+		
+		$('#submit-wrapper .submit-icon')
+		.removeClass('icon-confirm-white')
+		.addClass(OCA.Theming && OCA.Theming.inverted
+			? 'icon-loading-small'
+			: 'icon-loading-small-dark');
+	},
+
+	closeWindows : function(event){
+		window.close();
+	},
+
+
+};
+
+$(document).ready(OC.Newpassword.init);

--- a/core/routes.php
+++ b/core/routes.php
@@ -40,6 +40,8 @@ $application->registerRoutes($this, [
 		['name' => 'lost#email', 'url' => '/lostpassword/email', 'verb' => 'POST'],
 		['name' => 'lost#resetform', 'url' => '/lostpassword/reset/form/{token}/{userId}', 'verb' => 'GET'],
 		['name' => 'lost#setPassword', 'url' => '/lostpassword/set/{token}/{userId}', 'verb' => 'POST'],
+		['name' => 'lost#showPasswordEmailForm', 'url' => '/newpassword/{userId}', 'verb' => 'GET'],
+		['name' => 'lost#showNewPasswordForm', 'url' => '/newpassword', 'verb' => 'GET'],
 		['name' => 'user#getDisplayNames', 'url' => '/displaynames', 'verb' => 'POST'],
 		['name' => 'avatar#getAvatar', 'url' => '/avatar/{userId}/{size}', 'verb' => 'GET'],
 		['name' => 'avatar#deleteAvatar', 'url' => '/avatar/', 'verb' => 'DELETE'],

--- a/core/templates/lostpassword/newpassword.php
+++ b/core/templates/lostpassword/newpassword.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ *
+ * @copyright Copyright (c) 2019, Guillaume COMPAGNON <gcompagnon@outlook.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+style('core', 'lostpassword/resetpassword');
+
+script('core', 'visitortimezone');
+script('core', 'lostpassword/newpassword');
+use OC\Core\Controller\LostController;
+?>
+
+<!--[if IE 8]><style>input[type="checkbox"]{padding:0;}</style><![endif]-->
+<form method="post" name="email">
+	<fieldset>
+	<?php if (!empty($_['redirect_url'])) {
+		print_unescaped('<input type="hidden" name="redirect_url" value="' . \OCP\Util::sanitizeHTML($_['redirect_url']) . '">');
+	} ?>
+		<?php foreach($_['messages'] as $message): ?>
+			<div class="warning">
+				<?php p($message); ?><br>
+			</div>
+		<?php endforeach; ?>
+		<?php if (isset($_['internalexception']) && $_['internalexception']): ?>
+			<div class="warning">
+				<?php p($l->t('An internal error occurred.')); ?><br>
+				<small><?php p($l->t('Please try again or contact your administrator.')); ?> </small>
+				<small>
+				<?php p($l->t('email')); ?>  : 
+				<a href="mailto:<?php p($_['administrator_email']); ?>?subject= <?php p($l->t('An internal error occurred.')); ?>&body= <?php p($l->t('Username')) ?>  :  <?php p($_['displayName']); ?>" >
+					<?php p($_['administrator_email']); ?>
+				</a>
+				</small>
+			</div>
+		<?php endif; ?>
+		<div id="message" class="hidden">
+			<img class="float-spinner" alt=""
+				src="<?php p(image_path('core', 'loading-dark.gif'));?>">
+			<span id="messageText"></span>
+			<!-- the following div ensures that the spinner is always inside the #message div -->
+			<div style="clear: both;"></div>
+		</div>
+
+		<?php if (!empty($_['loginName'])) { ?>
+			<div class="info">
+			<p class="remember-login-container"> <?php p($l->t('Welcome %s',$_['displayName'])); ?></P>
+			</div>
+		<?php } ?>
+
+		<p class="grouptop">
+
+			<input type="text" name="user" id="user"
+				placeholder="<?php p($l->t('Username or email')); ?>"
+				aria-label="<?php p($l->t('Username or email')); ?>"
+				value="<?php p($_['loginName']); ?>"				
+				<?php p($_['user_autofocus'] ? 'autofocus' : ''); ?>
+				autocomplete="<?php p($_['login_form_autocomplete']); ?>" autocapitalize="none" autocorrect="off" required />
+			<label for="user" class="infield"><?php p($l->t('Username or email')); ?></label>
+		</p>
+		
+		<?php if (isset($_['canResetPassword']) && $_['canResetPassword'] ) { ?>
+		<div id="submit-wrapper">
+		<input type="submit" id="new-password-submit" class="login primary" title="" value="<?php p($l->t('Reset password')); ?>" />
+		<div class="submit-icon icon-confirm-white"></div>		
+		</div>
+
+		<div class="new-password-wrapper">
+		<?php if (isset($_['last_login']) && $_['last_login'] == 0 ) { ?>
+
+			<input type="hidden" name="action" id="action" value="NEW"/>
+			<p class="body-login-container">
+					<?php p($l->t("Click on 'First connection' to receive an email for choosing your first password")); ?>
+			</p>
+
+		<?php } else { ?>
+
+			<input type="hidden" name="action" id="action" value="RESET"/>
+			<p class="body-login-container">
+					<?php p($l->t("Click on 'Reset password' to receive an email for setting up a new password")); ?>
+				</p>
+
+		<?php } } else {  ?>
+
+			<p class="warning wrongUser">
+					<?php p($l->t("Please try again or contact %s.",$_['administrator_email'])); ?>
+			</p>
+		<?php }	?>
+		</div>
+
+		<div class="login-additional">
+			<p id="new-password"></p>
+			<p id="new-password-admin" class="info" style="display:none;" >
+				<?php p($l->t('email')); ?>   :  
+				<a  href="mailto:<?php p($_['administrator_email']); ?>?subject=<?php p($l->t('Error')) ?>&body=<?php p($l->t('Username')) ?>  :  <?php p($_['displayName']);?> - <?php p($l->t('Couldn\'t send reset email. Please contact your administrator.'));?>">
+					<?php p($_['administrator_email']); ?>
+  				</a>
+			</p>
+			<a id="new-password-close" href="" style="display:none;">
+					<?php p($l->t('Close this window')); ?>
+			</a>
+		</div>
+
+		<?php if ($_['throttle_delay'] > 5000) { ?>
+			<p class="warning throttledMsg">
+				<?php p($l->t('We have detected multiple invalid login attempts from your IP. Therefore your next login is throttled up to 30 seconds.')); ?>
+			</p>
+		<?php } ?>
+			
+		<input type="hidden" name="timezone_offset" id="timezone_offset"/>
+		<input type="hidden" name="timezone" id="timezone"/>
+		<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>"/>
+		
+	</fieldset>
+</form>

--- a/core/templates/lostpassword/newpassword.php
+++ b/core/templates/lostpassword/newpassword.php
@@ -41,12 +41,14 @@ use OC\Core\Controller\LostController;
 			<div class="warning">
 				<?php p($l->t('An internal error occurred.')); ?><br>
 				<small><?php p($l->t('Please try again or contact your administrator.')); ?> </small>
+				<?php if (isset($_['administrator_email']) && $_['administrator_email'] != '') {?>
 				<small>
 				<?php p($l->t('email')); ?>  : 
 				<a href="mailto:<?php p($_['administrator_email']); ?>?subject= <?php p($l->t('An internal error occurred.')); ?>&body= <?php p($l->t('Username')) ?>  :  <?php p($_['displayName']); ?>" >
 					<?php p($_['administrator_email']); ?>
 				</a>
 				</small>
+				<?php } ?>
 			</div>
 		<?php endif; ?>
 		<div id="message" class="hidden">
@@ -98,7 +100,11 @@ use OC\Core\Controller\LostController;
 		<?php } } else {  ?>
 
 			<p class="warning wrongUser">
-					<?php p($l->t("Please try again or contact %s.",$_['administrator_email'])); ?>
+			<?php if (isset($_['administrator_email']) && $_['administrator_email'] != '') { ?>
+				<?php p($l->t("Please try again or contact %s.",$_['administrator_email'])); ?>
+			<?php } else { ?>
+				<?php p($l->t("Please try again or contact your administrator.")); ?>
+			<?php }	?>
 			</p>
 		<?php }	?>
 		</div>
@@ -106,10 +112,12 @@ use OC\Core\Controller\LostController;
 		<div class="login-additional">
 			<p id="new-password"></p>
 			<p id="new-password-admin" class="info" style="display:none;" >
+			<?php if (isset($_['administrator_email']) && $_['administrator_email'] != '') { ?>
 				<?php p($l->t('email')); ?>   :  
 				<a  href="mailto:<?php p($_['administrator_email']); ?>?subject=<?php p($l->t('Error')) ?>&body=<?php p($l->t('Username')) ?>  :  <?php p($_['displayName']);?> - <?php p($l->t('Couldn\'t send reset email. Please contact your administrator.'));?>">
 					<?php p($_['administrator_email']); ?>
   				</a>
+			<?php }	?>
 			</p>
 			<a id="new-password-close" href="" style="display:none;">
 					<?php p($l->t('Close this window')); ?>


### PR DESCRIPTION
Duplicate Proposal for #16245  
(#16251 is pulled on stable 16 ( 16.0.1) )
pulled on MASTER ( $OC_VersionString = '17.0.0 alpha';)
Committer: same person - @gcompagnon @compagnon

/newpassword 
/newpassword/email 
/newpassword/userid
would provide a dedicated welcome page for new users , letting them enter the same process than Lost Password (new password feature is implemented into LostController)
This URL could be used into a customized Welcome email in a simple way for Business people/sales.

The new user could use that URL to choose his password, and the form could be customized to make user to accept conditions of use.

![image](https://user-images.githubusercontent.com/39604041/60715727-0ef0ad00-9f1e-11e9-865f-020c18a0af79.png)
If the user has never login(is enabled) => this is a First connection 
![image](https://user-images.githubusercontent.com/39604041/60715780-2465d700-9f1e-11e9-943d-0da284866d98.png)

If the user returns, on that URL: this is a Lost Password form
![image](https://user-images.githubusercontent.com/39604041/60716206-0d73b480-9f1f-11e9-8b03-4798dfe5f768.png)

* I have added also an administrator_email property on the config.php to display 'mailto' link to the * administrator email with the user id. l have updated some i10n messages for using that info instead of a "Administrator" , user knows the email. 
* Anti spam is enabled with throttle_delay

Here is an exception management example: a mailto on the administrator email is enabled
![image](https://user-images.githubusercontent.com/39604041/60716605-2335a980-9f20-11e9-8beb-36d52ddb6e19.png)