### PR TITLE
Clear the statscache before fetching the metadata

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -156,6 +156,7 @@ class Local extends \OC\Files\Storage\Common {
 	 */
 	public function getMetaData($path) {
 		$fullPath = $this->getSourcePath($path);
+		clearstatcache();
 		$stat = @stat($fullPath);
 		if (!$stat) {
 			return null;


### PR DESCRIPTION
Else if a lot of writes happen. It might happen that an old stat result
is used. Resulting in a wrong file size for the file. For example the
text app when a lot of people edit at the same time.

@icewind1991 can you checkif it makes sense? As it is hard to trigger it manually