### PR TITLE
Check the if we can actually access the storage cache for recent files

### DIFF
--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -442,6 +442,10 @@ class Folder extends Node implements \OCP\Files\Folder {
 		}, $result));
 
 		return array_values(array_filter($files, function (Node $node) {
+			$cacheEntry = $node->getMountPoint()->getStorage()->getCache()->get($node->getId());
+			if (!$cacheEntry) {
+				return false;
+			}
 			$relative = $this->getRelativePath($node->getPath());
 			return $relative !== null && $relative !== '/';
 		}));

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -447,7 +447,8 @@ class Folder extends Node implements \OCP\Files\Folder {
 				return false;
 			}
 			$relative = $this->getRelativePath($node->getPath());
-			return $relative !== null && $relative !== '/';
+			return $relative !== null && $relative !== '/'
+				&& ($cacheEntry->getPermissions() & \OCP\Constants::PERMISSION_READ) === \OCP\Constants::PERMISSION_READ;
 		}));
 	}
 

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -861,13 +861,15 @@ class FolderTest extends NodeTest {
 			'storage_mtime' => $baseTime,
 			'mtime' => $baseTime,
 			'mimetype' => 'text/plain',
-			'size' => 3
+			'size' => 3,
+			'permissions' => \OCP\Constants::PERMISSION_ALL
 		]);
 		$id2 = $cache->put('bar/foo/old.txt', [
 			'storage_mtime' => $baseTime - 100,
 			'mtime' => $baseTime - 100,
 			'mimetype' => 'text/plain',
-			'size' => 3
+			'size' => 3,
+			'permissions' => \OCP\Constants::PERMISSION_READ
 		]);
 		$cache->put('bar/asd/outside.txt', [
 			'storage_mtime' => $baseTime,
@@ -879,7 +881,8 @@ class FolderTest extends NodeTest {
 			'storage_mtime' => $baseTime - 600,
 			'mtime' => $baseTime - 600,
 			'mimetype' => 'text/plain',
-			'size' => 3
+			'size' => 3,
+			'permissions' => \OCP\Constants::PERMISSION_ALL
 		]);
 
 		$node = new \OC\Files\Node\Folder($root, $view, $folderPath, $folderInfo);
@@ -922,21 +925,24 @@ class FolderTest extends NodeTest {
 			'storage_mtime' => $baseTime,
 			'mtime' => $baseTime,
 			'mimetype' => \OCP\Files\FileInfo::MIMETYPE_FOLDER,
-			'size' => 3
+			'size' => 3,
+			'permissions' => 0
 		]);
 		$id2 = $cache->put('bar/foo/folder/bar.txt', [
 			'storage_mtime' => $baseTime,
 			'mtime' => $baseTime,
 			'mimetype' => 'text/plain',
 			'size' => 3,
-			'parent' => $id1
+			'parent' => $id1,
+			'permissions' => \OCP\Constants::PERMISSION_ALL
 		]);
 		$id3 = $cache->put('bar/foo/folder/asd.txt', [
 			'storage_mtime' => $baseTime - 100,
 			'mtime' => $baseTime - 100,
 			'mimetype' => 'text/plain',
 			'size' => 3,
-			'parent' => $id1
+			'parent' => $id1,
+			'permissions' => \OCP\Constants::PERMISSION_ALL
 		]);
 
 		$node = new \OC\Files\Node\Folder($root, $view, $folderPath, $folderInfo);
@@ -985,7 +991,8 @@ class FolderTest extends NodeTest {
 			'storage_mtime' => $baseTime,
 			'mtime' => $baseTime,
 			'mimetype' => 'text/plain',
-			'size' => 3
+			'size' => 3,
+			'permissions' => \OCP\Constants::PERMISSION_ALL
 		]);
 		$cache->put('outside.txt', [
 			'storage_mtime' => $baseTime - 100,


### PR DESCRIPTION
This will make sure we check the storage cache if it actually holds an entry for the node returned by the recent files search. 

@nickvergessen I dropped the initial approach to just reuse getById as it will cause an additional query for each file, which caused quite a high load.

fixes #16474 