### PR TITLE
do not overwrite global user auth credentials with empty values

### DIFF
--- a/apps/files_external/lib/Lib/Auth/Password/UserGlobalAuth.php
+++ b/apps/files_external/lib/Lib/Auth/Password/UserGlobalAuth.php
@@ -56,6 +56,11 @@ class UserGlobalAuth extends AuthMechanism {
 	}
 
 	public function saveBackendOptions(IUser $user, $id, $backendOptions) {
+		// backendOptions are set when invoked via Files app
+		// but they are not set when invoked via ext storage settings
+		if(!isset($backendOptions['user']) && !isset($backendOptions['password'])) {
+			return;
+		}
 		// make sure we're not setting any unexpected keys
 		$credentials = [
 			'user' => $backendOptions['user'],


### PR DESCRIPTION
fixes #18195 

explanation is in the code comment.

I could have tried to  provide the info in the settings page. I got lost in the legacy JS, but also you can safe the cycles to store what is already stored.