### PR TITLE
Nextcloud 16.0.5

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(16, 0, 5, 0);
+$OC_Version = array(16, 0, 5, 1);
 
 // The human readable string
-$OC_VersionString = '16.0.5 RC1';
+$OC_VersionString = '16.0.5';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #17211 Fix l10n in federated file sharing
* #17257 Fix spaces being collapsed in move dialog 

Pending PRs:

* [ ] #16814 Instead of upsert query, fallback to default on PSQL <= 9.4 @backportbot-nextcloud
* [ ] #17012 Return the proper jailed path when requesting the root path @backportbot-nextcloud
* [ ] #17227 Fix "create folder" icon overlaying home icon @backportbot-nextcloud
