### PR TITLE
Fix hover state color of drag-n-drop with theming and dark mode

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -98,7 +98,7 @@
 
 .file-drag, .file-drag #filestable tbody tr, .file-drag #filestable tbody tr:hover {
 	transition: background-color 0.3s ease!important;
-	background-color: rgb(179, 230, 255) !important;
+	background-color: var(--color-primary-light) !important;
 }
 
 .app-files #app-content.dir-drop {
@@ -110,7 +110,7 @@
 }
 
 .app-files #app-content.dir-drop #filestable tbody tr.dropping-to-dir{
-	background-color: rgb(179, 230, 255) !important;
+	background-color: var(--color-primary-light) !important;
 }
 
 /* icons for sidebar */


### PR DESCRIPTION
Before | After
---|---
![Bildschirmfoto von 2020-02-24 13-57-37](https://user-images.githubusercontent.com/213943/75155856-31377500-5711-11ea-92dc-3712164e5fef.png) | ![Bildschirmfoto von 2020-02-24 14-19-16](https://user-images.githubusercontent.com/213943/75155852-30064800-5711-11ea-8128-8f3961419822.png)

Fix #19618 