### PR TITLE
Remove deprecated legacy file actions

### DIFF
--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -67,16 +67,12 @@
 			var fileActions = new OCA.Files.FileActions();
 			// default actions
 			fileActions.registerDefaultActions();
-			// legacy actions
-			fileActions.merge(window.FileActions);
 			// regular actions
 			fileActions.merge(OCA.Files.fileActions);
 
 			this._onActionsUpdated = _.bind(this._onActionsUpdated, this);
 			OCA.Files.fileActions.on('setDefault.app-files', this._onActionsUpdated);
 			OCA.Files.fileActions.on('registerAction.app-files', this._onActionsUpdated);
-			window.FileActions.on('setDefault.app-files', this._onActionsUpdated);
-			window.FileActions.on('registerAction.app-files', this._onActionsUpdated);
 
 			this.files = OCA.Files.Files;
 
@@ -150,8 +146,6 @@
 			this.files = null;
 			OCA.Files.fileActions.off('setDefault.app-files', this._onActionsUpdated);
 			OCA.Files.fileActions.off('registerAction.app-files', this._onActionsUpdated);
-			window.FileActions.off('setDefault.app-files', this._onActionsUpdated);
-			window.FileActions.off('registerAction.app-files', this._onActionsUpdated);
 		},
 
 		_onActionsUpdated: function(ev) {

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -409,8 +409,6 @@
 					var fileName = $file.attr('data-file');
 
 					context.fileActions.currentFile = currentFile;
-					// also set on global object for legacy apps
-					window.FileActions.currentFile = currentFile;
 
 					var callContext = _.extend({}, context);
 
@@ -480,8 +478,6 @@
 
 			var fileName = fileInfoModel.get('name');
 			this.currentFile = fileName;
-			// also set on global object for legacy apps
-			window.FileActions.currentFile = fileName;
 
 			if (fileList) {
 				// compatibility with action handlers that expect these
@@ -659,7 +655,7 @@
 						if (type === OC.dialogs.FILEPICKER_TYPE_MOVE) {
 							context.fileList.move(filename, targetPath, false, context.dir);
 						}
-						context.fileList.dirInfo.dirLastCopiedTo = targetPath; 
+						context.fileList.dirInfo.dirLastCopiedTo = targetPath;
 					}, false, "httpd/unix-directory", true, actions, dialogDir);
 				}
 			});
@@ -814,25 +810,4 @@
 
 	// global file actions to be used by all lists
 	OCA.Files.fileActions = new OCA.Files.FileActions();
-	OCA.Files.legacyFileActions = new OCA.Files.FileActions();
-
-	// for backward compatibility
-	//
-	// legacy apps are expecting a stateful global FileActions object to register
-	// their actions on. Since legacy apps are very likely to break with other
-	// FileList views than the main one ("All files"), actions registered
-	// through window.FileActions will be limited to the main file list.
-	// @deprecated use OCA.Files.FileActions instead
-	window.FileActions = OCA.Files.legacyFileActions;
-	window.FileActions.register = function (mime, name, permissions, icon, action, displayName) {
-		console.warn('FileActions.register() is deprecated, please use OCA.Files.fileActions.register() instead', arguments);
-		OCA.Files.FileActions.prototype.register.call(
-				window.FileActions, mime, name, permissions, icon, action, displayName
-		);
-	};
-	window.FileActions.display = function (parent, triggerEvent, fileList) {
-		fileList = fileList || OCA.Files.App.fileList;
-		console.warn('FileActions.display() is deprecated, please use OCA.Files.fileActions.register() which automatically redisplays actions', mime, name);
-		OCA.Files.FileActions.prototype.display.call(window.FileActions, parent, triggerEvent, fileList);
-	};
 })();

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -839,8 +839,6 @@
 						var action = this.fileActions.getDefault(mime,type, permissions);
 						if (action) {
 							event.preventDefault();
-							// also set on global object for legacy apps
-							window.FileActions.currentFile = this.fileActions.currentFile;
 							action(filename, {
 								$file: $tr,
 								fileList: this,
@@ -865,8 +863,6 @@
 					var permissions = this.fileActions.getCurrentPermissions();
 					var action = this.fileActions.get(mime, type, permissions)['Details'];
 					if (action) {
-						// also set on global object for legacy apps
-						window.FileActions.currentFile = this.fileActions.currentFile;
 						action(filename, {
 							$file: $tr,
 							fileList: this,
@@ -1022,7 +1018,7 @@
 				if (type === OC.dialogs.FILEPICKER_TYPE_MOVE) {
 					self.move(files, targetPath, disableLoadingState);
 				}
-				self.dirInfo.dirLastCopiedTo = targetPath; 
+				self.dirInfo.dirLastCopiedTo = targetPath;
 			}, false, "httpd/unix-directory", true, actions, dialogDir);
 			event.preventDefault();
 		},
@@ -3273,7 +3269,7 @@
 
 		/**
 		 * Are all files selected?
-		 * 
+		 *
 		 * @returns {Boolean} all files are selected
 		 */
 		isAllSelected: function() {

--- a/apps/files/tests/js/appSpec.js
+++ b/apps/files/tests/js/appSpec.js
@@ -24,7 +24,6 @@ describe('OCA.Files.App tests', function() {
 	var pushStateStub;
 	var replaceStateStub;
 	var parseUrlQueryStub;
-	var oldLegacyFileActions;
 
 	beforeEach(function() {
 		$('#testArea').append(
@@ -43,9 +42,6 @@ describe('OCA.Files.App tests', function() {
 			'</div>'
 		);
 
-		oldLegacyFileActions = window.FileActions;
-		window.FileActions = new OCA.Files.FileActions();
-		OCA.Files.legacyFileActions = window.FileActions;
 		OCA.Files.fileActions = new OCA.Files.FileActions();
 
 		pushStateStub = sinon.stub(OC.Util.History, 'pushState');
@@ -58,8 +54,6 @@ describe('OCA.Files.App tests', function() {
 	afterEach(function() {
 		App.destroy();
 
-		window.FileActions = oldLegacyFileActions;
-
 		pushStateStub.restore();
 		replaceStateStub.restore();
 		parseUrlQueryStub.restore();
@@ -70,66 +64,6 @@ describe('OCA.Files.App tests', function() {
 			expect(App.fileList).toBeDefined();
 			expect(App.fileList.fileActions.actions.all).toBeDefined();
 			expect(App.fileList.$el.is('#app-content-files')).toEqual(true);
-		});
-		it('merges the legacy file actions with the default ones', function() {
-			var legacyActionStub = sinon.stub();
-			var actionStub = sinon.stub();
-			// legacy action
-			window.FileActions.register(
-					'all',
-					'LegacyTest',
-					OC.PERMISSION_READ,
-					OC.imagePath('core', 'actions/test'),
-					legacyActionStub
-			);
-			// legacy action to be overwritten
-			window.FileActions.register(
-					'all',
-					'OverwriteThis',
-					OC.PERMISSION_READ,
-					OC.imagePath('core', 'actions/test'),
-					legacyActionStub
-			);
-
-			// regular file actions
-			OCA.Files.fileActions.register(
-					'all',
-					'RegularTest',
-					OC.PERMISSION_READ,
-					OC.imagePath('core', 'actions/test'),
-					actionStub
-			);
-
-			// overwrite
-			OCA.Files.fileActions.register(
-					'all',
-					'OverwriteThis',
-					OC.PERMISSION_READ,
-					OC.imagePath('core', 'actions/test'),
-					actionStub
-			);
-
-			App.initialize();
-
-			var actions = App.fileList.fileActions.actions;
-			var context = { fileActions: sinon.createStubInstance(OCA.Files.FileActions) };
-			actions.all.OverwriteThis.action('testFileName', context);
-			expect(actionStub.calledOnce).toBe(true);
-			expect(context.fileActions._notifyUpdateListeners.callCount).toBe(2);
-			expect(context.fileActions._notifyUpdateListeners.getCall(0).calledWith('beforeTriggerAction')).toBe(true);
-			expect(context.fileActions._notifyUpdateListeners.getCall(1).calledWith('afterTriggerAction')).toBe(true);
-			actions.all.LegacyTest.action('testFileName', context);
-			expect(legacyActionStub.calledOnce).toBe(true);
-			expect(context.fileActions._notifyUpdateListeners.callCount).toBe(4);
-			expect(context.fileActions._notifyUpdateListeners.getCall(2).calledWith('beforeTriggerAction')).toBe(true);
-			expect(context.fileActions._notifyUpdateListeners.getCall(3).calledWith('afterTriggerAction')).toBe(true);
-			actions.all.RegularTest.action('testFileName', context);
-			expect(actionStub.calledTwice).toBe(true);
-			expect(context.fileActions._notifyUpdateListeners.callCount).toBe(6);
-			expect(context.fileActions._notifyUpdateListeners.getCall(4).calledWith('beforeTriggerAction')).toBe(true);
-			expect(context.fileActions._notifyUpdateListeners.getCall(5).calledWith('afterTriggerAction')).toBe(true);
-			// default one still there
-			expect(actions.dir.Open.action).toBeDefined();
 		});
 	});
 

--- a/apps/files/tests/js/favoritespluginspec.js
+++ b/apps/files/tests/js/favoritespluginspec.js
@@ -42,16 +42,6 @@ describe('OCA.Files.FavoritesPlugin tests', function() {
 		});
 	});
 	describe('file actions', function() {
-		var oldLegacyFileActions;
-
-		beforeEach(function() {
-			oldLegacyFileActions = window.FileActions;
-			window.FileActions = new OCA.Files.FileActions();
-		});
-
-		afterEach(function() {
-			window.FileActions = oldLegacyFileActions;
-		});
 		it('provides default file actions', function() {
 			var fileActions = fileList.fileActions;
 
@@ -77,22 +67,6 @@ describe('OCA.Files.FavoritesPlugin tests', function() {
 			fileList = Plugin.showFileList($('#app-content-favorites'));
 
 			expect(fileList.fileActions.actions.all.RegularTest).toBeDefined();
-		});
-		it('does not provide legacy file actions', function() {
-			var actionStub = sinon.stub();
-			// legacy file action
-			window.FileActions.register(
-					'all',
-					'LegacyTest',
-					OC.PERMISSION_READ,
-					OC.imagePath('core', 'actions/shared'),
-					actionStub
-			);
-
-			Plugin.favoritesFileList = null;
-			fileList = Plugin.showFileList($('#app-content-favorites'));
-
-			expect(fileList.fileActions.actions.all.LegacyTest).not.toBeDefined();
 		});
 		it('redirects to files app when opening a directory', function() {
 			var oldList = OCA.Files.App.fileList;

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -37,8 +37,6 @@ OCA.Sharing.PublicApp = {
 		fileActions = new OCA.Files.FileActions();
 		// default actions
 		fileActions.registerDefaultActions();
-		// legacy actions
-		fileActions.merge(window.FileActions);
 		// regular actions
 		fileActions.merge(OCA.Files.fileActions);
 

--- a/apps/files_sharing/tests/js/appSpec.js
+++ b/apps/files_sharing/tests/js/appSpec.js
@@ -57,16 +57,6 @@ describe('OCA.Sharing.App tests', function() {
 		});
 	});
 	describe('file actions', function() {
-		var oldLegacyFileActions;
-
-		beforeEach(function() {
-			oldLegacyFileActions = window.FileActions;
-			window.FileActions = new OCA.Files.FileActions();
-		});
-
-		afterEach(function() {
-			window.FileActions = oldLegacyFileActions;
-		});
 		it('provides default file actions', function() {
 			_.each([fileListIn, fileListOut], function(fileList) {
 				var fileActions = fileList.fileActions;
@@ -94,22 +84,6 @@ describe('OCA.Sharing.App tests', function() {
 			fileListIn = App.initSharingIn($('#app-content-sharingin'));
 
 			expect(fileListIn.fileActions.actions.all.RegularTest).toBeDefined();
-		});
-		it('does not provide legacy file actions', function() {
-			var actionStub = sinon.stub();
-			// legacy file action
-			window.FileActions.register(
-					'all',
-					'LegacyTest',
-					OC.PERMISSION_READ,
-					OC.imagePath('core', 'actions/shared'),
-					actionStub
-			);
-
-			App._inFileList = null;
-			fileListIn = App.initSharingIn($('#app-content-sharingin'));
-
-			expect(fileListIn.fileActions.actions.all.LegacyTest).not.toBeDefined();
 		});
 		it('redirects to files app when opening a directory', function() {
 			var oldList = OCA.Files.App.fileList;


### PR DESCRIPTION
`window.FileActions` has been marked as deprecated in 2014 and I couldn't find any use of that anymore.