### PR TITLE
Drop php 7.1 support

### DIFF
--- a/build/integration/run-docker.sh
+++ b/build/integration/run-docker.sh
@@ -212,7 +212,7 @@ cd "$(dirname $0)"
 
 # "--image XXX" option can be provided to set the Docker image to use to run
 # the integration tests (one of the "nextcloudci/phpX.Y:phpX.Y-Z" images).
-NEXTCLOUD_LOCAL_IMAGE="nextcloudci/php7.1:php7.1-15"
+NEXTCLOUD_LOCAL_IMAGE="nextcloudci/php7.3:php7.3-5"
 if [ "$1" = "--image" ]; then
 	NEXTCLOUD_LOCAL_IMAGE=$2
 

--- a/lib/versioncheck.php
+++ b/lib/versioncheck.php
@@ -1,9 +1,9 @@
 <?php
 
-// Show warning if a PHP version below 7.1 is used,
-if (version_compare(PHP_VERSION, '7.1') === -1) {
+// Show warning if a PHP version below 7.2 is used,
+if (version_compare(PHP_VERSION, '7.2') === -1) {
 	http_response_code(500);
-	echo 'This version of Nextcloud requires at least PHP 7.1<br/>';
+	echo 'This version of Nextcloud requires at least PHP 7.2<br/>';
 	echo 'You are currently running ' . PHP_VERSION . '. Please update your PHP version.';
 	exit(-1);
 }


### PR DESCRIPTION
18 will be relased when php7.1 is EOL already. So lets kill it!

Blocked by:
- [x] https://github.com/nextcloud/server/pull/18064

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>