### PR TITLE
do not run paged results against ldap_read ops on PHP7.3+

### DIFF
--- a/apps/user_ldap/lib/PagedResults/Php73.php
+++ b/apps/user_ldap/lib/PagedResults/Php73.php
@@ -135,7 +135,6 @@ class Php73 implements IAdapter {
 		$this->linkData[$linkId]['readArgs'] = func_get_args();
 		$this->linkData[$linkId]['readArgs'][] = 0; // $attrsonly default
 		$this->linkData[$linkId]['readArgs'][] = -1; // $sizelimit default
-		$this->preparePagesResultsArgs($linkId, 'readArgs');
 	}
 
 	public function getReadArgs($link): array {


### PR DESCRIPTION
- previously it was needed as the PHP LDAP handling of paged results was
strange
- but now the read operation would fail, e.g. with extra home dir attribute
set ("Home dir attribute can't be read from LDAP for uid: foobar"

That's also how to reproduce it. With PHP 7.3, set an home dir attribute in LDAP's advanced tab and go to users page. It'll fail without this change.