### PR TITLE
Remove user name from public sharing page

### DIFF
--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -123,6 +123,12 @@ thead {
 	opacity: 1;
 }
 
+#public-upload #emptycontent #displayavatar .icon-folder {
+	height: 48px;
+	width: 48px;
+	background-size: 48px;
+}
+
 #public-upload #emptycontent .button {
 	display: inline-block;
 	height: auto;

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -54,7 +54,7 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 		<label id="view-toggle" for="showgridview" class="button <?php p($_['showgridview'] ? 'icon-toggle-filelist' : 'icon-toggle-pictures') ?>"
 			title="<?php p($l->t('Toggle grid view'))?>"></label>
 	<?php } ?>
-	
+
 	<!-- files listing -->
 	<div id="files-public-content">
 		<div id="preview">
@@ -88,9 +88,14 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 		<div
 				id="emptycontent"
 				class="<?php if (!empty($_['note'])) { ?>has-note<?php } ?>">
-			<div id="displayavatar"><div class="avatardiv"></div></div>
-			<h2><?php p($l->t('Upload files to %s', [$_['shareOwner']])) ?></h2>
-			<p><span class="icon-folder"></span> <?php p($_['filename']) ?></p>
+			<?php if ($_['shareOwner']) { ?>
+				<div id="displayavatar"><div class="avatardiv"></div></div>
+				<h2><?php p($l->t('Upload files to %s', [$_['shareOwner']])) ?></h2>
+				<p><span class="icon-folder"></span> <?php p($_['filename']) ?></p>
+			<?php } else { ?>
+				<div id="displayavatar"><span class="icon-folder"></span></div>
+				<h2><?php p($l->t('Upload files to %s', [$_['filename']])) ?></h2>
+			<?php } ?>
 
 			<?php if (empty($_['note']) === false) { ?>
 				<h3><?php p($l->t('Note')); ?></h3>


### PR DESCRIPTION
Need to check the fallback from:
https://github.com/nextcloud/server/blob/5e4eda1ae0ea0ee7e690fee1017dae873a1a7512/apps/files_sharing/js/public.js#L391-L419

It seems like at least the userId is required to be leaked non the less, if we want to continue having this fallback available.