### PR TITLE
Show proper file name when fetching details fails

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2949,8 +2949,8 @@
 					deferred.resolve(status, data);
 				})
 				.fail(function(status) {
-					OC.Notification.show(t('files', 'Could not create file "{file}"',
-						{file: name}), {type: 'error'}
+					OCP.Toast.error(
+						t('files', 'Could not fetch file details "{file}"', { file: fileName })
 					);
 					deferred.reject(status);
 				});


### PR DESCRIPTION
The parameter is called `fileName` instead of `name`

https://github.com/nextcloud/server/blob/af4139ce64fe620327d856c36c79cb7d82f8cdc2/apps/files/js/filelist.js#L2920