### PR TITLE
Use Symfony's new contract Event class instead of the deprecated one

### DIFF
--- a/lib/private/Authentication/TwoFactorAuth/Registry.php
+++ b/lib/private/Authentication/TwoFactorAuth/Registry.php
@@ -30,20 +30,19 @@ use OC\Authentication\TwoFactorAuth\Db\ProviderUserAssignmentDao;
 use OCP\Authentication\TwoFactorAuth\IProvider;
 use OCP\Authentication\TwoFactorAuth\IRegistry;
 use OCP\Authentication\TwoFactorAuth\RegistryEvent;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUser;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\GenericEvent;
 
 class Registry implements IRegistry {
 
 	/** @var ProviderUserAssignmentDao */
 	private $assignmentDao;
 
-	/** @var EventDispatcherInterface */
+	/** @var IEventDispatcher */
 	private $dispatcher;
 
 	public function __construct(ProviderUserAssignmentDao $assignmentDao,
-								EventDispatcherInterface $dispatcher) {
+								IEventDispatcher $dispatcher) {
 		$this->assignmentDao = $assignmentDao;
 		$this->dispatcher = $dispatcher;
 	}

--- a/lib/public/EventDispatcher/Event.php
+++ b/lib/public/EventDispatcher/Event.php
@@ -25,7 +25,7 @@ declare(strict_types=1);
 
 namespace OCP\EventDispatcher;
 
-use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Contracts\EventDispatcher\Event as SymfonyEvent;
 
 /**
  * Base event class for the event dispatcher service
@@ -35,6 +35,20 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  *
  * @since 17.0.0
  */
-class Event extends GenericEvent {
+class Event extends SymfonyEvent {
+
+	/**
+	 * Compatibility constructor
+	 *
+	 * In Nextcloud 17.0.0 this event class used a now deprecated/removed Symfony base
+	 * class that had a constructor (with default arguments). To lower the risk of
+	 * a breaking change (PHP won't allow parent constructor calls if there is none),
+	 * this empty constructor's only purpose is to hopefully not break existing sub-
+	 * classes of this class.
+	 *
+	 * @since 18.0.0
+	 */
+	public function __construct() {
+	}
 
 }

--- a/lib/public/Security/CSP/AddContentSecurityPolicyEvent.php
+++ b/lib/public/Security/CSP/AddContentSecurityPolicyEvent.php
@@ -40,6 +40,7 @@ class AddContentSecurityPolicyEvent extends Event {
 	 * @since 17.0.0
 	 */
 	public function __construct(ContentSecurityPolicyManager $policyManager) {
+		parent::__construct();
 		$this->policyManager = $policyManager;
 	}
 

--- a/lib/public/Security/FeaturePolicy/AddFeaturePolicyEvent.php
+++ b/lib/public/Security/FeaturePolicy/AddFeaturePolicyEvent.php
@@ -40,6 +40,7 @@ class AddFeaturePolicyEvent extends Event {
 	 * @since 17.0.0
 	 */
 	public function __construct(FeaturePolicyManager $policyManager) {
+		parent::__construct();
 		$this->policyManager = $policyManager;
 	}
 

--- a/tests/lib/Authentication/TwoFactorAuth/RegistryTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/RegistryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * @copyright 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
@@ -29,27 +29,27 @@ use OC\Authentication\TwoFactorAuth\Registry;
 use OCP\Authentication\TwoFactorAuth\IProvider;
 use OCP\Authentication\TwoFactorAuth\IRegistry;
 use OCP\Authentication\TwoFactorAuth\RegistryEvent;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUser;
-use PHPUnit_Framework_MockObject_MockObject;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class RegistryTest extends TestCase {
 
-	/** @var ProviderUserAssignmentDao|PHPUnit_Framework_MockObject_MockObject */
+	/** @var ProviderUserAssignmentDao|MockObject */
 	private $dao;
+
+	/** @var IEventDispatcher|MockObject */
+	private $dispatcher;
 
 	/** @var Registry */
 	private $registry;
-
-	/** @var EventDispatcherInterface|\PHPUnit_Framework_MockObject_MockObject */
-	private $dispatcher;
 
 	protected function setUp() {
 		parent::setUp();
 
 		$this->dao = $this->createMock(ProviderUserAssignmentDao::class);
-		$this->dispatcher = $this->createMock(EventDispatcherInterface::class);
+		$this->dispatcher = $this->createMock(IEventDispatcher::class);
 
 		$this->registry = new Registry($this->dao, $this->dispatcher);
 	}


### PR DESCRIPTION
Leftover from the 4.3 bump at #17049. 

Fixes the 

> deprecated the `Event` class, use `Symfony\Contracts\EventDispatcher\Event` instead

deprecation for the new event dispatcher system. In theory this could be a breaking change as apps *might* have used methods of the old base class, but the likelihood is very low IMO.