### PR TITLE
Add support for GuzzleHTTP 'no' proxy

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -520,6 +520,12 @@ $CONFIG = array(
 /**
  * The URL of your proxy server, for example ``proxy.example.com:8081``.
  *
+ * Note: Guzzle (the http library used by Nextcloud) is reading the environment
+ * variables HTTP_PROXY (only for cli request), HTTPS_PROXY, and NO_PROXY by default.
+ *
+ * If you configure proxy with Nextcloud any default configuration by Guzzle
+ * is overwritten. Make sure to set ``proxyexclude`` accordingly if necessary.
+ *
  * Defaults to ``''`` (empty string)
  */
 'proxy' => '',
@@ -532,6 +538,16 @@ $CONFIG = array(
  */
 'proxyuserpwd' => '',
 
+/**
+ * List of host names that should not be proxied to.
+ * For example: ``['.mit.edu', 'foo.com']``.
+ *
+ * Hint: Use something like ``explode(',', getenv('NO_PROXY'))`` to sync this
+ * value with the global NO_PROXY option.
+ *
+ * Defaults to empty array.
+ */
+'proxyexclude' => [],
 
 /**
  * Deleted Items (trash bin)


### PR DESCRIPTION
The custom config allows to setup a proxy URI that is passed to GuzzleHTTP client as request options. Guzzle has the option to receive an array of proxies for each URI scheme as well as 'no' key value pair
to provide a list of host names that should not be proxied to.

Guzzle would automatically populate this value with environment's NO_PROXY environment variable. However, when providing a 'proxy' request option, it is needed to provide the 'no' value.

More info:
http://docs.guzzlephp.org/en/stable/request-options.html#proxy

This commit will add support for new config 'proxyexclude', which takes a list of host names to be excluded.

It will also get 'proxy' request option as and array instead of a string to Guzzle, and populate 'http' and 'https' URI schemas with proxy URI, and 'no' with 'proxyexclude' list.

Should fix: nextcloud/server#12402

Signed-off-by: Mohammed Abdellatif <m.latief@gmail.com>