### PR TITLE
Make it possible to resolve svg's outside \OC::$SERVERROOT

### DIFF
--- a/core/Controller/SvgController.php
+++ b/core/Controller/SvgController.php
@@ -32,6 +32,7 @@ declare(strict_types=1);
 namespace OC\Core\Controller;
 
 use OC\Template\IconsCacher;
+use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -97,13 +98,13 @@ class SvgController extends Controller {
 	 * @return DataDisplayResponse|NotFoundResponse
 	 */
 	public function getSvgFromApp(string $app, string $fileName, string $color = 'ffffff') {
-		$appRootPath = $this->appManager->getAppPath($app);
-		$appPath = substr($appRootPath, strlen($this->serverRoot));
-
-		if (!$appPath) {
+		try {
+			$appPath = $this->appManager->getAppPath($app);
+		} catch (AppPathNotFoundException $e) {
 			return new NotFoundResponse();
 		}
-		$path = $this->serverRoot . $appPath ."/img/$fileName.svg";
+
+		$path = $appPath . "/img/$fileName.svg";
 		return $this->getSvg($path, $color, $fileName);
 	}
 

--- a/tests/data/svg/files-app-red.svg
+++ b/tests/data/svg/files-app-red.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="32" viewBox="0 0 32 32" width="32" version="1.1"><path fill="#f00" d="m3 4c-0.5 0-1 0.5-1 1v22c0 0.52 0.48 1 1 1h26c0.52 0 1-0.482 1-1v-18c0-0.5-0.5-1-1-1h-13l-4-4z"/></svg>

--- a/tests/data/svg/settings-admin-red.svg
+++ b/tests/data/svg/settings-admin-red.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 16 16" height="16" width="16" version="1.1"><path color="#000" d="m1 1v4h4v-4h-4zm5 1v2h8v-2h-8zm-5 4v4h4v-4h-4zm5 1v2h8v-2h-8zm-5 4v4h4v-4h-4zm1 1h2v2h-2v-2zm4 0v2h8v-2h-8z" fill="#f00"/></svg>


### PR DESCRIPTION
Resolve update blocker for snap.

Is this pr backportable? Alternatively we could keep the current approach and add the patch as fallback. 