### PR TITLE
Load apps dav plugins on the old webdav route

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -52,7 +52,8 @@ $serverFactory = new OCA\DAV\Connector\Sabre\ServerFactory(
 	\OC::$server->getMountManager(),
 	\OC::$server->getTagManager(),
 	\OC::$server->getRequest(),
-	\OC::$server->getPreviewManager()
+	\OC::$server->getPreviewManager(),
+	\OC::$server->getEventDispatcher()
 );
 
 $requestUri = \OC::$server->getRequest()->getRequestUri();

--- a/apps/dav/appinfo/v1/webdav.php
+++ b/apps/dav/appinfo/v1/webdav.php
@@ -44,7 +44,8 @@ $serverFactory = new \OCA\DAV\Connector\Sabre\ServerFactory(
 	\OC::$server->getMountManager(),
 	\OC::$server->getTagManager(),
 	\OC::$server->getRequest(),
-	\OC::$server->getPreviewManager()
+	\OC::$server->getPreviewManager(),
+	\OC::$server->getEventDispatcher()
 );
 
 // Backends

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTestCase.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTestCase.php
@@ -67,7 +67,8 @@ abstract class RequestTestCase extends TestCase {
 			$this->getMockBuilder(IRequest::class)
 				->disableOriginalConstructor()
 				->getMock(),
-			\OC::$server->getPreviewManager()
+			\OC::$server->getPreviewManager(),
+			\OC::$server->getEventDispatcher()
 		);
 	}
 


### PR DESCRIPTION
The old webdav url /remote.php/webdav is still used by the android app so we need to make sure that DAV plugins are properly loaded there as well for https://github.com/nextcloud/text/pull/415

## ToDo

- [x] Proper DI
- [x] Fix tests (most likely)