### PR TITLE
Deprecate TemplateManager

### DIFF
--- a/apps/files/appinfo/app.php
+++ b/apps/files/appinfo/app.php
@@ -34,7 +34,6 @@ $l = \OC::$server->getL10N('files');
 \OC::$server->getSearch()->registerProvider(File::class, array('apps' => array('files')));
 
 $templateManager = \OC_Helper::getFileTemplateManager();
-$templateManager->registerTemplate('text/html', 'core/templates/filetemplates/template.html');
 $templateManager->registerTemplate('application/vnd.oasis.opendocument.presentation', 'core/templates/filetemplates/template.odp');
 $templateManager->registerTemplate('application/vnd.oasis.opendocument.text', 'core/templates/filetemplates/template.odt');
 $templateManager->registerTemplate('application/vnd.oasis.opendocument.spreadsheet', 'core/templates/filetemplates/template.ods');

--- a/core/templates/filetemplates/template.html
+++ b/core/templates/filetemplates/template.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html>
-	<head>
-
-	</head>
-	<body>
-
-	</body>
-</html>

--- a/lib/private/Files/Type/TemplateManager.php
+++ b/lib/private/Files/Type/TemplateManager.php
@@ -24,6 +24,9 @@
 
 namespace OC\Files\Type;
 
+/**
+ * @deprecated 18.0.0
+ */
 class TemplateManager {
 	protected $templates = array();
 
@@ -34,6 +37,7 @@ class TemplateManager {
 	/**
 	 * get the path of the template for a mimetype
 	 *
+	 * @deprecated 18.0.0
 	 * @param string $mimetype
 	 * @return string|null
 	 */
@@ -48,6 +52,7 @@ class TemplateManager {
 	/**
 	 * get the template content for a mimetype
 	 *
+	 * @deprecated 18.0.0
 	 * @param string $mimetype
 	 * @return string
 	 */

--- a/lib/private/legacy/helper.php
+++ b/lib/private/legacy/helper.php
@@ -189,6 +189,7 @@ class OC_Helper {
 	}
 
 	/**
+	 * @deprecated 18.0.0
 	 * @return \OC\Files\Type\TemplateManager
 	 */
 	static public function getFileTemplateManager() {


### PR DESCRIPTION
This is not used anywhere except richdocuments (as a fallback, but we can handle that differently in the app itself). If we want to have a unified template management we should look into providing a more decent API for that.