### PR TITLE
Emit moveToTrash event only for the deleting user

### DIFF
--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -127,13 +127,19 @@ class Storage extends Wrapper {
 	protected function shouldMoveToTrash($path) {
 		$normalized = Filesystem::normalizePath($this->mountPoint . '/' . $path);
 		$parts = explode('/', $normalized);
-		if (count($parts) < 4 ||  !$this->userManager->userExists($parts[1])) {
+		if (count($parts) < 4) {
 			return false;
 		}
 
 		// check if there is a app which want to disable the trash bin for this file
 		$fileId = $this->storage->getCache()->getId($path);
-		$nodes = $this->rootFolder->getUserFolder($parts[1])->getById($fileId);
+		$owner = $this->storage->getOwner($path);
+		if ($owner === false) {
+			$nodes = $this->rootFolder->getById($fileId);
+		} else {
+			$nodes = $this->rootFolder->getUserFolder($owner)->getById($fileId);
+		}
+
 		foreach ($nodes as $node) {
 			$event = $this->createMoveToTrashEvent($node);
 			$this->eventDispatcher->dispatch('OCA\Files_Trashbin::moveToTrash', $event);
@@ -142,7 +148,7 @@ class Storage extends Wrapper {
 			}
 		}
 
-		if ($parts[2] === 'files') {
+		if ($parts[2] === 'files' && $this->userManager->userExists($parts[1])) {
 			return true;
 		}
 

--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -125,10 +125,15 @@ class Storage extends Wrapper {
 	 * @return bool
 	 */
 	protected function shouldMoveToTrash($path) {
+		$normalized = Filesystem::normalizePath($this->mountPoint . '/' . $path);
+		$parts = explode('/', $normalized);
+		if (count($parts) < 4 ||  !$this->userManager->userExists($parts[1])) {
+			return false;
+		}
 
 		// check if there is a app which want to disable the trash bin for this file
 		$fileId = $this->storage->getCache()->getId($path);
-		$nodes = $this->rootFolder->getById($fileId);
+		$nodes = $this->rootFolder->getUserFolder($parts[1])->getById($fileId);
 		foreach ($nodes as $node) {
 			$event = $this->createMoveToTrashEvent($node);
 			$this->eventDispatcher->dispatch('OCA\Files_Trashbin::moveToTrash', $event);
@@ -137,13 +142,7 @@ class Storage extends Wrapper {
 			}
 		}
 
-		$normalized = Filesystem::normalizePath($this->mountPoint . '/' . $path);
-		$parts = explode('/', $normalized);
-		if (count($parts) < 4) {
-			return false;
-		}
-
-		if ($parts[2] === 'files' && $this->userManager->userExists($parts[1])) {
+		if ($parts[2] === 'files') {
 			return true;
 		}
 

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -36,6 +36,7 @@ use OCA\Files_Trashbin\Events\MoveToTrashEvent;
 use OCA\Files_Trashbin\Storage;
 use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCP\Files\Cache\ICache;
+use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\ILogger;
@@ -545,12 +546,14 @@ class StorageTest extends \Test\TestCase {
 		$logger = $this->getMockBuilder(ILogger::class)->getMock();
 		$eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 		$rootFolder = $this->createMock(IRootFolder::class);
+		$userFolder = $this->createMock(Folder::class);
 		$node = $this->getMockBuilder(Node::class)->disableOriginalConstructor()->getMock();
 		$trashManager = $this->createMock(ITrashManager::class);
 		$event = $this->getMockBuilder(MoveToTrashEvent::class)->disableOriginalConstructor()->getMock();
 		$event->expects($this->any())->method('shouldMoveToTrashBin')->willReturn(!$appDisablesTrash);
 
-		$rootFolder->expects($this->any())->method('getById')->with($fileID)->willReturn([$node]);
+		$userFolder->expects($this->any())->method('getById')->with($fileID)->willReturn([$node]);
+		$rootFolder->expects($this->any())->method('getUserFolder')->willReturn($userFolder);
 
 		$storage = $this->getMockBuilder(Storage::class)
 			->setConstructorArgs(


### PR DESCRIPTION
This is the same issue as in https://github.com/nextcloud/server/pull/16624 which causes a huge loading time caused by iterating over all mounts for a file id for all users if getById is called on the RootFolder:

https://github.com/nextcloud/server/blob/e43b341b04c5e13424f2d833803c0e444f8ab3b2/lib/private/Files/Node/Folder.php#L292

Since the moveToTrash event is only used in e2ee it should be fine to just check for the file in the users mount who is trying to delete the file.
