### PR TITLE
Disable Clear-Site-Data for Chrom* (and Opera, Brave, etc)

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -33,9 +33,9 @@
 
 namespace OC\Core\Controller;
 
+use OC\AppFramework\Http\Request;
 use OC\Authentication\Login\Chain;
 use OC\Authentication\Login\LoginData;
-use OC\Authentication\TwoFactorAuth\Manager;
 use OC\Security\Bruteforce\Throttler;
 use OC\User\Session;
 use OC_App;
@@ -128,7 +128,11 @@ class LoginController extends Controller {
 
 		$this->session->set('clearingExecutionContexts', '1');
 		$this->session->close();
-		$response->addHeader('Clear-Site-Data', '"cache", "storage"');
+
+		if (!$this->request->isUserAgent([Request::USER_AGENT_CHROME, Request::USER_AGENT_ANDROID_MOBILE_CHROME])) {
+			$response->addHeader('Clear-Site-Data', '"cache", "storage"');
+		}
+
 		return $response;
 	}
 

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -128,6 +128,10 @@ class LoginControllerTest extends TestCase {
 			->method('getCookie')
 			->with('nc_token')
 			->willReturn(null);
+		$this->request
+			->expects($this->once())
+			->method('isUserAgent')
+			->willReturn(false);
 		$this->config
 			->expects($this->never())
 			->method('deleteUserValue');
@@ -142,12 +146,36 @@ class LoginControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->loginController->logout());
 	}
 
+	public function testLogoutNoClearSiteData() {
+		$this->request
+			->expects($this->once())
+			->method('getCookie')
+			->with('nc_token')
+			->willReturn(null);
+		$this->request
+			->expects($this->once())
+			->method('isUserAgent')
+			->willReturn(true);
+		$this->urlGenerator
+			->expects($this->once())
+			->method('linkToRouteAbsolute')
+			->with('core.login.showLoginForm')
+			->willReturn('/login');
+
+		$expected = new RedirectResponse('/login');
+		$this->assertEquals($expected, $this->loginController->logout());
+	}
+
 	public function testLogoutWithToken() {
 		$this->request
 			->expects($this->once())
 			->method('getCookie')
 			->with('nc_token')
 			->willReturn('MyLoginToken');
+		$this->request
+			->expects($this->once())
+			->method('isUserAgent')
+			->willReturn(false);
 		$user = $this->createMock(IUser::class);
 		$user
 			->expects($this->once())


### PR DESCRIPTION
Close #9179 (again)

I think Clear-Site-Data is a good feature but it will slow down the logout for chromium based browsers. For some reason clearing the site data (see https://github.com/nextcloud/server/issues/9179#issuecomment-502928769 and https://github.com/nextcloud/server/issues/9179#issuecomment-509629565) takes a while. There is nothing we can do.

People will always complain to their administrators about the slow logout. We should give them a way to opt out. I've been thinking about sending the header only for firefox but this makes things even more complicated. 

Since this patch has no real impact I would like to ask for a backport to 17.