### PR TITLE
Add clean-git target to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,23 @@ clean:
 	rm -rf apps/files_trashbin/js/
 	rm -rf apps/files_versions/js/
 	rm -rf apps/oauth2/js/
-	rm -rf apps/systemtags/js/systemtags.js
-	rm -rf apps/systemtags/js/systemtags.map
+	rm -rf apps/systemtags/js/systemtags.*
 	rm -rf apps/twofactor_backupcodes/js
-	rm -rf apps/updatenotification/js/updatenotification.js
-	rm -rf apps/updatenotification/js/updatenotification.map
+	rm -rf apps/updatenotification/js/updatenotification.*
 	rm -rf apps/workflowengine/js/
 	rm -rf core/js/dist
 	rm -rf settings/js/vue-*
+
+clean-git: clean
+	git checkout -- apps/accessibility/js/
+	git checkout -- apps/comments/js/
+	git checkout -- apps/files_sharing/js/dist/
+	git checkout -- apps/files_trashbin/js/
+	git checkout -- apps/files_versions/js/
+	git checkout -- apps/oauth2/js/
+	git checkout -- apps/systemtags/js/systemtags.*
+	git checkout -- apps/twofactor_backupcodes/js
+	git checkout -- apps/updatenotification/js/updatenotification.*
+	git checkout -- apps/workflowengine/js/
+	git checkout -- core/js/dist
+	git checkout -- settings/js/vue-*


### PR DESCRIPTION
As recently discussed with @jancborchardt and @skjnldsv this useful to just get the clean state of the committed bundles. 