### PR TITLE
Always return overwritehost if configured

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -853,6 +853,10 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 * @return string Server host
 	 */
 	public function getInsecureServerHost(): string {
+		if ($this->fromTrustedProxy() && $this->getOverwriteHost() !== null) {
+			return $this->getOverwriteHost();
+		}
+
 		$host = 'localhost';
 		if ($this->fromTrustedProxy() && isset($this->server['HTTP_X_FORWARDED_HOST'])) {
 			if (strpos($this->server['HTTP_X_FORWARDED_HOST'], ',') !== false) {
@@ -868,6 +872,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 				$host = $this->server['SERVER_NAME'];
 			}
 		}
+
 		return $host;
 	}
 


### PR DESCRIPTION
As part of https://github.com/nextcloud/server/commit/1a4a68dbc6875b18a2c2ca45fd27990cc33b1d5e the ThemingDefaults are only loaded if the result of `getInsecureServerHost()` is part of the trusted domain list. When a `trusted_proxy` and `overwritehost` is configured but the reverse proxy doesn't set a `X-Forwarded-Host` header, the check fails and therefore the ThemingDefaults instance is not loaded.

This PR makes sure we always return the overwritehost if it is configured, as it is done in https://github.com/nextcloud/server/blob/43a941afd7081dbf8697f51d4857c0c8be8a0b97/lib/private/AppFramework/Http/Request.php#L885-L890