### PR TITLE
Continue with next app when one errors during register

### DIFF
--- a/lib/private/AppFramework/Bootstrap/Coordinator.php
+++ b/lib/private/AppFramework/Bootstrap/Coordinator.php
@@ -84,7 +84,7 @@ class Coordinator {
 					$apps[$appId] = $application = $this->serverContainer->query($applicationClassName);
 				} catch (QueryException $e) {
 					// Weird, but ok
-					return;
+					continue;
 				}
 				try {
 					$application->register($context->for($appId));


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/server/pull/21461 I overlooked that there is a loop. :speak_no_evil: 

My patch at #21461 had a little error in that it exits the method when a
query exception is encountered during the register step of an app. What
we actually want is to continue with the next app and finish the overall
registration procedure.

