### PR TITLE
dont set folder size to negative values during propagation

### DIFF
--- a/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
@@ -85,4 +85,12 @@ class FunctionBuilder implements IFunctionBuilder {
 	public function min($field) {
 		return new QueryFunction('MIN(' . $this->helper->quoteColumnName($field) . ')');
 	}
+
+	public function greatest($x, $y) {
+		return new QueryFunction('GREATEST(' . $this->helper->quoteColumnName($x) . ', ' . $this->helper->quoteColumnName($y) . ')');
+	}
+
+	public function least($x, $y) {
+		return new QueryFunction('LEAST(' . $this->helper->quoteColumnName($x) . ', ' . $this->helper->quoteColumnName($y) . ')');
+	}
 }

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/SqliteFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/SqliteFunctionBuilder.php
@@ -30,4 +30,13 @@ class SqliteFunctionBuilder extends FunctionBuilder {
 	public function concat($x, $y) {
 		return new QueryFunction('(' . $this->helper->quoteColumnName($x) . ' || ' . $this->helper->quoteColumnName($y) . ')');
 	}
+
+	public function greatest($x, $y) {
+		return new QueryFunction('MAX(' . $this->helper->quoteColumnName($x) . ', ' . $this->helper->quoteColumnName($y) . ')');
+	}
+
+	public function least($x, $y) {
+		return new QueryFunction('MIN(' . $this->helper->quoteColumnName($x) . ', ' . $this->helper->quoteColumnName($y) . ')');
+	}
+
 }

--- a/lib/public/DB/QueryBuilder/IFunctionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IFunctionBuilder.php
@@ -109,6 +109,8 @@ interface IFunctionBuilder {
 	/**
 	 * Takes the maximum of all rows in a column
 	 *
+	 * If you want to get the maximum value of multiple columns in the same row, use `greatest` instead
+	 *
 	 * @param mixed $field the column to maximum
 	 *
 	 * @return IQueryFunction
@@ -119,10 +121,38 @@ interface IFunctionBuilder {
 	/**
 	 * Takes the minimum of all rows in a column
 	 *
+	 * If you want to get the minimum value of multiple columns in the same row, use `least` instead
+	 *
 	 * @param mixed $field the column to minimum
 	 *
 	 * @return IQueryFunction
 	 * @since 18.0.0
 	 */
 	public function min($field);
+
+	/**
+	 * Takes the maximum of multiple values
+	 *
+	 * If you want to get the maximum value of all rows in a column, use `max` instead
+	 *
+	 * @param mixed $x the first input field or number
+	 * @param mixed $y the first input field or number
+	 *
+	 * @return IQueryFunction
+	 * @since 18.0.0
+	 */
+	public function greatest($x, $y);
+
+	/**
+	 * Takes the minimum of multiple values
+	 *
+	 * If you want to get the minimum value of all rows in a column, use `min` instead
+	 *
+	 * @param mixed $x the first input field or number
+	 * @param mixed $y the first input field or number
+	 *
+	 * @return IQueryFunction
+	 * @since 18.0.0
+	 */
+	public function least($x, $y);
 }

--- a/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
@@ -198,4 +198,24 @@ class FunctionBuilderTest extends TestCase {
 
 		$this->assertEquals(10, $query->execute()->fetchColumn());
 	}
+
+	public function testGreatest() {
+		$query = $this->connection->getQueryBuilder();
+
+		$query->select($query->func()->greatest($query->createNamedParameter(2, IQueryBuilder::PARAM_INT), new Literal(1)));
+		$query->from('appconfig')
+			->setMaxResults(1);
+
+		$this->assertEquals(2, $query->execute()->fetchColumn());
+	}
+
+	public function testLeast() {
+		$query = $this->connection->getQueryBuilder();
+
+		$query->select($query->func()->least($query->createNamedParameter(2, IQueryBuilder::PARAM_INT), new Literal(1)));
+		$query->from('appconfig')
+			->setMaxResults(1);
+
+		$this->assertEquals(1, $query->execute()->fetchColumn());
+	}
 }

--- a/tests/lib/Files/Cache/PropagatorTest.php
+++ b/tests/lib/Files/Cache/PropagatorTest.php
@@ -81,6 +81,17 @@ class PropagatorTest extends TestCase {
 		}
 	}
 
+	public function testSizePropagationNoNegative() {
+		$paths = ['', 'foo', 'foo/bar'];
+		$oldInfos = $this->getFileInfos($paths);
+		$this->storage->getPropagator()->propagateChange('foo/bar/file.txt', time(), -100);
+		$newInfos = $this->getFileInfos($paths);
+
+		foreach ($oldInfos as $i => $oldInfo) {
+			$this->assertEquals(-1, $newInfos[$i]->getSize());
+		}
+	}
+
 	public function testBatchedPropagation() {
 		$this->storage->mkdir('foo/baz');
 		$this->storage->mkdir('asd');


### PR DESCRIPTION
normally this shouldn't be a problem, but cache/storage desync might cause this
so this adds some failsafe to ensure we dont corrupt the cache further

the minimum value is set to -1 instead of 0 in order to triger a background scan
on the folder and figure out the size properly