### PR TITLE
add hub bundle for easy installation on upgraded instances

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -560,6 +560,7 @@ return array(
     'OC\\App\\AppStore\\Bundles\\EducationBundle' => $baseDir . '/lib/private/App/AppStore/Bundles/EducationBundle.php',
     'OC\\App\\AppStore\\Bundles\\EnterpriseBundle' => $baseDir . '/lib/private/App/AppStore/Bundles/EnterpriseBundle.php',
     'OC\\App\\AppStore\\Bundles\\GroupwareBundle' => $baseDir . '/lib/private/App/AppStore/Bundles/GroupwareBundle.php',
+    'OC\\App\\AppStore\\Bundles\\HubBundle' => $baseDir . '/lib/private/App/AppStore/Bundles/HubBundle.php',
     'OC\\App\\AppStore\\Bundles\\SocialSharingBundle' => $baseDir . '/lib/private/App/AppStore/Bundles/SocialSharingBundle.php',
     'OC\\App\\AppStore\\Fetcher\\AppFetcher' => $baseDir . '/lib/private/App/AppStore/Fetcher/AppFetcher.php',
     'OC\\App\\AppStore\\Fetcher\\CategoryFetcher' => $baseDir . '/lib/private/App/AppStore/Fetcher/CategoryFetcher.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -589,6 +589,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\App\\AppStore\\Bundles\\EducationBundle' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Bundles/EducationBundle.php',
         'OC\\App\\AppStore\\Bundles\\EnterpriseBundle' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Bundles/EnterpriseBundle.php',
         'OC\\App\\AppStore\\Bundles\\GroupwareBundle' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Bundles/GroupwareBundle.php',
+        'OC\\App\\AppStore\\Bundles\\HubBundle' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Bundles/HubBundle.php',
         'OC\\App\\AppStore\\Bundles\\SocialSharingBundle' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Bundles/SocialSharingBundle.php',
         'OC\\App\\AppStore\\Fetcher\\AppFetcher' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Fetcher/AppFetcher.php',
         'OC\\App\\AppStore\\Fetcher\\CategoryFetcher' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Fetcher/CategoryFetcher.php',

--- a/lib/private/App/AppStore/Bundles/BundleFetcher.php
+++ b/lib/private/App/AppStore/Bundles/BundleFetcher.php
@@ -42,6 +42,7 @@ class BundleFetcher {
 	public function getBundles() {
 		return [
 			new EnterpriseBundle($this->l10n),
+			new HubBundle($this->l10n),
 			new GroupwareBundle($this->l10n),
 			new SocialSharingBundle($this->l10n),
 			new EducationBundle($this->l10n),

--- a/lib/private/App/AppStore/Bundles/HubBundle.php
+++ b/lib/private/App/AppStore/Bundles/HubBundle.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\App\AppStore\Bundles;
+
+class HubBundle extends Bundle {
+
+	public function getName() {
+		return $this->l10n->t('Hub bundle');
+	}
+
+	public function getAppIdentifiers() {
+		return [
+			'spreed',
+			'contacts',
+			'calendar',
+			'mail',
+			'documentserver_community',
+			'onlyoffice',
+		];
+	}
+}

--- a/tests/lib/App/AppStore/Bundles/BundleFetcherTest.php
+++ b/tests/lib/App/AppStore/Bundles/BundleFetcherTest.php
@@ -26,6 +26,7 @@ use OC\App\AppStore\Bundles\CoreBundle;
 use OC\App\AppStore\Bundles\EducationBundle;
 use OC\App\AppStore\Bundles\EnterpriseBundle;
 use OC\App\AppStore\Bundles\GroupwareBundle;
+use OC\App\AppStore\Bundles\HubBundle;
 use OC\App\AppStore\Bundles\SocialSharingBundle;
 use OCP\IL10N;
 use Test\TestCase;
@@ -49,6 +50,7 @@ class BundleFetcherTest extends TestCase {
 	public function testGetBundles() {
 		$expected = [
 			new EnterpriseBundle($this->l10n),
+			new HubBundle($this->l10n),
 			new GroupwareBundle($this->l10n),
 			new SocialSharingBundle($this->l10n),
 			new EducationBundle($this->l10n),
@@ -69,7 +71,7 @@ class BundleFetcherTest extends TestCase {
 		$this->assertEquals(new GroupwareBundle($this->l10n), $this->bundleFetcher->getBundleByIdentifier('GroupwareBundle'));
 	}
 
-	
+
 	public function testGetBundleByIdentifierWithException() {
 		$this->expectException(\BadMethodCallException::class);
 		$this->expectExceptionMessage('Bundle with specified identifier does not exist');


### PR DESCRIPTION
Tada:

![Screenshot_20200123_210802](https://user-images.githubusercontent.com/2184312/73019721-73287f00-3e24-11ea-8508-63747e0c0697.png)

Q: Why are there so few?
A: https://github.com/nextcloud/server/issues/19104

Included are all that are being offered in the installation assistant on Nextcloud Hub when doing a fresh install.