### PR TITLE
Update MemoryInfo.php

### DIFF
--- a/lib/private/MemoryInfo.php
+++ b/lib/private/MemoryInfo.php
@@ -76,6 +76,6 @@ class MemoryInfo {
 				$memoryLimit *= 1024;
 		}
 
-		return $memoryLimit;
+		return (int)$memoryLimit;
 	}
 }


### PR DESCRIPTION
fixed memoryLimitToBytes function, which was causing TypeError on some servers, when memory_limit in php.ini was writen as non numeric. the error was:
TypeError: Return value of OC\MemoryInfo::memoryLimitToBytes() must be of the type integer, float returned