### PR TITLE
Add index on calendarid for calendarobject_props table

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -145,6 +145,14 @@ class Application extends App {
 						$subject->addHintForMissingSubject($table->getName(), 'cards_prop_abid');
 					}
 				}
+
+				if ($schema->hasTable('calendarobjects_props')) {
+					$table = $schema->getTable('calendarobjects_props');
+
+					if (!$table->hasIndex('calendarobject_calid_index')) {
+						$subject->addHintForMissingSubject($table->getName(), 'calendarobject_calid_index');
+					}
+				}
 			}
 		);
 

--- a/core/Command/Db/AddMissingIndices.php
+++ b/core/Command/Db/AddMissingIndices.php
@@ -221,6 +221,19 @@ class AddMissingIndices extends Command {
 			}
 		}
 
+		$output->writeln('<info>Check indices of the calendarobjects_props table.</info>');
+		if ($schema->hasTable('calendarobjects_props')) {
+			$table = $schema->getTable('calendarobjects_props');
+			if (!$table->hasIndex('calendarobject_calid_index')) {
+				$output->writeln('<info>Adding calendarobject_calid_index index to the calendarobjects_props table, this can take some time...</info>');
+
+				$table->addIndex(['calendarid', 'calendartype'], 'calendarobject_calid_index');
+				$this->connection->migrateToSchema($schema->getWrappedSchema());
+				$updated = true;
+				$output->writeln('<info>calendarobjects_props table updated successfully.</info>');
+			}
+		}
+
 		if (!$updated) {
 			$output->writeln('<info>Done.</info>');
 		}


### PR DESCRIPTION
Had a slow query on the `calendarobject_props` table.

```sql
DELETE FROM "oc_calendarobjects_props" WHERE ("calendarid" = '6557') AND ("calendartype" = '1');
```

Before
```
                                                                  QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------
 Gather  (cost=1000.00..493161.93 rows=514 width=58) (actual time=2175.423..2344.730 rows=111 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on oc_calendarobjects_props  (cost=0.00..492110.53 rows=214 width=58) (actual time=2019.057..2164.014 rows=37 loops=3)
         Filter: ((calendarid = '6686'::bigint) AND (calendartype = 1))
         Rows Removed by Filter: 8458169
 Planning Time: 0.078 ms
 Execution Time: 2344.754 ms
(8 lignes)
```

After
```                                                                          QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------
 Index Scan using calendarobject_calendar_index on oc_calendarobjects_props  (cost=0.56..576.99 rows=513 width=58) (actual time=0.093..0.123 rows=111 loops=1)
   Index Cond: ((calendarid = '6686'::bigint) AND (calendartype = 1))
 Planning Time: 0.431 ms
 Execution Time: 0.147 ms
(4 lignes)
```

The index didn't take time to create itself, so no need for manual migration.