### PR TITLE
[stable16] Make mariadb check case-insensitive

### DIFF
--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -45,7 +45,7 @@ class MySQL extends AbstractDatabase {
 		$row = $result->fetch();
 		$version = strtolower($row['Value']);
 
-		if (strpos($version, 'mariadb') !== false) {
+		if (stripos($version, 'mariadb') !== false) {
 			if (version_compare($version, '10.4', '>=')) {
 				throw new DatabaseSetupException(sprintf('Unsupported MariaDB version %s, Nextcloud 16 requires a version lower than 10.4', $row['Value']));
 			}


### PR DESCRIPTION
This should fix error messages like this:
```
Unsupported MySQL version 10.3.22-MariaDB-1:10.3.22+maria~bionic, Nextcloud 16 requires a version lower than 8.0
```
See: https://github.com/docker-library/official-images/pull/7812#issuecomment-616650805