### PR TITLE
relax permissions mask check for detecting part file rename

### DIFF
--- a/lib/private/Files/Storage/Wrapper/PermissionsMask.php
+++ b/lib/private/Files/Storage/Wrapper/PermissionsMask.php
@@ -80,13 +80,9 @@ class PermissionsMask extends Wrapper {
 	}
 
 	public function rename($path1, $path2) {
-		$p = strpos($path1, $path2);
-		if ($p === 0) {
-			$part = substr($path1, strlen($path2));
-			//This is a rename of the transfer file to the original file
-			if (strpos($part, '.ocTransferId') === 0) {
-				return $this->checkMask(Constants::PERMISSION_CREATE) and parent::rename($path1, $path2);
-			}
+		//This is a rename of the transfer file to the original file
+		if (dirname($path1) === dirname($path2) && strpos($path1, '.ocTransferId') > 0) {
+			return $this->checkMask(Constants::PERMISSION_CREATE) and parent::rename($path1, $path2);
 		}
 		return $this->checkMask(Constants::PERMISSION_UPDATE) and parent::rename($path1, $path2);
 	}


### PR DESCRIPTION
with files drop uploads the original file name isn't always used for the '.ocTransferId' source path

Signed-off-by: Robin Appelman <robin@icewind.nl>