### PR TITLE
Catch file transfer error and stop transfer ownership command

### DIFF
--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -215,6 +215,9 @@ class OwnershipTransferService {
 		return $shares;
 	}
 
+	/**
+	 * @throws TransferOwnershipException
+	 */
 	protected function transferFiles(string $sourceUid,
 									 string $sourcePath,
 									 string $finalTarget,
@@ -228,7 +231,9 @@ class OwnershipTransferService {
 			$view->mkdir($finalTarget);
 			$finalTarget = $finalTarget . '/' . basename($sourcePath);
 		}
-		$view->rename($sourcePath, $finalTarget);
+		if ($view->rename($sourcePath, $finalTarget) === false) {
+			throw new TransferOwnershipException("Could not transfer files", 1);
+		}
 		if (!is_dir("$sourceUid/files")) {
 			// because the files folder is moved away we need to recreate it
 			$view->mkdir("$sourceUid/files");


### PR DESCRIPTION
Ref https://github.com/nextcloud/server/issues/15664

This does not check quota as I do not have a clue how to do this. But it checks the returned value of the move operation. Better than nothing.