### PR TITLE
Update SecurityMiddleware.php

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -211,7 +211,7 @@ class SecurityMiddleware extends Middleware {
 	public function afterException($controller, $methodName, \Exception $exception): Response {
 		if ($exception instanceof SecurityException) {
 			if ($exception instanceof StrictCookieMissingException) {
-				return new RedirectResponse(\OC::$WEBROOT);
+				return new RedirectResponse(\OC::$WEBROOT . '/');
 			}
 			if (stripos($this->request->getHeader('Accept'),'html') === false) {
 				$response = new JSONResponse(

--- a/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
@@ -535,7 +535,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 			new StrictCookieMissingException()
 		);
 
-		$expected = new RedirectResponse(\OC::$WEBROOT);
+		$expected = new RedirectResponse(\OC::$WEBROOT . '/');
 		$this->assertEquals($expected , $response);
 	}
 


### PR DESCRIPTION
OC::$WEBROOT can be empty in case if your nextcloud installation has no url prefix. This will result in an empty Location Header.

in other areas OC::$WEBROOT is always used together with an /