### PR TITLE
Update the target when it isempty after sharing

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -784,6 +784,11 @@ class Manager implements IManager {
 		//reuse the node we already have
 		$share->setNode($oldShare->getNode());
 
+		// Reset the target if it is null for the new share
+		if ($share->getTarget() === '') {
+			$share->setTarget($target);
+		}
+
 		// Post share event
 		$event = new GenericEvent($share);
 		$this->legacyDispatcher->dispatch('OCP\Share::postShare', $event);


### PR DESCRIPTION
Hooks that listen to it (audit log) benefit from having the target
properly set.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>