### PR TITLE
allow using the same user-provided credentials for multiple storages

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -999,6 +999,10 @@ MountConfigListView.prototype = _.extend({
 		} else {
 			newElement = $('<input type="text" class="'+classes.join(' ')+'" data-parameter="'+parameter+'" placeholder="'+ trimmedPlaceholder+'" />');
 		}
+		if (placeholder.tooltip) {
+			newElement.attr('title', placeholder.tooltip);
+			newElement.tooltip();
+		}
 		highlightInput(newElement);
 		$td.append(newElement);
 		return newElement;
@@ -1213,8 +1217,6 @@ MountConfigListView.prototype = _.extend({
 		if (typeof message === 'string') {
 			$statusSpan.attr('title', message);
 			$statusSpan.tooltip();
-		} else {
-			$statusSpan.tooltip('destroy');
 		}
 	},
 

--- a/apps/files_external/lib/Lib/Auth/IUserProvided.php
+++ b/apps/files_external/lib/Lib/Auth/IUserProvided.php
@@ -22,6 +22,7 @@
 
 namespace OCA\Files_External\Lib\Auth;
 
+use OCA\Files_External\Lib\StorageConfig;
 use OCP\IUser;
 
 /**
@@ -32,6 +33,7 @@ interface IUserProvided {
 	 * @param IUser $user the user for which to save the user provided options
 	 * @param int $mountId the mount id to save the options for
 	 * @param array $options the user provided options
+	 * @param StorageConfig $storage
 	 */
-	public function saveBackendOptions(IUser $user, $mountId, array $options);
+	public function saveBackendOptions(IUser $user, $mountId, array $options, StorageConfig $storage);
 }

--- a/apps/files_external/lib/Lib/DefinitionParameter.php
+++ b/apps/files_external/lib/Lib/DefinitionParameter.php
@@ -38,12 +38,16 @@ class DefinitionParameter implements \JsonSerializable {
 	const FLAG_NONE = 0;
 	const FLAG_OPTIONAL = 1;
 	const FLAG_USER_PROVIDED = 2;
+	const FLAG_PRESERVE_SANITIZE = 4;
 
 	/** @var string name of parameter */
 	private $name;
 
 	/** @var string human-readable parameter text */
 	private $text;
+
+	/** @var string human-readable parameter tool tip */
+	private $tooltip;
 
 	/** @var int value type, see self::VALUE_* constants */
 	private $type = self::VALUE_TEXT;
@@ -92,6 +96,26 @@ class DefinitionParameter implements \JsonSerializable {
 	public function setType($type) {
 		$this->type = $type;
 		return $this;
+	}
+
+	/**
+	 * Set the tooltip for the parameter
+	 *
+	 * @param string $tooltip
+	 * @return DefinitionParameter
+	 */
+	public function setTooltip(string $tooltip): DefinitionParameter {
+		$this->tooltip = $tooltip;
+		return $this;
+	}
+
+	/**
+	 * Get the tooltip for the value
+	 *
+	 * @return string
+	 */
+	public function getTooltip(): ?string {
+		return $this->tooltip;
 	}
 
 	/**
@@ -152,7 +176,8 @@ class DefinitionParameter implements \JsonSerializable {
 		return [
 			'value' => $this->getText(),
 			'flags' => $this->getFlags(),
-			'type' => $this->getType()
+			'type' => $this->getType(),
+			'tooltip' => $this->getTooltip(),
 		];
 	}
 


### PR DESCRIPTION
All "user provided credentials" storages with the same credential identifier will use the same set of credentials.

This is useful for having multiple admin configured storages use the same set of user provided credentials

Also adds an option to set tooltips for external storage parameters and removes some deprecated code