### PR TITLE
18.0.3 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(18, 0, 2, 2);
+$OC_Version = array(18, 0, 3, 0);
 
 // The human readable string
-$OC_VersionString = '18.0.2';
+$OC_VersionString = '18.0.3 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #19879 [stable18] Use contacts name on federated activities
* #19882 [stable18]  Allow to edit admin/own user in the user management
* #19884 [stable18] Fix hostname in Apple configuration profile
* #19886 [stable18] Don't break when one remote share is down
* #19897 [stable18] Properly emit Viewer event on files and files_sharing
* #19916 [stable18] Get correct mimetype on objectstores
* #19921 [stable18] Properly respect hide download on sharebymail
* #19922 [stable18] Use placeholder values for password fields in external storage webui
* #19924 [stable18] Do not use the instance name as user part of from mail addresses
* #19933 [stable18] Don't allow anchors and queries in remote urls
* #19940 [stable18] fix external storage controller tests
* #19945 Bump acorn from 6.3.0 to 6.4.1
* #19950 [stable18] properly set 'hide_download' as integer
* #19966 [stable18] fix safari useragent for versions with 3 digits
* #19982 [stable18] Fix default action for deleted shares
* #19998 [stable18] Default value of lookupServerEnabled should be the same everywhere
* [firstrunwizard#301](https://github.com/nextcloud/firstrunwizard/pull/301) Bump acorn from 7.1.0 to 7.1.1
* [photos#239](https://github.com/nextcloud/photos/pull/239) Bump acorn from 6.3.0 to 6.4.1
* [viewer#422](https://github.com/nextcloud/viewer/pull/422) Public pages compatibility
* [viewer#425](https://github.com/nextcloud/viewer/pull/425) Bump acorn from 5.7.3 to 5.7.4


Pending PRs:

* [ ] #19999 [stable18] Only do regular polling of storage statistics if session_keepalive is enabled @backportbot-nextcloud
* [ ] #20001 [stable18] Fix single "ScopeContext" passed to "setScopes" @backportbot-nextcloud
