### PR TITLE
Allow inline styles for theming images

### DIFF
--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -379,6 +379,9 @@ class ThemingController extends Controller {
 		}
 
 		$response = new FileDisplayResponse($file);
+		$csp = new Http\ContentSecurityPolicy();
+		$csp->allowInlineStyle();
+		$response->setContentSecurityPolicy($csp);
 		$response->cacheFor(3600);
 		$response->addHeader('Content-Type', $this->config->getAppValue($this->appName, $key . 'Mime', ''));
 		$response->addHeader('Content-Disposition', 'attachment; filename="' . $key . '"');


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/12724

Firefox seems to apply the CSP rules from the image request itself, so we need inline styles to be allowed there in order to properly show svg logo images that use style elements inside of their svg.