### PR TITLE
Do not enforce the parent constructor of response to be called

### DIFF
--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -93,13 +93,9 @@ class Response {
 	private $throttleMetadata = [];
 
 	/**
-	 * Response constructor.
-	 *
 	 * @since 17.0.0
 	 */
 	public function __construct() {
-		$this->setContentSecurityPolicy(new EmptyContentSecurityPolicy());
-		$this->setFeaturePolicy(new EmptyFeaturePolicy());
 	}
 
 	/**
@@ -241,12 +237,8 @@ class Response {
 				$this->lastModified->format(\DateTime::RFC2822);
 		}
 
-		// Build Content-Security-Policy and use default if none has been specified
-		if(is_null($this->contentSecurityPolicy)) {
-			$this->setContentSecurityPolicy(new ContentSecurityPolicy());
-		}
-		$this->headers['Content-Security-Policy'] = $this->contentSecurityPolicy->buildPolicy();
-		$this->headers['Feature-Policy'] = $this->featurePolicy->buildPolicy();
+		$this->headers['Content-Security-Policy'] = $this->getContentSecurityPolicy()->buildPolicy();
+		$this->headers['Feature-Policy'] = $this->getFeaturePolicy()->buildPolicy();
 
 		if($this->ETag) {
 			$mergeWith['ETag'] = '"' . $this->ETag . '"';
@@ -296,6 +288,9 @@ class Response {
 	 * @since 8.1.0
 	 */
 	public function getContentSecurityPolicy() {
+		if ($this->contentSecurityPolicy === null) {
+			$this->setContentSecurityPolicy(new EmptyContentSecurityPolicy());
+		}
 		return $this->contentSecurityPolicy;
 	}
 
@@ -304,6 +299,9 @@ class Response {
 	 * @since 17.0.0
 	 */
 	public function getFeaturePolicy(): EmptyFeaturePolicy {
+		if ($this->featurePolicy === null) {
+			$this->setFeaturePolicy(new EmptyFeaturePolicy());
+		}
 		return $this->featurePolicy;
 	}
 


### PR DESCRIPTION
If there is no policy set we just take the default empty ones.
That way no obscure errors get thrown if the constructor is not called.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>