### PR TITLE
Fix empty 'more' apps navigation after installing an app

### DIFF
--- a/apps/settings/js/apps.js
+++ b/apps/settings/js/apps.js
@@ -42,11 +42,11 @@ OC.Settings.Apps = OC.Settings.Apps || {
 						var a = $('<a></a>').attr('href', entry.href);
 						var filename = $('<span></span>');
 						var loading = $('<div class="icon-loading-dark"></div>').css('display', 'none');
-						filename.text(entry.name);							filename.text(entry.name);
+						filename.text(entry.name);
 						a.prepend(loading);
+						a.prepend(filename);
 						a.prepend(img);
 						li.append(a);
-						li.append(filename);
 
 						// add app icon to the navigation
 						var previousElement = $('#navigation li[data-id=' + previousEntry.id + ']');
@@ -84,9 +84,9 @@ OC.Settings.Apps = OC.Settings.Apps || {
 						var loading = $('<div class="icon-loading-dark"></div>').css('display', 'none');
 						filename.text(entry.name);
 						a.prepend(loading);
+						a.prepend(filename);
 						a.prepend(img);
 						li.append(a);
-						li.append(filename);
 
 						// add app icon to the navigation
 						var previousElement = $('#appmenu li[data-id=' + previousEntry.id + ']');


### PR DESCRIPTION
Fixes this old issue with the "More apps" list looking empty after adding a new app.

(The issue with the app icons not being visible still exists. The ones in the "More apps" list would have to be inverted to be black in the light theme and white in the dark theme. But I can’t see how to easily fix this – maybe @juliushaertl?)

Before | After
-|-
![empty screen after enabling app](https://user-images.githubusercontent.com/925062/83366305-79200500-a3ae-11ea-8314-4603bf191e84.png) | ![empty list after enabling app fixed](https://user-images.githubusercontent.com/925062/83366302-78876e80-a3ae-11ea-80aa-51b06697f7c6.png)
