### PR TITLE
Allow searching for users by displayname in the database group backend

### DIFF
--- a/tests/lib/Group/DatabaseTest.php
+++ b/tests/lib/Group/DatabaseTest.php
@@ -25,13 +25,21 @@
 
 namespace Test\Group;
 
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
 /**
  * Class Database
  *
  * @group DB
  */
 class DatabaseTest extends Backend {
+
 	private $groups = array();
+
+	/**  @var \PHPUnit\Framework\MockObject\MockObject */
+	private $eventDispatcher;
+
+	private $userBackend;
 
 	/**
 	 * get a new unique group name
@@ -47,13 +55,22 @@ class DatabaseTest extends Backend {
 
 	protected function setUp() {
 		parent::setUp();
+		$this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
 		$this->backend = new \OC\Group\Database();
+		$this->userBackend = new \OC\User\Database($this->eventDispatcher);
+		$this->userBackend->createUser('foobarbaz', '1234');
+		$this->userBackend->createUser('bazbarfoo', '1234');
+		$this->userBackend->createUser('notme', '1234');
 	}
 
 	protected function tearDown() {
 		foreach ($this->groups as $group) {
 			$this->backend->deleteGroup($group);
 		}
+		$this->userBackend->deleteUser('foobarbaz');
+		$this->userBackend->deleteUser('bazbarfoo');
+		$this->userBackend->deleteUser('notme');
 		parent::tearDown();
 	}
 


### PR DESCRIPTION
When searching for users in a group by displayname only the uid was matched before: https://github.com/nextcloud/server/blob/653628c8fb69dc3f9d26751520f91e43a18f17ae/lib/private/Group/Group.php#L309

With this PR usersInGroup will also check for matching displaynames when called with a $search parameter