### PR TITLE
Don't show referrer policy warning if fallback policy set.

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -573,12 +573,8 @@
 					});
 				}
 
-				if (!xhr.getResponseHeader('Referrer-Policy') ||
-					(xhr.getResponseHeader('Referrer-Policy').toLowerCase() !== 'no-referrer' &&
-					xhr.getResponseHeader('Referrer-Policy').toLowerCase() !== 'no-referrer-when-downgrade' &&
-					xhr.getResponseHeader('Referrer-Policy').toLowerCase() !== 'strict-origin' &&
-					xhr.getResponseHeader('Referrer-Policy').toLowerCase() !== 'strict-origin-when-cross-origin' &&
-					xhr.getResponseHeader('Referrer-Policy').toLowerCase() !== 'same-origin')) {
+				const referrerPolicy = xhr.getResponseHeader('Referrer-Policy')
+				if (referrerPolicy === null || !/(no-referrer(-when-downgrade)?|strict-origin(-when-cross-origin)?|same-origin)(,|$)/.test(referrerPolicy)) {
 					messages.push({
 						msg: t('core', 'The "{header}" HTTP header is not set to "{val1}", "{val2}", "{val3}", "{val4}" or "{val5}". This can leak referer information. See the <a target="_blank" rel="noreferrer noopener" href="{link}">W3C Recommendation ↗</a>.',
 							{
@@ -591,7 +587,7 @@
 								link: 'https://www.w3.org/TR/referrer-policy/'
 							}),
 						type: OC.SetupChecks.MESSAGE_TYPE_INFO
-					});
+					})
 				}
 			} else {
 				messages.push({


### PR DESCRIPTION
Fix #19416 

Accept `no-referrer, strict-orgin-when-cross-origin` as referrer policy. It does not validate that the fallback policy is probably unsafe.

cc @SuperSandro2000

