### PR TITLE
normalize smb path while listing folder contents

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -207,7 +207,7 @@ class SMB extends Common implements INotifyStorage {
 	 */
 	protected function getFolderContents($path) {
 		try {
-			$path = $this->buildPath($path);
+			$path = ltrim($this->buildPath($path), '/');
 			$files = $this->share->dir($path);
 			foreach ($files as $file) {
 				$this->statCache[$path . '/' . $file->getName()] = $file;


### PR DESCRIPTION
currently when listing `'/'`, it will include a double slash in the paths used for the listing logic
this causes unneeeded cache misses in the statCache

Signed-off-by: Robin Appelman <robin@icewind.nl>