### PR TITLE
fixes auto-detecting UUID attributes

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1734,7 +1734,6 @@ class Access extends LDAPUtility {
 					$this->connection->$uuidAttr = $attribute;
 					return true;
 				}
-				continue;
 			}
 
 			$value = $this->readAttribute($dn, $attribute);
@@ -1750,9 +1749,6 @@ class Access extends LDAPUtility {
 				$this->connection->$uuidAttr = $attribute;
 				$this->connection->writeToCache($uuidAttr, $attribute);
 				return true;
-			} elseif ($value === false) {
-				// record not available
-				return false;
 			}
 		}
 		\OC::$server->getLogger()->debug('Could not autodetect the UUID attribute', ['app' => 'user_ldap']);


### PR DESCRIPTION
fixes #19970 (a regression introduced with https://github.com/nextcloud/server/pull/19549)

* the continue (and later the early return) avoided proper looping over the other attribute candidates
* less code is better