### PR TITLE
Show error if tag name is empty

### DIFF
--- a/apps/systemtags/js/admin.js
+++ b/apps/systemtags/js/admin.js
@@ -1,5 +1,6 @@
 /**
  * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
+ * @copyright Copyright (c) 2019 Gary Kim <gary@garykim.dev>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -82,6 +83,11 @@
 				userVisible: level === 2 || level === 3,
 				userAssignable: level === 3
 			};
+
+			if (!data.name) {
+				OCP.Toast.error(t('systemtags_manager', 'Tag name is empty'));
+				return;
+			}
 
 			if (tagId) {
 				var model = this.collection.get(tagId);


### PR DESCRIPTION
Currently when adding a Collaborative tag, it is possible to create tags with blank names.

This will cause an error toast instead if the tag name is empty.

We can also use the old `OC.Notifications` for backporting.