### PR TITLE
Dont always use the current users quota when calculating storage info

### DIFF
--- a/lib/private/legacy/helper.php
+++ b/lib/private/legacy/helper.php
@@ -42,6 +42,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OCP\IUser;
 use Symfony\Component\Process\ExecutableFinder;
 
 /**
@@ -503,19 +505,14 @@ class OC_Helper {
 				|| $storage->instanceOfStorage('\OC\Files\ObjectStore\HomeObjectStoreStorage')
 			) {
 				/** @var \OC\Files\Storage\Home $storage */
-				$userInstance = $storage->getUser();
-				$user = ($userInstance === null) ? null : $userInstance->getUID();
+				$user = $storage->getUser();
 			} else {
-				$user = \OC::$server->getUserSession()->getUser()->getUID();
+				$user = \OC::$server->getUserSession()->getUser();
 			}
-			if ($user) {
-				$quota = OC_Util::getUserQuota($user);
-			} else {
-				$quota = \OCP\Files\FileInfo::SPACE_UNLIMITED;
-			}
+			$quota = OC_Util::getUserQuota($user);
 			if ($quota !== \OCP\Files\FileInfo::SPACE_UNLIMITED) {
 				// always get free space / total space from root + mount points
-				return self::getGlobalStorageInfo();
+				return self::getGlobalStorageInfo($quota);
 			}
 		}
 
@@ -561,11 +558,10 @@ class OC_Helper {
 	/**
 	 * Get storage info including all mount points and quota
 	 *
+	 * @param int $quota
 	 * @return array
 	 */
-	private static function getGlobalStorageInfo() {
-		$quota = OC_Util::getUserQuota(\OCP\User::getUser());
-
+	private static function getGlobalStorageInfo($quota) {
 		$rootInfo = \OC\Files\Filesystem::getFileInfo('', 'ext');
 		$used = $rootInfo['size'];
 		if ($used < 0) {

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -251,8 +251,7 @@ class OC_Util {
 			) {
 				/** @var \OC\Files\Storage\Home $storage */
 				if (is_object($storage->getUser())) {
-					$user = $storage->getUser()->getUID();
-					$quota = OC_Util::getUserQuota($user);
+					$quota = OC_Util::getUserQuota($storage->getUser());
 					if ($quota !== \OCP\Files\FileInfo::SPACE_UNLIMITED) {
 						return new \OC\Files\Storage\Wrapper\Quota(array('storage' => $storage, 'quota' => $quota, 'root' => 'files'));
 					}
@@ -375,11 +374,10 @@ class OC_Util {
 	/**
 	 * Get the quota of a user
 	 *
-	 * @param string $userId
+	 * @param IUser|null $user
 	 * @return float Quota bytes
 	 */
-	public static function getUserQuota($userId) {
-		$user = \OC::$server->getUserManager()->get($userId);
+	public static function getUserQuota(?IUser $user) {
 		if (is_null($user)) {
 			return \OCP\Files\FileInfo::SPACE_UNLIMITED;
 		}


### PR DESCRIPTION
instead pass the quota as parameter.

Without this fix, when 'quota_include_external_storage' is enabled, the
webui will show the quota configured for the admin for every user
instead of the users quota

Signed-off-by: Robin Appelman <robin@icewind.nl>