### PR TITLE
Allow to overwrite the path on the cache event

### DIFF
--- a/lib/private/Files/Cache/AbstractCacheEvent.php
+++ b/lib/private/Files/Cache/AbstractCacheEvent.php
@@ -65,6 +65,14 @@ class AbstractCacheEvent extends Event implements ICacheEvent {
 	}
 
 	/**
+	 * @param string $path
+	 * @since 19.0.0
+	 */
+	public function setPath(string $path): void {
+		$this->path = $path;
+	}
+
+	/**
 	 * @return int
 	 * @since 16.0.0
 	 */

--- a/lib/public/Files/Cache/ICacheEvent.php
+++ b/lib/public/Files/Cache/ICacheEvent.php
@@ -45,6 +45,12 @@ interface ICacheEvent {
 	public function getPath(): string;
 
 	/**
+	 * @param string $path
+	 * @since 19.0.0
+	 */
+	public function setPath(string $path): void;
+
+	/**
 	 * @return int
 	 * @since 16.0.0
 	 */


### PR DESCRIPTION
Listening to the CacheEvent you currently get a full path that can not be found in any storage with groupfolders, because of the `__groupfolder/{id}/` prefix