### PR TITLE
Create account structure also for empty record

### DIFF
--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -148,7 +148,7 @@ class AccountManager implements IAccountManager {
 
 		$userDataArray = json_decode($result[0]['data'], true);
 		$jsonError = json_last_error();
-		if ($userDataArray === null || $jsonError !== JSON_ERROR_NONE) {
+		if ($userDataArray === null || $userDataArray === [] || $jsonError !== JSON_ERROR_NONE) {
 			$this->logger->critical("User data of $uid contained invalid JSON (error $jsonError), hence falling back to a default user record");
 			return $this->buildDefaultUserRecord($user);
 		}


### PR DESCRIPTION
Follow up to #17494, Fix #20498

![image](https://user-images.githubusercontent.com/3902676/82148292-a8356300-9853-11ea-8473-e7d3fa2b5099.png)

`{}` is valid json and not null :facepalm: Actually we should migrate the account manager to a typed structure with objects at some point :building_construction: 

The error message is not 100% correct now but who cares :see_no_evil: No backport required from my point.
