### PR TITLE
Move overwritehost check to isTrustedDomain

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -760,9 +760,6 @@ class OC {
 		 * FIXME: Should not be in here at all :see_no_evil:
 		 */
 		if (!OC::$CLI
-			// overwritehost is always trusted, workaround to not have to make
-			// \OC\AppFramework\Http\Request::getOverwriteHost public
-			&& self::$server->getConfig()->getSystemValue('overwritehost') === ''
 			&& !\OC::$server->getTrustedDomainHelper()->isTrustedDomain($host)
 			&& self::$server->getConfig()->getSystemValue('installed', false)
 		) {

--- a/lib/private/Security/TrustedDomainHelper.php
+++ b/lib/private/Security/TrustedDomainHelper.php
@@ -70,6 +70,11 @@ class TrustedDomainHelper {
 	 * have been configured
 	 */
 	public function isTrustedDomain($domainWithPort) {
+		// overwritehost is always trusted
+		if ($this->config->getSystemValue('overwritehost') !== '') {
+			return true;
+		}
+
 		$domain = $this->getDomainWithoutPort($domainWithPort);
 
 		// Read trusted domains from config

--- a/tests/lib/Security/TrustedDomainHelperTest.php
+++ b/tests/lib/Security/TrustedDomainHelperTest.php
@@ -31,7 +31,11 @@ class TrustedDomainHelperTest extends \Test\TestCase {
 	 * @param bool $result
 	 */
 	public function testIsTrustedDomain($trustedDomains, $testDomain, $result) {
-		$this->config->expects($this->once())
+		$this->config->expects($this->at(0))
+			->method('getSystemValue')
+			->with('overwritehost')
+			->will($this->returnValue(''));
+		$this->config->expects($this->at(1))
 			->method('getSystemValue')
 			->with('trusted_domains')
 			->will($this->returnValue($trustedDomains));
@@ -112,5 +116,16 @@ class TrustedDomainHelperTest extends \Test\TestCase {
 			[$trustedHostTestList, 'uppercase.domain', true],
 			[$trustedHostTestList, 'LOWERCASE.DOMAIN', true],
 		];
+	}
+
+	public function testIsTrustedDomainOverwriteHost() {
+		$this->config->expects($this->at(0))
+			->method('getSystemValue')
+			->with('overwritehost')
+			->will($this->returnValue('myproxyhost'));
+
+		$trustedDomainHelper = new TrustedDomainHelper($this->config);
+		$this->assertTrue($trustedDomainHelper->isTrustedDomain('myproxyhost'));
+		$this->assertTrue($trustedDomainHelper->isTrustedDomain('myotherhost'));
 	}
 }


### PR DESCRIPTION
Otherwise the trusted domain check in base.php might succeed while calling isTrustedDomain returns false