### PR TITLE
Settings: More spacing for development notice

### DIFF
--- a/apps/settings/templates/settings/personal/development.notice.php
+++ b/apps/settings/templates/settings/personal/development.notice.php
@@ -1,4 +1,4 @@
-<div class="followupsection">
+<div class="section">
 	<p>
 		<?php print_unescaped(str_replace(
 			[


### PR DESCRIPTION
A bit similar to https://github.com/nextcloud/firstrunwizard/pull/251, we use `.section` to separate sections which should be clearly separate. `.followupsection` is for subsections.

### Before
Development notice stuck to the bottom elements:
![settings section before](https://user-images.githubusercontent.com/925062/71715380-c1f58100-2e43-11ea-8ef8-d71fda913250.png)

### After
Proper spacing:
![settings section now](https://user-images.githubusercontent.com/925062/71715382-c1f58100-2e43-11ea-87d4-7e822557b200.png)
