### PR TITLE
Copy over the ETag and LastModified when formatting a Dataresponse

### DIFF
--- a/lib/public/AppFramework/Controller.php
+++ b/lib/public/AppFramework/Controller.php
@@ -91,6 +91,14 @@ abstract class Controller {
 						unset($headers['Content-Type']);
 					}
 					$response->setHeaders(array_merge($dataHeaders, $headers));
+
+					if ($data->getETag() !== null) {
+						$response->setETag($data->getETag());
+					}
+					if ($data->getLastModified() !== null) {
+						$response->setLastModified($data->getLastModified());
+					}
+
 					return $response;
 				}
 				return new JSONResponse($data);


### PR DESCRIPTION
This way the ETag checks etc are all working.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>