### PR TITLE
Move the Personal sections to the settings app

### DIFF
--- a/apps/settings/appinfo/info.xml
+++ b/apps/settings/appinfo/info.xml
@@ -16,4 +16,10 @@
 	<dependencies>
 		<nextcloud min-version="19" max-version="19"/>
 	</dependencies>
+
+	<settings>
+		<personal-section>OCA\Settings\Sections\Personal\PersonalInfo</personal-section>
+		<personal-section>OCA\Settings\Sections\Personal\Security</personal-section>
+		<personal-section>OCA\Settings\Sections\Personal\SyncClients</personal-section>
+	</settings>
 </info>

--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -41,4 +41,7 @@ return array(
     'OCA\\Settings\\Personal\\Security' => $baseDir . '/../lib/Settings/Personal/Security.php',
     'OCA\\Settings\\Personal\\Security\\Authtokens' => $baseDir . '/../lib/Settings/Personal/Security/Authtokens.php',
     'OCA\\Settings\\Personal\\ServerDevNotice' => $baseDir . '/../lib/Settings/Personal/ServerDevNotice.php',
+    'OCA\\Settings\\Sections\\Personal\\PersonalInfo' => $baseDir . '/../lib/Sections/Personal/PersonalInfo.php',
+    'OCA\\Settings\\Sections\\Personal\\Security' => $baseDir . '/../lib/Sections/Personal/Security.php',
+    'OCA\\Settings\\Sections\\Personal\\SyncClients' => $baseDir . '/../lib/Sections/Personal/SyncClients.php',
 );

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -56,6 +56,9 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\Personal\\Security' => __DIR__ . '/..' . '/../lib/Settings/Personal/Security.php',
         'OCA\\Settings\\Personal\\Security\\Authtokens' => __DIR__ . '/..' . '/../lib/Settings/Personal/Security/Authtokens.php',
         'OCA\\Settings\\Personal\\ServerDevNotice' => __DIR__ . '/..' . '/../lib/Settings/Personal/ServerDevNotice.php',
+        'OCA\\Settings\\Sections\\Personal\\PersonalInfo' => __DIR__ . '/..' . '/../lib/Sections/Personal/PersonalInfo.php',
+        'OCA\\Settings\\Sections\\Personal\\Security' => __DIR__ . '/..' . '/../lib/Sections/Personal/Security.php',
+        'OCA\\Settings\\Sections\\Personal\\SyncClients' => __DIR__ . '/..' . '/../lib/Sections/Personal/SyncClients.php',
     );
 
     public static function getInitializer(ClassLoader $loader)

--- a/apps/settings/lib/Sections/Personal/PersonalInfo.php
+++ b/apps/settings/lib/Sections/Personal/PersonalInfo.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Settings\Sections\Personal;
+
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\Settings\IIconSection;
+
+class PersonalInfo implements IIconSection {
+
+	/** @var IL10N */
+	private $l;
+
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
+	public function __construct(IL10N $l, IURLGenerator $urlGenerator) {
+		$this->l = $l;
+		$this->urlGenerator = $urlGenerator;
+	}
+
+	public function getIcon() {
+		return $this->urlGenerator->imagePath('core', 'actions/user.svg');
+	}
+
+	public function getID(): string {
+		return 'personal-info';
+	}
+
+	public function getName(): string {
+		return $this->l->t('Personal info');
+	}
+
+	public function getPriority(): int {
+		return 0;
+	}
+}

--- a/apps/settings/lib/Sections/Personal/Security.php
+++ b/apps/settings/lib/Sections/Personal/Security.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Settings\Sections\Personal;
+
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\Settings\IIconSection;
+
+class Security implements IIconSection {
+
+	/** @var IL10N */
+	private $l;
+
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
+	public function __construct(IL10N $l, IURLGenerator $urlGenerator) {
+		$this->l = $l;
+		$this->urlGenerator = $urlGenerator;
+	}
+
+	public function getIcon() {
+		return $this->urlGenerator->imagePath('settings', 'password.svg');
+	}
+
+	public function getID(): string {
+		return 'security';
+	}
+
+	public function getName(): string {
+		return $this->l->t('Security');
+	}
+
+	public function getPriority(): int {
+		return 5;
+	}
+}

--- a/apps/settings/lib/Sections/Personal/SyncClients.php
+++ b/apps/settings/lib/Sections/Personal/SyncClients.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Settings\Sections\Personal;
+
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\Settings\IIconSection;
+
+class SyncClients implements IIconSection {
+
+	/** @var IL10N */
+	private $l;
+
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
+	public function __construct(IL10N $l, IURLGenerator $urlGenerator) {
+		$this->l = $l;
+		$this->urlGenerator = $urlGenerator;
+	}
+
+	public function getIcon() {
+		return $this->urlGenerator->imagePath('core', 'clients/phone.svg');
+	}
+
+	public function getID(): string {
+		return 'sync-clients';
+	}
+
+	public function getName(): string {
+		return $this->l->t('Mobile & desktop');
+	}
+
+	public function getPriority(): int {
+		return 15;
+	}
+}

--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -350,11 +350,7 @@ class Manager implements IManager {
 			$this->l = $this->l10nFactory->get('lib');
 		}
 
-		$sections = [
-			0 => [new Section('personal-info', $this->l->t('Personal info'), 0, $this->url->imagePath('core', 'actions/user.svg'))],
-			5 => [new Section('security', $this->l->t('Security'), 0, $this->url->imagePath('settings', 'password.svg'))],
-			15 => [new Section('sync-clients', $this->l->t('Mobile & desktop'), 0, $this->url->imagePath('core', 'clients/phone.svg'))],
-		];
+		$sections = [];
 
 		$legacyForms = \OC_App::getForms('personal');
 		if (!empty($legacyForms) && $this->hasLegacyPersonalSettingsToRender($legacyForms)) {

--- a/tests/lib/Settings/ManagerTest.php
+++ b/tests/lib/Settings/ManagerTest.php
@@ -116,18 +116,7 @@ class ManagerTest extends TestCase {
 
 		$this->manager->registerSection('personal', \OCA\WorkflowEngine\Settings\Section::class);
 
-		$this->url->expects($this->exactly(3))
-			->method('imagePath')
-			->willReturnMap([
-				['core', 'actions/user.svg', '1'],
-				['settings', 'password.svg', '2'],
-				['core', 'clients/phone.svg', '3'],
-			]);
-
 		$this->assertEquals([
-			0 => [new Section('personal-info', 'Personal info', 0, '1')],
-			5 => [new Section('security', 'Security', 0, '2')],
-			15 => [new Section('sync-clients', 'Mobile & desktop', 0, '3')],
 			55 => [\OC::$server->query(\OCA\WorkflowEngine\Settings\Section::class)],
 		], $this->manager->getPersonalSections());
 	}
@@ -175,19 +164,7 @@ class ManagerTest extends TestCase {
 			->method('t')
 			->will($this->returnArgument(0));
 
-		$this->url->expects($this->exactly(3))
-			->method('imagePath')
-			->willReturnMap([
-				['core', 'actions/user.svg', '1'],
-				['settings', 'password.svg', '2'],
-				['core', 'clients/phone.svg', '3'],
-			]);
-
-		$this->assertArraySubset([
-			0 => [new Section('personal-info', 'Personal info', 0, '1')],
-			5 => [new Section('security', 'Security', 0, '2')],
-			15 => [new Section('sync-clients', 'Mobile & desktop', 0, '3')],
-		], $this->manager->getPersonalSections());
+		$this->assertEquals([], $this->manager->getPersonalSections());
 	}
 
 	public function testGetAdminSettings() {
@@ -276,7 +253,7 @@ class ManagerTest extends TestCase {
 		$this->manager->registerSection('personal', \OCA\WorkflowEngine\Settings\Section::class);
 		$this->manager->registerSection('admin', \OCA\WorkflowEngine\Settings\Section::class);
 
-		$this->url->expects($this->exactly(9))
+		$this->url->expects($this->exactly(6))
 			->method('imagePath')
 			->willReturnMap([
 				['core', 'actions/user.svg', '1'],
@@ -291,9 +268,6 @@ class ManagerTest extends TestCase {
 			]);
 
 		$this->assertEquals([
-			0 => [new Section('personal-info', 'Personal info', 0, '1')],
-			5 => [new Section('security', 'Security', 0, '2')],
-			15 => [new Section('sync-clients', 'Mobile & desktop', 0, '3')],
 			55 => [\OC::$server->query(\OCA\WorkflowEngine\Settings\Section::class)],
 		], $this->manager->getPersonalSections());
 


### PR DESCRIPTION
There is no need to have weird magic in the manager. This should be
properly registered in the right way. The settings code is messy
anyways. This is a start to make it a tad more clean.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>