### PR TITLE
Explicit cast for ProviderV1Adapter

### DIFF
--- a/lib/private/Preview/ProviderV1Adapter.php
+++ b/lib/private/Preview/ProviderV1Adapter.php
@@ -36,11 +36,11 @@ class ProviderV1Adapter implements IProviderV2 {
 	}
 
 	public function getMimeType(): string {
-		return $this->providerV1->getMimeType();
+		return (string)$this->providerV1->getMimeType();
 	}
 
 	public function isAvailable(FileInfo $file): bool {
-		return $this->providerV1->isAvailable($file);
+		return (bool)$this->providerV1->isAvailable($file);
 	}
 
 	public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage {


### PR DESCRIPTION
Explicitly cast return values of old preview providers to avoid inacessible folders when upgrading to 17.