### PR TITLE
Get the proper UID

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -432,6 +432,7 @@ return array(
     'OCP\\User\\Backend\\ICreateUserBackend' => $baseDir . '/lib/public/User/Backend/ICreateUserBackend.php',
     'OCP\\User\\Backend\\IGetDisplayNameBackend' => $baseDir . '/lib/public/User/Backend/IGetDisplayNameBackend.php',
     'OCP\\User\\Backend\\IGetHomeBackend' => $baseDir . '/lib/public/User/Backend/IGetHomeBackend.php',
+    'OCP\\User\\Backend\\IGetRealUIDBackend' => $baseDir . '/lib/public/User/Backend/IGetRealUIDBackend.php',
     'OCP\\User\\Backend\\IPasswordConfirmationBackend' => $baseDir . '/lib/public/User/Backend/IPasswordConfirmationBackend.php',
     'OCP\\User\\Backend\\IProvideAvatarBackend' => $baseDir . '/lib/public/User/Backend/IProvideAvatarBackend.php',
     'OCP\\User\\Backend\\ISetDisplayNameBackend' => $baseDir . '/lib/public/User/Backend/ISetDisplayNameBackend.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -466,6 +466,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\User\\Backend\\ICreateUserBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/ICreateUserBackend.php',
         'OCP\\User\\Backend\\IGetDisplayNameBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IGetDisplayNameBackend.php',
         'OCP\\User\\Backend\\IGetHomeBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IGetHomeBackend.php',
+        'OCP\\User\\Backend\\IGetRealUIDBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IGetRealUIDBackend.php',
         'OCP\\User\\Backend\\IPasswordConfirmationBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IPasswordConfirmationBackend.php',
         'OCP\\User\\Backend\\IProvideAvatarBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IProvideAvatarBackend.php',
         'OCP\\User\\Backend\\ISetDisplayNameBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/ISetDisplayNameBackend.php',

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -65,6 +65,7 @@ use OCP\User\Backend\ICountUsersBackend;
 use OCP\User\Backend\ICreateUserBackend;
 use OCP\User\Backend\IGetDisplayNameBackend;
 use OCP\User\Backend\IGetHomeBackend;
+use OCP\User\Backend\IGetRealUIDBackend;
 use OCP\User\Backend\ISetDisplayNameBackend;
 use OCP\User\Backend\ISetPasswordBackend;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -80,7 +81,8 @@ class Database extends ABackend
 	           IGetDisplayNameBackend,
 	           ICheckPasswordBackend,
 	           IGetHomeBackend,
-	           ICountUsersBackend {
+	           ICountUsersBackend,
+	           IGetRealUIDBackend {
 	/** @var CappedMemoryCache */
 	private $cache;
 
@@ -473,6 +475,15 @@ class Database extends ABackend
 				}
 			}
 		}
-
 	}
+
+	public function getRealUID(string $uid): string {
+		if (!$this->userExists($uid)) {
+			throw new \RuntimeException($uid . ' does not exist');
+		}
+
+		return $this->cache[$uid]['uid'];
+	}
+
+
 }

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -38,6 +38,7 @@ use OCP\IGroup;
 use OCP\IUserBackend;
 use OCP\IUserManager;
 use OCP\IConfig;
+use OCP\User\Backend\IGetRealUIDBackend;
 use OCP\UserInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -151,6 +152,10 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @return \OC\User\User
 	 */
 	protected function getUserObject($uid, $backend, $cacheUser = true) {
+		if ($backend instanceof IGetRealUIDBackend) {
+			$uid = $backend->getRealUID($uid);
+		}
+
 		if (isset($this->cachedUsers[$uid])) {
 			return $this->cachedUsers[$uid];
 		}

--- a/lib/public/User/Backend/IGetRealUIDBackend.php
+++ b/lib/public/User/Backend/IGetRealUIDBackend.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend;
+
+/**
+ * @since 17.0.0
+ */
+interface IGetRealUIDBackend {
+
+	/**
+	 * Some backends accept different UIDs than what is the internal UID to be used.
+	 * For example the database backend accepts differnt cased UIDs in all the functions
+	 * but the internal UID that is to be used should be correctly cased.
+	 *
+	 * This little function makes sure that the used UID will be correct hen using the user object
+	 *
+	 * @since 17.0.0
+	 * @param string $uid
+	 * @return string
+	 */
+	public function getRealUID(string $uid): string;
+}


### PR DESCRIPTION
Some user backends (like the database backend) allow us to obtain a user
case insensitive. However the UID itself is case sensitive.

Example:
* create a user User1
* login as User1
  - This results the data/User1 folder to be created etc
* now have some code somewhere that obtains the userFolder (from
IRootFolder) but pas in 'uSER1' as uid
  - The code will check if that is a valid user. And in this case it is
  since User1 and uSER1 both map to the same user
  - However the the UID in the user object is used for the folder a new
  folder fill be create data/uSER1

With this PR this is avoided now. Since we obtain the real UID casing in
the backend before creating the user object.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>