### PR TITLE
Fix missing parent constructor call in DAV reminder job

### DIFF
--- a/apps/dav/lib/BackgroundJob/BuildReminderIndexBackgroundJob.php
+++ b/apps/dav/lib/BackgroundJob/BuildReminderIndexBackgroundJob.php
@@ -66,6 +66,7 @@ class BuildReminderIndexBackgroundJob extends QueuedJob {
 								ILogger $logger,
 								IJobList $jobList,
 								ITimeFactory $timeFactory) {
+		parent::__construct($timeFactory);
 		$this->db = $db;
 		$this->reminderService = $reminderService;
 		$this->logger = $logger;


### PR DESCRIPTION
Fixes https://sentry.io/share/issue/82c7be4c3ff847dd9ecb3ed8dfacc2b8/