### PR TITLE
Do not rerender the selection menu on show

### DIFF
--- a/apps/files/js/filemultiselectmenu.js
+++ b/apps/files/js/filemultiselectmenu.js
@@ -36,7 +36,6 @@
 		 */
 		show: function(context) {
 			this._context = context;
-			this.render();
 			this.$el.removeClass('hidden');
 			if (window.innerWidth < 480) {
 				this.$el.removeClass('menu-center').addClass('menu-right');


### PR DESCRIPTION
Steps to reproduce:
1. Get a folder shared read only
2. Select a file with the checkbox
3. Open the selected actions menu

Before:
- You see the delete option

After:
- The delete option is properly hidden