### PR TITLE
Do not call count on null

### DIFF
--- a/build/integration/features/bootstrap/CommentsContext.php
+++ b/build/integration/features/bootstrap/CommentsContext.php
@@ -256,8 +256,12 @@ class CommentsContext implements \Behat\Behat\Context\Context {
 	 * @throws \Exception
 	 */
 	public function theResponseShouldContainOnlyComments($number) {
-		if (count($this->response) !== (int)$number) {
-			throw new \Exception("Found more comments than $number (" . count($this->response) . ")");
+		$count = 0;
+		if ($this->response !== null) {
+			$count = count($this->response);
+		}
+		if ($count !== (int)$number) {
+			throw new \Exception("Found more comments than $number (" . $count . ")");
 		}
 	}
 


### PR DESCRIPTION
PHP 7.2 emits a warning when count is called with an non-countable argument which breaks the comments integration tests, so this adds a check to properly handle null values in the integration test.