### PR TITLE
In iMIP email, make filename of attached ICS file unique

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -279,7 +279,7 @@ class IMipPlugin extends SabreIMipPlugin {
 
 		$attachment = $this->mailer->createAttachment(
 			$iTipMessage->message->serialize(),
-			'event.ics',// TODO(leon): Make file name unique, e.g. add event id
+			sprintf('event-%s.ics', $vevent->UID ?: 'nextcloud'),
 			'text/calendar; method=' . $iTipMessage->method
 		);
 		$message->attach($attachment);


### PR DESCRIPTION
Currently, the ICS file attached to invitation emails is always
named, invariably, "event.ics".

With this commit, the file is named "event-${UID}.ics" using the
UID of the calendar event.  For example:
`event-c4b6644a-c2c5-3a47-a5f2-3aeb9469447a.ics`.

So if I receive invitiation emails for two different calendar events
(even from different nextcloud servers), each gets saved to its
own distinct file.

Signed-off-by: brad@wbr.tech