### PR TITLE
Allow admin configured mounts to use user configured global credentials

### DIFF
--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -93,7 +93,8 @@ OCA.Files_External.StatusManager = {
 							status: statusCode,
 							id: mountData.id,
 							error: statusMessage,
-							userProvided: response.userProvided
+							userProvided: response.userProvided,
+							authMechanism: response.authMechanism
 						};
 					}
 					afterCallback(mountData, self.mountStatus[mountData.mount_point]);
@@ -178,7 +179,7 @@ OCA.Files_External.StatusManager = {
 			if (allMountStatus.hasOwnProperty(name) && allMountStatus[name].status > 0 && allMountStatus[name].status < 7) {
 				var mountData = allMountStatus[name];
 				if (mountData.type === "system") {
-					if (mountData.userProvided) {
+					if (mountData.userProvided || mountData.authMechanism === 'password::global::user') {
 						// personal mount whit credentials problems
 						this.showCredentialsDialog(name, mountData);
 					} else {

--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -45,6 +45,7 @@ use OCA\Files_External\Lib\Auth\PublicKey\RSA;
 use OCA\Files_External\Lib\Auth\OAuth2\OAuth2;
 use OCA\Files_External\Lib\Auth\OAuth1\OAuth1;
 use OCA\Files_External\Lib\Auth\Password\GlobalAuth;
+use OCA\Files_External\Lib\Auth\Password\UserGlobalAuth;
 use OCA\Files_External\Lib\Auth\Password\UserProvided;
 use OCA\Files_External\Lib\Auth\Password\LoginCredentials;
 use OCA\Files_External\Lib\Auth\Password\SessionCredentials;
@@ -136,6 +137,7 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 			$container->query(LoginCredentials::class),
 			$container->query(UserProvided::class),
 			$container->query(GlobalAuth::class),
+			$container->query(UserGlobalAuth::class),
 
 			// AuthMechanism::SCHEME_OAUTH1 mechanisms
 			$container->query(OAuth1::class),

--- a/apps/files_external/lib/Controller/UserGlobalStoragesController.php
+++ b/apps/files_external/lib/Controller/UserGlobalStoragesController.php
@@ -27,6 +27,7 @@ namespace OCA\Files_External\Controller;
 
 use OCA\Files_External\Lib\Auth\AuthMechanism;
 use OCA\Files_External\Lib\Auth\IUserProvided;
+use OCA\Files_External\Lib\Auth\Password\UserGlobalAuth;
 use OCA\Files_External\Lib\InsufficientDataForMeaningfulAnswerException;
 use OCP\ILogger;
 use \OCP\IRequest;
@@ -156,7 +157,7 @@ class UserGlobalStoragesController extends StoragesController {
 		try {
 			$storage = $this->service->getStorage($id);
 			$authMechanism = $storage->getAuthMechanism();
-			if ($authMechanism instanceof IUserProvided) {
+			if ($authMechanism instanceof IUserProvided || $authMechanism instanceof  UserGlobalAuth) {
 				$authMechanism->saveBackendOptions($this->userSession->getUser(), $id, $backendOptions);
 				$authMechanism->manipulateStorageConfig($storage, $this->userSession->getUser());
 			} else {

--- a/apps/files_external/lib/Lib/Auth/Password/UserGlobalAuth.php
+++ b/apps/files_external/lib/Lib/Auth/Password/UserGlobalAuth.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_External\Lib\Auth\Password;
+
+use OCA\Files_External\Service\BackendService;
+use OCP\IL10N;
+use OCP\IUser;
+use OCA\Files_External\Lib\Auth\AuthMechanism;
+use OCA\Files_External\Lib\StorageConfig;
+use OCP\Security\ICredentialsManager;
+use OCA\Files_External\Lib\InsufficientDataForMeaningfulAnswerException;
+
+/**
+ * User provided Global Username and Password
+ */
+class UserGlobalAuth extends AuthMechanism {
+
+	private const CREDENTIALS_IDENTIFIER = 'password::global';
+
+	/** @var ICredentialsManager */
+	protected $credentialsManager;
+
+	public function __construct(IL10N $l, ICredentialsManager $credentialsManager) {
+		$this->credentialsManager = $credentialsManager;
+
+		$this
+			->setIdentifier('password::global::user')
+			->setVisibility(BackendService::VISIBILITY_ADMIN)
+			->setScheme(self::SCHEME_PASSWORD)
+			->setText($l->t('Global credentials, user entered'));
+	}
+
+	public function manipulateStorageConfig(StorageConfig &$storage, IUser $user = null) {
+		if ($user === null) {
+			throw new InsufficientDataForMeaningfulAnswerException('No credentials saved');
+		}
+
+		$uid = $user->getUID();
+		$credentials = $this->credentialsManager->retrieve($uid, self::CREDENTIALS_IDENTIFIER);
+
+		if (is_array($credentials)) {
+			$storage->setBackendOption('user', $credentials['user']);
+			$storage->setBackendOption('password', $credentials['password']);
+		}
+	}
+
+}

--- a/apps/files_external/lib/Lib/Auth/Password/UserGlobalAuth.php
+++ b/apps/files_external/lib/Lib/Auth/Password/UserGlobalAuth.php
@@ -44,9 +44,18 @@ class UserGlobalAuth extends AuthMechanism {
 
 		$this
 			->setIdentifier('password::global::user')
-			->setVisibility(BackendService::VISIBILITY_ADMIN)
+			->setVisibility(BackendService::VISIBILITY_DEFAULT)
 			->setScheme(self::SCHEME_PASSWORD)
 			->setText($l->t('Global credentials, user entered'));
+	}
+
+	public function saveBackendOptions(IUser $user, $id, $backendOptions) {
+		// make sure we're not setting any unexpected keys
+		$credentials = [
+			'user' => $backendOptions['user'],
+			'password' => $backendOptions['password'],
+		];
+		$this->credentialsManager->store($user->getUID(), self::CREDENTIALS_IDENTIFIER, $credentials);
 	}
 
 	public function manipulateStorageConfig(StorageConfig &$storage, IUser $user = null) {

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -188,7 +188,6 @@
 	<?php endif; ?>
 </form>
 
-<?php if ($canCreateMounts): ?>
 <div class="followupsection">
 	<form autocomplete="false" action="#"
 		  id="global_credentials">
@@ -207,4 +206,3 @@
 		<input type="submit" value="<?php p($l->t('Save')) ?>"/>
 	</form>
 </div>
-<?php endif; ?>


### PR DESCRIPTION
This is useful when there are multiple admin configured mounts that should all use the same user configured credentials

Fixes #2861