### PR TITLE
Mark "Talk" active on /call/token URLs

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -128,6 +128,11 @@ class SecurityMiddleware extends Middleware {
 		// for normal HTML requests and not for AJAX requests
 		$this->navigationManager->setActiveEntry($this->appName);
 
+		/** @suppress PhanUndeclaredClassConstant */
+		if ($controller === \OCA\Talk\Controller\PageController::class && $methodName === 'showCall') {
+			$this->navigationManager->setActiveEntry('spreed');
+		}
+
 		// security checks
 		$isPublicPage = $this->reflector->hasAnnotation('PublicPage');
 		if(!$isPublicPage) {

--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -121,6 +121,8 @@ class SecurityMiddleware extends Middleware {
 	 * @param Controller $controller the controller
 	 * @param string $methodName the name of the method
 	 * @throws SecurityException when a security check fails
+	 *
+	 * @suppress PhanUndeclaredClassConstant
 	 */
 	public function beforeController($controller, $methodName) {
 
@@ -128,7 +130,6 @@ class SecurityMiddleware extends Middleware {
 		// for normal HTML requests and not for AJAX requests
 		$this->navigationManager->setActiveEntry($this->appName);
 
-		/** @suppress PhanUndeclaredClassConstant */
 		if ($controller === \OCA\Talk\Controller\PageController::class && $methodName === 'showCall') {
 			$this->navigationManager->setActiveEntry('spreed');
 		}


### PR DESCRIPTION
On backport to stable17 the class name needs to be changed, so manual backporting it is.

### Steps
1. Open Talk
2. Go to a conversation
3. Reload the page
4. Try to find the "active triangle" on the top navigation bar