### PR TITLE
reduce adressbook change events and handling

### DIFF
--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -253,7 +253,7 @@ class User_Proxy extends Proxy implements \OCP\IUserBackend, \OCP\UserInterface,
 	 * @return boolean either the user can or cannot
 	 */
 	public function canChangeAvatar($uid) {
-		return $this->handleRequest($uid, 'canChangeAvatar', array($uid));
+		return $this->handleRequest($uid, 'canChangeAvatar', [$uid], true);
 	}
 
 	/**

--- a/lib/private/Avatar/UserAvatar.php
+++ b/lib/private/Avatar/UserAvatar.php
@@ -97,7 +97,7 @@ class UserAvatar extends Avatar {
 
 		$this->validateAvatar($img);
 
-		$this->remove();
+		$this->remove(true);
 		$type = $this->getAvatarImageType($img);
 		$file = $this->folder->newFile('avatar.' . $type);
 		$file->putContent($data);
@@ -193,7 +193,7 @@ class UserAvatar extends Avatar {
 	 * @throws \OCP\Files\NotPermittedException
 	 * @throws \OCP\PreConditionNotMetException
 	 */
-	public function remove() {
+	public function remove(bool $silent = false) {
 		$avatars = $this->folder->getDirectoryListing();
 
 		$this->config->setUserValue($this->user->getUID(), 'avatar', 'version',
@@ -203,7 +203,9 @@ class UserAvatar extends Avatar {
 			$avatar->delete();
 		}
 		$this->config->setUserValue($this->user->getUID(), 'avatar', 'generated', 'true');
-		$this->user->triggerChange('avatar', '');
+		if(!$silent) {
+			$this->user->triggerChange('avatar', '');
+		}
 	}
 
 	/**

--- a/tests/lib/Avatar/UserAvatarTest.php
+++ b/tests/lib/Avatar/UserAvatarTest.php
@@ -223,8 +223,7 @@ class UserAvatarTest extends \Test\TestCase {
 		$this->config->expects($this->once())
 			->method('getUserValue');
 
-		// One on remove and once on setting the new avatar
-		$this->user->expects($this->exactly(2))->method('triggerChange');
+		$this->user->expects($this->exactly(1))->method('triggerChange');
 
 		$this->avatar->set($image->data());
 	}


### PR DESCRIPTION
This was observed when updating the Avatar from LDAP. 

When setting a new avatar against the ``IAvatar::set()``  implementation, first the old avatar is removed. That cleans up the files and does some config settings. However, this cause also the addressbook to be updated with an empty avatar. 

Then, when the new avatar is set, this happened again.

Now on LDAP this happened twice due to a wrong passOn parameter in the LDAP's proxy, which would lead to do it twice.

It can be easily reproduced:

* have LDAP configured
* log in with an LDAP user that gets it avatar from LDAP
* open the personal settings page
* run SQL query `select count(*) from oc_addressbookchanges` 
* refresh the personal settings page

Observed behaviour: the changes count is +4
 
Desired behaviour: the changes count is +1 (with this patch)

Now you could argue there should be no change when the avatar is still the same and there you are right. There  will be a follow up, because that solution might cover the deeper buried behaviour.