### PR TITLE
Fix max contrast retrieval to limit minimum color for relative time

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1540,7 +1540,7 @@
 
 			try {
 				var maxContrastHex = window.getComputedStyle(document.documentElement)
-					.getPropertyValue('--color-text-maxcontrast')
+					.getPropertyValue('--color-text-maxcontrast').trim()
 				var maxContrast = parseInt(maxContrastHex.substring(1, 3), 16)
 			} catch(error) {
 				var maxContrast = OCA.Accessibility

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1541,12 +1541,15 @@
 			try {
 				var maxContrastHex = window.getComputedStyle(document.documentElement)
 					.getPropertyValue('--color-text-maxcontrast').trim()
+				if (maxContrastHex.length < 4) {
+					throw Error();
+				}
 				var maxContrast = parseInt(maxContrastHex.substring(1, 3), 16)
 			} catch(error) {
 				var maxContrast = OCA.Accessibility
 					&& OCA.Accessibility.theme === 'themedark'
-						? '130'
-						: '118'
+						? 130
+						: 118
 			}
 
 			// size column


### PR DESCRIPTION
Fixes regression from #14776.


`maxContrastHex` was ` #989898` in my case. The `variables.css` looked fine:

```css
:root {
  --color-main-text: #222;
  --color-main-background: #fff;
  --color-main-background-translucent: rgba(255, 255, 255, 0.97);
  --color-background-dark: #ededed;
  --color-background-darker: #dbdbdb;
  --color-primary: #0082c9;
  --color-primary-text: #fff;
  --color-primary-text-dark: #ededed;
  --color-primary-element: #0082c9;
  --color-primary-element-light: #17adff;
  --color-error: #e9322d;
  --color-warning: #eca700;
  --color-success: #46ba61;
  --color-text-maxcontrast: #989898;
  --color-text-light: #484848;
...
```

Thus I trimmed the whitespace and now the file list does properly take it into account. 

To test this you need quite old files to reach the limit. I changed the `mtime` entry to a timestamp of "1 year ago" in the file cache for the welcome.txt to trigger it.

cc @charburner - https://github.com/nextcloud/server/pull/14776#commitcomment-33670344

