### PR TITLE
Handle throwables in the http dispatcher

### DIFF
--- a/lib/private/AppFramework/Http/Dispatcher.php
+++ b/lib/private/AppFramework/Http/Dispatcher.php
@@ -105,6 +105,10 @@ class Dispatcher {
 		} catch(\Exception $exception){
 			$response = $this->middlewareDispatcher->afterException(
 				$controller, $methodName, $exception);
+		} catch(\Throwable $throwable) {
+			$exception = new \Exception($throwable->getMessage(), $throwable->getCode(), $throwable);
+			$response = $this->middlewareDispatcher->afterException(
+			$controller, $methodName, $exception);
 		}
 
 		$response = $this->middlewareDispatcher->afterController(


### PR DESCRIPTION
This makes sure that controller methods that use type hinting will also return proper error messages instead of a 200 OK status with empty body when the parameter type doesn't match.

Found in #16682 