### PR TITLE
PHP 7.4 excludes the arguments from stack traces by default.

### DIFF
--- a/lib/private/Files/ObjectStore/SwiftFactory.php
+++ b/lib/private/Files/ObjectStore/SwiftFactory.php
@@ -78,12 +78,12 @@ class SwiftFactory {
 	 * @throws StorageAuthException
 	 */
 	public function getCachedTokenId() {
-		if ( !isset($this->params['cachedToken']) ) {
+		if (!isset($this->params['cachedToken'])) {
 			throw new StorageAuthException('Unauthenticated ObjectStore connection');
 		}
 
 		// Is it V2 token?
-		if ( isset($this->params['cachedToken']['token']) ) {
+		if (isset($this->params['cachedToken']['token'])) {
 			return $this->params['cachedToken']['token']['id'];
 		}
 

--- a/lib/public/AppFramework/App.php
+++ b/lib/public/AppFramework/App.php
@@ -77,7 +77,10 @@ class App {
 	 * @since 6.0.0
 	 */
 	public function __construct(string $appName, array $urlParams = []) {
-		if (\OC::$server->getConfig()->getSystemValueBool('debug')) {
+		$runIsSetupDirectly = \OC::$server->getConfig()->getSystemValueBool('debug')
+			&& (PHP_VERSION_ID < 70400 || (PHP_VERSION_ID >= 70400 && !ini_get('zend.exception_ignore_args')));
+
+		if ($runIsSetupDirectly) {
 			$applicationClassName = get_class($this);
 			$e = new \RuntimeException('App class ' . $applicationClassName . ' is not setup via query() but directly');
 			$setUpViaQuery = false;


### PR DESCRIPTION
That leads to a false positive is not setup via query() but directly warning for every app because
the check does not work anymore.

Runs only if debug => true.
ini_set seems to ignore non existing $vars: https://3v4l.org/DP4Lg
