### PR TITLE
Move scroll container to inner element

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -75,6 +75,11 @@
 	}
 }
 
+@mixin header-menu-height() {
+	min-height: calc(44px * 1.5); // show at least 1.5 entries
+	max-height: calc(100vh - #{$header-height} * 2);
+}
+
 #header {
 	/* Header menu */
 	$header-menu-entry-height: 44px;
@@ -88,13 +93,10 @@
 		z-index: 2000;
 		position: absolute;
 		max-width: 350px;
-		min-height: calc(44px * 1.5); // show at least 1.5 entries
-		max-height: calc(100vh - #{$header-height} * 2);
+		@include header-menu-height();
 		right: 5px; // relative to parent
 		top: $header-height;
 		margin: 0;
-		overflow-y: scroll;
-		-webkit-overflow-scrolling: touch;
 
 		&:not(.popovermenu) {
 			display: none;
@@ -113,9 +115,17 @@
 			right: 10px;
 		}
 
+		#apps > ul,
+		& > div,
+		& > ul {
+			overflow-y: auto;
+			-webkit-overflow-scrolling: touch;
+			@include header-menu-height();
+		}
+
 		/* Use by the apps menu and the settings right menu */
 		#apps > ul,
-		&.settings-menu {
+		&.settings-menu > ul {
 			li {
 				a {
 					display: inline-flex;


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/18606

To be tested together with https://github.com/nextcloud/notifications/pull/528

Reverts the approach from https://github.com/nextcloud/server/pull/16057 since using the wrapper menu element as a scroll container caused https://github.com/nextcloud/server/issues/18606. We now use the inner element to scroll but need to specify the same min-/max-height for both the wrapping and containing element. Otherwise the inner element would not adjust to the height properly.