### PR TITLE
Fix scrolling after switching to grid view

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -672,6 +672,11 @@
 				.addClass(show ? 'icon-toggle-filelist' : 'icon-toggle-pictures')
 				
 			$('.list-container').toggleClass('view-grid', show);
+			if (show) {
+				// If switching into grid view from list view, too few files might be displayed
+				// Try rendering the next page
+				this._onScroll();
+			}
 		},
 
 		/**


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/16510

Switching to grid view from list view can break the scrolling and fail to load more files.  In this situation, only the files that were visible in list view are initially displayed.  In a large enough browser window and/or high enough screen resolution, this could mean a lot of empty space on the page, and scrolling to load the rest of the files is broken/not possible.

To solve this, I used the same solution that currently exists when toggling hidden files:
https://github.com/nextcloud/server/blob/e51c269dbeddc3d9fa409801260b7265b50d658f/apps/files/js/filelist.js#L272-L275


One question though:  I'm stepping into the Nextcloud code for the first time.  When searching the code, I found the same `onGridViewChange` function here, but I have no idea what this file does.  It doesn't seem to implement the `on_scroll` function so the fix can't be applied here anyway.  So I assume no changes are needed here?
https://github.com/nextcloud/server/blob/265a284c70fe7e395088b9d1cc4f3d83f0e964fa/core/src/OC/dialogs.js#L922