### PR TITLE
Fix filepicker list not being keyboard tabbable, ref #16494

### DIFF
--- a/core/templates/filepicker.html
+++ b/core/templates/filepicker.html
@@ -41,7 +41,7 @@
 				</tr>
 			</thead>
 			<tbody>
-				<tr data-entryname="{filename}" data-type="{type}">
+				<tr data-entryname="{filename}" data-type="{type}" tabindex="0">
 					<td class="filename"
 						style="background-image:url({icon})">
 						<span class="filename-parts">


### PR DESCRIPTION
This is the first part of fixing **Accessibility: When trying to move or copy a file, I can no longer pick the destination folder #16494**

- [x] "Move or copy" picker list needs to be keyboard tabbable
- [ ] When pressing Enter on a folder, that folder should be entered into. Currently the primary action (Move) is performed, which makes it impossible to actually move files

For the second part someone with JS knowledge needs to take over – cc @juliushaertl @skjnldsv 