### PR TITLE
Don't call basename on null

### DIFF
--- a/apps/workflowengine/lib/Check/FileName.php
+++ b/apps/workflowengine/lib/Check/FileName.php
@@ -46,7 +46,7 @@ class FileName extends AbstractStringCheck implements IFileCheck {
 	 * @return string
 	 */
 	protected function getActualValue(): string {
-		return basename($this->path);
+		return $this->path === null ? '' : basename($this->path);
 	}
 
 	/**


### PR DESCRIPTION
Similar to https://github.com/nextcloud/server/pull/17332/commits/2f5eac1299aa6cf9d7b2400c2aebb95f5dbe193c it just fixes the result of the broken jailedpath call from https://github.com/nextcloud/server/commit/b5f407e02d03e19ef820135347a69619b863538f

Never the less I would do this PR now and do a quick backport so its not causing issues anymore until a final solution has been found.