### PR TITLE
Add support for download share on old android browser

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -494,6 +494,7 @@ class ShareController extends AuthPublicShareController {
 	/**
 	 * @PublicPage
 	 * @NoCSRFRequired
+	 * @NoSameSiteCookieRequired
 	 *
 	 * @param string $token
 	 * @param string $files


### PR DESCRIPTION
In old android browser, The browser can't follow the cookies, but the browser's downloader can't follow  cookies. So I skip the sameSite check when download share
```
__Host-nc_sameSiteCookielax=true;
__Host-nc_sameSiteCookiestrict=true
```