### PR TITLE
Expose currently active file list though OCA.Files.App

### DIFF
--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -40,6 +40,8 @@
 		 */
 		fileList: null,
 
+		currentFileList: null,
+
 		/**
 		 * Backbone model for storing files preferences
 		 */
@@ -112,6 +114,7 @@
 					maxChunkSize: OC.appConfig.files && OC.appConfig.files.max_chunk_size
 				}
 			);
+			this.updateCurrentFileList(this.fileList)
 			this.files.initialize();
 
 			// for backward compatibility, the global FileList will
@@ -158,6 +161,28 @@
 					ev.defaultAction.name
 				);
 			}
+		},
+
+		/**
+		 * Set the currently active file list
+		 *
+		 * Due to the file list implementations being registered after clicking the
+		 * navigation item for the first time, OCA.Files.App is not aware of those until
+		 * they have initialized themselves. Therefore the files list needs to call this
+		 * method manually
+		 *
+		 * @param {OCA.Files.FileList} newFileList
+		 */
+		updateCurrentFileList: function(newFileList) {
+			this.currentFileList = newFileList;
+		},
+
+		/**
+		 * Return the currently active file list
+		 * @return {?OCA.Files.FileList}
+		 */
+		getCurrentFileList: function () {
+			return this.currentFileList;
 		},
 
 		/**

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -434,6 +434,8 @@
 
 			OC.Plugins.attach('OCA.Files.FileList', this);
 
+			OCA.Files.App && OCA.Files.App.updateCurrentFileList(this);
+
 			this.initHeadersAndFooters()
 		},
 
@@ -738,6 +740,7 @@
 		 * Event handler when leaving previously hidden state
 		 */
 		_onShow: function(e) {
+			OCA.Files.App && OCA.Files.App.updateCurrentFileList(this);
 			if (this.shown) {
 				if (e.itemId === this.id) {
 					this._setCurrentDir('/', false);


### PR DESCRIPTION
Expose the currently active file list though OCA.Files.App to allow interaction with the current file list. Right now only OCA.Files.App.fileList (which is the same as window.FileList) are exposed but they always point to the all files list.