### PR TITLE
Remove files_texteditor from shipped apps

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -14,7 +14,6 @@
     "files_pdfviewer",
     "files_rightclick",
     "files_sharing",
-    "files_texteditor",
     "files_trashbin",
     "files_versions",
     "files_videoplayer",


### PR DESCRIPTION
I just checked if text app is there, not if the old one was removed, so with this the update process will work just fine since the app is not marked as shipped anymore: https://github.com/nextcloud/server/blob/5898e87e0f69ed4a3be73cd044c19d7c4872b639/lib/base.php#L383-L393

Fixes the update issue described in https://github.com/nextcloud/files_texteditor/pull/169#issuecomment-513699438