### PR TITLE
Remove reflect method form public interface

### DIFF
--- a/lib/public/AppFramework/Utility/IControllerMethodReflector.php
+++ b/lib/public/AppFramework/Utility/IControllerMethodReflector.php
@@ -40,6 +40,7 @@ interface IControllerMethodReflector {
 	 * @param string $method the method which we want to inspect
 	 * @return void
 	 * @since 8.0.0
+	 * @deprecated 17.0.0 Reflect should not be called multiple times and only be used internally. This will be removed in Nextcloud 18
 	 */
 	public function reflect($object, string $method);
 


### PR DESCRIPTION
The reflect method is (and should) only every be called internally.
Since if you call it again it would otherwise start mixing and matching
arguments etc.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>