### PR TITLE
Consider only reminders with calendar data

### DIFF
--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -39,6 +39,7 @@ use OCA\DAV\CalDAV\BirthdayService;
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CalDAV\CalendarManager;
 use OCA\DAV\CalDAV\CalendarProvider;
+use OCA\DAV\CalDAV\Reminder\Backend as ReminderBackend;
 use OCA\DAV\CalDAV\Reminder\NotificationProvider\AudioProvider;
 use OCA\DAV\CalDAV\Reminder\NotificationProvider\EmailProvider;
 use OCA\DAV\CalDAV\Reminder\NotificationProvider\PushProvider;
@@ -306,6 +307,9 @@ class Application extends App implements IBootstrap {
 				/** @var CalDavBackend $calDavBackend */
 				$calDavBackend = $container->query(CalDavBackend::class);
 				$calDavBackend->purgeAllCachedEventsForSubscription($subscriptionData['id']);
+				/** @var ReminderBackend $calDavBackend */
+				$reminderBackend = $container->query(ReminderBackend::class);
+				$reminderBackend->cleanRemindersForCalendar($subscriptionData['id']);
 			}
 		);
 

--- a/apps/dav/lib/CalDAV/Reminder/Backend.php
+++ b/apps/dav/lib/CalDAV/Reminder/Backend.php
@@ -67,8 +67,8 @@ class Backend {
 		$query->select(['cr.*', 'co.calendardata', 'c.displayname', 'c.principaluri'])
 			->from('calendar_reminders', 'cr')
 			->where($query->expr()->lte('cr.notification_date', $query->createNamedParameter($this->timeFactory->getTime())))
-			->leftJoin('cr', 'calendarobjects', 'co', $query->expr()->eq('cr.object_id', 'co.id'))
-			->leftJoin('cr', 'calendars', 'c', $query->expr()->eq('cr.calendar_id', 'c.id'));
+			->join('cr', 'calendarobjects', 'co', $query->expr()->eq('cr.object_id', 'co.id'))
+			->join('cr', 'calendars', 'c', $query->expr()->eq('cr.calendar_id', 'c.id'));
 		$stmt = $query->execute();
 
 		return array_map(

--- a/apps/dav/lib/CalDAV/Reminder/ReminderService.php
+++ b/apps/dav/lib/CalDAV/Reminder/ReminderService.php
@@ -119,6 +119,10 @@ class ReminderService {
 				? stream_get_contents($reminder['calendardata'])
 				: $reminder['calendardata'];
 
+			if (!$calendarData) {
+				continue;
+			}
+
 			$vcalendar = $this->parseCalendarData($calendarData);
 			if (!$vcalendar) {
 				$this->backend->removeReminder($reminder['id']);
@@ -167,6 +171,10 @@ class ReminderService {
 		$calendarData = is_resource($objectData['calendardata'])
 			? stream_get_contents($objectData['calendardata'])
 			: $objectData['calendardata'];
+
+		if (!$calendarData) {
+			return;
+		}
 
 		/** @var VObject\Component\VCalendar $vcalendar */
 		$vcalendar = $this->parseCalendarData($calendarData);


### PR DESCRIPTION
Encountered an issue once like this one https://help.nextcloud.com/t/subscribed-calendar-not-updating-in-webui-again-subscribed-calendars-are-a-total-mess-in-nc/79774/2

Not sure why we can have calendar objects with empty data referenced into reminders.

Fix https://github.com/nextcloud/server/issues/30112
Fix https://github.com/nextcloud/server/issues/30265