### PR TITLE
Fix editorconfig - we always used 4 space tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.php]
-indent_size = 8
+indent_size = 4
 
 [*.md]
 trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,8 +10,5 @@ indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.php]
-indent_size = 4
-
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
Signed-off-by: Joas Schilling <coding@schilljs.com>