### PR TITLE
Allow guest mentions of talk to be parsed

### DIFF
--- a/lib/private/Comments/Comment.php
+++ b/lib/private/Comments/Comment.php
@@ -226,14 +226,19 @@ class Comment implements IComment {
 	 *
 	 */
 	public function getMentions() {
-		$ok = preg_match_all("/\B(?<![^a-z0-9_\-@\.\'\s])@(\"[a-z0-9_\-@\.\' ]+\"|[a-z0-9_\-@\.\']+)/i", $this->getMessage(), $mentions);
+		$ok = preg_match_all("/\B(?<![^a-z0-9_\-@\.\'\s])@(\"guest\/[a-f0-9]+\"|\"[a-z0-9_\-@\.\' ]+\"|[a-z0-9_\-@\.\']+)/i", $this->getMessage(), $mentions);
 		if(!$ok || !isset($mentions[0]) || !is_array($mentions[0])) {
 			return [];
 		}
 		$uids = array_unique($mentions[0]);
 		$result = [];
 		foreach ($uids as $uid) {
-			$result[] = ['type' => 'user', 'id' => trim(substr($uid, 1), '"')];
+			$cleanUid = trim(substr($uid, 1), '"');
+			if (strpos($cleanUid, 'guest/') === 0) {
+				$result[] = ['type' => 'guest', 'id' => $cleanUid];
+			} else {
+				$result[] = ['type' => 'user', 'id' => $cleanUid];
+			}
 		}
 		return $result;
 	}

--- a/tests/lib/Comments/CommentTest.php
+++ b/tests/lib/Comments/CommentTest.php
@@ -155,13 +155,21 @@ class CommentTest extends TestCase {
 			[
 				'Also @"user with spaces" are now supported', ['user with spaces']
 			],
+			[
+				'Also @"guest/0123456789abcdef" are now supported', [], null, ['guest/0123456789abcdef']
+			],
 		];
 	}
 
 	/**
 	 * @dataProvider mentionsProvider
+	 *
+	 * @param string $message
+	 * @param array $expectedUids
+	 * @param string|null $author
+	 * @param array $expectedGuests
 	 */
-	public function testMentions($message, $expectedUids, $author = null) {
+	public function testMentions(string $message, array $expectedUids, ?string $author = null, array $expectedGuests = []): void {
 		$comment = new Comment();
 		$comment->setMessage($message);
 		if(!is_null($author)) {
@@ -169,9 +177,15 @@ class CommentTest extends TestCase {
 		}
 		$mentions = $comment->getMentions();
 		while($mention = array_shift($mentions)) {
-			$uid = array_shift($expectedUids);
-			$this->assertSame('user', $mention['type']);
-			$this->assertSame($uid, $mention['id']);
+			if ($mention['type'] === 'user') {
+				$id = array_shift($expectedUids);
+			} else if ($mention['type'] === 'guest') {
+				$id = array_shift($expectedGuests);
+			} else {
+				$this->fail('Unexpected mention type');
+				continue;
+			}
+			$this->assertSame($id, $mention['id']);
 		}
 		$this->assertEmpty($mentions);
 		$this->assertEmpty($expectedUids);


### PR DESCRIPTION
`@"guest/<sha1(webrtc session id)>"` is being used by talk to start working on mentions for guests, see https://github.com/nextcloud/spreed/pull/1974 for more information and details