### PR TITLE
Don't log the stack trace for ConnectException

### DIFF
--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -174,10 +174,10 @@ abstract class Fetcher {
 			$file->putContent(json_encode($responseJson));
 			return json_decode($file->getContent(), true)['data'];
 		} catch (ConnectException $e) {
-			$this->logger->logException($e, ['app' => 'appstoreFetcher', 'level' => ILogger::INFO, 'message' => 'Could not connect to appstore']);
+			$this->logger->warning('Could not connect to appstore: ' . $e->getMessage(), ['app' => 'appstoreFetcher']);
 			return [];
 		} catch (\Exception $e) {
-			$this->logger->logException($e, ['app' => 'appstoreFetcher', 'level' => ILogger::INFO]);
+			$this->logger->logException($e, ['app' => 'appstoreFetcher', 'level' => ILogger::WARN]);
 			return [];
 		}
 	}


### PR DESCRIPTION
Fix #18203 

The stack trace for ConnectException could contain the old apps.json content and is probably huge.