### PR TITLE
Move to subfolders for preview files

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1153,6 +1153,7 @@ return array(
     'OC\\Preview\\ProviderV2' => $baseDir . '/lib/private/Preview/ProviderV2.php',
     'OC\\Preview\\SVG' => $baseDir . '/lib/private/Preview/SVG.php',
     'OC\\Preview\\StarOffice' => $baseDir . '/lib/private/Preview/StarOffice.php',
+    'OC\\Preview\\Storage\\Root' => $baseDir . '/lib/private/Preview/Storage/Root.php',
     'OC\\Preview\\TIFF' => $baseDir . '/lib/private/Preview/TIFF.php',
     'OC\\Preview\\TXT' => $baseDir . '/lib/private/Preview/TXT.php',
     'OC\\Preview\\Watcher' => $baseDir . '/lib/private/Preview/Watcher.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1182,6 +1182,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Preview\\ProviderV2' => __DIR__ . '/../../..' . '/lib/private/Preview/ProviderV2.php',
         'OC\\Preview\\SVG' => __DIR__ . '/../../..' . '/lib/private/Preview/SVG.php',
         'OC\\Preview\\StarOffice' => __DIR__ . '/../../..' . '/lib/private/Preview/StarOffice.php',
+        'OC\\Preview\\Storage\\Root' => __DIR__ . '/../../..' . '/lib/private/Preview/Storage/Root.php',
         'OC\\Preview\\TIFF' => __DIR__ . '/../../..' . '/lib/private/Preview/TIFF.php',
         'OC\\Preview\\TXT' => __DIR__ . '/../../..' . '/lib/private/Preview/TXT.php',
         'OC\\Preview\\Watcher' => __DIR__ . '/../../..' . '/lib/private/Preview/Watcher.php',

--- a/lib/private/Preview/Storage/Root.php
+++ b/lib/private/Preview/Storage/Root.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Preview\Storage;
+
+use OC\Files\AppData\AppData;
+use OC\SystemConfig;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\Files\SimpleFS\ISimpleFolder;
+
+class Root extends AppData {
+	public function __construct(IRootFolder $rootFolder, SystemConfig $systemConfig) {
+		parent::__construct($rootFolder, $systemConfig, 'preview');
+	}
+
+
+	public function getFolder(string $name): ISimpleFolder {
+		$internalFolder = $this->getInternalFolder($name);
+
+		try {
+			return parent::getFolder($internalFolder);
+		} catch (NotFoundException $e) {
+			/*
+			 * The new folder structure is not found.
+			 * Lets try the old one
+			 */
+		}
+
+		return parent::getFolder($name);
+	}
+
+	public function newFolder(string $name): ISimpleFolder {
+		$internalFolder = $this->getInternalFolder($name);
+		return parent::newFolder($internalFolder);
+	}
+
+	/*
+	 * Do not allow directory listing on this special root
+	 * since it gets to big and time consuming
+	 */
+	public function getDirectoryListing(): array {
+		return [];
+	}
+
+	private function getInternalFolder(string $name): string {
+		return implode('/', str_split(substr(md5($name), 0, 7))) . '/' . $name;
+	}
+}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -281,7 +281,7 @@ class Server extends ServerContainer implements IServerContainer {
 			return new PreviewManager(
 				$c->getConfig(),
 				$c->getRootFolder(),
-				$c->getAppDataDir('preview'),
+				new \OC\Preview\Storage\Root($c->getRootFolder(), $c->getSystemConfig(), 'preview'),
 				$c->getEventDispatcher(),
 				$c->getGeneratorHelper(),
 				$c->getSession()->get('user_id')
@@ -291,7 +291,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 		$this->registerService(\OC\Preview\Watcher::class, function (Server $c) {
 			return new \OC\Preview\Watcher(
-				$c->getAppDataDir('preview')
+				new \OC\Preview\Storage\Root($c->getRootFolder(), $c->getSystemConfig(), 'preview')
 			);
 		});
 

--- a/tests/lib/Preview/BackgroundCleanupJobTest.php
+++ b/tests/lib/Preview/BackgroundCleanupJobTest.php
@@ -22,10 +22,13 @@
 
 namespace Test\Preview;
 
-use OC\Files\AppData\Factory;
 use OC\Preview\BackgroundCleanupJob;
+use OC\Preview\Storage\Root;
 use OC\PreviewManager;
+use OCP\Files\File;
+use OCP\Files\IMimeTypeLoader;
 use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
 use OCP\IDBConnection;
 use Test\Traits\MountProviderTrait;
 use Test\Traits\UserTrait;
@@ -47,9 +50,6 @@ class BackgroundCleanupJobTest extends \Test\TestCase {
 	/** @var bool */
 	private $trashEnabled;
 
-	/** @var Factory */
-	private $appDataFactory;
-
 	/** @var IDBConnection */
 	private $connection;
 
@@ -58,6 +58,9 @@ class BackgroundCleanupJobTest extends \Test\TestCase {
 
 	/** @var IRootFolder */
 	private $rootFolder;
+
+	/** @var IMimeTypeLoader */
+	private $mimeTypeLoader;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -76,13 +79,10 @@ class BackgroundCleanupJobTest extends \Test\TestCase {
 		$this->trashEnabled = $appManager->isEnabledForUser('files_trashbin', $this->userId);
 		$appManager->disableApp('files_trashbin');
 
-		$this->appDataFactory = new Factory(
-			\OC::$server->getRootFolder(),
-			\OC::$server->getSystemConfig()
-		);
 		$this->connection = \OC::$server->getDatabaseConnection();
 		$this->previewManager = \OC::$server->getPreviewManager();
 		$this->rootFolder = \OC::$server->getRootFolder();
+		$this->mimeTypeLoader = \OC::$server->getMimeTypeLoader();
 	}
 
 	protected function tearDown(): void {
@@ -94,6 +94,13 @@ class BackgroundCleanupJobTest extends \Test\TestCase {
 		$this->logout();
 
 		parent::tearDown();
+	}
+
+	private function getRoot(): Root {
+		return new Root(
+			\OC::$server->getRootFolder(),
+			\OC::$server->getSystemConfig()
+		);
 	}
 
 	private function setup11Previews(): array {
@@ -110,52 +117,89 @@ class BackgroundCleanupJobTest extends \Test\TestCase {
 		return $files;
 	}
 
+	private function countPreviews(Root $previewRoot, array $fileIds): int {
+		$i = 0;
+
+		foreach ($fileIds as $fileId) {
+			try {
+				$previewRoot->getFolder((string)$fileId);
+			} catch (NotFoundException $e) {
+				continue;
+			}
+
+			$i++;
+		}
+
+		return $i;
+	}
+
 	public function testCleanupSystemCron() {
 		$files = $this->setup11Previews();
+		$fileIds = array_map(function (File $f) {
+			return $f->getId();
+		}, $files);
 
-		$preview = $this->appDataFactory->get('preview');
+		$root = $this->getRoot();
 
-		$previews = $preview->getDirectoryListing();
-		$this->assertCount(11, $previews);
-
-		$job = new BackgroundCleanupJob($this->connection, $this->appDataFactory, true);
+		$this->assertSame(11, $this->countPreviews($root, $fileIds));
+		$job = new BackgroundCleanupJob($this->connection, $root, $this->mimeTypeLoader, true);
 		$job->run([]);
 
 		foreach ($files as $file) {
 			$file->delete();
 		}
 
-		$this->assertCount(11, $previews);
+		$root = $this->getRoot();
+		$this->assertSame(11, $this->countPreviews($root, $fileIds));
 		$job->run([]);
 
-		$previews = $preview->getDirectoryListing();
-		$this->assertCount(0, $previews);
+		$root = $this->getRoot();
+		$this->assertSame(0, $this->countPreviews($root, $fileIds));
 	}
 
 	public function testCleanupAjax() {
 		$files = $this->setup11Previews();
+		$fileIds = array_map(function (File $f) {
+			return $f->getId();
+		}, $files);
 
-		$preview = $this->appDataFactory->get('preview');
+		$root = $this->getRoot();
 
-		$previews = $preview->getDirectoryListing();
-		$this->assertCount(11, $previews);
-
-		$job = new BackgroundCleanupJob($this->connection, $this->appDataFactory, false);
+		$this->assertSame(11, $this->countPreviews($root, $fileIds));
+		$job = new BackgroundCleanupJob($this->connection, $root, $this->mimeTypeLoader, false);
 		$job->run([]);
 
 		foreach ($files as $file) {
 			$file->delete();
 		}
 
-		$this->assertCount(11, $previews);
+		$root = $this->getRoot();
+		$this->assertSame(11, $this->countPreviews($root, $fileIds));
 		$job->run([]);
 
-		$previews = $preview->getDirectoryListing();
-		$this->assertCount(1, $previews);
-
+		$root = $this->getRoot();
+		$this->assertSame(1, $this->countPreviews($root, $fileIds));
 		$job->run([]);
 
-		$previews = $preview->getDirectoryListing();
-		$this->assertCount(0, $previews);
+		$root = $this->getRoot();
+		$this->assertSame(0, $this->countPreviews($root, $fileIds));
+	}
+
+	public function testOldPreviews() {
+		$appdata = \OC::$server->getAppDataDir('preview');
+
+		$f1 = $appdata->newFolder('123456781');
+		$f1->newFile('foo.jpg', 'foo');
+		$f2 = $appdata->newFolder('123456782');
+		$f2->newFile('foo.jpg', 'foo');
+
+		$appdata = \OC::$server->getAppDataDir('preview');
+		$this->assertSame(2, count($appdata->getDirectoryListing()));
+
+		$job = new BackgroundCleanupJob($this->connection, $this->getRoot(), $this->mimeTypeLoader, true);
+		$job->run([]);
+
+		$appdata = \OC::$server->getAppDataDir('preview');
+		$this->assertSame(0, count($appdata->getDirectoryListing()));
 	}
 }


### PR DESCRIPTION
My take on #16747 @gbmaster please have a look as well.

Else the number of files can grow very large very quickly in the preview
folder. Esp on large systems.

This generates the md5 of the fileid. And then creates folders of the
first 7 charts. In that folder is then a folder with the fileid. And
inside there are the previews.

Since this is just an abstraction as to how things are stored. i chose to just extend appdata to handle it. This was non of the code touching it needs to be concerned with how things are stored. As long as they are stored (think of it as a poor mans objectstore).