### PR TITLE
Convert Unique to PK for compatibility with Percona XtraDB

### DIFF
--- a/core/Migrations/Version16000Date20190207141427.php
+++ b/core/Migrations/Version16000Date20190207141427.php
@@ -76,7 +76,7 @@ class Version16000Date20190207141427 extends SimpleMigrationStep {
 				'length' => 64,
 			]);
 
-			$table->addUniqueIndex(['collection_id', 'resource_type', 'resource_id'], 'collres_unique_res');
+			$table->setPrimaryKey(['collection_id', 'resource_type', 'resource_id'], 'collres_unique_res');
 		}
 
 		if (!$schema->hasTable('collres_accesscache')) {
@@ -105,7 +105,7 @@ class Version16000Date20190207141427 extends SimpleMigrationStep {
 				'default' => 0,
 			]);
 
-			$table->addUniqueIndex(['user_id', 'collection_id', 'resource_type', 'resource_id'], 'collres_unique_user');
+			$table->setPrimaryKey(['user_id', 'collection_id', 'resource_type', 'resource_id'], 'collres_unique_user');
 			$table->addIndex(['user_id', 'resource_type', 'resource_id'], 'collres_user_res');
 			$table->addIndex(['user_id', 'collection_id'], 'collres_user_coll');
 		}

--- a/core/Migrations/Version20000Date20200511105313.php
+++ b/core/Migrations/Version20000Date20200511105313.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020 Ben Klang <bklang@powerhrg.com>
+ *
+ * @author Ben Klang <bklang@powerhrg.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version20000Date20200511105313 extends SimpleMigrationStep {
+
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('collres_accesscache') && !$schema->getTable('collres_accesscache')->hasPrimaryKey()) {
+			// Converts a unique key to a primary key for compatibility with Percona XtraDB
+			// See https://github.com/nextcloud/server/issues/16311
+			// Step 1: Drop the old index
+			$schema->getTable('collres_accesscache')->dropIndex('collres_unique_user');
+		}
+
+		if ($schema->hasTable('collres_resources') && !$schema->getTable('collres_resources')->hasPrimaryKey()) {
+			// Converts a unique key to a primary key for compatibility with Percona XtraDB
+			// See https://github.com/nextcloud/server/issues/16311
+			// Step 1: Drop the old index
+			$schema->getTable('collres_resources')->dropIndex('collres_unique_res');
+		}
+
+		return $schema;
+	}
+}

--- a/core/Migrations/Version20000Date20200511105314.php
+++ b/core/Migrations/Version20000Date20200511105314.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020 Ben Klang <bklang@powerhrg.com>
+ *
+ * @author Ben Klang <bklang@powerhrg.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version20000Date20200511105314 extends SimpleMigrationStep {
+
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('collres_accesscache') && !$schema->getTable('collres_accesscache')->hasPrimaryKey()) {
+			// Converts a unique key to a primary key for compatibility with Percona XtraDB
+			// See https://github.com/nextcloud/server/issues/16311
+			// Step 2: Re-create the index as a Primary Key
+			$schema->getTable('collres_accesscache')->setPrimaryKey(['user_id', 'collection_id', 'resource_type', 'resource_id'], 'collres_unique_user');
+		}
+
+		if ($schema->hasTable('collres_resources') && !$schema->getTable('collres_resources')->hasPrimaryKey()) {
+			// Converts a unique key to a primary key for compatibility with Percona XtraDB
+			// See https://github.com/nextcloud/server/issues/16311
+			// Step 2: Re-create the index as a Primary Key
+			$schema->getTable('collres_resources')->setPrimaryKey(['collection_id', 'resource_type', 'resource_id'], 'collres_unique_res');
+		}
+
+		return $schema;
+	}
+}


### PR DESCRIPTION
This PR makes two changes:
1. Modifies an old migration changing a unique ID on the `collres_accesscache` table to a Primary key
2. Creates a new migration for installations which have already run the previous migration to sync them up

I realize that it is an unusual step to modify an old migration, but in this case it is necessary. [NextCloud upgrades are failing with Percona XtraDB](https://github.com/nextcloud/server/issues/16311) due to a missing primary key on this table. Because the breakage occurs in an existing migration, the fix must also occur in the existing migration. To ensure that we do not cause any existing installations to diverge, this commit also introduces a new pair of migrations that looks for the non-PK version of the table and updates those as well. See #16311 for additional details.  I did attempt to do the unique -> primary key conversion in a single step, but I kept running into errors. I was able to test the 2-step migration successfully to convert a NextCloud 18 database.