### PR TITLE
Make log rotation a real rotation

### DIFF
--- a/lib/public/Log/RotationTrait.php
+++ b/lib/public/Log/RotationTrait.php
@@ -49,7 +49,8 @@ trait RotationTrait {
 	 * @since 14.0.0
 	 */
 	protected function rotate():string {
-		$rotatedFile = $this->filePath.'.1';
+		// We use `time()` directly here to avoid loading more classes
+		$rotatedFile = $this->filePath . '.' . time();
 		rename($this->filePath, $rotatedFile);
 		return $rotatedFile;
 	}


### PR DESCRIPTION
before the "rotation" was to rename the file to ".1", overwriting any previous rotation. So basically it just allowed you to have 2 times the log size...