### PR TITLE
Fix color-box-shadow variable

### DIFF
--- a/apps/accessibility/css/dark.scss
+++ b/apps/accessibility/css/dark.scss
@@ -12,7 +12,7 @@ $color-text-lighter: darken($color-main-text, 20%);
 $color-loading-light: #777;
 $color-loading-dark: #ccc;
 
-$color-box-shadow: rgba(darken($color-main-background, 70%), 0.5);
+$color-box-shadow: transparentize(darken($color-main-background, 70%), 0.5);
 
 $color-border: lighten($color-main-background, 7%);
 $color-border-dark: lighten($color-main-background, 14%);

--- a/core/css/variables.scss
+++ b/core/css/variables.scss
@@ -72,7 +72,7 @@ $image-favicon: url('../img/logo/logo.svg?v=1') !default;
 $color-loading-light: #ccc !default;
 $color-loading-dark: #444 !default;
 
-$color-box-shadow: rgba(nc-darken($color-main-background, 70%), 0.5) !default;
+$color-box-shadow: transparentize(nc-darken($color-main-background, 70%), 0.5) !default;
 
 // light border like file table or app-content list
 $color-border: nc-darken($color-main-background, 7%) !default;


### PR DESCRIPTION
The color-box-shadow variable wasn't properly transparentized

BEFORE: 
![Screenshot from 2020-03-06 13-45-05](https://user-images.githubusercontent.com/26852655/76084718-d8899700-5fb0-11ea-8f1f-9fd795424a64.png)

AFTER:
![Screenshot from 2020-03-06 13-45-34](https://user-images.githubusercontent.com/26852655/76084724-dde6e180-5fb0-11ea-9055-78a4be96ae45.png)



Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>