### PR TITLE
Always use status 200 for avatar response

### DIFF
--- a/core/Controller/AvatarController.php
+++ b/core/Controller/AvatarController.php
@@ -142,8 +142,8 @@ class AvatarController extends Controller {
 			$avatarFile = $avatar->getFile($size);
 			$resp = new FileDisplayResponse(
 				$avatarFile,
-				$avatar->isCustomAvatar() ? Http::STATUS_OK : Http::STATUS_CREATED,
-				['Content-Type' => $avatarFile->getMimeType()]
+				Http::STATUS_OK,
+				['Content-Type' => $avatarFile->getMimeType(), 'X-NC-IsCustomAvatar' => (int)$avatar->isCustomAvatar()]
 			);
 		} catch (\Exception $e) {
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);

--- a/tests/Core/Controller/AvatarControllerTest.php
+++ b/tests/Core/Controller/AvatarControllerTest.php
@@ -193,6 +193,8 @@ class AvatarControllerTest extends \Test\TestCase {
 		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
 		$this->assertArrayHasKey('Content-Type', $response->getHeaders());
 		$this->assertEquals('image type', $response->getHeaders()['Content-Type']);
+		$this->assertArrayHasKey('X-NC-IsCustomAvatar', $response->getHeaders());
+		$this->assertEquals('1', $response->getHeaders()['X-NC-IsCustomAvatar']);
 
 		$this->assertEquals('my etag', $response->getETag());
 	}
@@ -206,9 +208,11 @@ class AvatarControllerTest extends \Test\TestCase {
 
 		$response = $this->avatarController->getAvatar('userId', 32);
 
-		$this->assertEquals(Http::STATUS_CREATED, $response->getStatus());
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
 		$this->assertArrayHasKey('Content-Type', $response->getHeaders());
 		$this->assertEquals('image type', $response->getHeaders()['Content-Type']);
+		$this->assertArrayHasKey('X-NC-IsCustomAvatar', $response->getHeaders());
+		$this->assertEquals('0', $response->getHeaders()['X-NC-IsCustomAvatar']);
 
 		$this->assertEquals('my etag', $response->getETag());
 	}


### PR DESCRIPTION
Fix #18603 

As discussed in #18603 caching a 201 response is hard. It's now possible to distinguish between generated and uploaded avatars by reading the `X-NC-IsCustomAvatar` (0 = generated, 1 = uploaded) header.

cc @nextcloud/android @nextcloud/ios @nextcloud/desktop 
