### PR TITLE
Correctly handle emtpy string in proxyuserpwd config

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -113,14 +113,14 @@ class Client implements IClient {
 	 * @return string
 	 */
 	private function getProxyUri(): string {
-		$proxyHost = $this->config->getSystemValue('proxy', null);
-		$proxyUserPwd = $this->config->getSystemValue('proxyuserpwd', null);
+		$proxyHost = $this->config->getSystemValue('proxy', '');
+		$proxyUserPwd = $this->config->getSystemValue('proxyuserpwd', '');
 		$proxyUri = '';
 
-		if ($proxyUserPwd !== null) {
+		if ($proxyUserPwd !== '' && $proxyUserPwd !== null) {
 			$proxyUri .= $proxyUserPwd . '@';
 		}
-		if ($proxyHost !== null) {
+		if ($proxyHost !== '' && $proxyHost !== null) {
 			$proxyUri .= $proxyHost;
 		}
 


### PR DESCRIPTION
As documented, the default value for config value proxyuserpwd is ''.
However, that value results in the error:
 "cURL error 5: Unsupported proxy syntax in '@'".
This patch handles the values of '' and null (the default in the code)
the same for config values proxyuserpwd and proxy.

Signed-off-by: Scott Shambarger <devel@shambarger.net>