### PR TITLE
Remove cache entry if file no longer exists on the underlying storage

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -409,6 +409,10 @@ class File extends Node implements IFile {
 		//throw exception if encryption is disabled but files are still encrypted
 		try {
 			if (!$this->info->isReadable()) {
+				if (!$this->fileView->file_exists(ltrim($this->path, '/'))) {
+					// the file was present in the file cache but doesn't exist on the storage
+					$this->fileView->unlink(ltrim($this->path, '/'));
+				}
 				// do a if the file did not exist
 				throw new NotFound();
 			}


### PR DESCRIPTION
When a file is removed from the filesystem and still present in the file cache we should remove it from the file cache once it gets requested for download. Otherwise the sync client would try rerequesting the file and show sync errors until the filecache becomes aware of the delete.

This should not have any effect on unavailable storage, since that would throw a `StorageNotAvailableException` when trying to obtain the file earlier in https://github.com/nextcloud/3rdparty/blob/5c583d1de872e1ad544429d416c7fd4eda170b96/sabre/dav/lib/DAV/CorePlugin.php#L81

This is more a hardening, since unfortunately there is no trace on why the the cache entry was not properly removed when the file got deleted.