### PR TITLE
Also set X-OC-Mtime header for files that are smaller than 10MB

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -242,6 +242,10 @@ OC.FileUpload.prototype = {
 			// TODO: if fails, it means same id already existed, need to retry
 		} else {
 			chunkFolderPromise = $.Deferred().resolve().promise();
+			var mtime = this.getFile().lastModified;
+			if (mtime) {
+				data.headers['X-OC-Mtime'] = mtime / 1000;
+			}
 		}
 
 		// wait for creation of the required directory before uploading


### PR DESCRIPTION
Turns out when uploading files over the web UI that are smaller than 10MB the X-OC-MTime header was not set, as they are not using chunked upload but a single PUT.