### PR TITLE
Fix the recent/favorite/shared filename problem

### DIFF
--- a/apps/files/css/mobile.scss
+++ b/apps/files/css/mobile.scss
@@ -2,7 +2,7 @@
    $breakpoint-mobile +1 = size where app-navigation is hidden +1
    688 = table min-width */
 $min-table-width: 688px;
-@media only screen and (max-width: $min-table-width + $navigation-width) and (min-width: $breakpoint-mobile + 1), only screen and (max-width: $min-table-width) {
+@media only screen and (max-width: $min-table-width + $navigation-width) and (min-width: $breakpoint-mobile -1), only screen and (max-width: $min-table-width) {
 
 .app-files #app-content.dir-drop{
 	background-color: rgba(255, 255, 255, 1)!important;


### PR DESCRIPTION
Recent/Favorite/Shared file pages brake when you shrink the page lower than 688px.
**Used to look like this:**
 ![MOBILE_688](https://user-images.githubusercontent.com/12728974/64970283-c0f50f80-d8a5-11e9-947e-2334aad51c67.png)

**Now it looks like this:**
![mobile_shnink_ok](https://user-images.githubusercontent.com/12728974/64970282-c0f50f80-d8a5-11e9-906c-e51ca1af4e3a.png)

Im not sure why when you change the min-with into -1 works, but it does. I found this one while i was testing.

@jancborchardt @skjnldsv @juliushaertl does this make sense to you?

