### PR TITLE
Only use background fade if nextcloud blue is set

### DIFF
--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -8,20 +8,28 @@
 }
 
 @mixin faded-background {
-	background-image: linear-gradient(40deg, $color-primary 0%, lighten($color-primary, 20%) 100%);
+	background-color: $color-primary;
+
+	@if ($color-primary == #0082C9) {
+		background-image: linear-gradient(40deg, $color-primary 0%, lighten($color-primary, 20%) 100%);
+	} @else {
+		/** This will be overwritten by the faded-background-image mixin if needed */
+		background-image: none;
+	}
 }
 
 @mixin faded-background-image {
-	@if ($color-primary == #0082C9) or ($has-custom-background == true) {
-		background-image: $image-login-background, linear-gradient(40deg, $color-primary 0%, lighten($color-primary, 20%) 100%);
+	@include faded-background;
+	background-size: contain;
 
-		@if($has-custom-background == true) {
-			background-size: cover;
-			background-repeat: no-repeat;
-		}
-	} @else {
-		@include faded-background;
-		background-size: contain;
+	@if ($color-primary == #0082C9) {
+		background-image: $image-login-background, linear-gradient(40deg, $color-primary 0%, lighten($color-primary, 20%) 100%);
+	}
+
+	@if($has-custom-background == true) {
+		background-size: cover;
+		background-repeat: no-repeat;
+		background-image: $image-login-background;
 	}
 }
 
@@ -138,6 +146,12 @@ $invert: luma($color-primary) > 0.6;
 	@include faded-background;
 }
 
+#body-login,
+#firstrunwizard .firstrunwizard-header,
+#theming-preview {
+	@include faded-background-image;
+}
+
 /* override styles for login screen in guest.css */
 @if ($has-custom-logo) {
 	// custom logo
@@ -156,22 +170,6 @@ $invert: luma($color-primary) > 0.6;
 		#header .logo {
 			opacity: .6;
 		}
-	}
-}
-
-@if variable_exists('theming-background-mime') and $theming-background-mime != ''  {
-	#body-login,
-	#firstrunwizard .firstrunwizard-header,
-	#theming-preview {
-		background-image: $image-login-background;
-		background-color: $color-primary;
-		@include faded-background-image;
-	}
-} @else {
-	#theming-preview {
-		background-image: $image-login-background;
-		background-color: $color-primary;
-		@include faded-background-image;
 	}
 }
 
@@ -231,7 +229,6 @@ input.primary,
 @if $image-login-plain == 'true' {
 	#body-login, #firstrunwizard .firstrunwizard-header, #theming-preview {
 		background-image: none !important;
-		background-color: $color-primary;
 	}
 	#body-login {
 
@@ -239,10 +236,6 @@ input.primary,
 			color: $color-primary-text;
 		}
 
-	}
-} @else {
-	#body-login {
-		@include faded-background-image;
 	}
 }
 


### PR DESCRIPTION
Fixes #19040

This PR ensures that we only use the app icons and faded color in the background if the default `#0082C9` and makes the code a bit more structured by moving all background logic to the existing mixins.