### PR TITLE
Add index on principaluri for schedulingobjects table

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -153,6 +153,13 @@ class Application extends App {
 						$subject->addHintForMissingSubject($table->getName(), 'calendarobject_calid_index');
 					}
 				}
+
+				if ($schema->hasTable('schedulingobjects')) {
+					$table = $schema->getTable('schedulingobjects');
+					if (!$table->hasIndex('schedulobj_principuri_index')) {
+						$subject->addHintForMissingSubject($table->getName(), 'schedulobj_principuri_index');
+					}
+				}
 			}
 		);
 

--- a/core/Command/Db/AddMissingIndices.php
+++ b/core/Command/Db/AddMissingIndices.php
@@ -234,6 +234,19 @@ class AddMissingIndices extends Command {
 			}
 		}
 
+		$output->writeln('<info>Check indices of the schedulingobjects table.</info>');
+		if ($schema->hasTable('schedulingobjects')) {
+			$table = $schema->getTable('schedulingobjects');
+			if (!$table->hasIndex('schedulobj_principuri_index')) {
+				$output->writeln('<info>Adding schedulobj_principuri_index index to the schedulingobjects table, this can take some time...</info>');
+
+				$table->addIndex(['principaluri'], 'schedulobj_principuri_index');
+				$this->connection->migrateToSchema($schema->getWrappedSchema());
+				$updated = true;
+				$output->writeln('<info>schedulingobjects table updated successfully.</info>');
+			}
+		}
+
 		if (!$updated) {
 			$output->writeln('<info>Done.</info>');
 		}


### PR DESCRIPTION
Following #17429 

#### Before
```sql
EXPLAIN ANALYZE SELECT "uri", "calendardata", "lastmodified", "etag", "size" FROM "oc_schedulingobjects" WHERE "principaluri" = 'principals/users/someuser';
```

```
                                                      QUERY PLAN
----------------------------------------------------------------------------------------------------------------------
 Seq Scan on oc_schedulingobjects  (cost=0.00..7111.77 rows=8 width=1114) (actual time=6.641..12.029 rows=21 loops=1)
   Filter: ((principaluri)::text = 'principals/users/someuser'::text)
   Rows Removed by Filter: 43732
 Planning Time: 0.198 ms
 Execution Time: 12.044 ms
(5 lignes)
```

#### After
```sql
EXPLAIN ANALYZE SELECT "uri", "calendardata", "lastmodified", "etag", "size" FROM "oc_schedulingobjects" WHERE "principaluri" = 'principals/users/someuser
```

```
                                                                           QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------
 Index Scan using schedulingobjects_principaluri_index on oc_schedulingobjects  (cost=0.41..10.45 rows=8 width=1114) (actual time=0.067..0.095 rows=21 loops=1)
   Index Cond: ((principaluri)::text = 'principals/users/someuser'::text)
 Planning Time: 0.137 ms
 Execution Time: 0.108 ms
(4 lignes)
```

Adding the index on ~40k rows took less than a second.