### PR TITLE
Allow gzip encoded requests by default

### DIFF
--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -98,11 +98,12 @@ abstract class Fetcher {
 
 		$options = [
 			'timeout' => 10,
-			'headers' => ['Accept-Encoding' => 'gzip'],
 		];
 
 		if ($ETag !== '') {
-			$options['headers']['If-None-Match'] = $ETag;
+			$options['headers'] = [
+				'If-None-Match' => $ETag,
+			];
 		}
 
 		$client = $this->clientService->newClient();

--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -89,6 +89,10 @@ class Client implements IClient {
 			$options[RequestOptions::HEADERS]['User-Agent'] = 'Nextcloud Server Crawler';
 		}
 
+		if (!isset($options[RequestOptions::HEADERS]['Accept-Encoding'])) {
+			$options[RequestOptions::HEADERS]['Accept-Encoding'] = 'gzip';
+		}
+
 		return $options;
 	}
 

--- a/tests/lib/App/AppStore/Fetcher/FetcherBase.php
+++ b/tests/lib/App/AppStore/Fetcher/FetcherBase.php
@@ -249,15 +249,7 @@ abstract class FetcherBase extends TestCase {
 		$client
 			->expects($this->once())
 			->method('get')
-			->with(
-				$this->equalTo($this->endpoint),
-				$this->equalTo([
-					'timeout' => 10,
-					'headers' => [
-						'Accept-Encoding' => 'gzip',
-					]
-				])
-			)
+			->with($this->endpoint)
 			->willReturn($response);
 		$response
 			->expects($this->once())
@@ -350,15 +342,7 @@ abstract class FetcherBase extends TestCase {
 		$client
 			->expects($this->once())
 			->method('get')
-			->with(
-				$this->equalTo($this->endpoint),
-				$this->equalTo([
-					'timeout' => 10,
-					'headers' => [
-						'Accept-Encoding' => 'gzip',
-					]
-				])
-			)
+			->with($this->endpoint)
 			->willReturn($response);
 		$response
 			->expects($this->once())
@@ -446,15 +430,7 @@ abstract class FetcherBase extends TestCase {
 		$client
 			->expects($this->once())
 			->method('get')
-			->with(
-				$this->equalTo($this->endpoint),
-				$this->equalTo([
-					'timeout' => 10,
-					'headers' => [
-						'Accept-Encoding' => 'gzip',
-					]
-				])
-			)
+			->with($this->endpoint)
 			->willReturn($response);
 		$response
 			->expects($this->once())
@@ -519,15 +495,7 @@ abstract class FetcherBase extends TestCase {
 		$client
 			->expects($this->once())
 			->method('get')
-			->with(
-				$this->equalTo($this->endpoint),
-				$this->equalTo([
-					'timeout' => 10,
-					'headers' => [
-						'Accept-Encoding' => 'gzip',
-					]
-				])
-			)
+			->with($this->endpoint)
 			->willThrowException(new \Exception());
 
 		$this->assertSame([], $this->fetcher->get());
@@ -584,8 +552,7 @@ abstract class FetcherBase extends TestCase {
 				$this->equalTo([
 					'timeout' => 10,
 					'headers' => [
-						'Accept-Encoding' => 'gzip',
-						'If-None-Match' => '"myETag"',
+						'If-None-Match' => '"myETag"'
 					]
 				])
 			)->willReturn($response);
@@ -657,7 +624,6 @@ abstract class FetcherBase extends TestCase {
 				$this->equalTo([
 					'timeout' => 10,
 					'headers' => [
-						'Accept-Encoding' => 'gzip',
 						'If-None-Match' => '"myETag"',
 					]
 				])
@@ -744,9 +710,6 @@ abstract class FetcherBase extends TestCase {
 				$this->equalTo($this->endpoint),
 				$this->equalTo([
 					'timeout' => 10,
-					'headers' => [
-						'Accept-Encoding' => 'gzip',
-					],
 				])
 			)
 			->willReturn($response);

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -292,6 +292,7 @@ class ClientTest extends \Test\TestCase {
 			],
 			'headers' => [
 				'User-Agent' => 'Nextcloud Server Crawler',
+				'Accept-Encoding' => 'gzip',
 			],
 			'timeout' => 30,
 		];
@@ -467,7 +468,8 @@ class ClientTest extends \Test\TestCase {
 		$this->assertEquals([
 			'verify' => \OC::$SERVERROOT . '/resources/config/ca-bundle.crt',
 			'headers' => [
-				'User-Agent' => 'Nextcloud Server Crawler'
+				'User-Agent' => 'Nextcloud Server Crawler',
+				'Accept-Encoding' => 'gzip',
 			],
 			'timeout' => 30,
 		], self::invokePrivate($this->client, 'buildRequestOptions', [[]]));
@@ -502,7 +504,8 @@ class ClientTest extends \Test\TestCase {
 				'https' => 'foo'
 			],
 			'headers' => [
-				'User-Agent' => 'Nextcloud Server Crawler'
+				'User-Agent' => 'Nextcloud Server Crawler',
+				'Accept-Encoding' => 'gzip',
 			],
 			'timeout' => 30,
 		], self::invokePrivate($this->client, 'buildRequestOptions', [[]]));
@@ -538,7 +541,8 @@ class ClientTest extends \Test\TestCase {
 				'no' => ['bar']
 			],
 			'headers' => [
-				'User-Agent' => 'Nextcloud Server Crawler'
+				'User-Agent' => 'Nextcloud Server Crawler',
+				'Accept-Encoding' => 'gzip',
 			],
 			'timeout' => 30,
 		], self::invokePrivate($this->client, 'buildRequestOptions', [[]]));


### PR DESCRIPTION
As requested by @ChristophWurst in https://github.com/nextcloud/server/pull/21050#issuecomment-631322335

I reverted the app fetcher specific entries for the encoding part to not need to maintain multiple code paths for this.