### PR TITLE
Only send samesite cookies

### DIFF
--- a/lib/private/Session/CryptoWrapper.php
+++ b/lib/private/Session/CryptoWrapper.php
@@ -86,7 +86,23 @@ class CryptoWrapper {
 				if($webRoot === '') {
 					$webRoot = '/';
 				}
-				setcookie(self::COOKIE_NAME, $this->passphrase, 0, $webRoot, '', $secureCookie, true);
+
+				if (PHP_VERSION_ID < 70300) {
+					setcookie(self::COOKIE_NAME, $this->passphrase, 0, $webRoot, '', $secureCookie, true);
+				} else {
+					setcookie(
+						self::COOKIE_NAME,
+						$this->passphrase,
+						[
+							'expires' => 0,
+							'path' => $webRoot,
+							'domain' => '',
+							'secure' => $secureCookie,
+							'httponly' => true,
+							'samesite' => 'Lax',
+						]
+					);
+				}
 			}
 		}
 	}

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -56,7 +56,7 @@ class Internal extends Session {
 		set_error_handler([$this, 'trapError']);
 		$this->invoke('session_name', [$name]);
 		try {
-			$this->invoke('session_start');
+			$this->startSession();
 		} catch (\Exception $e) {
 			setcookie($this->invoke('session_name'), '', -1, \OC::$WEBROOT ?: '/');
 		}
@@ -106,7 +106,7 @@ class Internal extends Session {
 	public function clear() {
 		$this->invoke('session_unset');
 		$this->regenerateId();
-		$this->invoke('session_start', [], true);
+		$this->startSession();
 		$_SESSION = [];
 	}
 
@@ -212,6 +212,14 @@ class Internal extends Session {
 			}
 		} catch(\Error $e) {
 			$this->trapError($e->getCode(), $e->getMessage());
+		}
+	}
+
+	private function startSession() {
+		if (PHP_VERSION_ID < 70300) {
+			$this->invoke('session_start');
+		} else {
+			$this->invoke('session_start', [['cookie_samesite' => 'Lax']]);
 		}
 	}
 }


### PR DESCRIPTION
This makes the last remaining two cookies lax. The session cookie
itself. And the session password as well (on php 7.3 that is). Samesite
cookies are the best cookies!

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>