### PR TITLE
Translate the maintenance mode message in webdav

### DIFF
--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -82,7 +82,7 @@ $server->httpRequest->setUrl(\OC::$server->getRequest()->getRequestUri());
 $server->setBaseUri($baseuri);
 
 // Add plugins
-$server->addPlugin(new MaintenancePlugin());
+$server->addPlugin(new MaintenancePlugin(\OC::$server->getConfig(), \OC::$server->getL10N('dav')));
 $server->addPlugin(new \Sabre\DAV\Auth\Plugin($authBackend, 'ownCloud'));
 $server->addPlugin(new \Sabre\CalDAV\Plugin());
 

--- a/apps/dav/appinfo/v1/carddav.php
+++ b/apps/dav/appinfo/v1/carddav.php
@@ -80,7 +80,7 @@ $server::$exposeVersion = false;
 $server->httpRequest->setUrl(\OC::$server->getRequest()->getRequestUri());
 $server->setBaseUri($baseuri);
 // Add plugins
-$server->addPlugin(new MaintenancePlugin());
+$server->addPlugin(new MaintenancePlugin(\OC::$server->getConfig(), \OC::$server->getL10N('dav')));
 $server->addPlugin(new \Sabre\DAV\Auth\Plugin($authBackend, 'ownCloud'));
 $server->addPlugin(new Plugin());
 

--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -55,7 +55,8 @@ $serverFactory = new OCA\DAV\Connector\Sabre\ServerFactory(
 	\OC::$server->getTagManager(),
 	\OC::$server->getRequest(),
 	\OC::$server->getPreviewManager(),
-	\OC::$server->getEventDispatcher()
+	\OC::$server->getEventDispatcher(),
+	\OC::$server->getL10N('dav')
 );
 
 $requestUri = \OC::$server->getRequest()->getRequestUri();

--- a/apps/dav/appinfo/v1/webdav.php
+++ b/apps/dav/appinfo/v1/webdav.php
@@ -46,7 +46,8 @@ $serverFactory = new \OCA\DAV\Connector\Sabre\ServerFactory(
 	\OC::$server->getTagManager(),
 	\OC::$server->getRequest(),
 	\OC::$server->getPreviewManager(),
-	\OC::$server->getEventDispatcher()
+	\OC::$server->getEventDispatcher(),
+	\OC::$server->getL10N('dav')
 );
 
 // Backends

--- a/apps/dav/appinfo/v2/direct.php
+++ b/apps/dav/appinfo/v2/direct.php
@@ -35,7 +35,7 @@ ignore_user_abort(true);
 
 $requestUri = \OC::$server->getRequest()->getRequestUri();
 
-$serverFactory = new \OCA\DAV\Direct\ServerFactory(\OC::$server->getConfig());
+$serverFactory = new \OCA\DAV\Direct\ServerFactory(\OC::$server->getConfig(), \OC::$server->getL10N('dav'));
 $server = $serverFactory->createServer(
 	$baseuri,
 	$requestUri,

--- a/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
+++ b/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
@@ -52,7 +52,7 @@ class InvitationResponseServer {
 		$this->server = new \OCA\DAV\Connector\Sabre\Server(new CachingTree($root));
 
 		// Add maintenance plugin
-		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\MaintenancePlugin(\OC::$server->getConfig()));
+		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\MaintenancePlugin(\OC::$server->getConfig(), \OC::$server->getL10N('dav')));
 
 		// Set URL explicitly due to reverse-proxy situations
 		$this->server->httpRequest->setUrl($baseUri);

--- a/apps/dav/lib/Connector/Sabre/MaintenancePlugin.php
+++ b/apps/dav/lib/Connector/Sabre/MaintenancePlugin.php
@@ -28,6 +28,7 @@
 namespace OCA\DAV\Connector\Sabre;
 
 use OCP\IConfig;
+use OCP\IL10N;
 use OCP\Util;
 use Sabre\DAV\Exception\ServiceUnavailable;
 use Sabre\DAV\ServerPlugin;
@@ -36,6 +37,9 @@ class MaintenancePlugin extends ServerPlugin {
 
 	/** @var IConfig */
 	private $config;
+
+	/** @var \OCP\IL10N */
+	private $l10n;
 
 	/**
 	 * Reference to main server object
@@ -47,11 +51,9 @@ class MaintenancePlugin extends ServerPlugin {
 	/**
 	 * @param IConfig $config
 	 */
-	public function __construct(IConfig $config = null) {
+	public function __construct(IConfig $config, IL10N $l10n) {
 		$this->config = $config;
-		if (is_null($config)) {
-			$this->config = \OC::$server->getConfig();
-		}
+		$this->l10n = \OC::$server->getL10N('dav');
 	}
 
 
@@ -80,10 +82,10 @@ class MaintenancePlugin extends ServerPlugin {
 	 */
 	public function checkMaintenanceMode() {
 		if ($this->config->getSystemValueBool('maintenance')) {
-			throw new ServiceUnavailable('System in maintenance mode.');
+			throw new ServiceUnavailable($this->l10n->t('System in maintenance mode.'));
 		}
 		if (Util::needUpgrade()) {
-			throw new ServiceUnavailable('Upgrade needed');
+			throw new ServiceUnavailable($this->l10n->t('Upgrade needed'));
 		}
 
 		return true;

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -38,6 +38,7 @@ use OCA\DAV\Files\BrowserErrorPagePlugin;
 use OCP\Files\Mount\IMountManager;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IPreview;
 use OCP\IRequest;
@@ -66,6 +67,8 @@ class ServerFactory {
 	private $previewManager;
 	/** @var EventDispatcherInterface */
 	private $eventDispatcher;
+	/** @var IL10N */
+	private $l10n;
 
 	/**
 	 * @param IConfig $config
@@ -86,7 +89,8 @@ class ServerFactory {
 		ITagManager $tagManager,
 		IRequest $request,
 		IPreview $previewManager,
-		EventDispatcherInterface $eventDispatcher
+		EventDispatcherInterface $eventDispatcher,
+		IL10N $l10n
 	) {
 		$this->config = $config;
 		$this->logger = $logger;
@@ -97,6 +101,7 @@ class ServerFactory {
 		$this->request = $request;
 		$this->previewManager = $previewManager;
 		$this->eventDispatcher = $eventDispatcher;
+		$this->l10n = $l10n;
 	}
 
 	/**
@@ -118,7 +123,7 @@ class ServerFactory {
 		$server->setBaseUri($baseUri);
 
 		// Load plugins
-		$server->addPlugin(new \OCA\DAV\Connector\Sabre\MaintenancePlugin($this->config));
+		$server->addPlugin(new \OCA\DAV\Connector\Sabre\MaintenancePlugin($this->config, $this->l10n));
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\BlockLegacyClientPlugin($this->config));
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\AnonymousOptionsPlugin());
 		$server->addPlugin($authPlugin);

--- a/apps/dav/lib/Direct/ServerFactory.php
+++ b/apps/dav/lib/Direct/ServerFactory.php
@@ -31,14 +31,18 @@ use OCA\DAV\Db\DirectMapper;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\IRootFolder;
 use OCP\IConfig;
+use OCP\IL10N;
 use OCP\IRequest;
 
 class ServerFactory {
 	/** @var IConfig */
 	private $config;
+	/** @var IL10N */
+	private $l10n;
 
-	public function __construct(IConfig $config) {
+	public function __construct(IConfig $config, IL10N $l10n) {
 		$this->config = $config;
+		$this->l10n = $l10n;
 	}
 
 	public function createServer(string $baseURI,
@@ -54,7 +58,7 @@ class ServerFactory {
 		$server->httpRequest->setUrl($requestURI);
 		$server->setBaseUri($baseURI);
 
-		$server->addPlugin(new \OCA\DAV\Connector\Sabre\MaintenancePlugin($this->config));
+		$server->addPlugin(new \OCA\DAV\Connector\Sabre\MaintenancePlugin($this->config, $this->l10n));
 
 		return $server;
 	}

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -92,7 +92,7 @@ class Server {
 		$this->server = new \OCA\DAV\Connector\Sabre\Server(new CachingTree($root));
 
 		// Add maintenance plugin
-		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\MaintenancePlugin(\OC::$server->getConfig()));
+		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\MaintenancePlugin(\OC::$server->getConfig(), \OC::$server->getL10N('dav')));
 
 		// Backends
 		$authBackend = new Auth(

--- a/apps/dav/tests/unit/Connector/Sabre/MaintenancePluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/MaintenancePluginTest.php
@@ -28,6 +28,7 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
 use OCA\DAV\Connector\Sabre\MaintenancePlugin;
 use OCP\IConfig;
+use OCP\IL10N;
 use Test\TestCase;
 
 /**
@@ -38,6 +39,8 @@ use Test\TestCase;
 class MaintenancePluginTest extends TestCase {
 	/** @var IConfig */
 	private $config;
+	/** @var \PHPUnit\Framework\MockObject\Builder\InvocationMocker|\PHPUnit_Framework_MockObject_Builder_InvocationMocker|IL10N  */
+	private $l10n;
 	/** @var MaintenancePlugin */
 	private $maintenancePlugin;
 
@@ -45,10 +48,11 @@ class MaintenancePluginTest extends TestCase {
 		parent::setUp();
 
 		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
-		$this->maintenancePlugin = new MaintenancePlugin($this->config);
+		$this->l10n = $this->getMockBuilder(IL10N::class)->getMock();
+		$this->maintenancePlugin = new MaintenancePlugin($this->config, $this->l10n);
 	}
 
-	
+
 	public function testMaintenanceMode() {
 		$this->expectException(\Sabre\DAV\Exception\ServiceUnavailable::class);
 		$this->expectExceptionMessage('System in maintenance mode.');
@@ -58,6 +62,10 @@ class MaintenancePluginTest extends TestCase {
 			->method('getSystemValueBool')
 			->with('maintenance')
 			->willReturn(true);
+		$this->l10n
+			->expects($this->any())
+			->method('t')
+			->willReturnArgument(0);
 
 		$this->maintenancePlugin->checkMaintenanceMode();
 	}

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTestCase.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTestCase.php
@@ -70,7 +70,8 @@ abstract class RequestTestCase extends TestCase {
 				->disableOriginalConstructor()
 				->getMock(),
 			\OC::$server->getPreviewManager(),
-			\OC::$server->getEventDispatcher()
+			\OC::$server->getEventDispatcher(),
+			\OC::$server->getL10N('dav')
 		);
 	}
 


### PR DESCRIPTION
Fixes #20812 

@rullzer Is it fine to translate those messages? Then they can be presented to the end user and don't need to be detected on those devices.