### PR TITLE
15.0.11 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(15, 0, 10, 0);
+$OC_Version = array(15, 0, 11, 0);
 
 // The human readable string
-$OC_VersionString = '15.0.10';
+$OC_VersionString = '15.0.11 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #16326 Prevent undefined offset 0 in findByUserIdOrMail
* #16344 Bump lodash.mergewith from 4.6.1 to 4.6.2 in /settings
* #16345 Bump lodash.merge from 4.6.1 to 4.6.2 in /settings
* #16346 Bump lodash.mergewith from 4.6.1 to 4.6.2 in /build
* #16348 Bump lodash from 4.17.11 to 4.17.14 in /apps/accessibility
* #16350 Bump lodash from 4.17.11 to 4.17.13 in /settings
* #16351 Bump lodash from 4.17.11 to 4.17.14 in /apps/updatenotification
* #16353 Bump lodash from 4.17.11 to 4.17.14 in /build
* #16357 Bump lodash from 4.17.11 to 4.17.14 in /apps/oauth2
* #16426 Only prevent disabling encrytion via the API
* #16433 Do not keep searching for recent
* #16445 Fix File#putContents(string) on ObjectStorage
* #16537 Allow to provide supported calendar component set internally as a string
* #16548 Bump fstream from 1.0.11 to 1.0.12 in /build
* #16549 Bump fstream from 1.0.11 to 1.0.12 in /settings
* #16565 Use a pattern to identify sensitive config keys
* #16568 Change send to sent
* #16608 Set proper defaults for v-tooltip usages
* #16611 Fix/xss/on favorite file
* #16631 Make sure we only fetch the file by id for the actual owner
* #16690 Properly return an int in the getId function of the cache
* [files_pdfviewer#146](https://github.com/nextcloud/files_pdfviewer/pull/146) Fix download button shown in public share page with hidden downloads
* [notifications#377](https://github.com/nextcloud/notifications/pull/377) Bump lodash from 4.17.10 to 4.17.14
* [notifications#385](https://github.com/nextcloud/notifications/pull/385) Trim the subject before encrypting the subject


Pending PRs:

* [x] #16224 Dont use part files for dav writes when the target folder doesn't have create permissions @backportbot-nextcloud
* [x] #16692 Fix enable/disable user audit message @backportbot-nextcloud