### PR TITLE
17.0.5 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(17, 0, 4, 2);
+$OC_Version = array(17, 0, 5, 0);
 
 // The human readable string
-$OC_VersionString = '17.0.4';
+$OC_VersionString = '17.0.5 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #19885 Fix hostname in Apple configuration profile
* #19917 Get correct mimetype on objectstores
* #19925 Do not use the instance name as user part of from mail addresses
* #20000 Default value of lookupServerEnabled should be the same everywhere
* [firstrunwizard#303](https://github.com/nextcloud/firstrunwizard/pull/303) Bump acorn from 6.1.1 to 6.4.1
* [notifications#590](https://github.com/nextcloud/notifications/pull/590) Bump acorn from 6.1.1 to 6.4.1


Pending PRs:

* [ ] #19983 Fix default action for deleted shares @rullzer
