### PR TITLE
Adjust to parent implementation

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/ExceptionPlugin.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/ExceptionPlugin.php
@@ -26,11 +26,11 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre\RequestTest;
 
 class ExceptionPlugin extends \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin {
 	/**
-	 * @var \Exception[]
+	 * @var \Throwable[]
 	 */
 	protected $exceptions = [];
 
-	public function logException(\Exception $ex) {
+	public function logException(\Throwable $ex) {
 		$exceptionClass = get_class($ex);
 		if (!isset($this->nonFatalExceptions[$exceptionClass])) {
 			$this->exceptions[] = $ex;
@@ -38,7 +38,7 @@ class ExceptionPlugin extends \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin {
 	}
 
 	/**
-	 * @return \Exception[]
+	 * @return \Throwable[]
 	 */
 	public function getExceptions() {
 		return $this->exceptions;


### PR DESCRIPTION
Running unit tests before:

```
phpunit --configuration phpunit-autotest.xml --log-junit autotest-results-mysql.xml --group DB
PHP Warning:  Declaration of OCA\DAV\Tests\unit\Connector\Sabre\RequestTest\ExceptionPlugin::logException(Exception $ex) should be compatible with OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin::logException(Throwable $ex) in …/apps/dav/tests/unit/Connector/Sabre/RequestTest/ExceptionPlugin.php on line 27
```
