### PR TITLE
Do not use the instance name as user part of from mail addresses

### DIFF
--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -169,7 +169,7 @@ class Mailer implements IMailer {
 		$debugMode = $this->config->getSystemValue('mail_smtpdebug', false);
 
 		if (empty($message->getFrom())) {
-			$message->setFrom([\OCP\Util::getDefaultEmailAddress($this->defaults->getName()) => $this->defaults->getName()]);
+			$message->setFrom([\OCP\Util::getDefaultEmailAddress('no-reply') => $this->defaults->getName()]);
 		}
 
 		$failedRecipients = [];


### PR DESCRIPTION
This will cause issues since the theming name can contain characters
that are not allowed in the local part of the mail address (like spaces).

This can still be configured with a proper mail address using mail_from_address /  mail_domain in config.php