### PR TITLE
16.0.9 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(16, 0, 8, 1);
+$OC_Version = array(16, 0, 9, 0);
 
 // The human readable string
-$OC_VersionString = '16.0.8';
+$OC_VersionString = '16.0.9 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #18230 Respect shareapi_allow_share_dialog_user_enumeration in Principal bac…
* #18885 Relax strict getHome behaviour for LDAP users in a shadow state
* #19096 Expose Argon2 options (as we did for bcrypt)
* #19209 Do not encode contacts menu mailto links
* #19285 For the DB ot pick an index specify the object_type
* #19310 Fix display of DTEND for multi-day all-day event
* #19362 Prevent archieved download on secure view
* #19371 Bump fstream from 1.0.11 to 1.0.12 in /build
* #19373 Bump lodash from 4.17.11 to 4.17.15 in /build
* #19374 Bump lodash.mergewith from 4.6.1 to 4.6.2 in /build
* #19453 Don't create invalid users
* #19472 When we receive intentional empty whats new info, do not try to show it
* #19594 Strip of users home path from share api message
* #19626 Remove noise from detectUuid and cache results
* #19638 Correctly trim long cyrillic note
* #19717 Fix non-centered no javascript message
* [files_videoplayer#158](https://github.com/nextcloud/files_videoplayer/pull/158) Move to github actions
* [viewer#386](https://github.com/nextcloud/viewer/pull/386) Stb16 actions