### PR TITLE
Fix connexion problem with KeeWeb (Error 503 http)

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -521,7 +521,7 @@ class OC {
 				// Windows webdav drive
 				'/^Microsoft-WebDAV-MiniRedir/',
 				// KeeWeb
-                                '/KeeWeb\/\d[.]\d[.]\d/',
+                                '/KeeWeb\/\d\.\d\.\d/',
 
 			];
 		}

--- a/lib/base.php
+++ b/lib/base.php
@@ -520,6 +520,9 @@ class OC {
 				'/^WebDAVFS/',
 				// Windows webdav drive
 				'/^Microsoft-WebDAV-MiniRedir/',
+				// KeeWeb
+                                '/KeeWeb\/\d[.]\d[.]\d/',
+
 			];
 		}
 


### PR DESCRIPTION
Fix Error 503 at connexion

Exemple : 
`[19/Aug/2019:17:37:57 +0200] "HEAD /remote.php/webdav/my_file.kdbx HTTP/1.1" 503 1763 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) KeeWeb/1.9.0 Chrome/76.0.3809.110 Electron/6.0.2 Safari/537.36"`