### PR TITLE
Apply Argon2 options for Argon2id hashing as well

### DIFF
--- a/lib/private/Security/Hasher.php
+++ b/lib/private/Security/Hasher.php
@@ -65,7 +65,7 @@ class Hasher implements IHasher {
 	public function __construct(IConfig $config) {
 		$this->config = $config;
 
-		if (\defined('PASSWORD_ARGON2I')) {
+		if (\defined('PASSWORD_ARGON2ID') || \defined('PASSWORD_ARGON2I')) {
 			// password_hash fails, when the minimum values are undershot.
 			// In this case, apply minimum.
 			$this->options['threads'] = max($this->config->getSystemValueInt('hashingThreads', PASSWORD_ARGON2_DEFAULT_THREADS), 1);


### PR DESCRIPTION
We check and apply Argon2 settings from config.php in case of Argon2i hashing. Since NC19 Argon2id hashing is used, when available, which uses the same settings, hence we should apply them for Argon2id as well: https://github.com/nextcloud/server/pull/20710#discussion_r417608921

To be sure, the minimum values could be retested for Argon2id explicitly: https://github.com/nextcloud/server/pull/19023#issuecomment-577658271