### PR TITLE
Remove rescanDelay from directory mtime

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -57,11 +57,6 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return false;
 	}
 
-	/**
-	 * @var int in seconds
-	 */
-	private $rescanDelay = 10;
-
 	/** @var CappedMemoryCache|Result[] */
 	private $objectCache;
 
@@ -378,7 +373,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			if ($this->is_dir($path)) {
 				//folders don't really exist
 				$stat['size'] = -1; //unknown
-				$stat['mtime'] = time() - $this->rescanDelay * 1000;
+				$stat['mtime'] = time();
 			} else {
 				$stat['size'] = $this->getContentLength($path);
 				$stat['mtime'] = strtotime($this->getLastModified($path));


### PR DESCRIPTION
I'm not entirely sure about the original purpose of that rescanDelay, but 10 seconds times 1000 being 2:47 hours looks like an odd value and this will cause all folders on external s3 storage having a 2:47 hour old mtime after being created. Also the rescanDelay seems to be no longer in use.

This was introduced in https://github.com/owncloud/core/pull/11375#discussion-diff-18287612 

Maybe @icewind1991 remembers what the purpose of the delay was :wink: 

