### PR TITLE
Apply share permission mask to all files obtained via shareinfo

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareInfoController.php
+++ b/apps/files_sharing/lib/Controller/ShareInfoController.php
@@ -81,11 +81,7 @@ class ShareInfoController extends ApiController {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		$isWritable = $share->getPermissions() & (\OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE);
-		if (!$isWritable) {
-			$this->addROWrapper();
-		}
-
+		$permissionMask = $share->getPermissions();
 		$node = $share->getNode();
 
 		if ($dir !== null && $node instanceof Folder) {
@@ -96,34 +92,34 @@ class ShareInfoController extends ApiController {
 			}
 		}
 
-		return new JSONResponse($this->parseNode($node));
+		return new JSONResponse($this->parseNode($node, $permissionMask));
 	}
 
-	private function parseNode(Node $node) {
+	private function parseNode(Node $node, int $permissionMask) {
 		if ($node instanceof File) {
-			return $this->parseFile($node);
+			return $this->parseFile($node, $permissionMask);
 		}
-		return $this->parseFolder($node);
+		return $this->parseFolder($node, $permissionMask);
 	}
 
-	private function parseFile(File $file) {
-		return $this->format($file);
+	private function parseFile(File $file, int $permissionMask) {
+		return $this->format($file, $permissionMask);
 	}
 
-	private function parseFolder(Folder $folder) {
-		$data = $this->format($folder);
+	private function parseFolder(Folder $folder, int $permissionMask) {
+		$data = $this->format($folder, $permissionMask);
 
 		$data['children'] = [];
 
 		$nodes = $folder->getDirectoryListing();
 		foreach ($nodes as $node) {
-			$data['children'][] = $this->parseNode($node);
+			$data['children'][] = $this->parseNode($node, $permissionMask);
 		}
 
 		return $data;
 	}
 
-	private function format(Node $node) {
+	private function format(Node $node, int $permissionMask) {
 		$entry = [];
 
 		$entry['id'] = $node->getId();
@@ -131,21 +127,12 @@ class ShareInfoController extends ApiController {
 		$entry['mtime'] = $node->getMTime();
 
 		$entry['name'] = $node->getName();
-		$entry['permissions'] = $node->getPermissions();
+		$entry['permissions'] = $node->getPermissions() & $permissionMask;
 		$entry['mimetype'] = $node->getMimetype();
 		$entry['size'] = $node->getSize();
 		$entry['type'] = $node->getType();
 		$entry['etag'] = $node->getEtag();
 
 		return $entry;
-	}
-
-	protected function addROWrapper() {
-		// FIXME: should not add storage wrappers outside of preSetup, need to find a better way
-		$previousLog = \OC\Files\Filesystem::logWarningWhenAddingStorageWrapper(false);
-		\OC\Files\Filesystem::addStorageWrapper('readonly', function ($mountPoint, $storage) {
-			return new \OC\Files\Storage\Wrapper\PermissionsMask(array('storage' => $storage, 'mask' => \OCP\Constants::PERMISSION_READ + \OCP\Constants::PERMISSION_SHARE));
-		});
-		\OC\Files\Filesystem::logWarningWhenAddingStorageWrapper($previousLog);
 	}
 }

--- a/apps/files_sharing/tests/Controller/ShareInfoControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareInfoControllerTest.php
@@ -173,9 +173,6 @@ class ShareInfoControllerTest extends TestCase {
 			->with($share, 'pass')
 			->willReturn(true);
 
-		$this->controller->expects($this->once())
-			->method('addROWrapper');
-
 		$expected = new JSONResponse([
 			'id' => 42,
 			'parentId' => 41,
@@ -285,7 +282,7 @@ class ShareInfoControllerTest extends TestCase {
 							'parentId' => 43,
 							'mtime' => 1339,
 							'name' => 'file',
-							'permissions' => 9,
+							'permissions' => 1,
 							'mimetype' => 'mime/type',
 							'size' => 3,
 							'type' => 'file',


### PR DESCRIPTION
This endpoint is used by federated shares to obtain the filelisting more efficient.
However not the full share permission mask was applied. It is now.