### PR TITLE
Remove type for size arg on Streamer constructor

### DIFF
--- a/lib/private/Streamer.php
+++ b/lib/private/Streamer.php
@@ -53,7 +53,7 @@ class Streamer {
 	 * @param int $numberOfFiles The number of files (and directories) that will
 	 *        be included in the streamed file
 	 */
-	public function __construct(IRequest $request, int $size, int $numberOfFiles) {
+	public function __construct(IRequest $request, $size, int $numberOfFiles) {
 
 		/**
 		 * zip32 constraints for a basic (without compression, volumes nor


### PR DESCRIPTION
Resolves #12422 and #15117

On 32 bit systems integers can not be bigger than 2 147 483 647. This is problematic as it throws an error when downloading a folder bigger than 2Go because php will cast the size to float.