### PR TITLE
Prevent array access on integer in BaseResponse

### DIFF
--- a/lib/private/AppFramework/OCS/BaseResponse.php
+++ b/lib/private/AppFramework/OCS/BaseResponse.php
@@ -126,7 +126,7 @@ abstract class BaseResponse extends Response   {
 	 */
 	protected function toXML(array $array, \XMLWriter $writer) {
 		foreach ($array as $k => $v) {
-			if ($k[0] === '@') {
+			if (\is_string($k) && $k[0] === '@') {
 				$writer->writeAttribute(substr($k, 1), $v);
 				continue;
 			}


### PR DESCRIPTION
The `OC\AppFramework\OCS\BaseResponse::toXML()` method iterates over the array provided as its parameter. It checks (among other things) if the first character of the current key of that array is `@`, but it doesn’t check if that key is actually a string (it may be an integer). This commit adds the missing check.

Signed-off-by: Grzegorz Szymaszek <gszymaszek@short.pl>