### PR TITLE
update icewind/smb to 3.2.1

### DIFF
--- a/apps/files_external/3rdparty/composer.json
+++ b/apps/files_external/3rdparty/composer.json
@@ -9,6 +9,6 @@
 	},
 	"require": {
 		"icewind/streams": "0.7.1",
-		"icewind/smb": "3.1.1"
+		"icewind/smb": "3.2.1"
 	}
 }

--- a/apps/files_external/3rdparty/composer.lock
+++ b/apps/files_external/3rdparty/composer.lock
@@ -4,29 +4,29 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5639a09feff2318b1b69e11a10a81e7d",
+    "content-hash": "adc3b3531ee8503b485092e60c569b42",
     "packages": [
         {
             "name": "icewind/smb",
-            "version": "v3.1.1",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/icewind1991/SMB.git",
-                "reference": "26b7b8780342d0e61313b464b880d50a2ea898e2"
+                "reference": "5330edcc579a2dcc4759b8e5779eb5aa3385a878"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/icewind1991/SMB/zipball/26b7b8780342d0e61313b464b880d50a2ea898e2",
-                "reference": "26b7b8780342d0e61313b464b880d50a2ea898e2",
+                "url": "https://api.github.com/repos/icewind1991/SMB/zipball/5330edcc579a2dcc4759b8e5779eb5aa3385a878",
+                "reference": "5330edcc579a2dcc4759b8e5779eb5aa3385a878",
                 "shasum": ""
             },
             "require": {
                 "icewind/streams": ">=0.2.0",
-                "php": ">=5.6"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.13",
-                "phpunit/phpunit": "^5.7"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "autoload": {
@@ -46,7 +46,7 @@
                 }
             ],
             "description": "php wrapper for smbclient and libsmbclient-php",
-            "time": "2019-03-04T15:02:42+00:00"
+            "time": "2020-03-24T18:19:18+00:00"
         },
         {
             "name": "icewind/streams",
@@ -97,5 +97,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/apps/files_external/3rdparty/composer/autoload_classmap.php
+++ b/apps/files_external/3rdparty/composer/autoload_classmap.php
@@ -6,6 +6,7 @@ $vendorDir = dirname(dirname(__FILE__));
 $baseDir = $vendorDir;
 
 return array(
+    'Icewind\\SMB\\ACL' => $vendorDir . '/icewind/smb/src/ACL.php',
     'Icewind\\SMB\\AbstractServer' => $vendorDir . '/icewind/smb/src/AbstractServer.php',
     'Icewind\\SMB\\AbstractShare' => $vendorDir . '/icewind/smb/src/AbstractShare.php',
     'Icewind\\SMB\\AnonymousAuth' => $vendorDir . '/icewind/smb/src/AnonymousAuth.php',

--- a/apps/files_external/3rdparty/composer/autoload_real.php
+++ b/apps/files_external/3rdparty/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInit98fe9b281934250b3a93f69a5ce843b3
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/files_external/3rdparty/composer/autoload_static.php
+++ b/apps/files_external/3rdparty/composer/autoload_static.php
@@ -36,6 +36,7 @@ class ComposerStaticInit98fe9b281934250b3a93f69a5ce843b3
     );
 
     public static $classMap = array (
+        'Icewind\\SMB\\ACL' => __DIR__ . '/..' . '/icewind/smb/src/ACL.php',
         'Icewind\\SMB\\AbstractServer' => __DIR__ . '/..' . '/icewind/smb/src/AbstractServer.php',
         'Icewind\\SMB\\AbstractShare' => __DIR__ . '/..' . '/icewind/smb/src/AbstractShare.php',
         'Icewind\\SMB\\AnonymousAuth' => __DIR__ . '/..' . '/icewind/smb/src/AnonymousAuth.php',

--- a/apps/files_external/3rdparty/composer/installed.json
+++ b/apps/files_external/3rdparty/composer/installed.json
@@ -1,28 +1,28 @@
 [
     {
         "name": "icewind/smb",
-        "version": "v3.1.1",
-        "version_normalized": "3.1.1.0",
+        "version": "v3.2.1",
+        "version_normalized": "3.2.1.0",
         "source": {
             "type": "git",
             "url": "https://github.com/icewind1991/SMB.git",
-            "reference": "26b7b8780342d0e61313b464b880d50a2ea898e2"
+            "reference": "5330edcc579a2dcc4759b8e5779eb5aa3385a878"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/icewind1991/SMB/zipball/26b7b8780342d0e61313b464b880d50a2ea898e2",
-            "reference": "26b7b8780342d0e61313b464b880d50a2ea898e2",
+            "url": "https://api.github.com/repos/icewind1991/SMB/zipball/5330edcc579a2dcc4759b8e5779eb5aa3385a878",
+            "reference": "5330edcc579a2dcc4759b8e5779eb5aa3385a878",
             "shasum": ""
         },
         "require": {
             "icewind/streams": ">=0.2.0",
-            "php": ">=5.6"
+            "php": ">=7.1"
         },
         "require-dev": {
             "friendsofphp/php-cs-fixer": "^2.13",
-            "phpunit/phpunit": "^5.7"
+            "phpunit/phpunit": "^7.0"
         },
-        "time": "2019-03-04T15:02:42+00:00",
+        "time": "2020-03-24T18:19:18+00:00",
         "type": "library",
         "installation-source": "dist",
         "autoload": {

--- a/apps/files_external/3rdparty/icewind/smb/.gitignore
+++ b/apps/files_external/3rdparty/icewind/smb/.gitignore
@@ -2,4 +2,5 @@
 vendor
 composer.lock
 .php_cs.cache
-
+listen.php
+test.php

--- a/apps/files_external/3rdparty/icewind/smb/README.md
+++ b/apps/files_external/3rdparty/icewind/smb/README.md
@@ -26,7 +26,7 @@ use Icewind\SMB\BasicAuth;
 require('vendor/autoload.php');
 
 $serverFactory = new ServerFactory();
-$auth = new BasicAuth('test', 'workgroup', 'test');
+$auth = new BasicAuth('user', 'workgroup', 'password');
 $server = $serverFactory->createServer('localhost', $auth);
 
 $share = $server->getShare('test');

--- a/apps/files_external/3rdparty/icewind/smb/composer.json
+++ b/apps/files_external/3rdparty/icewind/smb/composer.json
@@ -9,11 +9,11 @@
 		}
 	],
 	"require"          : {
-		"php": ">=5.6",
+		"php": ">=7.1",
 		"icewind/streams": ">=0.2.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^5.7",
+		"phpunit/phpunit": "^7.0",
 		"friendsofphp/php-cs-fixer": "^2.13"
 	},
 	"autoload"         : {

--- a/apps/files_external/3rdparty/icewind/smb/src/ACL.php
+++ b/apps/files_external/3rdparty/icewind/smb/src/ACL.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Icewind\SMB;
+
+class ACL {
+	const TYPE_ALLOW = 0;
+	const TYPE_DENY = 1;
+
+	const MASK_READ = 0x0001;
+	const MASK_WRITE = 0x0002;
+	const MASK_EXECUTE = 0x00020;
+	const MASK_DELETE = 0x10000;
+
+	const FLAG_OBJECT_INHERIT = 0x1;
+	const FLAG_CONTAINER_INHERIT = 0x2;
+
+	private $type;
+	private $flags;
+	private $mask;
+
+	public function __construct(int $type, int $flags, int $mask) {
+		$this->type = $type;
+		$this->flags = $flags;
+		$this->mask = $mask;
+	}
+
+	/**
+	 * Check if the acl allows a specific permissions
+	 *
+	 * Note that this does not take inherited acls into account
+	 *
+	 * @param int $mask one of the ACL::MASK_* constants
+	 * @return bool
+	 */
+	public function allows(int $mask): bool {
+		return $this->type === self::TYPE_ALLOW && ($this->mask & $mask) === $mask;
+	}
+
+	/**
+	 * Check if the acl allows a specific permissions
+	 *
+	 * Note that this does not take inherited acls into account
+	 *
+	 * @param int $mask one of the ACL::MASK_* constants
+	 * @return bool
+	 */
+	public function denies(int $mask): bool {
+		return $this->type === self::TYPE_DENY && ($this->mask & $mask) === $mask;
+	}
+
+	public function getType(): int {
+		return $this->type;
+	}
+
+	public function getFlags(): int {
+		return $this->flags;
+	}
+
+	public function getMask(): int {
+		return $this->mask;
+	}
+}

--- a/apps/files_external/3rdparty/icewind/smb/src/IFileInfo.php
+++ b/apps/files_external/3rdparty/icewind/smb/src/IFileInfo.php
@@ -65,4 +65,9 @@ interface IFileInfo {
 	 * @return bool
 	 */
 	public function isArchived();
+
+	/**
+	 * @return ACL[]
+	 */
+	public function getAcls(): array;
 }

--- a/apps/files_external/3rdparty/icewind/smb/src/ISystem.php
+++ b/apps/files_external/3rdparty/icewind/smb/src/ISystem.php
@@ -49,6 +49,13 @@ interface ISystem {
 	public function getNetPath();
 
 	/**
+	 * Get the full path to the `smbcacls` binary of false if the binary is not available
+	 *
+	 * @return string|bool
+	 */
+	public function getSmbcAclsPath();
+
+	/**
 	 * Get the full path to the `stdbuf` binary of false if the binary is not available
 	 *
 	 * @return string|bool

--- a/apps/files_external/3rdparty/icewind/smb/src/Native/NativeShare.php
+++ b/apps/files_external/3rdparty/icewind/smb/src/Native/NativeShare.php
@@ -94,9 +94,7 @@ class NativeShare extends AbstractShare {
 			$name = $file['name'];
 			if ($name !== '.' and $name !== '..') {
 				$fullPath = $path . '/' . $name;
-				$files [] = new NativeFileInfo($this, $fullPath, $name, function () use ($fullPath) {
-					return $this->getStat($fullPath);
-				});
+				$files [] = new NativeFileInfo($this, $fullPath, $name);
 			}
 		}
 
@@ -109,7 +107,12 @@ class NativeShare extends AbstractShare {
 	 * @return \Icewind\SMB\IFileInfo
 	 */
 	public function stat($path) {
-		return new NativeFileInfo($this, $path, self::mb_basename($path), $this->getStat($path));
+		$info = new NativeFileInfo($this, $path, self::mb_basename($path));
+
+		// trigger attribute loading
+		$info->getSize();
+
+		return $info;
 	}
 
 	/**
@@ -127,10 +130,6 @@ class NativeShare extends AbstractShare {
 		}
 
 		return '';
-	}
-
-	private function getStat($path) {
-		return $this->getState()->stat($this->buildUrl($path));
 	}
 
 	/**
@@ -223,6 +222,12 @@ class NativeShare extends AbstractShare {
 		if (!$target) {
 			throw new InvalidPathException('Invalid target path: Filename cannot be empty');
 		}
+
+		$sourceHandle = $this->getState()->open($this->buildUrl($source), 'r');
+		if (!$sourceHandle) {
+			throw new InvalidResourceException('Failed opening remote file "' . $source . '" for reading');
+		}
+
 		$targetHandle = @fopen($target, 'wb');
 		if (!$targetHandle) {
 			$error = error_get_last();
@@ -231,13 +236,8 @@ class NativeShare extends AbstractShare {
 			} else {
 				$reason = 'Unknown error';
 			}
+			$this->getState()->close($sourceHandle);
 			throw new InvalidResourceException('Failed opening local file "' . $target . '" for writing: ' . $reason);
-		}
-
-		$sourceHandle = $this->getState()->open($this->buildUrl($source), 'r');
-		if (!$sourceHandle) {
-			fclose($targetHandle);
-			throw new InvalidResourceException('Failed opening remote file "' . $source . '" for reading');
 		}
 
 		while ($data = $this->getState()->read($sourceHandle, NativeReadStream::CHUNK_SIZE)) {
@@ -289,7 +289,7 @@ class NativeShare extends AbstractShare {
 	 */
 	public function append($source) {
 		$url = $this->buildUrl($source);
-		$handle = $this->getState()->open($url, "a");
+		$handle = $this->getState()->open($url, "a+");
 		return NativeWriteStream::wrap($this->getState(), $handle, "a", $url);
 	}
 

--- a/apps/files_external/3rdparty/icewind/smb/src/Native/NativeState.php
+++ b/apps/files_external/3rdparty/icewind/smb/src/Native/NativeState.php
@@ -9,6 +9,7 @@ namespace Icewind\SMB\Native;
 
 use Icewind\SMB\Exception\AlreadyExistsException;
 use Icewind\SMB\Exception\ConnectionRefusedException;
+use Icewind\SMB\Exception\ConnectionResetException;
 use Icewind\SMB\Exception\Exception;
 use Icewind\SMB\Exception\FileInUseException;
 use Icewind\SMB\Exception\ForbiddenException;
@@ -48,6 +49,7 @@ class NativeState {
 		22  => InvalidArgumentException::class,
 		28  => OutOfSpaceException::class,
 		39  => NotEmptyException::class,
+		104 => ConnectionResetException::class,
 		110 => TimedOutException::class,
 		111 => ConnectionRefusedException::class,
 		112 => HostDownException::class,

--- a/apps/files_external/3rdparty/icewind/smb/src/System.php
+++ b/apps/files_external/3rdparty/icewind/smb/src/System.php
@@ -41,6 +41,10 @@ class System implements ISystem {
 		return $this->getBinaryPath('net');
 	}
 
+	public function getSmbcAclsPath() {
+		return $this->getBinaryPath('smbcacls');
+	}
+
 	public function getStdBufPath() {
 		return $this->getBinaryPath('stdbuf');
 	}

--- a/apps/files_external/3rdparty/icewind/smb/src/Wrapped/Connection.php
+++ b/apps/files_external/3rdparty/icewind/smb/src/Wrapped/Connection.php
@@ -117,8 +117,9 @@ class Connection extends RawConnection {
 	}
 
 	public function close($terminate = true) {
-		if (is_resource($this->getInputStream())) {
-			$this->write('close' . PHP_EOL);
+		if (get_resource_type($this->getInputStream()) === 'stream') {
+			// ignore any errors while trying to send the close command, the process might already be dead
+			@$this->write('close' . PHP_EOL);
 		}
 		parent::close($terminate);
 	}

--- a/apps/files_external/3rdparty/icewind/smb/src/Wrapped/FileInfo.php
+++ b/apps/files_external/3rdparty/icewind/smb/src/Wrapped/FileInfo.php
@@ -7,6 +7,7 @@
 
 namespace Icewind\SMB\Wrapped;
 
+use Icewind\SMB\ACL;
 use Icewind\SMB\IFileInfo;
 
 class FileInfo implements IFileInfo {
@@ -36,18 +37,25 @@ class FileInfo implements IFileInfo {
 	protected $mode;
 
 	/**
+	 * @var callable
+	 */
+	protected $aclCallback;
+
+	/**
 	 * @param string $path
 	 * @param string $name
 	 * @param int $size
 	 * @param int $time
 	 * @param int $mode
+	 * @param callable $aclCallback
 	 */
-	public function __construct($path, $name, $size, $time, $mode) {
+	public function __construct($path, $name, $size, $time, $mode, callable $aclCallback) {
 		$this->path = $path;
 		$this->name = $name;
 		$this->size = $size;
 		$this->time = $time;
 		$this->mode = $mode;
+		$this->aclCallback = $aclCallback;
 	}
 
 	/**
@@ -111,5 +119,12 @@ class FileInfo implements IFileInfo {
 	 */
 	public function isArchived() {
 		return (bool)($this->mode & IFileInfo::MODE_ARCHIVE);
+	}
+
+	/**
+	 * @return ACL[]
+	 */
+	public function getAcls(): array {
+		return ($this->aclCallback)();
 	}
 }

--- a/apps/files_external/3rdparty/icewind/smb/src/Wrapped/RawConnection.php
+++ b/apps/files_external/3rdparty/icewind/smb/src/Wrapped/RawConnection.php
@@ -173,18 +173,6 @@ class RawConnection {
 			return;
 		}
 		if ($terminate) {
-			// if for case that posix_ functions are not available
-			if (function_exists('posix_kill')) {
-				$status = proc_get_status($this->process);
-				$ppid = $status['pid'];
-				$pids = preg_split('/\s+/', `ps -o pid --no-heading --ppid $ppid`);
-				foreach ($pids as $pid) {
-					if (is_numeric($pid)) {
-						//9 is the SIGKILL signal
-						posix_kill($pid, 9);
-					}
-				}
-			}
 			proc_terminate($this->process);
 		}
 		proc_close($this->process);


### PR DESCRIPTION
Highlights include

- allow reading ACL's (this pr does not include the logic to use those acls)
- reduce the number of requests needed to populate `FileInfo`