### PR TITLE
HTTPS link to https://en.wikipedia.org/wiki/Server-sent_events

### DIFF
--- a/lib/private/legacy/eventsource.php
+++ b/lib/private/legacy/eventsource.php
@@ -27,7 +27,7 @@
  */
 
 /**
- * wrapper for server side events (http://en.wikipedia.org/wiki/Server-sent_events)
+ * wrapper for server side events (https://en.wikipedia.org/wiki/Server-sent_events)
  * includes a fallback for older browsers and IE
  *
  * use server side events with caution, to many open requests can hang the server


### PR DESCRIPTION
prevents a redirect