### PR TITLE
Increase the timeout for app downloads

### DIFF
--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -271,7 +271,7 @@ class Installer {
 				// Download the release
 				$tempFile = $this->tempManager->getTemporaryFile('.tar.gz');
 				$client = $this->clientService->newClient();
-				$client->get($app['releases'][0]['download'], ['save_to' => $tempFile]);
+				$client->get($app['releases'][0]['download'], ['save_to' => $tempFile, 'timeout' => 120]);
 
 				// Check if the signature actually matches the downloaded content
 				$certificate = openssl_get_publickey($app['certificate']);


### PR DESCRIPTION
Currently especially the document server (~300MB), the maps app (~30MB) and mail app (~20MB) are running into timeout issues. Increasing the timeout on the curl request will at least allow installing/updating via console.
For the web the php timeout could also be an issue, but that needs to be addressed with a note to the user in the UI instead.