### PR TITLE
Reflect unreadable state in the UI

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -84,6 +84,15 @@
 	tbody {
 		display: table;
 		width: 100%;
+
+		tr[data-permissions="0"],
+		tr[data-permissions="16"] {
+			background-color: var(--color-background-dark);
+
+			td.filename .nametext .innernametext {
+				color: var(--color-text-maxcontrast);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
When you have an external mount point mounted that is not readable, we mark them gray in the UI to avoid unnecessary clicks