### PR TITLE
Add return type hint to credential store and make it strict

### DIFF
--- a/lib/private/Authentication/LoginCredentials/Store.php
+++ b/lib/private/Authentication/LoginCredentials/Store.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * @copyright 2016 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
@@ -82,8 +83,8 @@ class Store implements IStore {
 	 * @return ICredentials the login credentials of the current user
 	 * @throws CredentialsUnavailableException
 	 */
-	public function getLoginCredentials() {
-		if (is_null($this->tokenProvider)) {
+	public function getLoginCredentials(): ICredentials {
+		if ($this->tokenProvider === null) {
 			throw new CredentialsUnavailableException();
 		}
 

--- a/lib/public/Authentication/LoginCredentials/IStore.php
+++ b/lib/public/Authentication/LoginCredentials/IStore.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * @copyright 2016 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
@@ -29,7 +30,7 @@ use OCP\Authentication\Exceptions\CredentialsUnavailableException;
  * @since 12
  */
 interface IStore {
-	
+
 	/**
 	 * Get login credentials of the currently logged in user
 	 *
@@ -38,6 +39,6 @@ interface IStore {
 	 * @throws CredentialsUnavailableException
 	 * @return ICredentials the login credentials of the current user
 	 */
-	public function getLoginCredentials();
-	
+	public function getLoginCredentials(): ICredentials;
+
 }


### PR DESCRIPTION
Noticed while testing https://github.com/nextcloud/mail/pull/2259.

This change is non-breaking as we always return an object that implements the interface.