### PR TITLE
Fix spaces being collapsed in move dialog

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -8,6 +8,7 @@
  * @copyright Copyright (c) 2016, Christoph Wurst <christoph@winzerhof-wurst.at>
  * @copyright Copyright (c) 2016, Raghu Nayyar <hey@raghunayyar.com>
  * @copyright Copyright (c) 2011-2017, Jan-Christoph Borchardt <hey@jancborchardt.net>
+ * @copyright Copyright (c) 2019, Gary Kim <gary@garykim.dev>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -891,7 +892,7 @@ code {
 				display: flex;
 				&__first {
 					overflow: hidden;
-					white-space: nowrap;
+					white-space: pre;
 					text-overflow: ellipsis;
 				}
 			}


### PR DESCRIPTION
This is a small one.
Would this be worth backporting?
Fix an issue where white space is missing in a file or folder name when in the "Move or copy" dialog.
Before:
![Screenshot from 2019-09-24 02-01-25](https://user-images.githubusercontent.com/47195730/65450283-5af12500-de6f-11e9-95b9-a3b26608841e.png)
After:
![Screenshot from 2019-09-24 01-54-35](https://user-images.githubusercontent.com/47195730/65450262-5298ea00-de6f-11e9-9f1d-e3c198f53fdf.png)
