### PR TITLE
prevent the server's app-navigation's css to overrule the scoped css …

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -77,7 +77,7 @@ kbd {
 
 /* APP-NAVIGATION ------------------------------------------------------------ */
 /* Navigation: folder like structure */
-#app-navigation {
+#app-navigation:not(.vue) {
 	width: $navigation-width;
 	position: fixed;
 	top: $header-height;


### PR DESCRIPTION
Prevent the server's app-navigation's css to overrule the scoped css in vue components. 

This allows us to migrate and refactor the css across the new `<Appnavigation>` component and its children.  

Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>