### PR TITLE
Add .editorconfig to expected files

### DIFF
--- a/build/files-checker.php
+++ b/build/files-checker.php
@@ -24,6 +24,7 @@ $expectedFiles = [
 	'..',
 	'.codecov.yml',
 	'.drone.yml',
+	'.editorconfig',
 	'.eslintrc.js',
 	'.git',
 	'.gitattributes',


### PR DESCRIPTION
Need to add `.editorconfig` to expected files to have checkers CI pipeline pass.