### PR TITLE
fix: acceptance test for comments requires activity app

### DIFF
--- a/tests/acceptance/run-local.sh
+++ b/tests/acceptance/run-local.sh
@@ -198,6 +198,10 @@ if [ ! -e "apps/notifications" ]; then
 	(cd apps && git clone --depth 1 https://github.com/nextcloud/notifications)
 fi
 
+if [ ! -e "apps/activity" ]; then
+	(cd apps && git clone --depth 1 https://github.com/nextcloud/activity)
+fi
+
 INSTALL_AND_CONFIGURE_SERVER_PARAMETERS=""
 if [ "$NEXTCLOUD_SERVER_DOMAIN" != "$DEFAULT_NEXTCLOUD_SERVER_DOMAIN" ]; then
 	INSTALL_AND_CONFIGURE_SERVER_PARAMETERS+="--nextcloud-server-domain $NEXTCLOUD_SERVER_DOMAIN"


### PR DESCRIPTION
The presence of the activity app makes the details sidebar reload
after creating a new folder.

The reload is required for the comment form to work.
Otherwise it will trigger a page reload.

Clone the activity app just like notifications
when preparing the test environment.

refs #20454

This at least fixes the first test for comments starting in line 21. Other comments tests are still failing for me locally.