### PR TITLE
Actually check if the owner is not null

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1687,6 +1687,11 @@ class View {
 		if (!$info) {
 			throw new NotFoundException($path . ' not found while trying to get owner');
 		}
+
+		if ($info->getOwner() === null) {
+			throw new NotFoundException($path . ' has no owner');
+		}
+
 		return $info->getOwner()->getUID();
 	}
 


### PR DESCRIPTION
Else this can error out on storages that do not have an owner (e.g.
groupfolders).

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>