### PR TITLE
Do not read certificate bundle from data dir by default

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -97,18 +97,18 @@ class Client implements IClient {
 	}
 
 	private function getCertBundle(): string {
-		if ($this->certificateManager->listCertificates() !== []) {
-			return $this->certificateManager->getAbsoluteBundlePath();
-		}
-
 		// If the instance is not yet setup we need to use the static path as
 		// $this->certificateManager->getAbsoluteBundlePath() tries to instantiiate
 		// a view
-		if ($this->config->getSystemValue('installed', false)) {
-			return $this->certificateManager->getAbsoluteBundlePath(null);
+		if ($this->config->getSystemValue('installed', false) === false) {
+			return \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';
 		}
 
-		return \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';
+		if ($this->certificateManager->listCertificates() === []) {
+			return \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';
+		}
+
+		return $this->certificateManager->getAbsoluteBundlePath();
 	}
 
 	/**

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -461,9 +461,8 @@ class ClientTest extends \Test\TestCase {
 			->with('installed', false)
 			->willReturn(false);
 		$this->certificateManager
-			->expects($this->once())
-			->method('listCertificates')
-			->willReturn([]);
+			->expects($this->never())
+			->method('listCertificates');
 
 		$this->assertEquals([
 			'verify' => \OC::$SERVERROOT . '/resources/config/ca-bundle.crt',


### PR DESCRIPTION
Before the resources/config/ca-bundle.crt was only used when the list of custom
certificates was empty and the instance was not installed. But it should also
be used when the list is empty and the instance is installed.

This is inverting the logic to stop if the instance is not installed to use the
default bundle. And it also does this when the list is empty.

Noticed while debugging user creation on an instance with object storage.