### PR TITLE
Fix public layout header title & description

### DIFF
--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -186,22 +186,6 @@ thead {
 	text-align: left;
 }
 
-/* Needed to ellipsize long header text on share page */
-#body-login #header-left,
-#body-login .header-left {
-	overflow: hidden;
-}
-
-#header .header-shared-by  {
-	color: var(--color-primary-text);
-	position: relative;
-	font-weight: 300;
-	font-size: 11px;
-	line-height: 11px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-
 #note-content {
 	padding: 5px;
 	display:inline-block;

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -64,6 +64,7 @@
 	box-sizing: border-box;
 	opacity: 1;
 	align-items: center;
+	display: flex;
 	flex-wrap: wrap;
 	overflow: hidden;
 
@@ -211,9 +212,9 @@
 	}
 
 	#header-left, .header-left {
-		flex: 0 0;
-		flex-grow: 1;
+		flex: 1 0;
 		white-space: nowrap;
+		min-width: 0;
 	}
 
 	#header-right, .header-right {
@@ -269,6 +270,7 @@
 	}
 }
 
+/* TODO: move into minimal css file for public shared template */
 /* only used for public share pages now as we have the app icons when logged in */
 .header-appname {
 	color: var(--color-primary-text);
@@ -277,6 +279,18 @@
 	margin: 0;
 	padding: 0;
 	padding-right: 5px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	// Take full width to push the header-shared-by bellow (if any)
+	flex: 1 1 100%;
+}
+
+.header-shared-by  {
+	color: var(--color-primary-text);
+	position: relative;
+	font-weight: 300;
+	font-size: 11px;
+	line-height: 11px;
 	overflow: hidden;
 	text-overflow: ellipsis;
 }

--- a/core/templates/layout.public.php
+++ b/core/templates/layout.public.php
@@ -39,17 +39,17 @@
 			<span id="nextcloud">
 				<div class="logo logo-icon svg"></div>
 				<h1 class="header-appname">
-					<?php if (isset($template)) {
-			p($template->getHeaderTitle());
-		} else {
-			p($theme->getName());
-		} ?>
+					<?php if (isset($template) && $template->getHeaderTitle() !== '') {
+						p($template->getHeaderTitle());
+					} else {
+						p($theme->getName());
+					} ?>
 				</h1>
+				<?php if (isset($template) && $template->getHeaderDetails() !== '') { ?>
 				<div class="header-shared-by">
-					<?php if (isset($template)) {
-			p($template->getHeaderDetails());
-		} ?>
+					<?php p($template->getHeaderDetails()); ?>
 				</div>
+				<?php } ?>
 			</span>
 		</div>
 


### PR DESCRIPTION
Before
![Kazam_screenshot_00010](https://user-images.githubusercontent.com/14975046/80705894-9760bf80-8ae7-11ea-82fb-e2644aca75ea.png)
![Kazam_screenshot_00011](https://user-images.githubusercontent.com/14975046/80705896-97f95600-8ae7-11ea-902f-01451493a460.png)
![Kazam_screenshot_00013](https://user-images.githubusercontent.com/14975046/80705897-9891ec80-8ae7-11ea-8d55-a578a1e01c15.png)

___
After
![Kazam_screenshot_00008](https://user-images.githubusercontent.com/14975046/80705917-a3e51800-8ae7-11ea-85cb-afb100a05fc1.png)
![Kazam_screenshot_00009](https://user-images.githubusercontent.com/14975046/80705918-a47dae80-8ae7-11ea-9d00-aabd2258cd97.png)
![Kazam_screenshot_00007](https://user-images.githubusercontent.com/14975046/80705915-a3e51800-8ae7-11ea-9670-fca52ff8bac5.png)

Broke by other stuff and #19913
Closes #19541
Fix #19479 

___

We should have some minimal css for this, to not rely on the header.scss file.
This is supposed to be  a minimal public template and we load 140kb of css ^^'