### PR TITLE
Use the displayname for federated notifications

### DIFF
--- a/apps/federatedfilesharing/lib/ocm/CloudFederationProviderFiles.php
+++ b/apps/federatedfilesharing/lib/ocm/CloudFederationProviderFiles.php
@@ -245,7 +245,7 @@ class CloudFederationProviderFiles implements ICloudFederationProvider {
 						->setAffectedUser($shareWith)
 						->setObject('remote_share', (int)$shareId, $name);
 					\OC::$server->getActivityManager()->publish($event);
-					$this->notifyAboutNewShare($shareWith, $shareId, $ownerFederatedId, $sharedByFederatedId, $name);
+					$this->notifyAboutNewShare($shareWith, $shareId, $ownerFederatedId, $sharedByFederatedId, $name, $sharedBy, $owner);
 				} else {
 					$groupMembers = $this->groupManager->get($shareWith)->getUsers();
 					foreach ($groupMembers as $user) {
@@ -256,7 +256,7 @@ class CloudFederationProviderFiles implements ICloudFederationProvider {
 							->setAffectedUser($user->getUID())
 							->setObject('remote_share', (int)$shareId, $name);
 						\OC::$server->getActivityManager()->publish($event);
-						$this->notifyAboutNewShare($user->getUID(), $shareId, $ownerFederatedId, $sharedByFederatedId, $name);
+						$this->notifyAboutNewShare($user->getUID(), $shareId, $ownerFederatedId, $sharedByFederatedId, $name, $sharedBy, $owner);
 					}
 				}
 				return $shareId;
@@ -333,13 +333,13 @@ class CloudFederationProviderFiles implements ICloudFederationProvider {
 	 * @param $sharedByFederatedId
 	 * @param $name
 	 */
-	private function notifyAboutNewShare($shareWith, $shareId, $ownerFederatedId, $sharedByFederatedId, $name) {
+	private function notifyAboutNewShare($shareWith, $shareId, $ownerFederatedId, $sharedByFederatedId, $name, $sharedBy, $owner) {
 		$notification = $this->notificationManager->createNotification();
 		$notification->setApp('files_sharing')
 			->setUser($shareWith)
 			->setDateTime(new \DateTime())
 			->setObject('remote_share', $shareId)
-			->setSubject('remote_share', [$ownerFederatedId, $sharedByFederatedId, trim($name, '/')]);
+			->setSubject('remote_share', [$ownerFederatedId, $sharedByFederatedId, trim($name, '/'), $sharedBy, $owner]);
 
 		$declineAction = $notification->createAction();
 		$declineAction->setLabel('decline')


### PR DESCRIPTION
Since we have the showing this is a lot nicer.
Especially on alrge isntances where the uid can be totally random.


Before:

![before](https://user-images.githubusercontent.com/45821/69058797-a4e02c80-0a14-11ea-9adb-83ff19adb3fd.png)

After:

![after](https://user-images.githubusercontent.com/45821/69058877-c6411880-0a14-11ea-900d-5fb7246fa46c.png)

TODO:
- [X] Pimp notifications https://github.com/nextcloud/notifications/pull/476

With notification PR now:

![after2](https://user-images.githubusercontent.com/45821/69059847-a1e63b80-0a16-11ea-8148-dc3e692f2147.png)


