### PR TITLE
Only round the real avatars

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -407,7 +407,7 @@ body {
 .avatar, .avatardiv {
 	border-radius: 50%;
 	flex-shrink: 0;
-	img {
+	&> img {
 		border-radius: 50%;
 		flex-shrink: 0;
 	}


### PR DESCRIPTION
Before this all images were rounded, including the icons of contacts menu options

Fix https://github.com/nextcloud/spreed/issues/2572

Before | After
---|---
![Bildschirmfoto von 2019-12-20 12-13-46](https://user-images.githubusercontent.com/213943/71251305-4b746180-2322-11ea-8b00-ad8277f85f91.png) | ![Bildschirmfoto von 2019-12-20 12-11-03](https://user-images.githubusercontent.com/213943/71251308-4d3e2500-2322-11ea-8b31-aa775a06f562.png)
