### PR TITLE
dont try to update storage mtime if we can't get the mtime

### DIFF
--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -224,12 +224,15 @@ class Updater implements IUpdater {
 	private function updateStorageMTimeOnly($internalPath) {
 		$fileId = $this->cache->getId($internalPath);
 		if ($fileId !== -1) {
-			$this->cache->update(
-				$fileId, [
-					'mtime' => null, // this magic tells it to not overwrite mtime
-					'storage_mtime' => $this->storage->filemtime($internalPath)
-				]
-			);
+			$mtime = $this->storage->filemtime($internalPath);
+			if ($mtime !== false) {
+				$this->cache->update(
+					$fileId, [
+						'mtime' => null, // this magic tells it to not overwrite mtime
+						'storage_mtime' => $mtime
+					]
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
same check as is already in place for `correctParentStorageMtime`