### PR TITLE
Set common-name to user's displayname if none is set

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -33,6 +33,7 @@ use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IURLGenerator;
+use OCP\IUserManager;
 use OCP\L10N\IFactory as L10NFactory;
 use OCP\Mail\IEMailTemplate;
 use OCP\Mail\IMailer;
@@ -92,6 +93,9 @@ class IMipPlugin extends SabreIMipPlugin {
 	/** @var Defaults */
 	private $defaults;
 
+	/** @var IUserManager */
+	private $userManager;
+
 	const MAX_DATE = '2038-01-01';
 
 	const METHOD_REQUEST = 'request';
@@ -113,7 +117,8 @@ class IMipPlugin extends SabreIMipPlugin {
 	public function __construct(IConfig $config, IMailer $mailer, ILogger $logger,
 								ITimeFactory $timeFactory, L10NFactory $l10nFactory,
 								IURLGenerator $urlGenerator, Defaults $defaults,
-								ISecureRandom $random, IDBConnection $db, $userId) {
+								ISecureRandom $random, IDBConnection $db, IUserManager $userManager,
+								$userId) {
 		parent::__construct('');
 		$this->userId = $userId;
 		$this->config = $config;
@@ -125,6 +130,7 @@ class IMipPlugin extends SabreIMipPlugin {
 		$this->random = $random;
 		$this->db = $db;
 		$this->defaults = $defaults;
+		$this->userManager = $userManager;
 	}
 
 	/**
@@ -167,6 +173,15 @@ class IMipPlugin extends SabreIMipPlugin {
 
 		$senderName = $iTipMessage->senderName ?: null;
 		$recipientName = $iTipMessage->recipientName ?: null;
+
+		if ($senderName === null || empty(trim($senderName))) {
+			$user = $this->userManager->get($this->userId);
+			if ($user) {
+				// getDisplayName automatically uses the uid
+				// if no display-name is set
+				$senderName = $user->getDisplayName();
+			}
+		}
 
 		/** @var VEvent $vevent */
 		$vevent = $iTipMessage->message->VEVENT;

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
@@ -36,6 +36,8 @@ use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\Mail\IAttachment;
 use OCP\Mail\IEMailTemplate;
@@ -48,7 +50,7 @@ use Test\TestCase;
 
 class IMipPluginTest extends TestCase {
 
-        protected function setUp(): void {
+		protected function setUp(): void {
 		$this->mailMessage = $this->createMock(IMessage::class);
 		$this->mailMessage->method('setFrom')->willReturn($this->mailMessage);
 		$this->mailMessage->method('setReplyTo')->willReturn($this->mailMessage);
@@ -70,7 +72,13 @@ class IMipPluginTest extends TestCase {
 
 		$this->config = $this->createMock(IConfig::class);
 
+		$this->userManager = $this->createMock(IUserManager::class);
+
 		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')
+			->will($this->returnCallback(function($text, $parameters = []) {
+				return vsprintf($text, $parameters);
+			}));
 		$l10nFactory = $this->createMock(IFactory::class);
 		$l10nFactory->method('get')->willReturn($l10n);
 
@@ -91,7 +99,7 @@ class IMipPluginTest extends TestCase {
 		$defaults->method('getName')
 			->will($this->returnValue('Instance Name 123'));
 
-		$this->plugin = new IMipPlugin($this->config, $this->mailer, $logger, $this->timeFactory, $l10nFactory, $urlGenerator, $defaults, $random, $db, 'user123');
+		$this->plugin = new IMipPlugin($this->config, $this->mailer, $logger, $this->timeFactory, $l10nFactory, $urlGenerator, $defaults, $random, $db, $this->userManager, 'user123');
 	}
 
 	public function testDelivery() {
@@ -121,6 +129,28 @@ class IMipPluginTest extends TestCase {
 		$this->assertEquals('5.0', $message->getScheduleStatus());
 	}
 
+	public function testDeliveryWithNoCommonName() {
+		$this->config
+			->method('getAppValue')
+			->with('dav', 'invitation_link_recipients', 'yes')
+			->willReturn('yes');
+
+		$message = $this->_testMessage();
+		$message->senderName = null;
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getDisplayName')->willReturn('Mr. Wizard');
+
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with('user123')
+			->willReturn($user);
+
+		$this->_expectSend();
+		$this->plugin->schedule($message);
+		$this->assertEquals('1.1', $message->getScheduleStatus());
+	}
+
 	/**
 	 * @dataProvider dataNoMessageSendForPastEvents
 	 */
@@ -139,7 +169,7 @@ class IMipPluginTest extends TestCase {
 
 		if ($expectsMail) {
 			$this->assertEquals('1.1', $message->getScheduleStatus());
- 		} else {
+		} else {
 			$this->assertEquals(false, $message->getScheduleStatus());
 		}
 	}
@@ -201,12 +231,13 @@ class IMipPluginTest extends TestCase {
 		$message->message->VEVENT->add( 'ORGANIZER', 'mailto:gandalf@wiz.ard' );
 		$message->message->VEVENT->add( 'ATTENDEE', 'mailto:'.$recipient, [ 'RSVP' => 'TRUE' ] );
 		$message->sender = 'mailto:gandalf@wiz.ard';
+		$message->senderName = 'Mr. Wizard';
 		$message->recipient = 'mailto:'.$recipient;
 		return $message;
 	}
 
 
-        private function _expectSend( $recipient = 'frodo@hobb.it', $expectSend = true, $expectButtons = true ) {
+	private function _expectSend( $recipient = 'frodo@hobb.it', $expectSend = true, $expectButtons = true ) {
 
 		// if the event is in the past, we skip out
 		if (!$expectSend) {
@@ -224,7 +255,10 @@ class IMipPluginTest extends TestCase {
 			->with([$recipient => null]);
 		$this->mailMessage->expects($this->once())
 			->method('setReplyTo')
-			->with(['gandalf@wiz.ard' => null]);
+			->with(['gandalf@wiz.ard' => 'Mr. Wizard']);
+		$this->mailMessage->expects($this->once())
+			->method('setFrom')
+			->with(['invitations-noreply@localhost' => 'Mr. Wizard via Instance Name 123']);
 		$this->mailer
 			->expects($this->once())
 			->method('send');


### PR DESCRIPTION
fixes #13896

Some calendar clients don't set a common-name for the organizer in calendar entries.
On master, this leads to emails with the from name: "via Nextcloud"

This pull-request makes sure, that if no common-name is set, we use the user's display name.
So you always have "User 123 via Nextcloud"