### PR TITLE
when we receive intentional empty whats new info, do not try to show it

### DIFF
--- a/lib/private/Updater/ChangesCheck.php
+++ b/lib/private/Updater/ChangesCheck.php
@@ -55,7 +55,11 @@ class ChangesCheck {
 	public function getChangesForVersion(string $version): array {
 		$version = $this->normalizeVersion($version);
 		$changesInfo = $this->mapper->getChanges($version);
-		return json_decode($changesInfo->getData(), true);
+		$changesData = json_decode($changesInfo->getData(), true);
+		if(empty($changesData)) {
+			throw new DoesNotExistException();
+		}
+		return $changesData;
 	}
 
 	/**

--- a/tests/lib/Updater/ChangesCheckTest.php
+++ b/tests/lib/Updater/ChangesCheckTest.php
@@ -279,6 +279,10 @@ class ChangesCheckTest extends TestCase {
 					],
 				]
 			],
+			[ # 4 - empty
+				'',
+				[]
+			],
 		];
 	}
 


### PR DESCRIPTION
for https://github.com/nextcloud/changelog_server/pull/23, fixes a potential (though not critical) JS error 