### PR TITLE
Allow Context subclasses in acceptance tests to access parent actor

### DIFF
--- a/tests/acceptance/features/core/ActorAware.php
+++ b/tests/acceptance/features/core/ActorAware.php
@@ -26,7 +26,7 @@ trait ActorAware {
 	/**
 	 * @var Actor
 	 */
-	private $actor;
+	protected $actor;
 
 	/**
 	 * @param Actor $actor


### PR DESCRIPTION
Although uncommon, in some cases a Context may need to be extended (for example, to override a step defined in the server with a specific behaviour in the acceptance tests of an app); in those cases the subclass should be able to access the actor attribute defined in the Context it is extending.
