### PR TITLE
Public API's GenericEvent replacement (take 2)

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -177,6 +177,7 @@ return array(
     'OCP\\Encryption\\Keys\\IStorage' => $baseDir . '/lib/public/Encryption/Keys/IStorage.php',
     'OCP\\EventDispatcher\\ABroadcastedEvent' => $baseDir . '/lib/public/EventDispatcher/ABroadcastedEvent.php',
     'OCP\\EventDispatcher\\Event' => $baseDir . '/lib/public/EventDispatcher/Event.php',
+    'OCP\\EventDispatcher\\GenericEvent' => $baseDir . '/lib/public/EventDispatcher/GenericEvent.php',
     'OCP\\EventDispatcher\\IEventDispatcher' => $baseDir . '/lib/public/EventDispatcher/IEventDispatcher.php',
     'OCP\\EventDispatcher\\IEventListener' => $baseDir . '/lib/public/EventDispatcher/IEventListener.php',
     'OCP\\Federation\\Exceptions\\ActionNotSupportedException' => $baseDir . '/lib/public/Federation/Exceptions/ActionNotSupportedException.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -206,6 +206,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Encryption\\Keys\\IStorage' => __DIR__ . '/../../..' . '/lib/public/Encryption/Keys/IStorage.php',
         'OCP\\EventDispatcher\\ABroadcastedEvent' => __DIR__ . '/../../..' . '/lib/public/EventDispatcher/ABroadcastedEvent.php',
         'OCP\\EventDispatcher\\Event' => __DIR__ . '/../../..' . '/lib/public/EventDispatcher/Event.php',
+        'OCP\\EventDispatcher\\GenericEvent' => __DIR__ . '/../../..' . '/lib/public/EventDispatcher/GenericEvent.php',
         'OCP\\EventDispatcher\\IEventDispatcher' => __DIR__ . '/../../..' . '/lib/public/EventDispatcher/IEventDispatcher.php',
         'OCP\\EventDispatcher\\IEventListener' => __DIR__ . '/../../..' . '/lib/public/EventDispatcher/IEventListener.php',
         'OCP\\Federation\\Exceptions\\ActionNotSupportedException' => __DIR__ . '/../../..' . '/lib/public/Federation/Exceptions/ActionNotSupportedException.php',

--- a/lib/private/Files/Node/HookConnector.php
+++ b/lib/private/Files/Node/HookConnector.php
@@ -24,10 +24,10 @@ namespace OC\Files\Node;
 
 use OC\Files\Filesystem;
 use OC\Files\View;
+use OCP\EventDispatcher\GenericEvent;
 use OCP\Files\FileInfo;
 use OCP\Util;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\GenericEvent;
 
 class HookConnector {
 	/**

--- a/lib/public/EventDispatcher/GenericEvent.php
+++ b/lib/public/EventDispatcher/GenericEvent.php
@@ -1,0 +1,169 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\EventDispatcher;
+
+use ArrayAccess;
+use ArrayIterator;
+use InvalidArgumentException;
+use IteratorAggregate;
+use Traversable;
+use function array_key_exists;
+
+/**
+ * Class GenericEvent
+ *
+ * convenience reimplementation of \Symfony\Component\GenericEvent against
+ * \OCP\EventDispatcher\Event
+ *
+ * @package OCP\EventDispatcher
+ * @since 18.0.0
+ */
+class GenericEvent extends Event implements ArrayAccess, IteratorAggregate {
+	protected $subject;
+	protected $arguments;
+
+	/**
+	 * Encapsulate an event with $subject and $args.
+	 *
+	 * @since 18.0.0
+	 */
+	public function __construct($subject = null, array $arguments = []) {
+		$this->subject = $subject;
+		$this->arguments = $arguments;
+	}
+
+	/**
+	 * Getter for subject property.
+	 *
+	 * @since 18.0.0
+	 */
+	public function getSubject() {
+		return $this->subject;
+	}
+
+	/**
+	 * Get argument by key.
+	 *
+	 * @throws InvalidArgumentException if key is not found
+	 * @since 18.0.0
+	 */
+	public function getArgument(string $key) {
+		if ($this->hasArgument($key)) {
+			return $this->arguments[$key];
+		}
+
+		throw new InvalidArgumentException(sprintf('Argument "%s" not found.', $key));
+	}
+
+	/**
+	 * Add argument to event.
+	 *
+	 * @since 18.0.0
+	 */
+	public function setArgument($key, $value): GenericEvent {
+		$this->arguments[$key] = $value;
+		return $this;
+	}
+
+	/**
+	 * Getter for all arguments.
+	 *
+	 * @since 18.0.0
+	 */
+	public function getArguments(): array {
+		return $this->arguments;
+	}
+
+	/**
+	 * Set args property.
+	 *
+	 * @since 18.0.0
+	 */
+	public function setArguments(array $args = []): GenericEvent {
+		$this->arguments = $args;
+		return $this;
+	}
+
+	/**
+	 * Has argument.
+	 *
+	 * @since 18.0.0
+	 */
+	public function hasArgument($key): bool {
+		return array_key_exists($key, $this->arguments);
+	}
+
+	/**
+	 * Retrieve an external iterator
+	 *
+	 * @link https://php.net/manual/en/iteratoraggregate.getiterator.php
+	 * @since 18.0.0
+	 */
+	public function getIterator(): Traversable {
+		return new ArrayIterator($this->arguments);
+	}
+
+	/**
+	 * Whether a offset exists
+	 *
+	 * @link https://php.net/manual/en/arrayaccess.offsetexists.php
+	 * @since 18.0.0
+	 */
+	public function offsetExists($offset): bool {
+		return $this->hasArgument($offset);
+	}
+
+	/**
+	 * Offset to retrieve
+	 *
+	 * @link https://php.net/manual/en/arrayaccess.offsetget.php
+	 * @since 18.0.0
+	 */
+	public function offsetGet($offset) {
+		return $this->arguments[$offset];
+	}
+
+	/**
+	 * Offset to set
+	 *
+	 * @link https://php.net/manual/en/arrayaccess.offsetset.php
+	 * @since 18.0.0
+	 */
+	public function offsetSet($offset, $value): void {
+		$this->setArgument($offset, $value);
+	}
+
+	/**
+	 * Offset to unset
+	 *
+	 * @link https://php.net/manual/en/arrayaccess.offsetunset.php
+	 * @since 18.0.0
+	 */
+	public function offsetUnset($offset): void {
+		if ($this->hasArgument($offset)) {
+			unset($this->arguments[$offset]);
+		}
+	}
+}

--- a/tests/lib/Files/Node/HookConnectorTest.php
+++ b/tests/lib/Files/Node/HookConnectorTest.php
@@ -13,6 +13,8 @@ use OC\Files\Node\HookConnector;
 use OC\Files\Node\Root;
 use OC\Files\Storage\Temporary;
 use OC\Files\View;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\GenericEvent as APIGenericEvent;
 use OCP\Files\Node;
 use OCP\ILogger;
 use OCP\IUserManager;
@@ -146,7 +148,8 @@ class HookConnectorTest extends TestCase {
 		$dispatcherCalled = false;
 		/** @var Node $dispatcherNode */
 		$dispatcherNode = null;
-		$this->eventDispatcher->addListener($expectedEvent, function (GenericEvent $event) use (&$dispatcherCalled, &$dispatcherNode) {
+		$this->eventDispatcher->addListener($expectedEvent, function ($event) use (&$dispatcherCalled, &$dispatcherNode) {
+			/** @var GenericEvent|APIGenericEvent $event */
 			$dispatcherCalled = true;
 			$dispatcherNode = $event->getSubject();
 		});
@@ -206,7 +209,8 @@ class HookConnectorTest extends TestCase {
 		$dispatcherSourceNode = null;
 		/** @var Node $dispatcherTargetNode */
 		$dispatcherTargetNode = null;
-		$this->eventDispatcher->addListener($expectedEvent, function (GenericEvent $event) use (&$dispatcherSourceNode, &$dispatcherTargetNode, &$dispatcherCalled) {
+		$this->eventDispatcher->addListener($expectedEvent, function ($event) use (&$dispatcherSourceNode, &$dispatcherTargetNode, &$dispatcherCalled) {
+			/** @var GenericEvent|APIGenericEvent $event */
 			$dispatcherCalled = true;
 			list($dispatcherSourceNode, $dispatcherTargetNode) = $event->getSubject();
 		});
@@ -237,7 +241,8 @@ class HookConnectorTest extends TestCase {
 		$dispatcherCalled = false;
 		/** @var Node $dispatcherNode */
 		$dispatcherNode = null;
-		$this->eventDispatcher->addListener('\OCP\Files::postDelete', function (GenericEvent $event) use (&$dispatcherCalled, &$dispatcherNode) {
+		$this->eventDispatcher->addListener('\OCP\Files::postDelete', function ($event) use (&$dispatcherCalled, &$dispatcherNode) {
+			/** @var GenericEvent|APIGenericEvent $event */
 			$dispatcherCalled = true;
 			$dispatcherNode = $event->getSubject();
 		});

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -15,7 +15,6 @@ use OC\Files\Storage\Common;
 use OC\Files\Storage\Temporary;
 use OC\Files\Stream\Quota;
 use OC\Files\View;
-use OCP\Constants;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\FileInfo;
 use OCP\Files\Storage\IStorage;


### PR DESCRIPTION
replacement of #17650 

The approach above is not really awesome, because it causes breaks and kills backwards compatibility.

The approach now is to
* Still add an own GenericEvent class in OCP
  * (combining it with Event does not work as it breaks current implementations that have some methods with a different signature)
* new Events should straight use `Event`, or less ideally this GenericEvent, anyway not Symfony's old ones
* old Events should throw a second event using the new class and phase out the old event as we do we regular deprecations
  * this is not within scope of this PR and can be handled invidiually. We should do it for the server parts sooner however.


