### PR TITLE
Add tab if alternate login present

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -95,6 +95,7 @@ body {
 	max-width: 100%;
 	max-height: 200px;
 }
+
 .wrapper {
 	width: 300px;
 	margin-top: 10vh;
@@ -143,13 +144,36 @@ form #datadirField legend {
 
 /* Buttons and input */
 #submit-wrapper,
-#reset-password-wrapper {
+#reset-password-wrapper,
+#alternative-logins {
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	position: relative; /* Make the wrapper the containing block of its
 						   absolutely positioned descendant icons */
 }
+
+#alternative-logins {
+	margin: 10px 15px 20px;
+	display: block;
+}
+
+#alternative-logins a {
+	margin: 5px;
+	display: block;
+	font-size: 15px;
+}
+
+
+@media only screen and (max-width: 1024px) {
+	.wrapper {
+		margin-top: 0;
+	}
+	#alternative-logins {
+		margin: 0px 15px 10px;
+	}
+}
+
 
 #submit-wrapper .submit-icon,
 #reset-password-wrapper .submit-icon {

--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -154,7 +154,7 @@ form #datadirField legend {
 }
 
 #alternative-logins {
-	margin: 10px 15px 20px;
+	margin: 30px 15px 20px;
 	display: block;
 }
 
@@ -170,7 +170,7 @@ form #datadirField legend {
 		margin-top: 0;
 	}
 	#alternative-logins {
-		margin: 0px 15px 10px;
+		margin: 30px 15px 10px;
 	}
 }
 

--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -159,7 +159,7 @@ form #datadirField legend {
 }
 
 #alternative-logins a {
-	margin: 5px;
+	margin: 10px 5px;
 	display: block;
 	font-size: 15px;
 }

--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -169,11 +169,12 @@ form #datadirField legend {
 	text-overflow: ellipsis;
 }
 
-#alternative-logins a::before {
+#alternative-logins a.button::before {
 	content: "";
 	background-repeat: no-repeat;
 	background-size: contain;
 	width: 0;
+	margin-right: 0;
 	height: 18px;
 	display: inline-block;
 	vertical-align: bottom;
@@ -190,9 +191,6 @@ form #datadirField legend {
 	}
 	#alternative-logins {
 		margin: 30px 15px 10px;
-	}
-	#alternative-logins .label-prefix {
-		display: none;
 	}
 }
 

--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -97,20 +97,19 @@ body {
 }
 
 .wrapper {
-	width: 300px;
+	max-width: 100%;
 	margin-top: 10vh;
 }
 
 /* Default FORM */
 form {
 	position: relative;
-	width: 280px;
 	margin: auto;
 	padding: 0;
 }
 form fieldset {
-	margin-bottom: 20px;
-	text-align: left;
+	width: 260px;
+	margin: auto auto 20px;
 	-webkit-user-select: none;
 	-moz-user-select: none;
 	-ms-user-select: none;
@@ -156,25 +155,34 @@ form #datadirField legend {
 #alternative-logins {
 	margin: 30px 15px 20px;
 	display: block;
+	min-width: 260px;
+	max-width: 400px;
+	overflow: hidden;
 }
 
 #alternative-logins a {
 	margin: 10px 5px;
 	display: block;
 	font-size: 15px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 #alternative-logins a::before {
 	content: "";
 	background-repeat: no-repeat;
 	background-size: contain;
-	width: 18px;
+	width: 0;
 	height: 18px;
 	display: inline-block;
 	vertical-align: bottom;
-	margin-right: 5px;
 }
 
+#alternative-logins .button {
+	color: #0082c9;
+	padding: 12px 20px;
+}
 
 @media only screen and (max-width: 1024px) {
 	.wrapper {
@@ -182,6 +190,9 @@ form #datadirField legend {
 	}
 	#alternative-logins {
 		margin: 30px 15px 10px;
+	}
+	#alternative-logins .label-prefix {
+		display: none;
 	}
 }
 
@@ -196,6 +207,10 @@ form #datadirField legend {
 							 From the user point of view the icon is part of the
 							 button, so the clicks on the icon have to be
 							 applied to the button instead. */
+}
+
+#submit-wrapper {
+	margin: 0 auto;
 }
 
 #submit-wrapper input.login:hover ~ .submit-icon.icon-confirm-white,

--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -164,6 +164,17 @@ form #datadirField legend {
 	font-size: 15px;
 }
 
+#alternative-logins a::before {
+	content: "";
+	background-repeat: no-repeat;
+	background-size: contain;
+	width: 18px;
+	height: 18px;
+	display: inline-block;
+	vertical-align: bottom;
+	margin-right: 5px;
+}
+
 
 @media only screen and (max-width: 1024px) {
 	.wrapper {

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -9,7 +9,6 @@ script('core', 'dist/login');
     <div id="alternative-logins">
         <?php foreach($_['alt_login'] as $login): ?>
             <a class="button primary <?php p($login['style']); ?>" href="<?php print_unescaped($login['href']); ?>" >
-                <?php p($l->t('Log in with')) ?>
                 <?php p($login['name']); ?>
             </a>
         <?php endforeach; ?>

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -8,7 +8,7 @@ script('core', 'dist/login');
 <?php if (!empty($_['alt_login'])) { ?>
     <div id="alternative-logins">
         <?php foreach($_['alt_login'] as $login): ?>
-            <a class="button primary <?php p($login['style']); ?>" href="<?php print_unescaped($login['href']); ?>" >
+            <a class="button primary <?php p(isset($login['style']) ? $login['style'] : ''); ?>" href="<?php print_unescaped($login['href']); ?>" >
                 <?php p($login['name']); ?>
             </a>
         <?php endforeach; ?>

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -8,7 +8,7 @@ script('core', 'dist/login');
 <?php if (!empty($_['alt_login'])) { ?>
     <div id="alternative-logins">
         <?php foreach($_['alt_login'] as $login): ?>
-            <a class="button <?php p($login['style'] ?? ''); ?>" aria-label="<?php p($login['label'] ?? ''); ?>" href="<?php print_unescaped($login['href']); ?>" >
+            <a class="button <?php p($login['style'] ?? ''); ?>" aria-label="<?php p($login['label'] ?? $login['name']); ?>" href="<?php print_unescaped($login['href']); ?>" >
                 <?php p($login['name']); ?>
             </a>
         <?php endforeach; ?>

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -8,7 +8,7 @@ script('core', 'dist/login');
 <?php if (!empty($_['alt_login'])) { ?>
     <div id="alternative-logins">
         <?php foreach($_['alt_login'] as $login): ?>
-            <a class="button <?php p($login['style'] ?? ''); ?>" aria-label="<?php p($login['label'] ?? $login['name']); ?>" href="<?php print_unescaped($login['href']); ?>" >
+            <a class="button <?php p($login['style'] ?? ''); ?>" href="<?php print_unescaped($login['href']); ?>" >
                 <?php p($login['name']); ?>
             </a>
         <?php endforeach; ?>

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -8,7 +8,7 @@ script('core', 'dist/login');
 <?php if (!empty($_['alt_login'])) { ?>
     <div id="alternative-logins">
         <?php foreach($_['alt_login'] as $login): ?>
-            <a class="button <?php p(isset($login['style']) ? $login['style'] : ''); ?>" aria-label="<?php p($login['label']); ?>" href="<?php print_unescaped($login['href']); ?>" >
+            <a class="button <?php p($login['style'] ?? ''); ?>" aria-label="<?php p($login['label'] ?? ''); ?>" href="<?php print_unescaped($login['href']); ?>" >
                 <?php p($login['name']); ?>
             </a>
         <?php endforeach; ?>

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -8,8 +8,8 @@ script('core', 'dist/login');
 <?php if (!empty($_['alt_login'])) { ?>
     <div id="alternative-logins">
         <?php foreach($_['alt_login'] as $login): ?>
-            <a class="button <?php p(isset($login['style']) ? $login['style'] : ''); ?>" href="<?php print_unescaped($login['href']); ?>" >
-                <?php echo $login['name']; ?>
+            <a class="button <?php p(isset($login['style']) ? $login['style'] : ''); ?>" aria-label="<?php p($login['label']); ?>" href="<?php print_unescaped($login['href']); ?>" >
+                <?php p($login['name']); ?>
             </a>
         <?php endforeach; ?>
     </div>

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -8,8 +8,8 @@ script('core', 'dist/login');
 <?php if (!empty($_['alt_login'])) { ?>
     <div id="alternative-logins">
         <?php foreach($_['alt_login'] as $login): ?>
-            <a class="button primary <?php p(isset($login['style']) ? $login['style'] : ''); ?>" href="<?php print_unescaped($login['href']); ?>" >
-                <?php p($login['name']); ?>
+            <a class="button <?php p(isset($login['style']) ? $login['style'] : ''); ?>" href="<?php print_unescaped($login['href']); ?>" >
+                <?php echo $login['name']; ?>
             </a>
         <?php endforeach; ?>
     </div>

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -3,12 +3,16 @@
 script('core', 'dist/login');
 ?>
 
-<?php if (!empty($_['alt_login'])) { ?>
-	<div id="alternative-logins">
-		<?php foreach($_['alt_login'] as $login): ?>
-			<a class="button primary" href="<?php print_unescaped($login['href']); ?>" ><?php p($login['name']); ?></a>
-		<?php endforeach; ?>
-	</div>
-<?php } ?>
 
 <div id="login"></div>
+
+<?php if (!empty($_['alt_login'])) { ?>
+    <div id="alternative-logins">
+        <?php foreach($_['alt_login'] as $login): ?>
+            <a class="button primary" href="<?php print_unescaped($login['href']); ?>" >
+                <?php p($l->t('Log in with')) ?>
+                <?php p($login['name']); ?>
+            </a>
+        <?php endforeach; ?>
+    </div>
+<?php } ?>

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -3,15 +3,12 @@
 script('core', 'dist/login');
 ?>
 
-<div id="login"></div>
 <?php if (!empty($_['alt_login'])) { ?>
-<form id="alternative-logins">
-	<fieldset>
-		<ul>
-			<?php foreach($_['alt_login'] as $login): ?>
-				<li><a class="button" href="<?php print_unescaped($login['href']); ?>" ><?php p($login['name']); ?></a></li>
-			<?php endforeach; ?>
-		</ul>
-	</fieldset>
-</form>
-<?php }
+	<div id="alternative-logins">
+		<?php foreach($_['alt_login'] as $login): ?>
+			<a class="button primary" href="<?php print_unescaped($login['href']); ?>" ><?php p($login['name']); ?></a>
+		<?php endforeach; ?>
+	</div>
+<?php } ?>
+
+<div id="login"></div>

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -3,13 +3,12 @@
 script('core', 'dist/login');
 ?>
 
-
 <div id="login"></div>
 
 <?php if (!empty($_['alt_login'])) { ?>
     <div id="alternative-logins">
         <?php foreach($_['alt_login'] as $login): ?>
-            <a class="button primary" href="<?php print_unescaped($login['href']); ?>" >
+            <a class="button primary <?php p($login['style']); ?>" href="<?php print_unescaped($login['href']); ?>" >
                 <?php p($l->t('Log in with')) ?>
                 <?php p($login['name']); ?>
             </a>


### PR DESCRIPTION
Recently installed Nextcloud for roughly 40 users. Users are supposed to login using Gitlab login provided by sociallogin app.

Not even half of the users noticed the "Alternate Login" button. Therefore i created a tab menu for login. I also introduced a setting in admin area to force alternate login as "active" tab.

<img width="528" alt="Bildschirmfoto 2019-08-22 um 01 04 16" src="https://user-images.githubusercontent.com/4623070/63474259-c878f280-c478-11e9-9e8e-25aa12a2b99d.png">

When no alternate login is available:

<img width="384" alt="Bildschirmfoto 2019-08-24 um 19 47 40" src="https://user-images.githubusercontent.com/4623070/63641586-052f2e80-c6b1-11e9-9835-128b615fd252.png">
