### PR TITLE
Search also the email and displayname in user mangement for groups

### DIFF
--- a/build/integration/features/bootstrap/Provisioning.php
+++ b/build/integration/features/bootstrap/Provisioning.php
@@ -70,6 +70,23 @@ trait Provisioning {
 	}
 
 	/**
+	 * @Given /^user "([^"]*)" with displayname "([^"]*)" exists$/
+	 * @param string $user
+	 */
+	public function assureUserWithDisplaynameExists($user, $displayname) {
+		try {
+			$this->userExists($user);
+		} catch (\GuzzleHttp\Exception\ClientException $ex) {
+			$previous_user = $this->currentUser;
+			$this->currentUser = "admin";
+			$this->creatingTheUser($user, $displayname);
+			$this->currentUser = $previous_user;
+		}
+		$this->userExists($user);
+		Assert::assertEquals(200, $this->response->getStatusCode());
+	}
+
+	/**
 	 * @Given /^user "([^"]*)" does not exist$/
 	 * @param string $user
 	 */
@@ -93,7 +110,7 @@ trait Provisioning {
 		}
 	}
 
-	public function creatingTheUser($user) {
+	public function creatingTheUser($user, $displayname = '') {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users";
 		$client = new Client();
 		$options = [];
@@ -105,6 +122,9 @@ trait Provisioning {
 			'userid' => $user,
 			'password' => '123456'
 		];
+		if ($displayname !== '') {
+			$options['form_params']['displayName'] = $displayname;
+		}
 		$options['headers'] = [
 			'OCS-APIREQUEST' => 'true',
 		];
@@ -541,6 +561,20 @@ trait Provisioning {
 	}
 
 	/**
+	 * @Then /^detailed users returned are$/
+	 * @param \Behat\Gherkin\Node\TableNode|null $usersList
+	 */
+	public function theDetailedUsersShouldBe($usersList) {
+		if ($usersList instanceof \Behat\Gherkin\Node\TableNode) {
+			$users = $usersList->getRows();
+			$usersSimplified = $this->simplifyArray($users);
+			$respondedArray = $this->getArrayOfDetailedUsersResponded($this->response);
+			$respondedArray = array_keys($respondedArray);
+			Assert::assertEquals($usersSimplified, $respondedArray);
+		}
+	}
+
+	/**
 	 * @Then /^groups returned are$/
 	 * @param \Behat\Gherkin\Node\TableNode|null $groupsList
 	 */
@@ -595,6 +629,18 @@ trait Provisioning {
 	 */
 	public function getArrayOfUsersResponded($resp) {
 		$listCheckedElements = simplexml_load_string($resp->getBody())->data[0]->users[0]->element;
+		$extractedElementsArray = json_decode(json_encode($listCheckedElements), 1);
+		return $extractedElementsArray;
+	}
+
+	/**
+	 * Parses the xml answer to get the array of detailed users returned.
+	 *
+	 * @param ResponseInterface $resp
+	 * @return array
+	 */
+	public function getArrayOfDetailedUsersResponded($resp) {
+		$listCheckedElements = simplexml_load_string($resp->getBody())->data[0]->users;
 		$extractedElementsArray = json_decode(json_encode($listCheckedElements), 1);
 		return $extractedElementsArray;
 	}

--- a/build/integration/features/provisioning-v2.feature
+++ b/build/integration/features/provisioning-v2.feature
@@ -19,3 +19,17 @@ Feature: provisioning
     Then the OCS status code should be "998"
     And the HTTP status code should be "404"
 
+  Scenario: Searching by displayname in groups
+    Given As an "admin"
+    And user "user-in-group" with displayname "specific-name" exists
+    And user "user-in-group2" with displayname "another-name" exists
+    And user "user-not-in-group" with displayname "specific-name" exists
+    And user "user-not-in-group2" with displayname "another-name" exists
+    And group "group-search" exists
+    And user "user-in-group" belongs to group "group-search"
+    And user "user-in-group2" belongs to group "group-search"
+    When sending "GET" to "/cloud/groups/group-search/users/details?offset=0&limit=25&search=ifi"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And detailed users returned are
+      | user-in-group |


### PR DESCRIPTION
Similar to #17800 but also searches the email address.

This streamlines the search in groups with the one in users: 

https://github.com/nextcloud/server/blob/145eee91fe611a9ae59c5e6d9a8d06104112c1a5/lib/private/User/Database.php#L266-L278

See #13951

* [x] when testing this it doesn't show the results - but executing the query by hand finds the correct users. Any idea what causes the trouble here?