### PR TITLE
14.0.14 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(14, 0, 13, 1);
+$OC_Version = array(14, 0, 14, 0);
 
 // The human readable string
-$OC_VersionString = '14.0.13';
+$OC_VersionString = '14.0.14 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #16193 Forward OCSException to initiator
* #16342 Bump lodash.merge from 4.6.1 to 4.6.2 in /settings
* #16347 Bump lodash from 4.17.11 to 4.17.14 in /settings
* #16354 Bump lodash from 4.17.11 to 4.17.14 in /apps/oauth2
* #16355 Bump lodash from 4.17.11 to 4.17.14 in /apps/updatenotification
* #16356 Bump lodash from 4.17.11 to 4.17.14 in /build
* #16358 Bump lodash from 4.17.11 to 4.17.14 in /apps/accessibility
* #16427 Only prevent disabling encrytion via the API
* #16434 Do not keep searching for recent
* #16609 Set proper defaults for v-tooltip usages
* #16612 Fix/xss/on favorite file
* #16648 Bump lodash.mergewith from 4.6.1 to 4.6.2 in /build
* #16650 Bump fstream from 1.0.11 to 1.0.12 in /build
* [notifications#386](https://github.com/nextcloud/notifications/pull/386) Trim the subject before encrypting the subject