### PR TITLE
Allow to have multiple links per public calendar

### DIFF
--- a/apps/dav/lib/CalDAV/Calendar.php
+++ b/apps/dav/lib/CalDAV/Calendar.php
@@ -350,21 +350,32 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IShareable {
 		return $uris;
 	}
 
-	/**
-	 * @param boolean $value
-	 * @return string|null
-	 */
-	public function setPublishStatus($value) {
-		$publicUri = $this->caldavBackend->setPublishStatus($value, $this);
-		$this->calendarInfo['publicuri'] = $publicUri;
+	public function addPublicLink() {
+		$publicUri = $this->caldavBackend->addPublicLink($this);
+		$this->calendarInfo['publicuris'][] = $publicUri;
 		return $publicUri;
 	}
 
+	public function removePublicLink(string $publicUri) {
+		$this->caldavBackend->removePublicLink($this, $publicUri);
+	}
+
+	public function removeAllPublicLinks() {
+		$this->caldavBackend->removeAllPublicLinks($this);
+	}
+
 	/**
-	 * @return mixed $value
+	 * @return bool $value
 	 */
-	public function getPublishStatus() {
-		return $this->caldavBackend->getPublishStatus($this);
+	public function getPublishStatus(): bool {
+		return count($this->getPublicURIs()) > 0;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function getPublicURIs() : array {
+		return array_map(function ($publicURI) { return $publicURI['publicuri']; }, $this->caldavBackend->getPublicURIs($this));
 	}
 
 	public function canWrite() {

--- a/apps/dav/lib/CalDAV/Publishing/Xml/Publisher.php
+++ b/apps/dav/lib/CalDAV/Publishing/Xml/Publisher.php
@@ -30,33 +30,26 @@ use Sabre\Xml\XmlSerializable;
 class Publisher implements XmlSerializable {
 
 	/**
-	 * @var string $publishUrl
+	 * @var string $publishUrls
 	 */
-	protected $publishUrl;
+	protected $publishUrls;
 
 	/**
-	 * @var boolean $isPublished
+	 * @param array $publishUrls
 	 */
-	protected $isPublished;
-
-	/**
-	 * @param string $publishUrl
-	 * @param boolean $isPublished
-	 */
-	function __construct($publishUrl, $isPublished) {
-		$this->publishUrl = $publishUrl;
-		$this->isPublished = $isPublished;
+	function __construct(array $publishUrls) {
+		$this->publishUrls = $publishUrls;
 	}
 
 	/**
-	 * @return string
+	 * @return array
 	 */
-	function getValue() {
-		return $this->publishUrl;
+	function getValue(): array {
+		return array_keys($this->publishUrls);
 	}
 
 	/**
-	 * The xmlSerialize metod is called during xml writing.
+	 * The xmlSerialize method is called during xml writing.
 	 *
 	 * Use the $writer argument to write its own xml serialization.
 	 *
@@ -75,12 +68,13 @@ class Publisher implements XmlSerializable {
 	 * @return void
 	 */
 	function xmlSerialize(Writer $writer) {
-		if (!$this->isPublished) {
+		foreach ($this->publishUrls as $publishUrl => $isPublished)
+		if (!$isPublished) {
 			// for pre-publish-url
-			$writer->write($this->publishUrl);
+			$writer->write($publishUrl);
 		} else {
 			// for publish-url
-			$writer->writeElement('{DAV:}href', $this->publishUrl);
+			$writer->writeElement('{DAV:}href', $publishUrl);
 		}
 	}
 }

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
@@ -7,7 +7,7 @@
  * @author Lukas Reschke <lukas@statuscode.ch>
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
- * @author Thomas Citharel <tcit@tcit.fr>
+ * @author Thomas Citharel <nextcloud@tcit.fr>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Vinicius Cubas Brand <vinicius@eita.org.br>
  *
@@ -41,6 +41,9 @@ use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sabre\DAV\Exception;
+use Sabre\DAV\Exception\NotFound;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\TestCase;
 
@@ -60,11 +63,11 @@ class PublicCalendarRootTest extends TestCase {
 	private $publicCalendarRoot;
 	/** @var IL10N */
 	private $l10n;
-	/** @var Principal|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var Principal| MockObject */
 	private $principal;
-	/** @var IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager| MockObject */
 	protected $userManager;
-	/** @var IGroupManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IGroupManager| MockObject */
 	protected $groupManager;
 	/** @var IConfig */
 	protected $config;
@@ -157,13 +160,15 @@ class PublicCalendarRootTest extends TestCase {
 
 	/**
 	 * @return Calendar
+	 * @throws Exception
+	 * @throws NotFound
 	 */
 	protected function createPublicCalendar() {
 		$this->backend->createCalendar(self::UNIT_TEST_USER, 'Example', []);
 
 		$calendarInfo = $this->backend->getCalendarsForUser(self::UNIT_TEST_USER)[0];
 		$calendar = new PublicCalendar($this->backend, $calendarInfo, $this->l10n, $this->config);
-		$publicUri = $calendar->setPublishStatus(true);
+		$publicUri = $calendar->addPublicLink();
 
 		$calendarInfo = $this->backend->getPublicCalendar($publicUri);
 		$calendar = new PublicCalendar($this->backend, $calendarInfo, $this->l10n, $this->config);

--- a/apps/dav/tests/unit/CalDAV/Publishing/PublisherTest.php
+++ b/apps/dav/tests/unit/CalDAV/Publishing/PublisherTest.php
@@ -33,15 +33,16 @@ use Test\TestCase;
 class PublisherTest extends TestCase {
 
 	const NS_CALENDARSERVER = 'http://calendarserver.org/ns/';
+	const NS_NEXTCLOUD = 'http://nextcloud.com/ns/';
 
 	public function testSerializePublished() {
-		$publish = new Publisher('urltopublish', true);
+		$publish = new Publisher(['urltopublish' => true]);
 
 		$xml = $this->write([
 			'{' . self::NS_CALENDARSERVER . '}publish-url' => $publish,
 		]);
 
-		$this->assertEquals('urltopublish', $publish->getValue());
+		$this->assertEquals(['urltopublish'], $publish->getValue());
 
 		$this->assertXmlStringEqualsXmlString(
 			'<?xml version="1.0"?>
@@ -50,14 +51,31 @@ class PublisherTest extends TestCase {
 			</x1:publish-url>', $xml);
 	}
 
+	public function testSerializeMultiplePublished() {
+		$publish = new Publisher(['urltopublish' => true, 'secondurltopublish' => true]);
+
+		$xml = $this->write([
+			'{' . self::NS_NEXTCLOUD . '}publish-urls' => $publish,
+		]);
+
+		$this->assertEquals(['urltopublish', 'secondurltopublish'], $publish->getValue());
+
+		$this->assertXmlStringEqualsXmlString(
+			'<?xml version="1.0"?>
+			<x1:publish-urls xmlns:d="DAV:" xmlns:x1="' . self::NS_NEXTCLOUD . '">
+			<d:href>urltopublish</d:href>
+			<d:href>secondurltopublish</d:href>
+			</x1:publish-urls>', $xml);
+	}
+
 	public function testSerializeNotPublished() {
-		$publish = new Publisher('urltopublish', false);
+		$publish = new Publisher(['urltopublish' => false]);
 
 		$xml = $this->write([
 			'{' . self::NS_CALENDARSERVER . '}pre-publish-url' => $publish,
 		]);
 
-		$this->assertEquals('urltopublish', $publish->getValue());
+		$this->assertEquals(['urltopublish'], $publish->getValue());
 
 		$this->assertXmlStringEqualsXmlString(
 			'<?xml version="1.0"?>

--- a/apps/dav/tests/unit/CalDAV/Publishing/PublishingTest.php
+++ b/apps/dav/tests/unit/CalDAV/Publishing/PublishingTest.php
@@ -30,6 +30,7 @@ use OCA\DAV\CalDAV\Publishing\PublishPlugin;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Server;
 use Sabre\DAV\SimpleCollection;
 use Sabre\HTTP\Request;
@@ -42,11 +43,11 @@ class PluginTest extends TestCase {
 	private $plugin;
 	/** @var Server */
 	private $server;
-	/** @var Calendar | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Calendar | MockObject */
 	private $book;
-	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig | MockObject */
 	private $config;
-	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator | MockObject */
 	private $urlGenerator;
 
 	protected function setUp(): void {
@@ -79,7 +80,7 @@ class PluginTest extends TestCase {
 
 	public function testPublishing() {
 
-		$this->book->expects($this->once())->method('setPublishStatus')->with(true);
+		$this->book->expects($this->once())->method('addPublicLink')->with();
 
 		// setup request
 		$request = new Request();
@@ -92,13 +93,26 @@ class PluginTest extends TestCase {
 
 	public function testUnPublishing() {
 
-		$this->book->expects($this->once())->method('setPublishStatus')->with(false);
+		$this->book->expects($this->once())->method('removeAllPublicLinks')->with();
 
 		// setup request
 		$request = new Request();
 		$request->addHeader('Content-Type', 'application/xml');
 		$request->setUrl('cal1');
 		$request->setBody('<o:unpublish-calendar xmlns:o="http://calendarserver.org/ns/"/>');
+		$response = new Response();
+		$this->plugin->httpPost($request, $response);
+	}
+
+	public function testUnPublishingALink() {
+
+		$this->book->expects($this->once())->method('removePublicLink')->with('urltounpublish');
+
+		// setup request
+		$request = new Request();
+		$request->addHeader('Content-Type', 'application/xml');
+		$request->setUrl('cal1');
+		$request->setBody('<o:unpublish-calendar xmlns:o="http://nextcloud.com/ns/">urltounpublish</o:unpublish-calendar>');
 		$response = new Response();
 		$this->plugin->httpPost($request, $response);
 	}


### PR DESCRIPTION
Needed for #20096

- [ ] Test with cdav-library
- [ ] Adapt Activity and everything else that uses `'\OCA\DAV\CalDAV\CalDavBackend::publishCalendar'` events

Adding a public link is still the old way:

```xml
<o:publish-calendar xmlns:o="http://calendarserver.org/ns/"/>
```

Removing all public links is just like we used to unpublish
```xml
<o:unpublish-calendar xmlns:o="http://calendarserver.org/ns/"/>
```

We now have the following for unpublishing a specific link (we can change `nc:unpublish-calendar` to something else).
```xml
<o:unpublish-calendar xmlns:o="http://nextcloud.com/ns/">urltounpublish</o:unpublish-calendar>
```

The public URLs are exposed this way:
```xml
<x1:publish-urls xmlns:d="DAV:" xmlns:x1="http://nextcloud.com/ns/">
	<d:href>urltopublish</d:href>
	<d:href>secondurltopublish</d:href>
</x1:publish-urls>
```

`publish-url` is still available and gives the first URL
```xml
<x1:publish-url xmlns:d="DAV:" xmlns:x1="http://calendarserver.org/ns/">
	<d:href>urltopublish</d:href>
</x1:publish-url>
```

Note : not sure if the collection of public calendars should contain unique calendars or one calendar per public link. Need help here @georgehrke.