### PR TITLE
Flow: Include root folder for shared storages when fetching system tags

### DIFF
--- a/apps/workflowengine/lib/Check/FileSystemTags.php
+++ b/apps/workflowengine/lib/Check/FileSystemTags.php
@@ -21,6 +21,7 @@
 
 namespace OCA\WorkflowEngine\Check;
 
+use OCA\Files_Sharing\SharedStorage;
 use OCA\WorkflowEngine\Entity\File;
 use OCP\Files\Cache\ICache;
 use OCP\Files\IHomeStorage;
@@ -95,7 +96,7 @@ class FileSystemTags implements ICheck, IFileCheck {
 	 */
 	protected function getSystemTags() {
 		$cache = $this->storage->getCache();
-		$fileIds = $this->getFileIds($cache, $this->path, !$this->storage->instanceOfStorage(IHomeStorage::class));
+		$fileIds = $this->getFileIds($cache, $this->path, !$this->storage->instanceOfStorage(IHomeStorage::class) || $this->storage->instanceOfStorage(SharedStorage::class));
 
 		$systemTags = [];
 		foreach ($fileIds as $i => $fileId) {


### PR DESCRIPTION
Make sure that checking for systemtags on files also works with tags being assigned to a shared folder.

**Steps to reproduce:**
User1: Create a folder A
User1: Assign a tag "action" to it
User1: Share a folder with user2
User1: Setup a flow rule to be triggered on file create if action is assigned
User2: Upload a file to the folder

**Before:**
Flow is not triggered as when fetching the list of file ids the topmost node (share root) was not included

**After:**
The flow gets triggered as expected