### PR TITLE
17.0.7 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(17, 0, 6, 2);
+$OC_Version = array(17, 0, 7, 0);
 
 // The human readable string
-$OC_VersionString = '17.0.6';
+$OC_VersionString = '17.0.7 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #19496 Bump handlebars from 4.1.2 to 4.3.0 in /build
* #20579 Array offset error due to empty file versions array
* #20603 Fix IE11 upload fallback methods
* #20620 Fix jsunit tests
* #20681 Only catch anonymous OPTIONS for Office
* #20683 Adhere to EMailTemplate interface in constructor call.
* #20704 Add tests for update notification controller for non-default updater …
* #20748 Add a wrapper to fall back to the share owner on public shares
* #20751 Fix public layout header title & description
* #20764 Fix Argon2 options checks
* #20775 Dont try to update storage mtime if we can't get the mtime
* #20809 Clarified trash bin retention by storage shortage override in config.sample.php
* #20882 Add locking to resolve concurent move to trashbin conflicts
* #20925 Use random_bytes
* #20966 Enable fseek for files in S3 storage
* #20977 Bump handlebars from 4.3.0 to 4.6.0 in /build
* #20986 Proxy server could cache http response when it is not private
* #20993 Update icewind/smb to 3.2.4
* #21055 Caching and compression for app store requests
* #21097 Do not read certificate bundle from data dir by default
* #21104 Don't remove last user in ldap group when limit is -1
* #21116 Use the loginname to verify the old password in user password changes
* [files_pdfviewer#182](https://github.com/nextcloud/files_pdfviewer/pull/182) Prevent download, printing and text selection when download is hidden


Pending PRs:

* [ ] #20803 Exclude groups from sharing: Skip delete groups @backportbot-nextcloud
* [x] #21110 Fix resharing of federated shares that were created out of links @juliushaertl
* [ ] #21130 Simplify getGroups, fixing wrong chunking logic @backportbot-nextcloud
