### PR TITLE
Adjust stale bot message

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -22,7 +22,7 @@ staleLabel: stale
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity and it seems to be missing some essential informations.
+  recent activity and might be missing some essential information.
   It will be closed if no further activity occurs. Thank you
   for your contributions.
 

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -22,7 +22,7 @@ staleLabel: stale
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. Additionally, it is marked as missing essential information.
+  recent activity and seems to be missing some essential information.
   It will be closed if no further activity occurs. Thank you
   for your contributions.
 

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -22,7 +22,7 @@ staleLabel: stale
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity and might be missing some essential information.
+  recent activity. Additionally, it is marked as missing essential information.
   It will be closed if no further activity occurs. Thank you
   for your contributions.
 


### PR DESCRIPTION
I noticed two tiny inconsistencies in the stale bot message.

* Include that not every stale issue is missing information.
* Fix plural of information. 