### PR TITLE
Add uid to delete temp token query

### DIFF
--- a/lib/private/Authentication/Token/PublicKeyTokenMapper.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenMapper.php
@@ -163,7 +163,8 @@ class PublicKeyTokenMapper extends QBMapper {
 		$qb = $this->db->getQueryBuilder();
 
 		$qb->delete('authtoken')
-			->where($qb->expr()->eq('type', $qb->createNamedParameter(IToken::TEMPORARY_TOKEN)))
+			->where($qb->expr()->eq('uid', $qb->createNamedParameter($except->getUID())))
+			->andWhere($qb->expr()->eq('type', $qb->createNamedParameter(IToken::TEMPORARY_TOKEN)))
 			->andWhere($qb->expr()->neq('id', $qb->createNamedParameter($except->getId())))
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)));
 


### PR DESCRIPTION
Fix #17166
Fix #17035

After a password change all temporary tokens (for every user) except the current token are deleted. Not sure why this popups now because the code is there for a long time :confused: 