### PR TITLE
Nested recursion breaking max nested level for parent comment calculation

### DIFF
--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -158,9 +158,9 @@ class Manager implements ICommentsManager {
 		$comment = $this->get($id);
 		if ($comment->getParentId() === '0') {
 			return $comment->getId();
-		} else {
-			return $this->determineTopmostParentId($comment->getParentId());
 		}
+
+		return $this->determineTopmostParentId($comment->getParentId());
 	}
 
 	/**

--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -159,7 +159,7 @@ class Manager implements ICommentsManager {
 		if ($comment->getParentId() === '0') {
 			return $comment->getId();
 		} else {
-			return $this->determineTopmostParentId($comment->getId());
+			return $this->determineTopmostParentId($comment->getParentId());
 		}
 	}
 


### PR DESCRIPTION
The bug had no effect so far because the comments app does not allow replying.
However the integration tests I'm writing for https://github.com/nextcloud/spreed/pull/2000 failed with the following error, when replying to a message which was already a reply:
```
Error: Maximum function nesting level of '256' reached, aborting! at …/server/lib/private/Comments/Manager.php#243
```