### PR TITLE
Trim the login name

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -289,7 +289,7 @@ class LoginController extends Controller {
 
 		$data = new LoginData(
 			$this->request,
-			$user,
+			trim($user),
 			$password,
 			$redirect_url,
 			$timezone,


### PR DESCRIPTION
Otherwise we keep on using it with leading or trailing whitespaces for
app tokens and other logic. The reason this doesn't throw an error
immediately with local users is that (My)SQL compares strings regardless
of their padding by default. So we look up 'uid ' and get the row for
the user 'uid'.
Other back-ends will lead to a hard error, though, and the user is
unable to log out as all request fail.

Ref https://stackoverflow.com/a/10495807/2239067