### PR TITLE
config.php setting to always accept internal shares

### DIFF
--- a/apps/files_sharing/composer/composer/autoload_classmap.php
+++ b/apps/files_sharing/composer/composer/autoload_classmap.php
@@ -46,6 +46,7 @@ return array(
     'OCA\\Files_Sharing\\Helper' => $baseDir . '/../lib/Helper.php',
     'OCA\\Files_Sharing\\Hooks' => $baseDir . '/../lib/Hooks.php',
     'OCA\\Files_Sharing\\ISharedStorage' => $baseDir . '/../lib/ISharedStorage.php',
+    'OCA\\Files_Sharing\\Listener\\GlobalShareAcceptanceListener' => $baseDir . '/../lib/Listener/GlobalShareAcceptanceListener.php',
     'OCA\\Files_Sharing\\Listener\\LoadAdditionalListener' => $baseDir . '/../lib/Listener/LoadAdditionalListener.php',
     'OCA\\Files_Sharing\\Listener\\LoadSidebarListener' => $baseDir . '/../lib/Listener/LoadSidebarListener.php',
     'OCA\\Files_Sharing\\Middleware\\OCSShareAPIMiddleware' => $baseDir . '/../lib/Middleware/OCSShareAPIMiddleware.php',

--- a/apps/files_sharing/composer/composer/autoload_static.php
+++ b/apps/files_sharing/composer/composer/autoload_static.php
@@ -61,6 +61,7 @@ class ComposerStaticInitFiles_Sharing
         'OCA\\Files_Sharing\\Helper' => __DIR__ . '/..' . '/../lib/Helper.php',
         'OCA\\Files_Sharing\\Hooks' => __DIR__ . '/..' . '/../lib/Hooks.php',
         'OCA\\Files_Sharing\\ISharedStorage' => __DIR__ . '/..' . '/../lib/ISharedStorage.php',
+        'OCA\\Files_Sharing\\Listener\\GlobalShareAcceptanceListener' => __DIR__ . '/..' . '/../lib/Listener/GlobalShareAcceptanceListener.php',
         'OCA\\Files_Sharing\\Listener\\LoadAdditionalListener' => __DIR__ . '/..' . '/../lib/Listener/LoadAdditionalListener.php',
         'OCA\\Files_Sharing\\Listener\\LoadSidebarListener' => __DIR__ . '/..' . '/../lib/Listener/LoadSidebarListener.php',
         'OCA\\Files_Sharing\\Middleware\\OCSShareAPIMiddleware' => __DIR__ . '/..' . '/../lib/Middleware/OCSShareAPIMiddleware.php',

--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -35,6 +35,7 @@ use OCA\Files_Sharing\Capabilities;
 use OCA\Files_Sharing\Controller\ExternalSharesController;
 use OCA\Files_Sharing\Controller\ShareController;
 use OCA\Files_Sharing\External\Manager;
+use OCA\Files_Sharing\Listener\GlobalShareAcceptanceListener;
 use OCA\Files_Sharing\Listener\LoadAdditionalListener;
 use OCA\Files_Sharing\Listener\LoadSidebarListener;
 use OCA\Files_Sharing\Middleware\OCSShareAPIMiddleware;
@@ -54,6 +55,7 @@ use OCP\Files\Config\IMountProviderCollection;
 use OCP\IContainer;
 use OCP\IGroup;
 use OCP\IServerContainer;
+use OCP\Share\Events\ShareCreatedEvent;
 use OCP\Util;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -210,6 +212,7 @@ class Application extends App {
 		$dispatcher->addListener('\OCP\Collaboration\Resources::loadAdditionalScripts', function() {
 			\OCP\Util::addScript('files_sharing', 'dist/collaboration');
 		});
+		$dispatcher->addServiceListener(ShareCreatedEvent::class, GlobalShareAcceptanceListener::class);
 
 		// notifications api to accept incoming user shares
 		$dispatcher->addListener('OCP\Share::postShare', function(GenericEvent $event) {
@@ -233,7 +236,7 @@ class Application extends App {
 		}
 
 		$sharingSublistArray = [];
-	
+
 		if (\OCP\Util::isSharingDisabledForUser() === false) {
 			array_push($sharingSublistArray, [
 				'id' => 'sharingout',
@@ -243,7 +246,7 @@ class Application extends App {
 				'name' => $l->t('Shared with others'),
 			]);
 		}
-	
+
 		array_push($sharingSublistArray, [
 			'id' => 'sharingin',
 			'appname' => 'files_sharing',
@@ -251,7 +254,7 @@ class Application extends App {
 			'order' => 15,
 			'name' => $l->t('Shared with you'),
 		]);
-	
+
 		if (\OCP\Util::isSharingDisabledForUser() === false) {
 			// Check if sharing by link is enabled
 			if ($config->getAppValue('core', 'shareapi_allow_links', 'yes') === 'yes') {
@@ -264,7 +267,7 @@ class Application extends App {
 				]);
 			}
 		}
-	
+
 		array_push($sharingSublistArray, [
 			'id' => 'deletedshares',
 			'appname' => 'files_sharing',
@@ -272,7 +275,7 @@ class Application extends App {
 			'order' => 19,
 			'name' => $l->t('Deleted shares'),
 		]);
-	
+
 		// show_Quick_Access stored as string
 		\OCA\Files\App::getNavigationManager()->add([
 			'id' => 'shareoverview',

--- a/apps/files_sharing/lib/Listener/GlobalShareAcceptanceListener.php
+++ b/apps/files_sharing/lib/Listener/GlobalShareAcceptanceListener.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_Sharing\Listener;
+
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IConfig;
+use OCP\Share\Events\ShareCreatedEvent;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+
+class GlobalShareAcceptanceListener implements IEventListener {
+
+	/** @var IConfig */
+	private $config;
+	/** @var IManager */
+	private $shareManager;
+
+	public function __construct(IConfig $config, IManager $shareManager) {
+		$this->config = $config;
+		$this->shareManager = $shareManager;
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof ShareCreatedEvent)) {
+			return;
+		}
+
+		if ($this->config->getSystemValueBool('sharing.interal_shares_accepted', false)) {
+			$share = $event->getShare();
+
+			if ($share->getShareType() === IShare::TYPE_USER || $share->getShareType() === IShare::TYPE_GROUP) {
+				$share->setStatus(IShare::STATUS_ACCEPTED);
+				$this->shareManager->updateShare($share);
+			}
+		}
+	}
+
+}

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1339,6 +1339,13 @@ $CONFIG = array(
 'sharing.minSearchStringLength' => 0,
 
 /**
+ * Starting with Nextcloud 18 also internal shares have to be accepted. Setting
+ * this setting to true forces all internal shares to be accepted directly.
+ * (resulting in pre 18 behavior).
+ */
+'sharing.interal_shares_accepted' => false,
+
+/**
  * All other configuration options
  */
 

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -418,6 +418,7 @@ return array(
     'OCP\\Settings\\ISettings' => $baseDir . '/lib/public/Settings/ISettings.php',
     'OCP\\Settings\\ISubAdminSettings' => $baseDir . '/lib/public/Settings/ISubAdminSettings.php',
     'OCP\\Share' => $baseDir . '/lib/public/Share.php',
+    'OCP\\Share\\Events\\ShareCreatedEvent' => $baseDir . '/lib/public/Share/Events/ShareCreatedEvent.php',
     'OCP\\Share\\Exceptions\\GenericShareException' => $baseDir . '/lib/public/Share/Exceptions/GenericShareException.php',
     'OCP\\Share\\Exceptions\\IllegalIDChangeException' => $baseDir . '/lib/public/Share/Exceptions/IllegalIDChangeException.php',
     'OCP\\Share\\Exceptions\\ShareNotFound' => $baseDir . '/lib/public/Share/Exceptions/ShareNotFound.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -447,6 +447,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Settings\\ISettings' => __DIR__ . '/../../..' . '/lib/public/Settings/ISettings.php',
         'OCP\\Settings\\ISubAdminSettings' => __DIR__ . '/../../..' . '/lib/public/Settings/ISubAdminSettings.php',
         'OCP\\Share' => __DIR__ . '/../../..' . '/lib/public/Share.php',
+        'OCP\\Share\\Events\\ShareCreatedEvent' => __DIR__ . '/../../..' . '/lib/public/Share/Events/ShareCreatedEvent.php',
         'OCP\\Share\\Exceptions\\GenericShareException' => __DIR__ . '/../../..' . '/lib/public/Share/Exceptions/GenericShareException.php',
         'OCP\\Share\\Exceptions\\IllegalIDChangeException' => __DIR__ . '/../../..' . '/lib/public/Share/Exceptions/IllegalIDChangeException.php',
         'OCP\\Share\\Exceptions\\ShareNotFound' => __DIR__ . '/../../..' . '/lib/public/Share/Exceptions/ShareNotFound.php',

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1171,7 +1171,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getEventDispatcher(),
 				$c->getMailer(),
 				$c->getURLGenerator(),
-				$c->getThemingDefaults()
+				$c->getThemingDefaults(),
+				$c->query(IEventDispatcher::class)
 			);
 
 			return $manager;

--- a/lib/public/Share/Events/ShareCreatedEvent.php
+++ b/lib/public/Share/Events/ShareCreatedEvent.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Share\Events;
+
+use OCP\EventDispatcher\Event;
+use OCP\Share\IShare;
+
+/**
+ * @since 18.0.0
+ */
+class ShareCreatedEvent extends Event {
+
+	/** @var IShare */
+	private $share;
+
+	/**
+	 * @since 18.0.0
+	 */
+	public function __construct(IShare $share) {
+		parent::__construct();
+
+		$this->share = $share;
+	}
+
+	/**
+	 * @since 18.0.0
+	 */
+	public function getShare(): IShare {
+		return $this->share;
+	}
+}


### PR DESCRIPTION
Part of #18255

Setting this new setting to true basically reverts back to the pre 18 behavior by just always accepting the internal shares.