### PR TITLE
Remove unneeded more-white icon

### DIFF
--- a/core/img/actions/more-white.svg
+++ b/core/img/actions/more-white.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewbox="0 0 16 16" width="16" height="16"><path d="M3 6a2 2 0 1 0 0 4 2 2 0 0 0 0-4zm5 0a2 2 0 1 0 0 4 2 2 0 0 0 0-4zm5 0a2 2 0 1 0 0 4 2 2 0 0 0 0-4z" fill="#fff"/></svg>


### PR DESCRIPTION
As a follow-up to @jenniferpiperek’s https://github.com/nextcloud/server/pull/17178 improving the more icon. :) Now also in the white version.

Quick review @nextcloud/designers 