### PR TITLE
18.0.4 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(18, 0, 3, 0);
+$OC_Version = array(18, 0, 4, 0);
 
 // The human readable string
-$OC_VersionString = '18.0.3';
+$OC_VersionString = '18.0.4 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #19879 [stable18] Use contacts name on federated activities
* #19882 [stable18]  Allow to edit admin/own user in the user management
* #19884 [stable18] Fix hostname in Apple configuration profile
* #19886 [stable18] Don't break when one remote share is down
* #19897 [stable18] Properly emit Viewer event on files and files_sharing
* #19916 [stable18] Get correct mimetype on objectstores
* #19921 [stable18] Properly respect hide download on sharebymail
* #19922 [stable18] Use placeholder values for password fields in external storage webui
* #19924 [stable18] Do not use the instance name as user part of from mail addresses
* #19933 [stable18] Don't allow anchors and queries in remote urls
* #19940 [stable18] fix external storage controller tests
* #19945 Bump acorn from 6.3.0 to 6.4.1
* #19950 [stable18] properly set 'hide_download' as integer
* #19966 [stable18] fix safari useragent for versions with 3 digits
* #19982 [stable18] Fix default action for deleted shares
* #19998 [stable18] Default value of lookupServerEnabled should be the same everywhere
* #19999 [stable18] Only do regular polling of storage statistics if session_keepalive is enabled
* #20001 [stable18] Fix single "ScopeContext" passed to "setScopes"
* #20008 [stable18] Fix invalid instantiation of TemplateResponse if client not found
* #20016 [stable18] Update the target when it isempty after sharing
* #20021 [stable18] remove the requirement that everything that looks like a placeholder …
* #20030 [stable18] Handle long dav property paths by hashing them
* #20044 [stable18] Allow the video player on the hide download
* #20046 [stable18] fixes auto-detecting UUID attributes
* #20051 [stable18] Force compatible dependency versions in acceptance tests
* #20060 [stable18] Adjust acceptance tests to incoming shares being accepted by default
* #20104 [stable18] fix dav browser error page not styled
* #20136 [stable18] Fix language multiselect action
* #20140 [stable18] Remove admin_notifications since it is obsolete since Nextcloud 14
* #20144 [stable18] change quota design
* #20148 [stable18] RefreshWebcalService: randomly generate calendar-object uri
* #20155 [stable18] Close updatenotification channel selector on click outside
* #20158 [stable18] Add app config to disable user flows
* #20161 [stable18] Auto accept group shares for users added to a group
* #20166 [stable18] Check the user on remote wipe
* #20175 [stable18] Bugfix - Prevent PHP Warning for count on null on LDAP
* #20195 Bump version on stable18
* #20202 [stable18] Actually check if the owner is not null
* #20238 [stable18] Remove Acrobat logo from PDF filetype icon
* #20258 [stable18] Dont always use the current users quota when calculating storage info
* #20274 Silence LDAP deprecation logs in NC 18
* #20296 [stable18] fixes the return type of BeforeUserLoggedInEvent
* #20335 [stable18] Catch NotFoundException when getting the user folder
* #20366 [stable18] Try to use the display name of file transfers
* #20382 [stable18] Clear comment on successful post
* #20387 [stable18] Fix systemtags overflow
* #20407 [stable18] Add text restore after restore icon
* #20433 [stable18] Make sure group management works with all types of group names
* [activity#441](https://github.com/nextcloud/activity/pull/441) [stable18] Email activity is missing information
* [activity#446](https://github.com/nextcloud/activity/pull/446) [stable18] catch new notfound exception while trying to get owner
* [files_pdfviewer#169](https://github.com/nextcloud/files_pdfviewer/pull/169) [stable18] Bump pdf.js to 2.1.266
* [firstrunwizard#301](https://github.com/nextcloud/firstrunwizard/pull/301) Bump acorn from 7.1.0 to 7.1.1
* [firstrunwizard#313](https://github.com/nextcloud/firstrunwizard/pull/313) [stable18] Hide slide for app store if disabled
* [notifications#608](https://github.com/nextcloud/notifications/pull/608) [stable18] Request the permissions for notifications via user interaction
* [photos#239](https://github.com/nextcloud/photos/pull/239) Bump acorn from 6.3.0 to 6.4.1
* [recommendations#196](https://github.com/nextcloud/recommendations/pull/196) Bump acorn from 6.4.0 to 6.4.1
* [serverinfo#189](https://github.com/nextcloud/serverinfo/pull/189) [stable18] Update DefaultOs.php
* [viewer#422](https://github.com/nextcloud/viewer/pull/422) Public pages compatibility
* [viewer#423](https://github.com/nextcloud/viewer/pull/423) Move cypress to gh actions
* [viewer#425](https://github.com/nextcloud/viewer/pull/425) Bump acorn from 5.7.3 to 5.7.4
* [viewer#428](https://github.com/nextcloud/viewer/pull/428) [stable18] Fix trying to open the sidebar when not available
* [viewer#435](https://github.com/nextcloud/viewer/pull/435) [stable18] Add public testing
* [viewer#450](https://github.com/nextcloud/viewer/pull/450) [stable18] Fix public preview url cropping
* [viewer#453](https://github.com/nextcloud/viewer/pull/453) [stable18] Fix babel transpile settings


Pending PRs:

* [x] #20102 [stable18] fix OCA\DAV\CalDAV\CalDavBackend search $options @backportbot-nextcloud
* [x] #20163 [stable18] Use global used space in quota wrappen when external storage is included @backportbot-nextcloud
* [x] #20282 [stable18] Check for empty authorization headers for office requests @backportbot-nextcloud
* [x] #20334 [stable18] Properly catch NoUserException during upload cleanup @backportbot-nextcloud
* [ ] #20405 [stable18] update icewind/smb to 3.2.3 @backportbot-nextcloud
* [x] #20420 [18] Use a normal string to translate. @kesselb
* [x] [activity#449](https://github.com/nextcloud/activity/pull/449) [stable18] Skip notifications for users with invalid email address. @backportbot-nextcloud