### PR TITLE
Do not disable authentication apps

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -158,8 +158,9 @@ class OC_App {
 					throw $ex;
 				}
 				\OC::$server->getLogger()->logException($ex);
-				if (!\OC::$server->getAppManager()->isShipped($app)) {
-					// Only disable apps which are not shipped
+
+				if (!\OC::$server->getAppManager()->isShipped($app) && !self::isType($app, ['authentication'])) {
+					// Only disable apps which are not shipped and that are not authentication apps
 					\OC::$server->getAppManager()->disableApp($app, true);
 				}
 			}


### PR DESCRIPTION
For #18249

If an app encounters an error during loading of app.php the app is
normally disabled. However. We should make sure that this doesn't happen
for authentication apps (looking at your user_saml).

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>