### PR TITLE
Return loginname from getAppPassword

### DIFF
--- a/core/Controller/AppPasswordController.php
+++ b/core/Controller/AppPasswordController.php
@@ -116,7 +116,8 @@ class AppPasswordController extends \OCP\AppFramework\OCSController {
 		$this->eventDispatcher->dispatch('app_password_created', $event);
 
 		return new DataResponse([
-			'apppassword' => $token
+			'apppassword' => $token,
+			'loginname' => $credentials->getLoginName()
 		]);
 	}
 


### PR DESCRIPTION
In many cases the user supplied username is not the loginname to use with the generated app password,eg 
* user gave her email address as user name
* with an LDAP backend, where loginname is the LDAP GUID
* character case: the web login is case insensitive, so the user might use wrong character case and the admin might not have set an all lowercase user name. In this case the client can't guess the correct character case.
 
A client might use `/ocs/v1.php/cloud/user` to get the login name but that
* is undocumented
* comes at extra cost in network resources and time

So it would be great to get the login name together with the generated app password.