### PR TITLE
Fix comments search result to work with multibyte strings

### DIFF
--- a/apps/comments/lib/Search/Result.php
+++ b/apps/comments/lib/Search/Result.php
@@ -82,12 +82,12 @@ class Result extends BaseResult {
 	 * @throws NotFoundException
 	 */
 	protected function getRelevantMessagePart(string $message, string $search): string {
-		$start = stripos($message, $search);
+		$start = mb_stripos($message, $search);
 		if ($start === false) {
 			throw new NotFoundException('Comment section not found');
 		}
 
-		$end = $start + strlen($search);
+		$end = $start + mb_strlen($search);
 
 		if ($start <= 25) {
 			$start = 0;
@@ -97,15 +97,15 @@ class Result extends BaseResult {
 			$prefix = '…';
 		}
 
-		if ((strlen($message) - $end) <= 25) {
-			$end = strlen($message);
+		if ((mb_strlen($message) - $end) <= 25) {
+			$end = mb_strlen($message);
 			$suffix = '';
 		} else {
 			$end += 25;
 			$suffix = '…';
 		}
 
-		return $prefix . substr($message, $start, $end - $start) . $suffix;
+		return $prefix . mb_substr($message, $start, $end - $start) . $suffix;
 	}
 
 }


### PR DESCRIPTION
Currently, the searching in comments breaks up, if comments contain multibyte characters and string manipulation logic in getRelevantMessagePart happens to cut through them rendering the resulting string invalid (not UTF-8 compliant). This patch replaces all string manipulating functions in this code to multibyte aware ones.

Signed-off-by: Michał Węgrzynek <michal.wegrzynek@malloc.com.pl>