### PR TITLE
[provisioning_api] Optimization for for large installations

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -499,8 +499,8 @@ class UsersController extends AUserData {
 		} else {
 			// Check if admin / subadmin
 			$subAdminManager = $this->groupManager->getSubAdmin();
-			if ($subAdminManager->isUserAccessible($currentLoggedInUser, $targetUser)
-			|| $this->groupManager->isAdmin($currentLoggedInUser->getUID())) {
+			if ($this->groupManager->isAdmin($currentLoggedInUser->getUID())
+			|| $subAdminManager->isUserAccessible($currentLoggedInUser, $targetUser)) {
 				// They have permissions over the user
 				$permittedFields[] = 'display';
 				$permittedFields[] = AccountManager::PROPERTY_DISPLAYNAME;


### PR DESCRIPTION
Patch to optimize for large installations where subadmins have access to many groups (>250)

This fix reduces API calls to editUser (ex change locale/display name) from >2 minutes (!) to ~3 seconds per call in average in current installation.

Signed-off-by: Mikael Hammarin <mikael@try2.se>