### PR TITLE
18 beta 3

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(18, 0, 0, 4);
+$OC_Version = array(18, 0, 0, 5);
 
 // The human readable string
-$OC_VersionString = '18.0.0 Beta2';
+$OC_VersionString = '18.0.0 Beta3';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #17018 Allow to force enable apps via CLI
* #17239 Move users management to multi line
* #17494 Return a default user record if json is broken
* #17784 Disable Clear-Site-Data for Chrom* (and Opera, Brave, etc)
* #18061 Load apps dav plugins on the old webdav route
* #18270 Transfer ownership function polishing
* #18302 Fix comments search result to work with multibyte strings
* #18351 Add typed events for the filesystem/scanner
* #18359 Dismiss transferownership notification cancels transfer
* #18365 Bump the CRL
* #18372 Clarified default permission setting string
* #18378 Removed unclear wording "non-link shares"
* #18384 Config.php setting to always accept internal shares
* #18385 Allow users to accept (internal) shares by default
* #18401 L10n. Change grammar.
* #18407 Bump css-loader from 3.2.1 to 3.3.2
* #18408 Bump eslint-plugin-import from 2.18.2 to 2.19.1
* #18410 Bump url-search-params-polyfill from 7.0.0 to 7.0.1
* #18417 Make it possible to find transfer to user by email
* #18418 Bump serialize-javascript to v2.1.2
* #18422 Design fixes for recommended apps
* #18428 Return empty template for default creators
* #18429 Add a fallback locale for personal settings page
* #18430 Fix/noid/double flow
* #18431 Query FederatedFileSharing Application instead of creating it
* #18438 Remove no longer generated chunks
* #18443 Update app info schema files
* #18446 Don't overwrite the settings from files
* #18448 Pass the proper storage-internal path
* #18456 Fix Office preview generation
* #18457 Use the user from the notification
* #18461 Flows that are managing themselves do not necessarily set the entity
* #18462 Fix listing users in groups with slash in the name
* [firstrunwizard#226](https://github.com/nextcloud/firstrunwizard/pull/226) Update recommended app notifications
* [logreader#289](https://github.com/nextcloud/logreader/pull/289) Update master php testing versions
* [notifications#514](https://github.com/nextcloud/notifications/pull/514) Update npm deps
* [photos#39](https://github.com/nextcloud/photos/pull/39) Bump css-loader from 3.3.0 to 3.3.2
* [photos#42](https://github.com/nextcloud/photos/pull/42) Bump cdav-library from `964c26c` to `723e236`
* [photos#58](https://github.com/nextcloud/photos/pull/58) Bump @nextcloud/axios from 0.5.0 to 1.1.0
* [privacy#287](https://github.com/nextcloud/privacy/pull/287) Bump eslint-plugin-import from 2.18.2 to 2.19.1
* [privacy#288](https://github.com/nextcloud/privacy/pull/288) Bump css-loader from 3.2.1 to 3.3.2
* [privacy#289](https://github.com/nextcloud/privacy/pull/289) Bump vue and vue-template-compiler
* [recommendations#154](https://github.com/nextcloud/recommendations/pull/154) Bump @babel/preset-env from 7.7.1 to 7.7.6
* [recommendations#160](https://github.com/nextcloud/recommendations/pull/160) Bump vue and vue-template-compiler
* [recommendations#162](https://github.com/nextcloud/recommendations/pull/162) Bump css-loader from 3.3.0 to 3.4.0


Pending PRs:

* [ ] #12946 Fix calendar emails to be outlook compatible @hdijkema
* [ ] #14845 Prepend wildcard to the LDAP search term @Toilal
* [ ] #16035 Dont show remote and email options if we have an exact match for local user email @icewind1991
* [ ] #16158 Jpeg use imagick @nachoparker
* [ ] #16632 Set proper root path for single file shares originating from other storages @juliushaertl
* [ ] #16737 New Group-Member association attribute (zimbraMailForwardingAddress) @tofuSCHNITZEL
* [ ] #16747 Prevent hitting the directory limit when creating image previews (#13091) @gbmaster
* [ ] #16791 Allow using the same user-provided credentials for multiple storages @icewind1991
* [ ] #16792 Harden data and config protection .htaccess @MichaIng
* [ ] #17028 Do not generate unnecessary max preview file @phpbg
* [ ] #17077 Disable link shares of disabled users @rullzer
* [ ] #17218 Fix: SMB/CIFS/CEPH mounted drive caused large file upload errors @stereu
* [ ] #17379 Add expiration date to share email @RageZBla
* [ ] #17609 Remove type hint for AbstractTrash.getSize() @scriptator
* [ ] #17623 Add support for download share on old android browser @j3l11234
* [ ] #17684 Add support for GuzzleHTTP 'no' proxy @mlatief
* [ ] #17705 Bump eslint-config-nextcloud from 0.0.6 to 0.1.0 @dependabot-preview
* [ ] #17717 Relax strict getHome behaviour for LDAP users in a shadow state @blizzz
* [ ] #17718 [provisioning_api] Optimization for for large installations @mikaelh
* [ ] #17861 Fix tab navigation of menu in public share pages @danxuliu
* [ ] #18010 Add create and delete checkbox for sharesidebar @GretaD
* [ ] #18080 Adding timeout param @daita
* [ ] #18126 Extend propertypath to 4000 @J0WI
* [ ] #18162 Flow file entity to provide the internal URL @blizzz
* [ ] #18193 Add tooltips to display name and email @onehappycat
* [ ] #18225 Add typed events for all user hooks and legacy events @ChristophWurst
* [ ] #18235 Confirm auth on share generated by Circles @daita
* [ ] #18411 Bump vue and vue-template-compiler @dependabot-preview
* [ ] #18427 Bump marked from 0.7.0 to 0.8.0 @rullzer
* [ ] #18433 Use File Node API for more download cases, skip unreadable files @blizzz
* [ ] #18442 Restore old behavior allowing to set custom appstore @georgehrke
* [ ] #18449 Fix Sidebar enabled check @skjnldsv
* [ ] #18455 Fix userlist alignment @GretaD
* [ ] [serverinfo#164](https://github.com/nextcloud/serverinfo/pull/164) Fix DOM problems and styling @LordSimal
