### PR TITLE
Use a proper upload file so propfinds return 404

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -223,6 +223,7 @@ return array(
     'OCA\\DAV\\Upload\\CleanupService' => $baseDir . '/../lib/Upload/CleanupService.php',
     'OCA\\DAV\\Upload\\FutureFile' => $baseDir . '/../lib/Upload/FutureFile.php',
     'OCA\\DAV\\Upload\\RootCollection' => $baseDir . '/../lib/Upload/RootCollection.php',
+    'OCA\\DAV\\Upload\\UploadFile' => $baseDir . '/../lib/Upload/UploadFile.php',
     'OCA\\DAV\\Upload\\UploadFolder' => $baseDir . '/../lib/Upload/UploadFolder.php',
     'OCA\\DAV\\Upload\\UploadHome' => $baseDir . '/../lib/Upload/UploadHome.php',
 );

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -238,6 +238,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Upload\\CleanupService' => __DIR__ . '/..' . '/../lib/Upload/CleanupService.php',
         'OCA\\DAV\\Upload\\FutureFile' => __DIR__ . '/..' . '/../lib/Upload/FutureFile.php',
         'OCA\\DAV\\Upload\\RootCollection' => __DIR__ . '/..' . '/../lib/Upload/RootCollection.php',
+        'OCA\\DAV\\Upload\\UploadFile' => __DIR__ . '/..' . '/../lib/Upload/UploadFile.php',
         'OCA\\DAV\\Upload\\UploadFolder' => __DIR__ . '/..' . '/../lib/Upload/UploadFolder.php',
         'OCA\\DAV\\Upload\\UploadHome' => __DIR__ . '/..' . '/../lib/Upload/UploadHome.php',
     );

--- a/apps/dav/lib/Upload/UploadFile.php
+++ b/apps/dav/lib/Upload/UploadFile.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DAV\Upload;
+
+use OCA\DAV\Connector\Sabre\File;
+use Sabre\DAV\IFile;
+
+class UploadFile implements IFile {
+
+	/**  @var File */
+	private $file;
+
+	public function __construct(File $file) {
+		$this->file = $file;
+	}
+
+	public function put($data) {
+		return $this->file->put($data);
+	}
+
+	public function get() {
+		return $this->file->get();
+	}
+
+	public function getContentType() {
+		return $this->file->getContentType();
+	}
+
+	public function getETag() {
+		return $this->file->getETag();
+	}
+
+	public function getSize() {
+		return $this->file->getSize();
+	}
+
+	public function delete() {
+		$this->file->delete();
+	}
+
+	public function getName() {
+		return $this->file->getName();
+	}
+
+	public function setName($name) {
+		$this->file->setName($name);
+	}
+
+	public function getLastModified() {
+		return $this->file->getLastModified();
+	}
+}

--- a/apps/dav/lib/Upload/UploadFolder.php
+++ b/apps/dav/lib/Upload/UploadFolder.php
@@ -53,12 +53,19 @@ class UploadFolder implements ICollection {
 		if ($name === '.file') {
 			return new FutureFile($this->node, '.file');
 		}
-		return $this->node->getChild($name);
+		return new UploadFile($this->node->getChild($name));
 	}
 
 	public function getChildren() {
-		$children = $this->node->getChildren();
+		$tmpChildren = $this->node->getChildren();
+
+		$children = [];
 		$children[] = new FutureFile($this->node, '.file');
+
+		foreach ($tmpChildren as $child) {
+			$children[] = new UploadFile($child);
+		}
+
 		return $children;
 	}
 

--- a/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
@@ -32,6 +32,7 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\File;
 use OCA\DAV\Connector\Sabre\Node;
+use OCA\DAV\Upload\UploadFile;
 use OCP\Files\Folder;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -189,7 +190,7 @@ class SharesPluginTest extends \Test\TestCase {
 		$this->userFolder->method('get')
 			->with('/subdir')
 			->willReturn($node);
-		
+
 		$dummyShares = array_map(function ($type) {
 			$share = $this->getMockBuilder(IShare::class)->getMock();
 			$share->expects($this->any())
@@ -281,5 +282,25 @@ class SharesPluginTest extends \Test\TestCase {
 			[[\OCP\Share::SHARE_TYPE_GROUP, \OCP\Share::SHARE_TYPE_LINK]],
 			[[\OCP\Share::SHARE_TYPE_USER, \OCP\Share::SHARE_TYPE_REMOTE]],
 		];
+	}
+
+	public function testGetPropertiesSkipChunks(): void {
+		$sabreNode = $this->getMockBuilder(UploadFile::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propFind = new \Sabre\DAV\PropFind(
+			'/dummyPath',
+			[self::SHARETYPES_PROPERTYNAME],
+			0
+		);
+
+		$this->plugin->handleGetProperties(
+			$propFind,
+			$sabreNode
+		);
+
+		$result = $propFind->getResultForMultiStatus();
+		$this->assertCount(1, $result[404]);
 	}
 }

--- a/apps/dav/tests/unit/Connector/Sabre/TagsPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/TagsPluginTest.php
@@ -30,6 +30,7 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\File;
 use OCA\DAV\Connector\Sabre\Node;
+use OCA\DAV\Upload\UploadFile;
 use OCP\ITagManager;
 use OCP\ITags;
 use Sabre\DAV\Tree;
@@ -264,6 +265,26 @@ class TagsPluginTest extends \Test\TestCase {
 				]
 			],
 		];
+	}
+
+	public function testGetPropertiesSkipChunks(): void {
+		$sabreNode = $this->getMockBuilder(UploadFile::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propFind = new \Sabre\DAV\PropFind(
+			'/dummyPath',
+			[self::TAGS_PROPERTYNAME, self::TAG_FAVORITE],
+			0
+		);
+
+		$this->plugin->handleGetProperties(
+			$propFind,
+			$sabreNode
+		);
+
+		$result = $propFind->getResultForMultiStatus();
+		$this->assertCount(2, $result[404]);
 	}
 
 	public function testUpdateTags() {


### PR DESCRIPTION
Fixes #20235, Closes #20569

By using an UploadFile we make sure that we don't need to have another
check everywhere for the path. But we just have ot check (which we have
to anyway) if it is a proper Connector/File (or directory).

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>