### PR TITLE
Caching and compression for app store requests

### DIFF
--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -98,12 +98,11 @@ abstract class Fetcher {
 
 		$options = [
 			'timeout' => 10,
+			'headers' => ['Accept-Encoding' => 'gzip'],
 		];
 
 		if ($ETag !== '') {
-			$options['headers'] = [
-				'If-None-Match' => $ETag,
-			];
+			$options['headers']['If-None-Match'] = $ETag;
 		}
 
 		$client = $this->clientService->newClient();

--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -41,7 +41,7 @@ use OCP\IConfig;
 use OCP\ILogger;
 
 abstract class Fetcher {
-	public const INVALIDATE_AFTER_SECONDS = 300;
+	public const INVALIDATE_AFTER_SECONDS = 3600;
 
 	/** @var IAppData */
 	protected $appData;
@@ -153,7 +153,7 @@ abstract class Fetcher {
 				// No caching when the version has been updated
 				if (isset($jsonBlob['ncversion']) && $jsonBlob['ncversion'] === $this->getVersion()) {
 
-					// If the timestamp is older than 300 seconds request the files new
+					// If the timestamp is older than 3600 seconds request the files new
 					if ((int)$jsonBlob['timestamp'] > ($this->timeFactory->getTime() - self::INVALIDATE_AFTER_SECONDS)) {
 						return $jsonBlob['data'];
 					}

--- a/tests/lib/App/AppStore/Fetcher/FetcherBase.php
+++ b/tests/lib/App/AppStore/Fetcher/FetcherBase.php
@@ -239,7 +239,7 @@ abstract class FetcherBase extends TestCase {
 		$this->timeFactory
 			->expects($this->at(0))
 			->method('getTime')
-			->willReturn(1501);
+			->willReturn(4801);
 		$client = $this->createMock(IClient::class);
 		$this->clientService
 			->expects($this->once())
@@ -533,11 +533,11 @@ abstract class FetcherBase extends TestCase {
 		$this->timeFactory
 			->expects($this->at(0))
 			->method('getTime')
-			->willReturn(1501);
+			->willReturn(4801);
 		$this->timeFactory
 			->expects($this->at(1))
 			->method('getTime')
-			->willReturn(1502);
+			->willReturn(4802);
 		$client = $this->createMock(IClient::class);
 		$this->clientService
 			->expects($this->once())
@@ -559,7 +559,7 @@ abstract class FetcherBase extends TestCase {
 		$response->method('getStatusCode')
 			->willReturn(304);
 
-		$newData = '{"data":[{"id":"MyNewApp","foo":"foo"},{"id":"bar"}],"timestamp":1502,"ncversion":"11.0.0.2","ETag":"\"myETag\""}';
+		$newData = '{"data":[{"id":"MyNewApp","foo":"foo"},{"id":"bar"}],"timestamp":4802,"ncversion":"11.0.0.2","ETag":"\"myETag\""}';
 		$file
 			->expects($this->at(1))
 			->method('putContent')
@@ -638,7 +638,7 @@ abstract class FetcherBase extends TestCase {
 		$response->method('getHeader')
 			->with($this->equalTo('ETag'))
 			->willReturn('"newETag"');
-		$fileData = '{"data":[{"id":"MyNewApp","foo":"foo"},{"id":"bar"}],"timestamp":1502,"ncversion":"11.0.0.2","ETag":"\"newETag\""}';
+		$fileData = '{"data":[{"id":"MyNewApp","foo":"foo"},{"id":"bar"}],"timestamp":4802,"ncversion":"11.0.0.2","ETag":"\"newETag\""}';
 		$file
 			->expects($this->at(1))
 			->method('putContent')
@@ -650,11 +650,11 @@ abstract class FetcherBase extends TestCase {
 		$this->timeFactory
 			->expects($this->at(0))
 			->method('getTime')
-			->willReturn(1501);
+			->willReturn(4801);
 		$this->timeFactory
 			->expects($this->at(1))
 			->method('getTime')
-			->willReturn(1502);
+			->willReturn(4802);
 
 		$expected = [
 			[

--- a/tests/lib/App/AppStore/Fetcher/FetcherBase.php
+++ b/tests/lib/App/AppStore/Fetcher/FetcherBase.php
@@ -249,7 +249,15 @@ abstract class FetcherBase extends TestCase {
 		$client
 			->expects($this->once())
 			->method('get')
-			->with($this->endpoint)
+			->with(
+				$this->equalTo($this->endpoint),
+				$this->equalTo([
+					'timeout' => 10,
+					'headers' => [
+						'Accept-Encoding' => 'gzip',
+					]
+				])
+			)
 			->willReturn($response);
 		$response
 			->expects($this->once())
@@ -342,7 +350,15 @@ abstract class FetcherBase extends TestCase {
 		$client
 			->expects($this->once())
 			->method('get')
-			->with($this->endpoint)
+			->with(
+				$this->equalTo($this->endpoint),
+				$this->equalTo([
+					'timeout' => 10,
+					'headers' => [
+						'Accept-Encoding' => 'gzip',
+					]
+				])
+			)
 			->willReturn($response);
 		$response
 			->expects($this->once())
@@ -430,7 +446,15 @@ abstract class FetcherBase extends TestCase {
 		$client
 			->expects($this->once())
 			->method('get')
-			->with($this->endpoint)
+			->with(
+				$this->equalTo($this->endpoint),
+				$this->equalTo([
+					'timeout' => 10,
+					'headers' => [
+						'Accept-Encoding' => 'gzip',
+					]
+				])
+			)
 			->willReturn($response);
 		$response
 			->expects($this->once())
@@ -495,7 +519,15 @@ abstract class FetcherBase extends TestCase {
 		$client
 			->expects($this->once())
 			->method('get')
-			->with($this->endpoint)
+			->with(
+				$this->equalTo($this->endpoint),
+				$this->equalTo([
+					'timeout' => 10,
+					'headers' => [
+						'Accept-Encoding' => 'gzip',
+					]
+				])
+			)
 			->willThrowException(new \Exception());
 
 		$this->assertSame([], $this->fetcher->get());
@@ -552,7 +584,8 @@ abstract class FetcherBase extends TestCase {
 				$this->equalTo([
 					'timeout' => 10,
 					'headers' => [
-						'If-None-Match' => '"myETag"'
+						'Accept-Encoding' => 'gzip',
+						'If-None-Match' => '"myETag"',
 					]
 				])
 			)->willReturn($response);
@@ -624,6 +657,7 @@ abstract class FetcherBase extends TestCase {
 				$this->equalTo([
 					'timeout' => 10,
 					'headers' => [
+						'Accept-Encoding' => 'gzip',
 						'If-None-Match' => '"myETag"',
 					]
 				])
@@ -710,6 +744,9 @@ abstract class FetcherBase extends TestCase {
 				$this->equalTo($this->endpoint),
 				$this->equalTo([
 					'timeout' => 10,
+					'headers' => [
+						'Accept-Encoding' => 'gzip',
+					],
 				])
 			)
 			->willReturn($response);


### PR DESCRIPTION
While looking into our apps.nextcloud.com server I realized that the requests are not compressed. Even if the server supports it the clients don't request it. Thus the server sends out 5 MB instead of the compressed 2 MB. This and the raised cache time of 60 instead of 5 minutes should reduce the overall load of the app store server quite a lot.

As those are quite small changes I would backport them down to stable16.