### PR TITLE
Unify function spacing to PSR2 recommendation

### DIFF
--- a/apps/accessibility/lib/Controller/AccessibilityController.php
+++ b/apps/accessibility/lib/Controller/AccessibilityController.php
@@ -247,7 +247,7 @@ class AccessibilityController extends Controller {
 	 *
 	 * @return array
 	 */
-	private function getUserValues(): array{
+	private function getUserValues(): array {
 		$userTheme = $this->config->getUserValue($this->userSession->getUser()->getUID(), $this->appName, 'theme', false);
 		$userFont  = $this->config->getUserValue($this->userSession->getUser()->getUID(), $this->appName, 'font', false);
 		$userHighContrast = $this->config->getUserValue($this->userSession->getUser()->getUID(), $this->appName, 'highcontrast', false);

--- a/apps/accessibility/lib/Controller/ConfigController.php
+++ b/apps/accessibility/lib/Controller/ConfigController.php
@@ -116,7 +116,7 @@ class ConfigController extends OCSController {
 			$highcontrast = [$this->accessibilityProvider->getHighContrast()];
 			$fonts  = $this->accessibilityProvider->getFonts();
 
-			$availableOptions = array_map(function($option) {
+			$availableOptions = array_map(function ($option) {
 				return $option['id'];
 			}, array_merge($themes, $highcontrast, $fonts));
 

--- a/apps/accessibility/lib/Migration/RepairUserConfig.php
+++ b/apps/accessibility/lib/Migration/RepairUserConfig.php
@@ -73,7 +73,7 @@ class RepairUserConfig implements IRepairStep {
 	 */
 	public function run(IOutput $output) {
 		$output->startProgress();
-		$this->userManager->callForSeenUsers(function(IUser $user) use ($output) {
+		$this->userManager->callForSeenUsers(function (IUser $user) use ($output) {
 			$theme = $this->config->getUserValue($user->getUID(), Application::APP_NAME, 'theme', false);
 			if ($theme === 'themedark') {
 				$this->config->setUserValue($user->getUID(), Application::APP_NAME, 'theme', 'dark');

--- a/apps/admin_audit/lib/AppInfo/Application.php
+++ b/apps/admin_audit/lib/AppInfo/Application.php
@@ -120,7 +120,7 @@ class Application extends App {
 		$userSession->listen('\OC\User', 'postUnassignedUserId', [$userActions, 'unassign']);
 	}
 
-	protected function groupHooks()  {
+	protected function groupHooks() {
 		$groupActions = new GroupManagement($this->logger);
 
 		/** @var IGroupManager|Manager $groupManager */
@@ -154,15 +154,15 @@ class Application extends App {
 	protected function appHooks() {
 
 		$eventDispatcher = $this->getContainer()->getServer()->getEventDispatcher();
-		$eventDispatcher->addListener(ManagerEvent::EVENT_APP_ENABLE, function(ManagerEvent $event) {
+		$eventDispatcher->addListener(ManagerEvent::EVENT_APP_ENABLE, function (ManagerEvent $event) {
 			$appActions = new AppManagement($this->logger);
 			$appActions->enableApp($event->getAppID());
 		});
-		$eventDispatcher->addListener(ManagerEvent::EVENT_APP_ENABLE_FOR_GROUPS, function(ManagerEvent $event) {
+		$eventDispatcher->addListener(ManagerEvent::EVENT_APP_ENABLE_FOR_GROUPS, function (ManagerEvent $event) {
 			$appActions = new AppManagement($this->logger);
 			$appActions->enableAppForGroups($event->getAppID(), $event->getGroups());
 		});
-		$eventDispatcher->addListener(ManagerEvent::EVENT_APP_DISABLE, function(ManagerEvent $event) {
+		$eventDispatcher->addListener(ManagerEvent::EVENT_APP_DISABLE, function (ManagerEvent $event) {
 			$appActions = new AppManagement($this->logger);
 			$appActions->disableApp($event->getAppID());
 		});
@@ -171,7 +171,7 @@ class Application extends App {
 
 	protected function consoleHooks() {
 		$eventDispatcher = $this->getContainer()->getServer()->getEventDispatcher();
-		$eventDispatcher->addListener(ConsoleEvent::EVENT_RUN, function(ConsoleEvent $event) {
+		$eventDispatcher->addListener(ConsoleEvent::EVENT_RUN, function (ConsoleEvent $event) {
 			$appActions = new Console($this->logger);
 			$appActions->runCommand($event->getArguments());
 		});
@@ -182,7 +182,7 @@ class Application extends App {
 		$eventDispatcher = $this->getContainer()->getServer()->getEventDispatcher();
 		$eventDispatcher->addListener(
 			IPreview::EVENT,
-			function(GenericEvent $event) use ($fileActions) {
+			function (GenericEvent $event) use ($fileActions) {
 				/** @var File $file */
 				$file = $event->getSubject();
 				$fileActions->preview([
@@ -253,11 +253,11 @@ class Application extends App {
 
 	protected function securityHooks() {
 		$eventDispatcher = $this->getContainer()->getServer()->getEventDispatcher();
-		$eventDispatcher->addListener(IProvider::EVENT_SUCCESS, function(GenericEvent $event) {
+		$eventDispatcher->addListener(IProvider::EVENT_SUCCESS, function (GenericEvent $event) {
 			$security = new Security($this->logger);
 			$security->twofactorSuccess($event->getSubject(), $event->getArguments());
 		});
-		$eventDispatcher->addListener(IProvider::EVENT_FAILED, function(GenericEvent $event) {
+		$eventDispatcher->addListener(IProvider::EVENT_FAILED, function (GenericEvent $event) {
 			$security = new Security($this->logger);
 			$security->twofactorFailed($event->getSubject(), $event->getArguments());
 		});

--- a/apps/comments/lib/AppInfo/Application.php
+++ b/apps/comments/lib/AppInfo/Application.php
@@ -45,7 +45,7 @@ class Application extends App {
 
 	const APP_ID = 'comments';
 
-	public function __construct (array $urlParams = []) {
+	public function __construct(array $urlParams = []) {
 		parent::__construct(self::APP_ID, $urlParams);
 		$container = $this->getContainer();
 
@@ -77,8 +77,8 @@ class Application extends App {
 	}
 
 	protected function registerDavEntity(IEventDispatcher $dispatcher) {
-		$dispatcher->addListener(CommentsEntityEvent::EVENT_ENTITY, function(CommentsEntityEvent $event) {
-			$event->addEntityCollection('files', function($name) {
+		$dispatcher->addListener(CommentsEntityEvent::EVENT_ENTITY, function (CommentsEntityEvent $event) {
+			$event->addEntityCollection('files', function ($name) {
 				$nodes = \OC::$server->getUserFolder()->getById((int)$name);
 				return !empty($nodes);
 			});

--- a/apps/comments/lib/Collaboration/CommentersSorter.php
+++ b/apps/comments/lib/Collaboration/CommentersSorter.php
@@ -60,7 +60,7 @@ class CommentersSorter implements ISorter {
 			// at least on PHP 5.6 usort turned out to be not stable. So we add
 			// the current index to the value and compare it on a draw
 			$i = 0;
-			$workArray = array_map(function($element) use (&$i) {
+			$workArray = array_map(function ($element) use (&$i) {
 				return [$i++, $element];
 			}, $byType);
 

--- a/apps/dav/appinfo/app.php
+++ b/apps/dav/appinfo/app.php
@@ -39,14 +39,14 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 $app = \OC::$server->query(Application::class);
 $app->registerHooks();
 
-\OC::$server->registerService('CardDAVSyncService', function() use ($app) {
+\OC::$server->registerService('CardDAVSyncService', function () use ($app) {
 	return $app->getSyncService();
 });
 
 $eventDispatcher = \OC::$server->getEventDispatcher();
 
 $eventDispatcher->addListener('OCP\Federation\TrustedServerEvent::remove',
-	function(GenericEvent $event) use ($app) {
+	function (GenericEvent $event) use ($app) {
 		/** @var CardDavBackend $cardDavBackend */
 		$cardDavBackend = $app->getContainer()->query(CardDavBackend::class);
 		$addressBookUri = $event->getSubject();
@@ -58,7 +58,7 @@ $eventDispatcher->addListener('OCP\Federation\TrustedServerEvent::remove',
 );
 
 $eventDispatcher->addListener('\OCA\DAV\CalDAV\CalDavBackend::createSubscription',
-	function(GenericEvent $event) use ($app) {
+	function (GenericEvent $event) use ($app) {
 		$jobList = $app->getContainer()->getServer()->getJobList();
 		$subscriptionData = $event->getArgument('subscriptionData');
 
@@ -77,7 +77,7 @@ $eventDispatcher->addListener('\OCA\DAV\CalDAV\CalDavBackend::createSubscription
 );
 
 $eventDispatcher->addListener('\OCA\DAV\CalDAV\CalDavBackend::deleteSubscription',
-	function(GenericEvent $event) use ($app) {
+	function (GenericEvent $event) use ($app) {
 		$jobList = $app->getContainer()->getServer()->getJobList();
 		$subscriptionData = $event->getArgument('subscriptionData');
 
@@ -92,7 +92,7 @@ $eventDispatcher->addListener('\OCA\DAV\CalDAV\CalDavBackend::deleteSubscription
 	}
 );
 
-$eventHandler = function() use ($app) {
+$eventHandler = function () use ($app) {
 	try {
 		$job = $app->getContainer()->query(\OCA\DAV\BackgroundJob\UpdateCalendarResourcesRoomsBackgroundJob::class);
 		$job->run([]);
@@ -106,7 +106,7 @@ $eventDispatcher->addListener('\OCP\Calendar\Resource\ForceRefreshEvent', $event
 $eventDispatcher->addListener('\OCP\Calendar\Room\ForceRefreshEvent', $eventHandler);
 
 $cm = \OC::$server->getContactsManager();
-$cm->register(function() use ($cm, $app) {
+$cm->register(function () use ($cm, $app) {
 	$user = \OC::$server->getUserSession()->getUser();
 	if (!is_null($user)) {
 		$app->setupContactsProvider($cm, $user->getUID());
@@ -116,7 +116,7 @@ $cm->register(function() use ($cm, $app) {
 });
 
 $calendarManager = \OC::$server->getCalendarManager();
-$calendarManager->register(function() use ($calendarManager, $app) {
+$calendarManager->register(function () use ($calendarManager, $app) {
 	$user = \OC::$server->getUserSession()->getUser();
 	if ($user !== null) {
 		$app->setupCalendarProvider($calendarManager, $user->getUID());

--- a/apps/dav/appinfo/v1/webdav.php
+++ b/apps/dav/appinfo/v1/webdav.php
@@ -68,7 +68,7 @@ $authPlugin->addBackend($bearerAuthPlugin);
 
 $requestUri = \OC::$server->getRequest()->getRequestUri();
 
-$server = $serverFactory->createServer($baseuri, $requestUri, $authPlugin, function() {
+$server = $serverFactory->createServer($baseuri, $requestUri, $authPlugin, function () {
 	// use the view for the logged in user
 	return \OC\Files\Filesystem::getView();
 });

--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -65,7 +65,7 @@ class Application extends App {
 		$container = $this->getContainer();
 		$server = $container->getServer();
 
-		$container->registerService(PhotoCache::class, function(SimpleContainer $s) use ($server) {
+		$container->registerService(PhotoCache::class, function (SimpleContainer $s) use ($server) {
 			return new PhotoCache(
 				$server->getAppDataDir('dav-photocache'),
 				$server->getLogger()
@@ -147,7 +147,7 @@ class Application extends App {
 			}
 		});
 
-		$clearPhotoCache = function($event) {
+		$clearPhotoCache = function ($event) {
 			if ($event instanceof GenericEvent) {
 				/** @var PhotoCache $p */
 				$p = $this->getContainer()->query(PhotoCache::class);
@@ -160,20 +160,20 @@ class Application extends App {
 		$dispatcher->addListener('\OCA\DAV\CardDAV\CardDavBackend::updateCard', $clearPhotoCache);
 		$dispatcher->addListener('\OCA\DAV\CardDAV\CardDavBackend::deleteCard', $clearPhotoCache);
 
-		$dispatcher->addListener('OC\AccountManager::userUpdated', function(GenericEvent $event) {
+		$dispatcher->addListener('OC\AccountManager::userUpdated', function (GenericEvent $event) {
 			$user = $event->getSubject();
 			$syncService = $this->getContainer()->query(SyncService::class);
 			$syncService->updateUser($user);
 		});
 
-		$dispatcher->addListener('\OCA\DAV\CalDAV\CalDavBackend::createCalendar', function(GenericEvent $event) {
+		$dispatcher->addListener('\OCA\DAV\CalDAV\CalDavBackend::createCalendar', function (GenericEvent $event) {
 			/** @var Backend $backend */
 			$backend = $this->getContainer()->query(Backend::class);
 			$backend->onCalendarAdd(
 				$event->getArgument('calendarData')
 			);
 		});
-		$dispatcher->addListener('\OCA\DAV\CalDAV\CalDavBackend::updateCalendar', function(GenericEvent $event) {
+		$dispatcher->addListener('\OCA\DAV\CalDAV\CalDavBackend::updateCalendar', function (GenericEvent $event) {
 			/** @var Backend $backend */
 			$backend = $this->getContainer()->query(Backend::class);
 			$backend->onCalendarUpdate(
@@ -182,7 +182,7 @@ class Application extends App {
 				$event->getArgument('propertyMutations')
 			);
 		});
-		$dispatcher->addListener('\OCA\DAV\CalDAV\CalDavBackend::deleteCalendar', function(GenericEvent $event) {
+		$dispatcher->addListener('\OCA\DAV\CalDAV\CalDavBackend::deleteCalendar', function (GenericEvent $event) {
 			/** @var Backend $backend */
 			$backend = $this->getContainer()->query(Backend::class);
 			$backend->onCalendarDelete(
@@ -195,7 +195,7 @@ class Application extends App {
 				$event->getArgument('calendarId')
 			);
 		});
-		$dispatcher->addListener('\OCA\DAV\CalDAV\CalDavBackend::updateShares', function(GenericEvent $event) {
+		$dispatcher->addListener('\OCA\DAV\CalDAV\CalDavBackend::updateShares', function (GenericEvent $event) {
 			/** @var Backend $backend */
 			$backend = $this->getContainer()->query(Backend::class);
 			$backend->onCalendarUpdateShares(
@@ -208,7 +208,7 @@ class Application extends App {
 			// Here we should recalculate if reminders should be sent to new or old sharees
 		});
 
-		$dispatcher->addListener('\OCA\DAV\CalDAV\CalDavBackend::publishCalendar', function(GenericEvent $event) {
+		$dispatcher->addListener('\OCA\DAV\CalDAV\CalDavBackend::publishCalendar', function (GenericEvent $event) {
 			/** @var Backend $backend */
 			$backend = $this->getContainer()->query(Backend::class);
 			$backend->onCalendarPublication(
@@ -217,7 +217,7 @@ class Application extends App {
 			);
 		});
 
-		$listener = function(GenericEvent $event, $eventName) {
+		$listener = function (GenericEvent $event, $eventName) {
 			/** @var Backend $backend */
 			$backend = $this->getContainer()->query(Backend::class);
 

--- a/apps/dav/lib/AppInfo/PluginManager.php
+++ b/apps/dav/lib/AppInfo/PluginManager.php
@@ -272,7 +272,7 @@ class PluginManager {
 	 * @param string[] $plugin
 	 */
 	private function loadSabreAddressBookPluginsFromInfoXml(array $plugins): void {
-		$providers = array_map(function(string $className): IAddressBookProvider {
+		$providers = array_map(function (string $className): IAddressBookProvider {
 			$instance = $this->createPluginInstance($className);
 			if (!($instance instanceof IAddressBookProvider)) {
 				throw new \Exception("Sabre address book plugin class '$className' does not implement the \OCA\DAV\CardDAV\Integration\IAddressBookProvider interface");

--- a/apps/dav/lib/BackgroundJob/RegisterRegenerateBirthdayCalendars.php
+++ b/apps/dav/lib/BackgroundJob/RegisterRegenerateBirthdayCalendars.php
@@ -57,7 +57,7 @@ class RegisterRegenerateBirthdayCalendars extends QueuedJob {
 	 * @inheritDoc
 	 */
 	public function run($argument) {
-		$this->userManager->callForSeenUsers(function(IUser $user) {
+		$this->userManager->callForSeenUsers(function (IUser $user) {
 			$this->jobList->add(GenerateBirthdayCalendarBackgroundJob::class, [
 				'userId' => $user->getUID(),
 				'purgeBeforeGenerating' => true

--- a/apps/dav/lib/BackgroundJob/UpdateCalendarResourcesRoomsBackgroundJob.php
+++ b/apps/dav/lib/BackgroundJob/UpdateCalendarResourcesRoomsBackgroundJob.php
@@ -398,7 +398,7 @@ class UpdateCalendarResourcesRoomsBackgroundJob extends TimedJob {
 			->where($query->expr()->eq('backend_id', $query->createNamedParameter($backendId)));
 		$stmt = $query->execute();
 
-		return array_map(function($row) {
+		return array_map(function ($row) {
 			return $row['resource_id'];
 		}, $stmt->fetchAll(\PDO::FETCH_NAMED));
 	}

--- a/apps/dav/lib/BackgroundJob/UploadCleanup.php
+++ b/apps/dav/lib/BackgroundJob/UploadCleanup.php
@@ -77,7 +77,7 @@ class UploadCleanup extends TimedJob {
 		// The folder has to be more than a day old
 		$initial = $uploadFolder->getMTime() < $time;
 
-		$expire = array_reduce($files, function(bool $carry, File $file) use ($time) {
+		$expire = array_reduce($files, function (bool $carry, File $file) use ($time) {
 			return $carry && $file->getMTime() < $time;
 		}, $initial);
 

--- a/apps/dav/lib/CalDAV/BirthdayCalendar/EnablePlugin.php
+++ b/apps/dav/lib/CalDAV/BirthdayCalendar/EnablePlugin.php
@@ -87,7 +87,7 @@ class EnablePlugin extends ServerPlugin {
 	 *
 	 * @return string
 	 */
-	public function getPluginName()	{
+	public function getPluginName() {
 		return 'nc-enable-birthday-calendar';
 	}
 

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -308,7 +308,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$principals = $this->principalBackend->getGroupMembership($principalUriOriginal, true);
 		$principals = array_merge($principals, $this->principalBackend->getCircleMembership($principalUriOriginal));
 
-		$principals = array_map(function($principal) {
+		$principals = array_map(function ($principal) {
 			return urldecode($principal);
 		}, $principals);
 		$principals[]= $principalUri;
@@ -800,7 +800,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		/**
 		 * @suppress SqlInjectionChecker
 		 */
-		$propPatch->handle($supportedProperties, function($mutations) use ($calendarId) {
+		$propPatch->handle($supportedProperties, function ($mutations) use ($calendarId) {
 			$newValues = [];
 			foreach ($mutations as $propertyName => $propertyValue) {
 
@@ -1587,7 +1587,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$result = $outerQuery->execute();
 		$calendarObjects = $result->fetchAll();
 
-		return array_map(function($o) {
+		return array_map(function ($o) {
 			$calendarData = Reader::read($o['calendardata']);
 			$comps = $calendarData->getComponents();
 			$objects = [];
@@ -1605,10 +1605,10 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 				'type' => $o['componenttype'],
 				'uid' => $o['uid'],
 				'uri' => $o['uri'],
-				'objects' => array_map(function($c) {
+				'objects' => array_map(function ($c) {
 					return $this->transformSearchData($c);
 				}, $objects),
-				'timezones' => array_map(function($c) {
+				'timezones' => array_map(function ($c) {
 					return $this->transformSearchData($c);
 				}, $timezones),
 			];
@@ -1624,7 +1624,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		/** @var Component[] $subComponents */
 		$subComponents = $comp->getComponents();
 		/** @var Property[] $properties */
-		$properties = array_filter($comp->children(), function($c) {
+		$properties = array_filter($comp->children(), function ($c) {
 			return $c instanceof Property;
 		});
 		$validationRules = $comp->getValidationRules();
@@ -1993,7 +1993,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		/**
 		 * @suppress SqlInjectionChecker
 		 */
-		$propPatch->handle($supportedProperties, function($mutations) use ($subscriptionId) {
+		$propPatch->handle($supportedProperties, function ($mutations) use ($subscriptionId) {
 
 			$newValues = [];
 

--- a/apps/dav/lib/CalDAV/Calendar.php
+++ b/apps/dav/lib/CalDAV/Calendar.php
@@ -225,7 +225,7 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IShareable {
 			parent::getOwner(),
 			'principals/system/public'
 		];
-		return array_filter($acl, function($rule) use ($allowedPrincipals) {
+		return array_filter($acl, function ($rule) use ($allowedPrincipals) {
 			return \in_array($rule['principal'], $allowedPrincipals, true);
 		});
 	}
@@ -246,7 +246,7 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IShareable {
 			$this->calendarInfo['{http://owncloud.org/ns}owner-principal'] !== $this->calendarInfo['principaluri']) {
 			$principal = 'principal:' . parent::getOwner();
 			$shares = $this->caldavBackend->getShares($this->getResourceId());
-			$shares = array_filter($shares, function($share) use ($principal){
+			$shares = array_filter($shares, function ($share) use ($principal) {
 				return $share['href'] === $principal;
 			});
 			if (empty($shares)) {

--- a/apps/dav/lib/CalDAV/Publishing/PublishPlugin.php
+++ b/apps/dav/lib/CalDAV/Publishing/PublishPlugin.php
@@ -95,7 +95,7 @@ class PublishPlugin extends ServerPlugin {
 	 *
 	 * @return string
 	 */
-	public function getPluginName()	{
+	public function getPluginName() {
 		return 'oc-calendar-publishing';
 	}
 
@@ -128,7 +128,7 @@ class PublishPlugin extends ServerPlugin {
 				}
 			});
 
-			$propFind->handle('{'.self::NS_CALENDARSERVER.'}allowed-sharing-modes', function() use ($node) {
+			$propFind->handle('{'.self::NS_CALENDARSERVER.'}allowed-sharing-modes', function () use ($node) {
 				$canShare = (!$node->isSubscription() && $node->canWrite());
 				$canPublish = (!$node->isSubscription() && $node->canWrite());
 

--- a/apps/dav/lib/CalDAV/Reminder/ReminderService.php
+++ b/apps/dav/lib/CalDAV/Reminder/ReminderService.php
@@ -727,7 +727,7 @@ class ReminderService {
 	 * @return VObject\Component\VEvent[]
 	 */
 	private function getRecurrenceExceptionFromListOfVEvents(array $vevents):array {
-		return array_values(array_filter($vevents, function(VEvent $vevent) {
+		return array_values(array_filter($vevents, function (VEvent $vevent) {
 			return $vevent->{'RECURRENCE-ID'} !== null;
 		}));
 	}
@@ -737,7 +737,7 @@ class ReminderService {
 	 * @return VEvent|null
 	 */
 	private function getMasterItemFromListOfVEvents(array $vevents):?VEvent {
-		$elements = array_values(array_filter($vevents, function(VEvent $vevent) {
+		$elements = array_values(array_filter($vevents, function (VEvent $vevent) {
 			return $vevent->{'RECURRENCE-ID'} === null;
 		}));
 

--- a/apps/dav/lib/CalDAV/ResourceBooking/AbstractPrincipalBackend.php
+++ b/apps/dav/lib/CalDAV/ResourceBooking/AbstractPrincipalBackend.php
@@ -305,11 +305,11 @@ abstract class AbstractPrincipalBackend implements BackendInterface {
 
 				default:
 					$rowsByMetadata = $this->searchPrincipalsByMetadataKey($prop, $value);
-					$filteredRows = array_filter($rowsByMetadata, function($row) use ($usersGroups) {
+					$filteredRows = array_filter($rowsByMetadata, function ($row) use ($usersGroups) {
 						return $this->isAllowedToAccessResource($row, $usersGroups);
 					});
 
-					$results[] = array_map(function($row) {
+					$results[] = array_map(function ($row) {
 						return $row['uri'];
 					}, $filteredRows);
 

--- a/apps/dav/lib/CalDAV/Schedule/Plugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/Plugin.php
@@ -261,7 +261,7 @@ EOF;
 	 */
 	function propFindDefaultCalendarUrl(PropFind $propFind, INode $node) {
 		if ($node instanceof IPrincipal) {
-			$propFind->handle('{' . self::NS_CALDAV . '}schedule-default-calendar-URL', function() use ($node) {
+			$propFind->handle('{' . self::NS_CALDAV . '}schedule-default-calendar-URL', function () use ($node) {
 				/** @var \OCA\DAV\CalDAV\Plugin $caldavPlugin */
 				$caldavPlugin = $this->server->getPlugin('caldav');
 				$principalUrl = $node->getPrincipalUrl();

--- a/apps/dav/lib/CalDAV/WebcalCaching/RefreshWebcalService.php
+++ b/apps/dav/lib/CalDAV/WebcalCaching/RefreshWebcalService.php
@@ -166,7 +166,7 @@ class RefreshWebcalService {
 	public function getSubscription(string $principalUri, string $uri) {
 		$subscriptions = array_values(array_filter(
 			$this->calDavBackend->getSubscriptionsForUser($principalUri),
-			function($sub) use ($uri) {
+			function ($sub) use ($uri) {
 				return $sub['uri'] === $uri;
 			}
 		));
@@ -197,7 +197,7 @@ class RefreshWebcalService {
 				->withHeader('Accept', 'text/calendar, application/calendar+json, application/calendar+xml')
 				->withHeader('User-Agent', 'Nextcloud Webcal Crawler');
 		}));
-		$handlerStack->push(Middleware::mapResponse(function(ResponseInterface $response) use (&$didBreak301Chain, &$latestLocation) {
+		$handlerStack->push(Middleware::mapResponse(function (ResponseInterface $response) use (&$didBreak301Chain, &$latestLocation) {
 			if (!$didBreak301Chain) {
 				if ($response->getStatusCode() !== 301) {
 					$didBreak301Chain = true;

--- a/apps/dav/lib/CardDAV/AddressBook.php
+++ b/apps/dav/lib/CardDAV/AddressBook.php
@@ -145,7 +145,7 @@ class AddressBook extends \Sabre\CardDAV\AddressBook implements IShareable {
 
 		$acl = $this->carddavBackend->applyShareAcl($this->getResourceId(), $acl);
 		$allowedPrincipals = [$this->getOwner(), parent::getOwner(), 'principals/system/system'];
-		return array_filter($acl, function($rule) use ($allowedPrincipals) {
+		return array_filter($acl, function ($rule) use ($allowedPrincipals) {
 			return \in_array($rule['principal'], $allowedPrincipals, true);
 		});
 	}
@@ -183,7 +183,7 @@ class AddressBook extends \Sabre\CardDAV\AddressBook implements IShareable {
 		if (isset($this->addressBookInfo['{http://owncloud.org/ns}owner-principal'])) {
 			$principal = 'principal:' . parent::getOwner();
 			$shares = $this->carddavBackend->getShares($this->getResourceId());
-			$shares = array_filter($shares, function($share) use ($principal){
+			$shares = array_filter($shares, function ($share) use ($principal) {
 				return $share['href'] === $principal;
 			});
 			if (empty($shares)) {

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -174,7 +174,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		$principals = $this->principalBackend->getGroupMembership($principalUriOriginal, true);
 		$principals = array_merge($principals, $this->principalBackend->getCircleMembership($principalUriOriginal));
 
-		$principals = array_map(function($principal) {
+		$principals = array_map(function ($principal) {
 			return urldecode($principal);
 		}, $principals);
 		$principals[]= $principalUri;
@@ -363,7 +363,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		/**
 		 * @suppress SqlInjectionChecker
 		 */
-		$propPatch->handle($supportedProperties, function($mutations) use ($addressBookId) {
+		$propPatch->handle($supportedProperties, function ($mutations) use ($addressBookId) {
 
 			$updates = [];
 			foreach($mutations as $property=>$newValue) {
@@ -939,7 +939,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 
 		$result->closeCursor();
 
-		return array_map(function($array) {
+		return array_map(function ($array) {
 			$array['carddata'] = $this->readBlob($array['carddata']);
 			return $array;
 		}, $cards);

--- a/apps/dav/lib/CardDAV/SyncService.php
+++ b/apps/dav/lib/CardDAV/SyncService.php
@@ -322,7 +322,7 @@ class SyncService {
 
 	public function syncInstance(\Closure $progressCallback = null) {
 		$systemAddressBook = $this->getLocalSystemAddressBook();
-		$this->userManager->callForSeenUsers(function($user) use ($systemAddressBook, $progressCallback) {
+		$this->userManager->callForSeenUsers(function ($user) use ($systemAddressBook, $progressCallback) {
 			$this->updateUser($user);
 			if (!is_null($progressCallback)) {
 				$progressCallback();

--- a/apps/dav/lib/CardDAV/UserAddressBooks.php
+++ b/apps/dav/lib/CardDAV/UserAddressBooks.php
@@ -72,7 +72,7 @@ class UserAddressBooks extends \Sabre\CardDAV\AddressBookHome {
 
 		$addressBooks = $this->carddavBackend->getAddressBooksForUser($this->principalUri);
 		/** @var IAddressBook[] $objects */
-		$objects = array_map(function(array $addressBook) {
+		$objects = array_map(function (array $addressBook) {
 			if ($addressBook['principaluri'] === 'principals/system/system') {
 				return new SystemAddressbook($this->carddavBackend, $addressBook, $this->l10n, $this->config);
 			}
@@ -80,7 +80,7 @@ class UserAddressBooks extends \Sabre\CardDAV\AddressBookHome {
 			return new AddressBook($this->carddavBackend, $addressBook, $this->l10n);
 		}, $addressBooks);
 		/** @var IAddressBook[][] $objectsFromPlugins */
-		$objectsFromPlugins = array_map(function(IAddressBookProvider $plugin): array {
+		$objectsFromPlugins = array_map(function (IAddressBookProvider $plugin): array {
 			return $plugin->fetchAllForAddressBookHome($this->principalUri);
 		}, $this->pluginManager->getAddressBookPlugins());
 

--- a/apps/dav/lib/Command/SyncBirthdayCalendar.php
+++ b/apps/dav/lib/Command/SyncBirthdayCalendar.php
@@ -96,7 +96,7 @@ class SyncBirthdayCalendar extends Command {
 		$output->writeln("Start birthday calendar sync for all users ...");
 		$p = new ProgressBar($output);
 		$p->start();
-		$this->userManager->callForSeenUsers(function($user) use ($p)  {
+		$this->userManager->callForSeenUsers(function ($user) use ($p) {
 			$p->advance();
 
 			$userId = $user->getUID();
@@ -113,7 +113,7 @@ class SyncBirthdayCalendar extends Command {
 		$output->writeln('');
 	}
 
-	protected function verifyEnabled () {
+	protected function verifyEnabled() {
 		$isEnabled = $this->config->getAppValue('dav', 'generateBirthdayCalendar', 'yes');
 
 		if ($isEnabled !== 'yes') {

--- a/apps/dav/lib/Command/SyncSystemAddressBook.php
+++ b/apps/dav/lib/Command/SyncSystemAddressBook.php
@@ -56,7 +56,7 @@ class SyncSystemAddressBook extends Command {
 		$output->writeln('Syncing users ...');
 		$progress = new ProgressBar($output);
 		$progress->start();
-		$this->syncService->syncInstance(function() use ($progress) {
+		$this->syncService->syncInstance(function () use ($progress) {
 			$progress->advance();
 		});
 

--- a/apps/dav/lib/Comments/CommentNode.php
+++ b/apps/dav/lib/Comments/CommentNode.php
@@ -85,7 +85,7 @@ class CommentNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 		$this->logger = $logger;
 
 		$methods = get_class_methods($this->comment);
-		$methods = array_filter($methods, function($name){
+		$methods = array_filter($methods, function ($name) {
 			return strpos($name, 'get') === 0;
 		});
 		foreach($methods as $getter) {
@@ -283,7 +283,7 @@ class CommentNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 	 * @return array
 	 */
 	protected function composeMentionsPropertyValue() {
-		return array_map(function($mention) {
+		return array_map(function ($mention) {
 			try {
 				$displayName = $this->commentsManager->resolveDisplayName($mention['type'], $mention['id']);
 			} catch (\OutOfBoundsException $e) {

--- a/apps/dav/lib/Comments/CommentsPlugin.php
+++ b/apps/dav/lib/Comments/CommentsPlugin.php
@@ -91,7 +91,7 @@ class CommentsPlugin extends ServerPlugin {
 
 		$this->server->xml->namespaceMap[self::NS_OWNCLOUD] = 'oc';
 
-		$this->server->xml->classMap['DateTime'] = function(Writer $writer, \DateTime $value) {
+		$this->server->xml->classMap['DateTime'] = function (Writer $writer, \DateTime $value) {
 			$writer->write(\Sabre\HTTP\toDate($value));
 		};
 

--- a/apps/dav/lib/Connector/Sabre/CommentPropertiesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/CommentPropertiesPlugin.php
@@ -99,15 +99,15 @@ class CommentPropertiesPlugin extends ServerPlugin {
 			}
 		}
 
-		$propFind->handle(self::PROPERTY_NAME_COUNT, function() use ($node) {
+		$propFind->handle(self::PROPERTY_NAME_COUNT, function () use ($node) {
 			return $this->commentsManager->getNumberOfCommentsForObject('files', (string)$node->getId());
 		});
 
-		$propFind->handle(self::PROPERTY_NAME_HREF, function() use ($node) {
+		$propFind->handle(self::PROPERTY_NAME_HREF, function () use ($node) {
 			return $this->getCommentsLink($node);
 		});
 
-		$propFind->handle(self::PROPERTY_NAME_UNREAD, function() use ($node) {
+		$propFind->handle(self::PROPERTY_NAME_UNREAD, function () use ($node) {
 			if (isset($this->cachedUnreadCount[$node->getId()])) {
 				return $this->cachedUnreadCount[$node->getId()];
 			} else {

--- a/apps/dav/lib/Connector/Sabre/FakeLockerPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FakeLockerPlugin.php
@@ -89,10 +89,10 @@ class FakeLockerPlugin extends ServerPlugin {
 	 * @return void
 	 */
 	function propFind(PropFind $propFind, INode $node) {
-		$propFind->handle('{DAV:}supportedlock', function() {
+		$propFind->handle('{DAV:}supportedlock', function () {
 			return new SupportedLock(true);
 		});
-		$propFind->handle('{DAV:}lockdiscovery', function() use ($propFind) {
+		$propFind->handle('{DAV:}lockdiscovery', function () use ($propFind) {
 			return new LockDiscovery([]);
 		});
 	}

--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -180,7 +180,7 @@ class FilesPlugin extends ServerPlugin {
 		$this->server->on('afterWriteContent', [$this, 'sendFileIdHeader']);
 		$this->server->on('afterMethod:GET', [$this,'httpGet']);
 		$this->server->on('afterMethod:GET', [$this, 'handleDownloadToken']);
-		$this->server->on('afterResponse', function($request, ResponseInterface $response) {
+		$this->server->on('afterResponse', function ($request, ResponseInterface $response) {
 			$body = $response->getBody();
 			if (is_resource($body)) {
 				fclose($body);
@@ -305,15 +305,15 @@ class FilesPlugin extends ServerPlugin {
 			 * }
 			 */
 
-			$propFind->handle(self::FILEID_PROPERTYNAME, function() use ($node) {
+			$propFind->handle(self::FILEID_PROPERTYNAME, function () use ($node) {
 				return $node->getFileId();
 			});
 
-			$propFind->handle(self::INTERNAL_FILEID_PROPERTYNAME, function() use ($node) {
+			$propFind->handle(self::INTERNAL_FILEID_PROPERTYNAME, function () use ($node) {
 				return $node->getInternalFileId();
 			});
 
-			$propFind->handle(self::PERMISSIONS_PROPERTYNAME, function() use ($node) {
+			$propFind->handle(self::PERMISSIONS_PROPERTYNAME, function () use ($node) {
 				$perms = $node->getDavPermissions();
 				if ($this->isPublic) {
 					// remove mount information
@@ -322,13 +322,13 @@ class FilesPlugin extends ServerPlugin {
 				return $perms;
 			});
 
-			$propFind->handle(self::SHARE_PERMISSIONS_PROPERTYNAME, function() use ($node, $httpRequest) {
+			$propFind->handle(self::SHARE_PERMISSIONS_PROPERTYNAME, function () use ($node, $httpRequest) {
 				return $node->getSharePermissions(
 					$httpRequest->getRawServerValue('PHP_AUTH_USER')
 				);
 			});
 
-			$propFind->handle(self::OCM_SHARE_PERMISSIONS_PROPERTYNAME, function() use ($node, $httpRequest) {
+			$propFind->handle(self::OCM_SHARE_PERMISSIONS_PROPERTYNAME, function () use ($node, $httpRequest) {
 				$ncPermissions = $node->getSharePermissions(
 					$httpRequest->getRawServerValue('PHP_AUTH_USER')
 				);
@@ -336,11 +336,11 @@ class FilesPlugin extends ServerPlugin {
 				return json_encode($ocmPermissions);
 			});
 
-			$propFind->handle(self::GETETAG_PROPERTYNAME, function() use ($node) {
+			$propFind->handle(self::GETETAG_PROPERTYNAME, function () use ($node) {
 				return $node->getETag();
 			});
 
-			$propFind->handle(self::OWNER_ID_PROPERTYNAME, function() use ($node) {
+			$propFind->handle(self::OWNER_ID_PROPERTYNAME, function () use ($node) {
 				$owner = $node->getOwner();
 				if (!$owner) {
 					return null;
@@ -348,7 +348,7 @@ class FilesPlugin extends ServerPlugin {
 					return $owner->getUID();
 				}
 			});
-			$propFind->handle(self::OWNER_DISPLAY_NAME_PROPERTYNAME, function() use ($node) {
+			$propFind->handle(self::OWNER_DISPLAY_NAME_PROPERTYNAME, function () use ($node) {
 				$owner = $node->getOwner();
 				if (!$owner) {
 					return null;
@@ -360,14 +360,14 @@ class FilesPlugin extends ServerPlugin {
 			$propFind->handle(self::HAS_PREVIEW_PROPERTYNAME, function () use ($node) {
 				return json_encode($this->previewManager->isAvailable($node->getFileInfo()));
 			});
-			$propFind->handle(self::SIZE_PROPERTYNAME, function() use ($node) {
+			$propFind->handle(self::SIZE_PROPERTYNAME, function () use ($node) {
 				return $node->getSize();
 			});
 			$propFind->handle(self::MOUNT_TYPE_PROPERTYNAME, function () use ($node) {
 				return $node->getFileInfo()->getMountPoint()->getMountType();
 			});
 
-			$propFind->handle(self::SHARE_NOTE, function() use ($node, $httpRequest) {
+			$propFind->handle(self::SHARE_NOTE, function () use ($node, $httpRequest) {
 				return $node->getNoteFromShare(
 					$httpRequest->getRawServerValue('PHP_AUTH_USER')
 				);
@@ -375,13 +375,13 @@ class FilesPlugin extends ServerPlugin {
 		}
 
 		if ($node instanceof \OCA\DAV\Connector\Sabre\Node) {
-			$propFind->handle(self::DATA_FINGERPRINT_PROPERTYNAME, function() use ($node) {
+			$propFind->handle(self::DATA_FINGERPRINT_PROPERTYNAME, function () use ($node) {
 				return $this->config->getSystemValue('data-fingerprint', '');
 			});
 		}
 
 		if ($node instanceof \OCA\DAV\Connector\Sabre\File) {
-			$propFind->handle(self::DOWNLOADURL_PROPERTYNAME, function() use ($node) {
+			$propFind->handle(self::DOWNLOADURL_PROPERTYNAME, function () use ($node) {
 				/** @var $node \OCA\DAV\Connector\Sabre\File */
 				try {
 					$directDownloadUrl = $node->getDirectDownload();
@@ -396,7 +396,7 @@ class FilesPlugin extends ServerPlugin {
 				return false;
 			});
 
-			$propFind->handle(self::CHECKSUMS_PROPERTYNAME, function() use ($node) {
+			$propFind->handle(self::CHECKSUMS_PROPERTYNAME, function () use ($node) {
 				$checksum = $node->getChecksum();
 				if ($checksum === null || $checksum === '') {
 					return null;
@@ -405,22 +405,22 @@ class FilesPlugin extends ServerPlugin {
 				return new ChecksumList($checksum);
 			});
 
-			$propFind->handle(self::CREATION_TIME_PROPERTYNAME, function() use ($node) {
+			$propFind->handle(self::CREATION_TIME_PROPERTYNAME, function () use ($node) {
 				return $node->getFileInfo()->getCreationTime();
 			});
 
-			$propFind->handle(self::UPLOAD_TIME_PROPERTYNAME, function() use ($node) {
+			$propFind->handle(self::UPLOAD_TIME_PROPERTYNAME, function () use ($node) {
 				return $node->getFileInfo()->getUploadTime();
 			});
 
 		}
 
 		if ($node instanceof \OCA\DAV\Connector\Sabre\Directory) {
-			$propFind->handle(self::SIZE_PROPERTYNAME, function() use ($node) {
+			$propFind->handle(self::SIZE_PROPERTYNAME, function () use ($node) {
 				return $node->getSize();
 			});
 
-			$propFind->handle(self::IS_ENCRYPTED_PROPERTYNAME, function() use ($node) {
+			$propFind->handle(self::IS_ENCRYPTED_PROPERTYNAME, function () use ($node) {
 				return $node->getFileInfo()->isEncrypted() ? '1' : '0';
 			});
 		}
@@ -467,14 +467,14 @@ class FilesPlugin extends ServerPlugin {
 			return;
 		}
 
-		$propPatch->handle(self::LASTMODIFIED_PROPERTYNAME, function($time) use ($node) {
+		$propPatch->handle(self::LASTMODIFIED_PROPERTYNAME, function ($time) use ($node) {
 			if (empty($time)) {
 				return false;
 			}
 			$node->touch($time);
 			return true;
 		});
-		$propPatch->handle(self::GETETAG_PROPERTYNAME, function($etag) use ($node) {
+		$propPatch->handle(self::GETETAG_PROPERTYNAME, function ($etag) use ($node) {
 			if (empty($etag)) {
 				return false;
 			}
@@ -483,7 +483,7 @@ class FilesPlugin extends ServerPlugin {
 			}
 			return false;
 		});
-		$propPatch->handle(self::CREATION_TIME_PROPERTYNAME, function($time) use ($node) {
+		$propPatch->handle(self::CREATION_TIME_PROPERTYNAME, function ($time) use ($node) {
 			if (empty($time)) {
 				return false;
 			}

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -273,7 +273,7 @@ class Principal implements BackendInterface {
 					$users = $this->userManager->getByEmail($value);
 
 					if (!$allowEnumeration) {
-						$users = \array_filter($users, static function(IUser $user) use ($value) {
+						$users = \array_filter($users, static function (IUser $user) use ($value) {
 							return $user->getEMailAddress() === $value;
 						});
 					}
@@ -287,7 +287,7 @@ class Principal implements BackendInterface {
 						});
 					}
 
-					$results[] = array_reduce($users, function(array $carry, IUser $user) use ($restrictGroups) {
+					$results[] = array_reduce($users, function (array $carry, IUser $user) use ($restrictGroups) {
 						// is sharing restricted to groups only?
 						if ($restrictGroups !== false) {
 							$userGroups = $this->groupManager->getUserGroupIds($user);
@@ -305,7 +305,7 @@ class Principal implements BackendInterface {
 					$users = $this->userManager->searchDisplayName($value);
 
 					if (!$allowEnumeration) {
-						$users = \array_filter($users, static function(IUser $user) use ($value) {
+						$users = \array_filter($users, static function (IUser $user) use ($value) {
 							return $user->getDisplayName() === $value;
 						});
 					}
@@ -319,7 +319,7 @@ class Principal implements BackendInterface {
 						});
 					}
 
-					$results[] = array_reduce($users, function(array $carry, IUser $user) use ($restrictGroups) {
+					$results[] = array_reduce($users, function (array $carry, IUser $user) use ($restrictGroups) {
 						// is sharing restricted to groups only?
 						if ($restrictGroups !== false) {
 							$userGroups = $this->groupManager->getUserGroupIds($user);
@@ -518,7 +518,7 @@ class Principal implements BackendInterface {
 
 			$circles = \OCA\Circles\Api\v1\Circles::joinedCircles($name, true);
 
-			$circles = array_map(function($circle) {
+			$circles = array_map(function ($circle) {
 				/** @var \OCA\Circles\Model\Circle $circle */
 				return 'principals/circles/' . urlencode($circle->getUniqueId());
 			}, $circles);

--- a/apps/dav/lib/Connector/Sabre/SharesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/SharesPlugin.php
@@ -200,14 +200,14 @@ class SharesPlugin extends \Sabre\DAV\ServerPlugin {
 		$propFind->handle(self::SHARETYPES_PROPERTYNAME, function () use ($sabreNode) {
 			$shares = $this->getShares($sabreNode);
 
-			$shareTypes = array_unique(array_map(function(IShare $share) {
+			$shareTypes = array_unique(array_map(function (IShare $share) {
 				return $share->getShareType();
 			}, $shares));
 
 			return new ShareTypeList($shareTypes);
 		});
 
-		$propFind->handle(self::SHAREES_PROPERTYNAME, function() use ($sabreNode) {
+		$propFind->handle(self::SHAREES_PROPERTYNAME, function () use ($sabreNode) {
 			$shares = $this->getShares($sabreNode);
 
 			return new ShareeList($shares);

--- a/apps/dav/lib/Connector/Sabre/TagsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/TagsPlugin.php
@@ -246,12 +246,12 @@ class TagsPlugin extends \Sabre\DAV\ServerPlugin
 
 		$isFav = null;
 
-		$propFind->handle(self::TAGS_PROPERTYNAME, function() use (&$isFav, $node) {
+		$propFind->handle(self::TAGS_PROPERTYNAME, function () use (&$isFav, $node) {
 			list($tags, $isFav) = $this->getTagsAndFav($node->getId());
 			return new TagList($tags);
 		});
 
-		$propFind->handle(self::FAVORITE_PROPERTYNAME, function() use ($isFav, $node) {
+		$propFind->handle(self::FAVORITE_PROPERTYNAME, function () use ($isFav, $node) {
 			if (is_null($isFav)) {
 				list(, $isFav) = $this->getTagsAndFav($node->getId());
 			}
@@ -277,12 +277,12 @@ class TagsPlugin extends \Sabre\DAV\ServerPlugin
 			return;
 		}
 
-		$propPatch->handle(self::TAGS_PROPERTYNAME, function($tagList) use ($node) {
+		$propPatch->handle(self::TAGS_PROPERTYNAME, function ($tagList) use ($node) {
 			$this->updateTags($node->getId(), $tagList->getTags());
 			return true;
 		});
 
-		$propPatch->handle(self::FAVORITE_PROPERTYNAME, function($favState) use ($node) {
+		$propPatch->handle(self::FAVORITE_PROPERTYNAME, function ($favState) use ($node) {
 			if ((int)$favState === 1 || $favState === 'true') {
 				$this->getTagger()->tagAs($node->getId(), self::TAG_FAVORITE);
 			} else {

--- a/apps/dav/lib/Controller/BirthdayCalendarController.php
+++ b/apps/dav/lib/Controller/BirthdayCalendarController.php
@@ -78,7 +78,7 @@ class BirthdayCalendarController extends Controller {
 								IDBConnection $db, IConfig $config,
 								IJobList $jobList,
 								IUserManager $userManager,
-								CalDavBackend $calDavBackend){
+								CalDavBackend $calDavBackend) {
 		parent::__construct($appName, $request);
 		$this->db = $db;
 		$this->config = $config;
@@ -94,7 +94,7 @@ class BirthdayCalendarController extends Controller {
 		$this->config->setAppValue($this->appName, 'generateBirthdayCalendar', 'yes');
 
 		// add background job for each user
-		$this->userManager->callForSeenUsers(function(IUser $user) {
+		$this->userManager->callForSeenUsers(function (IUser $user) {
 			$this->jobList->add(GenerateBirthdayCalendarBackgroundJob::class, [
 				'userId' => $user->getUID(),
 			]);

--- a/apps/dav/lib/DAV/GroupPrincipalBackend.php
+++ b/apps/dav/lib/DAV/GroupPrincipalBackend.php
@@ -134,7 +134,7 @@ class GroupPrincipalBackend implements BackendInterface {
 			return [];
 		}
 
-		return array_map(function($user) {
+		return array_map(function ($user) {
 			return $this->userToPrincipal($user);
 		}, $group->getUsers());
 	}
@@ -210,7 +210,7 @@ class GroupPrincipalBackend implements BackendInterface {
 				case '{DAV:}displayname':
 					$groups = $this->groupManager->search($value);
 
-					$results[] = array_reduce($groups, function(array $carry, IGroup $group) use ($restrictGroups) {
+					$results[] = array_reduce($groups, function (array $carry, IGroup $group) use ($restrictGroups) {
 						$gid = $group->getGID();
 						// is sharing restricted to groups only?
 						if ($restrictGroups !== false) {

--- a/apps/dav/lib/DAV/Sharing/Plugin.php
+++ b/apps/dav/lib/DAV/Sharing/Plugin.php
@@ -192,7 +192,7 @@ class Plugin extends ServerPlugin {
 	function propFind(PropFind $propFind, INode $node) {
 		if ($node instanceof IShareable) {
 
-			$propFind->handle('{' . Plugin::NS_OWNCLOUD . '}invite', function() use ($node) {
+			$propFind->handle('{' . Plugin::NS_OWNCLOUD . '}invite', function () use ($node) {
 				return new Invite(
 					$node->getShares()
 				);

--- a/apps/dav/lib/Files/Sharing/FilesDropPlugin.php
+++ b/apps/dav/lib/Files/Sharing/FilesDropPlugin.php
@@ -66,7 +66,7 @@ class FilesDropPlugin extends ServerPlugin {
 		$this->enabled = false;
 	}
 
-	public function beforeMethod(RequestInterface $request, ResponseInterface $response){
+	public function beforeMethod(RequestInterface $request, ResponseInterface $response) {
 
 		if (!$this->enabled) {
 			return;

--- a/apps/dav/lib/Files/Sharing/PublicLinkCheckPlugin.php
+++ b/apps/dav/lib/Files/Sharing/PublicLinkCheckPlugin.php
@@ -56,7 +56,7 @@ class PublicLinkCheckPlugin extends ServerPlugin {
 		$server->on('beforeMethod:*', [$this, 'beforeMethod']);
 	}
 
-	public function beforeMethod(RequestInterface $request, ResponseInterface $response){
+	public function beforeMethod(RequestInterface $request, ResponseInterface $response) {
 		// verify that the owner didn't have his share permissions revoked
 		if ($this->fileInfo && !$this->fileInfo->isShareable()) {
 			throw new NotFound();

--- a/apps/dav/lib/Provisioning/Apple/AppleProvisioningPlugin.php
+++ b/apps/dav/lib/Provisioning/Apple/AppleProvisioningPlugin.php
@@ -156,7 +156,7 @@ class AppleProvisioningPlugin extends ServerPlugin {
 		$filename = $userId . '-' . AppleProvisioningNode::FILENAME;
 
 		$xmlSkeleton = $this->getTemplate();
-		$body = vsprintf($xmlSkeleton, array_map(function($v) {
+		$body = vsprintf($xmlSkeleton, array_map(function ($v) {
 				return \htmlspecialchars($v, ENT_XML1, 'UTF-8');
 			}, [
 				$description,

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -295,7 +295,7 @@ class Server {
 					\OC::$server->getThemingDefaults(),
 					\OC::$server->getRequest(),
 					\OC::$server->getL10N('dav'),
-					function() {
+					function () {
 						return UUIDUtil::getUUID();
 					}
 				));

--- a/apps/dav/lib/SystemTag/SystemTagPlugin.php
+++ b/apps/dav/lib/SystemTag/SystemTagPlugin.php
@@ -226,29 +226,29 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 			return;
 		}
 
-		$propFind->handle(self::ID_PROPERTYNAME, function() use ($node) {
+		$propFind->handle(self::ID_PROPERTYNAME, function () use ($node) {
 			return $node->getSystemTag()->getId();
 		});
 
-		$propFind->handle(self::DISPLAYNAME_PROPERTYNAME, function() use ($node) {
+		$propFind->handle(self::DISPLAYNAME_PROPERTYNAME, function () use ($node) {
 			return $node->getSystemTag()->getName();
 		});
 
-		$propFind->handle(self::USERVISIBLE_PROPERTYNAME, function() use ($node) {
+		$propFind->handle(self::USERVISIBLE_PROPERTYNAME, function () use ($node) {
 			return $node->getSystemTag()->isUserVisible() ? 'true' : 'false';
 		});
 
-		$propFind->handle(self::USERASSIGNABLE_PROPERTYNAME, function() use ($node) {
+		$propFind->handle(self::USERASSIGNABLE_PROPERTYNAME, function () use ($node) {
 			// this is the tag's inherent property "is user assignable"
 			return $node->getSystemTag()->isUserAssignable() ? 'true' : 'false';
 		});
 
-		$propFind->handle(self::CANASSIGN_PROPERTYNAME, function() use ($node) {
+		$propFind->handle(self::CANASSIGN_PROPERTYNAME, function () use ($node) {
 			// this is the effective permission for the current user
 			return $this->tagManager->canUserAssignTag($node->getSystemTag(), $this->userSession->getUser()) ? 'true' : 'false';
 		});
 
-		$propFind->handle(self::GROUPS_PROPERTYNAME, function() use ($node) {
+		$propFind->handle(self::GROUPS_PROPERTYNAME, function () use ($node) {
 			if (!$this->groupManager->isAdmin($this->userSession->getUser()->getUID())) {
 				// property only available for admins
 				throw new Forbidden();
@@ -281,7 +281,7 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 			self::USERVISIBLE_PROPERTYNAME,
 			self::USERASSIGNABLE_PROPERTYNAME,
 			self::GROUPS_PROPERTYNAME,
-		], function($props) use ($node) {
+		], function ($props) use ($node) {
 			$tag = $node->getSystemTag();
 			$name = $tag->getName();
 			$userVisible = $tag->isUserVisible();

--- a/apps/dav/lib/SystemTag/SystemTagsByIdCollection.php
+++ b/apps/dav/lib/SystemTag/SystemTagsByIdCollection.php
@@ -122,7 +122,7 @@ class SystemTagsByIdCollection implements ICollection {
 		}
 
 		$tags = $this->tagManager->getAllTags($visibilityFilter);
-		return array_map(function($tag) {
+		return array_map(function ($tag) {
 			return $this->makeNode($tag);
 		}, $tags);
 	}

--- a/apps/dav/lib/SystemTag/SystemTagsObjectMappingCollection.php
+++ b/apps/dav/lib/SystemTag/SystemTagsObjectMappingCollection.php
@@ -138,11 +138,11 @@ class SystemTagsObjectMappingCollection implements ICollection {
 		$tags = $this->tagManager->getTagsByIds($tagIds);
 
 		// filter out non-visible tags
-		$tags = array_filter($tags, function($tag) {
+		$tags = array_filter($tags, function ($tag) {
 			return $this->tagManager->canUserSeeTag($tag, $this->user);
 		});
 
-		return array_values(array_map(function($tag) {
+		return array_values(array_map(function ($tag) {
 			return $this->makeNode($tag);
 		}, $tags));
 	}

--- a/apps/dav/lib/SystemTag/SystemTagsRelationsCollection.php
+++ b/apps/dav/lib/SystemTag/SystemTagsRelationsCollection.php
@@ -60,7 +60,7 @@ class SystemTagsRelationsCollection extends SimpleCollection {
 				$tagMapper,
 				$userSession,
 				$groupManager,
-				function($name) {
+				function ($name) {
 					$nodes = \OC::$server->getUserFolder()->getById((int)$name);
 					return !empty($nodes);
 				}

--- a/apps/dav/lib/Traits/PrincipalProxyTrait.php
+++ b/apps/dav/lib/Traits/PrincipalProxyTrait.php
@@ -150,7 +150,7 @@ trait PrincipalProxyTrait {
 					$proxy->setPermissions($proxy->getPermissions() | $permission);
 					$this->proxyMapper->update($proxy);
 
-					$proxies = array_filter($proxies, function(Proxy $p) use ($proxy) {
+					$proxies = array_filter($proxies, function (Proxy $p) use ($proxy) {
 						return $p->getId() !== $proxy->getId();
 					});
 					break;

--- a/apps/dav/lib/Upload/FutureFile.php
+++ b/apps/dav/lib/Upload/FutureFile.php
@@ -86,7 +86,7 @@ class FutureFile implements \Sabre\DAV\IFile {
 	 */
 	function getSize() {
 		$children = $this->root->getChildren();
-		$sizes = array_map(function($node) {
+		$sizes = array_map(function ($node) {
 			/** @var IFile $node */
 			return $node->getSize();
 		}, $children);

--- a/apps/dav/lib/Upload/UploadHome.php
+++ b/apps/dav/lib/Upload/UploadHome.php
@@ -59,7 +59,7 @@ class UploadHome implements ICollection {
 	}
 
 	public function getChildren(): array {
-		return array_map(function($node) {
+		return array_map(function ($node) {
 			return new UploadFolder($node, $this->cleanupService);
 		}, $this->impl()->getChildren());
 	}

--- a/apps/dav/tests/unit/BackgroundJob/RegisterRegenerateBirthdayCalendarsTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/RegisterRegenerateBirthdayCalendarsTest.php
@@ -66,7 +66,7 @@ class RegisterRegenerateBirthdayCalendarsTest extends TestCase {
 	public function testRun() {
 		$this->userManager->expects($this->once())
 			->method('callForSeenUsers')
-			->willReturnCallback(function($closure) {
+			->willReturnCallback(function ($closure) {
 				$user1 = $this->createMock(IUser::class);
 				$user1->method('getUID')->willReturn('uid1');
 				$user2 = $this->createMock(IUser::class);

--- a/apps/dav/tests/unit/BackgroundJob/UpdateCalendarResourcesRoomsBackgroundJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/UpdateCalendarResourcesRoomsBackgroundJobTest.php
@@ -146,7 +146,7 @@ class UpdateCalendarResourcesRoomsBackgroundJobTest extends TestCase {
 		$res6->method('getBackend')->willReturn($backend3);
 
 		$res6->method('getAllAvailableMetadataKeys')->willReturn(['meta99', 'meta123']);
-		$res6->method('getMetadataForKey')->willReturnCallback(function($key) {
+		$res6->method('getMetadataForKey')->willReturnCallback(function ($key) {
 			switch($key) {
 				case 'meta99':
 					return 'value99-new';
@@ -165,7 +165,7 @@ class UpdateCalendarResourcesRoomsBackgroundJobTest extends TestCase {
 		$res7->method('getEMail')->willReturn('res7@foo.bar');
 		$res7->method('getBackend')->willReturn($backend3);
 		$res7->method('getAllAvailableMetadataKeys')->willReturn(['meta1']);
-		$res7->method('getMetadataForKey')->willReturnCallback(function($key) {
+		$res7->method('getMetadataForKey')->willReturnCallback(function ($key) {
 			switch($key) {
 				case 'meta1':
 					return 'value1';
@@ -181,7 +181,7 @@ class UpdateCalendarResourcesRoomsBackgroundJobTest extends TestCase {
 		$res8->method('getEMail')->willReturn('res8@foo.bar');
 		$res8->method('getBackend')->willReturn($backend4);
 		$res8->method('getAllAvailableMetadataKeys')->willReturn(['meta2']);
-		$res8->method('getMetadataForKey')->willReturnCallback(function($key) {
+		$res8->method('getMetadataForKey')->willReturnCallback(function ($key) {
 			switch($key) {
 				case 'meta2':
 					return 'value2';

--- a/apps/dav/tests/unit/CalDAV/Activity/BackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/BackendTest.php
@@ -97,7 +97,7 @@ class BackendTest extends TestCase {
 		$backend = $this->getBackend(['triggerCalendarActivity']);
 		$backend->expects($this->once())
 			->method('triggerCalendarActivity')
-			->willReturnCallback(function() use($expectedPayload, $expectedSubject) {
+			->willReturnCallback(function () use ($expectedPayload, $expectedSubject) {
 				$arguments = func_get_args();
 				$this->assertSame($expectedSubject, array_shift($arguments));
 				$this->assertEquals($expectedPayload, $arguments);

--- a/apps/dav/tests/unit/CalDAV/Activity/Filter/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Filter/CalendarTest.php
@@ -45,7 +45,7 @@ class CalendarTest extends TestCase {
 		$l = $this->createMock(IL10N::class);
 		$l->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($string, $args) {
+			->willReturnCallback(function ($string, $args) {
 				return vsprintf($string, $args);
 			});
 

--- a/apps/dav/tests/unit/CalDAV/Activity/Filter/TodoTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Filter/TodoTest.php
@@ -44,7 +44,7 @@ class TodoTest extends TestCase {
 		$l = $this->createMock(IL10N::class);
 		$l->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($string, $args) {
+			->willReturnCallback(function ($string, $args) {
 				return vsprintf($string, $args);
 			});
 

--- a/apps/dav/tests/unit/CalDAV/Activity/Provider/BaseTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Provider/BaseTest.php
@@ -141,7 +141,7 @@ class BaseTest extends TestCase {
 		$l = $this->createMock(IL10N::class);
 		$l->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($string, $args) {
+			->willReturnCallback(function ($string, $args) {
 				return 't(' . vsprintf($string, $args) . ')';
 			});
 

--- a/apps/dav/tests/unit/CalDAV/BirthdayCalendar/EnablePluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/BirthdayCalendar/EnablePluginTest.php
@@ -129,7 +129,7 @@ class EnablePluginTest extends TestCase {
 
 		$this->server->xml->expects($this->once())
 			->method('parse')
-			->willReturnCallback(function($requestBody, $url, &$documentType) {
+			->willReturnCallback(function ($requestBody, $url, &$documentType) {
 				$documentType =  '{http://nextcloud.com/ns}disable-birthday-calendar';
 			});
 
@@ -167,7 +167,7 @@ class EnablePluginTest extends TestCase {
 
 		$this->server->xml->expects($this->once())
 			->method('parse')
-			->willReturnCallback(function($requestBody, $url, &$documentType) {
+			->willReturnCallback(function ($requestBody, $url, &$documentType) {
 				$documentType = '{http://nextcloud.com/ns}enable-birthday-calendar';
 			});
 

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -401,7 +401,7 @@ EOD;
 			$this->assertArrayHasKey('classification', $card);
 		}
 
-		usort($calendarObjects, function($a, $b) {
+		usort($calendarObjects, function ($a, $b) {
 			return $a['id'] - $b['id'];
 		});
 
@@ -442,7 +442,7 @@ EOD;
 			'comp-filters' => $compFilter
 		]);
 
-		$expectedEventsInResult = array_map(function($index) use($events) {
+		$expectedEventsInResult = array_map(function ($index) use ($events) {
 			return $events[$index];
 		}, $expectedEventsInResult);
 		$this->assertEquals($expectedEventsInResult, $result, '', 0.0, 10, true);

--- a/apps/dav/tests/unit/CalDAV/CalendarManagerTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarManagerTest.php
@@ -70,7 +70,7 @@ class CalendarManagerTest extends \Test\TestCase {
 		$calendarManager = $this->createMock(Manager::class);
 		$calendarManager->expects($this->at(0))
 			->method('registerCalendar')
-			->willReturnCallback(function() {
+			->willReturnCallback(function () {
 				$parameter = func_get_arg(0);
 				$this->assertInstanceOf(CalendarImpl::class, $parameter);
 				$this->assertEquals(123, $parameter->getKey());
@@ -78,7 +78,7 @@ class CalendarManagerTest extends \Test\TestCase {
 
 		$calendarManager->expects($this->at(1))
 			->method('registerCalendar')
-			->willReturnCallback(function() {
+			->willReturnCallback(function () {
 				$parameter = func_get_arg(0);
 				$this->assertInstanceOf(CalendarImpl::class, $parameter);
 				$this->assertEquals(456, $parameter->getKey());

--- a/apps/dav/tests/unit/CalDAV/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarTest.php
@@ -569,7 +569,7 @@ EOD;
 
 		$backend->expects($this->any())
 			->method('getCalendarObject')
-			->willReturnCallback(function($cId, $uri) use($publicObject, $confidentialObject) {
+			->willReturnCallback(function ($cId, $uri) use ($publicObject, $confidentialObject) {
 				switch($uri) {
 					case 'event-0':
 						return $publicObject;

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotificationProvider/PushProviderTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotificationProvider/PushProviderTest.php
@@ -80,7 +80,7 @@ class PushProviderTest extends AbstractNotificationProviderTest {
 		);
 	}
 
-	public function testNotificationType():void  {
+	public function testNotificationType():void {
 		$this->assertEquals(PushProvider::NOTIFICATION_TYPE, 'DISPLAY');
 	}
 

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotificationProviderManagerTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotificationProviderManagerTest.php
@@ -56,7 +56,7 @@ class NotificationProviderManagerTest extends TestCase {
 	 * @throws ProviderNotAvailableException
 	 * @throws NotificationTypeDoesNotExistException
 	 */
-	public function testGetProviderForUnknownType(): void{
+	public function testGetProviderForUnknownType(): void {
 		$this->expectException(\OCA\DAV\CalDAV\Reminder\NotificationTypeDoesNotExistException::class);
 		$this->expectExceptionMessage('Type NOT EXISTENT is not an accepted type of notification');
 
@@ -67,19 +67,19 @@ class NotificationProviderManagerTest extends TestCase {
 	 * @throws NotificationTypeDoesNotExistException
 	 * @throws ProviderNotAvailableException
 	 */
-	public function testGetProviderForUnRegisteredType(): void{
+	public function testGetProviderForUnRegisteredType(): void {
 		$this->expectException(\OCA\DAV\CalDAV\Reminder\NotificationProvider\ProviderNotAvailableException::class);
 		$this->expectExceptionMessage('No notification provider for type AUDIO available');
 
 		$this->providerManager->getProvider('AUDIO');
 	}
 
-	public function testGetProvider(): void{
+	public function testGetProvider(): void {
 		$provider = $this->providerManager->getProvider('EMAIL');
 		$this->assertInstanceOf(EmailProvider::class, $provider);
 	}
 
-	public function testRegisterProvider(): void{
+	public function testRegisterProvider(): void {
 		$this->providerManager->registerProvider(PushProvider::class);
 		$provider = $this->providerManager->getProvider('DISPLAY');
 		$this->assertInstanceOf(PushProvider::class, $provider);
@@ -88,7 +88,7 @@ class NotificationProviderManagerTest extends TestCase {
 	/**
 	 * @throws \OCP\AppFramework\QueryException
 	 */
-	public function testRegisterBadProvider(): void{
+	public function testRegisterBadProvider(): void {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid notification provider registered');
 

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotifierTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotifierTest.php
@@ -61,18 +61,18 @@ class NotifierTest extends TestCase {
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($string, $args) {
+			->willReturnCallback(function ($string, $args) {
 				return vsprintf($string, $args);
 			});
 		$this->l10n->expects($this->any())
 			->method('l')
-			->willReturnCallback(function($string, $args) {
+			->willReturnCallback(function ($string, $args) {
 				/** \DateTime $args */
 				return $args->format(\DateTime::ATOM);
 			});
 		$this->l10n->expects($this->any())
 			->method('n')
-			->willReturnCallback(function($textSingular, $textPlural, $count, $args) {
+			->willReturnCallback(function ($textSingular, $textPlural, $count, $args) {
 				$text = $count === 1 ? $textSingular : $textPlural;
 				$text = str_replace('%n', (string)$count, $text);
 				return vsprintf($text, $args);

--- a/apps/dav/tests/unit/CalDAV/Reminder/ReminderServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/ReminderServiceTest.php
@@ -501,7 +501,7 @@ EOD;
 
 		$provider1->expects($this->once())
 			->method('send')
-			->with($this->callback(function($vevent) {
+			->with($this->callback(function ($vevent) {
 				if ($vevent->DTSTART->getDateTime()->format(\DateTime::ATOM) !== '2016-06-09T00:00:00+00:00') {
 					return false;
 				}
@@ -509,7 +509,7 @@ EOD;
 			}, 'Displayname 123', $user));
 		$provider2->expects($this->once())
 			->method('send')
-			->with($this->callback(function($vevent) {
+			->with($this->callback(function ($vevent) {
 				if ($vevent->DTSTART->getDateTime()->format(\DateTime::ATOM) !== '2016-06-09T00:00:00+00:00') {
 					return false;
 				}
@@ -517,7 +517,7 @@ EOD;
 			}, 'Displayname 123', $user));
 		$provider3->expects($this->once())
 			->method('send')
-			->with($this->callback(function($vevent) {
+			->with($this->callback(function ($vevent) {
 				if ($vevent->DTSTART->getDateTime()->format(\DateTime::ATOM) !== '2016-06-09T00:00:00+00:00') {
 					return false;
 				}
@@ -525,7 +525,7 @@ EOD;
 			}, 'Displayname 123', $user));
 		$provider4->expects($this->once())
 			->method('send')
-			->with($this->callback(function($vevent) {
+			->with($this->callback(function ($vevent) {
 				if ($vevent->DTSTART->getDateTime()->format(\DateTime::ATOM) !== '2016-06-30T00:00:00+00:00') {
 					return false;
 				}
@@ -533,7 +533,7 @@ EOD;
 			}, 'Displayname 123', $user));
 		$provider5->expects($this->once())
 			->method('send')
-			->with($this->callback(function($vevent) {
+			->with($this->callback(function ($vevent) {
 				if ($vevent->DTSTART->getDateTime()->format(\DateTime::ATOM) !== '2016-07-07T00:00:00+00:00') {
 					return false;
 				}

--- a/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTest.php
@@ -236,7 +236,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 
 		$this->proxyMapper->expects($this->at(1))
 			->method('insert')
-			->with($this->callback(function($proxy) {
+			->with($this->callback(function ($proxy) {
 				/** @var Proxy $proxy */
 				if ($proxy->getOwnerId() !== $this->principalPrefix . '/backend1-res1') {
 					return false;
@@ -252,7 +252,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 			}));
 		$this->proxyMapper->expects($this->at(2))
 			->method('insert')
-			->with($this->callback(function($proxy) {
+			->with($this->callback(function ($proxy) {
 				/** @var Proxy $proxy */
 				if ($proxy->getOwnerId() !== $this->principalPrefix . '/backend1-res1') {
 					return false;

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
@@ -107,7 +107,7 @@ class IMipPluginTest extends TestCase {
 
 		$l10n = $this->createMock(IL10N::class);
 		$l10n->method('t')
-			->willReturnCallback(function($text, $parameters = []) {
+			->willReturnCallback(function ($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			});
 		$l10nFactory = $this->createMock(IFactory::class);
@@ -223,7 +223,7 @@ class IMipPluginTest extends TestCase {
 	/**
 	 * @dataProvider dataIncludeResponseButtons
 	 */
-	public function testIncludeResponseButtons(string $config_setting, string $recipient, bool $has_buttons ) {
+	public function testIncludeResponseButtons(string $config_setting, string $recipient, bool $has_buttons) {
 		$message = $this->_testMessage([],$recipient);
 
 		$this->_expectSend($recipient, true, $has_buttons);
@@ -264,7 +264,7 @@ class IMipPluginTest extends TestCase {
 		$this->assertEquals('1.1', $message->getScheduleStatus());
 	}
 
-	private function _testMessage(array $attrs = [], string $recipient = 'frodo@hobb.it' ) {
+	private function _testMessage(array $attrs = [], string $recipient = 'frodo@hobb.it') {
 		$message = new Message();
 		$message->method = 'REQUEST';
 		$message->message = new VCalendar();

--- a/apps/dav/tests/unit/CalDAV/WebcalCaching/RefreshWebcalServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/WebcalCaching/RefreshWebcalServiceTest.php
@@ -116,7 +116,7 @@ class RefreshWebcalServiceTest extends TestCase {
 
 		$client->expects($this->once())
 			->method('get')
-			->with('https://foo.bar/bla2', $this->callback(function($obj) {
+			->with('https://foo.bar/bla2', $this->callback(function ($obj) {
 				return $obj['allow_redirects']['redirects'] === 10 && $obj['handler'] instanceof HandlerStack;
 			}))
 			->willReturn($response);

--- a/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
+++ b/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
@@ -280,7 +280,7 @@ class AddressBookImplTest extends TestCase {
 		// simulate that 'uid0' already exists, so the second uid will be returned
 		$this->backend->expects($this->exactly(2))->method('getContact')
 			->willReturnCallback(
-				function($id, $uid) {
+				function ($id, $uid) {
 					return ($uid === 'uid0.vcf');
 				}
 			);

--- a/apps/dav/tests/unit/CardDAV/BirthdayServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/BirthdayServiceTest.php
@@ -66,7 +66,7 @@ class BirthdayServiceTest extends TestCase {
 
 		$this->l10n->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($string, $args) {
+			->willReturnCallback(function ($string, $args) {
 				return vsprintf($string, $args);
 			});
 
@@ -392,7 +392,7 @@ class BirthdayServiceTest extends TestCase {
 		];
 	}
 
-	public function providesCardChanges(){
+	public function providesCardChanges() {
 		return[
 			['delete'],
 			['create'],

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -258,7 +258,7 @@ class CardDavBackendTest extends TestCase {
 		// Expect event
 		$this->dispatcher->expects($this->at(0))
 			->method('dispatch')
-			->with('\OCA\DAV\CardDAV\CardDavBackend::createCard', $this->callback(function(GenericEvent $e) use ($bookId, $uri) {
+			->with('\OCA\DAV\CardDAV\CardDavBackend::createCard', $this->callback(function (GenericEvent $e) use ($bookId, $uri) {
 				return $e->getArgument('addressBookId') === $bookId &&
 					$e->getArgument('cardUri') === $uri &&
 					$e->getArgument('cardData') === $this->vcardTest0;
@@ -285,7 +285,7 @@ class CardDavBackendTest extends TestCase {
 		// Expect event
 		$this->dispatcher->expects($this->at(0))
 			->method('dispatch')
-			->with('\OCA\DAV\CardDAV\CardDavBackend::updateCard', $this->callback(function(GenericEvent $e) use ($bookId, $uri) {
+			->with('\OCA\DAV\CardDAV\CardDavBackend::updateCard', $this->callback(function (GenericEvent $e) use ($bookId, $uri) {
 				return $e->getArgument('addressBookId') === $bookId &&
 					$e->getArgument('cardUri') === $uri &&
 					$e->getArgument('cardData') === $this->vcardTest0;
@@ -299,7 +299,7 @@ class CardDavBackendTest extends TestCase {
 		// Expect event
 		$this->dispatcher->expects($this->at(0))
 			->method('dispatch')
-			->with('\OCA\DAV\CardDAV\CardDavBackend::deleteCard', $this->callback(function(GenericEvent $e) use ($bookId, $uri) {
+			->with('\OCA\DAV\CardDAV\CardDavBackend::deleteCard', $this->callback(function (GenericEvent $e) use ($bookId, $uri) {
 				return $e->getArgument('addressBookId') === $bookId &&
 					$e->getArgument('cardUri') === $uri;
 			}));

--- a/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
@@ -140,7 +140,7 @@ class ImageExportPluginTest extends TestCase {
 			->willReturn(1);
 
 		$this->tree->method('getNodeForPath')
-			->willReturnCallback(function($path) use ($card, $book) {
+			->willReturnCallback(function ($path) use ($card, $book) {
 				if ($path === 'user/book/card') {
 					return $card;
 				} else if ($path === 'user/book') {

--- a/apps/dav/tests/unit/Comments/RootCollectionTest.php
+++ b/apps/dav/tests/unit/Comments/RootCollectionTest.php
@@ -100,8 +100,8 @@ class RootCollectionTest extends \Test\TestCase {
 			->method('getUser')
 			->willReturn($this->user);
 
-		$this->dispatcher->addListener(CommentsEntityEvent::EVENT_ENTITY, function(CommentsEntityEvent $event) {
-			$event->addEntityCollection('files', function() {
+		$this->dispatcher->addListener(CommentsEntityEvent::EVENT_ENTITY, function (CommentsEntityEvent $event) {
+			$event->addEntityCollection('files', function () {
 				return true;
 			});
 		});

--- a/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
@@ -62,7 +62,7 @@ class ExceptionLoggerPluginTest extends TestCase {
 		$config = $this->createMock(SystemConfig::class);
 		$config->expects($this->any())
 			->method('getValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				switch ($key) {
 					case 'loglevel':
 						return 0;

--- a/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
@@ -283,7 +283,7 @@ class ObjectTreeTest extends \Test\TestCase {
 			->getMock();
 		$view->expects($this->once())
 			->method('resolvePath')
-			->willReturnCallback(function($path) use ($storage){
+			->willReturnCallback(function ($path) use ($storage) {
 			return [$storage, ltrim($path, '/')];
 		});
 

--- a/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
@@ -392,7 +392,7 @@ class PrincipalTest extends TestCase {
 
 		$this->proxyMapper->expects($this->at(1))
 			->method('insert')
-			->with($this->callback(function($proxy) {
+			->with($this->callback(function ($proxy) {
 				/** @var Proxy $proxy */
 				if ($proxy->getOwnerId() !== 'principals/users/foo') {
 					return false;

--- a/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
@@ -125,7 +125,7 @@ class SharesPluginTest extends \Test\TestCase {
 				$this->equalTo(false),
 				$this->equalTo(-1)
 			)
-			->willReturnCallback(function($userId, $requestedShareType, $node, $flag, $limit) use ($shareTypes){
+			->willReturnCallback(function ($userId, $requestedShareType, $node, $flag, $limit) use ($shareTypes) {
 				if (in_array($requestedShareType, $shareTypes)) {
 					$share = $this->createMock(IShare::class);
 					$share->method('getShareType')
@@ -191,7 +191,7 @@ class SharesPluginTest extends \Test\TestCase {
 			->with('/subdir')
 			->willReturn($node);
 		
-		$dummyShares = array_map(function($type) {
+		$dummyShares = array_map(function ($type) {
 			$share = $this->getMockBuilder(IShare::class)->getMock();
 			$share->expects($this->any())
 				->method('getShareType')
@@ -208,7 +208,7 @@ class SharesPluginTest extends \Test\TestCase {
 				$this->equalTo(false),
 				$this->equalTo(-1)
 			)
-			->willReturnCallback(function($userId, $requestedShareType, $node, $flag, $limit) use ($shareTypes, $dummyShares){
+			->willReturnCallback(function ($userId, $requestedShareType, $node, $flag, $limit) use ($shareTypes, $dummyShares) {
 				if ($node->getId() === 111 && in_array($requestedShareType, $shareTypes)) {
 					foreach ($dummyShares as $dummyShare) {
 						if ($dummyShare->getShareType() === $requestedShareType) {

--- a/apps/dav/tests/unit/Controller/BirthdayCalendarControllerTest.php
+++ b/apps/dav/tests/unit/Controller/BirthdayCalendarControllerTest.php
@@ -82,7 +82,7 @@ class BirthdayCalendarControllerTest extends TestCase {
 
 		$this->userManager->expects($this->once())
 			->method('callForSeenUsers')
-			->willReturnCallback(function($closure) {
+			->willReturnCallback(function ($closure) {
 				$user1 = $this->createMock(IUser::class);
 				$user1->method('getUID')->willReturn('uid1');
 				$user2 = $this->createMock(IUser::class);

--- a/apps/dav/tests/unit/Controller/DirectControllerTest.php
+++ b/apps/dav/tests/unit/Controller/DirectControllerTest.php
@@ -143,7 +143,7 @@ class DirectControllerTest extends TestCase {
 			});
 
 		$this->urlGenerator->method('getAbsoluteURL')
-			->willReturnCallback(function(string $url) {
+			->willReturnCallback(function (string $url) {
 				return 'https://my.nextcloud/'.$url;
 			});
 

--- a/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
+++ b/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
@@ -108,7 +108,7 @@ EOF;
 		$called = false;
 		$this->responseServer->expects($this->once())
 			->method('handleITipMessage')
-			->willReturnCallback(function(Message $iTipMessage) use (&$called, $expected) {
+			->willReturnCallback(function (Message $iTipMessage) use (&$called, $expected) {
 				$called = true;
 				$this->assertEquals('this-is-the-events-uid', $iTipMessage->uid);
 				$this->assertEquals('VEVENT', $iTipMessage->component);
@@ -164,7 +164,7 @@ EOF;
 		$called = false;
 		$this->responseServer->expects($this->once())
 			->method('handleITipMessage')
-			->willReturnCallback(function(Message $iTipMessage) use (&$called, $expected) {
+			->willReturnCallback(function (Message $iTipMessage) use (&$called, $expected) {
 				$called = true;
 				$this->assertEquals('this-is-the-events-uid', $iTipMessage->uid);
 				$this->assertEquals('VEVENT', $iTipMessage->component);
@@ -221,7 +221,7 @@ EOF;
 		$called = false;
 		$this->responseServer->expects($this->once())
 			->method('handleITipMessage')
-			->willReturnCallback(function(Message $iTipMessage) use (&$called, $expected) {
+			->willReturnCallback(function (Message $iTipMessage) use (&$called, $expected) {
 				$called = true;
 				$this->assertEquals('this-is-the-events-uid', $iTipMessage->uid);
 				$this->assertEquals('VEVENT', $iTipMessage->component);
@@ -304,7 +304,7 @@ EOF;
 		$called = false;
 		$this->responseServer->expects($this->once())
 			->method('handleITipMessage')
-			->willReturnCallback(function(Message $iTipMessage) use (&$called, $expected) {
+			->willReturnCallback(function (Message $iTipMessage) use (&$called, $expected) {
 				$called = true;
 				$this->assertEquals('this-is-the-events-uid', $iTipMessage->uid);
 				$this->assertEquals('VEVENT', $iTipMessage->component);
@@ -382,7 +382,7 @@ EOF;
 		$called = false;
 		$this->responseServer->expects($this->once())
 			->method('handleITipMessage')
-			->willReturnCallback(function(Message $iTipMessage) use (&$called, $expected) {
+			->willReturnCallback(function (Message $iTipMessage) use (&$called, $expected) {
 				$called = true;
 				$this->assertEquals('this-is-the-events-uid', $iTipMessage->uid);
 				$this->assertEquals('VEVENT', $iTipMessage->component);

--- a/apps/dav/tests/unit/DAV/AnonymousOptionsTest.php
+++ b/apps/dav/tests/unit/DAV/AnonymousOptionsTest.php
@@ -37,7 +37,7 @@ class AnonymousOptionsTest extends TestCase {
 	private function sendRequest($method, $path, $userAgent = '') {
 		$server = new Server();
 		$server->addPlugin(new AnonymousOptionsPlugin());
-		$server->addPlugin(new Plugin(new BasicCallBack(function() {
+		$server->addPlugin(new Plugin(new BasicCallBack(function () {
 			return false;
 		})));
 

--- a/apps/dav/tests/unit/Files/Sharing/FilesDropPluginTest.php
+++ b/apps/dav/tests/unit/Files/Sharing/FilesDropPluginTest.php
@@ -124,7 +124,7 @@ class FilesDropPluginTest extends TestCase {
 			->willReturn('https://example.com');
 
 		$this->view->method('file_exists')
-			->willReturnCallback(function($path) {
+			->willReturnCallback(function ($path) {
 				if ($path === 'file.txt' || $path === '/file.txt') {
 					return true;
 				} else {
@@ -165,7 +165,7 @@ class FilesDropPluginTest extends TestCase {
 			->willReturn('https://example.com');
 
 		$this->view->method('file_exists')
-			->willReturnCallback(function($path) {
+			->willReturnCallback(function ($path) {
 				if ($path === 'file.txt' || $path === '/file.txt') {
 					return true;
 				} else {

--- a/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningPluginTest.php
+++ b/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningPluginTest.php
@@ -78,7 +78,7 @@ class AppleProvisioningPluginTest extends TestCase {
 			$this->themingDefaults,
 			$this->request,
 			$this->l10n,
-			function() {
+			function () {
 				return 'generated-uuid';
 			}
 		);
@@ -92,7 +92,7 @@ class AppleProvisioningPluginTest extends TestCase {
 
 		$plugin = new AppleProvisioningPlugin($this->userSession,
 			$this->urlGenerator, $this->themingDefaults, $this->request, $this->l10n,
-			function() {});
+			function () {});
 
 		$server->expects($this->at(0))
 			->method('on')

--- a/apps/dav/tests/unit/SystemTag/SystemTagsObjectMappingCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsObjectMappingCollectionTest.php
@@ -251,7 +251,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 
 		$this->tagManager->expects($this->exactly(3))
 			->method('canUserSeeTag')
-			->willReturnCallback(function($tag) {
+			->willReturnCallback(function ($tag) {
 				return $tag->isUserVisible();
 			});
 

--- a/apps/dav/tests/unit/SystemTag/SystemTagsObjectTypeCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsObjectTypeCollectionTest.php
@@ -84,7 +84,7 @@ class SystemTagsObjectTypeCollectionTest extends \Test\TestCase {
 			->getMock();
 		$userFolder = $this->userFolder;
 
-		$closure = function($name) use ($userFolder) {
+		$closure = function ($name) use ($userFolder) {
 			$nodes = $userFolder->getById(intval($name));
 			return !empty($nodes);
 		};

--- a/apps/encryption/lib/AppInfo/Application.php
+++ b/apps/encryption/lib/AppInfo/Application.php
@@ -111,7 +111,7 @@ class Application extends \OCP\AppFramework\App {
 		$this->encryptionManager->registerEncryptionModule(
 			Encryption::ID,
 			Encryption::DISPLAY_NAME,
-			function() use ($container) {
+			function () use ($container) {
 
 			return new Encryption(
 				$container->query('Crypt'),

--- a/apps/encryption/tests/Controller/SettingsControllerTest.php
+++ b/apps/encryption/tests/Controller/SettingsControllerTest.php
@@ -86,7 +86,7 @@ class SettingsControllerTest extends TestCase {
 
 		$this->l10nMock->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($message) {
+			->willReturnCallback(function ($message) {
 				return $message;
 			});
 

--- a/apps/encryption/tests/Controller/StatusControllerTest.php
+++ b/apps/encryption/tests/Controller/StatusControllerTest.php
@@ -63,7 +63,7 @@ class StatusControllerTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->l10nMock->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($message) {
+			->willReturnCallback(function ($message) {
 				return $message;
 			});
 		$this->encryptionManagerMock = $this->createMock(IManager::class);

--- a/apps/encryption/tests/Crypto/CryptTest.php
+++ b/apps/encryption/tests/Crypto/CryptTest.php
@@ -294,7 +294,7 @@ class CryptTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataProviderRemovePadding()  {
+	public function dataProviderRemovePadding() {
 		return [
 			['dataxx', 'data'],
 			['data', false]

--- a/apps/encryption/tests/Crypto/EncryptAllTest.php
+++ b/apps/encryption/tests/Crypto/EncryptAllTest.php
@@ -322,7 +322,7 @@ class EncryptAllTest extends TestCase {
 
 		$this->view->expects($this->any())->method('is_dir')
 			->willReturnCallback(
-				function($path) {
+				function ($path) {
 					if ($path === '/user1/files/foo') {
 						return true;
 					}

--- a/apps/encryption/tests/Crypto/EncryptionTest.php
+++ b/apps/encryption/tests/Crypto/EncryptionTest.php
@@ -323,7 +323,7 @@ class EncryptionTest extends TestCase {
 
 		$this->keyManagerMock->expects($this->any())
 			->method('addSystemKeys')
-			->willReturnCallback(function($accessList, $publicKeys) {
+			->willReturnCallback(function ($accessList, $publicKeys) {
 				return $publicKeys;
 			});
 
@@ -350,7 +350,7 @@ class EncryptionTest extends TestCase {
 		$this->keyManagerMock->expects($this->never())->method('getPublicKey');
 		$this->keyManagerMock->expects($this->never())->method('addSystemKeys');
 		$this->keyManagerMock->expects($this->once())->method('setVersion')
-			->willReturnCallback(function($path, $version, $view) {
+			->willReturnCallback(function ($path, $version, $view) {
 				$this->assertSame('path', $path);
 				$this->assertSame(2, $version);
 				$this->assertTrue($view instanceof \OC\Files\View);
@@ -368,20 +368,20 @@ class EncryptionTest extends TestCase {
 
 		$this->keyManagerMock->expects($this->any())
 			->method('getPublicKey')->willReturnCallback(
-				function($user) {
+				function ($user) {
 					throw new PublicKeyMissingException($user);
 				}
 			);
 
 		$this->keyManagerMock->expects($this->any())
 			->method('addSystemKeys')
-			->willReturnCallback(function($accessList, $publicKeys) {
+			->willReturnCallback(function ($accessList, $publicKeys) {
 				return $publicKeys;
 			});
 
 		$this->cryptMock->expects($this->once())->method('multiKeyEncrypt')
 			->willReturnCallback(
-				function($fileKey, $publicKeys) {
+				function ($fileKey, $publicKeys) {
 					$this->assertEmpty($publicKeys);
 					$this->assertSame('fileKey', $fileKey);
 				}

--- a/apps/encryption/tests/KeyManagerTest.php
+++ b/apps/encryption/tests/KeyManagerTest.php
@@ -242,7 +242,7 @@ class KeyManagerTest extends TestCase {
 
 		$this->keyStorageMock->expects($this->exactly(2))
 			->method('getUserKey')
-			->willReturnCallback(function ($uid, $keyID, $encryptionModuleId){
+			->willReturnCallback(function ($uid, $keyID, $encryptionModuleId) {
 				if ($keyID === 'publicKey') {
 					return '';
 				}
@@ -473,13 +473,13 @@ class KeyManagerTest extends TestCase {
 
 		$this->keyStorageMock->expects($this->any())
 			->method('getSystemUserKey')
-			->willReturnCallback(function($keyId, $encryptionModuleId) {
+			->willReturnCallback(function ($keyId, $encryptionModuleId) {
 				return $keyId;
 			});
 
 		$this->utilMock->expects($this->any())
 			->method('isRecoveryEnabledForUser')
-			->willReturnCallback(function($uid) {
+			->willReturnCallback(function ($uid) {
 				if ($uid === 'user1') {
 					return true;
 				}

--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -52,7 +52,7 @@ class Application extends App {
 		$cloudFederationManager = $server->getCloudFederationProviderManager();
 		$cloudFederationManager->addCloudFederationProvider('file',
 			'Federated Files Sharing',
-			function() use ($container) {
+			function () use ($container) {
 				$server = $container->getServer();
 				return new CloudFederationProviderFiles(
 					$server->getAppManager(),
@@ -72,7 +72,7 @@ class Application extends App {
 				);
 			});
 
-		$container->registerService('RequestHandlerController', function(SimpleContainer $c) use ($server) {
+		$container->registerService('RequestHandlerController', function (SimpleContainer $c) use ($server) {
 			$addressHandler = new AddressHandler(
 				$server->getURLGenerator(),
 				$server->getL10N('federatedfilesharing'),
@@ -111,7 +111,7 @@ class Application extends App {
 		
 		$eventDispatcher->addListener(
 			'OCA\Files::loadAdditionalScripts',
-			function() use ($federatedShareProvider) {
+			function () use ($federatedShareProvider) {
 				if ($federatedShareProvider->isIncomingServer2serverShareEnabled()) {
 					\OCP\Util::addScript('federatedfilesharing', 'external');
 				}

--- a/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
@@ -143,7 +143,7 @@ class MountPublicLinkControllerTest extends \Test\TestCase {
 		$this->addressHandler->expects($this->any())->method('splitUserRemote')
 			->with($shareWith)
 			->willReturnCallback(
-				function($shareWith) use ($validShareWith, $expectedReturnData) {
+				function ($shareWith) use ($validShareWith, $expectedReturnData) {
 					if ($validShareWith) {
 						return ['user', 'server'];
 					}

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -98,7 +98,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->getMock();
 		$this->l = $this->getMockBuilder(IL10N::class)->getMock();
 		$this->l->method('t')
-			->willReturnCallback(function($text, $parameters = []) {
+			->willReturnCallback(function ($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			});
 		$this->logger = $this->getMockBuilder(ILogger::class)->getMock();

--- a/apps/federation/lib/AppInfo/Application.php
+++ b/apps/federation/lib/AppInfo/Application.php
@@ -69,7 +69,7 @@ class Application extends App {
 		);
 
 		$dispatcher = $container->getServer()->getEventDispatcher();
-		$dispatcher->addListener('OCA\DAV\Connector\Sabre::authInit', function($event) use($container) {
+		$dispatcher->addListener('OCA\DAV\Connector\Sabre::authInit', function ($event) use ($container) {
 			if ($event instanceof SabrePluginEvent) {
 				$server = $event->getServer();
 				if ($server instanceof Server) {

--- a/apps/federation/lib/Command/SyncFederationAddressBooks.php
+++ b/apps/federation/lib/Command/SyncFederationAddressBooks.php
@@ -60,7 +60,7 @@ class SyncFederationAddressBooks extends Command {
 
 		$progress = new ProgressBar($output);
 		$progress->start();
-		$this->syncService->syncThemAll(function($url, $ex) use ($progress, $output) {
+		$this->syncService->syncThemAll(function ($url, $ex) use ($progress, $output) {
 			if ($ex instanceof \Exception) {
 				$output->writeln("Error while syncing $url : " . $ex->getMessage());
 

--- a/apps/federation/lib/SyncJob.php
+++ b/apps/federation/lib/SyncJob.php
@@ -48,7 +48,7 @@ class SyncJob extends TimedJob {
 	}
 
 	protected function run($argument) {
-		$this->syncService->syncThemAll(function($url, $ex) {
+		$this->syncService->syncThemAll(function ($url, $ex) {
 			if ($ex instanceof \Exception) {
 				$this->logger->logException($ex, [
 					'message' => "Error while syncing $url.",

--- a/apps/federation/tests/Middleware/AddServerMiddlewareTest.php
+++ b/apps/federation/tests/Middleware/AddServerMiddlewareTest.php
@@ -75,7 +75,7 @@ class AddServerMiddlewareTest extends TestCase {
 
 		$this->l10n->expects($this->any())->method('t')
 			->willReturnCallback(
-				function($message) {
+				function ($message) {
 					return $message;
 				}
 			);

--- a/apps/federation/tests/SyncFederationAddressbooksTest.php
+++ b/apps/federation/tests/SyncFederationAddressbooksTest.php
@@ -71,7 +71,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 
 		/** @var \OCA\DAV\CardDAV\SyncService $syncService */
 		$s = new SyncFederationAddressBooks($dbHandler, $syncService, $this->discoveryService);
-		$s->syncThemAll(function($url, $ex) {
+		$s->syncThemAll(function ($url, $ex) {
 			$this->callBacks[] = [$url, $ex];
 		});
 		$this->assertEquals(1, count($this->callBacks));
@@ -99,7 +99,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 
 		/** @var \OCA\DAV\CardDAV\SyncService $syncService */
 		$s = new SyncFederationAddressBooks($dbHandler, $syncService, $this->discoveryService);
-		$s->syncThemAll(function($url, $ex) {
+		$s->syncThemAll(function ($url, $ex) {
 			$this->callBacks[] = [$url, $ex];
 		});
 		$this->assertEquals(2, count($this->callBacks));

--- a/apps/federation/tests/TrustedServersTest.php
+++ b/apps/federation/tests/TrustedServersTest.php
@@ -216,7 +216,7 @@ class TrustedServersTest extends TestCase {
 			->willReturn($server);
 		$this->dispatcher->expects($this->once())->method('dispatch')
 			->willReturnCallback(
-				function($eventId, $event) {
+				function ($eventId, $event) {
 					$this->assertSame($eventId, 'OCP\Federation\TrustedServerEvent::remove');
 					$this->assertInstanceOf('Symfony\Component\EventDispatcher\GenericEvent', $event);
 					/** @var \Symfony\Component\EventDispatcher\GenericEvent $event */

--- a/apps/files/lib/AppInfo/Application.php
+++ b/apps/files/lib/AppInfo/Application.php
@@ -74,7 +74,7 @@ class Application extends App {
 		/**
 		 * Services
 		 */
-		$container->registerService('TagService', function(IContainer $c) use ($server) {
+		$container->registerService('TagService', function (IContainer $c) use ($server) {
 			$homeFolder = $c->query('ServerContainer')->getUserFolder();
 			return new TagService(
 				$c->query('ServerContainer')->getUserSession(),

--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -85,7 +85,7 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 		$backendService = $container->query(BackendService::class);
 		$backendService->registerBackendProvider($this);
 		$backendService->registerAuthMechanismProvider($this);
-		$backendService->registerConfigHandler('user', function() use ($container) {
+		$backendService->registerConfigHandler('user', function () use ($container) {
 			return $container->query(UserPlaceholderHandler::class);
 		});
 

--- a/apps/files_external/lib/Config/ConfigAdapter.php
+++ b/apps/files_external/lib/Config/ConfigAdapter.php
@@ -127,7 +127,7 @@ class ConfigAdapter implements IMountProvider {
 
 		$storageConfigs = $this->userGlobalStoragesService->getAllStoragesForUser();
 
-		$storages = array_map(function(StorageConfig $storageConfig) use ($user) {
+		$storages = array_map(function (StorageConfig $storageConfig) use ($user) {
 			try {
 				$this->prepareStorageConfig($storageConfig, $user);
 				return $this->constructStorage($storageConfig);
@@ -138,7 +138,7 @@ class ConfigAdapter implements IMountProvider {
 		}, $storageConfigs);
 
 
-		\OC\Files\Cache\Storage::getGlobalCache()->loadForStorageIds(array_map(function(Storage\IStorage $storage) {
+		\OC\Files\Cache\Storage::getGlobalCache()->loadForStorageIds(array_map(function (Storage\IStorage $storage) {
 			return $storage->getId();
 		}, $storages));
 
@@ -157,7 +157,7 @@ class ConfigAdapter implements IMountProvider {
 			return $storage;
 		}, $storages, $storageConfigs);
 
-		$mounts = array_map(function(StorageConfig $storageConfig, Storage\IStorage $storage) use ($user, $loader) {
+		$mounts = array_map(function (StorageConfig $storageConfig, Storage\IStorage $storage) use ($user, $loader) {
 			if ($storageConfig->getType() === StorageConfig::MOUNT_TYPE_PERSONAl) {
 				return new PersonalMount(
 					$this->userStoragesService,

--- a/apps/files_external/lib/Lib/Backend/Swift.php
+++ b/apps/files_external/lib/Lib/Backend/Swift.php
@@ -52,7 +52,7 @@ class Swift extends Backend {
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 			])
 			->addAuthScheme(AuthMechanism::SCHEME_OPENSTACK)
-			->setLegacyAuthMechanismCallback(function(array $params) use ($openstackAuth, $rackspaceAuth) {
+			->setLegacyAuthMechanismCallback(function (array $params) use ($openstackAuth, $rackspaceAuth) {
 				if (isset($params['options']['key']) && $params['options']['key']) {
 					return $rackspaceAuth;
 				}

--- a/apps/files_external/lib/Lib/Storage/FTP.php
+++ b/apps/files_external/lib/Lib/Storage/FTP.php
@@ -68,7 +68,7 @@ class FTP extends StreamWrapper{
 		
 	}
 
-	public function getId(){
+	public function getId() {
 		return 'ftp::' . $this->user . '@' . $this->host . '/' . $this->root;
 	}
 

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -169,7 +169,7 @@ class SFTP extends \OC\Files\Storage\Common {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function getId(){
+	public function getId() {
 		$id = 'sftp::' . $this->user . '@' . $this->host;
 		if ($this->port !== 22) {
 			$id .= ':' . $this->port;

--- a/apps/files_external/lib/Service/BackendService.php
+++ b/apps/files_external/lib/Service/BackendService.php
@@ -216,7 +216,7 @@ class BackendService {
 	 * @return Backend[]
 	 */
 	public function getAvailableBackends() {
-		return array_filter($this->getBackends(), function($backend) {
+		return array_filter($this->getBackends(), function ($backend) {
 			return !$backend->checkDependencies();
 		});
 	}
@@ -255,7 +255,7 @@ class BackendService {
 	 * @return AuthMechanism[]
 	 */
 	public function getAuthMechanismsByScheme(array $schemes) {
-		return array_filter($this->getAuthMechanisms(), function($authMech) use ($schemes) {
+		return array_filter($this->getAuthMechanisms(), function ($authMech) use ($schemes) {
 			return in_array($authMech->getScheme(), $schemes, true);
 		});
 	}

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -322,7 +322,7 @@ class OC_Mount_Config {
 		}
 
 		foreach ($dependencyGroups as $module => $dependants) {
-			$backends = implode(', ', array_map(function($backend) {
+			$backends = implode(', ', array_map(function ($backend) {
 				return '"' . $backend->getText() . '"';
 			}, $dependants));
 			$message .= '<p>' . OC_Mount_Config::getSingleDependencyMessage($l, $module, $backends) . '</p>';

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -134,10 +134,10 @@
 							<?php p($l->t('Add storage')); ?>
 						</option>
 						<?php
-							$sortedBackends = array_filter($_['backends'], function($backend) use ($_) {
+							$sortedBackends = array_filter($_['backends'], function ($backend) use ($_) {
 								return $backend->isVisibleFor($_['visibilityType']);
 							});
-							uasort($sortedBackends, function($a, $b) {
+							uasort($sortedBackends, function ($a, $b) {
 								return strcasecmp($a->getText(), $b->getText());
 							});
 						?>
@@ -172,7 +172,7 @@
 
 		<p id="userMountingBackends"<?php if (!$_['allowUserMounting']): ?> class="hidden"<?php endif; ?>>
 			<?php
-				$userBackends = array_filter($_['backends'], function($backend) {
+				$userBackends = array_filter($_['backends'], function ($backend) {
 					return $backend->isAllowedVisibleFor(BackendService::VISIBILITY_PERSONAL);
 				});
 			?>

--- a/apps/files_external/tests/Backend/BackendTest.php
+++ b/apps/files_external/tests/Backend/BackendTest.php
@@ -78,7 +78,7 @@ class BackendTest extends \Test\TestCase {
 
 	public function testLegacyAuthMechanismCallback() {
 		$backend = new Backend();
-		$backend->setLegacyAuthMechanismCallback(function(array $params) {
+		$backend->setLegacyAuthMechanismCallback(function (array $params) {
 			if (isset($params['ping'])) {
 				return 'pong';
 			}

--- a/apps/files_external/tests/FrontendDefinitionTraitTest.php
+++ b/apps/files_external/tests/FrontendDefinitionTraitTest.php
@@ -102,7 +102,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 			->willReturn('param');
 		$param->expects($this->once())
 			->method('validateValue')
-			->willReturnCallback(function(&$value) {
+			->willReturnCallback(function (&$value) {
 				$value = 'foobar';
 				return true;
 			});

--- a/apps/files_external/tests/Storage/FtpTest.php
+++ b/apps/files_external/tests/Storage/FtpTest.php
@@ -63,7 +63,7 @@ class FtpTest extends \Test\Files\Storage\Storage {
 		parent::tearDown();
 	}
 
-	public function testConstructUrl(){
+	public function testConstructUrl() {
 		$config =  [ 'host' => 'localhost',
 			'user' => 'ftp',
 			'password' => 'ftp',

--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -181,7 +181,7 @@ class Application extends App {
 			$server = $c->query('ServerContainer');
 			return new \OCA\Files_Sharing\External\MountProvider(
 				$server->getDatabaseConnection(),
-				function() use ($c) {
+				function () use ($c) {
 					return $c->query('ExternalManager');
 				},
 				$server->getCloudIdManager()
@@ -215,19 +215,19 @@ class Application extends App {
 		$dispatcher->addServiceListener(LoadAdditionalScriptsEvent::class, LoadAdditionalListener::class);
 		$dispatcher->addServiceListener(LoadSidebar::class, LoadSidebarListener::class);
 		$dispatcher->addServiceListener(ShareCreatedEvent::class, ShareInteractionListener::class);
-		$dispatcher->addListener('\OCP\Collaboration\Resources::loadAdditionalScripts', function() {
+		$dispatcher->addListener('\OCP\Collaboration\Resources::loadAdditionalScripts', function () {
 			\OCP\Util::addScript('files_sharing', 'dist/collaboration');
 		});
 		$dispatcher->addServiceListener(ShareCreatedEvent::class, UserShareAcceptanceListener::class);
 		$dispatcher->addServiceListener(UserAddedEvent::class, UserAddedToGroupListener::class);
 
 		// notifications api to accept incoming user shares
-		$dispatcher->addListener('OCP\Share::postShare', function(GenericEvent $event) {
+		$dispatcher->addListener('OCP\Share::postShare', function (GenericEvent $event) {
 			/** @var Listener $listener */
 			$listener = $this->getContainer()->query(Listener::class);
 			$listener->shareNotification($event);
 		});
-		$dispatcher->addListener(IGroup::class . '::postAddUser', function(GenericEvent $event) {
+		$dispatcher->addListener(IGroup::class . '::postAddUser', function (GenericEvent $event) {
 			/** @var Listener $listener */
 			$listener = $this->getContainer()->query(Listener::class);
 			$listener->userAddedToGroup($event);

--- a/apps/files_sharing/lib/Collaboration/ShareRecipientSorter.php
+++ b/apps/files_sharing/lib/Collaboration/ShareRecipientSorter.php
@@ -74,7 +74,7 @@ class ShareRecipientSorter implements ISorter {
 			// at least on PHP 5.6 usort turned out to be not stable. So we add
 			// the current index to the value and compare it on a draw
 			$i = 0;
-			$workArray = array_map(function($element) use (&$i) {
+			$workArray = array_map(function ($element) use (&$i) {
 				return [$i++, $element];
 			}, $byType);
 

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -602,7 +602,7 @@ class ShareAPIController extends OCSController {
 
 		$shares = array_merge($userShares, $groupShares, $circleShares, $roomShares);
 
-		$shares = array_filter($shares, function(IShare $share) {
+		$shares = array_filter($shares, function (IShare $share) {
 			return $share->getShareOwner() !== $this->currentUser;
 		});
 
@@ -639,7 +639,7 @@ class ShareAPIController extends OCSController {
 		$nodes = $folder->getDirectoryListing();
 
 		/** @var \OCP\Share\IShare[] $shares */
-		$shares = array_reduce($nodes, function($carry, $node) {
+		$shares = array_reduce($nodes, function ($carry, $node) {
 			$carry = array_merge($carry, $this->getAllShares($node, true));
 			return $carry;
 		}, []);

--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -257,7 +257,7 @@ class ShareesAPIController extends OCSController {
 	}
 
 	private function sortShareesByFrequency(array $sharees): array {
-		usort($sharees, function(array $s1, array $s2) {
+		usort($sharees, function (array $s1, array $s2) {
 			return $s2['count'] - $s1['count'];
 		});
 		return $sharees;

--- a/apps/files_sharing/lib/DeleteOrphanedSharesJob.php
+++ b/apps/files_sharing/lib/DeleteOrphanedSharesJob.php
@@ -41,7 +41,7 @@ class DeleteOrphanedSharesJob extends TimedJob {
 	/**
 	 * sets the correct interval for this timed job
 	 */
-	public function __construct(){
+	public function __construct() {
 		$this->interval = $this->defaultIntervalMin * 60;
 	}
 

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -155,7 +155,7 @@ class MountProvider implements IMountProvider {
 		$result = [];
 		// sort by stime, the super share will be based on the least recent share
 		foreach ($tmp as &$tmp2) {
-			@usort($tmp2, function($a, $b) {
+			@usort($tmp2, function ($a, $b) {
 				if ($a->getShareTime() <= $b->getShareTime()) {
 					return -1;
 				}

--- a/apps/files_sharing/lib/ShareBackend/Folder.php
+++ b/apps/files_sharing/lib/ShareBackend/Folder.php
@@ -112,7 +112,7 @@ class Folder extends File implements \OCP\Share_Backend_Collection {
 
 			$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
 
-			$parents = array_map(function($parent) use ($qb) {
+			$parents = array_map(function ($parent) use ($qb) {
 				return $qb->createNamedParameter($parent);
 			}, $parents);
 

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -108,7 +108,7 @@ class ApiTest extends TestCase {
 	private function createOCS($userId) {
 		$l = $this->getMockBuilder(IL10N::class)->getMock();
 		$l->method('t')
-			->willReturnCallback(function($text, $parameters = []) {
+			->willReturnCallback(function ($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			});
 		$config = $this->createMock(IConfig::class);

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -123,7 +123,7 @@ class ShareAPIControllerTest extends TestCase {
 
 		$this->l = $this->createMock(IL10N::class);
 		$this->l->method('t')
-			->willReturnCallback(function($text, $parameters = []) {
+			->willReturnCallback(function ($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			});
 		$this->config = $this->createMock(IConfig::class);
@@ -180,7 +180,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->shareManager
 			->expects($this->exactly(5))
 			->method('getShareById')
-			->willReturnCallback(function($id) {
+			->willReturnCallback(function ($id) {
 				if ($id === 'ocinternal:42' || $id === 'ocRoomShare:42' || $id === 'ocFederatedSharing:42' || $id === 'ocCircleShare:42' || $id === 'ocMailShare:42') {
 					throw new \OCP\Share\Exceptions\ShareNotFound();
 				} else {
@@ -1341,7 +1341,7 @@ class ShareAPIControllerTest extends TestCase {
 
 		$ocs->method('formatShare')
 			->willReturnCallback(
-				function($share) {
+				function ($share) {
 					return [
 						'id' => $share->getId(),
 						'share_type' => $share->getShareType()
@@ -1361,7 +1361,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->shareManager
 			->method('getSharesBy')
 			->willReturnCallback(
-				function($user, $shareType, $node) use ($shares) {
+				function ($user, $shareType, $node) use ($shares) {
 					if (!isset($shares[$node->getName()]) || !isset($shares[$node->getName()][$shareType])) {
 						return [];
 					}
@@ -1380,7 +1380,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->groupManager
 			->method('isInGroup')
 			->willReturnCallback(
-				function($user, $group) {
+				function ($user, $group) {
 					return $group === 'currentUserGroup';
 				}
 			);

--- a/apps/files_sharing/tests/Controller/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareControllerTest.php
@@ -284,7 +284,7 @@ class ShareControllerTest extends \Test\TestCase {
 			->with('core', 'shareapi_public_link_disclaimertext', null)
 			->willReturn('My disclaimer text');
 
-		$this->userManager->method('get')->willReturnCallback(function(string $uid) use ($owner, $initiator) {
+		$this->userManager->method('get')->willReturnCallback(function (string $uid) use ($owner, $initiator) {
 			if ($uid === 'ownerUID') {
 				return $owner;
 			}
@@ -298,14 +298,14 @@ class ShareControllerTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				'OCA\Files_Sharing::loadAdditionalScripts',
-				$this->callback(function($event) use ($share) {
+				$this->callback(function ($event) use ($share) {
 					return $event->getArgument('share') === $share;
 				})
 			);
 
 		$this->l10n->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($text, $parameters) {
+			->willReturnCallback(function ($text, $parameters) {
 				return vsprintf($text, $parameters);
 			});
 
@@ -432,7 +432,7 @@ class ShareControllerTest extends \Test\TestCase {
 			->with('core', 'shareapi_public_link_disclaimertext', null)
 			->willReturn('My disclaimer text');
 
-		$this->userManager->method('get')->willReturnCallback(function(string $uid) use ($owner, $initiator) {
+		$this->userManager->method('get')->willReturnCallback(function (string $uid) use ($owner, $initiator) {
 			if ($uid === 'ownerUID') {
 				return $owner;
 			}
@@ -446,14 +446,14 @@ class ShareControllerTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				'OCA\Files_Sharing::loadAdditionalScripts',
-				$this->callback(function($event) use ($share) {
+				$this->callback(function ($event) use ($share) {
 					return $event->getArgument('share') === $share;
 				})
 			);
 
 		$this->l10n->expects($this->any())
 			->method('t')
-			->will($this->returnCallback(function($text, $parameters) {
+			->will($this->returnCallback(function ($text, $parameters) {
 				return vsprintf($text, $parameters);
 			}));
 
@@ -583,7 +583,7 @@ class ShareControllerTest extends \Test\TestCase {
 			->with('core', 'shareapi_public_link_disclaimertext', null)
 			->willReturn('My disclaimer text');
 
-		$this->userManager->method('get')->willReturnCallback(function(string $uid) use ($owner, $initiator) {
+		$this->userManager->method('get')->willReturnCallback(function (string $uid) use ($owner, $initiator) {
 			if ($uid === 'ownerUID') {
 				return $owner;
 			}
@@ -597,14 +597,14 @@ class ShareControllerTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				'OCA\Files_Sharing::loadAdditionalScripts',
-				$this->callback(function($event) use ($share) {
+				$this->callback(function ($event) use ($share) {
 					return $event->getArgument('share') === $share;
 				})
 			);
 
 		$this->l10n->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($text, $parameters) {
+			->willReturnCallback(function ($text, $parameters) {
 				return vsprintf($text, $parameters);
 			});
 
@@ -712,7 +712,7 @@ class ShareControllerTest extends \Test\TestCase {
 			->with('token')
 			->willReturn($share);
 
-		$this->userManager->method('get')->willReturnCallback(function(string $uid) use ($owner, $initiator) {
+		$this->userManager->method('get')->willReturnCallback(function (string $uid) use ($owner, $initiator) {
 			if ($uid === 'ownerUID') {
 				return $owner;
 			}
@@ -724,7 +724,7 @@ class ShareControllerTest extends \Test\TestCase {
 
 		$this->l10n->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($text, $parameters) {
+			->willReturnCallback(function ($text, $parameters) {
 				return vsprintf($text, $parameters);
 			});
 
@@ -869,7 +869,7 @@ class ShareControllerTest extends \Test\TestCase {
 			->with('token')
 			->willReturn($share);
 
-		$this->userManager->method('get')->willReturnCallback(function(string $uid) use ($owner, $initiator) {
+		$this->userManager->method('get')->willReturnCallback(function (string $uid) use ($owner, $initiator) {
 			if ($uid === 'ownerUID') {
 				return $owner;
 			}
@@ -910,7 +910,7 @@ class ShareControllerTest extends \Test\TestCase {
 			->with('token')
 			->willReturn($share);
 
-		$this->userManager->method('get')->willReturnCallback(function(string $uid) use ($owner, $initiator) {
+		$this->userManager->method('get')->willReturnCallback(function (string $uid) use ($owner, $initiator) {
 			if ($uid === 'ownerUID') {
 				return $owner;
 			}

--- a/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
@@ -292,7 +292,7 @@ class ShareesAPIControllerTest extends TestCase {
 
 		$this->shareManager->expects($this->any())
 			->method('shareProviderExists')
-			->willReturnCallback(function($shareType) use ($emailSharingEnabled) {
+			->willReturnCallback(function ($shareType) use ($emailSharingEnabled) {
 				if ($shareType === \OCP\Share::SHARE_TYPE_EMAIL) {
 					return $emailSharingEnabled;
 				} else {

--- a/apps/files_sharing/tests/EtagPropagationTest.php
+++ b/apps/files_sharing/tests/EtagPropagationTest.php
@@ -456,7 +456,7 @@ class EtagPropagationTest extends PropagationTestCase {
 
 		$shares = $this->shareManager->getSharesBy(self::TEST_FILES_SHARING_API_USER1, \OCP\Share::SHARE_TYPE_USER, $node);
 		/** @var \OCP\Share\IShare[] $shares */
-		$shares = array_filter($shares, function(\OCP\Share\IShare $share) {
+		$shares = array_filter($shares, function (\OCP\Share\IShare $share) {
 			return $share->getSharedWith() === self::TEST_FILES_SHARING_API_USER2;
 		});
 		$this->assertCount(1, $shares);

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -110,7 +110,7 @@ class ManagerTest extends TestCase {
 				]
 			)->setMethods(['tryOCMEndPoint'])->getMock();
 
-		$this->testMountProvider = new MountProvider(\OC::$server->getDatabaseConnection(), function() {
+		$this->testMountProvider = new MountProvider(\OC::$server->getDatabaseConnection(), function () {
 			return $this->manager;
 		}, new CloudIdManager());
 	}

--- a/apps/files_sharing/tests/MountProviderTest.php
+++ b/apps/files_sharing/tests/MountProviderTest.php
@@ -145,7 +145,7 @@ class MountProviderTest extends \Test\TestCase {
 			->willReturn($roomShares);
 		$this->shareManager->expects($this->any())
 			->method('newShare')
-			->willReturnCallback(function() use ($rootFolder, $userManager) {
+			->willReturnCallback(function () use ($rootFolder, $userManager) {
 				return new \OC\Share20\Share($rootFolder, $userManager);
 			});
 		$mounts = $this->provider->getMountsForUser($this->user, $this->loader);
@@ -322,10 +322,10 @@ class MountProviderTest extends \Test\TestCase {
 		$rootFolder = $this->createMock(IRootFolder::class);
 		$userManager = $this->createMock(IUserManager::class);
 
-		$userShares = array_map(function($shareSpec) {
+		$userShares = array_map(function ($shareSpec) {
 			return $this->makeMockShare($shareSpec[0], $shareSpec[1], $shareSpec[2], $shareSpec[3], $shareSpec[4]);
 		}, $userShares);
-		$groupShares = array_map(function($shareSpec) {
+		$groupShares = array_map(function ($shareSpec) {
 			return $this->makeMockShare($shareSpec[0], $shareSpec[1], $shareSpec[2], $shareSpec[3], $shareSpec[4]);
 		}, $groupShares);
 
@@ -354,7 +354,7 @@ class MountProviderTest extends \Test\TestCase {
 			->willReturn($roomShares);
 		$this->shareManager->expects($this->any())
 			->method('newShare')
-			->willReturnCallback(function() use ($rootFolder, $userManager) {
+			->willReturnCallback(function () use ($rootFolder, $userManager) {
 				return new \OC\Share20\Share($rootFolder, $userManager);
 			});
 

--- a/apps/files_sharing/tests/SharedMountTest.php
+++ b/apps/files_sharing/tests/SharedMountTest.php
@@ -186,7 +186,7 @@ class SharedMountTest extends TestCase {
 	 * share file with a group if a user renames the file the filename should not change
 	 * for the other users
 	 */
-	public function testMoveGroupShare () {
+	public function testMoveGroupShare() {
 		$testGroup = $this->groupManager->createGroup('testGroup');
 		$user1 = $this->userManager->get(self::TEST_FILES_SHARING_API_USER1);
 		$user2 = $this->userManager->get(self::TEST_FILES_SHARING_API_USER2);
@@ -266,7 +266,7 @@ class SharedMountTest extends TestCase {
 	public function dataPermissionMovedGroupShare() {
 		$data = [];
 
-		$powerset = function($permissions) {
+		$powerset = function ($permissions) {
 			$results = [\OCP\Constants::PERMISSION_READ];
 
 			foreach ($permissions as $permission) {
@@ -460,7 +460,7 @@ class SharedMountTest extends TestCase {
 }
 
 class DummyTestClassSharedMount extends \OCA\Files_Sharing\SharedMount {
-	public function __construct($storage, $mountpoint, $arguments = null, $loader = null){
+	public function __construct($storage, $mountpoint, $arguments = null, $loader = null) {
 		// noop
 	}
 

--- a/apps/files_trashbin/lib/AppInfo/Application.php
+++ b/apps/files_trashbin/lib/AppInfo/Application.php
@@ -36,7 +36,7 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\IAppContainer;
 
 class Application extends App {
-	public function __construct (array $urlParams = []) {
+	public function __construct(array $urlParams = []) {
 		parent::__construct('files_trashbin', $urlParams);
 
 		$container = $this->getContainer();
@@ -65,7 +65,7 @@ class Application extends App {
 			);
 		});
 
-		$container->registerService(ITrashManager::class, function(IAppContainer $c) {
+		$container->registerService(ITrashManager::class, function (IAppContainer $c) {
 			return new TrashManager();
 		});
 

--- a/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
+++ b/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
@@ -80,7 +80,7 @@ class ExpireTrash extends \OC\BackgroundJob\TimedJob {
 			return;
 		}
 
-		$this->userManager->callForSeenUsers(function(IUser $user) {
+		$this->userManager->callForSeenUsers(function (IUser $user) {
 			$uid = $user->getUID();
 			if (!$this->setupFS($uid)) {
 				return;

--- a/apps/files_trashbin/lib/Command/ExpireTrash.php
+++ b/apps/files_trashbin/lib/Command/ExpireTrash.php
@@ -92,7 +92,7 @@ class ExpireTrash extends Command {
 		} else {
 			$p = new ProgressBar($output);
 			$p->start();
-			$this->userManager->callForSeenUsers(function(IUser $user) use ($p) {
+			$this->userManager->callForSeenUsers(function (IUser $user) use ($p) {
 				$p->advance();
 				$this->expireTrashForUser($user);
 			});

--- a/apps/files_trashbin/lib/Expiration.php
+++ b/apps/files_trashbin/lib/Expiration.php
@@ -50,7 +50,7 @@ class Expiration {
 	/** @var bool */
 	private $canPurgeToSaveSpace;
 
-	public function __construct(IConfig $config,ITimeFactory $timeFactory){
+	public function __construct(IConfig $config,ITimeFactory $timeFactory) {
 		$this->timeFactory = $timeFactory;
 		$this->setRetentionObligation($config->getSystemValue('trashbin_retention_obligation', 'auto'));
 	}
@@ -67,7 +67,7 @@ class Expiration {
 	 * Is trashbin expiration enabled
 	 * @return bool
 	 */
-	public function isEnabled(){
+	public function isEnabled() {
 		return $this->retentionObligation !== 'disabled';
 	}
 
@@ -77,7 +77,7 @@ class Expiration {
 	 * @param bool $quotaExceeded
 	 * @return bool
 	 */
-	public function isExpired($timestamp, $quotaExceeded = false){
+	public function isExpired($timestamp, $quotaExceeded = false) {
 		// No expiration if disabled
 		if (!$this->isEnabled()) {
 			return false;
@@ -126,7 +126,7 @@ class Expiration {
 		return $maxAge;
 	}
 
-	private function parseRetentionObligation(){
+	private function parseRetentionObligation() {
 		$splitValues = explode(',', $this->retentionObligation);
 		if (!isset($splitValues[0])) {
 			$minValue = self::DEFAULT_RETENTION_OBLIGATION;

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -549,7 +549,7 @@ class Trashbin {
 	 * wrapper function to emit the 'preDelete' hook of \OCP\Trashbin before a file is deleted
 	 * @param string $path
 	 */
-	protected static function emitTrashbinPreDelete($path){
+	protected static function emitTrashbinPreDelete($path) {
 		\OC_Hook::emit('\OCP\Trashbin', 'preDelete', ['path' => $path]);
 	}
 
@@ -557,7 +557,7 @@ class Trashbin {
 	 * wrapper function to emit the 'delete' hook of \OCP\Trashbin after a file has been deleted
 	 * @param string $path
 	 */
-	protected static function emitTrashbinPostDelete($path){
+	protected static function emitTrashbinPostDelete($path) {
 		\OC_Hook::emit('\OCP\Trashbin', 'delete', ['path' => $path]);
 	}
 

--- a/apps/files_trashbin/tests/ExpirationTest.php
+++ b/apps/files_trashbin/tests/ExpirationTest.php
@@ -32,7 +32,7 @@ class ExpirationTest extends \Test\TestCase {
 
 	const FAKE_TIME_NOW = 1000000;
 
-	public function expirationData(){
+	public function expirationData() {
 		$today = 100*self::SECONDS_PER_DAY;
 		$back10Days = (100-10)*self::SECONDS_PER_DAY;
 		$back20Days = (100-20)*self::SECONDS_PER_DAY;
@@ -105,7 +105,7 @@ class ExpirationTest extends \Test\TestCase {
 	 * @param bool $quotaExceeded
 	 * @param string $expectedResult
 	 */
-	public function testExpiration($retentionObligation, $timeNow, $timestamp, $quotaExceeded, $expectedResult){
+	public function testExpiration($retentionObligation, $timeNow, $timestamp, $quotaExceeded, $expectedResult) {
 		$mockedConfig = $this->getMockedConfig($retentionObligation);
 		$mockedTimeFactory = $this->getMockedTimeFactory($timeNow);
 
@@ -116,7 +116,7 @@ class ExpirationTest extends \Test\TestCase {
 	}
 
 
-	public function configData(){
+	public function configData() {
 		return [
 			[ 'disabled', null, null, null],
 			[ 'auto', Expiration::DEFAULT_RETENTION_OBLIGATION, Expiration::NO_OBLIGATION, true ],
@@ -138,7 +138,7 @@ class ExpirationTest extends \Test\TestCase {
 	 * @param int $expectedMaxAge
 	 * @param bool $expectedCanPurgeToSaveSpace
 	 */
-	public function testParseRetentionObligation($configValue, $expectedMinAge, $expectedMaxAge, $expectedCanPurgeToSaveSpace){
+	public function testParseRetentionObligation($configValue, $expectedMinAge, $expectedMaxAge, $expectedCanPurgeToSaveSpace) {
 		$mockedConfig = $this->getMockedConfig($configValue);
 		$mockedTimeFactory = $this->getMockedTimeFactory(
 				time()
@@ -151,7 +151,7 @@ class ExpirationTest extends \Test\TestCase {
 	}
 
 
-	public function timestampTestData(){
+	public function timestampTestData() {
 		return [
 			[ 'disabled', false],
 			[ 'auto', false ],
@@ -171,7 +171,7 @@ class ExpirationTest extends \Test\TestCase {
 	 * @param string $configValue
 	 * @param int $expectedMaxAgeTimestamp
 	 */
-	public function testGetMaxAgeAsTimestamp($configValue, $expectedMaxAgeTimestamp){
+	public function testGetMaxAgeAsTimestamp($configValue, $expectedMaxAgeTimestamp) {
 		$mockedConfig = $this->getMockedConfig($configValue);
 		$mockedTimeFactory = $this->getMockedTimeFactory(
 				self::FAKE_TIME_NOW
@@ -186,7 +186,7 @@ class ExpirationTest extends \Test\TestCase {
 	 * @param int $time
 	 * @return ITimeFactory|MockObject
 	 */
-	private function getMockedTimeFactory($time){
+	private function getMockedTimeFactory($time) {
 		$mockedTimeFactory = $this->createMock(ITimeFactory::class);
 		$mockedTimeFactory->expects($this->any())
 			->method('getTime')
@@ -199,7 +199,7 @@ class ExpirationTest extends \Test\TestCase {
 	 * @param string $returnValue
 	 * @return IConfig|MockObject
 	 */
-	private function getMockedConfig($returnValue){
+	private function getMockedConfig($returnValue) {
 		$mockedConfig = $this->createMock(IConfig::class);
 		$mockedConfig->expects($this->any())
 			->method('getSystemValue')

--- a/apps/files_versions/lib/AppInfo/Application.php
+++ b/apps/files_versions/lib/AppInfo/Application.php
@@ -75,7 +75,7 @@ class Application extends App {
 			);
 		});
 
-		$container->registerService(IVersionManager::class, function(IAppContainer $c) {
+		$container->registerService(IVersionManager::class, function (IAppContainer $c) {
 			return new VersionManager();
 		});
 

--- a/apps/files_versions/lib/BackgroundJob/ExpireVersions.php
+++ b/apps/files_versions/lib/BackgroundJob/ExpireVersions.php
@@ -58,7 +58,7 @@ class ExpireVersions extends \OC\BackgroundJob\TimedJob {
 			return;
 		}
 
-		$this->userManager->callForSeenUsers(function(IUser $user) {
+		$this->userManager->callForSeenUsers(function (IUser $user) {
 			$uid = $user->getUID();
 			if (!$this->setupFS($uid)) {
 				return;

--- a/apps/files_versions/lib/Command/ExpireVersions.php
+++ b/apps/files_versions/lib/Command/ExpireVersions.php
@@ -91,7 +91,7 @@ class ExpireVersions extends Command {
 		} else {
 			$p = new ProgressBar($output);
 			$p->start();
-			$this->userManager->callForSeenUsers(function(IUser $user) use ($p) {
+			$this->userManager->callForSeenUsers(function (IUser $user) use ($p) {
 				$p->advance();
 				$this->expireVersionsForUser($user);
 			});

--- a/apps/files_versions/lib/Expiration.php
+++ b/apps/files_versions/lib/Expiration.php
@@ -47,7 +47,7 @@ class Expiration {
 	/** @var bool */
 	private $canPurgeToSaveSpace;
 
-	public function __construct(IConfig $config,ITimeFactory $timeFactory){
+	public function __construct(IConfig $config,ITimeFactory $timeFactory) {
 		$this->timeFactory = $timeFactory;
 		$this->retentionObligation = $config->getSystemValue('versions_retention_obligation', 'auto');
 
@@ -60,14 +60,14 @@ class Expiration {
 	 * Is versions expiration enabled
 	 * @return bool
 	 */
-	public function isEnabled(){
+	public function isEnabled() {
 		return $this->retentionObligation !== 'disabled';
 	}
 
 	/**
 	 * Is default expiration active
 	 */
-	public function shouldAutoExpire(){
+	public function shouldAutoExpire() {
 		return $this->minAge === self::NO_OBLIGATION
 				|| $this->maxAge === self::NO_OBLIGATION;
 	}
@@ -78,7 +78,7 @@ class Expiration {
 	 * @param bool $quotaExceeded
 	 * @return bool
 	 */
-	public function isExpired($timestamp, $quotaExceeded = false){
+	public function isExpired($timestamp, $quotaExceeded = false) {
 		// No expiration if disabled
 		if (!$this->isEnabled()) {
 			return false;
@@ -119,7 +119,7 @@ class Expiration {
 	 * Get maximal retention obligation as a timestamp
 	 * @return int
 	 */
-	public function getMaxAgeAsTimestamp(){
+	public function getMaxAgeAsTimestamp() {
 		$maxAge = false;
 		if ($this->isEnabled() && $this->maxAge !== self::NO_OBLIGATION) {
 			$time = $this->timeFactory->getTime();
@@ -132,7 +132,7 @@ class Expiration {
 	 * Read versions_retention_obligation, validate it 
 	 * and set private members accordingly
 	 */
-	private function parseRetentionObligation(){
+	private function parseRetentionObligation() {
 		$splitValues = explode(',', $this->retentionObligation);
 		if (!isset($splitValues[0])) {
 			$minValue = 'auto';

--- a/apps/files_versions/lib/Hooks.php
+++ b/apps/files_versions/lib/Hooks.php
@@ -56,7 +56,7 @@ class Hooks {
 	/**
 	 * listen to write event.
 	 */
-	public static function write_hook( $params ) {
+	public static function write_hook($params) {
 		$path = $params[Filesystem::signal_param_path];
 		if($path !== '') {
 			Storage::store($path);

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -497,7 +497,7 @@ class Storage {
 	 * Expire versions that older than max version retention time
 	 * @param string $uid
 	 */
-	public static function expireOlderThanMaxForUser($uid){
+	public static function expireOlderThanMaxForUser($uid) {
 		$expiration = self::getExpiration();
 		$threshold = $expiration->getMaxAgeAsTimestamp();
 		$versions = self::getAllVersions($uid);
@@ -848,7 +848,7 @@ class Storage {
 	 * Static workaround
 	 * @return Expiration
 	 */
-	protected static function getExpiration(){
+	protected static function getExpiration() {
 		if (self::$application === null) {
 			self::$application = \OC::$server->query(Application::class);
 		}

--- a/apps/files_versions/tests/ExpirationTest.php
+++ b/apps/files_versions/tests/ExpirationTest.php
@@ -33,7 +33,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 class ExpirationTest extends \Test\TestCase {
 	const SECONDS_PER_DAY = 86400; //60*60*24
 
-	public function expirationData(){
+	public function expirationData() {
 		$today = 100*self::SECONDS_PER_DAY;
 		$back10Days = (100-10)*self::SECONDS_PER_DAY;
 		$back20Days = (100-20)*self::SECONDS_PER_DAY;
@@ -106,7 +106,7 @@ class ExpirationTest extends \Test\TestCase {
 	 * @param bool $quotaExceeded
 	 * @param string $expectedResult
 	 */
-	public function testExpiration($retentionObligation, $timeNow, $timestamp, $quotaExceeded, $expectedResult){
+	public function testExpiration($retentionObligation, $timeNow, $timestamp, $quotaExceeded, $expectedResult) {
 		$mockedConfig = $this->getMockedConfig($retentionObligation);
 		$mockedTimeFactory = $this->getMockedTimeFactory($timeNow);
 
@@ -117,7 +117,7 @@ class ExpirationTest extends \Test\TestCase {
 	}
 
 
-	public function configData(){
+	public function configData() {
 		return [
 			[ 'disabled', null, null, null],
 			[ 'auto', Expiration::NO_OBLIGATION, Expiration::NO_OBLIGATION, true ],
@@ -141,7 +141,7 @@ class ExpirationTest extends \Test\TestCase {
 	 * @param int $expectedMaxAge
 	 * @param bool $expectedCanPurgeToSaveSpace
 	 */
-	public function testParseRetentionObligation($configValue, $expectedMinAge, $expectedMaxAge, $expectedCanPurgeToSaveSpace){
+	public function testParseRetentionObligation($configValue, $expectedMinAge, $expectedMaxAge, $expectedCanPurgeToSaveSpace) {
 		$mockedConfig = $this->getMockedConfig($configValue);
 		$mockedTimeFactory = $this->getMockedTimeFactory(
 				time()
@@ -157,7 +157,7 @@ class ExpirationTest extends \Test\TestCase {
 	 * @param int $time
 	 * @return ITimeFactory|MockObject
 	 */
-	private function getMockedTimeFactory($time){
+	private function getMockedTimeFactory($time) {
 		$mockedTimeFactory = $this->createMock(ITimeFactory::class);
 		$mockedTimeFactory->expects($this->any())
 			->method('getTime')
@@ -170,7 +170,7 @@ class ExpirationTest extends \Test\TestCase {
 	 * @param string $returnValue
 	 * @return IConfig|MockObject
 	 */
-	private function getMockedConfig($returnValue){
+	private function getMockedConfig($returnValue) {
 		$mockedConfig = $this->createMock(IConfig::class);
 		$mockedConfig->expects($this->any())
 			->method('getSystemValue')

--- a/apps/files_versions/tests/VersioningTest.php
+++ b/apps/files_versions/tests/VersioningTest.php
@@ -746,7 +746,7 @@ class VersioningTest extends \Test\TestCase {
 		$eventHandler->expects($this->any())
 			->method('callback')
 			->willReturnCallback(
-				function($p) use (&$params) {
+				function ($p) use (&$params) {
 					$params = $p;
 				}
 			);

--- a/apps/lookup_server_connector/lib/AppInfo/Application.php
+++ b/apps/lookup_server_connector/lib/AppInfo/Application.php
@@ -33,7 +33,7 @@ use OCP\IUser;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 class Application extends App {
-	public function __construct () {
+	public function __construct() {
 		parent::__construct('lookup_server_connector');
 	}
 
@@ -49,7 +49,7 @@ class Application extends App {
 	 */
 	public function registerHooksAndEvents(): void {
 		$dispatcher = $this->getContainer()->getServer()->getEventDispatcher();
-		$dispatcher->addListener('OC\AccountManager::userUpdated', static function(GenericEvent $event) {
+		$dispatcher->addListener('OC\AccountManager::userUpdated', static function (GenericEvent $event) {
 			/** @var IUser $user */
 			$user = $event->getSubject();
 

--- a/apps/provisioning_api/lib/AppInfo/Application.php
+++ b/apps/provisioning_api/lib/AppInfo/Application.php
@@ -43,7 +43,7 @@ class Application extends App {
 		$container = $this->getContainer();
 		$server = $container->getServer();
 
-		$container->registerService(NewUserMailHelper::class, function(SimpleContainer $c) use ($server) {
+		$container->registerService(NewUserMailHelper::class, function (SimpleContainer $c) use ($server) {
 			return new NewUserMailHelper(
 				$server->query(Defaults::class),
 				$server->getURLGenerator(),
@@ -56,7 +56,7 @@ class Application extends App {
 				Util::getDefaultEmailAddress('no-reply')
 			);
 		});
-		$container->registerService('ProvisioningApiMiddleware', function(SimpleContainer $c) use ($server) {
+		$container->registerService('ProvisioningApiMiddleware', function (SimpleContainer $c) use ($server) {
 			$user = $server->getUserManager()->get($c['UserId']);
 			$isAdmin = $user !== null ? $server->getGroupManager()->isAdmin($user->getUID()) : false;
 			$isSubAdmin = $user !== null ? $server->getGroupManager()->getSubAdmin()->isSubAdmin($user) : false;

--- a/apps/provisioning_api/lib/Controller/GroupsController.php
+++ b/apps/provisioning_api/lib/Controller/GroupsController.php
@@ -93,7 +93,7 @@ class GroupsController extends AUserData {
 	 */
 	public function getGroups(string $search = '', int $limit = null, int $offset = 0): DataResponse {
 		$groups = $this->groupManager->search($search, $limit, $offset);
-		$groups = array_map(function($group) {
+		$groups = array_map(function ($group) {
 			/** @var IGroup $group */
 			return $group->getGID();
 		}, $groups);
@@ -113,7 +113,7 @@ class GroupsController extends AUserData {
 	 */
 	public function getGroupsDetails(string $search = '', int $limit = null, int $offset = 0): DataResponse {
 		$groups = $this->groupManager->search($search, $limit, $offset);
-		$groups = array_map(function($group) {
+		$groups = array_map(function ($group) {
 			/** @var IGroup $group */
 			return [
 				'id' => $group->getGID(),
@@ -166,7 +166,7 @@ class GroupsController extends AUserData {
 		if($this->groupManager->isAdmin($user->getUID())
 		   || $isSubadminOfGroup) {
 			$users = $this->groupManager->get($groupId)->getUsers();
-			$users =  array_map(function($user) {
+			$users =  array_map(function ($user) {
 				/** @var IUser $user */
 				return $user->getUID();
 			}, $users);

--- a/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
@@ -168,7 +168,7 @@ class GroupsControllerTest extends \Test\TestCase {
 
 		$this->subAdminManager
 			->method('isSubAdminOfGroup')
-			->willReturnCallback(function($_user, $_group) use ($user, $group) {
+			->willReturnCallback(function ($_user, $_group) use ($user, $group) {
 				if ($_user === $user && $_group === $group) {
 					return true;
 				}
@@ -179,7 +179,7 @@ class GroupsControllerTest extends \Test\TestCase {
 	private function useAccountManager() {
 		$this->accountManager->expects($this->any())
 			->method('getUser')
-			->willReturnCallback(function(IUser $user) {
+			->willReturnCallback(function (IUser $user) {
 				return [
 					AccountManager::PROPERTY_PHONE => ['value' => '0800-call-' . $user->getUID()],
 					AccountManager::PROPERTY_ADDRESS => ['value' => 'Holzweg 99, 0601 Herrera, Panama'],
@@ -496,7 +496,7 @@ class GroupsControllerTest extends \Test\TestCase {
 
 		$this->userManager->expects($this->any())
 			->method('get')
-			->willReturnCallback(function(string $uid) use ($users) {
+			->willReturnCallback(function (string $uid) use ($users) {
 				return isset($users[$uid]) ? $users[$uid] : null;
 			});
 

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -439,7 +439,7 @@ class UsersControllerTest extends TestCase {
 		$this->config
 			->expects($this->any())
 			->method('getAppValue')
-			->willReturnCallback(function($appid, $key, $default) {
+			->willReturnCallback(function ($appid, $key, $default) {
 				if($key === 'newUser.generateUserID') {
 					return 'yes';
 				}
@@ -477,7 +477,7 @@ class UsersControllerTest extends TestCase {
 		$this->secureRandom->expects($this->any())
 			->method('generate')
 			->with(10)
-			->willReturnCallback(function() { return (string)rand(1000000000, 9999999999); });
+			->willReturnCallback(function () { return (string)rand(1000000000, 9999999999); });
 
 		$this->assertTrue(key_exists(
 			'id',
@@ -494,7 +494,7 @@ class UsersControllerTest extends TestCase {
 		$this->config
 			->expects($this->any())
 			->method('getAppValue')
-			->willReturnCallback(function($appid, $key, $default) {
+			->willReturnCallback(function ($appid, $key, $default) {
 				if($key === 'newUser.generateUserID') {
 					return 'yes';
 				}
@@ -537,7 +537,7 @@ class UsersControllerTest extends TestCase {
 		$this->config
 			->expects($this->any())
 			->method('getAppValue')
-			->willReturnCallback(function($appid, $key, $default) {
+			->willReturnCallback(function ($appid, $key, $default) {
 				if($key === 'newUser.requireEmail') {
 					return 'yes';
 				}

--- a/apps/settings/lib/AppInfo/Application.php
+++ b/apps/settings/lib/AppInfo/Application.php
@@ -60,7 +60,7 @@ class Application extends App {
 	/**
 	 * @param array $urlParams
 	 */
-	public function __construct(array $urlParams=[]){
+	public function __construct(array $urlParams=[]) {
 		parent::__construct(self::APP_ID, $urlParams);
 
 		$container = $this->getContainer();
@@ -73,11 +73,11 @@ class Application extends App {
 		 * Core class wrappers
 		 */
 		/** FIXME: Remove once OC_User is non-static and mockable */
-		$container->registerService('isAdmin', function() {
+		$container->registerService('isAdmin', function () {
 			return \OC_User::isAdminUser(\OC_User::getUser());
 		});
 		/** FIXME: Remove once OC_SubAdmin is non-static and mockable */
-		$container->registerService('isSubAdmin', function(IContainer $c) {
+		$container->registerService('isSubAdmin', function (IContainer $c) {
 			$userObject = \OC::$server->getUserSession()->getUser();
 			$isSubAdmin = false;
 			if($userObject !== null) {
@@ -85,7 +85,7 @@ class Application extends App {
 			}
 			return $isSubAdmin;
 		});
-		$container->registerService('userCertificateManager', function(IContainer $c) {
+		$container->registerService('userCertificateManager', function (IContainer $c) {
 			return $c->query('ServerContainer')->getCertificateManager();
 		}, false);
 		$container->registerService('systemCertificateManager', function (IContainer $c) {

--- a/apps/settings/lib/Controller/AppSettingsController.php
+++ b/apps/settings/lib/Controller/AppSettingsController.php
@@ -247,7 +247,7 @@ class AppSettingsController extends Controller {
 		$dependencyAnalyzer = new DependencyAnalyzer(new Platform($this->config), $this->l10n);
 
 		// Extend existing app details
-		$apps = array_map(function($appData) use ($dependencyAnalyzer) {
+		$apps = array_map(function ($appData) use ($dependencyAnalyzer) {
 			if (isset($appData['appstoreData'])) {
 				$appstoreData = $appData['appstoreData'];
 				$appData['screenshot'] = isset($appstoreData['screenshots'][0]['url']) ? 'https://usercontent.apps.nextcloud.com/' . base64_encode($appstoreData['screenshots'][0]['url']) : '';

--- a/apps/settings/lib/Controller/UsersController.php
+++ b/apps/settings/lib/Controller/UsersController.php
@@ -184,7 +184,7 @@ class UsersController extends Controller {
 		if(!$isLDAPUsed) {
 			if ($this->isAdmin) {
 				$disabledUsers = $this->userManager->countDisabledUsers();
-				$userCount = array_reduce($this->userManager->countUsers(), function($v, $w) {
+				$userCount = array_reduce($this->userManager->countUsers(), function ($v, $w) {
 					return $v + (int)$w;
 				}, 0);
 			} else {

--- a/apps/settings/lib/Settings/Personal/PersonalInfo.php
+++ b/apps/settings/lib/Settings/Personal/PersonalInfo.php
@@ -175,7 +175,7 @@ class PersonalInfo implements ISettings {
 	 */
 	private function getGroups(IUser $user) {
 		$groups = array_map(
-			function(IGroup $group) {
+			function (IGroup $group) {
 				return $group->getDisplayName();
 			},
 			$this->groupManager->getUserGroups($user)
@@ -239,7 +239,7 @@ class PersonalInfo implements ISettings {
 
 		$localeCodes = $this->l10nFactory->findAvailableLocales();
 
-		$userLocale = array_filter($localeCodes, function($value) use ($userLocaleString) {
+		$userLocale = array_filter($localeCodes, function ($value) use ($userLocaleString) {
 			return $userLocaleString === $value['code'];
 		});
 
@@ -248,7 +248,7 @@ class PersonalInfo implements ISettings {
 			$userLocale = reset($userLocale);
 		}
 
-		$localesForLanguage = array_filter($localeCodes, function($localeCode) use ($userLang) {
+		$localesForLanguage = array_filter($localeCodes, function ($localeCode) use ($userLang) {
 			return 0 === strpos($localeCode['code'], $userLang);
 		});
 

--- a/apps/settings/tests/Controller/CheckSetupControllerTest.php
+++ b/apps/settings/tests/Controller/CheckSetupControllerTest.php
@@ -116,7 +116,7 @@ class CheckSetupControllerTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->l10n->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($message, array $replace) {
+			->willReturnCallback(function ($message, array $replace) {
 				return vsprintf($message, $replace);
 			});
 		$this->dispatcher = $this->getMockBuilder(EventDispatcherInterface::class)
@@ -513,7 +513,7 @@ class CheckSetupControllerTest extends TestCase {
 			->willReturn(true);
 
 		$this->urlGenerator->method('linkToDocs')
-			->willReturnCallback(function(string $key): string {
+			->willReturnCallback(function (string $key): string {
 				if ($key === 'admin-performance') {
 					return 'http://docs.example.org/server/go.php?to=admin-performance';
 				}
@@ -536,7 +536,7 @@ class CheckSetupControllerTest extends TestCase {
 			});
 
 		$this->urlGenerator->method('getAbsoluteURL')
-			->willReturnCallback(function(string $url): string {
+			->willReturnCallback(function (string $url): string {
 				if ($url === 'index.php/settings/admin') {
 					return 'https://server/index.php/settings/admin';
 				}
@@ -1391,7 +1391,7 @@ Array
 	 */
 	public function testIsMysqlUsedWithoutUTF8MB4(string $db, bool $useUTF8MB4, bool $expected) {
 		$this->config->method('getSystemValue')
-			->willReturnCallback(function($key, $default) use ($db, $useUTF8MB4) {
+			->willReturnCallback(function ($key, $default) use ($db, $useUTF8MB4) {
 				if ($key === 'dbtype') {
 					return $db;
 				}
@@ -1439,7 +1439,7 @@ Array
 	 */
 	public function testIsEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed(string $mode, string $className, bool $expected) {
 		$this->config->method('getSystemValue')
-			->willReturnCallback(function($key, $default) use ($mode, $className) {
+			->willReturnCallback(function ($key, $default) use ($mode, $className) {
 				if ($key === 'objectstore' && $mode === 'singlebucket') {
 					return ['class' => $className];
 				}

--- a/apps/settings/tests/Controller/MailSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/MailSettingsControllerTest.php
@@ -160,7 +160,7 @@ class MailSettingsControllerTest extends \Test\TestCase {
 
 		$this->l->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($text, $parameters = []) {
+			->willReturnCallback(function ($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			});
 		$this->userSession

--- a/apps/settings/tests/Controller/UsersControllerTest.php
+++ b/apps/settings/tests/Controller/UsersControllerTest.php
@@ -113,7 +113,7 @@ class UsersControllerTest extends \Test\TestCase {
 
 		$this->encryptionModule = $this->createMock(IEncryptionModule::class);
 		$this->encryptionManager->expects($this->any())->method('getEncryptionModules')
-			->willReturn(['encryptionModule' => ['callback' => function() { return $this->encryptionModule;}]]);
+			->willReturn(['encryptionModule' => ['callback' => function () { return $this->encryptionModule;}]]);
 
 	}
 
@@ -540,7 +540,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->willReturn($encryptionEnabled);
 		$this->encryptionManager->expects($this->any())
 			->method('getEncryptionModule')
-			->willReturnCallback(function() use ($encryptionModuleLoaded) {
+			->willReturnCallback(function () use ($encryptionModuleLoaded) {
 				if ($encryptionModuleLoaded) return $this->encryptionModule;
 				else throw new ModuleDoesNotExistsException();
 			});

--- a/apps/settings/tests/Mailer/NewUserMailHelperTest.php
+++ b/apps/settings/tests/Mailer/NewUserMailHelperTest.php
@@ -90,7 +90,7 @@ class NewUserMailHelperTest extends TestCase {
 		$this->config
 			->expects($this->any())
 			->method('getSystemValue')
-			->willReturnCallback(function($arg) {
+			->willReturnCallback(function ($arg) {
 				switch ($arg) {
 					case 'secret':
 						return 'MyInstanceWideSecret';

--- a/apps/sharebymail/tests/ShareByMailProviderTest.php
+++ b/apps/sharebymail/tests/ShareByMailProviderTest.php
@@ -113,7 +113,7 @@ class ShareByMailProviderTest extends TestCase {
 
 		$this->l = $this->getMockBuilder(IL10N::class)->getMock();
 		$this->l->method('t')
-			->willReturnCallback(function($text, $parameters = []) {
+			->willReturnCallback(function ($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			});
 		$this->logger = $this->getMockBuilder(ILogger::class)->getMock();
@@ -375,7 +375,7 @@ class ShareByMailProviderTest extends TestCase {
 			->with('files_sharing.sharecontroller.showShare', ['token' => 'token']);
 		$instance->expects($this->once())->method('sendMailNotification')
 			->willReturnCallback(
-				function() {
+				function () {
 					throw new \Exception('should be converted to a hint exception');
 				}
 			);

--- a/apps/systemtags/appinfo/app.php
+++ b/apps/systemtags/appinfo/app.php
@@ -32,14 +32,14 @@ use OCA\SystemTags\Activity\Listener;
 $eventDispatcher = \OC::$server->getEventDispatcher();
 $eventDispatcher->addListener(
 	'OCA\Files::loadAdditionalScripts',
-	function() {
+	function () {
 		// FIXME: no public API for these ?
 		\OCP\Util::addScript('dist/systemtags');
 		\OCP\Util::addScript('systemtags', 'systemtags');
 	}
 );
 
-$managerListener = function(ManagerEvent $event) {
+$managerListener = function (ManagerEvent $event) {
 	/** @var \OCA\SystemTags\Activity\Listener $listener */
 	$listener = \OC::$server->query(Listener::class);
 	$listener->event($event);
@@ -49,7 +49,7 @@ $eventDispatcher->addListener(ManagerEvent::EVENT_CREATE, $managerListener);
 $eventDispatcher->addListener(ManagerEvent::EVENT_DELETE, $managerListener);
 $eventDispatcher->addListener(ManagerEvent::EVENT_UPDATE, $managerListener);
 
-$mapperListener = function(MapperEvent $event) {
+$mapperListener = function (MapperEvent $event) {
 	$application = new \OCP\AppFramework\App('systemtags');
 	/** @var \OCA\SystemTags\Activity\Listener $listener */
 	$listener = \OC::$server->query(Listener::class);

--- a/apps/systemtags/lib/Controller/LastUsedController.php
+++ b/apps/systemtags/lib/Controller/LastUsedController.php
@@ -55,6 +55,6 @@ class LastUsedController extends Controller {
 	public function getLastUsedTagIds() {
 		$lastUsed = $this->config->getUserValue($this->userSession->getUser()->getUID(), 'systemtags', 'last_used', '[]');
 		$tagIds = json_decode($lastUsed, true);
-		return new DataResponse(array_map(function($id) { return (string) $id; }, $tagIds));
+		return new DataResponse(array_map(function ($id) { return (string) $id; }, $tagIds));
 	}
 }

--- a/apps/testing/lib/AppInfo/Application.php
+++ b/apps/testing/lib/AppInfo/Application.php
@@ -28,7 +28,7 @@ use OCA\Testing\AlternativeHomeUserBackend;
 use OCP\AppFramework\App;
 
 class Application extends App {
-	public function __construct (array $urlParams = []) {
+	public function __construct(array $urlParams = []) {
 		$appName = 'testing';
 		parent::__construct($appName, $urlParams);
 

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -180,7 +180,7 @@ class ThemingDefaults extends \OC_Defaults {
 		];
 
 		$navigation = $this->navigationManager->getAll(INavigationManager::TYPE_GUEST);
-		$guestNavigation = array_map(function($nav) {
+		$guestNavigation = array_map(function ($nav) {
 			return [
 				'text' => $nav['name'],
 				'url' => $nav['href']

--- a/apps/theming/tests/CapabilitiesTest.php
+++ b/apps/theming/tests/CapabilitiesTest.php
@@ -181,13 +181,13 @@ class CapabilitiesTest extends TestCase  {
 				->willReturn($background);
 			$this->url->expects($this->exactly(4))
 				->method('getAbsoluteURL')
-				->willReturnCallback(function($url) use($baseUrl) {
+				->willReturnCallback(function ($url) use ($baseUrl) {
 					return $baseUrl . $url;
 				});
 		} else {
 			$this->url->expects($this->exactly(3))
 				->method('getAbsoluteURL')
-				->willReturnCallback(function($url) use($baseUrl) {
+				->willReturnCallback(function ($url) use ($baseUrl) {
 					return $baseUrl . $url;
 				});
 		}

--- a/apps/theming/tests/Controller/ThemingControllerTest.php
+++ b/apps/theming/tests/Controller/ThemingControllerTest.php
@@ -151,7 +151,7 @@ class ThemingControllerTest extends TestCase {
 		$this->l10n
 			->expects($this->once())
 			->method('t')
-			->willReturnCallback(function($str) {
+			->willReturnCallback(function ($str) {
 				return $str;
 			});
 		$this->scssCacher
@@ -210,7 +210,7 @@ class ThemingControllerTest extends TestCase {
 		$this->l10n
 			->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($str) {
+			->willReturnCallback(function ($str) {
 				return $str;
 			});
 
@@ -241,7 +241,7 @@ class ThemingControllerTest extends TestCase {
 		$this->l10n
 			->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($str) {
+			->willReturnCallback(function ($str) {
 				return $str;
 			});
 
@@ -289,7 +289,7 @@ class ThemingControllerTest extends TestCase {
 		$this->l10n
 			->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($str) {
+			->willReturnCallback(function ($str) {
 				return $str;
 			});
 
@@ -333,7 +333,7 @@ class ThemingControllerTest extends TestCase {
 		$this->l10n
 			->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($str) {
+			->willReturnCallback(function ($str) {
 				return $str;
 			});
 
@@ -394,7 +394,7 @@ class ThemingControllerTest extends TestCase {
 		$this->l10n
 			->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($str) {
+			->willReturnCallback(function ($str) {
 				return $str;
 			});
 
@@ -470,7 +470,7 @@ class ThemingControllerTest extends TestCase {
 		$this->l10n
 			->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($str) {
+			->willReturnCallback(function ($str) {
 				return $str;
 			});
 
@@ -544,7 +544,7 @@ class ThemingControllerTest extends TestCase {
 		$this->l10n
 			->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($str) {
+			->willReturnCallback(function ($str) {
 				return $str;
 			});
 
@@ -602,7 +602,7 @@ class ThemingControllerTest extends TestCase {
 		$this->l10n
 			->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($str) {
+			->willReturnCallback(function ($str) {
 				return $str;
 			});
 
@@ -641,7 +641,7 @@ class ThemingControllerTest extends TestCase {
 		$this->l10n
 			->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($str) {
+			->willReturnCallback(function ($str) {
 				return $str;
 			});
 

--- a/apps/twofactor_backupcodes/lib/BackgroundJob/CheckBackupCodes.php
+++ b/apps/twofactor_backupcodes/lib/BackgroundJob/CheckBackupCodes.php
@@ -57,7 +57,7 @@ class CheckBackupCodes extends QueuedJob {
 	}
 
 	protected function run($argument) {
-		$this->userManager->callForSeenUsers(function(IUser $user) {
+		$this->userManager->callForSeenUsers(function (IUser $user) {
 			$providers = $this->registry->getProviderStates($user);
 			$isTwoFactorAuthenticated = $this->twofactorManager->isTwoFactorAuthenticated($user);
 

--- a/apps/twofactor_backupcodes/lib/BackgroundJob/RememberBackupCodesJob.php
+++ b/apps/twofactor_backupcodes/lib/BackgroundJob/RememberBackupCodesJob.php
@@ -72,7 +72,7 @@ class RememberBackupCodesJob extends TimedJob {
 		}
 
 		$providers = $this->registry->getProviderStates($user);
-		$state2fa = array_reduce($providers, function(bool $carry, bool $state) {
+		$state2fa = array_reduce($providers, function (bool $carry, bool $state) {
 			return $carry || $state;
 		}, false);
 

--- a/apps/twofactor_backupcodes/lib/Provider/BackupCodesProvider.php
+++ b/apps/twofactor_backupcodes/lib/Provider/BackupCodesProvider.php
@@ -143,7 +143,7 @@ class BackupCodesProvider implements IProvider, IProvidesPersonalSettings {
 	 * @return boolean
 	 */
 	public function isActive(IUser $user): bool {
-		$appIds = array_filter($this->appManager->getEnabledAppsForUser($user), function($appId) {
+		$appIds = array_filter($this->appManager->getEnabledAppsForUser($user), function ($appId) {
 			return $appId !== $this->appName;
 		});
 		foreach ($appIds as $appId) {

--- a/apps/twofactor_backupcodes/tests/Unit/BackgroundJob/CheckBackupCodeTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/BackgroundJob/CheckBackupCodeTest.php
@@ -69,7 +69,7 @@ class CheckBackupCodeTest extends TestCase {
 		$this->user = $this->createMock(IUser::class);
 
 		$this->userManager->method('callForSeenUsers')
-			->willReturnCallback(function(\Closure $e) {
+			->willReturnCallback(function (\Closure $e) {
 				$e($this->user);
 			});
 

--- a/apps/twofactor_backupcodes/tests/Unit/Listener/ClearNotificationsTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Listener/ClearNotificationsTest.php
@@ -68,7 +68,7 @@ class ClearNotificationsTest extends TestCase {
 
 		$this->notificationManager->expects($this->once())
 			->method('markProcessed')
-			->with($this->callback(function(INotification $n) {
+			->with($this->callback(function (INotification $n) {
 				return $n->getUser() === 'fritz' &&
 					$n->getApp() === 'twofactor_backupcodes' &&
 					$n->getObjectType() === 'create' &&

--- a/apps/twofactor_backupcodes/tests/Unit/Notification/NotifierTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Notification/NotifierTest.php
@@ -53,7 +53,7 @@ class NotifierTest extends TestCase {
 		$this->l = $this->createMock(IL10N::class);
 		$this->l->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($string, $args) {
+			->willReturnCallback(function ($string, $args) {
 				return vsprintf($string, $args);
 			});
 		$this->factory = $this->createMock(IFactory::class);

--- a/apps/updatenotification/lib/Controller/APIController.php
+++ b/apps/updatenotification/lib/Controller/APIController.php
@@ -78,7 +78,7 @@ class APIController extends OCSController {
 
 		// Get list of installed custom apps
 		$installedApps = $this->appManager->getInstalledApps();
-		$installedApps = array_filter($installedApps, function($app) {
+		$installedApps = array_filter($installedApps, function ($app) {
 			try {
 				$this->appManager->getAppPath($app);
 			} catch (AppPathNotFoundException $e) {
@@ -97,7 +97,7 @@ class APIController extends OCSController {
 		$this->appFetcher->setVersion($newVersion, 'future-apps.json', false);
 
 		// Apps available on the app store for that version
-		$availableApps = array_map(function(array $app) {
+		$availableApps = array_map(function (array $app) {
 			return $app['id'];
 		}, $this->appFetcher->get());
 

--- a/apps/user_ldap/appinfo/app.php
+++ b/apps/user_ldap/appinfo/app.php
@@ -27,10 +27,10 @@
  *
  */
 
-\OC::$server->registerService('LDAPUserPluginManager', function() {
+\OC::$server->registerService('LDAPUserPluginManager', function () {
 	return new OCA\User_LDAP\UserPluginManager();
 });
-\OC::$server->registerService('LDAPGroupPluginManager', function() {
+\OC::$server->registerService('LDAPGroupPluginManager', function () {
 	return new OCA\User_LDAP\GroupPluginManager();
 });
 

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -919,7 +919,7 @@ class Access extends LDAPUtility {
 		if(!$forceApplyAttributes) {
 			$isBackgroundJobModeAjax = $this->config
 					->getAppValue('core', 'backgroundjobs_mode', 'ajax') === 'ajax';
-			$recordsToUpdate = array_filter($ldapRecords, function($record) use ($isBackgroundJobModeAjax) {
+			$recordsToUpdate = array_filter($ldapRecords, function ($record) use ($isBackgroundJobModeAjax) {
 				$newlyMapped = false;
 				$uid = $this->dn2ocname($record['dn'][0], null, true, $newlyMapped, $record);
 				if(is_string($uid)) {
@@ -940,7 +940,7 @@ class Access extends LDAPUtility {
 	 * @param array $ldapRecords
 	 * @throws \Exception
 	 */
-	public function batchApplyUserAttributes(array $ldapRecords){
+	public function batchApplyUserAttributes(array $ldapRecords) {
 		$displayNameAttribute = strtolower($this->connection->ldapUserDisplayName);
 		foreach($ldapRecords as $userRecord) {
 			if(!isset($userRecord[$displayNameAttribute])) {
@@ -973,7 +973,7 @@ class Access extends LDAPUtility {
 	 */
 	public function fetchListOfGroups($filter, $attr, $limit = null, $offset = null) {
 		$groupRecords = $this->searchGroups($filter, $attr, $limit, $offset);
-		array_walk($groupRecords, function($record) {
+		array_walk($groupRecords, function ($record) {
 			$newlyMapped = false;
 			$gid = $this->dn2ocname($record['dn'][0], null, false, $newlyMapped, $record);
 			if(!$newlyMapped && is_string($gid)) {
@@ -993,7 +993,7 @@ class Access extends LDAPUtility {
 			if($manyAttributes) {
 				return $list;
 			} else {
-				$list = array_reduce($list, function($carry, $item) {
+				$list = array_reduce($list, function ($carry, $item) {
 					$attribute = array_keys($item)[0];
 					$carry[] = $item[$attribute][0];
 					return $carry;

--- a/apps/user_ldap/lib/AppInfo/Application.php
+++ b/apps/user_ldap/lib/AppInfo/Application.php
@@ -35,14 +35,14 @@ use OCP\AppFramework\IAppContainer;
 use OCP\IL10N;
 
 class Application extends App {
-	public function __construct () {
+	public function __construct() {
 		parent::__construct('user_ldap');
 		$container = $this->getContainer();
 
 		/**
 		 * Controller
 		 */
-		$container->registerService('RenewPasswordController', function(IAppContainer $c) {
+		$container->registerService('RenewPasswordController', function (IAppContainer $c) {
 			/** @var \OC\Server $server */
 			$server = $c->query('ServerContainer');
 
@@ -67,7 +67,7 @@ class Application extends App {
 
 		$container->getServer()->getEventDispatcher()->addListener(
 			'OCA\\Files_External::loadAdditionalBackends',
-			function() use ($container) {
+			function () use ($container) {
 				$storagesBackendService = $container->query(BackendService::class);
 				$storagesBackendService->registerConfigHandler('home', function () use ($container) {
 					return $container->query(ExtStorageConfigHandler::class);

--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -236,7 +236,7 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface, IGroupLD
 		$seen[$dnGroup] = 1;
 		$members = $this->access->readAttribute($dnGroup, $this->access->connection->ldapGroupMemberAssocAttr);
 		if (is_array($members)) {
-			$fetcher = function($memberDN, &$seen) {
+			$fetcher = function ($memberDN, &$seen) {
 				return $this->_groupMembers($memberDN, $seen);
 			};
 			$allMembers = $this->walkNestedGroups($dnGroup, $fetcher, $members);
@@ -260,7 +260,7 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface, IGroupLD
 			return [];
 		}
 
-		$fetcher = function($groupDN) {
+		$fetcher = function ($groupDN) {
 			if (isset($this->cachedNestedGroups[$groupDN])) {
 				$nestedGroups = $this->cachedNestedGroups[$groupDN];
 			} else {

--- a/apps/user_ldap/lib/Jobs/Sync.php
+++ b/apps/user_ldap/lib/Jobs/Sync.php
@@ -103,7 +103,7 @@ class Sync extends TimedJob {
 	 */
 	protected function getMinPagingSize() {
 		$configKeys = $this->config->getAppKeys('user_ldap');
-		$configKeys = array_filter($configKeys, function($key) {
+		$configKeys = array_filter($configKeys, function ($key) {
 			return strpos($key, 'ldap_paging_size') !== false;
 		});
 		$minPagingSize = null;

--- a/apps/user_ldap/lib/Jobs/UpdateGroups.php
+++ b/apps/user_ldap/lib/Jobs/UpdateGroups.php
@@ -50,14 +50,14 @@ class UpdateGroups extends \OC\BackgroundJob\TimedJob {
 
 	static private $groupBE;
 
-	public function __construct(){
+	public function __construct() {
 		$this->interval = self::getRefreshInterval();
 	}
 
 	/**
 	 * @param mixed $argument
 	 */
-	public function run($argument){
+	public function run($argument) {
 		self::updateGroups();
 	}
 

--- a/apps/user_ldap/lib/LDAP.php
+++ b/apps/user_ldap/lib/LDAP.php
@@ -194,7 +194,7 @@ class LDAP implements ILDAPWrapper {
 	 * @throws \Exception
 	 */
 	public function search($link, $baseDN, $filter, $attr, $attrsOnly = 0, $limit = 0) {
-		$oldHandler = set_error_handler(function($no, $message, $file, $line) use (&$oldHandler) {
+		$oldHandler = set_error_handler(function ($no, $message, $file, $line) use (&$oldHandler) {
 			if(strpos($message, 'Partial search results returned: Sizelimit exceeded') !== false) {
 				return true;
 			}

--- a/apps/user_ldap/lib/User/Manager.php
+++ b/apps/user_ldap/lib/User/Manager.php
@@ -195,7 +195,7 @@ class Manager {
 		}
 
 		$attributes = array_reduce($attributes,
-			function($list, $attribute) {
+			function ($list, $attribute) {
 				$attribute = strtolower(trim((string)$attribute));
 				if(!empty($attribute) && !in_array($attribute, $list)) {
 					$list[] = $attribute;

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -571,7 +571,7 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 	 * Backend name to be shown in user management
 	 * @return string the name of the backend to be shown
 	 */
-	public function getBackendName(){
+	public function getBackendName() {
 		return 'LDAP';
 	}
 	

--- a/apps/user_ldap/lib/Wizard.php
+++ b/apps/user_ldap/lib/Wizard.php
@@ -79,7 +79,7 @@ class Wizard extends LDAPUtility {
 		$this->result = new WizardResult();
 	}
 
-	public function  __destruct() {
+	public function __destruct() {
 		if($this->result->hasChanges()) {
 			$this->configuration->saveConfiguration();
 		}

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -538,7 +538,7 @@ class AccessTest extends TestCase {
 			->willReturn($fakeConnection);
 		$this->connection->expects($this->any())
 			->method('__get')
-			->willReturnCallback(function($key) use ($base) {
+			->willReturnCallback(function ($key) use ($base) {
 				if(stripos($key, 'base') !== false) {
 					return $base;
 				}
@@ -616,7 +616,7 @@ class AccessTest extends TestCase {
 		];
 		$expected = $fakeLdapEntries;
 		unset($expected['count']);
-		array_walk($expected, function(&$v) {
+		array_walk($expected, function (&$v) {
 			$v['dn'] = [$v['dn']];	// dn is translated into an array internally for consistency
 		});
 
@@ -628,7 +628,7 @@ class AccessTest extends TestCase {
 
 		$this->userMapper->expects($this->exactly($fakeLdapEntries['count']))
 			->method('getNameByDN')
-			->willReturnCallback(function($fdn) {
+			->willReturnCallback(function ($fdn) {
 				$parts = ldap_explode_dn($fdn, false);
 				return $parts[0];
 			});

--- a/apps/user_ldap/tests/Group_LDAPTest.php
+++ b/apps/user_ldap/tests/Group_LDAPTest.php
@@ -88,7 +88,7 @@ class Group_LDAPTest extends TestCase {
 
 		$access->connection->expects($this->any())
 			->method('__get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 				if($name === 'ldapDynamicGroupMemberURL') {
 					return '';
 				}
@@ -109,7 +109,7 @@ class Group_LDAPTest extends TestCase {
 
 		$access->expects($this->any())
 			->method('readAttribute')
-			->willReturnCallback(function($dn) use ($groupDN) {
+			->willReturnCallback(function ($dn) use ($groupDN) {
 				if($dn === $groupDN) {
 					return [
 						'uid=u11,ou=users,dc=foo,dc=bar',
@@ -148,7 +148,7 @@ class Group_LDAPTest extends TestCase {
 
 		$access->expects($this->any())
 			->method('readAttribute')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 				//the search operation will call readAttribute, thus we need
 				//to anaylze the "dn". All other times we just need to return
 				//something that is neither null or false, but once an array
@@ -162,7 +162,7 @@ class Group_LDAPTest extends TestCase {
 
 		$access->expects($this->any())
 			->method('dn2username')
-			->willReturnCallback(function() {
+			->willReturnCallback(function () {
 				return 'foobar' . \OC::$server->getSecureRandom()->generate(7);
 			});
 
@@ -520,7 +520,7 @@ class Group_LDAPTest extends TestCase {
 			->willReturn(null);
 		$access->expects($this->any())
 			->method('readAttribute')
-			->willReturnCallback(function($dn, $attr) {
+			->willReturnCallback(function ($dn, $attr) {
 				if($attr === 'primaryGroupToken') {
 					return [1337];
 				} else if($attr === 'gidNumber') {
@@ -557,7 +557,7 @@ class Group_LDAPTest extends TestCase {
 			->willReturn(null);
 		$access->expects($this->any())
 			->method('readAttribute')
-			->willReturnCallback(function($dn, $attr) {
+			->willReturnCallback(function ($dn, $attr) {
 				if($attr === 'primaryGroupToken') {
 					return [1337];
 				}
@@ -593,7 +593,7 @@ class Group_LDAPTest extends TestCase {
 
 		$access->expects($this->any())
 			->method('readAttribute')
-			->willReturnCallback(function($dn, $attr) {
+			->willReturnCallback(function ($dn, $attr) {
 				if($attr === 'primaryGroupToken') {
 					return [1337];
 				}
@@ -654,7 +654,7 @@ class Group_LDAPTest extends TestCase {
 		$access->connection = $this->createMock(Connection::class);
 		$access->connection->expects($this->any())
 			->method('__get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 				if($name === 'useMemberOfToDetectMembership') {
 					return 0;
 				} else if($name === 'ldapDynamicGroupMemberURL') {
@@ -692,7 +692,7 @@ class Group_LDAPTest extends TestCase {
 		$access->connection = $this->createMock(Connection::class);
 		$access->connection->expects($this->any())
 			->method('__get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 				switch($name) {
 					case 'useMemberOfToDetectMembership':
 						return 0;
@@ -1030,7 +1030,7 @@ class Group_LDAPTest extends TestCase {
 		$access = $this->getAccessMock();
 		$access->expects($this->any())
 			->method('readAttribute')
-			->willReturnCallback(function($group) use ($groupDN, $expectedMembers, $groupsInfo) {
+			->willReturnCallback(function ($group) use ($groupDN, $expectedMembers, $groupsInfo) {
 				if(isset($groupsInfo[$group])) {
 					return $groupsInfo[$group];
 				}
@@ -1041,7 +1041,7 @@ class Group_LDAPTest extends TestCase {
 		if(count($groupsInfo) > 1) {
 			$access->connection->expects($this->any())
 				->method('__get')
-				->willReturnCallback(function($name) {
+				->willReturnCallback(function ($name) {
 					if($name === 'ldapNestedGroups') {
 						return 1;
 					}
@@ -1079,7 +1079,7 @@ class Group_LDAPTest extends TestCase {
 		$access->connection = $this->createMock(Connection::class);
 		$access->connection->expects($this->any())
 			->method('__get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 				if($name === 'ldapGroupMemberAssocAttr') {
 					return 'member';
 				} else if($name === 'ldapGroupFilter') {

--- a/apps/user_ldap/tests/HelperTest.php
+++ b/apps/user_ldap/tests/HelperTest.php
@@ -67,7 +67,7 @@ class HelperTest extends \Test\TestCase {
 			]);
 
 		$this->config->method('getAppValue')
-			->willReturnCallback(function($app, $key, $default) {
+			->willReturnCallback(function ($app, $key, $default) {
 				if ($app !== 'user_ldap') {
 					$this->fail('wrong app');
 				}
@@ -93,7 +93,7 @@ class HelperTest extends \Test\TestCase {
 			]);
 
 		$this->config->method('getAppValue')
-			->willReturnCallback(function($app, $key, $default) {
+			->willReturnCallback(function ($app, $key, $default) {
 				if ($app !== 'user_ldap') {
 					$this->fail('wrong app');
 				}

--- a/apps/user_ldap/tests/Integration/AbstractIntegrationTest.php
+++ b/apps/user_ldap/tests/Integration/AbstractIntegrationTest.php
@@ -71,10 +71,10 @@ abstract class AbstractIntegrationTest {
 	 * the LDAP backend.
 	 */
 	public function init() {
-		\OC::$server->registerService('LDAPUserPluginManager', function() {
+		\OC::$server->registerService('LDAPUserPluginManager', function () {
 			return new \OCA\User_LDAP\UserPluginManager();
 		});
-		\OC::$server->registerService('LDAPGroupPluginManager', function() {
+		\OC::$server->registerService('LDAPGroupPluginManager', function () {
 			return new \OCA\User_LDAP\GroupPluginManager();
 		});
 

--- a/apps/user_ldap/tests/Jobs/SyncTest.php
+++ b/apps/user_ldap/tests/Jobs/SyncTest.php
@@ -128,7 +128,7 @@ class SyncTest extends TestCase {
 		$this->config->expects($this->once())
 			->method('setAppValue')
 			->with('user_ldap', 'background_sync_interval', $this->anything())
-			->willReturnCallback(function($a, $k, $interval) {
+			->willReturnCallback(function ($a, $k, $interval) {
 				$this->assertTrue($interval >= SYNC::MIN_INTERVAL);
 				$this->assertTrue($interval <= SYNC::MAX_INTERVAL);
 				return true;
@@ -294,7 +294,7 @@ class SyncTest extends TestCase {
 	public function testRun($runData) {
 		$this->config->expects($this->any())
 			->method('getAppValue')
-			->willReturnCallback(function($app, $key, $default) use ($runData) {
+			->willReturnCallback(function ($app, $key, $default) use ($runData) {
 				if($app === 'core' && $key === 'backgroundjobs_mode') {
 					return 'cron';
 				}

--- a/apps/user_ldap/tests/LDAPTest.php
+++ b/apps/user_ldap/tests/LDAPTest.php
@@ -60,7 +60,7 @@ class LDAPTest extends TestCase  {
 	public function testSearchWithErrorHandler(string $errorMessage, bool $passThrough) {
 
 		$wasErrorHandlerCalled = false;
-		$errorHandler = function($number, $message, $file, $line) use (&$wasErrorHandlerCalled) {
+		$errorHandler = function ($number, $message, $file, $line) use (&$wasErrorHandlerCalled) {
 			$wasErrorHandlerCalled = true;
 		};
 
@@ -70,7 +70,7 @@ class LDAPTest extends TestCase  {
 			->expects($this->once())
 			->method('invokeLDAPMethod')
 			->with('search', $this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything())
-			->willReturnCallback(function() use($errorMessage) {
+			->willReturnCallback(function () use ($errorMessage) {
 				trigger_error($errorMessage);
 			});
 

--- a/apps/user_ldap/tests/User/UserTest.php
+++ b/apps/user_ldap/tests/User/UserTest.php
@@ -606,7 +606,7 @@ class UserTest extends \Test\TestCase {
 	public function XtestUpdateAvatarThumbnailPhotoProvided() {
 		$this->access->expects($this->any())
 			->method('readAttribute')
-			->willReturnCallback(function($dn, $attr) {
+			->willReturnCallback(function ($dn, $attr) {
 				if($dn === $this->dn
 					&& $attr === 'jpegphoto')
 				{
@@ -671,7 +671,7 @@ class UserTest extends \Test\TestCase {
 	public function testUpdateAvatarCorruptPhotoProvided() {
 		$this->access->expects($this->any())
 			->method('readAttribute')
-			->willReturnCallback(function($dn, $attr) {
+			->willReturnCallback(function ($dn, $attr) {
 				if($dn === $this->dn
 					&& $attr === 'jpegphoto')
 				{
@@ -724,7 +724,7 @@ class UserTest extends \Test\TestCase {
 	public function XtestUpdateAvatarUnsupportedThumbnailPhotoProvided() {
 		$this->access->expects($this->any())
 			->method('readAttribute')
-			->willReturnCallback(function($dn, $attr) {
+			->willReturnCallback(function ($dn, $attr) {
 				if($dn === $this->dn
 					&& $attr === 'jpegphoto')
 				{
@@ -789,7 +789,7 @@ class UserTest extends \Test\TestCase {
 	public function testUpdateAvatarNotProvided() {
 		$this->access->expects($this->any())
 			->method('readAttribute')
-			->willReturnCallback(function($dn, $attr) {
+			->willReturnCallback(function ($dn, $attr) {
 				if($dn === $this->dn
 					&& $attr === 'jpegPhoto')
 				{
@@ -1038,7 +1038,7 @@ class UserTest extends \Test\TestCase {
 		]);
 		$this->connection->expects($this->any())
 			->method('__get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 				if($name === 'homeFolderNamingRule') {
 					return 'attr:homeDirectory';
 				}
@@ -1193,7 +1193,7 @@ class UserTest extends \Test\TestCase {
 	public function testHandlePasswordExpiryWarningDefaultPolicy() {
 		$this->connection->expects($this->any())
 			->method('__get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 				if($name === 'ldapDefaultPPolicyDN') {
 					return 'cn=default,ou=policies,dc=foo,dc=bar';
 				}
@@ -1205,7 +1205,7 @@ class UserTest extends \Test\TestCase {
 
 		$this->access->expects($this->any())
 			->method('search')
-			->willReturnCallback(function($filter, $base) {
+			->willReturnCallback(function ($filter, $base) {
 				if($base === [$this->dn]) {
 					return [
 						[
@@ -1256,7 +1256,7 @@ class UserTest extends \Test\TestCase {
 	public function testHandlePasswordExpiryWarningCustomPolicy() {
 		$this->connection->expects($this->any())
 			->method('__get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 				if($name === 'ldapDefaultPPolicyDN') {
 					return 'cn=default,ou=policies,dc=foo,dc=bar';
 				}
@@ -1268,7 +1268,7 @@ class UserTest extends \Test\TestCase {
 
 		$this->access->expects($this->any())
 			->method('search')
-			->willReturnCallback(function($filter, $base) {
+			->willReturnCallback(function ($filter, $base) {
 				if($base === [$this->dn]) {
 					return [
 						[

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -108,7 +108,7 @@ class User_LDAPTest extends TestCase {
 	private function prepareMockForUserExists() {
 		$this->access->expects($this->any())
 			   ->method('username2dn')
-			   ->willReturnCallback(function($uid) {
+			   ->willReturnCallback(function ($uid) {
 					switch ($uid) {
 						case 'gunslinger':
 							return 'dnOfRoland,dc=test';
@@ -139,7 +139,7 @@ class User_LDAPTest extends TestCase {
 	private function prepareAccessForCheckPassword($noDisplayName = false) {
 		$this->connection->expects($this->any())
 			   ->method('__get')
-			   ->willReturnCallback(function($name) {
+			   ->willReturnCallback(function ($name) {
 					if($name === 'ldapLoginFilter') {
 						return '%uid';
 					}
@@ -148,7 +148,7 @@ class User_LDAPTest extends TestCase {
 
 		$this->access->expects($this->any())
 			   ->method('fetchListOfUsers')
-			   ->willReturnCallback(function($filter) {
+			   ->willReturnCallback(function ($filter) {
 					if($filter === 'roland') {
 						return [['dn' => ['dnOfRoland,dc=test']]];
 					}
@@ -156,7 +156,7 @@ class User_LDAPTest extends TestCase {
 			   });
 		$this->access->expects($this->any())
 			->method('fetchUsersByLoginName')
-			->willReturnCallback(function($uid) {
+			->willReturnCallback(function ($uid) {
 				if($uid === 'roland') {
 					return [['dn' => ['dnOfRoland,dc=test']]];
 				}
@@ -177,7 +177,7 @@ class User_LDAPTest extends TestCase {
 			   ->willReturn(true);
 		$this->access->expects($this->any())
 			   ->method('areCredentialsValid')
-			   ->willReturnCallback(function($dn, $pwd) {
+			   ->willReturnCallback(function ($dn, $pwd) {
 					if($pwd === 'dt19') {
 						return true;
 					}
@@ -363,22 +363,22 @@ class User_LDAPTest extends TestCase {
 	private function prepareAccessForGetUsers() {
 		$this->access->expects($this->once())
 			   ->method('escapeFilterPart')
-			   ->willReturnCallback(function($search) {
+			   ->willReturnCallback(function ($search) {
 				   return $search;
 			   });
 		$this->access->expects($this->any())
 			   ->method('getFilterPartForUserSearch')
-			   ->willReturnCallback(function($search) {
+			   ->willReturnCallback(function ($search) {
 					return $search;
 			   });
 		$this->access->expects($this->any())
 			   ->method('combineFilterWithAnd')
-			   ->willReturnCallback(function($param) {
+			   ->willReturnCallback(function ($param) {
 					return $param[2];
 			   });
 		$this->access->expects($this->any())
 			   ->method('fetchListOfUsers')
-			   ->willReturnCallback(function($search, $a, $l, $o) {
+			   ->willReturnCallback(function ($search, $a, $l, $o) {
 					$users = ['gunslinger', 'newyorker', 'ladyofshadows'];
 					if(empty($search)) {
 						$result = $users;
@@ -444,7 +444,7 @@ class User_LDAPTest extends TestCase {
 
 	private function getUsers($search = '', $limit = null, $offset = null) {
 		$users = \OC::$server->getUserManager()->search($search, $limit, $offset);
-		$uids = array_map(function(IUser $user) {
+		$uids = array_map(function (IUser $user) {
 			return $user->getUID();
 		}, $users);
 		return $uids;
@@ -544,7 +544,7 @@ class User_LDAPTest extends TestCase {
 
 		$this->access->expects($this->any())
 			->method('readAttribute')
-			->willReturnCallback(function($dn) {
+			->willReturnCallback(function ($dn) {
 				if($dn === 'dnOfRoland,dc=test') {
 					return [];
 				}
@@ -569,7 +569,7 @@ class User_LDAPTest extends TestCase {
 
 		$this->access->expects($this->any())
 			->method('readAttribute')
-			->willReturnCallback(function($dn) {
+			->willReturnCallback(function ($dn) {
 				if($dn === 'dnOfRoland,dc=test') {
 					return [];
 				}
@@ -601,7 +601,7 @@ class User_LDAPTest extends TestCase {
 
 		$this->connection->expects($this->any())
 			->method('__get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 				if($name === 'homeFolderNamingRule') {
 					return 'attr:testAttribute';
 				}
@@ -610,7 +610,7 @@ class User_LDAPTest extends TestCase {
 
 		$this->access->expects($this->any())
 			->method('readAttribute')
-			->willReturnCallback(function($dn, $attr) {
+			->willReturnCallback(function ($dn, $attr) {
 				switch ($dn) {
 					case 'dnOfRoland,dc=test':
 						if($attr === 'testAttribute') {
@@ -653,7 +653,7 @@ class User_LDAPTest extends TestCase {
 
 		$this->connection->expects($this->any())
 			->method('__get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 				if($name === 'homeFolderNamingRule') {
 					return 'attr:testAttribute';
 				}
@@ -662,7 +662,7 @@ class User_LDAPTest extends TestCase {
 
 		$this->access->expects($this->any())
 			->method('readAttribute')
-			->willReturnCallback(function($dn, $attr) {
+			->willReturnCallback(function ($dn, $attr) {
 				switch ($dn) {
 					case 'dnOfLadyOfShadows,dc=test':
 						if($attr === 'testAttribute') {
@@ -704,7 +704,7 @@ class User_LDAPTest extends TestCase {
 
 		$this->connection->expects($this->any())
 			->method('__get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 				if($name === 'homeFolderNamingRule') {
 					return 'attr:testAttribute';
 				}
@@ -712,7 +712,7 @@ class User_LDAPTest extends TestCase {
 			});
 		$this->access->expects($this->any())
 			->method('readAttribute')
-			->willReturnCallback(function($dn, $attr) {
+			->willReturnCallback(function ($dn, $attr) {
 				switch ($dn) {
 					default:
 						return false;
@@ -720,7 +720,7 @@ class User_LDAPTest extends TestCase {
 			});
 		$this->access->connection->expects($this->any())
 			->method('getFromCache')
-			->willReturnCallback(function($key) {
+			->willReturnCallback(function ($key) {
 				if($key === 'userExistsnewyorker') {
 					return true;
 				}
@@ -752,7 +752,7 @@ class User_LDAPTest extends TestCase {
 
 		$this->connection->expects($this->any())
 				->method('__get')
-				->willReturnCallback(function($name) {
+				->willReturnCallback(function ($name) {
 					if($name === 'homeFolderNamingRule') {
 						return 'attr:testAttribute';
 					}
@@ -798,7 +798,7 @@ class User_LDAPTest extends TestCase {
 
 		$this->connection->expects($this->any())
 			->method('getFromCache')
-			->willReturnCallback(function($uid) {
+			->willReturnCallback(function ($uid) {
 				return true;
 			});
 
@@ -809,7 +809,7 @@ class User_LDAPTest extends TestCase {
 	private function prepareAccessForGetDisplayName() {
 		$this->connection->expects($this->any())
 			   ->method('__get')
-			   ->willReturnCallback(function($name) {
+			   ->willReturnCallback(function ($name) {
 					if($name === 'ldapUserDisplayName') {
 						return 'displayname';
 					}
@@ -818,7 +818,7 @@ class User_LDAPTest extends TestCase {
 
 		$this->access->expects($this->any())
 			   ->method('readAttribute')
-			   ->willReturnCallback(function($dn, $attr) {
+			   ->willReturnCallback(function ($dn, $attr) {
 					switch ($dn) {
 						case 'dnOfRoland,dc=test':
 							if($attr === 'displayname') {
@@ -842,7 +842,7 @@ class User_LDAPTest extends TestCase {
 
 		$this->connection->expects($this->any())
 			->method('getConnectionResource')
-			->willReturnCallback(function() {
+			->willReturnCallback(function () {
 				return true;
 			});
 
@@ -864,11 +864,11 @@ class User_LDAPTest extends TestCase {
 		$mapper = $this->createMock(UserMapping::class);
 		$mapper->expects($this->any())
 			->method('getUUIDByDN')
-			->willReturnCallback(function($dn) { return $dn; });
+			->willReturnCallback(function ($dn) { return $dn; });
 
 		$this->userManager->expects($this->any())
 			->method('get')
-			->willReturnCallback(function($uid) use ($user1, $user2) {
+			->willReturnCallback(function ($uid) use ($user1, $user2) {
 				if($uid === 'gunslinger') {
 					return $user1;
 				} else if($uid === 'newyorker') {
@@ -881,7 +881,7 @@ class User_LDAPTest extends TestCase {
 			->willReturn($mapper);
 		$this->access->expects($this->any())
 			->method('getUserDnByUuid')
-			->willReturnCallback(function($uuid) { return $uuid . '1'; });
+			->willReturnCallback(function ($uuid) { return $uuid . '1'; });
 
 		//with displayName
 		$result = $backend->getDisplayName('gunslinger');
@@ -895,7 +895,7 @@ class User_LDAPTest extends TestCase {
 	public function testGetDisplayNamePublicAPI() {
 		$this->access->expects($this->any())
 			->method('username2dn')
-			->willReturnCallback(function($uid) {
+			->willReturnCallback(function ($uid) {
 				switch ($uid) {
 					case 'gunslinger':
 						return 'dnOfRoland,dc=test';
@@ -919,7 +919,7 @@ class User_LDAPTest extends TestCase {
 
 		$this->connection->expects($this->any())
 			->method('getConnectionResource')
-			->willReturnCallback(function() {
+			->willReturnCallback(function () {
 				return true;
 			});
 
@@ -943,11 +943,11 @@ class User_LDAPTest extends TestCase {
 		$mapper = $this->createMock(UserMapping::class);
 		$mapper->expects($this->any())
 			->method('getUUIDByDN')
-			->willReturnCallback(function($dn) { return $dn; });
+			->willReturnCallback(function ($dn) { return $dn; });
 
 		$this->userManager->expects($this->any())
 			->method('get')
-			->willReturnCallback(function($uid) use ($user1, $user2) {
+			->willReturnCallback(function ($uid) use ($user1, $user2) {
 				if($uid === 'gunslinger') {
 					return $user1;
 				} else if($uid === 'newyorker') {
@@ -960,7 +960,7 @@ class User_LDAPTest extends TestCase {
 			->willReturn($mapper);
 		$this->access->expects($this->any())
 			->method('getUserDnByUuid')
-			->willReturnCallback(function($uuid) { return $uuid . '1'; });
+			->willReturnCallback(function ($uuid) { return $uuid . '1'; });
 
 		//with displayName
 		$result = \OC::$server->getUserManager()->get('gunslinger')->getDisplayName();
@@ -1135,7 +1135,7 @@ class User_LDAPTest extends TestCase {
 	private function prepareAccessForSetPassword($enablePasswordChange = true) {
 		$this->connection->expects($this->any())
 			   ->method('__get')
-			   ->willReturnCallback(function($name) use (&$enablePasswordChange) {
+			   ->willReturnCallback(function ($name) use (&$enablePasswordChange) {
 					if($name === 'ldapLoginFilter') {
 						return '%uid';
 					}
@@ -1146,7 +1146,7 @@ class User_LDAPTest extends TestCase {
 			   });
 		$this->connection->expects($this->any())
 			   ->method('getFromCache')
-			   ->willReturnCallback(function($uid) {
+			   ->willReturnCallback(function ($uid) {
 					if($uid === 'userExists'.'roland') {
 						return true;
 					}
@@ -1155,7 +1155,7 @@ class User_LDAPTest extends TestCase {
 
 		$this->access->expects($this->any())
 			   ->method('fetchListOfUsers')
-			   ->willReturnCallback(function($filter) {
+			   ->willReturnCallback(function ($filter) {
 					if($filter === 'roland') {
 						return [['dn' => ['dnOfRoland,dc=test']]];
 					}
@@ -1163,7 +1163,7 @@ class User_LDAPTest extends TestCase {
 			   });
 		$this->access->expects($this->any())
 			->method('fetchUsersByLoginName')
-			->willReturnCallback(function($uid) {
+			->willReturnCallback(function ($uid) {
 				if($uid === 'roland') {
 					return [['dn' => ['dnOfRoland,dc=test']]];
 				}
@@ -1179,7 +1179,7 @@ class User_LDAPTest extends TestCase {
 			   ->willReturn(true);
 		$this->access->expects($this->any())
 			   ->method('setPassword')
-			   ->willReturnCallback(function($uid, $password) {
+			   ->willReturnCallback(function ($uid, $password) {
 					if(strlen($password) <= 5) {
 						throw new HintException('Password fails quality checking policy', '', 19);
 					}

--- a/apps/user_ldap/tests/WizardTest.php
+++ b/apps/user_ldap/tests/WizardTest.php
@@ -103,7 +103,7 @@ class WizardTest extends TestCase {
 
 		$configuration->expects($this->any())
 			->method('__get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 					if($name === 'ldapBase') {
 						return ['base'];
 					}
@@ -147,7 +147,7 @@ class WizardTest extends TestCase {
 		$ldap->expects($this->exactly(10))
 			->method('getDN')
 			//dummy value, usually invalid
-			->willReturnCallback(function($a, $b) {
+			->willReturnCallback(function ($a, $b) {
 				global $uidnumber;
 				return $uidnumber++;
 			});
@@ -163,7 +163,7 @@ class WizardTest extends TestCase {
 
 		$configuration->expects($this->any())
 			->method('__get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 					if($name === 'ldapBase') {
 						return ['base'];
 					}
@@ -174,7 +174,7 @@ class WizardTest extends TestCase {
 
 		$ldap->expects($this->any())
 			->method('isResource')
-			->willReturnCallback(function($r) {
+			->willReturnCallback(function ($r) {
 				if($r === true) {
 					return true;
 				}
@@ -200,7 +200,7 @@ class WizardTest extends TestCase {
 		$ldap->expects($this->exactly(2))
 			->method('firstEntry')
 			//dummy value, usually invalid
-			->willReturnCallback(function($r) {
+			->willReturnCallback(function ($r) {
 				global $uidnumber;
 				return $uidnumber;
 			});
@@ -208,7 +208,7 @@ class WizardTest extends TestCase {
 		$ldap->expects($this->exactly(46))
 			->method('nextEntry')
 			//dummy value, usually invalid
-			->willReturnCallback(function($r) {
+			->willReturnCallback(function ($r) {
 				global $uidnumber;
 				return $uidnumber;
 			});
@@ -223,7 +223,7 @@ class WizardTest extends TestCase {
 		$ldap->expects($this->exactly(46))
 			->method('getDN')
 			//dummy value, usually invalid
-			->willReturnCallback(function($a, $b) {
+			->willReturnCallback(function ($a, $b) {
 				global $uidnumber;
 				return $uidnumber++;
 			});
@@ -379,7 +379,7 @@ class WizardTest extends TestCase {
 
 		$configuration->expects($this->any())
 			->method('__get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 					if($name === 'ldapBase') {
 						return ['base'];
 					}
@@ -390,7 +390,7 @@ class WizardTest extends TestCase {
 
 		$ldap->expects($this->any())
 			->method('isResource')
-			->willReturnCallback(function($res) {
+			->willReturnCallback(function ($res) {
 				return (bool)$res;
 			});
 
@@ -416,7 +416,7 @@ class WizardTest extends TestCase {
 		$ldap->expects($this->any())
 			->method('nextEntry')
 			//dummy value, usually invalid
-			->willReturnCallback(function($a, $prev){
+			->willReturnCallback(function ($a, $prev) {
 				$current = $prev + 1;
 				if($current === 7) {
 					return false;
@@ -432,14 +432,14 @@ class WizardTest extends TestCase {
 		$ldap->expects($this->any())
 			->method('getAttributes')
 			//dummy value, usually invalid
-			->willReturnCallback(function($a, $entry) {
+			->willReturnCallback(function ($a, $entry) {
 				return ['cn' => [$entry], 'count' => 1];
 			});
 
 		$ldap->expects($this->any())
 			->method('getDN')
 			//dummy value, usually invalid
-			->willReturnCallback(function($a, $b) {
+			->willReturnCallback(function ($a, $b) {
 				return $b;
 			});
 

--- a/apps/workflowengine/lib/Check/AbstractStringCheck.php
+++ b/apps/workflowengine/lib/Check/AbstractStringCheck.php
@@ -50,7 +50,7 @@ abstract class AbstractStringCheck implements ICheck {
 	 * @param string $value
 	 * @return bool
 	 */
-	public function executeCheck($operator, $value)  {
+	public function executeCheck($operator, $value) {
 		$actualValue = $this->getActualValue();
 		return $this->executeStringCheck($operator, $value, $actualValue);
 	}

--- a/apps/workflowengine/lib/Check/RequestURL.php
+++ b/apps/workflowengine/lib/Check/RequestURL.php
@@ -46,7 +46,7 @@ class RequestURL extends AbstractStringCheck {
 	 * @param string $value
 	 * @return bool
 	 */
-	public function executeCheck($operator, $value)  {
+	public function executeCheck($operator, $value) {
 		$actualValue = $this->getActualValue();
 		if (in_array($operator, ['is', '!is'])) {
 			switch ($value) {

--- a/apps/workflowengine/lib/Settings/ASettings.php
+++ b/apps/workflowengine/lib/Settings/ASettings.php
@@ -147,7 +147,7 @@ abstract class ASettings implements ISettings {
 
 	private function entitiesToArray(array $entities) {
 		return array_map(function (IEntity $entity) {
-			$events = array_map(function(IEntityEvent $entityEvent) {
+			$events = array_map(function (IEntityEvent $entityEvent) {
 				return [
 					'eventName' => $entityEvent->getEventName(),
 					'displayName' => $entityEvent->getDisplayName()
@@ -164,7 +164,7 @@ abstract class ASettings implements ISettings {
 	}
 
 	private function operatorsToArray(array $operators) {
-		$operators = array_filter($operators, function(IOperation $operator) {
+		$operators = array_filter($operators, function (IOperation $operator) {
 			return $operator->isAvailableForScope($this->getScope());
 		});
 
@@ -182,7 +182,7 @@ abstract class ASettings implements ISettings {
 	}
 
 	private function checksToArray(array $checks) {
-		$checks = array_filter($checks, function(ICheck $check) {
+		$checks = array_filter($checks, function (ICheck $check) {
 			return $check->isAvailableForScope($this->getScope());
 		});
 

--- a/apps/workflowengine/tests/Check/AbstractStringCheckTest.php
+++ b/apps/workflowengine/tests/Check/AbstractStringCheckTest.php
@@ -31,7 +31,7 @@ class AbstractStringCheckTest extends \Test\TestCase {
 			->getMock();
 		$l->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($string, $args) {
+			->willReturnCallback(function ($string, $args) {
 					return sprintf($string, $args);
 				});
 

--- a/apps/workflowengine/tests/Check/RequestUserAgentTest.php
+++ b/apps/workflowengine/tests/Check/RequestUserAgentTest.php
@@ -44,7 +44,7 @@ class RequestUserAgentTest extends TestCase {
 			->getMock();
 		$l->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($string, $args) {
+			->willReturnCallback(function ($string, $args) {
 				return sprintf($string, $args);
 			});
 

--- a/apps/workflowengine/tests/ManagerTest.php
+++ b/apps/workflowengine/tests/ManagerTest.php
@@ -78,7 +78,7 @@ class ManagerTest extends TestCase {
 		/** @var IL10N|MockObject $l */
 		$this->l = $this->createMock(IL10N::class);
 		$this->l->method('t')
-			->willReturnCallback(function($text, $parameters = []) {
+			->willReturnCallback(function ($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			});
 
@@ -414,7 +414,7 @@ class ManagerTest extends TestCase {
 		$this->legacyDispatcher->expects($this->once())
 			->method('dispatch')
 			->with('OCP\WorkflowEngine::registerEntities', $this->anything())
-			->willReturnCallback(function() use ($extraEntity) {
+			->willReturnCallback(function () use ($extraEntity) {
 				$this->manager->registerEntity($extraEntity);
 			});
 

--- a/build/integration/features/bootstrap/AppConfiguration.php
+++ b/build/integration/features/bootstrap/AppConfiguration.php
@@ -96,7 +96,7 @@ trait AppConfiguration {
 	 * reset the configs before each scenario
 	 * @param BeforeScenarioScope $event
 	 */
-	public function prepareParameters(BeforeScenarioScope $event){
+	public function prepareParameters(BeforeScenarioScope $event) {
 		$user = $this->currentUser;
 		$this->currentUser = 'admin';
 

--- a/build/integration/features/bootstrap/BasicStructure.php
+++ b/build/integration/features/bootstrap/BasicStructure.php
@@ -370,7 +370,7 @@ trait BasicStructure {
 	private function getDataDirectory() {
 		// Based on "runOcc" from CommandLine trait
 		$args = ['config:system:get', 'datadirectory'];
-		$args = array_map(function($arg) {
+		$args = array_map(function ($arg) {
 			return escapeshellarg($arg);
 		}, $args);
 		$args[] = '--no-ansi --no-warnings';

--- a/build/integration/features/bootstrap/CalDavContext.php
+++ b/build/integration/features/bootstrap/CalDavContext.php
@@ -80,7 +80,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	 * @param string $calendar
 	 * @param string $endpoint
 	 */
-	public function requestsCalendar($user, $calendar, $endpoint)  {
+	public function requestsCalendar($user, $calendar, $endpoint) {
 		$davUrl = $this->baseUrl . $endpoint . $calendar;
 
 		$password = ($user === 'admin') ? 'admin' : '123456';

--- a/build/integration/features/bootstrap/CapabilitiesContext.php
+++ b/build/integration/features/bootstrap/CapabilitiesContext.php
@@ -42,7 +42,7 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 	 * @Then /^fields of capabilities match with$/
 	 * @param \Behat\Gherkin\Node\TableNode|null $formData
 	 */
-	public function checkCapabilitiesResponse(\Behat\Gherkin\Node\TableNode $formData){
+	public function checkCapabilitiesResponse(\Behat\Gherkin\Node\TableNode $formData) {
 		$capabilitiesXML = simplexml_load_string($this->response->getBody())->data->capabilities;
 
 		foreach ($formData->getHash() as $row) {

--- a/build/integration/features/bootstrap/CardDavContext.php
+++ b/build/integration/features/bootstrap/CardDavContext.php
@@ -206,7 +206,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	/**
 	 * @Given :user uploads the contact :fileName to the addressbook :addressbook
 	 */
-	public function uploadsTheContactToTheAddressbook($user, $fileName, $addressBook)  {
+	public function uploadsTheContactToTheAddressbook($user, $fileName, $addressBook) {
 		$davUrl = $this->baseUrl . '/remote.php/dav/addressbooks/users/'.$user.'/'.$addressBook . '/' . $fileName;
 		$password = ($user === 'admin') ? 'admin' : '123456';
 
@@ -239,7 +239,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	/**
 	 * @When Exporting the picture of contact :fileName from addressbook :addressBook as user :user
 	 */
-	public function whenExportingThePictureOfContactFromAddressbookAsUser($fileName, $addressBook, $user)  {
+	public function whenExportingThePictureOfContactFromAddressbookAsUser($fileName, $addressBook, $user) {
 		$davUrl = $this->baseUrl . '/remote.php/dav/addressbooks/users/'.$user.'/'.$addressBook . '/' . $fileName . '?photo=true';
 		$password = ($user === 'admin') ? 'admin' : '123456';
 
@@ -265,7 +265,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	/**
 	 * @When Downloading the contact :fileName from addressbook :addressBook as user :user
 	 */
-	public function whenDownloadingTheContactFromAddressbookAsUser($fileName, $addressBook, $user)  {
+	public function whenDownloadingTheContactFromAddressbookAsUser($fileName, $addressBook, $user) {
 		$davUrl = $this->baseUrl . '/remote.php/dav/addressbooks/users/'.$user.'/'.$addressBook . '/' . $fileName;
 		$password = ($user === 'admin') ? 'admin' : '123456';
 

--- a/build/integration/features/bootstrap/CommandLine.php
+++ b/build/integration/features/bootstrap/CommandLine.php
@@ -42,7 +42,7 @@ trait CommandLine {
 	 * @return int exit code
 	 */
 	public function runOcc($args = []) {
-		$args = array_map(function($arg) {
+		$args = array_map(function ($arg) {
 			return escapeshellarg($arg);
 		}, $args);
 		$args[] = '--no-ansi';

--- a/build/integration/features/bootstrap/CommandLineContext.php
+++ b/build/integration/features/bootstrap/CommandLineContext.php
@@ -42,14 +42,14 @@ class CommandLineContext implements \Behat\Behat\Context\Context {
 	/**
 	 * @Given Maintenance mode is enabled
 	 */
-	public function maintenanceModeIsEnabled()  {
+	public function maintenanceModeIsEnabled() {
 		$this->runOcc(['maintenance:mode', '--on']);
 	}
 
 	/**
 	 * @Then Maintenance mode is disabled
 	 */
-	public function maintenanceModeIsDisabled()  {
+	public function maintenanceModeIsDisabled() {
 		$this->runOcc(['maintenance:mode', '--off']);
 	}
 
@@ -82,7 +82,7 @@ class CommandLineContext implements \Behat\Behat\Context\Context {
 			return null;
 		}
 
-		usort($foundPaths, function($a, $b) {
+		usort($foundPaths, function ($a, $b) {
 			return $a['date'] - $b['date'];
 		});
 

--- a/build/integration/features/bootstrap/FederationContext.php
+++ b/build/integration/features/bootstrap/FederationContext.php
@@ -46,7 +46,7 @@ class FederationContext implements Context, SnippetAcceptingContext {
 	 * @param string $shareeUser
 	 * @param string $shareeServer "LOCAL" or "REMOTE"
 	 */
-	public function federateSharing($sharerUser, $sharerServer, $sharerPath, $shareeUser, $shareeServer){
+	public function federateSharing($sharerUser, $sharerServer, $sharerPath, $shareeUser, $shareeServer) {
 		if ($shareeServer == "REMOTE"){
 			$shareWith = "$shareeUser@" . substr($this->remoteBaseUrl, 0, -4);
 		} else {
@@ -67,7 +67,7 @@ class FederationContext implements Context, SnippetAcceptingContext {
 	 * @param string $shareeUser
 	 * @param string $shareeServer "LOCAL" or "REMOTE"
 	 */
-	public function federateGroupSharing($sharerUser, $sharerServer, $sharerPath, $shareeGroup, $shareeServer){
+	public function federateGroupSharing($sharerUser, $sharerServer, $sharerPath, $shareeGroup, $shareeServer) {
 		if ($shareeServer == "REMOTE"){
 			$shareWith = "$shareeGroup@" . substr($this->remoteBaseUrl, 0, -4);
 		} else {
@@ -83,7 +83,7 @@ class FederationContext implements Context, SnippetAcceptingContext {
 	 * @param string $user
 	 * @param string $server
 	 */
-	public function acceptLastPendingShare($user, $server){
+	public function acceptLastPendingShare($user, $server) {
 		$previous = $this->usingServer($server);
 		$this->asAn($user);
 		$this->sendingToWith('GET', "/apps/files_sharing/api/v1/remote_shares/pending", null);

--- a/build/integration/features/bootstrap/Sharing.php
+++ b/build/integration/features/bootstrap/Sharing.php
@@ -266,7 +266,7 @@ trait Sharing {
 								$shareWith = null,
 								$publicUpload = null,
 								$password = null,
-								$permissions = null){
+								$permissions = null) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares";
 		$client = new Client();
 		$options = [
@@ -311,7 +311,7 @@ trait Sharing {
 		}
 	}
 
-	public function isFieldInResponse($field, $contentExpected){
+	public function isFieldInResponse($field, $contentExpected) {
 		$data = simplexml_load_string($this->response->getBody())->data[0];
 		if ((string)$field == 'expiration'){
 			$contentExpected = date('Y-m-d', strtotime($contentExpected)) . " 00:00:00";
@@ -358,7 +358,7 @@ trait Sharing {
 	 *
 	 * @param string $filename
 	 */
-	public function checkSharedFileInResponse($filename){
+	public function checkSharedFileInResponse($filename) {
 		Assert::assertEquals(true, $this->isFieldInResponse('file_target', "/$filename"));
 	}
 
@@ -367,7 +367,7 @@ trait Sharing {
 	 *
 	 * @param string $filename
 	 */
-	public function checkSharedFileNotInResponse($filename){
+	public function checkSharedFileNotInResponse($filename) {
 		Assert::assertEquals(false, $this->isFieldInResponse('file_target', "/$filename"));
 	}
 
@@ -376,7 +376,7 @@ trait Sharing {
 	 *
 	 * @param string $user
 	 */
-	public function checkSharedUserInResponse($user){
+	public function checkSharedUserInResponse($user) {
 		Assert::assertEquals(true, $this->isFieldInResponse('share_with', "$user"));
 	}
 
@@ -385,11 +385,11 @@ trait Sharing {
 	 *
 	 * @param string $user
 	 */
-	public function checkSharedUserNotInResponse($user){
+	public function checkSharedUserNotInResponse($user) {
 		Assert::assertEquals(false, $this->isFieldInResponse('share_with', "$user"));
 	}
 
-	public function isUserOrGroupInSharedData($userOrGroup, $permissions = null){
+	public function isUserOrGroupInSharedData($userOrGroup, $permissions = null) {
 		$data = simplexml_load_string($this->response->getBody())->data[0];
 		foreach($data as $element) {
 			if ($element->share_with == $userOrGroup && ($permissions === null || $permissions == $element->permissions)){
@@ -406,7 +406,7 @@ trait Sharing {
 	 * @param string $user1
 	 * @param string $user2
 	 */
-	public function assureFileIsShared($entry, $filepath, $user1, $user2, $withPerms = null, $permissions = null){
+	public function assureFileIsShared($entry, $filepath, $user1, $user2, $withPerms = null, $permissions = null) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" . "?path=$filepath";
 		$client = new Client();
 		$options = [];
@@ -435,7 +435,7 @@ trait Sharing {
 	 * @param string $user
 	 * @param string $group
 	 */
-	public function assureFileIsSharedWithGroup($entry, $filepath, $user, $group, $withPerms = null, $permissions = null){
+	public function assureFileIsSharedWithGroup($entry, $filepath, $user, $group, $withPerms = null, $permissions = null) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" . "?path=$filepath";
 		$client = new Client();
 		$options = [];
@@ -460,7 +460,7 @@ trait Sharing {
 	/**
 	 * @When /^Deleting last share$/
 	 */
-	public function deletingLastShare(){
+	public function deletingLastShare() {
 		$share_id = $this->lastShareData->data[0]->id;
 		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
 		$this->sendingToWith("DELETE", $url, null);
@@ -469,7 +469,7 @@ trait Sharing {
 	/**
 	 * @When /^Getting info of last share$/
 	 */
-	public function gettingInfoOfLastShare(){
+	public function gettingInfoOfLastShare() {
 		$share_id = $this->lastShareData->data[0]->id;
 		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
 		$this->sendingToWith("GET", $url, null);
@@ -478,7 +478,7 @@ trait Sharing {
 	/**
 	 * @Then /^last share_id is included in the answer$/
 	 */
-	public function checkingLastShareIDIsIncluded(){
+	public function checkingLastShareIDIsIncluded() {
 		$share_id = $this->lastShareData->data[0]->id;
 		if (!$this->isFieldInResponse('id', $share_id)){
 			Assert::fail("Share id $share_id not found in response");
@@ -488,7 +488,7 @@ trait Sharing {
 	/**
 	 * @Then /^last share_id is not included in the answer$/
 	 */
-	public function checkingLastShareIDIsNotIncluded(){
+	public function checkingLastShareIDIsNotIncluded() {
 		$share_id = $this->lastShareData->data[0]->id;
 		if ($this->isFieldInResponse('id', $share_id)){
 			Assert::fail("Share id $share_id has been found in response");
@@ -499,7 +499,7 @@ trait Sharing {
 	 * @Then /^Share fields of last share match with$/
 	 * @param TableNode|null $body
 	 */
-	public function checkShareFields($body){
+	public function checkShareFields($body) {
 		if ($body instanceof TableNode) {
 			$fd = $body->getRowsHash();
 
@@ -601,7 +601,7 @@ trait Sharing {
 	 * @param string $contentExpected
 	 * @param \SimpleXMLElement $returnedShare
 	 */
-	private function assertFieldIsInReturnedShare(string $field, string $contentExpected, \SimpleXMLElement $returnedShare){
+	private function assertFieldIsInReturnedShare(string $field, string $contentExpected, \SimpleXMLElement $returnedShare) {
 		if ($contentExpected === 'IGNORE') {
 			return;
 		}

--- a/build/license.php
+++ b/build/license.php
@@ -98,12 +98,12 @@ EOD;
 			return;
 		}
 
-		$excludes = array_map(function($item) use ($folder) {
+		$excludes = array_map(function ($item) use ($folder) {
 			return $folder . '/' . $item;
 		}, ['vendor', '3rdparty', '.git', 'l10n', 'templates', 'composer']);
 
 		$iterator = new RecursiveDirectoryIterator($folder, RecursiveDirectoryIterator::SKIP_DOTS);
-		$iterator = new RecursiveCallbackFilterIterator($iterator, function($item) use ($folder, $excludes){
+		$iterator = new RecursiveCallbackFilterIterator($iterator, function ($item) use ($folder, $excludes) {
 			/** @var SplFileInfo $item */
 			foreach($excludes as $exclude) {
 				if (substr($item->getPath(), 0, strlen($exclude)) === $exclude) {
@@ -134,7 +134,7 @@ With help from many libraries and frameworks including:
 	jQuery
 	…
 ";
-		$authors = implode(PHP_EOL, array_map(function($author){
+		$authors = implode(PHP_EOL, array_map(function ($author) {
 			return " - ".$author;
 		}, $this->authors));
 		$template = str_replace('@AUTHORS@', $authors, $template);
@@ -328,7 +328,7 @@ With help from many libraries and frameworks including:
 		}
 		$authors = explode(PHP_EOL, $out);
 
-		$authors = array_filter($authors, function($author) {
+		$authors = array_filter($authors, function ($author) {
 			return !in_array($author, [
 				'',
 				'Not Committed Yet <not.committed.yet>',
@@ -342,7 +342,7 @@ With help from many libraries and frameworks including:
 			$authors = array_unique($authors);
 		}
 
-		$authors = array_map(function($author){
+		$authors = array_map(function ($author) {
 			$author = $this->fixInvalidEmail($author);
 			$this->authors[$author] = $author;
 			return " * @author $author";

--- a/core/Command/App/CheckCode.php
+++ b/core/Command/App/CheckCode.php
@@ -94,12 +94,12 @@ class CheckCode extends Command implements CompletionAwareInterface  {
 
 		$codeChecker = new CodeChecker($checkList, !$input->getOption('skip-validate-info'));
 
-		$codeChecker->listen('CodeChecker', 'analyseFileBegin', function($params) use ($output) {
+		$codeChecker->listen('CodeChecker', 'analyseFileBegin', function ($params) use ($output) {
 			if(OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity()) {
 				$output->writeln("<info>Analysing {$params}</info>");
 			}
 		});
-		$codeChecker->listen('CodeChecker', 'analyseFileFinished', function($filename, $errors) use ($output) {
+		$codeChecker->listen('CodeChecker', 'analyseFileFinished', function ($filename, $errors) use ($output) {
 			$count = count($errors);
 
 			// show filename if the verbosity is low, but there are errors in a file
@@ -111,7 +111,7 @@ class CheckCode extends Command implements CompletionAwareInterface  {
 			if($count > 0 || OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity()) {
 				$output->writeln(" {$count} errors");
 			}
-			usort($errors, function($a, $b) {
+			usort($errors, function ($a, $b) {
 				return $a['line'] >$b['line'];
 			});
 
@@ -127,7 +127,7 @@ class CheckCode extends Command implements CompletionAwareInterface  {
 
 		if(!$input->getOption('skip-validate-info')) {
 			$infoChecker = new InfoChecker();
-			$infoChecker->listen('InfoChecker', 'parseError', function($error) use ($output) {
+			$infoChecker->listen('InfoChecker', 'parseError', function ($error) use ($output) {
 				$output->writeln("<error>Invalid appinfo.xml file found: $error</error>");
 			});
 

--- a/core/Command/Check.php
+++ b/core/Command/Check.php
@@ -52,7 +52,7 @@ class Check extends Base {
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$errors = \OC_Util::checkServer($this->config);
 		if (!empty($errors)) {
-			$errors = array_map(function($item) {
+			$errors = array_map(function ($item) {
 				return (string) $item['error'];
 			}, $errors);
 

--- a/core/Command/Encryption/ListModules.php
+++ b/core/Command/Encryption/ListModules.php
@@ -85,7 +85,7 @@ class ListModules extends Base {
 	 */
 	protected function writeModuleList(InputInterface $input, OutputInterface $output, $items) {
 		if ($input->getOption('output') === self::OUTPUT_FORMAT_PLAIN) {
-			array_walk($items, function(&$item) {
+			array_walk($items, function (&$item) {
 				if (!$item['default']) {
 					$item = $item['displayName'];
 				} else {

--- a/core/Command/Maintenance/Mimetype/GenerateMimetypeFileBuilder.php
+++ b/core/Command/Maintenance/Mimetype/GenerateMimetypeFileBuilder.php
@@ -36,7 +36,7 @@ class GenerateMimetypeFileBuilder
 	 */
 	public function generateFile(array $aliases): string {
 		// Remove comments
-		$keys = array_filter(array_keys($aliases), function($k) {
+		$keys = array_filter(array_keys($aliases), function ($k) {
 			return $k[0] === '_';
 		});
 		foreach($keys as $key) {

--- a/core/Command/TwoFactorAuth/Base.php
+++ b/core/Command/TwoFactorAuth/Base.php
@@ -54,7 +54,7 @@ class Base extends \OC\Core\Command\Base {
 	 */
 	public function completeArgumentValues($argumentName, CompletionContext $context) {
 		if ($argumentName === 'uid') {
-			return array_map(function(IUser $user) {
+			return array_map(function (IUser $user) {
 				return $user->getUID();
 			}, $this->userManager->search($context->getCurrentWord(), 100));
 		}

--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -105,7 +105,7 @@ class Upgrade extends Command {
 			$dispatcher = \OC::$server->getEventDispatcher();
 			$progress = new ProgressBar($output);
 			$progress->setFormat(" %message%\n %current%/%max% [%bar%] %percent:3s%%");
-			$listener = function($event) use ($progress, $output) {
+			$listener = function ($event) use ($progress, $output) {
 				if ($event instanceof GenericEvent) {
 					$message = $event->getSubject();
 					if (OutputInterface::VERBOSITY_NORMAL < $output->getVerbosity()) {
@@ -128,7 +128,7 @@ class Upgrade extends Command {
 					}
 				}
 			};
-			$repairListener = function($event) use ($progress, $output) {
+			$repairListener = function ($event) use ($progress, $output) {
 				if (!$event instanceof GenericEvent) {
 					return;
 				}
@@ -182,17 +182,17 @@ class Upgrade extends Command {
 			$dispatcher->addListener('\OC\Repair::error', $repairListener);
 
 
-			$updater->listen('\OC\Updater', 'maintenanceEnabled', function () use($output) {
+			$updater->listen('\OC\Updater', 'maintenanceEnabled', function () use ($output) {
 				$output->writeln('<info>Turned on maintenance mode</info>');
 			});
-			$updater->listen('\OC\Updater', 'maintenanceDisabled', function () use($output) {
+			$updater->listen('\OC\Updater', 'maintenanceDisabled', function () use ($output) {
 				$output->writeln('<info>Turned off maintenance mode</info>');
 			});
-			$updater->listen('\OC\Updater', 'maintenanceActive', function () use($output) {
+			$updater->listen('\OC\Updater', 'maintenanceActive', function () use ($output) {
 				$output->writeln('<info>Maintenance mode is kept active</info>');
 			});
 			$updater->listen('\OC\Updater', 'updateEnd',
-				function ($success) use($output, $self) {
+				function ($success) use ($output, $self) {
 					if ($success) {
 						$message = "<info>Update successful</info>";
 					} else {
@@ -200,28 +200,28 @@ class Upgrade extends Command {
 					}
 					$output->writeln($message);
 				});
-			$updater->listen('\OC\Updater', 'dbUpgradeBefore', function () use($output) {
+			$updater->listen('\OC\Updater', 'dbUpgradeBefore', function () use ($output) {
 				$output->writeln('<info>Updating database schema</info>');
 			});
-			$updater->listen('\OC\Updater', 'dbUpgrade', function () use($output) {
+			$updater->listen('\OC\Updater', 'dbUpgrade', function () use ($output) {
 				$output->writeln('<info>Updated database</info>');
 			});
-			$updater->listen('\OC\Updater', 'dbSimulateUpgradeBefore', function () use($output) {
+			$updater->listen('\OC\Updater', 'dbSimulateUpgradeBefore', function () use ($output) {
 				$output->writeln('<info>Checking whether the database schema can be updated (this can take a long time depending on the database size)</info>');
 			});
-			$updater->listen('\OC\Updater', 'dbSimulateUpgrade', function () use($output) {
+			$updater->listen('\OC\Updater', 'dbSimulateUpgrade', function () use ($output) {
 				$output->writeln('<info>Checked database schema update</info>');
 			});
-			$updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use($output) {
+			$updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use ($output) {
 				$output->writeln('<comment>Disabled incompatible app: ' . $app . '</comment>');
 			});
-			$updater->listen('\OC\Updater', 'checkAppStoreAppBefore', function ($app) use($output) {
+			$updater->listen('\OC\Updater', 'checkAppStoreAppBefore', function ($app) use ($output) {
 				$output->writeln('<info>Checking for update of app ' . $app . ' in appstore</info>');
 			});
-			$updater->listen('\OC\Updater', 'upgradeAppStoreApp', function ($app) use($output) {
+			$updater->listen('\OC\Updater', 'upgradeAppStoreApp', function ($app) use ($output) {
 				$output->writeln('<info>Update app ' . $app . ' from appstore</info>');
 			});
-			$updater->listen('\OC\Updater', 'checkAppStoreApp', function ($app) use($output) {
+			$updater->listen('\OC\Updater', 'checkAppStoreApp', function ($app) use ($output) {
 				$output->writeln('<info>Checked for update of app "' . $app . '" in appstore </info>');
 			});
 			$updater->listen('\OC\Updater', 'appUpgradeCheckBefore', function () use ($output) {
@@ -239,19 +239,19 @@ class Upgrade extends Command {
 			$updater->listen('\OC\Updater', 'appUpgrade', function ($app, $version) use ($output) {
 				$output->writeln("<info>Updated <$app> to $version</info>");
 			});
-			$updater->listen('\OC\Updater', 'failure', function ($message) use($output, $self) {
+			$updater->listen('\OC\Updater', 'failure', function ($message) use ($output, $self) {
 				$output->writeln("<error>$message</error>");
 			});
-			$updater->listen('\OC\Updater', 'setDebugLogLevel', function ($logLevel, $logLevelName) use($output) {
+			$updater->listen('\OC\Updater', 'setDebugLogLevel', function ($logLevel, $logLevelName) use ($output) {
 				$output->writeln("<info>Set log level to debug</info>");
 			});
-			$updater->listen('\OC\Updater', 'resetLogLevel', function ($logLevel, $logLevelName) use($output) {
+			$updater->listen('\OC\Updater', 'resetLogLevel', function ($logLevel, $logLevelName) use ($output) {
 				$output->writeln("<info>Reset log level</info>");
 			});
-			$updater->listen('\OC\Updater', 'startCheckCodeIntegrity', function () use($output) {
+			$updater->listen('\OC\Updater', 'startCheckCodeIntegrity', function () use ($output) {
 				$output->writeln("<info>Starting code integrity check...</info>");
 			});
-			$updater->listen('\OC\Updater', 'finishedCheckCodeIntegrity', function () use($output) {
+			$updater->listen('\OC\Updater', 'finishedCheckCodeIntegrity', function () use ($output) {
 				$output->writeln("<info>Finished code integrity check</info>");
 			});
 

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -251,7 +251,7 @@ class LostController extends Controller {
 	 * @param string $user
 	 * @return JSONResponse
 	 */
-	public function email($user){
+	public function email($user) {
 		if ($this->config->getSystemValue('lost_password_link', '') !== '') {
 			return new JSONResponse($this->error($this->l10n->t('Password reset is disabled')));
 		}

--- a/core/Controller/PreviewController.php
+++ b/core/Controller/PreviewController.php
@@ -85,7 +85,7 @@ class PreviewController extends Controller {
 	 * @param string $mode
 	 * @return DataResponse|FileDisplayResponse
 	 */
-	public function getPreview (
+	public function getPreview(
 		string $file = '',
 		int $x = 32,
 		int $y = 32,

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -128,12 +128,12 @@ if (\OCP\Util::needUpgrade()) {
 	$incompatibleApps = [];
 
 	$dispatcher = \OC::$server->getEventDispatcher();
-	$dispatcher->addListener('\OC\DB\Migrator::executeSql', function($event) use ($eventSource, $l) {
+	$dispatcher->addListener('\OC\DB\Migrator::executeSql', function ($event) use ($eventSource, $l) {
 		if ($event instanceof GenericEvent) {
 			$eventSource->send('success', (string)$l->t('[%d / %d]: %s', [$event[0], $event[1], $event->getSubject()]));
 		}
 	});
-	$dispatcher->addListener('\OC\DB\Migrator::checkTable', function($event) use ($eventSource, $l) {
+	$dispatcher->addListener('\OC\DB\Migrator::checkTable', function ($event) use ($eventSource, $l) {
 		if ($event instanceof GenericEvent) {
 			$eventSource->send('success', (string)$l->t('[%d / %d]: Checking table %s', [$event[0], $event[1], $event->getSubject()]));
 		}
@@ -156,13 +156,13 @@ if (\OCP\Util::needUpgrade()) {
 	$updater->listen('\OC\Updater', 'maintenanceActive', function () use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Maintenance mode is kept active'));
 	});
-	$updater->listen('\OC\Updater', 'dbUpgradeBefore', function () use($eventSource, $l) {
+	$updater->listen('\OC\Updater', 'dbUpgradeBefore', function () use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Updating database schema'));
 	});
 	$updater->listen('\OC\Updater', 'dbUpgrade', function () use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Updated database'));
 	});
-	$updater->listen('\OC\Updater', 'dbSimulateUpgradeBefore', function () use($eventSource, $l) {
+	$updater->listen('\OC\Updater', 'dbSimulateUpgradeBefore', function () use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Checking whether the database schema can be updated (this can take a long time depending on the database size)'));
 	});
 	$updater->listen('\OC\Updater', 'dbSimulateUpgrade', function () use ($eventSource, $l) {
@@ -197,16 +197,16 @@ if (\OCP\Util::needUpgrade()) {
 		$eventSource->close();
 		$config->setSystemValue('maintenance', false);
 	});
-	$updater->listen('\OC\Updater', 'setDebugLogLevel', function ($logLevel, $logLevelName) use($eventSource, $l) {
+	$updater->listen('\OC\Updater', 'setDebugLogLevel', function ($logLevel, $logLevelName) use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Set log level to debug'));
 	});
-	$updater->listen('\OC\Updater', 'resetLogLevel', function ($logLevel, $logLevelName) use($eventSource, $l) {
+	$updater->listen('\OC\Updater', 'resetLogLevel', function ($logLevel, $logLevelName) use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Reset log level'));
 	});
-	$updater->listen('\OC\Updater', 'startCheckCodeIntegrity', function () use($eventSource, $l) {
+	$updater->listen('\OC\Updater', 'startCheckCodeIntegrity', function () use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Starting code integrity check'));
 	});
-	$updater->listen('\OC\Updater', 'finishedCheckCodeIntegrity', function () use($eventSource, $l) {
+	$updater->listen('\OC\Updater', 'finishedCheckCodeIntegrity', function () use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Finished code integrity check'));
 	});
 

--- a/lib/private/Accounts/Account.php
+++ b/lib/private/Accounts/Account.php
@@ -60,7 +60,7 @@ class Account implements IAccount {
 	}
 
 	public function getFilteredProperties(string $scope = null, string $verified = null): array {
-		return \array_filter($this->properties, function(IAccountProperty $obj) use ($scope, $verified){
+		return \array_filter($this->properties, function (IAccountProperty $obj) use ($scope, $verified) {
 			if ($scope !== null && $scope !== $obj->getScope()) {
 				return false;
 			}

--- a/lib/private/App/CodeChecker/CodeChecker.php
+++ b/lib/private/App/CodeChecker/CodeChecker.php
@@ -89,12 +89,12 @@ class CodeChecker extends BasicEmitter {
 			$excludedDirectories[] = 'lists';
 		}
 
-		$excludes = array_map(function($item) use ($folder) {
+		$excludes = array_map(function ($item) use ($folder) {
 			return $folder . '/' . $item;
 		}, $excludedDirectories);
 
 		$iterator = new RecursiveDirectoryIterator($folder, RecursiveDirectoryIterator::SKIP_DOTS);
-		$iterator = new RecursiveCallbackFilterIterator($iterator, function($item) use ($excludes){
+		$iterator = new RecursiveCallbackFilterIterator($iterator, function ($item) use ($excludes) {
 			/** @var SplFileInfo $item */
 			foreach($excludes as $exclude) {
 				if (substr($item->getPath(), 0, strlen($exclude)) === $exclude) {

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -284,7 +284,7 @@ class AppConfig implements IAppConfig {
 			return $this->getAppValues($app);
 		} else {
 			$appIds = $this->getApps();
-			$values = array_map(function($appId) use ($key) {
+			$values = array_map(function ($appId) use ($key) {
 				return isset($this->cache[$appId][$key]) ? $this->cache[$appId][$key] : null;
 			}, $appIds);
 			$result = array_combine($appIds, $values);

--- a/lib/private/AppFramework/App.php
+++ b/lib/private/AppFramework/App.php
@@ -199,7 +199,7 @@ class App {
 	 * @param DIContainer $container an instance of a pimple container.
 	 */
 	public static function part(string $controllerName, string $methodName, array $urlParams,
-								DIContainer $container){
+								DIContainer $container) {
 
 		$container['urlParams'] = $urlParams;
 		$controller = $container[$controllerName];

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -83,7 +83,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 	 * @param array $urlParams
 	 * @param ServerContainer|null $server
 	 */
-	public function __construct($appName, $urlParams = [], ServerContainer $server = null){
+	public function __construct($appName, $urlParams = [], ServerContainer $server = null) {
 		parent::__construct();
 		$this['AppName'] = $appName;
 		$this['urlParams'] = $urlParams;
@@ -105,11 +105,11 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		/**
 		 * Core services
 		 */
-		$this->registerService(IOutput::class, function(){
+		$this->registerService(IOutput::class, function () {
 			return new Output($this->getServer()->getWebRoot());
 		});
 
-		$this->registerService(Folder::class, function() {
+		$this->registerService(Folder::class, function () {
 			return $this->getServer()->getUserFolder();
 		});
 
@@ -117,7 +117,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return $this->getServer()->getAppDataDir($c->query('AppName'));
 		});
 
-		$this->registerService(IL10N::class, function($c) {
+		$this->registerService(IL10N::class, function ($c) {
 			return $this->getServer()->getL10N($c->query('AppName'));
 		});
 
@@ -156,14 +156,14 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return $c->query(OC\GlobalScale\Config::class);
 		});
 
-		$this->registerService('Protocol', function($c){
+		$this->registerService('Protocol', function ($c) {
 			/** @var \OC\Server $server */
 			$server = $c->query('ServerContainer');
 			$protocol = $server->getRequest()->getHttpProtocol();
 			return new Http($_SERVER, $protocol);
 		});
 
-		$this->registerService('Dispatcher', function($c) {
+		$this->registerService('Dispatcher', function ($c) {
 			return new Dispatcher(
 				$c['Protocol'],
 				$c['MiddlewareDispatcher'],
@@ -182,7 +182,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		/**
 		 * Middleware
 		 */
-		$this->registerService('MiddlewareDispatcher', function(SimpleContainer $c) {
+		$this->registerService('MiddlewareDispatcher', function (SimpleContainer $c) {
 			$server =  $this->getServer();
 
 			$dispatcher = new MiddlewareDispatcher();
@@ -376,7 +376,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 	 * @param string $serviceName e.g. 'OCA\Files\Capabilities'
 	 */
 	public function registerCapability($serviceName) {
-		$this->query('OC\CapabilitiesManager')->registerCapability(function() use ($serviceName) {
+		$this->query('OC\CapabilitiesManager')->registerCapability(function () use ($serviceName) {
 			return $this->query($serviceName);
 		});
 	}

--- a/lib/private/AppFramework/Middleware/MiddlewareDispatcher.php
+++ b/lib/private/AppFramework/Middleware/MiddlewareDispatcher.php
@@ -55,7 +55,7 @@ class MiddlewareDispatcher {
 	/**
 	 * Constructor
 	 */
-	public function __construct(){
+	public function __construct() {
 		$this->middlewares = [];
 		$this->middlewareCounter = 0;
 	}
@@ -65,7 +65,7 @@ class MiddlewareDispatcher {
 	 * Adds a new middleware
 	 * @param Middleware $middleWare the middleware which will be added
 	 */
-	public function registerMiddleware(Middleware $middleWare){
+	public function registerMiddleware(Middleware $middleWare) {
 		$this->middlewares[] = $middleWare;
 	}
 
@@ -87,7 +87,7 @@ class MiddlewareDispatcher {
 	 * @param string $methodName the name of the method that will be called on
 	 *                           the controller
 	 */
-	public function beforeController(Controller $controller, string $methodName){
+	public function beforeController(Controller $controller, string $methodName) {
 		// we need to count so that we know which middlewares we have to ask in
 		// case there is an exception
 		$middlewareCount = \count($this->middlewares);

--- a/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
@@ -80,7 +80,7 @@ class CORSMiddleware extends Middleware {
 	 * @throws SecurityException
 	 * @since 6.0.0
 	 */
-	public function beforeController($controller, $methodName){
+	public function beforeController($controller, $methodName) {
 		// ensure that @CORS annotated API routes are not used in conjunction
 		// with session authentication since this enables CSRF attack vectors
 		if ($this->reflector->hasAnnotation('CORS') &&
@@ -110,7 +110,7 @@ class CORSMiddleware extends Middleware {
 	 * @return Response a Response object
 	 * @throws SecurityException
 	 */
-	public function afterController($controller, $methodName, Response $response){
+	public function afterController($controller, $methodName, Response $response) {
 		// only react if its a CORS request and if the request sends origin and
 
 		if(isset($this->request->server['HTTP_ORIGIN']) &&
@@ -143,7 +143,7 @@ class CORSMiddleware extends Middleware {
 	 * @throws \Exception the passed in exception if it can't handle it
 	 * @return Response a Response object or null in case that the exception could not be handled
 	 */
-	public function afterException($controller, $methodName, \Exception $exception){
+	public function afterException($controller, $methodName, \Exception $exception) {
 		if($exception instanceof SecurityException){
 			$response =  new JSONResponse(['message' => $exception->getMessage()]);
 			if($exception->getCode() !== 0) {

--- a/lib/private/AppFramework/Middleware/SessionMiddleware.php
+++ b/lib/private/AppFramework/Middleware/SessionMiddleware.php
@@ -62,7 +62,7 @@ class SessionMiddleware extends Middleware {
 	 * @param Response $response
 	 * @return Response
 	 */
-	public function afterController($controller, $methodName, Response $response){
+	public function afterController($controller, $methodName, Response $response) {
 		$useSession = $this->reflector->hasAnnotation('UseSession');
 		if ($useSession) {
 			$this->session->close();

--- a/lib/private/AppFramework/Utility/ControllerMethodReflector.php
+++ b/lib/private/AppFramework/Utility/ControllerMethodReflector.php
@@ -46,7 +46,7 @@ class ControllerMethodReflector implements IControllerMethodReflector {
 	 * @param object $object an object or classname
 	 * @param string $method the method which we want to inspect
 	 */
-	public function reflect($object, string $method){
+	public function reflect($object, string $method) {
 		$reflection = new \ReflectionMethod($object, $method);
 		$docs = $reflection->getDocComment();
 

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -140,7 +140,7 @@ class Manager {
 	 */
 	public function getLoginSetupProviders(IUser $user): array {
 		$providers = $this->providerLoader->getProviders($user);
-		return array_filter($providers, function(IProvider $provider) {
+		return array_filter($providers, function (IProvider $provider) {
 			return ($provider instanceof IActivatableAtLogin);
 		});
 	}

--- a/lib/private/Authentication/TwoFactorAuth/ProviderSet.php
+++ b/lib/private/Authentication/TwoFactorAuth/ProviderSet.php
@@ -72,7 +72,7 @@ class ProviderSet {
 	 * @return IProvider[]
 	 */
 	public function getPrimaryProviders(): array {
-		return array_filter($this->providers, function(IProvider $provider) {
+		return array_filter($this->providers, function (IProvider $provider) {
 			return !($provider instanceof BackupCodesProvider);
 		});
 	}

--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -162,7 +162,7 @@ class UserPlugin implements ISearchPlugin {
 
 				if ($this->shareWithGroupOnly) {
 					// Only add, if we have a common group
-					$userGroupIds = array_map(function(IGroup $group) {
+					$userGroupIds = array_map(function (IGroup $group) {
 						return $group->getGID();
 					}, $userGroups);
 					$commonGroups = array_intersect($userGroupIds, $this->groupManager->getUserGroupIds($user));

--- a/lib/private/Collaboration/Resources/Collection.php
+++ b/lib/private/Collaboration/Resources/Collection.php
@@ -126,7 +126,7 @@ class Collection implements ICollection {
 	 * @since 16.0.0
 	 */
 	public function addResource(IResource $resource): void {
-		array_map(function(IResource $r) use ($resource) {
+		array_map(function (IResource $r) use ($resource) {
 			if ($this->isSameResource($r, $resource)) {
 				throw new ResourceException('Already part of the collection');
 			}
@@ -158,7 +158,7 @@ class Collection implements ICollection {
 	 * @since 16.0.0
 	 */
 	public function removeResource(IResource $resource): void {
-		$this->resources = array_filter($this->getResources(), function(IResource $r) use ($resource) {
+		$this->resources = array_filter($this->getResources(), function (IResource $r) use ($resource) {
 			return !$this->isSameResource($r, $resource);
 		});
 

--- a/lib/private/Collaboration/Resources/Listener.php
+++ b/lib/private/Collaboration/Resources/Listener.php
@@ -36,7 +36,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 class Listener {
 
 	public static function register(EventDispatcherInterface $dispatcher): void {
-		$listener = function(GenericEvent $event) {
+		$listener = function (GenericEvent $event) {
 			/** @var IUser $user */
 			$user = $event->getArgument('user');
 			/** @var IManager $resourceManager */
@@ -47,7 +47,7 @@ class Listener {
 		$dispatcher->addListener(IGroup::class . '::postAddUser', $listener);
 		$dispatcher->addListener(IGroup::class . '::postRemoveUser', $listener);
 
-		$dispatcher->addListener(IUser::class . '::postDelete', function(GenericEvent $event) {
+		$dispatcher->addListener(IUser::class . '::postDelete', function (GenericEvent $event) {
 			/** @var IUser $user */
 			$user = $event->getSubject();
 			/** @var IManager $resourceManager */
@@ -56,7 +56,7 @@ class Listener {
 			$resourceManager->invalidateAccessCacheForUser($user);
 		});
 
-		$dispatcher->addListener(IGroup::class . '::preDelete', function(GenericEvent $event) {
+		$dispatcher->addListener(IGroup::class . '::preDelete', function (GenericEvent $event) {
 			/** @var IGroup $group */
 			$group = $event->getSubject();
 			/** @var IManager $resourceManager */

--- a/lib/private/Command/FileAccess.php
+++ b/lib/private/Command/FileAccess.php
@@ -25,7 +25,7 @@ namespace OC\Command;
 use OCP\IUser;
 
 trait FileAccess {
-	protected function setupFS(IUser $user){
+	protected function setupFS(IUser $user) {
 		\OC_Util::setupFS($user->getUID());
 	}
 

--- a/lib/private/Contacts/ContactsMenu/ActionProviderStore.php
+++ b/lib/private/Contacts/ContactsMenu/ActionProviderStore.php
@@ -94,7 +94,7 @@ class ActionProviderStore {
 	 * @return string[]
 	 */
 	private function getAppProviderClasses(IUser $user) {
-		return array_reduce($this->appManager->getEnabledAppsForUser($user), function($all, $appId) {
+		return array_reduce($this->appManager->getEnabledAppsForUser($user), function ($all, $appId) {
 			$info = $this->appManager->getAppInfo($appId);
 
 			if (!isset($info['contactsmenu']) || !isset($info['contactsmenu'])) {
@@ -102,7 +102,7 @@ class ActionProviderStore {
 				return $all;
 			}
 
-			$providers = array_reduce($info['contactsmenu'], function($all, $provider) {
+			$providers = array_reduce($info['contactsmenu'], function ($all, $provider) {
 				return array_merge($all, [$provider]);
 			}, []);
 

--- a/lib/private/Contacts/ContactsMenu/ContactsStore.php
+++ b/lib/private/Contacts/ContactsMenu/ContactsStore.php
@@ -78,7 +78,7 @@ class ContactsStore implements IContactsStore {
 			'EMAIL'
 		]);
 
-		$entries = array_map(function(array $contact) {
+		$entries = array_map(function (array $contact) {
 			return $this->contactArrayToEntry($contact);
 		}, $allContacts);
 		return $this->filterContacts(
@@ -131,7 +131,7 @@ class ContactsStore implements IContactsStore {
 
 		$selfUID = $self->getUID();
 
-		return array_values(array_filter($entries, function(IEntry $entry) use ($self, $skipLocal, $ownGroupsOnly, $selfGroups, $selfUID, $disallowEnumeration, $filter) {
+		return array_values(array_filter($entries, function (IEntry $entry) use ($self, $skipLocal, $ownGroupsOnly, $selfGroups, $selfUID, $disallowEnumeration, $filter) {
 			if ($skipLocal && $entry->getProperty('isLocalSystemBook') === true) {
 				return false;
 			}
@@ -196,7 +196,7 @@ class ContactsStore implements IContactsStore {
 
 		$userId = $user->getUID();
 		$allContacts = $this->contactsManager->search($shareWith, $filter);
-		$contacts = array_filter($allContacts, function($contact) use ($userId) {
+		$contacts = array_filter($allContacts, function ($contact) use ($userId) {
 			return $contact['UID'] !== $userId;
 		});
 		$match = null;

--- a/lib/private/Contacts/ContactsMenu/Entry.php
+++ b/lib/private/Contacts/ContactsMenu/Entry.php
@@ -114,7 +114,7 @@ class Entry implements IEntry {
 	 * sort the actions by priority and name
 	 */
 	private function sortActions() {
-		usort($this->actions, function(IAction $action1, IAction $action2) {
+		usort($this->actions, function (IAction $action1, IAction $action2) {
 			$prio1 = $action1->getPriority();
 			$prio2 = $action2->getPriority();
 
@@ -151,7 +151,7 @@ class Entry implements IEntry {
 	 */
 	public function jsonSerialize() {
 		$topAction = !empty($this->actions) ? $this->actions[0]->jsonSerialize() : null;
-		$otherActions = array_map(function(IAction $action) {
+		$otherActions = array_map(function (IAction $action) {
 			return $action->jsonSerialize();
 		}, array_slice($this->actions, 1));
 

--- a/lib/private/Contacts/ContactsMenu/Manager.php
+++ b/lib/private/Contacts/ContactsMenu/Manager.php
@@ -100,7 +100,7 @@ class Manager {
 	 * @return IEntry[]
 	 */
 	private function sortEntries(array $entries) {
-		usort($entries, function(IEntry $entryA, IEntry $entryB) {
+		usort($entries, function (IEntry $entryA, IEntry $entryB) {
 			return strcasecmp($entryA->getFullName(), $entryB->getFullName());
 		});
 		return $entries;

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -160,7 +160,7 @@ class Connection extends ReconnectWrapper implements IDBConnection {
 	 * @param int $offset
 	 * @return \Doctrine\DBAL\Driver\Statement The prepared statement.
 	 */
-	public function prepare( $statement, $limit=null, $offset=null ) {
+	public function prepare($statement, $limit=null, $offset=null) {
 		if ($limit === -1) {
 			$limit = null;
 		}
@@ -289,7 +289,7 @@ class Connection extends ReconnectWrapper implements IDBConnection {
 			$insertQb = $this->getQueryBuilder();
 			$insertQb->insert($table)
 				->values(
-					array_map(function($value) use ($insertQb) {
+					array_map(function ($value) use ($insertQb) {
 						return $insertQb->createNamedParameter($value, $this->getType($value));
 					}, array_merge($keys, $values))
 				);
@@ -383,7 +383,7 @@ class Connection extends ReconnectWrapper implements IDBConnection {
 	 * @param string $table table name without the prefix
 	 * @return bool
 	 */
-	public function tableExists($table){
+	public function tableExists($table) {
 		$table = $this->tablePrefix . trim($table);
 		$schema = $this->getSchemaManager();
 		return $schema->tablesExist([$table]);

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -468,12 +468,12 @@ class MigrationService {
 		$instance = $this->createInstance($version);
 
 		if (!$schemaOnly) {
-			$instance->preSchemaChange($this->output, function() {
+			$instance->preSchemaChange($this->output, function () {
 				return new SchemaWrapper($this->connection);
 			}, ['tablePrefix' => $this->connection->getPrefix()]);
 		}
 
-		$toSchema = $instance->changeSchema($this->output, function() {
+		$toSchema = $instance->changeSchema($this->output, function () {
 			return new SchemaWrapper($this->connection);
 		}, ['tablePrefix' => $this->connection->getPrefix()]);
 
@@ -488,7 +488,7 @@ class MigrationService {
 		}
 
 		if (!$schemaOnly) {
-			$instance->postSchemaChange($this->output, function() {
+			$instance->postSchemaChange($this->output, function () {
 				return new SchemaWrapper($this->connection);
 			}, ['tablePrefix' => $this->connection->getPrefix()]);
 		}
@@ -538,7 +538,7 @@ class MigrationService {
 
 					if ($isUsingDefaultName) {
 						$sequenceName = $table->getName() . '_' . implode('_', $primaryKey->getColumns()) . '_seq';
-						$sequences = array_filter($sequences, function(Sequence $sequence) use ($sequenceName) {
+						$sequences = array_filter($sequences, function (Sequence $sequence) use ($sequenceName) {
 							return $sequence->getName() !== $sequenceName;
 						});
 					}

--- a/lib/private/DB/OracleConnection.php
+++ b/lib/private/DB/OracleConnection.php
@@ -98,7 +98,7 @@ class OracleConnection extends Connection {
 	 * @param string $table table name without the prefix
 	 * @return bool
 	 */
-	public function tableExists($table){
+	public function tableExists($table) {
 		$table = $this->tablePrefix . trim($table);
 		$table = $this->quoteIdentifier($table);
 		$schema = $this->getSchemaManager();

--- a/lib/private/DB/OracleMigrator.php
+++ b/lib/private/DB/OracleMigrator.php
@@ -77,7 +77,7 @@ class OracleMigrator extends Migrator {
 		return new Index(
 		//TODO migrate existing uppercase indexes, then $this->connection->quoteIdentifier($index->getName()),
 			$index->getName(),
-			array_map(function($columnName) {
+			array_map(function ($columnName) {
 				return $this->connection->quoteIdentifier($columnName);
 			}, $index->getColumns()),
 			$index->isUnique(),
@@ -96,11 +96,11 @@ class OracleMigrator extends Migrator {
 	 */
 	protected function quoteForeignKeyConstraint($fkc) {
 		return new ForeignKeyConstraint(
-			array_map(function($columnName) {
+			array_map(function ($columnName) {
 				return $this->connection->quoteIdentifier($columnName);
 			}, $fkc->getLocalColumns()),
 			$this->connection->quoteIdentifier($fkc->getForeignTableName()),
-			array_map(function($columnName) {
+			array_map(function ($columnName) {
 				return $this->connection->quoteIdentifier($columnName);
 			}, $fkc->getForeignColumns()),
 			$fkc->getName(),
@@ -118,16 +118,16 @@ class OracleMigrator extends Migrator {
 		$schemaDiff = parent::getDiff($targetSchema, $connection);
 
 		// oracle forces us to quote the identifiers
-		$schemaDiff->newTables = array_map(function(Table $table) {
+		$schemaDiff->newTables = array_map(function (Table $table) {
 			return new Table(
 				$this->connection->quoteIdentifier($table->getName()),
-				array_map(function(Column $column) {
+				array_map(function (Column $column) {
 					return $this->quoteColumn($column);
 				}, $table->getColumns()),
-				array_map(function(Index $index) {
+				array_map(function (Index $index) {
 					return $this->quoteIndex($index);
 				}, $table->getIndexes()),
-				array_map(function(ForeignKeyConstraint $fck) {
+				array_map(function (ForeignKeyConstraint $fck) {
 					return $this->quoteForeignKeyConstraint($fck);
 				}, $table->getForeignKeys()),
 				0,
@@ -135,7 +135,7 @@ class OracleMigrator extends Migrator {
 			);
 		}, $schemaDiff->newTables);
 
-		$schemaDiff->removedTables = array_map(function(Table $table) {
+		$schemaDiff->removedTables = array_map(function (Table $table) {
 			return new Table(
 				$this->connection->quoteIdentifier($table->getName()),
 				$table->getColumns(),
@@ -149,7 +149,7 @@ class OracleMigrator extends Migrator {
 		foreach ($schemaDiff->changedTables as $tableDiff) {
 			$tableDiff->name = $this->connection->quoteIdentifier($tableDiff->name);
 
-			$tableDiff->addedColumns = array_map(function(Column $column) {
+			$tableDiff->addedColumns = array_map(function (Column $column) {
 				return $this->quoteColumn($column);
 			}, $tableDiff->addedColumns);
 
@@ -163,39 +163,39 @@ class OracleMigrator extends Migrator {
 				return count($column->changedProperties) > 0;
 			});
 
-			$tableDiff->removedColumns = array_map(function(Column $column) {
+			$tableDiff->removedColumns = array_map(function (Column $column) {
 				return $this->quoteColumn($column);
 			}, $tableDiff->removedColumns);
 
-			$tableDiff->renamedColumns = array_map(function(Column $column) {
+			$tableDiff->renamedColumns = array_map(function (Column $column) {
 				return $this->quoteColumn($column);
 			}, $tableDiff->renamedColumns);
 
-			$tableDiff->addedIndexes = array_map(function(Index $index) {
+			$tableDiff->addedIndexes = array_map(function (Index $index) {
 				return $this->quoteIndex($index);
 			}, $tableDiff->addedIndexes);
 
-			$tableDiff->changedIndexes = array_map(function(Index $index) {
+			$tableDiff->changedIndexes = array_map(function (Index $index) {
 				return $this->quoteIndex($index);
 			}, $tableDiff->changedIndexes);
 
-			$tableDiff->removedIndexes = array_map(function(Index $index) {
+			$tableDiff->removedIndexes = array_map(function (Index $index) {
 				return $this->quoteIndex($index);
 			}, $tableDiff->removedIndexes);
 
-			$tableDiff->renamedIndexes = array_map(function(Index $index) {
+			$tableDiff->renamedIndexes = array_map(function (Index $index) {
 				return $this->quoteIndex($index);
 			}, $tableDiff->renamedIndexes);
 
-			$tableDiff->addedForeignKeys = array_map(function(ForeignKeyConstraint $fkc) {
+			$tableDiff->addedForeignKeys = array_map(function (ForeignKeyConstraint $fkc) {
 				return $this->quoteForeignKeyConstraint($fkc);
 			}, $tableDiff->addedForeignKeys);
 
-			$tableDiff->changedForeignKeys = array_map(function(ForeignKeyConstraint $fkc) {
+			$tableDiff->changedForeignKeys = array_map(function (ForeignKeyConstraint $fkc) {
 				return $this->quoteForeignKeyConstraint($fkc);
 			}, $tableDiff->changedForeignKeys);
 
-			$tableDiff->removedForeignKeys = array_map(function(ForeignKeyConstraint $fkc) {
+			$tableDiff->removedForeignKeys = array_map(function (ForeignKeyConstraint $fkc) {
 				return $this->quoteForeignKeyConstraint($fkc);
 			}, $tableDiff->removedForeignKeys);
 		}

--- a/lib/private/DB/SchemaWrapper.php
+++ b/lib/private/DB/SchemaWrapper.php
@@ -64,7 +64,7 @@ class SchemaWrapper implements ISchemaWrapper {
 	 */
 	public function getTableNamesWithoutPrefix() {
 		$tableNames = $this->schema->getTableNames();
-		return array_map(function($tableName) {
+		return array_map(function ($tableName) {
 			if (strpos($tableName, $this->connection->getPrefix()) === 0) {
 				return substr($tableName, strlen($this->connection->getPrefix()));
 			}

--- a/lib/private/Encryption/Util.php
+++ b/lib/private/Encryption/Util.php
@@ -275,7 +275,7 @@ class Util {
 		$result = [];
 		if (in_array('all', $users)) {
 			$users = $this->userManager->search('', null, null);
-			$result = array_map(function(IUser $user) {
+			$result = array_map(function (IUser $user) {
 				return $user->getUID();
 			}, $users);
 		} else {

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -554,7 +554,7 @@ class Cache implements ICache {
 	 */
 	private function removeChildren(ICacheEntry $entry) {
 		$children = $this->getFolderContentsById($entry->getId());
-		$childIds = array_map(function(ICacheEntry $cacheEntry) {
+		$childIds = array_map(function (ICacheEntry $cacheEntry) {
 			return $cacheEntry->getId();
 		}, $children);
 		$childFolders = array_filter($children, function ($child) {

--- a/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
@@ -41,7 +41,7 @@ class HomeObjectStoreStorage extends ObjectStoreStorage implements \OCP\Files\IH
 		parent::__construct($params);
 	}
 
-	public function getId () {
+	public function getId() {
 		return 'object::user:' . $this->user->getUID();
 	}
 

--- a/lib/private/Files/SimpleFS/SimpleFolder.php
+++ b/lib/private/Files/SimpleFS/SimpleFolder.php
@@ -51,7 +51,7 @@ class SimpleFolder implements ISimpleFolder   {
 	public function getDirectoryListing() {
 		$listing = $this->folder->getDirectoryListing();
 
-		$fileListing = array_map(function(Node $file) {
+		$fileListing = array_map(function (Node $file) {
 			if ($file instanceof File) {
 				return new SimpleFile($file);
 			}

--- a/lib/private/Files/Storage/CommonTest.php
+++ b/lib/private/Files/Storage/CommonTest.php
@@ -43,7 +43,7 @@ class CommonTest extends \OC\Files\Storage\Common{
 		$this->storage=new \OC\Files\Storage\Local($params);
 	}
 
-	public function getId(){
+	public function getId() {
 		return 'test::'.$this->storage->getId();
 	}
 	public function mkdir($path) {

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1454,7 +1454,7 @@ class View {
 
 			$sharingDisabled = \OCP\Util::isSharingDisabledForUser();
 
-			$fileNames = array_map(function(ICacheEntry $content) {
+			$fileNames = array_map(function (ICacheEntry $content) {
 				return $content->getName();
 			}, $contents);
 			/**
@@ -1735,7 +1735,7 @@ class View {
 
 		// put non shared mounts in front of the shared mount
 		// this prevent unneeded recursion into shares
-		usort($mounts, function(IMountPoint $a, IMountPoint $b) {
+		usort($mounts, function (IMountPoint $a, IMountPoint $b) {
 			return $a instanceof SharedMount && (!$b instanceof SharedMount) ? 1 : -1;
 		});
 

--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -165,7 +165,7 @@ class Database extends ABackend
 	 *
 	 * Checks whether the user is member of a group or not.
 	 */
-	public function inGroup( $uid, $gid ) {
+	public function inGroup($uid, $gid) {
 		$this->fixDI();
 
 		// check
@@ -234,7 +234,7 @@ class Database extends ABackend
 	 * This function fetches all groups a user belongs to. It does not check
 	 * if the user exists at all.
 	 */
-	public function getUserGroups( $uid ) {
+	public function getUserGroups($uid) {
 		//guests has empty or null $uid
 		if ($uid === null || $uid === '') {
 			return [];

--- a/lib/private/Group/Group.php
+++ b/lib/private/Group/Group.php
@@ -398,7 +398,7 @@ class Group implements IGroup {
 	 * @since 16.0.0
 	 */
 	public function hideFromCollaboration(): bool {
-		return array_reduce($this->backends, function(bool $hide, GroupInterface $backend) {
+		return array_reduce($this->backends, function (bool $hide, GroupInterface $backend) {
 			return $hide | ($backend instanceof IHideFromCollaborationBackend && $backend->hideGroup($this->gid));
 		}, false);
 	}

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -114,7 +114,7 @@ class Factory implements IFactory {
 	 * @return \OCP\IL10N
 	 */
 	public function get($app, $lang = null, $locale = null) {
-		return new LazyL10N(function() use ($app, $lang, $locale) {
+		return new LazyL10N(function () use ($app, $lang, $locale) {
 
 			$app = \OC_App::cleanAppId($app);
 			if ($lang !== null) {
@@ -369,7 +369,7 @@ class Factory implements IFactory {
 		}
 
 		$locales = $this->findAvailableLocales();
-		$userLocale = array_filter($locales, function($value) use ($locale) {
+		$userLocale = array_filter($locales, function ($value) use ($locale) {
 			return $locale === $value['code'];
 		});
 

--- a/lib/private/L10N/L10N.php
+++ b/lib/private/L10N/L10N.php
@@ -221,7 +221,7 @@ class L10N implements IL10N {
 	public function getPluralFormFunction(): \Closure {
 		if (\is_null($this->pluralFormFunction)) {
 			$lang = $this->getLanguageCode();
-			$this->pluralFormFunction = function($n) use ($lang) {
+			$this->pluralFormFunction = function ($n) use ($lang) {
 				return PluralizationRules::get($n, $lang);
 			};
 		}

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -120,7 +120,7 @@ class NavigationManager implements INavigationManager {
 
 		$result = $this->entries;
 		if ($type !== 'all') {
-			$result = array_filter($this->entries, function($entry) use ($type) {
+			$result = array_filter($this->entries, function ($entry) use ($type) {
 				return $entry['type'] === $type;
 			});
 		}
@@ -135,7 +135,7 @@ class NavigationManager implements INavigationManager {
 	 * @return array
 	 */
 	private function proceedNavigation(array $list): array {
-		uasort($list, function($a, $b) {
+		uasort($list, function ($a, $b) {
 			if (isset($a['order']) && isset($b['order'])) {
 				return ($a['order'] < $b['order']) ? -1 : 1;
 			} else if (isset($a['order']) || isset($b['order'])) {

--- a/lib/private/Route/Route.php
+++ b/lib/private/Route/Route.php
@@ -149,7 +149,7 @@ class Route extends SymfonyRoute implements IRoute {
 	 * @return void
 	 */
 	public function actionInclude($file) {
-		$function = function($param) use ($file) {
+		$function = function ($param) use ($file) {
 			unset($param["_route"]);
 			$_GET=array_merge($_GET, $param);
 			unset($param);

--- a/lib/private/Search/Result/File.php
+++ b/lib/private/Search/Result/File.php
@@ -106,7 +106,7 @@ class File extends \OCP\Search\Result {
 	 * @param string $path
 	 * @return string relative path
 	 */
-	protected function getRelativePath ($path) {
+	protected function getRelativePath($path) {
 		if (!isset(self::$userFolderCache)) {
 			$user = \OC::$server->getUserSession()->getUser()->getUID();
 			self::$userFolderCache = \OC::$server->getUserFolder($user);

--- a/lib/private/Security/Bruteforce/Throttler.php
+++ b/lib/private/Security/Bruteforce/Throttler.php
@@ -144,7 +144,7 @@ class Throttler {
 		}
 
 		$keys = $this->config->getAppKeys('bruteForce');
-		$keys = array_filter($keys, function($key) {
+		$keys = array_filter($keys, function ($key) {
 			$regex = '/^whitelist_/S';
 			return preg_match($regex, $key) === 1;
 		});

--- a/lib/private/Security/TrustedDomainHelper.php
+++ b/lib/private/Security/TrustedDomainHelper.php
@@ -98,7 +98,7 @@ class TrustedDomainHelper {
 			if (gettype($trusted) !== 'string') {
 				break;
 			}
-			$regex = '/^' . implode('[-\.a-zA-Z0-9]*', array_map(function($v) { return preg_quote($v, '/'); }, explode('*', $trusted))) . '$/i';
+			$regex = '/^' . implode('[-\.a-zA-Z0-9]*', array_map(function ($v) { return preg_quote($v, '/'); }, explode('*', $trusted))) . '$/i';
 			if (preg_match($regex, $domain) || preg_match($regex, $domainWithPort)) {
 				return true;
 			}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -700,7 +700,7 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 		$this->registerAlias(IValidator::class, Validator::class);
 
-		$this->registerService(AvatarManager::class, function(Server $c) {
+		$this->registerService(AvatarManager::class, function (Server $c) {
 			return new AvatarManager(
 				$c->query(\OC\User\Manager::class),
 				$c->getAppDataDir('avatar'),
@@ -1085,7 +1085,7 @@ class Server extends ServerContainer implements IServerContainer {
 			$factory = new $factoryClass($this);
 			$manager = $factory->getManager();
 
-			$manager->registerDisplayNameResolver('user', function($id) use ($c) {
+			$manager->registerDisplayNameResolver('user', function ($id) use ($c) {
 				$manager = $c->getUserManager();
 				$user = $manager->get($id);
 				if(is_null($user)) {
@@ -1231,7 +1231,7 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 		$this->registerDeprecatedAlias('ShareManager', \OCP\Share\IManager::class);
 
-		$this->registerService(\OCP\Collaboration\Collaborators\ISearch::class, function(Server $c) {
+		$this->registerService(\OCP\Collaboration\Collaborators\ISearch::class, function (Server $c) {
 			$instance = new Collaboration\Collaborators\Search($c);
 
 			// register default plugins
@@ -1316,7 +1316,7 @@ class Server extends ServerContainer implements IServerContainer {
 			);
 		});
 
-		$this->registerService(Installer::class, function(Server $c) {
+		$this->registerService(Installer::class, function (Server $c) {
 			return new Installer(
 				$c->getAppFetcher(),
 				$c->getHTTPClientService(),
@@ -1327,16 +1327,16 @@ class Server extends ServerContainer implements IServerContainer {
 			);
 		});
 
-		$this->registerService(IApiFactory::class, function(Server $c) {
+		$this->registerService(IApiFactory::class, function (Server $c) {
 			return new ApiFactory($c->getHTTPClientService());
 		});
 
-		$this->registerService(IInstanceFactory::class, function(Server $c) {
+		$this->registerService(IInstanceFactory::class, function (Server $c) {
 			$memcacheFactory = $c->getMemCacheFactory();
 			return new InstanceFactory($memcacheFactory->createLocal('remoteinstance.'), $c->getHTTPClientService());
 		});
 
-		$this->registerService(IContactsStore::class, function(Server $c) {
+		$this->registerService(IContactsStore::class, function (Server $c) {
 			return new ContactsStore(
 				$c->getContactsManager(),
 				$c->getConfig(),
@@ -1347,7 +1347,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerAlias(IContactsStore::class, ContactsStore::class);
 		$this->registerAlias(IAccountManager::class, AccountManager::class);
 
-		$this->registerService(IStorageFactory::class, function() {
+		$this->registerService(IStorageFactory::class, function () {
 			return new StorageFactory();
 		});
 
@@ -1386,7 +1386,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$dispatcher = $this->getEventDispatcher();
 
 		// Delete avatar on user deletion
-		$dispatcher->addListener('OCP\IUser::preDelete', function(GenericEvent $e) {
+		$dispatcher->addListener('OCP\IUser::preDelete', function (GenericEvent $e) {
 			$logger = $this->getLogger();
 			$manager = $this->getAvatarManager();
 			/** @var IUser $user */
@@ -2141,7 +2141,7 @@ class Server extends ServerContainer implements IServerContainer {
 	/**
 	 * @return \OCP\Collaboration\AutoComplete\IManager
 	 */
-	public function getAutoCompleteManager(){
+	public function getAutoCompleteManager() {
 		return $this->query(IManager::class);
 	}
 

--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -230,7 +230,7 @@ class Manager implements IManager {
 	 */
 	public function getAdminSettings($section, bool $subAdminOnly = false): array {
 		if ($subAdminOnly) {
-			$subAdminSettingsFilter = function(ISettings $settings) {
+			$subAdminSettingsFilter = function (ISettings $settings) {
 				return $settings instanceof ISubAdminSettings;
 			};
 			$appSettings = $this->getSettings('admin', $section, $subAdminSettingsFilter);

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -975,7 +975,7 @@ class Share extends Constants {
 
 			// filter out invalid items, these can appear when subshare entries exist
 			// for a group in which the requested user isn't a member any more
-			$items = array_filter($items, function($item) {
+			$items = array_filter($items, function ($item) {
 				return $item['share_type'] !== self::$shareTypeGroupUserUnique;
 			});
 

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -933,8 +933,8 @@ class DefaultShareProvider implements IShareProvider {
 				}
 
 
-				$groups = array_filter($groups, function($group) { return $group instanceof IGroup; });
-				$groups = array_map(function(IGroup $group) { return $group->getGID(); }, $groups);
+				$groups = array_filter($groups, function ($group) { return $group instanceof IGroup; });
+				$groups = array_map(function (IGroup $group) { return $group->getGID(); }, $groups);
 
 				$qb->andWhere($qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_GROUP)))
 					->andWhere($qb->expr()->in('share_with', $qb->createNamedParameter(

--- a/lib/private/Share20/LegacyHooks.php
+++ b/lib/private/Share20/LegacyHooks.php
@@ -75,7 +75,7 @@ class LegacyHooks {
 		/** @var IShare[] $deletedShares */
 		$deletedShares = $e->getArgument('deletedShares');
 
-		$formattedDeletedShares = array_map(function($share) {
+		$formattedDeletedShares = array_map(function ($share) {
 			return $this->formatHookParams($share);
 		}, $deletedShares);
 

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1200,7 +1200,7 @@ class Manager implements IManager {
 	public function getSharesInFolder($userId, Folder $node, $reshares = false) {
 		$providers = $this->factory->getAllProviders();
 
-		return array_reduce($providers, function($shares, IShareProvider $provider) use ($userId, $node, $reshares) {
+		return array_reduce($providers, function ($shares, IShareProvider $provider) use ($userId, $node, $reshares) {
 			$newShares = $provider->getSharesInFolder($userId, $node, $reshares);
 			foreach ($newShares as $fid => $data) {
 				if (!isset($shares[$fid])) {
@@ -1318,7 +1318,7 @@ class Manager implements IManager {
 		$shares = $this->getSharedWith($userId, $shareType, $node, $limit, $offset);
 
 		// Only get deleted shares
-		$shares = array_filter($shares, function(IShare $share) {
+		$shares = array_filter($shares, function (IShare $share) {
 			return $share->getPermissions() === 0;
 		});
 

--- a/lib/private/Streamer.php
+++ b/lib/private/Streamer.php
@@ -52,7 +52,7 @@ class Streamer {
 	 * @param int $numberOfFiles The number of files (and directories) that will
 	 *        be included in the streamed file
 	 */
-	public function __construct(IRequest $request, int $size, int $numberOfFiles){
+	public function __construct(IRequest $request, int $size, int $numberOfFiles) {
 
 		/**
 		 * zip32 constraints for a basic (without compression, volumes nor
@@ -89,7 +89,7 @@ class Streamer {
 	 * Send HTTP headers
 	 * @param string $name
 	 */
-	public function sendHeaders($name){
+	public function sendHeaders($name) {
 		$extension = $this->streamerInstance instanceof ZipStreamer ? '.zip' : '.tar';
 		$fullName = $name . $extension;
 		$this->streamerInstance->sendHeaders($fullName);
@@ -169,7 +169,7 @@ class Streamer {
 	 * @param string $dirName Directory Path and name to be added to the archive.
 	 * @return bool $success
 	 */
-	public function addEmptyDir($dirName){
+	public function addEmptyDir($dirName) {
 		return $this->streamerInstance->addEmptyDir($dirName);
 	}
 
@@ -179,7 +179,7 @@ class Streamer {
 	 * closing, the file is completely written to the output stream.
 	 * @return bool $success
 	 */
-	public function finalize(){
+	public function finalize() {
 		return $this->streamerInstance->finalize();
 	}
 }

--- a/lib/private/SubAdmin.php
+++ b/lib/private/SubAdmin.php
@@ -60,10 +60,10 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 		$this->groupManager = $groupManager;
 		$this->dbConn = $dbConn;
 
-		$this->userManager->listen('\OC\User', 'postDelete', function($user) {
+		$this->userManager->listen('\OC\User', 'postDelete', function ($user) {
 			$this->post_deleteUser($user);
 		});
-		$this->groupManager->listen('\OC\Group', 'postDelete', function($group) {
+		$this->groupManager->listen('\OC\Group', 'postDelete', function ($group) {
 			$this->post_deleteGroup($group);
 		});
 	}
@@ -135,7 +135,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 	 * @return array ['displayName' => displayname]
 	 */
 	public function getSubAdminsGroupsName(IUser $user): array {
-		return array_map(function($group) {
+		return array_map(function ($group) {
 			return ['displayName' => $group->getDisplayName()];
 		}, $this->getSubAdminsGroups($user));
 	}

--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -259,7 +259,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 		if (\count($tags) !== \count($tagIds)) {
 			// at least one tag missing, bail out
 			$foundTagIds = array_map(
-				function(ISystemTag $tag) {
+				function (ISystemTag $tag) {
 					return $tag->getId();
 				},
 				$tags

--- a/lib/private/Tagging/Tag.php
+++ b/lib/private/Tagging/Tag.php
@@ -63,7 +63,7 @@ class Tag extends Entity {
 	 * @todo migrate existing database columns to the correct names
 	 * to be able to drop this direct mapping
 	 */
-	public function columnToProperty($columnName){
+	public function columnToProperty($columnName) {
 		if ($columnName === 'category') {
 			return 'name';
 		} elseif ($columnName === 'uid') {
@@ -79,7 +79,7 @@ class Tag extends Entity {
 	 * @param string $property the name of the property
 	 * @return string the column name
 	 */
-	public function propertyToColumn($property){
+	public function propertyToColumn($property) {
 		if ($property === 'name') {
 			return 'category';
 		} elseif ($property === 'owner') {

--- a/lib/private/Tags.php
+++ b/lib/private/Tags.php
@@ -181,7 +181,7 @@ class Tags implements ITags {
 			return [];
 		}
 
-		usort($this->tags, function($a, $b) {
+		usort($this->tags, function ($a, $b) {
 			return strnatcasecmp($a->getName(), $b->getName());
 		});
 		$tagMap = [];
@@ -204,7 +204,7 @@ class Tags implements ITags {
 	 */
 	public function getTagsForUser($user) {
 		return array_filter($this->tags,
-			function($tag) use($user) {
+			function ($tag) use ($user) {
 				return $tag->getOwner() === $user;
 			}
 		);
@@ -802,7 +802,7 @@ class Tags implements ITags {
 			return false;
 		}
 		return array_search(strtolower($needle), array_map(
-			function($tag) use($mem) {
+			function ($tag) use ($mem) {
 				return strtolower(call_user_func([$tag, $mem]));
 			}, $haystack)
 		);

--- a/lib/private/Template/Base.php
+++ b/lib/private/Template/Base.php
@@ -48,7 +48,7 @@ class Base {
 	 * @param \OCP\IL10N $l10n
 	 * @param Defaults $theme
 	 */
-	public function __construct($template, $requestToken, $l10n, $theme ) {
+	public function __construct($template, $requestToken, $l10n, $theme) {
 		$this->vars = [];
 		$this->vars['requesttoken'] = $requestToken;
 		$this->l10n = $l10n;
@@ -100,7 +100,7 @@ class Base {
 	 *
 	 * If the key existed before, it will be overwritten
 	 */
-	public function assign( $key, $value) {
+	public function assign($key, $value) {
 		$this->vars[$key] = $value;
 		return true;
 	}
@@ -114,7 +114,7 @@ class Base {
 	 * exists, the value will be appended. It can be accessed via
 	 * $_[$key][$position] in the template.
 	 */
-	public function append( $key, $value ) {
+	public function append($key, $value) {
 		if( array_key_exists( $key, $this->vars )) {
 			$this->vars[$key][] = $value;
 		}

--- a/lib/private/Template/TemplateFileLocator.php
+++ b/lib/private/Template/TemplateFileLocator.php
@@ -32,7 +32,7 @@ class TemplateFileLocator {
 	/**
 	 * @param string[] $dirs
 	 */
-	public function __construct( $dirs ) {
+	public function __construct($dirs) {
 		$this->dirs = $dirs;
 	}
 
@@ -41,7 +41,7 @@ class TemplateFileLocator {
 	 * @return string
 	 * @throws \Exception
 	 */
-	public function find( $template ) {
+	public function find($template) {
 		if ($template === '') {
 			throw new \InvalidArgumentException('Empty template name');
 		}

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -64,7 +64,7 @@ class TemplateLayout extends \OC_Template {
 	 * @param string $renderAs
 	 * @param string $appId application id
 	 */
-	public function __construct( $renderAs, $appId = '' ) {
+	public function __construct($renderAs, $appId = '') {
 
 		// yes - should be injected ....
 		$this->config = \OC::$server->getConfig();

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -495,20 +495,20 @@ class Updater extends BasicEmitter {
 		$log = $this->log;
 
 		$dispatcher = \OC::$server->getEventDispatcher();
-		$dispatcher->addListener('\OC\DB\Migrator::executeSql', function($event) use ($log) {
+		$dispatcher->addListener('\OC\DB\Migrator::executeSql', function ($event) use ($log) {
 			if (!$event instanceof GenericEvent) {
 				return;
 			}
 			$log->info('\OC\DB\Migrator::executeSql: ' . $event->getSubject() . ' (' . $event->getArgument(0) . ' of ' . $event->getArgument(1) . ')', ['app' => 'updater']);
 		});
-		$dispatcher->addListener('\OC\DB\Migrator::checkTable', function($event) use ($log) {
+		$dispatcher->addListener('\OC\DB\Migrator::checkTable', function ($event) use ($log) {
 			if (!$event instanceof GenericEvent) {
 				return;
 			}
 			$log->info('\OC\DB\Migrator::checkTable: ' . $event->getSubject() . ' (' . $event->getArgument(0) . ' of ' . $event->getArgument(1) . ')', ['app' => 'updater']);
 		});
 
-		$repairListener = function($event) use ($log) {
+		$repairListener = function ($event) use ($log) {
 			if (!$event instanceof GenericEvent) {
 				return;
 			}
@@ -551,44 +551,44 @@ class Updater extends BasicEmitter {
 		$dispatcher->addListener('\OC\Repair::error', $repairListener);
 
 
-		$this->listen('\OC\Updater', 'maintenanceEnabled', function () use($log) {
+		$this->listen('\OC\Updater', 'maintenanceEnabled', function () use ($log) {
 			$log->info('\OC\Updater::maintenanceEnabled: Turned on maintenance mode', ['app' => 'updater']);
 		});
-		$this->listen('\OC\Updater', 'maintenanceDisabled', function () use($log) {
+		$this->listen('\OC\Updater', 'maintenanceDisabled', function () use ($log) {
 			$log->info('\OC\Updater::maintenanceDisabled: Turned off maintenance mode', ['app' => 'updater']);
 		});
-		$this->listen('\OC\Updater', 'maintenanceActive', function () use($log) {
+		$this->listen('\OC\Updater', 'maintenanceActive', function () use ($log) {
 			$log->info('\OC\Updater::maintenanceActive: Maintenance mode is kept active', ['app' => 'updater']);
 		});
-		$this->listen('\OC\Updater', 'updateEnd', function ($success) use($log) {
+		$this->listen('\OC\Updater', 'updateEnd', function ($success) use ($log) {
 			if ($success) {
 				$log->info('\OC\Updater::updateEnd: Update successful', ['app' => 'updater']);
 			} else {
 				$log->error('\OC\Updater::updateEnd: Update failed', ['app' => 'updater']);
 			}
 		});
-		$this->listen('\OC\Updater', 'dbUpgradeBefore', function () use($log) {
+		$this->listen('\OC\Updater', 'dbUpgradeBefore', function () use ($log) {
 			$log->info('\OC\Updater::dbUpgradeBefore: Updating database schema', ['app' => 'updater']);
 		});
-		$this->listen('\OC\Updater', 'dbUpgrade', function () use($log) {
+		$this->listen('\OC\Updater', 'dbUpgrade', function () use ($log) {
 			$log->info('\OC\Updater::dbUpgrade: Updated database', ['app' => 'updater']);
 		});
-		$this->listen('\OC\Updater', 'dbSimulateUpgradeBefore', function () use($log) {
+		$this->listen('\OC\Updater', 'dbSimulateUpgradeBefore', function () use ($log) {
 			$log->info('\OC\Updater::dbSimulateUpgradeBefore: Checking whether the database schema can be updated (this can take a long time depending on the database size)', ['app' => 'updater']);
 		});
-		$this->listen('\OC\Updater', 'dbSimulateUpgrade', function () use($log) {
+		$this->listen('\OC\Updater', 'dbSimulateUpgrade', function () use ($log) {
 			$log->info('\OC\Updater::dbSimulateUpgrade: Checked database schema update', ['app' => 'updater']);
 		});
-		$this->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use($log) {
+		$this->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use ($log) {
 			$log->info('\OC\Updater::incompatibleAppDisabled: Disabled incompatible app: ' . $app, ['app' => 'updater']);
 		});
-		$this->listen('\OC\Updater', 'checkAppStoreAppBefore', function ($app) use($log) {
+		$this->listen('\OC\Updater', 'checkAppStoreAppBefore', function ($app) use ($log) {
 			$log->info('\OC\Updater::checkAppStoreAppBefore: Checking for update of app "' . $app . '" in appstore', ['app' => 'updater']);
 		});
-		$this->listen('\OC\Updater', 'upgradeAppStoreApp', function ($app) use($log) {
+		$this->listen('\OC\Updater', 'upgradeAppStoreApp', function ($app) use ($log) {
 			$log->info('\OC\Updater::upgradeAppStoreApp: Update app "' . $app . '" from appstore', ['app' => 'updater']);
 		});
-		$this->listen('\OC\Updater', 'checkAppStoreApp', function ($app) use($log) {
+		$this->listen('\OC\Updater', 'checkAppStoreApp', function ($app) use ($log) {
 			$log->info('\OC\Updater::checkAppStoreApp: Checked for update of app "' . $app . '" in appstore', ['app' => 'updater']);
 		});
 		$this->listen('\OC\Updater', 'appUpgradeCheckBefore', function () use ($log) {
@@ -606,19 +606,19 @@ class Updater extends BasicEmitter {
 		$this->listen('\OC\Updater', 'appUpgrade', function ($app, $version) use ($log) {
 			$log->info('\OC\Updater::appUpgrade: Updated <' . $app . '> to ' . $version, ['app' => 'updater']);
 		});
-		$this->listen('\OC\Updater', 'failure', function ($message) use($log) {
+		$this->listen('\OC\Updater', 'failure', function ($message) use ($log) {
 			$log->error('\OC\Updater::failure: ' . $message, ['app' => 'updater']);
 		});
-		$this->listen('\OC\Updater', 'setDebugLogLevel', function () use($log) {
+		$this->listen('\OC\Updater', 'setDebugLogLevel', function () use ($log) {
 			$log->info('\OC\Updater::setDebugLogLevel: Set log level to debug', ['app' => 'updater']);
 		});
-		$this->listen('\OC\Updater', 'resetLogLevel', function ($logLevel, $logLevelName) use($log) {
+		$this->listen('\OC\Updater', 'resetLogLevel', function ($logLevel, $logLevelName) use ($log) {
 			$log->info('\OC\Updater::resetLogLevel: Reset log level to ' . $logLevelName . '(' . $logLevel . ')', ['app' => 'updater']);
 		});
-		$this->listen('\OC\Updater', 'startCheckCodeIntegrity', function () use($log) {
+		$this->listen('\OC\Updater', 'startCheckCodeIntegrity', function () use ($log) {
 			$log->info('\OC\Updater::startCheckCodeIntegrity: Starting code integrity check...', ['app' => 'updater']);
 		});
-		$this->listen('\OC\Updater', 'finishedCheckCodeIntegrity', function () use($log) {
+		$this->listen('\OC\Updater', 'finishedCheckCodeIntegrity', function () use ($log) {
 			$log->info('\OC\Updater::finishedCheckCodeIntegrity: Finished code integrity check', ['app' => 'updater']);
 		});
 

--- a/lib/private/User/Backend.php
+++ b/lib/private/User/Backend.php
@@ -96,7 +96,7 @@ abstract class Backend implements UserInterface {
 	 *
 	 * Deletes a user
 	 */
-	public function deleteUser( $uid ) {
+	public function deleteUser($uid) {
 		return false;
 	}
 

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -422,7 +422,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	public function countUsersOfGroups(array $groups) {
 		$users = [];
 		foreach($groups as $group) {
-			$usersIds = array_map(function($user) {
+			$usersIds = array_map(function ($user) {
 				return $user->getUID();
 			}, $group->getUsers());
 			$users = array_merge($users, $usersIds);
@@ -618,11 +618,11 @@ class Manager extends PublicEmitter implements IUserManager {
 	public function getByEmail($email) {
 		$userIds = $this->config->getUsersForUserValueCaseInsensitive('settings', 'email', $email);
 
-		$users = array_map(function($uid) {
+		$users = array_map(function ($uid) {
 			return $this->get($uid);
 		}, $userIds);
 
-		return array_values(array_filter($users, function($u) {
+		return array_values(array_filter($users, function ($u) {
 			return ($u instanceof IUser);
 		}));
 	}

--- a/lib/private/legacy/OC_DB.php
+++ b/lib/private/legacy/OC_DB.php
@@ -58,7 +58,7 @@ class OC_DB {
 	 *
 	 * SQL query via Doctrine prepare(), needs to be execute()'d!
 	 */
-	static public function prepare( $query , $limit = null, $offset = null, $isManipulation = null) {
+	static public function prepare($query , $limit = null, $offset = null, $isManipulation = null) {
 		$connection = \OC::$server->getDatabaseConnection();
 
 		if ($isManipulation === null) {
@@ -84,7 +84,7 @@ class OC_DB {
 	 * @param string $sql
 	 * @return bool
 	 */
-	static public function isManipulation( $sql ) {
+	static public function isManipulation($sql) {
 		$selectOccurrence = stripos($sql, 'SELECT');
 		if ($selectOccurrence !== false && $selectOccurrence < 10) {
 			return false;
@@ -113,7 +113,7 @@ class OC_DB {
 	 * @return OC_DB_StatementWrapper
 	 * @throws \OC\DatabaseException
 	 */
-	static public function executeAudited( $stmt, array $parameters = []) {
+	static public function executeAudited($stmt, array $parameters = []) {
 		if (is_string($stmt)) {
 			// convert to an array with 'sql'
 			if (stripos($stmt, 'LIMIT') !== false) { //OFFSET requires LIMIT, so we only need to check for LIMIT
@@ -172,7 +172,7 @@ class OC_DB {
 	 *
 	 * TODO: write more documentation
 	 */
-	public static function createDbFromStructure( $file ) {
+	public static function createDbFromStructure($file) {
 		$schemaManager = self::getMDB2SchemaManager();
 		return $schemaManager->createDbFromStructure($file);
 	}

--- a/lib/private/legacy/OC_DB_StatementWrapper.php
+++ b/lib/private/legacy/OC_DB_StatementWrapper.php
@@ -114,7 +114,7 @@ class OC_DB_StatementWrapper {
 	 * @param integer|null $length max length when using an OUT bind
 	 * @return boolean
 	 */
-	public function bindParam($column, &$variable, $type = null, $length = null){
+	public function bindParam($column, &$variable, $type = null, $length = null) {
 		return $this->statement->bindParam($column, $variable, $type, $length);
 	}
 }

--- a/lib/private/legacy/OC_Files.php
+++ b/lib/private/legacy/OC_Files.php
@@ -399,7 +399,7 @@ class OC_Files {
 			$view->lockFile($file, ILockingProvider::LOCK_SHARED);
 			if ($view->is_dir($file)) {
 				$contents = $view->getDirectoryContent($file);
-				$contents = array_map(function($fileInfo) use ($file) {
+				$contents = array_map(function ($fileInfo) use ($file) {
 					/** @var \OCP\Files\FileInfo $fileInfo */
 					return $file . '/' . $fileInfo->getName();
 				}, $contents);

--- a/lib/private/legacy/OC_Hook.php
+++ b/lib/private/legacy/OC_Hook.php
@@ -51,7 +51,7 @@ class OC_Hook {
 	 *
 	 * TODO: write example
 	 */
-	static public function connect($signalClass, $signalName, $slotClass, $slotName ) {
+	static public function connect($signalClass, $signalName, $slotClass, $slotName) {
 		// If we're trying to connect to an emitting class that isn't
 		// yet registered, register it
 		if( !array_key_exists($signalClass, self::$registered )) {

--- a/lib/private/legacy/OC_Response.php
+++ b/lib/private/legacy/OC_Response.php
@@ -33,7 +33,7 @@ class OC_Response {
 	 * @param string $filename file name
 	 * @param string $type disposition type, either 'attachment' or 'inline'
 	 */
-	static public function setContentDispositionHeader( $filename, $type = 'attachment' ) {
+	static public function setContentDispositionHeader($filename, $type = 'attachment') {
 		if (\OC::$server->getRequest()->isUserAgent(
 			[
 				\OC\AppFramework\Http\Request::USER_AGENT_IE,

--- a/lib/private/legacy/OC_Template.php
+++ b/lib/private/legacy/OC_Template.php
@@ -72,7 +72,7 @@ class OC_Template extends \OC\Template\Base {
 	 *                         "admin".
 	 * @param bool $registerCall = true
 	 */
-	public function __construct( $app, $name, $renderAs = "", $registerCall = true ) {
+	public function __construct($app, $name, $renderAs = "", $registerCall = true) {
 		// Read the selected theme from the config file
 		self::initTemplateEngine($renderAs);
 
@@ -227,7 +227,7 @@ class OC_Template extends \OC\Template\Base {
 	 * Includes another template. use <?php echo $this->inc('template'); ?> to
 	 * do this.
 	 */
-	public function inc( $file, $additionalParams = null ) {
+	public function inc($file, $additionalParams = null) {
 		return $this->load($this->path.$file.'.php', $additionalParams);
 	}
 
@@ -238,7 +238,7 @@ class OC_Template extends \OC\Template\Base {
 	 * @param array $parameters Parameters for the template
 	 * @return boolean|null
 	 */
-	public static function printUserPage( $application, $name, $parameters = [] ) {
+	public static function printUserPage($application, $name, $parameters = []) {
 		$content = new OC_Template( $application, $name, "user" );
 		foreach( $parameters as $key => $value ) {
 			$content->assign( $key, $value );
@@ -253,7 +253,7 @@ class OC_Template extends \OC\Template\Base {
 	 * @param array $parameters Parameters for the template
 	 * @return bool
 	 */
-	public static function printAdminPage( $application, $name, $parameters = [] ) {
+	public static function printAdminPage($application, $name, $parameters = []) {
 		$content = new OC_Template( $application, $name, "admin" );
 		foreach( $parameters as $key => $value ) {
 			$content->assign( $key, $value );
@@ -268,7 +268,7 @@ class OC_Template extends \OC\Template\Base {
 	 * @param array|string $parameters Parameters for the template
 	 * @return bool
 	 */
-	public static function printGuestPage( $application, $name, $parameters = [] ) {
+	public static function printGuestPage($application, $name, $parameters = []) {
 		$content = new OC_Template($application, $name, $name === 'error' ? $name : 'guest');
 		foreach( $parameters as $key => $value ) {
 			$content->assign( $key, $value );
@@ -283,7 +283,7 @@ class OC_Template extends \OC\Template\Base {
 	 * @param int $statusCode
 	 * @suppress PhanAccessMethodInternal
 	 */
-	public static function printErrorPage( $error_msg, $hint = '', $statusCode = 500) {
+	public static function printErrorPage($error_msg, $hint = '', $statusCode = 500) {
 		if (\OC::$server->getAppManager()->isEnabledForUser('theming') && !\OC_App::isAppLoaded('theming')) {
 			\OC_App::loadApp('theming');
 		}

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -1163,7 +1163,7 @@ class OC_Util {
 	 */
 	public static function sanitizeHTML($value) {
 		if (is_array($value)) {
-			$value = array_map(function($value) {
+			$value = array_map(function ($value) {
 				return self::sanitizeHTML($value);
 			}, $value);
 		} else {

--- a/lib/private/legacy/template/functions.php
+++ b/lib/private/legacy/template/functions.php
@@ -214,7 +214,7 @@ function component($app, $file) {
  *
  * For further information have a look at \OCP\IURLGenerator::linkTo
  */
-function link_to( $app, $file, $args = [] ) {
+function link_to($app, $file, $args = []) {
 	return \OC::$server->getURLGenerator()->linkTo($app, $file, $args);
 }
 
@@ -234,7 +234,7 @@ function link_to_docs($key) {
  *
  * For further information have a look at \OCP\IURLGenerator::imagePath
  */
-function image_path( $app, $image ) {
+function image_path($app, $image) {
 	return \OC::$server->getURLGenerator()->imagePath( $app, $image );
 }
 
@@ -243,7 +243,7 @@ function image_path( $app, $image ) {
  * @param string $mimetype mimetype
  * @return string link to the image
  */
-function mimetype_icon( $mimetype ) {
+function mimetype_icon($mimetype) {
 	return \OC::$server->getMimeTypeDetector()->mimeTypeIcon( $mimetype );
 }
 
@@ -253,7 +253,7 @@ function mimetype_icon( $mimetype ) {
  * @param string $path path of file
  * @return string link to the preview
  */
-function preview_icon( $path ) {
+function preview_icon($path) {
 	return \OC::$server->getURLGenerator()->linkToRoute('core.Preview.getPreview', ['x' => 32, 'y' => 32, 'file' => $path]);
 }
 
@@ -262,7 +262,7 @@ function preview_icon( $path ) {
  * @param string $token
  * @return string
  */
-function publicPreview_icon ( $path, $token ) {
+function publicPreview_icon($path, $token) {
 	return \OC::$server->getURLGenerator()->linkToRoute('files_sharing.PublicPreview.getPreview', ['x' => 32, 'y' => 32, 'file' => $path, 'token' => $token]);
 }
 
@@ -273,7 +273,7 @@ function publicPreview_icon ( $path, $token ) {
  *
  * For further information have a look at OC_Helper::humanFileSize
  */
-function human_file_size( $bytes ) {
+function human_file_size($bytes) {
 	return OC_Helper::humanFileSize( $bytes );
 }
 
@@ -282,7 +282,7 @@ function human_file_size( $bytes ) {
  * @param int $timestamp UNIX timestamp to strip
  * @return int timestamp without time value
  */
-function strip_time($timestamp){
+function strip_time($timestamp) {
 	$date = new \DateTime("@{$timestamp}");
 	$date->setTime(0, 0, 0);
 	return (int)$date->format('U');

--- a/lib/public/Accounts/PropertyDoesNotExistException.php
+++ b/lib/public/Accounts/PropertyDoesNotExistException.php
@@ -37,7 +37,7 @@ class PropertyDoesNotExistException extends \Exception {
 	 * @param string $msg the error message
 	 * @since 15.0.0
 	 */
-	public function __construct($property){
+	public function __construct($property) {
 		parent::__construct('Property ' . $property . ' does not exist.');
 	}
 

--- a/lib/public/App.php
+++ b/lib/public/App.php
@@ -56,7 +56,7 @@ class App {
 	 * @since 4.0.0
 	 * @deprecated 14.0.0 Use settings section in appinfo.xml to register personal admin sections
 	 */
-	public static function registerPersonal( $app, $page ) {
+	public static function registerPersonal($app, $page) {
 		\OC_App::registerPersonal( $app, $page );
 	}
 
@@ -68,7 +68,7 @@ class App {
 	 * @since 4.0.0
 	 * @deprecated 14.0.0 Use settings section in appinfo.xml to register admin sections
 	 */
-	public static function registerAdmin( $app, $page ) {
+	public static function registerAdmin($app, $page) {
 		\OC_App::registerAdmin( $app, $page );
 	}
 
@@ -80,7 +80,7 @@ class App {
 	 * @deprecated 14.0.0 ise \OC::$server->getAppManager()->getAppInfo($appId)
 	 * @since 4.0.0
 	 */
-	public static function getAppInfo( $app, $path=false ) {
+	public static function getAppInfo($app, $path=false) {
 		return \OC_App::getAppInfo( $app, $path);
 	}
 
@@ -93,7 +93,7 @@ class App {
 	 * @since 4.0.0
 	 * @deprecated 13.0.0 use \OC::$server->getAppManager()->isEnabledForUser($appId)
 	 */
-	public static function isEnabled( $app ) {
+	public static function isEnabled($app) {
 		return \OC::$server->getAppManager()->isEnabledForUser( $app );
 	}
 
@@ -104,7 +104,7 @@ class App {
 	 * @since 4.0.0
 	 * @deprecated 14.0.0 use \OC::$server->getAppManager()->getAppVersion($appId)
 	 */
-	public static function getAppVersion( $app ) {
+	public static function getAppVersion($app) {
 		return \OC::$server->getAppManager()->getAppVersion($app);
 	}
 }

--- a/lib/public/AppFramework/ApiController.php
+++ b/lib/public/AppFramework/ApiController.php
@@ -61,7 +61,7 @@ abstract class ApiController extends Controller {
 								IRequest $request,
 								$corsMethods='PUT, POST, GET, DELETE, PATCH',
 								$corsAllowedHeaders='Authorization, Content-Type, Accept',
-								$corsMaxAge=1728000){
+								$corsMaxAge=1728000) {
 		parent::__construct($appName, $request);
 		$this->corsMethods = $corsMethods;
 		$this->corsAllowedHeaders = $corsAllowedHeaders;

--- a/lib/public/AppFramework/Db/DoesNotExistException.php
+++ b/lib/public/AppFramework/Db/DoesNotExistException.php
@@ -39,7 +39,7 @@ class DoesNotExistException extends \Exception implements IMapperException {
 	 * @param string $msg the error message
 	 * @since 7.0.0
 	 */
-	public function __construct($msg){
+	public function __construct($msg) {
 		parent::__construct($msg);
 	}
 

--- a/lib/public/AppFramework/Db/Entity.php
+++ b/lib/public/AppFramework/Db/Entity.php
@@ -65,7 +65,7 @@ abstract class Entity {
 	 * @param array $row the row to map onto the entity
 	 * @since 7.0.0
 	 */
-	public static function fromRow(array $row){
+	public static function fromRow(array $row) {
 		$instance = new static();
 
 		foreach($row as $key => $value){
@@ -93,7 +93,7 @@ abstract class Entity {
 	 * Marks the entity as clean needed for setting the id after the insertion
 	 * @since 7.0.0
 	 */
-	public function resetUpdatedFields(){
+	public function resetUpdatedFields() {
 		$this->_updatedFields = [];
 	}
 
@@ -175,7 +175,7 @@ abstract class Entity {
 	 * @param string $attribute the name of the attribute
 	 * @since 7.0.0
 	 */
-	protected function markFieldUpdated($attribute){
+	protected function markFieldUpdated($attribute) {
 		$this->_updatedFields[$attribute] = true;
 	}
 
@@ -186,7 +186,7 @@ abstract class Entity {
 	 * @return string the property name
 	 * @since 7.0.0
 	 */
-	public function columnToProperty($columnName){
+	public function columnToProperty($columnName) {
 		$parts = explode('_', $columnName);
 		$property = null;
 
@@ -208,7 +208,7 @@ abstract class Entity {
 	 * @return string the column name
 	 * @since 7.0.0
 	 */
-	public function propertyToColumn($property){
+	public function propertyToColumn($property) {
 		$parts = preg_split('/(?=[A-Z])/', $property);
 		$column = null;
 
@@ -228,7 +228,7 @@ abstract class Entity {
 	 * @return array array of updated fields for update query
 	 * @since 7.0.0
 	 */
-	public function getUpdatedFields(){
+	public function getUpdatedFields() {
 		return $this->_updatedFields;
 	}
 
@@ -240,7 +240,7 @@ abstract class Entity {
 	 * @param string $type the type which will be used to call settype()
 	 * @since 7.0.0
 	 */
-	protected function addType($fieldName, $type){
+	protected function addType($fieldName, $type) {
 		$this->_fieldTypes[$fieldName] = $type;
 	}
 
@@ -252,7 +252,7 @@ abstract class Entity {
 	 * @return string slugified value
 	 * @since 7.0.0
 	 */
-	public function slugify($attributeName){
+	public function slugify($attributeName) {
 		// toSlug should only work for existing attributes
 		if(property_exists($this, $attributeName)){
 			$value = $this->$attributeName;

--- a/lib/public/AppFramework/Db/Mapper.php
+++ b/lib/public/AppFramework/Db/Mapper.php
@@ -49,7 +49,7 @@ abstract class Mapper {
 	 * @since 7.0.0
 	 * @deprecated 14.0.0 Move over to QBMapper
 	 */
-	public function __construct(IDBConnection $db, $tableName, $entityClass=null){
+	public function __construct(IDBConnection $db, $tableName, $entityClass=null) {
 		$this->db = $db;
 		$this->tableName = '*PREFIX*' . $tableName;
 
@@ -68,7 +68,7 @@ abstract class Mapper {
 	 * @since 7.0.0
 	 * @deprecated 14.0.0 Move over to QBMapper
 	 */
-	public function getTableName(){
+	public function getTableName() {
 		return $this->tableName;
 	}
 
@@ -80,7 +80,7 @@ abstract class Mapper {
 	 * @since 7.0.0 - return value added in 8.1.0
 	 * @deprecated 14.0.0 Move over to QBMapper
 	 */
-	public function delete(Entity $entity){
+	public function delete(Entity $entity) {
 		$sql = 'DELETE FROM `' . $this->tableName . '` WHERE `id` = ?';
 		$stmt = $this->execute($sql, [$entity->getId()]);
 		$stmt->closeCursor();
@@ -95,7 +95,7 @@ abstract class Mapper {
 	 * @since 7.0.0
 	 * @deprecated 14.0.0 Move over to QBMapper
 	 */
-	public function insert(Entity $entity){
+	public function insert(Entity $entity) {
 		// get updated fields to save, fields have to be set using a setter to
 		// be saved
 		$properties = $entity->getUpdatedFields();
@@ -145,7 +145,7 @@ abstract class Mapper {
 	 * @since 7.0.0 - return value was added in 8.0.0
 	 * @deprecated 14.0.0 Move over to QBMapper
 	 */
-	public function update(Entity $entity){
+	public function update(Entity $entity) {
 		// if entity wasn't changed it makes no sense to run a db query
 		$properties = $entity->getUpdatedFields();
 		if(count($properties) === 0) {
@@ -235,7 +235,7 @@ abstract class Mapper {
 	 * @since 7.0.0
 	 * @deprecated 14.0.0 Move over to QBMapper
 	 */
-	protected function execute($sql, array $params=[], $limit=null, $offset=null){
+	protected function execute($sql, array $params=[], $limit=null, $offset=null) {
 		$query = $this->db->prepare($sql, $limit, $offset);
 
 		if ($this->isAssocArray($params)) {
@@ -271,7 +271,7 @@ abstract class Mapper {
 	 * @since 7.0.0
 	 * @deprecated 14.0.0 Move over to QBMapper
 	 */
-	protected function findOneQuery($sql, array $params=[], $limit=null, $offset=null){
+	protected function findOneQuery($sql, array $params=[], $limit=null, $offset=null) {
 		$stmt = $this->execute($sql, $params, $limit, $offset);
 		$row = $stmt->fetch();
 
@@ -367,7 +367,7 @@ abstract class Mapper {
 	 * @since 7.0.0
 	 * @deprecated 14.0.0 Move over to QBMapper
 	 */
-	protected function findEntity($sql, array $params=[], $limit=null, $offset=null){
+	protected function findEntity($sql, array $params=[], $limit=null, $offset=null) {
 		return $this->mapRowToEntity($this->findOneQuery($sql, $params, $limit, $offset));
 	}
 

--- a/lib/public/AppFramework/Db/MultipleObjectsReturnedException.php
+++ b/lib/public/AppFramework/Db/MultipleObjectsReturnedException.php
@@ -39,7 +39,7 @@ class MultipleObjectsReturnedException extends \Exception implements IMapperExce
 	 * @param string $msg the error message
 	 * @since 7.0.0
 	 */
-	public function __construct($msg){
+	public function __construct($msg) {
 		parent::__construct($msg);
 	}
 

--- a/lib/public/AppFramework/Db/QBMapper.php
+++ b/lib/public/AppFramework/Db/QBMapper.php
@@ -58,7 +58,7 @@ abstract class QBMapper {
 	 * mapped to queries without using sql
 	 * @since 14.0.0
 	 */
-	public function __construct(IDBConnection $db, string $tableName, string $entityClass=null){
+	public function __construct(IDBConnection $db, string $tableName, string $entityClass=null) {
 		$this->db = $db;
 		$this->tableName = $tableName;
 

--- a/lib/public/AppFramework/Http/DataDisplayResponse.php
+++ b/lib/public/AppFramework/Http/DataDisplayResponse.php
@@ -73,7 +73,7 @@ class DataDisplayResponse extends Response {
 	 * @return DataDisplayResponse Reference to this object
 	 * @since 8.1.0
 	 */
-	public function setData($data){
+	public function setData($data) {
 		$this->data = $data;
 
 		return $this;
@@ -85,7 +85,7 @@ class DataDisplayResponse extends Response {
 	 * @return string the data
 	 * @since 8.1.0
 	 */
-	public function getData(){
+	public function getData() {
 		return $this->data;
 	}
 

--- a/lib/public/AppFramework/Http/DataResponse.php
+++ b/lib/public/AppFramework/Http/DataResponse.php
@@ -68,7 +68,7 @@ class DataResponse extends Response {
 	 * @return DataResponse Reference to this object
 	 * @since 8.0.0
 	 */
-	public function setData($data){
+	public function setData($data) {
 		$this->data = $data;
 
 		return $this;
@@ -80,7 +80,7 @@ class DataResponse extends Response {
 	 * @return array the data
 	 * @since 8.0.0
 	 */
-	public function getData(){
+	public function getData() {
 		return $this->data;
 	}
 

--- a/lib/public/AppFramework/Http/JSONResponse.php
+++ b/lib/public/AppFramework/Http/JSONResponse.php
@@ -86,7 +86,7 @@ class JSONResponse extends Response {
 	 * @return JSONResponse Reference to this object
 	 * @since 6.0.0 - return value was added in 7.0.0
 	 */
-	public function setData($data){
+	public function setData($data) {
 		$this->data = $data;
 
 		return $this;
@@ -98,7 +98,7 @@ class JSONResponse extends Response {
 	 * @return array the data
 	 * @since 6.0.0
 	 */
-	public function getData(){
+	public function getData() {
 		return $this->data;
 	}
 

--- a/lib/public/AppFramework/Http/StreamResponse.php
+++ b/lib/public/AppFramework/Http/StreamResponse.php
@@ -42,7 +42,7 @@ class StreamResponse extends Response implements ICallbackResponse {
 	 * @param string|resource $filePath the path to the file or a file handle which should be streamed
 	 * @since 8.1.0
 	 */
-	public function __construct ($filePath) {
+	public function __construct($filePath) {
 		parent::__construct();
 
 		$this->filePath = $filePath;
@@ -55,7 +55,7 @@ class StreamResponse extends Response implements ICallbackResponse {
 	 * @param IOutput $output a small wrapper that handles output
 	 * @since 8.1.0
 	 */
-	public function callback (IOutput $output) {
+	public function callback(IOutput $output) {
 		// handle caching
 		if ($output->getHttpResponseCode() !== Http::STATUS_NOT_MODIFIED) {
 			if (!(is_resource($this->filePath) || file_exists($this->filePath))) {

--- a/lib/public/AppFramework/Http/Template/PublicTemplateResponse.php
+++ b/lib/public/AppFramework/Http/Template/PublicTemplateResponse.php
@@ -98,7 +98,7 @@ class PublicTemplateResponse extends TemplateResponse {
 			}
 			$this->headerActions[] = $action;
 		}
-		usort($this->headerActions, function(IMenuAction $a, IMenuAction $b) {
+		usort($this->headerActions, function (IMenuAction $a, IMenuAction $b) {
 			return $a->getPriority() > $b->getPriority();
 		});
 	}

--- a/lib/public/AppFramework/Http/TemplateResponse.php
+++ b/lib/public/AppFramework/Http/TemplateResponse.php
@@ -96,7 +96,7 @@ class TemplateResponse extends Response {
 	 * @return TemplateResponse Reference to this object
 	 * @since 6.0.0 - return value was added in 7.0.0
 	 */
-	public function setParams(array $params){
+	public function setParams(array $params) {
 		$this->params = $params;
 
 		return $this;
@@ -108,7 +108,7 @@ class TemplateResponse extends Response {
 	 * @return array the params
 	 * @since 6.0.0
 	 */
-	public function getParams(){
+	public function getParams() {
 		return $this->params;
 	}
 
@@ -118,7 +118,7 @@ class TemplateResponse extends Response {
 	 * @return string the name of the used template
 	 * @since 6.0.0
 	 */
-	public function getTemplateName(){
+	public function getTemplateName() {
 		return $this->templateName;
 	}
 
@@ -132,7 +132,7 @@ class TemplateResponse extends Response {
 	 * @return TemplateResponse Reference to this object
 	 * @since 6.0.0 - return value was added in 7.0.0
 	 */
-	public function renderAs($renderAs){
+	public function renderAs($renderAs) {
 		$this->renderAs = $renderAs;
 
 		return $this;
@@ -144,7 +144,7 @@ class TemplateResponse extends Response {
 	 * @return string the renderAs value
 	 * @since 6.0.0
 	 */
-	public function getRenderAs(){
+	public function getRenderAs() {
 		return $this->renderAs;
 	}
 
@@ -154,7 +154,7 @@ class TemplateResponse extends Response {
 	 * @return string the rendered html
 	 * @since 6.0.0
 	 */
-	public function render(){
+	public function render() {
 		// \OCP\Template needs an empty string instead of 'blank' for an unwrapped response
 		$renderAs = $this->renderAs === 'blank' ? '' : $this->renderAs;
 

--- a/lib/public/AppFramework/Middleware.php
+++ b/lib/public/AppFramework/Middleware.php
@@ -52,7 +52,7 @@ abstract class Middleware {
 	 *                           the controller
 	 * @since 6.0.0
 	 */
-	public function beforeController($controller, $methodName){
+	public function beforeController($controller, $methodName) {
 
 	}
 
@@ -72,7 +72,7 @@ abstract class Middleware {
 	 * @return Response a Response object in case that the exception was handled
 	 * @since 6.0.0
 	 */
-	public function afterException($controller, $methodName, \Exception $exception){
+	public function afterException($controller, $methodName, \Exception $exception) {
 		throw $exception;
 	}
 
@@ -88,7 +88,7 @@ abstract class Middleware {
 	 * @return Response a Response object
 	 * @since 6.0.0
 	 */
-	public function afterController($controller, $methodName, Response $response){
+	public function afterController($controller, $methodName, Response $response) {
 		return $response;
 	}
 
@@ -104,7 +104,7 @@ abstract class Middleware {
 	 * @return string the output that should be printed
 	 * @since 6.0.0
 	 */
-	public function beforeOutput($controller, $methodName, $output){
+	public function beforeOutput($controller, $methodName, $output) {
 		return $output;
 	}
 

--- a/lib/public/AppFramework/OCSController.php
+++ b/lib/public/AppFramework/OCSController.php
@@ -63,7 +63,7 @@ abstract class OCSController extends ApiController {
 								IRequest $request,
 								$corsMethods='PUT, POST, GET, DELETE, PATCH',
 								$corsAllowedHeaders='Authorization, Content-Type, Accept',
-								$corsMaxAge=1728000){
+								$corsMaxAge=1728000) {
 		parent::__construct($appName, $request, $corsMethods,
 							$corsAllowedHeaders, $corsMaxAge);
 		$this->registerResponder('json', function ($data) {

--- a/lib/public/Files.php
+++ b/lib/public/Files.php
@@ -54,7 +54,7 @@ class Files {
 	 * @since 5.0.0
 	 * @deprecated 14.0.0
 	 */
-	static public function rmdirr( $dir ) {
+	static public function rmdirr($dir) {
 		return \OC_Helper::rmdirr( $dir );
 	}
 
@@ -66,7 +66,7 @@ class Files {
 	 * @since 5.0.0
 	 * @deprecated 14.0.0
 	 */
-	static public function getMimeType( $path ) {
+	static public function getMimeType($path) {
 		return \OC::$server->getMimeTypeDetector()->detect($path);
 	}
 
@@ -89,7 +89,7 @@ class Files {
 	 * @since 5.0.0
 	 * @deprecated 14.0.0
 	 */
-	public static function streamCopy( $source, $target ) {
+	public static function streamCopy($source, $target) {
 		list($count, ) = \OC_Helper::streamCopy( $source, $target );
 		return $count;
 	}

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -128,7 +128,7 @@ class Util {
 	 * @since 4.0.0
 	 * @deprecated 13.0.0 use log of \OCP\ILogger
 	 */
-	public static function writeLog( $app, $message, $level ) {
+	public static function writeLog($app, $message, $level) {
 		$context = ['app' => $app];
 		\OC::$server->getLogger()->log($level, $message, $context);
 	}
@@ -170,7 +170,7 @@ class Util {
 	 * @param string $file
 	 * @since 4.0.0
 	 */
-	public static function addStyle( $application, $file = null ) {
+	public static function addStyle($application, $file = null) {
 		\OC_Util::addStyle( $application, $file );
 	}
 
@@ -180,7 +180,7 @@ class Util {
 	 * @param string $file
 	 * @since 4.0.0
 	 */
-	public static function addScript( $application, $file = null ) {
+	public static function addScript($application, $file = null) {
 		\OC_Util::addScript( $application, $file );
 	}
 
@@ -216,7 +216,7 @@ class Util {
 	 * @return string the url
 	 * @since 4.0.0 - parameter $args was added in 4.5.0
 	 */
-	public static function linkToAbsolute( $app, $file, $args = [] ) {
+	public static function linkToAbsolute($app, $file, $args = []) {
 		$urlGenerator = \OC::$server->getURLGenerator();
 		return $urlGenerator->getAbsoluteURL(
 			$urlGenerator->linkTo($app, $file, $args)
@@ -229,7 +229,7 @@ class Util {
 	 * @return string the url
 	 * @since 4.0.0
 	 */
-	public static function linkToRemote( $service ) {
+	public static function linkToRemote($service) {
 		$urlGenerator = \OC::$server->getURLGenerator();
 		$remoteBase = $urlGenerator->linkTo('', 'remote.php') . '/' . $service;
 		return $urlGenerator->getAbsoluteURL(

--- a/tests/Core/Command/Config/App/GetConfigTest.php
+++ b/tests/Core/Command/Config/App/GetConfigTest.php
@@ -147,7 +147,7 @@ class GetConfigTest extends TestCase {
 			$output = '';
 			$this->consoleOutput->expects($this->any())
 				->method('writeln')
-				->willReturnCallback(function($value) {
+				->willReturnCallback(function ($value) {
 					global $output;
 					$output .= $value . "\n";
 					return $output;

--- a/tests/Core/Command/Config/ListConfigsTest.php
+++ b/tests/Core/Command/Config/ListConfigsTest.php
@@ -320,7 +320,7 @@ class ListConfigsTest extends TestCase {
 		$output = '';
 		$this->consoleOutput->expects($this->any())
 			->method('writeln')
-			->willReturnCallback(function($value) {
+			->willReturnCallback(function ($value) {
 				global $output;
 				$output .= $value . "\n";
 				return $output;

--- a/tests/Core/Command/Config/System/GetConfigTest.php
+++ b/tests/Core/Command/Config/System/GetConfigTest.php
@@ -156,7 +156,7 @@ class GetConfigTest extends TestCase {
 			$output = '';
 			$this->consoleOutput->expects($this->any())
 				->method('writeln')
-				->willReturnCallback(function($value) {
+				->willReturnCallback(function ($value) {
 					global $output;
 					$output .= $value . "\n";
 					return $output;

--- a/tests/Core/Command/Encryption/ChangeKeyStorageRootTest.php
+++ b/tests/Core/Command/Encryption/ChangeKeyStorageRootTest.php
@@ -332,7 +332,7 @@ class ChangeKeyStorageRootTest extends TestCase {
 	public function testPrepareParentFolder($path, $pathExists) {
 		$this->view->expects($this->any())->method('file_exists')
 			->willReturnCallback(
-				function($fileExistsPath) use ($path, $pathExists) {
+				function ($fileExistsPath) use ($path, $pathExists) {
 					if ($path === $fileExistsPath) {
 						return $pathExists;
 					}

--- a/tests/Core/Command/Encryption/DecryptAllTest.php
+++ b/tests/Core/Command/Encryption/DecryptAllTest.php
@@ -217,7 +217,7 @@ class DecryptAllTest extends TestCase {
 		$this->decryptAll->expects($this->once())
 			->method('decryptAll')
 			->with($this->consoleInput, $this->consoleOutput, 'user1')
-			->willReturnCallback(function() { throw new \Exception(); });
+			->willReturnCallback(function () { throw new \Exception(); });
 
 		$this->invokePrivate($instance, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}

--- a/tests/Core/Command/Group/AddTest.php
+++ b/tests/Core/Command/Group/AddTest.php
@@ -52,7 +52,7 @@ class AddTest extends TestCase {
 
 		$this->input = $this->createMock(InputInterface::class);
 		$this->input->method('getArgument')
-			->willReturnCallback(function($arg) {
+			->willReturnCallback(function ($arg) {
 				if ($arg === 'groupid') {
 					return 'myGroup';
 				}

--- a/tests/Core/Command/Group/AddUserTest.php
+++ b/tests/Core/Command/Group/AddUserTest.php
@@ -58,7 +58,7 @@ class AddUserTest extends TestCase {
 
 		$this->input = $this->createMock(InputInterface::class);
 		$this->input->method('getArgument')
-			->willReturnCallback(function($arg) {
+			->willReturnCallback(function ($arg) {
 				if ($arg === 'group') {
 					return 'myGroup';
 				} else if ($arg === 'user') {

--- a/tests/Core/Command/Group/DeleteTest.php
+++ b/tests/Core/Command/Group/DeleteTest.php
@@ -57,7 +57,7 @@ class DeleteTest extends TestCase {
 	public function testDoesNotExists() {
 		$gid = 'myGroup';
 		$this->input->method('getArgument')
-			->willReturnCallback(function($arg) use ($gid) {
+			->willReturnCallback(function ($arg) use ($gid) {
 				if ($arg === 'groupid') {
 					return $gid;
 				}
@@ -79,7 +79,7 @@ class DeleteTest extends TestCase {
 	public function testDeleteAdmin() {
 		$gid = 'admin';
 		$this->input->method('getArgument')
-			->willReturnCallback(function($arg) use ($gid) {
+			->willReturnCallback(function ($arg) use ($gid) {
 				if ($arg === 'groupid') {
 					return $gid;
 				}
@@ -98,7 +98,7 @@ class DeleteTest extends TestCase {
 	public function testDeleteFailed() {
 		$gid = 'myGroup';
 		$this->input->method('getArgument')
-			->willReturnCallback(function($arg) use ($gid) {
+			->willReturnCallback(function ($arg) use ($gid) {
 				if ($arg === 'groupid') {
 					return $gid;
 				}
@@ -124,7 +124,7 @@ class DeleteTest extends TestCase {
 	public function testDelete() {
 		$gid = 'myGroup';
 		$this->input->method('getArgument')
-			->willReturnCallback(function($arg) use ($gid) {
+			->willReturnCallback(function ($arg) use ($gid) {
 				if ($arg === 'groupid') {
 					return $gid;
 				}

--- a/tests/Core/Command/Group/ListCommandTest.php
+++ b/tests/Core/Command/Group/ListCommandTest.php
@@ -56,7 +56,7 @@ class ListCommandTest extends TestCase {
 
 		$this->input = $this->createMock(InputInterface::class);
 		$this->input->method('getOption')
-			->willReturnCallback(function($arg) {
+			->willReturnCallback(function ($arg) {
 				if ($arg === 'limit') {
 					return '100';
 				} else if ($arg === 'offset') {

--- a/tests/Core/Command/Group/RemoveUserTest.php
+++ b/tests/Core/Command/Group/RemoveUserTest.php
@@ -58,7 +58,7 @@ class RemoveUserTest extends TestCase {
 
 		$this->input = $this->createMock(InputInterface::class);
 		$this->input->method('getArgument')
-			->willReturnCallback(function($arg) {
+			->willReturnCallback(function ($arg) {
 				if ($arg === 'group') {
 					return 'myGroup';
 				} else if ($arg === 'user') {

--- a/tests/Core/Controller/ClientFlowLoginControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginControllerTest.php
@@ -83,7 +83,7 @@ class ClientFlowLoginControllerTest extends TestCase {
 		$this->l10n
 			->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($text, $parameters = []) {
+			->willReturnCallback(function ($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			});
 		$this->defaults = $this->createMock(Defaults::class);

--- a/tests/Core/Controller/ClientFlowLoginV2ControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginV2ControllerTest.php
@@ -184,7 +184,7 @@ class ClientFlowLoginV2ControllerTest extends TestCase {
 
 	public function testGrantPageInvalidStateToken() {
 		$this->session->method('get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 				return null;
 			});
 
@@ -194,7 +194,7 @@ class ClientFlowLoginV2ControllerTest extends TestCase {
 
 	public function testGrantPageInvalidLoginToken() {
 		$this->session->method('get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 				if ($name === 'client.flow.v2.state.token') {
 					return 'stateToken';
 				}
@@ -214,7 +214,7 @@ class ClientFlowLoginV2ControllerTest extends TestCase {
 
 	public function testGrantPageValid() {
 		$this->session->method('get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 				if ($name === 'client.flow.v2.state.token') {
 					return 'stateToken';
 				}
@@ -236,7 +236,7 @@ class ClientFlowLoginV2ControllerTest extends TestCase {
 
 	public function testGenerateAppPasswordInvalidStateToken() {
 		$this->session->method('get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 				return null;
 			});
 
@@ -246,7 +246,7 @@ class ClientFlowLoginV2ControllerTest extends TestCase {
 
 	public function testGenerateAppPassworInvalidLoginToken() {
 		$this->session->method('get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 				if ($name === 'client.flow.v2.state.token') {
 					return 'stateToken';
 				}
@@ -266,7 +266,7 @@ class ClientFlowLoginV2ControllerTest extends TestCase {
 
 	public function testGenerateAppPassworValid() {
 		$this->session->method('get')
-			->willReturnCallback(function($name) {
+			->willReturnCallback(function ($name) {
 				if ($name === 'client.flow.v2.state.token') {
 					return 'stateToken';
 				}

--- a/tests/Core/Controller/CssControllerTest.php
+++ b/tests/Core/Controller/CssControllerTest.php
@@ -159,7 +159,7 @@ class CssControllerTest extends TestCase {
 
 		$folder->method('getFile')
 			->willReturnCallback(
-				function($fileName) use ($file) {
+				function ($fileName) use ($file) {
 					if ($fileName === 'file.css') {
 						return $file;
 					}

--- a/tests/Core/Controller/JsControllerTest.php
+++ b/tests/Core/Controller/JsControllerTest.php
@@ -159,7 +159,7 @@ class JsControllerTest extends TestCase {
 
 		$folder->method('getFile')
 			->willReturnCallback(
-				function($fileName) use ($file) {
+				function ($fileName) use ($file) {
 					if ($fileName === 'file.js') {
 						return $file;
 					}

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -588,7 +588,7 @@ class LoginControllerTest extends TestCase {
 		$this->chain->expects($this->once())
 			->method('process')
 			->with($this->equalTo($loginData))
-			->willReturnCallback(function(LoginData $data) use ($loginResult) {
+			->willReturnCallback(function (LoginData $data) use ($loginResult) {
 				$data->setUsername('john');
 				return $loginResult;
 			});

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -110,7 +110,7 @@ class LostControllerTest extends \Test\TestCase {
 		$this->l10n
 			->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($text, $parameters = []) {
+			->willReturnCallback(function ($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			});
 		$this->defaults = $this->getMockBuilder('\OCP\Defaults')
@@ -766,7 +766,7 @@ class LostControllerTest extends \Test\TestCase {
 		$encryptionModule = $this->createMock(IEncryptionModule::class);
 		$encryptionModule->expects($this->once())->method('needDetailedAccessList')->willReturn(true);
 		$this->encryptionManager->expects($this->once())->method('getEncryptionModules')
-			->willReturn([0 => ['callback' => function() use ($encryptionModule) { return $encryptionModule; }]]);
+			->willReturn([0 => ['callback' => function () use ($encryptionModule) { return $encryptionModule; }]]);
 		$response = $this->lostController->setPassword('myToken', 'user', 'newpass', false);
 		$expectedResponse = ['status' => 'error', 'msg' => '', 'encryption' => true];
 		$this->assertSame($expectedResponse, $response);
@@ -776,7 +776,7 @@ class LostControllerTest extends \Test\TestCase {
 		$encryptionModule = $this->createMock(IEncryptionModule::class);
 		$encryptionModule->expects($this->once())->method('needDetailedAccessList')->willReturn(false);
 		$this->encryptionManager->expects($this->once())->method('getEncryptionModules')
-			->willReturn([0 => ['callback' => function() use ($encryptionModule) { return $encryptionModule; }]]);
+			->willReturn([0 => ['callback' => function () use ($encryptionModule) { return $encryptionModule; }]]);
 		$this->config->method('getUserValue')
 			->with('ValidTokenUser', 'core', 'lostpassword', null)
 			->willReturn('encryptedData');

--- a/tests/acceptance/features/bootstrap/SettingsContext.php
+++ b/tests/acceptance/features/bootstrap/SettingsContext.php
@@ -204,7 +204,7 @@ class SettingsContext implements Context, ActorAwareInterface {
 
 		$actor = $this->actor;
 
-		$tagFoundInDropdownCallback = function() use($actor, $tag) {
+		$tagFoundInDropdownCallback = function () use ($actor, $tag) {
 			// Open the dropdown to look for the tag.
 			$actor->find(self::systemTagsSelectTagButton())->click();
 

--- a/tests/acceptance/features/bootstrap/ThemingAppContext.php
+++ b/tests/acceptance/features/bootstrap/ThemingAppContext.php
@@ -93,7 +93,7 @@ class ThemingAppContext implements Context, ActorAwareInterface {
 
 		$actor = $this->actor;
 
-		$colorSelectorLoadedCallback = function() use($actor) {
+		$colorSelectorLoadedCallback = function () use ($actor) {
 			$colorSelectorValue = $this->getRGBArray($actor->getSession()->evaluateScript("return $('#theming-color')[0].value;"));
 			$inputBgColor = $this->getRGBArray($actor->getSession()->evaluateScript("return $('#theming-color').css('background-color');"));
 			if ($colorSelectorValue == $inputBgColor) {
@@ -108,7 +108,7 @@ class ThemingAppContext implements Context, ActorAwareInterface {
 		}
 	}
 
-	private function getRGBArray ($color) {
+	private function getRGBArray($color) {
 		if (preg_match("/rgb\(\s*(\d+),\s*(\d+),\s*(\d+)\)/", $color, $matches)) {
 		// Already an RGB (R, G, B) color
 		// Convert from "rgb(R, G, B)" string to RGB array
@@ -128,7 +128,7 @@ class ThemingAppContext implements Context, ActorAwareInterface {
 	 * @Then I see that the header color is eventually :color
 	 */
 	public function iSeeThatTheHeaderColorIsEventually($color) {
-		$headerColorMatchesCallback = function() use($color) {
+		$headerColorMatchesCallback = function () use ($color) {
 			$headerColor = $this->actor->getSession()->evaluateScript("return $('#header').css('background-color');");
 			$headerColor = $this->getRGBArray($headerColor);
 			$color = $this->getRGBArray($color);
@@ -149,7 +149,7 @@ class ThemingAppContext implements Context, ActorAwareInterface {
 
 		$actor = $this->actor;
 
-		$savedStatusMessageShownCallback = function() use($actor) {
+		$savedStatusMessageShownCallback = function () use ($actor) {
 			if ($actor->find(self::statusMessage())->getText() !== "Saved") {
 				return false;
 			}

--- a/tests/acceptance/features/bootstrap/WaitFor.php
+++ b/tests/acceptance/features/bootstrap/WaitFor.php
@@ -39,7 +39,7 @@ class WaitFor {
 	 *         the timeout expires, false otherwise.
 	 */
 	public static function elementToBeEventuallyShown(Actor $actor, Locator $elementLocator, $timeout = 10, $timeoutStep = 1) {
-		$elementShownCallback = function() use ($actor, $elementLocator) {
+		$elementShownCallback = function () use ($actor, $elementLocator) {
 			try {
 				return $actor->find($elementLocator)->isVisible();
 			} catch (NoSuchElementException $exception) {
@@ -64,7 +64,7 @@ class WaitFor {
 	 *         the timeout expires, false otherwise.
 	 */
 	public static function elementToBeEventuallyNotShown(Actor $actor, Locator $elementLocator, $timeout = 10, $timeoutStep = 1) {
-		$elementNotShownCallback = function() use ($actor, $elementLocator) {
+		$elementNotShownCallback = function () use ($actor, $elementLocator) {
 			try {
 				return !$actor->find($elementLocator)->isVisible();
 			} catch (NoSuchElementException $exception) {

--- a/tests/acceptance/features/core/ElementFinder.php
+++ b/tests/acceptance/features/core/ElementFinder.php
@@ -56,7 +56,7 @@ class ElementFinder {
 		$locator = $elementLocator->getLocator();
 		$ancestorElement = self::findAncestorElement($session, $elementLocator, $timeout, $timeoutStep);
 
-		$findCallback = function() use (&$element, $selector, $locator, $ancestorElement) {
+		$findCallback = function () use (&$element, $selector, $locator, $ancestorElement) {
 			$element = $ancestorElement->find($selector, $locator);
 
 			return $element !== null;

--- a/tests/acceptance/features/core/ElementWrapper.php
+++ b/tests/acceptance/features/core/ElementWrapper.php
@@ -141,7 +141,7 @@ class ElementWrapper {
 	 * @return bool true if the wrapped element is visible, false otherwise.
 	 */
 	public function isVisible() {
-		$commandCallback = function() {
+		$commandCallback = function () {
 			return $this->element->isVisible();
 		};
 		return $this->executeCommand($commandCallback, "visibility could not be got");
@@ -153,7 +153,7 @@ class ElementWrapper {
 	 * @return bool true if the wrapped element is checked, false otherwise.
 	 */
 	public function isChecked() {
-		$commandCallback = function() {
+		$commandCallback = function () {
 			return $this->element->isChecked();
 		};
 		return $this->executeCommand($commandCallback, "check state could not be got");
@@ -169,7 +169,7 @@ class ElementWrapper {
 	 *         is not visible.
 	 */
 	public function getText() {
-		$commandCallback = function() {
+		$commandCallback = function () {
 			return $this->element->getText();
 		};
 		return $this->executeCommand($commandCallback, "text could not be got");
@@ -183,7 +183,7 @@ class ElementWrapper {
 	 * @return string the value of the wrapped element.
 	 */
 	public function getValue() {
-		$commandCallback = function() {
+		$commandCallback = function () {
 			return $this->element->getValue();
 		};
 		return $this->executeCommand($commandCallback, "value could not be got");
@@ -198,7 +198,7 @@ class ElementWrapper {
 	 * @param string $value the value to set.
 	 */
 	public function setValue($value) {
-		$commandCallback = function() use ($value) {
+		$commandCallback = function () use ($value) {
 			$this->element->setValue($value);
 		};
 		$this->executeCommandOnVisibleElement($commandCallback, "value could not be set");
@@ -211,7 +211,7 @@ class ElementWrapper {
 	 * timeout set when finding it).
 	 */
 	public function click() {
-		$commandCallback = function() {
+		$commandCallback = function () {
 			$this->element->click();
 		};
 		$this->executeCommandOnVisibleElement($commandCallback, "could not be clicked");
@@ -224,7 +224,7 @@ class ElementWrapper {
 	 * timeout set when finding it).
 	 */
 	public function check() {
-		$commandCallback = function() {
+		$commandCallback = function () {
 			$this->element->check();
 		};
 		$this->executeCommand($commandCallback, "could not be checked");
@@ -237,7 +237,7 @@ class ElementWrapper {
 	 * timeout set when finding it).
 	 */
 	public function uncheck() {
-		$commandCallback = function() {
+		$commandCallback = function () {
 			$this->element->uncheck();
 		};
 		$this->executeCommand($commandCallback, "could not be unchecked");
@@ -325,7 +325,7 @@ class ElementWrapper {
 	 *         otherwise.
 	 */
 	private function waitForElementToBeVisible() {
-		$isVisibleCallback = function() {
+		$isVisibleCallback = function () {
 			return $this->isVisible();
 		};
 		$timeout = $this->elementFinder->getTimeout();

--- a/tests/acceptance/features/core/Utils.php
+++ b/tests/acceptance/features/core/Utils.php
@@ -71,7 +71,7 @@ class Utils {
 	 * @return boolean true if the server was found, false otherwise.
 	 */
 	public static function waitForServer($url, $timeout, $timeoutStep = 0.5) {
-		$isServerUpCallback = function() use ($url) {
+		$isServerUpCallback = function () use ($url) {
 			$curlHandle = curl_init($url);
 
 			// Returning the transfer as the result of curl_exec prevents the

--- a/tests/lib/Activity/ManagerTest.php
+++ b/tests/lib/Activity/ManagerTest.php
@@ -61,7 +61,7 @@ class ManagerTest extends TestCase {
 
 		$this->assertSame([], self::invokePrivate($this->activityManager, 'getConsumers'));
 
-		$this->activityManager->registerConsumer(function() {
+		$this->activityManager->registerConsumer(function () {
 			return new NoOpConsumer();
 		});
 
@@ -79,7 +79,7 @@ class ManagerTest extends TestCase {
 	public function testGetConsumersInvalidConsumer() {
 		$this->expectException(\InvalidArgumentException::class);
 
-		$this->activityManager->registerConsumer(function() {
+		$this->activityManager->registerConsumer(function () {
 			return new \stdClass();
 		});
 
@@ -240,7 +240,7 @@ class ManagerTest extends TestCase {
 		$consumer->expects($this->once())
 			->method('receive')
 			->with($event)
-			->willReturnCallback(function(\OCP\Activity\IEvent $event) use ($expected) {
+			->willReturnCallback(function (\OCP\Activity\IEvent $event) use ($expected) {
 				$this->assertLessThanOrEqual(time() + 2, $event->getTimestamp(), 'Timestamp not set correctly');
 				$this->assertGreaterThanOrEqual(time() - 2, $event->getTimestamp(), 'Timestamp not set correctly');
 				$this->assertSame($expected, $event->getAuthor(), 'Author name not set correctly');
@@ -270,7 +270,7 @@ class ManagerTest extends TestCase {
 			->getMock();
 		$consumer->expects($this->once())
 			->method('receive')
-			->willReturnCallback(function(\OCP\Activity\IEvent $event) {
+			->willReturnCallback(function (\OCP\Activity\IEvent $event) {
 				$this->assertSame('test_app', $event->getApp(), 'App not set correctly');
 				$this->assertSame('test_type', $event->getType(), 'Type not set correctly');
 				$this->assertSame('test_affected', $event->getAffectedUser(), 'Affected user not set correctly');

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -465,7 +465,7 @@ class AppManagerTest extends TestCase {
 		$manager->expects($this->any())
 			->method('getAppInfo')
 			->willReturnCallback(
-				function($appId) use ($appInfos) {
+				function ($appId) use ($appInfos) {
 					return $appInfos[$appId];
 				}
 			);
@@ -514,7 +514,7 @@ class AppManagerTest extends TestCase {
 		$manager->expects($this->any())
 			->method('getAppInfo')
 			->willReturnCallback(
-				function($appId) use ($appInfos) {
+				function ($appId) use ($appInfos) {
 					return $appInfos[$appId];
 				}
 			);

--- a/tests/lib/App/AppStore/Fetcher/AppFetcherTest.php
+++ b/tests/lib/App/AppStore/Fetcher/AppFetcherTest.php
@@ -1863,7 +1863,7 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 
 	public function testGetWithFilter() {
 		$this->config->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				if ($key === 'appstoreenabled') {
 					return true;
 				} else if ($key === 'version') {
@@ -1946,7 +1946,7 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 	public function testAppstoreDisabled() {
 		$this->config
 			->method('getSystemValue')
-			->willReturnCallback(function($var, $default) {
+			->willReturnCallback(function ($var, $default) {
 				if ($var === 'appstoreenabled') {
 					return false;
 				} else if ($var === 'version') {
@@ -1965,7 +1965,7 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 	public function testNoInternet() {
 		$this->config
 			->method('getSystemValue')
-			->willReturnCallback(function($var, $default) {
+			->willReturnCallback(function ($var, $default) {
 				if ($var === 'has_internet_connection') {
 					return false;
 				} else if ($var === 'version') {
@@ -1982,7 +1982,7 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 
 	public function testSetVersion() {
 		$this->config->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				if ($key === 'appstoreenabled') {
 					return true;
 				} else if ($key === 'version') {

--- a/tests/lib/App/AppStore/Fetcher/CategoryFetcherTest.php
+++ b/tests/lib/App/AppStore/Fetcher/CategoryFetcherTest.php
@@ -41,7 +41,7 @@ class CategoryFetcherTest extends FetcherBase {
 	public function testAppstoreDisabled() {
 		$this->config
 			->method('getSystemValue')
-			->willReturnCallback(function($var, $default) {
+			->willReturnCallback(function ($var, $default) {
 				if ($var === 'appstoreenabled') {
 					return false;
 				}
@@ -57,7 +57,7 @@ class CategoryFetcherTest extends FetcherBase {
 	public function testNoInternet() {
 		$this->config
 			->method('getSystemValue')
-			->willReturnCallback(function($var, $default) {
+			->willReturnCallback(function ($var, $default) {
 				if ($var === 'has_internet_connection') {
 					return false;
 				}

--- a/tests/lib/App/AppStore/Fetcher/FetcherBase.php
+++ b/tests/lib/App/AppStore/Fetcher/FetcherBase.php
@@ -210,7 +210,7 @@ abstract class FetcherBase extends TestCase {
 
 	public function testGetWithAlreadyExistingFileAndOutdatedTimestamp() {
 		$this->config->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				if ($key === 'appstoreenabled') {
 					return true;
 				} else if ($key === 'version') {
@@ -463,7 +463,7 @@ abstract class FetcherBase extends TestCase {
 
 	public function testGetWithExceptionInClient() {
 		$this->config->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				if ($key === 'appstoreenabled') {
 					return true;
 				} else {
@@ -503,7 +503,7 @@ abstract class FetcherBase extends TestCase {
 
 	public function testGetMatchingETag() {
 		$this->config->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				if ($key === 'appstoreenabled') {
 					return true;
 				} else if ($key === 'version') {
@@ -584,7 +584,7 @@ abstract class FetcherBase extends TestCase {
 
 	public function testGetNoMatchingETag() {
 		$this->config->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				if ($key === 'appstoreenabled') {
 					return true;
 				} else if ($key === 'version') {
@@ -671,7 +671,7 @@ abstract class FetcherBase extends TestCase {
 
 	public function testFetchAfterUpgradeNoETag() {
 		$this->config->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				if ($key === 'appstoreenabled') {
 					return true;
 				} else if ($key === 'version') {

--- a/tests/lib/App/DependencyAnalyzerTest.php
+++ b/tests/lib/App/DependencyAnalyzerTest.php
@@ -44,12 +44,12 @@ class DependencyAnalyzerTest extends TestCase {
 			->willReturn( 'Linux');
 		$this->platformMock->expects($this->any())
 			->method('isCommandKnown')
-			->willReturnCallback( function($command) {
+			->willReturnCallback( function ($command) {
 				return ($command === 'grep');
 			});
 		$this->platformMock->expects($this->any())
 			->method('getLibraryVersion')
-			->willReturnCallback( function($lib) {
+			->willReturnCallback( function ($lib) {
 				if ($lib === 'curl') {
 					return "2.3.4";
 				}
@@ -64,7 +64,7 @@ class DependencyAnalyzerTest extends TestCase {
 			->getMock();
 		$this->l10nMock->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($text, $parameters = []) {
+			->willReturnCallback(function ($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			});
 

--- a/tests/lib/AppFramework/AppTest.php
+++ b/tests/lib/AppFramework/AppTest.php
@@ -87,7 +87,7 @@ class AppTest extends \Test\TestCase {
 	}
 
 
-	public function testControllerNameAndMethodAreBeingPassed(){
+	public function testControllerNameAndMethodAreBeingPassed() {
 		$return = ['HTTP/2.0 200 OK', [], [], null, new Response()];
 		$this->dispatcher->expects($this->once())
 			->method('dispatch')
@@ -127,7 +127,7 @@ class AppTest extends \Test\TestCase {
 	}
 
 
-	public function testOutputIsPrinted(){
+	public function testOutputIsPrinted() {
 		$return = ['HTTP/2.0 200 OK', [], [], $this->output, new Response()];
 		$this->dispatcher->expects($this->once())
 			->method('dispatch')
@@ -166,7 +166,7 @@ class AppTest extends \Test\TestCase {
 	}
 
 
-	public function testCallbackIsCalled(){
+	public function testCallbackIsCalled() {
 		$mock = $this->getMockBuilder('OCP\AppFramework\Http\ICallbackResponse')
 			->getMock();
 

--- a/tests/lib/AppFramework/Controller/AuthPublicShareControllerTest.php
+++ b/tests/lib/AppFramework/Controller/AuthPublicShareControllerTest.php
@@ -129,7 +129,7 @@ class AuthPublicShareControllerTest extends \Test\TestCase {
 		$hashSet = false;
 		$this->session
 			->method('set')
-			->willReturnCallback(function($key, $value) use (&$tokenSet, &$hashSet) {
+			->willReturnCallback(function ($key, $value) use (&$tokenSet, &$hashSet) {
 				if ($key === 'public_link_authenticated_token' && $value === 'token') {
 					$tokenSet = true;
 					return true;

--- a/tests/lib/AppFramework/Db/EntityTest.php
+++ b/tests/lib/AppFramework/Db/EntityTest.php
@@ -71,7 +71,7 @@ class EntityTest extends \Test\TestCase {
 	}
 
 
-	public function testResetUpdatedFields(){
+	public function testResetUpdatedFields() {
 		$entity = new TestEntity();
 		$entity->setId(3);
 		$entity->resetUpdatedFields();
@@ -80,7 +80,7 @@ class EntityTest extends \Test\TestCase {
 	}
 
 
-	public function testFromRow(){
+	public function testFromRow() {
 		$row = [
 			'pre_name' => 'john',
 			'email' => 'john@something.com'
@@ -92,7 +92,7 @@ class EntityTest extends \Test\TestCase {
 	}
 
 
-	public function testGetSetId(){
+	public function testGetSetId() {
 		$id = 3;
 		$this->entity->setId(3);
 
@@ -100,28 +100,28 @@ class EntityTest extends \Test\TestCase {
 	}
 
 
-	public function testColumnToPropertyNoReplacement(){
+	public function testColumnToPropertyNoReplacement() {
 		$column = 'my';
 		$this->assertEquals('my',
 			$this->entity->columnToProperty($column));
 	}
 
 
-	public function testColumnToProperty(){
+	public function testColumnToProperty() {
 		$column = 'my_attribute';
 		$this->assertEquals('myAttribute',
 			$this->entity->columnToProperty($column));
 	}
 
 
-	public function testPropertyToColumnNoReplacement(){
+	public function testPropertyToColumnNoReplacement() {
 		$property = 'my';
 		$this->assertEquals('my',
 			$this->entity->propertyToColumn($property));
 	}
 
 
-	public function testSetterMarksFieldUpdated(){
+	public function testSetterMarksFieldUpdated() {
 		$this->entity->setId(3);
 
 		$this->assertContains('id', $this->entity->getUpdatedFields());
@@ -129,7 +129,7 @@ class EntityTest extends \Test\TestCase {
 
 
 	
-	public function testCallShouldOnlyWorkForGetterSetter(){
+	public function testCallShouldOnlyWorkForGetterSetter() {
 		$this->expectException(\BadFunctionCallException::class);
 
 		$this->entity->something();
@@ -137,21 +137,21 @@ class EntityTest extends \Test\TestCase {
 
 
 	
-	public function testGetterShouldFailIfAttributeNotDefined(){
+	public function testGetterShouldFailIfAttributeNotDefined() {
 		$this->expectException(\BadFunctionCallException::class);
 
 		$this->entity->getTest();
 	}
 
 	
-	public function testSetterShouldFailIfAttributeNotDefined(){
+	public function testSetterShouldFailIfAttributeNotDefined() {
 		$this->expectException(\BadFunctionCallException::class);
 
 		$this->entity->setTest();
 	}
 
 
-	public function testFromRowShouldNotAssignEmptyArray(){
+	public function testFromRowShouldNotAssignEmptyArray() {
 		$row = [];
 		$entity2 = new TestEntity();
 
@@ -160,7 +160,7 @@ class EntityTest extends \Test\TestCase {
 	}
 
 
-	public function testIdGetsConvertedToInt(){
+	public function testIdGetsConvertedToInt() {
 		$row = ['id' => '4'];
 
 		$this->entity = TestEntity::fromRow($row);
@@ -168,7 +168,7 @@ class EntityTest extends \Test\TestCase {
 	}
 
 
-	public function testSetType(){
+	public function testSetType() {
 		$row = ['testId' => '4'];
 
 		$this->entity = TestEntity::fromRow($row);
@@ -176,7 +176,7 @@ class EntityTest extends \Test\TestCase {
 	}
 
 
-	public function testFromParams(){
+	public function testFromParams() {
 		$params = [
 			'testId' => 4,
 			'email' => 'john@doe'
@@ -189,7 +189,7 @@ class EntityTest extends \Test\TestCase {
 		$this->assertTrue($entity instanceof TestEntity);
 	}
 
-	public function testSlugify(){
+	public function testSlugify() {
 		$entity = new TestEntity();
 		$entity->setName('Slugify this!');
 		$this->assertEquals('slugify-this', $entity->slugify('name'));

--- a/tests/lib/AppFramework/Db/MapperTest.php
+++ b/tests/lib/AppFramework/Db/MapperTest.php
@@ -44,12 +44,12 @@ class Example extends Entity {
 
 
 class ExampleMapper extends Mapper {
-	public function __construct(IDBConnection $db){ parent::__construct($db, 'table'); }
-	public function find($table, $id){ return $this->findOneQuery($table, $id); }
-	public function findOneEntity($table, $id){ return $this->findEntity($table, $id); }
-	public function findAllEntities($table){ return $this->findEntities($table); }
-	public function mapRow($row){ return $this->mapRowToEntity($row); }
-	public function execSql($sql, $params){ return $this->execute($sql, $params); }
+	public function __construct(IDBConnection $db) { parent::__construct($db, 'table'); }
+	public function find($table, $id) { return $this->findOneQuery($table, $id); }
+	public function findOneEntity($table, $id) { return $this->findEntity($table, $id); }
+	public function findAllEntities($table) { return $this->findEntities($table); }
+	public function mapRow($row) { return $this->mapRowToEntity($row); }
+	public function execSql($sql, $params) { return $this->execute($sql, $params); }
 }
 
 
@@ -66,12 +66,12 @@ class MapperTest extends MapperTestUtility {
 	}
 
 
-	public function testMapperShouldSetTableName(){
+	public function testMapperShouldSetTableName() {
 		$this->assertEquals('*PREFIX*table', $this->mapper->getTableName());
 	}
 
 
-	public function testFindQuery(){
+	public function testFindQuery() {
 		$sql = 'hi';
 		$params = ['jo'];
 		$rows = [
@@ -81,7 +81,7 @@ class MapperTest extends MapperTestUtility {
 		$this->mapper->find($sql, $params);
 	}
 
-	public function testFindEntity(){
+	public function testFindEntity() {
 		$sql = 'hi';
 		$params = ['jo'];
 		$rows = [
@@ -91,7 +91,7 @@ class MapperTest extends MapperTestUtility {
 		$this->mapper->findOneEntity($sql, $params);
 	}
 
-	public function testFindNotFound(){
+	public function testFindNotFound() {
 		$sql = 'hi';
 		$params = ['jo'];
 		$rows = [];
@@ -100,7 +100,7 @@ class MapperTest extends MapperTestUtility {
 		$this->mapper->find($sql, $params);
 	}
 
-	public function testFindEntityNotFound(){
+	public function testFindEntityNotFound() {
 		$sql = 'hi';
 		$params = ['jo'];
 		$rows = [];
@@ -109,7 +109,7 @@ class MapperTest extends MapperTestUtility {
 		$this->mapper->findOneEntity($sql, $params);
 	}
 
-	public function testFindMultiple(){
+	public function testFindMultiple() {
 		$sql = 'hi';
 		$params = ['jo'];
 		$rows = [
@@ -120,7 +120,7 @@ class MapperTest extends MapperTestUtility {
 		$this->mapper->find($sql, $params);
 	}
 
-	public function testFindEntityMultiple(){
+	public function testFindEntityMultiple() {
 		$sql = 'hi';
 		$params = ['jo'];
 		$rows = [
@@ -132,7 +132,7 @@ class MapperTest extends MapperTestUtility {
 	}
 
 
-	public function testDelete(){
+	public function testDelete() {
 		$sql = 'DELETE FROM `*PREFIX*table` WHERE `id` = ?';
 		$params = [2];
 
@@ -144,7 +144,7 @@ class MapperTest extends MapperTestUtility {
 	}
 
 
-	public function testCreate(){
+	public function testCreate() {
 		$this->db->expects($this->once())
 			->method('lastInsertId')
 			->with($this->equalTo('*PREFIX*table'))
@@ -164,7 +164,7 @@ class MapperTest extends MapperTestUtility {
 	}
 
 
-	public function testCreateShouldReturnItemWithCorrectInsertId(){
+	public function testCreateShouldReturnItemWithCorrectInsertId() {
 		$this->db->expects($this->once())
 			->method('lastInsertId')
 			->with($this->equalTo('*PREFIX*table'))
@@ -195,7 +195,7 @@ class MapperTest extends MapperTestUtility {
 	}
 
 
-	public function testUpdate(){
+	public function testUpdate() {
 		$sql = 'UPDATE `*PREFIX*table` ' .
 				'SET ' .
 				'`pre_name` = ?,'.
@@ -214,7 +214,7 @@ class MapperTest extends MapperTestUtility {
 	}
 
 
-	public function testUpdateNoId(){
+	public function testUpdateNoId() {
 		$params = ['john', 'my@email'];
 		$entity = new Example();
 		$entity->setPreName($params[0]);
@@ -226,7 +226,7 @@ class MapperTest extends MapperTestUtility {
 	}
 
 
-	public function testUpdateNothingChangedNoQuery(){
+	public function testUpdateNothingChangedNoQuery() {
 		$params = ['john', 'my@email'];
 		$entity = new Example();
 		$entity->setId(3);
@@ -240,7 +240,7 @@ class MapperTest extends MapperTestUtility {
 	}
 
 
-	public function testMapRowToEntity(){
+	public function testMapRowToEntity() {
 		$entity1 = $this->mapper->mapRow(['pre_name' => 'test1', 'email' => 'test2']);
 		$entity2 = new Example();
 		$entity2->setPreName('test1');
@@ -249,7 +249,7 @@ class MapperTest extends MapperTestUtility {
 		$this->assertEquals($entity2, $entity1);
 	}
 
-	public function testFindEntities(){
+	public function testFindEntities() {
 		$sql = 'hi';
 		$rows = [
 			['pre_name' => 'hi']
@@ -262,7 +262,7 @@ class MapperTest extends MapperTestUtility {
 		$this->assertEquals([$entity], $result);
 	}
 
-	public function testFindEntitiesNotFound(){
+	public function testFindEntitiesNotFound() {
 		$sql = 'hi';
 		$rows = [];
 		$this->setMapperResult($sql, [], $rows);
@@ -270,7 +270,7 @@ class MapperTest extends MapperTestUtility {
 		$this->assertEquals([], $result);
 	}
 
-	public function testFindEntitiesMultiple(){
+	public function testFindEntitiesMultiple() {
 		$sql = 'hi';
 		$rows = [
 			['pre_name' => 'jo'], ['email' => 'ho']

--- a/tests/lib/AppFramework/Db/MapperTestUtility.php
+++ b/tests/lib/AppFramework/Db/MapperTestUtility.php
@@ -89,7 +89,7 @@ abstract class MapperTestUtility extends \Test\TestCase {
 	 * will be called on the result
 	 */
 	protected function setMapperResult($sql, $arguments=[], $returnRows=[],
-		$limit=null, $offset=null, $expectClose=false){
+		$limit=null, $offset=null, $expectClose=false) {
 		if($limit === null && $offset === null) {
 			$this->db->expects($this->at($this->prepareAt))
 				->method('prepare')
@@ -124,7 +124,7 @@ abstract class MapperTestUtility extends \Test\TestCase {
 		$this->query->expects($this->any())
 			->method('fetch')
 			->willReturnCallback(
-				function() use ($iterators, $fetchAt){
+				function () use ($iterators, $fetchAt) {
 					$iterator = $iterators[$fetchAt];
 					$result = $iterator->next();
 
@@ -164,7 +164,7 @@ abstract class MapperTestUtility extends \Test\TestCase {
 
 		$this->query->expects($this->at($this->queryAt))
 			->method('execute')
-			->willReturnCallback(function($sql, $p=null, $o=null, $s=null) {
+			->willReturnCallback(function ($sql, $p=null, $o=null, $s=null) {
 
 			});
 		$this->queryAt++;
@@ -191,11 +191,11 @@ class ArgumentIterator {
 
 	private $arguments;
 
-	public function __construct($arguments){
+	public function __construct($arguments) {
 		$this->arguments = $arguments;
 	}
 
-	public function next(){
+	public function next() {
 		$result = array_shift($this->arguments);
 		if($result === null){
 			return false;

--- a/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
+++ b/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
@@ -49,24 +49,24 @@ class DIContainerTest extends \Test\TestCase {
 	}
 
 
-	public function testProvidesRequest(){
+	public function testProvidesRequest() {
 		$this->assertTrue(isset($this->container['Request']));
 	}
 
-	public function testProvidesMiddlewareDispatcher(){
+	public function testProvidesMiddlewareDispatcher() {
 		$this->assertTrue(isset($this->container['MiddlewareDispatcher']));
 	}
 
-	public function testProvidesAppName(){
+	public function testProvidesAppName() {
 		$this->assertTrue(isset($this->container['AppName']));
 	}
 
 
-	public function testAppNameIsSetCorrectly(){
+	public function testAppNameIsSetCorrectly() {
 		$this->assertEquals('name', $this->container['AppName']);
 	}
 
-	public function testMiddlewareDispatcherIncludesSecurityMiddleware(){
+	public function testMiddlewareDispatcherIncludesSecurityMiddleware() {
 		$this->container['Request'] = new Request(
 			['method' => 'GET'],
 			$this->createMock(ISecureRandom::class),

--- a/tests/lib/AppFramework/Http/DispatcherTest.php
+++ b/tests/lib/AppFramework/Http/DispatcherTest.php
@@ -51,7 +51,7 @@ class TestController extends Controller {
 	 * @return array
 	 */
 	public function exec($int, $bool, $test=4, $test2=1) {
-		$this->registerResponder('text', function($in) {
+		$this->registerResponder('text', function ($in) {
 			return new JSONResponse(['text' => $in]);
 		});
 		return [$int, $bool, $test, $test2];
@@ -231,7 +231,7 @@ class DispatcherTest extends \Test\TestCase {
 	}
 
 
-	public function testHeadersAndOutputAreReturned(){
+	public function testHeadersAndOutputAreReturned() {
 		$out = 'yo';
 		$httpHeaders = 'Http';
 		$responseHeaders = ['hell' => 'yeah'];
@@ -281,12 +281,12 @@ class DispatcherTest extends \Test\TestCase {
 				->method('beforeController');
 		$this->middlewareDispatcher->expects($this->once())
 			->method('afterController')
-			->willReturnCallback(function($a, $b, $in) {
+			->willReturnCallback(function ($a, $b, $in) {
 				return $in;
 			});
 		$this->middlewareDispatcher->expects($this->once())
 			->method('beforeOutput')
-			->willReturnCallback(function($a, $b, $in) {
+			->willReturnCallback(function ($a, $b, $in) {
 				return $in;
 			});
 	}

--- a/tests/lib/AppFramework/Http/RedirectResponseTest.php
+++ b/tests/lib/AppFramework/Http/RedirectResponseTest.php
@@ -47,7 +47,7 @@ class RedirectResponseTest extends \Test\TestCase {
 	}
 
 
-	public function testGetRedirectUrl(){
+	public function testGetRedirectUrl() {
 		$this->assertEquals('/url', $this->response->getRedirectUrl());
 	}
 

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -716,7 +716,7 @@ class RequestTest extends \Test\TestCase {
 	public function testGetServerProtocolWithProtoValid() {
 		$this->config
 			->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				if ($key === 'trusted_proxies') {
 					return ['1.2.3.4'];
 				}
@@ -757,7 +757,7 @@ class RequestTest extends \Test\TestCase {
 	public function testGetServerProtocolWithHttpsServerValueOn() {
 		$this->config
 			->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				return $default;
 			});
 
@@ -778,7 +778,7 @@ class RequestTest extends \Test\TestCase {
 	public function testGetServerProtocolWithHttpsServerValueOff() {
 		$this->config
 			->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				return $default;
 			});
 
@@ -799,7 +799,7 @@ class RequestTest extends \Test\TestCase {
 	public function testGetServerProtocolWithHttpsServerValueEmpty() {
 		$this->config
 			->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				return $default;
 			});
 
@@ -820,7 +820,7 @@ class RequestTest extends \Test\TestCase {
 	public function testGetServerProtocolDefault() {
 		$this->config
 			->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				return $default;
 			});
 
@@ -837,7 +837,7 @@ class RequestTest extends \Test\TestCase {
 	public function testGetServerProtocolBehindLoadBalancers() {
 		$this->config
 			->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				if ($key === 'trusted_proxies') {
 					return ['1.2.3.4'];
 				}
@@ -1059,7 +1059,7 @@ class RequestTest extends \Test\TestCase {
 	public function testInsecureServerHostHttpFromForwardedHeaderSingle() {
 		$this->config
 			->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				if ($key === 'trusted_proxies') {
 					return ['1.2.3.4'];
 				}
@@ -1088,7 +1088,7 @@ class RequestTest extends \Test\TestCase {
 	public function testInsecureServerHostHttpFromForwardedHeaderStacked() {
 		$this->config
 			->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				if ($key === 'trusted_proxies') {
 					return ['1.2.3.4'];
 				}
@@ -1117,7 +1117,7 @@ class RequestTest extends \Test\TestCase {
 	public function testGetServerHostWithOverwriteHost() {
 		$this->config
 			->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				if ($key === 'overwritecondaddr') {
 					return '';
 				} else if ($key === 'overwritehost') {
@@ -1141,7 +1141,7 @@ class RequestTest extends \Test\TestCase {
 	public function testGetServerHostWithTrustedDomain() {
 		$this->config
 			->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				if ($key === 'trusted_proxies') {
 					return ['1.2.3.4'];
 				} else if ($key === 'trusted_domains') {
@@ -1170,7 +1170,7 @@ class RequestTest extends \Test\TestCase {
 	public function testGetServerHostWithUntrustedDomain() {
 		$this->config
 			->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				if ($key === 'trusted_proxies') {
 					return ['1.2.3.4'];
 				} else if ($key === 'trusted_domains') {
@@ -1199,7 +1199,7 @@ class RequestTest extends \Test\TestCase {
 	public function testGetServerHostWithNoTrustedDomain() {
 		$this->config
 			->method('getSystemValue')
-			->willReturnCallback(function($key, $default) {
+			->willReturnCallback(function ($key, $default) {
 				if ($key === 'trusted_proxies') {
 					return ['1.2.3.4'];
 				}

--- a/tests/lib/AppFramework/Http/ResponseTest.php
+++ b/tests/lib/AppFramework/Http/ResponseTest.php
@@ -40,7 +40,7 @@ class ResponseTest extends \Test\TestCase {
 	}
 
 
-	public function testAddHeader(){
+	public function testAddHeader() {
 		$this->childResponse->addHeader(' hello ', 'world');
 		$headers = $this->childResponse->getHeaders();
 		$this->assertEquals('world', $headers['hello']);
@@ -87,14 +87,14 @@ class ResponseTest extends \Test\TestCase {
 		$this->assertEquals(new Http\EmptyContentSecurityPolicy(), $this->childResponse->getContentSecurityPolicy());
 	}
 
-	public function testAddHeaderValueNullDeletesIt(){
+	public function testAddHeaderValueNullDeletesIt() {
 		$this->childResponse->addHeader('hello', 'world');
 		$this->childResponse->addHeader('hello', null);
 		$this->assertEquals(3, count($this->childResponse->getHeaders()));
 	}
 
 
-	public function testCacheHeadersAreDisabledByDefault(){
+	public function testCacheHeadersAreDisabledByDefault() {
 		$headers = $this->childResponse->getHeaders();
 		$this->assertEquals('no-cache, no-store, must-revalidate', $headers['Cache-Control']);
 	}
@@ -186,7 +186,7 @@ class ResponseTest extends \Test\TestCase {
 	}
 
 
-	public function testRenderReturnNullByDefault(){
+	public function testRenderReturnNullByDefault() {
 		$this->assertEquals(null, $this->childResponse->render());
 	}
 

--- a/tests/lib/AppFramework/Http/StreamResponseTest.php
+++ b/tests/lib/AppFramework/Http/StreamResponseTest.php
@@ -39,7 +39,7 @@ class StreamResponseTest extends \Test\TestCase {
 			->getMock();
 	}
 
-	public function testOutputNotModified(){
+	public function testOutputNotModified() {
 		$path = __FILE__;
 		$this->output->expects($this->once())
 			->method('getHttpResponseCode')
@@ -51,7 +51,7 @@ class StreamResponseTest extends \Test\TestCase {
 		$response->callback($this->output);
 	}
 
-	public function testOutputOk(){
+	public function testOutputOk() {
 		$path = __FILE__;
 		$this->output->expects($this->once())
 			->method('getHttpResponseCode')
@@ -65,7 +65,7 @@ class StreamResponseTest extends \Test\TestCase {
 		$response->callback($this->output);
 	}
 
-	public function testOutputNotFound(){
+	public function testOutputNotFound() {
 		$path = __FILE__ . 'test';
 		$this->output->expects($this->once())
 			->method('getHttpResponseCode')
@@ -80,7 +80,7 @@ class StreamResponseTest extends \Test\TestCase {
 		$response->callback($this->output);
 	}
 
-	public function testOutputReadFileError(){
+	public function testOutputReadFileError() {
 		$path = __FILE__;
 		$this->output->expects($this->once())
 			->method('getHttpResponseCode')

--- a/tests/lib/AppFramework/Http/TemplateResponseTest.php
+++ b/tests/lib/AppFramework/Http/TemplateResponseTest.php
@@ -40,7 +40,7 @@ class TemplateResponseTest extends \Test\TestCase {
 	}
 
 
-	public function testSetParamsConstructor(){
+	public function testSetParamsConstructor() {
 		$params = ['hi' => 'yo'];
 		$this->tpl = new TemplateResponse('app', 'home', $params);
 
@@ -48,7 +48,7 @@ class TemplateResponseTest extends \Test\TestCase {
 	}
 
 
-	public function testSetRenderAsConstructor(){
+	public function testSetRenderAsConstructor() {
 		$renderAs = 'myrender';
 		$this->tpl = new TemplateResponse('app', 'home', [], $renderAs);
 
@@ -56,7 +56,7 @@ class TemplateResponseTest extends \Test\TestCase {
 	}
 
 
-	public function testSetParams(){
+	public function testSetParams() {
 		$params = ['hi' => 'yo'];
 		$this->tpl->setParams($params);
 
@@ -64,11 +64,11 @@ class TemplateResponseTest extends \Test\TestCase {
 	}
 
 
-	public function testGetTemplateName(){
+	public function testGetTemplateName() {
 		$this->assertEquals('home', $this->tpl->getTemplateName());
 	}
 
-	public function testGetRenderAs(){
+	public function testGetRenderAs() {
 		$render = 'myrender';
 		$this->tpl->renderAs($render);
 		$this->assertEquals($render, $this->tpl->getRenderAs());

--- a/tests/lib/AppFramework/Middleware/AdditionalScriptsMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/AdditionalScriptsMiddlewareTest.php
@@ -82,7 +82,7 @@ class AdditionalScriptsMiddlewareTest extends \Test\TestCase {
 	public function testStandaloneTemplateResponse() {
 		$this->dispatcher->expects($this->once())
 			->method('dispatch')
-			->willReturnCallback(function($eventName) {
+			->willReturnCallback(function ($eventName) {
 				if ($eventName === TemplateResponse::EVENT_LOAD_ADDITIONAL_SCRIPTS) {
 					return;
 				}
@@ -98,7 +98,7 @@ class AdditionalScriptsMiddlewareTest extends \Test\TestCase {
 	public function testTemplateResponseNotLoggedIn() {
 		$this->dispatcher->expects($this->once())
 			->method('dispatch')
-			->willReturnCallback(function($eventName) {
+			->willReturnCallback(function ($eventName) {
 				if ($eventName === TemplateResponse::EVENT_LOAD_ADDITIONAL_SCRIPTS) {
 					return;
 				}
@@ -116,7 +116,7 @@ class AdditionalScriptsMiddlewareTest extends \Test\TestCase {
 
 		$this->dispatcher->expects($this->exactly(2))
 			->method('dispatch')
-			->willReturnCallback(function($eventName) use (&$events) {
+			->willReturnCallback(function ($eventName) use (&$events) {
 				if ($eventName === TemplateResponse::EVENT_LOAD_ADDITIONAL_SCRIPTS ||
 					$eventName === TemplateResponse::EVENT_LOAD_ADDITIONAL_SCRIPTS_LOGGEDIN) {
 					$events[] = $eventName;

--- a/tests/lib/AppFramework/Middleware/MiddlewareDispatcherTest.php
+++ b/tests/lib/AppFramework/Middleware/MiddlewareDispatcherTest.php
@@ -60,7 +60,7 @@ class TestMiddleware extends Middleware {
 		$this->beforeControllerThrowsEx = $beforeControllerThrowsEx;
 	}
 
-	public function beforeController($controller, $methodName){
+	public function beforeController($controller, $methodName) {
 		self::$beforeControllerCalled++;
 		$this->beforeControllerOrder = self::$beforeControllerCalled;
 		$this->controller = $controller;
@@ -70,7 +70,7 @@ class TestMiddleware extends Middleware {
 		}
 	}
 
-	public function afterException($controller, $methodName, \Exception $exception){
+	public function afterException($controller, $methodName, \Exception $exception) {
 		self::$afterExceptionCalled++;
 		$this->afterExceptionOrder = self::$afterExceptionCalled;
 		$this->controller = $controller;
@@ -79,7 +79,7 @@ class TestMiddleware extends Middleware {
 		parent::afterException($controller, $methodName, $exception);
 	}
 
-	public function afterController($controller, $methodName, Response $response){
+	public function afterController($controller, $methodName, Response $response) {
 		self::$afterControllerCalled++;
 		$this->afterControllerOrder = self::$afterControllerCalled;
 		$this->controller = $controller;
@@ -88,7 +88,7 @@ class TestMiddleware extends Middleware {
 		return parent::afterController($controller, $methodName, $response);
 	}
 
-	public function beforeOutput($controller, $methodName, $output){
+	public function beforeOutput($controller, $methodName, $output) {
 		self::$beforeOutputCalled++;
 		$this->beforeOutputOrder = self::$beforeOutputCalled;
 		$this->controller = $controller;
@@ -124,7 +124,7 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 	}
 
 
-	private function getControllerMock(){
+	private function getControllerMock() {
 		return $this->getMockBuilder('OCP\AppFramework\Controller')
 			->setMethods(['method'])
 			->setConstructorArgs(['app',
@@ -137,14 +137,14 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 	}
 
 
-	private function getMiddleware($beforeControllerThrowsEx=false){
+	private function getMiddleware($beforeControllerThrowsEx=false) {
 		$m1 = new TestMiddleware($beforeControllerThrowsEx);
 		$this->dispatcher->registerMiddleware($m1);
 		return $m1;
 	}
 
 
-	public function testAfterExceptionShouldReturnResponseOfMiddleware(){
+	public function testAfterExceptionShouldReturnResponseOfMiddleware() {
 		$response = new Response();
 		$m1 = $this->getMockBuilder('\OCP\AppFramework\Middleware')
 			->setMethods(['afterException', 'beforeController'])
@@ -167,7 +167,7 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 	}
 
 
-	public function testAfterExceptionShouldThrowAgainWhenNotHandled(){
+	public function testAfterExceptionShouldThrowAgainWhenNotHandled() {
 		$m1 = new TestMiddleware(false);
 		$m2 = new TestMiddleware(true);
 
@@ -180,7 +180,7 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 	}
 
 
-	public function testBeforeControllerCorrectArguments(){
+	public function testBeforeControllerCorrectArguments() {
 		$m1 = $this->getMiddleware();
 		$this->dispatcher->beforeController($this->controller, $this->method);
 
@@ -189,7 +189,7 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 	}
 
 
-	public function testAfterControllerCorrectArguments(){
+	public function testAfterControllerCorrectArguments() {
 		$m1 = $this->getMiddleware();
 
 		$this->dispatcher->afterController($this->controller, $this->method, $this->response);
@@ -200,7 +200,7 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 	}
 
 
-	public function testAfterExceptionCorrectArguments(){
+	public function testAfterExceptionCorrectArguments() {
 		$m1 = $this->getMiddleware();
 
 		$this->expectException(\Exception::class);
@@ -214,7 +214,7 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 	}
 
 
-	public function testBeforeOutputCorrectArguments(){
+	public function testBeforeOutputCorrectArguments() {
 		$m1 = $this->getMiddleware();
 
 		$this->dispatcher->beforeOutput($this->controller, $this->method, $this->out);
@@ -225,7 +225,7 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 	}
 
 
-	public function testBeforeControllerOrder(){
+	public function testBeforeControllerOrder() {
 		$m1 = $this->getMiddleware();
 		$m2 = $this->getMiddleware();
 
@@ -235,7 +235,7 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 		$this->assertEquals(2, $m2->beforeControllerOrder);
 	}
 
-	public function testAfterControllerOrder(){
+	public function testAfterControllerOrder() {
 		$m1 = $this->getMiddleware();
 		$m2 = $this->getMiddleware();
 
@@ -246,7 +246,7 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 	}
 
 
-	public function testAfterExceptionOrder(){
+	public function testAfterExceptionOrder() {
 		$m1 = $this->getMiddleware();
 		$m2 = $this->getMiddleware();
 
@@ -259,7 +259,7 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 	}
 
 
-	public function testBeforeOutputOrder(){
+	public function testBeforeOutputOrder() {
 		$m1 = $this->getMiddleware();
 		$m2 = $this->getMiddleware();
 
@@ -270,7 +270,7 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 	}
 
 
-	public function testExceptionShouldRunAfterExceptionOfOnlyPreviouslyExecutedMiddlewares(){
+	public function testExceptionShouldRunAfterExceptionOfOnlyPreviouslyExecutedMiddlewares() {
 		$m1 = $this->getMiddleware();
 		$m2 = $this->getMiddleware(true);
 		$m3 = $this->getMockBuilder('\OCP\AppFramework\Middleware')->getMock();

--- a/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
@@ -112,7 +112,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	 * @PublicPage
 	 * @NoCSRFRequired
 	 */
-	public function testSetNavigationEntry(){
+	public function testSetNavigationEntry() {
 		$this->navigationManager->expects($this->once())
 			->method('setActiveEntry')
 			->with($this->equalTo('files'));
@@ -208,7 +208,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	 * @PublicPage
 	 * @NoCSRFRequired
 	 */
-	public function testNoChecks(){
+	public function testNoChecks() {
 		$this->request->expects($this->never())
 			->method('passesCSRFCheck')
 			->willReturn(false);
@@ -224,7 +224,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	 * @param string $method
 	 * @param string $expects
 	 */
-	private function securityCheck($method, $expects, $shouldFail=false){
+	private function securityCheck($method, $expects, $shouldFail=false) {
 		// admin check requires login
 		if ($expects === 'isAdminUser') {
 			$isLoggedIn = true;
@@ -250,7 +250,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	/**
 	 * @PublicPage
 	 */
-	public function testCsrfCheck(){
+	public function testCsrfCheck() {
 		$this->expectException(\OC\AppFramework\Middleware\Security\Exceptions\CrossSiteRequestForgeryException::class);
 
 		$this->request->expects($this->once())
@@ -268,7 +268,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	 * @PublicPage
 	 * @NoCSRFRequired
 	 */
-	public function testNoCsrfCheck(){
+	public function testNoCsrfCheck() {
 		$this->request->expects($this->never())
 			->method('passesCSRFCheck')
 			->willReturn(false);
@@ -280,7 +280,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	/**
 	 * @PublicPage
 	 */
-	public function testPassesCsrfCheck(){
+	public function testPassesCsrfCheck() {
 		$this->request->expects($this->once())
 			->method('passesCSRFCheck')
 			->willReturn(true);
@@ -295,7 +295,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	/**
 	 * @PublicPage
 	 */
-	public function testFailCsrfCheck(){
+	public function testFailCsrfCheck() {
 		$this->expectException(\OC\AppFramework\Middleware\Security\Exceptions\CrossSiteRequestForgeryException::class);
 
 		$this->request->expects($this->once())
@@ -411,7 +411,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	 * @NoCSRFRequired
 	 * @NoAdminRequired
 	 */
-	public function testLoggedInCheck(){
+	public function testLoggedInCheck() {
 		$this->securityCheck(__FUNCTION__, 'isLoggedIn');
 	}
 
@@ -420,7 +420,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	 * @NoCSRFRequired
 	 * @NoAdminRequired
 	 */
-	public function testFailLoggedInCheck(){
+	public function testFailLoggedInCheck() {
 		$this->securityCheck(__FUNCTION__, 'isLoggedIn', true);
 	}
 
@@ -428,7 +428,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	/**
 	 * @NoCSRFRequired
 	 */
-	public function testIsAdminCheck(){
+	public function testIsAdminCheck() {
 		$this->securityCheck(__FUNCTION__, 'isAdminUser');
 	}
 
@@ -436,7 +436,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	 * @NoCSRFRequired
 	 * @SubAdminRequired
 	 */
-	public function testIsNotSubAdminCheck(){
+	public function testIsNotSubAdminCheck() {
 		$this->reader->reflect(__CLASS__,__FUNCTION__);
 		$sec = $this->getMiddleware(true, false, false);
 
@@ -448,7 +448,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	 * @NoCSRFRequired
 	 * @SubAdminRequired
 	 */
-	public function testIsSubAdminCheck(){
+	public function testIsSubAdminCheck() {
 		$this->reader->reflect(__CLASS__,__FUNCTION__);
 		$sec = $this->getMiddleware(true, false, true);
 
@@ -460,7 +460,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	 * @NoCSRFRequired
 	 * @SubAdminRequired
 	 */
-	public function testIsSubAdminAndAdminCheck(){
+	public function testIsSubAdminAndAdminCheck() {
 		$this->reader->reflect(__CLASS__,__FUNCTION__);
 		$sec = $this->getMiddleware(true, true, true);
 
@@ -471,12 +471,12 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	/**
 	 * @NoCSRFRequired
 	 */
-	public function testFailIsAdminCheck(){
+	public function testFailIsAdminCheck() {
 		$this->securityCheck(__FUNCTION__, 'isAdminUser', true);
 	}
 
 
-	public function testAfterExceptionNotCaughtThrowsItAgain(){
+	public function testAfterExceptionNotCaughtThrowsItAgain() {
 		$ex = new \Exception();
 		$this->expectException(\Exception::class);
 		$this->middleware->afterException($this->controller, 'test', $ex);
@@ -588,7 +588,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->assertEquals($expected , $response);
 	}
 
-	public function testAfterAjaxExceptionReturnsJSONError(){
+	public function testAfterAjaxExceptionReturnsJSONError() {
 		$response = $this->middleware->afterException($this->controller, 'test',
 			$this->secAjaxException);
 

--- a/tests/lib/AppFramework/Utility/ControllerMethodReflectorTest.php
+++ b/tests/lib/AppFramework/Utility/ControllerMethodReflectorTest.php
@@ -30,17 +30,17 @@ class BaseController {
 	/**
 	 * @Annotation
 	 */
-	public function test(){}
+	public function test() {}
 
 	/**
 	 * @Annotation
 	 */
-	public function test2(){}
+	public function test2() {}
 
 	/**
 	 * @Annotation
 	 */
-	public function test3(){}
+	public function test3() {}
 
 }
 
@@ -63,7 +63,7 @@ class ControllerMethodReflectorTest extends \Test\TestCase {
 	/**
 	 * @Annotation
 	 */
-	public function testReadAnnotation(){
+	public function testReadAnnotation() {
 		$reader = new ControllerMethodReflector();
 		$reader->reflect(
 			'\Test\AppFramework\Utility\ControllerMethodReflectorTest',
@@ -105,7 +105,7 @@ class ControllerMethodReflectorTest extends \Test\TestCase {
 	 * @Annotation
 	 * @param test
 	 */
-	public function testReadAnnotationNoLowercase(){
+	public function testReadAnnotationNoLowercase() {
 		$reader = new ControllerMethodReflector();
 		$reader->reflect(
 			'\Test\AppFramework\Utility\ControllerMethodReflectorTest',
@@ -121,7 +121,7 @@ class ControllerMethodReflectorTest extends \Test\TestCase {
 	 * @Annotation
 	 * @param int $test
 	 */
-	public function testReadTypeIntAnnotations(){
+	public function testReadTypeIntAnnotations() {
 		$reader = new ControllerMethodReflector();
 		$reader->reflect(
 			'\Test\AppFramework\Utility\ControllerMethodReflectorTest',
@@ -136,12 +136,12 @@ class ControllerMethodReflectorTest extends \Test\TestCase {
 	 * @param int $a
 	 * @param int $b
 	 */
-	public function arguments3($a, float $b, int $c, $d){}
+	public function arguments3($a, float $b, int $c, $d) {}
 
 	/**
 	 * @requires PHP 7
 	 */
-	public function testReadTypeIntAnnotationsScalarTypes(){
+	public function testReadTypeIntAnnotationsScalarTypes() {
 		$reader = new ControllerMethodReflector();
 		$reader->reflect(
 			'\Test\AppFramework\Utility\ControllerMethodReflectorTest',
@@ -159,7 +159,7 @@ class ControllerMethodReflectorTest extends \Test\TestCase {
 	 * @Annotation
 	 * @param double $test something special
 	 */
-	public function testReadTypeDoubleAnnotations(){
+	public function testReadTypeDoubleAnnotations() {
 		$reader = new ControllerMethodReflector();
 		$reader->reflect(
 			'\Test\AppFramework\Utility\ControllerMethodReflectorTest',
@@ -173,7 +173,7 @@ class ControllerMethodReflectorTest extends \Test\TestCase {
 	 * @Annotation
 	 * @param 	string  $foo
 	 */
-	public function testReadTypeWhitespaceAnnotations(){
+	public function testReadTypeWhitespaceAnnotations() {
 		$reader = new ControllerMethodReflector();
 		$reader->reflect(
 			'\Test\AppFramework\Utility\ControllerMethodReflectorTest',

--- a/tests/lib/AppFramework/Utility/SimpleContainerTest.php
+++ b/tests/lib/AppFramework/Utility/SimpleContainerTest.php
@@ -158,7 +158,7 @@ class SimpleContainerTest extends \Test\TestCase {
 	}
 
 	public function testRegisterAliasService() {
-		$this->container->registerService('test', function() {
+		$this->container->registerService('test', function () {
 			return new \StdClass;
 		}, true);
 		$this->container->registerAlias('test1', 'test');
@@ -183,7 +183,7 @@ class SimpleContainerTest extends \Test\TestCase {
 	 * @dataProvider sanitizeNameProvider
 	 */
 	public function testSanitizeName($register, $query) {
-		$this->container->registerService($register, function() {
+		$this->container->registerService($register, function () {
 			return 'abc';
 		});
 		$this->assertEquals('abc', $this->container->query($query));
@@ -199,7 +199,7 @@ class SimpleContainerTest extends \Test\TestCase {
 	}
 
 	public function testRegisterFactory() {
-		$this->container->registerService('test', function() {
+		$this->container->registerService('test', function () {
 			return new \StdClass();
 		}, false);
 		$this->assertNotSame(
@@ -207,7 +207,7 @@ class SimpleContainerTest extends \Test\TestCase {
 	}
 
 	public function testRegisterAliasFactory() {
-		$this->container->registerService('test', function() {
+		$this->container->registerService('test', function () {
 			return new \StdClass();
 		}, false);
 		$this->container->registerAlias('test1', 'test');

--- a/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
@@ -285,7 +285,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 		$this->mapper
 			->expects($this->at(2))
 			->method('delete')
-			->with($this->callback(function($token) use ($oldToken) {
+			->with($this->callback(function ($token) use ($oldToken) {
 				return $token === $oldToken;
 			}));
 
@@ -325,7 +325,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 		$this->mapper
 			->expects($this->at(2))
 			->method('delete')
-			->with($this->callback(function($token) use ($oldToken) {
+			->with($this->callback(function ($token) use ($oldToken) {
 				return $token === $oldToken;
 			}));
 

--- a/tests/lib/Authentication/TwoFactorAuth/MandatoryTwoFactorTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/MandatoryTwoFactorTest.php
@@ -109,7 +109,7 @@ class MandatoryTwoFactorTest extends TestCase {
 				['twofactor_enforced_excluded_groups', [], []],
 			]);
 		$this->groupManager->method('isInGroup')
-			->willReturnCallback(function($user, $group) {
+			->willReturnCallback(function ($user, $group) {
 				return $user === 'user123' && $group ==='twofactorers';
 			});
 
@@ -147,7 +147,7 @@ class MandatoryTwoFactorTest extends TestCase {
 				['twofactor_enforced_excluded_groups', [], ['yoloers']],
 			]);
 		$this->groupManager->method('isInGroup')
-			->willReturnCallback(function($user, $group) {
+			->willReturnCallback(function ($user, $group) {
 				return $user === 'user123' && $group ==='yoloers';
 			});
 

--- a/tests/lib/Authentication/TwoFactorAuth/RegistryTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/RegistryTest.php
@@ -81,7 +81,7 @@ class RegistryTest extends TestCase {
 			->method('dispatch')
 			->with(
 				$this->equalTo(IRegistry::EVENT_PROVIDER_ENABLED),
-				$this->callback(function(RegistryEvent $e) use ($user, $provider) {
+				$this->callback(function (RegistryEvent $e) use ($user, $provider) {
 					return $e->getUser() === $user && $e->getProvider() === $provider;
 				})
 			);
@@ -102,7 +102,7 @@ class RegistryTest extends TestCase {
 			->method('dispatch')
 			->with(
 				$this->equalTo(IRegistry::EVENT_PROVIDER_DISABLED),
-				$this->callback(function(RegistryEvent $e) use ($user, $provider) {
+				$this->callback(function (RegistryEvent $e) use ($user, $provider) {
 					return $e->getUser() === $user && $e->getProvider() === $provider;
 				})
 			);

--- a/tests/lib/Avatar/UserAvatarTest.php
+++ b/tests/lib/Avatar/UserAvatarTest.php
@@ -57,13 +57,13 @@ class UserAvatarTest extends \Test\TestCase {
 			->willReturn($file);
 
 		$this->folder->method('getFile')
-			->willReturnCallback(function($path) {
+			->willReturnCallback(function ($path) {
 				if ($path === 'avatar.64.png') {
 					throw new NotFoundException();
 				}
 			});
 		$this->folder->method('fileExists')
-			->willReturnCallback(function($path) {
+			->willReturnCallback(function ($path) {
 				if ($path === 'generated') {
 					return true;
 				}
@@ -134,7 +134,7 @@ class UserAvatarTest extends \Test\TestCase {
 
 		$this->folder->method('getFile')
 			->willReturnCallback(
-				function($path) use ($file) {
+				function ($path) use ($file) {
 					if ($path === 'avatar.png') {
 						return $file;
 					} else {

--- a/tests/lib/CapabilitiesManagerTest.php
+++ b/tests/lib/CapabilitiesManagerTest.php
@@ -53,7 +53,7 @@ class CapabilitiesManagerTest extends TestCase {
 	 * Test a valid capabilitie
 	 */
 	public function testValidCapability() {
-		$this->manager->registerCapability(function() {
+		$this->manager->registerCapability(function () {
 			return new SimpleCapability();
 		});
 
@@ -65,13 +65,13 @@ class CapabilitiesManagerTest extends TestCase {
 	 * Test a public capabilitie
 	 */
 	public function testPublicCapability() {
-		$this->manager->registerCapability(function() {
+		$this->manager->registerCapability(function () {
 			return new PublicSimpleCapability1();
 		});
-		$this->manager->registerCapability(function() {
+		$this->manager->registerCapability(function () {
 			return new SimpleCapability2();
 		});
-		$this->manager->registerCapability(function() {
+		$this->manager->registerCapability(function () {
 			return new SimpleCapability3();
 		});
 
@@ -86,7 +86,7 @@ class CapabilitiesManagerTest extends TestCase {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('The given Capability (Test\\NoCapability) does not implement the ICapability interface');
 
-		$this->manager->registerCapability(function() {
+		$this->manager->registerCapability(function () {
 			return new NoCapability();
 		});
 
@@ -98,13 +98,13 @@ class CapabilitiesManagerTest extends TestCase {
 	 * Test a bunch of merged Capabilities
 	 */
 	public function testMergedCapabilities() {
-		$this->manager->registerCapability(function() {
+		$this->manager->registerCapability(function () {
 			return new SimpleCapability();
 		});
-		$this->manager->registerCapability(function() {
+		$this->manager->registerCapability(function () {
 			return new SimpleCapability2();
 		});
-		$this->manager->registerCapability(function() {
+		$this->manager->registerCapability(function () {
 			return new SimpleCapability3();
 		});
 
@@ -124,10 +124,10 @@ class CapabilitiesManagerTest extends TestCase {
 	 * Test deep identical capabilities
 	 */
 	public function testDeepIdenticalCapabilities() {
-		$this->manager->registerCapability(function() {
+		$this->manager->registerCapability(function () {
 			return new DeepCapability();
 		});
-		$this->manager->registerCapability(function() {
+		$this->manager->registerCapability(function () {
 			return new DeepCapability();
 		});
 

--- a/tests/lib/Collaboration/Collaborators/GroupPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/GroupPluginTest.php
@@ -459,8 +459,7 @@ class GroupPluginTest extends TestCase {
 		$this->config->expects($this->any())
 			->method('getAppValue')
 			->willReturnCallback(
-				function($appName, $key, $default)
-				use ($shareWithGroupOnly, $shareeEnumeration)
+				function ($appName, $key, $default) use ($shareWithGroupOnly, $shareeEnumeration)
 				{
 					if ($appName === 'core' && $key === 'shareapi_only_share_with_group_members') {
 						return $shareWithGroupOnly ? 'yes' : 'no';

--- a/tests/lib/Collaboration/Collaborators/MailPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/MailPluginTest.php
@@ -86,8 +86,7 @@ class MailPluginTest extends TestCase {
 		$this->config->expects($this->any())
 			->method('getAppValue')
 			->willReturnCallback(
-				function($appName, $key, $default)
-				use ($shareeEnumeration)
+				function ($appName, $key, $default) use ($shareeEnumeration)
 				{
 					if ($appName === 'core' && $key === 'shareapi_allow_share_dialog_user_enumeration') {
 						return $shareeEnumeration ? 'yes' : 'no';
@@ -534,7 +533,7 @@ class MailPluginTest extends TestCase {
 		$this->config->expects($this->any())
 			->method('getAppValue')
 			->willReturnCallback(
-				function($appName, $key, $default) {
+				function ($appName, $key, $default) {
 					if ($appName === 'core' && $key === 'shareapi_allow_share_dialog_user_enumeration') {
 						return 'yes';
 					} else if ($appName === 'core' && $key === 'shareapi_only_share_with_group_members') {
@@ -564,13 +563,13 @@ class MailPluginTest extends TestCase {
 
 		$this->groupManager->expects($this->any())
 			->method('getUserGroupIds')
-			->willReturnCallback(function(\OCP\IUser $user) use ($userToGroupMapping) {
+			->willReturnCallback(function (\OCP\IUser $user) use ($userToGroupMapping) {
 				return $userToGroupMapping[$user->getUID()];
 			});
 
 		$this->groupManager->expects($this->any())
 			->method('isInGroup')
-			->willReturnCallback(function($userId, $group) use ($userToGroupMapping) {
+			->willReturnCallback(function ($userId, $group) use ($userToGroupMapping) {
 				return in_array($group, $userToGroupMapping[$userId]);
 			});
 

--- a/tests/lib/Collaboration/Collaborators/RemotePluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/RemotePluginTest.php
@@ -92,8 +92,7 @@ class RemotePluginTest extends TestCase {
 		$this->config->expects($this->any())
 			->method('getAppValue')
 			->willReturnCallback(
-				function($appName, $key, $default)
-				use ($shareeEnumeration)
+				function ($appName, $key, $default) use ($shareeEnumeration)
 				{
 					if ($appName === 'core' && $key === 'shareapi_allow_share_dialog_user_enumeration') {
 						return $shareeEnumeration ? 'yes' : 'no';

--- a/tests/lib/Collaboration/Collaborators/SearchTest.php
+++ b/tests/lib/Collaboration/Collaborators/SearchTest.php
@@ -75,7 +75,7 @@ class SearchTest extends TestCase {
 		$userPlugin = $this->createMock(ISearchPlugin::class);
 		$userPlugin->expects($this->any())
 			->method('search')
-			->willReturnCallback(function() use ($searchResult, $mockedUserResult, $expectedMoreResults) {
+			->willReturnCallback(function () use ($searchResult, $mockedUserResult, $expectedMoreResults) {
 				$type = new SearchResultType('users');
 				$searchResult->addResultSet($type, $mockedUserResult);
 				return $expectedMoreResults;
@@ -84,7 +84,7 @@ class SearchTest extends TestCase {
 		$groupPlugin = $this->createMock(ISearchPlugin::class);
 		$groupPlugin->expects($this->any())
 			->method('search')
-			->willReturnCallback(function() use ($searchResult, $mockedGroupsResult, $expectedMoreResults) {
+			->willReturnCallback(function () use ($searchResult, $mockedGroupsResult, $expectedMoreResults) {
 				$type = new SearchResultType('groups');
 				$searchResult->addResultSet($type, $mockedGroupsResult);
 				return $expectedMoreResults;
@@ -93,7 +93,7 @@ class SearchTest extends TestCase {
 		$remotePlugin = $this->createMock(ISearchPlugin::class);
 		$remotePlugin->expects($this->any())
 			->method('search')
-			->willReturnCallback(function() use ($searchResult, $mockedRemotesResult, $expectedMoreResults) {
+			->willReturnCallback(function () use ($searchResult, $mockedRemotesResult, $expectedMoreResults) {
 				if($mockedRemotesResult !== null) {
 					$type = new SearchResultType('remotes');
 					$searchResult->addResultSet($type, $mockedRemotesResult['results'], $mockedRemotesResult['exact']);
@@ -106,7 +106,7 @@ class SearchTest extends TestCase {
 
 		$this->container->expects($this->any())
 			->method('resolve')
-			->willReturnCallback(function($class) use ($searchResult, $userPlugin, $groupPlugin, $remotePlugin) {
+			->willReturnCallback(function ($class) use ($searchResult, $userPlugin, $groupPlugin, $remotePlugin) {
 				if($class === SearchResult::class) {
 					return $searchResult;
 				} elseif ($class === $userPlugin) {

--- a/tests/lib/Collaboration/Collaborators/UserPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/UserPluginTest.php
@@ -94,8 +94,7 @@ class UserPluginTest extends TestCase {
 		$this->config->expects($this->any())
 			->method('getAppValue')
 			->willReturnCallback(
-				function ($appName, $key, $default)
-				use ($shareWithGroupOnly, $shareeEnumeration, $shareeEnumerationLimitToGroup) {
+				function ($appName, $key, $default) use ($shareWithGroupOnly, $shareeEnumeration, $shareeEnumerationLimitToGroup) {
 					if ($appName === 'core' && $key === 'shareapi_only_share_with_group_members') {
 						return $shareWithGroupOnly ? 'yes' : 'no';
 					} else if ($appName === 'core' && $key === 'shareapi_allow_share_dialog_user_enumeration') {

--- a/tests/lib/Comments/CommentTest.php
+++ b/tests/lib/Comments/CommentTest.php
@@ -112,7 +112,7 @@ class CommentTest extends TestCase {
 	/**
 	 * @dataProvider roleSetterProvider
 	 */
-	public function testSetRoleInvalidInput($role, $type, $id){
+	public function testSetRoleInvalidInput($role, $type, $id) {
 		$this->expectException(\InvalidArgumentException::class);
 
 		$comment = new Comment();

--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -378,7 +378,7 @@ class ManagerTest extends TestCase {
 			$expected = array_reverse($expected);
 		}
 
-		$this->assertSame($expected, array_map(function(IComment $c) {
+		$this->assertSame($expected, array_map(function (IComment $c) {
 			return (int) $c->getId();
 		}, $comments));
 	}

--- a/tests/lib/ContactsManagerTest.php
+++ b/tests/lib/ContactsManagerTest.php
@@ -14,7 +14,7 @@ class ContactsManagerTest extends \Test\TestCase {
 		$this->cm = new \OC\ContactsManager();
 	}
 
-	public function searchProvider(){
+	public function searchProvider() {
 		$search1 = [
 			0 => [
 				'N' => [0 => '', 1 => 'Jan', 2 => 'Jansen', 3 => '', 4 => '',],
@@ -62,7 +62,7 @@ class ContactsManagerTest extends \Test\TestCase {
 	/**
 	 * @dataProvider searchProvider
 	 */
-	public function testSearch($search1, $search2, $expectedResult ){
+	public function testSearch($search1, $search2, $expectedResult) {
 		/** @var \PHPUnit_Framework_MockObject_MockObject|IAddressBook $addressbook */
 		$addressbook1 = $this->getMockBuilder('\OCP\IAddressBook')
 			->disableOriginalConstructor()
@@ -96,7 +96,7 @@ class ContactsManagerTest extends \Test\TestCase {
 	}
 	
 
-	public function testDeleteHavePermission(){
+	public function testDeleteHavePermission() {
 		/** @var \PHPUnit_Framework_MockObject_MockObject|IAddressBook $addressbook */
 		$addressbook = $this->getMockBuilder('\OCP\IAddressBook')
 			->disableOriginalConstructor()
@@ -116,7 +116,7 @@ class ContactsManagerTest extends \Test\TestCase {
 		$this->assertEquals($result, 'returnMe');
 	}
 
-	public function testDeleteNoPermission(){
+	public function testDeleteNoPermission() {
 		/** @var \PHPUnit_Framework_MockObject_MockObject|IAddressBook $addressbook */
 		$addressbook = $this->getMockBuilder('\OCP\IAddressBook')
 			->disableOriginalConstructor()
@@ -134,7 +134,7 @@ class ContactsManagerTest extends \Test\TestCase {
 		$this->assertEquals($result, null);
 	}
 
-	public function testDeleteNoAddressbook(){
+	public function testDeleteNoAddressbook() {
 		/** @var \PHPUnit_Framework_MockObject_MockObject|IAddressBook $addressbook */
 		$addressbook = $this->getMockBuilder('\OCP\IAddressBook')
 			->disableOriginalConstructor()
@@ -149,7 +149,7 @@ class ContactsManagerTest extends \Test\TestCase {
 
 	}
 
-	public function testCreateOrUpdateHavePermission(){
+	public function testCreateOrUpdateHavePermission() {
 		/** @var \PHPUnit_Framework_MockObject_MockObject|IAddressBook $addressbook */
 		$addressbook = $this->getMockBuilder('\OCP\IAddressBook')
 			->disableOriginalConstructor()
@@ -168,7 +168,7 @@ class ContactsManagerTest extends \Test\TestCase {
 		$this->assertEquals($result, 'returnMe');
 	}
 
-	public function testCreateOrUpdateNoPermission(){
+	public function testCreateOrUpdateNoPermission() {
 		/** @var \PHPUnit_Framework_MockObject_MockObject|IAddressBook $addressbook */
 		$addressbook = $this->getMockBuilder('\OCP\IAddressBook')
 			->disableOriginalConstructor()
@@ -187,7 +187,7 @@ class ContactsManagerTest extends \Test\TestCase {
 
 	}
 
-	public function testCreateOrUpdateNOAdressbook(){
+	public function testCreateOrUpdateNOAdressbook() {
 		/** @var \PHPUnit_Framework_MockObject_MockObject|IAddressBook $addressbook */
 		$addressbook = $this->getMockBuilder('\OCP\IAddressBook')
 			->disableOriginalConstructor()
@@ -201,12 +201,12 @@ class ContactsManagerTest extends \Test\TestCase {
 		$this->assertEquals($result, null);
 	}
 
-	public function testIsEnabledIfNot(){
+	public function testIsEnabledIfNot() {
 		$result = $this->cm->isEnabled();
 		$this->assertFalse($result);
 	}
 
-	public function testIsEnabledIfSo(){
+	public function testIsEnabledIfSo() {
 		/** @var \PHPUnit_Framework_MockObject_MockObject|IAddressBook $addressbook */
 		$addressbook = $this->getMockBuilder('\OCP\IAddressBook')
 			->disableOriginalConstructor()

--- a/tests/lib/Encryption/DecryptAllTest.php
+++ b/tests/lib/Encryption/DecryptAllTest.php
@@ -177,7 +177,7 @@ class DecryptAllTest extends TestCase {
 			->with($this->inputInterface, $this->outputInterface, $user)
 			->willReturn($success);
 
-		$callback = function() use ($dummyEncryptionModule) {return $dummyEncryptionModule;};
+		$callback = function () use ($dummyEncryptionModule) {return $dummyEncryptionModule;};
 		$moduleDescription = [
 			'id' => 'id',
 			'displayName' => 'displayName',
@@ -283,7 +283,7 @@ class DecryptAllTest extends TestCase {
 
 		$this->view->expects($this->any())->method('is_dir')
 			->willReturnCallback(
-				function($path) {
+				function ($path) {
 					if ($path === '/user1/files/foo') {
 						return true;
 					}
@@ -379,7 +379,7 @@ class DecryptAllTest extends TestCase {
 		$this->view->expects($this->once())
 			->method('copy')
 			->with($path, $path . '.decrypted.42')
-			->willReturnCallback(function() { throw new DecryptionFailedException();});
+			->willReturnCallback(function () { throw new DecryptionFailedException();});
 
 		$this->view->expects($this->never())->method('rename');
 		$this->view->expects($this->once())

--- a/tests/lib/Encryption/Keys/StorageTest.php
+++ b/tests/lib/Encryption/Keys/StorageTest.php
@@ -338,7 +338,7 @@ class StorageTest extends TestCase {
 			->willReturnCallback([$this, 'getUidAndFilenameCallback']);
 		$this->util->expects($this->any())
 			->method('isSystemWideMountPoint')
-			->willReturnCallback(function($path, $owner) use ($systemWideMountSource, $systemWideMountTarget) {
+			->willReturnCallback(function ($path, $owner) use ($systemWideMountSource, $systemWideMountTarget) {
 				if(strpos($path, 'source.txt') !== false) {
 					return $systemWideMountSource;
 				}
@@ -369,7 +369,7 @@ class StorageTest extends TestCase {
 			->willReturnCallback([$this, 'getUidAndFilenameCallback']);
 		$this->util->expects($this->any())
 			->method('isSystemWideMountPoint')
-			->willReturnCallback(function($path, $owner) use ($systemWideMountSource, $systemWideMountTarget) {
+			->willReturnCallback(function ($path, $owner) use ($systemWideMountSource, $systemWideMountTarget) {
 				if(strpos($path, 'source.txt') !== false) {
 					return $systemWideMountSource;
 				}

--- a/tests/lib/Encryption/ManagerTest.php
+++ b/tests/lib/Encryption/ManagerTest.php
@@ -60,7 +60,7 @@ class ManagerTest extends TestCase {
 		$em = $this->createMock(IEncryptionModule::class);
 		$em->expects($this->any())->method('getId')->willReturn('id');
 		$em->expects($this->any())->method('getDisplayName')->willReturn('TestDummyModule0');
-		$this->manager->registerEncryptionModule('id', 'TestDummyModule0', function() use ($em) {return $em;});
+		$this->manager->registerEncryptionModule('id', 'TestDummyModule0', function () use ($em) {return $em;});
 		$this->assertFalse($this->manager->isEnabled());
 	}
 
@@ -117,7 +117,7 @@ class ManagerTest extends TestCase {
 		$this->config->expects($this->any())
 			->method('getAppValue')
 			->with('core', 'default_encryption_module')
-			->willReturnCallback(function() { global $defaultId; return $defaultId; });
+			->willReturnCallback(function () { global $defaultId; return $defaultId; });
 
 		$this->addNewEncryptionModule($this->manager, 0);
 		$this->assertCount(1, $this->manager->getEncryptionModules());
@@ -138,7 +138,7 @@ class ManagerTest extends TestCase {
 		$this->config->expects($this->any())
 			->method('getAppValue')
 			->with('core', 'default_encryption_module')
-			->willReturnCallback(function() { global $defaultId; return $defaultId; });
+			->willReturnCallback(function () { global $defaultId; return $defaultId; });
 
 		$this->addNewEncryptionModule($this->manager, 0);
 		$defaultId = 'ID0';
@@ -160,7 +160,7 @@ class ManagerTest extends TestCase {
 		$this->config->expects($this->any())
 			->method('getAppValue')
 			->with('core', 'default_encryption_module')
-			->willReturnCallback(function() { global $defaultId; return $defaultId; });
+			->willReturnCallback(function () { global $defaultId; return $defaultId; });
 
 		$this->addNewEncryptionModule($this->manager, 0);
 		$this->assertCount(1, $this->manager->getEncryptionModules());
@@ -251,7 +251,7 @@ class ManagerTest extends TestCase {
 			->method('getDisplayName')
 			->willReturn('TestDummyModule' . $id);
 		/** @var \OCP\Encryption\IEncryptionModule $encryptionModule */
-		$manager->registerEncryptionModule('ID' . $id, 'TestDummyModule' . $id, function() use ($encryptionModule) {
+		$manager->registerEncryptionModule('ID' . $id, 'TestDummyModule' . $id, function () use ($encryptionModule) {
 			return $encryptionModule;
 		});
 	}

--- a/tests/lib/Encryption/UpdateTest.php
+++ b/tests/lib/Encryption/UpdateTest.php
@@ -147,7 +147,7 @@ class UpdateTest extends TestCase {
 		} else {
 			$updateMock->expects($this->once())
 				->method('getOwnerPath')
-				->willReturnCallback(function($path) use ($target) {
+				->willReturnCallback(function ($path) use ($target) {
 					$this->assertSame(
 						$target,
 						$path,

--- a/tests/lib/Files/Cache/QuerySearchHelperTest.php
+++ b/tests/lib/Files/Cache/QuerySearchHelperTest.php
@@ -200,7 +200,7 @@ class QuerySearchHelperTest extends TestCase {
 			'mimetype' => 'image/png'
 		]);
 
-		$fileIds = array_map(function($i) use ($fileId) {
+		$fileIds = array_map(function ($i) use ($fileId) {
 			return $fileId[$i];
 		}, $fileIds);
 

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -46,7 +46,7 @@ class DummyMountProvider implements IMountProvider {
 	 * @param IStorageFactory $loader
 	 * @return \OCP\Files\Mount\IMountPoint[]
 	 */
-	public function  getMountsForUser(IUser $user, IStorageFactory $loader) {
+	public function getMountsForUser(IUser $user, IStorageFactory $loader) {
 		return isset($this->mounts[$user->getUID()]) ? $this->mounts[$user->getUID()] : [];
 	}
 }

--- a/tests/lib/Files/Mount/MountPointTest.php
+++ b/tests/lib/Files/Mount/MountPointTest.php
@@ -51,7 +51,7 @@ class MountPointTest extends \Test\TestCase {
 			->will($this->throwException(new \Exception('Test storage init exception')));
 
 		$called = false;
-		$wrapper = function($mountPoint, $storage) use ($called) {
+		$wrapper = function ($mountPoint, $storage) use ($called) {
 			$called = true;
 		};
 

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -174,7 +174,7 @@ class EncryptionTest extends Storage {
 			->disableOriginalConstructor()->getMock();
 		$this->cache->expects($this->any())
 			->method('get')
-			->willReturnCallback(function($path) {return ['encrypted' => false, 'path' => $path];});
+			->willReturnCallback(function ($path) {return ['encrypted' => false, 'path' => $path];});
 
 		$this->mountManager = $this->createMock(\OC\Files\Mount\Manager::class);
 		$this->mountManager->method('findByStorageId')
@@ -253,7 +253,7 @@ class EncryptionTest extends Storage {
 		$cache->expects($this->any())
 			->method('get')
 			->willReturnCallback(
-				function($path) use ($encrypted) {
+				function ($path) use ($encrypted) {
 					return ['encrypted' => $encrypted, 'path' => $path, 'size' => 0, 'fileid' => 1];
 				}
 			);
@@ -387,7 +387,7 @@ class EncryptionTest extends Storage {
 		$this->instance->expects($this->any())->method('fixUnencryptedSize')
 			->with('/test.txt', $encryptedSize, $unencryptedSize)
 			->willReturnCallback(
-				function() use ($failure, $expected) {
+				function () use ($failure, $expected) {
 					if ($failure) {
 						throw new \Exception();
 					} else {
@@ -645,7 +645,7 @@ class EncryptionTest extends Storage {
 			->disableOriginalConstructor()->getMock();
 		$cache->expects($this->any())
 			->method('get')
-			->willReturnCallback(function($path) use ($isEncrypted) {return ['encrypted' => $isEncrypted, 'path' => $path];});
+			->willReturnCallback(function ($path) use ($isEncrypted) {return ['encrypted' => $isEncrypted, 'path' => $path];});
 
 		$instance = $this->getMockBuilder('\OC\Files\Storage\Wrapper\Encryption')
 			->setConstructorArgs(
@@ -737,7 +737,7 @@ class EncryptionTest extends Storage {
 
 		$storage2->expects($this->any())
 			->method('fopen')
-			->willReturnCallback(function($path, $mode) {
+			->willReturnCallback(function ($path, $mode) {
 				$temp = \OC::$server->getTempManager();
 				return fopen($temp->getTemporaryFile(), $mode);
 			});
@@ -786,7 +786,7 @@ class EncryptionTest extends Storage {
 
 		$storage2->expects($this->any())
 			->method('fopen')
-			->willReturnCallback(function($path, $mode) {
+			->willReturnCallback(function ($path, $mode) {
 				$temp = \OC::$server->getTempManager();
 				return fopen($temp->getTemporaryFile(), $mode);
 			});
@@ -839,7 +839,7 @@ class EncryptionTest extends Storage {
 	 * @param bool $copyResult
 	 * @param bool $encrypted
 	 */
-	public function  testCopyBetweenStorageVersions($sourceInternalPath, $targetInternalPath, $copyResult, $encrypted) {
+	public function testCopyBetweenStorageVersions($sourceInternalPath, $targetInternalPath, $copyResult, $encrypted) {
 
 		$sourceStorage = $this->createMock(\OC\Files\Storage\Storage::class);
 
@@ -1005,7 +1005,7 @@ class EncryptionTest extends Storage {
 			->method('getEncryptionModule')
 			->with($fullPath)
 			->willReturnCallback(
-				function() use ($encryptionModule) {
+				function () use ($encryptionModule) {
 					if ($encryptionModule === false) {
 						throw new ModuleDoesNotExistsException();
 					}

--- a/tests/lib/Files/Stream/EncryptionTest.php
+++ b/tests/lib/Files/Stream/EncryptionTest.php
@@ -342,7 +342,7 @@ class EncryptionTest extends \Test\TestCase {
 		$encryptionModule->expects($this->any())->method('end')->willReturn('');
 		$encryptionModule->expects($this->any())->method('isReadable')->willReturn(true);
 		$encryptionModule->expects($this->any())->method('needDetailedAccessList')->willReturn(false);
-		$encryptionModule->expects($this->any())->method('encrypt')->willReturnCallback(function($data) {
+		$encryptionModule->expects($this->any())->method('encrypt')->willReturnCallback(function ($data) {
 			// simulate different block size by adding some padding to the data
 			if (isset($data[6125])) {
 				return str_pad($data, 8192, 'X');
@@ -350,7 +350,7 @@ class EncryptionTest extends \Test\TestCase {
 			// last block
 			return $data;
 		});
-		$encryptionModule->expects($this->any())->method('decrypt')->willReturnCallback(function($data) {
+		$encryptionModule->expects($this->any())->method('decrypt')->willReturnCallback(function ($data) {
 			if (isset($data[8191])) {
 				return substr($data, 0, 6126);
 			}

--- a/tests/lib/Files/Type/DetectionTest.php
+++ b/tests/lib/Files/Type/DetectionTest.php
@@ -241,7 +241,7 @@ class DetectionTest extends \Test\TestCase {
 				[$this->equalTo('core'), $this->equalTo('filetypes/my.png')]
 			)
 			->willReturnCallback(
-				function($appName, $file) {
+				function ($appName, $file) {
 					if ($file === 'filetypes/my.png') {
 						return 'my.svg';
 					}
@@ -272,7 +272,7 @@ class DetectionTest extends \Test\TestCase {
 				[$this->equalTo('core'), $this->equalTo('filetypes/file.png')]
 			)
 			->willReturnCallback(
-				function($appName, $file) {
+				function ($appName, $file) {
 					if ($file === 'filetypes/file.png') {
 						return 'file.svg';
 					}

--- a/tests/lib/Group/ManagerTest.php
+++ b/tests/lib/Group/ManagerTest.php
@@ -91,7 +91,7 @@ class ManagerTest extends TestCase {
 			->getMock();
 		$backend->expects($this->any())
 			->method('implementsActions')
-			->willReturnCallback(function($actions) use ($implementedActions) {
+			->willReturnCallback(function ($actions) use ($implementedActions) {
 				return (bool)($actions & $implementedActions);
 			});
 		return $backend;
@@ -546,7 +546,7 @@ class ManagerTest extends TestCase {
 
 		$backend->expects($this->any())
 			->method('inGroup')
-			->willReturnCallback(function($uid, $gid) {
+			->willReturnCallback(function ($uid, $gid) {
 				switch($uid) {
 					case 'user1' : return false;
 					case 'user2' : return true;
@@ -560,7 +560,7 @@ class ManagerTest extends TestCase {
 		$this->userManager->expects($this->any())
 			->method('searchDisplayName')
 			->with('user3')
-			->willReturnCallback(function($search, $limit, $offset) {
+			->willReturnCallback(function ($search, $limit, $offset) {
 				switch($offset) {
 					case 0 : return ['user3' => $this->getTestUser('user3'),
 						'user33' => $this->getTestUser('user33')];
@@ -570,7 +570,7 @@ class ManagerTest extends TestCase {
 			});
 		$this->userManager->expects($this->any())
 			->method('get')
-			->willReturnCallback(function($uid) {
+			->willReturnCallback(function ($uid) {
 				switch($uid) {
 					case 'user1' : return $this->getTestUser('user1');
 					case 'user2' : return $this->getTestUser('user2');
@@ -604,7 +604,7 @@ class ManagerTest extends TestCase {
 
 				$backend->expects($this->any())
 			->method('inGroup')
-			->willReturnCallback(function($uid, $gid) {
+			->willReturnCallback(function ($uid, $gid) {
 					switch($uid) {
 						case 'user1' : return false;
 						case 'user2' : return true;
@@ -619,7 +619,7 @@ class ManagerTest extends TestCase {
 		$this->userManager->expects($this->any())
 			->method('searchDisplayName')
 			->with('user3')
-			->willReturnCallback(function($search, $limit, $offset) {
+			->willReturnCallback(function ($search, $limit, $offset) {
 				switch($offset) {
 					case 0 : return ['user3' => $this->getTestUser('user3'),
 						'user33' => $this->getTestUser('user33')];
@@ -629,7 +629,7 @@ class ManagerTest extends TestCase {
 			});
 		$this->userManager->expects($this->any())
 			->method('get')
-			->willReturnCallback(function($uid) {
+			->willReturnCallback(function ($uid) {
 				switch($uid) {
 					case 'user1' : return $this->getTestUser('user1');
 					case 'user2' : return $this->getTestUser('user2');
@@ -665,7 +665,7 @@ class ManagerTest extends TestCase {
 
 		$backend->expects($this->any())
 			->method('inGroup')
-			->willReturnCallback(function($uid) {
+			->willReturnCallback(function ($uid) {
 					switch($uid) {
 						case 'user1' : return false;
 						case 'user2' : return true;
@@ -680,7 +680,7 @@ class ManagerTest extends TestCase {
 		$this->userManager->expects($this->any())
 			->method('searchDisplayName')
 			->with('user3')
-			->willReturnCallback(function($search, $limit, $offset) {
+			->willReturnCallback(function ($search, $limit, $offset) {
 				switch($offset) {
 					case 0 :
 						return [
@@ -693,7 +693,7 @@ class ManagerTest extends TestCase {
 			});
 		$this->userManager->expects($this->any())
 			->method('get')
-			->willReturnCallback(function($uid) {
+			->willReturnCallback(function ($uid) {
 				switch($uid) {
 					case 'user1' : return $this->getTestUser('user1');
 					case 'user2' : return $this->getTestUser('user2');
@@ -734,7 +734,7 @@ class ManagerTest extends TestCase {
 
 		$this->userManager->expects($this->any())
 			->method('get')
-			->willReturnCallback(function($uid) {
+			->willReturnCallback(function ($uid) {
 				switch($uid) {
 					case 'user1' : return $this->getTestUser('user1');
 					case 'user2' : return $this->getTestUser('user2');
@@ -773,7 +773,7 @@ class ManagerTest extends TestCase {
 
 		$this->userManager->expects($this->any())
 			->method('get')
-			->willReturnCallback(function($uid) {
+			->willReturnCallback(function ($uid) {
 				switch($uid) {
 					case 'user1' : return $this->getTestUser('user1');
 					case 'user2' : return $this->getTestUser('user2');
@@ -812,7 +812,7 @@ class ManagerTest extends TestCase {
 
 		$this->userManager->expects($this->any())
 			->method('get')
-			->willReturnCallback(function($uid) {
+			->willReturnCallback(function ($uid) {
 				switch($uid) {
 					case 'user1' : return $this->getTestUser('user1');
 					case 'user2' : return $this->getTestUser('user2');

--- a/tests/lib/InitialStateServiceTest.php
+++ b/tests/lib/InitialStateServiceTest.php
@@ -84,7 +84,7 @@ class InitialStateServiceTest extends TestCase {
 	 * @dataProvider staticData
 	 */
 	public function testLazyData($value) {
-		$this->service->provideLazyInitialState('test', 'key', function() use ($value) {
+		$this->service->provideLazyInitialState('test', 'key', function () use ($value) {
 			return $value;
 		});
 		$data = $this->service->getInitialStates();

--- a/tests/lib/IntegrityCheck/CheckerTest.php
+++ b/tests/lib/IntegrityCheck/CheckerTest.php
@@ -140,7 +140,7 @@ class CheckerTest extends TestCase {
 			->method('file_put_contents')
 			->with(
 					$this->equalTo(\OC::$SERVERROOT . '/tests/data/integritycheck/app//appinfo/signature.json'),
-					$this->callback(function($signature) use ($expectedSignatureFileData) {
+					$this->callback(function ($signature) use ($expectedSignatureFileData) {
 						$expectedArray = json_decode($expectedSignatureFileData, true);
 						$actualArray = json_decode($signature, true);
 						$this->assertEquals($expectedArray, $actualArray);
@@ -546,7 +546,7 @@ class CheckerTest extends TestCase {
 				->method('file_put_contents')
 				->with(
 						\OC::$SERVERROOT . '/tests/data/integritycheck/app//core/signature.json',
-						$this->callback(function($signature) use ($expectedSignatureFileData) {
+						$this->callback(function ($signature) use ($expectedSignatureFileData) {
 						$expectedArray = json_decode($expectedSignatureFileData, true);
 						$actualArray = json_decode($signature, true);
 						$this->assertEquals($expectedArray, $actualArray);
@@ -581,7 +581,7 @@ class CheckerTest extends TestCase {
 				->method('file_put_contents')
 				->with(
 						\OC::$SERVERROOT . '/tests/data/integritycheck/htaccessUnmodified//core/signature.json',
-					$this->callback(function($signature) use ($expectedSignatureFileData) {
+					$this->callback(function ($signature) use ($expectedSignatureFileData) {
 						$expectedArray = json_decode($expectedSignatureFileData, true);
 						$actualArray = json_decode($signature, true);
 						$this->assertEquals($expectedArray, $actualArray);
@@ -611,7 +611,7 @@ class CheckerTest extends TestCase {
 				->method('file_put_contents')
 				->with(
 						\OC::$SERVERROOT . '/tests/data/integritycheck/htaccessWithInvalidModifiedContent//core/signature.json',
-					$this->callback(function($signature) use ($expectedSignatureFileData) {
+					$this->callback(function ($signature) use ($expectedSignatureFileData) {
 						$expectedArray = json_decode($expectedSignatureFileData, true);
 						$actualArray = json_decode($signature, true);
 						$this->assertEquals($expectedArray, $actualArray);
@@ -646,7 +646,7 @@ class CheckerTest extends TestCase {
 				->method('file_put_contents')
 				->with(
 						\OC::$SERVERROOT . '/tests/data/integritycheck/htaccessWithValidModifiedContent/core/signature.json',
-					$this->callback(function($signature) use ($expectedSignatureFileData) {
+					$this->callback(function ($signature) use ($expectedSignatureFileData) {
 						$expectedArray = json_decode($expectedSignatureFileData, true);
 						$actualArray = json_decode($signature, true);
 						$this->assertEquals($expectedArray, $actualArray);

--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -419,7 +419,7 @@ class FactoryTest extends TestCase {
 			->willReturn($availableLanguages);
 
 		$factory->expects($this->any())
-			->method('respectDefaultLanguage')->willReturnCallback(function($app, $lang) {
+			->method('respectDefaultLanguage')->willReturnCallback(function ($app, $lang) {
 				return $lang;
 			});
 
@@ -510,7 +510,7 @@ class FactoryTest extends TestCase {
 
 		$this->config->expects($this->any())
 			->method('getSystemValue')
-			->willReturnCallback(function($var, $default) use ($defaultLang) {
+			->willReturnCallback(function ($var, $default) use ($defaultLang) {
 				if ($var === 'installed') {
 					return true;
 				} else if ($var === 'default_language') {
@@ -558,7 +558,7 @@ class FactoryTest extends TestCase {
 				return $availableLang;
 			});
 		$factory->expects($this->any())
-			->method('respectDefaultLanguage')->willReturnCallback(function($app, $lang) {
+			->method('respectDefaultLanguage')->willReturnCallback(function ($app, $lang) {
 			return $lang;
 			});
 

--- a/tests/lib/LegacyHelperTest.php
+++ b/tests/lib/LegacyHelperTest.php
@@ -54,7 +54,7 @@ class LegacyHelperTest extends \Test\TestCase {
 		$this->assertEquals($expected, $result);
 	}
 
-	function providesComputerFileSize(){
+	function providesComputerFileSize() {
 		return [
 			[0.0, "0 B"],
 			[1024.0, "1 KB"],

--- a/tests/lib/Lockdown/LockdownManagerTest.php
+++ b/tests/lib/Lockdown/LockdownManagerTest.php
@@ -32,7 +32,7 @@ class LockdownManagerTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->sessionCallback = function() {
+		$this->sessionCallback = function () {
 			return $this->createMock(ISession::class);
 		};
 	}

--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -176,7 +176,7 @@ class LoggerTest extends TestCase implements IWriter {
 	 * @dataProvider userAndPasswordData
 	 */
 	public function testDetectclosure(string $user, string $password): void {
-		$a = function($user, $password) {
+		$a = function ($user, $password) {
 			throw new \Exception('test');
 		};
 		$this->registry->expects($this->once())

--- a/tests/lib/Memcache/RedisTest.php
+++ b/tests/lib/Memcache/RedisTest.php
@@ -23,7 +23,7 @@ class RedisTest extends Cache {
 
 		$errorOccurred = false;
 		set_error_handler(
-			function($errno, $errstr) {
+			function ($errno, $errstr) {
 				throw new \RuntimeException($errstr, 123456789);
 			},
 			E_WARNING

--- a/tests/lib/Preview/GeneratorTest.php
+++ b/tests/lib/Preview/GeneratorTest.php
@@ -112,7 +112,7 @@ class GeneratorTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				$this->equalTo(IPreview::EVENT),
-				$this->callback(function(GenericEvent $event) use ($file) {
+				$this->callback(function (GenericEvent $event) use ($file) {
 					return $event->getSubject() === $file &&
 						$event->getArgument('width') === 100 &&
 						$event->getArgument('height') === 100;
@@ -146,7 +146,7 @@ class GeneratorTest extends \Test\TestCase {
 			->willReturn($previewFolder);
 
 		$this->config->method('getSystemValue')
-			->willReturnCallback(function($key, $defult) {
+			->willReturnCallback(function ($key, $defult) {
 				return $defult;
 			});
 
@@ -168,7 +168,7 @@ class GeneratorTest extends \Test\TestCase {
 			]);
 
 		$this->helper->method('getProvider')
-			->willReturnCallback(function($provider) use ($invalidProvider, $validProvider, $unavailableProvider) {
+			->willReturnCallback(function ($provider) use ($invalidProvider, $validProvider, $unavailableProvider) {
 				if ($provider === 'wrongProvider') {
 					$this->fail('Wrongprovider should not be constructed!');
 				} else if ($provider === 'brokenProvider') {
@@ -210,7 +210,7 @@ class GeneratorTest extends \Test\TestCase {
 		$previewFolder->method('getDirectoryListing')
 			->willReturn([]);
 		$previewFolder->method('newFile')
-			->willReturnCallback(function($filename) use ($maxPreview, $previewFile) {
+			->willReturnCallback(function ($filename) use ($maxPreview, $previewFile) {
 				if ($filename === '2048-2048-max.png') {
 					return $maxPreview;
 				} else if ($filename === '256-256.png') {
@@ -248,7 +248,7 @@ class GeneratorTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				$this->equalTo(IPreview::EVENT),
-				$this->callback(function(GenericEvent $event) use ($file) {
+				$this->callback(function (GenericEvent $event) use ($file) {
 					return $event->getSubject() === $file &&
 					$event->getArgument('width') === 100 &&
 					$event->getArgument('height') === 100;
@@ -274,7 +274,7 @@ class GeneratorTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				$this->equalTo(IPreview::EVENT),
-				$this->callback(function(GenericEvent $event) use ($file) {
+				$this->callback(function (GenericEvent $event) use ($file) {
 					return $event->getSubject() === $file &&
 					$event->getArgument('width') === 0 &&
 					$event->getArgument('height') === 0 &&
@@ -314,7 +314,7 @@ class GeneratorTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				$this->equalTo(IPreview::EVENT),
-				$this->callback(function(GenericEvent $event) use ($file) {
+				$this->callback(function (GenericEvent $event) use ($file) {
 					return $event->getSubject() === $file &&
 					$event->getArgument('width') === 100 &&
 					$event->getArgument('height') === 100;
@@ -427,7 +427,7 @@ class GeneratorTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				$this->equalTo(IPreview::EVENT),
-				$this->callback(function(GenericEvent $event) use ($file, $reqX, $reqY, $crop, $mode) {
+				$this->callback(function (GenericEvent $event) use ($file, $reqX, $reqY, $crop, $mode) {
 					return $event->getSubject() === $file &&
 					$event->getArgument('width') === $reqX &&
 					$event->getArgument('height') === $reqY &&

--- a/tests/lib/Security/Bruteforce/ThrottlerTest.php
+++ b/tests/lib/Security/Bruteforce/ThrottlerTest.php
@@ -185,7 +185,7 @@ class ThrottlerTest extends TestCase {
 			->willReturn($enabled);
 
 		$this->config->method('getAppValue')
-			->willReturnCallback(function($app, $key, $default) use ($whitelists) {
+			->willReturnCallback(function ($app, $key, $default) use ($whitelists) {
 				if ($app !== 'bruteForce') {
 					return $default;
 				}

--- a/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
+++ b/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
@@ -79,7 +79,7 @@ class ContentSecurityPolicyManagerTest extends TestCase {
 	}
 
 	public function testGetDefaultPolicyWithPoliciesViaEvent() {
-		$this->dispatcher->addListener(AddContentSecurityPolicyEvent::class, function(AddContentSecurityPolicyEvent $e) {
+		$this->dispatcher->addListener(AddContentSecurityPolicyEvent::class, function (AddContentSecurityPolicyEvent $e) {
 			$policy = new \OCP\AppFramework\Http\ContentSecurityPolicy();
 			$policy->addAllowedFontDomain('mydomain.com');
 			$policy->addAllowedImageDomain('anotherdomain.de');
@@ -87,7 +87,7 @@ class ContentSecurityPolicyManagerTest extends TestCase {
 			$e->addPolicy($policy);
 		});
 
-		$this->dispatcher->addListener(AddContentSecurityPolicyEvent::class, function(AddContentSecurityPolicyEvent $e) {
+		$this->dispatcher->addListener(AddContentSecurityPolicyEvent::class, function (AddContentSecurityPolicyEvent $e) {
 			$policy = new \OCP\AppFramework\Http\ContentSecurityPolicy();
 			$policy->addAllowedFontDomain('example.com');
 			$policy->addAllowedImageDomain('example.org');
@@ -96,7 +96,7 @@ class ContentSecurityPolicyManagerTest extends TestCase {
 			$e->addPolicy($policy);
 		});
 
-		$this->dispatcher->addListener(AddContentSecurityPolicyEvent::class, function(AddContentSecurityPolicyEvent $e) {
+		$this->dispatcher->addListener(AddContentSecurityPolicyEvent::class, function (AddContentSecurityPolicyEvent $e) {
 			$policy = new \OCP\AppFramework\Http\EmptyContentSecurityPolicy();
 			$policy->addAllowedChildSrcDomain('childdomain');
 			$policy->addAllowedFontDomain('anotherFontDomain');

--- a/tests/lib/Security/CertificateManagerTest.php
+++ b/tests/lib/Security/CertificateManagerTest.php
@@ -181,7 +181,7 @@ class CertificateManagerTest extends \Test\TestCase {
 		}
 
 		$view->expects($this->any())->method('filemtime')
-			->willReturnCallback(function($path) use ($systemWideMtime, $targetBundleMtime)  {
+			->willReturnCallback(function ($path) use ($systemWideMtime, $targetBundleMtime) {
 				if ($path === 'SystemBundlePath') {
 					return $systemWideMtime;
 				} elseif ($path === 'targetBundlePath') {

--- a/tests/lib/Security/FeaturePolicy/FeaturePolicyManagerTest.php
+++ b/tests/lib/Security/FeaturePolicy/FeaturePolicyManagerTest.php
@@ -51,7 +51,7 @@ class FeaturePolicyManagerTest extends TestCase {
 	}
 
 	public function testGetDefaultPolicyWithPoliciesViaEvent() {
-		$this->dispatcher->addListener(AddFeaturePolicyEvent::class, function(AddFeaturePolicyEvent $e) {
+		$this->dispatcher->addListener(AddFeaturePolicyEvent::class, function (AddFeaturePolicyEvent $e) {
 			$policy = new FeaturePolicy();
 			$policy->addAllowedMicrophoneDomain('mydomain.com');
 			$policy->addAllowedPaymentDomain('mypaymentdomain.com');
@@ -59,7 +59,7 @@ class FeaturePolicyManagerTest extends TestCase {
 			$e->addPolicy($policy);
 		});
 
-		$this->dispatcher->addListener(AddFeaturePolicyEvent::class, function(AddFeaturePolicyEvent $e) {
+		$this->dispatcher->addListener(AddFeaturePolicyEvent::class, function (AddFeaturePolicyEvent $e) {
 			$policy = new FeaturePolicy();
 			$policy->addAllowedPaymentDomain('mydomainother.com');
 			$policy->addAllowedGeoLocationDomain('mylocation.here');
@@ -67,7 +67,7 @@ class FeaturePolicyManagerTest extends TestCase {
 			$e->addPolicy($policy);
 		});
 
-		$this->dispatcher->addListener(AddFeaturePolicyEvent::class, function(AddFeaturePolicyEvent $e) {
+		$this->dispatcher->addListener(AddFeaturePolicyEvent::class, function (AddFeaturePolicyEvent $e) {
 			$policy = new FeaturePolicy();
 			$policy->addAllowedAutoplayDomain('youtube.com');
 

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -1767,7 +1767,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		}
 
 		$this->userManager->method('get')->willReturnCallback(
-			function($userId) use ($users) {
+			function ($userId) use ($users) {
 				return $users[$userId];
 			}
 		);
@@ -1824,7 +1824,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		}
 
 		$this->userManager->method('get')->willReturnCallback(
-			function($userId) use ($users) {
+			function ($userId) use ($users) {
 				return $users[$userId];
 			}
 		);
@@ -1890,7 +1890,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		}
 
 		$this->userManager->method('get')->willReturnCallback(
-			function($userId) use ($users) {
+			function ($userId) use ($users) {
 				return $users[$userId];
 			}
 		);
@@ -1947,7 +1947,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		}
 
 		$this->userManager->method('get')->willReturnCallback(
-			function($userId) use ($users) {
+			function ($userId) use ($users) {
 				return $users[$userId];
 			}
 		);
@@ -1960,7 +1960,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		}
 
 		$this->groupManager->method('get')->willReturnCallback(
-			function($groupId) use ($groups) {
+			function ($groupId) use ($groups) {
 				return $groups[$groupId];
 			}
 		);
@@ -2025,7 +2025,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		}
 
 		$this->userManager->method('get')->willReturnCallback(
-			function($userId) use ($users) {
+			function ($userId) use ($users) {
 				return $users[$userId];
 			}
 		);
@@ -2038,7 +2038,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		}
 
 		$this->groupManager->method('get')->willReturnCallback(
-			function($groupId) use ($groups) {
+			function ($groupId) use ($groups) {
 				return $groups[$groupId];
 			}
 		);

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -123,7 +123,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->l10nFactory = $this->createMock(IFactory::class);
 		$this->l = $this->createMock(IL10N::class);
 		$this->l->method('t')
-			->willReturnCallback(function($text, $parameters = []) {
+			->willReturnCallback(function ($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			});
 
@@ -233,7 +233,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				'OCP\Share::preUnshare',
-				$this->callBack(function(GenericEvent $e) use ($share) {
+				$this->callBack(function (GenericEvent $e) use ($share) {
 					return $e->getSubject() === $share;
 				})
 			);
@@ -241,7 +241,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				'OCP\Share::postUnshare',
-				$this->callBack(function(GenericEvent $e) use ($share) {
+				$this->callBack(function (GenericEvent $e) use ($share) {
 					return $e->getSubject() === $share &&
 						$e->getArgument('deletedShares') === [$share];
 				})
@@ -279,7 +279,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				'OCP\Share::preUnshare',
-				$this->callBack(function(GenericEvent $e) use ($share) {
+				$this->callBack(function (GenericEvent $e) use ($share) {
 					return $e->getSubject() === $share;
 				})
 			);
@@ -287,7 +287,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				'OCP\Share::postUnshare',
-				$this->callBack(function(GenericEvent $e) use ($share) {
+				$this->callBack(function (GenericEvent $e) use ($share) {
 					return $e->getSubject() === $share &&
 						$e->getArgument('deletedShares') === [$share];
 				})
@@ -348,7 +348,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				'OCP\Share::preUnshare',
-				$this->callBack(function(GenericEvent $e) use ($share1) {
+				$this->callBack(function (GenericEvent $e) use ($share1) {
 					return $e->getSubject() === $share1;
 				})
 			);
@@ -356,7 +356,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				'OCP\Share::postUnshare',
-				$this->callBack(function(GenericEvent $e) use ($share1, $share2, $share3) {
+				$this->callBack(function (GenericEvent $e) use ($share1, $share2, $share3) {
 					return $e->getSubject() === $share1 &&
 						$e->getArgument('deletedShares') === [$share3, $share2, $share1];
 				})
@@ -391,7 +391,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				'OCP\Share::postUnshareFromSelf',
-				$this->callBack(function(GenericEvent $e) use ($share) {
+				$this->callBack(function (GenericEvent $e) use ($share) {
 					return $e->getSubject() === $share;
 				})
 			);
@@ -423,7 +423,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->defaultProvider
 			->expects($this->exactly(4))
 			->method('getChildren')
-			->willReturnCallback(function($_share) use ($share, $shares) {
+			->willReturnCallback(function ($_share) use ($share, $shares) {
 				if ($_share === $share) {
 					return $shares;
 				}
@@ -505,7 +505,7 @@ class ManagerTest extends \Test\TestCase {
 		]);
 
 		$this->eventDispatcher->expects($this->once())->method('dispatch')
-			->willReturnCallback(function(Event $event) {
+			->willReturnCallback(function (Event $event) {
 				$this->assertInstanceOf(ValidatePasswordPolicyEvent::class, $event);
 				/** @var ValidatePasswordPolicyEvent $event */
 				$this->assertSame('password', $event->getPassword());
@@ -526,7 +526,7 @@ class ManagerTest extends \Test\TestCase {
 		]);
 
 		$this->eventDispatcher->expects($this->once())->method('dispatch')
-			->willReturnCallback(function(Event $event) {
+			->willReturnCallback(function (Event $event) {
 				$this->assertInstanceOf(ValidatePasswordPolicyEvent::class, $event);
 				/** @var ValidatePasswordPolicyEvent $event */
 				$this->assertSame('password', $event->getPassword());
@@ -1773,7 +1773,7 @@ class ManagerTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('create')
 			->with($share)
-			->willReturnCallback(function(Share $share) {
+			->willReturnCallback(function (Share $share) {
 				return $share->setId(42);
 			});
 
@@ -1782,7 +1782,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				$this->equalTo('OCP\Share::preShare'),
-				$this->callback(function(GenericEvent $e) use ($path, $date) {
+				$this->callback(function (GenericEvent $e) use ($path, $date) {
 					/** @var IShare $share */
 					$share = $e->getSubject();
 
@@ -1801,7 +1801,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				$this->equalTo('OCP\Share::postShare'),
-				$this->callback(function(GenericEvent $e) use ($path, $date) {
+				$this->callback(function (GenericEvent $e) use ($path, $date) {
 					/** @var IShare $share */
 					$share = $e->getSubject();
 
@@ -1882,7 +1882,7 @@ class ManagerTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('create')
 			->with($share)
-			->willReturnCallback(function(Share $share) {
+			->willReturnCallback(function (Share $share) {
 				return $share->setId(42);
 			});
 
@@ -1891,7 +1891,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				$this->equalTo('OCP\Share::preShare'),
-				$this->callback(function(GenericEvent $e) use ($path) {
+				$this->callback(function (GenericEvent $e) use ($path) {
 					/** @var IShare $share */
 					$share = $e->getSubject();
 
@@ -1910,7 +1910,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('dispatch')
 			->with(
 				$this->equalTo('OCP\Share::postShare'),
-				$this->callback(function(GenericEvent $e) use ($path) {
+				$this->callback(function (GenericEvent $e) use ($path) {
 					/** @var IShare $share */
 					$share = $e->getSubject();
 
@@ -1993,7 +1993,7 @@ class ManagerTest extends \Test\TestCase {
 			->with(
 				$this->equalTo('OCP\Share::preShare'),
 				$this->isInstanceOf(GenericEvent::class)
-			)->willReturnCallback(function($name, GenericEvent $e) {
+			)->willReturnCallback(function ($name, GenericEvent $e) {
 					$e->setArgument('error', 'I won\'t let you share!');
 					$e->stopPropagation();
 				}
@@ -2145,7 +2145,7 @@ class ManagerTest extends \Test\TestCase {
 		 */
 		$this->defaultProvider
 			->method('getSharesBy')
-			->willReturnCallback(function($uid, $type, $node, $reshares, $limit, $offset) use (&$shares2) {
+			->willReturnCallback(function ($uid, $type, $node, $reshares, $limit, $offset) use (&$shares2) {
 				return array_slice($shares2, $offset, $limit);
 			});
 
@@ -2153,7 +2153,7 @@ class ManagerTest extends \Test\TestCase {
 		 * Simulate the deleteShare call.
 		 */
 		$manager->method('deleteShare')
-			->willReturnCallback(function($share) use (&$shares2) {
+			->willReturnCallback(function ($share) use (&$shares2) {
 				for($i = 0; $i < count($shares2); $i++) {
 					if ($shares2[$i]->getId() === $share->getId()) {
 						array_splice($shares2, $i, 1);
@@ -2255,7 +2255,7 @@ class ManagerTest extends \Test\TestCase {
 
 		$factory->expects($this->any())
 			->method('getProviderForType')
-			->willReturnCallback(function($shareType) use ($roomShareProvider) {
+			->willReturnCallback(function ($shareType) use ($roomShareProvider) {
 				if ($shareType !== \OCP\Share::SHARE_TYPE_ROOM) {
 					throw new Exception\ProviderException();
 				}
@@ -2464,7 +2464,7 @@ class ManagerTest extends \Test\TestCase {
 			->setPassword('passwordHash');
 
 		$this->hasher->method('verify')->with('password', 'passwordHash', '')
-			->willReturnCallback(function($pass, $hash, &$newHash) {
+			->willReturnCallback(function ($pass, $hash, &$newHash) {
 				$newHash = 'newHash';
 
 				return true;
@@ -3741,12 +3741,12 @@ class ManagerTest extends \Test\TestCase {
 		$share4 = $this->createMock(IShare::class);
 
 		$this->defaultProvider->method('getAllShares')
-			->willReturnCallback(function() use ($share1, $share2) {
+			->willReturnCallback(function () use ($share1, $share2) {
 				yield $share1;
 				yield $share2;
 			});
 		$extraProvider->method('getAllShares')
-			->willReturnCallback(function() use ($share3, $share4) {
+			->willReturnCallback(function () use ($share3, $share4) {
 				yield $share3;
 				yield $share4;
 			});

--- a/tests/lib/SystemTag/SystemTagObjectMapperTest.php
+++ b/tests/lib/SystemTag/SystemTagObjectMapperTest.php
@@ -88,7 +88,7 @@ class SystemTagObjectMapperTest extends TestCase {
 
 		$this->tagManager->expects($this->any())
 			->method('getTagsByIds')
-			->willReturnCallback(function($tagIds) {
+			->willReturnCallback(function ($tagIds) {
 				$result = [];
 				if (in_array(1, $tagIds)) {
 					$result[1] = $this->tag1;

--- a/tests/lib/Template/JSCombinerTest.php
+++ b/tests/lib/Template/JSCombinerTest.php
@@ -120,7 +120,7 @@ class JSCombinerTest extends \Test\TestCase {
 		$fileDeps = $this->createMock(ISimpleFile::class);
 
 		$folder->method('getFile')
-			->willReturnCallback(function($path) use ($file, $gzfile) {
+			->willReturnCallback(function ($path) use ($file, $gzfile) {
 				if ($path === 'combine.js') {
 					return $file;
 				} else if ($path === 'combine.js.deps') {
@@ -157,7 +157,7 @@ class JSCombinerTest extends \Test\TestCase {
 		$gzfile = $this->createMock(ISimpleFile::class);
 
 		$folder->method('getFile')
-			->willReturnCallback(function($path) use ($file, $gzfile) {
+			->willReturnCallback(function ($path) use ($file, $gzfile) {
 				if ($path === 'combine.js') {
 					return $file;
 				} else if ($path === 'combine.js.deps') {
@@ -200,7 +200,7 @@ class JSCombinerTest extends \Test\TestCase {
 			->willReturn(true);
 
 		$folder->method('getFile')
-			->willReturnCallback(function($path) use ($file, $fileDeps) {
+			->willReturnCallback(function ($path) use ($file, $fileDeps) {
 				if ($path === 'combine.js') {
 					return $file;
 				}
@@ -245,7 +245,7 @@ class JSCombinerTest extends \Test\TestCase {
 			->willReturn('{}');
 
 		$folder->method('getFile')
-			->willReturnCallback(function($path) use ($file) {
+			->willReturnCallback(function ($path) use ($file) {
 				if ($path === 'combine.js') {
 					return $file;
 				}
@@ -262,7 +262,7 @@ class JSCombinerTest extends \Test\TestCase {
 		$file = $this->createMock(ISimpleFile::class);
 
 		$folder->method('getFile')
-			->willReturnCallback(function($path) use ($file) {
+			->willReturnCallback(function ($path) use ($file) {
 				if ($path === 'combine.js') {
 					return $file;
 				}

--- a/tests/lib/Template/SCSSCacherTest.php
+++ b/tests/lib/Template/SCSSCacherTest.php
@@ -120,7 +120,7 @@ class SCSSCacherTest extends \Test\TestCase {
 					  substr(md5('http://localhost/nextcloud/index.php'), 0, 4) . '-';
 
 		$folder->method('getFile')
-			->willReturnCallback(function($path) use ($file, $gzfile, $filePrefix) {
+			->willReturnCallback(function ($path) use ($file, $gzfile, $filePrefix) {
 				if ($path === $filePrefix.'styles.css') {
 					return $file;
 				} else if ($path === $filePrefix.'styles.css.deps') {
@@ -160,7 +160,7 @@ class SCSSCacherTest extends \Test\TestCase {
 					  substr(md5('http://localhost/nextcloud/index.php'), 0, 4) . '-';
 
 		$folder->method('getFile')
-			->willReturnCallback(function($path) use ($file, $gzfile, $filePrefix) {
+			->willReturnCallback(function ($path) use ($file, $gzfile, $filePrefix) {
 				if ($path === $filePrefix.'styles.css') {
 					return $file;
 				} else if ($path === $filePrefix.'styles.css.deps') {
@@ -196,7 +196,7 @@ class SCSSCacherTest extends \Test\TestCase {
 					  substr(md5('http://localhost/nextcloud/index.php'), 0, 4) . '-';
 
 		$folder->method('getFile')
-			->willReturnCallback(function($name) use ($file, $fileDeps, $gzFile, $filePrefix) {
+			->willReturnCallback(function ($name) use ($file, $fileDeps, $gzFile, $filePrefix) {
 				if ($name === $filePrefix.'styles.css') {
 					return $file;
 				} else if ($name === $filePrefix.'styles.css.deps') {
@@ -234,7 +234,7 @@ class SCSSCacherTest extends \Test\TestCase {
 		$filePrefix = substr(md5(\OC_Util::getVersionString('core')), 0, 4) . '-' .
 					  substr(md5('http://localhost/nextcloud/index.php'), 0, 4) . '-';
 		$folder->method('getFile')
-			->willReturnCallback(function($name) use ($file, $fileDeps, $gzFile, $filePrefix) {
+			->willReturnCallback(function ($name) use ($file, $fileDeps, $gzFile, $filePrefix) {
 				if ($name === $filePrefix.'styles.css') {
 					return $file;
 				} else if ($name === $filePrefix.'styles.css.deps') {
@@ -272,7 +272,7 @@ class SCSSCacherTest extends \Test\TestCase {
 
 		$file->expects($this->once())->method('getSize')->willReturn(1);
 		$folder->method('getFile')
-			->willReturnCallback(function($path) use ($file) {
+			->willReturnCallback(function ($path) use ($file) {
 				if ($path === 'styles.css') {
 					return $file;
 				} else if ($path === 'styles.css.deps') {
@@ -300,7 +300,7 @@ class SCSSCacherTest extends \Test\TestCase {
 		$path = \OC::$SERVERROOT . '/core/css/';
 
 		$folder->method('getFile')->willThrowException(new NotFoundException());
-		$folder->method('newFile')->willReturnCallback(function($fileName) use ($file, $depsFile, $gzipFile) {
+		$folder->method('newFile')->willReturnCallback(function ($fileName) use ($file, $depsFile, $gzipFile) {
 			if ($fileName === 'styles.css') {
 				return $file;
 			} else if ($fileName === 'styles.css.deps') {
@@ -334,7 +334,7 @@ class SCSSCacherTest extends \Test\TestCase {
 		$webDir = "core/css";
 		$path = \OC::$SERVERROOT;
 
-		$folder->method('getFile')->willReturnCallback(function($fileName) use ($file, $depsFile, $gzipFile) {
+		$folder->method('getFile')->willReturnCallback(function ($fileName) use ($file, $depsFile, $gzipFile) {
 			if ($fileName === 'styles.css') {
 				return $file;
 			} else if ($fileName === 'styles.css.deps') {
@@ -368,7 +368,7 @@ class SCSSCacherTest extends \Test\TestCase {
 		$webDir = "tests/data/scss";
 		$path = \OC::$SERVERROOT . $webDir;
 
-		$folder->method('getFile')->willReturnCallback(function($fileName) use ($file, $depsFile, $gzipFile) {
+		$folder->method('getFile')->willReturnCallback(function ($fileName) use ($file, $depsFile, $gzipFile) {
 			if ($fileName === 'styles-success.css') {
 				return $file;
 			} else if ($fileName === 'styles-success.css.deps') {
@@ -384,7 +384,7 @@ class SCSSCacherTest extends \Test\TestCase {
 			->willReturn('body{background-color:#0082c9}');
 
 		$file->expects($this->at(0))->method('putContent')->with($this->callback(
-			function ($content){
+			function ($content) {
 				return 'body{background-color:#0082c9}' === $content;
 			}));
 		$depsFile->expects($this->at(0))->method('putContent')->with($this->callback(

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -479,7 +479,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 		$l10n
 			->expects($this->any())
 			->method('t')
-			->willReturnCallback(function($text, $parameters = []) {
+			->willReturnCallback(function ($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			});
 

--- a/tests/lib/Updater/ChangesCheckTest.php
+++ b/tests/lib/Updater/ChangesCheckTest.php
@@ -348,8 +348,8 @@ class ChangesCheckTest extends TestCase {
 
 	public function changeDataProvider():array {
 		$testDataFound = $testDataNotFound = $this->versionProvider();
-		array_walk($testDataFound, function(&$params) { $params[] = true; });
-		array_walk($testDataNotFound, function(&$params) { $params[] = false; });
+		array_walk($testDataFound, function (&$params) { $params[] = true; });
+		array_walk($testDataNotFound, function (&$params) { $params[] = false; });
 		return array_merge($testDataFound, $testDataNotFound);
 	}
 

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -264,7 +264,7 @@ class SessionTest extends \Test\TestCase {
 		$this->dispatcher->expects($this->once())
 			->method('dispatchTyped')
 			->with(
-				$this->callback(function(PostLoginEvent $e) {
+				$this->callback(function (PostLoginEvent $e) {
 					return $e->getUser()->getUID() === 'foo' &&
 						$e->getPassword() === 'bar' &&
 						$e->isTokenLogin() === false;
@@ -1375,7 +1375,7 @@ class SessionTest extends \Test\TestCase {
 
 		$this->session
 			->method('set')
-			->willReturnCallback(function($k, $v) use (&$davAuthenticatedSet, &$lastPasswordConfirmSet) {
+			->willReturnCallback(function ($k, $v) use (&$davAuthenticatedSet, &$lastPasswordConfirmSet) {
 				switch ($k) {
 					case Auth::DAV_AUTHENTICATED:
 						$davAuthenticatedSet = $v;

--- a/tests/lib/Util/User/Dummy.php
+++ b/tests/lib/Util/User/Dummy.php
@@ -175,7 +175,7 @@ class Dummy extends Backend implements \OCP\IUserBackend {
 	 * Backend name to be shown in user management
 	 * @return string the name of the backend to be shown
 	 */
-	public function getBackendName(){
+	public function getBackendName() {
 		return 'Dummy';
 	}
 }

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -233,7 +233,7 @@ class UtilTest extends \Test\TestCase {
 		$appManager = $this->createMock(IAppManager::class);
 		$appManager->expects($this->any())
 			->method('isEnabledForUser')
-			->willReturnCallback(function($appId) use ($enabledApps){
+			->willReturnCallback(function ($appId) use ($enabledApps) {
 				return in_array($appId, $enabledApps);
 		});
 		Dummy_OC_Util::$appManager = $appManager;


### PR DESCRIPTION
We have a mix of `function(` and `function (`, so let's use unify and use the recommendation by PSR.