### PR TITLE
Sanity check when transfering ownership of files/shares

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -155,7 +155,10 @@ class TransferOwnership extends Command {
 		$this->collectUsersShares($output);
 
 		// transfer the files
-		$this->transfer($output);
+		if($this->transfer($output) === false) {
+			$output->writeln('<error>File transfer failed</error>');
+			return 1;
+		}
 
 		// restore the shares
 		$this->restoreShares($output);
@@ -259,7 +262,9 @@ class TransferOwnership extends Command {
 			$view->mkdir($this->finalTarget);
 			$this->finalTarget = $this->finalTarget . '/' . basename($this->sourcePath);
 		}
-		$view->rename($this->sourcePath, $this->finalTarget);
+		if ($view->rename($this->sourcePath, $this->finalTarget) === false) {
+			return false;
+		}
 		if (!is_dir("$this->sourceUser/files")) {
 			// because the files folder is moved away we need to recreate it
 			$view->mkdir("$this->sourceUser/files");


### PR DESCRIPTION
If the result is not checked it is possible that the file transfer failed or is denied (eg. quota exceeded). If this happens it should not be tried to change the shares to the (not existend) target path.
If the check is not present the transfer ownership currently may show `Share with id <shareid here> points at deleted file, skipping` for each share the original user had