### PR TITLE
Warn admins about delayed cron executions

### DIFF
--- a/apps/settings/templates/settings/admin/server.php
+++ b/apps/settings/templates/settings/admin/server.php
@@ -29,26 +29,40 @@
 <div class="section" id="backgroundjobs">
 	<h2 class="inlineblock"><?php p($l->t('Background jobs'));?></h2>
 	<p class="cronlog inlineblock">
-		<?php if ($_['lastcron'] !== false):
+		<?php if ($_['lastcron'] !== false) {
 			$relative_time = relative_modified_date($_['lastcron']);
+			$maxAgeRelativeTime = relative_modified_date($_['cronMaxAge']);
 
 			$formatter = \OC::$server->getDateTimeFormatter();
 			$absolute_time = $formatter->formatDateTime($_['lastcron'], 'long', 'long');
-			if (time() - $_['lastcron'] <= 600): ?>
-				<span class="status success"></span>
-				<span class="crondate" title="<?php p($absolute_time);?>">
-				<?php p($l->t("Last job ran %s.", [$relative_time]));?>
-			</span>
-			<?php else: ?>
+			$maxAgeAbsoluteTime = $formatter->formatDateTime($_['cronMaxAge'], 'long', 'long');
+			if (time() - $_['lastcron'] > 600) { ?>
 				<span class="status error"></span>
 				<span class="crondate" title="<?php p($absolute_time);?>">
-				<?php p($l->t("Last job execution ran %s. Something seems wrong.", [$relative_time]));?>
-			</span>
-			<?php endif;
-		else: ?>
+					<?php p($l->t("Last job execution ran %s. Something seems wrong.", [$relative_time]));?>
+				</span>
+			<?php } else if (time() - $_['cronMaxAge'] > 12*3600) {
+					if ($_['backgroundjobs_mode'] === 'cron') { ?>
+						<span class="status warning"></span>
+						<span class="crondate" title="<?php p($maxAgeAbsoluteTime);?>">
+							<?php p($l->t("Some jobs haven’t been executed since %s. Please consider increasing the execution frequency.", [$maxAgeRelativeTime]));?>
+						</span>
+					<?php } else { ?>
+						<span class="status error"></span>
+						<span class="crondate" title="<?php p($maxAgeAbsoluteTime);?>">
+							<?php p($l->t("Some jobs didn’t execute since %s. Please consider switching to system cron.", [$maxAgeRelativeTime]));?>
+						</span>
+					<?php }
+			} else { ?>
+				<span class="status success"></span>
+				<span class="crondate" title="<?php p($absolute_time);?>">
+					<?php p($l->t("Last job ran %s.", [$relative_time]));?>
+				</span>
+			<?php }
+		} else { ?>
 			<span class="status error"></span>
 			<?php p($l->t("Background job didn’t run yet!"));
-		endif; ?>
+		} ?>
 	</p>
 	<a target="_blank" rel="noreferrer noopener" class="icon-info"
 	   title="<?php p($l->t('Open documentation'));?>"


### PR DESCRIPTION
When there is a background job that was not even tested for execution in the last 12 hours, we show a warning and recommend to:
  + Add more executions in case of system cron or 
    > ![Bildschirmfoto von 2020-02-06 20-07-58](https://user-images.githubusercontent.com/213943/73970452-7d1aa980-491d-11ea-9258-757142b3df4e.png)

  + Switch to system cron if it is not used
    > ![Bildschirmfoto von 2020-02-06 20-08-08](https://user-images.githubusercontent.com/213943/73970457-80159a00-491d-11ea-885f-90ef39eabb02.png)

Fix #18582

