### PR TITLE
Fix Argon2 options checks

### DIFF
--- a/lib/private/Security/Hasher.php
+++ b/lib/private/Security/Hasher.php
@@ -67,16 +67,11 @@ class Hasher implements IHasher {
 
 		if (\defined('PASSWORD_ARGON2I')) {
 			// password_hash fails, when the minimum values are undershot.
-			// In this case, ignore and revert to default
-			if ($this->config->getSystemValueInt('hashingMemoryCost', PASSWORD_ARGON2_DEFAULT_MEMORY_COST) >= 8) {
-				$this->options['memory_cost'] = $this->config->getSystemValueInt('hashingMemoryCost', PASSWORD_ARGON2_DEFAULT_MEMORY_COST);
-			}
-			if ($this->config->getSystemValueInt('hashingTimeCost', PASSWORD_ARGON2_DEFAULT_MEMORY_COST) >= 1) {
-				$this->options['time_cost'] = $this->config->getSystemValueInt('hashingTimeCost', PASSWORD_ARGON2_DEFAULT_TIME_COST);
-			}
-			if ($this->config->getSystemValueInt('hashingThreads', PASSWORD_ARGON2_DEFAULT_MEMORY_COST) >= 1) {
-				$this->options['threads'] = $this->config->getSystemValueInt('hashingThreads', PASSWORD_ARGON2_DEFAULT_THREADS);
-			}
+			// In this case, apply minimum.
+			$this->options['threads'] = max($this->config->getSystemValueInt('hashingThreads', PASSWORD_ARGON2_DEFAULT_THREADS), 1);
+			// The minimum memory cost is 8 KiB per thread.
+			$this->options['memory_cost'] = max($this->config->getSystemValueInt('hashingMemoryCost', PASSWORD_ARGON2_DEFAULT_MEMORY_COST), $this->options['threads'] * 8);
+			$this->options['time_cost'] = max($this->config->getSystemValueInt('hashingTimeCost', PASSWORD_ARGON2_DEFAULT_TIME_COST), 1);
 		}
 
 		$hashingCost = $this->config->getSystemValue('hashingCost', null);

--- a/tests/lib/Security/HasherTest.php
+++ b/tests/lib/Security/HasherTest.php
@@ -113,6 +113,11 @@ class HasherTest extends \Test\TestCase {
 
 		$this->config = $this->createMock(IConfig::class);
 
+		$this->config->method('getSystemValueInt')
+			->willReturnCallback(function ($name, $default) {
+				return $default;
+			});
+
 		$this->hasher = new Hasher($this->config);
 	}
 


### PR DESCRIPTION
As of: https://github.com/nextcloud/server/pull/19023#issuecomment-577658271

The minimum for memory cost is 8 KiB per thread. Threads must be checked and set first to allow checking against the correct memory cost mimimum.
Options are now applied the following way:
- If config.php contains the setting with an integer higher or equal to the minimum, it is applied.
- If config.php contains the setting with an integer lower than the minimum, the minimum is applied.
- If config.php does not contain the setting or with no integer value, the PHP default is applied.