### PR TITLE
Use paginated search for contacts

### DIFF
--- a/apps/dav/lib/CardDAV/AddressBookImpl.php
+++ b/apps/dav/lib/CardDAV/AddressBookImpl.php
@@ -105,6 +105,8 @@ class AddressBookImpl implements IAddressBook {
 	 * 	- 'types' boolean (since 15.0.0) If set to true, fields that come with a TYPE property will be an array
 	 *    example: ['id' => 5, 'FN' => 'Thomas Tanghus', 'EMAIL' => ['type => 'HOME', 'value' => 'g@h.i']]
 	 * 	- 'escape_like_param' - If set to false wildcards _ and % are not escaped
+	 * 	- 'limit' - Set a numeric limit for the search results
+	 * 	- 'offset' - Set the offset for the limited search results
 	 * @return array an array of contacts which are arrays of key-value-pairs
 	 *  example result:
 	 *  [

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -965,6 +965,12 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 				$query2->andWhere($query2->expr()->ilike('cp.value', $query->createNamedParameter('%' . $this->db->escapeLikeParameter($pattern) . '%')));
 			}
 		}
+		if (isset($options['limit'])) {
+			$query2->setMaxResults($options['limit']);
+		}
+		if (isset($options['offset'])) {
+			$query2->setFirstResult($options['offset']);
+		}
 
 		$query->select('c.carddata', 'c.uri')->from($this->dbCardsTable, 'c')
 			->where($query->expr()->in('c.id', $query->createFunction($query2->getSQL())));

--- a/lib/private/Collaboration/Collaborators/MailPlugin.php
+++ b/lib/private/Collaboration/Collaborators/MailPlugin.php
@@ -81,8 +81,7 @@ class MailPlugin implements ISearchPlugin {
 		$emailType = new SearchResultType('emails');
 
 		// Search in contacts
-		//@todo Pagination missing
-		$addressBookContacts = $this->contactsManager->search($search, ['EMAIL', 'FN']);
+		$addressBookContacts = $this->contactsManager->search($search, ['EMAIL', 'FN'], ['limit' => $limit, 'offset' => $offset]);
 		$lowerSearch = strtolower($search);
 		foreach ($addressBookContacts as $contact) {
 			if (isset($contact['EMAIL'])) {

--- a/lib/private/Collaboration/Collaborators/RemotePlugin.php
+++ b/lib/private/Collaboration/Collaborators/RemotePlugin.php
@@ -67,8 +67,7 @@ class RemotePlugin implements ISearchPlugin {
 		$resultType = new SearchResultType('remotes');
 
 		// Search in contacts
-		//@todo Pagination missing
-		$addressBookContacts = $this->contactsManager->search($search, ['CLOUD', 'FN']);
+		$addressBookContacts = $this->contactsManager->search($search, ['CLOUD', 'FN'], ['limit' => $limit, 'offset' => $offset]);
 		foreach ($addressBookContacts as $contact) {
 			if (isset($contact['isLocalSystemBook'])) {
 				continue;

--- a/lib/private/ContactsManager.php
+++ b/lib/private/ContactsManager.php
@@ -40,6 +40,8 @@ namespace OC {
 		 * @param array $searchProperties defines the properties within the query pattern should match
 		 * @param array $options = array() to define the search behavior
 		 * 	- 'escape_like_param' - If set to false wildcards _ and % are not escaped
+		 * 	- 'limit' - Set a numeric limit for the search results
+		 * 	- 'offset' - Set the offset for the limited search results
 		 * @return array an array of contacts which are arrays of key-value-pairs
 		 */
 		public function search($pattern, $searchProperties = [], $options = []) {

--- a/lib/public/Contacts/IManager.php
+++ b/lib/public/Contacts/IManager.php
@@ -96,6 +96,8 @@ interface IManager {
 	 * @param array $searchProperties defines the properties within the query pattern should match
 	 * @param array $options = array() to define the search behavior
 	 * 	- 'escape_like_param' - If set to false wildcards _ and % are not escaped
+	 * 	- 'limit' - Set a numeric limit for the search results
+	 * 	- 'offset' - Set the offset for the limited search results
 	 * @return array an array of contacts which are arrays of key-value-pairs
 	 * @since 6.0.0
 	 */

--- a/lib/public/IAddressBook.php
+++ b/lib/public/IAddressBook.php
@@ -71,6 +71,8 @@ namespace OCP {
 		 * 	- 'types' boolean (since 15.0.0) If set to true, fields that come with a TYPE property will be an array
 		 *    example: ['id' => 5, 'FN' => 'Thomas Tanghus', 'EMAIL' => ['type => 'HOME', 'value' => 'g@h.i']]
 		 * 	- 'escape_like_param' - If set to false wildcards _ and % are not escaped
+		 * 	- 'limit' - Set a numeric limit for the search results
+		 * 	- 'offset' - Set the offset for the limited search results
 		 * @return array an array of contacts which are arrays of key-value-pairs
 		 *  example result:
 		 *  [


### PR DESCRIPTION
This PR drastically improves the performance of searching for sharees when the system addressbook contains a lot of users. Without it all matching contact entries would be queried from the database for both SHARE_TYPE_REMOTE and SHARE_TYPE_EMAIL which led to quite bad performance when searching with queries that matched a lot of entries (1-3 characters)