### PR TITLE
Enhance backgroundjob timings

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -94,6 +94,7 @@ return array(
     'OCP\\Authentication\\TwoFactorAuth\\TwoFactorException' => $baseDir . '/lib/public/Authentication/TwoFactorAuth/TwoFactorException.php',
     'OCP\\AutoloadNotAllowedException' => $baseDir . '/lib/public/AutoloadNotAllowedException.php',
     'OCP\\BackgroundJob' => $baseDir . '/lib/public/BackgroundJob.php',
+    'OCP\\BackgroundJob\\DailyJob' => $baseDir . '/lib/public/BackgroundJob/DailyJob.php',
     'OCP\\BackgroundJob\\IJob' => $baseDir . '/lib/public/BackgroundJob/IJob.php',
     'OCP\\BackgroundJob\\IJobList' => $baseDir . '/lib/public/BackgroundJob/IJobList.php',
     'OCP\\BackgroundJob\\Job' => $baseDir . '/lib/public/BackgroundJob/Job.php',

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -94,6 +94,7 @@ return array(
     'OCP\\Authentication\\TwoFactorAuth\\TwoFactorException' => $baseDir . '/lib/public/Authentication/TwoFactorAuth/TwoFactorException.php',
     'OCP\\AutoloadNotAllowedException' => $baseDir . '/lib/public/AutoloadNotAllowedException.php',
     'OCP\\BackgroundJob' => $baseDir . '/lib/public/BackgroundJob.php',
+    'OCP\\BackgroundJob\\AtJob' => $baseDir . '/lib/public/BackgroundJob/AtJob.php',
     'OCP\\BackgroundJob\\DailyJob' => $baseDir . '/lib/public/BackgroundJob/DailyJob.php',
     'OCP\\BackgroundJob\\IJob' => $baseDir . '/lib/public/BackgroundJob/IJob.php',
     'OCP\\BackgroundJob\\IJobList' => $baseDir . '/lib/public/BackgroundJob/IJobList.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -123,6 +123,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Authentication\\TwoFactorAuth\\TwoFactorException' => __DIR__ . '/../../..' . '/lib/public/Authentication/TwoFactorAuth/TwoFactorException.php',
         'OCP\\AutoloadNotAllowedException' => __DIR__ . '/../../..' . '/lib/public/AutoloadNotAllowedException.php',
         'OCP\\BackgroundJob' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob.php',
+        'OCP\\BackgroundJob\\AtJob' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/AtJob.php',
         'OCP\\BackgroundJob\\DailyJob' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/DailyJob.php',
         'OCP\\BackgroundJob\\IJob' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/IJob.php',
         'OCP\\BackgroundJob\\IJobList' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/IJobList.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -123,6 +123,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Authentication\\TwoFactorAuth\\TwoFactorException' => __DIR__ . '/../../..' . '/lib/public/Authentication/TwoFactorAuth/TwoFactorException.php',
         'OCP\\AutoloadNotAllowedException' => __DIR__ . '/../../..' . '/lib/public/AutoloadNotAllowedException.php',
         'OCP\\BackgroundJob' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob.php',
+        'OCP\\BackgroundJob\\DailyJob' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/DailyJob.php',
         'OCP\\BackgroundJob\\IJob' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/IJob.php',
         'OCP\\BackgroundJob\\IJobList' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/IJobList.php',
         'OCP\\BackgroundJob\\Job' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/Job.php',

--- a/lib/public/BackgroundJob/AtJob.php
+++ b/lib/public/BackgroundJob/AtJob.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\BackgroundJob;
+
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\ILogger;
+
+/**
+ * @since 18.0.0
+ *
+ * Base class for a background job that should run once a day as close to the set
+ * time as possible (later but as close to is as possible).
+ *
+ * So lets say it is set at 08:00 but the first cron job runs at 08:06, then it
+ * will try to run the job
+ */
+abstract class AtJob extends Job {
+	/** @var int */
+	private $hour;
+	/** @var int */
+	private $minute;
+
+	/**
+	 * AtJob constructor.
+	 *
+	 * @param ITimeFactory $time
+	 * @param int $hour The hour to run this job
+	 * @param int $minute The minute to run this job
+	 *
+	 * @since 18.0.0
+	 */
+	public function __construct(ITimeFactory $time, int $hour, int $minute) {
+		parent::__construct($time);
+		$this->hour = $hour;
+		$this->minute = $minute;
+	}
+
+	private function verifyTime() {
+		if ($this->hour < 0 || $this->hour > 23
+			|| $this->minute < 0 || $this->minute > 59) {
+			throw new \RuntimeException('Invalid minute specified: ' . $this->hour . ':' . $this->minute);
+		}
+	}
+
+	/**
+	 * @since 18.0.0
+	 */
+	public function execute($jobList, ILogger $logger = null) {
+		$this->verifyTime();
+
+		$last = new \DateTime();
+		$last->setTimestamp($this->lastRun);
+		$last->setTime($this->hour,$this->minute, 0, 0);
+
+		$now = $this->time->getDateTime();
+		$now->setTime($this->hour,$this->minute,0,0);
+
+		$diff = $now->diff($last, true);
+		if ($diff->days >= 1) {
+			parent::execute($jobList, $logger);
+		}
+	}
+}

--- a/lib/public/BackgroundJob/DailyJob.php
+++ b/lib/public/BackgroundJob/DailyJob.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 
 namespace OCP\BackgroundJob;
 
-use OCP\ILogger;
+use OCP\AppFramework\Utility\ITimeFactory;
 
 /**
  * @since 18.0.0
@@ -32,22 +32,14 @@ use OCP\ILogger;
  * Base class for a background job that should run once a day as close to
  * midnight as possible
  */
-abstract class DailyJob extends Job {
+abstract class DailyJob extends AtJob {
 
 	/**
 	 * @since 18.0.0
 	 */
-	public function execute($jobList, ILogger $logger = null) {
-		$last = new \DateTime();
-		$last->setTimestamp($this->lastRun);
-		$last->setTime(0,0, 0, 0);
-
-		$now = $this->time->getDateTime();
-		$now->setTime(0,0,0,0);
-
-		$diff = $now->diff($last, true);
-		if ($diff->days >= 1) {
-			parent::execute($jobList, $logger);
-		}
+	public function __construct(ITimeFactory $time) {
+		parent::__construct($time, 0, 0);
 	}
+
+
 }

--- a/lib/public/BackgroundJob/DailyJob.php
+++ b/lib/public/BackgroundJob/DailyJob.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\BackgroundJob;
+
+use OCP\ILogger;
+
+/**
+ * @since 18.0.0
+ *
+ * Base class for a background job that should run once a day as close to
+ * midnight as possible
+ */
+abstract class DailyJob extends Job {
+
+	/**
+	 * @since 18.0.0
+	 */
+	public function execute($jobList, ILogger $logger = null) {
+		$last = new \DateTime();
+		$last->setTimestamp($this->lastRun);
+		$last->setTime(0,0, 0, 0);
+
+		$now = $this->time->getDateTime();
+		$now->setTime(0,0,0,0);
+
+		$diff = $now->diff($last, true);
+		if ($diff->days >= 1) {
+			parent::execute($jobList, $logger);
+		}
+	}
+}


### PR DESCRIPTION
This adds the AtJob backgroundjob. A background job that will run once a day after, but as close to the specified time as possible.

Example usages:

* Run share expiration as close to midnight as possible
* Run suspiciouslogin training at 03:00 when the system is likely to have low usage

There is also teh dailyJob which is just a prefilled instance to run at midnight.

TODO;
- [ ] Tests