### PR TITLE
fix #21285 - Return correct loginname in credentials,

### DIFF
--- a/lib/private/Authentication/LoginCredentials/Store.php
+++ b/lib/private/Authentication/LoginCredentials/Store.php
@@ -109,7 +109,7 @@ class Store implements IStore {
 
 		if ($trySession && $this->session->exists('login_credentials')) {
 			$creds = json_decode($this->session->get('login_credentials'));
-			return new Credentials($creds->uid, $creds->uid, $creds->password);
+			return new Credentials($creds->uid, $this->session->get('loginname'), $creds->password);
 		}
 
 		// If we reach this line, an exception was thrown.

--- a/tests/lib/Authentication/LoginCredentials/StoreTest.php
+++ b/tests/lib/Authentication/LoginCredentials/StoreTest.php
@@ -142,7 +142,8 @@ class StoreTest extends TestCase {
 	}
 
 	public function testGetLoginCredentialsInvalidTokenLoginCredentials() {
-		$uid = 'user987';
+		$uid = 'id987';
+		$user = 'user987';
 		$password = '7389374';
 
 		$this->session->expects($this->once())
@@ -159,8 +160,8 @@ class StoreTest extends TestCase {
 		$this->session->expects($this->once())
 			->method('get')
 			->with($this->equalTo('login_credentials'))
-			->willReturn('{"run":true,"uid":"user987","password":"7389374"}');
-		$expected = new Credentials('user987', 'user987', '7389374');
+			->willReturn('{"run":true,"uid":"id987","password":"7389374"}');
+		$expected = new Credentials($uid, $user, $password);
 
 		$actual = $this->store->getLoginCredentials();
 


### PR DESCRIPTION
Fix #21285 

even when token is invalid or has no password.

Returning the uid as loginname is wrong, and leads to problems when
these differ. E.g. the getapppassword API was creating app token with
the uid as loginname. In a scenario with external authentication (such
as LDAP), these tokens were then invalidated next time their underlying
password was checked, and systematically ceased to function.

Signed-off-by: Lionel Elie Mamane <lionel@mamane.lu>