### PR TITLE
Modify regex to match some other chromium browsers

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -71,7 +71,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	// Firefox User Agent from https://developer.mozilla.org/en-US/docs/Web/HTTP/Gecko_user_agent_string_reference
 	const USER_AGENT_FIREFOX = '/^Mozilla\/5\.0 \([^)]+\) Gecko\/[0-9.]+ Firefox\/[0-9.]+$/';
 	// Chrome User Agent from https://developer.chrome.com/multidevice/user-agent
-	const USER_AGENT_CHROME = '/^Mozilla\/5\.0 \([^)]+\) AppleWebKit\/[0-9.]+ \(KHTML, like Gecko\)( Ubuntu Chromium\/[0-9.]+|) Chrome\/[0-9.]+ (Mobile Safari|Safari)\/[0-9.]+$/';
+	const USER_AGENT_CHROME = '/^Mozilla\/5\.0 \([^)]+\) AppleWebKit\/[0-9.]+ \(KHTML, like Gecko\)( Ubuntu Chromium\/[0-9.]+|) Chrome\/[0-9.]+ (Mobile Safari|Safari)\/[0-9.]+( (Vivaldi|Brave|OPR)\/[0-9.]+|)$/';
 	// Safari User Agent from http://www.useragentstring.com/pages/Safari/
 	const USER_AGENT_SAFARI = '/^Mozilla\/5\.0 \([^)]+\) AppleWebKit\/[0-9.]+ \(KHTML, like Gecko\) Version\/[0-9.]+ Safari\/[0-9.A-Z]+$/';
 	// Android Chrome user agent: https://developers.google.com/chrome/mobile/docs/user-agent

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -103,7 +103,7 @@ class RequestTest extends \Test\TestCase {
 	}
 
 
-	
+
 	public function testImmutableArrayAccess() {
 		$this->expectException(\RuntimeException::class);
 
@@ -123,7 +123,7 @@ class RequestTest extends \Test\TestCase {
 		$request['nickname'] = 'Janey';
 	}
 
-	
+
 	public function testImmutableMagicAccess() {
 		$this->expectException(\RuntimeException::class);
 
@@ -143,7 +143,7 @@ class RequestTest extends \Test\TestCase {
 		$request->{'nickname'} = 'Janey';
 	}
 
-	
+
 	public function testGetTheMethodRight() {
 		$this->expectException(\LogicException::class);
 
@@ -999,6 +999,27 @@ class RequestTest extends \Test\TestCase {
 				],
 				true,
 			],
+			[
+				'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.99 Safari/537.36 Vivaldi/2.9.1705.41',
+				[
+					Request::USER_AGENT_CHROME
+				],
+				true
+			],
+			[
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.38 Safari/537.36 Brave/75',
+				[
+					Request::USER_AGENT_CHROME
+				],
+				true
+			],
+			[
+				'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36 OPR/50.0.2762.67',
+				[
+					Request::USER_AGENT_CHROME
+				],
+				true
+			]
 		];
 	}
 
@@ -1246,7 +1267,7 @@ class RequestTest extends \Test\TestCase {
 		$this->assertSame('www.owncloud.org', self::invokePrivate($request, 'getOverwriteHost'));
 	}
 
-	
+
 	public function testGetPathInfoNotProcessible() {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('The requested uri(/foo.php) cannot be processed by the script \'/var/www/index.php\')');
@@ -1267,7 +1288,7 @@ class RequestTest extends \Test\TestCase {
 		$request->getPathInfo();
 	}
 
-	
+
 	public function testGetRawPathInfoNotProcessible() {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('The requested uri(/foo.php) cannot be processed by the script \'/var/www/index.php\')');


### PR DESCRIPTION
Fix #18579 

Removing `$` is probably cheaper.