### PR TITLE
shortcut in reading nested group members when IN_CHAIN is available

### DIFF
--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -45,6 +45,10 @@ class Configuration {
 	public const AVATAR_PREFIX_NONE = 'none';
 	public const AVATAR_PREFIX_DATA_ATTRIBUTE = 'data:';
 
+	public const LDAP_SERVER_FEATURE_UNKNOWN = 'unknown';
+	public const LDAP_SERVER_FEATURE_AVAILABLE = 'available';
+	public const LDAP_SERVER_FEATURE_UNAVAILABLE = 'unavailable';
+
 	protected $configPrefix = null;
 	protected $configRead = false;
 	/**
@@ -110,6 +114,7 @@ class Configuration {
 		'ldapDynamicGroupMemberURL' => null,
 		'ldapDefaultPPolicyDN' => null,
 		'ldapExtStorageHomeAttribute' => null,
+		'ldapMatchingRuleInChainState' => self::LDAP_SERVER_FEATURE_UNKNOWN,
 	];
 
 	/**
@@ -482,6 +487,7 @@ class Configuration {
 			'ldap_default_ppolicy_dn'           => '',
 			'ldap_user_avatar_rule'             => 'default',
 			'ldap_ext_storage_home_attribute'   => '',
+			'ldap_matching_rule_in_chain_state' => self::LDAP_SERVER_FEATURE_UNKNOWN,
 		];
 	}
 
@@ -543,6 +549,7 @@ class Configuration {
 			'ldap_dynamic_group_member_url'     => 'ldapDynamicGroupMemberURL',
 			'ldap_default_ppolicy_dn'           => 'ldapDefaultPPolicyDN',
 			'ldap_ext_storage_home_attribute'   => 'ldapExtStorageHomeAttribute',
+			'ldap_matching_rule_in_chain_state' => 'ldapMatchingRuleInChainState',
 			'ldapIgnoreNamingRules'             => 'ldapIgnoreNamingRules',	// sysconfig
 		];
 		return $array;

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -72,6 +72,7 @@ use OCP\ILogger;
  * @property string ldapGidNumber
  * @property int hasMemberOfFilterSupport
  * @property int useMemberOfToDetectMembership
+ * @property string ldapMatchingRuleInChainState
  */
 class Connection extends LDAPUtility {
 	private $ldapConnectionRes = null;

--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -254,21 +254,27 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 		) {
 			$attemptedLdapMatchingRuleInChain = true;
 			// compatibility hack with servers supporting :1.2.840.113556.1.4.1941:, and others)
-			$filter = $this->access->combineFilterWithAnd([$this->access->connection->ldapUserFilter, 'memberof:1.2.840.113556.1.4.1941:=' . $dnGroup]);
+			$filter = $this->access->combineFilterWithAnd([
+				$this->access->connection->ldapUserFilter,
+				$this->access->connection->ldapUserDisplayName . '=*',
+				'memberof:1.2.840.113556.1.4.1941:=' . $dnGroup
+			]);
 			$memberRecords = $this->access->fetchListOfUsers(
 				$filter,
 				$this->access->userManager->getAttributes(true)
 			);
-			if (!empty($memberRecords)) {
-				if ($this->access->connection->ldapMatchingRuleInChainState === Configuration::LDAP_SERVER_FEATURE_UNKNOWN) {
-					$this->access->connection->ldapMatchingRuleInChainState = Configuration::LDAP_SERVER_FEATURE_AVAILABLE;
-					$this->access->connection->saveConfiguration();
-				}
-				return array_reduce($memberRecords, function ($carry, $record) {
-					$carry[] = $record['dn'][0];
-					return $carry;
-				}, []);
+			$result = array_reduce($memberRecords, function ($carry, $record) {
+				$carry[] = $record['dn'][0];
+				return $carry;
+			}, []);
+			if ($this->access->connection->ldapMatchingRuleInChainState === Configuration::LDAP_SERVER_FEATURE_AVAILABLE) {
+				return $result;
+			} elseif (!empty($memberRecords)) {
+				$this->access->connection->ldapMatchingRuleInChainState = Configuration::LDAP_SERVER_FEATURE_AVAILABLE;
+				$this->access->connection->saveConfiguration();
+				return $result;
 			}
+			// when feature availability is unknown, and the result is empty, continue and test with original approach
 		}
 
 		$seen[$dnGroup] = 1;
@@ -283,7 +289,10 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 		$allMembers += $this->getDynamicGroupMembers($dnGroup);
 
 		$this->access->connection->writeToCache($cacheKey, $allMembers);
-		if (isset($attemptedLdapMatchingRuleInChain) && !empty($allMembers)) {
+		if (isset($attemptedLdapMatchingRuleInChain)
+			&& $this->access->connection->ldapMatchingRuleInChainState === Configuration::LDAP_SERVER_FEATURE_UNKNOWN
+			&& !empty($allMembers)
+		) {
 			$this->access->connection->ldapMatchingRuleInChainState = Configuration::LDAP_SERVER_FEATURE_UNAVAILABLE;
 			$this->access->connection->saveConfiguration();
 		}

--- a/apps/user_ldap/tests/Group_LDAPTest.php
+++ b/apps/user_ldap/tests/Group_LDAPTest.php
@@ -73,6 +73,8 @@ class Group_LDAPTest extends TestCase {
 			->method('getConnection')
 			->willReturn($connector);
 
+		$access->userManager = $this->createMock(Manager::class);
+
 		return $access;
 	}
 

--- a/apps/user_ldap/tests/Group_LDAPTest.php
+++ b/apps/user_ldap/tests/Group_LDAPTest.php
@@ -129,6 +129,10 @@ class Group_LDAPTest extends TestCase {
 			->method('countUsers')
 			->willReturn(2);
 
+		$access->userManager->expects($this->any())
+			->method('getAttributes')
+			->willReturn(['displayName', 'mail']);
+
 		$groupBackend = new GroupLDAP($access, $pluginManager);
 		$users = $groupBackend->countUsersInGroup('group');
 
@@ -171,6 +175,10 @@ class Group_LDAPTest extends TestCase {
 		$access->expects($this->any())
 			->method('escapeFilterPart')
 			->willReturnArgument(0);
+
+		$access->userManager->expects($this->any())
+			->method('getAttributes')
+			->willReturn(['displayName', 'mail']);
 
 		$groupBackend = new GroupLDAP($access, $pluginManager);
 		$users = $groupBackend->countUsersInGroup('group', '3');
@@ -546,7 +554,10 @@ class Group_LDAPTest extends TestCase {
 		$access->expects($this->any())
 			->method('combineFilterWithAnd')
 			->willReturn('pseudo=filter');
-		$access->userManager = $this->createMock(Manager::class);
+
+		$access->userManager->expects($this->any())
+			->method('getAttributes')
+			->willReturn(['displayName', 'mail']);
 
 		$groupBackend = new GroupLDAP($access, $pluginManager);
 		$users = $groupBackend->usersInGroup('foobar');
@@ -587,7 +598,10 @@ class Group_LDAPTest extends TestCase {
 		$access->expects($this->any())
 			->method('combineFilterWithAnd')
 			->willReturn('pseudo=filter');
-		$access->userManager = $this->createMock(Manager::class);
+
+		$access->userManager->expects($this->any())
+			->method('getAttributes')
+			->willReturn(['displayName', 'mail']);
 
 		$groupBackend = new GroupLDAP($access, $pluginManager);
 		$users = $groupBackend->usersInGroup('foobar');
@@ -626,6 +640,10 @@ class Group_LDAPTest extends TestCase {
 		$access->expects($this->any())
 			->method('isDNPartOfBase')
 			->willReturn(true);
+
+		$access->userManager->expects($this->any())
+			->method('getAttributes')
+			->willReturn(['displayName', 'mail']);
 
 		$groupBackend = new GroupLDAP($access, $pluginManager);
 		$users = $groupBackend->countUsersInGroup('foobar');


### PR DESCRIPTION
Currently, to support members in nested groups, we cycle through them. Some LDAP server do implement the LDAP_MATCHING_RULE_IN_CHAIN (aka 1.2.840.113556.1.4.1941) extensible matcher (AD, Samba 4), which would speed up reading of group members drastically.

This matcher can not be used blindly, as server that do not implement it, return empty results. To avoid testing every time, the state is saved in the configuration, so that when working in servers that do not support this mechanism, it is not being attempted all over again.