### PR TITLE
pass the proper storage-internal path

### DIFF
--- a/apps/workflowengine/lib/Entity/File.php
+++ b/apps/workflowengine/lib/Entity/File.php
@@ -113,7 +113,7 @@ class File implements IEntity, IDisplayText {
 		try {
 			$node = $this->getNode();
 			$ruleMatcher->setEntitySubject($this, $node);
-			$ruleMatcher->setFileInfo($node->getStorage(), $node->getPath());
+			$ruleMatcher->setFileInfo($node->getStorage(), $node->getInternalPath());
 		} catch (NotFoundException $e) {
 			// pass
 		}


### PR DESCRIPTION
* currently, this leads to failed retrieval of file IDs, meaning flows relying on system tags do not work
* files_accesscontrol did work, because it acts on the file wrapper level, and there it got the right path
