### PR TITLE
Do not encode contacts menu mailto links

### DIFF
--- a/lib/private/Contacts/ContactsMenu/ActionFactory.php
+++ b/lib/private/Contacts/ContactsMenu/ActionFactory.php
@@ -50,7 +50,7 @@ class ActionFactory implements IActionFactory {
 	 * @return ILinkAction
 	 */
 	public function newEMailAction($icon, $name, $email) {
-		return $this->newLinkAction($icon, $name, 'mailto:' . urlencode($email));
+		return $this->newLinkAction($icon, $name, 'mailto:' . $email);
 	}
 
 }

--- a/tests/lib/Contacts/ContactsMenu/ActionFactoryTest.php
+++ b/tests/lib/Contacts/ContactsMenu/ActionFactoryTest.php
@@ -61,7 +61,7 @@ class ActionFactoryTest extends TestCase {
 		$this->assertInstanceOf(IAction::class, $action);
 		$this->assertEquals($name, $action->getName());
 		$this->assertEquals(10, $action->getPriority());
-		$this->assertEquals('mailto:user%40example.com', $action->getHref());
+		$this->assertEquals('mailto:user@example.com', $action->getHref());
 	}
 
 }


### PR DESCRIPTION
While writing unit tests for https://github.com/nextcloud/mail/pull/2569 I realized that our mailto links look different to other examples on the internet. Ours use `%40` in the `href` and the others just use `@`. Also https://www.lifewire.com/constructing-mailto-urls-1166417 shows that you only need to encode `subject` or other enhanced props (not relevant here).

In any case, I think we should remove the encoding. Links then work fine with Mail, but also with Gnome Evolution. I do not have other clients at hand to test. I also tried to inject HTML with an invalid contacts email address but we escape that on a HTML level when the `<a>` is rendered.