### PR TITLE
Flow: report list of entities without array keys to frontend

### DIFF
--- a/apps/workflowengine/lib/Manager.php
+++ b/apps/workflowengine/lib/Manager.php
@@ -601,7 +601,7 @@ class Manager implements IManager {
 	public function getEntitiesList(): array {
 		$this->eventDispatcher->dispatch(IManager::EVENT_NAME_REG_ENTITY, new GenericEvent($this));
 
-		return array_merge($this->getBuildInEntities(), $this->registeredEntities);
+		return array_values(array_merge($this->getBuildInEntities(), $this->registeredEntities));
 	}
 
 	/**
@@ -640,7 +640,7 @@ class Manager implements IManager {
 	protected function getBuildInEntities(): array {
 		try {
 			return [
-				$this->container->query(File::class),
+				File::class => $this->container->query(File::class),
 			];
 		} catch (QueryException $e) {
 			$this->logger->logException($e);


### PR DESCRIPTION
lead to a blank flow settings page when a third party entity was registered. You can try with https://github.com/blizzz/flow_http_requests (it otherwise is pretty much incomplete). Possible this can be fixed on Vue side, too, I didn't look into it. It is already reasonable to reduce the data that goes down a little.