### PR TITLE
Fix ReflectionType::__toString() is deprecated

### DIFF
--- a/lib/private/AppFramework/Utility/ControllerMethodReflector.php
+++ b/lib/private/AppFramework/Utility/ControllerMethodReflector.php
@@ -76,8 +76,8 @@ class ControllerMethodReflector implements IControllerMethodReflector {
 			// over phpdoc annotations
 			if (method_exists($param, 'getType')) {
 				$type = $param->getType();
-				if ($type !== null) {
-					$this->types[$param->getName()] = (string) $type;
+				if ($type instanceof \ReflectionNamedType) {
+					$this->types[$param->getName()] = $type->getName();
 				}
 			}
 

--- a/lib/private/AppFramework/Utility/ControllerMethodReflector.php
+++ b/lib/private/AppFramework/Utility/ControllerMethodReflector.php
@@ -72,13 +72,10 @@ class ControllerMethodReflector implements IControllerMethodReflector {
 		}
 
 		foreach ($reflection->getParameters() as $param) {
-			// extract type information from PHP 7 scalar types and prefer them
-			// over phpdoc annotations
-			if (method_exists($param, 'getType')) {
-				$type = $param->getType();
-				if ($type instanceof \ReflectionNamedType) {
-					$this->types[$param->getName()] = $type->getName();
-				}
+			// extract type information from PHP 7 scalar types and prefer them over phpdoc annotations
+			$type = $param->getType();
+			if ($type instanceof \ReflectionNamedType) {
+				$this->types[$param->getName()] = $type->getName();
 			}
 
 			$default = null;


### PR DESCRIPTION
As of PHP 7.1.0, ReflectionType::__toString() is deprecated, and ReflectionParameter::getType() may return an instance of ReflectionNamedType. To get the name of the parameter type, ReflectionNamedType() is available in this case.

https://www.php.net/manual/en/reflectionparameter.gettype.php

https://github.com/nextcloud/server/pull/17522/commits/6681a216487cfd29f344f8de12cfe134f4ac641d fix the warning
https://github.com/nextcloud/server/pull/17522/commits/e6ba844619251f601ffccde68a284e5907888fd1 remove check for php < 7.0

I'm not sure about https://github.com/nextcloud/server/pull/17522/commits/a730e00defa0b69e8630cdc59f84e183a1039454. I read https://stackoverflow.com/questions/23774355/php-reflectionparameter-isoptional-vs-isdefaultvalueavailable and think we should use `isDefaultValueAvailable` instead of `isOptional` but don't know yet how to trigger a `ReflectionException` from `getDefaultValue` with the current code. Might be better to leave it ;)

