### PR TITLE
Cast comment id to integer for delete 

### DIFF
--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -683,7 +683,7 @@ class Manager implements ICommentsManager {
 
 		$qb = $this->dbConn->getQueryBuilder();
 		$query = $qb->delete('comments')
-			->where($qb->expr()->eq('id', $qb->createParameter('id')))
+			->where($qb->expr()->eq('id', $qb->createParameter('id'), IQueryBuilder::PARAM_INT))
 			->setParameter('id', $id);
 
 		try {


### PR DESCRIPTION
Fix #17314

I'm not sure if there is a real issue somewhere but it logs a warning to pqsql log. It's a bit confusing that most of the time the comment id is a string while an integer on db.