### PR TITLE
add option to disable background scanning of files

### DIFF
--- a/apps/files/lib/BackgroundJob/ScanFiles.php
+++ b/apps/files/lib/BackgroundJob/ScanFiles.php
@@ -97,6 +97,10 @@ class ScanFiles extends \OC\BackgroundJob\TimedJob {
 	 * @throws \Exception
 	 */
 	protected function run($argument) {
+		if ($this->config->getSystemValueBool('files_no_background_scan', false)) {
+			return;
+		}
+		
 		$offset = $this->config->getAppValue('files', 'cronjob_scan_files', 0);
 		$users = $this->userManager->search('', self::USERS_PER_SESSION, $offset);
 		if (!count($users)) {


### PR DESCRIPTION
when using (only) object store this job doesn't do any scanning anyway,
but all the setup can still be expensive on large setups

Signed-off-by: Robin Appelman <robin@icewind.nl>