### PR TITLE
Properly initialize the CacheJail for sharing

### DIFF
--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -67,12 +67,12 @@ class Cache extends CacheJail {
 
 		parent::__construct(
 			null,
-			''	
+			''
 		);
 	}
 
 	protected function getRoot() {
-		if (is_null($this->root)) {
+		if ($this->root === '') {
 			$absoluteRoot = $this->sourceRootInfo->getPath();
 
 			// the sourceRootInfo path is the absolute path of the folder in the "real" storage
@@ -138,7 +138,7 @@ class Cache extends CacheJail {
 
 	protected function formatCacheEntry($entry, $path = null) {
 		if (is_null($path)) {
-			$path = isset($entry['path']) ? $entry['path'] : '';
+			$path = $entry['path'] ?? '';
 			$entry['path'] = $this->getJailedPath($path);
 		} else {
 			$entry['path'] = $path;

--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -67,7 +67,7 @@ class Cache extends CacheJail {
 
 		parent::__construct(
 			null,
-			null
+			''	
 		);
 	}
 


### PR DESCRIPTION
Replaces https://github.com/nextcloud/server/pull/16911

The set root path is expected to be an empty string instead of null when obtaining the jailed path in 
https://github.com/nextcloud/server/blob/0487144b2679f83f9a6b59b55561af062f692836/lib/private/Files/Cache/Wrapper/CacheJail.php#L71

This fixes two issues when sharing a complete group folder:

Search:
- Create a group folder and add some files to it
- Share the whole group folder with another user or guest account
- Search in the home folder for a file that exists in the groupfolder as user or guest
:boom: Filename not displayed properly and path is set wrong
:heavy_check_mark: File is displayed and linked properly

Activity:
- Create a group folder and add some files to it
- As admin share the whole group folder with a guest account
- As a guest user upload a file to the group folder
:boom: The activity app for the admin shows a broken entry
:heavy_check_mark: The activity app for the admin shows the correct file entry