### PR TITLE
Fix absolute redirect

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -260,7 +260,7 @@ class LoginController extends Controller {
 
 	private function generateRedirect(?string $redirectUrl): RedirectResponse {
 		if ($redirectUrl !== null && $this->userSession->isLoggedIn()) {
-			$location = $this->urlGenerator->getAbsoluteURL(urldecode($redirectUrl));
+			$location = $this->urlGenerator->getAbsoluteURL($redirectUrl);
 			// Deny the redirect if the URL contains a @
 			// This prevents unvalidated redirects like ?redirect_url=:user@domain.com
 			if (strpos($location, '@') === false) {

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -509,7 +509,7 @@ class LoginControllerTest extends TestCase {
 			->method('getUID')
 			->willReturn('jane');
 		$password = 'secret';
-		$originalUrl = 'another%20url';
+		$originalUrl = 'another url';
 		$redirectUrl = 'http://localhost/another url';
 
 		$this->request
@@ -551,7 +551,7 @@ class LoginControllerTest extends TestCase {
 			$this->request,
 			$user,
 			$password,
-			'%2Fapps%2Fmail'
+			'/apps/mail'
 		);
 		$loginResult = LoginResult::success($loginData);
 		$this->chain->expects($this->once())
@@ -563,11 +563,11 @@ class LoginControllerTest extends TestCase {
 			->willReturn(true);
 		$this->urlGenerator->expects($this->once())
 			->method('getAbsoluteURL')
-			->with(urldecode('/apps/mail'))
+			->with('/apps/mail')
 			->willReturn($redirectUrl);
 		$expected = new \OCP\AppFramework\Http\RedirectResponse($redirectUrl);
 
-		$response = $this->loginController->tryLogin($user, $password, '%2Fapps%2Fmail');
+		$response = $this->loginController->tryLogin($user, $password, '/apps/mail');
 
 		$this->assertEquals($expected, $response);
 	}


### PR DESCRIPTION
Fix #6822

It will just not work for url with like a hash in it.
Because we moved all of our apps to proper javascript url history, this should not be an issue anymore.