### PR TITLE
Increase server version to trigger latest migration

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(18, 0, 0, 0);
+$OC_Version = array(18, 0, 0, 1);
 
 // The human readable string
 $OC_VersionString = '18.0.0 Alpha';


### PR DESCRIPTION
I ran into `Column not found: 1054 Unknown column 'displayname' in 'field list'` on my dev instance today because @nickvergessen added a new migration https://github.com/nextcloud/server/pull/17221 but didn't touch the version.