### PR TITLE
Use HTTP1.1 to read S3 objects

### DIFF
--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -61,6 +61,7 @@ trait S3ObjectTrait {
 		}
 		$opts = [
 			'http' => [
+				'protocol_version'  => 1.1,
 				'header' => $headers
 			]
 		];


### PR DESCRIPTION
Some of the READs otherwise use HTTP/1.0 which is not always supported
by all backends. HTTP/1.1 is there since 1999 way longer than S3 so safe
to assume it is always there IMO.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>