### PR TITLE
Ignore sharees and share-types property for chunks inside uploads/

### DIFF
--- a/apps/dav/lib/Connector/Sabre/SharesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/SharesPlugin.php
@@ -179,6 +179,10 @@ class SharesPlugin extends \Sabre\DAV\ServerPlugin {
 			return;
 		}
 
+		if (strpos($sabreNode->getFileInfo()->getInternalPath(), 'uploads/') === 0) {
+			return;
+		}
+
 		// need prefetch ?
 		if ($sabreNode instanceof \OCA\DAV\Connector\Sabre\Directory
 			&& $propFind->getDepth() !== 0


### PR DESCRIPTION
Fix #20235 

There are no shares for files (chunks) in `uploads/`. Ignore the properties for such objects.

Not sure if that is a good way to fix it. Please have a closer look at the mocks especially the internal paths. 

