### PR TITLE
Fix invalid usage of \Exception::getResult

### DIFF
--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -67,8 +67,14 @@ try {
 	OC_API::setContentType();
 	http_response_code(405);
 	exit();
-} catch (Exception $ex) {
+} catch (\OC\OCS\Exception $ex) {
 	OC_API::respond($ex->getResult(), OC_API::requestedFormat());
+	exit();
+} catch (Throwable $ex) {
+	OC::$server->getLogger()->logException($ex);
+
+	OC_API::setContentType();
+	http_response_code(500);
 	exit();
 }
 


### PR DESCRIPTION
Only OCS exceptions have a getResult method. Any other exception will
cause another error due to this invalid method call.

This splits the catch into a specific one for OCS and then a generic one
for anything else that can't be handled.

Neither did I reproduce this issue locally not did I verify the fix :shrug: 