### PR TITLE
Fix #19555: Users settings: Don't let rows overlap the groups dropdown

### DIFF
--- a/apps/settings/css/settings.scss
+++ b/apps/settings/css/settings.scss
@@ -1512,7 +1512,6 @@ doesnotexist:-o-prefocus, .strengthify-wrapper {
 			grid-row-start: span 1;
 			grid-gap: 3px;
 			align-items: center;
-			z-index: 0;
 			/* let's define the column until storage path,
 			   what follows will be manually defined  */
 			grid-template-columns: 44px minmax($grid-col-min-width + 30px, 1fr) repeat(auto-fit, minmax($grid-col-min-width, 1fr));


### PR DESCRIPTION
Fixes #19555 by removing the change of `z-index` on rows.

The line got added in https://github.com/nextcloud/server/commit/04281407f12a12b19cc48710f86dcce91c448963