### PR TITLE
Declare ext-json as dependency in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
             "OCP\\": "lib/public"
         }
     },
+    "require": {
+        "ext-json": "*"
+    },
     "require-dev": {
         "jakub-onderka/php-parallel-lint": "^0.9.2",
         "jakub-onderka/php-console-highlighter": "^0.3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b37c8b04970af89937957aad3c18a12",
+    "content-hash": "c6266c06daad42dd49f2bd3d5288467d",
     "packages": [],
     "packages-dev": [
         {
@@ -1711,7 +1711,9 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "ext-json": "*"
+    },
     "platform-dev": [],
     "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
This makes phpstorm happy as it knows that the functions like
json_encode are available.

One day we can also add the rest of https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation. I'm sure some static analyzers will like that.