### PR TITLE
Array offset error due to empty file versions array

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -641,6 +641,11 @@ class Storage {
 		}
 
 		$firstVersion = reset($versions);
+
+		if ($firstVersion === false) {
+			return [$toDelete, $size];
+		}
+
 		$firstKey = key($versions);
 		$prevTimestamp = $firstVersion['version'];
 		$nextVersion = $firstVersion['version'] - $step;

--- a/apps/files_versions/tests/VersioningTest.php
+++ b/apps/files_versions/tests/VersioningTest.php
@@ -274,6 +274,11 @@ class VersioningTest extends \Test\TestCase {
 				],
 				9 // size of all deleted files (every file has the size 1)
 			],
+			// fourth set of versions: empty (see issue #19066)
+			[
+				[],
+				0
+			]
 
 		];
 	}


### PR DESCRIPTION
Fixes issue #19066 implementing fix proposed by @kesselb (https://github.com/nextcloud/server/issues/19066#issuecomment-577199256)