### PR TITLE
Hash event UID to make sure it's not too long for PushProvider notifications

### DIFF
--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/PushProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/PushProvider.php
@@ -93,6 +93,9 @@ class PushProvider extends AbstractProvider {
 
 		$eventDetails = $this->extractEventDetails($vevent);
 		$eventDetails['calendar_displayname'] = $calendarDisplayName;
+		$eventUUID = (string) $vevent->UID;
+		// Empty Notification ObjectId will be catched by OC\Notification\Notification
+		$eventUUIDHash = $eventUUID ? hash('sha256', $eventUUID, false) : '';
 
 		foreach($users as $user) {
 			/** @var INotification $notification */
@@ -100,7 +103,7 @@ class PushProvider extends AbstractProvider {
 			$notification->setApp(Application::APP_ID)
 				->setUser($user->getUID())
 				->setDateTime($this->timeFactory->getDateTime())
-				->setObject(Application::APP_ID, (string) $vevent->UID)
+				->setObject(Application::APP_ID, $eventUUIDHash)
 				->setSubject('calendar_reminder', [
 					'title' => $eventDetails['title'],
 					'start_atom' => $eventDetails['start_atom']

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotificationProvider/PushProviderTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotificationProvider/PushProviderTest.php
@@ -189,7 +189,7 @@ class PushProviderTest extends AbstractNotificationProviderTest {
 
 		$notification->expects($this->once())
 			->method('setObject')
-			->with('dav', 'uid1234')
+			->with('dav', hash('sha256', 'uid1234', false))
 			->willReturn($notification);
 
 		$notification->expects($this->once())


### PR DESCRIPTION
Notifications object ID [is limited to 64 characters](https://github.com/nextcloud/server/blob/master/lib/private/Notification/Notification.php#L207), event UID is not. A Sha256 hash is limited to 64 characters.