### PR TITLE
Fix oauth client redirect

### DIFF
--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -196,7 +196,11 @@ class ClientFlowLoginController extends Controller {
 		$this->session->set(self::stateName, $stateToken);
 
 		$csp = new Http\ContentSecurityPolicy();
-		$csp->addAllowedFormActionDomain('nc://*');
+		if ($client) {
+			$csp->addAllowedFormActionDomain($client->getRedirectUri());
+		} else {
+			$csp->addAllowedFormActionDomain('nc://*');
+		}
 
 		$response = new StandaloneTemplateResponse(
 			$this->appName,
@@ -241,7 +245,11 @@ class ClientFlowLoginController extends Controller {
 		}
 
 		$csp = new Http\ContentSecurityPolicy();
-		$csp->addAllowedFormActionDomain('nc://*');
+		if ($client) {
+			$csp->addAllowedFormActionDomain($client->getRedirectUri());
+		} else {
+			$csp->addAllowedFormActionDomain('nc://*');
+		}
 
 		$response = new StandaloneTemplateResponse(
 			$this->appName,

--- a/tests/Core/Controller/ClientFlowLoginControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginControllerTest.php
@@ -200,6 +200,7 @@ class ClientFlowLoginControllerTest extends TestCase {
 			->willReturn('Mac OS X Sync Client');
 		$client = new Client();
 		$client->setName('My external service');
+		$client->setRedirectUri('https://example.com/redirect.php');
 		$this->clientMapper
 			->expects($this->once())
 			->method('getByIdentifier')
@@ -249,7 +250,7 @@ class ClientFlowLoginControllerTest extends TestCase {
 			'guest'
 		);
 		$csp = new Http\ContentSecurityPolicy();
-		$csp->addAllowedFormActionDomain('nc://*');
+		$csp->addAllowedFormActionDomain('https://example.com/redirect.php');
 		$expected->setContentSecurityPolicy($csp);
 		$this->assertEquals($expected, $this->clientFlowLoginController->showAuthPickerPage('MyClientIdentifier'));
 	}


### PR DESCRIPTION
**Problem**: Chrome prevents redirect to oauth redirect url because of CSP 'form-action' on grant page. Firefox allows redirect from form submission responses but Chrome doesn't (see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action), [W3C](https://github.com/w3c/webappsec-csp/issues/8)).
**Solution**: allow oauth redirect url in CSP.