### PR TITLE
Properly search for users when limittogroups is enabled

### DIFF
--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -95,7 +95,15 @@ class UserPlugin implements ISearchPlugin {
 				$usersInGroup = $this->groupManager->displayNamesInGroup($userGroupId, $search, $limit, $offset);
 				foreach ($usersInGroup as $userId => $displayName) {
 					$userId = (string) $userId;
-					$users[$userId] = $this->userManager->get($userId);
+					$user = $this->userManager->get($userId);
+					if (!$user->isEnabled()) {
+						// Ignore disabled users
+						continue;
+					}
+					$users[$userId] = $user;
+				}
+				if (count($usersInGroup) >= $limit) {
+					$hasMoreResults = true;
 				}
 			}
 		} else {

--- a/tests/lib/Collaboration/Collaborators/UserPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/UserPluginTest.php
@@ -328,7 +328,7 @@ class UserPluginTest extends TestCase {
 					['label' => 'Test One', 'value' => ['shareType' => IShare::TYPE_USER, 'shareWith' => 'test1'], 'status' => []],
 					['label' => 'Test Two', 'value' => ['shareType' => IShare::TYPE_USER, 'shareWith' => 'test2'], 'status' => []],
 				],
-				false,
+				true,
 				false,
 				[
 					['test1', $this->getUserMock('test1', 'Test One')],


### PR DESCRIPTION
Searching just for the uid is not enough.
This makes sure this done properly again now.

Actually fixes a valid failure in the integrationtests...