### PR TITLE
Make the warning about wrong permissions more clear.

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -92,12 +92,13 @@ try {
 			echo "The posix extensions are required - see http://php.net/manual/en/book.posix.php" . PHP_EOL;
 			exit(1);
 		}
+
 		$user = posix_getpwuid(posix_getuid());
 		$configUser = posix_getpwuid(fileowner(OC::$configDir . 'config.php'));
 		if ($user['name'] !== $configUser['name']) {
-			echo "Console has to be executed with the same user as the web server is operated" . PHP_EOL;
+			echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
 			echo "Current user: " . $user['name'] . PHP_EOL;
-			echo "Web server user: " . $configUser['name'] . PHP_EOL;
+			echo "Owner of config.php: " . $configUser['name'] . PHP_EOL;
 			exit(1);
 		}
 


### PR DESCRIPTION
Fix #5548 