### PR TITLE
fix "create folder" icon overlaying home icon

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -774,8 +774,8 @@ code {
 		background-color: var(--color-background-dark);
 		border: 1px solid var(--color-border-dark);
 		border-radius: var(--border-radius-pill);
-		position: absolute;
-		top: 4px;
+		position: relative;
+		top: -5px;
 
 		.icon.icon-add{
 			background-image: var(--icon-add-000);


### PR DESCRIPTION
First contribution. Home icon is blocked. I've edited CSS from absolute to relative and adjusted position accordingly.

Steps to reproduce
Go to any uploaded files and right click on it, select "Move or Copy"

Actual behaviour
"Create new folder" icon is overlaying "home" icon.
![image](https://user-images.githubusercontent.com/2391759/64335419-56261780-d00d-11e9-88fd-3286bc061571.png)

Expected behaviour
"Create new folder" icon should be to the left of "span.dirtree.breadcrumb", not covering "Home" icon.
![image](https://user-images.githubusercontent.com/2391759/64335837-39d6aa80-d00e-11e9-839e-ca77a960c288.png)


Server configuration
Operating system:
Ubuntu 18.04

Web server:
apache2 2.4.29

Database:
mysql 5.8

PHP version:
7.2.19

Nextcloud version: (see Nextcloud admin page)
16.0.4

Updated from an older Nextcloud/ownCloud or fresh install:
fresh installed. Currently updates using settings/admin/overview button.

Where did you install Nextcloud from:
single php file from nextcloud deploy.