### PR TITLE
Set the proper filename for version downloads

### DIFF
--- a/apps/files_versions/appinfo/info.xml
+++ b/apps/files_versions/appinfo/info.xml
@@ -37,6 +37,9 @@
 	</commands>
 
 	<sabre>
+		<plugins>
+			<plugin>OCA\Files_Versions\Sabre\Plugin</plugin>
+		</plugins>
 		<collections>
 			<collection>OCA\Files_Versions\Sabre\RootCollection</collection>
 		</collections>

--- a/apps/files_versions/composer/composer/autoload_classmap.php
+++ b/apps/files_versions/composer/composer/autoload_classmap.php
@@ -16,6 +16,7 @@ return array(
     'OCA\\Files_Versions\\Events\\CreateVersionEvent' => $baseDir . '/../lib/Events/CreateVersionEvent.php',
     'OCA\\Files_Versions\\Expiration' => $baseDir . '/../lib/Expiration.php',
     'OCA\\Files_Versions\\Hooks' => $baseDir . '/../lib/Hooks.php',
+    'OCA\\Files_Versions\\Sabre\\Plugin' => $baseDir . '/../lib/Sabre/Plugin.php',
     'OCA\\Files_Versions\\Sabre\\RestoreFolder' => $baseDir . '/../lib/Sabre/RestoreFolder.php',
     'OCA\\Files_Versions\\Sabre\\RootCollection' => $baseDir . '/../lib/Sabre/RootCollection.php',
     'OCA\\Files_Versions\\Sabre\\VersionCollection' => $baseDir . '/../lib/Sabre/VersionCollection.php',

--- a/apps/files_versions/composer/composer/autoload_static.php
+++ b/apps/files_versions/composer/composer/autoload_static.php
@@ -31,6 +31,7 @@ class ComposerStaticInitFiles_Versions
         'OCA\\Files_Versions\\Events\\CreateVersionEvent' => __DIR__ . '/..' . '/../lib/Events/CreateVersionEvent.php',
         'OCA\\Files_Versions\\Expiration' => __DIR__ . '/..' . '/../lib/Expiration.php',
         'OCA\\Files_Versions\\Hooks' => __DIR__ . '/..' . '/../lib/Hooks.php',
+        'OCA\\Files_Versions\\Sabre\\Plugin' => __DIR__ . '/..' . '/../lib/Sabre/Plugin.php',
         'OCA\\Files_Versions\\Sabre\\RestoreFolder' => __DIR__ . '/..' . '/../lib/Sabre/RestoreFolder.php',
         'OCA\\Files_Versions\\Sabre\\RootCollection' => __DIR__ . '/..' . '/../lib/Sabre/RootCollection.php',
         'OCA\\Files_Versions\\Sabre\\VersionCollection' => __DIR__ . '/..' . '/../lib/Sabre/VersionCollection.php',

--- a/apps/files_versions/lib/Sabre/Plugin.php
+++ b/apps/files_versions/lib/Sabre/Plugin.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_Versions\Sabre;
+
+use OC\AppFramework\Http\Request;
+use OCP\IRequest;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+
+class Plugin extends ServerPlugin {
+
+	/** @var Server */
+	private $server;
+	/** @var IRequest */
+	private $request;
+
+	function __construct(IRequest $request) {
+		$this->request = $request;
+	}
+
+	function initialize(Server $server) {
+		$this->server = $server;
+
+		$server->on('afterMethod:GET', [$this, 'afterGet']);
+	}
+
+	public function afterGet(RequestInterface $request, ResponseInterface $response) {
+		$path = $request->getPath();
+		if (strpos($path, 'versions') !== 0) {
+			return;
+		}
+
+		try {
+			$node = $this->server->tree->getNodeForPath($path);
+		} catch (NotFound $e) {
+			return;
+		}
+
+		if (!($node instanceof VersionFile)) {
+			return;
+		}
+
+		$filename = $node->getVersion()->getSourceFileName();
+
+		if ($this->request->isUserAgent(
+			[
+				Request::USER_AGENT_IE,
+				Request::USER_AGENT_ANDROID_MOBILE_CHROME,
+				Request::USER_AGENT_FREEBOX,
+			])) {
+			$response->addHeader('Content-Disposition', 'attachment; filename="' . rawurlencode($filename) . '"');
+		} else {
+			$response->addHeader('Content-Disposition', 'attachment; filename*=UTF-8\'\'' . rawurlencode($filename)
+				. '; filename="' . rawurlencode($filename) . '"');
+		}
+	}
+
+}

--- a/apps/files_versions/lib/Sabre/VersionFile.php
+++ b/apps/files_versions/lib/Sabre/VersionFile.php
@@ -86,4 +86,8 @@ class VersionFile implements IFile {
 	public function rollBack() {
 		$this->versionManager->rollback($this->version);
 	}
+
+	public function getVersion(): IVersion {
+		return $this->version;
+	}
 }


### PR DESCRIPTION
Before it just used the internalid (timestamp often) which is not really
user friendly.

This means that if the file is download the user has to manually rename it. Which is well. Not really user friendly.