### PR TITLE
Set timeout to 0 for cli requests and 30 seconds for web requests.

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -48,27 +48,33 @@ class Client implements IClient {
 	private $config;
 	/** @var ICertificateManager */
 	private $certificateManager;
+	/** @var bool */
+	private $isCli;
 
 	/**
 	 * @param IConfig $config
 	 * @param ICertificateManager $certificateManager
 	 * @param GuzzleClient $client
+	 * @param bool $isCli
 	 */
 	public function __construct(
 		IConfig $config,
 		ICertificateManager $certificateManager,
-		GuzzleClient $client
+		GuzzleClient $client,
+		bool $isCli
 	) {
 		$this->config = $config;
 		$this->client = $client;
 		$this->certificateManager = $certificateManager;
+		$this->isCli = $isCli;
 	}
 
 	private function buildRequestOptions(array $options): array {
+		$timeout = $this->isCli === false ? 30 : 0;
 		$defaults = [
 			RequestOptions::PROXY => $this->getProxyUri(),
 			RequestOptions::VERIFY => $this->getCertBundle(),
-			RequestOptions::TIMEOUT => 30,
+			RequestOptions::TIMEOUT => $timeout,
 		];
 
 		$options = array_merge($defaults, $options);

--- a/lib/private/Http/Client/ClientService.php
+++ b/lib/private/Http/Client/ClientService.php
@@ -58,6 +58,6 @@ class ClientService implements IClientService {
 	 * @return Client
 	 */
 	public function newClient(): IClient {
-		return new Client($this->config, $this->certificateManager, new GuzzleClient());
+		return new Client($this->config, $this->certificateManager, new GuzzleClient(), \OC::$CLI);
 	}
 }

--- a/tests/lib/Http/Client/ClientServiceTest.php
+++ b/tests/lib/Http/Client/ClientServiceTest.php
@@ -26,7 +26,7 @@ class ClientServiceTest extends \Test\TestCase {
 
 		$clientService = new ClientService($config, $certificateManager);
 		$this->assertEquals(
-			new Client($config, $certificateManager, new GuzzleClient()),
+			new Client($config, $certificateManager, new GuzzleClient(), true),
 			$clientService->newClient()
 		);
 	}

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -39,7 +39,8 @@ class ClientTest extends \Test\TestCase {
 		$this->client = new Client(
 			$this->config,
 			$this->certificateManager,
-			$this->guzzleClient
+			$this->guzzleClient,
+			true
 		);
 	}
 
@@ -113,7 +114,7 @@ class ClientTest extends \Test\TestCase {
 			'headers' => [
 				'User-Agent' => 'Nextcloud Server Crawler',
 			],
-			'timeout' => 30,
+			'timeout' => 0,
 		];
 	}
 
@@ -272,7 +273,7 @@ class ClientTest extends \Test\TestCase {
 			'headers' => [
 				'User-Agent' => 'Nextcloud Server Crawler'
 			],
-			'timeout' => 30,
+			'timeout' => 0,
 		], self::invokePrivate($this->client, 'buildRequestOptions', [[]]));
 	}
 
@@ -299,7 +300,32 @@ class ClientTest extends \Test\TestCase {
 			'headers' => [
 				'User-Agent' => 'Nextcloud Server Crawler'
 			],
-			'timeout' => 30,
+			'timeout' => 0,
 		], self::invokePrivate($this->client, 'buildRequestOptions', [[]]));
+	}
+
+	public function testTimeoutForWebRequest(): void {
+		$this->certificateManager
+			->expects($this->once())
+			->method('getAbsoluteBundlePath')
+			->with(null)
+			->willReturn('/my/path.crt');
+
+		$client = new Client(
+			$this->config,
+			$this->certificateManager,
+			$this->guzzleClient,
+			false
+		);
+
+		$this->assertEquals([
+			'verify' => '/my/path.crt',
+			'proxy' => null,
+			'headers' => [
+				'User-Agent' => 'Nextcloud Server Crawler'
+			],
+			'timeout' => 30,
+		], self::invokePrivate($client, 'buildRequestOptions', [[]]));
+
 	}
 }


### PR DESCRIPTION
I'm not able to download documentserver_community. It seems to be a big app. 30 seconds are not enough time to finish. 

This patch will
- disable the timeout for cli requests
- use the default value of 30 seconds for web requests

