### PR TITLE
Do not escape slashes for logged exceptions

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -324,7 +324,7 @@ class Log implements ILogger {
 		try {
 			if ($level >= $minLevel) {
 				if (!$this->logger instanceof IFileBased) {
-					$data = json_encode($data, JSON_PARTIAL_OUTPUT_ON_ERROR);
+					$data = json_encode($data, JSON_PARTIAL_OUTPUT_ON_ERROR | JSON_UNESCAPED_SLASHES);
 				}
 				$this->writeLog($app, $data, $level);
 			}


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/server/pull/17440 to also make logged exceptions more readable.