### PR TITLE
Remove unecessary constraint on database name

### DIFF
--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -75,9 +75,6 @@ abstract class AbstractDatabase {
 		} else if(empty($config['dbname'])) {
 			$errors[] = $this->trans->t("%s enter the database name.", array($this->dbprettyname));
 		}
-		if(substr_count($config['dbname'], '.') >= 1) {
-			$errors[] = $this->trans->t("%s you may not use dots in the database name", array($this->dbprettyname));
-		}
 		return $errors;
 	}
 


### PR DESCRIPTION
Installation of nextcloud prevents database name to have dots inside.

This is not a limitation of database (Postgres and Mysql supports this), but an added constraint added out of the blue.

Nextcloud should not add limitation of their own. I'm installing broad list of services, and none of them have ever decided to enforce their own naming constraints by preventing their installation if we don't follow them. I'm using in my case the domain name of the service as database name (as another reporter of this bug did).

This topic was mentioned a few time in issues in owncloud, but these are locked and closed. However, it hits nexcloud the same.

https://github.com/owncloud/core/issues/19390
https://github.com/owncloud/core/issues/20381

Removing these 3 lines will make everything work for me on postgres...

How can I help more ? Many thanks.