### PR TITLE
Allow removing federated shares of locally reshared files

### DIFF
--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -563,6 +563,11 @@ class FederatedShareProvider implements IShareProvider {
 	 * @throws \OC\HintException
 	 */
 	protected function revokeShare($share, $isOwner) {
+		if ($this->userManager->userExists($share->getShareOwner() && $this->userManager->userExists($share->getSharedBy()))) {
+			// If both the owner and the initiator of the share are local users we don't have to notify anybody else
+			return;
+		}
+
 		// also send a unShare request to the initiator, if this is a different user than the owner
 		if ($share->getShareOwner() !== $share->getSharedBy()) {
 			if ($isOwner) {


### PR DESCRIPTION
* UserA shares a folder to UserB
* UserB does a federated share to userC@serverC
* UserB now tries to revoke the federated share

Before we always tried to notify the remote cloud. The case that the
file was reshared locally was not considered. This patch makes sure not
to try to notify a federated server if both users are local users.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>