### PR TITLE
actually return the quote when getting global storage info

### DIFF
--- a/lib/private/legacy/helper.php
+++ b/lib/private/legacy/helper.php
@@ -586,8 +586,13 @@ class OC_Helper {
 			$relative = 0;
 		}
 
-		return array('free' => $free, 'used' => $used, 'total' => $total, 'relative' => $relative);
-
+		return [
+			'free' => $free,
+			'used' => $used,
+			'total' => $total,
+			'relative' => $relative,
+			'quota' => $quota
+		];
 	}
 
 	/**


### PR DESCRIPTION
prevents 'undefined index' errors when 'include external storage in quota' is enabled

Signed-off-by: Robin Appelman <robin@icewind.nl>