### PR TITLE
Set content type for propfind request

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -40,6 +40,7 @@
 						'<d:propfind xmlns:d="DAV:">' +
 						'<d:prop><d:resourcetype/></d:prop>' +
 						'</d:propfind>',
+				contentType: 'application/xml; charset=utf-8',
 				complete: afterCall,
 				allowAuthErrors: true
 			});


### PR DESCRIPTION
Fix #12685 

Without the request is sent as application/x-www-form-urlencoded; charset=UTF-8 and might be blocked by some application firewalls because content and content type do not match.