### PR TITLE
Don't remove last user in ldap group when limit is -1

### DIFF
--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -842,6 +842,9 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface, IGroupLD
 			return $groupUsers;
 		}
 
+		if ($limit === -1) {
+			$limit = null;
+		}
 		// check for cache of the query without limit and offset
 		$groupUsers = $this->access->connection->getFromCache('usersInGroup-' . $gid . '-' . $search);
 		if (!is_null($groupUsers)) {
@@ -850,9 +853,6 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface, IGroupLD
 			return $groupUsers;
 		}
 
-		if ($limit === -1) {
-			$limit = null;
-		}
 		$groupDN = $this->access->groupname2dn($gid);
 		if (!$groupDN) {
 			// group couldn't be found, return empty resultset


### PR DESCRIPTION
When limit is -1 the default value, the last user is not supposed to be removed from "cache of the query without limit and offset".