### PR TITLE
Fix generated avatars and nophoto cache files

### DIFF
--- a/apps/dav/lib/CardDAV/PhotoCache.php
+++ b/apps/dav/lib/CardDAV/PhotoCache.php
@@ -108,7 +108,7 @@ class PhotoCache {
 		$data = $this->getPhoto($card);
 
 		if ($data === false || !isset($data['Content-Type'])) {
-			$folder->newFile('nophoto');
+			$folder->newFile('nophoto', '');
 			return;
 		}
 
@@ -116,7 +116,7 @@ class PhotoCache {
 		$extension = self::ALLOWED_CONTENT_TYPES[$contentType] ?? null;
 
 		if ($extension === null) {
-			$folder->newFile('nophoto');
+			$folder->newFile('nophoto', '');
 			return;
 		}
 

--- a/lib/private/Avatar/UserAvatar.php
+++ b/lib/private/Avatar/UserAvatar.php
@@ -252,7 +252,7 @@ class UserAvatar extends Avatar {
 			$avatar->putContent($data);
 			$ext = 'png';
 
-			$this->folder->newFile('generated');
+			$this->folder->newFile('generated', '');
 			$this->config->setUserValue($this->user->getUID(), 'avatar', 'generated', 'true');
 		}
 


### PR DESCRIPTION
Since nextcloud/server#19493 newFile() by default does not write the file anymore.
Setting an empty string as content will make it write the file immediate,
without having to call putContent() afterwards.

### Note
This was a very drastic change which is not easily noticable with quick testing (especially as most people mock away filesystem stuff in their unit tests). Should at least add it to the release notes!