### PR TITLE
Print error on data dir error

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -652,30 +652,35 @@ class OC {
 		if (!defined('OC_CONSOLE')) {
 			$errors = OC_Util::checkServer(\OC::$server->getSystemConfig());
 			if (count($errors) > 0) {
-				if (self::$CLI) {
-					// Convert l10n string into regular string for usage in database
-					$staticErrors = [];
-					foreach ($errors as $error) {
-						echo $error['error'] . "\n";
-						echo $error['hint'] . "\n\n";
-						$staticErrors[] = [
-							'error' => (string)$error['error'],
-							'hint' => (string)$error['hint'],
-						];
-					}
-
-					try {
-						\OC::$server->getConfig()->setAppValue('core', 'cronErrors', json_encode($staticErrors));
-					} catch (\Exception $e) {
-						echo('Writing to database failed');
-					}
-					exit(1);
-				} else {
+				if (!self::$CLI) {
 					http_response_code(503);
 					OC_Util::addStyle('guest');
-					OC_Template::printGuestPage('', 'error', array('errors' => $errors));
-					exit;
+					try {
+						OC_Template::printGuestPage('', 'error', array('errors' => $errors));
+						exit;
+					} catch (\Exception $e) {
+						// In case any error happens when showing the error page, we simply fall back to posting the text.
+						// This might be the case when e.g. the data directory is broken and we can not load/write SCSS to/from it.
+					}
 				}
+
+				// Convert l10n string into regular string for usage in database
+				$staticErrors = [];
+				foreach ($errors as $error) {
+					echo $error['error'] . "\n";
+					echo $error['hint'] . "\n\n";
+					$staticErrors[] = [
+						'error' => (string)$error['error'],
+						'hint' => (string)$error['hint'],
+					];
+				}
+
+				try {
+					\OC::$server->getConfig()->setAppValue('core', 'cronErrors', json_encode($staticErrors));
+				} catch (\Exception $e) {
+					echo('Writing to database failed');
+				}
+				exit(1);
 			} elseif (self::$CLI && \OC::$server->getConfig()->getSystemValue('installed', false)) {
 				\OC::$server->getConfig()->deleteAppValue('core', 'cronErrors');
 			}

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -266,7 +266,7 @@ class OC_Template extends \OC\Template\Base {
 	 * @return bool
 	 */
 	public static function printGuestPage( $application, $name, $parameters = array() ) {
-		$content = new OC_Template( $application, $name, "guest" );
+		$content = new OC_Template($application, $name, $name === 'error' ? $name : 'guest');
 		foreach( $parameters as $key => $value ) {
 			$content->assign( $key, $value );
 		}


### PR DESCRIPTION
1. Break your data directory e.g. (`chmod ugo-rwx -R data/`)
2. Visit `index.php`
3. Visit `index.php/apps/files` (e.g. from a bookmark

### Before
![Bildschirmfoto von 2019-09-16 19-39-24](https://user-images.githubusercontent.com/213943/64980388-08859680-d8ba-11e9-8293-7855f3d73662.png)

### After
![Bildschirmfoto von 2019-09-16 19-39-29](https://user-images.githubusercontent.com/213943/64980413-13402b80-d8ba-11e9-953e-3a61fed6af31.png)

Also I had an issue when my data dir is not mounted at all. So I added a second level fallback, when showing the error page also fails, we just print the plain messages.
> ![Bildschirmfoto von 2019-09-16 19-43-43](https://user-images.githubusercontent.com/213943/64980562-5e5a3e80-d8ba-11e9-82ad-62fdec69fdac.png)
