### PR TITLE
Allow group search by display name

### DIFF
--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -287,6 +287,9 @@ class Database extends ABackend implements
 			$query->where($query->expr()->iLike('gid', $query->createNamedParameter(
 				'%' . $this->dbConn->escapeLikeParameter($search) . '%'
 			)));
+			$query->orWhere($query->expr()->iLike('displayname', $query->createNamedParameter(
+				'%' . $this->dbConn->escapeLikeParameter($search) . '%'
+			)));
 		}
 
 		$query->setMaxResults($limit)


### PR DESCRIPTION
Steps to test

* Run `occ group:add  abc --display-name="def"`
* Try to share a file with 'def'

On master: no result
Here: 'def' is suggested