### PR TITLE
Correctly remove apps without any releases

### DIFF
--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -115,6 +115,7 @@ class AppFetcher extends Fetcher {
 
 			if (empty($releases)) {
 				// Remove apps that don't have a matching release
+				$response['data'][$dataKey] = [];
 				continue;
 			}
 
@@ -136,7 +137,7 @@ class AppFetcher extends Fetcher {
 			}
 		}
 
-		$response['data'] = array_values($response['data']);
+		$response['data'] = array_values(array_filter($response['data']));
 		return $response;
 	}
 


### PR DESCRIPTION
Not sure how this worked in the past, but it seems to be broken in the original fix aswell:
https://github.com/nextcloud/server/commit/95c9e0edd216e7a0afd16da27492ec833728bdb2

Anyway clearing the data  and afterwards removing empty apps solves the issue for me.

Fix #16771

---

When you try to test this, you need to comment out the caching:
https://github.com/nextcloud/server/blob/8e278a2c3857147e649391b5905f8e373584f0e2/lib/private/App/AppStore/Fetcher/Fetcher.php#L154-L162
And make sure you are on the beta channel:
https://github.com/nextcloud/server/blob/d0409548c6827f78378371802d67f89153b38c54/lib/private/legacy/util.php#L524-L525
If you do this on stable16 with talk enable, it will correctly tell you talk has no 17 update atm.
