### PR TITLE
Fix three dots menu on mobile devices

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -64,7 +64,7 @@
 	box-sizing: border-box;
 	opacity: 1;
 	align-items: center;
-	flex-wrap: wrap;
+	display: grid;
 	overflow: hidden;
 
 	&:focus {


### PR DESCRIPTION
`flex-wrap` has no effect here.

Fixes #19479

![image](https://user-images.githubusercontent.com/12234510/74828502-81789680-530f-11ea-9275-8b584ef52529.png)


