### PR TITLE
Array access on int will fail on php7.4

### DIFF
--- a/lib/private/AppFramework/OCS/BaseResponse.php
+++ b/lib/private/AppFramework/OCS/BaseResponse.php
@@ -126,7 +126,7 @@ abstract class BaseResponse extends Response   {
 	 */
 	protected function toXML(array $array, \XMLWriter $writer) {
 		foreach ($array as $k => $v) {
-			if ($k[0] === '@') {
+			if (\is_string($k) && strpos($k, '@') === 0) {
 				$writer->writeAttribute(substr($k, 1), $v);
 				continue;
 			}

--- a/tests/lib/AppFramework/OCS/BaseResponseTest.php
+++ b/tests/lib/AppFramework/OCS/BaseResponseTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @author 2020 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Test\AppFramework\Middleware;
+
+
+use OC\AppFramework\OCS\BaseResponse;
+
+class BaseResponseTest extends \Test\TestCase {
+
+	public function testToXml(): void {
+
+		/** @var BaseResponse $response */
+		$response = $this->createMock(BaseResponse::class);
+
+		$writer = new \XMLWriter();
+		$writer->openMemory();
+		$writer->setIndent(false);
+		$writer->startDocument();
+
+		$data = [
+			'hello' => 'hello',
+			'information' => [
+				'@test' => 'some data',
+				'someElement' => 'withAttribute',
+			],
+			'value without key',
+		];
+
+		$this->invokePrivate($response, 'toXml', [$data, $writer]);
+		$writer->endDocument();
+
+		$this->assertEquals(
+			"<?xml version=\"1.0\"?>\n<hello>hello</hello><information test=\"some data\"><someElement>withAttribute</someElement></information><element>value without key</element>\n",
+			$writer->outputMemory(true)
+		);
+	}
+
+}


### PR DESCRIPTION
Fix #18689 

Probably possible to move writeAttribute into the else block of is_numeric. No idea how to trigger this kind of failure in the wild hence those weird test ;)