### PR TITLE
Add link to help.nextcloud.com and bugbounty

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: Bug report
+name: 🐛 Bug report
 about: Help us improving by reporting a bug
 labels: bug, 0. Needs triage
 ---

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature request
+name: ✨ Feature request
 about: Suggest an idea for this project
 labels: enhancement, 0. Needs triage
 ---

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: ✨ Feature request
+name: 🚀 Feature request
 about: Suggest an idea for this project
 labels: enhancement, 0. Needs triage
 ---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+    - name: ❓ Question
+      url: https://help.nextcloud.com/
+      about: I have a question ...
+    - name: 🔒 Security Vulnerability
+      url: https://hackerone.com/nextcloud
+      about: Found a security vulnerability?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
     - name: ❓ Question
       url: https://help.nextcloud.com/
-      about: I have a question ...
+      about: I have a question …
     - name: 🔒 Security Vulnerability
       url: https://hackerone.com/nextcloud
       about: Found a security vulnerability?


### PR DESCRIPTION
Noticed at https://github.com/terraform-providers/terraform-provider-aws/issues/new/choose that they added some links to the new issue chooser. 

That seems to be a new GitHub feature https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository

