### PR TITLE
Fix Argument 3 passed to OCA\Encryption\Recovery::__construct() must …

### DIFF
--- a/apps/encryption/lib/AppInfo/Application.php
+++ b/apps/encryption/lib/AppInfo/Application.php
@@ -167,10 +167,8 @@ class Application extends \OCP\AppFramework\App {
 				return new Recovery(
 					$server->getUserSession(),
 					$c->query('Crypt'),
-					$server->getSecureRandom(),
 					$c->query('KeyManager'),
 					$server->getConfig(),
-					$server->getEncryptionKeyStorage(),
 					$server->getEncryptionFilesHelper(),
 					new View());
 			});

--- a/apps/encryption/lib/Recovery.php
+++ b/apps/encryption/lib/Recovery.php
@@ -30,12 +30,10 @@ namespace OCA\Encryption;
 use OC\Files\View;
 use OCA\Encryption\Crypto\Crypt;
 use OCP\Encryption\IFile;
-use OCP\Encryption\Keys\IStorage;
 use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\PreConditionNotMetException;
-use OCP\Security\ISecureRandom;
 
 class Recovery {
 

--- a/apps/settings/lib/Controller/ChangePasswordController.php
+++ b/apps/settings/lib/Controller/ChangePasswordController.php
@@ -215,10 +215,8 @@ class ChangePasswordController extends Controller {
 			$recovery = new \OCA\Encryption\Recovery(
 				\OC::$server->getUserSession(),
 				$crypt,
-				\OC::$server->getSecureRandom(),
 				$keyManager,
 				\OC::$server->getConfig(),
-				$keyStorage,
 				\OC::$server->getEncryptionFilesHelper(),
 				new \OC\Files\View());
 			$recoveryAdminEnabled = $recovery->isRecoveryKeyEnabled();


### PR DESCRIPTION
…be an instance of OCA\Encryption\KeyManager

Fix #18295 

