### PR TITLE
fix obsolete usage of OCdialogs

### DIFF
--- a/apps/user_ldap/js/wizard/wizardTabGeneric.js
+++ b/apps/user_ldap/js/wizard/wizardTabGeneric.js
@@ -553,7 +553,7 @@ OCA = OCA || {};
 			) {
 				toggleFnc(true);
 			} else {
-				OCdialogs.confirm(
+				OC.dialogs.confirm(
 					t('user_ldap', 'Switching the mode will enable automatic LDAP queries. Depending on your LDAP size they may take a while. Do you still want to switch the mode?'),
 					t('user_ldap', 'Mode switch'),
 					toggleFnc


### PR DESCRIPTION
to reproduce:
1. in LDAP Wizard fill in the basics of a new connection and tick the last checkbox ("Manually enter LDAP filters")
2. Go to the next tab
3. Try to switch away from manual to the assisted mode 

What happens:
* nothing, and in the browser console that OCdialogs is undefined
* actually saw this on 18

Expected is a confirmation dialog (to avoid long runnning ops against big LDAPs)

Background: https://github.com/nextcloud/server/issues/15339