### PR TITLE
18.0.5 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(18, 0, 4, 2);
+$OC_Version = array(18, 0, 5, 0);
 
 // The human readable string
-$OC_VersionString = '18.0.4';
+$OC_VersionString = '18.0.5 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #20574 [stable18] dont show remote and email options if we have an exact match for local user email
* #20578 [stable18] Array offset error due to empty file versions array
* #20588 [stable18] Set fileInfo correctly for LegacyTabs
* #20596 [stable18] Fix Sharing recommendation user display
* #20602 [stable18] Fix IE11 upload fallback methods
* #20635 [stable18] Allow specifying a default expiration date
* #20647 [stable18] Fix security header setting in .htaccess by adding 'onsuccess unset'
* #20680 [stable18] Only catch anonymous OPTIONS for Office
* #20682 [stable18] Adhere to EMailTemplate interface in constructor call.
* #20701 [stable18] Don't remove last user in ldap group when limit is -1
* #20703 [stable18] Add tests for update notification controller for non-default updater …
* #20740 [stable18] Allow to navigate to others with access from the sidebar
* #20747 [stable18] Add a wrapper to fall back to the share owner on public shares
* #20750 [stable18] Fix public layout header title & description
* #20763 [stable18] Fix Argon2 options checks
* #20774 [stable18] dont try to update storage mtime if we can't get the mtime
* #20802 [stable18] Exclude groups from sharing: Skip delete groups
* #20805 [stable18] Correctly hide table headers in filepicker
* #20808 [stable18] clarified trash bin retention by storage shortage override in config.sample.php
* #20830 [stable18] Fix filtering our owner & current user from shares
* #20877 [stable18] Fix languages empty array
* #20881 [stable18] add locking to resolve concurent move to trashbin conflicts
* #20886 [stable18] Fix color-text-maxcontrast not passing WCAG AA
* #20924 [stable18] Use random_bytes
* #20955 [stable18] Proxy server could cache http response when it is not private
* #20965 [stable18] Enable fseek for files in S3 storage
* #20975 Bump handlebars from 4.5.3 to 4.6.0 in /build
* #20992 [stable18] update icewind/smb to 3.2.4
* #20994 [stable18] Fix issues with Keystone auth v3 in files_external app
* #20996 [stable18] Don't load text file preview when text app is available (Fixes: #20615)
* #21030 [stable18] Remove entries from locales.json incompatible with punic
* #21053 [stable18] Caching and compression for app store requests
* #21096 [stable18] Do not read certificate bundle from data dir by default
* #21115 [stable18] use the loginname to verify the old password in user password changes
* #21132 [stable18] Move the password confirmation form template to post
* [activity#457](https://github.com/nextcloud/activity/pull/457) [stable18] Use the usermountcache to get all users who have access to a file
* [files_pdfviewer#181](https://github.com/nextcloud/files_pdfviewer/pull/181) [stable18] Prevent download, printing and text selection when download is hidden
* [notifications#647](https://github.com/nextcloud/notifications/pull/647) Bump handlebars from 4.5.3 to 4.6.0
* [viewer#477](https://github.com/nextcloud/viewer/pull/477) [stable18] Revert "Delete menu-sidebar-white.svg"


Pending PRs:

* [ ] #20842 [stable18] Do not filter id matching userId on non-user-share shares @backportbot-nextcloud
* [x] #21109 [stable18] Fix resharing of federated shares that were created out of links @juliushaertl
* [x] #21127 [stable18] Make the translation sanitization optional @ChristophWurst
* [ ] #21129 [stable18] simplify getGroups, fixing wrong chunking logic @backportbot-nextcloud
* [ ] [3rdparty#442](https://github.com/nextcloud/3rdparty/pull/442) [stable18] Fix Trying to access array offset on value of type null notice @backportbot-nextcloud
