### PR TITLE
for the DB ot pick an index specify the object_type

### DIFF
--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -601,11 +601,13 @@ class Manager implements ICommentsManager {
 		$query = $qb->select('f.fileid')
 			->addSelect($qb->func()->count('c.id', 'num_ids'))
 			->from('filecache', 'f')
-			->leftJoin('f', 'comments', 'c', $qb->expr()->eq(
-				'f.fileid', $qb->expr()->castColumn('c.object_id', IQueryBuilder::PARAM_INT)
+			->leftJoin('f', 'comments', 'c', $qb->expr()->andX(
+				$qb->expr()->eq('f.fileid', $qb->expr()->castColumn('c.object_id', IQueryBuilder::PARAM_INT)),
+				$qb->expr()->eq('c.object_type', $qb->createNamedParameter('files'))
 			))
-			->leftJoin('c', 'comments_read_markers', 'm', $qb->expr()->eq(
-				'c.object_id', 'm.object_id'
+			->leftJoin('c', 'comments_read_markers', 'm', $qb->expr()->andX(
+				$qb->expr()->eq('c.object_id', 'm.object_id'),
+				$qb->expr()->eq('m.object_type', $qb->createNamedParameter('files'))
 			))
 			->where(
 				$qb->expr()->andX(


### PR DESCRIPTION
The indices in the comments DB  include the whole object, consisting of a type and its ID. The queries did not take the type in account (well, not everywhere), which used some subqueries to run expensive without using the index.

Before:

```
+----+-------------+-------+------------+-------+-------------------------------------------------------------------------------------------------------------------+-----------------------+---------+-------+------+----------+-----------------------------------------------------------------+
| id | select_type | table | partitions | type  | possible_keys                                                                                                     | key                   | key_len | ref   | rows | filtered | Extra                                                           |
+----+-------------+-------+------------+-------+-------------------------------------------------------------------------------------------------------------------+-----------------------+---------+-------+------+----------+-----------------------------------------------------------------+
|  1 | SIMPLE      | f     | NULL       | ref   | PRIMARY,fs_storage_path_hash,fs_parent_name_hash,fs_storage_mimetype,fs_storage_mimepart,fs_storage_size,fs_mtime | fs_parent_name_hash   | 8       | const |    1 |   100.00 | Using index; Using temporary; Using filesort                    |
|  1 | SIMPLE      | c     | NULL       | index | NULL                                                                                                              | comments_object_index | 522     | NULL  |  427 |    55.00 | Using where; Using index; Using join buffer (Block Nested Loop) |
|  1 | SIMPLE      | m     | NULL       | ALL   | NULL                                                                                                              | NULL                  | NULL    | NULL  |   23 |     8.80 | Using where; Using join buffer (Block Nested Loop)              |
+----+-------------+-------+------------+-------+-------------------------------------------------------------------------------------------------------------------+-----------------------+---------+-------+------+----------+-----------------------------------------------------------------+
```

Now

```
+----+-------------+-------+------------+------+-------------------------------------------------------------------------------------------------------------------+------------------------------+---------+-------------------------------+------+----------+-----------------------------------------------------------+
| id | select_type | table | partitions | type | possible_keys                                                                                                     | key                          | key_len | ref                           | rows | filtered | Extra                                                     |
+----+-------------+-------+------------+------+-------------------------------------------------------------------------------------------------------------------+------------------------------+---------+-------------------------------+------+----------+-----------------------------------------------------------+
|  1 | SIMPLE      | f     | NULL       | ref  | PRIMARY,fs_storage_path_hash,fs_parent_name_hash,fs_storage_mimetype,fs_storage_mimepart,fs_storage_size,fs_mtime | fs_parent_name_hash          | 8       | const                         |    1 |   100.00 | Using where; Using index; Using temporary; Using filesort |
|  1 | SIMPLE      | c     | NULL       | ref  | comments_object_index                                                                                             | comments_object_index        | 258     | const                         |   20 |   100.00 | Using where; Using index                                  |
|  1 | SIMPLE      | m     | NULL       | ref  | comments_marker_object_index                                                                                      | comments_marker_object_index | 516     | const,nextcloud.c.object_id |    1 |    16.00 | Using where                                               |
+----+-------------+-------+------------+------+-------------------------------------------------------------------------------------------------------------------+------------------------------+---------+-------------------------------+------+----------+-----------------------------------------------------------+
```