### PR TITLE
Fix loading of the syslog logging class

### DIFF
--- a/lib/private/Log/Syslog.php
+++ b/lib/private/Log/Syslog.php
@@ -40,7 +40,7 @@ class Syslog extends LogDetails implements IWriter {
 
 	public function __construct(SystemConfig $config) {
 		parent::__construct($config);
-		openlog($config->getSystemValue('syslog_tag', 'Nextcloud'), LOG_PID | LOG_CONS, LOG_USER);
+		openlog($config->getValue('syslog_tag', 'Nextcloud'), LOG_PID | LOG_CONS, LOG_USER);
 	}
 
 	public function __destruct() {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -449,9 +449,10 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerAlias('AllConfig', \OC\AllConfig::class);
 		$this->registerAlias(\OCP\IConfig::class, \OC\AllConfig::class);
 
-		$this->registerService('SystemConfig', function ($c) use ($config) {
+		$this->registerService(\OC\SystemConfig::class, function ($c) use ($config) {
 			return new \OC\SystemConfig($config);
 		});
+		$this->registerAlias('SystemConfig', \OC\SystemConfig::class);
 
 		$this->registerService(\OC\AppConfig::class, function (Server $c) {
 			return new \OC\AppConfig($c->getDatabaseConnection());


### PR DESCRIPTION
- Use getValue since getSystemValue is not available
- Register alias for the SystemConfig class name, since otherwise querying the Syslog class in the LogFactory will fail