### PR TITLE
deprecate md5 js global

### DIFF
--- a/core/src/globals.js
+++ b/core/src/globals.js
@@ -113,7 +113,7 @@ window['jstimezonedetect'] = jstimezonedetect
 window['jstz'] = jstimezonedetect
 window['jQuery'] = $
 window['marked'] = deprecate(marked, 'marked')
-window['md5'] = md5
+setDeprecatedProp('md5', () => md5, 'The global md5 is deprecated, ship your own (blueimp-md5)')
 window['moment'] = moment
 
 window['OC'] = OC


### PR DESCRIPTION
Apps should ship their own blueimp-md5

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>