### PR TITLE
clear LDAP cache after user deletion

### DIFF
--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -389,6 +389,7 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 
 		$this->access->getUserMapper()->unmap($uid); // we don't emit unassign signals here, since it is implicit to delete signals fired from core
 		$this->access->userManager->invalidate($uid);
+		$this->access->connection->clearCache();
 		return true;
 	}
 


### PR DESCRIPTION
Before:

```
$ php occ user:delete person_133176
The specified user was deleted
$ php occ user:info 'person_133176'                       
  - user_id: person_133176
  - display_name: Iris, Burns (person_133176)
  - email: 
  - cloud_id: person_133176@nc.zara/master
  - enabled: true
  - groups:
  - quota: none
  - last_seen: 1970-01-01T00:00:00+00:00
  - user_directory: /path/to/data/person_133176
  - backend: LDAP
```

(^ the data is even incomplete, e.g. no email)

Now:

```
$ php occ user:delete person_133176
The specified user was deleted
$ php occ user:info 'person_133176'
user not found
```