### PR TITLE
QBMapper id doesn't have to be an int

### DIFF
--- a/lib/public/AppFramework/Db/QBMapper.php
+++ b/lib/public/AppFramework/Db/QBMapper.php
@@ -187,7 +187,7 @@ abstract class QBMapper {
 		}
 
 		$qb->where(
-			$qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT))
+			$qb->expr()->eq('id', $qb->createNamedParameter($id, $this->getParameterTypeForProperty($entity, 'id')))
 		);
 		$qb->execute();
 


### PR DESCRIPTION
Found when looking at https://github.com/nextcloud/mail/issues/1969

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>