### PR TITLE
Add app config to disable user flows

### DIFF
--- a/apps/workflowengine/lib/Controller/UserWorkflowsController.php
+++ b/apps/workflowengine/lib/Controller/UserWorkflowsController.php
@@ -106,7 +106,7 @@ class UserWorkflowsController extends AWorkflowController {
 	protected function getScopeContext(): ScopeContext {
 		if($this->scopeContext === null) {
 			$user = $this->session->getUser();
-			if(!$user) {
+			if(!$user || !$this->manager->isUserScopeEnabled()) {
 				throw new OCSForbiddenException('User not logged in');
 			}
 			$this->scopeContext = new ScopeContext(IManager::SCOPE_USER, $user->getUID());

--- a/apps/workflowengine/lib/Manager.php
+++ b/apps/workflowengine/lib/Manager.php
@@ -23,6 +23,7 @@ namespace OCA\WorkflowEngine;
 
 use Doctrine\DBAL\DBALException;
 use OC\Cache\CappedMemoryCache;
+use OCA\WorkflowEngine\AppInfo\Application;
 use OCA\WorkflowEngine\Check\FileMimeType;
 use OCA\WorkflowEngine\Check\FileName;
 use OCA\WorkflowEngine\Check\FileSize;
@@ -40,6 +41,7 @@ use OCP\AppFramework\QueryException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Storage\IStorage;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\ILogger;
@@ -108,6 +110,9 @@ class Manager implements IManager {
 	/** @var IEventDispatcher */
 	private $dispatcher;
 
+	/** @var IConfig */
+	private $config;
+
 	public function __construct(
 		IDBConnection $connection,
 		IServerContainer $container,
@@ -115,7 +120,8 @@ class Manager implements IManager {
 		LegacyDispatcher $eventDispatcher,
 		ILogger $logger,
 		IUserSession $session,
-		IEventDispatcher $dispatcher
+		IEventDispatcher $dispatcher,
+		IConfig $config
 	) {
 		$this->connection = $connection;
 		$this->container = $container;
@@ -125,6 +131,7 @@ class Manager implements IManager {
 		$this->operationsByScope = new CappedMemoryCache(64);
 		$this->session = $session;
 		$this->dispatcher = $dispatcher;
+		$this->config = $config;
 	}
 
 	public function getRuleMatcher(): IRuleMatcher {
@@ -707,5 +714,9 @@ class Manager implements IManager {
 			$this->logger->logException($e);
 			return [];
 		}
+	}
+
+	public function isUserScopeEnabled(): bool {
+		return $this->config->getAppValue(Application::APP_ID, 'user_scope_disabled', 'no') === 'no';
 	}
 }

--- a/apps/workflowengine/lib/Service/RuleMatcher.php
+++ b/apps/workflowengine/lib/Service/RuleMatcher.php
@@ -117,7 +117,7 @@ class RuleMatcher implements IRuleMatcher {
 	public function getMatchingOperations(string $class, bool $returnFirstMatchingOperationOnly = true): array {
 		$scopes[] = new ScopeContext(IManager::SCOPE_ADMIN);
 		$user = $this->session->getUser();
-		if($user !== null) {
+		if($user !== null && $this->manager->isUserScopeEnabled()) {
 			$scopes[] = new ScopeContext(IManager::SCOPE_USER, $user->getUID());
 		}
 

--- a/apps/workflowengine/lib/Settings/ASettings.php
+++ b/apps/workflowengine/lib/Settings/ASettings.php
@@ -50,7 +50,7 @@ abstract class ASettings implements ISettings {
 	private $eventDispatcher;
 
 	/** @var Manager */
-	private $manager;
+	protected $manager;
 
 	/** @var IInitialStateService */
 	private $initialStateService;

--- a/apps/workflowengine/lib/Settings/Personal.php
+++ b/apps/workflowengine/lib/Settings/Personal.php
@@ -31,4 +31,8 @@ class Personal extends ASettings {
 	function getScope(): int {
 		return IManager::SCOPE_USER;
 	}
+
+	public function getSection() {
+		return $this->manager->isUserScopeEnabled() ? 'workflow' : null;
+	}
 }

--- a/apps/workflowengine/tests/ManagerTest.php
+++ b/apps/workflowengine/tests/ManagerTest.php
@@ -28,6 +28,7 @@ use OCA\WorkflowEngine\Helper\ScopeContext;
 use OCA\WorkflowEngine\Manager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\ILogger;
@@ -67,6 +68,8 @@ class ManagerTest extends TestCase {
 	protected $l;
 	/** @var MockObject|IEventDispatcher */
 	protected $dispatcher;
+	/** @var MockObject|IConfig */
+	protected $config;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -84,6 +87,7 @@ class ManagerTest extends TestCase {
 		$this->logger = $this->createMock(ILogger::class);
 		$this->session = $this->createMock(IUserSession::class);
 		$this->dispatcher = $this->createMock(IEventDispatcher::class);
+		$this->config = $this->createMock(IConfig::class);
 
 		$this->manager = new Manager(
 			\OC::$server->getDatabaseConnection(),
@@ -92,7 +96,8 @@ class ManagerTest extends TestCase {
 			$this->legacyDispatcher,
 			$this->logger,
 			$this->session,
-			$this->dispatcher
+			$this->dispatcher,
+			$this->config
 		);
 		$this->clearTables();
 	}


### PR DESCRIPTION
Implements https://github.com/nextcloud/server/issues/19804

With this admins can disable user flows since they can have quite some impact on the performance of a system and you might not want to give users the ability to define their own flows while still making use of the administrator level ones like file_accesscontrol/automated tagging

Can be enabled by running:
`occ config:app:set workflowengine user_scope_disabled --value yes`