### PR TITLE
Respect "prefers-color-scheme" media selector for guests

### DIFF
--- a/apps/accessibility/lib/AppInfo/Application.php
+++ b/apps/accessibility/lib/AppInfo/Application.php
@@ -63,6 +63,12 @@ class Application extends App {
 				$linkToCSS = $this->urlGenerator->linkToRoute(self::APP_NAME . '.accessibility.getCss', ['md5' => $hash]);
 				\OCP\Util::addHeader('link', ['rel' => 'stylesheet', 'href' => $linkToCSS]);
 			}
+		} else {
+			$userValues = ['dark'];
+
+			$hash = md5(implode('-', $userValues));
+			$linkToCSS = $this->urlGenerator->linkToRoute(self::APP_NAME . '.accessibility.getCss', ['md5' => $hash]);
+			\OCP\Util::addHeader('link', ['rel' => 'stylesheet', 'media' => '(prefers-color-scheme: dark)', 'href' => $linkToCSS]);
 		}
 	}
 

--- a/apps/accessibility/lib/Controller/AccessibilityController.php
+++ b/apps/accessibility/lib/Controller/AccessibilityController.php
@@ -131,7 +131,7 @@ class AccessibilityController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
+	 * @PublicPage
 	 * @NoCSRFRequired
 	 * @NoSameSiteCookieRequired
 	 *
@@ -140,7 +140,11 @@ class AccessibilityController extends Controller {
 	public function getCss(): DataDisplayResponse {
 		$css        = '';
 		$imports    = '';
-		$userValues = $this->getUserValues();
+		if ($this->userSession->isLoggedIn()) {
+			$userValues = $this->getUserValues();
+		} else {
+			$userValues = ['dark'];
+		}
 
 		foreach ($userValues as $key => $scssFile) {
 			if ($scssFile !== false) {
@@ -199,7 +203,9 @@ class AccessibilityController extends Controller {
 		$response->addHeader('Pragma', 'cache');
 
 		// store current cache hash
-		$this->config->setUserValue($this->userSession->getUser()->getUID(), $this->appName, 'icons-css', md5($css));
+		if ($this->userSession->isLoggedIn()) {
+			$this->config->setUserValue($this->userSession->getUser()->getUID(), $this->appName, 'icons-css', md5($css));
+		}
 
 		return $response;
 	}


### PR DESCRIPTION
Guests now automatically see dark theme when the browser tells the website it prefers a `dark` style:
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme

A similar setting for contrast `high` seems to be in development but is not supported:
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-contrast

See https://stackoverflow.com/a/56757527 for helps how to test this quickly

Edit by @georgehrke:
fixes https://github.com/nextcloud/server/issues/12276
