### PR TITLE
Rename updatenotifications webpack module to updatenotification

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -14,7 +14,7 @@ const oauth2 = require('./apps/oauth2/webpack')
 const settings = require('./apps/settings/webpack')
 const systemtags = require('./apps/systemtags/webpack')
 const twofactor_backupscodes = require('./apps/twofactor_backupcodes/webpack')
-const updatenotifications = require('./apps/updatenotification/webpack')
+const updatenotification = require('./apps/updatenotification/webpack')
 const workflowengine = require('./apps/workflowengine/webpack')
 
 const modules = {
@@ -29,7 +29,7 @@ const modules = {
 	settings,
 	systemtags,
 	twofactor_backupscodes,
-	updatenotifications,
+	updatenotification,
 	workflowengine
 }
 


### PR DESCRIPTION
This is the most nitpicky PR I have ever made and I am sorry about that.

The module build name for `updatenotification` is actually `updatenotifications` which can be confusing (it confused me for 5 minutes when I was working on it). It is the only module with a name that is different from the app's name.