### PR TITLE
Revert "Avoid scrolling to the hidden input when toggling grid/list view"

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -1080,10 +1080,6 @@ table.dragshadow td.size {
 		opacity: 1;
 	}
 }
-/* Make sure the hidden input is not rendered at all to avoid scrolling to top */
-#showgridview {
-	display: none;
-}
 
 /* Adjustments for link share page */
 #body-public {


### PR DESCRIPTION
And add script to prevent focus default on the checkbox 