### PR TITLE
15.0.12 RC 1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(15, 0, 11, 1);
+$OC_Version = array(15, 0, 12, 0);
 
 // The human readable string
-$OC_VersionString = '15.0.11';
+$OC_VersionString = '15.0.12';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #16803 Filter more configs
* #16825 Undefined variable response when server is no nextcloud anymore
* #16849 Only add the app-itunes-app tag if the id is set
* #16884 Use custom client URL in welcome emails
* #16897 Bump mixin-deep from 1.3.1 to 1.3.2 in /apps/accessibility
* #16900 Bump mixin-deep from 1.3.1 to 1.3.2 in /apps/oauth2
* #16902 Bump mixin-deep from 1.3.1 to 1.3.2 in /apps/updatenotification
* #16904 Bump mixin-deep from 1.3.1 to 1.3.2 in /settings
* #16905 Bump mixin-deep from 1.3.1 to 1.3.2 in /build
* #16992 Be sure to get the jailed path if the storage is a jail
* #16996 Only run code coverage CI on merge
* #17058 Returns 404
* #17062 Properly initialize the CacheJail for sharing
* #17071 Fix SMB availability status + higher delay on auth issues
* #17100 Emit moveToTrash event only for the deleting user
* #17158 Don't send executionContexts for Clear-Site-Data
* [nextcloud_announcements#49](https://github.com/nextcloud/nextcloud_announcements/pull/49) Randomize the interval.
* [nextcloud_announcements#53](https://github.com/nextcloud/nextcloud_announcements/pull/53) Stable16] Improve the notification
* [notifications#419](https://github.com/nextcloud/notifications/pull/419) Bump mixin-deep from 1.3.1 to 1.3.2


Pending PRs:

* [ ] #17013 Return the proper jailed path when requesting the root path @backportbot-nextcloud
* [x] #17198 Add uid to delete temp token query @backportbot-nextcloud