### PR TITLE
Strip of users home path from share api message

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -289,7 +289,8 @@ class Manager implements IManager {
 
 		// Check if we actually have share permissions
 		if (!$share->getNode()->isShareable()) {
-			$message_t = $this->l->t('You are not allowed to share %s', [$share->getNode()->getPath()]);
+			$path = $userFolder->getRelativePath($share->getNode()->getPath());
+			$message_t = $this->l->t('You are not allowed to share %s', [$path]);
 			throw new GenericShareException($message_t, $message_t, 404);
 		}
 
@@ -333,7 +334,8 @@ class Manager implements IManager {
 
 		// Check that we do not share with more permissions than we have
 		if ($share->getPermissions() & ~$permissions) {
-			$message_t = $this->l->t('Can’t increase permissions of %s', [$share->getNode()->getPath()]);
+			$path = $userFolder->getRelativePath($share->getNode()->getPath());
+			$message_t = $this->l->t('Can’t increase permissions of %s', [$path]);
 			throw new GenericShareException($message_t, $message_t, 404);
 		}
 

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -708,6 +708,9 @@ class ManagerTest extends \Test\TestCase {
 
 		$userFolder = $this->createMock(Folder::class);
 		$userFolder->method('getPath')->willReturn('myrootfolder');
+		$userFolder->expects($this->any())
+			->method('getRelativePath')
+			->willReturnArgument(0);
 		$this->rootFolder->method('getUserFolder')->willReturn($userFolder);
 
 


### PR DESCRIPTION
* Share a folder without reshare permissions
* Try to share that file e.g. in talk (https://github.com/nextcloud/spreed/pull/2976)

### Before
You are not allowed to share /445d1288-a75a-44df-87fd-bb4c72bdc488/files/Resharing disabled/1P8A0501.jpg

### After
You are not allowed to share /Resharing disabled/1P8A0501.jpg