### PR TITLE
Return back theme config after web upgrade

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -401,6 +401,7 @@ class OC {
 		}
 		$tmpl->assign('oldTheme', $oldTheme);
 		$tmpl->printPage();
+		$systemConfig->setValue('theme', $oldTheme);
 	}
 
 	public static function initSession() {

--- a/lib/base.php
+++ b/lib/base.php
@@ -365,6 +365,7 @@ class OC {
 
 		$oldTheme = $systemConfig->getValue('theme');
 		$systemConfig->setValue('theme', '');
+		$systemConfig->setValue('old_theme', $oldTheme);
 		OC_Util::addScript('update');
 
 		/** @var \OC\App\AppManager $appManager */
@@ -401,7 +402,6 @@ class OC {
 		}
 		$tmpl->assign('oldTheme', $oldTheme);
 		$tmpl->printPage();
-		$systemConfig->setValue('theme', $oldTheme);
 	}
 
 	public static function initSession() {

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -156,6 +156,11 @@ class Updater extends BasicEmitter {
 		$this->config->setSystemValue('loglevel', $logLevel);
 		$this->config->setSystemValue('installed', true);
 
+		if ($oldTheme = $this->config->getSystemValue('old_theme')) {
+			$this->config->setSystemValue('theme', $oldTheme);
+			$this->config->deleteSystemValue('old_theme');
+		}
+
 		return $success;
 	}
 


### PR DESCRIPTION
It is very annoying to go on server and edit `config.php` after web upgrade. 
Is not web upgrade should prevent "go on server" ?

Close https://github.com/nextcloud/server/issues/2785