### PR TITLE
delay sending event from app init to when they are needed

### DIFF
--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -93,12 +93,6 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 		// force-load auth mechanisms since some will register hooks
 		// TODO: obsolete these and use the TokenProvider to get the user's password from the session
 		$this->getAuthMechanisms();
-
-		// don't remove this, as app loading order might be a side effect and
-		// querying the service from the server not reliable
-		\OC::$server->getEventDispatcher()->dispatch(
-			'OCA\\Files_External::loadAdditionalBackends'
-		);
 	}
 
 	/**

--- a/apps/files_external/lib/Service/BackendService.php
+++ b/apps/files_external/lib/Service/BackendService.php
@@ -106,7 +106,18 @@ class BackendService {
 		$this->backendProviders[] = $provider;
 	}
 
+	private function callForRegistrations() {
+		static $eventSent = false;
+		if(!$eventSent) {
+			\OC::$server->getEventDispatcher()->dispatch(
+				'OCA\\Files_External::loadAdditionalBackends'
+			);
+			$eventSent = true;
+		}
+	}
+
 	private function loadBackendProviders() {
+		$this->callForRegistrations();
 		foreach ($this->backendProviders as $provider) {
 			$this->registerBackends($provider->getBackends());
 		}
@@ -124,6 +135,7 @@ class BackendService {
 	}
 
 	private function loadAuthMechanismProviders() {
+		$this->callForRegistrations();
 		foreach ($this->authMechanismProviders as $provider) {
 			$this->registerAuthMechanisms($provider->getAuthMechanisms());
 		}
@@ -321,6 +333,7 @@ class BackendService {
 	}
 
 	protected function loadConfigHandlers():void {
+		$this->callForRegistrations();
 		$newLoaded = false;
 		foreach ($this->configHandlerLoaders as $placeholder => $loader) {
 			$handler = $loader();


### PR DESCRIPTION
Found while working on #16525, this is how to reproduce:

1. Have LDAP enabled and an attributre entered for the "$home" variable for the external storage
2. Have an external storage configured using it
3.  Run `occ files:scan` for an affected user

Output Before:

```
…
        Folder  /62A5ABEE-0360-47BE-BD40-1E5E387686BA/files_trashbin/files/Ogogogog.d1563983159
        Folder  /62A5ABEE-0360-47BE-BD40-1E5E387686BA/files/Common Files (Samba4)/
…
```

Output now (see the personal files showing up):

```
…
        Folder  /62A5ABEE-0360-47BE-BD40-1E5E387686BA/files_trashbin/files/Ogogogog.d1563983159
        Folder  /62A5ABEE-0360-47BE-BD40-1E5E387686BA/files/Personal Files (Samba4)/
        File    /62A5ABEE-0360-47BE-BD40-1E5E387686BA/files/Personal Files (Samba4)/Backtrace2.txt
        Folder  /62A5ABEE-0360-47BE-BD40-1E5E387686BA/files/Common Files (Samba4)/
…
```

No problem in the web interface.