### PR TITLE
enable option '--no-interaction' for db:convert-type

### DIFF
--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -212,12 +212,14 @@ class ConvertType extends Command implements CompletionAwareInterface {
 				$output->writeln('<comment>can be included by specifying the --all-apps option.</comment>');
 			}
 
-			/** @var QuestionHelper $helper */
-			$helper = $this->getHelper('question');
-			$question = new ConfirmationQuestion('Continue with the conversion (y/n)? [n] ', false);
+			if ($input->isInteractive()) {
+				/** @var QuestionHelper $helper */
+				$helper = $this->getHelper('question');
+				$question = new ConfirmationQuestion('Continue with the conversion (y/n)? [n] ', false);
 
-			if (!$helper->ask($input, $output, $question)) {
-				return;
+				if (!$helper->ask($input, $output, $question)) {
+					return;
+				}
 			}
 		}
 		$intersectingTables = array_intersect($toTables, $fromTables);

--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -212,14 +212,14 @@ class ConvertType extends Command implements CompletionAwareInterface {
 				$output->writeln('<comment>can be included by specifying the --all-apps option.</comment>');
 			}
 
-			if ($input->isInteractive()) {
-				/** @var QuestionHelper $helper */
-				$helper = $this->getHelper('question');
-				$question = new ConfirmationQuestion('Continue with the conversion (y/n)? [n] ', false);
+			$continueConversion = !$input->isInteractive(); // assume yes for --no-interaction and no otherwise.
+			$question = new ConfirmationQuestion('Continue with the conversion (y/n)? [n] ', $continueConversion);
 
-				if (!$helper->ask($input, $output, $question)) {
-					return;
-				}
+			/** @var QuestionHelper $helper */
+			$helper = $this->getHelper('question');
+
+			if (!$helper->ask($input, $output, $question)) {
+				return;
 			}
 		}
 		$intersectingTables = array_intersect($toTables, $fromTables);


### PR DESCRIPTION
Signed-off-by: Bernhard Ostertag <bernieo.code@gmx.de>

When converting database type the option `--no-interaction` is currently ignored, which makes it impossible for some users to change the database type via `occ` (for example see: https://help.nextcloud.com/t/failed-to-connect-to-database-when-converting-sqlite-to-mysql/66782/7)

This pull request adds a check for the option `--no-interaction` for the command `occ db:convert-type`