### PR TITLE
Fix Symfony event dispatcher dispatch call

### DIFF
--- a/lib/private/EventDispatcher/SymfonyAdapter.php
+++ b/lib/private/EventDispatcher/SymfonyAdapter.php
@@ -64,7 +64,7 @@ class SymfonyAdapter implements EventDispatcherInterface {
 				'Deprecated event type for {name}: {class}',
 				[ 'name' => $eventName, 'class' => is_object($event) ? get_class($event) : 'null' ]
 			);
-			$this->eventDispatcher->getSymfonyDispatcher()->dispatch($eventName, $event);
+			$this->eventDispatcher->getSymfonyDispatcher()->dispatch($event, $eventName);
 		}
 	}
 


### PR DESCRIPTION
Then we can use `EventDispatcherInterface` (that proxies through our adapter when used via DI) just like before but still satisfy Symfony's new dispatch argument order.