### PR TITLE
add (hidden) option to configure smb timeout

### DIFF
--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -54,7 +54,7 @@ class SMB extends Backend {
 					->setType(DefinitionParameter::VALUE_BOOLEAN)
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('timeout', $l->t('Timeout')))
-					->setFlag(DefinitionParameter::VALUE_HIDDEN)
+					->setType(DefinitionParameter::VALUE_HIDDEN)
 			])
 			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
 			->addAuthScheme(AuthMechanism::SCHEME_SMB)

--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -53,6 +53,8 @@ class SMB extends Backend {
 				(new DefinitionParameter('show_hidden', $l->t('Show hidden files')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN)
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+				(new DefinitionParameter('timeout', $l->t('Timeout')))
+					->setFlag(DefinitionParameter::VALUE_HIDDEN)
 			])
 			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
 			->addAuthScheme(AuthMechanism::SCHEME_SMB)

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -44,6 +44,7 @@ use Icewind\SMB\Exception\NotFoundException;
 use Icewind\SMB\Exception\TimedOutException;
 use Icewind\SMB\IFileInfo;
 use Icewind\SMB\Native\NativeServer;
+use Icewind\SMB\Options;
 use Icewind\SMB\ServerFactory;
 use Icewind\SMB\System;
 use Icewind\Streams\CallbackWrapper;
@@ -105,7 +106,14 @@ class SMB extends Common implements INotifyStorage {
 			$this->logger = \OC::$server->getLogger();
 		}
 
-		$serverFactory = new ServerFactory();
+		$options = new Options();
+		if (isset($params['timeout'])) {
+			$timeout = (int)$params['timeout'];
+			if ($timeout > 0) {
+				$options->setTimeout($timeout);
+			}
+		}
+		$serverFactory = new ServerFactory($options);
 		$this->server = $serverFactory->createServer($params['host'], $auth);
 		$this->share = $this->server->getShare(trim($params['share'], '/'));
 


### PR DESCRIPTION
hidden from ui to prevent clutter

```occ files_external:config <mount> timeout 30```

Signed-off-by: Robin Appelman <robin@icewind.nl>