### PR TITLE
Allow filtering the search results to the users home storage

### DIFF
--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -119,6 +119,7 @@ class FileSearchBackend implements ISearchBackend {
 			new SearchPropertyDefinition(FilesPlugin::SIZE_PROPERTYNAME, true, true, true, SearchPropertyDefinition::DATATYPE_NONNEGATIVE_INTEGER),
 			new SearchPropertyDefinition(TagsPlugin::FAVORITE_PROPERTYNAME, true, true, true, SearchPropertyDefinition::DATATYPE_BOOLEAN),
 			new SearchPropertyDefinition(FilesPlugin::INTERNAL_FILEID_PROPERTYNAME, true, true, false, SearchPropertyDefinition::DATATYPE_NONNEGATIVE_INTEGER),
+			new SearchPropertyDefinition(FilesPlugin::OWNER_ID_PROPERTYNAME, true, true, false),
 
 			// select only properties
 			new SearchPropertyDefinition('{DAV:}resourcetype', false, true, false),
@@ -126,7 +127,6 @@ class FileSearchBackend implements ISearchBackend {
 			new SearchPropertyDefinition(FilesPlugin::CHECKSUMS_PROPERTYNAME, false, true, false),
 			new SearchPropertyDefinition(FilesPlugin::PERMISSIONS_PROPERTYNAME, false, true, false),
 			new SearchPropertyDefinition(FilesPlugin::GETETAG_PROPERTYNAME, false, true, false),
-			new SearchPropertyDefinition(FilesPlugin::OWNER_ID_PROPERTYNAME, false, true, false),
 			new SearchPropertyDefinition(FilesPlugin::OWNER_DISPLAY_NAME_PROPERTYNAME, false, true, false),
 			new SearchPropertyDefinition(FilesPlugin::DATA_FINGERPRINT_PROPERTYNAME, false, true, false),
 			new SearchPropertyDefinition(FilesPlugin::HAS_PREVIEW_PROPERTYNAME, false, true, false, SearchPropertyDefinition::DATATYPE_BOOLEAN),
@@ -169,10 +169,12 @@ class FileSearchBackend implements ISearchBackend {
 			return new SearchResult($davNode, $path);
 		}, $results);
 
-		// Sort again, since the result from multiple storages is appended and not sorted
-		usort($nodes, function (SearchResult $a, SearchResult $b) use ($search) {
-			return $this->sort($a, $b, $search->orderBy);
-		});
+		if (!$query->limitToHome()) {
+			// Sort again, since the result from multiple storages is appended and not sorted
+			usort($nodes, function (SearchResult $a, SearchResult $b) use ($search) {
+				return $this->sort($a, $b, $search->orderBy);
+			});
+		}
 
 		// If a limit is provided use only return that number of files
 		if ($search->limit->maxResults !== 0) {
@@ -267,11 +269,29 @@ class FileSearchBackend implements ISearchBackend {
 	 * @param Query $query
 	 * @return ISearchQuery
 	 */
-	private function transformQuery(Query $query) {
+	private function transformQuery(Query $query): ISearchQuery {
 		// TODO offset
 		$limit = $query->limit;
 		$orders = array_map([$this, 'mapSearchOrder'], $query->orderBy);
-		return new SearchQuery($this->transformSearchOperation($query->where), (int)$limit->maxResults, 0, $orders, $this->user);
+
+		$limitHome = false;
+		$ownerProp = $this->extractWhereValue($query->where, FilesPlugin::OWNER_ID_PROPERTYNAME, Operator::OPERATION_EQUAL);
+		if ($ownerProp !== null) {
+			if ($ownerProp === $this->user->getUID()) {
+				$limitHome = true;
+			} else {
+				throw new \InvalidArgumentException("Invalid search value for '{http://owncloud.org/ns}owner-id', only the current user id is allowed");
+			}
+		}
+
+		return new SearchQuery(
+			$this->transformSearchOperation($query->where),
+			(int)$limit->maxResults,
+			0,
+			$orders,
+			$this->user,
+			$limitHome
+		);
 	}
 
 	/**
@@ -358,6 +378,54 @@ class FileSearchBackend implements ISearchBackend {
 				return ($date instanceof \DateTime && $date->getTimestamp() !== false) ? $date->getTimestamp() : 0;
 			default:
 				return $value;
+		}
+	}
+
+	/**
+	 * Get a specific property from the were clause
+	 */
+	private function extractWhereValue(Operator &$operator, string $propertyName, string $comparison, bool $acceptableLocation = true): ?string {
+		switch ($operator->type) {
+			case Operator::OPERATION_AND:
+			case Operator::OPERATION_OR:
+			case Operator::OPERATION_NOT:
+				foreach ($operator->arguments as &$argument) {
+					$value = $this->extractWhereValue($argument, $propertyName, $comparison, $acceptableLocation && $operator->type === Operator::OPERATION_AND);
+					if ($value !== null) {
+						return $value;
+					}
+				}
+				return null;
+			case Operator::OPERATION_EQUAL:
+			case Operator::OPERATION_GREATER_OR_EQUAL_THAN:
+			case Operator::OPERATION_GREATER_THAN:
+			case Operator::OPERATION_LESS_OR_EQUAL_THAN:
+			case Operator::OPERATION_LESS_THAN:
+			case Operator::OPERATION_IS_LIKE:
+				if ($operator->arguments[0]->name === $propertyName) {
+					if ($operator->type === $comparison) {
+						if ($acceptableLocation) {
+							if ($operator->arguments[1] instanceof Literal) {
+								$value = $operator->arguments[1]->value;
+
+								// to remove the comparison from the query, we replace it with an empty AND
+								$operator = new Operator(Operator::OPERATION_AND);
+
+								return $value;
+							} else {
+								throw new \InvalidArgumentException("searching by '$propertyName' is only allowed with a literal value");
+							}
+						} else{
+							throw new \InvalidArgumentException("searching by '$propertyName' is not allowed inside a '{DAV:}or' or '{DAV:}not'");
+						}
+					} else {
+						throw new \InvalidArgumentException("searching by '$propertyName' is only allowed inside a '$comparison'");
+					}
+				} else {
+					return null;
+				}
+			default:
+				return null;
 		}
 	}
 }

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -793,7 +793,10 @@ class Cache implements ICache {
 				->andWhere($builder->expr()->eq('tag.uid', $builder->createNamedParameter($searchQuery->getUser()->getUID())));
 		}
 
-		$query->andWhere($this->querySearchHelper->searchOperatorToDBExpr($builder, $searchQuery->getSearchOperation()));
+		$searchExpr = $this->querySearchHelper->searchOperatorToDBExpr($builder, $searchQuery->getSearchOperation());
+		if ($searchExpr) {
+			$query->andWhere($searchExpr);
+		}
 
 		$this->querySearchHelper->addSearchOrdersToQuery($query, $searchQuery->getOrder());
 

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -88,14 +88,18 @@ class QuerySearchHelper {
 	 * @param ISearchOperator $operator
 	 */
 	public function searchOperatorArrayToDBExprArray(IQueryBuilder $builder, array $operators) {
-		return array_map(function ($operator) use ($builder) {
+		return array_filter(array_map(function ($operator) use ($builder) {
 			return $this->searchOperatorToDBExpr($builder, $operator);
-		}, $operators);
+		}, $operators));
 	}
 
 	public function searchOperatorToDBExpr(IQueryBuilder $builder, ISearchOperator $operator) {
 		$expr = $builder->expr();
 		if ($operator instanceof ISearchBinaryOperator) {
+			if (count($operator->getArguments()) === 0) {
+				return null;
+			}
+
 			switch ($operator->getType()) {
 				case ISearchBinaryOperator::OPERATOR_NOT:
 					$negativeOperator = $operator->getArguments()[0];
@@ -120,6 +124,11 @@ class QuerySearchHelper {
 
 	private function searchComparisonToDBExpr(IQueryBuilder $builder, ISearchComparison $comparison, array $operatorMap) {
 		$this->validateComparison($comparison);
+
+		// "owner" search is done by limiting the storages queries and should not be put in the sql
+		if ($comparison->getField() === 'owner') {
+			return null;
+		}
 
 		list($field, $value, $type) = $this->getOperatorFieldAndValue($comparison);
 		if (isset($operatorMap[$type])) {

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -125,11 +125,6 @@ class QuerySearchHelper {
 	private function searchComparisonToDBExpr(IQueryBuilder $builder, ISearchComparison $comparison, array $operatorMap) {
 		$this->validateComparison($comparison);
 
-		// "owner" search is done by limiting the storages queries and should not be put in the sql
-		if ($comparison->getField() === 'owner') {
-			return null;
-		}
-
 		list($field, $value, $type) = $this->getOperatorFieldAndValue($comparison);
 		if (isset($operatorMap[$type])) {
 			$queryOperator = $operatorMap[$type];

--- a/lib/private/Files/Search/SearchQuery.php
+++ b/lib/private/Files/Search/SearchQuery.php
@@ -39,6 +39,7 @@ class SearchQuery implements ISearchQuery {
 	private $order;
 	/** @var IUser */
 	private $user;
+	private $limitToHome;
 
 	/**
 	 * SearchQuery constructor.
@@ -48,13 +49,22 @@ class SearchQuery implements ISearchQuery {
 	 * @param int $offset
 	 * @param array $order
 	 * @param IUser $user
+	 * @param bool $limitToHome
 	 */
-	public function __construct(ISearchOperator $searchOperation, $limit, $offset, array $order, IUser $user) {
+	public function __construct(
+		ISearchOperator $searchOperation,
+		int $limit,
+		int $offset,
+		array $order,
+		IUser $user,
+		bool $limitToHome = false
+	) {
 		$this->searchOperation = $searchOperation;
 		$this->limit = $limit;
 		$this->offset = $offset;
 		$this->order = $order;
 		$this->user = $user;
+		$this->limitToHome = $limitToHome;
 	}
 
 	/**
@@ -90,5 +100,9 @@ class SearchQuery implements ISearchQuery {
 	 */
 	public function getUser() {
 		return $this->user;
+	}
+
+	public function limitToHome(): bool {
+		return $this->limitToHome;
 	}
 }

--- a/lib/public/Files/Search/ISearchQuery.php
+++ b/lib/public/Files/Search/ISearchQuery.php
@@ -66,4 +66,11 @@ interface ISearchQuery {
 	 * @since 12.0.0
 	 */
 	public function getUser();
+
+	/**
+	 * Whether or not the search should be limited to the users home storage
+	 *
+	 * @return bool
+	 */
+	public function limitToHome(): bool;
 }

--- a/lib/public/Files/Search/ISearchQuery.php
+++ b/lib/public/Files/Search/ISearchQuery.php
@@ -71,6 +71,7 @@ interface ISearchQuery {
 	 * Whether or not the search should be limited to the users home storage
 	 *
 	 * @return bool
+	 * @since 18.0.0
 	 */
 	public function limitToHome(): bool;
 }


### PR DESCRIPTION
This is done by adding a

```xml
<d:eq>
    <d:prop>
        <oc:owner-id/>
    </d:prop>
    <d:literal>$userId</d:literal>
</d:eq>
```

clause to the search query.

Searching by `owner-id` can only be done with the current user id
and the comparison can not be inside a `<d:not>` or `<d:or>` statement

Signed-off-by: Robin Appelman <robin@icewind.nl>