### PR TITLE
Add a PSR-3 logger adapter and make it injectable

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1071,6 +1071,7 @@ return array(
     'OC\\Log\\File' => $baseDir . '/lib/private/Log/File.php',
     'OC\\Log\\LogDetails' => $baseDir . '/lib/private/Log/LogDetails.php',
     'OC\\Log\\LogFactory' => $baseDir . '/lib/private/Log/LogFactory.php',
+    'OC\\Log\\PsrLoggerAdapter' => $baseDir . '/lib/private/Log/PsrLoggerAdapter.php',
     'OC\\Log\\Rotate' => $baseDir . '/lib/private/Log/Rotate.php',
     'OC\\Log\\Syslog' => $baseDir . '/lib/private/Log/Syslog.php',
     'OC\\Log\\Systemdlog' => $baseDir . '/lib/private/Log/Systemdlog.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1100,6 +1100,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Log\\File' => __DIR__ . '/../../..' . '/lib/private/Log/File.php',
         'OC\\Log\\LogDetails' => __DIR__ . '/../../..' . '/lib/private/Log/LogDetails.php',
         'OC\\Log\\LogFactory' => __DIR__ . '/../../..' . '/lib/private/Log/LogFactory.php',
+        'OC\\Log\\PsrLoggerAdapter' => __DIR__ . '/../../..' . '/lib/private/Log/PsrLoggerAdapter.php',
         'OC\\Log\\Rotate' => __DIR__ . '/../../..' . '/lib/private/Log/Rotate.php',
         'OC\\Log\\Syslog' => __DIR__ . '/../../..' . '/lib/private/Log/Syslog.php',
         'OC\\Log\\Systemdlog' => __DIR__ . '/../../..' . '/lib/private/Log/Systemdlog.php',

--- a/lib/private/Log/PsrLoggerAdapter.php
+++ b/lib/private/Log/PsrLoggerAdapter.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OC\Log;
+
+use OCP\ILogger;
+use Psr\Log\InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+
+final class PsrLoggerAdapter implements LoggerInterface {
+
+	/** @var ILogger */
+	private $logger;
+
+	public function __construct(ILogger $logger) {
+		$this->logger = $logger;
+	}
+
+	/**
+	 * System is unusable.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 */
+	public function emergency($message, array $context = []): void {
+		$this->logger->emergency($message, $context);
+	}
+
+	/**
+	 * Action must be taken immediately.
+	 *
+	 * Example: Entire website down, database unavailable, etc. This should
+	 * trigger the SMS alerts and wake you up.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 */
+	public function alert($message, array $context = []) {
+		$this->logger->alert($message, $context);
+	}
+
+	/**
+	 * Critical conditions.
+	 *
+	 * Example: Application component unavailable, unexpected exception.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 */
+	public function critical($message, array $context = []) {
+		$this->logger->critical($message, $context);
+	}
+
+	/**
+	 * Runtime errors that do not require immediate action but should typically
+	 * be logged and monitored.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 */
+	public function error($message, array $context = []) {
+		$this->logger->error($message, $context);
+	}
+
+	/**
+	 * Exceptional occurrences that are not errors.
+	 *
+	 * Example: Use of deprecated APIs, poor use of an API, undesirable things
+	 * that are not necessarily wrong.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 */
+	public function warning($message, array $context = []) {
+		$this->logger->warning($message, $context);
+	}
+
+	/**
+	 * Normal but significant events.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 */
+	public function notice($message, array $context = []) {
+		$this->logger->notice($message, $context);
+	}
+
+	/**
+	 * Interesting events.
+	 *
+	 * Example: User logs in, SQL logs.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 */
+	public function info($message, array $context = []) {
+		$this->logger->info($message, $context);
+	}
+
+	/**
+	 * Detailed debug information.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 */
+	public function debug($message, array $context = []) {
+		$this->logger->debug($message, $context);
+	}
+
+	/**
+	 * Logs with an arbitrary level.
+	 *
+	 * @param mixed $level
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return void
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	public function log($level, $message, array $context = []) {
+		if (!is_int($level) || $level < ILogger::DEBUG || $level > ILogger::FATAL) {
+			throw new InvalidArgumentException('Nextcloud allows only integer log levels');
+		}
+		$this->logger->log($level, $message, $context);
+	}
+
+}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -101,6 +101,7 @@ use OC\Lock\MemcacheLockingProvider;
 use OC\Lock\NoopLockingProvider;
 use OC\Lockdown\LockdownManager;
 use OC\Log\LogFactory;
+use OC\Log\PsrLoggerAdapter;
 use OC\Mail\Mailer;
 use OC\Memcache\ArrayCache;
 use OC\Memcache\Factory;
@@ -222,6 +223,7 @@ use OCP\User\Events\UserDeletedEvent;
 use OCP\User\Events\UserLoggedInEvent;
 use OCP\User\Events\UserLoggedInWithCookieEvent;
 use OCP\User\Events\UserLoggedOutEvent;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use OCA\Files_External\Service\UserStoragesService;
@@ -720,6 +722,8 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 		$this->registerAlias(ILogger::class, \OC\Log::class);
 		$this->registerDeprecatedAlias('Logger', \OC\Log::class);
+		// PSR-3 logger
+		$this->registerAlias(LoggerInterface::class, PsrLoggerAdapter::class);
 
 		$this->registerService(ILogFactory::class, function (Server $c) {
 			return new LogFactory($c, $this->getSystemConfig());


### PR DESCRIPTION
Stumbled over https://www.php-fig.org/psr/psr-3/ because I'm writing a php library that I would like to make Nextcloud-agnostic. To be able to use a logger in the library, I chose to use the PSR-3 standard and inject a tiny adapter.

I figured it would make sense to have this in our code base. This smoothens the integration of 3rd party libraries.

Adding the interface as base of our ILogger is not possible as we have `string` type hints on the messages, whereas the PSR3 interface only has documented types.