### PR TITLE
Feature/16245/administrator email as system value

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -55,6 +55,14 @@ $CONFIG = array(
 'passwordsalt' => '',
 
 /**
+  * The adminitsrator email provides a place to personalize a support email to 
+  * display in all messages errors
+  *
+  * 'administrator_email' => 'support@nextcloud.com',
+ */
+'administrator_email' => 'your administrator email',
+
+/**
  * Your list of trusted domains that users can log into. Specifying trusted
  * domains prevents host header poisoning. Do not remove this, as it performs
  * necessary security checks.

--- a/lib/private/SystemConfig.php
+++ b/lib/private/SystemConfig.php
@@ -50,6 +50,7 @@ class SystemConfig {
 		'mail_smtpname' => true,
 		'mail_smtppassword' => true,
 		'passwordsalt' => true,
+		'administrator_email' => true,
 		'secret' => true,
 		'updater.secret' => true,
 		'trusted_proxies' => true,


### PR DESCRIPTION
for #16245 
pulled on MASTER ( $OC_VersionString = '17.0.0 alpha';)
Committer:  @compagnon  
@kesselb 

For being able to generate mailto:// with error message and userid, in case of errors during login, lostpassword, or first connexion, could it possible to add a System Value called 'administrator_email'?
