### PR TITLE
Enable passwordless for everyone not only admins.

### DIFF
--- a/apps/settings/lib/Controller/WebAuthnController.php
+++ b/apps/settings/lib/Controller/WebAuthnController.php
@@ -65,6 +65,7 @@ class WebAuthnController extends Controller {
 
 	/**
 	 * @NoAdminRequired
+	 * @NoSubadminRequired
 	 * @PasswordConfirmationRequired
 	 * @UseSession
 	 * @NoCSRFRequired
@@ -82,6 +83,7 @@ class WebAuthnController extends Controller {
 
 	/**
 	 * @NoAdminRequired
+	 * @NoSubadminRequired
 	 * @PasswordConfirmationRequired
 	 * @UseSession
 	 */
@@ -103,6 +105,7 @@ class WebAuthnController extends Controller {
 
 	/**
 	 * @NoAdminRequired
+	 * @NoSubadminRequired
 	 * @PasswordConfirmationRequired
 	 */
 	public function deleteRegistration(int $id): JSONResponse {


### PR DESCRIPTION
Adding `NoSubadminRequired` looks safe to me. start, finish and delete uses the current user session only. 