### PR TITLE
Add IAppManager::getAppWebPath()

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -411,7 +411,7 @@ class AppManager implements IAppManager {
 	 * @return string
 	 * @throws AppPathNotFoundException if app path can't be found
 	 */
-	public function getAppWebPath($appId) {
+	public function getAppWebPath(string $appId): string {
 		$appWebPath = \OC_App::getAppWebPath($appId);
 		if($appWebPath === false) {
 			throw new AppPathNotFoundException('Could not find web path for ' . $appId);

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -13,6 +13,7 @@
  * @author Robin Appelman <robin@icewind.nl>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Vincent Petry <pvince81@owncloud.com>
+ * @author Daniel Rudolf <nextcloud.com@daniel-rudolf.de>
  *
  * @license AGPL-3.0
  *
@@ -401,6 +402,21 @@ class AppManager implements IAppManager {
 			throw new AppPathNotFoundException('Could not find path for ' . $appId);
 		}
 		return $appPath;
+	}
+
+	/**
+	 * Get the web path for the given app.
+	 *
+	 * @param string $appId
+	 * @return string
+	 * @throws AppPathNotFoundException if app path can't be found
+	 */
+	public function getAppWebPath($appId) {
+		$appWebPath = \OC_App::getAppWebPath($appId);
+		if($appWebPath === false) {
+			throw new AppPathNotFoundException('Could not find web path for ' . $appId);
+		}
+		return $appWebPath;
 	}
 
 	/**

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -485,6 +485,7 @@ class OC_App {
 	 *
 	 * @param string $appId
 	 * @return string|false
+	 * @deprecated 11.0.0 use \OC::$server->getAppManager()->getAppPath()
 	 */
 	public static function getAppPath(string $appId) {
 		if ($appId === null || trim($appId) === '') {
@@ -503,6 +504,7 @@ class OC_App {
 	 *
 	 * @param string $appId
 	 * @return string|false
+	 * @deprecated 18.0.0 use \OC::$server->getAppManager()->getAppWebPath()
 	 */
 	public static function getAppWebPath(string $appId) {
 		if (($dir = self::findAppInDirectories($appId)) != false) {

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -8,6 +8,7 @@
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Robin Appelman <robin@icewind.nl>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Daniel Rudolf <nextcloud.com@daniel-rudolf.de>
  *
  * @license AGPL-3.0
  *
@@ -124,6 +125,16 @@ interface IAppManager {
 	 * @throws AppPathNotFoundException
 	 */
 	public function getAppPath($appId);
+
+	/**
+	 * Get the web path for the given app.
+	 *
+	 * @param string $appId
+	 * @return string
+	 * @since 17.0.0
+	 * @throws AppPathNotFoundException
+	 */
+	public function getAppWebPath($appId);
 
 	/**
 	 * List all apps enabled for a user

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -131,10 +131,10 @@ interface IAppManager {
 	 *
 	 * @param string $appId
 	 * @return string
-	 * @since 17.0.0
+	 * @since 18.0.0
 	 * @throws AppPathNotFoundException
 	 */
-	public function getAppWebPath($appId);
+	public function getAppWebPath(string $appId): string;
 
 	/**
 	 * List all apps enabled for a user


### PR DESCRIPTION
AFAIK there's currently no public API replacement for [`\OC_App::getAppWebPath()`](https://github.com/nextcloud/server/blob/a4e6073e47b1574c4dd9342bde1601ece28bdb3c/lib/private/legacy/app.php#L500-L512), making it impossible for e.g. [`cms_pico`](https://github.com/nextcloud/cms_pico) (resp. nextcloud/cms_pico#77) to pass the `private` app check.

`\OC_App::getAppWebPath()` is used in [`apps/cms_pico/lib/AppInfo/Application.php`](https://github.com/nextcloud/cms_pico/blob/4a0ede227a565a805d73204a61d355694ecd2530/lib/AppInfo/Application.php#L75-L83) and is required to build various asset URLs. `IURLGenerator::linkTo()` is no alternative here since we don't require the URL of a single file, but a base URL (and `IURLGenerator::linkTo()` furthermore does a very, very extensive and rather expensive trial & error).

```
$ php ./occ app:check-code cms_pico -c private
Analysing /var/www/html/nextcloud/apps/cms_pico/lib/AppInfo/Application.php
 1 errors
    line   90: OC_App - Static method of private class must not be called
App is not compliant
```

For `\OC_App::getAppPath()` there's `IAppManager::getAppPath()`, so `IAppManager::getAppWebPath()` feels natural.

**Targeting NC 17.0.0**; might be too much of a last-minute change, but anyway, the patch has virtually no impact, so this feels justifiable...