### PR TITLE
Auto accept group shares for users added to a group

### DIFF
--- a/apps/files_sharing/composer/composer/autoload_classmap.php
+++ b/apps/files_sharing/composer/composer/autoload_classmap.php
@@ -50,6 +50,7 @@ return array(
     'OCA\\Files_Sharing\\ISharedStorage' => $baseDir . '/../lib/ISharedStorage.php',
     'OCA\\Files_Sharing\\Listener\\LoadAdditionalListener' => $baseDir . '/../lib/Listener/LoadAdditionalListener.php',
     'OCA\\Files_Sharing\\Listener\\LoadSidebarListener' => $baseDir . '/../lib/Listener/LoadSidebarListener.php',
+    'OCA\\Files_Sharing\\Listener\\UserAddedToGroupListener' => $baseDir . '/../lib/Listener/UserAddedToGroupListener.php',
     'OCA\\Files_Sharing\\Listener\\UserShareAcceptanceListener' => $baseDir . '/../lib/Listener/UserShareAcceptanceListener.php',
     'OCA\\Files_Sharing\\Middleware\\OCSShareAPIMiddleware' => $baseDir . '/../lib/Middleware/OCSShareAPIMiddleware.php',
     'OCA\\Files_Sharing\\Middleware\\ShareInfoMiddleware' => $baseDir . '/../lib/Middleware/ShareInfoMiddleware.php',

--- a/apps/files_sharing/composer/composer/autoload_static.php
+++ b/apps/files_sharing/composer/composer/autoload_static.php
@@ -65,6 +65,7 @@ class ComposerStaticInitFiles_Sharing
         'OCA\\Files_Sharing\\ISharedStorage' => __DIR__ . '/..' . '/../lib/ISharedStorage.php',
         'OCA\\Files_Sharing\\Listener\\LoadAdditionalListener' => __DIR__ . '/..' . '/../lib/Listener/LoadAdditionalListener.php',
         'OCA\\Files_Sharing\\Listener\\LoadSidebarListener' => __DIR__ . '/..' . '/../lib/Listener/LoadSidebarListener.php',
+        'OCA\\Files_Sharing\\Listener\\UserAddedToGroupListener' => __DIR__ . '/..' . '/../lib/Listener/UserAddedToGroupListener.php',
         'OCA\\Files_Sharing\\Listener\\UserShareAcceptanceListener' => __DIR__ . '/..' . '/../lib/Listener/UserShareAcceptanceListener.php',
         'OCA\\Files_Sharing\\Middleware\\OCSShareAPIMiddleware' => __DIR__ . '/..' . '/../lib/Middleware/OCSShareAPIMiddleware.php',
         'OCA\\Files_Sharing\\Middleware\\ShareInfoMiddleware' => __DIR__ . '/..' . '/../lib/Middleware/ShareInfoMiddleware.php',

--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -39,6 +39,7 @@ use OCA\Files_Sharing\External\Manager;
 use OCA\Files_Sharing\Listener\GlobalShareAcceptanceListener;
 use OCA\Files_Sharing\Listener\LoadAdditionalListener;
 use OCA\Files_Sharing\Listener\LoadSidebarListener;
+use OCA\Files_Sharing\Listener\UserAddedToGroupListener;
 use OCA\Files_Sharing\Listener\UserShareAcceptanceListener;
 use OCA\Files_Sharing\Middleware\OCSShareAPIMiddleware;
 use OCA\Files_Sharing\Middleware\ShareInfoMiddleware;
@@ -54,6 +55,7 @@ use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\ICloudIdManager;
 use OCP\Files\Config\IMountProviderCollection;
+use OCP\Group\Events\UserAddedEvent;
 use OCP\IContainer;
 use OCP\IGroup;
 use OCP\IServerContainer;
@@ -215,6 +217,7 @@ class Application extends App {
 			\OCP\Util::addScript('files_sharing', 'dist/collaboration');
 		});
 		$dispatcher->addServiceListener(ShareCreatedEvent::class, UserShareAcceptanceListener::class);
+		$dispatcher->addServiceListener(UserAddedEvent::class, UserAddedToGroupListener::class);
 
 		// notifications api to accept incoming user shares
 		$dispatcher->addListener('OCP\Share::postShare', function(GenericEvent $event) {

--- a/apps/files_sharing/lib/Listener/UserAddedToGroupListener.php
+++ b/apps/files_sharing/lib/Listener/UserAddedToGroupListener.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_Sharing\Listener;
+
+use OCA\Files_Sharing\AppInfo\Application;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Group\Events\UserAddedEvent;
+use OCP\IConfig;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+
+class UserAddedToGroupListener implements IEventListener {
+
+	/** @var IManager */
+	private $shareManager;
+
+	/** @var IConfig */
+	private $config;
+
+	public function __construct(IManager $shareManager, IConfig $config) {
+		$this->shareManager = $shareManager;
+		$this->config = $config;
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof UserAddedEvent)) {
+			return;
+		}
+
+		$user = $event->getUser();
+		$group = $event->getGroup();
+
+		// This user doesn't have autoaccept so we can skip it all
+		if (!$this->hasAutoAccept($user->getUID())) {
+			return;
+		}
+
+		// Get all group shares this user has access to now to filter later
+		$shares = $this->shareManager->getSharedWith($user->getUID(), IShare::TYPE_GROUP);
+
+		foreach ($shares as $share) {
+			// If this is not the new group we can skip it
+			if ($share->getSharedWith() !== $group->getGID()) {
+				continue;
+			}
+
+			// Accept the share if needed
+			$this->shareManager->acceptShare($share, $user->getUID());
+		}
+	}
+
+
+	private function hasAutoAccept(string $userId): bool {
+		$defaultAcceptSystemConfig = $this->config->getSystemValueBool('sharing.enable_share_accept', false) ? 'no' : 'yes';
+		$acceptDefault = $this->config->getUserValue($userId, Application::APP_ID, 'default_accept', $defaultAcceptSystemConfig) === 'yes';
+		return (!$this->config->getSystemValueBool('sharing.force_share_accept', false) && $acceptDefault);
+	}
+
+}


### PR DESCRIPTION
In case auto accepting is enabled (the default). Users that are newly
added to a group should not have to accept those shares.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>