### PR TITLE
Add support for shared file IDs on SMB storage

### DIFF
--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -60,6 +60,9 @@ class SMB extends Backend {
 					->setType(DefinitionParameter::VALUE_BOOLEAN)
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL)
 					->setTooltip($l->t("Check the ACL's of each file or folder inside a directory to filter out items where the user has no read permissions, comes with a performance penalty")),
+				(new DefinitionParameter('shared',$l->t('Shared storage')))
+					->setType(DefinitionParameter::VALUE_BOOLEAN)
+					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('timeout', $l->t('Timeout')))
 					->setType(DefinitionParameter::VALUE_HIDDEN)
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -94,6 +94,9 @@ class SMB extends Common implements INotifyStorage {
 	/** @var bool */
 	protected $checkAcl;
 
+	/** @var bool */
+	protected $isSharedStorage;
+
 	public function __construct($params) {
 		if (!isset($params['host'])) {
 			throw new \Exception('Invalid configuration, no host provided');
@@ -131,6 +134,7 @@ class SMB extends Common implements INotifyStorage {
 
 		$this->showHidden = isset($params['show_hidden']) && $params['show_hidden'];
 		$this->checkAcl = isset($params['check_acl']) && $params['check_acl'];
+		$this->isSharedStorage = isset($params['shared']) && $params['shared'];
 
 		$this->statCache = new CappedMemoryCache();
 		parent::__construct($params);
@@ -153,6 +157,12 @@ class SMB extends Common implements INotifyStorage {
 		// FIXME: double slash to keep compatible with the old storage ids,
 		// failure to do so will lead to creation of a new storage id and
 		// loss of shares from the storage
+		
+		// If this is shared storage, generate the same file IDs for all users
+		if ($this->isSharedStorage) {
+			return 'smb::' . $this->server->getHost() . '//' . $this->share->getName() . '/' . $this->root;
+		}
+		
 		return 'smb::' . $this->server->getAuth()->getUsername() . '@' . $this->server->getHost() . '//' . $this->share->getName() . '/' . $this->root;
 	}
 

--- a/apps/files_external/tests/Storage/SmbTest.php
+++ b/apps/files_external/tests/Storage/SmbTest.php
@@ -96,6 +96,19 @@ class SmbTest extends \Test\Files\Storage\Storage {
 		$this->instance = null;
 	}
 
+	public function testStorageId() {
+		$this->instance = new SMB([
+			'host' => 'testhost',
+			'user' => 'testuser',
+			'password' => 'somepass',
+			'share' => 'someshare',
+			'root' => 'someroot',
+			'shared' => true
+		]);
+		$this->assertEquals('smb::testhost//someshare//someroot/', $this->instance->getId());
+		$this->instance = null;
+	}
+
 	public function testNotifyGetChanges() {
 		$notifyHandler = $this->instance->notify('');
 		sleep(1); //give time for the notify to start

--- a/apps/files_external/tests/Storage/SmbTest.php
+++ b/apps/files_external/tests/Storage/SmbTest.php
@@ -96,7 +96,7 @@ class SmbTest extends \Test\Files\Storage\Storage {
 		$this->instance = null;
 	}
 
-	public function testStorageId() {
+	public function testSharedStorageId() {
 		$this->instance = new SMB([
 			'host' => 'testhost',
 			'user' => 'testuser',


### PR DESCRIPTION
Add a checkbox in external storage config so an admin can mark that external SMB storage is shared among users. If checked, Nextcloud file IDs on that storage will be the same for all users, even when using log-in credentials for authentication. Includes a test to verify the ID structure.

This creates WOPI URLs that are the same across users, so collaborative editing works as expected for documents on SMB shares using log-in credentials as the authentication method.

Signed-off-by: David <ddean@njstatelib.org>

Fix https://github.com/nextcloud/server/pull/21049