### PR TITLE
Fix important private data leak

### DIFF
--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -113,6 +113,15 @@ class JSConfigHelper {
 	}
 
 	public function getConfig() {
+		
+		if (($this->config->getSystemValue('privatized', true)) && (!\OCP\User::isLoggedIn())) {
+			$result = '';
+			if ($this->appManager->isInstalled('files_videoplayer')) {
+				$result .= 'var _oc_appswebroots={"files_videoplayer":"' . \OC_App::getAppWebPath('files_videoplayer') . '"};' . PHP_EOL;
+			}
+			$result .= 'var oc_appconfig={"core":{"enforcePasswordForPublicLink":' . json_encode(\OCP\Util::isPublicLinkPasswordRequired()) . '}};' . PHP_EOL;
+			return $result;
+		}
 
 		$userBackendAllowsPasswordConfirmation = true;
 		if ($this->currentUser !== null) {


### PR DESCRIPTION
Current version expose many unnecessary informations about the installation to non logged-in visitor

- Password policy
- Installed apps
- Bruteforce delay
- Hostname
- Version  
- etc.

This patch fix this through the config option `'privatized' => true,` this remain an optional feature to avoid impacting the current behavior