### PR TITLE
Load the app.php before running apps' boot method

### DIFF
--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -149,9 +149,6 @@ class OC_App {
 		// in case someone calls loadApp() directly
 		self::registerAutoloading($app, $appPath);
 
-		/** @var \OC\AppFramework\Bootstrap\Coordinator $coordinator */
-		$coordinator = \OC::$server->query(\OC\AppFramework\Bootstrap\Coordinator::class);
-		$coordinator->bootApp($app);
 		if (is_file($appPath . '/appinfo/app.php')) {
 			\OC::$server->getEventLogger()->start('load_app_' . $app, 'Load app: ' . $app);
 			try {
@@ -175,6 +172,10 @@ class OC_App {
 			}
 			\OC::$server->getEventLogger()->end('load_app_' . $app);
 		}
+
+		/** @var \OC\AppFramework\Bootstrap\Coordinator $coordinator */
+		$coordinator = \OC::$server->query(\OC\AppFramework\Bootstrap\Coordinator::class);
+		$coordinator->bootApp($app);
 
 		$info = self::getAppInfo($app);
 		if (!empty($info['activity']['filters'])) {

--- a/lib/public/AppFramework/Bootstrap/IBootstrap.php
+++ b/lib/public/AppFramework/Bootstrap/IBootstrap.php
@@ -38,6 +38,13 @@ interface IBootstrap {
 	public function register(IRegistrationContext $context): void;
 
 	/**
+	 * Boot the application
+	 *
+	 * At this stage you can assume that all services are registered and the DI
+	 * container(s) are ready to be queried.
+	 *
+	 * This is also the state where an optional `appinfo/app.php` was loaded.
+	 *
 	 * @param IBootContext $context
 	 *
 	 * @since 20.0.0


### PR DESCRIPTION
Some apps require the composer autoloader from app.php. If we run boot
before including that file, classes and functions from dependencies
won't be found.

Follow-up to #20865 