### PR TITLE
Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.php]
+indent_size = 8
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Fixes: #9059
It'd be good to add a `.editorconfig` file so that anyone contributing to Nextcloud can follow the same rules for tabs/spaces, newlines, charsets etc.
Editorconfig (http://editorconfig.org/) is very popular and it's become standard for open-source projects to include one. I based the rules on the current code-base.