### PR TITLE
Pass $configargs to openssl_pkey_export

### DIFF
--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -316,7 +316,10 @@ class PublicKeyTokenProvider implements IProvider {
 			throw new \RuntimeException('OpenSSL reported a problem');
 		}
 
-		openssl_pkey_export($res, $privateKey);
+		if (openssl_pkey_export($res, $privateKey, null, $config) === false) {
+			$this->logOpensslError();
+			throw new \RuntimeException('OpenSSL reported a problem');
+		}
 
 		// Extract the public key from $res to $pubKey
 		$publicKey = openssl_pkey_get_details($res);


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/16378 https://github.com/nextcloud/server/issues/11227

There are some reports that calling `openssl_pkey_export` with passphrase null and the same config options as `openssl_pkey_new` fixes:

> openssl_pkey_export(): cannot get key from parameter 1 at \/srv\/www\/nextcloud.pgnd.lan\/server\/lib\/private\/Authentication\/Token\/PublicKeyTokenProvider.php#311

Unfortunately it's hard to reproduce this kind of problem. Could not verify myself but makes sense somehow - calling `openssl_pkey_export` and `openssl_pkey_new` with the same configuration.

