### PR TITLE
Move the password confirmation form template to post

### DIFF
--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -156,7 +156,7 @@
 		</header>
 
 		<div id="sudo-login-background" class="hidden"></div>
-		<form id="sudo-login-form" class="hidden">
+		<form id="sudo-login-form" class="hidden" method="POST">
 			<label>
 				<?php p($l->t('This action requires you to confirm your password')); ?><br/>
 				<input type="password" class="question" autocomplete="new-password" name="question" value=" <?php /* Hack against browsers ignoring autocomplete="off" */ ?>"


### PR DESCRIPTION
I know we use JS for this. But it triggers some false positives on
testing.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>