### PR TITLE
Accept incoming shares in acceptance tests

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -19,6 +19,7 @@ default:
         - FilesAppContext
         - FilesAppSharingContext
         - LoginPageContext
+        - NotificationsContext
         - PublicShareContext
         - SearchContext
         - SettingsContext
@@ -48,6 +49,7 @@ default:
         - FilesAppContext
         - FilesAppSharingContext
         - LoginPageContext
+        - NotificationsContext
         - PublicShareContext
         - SearchContext
         - SettingsContext

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -19,12 +19,12 @@ default:
         - FilesAppContext
         - FilesAppSharingContext
         - LoginPageContext
-        - NotificationContext
         - PublicShareContext
         - SearchContext
         - SettingsContext
         - SettingsMenuContext
         - ThemingAppContext
+        - ToastContext
         - UsersSettingsContext
       filters:
         tags: "~@apache"
@@ -48,12 +48,12 @@ default:
         - FilesAppContext
         - FilesAppSharingContext
         - LoginPageContext
-        - NotificationContext
         - PublicShareContext
         - SearchContext
         - SettingsContext
         - SettingsMenuContext
         - ThemingAppContext
+        - ToastContext
         - UsersSettingsContext
       filters:
         tags: "@apache"

--- a/tests/acceptance/features/app-comments.feature
+++ b/tests/acceptance/features/app-comments.feature
@@ -47,6 +47,7 @@ Feature: app-comments
     And I create a new comment with "Hello world" as message
     And I see a comment with "Hello world" as message
     When I act as Jane
+    And I accept the share for "shared.txt" in the notifications
     # The Files app is open again to reload the file list and the comments
     And I open the Files app
     And I open the details view for "shared.txt"
@@ -63,6 +64,7 @@ Feature: app-comments
     And I share "shared.txt" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
+    And I accept the share for "shared.txt" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I open the details view for "shared.txt"
@@ -92,6 +94,7 @@ Feature: app-comments
     And I create a new comment with "Hello world" as message
     And I see a comment with "Hello world" as message
     When I act as Jane
+    And I accept the share for "shared.txt" in the notifications
     # The Files app is open again to reload the file list and the comments
     And I open the Files app
     Then I see that "shared.txt" has unread comments
@@ -109,6 +112,7 @@ Feature: app-comments
     And I share "shared.txt" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
+    And I accept the share for "shared.txt" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I open the details view for "shared.txt"
@@ -137,6 +141,7 @@ Feature: app-comments
     And I create a new comment with "Hello world" as message
     And I see a comment with "Hello world" as message
     When I act as Jane
+    And I accept the share for "Folder" in the notifications
     # The Files app is open again to reload the file list and the comments
     And I open the Files app
     Then I see that "Folder" has unread comments
@@ -154,6 +159,7 @@ Feature: app-comments
     And I share "Folder" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
+    And I accept the share for "Folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I open the details view for "Folder"
@@ -184,6 +190,7 @@ Feature: app-comments
     And I create a new comment with "Hello world" as message
     And I see a comment with "Hello world" as message
     When I act as Jane
+    And I accept the share for "Folder" in the notifications
     # The Files app is open again to reload the file list and the comments
     And I open the Files app
     And I enter in the folder named "Folder"
@@ -202,6 +209,7 @@ Feature: app-comments
     And I share "Folder" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
+    And I accept the share for "Folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I enter in the folder named "Folder"
@@ -256,6 +264,7 @@ Feature: app-comments
     And I share "shared.txt" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
+    And I accept the share for "shared.txt" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I open the details view for "shared.txt"

--- a/tests/acceptance/features/app-files-sharing.feature
+++ b/tests/acceptance/features/app-files-sharing.feature
@@ -11,6 +11,7 @@ Feature: app-files-sharing
     When I share "farewell.txt" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
+    And I accept the share for "farewell.txt" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     Then I see that the file list contains a file named "farewell.txt"
@@ -29,28 +30,11 @@ Feature: app-files-sharing
     When I share "welcome.txt" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
+    And I accept the share for "welcome.txt" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     Then I see that the file list contains a file named "welcome (2).txt"
     And I open the details view for "welcome (2).txt"
-    And I see that the details view is open
-    And I open the "Sharing" tab in the details view
-    And I see that the "Sharing" tab in the details view is eventually loaded
-    And I see that the file is shared with me by "admin"
-
-  Scenario: share a skeleton file with another user before first login
-    # If a file is shared with a user before her first login the skeleton would
-    # not have been created, so if the shared file has the same name as one from
-    # the skeleton the shared file will take its place and the skeleton file
-    # will not be added.
-    Given I act as John
-    And I am logged in as the admin
-    When I share "welcome.txt" with "user0"
-    And I see that the file is shared with "user0"
-    And I act as Jane
-    And I am logged in
-    Then I see that the file list contains a file named "welcome.txt"
-    And I open the details view for "welcome.txt"
     And I see that the details view is open
     And I open the "Sharing" tab in the details view
     And I see that the "Sharing" tab in the details view is eventually loaded
@@ -69,11 +53,13 @@ Feature: app-files-sharing
     And I share "farewell.txt" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
+    And I accept the share for "farewell.txt" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     When I share "farewell.txt" with "user1"
     And I see that the file is shared with "user1"
     And I act as Jim
+    And I accept the share for "farewell.txt" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     Then I see that the file list contains a file named "farewell.txt"
@@ -94,6 +80,7 @@ Feature: app-files-sharing
     And I share "farewell.txt" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
+    And I accept the share for "farewell.txt" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I share "farewell.txt" with "user1"
@@ -119,6 +106,7 @@ Feature: app-files-sharing
     When I share "Shared folder" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
+    And I accept the share for "Shared folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     Then I see that the file list contains a file named "Shared folder"
@@ -142,6 +130,7 @@ Feature: app-files-sharing
     And I create a new folder named "Subfolder"
     And I see that the file list contains a file named "Subfolder"
     When I act as Jane
+    And I accept the share for "Shared folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I enter in the folder named "Shared folder"
@@ -158,6 +147,7 @@ Feature: app-files-sharing
     And I share "Shared folder" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
+    And I accept the share for "Shared folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I enter in the folder named "Shared folder"
@@ -180,6 +170,7 @@ Feature: app-files-sharing
     And I share "Shared folder" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
+    And I accept the share for "Shared folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I share "Shared folder" with "user1"
@@ -188,6 +179,7 @@ Feature: app-files-sharing
     And I create a new folder named "Subfolder"
     And I see that the file list contains a file named "Subfolder"
     When I act as Jim
+    And I accept the share for "Shared folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I enter in the folder named "Shared folder"
@@ -206,10 +198,12 @@ Feature: app-files-sharing
     And I share "Shared folder" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
+    And I accept the share for "Shared folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I share "Shared folder" with "user1"
     And I act as Jim
+    And I accept the share for "Shared folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I enter in the folder named "Shared folder"
@@ -232,6 +226,7 @@ Feature: app-files-sharing
     And I set the share with "user0" as not reshareable
     And I see that "user0" can not reshare the share
     When I act as Jane
+    And I accept the share for "Shared folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     Then I see that the file list contains a file named "Shared folder"
@@ -258,6 +253,7 @@ Feature: app-files-sharing
     And I create a new folder named "Subfolder"
     And I see that the file list contains a file named "Subfolder"
     When I act as Jane
+    And I accept the share for "Shared folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I enter in the folder named "Shared folder"

--- a/tests/acceptance/features/bootstrap/NotificationsContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsContext.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ *
+ * @copyright Copyright (c) 2019, Daniel Calviño Sánchez (danxuliu@gmail.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use Behat\Behat\Context\Context;
+
+class NotificationsContext implements Context, ActorAwareInterface {
+
+	use ActorAware;
+
+	/**
+	 * @return Locator
+	 */
+	public static function notificationsButton() {
+		return Locator::forThe()->css("#header .notifications .notifications-button")->
+				describedAs("Notifications button in the header");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function notificationsContainer() {
+		return Locator::forThe()->css("#header .notifications .notification-container")->
+				describedAs("Notifications container");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function incomingShareNotificationForFile($fileName) {
+		return Locator::forThe()->xpath("//div[contains(concat(' ', normalize-space(@class), ' '), ' notification ') and //div[starts-with(normalize-space(), 'You received $fileName as a share by')]]")->
+				descendantOf(self::notificationsContainer())->
+				describedAs("Notification of incoming share for file $fileName");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function actionsInIncomingShareNotificationForFile($fileName) {
+		return Locator::forThe()->css(".notification-actions")->
+				descendantOf(self::incomingShareNotificationForFile($fileName))->
+				describedAs("Actions in notification of incoming share for file $fileName");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function actionInIncomingShareNotificationForFile($fileName, $action) {
+		return Locator::forThe()->xpath("//button[normalize-space() = '$action']")->
+				descendantOf(self::actionsInIncomingShareNotificationForFile($fileName))->
+				describedAs("$action button in notification of incoming share for file $fileName");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function acceptButtonInIncomingShareNotificationForFile($fileName) {
+		return self::actionInIncomingShareNotificationForFile($fileName, 'Accept');
+	}
+
+	/**
+	 * @Given I accept the share for :fileName in the notifications
+	 */
+	public function iAcceptTheShareForInTheNotifications($fileName) {
+		$this->actor->find(self::notificationsButton(), 10)->click();
+
+		// Notifications are refreshed every 30 seconds, so wait a bit longer.
+		// As the waiting is long enough already the find timeout multiplier is
+		// capped at 2 when finding notifications.
+		$findTimeoutMultiplier = $this->actor->getFindTimeoutMultiplier();
+		$this->actor->setFindTimeoutMultiplier(max(2, $findTimeoutMultiplier));
+		$this->actor->find(self::acceptButtonInIncomingShareNotificationForFile($fileName), 35)->click();
+		$this->actor->setFindTimeoutMultiplier($findTimeoutMultiplier);
+
+		// Hide the notifications again
+		$this->actor->find(self::notificationsButton(), 10)->click();
+	}
+
+}

--- a/tests/acceptance/features/bootstrap/ToastContext.php
+++ b/tests/acceptance/features/bootstrap/ToastContext.php
@@ -23,33 +23,33 @@
 
 use Behat\Behat\Context\Context;
 
-class NotificationContext implements Context, ActorAwareInterface {
+class ToastContext implements Context, ActorAwareInterface {
 
 	use ActorAware;
 
 	/**
 	 * @return Locator
 	 */
-	public static function notificationMessage($message) {
+	public static function toastMessage($message) {
 		return Locator::forThe()->xpath("//*[contains(concat(' ', normalize-space(@class), ' '), ' toastify ') and normalize-space(text()) = '$message']")->
-				descendantOf(self::notificationContainer())->
-				describedAs("$message notification");
+				descendantOf(self::toastContainer())->
+				describedAs("$message toast");
 	}
 
 	/**
 	 * @return Locator
 	 */
-	private static function notificationContainer() {
+	private static function toastContainer() {
 		return Locator::forThe()->id("content")->
-				describedAs("Notification container");
+				describedAs("Toast container");
 	}
 
 	/**
-	 * @Then I see that the :message notification is shown
+	 * @Then I see that the :message toast is shown
 	 */
-	public function iSeeThatTheNotificationIsShown($message) {
+	public function iSeeThatTheToastIsShown($message) {
 		PHPUnit_Framework_Assert::assertTrue($this->actor->find(
-				self::notificationMessage($message), 10)->isVisible());
+				self::toastMessage($message), 10)->isVisible());
 	}
 
 }

--- a/tests/acceptance/run-local.sh
+++ b/tests/acceptance/run-local.sh
@@ -193,6 +193,11 @@ cd ../../
 # server to make possible to run the Nextcloud server on Apache if needed.
 ln --symbolic $(pwd) /var/www/html
 
+# Add Notifications app to the "apps" directory (unless it is already there).
+if [ ! -e "apps/notifications" ]; then
+	(cd apps && git clone --depth 1 https://github.com/nextcloud/notifications)
+fi
+
 INSTALL_AND_CONFIGURE_SERVER_PARAMETERS=""
 if [ "$NEXTCLOUD_SERVER_DOMAIN" != "$DEFAULT_NEXTCLOUD_SERVER_DOMAIN" ]; then
 	INSTALL_AND_CONFIGURE_SERVER_PARAMETERS+="--nextcloud-server-domain $NEXTCLOUD_SERVER_DOMAIN"


### PR DESCRIPTION
Follow up to #16828

Fortunately the Notifications app is already built in the development branches, so there was no need to update the acceptance test images with NPM to built it before running the tests. Just clone it in _apps_ and everything is ready :-D
