### PR TITLE
Set timeout for http requests to 10min

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -63,7 +63,7 @@ class Client implements IClient {
 		$defaults = [
 			RequestOptions::PROXY => $this->getProxyUri(),
 			RequestOptions::VERIFY => $this->getCertBundle(),
-			RequestOptions::TIMEOUT => 30,
+			RequestOptions::TIMEOUT => 600,
 		];
 
 		$options = array_merge($defaults, $options);

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -113,7 +113,7 @@ class ClientTest extends \Test\TestCase {
 			'headers' => [
 				'User-Agent' => 'Nextcloud Server Crawler',
 			],
-			'timeout' => 30,
+			'timeout' => 600,
 		];
 	}
 
@@ -272,7 +272,7 @@ class ClientTest extends \Test\TestCase {
 			'headers' => [
 				'User-Agent' => 'Nextcloud Server Crawler'
 			],
-			'timeout' => 30,
+			'timeout' => 600,
 		], self::invokePrivate($this->client, 'buildRequestOptions', [[]]));
 	}
 
@@ -299,7 +299,7 @@ class ClientTest extends \Test\TestCase {
 			'headers' => [
 				'User-Agent' => 'Nextcloud Server Crawler'
 			],
-			'timeout' => 30,
+			'timeout' => 600,
 		], self::invokePrivate($this->client, 'buildRequestOptions', [[]]));
 	}
 }


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/17776
Fix https://github.com/nextcloud/server/issues/17792
Fix https://github.com/nextcloud/server/issues/17808

I fear there will be more reports if we keep such a low value. Probably a config value make sense here.