### PR TITLE
Limit database table prefix to 3 characters

### DIFF
--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -13,6 +13,7 @@
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Thomas Pulzer <t.pulzer@kniel.de>
+ * @author Ruben Barkow-Kuder <github@r.z11.de>
  *
  * @license AGPL-3.0
  *
@@ -180,6 +181,10 @@ class Install extends Command {
 
 		if ($adminEmail !== null && !filter_var($adminEmail, FILTER_VALIDATE_EMAIL)) {
 			throw new InvalidArgumentException('Invalid e-mail-address <' . $adminEmail . '> for <' . $adminLogin . '>.');
+		}
+
+		if ($dbTablePrefix !== null && strlen($dbTablePrefix)>3) {
+			throw new InvalidArgumentException('Invalid database prefix: <'.$dbTablePrefix.'> (maximum length is 3 characters.)');
 		}
 
 		$options = [


### PR DESCRIPTION
In MariaDB the maximum string length for a table name is 64 characters, so limiting the table prefix prevents errors like https://github.com/nextcloud/spreed/issues/3593 and https://github.com/nextcloud/social/issues/850