### PR TITLE
Only do regular polling of storage statistics if session_keepalive is enabled

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -291,7 +291,7 @@
 			setTimeout(Files.displayStorageWarnings, 100);
 
 			// only possible at the moment if user is logged in or the files app is loaded
-			if (OC.currentUser && OCA.Files.App) {
+			if (OC.currentUser && OCA.Files.App && OC.config.session_keepalive) {
 				// start on load - we ask the server every 5 minutes
 				var func = _.bind(OCA.Files.App.fileList.updateStorageStatistics, OCA.Files.App.fileList);
 				var updateStorageStatisticsInterval = 5*60*1000;


### PR DESCRIPTION
The polling interval is set to 5 minutes, so the session will never timeout if `session_lifetime` is set to a higher value then 5 minutes.