### PR TITLE
Restrict sharing user enumeration to groups

### DIFF
--- a/apps/dav/lib/CardDAV/SystemAddressbook.php
+++ b/apps/dav/lib/CardDAV/SystemAddressbook.php
@@ -40,7 +40,9 @@ class SystemAddressbook extends AddressBook {
 	}
 
 	public function getChildren() {
-		if ($this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') !== 'yes') {
+		$shareEnumeration = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
+		$restrictShareEnumeration = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'yes') === 'yes';
+		if (!$shareEnumeration || ($shareEnumeration && $restrictShareEnumeration)) {
 			return [];
 		}
 

--- a/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
@@ -431,10 +431,9 @@ class PrincipalTest extends TestCase {
 			->will($this->returnValue($sharingEnabled));
 
 		if ($sharingEnabled) {
-			$this->config->expects($this->once())
-				->method('getAppValue')
-				->with('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes')
-				->willReturn('yes');
+			$this->shareManager->expects($this->once())
+				->method('allowEnumeration')
+				->willReturn(true);
 
 			$this->shareManager->expects($this->once())
 				->method('shareWithGroupMembersOnly')
@@ -526,10 +525,9 @@ class PrincipalTest extends TestCase {
 			->method('shareAPIEnabled')
 			->will($this->returnValue(true));
 
-		$this->config->expects($this->exactly(2))
-			->method('getAppValue')
-			->with('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes')
-			->willReturn('yes');
+		$this->shareManager->expects($this->exactly(2))
+			->method('allowEnumeration')
+			->willReturn(true);
 
 		$this->shareManager->expects($this->exactly(2))
 			->method('shareWithGroupMembersOnly')
@@ -557,10 +555,9 @@ class PrincipalTest extends TestCase {
 			->method('shareAPIEnabled')
 			->will($this->returnValue(true));
 
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->with('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes')
-			->willReturn('no');
+		$this->shareManager->expects($this->once())
+			->method('allowEnumeration')
+			->willReturn(false);
 
 		$this->shareManager->expects($this->once())
 			->method('shareWithGroupMembersOnly')
@@ -593,10 +590,9 @@ class PrincipalTest extends TestCase {
 			->method('shareAPIEnabled')
 			->will($this->returnValue(true));
 
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->with('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes')
-			->willReturn('no');
+		$this->shareManager->expects($this->once())
+			->method('allowEnumeration')
+			->willReturn(false);
 
 		$this->shareManager->expects($this->once())
 			->method('shareWithGroupMembersOnly')

--- a/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
@@ -624,6 +624,128 @@ class PrincipalTest extends TestCase {
 			['{http://sabredav.org/ns}email-address' => 'user2@foo.bar']));
 	}
 
+	public function testSearchPrincipalWithEnumerationLimitedDisplayname() {
+		$this->shareManager->expects($this->at(0))
+			->method('shareAPIEnabled')
+			->will($this->returnValue(true));
+
+		$this->shareManager->expects($this->at(1))
+			->method('allowEnumeration')
+			->willReturn(true);
+
+		$this->shareManager->expects($this->at(2))
+			->method('limitEnumerationToGroups')
+			->willReturn(true);
+
+		$this->shareManager->expects($this->once())
+			->method('shareWithGroupMembersOnly')
+			->will($this->returnValue(false));
+
+		$user2 = $this->createMock(IUser::class);
+		$user2->method('getUID')->will($this->returnValue('user2'));
+		$user2->method('getDisplayName')->will($this->returnValue('User 2'));
+		$user2->method('getEMailAddress')->will($this->returnValue('user2@foo.bar'));
+		$user3 = $this->createMock(IUser::class);
+		$user3->method('getUID')->will($this->returnValue('user3'));
+		$user3->method('getDisplayName')->will($this->returnValue('User 22'));
+		$user3->method('getEMailAddress')->will($this->returnValue('user2@foo.bar123'));
+		$user4 = $this->createMock(IUser::class);
+		$user4->method('getUID')->will($this->returnValue('user4'));
+		$user4->method('getDisplayName')->will($this->returnValue('User 222'));
+		$user4->method('getEMailAddress')->will($this->returnValue('user2@foo.bar456'));
+
+
+		$this->userSession->expects($this->at(0))
+			->method('getUser')
+			->willReturn($user2);
+
+		$this->groupManager->expects($this->at(0))
+			->method('getUserGroupIds')
+			->willReturn(['group1']);
+		$this->groupManager->expects($this->at(1))
+			->method('getUserGroupIds')
+			->willReturn(['group1']);
+		$this->groupManager->expects($this->at(2))
+			->method('getUserGroupIds')
+			->willReturn(['group1']);
+		$this->groupManager->expects($this->at(3))
+			->method('getUserGroupIds')
+			->willReturn(['group2']);
+
+		$this->userManager->expects($this->at(0))
+			->method('searchDisplayName')
+			->with('User')
+			->willReturn([$user2, $user3, $user4]);
+
+
+		$this->assertEquals([
+			'principals/users/user2',
+			'principals/users/user3',
+		], $this->connector->searchPrincipals('principals/users',
+			['{DAV:}displayname' => 'User']));
+	}
+
+	public function testSearchPrincipalWithEnumerationLimitedMail() {
+		$this->shareManager->expects($this->at(0))
+			->method('shareAPIEnabled')
+			->will($this->returnValue(true));
+
+		$this->shareManager->expects($this->at(1))
+			->method('allowEnumeration')
+			->willReturn(true);
+
+		$this->shareManager->expects($this->at(2))
+			->method('limitEnumerationToGroups')
+			->willReturn(true);
+
+		$this->shareManager->expects($this->once())
+			->method('shareWithGroupMembersOnly')
+			->will($this->returnValue(false));
+
+		$user2 = $this->createMock(IUser::class);
+		$user2->method('getUID')->will($this->returnValue('user2'));
+		$user2->method('getDisplayName')->will($this->returnValue('User 2'));
+		$user2->method('getEMailAddress')->will($this->returnValue('user2@foo.bar'));
+		$user3 = $this->createMock(IUser::class);
+		$user3->method('getUID')->will($this->returnValue('user3'));
+		$user3->method('getDisplayName')->will($this->returnValue('User 22'));
+		$user3->method('getEMailAddress')->will($this->returnValue('user2@foo.bar123'));
+		$user4 = $this->createMock(IUser::class);
+		$user4->method('getUID')->will($this->returnValue('user4'));
+		$user4->method('getDisplayName')->will($this->returnValue('User 222'));
+		$user4->method('getEMailAddress')->will($this->returnValue('user2@foo.bar456'));
+
+
+		$this->userSession->expects($this->at(0))
+			->method('getUser')
+			->willReturn($user2);
+
+		$this->groupManager->expects($this->at(0))
+			->method('getUserGroupIds')
+			->willReturn(['group1']);
+		$this->groupManager->expects($this->at(1))
+			->method('getUserGroupIds')
+			->willReturn(['group1']);
+		$this->groupManager->expects($this->at(2))
+			->method('getUserGroupIds')
+			->willReturn(['group1']);
+		$this->groupManager->expects($this->at(3))
+			->method('getUserGroupIds')
+			->willReturn(['group2']);
+
+		$this->userManager->expects($this->at(0))
+			->method('getByEmail')
+			->with('user')
+			->willReturn([$user2, $user3, $user4]);
+
+
+		$this->assertEquals([
+			'principals/users/user2',
+			'principals/users/user3'
+		], $this->connector->searchPrincipals('principals/users',
+			['{http://sabredav.org/ns}email-address' => 'user']));
+	}
+
 	public function testFindByUriSharingApiDisabled() {
 		$this->shareManager->expects($this->once())
 			->method('shareApiEnabled')

--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -66,12 +66,6 @@ class ShareesAPIController extends OCSController {
 	/** @var IManager */
 	protected $shareManager;
 
-	/** @var bool */
-	protected $shareWithGroupOnly = false;
-
-	/** @var bool */
-	protected $shareeEnumeration = true;
-
 	/** @var int */
 	protected $offset = 0;
 
@@ -205,8 +199,6 @@ class ShareesAPIController extends OCSController {
 		}
 		sort($shareTypes);
 
-		$this->shareWithGroupOnly = $this->config->getAppValue('core', 'shareapi_only_share_with_group_members', 'no') === 'yes';
-		$this->shareeEnumeration = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
 		$this->limit = (int) $perPage;
 		$this->offset = $perPage * ($page - 1);
 

--- a/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
@@ -237,12 +237,10 @@ class ShareesAPIControllerTest extends TestCase {
 
 		/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject $config */
 		$config = $this->createMock(IConfig::class);
-		$config->expects($this->exactly(3))
+		$config->expects($this->exactly(1))
 			->method('getAppValue')
 			->with($this->anything(), $this->anything(), $this->anything())
 			->willReturnMap([
-				['core', 'shareapi_only_share_with_group_members', 'no', $apiSetting],
-				['core', 'shareapi_allow_share_dialog_user_enumeration', 'yes', $enumSetting],
 				['files_sharing', 'lookupServerEnabled', 'yes', 'yes'],
 			]);
 
@@ -302,9 +300,6 @@ class ShareesAPIControllerTest extends TestCase {
 			}));
 
 		$this->assertInstanceOf(Http\DataResponse::class, $sharees->search($search, $itemType, $page, $perPage, $shareType));
-
-		$this->assertSame($shareWithGroupOnly, $this->invokePrivate($sharees, 'shareWithGroupOnly'));
-		$this->assertSame($shareeEnumeration, $this->invokePrivate($sharees, 'shareeEnumeration'));
 	}
 
 	public function dataSearchInvalid() {

--- a/apps/settings/js/admin.js
+++ b/apps/settings/js/admin.js
@@ -142,6 +142,10 @@ $(document).ready(function(){
 		savePublicShareDisclaimerText(this.value);
 	});
 
+	$('#shareapi_allow_share_dialog_user_enumeration').on('change', function() {
+		$('#shareapi_restrict_user_enumeration_to_group_setting').toggleClass('hidden', !this.checked);
+	})
+
 	$('#allowLinks').change(function() {
 		$("#publicLinkSettings").toggleClass('hidden', !this.checked);
 		$('#setDefaultExpireDate').toggleClass('hidden', !(this.checked && $('#shareapiDefaultExpireDate')[0].checked));

--- a/apps/settings/lib/Settings/Admin/Sharing.php
+++ b/apps/settings/lib/Settings/Admin/Sharing.php
@@ -73,6 +73,7 @@ class Sharing implements ISettings {
 			'allowPublicUpload'                    => $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes'),
 			'allowResharing'                       => $this->config->getAppValue('core', 'shareapi_allow_resharing', 'yes'),
 			'allowShareDialogUserEnumeration'      => $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes'),
+			'restrictUserEnumerationToGroup'       => $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'no'),
 			'enforceLinkPassword'                  => Util::isPublicLinkPasswordRequired(),
 			'onlyShareWithGroupMembers'            => $this->shareManager->shareWithGroupMembersOnly(),
 			'shareAPIEnabled'                      => $this->config->getAppValue('core', 'shareapi_enabled', 'yes'),

--- a/apps/settings/templates/settings/admin/sharing.php
+++ b/apps/settings/templates/settings/admin/sharing.php
@@ -109,11 +109,19 @@
 		<br />
 		<em><?php p($l->t('These groups will still be able to receive shares, but not to initiate them.')); ?></em>
 	</p>
+
 	<p class="<?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
 		<input type="checkbox" name="shareapi_allow_share_dialog_user_enumeration" value="1" id="shareapi_allow_share_dialog_user_enumeration" class="checkbox"
 			<?php if ($_['allowShareDialogUserEnumeration'] === 'yes') print_unescaped('checked="checked"'); ?> />
 		<label for="shareapi_allow_share_dialog_user_enumeration"><?php p($l->t('Allow username autocompletion in share dialog. If this is disabled the full username or email address needs to be entered.'));?></label><br />
 	</p>
+
+	<p id="shareapi_restrict_user_enumeration_to_group_setting" class="indent <?php if ($_['shareAPIEnabled'] === 'no' || $_['allowShareDialogUserEnumeration'] === 'no') p('hidden');?>">
+		<input type="checkbox" name="shareapi_restrict_user_enumeration_to_group" value="1" id="shareapi_restrict_user_enumeration_to_group" class="checkbox"
+			<?php if ($_['restrictUserEnumerationToGroup'] === 'yes') print_unescaped('checked="checked"'); ?> />
+		<label for="shareapi_restrict_user_enumeration_to_group"><?php p($l->t('Restrict username autocompletion to users within the same groups'));?></label><br />
+	</p>
+
 	<p>
 		<input type="checkbox" id="publicShareDisclaimer" class="checkbox noJSAutoUpdate"
 			<?php if ($_['publicShareDisclaimerText'] !== null) print_unescaped('checked="checked"'); ?> />

--- a/apps/settings/tests/Settings/Admin/SharingTest.php
+++ b/apps/settings/tests/Settings/Admin/SharingTest.php
@@ -94,55 +94,60 @@ class SharingTest extends TestCase {
 		$this->config
 			->expects($this->at(6))
 			->method('getAppValue')
+			->with('core', 'shareapi_restrict_user_enumeration_to_group', 'no')
+			->willReturn('no');
+		$this->config
+			->expects($this->at(7))
+			->method('getAppValue')
 			->with('core', 'shareapi_enabled', 'yes')
 			->willReturn('yes');
 		$this->config
-			->expects($this->at(7))
+			->expects($this->at(8))
 			->method('getAppValue')
 			->with('core', 'shareapi_default_expire_date', 'no')
 			->willReturn('no');
 		$this->config
-			->expects($this->at(8))
+			->expects($this->at(9))
 			->method('getAppValue')
 			->with('core', 'shareapi_expire_after_n_days', '7')
 			->willReturn('7');
 		$this->config
-			->expects($this->at(9))
+			->expects($this->at(10))
 			->method('getAppValue')
 			->with('core', 'shareapi_enforce_expire_date', 'no')
 			->willReturn('no');
 		$this->config
-			->expects($this->at(10))
+			->expects($this->at(11))
 			->method('getAppValue')
 			->with('core', 'shareapi_exclude_groups', 'no')
 			->willReturn('no');
 		$this->config
-			->expects($this->at(11))
+			->expects($this->at(12))
 			->method('getAppValue')
 			->with('core', 'shareapi_public_link_disclaimertext', null)
 			->willReturn('Lorem ipsum');
 		$this->config
-			->expects($this->at(12))
+			->expects($this->at(13))
 			->method('getAppValue')
 			->with('core', 'shareapi_enable_link_password_by_default', 'no')
 			->willReturn('yes');
 		$this->config
-			->expects($this->at(13))
+			->expects($this->at(14))
 			->method('getAppValue')
 			->with('core', 'shareapi_default_permissions', Constants::PERMISSION_ALL)
 			->willReturn(Constants::PERMISSION_ALL);
 		$this->config
-			->expects($this->at(14))
+			->expects($this->at(15))
 			->method('getAppValue')
 			->with('core', 'shareapi_default_internal_expire_date', 'no')
 			->willReturn('no');
 		$this->config
-			->expects($this->at(15))
+			->expects($this->at(16))
 			->method('getAppValue')
 			->with('core', 'shareapi_internal_expire_after_n_days', '7')
 			->willReturn('7');
 		$this->config
-			->expects($this->at(16))
+			->expects($this->at(17))
 			->method('getAppValue')
 			->with('core', 'shareapi_enforce_internal_expire_date', 'no')
 			->willReturn('no');
@@ -156,6 +161,7 @@ class SharingTest extends TestCase {
 				'allowPublicUpload'               => 'yes',
 				'allowResharing'                  => 'yes',
 				'allowShareDialogUserEnumeration' => 'yes',
+				'restrictUserEnumerationToGroup'  => 'no',
 				'enforceLinkPassword'             => false,
 				'onlyShareWithGroupMembers'       => false,
 				'shareAPIEnabled'                 => 'yes',
@@ -212,55 +218,60 @@ class SharingTest extends TestCase {
 		$this->config
 			->expects($this->at(6))
 			->method('getAppValue')
+			->with('core', 'shareapi_restrict_user_enumeration_to_group', 'no')
+			->willReturn('no');
+		$this->config
+			->expects($this->at(7))
+			->method('getAppValue')
 			->with('core', 'shareapi_enabled', 'yes')
 			->willReturn('yes');
 		$this->config
-			->expects($this->at(7))
+			->expects($this->at(8))
 			->method('getAppValue')
 			->with('core', 'shareapi_default_expire_date', 'no')
 			->willReturn('no');
 		$this->config
-			->expects($this->at(8))
+			->expects($this->at(9))
 			->method('getAppValue')
 			->with('core', 'shareapi_expire_after_n_days', '7')
 			->willReturn('7');
 		$this->config
-			->expects($this->at(9))
+			->expects($this->at(10))
 			->method('getAppValue')
 			->with('core', 'shareapi_enforce_expire_date', 'no')
 			->willReturn('no');
 		$this->config
-			->expects($this->at(10))
+			->expects($this->at(11))
 			->method('getAppValue')
 			->with('core', 'shareapi_exclude_groups', 'no')
 			->willReturn('yes');
 		$this->config
-			->expects($this->at(11))
+			->expects($this->at(12))
 			->method('getAppValue')
 			->with('core', 'shareapi_public_link_disclaimertext', null)
 			->willReturn('Lorem ipsum');
 		$this->config
-			->expects($this->at(12))
+			->expects($this->at(13))
 			->method('getAppValue')
 			->with('core', 'shareapi_enable_link_password_by_default', 'no')
 			->willReturn('yes');
 		$this->config
-			->expects($this->at(13))
+			->expects($this->at(14))
 			->method('getAppValue')
 			->with('core', 'shareapi_default_permissions', Constants::PERMISSION_ALL)
 			->willReturn(Constants::PERMISSION_ALL);
 		$this->config
-			->expects($this->at(14))
+			->expects($this->at(15))
 			->method('getAppValue')
 			->with('core', 'shareapi_default_internal_expire_date', 'no')
 			->willReturn('no');
 		$this->config
-			->expects($this->at(15))
+			->expects($this->at(16))
 			->method('getAppValue')
 			->with('core', 'shareapi_internal_expire_after_n_days', '7')
 			->willReturn('7');
 		$this->config
-			->expects($this->at(16))
+			->expects($this->at(17))
 			->method('getAppValue')
 			->with('core', 'shareapi_enforce_internal_expire_date', 'no')
 			->willReturn('no');
@@ -275,6 +286,7 @@ class SharingTest extends TestCase {
 				'allowPublicUpload'               => 'yes',
 				'allowResharing'                  => 'yes',
 				'allowShareDialogUserEnumeration' => 'yes',
+				'restrictUserEnumerationToGroup'  => 'no',
 				'enforceLinkPassword'             => false,
 				'onlyShareWithGroupMembers'       => false,
 				'shareAPIEnabled'                 => 'yes',

--- a/lib/private/Contacts/ContactsMenu/ContactsStore.php
+++ b/lib/private/Contacts/ContactsMenu/ContactsStore.php
@@ -107,12 +107,13 @@ class ContactsStore implements IContactsStore {
 									array $entries,
 									$filter) {
 		$disallowEnumeration = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') !== 'yes';
+		$restrictEnumeration = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'yes') === 'yes';
 		$excludedGroups = $this->config->getAppValue('core', 'shareapi_exclude_groups', 'no') === 'yes';
 
 		// whether to filter out local users
 		$skipLocal = false;
 		// whether to filter out all users which doesn't have the same group as the current user
-		$ownGroupsOnly = $this->config->getAppValue('core', 'shareapi_only_share_with_group_members', 'no') === 'yes';
+		$ownGroupsOnly = $this->config->getAppValue('core', 'shareapi_only_share_with_group_members', 'no') === 'yes' || $restrictEnumeration;
 
 		$selfGroups = $this->groupManager->getUserGroupIds($self);
 

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1764,6 +1764,15 @@ class Manager implements IManager {
 		return $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes') === 'yes';
 	}
 
+	public function allowEnumeration(): bool {
+		return $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
+	}
+
+	public function limitEnumerationToGroups(): bool {
+		return $this->allowEnumeration() &&
+			$this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'no') === 'yes';
+	}
+
 	/**
 	 * Copied from \OC_Util::isSharingDisabledForUser
 	 *

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -369,6 +369,22 @@ interface IManager {
 	public function allowGroupSharing();
 
 	/**
+	 * Check if user enumeration is allowed
+	 *
+	 * @return bool
+	 * @since 19.0.0
+	 */
+	public function allowEnumeration(): bool;
+
+	/**
+	 * Check if user enumeration is limited to the users groups
+	 *
+	 * @return bool
+	 * @since 19.0.0
+	 */
+	public function limitEnumerationToGroups(): bool;
+
+	/**
 	 * Check if sharing is disabled for the given user
 	 *
 	 * @param string $userId


### PR DESCRIPTION
This PR adds a second configuration flag to allow limiting user enumeration to a users own groups. This PR covers searching though sharing dialogs as well as contacts store which is used for the contacts menu. There are some apps listed below that sill need a separate fix to adapt to this new configration value.

Might be easier to review the commits individually.


Some notes on the implementation:
- Remote address books can always be enumerated since we do not have shared groups across instances
- The RemotePlugin doesn't need to apply the limit, as the wide search only applies for user addressbooks, where having the full cloud id in there is equal to having an exact match
- The system addressbook will act as if enumeration would be blocked in general, since for federated setups this setting would not work at all and the search plugins exclude the system addressbook anyway since the entries are searched though the user manager

## Apps requiring adjustments

- Mail: Check if system users are not already excluded https://github.com/nextcloud/mail/blob/897742cb7545e3021747f170e612062cad5ceedd/lib/Service/ContactsIntegration.php#L56
- Circles: Circles has a dedicated search service so this requires some separate work to make sure that local users and groups are limited to the users own ones

## Covers
- [x] Sharing: Files, talk, deck, 
- [x] Contacts menu
- [x] Contacts: Principal search needs some more testing
