### PR TITLE
Make TAG_FAVORITE public

### DIFF
--- a/apps/files/lib/Service/TagService.php
+++ b/apps/files/lib/Service/TagService.php
@@ -24,7 +24,6 @@
 
 namespace OCA\Files\Service;
 
-use OC\Tags;
 use OCA\Files\Activity\FavoriteProvider;
 use OCP\Activity\IManager;
 use OCP\Files\Folder;
@@ -92,14 +91,14 @@ class TagService {
 
 		$newTags = array_diff($tags, $currentTags);
 		foreach ($newTags as $tag) {
-			if ($tag === Tags::TAG_FAVORITE) {
+			if ($tag === ITags::TAG_FAVORITE) {
 				$this->addActivity(true, $fileId, $path);
 			}
 			$this->tagger->tagAs($fileId, $tag);
 		}
 		$deletedTags = array_diff($currentTags, $tags);
 		foreach ($deletedTags as $tag) {
-			if ($tag === Tags::TAG_FAVORITE) {
+			if ($tag === ITags::TAG_FAVORITE) {
 				$this->addActivity(false, $fileId, $path);
 			}
 			$this->tagger->unTag($fileId, $tag);

--- a/apps/files/tests/Service/TagServiceTest.php
+++ b/apps/files/tests/Service/TagServiceTest.php
@@ -25,9 +25,9 @@
 
 namespace OCA\Files\Tests\Service;
 
-use OC\Tags;
 use OCA\Files\Service\TagService;
 use OCP\Activity\IManager;
+use OCP\ITags;
 use OCP\IUser;
 use OCP\IUserSession;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -172,7 +172,7 @@ class TagServiceTest extends \Test\TestCase {
 			);
 
 		// set tags
-		$this->tagService->updateFileTags('subdir/test.txt', [Tags::TAG_FAVORITE]);
+		$this->tagService->updateFileTags('subdir/test.txt', [ITags::TAG_FAVORITE]);
 
 		// remove tag
 		$this->tagService->updateFileTags('subdir/test.txt', []);

--- a/lib/private/Tags.php
+++ b/lib/private/Tags.php
@@ -48,8 +48,9 @@ use OC\Tagging\Tag;
 use OC\Tagging\TagMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\ILogger;
+use OCP\ITags;
 
-class Tags implements \OCP\ITags {
+class Tags implements ITags {
 
 	/**
 	 * Tags
@@ -111,8 +112,6 @@ class Tags implements \OCP\ITags {
 
 	const TAG_TABLE = '*PREFIX*vcategory';
 	const RELATION_TABLE = '*PREFIX*vcategory_to_object';
-
-	const TAG_FAVORITE = '_$!<Favorite>!$_';
 
 	/**
 	* Constructor.
@@ -186,7 +185,7 @@ class Tags implements \OCP\ITags {
 		$tagMap = array();
 
 		foreach($this->tags as $tag) {
-			if($tag->getName() !== self::TAG_FAVORITE) {
+			if($tag->getName() !== ITags::TAG_FAVORITE) {
 				$tagMap[] = $this->tagMap($tag);
 			}
 		}
@@ -624,12 +623,12 @@ class Tags implements \OCP\ITags {
 	* @return array|false An array of object ids.
 	*/
 	public function getFavorites() {
-		if(!$this->userHasTag(self::TAG_FAVORITE, $this->user)) {
+		if(!$this->userHasTag(ITags::TAG_FAVORITE, $this->user)) {
 			return [];
 		}
 
 		try {
-			return $this->getIdsForTag(self::TAG_FAVORITE);
+			return $this->getIdsForTag(ITags::TAG_FAVORITE);
 		} catch(\Exception $e) {
 			\OC::$server->getLogger()->logException($e, [
 				'message' => __METHOD__,
@@ -647,10 +646,10 @@ class Tags implements \OCP\ITags {
 	* @return boolean
 	*/
 	public function addToFavorites($objid) {
-		if(!$this->userHasTag(self::TAG_FAVORITE, $this->user)) {
-			$this->add(self::TAG_FAVORITE);
+		if(!$this->userHasTag(ITags::TAG_FAVORITE, $this->user)) {
+			$this->add(ITags::TAG_FAVORITE);
 		}
-		return $this->tagAs($objid, self::TAG_FAVORITE);
+		return $this->tagAs($objid, ITags::TAG_FAVORITE);
 	}
 
 	/**
@@ -660,7 +659,7 @@ class Tags implements \OCP\ITags {
 	* @return boolean
 	*/
 	public function removeFromFavorites($objid) {
-		return $this->unTag($objid, self::TAG_FAVORITE);
+		return $this->unTag($objid, ITags::TAG_FAVORITE);
 	}
 
 	/**

--- a/lib/public/ITags.php
+++ b/lib/public/ITags.php
@@ -53,6 +53,10 @@ use OC\Tags;
  */
 
 interface ITags {
+	/**
+	 * @since 19.0.0
+	 */
+	public const TAG_FAVORITE = '_$!<Favorite>!$_';
 
 	/**
 	 * Check if any tags are saved for this type and user.


### PR DESCRIPTION
Fix #19404 

Actually PHPStorm did most of the work ;)

I need some advice regarding: https://github.com/nextcloud/server/pull/19412/files#diff-285a829dbb3541adc9e8ee65266f70aeR188 PHPStorm replaced `self::TAG_FAVORITE` with `ITags::TAG_FAVORITE` in `OC\Tags`. `OC\Tags` implements `ITags` hence the constants are available. Is `self::CONSTANT_NAME` some kind of anti pattern? 
