### PR TITLE
[#18661] Always include custom login image in theming

### DIFF
--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -12,7 +12,7 @@
 }
 
 @mixin faded-background-image {
-	@if ($color-primary == #0082C9) {
+	@if ($color-primary == #0082C9) or ($has-custom-background == true) {
 		background-image: $image-login-background, linear-gradient(40deg, $color-primary 0%, lighten($color-primary, 20%) 100%);
 
 		@if($has-custom-background == true) {


### PR DESCRIPTION
Fixes #18661 

This change will always show a custom login image regardless of the used color.

Signed-off-by: Marius David Wieschollek <git.public@mdns.eu>