### PR TITLE
re-acquired expired shared locks on large file uploads

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -1201,4 +1201,25 @@ class FileTest extends TestCase {
 
 		$this->assertEquals('new content', $view->file_get_contents('root/file.txt'));
 	}
+
+	public function testPutLockExpired() {
+		$view = new \OC\Files\View('/' . $this->user . '/files/');
+
+		$path = 'test-locking.txt';
+		$info = new \OC\Files\FileInfo(
+			'/' . $this->user . '/files/' . $path,
+			$this->getMockStorage(),
+			null,
+			['permissions' => \OCP\Constants::PERMISSION_ALL],
+			null
+		);
+
+		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+
+		// don't lock before the PUT to simulate an expired shared lock
+		$this->assertNotEmpty($file->put($this->getStream('test data')));
+
+		// afterMethod unlocks
+		$view->unlockFile($path, ILockingProvider::LOCK_SHARED);
+	}
 }


### PR DESCRIPTION
during large file uploads, the shared lock that we get at the begining can expire
leading to locked errors later on, instead of erroring, try to re-get the lock

Signed-off-by: Robin Appelman <robin@icewind.nl>