### PR TITLE
Create SimpleFile only when writing the content

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -985,6 +985,7 @@ return array(
     'OC\\Files\\Search\\SearchComparison' => $baseDir . '/lib/private/Files/Search/SearchComparison.php',
     'OC\\Files\\Search\\SearchOrder' => $baseDir . '/lib/private/Files/Search/SearchOrder.php',
     'OC\\Files\\Search\\SearchQuery' => $baseDir . '/lib/private/Files/Search/SearchQuery.php',
+    'OC\\Files\\SimpleFS\\NewSimpleFile' => $baseDir . '/lib/private/Files/SimpleFS/NewSimpleFile.php',
     'OC\\Files\\SimpleFS\\SimpleFile' => $baseDir . '/lib/private/Files/SimpleFS/SimpleFile.php',
     'OC\\Files\\SimpleFS\\SimpleFolder' => $baseDir . '/lib/private/Files/SimpleFS/SimpleFolder.php',
     'OC\\Files\\Storage\\Common' => $baseDir . '/lib/private/Files/Storage/Common.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1014,6 +1014,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Files\\Search\\SearchComparison' => __DIR__ . '/../../..' . '/lib/private/Files/Search/SearchComparison.php',
         'OC\\Files\\Search\\SearchOrder' => __DIR__ . '/../../..' . '/lib/private/Files/Search/SearchOrder.php',
         'OC\\Files\\Search\\SearchQuery' => __DIR__ . '/../../..' . '/lib/private/Files/Search/SearchQuery.php',
+        'OC\\Files\\SimpleFS\\NewSimpleFile' => __DIR__ . '/../../..' . '/lib/private/Files/SimpleFS/NewSimpleFile.php',
         'OC\\Files\\SimpleFS\\SimpleFile' => __DIR__ . '/../../..' . '/lib/private/Files/SimpleFS/SimpleFile.php',
         'OC\\Files\\SimpleFS\\SimpleFolder' => __DIR__ . '/../../..' . '/lib/private/Files/SimpleFS/SimpleFolder.php',
         'OC\\Files\\Storage\\Common' => __DIR__ . '/../../..' . '/lib/private/Files/Storage/Common.php',

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -173,15 +173,21 @@ class Folder extends Node implements \OCP\Files\Folder {
 
 	/**
 	 * @param string $path
+	 * @param string | resource | null $content
 	 * @return \OC\Files\Node\File
 	 * @throws \OCP\Files\NotPermittedException
 	 */
-	public function newFile($path) {
+	public function newFile($path, $content = null) {
 		if ($this->checkPermissions(\OCP\Constants::PERMISSION_CREATE)) {
 			$fullPath = $this->getFullPath($path);
 			$nonExisting = new NonExistingFile($this->root, $this->view, $fullPath);
 			$this->sendHooks(['preWrite', 'preCreate'], [$nonExisting]);
-			if (!$this->view->touch($fullPath)) {
+			if ($content !== null) {
+				$result = $this->view->file_put_contents($fullPath, $content);
+			} else {
+				$result = $this->view->touch($fullPath);
+			}
+			if (!$result) {
 				throw new NotPermittedException('Could not create path');
 			}
 			$node = new File($this->root, $this->view, $fullPath);

--- a/lib/private/Files/Node/LazyRoot.php
+++ b/lib/private/Files/Node/LazyRoot.php
@@ -394,7 +394,7 @@ class LazyRoot implements IRootFolder {
 	/**
 	 * @inheritDoc
 	 */
-	public function newFile($path) {
+	public function newFile($path, $content = null) {
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
 

--- a/lib/private/Files/Node/NonExistingFolder.php
+++ b/lib/private/Files/Node/NonExistingFolder.php
@@ -139,7 +139,7 @@ class NonExistingFolder extends Folder {
 		throw new NotFoundException();
 	}
 
-	public function newFile($path) {
+	public function newFile($path, $content = null) {
 		throw new NotFoundException();
 	}
 

--- a/lib/private/Files/SimpleFS/NewSimpleFile.php
+++ b/lib/private/Files/SimpleFS/NewSimpleFile.php
@@ -123,7 +123,7 @@ class NewSimpleFile implements ISimpleFile {
 	public function putContent($data) {
 		try {
 			if ($this->file) {
-				return $this->file->putContent($data);
+				$this->file->putContent($data);
 			} else {
 				$this->file = $this->parentFolder->newFile($this->name, $data);
 			}

--- a/lib/private/Files/SimpleFS/NewSimpleFile.php
+++ b/lib/private/Files/SimpleFS/NewSimpleFile.php
@@ -1,0 +1,221 @@
+<?php declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Files\SimpleFS;
+
+use Icewind\Streams\CallbackWrapper;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use OCP\Files\SimpleFS\ISimpleFile;
+
+class NewSimpleFile implements ISimpleFile {
+	private $parentFolder;
+	private $name;
+	/** @var File|null */
+	private $file = null;
+
+	/**
+	 * File constructor.
+	 *
+	 * @param File $file
+	 */
+	public function __construct(Folder $parentFolder, string $name) {
+		$this->parentFolder = $parentFolder;
+		$this->name = $name;
+	}
+
+	/**
+	 * Get the name
+	 *
+	 * @return string
+	 */
+	public function getName() {
+		return $this->name;
+	}
+
+	/**
+	 * Get the size in bytes
+	 *
+	 * @return int
+	 */
+	public function getSize() {
+		if ($this->file) {
+			return $this->file->getSize();
+		} else {
+			return 0;
+		}
+	}
+
+	/**
+	 * Get the ETag
+	 *
+	 * @return string
+	 */
+	public function getETag() {
+		if ($this->file) {
+			return $this->file->getEtag();
+		} else {
+			return '';
+		}
+	}
+
+	/**
+	 * Get the last modification time
+	 *
+	 * @return int
+	 */
+	public function getMTime() {
+		if ($this->file) {
+			return $this->file->getMTime();
+		} else {
+			return time();
+		}
+	}
+
+	/**
+	 * Get the content
+	 *
+	 * @return string
+	 * @throws NotFoundException
+	 * @throws NotPermittedException
+	 */
+	public function getContent() {
+		if ($this->file) {
+			$result = $this->file->getContent();
+
+			if ($result === false) {
+				$this->checkFile();
+			}
+
+			return $result;
+		} else {
+			return '';
+		}
+	}
+
+	/**
+	 * Overwrite the file
+	 *
+	 * @param string|resource $data
+	 * @throws NotPermittedException
+	 * @throws NotFoundException
+	 */
+	public function putContent($data) {
+		try {
+			if ($this->file) {
+				return $this->file->putContent($data);
+			} else {
+				$this->file = $this->parentFolder->newFile($this->name, $data);
+			}
+		} catch (NotFoundException $e) {
+			$this->checkFile();
+		}
+	}
+
+	/**
+	 * Sometimes there are some issues with the AppData. Most of them are from
+	 * user error. But we should handle them gracefull anyway.
+	 *
+	 * If for some reason the current file can't be found. We remove it.
+	 * Then traverse up and check all folders if they exists. This so that the
+	 * next request will have a valid appdata structure again.
+	 *
+	 * @throws NotFoundException
+	 */
+	private function checkFile() {
+		$cur = $this->file;
+
+		while ($cur->stat() === false) {
+			$parent = $cur->getParent();
+			try {
+				$cur->delete();
+			} catch (NotFoundException $e) {
+				// Just continue then
+			}
+			$cur = $parent;
+		}
+
+		if ($cur !== $this->file) {
+			throw new NotFoundException('File does not exist');
+		}
+	}
+
+
+	/**
+	 * Delete the file
+	 *
+	 * @throws NotPermittedException
+	 */
+	public function delete() {
+		if ($this->file) {
+			$this->file->delete();
+		}
+	}
+
+	/**
+	 * Get the MimeType
+	 *
+	 * @return string
+	 */
+	public function getMimeType() {
+		if ($this->file) {
+			return $this->file->getMimeType();
+		} else {
+			return 'text/plain';
+		}
+	}
+
+	/**
+	 * Open the file as stream for reading, resulting resource can be operated as stream like the result from php's own fopen
+	 *
+	 * @return resource
+	 * @throws \OCP\Files\NotPermittedException
+	 * @since 14.0.0
+	 */
+	public function read() {
+		if ($this->file) {
+			return $this->file->fopen('r');
+		} else {
+			return fopen('php://temp', 'r');
+		}
+	}
+
+	/**
+	 * Open the file as stream for writing, resulting resource can be operated as stream like the result from php's own fopen
+	 *
+	 * @return resource
+	 * @throws \OCP\Files\NotPermittedException
+	 * @since 14.0.0
+	 */
+	public function write() {
+		if ($this->file) {
+			return $this->file->fopen('w');
+		} else {
+			$source = fopen('php://temp', 'w+');
+			return CallbackWrapper::wrap($source, null, null, null, null, function () use ($source) {
+				rewind($source);
+				$this->putContent($source);
+			});
+		}
+	}
+}

--- a/lib/private/Files/SimpleFS/SimpleFolder.php
+++ b/lib/private/Files/SimpleFS/SimpleFolder.php
@@ -80,8 +80,13 @@ class SimpleFolder implements ISimpleFolder   {
 		return new SimpleFile($file);
 	}
 
-	public function newFile($name) {
-		// delay creating the file until it's written to
-		return new NewSimpleFile($this->folder, $name);
+	public function newFile($name, $content = null) {
+		if ($content === null) {
+			// delay creating the file until it's written to
+			return new NewSimpleFile($this->folder, $name);
+		} else {
+			$file = $this->folder->newFile($name, $content);
+			return new SimpleFile($file);
+		}
 	}
 }

--- a/lib/private/Files/SimpleFS/SimpleFolder.php
+++ b/lib/private/Files/SimpleFS/SimpleFolder.php
@@ -81,8 +81,7 @@ class SimpleFolder implements ISimpleFolder   {
 	}
 
 	public function newFile($name) {
-		$file = $this->folder->newFile($name);
-
-		return new SimpleFile($file);
+		// delay creating the file until it's written to
+		return new NewSimpleFile($this->folder, $name);
 	}
 }

--- a/lib/public/Files/Folder.php
+++ b/lib/public/Files/Folder.php
@@ -109,7 +109,7 @@ interface Folder extends Node {
 	 * Create a new file
 	 *
 	 * @param string $path relative path of the new file
-	 * @param string | resource | null $content content for the new file, since 19.0.0
+	 * @param string|resource|null $content content for the new file, since 19.0.0
 	 * @return \OCP\Files\File
 	 * @throws \OCP\Files\NotPermittedException
 	 * @since 6.0.0

--- a/lib/public/Files/Folder.php
+++ b/lib/public/Files/Folder.php
@@ -109,11 +109,12 @@ interface Folder extends Node {
 	 * Create a new file
 	 *
 	 * @param string $path relative path of the new file
+	 * @param string | resource | null $content content for the new file, since 19.0.0
 	 * @return \OCP\Files\File
 	 * @throws \OCP\Files\NotPermittedException
 	 * @since 6.0.0
 	 */
-	public function newFile($path);
+	public function newFile($path, $content = null);
 
 	/**
 	 * search for files with the name matching $query

--- a/lib/public/Files/SimpleFS/ISimpleFolder.php
+++ b/lib/public/Files/SimpleFS/ISimpleFolder.php
@@ -64,11 +64,12 @@ interface ISimpleFolder {
 	 * Creates a new file with $name in the folder
 	 *
 	 * @param string $name
+	 * @param string|resource|null $content @since 19.0.0
 	 * @return ISimpleFile
 	 * @throws NotPermittedException
 	 * @since 11.0.0
 	 */
-	public function newFile($name);
+	public function newFile($name, $content = null);
 
 	/**
 	 * Remove the folder and all the files in it

--- a/tests/lib/Files/SimpleFS/SimpleFolderTest.php
+++ b/tests/lib/Files/SimpleFS/SimpleFolderTest.php
@@ -24,116 +24,93 @@
 namespace Test\File\SimpleFS;
 
 use OC\Files\SimpleFS\SimpleFolder;
+use OC\Files\Storage\Temporary;
+use OC\Files\View;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
+use Test\Traits\MountProviderTrait;
+use Test\Traits\UserTrait;
 
-class SimpleFolderTest extends \Test\TestCase  {
-	/** @var Folder|\PHPUnit_Framework_MockObject_MockObject */
+/**
+ * @group DB
+ */
+class SimpleFolderTest extends \Test\TestCase {
+	use MountProviderTrait;
+	use UserTrait;
+
+	/** @var Folder */
 	private $folder;
+
+	/** @var Folder */
+	private $parentFolder;
 
 	/** @var SimpleFolder */
 	private $simpleFolder;
 
+	private $storage;
+
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->folder = $this->createMock(Folder::class);
+		$this->storage = new Temporary([]);
+		$this->createUser('simple', 'simple');
+		$this->registerMount('simple', $this->storage, '/simple/files');
+		$this->loginAsUser('simple');
+
+		$this->parentFolder = \OC::$server->getUserFolder('simple');
+
+		$this->folder = $this->parentFolder->newFolder('test');
 		$this->simpleFolder = new SimpleFolder($this->folder);
 	}
 
 	public function testGetName() {
-		$this->folder->expects($this->once())
-			->method('getName')
-			->willReturn('myname');
-
-		$this->assertEquals('myname', $this->simpleFolder->getName());
+		$this->assertEquals('test', $this->simpleFolder->getName());
 	}
 
 	public function testDelete() {
-		$this->folder->expects($this->once())
-			->method('delete');
-
+		$this->assertTrue($this->parentFolder->nodeExists('test'));
 		$this->simpleFolder->delete();
+		$this->assertFalse($this->parentFolder->nodeExists('test'));
 	}
 
-	public function dataFileExists() {
-		return [
-			[true],
-			[false],
-		];
+	public function testFileExists() {
+		$this->folder->newFile('exists');
+
+		$this->assertFalse($this->simpleFolder->fileExists('not-exists'));
+		$this->assertTrue($this->simpleFolder->fileExists('exists'));
 	}
 
-	/**
-	 * @dataProvider dataFileExists
-	 * @param bool $exists
-	 */
-	public function testFileExists($exists) {
-		$this->folder->expects($this->once())
-			->method('nodeExists')
-			->with($this->equalTo('file'))
-			->willReturn($exists);
+	public function testGetFile() {
+		$this->folder->newFile('exists');
 
-		$this->assertEquals($exists, $this->simpleFolder->fileExists('file'));
-	}
+		$result = $this->simpleFolder->getFile('exists');
+		$this->assertInstanceOf(ISimpleFile::class, $result);
 
-	public function dataGetFile() {
-		return [
-			[File::class, false],
-			[Folder::class, true],
-			[Node::class, true],
-		];
-	}
-
-	/**
-	 * @dataProvider dataGetFile
-	 * @param string $class
-	 * @param bool $exception
-	 */
-	public function testGetFile($class, $exception) {
-		$node = $this->createMock($class);
-
-		$this->folder->expects($this->once())
-			->method('get')
-			->with($this->equalTo('file'))
-			->willReturn($node);
-
-		try {
-			$result = $this->simpleFolder->getFile('file');
-			$this->assertFalse($exception);
-			$this->assertInstanceOf(ISimpleFile::class, $result);
-		} catch (NotFoundException $e) {
-			$this->assertTrue($exception);
-		}
+		$this->expectException(NotFoundException::class);
+		$this->simpleFolder->getFile('not-exists');
 	}
 
 	public function testNewFile() {
-		$file = $this->createMock(File::class);
-
-		$this->folder->expects($this->once())
-			->method('newFile')
-			->with($this->equalTo('file'))
-			->willReturn($file);
-
 		$result = $this->simpleFolder->newFile('file');
 		$this->assertInstanceOf(ISimpleFile::class, $result);
+		$this->assertFalse($this->folder->nodeExists('file'));
+		$result->putContent('bar');
+
+		$this->assertTrue($this->folder->nodeExists('file'));
+		$this->assertEquals('bar', $result->getContent());
 	}
 
 	public function testGetDirectoryListing() {
-		$file = $this->createMock(File::class);
-		$folder = $this->createMock(Folder::class);
-		$node = $this->createMock(Node::class);
-
-		$this->folder->expects($this->once())
-			->method('getDirectoryListing')
-			->willReturn([$file, $folder, $node]);
+		$this->folder->newFile('file1');
+		$this->folder->newFile('file2');
 
 		$result = $this->simpleFolder->getDirectoryListing();
-
-		$this->assertCount(1, $result);
+		$this->assertCount(2, $result);
 		$this->assertInstanceOf(ISimpleFile::class, $result[0]);
+		$this->assertInstanceOf(ISimpleFile::class, $result[1]);
 	}
 
 }


### PR DESCRIPTION
instead of first creating an empty file and then writing the content.

This solves the overhead of creating an empty file with the common pattern:

```php
$file = $simpleFilder->newFile('foo.txt');
$file->putContent('bar.txt');
```

roughly halving the number of storage and database operations that need to be done when creating a `SimpleFile`.

This is not automatically done with `File` because that has a more complex api which I'm more hesitant to touch.
Instead the `Folder::newFile` api has been extended to accept the content for the new file.

In my local testing, the overhead of first creating an empty file took about 20% of the time for preview generation