### PR TITLE
Catch NotFoundException when getting the user folder

### DIFF
--- a/apps/dav/lib/BackgroundJob/UploadCleanup.php
+++ b/apps/dav/lib/BackgroundJob/UploadCleanup.php
@@ -55,10 +55,9 @@ class UploadCleanup extends TimedJob {
 		$uid = $argument['uid'];
 		$folder = $argument['folder'];
 
-		$userFolder = $this->rootFolder->getUserFolder($uid);
-		$userRoot = $userFolder->getParent();
-
 		try {
+			$userFolder = $this->rootFolder->getUserFolder($uid);
+			$userRoot = $userFolder->getParent();
 			/** @var Folder $uploads */
 			$uploads = $userRoot->get('uploads');
 			/** @var Folder $uploadFolder */


### PR DESCRIPTION
There might be cases where the job is scheduled and the user data is removed between scheduling and actually running the job, so we should catch the NotFoundException here as well, as it is done in https://github.com/nextcloud/server/blob/5bf3d1bb384da56adbf205752be8f840aac3b0c5/apps/dav/lib/Migration/ChunkCleanup.php#L75