### PR TITLE
Fix broken upgrade caused by undefined method call

### DIFF
--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -151,6 +151,5 @@ class AppFetcher extends Fetcher {
 		parent::setVersion($version);
 		$this->fileName = $fileName;
 		$this->ignoreMaxVersion = $ignoreMaxVersion;
-		$this->setEndpoint();
 	}
 }


### PR DESCRIPTION
Not removed method call from f0bef8881dd9861c615f56da058a165c2cc5ce86

Makes occ upgrade fail