### PR TITLE
Always try and show pre rendered preview

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -126,9 +126,6 @@ class Generator {
 		if ($mimeType === null) {
 			$mimeType = $file->getMimeType();
 		}
-		if (!$this->previewManager->isMimeSupported($mimeType)) {
-			throw new NotFoundException();
-		}
 
 		$previewFolder = $this->getPreviewFolder($file);
 
@@ -155,7 +152,7 @@ class Generator {
 			$crop = $specification['crop'] ?? false;
 			$mode = $specification['mode'] ?? IPreview::MODE_FILL;
 
-			// If both width and heigth are -1 we just want the max preview
+			// If both width and height are -1 we just want the max preview
 			if ($width === -1 && $height === -1) {
 				$width = $maxWidth;
 				$height = $maxHeight;
@@ -176,6 +173,10 @@ class Generator {
 				try {
 					$preview = $this->getCachedPreview($previewFolder, $width, $height, $crop, $maxPreview->getMimeType(), $previewVersion);
 				} catch (NotFoundException $e) {
+					if (!$this->previewManager->isMimeSupported($mimeType)) {
+						throw new NotFoundException();
+					}
+
 					if ($maxPreviewImage === null) {
 						$maxPreviewImage = $this->helper->getImage($maxPreview);
 					}


### PR DESCRIPTION
Currently if the following situation happens

Server generates preview
Server has command removed which allows a preview to be shown
Client asks for preview, gets a 404 error when preview exists
(Mime checked before preview)

This happens more often with documents, or video as the commands are not
native PHP, they require a binary on the server.

After the fix the following would happen

Server generates preview
Server has command removed which allows a preview to be shown
Client asks for preview, gets preview which has been generated
(Mime checked after preview)

This would also allow offline generation (for example a docker image
containing the extra binaries), allowing a reduction in attack surface
of the instance serving the preview data.