### PR TITLE
fix invalid session start

### DIFF
--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -104,7 +104,6 @@ class Internal extends Session {
 	public function clear() {
 		$this->invoke('session_unset');
 		$this->regenerateId();
-		$this->startSession();
 		$_SESSION = [];
 	}
 


### PR DESCRIPTION
This will fix errors like `A session had already been started`

The reason was that there was a already started session and `regenerateId()` was assigning a new session id to it. So there is no need to call `start_session()` again.

This will fix https://github.com/nextcloud/server/issues/20490