### PR TITLE
18.0.1 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(18, 0, 0, 10);
+$OC_Version = array(18, 0, 1, 0);
 
 // The human readable string
-$OC_VersionString = '18.0.0';
+$OC_VersionString = '18.0.1 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #18961 [stable18] Fix cursor on disabled contenteditable divs
* #18982 Bump style-loader from 1.1.2 to 1.1.3
* #19025 [stable18] Increase the timeout for app downloads
* #19060 [stable18] Fix loaded controller check
* #19089 [stable18] Allow to await the sidebar
* #19094 [stable18] expose Argon2 options (as we did for bcrypt)
* #19108 [stable18] fix multiselect actions for files
* #19117 [stable18] Adjust filelist color handling to new dark theme value
* #19118 [stable18] Reduce legacy event log level to debug
* #19119 [stable18] New file menu needs to be above the filelist header
* #19121 [stable18] Do not invert avatar colors when dark theme is enabled
* #19149 [stable18] Use the target for file notifications
* #19150 [stable18] Use correct appid for talk
* #19153 [stable18] add hub bundle for easy installation on upgraded instances
* #19166 [stable18] apps can have polyamorous relationships with bundles
* #19189 [stable18] Use themed favicon-fb
* #19190 [stable18] Fix "Call to undefined method OCA\\WorkflowEngine\\Entity\\File::t()"
* #19206 [stable18] Fix query selector for inverted icons
* #19207 [stable18] Do not encode contacts menu mailto links
* #19212 [stable18] Give the sharing tab a unique id so it also opens properly on other languages
* #19228 [stable18] WebcalRefreshJob: Fix reading refresh rate
* #19269 [stable18] Make sure to catch php errors during job execution
* #19271 [stable18] Center Buttons
* #19277 [stable18] Use the l10n from settings
* #19278 [stable18] Use proper andwhere clause
* #19279 [stable18] Add move (and firstlogin) option to transferownership service
* #19283 [stable18] for the DB ot pick an index specify the object_type
* #19291 [stable18] owner transfer multiselect fixes
* #19292 [stable18] Allow respecting PASSWORD_DEFAULT
* #19297 [stable18] Keep the modification time during decryptFile
* #19302 [stable18] Fix data Apache2 .htaccess typo
* [activity#417](https://github.com/nextcloud/activity/pull/417) [stable18] Update master php testing versions
* [activity#418](https://github.com/nextcloud/activity/pull/418) Update stable18 target versions
* [files_pdfviewer#164](https://github.com/nextcloud/files_pdfviewer/pull/164) [stable18] Update master php testing versions
* [files_pdfviewer#165](https://github.com/nextcloud/files_pdfviewer/pull/165) Update stable18 target versions
* [files_texteditor#194](https://github.com/nextcloud/files_texteditor/pull/194) Update stable18 target versions
* [firstrunwizard#274](https://github.com/nextcloud/firstrunwizard/pull/274) Update stable18 target versions
* [logreader#313](https://github.com/nextcloud/logreader/pull/313) Update stable18 target versions
* [nextcloud_announcements#64](https://github.com/nextcloud/nextcloud_announcements/pull/64) [stable18] Update master php testing versions
* [nextcloud_announcements#65](https://github.com/nextcloud/nextcloud_announcements/pull/65) Update stable18 target versions
* [notifications#547](https://github.com/nextcloud/notifications/pull/547) Update stable18 target versions
* [notifications#555](https://github.com/nextcloud/notifications/pull/555) [stable18] Add linting via github actions
* [password_policy#93](https://github.com/nextcloud/password_policy/pull/93) [stable18] Update master php testing versions
* [password_policy#94](https://github.com/nextcloud/password_policy/pull/94) Update stable18 target versions
* [photos#153](https://github.com/nextcloud/photos/pull/153) [stable18] Lint with github actions
* [photos#158](https://github.com/nextcloud/photos/pull/158) [stable18] No more drone. Do it all on github actions
* [photos#160](https://github.com/nextcloud/photos/pull/160) [stable18] Respect .noimage and .nomedia files
* [photos#172](https://github.com/nextcloud/photos/pull/172) [stable18] added headers for your photos and favs
* [photos#174](https://github.com/nextcloud/photos/pull/174) [stable18] Fix/actions
* [photos#175](https://github.com/nextcloud/photos/pull/175) [stable18] Fix url escaping
* [privacy#323](https://github.com/nextcloud/privacy/pull/323) Update stable18 target versions
* [recommendations#182](https://github.com/nextcloud/recommendations/pull/182) Update stable18 target versions
* [serverinfo#170](https://github.com/nextcloud/serverinfo/pull/170) Update stable18 target versions
* [survey_client#104](https://github.com/nextcloud/survey_client/pull/104) [stable18] Update master php testing versions
* [survey_client#105](https://github.com/nextcloud/survey_client/pull/105) Update stable18 target versions
* [viewer#368](https://github.com/nextcloud/viewer/pull/368) [stable18] GitHub actions/lint
* [viewer#370](https://github.com/nextcloud/viewer/pull/370) Fix url escaping
* [viewer#379](https://github.com/nextcloud/viewer/pull/379) [stable18] Adjust tests syntax & formatting
