### PR TITLE
Removed nested call to beforeunload

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -3797,8 +3797,5 @@ $(document).ready(function() {
 			OCA.Files.FileList.lastAction();
 		}
 	});
-	$(window).on('unload', function () {
-		$(window).trigger('beforeunload');
-	});
 
 });


### PR DESCRIPTION
Fix #18890 

### Steps to reproduce
1. Go to Talk
2. Start a call
3. Click on any other app in the top navigation
4. Confirm that you want to navigate away
5. Confirm that you want to navigate away… again

This was introduced 7 years ago to fix Opera... I'm willing to accept breakage of this.
https://github.com/nextcloud/server/commit/bb0164c9fc968497f0e294c29f7efde50e2c9945