### PR TITLE
Allow accessing CORS routes on ApiControllers if a proper CSRF token is provided

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
@@ -26,7 +26,6 @@
 
 namespace OC\AppFramework\Middleware\Security;
 
-use OC\AppFramework\Middleware\Security\Exceptions\CrossSiteRequestForgeryException;
 use OC\AppFramework\Middleware\Security\Exceptions\SecurityException;
 use OC\AppFramework\Utility\ControllerMethodReflector;
 use OC\Authentication\Exceptions\PasswordLoginForbiddenException;
@@ -95,7 +94,7 @@ class CORSMiddleware extends Middleware {
 			}
 			$this->session->logout();
 			try {
-				if (!$this->session->logClientIn($user, $pass, $this->request, $this->throttler)) {
+				if (!empty($user) && !empty($pass) && !$this->session->logClientIn($user, $pass, $this->request, $this->throttler)) {
 					throw new SecurityException('CORS requires basic auth', Http::STATUS_UNAUTHORIZED);
 				}
 			} catch (PasswordLoginForbiddenException $ex) {


### PR DESCRIPTION
The current implementation always requires basic auth when `@CORS` annotated routes are accessed. That leads to apps implementing basically two endpoints that have the same implementation but one with `@CORS @NoCSRFRequired` and one without those.

This PR would basically allow apps to provide one API endpoint for both internal usage in Nextcloud as well as external API calls, but the CORSMiddleware doesn't block the request if a valid CSRF token is provided.

I think this should cover the CSRF attack vectors that are described in https://github.com/nextcloud/server/blob/b801d2765868c90580e8f1097e225f590db62003/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php#L85-L86 or am I missing something?

---

The second commit is just for checking if username and password are actually provided so that the type hint added in https://github.com/nextcloud/server/blob/1b46621cd31dabb48084c8e23f741de77e7007b4/lib/public/User/Events/BeforeUserLoggedInEvent.php#L46 doesn't cause a `TypeError` to be thrown but when calling `logClientIn` in the CORSMiddleware.
