### PR TITLE
add and remove tags from multiple files at once

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -1138,3 +1138,15 @@ table.dragshadow td.size {
 #gallery-button {
 	display: none;
 }
+
+#tag_multiple_files_container {
+	overflow: hidden;
+	background-color: #fff;
+	border-radius: 3px;
+	position: relative;
+
+	td {
+		padding: 0 0.5em 0 0.5em;
+	}
+}
+

--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -102,6 +102,11 @@
 							displayName: t('files', 'Delete'),
 							iconClass: 'icon-delete',
 						},
+                        {   name: 'tags',
+                            displayName:  'Tags',
+                            iconClass: 'icon-tag'
+
+                        }
 					],
 					sorting: {
 						mode: $('#defaultFileSorting').val(),

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1163,10 +1163,9 @@
          * @private
          */
 		_onSelectTag: function(tagModel) {
-        	console.log('selected',tagModel.attributes);
         	var selectedFiles = _.pluck(this.getSelectedFiles(),'id')
 			if (!_.isArray(selectedFiles)) {
-				console.log('selected files - no array!', selectedFiles);
+				return;
 			}
             selectedFiles.forEach(function(fileId) {
                 $.ajax({
@@ -1182,10 +1181,9 @@
          * @private
          */
 		_onDeselectTag: function(tagId) {
-            var selectedFiles = _.pluck(this.getSelectedFiles(),'id')
-            console.log('removing tag', tagId, 'for files', selectedFiles, this.getSelectedFiles())
+            var selectedFiles = _.pluck(this.getSelectedFiles(),'id');
             if (!_.isArray(selectedFiles)) {
-                console.log('selected files - no array!', selectedFiles);
+                return;
             }
             selectedFiles.forEach(function(fileId) {
             	console.log('remove tag route',OC.linkToRemote('dav') + '/systemtags-relations/files/' +fileId + '/'+ tagId)

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1129,7 +1129,6 @@
                 self._inputView.on('deselect', self._onDeselectTag, self);
                 self._inputView.render();
                 self.tagsContainer = $('<tr id="tag_multiple_files_container"><th colspan="4"></th></tr>');
-               // console.log('inputView',self._inputView, self._inputView.$el,'tag container', self.tagsContainer);
                 self.tagsContainer.children()[0].append(self._inputView.$el.context);
                 $('#app-content-files>#filestable>thead').append(self.tagsContainer);
 


### PR DESCRIPTION
#10674 
Adds an option to the actions when multiple files are selected.
The tags from all selected files are fetched and the tags which are common to all files will be preselected.
When Tags are deselected they will be removed from all selected files.
When new Tags are selected or created they will be added to all files