### PR TITLE
19 RC2

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [19, 0, 0, 9];
+$OC_Version = [19, 0, 0, 10];
 
 // The human readable string
-$OC_VersionString = '19.0.0 RC1';
+$OC_VersionString = '19.0.0 RC2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #20871 [stable19] Fix replacement dialog
* #20872 [stable19] Do not process the same FileInfo twice
* #20873 [stable19] Install page app naming
* #20878 [stable19] Fix languages empty array
* #20880 [stable19] macOS contacts: prefer personal over app generated
* #20885 [stable19] Fix color-text-maxcontrast not passing WCAG AA
* #20923 [stable19] Use random_bytes
* #20940 [stable19] Remember the webauthn name of devices
* #20944 [stable19] Proxy server could cache http response when it is not private
* #20954 [stable19] Trailing comma's in functin arguments break on 7.2
* [activity#461](https://github.com/nextcloud/activity/pull/461) Update stable19 target versions
* [files_pdfviewer#177](https://github.com/nextcloud/files_pdfviewer/pull/177) Update stable19 target versions
* [firstrunwizard#331](https://github.com/nextcloud/firstrunwizard/pull/331) Update stable19 target versions
* [logreader#344](https://github.com/nextcloud/logreader/pull/344) Update stable19 target versions
* [nextcloud_announcements#67](https://github.com/nextcloud/nextcloud_announcements/pull/67) Update stable19 target versions
* [notifications#635](https://github.com/nextcloud/notifications/pull/635) Update stable19 target versions
* [password_policy#105](https://github.com/nextcloud/password_policy/pull/105) Update stable19 target versions
* [recommendations#215](https://github.com/nextcloud/recommendations/pull/215) Update stable19 target versions
* [serverinfo#204](https://github.com/nextcloud/serverinfo/pull/204) Update stable19 target versions
* [survey_client#107](https://github.com/nextcloud/survey_client/pull/107) Update stable19 target versions


Pending PRs:

* [x] #20960 [stable19] Respect exit code of lint run - changed from -exec to xargs as this e… @MorrisJobke
* [x] #20961 [stable19] Allow links to conversations @backportbot-nextcloud
