### PR TITLE
pass through ServerNotAvailableException on app init

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -55,6 +55,7 @@ use OC\App\Platform;
 use OC\DB\MigrationService;
 use OC\Installer;
 use OC\Repair;
+use OC\ServerNotAvailableException;
 use OCP\App\ManagerEvent;
 use OCP\ILogger;
 
@@ -153,6 +154,9 @@ class OC_App {
 			try {
 				self::requireAppFile($app);
 			} catch (Throwable $ex) {
+				if($ex instanceof ServerNotAvailableException) {
+					throw $ex;
+				}
 				\OC::$server->getLogger()->logException($ex);
 				if (!\OC::$server->getAppManager()->isShipped($app)) {
 					// Only disable apps which are not shipped


### PR DESCRIPTION
it is safe to assume it is not the app's fault, so it should not be disabled