### PR TITLE
Always use the latest timestamp for merged activities

### DIFF
--- a/lib/private/Activity/EventMerger.php
+++ b/lib/private/Activity/EventMerger.php
@@ -111,7 +111,8 @@ class EventMerger implements IEventMerger {
 
 			$event->setRichSubject($newSubject, $parameters)
 				->setParsedSubject($parsedSubject)
-				->setChildEvent($previousEvent);
+				->setChildEvent($previousEvent)
+				->setTimestamp(max($event->getTimestamp(), $previousEvent->getTimestamp()));
 		} catch (\UnexpectedValueException $e) {
 			return $event;
 		}


### PR DESCRIPTION
Make sure that merged activities always have the latest timestamp set.