### PR TITLE
Make the sharing constants publicly available

### DIFF
--- a/lib/private/Share/Constants.php
+++ b/lib/private/Share/Constants.php
@@ -27,18 +27,47 @@
 
 namespace OC\Share;
 
+use OCP\Share\IShare;
+
 class Constants {
 
+	/**
+	 * @deprecated 17.0.0 - use IShare::TYPE_USER instead
+	 */
 	const SHARE_TYPE_USER = 0;
+	/**
+	 * @deprecated 17.0.0 - use IShare::TYPE_GROUP instead
+	 */
 	const SHARE_TYPE_GROUP = 1;
 	// const SHARE_TYPE_USERGROUP = 2; // Internal type used by DefaultShareProvider
+	/**
+	 * @deprecated 17.0.0 - use IShare::TYPE_LINK instead
+	 */
 	const SHARE_TYPE_LINK = 3;
+	/**
+	 * @deprecated 17.0.0 - use IShare::TYPE_EMAIL instead
+	 */
 	const SHARE_TYPE_EMAIL = 4;
 	const SHARE_TYPE_CONTACT = 5; // ToDo Check if it is still in use otherwise remove it
+	/**
+	 * @deprecated 17.0.0 - use IShare::TYPE_REMOTE instead
+	 */
 	const SHARE_TYPE_REMOTE = 6;
+	/**
+	 * @deprecated 17.0.0 - use IShare::TYPE_CIRCLE instead
+	 */
 	const SHARE_TYPE_CIRCLE = 7;
+	/**
+	 * @deprecated 17.0.0 - use IShare::TYPE_GUEST instead
+	 */
 	const SHARE_TYPE_GUEST = 8;
+	/**
+	 * @deprecated 17.0.0 - use IShare::REMOTE_GROUP instead
+	 */
 	const SHARE_TYPE_REMOTE_GROUP = 9;
+	/**
+	 * @deprecated 17.0.0 - use IShare::TYPE_ROOM instead
+	 */
 	const SHARE_TYPE_ROOM = 10;
 	// const SHARE_TYPE_USERROOM = 11; // Internal type used by RoomShareProvider
 

--- a/lib/public/Share/IShare.php
+++ b/lib/public/Share/IShare.php
@@ -40,6 +40,63 @@ use OCP\Share\Exceptions\IllegalIDChangeException;
 interface IShare {
 
 	/**
+	 * @since 17.0.0
+	 */
+	public const TYPE_USER = 0;
+
+	/**
+	 * @since 17.0.0
+	 */
+	public const TYPE_GROUP = 1;
+
+	/**
+	 * @since 17.0.0
+	 */
+	public const TYPE_LINK = 3;
+
+	/**
+	 * @since 17.0.0
+	 */
+	public const TYPE_EMAIL = 4;
+
+	/**
+	 * ToDo Check if it is still in use otherwise remove it
+	 * @since 17.0.0
+	 */
+	// public const TYPE_CONTACT = 5;
+
+	/**
+	 * @since 17.0.0
+	 */
+	public const TYPE_REMOTE = 6;
+
+	/**
+	 * @since 17.0.0
+	 */
+	public const TYPE_CIRCLE = 7;
+
+	/**
+	 * @since 17.0.0
+	 */
+	public const TYPE_GUEST = 8;
+
+	/**
+	 * @since 17.0.0
+	 */
+	public const TYPE_REMOTE_GROUP = 9;
+
+	/**
+	 * @since 17.0.0
+	 */
+	public const TYPE_ROOM = 10;
+
+	/**
+	 * Internal type used by RoomShareProvider
+	 * @since 17.0.0
+	 */
+	// const TYPE_USERROOM = 11;
+
+	/**
 	 * Set the internal id of the share
 	 * It is only allowed to set the internal id of a share once.
 	 * Attempts to override the internal id will result in an IllegalIDChangeException


### PR DESCRIPTION
Since `OCP\Share` is deprecated there is no public way to access the constants anymore.
So I copied them to the interface `OCP\Share\IShare` and added deprecation messages.