### PR TITLE
19 beta 7

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [19, 0, 0, 7];
+$OC_Version = [19, 0, 0, 8];
 
 // The human readable string
-$OC_VersionString = '19.0.0 beta 6';
+$OC_VersionString = '19.0.0 beta 7';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #19124 Exclude groups from sharing: Skip delete groups
* #20291 Fix focus for user actionmenu
* #20380 Fix design and layout of notification mails
* #20538 Fix share expiration date not shown
* #20716 Add index to properties table
* #20722 Set etag for capabilities endpoint
* #20725 Fix getDirectoryContent implementation for Jail wrapper
* #20726 Fix federated link sharing permissions
* #20744 Fix public layout header title & description
* #20749 PHP 7.4 excludes the arguments from stack traces by default.
* #20759 Update education bundle
* #20761 Fix owner on publicownerwrapper
* #20762 Fix expiry datepicker allowing all dates
* #20767 Apply Argon2 options for Argon2id hashing as well
* #20771 Do not process the same shares twice
* #20779 Comply with php-cs for CI
* #20787 Fix OC_Image new resize functions
* #20794 Apply patch for scssphp
* #20807 Clarified trash bin retention by storage shortage override in config.sample.php
* [3rdparty#441](https://github.com/nextcloud/3rdparty/pull/441) Fix Trying to access array offset on value of type null notice
* [notifications#631](https://github.com/nextcloud/notifications/pull/631) Bump @babel/core from 7.9.0 to 7.9.6
* [notifications#632](https://github.com/nextcloud/notifications/pull/632) Bump vue-loader from 15.9.1 to 15.9.2
* [notifications#633](https://github.com/nextcloud/notifications/pull/633) Bump @babel/preset-env from 7.9.5 to 7.9.6
* [privacy#400](https://github.com/nextcloud/privacy/pull/400) Bump vue-loader from 15.9.1 to 15.9.2
* [viewer#489](https://github.com/nextcloud/viewer/pull/489) Bump @babel/preset-env from 7.9.5 to 7.9.6
* [viewer#490](https://github.com/nextcloud/viewer/pull/490) Bump vue-loader from 15.9.1 to 15.9.2
* [viewer#491](https://github.com/nextcloud/viewer/pull/491) Bump @babel/core from 7.9.0 to 7.9.6


Pending PRs:

* [ ] #20719 Fix languages empty array @GretaD
* [ ] #20772 Properly search for users when limittogroups is enabled @rullzer
