### PR TITLE
properly mark birthday calendars as not shareable for now

### DIFF
--- a/apps/dav/lib/CalDAV/Calendar.php
+++ b/apps/dav/lib/CalDAV/Calendar.php
@@ -363,7 +363,11 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IShareable {
 		return $this->caldavBackend->getPublishStatus($this);
 	}
 
-	private function canWrite() {
+	public function canWrite() {
+		if ($this->getName() === BirthdayService::BIRTHDAY_CALENDAR_URI) {
+			return false;
+		}
+
 		if (isset($this->calendarInfo['{http://owncloud.org/ns}read-only'])) {
 			return !$this->calendarInfo['{http://owncloud.org/ns}read-only'];
 		}

--- a/apps/dav/lib/CalDAV/Publishing/PublishPlugin.php
+++ b/apps/dav/lib/CalDAV/Publishing/PublishPlugin.php
@@ -126,7 +126,10 @@ class PublishPlugin extends ServerPlugin {
 			});
 
 			$propFind->handle('{'.self::NS_CALENDARSERVER.'}allowed-sharing-modes', function() use ($node) {
-				return new AllowedSharingModes(!$node->isSubscription(), !$node->isSubscription());
+				$canShare = (!$node->isSubscription() && $node->canWrite());
+				$canPublish = (!$node->isSubscription() && $node->canWrite());
+
+				return new AllowedSharingModes($canShare, $canPublish);
 			});
 		}
 	}


### PR DESCRIPTION
The DAV Sharing plugin enforces an (arbitrary) check for the calendar to be writeable: https://github.com/nextcloud/server/blob/master/apps/dav/lib/DAV/Sharing/Plugin.php#L166

This should ideally be fixed, but is something to look into for Nextcloud 18. In the meantime, properly mark the birthday calendar as not shareable. 