### PR TITLE
Remove whitespace above file list ref #17891

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -61,6 +61,7 @@ Nextcloud is written by:
  - Derek <derek.kelly27@gmail.com>
  - Dominik Schmidt <dev@dominik-schmidt.de>
  - Donquixote <marjunebatac@gmail.com>
+ - Fabian Dreßler <nudelsalat@clouz.de>
  - Fabian Henze <flyser42@gmx.de>
  - Fabrizio Steiner <fabrizio.steiner@gmail.com>
  - Felix A. Epp <work@felixepp.de>

--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -1,6 +1,10 @@
-/* Copyright (c) 2011, Jan-Christoph Borchardt, http://jancborchardt.net
- This file is licensed under the Affero General Public License version 3 or later.
- See the COPYING-README file. */
+/**
+ * Copyright (c) 2011, Jan-Christoph Borchardt, http://jancborchardt.net
+ * @copyright Copyright (c) 2019, Fabian Dreßler <nudelsalat@clouz.de>
+ *
+ * This file is licensed under the Affero General Public License version 3 or later.
+ * See the COPYING-README file. 
+ */
 
 /* SETTINGS */
 #files-setting-showhidden {
@@ -74,8 +78,8 @@
 			position: -webkit-sticky;
 			position: sticky;
 			// header + breadcrumbs
-			top: $header-height;
-			padding-top: 40px;
+			// 44px coming from #controls in core/css/styles.scss
+			top: $header-height + 44px;
 			// under breadcrumbs, over file list
 			z-index: 55;
 			display: block;


### PR DESCRIPTION
This reverts #16366 and fixes #17891

Result:
![padding-filelist](https://user-images.githubusercontent.com/12748782/69070992-70c33680-0a29-11ea-9968-8c45241b8bff.png)

Signed-off-by: Fabian Dreßler <nudelsalat@clouz.de>