### PR TITLE
use `nodeExists` instead of catching exceptions

### DIFF
--- a/lib/private/DirectEditing/Manager.php
+++ b/lib/private/DirectEditing/Manager.php
@@ -124,10 +124,9 @@ class Manager implements IManager {
 
 	public function create(string $path, string $editorId, string $creatorId, $templateId = null): string {
 		$userFolder = $this->rootFolder->getUserFolder($this->userId);
-		try {
-			$file = $userFolder->get($path);
+		if ($userFolder->nodeExists($path)) {
 			throw new \RuntimeException('File already exists');
-		} catch (\OCP\Files\NotFoundException $e) {
+		} else {
 			$file = $userFolder->newFile($path);
 			$editor = $this->getEditor($editorId);
 			$creators = $editor->getCreators();

--- a/tests/lib/DirectEditing/ManagerTest.php
+++ b/tests/lib/DirectEditing/ManagerTest.php
@@ -153,9 +153,9 @@ class ManagerTest extends TestCase {
 			->method('generate')
 			->willReturn($expectedToken);
 		$this->userFolder
-			->method('get')
+			->method('nodeExists')
 			->with('/File.txt')
-			->willThrowException(new NotFoundException());
+			->willReturn(false);
 		$this->userFolder->expects($this->once())
 			->method('newFile')
 			->willReturn($file);
@@ -173,9 +173,9 @@ class ManagerTest extends TestCase {
 			->method('generate')
 			->willReturn($expectedToken);
 		$this->userFolder
-			->method('get')
+			->method('nodeExists')
 			->with('/File.txt')
-			->willThrowException(new NotFoundException());
+			->willReturn(false);
 		$this->userFolder->expects($this->once())
 			->method('newFile')
 			->willReturn($file);
@@ -188,6 +188,10 @@ class ManagerTest extends TestCase {
 
 	public function testCreateFileAlreadyExists() {
 		$this->expectException(\RuntimeException::class);
+		$this->userFolder
+			->method('nodeExists')
+			->with('/File.txt')
+			->willReturn(true);
 
 		$this->manager->create('/File.txt', 'testeditor', 'createEmpty');
 	}


### PR DESCRIPTION
makes the intent of the code more clear imo

From #18805