### PR TITLE
fixes the throttler not checking the user state on postLogin

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -812,7 +812,7 @@ class OC {
 			// NOTE: This will be replaced to use OCP
 			$userSession = self::$server->getUserSession();
 			$userSession->listen('\OC\User', 'postLogin', function () use ($userSession) {
-				if (!defined('PHPUNIT_RUN')) {
+				if (!defined('PHPUNIT_RUN') && $userSession->isLoggedIn()) {
 					// reset brute force delay for this IP address and username
 					$uid = \OC::$server->getUserSession()->getUser()->getUID();
 					$request = \OC::$server->getRequest();


### PR DESCRIPTION
A listener to the post login events can still reject a login, so that a user is not necessarily available at the time. `\OC\User\Session::completeLogin()` checks for it after the events have been sent itself and throws a LoginException. 

In general this is already very hackish. Perhaps best is when any listener would throw an LoginException directly, but it is private, and also it appears that the designated way of  doing things was this. As I don't know what else might cling to this behaviour or not, fixing the listener seems safest for now. Not eager for surprises at the moment.