### PR TITLE
Trailing comma's in functin arguments break on 7.2

### DIFF
--- a/core/Controller/OCJSController.php
+++ b/core/Controller/OCJSController.php
@@ -93,7 +93,7 @@ class OCJSController extends Controller {
 			$iniWrapper,
 			$urlGenerator,
 			$capabilitiesManager,
-			$initialStateService,
+			$initialStateService
 		);
 	}
 


### PR DESCRIPTION
Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>