### PR TITLE
Remove superfluous fclose

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -685,7 +685,6 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			$source = fopen($tmpFile, 'r');
 			$this->writeObject($path, $source);
 			$this->invalidateCache($path);
-			fclose($source);
 
 			unlink($tmpFile);
 			return true;


### PR DESCRIPTION
Fix #15486 

In `writeObject` the source is wrapped into a CallbackStream and later closed.

- https://github.com/nextcloud/3rdparty/blob/a80ed083c6af8b54f9a300b7e01b84c7ffbce3a9/icewind/streams/src/CallbackWrapper.php#L113
- https://github.com/nextcloud/3rdparty/blob/fd7789eb48a8cd8a7e2c8e167ed264d7f2d6d25b/icewind/streams/src/Wrapper.php#L131

If I understand the above wrapper code correctly `fclose` on `CallbackStream` should close the source and therefore the `fclose` in `writeBack` is superfluous.