### PR TITLE
macOS contacts: prefer personal over app generated

### DIFF
--- a/apps/contactsinteraction/lib/AddressBook.php
+++ b/apps/contactsinteraction/lib/AddressBook.php
@@ -34,7 +34,6 @@ use OCA\DAV\DAV\Sharing\Plugin;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IL10N;
 use Sabre\DAV\Exception\NotFound;
-use Sabre\DAV\Exception\NotImplemented;
 use Sabre\DAV\PropPatch;
 use Sabre\DAVACL\ACLTrait;
 use Sabre\DAVACL\IACL;

--- a/apps/contactsinteraction/lib/AddressBook.php
+++ b/apps/contactsinteraction/lib/AddressBook.php
@@ -130,8 +130,8 @@ class AddressBook extends ExternalAddressBook implements IACL {
 	/**
 	 * @inheritDoc
 	 */
-	public function getLastModified() {
-		throw new NotImplemented();
+	public function getLastModified(): ?int {
+		return $this->mapper->findLastUpdatedForUserId($this->getUid());
 	}
 
 	/**
@@ -149,6 +149,7 @@ class AddressBook extends ExternalAddressBook implements IACL {
 			'principaluri' => $this->principalUri,
 			'{DAV:}displayname' => $this->l10n->t('Recently contacted'),
 			'{' . Plugin::NS_OWNCLOUD . '}read-only' => true,
+			'{' . \OCA\DAV\CalDAV\Plugin::NS_CALENDARSERVER . '}getctag' => 'http://sabre.io/ns/sync/' . ($this->getLastModified() ?? 0),
 		];
 	}
 

--- a/apps/contactsinteraction/lib/Card.php
+++ b/apps/contactsinteraction/lib/Card.php
@@ -95,7 +95,7 @@ class Card implements ICard, IACL {
 	 * @inheritDoc
 	 */
 	public function getETag(): ?string {
-		return null;
+		return '"' . md5((string) $this->getLastModified()) . '"';
 	}
 
 	/**

--- a/apps/contactsinteraction/lib/Db/RecentContactMapper.php
+++ b/apps/contactsinteraction/lib/Db/RecentContactMapper.php
@@ -104,6 +104,30 @@ class RecentContactMapper extends QBMapper {
 		return $this->findEntities($select);
 	}
 
+	/**
+	 * @param string $uid
+	 * @return int|null
+	 */
+	public function findLastUpdatedForUserId(string $uid):?int {
+		$qb = $this->db->getQueryBuilder();
+
+		$select = $qb
+			->select('last_contact')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('actor_uid', $qb->createNamedParameter($uid)))
+			->orderBy('last_contact', 'DESC')
+			->setMaxResults(1);
+
+		$cursor = $select->execute();
+		$row = $cursor->fetch();
+
+		if ($row === false) {
+			return null;
+		}
+
+		return (int)$row['last_contact'];
+	}
+
 	public function cleanUp(int $olderThan): void {
 		$qb = $this->db->getQueryBuilder();
 

--- a/apps/dav/lib/CardDAV/Integration/ExternalAddressBook.php
+++ b/apps/dav/lib/CardDAV/Integration/ExternalAddressBook.php
@@ -34,7 +34,7 @@ use Sabre\DAV;
 abstract class ExternalAddressBook implements IAddressBook, DAV\IProperties {
 
 	/** @var string */
-	private const PREFIX = 'app-generated';
+	private const PREFIX = 'z-app-generated';
 
 	/**
 	 * @var string


### PR DESCRIPTION
https://sabre.io/dav/clients/osx-addressbook/

This PR is adding support for ctag:
> This client requires impementation of the proprietary '{http://calendarserver.org/ns/}getctag' property. Without it, it will simply not request any vcards.

This PR renames `app-generated` to `z-app-generated`:
> OS X addressbook can only ever work with 1 address book. Even though the CardDAV standard makes it easy for users to own more than one addressbook, this is not supported.
> 
> Unfortunately this means that if a user has more than one addressbook in their account, only the 'first' will show up, and contacts from other addressbooks are completely hidden to the user.
> 
> This can cause for a lot of confusion, and there is no obvious solution other than simply enforce a 1 address book limit for users.

tl;dr:
Without this PR, macOS Contacts will only show the 5 contacts from the contacts interaction addressbook, but all the contacts from the personal addressbook will be gone.