### PR TITLE
Fix tab navigation of menu in public share pages

### DIFF
--- a/core/css/public.scss
+++ b/core/css/public.scss
@@ -11,6 +11,16 @@ $footer-height: 65px;
 			ul li {
 				min-width: 270px;
 			}
+			#header-actions-toggle {
+				background-color: transparent;
+				border-color: transparent;
+
+				&:hover,
+				&:focus,
+				&:active {
+					opacity: 1;
+				}
+			}
 			#save-external-share {
 				form {
 					display: flex;

--- a/core/css/public.scss
+++ b/core/css/public.scss
@@ -21,10 +21,9 @@ $footer-height: 65px;
 					opacity: 1;
 				}
 			}
-			#save-external-share {
+			#external-share-menu-item {
 				form {
 					display: flex;
-					margin: 0;
 				}
 				.hidden {
 					display: none;

--- a/core/js/public/publicpage.js
+++ b/core/js/public/publicpage.js
@@ -26,9 +26,8 @@ $(document).ready(function () {
 		$(this).next('.popovermenu').toggleClass('open');
 	});
 
-	$('#save-external-share').find('label').click(function () {
-		$(this).toggleClass('hidden');
-		$('.save-form').toggleClass('hidden')
+	$('#save-external-share').click(function () {
+		$('#external-share-menu-item').toggleClass('hidden')
 		$('#remote_address').focus();
 	});
 

--- a/core/templates/layout.public.php
+++ b/core/templates/layout.public.php
@@ -61,7 +61,7 @@
 			</span>
 			<?php if($template->getActionCount() > 1) { ?>
 			<div id="header-secondary-action">
-				<span id="header-actions-toggle" class="menutoggle icon-more-white"></span>
+				<button id="header-actions-toggle" class="menutoggle icon-more-white"></button>
 				<div id="header-actions-menu" class="popovermenu menu">
 					<ul>
 						<?php

--- a/lib/public/AppFramework/Http/Template/ExternalShareMenuAction.php
+++ b/lib/public/AppFramework/Http/Template/ExternalShareMenuAction.php
@@ -67,14 +67,15 @@ class ExternalShareMenuAction extends SimpleMenuAction {
 	 */
 	public function render(): string {
 		return '<li>' .
-			'    <a id="save-external-share" data-protected="false" data-owner-display-name="' . Util::sanitizeHTML($this->displayname) . '" data-owner="' . Util::sanitizeHTML($this->owner) . '" data-name="' . Util::sanitizeHTML($this->shareName) . '">' .
-			'        <span class="icon ' . Util::sanitizeHTML($this->getIcon()) . '"></span>' .
-			'        <label for="remote_address">' . Util::sanitizeHTML($this->getLabel()) . '</label>' .
-			'        <form class="save-form hidden" action="#">' .
+			'    <button id="save-external-share" class="icon ' . Util::sanitizeHTML($this->getIcon()) . '" data-protected="false" data-owner-display-name="' . Util::sanitizeHTML($this->displayname) . '" data-owner="' . Util::sanitizeHTML($this->owner) . '" data-name="' . Util::sanitizeHTML($this->shareName) . '">' . Util::sanitizeHTML($this->getLabel()) . '</button>' .
+			'</li>' .
+			'<li id="external-share-menu-item" class="hidden">' .
+			'    <span class="menuitem">' .
+			'        <form class="save-form" action="#">' .
 			'            <input type="text" id="remote_address" placeholder="user@yourNextcloud.org">' .
 			'            <input type="submit" value=" " id="save-button-confirm" class="icon-confirm" disabled="disabled"></button>' .
 			'        </form>' .
-			'    </a>' .
+			'    </span>' .
 			'</li>';
 	}
 }

--- a/lib/public/AppFramework/Http/Template/ExternalShareMenuAction.php
+++ b/lib/public/AppFramework/Http/Template/ExternalShareMenuAction.php
@@ -67,14 +67,14 @@ class ExternalShareMenuAction extends SimpleMenuAction {
 	 */
 	public function render(): string {
 		return '<li>' .
-			'<a id="save-external-share" data-protected="false" data-owner-display-name="' . Util::sanitizeHTML($this->displayname) . '" data-owner="' . Util::sanitizeHTML($this->owner) . '" data-name="' . Util::sanitizeHTML($this->shareName) . '">' .
-			'<span class="icon ' . Util::sanitizeHTML($this->getIcon()) . '"></span>' .
-			'<label for="remote_address">' . Util::sanitizeHTML($this->getLabel()) . '</label>' .
-			'<form class="save-form hidden" action="#">' .
-			'<input type="text" id="remote_address" placeholder="user@yourNextcloud.org">' .
-			'<input type="submit" value=" " id="save-button-confirm" class="icon-confirm" disabled="disabled"></button>' .
-			'</form>' .
-			'</a>' .
+			'    <a id="save-external-share" data-protected="false" data-owner-display-name="' . Util::sanitizeHTML($this->displayname) . '" data-owner="' . Util::sanitizeHTML($this->owner) . '" data-name="' . Util::sanitizeHTML($this->shareName) . '">' .
+			'        <span class="icon ' . Util::sanitizeHTML($this->getIcon()) . '"></span>' .
+			'        <label for="remote_address">' . Util::sanitizeHTML($this->getLabel()) . '</label>' .
+			'        <form class="save-form hidden" action="#">' .
+			'            <input type="text" id="remote_address" placeholder="user@yourNextcloud.org">' .
+			'            <input type="submit" value=" " id="save-button-confirm" class="icon-confirm" disabled="disabled"></button>' .
+			'        </form>' .
+			'    </a>' .
 			'</li>';
 	}
 }


### PR DESCRIPTION
@jancborchardt I tried to show and hide the menu item with a nice transition... but I failed, sorry :-P

I have also noticed that the `aria-expanded` attribute in the menu toggle is not changed when the menu is opened, but I do not have the time right now to check what is wrong (but it seems that [OC.Menu.registerMenu](https://github.com/nextcloud/server/blob/b9bc2417e7a8dc81feb0abe20359bedaf864f790/core/src/OC/menu.js#L68) is not used in this menu).