### PR TITLE
Properly catch NoUserException during upload cleanup

### DIFF
--- a/apps/dav/lib/BackgroundJob/UploadCleanup.php
+++ b/apps/dav/lib/BackgroundJob/UploadCleanup.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace OCA\DAV\BackgroundJob;
 
+use OC\User\NoUserException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\BackgroundJob\TimedJob;
@@ -63,7 +64,7 @@ class UploadCleanup extends TimedJob {
 			$uploads = $userRoot->get('uploads');
 			/** @var Folder $uploadFolder */
 			$uploadFolder = $uploads->get($folder);
-		} catch (NotFoundException $e) {
+		} catch (NotFoundException|NoUserException $e) {
 			$this->jobList->remove(self::class, $argument);
 			return;
 		}

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -35,6 +35,7 @@ use OC\Cache\CappedMemoryCache;
 use OC\Files\Mount\Manager;
 use OC\Files\Mount\MountPoint;
 use OC\Hooks\PublicEmitter;
+use OC\User\NoUserException;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
@@ -352,7 +353,8 @@ class Root extends Folder implements IRootFolder {
 	 *
 	 * @param string $userId user ID
 	 * @return \OCP\Files\Folder
-	 * @throws \OC\User\NoUserException
+	 * @throws NoUserException
+	 * @throws NotPermittedException
 	 */
 	public function getUserFolder($userId) {
 		$userObject = $this->userManager->get($userId);
@@ -367,7 +369,7 @@ class Root extends Folder implements IRootFolder {
 					'app' => 'files',
 				]
 			);
-			throw new \OC\User\NoUserException('Backends provided no user object');
+			throw new NoUserException('Backends provided no user object');
 		}
 
 		$userId = $userObject->getUID();

--- a/lib/public/Files/IRootFolder.php
+++ b/lib/public/Files/IRootFolder.php
@@ -25,6 +25,7 @@
 namespace OCP\Files;
 
 use OC\Hooks\Emitter;
+use OC\User\NoUserException;
 
 /**
  * Interface IRootFolder
@@ -39,6 +40,9 @@ interface IRootFolder extends Folder, Emitter {
 	 *
 	 * @param string $userId user ID
 	 * @return \OCP\Files\Folder
+	 * @throws NoUserException
+	 * @throws NotPermittedException
+	 *
 	 * @since 8.2.0
 	 */
 	public function getUserFolder($userId);


### PR DESCRIPTION
Follow up to https://github.com/nextcloud/server/pull/19655

`getUserFolder` might throw a `NoUserException` if the job was scheduled before the user removal. This would cause the background job to never succee and causing `Backends provided no user object` errors.

The second commit adds proper annotations for the exceptions being thrown by `getUserFolder`.