### PR TITLE
allow to provide supported calendar component set internally as a string

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -739,7 +739,12 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 				throw new DAV\Exception('The ' . $sccs . ' property must be of type: \Sabre\CalDAV\Property\SupportedCalendarComponentSet');
 			}
 			$values['components'] = implode(',',$properties[$sccs]->getValue());
+		} else if (isset($properties['components'])) {
+			// Allow to provide components internally without having
+			// to create a SupportedCalendarComponentSet object
+			$values['components'] = $properties['components'];
 		}
+
 		$transp = '{' . Plugin::NS_CALDAV . '}schedule-calendar-transp';
 		if (isset($properties[$transp])) {
 			$values['transparent'] = (int) ($properties[$transp]->getValue() === 'transparent');


### PR DESCRIPTION
To test:
- delete your contact's birthday calendar
- run `php occ dav:sync-birthday-calendar`
- check `components` row in database

On master it's `VEVENT,VTODO`
(the default value from https://github.com/nextcloud/server/blob/3a6d8174a92734a3cc4be476163f4a98ca4d3f81/apps/dav/lib/CalDAV/CalDavBackend.php#L731)

On this branch it's `VEVENT`
(as intended in https://github.com/nextcloud/server/blob/3a6d8174a92734a3cc4be476163f4a98ca4d3f81/apps/dav/lib/CalDAV/BirthdayService.php#L147)

fixes #5504 