### PR TITLE
18.0.2 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(18, 0, 1, 3);
+$OC_Version = array(18, 0, 2, 0);
 
 // The human readable string
-$OC_VersionString = '18.0.1';
+$OC_VersionString = '18.0.2 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #19439 [stable18] disable timeout on app install via cli
* #19441 [stable18] Show proper file name when fetching details fails
* #19451 [stable18] Don't create invalid users
* #19470 [stable18] when we receive intentional empty whats new info, do not try to show it
* #19481 [stable18] Reduce flow logging at INFO level, move to DEBUG
* #19516 [stable18] Continue with next foreach iteration
* #19522 [stable18] Allow to overwrite the path on the cache event
* #19573 [stable18] Move RefreshWebcalJob logic to a proper service so that it may be called independently
* #19574 [stable18] Make sure the secondary view registered for systemtags has an id
* #19591 [stable18] Strip of users home path from share api message
* #19607 [stable18] FIx logging in accessibility controller
* #19610 [stable18] Change the route generation of AuthPublicShareController.php
* #19612 Replace tab character with space
* #19624 [stable18] remove noise from detectUuid and cache results
* #19628 [stable18] Make sure that the transfer details are present in the database during the cron run
* #19630 [stable18] Fix hover state color of drag-n-drop with theming and dark mode
* #19636 [stable18] Correctly trim long cyrillic note
* #19639 [stable18] Hash event UID to make sure it's not too long for PushProvider notifications
* #19690 [stable18] Theme search results
* #19696 [stable18] Also cache avatars when it's not allowed
* #19702 [stable18] Revive the "send email to new users" toggle for the user form
* #19715 [stable18] Fix non-centered no javascript message
* #19729 [stable18] Allow single file downloads so the video player works again
* #19744 [stable18] Add message for DoesNotExistException
* #19762 Fetch translate for Tags from files app
* #19767 [stable18] Various user settings fixes
* #19773 [stable18] Do not allow transfer ownership when the user isn't the owner
* #19784 [stable18] Introduce a default refresh rate app setting for calendar subscriptions
* [activity#430](https://github.com/nextcloud/activity/pull/430) [stable18] Correctly set up Application class
* [files_videoplayer#153](https://github.com/nextcloud/files_videoplayer/pull/153) [stable18] Fix 18 public folder
* [files_videoplayer#156](https://github.com/nextcloud/files_videoplayer/pull/156) [stable18] Move to github actions
* [notifications#576](https://github.com/nextcloud/notifications/pull/576) [stable18] Fix push notifications for multibyte notifications
* [notifications#582](https://github.com/nextcloud/notifications/pull/582) [stable18] Prevent delete for impersonated users
* [notifications#583](https://github.com/nextcloud/notifications/pull/583) [stable18] Delete unknown devices
* [notifications#584](https://github.com/nextcloud/notifications/pull/584) [stable18] Fix long message
* [photos#211](https://github.com/nextcloud/photos/pull/211) [stable18] ignore unavailable storages while scanning for albums
* [photos#213](https://github.com/nextcloud/photos/pull/213) [stable18] Don't flatten out albums
* [serverinfo#177](https://github.com/nextcloud/serverinfo/pull/177) [stable18] Avoid line breaks after long device names in "df" command
* [serverinfo#178](https://github.com/nextcloud/serverinfo/pull/178) [stable18] Do not print errors if time server config is not available
* [viewer#405](https://github.com/nextcloud/viewer/pull/405) [stable18] Change sidebar file while changing file in slideshow
