### PR TITLE
17.0.0 beta 2

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(17, 0, 0, 3);
+$OC_Version = array(17, 0, 0, 4);
 
 // The human readable string
-$OC_VersionString = '17.0.0 Beta 1';
+$OC_VersionString = '17.0.0 Beta 2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #16756 Allow Context subclasses in acceptance tests to access parent actor
* #16766 Frame-src doesn't respect the nonce attribute
* #16775 Make the warning about wrong permissions more clear.
* #16778 Bump webpack from 4.39.1 to 4.39.2
* #16779 Bump css-vars-ponyfill from 2.0.2 to 2.1.1
* #16781 Send new password instead of empty string
* #16782 Stop if there is no encrypted token
* #16784 Fix foreach error for reminder generator
* #16788 Do not enforce the parent constructor of response to be called
* #16793 Filter more configs
* #16796 Codechecker: removed unused use
* #16798 Fix scrolling after switching to grid view
* #16808 Undefined variable response when server is no nextcloud anymore
* #16811 Correctly remove apps without any releases
* #16812 Explicit cast for ProviderV1Adapter
* #16813 Autoloader.php could raise Not AllowedException
* #16820 Change access handling of projects
* #16822 Only trigger the events with tags that where actually assigned
* [activity#388](https://github.com/nextcloud/activity/pull/388) Better dark theme support
* [privacy#187](https://github.com/nextcloud/privacy/pull/187) Bump webpack from 4.39.1 to 4.39.2
* [privacy#189](https://github.com/nextcloud/privacy/pull/189) Bump jest from 24.8.0 to 24.9.0
* [privacy#190](https://github.com/nextcloud/privacy/pull/190) Bump webpack-cli from 3.3.6 to 3.3.7
* [privacy#191](https://github.com/nextcloud/privacy/pull/191) Bump babel-jest from 24.8.0 to 24.9.0
* [viewer#214](https://github.com/nextcloud/viewer/pull/214) Bump webpack from 4.39.1 to 4.39.2