### PR TITLE
\OC::server() method

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -124,9 +124,22 @@ class OC {
 	public static $server = null;
 
 	/**
+	 * @var \OC\Server
+	 */
+	private static $serverContainer = null;
+
+	/**
 	 * @var \OC\Config
 	 */
 	private static $config = null;
+
+	/**
+	 * @return \OC\Server
+	 */
+	public static function server()
+	{
+		return self::$serverContainer;
+	}
 
 	/**
 	 * @throws \RuntimeException when the 3rdparty directory is missing or
@@ -598,7 +611,8 @@ class OC {
 		}
 
 		// setup the basic server
-		self::$server = new \OC\Server(\OC::$WEBROOT, self::$config);
+		self::$serverContainer = new \OC\Server(self::$WEBROOT, self::$config);
+		self::$server = self::$serverContainer;
 		\OC::$server->getEventLogger()->log('autoloader', 'Autoloader', $loaderStart, $loaderEnd);
 		\OC::$server->getEventLogger()->start('boot', 'Initialize');
 


### PR DESCRIPTION
Currently anyone (read any app) can change global server container. This is first step to change it to "read only". After merging this PR you can use `\OC::server()` instead `\OC::$server` to be sure to get exactly properly initiated server container.

Next I can change all `\OC::$server` calls to `\OC::server()` in nextcloud codebase.
Then we can deprecate `public static $server` etc.

PS. public static properties (especially in such "global" classes like `\OC`) are smells :wink: 