### PR TITLE
Also bail out when the path is actually null

### DIFF
--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -831,7 +831,7 @@ class DefaultShareProvider implements IShareProvider {
 	 */
 	private function isAccessibleResult($data) {
 		// exclude shares leading to deleted file entries
-		if ($data['fileid'] === null) {
+		if ($data['fileid'] === null || $data['path'] === null) {
 			return false;
 		}
 


### PR DESCRIPTION
Apparently this can happen when a external mount was shared
that is later not available anymore

Ref https://help.nextcloud.com/t/nextcloud-talk-kills-nextcloud-after-update-to-v18-0-3/75257

@daita please check if you have this code in circles too