### PR TITLE
mb substring in audit_log

### DIFF
--- a/apps/admin_audit/lib/AppInfo/Application.php
+++ b/apps/admin_audit/lib/AppInfo/Application.php
@@ -183,7 +183,7 @@ class Application extends App {
 				/** @var File $file */
 				$file = $event->getSubject();
 				$fileActions->preview([
-					'path' => substr($file->getInternalPath(), 5),
+					'path' => mb_substr($file->getInternalPath(), 5),
 					'width' => $event->getArguments()['width'],
 					'height' => $event->getArguments()['height'],
 					'crop' => $event->getArguments()['crop'],


### PR DESCRIPTION
Fix corruption for logging internal path with multibyte characters in file preview event