### PR TITLE
Respect exit code of lint run - changed from -exec to xargs as this exits properly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
     "scripts": {
         "cs:fix": "php-cs-fixer fix",
         "cs:check": "php-cs-fixer fix --dry-run --diff",
-        "lint": "find . -name \\*.php -not -path './lib/composer/*' -not -path './build/.phan/*' -exec php -l \"{}\" \\;"
+        "lint": "find . -name \\*.php -not -path './lib/composer/*' -not -path './build/.phan/*' -print0 | xargs -0 -n1 php -l"
     }
 }

--- a/lib/private/AppFramework/Services/AppConfig.php
+++ b/lib/private/AppFramework/Services/AppConfig.php
@@ -70,6 +70,6 @@ class AppConfig implements IAppConfig {
 	}
 
 	public function deleteUserValue(string $userId, string $key): void {
-		return $this->config->deleteUserValue($userId, $this->appName, $key);
+		$this->config->deleteUserValue($userId, $this->appName, $key);
 	}
 }


### PR DESCRIPTION
Found while debugging #20951

So this one will fail for now until #20951 is merged. Then I will rebase.