### PR TITLE
Fix provisioning_api getUsers types

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -126,7 +126,7 @@ class UsersController extends AUserData {
 	 * @param int $offset
 	 * @return DataResponse
 	 */
-	public function getUsers(string $search = '', $limit = null, $offset = 0): DataResponse {
+	public function getUsers(string $search = '', int $limit = null, int $offset = 0): DataResponse {
 		$user = $this->userSession->getUser();
 		$users = [];
 
@@ -159,7 +159,7 @@ class UsersController extends AUserData {
 	 *
 	 * returns a list of users and their data
 	 */
-	public function getUsersDetails(string $search = '', $limit = null, $offset = 0): DataResponse {
+	public function getUsersDetails(string $search = '', int $limit = null, int $offset = 0): DataResponse {
 		$currentUser = $this->userSession->getUser();
 		$users = [];
 


### PR DESCRIPTION
Fix #17903, Fix #18137


Please review @Ases @finalls @markuman @markushagge @nursoda @j-ed 

Otherwise it is passed as string and ignored by the Users Backend 
https://github.com/nextcloud/server/blob/1a886b1472cad1fb04e8073d2749514e2d97a506/lib/private/User/Database.php#L491-L497