### PR TITLE
Make renewSessionToken return the new token

### DIFF
--- a/lib/private/Authentication/Token/DefaultTokenProvider.php
+++ b/lib/private/Authentication/Token/DefaultTokenProvider.php
@@ -196,8 +196,9 @@ class DefaultTokenProvider implements IProvider {
 	 * @param string $oldSessionId
 	 * @param string $sessionId
 	 * @throws InvalidTokenException
+	 * @return IToken
 	 */
-	public function renewSessionToken(string $oldSessionId, string $sessionId) {
+	public function renewSessionToken(string $oldSessionId, string $sessionId): IToken {
 		$token = $this->getToken($oldSessionId);
 
 		$newToken = new DefaultToken();
@@ -214,6 +215,8 @@ class DefaultTokenProvider implements IProvider {
 		$newToken->setLastActivity($this->time->getTime());
 		$this->mapper->insert($newToken);
 		$this->mapper->delete($token);
+
+		return $newToken;
 	}
 
 	/**

--- a/lib/private/Authentication/Token/IProvider.php
+++ b/lib/private/Authentication/Token/IProvider.php
@@ -84,8 +84,9 @@ interface IProvider {
 	 * @param string $sessionId
 	 * @throws InvalidTokenException
 	 * @throws \RuntimeException when OpenSSL reports a problem
+	 * @return IToken The new token
 	 */
-	public function renewSessionToken(string $oldSessionId, string $sessionId);
+	public function renewSessionToken(string $oldSessionId, string $sessionId): IToken;
 
 	/**
 	 * Invalidate (delete) the given session token

--- a/lib/private/Authentication/Token/Manager.php
+++ b/lib/private/Authentication/Token/Manager.php
@@ -158,14 +158,15 @@ class Manager implements IProvider {
 	 * @param string $oldSessionId
 	 * @param string $sessionId
 	 * @throws InvalidTokenException
+	 * @return IToken
 	 */
-	public function renewSessionToken(string $oldSessionId, string $sessionId) {
+	public function renewSessionToken(string $oldSessionId, string $sessionId): IToken {
 		try {
-			$this->publicKeyTokenProvider->renewSessionToken($oldSessionId, $sessionId);
+			return $this->publicKeyTokenProvider->renewSessionToken($oldSessionId, $sessionId);
 		} catch (ExpiredTokenException $e) {
 			throw $e;
 		} catch (InvalidTokenException $e) {
-			$this->defaultTokenProvider->renewSessionToken($oldSessionId, $sessionId);
+			return $this->defaultTokenProvider->renewSessionToken($oldSessionId, $sessionId);
 		}
 	}
 

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -129,7 +129,7 @@ class PublicKeyTokenProvider implements IProvider {
 		return $token;
 	}
 
-	public function renewSessionToken(string $oldSessionId, string $sessionId) {
+	public function renewSessionToken(string $oldSessionId, string $sessionId): IToken {
 		$this->cache->clear();
 
 		$token = $this->getToken($oldSessionId);
@@ -144,7 +144,7 @@ class PublicKeyTokenProvider implements IProvider {
 			$password = $this->decryptPassword($token->getPassword(), $privateKey);
 		}
 
-		$this->generateToken(
+		$newToken = $this->generateToken(
 			$sessionId,
 			$token->getUID(),
 			$token->getLoginName(),
@@ -155,6 +155,8 @@ class PublicKeyTokenProvider implements IProvider {
 		);
 
 		$this->mapper->delete($token);
+
+		return $newToken;
 	}
 
 	public function invalidateToken(string $token) {

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -861,7 +861,7 @@ class Session implements IUserSession, Emitter {
 
 		try {
 			$sessionId = $this->session->getId();
-			$this->tokenProvider->renewSessionToken($oldSessionId, $sessionId);
+			$token = $this->tokenProvider->renewSessionToken($oldSessionId, $sessionId);
 		} catch (SessionNotAvailableException $ex) {
 			return false;
 		} catch (InvalidTokenException $ex) {
@@ -870,7 +870,6 @@ class Session implements IUserSession, Emitter {
 		}
 
 		$this->setMagicInCookie($user->getUID(), $newToken);
-		$token = $this->tokenProvider->getToken($sessionId);
 
 		//login
 		$this->setUser($user);

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -595,24 +595,23 @@ class SessionTest extends \Test\TestCase {
 			->method('setUserValue')
 			->with('foo', 'login_token', 'abcdefg123456', 10000);
 
-		$session->expects($this->once())
-			->method('getId')
-			->will($this->returnValue($sessionId));
-		$this->tokenProvider->expects($this->once())
-			->method('renewSessionToken')
-			->with($oldSessionId, $sessionId)
-			->will($this->returnValue(true));
-
 		$tokenObject = $this->createMock(IToken::class);
 		$tokenObject->expects($this->once())
 			->method('getLoginName')
 			->willReturn('foobar');
 		$tokenObject->method('getId')
 			->willReturn(42);
+
+		$session->expects($this->once())
+			->method('getId')
+			->will($this->returnValue($sessionId));
 		$this->tokenProvider->expects($this->once())
-			->method('getToken')
-			->with($sessionId)
+			->method('renewSessionToken')
+			->with($oldSessionId, $sessionId)
 			->willReturn($tokenObject);
+
+		$this->tokenProvider->expects($this->never())
+			->method('getToken');
 
 		$user->expects($this->any())
 			->method('getUID')


### PR DESCRIPTION
Avoids directly getting the token again. We just inserted it so it and
have all the info. So that query is just a waste.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>