### PR TITLE
Always check via http and https whether htaccess is working

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1249,6 +1249,18 @@ class OC_Util {
 			$content = false;
 		}
 
+		if (strpos($url, 'https:') === 0) {
+			$url = 'http:' . substr($url, 6);
+		} else {
+			$url = 'https:' . substr($url, 5);
+		}
+
+		try {
+			$fallbackContent = \OC::$server->getHTTPClientService()->newClient()->get($url)->getBody();
+		} catch (\Exception $e) {
+			$fallbackContent = false;
+		}
+
 		// cleanup
 		@unlink($testFile);
 
@@ -1256,7 +1268,7 @@ class OC_Util {
 		 * If the content is not equal to test content our .htaccess
 		 * is working as required
 		 */
-		return $content !== $testContent;
+		return $content !== $testContent && $fallbackContent !== $testContent;
 	}
 
 	/**


### PR DESCRIPTION
Some hardening, we should of course make sure also a invalid configured http(s) way doesnt work, when the admin is using the other way.