### PR TITLE
cron: Adapt to 5 minutes recommendation

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -111,8 +111,9 @@ try {
 		// Work
 		$jobList = \OC::$server->getJobList();
 
-		// We only ask for jobs for 14 minutes, because after 15 minutes the next
-		// system cron task should spawn.
+		// We only ask for jobs for 14 minutes, because after 5 minutes the next
+		// system cron task should spawn and we want to have at most three
+		// cron jobs running in parallel.
 		$endTime = time() + 14 * 60;
 
 		$executedJobs = [];


### PR DESCRIPTION
cron is still assuming that it will be scheduled every 15 minutes. Adapt this to the new 5 minutes recommendation to avoid overlapping executions.