### PR TITLE
Fix 1px jump when selecting multi table entries

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -293,7 +293,6 @@ table.multiselect thead {
 table.multiselect thead th {
 	background-color: var(--color-main-background-translucent);
 	font-weight: bold;
-	border-bottom: 0;
 }
 
 #app-content.with-app-sidebar table.multiselect thead{


### PR DESCRIPTION
I just changed the CSS to keep the header border if items are selected.

![select_some](https://user-images.githubusercontent.com/6216686/61576970-61ff5e00-aae1-11e9-959d-c25ed3dd39b9.png)
![select_all](https://user-images.githubusercontent.com/6216686/61576971-61ff5e00-aae1-11e9-9f98-b692899d5c11.png)


#16076