### PR TITLE
Skip password confirmation for ocs-apirequest

### DIFF
--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -237,6 +237,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			$dispatcher->registerMiddleware(
 				new OC\AppFramework\Middleware\Security\PasswordConfirmationMiddleware(
 					$c->query(IControllerMethodReflector::class),
+					$c->query(IRequest::class),
 					$c->query(ISession::class),
 					$c->query(IUserSession::class),
 					$c->query(ITimeFactory::class)

--- a/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
@@ -27,6 +27,7 @@ use OC\AppFramework\Middleware\Security\PasswordConfirmationMiddleware;
 use OC\AppFramework\Utility\ControllerMethodReflector;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -35,6 +36,8 @@ use Test\TestCase;
 class PasswordConfirmationMiddlewareTest extends TestCase {
 	/** @var ControllerMethodReflector */
 	private $reflector;
+	/** @var IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	private $request;
 	/** @var ISession|\PHPUnit_Framework_MockObject_MockObject */
 	private $session;
 	/** @var IUserSession|\PHPUnit_Framework_MockObject_MockObject */
@@ -50,6 +53,7 @@ class PasswordConfirmationMiddlewareTest extends TestCase {
 
 	protected function setUp() {
 		$this->reflector = new ControllerMethodReflector();
+		$this->request = $this->createMock(IRequest::class);
 		$this->session = $this->createMock(ISession::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->user = $this->createMock(IUser::class);
@@ -58,6 +62,7 @@ class PasswordConfirmationMiddlewareTest extends TestCase {
 
 		$this->middleware = new PasswordConfirmationMiddleware(
 			$this->reflector,
+			$this->request,
 			$this->session,
 			$this->userSession,
 			$this->timeFactory


### PR DESCRIPTION
**Problem**: OAuth client cannot use some part of nextcloud API 30 minutes after authentication because nextcloud requires password confirmation even for requests with`ocs-apirequest: true` and `authorization: Bearer ...` headers.
**Solution**: Skip password confirmation for requests with mentioned headers (as already implemented in [SecurityMiddleware](https://github.com/nextcloud/server/blob/v17.0.0/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php#L168))

I will add tests later If you find that this is right thing)

Also it will be good to make method `isOcsApiRequest` to not duplicate this checks in 2 middlewares. Is Request class right place for this?

Related: #6476