### PR TITLE
Remove db prefix option from cli install command

### DIFF
--- a/autotest-external.sh
+++ b/autotest-external.sh
@@ -148,7 +148,7 @@ EOF
 
 	# trigger installation
 	echo "Installing ...."
-	./occ maintenance:install -vvv --database=$1 --database-name=$DATABASENAME --database-host=localhost --database-user=$DATABASEUSER --database-pass=owncloud --database-table-prefix=oc_ --admin-user=$ADMINLOGIN --admin-pass=admin --data-dir=$DATADIR
+	./occ maintenance:install -vvv --database=$1 --database-name=$DATABASENAME --database-host=localhost --database-user=$DATABASEUSER --database-pass=owncloud --admin-user=$ADMINLOGIN --admin-pass=admin --data-dir=$DATADIR
 
 	./occ config:system:set --value true --type boolean allow_local_remote_servers
 

--- a/autotest.sh
+++ b/autotest.sh
@@ -355,7 +355,7 @@ function execute_tests {
 
 	# trigger installation
 	echo "Installing ...."
-	"$PHP" ./occ maintenance:install -vvv --database="$_DB" --database-name="$DATABASENAME" --database-host="$DATABASEHOST" --database-user="$DATABASEUSER" --database-pass=owncloud --database-table-prefix=oc_ --admin-user="$ADMINLOGIN" --admin-pass=admin --data-dir="$DATADIR"
+	"$PHP" ./occ maintenance:install -vvv --database="$_DB" --database-name="$DATABASENAME" --database-host="$DATABASEHOST" --database-user="$DATABASEUSER" --database-pass=owncloud --admin-user="$ADMINLOGIN" --admin-pass=admin --data-dir="$DATADIR"
 
 	#test execution
 	echo "Testing with $DB ..."

--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -66,7 +66,6 @@ class Install extends Command {
 			->addOption('database-port', null, InputOption::VALUE_REQUIRED, 'Port the database is listening on')
 			->addOption('database-user', null, InputOption::VALUE_REQUIRED, 'User name to connect to the database')
 			->addOption('database-pass', null, InputOption::VALUE_OPTIONAL, 'Password of the database user', null)
-			->addOption('database-table-prefix', null, InputOption::VALUE_OPTIONAL, 'Prefix for all tables (default: oc_)', null)
 			->addOption('database-table-space', null, InputOption::VALUE_OPTIONAL, 'Table space of the database (oci only)', null)
 			->addOption('admin-user', null, InputOption::VALUE_REQUIRED, 'User name of the admin account', 'admin')
 			->addOption('admin-pass', null, InputOption::VALUE_REQUIRED, 'Password of the admin account')
@@ -139,11 +138,6 @@ class Install extends Command {
 			// Append the port to the host so it is the same as in the config (there is no dbport config)
 			$dbHost .= ':' . $dbPort;
 		}
-		$dbTablePrefix = 'oc_';
-		if ($input->hasParameterOption('--database-table-prefix')) {
-			$dbTablePrefix = (string) $input->getOption('database-table-prefix');
-			$dbTablePrefix = trim($dbTablePrefix);
-		}
 		if ($input->hasParameterOption('--database-pass')) {
 			$dbPass = (string) $input->getOption('database-pass');
 		}
@@ -188,7 +182,6 @@ class Install extends Command {
 			'dbpass' => $dbPass,
 			'dbname' => $dbName,
 			'dbhost' => $dbHost,
-			'dbtableprefix' => $dbTablePrefix,
 			'adminlogin' => $adminLogin,
 			'adminpass' => $adminPassword,
 			'adminemail' => $adminEmail,


### PR DESCRIPTION
The web UI has no option and this is still causing issues while not fixing anything.
There are indexes without the prefix so multiple installations in one DB don't work anyway,
and setting it to values longer than 3 chars breaks apps from time to time:
https://github.com/nextcloud/spreed/issues/3593
https://github.com/nextcloud/social/issues/850

So instead of decreasing the limit as proposed in #20998 let's just get rid of it

Fix #20998