### PR TITLE
Cache the avatar for a day

### DIFF
--- a/core/Controller/AvatarController.php
+++ b/core/Controller/AvatarController.php
@@ -153,8 +153,8 @@ class AvatarController extends Controller {
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
 
-		// Cache for 30 minutes
-		$response->cacheFor(1800);
+		// Cache for 1 day
+		$response->cacheFor(60*60*24);
 		return $response;
 	}
 


### PR DESCRIPTION
I noticed that on larger systems esp when using talk the avatars get
revalidated like crazy. Because people keep the tab open etc. You can do
with a slightly outdated avatar!

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>