### PR TITLE
fixes the check for postgresql

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -978,9 +978,9 @@ class OC_Util {
 				$data = $result->fetchRow();
 				if (isset($data['server_version'])) {
 					$version = $data['server_version'];
-					if (version_compare($version, '9.0.0', '<')) {
+					if (version_compare($version, '9.5.0', '<')) {
 						$errors[] = array(
-							'error' => $l->t('PostgreSQL >= 9 required'),
+							'error' => $l->t('PostgreSQL >= 9.5 required'),
 							'hint' => $l->t('Please upgrade your database version')
 						);
 					}


### PR DESCRIPTION
I hope that's the single check for the DB version, I did not find another one. But that's only active on setup, not on upgrade.

references:
* https://github.com/nextcloud/documentation/pull/1516
* https://github.com/nextcloud/server/issues/15613