### PR TITLE
Improve Opcache detection

### DIFF
--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -516,7 +516,7 @@ Raw output
 	}
 
 	protected function hasOpcacheLoaded(): bool {
-		return function_exists('opcache_get_status');
+		return extension_loaded('Zend OPcache');
 	}
 
 	/**


### PR DESCRIPTION
Improve Opcache detection by checking if extension is loaded, as opcache_get_status() is commonly disabled on shared hosting servers