### PR TITLE
enforcement of two-factor authentication for specific network ranges

### DIFF
--- a/apps/settings/l10n/cs.js
+++ b/apps/settings/l10n/cs.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Unlimited" : "Neomezeně",
     "Verifying" : "Ověřuje se",
     "Nextcloud settings" : "Nastavení Nextcloud",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "Dvoufázové ověřování je možné vynutit pro všechny uživatele a konkrétní skupiny. Pokud nemají nastaveného poskytovatele dvoufázového ověřování, nebudou se moci přihlásit do systému.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "Dvoufázové ověřování je možné vynutit pro všechny uživatele a konkrétní skupiny. Pokud nemají nastaveného poskytovatele dvoufázového ověřování, nebudou se moci přihlásit do systému.",
     "Enforce two-factor authentication" : "Vynutit dvoufázové ověřování",
     "Limit to groups" : "Omezit na skupiny",
     "Enforcement of two-factor authentication can be set for certain groups only." : "Vynucení dvoufázového ověřování je možné nastavit pouze pro určité skupiny.",

--- a/apps/settings/l10n/de.js
+++ b/apps/settings/l10n/de.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Unlimited" : "Unbegrenzt",
     "Verifying" : "Überprüfe",
     "Nextcloud settings" : "Nextcloud-Einstellungen",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "Zwei-Faktor-Authentifizierung kann für alle Benutzer und Gruppen erzwungen werden. Dann können Benutzer für die keine Zwei-Faktor-Authentifizierung eingerichtet ist, sich nicht am System anmelden.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "Zwei-Faktor-Authentifizierung kann für alle Benutzer, bestimmte Netzwerke und bestimmte Gruppen erzwungen werden. Dann können Benutzer für die keine Zwei-Faktor-Authentifizierung eingerichtet ist, sich nicht am System anmelden.",
     "Enforce two-factor authentication" : "Zwei-Faktor-Authentifizierung erzwingen",
     "Limit to groups" : "Auf Gruppen beschränken",
     "Enforcement of two-factor authentication can be set for certain groups only." : "Erzwingen der Zwei-Faktor-Authentifizierung kann nur für bestimmte Gruppen eingestellt werden.",

--- a/apps/settings/l10n/de_DE.js
+++ b/apps/settings/l10n/de_DE.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Unlimited" : "Unbegrenzt",
     "Verifying" : "Überprüfe",
     "Nextcloud settings" : "Nextcloud-Einstellungen",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "Zwei-Faktor-Authentifizierung kann für alle Benutzer und Gruppen erzwungen werden. Dann können Benutzer für die keine Zwei-Faktor-Authentifizierung eingerichtet ist, sich nicht am System anmelden.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "Zwei-Faktor-Authentifizierung kann für alle Benutzer, bestimmte Netzwerke und bestimmte Gruppen erzwungen werden. Dann können Benutzer für die keine Zwei-Faktor-Authentifizierung eingerichtet ist, sich nicht am System anmelden.",
     "Enforce two-factor authentication" : "Zwei-Faktor-Authentifizierung erzwingen",
     "Limit to groups" : "Auf Gruppen beschränken",
     "Enforcement of two-factor authentication can be set for certain groups only." : "Erzwingen der Zwei-Faktor-Authentifizierung kann nur für bestimmte Gruppen eingestellt werden.",

--- a/apps/settings/l10n/el.js
+++ b/apps/settings/l10n/el.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Unlimited" : "Απεριόριστο",
     "Verifying" : "Γίνεται επαλήθευση",
     "Nextcloud settings" : "Ρυθμίσεις Nextcloud ",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "Η πιστοποίηση δύο-παραγόντων μπορεί να επιβληθεί σε όλους τους χρήστες και σε ομάδες. Εάν δεν έχουν ρυθμίσει πάροχο πιστοποίησης δύο βημάτων, δεν θα μπορούν να συνδεθούν.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "Η πιστοποίηση δύο-παραγόντων μπορεί να επιβληθεί σε όλους τους χρήστες και σε ομάδες. Εάν δεν έχουν ρυθμίσει πάροχο πιστοποίησης δύο βημάτων, δεν θα μπορούν να συνδεθούν.",
     "Enforce two-factor authentication" : "Υποχρεωτική πιστοποίηση δύο-παραγόντων",
     "Limit to groups" : "Όριο στις ομάδες",
     "Enforcement of two-factor authentication can be set for certain groups only." : "Η υποχρεωτική χρήση πιστοποίησης δύο-βημάτων μπορεί να ρυθμιστεί μόνο για ομάδες.",

--- a/apps/settings/l10n/es.js
+++ b/apps/settings/l10n/es.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Unlimited" : "Ilimitado",
     "Verifying" : "Verificar",
     "Nextcloud settings" : "Ajustes de Nextcloud",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "La verificación en dos pasos se puede aplicar para todos los usuarios y grupos específicos. Si no tienen configurado un proveedor de dos pasos, no podrán iniciar sesión en el sistema.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "La verificación en dos pasos se puede aplicar para todos los usuarios y grupos específicos. Si no tienen configurado un proveedor de dos pasos, no podrán iniciar sesión en el sistema.",
     "Enforce two-factor authentication" : "Imponer verificación en dos pasos",
     "Limit to groups" : "Límite para grupos",
     "Enforcement of two-factor authentication can be set for certain groups only." : "La obligatoriedad de la autenticación de dos pasos puede establecerse solo para ciertos grupos.",

--- a/apps/settings/l10n/fi.js
+++ b/apps/settings/l10n/fi.js
@@ -112,7 +112,7 @@ OC.L10N.register(
     "Unlimited" : "Rajoittamaton",
     "Verifying" : "Vahvistetaan",
     "Nextcloud settings" : "Nextcloud-asetukset",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "Kaksivaiheinen tunnistautuminen voidaan pakottaa kaikille käyttäjille ja halutuille ryhmille. Mikäli heillä ei ole kaksivaiheista tunnistautumistapaa määriteltynä, he eivät pysty kirjautumaan järjestelmään.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "Kaksivaiheinen tunnistautuminen voidaan pakottaa kaikille käyttäjille ja halutuille ryhmille. Mikäli heillä ei ole kaksivaiheista tunnistautumistapaa määriteltynä, he eivät pysty kirjautumaan järjestelmään.",
     "Enforce two-factor authentication" : "Pakota kaksivaiheinen tunnistautuminen",
     "Limit to groups" : "Rajoita ryhmiin",
     "Enforcement of two-factor authentication can be set for certain groups only." : "Kaksivaiheisen tunnistautumisen pakottaminen on mahdollista kohdentaa vain tietyille ryhmille.",

--- a/apps/settings/l10n/fr.js
+++ b/apps/settings/l10n/fr.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Unlimited" : "Illimité",
     "Verifying" : "Vérification en cours",
     "Nextcloud settings" : "Paramètres Nextcloud",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "L'authentification à deux facteurs peut être forcée pour tous les utilisateurs et des groupes spécifiques. S'ils n'ont pas un fournisseur à deux facteurs configuré, ils ne seront pas capable de s'identifier au système.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "L'authentification à deux facteurs peut être forcée pour tous les utilisateurs et des groupes spécifiques. S'ils n'ont pas un fournisseur à deux facteurs configuré, ils ne seront pas capable de s'identifier au système.",
     "Enforce two-factor authentication" : "Imposer l'authentification à deux facteurs",
     "Limit to groups" : "Limiter aux groupes",
     "Enforcement of two-factor authentication can be set for certain groups only." : "L'application de l'authentification à deux facteurs ne peut être définie que pour certains groupes.",

--- a/apps/settings/l10n/gl.js
+++ b/apps/settings/l10n/gl.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Unlimited" : "Sen límites",
     "Verifying" : "Verificando",
     "Nextcloud settings" : "Axustes do Nextcloud",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "A autenticación de dous factores pode ser aplicada para todos os usuarios e grupos específicos. Se non tiveran configurado un provedor de dous factores, non podería acceder ao sistema.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "A autenticación de dous factores pode ser aplicada para todos os usuarios e grupos específicos. Se non tiveran configurado un provedor de dous factores, non podería acceder ao sistema.",
     "Enforce two-factor authentication" : "Obrigar a autenticación de dous factores",
     "Limit to groups" : "Límite para grupos",
     "Enforcement of two-factor authentication can be set for certain groups only." : "A obrigatoriedade da autenticación de dous factores pode estabelecerse só para certos grupos.",

--- a/apps/settings/l10n/hr.js
+++ b/apps/settings/l10n/hr.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Unlimited" : "Neograničeno",
     "Verifying" : "Provjeravanje",
     "Nextcloud settings" : "Postavke Nextclouda",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "Dvofaktorska autentifikacija može se primijeniti na sve korisnike i određene grupe. Ako nisu konfigurirali davatelje usluge dvofaktorske autentifikacije, neće se moći prijaviti u sustav.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "Dvofaktorska autentifikacija može se primijeniti na sve korisnike i određene grupe. Ako nisu konfigurirali davatelje usluge dvofaktorske autentifikacije, neće se moći prijaviti u sustav.",
     "Enforce two-factor authentication" : "Primijeni dvofaktorsku autentifikaciju",
     "Limit to groups" : "Ograniči na grupe",
     "Enforcement of two-factor authentication can be set for certain groups only." : "Primjena dvofaktorske autentifikacije može se postaviti samo za određene grupe.",

--- a/apps/settings/l10n/it.js
+++ b/apps/settings/l10n/it.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Unlimited" : "Illimitata",
     "Verifying" : "Verifica",
     "Nextcloud settings" : "Impostazioni di Nextcloud",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "L'autenticazione a due fattori può essere imposta per tutti gli utenti e gruppi specifici. Se non hanno un fornitore a due fattori configurato, non saranno in grado di accedere al sistema.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "L'autenticazione a due fattori può essere imposta per tutti gli utenti e gruppi specifici. Se non hanno un fornitore a due fattori configurato, non saranno in grado di accedere al sistema.",
     "Enforce two-factor authentication" : "Applica l'autenticazione a due fattori",
     "Limit to groups" : "Limita a gruppi",
     "Enforcement of two-factor authentication can be set for certain groups only." : "L'applicazione dell'autenticazione a due fattori può essere impostata solo per determinati gruppi.",

--- a/apps/settings/l10n/mk.js
+++ b/apps/settings/l10n/mk.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Unlimited" : "Неограничено",
     "Verifying" : "Потврдување",
     "Nextcloud settings" : "Nextcloud параметри",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "Двофакторна автентикација може да биде задолжителна за сите корисници и одредени групи. Доколку корисниците немаат поставено провајдер за двофакторна автентикација, нема да можат да се најават на системот.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "Двофакторна автентикација може да биде задолжителна за сите корисници и одредени групи. Доколку корисниците немаат поставено провајдер за двофакторна автентикација, нема да можат да се најават на системот.",
     "Enforce two-factor authentication" : "Задолжителна двофакторна автентикација",
     "Limit to groups" : "Ограничување на групи",
     "Enforcement of two-factor authentication can be set for certain groups only." : "Задолжителна двофакторна автентикација може да се постави само за одредени групи.",

--- a/apps/settings/l10n/nl.js
+++ b/apps/settings/l10n/nl.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Unlimited" : "Ongelimiteerd",
     "Verifying" : "Controleer",
     "Nextcloud settings" : "Nextcloud instellingen",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "Twee-factor-authenticatie kan worden afgedwongen voor alle gebruikers en specifieke groepen. Als ze geen twee-factor provider hebben ingesteld, dan kunnen ze niet inloggen in het systeem.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "Twee-factor-authenticatie kan worden afgedwongen voor alle gebruikers en specifieke groepen. Als ze geen twee-factor provider hebben ingesteld, dan kunnen ze niet inloggen in het systeem.",
     "Enforce two-factor authentication" : "Forceren gebruik twee-factor-authenticatie",
     "Limit to groups" : "Beperk tot groepen",
     "Enforcement of two-factor authentication can be set for certain groups only." : "Forceren van gebruik twee-factor-authenticatie kan worden ingesteld voor bepaalde groepen",

--- a/apps/settings/l10n/pl.js
+++ b/apps/settings/l10n/pl.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Unlimited" : "Bez limitu",
     "Verifying" : "Sprawdzanie",
     "Nextcloud settings" : "Ustawienia Nextcloud",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "Uwierzytelnianie dwuskładnikowe może być wymuszane dla wszystkich użytkowników i określonych grup. Jeśli nie mają skonfigurowanego dostawcy logowania dwuskładnikowego, nie będą mogli zalogować się do systemu.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "Uwierzytelnianie dwuskładnikowe może być wymuszane dla wszystkich użytkowników i określonych grup. Jeśli nie mają skonfigurowanego dostawcy logowania dwuskładnikowego, nie będą mogli zalogować się do systemu.",
     "Enforce two-factor authentication" : "Wymuś uwierzytelnianie dwuskładnikowe",
     "Limit to groups" : "Ogranicz do grup",
     "Enforcement of two-factor authentication can be set for certain groups only." : "Wymuszanie uwierzytelniania dwuskładnikowego można ustawić tylko dla niektórych grup.",

--- a/apps/settings/l10n/pt_BR.js
+++ b/apps/settings/l10n/pt_BR.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Unlimited" : "Ilimitado",
     "Verifying" : "Verificando",
     "Nextcloud settings" : "Configurações Nextcloud",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "A autenticação de dois fatores pode ser imposta a todos os usuários e grupos específicos. Se eles não tiverem um provedor de dois fatores configurado, não poderão fazer login no sistema.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "A autenticação de dois fatores pode ser imposta a todos os usuários e grupos específicos. Se eles não tiverem um provedor de dois fatores configurado, não poderão fazer login no sistema.",
     "Enforce two-factor authentication" : "Aplicar autenticação de dois fatores",
     "Limit to groups" : "Limitado a grupos",
     "Enforcement of two-factor authentication can be set for certain groups only." : "A obrigatoriedade da autenticação de dois fatores pode ser definida para determinados grupos apenas.",

--- a/apps/settings/l10n/ru.js
+++ b/apps/settings/l10n/ru.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Unlimited" : "Неограничено",
     "Verifying" : "Проверка",
     "Nextcloud settings" : "Параметры Nextcloud",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "Двухфаторная аутентификация может быть принудительна включена для всех пользователей и выбранных групп. В случае, если у пользователя не настроен механизм подтверждения подлинности вторым фактором, он не сможет войти в систему.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "Двухфаторная аутентификация может быть принудительна включена для всех пользователей и выбранных групп. В случае, если у пользователя не настроен механизм подтверждения подлинности вторым фактором, он не сможет войти в систему.",
     "Enforce two-factor authentication" : "Требовать двухфакторую аунтефикацию",
     "Limit to groups" : "Разрешить использование только участникам этих групп",
     "Enforcement of two-factor authentication can be set for certain groups only." : "Требование использовать двухфакторную аутентификацию может быть применено только к определённым группам. ",

--- a/apps/settings/l10n/sl.js
+++ b/apps/settings/l10n/sl.js
@@ -109,7 +109,7 @@ OC.L10N.register(
     "Unlimited" : "Neomejeno",
     "Verifying" : "Preverjanje",
     "Nextcloud settings" : "Nastavitve Nextcloud",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "Dvostopenjsko overjanje je mogoče vsiliti za vse uporabnike in določene skupine. Če za tovrstno prijavo nimajo nastavljenega ustreznega ponudnika, se v sistem ne bodo uspeli povezati.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "Dvostopenjsko overjanje je mogoče vsiliti za vse uporabnike in določene skupine. Če za tovrstno prijavo nimajo nastavljenega ustreznega ponudnika, se v sistem ne bodo uspeli povezati.",
     "Enforce two-factor authentication" : "Vsili dvo-stopenjsko overjanje",
     "Limit to groups" : "Omeji na skupine",
     "Enforcement of two-factor authentication can be set for certain groups only." : "Vsiljeno dvo-stopenjsko overjanje je mogoče določiti le za določene skupine.",

--- a/apps/settings/l10n/sr.js
+++ b/apps/settings/l10n/sr.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Unlimited" : "Неограничено",
     "Verifying" : "Проверавам",
     "Nextcloud settings" : "Некстклауд поставке",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "Двофакторска провера идентитета се може захтевати свим корисницима и и одређеним групама. Ако немају већ подешеног провајдера другог фактора, неће моћи да се пријаве на систем.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "Двофакторска провера идентитета се може захтевати свим корисницима и и одређеним групама. Ако немају већ подешеног провајдера другог фактора, неће моћи да се пријаве на систем.",
     "Enforce two-factor authentication" : "Захтевај двофакторску проверу идентитета",
     "Limit to groups" : "Ограничи на групе",
     "Enforcement of two-factor authentication can be set for certain groups only." : "Двофакторска провера идентитета се може захтевати за само поједине групе.",

--- a/apps/settings/l10n/sv.js
+++ b/apps/settings/l10n/sv.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Unlimited" : "Obegränsat",
     "Verifying" : "Verifiera",
     "Nextcloud settings" : "Nextcloud-inställningar",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "Tvåfaktorsautentisering kan påtvingas för alla användare och specifika grupper. Om de inte har en tvåfaktorsleverantör konfigurerad kommer de inte att kunna logga in i systemet.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "Tvåfaktorsautentisering kan påtvingas för alla användare och specifika grupper. Om de inte har en tvåfaktorsleverantör konfigurerad kommer de inte att kunna logga in i systemet.",
     "Enforce two-factor authentication" : "Påtvinga tvåfaktorsautentisering",
     "Limit to groups" : "Begränsa till grupper",
     "Enforcement of two-factor authentication can be set for certain groups only." : "Påtvingad tvåfaktorsautentisering kan bara aktiveras för vissa grupper.",

--- a/apps/settings/l10n/tr.js
+++ b/apps/settings/l10n/tr.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Unlimited" : "Sınırsız",
     "Verifying" : "Doğrulanıyor",
     "Nextcloud settings" : "Nextcloud ayarları",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "Tüm kullanıcılar ve belirli gruplar için iki aşamalı kimlik doğrulama kullanılır. Yapılandırılmış bir iki aşamalı kimlik doğrulama hizmeti sağlayıcısı olmayan kullanıcılar oturum açamaz.",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "Tüm kullanıcılar ve belirli gruplar için iki aşamalı kimlik doğrulama kullanılır. Yapılandırılmış bir iki aşamalı kimlik doğrulama hizmeti sağlayıcısı olmayan kullanıcılar oturum açamaz.",
     "Enforce two-factor authentication" : "İki aşamalı kimlik doğrulama dayatılsın",
     "Limit to groups" : "Şu gruplarla sınırla",
     "Enforcement of two-factor authentication can be set for certain groups only." : "İki aşamalı kimlik doğrulaması yalnız belirli gruplara dayatılabilir.",

--- a/apps/settings/l10n/zh_CN.js
+++ b/apps/settings/l10n/zh_CN.js
@@ -118,7 +118,7 @@ OC.L10N.register(
     "Unlimited" : "无限",
     "Verifying" : "正在验证",
     "Nextcloud settings" : "Nextcloud 设置",
-    "Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system." : "两步验证可以对于所有用户和特定分组启用。如果没有设置两步验证提供者，他们则不能登录到系统。",
+    "Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system." : "两步验证可以对于所有用户和特定分组启用。如果没有设置两步验证提供者，他们则不能登录到系统。",
     "Enforce two-factor authentication" : "强制启用两步验证",
     "Limit to groups" : "限制于组",
     "Enforcement of two-factor authentication can be set for certain groups only." : "可以仅为某些组设置两步验证的强制执行。",

--- a/apps/settings/lib/Controller/TwoFactorSettingsController.php
+++ b/apps/settings/lib/Controller/TwoFactorSettingsController.php
@@ -49,9 +49,9 @@ class TwoFactorSettingsController extends Controller {
 		return new JSONResponse($this->mandatoryTwoFactor->getState());
 	}
 
-	public function update(bool $enforced, array $enforcedGroups = [], array $excludedGroups = []): JSONResponse {
+	public function update(bool $enforced, array $enforcedGroups = [], array $excludedGroups = [], array $enforcedNetworks = [], array $excludedNetworks = []): JSONResponse {
 		$this->mandatoryTwoFactor->setState(
-			new EnforcementState($enforced, $enforcedGroups, $excludedGroups)
+			new EnforcementState($enforced, $enforcedGroups, $excludedGroups, $enforcedNetworks, $excludedNetworks)
 		);
 
 		return new JSONResponse($this->mandatoryTwoFactor->getState());

--- a/apps/settings/src/components/AdminTwoFactor.vue
+++ b/apps/settings/src/components/AdminTwoFactor.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
 		<p class="settings-hint">
-			{{ t('settings', 'Two-factor authentication can be enforced for all users and specific groups. If they do not have a two-factor provider configured, they will be unable to log into the system.') }}
+			{{ t('settings', 'Two-factor authentication can be enforced for all users, specific networks and specific groups. If users do not have a two-factor provider configured, they will be unable to log into the system.') }}
 		</p>
 		<p v-if="loading">
 			<span class="icon-loading-small two-factor-loading" />
@@ -111,6 +111,24 @@ export default {
 				this.$store.commit('setExcludedGroups', val)
 			},
 		},
+		enforcedNetworks: {
+			get: function() {
+				return this.$store.state.enforcedNetworks
+			},
+			set: function(val) {
+				this.dirty = true
+				this.$store.commit('setEnforcedNetworks', val)
+			},
+		},
+		excludedNetworks: {
+			get: function() {
+				return this.$store.state.excludedNetworks
+			},
+			set: function(val) {
+				this.dirty = true
+				this.$store.commit('setExcludedNetworks', val)
+			},
+		},
 	},
 	mounted() {
 		// Groups are loaded dynamically, but the assigned ones *should*
@@ -139,6 +157,8 @@ export default {
 				enforced: this.enforced,
 				enforcedGroups: this.enforcedGroups,
 				excludedGroups: this.excludedGroups,
+				enforcedNetworks: this.enforcedNetworks,
+				excludedNetworks: this.excludedNetworks,
 			}
 			axios.put(OC.generateUrl('/settings/api/admin/twofactorauth'), data)
 				.then(resp => resp.data)

--- a/core/Command/TwoFactorAuth/Enforce.php
+++ b/core/Command/TwoFactorAuth/Enforce.php
@@ -72,13 +72,27 @@ class Enforce extends Command {
 			InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
 			'exclude mandatory two-factor auth for the given group(s)'
 		);
+		$this->addOption(
+			'network',
+			null,
+			InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+			'enforce only for the given network(s)'
+		);
+		$this->addOption(
+			'exclude_network',
+			null,
+			InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+			'exclude mandatory two-factor auth for the given network(s)'
+		);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		if ($input->getOption('on')) {
 			$enforcedGroups = $input->getOption('group');
 			$excludedGroups = $input->getOption('exclude');
-			$this->mandatoryTwoFactor->setState(new EnforcementState(true, $enforcedGroups, $excludedGroups));
+			$enforcedNetworks = $input->getOption('network');
+			$excludedNetworks = $input->getOption('exclude_network');
+			$this->mandatoryTwoFactor->setState(new EnforcementState(true, $enforcedGroups, $excludedGroups, $enforcedNetworks, $excludedNetworks));
 		} elseif ($input->getOption('off')) {
 			$this->mandatoryTwoFactor->setState(new EnforcementState(false));
 		}
@@ -103,6 +117,14 @@ class Enforce extends Command {
 		if (!empty($state->getExcludedGroups())) {
 			$message .= ', except members of ' . implode(', ', $state->getExcludedGroups());
 		}
+
+		if (!empty($state->getEnforcedNetworks())) {
+			$message .= ' on the networks ' . implode(', ', $state->getEnforcedNetworks());
+		}
+		if (!empty($state->getExcludedNetworks())) {
+			$message .= ' but the ranges ' . implode(', ', $state->getExcludedNetworks());
+		}
+
 		$output->writeln($message);
 	}
 

--- a/lib/private/Authentication/TwoFactorAuth/EnforcementState.php
+++ b/lib/private/Authentication/TwoFactorAuth/EnforcementState.php
@@ -48,10 +48,14 @@ class EnforcementState implements JsonSerializable {
 	 */
 	public function __construct(bool $enforced,
 								array $enforcedGroups = [],
-								array $excludedGroups = []) {
+								array $excludedGroups = [],
+								array $enforcedNetworks = [],
+								array $excludedNetworks = []) {
 		$this->enforced = $enforced;
 		$this->enforcedGroups = $enforcedGroups;
 		$this->excludedGroups = $excludedGroups;
+		$this->enforcedNetworks = $enforcedNetworks;
+		$this->excludedNetworks = $excludedNetworks;
 	}
 
 	/**
@@ -75,11 +79,27 @@ class EnforcementState implements JsonSerializable {
 		return $this->excludedGroups;
 	}
 
+	/**
+	 * @return string[]
+	 */
+	public function getEnforcedNetworks(): array {
+		return $this->enforcedNetworks;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getExcludedNetworks(): array {
+		return $this->excludedNetworks;
+	}
+
 	public function jsonSerialize(): array {
 		return [
 			'enforced' => $this->enforced,
 			'enforcedGroups' => $this->enforcedGroups,
 			'excludedGroups' => $this->excludedGroups,
+			'enforcedNetworks' => $this->enforcedNetworks,
+			'excludedNetworks' => $this->excludedNetworks,
 		];
 	}
 

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -109,7 +109,7 @@ class Manager {
 	 * @return boolean
 	 */
 	public function isTwoFactorAuthenticated(IUser $user): bool {
-		if ($this->mandatoryTwoFactor->isEnforcedFor($user)) {
+		if ($this->mandatoryTwoFactor->isEnforcedForNetwork(\OC::$server->getRequest()->getRemoteAddress()) && $this->mandatoryTwoFactor->isEnforcedFor($user)) {
 			return true;
 		}
 

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -109,7 +109,7 @@ class Manager {
 	 * @return boolean
 	 */
 	public function isTwoFactorAuthenticated(IUser $user): bool {
-		if ($this->mandatoryTwoFactor->isEnforcedForNetwork(\OC::$server->getRequest()->getRemoteAddress()) && $this->mandatoryTwoFactor->isEnforcedFor($user)) {
+		if ($this->mandatoryTwoFactor->isEnforcedForNetwork(\OC::$server->getRequest()->getRemoteAddress()) || $this->mandatoryTwoFactor->isEnforcedFor($user)) {
 			return true;
 		}
 

--- a/lib/private/Authentication/TwoFactorAuth/MandatoryTwoFactor.php
+++ b/lib/private/Authentication/TwoFactorAuth/MandatoryTwoFactor.php
@@ -50,7 +50,9 @@ class MandatoryTwoFactor {
 		return new EnforcementState(
 			$this->config->getSystemValue('twofactor_enforced', 'false') === 'true',
 			$this->config->getSystemValue('twofactor_enforced_groups', []),
-			$this->config->getSystemValue('twofactor_enforced_excluded_groups', [])
+			$this->config->getSystemValue('twofactor_enforced_excluded_groups', []),
+			$this->config->getSystemValue('twofactor_enforced_networks', []),
+			$this->config->getSystemValue('twofactor_enforced_excluded_networks', [])
 		);
 	}
 
@@ -61,6 +63,170 @@ class MandatoryTwoFactor {
 		$this->config->setSystemValue('twofactor_enforced', $state->isEnforced() ? 'true' : 'false');
 		$this->config->setSystemValue('twofactor_enforced_groups', $state->getEnforcedGroups());
 		$this->config->setSystemValue('twofactor_enforced_excluded_groups', $state->getExcludedGroups());
+		$this->config->setSystemValue('twofactor_enforced_networks', $state->getEnforcedNetworks());
+		$this->config->setSystemValue('twofactor_enforced_excluded_networks', $state->getExcludedNetworks());
+	}
+
+	/**
+	 * Checks if an IPv4 or IPv6 address is contained in the list of given IPs or subnets.
+	 *
+	 * @param string       $requestIp IP to check
+	 * @param string|array $ips       List of IPs or subnets (can be a string if only a single one)
+	 *
+	 * @return bool Whether the IP is valid
+	 *
+	 * @copyright Copyright (c) 2004-2016 Fabien Potencier
+	 * @license MIT
+	 */
+	public static function checkIp($requestIp, $ips)
+	{
+		if (!is_array($ips)) {
+			$ips = array($ips);
+		}
+
+		$method = substr_count($requestIp, ':') > 1 ? 'checkIp6' : 'checkIp4';
+
+		foreach ($ips as $ip) {
+			if (self::$method($requestIp, $ip)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Compares two IPv4 addresses.
+	 * In case a subnet is given, it checks if it contains the request IP.
+	 *
+	 * @param string $requestIp IPv4 address to check
+	 * @param string $ip        IPv4 address or subnet in CIDR notation
+	 *
+	 * @return bool Whether the request IP matches the IP, or whether the request IP is within the CIDR subnet
+	 *
+	 * @copyright Copyright (c) 2004-2016 Fabien Potencier
+	 * @license MIT
+	 */
+	public static function checkIp4($requestIp, $ip)
+	{
+		if (false !== strpos($ip, '/')) {
+			list($address, $netmask) = explode('/', $ip, 2);
+
+			if ($netmask === '0') {
+				// Ensure IP is valid - using ip2long below implicitly validates, but we need to do it manually here
+				return filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4);
+			}
+
+			if ($netmask < 0 || $netmask > 32) {
+				return false;
+			}
+		} else {
+			$address = $ip;
+			$netmask = 32;
+		}
+
+		return 0 === substr_compare(sprintf('%032b', ip2long($requestIp)), sprintf('%032b', ip2long($address)), 0, (int)$netmask);
+	}
+
+	/**
+	 * Compares two IPv6 addresses.
+	 * In case a subnet is given, it checks if it contains the request IP.
+	 *
+	 * @author David Soria Parra <dsp at php dot net>
+	 *
+	 * @see https://github.com/dsp/v6tools
+	 *
+	 * @param string $requestIp IPv6 address to check
+	 * @param string $ip        IPv6 address or subnet in CIDR notation
+	 *
+	 * @return bool Whether the IP is valid
+	 *
+	 * @throws \RuntimeException When IPV6 support is not enabled
+	 *
+	 * @copyright Copyright (c) 2004-2016 Fabien Potencier
+	 * @license MIT
+	 */
+	public static function checkIp6($requestIp, $ip)
+	{
+		if (!((extension_loaded('sockets') && defined('AF_INET6')) || @inet_pton('::1'))) {
+			throw new \RuntimeException('Unable to check Ipv6. Check that PHP was not compiled with option "disable-ipv6".');
+		}
+
+		if (false !== strpos($ip, '/')) {
+			list($address, $netmask) = explode('/', $ip, 2);
+
+			if ($netmask < 1 || $netmask > 128) {
+				return false;
+			}
+		} else {
+			$address = $ip;
+			$netmask = 128;
+		}
+
+		$bytesAddr = unpack('n*', @inet_pton($address));
+		$bytesTest = unpack('n*', @inet_pton($requestIp));
+
+		if (!$bytesAddr || !$bytesTest) {
+			return false;
+		}
+
+		for ($i = 1, $ceil = ceil($netmask / 16); $i <= $ceil; ++$i) {
+			$left = $netmask - 16 * ($i - 1);
+			$left = ($left <= 16) ? $left : 16;
+			$mask = ~(0xffff >> $left) & 0xffff;
+			if (($bytesAddr[$i] & $mask) != ($bytesTest[$i] & $mask)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if two-factor auth is enforced for a specific network
+	 *
+	 * The admin(s) can enforce two-factor auth system-wide, for certain networks only
+	 * and also have the option to exclude networks. This method will check a specfific
+	 * network.
+	 *
+	 * @param String $ip
+	 *
+	 * @return bool
+	 */
+	public function isEnforcedForNetwork(String $ip): bool {
+		$state = $this->getState();
+		if (!$state->isEnforced()) {
+			return false;
+		}
+
+		/*
+		 * If there is a list of enforced networks, we only enforce 2FA for clients in these networks.
+		 * For all the other networks it is not enforced (overruling the excluded groups list).
+		 */
+		if (!empty($state->getEnforcedNetworks())) {
+			foreach ($state->getEnforcedNetworks() as $network) {
+				if (self::checkIp($ip, $network)) {
+					return true;
+				}
+			}
+			// Client not in one of these networks -> no 2FA enforced
+			return false;
+		}
+
+		/**
+		 * If the client ip is in the range of excluded networks, 2FA won't be enforced.
+		 */
+		foreach ($state->getExcludedNetworks() as $network) {
+			if (self::checkIp($ip, $network)) {
+				return false;
+			}
+		}
+
+		/**
+		 * No enforced network configured and client ip not in range aif excluded networks,
+		 * so 2FA is enforced.
+		 */
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
Support enforcement of two-factor authentication for specific network ranges (refs #20857). This patch still has some work open for the ui (someone familiar with vue?) and for translations.

The patch uses code from the Symfony package, MIT licensed. I expect this to be compatible with AGPLv3. Can anybody confirm this?