### PR TITLE
Get first element of nodes array

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -181,7 +181,7 @@ class ShareAPIController extends OCSController {
 					throw new NotFoundException();
 				}
 			} else {
-				$node = $nodes[0];
+				$node = reset($nodes);
 			}
 		}
 


### PR DESCRIPTION
Geting first element of nodes array instead of element with key 0. In some cases key 0 not exists in this array ie. when file is shared from group folder with member of this group who have no permission to read this file.