### PR TITLE
Make Cache::removeChildren non recursive

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -4022,6 +4022,11 @@
       <code>$entry</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/private/Files/Cache/CacheQueryBuilder.php">
+    <ImplicitToStringCast occurrences="1">
+      <code>$this-&gt;createNamedParameter($parents, IQueryBuilder::PARAM_INT_ARRAY)</code>
+    </ImplicitToStringCast>
+  </file>
   <file src="lib/private/Files/Cache/FailedCache.php">
     <InvalidReturnStatement occurrences="1">
       <code>[]</code>

--- a/lib/private/Files/Cache/CacheQueryBuilder.php
+++ b/lib/private/Files/Cache/CacheQueryBuilder.php
@@ -94,4 +94,17 @@ class CacheQueryBuilder extends QueryBuilder {
 
 		return $this;
 	}
+
+	public function whereParentIn(array $parents) {
+		$alias = $this->alias;
+		if ($alias) {
+			$alias .= '.';
+		} else {
+			$alias = '';
+		}
+
+		$this->andWhere($this->expr()->in("{$alias}parent", $this->createNamedParameter($parents, IQueryBuilder::PARAM_INT_ARRAY)));
+
+		return $this;
+	}
 }


### PR DESCRIPTION
Currently the "add new files during scanning" call stack is smaller than
the "remove deleted files during scanning" call stack. This can lead to
the scanner adding folders in the folder tree that are to deep to be
removed.

This changes the `removeChildren` logic to be non recursive so there is
no limit to the depth of the folder tree during removal

Signed-off-by: Robin Appelman <robin@icewind.nl>