### PR TITLE
Correctly hide table headers in filepicker

### DIFF
--- a/core/css/mobile.scss
+++ b/core/css/mobile.scss
@@ -121,6 +121,8 @@
 	}
 
 	/* do not show dates in filepicker */
+	#oc-dialog-filepicker-content .filelist #headerSize,
+	#oc-dialog-filepicker-content .filelist #headerDate,
 	#oc-dialog-filepicker-content .filelist .filesize,
 	#oc-dialog-filepicker-content .filelist .date {
 		display: none;


### PR DESCRIPTION
Fixes #20639 

The headers for filesize and date are now hidden at the same time as the columns in the body:
![filepicker](https://user-images.githubusercontent.com/2496460/80248571-796f0700-8670-11ea-9d6a-73906f43728b.gif)

![Screenshot_2020-04-24 Inventar - Nextcloud](https://user-images.githubusercontent.com/2496460/80248604-8be94080-8670-11ea-9429-1897ffc26a8e.png)

