### PR TITLE
 Add border-top to settings menu when its open ref #16076

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -711,7 +711,7 @@ $min-content-width: $breakpoint-mobile - $navigation-width - $list-min-width;
 }
 
 
-.settings-button {
+#app-settings-header .settings-button {
 	display: block;
 	height: 44px;
 	width: 100%;
@@ -732,7 +732,9 @@ $min-content-width: $breakpoint-mobile - $navigation-width - $list-min-width;
 	color: var(--color-main-text);
 	opacity: .57;
 
-	&.opened,
+	&.opened {
+		border-top: solid 1px var(--color-border);
+	}
 	&:hover,
 	&:focus {
 		background-color: var(--color-main-background);


### PR DESCRIPTION
ref #16076
It was like this:
![usedtobe](https://user-images.githubusercontent.com/12728974/61292083-910b8c00-a7d0-11e9-8bc5-3f9ee9dd77e6.png)
Now
![clickoutside](https://user-images.githubusercontent.com/12728974/61292085-910b8c00-a7d0-11e9-9fef-6abd3dd5c76d.png)

