### PR TITLE
Do not use the deprecated service name

### DIFF
--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -83,10 +83,6 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 
 		$container = $this->getContainer();
 
-		$container->registerService(IUserMountCache::class, function (IAppContainer $c) {
-			return $c->getServer()->query('UserMountCache');
-		});
-
 		/** @var BackendService $backendService */
 		$backendService = $container->query(BackendService::class);
 		$backendService->registerBackendProvider($this);


### PR DESCRIPTION
Fixes 

```
{"reqId":"775f9dJzsK8Q1vwVw2t7","level":0,"time":"2020-03-19T14:01:01+00:00","remoteAddr":"::1","user":"admin","app":"serverDI","method":"PROPFIND","url":"/remote.php/dav/addressbooks/users/admin/app-generated--contactsinteraction--recent/1","message":"The requested alias \"UserMountCache\" is depreacted. Please request \"OCP\\Files\\Config\\IUserMountCache\" directly. This alias will be removed in a future Nextcloud version.","userAgent":"Mozilla/5.0 (X11; Linux x86_64; rv:74.0) Gecko/20100101 Firefox/74.0","version":"19.0.0.0"}
```

spamming nextcloud.log.