### PR TITLE
Stop if there is no encrypted token

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -194,8 +194,12 @@ class LostController extends Controller {
 			throw new \Exception($this->l10n->t('Couldn\'t reset password because the token is invalid'));
 		}
 
+		$encryptedToken = $this->config->getUserValue($userId, 'core', 'lostpassword', null);
+		if ($encryptedToken === null) {
+			throw new \Exception($this->l10n->t('Couldn\'t reset password because the token is invalid'));
+		}
+
 		try {
-			$encryptedToken = $this->config->getUserValue($userId, 'core', 'lostpassword', null);
 			$mailAddress = !is_null($user->getEMailAddress()) ? $user->getEMailAddress() : '';
 			$decryptedToken = $this->crypto->decrypt($encryptedToken, $mailAddress.$this->config->getSystemValue('secret'));
 		} catch (\Exception $e) {

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -699,6 +699,22 @@ class LostControllerTest extends \Test\TestCase {
 		$this->assertSame($expectedResponse, $response);
 	}
 
+	public function testIsSetPasswordTokenNullFailing() {
+		$this->config->method('getUserValue')
+			->with('ValidTokenUser', 'core', 'lostpassword', null)
+			->willReturn(null);
+		$this->userManager->method('get')
+			->with('ValidTokenUser')
+			->willReturn($this->existingUser);
+
+		$response = $this->lostController->setPassword('', 'ValidTokenUser', 'NewPassword', true);
+		$expectedResponse = [
+			'status' => 'error',
+			'msg' => 'Couldn\'t reset password because the token is invalid'
+		];
+		$this->assertSame($expectedResponse, $response);
+	}
+
 	public function testSetPasswordForDisabledUser() {
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -712,7 +712,7 @@ class LostControllerTest extends \Test\TestCase {
 			->willReturn('encryptedData');
 		$this->userManager->method('get')
 			->with('DisabledUser')
-			->willReturn($this->existingUser);
+			->willReturn($user);
 
 		$response = $this->lostController->setPassword('TheOnlyAndOnlyOneTokenToResetThePassword', 'DisabledUser', 'NewPassword', true);
 		$expectedResponse = [


### PR DESCRIPTION
Fix #16729 

`Argument 1 passed to OC\Security\Crypto::decrypt() must be of the type string, null given`