### PR TITLE
Disable Client-Side Monitoring on AWS storage

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -47,7 +47,7 @@ trait S3ConnectionTrait {
 
 	/** @var int */
 	protected $timeout;
-	
+
 	/** @var int */
 	protected $uploadPartSize;
 
@@ -99,7 +99,8 @@ trait S3ConnectionTrait {
 			'endpoint' => $base_url,
 			'region' => $this->params['region'],
 			'use_path_style_endpoint' => isset($this->params['use_path_style']) ? $this->params['use_path_style'] : false,
-			'signature_provider' => \Aws\or_chain([self::class, 'legacySignatureProvider'], ClientResolver::_default_signature_provider())
+			'signature_provider' => \Aws\or_chain([self::class, 'legacySignatureProvider'], ClientResolver::_default_signature_provider()),
+			'csm' => false,
 		];
 		if (isset($this->params['proxy'])) {
 			$options['request.options'] = ['proxy' => $this->params['proxy']];


### PR DESCRIPTION
The S3 client enables this by default and then tries to read
`.aws/config`. This causes `open_basedir` restriction related error for
some setups. So this patch disables the CSM because it's most likely
unused anyway.

:warning: Due to the lack of a local s3 system I did not test this patch :warning: 

Ref https://github.com/aws/aws-sdk-php/issues/1659#issuecomment-507453483
Ref https://github.com/aws/aws-sdk-php/issues/1931