### PR TITLE
Do not follow symlinks with webpack

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -93,6 +93,7 @@ module.exports = []
 				// make sure to use the handlebar runtime when importing
 				handlebars: 'handlebars/runtime'
 			},
-			extensions: ['*', '.js', '.vue']
+			extensions: ['*', '.js', '.vue'],
+			symlinks: false
 		}
 	}, config))


### PR DESCRIPTION
Allow us to use npm link without issues (eslint)

