### PR TITLE
Allow use of server var for CSP nonce

### DIFF
--- a/lib/private/Security/CSP/ContentSecurityPolicyNonceManager.php
+++ b/lib/private/Security/CSP/ContentSecurityPolicyNonceManager.php
@@ -58,7 +58,11 @@ class ContentSecurityPolicyNonceManager {
 	 */
 	public function getNonce(): string {
 		if($this->nonce === '') {
-			$this->nonce = base64_encode($this->csrfTokenManager->getToken()->getEncryptedValue());
+			if (empty($this->request->server['CSP_NONCE'])) {
+				$this->nonce = base64_encode($this->csrfTokenManager->getToken()->getEncryptedValue());
+			} else {
+				$this->nonce = $this->request->server['CSP_NONCE'];
+			}
 		}
 
 		return $this->nonce;

--- a/tests/lib/Security/CSP/ContentSecurityPolicyNonceManagerTest.php
+++ b/tests/lib/Security/CSP/ContentSecurityPolicyNonceManagerTest.php
@@ -21,23 +21,26 @@
 
 namespace Test\Security\CSP;
 
+use OC\AppFramework\Http\Request;
 use OC\Security\CSP\ContentSecurityPolicyNonceManager;
 use OC\Security\CSRF\CsrfToken;
 use OC\Security\CSRF\CsrfTokenManager;
-use OCP\IRequest;
 use Test\TestCase;
 
 class ContentSecurityPolicyNonceManagerTest extends TestCase  {
 	/** @var CsrfTokenManager */
 	private $csrfTokenManager;
+	/** @var Request */
+	private $request;
 	/** @var ContentSecurityPolicyNonceManager */
 	private $nonceManager;
 
 	public function setUp() {
 		$this->csrfTokenManager = $this->createMock(CsrfTokenManager::class);
+		$this->request = $this->createMock(Request::class);
 		$this->nonceManager = new ContentSecurityPolicyNonceManager(
 			$this->csrfTokenManager,
-			$this->createMock(IRequest::class)
+			$this->request
 		);
 	}
 
@@ -55,5 +58,21 @@ class ContentSecurityPolicyNonceManagerTest extends TestCase  {
 
 		$this->assertSame('TXlUb2tlbg==', $this->nonceManager->getNonce());
 		$this->assertSame('TXlUb2tlbg==', $this->nonceManager->getNonce());
+	}
+
+	public function testGetNonceServerVar() {
+		$token = 'SERVERNONCE';
+		$this->request
+			->method('__isset')
+			->with('server')
+			->willReturn(true);
+
+		$this->request
+			->method('__get')
+			->with('server')
+			->willReturn(['CSP_NONCE' => $token]);
+
+		$this->assertSame($token, $this->nonceManager->getNonce());
+		$this->assertSame($token, $this->nonceManager->getNonce());
 	}
 }


### PR DESCRIPTION
Allowing the server to pass a nonce to the application allows for stricter control of the CSP, by allowing a strict CSP to be enforced by the web server.

Fix towards #14980