### PR TITLE
Check that username and password are present.

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1077,10 +1077,12 @@ class OC {
 		);
 		foreach ($vars as $var) {
 			if (isset($_SERVER[$var]) && preg_match('/Basic\s+(.*)$/i', $_SERVER[$var], $matches)) {
-				list($name, $password) = explode(':', base64_decode($matches[1]), 2);
-				$_SERVER['PHP_AUTH_USER'] = $name;
-				$_SERVER['PHP_AUTH_PW'] = $password;
-				break;
+				$credentials = explode(':', base64_decode($matches[1]), 2);
+				if (count($credentials) === 2) {
+					$_SERVER['PHP_AUTH_USER'] = $credentials[0];
+					$_SERVER['PHP_AUTH_PW'] = $credentials[1];
+					break;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Closes #19537 

Send a request with invalid credentials like below. Not sure if any security implication.

Before `$_SERVER['PHP_AUTH_PW'] = null;` and `list` will trigger a warning.

After `$_SERVER['PHP_AUTH_PW'] undefined;` and no warning.



Test:

```
php -r "echo base64_encode('credentials');"
Y3JlZGVudGlhbHM=
```

```
curl --request PROPFIND 'https://nextcloud.test/remote.php/dav/files/admin/' \
--header 'Authorization: Basic Y3JlZGVudGlhbHM='
```

