### PR TITLE
Add event subscriber for transaction isolation level

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -886,6 +886,7 @@ return array(
     'OC\\DB\\SQLiteMigrator' => $baseDir . '/lib/private/DB/SQLiteMigrator.php',
     'OC\\DB\\SQLiteSessionInit' => $baseDir . '/lib/private/DB/SQLiteSessionInit.php',
     'OC\\DB\\SchemaWrapper' => $baseDir . '/lib/private/DB/SchemaWrapper.php',
+    'OC\\DB\\SetTransactionIsolationLevel' => $baseDir . '/lib/private/DB/SetTransactionIsolationLevel.php',
     'OC\\Dashboard\\DashboardManager' => $baseDir . '/lib/private/Dashboard/DashboardManager.php',
     'OC\\DatabaseException' => $baseDir . '/lib/private/DatabaseException.php',
     'OC\\DatabaseSetupException' => $baseDir . '/lib/private/DatabaseSetupException.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -915,6 +915,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\DB\\SQLiteMigrator' => __DIR__ . '/../../..' . '/lib/private/DB/SQLiteMigrator.php',
         'OC\\DB\\SQLiteSessionInit' => __DIR__ . '/../../..' . '/lib/private/DB/SQLiteSessionInit.php',
         'OC\\DB\\SchemaWrapper' => __DIR__ . '/../../..' . '/lib/private/DB/SchemaWrapper.php',
+        'OC\\DB\\SetTransactionIsolationLevel' => __DIR__ . '/../../..' . '/lib/private/DB/SetTransactionIsolationLevel.php',
         'OC\\Dashboard\\DashboardManager' => __DIR__ . '/../../..' . '/lib/private/Dashboard/DashboardManager.php',
         'OC\\DatabaseException' => __DIR__ . '/../../..' . '/lib/private/DatabaseException.php',
         'OC\\DatabaseSetupException' => __DIR__ . '/../../..' . '/lib/private/DatabaseSetupException.php',

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -151,8 +151,6 @@ class Connection extends ReconnectWrapper implements IDBConnection {
 		parent::__construct($params, $driver, $config, $eventManager);
 		$this->adapter = new $params['adapter']($this);
 		$this->tablePrefix = $params['tablePrefix'];
-
-		$this->setTransactionIsolation(TransactionIsolationLevel::READ_COMMITTED);
 	}
 
 	/**

--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -122,6 +122,7 @@ class ConnectionFactory {
 	public function getConnection($type, $additionalConnectionParams) {
 		$normalizedType = $this->normalizeType($type);
 		$eventManager = new EventManager();
+		$eventManager->addEventSubscriber(new SetTransactionIsolationLevel());
 		switch ($normalizedType) {
 			case 'mysql':
 				$eventManager->addEventSubscriber(

--- a/lib/private/DB/SetTransactionIsolationLevel.php
+++ b/lib/private/DB/SetTransactionIsolationLevel.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2019 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @author Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\DB;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\DBAL\Event\ConnectionEventArgs;
+use Doctrine\DBAL\Events;
+use Doctrine\DBAL\TransactionIsolationLevel;
+
+class SetTransactionIsolationLevel implements EventSubscriber {
+	/**
+	 * @param ConnectionEventArgs $args
+	 * @return void
+	 */
+	public function postConnect(ConnectionEventArgs $args) {
+		$args->getConnection()->setTransactionIsolation(TransactionIsolationLevel::READ_COMMITTED);
+	}
+
+	public function getSubscribedEvents() {
+		return [Events::postConnect];
+	}
+}


### PR DESCRIPTION
Fix #17947

Tricky one. Take a long running task (e.g. uploading a file). Connection is lost from sql server. `ReconnectWrapper` will handle the disconnect and reconnect. TransactionLevel is correct for the first connection but not for the reconnected one because setTransactionLevel works per connection.

This change is probably danger. `setTransactionIsolation(parent::TRANSACTION_READ_COMMITTED);` is the same as calling `$this->connect()` from the constructor.

**Master:** A new `DB\Connection` instance will connect immediately to the sql server (triggered by `setTransactionIsolation`.

**This PR:** Connection to sql server is established on demand. `postConnect` will run before the requested query. 

Don't have a reliable way to reproduce it yet. Keeping a process open with xdebug and kill the sql connection works sometimes ;)



