### PR TITLE
17.0.6 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(17, 0, 5, 0);
+$OC_Version = array(17, 0, 6, 0);
 
 // The human readable string
-$OC_VersionString = '17.0.5';
+$OC_VersionString = '17.0.6 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #19885 Fix hostname in Apple configuration profile
* #19917 Get correct mimetype on objectstores
* #19925 Do not use the instance name as user part of from mail addresses
* #19983 Fix default action for deleted shares
* #20000 Default value of lookupServerEnabled should be the same everywhere
* #20017 Update the target when it isempty after sharing
* #20034 Handle long dav property paths by hashing them
* #20047 Fixes auto-detecting UUID attributes
* #20052 Force compatible dependency versions in acceptance tests
* #20055 Remove the requirement that everything that looks like a placeholder …
* #20131 Fix PDF and video viewers on public links
* #20141 Remove admin_notifications since it is obsolete since Nextcloud 14
* #20149 RefreshWebcalService: randomly generate calendar-object uri
* #20157 Close updatenotification channel selector on click outside
* #20167 Check the user on remote wipe
* #20176 Bugfix - Prevent PHP Warning for count on null on LDAP
* #20194 Bump version on stable17
* #20203 Actually check if the owner is not null
* #20239 Remove Acrobat logo from PDF filetype icon
* #20259 Dont always use the current users quota when calculating storage info
* #20263 Do not flood console when uploading files
* #20336 Catch NotFoundException when getting the user folder
* [activity#442](https://github.com/nextcloud/activity/pull/442) Email activity is missing information
* [activity#447](https://github.com/nextcloud/activity/pull/447) Catch new notfound exception while trying to get owner
* [files_pdfviewer#170](https://github.com/nextcloud/files_pdfviewer/pull/170) Bump pdf.js to 2.1.266
* [firstrunwizard#303](https://github.com/nextcloud/firstrunwizard/pull/303) Bump acorn from 6.1.1 to 6.4.1
* [notifications#590](https://github.com/nextcloud/notifications/pull/590) Bump acorn from 6.1.1 to 6.4.1
* [recommendations#197](https://github.com/nextcloud/recommendations/pull/197) Bump acorn from 6.2.1 to 6.4.1


Pending PRs:

* [x] #20164 Use global used space in quota wrappen when external storage is included @backportbot-nextcloud
* [x] #20189 Fix OCA\DAV\CalDAV\CalDavBackend search $options @tcitworld
* [x] #20283 Check for empty authorization headers for office requests @backportbot-nextcloud
* [ ] #20406 Update icewind/smb to 3.2.3 @backportbot-nextcloud
* [x] #20408 Add text restore after restore icon @backportbot-nextcloud
