### PR TITLE
Adjust DirectEditing test to PHPUnit8

### DIFF
--- a/tests/lib/DirectEditing/ManagerTest.php
+++ b/tests/lib/DirectEditing/ManagerTest.php
@@ -106,7 +106,7 @@ class ManagerTest extends TestCase {
 	 */
 	private $userFolder;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->editor = new Editor();


### PR DESCRIPTION
#17625 was merged after #18064 without rerunning drone, so tests fail on master