### PR TITLE
Move can create token logic

### DIFF
--- a/apps/settings/lib/Settings/Personal/Security.php
+++ b/apps/settings/lib/Settings/Personal/Security.php
@@ -50,9 +50,6 @@ use OCP\Settings\ISettings;
 
 class Security implements ISettings {
 
-	/** @var IInitialStateService */
-	private $initialStateService;
-
 	/** @var IUserManager */
 	private $userManager;
 
@@ -68,13 +65,11 @@ class Security implements ISettings {
 	/** @var IConfig */
 	private $config;
 
-	public function __construct(IInitialStateService $initialStateService,
-								IUserManager $userManager,
+	public function __construct(IUserManager $userManager,
 								ProviderLoader $providerLoader,
 								IUserSession $userSession,
 								IConfig $config,
 								?string $UserId) {
-		$this->initialStateService = $initialStateService;
 		$this->userManager = $userManager;
 		$this->providerLoader = $providerLoader;
 		$this->userSession = $userSession;
@@ -88,12 +83,6 @@ class Security implements ISettings {
 		if ($user !== null) {
 			$passwordChangeSupported = $user->canChangePassword();
 		}
-
-		$this->initialStateService->provideInitialState(
-			'settings',
-			'can_create_app_token',
-			$this->userSession->getImpersonatingUserID() === null
-		);
 
 		return new TemplateResponse('settings', 'settings/personal/security', [
 			'passwordChangeSupported' => $passwordChangeSupported,

--- a/apps/settings/lib/Settings/Personal/Security/Authtokens.php
+++ b/apps/settings/lib/Settings/Personal/Security/Authtokens.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace OCA\Settings\Personal\Security;
 
+use OCP\IUserSession;
 use function array_map;
 use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\INamedToken;
@@ -52,14 +53,19 @@ class Authtokens implements ISettings {
 	/** @var string|null */
 	private $uid;
 
+	/** @var IUserSession */
+	private $userSession;
+
 	public function __construct(IAuthTokenProvider $tokenProvider,
 								ISession $session,
+								IUserSession $userSession,
 								IInitialStateService $initialStateService,
 								?string $UserId) {
 		$this->tokenProvider = $tokenProvider;
 		$this->session = $session;
 		$this->initialStateService = $initialStateService;
 		$this->uid = $UserId;
+		$this->userSession = $userSession;
 	}
 
 	public function getForm(): TemplateResponse {
@@ -67,6 +73,12 @@ class Authtokens implements ISettings {
 			'settings',
 			'app_tokens',
 			$this->getAppTokens()
+		);
+
+		$this->initialStateService->provideInitialState(
+			'settings',
+			'can_create_app_token',
+			$this->userSession->getImpersonatingUserID() === null
 		);
 
 		return new TemplateResponse('settings', 'settings/personal/security/authtokens');

--- a/apps/settings/tests/Settings/Personal/Security/AuthtokensTest.php
+++ b/apps/settings/tests/Settings/Personal/Security/AuthtokensTest.php
@@ -25,7 +25,7 @@ declare(strict_types=1);
  *
  */
 
-namespace Test\Settings\Personal\Security;
+namespace OCA\Settings\Tests\Settings\Personal\Security;
 
 use OC\Authentication\Token\DefaultToken;
 use OC\Authentication\Token\IProvider as IAuthTokenProvider;
@@ -34,6 +34,7 @@ use OCA\Settings\Personal\Security\Authtokens;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IInitialStateService;
 use OCP\ISession;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -44,6 +45,9 @@ class AuthtokensTest extends TestCase {
 
 	/** @var ISession|MockObject */
 	private $session;
+
+	/** @var IUserSession|MockObject */
+	private $userSession;
 
 	/** @var IInitialStateService|MockObject */
 	private $initialStateService;
@@ -59,12 +63,14 @@ class AuthtokensTest extends TestCase {
 
 		$this->authTokenProvider = $this->createMock(IAuthTokenProvider::class);
 		$this->session = $this->createMock(ISession::class);
+		$this->userSession = $this->createMock(IUserSession::class);
 		$this->initialStateService = $this->createMock(IInitialStateService::class);
 		$this->uid = 'test123';
 
 		$this->section = new Authtokens(
 			$this->authTokenProvider,
 			$this->session,
+			$this->userSession,
 			$this->initialStateService,
 			$this->uid
 		);
@@ -93,7 +99,7 @@ class AuthtokensTest extends TestCase {
 			->method('getToken')
 			->with('session123')
 			->willReturn($sessionToken);
-		$this->initialStateService->expects($this->once())
+		$this->initialStateService->expects($this->at(0))
 			->method('provideInitialState')
 			->with('settings', 'app_tokens', [
 				[
@@ -116,6 +122,10 @@ class AuthtokensTest extends TestCase {
 					'canRename' => true,
 				],
 			]);
+
+		$this->initialStateService->expects($this->at(1))
+			->method('provideInitialState')
+			->with('settings', 'can_create_app_token', true);
 
 		$form = $this->section->getForm();
 

--- a/apps/settings/tests/Settings/Personal/SecurityTest.php
+++ b/apps/settings/tests/Settings/Personal/SecurityTest.php
@@ -32,7 +32,6 @@ use OC\Authentication\TwoFactorAuth\ProviderLoader;
 use OCA\Settings\Personal\Security;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
-use OCP\IInitialStateService;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
@@ -40,9 +39,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class SecurityTest extends TestCase {
-
-	/** @var IInitialStateService|MockObject */
-	private $initialStateService;
 
 	/** @var IUserManager|MockObject */
 	private $userManager;
@@ -65,7 +61,6 @@ class SecurityTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->initialStateService = $this->createMock(IInitialStateService::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->providerLoader = $this->createMock(ProviderLoader::class);
 		$this->userSession = $this->createMock(IUserSession::class);
@@ -73,7 +68,6 @@ class SecurityTest extends TestCase {
 		$this->uid = 'test123';
 
 		$this->section = new Security(
-			$this->initialStateService,
 			$this->userManager,
 			$this->providerLoader,
 			$this->userSession,


### PR DESCRIPTION
It makes sense to have this in the actual authtoken settings. As well.
This is where it is used.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>