### PR TITLE
Add move (and firstlogin) option to transferownership service

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -77,7 +77,12 @@ class TransferOwnership extends Command {
 				InputOption::VALUE_REQUIRED,
 				'selectively provide the path to transfer. For example --path="folder_name"',
 				''
-			);
+			)->addOption(
+				'move',
+				null,
+				InputOption::VALUE_NONE,
+				'move data from source user to root directory of destination user, which must be empty'
+		);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
@@ -99,7 +104,8 @@ class TransferOwnership extends Command {
 				$sourceUserObject,
 				$destinationUserObject,
 				ltrim($input->getOption('path'), '/'),
-				$output
+				$output,
+				$input->getOption('move') === true
 			);
 		} catch (TransferOwnershipException $e) {
 			$output->writeln("<error>" . $e->getMessage() . "</error>");

--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -80,7 +80,8 @@ class OwnershipTransferService {
 							 IUser $destinationUser,
 							 string $path,
 							 ?OutputInterface $output = null,
-							 bool $move = false): void {
+							 bool $move = false,
+							 bool $firstLogin = false): void {
 		$output = $output ?? new NullOutput();
 		$sourceUid = $sourceUser->getUID();
 		$destinationUid = $destinationUser->getUID();
@@ -107,7 +108,13 @@ class OwnershipTransferService {
 			throw new TransferOwnershipException("Unknown path provided: $path", 1);
 		}
 
-		if ($move && (!$view->is_dir($finalTarget) || count($view->getDirectoryContent($finalTarget)) > 0)) {
+		if ($move && (
+				!$view->is_dir($finalTarget) || (
+					!$firstLogin &&
+					count($view->getDirectoryContent($finalTarget)) > 0
+				)
+			)
+		) {
 			throw new TransferOwnershipException("Destination path does not exists or is not empty", 1);
 		}
 

--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -286,7 +286,7 @@ class OwnershipTransferService {
 				}
 			} catch (\OCP\Files\NotFoundException $e) {
 				$output->writeln('<error>Share with id ' . $share->getId() . ' points at deleted file, skipping</error>');
-			} catch (\Exception $e) {
+			} catch (\Throwable $e) {
 				$output->writeln('<error>Could not restore share with id ' . $share->getId() . ':' . $e->getTraceAsString() . '</error>');
 			}
 			$progress->advance();

--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -87,7 +87,7 @@ class OwnershipTransferService {
 		$sourcePath = rtrim($sourceUid . '/files/' . $path, '/');
 
 		// target user has to be ready
-		if (!$this->encryptionManager->isReadyForUser($destinationUid)) {
+		if ($destinationUser->getLastLogin() === 0 || !$this->encryptionManager->isReadyForUser($destinationUid)) {
 			throw new TransferOwnershipException("The target user is not ready to accept files. The user has at least to have logged in once.", 2);
 		}
 


### PR DESCRIPTION
This allows us to avoid the transfer folder for converted guest users.