### PR TITLE
files_trashbin: File can be without extension

### DIFF
--- a/apps/files_trashbin/lib/Controller/PreviewController.php
+++ b/apps/files_trashbin/lib/Controller/PreviewController.php
@@ -103,7 +103,7 @@ class PreviewController extends Controller {
 			}
 
 			$pathParts = pathinfo($file->getName());
-			$extension = $pathParts['extension'];
+			$extension = $pathParts['extension'] ?? '';
 			$fileName = $pathParts['filename'];
 			/*
 			 * Files in the root of the trashbin are timetamped.


### PR DESCRIPTION
After this change, log will not contains warning when generating preview for deleted file without extension.