### PR TITLE
Fix spaces being collapsed in move dialog again

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -896,6 +896,9 @@ code {
 					white-space: pre;
 					text-overflow: ellipsis;
 				}
+				&__last {
+					white-space: pre;
+				}
 			}
 		}
 		.filesize, .date {


### PR DESCRIPTION
As it turns out, #17240 did not fully fix the collapsing folder name issue. :man_shrugging: My bad, should have tested more names.
This should hopefully fix it fully?