### PR TITLE
Fix issues with Keystone auth v3 in files_external app

### DIFF
--- a/apps/files_external/lib/Lib/Auth/OpenStack/OpenStackV3.php
+++ b/apps/files_external/lib/Lib/Auth/OpenStack/OpenStackV3.php
@@ -46,6 +46,7 @@ class OpenStackV3 extends AuthMechanism {
 				new DefinitionParameter('domain', $l->t('Domain')),
 				(new DefinitionParameter('password', $l->t('Password')))
 					->setType(DefinitionParameter::VALUE_PASSWORD),
+				new DefinitionParameter('tenant', $l->t('Tenant name')),
 				new DefinitionParameter('url', $l->t('Identity endpoint URL'))
 			])
 		;

--- a/apps/files_external/lib/Lib/Backend/Swift.php
+++ b/apps/files_external/lib/Lib/Backend/Swift.php
@@ -44,8 +44,7 @@ class Swift extends Backend {
 			->addParameters([
 				(new DefinitionParameter('service_name', $l->t('Service name')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
-				(new DefinitionParameter('region', $l->t('Region')))
-					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+				new DefinitionParameter('region', $l->t('Region')),
 				new DefinitionParameter('bucket', $l->t('Bucket')),
 				(new DefinitionParameter('timeout', $l->t('Request timeout (seconds)')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),

--- a/lib/private/Files/ObjectStore/SwiftFactory.php
+++ b/lib/private/Files/ObjectStore/SwiftFactory.php
@@ -119,6 +119,10 @@ class SwiftFactory {
 		if (!isset($this->params['tenantName']) && isset($this->params['tenant'])) {
 			$this->params['tenantName'] = $this->params['tenant'];
 		}
+		if (isset($this->params['domain'])) {
+			$this->params['scope']['project']['name'] = $this->params['tenant'];
+			$this->params['scope']['project']['domain']['name'] = $this->params['domain'];
+		}
 		$this->params = array_merge(self::DEFAULT_OPTIONS, $this->params);
 
 		$cacheKey = $userName . '@' . $this->params['url'] . '/' . $this->params['container'];


### PR DESCRIPTION
This PR fixes some issues with Keystone auth v3 in files_external app :

- Keystone auth v3 requires a scoped authorization payload (already fixed for primary storage in ba71918.
- Tenant (project) name parameter was missing.
- Region parameter is mandatory, because of [this check](https://github.com/nextcloud/server/blob/master/apps/files_external/lib/Lib/Storage/Swift.php#L163).

Fixes #5882 
Fixes #11264