### PR TITLE
Make timeout a optional parameter

### DIFF
--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -55,6 +55,7 @@ class SMB extends Backend {
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('timeout', $l->t('Timeout')))
 					->setType(DefinitionParameter::VALUE_HIDDEN)
+					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 			])
 			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
 			->addAuthScheme(AuthMechanism::SCHEME_SMB)


### PR DESCRIPTION
Fix #17846 

otherwise you cannot create a new smb storage via gui