### PR TITLE
Remove settings/ from phan

### DIFF
--- a/build/.phan/config.php
+++ b/build/.phan/config.php
@@ -24,7 +24,6 @@ return [
 		'lib/composer',
 		'ocs-provider/',
 		'ocs/',
-		'settings/',
 		'tests/lib/Util/User',
 		'themes',
 	],


### PR DESCRIPTION
settings is a app now. so the directory does not exist: https://github.com/nextcloud/server/pull/17182

e.g. https://drone.nextcloud.com/nextcloud/server/22312/5/6
