### PR TITLE
16.0.10 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(16, 0, 9, 2);
+$OC_Version = array(16, 0, 10, 0);
 
 // The human readable string
-$OC_VersionString = '16.0.9';
+$OC_VersionString = '16.0.10 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #19926 Do not use the instance name as user part of from mail addresses
* #19946 Bump acorn from 6.1.1 to 6.4.1
* #19984 Fix default action for deleted shares
* #20002 Default value of lookupServerEnabled should be the same everywhere
* #20018 Update the target when it isempty after sharing
* #20048 Fixes auto-detecting UUID attributes
* #20053 Force compatible dependency versions in acceptance tests
* #20142 Remove admin_notifications since it is obsolete since Nextcloud 14
* #20147 Fix PDF and video viewers on public links
* #20177 Bugfix - Prevent PHP Warning for count on null on LDAP
* #20240 Remove Acrobat logo from PDF filetype icon
* #20337 Catch NotFoundException when getting the user folder
* [activity#443](https://github.com/nextcloud/activity/pull/443) Email activity is missing information
* [firstrunwizard#302](https://github.com/nextcloud/firstrunwizard/pull/302) Bump acorn from 6.1.1 to 6.4.1
* [notifications#591](https://github.com/nextcloud/notifications/pull/591) Bump acorn from 6.1.1 to 6.4.1
* [recommendations#198](https://github.com/nextcloud/recommendations/pull/198) Bump acorn from 6.1.1 to 6.4.1


Pending PRs:

* [x] #19328 Fix occ maintenance:install database connect failure @backportbot-nextcloud
* [x] #20190 Fix OCA\DAV\CalDAV\CalDavBackend search $options @tcitworld
* [x] [files_pdfviewer#171](https://github.com/nextcloud/files_pdfviewer/pull/171) Bump pdf.js to 2.1.266 @backportbot-nextcloud
