### PR TITLE
Remove unnedeed IE8 CSS

### DIFF
--- a/apps/user_ldap/templates/renewpassword.php
+++ b/apps/user_ldap/templates/renewpassword.php
@@ -6,7 +6,6 @@ script('user_ldap', [
 style('user_ldap', 'renewPassword');
 ?>
 
-<!--[if IE 8]><style>input[type="checkbox"]{padding:0;}</style><![endif]-->
 <form method="post" name="renewpassword" id="renewpassword" action="<?php p(\OC::$server->getURLGenerator()->linkToRoute('user_ldap.renewPassword.tryRenewPassword')); ?>">
 	<fieldset>
 		<div class="warning title">


### PR DESCRIPTION
IE8 is not supported at all by Microsoft, has a [tiny marketshare](https://caniuse.com/usage-table) and doesn't work with Nextcloud anyway (as Nextcloud uses jQuery 2.x which doesn't work with IE8)