### PR TITLE
Unify default value for restricting user enumeration with settings

### DIFF
--- a/apps/dav/lib/CardDAV/SystemAddressbook.php
+++ b/apps/dav/lib/CardDAV/SystemAddressbook.php
@@ -41,7 +41,7 @@ class SystemAddressbook extends AddressBook {
 
 	public function getChildren() {
 		$shareEnumeration = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
-		$restrictShareEnumeration = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'yes') === 'yes';
+		$restrictShareEnumeration = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'no') === 'yes';
 		if (!$shareEnumeration || ($shareEnumeration && $restrictShareEnumeration)) {
 			return [];
 		}

--- a/lib/private/Contacts/ContactsMenu/ContactsStore.php
+++ b/lib/private/Contacts/ContactsMenu/ContactsStore.php
@@ -107,7 +107,7 @@ class ContactsStore implements IContactsStore {
 									array $entries,
 									$filter) {
 		$disallowEnumeration = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') !== 'yes';
-		$restrictEnumeration = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'yes') === 'yes';
+		$restrictEnumeration = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'no') === 'yes';
 		$excludedGroups = $this->config->getAppValue('core', 'shareapi_exclude_groups', 'no') === 'yes';
 
 		// whether to filter out local users

--- a/tests/acceptance/features/bootstrap/SettingsContext.php
+++ b/tests/acceptance/features/bootstrap/SettingsContext.php
@@ -49,6 +49,25 @@ class SettingsContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function restrictUsernameAutocompletionToGroupsCheckbox() {
+		// forThe()->checkbox("Restrict username...") can not be used here; that
+		// would return the checkbox itself, but the element that the user
+		// interacts with is the label.
+		return Locator::forThe()->xpath("//label[normalize-space() = 'Restrict username autocompletion to users within the same groups']")->
+				describedAs("Restrict username autocompletion to groups checkbox in Sharing section in Administration Sharing Settings");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function restrictUsernameAutocompletionToGroupsCheckboxInput() {
+		return Locator::forThe()->checkbox("Restrict username autocompletion to users within the same groups")->
+				describedAs("Restrict username autocompletion to groups checkbox input in Sharing section in Administration Sharing Settings");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function systemTagsSelectTagButton() {
 		return Locator::forThe()->id("s2id_systemtag")->
 				describedAs("Select tag button in system tags section in Administration Settings");
@@ -113,6 +132,15 @@ class SettingsContext implements Context, ActorAwareInterface {
 	}
 
 	/**
+	 * @When I enable restricting username autocompletion to groups
+	 */
+	public function iEnableRestrictingUsernameAutocompletionToGroups() {
+		$this->iSeeThatUsernameAutocompletionIsNotRestrictedToGroups();
+
+		$this->actor->find(self::restrictUsernameAutocompletionToGroupsCheckbox(), 2)->click();
+	}
+
+	/**
 	 * @When I create the tag :tag in the settings
 	 */
 	public function iCreateTheTagInTheSettings($tag) {
@@ -127,6 +155,22 @@ class SettingsContext implements Context, ActorAwareInterface {
 	public function iSeeThatSharesAreAcceptedByDefault() {
 		PHPUnit_Framework_Assert::assertTrue(
 				$this->actor->find(self::acceptSharesByDefaultCheckboxInput(), 10)->isChecked());
+	}
+
+	/**
+	 * @Then I see that username autocompletion is restricted to groups
+	 */
+	public function iSeeThatUsernameAutocompletionIsRestrictedToGroups() {
+		PHPUnit_Framework_Assert::assertTrue(
+				$this->actor->find(self::restrictUsernameAutocompletionToGroupsCheckboxInput(), 10)->isChecked());
+	}
+
+	/**
+	 * @Then I see that username autocompletion is not restricted to groups
+	 */
+	public function iSeeThatUsernameAutocompletionIsNotRestrictedToGroups() {
+		PHPUnit_Framework_Assert::assertFalse(
+				$this->actor->find(self::restrictUsernameAutocompletionToGroupsCheckboxInput(), 10)->isChecked());
 	}
 
 	/**

--- a/tests/acceptance/features/header.feature
+++ b/tests/acceptance/features/header.feature
@@ -28,6 +28,17 @@ Feature: header
     And I see that the contact "user0" in the Contacts menu is shown
     And I see that the contact "admin" in the Contacts menu is not shown
 
+  Scenario: users from other groups are not seen in the contacts menu when autocompletion is restricted within the same group
+    Given I am logged in as the admin
+    And I visit the settings page
+    And I open the "Sharing" section of the "Administration" group
+    And I enable restricting username autocompletion to groups
+    And I see that username autocompletion is restricted to groups
+    When I open the Contacts menu
+    Then I see that the Contacts menu is shown
+    And I see that the contact "user0" in the Contacts menu is not shown
+    And I see that the contact "admin" in the Contacts menu is not shown
+
   Scenario: just added users are seen in the contacts menu
     Given I am logged in as the admin
     And I open the User settings

--- a/tests/lib/Contacts/ContactsMenu/ContactsStoreTest.php
+++ b/tests/lib/Contacts/ContactsMenu/ContactsStoreTest.php
@@ -178,7 +178,7 @@ class ContactsStoreTest extends TestCase {
 
 		$this->config->expects($this->at(1))
 			->method('getAppValue')
-			->with($this->equalTo('core'), $this->equalTo('shareapi_restrict_user_enumeration_to_group'), $this->equalTo('yes'))
+			->with($this->equalTo('core'), $this->equalTo('shareapi_restrict_user_enumeration_to_group'), $this->equalTo('no'))
 			->willReturn('no');
 
 		$this->config->expects($this->at(2))
@@ -234,7 +234,7 @@ class ContactsStoreTest extends TestCase {
 			->willReturn('yes');
 
 		$this->config->expects($this->at(1)) ->method('getAppValue')
-			->with($this->equalTo('core'), $this->equalTo('shareapi_restrict_user_enumeration_to_group'), $this->equalTo('yes'))
+			->with($this->equalTo('core'), $this->equalTo('shareapi_restrict_user_enumeration_to_group'), $this->equalTo('no'))
 			->willReturn('no');
 
 		$this->config->expects($this->at(2)) ->method('getAppValue')
@@ -320,7 +320,7 @@ class ContactsStoreTest extends TestCase {
 			->willReturn('yes');
 
 		$this->config->expects($this->at(1)) ->method('getAppValue')
-			->with($this->equalTo('core'), $this->equalTo('shareapi_restrict_user_enumeration_to_group'), $this->equalTo('yes'))
+			->with($this->equalTo('core'), $this->equalTo('shareapi_restrict_user_enumeration_to_group'), $this->equalTo('no'))
 			->willReturn('yes');
 
 		$this->config->expects($this->at(2)) ->method('getAppValue')


### PR DESCRIPTION
Follow up to #19569

If the value was never enabled or disabled, the settings show _Restrict username enumeration to groups_ as disabled. However, in some components it was enabled by default, which caused an inconsistency in the behaviour with respect to the settings, for example in the contacts menu.

The acceptance tests for _header_ were failing because of this. I have also added a new test to check the behaviour when username autocompletion is restricted to groups.
