### PR TITLE
Force compatible dependency versions in acceptance tests

### DIFF
--- a/tests/acceptance/composer.json
+++ b/tests/acceptance/composer.json
@@ -1,9 +1,9 @@
 {
   "require-dev": {
     "behat/behat": "^3.0",
-    "behat/mink": "^1.5",
+    "behat/mink": "1.7.1",
     "behat/mink-extension": "*",
-    "behat/mink-selenium2-driver": "*",
+    "behat/mink-selenium2-driver": "1.3.1",
     "phpunit/phpunit": "~4.6"
   },
   "autoload": {


### PR DESCRIPTION
`behat/mink 1.8` and `behat/mink-selenium2-driver 1.4` introduced behaviour changes that broke the acceptance tests. Until the tests are updated to work with the newer versions the last known versions are forced.

Note that some acceptance tests still fail after enforcing the compatible versions, although that is caused by changes in the Nextcloud server itself.
