### PR TITLE
Revert "[stable17] Bring the default font size up to 15px"

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -17,8 +17,7 @@ ul { list-style:none; }
 body {
 	background-color: #ffffff;
 	font-weight: normal;
-	/* bring the default font size up to 15px */
-	font-size: .9375em;
+	font-size: .8em;
 	line-height: 1.6em;
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 	color: #000;

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -88,8 +88,7 @@ ul {
 body {
 	background-color: var(--color-main-background);
 	font-weight: normal;
-	/* bring the default font size up to 15px */
-	font-size: .9375em;
+	font-size: .8em;
 	line-height: 1.6em;
 	font-family: var(--font-face);
 	color: var(--color-main-text);


### PR DESCRIPTION
Reverts nextcloud/server#17309

> Georg Ehrke:
> Why was this backported? github.com/nextcloud/server/pull/17309
> 
> As Jan-C. Borchardt pointed out in github.com/nextcloud/server/issues/17236, most of the other stuff is sized in pixels, so this backport is likely to break the design of some apps in a minor update from 17.0.0 to 17.0.1.