### PR TITLE
Handle unset owner in sharing

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -302,7 +302,7 @@ class Manager implements IManager {
 		$isFederatedShare = $share->getNode()->getStorage()->instanceOfStorage('\OCA\Files_Sharing\External\Storage');
 		$permissions = 0;
 		$mount = $share->getNode()->getMountPoint();
-		if (!$isFederatedShare && $share->getNode()->getOwner()->getUID() !== $share->getSharedBy()) {
+		if (!$isFederatedShare && $share->getNode()->getOwner() && $share->getNode()->getOwner()->getUID() !== $share->getSharedBy()) {
 			// When it's a reshare use the parent share permissions as maximum
 			$userMountPointId = $mount->getStorageRootId();
 			$userMountPoints = $userFolder->getById($userMountPointId);
@@ -711,7 +711,11 @@ class Manager implements IManager {
 			}
 			$share->setShareOwner($parent->getOwner()->getUID());
 		} else {
-			$share->setShareOwner($share->getNode()->getOwner()->getUID());
+			if ($share->getNode()->getOwner()) {
+				$share->setShareOwner($share->getNode()->getOwner()->getUID());
+			} else {
+				$share->setShareOwner($share->getSharedBy());
+			}
 		}
 
 		//Verify share type


### PR DESCRIPTION
Follow up to https://github.com/nextcloud/server/pull/19424/files

My problem with this is the return type of the Note api is documented as `IUser` and not `IUser|null`, and I expect a lot more apps to fall into this pit.

Would it make sense to return the last mounted user as owner instead?