### PR TITLE
Add a message to the log entry of an app being disabled

### DIFF
--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -157,11 +157,17 @@ class OC_App {
 				if ($ex instanceof ServerNotAvailableException) {
 					throw $ex;
 				}
-				\OC::$server->getLogger()->logException($ex);
-
 				if (!\OC::$server->getAppManager()->isShipped($app) && !self::isType($app, ['authentication'])) {
+					\OC::$server->getLogger()->logException($ex, [
+						'message' => "App $app threw an error during app.php load and will be disabled: " . $ex->getMessage(),
+					]);
+
 					// Only disable apps which are not shipped and that are not authentication apps
 					\OC::$server->getAppManager()->disableApp($app, true);
+				} else {
+					\OC::$server->getLogger()->logException($ex, [
+						'message' => "App $app threw an error during app.php load: " . $ex->getMessage(),
+					]);
 				}
 			}
 			\OC::$server->getEventLogger()->end('load_app_' . $app);


### PR DESCRIPTION
As an admin, it's always a surprise to see that an app got disabled. On
a busy server with many log entries, it's hard to locate the entry that
explains why Nextcloud disabled an app. Adding a message will make it
more obvious, allowing admins and developers to grep for the string.