### PR TITLE
Fix releasing a shared lock multiple times

### DIFF
--- a/lib/private/Lock/MemcacheLockingProvider.php
+++ b/lib/private/Lock/MemcacheLockingProvider.php
@@ -94,8 +94,12 @@ class MemcacheLockingProvider extends AbstractLockingProvider {
 	 */
 	public function releaseLock(string $path, int $type) {
 		if ($type === self::LOCK_SHARED) {
+			$ownSharedLockCount = $this->getOwnSharedLockCount($path);
 			$newValue = 0;
-			if ($this->getOwnSharedLockCount($path) === 1) {
+			if ($ownSharedLockCount === 0) { // if we are not holding the lock, don't try to release it
+				return;
+			}
+			if ($ownSharedLockCount === 1) {
 				$removed = $this->memcache->cad($path, 1); // if we're the only one having a shared lock we can remove it in one go
 				if (!$removed) { //someone else also has a shared lock, decrease only
 					$newValue = $this->memcache->dec($path);


### PR DESCRIPTION
This patch makes `MemcacheLockingProvider` handle multiple releases of the same shared lock gracefully.

Previously, the lock will get negative values that cause problems as seen in https://github.com/nextcloud/server/issues/21073

During PUT requests, https://github.com/nextcloud/server/blob/5e35594cb6a8eeb89197ae2ac044bc352bbaba38/apps/dav/lib/Connector/Sabre/Directory.php#L157 releases a lock once, and https://github.com/nextcloud/server/blob/5e35594cb6a8eeb89197ae2ac044bc352bbaba38/apps/dav/lib/Connector/Sabre/LockPlugin.php#L83 releases the same lock again (see the issue); `LockPlugin` never acquired the lock.

`MemcacheLockingProvider` already had some logic to handle multiple releases (negative going lock values), but it was subject to a race condition.