### PR TITLE
Do not escape slashes in log json

### DIFF
--- a/lib/private/Log/LogDetails.php
+++ b/lib/private/Log/LogDetails.php
@@ -90,12 +90,12 @@ abstract class LogDetails {
 		// them manually.
 		foreach($entry as $key => $value) {
 			if(is_string($value)) {
-				$testEncode = json_encode($value);
+				$testEncode = json_encode($value, JSON_UNESCAPED_SLASHES);
 				if($testEncode === false) {
 					$entry[$key] = utf8_encode($value);
 				}
 			}
 		}
-		return json_encode($entry, JSON_PARTIAL_OUTPUT_ON_ERROR);
+		return json_encode($entry, JSON_PARTIAL_OUTPUT_ON_ERROR | JSON_UNESCAPED_SLASHES);
 	}
 }


### PR DESCRIPTION
This makes log output far easier to read. I could not think of why slashes would need to be escaped in the resulting JSON if it is just passed to the logs, but correct me if I'm wrong.