### PR TITLE
Provide the proper language to the mailer

### DIFF
--- a/apps/settings/tests/Mailer/NewUserMailHelperTest.php
+++ b/apps/settings/tests/Mailer/NewUserMailHelperTest.php
@@ -78,7 +78,7 @@ class NewUserMailHelperTest extends TestCase {
 		$template = new EMailTemplate(
 			$this->defaults,
 			$this->urlGenerator,
-			$this->l10n,
+			$this->l10nFactory,
 			'test.TestTemplate',
 			[]
 		);
@@ -377,8 +377,8 @@ Set your password: https://example.com/resetPassword/MySuperLongSecureRandomToke
 Install Client: https://nextcloud.com/install/#install-clients
 
 
--- 
-TestCloud - 
+--
+TestCloud -
 This is an automatically sent email, please do not reply.
 EOF;
 

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -145,8 +145,8 @@ class ThemingDefaults extends \OC_Defaults {
 		return $this->config->getAppValue('theming', 'url', $this->url);
 	}
 
-	public function getSlogan() {
-		return \OCP\Util::sanitizeHTML($this->config->getAppValue('theming', 'slogan', parent::getSlogan()));
+	public function getSlogan(?string $lang = null) {
+		return \OCP\Util::sanitizeHTML($this->config->getAppValue('theming', 'slogan', parent::getSlogan($lang)));
 	}
 
 	public function getImprintUrl() {

--- a/lib/private/Mail/EMailTemplate.php
+++ b/lib/private/Mail/EMailTemplate.php
@@ -35,8 +35,8 @@ declare(strict_types=1);
 namespace OC\Mail;
 
 use OCP\Defaults;
-use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
 use OCP\Mail\IEMailTemplate;
 
 /**
@@ -52,8 +52,8 @@ class EMailTemplate implements IEMailTemplate {
 	protected $themingDefaults;
 	/** @var IURLGenerator */
 	protected $urlGenerator;
-	/** @var IL10N */
-	protected $l10n;
+	/** @var IFactory */
+	protected $l10nFactory;
 	/** @var string */
 	protected $emailId;
 	/** @var array */
@@ -350,21 +350,14 @@ EOF;
 </table>
 EOF;
 
-	/**
-	 * @param Defaults $themingDefaults
-	 * @param IURLGenerator $urlGenerator
-	 * @param IL10N $l10n
-	 * @param string $emailId
-	 * @param array $data
-	 */
 	public function __construct(Defaults $themingDefaults,
 								IURLGenerator $urlGenerator,
-								IL10N $l10n,
+								IFactory $l10nFactory,
 								$emailId,
 								array $data) {
 		$this->themingDefaults = $themingDefaults;
 		$this->urlGenerator = $urlGenerator;
-		$this->l10n = $l10n;
+		$this->l10nFactory = $l10nFactory;
 		$this->htmlBody .= $this->head;
 		$this->emailId = $emailId;
 		$this->data = $data;
@@ -605,9 +598,10 @@ EOF;
 	 *
 	 * @param string $text If the text is empty the default "Name - Slogan<br>This is an automatically sent email" will be used
 	 */
-	public function addFooter(string $text = '') {
+	public function addFooter(string $text = '', ?string $lang = null) {
 		if ($text === '') {
-			$text = $this->themingDefaults->getName() . ' - ' . $this->themingDefaults->getSlogan() . '<br>' . $this->l10n->t('This is an automatically sent email, please do not reply.');
+			$l10n = $this->l10nFactory->get('lib', $lang);
+			$text = $this->themingDefaults->getName() . ' - ' . $this->themingDefaults->getSlogan($lang) . '<br>' . $l10n->t('This is an automatically sent email, please do not reply.');
 		}
 
 		if ($this->footerAdded) {

--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -41,6 +41,7 @@ use OCP\IConfig;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
 use OCP\Mail\IAttachment;
 use OCP\Mail\IEMailTemplate;
 use OCP\Mail\IMailer;
@@ -80,6 +81,8 @@ class Mailer implements IMailer {
 	private $l10n;
 	/** @var IEventDispatcher */
 	private $dispatcher;
+	/** @var IFactory */
+	private $l10nFactory;
 
 	/**
 	 * @param IConfig $config
@@ -94,13 +97,15 @@ class Mailer implements IMailer {
 						 Defaults $defaults,
 						 IURLGenerator $urlGenerator,
 						 IL10N $l10n,
-						 IEventDispatcher $dispatcher) {
+						 IEventDispatcher $dispatcher,
+						 IFactory $l10nFactory) {
 		$this->config = $config;
 		$this->logger = $logger;
 		$this->defaults = $defaults;
 		$this->urlGenerator = $urlGenerator;
 		$this->l10n = $l10n;
 		$this->dispatcher = $dispatcher;
+		$this->l10nFactory = $l10nFactory;
 	}
 
 	/**
@@ -158,7 +163,7 @@ class Mailer implements IMailer {
 		return new EMailTemplate(
 			$this->defaults,
 			$this->urlGenerator,
-			$this->l10n,
+			$this->l10nFactory,
 			$emailId,
 			$data
 		);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -995,7 +995,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->query(Defaults::class),
 				$c->getURLGenerator(),
 				$c->getL10N('lib'),
-				$c->query(IEventDispatcher::class)
+				$c->query(IEventDispatcher::class),
+				$c->getL10NFactory()
 			);
 		});
 		$this->registerDeprecatedAlias('Mailer', IMailer::class);

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -891,9 +891,9 @@ class Manager implements IManager {
 		$initiatorEmail = $initiatorUser->getEMailAddress();
 		if ($initiatorEmail !== null) {
 			$message->setReplyTo([$initiatorEmail => $initiatorDisplayName]);
-			$emailTemplate->addFooter($instanceName . ($this->defaults->getSlogan() !== '' ? ' - ' . $this->defaults->getSlogan() : ''));
+			$emailTemplate->addFooter($instanceName . ($this->defaults->getSlogan($l->getLanguageCode()) !== '' ? ' - ' . $this->defaults->getSlogan($l->getLanguageCode()) : ''));
 		} else {
-			$emailTemplate->addFooter();
+			$emailTemplate->addFooter('', $l->getLanguageCode());
 		}
 
 		$message->useTemplate($emailTemplate);

--- a/lib/private/legacy/OC_Defaults.php
+++ b/lib/private/legacy/OC_Defaults.php
@@ -214,12 +214,12 @@ class OC_Defaults {
 	 * Returns slogan
 	 * @return string slogan
 	 */
-	public function getSlogan() {
+	public function getSlogan(?string $lang = null) {
 		if ($this->themeExist('getSlogan')) {
-			return $this->theme->getSlogan();
+			return $this->theme->getSlogan($lang);
 		} else {
 			if ($this->defaultSlogan === null) {
-				$l10n = \OC::$server->getL10N('lib');
+				$l10n = \OC::$server->getL10N('lib', $lang);
 				$this->defaultSlogan = $l10n->t('a safe home for all your data');
 			}
 			return $this->defaultSlogan;

--- a/lib/public/Defaults.php
+++ b/lib/public/Defaults.php
@@ -137,8 +137,8 @@ class Defaults {
 	 * @return string
 	 * @since 6.0.0
 	 */
-	public function getSlogan() {
-		return $this->defaults->getSlogan();
+	public function getSlogan(?string $lang = null) {
+		return $this->defaults->getSlogan($lang);
 	}
 
 	/**

--- a/lib/public/Mail/IEMailTemplate.php
+++ b/lib/public/Mail/IEMailTemplate.php
@@ -140,10 +140,11 @@ interface IEMailTemplate {
 	 * Adds a logo and a text to the footer. <br> in the text will be replaced by new lines in the plain text email
 	 *
 	 * @param string $text If the text is empty the default "Name - Slogan<br>This is an automatically sent email" will be used
+	 * @param string $lang Optional language to set the default footer in
 	 *
 	 * @since 12.0.0
 	 */
-	public function addFooter(string $text = '');
+	public function addFooter(string $text = '', ?string $lang = null);
 
 	/**
 	 * Returns the rendered email subject as string

--- a/tests/lib/Mail/EMailTemplateTest.php
+++ b/tests/lib/Mail/EMailTemplateTest.php
@@ -27,6 +27,7 @@ use OC\Mail\EMailTemplate;
 use OCP\Defaults;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
 use Test\TestCase;
 
 class EMailTemplateTest extends TestCase {
@@ -34,7 +35,7 @@ class EMailTemplateTest extends TestCase {
 	private $defaults;
 	/** @var IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
 	private $urlGenerator;
-	/** @var IL10N|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IFactory|\PHPUnit_Framework_MockObject_MockObject */
 	private $l10n;
 	/** @var EMailTemplate */
 	private $emailTemplate;
@@ -44,7 +45,11 @@ class EMailTemplateTest extends TestCase {
 
 		$this->defaults = $this->createMock(Defaults::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
-		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n = $this->createMock(IFactory::class);
+
+		$this->l10n->method('get')
+			->with('lib', '')
+			->willReturn($this->createMock(IL10N::class));
 
 		$this->emailTemplate = new EMailTemplate(
 			$this->defaults,

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -20,6 +20,7 @@ use OCP\IConfig;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
 use OCP\Mail\Events\BeforeMessageSent;
 use Test\TestCase;
 use Swift_SwiftException;
@@ -56,7 +57,8 @@ class MailerTest extends TestCase {
 			$this->defaults,
 			$this->urlGenerator,
 			$this->l10n,
-			$this->dispatcher
+			$this->dispatcher,
+			$this->createMock(IFactory::class)
 		);
 	}
 
@@ -153,7 +155,7 @@ class MailerTest extends TestCase {
 		$this->assertInstanceOf('\OC\Mail\Message', $this->mailer->createMessage());
 	}
 
-	
+
 	public function testSendInvalidMailException() {
 		$this->expectException(\Exception::class);
 


### PR DESCRIPTION
Else we can't properly translate the footer in the recipients e-mail language.

1. Create 2 users (userA and userB)
2. set language of userB to something other than English
3. share a file from userA to user B

before:
* footer in language of userA

After:
* footer in language of userB