### PR TITLE
[stable16] fix method scope

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -635,7 +635,7 @@ class Access extends LDAPUtility {
 		return false;
 	}
 
-	protected function mapAndAnnounceIfApplicable(
+	public function mapAndAnnounceIfApplicable(
 		AbstractMapping $mapper,
 		string $fdn,
 		string $name,


### PR DESCRIPTION
was due to a backport while relying on not backported changes

The call is in `Group_LDAP::createGroup()` and was introduced with bugfix https://github.com/nextcloud/server/pull/16101, but the scope was changed in https://github.com/nextcloud/server/pull/15964. Only affects 16 and only in combination with apps making use of the plugin system, i.e. `ldap_write_support`.