### PR TITLE
Convert various columns in oc_mounts to bigint

### DIFF
--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -601,6 +601,7 @@ Raw output
 			'file_locks' => ['id'],
 			'jobs' => ['id'],
 			'mimetypes' => ['id'],
+			'mounts' => ['id', 'storage_id', 'root_id', 'mount_id'],
 			'storages' => ['numeric_id'],
 		];
 

--- a/core/Command/Db/ConvertFilecacheBigInt.php
+++ b/core/Command/Db/ConvertFilecacheBigInt.php
@@ -65,6 +65,7 @@ class ConvertFilecacheBigInt extends Command {
 			'file_locks' => ['id'],
 			'jobs' => ['id'],
 			'mimetypes' => ['id'],
+			'mounts' => ['id', 'storage_id', 'root_id', 'mount_id'],
 			'storages' => ['numeric_id'],
 		];
 	}


### PR DESCRIPTION
Fixes error messages like:
```
'SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'root_id' at row 1"'.
```