### PR TITLE
[stable17] Fix resharing of federated shares that were created out of links

### DIFF
--- a/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php
+++ b/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php
@@ -48,6 +48,7 @@ use OCP\ISession;
 use OCP\IUserSession;
 use OCP\Share\IManager;
 use OCP\Util;
+use OCP\Share\IShare;
 
 /**
  * Class MountPublicLinkController
@@ -161,6 +162,7 @@ class MountPublicLinkController extends Controller {
 		}
 
 		$share->setSharedWith($shareWith);
+		$share->setShareType(IShare::TYPE_REMOTE);
 
 		try {
 			$this->federatedShareProvider->create($share);

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -470,15 +470,18 @@ class ShareAPIController extends OCSController {
 					throw new OCSNotFoundException($this->l->t('Public upload is only possible for publicly shared folders'));
 				}
 
-				$share->setPermissions(
-					Constants::PERMISSION_READ |
+				$permissions = Constants::PERMISSION_READ |
 					Constants::PERMISSION_CREATE |
 					Constants::PERMISSION_UPDATE |
-					Constants::PERMISSION_DELETE
-				);
+					Constants::PERMISSION_DELETE;
 			} else {
-				$share->setPermissions(Constants::PERMISSION_READ);
+				$permissions = Constants::PERMISSION_READ;
 			}
+			// TODO: It might make sense to have a dedicated setting to allow/deny converting link shares into federated ones
+			if ($this->shareManager->outgoingServer2ServerSharesAllowed()) {
+				$permissions |= Constants::PERMISSION_SHARE;
+			}
+			$share->setPermissions($permissions);
 
 			// Set password
 			if ($password !== '') {

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -477,10 +477,12 @@ class ShareAPIController extends OCSController {
 			} else {
 				$permissions = Constants::PERMISSION_READ;
 			}
+
 			// TODO: It might make sense to have a dedicated setting to allow/deny converting link shares into federated ones
-			if ($this->shareManager->outgoingServer2ServerSharesAllowed()) {
+			if (($permissions & Constants::PERMISSION_READ) && $this->shareManager->outgoingServer2ServerSharesAllowed()) {
 				$permissions |= Constants::PERMISSION_SHARE;
 			}
+
 			$share->setPermissions($permissions);
 
 			// Set password
@@ -906,6 +908,11 @@ class ShareAPIController extends OCSController {
 			}
 
 			if ($newPermissions !== null) {
+				// TODO: It might make sense to have a dedicated setting to allow/deny converting link shares into federated ones
+				if (($newPermissions & Constants::PERMISSION_READ) && $this->shareManager->outgoingServer2ServerSharesAllowed()) {
+					$newPermissions |= Constants::PERMISSION_SHARE;
+				}
+
 				$share->setPermissions($newPermissions);
 				$permissions = $newPermissions;
 			}

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -203,7 +203,9 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 
 		$data = $result->getData();
-		$this->assertEquals(1, $data['permissions']);
+		$this->assertEquals(\OCP\Constants::PERMISSION_READ |
+			\OCP\Constants::PERMISSION_SHARE,
+			$data['permissions']);
 		$this->assertEmpty($data['expiration']);
 		$this->assertTrue(is_string($data['token']));
 
@@ -228,7 +230,8 @@ class ApiTest extends TestCase {
 			\OCP\Constants::PERMISSION_READ |
 			\OCP\Constants::PERMISSION_CREATE |
 			\OCP\Constants::PERMISSION_UPDATE |
-			\OCP\Constants::PERMISSION_DELETE,
+			\OCP\Constants::PERMISSION_DELETE |
+			\OCP\Constants::PERMISSION_SHARE,
 			$data['permissions']
 		);
 		$this->assertEmpty($data['expiration']);

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -977,7 +977,8 @@ class ApiTest extends TestCase {
 			\OCP\Constants::PERMISSION_READ |
 			\OCP\Constants::PERMISSION_CREATE |
 			\OCP\Constants::PERMISSION_UPDATE |
-			\OCP\Constants::PERMISSION_DELETE,
+			\OCP\Constants::PERMISSION_DELETE |
+			\OCP\Constants::PERMISSION_SHARE,
 			$share1->getPermissions()
 		);
 

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -90,7 +90,7 @@ Feature: sharing
     And the HTTP status code should be "200"
     And Share fields of last share match with
       | id | A_NUMBER |
-      | permissions | 15 |
+      | permissions | 31 |
       | expiration | +3 days |
       | url | AN_URL |
       | token | A_TOKEN |
@@ -128,7 +128,7 @@ Feature: sharing
       | share_type | 3 |
       | file_source | A_NUMBER |
       | file_target | /FOLDER |
-      | permissions | 1 |
+      | permissions | 17 |
       | stime | A_NUMBER |
       | expiration | +3 days |
       | token | A_TOKEN |
@@ -160,7 +160,7 @@ Feature: sharing
       | share_type | 3 |
       | file_source | A_NUMBER |
       | file_target | /FOLDER |
-      | permissions | 1 |
+      | permissions | 17 |
       | stime | A_NUMBER |
       | token | A_TOKEN |
       | storage | A_NUMBER |

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -191,7 +191,7 @@ Feature: sharing
       | share_type | 3 |
       | file_source | A_NUMBER |
       | file_target | /FOLDER |
-      | permissions | 15 |
+      | permissions | 31 |
       | stime | A_NUMBER |
       | token | A_TOKEN |
       | storage | A_NUMBER |
@@ -253,7 +253,7 @@ Feature: sharing
       | share_type | 3 |
       | file_source | A_NUMBER |
       | file_target | /FOLDER |
-      | permissions | 15 |
+      | permissions | 31 |
       | stime | A_NUMBER |
       | token | A_TOKEN |
       | storage | A_NUMBER |

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -537,11 +537,6 @@ class Manager implements IManager {
 			throw new \Exception('Link sharing is not allowed');
 		}
 
-		// Link shares by definition can't have share permissions
-		if ($share->getPermissions() & \OCP\Constants::PERMISSION_SHARE) {
-			throw new \InvalidArgumentException('Link shares can’t have reshare permissions');
-		}
-
 		// Check if public upload is allowed
 		if (!$this->shareApiLinkAllowPublicUpload() &&
 			($share->getPermissions() & (\OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE))) {

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1363,24 +1363,6 @@ class ManagerTest extends \Test\TestCase {
 
 	/**
 	 * @expectedException Exception
-	 * @expectedExceptionMessage Link shares can’t have reshare permissions
-	 */
-	public function testLinkCreateChecksSharePermissions() {
-		$share = $this->manager->newShare();
-
-		$share->setPermissions(\OCP\Constants::PERMISSION_SHARE);
-
-		$this->config
-			->method('getAppValue')
-			->will($this->returnValueMap([
-				['core', 'shareapi_allow_links', 'yes', 'yes'],
-			]));
-
-		self::invokePrivate($this->manager, 'linkCreateChecks', [$share]);
-	}
-
-	/**
-	 * @expectedException Exception
 	 * @expectedExceptionMessage Public upload is not allowed
 	 */
 	public function testLinkCreateChecksNoPublicUpload() {


### PR DESCRIPTION
Combined backport of #19793 #20846

#20726 is not needed since 17 still doesn't have the vue sidebar and the old sharing tab seems to handle the additional share permission properly already.