### PR TITLE
Limit the size of the container on guest pages

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -99,7 +99,8 @@ body {
 }
 
 .wrapper {
-	max-width: 100%;
+	width: 100%;
+	max-width: 700px;
 	margin-top: 10vh;
 }
 

--- a/core/templates/update.use-cli.php
+++ b/core/templates/update.use-cli.php
@@ -14,7 +14,7 @@
 
 	<?php if ($_['tooBig']) { ?>
 		<div class="warning updateAnyways">
-			<?php p($l->t('I know that if I continue doing the update via web UI has the risk, that the request runs into a timeout and could cause data loss, but I have a backup and know how to restore my instance in case of a failure.' )); ?>
+			<p><?php p($l->t('I know that if I continue doing the update via web UI has the risk, that the request runs into a timeout and could cause data loss, but I have a backup and know how to restore my instance in case of a failure.' )); ?></p>
 			<a href="?IKnowThatThisIsABigInstanceAndTheUpdateRequestCouldRunIntoATimeoutAndHowToRestoreABackup=IAmSuperSureToDoThis" class="button updateAnywaysButton"><?php p($l->t('Upgrade via web on my own risk' )); ?></a>
 		</div>
 	<?php } ?>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/3404133/72167848-342e0e80-33cc-11ea-913c-1848f2f41a4e.png)

After:
![image](https://user-images.githubusercontent.com/3404133/72167800-24aec580-33cc-11ea-9c70-258fb93ab4dd.png)

It was actually smaller than 700px before, but I think that is a better value as it gives the text a bit more space and makes it more readable.