### PR TITLE
Make sure quota_preset is using numerical indexes

### DIFF
--- a/apps/settings/lib/Controller/UsersController.php
+++ b/apps/settings/lib/Controller/UsersController.php
@@ -214,12 +214,7 @@ class UsersController extends Controller {
 		];
 
 		/* QUOTAS PRESETS */
-		$quotaPreset = $this->config->getAppValue('files', 'quota_preset', '1 GB, 5 GB, 10 GB');
-		$quotaPreset = explode(',', $quotaPreset);
-		foreach ($quotaPreset as &$preset) {
-			$preset = trim($preset);
-		}
-		$quotaPreset = array_diff($quotaPreset, array('default', 'none'));
+		$quotaPreset = $this->parseQuotaPreset($this->config->getAppValue('files', 'quota_preset', '1 GB, 5 GB, 10 GB'));
 		$defaultQuota = $this->config->getAppValue('files', 'default_quota', 'none');
 
 		\OC::$server->getEventDispatcher()->dispatch('OC\Settings\Users::loadAdditionalScripts');
@@ -245,6 +240,19 @@ class UsersController extends Controller {
 		$serverData['newUserRequireEmail'] = $this->config->getAppValue('core', 'newUser.requireEmail', 'no') === 'yes';
 
 		return new TemplateResponse('settings', 'settings-vue', ['serverData' => $serverData]);
+	}
+
+	/**
+	 * Parse the app value for quota_present
+	 *
+	 * @param string $quotaPreset
+	 * @return array
+	 */
+	protected function parseQuotaPreset(string $quotaPreset): array {
+		// 1 GB, 5 GB, 10 GB => [1 GB, 5 GB, 10 GB]
+		$presets = array_filter(array_map('trim', explode(',', $quotaPreset)));
+		// Drop default and none, Make array indexes numerically
+		return array_values(array_diff($presets, ['default', 'none']));
 	}
 
 	/**


### PR DESCRIPTION
Fix #19162 

If one set quota_present to "default, none, 1 GB, 5 GB, 10 GB" the old implementation will remove default and none but keep the array indexes. Later json_encode will recognize a array with 2 as first index as object and hence quotaPreset.reduce will fail.

```
<?php

$array = json_encode([0 => '1 GB', 1 => '2 GB']);
$object = json_encode([2 => '1 GB', 3 => '2 GB']);

var_dump($array, $object);
```

```
string(15) "["1 GB","2 GB"]"
string(23) "{"2":"1 GB","3":"2 GB"}"
```
