### PR TITLE
Fix/xss/on favorite file

### DIFF
--- a/apps/files/js/tagsplugin.js
+++ b/apps/files/js/tagsplugin.js
@@ -103,7 +103,7 @@
 		var innerTagA = document.createElement('A');
 		innerTagA.setAttribute("href", url);
 		innerTagA.setAttribute("class", "nav-icon-files svg");
-		innerTagA.innerHTML = appName;
+		innerTagA.innerHTML = _.escape(appName);
 
 		var length = listLIElements.length + 1;
 		var innerTagLI = document.createElement('li');

--- a/apps/theming/js/3rdparty/jscolor/jscolor.js
+++ b/apps/theming/js/3rdparty/jscolor/jscolor.js
@@ -1100,7 +1100,7 @@ var jsc = {
 				if (jsc.isElementType(this.valueElement, 'input')) {
 					this.valueElement.value = value;
 				} else {
-					this.valueElement.innerHTML = value;
+					this.valueElement.innerHTML = _.escape(value);
 				}
 			}
 			if (!(flags & jsc.leaveStyle)) {


### PR DESCRIPTION
This fixes an XSS vulnerability with low availability in `files/js/tagsplugin.js`.

Additionally this PR addresses a potential XSS in `jscolor.js` - I did not find a call path that could be exploited, but using innerHTML without sanitizing its input is unnecessarily dangerous.