### PR TITLE
Skip session validation during app load (Fixes #20756)

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -351,6 +351,21 @@ class AppManager implements IAppManager {
 	}
 
 	/**
+	 * Whether a list of types contains only protected app types
+	 *
+	 * @param string[] $types
+	 * @return bool
+	 */
+	public function hasOnlyProtectedAppTypes($types) {
+		if (empty($types)) {
+			return false;
+		}
+
+		$unprotectedTypes = array_diff($types, $this->protectedAppTypes);
+		return empty($unprotectedTypes);
+	}
+
+	/**
 	 * Enable an app only for specific groups
 	 *
 	 * @param string $appId

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -223,9 +223,10 @@ class Session implements IUserSession, Emitter {
 	/**
 	 * get the current active user
 	 *
+	 * @param bool $validate whether to validate session
 	 * @return IUser|null Current user, otherwise null
 	 */
-	public function getUser() {
+	public function getUser($validate = true) {
 		// FIXME: This is a quick'n dirty work-around for the incognito mode as
 		// described at https://github.com/owncloud/core/pull/12912#issuecomment-67391155
 		if (OC_User::isIncognitoMode()) {
@@ -236,11 +237,16 @@ class Session implements IUserSession, Emitter {
 			if (is_null($uid)) {
 				return null;
 			}
-			$this->activeUser = $this->manager->get($uid);
-			if (is_null($this->activeUser)) {
+			// UserManager will cache user for later validation...
+			$user = $this->manager->get($uid);
+			if (is_null($user)) {
 				return null;
 			}
-			$this->validateSession();
+			if ($validate === true) {
+				// only set activeUser when validating...
+				$this->activeUser = $user;
+				$this->validateSession();
+			}
 		}
 		return $this->activeUser;
 	}

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -223,10 +223,9 @@ class Session implements IUserSession, Emitter {
 	/**
 	 * get the current active user
 	 *
-	 * @param bool $validate whether to validate session
 	 * @return IUser|null Current user, otherwise null
 	 */
-	public function getUser($validate = true) {
+	public function getUser() {
 		// FIXME: This is a quick'n dirty work-around for the incognito mode as
 		// described at https://github.com/owncloud/core/pull/12912#issuecomment-67391155
 		if (OC_User::isIncognitoMode()) {
@@ -237,16 +236,11 @@ class Session implements IUserSession, Emitter {
 			if (is_null($uid)) {
 				return null;
 			}
-			// UserManager will cache user for later validation...
-			$user = $this->manager->get($uid);
-			if (is_null($user)) {
+			$this->activeUser = $this->manager->get($uid);
+			if (is_null($this->activeUser)) {
 				return null;
 			}
-			if ($validate === true) {
-				// only set activeUser when validating...
-				$this->activeUser = $user;
-				$this->validateSession();
-			}
+			$this->validateSession();
 		}
 		return $this->activeUser;
 	}

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -110,8 +110,12 @@ class OC_App {
 		if ((bool) \OC::$server->getSystemConfig()->getValue('maintenance', false)) {
 			return false;
 		}
+		// If only protected types, don't filter by user (prevents
+		// session invalidation when loading prelogin/authentication
+		// types).
+		$all = \OC::$server->getAppManager()->hasOnlyProtectedAppTypes($types);
 		// Load the enabled apps here
-		$apps = self::getEnabledApps();
+		$apps = self::getEnabledApps(false, $all);
 
 		// Add each apps' folder as allowed class path
 		foreach ($apps as $app) {

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -348,8 +348,7 @@ class OC_App {
 		if ($all) {
 			$user = null;
 		} else {
-			// getUser but don't validate session yet
-			$user = \OC::$server->getUserSession()->getUser(false);
+			$user = \OC::$server->getUserSession()->getUser();
 		}
 
 		if (is_null($user)) {

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -348,7 +348,8 @@ class OC_App {
 		if ($all) {
 			$user = null;
 		} else {
-			$user = \OC::$server->getUserSession()->getUser();
+			// getUser but don't validate session yet
+			$user = \OC::$server->getUserSession()->getUser(false);
 		}
 
 		if (is_null($user)) {


### PR DESCRIPTION
Adds parameter to User\Session:getUser() to skip validation, and
modifies OC_App::getEnabledApps() to use this parameter to skip
session validation when loading apps.

see #20756 for a detailed explanation

Signed-off-by: Scott Shambarger <devel@shambarger.net>

fixes #20756 
fixes nextcloud/user_external#101
fixes nextcloud/user_external#70
fixes nextcloud/user_external#3