### PR TITLE
Log usage of a deprecated event instead of emitting

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -938,6 +938,7 @@ return array(
     'OC\\Encryption\\Update' => $baseDir . '/lib/private/Encryption/Update.php',
     'OC\\Encryption\\Util' => $baseDir . '/lib/private/Encryption/Util.php',
     'OC\\EventDispatcher\\EventDispatcher' => $baseDir . '/lib/private/EventDispatcher/EventDispatcher.php',
+    'OC\\EventDispatcher\\GenericEventWrapper' => $baseDir . '/lib/private/EventDispatcher/GenericEventWrapper.php',
     'OC\\EventDispatcher\\ServiceEventListener' => $baseDir . '/lib/private/EventDispatcher/ServiceEventListener.php',
     'OC\\EventDispatcher\\SymfonyAdapter' => $baseDir . '/lib/private/EventDispatcher/SymfonyAdapter.php',
     'OC\\Federation\\CloudFederationFactory' => $baseDir . '/lib/private/Federation/CloudFederationFactory.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -967,6 +967,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Encryption\\Update' => __DIR__ . '/../../..' . '/lib/private/Encryption/Update.php',
         'OC\\Encryption\\Util' => __DIR__ . '/../../..' . '/lib/private/Encryption/Util.php',
         'OC\\EventDispatcher\\EventDispatcher' => __DIR__ . '/../../..' . '/lib/private/EventDispatcher/EventDispatcher.php',
+        'OC\\EventDispatcher\\GenericEventWrapper' => __DIR__ . '/../../..' . '/lib/private/EventDispatcher/GenericEventWrapper.php',
         'OC\\EventDispatcher\\ServiceEventListener' => __DIR__ . '/../../..' . '/lib/private/EventDispatcher/ServiceEventListener.php',
         'OC\\EventDispatcher\\SymfonyAdapter' => __DIR__ . '/../../..' . '/lib/private/EventDispatcher/SymfonyAdapter.php',
         'OC\\Federation\\CloudFederationFactory' => __DIR__ . '/../../..' . '/lib/private/Federation/CloudFederationFactory.php',

--- a/lib/private/EventDispatcher/GenericEventWrapper.php
+++ b/lib/private/EventDispatcher/GenericEventWrapper.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\EventDispatcher;
+
+use OCP\ILogger;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class GenericEventWrapper extends GenericEvent {
+
+	/** @var ILogger */
+	private $logger;
+
+	/** @var GenericEvent */
+	private $event;
+
+	/** @var string */
+	private $eventName;
+
+	public function __construct(ILogger $logger, string $eventName, ?GenericEvent $event) {
+		$this->logger = $logger;
+		$this->event = $event;
+		$this->eventName = $eventName;
+	}
+
+	private function log() {
+		$this->logger->info(
+			'Deprecated event type for {name}: {class} is used',
+			[ 'name' => $this->eventName, 'class' => is_object($this->event) ? get_class($this->event) : 'null' ]
+		);
+	}
+
+	public function isPropagationStopped() {
+		$this->log();
+		return $this->event->isPropagationStopped();
+	}
+
+	public function stopPropagation() {
+		$this->log();
+		$this->event->stopPropagation();
+	}
+
+	public function getSubject() {
+		$this->log();
+		return $this->event->getSubject();
+	}
+
+	public function getArgument($key) {
+		$this->log();
+		return $this->event->getArgument($key);
+	}
+
+	public function setArgument($key, $value) {
+		$this->log();
+		return $this->event->setArgument($key, $value);
+	}
+
+	public function getArguments() {
+		return $this->event->getArguments();
+	}
+
+	public function setArguments(array $args = []) {
+		return $this->event->setArguments($args);
+	}
+
+	public function hasArgument($key) {
+		return $this->event->hasArgument($key);
+	}
+
+	public function offsetGet($key) {
+		return $this->event->offsetGet($key);
+	}
+
+	public function offsetSet($key, $value) {
+		return $this->event->offsetSet($key, $value);
+	}
+
+	public function offsetUnset($key) {
+		return $this->event->offsetUnset($key);
+	}
+
+	public function offsetExists($key) {
+		return $this->event->offsetExists($key);
+	}
+
+	public function getIterator() {
+		return$this->event->getIterator();
+	}
+}


### PR DESCRIPTION
This way we can track down what is being used and migrate them over. And
slowly kill the old way in a release or 2.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>