### PR TITLE
Remove unneeded babel config variable

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,16 +1,15 @@
 module.exports = {
 	plugins: [
 		'@babel/plugin-syntax-dynamic-import',
-		['@babel/plugin-proposal-class-properties', { loose: true }]
+		['@babel/plugin-proposal-class-properties', { loose: true }],
 	],
 	presets: [
 		[
 			'@babel/preset-env',
 			{
 				modules: false,
-				corejs: 3,
 				useBuiltIns: false,
-			}
-		]
-	]
-};
+			},
+		],
+	],
+}


### PR DESCRIPTION
> The `corejs` option only has an effect when the `useBuiltIns` option is not `false`
