### PR TITLE
17.0.2 RC1

### DIFF
--- a/resources/config/ca-bundle.crt
+++ b/resources/config/ca-bundle.crt
@@ -1,7 +1,7 @@
 ##
 ## Bundle of CA Root Certificates
 ##
-## Certificate data from Mozilla as of: Wed Oct 16 03:12:09 2019 GMT
+## Certificate data from Mozilla as of: Wed Nov 27 04:12:10 2019 GMT
 ##
 ## This is a bundle of X.509 certificates of public Certificate Authorities
 ## (CA). These were automatically extracted from Mozilla's root certificates
@@ -14,7 +14,7 @@
 ## Just configure this file as the SSLCACertificateFile.
 ##
 ## Conversion done with mk-ca-bundle.pl version 1.27.
-## SHA256: c979c6f35714a0fedb17d9e5ba37adecbbc91a8faf4186b4e23d6f9ca44fd6cb
+## SHA256: 607309057d0ec70f8e4e97b03906bafb2fcebb24cd37b5e8293e681ae26ceae0
 ##
 
 

--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(17, 0, 1, 1);
+$OC_Version = array(17, 0, 2, 0);
 
 // The human readable string
-$OC_VersionString = '17.0.1';
+$OC_VersionString = '17.0.2 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #17851 Actually return the quote when getting global storage info
* #17858 Also set X-OC-Mtime header for files that are smaller than 10MB
* #17883 FIX: horizontal scrolling on mobile due to tab accessibility navigation 'skip to content' positioned at a fixed position
* #17916 Fix reshare with circle
* #17919 Bump icewind/searchdav
* #17925 Make timeout a optional parameter
* #17928 Check quota before transfer ownership
* #17945 Re-acquired expired shared locks on large file uploads
* #17952 Pass through ServerNotAvailableException on app init
* #18036 Do not check for updates if we have no internet
* #18040 Convert more columns to bigint
* #18043 Fix installing with MySQL 8.0.4+
* #18047 Uid can be false when the user record does not exit
* #18050 Update the CRL
* #18054 Make chunksize (used to check for gone LDAP users) configurable
* #18075 Remove objectstore credentials
* #18100 Incorrect integer value: '' for column 'password_invalid' while migra…
* #18156 Trim the login name
* #18186 Delay creation of the cert bundle
* #18189 Handle token insert conflicts
* #18198 Throw an invalid token exception is token is marked outdated
* #18205 Backport #18120
* #18221 Mark "Talk" active on /call/token URLs
* #18247 Allow to unfavorite all files
* #18252 Hide the tooltip if the list row is rerendered
* #18306 Move overwritehost check to isTrustedDomain
* #18307 Convert various columns in oc_mounts to bigint
* #18332 Do not disable authentication apps
* #18337 Sharee API GS fixes
* #18352 Handle IPv6 addresses with an explict incoming interface at the end
* #18355 Adding share type circles
* #18358 Fix restoring shared versions
* [3rdparty#351](https://github.com/nextcloud/3rdparty/pull/351) Update icewind/searchdav to 1.0.2
* [activity#407](https://github.com/nextcloud/activity/pull/407) Is_dir can be null on blacklisted files
* [activity#412](https://github.com/nextcloud/activity/pull/412) Remove debug log
* [notifications#471](https://github.com/nextcloud/notifications/pull/471) Stable17 Use @nextcloud/axios so the csrf token gets refreshed
* [notifications#495](https://github.com/nextcloud/notifications/pull/495) Fix header icon hover & focus feedback
* [notifications#499](https://github.com/nextcloud/notifications/pull/499) Fix cutting of multibyte characters
* [notifications#506](https://github.com/nextcloud/notifications/pull/506) Do not send push notifications when nothing was deleted


Pending PRs:

* [x] #18366 Support more IPv6 addresses in the RefreshWebcalJob @backportbot-nextcloud
