### PR TITLE
Fix Application instances created multiple times

### DIFF
--- a/apps/dav/appinfo/app.php
+++ b/apps/dav/appinfo/app.php
@@ -29,7 +29,8 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 
 \OC_App::loadApps(['dav']);
 
-$app = new Application();
+/** @var Application $app */
+$app = \OC::$server->query(Application::class);
 $app->registerHooks();
 
 \OC::$server->registerService('CardDAVSyncService', function() use ($app) {

--- a/apps/encryption/appinfo/app.php
+++ b/apps/encryption/appinfo/app.php
@@ -28,7 +28,8 @@ namespace OCA\Encryption\AppInfo;
 
 $encryptionSystemReady = \OC::$server->getEncryptionManager()->isReady();
 
-$app = new Application();
+/** @var Application $app */
+$app = \OC::$server->query(Application::class);
 if ($encryptionSystemReady) {
 	$app->registerEncryptionModule();
 	$app->registerHooks();

--- a/apps/encryption/appinfo/routes.php
+++ b/apps/encryption/appinfo/routes.php
@@ -24,7 +24,9 @@
 
 namespace OCA\Encryption\AppInfo;
 
-(new Application())->registerRoutes($this, array('routes' => array(
+/** @var Application $app */
+$app = \OC::$server->query(Application::class);
+$app->registerRoutes($this, array('routes' => array(
 
 	[
 		'name' => 'Recovery#adminRecovery',

--- a/apps/encryption/appinfo/routes.php
+++ b/apps/encryption/appinfo/routes.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -21,43 +22,37 @@
  *
  */
 
-
-namespace OCA\Encryption\AppInfo;
-
-/** @var Application $app */
-$app = \OC::$server->query(Application::class);
-$app->registerRoutes($this, array('routes' => array(
-
-	[
-		'name' => 'Recovery#adminRecovery',
-		'url' => '/ajax/adminRecovery',
-		'verb' => 'POST'
-	],
-	[
-		'name' => 'Settings#updatePrivateKeyPassword',
-		'url' => '/ajax/updatePrivateKeyPassword',
-		'verb' => 'POST'
-	],
-	[
-		'name' => 'Settings#setEncryptHomeStorage',
-		'url' => '/ajax/setEncryptHomeStorage',
-		'verb' => 'POST'
-	],
-	[
-		'name' => 'Recovery#changeRecoveryPassword',
-		'url' => '/ajax/changeRecoveryPassword',
-		'verb' => 'POST'
-	],
-	[
-		'name' => 'Recovery#userSetRecovery',
-		'url' => '/ajax/userSetRecovery',
-		'verb' => 'POST'
-	],
-	[
-		'name' => 'Status#getStatus',
-		'url' => '/ajax/getStatus',
-		'verb' => 'GET'
+return [
+	'routes' => [
+		[
+			'name' => 'Recovery#adminRecovery',
+			'url' => '/ajax/adminRecovery',
+			'verb' => 'POST'
+		],
+		[
+			'name' => 'Settings#updatePrivateKeyPassword',
+			'url' => '/ajax/updatePrivateKeyPassword',
+			'verb' => 'POST'
+		],
+		[
+			'name' => 'Settings#setEncryptHomeStorage',
+			'url' => '/ajax/setEncryptHomeStorage',
+			'verb' => 'POST'
+		],
+		[
+			'name' => 'Recovery#changeRecoveryPassword',
+			'url' => '/ajax/changeRecoveryPassword',
+			'verb' => 'POST'
+		],
+		[
+			'name' => 'Recovery#userSetRecovery',
+			'url' => '/ajax/userSetRecovery',
+			'verb' => 'POST'
+		],
+		[
+			'name' => 'Status#getStatus',
+			'url' => '/ajax/getStatus',
+			'verb' => 'GET'
+		],
 	]
-
-
-)));
+];

--- a/apps/federation/appinfo/app.php
+++ b/apps/federation/appinfo/app.php
@@ -22,5 +22,6 @@
 
 namespace OCA\Federation\AppInfo;
 
-$app = new Application();
+/** @var Application $app */
+$app = \OC::$server->query(Application::class);
 $app->registerHooks();

--- a/apps/files/appinfo/routes.php
+++ b/apps/files/appinfo/routes.php
@@ -29,7 +29,8 @@ declare(strict_types=1);
  */
 namespace OCA\Files\AppInfo;
 
-$application = new Application();
+/** @var Application $application */
+$application = \OC::$server->query(Application::class);
 $application->registerRoutes(
 	$this,
 	[

--- a/apps/files_trashbin/appinfo/routes.php
+++ b/apps/files_trashbin/appinfo/routes.php
@@ -24,7 +24,8 @@
 
 namespace OCA\Files_Trashbin\AppInfo;
 
-$application = new Application();
+/** @var Application $application */
+$application = \OC::$server->query(Application::class);
 $application->registerRoutes($this, [
 	'routes' => [
 		[

--- a/apps/files_trashbin/appinfo/routes.php
+++ b/apps/files_trashbin/appinfo/routes.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  * @copyright Copyright (c) 2016, Roeland Jago Douma <roeland@famdouma.nl>
@@ -22,11 +23,7 @@
  *
  */
 
-namespace OCA\Files_Trashbin\AppInfo;
-
-/** @var Application $application */
-$application = \OC::$server->query(Application::class);
-$application->registerRoutes($this, [
+return [
 	'routes' => [
 		[
 			'name' => 'Preview#getPreview',
@@ -34,4 +31,4 @@ $application->registerRoutes($this, [
 			'verb' => 'GET',
 		],
 	],
-]);
+];

--- a/apps/files_trashbin/lib/AppInfo/Application.php
+++ b/apps/files_trashbin/lib/AppInfo/Application.php
@@ -46,12 +46,7 @@ class Application extends App {
 		/*
 		 * Register expiration
 		 */
-		$container->registerService('Expiration', function($c) {
-			return  new Expiration(
-				$c->query('ServerContainer')->getConfig(),
-				$c->query(ITimeFactory::class)
-			);
-		});
+		$container->registerAlias('Expiration', Expiration::class);
 
 		/*
 		 * Register $principalBackend for the DAV collection

--- a/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
+++ b/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
@@ -62,7 +62,8 @@ class ExpireTrash extends \OC\BackgroundJob\TimedJob {
 	}
 
 	protected function fixDIForJobs() {
-		$application = new Application();
+		/** @var Application $application */
+		$application = \OC::$server->query(Application::class);
 		$this->userManager = \OC::$server->getUserManager();
 		$this->expiration = $application->getContainer()->query('Expiration');
 	}

--- a/apps/files_trashbin/lib/Expiration.php
+++ b/apps/files_trashbin/lib/Expiration.php
@@ -49,7 +49,11 @@ class Expiration {
 
 	public function __construct(IConfig $config,ITimeFactory $timeFactory){
 		$this->timeFactory = $timeFactory;
-		$this->retentionObligation = $config->getSystemValue('trashbin_retention_obligation', 'auto');
+		$this->setRetentionObligation($config->getSystemValue('trashbin_retention_obligation', 'auto'));
+	}
+
+	public function setRetentionObligation(string $obligation) {
+		$this->retentionObligation = $obligation;
 
 		if ($this->retentionObligation !== 'disabled') {
 			$this->parseRetentionObligation();

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -747,7 +747,8 @@ class Trashbin {
 	 */
 	private static function scheduleExpire($user) {
 		// let the admin disable auto expire
-		$application = new Application();
+		/** @var Application $application */
+		$application = \OC::$server->query(Application::class);
 		$expiration = $application->getContainer()->query('Expiration');
 		if ($expiration->isEnabled()) {
 			\OC::$server->getCommandBus()->push(new Expire($user));
@@ -764,7 +765,8 @@ class Trashbin {
 	 * @return int size of deleted files
 	 */
 	protected static function deleteFiles($files, $user, $availableSpace) {
-		$application = new Application();
+		/** @var Application $application */
+		$application = \OC::$server->query(Application::class);
 		$expiration = $application->getContainer()->query('Expiration');
 		$size = 0;
 
@@ -791,7 +793,8 @@ class Trashbin {
 	 * @return integer[] size of deleted files and number of deleted files
 	 */
 	public static function deleteExpiredFiles($files, $user) {
-		$application = new Application();
+		/** @var Application $application */
+		$application = \OC::$server->query(Application::class);
 		$expiration = $application->getContainer()->query('Expiration');
 		$size = 0;
 		$count = 0;

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -793,9 +793,8 @@ class Trashbin {
 	 * @return integer[] size of deleted files and number of deleted files
 	 */
 	public static function deleteExpiredFiles($files, $user) {
-		/** @var Application $application */
-		$application = \OC::$server->query(Application::class);
-		$expiration = $application->getContainer()->query('Expiration');
+		/** @var Expiration $expiration */
+		$expiration = \OC::$server->query(Expiration::class);
 		$size = 0;
 		$count = 0;
 		foreach ($files as $file) {

--- a/apps/files_trashbin/tests/TrashbinTest.php
+++ b/apps/files_trashbin/tests/TrashbinTest.php
@@ -67,7 +67,7 @@ class TrashbinTest extends \Test\TestCase {
 		// clear share hooks
 		\OC_Hook::clear('OCP\\Share');
 		\OC::registerShareHooks();
-		$application = new \OCA\Files_Sharing\AppInfo\Application();
+		$application = \OC::$server->query(\OCA\Files_Sharing\AppInfo\Application::class);
 		$application->registerMountProviders();
 
 		//disable encryption

--- a/apps/files_trashbin/tests/TrashbinTest.php
+++ b/apps/files_trashbin/tests/TrashbinTest.php
@@ -152,7 +152,9 @@ class TrashbinTest extends \Test\TestCase {
 	 */
 	public function testExpireOldFiles() {
 
-		$currentTime = time();
+		/** @var \OCP\AppFramework\Utility\ITimeFactory $time */
+		$time = \OC::$server->query(\OCP\AppFramework\Utility\ITimeFactory::class);
+		$currentTime = $time->getTime();
 		$expireAt = $currentTime - 2 * 24 * 60 * 60;
 		$expiredDate = $currentTime - 3 * 24 * 60 * 60;
 

--- a/apps/files_trashbin/tests/TrashbinTest.php
+++ b/apps/files_trashbin/tests/TrashbinTest.php
@@ -76,7 +76,9 @@ class TrashbinTest extends \Test\TestCase {
 		$config = \OC::$server->getConfig();
 		//configure trashbin
 		self::$rememberRetentionObligation = $config->getSystemValue('trashbin_retention_obligation', \OCA\Files_Trashbin\Expiration::DEFAULT_RETENTION_OBLIGATION);
-		$config->setSystemValue('trashbin_retention_obligation', 'auto, 2');
+		/** @var \OCA\Files_Trashbin\Expiration $expiration */
+		$expiration = \OC::$server->query(\OCA\Files_Trashbin\Expiration::class);
+		$expiration->setRetentionObligation('auto, 2');
 
 		// register hooks
 		\OCA\Files_Trashbin\Trashbin::registerHooks();
@@ -94,7 +96,9 @@ class TrashbinTest extends \Test\TestCase {
 			$user->delete();
 		}
 
-		\OC::$server->getConfig()->setSystemValue('trashbin_retention_obligation', self::$rememberRetentionObligation);
+		/** @var \OCA\Files_Trashbin\Expiration $expiration */
+		$expiration = \OC::$server->query(\OCA\Files_Trashbin\Expiration::class);
+		$expiration->setRetentionObligation(self::$rememberRetentionObligation);
 
 		\OC_Hook::clear();
 
@@ -686,9 +690,9 @@ class TrashbinForTesting extends \OCA\Files_Trashbin\Trashbin {
 	 * @param OCP\Files\FileInfo[] $files
 	 * @param integer $limit
 	 */
-	public function dummyDeleteExpiredFiles($files, $limit) {
+	public function dummyDeleteExpiredFiles($files) {
 		// dummy value for $retention_obligation because it is not needed here
-		return parent::deleteExpiredFiles($files, TrashbinTest::TEST_TRASHBIN_USER1, $limit, 0);
+		return parent::deleteExpiredFiles($files, TrashbinTest::TEST_TRASHBIN_USER1);
 	}
 
 	/**

--- a/apps/files_versions/appinfo/routes.php
+++ b/apps/files_versions/appinfo/routes.php
@@ -26,7 +26,8 @@
 
 namespace OCA\Files_Versions\AppInfo;
 
-$application = new Application();
+/** @var Application $application */
+$application = \OC::$server->query(Application::class);
 $application->registerRoutes($this, [
 	'routes' => [
 		[

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -850,8 +850,8 @@ class Storage {
 	 * @return Expiration
 	 */
 	protected static function getExpiration(){
-		if (is_null(self::$application)) {
-			self::$application = new Application();
+		if (self::$application === null) {
+			self::$application = \OC::$server->query(Application::class);
 		}
 		return self::$application->getContainer()->query(Expiration::class);
 	}

--- a/apps/provisioning_api/lib/FederatedFileSharingFactory.php
+++ b/apps/provisioning_api/lib/FederatedFileSharingFactory.php
@@ -25,9 +25,19 @@ declare(strict_types=1);
 namespace OCA\Provisioning_API;
 
 use OCA\FederatedFileSharing\AppInfo\Application;
+use OCP\IServerContainer;
 
 class FederatedFileSharingFactory {
-	public function get(): Application {
-		return new Application();
+
+	/** @var IServerContainer */
+	private $serverContainer;
+
+	public function __construct(IServerContainer $serverContainer) {
+		$this->serverContainer = $serverContainer;
 	}
+
+	public function get(): Application {
+		return $this->serverContainer->query(Application::class);
+	}
+
 }

--- a/apps/settings/appinfo/routes.php
+++ b/apps/settings/appinfo/routes.php
@@ -38,7 +38,8 @@ namespace OCA\Settings;
 
 use OCA\Settings\AppInfo\Application;
 
-$application = new Application();
+/** @var Application $application */
+$application = \OC::$server->query(Application::class);
 $this->useCollection('root');
 $application->registerRoutes($this, [
 	'resources' => [

--- a/apps/settings/lib/Settings/Personal/PersonalInfo.php
+++ b/apps/settings/lib/Settings/Personal/PersonalInfo.php
@@ -90,7 +90,7 @@ class PersonalInfo implements ISettings {
 		$federatedFileSharingEnabled = $this->appManager->isEnabledForUser('federatedfilesharing');
 		$lookupServerUploadEnabled = false;
 		if($federatedFileSharingEnabled) {
-			$federatedFileSharing = new Application();
+			$federatedFileSharing = \OC::$server->query(Application::class);
 			$shareProvider = $federatedFileSharing->getFederatedShareProvider();
 			$lookupServerUploadEnabled = $shareProvider->isLookupServerUploadEnabled();
 		}

--- a/core/routes.php
+++ b/core/routes.php
@@ -34,7 +34,8 @@
 
 use OC\Core\Application;
 
-$application = new Application();
+/** @var Application $application */
+$application = \OC::$server->query(Application::class);
 $application->registerRoutes($this, [
 	'routes' => [
 		['name' => 'lost#email', 'url' => '/lostpassword/email', 'verb' => 'POST'],

--- a/lib/base.php
+++ b/lib/base.php
@@ -727,7 +727,7 @@ class OC {
 		// Make sure that the application class is not loaded before the database is setup
 		if ($systemConfig->getValue("installed", false)) {
 			OC_App::loadApp('settings');
-			$settings = new \OCA\Settings\AppInfo\Application();
+			$settings = \OC::$server->query(\OCA\Settings\AppInfo\Application::class);
 			$settings->register();
 		}
 

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -371,7 +371,7 @@ class Router implements IRouter {
 			$applicationClassName = $appNameSpace . '\\AppInfo\\Application';
 
 			if (class_exists($applicationClassName)) {
-				$application = new $applicationClassName();
+				$application = \OC::$server->query($applicationClassName);
 			} else {
 				$application = new App($appName);
 			}

--- a/lib/private/ServerContainer.php
+++ b/lib/private/ServerContainer.php
@@ -100,8 +100,9 @@ class ServerContainer extends SimpleContainer {
 			if (!isset($this->hasNoAppContainer[$namespace])) {
 				$applicationClassName = 'OCA\\' . $sensitiveNamespace . '\\AppInfo\\Application';
 				if (class_exists($applicationClassName)) {
-					new $applicationClassName();
+					$app = new $applicationClassName();
 					if (isset($this->appContainers[$namespace])) {
+						$this->appContainers[$namespace]->offsetSet($applicationClassName, $app);
 						return $this->appContainers[$namespace];
 					}
 				}


### PR DESCRIPTION
Apps can have an `Application`, which is loaded automatically for them. This is used for initialization.

However, we didn't pay attention to the number of instances we create. Some requests had one, some had two. This ended in stuff being run twice, like event listeners firing off twice due to double registration. A workaround was added to Mail, Suspicious Login and Push, but it's time to fix this here.

So, here it is. I changed the code to always fetch the Application instance from the server container (except for when we're inside the container code, then we have no other choice but create the instance manually). I tested the code with Mail, where I attached a debugger to the BootstrapSingleton and the instance was never fetched a second time.

We can't solve the problem for apps that still create an instance of the class manually. But for those where it's a problem, they can now safely use the server container to get an instance, e.g. in app.php or routes.php.

You can review the commits separately. The first one changes the way server creates instances, the second one fixes all other usages.

In theory we could even have a tiny performance improvement as fewer class instances are loaded. But I double that it makes a noticeable difference.