### PR TITLE
Add detailed users listing in occ user:info command

### DIFF
--- a/core/Command/User/ListCommand.php
+++ b/core/Command/User/ListCommand.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * @copyright Copyright (c) 2016 Robin Appelman <robin@icewind.nl>
  *
  * @author Robin Appelman <robin@icewind.nl>
+ * @author John Molakvoæ <skjnldsv@protonmail.com>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -24,6 +26,7 @@
 namespace OC\Core\Command\User;
 
 use OC\Core\Command\Base;
+use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserManager;
 use Symfony\Component\Console\Input\InputInterface;
@@ -31,14 +34,21 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends Base {
+
 	/** @var IUserManager */
 	protected $userManager;
 
+	/** @var IGroupManager */
+	protected $groupManager;
+
 	/**
 	 * @param IUserManager $userManager
+	 * @param IGroupManager $groupManager
 	 */
-	public function __construct(IUserManager $userManager) {
+	public function __construct(IUserManager $userManager,
+								IGroupManager $groupManager) {
 		$this->userManager = $userManager;
+		$this->groupManager = $groupManager;
 		parent::__construct();
 	}
 
@@ -64,23 +74,46 @@ class ListCommand extends Base {
 				InputOption::VALUE_OPTIONAL,
 				'Output format (plain, json or json_pretty, default is plain)',
 				$this->defaultOutputFormat
+			)->addOption(
+				'info',
+				'i',
+				InputOption::VALUE_NONE,
+				'Show detailed info'
 			);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$users = $this->userManager->search('', (int)$input->getOption('limit'), (int)$input->getOption('offset'));
-		$this->writeArrayInOutputFormat($input, $output, $this->formatUsers($users));
+		$users = $this->userManager->search('', (int) $input->getOption('limit'), (int) $input->getOption('offset'));
+
+		$this->writeArrayInOutputFormat($input, $output, $this->formatUsers($users, (bool)$input->getOption('info')));
 	}
 
 	/**
 	 * @param IUser[] $users
+	 * @param bool [$detailed=false]
 	 * @return array
 	 */
-	private function formatUsers(array $users) {
+	private function formatUsers(array $users, bool $detailed = false) {
 		$keys = array_map(function (IUser $user) {
 			return $user->getUID();
 		}, $users);
-		$values = array_map(function (IUser $user) {
+	
+		$values = array_map(function (IUser $user) use ($detailed) {
+			if ($detailed) {
+				$groups = $this->groupManager->getUserGroupIds($user);
+				return [
+					'user_id' => $user->getUID(),
+					'display_name' => $user->getDisplayName(),
+					'email' => $user->getEMailAddress() ? $user->getEMailAddress() : '',
+					'cloud_id' => $user->getCloudId(),
+					'enabled' => $user->isEnabled(),
+					'groups' => $groups,
+					'quota' => $user->getQuota(),
+					'last_seen' => date(\DateTime::ATOM, $user->getLastLogin()), // ISO-8601
+					'user_directory' => $user->getHome(),
+					'backend' => $user->getBackendClassName()
+				];
+			}
 			return $user->getDisplayName();
 		}, $users);
 		return array_combine($keys, $values);

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -154,7 +154,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\User\Report(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\ResetPassword(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->getConfig(), \OC::$server->getDatabaseConnection()));
-	$application->add(new OC\Core\Command\User\ListCommand(\OC::$server->getUserManager()));
+	$application->add(new OC\Core\Command\User\ListCommand(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\User\Info(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
 
 	$application->add(new OC\Core\Command\Group\Add(\OC::$server->getGroupManager()));


### PR DESCRIPTION
```yaml
# occ user:list --info
  - admin:
    - user_id: admin
    - display_name: admin
    - email: 
    - cloud_id: admin@dev.skjnldsv.com
    - enabled: true
    - groups:
      - 0: admin
    - quota: none
    - last_seen: 2019-10-15T19:33:00+00:00
    - user_directory: /var/www/nextcloud/data/admin
    - backend: Database
  - Test1:
    - user_id: Test1
    - display_name: Test1
    - email: 
    - cloud_id: Test1@dev.skjnldsv.com
    - enabled: true
    - groups:
    - quota: none
    - last_seen: 2019-10-14T19:35:14+00:00
    - user_directory: /var/www/nextcloud/data/Test1
    - backend: Database

```