### PR TITLE
[stable17] Load additional scripts on help page

### DIFF
--- a/settings/help.php
+++ b/settings/help.php
@@ -28,7 +28,10 @@
  *
  */
 
+use OCP\AppFramework\Http\TemplateResponse;
+
 OC_Util::checkLoggedIn();
+\OC::$server->getEventDispatcher()->dispatch(TemplateResponse::EVENT_LOAD_ADDITIONAL_SCRIPTS_LOGGEDIN);
 
 // Load the files we need
 OC_Util::addStyle( "settings", "settings" );


### PR DESCRIPTION
Make sure the about dialog is also showing on the help page

On master this will be fixed by https://github.com/nextcloud/server/pull/17577