### PR TITLE
add a fallback locale for personal settings page

### DIFF
--- a/apps/settings/lib/Settings/Personal/PersonalInfo.php
+++ b/apps/settings/lib/Settings/Personal/PersonalInfo.php
@@ -251,6 +251,13 @@ class PersonalInfo implements ISettings {
 			return 0 === strpos($localeCode['code'], $userLang);
 		});
 
+		if (!$userLocale) {
+			$userLocale = [
+				'code' => 'en',
+				'name' => 'English'
+			];
+		}
+
 		return [
 			'activelocaleLang' => $userLocaleString,
 			'activelocale' => $userLocale,


### PR DESCRIPTION
otherwise if the locale is set to an invalid or no longer existing locale
the rendering of the setting page will throw an exception

Signed-off-by: Robin Appelman <robin@icewind.nl>