### PR TITLE
Do not use closing tags

### DIFF
--- a/apps/settings/templates/settings/empty.php
+++ b/apps/settings/templates/settings/empty.php
@@ -22,4 +22,3 @@
  */
 
 	# used for Personal/Additional settings as fallback for legacy settings
-?>


### PR DESCRIPTION
PSR2 doesn't like them and neither do I. They might cause whitespaces to be returned where you don't want them -> :fire: 