### PR TITLE
Comply with php-cs for CI

### DIFF
--- a/core/templates/layout.public.php
+++ b/core/templates/layout.public.php
@@ -39,11 +39,11 @@
 			<span id="nextcloud">
 				<div class="logo logo-icon svg"></div>
 				<h1 class="header-appname">
-					<?php if (isset($template) && $template->getHeaderTitle() !== '') {
-						p($template->getHeaderTitle());
-					} else {
-						p($theme->getName());
-					} ?>
+					<?php if (isset($template) && $template->getHeaderTitle() !== '') { ?>
+						<?php p($template->getHeaderTitle()); ?>
+					<?php } else { ?>
+						<?php	p($theme->getName()); ?>
+					<?php } ?>
 				</h1>
 				<?php if (isset($template) && $template->getHeaderDetails() !== '') { ?>
 				<div class="header-shared-by">


### PR DESCRIPTION
This is a fix to match php-cs for the CI but I'm thinking it may be better to exclude the templates from php-cs-fixer. This fix doesn't really make much sense. Any thoughts?
EDIT: I changed the fix so the indentation still makes sense but this was the fix made by `cs:fix`:

```diff
diff --git a/core/templates/layout.public.php b/core/templates/layout.public.php
index e0445f419c4..ccc947e68ed 100644
--- a/core/templates/layout.public.php
+++ b/core/templates/layout.public.php
@@ -40,10 +40,10 @@
 				<div class="logo logo-icon svg"></div>
 				<h1 class="header-appname">
 					<?php if (isset($template) && $template->getHeaderTitle() !== '') {
-						p($template->getHeaderTitle());
-					} else {
-						p($theme->getName());
-					} ?>
+			p($template->getHeaderTitle());
+		} else {
+			p($theme->getName());
+		} ?>
 				</h1>
 				<?php if (isset($template) && $template->getHeaderDetails() !== '') { ?>
 				<div class="header-shared-by">

```
