### PR TITLE
Make sure we only fetch the file by id for the actual owner

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -183,7 +183,7 @@ class Storage {
 		$eventDispatcher = \OC::$server->getEventDispatcher();
 		$fileInfo = $files_view->getFileInfo($filename);
 		$id = $fileInfo->getId();
-		$nodes = \OC::$server->getRootFolder()->getById($id);
+		$nodes = \OC::$server->getRootFolder()->getUserFolder($uid)->getById($id);
 		foreach ($nodes as $node) {
 			$event = new CreateVersionEvent($node);
 			$eventDispatcher->dispatch('OCA\Files_Versions::createVersion', $event);


### PR DESCRIPTION
The main issue is that getById on the root folder fetches a list of nodes from all mountpoints where the fileId is found. This is a quite expensive operation especially if there are lots of mounts for the given file. We only need the owners node for emitting an event here.
