### PR TITLE
Only catch anonymous OPTIONS for Office

### DIFF
--- a/apps/dav/lib/Connector/Sabre/AnonymousOptionsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/AnonymousOptionsPlugin.php
@@ -67,9 +67,9 @@ class AnonymousOptionsPlugin extends ServerPlugin {
 		$emptyAuth = $request->getHeader('Authorization') === null
 			|| $request->getHeader('Authorization') === ''
 			|| trim($request->getHeader('Authorization')) === 'Bearer';
-		$isAnonymousOption = $request->getMethod() === 'OPTIONS' && $emptyAuth;
+		$isAnonymousOfficeOption = $request->getMethod() === 'OPTIONS' && $isOffice && $emptyAuth;
 		$isOfficeHead = $request->getMethod() === 'HEAD' && $isOffice && $emptyAuth;
-		if ($isAnonymousOption || $isOfficeHead) {
+		if ($isAnonymousOfficeOption || $isOfficeHead) {
 			/** @var CorePlugin $corePlugin */
 			$corePlugin = $this->server->getPlugin('core');
 			// setup a fake tree for anonymous access

--- a/apps/dav/tests/unit/DAV/AnonymousOptionsTest.php
+++ b/apps/dav/tests/unit/DAV/AnonymousOptionsTest.php
@@ -53,17 +53,35 @@ class AnonymousOptionsTest extends TestCase {
 	public function testAnonymousOptionsRoot() {
 		$response = $this->sendRequest('OPTIONS', '');
 
-		$this->assertEquals(200, $response->getStatus());
+		$this->assertEquals(401, $response->getStatus());
 	}
 
 	public function testAnonymousOptionsNonRoot() {
 		$response = $this->sendRequest('OPTIONS', 'foo');
 
-		$this->assertEquals(200, $response->getStatus());
+		$this->assertEquals(401, $response->getStatus());
 	}
 
 	public function testAnonymousOptionsNonRootSubDir() {
 		$response = $this->sendRequest('OPTIONS', 'foo/bar');
+
+		$this->assertEquals(401, $response->getStatus());
+	}
+
+	public function testAnonymousOptionsRootOffice() {
+		$response = $this->sendRequest('OPTIONS', '', 'Microsoft Office does strange things');
+
+		$this->assertEquals(200, $response->getStatus());
+	}
+
+	public function testAnonymousOptionsNonRootOffice() {
+		$response = $this->sendRequest('OPTIONS', 'foo', 'Microsoft Office does strange things');
+
+		$this->assertEquals(200, $response->getStatus());
+	}
+
+	public function testAnonymousOptionsNonRootSubDirOffice() {
+		$response = $this->sendRequest('OPTIONS', 'foo/bar', 'Microsoft Office does strange things');
 
 		$this->assertEquals(200, $response->getStatus());
 	}


### PR DESCRIPTION
Should do the trick and still work for the original issue with opening office files in subdirectories when mounting the WebDAV endpoint in Windows, but I cannot test that as I don't have a Windows/Office installation.

For #20624 