### PR TITLE
Create css4 variables to be used with rgb

### DIFF
--- a/core/css/css-variables.scss
+++ b/core/css/css-variables.scss
@@ -3,22 +3,14 @@
 // All css4 variables must be fixed! Scss is a PRE processor
 // css4 variables are processed after scss!
 :root {
-	--color-main-text: $color-main-text;
-	--color-main-background: $color-main-background;
-	--color-main-background-translucent: $color-main-background-translucent;
 
-	--color-background-dark: $color-background-dark;
-	--color-background-darker: $color-background-darker;
-
-	--color-primary: $color-primary;
-	--color-primary-text: $color-primary-text;
-	--color-primary-text-dark: $color-primary-text-dark;
-	--color-primary-element: $color-primary-element;
-	--color-primary-element-light: $color-primary-element-light;
-
-	--color-error: $color-error;
-	--color-warning: $color-warning;
-	--color-success: $color-success;
+	// generate css variables colours
+	// associated with their rgb so we can use rgba
+	// color: rgba(var(--color-primary-rgb), 0.1)
+	@each $color,$value in $colors {
+		--#{$color}: $value;
+		--#{$color}-rgb: red($value), green($value), blue($value);
+	}
 
 	--color-text-maxcontrast: $color-text-maxcontrast;
 	--color-text-light: $color-text-light;

--- a/core/css/variables.scss
+++ b/core/css/variables.scss
@@ -47,20 +47,48 @@ $color-primary-text-dark: darken($color-primary-text, 7%) !default;
 $color-primary-element: $color-primary !default;
 $color-primary-element-light: lighten($color-primary-element, 15%) !default;
 
-$color-error: #e9322d;
-$color-warning: #eca700;
-$color-success: #46ba61;
-// used for svg
-$color-white: #fff;
-$color-black: #000;
-$color-yellow: #FC0;
-
 // rgb(118, 118, 118) / #767676
 // min. color contrast for normal text on white background according to WCAG AA
 // (Works as well: color: #000; opacity: 0.57;)
 $color-text-maxcontrast: nc-lighten($color-main-text, 46.2%) !default;
 $color-text-light: nc-lighten($color-main-text, 15%) !default;
 $color-text-lighter: nc-lighten($color-main-text, 30%) !default;
+
+$color-error: #e9322d;
+$color-warning: #eca700;
+$color-success: #46ba61;
+
+// automated rgb css variables generator
+// please add every colours that needs to have their rgb truple generated
+$colors: (
+	color-main-text: $color-main-text,
+	color-main-background: $color-main-background,
+	color-main-background-translucent: $color-main-background-translucent,
+
+	color-background-dark: $color-background-dark,
+	color-background-darker: $color-background-darker,
+
+	color-primary: $color-primary,
+	color-primary-text: $color-primary-text,
+
+	color-primary-text-dark: $color-primary-text-dark,
+	color-primary-element: $color-primary-element,
+	color-primary-element-light: $color-primary-element-light,
+
+	color-text-maxcontrast: $color-text-maxcontrast,
+	color-text-light: $color-text-light,
+	color-text-lighter: $color-text-lighter,
+
+	color-error: $color-error,
+	color-warning: $color-warning,
+	color-success: $color-success
+);
+
+
+// used for svg icons colour generation
+$color-white: #fff;
+$color-black: #000;
+$color-yellow: #FC0;
 
 $image-logo: url('../img/logo/logo.svg?v=1') !default;
 $image-login-background: url('../img/background.png?v=2') !default;


### PR DESCRIPTION
```css
:root {
  --color-main-text: #222;
  --color-main-text-rgb: 34, 34, 34;
  --color-main-background: #fff;
  --color-main-background-rgb: 255, 255, 255;
  --color-main-background-translucent: rgba(255, 255, 255, 0.97);
  --color-main-background-translucent-rgb: 255, 255, 255;
  --color-background-dark: #ededed;
  --color-background-dark-rgb: 237.15, 237.15, 237.15;
  --color-background-darker: #dbdbdb;
  --color-background-darker-rgb: 219.3, 219.3, 219.3;
```

Allowing us to do this
```css
.xxx {
	color: rgba(var(--color-primary-rgb), 0.1)
}
```

What do you think @nextcloud/designers? Or shall we convert all of the variables to rgb directly?
Backports?