### PR TITLE
Allow to force enable apps via CLI

### DIFF
--- a/apps/settings/lib/Controller/AppSettingsController.php
+++ b/apps/settings/lib/Controller/AppSettingsController.php
@@ -549,13 +549,7 @@ class AppSettingsController extends Controller {
 
 	public function force(string $appId): JSONResponse {
 		$appId = OC_App::cleanAppId($appId);
-
-		$ignoreMaxApps = $this->config->getSystemValue('app_install_overwrite', []);
-		if (!in_array($appId, $ignoreMaxApps, true)) {
-			$ignoreMaxApps[] = $appId;
-			$this->config->setSystemValue('app_install_overwrite', $ignoreMaxApps);
-		}
-
+		$this->appManager->ignoreNextcloudRequirementForApp($appId);
 		return new JSONResponse();
 	}
 

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -94,10 +94,11 @@ class Installer {
 	 * Installs an app that is located in one of the app folders already
 	 *
 	 * @param string $appId App to install
+	 * @param bool $forceEnable
 	 * @throws \Exception
 	 * @return string app ID
 	 */
-	public function installApp($appId) {
+	public function installApp(string $appId, bool $forceEnable = false): string {
 		$app = \OC_App::findAppInDirectories($appId);
 		if($app === false) {
 			throw new \Exception('App not found in any app directory');
@@ -117,7 +118,7 @@ class Installer {
 		}
 
 		$ignoreMaxApps = $this->config->getSystemValue('app_install_overwrite', []);
-		$ignoreMax = in_array($appId, $ignoreMaxApps);
+		$ignoreMax = $forceEnable || in_array($appId, $ignoreMaxApps, true);
 
 		$version = implode('.', \OCP\Util::getVersion());
 		if (!\OC_App::isAppCompatible($version, $info, $ignoreMax)) {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -798,6 +798,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService(AppManager::class, function (Server $c) {
 			return new \OC\App\AppManager(
 				$c->getUserSession(),
+				$c->getConfig(),
 				$c->query(\OC\AppConfig::class),
 				$c->getGroupManager(),
 				$c->getMemCacheFactory(),

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -86,10 +86,11 @@ interface IAppManager {
 	 * Enable an app for every user
 	 *
 	 * @param string $appId
+	 * @param bool $forceEnable
 	 * @throws AppPathNotFoundException
 	 * @since 8.0.0
 	 */
-	public function enableApp($appId);
+	public function enableApp(string $appId, bool $forceEnable = false): void;
 
 	/**
 	 * Whether a list of types contains a protected app type
@@ -105,10 +106,11 @@ interface IAppManager {
 	 *
 	 * @param string $appId
 	 * @param \OCP\IGroup[] $groups
+	 * @param bool $forceEnable
 	 * @throws \Exception
 	 * @since 8.0.0
 	 */
-	public function enableAppForGroups($appId, $groups);
+	public function enableAppForGroups(string $appId, array $groups, bool $forceEnable = false): void;
 
 	/**
 	 * Disable an app for every user

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
@@ -11,20 +11,17 @@ namespace Test\App;
 
 use OC\App\AppManager;
 use OC\AppConfig;
-use OC\Group\Group;
-use OC\User\User;
 use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
-use OCP\IAppConfig;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\ILogger;
-use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\TestCase;
 
@@ -35,7 +32,7 @@ use Test\TestCase;
  */
 class AppManagerTest extends TestCase {
 	/**
-	 * @return AppConfig|\PHPUnit_Framework_MockObject_MockObject
+	 * @return AppConfig|MockObject
 	 */
 	protected function getAppConfig() {
 		$appConfig = array();
@@ -73,25 +70,28 @@ class AppManagerTest extends TestCase {
 		return $config;
 	}
 
-	/** @var IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserSession|MockObject */
 	protected $userSession;
 
-	/** @var IGroupManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig|MockObject */
+	private $config;
+
+	/** @var IGroupManager|MockObject */
 	protected $groupManager;
 
-	/** @var AppConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var AppConfig|MockObject */
 	protected $appConfig;
 
-	/** @var ICache|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var ICache|MockObject */
 	protected $cache;
 
-	/** @var ICacheFactory|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var ICacheFactory|MockObject */
 	protected $cacheFactory;
 
-	/** @var EventDispatcherInterface|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var EventDispatcherInterface|MockObject */
 	protected $eventDispatcher;
 
-	/** @var ILogger|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var ILogger|MockObject */
 	protected $logger;
 
 	/** @var IAppManager */
@@ -102,6 +102,7 @@ class AppManagerTest extends TestCase {
 
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->config = $this->createMock(IConfig::class);
 		$this->appConfig = $this->getAppConfig();
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
 		$this->cache = $this->createMock(ICache::class);
@@ -111,7 +112,15 @@ class AppManagerTest extends TestCase {
 			->method('createDistributed')
 			->with('settings')
 			->willReturn($this->cache);
-		$this->manager = new AppManager($this->userSession, $this->appConfig, $this->groupManager, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$this->manager = new AppManager(
+			$this->userSession,
+			$this->config,
+			$this->appConfig,
+			$this->groupManager,
+			$this->cacheFactory,
+			$this->eventDispatcher,
+			$this->logger
+		);
 	}
 
 	protected function expectClearCache() {
@@ -161,10 +170,10 @@ class AppManagerTest extends TestCase {
 		$groups = [$group1, $group2];
 		$this->expectClearCache();
 
-		/** @var AppManager|\PHPUnit_Framework_MockObject_MockObject $manager */
+		/** @var AppManager|MockObject $manager */
 		$manager = $this->getMockBuilder(AppManager::class)
 			->setConstructorArgs([
-				$this->userSession, $this->appConfig, $this->groupManager, $this->cacheFactory, $this->eventDispatcher, $this->logger
+				$this->userSession, $this->config, $this->appConfig, $this->groupManager, $this->cacheFactory, $this->eventDispatcher, $this->logger
 			])
 			->setMethods([
 				'getAppPath',
@@ -208,10 +217,10 @@ class AppManagerTest extends TestCase {
 		$groups = [$group1, $group2];
 		$this->expectClearCache();
 
-		/** @var AppManager|\PHPUnit_Framework_MockObject_MockObject $manager */
+		/** @var AppManager|MockObject $manager */
 		$manager = $this->getMockBuilder(AppManager::class)
 			->setConstructorArgs([
-				$this->userSession, $this->appConfig, $this->groupManager, $this->cacheFactory, $this->eventDispatcher, $this->logger
+				$this->userSession, $this->config, $this->appConfig, $this->groupManager, $this->cacheFactory, $this->eventDispatcher, $this->logger
 			])
 			->setMethods([
 				'getAppPath',
@@ -262,10 +271,10 @@ class AppManagerTest extends TestCase {
 
 		$groups = [$group1, $group2];
 
-		/** @var AppManager|\PHPUnit_Framework_MockObject_MockObject $manager */
+		/** @var AppManager|MockObject $manager */
 		$manager = $this->getMockBuilder(AppManager::class)
 			->setConstructorArgs([
-				$this->userSession, $this->appConfig, $this->groupManager, $this->cacheFactory, $this->eventDispatcher, $this->logger
+				$this->userSession, $this->config, $this->appConfig, $this->groupManager, $this->cacheFactory, $this->eventDispatcher, $this->logger
 			])
 			->setMethods([
 				'getAppPath',
@@ -426,9 +435,9 @@ class AppManagerTest extends TestCase {
 	}
 
 	public function testGetAppsNeedingUpgrade() {
-		/** @var AppManager|\PHPUnit_Framework_MockObject_MockObject $manager */
+		/** @var AppManager|MockObject $manager */
 		$manager = $this->getMockBuilder(AppManager::class)
-			->setConstructorArgs([$this->userSession, $this->appConfig, $this->groupManager, $this->cacheFactory, $this->eventDispatcher, $this->logger])
+			->setConstructorArgs([$this->userSession, $this->config, $this->appConfig, $this->groupManager, $this->cacheFactory, $this->eventDispatcher, $this->logger])
 			->setMethods(['getAppInfo'])
 			->getMock();
 
@@ -476,9 +485,9 @@ class AppManagerTest extends TestCase {
 	}
 
 	public function testGetIncompatibleApps() {
-		/** @var AppManager|\PHPUnit_Framework_MockObject_MockObject $manager */
+		/** @var AppManager|MockObject $manager */
 		$manager = $this->getMockBuilder(AppManager::class)
-			->setConstructorArgs([$this->userSession, $this->appConfig, $this->groupManager, $this->cacheFactory, $this->eventDispatcher, $this->logger])
+			->setConstructorArgs([$this->userSession, $this->config, $this->appConfig, $this->groupManager, $this->cacheFactory, $this->eventDispatcher, $this->logger])
 			->setMethods(['getAppInfo'])
 			->getMock();
 

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -549,6 +549,7 @@ class AppTest extends \Test\TestCase {
 		$this->overwriteService('AppConfig', $appConfig);
 		$this->overwriteService('AppManager', new \OC\App\AppManager(
 			\OC::$server->getUserSession(),
+			\OC::$server->getConfig(),
 			$appConfig,
 			\OC::$server->getGroupManager(),
 			\OC::$server->getMemCacheFactory(),


### PR DESCRIPTION
### Steps
1. Check out master of server
2. Check out stable17 of activity app
3. Try to enable it via CLI, to fix it for master :boom: 

The UI had the red button to force enable it. This is now possible via:
`occ app:enable activity --force`


cc @jancborchardt should help you a lot