### PR TITLE
Have proper permissions defined for shares without an node owner

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -291,7 +291,8 @@ class Manager implements IManager {
 		}
 
 		$mount = $share->getNode()->getMountPoint();
-		if ($share->getNode()->getOwner()->getUID() !== $share->getSharedBy()) {
+		$permissions = $share->getNode()->getPermissions();
+		if ($share->getNode()->getOwner()->getUID() !== '' && $share->getNode()->getOwner()->getUID() !== $share->getSharedBy()) {
 			// When it's a reshare use the parent share permissions as maximum
 			$userMountPointId = $mount->getStorageRootId();
 			$userMountPoints = $userFolder->getById($userMountPointId);


### PR DESCRIPTION
When sharing a file from a groupfolder via the OCS API the owner is not set while when sharing though the webinterface (with a cookie set) the owner of the share node will be set to the current user. While this commit fixes the issue I still want to figure out why there is a difference in the node owner.