### PR TITLE
Deleted max-width parameter from alternate-login tag

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -159,7 +159,6 @@ form #datadirField legend {
 	margin: 30px 15px 20px;
 	display: block;
 	min-width: 260px;
-	max-width: 400px;
 	overflow: hidden;
 }
 


### PR DESCRIPTION
When using app "https://github.com/pellaeon/registration" the "Registration" button on the start page is off-center. This seems to result from the combination of min-width and max-width for the css-tag #alternate-login, defined here.
I hope this does not clash with any other modules showing on the login page.