### PR TITLE
18.0.1 final

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(18, 0, 1, 2);
+$OC_Version = array(18, 0, 1, 3);
 
 // The human readable string
-$OC_VersionString = '18.0.1 RC3';
+$OC_VersionString = '18.0.1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #19420 [stable18] Allow to serve static webm directly
* #19428 [stable18] Allow to serve static mp4 directly
* [notifications#565](https://github.com/nextcloud/notifications/pull/565) [stable18] Support Strict VoIP push notifications for iOS 13 SDK
* [viewer#396](https://github.com/nextcloud/viewer/pull/396) [stable18] Revert "Fix url escaping"
