### PR TITLE
make TrustedDomainHelper case insensitive

### DIFF
--- a/lib/private/Security/TrustedDomainHelper.php
+++ b/lib/private/Security/TrustedDomainHelper.php
@@ -90,7 +90,7 @@ class TrustedDomainHelper {
 			if (gettype($trusted) !== 'string') {
 				break;
 			}
-			$regex = '/^' . implode('[-\.a-zA-Z0-9]*', array_map(function($v) { return preg_quote($v, '/'); }, explode('*', $trusted))) . '$/';
+			$regex = '/^' . implode('[-\.a-zA-Z0-9]*', array_map(function($v) { return preg_quote($v, '/'); }, explode('*', $trusted))) . '$/i';
 			if (preg_match($regex, $domain) || preg_match($regex, $domainWithPort)) {
  				return true;
  			}

--- a/tests/lib/Security/TrustedDomainHelperTest.php
+++ b/tests/lib/Security/TrustedDomainHelperTest.php
@@ -54,6 +54,8 @@ class TrustedDomainHelperTest extends \Test\TestCase {
 			'cen*ter',
 			'*.leadingwith.port:123',
 			'trailingwith.port*:456',
+			'UPPERCASE.DOMAIN',
+			'lowercase.domain',
 		];
 		return [
 			// empty defaults to false with 8.1
@@ -106,6 +108,9 @@ class TrustedDomainHelperTest extends \Test\TestCase {
 			[$trustedHostTestList, '-bad', false],
 			[$trustedHostTestList, '-bad.leading.host', false],
 			[$trustedHostTestList, 'bad..der.leading.host', false],
+			// case sensitivity
+			[$trustedHostTestList, 'uppercase.domain', true],
+			[$trustedHostTestList, 'LOWERCASE.DOMAIN', true],
 		];
 	}
 }


### PR DESCRIPTION
solves #17377
@kesselb @rullzer 
(this is a second try, after I screwed up the sign-off on the first one)
