### PR TITLE
Fix DAV mimetype search

### DIFF
--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -136,16 +136,19 @@ class QuerySearchHelper {
 		$type = $operator->getType();
 		if ($field === 'mimetype') {
 			if ($operator->getType() === ISearchComparison::COMPARE_EQUAL) {
-				$value = $this->mimetypeLoader->getId($value);
+				$value = (int)$this->mimetypeLoader->getId($value);
 			} else if ($operator->getType() === ISearchComparison::COMPARE_LIKE) {
 				// transform "mimetype='foo/%'" to "mimepart='foo'"
 				if (preg_match('|(.+)/%|', $value, $matches)) {
 					$field = 'mimepart';
-					$value = $this->mimetypeLoader->getId($matches[1]);
+					$value = (int)$this->mimetypeLoader->getId($matches[1]);
 					$type = ISearchComparison::COMPARE_EQUAL;
-				}
-				if (strpos($value, '%') !== false) {
+				} else if (strpos($value, '%') !== false) {
 					throw new \InvalidArgumentException('Unsupported query value for mimetype: ' . $value . ', only values in the format "mime/type" or "mime/%" are supported');
+				} else {
+					$field = 'mimetype';
+					$value = (int)$this->mimetypeLoader->getId($value);
+					$type = ISearchComparison::COMPARE_EQUAL;
 				}
 			}
 		} else if ($field === 'favorite') {


### PR DESCRIPTION
Fixes #15048
Catches the case where a full mimetype is sumbitted in the where like
clause. Before we didn't catch this and it was just forwarded as is
causing invalid queries.

@tobiasKaminsky @skjnldsv please check ;)