### PR TITLE
[stable16] Mark files_rightclick as shipped so it's marked as official

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -12,6 +12,7 @@
     "files",
     "files_external",
     "files_pdfviewer",
+    "files_rightclick",
     "files_sharing",
     "files_texteditor",
     "files_trashbin",


### PR DESCRIPTION
This PR is a backport of #16145 for stable16.