### PR TITLE
Change the save credentials button label

### DIFF
--- a/settings/css/settings.scss
+++ b/settings/css/settings.scss
@@ -1193,7 +1193,7 @@ table.grid td.date {
 		text-align: right;
 	}
 	select:nth-child(2),
-	input {
+	input:not([type='button']) {
 		width: 143px;
 	}
 }

--- a/settings/templates/settings/admin/additional-mail.php
+++ b/settings/templates/settings/admin/additional-mail.php
@@ -141,7 +141,7 @@ $mail_sendmailmode = [
 				   value="<?php p($_['mail_smtpname']) ?>" />
 			<input type="text" name="mail_smtppassword" id="mail_smtppassword" autocomplete="off"
 				   placeholder="<?php p($l->t('SMTP Password'))?>" value="<?php p($_['mail_smtppassword']) ?>" />
-			<input id="mail_credentials_settings_submit" type="button" value="<?php p($l->t('Store credentials')) ?>">
+			<input id="mail_credentials_settings_submit" type="button" value="<?php p($l->t('Save')) ?>">
 		</p>
 	</form>
 


### PR DESCRIPTION
Change the save credentials button label into Save and the email_settings input class
to make sure the word will always fit the button.

ref #16878  

