### PR TITLE
DAV's exception logger should deal with any Throwable

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
@@ -110,7 +110,7 @@ class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
 	 * Log exception
 	 *
 	 */
-	public function logException(\Exception $ex) {
+	public function logException(\Throwable $ex) {
 		$exceptionClass = get_class($ex);
 		$level = ILogger::FATAL;
 		if (isset($this->nonFatalExceptions[$exceptionClass]) ||


### PR DESCRIPTION
I was having an occasion where a TypeError was passed in via sabre's WildcardEmitterTrait

``
"Exception": "TypeError",
    "Message": "Argument 1 passed to OCA\\DAV\\Connector\\Sabre\\ExceptionLoggerPlugin::logException() must be an instance of Exception, instance of TypeError given, called in /srv/http/nextcloud/master/3rdparty/sabre/event/lib/WildcardEmitterTrait.php on line 89",
``