### PR TITLE
Use the new Symfony event dispatcher signature

### DIFF
--- a/lib/private/EventDispatcher/EventDispatcher.php
+++ b/lib/private/EventDispatcher/EventDispatcher.php
@@ -71,8 +71,7 @@ class EventDispatcher implements IEventDispatcher {
 
 	public function dispatch(string $eventName,
 							 Event $event): void {
-
-		$this->dispatcher->dispatch($eventName, $event);
+		$this->dispatcher->dispatch($event, $eventName);
 	}
 
 	/**


### PR DESCRIPTION
Leftover from the 4.3 bump at #17049. 

Fixes the 

> The signature of the `EventDispatcherInterface::dispatch()` method should be updated to `dispatch($event, string $eventName = null)`, not doing so is deprecated

deprecation for the new event dispatcher.