### PR TITLE
Ignore unavailable app on foreign route call

### DIFF
--- a/lib/private/AppFramework/Routing/RouteConfig.php
+++ b/lib/private/AppFramework/Routing/RouteConfig.php
@@ -33,7 +33,9 @@ declare(strict_types=1);
 namespace OC\AppFramework\Routing;
 
 use OC\AppFramework\DependencyInjection\DIContainer;
+use OCP\App\AppPathNotFoundException;
 use OCP\AppFramework\App;
+use OCP\ILogger;
 use OCP\Route\IRouter;
 
 /**
@@ -170,6 +172,18 @@ class RouteConfig {
 				} else if ($controllerName === 'RequesthandlerController') {
 					$controllerName = 'RequestHandlerController';
 				}
+
+				if ($this->appName !== $appName) {
+					try {
+						\OC::$server->getAppManager()->getAppPath($appName);
+					} catch (AppPathNotFoundException $e) {
+						\OC::$server->getLogger()->logException($e, [
+							'level' => ILogger::DEBUG,
+						]);
+						continue;
+					}
+				}
+
 				$controllerName = App::buildAppNamespace($appName) . '\\Controller\\' . $controllerName;
 			}
 


### PR DESCRIPTION
Turns out with non default apps_path the Talk installation still fails because the path is wrong invalid causing double namespace registration again.

Fix https://github.com/nextcloud/spreed/issues/2806

I'm very close to just killing the restriction for apps instead to have their prefix, and just do the same as with ocs routes, just allow it for apps to be in root but don't promote it. If they don't specify a `root` we fall back to the `apps/{id}` like before...