### PR TITLE
Fix installing Talk due to hardcoded route

### DIFF
--- a/lib/private/AppFramework/App.php
+++ b/lib/private/AppFramework/App.php
@@ -68,8 +68,19 @@ class App {
 		if (isset($appInfo['namespace'])) {
 			self::$nameSpaceCache[$appId] = trim($appInfo['namespace']);
 		} else {
-			// if the tag is not found, fall back to uppercasing the first letter
-			self::$nameSpaceCache[$appId] = ucfirst($appId);
+			if ($appId !== 'spreed') {
+				// if the tag is not found, fall back to uppercasing the first letter
+				self::$nameSpaceCache[$appId] = ucfirst($appId);
+			} else {
+				// For the Talk app (appid spreed) the above fallback doesn't work.
+				// This leads to a problem when trying to install it freshly,
+				// because the apps namespace is already registered before the
+				// app is downloaded from the appstore, because of the hackish
+				// global route index.php/call/{token} which is registered via
+				// the core/routes.php so it does not have the app namespace.
+				// @ref https://github.com/nextcloud/server/pull/19433
+				self::$nameSpaceCache[$appId] = 'Talk';
+			}
 		}
 
 		return $topNamespace . self::$nameSpaceCache[$appId];


### PR DESCRIPTION
Due to the hardcoded routes in https://github.com/nextcloud/server/blob/302558cfd2b3dd37e6332c0d9c650174b64f20fb/core/routes.php#L98-L99 the spreed appid is registered with the namespace `Spreed` when it is not installed.

Now when the app is installed, it breaks because it tries to find the migration files in the MigrationService as it is searching with the wrong namespace because it was setup with the broken namespace. 

Fix https://github.com/nextcloud/spreed/issues/2806