### PR TITLE
Fix restoring shared versions

### DIFF
--- a/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
+++ b/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
@@ -91,7 +91,7 @@ class LegacyVersionsBackend implements IVersionBackend {
 	}
 
 	public function rollback(IVersion $version) {
-		return Storage::rollback($version->getVersionPath(), $version->getRevisionId());
+		return Storage::rollback($version->getVersionPath(), $version->getRevisionId(), $version->getUser());
 	}
 
 	private function getVersionFolder(IUser $user): Folder {


### PR DESCRIPTION
To trigger:

1. userA shares a folder "testfolder" with userB which contains a file with versions
2. userB receives the folder in their root.
3. userB tries to restore a version -> works
4. userB moves the "testfolder" into another folder "foo"
5. userB navigates to the file in the folder and try to restore a version -> fails 

@icewind1991 please check/continue this. I'm not sure if this is the right way to tackle it.
