### PR TITLE
Allow TemplateResponse to be compressed

### DIFF
--- a/lib/private/AppFramework/Middleware/CompressionMiddleware.php
+++ b/lib/private/AppFramework/Middleware/CompressionMiddleware.php
@@ -29,6 +29,7 @@ use OC\AppFramework\OCS\BaseResponse;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
+use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Middleware;
 use OCP\IRequest;
 
@@ -65,6 +66,9 @@ class CompressionMiddleware extends Middleware {
 			$allowGzip = true;
 		}
 		if ($response instanceof JSONResponse) {
+			$allowGzip = true;
+		}
+		if ($response instanceof TemplateResponse) {
 			$allowGzip = true;
 		}
 


### PR DESCRIPTION
Followup to #20270 

Found this morning while browsing the network tab.

Before:

![Bildschirmfoto 2020-05-15 um 08 39 57](https://user-images.githubusercontent.com/245432/82019527-adde4d80-9687-11ea-8b6b-a8a1461dfc14.png)

After:

![Bildschirmfoto 2020-05-15 um 08 37 52](https://user-images.githubusercontent.com/245432/82019523-acad2080-9687-11ea-8e5d-895c9497a21c.png)


Or was there a reason to no compress this response?