### PR TITLE
Fix updating and deleting authtokens

### DIFF
--- a/apps/settings/lib/Controller/AuthSettingsController.php
+++ b/apps/settings/lib/Controller/AuthSettingsController.php
@@ -29,6 +29,7 @@ namespace OCA\Settings\Controller;
 
 use BadMethodCallException;
 use OC\Authentication\Exceptions\InvalidTokenException;
+use OC\Authentication\Exceptions\ExpiredTokenException;
 use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Exceptions\WipeTokenException;
 use OC\Authentication\Token\INamedToken;
@@ -259,10 +260,13 @@ class AuthSettingsController extends Controller {
 	 * @param int $id
 	 * @return IToken
 	 * @throws InvalidTokenException
-	 * @throws \OC\Authentication\Exceptions\ExpiredTokenException
 	 */
 	private function findTokenByIdAndUser(int $id): IToken {
-		$token = $this->tokenProvider->getTokenById($id);
+		try {
+			$token = $this->tokenProvider->getTokenById($id);
+		} catch (ExpiredTokenException $e) {
+			$token = $e->getToken();
+		}
 		if ($token->getUID() !== $this->uid) {
 			throw new InvalidTokenException('This token does not belong to you!');
 		}

--- a/apps/settings/tests/Controller/AuthSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/AuthSettingsControllerTest.php
@@ -23,6 +23,7 @@ namespace Test\Settings\Controller;
 
 use OC\AppFramework\Http;
 use OC\Authentication\Exceptions\InvalidTokenException;
+use OC\Authentication\Exceptions\ExpiredTokenException;
 use OC\Authentication\Token\DefaultToken;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
@@ -188,6 +189,30 @@ class AuthSettingsControllerTest extends TestCase {
 		$this->assertEquals([], $this->controller->destroy($tokenId));
 	}
 
+	public function testDestroyExpired() {
+		$tokenId = 124;
+		$token = $this->createMock(DefaultToken::class);
+
+		$token->expects($this->exactly(2))
+			->method('getId')
+			->willReturn($tokenId);
+
+		$token->expects($this->once())
+			->method('getUID')
+			->willReturn($this->uid);
+
+		$this->tokenProvider->expects($this->once())
+			->method('getTokenById')
+			->with($this->equalTo($tokenId))
+			->willThrowException(new ExpiredTokenException($token));
+
+		$this->tokenProvider->expects($this->once())
+			->method('invalidateTokenById')
+			->with($this->uid, $tokenId);
+
+		$this->assertSame([], $this->controller->destroy($tokenId));
+	}
+
 	public function testDestroyWrongUser() {
 		$tokenId = 124;
 		$token = $this->createMock(DefaultToken::class);
@@ -312,6 +337,26 @@ class AuthSettingsControllerTest extends TestCase {
 
 		$token->expects($this->never())
 			->method('setScope');
+
+		$this->tokenProvider->expects($this->once())
+			->method('updateToken')
+			->with($this->equalTo($token));
+
+		$this->assertSame([], $this->controller->update($tokenId, ['filesystem' => true], 'App password'));
+	}
+
+	public function testUpdateExpired() {
+		$tokenId = 42;
+		$token = $this->createMock(DefaultToken::class);
+
+		$token->expects($this->once())
+			->method('getUID')
+			->willReturn($this->uid);
+
+		$this->tokenProvider->expects($this->once())
+			->method('getTokenById')
+			->with($this->equalTo($tokenId))
+			->willThrowException(new ExpiredTokenException($token));
 
 		$this->tokenProvider->expects($this->once())
 			->method('updateToken')


### PR DESCRIPTION
**Problem**: updating and deleting expired authtokens don't works because `PublicKeyTokenProvider->getTokenById` throws `ExpiredTokenException` and client receives response 404.
**Solution**: we need to catch `ExpiredTokenException` and get token from this exception (as already implemented in [OauthApiController](https://github.com/nextcloud/server/blob/v17.0.0/apps/oauth2/lib/Controller/OauthApiController.php#L132))