### PR TITLE
Allow Re-Sharing of folders shared by circle

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -303,7 +303,8 @@ class Manager implements IManager {
 			$incomingShares = $this->getSharedWith($share->getSharedBy(), Share::SHARE_TYPE_USER, $userMountPoint, -1, 0);
 			$incomingShares = array_merge($incomingShares, $this->getSharedWith($share->getSharedBy(), Share::SHARE_TYPE_GROUP, $userMountPoint, -1, 0));
 			$incomingShares = array_merge($incomingShares, $this->getSharedWith($share->getSharedBy(), Share::SHARE_TYPE_ROOM, $userMountPoint, -1, 0));
-
+			$incomingShares = array_merge($incomingShares, $this->getSharedWith($share->getSharedBy(), Share::SHARE_TYPE_CIRCLE, $userMountPoint, -1, 0));
+			
 			/** @var \OCP\Share\IShare[] $incomingShares */
 			if (!empty($incomingShares)) {
 				foreach ($incomingShares as $incomingShare) {


### PR DESCRIPTION
If a user is in circle A and a folder is shared to this circle with re-sharing permission, the user cannot re-share the folder or a subfolder without this line. There is a error message in the log:

```
{"reqId":"R0th0ufni5warwevBqni","level":3,"time":"2019-09-27T07:46:38+00:00","remoteAddr":"xxx.xx.xx.xx","user":"xxx","app":"PHP","method":"POST","url":"\/ocs\/v2.php\/apps\/f/v1\/shares?format=json","message":"Undefined variable: permissions at \/data\/nextcloud_16\/lib\/private\/Share20\/Manager.php#325","userAgent":"Mozilla\/5.0 (Macintosh; Intel MppleWebKit\/605.1.15 (KHTML, like Gecko) Version\/13.0 Safari\/605.1.15","version":"16.0.4.1"}
{"reqId":"R0th0ufni5warwevBqni","level":3,"time":"2019-09-27T07:46:38+00:00","remoteAddr":"xxx.xx.xx.xx","user":"xxx","app":"PHP","method":"POST","url":"\/ocs\/v2.php\/apps\/f/v1\/shares?format=json","message":"Error: Unsupported operand types at \/data\/nextcloud_16\/lib\/private\/Share20\/Manager.php#325","userAgent":"Mozilla\/5.0 (Macintosh; Intel AppleWebKit\/605.1.15 (KHTML, like Gecko) Version\/13.0 Safari\/605.1.15","version":"16.0.4.1"}
```
