### PR TITLE
Fix single "ScopeContext" passed to "setScopes"

### DIFF
--- a/apps/workflowengine/lib/Service/RuleMatcher.php
+++ b/apps/workflowengine/lib/Service/RuleMatcher.php
@@ -143,7 +143,7 @@ class RuleMatcher implements IRuleMatcher {
 				if ($this->entity->isLegitimatedForUserId($scopeCandidate->getScopeId())) {
 					$ctx = new LogContext();
 					$ctx
-						->setScopes($scopeCandidate)
+						->setScopes([$scopeCandidate])
 						->setEntity($this->entity)
 						->setOperation($this->operation);
 					$this->logger->logScopeExpansion($ctx);


### PR DESCRIPTION
[`setScopes` expects an array](https://github.com/nextcloud/server/blob/761a663667ae6a0d2bcc137b7fe0a37ba88af175/apps/workflowengine/lib/Helper/LogContext.php#L40), but a [single `ScopeContext`](https://github.com/nextcloud/server/blob/46aaeb45612e20b6f460396533faf7f26ed1d6f7/apps/workflowengine/lib/Service/RuleMatcher.php#L139) was being passed instead.

## How to test

- Enable the Talk app
- Create a new conversation named Test
- Open the Flow personal settings
- Create a new _Write to conversation_ flow _When file created and mime type is folder then write to conversation Test_
- Open the Files app
- Create a new folder and share by link with permissions to upload and edit
- Copy the share link
- In a private window, open the share link
- Create a new folder

### Result with this pull request

The folder appears in the list.

### Result without this pull request

The error _Could not create folder_ is shown (although if the public share page is reloaded it can be seen that the folder was actually created).

