### PR TITLE
Fix loading icons on replaced elements

### DIFF
--- a/core/css/icons.scss
+++ b/core/css/icons.scss
@@ -81,7 +81,7 @@
 }
 
 /* Css replaced elements don't have ::after nor ::before */
-img, object, video, button, textarea, input, select, div[contenteditable='true'] {
+audio, canvas, embed, iframe, img, input, object, video {
 	&.icon-loading {
 		background-image: url('../img/loading.gif');
 	}

--- a/core/css/icons.scss
+++ b/core/css/icons.scss
@@ -82,16 +82,16 @@
 
 /* Css replaced elements don't have ::after nor ::before */
 img, object, video, button, textarea, input, select, div[contenteditable='true'] {
-	.icon-loading {
+	&.icon-loading {
 		background-image: url('../img/loading.gif');
 	}
-	.icon-loading-dark {
+	&.icon-loading-dark {
 		background-image: url('../img/loading-dark.gif');
 	}
-	.icon-loading-small {
+	&.icon-loading-small {
 		background-image: url('../img/loading-small.gif');
 	}
-	.icon-loading-small-dark {
+	&.icon-loading-small-dark {
 		background-image: url('../img/loading-small-dark.gif');
 	}
 }


### PR DESCRIPTION
Found while testing https://github.com/nextcloud/spreed/pull/2985

Replaced elements do not have `::after` nor `::before` pseudo-elements, so the regular loading icon needs to be shown using a background image instead of the default, and nicer looking, `::after` pseudo-element approach. However, the CSS rules were not applied to the replaced elements themselves, which are the ones that do not have `::after` pseudo-elements, but to their descendants.

Moreover, the list of replaced elements did not match [the current list of replaced elements from the spec](https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements). Therefore, showing the loading icon with a background image instead of with the default `::after` pseudo-element was applied to elements that do not need that (like `button`), and it was not applied to other elements that do (at least, in theory, although it is highly unlikely that a loading icon is added to, for example, an `audio` element, but they were added anyway for consistency with the spec).

Finally, note that the spec lists some elements as replaced elements or as ordinary elements depending on the context, like `input`. For now all the elements that might be replaced elements use the loading image by default, so apps will need to override that when the elements are treated as ordinary elements. Of course that can be flipped in the future to instead make an element to use the `::after` approach by default if it is found that the element requires the override often.
