### PR TITLE
Check for empty authorization headers for office requests

### DIFF
--- a/apps/dav/lib/Connector/Sabre/AnonymousOptionsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/AnonymousOptionsPlugin.php
@@ -62,8 +62,11 @@ class AnonymousOptionsPlugin extends ServerPlugin {
 	 */
 	public function handleAnonymousOptions(RequestInterface $request, ResponseInterface $response) {
 		$isOffice = preg_match('/Microsoft Office/i', $request->getHeader('User-Agent'));
-		$isAnonymousOption = ($request->getMethod() === 'OPTIONS' && ($request->getHeader('Authorization') === null || trim($request->getHeader('Authorization')) === 'Bearer') && $this->isRequestInRoot($request->getPath()));
-		$isOfficeHead = $request->getMethod() === 'HEAD' && $isOffice && $request->getHeader('Authorization') === 'Bearer';
+		$emptyAuth = $request->getHeader('Authorization') === null
+			|| $request->getHeader('Authorization') === ''
+			|| trim($request->getHeader('Authorization')) === 'Bearer';
+		$isAnonymousOption = $request->getMethod() === 'OPTIONS' && $emptyAuth;
+		$isOfficeHead = $request->getMethod() === 'HEAD' && $isOffice && $emptyAuth;
 		if ($isAnonymousOption || $isOfficeHead) {
 			/** @var CorePlugin $corePlugin */
 			$corePlugin = $this->server->getPlugin('core');

--- a/apps/dav/tests/unit/DAV/AnonymousOptionsTest.php
+++ b/apps/dav/tests/unit/DAV/AnonymousOptionsTest.php
@@ -33,7 +33,7 @@ use Sabre\HTTP\Sapi;
 use Test\TestCase;
 
 class AnonymousOptionsTest extends TestCase {
-	private function sendRequest($method, $path) {
+	private function sendRequest($method, $path, $userAgent = '') {
 		$server = new Server();
 		$server->addPlugin(new AnonymousOptionsPlugin());
 		$server->addPlugin(new Plugin(new BasicCallBack(function() {
@@ -42,6 +42,7 @@ class AnonymousOptionsTest extends TestCase {
 
 		$server->httpRequest->setMethod($method);
 		$server->httpRequest->setUrl($path);
+		$server->httpRequest->setHeader('User-Agent', $userAgent);
 
 		$server->sapi = new SapiMock();
 		$server->exec();
@@ -63,7 +64,19 @@ class AnonymousOptionsTest extends TestCase {
 	public function testAnonymousOptionsNonRootSubDir() {
 		$response = $this->sendRequest('OPTIONS', 'foo/bar');
 
-		$this->assertEquals(401, $response->getStatus());
+		$this->assertEquals(200, $response->getStatus());
+	}
+
+	public function testAnonymousHead() {
+		$response = $this->sendRequest('HEAD', '', 'Microsoft Office does strange things');
+
+		$this->assertEquals(200, $response->getStatus());
+	}
+
+	public function testAnonymousHeadNoOffice() {
+		$response = $this->sendRequest('HEAD', '');
+
+		$this->assertEquals(401, $response->getStatus(), 'curl');
 	}
 }
 


### PR DESCRIPTION
Apparently some office versions do also sent an request without an authorization header or with `Authorization: Bearer` and expect the request to return a successful status for their HEAD request. The OPTIONS request is also not only performed on the root folder but the parent one.

This should fix opening Office files from a mounted webdav drive in Windows without requesting the credentials again.

Follow up to https://github.com/nextcloud/server/pull/16739