### PR TITLE
19 beta 6

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [19, 0, 0, 6];
+$OC_Version = [19, 0, 0, 7];
 
 // The human readable string
-$OC_VersionString = '19.0.0 beta 5';
+$OC_VersionString = '19.0.0 beta 6';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #17623 Add support for download share on old android browser
* #18816 Use paginated search for contacts
* #18883 Optimize Openstack Swift files download
* #19002 Fix security header setting in .htaccess by adding 'onsuccess unset'
* #19039 Provide links to calendar in event creation/update activities
* #19084 Make it possible to resolve svg's outside \OC::$SERVERROOT
* #19436 Do not include mountpoints when calculating quota usage on WebDAV
* #19514 Already enabled apps
* #19793 Fix resharing of federated shares that were created out of links
* #19919 LDAP Group Backend optimizations
* #19929 Delete avatar if a user is deleted
* #20262 Allow to navigate to others with access from the sidebar
* #20298 Allow to configure auto logout after browser inactivity
* #20558 Bump vue-click-outside from 1.0.7 to 1.1.0
* #20559 Bump mochapack from 1.1.13 to 1.1.15
* #20570 Use a proper upload file so propfinds return 404
* #20587 Allow specifying a default expiration date
* #20599 Filter out blacklisted files in getDirectoryContent
* #20618 Fix workflow UI
* #20626 Add folder argument to files:scan-app-data
* #20627 Remove obsolete repair steps for logo and updater channel
* #20632 Only catch anonymous OPTIONS for Office
* #20634 Generate legacy image placeholder text by taking first letters
* #20636 Add tests for update notification controller for non-default updater …
* #20640 Correctly hide table headers in filepicker
* #20650 Adhere to EMailTemplate interface in constructor call.
* #20655 Bump node-sass from 4.13.0 to 4.14.0 in /build
* #20658 Bump node-sass from 4.13.1 to 4.14.0
* #20661 Bump css-loader from 3.5.2 to 3.5.3
* #20663 Bump webpack from 4.42.1 to 4.43.0
* #20673 Set exit code if something went wrong.
* #20676 Don't remove last user in ldap group when limit is -1
* #20677 Scaling user provisioning for subadmins with many groups
* #20678 Fix missing argument in JSConfigHelper
* #20710 Fix Argon2 options checks
* #20714 Update license headers for 19
* #20715 Bump style-loader from 1.1.4 to 1.2.1
* #20717 Define getSystemValueBool/Int/String function default parameter with correct type
* #20718 Add a wrapper to fall back to the share owner on public shares
* #20720 Temporary fix contacts search
* #20742 Run the cs fixer for green ci
* [firstrunwizard#325](https://github.com/nextcloud/firstrunwizard/pull/325) Bump node-sass from 4.13.1 to 4.14.0
* [firstrunwizard#326](https://github.com/nextcloud/firstrunwizard/pull/326) Bump css-loader from 3.5.2 to 3.5.3
* [firstrunwizard#328](https://github.com/nextcloud/firstrunwizard/pull/328) Bump @babel/preset-env from 7.9.5 to 7.9.6
* [notifications#620](https://github.com/nextcloud/notifications/pull/620) Allow to test push notifications
* [notifications#621](https://github.com/nextcloud/notifications/pull/621) Try to continue notification polling after the browser was closed ove…
* [notifications#624](https://github.com/nextcloud/notifications/pull/624) Fix unit tests after #620
* [notifications#625](https://github.com/nextcloud/notifications/pull/625) Set the ETag when requesting notifications
* [notifications#626](https://github.com/nextcloud/notifications/pull/626) Bump node-sass from 4.13.1 to 4.14.0
* [notifications#627](https://github.com/nextcloud/notifications/pull/627) Bump css-loader from 3.5.2 to 3.5.3
* [notifications#628](https://github.com/nextcloud/notifications/pull/628) Bump webpack from 4.42.1 to 4.43.0
* [password_policy#102](https://github.com/nextcloud/password_policy/pull/102) Disable account after failed login attempts
* [password_policy#103](https://github.com/nextcloud/password_policy/pull/103) Else wrong user/password attempts generate an exception
* [privacy#389](https://github.com/nextcloud/privacy/pull/389) Correction of the description
* [privacy#390](https://github.com/nextcloud/privacy/pull/390) Bump stylelint from 13.3.2 to 13.3.3
* [privacy#391](https://github.com/nextcloud/privacy/pull/391) Bump webpack from 4.42.1 to 4.43.0
* [privacy#392](https://github.com/nextcloud/privacy/pull/392) Bump phpunit/phpunit from 8.5.3 to 8.5.4
* [privacy#393](https://github.com/nextcloud/privacy/pull/393) Bump vuex from 3.2.0 to 3.3.0
* [privacy#394](https://github.com/nextcloud/privacy/pull/394) Bump css-loader from 3.5.2 to 3.5.3
* [privacy#396](https://github.com/nextcloud/privacy/pull/396) Bump @babel/preset-env from 7.9.5 to 7.9.6
* [privacy#397](https://github.com/nextcloud/privacy/pull/397) Bump babel-jest from 25.4.0 to 25.5.1
* [privacy#398](https://github.com/nextcloud/privacy/pull/398) Bump @babel/core from 7.9.0 to 7.9.6
* [recommendations#211](https://github.com/nextcloud/recommendations/pull/211) Bump vuex from 3.1.3 to 3.3.0
* [serverinfo#202](https://github.com/nextcloud/serverinfo/pull/202) More tests for getMemory, getCPUName and getUptime
* [viewer#476](https://github.com/nextcloud/viewer/pull/476) Revert "Delete menu-sidebar-white.svg"
* [viewer#478](https://github.com/nextcloud/viewer/pull/478) Bump webdav from 3.2.0 to 3.3.0
* [viewer#479](https://github.com/nextcloud/viewer/pull/479) Bump node-sass from 4.13.1 to 4.14.0
* [viewer#480](https://github.com/nextcloud/viewer/pull/480) Bump css-loader from 3.5.2 to 3.5.3
* [viewer#481](https://github.com/nextcloud/viewer/pull/481) Bump stylelint-scss from 3.17.0 to 3.17.1
* [viewer#482](https://github.com/nextcloud/viewer/pull/482) Bump webpack from 4.42.1 to 4.43.0


Pending PRs:

* [ ] #18199 Add and remove tags from multiple files at once @rolandinus
* [x] #19124 Exclude groups from sharing: Skip delete groups @kesselb
* [ ] #20291 Fix focus for user actionmenu @GretaD
* [ ] #20380 Fix design and layout of notification mails @jancborchardt
* [ ] #20538 Fix share expiration date not shown @gary-kim
* [ ] #20716 Add index to oc_properties @mario
* [ ] #20719 Fix languages empty array @GretaD
* [ ] #20725 Fix getDirectoryContent implementation for Jail wrapper @icewind1991
* [ ] #20726 Fix federated link sharing permissions @skjnldsv
* [ ] #20744 Fix public layout header title & description @skjnldsv
* [ ] #20749 PHP 7.4 excludes the arguments from stack traces by default. @kesselb
