### PR TITLE
Fix opening office documents from webdav network mounts on windows

### DIFF
--- a/apps/dav/lib/Connector/Sabre/AnonymousOptionsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/AnonymousOptionsPlugin.php
@@ -57,7 +57,10 @@ class AnonymousOptionsPlugin extends ServerPlugin {
 	 * @return bool
 	 */
 	public function handleAnonymousOptions(RequestInterface $request, ResponseInterface $response) {
-		if ($request->getHeader('Authorization') === null && $request->getMethod() === 'OPTIONS' && $this->isRequestInRoot($request->getPath())) {
+		$isOffice = preg_match('/Microsoft Office/i', $request->getHeader('User-Agent'));
+		$isAnonymousOption = ($request->getMethod() === 'OPTIONS' && ($request->getHeader('Authorization') === null || trim($request->getHeader('Authorization')) === 'Bearer') && $this->isRequestInRoot($request->getPath()));
+		$isOfficeHead = $request->getMethod() === 'HEAD' && $isOffice && $request->getHeader('Authorization') === 'Bearer';
+		if ($isAnonymousOption || $isOfficeHead) {
 			/** @var CorePlugin $corePlugin */
 			$corePlugin = $this->server->getPlugin('core');
 			// setup a fake tree for anonymous access


### PR DESCRIPTION
I tried to debug opening office documents from a webdav mounted drive on windows a bit, which prompt for credentials when opening files that are not located in the root folder. This PR at fixes the issue with Windows 10 and current Office 365.

Related previous fix https://github.com/nextcloud/server/pull/12556

The following requests happen without that patch applied and
### Access log when opening a file in office

#### /test.docx (works)
<pre>
[14/Aug/2019:08:25:36 +0200] "GET /remote.php/webdav/Test.docx HTTP/2.0" 304 46 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"

<b>[14/Aug/2019:08:25:36 +0200] "OPTIONS /remote.php/ HTTP/1.1" 404 9468 "-" "Microsoft Office Word 2014"
[14/Aug/2019:08:25:36 +0200] "OPTIONS /remote.php/ HTTP/1.1" 404 9460 "-" "Microsoft Office Word 2014"</b>

[14/Aug/2019:08:25:37 +0200] "LOCK /remote.php/webdav/Test.docx HTTP/2.0" 200 643 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"
[14/Aug/2019:08:25:37 +0200] "PROPFIND /remote.php/webdav/~%24Test.docx HTTP/2.0" 404 275 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"
[14/Aug/2019:08:25:37 +0200] "PUT /remote.php/webdav/~%24Test.docx HTTP/2.0" 201 113 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"
[14/Aug/2019:08:25:37 +0200] "LOCK /remote.php/webdav/~%24Test.docx HTTP/2.0" 200 622 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"
[14/Aug/2019:08:25:37 +0200] "HEAD /remote.php/webdav/~%24Test.docx HTTP/2.0" 401 35 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"
[14/Aug/2019:08:25:37 +0200] "HEAD /remote.php/webdav/~%24Test.docx HTTP/2.0" 200 89 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"
[14/Aug/2019:08:25:37 +0200] "PUT /remote.php/webdav/~%24Test.docx HTTP/2.0" 204 64 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"
[14/Aug/2019:08:25:38 +0200] "PROPPATCH /remote.php/webdav/~%24Test.docx HTTP/2.0" 207 632 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"
[14/Aug/2019:08:25:38 +0200] "UNLOCK /remote.php/webdav/~%24Test.docx HTTP/2.0" 204 33 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"
[14/Aug/2019:08:25:38 +0200] "PROPFIND /remote.php/webdav/~%24Test.docx HTTP/2.0" 207 662 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"
[14/Aug/2019:08:25:38 +0200] "DELETE /remote.php/webdav/~%24Test.docx HTTP/2.0" 204 33 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"
[14/Aug/2019:08:25:38 +0200] "UNLOCK /remote.php/webdav/Test.docx HTTP/2.0" 204 33 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"
</pre>


#### /Demo/test.docx (doesn't work)
<pre>[14/Aug/2019:08:24:54 +0200] "PROPFIND /remote.php/webdav/Documents/desktop.ini HTTP/2.0" 404 662 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"
[14/Aug/2019:08:24:54 +0200] "PROPFIND /remote.php/webdav HTTP/2.0" 207 641 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"
[14/Aug/2019:08:24:55 +0200] "PROPFIND /remote.php/webdav/Documents HTTP/2.0" 207 649 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"
[14/Aug/2019:08:24:55 +0200] "PROPFIND /remote.php/webdav/Documents/Test.docx HTTP/2.0" 207 670 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"
[14/Aug/2019:08:24:55 +0200] "PROPFIND /remote.php/webdav/Documents/Test.docx HTTP/2.0" 207 670 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"
[14/Aug/2019:08:24:55 +0200] "GET /remote.php/webdav/Documents/Test.docx HTTP/2.0" 200 12106 "-" "Microsoft-WebDAV-MiniRedir/10.0.17763"

<b>[14/Aug/2019:08:24:56 +0200] "OPTIONS /remote.php/webdav/ HTTP/1.1" 401 6666 "-" "Microsoft Office Word 2014"
[14/Aug/2019:08:24:56 +0200] "OPTIONS /remote.php/webdav/ HTTP/1.1" 401 6662 "-" "Microsoft Office Word 2014"</b>
</pre>

Office sends OPTIONS/HEAD requests before opening the document with an "Authorization: Bearer" header without a token, which causes an unauthorized response, which when checking for that seems to fix the ever showing credentials dialog. However I still don't get why the request for the file in the root would go to /remote.php/ and works because a 404 is returned :woman_shrugging: 