### PR TITLE
Use checkout v2 for npm build action

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -17,7 +17,7 @@ jobs:
         node-version: [12.x]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Use node ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
Saves checking out the whole tree.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>