### PR TITLE
Fix direct editing access check on Postgres

### DIFF
--- a/lib/private/DirectEditing/Token.php
+++ b/lib/private/DirectEditing/Token.php
@@ -62,7 +62,7 @@ class Token implements IToken {
 	}
 
 	public function hasBeenAccessed(): bool {
-		return $this->data['accessed'] === '1';
+		return (bool) $this->data['accessed'];
 	}
 
 	public function getEditor(): string {


### PR DESCRIPTION
Postgres is returning a real boolean, so we need to cast the column value properly and not check for matching a `1`

Fixes failing postgres tests that slipped in with #17625 