### PR TITLE
Add mimetype for keepass database.

### DIFF
--- a/resources/config/mimetypemapping.dist.json
+++ b/resources/config/mimetypemapping.dist.json
@@ -81,6 +81,7 @@
 	"js": ["application/javascript", "text/plain"],
 	"json": ["application/json", "text/plain"],
 	"k25": ["image/x-dcraw"],
+	"kdbx": ["application/x-kdbx"],
 	"kdc": ["image/x-dcraw"],
 	"key": ["application/x-iwork-keynote-sffkey"],
 	"keynote": ["application/x-iwork-keynote-sffkey"],


### PR DESCRIPTION
Make it possible to register actions for kdbx files. 

For an app it's hard to register a custom mime type without using nextcloud's internals (see https://github.com/jhass/nextcloud-keeweb/pull/124). 