### PR TITLE
Do not only catch Exceptions but any Throwable during rmt share delete

### DIFF
--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -520,7 +520,7 @@ class Manager {
 		if ($result && $share !== false && (int)$share['share_type'] === Share::SHARE_TYPE_USER) {
 			try {
 				$this->sendFeedbackToRemote($share['remote'], $share['share_token'], $share['remote_id'], 'decline');
-			} catch (\Exception $e) {
+			} catch (\Throwable $e) {
 				// if we fail to notify the remote (probably cause the remote is down)
 				// we still want the share to be gone to prevent undeletable remotes
 			}
@@ -630,7 +630,7 @@ class Manager {
 		}
 
 		$query = 'SELECT `id`, `remote`, `remote_id`, `share_token`, `name`, `owner`, `user`, `mountpoint`, `accepted`
-		          FROM `*PREFIX*share_external` 
+		          FROM `*PREFIX*share_external`
 				  WHERE (`user` = ? OR `user` IN (?))';
 		$parameters = [$this->uid, implode(',',$userGroups)];
 		if (!is_null($accepted)) {


### PR DESCRIPTION
When a remote share is deleted, we notify the remote instance. This may
trigger various error conditions, which we want to catch in order to
avoid undeletable shares. The try-catch, however, did only capture
exceptions, so things like TypeErrors were not caught and caused the
process to fail hard.