### PR TITLE
Include the share in the Files_Sharing::loadAdditionalScripts event

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -445,7 +445,8 @@ class ShareController extends AuthPublicShareController {
 		\OCP\Util::addHeader('meta', ['property' => "og:type", 'content' => "object"]);
 		\OCP\Util::addHeader('meta', ['property' => "og:image", 'content' => $ogPreview]);
 
-		$this->eventDispatcher->dispatch('OCA\Files_Sharing::loadAdditionalScripts');
+		$event = new GenericEvent(null, ['share' => $share]);
+		$this->eventDispatcher->dispatch('OCA\Files_Sharing::loadAdditionalScripts', $event);
 
 		$csp = new \OCP\AppFramework\Http\ContentSecurityPolicy();
 		$csp->addAllowedFrameDomain('\'self\'');

--- a/apps/files_sharing/tests/Controller/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareControllerTest.php
@@ -254,7 +254,12 @@ class ShareControllerTest extends \Test\TestCase {
 
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatch')
-			->with('OCA\Files_Sharing::loadAdditionalScripts');
+			->with(
+				'OCA\Files_Sharing::loadAdditionalScripts',
+				$this->callback(function($event) use ($share) {
+					return $event->getArgument('share') === $share;
+				})
+			);
 
 		$this->l10n->expects($this->any())
 			->method('t')
@@ -374,7 +379,12 @@ class ShareControllerTest extends \Test\TestCase {
 
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatch')
-			->with('OCA\Files_Sharing::loadAdditionalScripts');
+			->with(
+				'OCA\Files_Sharing::loadAdditionalScripts',
+				$this->callback(function($event) use ($share) {
+					return $event->getArgument('share') === $share;
+				})
+			);
 
 		$this->l10n->expects($this->any())
 			->method('t')


### PR DESCRIPTION
This provides a better context for apps using the event, for example to load one script or another depending on whether the share is a file or a folder.

This should be backported to Nextcloud 17, as it is needed by Talk to fix some issues in the public share page for folder shares.
