### PR TITLE
Don't try to format deleted shares

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -768,6 +768,16 @@ class ShareAPIController extends OCSController {
 		$known = $formatted = $miniFormatted = [];
 		$resharingRight = false;
 		foreach ($shares as $share) {
+			try {
+				$share->getNode();
+			} catch (NotFoundException $e) {
+				/*
+				 * Ignore shares where we can't get the node
+				 * For example delted shares
+				 */
+				continue;
+			}
+
 			if (in_array($share->getId(), $known) || $share->getSharedWith() === $this->currentUser) {
 				continue;
 			}


### PR DESCRIPTION
Fixes #15455

The issue is that we have a fallback for shares to use the target. So
when the target exists again we happily format it (not that the shares
are still invalid).

This just tries to get the node. If we can't then boom.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>