### PR TITLE
Fix autocomplete for LDAP with `shareapi_only_share_with_group_members` on

### DIFF
--- a/build/integration/sharees_features/sharees.feature
+++ b/build/integration/sharees_features/sharees.feature
@@ -72,6 +72,23 @@ Feature: sharees
     And "exact remotes" sharees returned is empty
     And "remotes" sharees returned is empty
 
+  Scenario: Search only with group members - allowed with exact match
+    Given As an "test"
+    And parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
+    And user "Sharee1" belongs to group "ShareeGroup"
+    When getting sharees for
+      | search | Sharee1 |
+      | itemType | file |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And "exact users" sharees returned are
+      | Sharee1 | 0 | Sharee1 |
+    And "users" sharees returned is empty
+    And "exact groups" sharees returned is empty
+    And "groups" sharees returned is empty
+    And "exact remotes" sharees returned is empty
+    And "remotes" sharees returned is empty
+
   Scenario: Search only with group members - no group as non-member
     Given As an "Sharee1"
     And parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"

--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -33,7 +33,6 @@ use OCP\Collaboration\Collaborators\ISearchPlugin;
 use OCP\Collaboration\Collaborators\ISearchResult;
 use OCP\Collaboration\Collaborators\SearchResultType;
 use OCP\IConfig;
-use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserManager;

--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -73,20 +73,19 @@ class UserPlugin implements ISearchPlugin {
 		$users = [];
 		$hasMoreResults = false;
 
-		$userGroups = [];
+		$currentUserGroups = $this->groupManager->getUserGroupIds($this->userSession->getUser());
 		if ($this->shareWithGroupOnly) {
 			// Search in all the groups this user is part of
-			$userGroups = $this->groupManager->getUserGroups($this->userSession->getUser());
-			foreach ($userGroups as $userGroup) {
-				$usersInGroup = $userGroup->searchDisplayName($search, $limit, $offset);
-				foreach ($usersInGroup as $user) {
-					$users[$user->getUID()] = $user;
+			foreach ($currentUserGroups as $userGroupId) {
+				$usersInGroup = $this->groupManager->displayNamesInGroup($userGroupId, $search, $limit, $offset);
+				foreach ($usersInGroup as $userId => $displayName) {
+					$userId = (string) $userId;
+					$users[$userId] = $this->userManager->get($userId);
 				}
 			}
 		} else {
 			// Search in all users
 			$usersTmp = $this->userManager->searchDisplayName($search, $limit, $offset);
-			$currentUserGroups = $this->groupManager->getUserGroupIds($this->userSession->getUser());
 			foreach ($usersTmp as $user) {
 				if ($user->isEnabled()) { // Don't keep deactivated users
 					$users[$user->getUID()] = $user;
@@ -155,9 +154,6 @@ class UserPlugin implements ISearchPlugin {
 
 				if ($this->shareWithGroupOnly) {
 					// Only add, if we have a common group
-					$userGroupIds = array_map(function (IGroup $group) {
-						return $group->getGID();
-					}, $userGroups);
 					$commonGroups = array_intersect($userGroupIds, $this->groupManager->getUserGroupIds($user));
 					$addUser = !empty($commonGroups);
 				}

--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -153,7 +153,7 @@ class UserPlugin implements ISearchPlugin {
 
 				if ($this->shareWithGroupOnly) {
 					// Only add, if we have a common group
-					$commonGroups = array_intersect($userGroupIds, $this->groupManager->getUserGroupIds($user));
+					$commonGroups = array_intersect($currentUserGroups, $this->groupManager->getUserGroupIds($user));
 					$addUser = !empty($commonGroups);
 				}
 


### PR DESCRIPTION
Move back to IGroupManager::displayNamesInGroup()

The problem is that despite it's name IGroup::searchDisplayName()
only searches by userid and this is less fixable than changing back to this method here

Fix #21451 

Also fixes the broken integration test `sharees_features/sharees.feature:57` which is failing since the merge of #16035 