### PR TITLE
Accept incoming shares in integration tests

### DIFF
--- a/build/integration/features/bootstrap/Sharing.php
+++ b/build/integration/features/bootstrap/Sharing.php
@@ -112,6 +112,39 @@ trait Sharing {
 	}
 
 	/**
+	 * @When /^accepting last share$/
+	 */
+	public function acceptingLastShare() {
+		$share_id = $this->lastShareData->data[0]->id;
+		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/pending/$share_id";
+		$this->sendingToWith("POST", $url, null);
+
+		$this->theHTTPStatusCodeShouldBe('200');
+	}
+
+	/**
+	 * @When /^user "([^"]*)" accepts last share$/
+	 *
+	 * @param string $user
+	 */
+	public function userAcceptsLastShare(string $user) {
+		// "As userXXX" and "user userXXX accepts last share" steps are not
+		// expected to be used in the same scenario, but restore the user just
+		// in case.
+		$previousUser = $this->currentUser;
+
+		$this->currentUser = $user;
+
+		$share_id = $this->lastShareData->data[0]->id;
+		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/pending/$share_id";
+		$this->sendingToWith("POST", $url, null);
+
+		$this->currentUser = $previousUser;
+
+		$this->theHTTPStatusCodeShouldBe('200');
+	}
+
+	/**
 	 * @Then /^Public shared file "([^"]*)" can be downloaded$/
 	 */
 	public function checkPublicSharedFile($filename) {

--- a/build/integration/features/comments-search.feature
+++ b/build/integration/features/comments-search.feature
@@ -20,7 +20,7 @@ Feature: comments-search
     Given user "user0" exists
     And user "user1" exists
     And User "user1" uploads file "data/textfile.txt" to "/sharedFileToComment.txt"
-    And As "user1" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    And as "user1" creating a share with
       | path | sharedFileToComment.txt |
       | shareWith | user0 |
       | shareType | 0 |
@@ -41,7 +41,7 @@ Feature: comments-search
     Given user "user0" exists
     And user "user1" exists
     And User "user0" uploads file "data/textfile.txt" to "/mySharedFileToComment.txt"
-    And As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    And as "user0" creating a share with
       | path | mySharedFileToComment.txt |
       | shareWith | user1 |
       | shareType | 0 |
@@ -62,7 +62,7 @@ Feature: comments-search
     Given user "user0" exists
     And user "user1" exists
     And User "user1" uploads file "data/textfile.txt" to "/sharedFileToComment.txt"
-    And As "user1" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    And as "user1" creating a share with
       | path | sharedFileToComment.txt |
       | shareWith | user0 |
       | shareType | 0 |
@@ -175,12 +175,12 @@ Feature: comments-search
     And user "user1" exists
     And User "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
     And User "user0" uploads file "data/textfile.txt" to "/mySharedFileToComment.txt"
-    And As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    And as "user0" creating a share with
       | path | mySharedFileToComment.txt |
       | shareWith | user1 |
       | shareType | 0 |
     And User "user1" uploads file "data/textfile.txt" to "/sharedFileToComment.txt"
-    And As "user1" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    And as "user1" creating a share with
       | path | sharedFileToComment.txt |
       | shareWith | user0 |
       | shareType | 0 |

--- a/build/integration/features/comments-search.feature
+++ b/build/integration/features/comments-search.feature
@@ -24,6 +24,7 @@ Feature: comments-search
       | path | sharedFileToComment.txt |
       | shareWith | user0 |
       | shareType | 0 |
+    And user "user0" accepts last share
     And "user0" posts a comment with content "My first comment" on the file named "/sharedFileToComment.txt" it should return "201"
     When Logging in using web as "user0"
     And searching for "first" in app "files"
@@ -45,6 +46,7 @@ Feature: comments-search
       | path | mySharedFileToComment.txt |
       | shareWith | user1 |
       | shareType | 0 |
+    And user "user1" accepts last share
     And "user1" posts a comment with content "Other's first comment" on the file named "/mySharedFileToComment.txt" it should return "201"
     When Logging in using web as "user0"
     And searching for "first" in app "files"
@@ -66,6 +68,7 @@ Feature: comments-search
       | path | sharedFileToComment.txt |
       | shareWith | user0 |
       | shareType | 0 |
+    And user "user0" accepts last share
     And "user1" posts a comment with content "Other's first comment" on the file named "/sharedFileToComment.txt" it should return "201"
     When Logging in using web as "user0"
     And searching for "first" in app "files"
@@ -179,11 +182,13 @@ Feature: comments-search
       | path | mySharedFileToComment.txt |
       | shareWith | user1 |
       | shareType | 0 |
+    And user "user1" accepts last share
     And User "user1" uploads file "data/textfile.txt" to "/sharedFileToComment.txt"
     And as "user1" creating a share with
       | path | sharedFileToComment.txt |
       | shareWith | user0 |
       | shareType | 0 |
+    And user "user0" accepts last share
     And "user0" posts a comment with content "My first comment to be found" on the file named "/myFileToComment.txt" it should return "201"
     And "user0" posts a comment with content "The second comment should not be found" on the file named "/myFileToComment.txt" it should return "201"
     And "user0" posts a comment with content "My first comment to be found" on the file named "/mySharedFileToComment.txt" it should return "201"

--- a/build/integration/features/comments.feature
+++ b/build/integration/features/comments.feature
@@ -18,7 +18,7 @@ Feature: comments
     Given user "user0" exists
     Given user "12345" exists
     Given User "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToComment.txt |
       | shareWith | 12345 |
       | shareType | 0 |
@@ -68,7 +68,7 @@ Feature: comments
     Given user "user1" exists
     Given As an "user0"
     Given User "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToComment.txt |
       | shareWith | user1 |
       | shareType | 0 |
@@ -90,7 +90,7 @@ Feature: comments
     Given user "user0" exists
     Given user "user1" exists
     Given User "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToComment.txt |
       | shareWith | user1 |
       | shareType | 0 |
@@ -135,7 +135,7 @@ Feature: comments
     Given user "user0" exists
     Given user "user1" exists
     Given User "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToComment.txt |
       | shareWith | user1 |
       | shareType | 0 |
@@ -163,7 +163,7 @@ Feature: comments
     Given user "user0" exists
     Given user "user1" exists
     Given User "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToComment.txt |
       | shareWith | user1 |
       | shareType | 0 |
@@ -192,7 +192,7 @@ Feature: comments
     Given user "user0" exists
     Given user "user1" exists
     Given User "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToComment.txt |
       | shareWith | user1 |
       | shareType | 0 |

--- a/build/integration/features/comments.feature
+++ b/build/integration/features/comments.feature
@@ -22,6 +22,7 @@ Feature: comments
       | path | myFileToComment.txt |
       | shareWith | 12345 |
       | shareType | 0 |
+    Given user "12345" accepts last share
     When "12345" posts a comment with content "A comment from another user" on the file named "/myFileToComment.txt" it should return "201"
     Then As "12345" load all the comments of the file named "/myFileToComment.txt" it should return "207"
     And the response should contain a property "oc:parentId" with value "0"
@@ -72,6 +73,7 @@ Feature: comments
       | path | myFileToComment.txt |
       | shareWith | user1 |
       | shareType | 0 |
+    And user "user1" accepts last share
     Given "user1" posts a comment with content "My first comment" on the file named "/myFileToComment.txt" it should return "201"
     When As "user1" load all the comments of the file named "/myFileToComment.txt" it should return "207"
     Then the response should contain a property "oc:parentId" with value "0"
@@ -94,6 +96,7 @@ Feature: comments
       | path | myFileToComment.txt |
       | shareWith | user1 |
       | shareType | 0 |
+    And user "user1" accepts last share
     Given "user1" posts a comment with content "My first comment" on the file named "/myFileToComment.txt" it should return "201"
     When As "user1" load all the comments of the file named "/myFileToComment.txt" it should return "207"
     Then the response should contain a property "oc:parentId" with value "0"
@@ -139,6 +142,7 @@ Feature: comments
       | path | myFileToComment.txt |
       | shareWith | user1 |
       | shareType | 0 |
+    And user "user1" accepts last share
     Given "user1" posts a comment with content "My first comment" on the file named "/myFileToComment.txt" it should return "201"
     When As "user0" load all the comments of the file named "/myFileToComment.txt" it should return "207"
     Then the response should contain a property "oc:parentId" with value "0"
@@ -167,6 +171,7 @@ Feature: comments
       | path | myFileToComment.txt |
       | shareWith | user1 |
       | shareType | 0 |
+    And user "user1" accepts last share
     When "user1" posts a comment with content "My first comment" on the file named "/myFileToComment.txt" it should return "201"
     Then As "user0" load all the comments of the file named "/myFileToComment.txt" it should return "207"
     And the response should contain a property "oc:parentId" with value "0"
@@ -196,6 +201,7 @@ Feature: comments
       | path | myFileToComment.txt |
       | shareWith | user1 |
       | shareType | 0 |
+    And user "user1" accepts last share
     Given "user1" posts a comment with content "My first comment" on the file named "/myFileToComment.txt" it should return "201"
     When As "user0" load all the comments of the file named "/myFileToComment.txt" it should return "207"
     Then the response should contain a property "oc:parentId" with value "0"

--- a/build/integration/features/dav-v2.feature
+++ b/build/integration/features/dav-v2.feature
@@ -77,6 +77,7 @@ Feature: dav-v2
 		  | shareType | 0 |
 		  | permissions | 31 |
 		  | shareWith | user0 |
+        And user "user0" accepts last share
 		And As an "user0"
 		When User "user0" uploads file "data/textfile.txt" to "/testquota/asdf.txt"
 		Then the HTTP status code should be "201"

--- a/build/integration/features/external-storage.feature
+++ b/build/integration/features/external-storage.feature
@@ -12,6 +12,7 @@ Feature: external-storage
     And User "user0" moved file "/textfile0.txt" to "/local_storage/foo/textfile0.txt"
     And folder "/local_storage/foo" of user "user0" is shared with user "user1"
     And As an "user1"
+    And accepting last share
     When creating a share with
       | path | foo |
       | shareType | 3 |

--- a/build/integration/features/favorites.feature
+++ b/build/integration/features/favorites.feature
@@ -142,6 +142,7 @@ Feature: favorite
         And user "user0" created a folder "/shared"
         And User "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
         And folder "/shared" of user "user0" is shared with user "user1"
+        And user "user1" accepts last share
         And user "user1" favorites element "/shared/shared_file.txt"
         When User "user1" moved file "/shared/shared_file.txt" to "/taken_out.txt"
         Then user "user1" in folder "/" should have favorited the following elements

--- a/build/integration/features/tags.feature
+++ b/build/integration/features/tags.feature
@@ -117,7 +117,7 @@ Feature: tags
     Given user "12345" exists
     Given "admin" creates a "normal" tag with name "MySuperAwesomeTagName"
     Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | 12345 |
       | shareType | 0 |
@@ -144,7 +144,7 @@ Feature: tags
     Given "admin" creates a "normal" tag with name "MyFirstTag"
     Given "admin" creates a "not user-assignable" tag with name "MySecondTag"
     Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
@@ -161,7 +161,7 @@ Feature: tags
     Given user "user1" belongs to group "group1"
     Given "admin" creates a "not user-assignable" tag with name "MySuperAwesomeTagName" and groups "group1"
     Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
@@ -177,7 +177,7 @@ Feature: tags
     Given "admin" creates a "normal" tag with name "MyFirstTag"
     Given "admin" creates a "not user-visible" tag with name "MySecondTag"
     Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
@@ -192,7 +192,7 @@ Feature: tags
     Given "admin" creates a "normal" tag with name "MyFirstTag"
     Given "admin" creates a "not user-visible" tag with name "MySecondTag"
     Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | admin |
       | shareType | 0 |
@@ -210,7 +210,7 @@ Feature: tags
     Given "admin" creates a "normal" tag with name "MyFirstTag"
     Given "admin" creates a "not user-assignable" tag with name "MySecondTag"
     Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | admin |
       | shareType | 0 |
@@ -230,7 +230,7 @@ Feature: tags
     Given "admin" creates a "normal" tag with name "MyFirstTag"
     Given "admin" creates a "normal" tag with name "MySecondTag"
     Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
@@ -261,11 +261,11 @@ Feature: tags
     Given "admin" creates a "not user-visible" tag with name "MyFirstTag"
     Given "admin" creates a "normal" tag with name "MySecondTag"
     Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | admin |
       | shareType | 0 |
@@ -285,11 +285,11 @@ Feature: tags
     Given "admin" creates a "not user-visible" tag with name "MyFirstTag"
     Given "admin" creates a "normal" tag with name "MySecondTag"
     Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | admin |
       | shareType | 0 |
@@ -308,11 +308,11 @@ Feature: tags
     Given "admin" creates a "not user-visible" tag with name "MyFirstTag"
     Given "admin" creates a "normal" tag with name "MySecondTag"
     Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | admin |
       | shareType | 0 |
@@ -328,11 +328,11 @@ Feature: tags
     Given "admin" creates a "not user-assignable" tag with name "MyFirstTag"
     Given "admin" creates a "normal" tag with name "MySecondTag"
     Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | admin |
       | shareType | 0 |
@@ -353,11 +353,11 @@ Feature: tags
     Given "admin" creates a "not user-assignable" tag with name "MyFirstTag"
     Given "admin" creates a "normal" tag with name "MySecondTag"
     Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | admin |
       | shareType | 0 |
@@ -376,11 +376,11 @@ Feature: tags
     Given "admin" creates a "not user-assignable" tag with name "MyFirstTag"
     Given "admin" creates a "normal" tag with name "MySecondTag"
     Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | admin |
       | shareType | 0 |

--- a/build/integration/features/tags.feature
+++ b/build/integration/features/tags.feature
@@ -121,6 +121,7 @@ Feature: tags
       | path | myFileToTag.txt |
       | shareWith | 12345 |
       | shareType | 0 |
+    Given user "12345" accepts last share
     When "12345" adds the tag "MySuperAwesomeTagName" to "/myFileToTag.txt" shared by "user0"
     Then The response should have a status code "201"
     And "/myFileToTag.txt" shared by "user0" has the following tags
@@ -148,6 +149,7 @@ Feature: tags
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
+    Given user "user1" accepts last share
     When "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     When "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     Then The response should have a status code "403"
@@ -165,6 +167,7 @@ Feature: tags
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
+    Given user "user1" accepts last share
     When "user1" adds the tag "MySuperAwesomeTagName" to "/myFileToTag.txt" shared by "user0"
     Then The response should have a status code "201"
     And "/myFileToTag.txt" shared by "user0" has the following tags
@@ -181,6 +184,7 @@ Feature: tags
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
+    Given user "user1" accepts last share
     When "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     When "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     Then The response should have a status code "412"
@@ -196,6 +200,7 @@ Feature: tags
       | path | myFileToTag.txt |
       | shareWith | admin |
       | shareType | 0 |
+    Given user "admin" accepts last share
     When "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     When "admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     Then The response should have a status code "201"
@@ -214,6 +219,7 @@ Feature: tags
       | path | myFileToTag.txt |
       | shareWith | admin |
       | shareType | 0 |
+    Given user "admin" accepts last share
     When "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     When "admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     Then The response should have a status code "201"
@@ -234,6 +240,7 @@ Feature: tags
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
+    Given user "user1" accepts last share
     Given "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     When "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
@@ -265,10 +272,12 @@ Feature: tags
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
+    Given user "user1" accepts last share
     Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | admin |
       | shareType | 0 |
+    Given user "admin" accepts last share
     Given "admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     When "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
@@ -289,10 +298,12 @@ Feature: tags
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
+    Given user "user1" accepts last share
     Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | admin |
       | shareType | 0 |
+    Given user "admin" accepts last share
     Given "admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     When "admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
@@ -312,10 +323,12 @@ Feature: tags
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
+    Given user "user1" accepts last share
     Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | admin |
       | shareType | 0 |
+    Given user "admin" accepts last share
     Given "admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     Given As "user0" remove all shares from the file named "/myFileToTag.txt"
@@ -332,10 +345,12 @@ Feature: tags
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
+    Given user "user1" accepts last share
     Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | admin |
       | shareType | 0 |
+    Given user "admin" accepts last share
     Given "admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     When "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
@@ -357,10 +372,12 @@ Feature: tags
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
+    Given user "user1" accepts last share
     Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | admin |
       | shareType | 0 |
+    Given user "admin" accepts last share
     Given "admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     When "admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
@@ -380,10 +397,12 @@ Feature: tags
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
+    Given user "user1" accepts last share
     Given as "user0" creating a share with
       | path | myFileToTag.txt |
       | shareWith | admin |
       | shareType | 0 |
+    Given user "admin" accepts last share
     Given "admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     Given As "user0" remove all shares from the file named "/myFileToTag.txt"

--- a/build/integration/features/transfer-ownership.feature
+++ b/build/integration/features/transfer-ownership.feature
@@ -27,6 +27,7 @@ Feature: transfer-ownership
 		And user "user2" exists
 		And User "user0" uploads file "data/textfile.txt" to "/somefile.txt"
 		And file "/somefile.txt" of user "user0" is shared with user "user2" with permissions 19
+		And user "user2" accepts last share
 		When transfering ownership from "user0" to "user1"
 		And the command was successful
 		And As an "user2"
@@ -39,6 +40,7 @@ Feature: transfer-ownership
 		And User "user0" created a folder "/test"
 		And User "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
 		And folder "/test" of user "user0" is shared with user "user2" with permissions 31
+		And user "user2" accepts last share
 		When transfering ownership from "user0" to "user1"
 		And the command was successful
 		And As an "user2"
@@ -50,6 +52,7 @@ Feature: transfer-ownership
 		And User "user0" created a folder "/test"
 		And User "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
 		And folder "/test" of user "user0" is shared with user "user1" with permissions 31
+		And user "user1" accepts last share
 		When transfering ownership from "user0" to "user1"
 		And the command was successful
 		And As an "user1"
@@ -66,7 +69,9 @@ Feature: transfer-ownership
 		And User "user0" created a folder "/test"
 		And User "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
 		And folder "/test" of user "user0" is shared with group "group1" with permissions 31
+		And user "user2" accepts last share
 		And folder "/test" of user "user0" is shared with user "user2" with permissions 31
+		And user "user2" accepts last share
 		When transfering ownership from "user0" to "user1"
 		And the command was successful
 		And As an "user2"
@@ -80,6 +85,7 @@ Feature: transfer-ownership
 		And user "user2" belongs to group "test"
 		And User "user0" uploads file "data/textfile.txt" to "/somefile.txt"
 		And file "/somefile.txt" of user "user0" is shared with group "test"
+		And user "user2" accepts last share
 		When transfering ownership from "user0" to "test"
 		And the command was successful
 		And As an "user2"
@@ -91,6 +97,7 @@ Feature: transfer-ownership
 		And user "user2" exists
 		And User "user2" created a folder "/test"
 		And folder "/test" of user "user2" is shared with user "user0" with permissions 31
+		And user "user0" accepts last share
 		When transfering ownership from "user0" to "user1"
 		And the command was successful
 		And As an "user1"
@@ -114,6 +121,7 @@ Feature: transfer-ownership
 		And User "user0" created a folder "/sub"
 		And User "user0" created a folder "/sub/test"
 		And folder "/sub/test" of user "user0" is shared with user "user2" with permissions 31
+		And user "user2" accepts last share
 		And User "user0" deletes folder "/sub"
 		When transfering ownership from "user0" to "user1"
 		Then the command was successful
@@ -148,6 +156,7 @@ Feature: transfer-ownership
 		And User "user0" created a folder "/test"
 		And User "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
 		And file "/test/somefile.txt" of user "user0" is shared with user "user2" with permissions 19
+		And user "user2" accepts last share
 		When transfering ownership of path "test" from "user0" to "user1"
 		And the command was successful
 		And As an "user2"
@@ -160,6 +169,7 @@ Feature: transfer-ownership
 		And User "user0" created a folder "/test"
 		And User "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
 		And folder "/test" of user "user0" is shared with user "user2" with permissions 31
+		And user "user2" accepts last share
 		When transfering ownership of path "test" from "user0" to "user1"
 		And the command was successful
 		And As an "user2"
@@ -171,6 +181,7 @@ Feature: transfer-ownership
 		And User "user0" created a folder "/test"
 		And User "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
 		And folder "/test" of user "user0" is shared with user "user1" with permissions 31
+		And user "user1" accepts last share
 		When transfering ownership of path "test" from "user0" to "user1"
 		And the command was successful
 		And As an "user1"
@@ -187,7 +198,9 @@ Feature: transfer-ownership
 		And User "user0" created a folder "/test"
 		And User "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
 		And folder "/test" of user "user0" is shared with group "group1" with permissions 31
+		And user "user2" accepts last share
 		And folder "/test" of user "user0" is shared with user "user2" with permissions 31
+		And user "user2" accepts last share
 		When transfering ownership of path "test" from "user0" to "user1"
 		And the command was successful
 		And As an "user2"
@@ -200,6 +213,7 @@ Feature: transfer-ownership
 		And User "user2" created a folder "/test"
 		And User "user0" created a folder "/sub"
 		And folder "/test" of user "user2" is shared with user "user0" with permissions 31
+		And user "user0" accepts last share
 		And User "user0" moved folder "/test" to "/sub/test"
 		When transfering ownership of path "sub" from "user0" to "user1"
 		And the command was successful

--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -48,6 +48,7 @@ Feature: webdav-related
 		  | shareType | 0 |
 		  | permissions | 1 |
 		  | shareWith | user0 |
+		And user "user0" accepts last share
 		And As an "user0"
 		And User "user0" moves file "/textfile0.txt" to "/testshare/textfile0.txt"
 		And the HTTP status code should be "403"
@@ -66,6 +67,7 @@ Feature: webdav-related
 		  | shareType | 0 |
 		  | permissions | 1 |
 		  | shareWith | user0 |
+		And user "user0" accepts last share
 		And User "user1" copies file "/welcome.txt" to "/testshare/overwritethis.txt"
 		And As an "user0"
 		When User "user0" moves file "/textfile0.txt" to "/testshare/overwritethis.txt"
@@ -102,6 +104,7 @@ Feature: webdav-related
 		  | shareType | 0 |
 		  | permissions | 1 |
 		  | shareWith | user0 |
+		And user "user0" accepts last share
 		And As an "user0"
 		When User "user0" copies file "/textfile0.txt" to "/testshare/textfile0.txt"
 		Then the HTTP status code should be "403"
@@ -120,6 +123,7 @@ Feature: webdav-related
 		  | shareType | 0 |
 		  | permissions | 1 |
 		  | shareWith | user0 |
+		And user "user0" accepts last share
 		And User "user1" copies file "/welcome.txt" to "/testshare/overwritethis.txt"
 		And As an "user0"
 		When User "user0" copies file "/textfile0.txt" to "/testshare/overwritethis.txt"
@@ -172,6 +176,7 @@ Feature: webdav-related
 		  | shareType | 0 |
 		  | permissions | 31 |
 		  | shareWith | user0 |
+		And user "user0" accepts last share
 		Then as "user0" gets properties of folder "/testquota" with
 		  |{DAV:}quota-available-bytes|
 		And the single response should contain a property "{DAV:}quota-available-bytes" with value "10485421"
@@ -190,6 +195,7 @@ Feature: webdav-related
 		  | shareType | 0 |
 		  | permissions | 31 |
 		  | shareWith | user0 |
+		And user "user0" accepts last share
 		And As an "user0"
 		When User "user0" uploads file "data/textfile.txt" to "/testquota/asdf.txt"
 		Then the HTTP status code should be "201"
@@ -212,6 +218,7 @@ Feature: webdav-related
 		And user "user1" has a quota of "1 KB"
 		And user "user0" adds a file of 93 bytes to "/user0.txt"
 		And file "user0.txt" of user "user0" is shared with user "user1"
+		And user "user1" accepts last share
 		When as "user1" gets properties of folder "/" with
 		  |{DAV:}quota-available-bytes|
 		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "685"
@@ -425,6 +432,7 @@ Feature: webdav-related
 			| shareType | 0 |
 			| permissions | 31 |
 			| shareWith | user0 |
+		And user "user0" accepts last share
 		And User "user0" uploads file with content "copytest" to "/copytest.txt"
 		When User "user0" copies file "/copytest.txt" to "/testcopypermissionsAllowed/copytest.txt"
 		Then the HTTP status code should be "201"
@@ -440,6 +448,7 @@ Feature: webdav-related
 			| shareType | 0 |
 			| permissions | 1 |
 			| shareWith | user0 |
+		And user "user0" accepts last share
 		And User "user0" uploads file with content "copytest" to "/copytest.txt"
 		When User "user0" copies file "/copytest.txt" to "/testcopypermissionsNotAllowed/copytest.txt"
 		Then the HTTP status code should be "403"
@@ -458,6 +467,7 @@ Feature: webdav-related
 			| shareType   | 0          |
 			| permissions | 23         |
 			| shareWith   | user0      |
+		And user "user0" accepts last share
 		And As an "user0"
 		And User "user0" uploads file "data/textfile.txt" to "/testfolder/asdf.txt"
 		And As an "user1"

--- a/build/integration/sharing_features/sharing-v1-part2.feature
+++ b/build/integration/sharing_features/sharing-v1-part2.feature
@@ -11,6 +11,7 @@ Feature: sharing
     And user "user2" exists
     And user "user3" exists
     And file "textfile0.txt" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And file "textfile0 (2).txt" of user "user1" is shared with user "user2"
     And As an "user0"
     When sending "GET" to "/apps/files_sharing/api/v1/shares?reshares=true&path=textfile0.txt"
@@ -25,6 +26,7 @@ Feature: sharing
     And user "user1" exists
     And user "user2" exists
     And file "textfile0.txt" of user "user1" is shared with user "user0"
+    And user "user0" accepts last share
     And Updating last share with
       | permissions | 1 |
     And file "textfile0.txt" of user "user1" is shared with user "user2"
@@ -49,6 +51,7 @@ Feature: sharing
     And user "user2" exists
     And user "user3" exists
     And file "textfile0.txt" of user "user1" is shared with user "user0"
+    And user "user0" accepts last share
     And save the last share data as "textfile0.txt from user1"
     And file "textfile0 (2).txt" of user "user0" is shared with user "user3"
     And restore the last share data from "textfile0.txt from user1"
@@ -89,8 +92,11 @@ Feature: sharing
     And user "user2" exists
     And user "user3" exists
     And file "textfile0.txt" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And file "textfile0 (2).txt" of user "user1" is shared with user "user2"
+    And user "user2" accepts last share
     And file "textfile0 (2).txt" of user "user2" is shared with user "user3"
+    And user "user3" accepts last share
     And As an "user1"
     When User "user1" deletes file "/textfile0 (2).txt"
     And As an "user3"
@@ -155,6 +161,7 @@ Feature: sharing
       | displayname_owner | user0 |
       | mimetype          | text/plain |
     And As an "user1"
+    And accepting last share
     And Getting info of last share
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -215,6 +222,7 @@ Feature: sharing
     Given user "user0" exists
     And user "user1" exists
     And file "textfile0.txt" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And file "textfile0.txt" of user "user1" is shared with user "user0"
     When As an "user0"
     And sending "GET" to "/apps/files_sharing/api/v1/shares?subfiles=true&path=/"
@@ -259,7 +267,9 @@ Feature: sharing
     And user "user2" exists
     And user "user3" exists
     And file "PARENT" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And file "PARENT (2)/CHILD" of user "user1" is shared with user "user2"
+    And user "user2" accepts last share
     And file "CHILD" of user "user2" is shared with user "user3"
     When As an "user0"
     And sending "GET" to "/apps/files_sharing/api/v1/shares?subfiles=true&path=PARENT"
@@ -299,7 +309,9 @@ Feature: sharing
     And user "user2" exists
     And user "user3" exists
     And file "PARENT" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And file "PARENT (2)/CHILD" of user "user1" is shared with user "user2"
+    And user "user2" accepts last share
     And file "CHILD" of user "user2" is shared with user "user3"
     When As an "user1"
     And sending "GET" to "/apps/files_sharing/api/v1/shares?subfiles=true&path=PARENT (2)"
@@ -340,7 +352,9 @@ Feature: sharing
     And user "user3" exists
     And file "PARENT" of user "user0" is shared with user "user1"
     And save the last share data as "parent folder"
+    And user "user1" accepts last share
     And file "PARENT (2)/CHILD" of user "user1" is shared with user "user2"
+    And user "user2" accepts last share
     And file "CHILD" of user "user2" is shared with user "user3"
     And As an "user0"
     And restore the last share data from "parent folder"
@@ -369,6 +383,7 @@ Feature: sharing
     And user "user1" exists
     And user "user2" exists
     And file "textfile0.txt" of user "user1" is shared with user "user0"
+    And user "user0" accepts last share
     And Updating last share with
       | permissions | 1 |
     And file "textfile0.txt" of user "user1" is shared with user "user2"
@@ -393,7 +408,9 @@ Feature: sharing
     And user "user1" exists
     And user "user2" exists
     And file "textfile0.txt" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And file "textfile0.txt" of user "user1" is shared with user "user0"
+    And user "user0" accepts last share
     And Updating last share with
       | permissions | 1 |
     And file "textfile0.txt" of user "user1" is shared with user "user2"
@@ -432,6 +449,7 @@ Feature: sharing
     And group "group1" exists
     And user "user1" belongs to group "group1"
     And file "textfile0.txt" of user "user0" is shared with group "group1"
+    And user "user1" accepts last share
     And User "user1" moved file "/textfile0 (2).txt" to "/FOLDER/textfile0.txt"
     And As an "user0"
     When Updating last share with
@@ -491,6 +509,7 @@ Feature: sharing
     And user "user1" exists
     And file "textfile0.txt" of user "user0" is shared with user "user1"
     And file "textfile1.txt" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And As an "user1"
     When sending "GET" to "/apps/files_sharing/api/v1/shares?shared_with_me=true&path=textfile1 (2).txt"
     Then the OCS status code should be "100"
@@ -501,6 +520,7 @@ Feature: sharing
     Given user "user0" exists
     And user "user1" exists
     And file "textfile0.txt" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And file "textfile1.txt" of user "user0" is shared with user "user1"
     And As an "user1"
     When sending "GET" to "/apps/files_sharing/api/v1/shares?shared_with_me=true&path=textfile0 (2).txt"
@@ -533,6 +553,7 @@ Feature: sharing
       | shareWith | user1 |
       | permissions | 8 |
     And As an "user1"
+    And accepting last share
     When creating a share with
       | path | /textfile0 (2).txt |
       | shareType | 0 |
@@ -553,6 +574,7 @@ Feature: sharing
       | shareWith | user1 |
       | permissions | 16 |
     And As an "user1"
+    And accepting last share
     When creating a share with
       | path | /textfile0 (2).txt |
       | shareType | 0 |
@@ -573,6 +595,7 @@ Feature: sharing
       | shareWith | user1 |
       | permissions | 16 |
     And As an "user1"
+    And accepting last share
     When creating a share with
       | path | /PARENT (2) |
       | shareType | 0 |
@@ -593,6 +616,7 @@ Feature: sharing
       | shareWith | user1 |
       | permissions | 16 |
     And As an "user1"
+    And accepting last share
     When creating a share with
       | path | /textfile0 (2).txt |
       | shareType | 0 |
@@ -636,6 +660,7 @@ Feature: sharing
     And user "user1" exists
     And user "user2" exists
     And file "textfile0.txt" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And file "textfile0.txt" of user "user0" is shared with user "user2"
     And As an "user1"
     When Getting info of last share
@@ -668,7 +693,9 @@ Feature: sharing
     And group "group0" exists
     And user "user1" belongs to group "group0"
     And file "/PARENT" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     When file "/PARENT/CHILD" of user "user0" is shared with group "group0"
+    And user "user1" accepts last share
     Then user "user1" should see following elements
       | /FOLDER/ |
       | /PARENT/ |
@@ -694,7 +721,10 @@ Feature: sharing
     And user "user0" created a folder "/common"
     And user "user0" created a folder "/common/sub"
     And file "common" of user "user0" is shared with group "group0"
+    And user "user1" accepts last share
+    And user "user2" accepts last share
     And file "textfile0.txt" of user "user1" is shared with user "user2"
+    And user "user2" accepts last share
     And User "user1" moved file "/textfile0.txt" to "/common/textfile0.txt"
     And User "user1" moved file "/common/textfile0.txt" to "/common/sub/textfile0.txt"
     And As an "user2"
@@ -715,7 +745,10 @@ Feature: sharing
     And user "user0" created a folder "/common"
     And user "user0" created a folder "/common/sub"
     And file "common" of user "user0" is shared with group "group0"
+    And user "user1" accepts last share
+    And user "user2" accepts last share
     And file "textfile0.txt" of user "user1" is shared with user "user2"
+    And user "user2" accepts last share
     And User "user1" moved file "/textfile0.txt" to "/common/textfile0.txt"
     And User "user1" moved file "/common/textfile0.txt" to "/common/sub/textfile0.txt"
     And As an "user2"
@@ -731,6 +764,7 @@ Feature: sharing
     And group "group1" exists
     And user "user1" belongs to group "group1"
     And file "textfile0.txt" of user "user0" is shared with group "group1"
+    And user "user1" accepts last share
     And User "user1" moved file "/textfile0 (2).txt" to "/FOLDER/textfile0.txt"
     And As an "user0"
     And Deleting last share
@@ -764,6 +798,7 @@ Feature: sharing
     And user "user1" exists
     And user "user2" exists
     And file "textfile0.txt" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And file "textfile0.txt" of user "user0" is shared with user "user2"
     And As an "user1"
     When Deleting last share
@@ -780,6 +815,8 @@ Feature: sharing
     And user "user2" belongs to group "group"
     And user "user0" created a folder "/TMP"
     And file "TMP" of user "user0" is shared with group "group"
+    And user "user1" accepts last share
+    And user "user2" accepts last share
     And user "user1" created a folder "/myFOLDER"
     And User "user1" moves file "/TMP" to "/myFOLDER/myTMP"
     And user "user2" does not exist
@@ -794,6 +831,7 @@ Feature: sharing
     And user "user1" has a quota of "0"
     And User "user0" moved file "/welcome.txt" to "/myfile.txt"
     And file "myfile.txt" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     When User "user1" uploads file "data/textfile.txt" to "/myfile.txt"
     Then the HTTP status code should be "204"
 
@@ -811,6 +849,7 @@ Feature: sharing
     And user "user2" exists
     And user "user0" created a folder "/TMP"
     And file "TMP" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And file "TMP" of user "user1" is shared with user "user2"
     And As an "user1"
     When Updating last share with
@@ -830,6 +869,7 @@ Feature: sharing
       | shareWith | user1 |
       | permissions | 21 |
     And As an "user1"
+    And accepting last share
     And creating a share with
       | path | /TMP |
       | shareType | 0 |
@@ -853,6 +893,7 @@ Feature: sharing
       | shareWith | user1 |
       | permissions | 21 |
     And As an "user1"
+    And accepting last share
     And creating a share with
       | path | /TMP/SUB |
       | shareType | 0 |

--- a/build/integration/sharing_features/sharing-v1-part3.feature
+++ b/build/integration/sharing_features/sharing-v1-part3.feature
@@ -120,7 +120,7 @@ Feature: sharing
     And user "user1" exists
     And assure user "user0" is disabled
     And As an "user0"
-    When sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    When creating a share with
       | path | welcome.txt |
       | shareWith | user1 |
       | shareType | 0 |
@@ -339,7 +339,7 @@ Feature: sharing
     And user "user0" belongs to group "sharing-group"
     And file "welcome.txt" of user "user0" is shared with group "sharing-group"
     And Deleting last share
-    When sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    When creating a share with
       | path | welcome.txt |
       | shareWith | sharing-group |
       | shareType | 1 |

--- a/build/integration/sharing_features/sharing-v1-part3.feature
+++ b/build/integration/sharing_features/sharing-v1-part3.feature
@@ -143,11 +143,11 @@ Feature: sharing
     And Deleting last share
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And Getting info of last share 
+    And Getting info of last share
     And the OCS status code should be "404"
     And the HTTP status code should be "200"
     And As an "user1"
-    And Getting info of last share 
+    And Getting info of last share
     And the OCS status code should be "404"
     And the HTTP status code should be "200"
 

--- a/build/integration/sharing_features/sharing-v1-part3.feature
+++ b/build/integration/sharing_features/sharing-v1-part3.feature
@@ -10,6 +10,7 @@ Feature: sharing
     And user "user1" exists
     And User "user0" uploads file with content "foo" to "/tmp.txt"
     And file "/tmp.txt" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     When as "user1" gets properties of folder "/tmp.txt" with
       |{http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
@@ -19,6 +20,7 @@ Feature: sharing
     And user "user1" exists
     And User "user0" uploads file with content "foo" to "/tmp.txt"
     And file "tmp.txt" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And As an "user0"
     And Updating last share with
       | permissions | 3 |
@@ -31,6 +33,7 @@ Feature: sharing
     And user "user1" exists
     And User "user0" uploads file with content "foo" to "/tmp.txt"
     And file "tmp.txt" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And As an "user0"
     And Updating last share with
       | permissions | 17 |
@@ -50,6 +53,7 @@ Feature: sharing
     And user "user1" exists
     And user "user0" created a folder "/tmp"
     And file "/tmp" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     When as "user1" gets properties of folder "/tmp" with
       |{http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
@@ -59,6 +63,7 @@ Feature: sharing
     And user "user1" exists
     And user "user0" created a folder "/tmp"
     And file "/tmp" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And As an "user0"
     And Updating last share with
       | permissions | 29 |
@@ -71,6 +76,7 @@ Feature: sharing
     And user "user1" exists
     And user "user0" created a folder "/tmp"
     And file "/tmp" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And As an "user0"
     And Updating last share with
       | permissions | 27 |
@@ -83,6 +89,7 @@ Feature: sharing
     And user "user1" exists
     And user "user0" created a folder "/tmp"
     And file "/tmp" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And As an "user0"
     And Updating last share with
       | permissions | 23 |
@@ -95,6 +102,7 @@ Feature: sharing
     And user "user1" exists
     And user "user0" created a folder "/tmp"
     And file "/tmp" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And As an "user0"
     And Updating last share with
       | permissions | 15 |
@@ -109,7 +117,9 @@ Feature: sharing
     And user "user0" created a folder "/foo"
     And user "user1" created a folder "/foo"
     When file "/foo" of user "user0" is shared with user "user2"
+    And user "user2" accepts last share
     And file "/foo" of user "user1" is shared with user "user2"
+    And user "user2" accepts last share
     Then user "user2" should see following elements
       | /foo/       |
       | /foo%20(2)/ |
@@ -176,7 +186,9 @@ Feature: sharing
     And user "user1" belongs to group "group1"
     And user "user0" created a folder "/merge-test-outside"
     When folder "/merge-test-outside" of user "user0" is shared with group "group1"
+    And user "user1" accepts last share
     And folder "/merge-test-outside" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     Then as "user1" the folder "/merge-test-outside" exists
     And as "user1" the folder "/merge-test-outside (2)" does not exist
 
@@ -188,7 +200,9 @@ Feature: sharing
     And user "user1" belongs to group "group1"
     And user "user0" created a folder "/merge-test-outside-perms"
     When folder "/merge-test-outside-perms" of user "user0" is shared with group "group1" with permissions 1
+    And user "user1" accepts last share
     And folder "/merge-test-outside-perms" of user "user0" is shared with user "user1" with permissions 31
+    And user "user1" accepts last share
     Then as "user1" gets properties of folder "/merge-test-outside-perms" with
       |{http://owncloud.org/ns}permissions|
     And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRGDNVCK"
@@ -204,7 +218,9 @@ Feature: sharing
     And user "user1" belongs to group "group2"
     And user "user0" created a folder "/merge-test-outside-twogroups"
     When folder "/merge-test-outside-twogroups" of user "user0" is shared with group "group1"
+    And user "user1" accepts last share
     And folder "/merge-test-outside-twogroups" of user "user0" is shared with group "group2"
+    And user "user1" accepts last share
     Then as "user1" the folder "/merge-test-outside-twogroups" exists
     And as "user1" the folder "/merge-test-outside-twogroups (2)" does not exist
 
@@ -218,7 +234,9 @@ Feature: sharing
     And user "user1" belongs to group "group2"
     And user "user0" created a folder "/merge-test-outside-twogroups-perms"
     When folder "/merge-test-outside-twogroups-perms" of user "user0" is shared with group "group1" with permissions 1
+    And user "user1" accepts last share
     And folder "/merge-test-outside-twogroups-perms" of user "user0" is shared with group "group2" with permissions 31
+    And user "user1" accepts last share
     Then as "user1" gets properties of folder "/merge-test-outside-twogroups-perms" with
       |{http://owncloud.org/ns}permissions|
     And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRGDNVCK"
@@ -234,8 +252,11 @@ Feature: sharing
     And user "user1" belongs to group "group2"
     And user "user0" created a folder "/merge-test-outside-twogroups-member-perms"
     When folder "/merge-test-outside-twogroups-member-perms" of user "user0" is shared with group "group1" with permissions 1
+    And user "user1" accepts last share
     And folder "/merge-test-outside-twogroups-member-perms" of user "user0" is shared with group "group2" with permissions 31
+    And user "user1" accepts last share
     And folder "/merge-test-outside-twogroups-member-perms" of user "user0" is shared with user "user1" with permissions 1
+    And user "user1" accepts last share
     Then as "user1" gets properties of folder "/merge-test-outside-twogroups-member-perms" with
       |{http://owncloud.org/ns}permissions|
     And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRGDNVCK"
@@ -289,9 +310,11 @@ Feature: sharing
     And user "user1" belongs to group "group1"
     And user "user0" created a folder "/merge-test-outside-groups-renamebeforesecondshare"
     When folder "/merge-test-outside-groups-renamebeforesecondshare" of user "user0" is shared with group "group1"
+    And user "user1" accepts last share
     And User "user1" moved folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed"
     And Sleep for "1" seconds
     And folder "/merge-test-outside-groups-renamebeforesecondshare" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     Then as "user1" gets properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" with
       |{http://owncloud.org/ns}permissions|
     And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRGDNVCK"
@@ -306,9 +329,11 @@ Feature: sharing
     And user "user1" belongs to group "group1"
     And user "user0" created a folder "/merge-test-outside-groups-renamebeforesecondshare"
     When folder "/merge-test-outside-groups-renamebeforesecondshare" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And User "user1" moved folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed"
     And Sleep for "1" seconds
     And folder "/merge-test-outside-groups-renamebeforesecondshare" of user "user0" is shared with group "group1"
+    And user "user1" accepts last share
     Then as "user1" gets properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" with
       |{http://owncloud.org/ns}permissions|
     And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRGDNVCK"
@@ -328,6 +353,7 @@ Feature: sharing
     And user "user0" created a folder "/common"
     And user "user0" created a folder "/common/sub"
     And file "/common/sub" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And User "user0" deletes folder "/common"
     When User "user0" empties trashbin
     Then as "user1" the folder "/sub" does not exist
@@ -354,6 +380,7 @@ Feature: sharing
     And user "user0" belongs to group "sharing-group"
     And user "user1" belongs to group "sharing-group"
     And file "/PARENT/parent.txt" of user "user0" is shared with group "sharing-group"
+    And user "user1" accepts last share
     And user "user0" stores etag of element "/PARENT"
     And user "user1" stores etag of element "/"
     And As an "user1"
@@ -390,6 +417,7 @@ Feature: sharing
       | shareType | 0 |
       | shareWith | user1 |
       | permissions | 31 |
+    And user "user1" accepts last share
     And creating a share with
       | path | TMP |
       | shareType | 0 |
@@ -413,6 +441,7 @@ Feature: sharing
       | shareWith | user1 |
       | permissions | 17  |
     When As an "user1"
+    And accepting last share
     And creating a share with
       | path | TMP |
       | shareType | 3 |
@@ -434,6 +463,7 @@ Feature: sharing
       | shareWith | user1 |
       | permissions | 17  |
     When As an "user1"
+    And accepting last share
     And creating a share with
       | path | TMP/SUB |
       | shareType | 3 |
@@ -449,6 +479,7 @@ Feature: sharing
     And user "user0" created a folder "/shared"
     And User "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And folder "/shared" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     When User "user1" deletes file "/shared/shared_file.txt"
     Then as "user1" the file "/shared/shared_file.txt" does not exist
     And as "user0" the file "/shared/shared_file.txt" does not exist
@@ -463,6 +494,7 @@ Feature: sharing
     And user "user0" created a folder "/shared/sub"
     And User "user0" moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
     And folder "/shared" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     When User "user1" deletes folder "/shared/sub"
     Then as "user1" the folder "/shared/sub" does not exist
     And as "user0" the folder "/shared/sub" does not exist
@@ -477,6 +509,7 @@ Feature: sharing
     And user "user1" exists
     And user "user0" created a folder "/shared"
     And folder "/shared" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     When User "user1" moved file "/textfile0.txt" to "/shared/shared_file.txt"
     Then as "user1" the file "/shared/shared_file.txt" exists
     And as "user0" the file "/shared/shared_file.txt" exists
@@ -490,6 +523,7 @@ Feature: sharing
     And As an "user0"
     And user "user0" created a folder "/share"
     And folder "/share" of user "user0" is shared with group "group1"
+    And user "user1" accepts last share
     And user "user0" created a folder "/share/subfolder"
     And As an "user1"
     And save the last share data as "original"

--- a/build/integration/sharing_features/sharing-v1.feature
+++ b/build/integration/sharing_features/sharing-v1.feature
@@ -119,7 +119,7 @@ Feature: sharing
       | expireDate | +3 days |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And Getting info of last share 
+    And Getting info of last share
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And Share fields of last share match with
@@ -148,11 +148,11 @@ Feature: sharing
     When creating a share with
       | path | FOLDER |
       | shareType | 3 |
-    And Updating last share with 
+    And Updating last share with
       | password | publicpw |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And Getting info of last share 
+    And Getting info of last share
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And Share fields of last share match with
@@ -184,7 +184,7 @@ Feature: sharing
       | permissions | 7 |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And Getting info of last share 
+    And Getting info of last share
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And Share fields of last share match with
@@ -248,7 +248,7 @@ Feature: sharing
       | publicUpload | true |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And Getting info of last share 
+    And Getting info of last share
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And Share fields of last share match with

--- a/build/integration/sharing_features/sharing-v1.feature
+++ b/build/integration/sharing_features/sharing-v1.feature
@@ -7,7 +7,7 @@ Feature: sharing
     Given user "user0" exists
     And user "user1" exists
     And As an "user0"
-    When sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    When creating a share with
       | path | welcome.txt |
       | shareWith | user1 |
       | shareType | 0 |
@@ -21,7 +21,7 @@ Feature: sharing
     And user "user1" exists
     And group "sharing-group" exists
     And As an "user0"
-    When sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    When creating a share with
       | path | welcome.txt |
       | shareWith | sharing-group |
       | shareType | 1 |
@@ -36,7 +36,7 @@ Feature: sharing
     And user "user1" belongs to group "sharing-group"
     And file "welcome.txt" of user "user0" is shared with group "sharing-group"
     And As an "user0"
-    Then sending "POST" to "/apps/files_sharing/api/v1/shares" with
+    Then creating a share with
       | path | welcome.txt |
       | shareWith | user1 |
       | shareType | 0 |

--- a/build/integration/sharing_features/sharing-v1.feature
+++ b/build/integration/sharing_features/sharing-v1.feature
@@ -35,6 +35,7 @@ Feature: sharing
     And group "sharing-group" exists
     And user "user1" belongs to group "sharing-group"
     And file "welcome.txt" of user "user0" is shared with group "sharing-group"
+    And user "user1" accepts last share
     And As an "user0"
     Then creating a share with
       | path | welcome.txt |
@@ -311,6 +312,7 @@ Feature: sharing
     And user "user2" exists
     And user "user3" exists
     And file "textfile0.txt" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
     And file "textfile0.txt" of user "user0" is shared with user "user2"
     And As an "user1"
     When sending "GET" to "/apps/files_sharing/api/v1/shares?path=textfile0 (2).txt&reshares=true"


### PR DESCRIPTION
Follow up to #16828 

Besides the integration tests that were failing I have fixed too some that were silently broken (for example, after the behaviour change the [orphaned shares test](https://github.com/nextcloud/server/blob/ff895abac081ffd53b9d1509565e9dfe923b6d60/build/integration/sharing_features/sharing-v1-part3.feature#L324) passed anyway, but as the share was not accepted it was not testing anything because the file did not exist). There are surely some left, though. I guess that we will find them... eventually :-P

Also the integration tests should be extended to explicitly check the new behaviour, but... something for the future too ;-)
