### PR TITLE
Do not include mountpoints when calculating quota usage on WebDAV

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -326,7 +326,8 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node implements \Sabre\DAV\ICol
 			return $this->quotaInfo;
 		}
 		try {
-			$storageInfo = \OC_Helper::getStorageInfo($this->info->getPath(), $this->info);
+			$info = $this->fileView->getFileInfo($this->path, false);
+			$storageInfo = \OC_Helper::getStorageInfo($this->info->getPath(), $info);
 			if ($storageInfo['quota'] === \OCP\Files\FileInfo::SPACE_UNLIMITED) {
 				$free = \OCP\Files\FileInfo::SPACE_UNLIMITED;
 			} else {

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -98,7 +98,7 @@ class DirectoryTest extends \Test\TestCase {
 		return new Directory($this->view, $this->info);
 	}
 
-	
+
 	public function testDeleteRootFolderFails() {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
@@ -111,7 +111,7 @@ class DirectoryTest extends \Test\TestCase {
 		$dir->delete();
 	}
 
-	
+
 	public function testDeleteForbidden() {
 		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\Forbidden::class);
 
@@ -130,7 +130,7 @@ class DirectoryTest extends \Test\TestCase {
 		$dir->delete();
 	}
 
-	
+
 	public function testDeleteFolderWhenAllowed() {
 		// deletion allowed
 		$this->info->expects($this->once())
@@ -147,7 +147,7 @@ class DirectoryTest extends \Test\TestCase {
 		$dir->delete();
 	}
 
-	
+
 	public function testDeleteFolderFailsWhenNotAllowed() {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
@@ -159,7 +159,7 @@ class DirectoryTest extends \Test\TestCase {
 		$dir->delete();
 	}
 
-	
+
 	public function testDeleteFolderThrowsWhenDeletionFailed() {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
@@ -217,7 +217,7 @@ class DirectoryTest extends \Test\TestCase {
 		$dir->getChildren();
 	}
 
-	
+
 	public function testGetChildrenNoPermission() {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
@@ -230,7 +230,7 @@ class DirectoryTest extends \Test\TestCase {
 		$dir->getChildren();
 	}
 
-	
+
 	public function testGetChildNoPermission() {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
@@ -242,7 +242,7 @@ class DirectoryTest extends \Test\TestCase {
 		$dir->getChild('test');
 	}
 
-	
+
 	public function testGetChildThrowStorageNotAvailableException() {
 		$this->expectException(\Sabre\DAV\Exception\ServiceUnavailable::class);
 
@@ -254,7 +254,7 @@ class DirectoryTest extends \Test\TestCase {
 		$dir->getChild('.');
 	}
 
-	
+
 	public function testGetChildThrowInvalidPath() {
 		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\InvalidPath::class);
 
@@ -295,6 +295,10 @@ class DirectoryTest extends \Test\TestCase {
 			->method('getStorage')
 			->willReturn($storage);
 
+		$this->view->expects($this->once())
+			->method('getFileInfo')
+			->willReturn($this->info);
+
 		$dir = new Directory($this->view, $this->info);
 		$this->assertEquals([200, -3], $dir->getQuotaInfo()); //200 used, unlimited
 	}
@@ -326,6 +330,10 @@ class DirectoryTest extends \Test\TestCase {
 		$this->info->expects($this->once())
 			->method('getStorage')
 			->willReturn($storage);
+
+		$this->view->expects($this->once())
+			->method('getFileInfo')
+			->willReturn($this->info);
 
 		$dir = new Directory($this->view, $this->info);
 		$this->assertEquals([200, 800], $dir->getQuotaInfo()); //200 used, 800 free
@@ -404,7 +412,7 @@ class DirectoryTest extends \Test\TestCase {
 		$this->assertTrue($targetNode->moveInto(basename($destination), $source, $sourceNode));
 	}
 
-	
+
 	public function testFailingMove() {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 		$this->expectExceptionMessage('Could not copy directory b, target exists');


### PR DESCRIPTION
Otherwise the quota calculation shown in the desktop client differs from how we calculate quota and show it in the web interface.

cc @misch7 as discussed