### PR TITLE
No need to have these classes we tighten the default CSP from time to time

### DIFF
--- a/lib/public/AppFramework/Http/StrictContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/StrictContentSecurityPolicy.php
@@ -39,6 +39,7 @@ namespace OCP\AppFramework\Http;
  *
  * @package OCP\AppFramework\Http
  * @since 14.0.0
+ * @deprecated 17.0.0
  */
 class StrictContentSecurityPolicy extends EmptyContentSecurityPolicy {
 	/** @var bool Whether inline JS snippets are allowed */

--- a/lib/public/AppFramework/Http/StrictEvalContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/StrictEvalContentSecurityPolicy.php
@@ -39,6 +39,7 @@ namespace OCP\AppFramework\Http;
  *
  * @package OCP\AppFramework\Http
  * @since 14.0.0
+ * @deprecated 17.0.0
  */
 class StrictEvalContentSecurityPolicy extends ContentSecurityPolicy {
 

--- a/lib/public/AppFramework/Http/StrictInlineContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/StrictInlineContentSecurityPolicy.php
@@ -39,6 +39,7 @@ namespace OCP\AppFramework\Http;
  *
  * @package OCP\AppFramework\Http
  * @since 14.0.0
+ * @deprecated 17.0.0
  */
 class StrictInlineContentSecurityPolicy extends ContentSecurityPolicy {
 


### PR DESCRIPTION
They don't serve a real purpose now. So lets deprecate and remove them later