### PR TITLE
Don't load text file preview when text app is available (Fixes: #20615)

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -152,7 +152,8 @@ OCA.Sharing.PublicApp = {
 			img.attr('src', $('#downloadURL').val());
 			imgcontainer.appendTo('#imgframe');
 		} else if (mimetype.substr(0, mimetype.indexOf('/')) === 'text' && window.btoa) {
-			if (OC.appswebroots['files_texteditor'] !== undefined) {
+			if (OC.appswebroots['files_texteditor'] !== undefined ||
+				OC.appswebroots['text'] !== undefined) {
 				// the text editor handles the previewing
 				return;
 			}


### PR DESCRIPTION
When opening a shared text document, the files_sharing app uses
internal preview support in case no other app to open the text file is
available.

So far, it only checks for the old files_texteditor app, not for the new
new text app. This commit fixes this by checking for both.