### PR TITLE
Set proper root path for single file shares originating from other storages

### DIFF
--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -244,57 +244,55 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 	}
 
 	public function fopen($path, $mode) {
-		if ($source = $this->getUnjailedPath($path)) {
-			switch ($mode) {
-				case 'r+':
-				case 'rb+':
-				case 'w+':
-				case 'wb+':
-				case 'x+':
-				case 'xb+':
-				case 'a+':
-				case 'ab+':
-				case 'w':
-				case 'wb':
-				case 'x':
-				case 'xb':
-				case 'a':
-				case 'ab':
-					$creatable = $this->isCreatable(dirname($path));
-					$updatable = $this->isUpdatable($path);
-					// if neither permissions given, no need to continue
-					if (!$creatable && !$updatable) {
-						if (pathinfo($path, PATHINFO_EXTENSION) === 'part') {
-							$updatable = $this->isUpdatable(dirname($path));
-						}
-
-						if (!$updatable) {
-							return false;
-						}
+		$source = $this->getUnjailedPath($path);
+		switch ($mode) {
+			case 'r+':
+			case 'rb+':
+			case 'w+':
+			case 'wb+':
+			case 'x+':
+			case 'xb+':
+			case 'a+':
+			case 'ab+':
+			case 'w':
+			case 'wb':
+			case 'x':
+			case 'xb':
+			case 'a':
+			case 'ab':
+				$creatable = $this->isCreatable(dirname($path));
+				$updatable = $this->isUpdatable($path);
+				// if neither permissions given, no need to continue
+				if (!$creatable && !$updatable) {
+					if (pathinfo($path, PATHINFO_EXTENSION) === 'part') {
+						$updatable = $this->isUpdatable(dirname($path));
 					}
 
-					$exists = $this->file_exists($path);
-					// if a file exists, updatable permissions are required
-					if ($exists && !$updatable) {
+					if (!$updatable) {
 						return false;
 					}
+				}
 
-					// part file is allowed if !$creatable but the final file is $updatable
-					if (pathinfo($path, PATHINFO_EXTENSION) !== 'part') {
-						if (!$exists && !$creatable) {
-							return false;
-						}
+				$exists = $this->file_exists($path);
+				// if a file exists, updatable permissions are required
+				if ($exists && !$updatable) {
+					return false;
+				}
+
+				// part file is allowed if !$creatable but the final file is $updatable
+				if (pathinfo($path, PATHINFO_EXTENSION) !== 'part') {
+					if (!$exists && !$creatable) {
+						return false;
 					}
-			}
-			$info = [
-				'target' => $this->getMountPoint() . $path,
-				'source' => $source,
-				'mode' => $mode,
-			];
-			\OCP\Util::emitHook('\OC\Files\Storage\Shared', 'fopen', $info);
-			return $this->nonMaskedStorage->fopen($this->getUnjailedPath($path), $mode);
+				}
 		}
-		return false;
+		$info = [
+			'target' => $this->getMountPoint() . $path,
+			'source' => $source,
+			'mode' => $mode,
+		];
+		\OCP\Util::emitHook('\OC\Files\Storage\Shared', 'fopen', $info);
+		return $this->nonMaskedStorage->fopen($this->getUnjailedPath($path), $mode);
 	}
 
 	/**

--- a/lib/private/Files/Storage/Wrapper/Jail.php
+++ b/lib/private/Files/Storage/Wrapper/Jail.php
@@ -56,11 +56,7 @@ class Jail extends Wrapper {
 	}
 
 	public function getUnjailedPath($path) {
-		if ($path === '') {
-			return $this->rootPath;
-		} else {
-			return Filesystem::normalizePath($this->rootPath . '/' . $path);
-		}
+		return Filesystem::normalizePath($this->rootPath . '/' . $path);
 	}
 
 	/**

--- a/lib/private/Files/Storage/Wrapper/Jail.php
+++ b/lib/private/Files/Storage/Wrapper/Jail.php
@@ -56,7 +56,7 @@ class Jail extends Wrapper {
 	}
 
 	public function getUnjailedPath($path) {
-		return Filesystem::normalizePath($this->rootPath . '/' . $path);
+		return trim(Filesystem::normalizePath($this->rootPath . '/' . $path), '/');
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/16617

The main issue here seems to be that the SharedStorage assumes an non-empty result of getUnjailedPath in https://github.com/nextcloud/server/blob/d5f19c1031c4abc7abe9986d1f0b786df5885dbf/apps/files_sharing/lib/SharedStorage.php#L249 which is not given for shares that originate in the root of a mountpoint (like single file federated shares).

I'm not 100% sure this is the right approach, so some input from @icewind1991 or @rullzer  would be highly appreciated. :wink: Maybe we could even just obit the if statement checking for the getUnjailedPath not being empty?