### PR TITLE
Increase contast between text and placeholder in input fields

### DIFF
--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -52,7 +52,7 @@ div[contenteditable=true],
 	padding: 7px 6px;
 	font-size: 13px;
 	background-color: var(--color-main-background);
-	color: var(--color-text-lighter);
+	color: var(--color-main-text);
 	border: 1px solid var(--color-border-dark);
 	outline: none;
 	border-radius: var(--border-radius);
@@ -933,4 +933,10 @@ label.infield {
 	width: 1px;
 	height: 1px;
 	overflow: hidden;
+}
+
+::placeholder,
+::-ms-input-placeholder,
+::-webkit-input-placeholder {
+	color: var(--color-text-maxcontrast);
 }


### PR DESCRIPTION
The current input styling makes it really hard to distinguish between a placeholder and the actual text value. This PR sets the placeholder color to maxcontrast and the value color to the main text color.

Screenshots (left is placeholder, right is the filled out field)

Before:
![image](https://user-images.githubusercontent.com/3404133/66575829-e9a3b880-eb76-11e9-8307-f9b1be57a723.png)

After:
![image](https://user-images.githubusercontent.com/3404133/66575862-fa542e80-eb76-11e9-8220-f3f667ab8494.png)
