### PR TITLE
Correctly handle emtpy string in proxyuserpwd config

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -95,15 +95,15 @@ class Client implements IClient {
 	 * @return string|null
 	 */
 	private function getProxyUri(): ?string {
-		$proxyHost = $this->config->getSystemValue('proxy', null);
+		$proxyHost = $this->config->getSystemValue('proxy', '');
 
-		if ($proxyHost === null) {
+		if ($proxyHost === '' || $proxyHost === null) {
 			return null;
 		}
 
-		$proxyUserPwd = $this->config->getSystemValue('proxyuserpwd', null);
+		$proxyUserPwd = $this->config->getSystemValue('proxyuserpwd', '');
 
-		if ($proxyUserPwd === null) {
+		if ($proxyUserPwd === '' || $proxyUserPwd === null) {
 			return $proxyHost;
 		}
 

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -70,12 +70,22 @@ class ClientTest extends \Test\TestCase {
 		$this->config
 			->expects($this->at(0))
 			->method('getSystemValue')
-			->with('proxy', null)
+			->with(
+				$this->equalTo('proxy'),
+				$this->callback(function ($input) {
+					return $input === '';
+				})
+			)
 			->willReturn('foo');
 		$this->config
 			->expects($this->at(1))
 			->method('getSystemValue')
-			->with('proxyuserpwd', null)
+			->with(
+				$this->equalTo('proxyuserpwd'),
+				$this->callback(function ($input) {
+					return $input === '';
+				})
+			)
 			->willReturn('username:password');
 		$this->assertSame('username:password@foo', self::invokePrivate($this->client, 'getProxyUri'));
 	}


### PR DESCRIPTION
As documented, the default value for config value proxyuserpwd is ''.
However, that value results in the error:
 "cURL error 5: Unsupported proxy syntax in '@'".
This patch handles the values of '' and null (the default in the code)
the same for config values proxyuserpwd and proxy.

Follow up to #16644 with adjusted tests.