### PR TITLE
 Trash bin: fix exception triggered if no correct fileId is provided.

### DIFF
--- a/apps/files_trashbin/lib/Controller/PreviewController.php
+++ b/apps/files_trashbin/lib/Controller/PreviewController.php
@@ -88,12 +88,12 @@ class PreviewController extends Controller {
 	 * @return DataResponse|Http\FileDisplayResponse
 	 */
 	public function getPreview(
-		int $fileId,
+		int $fileId = -1,
 		int $x = 128,
 		int $y = 128
 	) {
 
-		if ($x === 0 || $y === 0) {
+		if ($fileId === -1 || $x === 0 || $y === 0) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 


### PR DESCRIPTION
Somehow in some installations the trash bin preview controller is called with incorrect `$fileId`. By assigning a default value and catching the default, a `BAD_REQUEST` can be returned instead. This behavior is taken from the "normal" files preview controller.

This fixes #17115