### PR TITLE
Fix filename and popover menu misalignment

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -59,7 +59,7 @@
 	position: relative;
 	width: 100%;
 	min-width: 250px;
-	display: flex;
+	display: block;
 	flex-direction: column;
 	// hide table if emptycontent is not hidden
 	#emptycontent:not(.hidden) ~ & {
@@ -76,6 +76,14 @@
 		z-index: 60;
 		display: block;
 		background-color: var(--color-main-background-translucent);
+	}
+
+	/**
+	 * This is a dirty hack as the sticky header requires us to use a different display type on the table element
+	 */
+	tbody {
+		display: table;
+		width: 100%;
 	}
 }
 
@@ -383,13 +391,12 @@ table {
 			width: 0;
 			flex-grow: 1;
 			display: flex;
-			padding: 0;
 			overflow: hidden;
 			white-space: nowrap;
 			text-overflow: ellipsis;
 			height: 100%;
 			z-index: 10;
-			padding-right: 20px;
+			padding: 0 20px 0 0;
 		}
 	}
 

--- a/apps/files/css/mobile.scss
+++ b/apps/files/css/mobile.scss
@@ -8,11 +8,6 @@ $min-table-width: 688px;
 	background-color: rgba(255, 255, 255, 1)!important;
 }
 
-#body-user #filestable {
-	min-width: 250px;
-	display: initial;
-}
-
 table th#headerSize,
 table td.filesize,
 table th#headerDate,


### PR DESCRIPTION
Dirty hack to fix the regression
before

![filepopover_bad](https://user-images.githubusercontent.com/12728974/74356014-f56de880-4dbd-11ea-92c6-d6732fbb7339.png)
After

![filepopovermenu](https://user-images.githubusercontent.com/12728974/74356017-f6067f00-4dbd-11ea-8afc-76612a4b18e2.png)
