### PR TITLE
Fix resharing of federated shares that were created out of links

### DIFF
--- a/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php
+++ b/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php
@@ -43,6 +43,7 @@ use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUserSession;
 use OCP\Share\IManager;
+use OCP\Share\IShare;
 
 /**
  * Class MountPublicLinkController
@@ -155,6 +156,7 @@ class MountPublicLinkController extends Controller {
 		}
 
 		$share->setSharedWith($shareWith);
+		$share->setShareType(IShare::TYPE_REMOTE);
 
 		try {
 			$this->federatedShareProvider->create($share);

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -492,15 +492,18 @@ class ShareAPIController extends OCSController {
 					throw new OCSNotFoundException($this->l->t('Public upload is only possible for publicly shared folders'));
 				}
 
-				$share->setPermissions(
-					Constants::PERMISSION_READ |
+				$permissions = Constants::PERMISSION_READ |
 					Constants::PERMISSION_CREATE |
 					Constants::PERMISSION_UPDATE |
-					Constants::PERMISSION_DELETE
-				);
+					Constants::PERMISSION_DELETE;
 			} else {
-				$share->setPermissions(Constants::PERMISSION_READ);
+				$permissions = Constants::PERMISSION_READ;
 			}
+			// TODO: It might make sense to have a dedicated setting to allow/deny converting link shares into federated ones
+			if ($this->shareManager->outgoingServer2ServerSharesAllowed()) {
+				$permissions |= Constants::PERMISSION_SHARE;
+			}
+			$share->setPermissions($permissions);
 
 			// Set password
 			if ($password !== '') {

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -203,7 +203,9 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 
 		$data = $result->getData();
-		$this->assertEquals(1, $data['permissions']);
+		$this->assertEquals(\OCP\Constants::PERMISSION_READ |
+			\OCP\Constants::PERMISSION_SHARE,
+			$data['permissions']);
 		$this->assertEmpty($data['expiration']);
 		$this->assertTrue(is_string($data['token']));
 
@@ -228,7 +230,8 @@ class ApiTest extends TestCase {
 			\OCP\Constants::PERMISSION_READ |
 			\OCP\Constants::PERMISSION_CREATE |
 			\OCP\Constants::PERMISSION_UPDATE |
-			\OCP\Constants::PERMISSION_DELETE,
+			\OCP\Constants::PERMISSION_DELETE |
+			\OCP\Constants::PERMISSION_SHARE,
 			$data['permissions']
 		);
 		$this->assertEmpty($data['expiration']);

--- a/build/integration/sharing_features/sharing-v1.feature
+++ b/build/integration/sharing_features/sharing-v1.feature
@@ -91,7 +91,7 @@ Feature: sharing
     And the HTTP status code should be "200"
     And Share fields of last share match with
       | id | A_NUMBER |
-      | permissions | 15 |
+      | permissions | 31 |
       | expiration | +3 days |
       | url | AN_URL |
       | token | A_TOKEN |
@@ -130,7 +130,7 @@ Feature: sharing
       | share_type | 3 |
       | file_source | A_NUMBER |
       | file_target | /FOLDER |
-      | permissions | 1 |
+      | permissions | 17 |
       | stime | A_NUMBER |
       | expiration | +3 days |
       | token | A_TOKEN |
@@ -163,7 +163,7 @@ Feature: sharing
       | share_type | 3 |
       | file_source | A_NUMBER |
       | file_target | /FOLDER |
-      | permissions | 1 |
+      | permissions | 17 |
       | stime | A_NUMBER |
       | token | A_TOKEN |
       | storage | A_NUMBER |

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -615,11 +615,6 @@ class Manager implements IManager {
 			throw new \Exception('Link sharing is not allowed');
 		}
 
-		// Link shares by definition can't have share permissions
-		if ($share->getPermissions() & \OCP\Constants::PERMISSION_SHARE) {
-			throw new \InvalidArgumentException('Link shares can’t have reshare permissions');
-		}
-
 		// Check if public upload is allowed
 		if (!$this->shareApiLinkAllowPublicUpload() &&
 			($share->getPermissions() & (\OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE))) {

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1373,24 +1373,6 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 
-	public function testLinkCreateChecksSharePermissions() {
-		$this->expectException(\Exception::class);
-		$this->expectExceptionMessage('Link shares can’t have reshare permissions');
-
-		$share = $this->manager->newShare();
-
-		$share->setPermissions(\OCP\Constants::PERMISSION_SHARE);
-
-		$this->config
-			->method('getAppValue')
-			->willReturnMap([
-				['core', 'shareapi_allow_links', 'yes', 'yes'],
-			]);
-
-		self::invokePrivate($this->manager, 'linkCreateChecks', [$share]);
-	}
-
-
 	public function testLinkCreateChecksNoPublicUpload() {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('Public upload is not allowed');


### PR DESCRIPTION
This basically fixes two seaparte issues that caused the issue description from below:
- When converting a link share into a federated share, the share type LINK was kept in the oc_share entry
- Link shares have reshare permissions by default now if outgoing server2server sharing is enabled

## Steps to reproduce

1. Create 3 different test users (User A, User B, User C)
2. User A shares a folder with the name “FOLDER” by link (with write perms) and sends this link to User B
3. User B takes this link and adds the shared folder to his Nextcloud space. User B can now access this shared folder as if it was his own folder.
4. User B shares the folder to User C as a “native” share (by searching for “User C” in the share dialog)
5. User C now sees the folder “FOLDER” in his personal Nextcloud space. As soon as User C clicks the folder it disappears and an error message pops up („Operation not permitted“). The folder is not listed under the normal files any more, but still shows up as “Shared with you”.

### Caveat

One unfixed part remains. Since before this patch accessing the reshare was possible for the first time and only failed on continuous requests. This is mainly caused by the super share being initialized first https://github.com/nextcloud/server/blob/5bf3d1bb384da56adbf205752be8f840aac3b0c5/apps/files_sharing/lib/SharedStorage.php#L90 and not being updated after the external share is being scanned and the permission of the node is updated https://github.com/nextcloud/server/blob/5bf3d1bb384da56adbf205752be8f840aac3b0c5/lib/private/Files/Cache/Watcher.php#L103 
