### PR TITLE
Fetch the share for the recipient

### DIFF
--- a/apps/files_sharing/lib/Notification/Notifier.php
+++ b/apps/files_sharing/lib/Notification/Notifier.php
@@ -58,6 +58,8 @@ class Notifier implements INotifier {
 	protected $userManager;
 	/** @var IURLGenerator */
 	protected $url;
+	/** @var string */
+	private $userId;
 
 
 	public function __construct(IFactory $l10nFactory,
@@ -65,13 +67,15 @@ class Notifier implements INotifier {
 								IRootFolder $rootFolder,
 								IGroupManager $groupManager,
 								IUserManager $userManager,
-								IURLGenerator $url) {
+								IURLGenerator $url,
+								string $userId) {
 		$this->l10nFactory = $l10nFactory;
 		$this->shareManager = $shareManager;
 		$this->rootFolder = $rootFolder;
 		$this->groupManager = $groupManager;
 		$this->userManager = $userManager;
 		$this->url = $url;
+		$this->userId = $userId;
 	}
 
 	/**
@@ -113,7 +117,7 @@ class Notifier implements INotifier {
 		$attemptId = $notification->getObjectId();
 
 		try {
-			$share = $this->shareManager->getShareById($attemptId);
+			$share = $this->shareManager->getShareById($attemptId, $this->userId);
 		} catch (ShareNotFound $e) {
 			throw new AlreadyProcessedException();
 		}


### PR DESCRIPTION
Fixes #18020

For group shares your invite might be handled but that doesn't mean the
whole share is handled. So we just need to make sure to fetch the share
for the current user.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>