### PR TITLE
Upload part size as S3 parameter instead of constant value

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -47,6 +47,9 @@ trait S3ConnectionTrait {
 
 	/** @var int */
 	protected $timeout;
+	
+	/** @var int */
+	protected $uploadPartSize;
 
 	protected $test;
 
@@ -60,6 +63,7 @@ trait S3ConnectionTrait {
 		$this->test = isset($params['test']);
 		$this->bucket = $params['bucket'];
 		$this->timeout = !isset($params['timeout']) ? 15 : $params['timeout'];
+		$this->uploadPartSize = !isset($params['uploadPartSize']) ? 524288000 : $params['uploadPartSize'];
 		$params['region'] = empty($params['region']) ? 'eu-west-1' : $params['region'];
 		$params['hostname'] = empty($params['hostname']) ? 's3.' . $params['region'] . '.amazonaws.com' : $params['hostname'];
 		if (!isset($params['port']) || $params['port'] === '') {

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -33,8 +33,6 @@ use Aws\S3\S3Client;
 use Icewind\Streams\CallbackWrapper;
 use OC\Files\Stream\SeekableHttpStream;
 
-const S3_UPLOAD_PART_SIZE = 524288000; // 500MB
-
 trait S3ObjectTrait {
 	/**
 	 * Returns the connection
@@ -91,7 +89,7 @@ trait S3ObjectTrait {
 		$uploader = new MultipartUploader($this->getConnection(), $countStream, [
 			'bucket' => $this->bucket,
 			'key' => $urn,
-			'part_size' => S3_UPLOAD_PART_SIZE,
+			'part_size' => $this->uploadPartSize,
 		]);
 
 		try {


### PR DESCRIPTION
Some S3 providers need a custom upload part size (500 MB static value in Nextcloud).

Here is a commit to change this value via S3 configuration, instead of using S3_UPLOAD_PART_SIZE constant.

A new parameter is added for an S3 connection : uploadPartSize

Signed-off-by: Florent <florent@coppint.com>