### PR TITLE
Don't send executionContexts for Clear-Site-Data

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -128,7 +128,7 @@ class LoginController extends Controller {
 
 		$this->session->set('clearingExecutionContexts', '1');
 		$this->session->close();
-		$response->addHeader('Clear-Site-Data', '"cache", "storage", "executionContexts"');
+		$response->addHeader('Clear-Site-Data', '"cache", "storage"');
 		return $response;
 	}
 

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -138,7 +138,7 @@ class LoginControllerTest extends TestCase {
 			->willReturn('/login');
 
 		$expected = new RedirectResponse('/login');
-		$expected->addHeader('Clear-Site-Data', '"cache", "storage", "executionContexts"');
+		$expected->addHeader('Clear-Site-Data', '"cache", "storage"');
 		$this->assertEquals($expected, $this->loginController->logout());
 	}
 
@@ -168,7 +168,7 @@ class LoginControllerTest extends TestCase {
 			->willReturn('/login');
 
 		$expected = new RedirectResponse('/login');
-		$expected->addHeader('Clear-Site-Data', '"cache", "storage", "executionContexts"');
+		$expected->addHeader('Clear-Site-Data', '"cache", "storage"');
 		$this->assertEquals($expected, $this->loginController->logout());
 	}
 


### PR DESCRIPTION
Fix #9179 

There are plans to remove executionContexts from the spec: https://github.com/w3c/webappsec-clear-site-data/issues/59

Firefox already [removed it](https://bugzilla.mozilla.org/show_bug.cgi?id=1548034) and Chromium never ended up [implementing this](https://bugs.chromium.org/p/chromium/issues/detail?id=898503).

