### PR TITLE
Always sort shares in a reliable way

### DIFF
--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -156,10 +156,12 @@ class MountProvider implements IMountProvider {
 		// sort by stime, the super share will be based on the least recent share
 		foreach ($tmp as &$tmp2) {
 			@usort($tmp2, function ($a, $b) {
-				if ($a->getShareTime() <= $b->getShareTime()) {
-					return -1;
+				$aTime = $a->getShareTime()->getTimestamp();
+				$bTime = $b->getShareTime()->getTimestamp();
+				if ($aTime === $bTime) {
+					return $a->getId() < $b->getId() ? -1 : 1;
 				}
-				return 1;
+				return $aTime < $bTime ? -1 : 1;
 			});
 			$result[] = $tmp2;
 		}

--- a/lib/public/Share/IShare.php
+++ b/lib/public/Share/IShare.php
@@ -550,7 +550,7 @@ interface IShare {
 	 * This is mainly for public shares. It will signal that the share page should
 	 * hide download buttons etc.
 	 *
-	 * @param bool $ro
+	 * @param bool $hide
 	 * @return IShare
 	 * @since 15.0.0
 	 */


### PR DESCRIPTION
Before the sorting wasn't really reliable.
In case you had 2 shares with the same timestamp, you could load them in 2 different orders.
This actually broke the talk integration tests in 90% of the time (when both shares have the same timestamp) while almost always working locally because the requests took a bit long and always working while debugging because then it always was longer than 1 second for me.

Now this makes sure that sorting is always done in the same way and in case of same timestamp it sorts by id.