### PR TITLE
Adjust acceptance tests to incoming shares being accepted by default

### DIFF
--- a/tests/acceptance/features/app-comments.feature
+++ b/tests/acceptance/features/app-comments.feature
@@ -47,7 +47,6 @@ Feature: app-comments
     And I create a new comment with "Hello world" as message
     And I see a comment with "Hello world" as message
     When I act as Jane
-    And I accept the share for "shared.txt" in the notifications
     # The Files app is open again to reload the file list and the comments
     And I open the Files app
     And I open the details view for "shared.txt"
@@ -64,7 +63,6 @@ Feature: app-comments
     And I share "shared.txt" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
-    And I accept the share for "shared.txt" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I open the details view for "shared.txt"
@@ -94,7 +92,6 @@ Feature: app-comments
     And I create a new comment with "Hello world" as message
     And I see a comment with "Hello world" as message
     When I act as Jane
-    And I accept the share for "shared.txt" in the notifications
     # The Files app is open again to reload the file list and the comments
     And I open the Files app
     Then I see that "shared.txt" has unread comments
@@ -112,7 +109,6 @@ Feature: app-comments
     And I share "shared.txt" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
-    And I accept the share for "shared.txt" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I open the details view for "shared.txt"
@@ -141,7 +137,6 @@ Feature: app-comments
     And I create a new comment with "Hello world" as message
     And I see a comment with "Hello world" as message
     When I act as Jane
-    And I accept the share for "Folder" in the notifications
     # The Files app is open again to reload the file list and the comments
     And I open the Files app
     Then I see that "Folder" has unread comments
@@ -159,7 +154,6 @@ Feature: app-comments
     And I share "Folder" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
-    And I accept the share for "Folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I open the details view for "Folder"
@@ -190,7 +184,6 @@ Feature: app-comments
     And I create a new comment with "Hello world" as message
     And I see a comment with "Hello world" as message
     When I act as Jane
-    And I accept the share for "Folder" in the notifications
     # The Files app is open again to reload the file list and the comments
     And I open the Files app
     And I enter in the folder named "Folder"
@@ -209,7 +202,6 @@ Feature: app-comments
     And I share "Folder" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
-    And I accept the share for "Folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I enter in the folder named "Folder"
@@ -264,7 +256,6 @@ Feature: app-comments
     And I share "shared.txt" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
-    And I accept the share for "shared.txt" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I open the details view for "shared.txt"

--- a/tests/acceptance/features/app-files-sharing.feature
+++ b/tests/acceptance/features/app-files-sharing.feature
@@ -11,7 +11,6 @@ Feature: app-files-sharing
     When I share "farewell.txt" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
-    And I accept the share for "farewell.txt" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     Then I see that the file list contains a file named "farewell.txt"
@@ -30,11 +29,28 @@ Feature: app-files-sharing
     When I share "welcome.txt" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
-    And I accept the share for "welcome.txt" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     Then I see that the file list contains a file named "welcome (2).txt"
     And I open the details view for "welcome (2).txt"
+    And I see that the details view is open
+    And I open the "Sharing" tab in the details view
+    And I see that the "Sharing" tab in the details view is eventually loaded
+    And I see that the file is shared with me by "admin"
+
+  Scenario: share a skeleton file with another user before first login
+    # If a file is shared with a user before her first login the skeleton would
+    # not have been created, so if the shared file has the same name as one from
+    # the skeleton the shared file will take its place and the skeleton file
+    # will not be added.
+    Given I act as John
+    And I am logged in as the admin
+    When I share "welcome.txt" with "user0"
+    And I see that the file is shared with "user0"
+    And I act as Jane
+    And I am logged in
+    Then I see that the file list contains a file named "welcome.txt"
+    And I open the details view for "welcome.txt"
     And I see that the details view is open
     And I open the "Sharing" tab in the details view
     And I see that the "Sharing" tab in the details view is eventually loaded
@@ -53,13 +69,11 @@ Feature: app-files-sharing
     And I share "farewell.txt" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
-    And I accept the share for "farewell.txt" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     When I share "farewell.txt" with "user1"
     And I see that the file is shared with "user1"
     And I act as Jim
-    And I accept the share for "farewell.txt" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     Then I see that the file list contains a file named "farewell.txt"
@@ -80,7 +94,6 @@ Feature: app-files-sharing
     And I share "farewell.txt" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
-    And I accept the share for "farewell.txt" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I share "farewell.txt" with "user1"
@@ -106,7 +119,6 @@ Feature: app-files-sharing
     When I share "Shared folder" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
-    And I accept the share for "Shared folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     Then I see that the file list contains a file named "Shared folder"
@@ -130,7 +142,6 @@ Feature: app-files-sharing
     And I create a new folder named "Subfolder"
     And I see that the file list contains a file named "Subfolder"
     When I act as Jane
-    And I accept the share for "Shared folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I enter in the folder named "Shared folder"
@@ -147,7 +158,6 @@ Feature: app-files-sharing
     And I share "Shared folder" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
-    And I accept the share for "Shared folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I enter in the folder named "Shared folder"
@@ -170,7 +180,6 @@ Feature: app-files-sharing
     And I share "Shared folder" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
-    And I accept the share for "Shared folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I share "Shared folder" with "user1"
@@ -179,7 +188,6 @@ Feature: app-files-sharing
     And I create a new folder named "Subfolder"
     And I see that the file list contains a file named "Subfolder"
     When I act as Jim
-    And I accept the share for "Shared folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I enter in the folder named "Shared folder"
@@ -198,12 +206,10 @@ Feature: app-files-sharing
     And I share "Shared folder" with "user0"
     And I see that the file is shared with "user0"
     And I act as Jane
-    And I accept the share for "Shared folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I share "Shared folder" with "user1"
     And I act as Jim
-    And I accept the share for "Shared folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I enter in the folder named "Shared folder"
@@ -226,7 +232,6 @@ Feature: app-files-sharing
     And I set the share with "user0" as not reshareable
     And I see that "user0" can not reshare the share
     When I act as Jane
-    And I accept the share for "Shared folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     Then I see that the file list contains a file named "Shared folder"
@@ -253,7 +258,6 @@ Feature: app-files-sharing
     And I create a new folder named "Subfolder"
     And I see that the file list contains a file named "Subfolder"
     When I act as Jane
-    And I accept the share for "Shared folder" in the notifications
     # The Files app is open again to reload the file list
     And I open the Files app
     And I enter in the folder named "Shared folder"

--- a/tests/acceptance/features/app-files-sharing.feature
+++ b/tests/acceptance/features/app-files-sharing.feature
@@ -20,6 +20,33 @@ Feature: app-files-sharing
     And I see that the "Sharing" tab in the details view is eventually loaded
     And I see that the file is shared with me by "admin"
 
+  Scenario: share a file with another user that needs to accept shares
+    Given I act as John
+    And I am logged in as the admin
+    And I act as Jane
+    And I am logged in
+    And I visit the settings page
+    And I open the "Sharing" section
+    And I disable accepting the shares by default
+    And I see that shares are not accepted by default
+    And I act as John
+    And I rename "welcome.txt" to "farewell.txt"
+    And I see that the file list contains a file named "farewell.txt"
+    When I share "farewell.txt" with "user0"
+    And I see that the file is shared with "user0"
+    And I act as Jane
+    And I open the Files app
+    And I see that the file list does not contain a file named "farewell.txt"
+    And I accept the share for "/farewell.txt" in the notifications
+    # The Files app is open again to reload the file list
+    And I open the Files app
+    Then I see that the file list contains a file named "farewell.txt"
+    And I open the details view for "farewell.txt"
+    And I see that the details view is open
+    And I open the "Sharing" tab in the details view
+    And I see that the "Sharing" tab in the details view is eventually loaded
+    And I see that the file is shared with me by "admin"
+
   Scenario: share a file with another user who already has a file with that name
     Given I act as John
     And I am logged in as the admin

--- a/tests/acceptance/features/bootstrap/NotificationsContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsContext.php
@@ -87,7 +87,7 @@ class NotificationsContext implements Context, ActorAwareInterface {
 		// As the waiting is long enough already the find timeout multiplier is
 		// capped at 2 when finding notifications.
 		$findTimeoutMultiplier = $this->actor->getFindTimeoutMultiplier();
-		$this->actor->setFindTimeoutMultiplier(max(2, $findTimeoutMultiplier));
+		$this->actor->setFindTimeoutMultiplier(min(2, $findTimeoutMultiplier));
 		$this->actor->find(self::acceptButtonInIncomingShareNotificationForFile($fileName), 35)->click();
 		$this->actor->setFindTimeoutMultiplier($findTimeoutMultiplier);
 

--- a/tests/acceptance/features/bootstrap/SettingsContext.php
+++ b/tests/acceptance/features/bootstrap/SettingsContext.php
@@ -30,6 +30,25 @@ class SettingsContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function acceptSharesByDefaultCheckbox() {
+		// forThe()->checkbox("Accept user...") can not be used here; that would
+		// return the checkbox itself, but the element that the user interacts
+		// with is the label.
+		return Locator::forThe()->xpath("//label[normalize-space() = 'Accept user and group shares by default']")->
+				describedAs("Accept shares by default checkbox in Sharing section in Personal Sharing Settings");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function acceptSharesByDefaultCheckboxInput() {
+		return Locator::forThe()->checkbox("Accept user and group shares by default")->
+				describedAs("Accept shares by default checkbox input in Sharing section in Personal Sharing Settings");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function systemTagsSelectTagButton() {
 		return Locator::forThe()->id("s2id_systemtag")->
 				describedAs("Select tag button in system tags section in Administration Settings");
@@ -85,12 +104,37 @@ class SettingsContext implements Context, ActorAwareInterface {
 	}
 
 	/**
+	 * @When I disable accepting the shares by default
+	 */
+	public function iDisableAcceptingTheSharesByDefault() {
+		$this->iSeeThatSharesAreAcceptedByDefault();
+
+		$this->actor->find(self::acceptSharesByDefaultCheckbox(), 2)->click();
+	}
+
+	/**
 	 * @When I create the tag :tag in the settings
 	 */
 	public function iCreateTheTagInTheSettings($tag) {
 		$this->actor->find(self::systemTagsResetButton(), 10)->click();
 		$this->actor->find(self::systemTagsTagNameInput())->setValue($tag);
 		$this->actor->find(self::systemTagsCreateOrUpdateButton())->click();
+	}
+
+	/**
+	 * @Then I see that shares are accepted by default
+	 */
+	public function iSeeThatSharesAreAcceptedByDefault() {
+		PHPUnit_Framework_Assert::assertTrue(
+				$this->actor->find(self::acceptSharesByDefaultCheckboxInput(), 10)->isChecked());
+	}
+
+	/**
+	 * @Then I see that shares are not accepted by default
+	 */
+	public function iSeeThatSharesAreNotAcceptedByDefault() {
+		PHPUnit_Framework_Assert::assertFalse(
+				$this->actor->find(self::acceptSharesByDefaultCheckboxInput(), 10)->isChecked());
 	}
 
 	/**


### PR DESCRIPTION
Follow up to #18940

Now the acceptance tests assume that the share is accepted by default (so they no longer wait for the notification), and a specific test was added to verify the behaviour when the user has disabled accepting shares by default.