### PR TITLE
Return the proper jailed path when requesting the root path

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Jail.php
+++ b/lib/private/Files/Storage/Wrapper/Jail.php
@@ -65,7 +65,7 @@ class Jail extends Wrapper {
 	public function getJailedPath($path) {
 		$root = rtrim($this->rootPath, '/') . '/';
 
-		if (strpos($path, $root) !== 0) {
+		if ($path !== $this->rootPath && strpos($path, $root) !== 0) {
 			return null;
 		} else {
 			$path = substr($path, strlen($this->rootPath));


### PR DESCRIPTION
Fix fixes an issue encountered with https://github.com/nextcloud/server/pull/16932

To reproduce, try to create a file in the root of a group folder with a rule setup in files_accesscontrol

The issue when creating a directory in the root of a group folder is that the path is not ending with a `/`, therefore the check for the matching root path (which is always ending with a `/` due to the rtrim is failing.

So this makes sure the jailed path is returned properly then:
![image](https://user-images.githubusercontent.com/3404133/64250669-05cc8e00-cf17-11e9-98c8-ea9a7feb7673.png)


