### PR TITLE
Fix folder permission styling

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -786,6 +786,11 @@ table.dragshadow td.size {
 	}
 }
 
+.notCreatable {
+	padding-left: 12px;
+	padding-top: 12px;
+	color: var(--color-text-lighter);
+}
 
 #quota {
 	margin: 0 !important;


### PR DESCRIPTION
The styling was previously in https://github.com/nextcloud/server/blob/stable17/apps/files_sharing/src/style/sharetabview.scss#L260-L264 but got lost somewhere between stable17 and now.

Fix #18708 

Before
![](https://user-images.githubusercontent.com/1804221/71880927-9d462580-3131-11ea-8417-90649e6e01b0.png)
After
![image](https://user-images.githubusercontent.com/3404133/71965041-2c6d3f00-31ff-11ea-960e-e5f3c51c850f.png)
