### PR TITLE
Fix color-text-maxcontrast not passing WCAG AA

### DIFF
--- a/core/css/variables.scss
+++ b/core/css/variables.scss
@@ -60,7 +60,7 @@ $color-yellow: #FC0;
 // rgb(118, 118, 118) / #767676
 // min. color contrast for normal text on white background according to WCAG AA
 // (Works as well: color: #000; opacity: 0.57;)
-$color-text-maxcontrast: nc-lighten($color-main-text, 46.2%) !default;
+$color-text-maxcontrast: nc-lighten($color-main-text, 33%) !default;
 $color-text-light: nc-lighten($color-main-text, 15%) !default;
 $color-text-lighter: nc-lighten($color-main-text, 30%) !default;
 


### PR DESCRIPTION
The intended value is #767676 on white, as per the comment at https://github.com/nextcloud/server/blob/master/core/css/variables.scss#L60
- #767676 passes AA: https://contrast-ratio.com/#%23767676-on-white
- #989898 does not https://contrast-ratio.com/#%23989898-on-white

This stems from when I changed the color-main-text from #000 to #222 but didn’t adjust the lighten percentage. We should also backport this to 19, right?

@skjnldsv I would additionally say since the values are so similar, we limit the text variables to just color-main-text and color-text-maxcontrast. I would make both "light" and "lighter" map to "color-text-maxcontrast" for compatibility.