### PR TITLE
16.0.5 RC 1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(16, 0, 4, 2);
+$OC_Version = array(16, 0, 5, 0);
 
 // The human readable string
-$OC_VersionString = '16.0.4';
+$OC_VersionString = '16.0.5 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #16745 Make possible to focus grid/list view toggle via keyboard
* #16753 Fix tracking of auto disabled apps in Updater
* #16802 Filter more configs
* #16818 Correctly remove apps without any releases
* #16826 Undefined variable response when server is no nextcloud anymore
* #16837 Change access handling of projects
* #16848 Only add the app-itunes-app tag if the id is set
* #16883 Use custom client URL in welcome emails
* #16891 Properly redirect if accessing invalid file though /f/ entrypoint
* #16896 Bump mixin-deep from 1.3.1 to 1.3.2
* #16909 Only run integration tests when PHP was modified
* #16921 Ignore Enter key up event on menu button toggles
* #16991 Be sure to get the jailed path if the storage is a jail
* #16995 Only run code coverage CI on merge
* #16997 Returns 404
* #17061 Properly initialize the CacheJail for sharing
* #17070 Fix SMB availability status + higher delay on auth issues
* #17091 When you click on thumbnail of a file, it should open the file not the sidebar
* #17099 Emit moveToTrash event only for the deleting user
* #17103 Fix opening apps with Ctrl+click
* #17157 Don't send executionContexts for Clear-Site-Data
* #17197 Add uid to delete temp token query
* [activity#389](https://github.com/nextcloud/activity/pull/389) Better dark theme support
* [activity#390](https://github.com/nextcloud/activity/pull/390) Fix travis database tests
* [files_texteditor#174](https://github.com/nextcloud/files_texteditor/pull/174) Bump lodash from 4.17.11 to 4.17.14
* [files_texteditor#183](https://github.com/nextcloud/files_texteditor/pull/183) Translate menu action
* [files_videoplayer#138](https://github.com/nextcloud/files_videoplayer/pull/138) Bump mixin-deep from 1.3.1 to 1.3.2
* [firstrunwizard#211](https://github.com/nextcloud/firstrunwizard/pull/211) Bump mixin-deep from 1.3.1 to 1.3.2
* [nextcloud_announcements#48](https://github.com/nextcloud/nextcloud_announcements/pull/48) Randomize the interval.
* [nextcloud_announcements#51](https://github.com/nextcloud/nextcloud_announcements/pull/51) Improve the notification
* [notifications#415](https://github.com/nextcloud/notifications/pull/415) Also set the subject when the subject is not too long
* [notifications#418](https://github.com/nextcloud/notifications/pull/418) Bump eslint-utils from 1.3.1 to 1.4.2
* [notifications#420](https://github.com/nextcloud/notifications/pull/420) The backports of #392 and #390 did not work out as expected
* [recommendations#121](https://github.com/nextcloud/recommendations/pull/121) Bump mixin-deep from 1.3.1 to 1.3.2
* [viewer#221](https://github.com/nextcloud/viewer/pull/221) Bump eslint-utils from 1.3.1 to 1.4.2


Pending PRs:

* [ ] #16814 Instead of upsert query, fallback to default on PSQL <= 9.4 @backportbot-nextcloud
* [x] #16994 Remove orphaned calendar data from deleted subscriptions @backportbot-nextcloud
* [ ] #17012 Return the proper jailed path when requesting the root path @backportbot-nextcloud
* [x] #17155 Always use the folder icon depending on the mount type if not a share mount @juliushaertl
