### PR TITLE
Fix deadlock in SCSSCacher

### DIFF
--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -175,6 +175,10 @@ class SCSSCacher {
 				$retry++;
 			}
 			$this->logger->debug('SCSSCacher: Giving up scss caching for '.$lockKey, ['app' => 'core']);
+			
+			// Cleaning lock
+			$this->lockingCache->remove($lockKey);
+			
 			return false;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/pull/15794#issuecomment-631573831


![Screenshot Capture - 2020-05-20 - 18-09-19](https://user-images.githubusercontent.com/44934014/82469991-0d43bf80-9ac5-11ea-9e2f-09c6e0a639f2.png)

---

It seems to me that the lock needs to be released in this return path too, otherwise it would create a deadlock on every next run. Please double check for me, I'm wholly unfamiliar with the code base. Either way, it solves the slowness in the production deployment I maintain.

It would be great if this change could be backported to 18.x and previous releases.