### PR TITLE
Adhere to EMailTemplate interface in constructor call.

### DIFF
--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -154,7 +154,7 @@ class Mailer implements IMailer {
 			return new $class(
 				$this->defaults,
 				$this->urlGenerator,
-				$this->l10n,
+				$this->l10nFactory,
 				$emailId,
 				$data
 			);


### PR DESCRIPTION
Email creation appears to have been refactored lately but it looks like custom template-based emails were left out. See #20648  