### PR TITLE
Fix search limit to home

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -797,6 +797,10 @@ class Cache implements ICache {
 			$query->andWhere($searchExpr);
 		}
 
+		if ($searchQuery->limitToHome() && ($this instanceof HomeCache)) {
+			$query->andWhere($builder->expr()->like('path', $query->expr()->literal('files/%')));
+		}
+
 		$this->querySearchHelper->addSearchOrdersToQuery($query, $searchQuery->getOrder());
 
 		if ($searchQuery->getLimit()) {


### PR DESCRIPTION
As reported by @skjnldsv in https://github.com/nextcloud/server/pull/17941
Fix https://github.com/nextcloud/server/issues/18204

Now do a proper like query on the path when we limit to the home storage. To ensure that if you hvae a lot of versions or trashbin files you still get your search results.