### PR TITLE
Fix query selector for inverted icons

### DIFF
--- a/apps/accessibility/css/dark.scss
+++ b/apps/accessibility/css/dark.scss
@@ -22,7 +22,8 @@ $color-border-dark: lighten($color-main-background, 14%);
 #contactsmenu-menu a,
 #expanddiv a,
 .activity-section .activity-icon.monochrome {
-	img :not(.avatardiv){
+	& > img,
+	:not(.avatardiv) > img {
 		filter: invert(100%);
 	}
 }


### PR DESCRIPTION
Check icons in | Before | After
---|---|---
Files  | :heavy_check_mark: | :heavy_check_mark: 
Talk | :heavy_check_mark: | :heavy_check_mark: 
Activity | :heavy_multiplication_x: : | :heavy_check_mark: 
Settings menu | :heavy_multiplication_x: : | :heavy_check_mark: 
Settings app | :heavy_multiplication_x: : | :heavy_check_mark: 

Follow up to #19113 