### PR TITLE
Change access handling of projects

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1079,6 +1079,7 @@ return array(
     'OC\\Repair\\NC14\\AddPreviewBackgroundCleanupJob' => $baseDir . '/lib/private/Repair/NC14/AddPreviewBackgroundCleanupJob.php',
     'OC\\Repair\\NC16\\AddClenupLoginFlowV2BackgroundJob' => $baseDir . '/lib/private/Repair/NC16/AddClenupLoginFlowV2BackgroundJob.php',
     'OC\\Repair\\NC16\\CleanupCardDAVPhotoCache' => $baseDir . '/lib/private/Repair/NC16/CleanupCardDAVPhotoCache.php',
+    'OC\\Repair\\NC16\\ClearCollectionsAccessCache' => $baseDir . '/lib/private/Repair/NC16/ClearCollectionsAccessCache.php',
     'OC\\Repair\\NC16\\RemoveCypressFiles' => $baseDir . '/lib/private/Repair/NC16/RemoveCypressFiles.php',
     'OC\\Repair\\NC17\\SetEnterpriseLogo' => $baseDir . '/lib/private/Repair/NC17/SetEnterpriseLogo.php',
     'OC\\Repair\\NC17\\SwitchUpdateChannel' => $baseDir . '/lib/private/Repair/NC17/SwitchUpdateChannel.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1113,6 +1113,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Repair\\NC14\\AddPreviewBackgroundCleanupJob' => __DIR__ . '/../../..' . '/lib/private/Repair/NC14/AddPreviewBackgroundCleanupJob.php',
         'OC\\Repair\\NC16\\AddClenupLoginFlowV2BackgroundJob' => __DIR__ . '/../../..' . '/lib/private/Repair/NC16/AddClenupLoginFlowV2BackgroundJob.php',
         'OC\\Repair\\NC16\\CleanupCardDAVPhotoCache' => __DIR__ . '/../../..' . '/lib/private/Repair/NC16/CleanupCardDAVPhotoCache.php',
+        'OC\\Repair\\NC16\\ClearCollectionsAccessCache' => __DIR__ . '/../../..' . '/lib/private/Repair/NC16/ClearCollectionsAccessCache.php',
         'OC\\Repair\\NC16\\RemoveCypressFiles' => __DIR__ . '/../../..' . '/lib/private/Repair/NC16/RemoveCypressFiles.php',
         'OC\\Repair\\NC17\\SetEnterpriseLogo' => __DIR__ . '/../../..' . '/lib/private/Repair/NC17/SetEnterpriseLogo.php',
         'OC\\Repair\\NC17\\SwitchUpdateChannel' => __DIR__ . '/../../..' . '/lib/private/Repair/NC17/SwitchUpdateChannel.php',

--- a/lib/private/Collaboration/Resources/Manager.php
+++ b/lib/private/Collaboration/Resources/Manager.php
@@ -353,12 +353,15 @@ class Manager implements IManager {
 			return $access;
 		}
 
-		$access = false;
+		$access = null;
+		// Access is granted when a user can access all resources
 		foreach ($collection->getResources() as $resource) {
-			if ($resource->canAccess($user)) {
-				$access = true;
+			if (!$resource->canAccess($user)) {
+				$access = false;
 				break;
 			}
+
+			$access = true;
 		}
 
 		$this->cacheAccessForCollection($collection, $user, $access);

--- a/lib/private/Collaboration/Resources/Manager.php
+++ b/lib/private/Collaboration/Resources/Manager.php
@@ -464,6 +464,14 @@ class Manager implements IManager {
 		}
 	}
 
+	public function invalidateAccessCacheForAllCollections(): void {
+		$query = $this->connection->getQueryBuilder();
+
+		$query->delete(self::TABLE_ACCESS_CACHE)
+			->where($query->expr()->neq('collection_id', $query->createNamedParameter(0)));
+		$query->execute();
+	}
+
 	public function invalidateAccessCacheForCollection(ICollection $collection): void {
 		$query = $this->connection->getQueryBuilder();
 

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -42,6 +42,7 @@ use OC\Repair\NC13\AddLogRotateJob;
 use OC\Repair\NC14\AddPreviewBackgroundCleanupJob;
 use OC\Repair\NC16\AddClenupLoginFlowV2BackgroundJob;
 use OC\Repair\NC16\CleanupCardDAVPhotoCache;
+use OC\Repair\NC16\ClearCollectionsAccessCache;
 use OC\Repair\NC16\RemoveCypressFiles;
 use OC\Repair\NC17\SetEnterpriseLogo;
 use OC\Repair\NC17\SwitchUpdateChannel;
@@ -56,6 +57,7 @@ use OC\Template\JSCombiner;
 use OC\Template\SCSSCacher;
 use OCP\AppFramework\QueryException;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Collaboration\Resources\IManager;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -150,6 +152,7 @@ class Repair implements IOutput {
 			new CleanupCardDAVPhotoCache(\OC::$server->getConfig(), \OC::$server->getAppDataDir('dav-photocache'), \OC::$server->getLogger()),
 			new AddClenupLoginFlowV2BackgroundJob(\OC::$server->getJobList()),
 			new RemoveLinkShares(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig(), \OC::$server->getGroupManager(), \OC::$server->getNotificationManager(), \OC::$server->query(ITimeFactory::class)),
+			new ClearCollectionsAccessCache(\OC::$server->getConfig(), \OC::$server->query(IManager::class)),
 			\OC::$server->query(RemoveCypressFiles::class),
 			\OC::$server->query(SwitchUpdateChannel::class),
 			\OC::$server->query(SetEnterpriseLogo::class),

--- a/lib/private/Repair/NC16/ClearCollectionsAccessCache.php
+++ b/lib/private/Repair/NC16/ClearCollectionsAccessCache.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Repair\NC16;
+
+use OC\Collaboration\Resources\Manager;
+use OCP\Collaboration\Resources\IManager;
+use OCP\IConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class ClearCollectionsAccessCache implements IRepairStep {
+
+	/** @var IConfig */
+	private $config;
+
+	/** @var IManager|Manager */
+	private $manager;
+
+	public function __construct(IConfig $config, IManager $manager) {
+		$this->config = $config;
+		$this->manager = $manager;
+	}
+
+	public function getName(): string {
+		return 'Clear access cache of projects';
+	}
+
+	private function shouldRun(): bool {
+		$versionFromBeforeUpdate = $this->config->getSystemValue('version', '0.0.0.0');
+		return version_compare($versionFromBeforeUpdate, '17.0.0.3', '<=');
+	}
+
+	public function run(IOutput $output): void {
+		if ($this->shouldRun()) {
+			$this->manager->invalidateAccessCacheForAllCollections();
+		}
+	}
+}

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(17, 0, 0, 2);
+$OC_Version = array(17, 0, 0, 3);
 
 // The human readable string
 $OC_VersionString = '17.0.0 Beta 1';


### PR DESCRIPTION
Quite some people are too confused when they see a project which only contains one resource. The problem is they can not see the other ones.
So we will change this for now and only show projects, when all resources can be accessed.