### PR TITLE
Add config flag for subscription and hide server development notice

### DIFF
--- a/apps/settings/lib/Settings/Personal/ServerDevNotice.php
+++ b/apps/settings/lib/Settings/Personal/ServerDevNotice.php
@@ -27,8 +27,17 @@ namespace OCA\Settings\Settings\Personal;
 
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Settings\ISettings;
+use OCP\Support\Subscription\IRegistry;
 
 class ServerDevNotice implements ISettings {
+
+	/** @var IRegistry */
+	private $registry;
+
+	public function __construct(IRegistry $registry) {
+		$this->registry = $registry;
+	}
+
 	/**
 	 * @return TemplateResponse
 	 */
@@ -40,6 +49,10 @@ class ServerDevNotice implements ISettings {
 	 * @return string the section ID, e.g. 'sharing'
 	 */
 	public function getSection() {
+		if ($this->registry->delegateHasValidSubscription()) {
+			return null;
+		}
+
 		return 'personal-info';
 	}
 

--- a/apps/settings/tests/Controller/AdminSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/AdminSettingsControllerTest.php
@@ -37,6 +37,7 @@ use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Settings\IManager;
+use OCP\Support\Subscription\IRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -99,6 +100,7 @@ class AdminSettingsControllerTest extends TestCase {
 
 	public function testIndex() {
 		$user = $this->createMock(IUser::class);
+		$registry = $this->createMock(IRegistry::class);
 		$this->userSession
 			->method('getUser')
 			->willReturn($user);
@@ -123,7 +125,7 @@ class AdminSettingsControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getAdminSettings')
 			->with('test')
-			->willReturn([5 => new ServerDevNotice()]);
+			->willReturn([5 => new ServerDevNotice($registry)]);
 
 		$idx = $this->adminSettingsController->index('test');
 

--- a/lib/private/Support/Subscription/Registry.php
+++ b/lib/private/Support/Subscription/Registry.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace OC\Support\Subscription;
 
+use OCP\IConfig;
 use OCP\Support\Subscription\Exception\AlreadyRegisteredException;
 use OCP\Support\Subscription\IRegistry;
 use OCP\Support\Subscription\ISubscription;
@@ -36,6 +37,13 @@ class Registry implements IRegistry {
 
 	/** @var ISubscription */
 	private $subscription = null;
+
+	/** @var IConfig */
+	private $config;
+
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
 
 	/**
 	 * Register a subscription instance. In case it is called multiple times the
@@ -71,6 +79,11 @@ class Registry implements IRegistry {
 	 * @since 17.0.0
 	 */
 	public function delegateHasValidSubscription(): bool {
+		// Allow overwriting this manually for environments where the subscription information cannot be fetched
+		if ($this->config->getSystemValueBool('has_valid_subscription')) {
+			return true;
+		}
+
 		if ($this->subscription instanceof ISubscription) {
 			return $this->subscription->hasValidSubscription();
 		}

--- a/tests/lib/Support/Subscription/RegistryTest.php
+++ b/tests/lib/Support/Subscription/RegistryTest.php
@@ -23,8 +23,10 @@
 namespace Test\Support\Subscription;
 
 use OC\Support\Subscription\Registry;
+use OCP\IConfig;
 use OCP\Support\Subscription\ISubscription;
 use OCP\Support\Subscription\ISupportedApps;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class RegistryTest extends TestCase {
@@ -32,10 +34,14 @@ class RegistryTest extends TestCase {
 	/** @var Registry */
 	private $registry;
 
+	/** @var MockObject|IConfig */
+	private $config;
+
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->registry = new Registry();
+		$this->config = $this->createMock(IConfig::class);
+		$this->registry = new Registry($this->config);
 	}
 
 	/**
@@ -70,6 +76,16 @@ class RegistryTest extends TestCase {
 			->method('hasValidSubscription')
 			->willReturn(true);
 		$this->registry->register($subscription);
+
+		$this->assertSame(true, $this->registry->delegateHasValidSubscription());
+	}
+
+	public function testDelegateHasValidSubscriptionConfig() {
+		/* @var ISubscription|\PHPUnit_Framework_MockObject_MockObject $subscription */
+		$this->config->expects($this->once())
+			->method('getSystemValueBool')
+			->with('has_valid_subscription')
+			->willReturn(true);
 
 		$this->assertSame(true, $this->registry->delegateHasValidSubscription());
 	}


### PR DESCRIPTION
This allow overwriting this manually for environments where the subscription information cannot be fetched and makes sure that the development notice and social links are hidden in the personal settings if the subscription is valid.