### PR TITLE
getXbyY can still return false, e.g. when using ldap write support

### DIFF
--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -123,7 +123,7 @@ abstract class AbstractMapping {
 	 */
 	public function getDNByName($name) {
 		$dn = array_search($name, $this->cache);
-		if ($dn === false && $dn = $this->getXbyY('ldap_dn', 'owncloud_name', $name)) {
+		if ($dn === false && ($dn = $this->getXbyY('ldap_dn', 'owncloud_name', $name)) !== false) {
 			$this->cache[$dn] = $name;
 		}
 		return $dn;

--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -123,8 +123,7 @@ abstract class AbstractMapping {
 	 */
 	public function getDNByName($name) {
 		$dn = array_search($name, $this->cache);
-		if ($dn === false) {
-			$dn = $this->getXbyY('ldap_dn', 'owncloud_name', $name);
+		if ($dn === false && $dn = $this->getXbyY('ldap_dn', 'owncloud_name', $name)) {
 			$this->cache[$dn] = $name;
 		}
 		return $dn;


### PR DESCRIPTION
To reproduce: 
1. have ldap_write_support on master (e.g. from https://github.com/nextcloud/ldap_write_support/pull/165)
2. try to create a user
3. You'll get an error message and an exception logged saying "Translation to LDAP DN unsuccessful"