### PR TITLE
Don't break event listeners with the GenericEventWrapper

### DIFF
--- a/lib/private/EventDispatcher/SymfonyAdapter.php
+++ b/lib/private/EventDispatcher/SymfonyAdapter.php
@@ -63,7 +63,7 @@ class SymfonyAdapter implements EventDispatcherInterface {
 		if ($event instanceof Event) {
 			$this->eventDispatcher->dispatch($eventName, $event);
 		} else {
-			if ($event instanceof GenericEvent) {
+			if ($event instanceof GenericEvent && get_class($event) === GenericEvent::class) {
 				$newEvent = new GenericEventWrapper($this->logger, $eventName, $event);
 			} else {
 				$newEvent = $event;


### PR DESCRIPTION
Follow up to #20914 

This broke the autocomplete endpoint as `AutoCompleteEvent extends GenericEvent`

### Before
`Argument 1 passed to OCA\\Talk\\Collaboration\\Collaborators\\Listener::OCA\\Talk\\Collaboration\\Collaborators\\{closure}() must be an instance of OCP\\Collaboration\\AutoComplete\\AutoCompleteEvent, instance of OC\\EventDispatcher\\GenericEventWrapper given, called in /home/nickv/Nextcloud/20/server/3rdparty/symfony/event-dispatcher/EventDispatcher.php on line 264`

### After
You can add people to talk conversations again with Info logged:

`Deprecated event type for OCP\\Collaboration\\AutoComplete\\IManager::filterResults: OCP\\Collaboration\\AutoComplete\\AutoCompleteEvent`