### PR TITLE
Fix login flow form actions

### DIFF
--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -195,7 +195,10 @@ class ClientFlowLoginController extends Controller {
 		);
 		$this->session->set(self::stateName, $stateToken);
 
-		return new StandaloneTemplateResponse(
+		$csp = new Http\ContentSecurityPolicy();
+		$csp->addAllowedFormActionDomain('nc://*');
+
+		$response = new StandaloneTemplateResponse(
 			$this->appName,
 			'loginflow/authpicker',
 			[
@@ -209,6 +212,9 @@ class ClientFlowLoginController extends Controller {
 			],
 			'guest'
 		);
+
+		$response->setContentSecurityPolicy($csp);
+		return $response;
 	}
 
 	/**
@@ -234,7 +240,10 @@ class ClientFlowLoginController extends Controller {
 			$clientName = $client->getName();
 		}
 
-		return new StandaloneTemplateResponse(
+		$csp = new Http\ContentSecurityPolicy();
+		$csp->addAllowedFormActionDomain('nc://*');
+
+		$response = new StandaloneTemplateResponse(
 			$this->appName,
 			'loginflow/grant',
 			[
@@ -248,6 +257,9 @@ class ClientFlowLoginController extends Controller {
 			],
 			'guest'
 		);
+
+		$response->setContentSecurityPolicy($csp);
+		return $response;
 	}
 
 	/**

--- a/tests/Core/Controller/ClientFlowLoginControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginControllerTest.php
@@ -186,6 +186,9 @@ class ClientFlowLoginControllerTest extends TestCase {
 			],
 			'guest'
 		);
+		$csp = new Http\ContentSecurityPolicy();
+		$csp->addAllowedFormActionDomain('nc://*');
+		$expected->setContentSecurityPolicy($csp);
 		$this->assertEquals($expected, $this->clientFlowLoginController->showAuthPickerPage());
 	}
 
@@ -245,6 +248,9 @@ class ClientFlowLoginControllerTest extends TestCase {
 			],
 			'guest'
 		);
+		$csp = new Http\ContentSecurityPolicy();
+		$csp->addAllowedFormActionDomain('nc://*');
+		$expected->setContentSecurityPolicy($csp);
 		$this->assertEquals($expected, $this->clientFlowLoginController->showAuthPickerPage('MyClientIdentifier'));
 	}
 


### PR DESCRIPTION
So fun fact. Chrome considers a redirect after submitting a form part of
the form actions. Since we redirect to a new protocol (nc://login/).
Causing the form submission to work but the redirect failing hard.

Basically otherwise master is broken with the desktop client (uses chromium) and probably 90% of android (also chrome).

Easiest way to test is probably to try to authenticate your desktop client via the login flow