### PR TITLE
getRemoteAddress: Remove optional port number

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -659,6 +659,8 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 				if(isset($this->server[$header])) {
 					foreach(explode(',', $this->server[$header]) as $IP) {
 						$IP = trim($IP);
+						// Use IP only, remove the optional port (see RFC 7239, Section 5.3 and RFC 7230, Section 5.4)
+						$IP = explode(':', $IP)[0];  
 						if (filter_var($IP, FILTER_VALIDATE_IP) !== false) {
 							return $IP;
 						}


### PR DESCRIPTION
The `HTTP_X_FORWARED_FOR` header might contain the IP address and the port number, when used via an IIS proxy.
See https://serverfault.com/a/757994
As our setup requires the use of IIS as an incoming SSL proxy, this change allows the remote IP to be correctly detected.
In my opinion, as the port number is allowed according to the linked RFCs, NC should handle this case.