### PR TITLE
Don't create invalid users

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1392,7 +1392,7 @@ class View {
 			}
 			$ownerId = $storage->getOwner($internalPath);
 			$owner = null;
-			if ($ownerId !== null) {
+			if ($ownerId !== null && $ownerId !== false) {
 				// ownerId might be null if files are accessed with an access token without file system access
 				$owner = $this->getUserObjectForOwner($ownerId);
 			}


### PR DESCRIPTION
Some storages return false on `getOwner`, which means we create a user object with userid `''` instead of keeping null as an owner

* https://github.com/nextcloud/server/blob/5bf3d1bb384da56adbf205752be8f840aac3b0c5/lib/private/Files/Storage/Common.php#L405
* https://github.com/nextcloud/groupfolders/blob/b5b26aecdc5bc3c82039387812851797f312a6db/lib/Mount/GroupFolderStorage.php#L54
