### PR TITLE
18.0.1 RC2

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(18, 0, 1, 0);
+$OC_Version = array(18, 0, 1, 1);
 
 // The human readable string
-$OC_VersionString = '18.0.1 RC1';
+$OC_VersionString = '18.0.1 RC2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* backported translations
* #19315 [stable18] do not overwrite global user auth credentials with empty values
* #19326 [stable18] Fix occ maintenance:install database connect failure
* #19330 [stable18] Fix event type
* #19332 [stable18] Array access on int will fail on php7.4
* #19334 [stable18] Make sure the default share provider does not execute for other things


Pending PRs:

* [x] #19340 [stable18] Disable link shares of disabled users @backportbot-nextcloud
