### PR TITLE
handle IPv6 addresses with an explict incoming interface at the end

### DIFF
--- a/lib/private/Security/Normalizer/IpAddress.php
+++ b/lib/private/Security/Normalizer/IpAddress.php
@@ -75,6 +75,10 @@ class IpAddress {
 		if ($ip[0] === '[' && $ip[-1] === ']') { // If IP is with brackets, for example [::1]
 			$ip = substr($ip, 1, strlen($ip) - 2);
 		}
+		$pos = strpos($ip, '%'); // if there is an explicit interface added to the IP, e.g. fe80::ae2d:d1e7:fe1e:9a8d%enp2s0
+		if ($pos !== false) {
+			$ip = substr($ip, 0, $pos-1);
+		}
 		$binary = \inet_pton($ip);
 		for ($i = 128; $i > $maskBits; $i -= 8) {
 			$j = \intdiv($i, 8) - 1;


### PR DESCRIPTION
I access the local nextcloud v17.0.1 instance via link only IPv6 address using apache v2.4.41 and php-apache v7.3.11 and got an internal server error when I try to log in:
 
access log:
```
fe80::ae2d:d1e7:fe1e:9a8d%enp2s0 - - [08/Dec/2019:12:01:55 +0100] "GET /index.php/login HTTP/1.1" 500 5067
```
nextcloud.log:
```
{"reqId":"skeRZ33woj8LjSQMRRvR","level":3,"time":"2019-12-10T20:40:09+00:00","remoteAddr":"fe80::ae2d:d1e7:fe1e:9a8d%enp2s0","user":"--","app":"index","method":"GET","url":"\/index.php\/login","message":{"Exception":"Exception","Message":"inet_ntop() expects parameter 1 to be string, bool given","Code":0,"Trace":[{"file":"\/usr\/share\/webapps\/nextcloud\/lib\/private\/AppFramework\/App.php","line":126,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->","args":[{"__class__":"OC\\Core\\Controller\\LoginController"},"showLoginForm"]},{"file":"\/usr\/share\/webapps\/nextcloud\/lib\/private\/AppFramework\/Routing\/RouteActionHandler.php","line":47,"function":"main","class":"OC\\AppFramework\\App","type":"::","args":["OC\\Core\\Controller\\LoginController","showLoginForm",{"__class__":"OC\\AppFramework\\DependencyInjection\\DIContainer"},{"_route":"core.login.showLoginForm"}]},{"function":"__invoke","class":"OC\\AppFramework\\Routing\\RouteActionHandler","type":"->","args":[{"_route":"core.login.showLoginForm"}]},{"file":"\/usr\/share\/webapps\/nextcloud\/lib\/private\/Route\/Router.php","line":297,"function":"call_user_func","args":[{"__class__":"OC\\AppFramework\\Routing\\RouteActionHandler"},{"_route":"core.login.showLoginForm"}]},{"file":"\/usr\/share\/webapps\/nextcloud\/lib\/base.php","line":1000,"function":"match","class":"OC\\Route\\Router","type":"->","args":["\/login"]},{"file":"\/usr\/share\/webapps\/nextcloud\/index.php","line":42,"function":"handleRequest","class":"OC","type":"::","args":[]}],"File":"\/usr\/share\/webapps\/nextcloud\/lib\/private\/AppFramework\/Http\/Dispatcher.php","Line":109,"Previous":{"Exception":"TypeError","Message":"inet_ntop() expects parameter 1 to be string, bool given","Code":0,"Trace":[{"file":"\/usr\/share\/webapps\/nextcloud\/lib\/private\/Security\/Normalizer\/IpAddress.php","line":82,"function":"inet_ntop","args":[false]},{"file":"\/usr\/share\/webapps\/nextcloud\/lib\/private\/Security\/Normalizer\/IpAddress.php","line":99,"function":"getIPv6Subnet","class":"OC\\Security\\Normalizer\\IpAddress","type":"->","args":["fe80::ae2d:d1e7:fe1e:9a8d%enp2s0",128]},{"file":"\/usr\/share\/webapps\/nextcloud\/lib\/private\/Security\/Bruteforce\/Throttler.php","line":221,"function":"getSubnet","class":"OC\\Security\\Normalizer\\IpAddress","type":"->","args":[]},{"file":"\/usr\/share\/webapps\/nextcloud\/core\/Controller\/LoginController.php","line":177,"function":"getDelay","class":"OC\\Security\\Bruteforce\\Throttler","type":"->","args":["fe80::ae2d:d1e7:fe1e:9a8d%enp2s0"]},{"file":"\/usr\/share\/webapps\/nextcloud\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":170,"function":"showLoginForm","class":"OC\\Core\\Controller\\LoginController","type":"->","args":[null,null]},{"file":"\/usr\/share\/webapps\/nextcloud\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":99,"function":"executeController","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->","args":[{"__class__":"OC\\Core\\Controller\\LoginController"},"showLoginForm"]},{"file":"\/usr\/share\/webapps\/nextcloud\/lib\/private\/AppFramework\/App.php","line":126,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->","args":[{"__class__":"OC\\Core\\Controller\\LoginController"},"showLoginForm"]},{"file":"\/usr\/share\/webapps\/nextcloud\/lib\/private\/AppFramework\/Routing\/RouteActionHandler.php","line":47,"function":"main","class":"OC\\AppFramework\\App","type":"::","args":["OC\\Core\\Controller\\LoginController","showLoginForm",{"__class__":"OC\\AppFramework\\DependencyInjection\\DIContainer"},{"_route":"core.login.showLoginForm"}]},{"function":"__invoke","class":"OC\\AppFramework\\Routing\\RouteActionHandler","type":"->","args":[{"_route":"core.login.showLoginForm"}]},{"file":"\/usr\/share\/webapps\/nextcloud\/lib\/private\/Route\/Router.php","line":297,"function":"call_user_func","args":[{"__class__":"OC\\AppFramework\\Routing\\RouteActionHandler"},{"_route":"core.login.showLoginForm"}]},{"file":"\/usr\/share\/webapps\/nextcloud\/lib\/base.php","line":1000,"function":"match","class":"OC\\Route\\Router","type":"->","args":["\/login"]},{"file":"\/usr\/share\/webapps\/nextcloud\/index.php","line":42,"function":"handleRequest","class":"OC","type":"::","args":[]}],"File":"\/usr\/share\/webapps\/nextcloud\/lib\/private\/Security\/Normalizer\/IpAddress.php","Line":82},"CustomMessage":"--"},"userAgent":"Mozilla\/5.0 (X11; Ubuntu; Linux x86_64; rv:71.0) Gecko\/20100101 Firefox\/71.0","version":"17.0.1.1"}
```
After removing the interface name at the end of the IP address it works fine.