### PR TITLE
Supress warnings touch can generate

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -202,9 +202,9 @@ class Local extends \OC\Files\Storage\Common {
 			return false;
 		}
 		if (!is_null($mtime)) {
-			$result = touch($this->getSourcePath($path), $mtime);
+			$result = @touch($this->getSourcePath($path), $mtime);
 		} else {
-			$result = touch($this->getSourcePath($path));
+			$result = @touch($this->getSourcePath($path));
 		}
 		if ($result) {
 			clearstatcache(true, $this->getSourcePath($path));


### PR DESCRIPTION
We already get the return value. Having the warning being logged explicitly doesn't help and pollutes the log.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>