### PR TITLE
Remove unused backupscode function

### DIFF
--- a/apps/twofactor_backupcodes/appinfo/routes.php
+++ b/apps/twofactor_backupcodes/appinfo/routes.php
@@ -23,11 +23,6 @@
 return [
 	'routes' => [
 		[
-			'name' => 'settings#state',
-			'url' => '/settings/state',
-			'verb' => 'GET'
-		],
-		[
 			'name' => 'settings#createCodes',
 			'url' => '/settings/create',
 			'verb' => 'POST'

--- a/apps/twofactor_backupcodes/lib/Controller/SettingsController.php
+++ b/apps/twofactor_backupcodes/lib/Controller/SettingsController.php
@@ -50,15 +50,6 @@ class SettingsController extends Controller {
 
 	/**
 	 * @NoAdminRequired
-	 * @return JSONResponse
-	 */
-	public function state() {
-		$user = $this->userSession->getUser();
-		return $this->storage->getBackupCodesState($user);
-	}
-
-	/**
-	 * @NoAdminRequired
 	 * @PasswordConfirmationRequired
 	 *
 	 * @return JSONResponse


### PR DESCRIPTION
We use the initial state API so no need for this anymore.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>