### PR TITLE
Add config to provide a no proxy option to guzzle

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -532,6 +532,13 @@ $CONFIG = array(
  */
 'proxyuserpwd' => '',
 
+/**
+ * Exclude list from hosts that should not be handled by the proxy.
+ * The format is: ``['host1', 'host2']``.
+ *
+ * Defaults to ``'null``
+ */
+'noproxy' => null,
 
 /**
  * Deleted Items (trash bin)

--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -65,8 +65,13 @@ class Client implements IClient {
 	}
 
 	private function buildRequestOptions(array $options): array {
+		$proxyUri = $this->getProxyUri();
 		$defaults = [
-			RequestOptions::PROXY => $this->getProxyUri(),
+			RequestOptions::PROXY => $proxyUri ? [
+				'http' => $proxyUri,
+				'https' => $proxyUri,
+				'no' => $this->getNoProxy(),
+			] : null,
 			RequestOptions::VERIFY => $this->getCertBundle(),
 			RequestOptions::TIMEOUT => 30,
 		];
@@ -114,6 +119,19 @@ class Client implements IClient {
 		}
 
 		return $proxyUserPwd . '@' . $proxyHost;
+	}
+
+	private function getNoProxy(): ?array {
+		$noProxy = $this->config->getSystemValue('noproxy', null);
+
+		if ($noProxy === null) {
+			if ($noProxy = getenv('NO_PROXY')) {
+				$cleanedNoProxy = str_replace(' ', '', $noProxy);
+				return explode(',', $cleanedNoProxy);
+			}
+			return null;
+		}
+		return $noProxy;
 	}
 
 	/**


### PR DESCRIPTION
This allows to specify a list of hosts that should not be handled by the default proxy. If non is defined the NO_PROXY environment variable is checked as a possible fallback.

http://docs.guzzlephp.org/en/stable/request-options.html#proxy