### PR TITLE
List ext-pdo as hard requirement for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         }
     },
     "require": {
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-pdo": "*"
     },
     "require-dev": {
         "jakub-onderka/php-parallel-lint": "^0.9.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6266c06daad42dd49f2bd3d5288467d",
+    "content-hash": "1fdbc1b1b14d4a9a25d6eb1084490f1a",
     "packages": [],
     "packages-dev": [
         {
@@ -1712,7 +1712,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-pdo": "*"
     },
     "platform-dev": [],
     "plugin-api-version": "1.1.0"


### PR DESCRIPTION
Nextcloud won't run without this. So it makes sense to declare it as hard requirement for composer. This makes your IDE happy.

## Before

IDE complains in files like `\OCP\DB\QueryBuilder\IQueryBuilder` because `\PDO` requires `ext-pdo`

## After

Happy IDE