### PR TITLE
Force compatible EventDispatcher version in integration tests

### DIFF
--- a/build/integration/composer.json
+++ b/build/integration/composer.json
@@ -4,6 +4,7 @@
     "behat/behat": "~3.6.1",
     "guzzlehttp/guzzle": "6.5.2",
     "jarnaiz/behat-junit-formatter": "^1.3",
-    "sabre/dav": "3.2.3"
+    "sabre/dav": "3.2.3",
+    "symfony/event-dispatcher": "~4.4"
   }
 }


### PR DESCRIPTION
Fixes a regression introduced in #19367

Nextcloud requires `EventDispatcher` from Symfony 4.4. Behat required Symfony 4.x until Behat 3.5, but since [Behat 3.6 it supports Symfony 5.x](https://packagist.org/packages/behat/behat#3.6.0) too. However, as the `EventDispatcher` version was not restricted in the _composer.json_ file Composer installed the latest compatible version with all the dependencies, which happened to be Symfony 5.x. This caused `EventDispatcher` from Symfony 5.x to be installed when running the integration tests, which caused a [PHP fatal error due to an incompatible declaration](https://github.com/nextcloud/server/pull/19777#issuecomment-597726761) (although only for the remote API tests, as [those are the only ones that import _base.php_](https://github.com/nextcloud/server/blob/5bf3d1bb384da56adbf205752be8f840aac3b0c5/build/integration/features/bootstrap/RemoteContext.php#L48)). To prevent that now the `EventDispatcher` is explicitly limited to Symfony 4.4 only.

Note that even if the EventDispatcher from Symfony 4.4 is installed other components of Symfony 5.x (like config or filesystem) are installed too, although this does not seem to cause any issue. Listing `symfony/symfony` instead of just `symfony/event-dispatcher` would cause all the components to be installed from Symfony 4.4, but that also pulled extra components that were not neeeded, so that is why I just used `symfony/event-dispatcher`.
