### PR TITLE
Use empty for the OCP @since checker

### DIFF
--- a/build/OCPSinceChecker.php
+++ b/build/OCPSinceChecker.php
@@ -55,7 +55,7 @@ class SinceTagCheckVisitor extends \PhpParser\NodeVisitorAbstract {
 			/** @var \PhpParser\Comment\Doc[] $comments */
 			$comments = $node->getAttribute('comments');
 
-			if (count($comments) === 0) {
+			if (empty($comments)) {
 				$this->errors[] = 'PHPDoc is needed for ' . $this->namespace . '\\' . $this->className . '::' . $node->name;
 				return;
 			}
@@ -78,7 +78,7 @@ class SinceTagCheckVisitor extends \PhpParser\NodeVisitorAbstract {
 			/** @var \PhpParser\Comment\Doc[] $comments */
 			$comments = $node->getAttribute('comments');
 
-			if (count($comments) === 0) {
+			if (empty($comments)) {
 				$this->errors[] = 'PHPDoc is needed for ' . $this->namespace . '\\' . $this->className . '::' . $node->name;
 				return;
 			}


### PR DESCRIPTION
Empty is more concise and works on more types, also on null.