### PR TITLE
Allow links to conversations

### DIFF
--- a/lib/public/RichObjectStrings/Definitions.php
+++ b/lib/public/RichObjectStrings/Definitions.php
@@ -185,6 +185,12 @@ class Definitions {
 					'description' => 'The type of the call: one2one, group or public',
 					'example' => 'one2one',
 				],
+				'link' => [
+					'since' => '19.0.0',
+					'required' => false,
+					'description' => 'The link to the conversation',
+					'example' => 'https://localhost/index.php/call/R4nd0mToken',
+				],
 			],
 		],
 		'circle' => [


### PR DESCRIPTION
Ref https://github.com/nextcloud/spreed/issues/3523

increases the usability of talk activities by 9000 as it makes the emails `Alice Ada invited you to "Convo name"` clickable