### PR TITLE
fix wording log in vs. login

### DIFF
--- a/core/templates/twofactorselectchallenge.php
+++ b/core/templates/twofactorselectchallenge.php
@@ -72,6 +72,6 @@ $noProviders = empty($_['providers']);
 	</p>
 	<?php endif; ?>
 	<p><a class="two-factor-secondary" href="<?php print_unescaped($_['logout_url']); ?>">
-		<?php p($l->t('Cancel log in')) ?>
+		<?php p($l->t('Cancel login')) ?>
 	</a></p>
 </div>

--- a/core/templates/twofactorsetupchallenge.php
+++ b/core/templates/twofactorsetupchallenge.php
@@ -11,6 +11,6 @@ $template = $_['template'];
 	<h2 class="two-factor-header"><?php p($provider->getDisplayName()); ?></h2>
 	<?php print_unescaped($template); ?>
 	<p><a class="two-factor-secondary" href="<?php print_unescaped($_['logout_url']); ?>">
-			<?php p($l->t('Cancel log in')) ?>
+			<?php p($l->t('Cancel login')) ?>
 	</a></p>
 </div>

--- a/core/templates/twofactorsetupselection.php
+++ b/core/templates/twofactorsetupselection.php
@@ -53,6 +53,6 @@ declare(strict_types=1);
 	<?php endforeach; ?>
 	</ul>
 	<p><a class="two-factor-secondary" href="<?php print_unescaped($_['logout_url']); ?>">
-		<?php p($l->t('Cancel log in')) ?>
+		<?php p($l->t('Cancel login')) ?>
 	</a></p>
 </div>

--- a/core/templates/twofactorshowchallenge.php
+++ b/core/templates/twofactorshowchallenge.php
@@ -34,6 +34,6 @@ $template = $_['template'];
 	</p>
 	<?php endif; ?>
 	<p><a class="two-factor-secondary" href="<?php print_unescaped($_['logout_url']); ?>">
-		<?php p($l->t('Cancel log in')) ?>
+		<?php p($l->t('Cancel login')) ?>
 	</a></p>
 </div>


### PR DESCRIPTION
"log in" is used as verb, while "login" is a noun.
In this case, what's supposed to be cancelled is the login process - therefore the noun must be used.

Signed-off-by: Sascha Wiswedel <sascha.wiswedel@nextcloud.com>