### PR TITLE
Temporary fix contacts search

### DIFF
--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -966,12 +966,14 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 				$query2->andWhere($query2->expr()->ilike('cp.value', $query->createNamedParameter('%' . $this->db->escapeLikeParameter($pattern) . '%')));
 			}
 		}
-		if (isset($options['limit'])) {
-			$query2->setMaxResults($options['limit']);
-		}
-		if (isset($options['offset'])) {
-			$query2->setFirstResult($options['offset']);
-		}
+//		// FIXME Broken on MySQL: SQLSTATE[42000]: Syntax error or access violation: 1235 This version of MySQL doesn't yet support 'LIMIT & IN/ALL/ANY/SOME subquery'
+//		// FIXME Should use 2 queries instead
+//		if (isset($options['limit'])) {
+//			$query2->setMaxResults($options['limit']);
+//		}
+//		if (isset($options['offset'])) {
+//			$query2->setFirstResult($options['offset']);
+//		}
 
 		$query->select('c.carddata', 'c.uri')->from($this->dbCardsTable, 'c')
 			->where($query->expr()->in('c.id', $query->createFunction($query2->getSQL())));


### PR DESCRIPTION
Regression from #18816 resulting in:
> SQLSTATE[42000]: Syntax error or access violation: 1235 This version of MySQL doesn't yet support 'LIMIT & IN/ALL/ANY/SOME subquery'