### PR TITLE
allow setting tooltips for external storage config options

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -999,6 +999,11 @@ MountConfigListView.prototype = _.extend({
 		} else {
 			newElement = $('<input type="text" class="'+classes.join(' ')+'" data-parameter="'+parameter+'" placeholder="'+ trimmedPlaceholder+'" />');
 		}
+
+		if (placeholder.tooltip) {
+			newElement.attr('title', placeholder.tooltip);
+		}
+
 		highlightInput(newElement);
 		$td.append(newElement);
 		return newElement;

--- a/apps/files_external/lib/Lib/DefinitionParameter.php
+++ b/apps/files_external/lib/Lib/DefinitionParameter.php
@@ -48,6 +48,9 @@ class DefinitionParameter implements \JsonSerializable {
 	/** @var string human-readable parameter text */
 	private $text;
 
+	/** @var string human-readable parameter tooltip */
+	private $tooltip = '';
+
 	/** @var int value type, see self::VALUE_* constants */
 	private $type = self::VALUE_TEXT;
 
@@ -147,6 +150,22 @@ class DefinitionParameter implements \JsonSerializable {
 	}
 
 	/**
+	 * @return string
+	 */
+	public function getTooltip(): string {
+		return $this->tooltip;
+	}
+
+	/**
+	 * @param string $tooltip
+	 * @return self
+	 */
+	public function setTooltip(string $tooltip) {
+		$this->tooltip = $tooltip;
+		return $this;
+	}
+
+	/**
 	 * Serialize into JSON for client-side JS
 	 *
 	 * @return string
@@ -155,7 +174,8 @@ class DefinitionParameter implements \JsonSerializable {
 		return [
 			'value' => $this->getText(),
 			'flags' => $this->getFlags(),
-			'type' => $this->getType()
+			'type' => $this->getType(),
+			'tooltip' => $this->getTooltip(),
 		];
 	}
 

--- a/apps/files_external/tests/DefinitionParameterTest.php
+++ b/apps/files_external/tests/DefinitionParameterTest.php
@@ -33,14 +33,16 @@ class DefinitionParameterTest extends \Test\TestCase {
 		$this->assertEquals([
 			'value' => 'bar',
 			'flags' => 0,
-			'type' => 0
+			'type' => 0,
+			'tooltip' => '',
 		], $param->jsonSerialize());
 
 		$param->setType(Param::VALUE_BOOLEAN);
 		$this->assertEquals([
 			'value' => 'bar',
 			'flags' => 0,
-			'type' => Param::VALUE_BOOLEAN
+			'type' => Param::VALUE_BOOLEAN,
+			'tooltip' => '',
 		], $param->jsonSerialize());
 
 		$param->setType(Param::VALUE_PASSWORD);
@@ -48,7 +50,8 @@ class DefinitionParameterTest extends \Test\TestCase {
 		$this->assertEquals([
 			'value' => 'bar',
 			'flags' => Param::FLAG_OPTIONAL,
-			'type' => Param::VALUE_PASSWORD
+			'type' => Param::VALUE_PASSWORD,
+			'tooltip' => '',
 		], $param->jsonSerialize());
 
 		$param->setType(Param::VALUE_HIDDEN);
@@ -56,7 +59,8 @@ class DefinitionParameterTest extends \Test\TestCase {
 		$this->assertEquals([
 			'value' => 'bar',
 			'flags' => Param::FLAG_NONE,
-			'type' => Param::VALUE_HIDDEN
+			'type' => Param::VALUE_HIDDEN,
+			'tooltip' => '',
 		], $param->jsonSerialize());
 	}
 


### PR DESCRIPTION
allows explaining non-obvious config options a bit more

Would like to add a tooltip to the option from https://github.com/nextcloud/server/pull/19399