### PR TITLE
treat LDAP error 50 as auth issue, prevents lost server connection errors

### DIFF
--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -675,7 +675,8 @@ class Connection extends LDAPUtility {
 				ILogger::WARN);
 
 			// Set to failure mode, if LDAP error code is not LDAP_SUCCESS or LDAP_INVALID_CREDENTIALS
-			if($errno !== 0x00 && $errno !== 0x31) {
+			// or (needed for Apple Open Directory:) LDAP_INSUFFICIENT_ACCESS
+			if($errno !== 0 && $errno !== 49 && $errno !== 50) {
 				$this->ldapConnectionRes = null;
 			}
 


### PR DESCRIPTION
To reproduce if you have such an LDAP server on hand:
1. Have the LDAP connection set up
2. Try to login with an LDAP user and a wrong password

Excpected behaviour is that login failed, the login screen (and perhaps the option to reset the password).

Actual behaviour was that an Internal server error was presented.

This change was found working with a customer.