### PR TITLE
Fix Sidebar legacy FileInfoModel requirement

### DIFF
--- a/apps/files/lib/Listener/LoadSidebarListener.php
+++ b/apps/files/lib/Listener/LoadSidebarListener.php
@@ -39,6 +39,9 @@ class LoadSidebarListener implements IEventListener {
 		}
 
 		Util::addScript(Application::APP_ID, 'dist/sidebar');
+		// needed by the Sidebar legacy tabs
+		// TODO: remove when all tabs migrated to the new api
+		Util::addScript('files', 'fileinfomodel');
 	}
 
 }


### PR DESCRIPTION
Because the sidebar legacy tabs require the fileinfo to be set with the FileInfoModel https://github.com/nextcloud/server/blob/ec01e0a790448fff38364f629a4de4edb5d465bf/apps/files/src/components/LegacyTab.vue#L88, we need to have it available