### PR TITLE
files_external: proper user context for sharing

### DIFF
--- a/apps/files_external/lib/Config/ConfigAdapter.php
+++ b/apps/files_external/lib/Config/ConfigAdapter.php
@@ -76,7 +76,7 @@ class ConfigAdapter implements IMountProvider {
 	 */
 	private function prepareStorageConfig(StorageConfig &$storage, IUser $user) {
 		foreach ($storage->getBackendOptions() as $option => $value) {
-			$storage->setBackendOption($option, \OC_Mount_Config::substitutePlaceholdersInConfig($value));
+			$storage->setBackendOption($option, \OC_Mount_Config::substitutePlaceholdersInConfig($value, $user->getUID()));
 		}
 
 		$objectStore = $storage->getBackendOption('objectstore');

--- a/apps/files_external/lib/Config/SimpleSubstitutionTrait.php
+++ b/apps/files_external/lib/Config/SimpleSubstitutionTrait.php
@@ -34,7 +34,7 @@ trait SimpleSubstitutionTrait {
 	 * @var string the placeholder without $ prefix
 	 * @since 16.0.0
 	 */
-	private $placeholder;
+	protected $placeholder;
 
 	/** @var string */
 	protected $sanitizedPlaceholder;

--- a/apps/files_external/lib/Config/UserContext.php
+++ b/apps/files_external/lib/Config/UserContext.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_External\Config;
+
+use OCP\IRequest;
+use OCP\IUserSession;
+use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\IManager as ShareManager;
+
+class UserContext {
+
+	/** @var IUserSession */
+	private $session;
+
+	/** @var ShareManager */
+	private $shareManager;
+
+	/** @var IRequest */
+	private $request;
+
+	public function __construct(IUserSession $session, ShareManager $manager, IRequest $request) {
+		$this->session = $session;
+		$this->shareManager = $manager;
+		$this->request = $request;
+	}
+
+	public function getSession(): IUserSession {
+		return $this->session;
+	}
+
+
+	protected function getUserId(): ?string {
+		if($this->session && $this->session->getUser() !== null) {
+			return $this->session->getUser()->getUID();
+		}
+		try {
+			$shareToken = $this->request->getParam('token');
+			$share = $this->shareManager->getShareByToken($shareToken);
+			return $share->getShareOwner();
+		} catch (ShareNotFound $e) {}
+
+		return null;
+	}
+
+}

--- a/apps/files_external/lib/Config/UserContext.php
+++ b/apps/files_external/lib/Config/UserContext.php
@@ -39,6 +39,8 @@ class UserContext {
 	/** @var IRequest */
 	private $request;
 
+	private $user;
+
 	public function __construct(IUserSession $session, ShareManager $manager, IRequest $request) {
 		$this->session = $session;
 		$this->shareManager = $manager;
@@ -49,8 +51,14 @@ class UserContext {
 		return $this->session;
 	}
 
+	public function setUser($user): void {
+		$this->user = $user;
+	}
 
 	protected function getUserId(): ?string {
+		if ($this->user !== null) {
+			return $this->user;
+		}
 		if($this->session && $this->session->getUser() !== null) {
 			return $this->session->getUser()->getUID();
 		}

--- a/apps/files_external/lib/Config/UserContext.php
+++ b/apps/files_external/lib/Config/UserContext.php
@@ -24,6 +24,8 @@
 namespace OCA\Files_External\Config;
 
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager as ShareManager;
@@ -39,25 +41,30 @@ class UserContext {
 	/** @var IRequest */
 	private $request;
 
-	private $user;
+	/** @var string */
+	private $userId;
 
-	public function __construct(IUserSession $session, ShareManager $manager, IRequest $request) {
+	/** @var IUserManager */
+	private $userManager;
+
+	public function __construct(IUserSession $session, ShareManager $manager, IRequest $request, IUserManager $userManager) {
 		$this->session = $session;
 		$this->shareManager = $manager;
 		$this->request = $request;
+		$this->userManager = $userManager;
 	}
 
 	public function getSession(): IUserSession {
 		return $this->session;
 	}
 
-	public function setUser($user): void {
-		$this->user = $user;
+	public function setUserId(string $userId): void {
+		$this->userId = $userId;
 	}
 
 	protected function getUserId(): ?string {
-		if ($this->user !== null) {
-			return $this->user;
+		if ($this->userId !== null) {
+			return $this->userId;
 		}
 		if($this->session && $this->session->getUser() !== null) {
 			return $this->session->getUser()->getUID();
@@ -68,6 +75,14 @@ class UserContext {
 			return $share->getShareOwner();
 		} catch (ShareNotFound $e) {}
 
+		return null;
+	}
+
+	protected function getUser(): ?IUser {
+		$userId = $this->getUserId();
+		if($userId !== null) {
+			return $this->userManager->get($userId);
+		}
 		return null;
 	}
 

--- a/apps/files_external/lib/Config/UserPlaceholderHandler.php
+++ b/apps/files_external/lib/Config/UserPlaceholderHandler.php
@@ -23,18 +23,8 @@
 
 namespace OCA\Files_External\Config;
 
-use OCP\IUserSession;
-
-class UserPlaceholderHandler implements IConfigHandler {
+class UserPlaceholderHandler extends UserContext implements IConfigHandler {
 	use SimpleSubstitutionTrait;
-
-	/** @var IUserSession */
-	private $session;
-
-	public function __construct(IUserSession $session) {
-		$this->session = $session;
-		$this->placeholder = 'user';
-	}
 
 	/**
 	 * @param mixed $optionValue
@@ -42,12 +32,11 @@ class UserPlaceholderHandler implements IConfigHandler {
 	 * @since 16.0.0
 	 */
 	public function handle($optionValue) {
-		$user = $this->session->getUser();
-		if($user === null) {
+		$this->placeholder = 'user';
+		$uid = $this->getUserId();
+		if($uid === null) {
 			return $optionValue;
 		}
-		$uid = $user->getUID();
-
 		return $this->processInput($optionValue, $uid);
 	}
 }

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -222,8 +222,8 @@ class OC_Mount_Config {
 		/** @var IConfigHandler[] $handlers */
 		$handlers = $backendService->getConfigHandlers();
 		foreach ($handlers as $handler) {
-			if ($handler instanceof UserContext) {
-				$handler->setUser($user);
+			if ($handler instanceof UserContext && $userId !== null) {
+				$handler->setUserId($userId);
 			}
 			$input = $handler->handle($input);
 		}

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -212,11 +212,12 @@ class OC_Mount_Config {
 
 	/**
 	 * @param mixed $input
+	 * @param string|null $userId
 	 * @return mixed
 	 * @throws \OCP\AppFramework\QueryException
 	 * @since 16.0.0
 	 */
-	public static function substitutePlaceholdersInConfig($input, $user = null) {
+	public static function substitutePlaceholdersInConfig($input, string $userId = null) {
 		/** @var BackendService $backendService */
 		$backendService = self::$app->getContainer()->query(BackendService::class);
 		/** @var IConfigHandler[] $handlers */

--- a/apps/files_external/tests/Config/UserPlaceholderHandlerTest.php
+++ b/apps/files_external/tests/Config/UserPlaceholderHandlerTest.php
@@ -24,8 +24,12 @@
 namespace OCA\files_external\tests\Config;
 
 use OCA\Files_External\Config\UserPlaceholderHandler;
+use OCP\IRequest;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\IManager;
 
 class UserPlaceholderHandlerTest extends \Test\TestCase {
 	/** @var IUser|\PHPUnit_Framework_MockObject_MockObject */
@@ -33,6 +37,15 @@ class UserPlaceholderHandlerTest extends \Test\TestCase {
 
 	/** @var IUserSession|\PHPUnit_Framework_MockObject_MockObject */
 	protected $session;
+
+	/** @var IManager|\PHPUnit_Framework_MockObject_MockObject */
+	private $shareManager;
+
+	/** @var IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	private $request;
+
+	/** @var IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	private $userManager;
 
 	/** @var UserPlaceholderHandler */
 	protected $handler;
@@ -45,8 +58,11 @@ class UserPlaceholderHandlerTest extends \Test\TestCase {
 			->method('getUid')
 			->willReturn('alice');
 		$this->session = $this->createMock(IUserSession::class);
+		$this->shareManager = $this->createMock(IManager::class);
+		$this->request = $this->createMock(IRequest::class);
+		$this->userManager = $this->createMock(IUserManager::class);
 
-		$this->handler = new UserPlaceholderHandler($this->session);
+		$this->handler = new UserPlaceholderHandler($this->session, $this->shareManager, $this->request, $this->userManager);
 	}
 
 	protected function setUser() {
@@ -75,6 +91,9 @@ class UserPlaceholderHandlerTest extends \Test\TestCase {
 	 * @dataProvider optionProvider
 	 */
 	public function testHandleNoUser($option) {
+		$this->shareManager->expects($this->once())
+			->method('getShareByToken')
+			->willThrowException(new ShareNotFound());
 		$this->assertSame($option, $this->handler->handle($option));
 	}
 

--- a/apps/user_ldap/lib/Handler/ExtStorageConfigHandler.php
+++ b/apps/user_ldap/lib/Handler/ExtStorageConfigHandler.php
@@ -25,19 +25,11 @@ namespace OCA\User_LDAP\Handler;
 
 use OCA\Files_External\Config\IConfigHandler;
 use OCA\Files_External\Config\SimpleSubstitutionTrait;
+use OCA\Files_External\Config\UserContext;
 use OCA\User_LDAP\User_Proxy;
-use OCP\IUserSession;
 
-class ExtStorageConfigHandler implements IConfigHandler {
+class ExtStorageConfigHandler extends UserContext implements IConfigHandler {
 	use SimpleSubstitutionTrait;
-
-	/** @var IUserSession */
-	private $session;
-
-	public function __construct(IUserSession $session) {
-		$this->placeholder = 'home';
-		$this->session = $session;
-	}
 
 	/**
 	 * @param mixed $optionValue
@@ -46,7 +38,8 @@ class ExtStorageConfigHandler implements IConfigHandler {
 	 * @throws \Exception
 	 */
 	public function handle($optionValue) {
-		$user = $this->session->getUser();
+		$this->placeholder = 'home';
+		$user = $this->getSession()->getUser();
 		if($user === null) {
 			return $optionValue;
 		}

--- a/apps/user_ldap/lib/Handler/ExtStorageConfigHandler.php
+++ b/apps/user_ldap/lib/Handler/ExtStorageConfigHandler.php
@@ -41,7 +41,7 @@ class ExtStorageConfigHandler extends UserContext implements IConfigHandler {
 		$this->placeholder = 'home';
 		$user = $this->getUser();
 
-		if($user->getUID() === null) {
+		if($user === null) {
 			return $optionValue;
 		}
 

--- a/apps/user_ldap/lib/Handler/ExtStorageConfigHandler.php
+++ b/apps/user_ldap/lib/Handler/ExtStorageConfigHandler.php
@@ -39,8 +39,9 @@ class ExtStorageConfigHandler extends UserContext implements IConfigHandler {
 	 */
 	public function handle($optionValue) {
 		$this->placeholder = 'home';
-		$user = $this->getSession()->getUser();
-		if($user === null) {
+		$user = $this->getUser();
+
+		if($user->getUID() === null) {
 			return $optionValue;
 		}
 


### PR DESCRIPTION
This will make sure we also have a proper user context for non-logged in users that access the instance though share links. Otherwise the file system setup doesn't work properly for share links, if either a $home or $user variable is configured for substitution.

Steps to reproduce:
- Configure external storage mounted to / with $user contained in the path
- Try to access file shared via link