### PR TITLE
Viewer should be always enabled

### DIFF
--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -344,6 +344,7 @@ Feature: provisioning
 			| twofactor_backupcodes |
 			| updatenotification |
 			| user_ldap |
+			| viewer |
 			| workflowengine |
 			| files_external |
 			| oauth2 |

--- a/core/shipped.json
+++ b/core/shipped.json
@@ -52,6 +52,7 @@
     "oauth2",
     "settings",
     "twofactor_backupcodes",
+    "viewer",
     "workflowengine"
   ]
 }

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -390,6 +390,7 @@ class AppManagerTest extends TestCase {
 			'test1',
 			'test3',
 			'twofactor_backupcodes',
+			'viewer',
 			'workflowengine',
 		];
 		$this->assertEquals($apps, $this->manager->getInstalledApps());
@@ -418,6 +419,7 @@ class AppManagerTest extends TestCase {
 			'test1',
 			'test3',
 			'twofactor_backupcodes',
+			'viewer',
 			'workflowengine',
 		];
 		$this->assertEquals($enabled, $this->manager->getEnabledAppsForUser($user));
@@ -444,6 +446,7 @@ class AppManagerTest extends TestCase {
 			'testnoversion' => ['id' => 'testnoversion', 'requiremin' => '8.2.0'],
 			'settings' => ['id' => 'settings'],
 			'twofactor_backupcodes' => ['id' => 'twofactor_backupcodes'],
+			'viewer' => ['id' => 'viewer'],
 			'workflowengine' => ['id' => 'workflowengine'],
 			'oauth2' => ['id' => 'oauth2'],
 		];
@@ -494,6 +497,7 @@ class AppManagerTest extends TestCase {
 			'twofactor_backupcodes' => ['id' => 'twofactor_backupcodes'],
 			'workflowengine' => ['id' => 'workflowengine'],
 			'oauth2' => ['id' => 'oauth2'],
+			'viewer' => ['id' => 'viewer'],
 		];
 
 		$manager->expects($this->any())
@@ -537,6 +541,7 @@ class AppManagerTest extends TestCase {
 			'test1',
 			'test3',
 			'twofactor_backupcodes',
+			'viewer',
 			'workflowengine',
 		];
 		$this->assertEquals($enabled, $this->manager->getEnabledAppsForGroup($group));

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -346,6 +346,7 @@ class AppTest extends \Test\TestCase {
 					'provisioning_api',
 					'settings',
 					'twofactor_backupcodes',
+					'viewer',
 					'workflowengine',
 				),
 				false
@@ -367,6 +368,7 @@ class AppTest extends \Test\TestCase {
 					'provisioning_api',
 					'settings',
 					'twofactor_backupcodes',
+					'viewer',
 					'workflowengine',
 				),
 				false
@@ -389,6 +391,7 @@ class AppTest extends \Test\TestCase {
 					'provisioning_api',
 					'settings',
 					'twofactor_backupcodes',
+					'viewer',
 					'workflowengine',
 				),
 				false
@@ -411,6 +414,7 @@ class AppTest extends \Test\TestCase {
 					'provisioning_api',
 					'settings',
 					'twofactor_backupcodes',
+					'viewer',
 					'workflowengine',
 				),
 				false,
@@ -433,6 +437,7 @@ class AppTest extends \Test\TestCase {
 					'provisioning_api',
 					'settings',
 					'twofactor_backupcodes',
+					'viewer',
 					'workflowengine',
 				),
 				true,
@@ -511,11 +516,11 @@ class AppTest extends \Test\TestCase {
 			);
 
 		$apps = \OC_App::getEnabledApps();
-		$this->assertEquals(array('files', 'app3', 'cloud_federation_api', 'dav', 'federatedfilesharing', 'lookup_server_connector', 'oauth2', 'provisioning_api', 'settings', 'twofactor_backupcodes', 'workflowengine'), $apps);
+		$this->assertEquals(array('files', 'app3', 'cloud_federation_api', 'dav', 'federatedfilesharing', 'lookup_server_connector', 'oauth2', 'provisioning_api', 'settings', 'twofactor_backupcodes', 'viewer', 'workflowengine'), $apps);
 
 		// mock should not be called again here
 		$apps = \OC_App::getEnabledApps();
-		$this->assertEquals(array('files', 'app3', 'cloud_federation_api', 'dav', 'federatedfilesharing', 'lookup_server_connector', 'oauth2', 'provisioning_api', 'settings', 'twofactor_backupcodes', 'workflowengine'), $apps);
+		$this->assertEquals(array('files', 'app3', 'cloud_federation_api', 'dav', 'federatedfilesharing', 'lookup_server_connector', 'oauth2', 'provisioning_api', 'settings', 'twofactor_backupcodes', 'viewer', 'workflowengine'), $apps);
 
 		$this->restoreAppConfig();
 		\OC_User::setUserId(null);


### PR DESCRIPTION
Disabling this should not be possible as our unified viewer is used in other parts as well.

fix https://github.com/nextcloud/photos/issues/38