### PR TITLE
(GlobalScale) lock federation to internal

### DIFF
--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -122,7 +122,6 @@ class RequestHandlerController extends Controller {
 	 * Example: curl -H "Content-Type: application/json" -X POST -d '{"shareWith":"admin1@serve1","name":"welcome server2.txt","description":"desc","providerId":"2","owner":"admin2@http://localhost/server2","ownerDisplayName":"admin2 display","shareType":"user","resourceType":"file","protocol":{"name":"webdav","options":{"sharedSecret":"secret","permissions":"webdav-property"}}}' http://localhost/server/index.php/ocm/shares
 	 */
 	public function addShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $protocol, $shareType, $resourceType) {
-
 		// check if all required parameters are set
 		if ($shareWith === null ||
 			$name === null ||
@@ -177,6 +176,8 @@ class RequestHandlerController extends Controller {
 		$ownerDisplayName = $ownerDisplayName === null ? $owner : $ownerDisplayName;
 		$sharedByDisplayName = $sharedByDisplayName === null ? $sharedBy : $sharedByDisplayName;
 
+		$password = '';
+
 		// sharedBy* parameter is optional, if nothing is set we assume that it is the same user as the owner
 		if ($sharedBy === null) {
 			$sharedBy = $owner;
@@ -185,7 +186,7 @@ class RequestHandlerController extends Controller {
 
 		try {
 			$provider = $this->cloudFederationProviderManager->getCloudFederationProvider($resourceType);
-			$share = $this->factory->getCloudFederationShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, '', $shareType, $resourceType);
+			$share = $this->factory->getCloudFederationShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, '', $shareType, $resourceType, $password);
 			$share->setProtocol($protocol);
 			$provider->shareReceived($share);
 		} catch (ProviderDoesNotExistsException $e) {

--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -29,6 +29,8 @@
  *
  */
 
+use OCP\GlobalScale\IConfig as IGlobalScaleConfig;
+
 // load needed apps
 $RUNTIME_APPTYPES = ['filesystem', 'authentication', 'logging'];
 
@@ -41,7 +43,8 @@ OC_Util::obEnd();
 $authBackend = new OCA\DAV\Connector\PublicAuth(
 	\OC::$server->getRequest(),
 	\OC::$server->getShareManager(),
-	\OC::$server->getSession()
+	\OC::$server->getSession(),
+	\OC::$server->query(IGlobalScaleConfig::class)
 );
 $authPlugin = new \Sabre\DAV\Auth\Plugin($authBackend);
 

--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -37,7 +37,8 @@ use OCA\FederatedFileSharing\Notifications;
 use OCA\FederatedFileSharing\Notifier;
 use OCA\FederatedFileSharing\OCM\CloudFederationProviderFiles;
 use OCP\AppFramework\App;
-use OCP\GlobalScale\IConfig;
+
+use OCP\GlobalScale\IConfig as IGlobalScaleConfig;
 
 class Application extends App {
 
@@ -68,6 +69,7 @@ class Application extends App {
 					$server->getURLGenerator(),
 					$server->getCloudFederationFactory(),
 					$server->getCloudFederationProviderManager(),
+					$server->query(IGlobalScaleConfig::class),
 					$server->getDatabaseConnection(),
 					$server->getGroupManager()
 				);
@@ -109,7 +111,7 @@ class Application extends App {
 		$federatedShareProvider = $this->getFederatedShareProvider();
 
 		$manager->registerNotifierService(Notifier::class);
-		
+
 		$eventDispatcher->addListener(
 			'OCA\Files::loadAdditionalScripts',
 			function() use ($federatedShareProvider) {
@@ -166,7 +168,7 @@ class Application extends App {
 			\OC::$server->getConfig(),
 			\OC::$server->getUserManager(),
 			\OC::$server->getCloudIdManager(),
-			$c->query(IConfig::class),
+			$c->query(IGlobalScaleConfig::class),
 			\OC::$server->getCloudFederationProviderManager()
 
 		);

--- a/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php
+++ b/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php
@@ -196,6 +196,10 @@ class MountPublicLinkController extends Controller {
 
 		$cloudId = $this->cloudIdManager->getCloudId($this->userSession->getUser()->getUID(), $this->addressHandler->generateRemoteURL());
 
+		if (!$this->federatedShareProvider->allowedIncomingFederation($cloudId->getRemote(), $token, $password)) {
+			return new JSONResponse(['message' => $this->l->t('Server to server sharing is only available internally')], Http::STATUS_BAD_REQUEST);
+		}
+
 		$httpClient = $this->clientService->newClient();
 
 		try {

--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -146,6 +146,7 @@ class RequestHandlerController extends OCSController {
 		$remoteId = isset($_POST['remoteId']) ? (int)$_POST['remoteId'] : null;
 		$sharedByFederatedId = isset($_POST['sharedByFederatedId']) ? $_POST['sharedByFederatedId'] : null;
 		$ownerFederatedId = isset($_POST['ownerFederatedId']) ? $_POST['ownerFederatedId'] : null;
+		$password = isset($_POST['password']) ? $_POST['password'] : '';
 
 		if ($ownerFederatedId === null) {
 			$ownerFederatedId = $this->cloudIdManager->getCloudId($owner, $this->cleanupRemote($remote))->getId();
@@ -167,7 +168,8 @@ class RequestHandlerController extends OCSController {
 			$sharedBy,
 			$token,
 			'user',
-			'file'
+			'file',
+			$password
 		);
 
 		try {

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -40,6 +40,7 @@ use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
+use OCP\GlobalScale\IConfig as IGlobalScaleConfig;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
@@ -92,7 +93,7 @@ class FederatedShareProvider implements IShareProvider {
 	/** @var ICloudIdManager */
 	private $cloudIdManager;
 
-	/** @var \OCP\GlobalScale\IConfig */
+	/** @var IGlobalScaleConfig */
 	private $gsConfig;
 
 	/** @var ICloudFederationProviderManager */
@@ -114,22 +115,22 @@ class FederatedShareProvider implements IShareProvider {
 	 * @param IConfig $config
 	 * @param IUserManager $userManager
 	 * @param ICloudIdManager $cloudIdManager
-	 * @param \OCP\GlobalScale\IConfig $globalScaleConfig
+	 * @param IGlobalScaleConfig $globalScaleConfig
 	 * @param ICloudFederationProviderManager $cloudFederationProviderManager
 	 */
 	public function __construct(
-			IDBConnection $connection,
-			AddressHandler $addressHandler,
-			Notifications $notifications,
-			TokenHandler $tokenHandler,
-			IL10N $l10n,
-			ILogger $logger,
-			IRootFolder $rootFolder,
-			IConfig $config,
-			IUserManager $userManager,
-			ICloudIdManager $cloudIdManager,
-			\OCP\GlobalScale\IConfig $globalScaleConfig,
-			ICloudFederationProviderManager $cloudFederationProviderManager
+		IDBConnection $connection,
+		AddressHandler $addressHandler,
+		Notifications $notifications,
+		TokenHandler $tokenHandler,
+		IL10N $l10n,
+		ILogger $logger,
+		IRootFolder $rootFolder,
+		IConfig $config,
+		IUserManager $userManager,
+		ICloudIdManager $cloudIdManager,
+		IGlobalScaleConfig $globalScaleConfig,
+		ICloudFederationProviderManager $cloudFederationProviderManager
 	) {
 		$this->dbConnection = $connection;
 		$this->addressHandler = $addressHandler;
@@ -193,8 +194,16 @@ class FederatedShareProvider implements IShareProvider {
 		}
 
 
-		// don't allow federated shares if source and target server are the same
 		$cloudId = $this->cloudIdManager->resolveCloudId($shareWith);
+		// check that cloudId is an allowed recipient
+		if (!$this->allowedOutgoingFederation($cloudId->getRemote())) {
+			$message = 'Not allowed to create a federated share outside of the internal GlobalScale.';
+			$message_t = $this->l->t($message);
+			$this->logger->debug($message, ['app' => 'Federated File Sharing']);
+			throw new \Exception($message_t);
+		}
+
+		// don't allow federated shares if source and target server are the same
 		$currentServer = $this->addressHandler->generateRemoteURL();
 		$currentUser = $sharedBy;
 		if ($this->addressHandler->compareAddresses($cloudId->getUser(), $cloudId->getRemote(), $currentUser, $currentServer)) {
@@ -274,6 +283,14 @@ class FederatedShareProvider implements IShareProvider {
 				$sharedByFederatedId = $cloudId->getId();
 			}
 			$ownerCloudId = $this->cloudIdManager->getCloudId($share->getShareOwner(), $this->addressHandler->generateRemoteURL());
+			// if in GS and recipient is internal, generate password
+			list(, $remote) = $this->addressHandler->splitUserRemote($share->getSharedWith());
+			$password = '';
+			if ($this->gsConfig->remoteIsInternal($remote)) {
+				$password = $this->gsConfig->generateInternalKey($token);
+			}
+			$share->setPassword($password);
+
 			$send = $this->notifications->sendRemoteShare(
 				$token,
 				$share->getSharedWith(),
@@ -283,7 +300,8 @@ class FederatedShareProvider implements IShareProvider {
 				$ownerCloudId->getId(),
 				$share->getSharedBy(),
 				$sharedByFederatedId,
-				$share->getShareType()
+				$share->getShareType(),
+				$share->getPassword()
 			);
 
 			if ($send === false) {
@@ -977,13 +995,16 @@ class FederatedShareProvider implements IShareProvider {
 	/**
 	 * check if users from other Nextcloud instances are allowed to mount public links share by this instance
 	 *
+	 * @param string $remote
+	 *
 	 * @return bool
 	 */
 	public function isOutgoingServer2serverShareEnabled() {
-		if ($this->gsConfig->onlyInternalFederation()) {
-			return false;
+		if ($this->gsConfig->onlyInternalFederation(IGlobalScaleConfig::OUTGOING)) {
+			return true;
 		}
 		$result = $this->config->getAppValue('files_sharing', 'outgoing_server2server_share_enabled', 'yes');
+
 		return ($result === 'yes');
 	}
 
@@ -993,10 +1014,11 @@ class FederatedShareProvider implements IShareProvider {
 	 * @return bool
 	 */
 	public function isIncomingServer2serverShareEnabled() {
-		if ($this->gsConfig->onlyInternalFederation()) {
-			return false;
+		if ($this->gsConfig->onlyInternalFederation(IGlobalScaleConfig::INCOMING)) {
+			return true;
 		}
 		$result = $this->config->getAppValue('files_sharing', 'incoming_server2server_share_enabled', 'yes');
+
 		return ($result === 'yes');
 	}
 
@@ -1007,10 +1029,11 @@ class FederatedShareProvider implements IShareProvider {
 	 * @return bool
 	 */
 	public function isOutgoingServer2serverGroupShareEnabled() {
-		if ($this->gsConfig->onlyInternalFederation()) {
-			return false;
+		if ($this->gsConfig->onlyInternalFederation(IGlobalScaleConfig::OUTGOING)) {
+			return true;
 		}
 		$result = $this->config->getAppValue('files_sharing', 'outgoing_server2server_group_share_enabled', 'no');
+
 		return ($result === 'yes');
 	}
 
@@ -1020,12 +1043,38 @@ class FederatedShareProvider implements IShareProvider {
 	 * @return bool
 	 */
 	public function isIncomingServer2serverGroupShareEnabled() {
-		if ($this->gsConfig->onlyInternalFederation()) {
-			return false;
+		if ($this->gsConfig->onlyInternalFederation(IGlobalScaleConfig::INCOMING)) {
+			return true;
 		}
 		$result = $this->config->getAppValue('files_sharing', 'incoming_server2server_group_share_enabled', 'no');
+
 		return ($result === 'yes');
 	}
+
+
+	/**
+	 * @param string $remote
+	 *
+	 * @return bool
+	 * @since 19.0.0
+	 */
+	public function allowedOutgoingFederation(string $remote) {
+		return $this->gsConfig->allowedOutgoingFederation($remote);
+	}
+
+
+	/**
+	 * @param string $token
+	 * @param string $key
+	 * @param string $remote
+	 *
+	 * @return bool
+	 * @since 19.0.0
+	 */
+	public function allowedIncomingFederation(string $remote, string $token, string $key): bool {
+		return $this->gsConfig->allowedIncomingFederation($remote, $token, $key);
+	}
+
 
 	/**
 	 * check if federated group sharing is supported, therefore the OCM API need to be enabled
@@ -1047,6 +1096,7 @@ class FederatedShareProvider implements IShareProvider {
 			return true;
 		}
 		$result = $this->config->getAppValue('files_sharing', 'lookupServerEnabled', 'no');
+
 		return ($result === 'yes');
 	}
 
@@ -1062,6 +1112,7 @@ class FederatedShareProvider implements IShareProvider {
 			return false;
 		}
 		$result = $this->config->getAppValue('files_sharing', 'lookupServerUploadEnabled', 'yes');
+
 		return ($result === 'yes');
 	}
 
@@ -1130,4 +1181,5 @@ class FederatedShareProvider implements IShareProvider {
 		}
 		$cursor->closeCursor();
 	}
+
 }

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -88,11 +88,13 @@ class Notifications {
 	 * @param string $sharedBy
 	 * @param string $sharedByFederatedId
 	 * @param int $shareType (can be a remote user or group share)
+	 * @param string $password (used to confirm that share is internal to GS)
+	 *
 	 * @return bool
 	 * @throws \OC\HintException
 	 * @throws \OC\ServerNotAvailableException
 	 */
-	public function sendRemoteShare($token, $shareWith, $name, $remote_id, $owner, $ownerFederatedId, $sharedBy, $sharedByFederatedId, $shareType) {
+	public function sendRemoteShare($token, $shareWith, $name, $remote_id, $owner, $ownerFederatedId, $sharedBy, $sharedByFederatedId, $shareType, string $password = '') {
 
 		list($user, $remote) = $this->addressHandler->splitUserRemote($shareWith);
 
@@ -109,7 +111,8 @@ class Notifications {
 				'sharedBy' => $sharedBy,
 				'sharedByFederatedId' => $sharedByFederatedId,
 				'remote' => $local,
-				'shareType' => $shareType
+				'shareType' => $shareType,
+				'password' => $password
 			);
 
 			$result = $this->tryHttpPostToShareEndpoint($remote, '', $fields);
@@ -394,7 +397,8 @@ class Notifications {
 					$fields['sharedBy'],
 					$fields['token'],
 					$fields['shareType'],
-					'file'
+					'file',
+					''
 				);
 				return $this->federationProviderManager->sendShare($share);
 			case 'reshare':

--- a/apps/federatedfilesharing/lib/Settings/Admin.php
+++ b/apps/federatedfilesharing/lib/Settings/Admin.php
@@ -27,7 +27,7 @@ namespace OCA\FederatedFileSharing\Settings;
 
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCP\AppFramework\Http\TemplateResponse;
-use OCP\GlobalScale\IConfig;
+use OCP\GlobalScale\IConfig as IGlobalScaleConfig;
 use OCP\Settings\ISettings;
 
 class Admin implements ISettings {
@@ -35,16 +35,16 @@ class Admin implements ISettings {
 	/** @var FederatedShareProvider */
 	private $fedShareProvider;
 
-	/** @var IConfig */
+	/** @var IGlobalScaleConfig */
 	private $gsConfig;
 
 	/**
 	 * Admin constructor.
 	 *
 	 * @param FederatedShareProvider $fedShareProvider
-	 * @param IConfig $globalScaleConfig
+	 * @param IGlobalScaleConfig $globalScaleConfig
 	 */
-	public function __construct(FederatedShareProvider $fedShareProvider, IConfig $globalScaleConfig) {
+	public function __construct(FederatedShareProvider $fedShareProvider, IGlobalScaleConfig $globalScaleConfig) {
 		$this->fedShareProvider = $fedShareProvider;
 		$this->gsConfig = $globalScaleConfig;
 	}
@@ -55,7 +55,8 @@ class Admin implements ISettings {
 	public function getForm() {
 
 		$parameters = [
-			'internalOnly' => $this->gsConfig->onlyInternalFederation(),
+			'incomingInternalOnly' => $this->gsConfig->onlyInternalFederation(IGlobalScaleConfig::INCOMING),
+			'outgoingInternalOnly' => $this->gsConfig->onlyInternalFederation(IGlobalScaleConfig::OUTGOING),
 			'outgoingServer2serverShareEnabled' => $this->fedShareProvider->isOutgoingServer2serverShareEnabled(),
 			'incomingServer2serverShareEnabled' => $this->fedShareProvider->isIncomingServer2serverShareEnabled(),
 			'federatedGroupSharingSupported' => $this->fedShareProvider->isFederatedGroupSharingSupported(),

--- a/apps/federatedfilesharing/templates/settings-admin.php
+++ b/apps/federatedfilesharing/templates/settings-admin.php
@@ -5,7 +5,7 @@ script('federatedfilesharing', 'settings-admin');
 style('federatedfilesharing', 'settings-admin');
 ?>
 
-<?php if($_['internalOnly'] === false): ?>
+<?php if($_['outgoingInternalOnly'] === false || $_['incomingInternalOnly'] === false): ?>
 
 <div id="fileSharingSettings" class="section">
 	<h2>
@@ -17,6 +17,7 @@ style('federatedfilesharing', 'settings-admin');
 
 	<p class="settings-hint"><?php p($l->t('Adjust how people can share between servers.')); ?></p>
 
+	<?php if($_['outgoingInternalOnly'] === false): ?>
 	<p>
 		<input type="checkbox" name="outgoing_server2server_share_enabled" id="outgoingServer2serverShareEnabled" class="checkbox"
 			   value="1" <?php if ($_['outgoingServer2serverShareEnabled']) print_unescaped('checked="checked"'); ?> />
@@ -24,6 +25,9 @@ style('federatedfilesharing', 'settings-admin');
 			<?php p($l->t('Allow users on this server to send shares to other servers'));?>
 		</label>
 	</p>
+	<?php endif; ?>
+
+	<?php if($_['incomingInternalOnly'] === false): ?>
 	<p>
 		<input type="checkbox" name="incoming_server2server_share_enabled" id="incomingServer2serverShareEnabled" class="checkbox"
 			   value="1" <?php if ($_['incomingServer2serverShareEnabled']) print_unescaped('checked="checked"'); ?> />
@@ -31,7 +35,10 @@ style('federatedfilesharing', 'settings-admin');
 			<?php p($l->t('Allow users on this server to receive shares from other servers'));?>
 		</label><br/>
 	</p>
+	<?php endif; ?>
+
 	<?php if($_['federatedGroupSharingSupported']): ?>
+	<?php if($_['outgoingInternalOnly'] === false): ?>
 	<p>
 		<input type="checkbox" name="outgoing_server2server_group_share_enabled" id="outgoingServer2serverGroupShareEnabled" class="checkbox"
 			   value="1" <?php if ($_['outgoingServer2serverGroupShareEnabled']) print_unescaped('checked="checked"'); ?> />
@@ -39,6 +46,8 @@ style('federatedfilesharing', 'settings-admin');
 			<?php p($l->t('Allow users on this server to send shares to groups on other servers'));?>
 		</label>
 	</p>
+	<?php endif; ?>
+	<?php if($_['incomingInternalOnly'] === false): ?>
 	<p>
 		<input type="checkbox" name="incoming_server2server_group_share_enabled" id="incomingServer2serverGroupShareEnabled" class="checkbox"
 			   value="1" <?php if ($_['incomingServer2serverGroupShareEnabled']) print_unescaped('checked="checked"'); ?> />
@@ -47,6 +56,7 @@ style('federatedfilesharing', 'settings-admin');
 		</label><br/>
 	</p>
 	<?php endif; ?>
+	<?php endif; ?>
 	<p>
 		<input type="checkbox" name="lookupServerEnabled" id="lookupServerEnabled" class="checkbox"
 			   value="1" <?php if ($_['lookupServerEnabled']) print_unescaped('checked="checked"'); ?> />
@@ -54,6 +64,7 @@ style('federatedfilesharing', 'settings-admin');
 			<?php p($l->t('Search global and public address book for users'));?>
 		</label><br/>
 	</p>
+	<?php if($_['outgoingInternalOnly'] === false): ?>
 	<p>
 		<input type="checkbox" name="lookupServerUploadEnabled" id="lookupServerUploadEnabled" class="checkbox"
 			   value="1" <?php if ($_['lookupServerUploadEnabled']) print_unescaped('checked="checked"'); ?> />
@@ -61,6 +72,7 @@ style('federatedfilesharing', 'settings-admin');
 			<?php p($l->t('Allow users to publish their data to a global and public address book'));?>
 		</label><br/>
 	</p>
+	<?php endif; ?>
 
 </div>
 

--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -36,7 +36,6 @@ use OCA\Files_Sharing\Capabilities;
 use OCA\Files_Sharing\Controller\ExternalSharesController;
 use OCA\Files_Sharing\Controller\ShareController;
 use OCA\Files_Sharing\External\Manager;
-use OCA\Files_Sharing\Listener\GlobalShareAcceptanceListener;
 use OCA\Files_Sharing\Listener\LoadAdditionalListener;
 use OCA\Files_Sharing\Listener\LoadSidebarListener;
 use OCA\Files_Sharing\Listener\UserShareAcceptanceListener;
@@ -54,6 +53,7 @@ use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\ICloudIdManager;
 use OCP\Files\Config\IMountProviderCollection;
+use OCP\GlobalScale\IConfig as IGlobalScaleConfig;
 use OCP\IContainer;
 use OCP\IGroup;
 use OCP\IServerContainer;
@@ -131,6 +131,7 @@ class Application extends App {
 				$server->query(\OCP\OCS\IDiscoveryService::class),
 				$server->getCloudFederationProviderManager(),
 				$server->getCloudFederationFactory(),
+				$server->query(IGlobalScaleConfig::class),
 				$server->getGroupManager(),
 				$server->getUserManager(),
 				$uid

--- a/apps/files_sharing/lib/External/MountProvider.php
+++ b/apps/files_sharing/lib/External/MountProvider.php
@@ -38,7 +38,7 @@ class MountProvider implements IMountProvider {
 	private $connection;
 
 	/**
-	 * @var callable
+	 * @var Manager
 	 */
 	private $managerProvider;
 
@@ -67,6 +67,7 @@ class MountProvider implements IMountProvider {
 		$data['cloudId'] = $this->cloudIdManager->getCloudId($data['owner'], $data['remote']);
 		$data['certificateManager'] = \OC::$server->getCertificateManager($user->getUID());
 		$data['HttpClientService'] = \OC::$server->getHTTPClientService();
+		$data['password'] = $manager->generateGSPassword($data['token'], $data['remote']);
 		return new Mount(self::STORAGE, $mountPoint, $data, $manager, $storageFactory);
 	}
 

--- a/lib/private/Federation/CloudFederationFactory.php
+++ b/lib/private/Federation/CloudFederationFactory.php
@@ -43,12 +43,14 @@ class CloudFederationFactory implements ICloudFederationFactory {
 	 * @param string $sharedSecret used to authenticate requests across servers
 	 * @param string $shareType ('group' or 'user' share)
 	 * @param $resourceType ('file', 'calendar',...)
+	 * @param $password
+	 *
 	 * @return ICloudFederationShare
 	 *
 	 * @since 14.0.0
 	 */
-	public function getCloudFederationShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $sharedSecret, $shareType, $resourceType) {
-		return new CloudFederationShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $shareType, $resourceType, $sharedSecret);
+	public function getCloudFederationShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $sharedSecret, $shareType, $resourceType, $password) {
+		return new CloudFederationShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $shareType, $resourceType, $sharedSecret, $password);
 	}
 
 	/**

--- a/lib/private/Federation/CloudFederationShare.php
+++ b/lib/private/Federation/CloudFederationShare.php
@@ -38,6 +38,7 @@ class CloudFederationShare implements ICloudFederationShare {
 		'ownerDisplayName' => '',
 		'sharedBy' => '',
 		'sharedByDisplayName' => '',
+		'password' => '',
 		'protocol' => []
 	];
 
@@ -55,6 +56,7 @@ class CloudFederationShare implements ICloudFederationShare {
 	 * @param string $shareType ('group' or 'user' share)
 	 * @param string $resourceType ('file', 'calendar',...)
 	 * @param string $sharedSecret
+	 * @param string $password
 	 */
 	public function __construct($shareWith = '',
 								$name = '',
@@ -66,7 +68,8 @@ class CloudFederationShare implements ICloudFederationShare {
 								$sharedByDisplayName = '',
 								$shareType = '',
 								$resourceType = '',
-								$sharedSecret = ''
+								$sharedSecret = '',
+								$password = ''
 	) {
 		$this->setShareWith($shareWith);
 		$this->setResourceName($name);
@@ -85,7 +88,7 @@ class CloudFederationShare implements ICloudFederationShare {
 		]);
 		$this->setShareType($shareType);
 		$this->setResourceType($resourceType);
-
+		$this->setPassword($password);
 	}
 
 	/**
@@ -212,6 +215,17 @@ class CloudFederationShare implements ICloudFederationShare {
 			$this->share['shareType'] = 'user';
 		}
 	}
+
+
+	/**
+	 * @param $password
+	 *
+	 * @since 19.0.0
+	 */
+	public function setPassword($password) {
+		$this->share['password'] = $password;
+	}
+
 
 	/**
 	 * get the whole share, ready to send out
@@ -355,4 +369,15 @@ class CloudFederationShare implements ICloudFederationShare {
 	public function getProtocol() {
 		return $this->share['protocol'];
 	}
+
+
+	/**
+	 * get password
+	 *
+	 * @return string
+	 */
+	public function getPassword(): string {
+		return $this->share['password'];
+	}
+
 }

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1232,7 +1232,7 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 
 		$this->registerService(IConfig::class, function (Server $c) {
-			return new GlobalScale\Config($c->getConfig());
+			return new GlobalScale\Config($c->getHTTPClientService(), $c->getConfig());
 		});
 
 		$this->registerService(ICloudFederationProviderManager::class, function (Server $c) {

--- a/lib/public/Federation/ICloudFederationFactory.php
+++ b/lib/public/Federation/ICloudFederationFactory.php
@@ -46,11 +46,13 @@ interface ICloudFederationFactory {
 	 * @param string $sharedSecret used to authenticate requests across servers
 	 * @param string $shareType ('group' or 'user' share)
 	 * @param $resourceType ('file', 'calendar',...)
+	 * @param $password
+	 *
 	 * @return ICloudFederationShare
 	 *
 	 * @since 14.0.0
 	 */
-	public function getCloudFederationShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $sharedSecret, $shareType, $resourceType);
+	public function getCloudFederationShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $sharedSecret, $shareType, $resourceType, $password);
 
 	/**
 	 * get a Cloud FederationNotification object to prepare a notification you

--- a/lib/public/Federation/ICloudFederationShare.php
+++ b/lib/public/Federation/ICloudFederationShare.php
@@ -249,4 +249,15 @@ interface ICloudFederationShare {
 	 */
 	public function getProtocol();
 
+
+	/**
+	 * return password
+	 *
+	 * @return string
+	 *
+	 * @since 19.0.0
+	 */
+	public function getPassword(): string;
+
 }
+

--- a/lib/public/GlobalScale/IConfig.php
+++ b/lib/public/GlobalScale/IConfig.php
@@ -33,20 +33,76 @@ namespace OCP\GlobalScale;
  */
 interface IConfig {
 
+
+	const INCOMING = 'incoming';
+	const OUTGOING = 'outgoing';
+
+
 	/**
 	 * check if global scale is enabled
 	 *
-	 * @since 12.0.1
 	 * @return bool
+	 * @since 12.0.1
 	 */
 	public function isGlobalScaleEnabled();
 
 	/**
 	 * check if federation should only be used internally in a global scale setup
 	 *
+	 * @param string $type since 19.0.0
+	 *
+	 * @return bool
 	 * @since 12.0.1
+	 */
+	public function onlyInternalFederation(string $type);
+
+
+	/**
+	 * check if the outgoing federation is allowed, based on the $remote address
+	 * If $token+$key is provided, only check the $token+$key (mainly for reading file purpose)
+	 *
+	 * @param string $remote
+	 * @param string $token
+	 * @param string $key
+	 *
+	 * @return bool
+	 * @since 19.0.0
+	 */
+	public function allowedOutgoingFederation(string $remote, string $token = '', string $key = ''): bool;
+
+
+	/**
+	 * check if the incoming federation is allowed, based on the $token+$key.
+	 * ~! If $remote is provided, only check the $remote (mainly for re-share purposing) !~
+	 *
+	 * @param string $remote
+	 * @param string $token
+	 * @param string $key
+	 *
+	 * @return bool
+	 * @since 19.0.0
+	 */
+	public function allowedIncomingFederation(string $remote, string $token, string $key): bool;
+
+
+	/**
+	 * generate the key to confirm internal federation.
+	 *
+	 * @param $token
+	 *
+	 * @return string
+	 */
+	public function generateInternalKey(string $token): string;
+
+
+	/**
+	 * check that remote instance is internal.
+	 *
+	 * @param string $remote
+	 *
 	 * @return bool
 	 */
-	public function onlyInternalFederation();
+	public function remoteIsInternal(string $remote): bool;
 
 }
+


### PR DESCRIPTION
This is a long awaited feature: having `gs.federation = 'internal'` working.
In a **GlobalScale** setup, in order to have its users being able to share files to users from another instance of Nextcloud, admin must enable the global federation shares. Meaning that it is not possible to enable the federation share only for _local_ instances defined within the lookup-server. 
As a side note, the value is currently 'internal' by default, meaning that if the admin does not set the `gs.federation` to `'external'` (and open the federated shares to the outside), shares between local instances of GS are not available. This PR respects the default value.

This PR will allow to manage those entries in `config/config.php`:

`gs.federation = 'internal'`  
_to limit all shares only to local instances of the GS._

`gs.federation.incoming = 'internal'`  
_to limit incoming shares only to local instances of the GS_

`gs.federation.outgoing = 'internal'`  
_to limit incoming shares only to local instances of the GS_

### How is it working:

- if the config is set to internal, federated shares a allowed without checking the settings related to federated shares.

- When creating a federated shares, if the outgoing shares is limited to internal, we check that the address of the remote recipient is considered as local before initiating the generation of the federated share. 

- To avoid some spoofing from an external request, a password is added to the share during the exchange, but not stored. The password is based on the token of the share and the jwt key from the `config/config.php`. The password is added regardless of the limitation to internal outgoing shares, as long as the address of the recipient is known by the lookup-server.

- When receiving a federated share, if the incoming shares is limited to internal, we compare the password of the share.

This way, every instances of the GlobalScale setup can have their own setup regarding internal/external federated shares.


### WIP

Tests are not yet implemented, this edit affect so many files and test might ask for a lot of work, please review and confirm the concept first.


### dependencies

To retrieve the local instances of a LUS: https://github.com/nextcloud/lookup-server/pull/43
