### PR TITLE
Fix loaded controller check

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -131,7 +131,7 @@ class SecurityMiddleware extends Middleware {
 		// for normal HTML requests and not for AJAX requests
 		$this->navigationManager->setActiveEntry($this->appName);
 
-		if ($controller === \OCA\Talk\Controller\PageController::class && $methodName === 'showCall') {
+		if (get_class($controller) === \OCA\Talk\Controller\PageController::class && $methodName === 'showCall') {
 			$this->navigationManager->setActiveEntry('spreed');
 		}
 


### PR DESCRIPTION
Comparing objects to strings doesn't work too good in php with `===`

### Steps
1. Navigate to Talk
2. Enter a conversation
3. Do a page reload and check the triangle on the top menu