### PR TITLE
Improve traces of invalid token exceptions

### DIFF
--- a/lib/private/Authentication/Exceptions/InvalidTokenException.php
+++ b/lib/private/Authentication/Exceptions/InvalidTokenException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *

--- a/lib/private/Authentication/Token/DefaultTokenProvider.php
+++ b/lib/private/Authentication/Token/DefaultTokenProvider.php
@@ -117,7 +117,7 @@ class DefaultTokenProvider implements IProvider {
 	 */
 	public function updateToken(IToken $token) {
 		if (!($token instanceof DefaultToken)) {
-			throw new InvalidTokenException();
+			throw new InvalidTokenException("Invalid token type");
 		}
 		$this->mapper->update($token);
 	}
@@ -130,7 +130,7 @@ class DefaultTokenProvider implements IProvider {
 	 */
 	public function updateTokenActivity(IToken $token) {
 		if (!($token instanceof DefaultToken)) {
-			throw new InvalidTokenException();
+			throw new InvalidTokenException("Invalid token type");
 		}
 		/** @var DefaultToken $token */
 		$now = $this->time->getTime();
@@ -157,7 +157,7 @@ class DefaultTokenProvider implements IProvider {
 		try {
 			$token = $this->mapper->getToken($this->hashToken($tokenId));
 		} catch (DoesNotExistException $ex) {
-			throw new InvalidTokenException();
+			throw new InvalidTokenException("Token does not exist", 0, $ex);
 		}
 
 		if ((int)$token->getExpires() !== 0 && $token->getExpires() < $this->time->getTime()) {
@@ -179,7 +179,7 @@ class DefaultTokenProvider implements IProvider {
 		try {
 			$token = $this->mapper->getTokenById($tokenId);
 		} catch (DoesNotExistException $ex) {
-			throw new InvalidTokenException();
+			throw new InvalidTokenException("Token with ID $tokenId does not exist", 0, $ex);
 		}
 
 		if ((int)$token->getExpires() !== 0 && $token->getExpires() < $this->time->getTime()) {
@@ -241,7 +241,7 @@ class DefaultTokenProvider implements IProvider {
 	 */
 	public function setPassword(IToken $token, string $tokenId, string $password) {
 		if (!($token instanceof DefaultToken)) {
-			throw new InvalidTokenException();
+			throw new InvalidTokenException("Invalid token type");
 		}
 		/** @var DefaultToken $token */
 		$token->setPassword($this->encryptPassword($password, $tokenId));
@@ -334,13 +334,13 @@ class DefaultTokenProvider implements IProvider {
 		} catch (Exception $ex) {
 			// Delete the invalid token
 			$this->invalidateToken($token);
-			throw new InvalidTokenException();
+			throw new InvalidTokenException("Can not decrypt token password: " . $ex->getMessage(), 0, $ex);
 		}
 	}
 
 	public function markPasswordInvalid(IToken $token, string $tokenId) {
 		if (!($token instanceof DefaultToken)) {
-			throw new InvalidTokenException();
+			throw new InvalidTokenException("Invalid token type");
 		}
 
 		//No need to mark as invalid. We just invalide default tokens

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -103,7 +103,7 @@ class PublicKeyTokenProvider implements IProvider {
 				$token = $this->mapper->getToken($this->hashToken($tokenId));
 				$this->cache[$token->getToken()] = $token;
 			} catch (DoesNotExistException $ex) {
-				throw new InvalidTokenException();
+				throw new InvalidTokenException("Token does not exist: " . $ex->getMessage(), 0, $ex);
 			}
 		}
 
@@ -127,7 +127,7 @@ class PublicKeyTokenProvider implements IProvider {
 		try {
 			$token = $this->mapper->getTokenById($tokenId);
 		} catch (DoesNotExistException $ex) {
-			throw new InvalidTokenException();
+			throw new InvalidTokenException("Token with ID $tokenId does not exist: " . $ex->getMessage(), 0, $ex);
 		}
 
 		if ((int)$token->getExpires() !== 0 && $token->getExpires() < $this->time->getTime()) {
@@ -152,7 +152,7 @@ class PublicKeyTokenProvider implements IProvider {
 		$token = $this->getToken($oldSessionId);
 
 		if (!($token instanceof PublicKeyToken)) {
-			throw new InvalidTokenException();
+			throw new InvalidTokenException("Invalid token type");
 		}
 
 		$password = null;
@@ -203,7 +203,7 @@ class PublicKeyTokenProvider implements IProvider {
 		$this->cache->clear();
 
 		if (!($token instanceof PublicKeyToken)) {
-			throw new InvalidTokenException();
+			throw new InvalidTokenException("Invalid token type");
 		}
 		$this->mapper->update($token);
 	}
@@ -212,7 +212,7 @@ class PublicKeyTokenProvider implements IProvider {
 		$this->cache->clear();
 
 		if (!($token instanceof PublicKeyToken)) {
-			throw new InvalidTokenException();
+			throw new InvalidTokenException("Invalid token type");
 		}
 		/** @var DefaultToken $token */
 		$now = $this->time->getTime();
@@ -229,7 +229,7 @@ class PublicKeyTokenProvider implements IProvider {
 
 	public function getPassword(IToken $token, string $tokenId): string {
 		if (!($token instanceof PublicKeyToken)) {
-			throw new InvalidTokenException();
+			throw new InvalidTokenException("Invalid token type");
 		}
 
 		if ($token->getPassword() === null) {
@@ -247,7 +247,7 @@ class PublicKeyTokenProvider implements IProvider {
 		$this->cache->clear();
 
 		if (!($token instanceof PublicKeyToken)) {
-			throw new InvalidTokenException();
+			throw new InvalidTokenException("Invalid token type");
 		}
 
 		// When changing passwords all temp tokens are deleted
@@ -266,7 +266,7 @@ class PublicKeyTokenProvider implements IProvider {
 		$this->cache->clear();
 
 		if (!($token instanceof PublicKeyToken)) {
-			throw new InvalidTokenException();
+			throw new InvalidTokenException("Invalid token type");
 		}
 
 		// Decrypt private key with oldTokenId
@@ -295,7 +295,7 @@ class PublicKeyTokenProvider implements IProvider {
 		} catch (\Exception $ex) {
 			// Delete the invalid token
 			$this->invalidateToken($token);
-			throw new InvalidTokenException();
+			throw new InvalidTokenException("Could not decrypt token password: " . $ex->getMessage(), 0, $ex);
 		}
 	}
 
@@ -399,7 +399,7 @@ class PublicKeyTokenProvider implements IProvider {
 		$this->cache->clear();
 
 		if (!($token instanceof PublicKeyToken)) {
-			throw new InvalidTokenException();
+			throw new InvalidTokenException("Invalid token type");
 		}
 
 		$token->setPasswordInvalid(true);

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -531,6 +531,10 @@ class Session implements IUserSession, Emitter {
 		} catch (ExpiredTokenException $e) {
 			throw $e;
 		} catch (InvalidTokenException $ex) {
+			$this->logger->logException($ex, [
+				'level' => ILogger::DEBUG,
+				'message' => 'Token is not valid: ' . $ex->getMessage(),
+			]);
 			return false;
 		}
 	}


### PR DESCRIPTION
This should help with issues like https://github.com/nextcloud/twofactor_totp/issues/404#issuecomment-633916153.

In general a catch-and-throw-new should transport the previous exception. Otherwise the trace gets lost and debugging is more complicated than it needs to be.