### PR TITLE
obsolete: enable option '--no-interaction' for db:convert-type

### DIFF
--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -211,12 +211,14 @@ class ConvertType extends Command implements CompletionAwareInterface {
 				$output->writeln('<comment>can be included by specifying the --all-apps option.</comment>');
 			}
 
-			/** @var QuestionHelper $helper */
-			$helper = $this->getHelper('question');
-			$question = new ConfirmationQuestion('Continue with the conversion (y/n)? [n] ', false);
+			if ($input->isInteractive()) {
+				/** @var QuestionHelper $helper */
+				$helper = $this->getHelper('question');
+				$question = new ConfirmationQuestion('Continue with the conversion (y/n)? [n] ', false);
 
-			if (!$helper->ask($input, $output, $question)) {
-				return;
+				if (!$helper->ask($input, $output, $question)) {
+					return;
+				}
 			}
 		}
 		$intersectingTables = array_intersect($toTables, $fromTables);


### PR DESCRIPTION
Signed-off-by: Bernhard Ostertag <bernieo.github@gmx.de>

When converting database type the option `--no-interaction` is currently ignored, which makes it impossible for some users to change database type (for example see: https://help.nextcloud.com/t/failed-to-connect-to-database-when-converting-sqlite-to-mysql/66782/7)

This pull request adds a check for the option `--no-interaction` for the command `occ db:convert-type`