### PR TITLE
Fix jsConfigHelper lang/locale mixup

### DIFF
--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -70,8 +70,6 @@ class ThemingDefaults extends \OC_Defaults {
 	/** @var string */
 	private $url;
 	/** @var string */
-	private $slogan;
-	/** @var string */
 	private $color;
 
 	/** @var string */
@@ -115,7 +113,6 @@ class ThemingDefaults extends \OC_Defaults {
 		$this->title = parent::getTitle();
 		$this->entity = parent::getEntity();
 		$this->url = parent::getBaseUrl();
-		$this->slogan = parent::getSlogan();
 		$this->color = parent::getColorPrimary();
 		$this->iTunesAppId = parent::getiTunesAppId();
 		$this->iOSClientUrl = parent::getiOSClientUrl();
@@ -143,7 +140,7 @@ class ThemingDefaults extends \OC_Defaults {
 	}
 
 	public function getSlogan() {
-		return \OCP\Util::sanitizeHTML($this->config->getAppValue('theming', 'slogan', $this->slogan));
+		return \OCP\Util::sanitizeHTML($this->config->getAppValue('theming', 'slogan', parent::getSlogan()));
 	}
 
 	public function getImprintUrl() {

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -142,7 +142,6 @@ class TemplateLayout extends \OC_Template {
 		// Send the language and the locale to our layouts
 		$lang = \OC::$server->getL10NFactory()->findLanguage();
 		$locale = \OC::$server->getL10NFactory()->findLocale($lang);
-		$localeLang = \OC::$server->getL10NFactory()->findLanguageFromLocale('lib', $locale);
 
 		$lang = str_replace('_', '-', $lang);
 		$this->assign('language', $lang);
@@ -164,7 +163,7 @@ class TemplateLayout extends \OC_Template {
 		if ($this->config->getSystemValue('installed', false) && $renderAs != 'error') {
 			if (\OC::$server->getContentSecurityPolicyNonceManager()->browserSupportsCspV3()) {
 				$jsConfigHelper = new JSConfigHelper(
-					\OC::$server->getL10N('lib', $localeLang ?: $lang),
+					\OC::$server->getL10N('lib'),
 					\OC::$server->query(Defaults::class),
 					\OC::$server->getAppManager(),
 					\OC::$server->getSession(),

--- a/lib/private/legacy/defaults.php
+++ b/lib/private/legacy/defaults.php
@@ -52,7 +52,6 @@ class OC_Defaults {
 	private $defaultTextColorPrimary;
 
 	public function __construct() {
-		$l10n = \OC::$server->getL10N('lib');
 		$config = \OC::$server->getConfig();
 
 		$this->defaultEntity = 'Nextcloud'; /* e.g. company name, used for footers and copyright notices */
@@ -65,7 +64,6 @@ class OC_Defaults {
 		$this->defaultAndroidClientUrl = $config->getSystemValue('customclient_android', 'https://play.google.com/store/apps/details?id=com.nextcloud.client');
 		$this->defaultDocBaseUrl = 'https://docs.nextcloud.com';
 		$this->defaultDocVersion = \OC_Util::getVersion()[0]; // used to generate doc links
-		$this->defaultSlogan = $l10n->t('a safe home for all your data');
 		$this->defaultColorPrimary = '#0082c9';
 		$this->defaultTextColorPrimary = '#ffffff';
 
@@ -219,6 +217,10 @@ class OC_Defaults {
 		if ($this->themeExist('getSlogan')) {
 			return $this->theme->getSlogan();
 		} else {
+			if ($this->defaultSlogan === null) {
+				$l10n = \OC::$server->getL10N('lib');
+				$this->defaultSlogan = $l10n->t('a safe home for all your data');
+			}
 			return $this->defaultSlogan;
 		}
 	}


### PR DESCRIPTION
To test:

1. Set your language to US english
2. Set your locale to German
3. Reload

Open your js console and get the value of

* datepickerFormatDate
* dayNames

Before:

* datepickerFormatDate  in German format `dd.MM.yy"
* dayNames also in German

Now:

* datepickerFormatDate  in German format `dd.MM.yy"
* dayNames also in English