### PR TITLE
Handle token insert conflicts

### DIFF
--- a/tests/lib/Authentication/Token/ManagerTest.php
+++ b/tests/lib/Authentication/Token/ManagerTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2018 Roeland Jago Douma <roeland@famdouma.nl>
  *
@@ -23,6 +24,7 @@
 
 namespace Test\Authentication\Token;
 
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Token\DefaultToken;
@@ -31,21 +33,15 @@ use OC\Authentication\Token\ExpiredTokenException;
 use OC\Authentication\Token\IToken;
 use OC\Authentication\Token\Manager;
 use OC\Authentication\Token\PublicKeyToken;
-use OC\Authentication\Token\PublicKeyTokenMapper;
 use OC\Authentication\Token\PublicKeyTokenProvider;
-use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\IConfig;
-use OCP\ILogger;
-use OCP\IUser;
-use OCP\Security\ICrypto;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ManagerTest extends TestCase {
 
-	/** @var PublicKeyTokenProvider|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var PublicKeyTokenProvider|MockObject */
 	private $publicKeyTokenProvider;
-	/** @var DefaultTokenProvider|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var DefaultTokenProvider|MockObject */
 	private $defaultTokenProvider;
 	/** @var Manager */
 	private $manager;
@@ -78,6 +74,44 @@ class ManagerTest extends TestCase {
 				IToken::TEMPORARY_TOKEN,
 				IToken::REMEMBER
 			)->willReturn($token);
+
+		$actual = $this->manager->generateToken(
+			'token',
+			'uid',
+			'loginName',
+			'password',
+			'name',
+			IToken::TEMPORARY_TOKEN,
+			IToken::REMEMBER
+		);
+
+		$this->assertSame($token, $actual);
+	}
+
+	public function testGenerateConflictingToken() {
+		/** @var MockObject|UniqueConstraintViolationException $exception */
+		$exception = $this->createMock(UniqueConstraintViolationException::class);
+		$this->defaultTokenProvider->expects($this->never())
+			->method('generateToken');
+
+		$token = new PublicKeyToken();
+		$token->setUid('uid');
+
+		$this->publicKeyTokenProvider->expects($this->once())
+			->method('generateToken')
+			->with(
+				'token',
+				'uid',
+				'loginName',
+				'password',
+				'name',
+				IToken::TEMPORARY_TOKEN,
+				IToken::REMEMBER
+			)->willThrowException($exception);
+		$this->publicKeyTokenProvider->expects($this->once())
+			->method('getToken')
+			->with('token')
+			->willReturn($token);
 
 		$actual = $this->manager->generateToken(
 			'token',


### PR DESCRIPTION
Env-based SAML uses the "Apache auth" mechanism to log users in. In this
code path, we first delete all existin auth tokens from the database,
before a new one is inserted. This is problematic for concurrent
requests as they might reach the same code at the same time, hence both
trying to insert a new row wit the same token (the session ID). This
also bubbles up and disables user_saml.

As the token might still be OK (both request will insert the same data),
we can actually just check if the UIDs of the conflict row is the same
as the one we want to insert right now. In that case let's just use the
existing entry and carry on.

Fixes https://github.com/nextcloud/user_saml/issues/115 