### PR TITLE
Default to dark background in dark mode and better themed navbar

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -50,7 +50,7 @@
 	z-index: 2000;
 	height: $header-height;
 	background-color: var(--color-primary);
-	background-image: linear-gradient(40deg, var(--color-primary) 0%, rgba(28,175,255,1) 100%);
+	background-image: linear-gradient(40deg, var(--color-primary) 0%, var(--color-primary-element-light) 100%);
 	box-sizing: border-box;
 	justify-content: space-between;
 }

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -87,7 +87,6 @@ ul {
 
 body {
 	background-color: var(--color-main-background);
-	background-color: linear-gradient(40deg, var(--color-main-background) 0%, rgba(28,175,255,1) 100%);
 	font-weight: normal;
 	/* bring the default font size up to 14px */
 	font-size: .875em;


### PR DESCRIPTION
1. Be a developer with orange theme and dark mode
2. Have a problem with rendering images on your server (blue header)
3. Have a parse error in JS preventing talk from appearing

Before | After
---|---
![Bildschirmfoto von 2020-04-07 08-40-11](https://user-images.githubusercontent.com/213943/78638052-e4b48d00-78ab-11ea-8c6f-834863c9ff54.png) | ![Bildschirmfoto von 2020-04-07 08-39-00](https://user-images.githubusercontent.com/213943/78638074-ec743180-78ab-11ea-8e9a-6a50d0fd6556.png)

