### PR TITLE
Don't break when one remote share is down

### DIFF
--- a/apps/files_sharing/lib/Controller/RemoteController.php
+++ b/apps/files_sharing/lib/Controller/RemoteController.php
@@ -117,6 +117,10 @@ class RemoteController extends OCSController {
 		$view = new \OC\Files\View('/' . \OC_User::getUser() . '/files/');
 		$info = $view->getFileInfo($share['mountpoint']);
 
+		if ($info === false) {
+			return $share;
+		}
+
 		$share['mimetype'] = $info->getMimetype();
 		$share['mtime'] = $info->getMTime();
 		$share['permissions'] = $info->getPermissions();


### PR DESCRIPTION
getFileInfo can also return false
Found while trying to improve on #14797 