### PR TITLE
Make sure event names is always an array

### DIFF
--- a/apps/workflowengine/lib/AppInfo/Application.php
+++ b/apps/workflowengine/lib/AppInfo/Application.php
@@ -127,7 +127,7 @@ class Application extends \OCP\AppFramework\App {
 							}
 						}
 					);
-				}, $eventNames);
+				}, $eventNames ?? []);
 			}
 		}
 	}

--- a/apps/workflowengine/lib/Manager.php
+++ b/apps/workflowengine/lib/Manager.php
@@ -145,7 +145,7 @@ class Manager implements IManager {
 			$operations[$operation] = $operations[$row['class']] ?? [];
 			$operations[$operation][$entity] = $operations[$operation][$entity] ?? [];
 
-			$operations[$operation][$entity] = array_unique(array_merge($operations[$operation][$entity], $eventNames));
+			$operations[$operation][$entity] = array_unique(array_merge($operations[$operation][$entity], $eventNames ?? []));
 		}
 		$result->closeCursor();
 
@@ -589,7 +589,7 @@ class Manager implements IManager {
 
 			$operation['checks'][] = $check;
 		}
-		$operation['events'] = json_decode($operation['events'], true);
+		$operation['events'] = json_decode($operation['events'], true) ?? [];
 
 
 		return $operation;


### PR DESCRIPTION
Fixes error messages that were caused by existing workflow rules from before 18 that do have an empty string as event names set and therefore cause json_decode to return null.
