### PR TITLE
Fix security header setting in .htaccess by adding 'onsuccess unset' 

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -11,13 +11,30 @@
 
   <IfModule mod_env.c>
     # Add security and privacy related headers
+
+    # Avoid doubled headers by unsetting headers in "onsuccess" table,
+    # then add headers to "always" table: https://github.com/nextcloud/server/pull/19002
+    Header onsuccess unset Referrer-Policy
     Header always set Referrer-Policy "no-referrer"
+
+    Header onsuccess unset X-Content-Type-Options
     Header always set X-Content-Type-Options "nosniff"
+
+    Header onsuccess unset X-Download-Options
     Header always set X-Download-Options "noopen"
+
+    Header onsuccess unset X-Frame-Options
     Header always set X-Frame-Options "SAMEORIGIN"
+
+    Header onsuccess unset X-Permitted-Cross-Domain-Policies
     Header always set X-Permitted-Cross-Domain-Policies "none"
+
+    Header onsuccess unset X-Robots-Tag
     Header always set X-Robots-Tag "none"
+
+    Header onsuccess unset X-XSS-Protection
     Header always set X-XSS-Protection "1; mode=block"
+
     SetEnv modHeadersAvailable true
   </IfModule>
 


### PR DESCRIPTION
The headers might already be set by the system administrator at the http server
level (apache or nginx) for some or all virtualhosts.

Using `always set` in the .htaccess of Nextcloud leads to the situation where
the headers might be set twice (once in the default `onsuccess` table and once
in the `always` table)! Which leads to warnings in the admin area.

Adding `onsuccess unset` solves the problem, and forces the header in
the `onsucess` table to be unset, and the header in the `always` table to be set.

NOTE: with this change, Nextcloud overrides whatever the system administrator
might have already set

See github issues #16893 #16476 #16938 #18017