### PR TITLE
setting unsafe-eval is deprecated

### DIFF
--- a/lib/private/Security/CSP/ContentSecurityPolicy.php
+++ b/lib/private/Security/CSP/ContentSecurityPolicy.php
@@ -54,6 +54,8 @@ class ContentSecurityPolicy extends \OCP\AppFramework\Http\ContentSecurityPolicy
 
 	/**
 	 * @param boolean $evalScriptAllowed
+	 *
+	 * @deprecated 17.0.0 Unsafe eval should not be used anymore.
 	 */
 	public function setEvalScriptAllowed(bool $evalScriptAllowed) {
 		$this->evalScriptAllowed = $evalScriptAllowed;


### PR DESCRIPTION
This will be removed in a future version of Nextcloud.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>