### PR TITLE
fix generation of an url to an absolute ocs route when NC in subfolder

### DIFF
--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -94,8 +94,9 @@ class URLGenerator implements IURLGenerator {
 	public function linkToOCSRouteAbsolute(string $routeName, array $arguments = []): string {
 		$route = \OC::$server->getRouter()->generate('ocs.'.$routeName, $arguments, false);
 
-		if (strpos($route, '/index.php') === 0) {
-			$route = substr($route, 10);
+		$indexPhpPos = strpos($route, '/index.php/');
+		if ($indexPhpPos !== false) {
+			$route = substr($route, $indexPhpPos + 10);
 		}
 
 		$route = substr($route, 7);


### PR DESCRIPTION
Fixes accepting shares on master, when you're NC instance is installed in a subfolder.

Previously, the generated URL looked like: http://my.server/master/ocs/v2.php/ocsapp/apps/files_sharing/api/v1/shares/pending/104 which failed because the route could not be found. Now it results in: 

http://my.server/master/ocs/v2.php/apps/files_sharing/api/v1/shares/pending/104