### PR TITLE
Remove group from excluded_groups_list after delete

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1511,6 +1511,19 @@ class Manager implements IManager {
 	public function groupDeleted($gid) {
 		$provider = $this->factory->getProviderForType(\OCP\Share::SHARE_TYPE_GROUP);
 		$provider->groupDeleted($gid);
+
+		$excludedGroups = $this->config->getAppValue('core', 'shareapi_exclude_groups_list', '');
+		if ($excludedGroups === '') {
+			return;
+		}
+
+		$excludedGroups = json_decode($excludedGroups, true);
+		if (json_last_error() !== JSON_ERROR_NONE) {
+			return;
+		}
+
+		$excludedGroups = array_diff($excludedGroups, [$gid]);
+		$this->config->setAppValue('core', 'shareapi_exclude_groups_list', json_encode($excludedGroups));
 	}
 
 	/**


### PR DESCRIPTION
Follow up to https://github.com/nextcloud/server/pull/19124. Remove group from shareapi_exclude_groups_list on delete. No backport required from my point.