### PR TITLE
Deprecate hooks, emitter and Symfony dispatcher mechanisms

### DIFF
--- a/lib/private/Hooks/BasicEmitter.php
+++ b/lib/private/Hooks/BasicEmitter.php
@@ -23,6 +23,9 @@
 
 namespace OC\Hooks;
 
+/**
+ * @deprecated 18.0.0 use \OCP\EventDispatcher\IEventDispatcher
+ */
 abstract class BasicEmitter implements Emitter {
 	use EmitterTrait;
 }

--- a/lib/private/Hooks/Emitter.php
+++ b/lib/private/Hooks/Emitter.php
@@ -30,6 +30,7 @@ namespace OC\Hooks;
  * interface for all classes that are able to emit events
  *
  * @package OC\Hooks
+ * @deprecated 18.0.0 use events and the \OCP\EventDispatcher\IEventDispatcher service
  */
 interface Emitter {
 	/**

--- a/lib/private/Hooks/PublicEmitter.php
+++ b/lib/private/Hooks/PublicEmitter.php
@@ -24,6 +24,9 @@
 
 namespace OC\Hooks;
 
+/**
+ * @deprecated 18.0.0 use events and the \OCP\EventDispatcher\IEventDispatcher service
+ */
 class PublicEmitter extends BasicEmitter {
 	/**
 	 * @param string $scope

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1848,6 +1848,7 @@ class Server extends ServerContainer implements IServerContainer {
 	 *
 	 * @return EventDispatcherInterface
 	 * @since 8.2.0
+	 * @deprecated 18.0.0 use \OCP\EventDispatcher\IEventDispatcher
 	 */
 	public function getEventDispatcher() {
 		return $this->query(\OC\EventDispatcher\SymfonyAdapter::class);

--- a/lib/private/legacy/hook.php
+++ b/lib/private/legacy/hook.php
@@ -28,7 +28,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
-class OC_Hook{
+
+/**
+ * @deprecated 18.0.0 use events and the \OCP\EventDispatcher\IEventDispatcher service
+ */
+class OC_Hook {
 	public static $thrownExceptions = [];
 
 	static private $registered = array();


### PR DESCRIPTION
We won't remove them right away. But the deprecation is the first step towards a clean migration.

Ref #18028 
Ref #18322 