### PR TITLE
Check if file already exists during file creation

### DIFF
--- a/lib/private/DirectEditing/Manager.php
+++ b/lib/private/DirectEditing/Manager.php
@@ -123,15 +123,21 @@ class Manager implements IManager {
 
 	public function create(string $path, string $editorId, string $creatorId, $templateId = null): string {
 		$userFolder = $this->rootFolder->getUserFolder($this->userId);
-		$file = $userFolder->newFile($path);
-		$editor = $this->getEditor($editorId);
-		$creators = $editor->getCreators();
-		foreach ($creators as $creator) {
-			if ($creator->getId() === $creatorId) {
-				$creator->create($file, $creatorId, $templateId);
-				return $this->createToken($editorId, $file, $path);
+		try {
+			$file = $userFolder->get($path);
+			throw new \RuntimeException('File already exists');
+		} catch (\OCP\Files\NotFoundException $e) {
+			$file = $userFolder->newFile($path);
+			$editor = $this->getEditor($editorId);
+			$creators = $editor->getCreators();
+			foreach ($creators as $creator) {
+				if ($creator->getId() === $creatorId) {
+					$creator->create($file, $creatorId, $templateId);
+					return $this->createToken($editorId, $file, $path);
+				}
 			}
 		}
+
 		throw new \RuntimeException('No creator found');
 	}
 

--- a/tests/lib/DirectEditing/ManagerTest.php
+++ b/tests/lib/DirectEditing/ManagerTest.php
@@ -12,6 +12,7 @@ use OCP\DirectEditing\IEditor;
 use OCP\DirectEditing\IToken;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IUserSession;
@@ -151,6 +152,10 @@ class ManagerTest extends TestCase {
 		$this->random->expects($this->once())
 			->method('generate')
 			->willReturn($expectedToken);
+		$this->userFolder
+			->method('get')
+			->with('/File.txt')
+			->willThrowException(new NotFoundException());
 		$this->userFolder->expects($this->once())
 			->method('newFile')
 			->willReturn($file);
@@ -167,6 +172,10 @@ class ManagerTest extends TestCase {
 		$this->random->expects($this->once())
 			->method('generate')
 			->willReturn($expectedToken);
+		$this->userFolder
+			->method('get')
+			->with('/File.txt')
+			->willThrowException(new NotFoundException());
 		$this->userFolder->expects($this->once())
 			->method('newFile')
 			->willReturn($file);
@@ -175,6 +184,12 @@ class ManagerTest extends TestCase {
 		$secondResult = $this->manager->edit($expectedToken);
 		$this->assertInstanceOf(DataResponse::class, $firstResult);
 		$this->assertInstanceOf(NotFoundResponse::class, $secondResult);
+	}
+
+	public function testCreateFileAlreadyExists() {
+		$this->expectException(\RuntimeException::class);
+
+		$this->manager->create('/File.txt', 'testeditor', 'createEmpty');
 	}
 
 }


### PR DESCRIPTION
Make sure to not overwrite existing files when creating them though the direct editing API.