### PR TITLE
Fix cursor on click inputs and their descendants

### DIFF
--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -178,6 +178,22 @@ input[type='reset'] {
 	cursor: pointer;
 	box-sizing: border-box;
 	background-color: var(--color-background-dark);
+
+	&:disabled {
+		cursor: default;
+	}
+}
+select,
+button, .button {
+	* {
+		cursor: pointer;
+	}
+
+	&:disabled {
+		* {
+			cursor: default;
+		}
+	}
 }
 
 /* Buttons */


### PR DESCRIPTION
Found while testing nextcloud/spreed#2985

The cursor in primary buttons is shown as a pointer (if the button is not disabled) to convey that it can be interacted with. However, if an icon is included in the button the icon would use the default cursor (as the icon is typically included through a `span` element), which causes a weird cursor change between the button icon and the rest of the button.

I considered adding a
```
* {
  cursor: pointer;
}
```
rule instead so the cursor was applied to any descendant of the primary element ([which is done for inputs](https://github.com/nextcloud/server/blob/8c8fe4a5c0866d074f3794c83274c8bf631bb423/core/css/styles.scss#L73-L78)), but it looked too broad (but reasonable nevertheless, as I guess that any descendant of a primary element should have the pointer cursor, so just tell me if you prefer that instead ;-) ).
