### PR TITLE
Prevent hitting the directory limit when creating image previews (#13091)

### DIFF
--- a/lib/private/Preview/BackgroundCleanupJob.php
+++ b/lib/private/Preview/BackgroundCleanupJob.php
@@ -77,7 +77,8 @@ class BackgroundCleanupJob extends TimedJob {
 
 		while ($row = $cursor->fetch()) {
 			try {
-				$preview = $previews->getFolder($row['name']);
+				$folderName = implode('/', str_split(substr(md5($row['name']), 0, 7)));
+				$preview = $previews->getFolder($folderName);
 				$preview->delete();
 			} catch (NotFoundException $e) {
 				// continue

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -427,18 +427,21 @@ class Generator {
 	 */
 	private function getPreviewFolder(File $file) {
 		$folderName = implode('/', str_split($file->getId()));
+
 		try {
-			$folder = $this->appData->getFolder($folderName);
+			return $this->appData->getFolder($folderName);
 		} catch (NotFoundException $e) {
-			try {
-				// In order to have some retrocompatibility
-				$folder = $this->appData->getFolder($file->getId());
-			} catch (NotFoundException $e) {
-				$folder = $this->appData->newFolder($folderName);
-			}
+			// preview folder does not exist.
 		}
 
-		return $folder;
+		try {
+			// In order to have some retrocompatibility
+			return $this->appData->getFolder($file->getId());
+		} catch (NotFoundException $e) {
+			// preview folder does not exist.
+		}
+
+		return $this->appData->newFolder($folderName);
 	}
 
 	/**

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -426,10 +426,16 @@ class Generator {
 	 * @return ISimpleFolder
 	 */
 	private function getPreviewFolder(File $file) {
+		$folderName = implode('/', str_split($file->getId()));
 		try {
-			$folder = $this->appData->getFolder($file->getId());
+			$folder = $this->appData->getFolder($folderName);
 		} catch (NotFoundException $e) {
-			$folder = $this->appData->newFolder($file->getId());
+			try {
+				// In order to have some retrocompatibility
+				$folder = $this->appData->getFolder($file->getId());
+			} catch (NotFoundException $e) {
+				$folder = $this->appData->newFolder($folderName);
+			}
 		}
 
 		return $folder;

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -426,7 +426,7 @@ class Generator {
 	 * @return ISimpleFolder
 	 */
 	private function getPreviewFolder(File $file) {
-		$folderName = implode('/', str_split($file->getId()));
+		$folderName = implode('/', str_split(substr(md5($file->getId()), 0, 7)));
 
 		try {
 			return $this->appData->getFolder($folderName);

--- a/tests/lib/Preview/GeneratorTest.php
+++ b/tests/lib/Preview/GeneratorTest.php
@@ -90,7 +90,7 @@ class GeneratorTest extends \Test\TestCase {
 
 		$previewFolder = $this->createMock(ISimpleFolder::class);
 		$this->appData->method('getFolder')
-			->with($this->equalTo(42))
+			->with($this->equalTo('a/1/d/0/c/6/e'))
 			->willReturn($previewFolder);
 
 		$maxPreview = $this->createMock(ISimpleFile::class);
@@ -138,11 +138,14 @@ class GeneratorTest extends \Test\TestCase {
 
 		$previewFolder = $this->createMock(ISimpleFolder::class);
 		$this->appData->method('getFolder')
-			->with($this->equalTo(42))
+			->withConsecutive(
+				[$this->equalTo('a/1/d/0/c/6/e')],
+				[$this->equalTo(42)]
+			)
 			->willThrowException(new NotFoundException());
 
 		$this->appData->method('newFolder')
-			->with($this->equalTo(42))
+			->with($this->equalTo('a/1/d/0/c/6/e'))
 			->willReturn($previewFolder);
 
 		$this->config->method('getSystemValue')
@@ -301,7 +304,7 @@ class GeneratorTest extends \Test\TestCase {
 
 		$previewFolder = $this->createMock(ISimpleFolder::class);
 		$this->appData->method('getFolder')
-			->with($this->equalTo(42))
+			->with($this->equalTo('a/1/d/0/c/6/e'))
 			->willReturn($previewFolder);
 
 		$previewFolder->method('getDirectoryListing')
@@ -388,7 +391,7 @@ class GeneratorTest extends \Test\TestCase {
 
 		$previewFolder = $this->createMock(ISimpleFolder::class);
 		$this->appData->method('getFolder')
-			->with($this->equalTo(42))
+			->with($this->equalTo('a/1/d/0/c/6/e'))
 			->willReturn($previewFolder);
 
 		$maxPreview = $this->createMock(ISimpleFile::class);


### PR DESCRIPTION
Fix #13091 #14169

When creating image previews, the previous code was creating a folder in the "preview" folder using the file ID as a name. When the number of folders exceeds 32767, it is impossible to create further preview on some filesystems because of the "Too many links" error.
I changed the code in order to split the file ID into digits and using them to create a tree of folders, preventing the hit of the directory limit. This fixes the issue experienced by @giraudeo on FreeBSD and by me on OpenBSD.

Please consider this pull request.