### PR TITLE
Standardize scrollbar color and width across Webkit and Firefox

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -23,6 +23,8 @@ html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pr
 	font-family: inherit;
 	vertical-align: baseline;
 	cursor: default;
+	scrollbar-color: var(--color-border-dark) transparent;
+	scrollbar-width: thin;
 }
 
 html, body {
@@ -146,7 +148,7 @@ body {
 /* SCROLLING */
 
 ::-webkit-scrollbar {
-	width: 9px;
+	width: 6px;
 	height: 5px;
 }
 
@@ -155,9 +157,10 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-	background: var(--color-background-darker);
+	background: var(--color-border-dark);
 	border-radius: var(--border-radius);
 }
+
 
 /* SELECTION */
 


### PR DESCRIPTION
Especially in dark mode, the scrollbars in Firefox looked horrible:
![Firefox dark scroll before](https://user-images.githubusercontent.com/925062/62230569-5c97f280-b3c2-11e9-8863-b5b1dc6610f5.png)


This is now fixed and standardized across Chrome and Firefox (Firefox doesn’t support the slight rounding yet):

Chrome:
![Chrome light scroll](https://user-images.githubusercontent.com/925062/62230582-64579700-b3c2-11e9-8b7e-b76776671334.png)
Firefox:
![Firefox light scroll](https://user-images.githubusercontent.com/925062/62230584-64f02d80-b3c2-11e9-82a7-173c78b2df19.png)
Chrome:
![Chrome dark scroll](https://user-images.githubusercontent.com/925062/62230583-64f02d80-b3c2-11e9-8119-cf1d99ed5027.png)
Firefox:
![firefox dark scroll](https://user-images.githubusercontent.com/925062/62230585-64f02d80-b3c2-11e9-9ebc-649556df8ec4.png)
