### PR TITLE
Hide the tooltip if the list row is rerendered

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2566,6 +2566,7 @@
 		 * @return {Object} new row element
 		 */
 		updateRow: function($tr, fileInfo, options) {
+			$tr.find('[data-original-title]').tooltip('hide');
 			this.files.splice($tr.index(), 1);
 			$tr.remove();
 			options = _.extend({silent: true}, options);


### PR DESCRIPTION
Steps to reproduce:
- Click the share icon for a file in the files list
- Click the date on another file (tooltip shows)
- Let the cursor stay on the date until the highlighted row changes
- Move the cursor -> the tooltip stays

Could not reproduce on master, therefore just 17/16