### PR TITLE
[stable16] Fix tracking of auto disabled apps in Updater

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -86,6 +86,9 @@ class AppManager implements IAppManager {
 	/** @var array */
 	private $appVersions = [];
 
+	/** @var array */
+	private $autoDisabledApps = [];
+
 	/**
 	 * @param IUserSession $userSession
 	 * @param AppConfig $appConfig
@@ -146,6 +149,13 @@ class AppManager implements IAppManager {
 			return $this->checkAppForUser($enabled, $user);
 		});
 		return array_keys($appsForUser);
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getAutoDisabledApps(): array {
+		return $this->autoDisabledApps;
 	}
 
 	/**
@@ -282,12 +292,18 @@ class AppManager implements IAppManager {
 	 * Disable an app for every user
 	 *
 	 * @param string $appId
+	 * @param bool $automaticDisabled
 	 * @throws \Exception if app can't be disabled
 	 */
-	public function disableApp($appId) {
+	public function disableApp($appId, $automaticDisabled = false) {
 		if ($this->isAlwaysEnabled($appId)) {
 			throw new \Exception("$appId can't be disabled.");
 		}
+
+		if ($automaticDisabled) {
+			$this->autoDisabledApps[] = $appId;
+		}
+
 		unset($this->installedAppsCache[$appId]);
 		$this->appConfig->setValue($appId, 'enabled', 'no');
 

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -256,7 +256,8 @@ class Updater extends BasicEmitter {
 
 		// upgrade appstore apps
 		$this->upgradeAppStoreApps(\OC::$server->getAppManager()->getInstalledApps());
-		$this->upgradeAppStoreApps(\OC_App::$autoDisabledApps, true);
+		$autoDisabledApps = \OC::$server->getAppManager()->getAutoDisabledApps();
+		$this->upgradeAppStoreApps($autoDisabledApps, true);
 
 		// install new shipped apps on upgrade
 		OC_App::loadApps(['authentication']);
@@ -404,7 +405,7 @@ class Updater extends BasicEmitter {
 				if ($appManager->isShipped($app)) {
 					throw new \UnexpectedValueException('The files of the app "' . $app . '" were not correctly replaced before running the update');
 				}
-				\OC::$server->getAppManager()->disableApp($app);
+				\OC::$server->getAppManager()->disableApp($app, true);
 				$this->emit('\OC\Updater', 'incompatibleAppDisabled', array($app));
 			}
 			// no need to disable any app in case this is a non-core upgrade

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -70,7 +70,6 @@ class OC_App {
 	static private $loadedApps = [];
 	static private $altLogin = [];
 	static private $alreadyRegistered = [];
-	static public $autoDisabledApps = [];
 	const supportedApp = 300;
 	const officialApp = 200;
 
@@ -157,8 +156,7 @@ class OC_App {
 				\OC::$server->getLogger()->logException($ex);
 				if (!\OC::$server->getAppManager()->isShipped($app)) {
 					// Only disable apps which are not shipped
-					\OC::$server->getAppManager()->disableApp($app);
-					self::$autoDisabledApps[] = $app;
+					\OC::$server->getAppManager()->disableApp($app, true);
 				}
 			}
 			\OC::$server->getEventLogger()->end('load_app_' . $app);

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -109,9 +109,10 @@ interface IAppManager {
 	 * Disable an app for every user
 	 *
 	 * @param string $appId
+	 * @param bool $automaticDisabled
 	 * @since 8.0.0
 	 */
-	public function disableApp($appId);
+	public function disableApp($appId, $automaticDisabled = false);
 
 	/**
 	 * Get the directory for the given app.
@@ -158,4 +159,10 @@ interface IAppManager {
 	 * @since 9.0.0
 	 */
 	public function getAlwaysEnabledApps();
+
+	/**
+	 * @return array
+	 * @since 16.0.5
+	 */
+	public function getAutoDisabledApps(): array;
 }


### PR DESCRIPTION
This is a backport of #16507 (fixing #15416) for stable16. There were some conflicts, so the [automatic backport failed](https://github.com/nextcloud/server/pull/16507#issuecomment-521740064).