### PR TITLE
do not advertise nulled userId for for systemwide credentials

### DIFF
--- a/lib/private/Security/CredentialsManager.php
+++ b/lib/private/Security/CredentialsManager.php
@@ -53,7 +53,7 @@ class CredentialsManager implements ICredentialsManager {
 	/**
 	 * Store a set of credentials
 	 *
-	 * @param string|null $userId Null for system-wide credentials
+	 * @param string $userId empty string for system-wide credentials
 	 * @param string $identifier
 	 * @param mixed $credentials
 	 */
@@ -61,7 +61,7 @@ class CredentialsManager implements ICredentialsManager {
 		$value = $this->crypto->encrypt(json_encode($credentials));
 
 		$this->dbConnection->setValues(self::DB_TABLE, [
-			'user' => $userId,
+			'user' => (string)$userId,
 			'identifier' => $identifier,
 		], [
 			'credentials' => $value,
@@ -71,7 +71,7 @@ class CredentialsManager implements ICredentialsManager {
 	/**
 	 * Retrieve a set of credentials
 	 *
-	 * @param string|null $userId Null for system-wide credentials
+	 * @param string $userId empty string for system-wide credentials
 	 * @param string $identifier
 	 * @return mixed
 	 */
@@ -79,7 +79,7 @@ class CredentialsManager implements ICredentialsManager {
 		$qb = $this->dbConnection->getQueryBuilder();
 		$qb->select('credentials')
 			->from(self::DB_TABLE)
-			->where($qb->expr()->eq('user', $qb->createNamedParameter($userId)))
+			->where($qb->expr()->eq('user', $qb->createNamedParameter((string)$userId)))
 			->andWhere($qb->expr()->eq('identifier', $qb->createNamedParameter($identifier)))
 		;
 		$result = $qb->execute()->fetch();
@@ -95,14 +95,14 @@ class CredentialsManager implements ICredentialsManager {
 	/**
 	 * Delete a set of credentials
 	 *
-	 * @param string|null $userId Null for system-wide credentials
+	 * @param string $userId empty string for system-wide credentials
 	 * @param string $identifier
 	 * @return int rows removed
 	 */
 	public function delete($userId, $identifier) {
 		$qb = $this->dbConnection->getQueryBuilder();
 		$qb->delete(self::DB_TABLE)
-			->where($qb->expr()->eq('user', $qb->createNamedParameter($userId)))
+			->where($qb->expr()->eq('user', $qb->createNamedParameter((string)$userId)))
 			->andWhere($qb->expr()->eq('identifier', $qb->createNamedParameter($identifier)))
 		;
 		return $qb->execute();

--- a/lib/public/Security/ICredentialsManager.php
+++ b/lib/public/Security/ICredentialsManager.php
@@ -33,7 +33,7 @@ interface ICredentialsManager {
 	/**
 	 * Store a set of credentials
 	 *
-	 * @param string|null $userId Null for system-wide credentials
+	 * @param string $userId empty string for system-wide credentials
 	 * @param string $identifier
 	 * @param mixed $credentials
 	 * @since 8.2.0
@@ -43,7 +43,7 @@ interface ICredentialsManager {
 	/**
 	 * Retrieve a set of credentials
 	 *
-	 * @param string|null $userId Null for system-wide credentials
+	 * @param string $userId empty string for system-wide credentials
 	 * @param string $identifier
 	 * @return mixed
 	 * @since 8.2.0
@@ -53,7 +53,7 @@ interface ICredentialsManager {
 	/**
 	 * Delete a set of credentials
 	 *
-	 * @param string|null $userId Null for system-wide credentials
+	 * @param string $userId empty string for system-wide credentials
 	 * @param string $identifier
 	 * @return int rows removed
 	 * @since 8.2.0

--- a/tests/lib/Security/CredentialsManagerTest.php
+++ b/tests/lib/Security/CredentialsManagerTest.php
@@ -134,9 +134,9 @@ class CredentialsManagerTest extends \Test\TestCase {
 				'privateCredentials'
 			],
 			[
-				null,
-				'systemCredentials'
-			]
+				'',
+				'systemCredentials',
+			],
 		];
 	}
 }

--- a/tests/lib/Security/CredentialsManagerTest.php
+++ b/tests/lib/Security/CredentialsManagerTest.php
@@ -27,6 +27,9 @@ use OCP\IDBConnection;
 use OCP\ILogger;
 use OCP\Security\ICrypto;
 
+/**
+ * @group DB
+ */
 class CredentialsManagerTest extends \Test\TestCase {
 
 	/** @var ICrypto */
@@ -105,5 +108,35 @@ class CredentialsManagerTest extends \Test\TestCase {
 			->willReturn($qb);
 
 		$this->manager->retrieve($userId, $identifier);
+	}
+
+	/**
+	 * @dataProvider credentialsProvider
+	 */
+	public function testWithDB($userId, $identifier) {
+		$credentialsManager = \OC::$server->getCredentialsManager();
+
+		$secrets = 'Open Sesame';
+
+		$credentialsManager->store($userId, $identifier, $secrets);
+		$received = $credentialsManager->retrieve($userId, $identifier);
+
+		$this->assertSame($secrets, $received);
+
+		$removedRows = $credentialsManager->delete($userId, $identifier);
+		$this->assertSame(1, $removedRows);
+	}
+
+	public function credentialsProvider() {
+		return [
+			[
+				'alice',
+				'privateCredentials'
+			],
+			[
+				null,
+				'systemCredentials'
+			]
+		];
 	}
 }


### PR DESCRIPTION
these (first commit) are actually expected to FAIL, because NULL as a userid is not
allowed in the schema, but documented to be used on the source.

There you go:

![Screenshot_20200415_193341](https://user-images.githubusercontent.com/2184312/79368668-0d91ed80-7f50-11ea-9605-788b8f3ec95b.png)


I will push fixing commits after CI finished.

I left the API as is for compatibility (although it probably would have crashed earlier if someone was using it…). Now it is de-facto backwards compatible and uses strings against DB always.