### PR TITLE
adds an --update flag to check-user for manual sync of the ldap record

### DIFF
--- a/apps/user_ldap/lib/Command/CheckUser.php
+++ b/apps/user_ldap/lib/Command/CheckUser.php
@@ -29,32 +29,31 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-
 use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCA\User_LDAP\Mapping\UserMapping;
-use OCA\User_LDAP\Helper as LDAPHelper;
+use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\User_Proxy;
 
 class CheckUser extends Command {
-	/** @var \OCA\User_LDAP\User_Proxy */
+	/** @var User_Proxy */
 	protected $backend;
 
-	/** @var \OCA\User_LDAP\Helper */
+	/** @var Helper */
 	protected $helper;
 
-	/** @var \OCA\User_LDAP\User\DeletedUsersIndex */
+	/** @var DeletedUsersIndex */
 	protected $dui;
 
-	/** @var \OCA\User_LDAP\Mapping\UserMapping */
+	/** @var UserMapping */
 	protected $mapping;
 
 	/**
 	 * @param User_Proxy $uBackend
-	 * @param LDAPHelper $helper
+	 * @param Helper $helper
 	 * @param DeletedUsersIndex $dui
 	 * @param UserMapping $mapping
 	 */
-	public function __construct(User_Proxy $uBackend, LDAPHelper $helper, DeletedUsersIndex $dui, UserMapping $mapping) {
+	public function __construct(User_Proxy $uBackend, Helper $helper, DeletedUsersIndex $dui, UserMapping $mapping) {
 		$this->backend = $uBackend;
 		$this->helper = $helper;
 		$this->dui = $dui;
@@ -77,6 +76,12 @@ class CheckUser extends Command {
 					InputOption::VALUE_NONE,
 					'ignores disabled LDAP configuration'
 				     )
+			->addOption(
+				'update',
+				null,
+				InputOption::VALUE_NONE,
+				'syncs values from LDAP'
+			)
 		;
 	}
 
@@ -88,6 +93,9 @@ class CheckUser extends Command {
 			$exists = $this->backend->userExistsOnLDAP($uid);
 			if($exists === true) {
 				$output->writeln('The user is still available on LDAP.');
+				if($input->getOption('update')) {
+					$this->updateUser($uid, $output);
+				}
 				return;
 			}
 
@@ -131,6 +139,28 @@ class CheckUser extends Command {
 		// background job.
 
 		return true;
+	}
+
+	private function updateUser(string $uid, OutputInterface $output): void {
+		try {
+			$access = $this->backend->getLDAPAccess($uid);
+			$attrs = $access->userManager->getAttributes();
+			$user = $access->userManager->get($uid);
+			$avatarAttributes = $access->getConnection()->resolveRule('avatar');
+			$result = $access->search('objectclass=*', [$user->getDN()], $attrs, 1, 0);
+			foreach ($result[0] as $attribute => $valueSet) {
+				$output->writeln('  ' . $attribute . ': ');
+				foreach ($valueSet as $value) {
+					if (in_array($attribute, $avatarAttributes)) {
+						$value = '{ImageData}';
+					}
+					$output->writeln('    ' . $value);
+				}
+			}
+			$access->batchApplyUserAttributes($result);
+		} catch (\Exception $e) {
+			$output->writeln('<error>Error while trying to lookup and update attributes from LDAP</error>');
+		}
 	}
 
 }


### PR DESCRIPTION
This origins from a diagnosis patch today. The ldap:check-user originally is just a method to see whether a user is still available or not. With the new --update flag, the record data is also synced down (it would happen automatically twice a day or on LDAP login, but there was no other way to trigger it). Example output:

```
$ php occ ldap:check-user --update folk_9
The user is still available on LDAP.
  entryuuid: 
    e1a436b4-19d0-4a29-af99-46a80cedcc07
  dn: 
    uid=folk_9,ou=users,ou=small,dc=nc,dc=zara
  uid: 
    folk_9
  mail: 
    folk_9@wunder.bier
  displayname: 
    Linda, Hope
  jpegphoto: 
    {ImageData}
```