### PR TITLE
17.0.6 RC2

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(17, 0, 6, 0);
+$OC_Version = array(17, 0, 6, 1);
 
 // The human readable string
-$OC_VersionString = '17.0.6 RC1';
+$OC_VersionString = '17.0.6 RC2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #20406 Update icewind/smb to 3.2.3
* #20494 Close the streams in `writeStream` even when there is an exception


Pending PRs:

* [x] #20513 Provide the proper language to the mailer @backportbot-nextcloud
* [x] #20517 Do not advertise nulled userId for for systemwide credentials @backportbot-nextcloud
* [x] #20532 Update list of multiple properties @backportbot-nextclou