### PR TITLE
fix action menu on mobile

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -674,7 +674,10 @@ table tr.summary td {
 	padding-top: 20px;
 }
 .summary .info {
-	margin-left: 35px; /* td has padding of 15, col width is 50 */
+	margin-left: 2px;
+}
+.hiddeninfo {
+	white-space: pre-line;
 }
 
 table.dragshadow {


### PR DESCRIPTION
fix: #17719 
The problem is with the info sentence length in the end. So when that section is translated into a language that have long words/phrases and that doesnt fit with the width, the bug occurs . 

The white space fix the problem. Design-wise is it ok?

![de_file](https://user-images.githubusercontent.com/12728974/67871705-13764c80-fb31-11e9-82ca-bbccb2e0194a.png)
