### PR TITLE
16.0.4 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(16, 0, 3, 0);
+$OC_Version = array(16, 0, 4, 0);
 
 // The human readable string
-$OC_VersionString = '16.0.3';
+$OC_VersionString = '16.0.4 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #16254 Always set the display name for user shares
* #16325 Prevent undefined offset 0 in findByUserIdOrMail
* #16330 Use HTTP1.1 to read S3 objects
* #16338 Bump lodash.mergewith from 4.6.1 to 4.6.2
* #16341 Bump lodash.merge from 4.6.1 to 4.6.2
* #16352 Bump lodash from 4.17.11 to 4.17.13
* #16405 Addsubtag should push to array
* #16414 Add catch for RuntimeException
* #16425 Only prevent disabling encrytion via the API
* #16432 Do not keep searching for recent
* #16437 Update operationprogressbar.js
* #16444 Fix File#putContents(string) on ObjectStorage
* #16500 Pass $configargs to openssl_pkey_export
* #16524 Nested recursion breaking max nested level for parent comment calculation
* #16527 Allow hidden smb shares
* #16536 Allow to provide supported calendar component set internally as a string
* #16541 Lock SCSS so we only run 1 job at a time
* #16543 Fix max contrast retrieval to limit minimum color for relative time
* #16561 Supresses disclosing the userid for LDAP users in the welcome mail
* #16562 Use a pattern to identify sensitive config keys
* #16564 Do not log locked files
* #16566 Log email shares in admin_audit log
* #16567 Change send to sent
* #16578 Do not log all locked exceptions
* #16598 Check the if we can actually access the storage cache for recent files
* #16607 Set proper defaults for v-tooltip usages
* #16610 Fix/xss/on favorite file
* #16627 Log circles and remote shares in admin_audit
* #16630 Make sure we only fetch the file by id for the actual owner
* #16633 Remove unncessary code block in share recommendations, fixed undefined var error
* #16637 Files_external: proper user context for sharing
* #16689 Properly return an int in the getId function of the cache
* #16691 Fix enable/disable user audit message
* [files_pdfviewer#145](https://github.com/nextcloud/files_pdfviewer/pull/145) Fix download button shown in public share page with hidden downloads
* [files_texteditor#176](https://github.com/nextcloud/files_texteditor/pull/176) Run drone for webpack build
* [files_videoplayer#135](https://github.com/nextcloud/files_videoplayer/pull/135) Bump lodash from 4.17.11 to 4.17.14
* [firstrunwizard#199](https://github.com/nextcloud/firstrunwizard/pull/199) Bump lodash.mergewith from 4.6.1 to 4.6.2
* [firstrunwizard#200](https://github.com/nextcloud/firstrunwizard/pull/200) Bump lodash.merge from 4.6.1 to 4.6.2
* [firstrunwizard#202](https://github.com/nextcloud/firstrunwizard/pull/202) Bump lodash from 4.17.11 to 4.17.14
* [firstrunwizard#205](https://github.com/nextcloud/firstrunwizard/pull/205) Bump fstream from 1.0.11 to 1.0.12
* [notifications#376](https://github.com/nextcloud/notifications/pull/376) Bump lodash from 4.17.11 to 4.17.13
* [notifications#384](https://github.com/nextcloud/notifications/pull/384) Trim the subject before encrypting the subject
* [notifications#390](https://github.com/nextcloud/notifications/pull/390) Align the notification subject vertically to the icon
* [notifications#391](https://github.com/nextcloud/notifications/pull/391) Fix notification body text alignment and text contrast
* [notifications#392](https://github.com/nextcloud/notifications/pull/392) Fix mention and actions layout
* [recommendations#105](https://github.com/nextcloud/recommendations/pull/105) Bump lodash.mergewith from 4.6.1 to 4.6.2
* [recommendations#107](https://github.com/nextcloud/recommendations/pull/107) Bump lodash from 4.17.11 to 4.17.14
* [viewer#102](https://github.com/nextcloud/viewer/pull/102) Bump cypress-image-snapshot from 3.0.1 to 3.0.2
* [viewer#103](https://github.com/nextcloud/viewer/pull/103) Bump babel-loader from 8.0.5 to 8.0.6
* [viewer#104](https://github.com/nextcloud/viewer/pull/104) Bump cypress-file-upload from 3.1.1 to 3.1.2
* [viewer#109](https://github.com/nextcloud/viewer/pull/109) Bump @babel/preset-env from 7.4.4 to 7.4.5
* [viewer#116](https://github.com/nextcloud/viewer/pull/116) Bump eslint-plugin-node from 9.0.1 to 9.1.0
* [viewer#119](https://github.com/nextcloud/viewer/pull/119) Bump cypress-testing-library from 3.0.1 to 4.0.0
* [viewer#121](https://github.com/nextcloud/viewer/pull/121) Bump nextcloud-vue from 0.11.3 to 0.11.4
* [viewer#127](https://github.com/nextcloud/viewer/pull/127) Bump webpack-cli from 3.3.2 to 3.3.3
* [viewer#130](https://github.com/nextcloud/viewer/pull/130) Bump file-loader from 3.0.1 to 4.0.0
* [viewer#131](https://github.com/nextcloud/viewer/pull/131) Bump cypress-image-snapshot from 3.1.0 to 3.1.1
* [viewer#135](https://github.com/nextcloud/viewer/pull/135) Bump webpack from 4.33.0 to 4.34.0
* [viewer#137](https://github.com/nextcloud/viewer/pull/137) Bump cypress-file-upload from 3.1.2 to 3.1.3
* [viewer#138](https://github.com/nextcloud/viewer/pull/138) Bump webpack-cli from 3.3.3 to 3.3.4
* [viewer#139](https://github.com/nextcloud/viewer/pull/139) Bump nextcloud-server from 0.15.9 to 0.15.10
* [viewer#144](https://github.com/nextcloud/viewer/pull/144) Bump webpack from 4.34.0 to 4.35.0
* [viewer#152](https://github.com/nextcloud/viewer/pull/152) Bump eslint-plugin-vue from 5.2.2 to 5.2.3
* [viewer#153](https://github.com/nextcloud/viewer/pull/153) Bump webpack-cli from 3.3.4 to 3.3.5
* [viewer#154](https://github.com/nextcloud/viewer/pull/154) Bump eslint-plugin-promise from 4.1.1 to 4.2.1
* [viewer#155](https://github.com/nextcloud/viewer/pull/155) Bump url-loader from 2.0.0 to 2.0.1
* [viewer#156](https://github.com/nextcloud/viewer/pull/156) Bump eslint-plugin-import from 2.17.3 to 2.18.0
* [viewer#165](https://github.com/nextcloud/viewer/pull/165) Bump eslint-loader from 2.1.2 to 2.2.1
* [viewer#176](https://github.com/nextcloud/viewer/pull/176) Bump webpack from 4.35.2 to 4.35.3
* [viewer#178](https://github.com/nextcloud/viewer/pull/178) Bump stylelint-scss from 3.8.0 to 3.9.1
* [viewer#182](https://github.com/nextcloud/viewer/pull/182) Bump eslint-plugin-import from 2.18.0 to 2.18.2
* [viewer#187](https://github.com/nextcloud/viewer/pull/187) Bump webpack-cli from 3.3.5 to 3.3.6
* [viewer#188](https://github.com/nextcloud/viewer/pull/188) Bump vue-loader from 15.7.0 to 15.7.1
* [viewer#189](https://github.com/nextcloud/viewer/pull/189) Bump webpack from 4.35.3 to 4.36.1
* [viewer#194](https://github.com/nextcloud/viewer/pull/194) Bump webpack from 4.36.1 to 4.38.0
* [viewer#196](https://github.com/nextcloud/viewer/pull/196) Bump url-loader from 2.0.1 to 2.1.0
* [viewer#201](https://github.com/nextcloud/viewer/pull/201) Bump lodash from 4.17.11 to 4.17.15
* [viewer#202](https://github.com/nextcloud/viewer/pull/202) Bump webpack from 4.38.0 to 4.39.0
* [viewer#204](https://github.com/nextcloud/viewer/pull/204) Bump webpack from 4.39.0 to 4.39.1
* [viewer#47](https://github.com/nextcloud/viewer/pull/47) Detect and switch fullscreen
* [viewer#66](https://github.com/nextcloud/viewer/pull/66) Update version on master
* [viewer#67](https://github.com/nextcloud/viewer/pull/67) Test actions
* [viewer#68](https://github.com/nextcloud/viewer/pull/68) Revert "Test actions"
* [viewer#69](https://github.com/nextcloud/viewer/pull/69) Bump nextcloud-vue from 0.9.5 to 0.10.0
* [viewer#70](https://github.com/nextcloud/viewer/pull/70) Bump eslint-plugin-import from 2.16.0 to 2.17.2
* [viewer#71](https://github.com/nextcloud/viewer/pull/71) Bump eslint-import-resolver-webpack from 0.11.0 to 0.11.1
* [viewer#72](https://github.com/nextcloud/viewer/pull/72) Bump webpack from 4.29.6 to 4.30.0
* [viewer#73](https://github.com/nextcloud/viewer/pull/73) Fix/loading/race condition
* [viewer#90](https://github.com/nextcloud/viewer/pull/90) Bump webpack-cli from 3.3.1 to 3.3.2
* [viewer#92](https://github.com/nextcloud/viewer/pull/92) Bump eslint-plugin-node from 8.0.1 to 9.0.1
* [viewer#96](https://github.com/nextcloud/viewer/pull/96) Bump webpack from 4.30.0 to 4.31.0

Pending PRs:

* [x] #16695 Delay sending event from app init to when they are needed @backportbot-nextcloud
* [x] [files_texteditor#169](https://github.com/nextcloud/files_texteditor/pull/169) Change name from 'Text editor' to 'Plain text editor' to prevent confusion with 'Text' @backportbot-nextcloud