### PR TITLE
Keep the modification time during decryptFile

### DIFF
--- a/lib/private/Encryption/DecryptAll.php
+++ b/lib/private/Encryption/DecryptAll.php
@@ -266,6 +266,7 @@ class DecryptAll {
 
 		try {
 			$this->rootView->copy($source, $target);
+			$this->rootView->touch($target, $fileInfo->getMTime());
 			$this->rootView->rename($target, $source);
 		} catch (DecryptionFailedException $e) {
 			if ($this->rootView->file_exists($target)) {


### PR DESCRIPTION
Currently running `occ encryption:decrypt-all` changes modification timestamp of all the files.

It makes more sense to keep the same timestamp.

This PR keeps the modification time during decryptFile.