### PR TITLE
Add a capability when file comments are enabled

### DIFF
--- a/apps/comments/composer/composer/autoload_classmap.php
+++ b/apps/comments/composer/composer/autoload_classmap.php
@@ -11,6 +11,7 @@ return array(
     'OCA\\Comments\\Activity\\Provider' => $baseDir . '/../lib/Activity/Provider.php',
     'OCA\\Comments\\Activity\\Setting' => $baseDir . '/../lib/Activity/Setting.php',
     'OCA\\Comments\\AppInfo\\Application' => $baseDir . '/../lib/AppInfo/Application.php',
+    'OCA\\Comments\\Capabilities' => $baseDir . '/../lib/Capabilities.php',
     'OCA\\Comments\\Collaboration\\CommentersSorter' => $baseDir . '/../lib/Collaboration/CommentersSorter.php',
     'OCA\\Comments\\Controller\\Notifications' => $baseDir . '/../lib/Controller/Notifications.php',
     'OCA\\Comments\\EventHandler' => $baseDir . '/../lib/EventHandler.php',

--- a/apps/comments/composer/composer/autoload_static.php
+++ b/apps/comments/composer/composer/autoload_static.php
@@ -26,6 +26,7 @@ class ComposerStaticInitComments
         'OCA\\Comments\\Activity\\Provider' => __DIR__ . '/..' . '/../lib/Activity/Provider.php',
         'OCA\\Comments\\Activity\\Setting' => __DIR__ . '/..' . '/../lib/Activity/Setting.php',
         'OCA\\Comments\\AppInfo\\Application' => __DIR__ . '/..' . '/../lib/AppInfo/Application.php',
+        'OCA\\Comments\\Capabilities' => __DIR__ . '/..' . '/../lib/Capabilities.php',
         'OCA\\Comments\\Collaboration\\CommentersSorter' => __DIR__ . '/..' . '/../lib/Collaboration/CommentersSorter.php',
         'OCA\\Comments\\Controller\\Notifications' => __DIR__ . '/..' . '/../lib/Controller/Notifications.php',
         'OCA\\Comments\\EventHandler' => __DIR__ . '/..' . '/../lib/EventHandler.php',

--- a/apps/comments/lib/AppInfo/Application.php
+++ b/apps/comments/lib/AppInfo/Application.php
@@ -27,6 +27,7 @@
 
 namespace OCA\Comments\AppInfo;
 
+use OCA\Comments\Capabilities;
 use OCA\Comments\Controller\Notifications;
 use OCA\Comments\EventHandler;
 use OCA\Comments\JSSettingsHelper;
@@ -67,6 +68,7 @@ class Application extends App {
 		$this->registerNotifier();
 		$this->registerCommentsEventHandler();
 
+		$this->getContainer()->registerCapability(Capabilities::class);
 		$server->getSearch()->registerProvider(Provider::class, ['apps' => ['files']]);
 	}
 

--- a/apps/comments/lib/Capabilities.php
+++ b/apps/comments/lib/Capabilities.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Comments;
+
+use OCP\Capabilities\ICapability;
+
+class Capabilities implements ICapability {
+	public function getCapabilities(): array {
+		return [
+			'files' => [
+				'comments' => true,
+			]
+		];
+	}
+}


### PR DESCRIPTION
Fix nextcloud/files-clients#108 

So I'm unsure, we could backport it, but that still means you need to do a version check. So maybe instead of checking a minor version we just have this from 20 onwards?