### PR TITLE
fix credentials saving success message notification color

### DIFF
--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -413,7 +413,7 @@ OCA.Files_External.StatusManager = {
 					}
 				},
 				success: function (data) {
-					OC.Notification.show(t('files_external', 'Credentials saved'), {type: 'error'});
+					OC.Notification.show(t('files_external', 'Credentials saved'), {type: 'success'});
 					dialog.ocdialog('close');
 					/* Trigger status check again */
 					OCA.Files_External.StatusManager.recheckConnectivityForMount([OC.basename(data.mountPoint)], true);


### PR DESCRIPTION
When prompted for credentials for external storage from the files list on entering an external storage, the success message had a red status bar, now it's properly green (for success)

old
![credentials saved](https://user-images.githubusercontent.com/1804221/71094702-b2bbd580-21ab-11ea-9e21-26c1d67e579a.png)

new
![credentials saved green](https://user-images.githubusercontent.com/1804221/71094705-b4859900-21ab-11ea-9ac3-cda4362563b5.png)


Signed-off-by: Sascha Wiswedel <sascha.wiswedel@nextcloud.com>