### PR TITLE
Simplify text variables from 4 to 2, map -lighter to -maxcontrast

### DIFF
--- a/core/css/css-variables.scss
+++ b/core/css/css-variables.scss
@@ -23,8 +23,8 @@
 	--color-success: $color-success;
 
 	--color-text-maxcontrast: $color-text-maxcontrast;
-	--color-text-light: $color-text-light;
-	--color-text-lighter: $color-text-lighter;
+	--color-text-light: $color-main-text;
+	--color-text-lighter: $color-text-maxcontrast;
 
 	--image-logo: $image-logo;
 	--image-login-background: $image-login-background;

--- a/core/css/variables.scss
+++ b/core/css/variables.scss
@@ -61,8 +61,8 @@ $color-yellow: #FC0;
 // min. color contrast for normal text on white background according to WCAG AA
 // (Works as well: color: #000; opacity: 0.57;)
 $color-text-maxcontrast: nc-lighten($color-main-text, 33%) !default;
-$color-text-light: nc-lighten($color-main-text, 15%) !default;
-$color-text-lighter: nc-lighten($color-main-text, 30%) !default;
+$color-text-light: $color-main-text !default;
+$color-text-lighter: $color-text-maxcontrast !default;
 
 $image-logo: url('../img/logo/logo.svg?v=1') !default;
 $image-login-background: url('../img/background.png?v=2') !default;


### PR DESCRIPTION
As said in: **Fix color-text-maxcontrast not passing WCAG AA #20853**

> I would say since the values are so similar, we limit the text variables to just color-main-text and color-text-maxcontrast. I would make both "light" and "lighter" map to "color-text-maxcontrast" for compatibility.

Please review @nextcloud/designers 