### PR TITLE
[stable18] Reduce legacy event log level to debug

### DIFF
--- a/lib/private/EventDispatcher/SymfonyAdapter.php
+++ b/lib/private/EventDispatcher/SymfonyAdapter.php
@@ -63,7 +63,7 @@ class SymfonyAdapter implements EventDispatcherInterface {
 			$this->eventDispatcher->dispatch($eventName, $event);
 		} else {
 			// Legacy event
-			$this->logger->info(
+			$this->logger->debug(
 				'Deprecated event type for {name}: {class}',
 				[ 'name' => $eventName, 'class' => is_object($event) ? get_class($event) : 'null' ]
 			);


### PR DESCRIPTION
Newly opened to satisfy CI drone: #18966
_________
This is to reduce log flooding on info log level, which is currently expected due to deprecated event use in many apps and core: #18331
This information is helpful for developers only, hence should be sufficient as debug log. Especially due to the extremely high frequency this log can happen, it currently practically forces admins to disable info logs, which conflicts with other needs.

Fixes #18331, Fixes #19097

Signed-off-by: @MichaIng <micha@dietpi.com>