### PR TITLE
Fix JS error on personal security page

### DIFF
--- a/settings/templates/settings/personal/security.php
+++ b/settings/templates/settings/personal/security.php
@@ -22,6 +22,7 @@
  */
 
 script('settings', [
+	'settings',
 	'templates',
 	'vue-settings-personal-security',
 ]);


### PR DESCRIPTION
Else there is a missing OC.Settings on the personal security page warnings