### PR TITLE
Tell Safari to watch out for changes of filter

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -875,6 +875,7 @@ $outter-margin: ($popoveritem-height - $popovericon-size) / 2;
 	right: 0;
 	filter: drop-shadow(0 1px 3px var(--color-box-shadow));
 	display: none;
+	will-change: filter;
 
 	&:after {
 		bottom: 100%;


### PR DESCRIPTION
fixes #18779 
fixes https://github.com/nextcloud/server/issues/18381

fixes various issues related to missing redrawing of css filter:
![c7de0483778764c77d16076ca0e53bde0a93bedb0a7230efb857356d69c8dade](https://user-images.githubusercontent.com/1250540/72072566-8d277500-32ee-11ea-9042-84f72ea7b349.png)
![9a93f7d8a00d62186b611dd408c61f8e51276875143b37ae58c8fcd5d11e376d](https://user-images.githubusercontent.com/1250540/72072568-8dc00b80-32ee-11ea-842f-1f412e1800b8.png)


Please review @nextcloud/mac 
