### PR TITLE
fix calendar-user-type reporting

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/Plugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/Plugin.php
@@ -27,6 +27,7 @@ namespace OCA\DAV\CalDAV\Schedule;
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CalDAV\CalendarHome;
 use Sabre\DAV\INode;
+use Sabre\DAV\IProperties;
 use Sabre\DAV\PropFind;
 use Sabre\DAV\Server;
 use Sabre\DAV\Xml\Property\LocalHref;
@@ -55,19 +56,23 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 	 * @return void
 	 */
 	function propFind(PropFind $propFind, INode $node) {
-		// overwrite Sabre/Dav's implementation
-		$propFind->handle('{' . self::NS_CALDAV . '}calendar-user-type', function() use ($node) {
-			$calendarUserType = '{' . self::NS_CALDAV . '}calendar-user-type';
-			$props = $node->getProperties([$calendarUserType]);
-
-			if (isset($props[$calendarUserType])) {
-				return $props[$calendarUserType];
-			}
-
-			return 'INDIVIDUAL';
-		});
-
 		parent::propFind($propFind, $node);
+
+		if ($node instanceof IPrincipal) {
+			// overwrite Sabre/Dav's implementation
+			$propFind->handle('{' . self::NS_CALDAV . '}calendar-user-type', function () use ($node) {
+				if ($node instanceof IProperties) {
+					$calendarUserType = '{' . self::NS_CALDAV . '}calendar-user-type';
+					$props = $node->getProperties([$calendarUserType]);
+
+					if (isset($props[$calendarUserType])) {
+						return $props[$calendarUserType];
+					}
+				}
+
+				return 'INDIVIDUAL';
+			});
+		}
 	}
 
 	/**


### PR DESCRIPTION
This fixes different aspects:
- previously cutype was reported for any node, now Principals only
- properly checks for `IProperties` interface
- call `parent::propFind($propFind, $node);` first, so we actually override the handler