### PR TITLE
Fallback for cross-device link error during rename call

### DIFF
--- a/lib/private/Files/Storage/Local/CrossDeviceLinkException.php
+++ b/lib/private/Files/Storage/Local/CrossDeviceLinkException.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2020, Jakub Gawron <kubatek94@gmail.com>
+ *
+ * @author Jakub Gawron <kubatek94@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Files\Storage\Local;
+
+/**
+ * Exception thrown due to the "cross-device link not permitted" error. 
+ */
+class CrossDeviceLinkException extends \Exception {
+
+}

--- a/lib/private/Files/Storage/Local/CrossDeviceLinkException.php
+++ b/lib/private/Files/Storage/Local/CrossDeviceLinkException.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @copyright Copyright (c) 2020, Jakub Gawron <kubatek94@gmail.com>
  *

--- a/lib/private/Files/Storage/Local/DirectoryRenamer.php
+++ b/lib/private/Files/Storage/Local/DirectoryRenamer.php
@@ -112,7 +112,7 @@ class DirectoryRenamer {
 				return call_user_func_array($previousHandler, func_get_args());
 			}
 
-			return true;
+			return false;
 		}, E_WARNING | E_USER_WARNING);
 	}
 

--- a/lib/private/Files/Storage/Local/DirectoryRenamer.php
+++ b/lib/private/Files/Storage/Local/DirectoryRenamer.php
@@ -68,7 +68,6 @@ class DirectoryRenamer {
 
 	/**
 	 * Sets a temporary error handler that covers the cross-device link error with a state machine.
-	 * @throws CrossDeviceLinkException
 	 */
 	private function setupErrorHandler(): void {
 		$state = self::STATE_NO_ERROR;

--- a/lib/private/Files/Storage/Local/DirectoryRenamer.php
+++ b/lib/private/Files/Storage/Local/DirectoryRenamer.php
@@ -24,8 +24,6 @@
 
 namespace OC\Files\Storage\Local;
 
-use OC\Files\Storage\Local\CrossDeviceLinkException;
-
 /**
  * Support class for Local Storage, responsible only for handling directory renames.
  * It attempts to perform normal rename, 
@@ -80,7 +78,7 @@ class DirectoryRenamer {
 				case self::STATE_NO_ERROR:
 					if ($errstr === 'rename(): The first argument to copy() function cannot be a directory') {
 						$state = self::STATE_CAUGHT_RENAME_WARNING;
-						return;
+						return true;
 					}
 				break;
 			}

--- a/lib/private/Files/Storage/Local/DirectoryRenamer.php
+++ b/lib/private/Files/Storage/Local/DirectoryRenamer.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2020, Jakub Gawron <kubatek94@gmail.com>
+ *
+ * @author Jakub Gawron <kubatek94@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Files\Storage\Local;
+
+use OC\Files\Storage\Local\CrossDeviceLinkException;
+
+/**
+ * Support class for Local Storage, responsible only for handling directory renames.
+ * It attempts to perform normal rename, 
+ * but fallbacks to copy and unlink strategy when it fails due to "cross-device link not permitted" error. 
+ */
+class DirectoryRenamer {
+	const STATE_NO_ERROR = 0;
+	const STATE_CAUGHT_RENAME_WARNING = 1;
+
+	/**
+	 * @var callable
+	 */
+	private $fallbackHandler;
+
+	/**
+	 * @param callable $fallbackHandler Copy and unlink strategy to use when normal rename fails 
+	 */
+	public function __construct(callable $fallbackHandler) {
+		$this->fallbackHandler = $fallbackHandler;
+	}
+
+	/**
+	 * Rename a file or directory
+	 * 
+	 * @param string $oldname
+	 * @param string $newname
+	 * @return bool
+	 */
+	public function rename(string $oldname, string $newname): bool {
+		$this->setupErrorHandler();
+
+		try {
+			return rename($oldname, $newname);
+		} catch (CrossDeviceLinkException $e) {
+			return ($this->fallbackHandler)();
+		}
+		
+		return false;
+	}
+
+	/**
+	 * Sets a temporary error handler that covers the cross-device link error with a state machine.
+	 * @throws CrossDeviceLinkException
+	 */
+	private function setupErrorHandler(): void {
+		$state = self::STATE_NO_ERROR;
+
+		set_error_handler(function($errno, $errstr) use (&$state) {
+			// when we hit first warning, we'll check if it's what we expect
+			// if it is, we transition to next state and return
+			// otherwise we continue
+			switch ($state) {
+				case self::STATE_NO_ERROR:
+					if ($errstr === 'rename(): The first argument to copy() function cannot be a directory') {
+						$state = self::STATE_CAUGHT_RENAME_WARNING;
+						return;
+					}
+				break;
+			}
+
+			// when we hit second warning, or a first warning that wasn't the above expected warning
+			// we'll check if it is the cross-device link and if so, we throw the exception
+			// to let the caller know to use the fallback strategy
+			switch ($state) {
+				case self::STATE_NO_ERROR:
+				case self::STATE_CAUGHT_RENAME_WARNING:
+					if (static::endsWith($errstr, 'cross-device link')) {
+						restore_error_handler();
+						throw new CrossDeviceLinkException();
+					}
+				break;
+			}
+
+			// if we get to this point, we got called with warnings which we can't handle (or not in the order anticipated)
+			// so we restore the previous error handler and return false to let it handle that error
+			restore_error_handler();
+			return false;
+		}, E_WARNING);
+	}
+
+	/**
+	 * Check if $haystack ends with $needle (case insensitive)
+	 * @param string $haystack
+	 * @param string $needle
+	 * @return bool
+	 */
+	private static function endsWith(string $haystack, string $needle): bool {
+		return strcasecmp(
+			substr($haystack, -strlen($needle)), 
+			$needle
+		) === 0;
+	}
+}

--- a/tests/lib/Files/Storage/Local/DirectoryRenamerTest.php
+++ b/tests/lib/Files/Storage/Local/DirectoryRenamerTest.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * @copyright Copyright (c) 2020, Jakub Gawron <kubatek94@gmail.com>
+ *
+ * @author Jakub Gawron <kubatek94@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Files\Storage\Local {
+
+	class ImplHolder {
+		/**
+		 * @var callable|null
+		 */
+		public static $impl = null;
+	}
+
+	function rename(...$args) {
+		if (!is_callable(ImplHolder::$impl)) {
+			throw new \RuntimeException('Mock rename implementation has to be set on ImplHolder::$impl');
+		}
+		return call_user_func_array(ImplHolder::$impl, $args);
+	}
+}
+
+namespace Test\Files\Storage\Local {
+
+	use OC\Files\Storage\Local\DirectoryRenamer;
+	use OC\Files\Storage\Local\ImplHolder;
+
+	class DirectoryRenamerTest extends \Test\TestCase {
+
+		/**
+		 * @dataProvider renameImplFailsSoFallbackIsCalledProvider
+		 * @param callable $impl
+		 */
+		public function testFallbackIsCalledWhenRenameFails(callable $impl) {
+			ImplHolder::$impl = $impl;
+
+			$fallbackCalled = false;
+
+			$renamer = new DirectoryRenamer(function() use (&$fallbackCalled) {
+				$fallbackCalled = true;
+				return true;
+			});
+
+			$this->assertTrue(
+				$renamer->rename('//mnt/nfs/foo/y', '//mnt/nfs/bar/x')
+			);
+
+			$this->assertTrue($fallbackCalled, 'Fallback handler wasn\'t called');
+		}
+
+		/**
+		 * @dataProvider renameImplPassesSoFallbackIsNotCalledProvider
+		 * @param callable $impl
+		 */
+		public function testFallbackIsNotCalledWhenRenamePasses(callable $impl) {
+			ImplHolder::$impl = $impl;
+
+			$fallbackCalled = false;
+
+			$renamer = new DirectoryRenamer(function() use (&$fallbackCalled) {
+				$fallbackCalled = true;
+				return false;
+			});
+
+			$this->assertTrue(
+				$renamer->rename('//mnt/nfs/foo/y', '//mnt/nfs/bar/x')
+			);
+
+			$this->assertFalse($fallbackCalled, 'Fallback handler was called');
+		}
+
+		/**
+		 * @dataProvider renameImplFailsUnexpectedlySoFallbackIsNotCalledProvider
+		 * @param callable $impl
+		 * @param null|string $expectedWarning
+		 */
+		public function testFallbackIsNotCalledWhenRenameFailsUnexpectedly(callable $impl, ?string $expectedWarning) {
+			ImplHolder::$impl = $impl;
+
+			$fallbackCalled = false;
+
+			$renamer = new DirectoryRenamer(function() use (&$fallbackCalled) {
+				$fallbackCalled = true;
+				return false;
+			});
+
+			$warnings = [];
+
+			if ($expectedWarning) {
+				set_error_handler(function($_, $errmsg) use (&$warnings) {
+					$warnings[] = $errmsg;
+				}, E_USER_WARNING);
+			}
+
+			$this->assertFalse(
+				$renamer->rename('//mnt/nfs/foo/y', '//mnt/nfs/bar/x')
+			);
+
+			$this->assertFalse($fallbackCalled, 'Fallback handler was called');
+
+			if ($expectedWarning) {
+				$this->assertContains($expectedWarning, $warnings);
+			}
+		}
+
+		public function renameImplFailsSoFallbackIsCalledProvider() {
+			return [
+				[
+					function ($oldname, $newname) {
+						trigger_error('rename(): The first argument to copy() function cannot be a directory', E_USER_WARNING);
+						trigger_error('rename('.$oldname.','.$newname.'): Invalid cross-device link', E_USER_WARNING);
+						return false;
+					},
+				],
+				[
+					function ($oldname, $newname) {
+						trigger_error('rename('.$oldname.','.$newname.'): Invalid cross-device link', E_USER_WARNING);
+						return false;
+					},
+				],
+				[
+					function ($oldname, $newname) {
+						trigger_error('rename('.$oldname.','.$newname.'): Cross-device link', E_USER_WARNING);
+						return false;
+					},
+				],
+			];
+		}
+
+		public function renameImplPassesSoFallbackIsNotCalledProvider() {
+			return [
+				[
+					function () {
+						return true;
+					},
+				],
+			];
+		}
+
+		public function renameImplFailsUnexpectedlySoFallbackIsNotCalledProvider() {
+			return [
+				[
+					function () {
+						trigger_error('rename(): The first argument to copy() function cannot be a directory', E_USER_WARNING);
+						trigger_error('unable to rename, destination directory is not writable', E_USER_WARNING);
+						return false;
+					},
+					'unable to rename, destination directory is not writable',
+				],
+				[
+					function () {
+						trigger_error('unable to rename, destination directory is not writable', E_USER_WARNING);
+						return false;
+					},
+					'unable to rename, destination directory is not writable',
+				],
+				[
+					function ($oldname, $newname) {
+						trigger_error('unable to rename, destination directory is not writable', E_USER_WARNING);
+						trigger_error('rename('.$oldname.','.$newname.'): Invalid cross-device link', E_USER_WARNING);
+						return false;
+					},
+					'unable to rename, destination directory is not writable',
+				],
+			];
+		}
+	}
+}


### PR DESCRIPTION
Few issues (#16306, #14743, #10563) have been raised with a cross-device link error.

These can be reproduced within Docker while using volume mounts. When two folders from a single volume/device are mounted within the container and user tries to move folders between those two mounted volumes, the rename PHP function is called, but the underlying overlayfs driver returns an error, which is then triggered as warning by PHP.

According to Docker documentation (https://docs.docker.com/storage/storagedriver/overlayfs-driver/#modifying-files-or-directories), this case should be handled within the application and in case of the error, we should attempt a "copy and rename" strategy.

This PR addresses the issue. I tried to make it so that it handles the cross-device link error, but forwards unexpected warnings to the original error handler to make it rather transparent in case of other failures.

I'm open to any feedback :)