### PR TITLE
make help available to ordinary users again

### DIFF
--- a/apps/settings/lib/Controller/HelpController.php
+++ b/apps/settings/lib/Controller/HelpController.php
@@ -65,6 +65,7 @@ class HelpController extends Controller {
 	 *
 	 * @NoCSRFRequired
 	 * @NoAdminRequired
+	 * @NoSubadminRequired
 	 */
 	public function help(string $mode = 'user'): TemplateResponse {
 		$this->navigationManager->setActiveEntry('help');


### PR DESCRIPTION
To reproduce:

* in master, log in as ordinary user. No admin, no subadmin
* open Help from settings menu

![Screenshot_20191121_125443](https://user-images.githubusercontent.com/2184312/69335983-1bbc3600-0c5e-11ea-92d1-ff3772e0ebe5.png)

SAML integration tests are failing because of that…