### PR TITLE
Remove entries from locales.json incompatible with punic

### DIFF
--- a/resources/locales.json
+++ b/resources/locales.json
@@ -912,10 +912,6 @@
         "name": "English (United States)"
     },
     {
-        "code": "en_US_POSIX",
-        "name": "English (United States, Computer)"
-    },
-    {
         "code": "en_VC",
         "name": "English (St. Vincent & Grenadines)"
     },
@@ -1398,6 +1394,10 @@
     {
         "code": "ga",
         "name": "Irish"
+    },
+    {
+        "code": "ga_GB",
+        "name": "Irish (United Kingdom)"
     },
     {
         "code": "ga_IE",

--- a/resources/update-locales.php
+++ b/resources/update-locales.php
@@ -29,12 +29,20 @@ if (!extension_loaded('intl')) {
 	exit(1);
 }
 
-$locales = array_map(function (string $localeCode) {
+require '../3rdparty/autoload.php';
+
+$locales = array_map(static function (string $localeCode) {
 	return [
 		'code' => $localeCode,
 		'name' => Locale::getDisplayName($localeCode, 'en')
 	];
 }, ResourceBundle::getLocales(''));
+
+$locales = array_filter($locales, static function (array $locale) {
+	return is_array(Punic\Data::explodeLocale($locale['code']));
+});
+
+$locales = array_values($locales);
 
 if (file_put_contents(__DIR__ . '/locales.json', json_encode($locales, JSON_PRETTY_PRINT)) === false) {
 	echo 'Failed to update locales.json';


### PR DESCRIPTION
As reported at https://github.com/nextcloud/server/issues/20999 the list contains en_US_POSIX as locale but punic is unable to parse such a locale. If you select that locale everyone is confused