### PR TITLE
Close the streams in `writeStream` even when there is an exception

### DIFF
--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -858,9 +858,12 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 		if (!$target) {
 			return 0;
 		}
-		list($count, $result) = \OC_Helper::streamCopy($stream, $target);
-		fclose($stream);
-		fclose($target);
+		try {
+			[$count, $result] = \OC_Helper::streamCopy($stream, $target);
+		} finally {
+			fclose($target);
+			fclose($stream);
+		}
 		return $count;
 	}
 }


### PR DESCRIPTION
Signed-off-by: Robin Appelman <robin@icewind.nl>