### PR TITLE
Run acceptance tests on PHP 7.3

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1793,7 +1793,7 @@ steps:
   commands:
     - git submodule update --init
 - name: acceptance-access-levels
-  image: nextcloudci/acceptance-php7.1:acceptance-php7.1-2
+  image: nextcloudci/acceptance-php7.3:acceptance-php7.3-2
   commands:
     - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-access-levels --selenium-server selenium:4444 allow-git-repository-modifications features/access-levels.feature
 
@@ -1823,7 +1823,7 @@ steps:
   commands:
     - git submodule update --init
 - name: acceptance-app-comments
-  image: nextcloudci/acceptance-php7.1:acceptance-php7.1-2
+  image: nextcloudci/acceptance-php7.3:acceptance-php7.3-2
   commands:
     - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-app-comments --selenium-server selenium:4444 allow-git-repository-modifications features/app-comments.feature
 
@@ -1853,7 +1853,7 @@ steps:
   commands:
     - git submodule update --init
 - name: acceptance-app-files
-  image: nextcloudci/acceptance-php7.1:acceptance-php7.1-2
+  image: nextcloudci/acceptance-php7.3:acceptance-php7.3-2
   commands:
     - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-app-files --selenium-server selenium:4444 allow-git-repository-modifications features/app-files.feature
 
@@ -1883,7 +1883,7 @@ steps:
   commands:
     - git submodule update --init
 - name: acceptance-app-files-sharing
-  image: nextcloudci/acceptance-php7.1:acceptance-php7.1-2
+  image: nextcloudci/acceptance-php7.3:acceptance-php7.3-2
   commands:
     - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-app-files-sharing --selenium-server selenium:4444 allow-git-repository-modifications features/app-files-sharing.feature
 
@@ -1913,7 +1913,7 @@ steps:
   commands:
     - git submodule update --init
 - name: acceptance-app-files-sharing-link
-  image: nextcloudci/acceptance-php7.1:acceptance-php7.1-2
+  image: nextcloudci/acceptance-php7.3:acceptance-php7.3-2
   commands:
     - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-app-files-sharing-link --selenium-server selenium:4444 allow-git-repository-modifications features/app-files-sharing-link.feature
 
@@ -1943,7 +1943,7 @@ steps:
   commands:
     - git submodule update --init
 - name: acceptance-app-files-tags
-  image: nextcloudci/acceptance-php7.1:acceptance-php7.1-2
+  image: nextcloudci/acceptance-php7.3:acceptance-php7.3-2
   commands:
     - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-app-files-tags --selenium-server selenium:4444 allow-git-repository-modifications features/app-files-tags.feature
 
@@ -1973,7 +1973,7 @@ steps:
   commands:
     - git submodule update --init
 - name: acceptance-app-theming
-  image: nextcloudci/acceptance-php7.1:acceptance-php7.1-2
+  image: nextcloudci/acceptance-php7.3:acceptance-php7.3-2
   commands:
     - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-app-theming --selenium-server selenium:4444 allow-git-repository-modifications features/app-theming.feature
 
@@ -2003,7 +2003,7 @@ steps:
   commands:
     - git submodule update --init
 - name: acceptance-header
-  image: nextcloudci/acceptance-php7.1:acceptance-php7.1-2
+  image: nextcloudci/acceptance-php7.3:acceptance-php7.3-2
   commands:
     - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-header --selenium-server selenium:4444 allow-git-repository-modifications features/header.feature
 
@@ -2033,7 +2033,7 @@ steps:
   commands:
     - git submodule update --init
 - name: acceptance-login
-  image: nextcloudci/acceptance-php7.1:acceptance-php7.1-2
+  image: nextcloudci/acceptance-php7.3:acceptance-php7.3-2
   commands:
     - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-login --selenium-server selenium:4444 allow-git-repository-modifications features/login.feature
 
@@ -2063,7 +2063,7 @@ steps:
   commands:
     - git submodule update --init
 - name: acceptance-users
-  image: nextcloudci/acceptance-php7.1:acceptance-php7.1-2
+  image: nextcloudci/acceptance-php7.3:acceptance-php7.3-2
   commands:
     - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-users --selenium-server selenium:4444 allow-git-repository-modifications features/users.feature
 
@@ -2093,7 +2093,7 @@ steps:
   commands:
     - git submodule update --init
 - name: acceptance-apps
-  image: nextcloudci/acceptance-php7.1:acceptance-php7.1-2
+  image: nextcloudci/acceptance-php7.3:acceptance-php7.3-2
   commands:
     - tests/acceptance/run-local.sh --timeout-multiplier 10 --nextcloud-server-domain acceptance-apps --selenium-server selenium:4444 allow-git-repository-modifications features/apps.feature
 

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -138,7 +138,7 @@ function prepareDocker() {
 	# Selenium server.
 	# The container exits immediately if no command is given, so a Bash session
 	# is created to prevent that.
-	docker run --detach --name=$NEXTCLOUD_LOCAL_CONTAINER --network=container:$SELENIUM_CONTAINER --interactive --tty nextcloudci/acceptance-php7.1:acceptance-php7.1-2 bash
+	docker run --detach --name=$NEXTCLOUD_LOCAL_CONTAINER --network=container:$SELENIUM_CONTAINER --interactive --tty nextcloudci/acceptance-php7.3:acceptance-php7.3-2 bash
 
 	# Use the $TMPDIR or, if not set, fall back to /tmp.
 	NEXTCLOUD_LOCAL_TAR="$($MKTEMP --tmpdir="${TMPDIR:-/tmp}" --suffix=.tar nextcloud-local-XXXXXXXXXX)"


### PR DESCRIPTION
There is no difference (as far as I know) between running the acceptance tests on PHP 7.1 or on PHP 7.3; this is simply a preparatory step to be ready when PHP 7.1 support is dropped in Nextcloud server.
