### PR TITLE
Clean up the public API I

### DIFF
--- a/lib/public/API.php
+++ b/lib/public/API.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *

--- a/lib/public/Accounts/PropertyDoesNotExistException.php
+++ b/lib/public/Accounts/PropertyDoesNotExistException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
  *
@@ -34,10 +37,11 @@ class PropertyDoesNotExistException extends \Exception {
 
 	/**
 	 * Constructor
+	 *
 	 * @param string $msg the error message
 	 * @since 15.0.0
 	 */
-	public function __construct($property){
+	public function __construct(string $property) {
 		parent::__construct('Property ' . $property . ' does not exist.');
 	}
 

--- a/lib/public/Activity/IConsumer.php
+++ b/lib/public/Activity/IConsumer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -22,14 +25,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
-
-/**
- * Public interface of ownCloud for apps to use.
- * Activity/IConsumer interface
- */
-
-// use OCP namespace for all classes that are considered public.
-// This means that they should be used by apps instead of the internal ownCloud classes
 
 namespace OCP\Activity;
 

--- a/lib/public/Activity/IEvent.php
+++ b/lib/public/Activity/IEvent.php
@@ -25,14 +25,6 @@ declare(strict_types=1);
  *
  */
 
-/**
- * Public interface of ownCloud for apps to use.
- * Activity/IEvent interface
- */
-
-// use OCP namespace for all classes that are considered public.
-// This means that they should be used by apps instead of the internal ownCloud classes
-
 namespace OCP\Activity;
 
 /**

--- a/lib/public/Activity/IEventMerger.php
+++ b/lib/public/Activity/IEventMerger.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
  *
@@ -23,11 +26,7 @@
 
 namespace OCP\Activity;
 
-
 /**
- * Interface EventMerger
- *
- * @package OCP\Activity
  * @since 11.0
  */
 interface IEventMerger {
@@ -61,6 +60,6 @@ interface IEventMerger {
 	 * @return IEvent
 	 * @since 11.0
 	 */
-	public function mergeEvents($mergeParameter, IEvent $event, IEvent $previousEvent = null);
+	public function mergeEvents(string $mergeParameter, IEvent $event, IEvent $previousEvent = null);
 
 }

--- a/lib/public/Activity/IExtension.php
+++ b/lib/public/Activity/IExtension.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -26,9 +29,6 @@
 namespace OCP\Activity;
 
 /**
- * Interface IExtension
- *
- * @package OCP\Activity
  * @since 8.0.0
  */
 interface IExtension {

--- a/lib/public/Activity/IFilter.php
+++ b/lib/public/Activity/IFilter.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
  *
@@ -24,9 +27,6 @@
 namespace OCP\Activity;
 
 /**
- * Interface IFilter
- *
- * @package OCP\Activity
  * @since 11.0.0
  */
 interface IFilter {

--- a/lib/public/Activity/IManager.php
+++ b/lib/public/Activity/IManager.php
@@ -29,9 +29,6 @@ declare(strict_types=1);
 namespace OCP\Activity;
 
 /**
- * Interface IManager
- *
- * @package OCP\Activity
  * @since 6.0.0
  */
 interface IManager {

--- a/lib/public/Activity/IProvider.php
+++ b/lib/public/Activity/IProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
  *
@@ -24,9 +27,6 @@
 namespace OCP\Activity;
 
 /**
- * Interface IProvider
- *
- * @package OCP\Activity
  * @since 11.0.0
  */
 interface IProvider {
@@ -40,5 +40,5 @@ interface IProvider {
 	 * @throws \InvalidArgumentException Should be thrown if your provider does not know this event
 	 * @since 11.0.0
 	 */
-	public function parse($language, IEvent $event, IEvent $previousEvent = null);
+	public function parse(string $language, IEvent $event, IEvent $previousEvent = null);
 }

--- a/lib/public/Activity/ISetting.php
+++ b/lib/public/Activity/ISetting.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
  *
@@ -24,9 +27,6 @@
 namespace OCP\Activity;
 
 /**
- * Interface ISetting
- *
- * @package OCP\Activity
  * @since 11.0.0
  */
 interface ISetting {

--- a/lib/public/App.php
+++ b/lib/public/App.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -56,7 +59,7 @@ class App {
 	 * @since 4.0.0
 	 * @deprecated 14.0.0 Use settings section in appinfo.xml to register personal admin sections
 	*/
-	public static function registerPersonal( $app, $page ) {
+	public static function registerPersonal(string $app, string $page ) {
 		\OC_App::registerPersonal( $app, $page );
 	}
 
@@ -68,7 +71,7 @@ class App {
 	 * @since 4.0.0
 	 * @deprecated 14.0.0 Use settings section in appinfo.xml to register admin sections
 	 */
-	public static function registerAdmin( $app, $page ) {
+	public static function registerAdmin(string $app, string $page ) {
 		\OC_App::registerAdmin( $app, $page );
 	}
 
@@ -80,7 +83,7 @@ class App {
 	 * @deprecated 14.0.0 ise \OC::$server->getAppManager()->getAppInfo($appId)
 	 * @since 4.0.0
 	*/
-	public static function getAppInfo( $app, $path=false ) {
+	public static function getAppInfo(string $app, bool $path=false ) {
 		return \OC_App::getAppInfo( $app, $path);
 	}
 
@@ -93,7 +96,7 @@ class App {
 	 * @since 4.0.0
 	 * @deprecated 13.0.0 use \OC::$server->getAppManager()->isEnabledForUser($appId)
 	 */
-	public static function isEnabled( $app ) {
+	public static function isEnabled(string $app) {
 		return \OC::$server->getAppManager()->isEnabledForUser( $app );
 	}
 
@@ -104,7 +107,7 @@ class App {
 	 * @since 4.0.0
 	 * @deprecated 14.0.0 use \OC::$server->getAppManager()->getAppVersion($appId)
 	 */
-	public static function getAppVersion( $app ) {
+	public static function getAppVersion(string $app) {
 		return \OC::$server->getAppManager()->getAppVersion($app);
 	}
 }

--- a/lib/public/App/AppPathNotFoundException.php
+++ b/lib/public/App/AppPathNotFoundException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016 Julius Härtl <jus@bitgrid.net>
  *
@@ -24,10 +27,9 @@
 
 namespace OCP\App;
 
+use Exception;
+
 /**
- * Class AppPathNotFoundException
- *
- * @package OCP\App
  * @since 11.0.0
  */
-class AppPathNotFoundException extends \Exception {}
+class AppPathNotFoundException extends Exception {}

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -35,9 +38,6 @@ use OCP\IGroup;
 use OCP\IUser;
 
 /**
- * Interface IAppManager
- *
- * @package OCP\App
  * @since 8.0.0
  */
 interface IAppManager {
@@ -49,7 +49,7 @@ interface IAppManager {
 	 * @return mixed
 	 * @since 14.0.0
 	 */
-	public function getAppInfo(string $appId, bool $path = false, $lang = null);
+	public function getAppInfo(string $appId, bool $path = false, string $lang = null);
 
 	/**
 	 * Returns the app information from "appinfo/info.xml".
@@ -65,11 +65,11 @@ interface IAppManager {
 	 * Check if an app is enabled for user
 	 *
 	 * @param string $appId
-	 * @param \OCP\IUser $user (optional) if not defined, the currently loggedin user will be used
+	 * @param IUser $user (optional) if not defined, the currently loggedin user will be used
 	 * @return bool
 	 * @since 8.0.0
 	 */
-	public function isEnabledForUser($appId, $user = null);
+	public function isEnabledForUser(string $appId, IUser $user = null);
 
 	/**
 	 * Check if an app is enabled in the instance
@@ -80,7 +80,7 @@ interface IAppManager {
 	 * @return bool
 	 * @since 8.0.0
 	 */
-	public function isInstalled($appId);
+	public function isInstalled(string $appId);
 
 	/**
 	 * Enable an app for every user
@@ -99,7 +99,7 @@ interface IAppManager {
 	 * @return bool
 	 * @since 12.0.0
 	 */
-	public function hasProtectedAppType($types);
+	public function hasProtectedAppType(array $types);
 
 	/**
 	 * Enable an app only for specific groups
@@ -119,7 +119,7 @@ interface IAppManager {
 	 * @param bool $automaticDisabled
 	 * @since 8.0.0
 	 */
-	public function disableApp($appId, $automaticDisabled = false);
+	public function disableApp(string $appId, bool $automaticDisabled = false);
 
 	/**
 	 * Get the directory for the given app.
@@ -129,7 +129,7 @@ interface IAppManager {
 	 * @since 11.0.0
 	 * @throws AppPathNotFoundException
 	 */
-	public function getAppPath($appId);
+	public function getAppPath(string $appId);
 
 	/**
 	 * Get the web path for the given app.
@@ -144,7 +144,7 @@ interface IAppManager {
 	/**
 	 * List all apps enabled for a user
 	 *
-	 * @param \OCP\IUser $user
+	 * @param IUser $user
 	 * @return string[]
 	 * @since 8.1.0
 	 */
@@ -169,7 +169,7 @@ interface IAppManager {
 	 * @return boolean
 	 * @since 9.0.0
 	 */
-	public function isShipped($appId);
+	public function isShipped(string $appId);
 
 	/**
 	 * @return string[]

--- a/lib/public/App/ManagerEvent.php
+++ b/lib/public/App/ManagerEvent.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -24,11 +27,9 @@
 namespace OCP\App;
 
 use OCP\EventDispatcher\Event;
+use OCP\IGroup;
 
 /**
- * Class ManagerEvent
- *
- * @package OCP\APP
  * @since 9.0.0
  */
 class ManagerEvent extends Event {
@@ -46,18 +47,19 @@ class ManagerEvent extends Event {
 	protected $event;
 	/** @var string */
 	protected $appID;
-	/** @var \OCP\IGroup[]|null */
+	/** @var IGroup[]|null */
 	protected $groups;
 
 	/**
 	 * DispatcherEvent constructor.
 	 *
 	 * @param string $event
-	 * @param $appID
-	 * @param \OCP\IGroup[]|null $groups
+	 * @param string $appID
+	 * @param IGroup[]|null $groups
 	 * @since 9.0.0
 	 */
-	public function __construct($event, $appID, array $groups = null) {
+	public function __construct(string $event, string $appID, array $groups = null) {
+		parent::__construct();
 		$this->event = $event;
 		$this->appID = $appID;
 		$this->groups = $groups;
@@ -86,7 +88,7 @@ class ManagerEvent extends Event {
 	 */
 	public function getGroups() {
 		return array_map(function ($group) {
-			/** @var \OCP\IGroup $group */
+			/** @var IGroup $group */
 			return $group->getGID();
 		}, $this->groups);
 	}

--- a/lib/public/AppFramework/ApiController.php
+++ b/lib/public/AppFramework/ApiController.php
@@ -57,11 +57,11 @@ abstract class ApiController extends Controller {
      * request should be cached, defaults to 1728000 seconds
 	 * @since 7.0.0
      */
-    public function __construct($appName,
+    public function __construct(string $appName,
                                 IRequest $request,
-                                $corsMethods='PUT, POST, GET, DELETE, PATCH',
-                                $corsAllowedHeaders='Authorization, Content-Type, Accept',
-                                $corsMaxAge=1728000){
+                                string $corsMethods = 'PUT, POST, GET, DELETE, PATCH',
+                                string $corsAllowedHeaders = 'Authorization, Content-Type, Accept',
+                                int $corsMaxAge = 1728000){
         parent::__construct($appName, $request);
         $this->corsMethods = $corsMethods;
         $this->corsAllowedHeaders = $corsAllowedHeaders;

--- a/lib/public/AppFramework/App.php
+++ b/lib/public/AppFramework/App.php
@@ -134,7 +134,7 @@ class App {
 	 * $a = new TasksApp();
 	 * $a->registerRoutes($this, $routes);
 	 *
-	 * @param \OCP\Route\IRouter $router
+	 * @param IRouter $router
 	 * @param array $routes
 	 * @since 6.0.0
 	 * @suppress PhanAccessMethodInternal

--- a/lib/public/AppFramework/Controller.php
+++ b/lib/public/AppFramework/Controller.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -27,13 +30,10 @@
  *
  */
 
-/**
- * Public interface of ownCloud for apps to use.
- * AppFramework\Controller class
- */
-
 namespace OCP\AppFramework;
 
+use Closure;
+use DomainException;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
@@ -54,7 +54,7 @@ abstract class Controller {
 
 	/**
 	 * current request
-	 * @var \OCP\IRequest
+	 * @var IRequest
 	 * @since 6.0.0
 	 */
 	protected $request;
@@ -71,7 +71,7 @@ abstract class Controller {
 	 * @param IRequest $request an instance of the request
 	 * @since 6.0.0 - parameter $appName was added in 7.0.0 - parameter $app was removed in 7.0.0
 	 */
-	public function __construct($appName,
+	public function __construct(string $appName,
 	                            IRequest $request) {
 		$this->appName = $appName;
 		$this->request = $request;
@@ -107,7 +107,7 @@ abstract class Controller {
 	 * @since 7.0.0
 	 * @since 9.1.0 Added default parameter
 	 */
-	public function getResponderByHTTPHeader($acceptHeader, $default='json') {
+	public function getResponderByHTTPHeader(string $acceptHeader, string $default = 'json') {
 		$headers = explode(',', $acceptHeader);
 
 		// return the first matching responder
@@ -129,10 +129,10 @@ abstract class Controller {
 	/**
 	 * Registers a formatter for a type
 	 * @param string $format
-	 * @param \Closure $responder
+	 * @param Closure $responder
 	 * @since 7.0.0
 	 */
-	protected function registerResponder($format, \Closure $responder) {
+	protected function registerResponder(string $format, Closure $responder) {
 		$this->responders[$format] = $responder;
 	}
 
@@ -142,19 +142,17 @@ abstract class Controller {
 	 * @param mixed $response the value that was returned from a controller and
 	 * is not a Response instance
 	 * @param string $format the format for which a formatter has been registered
-	 * @throws \DomainException if format does not match a registered formatter
+	 * @throws DomainException if format does not match a registered formatter
 	 * @return Response
 	 * @since 7.0.0
 	 */
-	public function buildResponse($response, $format='json') {
+	public function buildResponse($response, string $format = 'json') {
 		if(array_key_exists($format, $this->responders)) {
-
 			$responder = $this->responders[$format];
 
 			return $responder($response);
-
 		}
-		throw new \DomainException('No responder registered for format '.
+		throw new DomainException('No responder registered for format '.
 			$format . '!');
 	}
 }

--- a/lib/public/AppFramework/Db/DoesNotExistException.php
+++ b/lib/public/AppFramework/Db/DoesNotExistException.php
@@ -40,7 +40,7 @@ class DoesNotExistException extends \Exception implements IMapperException {
 	 * @param string $msg the error message
 	 * @since 7.0.0
 	 */
-	public function __construct($msg){
+	public function __construct(string $msg){
 		parent::__construct($msg);
 	}
 

--- a/lib/public/AppFramework/Db/Entity.php
+++ b/lib/public/AppFramework/Db/Entity.php
@@ -102,7 +102,7 @@ abstract class Entity {
 	 * Generic setter for properties
 	 * @since 7.0.0
 	 */
-	protected function setter($name, $args) {
+	protected function setter(string $name, array $args) {
 		// setters should only work for existing attributes
 		if(property_exists($this, $name)){
 			if($this->$name === $args[0]) {
@@ -126,7 +126,7 @@ abstract class Entity {
 	 * Generic getter for properties
 	 * @since 7.0.0
 	 */
-	protected function getter($name) {
+	protected function getter(string $name) {
 		// getters should only work for existing attributes
 		if(property_exists($this, $name)){
 			return $this->$name;
@@ -144,7 +144,7 @@ abstract class Entity {
 	 * getter method
 	 * @since 7.0.0
 	 */
-	public function __call($methodName, $args) {
+	public function __call(string $methodName, array $args) {
 		if (strpos($methodName, 'set') === 0) {
 			$this->setter(lcfirst(substr($methodName, 3)), $args);
 		} elseif (strpos($methodName, 'get') === 0) {
@@ -176,7 +176,7 @@ abstract class Entity {
 	 * @param string $attribute the name of the attribute
 	 * @since 7.0.0
 	 */
-	protected function markFieldUpdated($attribute){
+	protected function markFieldUpdated(string $attribute){
 		$this->_updatedFields[$attribute] = true;
 	}
 
@@ -187,7 +187,7 @@ abstract class Entity {
 	 * @return string the property name
 	 * @since 7.0.0
 	 */
-	public function columnToProperty($columnName){
+	public function columnToProperty(string $columnName){
 		$parts = explode('_', $columnName);
 		$property = null;
 
@@ -209,7 +209,7 @@ abstract class Entity {
 	 * @return string the column name
 	 * @since 7.0.0
 	 */
-	public function propertyToColumn($property){
+	public function propertyToColumn(string $property){
 		$parts = preg_split('/(?=[A-Z])/', $property);
 		$column = null;
 
@@ -241,7 +241,7 @@ abstract class Entity {
 	 * @param string $type the type which will be used to call settype()
 	 * @since 7.0.0
 	 */
-	protected function addType($fieldName, $type){
+	protected function addType(string $fieldName, string $type){
 		$this->_fieldTypes[$fieldName] = $type;
 	}
 
@@ -253,7 +253,7 @@ abstract class Entity {
 	 * @return string slugified value
 	 * @since 7.0.0
 	 */
-	public function slugify($attributeName){
+	public function slugify(string $attributeName){
 		// toSlug should only work for existing attributes
 		if(property_exists($this, $attributeName)){
 			$value = $this->$attributeName;

--- a/lib/public/AppFramework/Db/MultipleObjectsReturnedException.php
+++ b/lib/public/AppFramework/Db/MultipleObjectsReturnedException.php
@@ -40,7 +40,7 @@ class MultipleObjectsReturnedException extends \Exception implements IMapperExce
 	 * @param string $msg the error message
 	 * @since 7.0.0
 	 */
-	public function __construct($msg){
+	public function __construct(string $msg){
 		parent::__construct($msg);
 	}
 

--- a/lib/public/AppFramework/Db/QBMapper.php
+++ b/lib/public/AppFramework/Db/QBMapper.php
@@ -57,7 +57,7 @@ abstract class QBMapper {
 	 * mapped to queries without using sql
 	 * @since 14.0.0
 	 */
-	public function __construct(IDBConnection $db, string $tableName, string $entityClass=null){
+	public function __construct(IDBConnection $db, string $tableName, string $entityClass = null) {
 		$this->db = $db;
 		$this->tableName = $tableName;
 

--- a/lib/public/AppFramework/Http/DataDisplayResponse.php
+++ b/lib/public/AppFramework/Http/DataDisplayResponse.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -47,8 +50,8 @@ class DataDisplayResponse extends Response {
 	 * @param array $headers additional key value based headers
 	 * @since 8.1.0
 	 */
-	public function __construct($data='', $statusCode=Http::STATUS_OK,
-	                            $headers=[]) {
+	public function __construct(string $data = '', int $statusCode=Http::STATUS_OK,
+	                            array $headers=[]) {
 		parent::__construct();
 
 		$this->data = $data;
@@ -73,7 +76,7 @@ class DataDisplayResponse extends Response {
 	 * @return DataDisplayResponse Reference to this object
 	 * @since 8.1.0
 	 */
-	public function setData($data){
+	public function setData(string $data){
 		$this->data = $data;
 
 		return $this;

--- a/lib/public/AppFramework/Http/DataDownloadResponse.php
+++ b/lib/public/AppFramework/Http/DataDownloadResponse.php
@@ -43,7 +43,7 @@ class DataDownloadResponse extends DownloadResponse {
 	 * @param string $contentType the mimetype that the downloaded file should have
 	 * @since 8.0.0
 	 */
-	public function __construct($data, $filename, $contentType) {
+	public function __construct(string $data, string $filename, string $contentType) {
 		$this->data = $data;
 		parent::__construct($filename, $contentType);
 	}
@@ -52,7 +52,7 @@ class DataDownloadResponse extends DownloadResponse {
 	 * @param string $data
 	 * @since 8.0.0
 	 */
-	public function setData($data) {
+	public function setData(string $data) {
 		$this->data = $data;
 	}
 

--- a/lib/public/AppFramework/Http/DataResponse.php
+++ b/lib/public/AppFramework/Http/DataResponse.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -20,11 +23,6 @@
  * You should have received a copy of the GNU Affero General Public License, version 3,
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
- */
-
-/**
- * Public interface of ownCloud for apps to use.
- * AppFramework\HTTP\DataResponse class
  */
 
 namespace OCP\AppFramework\Http;
@@ -51,8 +49,8 @@ class DataResponse extends Response {
 	 * @param array $headers additional key value based headers
 	 * @since 8.0.0
 	 */
-	public function __construct($data=array(), $statusCode=Http::STATUS_OK,
-	                            array $headers=array()) {
+	public function __construct(array $data = [], int $statusCode=Http::STATUS_OK,
+	                            array $headers = []) {
 		parent::__construct();
 
 		$this->data = $data;

--- a/lib/public/AppFramework/Http/DownloadResponse.php
+++ b/lib/public/AppFramework/Http/DownloadResponse.php
@@ -41,7 +41,7 @@ class DownloadResponse extends Response {
 	 * @param string $contentType the mimetype that the downloaded file should have
 	 * @since 7.0.0
 	 */
-	public function __construct($filename, $contentType) {
+	public function __construct(string $filename, string $contentType) {
 		parent::__construct();
 
 		$this->filename = $filename;

--- a/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
@@ -88,7 +88,7 @@ class EmptyContentSecurityPolicy {
 	 * @since 8.1.0
 	 * @deprecated 10.0 CSP tokens are now used
 	 */
-	public function allowInlineScript($state = false) {
+	public function allowInlineScript(bool $state = false) {
 		$this->inlineScriptAllowed = $state;
 		return $this;
 	}
@@ -100,7 +100,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 11.0.0
 	 */
-	public function useJsNonce($nonce) {
+	public function useJsNonce(string $nonce) {
 		$this->useJsNonce = $nonce;
 		return $this;
 	}
@@ -112,7 +112,7 @@ class EmptyContentSecurityPolicy {
 	 * @since 8.1.0
 	 * @deprecated Eval should not be used anymore. Please update your scripts. This function will stop functioning in a future version of Nextcloud.
 	 */
-	public function allowEvalScript($state = true) {
+	public function allowEvalScript(bool $state = true) {
 		$this->evalScriptAllowed = $state;
 		return $this;
 	}
@@ -124,7 +124,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 8.1.0
 	 */
-	public function addAllowedScriptDomain($domain) {
+	public function addAllowedScriptDomain(string $domain) {
 		$this->allowedScriptDomains[] = $domain;
 		return $this;
 	}
@@ -136,7 +136,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 8.1.0
 	 */
-	public function disallowScriptDomain($domain) {
+	public function disallowScriptDomain(string $domain) {
 		$this->allowedScriptDomains = array_diff($this->allowedScriptDomains, [$domain]);
 		return $this;
 	}
@@ -147,7 +147,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 8.1.0
 	 */
-	public function allowInlineStyle($state = true) {
+	public function allowInlineStyle(bool $state = true) {
 		$this->inlineStyleAllowed = $state;
 		return $this;
 	}
@@ -159,7 +159,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 8.1.0
 	 */
-	public function addAllowedStyleDomain($domain) {
+	public function addAllowedStyleDomain(string $domain) {
 		$this->allowedStyleDomains[] = $domain;
 		return $this;
 	}
@@ -171,7 +171,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 8.1.0
 	 */
-	public function disallowStyleDomain($domain) {
+	public function disallowStyleDomain(string $domain) {
 		$this->allowedStyleDomains = array_diff($this->allowedStyleDomains, [$domain]);
 		return $this;
 	}
@@ -183,7 +183,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 8.1.0
 	 */
-	public function addAllowedFontDomain($domain) {
+	public function addAllowedFontDomain(string $domain) {
 		$this->allowedFontDomains[] = $domain;
 		return $this;
 	}
@@ -195,7 +195,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 8.1.0
 	 */
-	public function disallowFontDomain($domain) {
+	public function disallowFontDomain(string $domain) {
 		$this->allowedFontDomains = array_diff($this->allowedFontDomains, [$domain]);
 		return $this;
 	}
@@ -207,7 +207,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 8.1.0
 	 */
-	public function addAllowedImageDomain($domain) {
+	public function addAllowedImageDomain(string $domain) {
 		$this->allowedImageDomains[] = $domain;
 		return $this;
 	}
@@ -219,7 +219,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 8.1.0
 	 */
-	public function disallowImageDomain($domain) {
+	public function disallowImageDomain(string $domain) {
 		$this->allowedImageDomains = array_diff($this->allowedImageDomains, [$domain]);
 		return $this;
 	}
@@ -230,7 +230,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 8.1.0
 	 */
-	public function addAllowedConnectDomain($domain) {
+	public function addAllowedConnectDomain(string $domain) {
 		$this->allowedConnectDomains[] = $domain;
 		return $this;
 	}
@@ -242,7 +242,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 8.1.0
 	 */
-	public function disallowConnectDomain($domain) {
+	public function disallowConnectDomain(string $domain) {
 		$this->allowedConnectDomains = array_diff($this->allowedConnectDomains, [$domain]);
 		return $this;
 	}
@@ -253,7 +253,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 8.1.0
 	 */
-	public function addAllowedMediaDomain($domain) {
+	public function addAllowedMediaDomain(string $domain) {
 		$this->allowedMediaDomains[] = $domain;
 		return $this;
 	}
@@ -265,7 +265,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 8.1.0
 	 */
-	public function disallowMediaDomain($domain) {
+	public function disallowMediaDomain(string $domain) {
 		$this->allowedMediaDomains = array_diff($this->allowedMediaDomains, [$domain]);
 		return $this;
 	}
@@ -276,7 +276,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 8.1.0
 	 */
-	public function addAllowedObjectDomain($domain) {
+	public function addAllowedObjectDomain(string $domain) {
 		$this->allowedObjectDomains[] = $domain;
 		return $this;
 	}
@@ -288,7 +288,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 8.1.0
 	 */
-	public function disallowObjectDomain($domain) {
+	public function disallowObjectDomain(string $domain) {
 		$this->allowedObjectDomains = array_diff($this->allowedObjectDomains, [$domain]);
 		return $this;
 	}
@@ -299,7 +299,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 8.1.0
 	 */
-	public function addAllowedFrameDomain($domain) {
+	public function addAllowedFrameDomain(string $domain) {
 		$this->allowedFrameDomains[] = $domain;
 		return $this;
 	}
@@ -311,7 +311,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 8.1.0
 	 */
-	public function disallowFrameDomain($domain) {
+	public function disallowFrameDomain(string $domain) {
 		$this->allowedFrameDomains = array_diff($this->allowedFrameDomains, [$domain]);
 		return $this;
 	}
@@ -323,7 +323,7 @@ class EmptyContentSecurityPolicy {
 	 * @since 8.1.0
 	 * @deprecated 15.0.0 use addAllowedWorkerSrcDomains or addAllowedFrameDomain
 	 */
-	public function addAllowedChildSrcDomain($domain) {
+	public function addAllowedChildSrcDomain(string $domain) {
 		$this->allowedChildSrcDomains[] = $domain;
 		return $this;
 	}
@@ -336,7 +336,7 @@ class EmptyContentSecurityPolicy {
 	 * @since 8.1.0
 	 * @deprecated 15.0.0 use the WorkerSrcDomains or FrameDomain
 	 */
-	public function disallowChildSrcDomain($domain) {
+	public function disallowChildSrcDomain(string $domain) {
 		$this->allowedChildSrcDomains = array_diff($this->allowedChildSrcDomains, [$domain]);
 		return $this;
 	}
@@ -348,7 +348,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 13.0.0
 	 */
-	public function addAllowedFrameAncestorDomain($domain) {
+	public function addAllowedFrameAncestorDomain(string $domain) {
 		$this->allowedFrameAncestors[] = $domain;
 		return $this;
 	}
@@ -360,7 +360,7 @@ class EmptyContentSecurityPolicy {
 	 * @return $this
 	 * @since 13.0.0
 	 */
-	public function disallowFrameAncestorDomain($domain) {
+	public function disallowFrameAncestorDomain(string $domain) {
 		$this->allowedFrameAncestors = array_diff($this->allowedFrameAncestors, [$domain]);
 		return $this;
 	}

--- a/lib/public/AppFramework/Http/FileDisplayResponse.php
+++ b/lib/public/AppFramework/Http/FileDisplayResponse.php
@@ -24,6 +24,8 @@
 namespace OCP\AppFramework\Http;
 
 use OCP\AppFramework\Http;
+use OCP\Files\File;
+use OCP\Files\SimpleFS\ISimpleFile;
 
 /**
  * Class FileDisplayResponse
@@ -33,19 +35,19 @@ use OCP\AppFramework\Http;
  */
 class FileDisplayResponse extends Response implements ICallbackResponse {
 
-	/** @var \OCP\Files\File|\OCP\Files\SimpleFS\ISimpleFile */
+	/** @var File|ISimpleFile */
 	private $file;
 
 	/**
 	 * FileDisplayResponse constructor.
 	 *
-	 * @param \OCP\Files\File|\OCP\Files\SimpleFS\ISimpleFile $file
+	 * @param File|ISimpleFile $file
 	 * @param int $statusCode
 	 * @param array $headers
 	 * @since 11.0.0
 	 */
-	public function __construct($file, $statusCode=Http::STATUS_OK,
-								$headers=[]) {
+	public function __construct($file, int $statusCode = Http::STATUS_OK,
+								array $headers=[]) {
 		parent::__construct();
 
 		$this->file = $file;

--- a/lib/public/AppFramework/Http/IOutput.php
+++ b/lib/public/AppFramework/Http/IOutput.php
@@ -37,7 +37,7 @@ interface IOutput {
 	 * @param string $out
 	 * @since 8.1.0
 	 */
-	public function setOutput($out);
+	public function setOutput(string $out);
 
 	/**
 	 * @param string|resource $path or file handle
@@ -45,13 +45,13 @@ interface IOutput {
 	 * @return bool false if an error occurred
 	 * @since 8.1.0
 	 */
-	public function setReadfile($path);
+	public function setReadfile(string $path);
 
 	/**
 	 * @param string $header
 	 * @since 8.1.0
 	 */
-	public function setHeader($header);
+	public function setHeader(string $header);
 
 	/**
 	 * @return int returns the current http response code
@@ -63,7 +63,7 @@ interface IOutput {
 	 * @param int $code sets the http status code
 	 * @since 8.1.0
 	 */
-	public function setHttpResponseCode($code);
+	public function setHttpResponseCode(int $code);
 
 	/**
 	 * @param string $name
@@ -75,6 +75,6 @@ interface IOutput {
 	 * @param bool $httpOnly
 	 * @since 8.1.0
 	 */
-	public function setCookie($name, $value, $expire, $path, $domain, $secure, $httpOnly);
+	public function setCookie(string $name, string $value, int $expire, string $path, string $domain, bool $secure, bool $httpOnly);
 
 }

--- a/lib/public/AppFramework/Http/JSONResponse.php
+++ b/lib/public/AppFramework/Http/JSONResponse.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -25,11 +28,6 @@
  *
  */
 
-/**
- * Public interface of ownCloud for apps to use.
- * AppFramework\HTTP\JSONResponse class
- */
-
 namespace OCP\AppFramework\Http;
 
 use OCP\AppFramework\Http;
@@ -53,7 +51,7 @@ class JSONResponse extends Response {
 	 * @param int $statusCode the Http status code, defaults to 200
 	 * @since 6.0.0
 	 */
-	public function __construct($data=array(), $statusCode=Http::STATUS_OK) {
+	public function __construct($data = [], int $statusCode=Http::STATUS_OK) {
 		parent::__construct();
 
 		$this->data = $data;

--- a/lib/public/AppFramework/Http/NotFoundResponse.php
+++ b/lib/public/AppFramework/Http/NotFoundResponse.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *

--- a/lib/public/AppFramework/Http/OCSResponse.php
+++ b/lib/public/AppFramework/Http/OCSResponse.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -22,11 +25,6 @@
  * You should have received a copy of the GNU Affero General Public License, version 3,
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
- */
-
-/**
- * Public interface of ownCloud for apps to use.
- * AppFramework\HTTP\JSONResponse class
  */
 
 namespace OCP\AppFramework\Http;
@@ -56,8 +54,8 @@ class OCSResponse extends Response {
 	 * @since 8.1.0
 	 * @deprecated 9.2.0 To implement an OCS endpoint extend the OCSController
 	 */
-	public function __construct($format, $statuscode, $message,
-								$data=[], $itemscount='',
+	public function __construct(string $format, int $statuscode, string $message,
+								array $data = [], $itemscount='',
 								$itemsperpage='') {
 		parent::__construct();
 

--- a/lib/public/AppFramework/Http/RedirectResponse.php
+++ b/lib/public/AppFramework/Http/RedirectResponse.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -41,7 +44,7 @@ class RedirectResponse extends Response {
 	 * @param string $redirectURL the url to redirect to
 	 * @since 7.0.0
 	 */
-	public function __construct($redirectURL) {
+	public function __construct(string $redirectURL) {
 		parent::__construct();
 
 		$this->redirectURL = $redirectURL;

--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -25,11 +28,6 @@
  * You should have received a copy of the GNU Affero General Public License, version 3,
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
- */
-
-/**
- * Public interface of ownCloud for apps to use.
- * AppFramework\HTTP\Response class
  */
 
 namespace OCP\AppFramework\Http;
@@ -137,7 +135,7 @@ class Response {
 	 * @return $this
 	 * @since 8.0.0
 	 */
-	public function addCookie($name, $value, \DateTime $expireDate = null) {
+	public function addCookie(string $name, string $value, \DateTime $expireDate = null) {
 		$this->cookies[$name] = array('value' => $value, 'expireDate' => $expireDate);
 		return $this;
 	}
@@ -161,7 +159,7 @@ class Response {
 	 * @return $this
 	 * @since 8.0.0
 	 */
-	public function invalidateCookie($name) {
+	public function invalidateCookie(string $name) {
 		$this->addCookie($name, 'expired', new \DateTime('1971-01-01 00:00'));
 		return $this;
 	}
@@ -196,7 +194,7 @@ class Response {
 	 * @return $this
 	 * @since 6.0.0 - return value was added in 7.0.0
 	 */
-	public function addHeader($name, $value) {
+	public function addHeader(string $name, string $value) {
 		$name = trim($name);  // always remove leading and trailing whitespace
 		                      // to be able to reliably check for security
 		                      // headers
@@ -264,7 +262,7 @@ class Response {
 	 * @return Response Reference to this object
 	 * @since 6.0.0 - return value was added in 7.0.0
 	 */
-	public function setStatus($status) {
+	public function setStatus(int $status) {
 		$this->status = $status;
 
 		return $this;
@@ -351,7 +349,7 @@ class Response {
 	 * @return Response Reference to this object
 	 * @since 6.0.0 - return value was added in 7.0.0
 	 */
-	public function setETag($ETag) {
+	public function setETag(string $ETag) {
 		$this->ETag = $ETag;
 
 		return $this;

--- a/lib/public/AppFramework/Http/Template/ExternalShareMenuAction.php
+++ b/lib/public/AppFramework/Http/Template/ExternalShareMenuAction.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
  *

--- a/lib/public/AppFramework/Http/TemplateResponse.php
+++ b/lib/public/AppFramework/Http/TemplateResponse.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -75,8 +78,8 @@ class TemplateResponse extends Response {
 	 * @param string $renderAs how the page should be rendered, defaults to user
 	 * @since 6.0.0 - parameters $params and $renderAs were added in 7.0.0
 	 */
-	public function __construct($appName, $templateName, array $params=array(),
-	                            $renderAs='user') {
+	public function __construct(string $appName, string $templateName, array $params=array(),
+	                            string $renderAs = 'user') {
 		parent::__construct();
 
 		$this->templateName = $templateName;
@@ -132,7 +135,7 @@ class TemplateResponse extends Response {
 	 * @return TemplateResponse Reference to this object
 	 * @since 6.0.0 - return value was added in 7.0.0
 	 */
-	public function renderAs($renderAs){
+	public function renderAs(string $renderAs){
 		$this->renderAs = $renderAs;
 
 		return $this;

--- a/lib/public/AppFramework/Http/ZipResponse.php
+++ b/lib/public/AppFramework/Http/ZipResponse.php
@@ -54,6 +54,7 @@ class ZipResponse extends Response implements ICallbackResponse {
 	}
 
 	/**
+	 * @param resource $r
 	 * @since 15.0.0
 	 */
 	public function addResource($r, string $internalName, int $size, int $time = -1) {

--- a/lib/public/AppFramework/IAppContainer.php
+++ b/lib/public/AppFramework/IAppContainer.php
@@ -54,7 +54,7 @@ interface IAppContainer extends IContainer {
 	 * @return boolean
 	 * @since 6.0.0
 	 */
-	public function registerMiddleWare($middleWare);
+	public function registerMiddleWare(string $middleWare);
 
 	/**
 	 * Register a capability
@@ -62,5 +62,5 @@ interface IAppContainer extends IContainer {
 	 * @param string $serviceName e.g. 'OCA\Files\Capabilities'
 	 * @since 8.2.0
 	 */
-	 public function registerCapability($serviceName);
+	 public function registerCapability(string $serviceName);
 }

--- a/lib/public/AppFramework/Middleware.php
+++ b/lib/public/AppFramework/Middleware.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -24,13 +27,9 @@
  *
  */
 
-/**
- * Public interface of ownCloud for apps to use.
- * AppFramework\Middleware class
- */
-
 namespace OCP\AppFramework;
 
+use Exception;
 use OCP\AppFramework\Http\Response;
 
 /**
@@ -52,7 +51,7 @@ abstract class Middleware {
 	 *                           the controller
 	 * @since 6.0.0
 	 */
-	public function beforeController($controller, $methodName){
+	public function beforeController(Controller $controller, string $methodName){
 
 	}
 
@@ -67,12 +66,12 @@ abstract class Middleware {
 	 * @param Controller $controller the controller that is being called
 	 * @param string $methodName the name of the method that will be called on
 	 *                           the controller
-	 * @param \Exception $exception the thrown exception
-	 * @throws \Exception the passed in exception if it can't handle it
+	 * @param Exception $exception the thrown exception
+	 * @throws Exception the passed in exception if it can't handle it
 	 * @return Response a Response object in case that the exception was handled
 	 * @since 6.0.0
 	 */
-	public function afterException($controller, $methodName, \Exception $exception){
+	public function afterException(Controller $controller, string $methodName, Exception $exception){
 		throw $exception;
 	}
 
@@ -88,7 +87,7 @@ abstract class Middleware {
 	 * @return Response a Response object
 	 * @since 6.0.0
 	 */
-	public function afterController($controller, $methodName, Response $response){
+	public function afterController(Controller $controller, string $methodName, Response $response){
 		return $response;
 	}
 
@@ -104,7 +103,7 @@ abstract class Middleware {
 	 * @return string the output that should be printed
 	 * @since 6.0.0
 	 */
-	public function beforeOutput($controller, $methodName, $output){
+	public function beforeOutput(Controller $controller, string $methodName, string $output){
 		return $output;
 	}
 

--- a/lib/public/AppFramework/OCS/OCSBadRequestException.php
+++ b/lib/public/AppFramework/OCS/OCSBadRequestException.php
@@ -40,7 +40,7 @@ class OCSBadRequestException extends OCSException {
 	 * @param Exception|null $previous
 	 * @since 9.1.0
 	 */
-	public function __construct($message = '', Exception $previous = null) {
+	public function __construct(string $message = '', Exception $previous = null) {
 		parent::__construct($message, Http::STATUS_BAD_REQUEST, $previous);
 	}
 

--- a/lib/public/AppFramework/OCS/OCSForbiddenException.php
+++ b/lib/public/AppFramework/OCS/OCSForbiddenException.php
@@ -40,7 +40,7 @@ class OCSForbiddenException extends OCSException {
 	 * @param Exception|null $previous
 	 * @since 9.1.0
 	 */
-	public function __construct($message = '', Exception $previous = null) {
+	public function __construct(string $message = '', Exception $previous = null) {
 		parent::__construct($message, Http::STATUS_FORBIDDEN, $previous);
 	}
 }

--- a/lib/public/AppFramework/OCS/OCSNotFoundException.php
+++ b/lib/public/AppFramework/OCS/OCSNotFoundException.php
@@ -40,7 +40,7 @@ class OCSNotFoundException extends OCSException {
 	 * @param Exception|null $previous
 	 * @since 9.1.0
 	 */
-	public function __construct($message = '', Exception $previous = null) {
+	public function __construct(string $message = '', Exception $previous = null) {
 		parent::__construct($message, Http::STATUS_NOT_FOUND, $previous);
 	}
 }

--- a/lib/public/AppFramework/OCSController.php
+++ b/lib/public/AppFramework/OCSController.php
@@ -32,6 +32,8 @@
 
 namespace OCP\AppFramework;
 
+use OC\AppFramework\OCS\V1Response;
+use OC\AppFramework\OCS\V2Response;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\IRequest;
@@ -59,11 +61,11 @@ abstract class OCSController extends ApiController {
 	 * request should be cached, defaults to 1728000 seconds
 	 * @since 8.1.0
 	 */
-	public function __construct($appName,
+	public function __construct(string $appName,
 								IRequest $request,
-								$corsMethods='PUT, POST, GET, DELETE, PATCH',
-								$corsAllowedHeaders='Authorization, Content-Type, Accept',
-								$corsMaxAge=1728000){
+								string $corsMethods='PUT, POST, GET, DELETE, PATCH',
+								string $corsAllowedHeaders='Authorization, Content-Type, Accept',
+								int $corsMaxAge=1728000){
 		parent::__construct($appName, $request, $corsMethods,
 							$corsAllowedHeaders, $corsMaxAge);
 		$this->registerResponder('json', function ($data) {
@@ -79,7 +81,7 @@ abstract class OCSController extends ApiController {
 	 * @since 11.0.0
 	 * @internal
 	 */
-	public function setOCSVersion($version) {
+	public function setOCSVersion(int $version) {
 		$this->ocsVersion = $version;
 	}
 
@@ -93,7 +95,7 @@ abstract class OCSController extends ApiController {
 	 * @return Response
 	 * @since 9.1.0
 	 */
-	public function buildResponse($response, $format = 'xml') {
+	public function buildResponse($response, string $format = 'xml') {
 		return parent::buildResponse($response, $format);
 	}
 
@@ -104,11 +106,11 @@ abstract class OCSController extends ApiController {
 	 * @since 8.1.0
 	 * @return \OC\AppFramework\OCS\BaseResponse
 	 */
-	private function buildOCSResponse($format, DataResponse $data) {
+	private function buildOCSResponse(string $format, DataResponse $data) {
 		if ($this->ocsVersion === 1) {
-			return new \OC\AppFramework\OCS\V1Response($data, $format);
+			return new V1Response($data, $format);
 		}
-		return new \OC\AppFramework\OCS\V2Response($data, $format);
+		return new V2Response($data, $format);
 	}
 
 }

--- a/lib/public/AppFramework/PublicShareController.php
+++ b/lib/public/AppFramework/PublicShareController.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright 2018, Roeland Jago Douma <roeland@famdouma.nl>
  *
@@ -20,7 +23,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-declare(strict_types=1);
 
 namespace OCP\AppFramework;
 

--- a/lib/public/AppFramework/QueryException.php
+++ b/lib/public/AppFramework/QueryException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *

--- a/lib/public/AppFramework/Utility/IControllerMethodReflector.php
+++ b/lib/public/AppFramework/Utility/IControllerMethodReflector.php
@@ -45,7 +45,7 @@ interface IControllerMethodReflector {
 	 * @since 8.0.0
 	 * @deprecated 17.0.0 Reflect should not be called multiple times and only be used internally. This will be removed in Nextcloud 18
 	 */
-	public function reflect($object, string $method);
+	public function reflect(object $object, string $method);
 
 	/**
 	 * Inspects the PHPDoc parameters for types

--- a/lib/public/AppFramework/Utility/ITimeFactory.php
+++ b/lib/public/AppFramework/Utility/ITimeFactory.php
@@ -28,8 +28,12 @@ declare(strict_types=1);
 namespace OCP\AppFramework\Utility;
 
 
+use DateTime;
+use DateTimeZone;
+
 /**
  * Needed to mock calls to time()
+ *
  * @since 8.0.0
  */
 interface ITimeFactory {
@@ -42,10 +46,10 @@ interface ITimeFactory {
 
 	/**
 	 * @param string $time
-	 * @param \DateTimeZone $timezone
-	 * @return \DateTime
+	 * @param DateTimeZone $timezone
+	 * @return DateTime
 	 * @since 15.0.0
 	 */
-	public function getDateTime(string $time = 'now', \DateTimeZone $timezone = null): \DateTime;
+	public function getDateTime(string $time = 'now', DateTimeZone $timezone = null): DateTime;
 
 }

--- a/lib/public/Authentication/Exceptions/CredentialsUnavailableException.php
+++ b/lib/public/Authentication/Exceptions/CredentialsUnavailableException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright 2016 Christoph Wurst <christoph@winzerhof-wurst.at>
  *

--- a/lib/public/Authentication/Exceptions/PasswordUnavailableException.php
+++ b/lib/public/Authentication/Exceptions/PasswordUnavailableException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright 2017 Morris Jobke <hey@morrisjobke.de>
  *

--- a/lib/public/Authentication/LoginCredentials/ICredentials.php
+++ b/lib/public/Authentication/LoginCredentials/ICredentials.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright 2016 Christoph Wurst <christoph@winzerhof-wurst.at>
  *

--- a/lib/public/AutoloadNotAllowedException.php
+++ b/lib/public/AutoloadNotAllowedException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -22,11 +25,14 @@
 
 namespace OCP;
 
+use DomainException;
+
 /**
  * Exception for when a not allowed path is attempted to be autoloaded
+ *
  * @since 8.2.0
  */
-class AutoloadNotAllowedException extends \DomainException {
+class AutoloadNotAllowedException extends DomainException {
 	/**
 	 * @param string $path
 	 * @since 8.2.0

--- a/lib/public/BackgroundJob.php
+++ b/lib/public/BackgroundJob.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *

--- a/lib/public/BackgroundJob/IJob.php
+++ b/lib/public/BackgroundJob/IJob.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -36,23 +39,23 @@ interface IJob {
 	/**
 	 * Run the background job with the registered argument
 	 *
-	 * @param \OCP\BackgroundJob\IJobList $jobList The job list that manages the state of this job
+	 * @param IJobList $jobList The job list that manages the state of this job
 	 * @param ILogger|null $logger
 	 * @since 7.0.0
 	 */
-	public function execute($jobList, ILogger $logger = null);
+	public function execute(IJobList $jobList, ILogger $logger = null);
 
 	/**
 	 * @param int $id
 	 * @since 7.0.0
 	 */
-	public function setId($id);
+	public function setId(int $id);
 
 	/**
 	 * @param int $lastRun
 	 * @since 7.0.0
 	 */
-	public function setLastRun($lastRun);
+	public function setLastRun(int $lastRun);
 
 	/**
 	 * @param mixed $argument

--- a/lib/public/BackgroundJob/IJobList.php
+++ b/lib/public/BackgroundJob/IJobList.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -49,7 +52,7 @@ interface IJobList {
 	/**
 	 * Add a job to the list
 	 *
-	 * @param \OCP\BackgroundJob\IJob|string $job
+	 * @param IJob|string $job
 	 * @param mixed $argument The argument to be passed to $job->run() when the job is exectured
 	 * @since 7.0.0
 	 */
@@ -58,7 +61,7 @@ interface IJobList {
 	/**
 	 * Remove a job from the list
 	 *
-	 * @param \OCP\BackgroundJob\IJob|string $job
+	 * @param IJob|string $job
 	 * @param mixed $argument
 	 * @since 7.0.0
 	 */
@@ -67,7 +70,7 @@ interface IJobList {
 	/**
 	 * check if a job is in the list
 	 *
-	 * @param \OCP\BackgroundJob\IJob|string $job
+	 * @param IJob|string $job
 	 * @param mixed $argument
 	 * @return bool
 	 * @since 7.0.0
@@ -77,7 +80,7 @@ interface IJobList {
 	/**
 	 * get all jobs in the list
 	 *
-	 * @return \OCP\BackgroundJob\IJob[]
+	 * @return IJob[]
 	 * @since 7.0.0
 	 * @deprecated 9.0.0 - This method is dangerous since it can cause load and
 	 * memory problems when creating too many instances.
@@ -87,14 +90,14 @@ interface IJobList {
 	/**
 	 * get the next job in the list
 	 *
-	 * @return \OCP\BackgroundJob\IJob|null
+	 * @return IJob|null
 	 * @since 7.0.0
 	 */
 	public function getNext();
 
 	/**
 	 * @param int $id
-	 * @return \OCP\BackgroundJob\IJob|null
+	 * @return IJob|null
 	 * @since 7.0.0
 	 */
 	public function getById($id);
@@ -102,7 +105,7 @@ interface IJobList {
 	/**
 	 * set the job that was last ran to the current time
 	 *
-	 * @param \OCP\BackgroundJob\IJob $job
+	 * @param IJob $job
 	 * @since 7.0.0
 	 */
 	public function setLastJob(IJob $job);

--- a/lib/public/BackgroundJob/Job.php
+++ b/lib/public/BackgroundJob/Job.php
@@ -67,7 +67,7 @@ abstract class Job implements IJob {
 	 *
 	 * @since 15.0.0
 	 */
-	public function execute($jobList, ILogger $logger = null) {
+	public function execute(IJobList $jobList, ILogger $logger = null) {
 		$jobList->setLastRun($this);
 		if ($logger === null) {
 			$logger = \OC::$server->getLogger();
@@ -101,7 +101,7 @@ abstract class Job implements IJob {
 	/**
 	 * @since 15.0.0
 	 */
-	final public function setLastRun($lastRun) {
+	final public function setLastRun(int $lastRun) {
 		$this->lastRun = $lastRun;
 	}
 

--- a/lib/public/BackgroundJob/QueuedJob.php
+++ b/lib/public/BackgroundJob/QueuedJob.php
@@ -43,7 +43,7 @@ abstract class QueuedJob extends Job {
 	 *
 	 * @since 15.0.0
 	 */
-	final public function execute($jobList, ILogger $logger = null) {
+	final public function execute(IJobList $jobList, ILogger $logger = null) {
 		$jobList->remove($this, $this->argument);
 		parent::execute($jobList, $logger);
 	}

--- a/lib/public/BackgroundJob/TimedJob.php
+++ b/lib/public/BackgroundJob/TimedJob.php
@@ -56,7 +56,7 @@ abstract class TimedJob extends Job {
 	 *
 	 * @since 15.0.0
 	 */
-	final public function execute($jobList, ILogger $logger = null) {
+	final public function execute(IJobList $jobList, ILogger $logger = null) {
 		if (($this->time->getTime() - $this->lastRun) > $this->interval) {
 			parent::execute($jobList, $logger);
 		}

--- a/lib/public/Calendar/BackendTemporarilyUnavailableException.php
+++ b/lib/public/Calendar/BackendTemporarilyUnavailableException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright 2018, Georg Ehrke <oc.list@georgehrke.com>
  *
@@ -23,10 +26,12 @@
 
 namespace OCP\Calendar;
 
+use Exception;
+
 /**
  * Class BackendTemporarilyUnavailableException
  *
  * @package OCP\Calendar
  * @since 14.0.0
  */
-class BackendTemporarilyUnavailableException extends \Exception {}
+class BackendTemporarilyUnavailableException extends Exception {}

--- a/lib/public/Calendar/ICalendar.php
+++ b/lib/public/Calendar/ICalendar.php
@@ -61,7 +61,7 @@ interface ICalendar {
 	 * @return array an array of events/journals/todos which are arrays of key-value-pairs
 	 * @since 13.0.0
 	 */
-	public function search($pattern, array $searchProperties=[], array $options=[], $limit=null, $offset=null);
+	public function search(string $pattern, array $searchProperties=[], array $options=[], int $limit=null, int $offset=null);
 
 	/**
 	 * @return integer build up using \OCP\Constants

--- a/lib/public/Calendar/IManager.php
+++ b/lib/public/Calendar/IManager.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright 2017, Georg Ehrke <oc.list@georgehrke.com>
  *
@@ -22,6 +25,8 @@
  */
 
 namespace OCP\Calendar;
+
+use Closure;
 
 /**
  * This class provides access to the Nextcloud CalDAV backend.
@@ -68,7 +73,7 @@ interface IManager {
 	 * @return array an array of events/journals/todos which are arrays of arrays of key-value-pairs
 	 * @since 13.0.0
 	 */
-	public function search($pattern, array $searchProperties=[], array $options=[], $limit=null, $offset=null);
+	public function search(string $pattern, array $searchProperties=[], array $options=[], int $limit=null, int $offset=null);
 
 	/**
 	 * Check if calendars are available
@@ -100,11 +105,11 @@ interface IManager {
 	 * In order to improve lazy loading a closure can be registered which will be called in case
 	 * calendars are actually requested
 	 *
-	 * @param \Closure $callable
+	 * @param Closure $callable
 	 * @return void
 	 * @since 13.0.0
 	 */
-	public function register(\Closure $callable);
+	public function register(Closure $callable);
 
 	/**
 	 * @return ICalendar[]

--- a/lib/public/Calendar/Resource/IBackend.php
+++ b/lib/public/Calendar/Resource/IBackend.php
@@ -58,7 +58,7 @@ interface IBackend {
 	 * @return IResource|null
 	 * @since 14.0.0
 	 */
-	public function getResource($id);
+	public function getResource(string $id);
 
 	/**
 	 * Get unique identifier of the backend

--- a/lib/public/Calendar/Resource/IManager.php
+++ b/lib/public/Calendar/Resource/IManager.php
@@ -60,7 +60,7 @@ interface IManager {
 	 * @return IBackend|null
 	 * @since 14.0.0
 	 */
-	public function getBackend($backendId);
+	public function getBackend(string $backendId);
 
 	/**
 	 * removes all registered backend instances

--- a/lib/public/Calendar/Room/IBackend.php
+++ b/lib/public/Calendar/Room/IBackend.php
@@ -58,7 +58,7 @@ interface IBackend {
 	 * @return IRoom|null
 	 * @since 14.0.0
 	 */
-	public function getRoom($id);
+	public function getRoom(string $id);
 
 	/**
 	 * Get unique identifier of the backend

--- a/lib/public/Calendar/Room/IManager.php
+++ b/lib/public/Calendar/Room/IManager.php
@@ -60,7 +60,7 @@ interface IManager {
 	 * @return IBackend|null
 	 * @since 14.0.0
 	 */
-	public function getBackend($backendId);
+	public function getBackend(string $backendId);
 
 	/**
 	 * removes all registered backend instances

--- a/lib/public/Collaboration/AutoComplete/IManager.php
+++ b/lib/public/Collaboration/AutoComplete/IManager.php
@@ -34,7 +34,7 @@ interface IManager {
 	 * @param string $className – class name of the ISorter implementation
 	 * @since 13.0.0
 	 */
-	public function registerSorter($className);
+	public function registerSorter(string $className);
 
 	/**
 	 * @param array $sorters	list of sorter IDs, seperated by "|"

--- a/lib/public/Collaboration/Collaborators/ISearch.php
+++ b/lib/public/Collaboration/Collaborators/ISearch.php
@@ -39,7 +39,7 @@ interface ISearch {
 	 * @return array with two elements, 1st ISearchResult as array, 2nd a bool indicating whether more result are available
 	 * @since 13.0.0
 	 */
-	public function search($search, array $shareTypes, $lookup, $limit, $offset);
+	public function search(string $search, array $shareTypes, bool $lookup, int $limit, int $offset);
 
 	/**
 	 * @param array $pluginInfo with keys 'shareType' containing the name of a corresponding constant in \OCP\Share and

--- a/lib/public/Collaboration/Collaborators/ISearchPlugin.php
+++ b/lib/public/Collaboration/Collaborators/ISearchPlugin.php
@@ -38,5 +38,5 @@ interface ISearchPlugin {
 	 * @return bool whether the plugin has more results
 	 * @since 13.0.0
 	 */
-	public function search($search, $limit, $offset, ISearchResult $searchResult);
+	public function search(string $search, int $limit, int $offset, ISearchResult $searchResult);
 }

--- a/lib/public/Collaboration/Collaborators/ISearchResult.php
+++ b/lib/public/Collaboration/Collaborators/ISearchResult.php
@@ -44,7 +44,7 @@ interface ISearchResult {
 	 * @return bool
 	 * @since 13.0.0
 	 */
-	public function hasResult(SearchResultType $type, $collaboratorId);
+	public function hasResult(SearchResultType $type, string $collaboratorId);
 
 	/**
 	 * @param SearchResultType $type

--- a/lib/public/Collaboration/Collaborators/SearchResultType.php
+++ b/lib/public/Collaboration/Collaborators/SearchResultType.php
@@ -40,7 +40,7 @@ class SearchResultType {
 	 * @param string $label
 	 * @since 13.0.0
 	 */
-	public function __construct($label) {
+	public function __construct(string $label) {
 		$this->label = $this->getValidatedType($label);
 	}
 

--- a/lib/public/Collaboration/Resources/CollectionException.php
+++ b/lib/public/Collaboration/Resources/CollectionException.php
@@ -26,9 +26,11 @@ declare(strict_types=1);
 
 namespace OCP\Collaboration\Resources;
 
+use RuntimeException;
+
 /**
  * @since 16.0.0
  */
-class CollectionException extends \RuntimeException {
+class CollectionException extends RuntimeException {
 
 }

--- a/lib/public/Collaboration/Resources/ResourceException.php
+++ b/lib/public/Collaboration/Resources/ResourceException.php
@@ -27,9 +27,11 @@ declare(strict_types=1);
 namespace OCP\Collaboration\Resources;
 
 
+use RuntimeException;
+
 /**
  * @since 16.0.0
  */
-class ResourceException extends \RuntimeException {
+class ResourceException extends RuntimeException {
 
 }

--- a/lib/public/Command/IBus.php
+++ b/lib/public/Command/IBus.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -33,7 +36,7 @@ interface IBus {
 	/**
 	 * Schedule a command to be fired
 	 *
-	 * @param \OCP\Command\ICommand | callable $command
+	 * @param ICommand|callable $command
 	 * @since 8.1.0
 	 */
 	public function push($command);
@@ -44,5 +47,5 @@ interface IBus {
 	 * @param string $trait
 	 * @since 8.1.0
 	 */
-	public function requireSync($trait);
+	public function requireSync(string $trait);
 }

--- a/lib/public/Command/ICommand.php
+++ b/lib/public/Command/ICommand.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -24,9 +27,6 @@
 namespace OCP\Command;
 
 /**
- * Interface ICommand
- *
- * @package OCP\Command
  * @since 8.1.0
  */
 interface ICommand {

--- a/lib/public/Comments/CommentsEntityEvent.php
+++ b/lib/public/Comments/CommentsEntityEvent.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -23,6 +26,7 @@
 
 namespace OCP\Comments;
 
+use Closure;
 use OCP\EventDispatcher\Event;
 
 /**
@@ -37,7 +41,7 @@ class CommentsEntityEvent extends Event {
 
 	/** @var string */
 	protected $event;
-	/** @var \Closure[] */
+	/** @var Closure[] */
 	protected $collections;
 
 	/**
@@ -47,20 +51,21 @@ class CommentsEntityEvent extends Event {
 	 * @since 9.1.0
 	 */
 	public function __construct($event) {
+		parent::__construct();
 		$this->event = $event;
 		$this->collections = [];
 	}
 
 	/**
 	 * @param string $name
-	 * @param \Closure $entityExistsFunction The closure should take one
+	 * @param Closure $entityExistsFunction The closure should take one
 	 *                 argument, which is the id of the entity, that comments
 	 *                 should be handled for. The return should then be bool,
 	 *                 depending on whether comments are allowed (true) or not.
 	 * @throws \OutOfBoundsException when the entity name is already taken
 	 * @since 9.1.0
 	 */
-	public function addEntityCollection($name, \Closure $entityExistsFunction) {
+	public function addEntityCollection(string $name, Closure $entityExistsFunction) {
 		if (isset($this->collections[$name])) {
 			throw new \OutOfBoundsException('Duplicate entity name "' . $name . '"');
 		}
@@ -69,7 +74,7 @@ class CommentsEntityEvent extends Event {
 	}
 
 	/**
-	 * @return \Closure[]
+	 * @return Closure[]
 	 * @since 9.1.0
 	 */
 	public function getEntityCollections() {

--- a/lib/public/Comments/CommentsEvent.php
+++ b/lib/public/Comments/CommentsEvent.php
@@ -51,6 +51,7 @@ class CommentsEvent extends Event {
 	 * @since 9.0.0
 	 */
 	public function __construct($event, IComment $comment) {
+		parent::__construct();
 		$this->event = $event;
 		$this->comment = $comment;
 	}

--- a/lib/public/Comments/IComment.php
+++ b/lib/public/Comments/IComment.php
@@ -25,6 +25,8 @@
 
 namespace OCP\Comments;
 
+use DateTime;
+
 /**
  * Interface IComment
  *
@@ -61,7 +63,7 @@ interface IComment {
 	 * @throws IllegalIDChangeException
 	 * @since 9.0.0
 	 */
-	public function setId($id);
+	public function setId(string $id);
 
 	/**
 	 * returns the parent ID of the comment
@@ -77,7 +79,7 @@ interface IComment {
 	 * @return IComment
 	 * @since 9.0.0
 	 */
-	public function setParentId($parentId);
+	public function setParentId(string $parentId);
 
 	/**
 	 * returns the topmost parent ID of the comment
@@ -95,7 +97,7 @@ interface IComment {
 	 * @return IComment
 	 * @since 9.0.0
 	 */
-	public function setTopmostParentId($id);
+	public function setTopmostParentId(string $id);
 
 	/**
 	 * returns the number of children
@@ -112,7 +114,7 @@ interface IComment {
 	 * @return IComment
 	 * @since 9.0.0
 	 */
-	public function setChildrenCount($count);
+	public function setChildrenCount(int $count);
 
 	/**
 	 * returns the message of the comment
@@ -134,7 +136,7 @@ interface IComment {
 	 * @throws MessageTooLongException
 	 * @since 9.0.0 - $maxLength added in 16.0.2
 	 */
-	public function setMessage($message, $maxLength = self::MAX_MESSAGE_LENGTH);
+	public function setMessage(string $message, int $maxLength = self::MAX_MESSAGE_LENGTH);
 
 	/**
 	 * returns an array containing mentions that are included in the comment
@@ -173,7 +175,7 @@ interface IComment {
 	 * @return IComment
 	 * @since 9.0.0
 	 */
-	public function setVerb($verb);
+	public function setVerb(string $verb);
 
 	/**
 	 * returns the actor type
@@ -199,14 +201,14 @@ interface IComment {
 	 * @return IComment
 	 * @since 9.0.0
 	 */
-	public function setActor($actorType, $actorId);
+	public function setActor(string $actorType, string $actorId);
 
 	/**
 	 * returns the creation date of the comment.
 	 *
 	 * If not explicitly set, it shall default to the time of initialization.
 	 *
-	 * @return \DateTime
+	 * @return DateTime
 	 * @since 9.0.0
 	 */
 	public function getCreationDateTime();
@@ -214,16 +216,16 @@ interface IComment {
 	/**
 	 * sets the creation date of the comment and returns itself
 	 *
-	 * @param \DateTime $dateTime
+	 * @param DateTime $dateTime
 	 * @return IComment
 	 * @since 9.0.0
 	 */
-	public function setCreationDateTime(\DateTime $dateTime);
+	public function setCreationDateTime(DateTime $dateTime);
 
 	/**
 	 * returns the date of the most recent child
 	 *
-	 * @return \DateTime
+	 * @return DateTime
 	 * @since 9.0.0
 	 */
 	public function getLatestChildDateTime();
@@ -231,11 +233,11 @@ interface IComment {
 	/**
 	 * sets the date of the most recent child
 	 *
-	 * @param \DateTime $dateTime
+	 * @param DateTime $dateTime
 	 * @return IComment
 	 * @since 9.0.0
 	 */
-	public function setLatestChildDateTime(\DateTime $dateTime);
+	public function setLatestChildDateTime(DateTime $dateTime);
 
 	/**
 	 * returns the object type the comment is attached to
@@ -261,6 +263,6 @@ interface IComment {
 	 * @return IComment
 	 * @since 9.0.0
 	 */
-	public function setObject($objectType, $objectId);
+	public function setObject(string $objectType, string $objectId);
 
 }

--- a/lib/public/Comments/ICommentsEventHandler.php
+++ b/lib/public/Comments/ICommentsEventHandler.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016 Arthur Schiwon <blizzz@arthur-schiwon.de>
  *

--- a/lib/public/Comments/ICommentsManager.php
+++ b/lib/public/Comments/ICommentsManager.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -27,7 +30,10 @@
 
 namespace OCP\Comments;
 
+use Closure;
+use DateTime;
 use OCP\IUser;
+use OutOfBoundsException;
 
 /**
  * Interface ICommentsManager
@@ -58,7 +64,7 @@ interface ICommentsManager {
 	 * @throws NotFoundException
 	 * @since 9.0.0
 	 */
-	public function get($id);
+	public function get(string $id);
 
 	/**
 	 * returns the comment specified by the id and all it's child comments
@@ -96,7 +102,7 @@ interface ICommentsManager {
 	 *   ]
 	 * ]
 	 */
-	public function getTree($id, $limit = 0, $offset = 0);
+	public function getTree(string $id, int $limit = 0, int $offset = 0);
 
 	/**
 	 * returns comments for a specific object (e.g. a file).
@@ -108,17 +114,17 @@ interface ICommentsManager {
 	 * @param int $limit optional, number of maximum comments to be returned. if
 	 * not specified, all comments are returned.
 	 * @param int $offset optional, starting point
-	 * @param \DateTime|null $notOlderThan optional, timestamp of the oldest comments
+	 * @param DateTime|null $notOlderThan optional, timestamp of the oldest comments
 	 * that may be returned
 	 * @return IComment[]
 	 * @since 9.0.0
 	 */
 	public function getForObject(
-			$objectType,
-			$objectId,
-			$limit = 0,
-			$offset = 0,
-			\DateTime $notOlderThan = null
+			string $objectType,
+			string $objectId,
+			int $limit = 0,
+			int $offset = 0,
+			DateTime $notOlderThan = null
 	);
 
 	/**
@@ -156,13 +162,13 @@ interface ICommentsManager {
 	/**
 	 * @param $objectType string the object type, e.g. 'files'
 	 * @param $objectId string the id of the object
-	 * @param \DateTime|null $notOlderThan optional, timestamp of the oldest comments
+	 * @param DateTime|null $notOlderThan optional, timestamp of the oldest comments
 	 * that may be returned
 	 * @param string $verb Limit the verb of the comment - Added in 14.0.0
 	 * @return Int
 	 * @since 9.0.0
 	 */
-	public function getNumberOfCommentsForObject($objectType, $objectId, \DateTime $notOlderThan = null, $verb = '');
+	public function getNumberOfCommentsForObject(string $objectType, string $objectId, DateTime $notOlderThan = null, string $verb = '');
 
 	/**
 	 * Get the number of unread comments for all files in a folder
@@ -172,7 +178,7 @@ interface ICommentsManager {
 	 * @return array [$fileId => $unreadCount]
 	 * @since 12.0.0
 	 */
-	public function getNumberOfUnreadCommentsForFolder($folderId, IUser $user);
+	public function getNumberOfUnreadCommentsForFolder(int $folderId, IUser $user);
 
 	/**
 	 * creates a new comment and returns it. At this point of time, it is not
@@ -186,7 +192,7 @@ interface ICommentsManager {
 	 * @return IComment
 	 * @since 9.0.0
 	 */
-	public function create($actorType, $actorId, $objectType, $objectId);
+	public function create(string $actorType, string $actorId, string $objectType, string $objectId);
 
 	/**
 	 * permanently deletes the comment specified by the ID
@@ -198,7 +204,7 @@ interface ICommentsManager {
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function delete($id);
+	public function delete(string $id);
 
 	/**
 	 * saves the comment permanently
@@ -230,7 +236,7 @@ interface ICommentsManager {
 	 * @return boolean
 	 * @since 9.0.0
 	 */
-	public function deleteReferencesOfActor($actorType, $actorId);
+	public function deleteReferencesOfActor(string $actorType, string $actorId);
 
 	/**
 	 * deletes all comments made of a specific object (e.g. on file delete)
@@ -240,7 +246,7 @@ interface ICommentsManager {
 	 * @return boolean
 	 * @since 9.0.0
 	 */
-	public function deleteCommentsAtObject($objectType, $objectId);
+	public function deleteCommentsAtObject(string $objectType, string $objectId);
 
 	/**
 	 * sets the read marker for a given file to the specified date for the
@@ -248,11 +254,11 @@ interface ICommentsManager {
 	 *
 	 * @param string $objectType
 	 * @param string $objectId
-	 * @param \DateTime $dateTime
-	 * @param \OCP\IUser $user
+	 * @param DateTime $dateTime
+	 * @param IUser $user
 	 * @since 9.0.0
 	 */
-	public function setReadMark($objectType, $objectId, \DateTime $dateTime, \OCP\IUser $user);
+	public function setReadMark(string $objectType, string $objectId, DateTime $dateTime, IUser $user);
 
 	/**
 	 * returns the read marker for a given file to the specified date for the
@@ -261,20 +267,20 @@ interface ICommentsManager {
 	 *
 	 * @param string $objectType
 	 * @param string $objectId
-	 * @param \OCP\IUser $user
-	 * @return \DateTime|null
+	 * @param IUser $user
+	 * @return DateTime|null
 	 * @since 9.0.0
 	 */
-	public function getReadMark($objectType, $objectId, \OCP\IUser $user);
+	public function getReadMark(string $objectType, string $objectId, IUser $user);
 
 	/**
 	 * deletes the read markers for the specified user
 	 *
-	 * @param \OCP\IUser $user
+	 * @param IUser $user
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function deleteReadMarksFromUser(\OCP\IUser $user);
+	public function deleteReadMarksFromUser(IUser $user);
 
 	/**
 	 * deletes the read markers on the specified object
@@ -284,29 +290,29 @@ interface ICommentsManager {
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function deleteReadMarksOnObject($objectType, $objectId);
+	public function deleteReadMarksOnObject(string $objectType, string $objectId);
 
 	/**
 	 * registers an Entity to the manager, so event notifications can be send
 	 * to consumers of the comments infrastructure
 	 *
-	 * @param \Closure $closure
+	 * @param Closure $closure
 	 * @since 11.0.0
 	 */
-	public function registerEventHandler(\Closure $closure);
+	public function registerEventHandler(Closure $closure);
 
 	/**
 	 * registers a method that resolves an ID to a display name for a given type
 	 *
 	 * @param string $type
-	 * @param \Closure $closure
-	 * @throws \OutOfBoundsException
+	 * @param Closure $closure
+	 * @throws OutOfBoundsException
 	 * @since 11.0.0
 	 *
 	 * Only one resolver shall be registered per type. Otherwise a
 	 * \OutOfBoundsException has to thrown.
 	 */
-	public function registerDisplayNameResolver($type, \Closure $closure);
+	public function registerDisplayNameResolver(string $type, Closure $closure);
 
 	/**
 	 * resolves a given ID of a given Type to a display name.
@@ -314,13 +320,13 @@ interface ICommentsManager {
 	 * @param string $type
 	 * @param string $id
 	 * @return string
-	 * @throws \OutOfBoundsException
+	 * @throws OutOfBoundsException
 	 * @since 11.0.0
 	 *
 	 * If a provided type was not registered, an \OutOfBoundsException shall
 	 * be thrown. It is upon the resolver discretion what to return of the
 	 * provided ID is unknown. It must be ensured that a string is returned.
 	 */
-	public function resolveDisplayName($type, $id);
+	public function resolveDisplayName(string $type, string $id);
 
 }

--- a/lib/public/Comments/ICommentsManagerFactory.php
+++ b/lib/public/Comments/ICommentsManagerFactory.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *

--- a/lib/public/Comments/IllegalIDChangeException.php
+++ b/lib/public/Comments/IllegalIDChangeException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -24,8 +27,11 @@
 
 namespace OCP\Comments;
 
+use Exception;
+
 /**
  * Exception for illegal attempts to modify a comment ID
+ *
  * @since 9.0.0
  */
-class IllegalIDChangeException extends \Exception {}
+class IllegalIDChangeException extends Exception {}

--- a/lib/public/Comments/MessageTooLongException.php
+++ b/lib/public/Comments/MessageTooLongException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -23,8 +26,11 @@
 
 namespace OCP\Comments;
 
+use OverflowException;
+
 /**
  * Exception thrown when a comment message exceeds the allowed character limit
+ *
  * @since 9.0.0
  */
-class MessageTooLongException extends \OverflowException {}
+class MessageTooLongException extends OverflowException {}

--- a/lib/public/Comments/NotFoundException.php
+++ b/lib/public/Comments/NotFoundException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -24,8 +27,11 @@
 
 namespace OCP\Comments;
 
+use Exception;
+
 /**
  * Exception for not found entity
+ *
  * @since 9.0.0
  */
-class NotFoundException extends \Exception {}
+class NotFoundException extends Exception {}

--- a/lib/public/Console/ConsoleEvent.php
+++ b/lib/public/Console/ConsoleEvent.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -49,6 +52,7 @@ class ConsoleEvent extends Event {
 	 * @since 9.0.0
 	 */
 	public function __construct($event, array $arguments) {
+		parent::__construct();
 		$this->event = $event;
 		$this->arguments = $arguments;
 	}

--- a/lib/public/Constants.php
+++ b/lib/public/Constants.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *

--- a/lib/public/Contacts/ContactsMenu/IAction.php
+++ b/lib/public/Contacts/ContactsMenu/IAction.php
@@ -36,7 +36,7 @@ interface IAction extends JsonSerializable {
 	 * @param string $icon absolute URI to an icon
 	 * @since 12.0
 	 */
-	public function setIcon($icon);
+	public function setIcon(string $icon);
 
 	/**
 	 * @return string localized action name, e.g. 'Call'
@@ -48,13 +48,13 @@ interface IAction extends JsonSerializable {
 	 * @param string $name localized action name, e.g. 'Call'
 	 * @since 12.0
 	 */
-	public function setName($name);
+	public function setName(string $name);
 
 	/**
 	 * @param int $priority priorize actions, high order ones are shown on top
 	 * @since 12.0
 	 */
-	public function setPriority($priority);
+	public function setPriority(int $priority);
 
 	/**
 	 * @return int priority to priorize actions, high order ones are shown on top

--- a/lib/public/Contacts/ContactsMenu/IActionFactory.php
+++ b/lib/public/Contacts/ContactsMenu/IActionFactory.php
@@ -38,7 +38,7 @@ interface IActionFactory {
 	 * @param string $href target URL
 	 * @return ILinkAction
 	 */
-	public function newLinkAction($icon, $name, $href);
+	public function newLinkAction(string $icon, string $name, string $href);
 
 	/**
 	 * Construct and return a new email action for the contacts menu
@@ -50,5 +50,5 @@ interface IActionFactory {
 	 * @param string $email target e-mail address
 	 * @return ILinkAction
 	 */
-	public function newEMailAction($icon, $name, $email);
+	public function newEMailAction(string $icon, string $name, string $email);
 }

--- a/lib/public/Contacts/ContactsMenu/IContactsStore.php
+++ b/lib/public/Contacts/ContactsMenu/IContactsStore.php
@@ -47,6 +47,6 @@ interface IContactsStore {
 	 * @return IEntry|null
 	 * @since 13.0.0
 	 */
-	public function findOne(IUser $user, $shareType, $shareWith);
+	public function findOne(IUser $user, int $shareType, string $shareWith);
 
 }

--- a/lib/public/Contacts/ContactsMenu/IEntry.php
+++ b/lib/public/Contacts/ContactsMenu/IEntry.php
@@ -61,5 +61,5 @@ interface IEntry extends JsonSerializable {
 	 * @param string $key
 	 * @return mixed the value of the property or null
 	 */
-	public function getProperty($key);
+	public function getProperty(string $key);
 }

--- a/lib/public/Contacts/ContactsMenu/ILinkAction.php
+++ b/lib/public/Contacts/ContactsMenu/ILinkAction.php
@@ -32,7 +32,7 @@ interface ILinkAction extends IAction {
 	 * @since 12.0
 	 * @param string $href the target URL of the action
 	 */
-	public function setHref($href);
+	public function setHref(string $href);
 
 	/**
 	 * @since 12.0

--- a/lib/public/Contacts/IManager.php
+++ b/lib/public/Contacts/IManager.php
@@ -35,6 +35,9 @@
 
 namespace OCP\Contacts;
 
+use Closure;
+use OCP\IAddressBook;
+
 /**
  * This class provides access to the contacts app. Use this class exclusively if you want to access contacts.
  *
@@ -98,7 +101,7 @@ interface IManager {
 	 * @return array an array of contacts which are arrays of key-value-pairs
 	 * @since 6.0.0
 	 */
-	public function search($pattern, $searchProperties = array(), $options = array());
+	public function search(string $pattern, array $searchProperties = array(), array $options = array());
 
 	/**
 	 * This function can be used to delete the contact identified by the given id
@@ -108,7 +111,7 @@ interface IManager {
 	 * @return bool successful or not
 	 * @since 6.0.0
 	 */
-	public function delete($id, $address_book_key);
+	public function delete($id, string $address_book_key);
 
 	/**
 	 * This function is used to create a new contact if 'id' is not given or not present.
@@ -119,7 +122,7 @@ interface IManager {
 	 * @return array an array representing the contact just created or updated
 	 * @since 6.0.0
 	 */
-	public function createOrUpdate($properties, $address_book_key);
+	public function createOrUpdate(array $properties, string $address_book_key);
 
 	/**
 	 * Check if contacts are available (e.g. contacts app enabled)
@@ -132,34 +135,34 @@ interface IManager {
 	/**
 	 * Registers an address book
 	 *
-	 * @param \OCP\IAddressBook $address_book
+	 * @param IAddressBook $address_book
 	 * @return void
 	 * @since 6.0.0
 	 */
-	public function registerAddressBook(\OCP\IAddressBook $address_book);
+	public function registerAddressBook(IAddressBook $address_book);
 
 	/**
 	 * Unregisters an address book
 	 *
-	 * @param \OCP\IAddressBook $address_book
+	 * @param IAddressBook $address_book
 	 * @return void
 	 * @since 6.0.0
 	 */
-	public function unregisterAddressBook(\OCP\IAddressBook $address_book);
+	public function unregisterAddressBook(IAddressBook $address_book);
 
 	/**
 	 * In order to improve lazy loading a closure can be registered which will be called in case
 	 * address books are actually requested
 	 *
-	 * @param \Closure $callable
+	 * @param Closure $callable
 	 * @return void
 	 * @since 6.0.0
 	 */
-	public function register(\Closure $callable);
+	public function register(Closure $callable);
 
 	/**
 	 * Return a list of the user's addressbooks display names
-	 * 
+	 *
 	 * @return array
 	 * @since 6.0.0
 	 * @deprecated 16.0.0 - Use `$this->getUserAddressBooks()` instead
@@ -168,7 +171,7 @@ interface IManager {
 
 	/**
 	 * Return a list of the user's addressbooks
-	 * 
+	 *
 	 * @return IAddressBook[]
 	 * @since 16.0.0
 	 */
@@ -176,7 +179,7 @@ interface IManager {
 
 	/**
 	 * removes all registered address book instances
-	 * 
+	 *
 	 * @return void
 	 * @since 6.0.0
 	 */

--- a/lib/public/DB/ISchemaWrapper.php
+++ b/lib/public/DB/ISchemaWrapper.php
@@ -23,6 +23,10 @@
 
 namespace OCP\DB;
 
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaException;
+use Doctrine\DBAL\Schema\Table;
+
 /**
  * Interface ISchemaWrapper
  *
@@ -34,11 +38,11 @@ interface ISchemaWrapper {
 	/**
 	 * @param string $tableName
 	 *
-	 * @return \Doctrine\DBAL\Schema\Table
-	 * @throws \Doctrine\DBAL\Schema\SchemaException
+	 * @return Table
+	 * @throws SchemaException
 	 * @since 13.0.0
 	 */
-	public function getTable($tableName);
+	public function getTable(string $tableName);
 
 	/**
 	 * Does this schema have a table with the given name?
@@ -48,30 +52,30 @@ interface ISchemaWrapper {
 	 * @return boolean
 	 * @since 13.0.0
 	 */
-	public function hasTable($tableName);
+	public function hasTable(string $tableName);
 
 	/**
 	 * Creates a new table.
 	 *
 	 * @param string $tableName Prefix is automatically prepended
-	 * @return \Doctrine\DBAL\Schema\Table
+	 * @return Table
 	 * @since 13.0.0
 	 */
-	public function createTable($tableName);
+	public function createTable(string $tableName);
 
 	/**
 	 * Drops a table from the schema.
 	 *
 	 * @param string $tableName Prefix is automatically prepended
-	 * @return \Doctrine\DBAL\Schema\Schema
+	 * @return Schema
 	 * @since 13.0.0
 	 */
-	public function dropTable($tableName);
+	public function dropTable(string $tableName);
 
 	/**
 	 * Gets all tables of this schema.
 	 *
-	 * @return \Doctrine\DBAL\Schema\Table[]
+	 * @return Table[]
 	 * @since 13.0.0
 	 */
 	public function getTables();
@@ -83,7 +87,7 @@ interface ISchemaWrapper {
 	 * @since 13.0.0
 	 */
 	public function getTableNames();
-	
+
 	/**
 	 * Gets all table names
 	 *

--- a/lib/public/Defaults.php
+++ b/lib/public/Defaults.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -185,7 +188,7 @@ class Defaults {
 	 * @return string
 	 * @since 12.0.0
 	 */
-	public function getLogo($useSvg = true) {
+	public function getLogo(bool $useSvg = true) {
 		return $this->defaults->getLogo($useSvg);
 	}
 
@@ -203,7 +206,7 @@ class Defaults {
 	 * @return string URL to doc with key
 	 * @since 12.0.0
 	 */
-	public function buildDocLinkToKey($key) {
+	public function buildDocLinkToKey(string $key) {
 		return $this->defaults->buildDocLinkToKey($key);
 	}
 

--- a/lib/public/Diagnostics/IEvent.php
+++ b/lib/public/Diagnostics/IEvent.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *

--- a/lib/public/Diagnostics/IEventLogger.php
+++ b/lib/public/Diagnostics/IEventLogger.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -38,7 +41,7 @@ interface IEventLogger {
 	 * @param string $description
 	 * @since 8.0.0
 	 */
-	public function start($id, $description);
+	public function start(string $id, string $description);
 
 	/**
 	 * Mark the end of an event with specific ID $id, marked by start() method.
@@ -48,7 +51,7 @@ interface IEventLogger {
 	 * @param string $id
 	 * @since 8.0.0
 	 */
-	public function end($id);
+	public function end(string $id);
 
 	/**
 	 * Mark the start and the end of an event with specific ID $id and description $description,
@@ -62,13 +65,13 @@ interface IEventLogger {
 	 * @param float $end
 	 * @since 8.0.0
 	 */
-	public function log($id, $description, $start, $end);
+	public function log(string $id, string $description, float $start, float $end);
 
 	/**
 	 * This method should return all \OCP\Diagnostics\IEvent objects stored using
 	 * start()/end() or log() methods
 	 *
-	 * @return \OCP\Diagnostics\IEvent[]
+	 * @return IEvent[]
 	 * @since 8.0.0
 	 */
 	public function getEvents();

--- a/lib/public/Diagnostics/IQuery.php
+++ b/lib/public/Diagnostics/IQuery.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *

--- a/lib/public/Diagnostics/IQueryLogger.php
+++ b/lib/public/Diagnostics/IQueryLogger.php
@@ -47,7 +47,7 @@ interface IQueryLogger extends SQLLogger {
 	 * @param array|null $types
 	 * @since 8.0.0
 	 */
-	public function startQuery(string $sql, array $params = null, array $types = null);
+	public function startQuery($sql, array $params = null, array $types = null);
 
 	/**
 	 * Mark the end of the current active query. Ending query should store \OCP\Diagnostics\IQuery to

--- a/lib/public/Diagnostics/IQueryLogger.php
+++ b/lib/public/Diagnostics/IQueryLogger.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -35,21 +38,21 @@ use Doctrine\DBAL\Logging\SQLLogger;
  */
 interface IQueryLogger extends SQLLogger {
 	/**
-	 * Mark the start of a query providing query SQL statement, its parameters and types. 
-	 * This method should be called as close to the DB as possible and after 
-	 * query is finished finalized with stopQuery() method. 
-	 * 
+	 * Mark the start of a query providing query SQL statement, its parameters and types.
+	 * This method should be called as close to the DB as possible and after
+	 * query is finished finalized with stopQuery() method.
+	 *
 	 * @param string $sql
 	 * @param array|null $params
 	 * @param array|null $types
 	 * @since 8.0.0
 	 */
-	public function startQuery($sql, array $params = null, array $types = null);
+	public function startQuery(string $sql, array $params = null, array $types = null);
 
 	/**
 	 * Mark the end of the current active query. Ending query should store \OCP\Diagnostics\IQuery to
 	 * be returned with getQueries() method.
-	 * 
+	 *
 	 * @return mixed
 	 * @since 8.0.0
 	 */
@@ -58,8 +61,8 @@ interface IQueryLogger extends SQLLogger {
 	/**
 	 * This method should return all \OCP\Diagnostics\IQuery objects stored using
 	 * startQuery()/stopQuery() methods.
-	 * 
-	 * @return \OCP\Diagnostics\IQuery[]
+	 *
+	 * @return IQuery[]
 	 * @since 8.0.0
 	 */
 	public function getQueries();
@@ -67,8 +70,8 @@ interface IQueryLogger extends SQLLogger {
 	/**
 	 * Activate the module for the duration of the request. Deactivated module
 	 * does not create and store \OCP\Diagnostics\IQuery objects.
-	 * Only activated module should create and store objects to be 
-	 * returned with getQueries() call. 
+	 * Only activated module should create and store objects to be
+	 * returned with getQueries() call.
 	 *
 	 * @since 12.0.0
 	 */

--- a/lib/public/DirectEditing/ACreateEmpty.php
+++ b/lib/public/DirectEditing/ACreateEmpty.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
  *

--- a/lib/public/DirectEditing/ACreateFromTemplate.php
+++ b/lib/public/DirectEditing/ACreateFromTemplate.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
  *

--- a/lib/public/DirectEditing/ATemplate.php
+++ b/lib/public/DirectEditing/ATemplate.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
  *

--- a/lib/public/DirectEditing/IToken.php
+++ b/lib/public/DirectEditing/IToken.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
  *

--- a/lib/public/DirectEditing/RegisterDirectEditorEvent.php
+++ b/lib/public/DirectEditing/RegisterDirectEditorEvent.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
  *

--- a/lib/public/Encryption/Exceptions/GenericEncryptionException.php
+++ b/lib/public/Encryption/Exceptions/GenericEncryptionException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -25,6 +28,7 @@
  */
 
 namespace OCP\Encryption\Exceptions;
+use Exception;
 use OC\HintException;
 
 /**
@@ -39,10 +43,10 @@ class GenericEncryptionException extends HintException {
 	 * @param string $message
 	 * @param string $hint
 	 * @param int $code
-	 * @param \Exception|null $previous
+	 * @param Exception|null $previous
 	 * @since 8.1.0
 	 */
-	public function __construct($message = '', $hint = '', $code = 0, \Exception $previous = null) {
+	public function __construct(string $message = '', string $hint = '', int $code = 0, Exception $previous = null) {
 		if (empty($message)) {
 			$message = 'Unspecified encryption exception';
 		}

--- a/lib/public/Encryption/IEncryptionModule.php
+++ b/lib/public/Encryption/IEncryptionModule.php
@@ -66,7 +66,7 @@ interface IEncryptionModule {
 	 *                       or if no additional data is needed return a empty array
 	 * @since 8.1.0
 	 */
-	public function begin($path, $user, $mode, array $header, array $accessList);
+	public function begin(string $path, string $user, string $mode, array $header, array $accessList);
 
 	/**
 	 * last chunk received. This is the place where you can perform some final
@@ -82,7 +82,7 @@ interface IEncryptionModule {
 	 * @since 8.1.0
 	 * @since 9.0.0 parameter $position added
 	 */
-	public function end($path, $position);
+	public function end(string $path, string $position);
 
 	/**
 	 * encrypt data
@@ -95,7 +95,7 @@ interface IEncryptionModule {
 	 * @since 8.1.0
 	 * @since 9.0.0 parameter $position added
 	 */
-	public function encrypt($data, $position);
+	public function encrypt(string $data, string $position);
 
 	/**
 	 * decrypt data
@@ -108,7 +108,7 @@ interface IEncryptionModule {
 	 * @since 8.1.0
 	 * @since 9.0.0 parameter $position added
 	 */
-	public function decrypt($data, $position);
+	public function decrypt(string $data, string $position);
 
 	/**
 	 * update encrypted file, e.g. give additional users access to the file
@@ -119,7 +119,7 @@ interface IEncryptionModule {
 	 * @return boolean
 	 * @since 8.1.0
 	 */
-	public function update($path, $uid, array $accessList);
+	public function update(string $path, string $uid, array $accessList);
 
 	/**
 	 * should the file be encrypted or not
@@ -128,7 +128,7 @@ interface IEncryptionModule {
 	 * @return boolean
 	 * @since 8.1.0
 	 */
-	public function shouldEncrypt($path);
+	public function shouldEncrypt(string $path);
 
 	/**
 	 * get size of the unencrypted payload per block.
@@ -138,7 +138,7 @@ interface IEncryptionModule {
 	 * @return int
 	 * @since 8.1.0 optional parameter $signed was added in 9.0.0
 	 */
-	public function getUnencryptedBlockSize($signed = false);
+	public function getUnencryptedBlockSize(bool $signed = false);
 
 	/**
 	 * check if the encryption module is able to read the file,
@@ -181,7 +181,7 @@ interface IEncryptionModule {
 	 * @return boolean
 	 * @since 9.1.0
 	 */
-	public function isReadyForUser($user);
+	public function isReadyForUser(string $user);
 
 	/**
 	 * Does the encryption module needs a detailed list of users with access to the file?

--- a/lib/public/Encryption/IFile.php
+++ b/lib/public/Encryption/IFile.php
@@ -39,6 +39,6 @@ interface IFile {
 	 * @return array
 	 * @since 8.1.0
 	 */
-	public function getAccessList($path);
+	public function getAccessList(string $path);
 
 }

--- a/lib/public/Encryption/IManager.php
+++ b/lib/public/Encryption/IManager.php
@@ -52,7 +52,7 @@ interface IManager {
 	 * @throws ModuleAlreadyExistsException
 	 * @since 8.1.0
 	 */
-	public function registerEncryptionModule($id, $displayName, callable $callback);
+	public function registerEncryptionModule(string $id, string $displayName, callable $callback);
 
 	/**
 	 * Unregisters an encryption module
@@ -60,7 +60,7 @@ interface IManager {
 	 * @param string $moduleId
 	 * @since 8.1.0
 	 */
-	public function unregisterEncryptionModule($moduleId);
+	public function unregisterEncryptionModule(string $moduleId);
 
 	/**
 	 * get a list of all encryption modules
@@ -79,7 +79,7 @@ interface IManager {
 	 * @throws ModuleDoesNotExistsException
 	 * @since 8.1.0
 	 */
-	public function getEncryptionModule($moduleId = '');
+	public function getEncryptionModule(string $moduleId = '');
 
 	/**
 	 * get default encryption module Id
@@ -96,6 +96,6 @@ interface IManager {
 	 * @return string
 	 * @since 8.1.0
 	 */
-	public function setDefaultEncryptionModule($moduleId);
+	public function setDefaultEncryptionModule(string $moduleId);
 
 }

--- a/lib/public/EventDispatcher/GenericEvent.php
+++ b/lib/public/EventDispatcher/GenericEvent.php
@@ -52,6 +52,7 @@ class GenericEvent extends Event implements ArrayAccess, IteratorAggregate {
 	 * @since 18.0.0
 	 */
 	public function __construct($subject = null, array $arguments = []) {
+		parent::__construct();
 		$this->subject = $subject;
 		$this->arguments = $arguments;
 	}

--- a/lib/public/Federation/Exceptions/ActionNotSupportedException.php
+++ b/lib/public/Federation/Exceptions/ActionNotSupportedException.php
@@ -40,7 +40,7 @@ class ActionNotSupportedException extends HintException {
 	 * @since 14.0.0
 	 *
 	 */
-	public function __construct($action) {
+	public function __construct(string $action) {
 		$l = \OC::$server->getL10N('federation');
 		$message = 'Action "' . $action . '" not supported or implemented.';
 		$hint = $l->t('Action "%s" not supported or implemented.', [$action]);

--- a/lib/public/Federation/Exceptions/ProviderAlreadyExistsException.php
+++ b/lib/public/Federation/Exceptions/ProviderAlreadyExistsException.php
@@ -44,7 +44,7 @@ class ProviderAlreadyExistsException extends HintException {
 	 * @param string $newProviderId cloud federation provider ID of the new provider
 	 * @param string $existingProviderName name of cloud federation provider which already use the same ID
 	 */
-	public function __construct($newProviderId, $existingProviderName) {
+	public function __construct(string $newProviderId, string $existingProviderName) {
 		$l = \OC::$server->getL10N('federation');
 		$message = 'ID "' . $newProviderId . '" already used by cloud federation provider "' . $existingProviderName . '"';
 		$hint = $l->t('ID "%1$s" already used by cloud federation provider "%2$s"', [$newProviderId, $existingProviderName]);

--- a/lib/public/Federation/Exceptions/ProviderCouldNotAddShareException.php
+++ b/lib/public/Federation/Exceptions/ProviderCouldNotAddShareException.php
@@ -23,6 +23,7 @@
 
 namespace OCP\Federation\Exceptions;
 
+use Exception;
 use OC\HintException;
 use OCP\AppFramework\Http;
 
@@ -43,9 +44,9 @@ class ProviderCouldNotAddShareException extends HintException {
 	 * @param string $message
 	 * @param string $hint
 	 * @param int $code
-	 * @param \Exception|null $previous
+	 * @param Exception|null $previous
 	 */
-	public function __construct($message, $hint = '', $code = Http::STATUS_BAD_REQUEST, \Exception $previous = null) {
+	public function __construct(string $message, string $hint = '', int $code = Http::STATUS_BAD_REQUEST, Exception $previous = null) {
 		parent::__construct($message, $hint, $code, $previous);
 	}
 

--- a/lib/public/Federation/Exceptions/ProviderDoesNotExistsException.php
+++ b/lib/public/Federation/Exceptions/ProviderDoesNotExistsException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2018 Bjoern Schiessle <bjoern@schiessle.org>
  *
@@ -41,7 +44,7 @@ class ProviderDoesNotExistsException extends HintException {
 	 *
 	 * @param string $providerId cloud federation provider ID
 	 */
-	public function __construct($providerId) {
+	public function __construct(string $providerId) {
 		$l = \OC::$server->getL10N('federation');
 		$message = 'Cloud Federation Provider with ID: "' . $providerId . '" does not exist.';
 		$hint = $l->t('Cloud Federation Provider with ID: "%s" does not exist.', [$providerId]);

--- a/lib/public/Federation/ICloudFederationFactory.php
+++ b/lib/public/Federation/ICloudFederationFactory.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2018 Bjoern Schiessle <bjoern@schiessle.org>
  *
@@ -45,12 +48,22 @@ interface ICloudFederationFactory {
 	 * @param string $sharedByDisplayName display name of the user who shared the resource
 	 * @param string $sharedSecret used to authenticate requests across servers
 	 * @param string $shareType ('group' or 'user' share)
-	 * @param $resourceType ('file', 'calendar',...)
+	 * @param string $resourceType ('file', 'calendar',...)
 	 * @return ICloudFederationShare
 	 *
 	 * @since 14.0.0
 	 */
-	public function getCloudFederationShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $sharedSecret, $shareType, $resourceType);
+	public function getCloudFederationShare(string $shareWith,
+											string $name,
+											string $description,
+											string $providerId,
+											string $owner,
+											string $ownerDisplayName,
+											string $sharedBy,
+											string $sharedByDisplayName,
+											string $sharedSecret,
+											string $shareType,
+											string $resourceType);
 
 	/**
 	 * get a Cloud FederationNotification object to prepare a notification you

--- a/lib/public/Federation/ICloudFederationNotification.php
+++ b/lib/public/Federation/ICloudFederationNotification.php
@@ -37,12 +37,12 @@ interface ICloudFederationNotification {
 	 *
 	 * @param string $notificationType (e.g. SHARE_ACCEPTED)
 	 * @param string $resourceType (e.g. file, calendar, contact,...)
-	 * @param $providerId id of the share
+	 * @param mixed $providerId id of the share
 	 * @param array $notification , payload of the notification
 	 *
 	 * @since 14.0.0
 	 */
-	public function setMessage($notificationType, $resourceType, $providerId, array $notification);
+	public function setMessage(string $notificationType, string $resourceType, $providerId, array $notification);
 
 	/**
 	 * get message, ready to send out

--- a/lib/public/Federation/ICloudFederationProvider.php
+++ b/lib/public/Federation/ICloudFederationProvider.php
@@ -78,7 +78,7 @@ interface ICloudFederationProvider {
 	 *
 	 * @since 14.0.0
 	 */
-	public function notificationReceived($notificationType, $providerId, array $notification);
+	public function notificationReceived(string $notificationType, string $providerId, array $notification);
 
 	/**
 	 * get the supported share types, e.g. "user", "group", etc.

--- a/lib/public/Federation/ICloudFederationProviderManager.php
+++ b/lib/public/Federation/ICloudFederationProviderManager.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2018 Bjoern Schiessle <bjoern@schiessle.org>
  *
@@ -45,7 +48,7 @@ interface ICloudFederationProviderManager {
 	 *
 	 * @since 14.0.0
 	 */
-	public function addCloudFederationProvider($resourceType, $displayName, callable $callback);
+	public function addCloudFederationProvider(string $resourceType, string $displayName, callable $callback);
 
 	/**
 	 * remove cloud federation provider
@@ -54,7 +57,7 @@ interface ICloudFederationProviderManager {
 	 *
 	 * @since 14.0.0
 	 */
-	public function removeCloudFederationProvider($resourceType);
+	public function removeCloudFederationProvider(string $resourceType);
 
 	/**
 	 * get a list of all cloudFederationProviders
@@ -74,7 +77,7 @@ interface ICloudFederationProviderManager {
 	 *
 	 * @since 14.0.0
 	 */
-	public function getCloudFederationProvider($resourceType);
+	public function getCloudFederationProvider(string $resourceType);
 
 	/**
 	 * send federated share
@@ -95,7 +98,7 @@ interface ICloudFederationProviderManager {
 	 *
 	 * @since 14.0.0
 	 */
-	public function sendNotification($url, ICloudFederationNotification $notification);
+	public function sendNotification(string $url, ICloudFederationNotification $notification);
 
 	/**
 	 * check if the new cloud federation API is ready to be used

--- a/lib/public/Federation/ICloudFederationShare.php
+++ b/lib/public/Federation/ICloudFederationShare.php
@@ -39,7 +39,7 @@ interface ICloudFederationShare {
 	 *
 	 * @since 14.0.0
 	 */
-	public function setShareWith($user);
+	public function setShareWith(string $user);
 
 	/**
 	 * set resource name (e.g. file, calendar, contact,...)
@@ -48,7 +48,7 @@ interface ICloudFederationShare {
 	 *
 	 * @since 14.0.0
 	 */
-	public function setResourceName($name);
+	public function setResourceName(string $name);
 
 	/**
 	 * set resource type (e.g. file, calendar, contact,...)
@@ -57,7 +57,7 @@ interface ICloudFederationShare {
 	 *
 	 * @since 14.0.0
 	 */
-	public function setResourceType($resourceType);
+	public function setResourceType(string $resourceType);
 
 	/**
 	 * set resource description (optional)
@@ -66,7 +66,7 @@ interface ICloudFederationShare {
 	 *
 	 * @since 14.0.0
 	 */
-	public function setDescription($description);
+	public function setDescription(string $description);
 
 	/**
 	 * set provider ID (e.g. file ID)
@@ -75,7 +75,7 @@ interface ICloudFederationShare {
 	 *
 	 * @since 14.0.0
 	 */
-	public function setProviderId($providerId);
+	public function setProviderId(string $providerId);
 
 	/**
 	 * set owner UID
@@ -84,7 +84,7 @@ interface ICloudFederationShare {
 	 *
 	 * @since 14.0.0
 	 */
-	public function setOwner($owner);
+	public function setOwner(string $owner);
 
 	/**
 	 * set owner display name
@@ -93,7 +93,7 @@ interface ICloudFederationShare {
 	 *
 	 * @since 14.0.0
 	 */
-	public function setOwnerDisplayName($ownerDisplayName);
+	public function setOwnerDisplayName(string $ownerDisplayName);
 
 	/**
 	 * set UID of the user who sends the share
@@ -102,16 +102,16 @@ interface ICloudFederationShare {
 	 *
 	 * @since 14.0.0
 	 */
-	public function setSharedBy($sharedBy);
+	public function setSharedBy(string $sharedBy);
 
 	/**
 	 * set display name of the user who sends the share
 	 *
-	 * @param $sharedByDisplayName
+	 * @param string $sharedByDisplayName
 	 *
 	 * @since 14.0.0
 	 */
-	public function setSharedByDisplayName($sharedByDisplayName);
+	public function setSharedByDisplayName(string $sharedByDisplayName);
 
 	/**
 	 * set protocol specification
@@ -129,7 +129,7 @@ interface ICloudFederationShare {
 	 *
 	 * @since 14.0.0
 	 */
-	public function setShareType($shareType);
+	public function setShareType(string $shareType);
 
 	/**
 	 * get the whole share, ready to send out

--- a/lib/public/Files.php
+++ b/lib/public/Files.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -54,8 +57,8 @@ class Files {
 	 * @since 5.0.0
 	 * @deprecated 14.0.0
 	 */
-	static public function rmdirr( $dir ) {
-		return \OC_Helper::rmdirr( $dir );
+	static public function rmdirr($dir) {
+		return \OC_Helper::rmdirr($dir);
 	}
 
 	/**
@@ -66,7 +69,7 @@ class Files {
 	 * @since 5.0.0
 	 * @deprecated 14.0.0
 	 */
-	static public function getMimeType( $path ) {
+	static public function getMimeType(string $path) {
 		return \OC::$server->getMimeTypeDetector()->detect($path);
 	}
 
@@ -77,7 +80,7 @@ class Files {
 	 * @since 6.0.0
 	 * @deprecated 14.0.0
 	 */
-	static public function searchByMime($mimetype) {
+	static public function searchByMime(string $mimetype) {
 		return \OC\Files\Filesystem::searchByMime($mimetype);
 	}
 
@@ -89,7 +92,7 @@ class Files {
 	 * @since 5.0.0
 	 * @deprecated 14.0.0
 	 */
-	public static function streamCopy( $source, $target ) {
+	public static function streamCopy($source, $target) {
 		list($count, ) = \OC_Helper::streamCopy( $source, $target );
 		return $count;
 	}
@@ -102,7 +105,7 @@ class Files {
 	 * @since 5.0.0
 	 * @deprecated 14.0.0 use getNonExistingName of the OCP\Files\Folder object
 	 */
-	public static function buildNotExistingFileName($path, $filename) {
+	public static function buildNotExistingFileName(string $path, string $filename) {
 		return \OC_Helper::buildNotExistingFileName($path, $filename);
 	}
 
@@ -114,7 +117,7 @@ class Files {
 	 * @since 5.0.0
 	 * @deprecated 14.0.0 use IAppData instead
 	 */
-	public static function getStorage($app) {
+	public static function getStorage(string $app) {
 		return \OC_App::getStorage( $app );
 	}
 }

--- a/lib/public/GroupInterface.php
+++ b/lib/public/GroupInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -69,7 +72,7 @@ interface GroupInterface {
 	 * Returns the supported actions as int to be
 	 * compared with \OC_Group_Backend::CREATE_GROUP etc.
 	 */
-	public function implementsActions($actions);
+	public function implementsActions(int $actions);
 
 	/**
 	 * is user in group?
@@ -80,7 +83,7 @@ interface GroupInterface {
 	 *
 	 * Checks whether the user is member of a group or not.
 	 */
-	public function inGroup($uid, $gid);
+	public function inGroup(string $uid, string $gid);
 
 	/**
 	 * Get all groups a user belongs to
@@ -91,7 +94,7 @@ interface GroupInterface {
 	 * This function fetches all groups a user belongs to. It does not check
 	 * if the user exists at all.
 	 */
-	public function getUserGroups($uid);
+	public function getUserGroups(string $uid);
 
 	/**
 	 * get a list of all groups
@@ -103,7 +106,7 @@ interface GroupInterface {
 	 *
 	 * Returns a list with all groups
 	 */
-	public function getGroups($search = '', $limit = -1, $offset = 0);
+	public function getGroups(string $search = '', int $limit = -1, int $offset = 0);
 
 	/**
 	 * check if a group exists
@@ -111,7 +114,7 @@ interface GroupInterface {
 	 * @return bool
 	 * @since 4.5.0
 	 */
-	public function groupExists($gid);
+	public function groupExists(string $gid);
 
 	/**
 	 * get a list of all users in a group
@@ -122,6 +125,6 @@ interface GroupInterface {
 	 * @return array an array of user ids
 	 * @since 4.5.0
 	 */
-	public function usersInGroup($gid, $search = '', $limit = -1, $offset = 0);
+	public function usersInGroup(string $gid, string $search = '',int $limit = -1, int $offset = 0);
 
 }

--- a/lib/public/IAddressBook.php
+++ b/lib/public/IAddressBook.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -79,14 +82,14 @@ namespace OCP {
 		 *	]
 		 * @since 5.0.0
 		 */
-		public function search($pattern, $searchProperties, $options);
+		public function search(string $pattern, array $searchProperties, array $options);
 
 		/**
 		 * @param array $properties this array if key-value-pairs defines a contact
 		 * @return array an array representing the contact just created or updated
 		 * @since 5.0.0
 		 */
-		public function createOrUpdate($properties);
+		public function createOrUpdate(array $properties);
 		//	// dummy
 		//	return array('id'    => 0, 'FN' => 'Thomas Müller', 'EMAIL' => 'a@b.c',
 		//		     'PHOTO' => 'VALUE=uri:http://www.abc.com/pub/photos/jqpublic.gif',

--- a/lib/public/IAppConfig.php
+++ b/lib/public/IAppConfig.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -40,7 +43,7 @@ interface IAppConfig {
 	 * @return bool
 	 * @since 7.0.0
 	 */
-	public function hasKey($app, $key);
+	public function hasKey(string $app, string $key);
 
 	/**
 	 * get multiply values, either the app or key can be used as wildcard by setting it to false
@@ -50,7 +53,7 @@ interface IAppConfig {
 	 * @return array|false
 	 * @since 7.0.0
 	 */
-	public function getValues($app, $key);
+	public function getValues(string $app, string $key);
 
 	/**
 	 * get all values of the app or and filters out sensitive data
@@ -59,7 +62,7 @@ interface IAppConfig {
 	 * @return array
 	 * @since 12.0.0
 	 */
-	public function getFilteredValues($app);
+	public function getFilteredValues(string $app);
 
 	/**
 	 * Get all apps using the config

--- a/lib/public/IAvatar.php
+++ b/lib/public/IAvatar.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -27,6 +30,8 @@
 
 namespace OCP;
 
+use Exception;
+use OC\NotSquareException;
 use OCP\Files\File;
 use OCP\Files\NotFoundException;
 
@@ -38,8 +43,9 @@ interface IAvatar {
 
 	/**
 	 * get the users avatar
+	 *
 	 * @param int $size size in px of the avatar, avatars are square, defaults to 64, -1 can be used to not scale the image
-	 * @return boolean|\OCP\IImage containing the avatar or false if there's no image
+	 * @return boolean|IImage containing the avatar or false if there's no image
 	 * @since 6.0.0 - size of -1 was added in 9.0.0
 	 */
 	public function get($size = 64);
@@ -62,11 +68,12 @@ interface IAvatar {
 
 	/**
 	 * sets the users avatar
-	 * @param \OCP\IImage|resource|string $data An image object, imagedata or path to set a new avatar
-	 * @throws \Exception if the provided file is not a jpg or png image
-	 * @throws \Exception if the provided image is not valid
-	 * @throws \OC\NotSquareException if the image is not square
+	 *
+	 * @param IImage|resource|string $data An image object, imagedata or path to set a new avatar
 	 * @return void
+	 * @throws Exception if the provided image is not valid
+	 * @throws NotSquareException if the image is not square
+	 * @throws Exception if the provided file is not a jpg or png image
 	 * @since 6.0.0
 	 */
 	public function set($data);
@@ -85,7 +92,7 @@ interface IAvatar {
 	 * @throws NotFoundException
 	 * @since 9.0.0
 	 */
-	public function getFile($size);
+	public function getFile(int $size);
 
 	/**
 	 * @param string $text

--- a/lib/public/ICache.php
+++ b/lib/public/ICache.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -47,7 +50,7 @@ interface ICache {
 	 * @return mixed
 	 * @since 6.0.0
 	 */
-	public function get($key);
+	public function get(string $key);
 
 	/**
 	 * Set a value in the user cache
@@ -57,7 +60,7 @@ interface ICache {
 	 * @return bool
 	 * @since 6.0.0
 	 */
-	public function set($key, $value, $ttl = 0);
+	public function set(string $key, $value, int $ttl = 0);
 
 	/**
 	 * Check if a value is set in the user cache
@@ -66,7 +69,7 @@ interface ICache {
 	 * @since 6.0.0
 	 * @deprecated 9.1.0 Directly read from GET to prevent race conditions
 	 */
-	public function hasKey($key);
+	public function hasKey(string $key);
 
 	/**
 	 * Remove an item from the user cache
@@ -74,7 +77,7 @@ interface ICache {
 	 * @return bool
 	 * @since 6.0.0
 	 */
-	public function remove($key);
+	public function remove(string $key);
 
 	/**
 	 * Clear the user cache of all entries starting with a prefix
@@ -82,5 +85,5 @@ interface ICache {
 	 * @return bool
 	 * @since 6.0.0
 	 */
-	public function clear($prefix = '');
+	public function clear(string $prefix = '');
 }

--- a/lib/public/ICertificate.php
+++ b/lib/public/ICertificate.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *

--- a/lib/public/ICertificateManager.php
+++ b/lib/public/ICertificateManager.php
@@ -24,15 +24,18 @@
 
 namespace OCP;
 
+use Exception;
+
 /**
  * Manage trusted certificates for users
+ *
  * @since 8.0.0
  */
 interface ICertificateManager {
 	/**
 	 * Returns all certificates trusted by the user
 	 *
-	 * @return \OCP\ICertificate[]
+	 * @return ICertificate[]
 	 * @since 8.0.0
 	 */
 	public function listCertificates();
@@ -40,17 +43,17 @@ interface ICertificateManager {
 	/**
 	 * @param string $certificate the certificate data
 	 * @param string $name the filename for the certificate
-	 * @return \OCP\ICertificate
-	 * @throws \Exception If the certificate could not get added
+	 * @return ICertificate
+	 * @throws Exception If the certificate could not get added
 	 * @since 8.0.0 - since 8.1.0 throws exception instead of returning false
 	 */
-	public function addCertificate($certificate, $name);
+	public function addCertificate(string $certificate, string $name);
 
 	/**
 	 * @param string $name
 	 * @since 8.0.0
 	 */
-	public function removeCertificate($name);
+	public function removeCertificate(string $name);
 
 	/**
 	 * Get the path to the certificate bundle for this user
@@ -59,7 +62,7 @@ interface ICertificateManager {
 	 * @return string
 	 * @since 8.0.0
 	 */
-	public function getCertificateBundle($uid = '');
+	public function getCertificateBundle(string $uid = '');
 
 	/**
 	 * Get the full local path to the certificate bundle for this user
@@ -68,5 +71,5 @@ interface ICertificateManager {
 	 * @return string
 	 * @since 9.0.0
 	 */
-	public function getAbsoluteBundlePath($uid = '');
+	public function getAbsoluteBundlePath(string $uid = '');
 }

--- a/lib/public/IConfig.php
+++ b/lib/public/IConfig.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -64,7 +67,7 @@ interface IConfig {
 	 * @param mixed $value the value that should be stored
 	 * @since 8.0.0
 	 */
-	public function setSystemValue($key, $value);
+	public function setSystemValue(string $key, $value);
 
 	/**
 	 * Looks up a system wide defined value
@@ -74,7 +77,7 @@ interface IConfig {
 	 * @return mixed the value or $default
 	 * @since 6.0.0 - parameter $default was added in 7.0.0
 	 */
-	public function getSystemValue($key, $default = '');
+	public function getSystemValue(string $key, $default = '');
 
 	/**
 	 * Looks up a boolean system wide defined value
@@ -122,7 +125,7 @@ interface IConfig {
 	 * @param string $key the key of the value, under which it was saved
 	 * @since 8.0.0
 	 */
-	public function deleteSystemValue($key);
+	public function deleteSystemValue(string $key);
 
 	/**
 	 * Get all keys stored for an app
@@ -131,7 +134,7 @@ interface IConfig {
 	 * @return string[] the keys stored for the app
 	 * @since 8.0.0
 	 */
-	public function getAppKeys($appName);
+	public function getAppKeys(string $appName);
 
 	/**
 	 * Writes a new app wide value
@@ -142,7 +145,7 @@ interface IConfig {
 	 * @return void
 	 * @since 6.0.0
 	 */
-	public function setAppValue($appName, $key, $value);
+	public function setAppValue(string $appName, $key, string $value);
 
 	/**
 	 * Looks up an app wide defined value
@@ -153,7 +156,7 @@ interface IConfig {
 	 * @return string the saved value
 	 * @since 6.0.0 - parameter $default was added in 7.0.0
 	 */
-	public function getAppValue($appName, $key, $default = '');
+	public function getAppValue(string $appName, string $key, string $default = '');
 
 	/**
 	 * Delete an app wide defined value
@@ -162,7 +165,7 @@ interface IConfig {
 	 * @param string $key the key of the value, under which it was saved
 	 * @since 8.0.0
 	 */
-	public function deleteAppValue($appName, $key);
+	public function deleteAppValue(string $appName, string $key);
 
 	/**
 	 * Removes all keys in appconfig belonging to the app
@@ -170,7 +173,7 @@ interface IConfig {
 	 * @param string $appName the appName the configs are stored under
 	 * @since 8.0.0
 	 */
-	public function deleteAppValues($appName);
+	public function deleteAppValues(string $appName);
 
 
 	/**
@@ -185,7 +188,7 @@ interface IConfig {
 	 * @throws \UnexpectedValueException when trying to store an unexpected value
 	 * @since 6.0.0 - parameter $precondition was added in 8.0.0
 	 */
-	public function setUserValue($userId, $appName, $key, $value, $preCondition = null);
+	public function setUserValue(string $userId, string $appName, string $key, string $value, bool $preCondition = null);
 
 	/**
 	 * Shortcut for getting a user defined value
@@ -197,7 +200,7 @@ interface IConfig {
 	 * @return string
 	 * @since 6.0.0 - parameter $default was added in 7.0.0
 	 */
-	public function getUserValue($userId, $appName, $key, $default = '');
+	public function getUserValue(string $userId, string $appName, string $key, $default = '');
 
 	/**
 	 * Fetches a mapped list of userId -> value, for a specified app and key and a list of user IDs.
@@ -208,7 +211,7 @@ interface IConfig {
 	 * @return array Mapped values: userId => value
 	 * @since 8.0.0
 	 */
-	public function getUserValueForUsers($appName, $key, $userIds);
+	public function getUserValueForUsers(string $appName, string $key, array $userIds);
 
 	/**
 	 * Get the keys of all stored by an app for the user
@@ -218,7 +221,7 @@ interface IConfig {
 	 * @return string[]
 	 * @since 8.0.0
 	 */
-	public function getUserKeys($userId, $appName);
+	public function getUserKeys(string $userId, string $appName);
 
 	/**
 	 * Delete a user value
@@ -228,7 +231,7 @@ interface IConfig {
 	 * @param string $key the key under which the value is being stored
 	 * @since 8.0.0
 	 */
-	public function deleteUserValue($userId, $appName, $key);
+	public function deleteUserValue(string $userId, string $appName, string $key);
 
 	/**
 	 * Delete all user values
@@ -236,7 +239,7 @@ interface IConfig {
 	 * @param string $userId the userId of the user that we want to remove all values from
 	 * @since 8.0.0
 	 */
-	public function deleteAllUserValues($userId);
+	public function deleteAllUserValues(string $userId);
 
 	/**
 	 * Delete all user related values of one app
@@ -244,7 +247,7 @@ interface IConfig {
 	 * @param string $appName the appName of the app that we want to remove all values from
 	 * @since 8.0.0
 	 */
-	public function deleteAppFromAllUsers($appName);
+	public function deleteAppFromAllUsers(string $appName);
 
 	/**
 	 * Determines the users that have the given value set for a specific app-key-pair
@@ -255,5 +258,5 @@ interface IConfig {
 	 * @return array of user IDs
 	 * @since 8.0.0
 	 */
-	public function getUsersForUserValue($appName, $key, $value);
+	public function getUsersForUserValue(string $appName, string $key, string $value);
 }

--- a/lib/public/IContainer.php
+++ b/lib/public/IContainer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -56,7 +59,7 @@ interface IContainer {
 	 * @since 8.2.0
 	 * @throws QueryException if the class could not be found or instantiated
 	 */
-	public function resolve($name);
+	public function resolve(string $name);
 
 	/**
 	 * Look up a service for a given name in the container.
@@ -77,7 +80,7 @@ interface IContainer {
 	 * @return void
 	 * @since 6.0.0
 	 */
-	public function registerParameter($name, $value);
+	public function registerParameter(string $name, $value);
 
 	/**
 	 * A service is registered in the container where a closure is passed in which will actually
@@ -92,7 +95,7 @@ interface IContainer {
 	 * @return void
 	 * @since 6.0.0
 	 */
-	public function registerService($name, Closure $closure, $shared = true);
+	public function registerService(string $name, Closure $closure, bool $shared = true);
 
 	/**
 	 * Shortcut for returning a service from a service under a different key,
@@ -102,5 +105,5 @@ interface IContainer {
 	 * @param string $target the target that should be resolved instead
 	 * @since 8.2.0
 	 */
-	public function registerAlias($alias, $target);
+	public function registerAlias(string $alias, string $target);
 }

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -37,6 +40,8 @@
 // This means that they should be used by apps instead of the internal ownCloud classes
 
 namespace OCP;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 
@@ -67,7 +72,7 @@ interface IDBConnection {
 	 * @return \Doctrine\DBAL\Driver\Statement The prepared statement.
 	 * @since 6.0.0
 	 */
-	public function prepare($sql, $limit=null, $offset=null);
+	public function prepare(string $sql, int $limit = null, int $offset = null);
 
 	/**
 	 * Executes an, optionally parameterized, SQL query.
@@ -81,7 +86,7 @@ interface IDBConnection {
 	 * @return \Doctrine\DBAL\Driver\Statement The executed statement.
 	 * @since 8.0.0
 	 */
-	public function executeQuery($query, array $params = array(), $types = array());
+	public function executeQuery(string $query, array $params = array(), $types = array());
 
 	/**
 	 * Executes an SQL INSERT/UPDATE/DELETE query with the given parameters
@@ -95,7 +100,7 @@ interface IDBConnection {
 	 * @return integer The number of affected rows.
 	 * @since 8.0.0
 	 */
-	public function executeUpdate($query, array $params = array(), array $types = array());
+	public function executeUpdate(string $query, array $params = array(), array $types = array());
 
 	/**
 	 * Used to get the id of the just inserted element
@@ -103,7 +108,7 @@ interface IDBConnection {
 	 * @return int the id of the inserted element
 	 * @since 6.0.0
 	 */
-	public function lastInsertId($table = null);
+	public function lastInsertId(string $table = null);
 
 	/**
 	 * Insert a row if the matching row does not exists. To accomplish proper race condition avoidance
@@ -120,7 +125,7 @@ interface IDBConnection {
 	 * @since 6.0.0 - parameter $compare was added in 8.1.0, return type changed from boolean in 8.1.0
 	 * @deprecated 15.0.0 - use unique index and "try { $db->insert() } catch (UniqueConstraintViolationException $e) {}" instead, because it is more reliable and does not have the risk for deadlocks - see https://github.com/nextcloud/server/pull/12371
 	 */
-	public function insertIfNotExist($table, $input, array $compare = null);
+	public function insertIfNotExist(string $table, array $input, array $compare = null);
 
 
 	/**
@@ -160,7 +165,7 @@ interface IDBConnection {
 	 * @param string $tableName
 	 * @since 9.1.0
 	 */
-	public function lockTable($tableName);
+	public function lockTable(string $tableName);
 
 	/**
 	 * Release a previous acquired lock again
@@ -240,13 +245,13 @@ interface IDBConnection {
 	 * @return string The quoted parameter.
 	 * @since 8.0.0
 	 */
-	public function quote($input, $type = IQueryBuilder::PARAM_STR);
+	public function quote($input, int $type = IQueryBuilder::PARAM_STR);
 
 	/**
 	 * Gets the DatabasePlatform instance that provides all the metadata about
 	 * the platform this driver connects to.
 	 *
-	 * @return \Doctrine\DBAL\Platforms\AbstractPlatform The database platform.
+	 * @return AbstractPlatform The database platform.
 	 * @since 8.0.0
 	 */
 	public function getDatabasePlatform();
@@ -275,7 +280,7 @@ interface IDBConnection {
 	 * @return string
 	 * @since 9.0.0
 	 */
-	public function escapeLikeParameter($param);
+	public function escapeLikeParameter(string $param);
 
 	/**
 	 * Check whether or not the current database support 4byte wide unicode

--- a/lib/public/IDateTimeFormatter.php
+++ b/lib/public/IDateTimeFormatter.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -24,6 +27,9 @@
 
 namespace OCP;
 
+use DateTime;
+use DateTimeZone;
+
 /**
  * Interface IDateTimeFormatter
  *
@@ -34,24 +40,24 @@ interface IDateTimeFormatter {
 	/**
 	 * Formats the date of the given timestamp
 	 *
-	 * @param int|\DateTime		$timestamp
+	 * @param int|DateTime		$timestamp
 	 * @param string	$format			Either 'full', 'long', 'medium' or 'short'
 	 * 				full:	e.g. 'EEEE, MMMM d, y'	=> 'Wednesday, August 20, 2014'
 	 * 				long:	e.g. 'MMMM d, y'		=> 'August 20, 2014'
 	 * 				medium:	e.g. 'MMM d, y'			=> 'Aug 20, 2014'
 	 * 				short:	e.g. 'M/d/yy'			=> '8/20/14'
 	 * 				The exact format is dependent on the language
-	 * @param \DateTimeZone|null	$timeZone	The timezone to use
-	 * @param \OCP\IL10N|null	$l			The locale to use
+	 * @param DateTimeZone|null	$timeZone	The timezone to use
+	 * @param IL10N|null	$l			The locale to use
 	 * @return string Formatted date string
 	 * @since 8.0.0
 	 */
-	public function formatDate($timestamp, $format = 'long', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null);
+	public function formatDate($timestamp, string $format = 'long', DateTimeZone $timeZone = null, IL10N $l = null);
 
 	/**
 	 * Formats the date of the given timestamp
 	 *
-	 * @param int|\DateTime		$timestamp
+	 * @param int|DateTime		$timestamp
 	 * @param string	$format			Either 'full', 'long', 'medium' or 'short'
 	 * 				full:	e.g. 'EEEE, MMMM d, y'	=> 'Wednesday, August 20, 2014'
 	 * 				long:	e.g. 'MMMM d, y'		=> 'August 20, 2014'
@@ -59,51 +65,51 @@ interface IDateTimeFormatter {
 	 * 				short:	e.g. 'M/d/yy'			=> '8/20/14'
 	 * 				The exact format is dependent on the language
 	 * 					Uses 'Today', 'Yesterday' and 'Tomorrow' when applicable
-	 * @param \DateTimeZone|null	$timeZone	The timezone to use
-	 * @param \OCP\IL10N|null	$l			The locale to use
+	 * @param DateTimeZone|null	$timeZone	The timezone to use
+	 * @param IL10N|null	$l			The locale to use
 	 * @return string Formatted relative date string
 	 * @since 8.0.0
 	 */
-	public function formatDateRelativeDay($timestamp, $format = 'long', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null);
+	public function formatDateRelativeDay($timestamp, string $format = 'long', DateTimeZone $timeZone = null, IL10N $l = null);
 
 	/**
 	 * Gives the relative date of the timestamp
 	 * Only works for past dates
 	 *
-	 * @param int|\DateTime	$timestamp
-	 * @param int|\DateTime|null	$baseTimestamp	Timestamp to compare $timestamp against, defaults to current time
-	 * @param \OCP\IL10N|null		$l			The locale to use
+	 * @param int|DateTime	$timestamp
+	 * @param int|DateTime|null	$baseTimestamp	Timestamp to compare $timestamp against, defaults to current time
+	 * @param IL10N|null		$l			The locale to use
 	 * @return string	Dates returned are:
 	 * 				<  1 month	=> Today, Yesterday, n days ago
 	 * 				< 13 month	=> last month, n months ago
 	 * 				>= 13 month	=> last year, n years ago
 	 * @since 8.0.0
 	 */
-	public function formatDateSpan($timestamp, $baseTimestamp = null, \OCP\IL10N $l = null);
+	public function formatDateSpan($timestamp, $baseTimestamp = null, IL10N $l = null);
 
 	/**
 	 * Formats the time of the given timestamp
 	 *
-	 * @param int|\DateTime $timestamp
+	 * @param int|DateTime $timestamp
 	 * @param string	$format			Either 'full', 'long', 'medium' or 'short'
 	 * 				full:	e.g. 'h:mm:ss a zzzz'	=> '11:42:13 AM GMT+0:00'
 	 * 				long:	e.g. 'h:mm:ss a z'		=> '11:42:13 AM GMT'
 	 * 				medium:	e.g. 'h:mm:ss a'		=> '11:42:13 AM'
 	 * 				short:	e.g. 'h:mm a'			=> '11:42 AM'
 	 * 				The exact format is dependent on the language
-	 * @param \DateTimeZone|null	$timeZone	The timezone to use
-	 * @param \OCP\IL10N|null		$l			The locale to use
+	 * @param DateTimeZone|null	$timeZone	The timezone to use
+	 * @param IL10N|null		$l			The locale to use
 	 * @return string Formatted time string
 	 * @since 8.0.0
 	 */
-	public function formatTime($timestamp, $format = 'medium', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null);
+	public function formatTime($timestamp, string $format = 'medium', DateTimeZone $timeZone = null, IL10N $l = null);
 
 	/**
 	 * Gives the relative past time of the timestamp
 	 *
-	 * @param int|\DateTime	$timestamp
-	 * @param int|\DateTime|null	$baseTimestamp	Timestamp to compare $timestamp against, defaults to current time
-	 * @param \OCP\IL10N|null		$l			The locale to use
+	 * @param int|DateTime	$timestamp
+	 * @param int|DateTime|null	$baseTimestamp	Timestamp to compare $timestamp against, defaults to current time
+	 * @param IL10N|null		$l			The locale to use
 	 * @return string	Dates returned are:
 	 * 				< 60 sec	=> seconds ago
 	 * 				<  1 hour	=> n minutes ago
@@ -113,32 +119,32 @@ interface IDateTimeFormatter {
 	 * 				>= 13 month	=> last year, n years ago
 	 * @since 8.0.0
 	 */
-	public function formatTimeSpan($timestamp, $baseTimestamp = null, \OCP\IL10N $l = null);
+	public function formatTimeSpan($timestamp, $baseTimestamp = null, IL10N $l = null);
 
 	/**
 	 * Formats the date and time of the given timestamp
 	 *
-	 * @param int|\DateTime $timestamp
+	 * @param int|DateTime $timestamp
 	 * @param string	$formatDate		See formatDate() for description
 	 * @param string	$formatTime		See formatTime() for description
-	 * @param \DateTimeZone|null	$timeZone	The timezone to use
-	 * @param \OCP\IL10N|null		$l			The locale to use
+	 * @param DateTimeZone|null	$timeZone	The timezone to use
+	 * @param IL10N|null		$l			The locale to use
 	 * @return string Formatted date and time string
 	 * @since 8.0.0
 	 */
-	public function formatDateTime($timestamp, $formatDate = 'long', $formatTime = 'medium', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null);
+	public function formatDateTime($timestamp, string $formatDate = 'long', $formatTime = 'medium', DateTimeZone $timeZone = null, IL10N $l = null);
 
 	/**
 	 * Formats the date and time of the given timestamp
 	 *
-	 * @param int|\DateTime $timestamp
+	 * @param int|DateTime $timestamp
 	 * @param string	$formatDate		See formatDate() for description
 	 * 					Uses 'Today', 'Yesterday' and 'Tomorrow' when applicable
 	 * @param string	$formatTime		See formatTime() for description
-	 * @param \DateTimeZone|null	$timeZone	The timezone to use
-	 * @param \OCP\IL10N|null		$l			The locale to use
+	 * @param DateTimeZone|null	$timeZone	The timezone to use
+	 * @param IL10N|null		$l			The locale to use
 	 * @return string Formatted relative date and time string
 	 * @since 8.0.0
 	 */
-	public function formatDateTimeRelativeDay($timestamp, $formatDate = 'long', $formatTime = 'medium', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null);
+	public function formatDateTimeRelativeDay($timestamp, string $formatDate = 'long', $formatTime = 'medium', DateTimeZone $timeZone = null, IL10N $l = null);
 }

--- a/lib/public/IDateTimeZone.php
+++ b/lib/public/IDateTimeZone.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -23,6 +26,8 @@
 
 namespace OCP;
 
+use DateTimeZone;
+
 /**
  * Interface IDateTimeZone
  *
@@ -32,7 +37,7 @@ namespace OCP;
 interface IDateTimeZone {
 	/**
 	 * @param bool|int $timestamp
-	 * @return \DateTimeZone
+	 * @return DateTimeZone
 	 * @since 8.0.0 - parameter $timestamp was added in 8.1.0
 	 */
 	public function getTimeZone($timestamp = false);

--- a/lib/public/IEventSource.php
+++ b/lib/public/IEventSource.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -42,7 +45,7 @@ interface IEventSource {
 	 * if only one parameter is given, a typeless message will be send with that parameter as data
 	 * @since 8.0.0
 	 */
-	public function send($type, $data = null);
+	public function send(string $type, $data = null);
 
 	/**
 	 * close the connection of the event source

--- a/lib/public/IGroup.php
+++ b/lib/public/IGroup.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -100,7 +103,7 @@ interface IGroup {
 	 * @return \OCP\IUser[]
 	 * @since 8.0.0
 	 */
-	public function searchUsers($search, $limit = null, $offset = null);
+	public function searchUsers(string $search, int $limit = null, int $offset = null);
 
 	/**
 	 * returns the number of users matching the search string
@@ -109,7 +112,7 @@ interface IGroup {
 	 * @return int|bool
 	 * @since 8.0.0
 	 */
-	public function count($search = '');
+	public function count(string $search = '');
 
 	/**
 	 * returns the number of disabled users
@@ -128,7 +131,7 @@ interface IGroup {
 	 * @return \OCP\IUser[]
 	 * @since 8.0.0
 	 */
-	public function searchDisplayName($search, $limit = null, $offset = null);
+	public function searchDisplayName(string $search, int $limit = null, int $offset = null);
 
 	/**
 	 * delete the group

--- a/lib/public/IGroupManager.php
+++ b/lib/public/IGroupManager.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -57,7 +60,7 @@ interface IGroupManager {
 	public function isBackendUsed($backendClass);
 
 	/**
-	 * @param \OCP\GroupInterface $backend
+	 * @param GroupInterface $backend
 	 * @since 8.0.0
 	 */
 	public function addBackend($backend);
@@ -69,7 +72,8 @@ interface IGroupManager {
 
 	/**
 	 * Get the active backends
-	 * @return \OCP\GroupInterface[]
+	 *
+	 * @return GroupInterface[]
 	 * @since 13.0.0
 	 */
 	public function getBackends();
@@ -86,14 +90,14 @@ interface IGroupManager {
 	 * @return bool
 	 * @since 8.0.0
 	 */
-	public function groupExists($gid);
+	public function groupExists(string $gid);
 
 	/**
 	 * @param string $gid
 	 * @return \OCP\IGroup|null
 	 * @since 8.0.0
 	 */
-	public function createGroup($gid);
+	public function createGroup(string $gid);
 
 	/**
 	 * @param string $search
@@ -102,7 +106,7 @@ interface IGroupManager {
 	 * @return \OCP\IGroup[]
 	 * @since 8.0.0
 	 */
-	public function search($search, $limit = null, $offset = null);
+	public function search(string $search, int $limit = null, int $offset = null);
 
 	/**
 	 * @param \OCP\IUser|null $user
@@ -128,7 +132,7 @@ interface IGroupManager {
 	 * @return array an array of display names (value) and user ids (key)
 	 * @since 8.0.0
 	 */
-	public function displayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0);
+	public function displayNamesInGroup(string $gid, string $search = '', int $limit = -1, int $offset = 0);
 
 	/**
 	 * Checks if a userId is in the admin group
@@ -136,7 +140,7 @@ interface IGroupManager {
 	 * @return bool if admin
 	 * @since 8.0.0
 	 */
-	public function isAdmin($userId);
+	public function isAdmin(string $userId);
 
 	/**
 	 * Checks if a userId is in a group
@@ -145,5 +149,5 @@ interface IGroupManager {
 	 * @return bool if in group
 	 * @since 8.0.0
 	 */
-	public function isInGroup($userId, $group);
+	public function isInGroup(string $userId, string $group);
 }

--- a/lib/public/IImage.php
+++ b/lib/public/IImage.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -95,7 +98,7 @@ interface IImage {
 	 * @return bool
 	 * @since 8.1.0
 	 */
-	public function save($filePath = null, $mimeType = null);
+	public function save(string $filePath = null, string $mimeType = null);
 
 	/**
 	 * @return resource Returns the image resource in any.
@@ -136,11 +139,11 @@ interface IImage {
 	/**
 	 * Resizes the image preserving ratio.
 	 *
-	 * @param integer $maxSize The maximum size of either the width or height.
+	 * @param int $maxSize The maximum size of either the width or height.
 	 * @return bool
 	 * @since 8.1.0
 	 */
-	public function resize($maxSize);
+	public function resize(int $maxSize);
 
 	/**
 	 * @param int $width
@@ -157,7 +160,7 @@ interface IImage {
 	 * @return bool for success or failure
 	 * @since 8.1.0
 	 */
-	public function centerCrop($size = 0);
+	public function centerCrop(int $size = 0);
 
 	/**
 	 * Crops the image from point $x$y with dimension $wx$h.
@@ -174,20 +177,20 @@ interface IImage {
 	/**
 	 * Resizes the image to fit within a boundary while preserving ratio.
 	 *
-	 * @param integer $maxWidth
-	 * @param integer $maxHeight
+	 * @param int $maxWidth
+	 * @param int $maxHeight
 	 * @return bool
 	 * @since 8.1.0
 	 */
-	public function fitIn($maxWidth, $maxHeight);
+	public function fitIn(int $maxWidth, int $maxHeight);
 
 	/**
 	 * Shrinks the image to fit within a boundary while preserving ratio.
 	 *
-	 * @param integer $maxWidth
-	 * @param integer $maxHeight
+	 * @param int $maxWidth
+	 * @param int $maxHeight
 	 * @return bool
 	 * @since 8.1.0
 	 */
-	public function scaleDownToFit($maxWidth, $maxHeight);
+	public function scaleDownToFit(int $maxWidth, int $maxHeight);
 }

--- a/lib/public/IInitialStateService.php
+++ b/lib/public/IInitialStateService.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace OCP;
 
 use Closure;
+use JsonSerializable;
 
 /**
  * @since 16.0.0
@@ -38,11 +39,11 @@ interface IInitialStateService {
 	 * Use this if you know your initial state sill be used for example if
 	 * you are in the render function of you controller.
 	 *
-	 * @since 16.0.0
-	 *
 	 * @param string $appName
 	 * @param string $key
-	 * @param bool|int|float|string|array|\JsonSerializable $data
+	 * @param bool|int|float|string|array|JsonSerializable $data
+	 *@since 16.0.0
+	 *
 	 */
 	public function provideInitialState(string $appName, string $key, $data): void;
 

--- a/lib/public/IL10N.php
+++ b/lib/public/IL10N.php
@@ -57,7 +57,7 @@ interface IL10N {
 	 * returned.
 	 * @since 6.0.0
 	 */
-	public function t(string $text, $parameters = []): string;
+	public function t(string $text, array $parameters = []): string;
 
 	/**
 	 * Translating

--- a/lib/public/IMemcache.php
+++ b/lib/public/IMemcache.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -48,17 +51,17 @@ interface IMemcache extends ICache {
 	 * @return bool
 	 * @since 8.1.0
 	 */
-	public function add($key, $value, $ttl = 0);
+	public function add(string $key, $value, int $ttl = 0);
 
 	/**
 	 * Increase a stored number
 	 *
 	 * @param string $key
 	 * @param int $step
-	 * @return int | bool
+	 * @return int|bool
 	 * @since 8.1.0
 	 */
-	public function inc($key, $step = 1);
+	public function inc(string $key, int $step = 1);
 
 	/**
 	 * Decrease a stored number
@@ -68,7 +71,7 @@ interface IMemcache extends ICache {
 	 * @return int | bool
 	 * @since 8.1.0
 	 */
-	public function dec($key, $step = 1);
+	public function dec(string $key, int $step = 1);
 
 	/**
 	 * Compare and set
@@ -79,7 +82,7 @@ interface IMemcache extends ICache {
 	 * @return bool
 	 * @since 8.1.0
 	 */
-	public function cas($key, $old, $new);
+	public function cas(string $key, $old, $new);
 
 	/**
 	 * Compare and delete
@@ -89,5 +92,5 @@ interface IMemcache extends ICache {
 	 * @return bool
 	 * @since 8.1.0
 	 */
-	public function cad($key, $old);
+	public function cad(string $key, $old);
 }

--- a/lib/public/IMemcacheTTL.php
+++ b/lib/public/IMemcacheTTL.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -36,5 +39,5 @@ interface IMemcacheTTL extends IMemcache {
 	 * @param int $ttl time to live in seconds
 	 * @since 8.2.2
 	 */
-	public function setTTL($key, $ttl);
+	public function setTTL(string $key, int $ttl);
 }

--- a/lib/public/IPreview.php
+++ b/lib/public/IPreview.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -35,7 +38,9 @@
 
 namespace OCP;
 
+use Closure;
 use OCP\Files\File;
+use OCP\Files\FileInfo;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
 
@@ -60,11 +65,11 @@ interface IPreview {
 	 * $callable has to return an instance of \OCP\Preview\IProvider
 	 *
 	 * @param string $mimeTypeRegex Regex with the mime types that are supported by this provider
-	 * @param \Closure $callable
+	 * @param Closure $callable
 	 * @return void
 	 * @since 8.1.0
 	 */
-	public function registerProvider($mimeTypeRegex, \Closure $callable);
+	public function registerProvider(string $mimeTypeRegex, Closure $callable);
 
 	/**
 	 * Get all providers
@@ -105,14 +110,14 @@ interface IPreview {
 	 * @return boolean
 	 * @since 6.0.0
 	 */
-	public function isMimeSupported($mimeType = '*');
+	public function isMimeSupported(string $mimeType = '*');
 
 	/**
 	 * Check if a preview can be generated for a file
 	 *
-	 * @param \OCP\Files\FileInfo $file
+	 * @param FileInfo $file
 	 * @return bool
 	 * @since 8.0.0
 	 */
-	public function isAvailable(\OCP\Files\FileInfo $file);
+	public function isAvailable(FileInfo $file);
 }

--- a/lib/public/ISearch.php
+++ b/lib/public/ISearch.php
@@ -42,7 +42,7 @@ interface ISearch {
 	 * @return array An array of OCP\Search\Result's
 	 * @since 8.0.0
 	 */
-	public function searchPaged($query, array $inApps = array(), $page = 1, $size = 30);
+	public function searchPaged(string $query, array $inApps = array(), int $page = 1, int $size = 30);
 
 	/**
 	 * Register a new search provider to search with
@@ -50,14 +50,14 @@ interface ISearch {
 	 * @param array $options optional
 	 * @since 7.0.0
 	 */
-	public function registerProvider($class, array $options = array());
+	public function registerProvider(string $class, array $options = array());
 
 	/**
 	 * Remove one existing search provider
 	 * @param string $provider class name of a OCP\Search\Provider
 	 * @since 7.0.0
 	 */
-	public function removeProvider($provider);
+	public function removeProvider(string $provider);
 
 	/**
 	 * Remove all registered search providers

--- a/lib/public/IServerContainer.php
+++ b/lib/public/IServerContainer.php
@@ -141,7 +141,7 @@ interface IServerContainer extends IContainer {
 	 * @since 6.0.0 - parameter $userId was added in 8.0.0
 	 * @see getUserFolder in \OCP\Files\IRootFolder
 	 */
-	public function getUserFolder($userId = null);
+	public function getUserFolder(string $userId = null);
 
 	/**
 	 * Returns an app-specific view in ownClouds data directory
@@ -245,7 +245,7 @@ interface IServerContainer extends IContainer {
 	 * @return \OCP\IL10N
 	 * @since 6.0.0 - parameter $lang was added in 8.0.0
 	 */
-	public function getL10N($app, $lang = null);
+	public function getL10N(string $app, string $lang = null);
 
 	/**
 	 * @return \OC\Encryption\Manager
@@ -368,7 +368,7 @@ interface IServerContainer extends IContainer {
 	 * @return \OCP\ICertificateManager | null if $userId is null and no user is logged in
 	 * @since 8.0.0
 	 */
-	public function getCertificateManager($userId = null);
+	public function getCertificateManager(string $userId = null);
 
 	/**
 	 * Create a new event source

--- a/lib/public/ITagManager.php
+++ b/lib/public/ITagManager.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -60,5 +63,5 @@ interface ITagManager {
 	 * @return \OCP\ITags
 	 * @since 6.0.0 - parameter $includeShared and $userId were added in 8.0.0
 	*/
-	public function load($type, $defaultTags = array(), $includeShared = false, $userId = null);
+	public function load(string $type, array $defaultTags = array(), bool $includeShared = false, string $userId = null);
 }

--- a/lib/public/ITags.php
+++ b/lib/public/ITags.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -70,7 +73,7 @@ interface ITags {
 	 * @return array|false
 	 * @since 8.0.0
 	 */
-	public function getTag($id);
+	public function getTag(string $id);
 
 	/**
 	 * Get the tags for a specific user.
@@ -121,7 +124,7 @@ interface ITags {
 	 * @return bool
 	 * @since 6.0.0
 	 */
-	public function hasTag($name);
+	public function hasTag(string $name);
 
 	/**
 	 * Checks whether a tag is saved for the given user,
@@ -132,7 +135,7 @@ interface ITags {
 	 * @return bool
 	 * @since 8.0.0
 	 */
-	public function userHasTag($name, $user);
+	public function userHasTag(string $name, string $user);
 
 	/**
 	 * Add a new tag.
@@ -141,7 +144,7 @@ interface ITags {
 	 * @return int|false the id of the added tag or false if it already exists.
 	 * @since 6.0.0
 	 */
-	public function add($name);
+	public function add(string $name);
 
 	/**
 	 * Rename tag.
@@ -151,7 +154,7 @@ interface ITags {
 	 * @return bool
 	 * @since 6.0.0
 	 */
-	public function rename($from, $to);
+	public function rename($from, string $to);
 
 	/**
 	 * Add a list of new tags.
@@ -163,7 +166,7 @@ interface ITags {
 	 * @return bool Returns false on error.
 	 * @since 6.0.0
 	 */
-	public function addMultiple($names, $sync=false, $id = null);
+	public function addMultiple(array $names, bool $sync = false, int $id = null);
 
 	/**
 	 * Delete tag/object relations from the db
@@ -189,7 +192,7 @@ interface ITags {
 	 * @return boolean
 	 * @since 6.0.0
 	 */
-	public function addToFavorites($objid);
+	public function addToFavorites(int $objid);
 
 	/**
 	 * Remove an object from favorites
@@ -198,7 +201,7 @@ interface ITags {
 	 * @return boolean
 	 * @since 6.0.0
 	 */
-	public function removeFromFavorites($objid);
+	public function removeFromFavorites(int $objid);
 
 	/**
 	 * Creates a tag/object relation.
@@ -208,7 +211,7 @@ interface ITags {
 	 * @return boolean Returns false on database error.
 	 * @since 6.0.0
 	 */
-	public function tagAs($objid, $tag);
+	public function tagAs(int $objid, string $tag);
 
 	/**
 	 * Delete single tag/object relation from the db
@@ -218,7 +221,7 @@ interface ITags {
 	 * @return boolean
 	 * @since 6.0.0
 	 */
-	public function unTag($objid, $tag);
+	public function unTag(int $objid, string $tag);
 
 	/**
 	 * Delete tags from the database
@@ -227,6 +230,6 @@ interface ITags {
 	 * @return bool Returns false on error
 	 * @since 6.0.0
 	 */
-	public function delete($names);
+	public function delete(array $names);
 
 }

--- a/lib/public/ITempManager.php
+++ b/lib/public/ITempManager.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -38,7 +41,7 @@ interface ITempManager {
 	 * @return string
 	 * @since 8.0.0
 	 */
-	public function getTemporaryFile($postFix = '');
+	public function getTemporaryFile(string $postFix = '');
 
 	/**
 	 * Create a temporary folder and return the path
@@ -47,7 +50,7 @@ interface ITempManager {
 	 * @return string
 	 * @since 8.0.0
 	 */
-	public function getTemporaryFolder($postFix = '');
+	public function getTemporaryFolder(string $postFix = '');
 
 	/**
 	 * Remove the temporary files and folders generated during this request

--- a/lib/public/IUser.php
+++ b/lib/public/IUser.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -61,7 +64,7 @@ interface IUser {
 	 * @return bool
 	 * @since 8.0.0
 	 */
-	public function setDisplayName($displayName);
+	public function setDisplayName(string $displayName);
 
 	/**
 	 * returns the timestamp of the user's last login or 0 if the user did never
@@ -94,7 +97,7 @@ interface IUser {
 	 * @return bool
 	 * @since 8.0.0
 	 */
-	public function setPassword($password, $recoveryPassword = null);
+	public function setPassword(string $password, string $recoveryPassword = null);
 
 	/**
 	 * get the users home folder to mount
@@ -175,7 +178,7 @@ interface IUser {
 	 * @return IImage|null
 	 * @since 9.0.0
 	 */
-	public function getAvatarImage($size);
+	public function getAvatarImage(int $size);
 
 	/**
 	 * get the federation cloud id
@@ -192,7 +195,7 @@ interface IUser {
 	 * @return void
 	 * @since 9.0.0
 	 */
-	public function setEMailAddress($mailAddress);
+	public function setEMailAddress(string $mailAddress);
 
 	/**
 	 * get the users' quota in human readable form. If a specific quota is not
@@ -211,5 +214,5 @@ interface IUser {
 	 * @return void
 	 * @since 9.0.0
 	 */
-	public function setQuota($quota);
+	public function setQuota(string $quota);
 }

--- a/lib/public/IUserBackend.php
+++ b/lib/public/IUserBackend.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -31,6 +34,9 @@
 namespace OCP;
 
 
+use Closure;
+use InvalidArgumentException;
+
 /**
  * Class Manager
  *
@@ -52,14 +58,15 @@ interface IUserManager {
 		/**
 	 * register a user backend
 	 *
-	 * @param \OCP\UserInterface $backend
+	 * @param UserInterface $backend
 	 * @since 8.0.0
 	 */
-	public function registerBackend($backend);
+	public function registerBackend(UserInterface $backend);
 
 	/**
 	 * Get the active backends
-	 * @return \OCP\UserInterface[]
+	 *
+	 * @return UserInterface[]
 	 * @since 8.0.0
 	 */
 	public function getBackends();
@@ -67,10 +74,10 @@ interface IUserManager {
 	/**
 	 * remove a user backend
 	 *
-	 * @param \OCP\UserInterface $backend
+	 * @param UserInterface $backend
 	 * @since 8.0.0
 	 */
-	public function removeBackend($backend);
+	public function removeBackend(UserInterface $backend);
 
 	/**
 	 * remove all user backends
@@ -82,10 +89,10 @@ interface IUserManager {
 	 * get a user by user id
 	 *
 	 * @param string $uid
-	 * @return \OCP\IUser|null Either the user or null if the specified user does not exist
+	 * @return IUser|null Either the user or null if the specified user does not exist
 	 * @since 8.0.0
 	 */
-	public function get($uid);
+	public function get(string $uid);
 
 	/**
 	 * check if a user exists
@@ -94,7 +101,7 @@ interface IUserManager {
 	 * @return bool
 	 * @since 8.0.0
 	 */
-	public function userExists($uid);
+	public function userExists(string $uid);
 
 	/**
 	 * Check if the password is valid for the user
@@ -104,7 +111,7 @@ interface IUserManager {
 	 * @return mixed the User object on success, false otherwise
 	 * @since 8.0.0
 	 */
-	public function checkPassword($loginName, $password);
+	public function checkPassword(string $loginName, string $password);
 
 	/**
 	 * search by user id
@@ -112,10 +119,10 @@ interface IUserManager {
 	 * @param string $pattern
 	 * @param int $limit
 	 * @param int $offset
-	 * @return \OCP\IUser[]
+	 * @return IUser[]
 	 * @since 8.0.0
 	 */
-	public function search($pattern, $limit = null, $offset = null);
+	public function search(string $pattern, int $limit = null, int $offset = null);
 
 	/**
 	 * search by displayName
@@ -123,29 +130,29 @@ interface IUserManager {
 	 * @param string $pattern
 	 * @param int $limit
 	 * @param int $offset
-	 * @return \OCP\IUser[]
+	 * @return IUser[]
 	 * @since 8.0.0
 	 */
-	public function searchDisplayName($pattern, $limit = null, $offset = null);
+	public function searchDisplayName(string $pattern, int $limit = null, int $offset = null);
 
 	/**
 	 * @param string $uid
 	 * @param string $password
-	 * @throws \InvalidArgumentException
-	 * @return bool|\OCP\IUser the created user or false
+	 * @return bool|IUser the created user or false
+	 * @throws InvalidArgumentException
 	 * @since 8.0.0
 	 */
-	public function createUser($uid, $password);
+	public function createUser(string $uid, string $password);
 
 	/**
 	 * @param string $uid
 	 * @param string $password
 	 * @param UserInterface $backend
 	 * @return IUser|null
-	 * @throws \InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 * @since 12.0.0
 	 */
-	public function createUserFromBackend($uid, $password, UserInterface $backend);
+	public function createUserFromBackend(string $uid, string $password, UserInterface $backend);
 
 	/**
 	 * returns how many users per backend exist (if supported by backend)
@@ -156,11 +163,11 @@ interface IUserManager {
 	public function countUsers();
 
 	/**
-	 * @param \Closure $callback
+	 * @param Closure $callback
 	 * @param string $search
 	 * @since 9.0.0
 	 */
-	public function callForAllUsers(\Closure $callback, $search = '');
+	public function callForAllUsers(Closure $callback, $search = '');
 
 	/**
 	 * returns how many users have logged in once
@@ -179,15 +186,15 @@ interface IUserManager {
 	public function countSeenUsers();
 
 	/**
-	 * @param \Closure $callback
+	 * @param Closure $callback
 	 * @since 11.0.0
 	 */
-	public function callForSeenUsers(\Closure $callback);
+	public function callForSeenUsers(Closure $callback);
 
 	/**
 	 * @param string $email
 	 * @return IUser[]
 	 * @since 9.1.0
 	 */
-	public function getByEmail($email);
+	public function getByEmail(string $email);
 }

--- a/lib/public/IUserSession.php
+++ b/lib/public/IUserSession.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -65,7 +68,7 @@ interface IUserSession {
 	/**
 	 * set the currently active user
 	 *
-	 * @param \OCP\IUser|null $user
+	 * @param IUser|null $user
 	 * @since 8.0.0
 	 */
 	public function setUser($user);
@@ -73,7 +76,7 @@ interface IUserSession {
 	/**
 	 * get the current active user
 	 *
-	 * @return \OCP\IUser|null Current user, otherwise null
+	 * @return IUser|null Current user, otherwise null
 	 * @since 8.0.0
 	 */
 	public function getUser();

--- a/lib/public/Image.php
+++ b/lib/public/Image.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -23,20 +26,13 @@
  *
  */
 
-/**
- * Public interface of ownCloud for apps to use.
- * Image class
- *
- */
-
-// use OCP namespace for all classes that are considered public.
-// This means that they should be used by apps instead of the internal ownCloud classes
-
 namespace OCP;
+
+use OC_Image;
 
 /**
  * This class provides functions to handle images
+ *
  * @since 6.0.0
  */
-class Image extends \OC_Image {
-}
+class Image extends OC_Image {}

--- a/lib/public/PreConditionNotMetException.php
+++ b/lib/public/PreConditionNotMetException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -26,8 +29,11 @@
 
 namespace OCP;
 
+use Exception;
+
 /**
  * Exception if the precondition of the config update method isn't met
+ *
  * @since 8.0.0
  */
-class PreConditionNotMetException extends \Exception {}
+class PreConditionNotMetException extends Exception {}

--- a/lib/public/SabrePluginEvent.php
+++ b/lib/public/SabrePluginEvent.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -48,6 +51,7 @@ class SabrePluginEvent extends Event {
 	 * @since 8.2.0
 	 */
 	public function __construct($server = null) {
+		parent::__construct();
 		$this->message = '';
 		$this->statusCode = Http::STATUS_OK;
 		$this->server = $server;
@@ -58,7 +62,7 @@ class SabrePluginEvent extends Event {
 	 * @return self
 	 * @since 8.2.0
 	 */
-	public function setStatusCode($statusCode) {
+	public function setStatusCode(int $statusCode) {
 		$this->statusCode = (int) $statusCode;
 		return $this;
 	}
@@ -68,7 +72,7 @@ class SabrePluginEvent extends Event {
 	 * @return self
 	 * @since 8.2.0
 	 */
-	public function setMessage($message) {
+	public function setMessage(string $message) {
 		$this->message = (string) $message;
 		return $this;
 	}

--- a/lib/public/SabrePluginException.php
+++ b/lib/public/SabrePluginException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *

--- a/lib/public/Share.php
+++ b/lib/public/Share.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -59,7 +62,7 @@ class Share extends \OC\Share\Constants {
 	 * @since 6.0.0 - parameter $owner was added in 8.0.0
 	 * @deprecated 17.0.0
 	 */
-	public static function getItemSharedWithUser($itemType, $itemSource, $user, $owner = null) {
+	public static function getItemSharedWithUser(string $itemType, string $itemSource, string $user, string $owner = null) {
 		return \OC\Share\Share::getItemSharedWithUser($itemType, $itemSource, $user, $owner);
 	}
 
@@ -74,7 +77,7 @@ class Share extends \OC\Share\Constants {
 	 * @since 5.0.0
 	 * @deprecated 17.0.0
 	 */
-	public static function getItemSharedWithBySource($itemType, $itemSource, $format = self::FORMAT_NONE,
+	public static function getItemSharedWithBySource(string $itemType, string $itemSource, int $format = self::FORMAT_NONE,
 		$parameters = null, $includeCollections = false) {
 		// not used by any app - only here to not break apps syntax
 	}
@@ -87,7 +90,7 @@ class Share extends \OC\Share\Constants {
 	 * @since 5.0.0 - parameter $checkPasswordProtection was added in 7.0.0
 	 * @deprecated 17.0.0
 	 */
-	public static function getShareByToken($token, $checkPasswordProtection = true) {
+	public static function getShareByToken(string $token, bool $checkPasswordProtection = true) {
 		// not used by any app - only here to not break apps syntax
 	}
 
@@ -103,8 +106,8 @@ class Share extends \OC\Share\Constants {
 	 * @since 5.0.0
 	 * @deprecated 17.0.0
 	 */
-	public static function getItemsShared($itemType, $format = self::FORMAT_NONE, $parameters = null,
-		$limit = -1, $includeCollections = false) {
+	public static function getItemsShared(string $itemType, int $format = self::FORMAT_NONE, $parameters = null,
+		int $limit = -1, bool $includeCollections = false) {
 
 		// only used by AppVNCSafe app (https://github.com/vnc-biz/nextcloud-appvncsafe/issues/2) - only here to not break apps syntax
 	}
@@ -120,8 +123,8 @@ class Share extends \OC\Share\Constants {
 	 * @since 5.0.0
 	 * @deprecated 17.0.0
 	 */
-	public static function getItemShared($itemType, $itemSource, $format = self::FORMAT_NONE,
-	                                     $parameters = null, $includeCollections = false) {
+	public static function getItemShared(string $itemType, string $itemSource, int $format = self::FORMAT_NONE,
+	                                     $parameters = null, bool $includeCollections = false) {
 
 		return \OC\Share\Share::getItemShared($itemType, $itemSource, $format, $parameters, $includeCollections);
 	}
@@ -136,7 +139,7 @@ class Share extends \OC\Share\Constants {
 	 * @since 6.0.0 - parameter $originIsSource was added in 8.0.0
 	 * @deprecated 17.0.0
 	 */
-	public static function setSendMailStatus($itemType, $itemSource, $shareType, $recipient, $status) {
+	public static function setSendMailStatus(string $itemType, string $itemSource, int $shareType, string $recipient, bool $status) {
 		// not used by any app - only here to not break apps syntax
 	}
 }

--- a/lib/public/Share_Backend.php
+++ b/lib/public/Share_Backend.php
@@ -44,7 +44,7 @@ interface Share_Backend {
 	 * Return false if the item does not exist for the user
 	 * @since 5.0.0
 	 */
-	public function isValidSource($itemSource, $uidOwner);
+	public function isValidSource(string $itemSource, string $uidOwner);
 
 	/**
 	 * Get a unique name of the item for the specified user
@@ -57,7 +57,7 @@ interface Share_Backend {
 	 * If it does generate a new name e.g. name_#
 	 * @since 5.0.0
 	 */
-	public function generateTarget($itemSource, $shareWith, $exclude = null);
+	public function generateTarget(string $itemSource, $shareWith, array $exclude = null);
 
 	/**
 	 * Converts the shared item sources back into the item in the specified format
@@ -81,7 +81,7 @@ interface Share_Backend {
 	 * It is only called through calls to the public getItem(s)Shared(With) functions.
 	 * @since 5.0.0
 	 */
-	public function formatItems($items, $format, $parameters = null);
+	public function formatItems(string $items, int $format, $parameters = null);
 
 	/**
 	 * Check if a given share type is allowd by the back-end
@@ -94,6 +94,6 @@ interface Share_Backend {
 	 * all share types defined by the share API
 	 * @since 8.0.0
 	 */
-	public function isShareTypeAllowed($shareType);
+	public function isShareTypeAllowed(int $shareType);
 
 }

--- a/lib/public/Share_Backend_Collection.php
+++ b/lib/public/Share_Backend_Collection.php
@@ -39,5 +39,5 @@ interface Share_Backend_Collection extends Share_Backend {
 	 * @return array Returns an array of children each inside an array with the keys: source, target, and file_path if applicable
 	 * @since 5.0.0
 	 */
-	public function getChildren($itemSource);
+	public function getChildren(string $itemSource);
 }

--- a/lib/public/Share_Backend_File_Dependent.php
+++ b/lib/public/Share_Backend_File_Dependent.php
@@ -40,6 +40,6 @@ interface Share_Backend_File_Dependent extends Share_Backend {
 	 * @return string|false
 	 * @since 5.0.0
 	 */
-	public function getFilePath($itemSource, $uidOwner);
+	public function getFilePath(string $itemSource, string $uidOwner);
 
 }

--- a/lib/public/Template.php
+++ b/lib/public/Template.php
@@ -44,7 +44,7 @@ class Template extends \OC_Template {
 	 * @since 8.0.0
 	 * @suppress PhanDeprecatedFunction
 	 */
-	public static function image_path($app, $image) {
+	public static function image_path(string $app, string $image) {
 		return \image_path($app, $image);
 	}
 
@@ -57,7 +57,7 @@ class Template extends \OC_Template {
 	 * @since 8.0.0
 	 * @suppress PhanDeprecatedFunction
 	 */
-	public static function mimetype_icon($mimetype) {
+	public static function mimetype_icon(string $mimetype) {
 		return \mimetype_icon($mimetype);
 	}
 
@@ -69,7 +69,7 @@ class Template extends \OC_Template {
 	 * @since 8.0.0
 	 * @suppress PhanDeprecatedFunction
 	 */
-	public static function preview_icon($path) {
+	public static function preview_icon(string $path) {
 		return \preview_icon($path);
 	}
 
@@ -83,7 +83,7 @@ class Template extends \OC_Template {
 	 * @since 8.0.0
 	 * @suppress PhanDeprecatedFunction
 	 */
-	public static function publicPreview_icon($path, $token) {
+	public static function publicPreview_icon(string $path, string$token) {
 		return \publicPreview_icon($path, $token);
 	}
 
@@ -96,7 +96,7 @@ class Template extends \OC_Template {
 	 * @since 8.0.0
 	 * @suppress PhanDeprecatedFunction
 	 */
-	public static function human_file_size($bytes) {
+	public static function human_file_size(int $bytes) {
 		return \human_file_size($bytes);
 	}
 
@@ -110,7 +110,7 @@ class Template extends \OC_Template {
 	 * @suppress PhanDeprecatedFunction
 	 * @suppress PhanTypeMismatchArgument
 	 */
-	public static function relative_modified_date($timestamp, $dateOnly = false) {
+	public static function relative_modified_date(int $timestamp, bool $dateOnly = false) {
 		return \relative_modified_date($timestamp, null, $dateOnly);
 	}
 
@@ -124,7 +124,7 @@ class Template extends \OC_Template {
 	 * @since 8.0.0
 	 * @suppress PhanDeprecatedFunction
 	 */
-	public static function html_select_options($options, $selected, $params=array()) {
+	public static function html_select_options(array $options, $selected, array $params=array()) {
 		return \html_select_options($options, $selected, $params);
 	}
 }

--- a/lib/public/User.php
+++ b/lib/public/User.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *

--- a/lib/public/UserInterface.php
+++ b/lib/public/UserInterface.php
@@ -52,7 +52,7 @@ interface UserInterface {
 	 * @since 4.5.0
 	 * @deprecated 14.0.0 Switch to the interfaces from OCP\User\Backend
 	 */
-	public function implementsActions($actions);
+	public function implementsActions(int $actions);
 
 	/**
 	 * delete a user
@@ -60,7 +60,7 @@ interface UserInterface {
 	 * @return bool
 	 * @since 4.5.0
 	 */
-	public function deleteUser($uid);
+	public function deleteUser(string $uid);
 
 	/**
 	 * Get a list of all users
@@ -71,7 +71,7 @@ interface UserInterface {
 	 * @return string[] an array of all uids
 	 * @since 4.5.0
 	 */
-	public function getUsers($search = '', $limit = null, $offset = null);
+	public function getUsers(string $search = '', int $limit = null, int $offset = null);
 
 	/**
 	 * check if a user exists
@@ -79,7 +79,7 @@ interface UserInterface {
 	 * @return boolean
 	 * @since 4.5.0
 	 */
-	public function userExists($uid);
+	public function userExists(string $uid);
 
 	/**
 	 * get display name of the user
@@ -87,7 +87,7 @@ interface UserInterface {
 	 * @return string display name
 	 * @since 4.5.0
 	 */
-	public function getDisplayName($uid);
+	public function getDisplayName(string $uid);
 
 	/**
 	 * Get a list of all display names and user ids.
@@ -98,7 +98,7 @@ interface UserInterface {
 	 * @return array an array of all displayNames (value) and the corresponding uids (key)
 	 * @since 4.5.0
 	 */
-	public function getDisplayNames($search = '', $limit = null, $offset = null);
+	public function getDisplayNames(string $search = '', string $limit = null, string $offset = null);
 
 	/**
 	 * Check if a user list is available or not

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -106,7 +106,7 @@ class Util {
 	 * @param string $channel
 	 * @since 8.1.0
 	 */
-	public static function setChannel($channel) {
+	public static function setChannel(string $channel) {
 		\OC::$server->getConfig()->setSystemValue('updater.release.channel', $channel);
 	}
 
@@ -127,7 +127,7 @@ class Util {
 	 * @since 4.0.0
 	 * @deprecated 13.0.0 use log of \OCP\ILogger
 	 */
-	public static function writeLog( $app, $message, $level ) {
+	public static function writeLog(string $app, string $message, int $level ) {
 		$context = ['app' => $app];
 		\OC::$server->getLogger()->log($level, $message, $context);
 	}
@@ -159,7 +159,7 @@ class Util {
 	 * @return \OCP\IL10N
 	 * @since 6.0.0 - parameter $language was added in 8.0.0
 	 */
-	public static function getL10N($application, $language = null) {
+	public static function getL10N(string $application, string $language = null) {
 		return \OC::$server->getL10N($application, $language);
 	}
 
@@ -169,7 +169,7 @@ class Util {
 	 * @param string $file
 	 * @since 4.0.0
 	 */
-	public static function addStyle( $application, $file = null ) {
+	public static function addStyle(string $application, string $file = null ) {
 		\OC_Util::addStyle( $application, $file );
 	}
 
@@ -179,7 +179,7 @@ class Util {
 	 * @param string $file
 	 * @since 4.0.0
 	 */
-	public static function addScript( $application, $file = null ) {
+	public static function addScript(string $application, string $file = null ) {
 		\OC_Util::addScript( $application, $file );
 	}
 
@@ -189,7 +189,7 @@ class Util {
 	 * @param string $languageCode language code, defaults to the current locale
 	 * @since 8.0.0
 	 */
-	public static function addTranslations($application, $languageCode = null) {
+	public static function addTranslations(string $application, string $languageCode = null) {
 		\OC_Util::addTranslations($application, $languageCode);
 	}
 
@@ -202,7 +202,7 @@ class Util {
 	 * @param string $text the text content for the element
 	 * @since 4.0.0
 	 */
-	public static function addHeader($tag, $attributes, $text=null) {
+	public static function addHeader(string $tag, array $attributes, string $text=null) {
 		\OC_Util::addHeader($tag, $attributes, $text);
 	}
 
@@ -215,7 +215,7 @@ class Util {
 	 * @return string the url
 	 * @since 4.0.0 - parameter $args was added in 4.5.0
 	 */
-	public static function linkToAbsolute( $app, $file, $args = array() ) {
+	public static function linkToAbsolute(string $app, string $file, array $args = array() ) {
 		$urlGenerator = \OC::$server->getURLGenerator();
 		return $urlGenerator->getAbsoluteURL(
 			$urlGenerator->linkTo($app, $file, $args)
@@ -243,7 +243,7 @@ class Util {
 	 * @since 4.5.0
 	 * @deprecated 15.0.0 - use OCP\IURLGenerator
 	 */
-	public static function linkToPublic($service) {
+	public static function linkToPublic(string $service) {
 		$urlGenerator = \OC::$server->getURLGenerator();
 		if ($service === 'files') {
 			return $urlGenerator->getAbsoluteURL('/s');
@@ -282,7 +282,7 @@ class Util {
 	 * is passed to this function
 	 * @since 5.0.0
 	 */
-	public static function getDefaultEmailAddress($user_part) {
+	public static function getDefaultEmailAddress(string $user_part) {
 		$config = \OC::$server->getConfig();
 		$user_part = $config->getSystemValue('mail_from_address', $user_part);
 		$host_name = self::getServerHostName();
@@ -304,7 +304,7 @@ class Util {
 	 * @return string a human readable file size
 	 * @since 4.0.0
 	 */
-	public static function humanFileSize($bytes) {
+	public static function humanFileSize(int $bytes) {
 		return \OC_Helper::humanFileSize($bytes);
 	}
 
@@ -316,7 +316,7 @@ class Util {
 	 * Inspired by: http://www.php.net/manual/en/function.filesize.php#92418
 	 * @since 4.0.0
 	 */
-	public static function computerFileSize($str) {
+	public static function computerFileSize(string $str) {
 		return \OC_Helper::computerFileSize($str);
 	}
 
@@ -334,7 +334,7 @@ class Util {
 	 * TODO: write example
 	 * @since 4.0.0
 	 */
-	static public function connectHook($signalClass, $signalName, $slotClass, $slotName) {
+	static public function connectHook(string $signalClass, string $signalName, $slotClass, string $slotName) {
 		return \OC_Hook::connect($signalClass, $signalName, $slotClass, $slotName);
 	}
 
@@ -348,7 +348,7 @@ class Util {
 	 * TODO: write example
 	 * @since 4.0.0
 	 */
-	static public function emitHook($signalclass, $signalname, $params = array()) {
+	static public function emitHook(string $signalclass, string $signalname, array $params = array()) {
 		return \OC_Hook::emit($signalclass, $signalname, $params);
 	}
 
@@ -381,7 +381,7 @@ class Util {
 	 * @return string|array an array of sanitized strings or a single sanitized string, depends on the input parameter.
 	 * @since 4.5.0
 	 */
-	public static function sanitizeHTML($value) {
+	public static function sanitizeHTML(string $value) {
 		return \OC_Util::sanitizeHTML($value);
 	}
 
@@ -396,7 +396,7 @@ class Util {
 	 * @return string
 	 * @since 6.0.0
 	 */
-	public static function encodePath($component) {
+	public static function encodePath(string $component) {
 		return \OC_Util::encodePath($component);
 	}
 
@@ -409,7 +409,7 @@ class Util {
 	 * @return array
 	 * @since 4.5.0
 	 */
-	public static function mb_array_change_key_case($input, $case = MB_CASE_LOWER, $encoding = 'UTF-8') {
+	public static function mb_array_change_key_case(string $input, int $case = MB_CASE_LOWER, string $encoding = 'UTF-8') {
 		return \OC_Helper::mb_array_change_key_case($input, $case, $encoding);
 	}
 
@@ -423,7 +423,7 @@ class Util {
 	 * @since 4.5.0
 	 * @deprecated 15.0.0
 	 */
-	public static function recursiveArraySearch($haystack, $needle, $index = null) {
+	public static function recursiveArraySearch(array $haystack, string $needle, $index = null) {
 		return \OC_Helper::recursiveArraySearch($haystack, $needle, $index);
 	}
 
@@ -435,7 +435,7 @@ class Util {
 	 * @return int number of bytes representing
 	 * @since 5.0.0
 	 */
-	public static function maxUploadFilesize($dir, $free = null) {
+	public static function maxUploadFilesize(string $dir, int $free = null) {
 		return \OC_Helper::maxUploadFilesize($dir, $free);
 	}
 
@@ -445,7 +445,7 @@ class Util {
 	 * @return int number of bytes representing
 	 * @since 7.0.0
 	 */
-	public static function freeSpace($dir) {
+	public static function freeSpace(string $dir) {
 		return \OC_Helper::freeSpace($dir);
 	}
 
@@ -467,7 +467,7 @@ class Util {
 	 * @since 7.0.0
 	 * @suppress PhanDeprecatedFunction
 	 */
-	public static function isValidFileName($file) {
+	public static function isValidFileName(string $file) {
 		return \OC_Util::isValidFileName($file);
 	}
 
@@ -479,7 +479,7 @@ class Util {
 	 * or 0 if the strings are identical
 	 * @since 7.0.0
 	 */
-	public static function naturalSortCompare($a, $b) {
+	public static function naturalSortCompare(string $a, string $b) {
 		return \OC\NaturalSort::getInstance()->compare($a, $b);
 	}
 


### PR DESCRIPTION
* Add type hints to parameters -> [this is fine since php7.2, implementations can have a broader type](https://wiki.php.net/rfc/parameter-no-type-variance)
* Add missing parent constructor calls
* Make files strict
* General clean-ups on the go

I did not cover all files in the public API. Simply because there is so much more than I expected. And stuff I wish I hadn't seen.

![zyhfrqra64c31](https://user-images.githubusercontent.com/1374172/73695316-24a79a00-46da-11ea-8e09-57b12f25acf2.jpg)

CI will hate me. But let's see.
