### PR TITLE
Remove reference link for memcached options as domain doesn't exist anymore

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1187,7 +1187,7 @@ $CONFIG = array(
 ),
 
 /**
- * Connection options for memcached, see http://apprize.info/php/scaling/15.html
+ * Connection options for memcached
  */
 'memcached_options' => array(
 	// Set timeouts to 50ms


### PR DESCRIPTION
Remove reference link as domain doesn't exist anymore.