### PR TITLE
Fix password reset saying Admin changed my password when reset from login page

### DIFF
--- a/apps/settings/lib/Activity/Provider.php
+++ b/apps/settings/lib/Activity/Provider.php
@@ -41,6 +41,7 @@ class Provider implements IProvider {
 	public const PASSWORD_CHANGED_BY = 'password_changed_by';
 	public const PASSWORD_CHANGED_SELF = 'password_changed_self';
 	public const PASSWORD_RESET = 'password_changed';
+	public const PASSWORD_RESET_SELF = 'password_reset_self';
 	public const EMAIL_CHANGED_BY = 'email_changed_by';
 	public const EMAIL_CHANGED_SELF = 'email_changed_self';
 	public const EMAIL_CHANGED = 'email_changed';
@@ -105,6 +106,8 @@ class Provider implements IProvider {
 			$subject = $this->l->t('You changed your password');
 		} elseif ($event->getSubject() === self::PASSWORD_RESET) {
 			$subject = $this->l->t('Your password was reset by an administrator');
+		} elseif ($event->getSubject() === self::PASSWORD_RESET_SELF) {
+			$subject = $this->l->t('Your password was reset');
 		} elseif ($event->getSubject() === self::EMAIL_CHANGED_BY) {
 			$subject = $this->l->t('{actor} changed your email address');
 		} elseif ($event->getSubject() === self::EMAIL_CHANGED_SELF) {
@@ -143,6 +146,7 @@ class Provider implements IProvider {
 		switch ($subject) {
 			case self::PASSWORD_CHANGED_SELF:
 			case self::PASSWORD_RESET:
+			case self::PASSWORD_RESET_SELF:
 			case self::EMAIL_CHANGED_SELF:
 			case self::EMAIL_CHANGED:
 				return [];

--- a/apps/settings/lib/Hooks.php
+++ b/apps/settings/lib/Hooks.php
@@ -106,6 +106,7 @@ class Hooks {
 		$actor = $this->userSession->getUser();
 		if ($actor instanceof IUser) {
 			if ($actor->getUID() !== $user->getUID()) {
+				// Admin changed the password through the user panel
 				$this->l = $this->languageFactory->get(
 					'settings',
 					$this->config->getUserValue(
@@ -118,13 +119,21 @@ class Hooks {
 				$event->setAuthor($actor->getUID())
 					->setSubject(Provider::PASSWORD_CHANGED_BY, [$actor->getUID()]);
 			} else {
+				// User changed their password themselves through settings
 				$text = $this->l->t('Your password on %s was changed.', [$instanceUrl]);
 				$event->setAuthor($actor->getUID())
 					->setSubject(Provider::PASSWORD_CHANGED_SELF);
 			}
 		} else {
-			$text = $this->l->t('Your password on %s was reset by an administrator.', [$instanceUrl]);
-			$event->setSubject(Provider::PASSWORD_RESET);
+			if (PHP_SAPI === 'cli') {
+				// Admin used occ to reset the password
+				$text = $this->l->t('Your password on %s was reset by an administrator.', [$instanceUrl]);
+				$event->setSubject(Provider::PASSWORD_RESET);
+			} else {
+				// User reset their password from Lost page
+				$text = $this->l->t('Your password on %s was reset.', [$instanceUrl]);
+				$event->setSubject(Provider::PASSWORD_RESET_SELF);
+			}
 		}
 
 		$this->activityManager->publish($event);


### PR DESCRIPTION
When resetting my password without being logged in I was getting the wrong message (there's no session since we're logged out, and it assumed it was an admin action).

Before : "Your password was reset by an administrator"
After : "Your password was reset"

Not sure if this covers all cases, but at least the message stays valid.