### PR TITLE
Large Object support for OpenStack Swift

### DIFF
--- a/lib/private/Files/ObjectStore/Swift.php
+++ b/lib/private/Files/ObjectStore/Swift.php
@@ -32,6 +32,8 @@ use OCP\Files\ObjectStore\IObjectStore;
 use OCP\Files\StorageAuthException;
 use OpenStack\Common\Error\BadResponseError;
 
+const SWIFT_SEGMENT_SIZE = 1073741824; // 1GB
+
 class Swift implements IObjectStore {
 	/**
 	 * @var array
@@ -80,10 +82,18 @@ class Swift implements IObjectStore {
 		file_put_contents($tmpFile, $stream);
 		$handle = fopen($tmpFile, 'rb');
 
-		$this->getContainer()->createObject([
-			'name' => $urn,
-			'stream' => stream_for($handle)
-		]);
+		if (filesize($tmpFile) < SWIFT_SEGMENT_SIZE) {
+			$this->getContainer()->createObject([
+				'name' => $urn,
+				'stream' => stream_for($handle)
+			]);
+		} else {
+			$this->getContainer()->createLargeObject([
+				'name' => $urn,
+				'stream' => stream_for($handle),
+				'segmentSize' => SWIFT_SEGMENT_SIZE
+			]);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Until now, you wouldn't be able to create objects larger that 5GB.

It's worth noting that it doesn't improve efficiency. Here is how it work for default configuration:

1. Client divide file to chunks and upload each of those chunks as separate file

2. All chunks are pushed to object storage as they are received by Nextcloud

3. Client send MOVE request which assembly file and store it. In case of Swift (and probably other object storages too), it download all chunks, assembly it locally into one file, and then uploads again to Swift

You can improve efficiency by setting `cache_path` to for e.g. `/tmp/nextcloud_cache`, then file chunks wont be uploaded to Swift, but you will still have to wait when the assembled file is being uploaded to Swift. For large file it can lead to timeout on the client side.

Setting `cache_path` may not be appropriate for multi-node installation, in that case you probably need to have sticky-session or place cache on shared storage.

Edit: I see that issue has been already reported for e.g.: #6105, #7070
