### PR TITLE
Define a guest type so Talk can use it in it's notifications

### DIFF
--- a/lib/public/RichObjectStrings/Definitions.php
+++ b/lib/public/RichObjectStrings/Definitions.php
@@ -268,6 +268,25 @@ class Definitions {
 				],
 			],
 		],
+		'guest' => [
+			'author' => 'Nextcloud',
+			'app' => 'spreed',
+			'since' => '17.0.0',
+			'parameters' => [
+				'id' => [
+					'since' => '17.0.0',
+					'required' => true,
+					'description' => 'The id used to identify the guest user',
+					'example' => '42',
+				],
+				'name' => [
+					'since' => '17.0.0',
+					'required' => true,
+					'description' => 'Potential displayname of the guest user',
+					'example' => 'Foobar Cats',
+				],
+			],
+		],
 		'highlight' => [
 			'author' => 'Nextcloud',
 			'app' => 'core',


### PR DESCRIPTION
* Talk has guest mentions since 17
* If you mention a guest and a normal user the notification is created correctly for the normal user
* But it can not be rendered because `guest` is not a valid parameter type so far.
