### PR TITLE
Fix create SimpleFile with empty content

### DIFF
--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -185,6 +185,9 @@ class Folder extends Node implements \OCP\Files\Folder {
 			$this->sendHooks(['preWrite', 'preCreate'], [$nonExisting]);
 			if ($content !== null) {
 				$result = $this->view->file_put_contents($fullPath, $content);
+				if ($content === '' && $result === 0) {
+					$result = true;
+				}
 			} else {
 				$result = $this->view->touch($fullPath);
 			}


### PR DESCRIPTION
After that change https://github.com/nextcloud/server/pull/19493 where
you have to provide content to method `newFile` is a bug with empty `''`
content.

Php function `file_put_contents` will returns the numbers of bytes that
written to the file, or `FALSE` on failure
https://www.php.net/manual/en/function.file-put-contents.php

So for empty `''` content it will return `0` which is `true` for this
statement:

```
if (!$result) {
    throw new NotPermittedException('Could not create path');
}
```

From now empty content will not throws an exception.