### PR TITLE
Fix empty event UUID reminder notifications

### DIFF
--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/PushProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/PushProvider.php
@@ -95,8 +95,10 @@ class PushProvider extends AbstractProvider {
 		$eventDetails = $this->extractEventDetails($vevent);
 		$eventDetails['calendar_displayname'] = $calendarDisplayName;
 		$eventUUID = (string) $vevent->UID;
-		// Empty Notification ObjectId will be catched by OC\Notification\Notification
-		$eventUUIDHash = $eventUUID ? hash('sha256', $eventUUID, false) : '';
+		if (!$eventUUID) {
+			return;
+		};
+		$eventUUIDHash = hash('sha256', $eventUUID, false);
 
 		foreach ($users as $user) {
 			/** @var INotification $notification */


### PR DESCRIPTION
Turns out it's not properly catched and makes the `dav:send-event-reminders` command fail.