### PR TITLE
15.0.14 RC1

### DIFF
--- a/resources/config/ca-bundle.crt
+++ b/resources/config/ca-bundle.crt
@@ -1,7 +1,7 @@
 ##
 ## Bundle of CA Root Certificates
 ##
-## Certificate data from Mozilla as of: Wed Oct 16 03:12:09 2019 GMT
+## Certificate data from Mozilla as of: Wed Nov 27 04:12:10 2019 GMT
 ##
 ## This is a bundle of X.509 certificates of public Certificate Authorities
 ## (CA). These were automatically extracted from Mozilla's root certificates
@@ -14,7 +14,7 @@
 ## Just configure this file as the SSLCACertificateFile.
 ##
 ## Conversion done with mk-ca-bundle.pl version 1.27.
-## SHA256: c979c6f35714a0fedb17d9e5ba37adecbbc91a8faf4186b4e23d6f9ca44fd6cb
+## SHA256: 607309057d0ec70f8e4e97b03906bafb2fcebb24cd37b5e8293e681ae26ceae0
 ##
 
 

--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(15, 0, 13, 1);
+$OC_Version = array(15, 0, 14, 0);
 
 // The human readable string
-$OC_VersionString = '15.0.13';
+$OC_VersionString = '15.0.14 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #17853 Actually return the quote when getting global storage info
* #17911 Always check via http and https whether htaccess is working
* #17954 Pass through ServerNotAvailableException on app init
* #18049 Uid can be false when the user record does not exit
* #18052 Update the CRL
* #18106 Revert "Load additional scripts on help page"
* #18117 Incorrect integer value: '' for column 'password_invalid' while migra…
* #18190 Delay creation of the cert bundle
* #18214 Correctly remove apps without any releases
* #18285 Fix removing groups that have a slash in the name
* #18310 Convert various columns in oc_mounts to bigint
* [activity#414](https://github.com/nextcloud/activity/pull/414) Remove debug log


Pending PRs:

* [x] #18357 Adding share type circles @backportbot-nextcloud
* [x] #18368 Support more IPv6 addresses in the RefreshWebcalJob @backportbot-nextcloud
