### PR TITLE
Don't try to resize a svg uploaded as background image

### DIFF
--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -280,8 +280,7 @@ class ThemingController extends Controller {
 			);
 		}
 
-		$resizeKeys = ['background'];
-		if (in_array($key, $resizeKeys, true)) {
+		if ($key === 'background' && strpos($detectedMimeType, 'image/svg') === false) {
 			// Optimize the image since some people may upload images that will be
 			// either to big or are not progressive rendering.
 			$newImage = @imagecreatefromstring(file_get_contents($image['tmp_name'], 'r'));


### PR DESCRIPTION
Fix #18727 

image* are gd functions without support for svg hence we are not able to resize them. 
