### PR TITLE
Support more IPv6 addresses in the RefreshWebcalJob

### DIFF
--- a/apps/dav/lib/BackgroundJob/RefreshWebcalJob.php
+++ b/apps/dav/lib/BackgroundJob/RefreshWebcalJob.php
@@ -251,6 +251,17 @@ class RefreshWebcalJob extends Job {
 				$this->logger->warning("Subscription $subscriptionId was not refreshed because it violates local access rules");
 				return null;
 			}
+
+			// Also check for IPv6 IPv4 nesting, because that's not covered by filter_var
+			if ((bool)filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) && substr_count($host, '.') > 0) {
+				$delimiter = strrpos($host, ':'); // Get last colon
+				$ipv4Address = substr($host, $delimiter + 1);
+
+				if (!filter_var($ipv4Address, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+					$this->logger->warning("Subscription $subscriptionId was not refreshed because it violates local access rules");
+					return null;
+				}
+			}
 		}
 
 		try {

--- a/apps/dav/tests/unit/BackgroundJob/RefreshWebcalJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/RefreshWebcalJobTest.php
@@ -241,6 +241,8 @@ class RefreshWebcalJobTest extends TestCase {
 			['172.16.42.1'],
 			['[fdf8:f53b:82e4::53]/secret.ics'],
 			['[fe80::200:5aee:feaa:20a2]/secret.ics'],
+			['[0:0:0:0:0:0:10.0.0.1]/secret.ics'],
+			['[0:0:0:0:0:ffff:127.0.0.0]/secret.ics'],
 			['10.0.0.1'],
 			['another-host.local'],
 			['service.localhost'],


### PR DESCRIPTION
This allows you to use IPv4 in IPv6 nesting for RefreshWebcalJob.