### PR TITLE
Fix/noid/double flow

### DIFF
--- a/apps/workflowengine/lib/AppInfo/Application.php
+++ b/apps/workflowengine/lib/AppInfo/Application.php
@@ -110,7 +110,7 @@ class Application extends \OCP\AppFramework\App {
 									$operation->onEventCompat($eventName, $event, $ruleMatcher);
 								} else {
 									$logger = $this->getContainer()->getServer()->getLogger();
-									$logger->warning(
+									$logger->debug(
 										'Cannot handle event {name} of {event} against entity {entity} and operation {operation}',
 										[
 											'app' => self::APP_ID,

--- a/apps/workflowengine/lib/Service/RuleMatcher.php
+++ b/apps/workflowengine/lib/Service/RuleMatcher.php
@@ -124,7 +124,7 @@ class RuleMatcher implements IRuleMatcher {
 		$additionalScopes = $this->manager->getAllConfiguredScopesForOperation($class);
 		foreach ($additionalScopes as $hash => $scopeCandidate) {
 			/** @var ScopeContext $scopeCandidate */
-			if ($scopeCandidate->getScope() !== IManager::SCOPE_USER) {
+			if ($scopeCandidate->getScope() !== IManager::SCOPE_USER || in_array($scopeCandidate, $scopes)) {
 				continue;
 			}
 			if ($this->entity->isLegitimatedForUserId($scopeCandidate->getScopeId())) {


### PR DESCRIPTION
Saw with talk from master: any event would write twice. It's because the legimity check tried for the same running user again. Easy fix. 

Also lowers a logging message.