### PR TITLE
Make isXXX available for bool properties only

### DIFF
--- a/lib/public/AppFramework/Db/Entity.php
+++ b/lib/public/AppFramework/Db/Entity.php
@@ -87,7 +87,7 @@ abstract class Entity {
 		return $this->_fieldTypes;
 	}
 
-	
+
 	/**
 	 * Marks the entity as clean needed for setting the id after the insertion
 	 * @since 7.0.0
@@ -115,7 +115,7 @@ abstract class Entity {
 			$this->$name = $args[0];
 
 		} else {
-			throw new \BadFunctionCallException($name . 
+			throw new \BadFunctionCallException($name .
 				' is not a valid attribute');
 		}
 	}
@@ -129,7 +129,7 @@ abstract class Entity {
 		if(property_exists($this, $name)){
 			return $this->$name;
 		} else {
-			throw new \BadFunctionCallException($name . 
+			throw new \BadFunctionCallException($name .
 				' is not a valid attribute');
 		}
 	}
@@ -137,7 +137,7 @@ abstract class Entity {
 
 	/**
 	 * Each time a setter is called, push the part after set
-	 * into an array: for instance setId will save Id in the 
+	 * into an array: for instance setId will save Id in the
 	 * updated fields array so it can be easily used to create the
 	 * getter method
 	 * @since 7.0.0
@@ -147,7 +147,7 @@ abstract class Entity {
 			$this->setter(lcfirst(substr($methodName, 3)), $args);
 		} elseif (strpos($methodName, 'get') === 0) {
 			return $this->getter(lcfirst(substr($methodName, 3)));
-		} elseif (strpos($methodName, 'is') === 0) {
+		} elseif ($this->isGetterForBoolProperty($methodName)) {
 			return $this->getter(lcfirst(substr($methodName, 2)));
 		} else {
 			throw new \BadFunctionCallException($methodName .
@@ -156,6 +156,18 @@ abstract class Entity {
 
 	}
 
+	/**
+	 * @param string $methodName
+	 * @return bool
+	 * @since 18.0.0
+	 */
+	protected function isGetterForBoolProperty(string $methodName): bool {
+		if (strpos($methodName, 'is') === 0) {
+			$fieldName = lcfirst(substr($methodName, 2));
+			return isset($this->_fieldTypes[$fieldName]) && strpos($this->_fieldTypes[$fieldName], 'bool') === 0;
+		}
+		return false;
+	}
 
 	/**
 	 * Mark am attribute as updated
@@ -168,7 +180,7 @@ abstract class Entity {
 
 
 	/**
-	 * Transform a database columnname to a property 
+	 * Transform a database columnname to a property
 	 * @param string $columnName the name of the column
 	 * @return string the property name
 	 * @since 7.0.0

--- a/tests/lib/AppFramework/Db/EntityTest.php
+++ b/tests/lib/AppFramework/Db/EntityTest.php
@@ -25,6 +25,7 @@ namespace Test\AppFramework\Db;
 
 
 use OCP\AppFramework\Db\Entity;
+use PHPUnit\Framework\Constraint\IsType;
 
 
 /**
@@ -38,18 +39,28 @@ use OCP\AppFramework\Db\Entity;
  * @method void setEmail(string $email)
  * @method string getPreName()
  * @method void setPreName(string $preName)
+ * @method bool getTrueOrFalse()
+ * @method bool isTrueOrFalse()
+ * @method void setTrueOrFalse(bool $trueOrFalse)
+ * @method bool getAnotherBool()
+ * @method bool isAnotherBool()
+ * @method void setAnotherBool(bool $anotherBool)
  */
 class TestEntity extends Entity {
 	protected $name;
 	protected $email;
 	protected $testId;
 	protected $preName;
+	protected $trueOrFalse;
+	protected $anotherBool;
 
-	public function __construct($name=null){
+	public function __construct($name = null) {
 		$this->addType('testId', 'integer');
+		$this->addType('trueOrFalse', 'bool');
+		$this->addType('anotherBool', 'boolean');
 		$this->name = $name;
 	}
-};
+}
 
 
 class EntityTest extends \Test\TestCase {
@@ -73,7 +84,7 @@ class EntityTest extends \Test\TestCase {
 
 	public function testFromRow(){
 		$row = array(
-			'pre_name' => 'john', 
+			'pre_name' => 'john',
 			'email' => 'john@something.com'
 		);
 		$this->entity = TestEntity::fromRow($row);
@@ -93,21 +104,21 @@ class EntityTest extends \Test\TestCase {
 
 	public function testColumnToPropertyNoReplacement(){
 		$column = 'my';
-		$this->assertEquals('my', 
+		$this->assertEquals('my',
 			$this->entity->columnToProperty($column));
 	}
 
 
 	public function testColumnToProperty(){
 		$column = 'my_attribute';
-		$this->assertEquals('myAttribute', 
+		$this->assertEquals('myAttribute',
 			$this->entity->columnToProperty($column));
 	}
 
 
 	public function testPropertyToColumnNoReplacement(){
 		$property = 'my';
-		$this->assertEquals('my', 
+		$this->assertEquals('my',
 			$this->entity->propertyToColumn($property));
 	}
 
@@ -137,7 +148,6 @@ class EntityTest extends \Test\TestCase {
 	/**
 	 * @expectedException \BadFunctionCallException
 	 */
-
 	public function testSetterShouldFailIfAttributeNotDefined(){
 		$this->entity->setTest();
 	}
@@ -208,7 +218,9 @@ class EntityTest extends \Test\TestCase {
 		$entity = new TestEntity();
 		$this->assertEquals(array(
 			'id' => 'integer',
-			'testId' => 'integer'
+			'testId' => 'integer',
+			'trueOrFalse' => 'bool',
+			'anotherBool' => 'boolean',
 		), $entity->getFieldTypes());
 	}
 
@@ -226,5 +238,20 @@ class EntityTest extends \Test\TestCase {
 		$this->assertEquals(0, count($entity->getUpdatedFields()));
 	}
 
+	public function testIsGetter() {
+		$entity = new TestEntity();
+		$entity->setTrueOrFalse(false);
+		$entity->setAnotherBool(false);
+		$this->assertThat($entity->isTrueOrFalse(), new IsType(IsType::TYPE_BOOL));
+		$this->assertThat($entity->isAnotherBool(), new IsType(IsType::TYPE_BOOL));
+	}
 
+	/**
+	 * @expectedException BadFunctionCallException
+	 */
+	public function testIsGetterShoudFailForOtherType() {
+		$entity = new TestEntity();
+		$entity->setName('hello');
+		$this->assertThat($entity->isName(), new IsType(IsType::TYPE_BOOL));
+	}
 }


### PR DESCRIPTION
I'm not sure about this one. Probably not necessary but without isXXX is just an alias for getXXX. I fail somehow to revert the whitespace changes :confused: 