### PR TITLE
Only trigger the events with tags that where actually assigned

### DIFF
--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -154,20 +154,26 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 				'systemtagid' => $query->createParameter('tagid'),
 			]);
 
+		$tagsAssigned = [];
 		foreach ($tagIds as $tagId) {
 			try {
 				$query->setParameter('tagid', $tagId);
 				$query->execute();
+				$tagsAssigned[] = $tagId;
 			} catch (UniqueConstraintViolationException $e) {
 				// ignore existing relations
 			}
+		}
+
+		if (empty($tagsAssigned)) {
+			return;
 		}
 
 		$this->dispatcher->dispatch(MapperEvent::EVENT_ASSIGN, new MapperEvent(
 			MapperEvent::EVENT_ASSIGN,
 			$objectType,
 			$objId,
-			$tagIds
+			$tagsAssigned
 		));
 	}
 


### PR DESCRIPTION
1. Set up automated tagging with a rule like the following:
> ![Bildschirmfoto von 2019-08-21 11-31-51](https://user-images.githubusercontent.com/213943/63422667-1ce58900-c40b-11e9-9b61-92ccd08ed8cd.png)
2. Create a folder and tag it
3. Upload a file inside the folder
4. Rename the file
5. Open activity in the sidebar
6. See multiple entries with `Added system tag "Tag"`

Fix https://github.com/nextcloud/files_automatedtagging/issues/75