### PR TITLE
Add return value to all commands

### DIFF
--- a/apps/dav/lib/Command/CreateAddressBook.php
+++ b/apps/dav/lib/Command/CreateAddressBook.php
@@ -64,7 +64,7 @@ class CreateAddressBook extends Command {
 						'Name of the addressbook');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $input->getArgument('user');
 		if (!$this->userManager->userExists($user)) {
 			throw new \InvalidArgumentException("User <$user> in unknown.");
@@ -72,5 +72,6 @@ class CreateAddressBook extends Command {
 
 		$name = $input->getArgument('name');
 		$this->cardDavBackend->createAddressBook("principals/users/$user", $name, []);
+		return 0;
 	}
 }

--- a/apps/dav/lib/Command/CreateCalendar.php
+++ b/apps/dav/lib/Command/CreateCalendar.php
@@ -73,7 +73,7 @@ class CreateCalendar extends Command {
 				'Name of the calendar');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $input->getArgument('user');
 		if (!$this->userManager->userExists($user)) {
 			throw new \InvalidArgumentException("User <$user> in unknown.");
@@ -94,5 +94,6 @@ class CreateCalendar extends Command {
 		$name = $input->getArgument('name');
 		$caldav = new CalDavBackend($this->dbConnection, $principalBackend, $this->userManager, $this->groupManager, $random, $logger, $dispatcher);
 		$caldav->createCalendar("principals/users/$user", $name, []);
+		return 0;
 	}
 }

--- a/apps/dav/lib/Command/ListCalendars.php
+++ b/apps/dav/lib/Command/ListCalendars.php
@@ -62,7 +62,7 @@ class ListCalendars extends Command {
 				'User for whom all calendars will be listed');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $input->getArgument('uid');
 		if (!$this->userManager->userExists($user)) {
 			throw new \InvalidArgumentException("User <$user> is unknown.");
@@ -101,5 +101,6 @@ class ListCalendars extends Command {
 		} else {
 			$output->writeln("<info>User <$user> has no calendars</info>");
 		}
+		return 0;
 	}
 }

--- a/apps/dav/lib/Command/MoveCalendar.php
+++ b/apps/dav/lib/Command/MoveCalendar.php
@@ -106,7 +106,7 @@ class MoveCalendar extends Command {
 			->addOption('force', 'f', InputOption::VALUE_NONE, "Force the migration by removing existing shares");
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$userOrigin = $input->getArgument('sourceuid');
 		$userDestination = $input->getArgument('destinationuid');
 
@@ -137,6 +137,7 @@ class MoveCalendar extends Command {
 		$this->calDav->moveCalendar($name, self::URI_USERS . $userOrigin, self::URI_USERS . $userDestination);
 
 		$this->io->success("Calendar <$name> was moved from user <$userOrigin> to <$userDestination>");
+		return 0;
 	}
 
 	/**

--- a/apps/dav/lib/Command/RemoveInvalidShares.php
+++ b/apps/dav/lib/Command/RemoveInvalidShares.php
@@ -57,7 +57,7 @@ class RemoveInvalidShares extends Command {
 			->setDescription('Remove invalid dav shares');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$query = $this->connection->getQueryBuilder();
 		$result = $query->selectDistinct('principaluri')
 			->from('dav_shares')
@@ -72,6 +72,7 @@ class RemoveInvalidShares extends Command {
 		}
 
 		$result->closeCursor();
+		return 0;
 	}
 
 	/**

--- a/apps/dav/lib/Command/SendEventReminders.php
+++ b/apps/dav/lib/Command/SendEventReminders.php
@@ -67,19 +67,20 @@ class SendEventReminders extends Command {
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output):void {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if ($this->config->getAppValue('dav', 'sendEventReminders', 'yes') !== 'yes') {
 			$output->writeln('<error>Sending event reminders disabled!</error>');
 			$output->writeln('<info>Please run "php occ config:app:set dav sendEventReminders --value yes"');
-			return;
+			return 1;
 		}
 
 		if ($this->config->getAppValue('dav', 'sendEventRemindersMode', 'backgroundjob') !== 'occ') {
 			$output->writeln('<error>Sending event reminders mode set to background-job!</error>');
 			$output->writeln('<info>Please run "php occ config:app:set dav sendEventRemindersMode --value occ"');
-			return;
+			return 1;
 		}
 
 		$this->reminderService->processReminders();
+		return 0;
 	}
 }

--- a/apps/dav/lib/Command/SyncBirthdayCalendar.php
+++ b/apps/dav/lib/Command/SyncBirthdayCalendar.php
@@ -73,7 +73,7 @@ class SyncBirthdayCalendar extends Command {
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$this->verifyEnabled();
 
 		$user = $input->getArgument('user');
@@ -91,7 +91,7 @@ class SyncBirthdayCalendar extends Command {
 
 			$output->writeln("Start birthday calendar sync for $user");
 			$this->birthdayService->syncUser($user);
-			return;
+			return 0;
 		}
 		$output->writeln("Start birthday calendar sync for all users ...");
 		$p = new ProgressBar($output);
@@ -111,6 +111,7 @@ class SyncBirthdayCalendar extends Command {
 
 		$p->finish();
 		$output->writeln('');
+		return 0;
 	}
 
 	protected function verifyEnabled() {

--- a/apps/dav/lib/Command/SyncSystemAddressBook.php
+++ b/apps/dav/lib/Command/SyncSystemAddressBook.php
@@ -53,7 +53,7 @@ class SyncSystemAddressBook extends Command {
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$output->writeln('Syncing users ...');
 		$progress = new ProgressBar($output);
 		$progress->start();
@@ -63,5 +63,6 @@ class SyncSystemAddressBook extends Command {
 
 		$progress->finish();
 		$output->writeln('');
+		return 0;
 	}
 }

--- a/apps/encryption/lib/Command/DisableMasterKey.php
+++ b/apps/encryption/lib/Command/DisableMasterKey.php
@@ -63,7 +63,7 @@ class DisableMasterKey extends Command {
 			->setDescription('Disable the master key and use per-user keys instead. Only available for fresh installations with no existing encrypted data! There is no way to enable it again.');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$isMasterKeyEnabled = $this->util->isMasterKeyEnabled();
 
 		if (!$isMasterKeyEnabled) {
@@ -80,7 +80,9 @@ class DisableMasterKey extends Command {
 				$output->writeln('Master key successfully disabled.');
 			} else {
 				$output->writeln('aborted.');
+				return 1;
 			}
 		}
+		return 0;
 	}
 }

--- a/apps/encryption/lib/Command/EnableMasterKey.php
+++ b/apps/encryption/lib/Command/EnableMasterKey.php
@@ -62,7 +62,7 @@ class EnableMasterKey extends Command {
 			->setDescription('Enable the master key. Only available for fresh installations with no existing encrypted data! There is also no way to disable it again.');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$isAlreadyEnabled = $this->util->isMasterKeyEnabled();
 
 		if ($isAlreadyEnabled) {
@@ -76,7 +76,9 @@ class EnableMasterKey extends Command {
 				$output->writeln('Master key successfully enabled.');
 			} else {
 				$output->writeln('aborted.');
+				return 1;
 			}
 		}
+		return 0;
 	}
 }

--- a/apps/encryption/lib/Command/RecoverUser.php
+++ b/apps/encryption/lib/Command/RecoverUser.php
@@ -73,25 +73,25 @@ class RecoverUser extends Command {
 		);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$isMasterKeyEnabled = $this->util->isMasterKeyEnabled();
 
 		if ($isMasterKeyEnabled) {
 			$output->writeln('You use the master key, no individual user recovery needed.');
-			return;
+			return 0;
 		}
 
 		$uid = $input->getArgument('user');
 		$userExists = $this->userManager->userExists($uid);
 		if ($userExists === false) {
 			$output->writeln('User "' . $uid . '" unknown.');
-			return;
+			return 1;
 		}
 
 		$recoveryKeyEnabled = $this->util->isRecoveryEnabledForUser($uid);
 		if ($recoveryKeyEnabled === false) {
 			$output->writeln('Recovery key is not enabled for: ' . $uid);
-			return;
+			return 1;
 		}
 
 		$question = new Question('Please enter the recovery key password: ');
@@ -107,5 +107,6 @@ class RecoverUser extends Command {
 		$output->write('Start to recover users files... This can take some time...');
 		$this->userManager->get($uid)->setPassword($newLoginPassword, $recoveryPassword);
 		$output->writeln('Done.');
+		return 0;
 	}
 }

--- a/apps/federation/lib/Command/SyncFederationAddressBooks.php
+++ b/apps/federation/lib/Command/SyncFederationAddressBooks.php
@@ -56,7 +56,7 @@ class SyncFederationAddressBooks extends Command {
 	 * @param OutputInterface $output
 	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$progress = new ProgressBar($output);
 		$progress->start();
 		$this->syncService->syncThemAll(function ($url, $ex) use ($progress, $output) {

--- a/apps/files/lib/Command/DeleteOrphanedFiles.php
+++ b/apps/files/lib/Command/DeleteOrphanedFiles.php
@@ -51,7 +51,7 @@ class DeleteOrphanedFiles extends Command {
 			->setDescription('cleanup filecache');
 	}
 
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$deletedEntries = 0;
 
 		$query = $this->connection->getQueryBuilder();
@@ -78,5 +78,6 @@ class DeleteOrphanedFiles extends Command {
 		}
 
 		$output->writeln("$deletedEntries orphaned file cache entries deleted");
+		return 0;
 	}
 }

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -169,7 +169,7 @@ class Scan extends Base {
 		return substr_count($mountPoint->getMountPoint(), '/') <= 3;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$inputPath = $input->getOption('path');
 		if ($inputPath) {
 			$inputPath = '/' . trim($inputPath, '/');
@@ -190,7 +190,7 @@ class Scan extends Base {
 		$users_total = count($users);
 		if ($users_total === 0) {
 			$output->writeln('<error>Please specify the user id to scan, --all to scan for all users or --path=...</error>');
-			return;
+			return 1;
 		}
 
 		$this->initTools();
@@ -219,6 +219,7 @@ class Scan extends Base {
 		}
 
 		$this->presentStats($output);
+		return 0;
 	}
 
 	/**

--- a/apps/files/lib/Command/ScanAppData.php
+++ b/apps/files/lib/Command/ScanAppData.php
@@ -149,7 +149,7 @@ class ScanAppData extends Base {
 	}
 
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		# restrict the verbosity level to VERBOSITY_VERBOSE
 		if ($output->getVerbosity() > OutputInterface::VERBOSITY_VERBOSE) {
 			$output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);

--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -86,7 +86,7 @@ class TransferOwnership extends Command {
 		);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$sourceUserObject = $this->userManager->get($input->getArgument('source-user'));
 		$destinationUserObject = $this->userManager->get($input->getArgument('destination-user'));
 

--- a/apps/files_external/lib/Command/Applicable.php
+++ b/apps/files_external/lib/Command/Applicable.php
@@ -100,7 +100,7 @@ class Applicable extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$mountId = $input->getArgument('mount_id');
 		try {
 			$mount = $this->globalService->getStorage($mountId);
@@ -154,5 +154,6 @@ class Applicable extends Base {
 			'users' => $applicableUsers,
 			'groups' => $applicableGroups
 		]);
+		return 0;
 	}
 }

--- a/apps/files_external/lib/Command/Backends.php
+++ b/apps/files_external/lib/Command/Backends.php
@@ -59,7 +59,7 @@ class Backends extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$authBackends = $this->backendService->getAuthMechanisms();
 		$storageBackends = $this->backendService->getBackends();
 
@@ -87,6 +87,7 @@ class Backends extends Base {
 		}
 
 		$this->writeArrayInOutputFormat($input, $output, $data);
+		return 0;
 	}
 
 	private function serializeAuthBackend(\JsonSerializable $backend) {

--- a/apps/files_external/lib/Command/Config.php
+++ b/apps/files_external/lib/Command/Config.php
@@ -64,7 +64,7 @@ class Config extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$mountId = $input->getArgument('mount_id');
 		$key = $input->getArgument('key');
 		try {
@@ -80,6 +80,7 @@ class Config extends Base {
 		} else {
 			$this->getOption($mount, $key, $output);
 		}
+		return 0;
 	}
 
 	/**

--- a/apps/files_external/lib/Command/Create.php
+++ b/apps/files_external/lib/Command/Create.php
@@ -119,7 +119,7 @@ class Create extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $input->getOption('user');
 		$mountPoint = $input->getArgument('mount_point');
 		$storageIdentifier = $input->getArgument('storage_backend');

--- a/apps/files_external/lib/Command/Delete.php
+++ b/apps/files_external/lib/Command/Delete.php
@@ -84,7 +84,7 @@ class Delete extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$mountId = $input->getArgument('mount_id');
 		try {
 			$mount = $this->globalService->getStorage($mountId);
@@ -105,10 +105,11 @@ class Delete extends Base {
 			$question = new ConfirmationQuestion('Delete this mount? [y/N] ', false);
 
 			if (!$questionHelper->ask($input, $output, $question)) {
-				return null;
+				return 1;
 			}
 		}
 
 		$this->globalService->removeStorage($mountId);
+		return 0;
 	}
 }

--- a/apps/files_external/lib/Command/Export.php
+++ b/apps/files_external/lib/Command/Export.php
@@ -45,7 +45,7 @@ class Export extends ListCommand {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$listCommand = new ListCommand($this->globalService, $this->userService, $this->userSession, $this->userManager);
 		$listInput = new ArrayInput([], $listCommand->getDefinition());
 		$listInput->setArgument('user_id', $input->getArgument('user_id'));
@@ -54,5 +54,6 @@ class Export extends ListCommand {
 		$listInput->setOption('show-password', true);
 		$listInput->setOption('full', true);
 		$listCommand->execute($listInput, $output);
+		return 0;
 	}
 }

--- a/apps/files_external/lib/Command/Import.php
+++ b/apps/files_external/lib/Command/Import.php
@@ -107,7 +107,7 @@ class Import extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $input->getOption('user');
 		$path = $input->getArgument('path');
 		if ($path === '-') {

--- a/apps/files_external/lib/Command/ListCommand.php
+++ b/apps/files_external/lib/Command/ListCommand.php
@@ -96,7 +96,7 @@ class ListCommand extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if ($input->getOption('all')) {
 			/** @var  $mounts StorageConfig[] */
 			$mounts = $this->globalService->getStorageForAllUsers();
@@ -110,6 +110,7 @@ class ListCommand extends Base {
 		}
 
 		$this->listMounts($userId, $mounts, $input, $output);
+		return 0;
 	}
 
 	/**

--- a/apps/files_external/lib/Command/Notify.php
+++ b/apps/files_external/lib/Command/Notify.php
@@ -88,7 +88,7 @@ class Notify extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$mount = $this->globalService->getStorage($input->getArgument('mount_id'));
 		if (is_null($mount)) {
 			$output->writeln('<error>Mount not found</error>');
@@ -147,6 +147,7 @@ class Notify extends Base {
 			}
 			$this->markParentAsOutdated($mount->getId(), $change->getPath(), $output);
 		});
+		return 0;
 	}
 
 	private function createStorage(StorageConfig $mount) {

--- a/apps/files_external/lib/Command/Verify.php
+++ b/apps/files_external/lib/Command/Verify.php
@@ -65,7 +65,7 @@ class Verify extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$mountId = $input->getArgument('mount_id');
 		$configInput = $input->getOption('config');
 
@@ -83,6 +83,7 @@ class Verify extends Base {
 			'code' => $mount->getStatus(),
 			'message' => $mount->getStatusMessage()
 		]);
+		return 0;
 	}
 
 	private function manipulateStorageConfig(StorageConfig $storage) {

--- a/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
+++ b/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
@@ -59,7 +59,7 @@ class CleanupRemoteStorages extends Command {
 			);
 	}
 
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$remoteStorages = $this->getRemoteStorages();
 
 		$output->writeln(count($remoteStorages) . ' remote storage(s) need(s) to be checked');
@@ -93,6 +93,7 @@ class CleanupRemoteStorages extends Command {
 				}
 			}
 		}
+		return 0;
 	}
 
 	public function countFiles($numericId, OutputInterface $output) {

--- a/apps/files_sharing/lib/Command/ExiprationNotification.php
+++ b/apps/files_sharing/lib/Command/ExiprationNotification.php
@@ -63,7 +63,7 @@ class ExiprationNotification extends Command {
 			->setDescription('Notify share initiators when a share will expire the next day.');
 	}
 
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		//Current time
 		$minTime = $this->time->getDateTime();
 		$minTime->add(new \DateInterval('P1D'));
@@ -94,5 +94,6 @@ class ExiprationNotification extends Command {
 			$notification->setUser($share->getSharedBy());
 			$this->notificationManager->notify($notification);
 		}
+		return 0;
 	}
 }

--- a/apps/files_trashbin/lib/Command/CleanUp.php
+++ b/apps/files_trashbin/lib/Command/CleanUp.php
@@ -77,7 +77,7 @@ class CleanUp extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$users = $input->getArgument('user_id');
 		if ((!empty($users)) and ($input->getOption('all-users'))) {
 			throw new InvalidOptionException('Either specify a user_id or --all-users');
@@ -88,6 +88,7 @@ class CleanUp extends Command {
 					$this->removeDeletedFiles($user);
 				} else {
 					$output->writeln("<error>Unknown user $user</error>");
+					return 1;
 				}
 			}
 		} elseif ($input->getOption('all-users')) {
@@ -112,6 +113,7 @@ class CleanUp extends Command {
 		} else {
 			throw new InvalidOptionException('Either specify a user_id or --all-users');
 		}
+		return 0;
 	}
 
 	/**

--- a/apps/files_trashbin/lib/Command/ExpireTrash.php
+++ b/apps/files_trashbin/lib/Command/ExpireTrash.php
@@ -42,7 +42,7 @@ class ExpireTrash extends Command {
 	 * @var Expiration
 	 */
 	private $expiration;
-	
+
 	/**
 	 * @var IUserManager
 	 */
@@ -71,11 +71,11 @@ class ExpireTrash extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$maxAge = $this->expiration->getMaxAgeAsTimestamp();
 		if (!$maxAge) {
 			$output->writeln("No expiry configured.");
-			return;
+			return 1;
 		}
 
 		$users = $input->getArgument('user_id');
@@ -87,6 +87,7 @@ class ExpireTrash extends Command {
 					$this->expireTrashForUser($userObject);
 				} else {
 					$output->writeln("<error>Unknown user $user</error>");
+					return 1;
 				}
 			}
 		} else {
@@ -99,6 +100,7 @@ class ExpireTrash extends Command {
 			$p->finish();
 			$output->writeln('');
 		}
+		return 0;
 	}
 
 	public function expireTrashForUser(IUser $user) {

--- a/apps/files_versions/lib/Command/CleanUp.php
+++ b/apps/files_versions/lib/Command/CleanUp.php
@@ -61,7 +61,7 @@ class CleanUp extends Command {
 	}
 
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$users = $input->getArgument('user_id');
 		if (!empty($users)) {
 			foreach ($users as $user) {
@@ -70,6 +70,7 @@ class CleanUp extends Command {
 					$this->deleteVersions($user);
 				} else {
 					$output->writeln("<error>Unknown user $user</error>");
+					return 1;
 				}
 			}
 		} else {
@@ -95,6 +96,7 @@ class CleanUp extends Command {
 				} while (count($users) >= $limit);
 			}
 		}
+		return 0;
 	}
 
 

--- a/apps/files_versions/lib/Command/ExpireVersions.php
+++ b/apps/files_versions/lib/Command/ExpireVersions.php
@@ -74,7 +74,7 @@ class ExpireVersions extends Command {
 		$maxAge = $this->expiration->getMaxAgeAsTimestamp();
 		if (!$maxAge) {
 			$output->writeln("No expiry configured.");
-			return;
+			return 1;
 		}
 
 		$users = $input->getArgument('user_id');

--- a/apps/files_versions/lib/Command/ExpireVersions.php
+++ b/apps/files_versions/lib/Command/ExpireVersions.php
@@ -41,7 +41,7 @@ class ExpireVersions extends Command {
 	 * @var Expiration
 	 */
 	private $expiration;
-	
+
 	/**
 	 * @var IUserManager
 	 */
@@ -70,7 +70,7 @@ class ExpireVersions extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$maxAge = $this->expiration->getMaxAgeAsTimestamp();
 		if (!$maxAge) {
 			$output->writeln("No expiry configured.");
@@ -86,6 +86,7 @@ class ExpireVersions extends Command {
 					$this->expireVersionsForUser($userObject);
 				} else {
 					$output->writeln("<error>Unknown user $user</error>");
+					return 1;
 				}
 			}
 		} else {
@@ -98,6 +99,7 @@ class ExpireVersions extends Command {
 			$p->finish();
 			$output->writeln('');
 		}
+		return 0;
 	}
 
 	public function expireVersionsForUser(IUser $user) {

--- a/apps/updatenotification/lib/Command/Check.php
+++ b/apps/updatenotification/lib/Command/Check.php
@@ -63,7 +63,7 @@ class Check extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$updatesAvailableCount = 0;
 
 		// Server

--- a/apps/user_ldap/lib/Command/CheckUser.php
+++ b/apps/user_ldap/lib/Command/CheckUser.php
@@ -87,7 +87,7 @@ class CheckUser extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		try {
 			$uid = $input->getArgument('ocName');
 			$this->isAllowed($input->getOption('force'));
@@ -98,15 +98,17 @@ class CheckUser extends Command {
 				if ($input->getOption('update')) {
 					$this->updateUser($uid, $output);
 				}
-				return;
+				return 0;
 			}
 
 			$this->dui->markUser($uid);
 			$output->writeln('The user does not exists on LDAP anymore.');
 			$output->writeln('Clean up the user\'s remnants by: ./occ user:delete "'
 				. $uid . '"');
+			return 0;
 		} catch (\Exception $e) {
 			$output->writeln('<error>' . $e->getMessage(). '</error>');
+			return 1;
 		}
 	}
 

--- a/apps/user_ldap/lib/Command/CreateEmptyConfig.php
+++ b/apps/user_ldap/lib/Command/CreateEmptyConfig.php
@@ -58,7 +58,7 @@ class CreateEmptyConfig extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$configPrefix = $this->helper->getNextServerConfigurationPrefix();
 		$configHolder = new Configuration($configPrefix);
 		$configHolder->saveConfiguration();
@@ -68,5 +68,6 @@ class CreateEmptyConfig extends Command {
 			$prose = 'Created new configuration with configID ';
 		}
 		$output->writeln($prose . "{$configPrefix}");
+		return 0;
 	}
 }

--- a/apps/user_ldap/lib/Command/DeleteConfig.php
+++ b/apps/user_ldap/lib/Command/DeleteConfig.php
@@ -57,15 +57,17 @@ class DeleteConfig extends Command {
 	}
 
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$configPrefix = $input->getArgument('configID');
 
 		$success = $this->helper->deleteServerConfiguration($configPrefix);
 
 		if ($success) {
 			$output->writeln("Deleted configuration with configID '{$configPrefix}'");
+			return 0;
 		} else {
 			$output->writeln("Cannot delete configuration with configID '{$configPrefix}'");
+			return 1;
 		}
 	}
 }

--- a/apps/user_ldap/lib/Command/Search.php
+++ b/apps/user_ldap/lib/Command/Search.php
@@ -105,7 +105,7 @@ class Search extends Command {
 		}
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$helper = new Helper($this->ocConfig);
 		$configPrefixes = $helper->getServerConfigurationPrefixes(true);
 		$ldapWrapper = new LDAP();
@@ -141,5 +141,6 @@ class Search extends Command {
 			$line = $name . ($printID ? ' ('.$id.')' : '');
 			$output->writeln($line);
 		}
+		return 0;
 	}
 }

--- a/apps/user_ldap/lib/Command/SetConfig.php
+++ b/apps/user_ldap/lib/Command/SetConfig.php
@@ -59,13 +59,13 @@ class SetConfig extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$helper = new Helper(\OC::$server->getConfig());
 		$availableConfigs = $helper->getServerConfigurationPrefixes();
 		$configID = $input->getArgument('configID');
 		if (!in_array($configID, $availableConfigs)) {
 			$output->writeln("Invalid configID");
-			return;
+			return 1;
 		}
 
 		$this->setValue(
@@ -73,6 +73,7 @@ class SetConfig extends Command {
 			$input->getArgument('configKey'),
 			$input->getArgument('configValue')
 		);
+		return 0;
 	}
 
 	/**

--- a/apps/user_ldap/lib/Command/ShowConfig.php
+++ b/apps/user_ldap/lib/Command/ShowConfig.php
@@ -66,20 +66,21 @@ class ShowConfig extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$availableConfigs = $this->helper->getServerConfigurationPrefixes();
 		$configID = $input->getArgument('configID');
 		if (!is_null($configID)) {
 			$configIDs[] = $configID;
 			if (!in_array($configIDs[0], $availableConfigs)) {
 				$output->writeln("Invalid configID");
-				return;
+				return 1;
 			}
 		} else {
 			$configIDs = $availableConfigs;
 		}
 
 		$this->renderConfigs($configIDs, $output, $input->getOption('show-password'));
+		return 0;
 	}
 
 	/**

--- a/apps/user_ldap/lib/Command/ShowRemnants.php
+++ b/apps/user_ldap/lib/Command/ShowRemnants.php
@@ -75,7 +75,7 @@ class ShowRemnants extends Command {
 	 *
 	 * {@inheritdoc}
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		/** @var \Symfony\Component\Console\Helper\Table $table */
 		$table = new Table($output);
 		$table->setHeaders([
@@ -103,5 +103,6 @@ class ShowRemnants extends Command {
 			$table->setRows($rows);
 			$table->render($output);
 		}
+		return 0;
 	}
 }

--- a/apps/user_ldap/lib/Command/TestConfig.php
+++ b/apps/user_ldap/lib/Command/TestConfig.php
@@ -47,13 +47,13 @@ class TestConfig extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$helper = new Helper(\OC::$server->getConfig());
 		$availableConfigs = $helper->getServerConfigurationPrefixes();
 		$configID = $input->getArgument('configID');
 		if (!in_array($configID, $availableConfigs)) {
 			$output->writeln("Invalid configID");
-			return;
+			return 1;
 		}
 
 		$result = $this->testConfig($configID);
@@ -61,11 +61,13 @@ class TestConfig extends Command {
 			$output->writeln('The configuration is valid and the connection could be established!');
 		} elseif ($result === 1) {
 			$output->writeln('The configuration is invalid. Please have a look at the logs for further details.');
+			return 1;
 		} elseif ($result === 2) {
 			$output->writeln('The configuration is valid, but the Bind failed. Please check the server settings and credentials.');
 		} else {
 			$output->writeln('Your LDAP server was kidnapped by aliens.');
 		}
+		return 0;
 	}
 
 	/**

--- a/apps/workflowengine/lib/Command/Index.php
+++ b/apps/workflowengine/lib/Command/Index.php
@@ -69,7 +69,7 @@ class Index extends Command {
 		return $scopes[$scope] ?? -1;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$ops = $this->manager->getAllOperations(
 			new ScopeContext(
 				$this->mappedScope($input->getArgument('scope')),
@@ -77,5 +77,6 @@ class Index extends Command {
 			)
 		);
 		$output->writeln(\json_encode($ops));
+		return 0;
 	}
 }

--- a/core/Command/App/CheckCode.php
+++ b/core/Command/App/CheckCode.php
@@ -80,7 +80,7 @@ class CheckCode extends Command implements CompletionAwareInterface {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appId = $input->getArgument('app-id');
 
 		$checkList = new EmptyCheck();

--- a/core/Command/App/Disable.php
+++ b/core/Command/App/Disable.php
@@ -60,7 +60,7 @@ class Disable extends Command implements CompletionAwareInterface {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appIds = $input->getArgument('app-id');
 
 		foreach ($appIds as $appId) {

--- a/core/Command/App/Enable.php
+++ b/core/Command/App/Enable.php
@@ -83,7 +83,7 @@ class Enable extends Command implements CompletionAwareInterface {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appIds = $input->getArgument('app-id');
 		$groups = $this->resolveGroupIds($input->getOption('groups'));
 		$forceEnable = (bool) $input->getOption('force');

--- a/core/Command/App/GetPath.php
+++ b/core/Command/App/GetPath.php
@@ -51,7 +51,7 @@ class GetPath extends Base {
 	 * @param OutputInterface $output An OutputInterface instance
 	 * @return null|int null or 0 if everything went fine, or an error code
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appName = $input->getArgument('app');
 		$path = \OC_App::getAppPath($appName);
 		if ($path !== false) {

--- a/core/Command/App/Install.php
+++ b/core/Command/App/Install.php
@@ -51,7 +51,7 @@ class Install extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appId = $input->getArgument('app-id');
 
 		if (\OC_App::getAppPath($appId)) {

--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -61,7 +61,7 @@ class ListApps extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if ($input->getOption('shipped') === 'true' || $input->getOption('shipped') === 'false') {
 			$shippedFilter = $input->getOption('shipped') === 'true';
 		} else {
@@ -97,6 +97,7 @@ class ListApps extends Base {
 		}
 
 		$this->writeAppList($input, $output, $apps);
+		return 0;
 	}
 
 	/**

--- a/core/Command/App/Remove.php
+++ b/core/Command/App/Remove.php
@@ -75,7 +75,7 @@ class Remove extends Command implements CompletionAwareInterface {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appId = $input->getArgument('app-id');
 
 		// Check if the app is installed

--- a/core/Command/App/Update.php
+++ b/core/Command/App/Update.php
@@ -80,7 +80,7 @@ class Update extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$singleAppId = $input->getArgument('app-id');
 
 		if ($singleAppId) {

--- a/core/Command/Background/Base.php
+++ b/core/Command/Background/Base.php
@@ -48,8 +48,8 @@ abstract class Base extends Command {
 	 * @param \OCP\IConfig $config
 	 */
 	public function __construct(IConfig $config) {
-		$this->config = $config;
 		parent::__construct();
+		$this->config = $config;
 	}
 
 	protected function configure() {
@@ -67,9 +67,10 @@ abstract class Base extends Command {
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$mode = $this->getMode();
 		$this->config->setAppValue('core', 'backgroundjobs_mode', $mode);
 		$output->writeln("Set mode for background jobs to '$mode'");
+		return 0;
 	}
 }

--- a/core/Command/Broadcast/Test.php
+++ b/core/Command/Broadcast/Test.php
@@ -60,7 +60,7 @@ class Test extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$name = $input->getArgument('name');
 		$uid = $input->getArgument('uid');
 

--- a/core/Command/Check.php
+++ b/core/Command/Check.php
@@ -50,7 +50,7 @@ class Check extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$errors = \OC_Util::checkServer($this->config);
 		if (!empty($errors)) {
 			$errors = array_map(function ($item) {

--- a/core/Command/Config/App/DeleteConfig.php
+++ b/core/Command/Config/App/DeleteConfig.php
@@ -65,7 +65,7 @@ class DeleteConfig extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appName = $input->getArgument('app');
 		$configName = $input->getArgument('name');
 

--- a/core/Command/Config/App/GetConfig.php
+++ b/core/Command/Config/App/GetConfig.php
@@ -72,7 +72,7 @@ class GetConfig extends Base {
 	 * @param OutputInterface $output An OutputInterface instance
 	 * @return null|int null or 0 if everything went fine, or an error code
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appName = $input->getArgument('app');
 		$configName = $input->getArgument('name');
 		$defaultValue = $input->getOption('default-value');

--- a/core/Command/Config/App/SetConfig.php
+++ b/core/Command/Config/App/SetConfig.php
@@ -71,7 +71,7 @@ class SetConfig extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appName = $input->getArgument('app');
 		$configName = $input->getArgument('name');
 

--- a/core/Command/Config/Import.php
+++ b/core/Command/Config/Import.php
@@ -60,7 +60,7 @@ class Import extends Command implements CompletionAwareInterface {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$importFile = $input->getArgument('file');
 		if ($importFile !== null) {
 			$content = $this->getArrayFromFile($importFile);
@@ -72,7 +72,7 @@ class Import extends Command implements CompletionAwareInterface {
 			$configs = $this->validateFileContent($content);
 		} catch (\UnexpectedValueException $e) {
 			$output->writeln('<error>' . $e->getMessage(). '</error>');
-			return;
+			return 1;
 		}
 
 		if (!empty($configs['system'])) {
@@ -92,6 +92,7 @@ class Import extends Command implements CompletionAwareInterface {
 		}
 
 		$output->writeln('<info>Config successfully imported from: ' . $importFile . '</info>');
+		return 0;
 	}
 
 	/**

--- a/core/Command/Config/ListConfigs.php
+++ b/core/Command/Config/ListConfigs.php
@@ -71,7 +71,7 @@ class ListConfigs extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$app = $input->getArgument('app');
 		$noSensitiveValues = !$input->getOption('private');
 
@@ -102,6 +102,7 @@ class ListConfigs extends Base {
 		}
 
 		$this->writeArrayInOutputFormat($input, $output, $configs);
+		return 0;
 	}
 
 	/**

--- a/core/Command/Config/System/DeleteConfig.php
+++ b/core/Command/Config/System/DeleteConfig.php
@@ -62,7 +62,7 @@ class DeleteConfig extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$configNames = $input->getArgument('name');
 		$configName = $configNames[0];
 

--- a/core/Command/Config/System/GetConfig.php
+++ b/core/Command/Config/System/GetConfig.php
@@ -68,7 +68,7 @@ class GetConfig extends Base {
 	 * @param OutputInterface $output An OutputInterface instance
 	 * @return null|int null or 0 if everything went fine, or an error code
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$configNames = $input->getArgument('name');
 		$configName = array_shift($configNames);
 		$defaultValue = $input->getOption('default-value');

--- a/core/Command/Config/System/SetConfig.php
+++ b/core/Command/Config/System/SetConfig.php
@@ -77,7 +77,7 @@ class SetConfig extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$configNames = $input->getArgument('name');
 		$configName = $configNames[0];
 		$configValue = $this->castValue($input->getOption('value'), $input->getOption('type'));

--- a/core/Command/Db/AddMissingColumns.php
+++ b/core/Command/Db/AddMissingColumns.php
@@ -63,12 +63,13 @@ class AddMissingColumns extends Command {
 			->setDescription('Add missing optional columns to the database tables');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$this->addCoreColumns($output);
 
 		// Dispatch event so apps can also update columns if needed
 		$event = new GenericEvent($output);
 		$this->dispatcher->dispatch(IDBConnection::ADD_MISSING_COLUMNS_EVENT, $event);
+		return 0;
 	}
 
 	/**

--- a/core/Command/Db/AddMissingIndices.php
+++ b/core/Command/Db/AddMissingIndices.php
@@ -69,12 +69,13 @@ class AddMissingIndices extends Command {
 			->setDescription('Add missing indices to the database tables');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$this->addCoreIndexes($output);
 
 		// Dispatch event so apps can also update indexes if needed
 		$event = new GenericEvent($output);
 		$this->dispatcher->dispatch(IDBConnection::ADD_MISSING_INDEXES_EVENT, $event);
+		return 0;
 	}
 
 	/**

--- a/core/Command/Db/ConvertFilecacheBigInt.php
+++ b/core/Command/Db/ConvertFilecacheBigInt.php
@@ -71,7 +71,7 @@ class ConvertFilecacheBigInt extends Command {
 		];
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$schema = new SchemaWrapper($this->connection);
 		$isSqlite = $this->connection->getDatabasePlatform() instanceof SqlitePlatform;
 		$updates = [];

--- a/core/Command/Db/ConvertMysqlToMB4.php
+++ b/core/Command/Db/ConvertMysqlToMB4.php
@@ -68,7 +68,7 @@ class ConvertMysqlToMB4 extends Command {
 			->setDescription('Convert charset of MySQL/MariaDB to use utf8mb4');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if (!$this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
 			$output->writeln("This command is only valid for MySQL/MariaDB databases.");
 			return 1;

--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -188,7 +188,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 		}
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$this->validateInput($input, $output);
 		$this->readPassword($input, $output);
 
@@ -221,11 +221,12 @@ class ConvertType extends Command implements CompletionAwareInterface {
 			$helper = $this->getHelper('question');
 
 			if (!$helper->ask($input, $output, $question)) {
-				return;
+				return 1;
 			}
 		}
 		$intersectingTables = array_intersect($toTables, $fromTables);
 		$this->convertDB($fromDB, $toDB, $intersectingTables, $input, $output);
+		return 0;
 	}
 
 	protected function createSchema(Connection $fromDB, Connection $toDB, InputInterface $input, OutputInterface $output) {

--- a/core/Command/Db/Migrations/ExecuteCommand.php
+++ b/core/Command/Db/Migrations/ExecuteCommand.php
@@ -75,7 +75,7 @@ class ExecuteCommand extends Command implements CompletionAwareInterface {
 	 * @param OutputInterface $output
 	 * @return int
 	 */
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$appName = $input->getArgument('app');
 		$ms = new MigrationService($appName, $this->connection, new ConsoleOutput($output));
 		$version = $input->getArgument('version');

--- a/core/Command/Db/Migrations/GenerateCommand.php
+++ b/core/Command/Db/Migrations/GenerateCommand.php
@@ -110,7 +110,7 @@ class {{classname}} extends SimpleMigrationStep {
 		parent::configure();
 	}
 
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$appName = $input->getArgument('app');
 		$version = $input->getArgument('version');
 

--- a/core/Command/Db/Migrations/GenerateFromSchemaFileCommand.php
+++ b/core/Command/Db/Migrations/GenerateFromSchemaFileCommand.php
@@ -52,7 +52,7 @@ class GenerateFromSchemaFileCommand extends GenerateCommand {
 		$this->setName('migrations:generate-from-schema');
 	}
 
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$appName = $input->getArgument('app');
 		$version = $input->getArgument('version');
 

--- a/core/Command/Db/Migrations/MigrateCommand.php
+++ b/core/Command/Db/Migrations/MigrateCommand.php
@@ -55,12 +55,13 @@ class MigrateCommand extends Command implements CompletionAwareInterface {
 		parent::configure();
 	}
 
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$appName = $input->getArgument('app');
 		$ms = new MigrationService($appName, $this->connection, new ConsoleOutput($output));
 		$version = $input->getArgument('version');
 
 		$ms->migrate($version);
+		return 0;
 	}
 
 	/**

--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -53,7 +53,7 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 			->addArgument('app', InputArgument::REQUIRED, 'Name of the app this migration command shall work on');
 	}
 
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$appName = $input->getArgument('app');
 		$ms = new MigrationService($appName, $this->connection, new ConsoleOutput($output));
 
@@ -68,6 +68,7 @@ class StatusCommand extends Command implements CompletionAwareInterface {
 				$output->writeln("    <comment>>></comment> $key: " . str_repeat(' ', 50 - strlen($key)) . $value);
 			}
 		}
+		return 0;
 	}
 
 	/**

--- a/core/Command/Encryption/ChangeKeyStorageRoot.php
+++ b/core/Command/Encryption/ChangeKeyStorageRoot.php
@@ -84,14 +84,14 @@ class ChangeKeyStorageRoot extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$oldRoot = $this->util->getKeyStorageRoot();
 		$newRoot = $input->getArgument('newRoot');
 
 		if ($newRoot === null) {
 			$question = new ConfirmationQuestion('No storage root given, do you want to reset the key storage root to the default location? (y/n) ', false);
 			if (!$this->questionHelper->ask($input, $output, $question)) {
-				return;
+				return 1;
 			}
 			$newRoot = '';
 		}
@@ -104,7 +104,9 @@ class ChangeKeyStorageRoot extends Command {
 			$this->util->setKeyStorageRoot($newRoot);
 			$output->writeln('');
 			$output->writeln("Key storage root successfully changed to <info>$newRootDescription</info>");
+			return 0;
 		}
+		return 1;
 	}
 
 	/**

--- a/core/Command/Encryption/DecryptAll.php
+++ b/core/Command/Encryption/DecryptAll.php
@@ -125,14 +125,14 @@ class DecryptAll extends Command {
 		);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if (!$input->isInteractive()) {
 			$output->writeln('Invalid TTY.');
 			$output->writeln('If you are trying to execute the command in a Docker ');
 			$output->writeln("container, do not forget to execute 'docker exec' with");
 			$output->writeln("the '-i' and '-t' options.");
 			$output->writeln('');
-			return;
+			return 1;
 		}
 
 		$isMaintenanceModeEnabled = $this->config->getSystemValue('maintenance', false);
@@ -141,7 +141,7 @@ class DecryptAll extends Command {
 			$output->writeln("in order to load the relevant encryption modules correctly.");
 			$output->writeln("Your instance will automatically be put to maintenance mode");
 			$output->writeln("during the actual decryption of the files.");
-			return;
+			return 1;
 		}
 
 		try {
@@ -151,7 +151,7 @@ class DecryptAll extends Command {
 				$output->writeln('done.');
 			} else {
 				$output->writeln('Server side encryption not enabled. Nothing to do.');
-				return;
+				return 0;
 			}
 
 			$uid = $input->getArgument('user');
@@ -181,11 +181,13 @@ class DecryptAll extends Command {
 					$this->config->setAppValue('core', 'encryption_enabled', 'yes');
 				}
 				$this->resetMaintenanceAndTrashbin();
+				return 0;
 			} else {
 				$output->write('Enable server side encryption... ');
 				$this->config->setAppValue('core', 'encryption_enabled', 'yes');
 				$output->writeln('done.');
 				$output->writeln('aborted');
+				return 1;
 			}
 		} catch (\Exception $e) {
 			// enable server side encryption again if something went wrong

--- a/core/Command/Encryption/Disable.php
+++ b/core/Command/Encryption/Disable.php
@@ -46,12 +46,13 @@ class Disable extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if ($this->config->getAppValue('core', 'encryption_enabled', 'no') !== 'yes') {
 			$output->writeln('Encryption is already disabled');
 		} else {
 			$this->config->setAppValue('core', 'encryption_enabled', 'no');
 			$output->writeln('<info>Encryption disabled</info>');
 		}
+		return 0;
 	}
 }

--- a/core/Command/Encryption/Enable.php
+++ b/core/Command/Encryption/Enable.php
@@ -54,7 +54,7 @@ class Enable extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if ($this->config->getAppValue('core', 'encryption_enabled', 'no') === 'yes') {
 			$output->writeln('Encryption is already enabled');
 		} else {
@@ -66,15 +66,19 @@ class Enable extends Command {
 		$modules = $this->encryptionManager->getEncryptionModules();
 		if (empty($modules)) {
 			$output->writeln('<error>No encryption module is loaded</error>');
+			return 1;
 		} else {
 			$defaultModule = $this->config->getAppValue('core', 'default_encryption_module', null);
 			if ($defaultModule === null) {
 				$output->writeln('<error>No default module is set</error>');
+				return 1;
 			} elseif (!isset($modules[$defaultModule])) {
 				$output->writeln('<error>The current default module does not exist: ' . $defaultModule . '</error>');
+				return 1;
 			} else {
 				$output->writeln('Default module: ' . $defaultModule);
 			}
 		}
+		return 0;
 	}
 }

--- a/core/Command/Encryption/EncryptAll.php
+++ b/core/Command/Encryption/EncryptAll.php
@@ -106,14 +106,14 @@ class EncryptAll extends Command {
 		);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if (!$input->isInteractive()) {
 			$output->writeln('Invalid TTY.');
 			$output->writeln('If you are trying to execute the command in a Docker ');
 			$output->writeln("container, do not forget to execute 'docker exec' with");
 			$output->writeln("the '-i' and '-t' options.");
 			$output->writeln('');
-			return;
+			return 1;
 		}
 
 		if ($this->encryptionManager->isEnabled() === false) {
@@ -141,6 +141,8 @@ class EncryptAll extends Command {
 			$this->resetMaintenanceAndTrashbin();
 		} else {
 			$output->writeln('aborted');
+			return 1;
 		}
+		return 0;
 	}
 }

--- a/core/Command/Encryption/ListModules.php
+++ b/core/Command/Encryption/ListModules.php
@@ -59,12 +59,12 @@ class ListModules extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$isMaintenanceModeEnabled = $this->config->getSystemValue('maintenance', false);
 		if ($isMaintenanceModeEnabled) {
 			$output->writeln("Maintenance mode must be disabled when listing modules");
 			$output->writeln("in order to list the relevant encryption modules correctly.");
-			return;
+			return 1;
 		}
 
 		$encryptionModules = $this->encryptionManager->getEncryptionModules();
@@ -76,6 +76,7 @@ class ListModules extends Base {
 			$encModules[$module['id']]['default'] = $module['id'] === $defaultEncryptionModuleId;
 		}
 		$this->writeModuleList($input, $output, $encModules);
+		return 0;
 	}
 
 	/**

--- a/core/Command/Encryption/SetDefaultModule.php
+++ b/core/Command/Encryption/SetDefaultModule.php
@@ -65,12 +65,12 @@ class SetDefaultModule extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$isMaintenanceModeEnabled = $this->config->getSystemValue('maintenance', false);
 		if ($isMaintenanceModeEnabled) {
 			$output->writeln("Maintenance mode must be disabled when setting default module,");
 			$output->writeln("in order to load the relevant encryption modules correctly.");
-			return;
+			return 1;
 		}
 
 		$moduleId = $input->getArgument('module');
@@ -81,6 +81,8 @@ class SetDefaultModule extends Command {
 			$output->writeln('<info>Set default module to "' . $moduleId . '"</info>');
 		} else {
 			$output->writeln('<error>The specified module "' . $moduleId . '" does not exist</error>');
+			return 1;
 		}
+		return 0;
 	}
 }

--- a/core/Command/Encryption/ShowKeyStorageRoot.php
+++ b/core/Command/Encryption/ShowKeyStorageRoot.php
@@ -48,11 +48,12 @@ class ShowKeyStorageRoot extends Command {
 			->setDescription('Show current key storage root');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$currentRoot = $this->util->getKeyStorageRoot();
 
 		$rootDescription = $currentRoot !== '' ? $currentRoot : 'default storage location (data/)';
 
 		$output->writeln("Current key storage root:  <info>$rootDescription</info>");
+		return 0;
 	}
 }

--- a/core/Command/Encryption/Status.php
+++ b/core/Command/Encryption/Status.php
@@ -48,10 +48,11 @@ class Status extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$this->writeArrayInOutputFormat($input, $output, [
 			'enabled' => $this->encryptionManager->isEnabled(),
 			'defaultModule' => $this->encryptionManager->getDefaultEncryptionModuleId(),
 		]);
+		return 0;
 	}
 }

--- a/core/Command/Group/Add.php
+++ b/core/Command/Group/Add.php
@@ -65,7 +65,7 @@ class Add extends Base {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$gid = $input->getArgument('groupid');
 		$group = $this->groupManager->get($gid);
 		if ($group) {

--- a/core/Command/Group/AddUser.php
+++ b/core/Command/Group/AddUser.php
@@ -61,7 +61,7 @@ class AddUser extends Base {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$group = $this->groupManager->get($input->getArgument('group'));
 		if (is_null($group)) {
 			$output->writeln('<error>group not found</error>');
@@ -73,5 +73,6 @@ class AddUser extends Base {
 			return 1;
 		}
 		$group->addUser($user);
+		return 0;
 	}
 }

--- a/core/Command/Group/Delete.php
+++ b/core/Command/Group/Delete.php
@@ -55,7 +55,7 @@ class Delete extends Base {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$gid = $input->getArgument('groupid');
 		if ($gid === 'admin') {
 			$output->writeln('<error>Group "' . $gid . '" could not be deleted.</error>');
@@ -72,5 +72,6 @@ class Delete extends Base {
 			$output->writeln('<error>Group "' . $gid . '" could not be deleted. Please check the logs.</error>');
 			return 1;
 		}
+		return 0;
 	}
 }

--- a/core/Command/Group/ListCommand.php
+++ b/core/Command/Group/ListCommand.php
@@ -67,9 +67,10 @@ class ListCommand extends Base {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$groups = $this->groupManager->search('', (int)$input->getOption('limit'), (int)$input->getOption('offset'));
 		$this->writeArrayInOutputFormat($input, $output, $this->formatGroups($groups));
+		return 0;
 	}
 
 	/**

--- a/core/Command/Group/RemoveUser.php
+++ b/core/Command/Group/RemoveUser.php
@@ -61,7 +61,7 @@ class RemoveUser extends Base {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$group = $this->groupManager->get($input->getArgument('group'));
 		if (is_null($group)) {
 			$output->writeln('<error>group not found</error>');
@@ -73,5 +73,6 @@ class RemoveUser extends Base {
 			return 1;
 		}
 		$group->removeUser($user);
+		return 0;
 	}
 }

--- a/core/Command/Integrity/CheckApp.php
+++ b/core/Command/Integrity/CheckApp.php
@@ -66,7 +66,7 @@ class CheckApp extends Base {
 	/**
 	 * {@inheritdoc }
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appid = $input->getArgument('appid');
 		$path = (string)$input->getOption('path');
 		$result = $this->checker->verifyAppSignature($appid, $path);
@@ -74,5 +74,6 @@ class CheckApp extends Base {
 		if (count($result)>0) {
 			return 1;
 		}
+		return 0;
 	}
 }

--- a/core/Command/Integrity/CheckCore.php
+++ b/core/Command/Integrity/CheckCore.php
@@ -59,11 +59,12 @@ class CheckCore extends Base {
 	/**
 	 * {@inheritdoc }
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$result = $this->checker->verifyCoreSignature();
 		$this->writeArrayInOutputFormat($input, $output, $result);
 		if (count($result)>0) {
 			return 1;
 		}
+		return 0;
 	}
 }

--- a/core/Command/Integrity/SignApp.php
+++ b/core/Command/Integrity/SignApp.php
@@ -73,7 +73,7 @@ class SignApp extends Command {
 	/**
 	 * {@inheritdoc }
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$path = $input->getOption('path');
 		$privateKeyPath = $input->getOption('privateKey');
 		$keyBundlePath = $input->getOption('certificate');
@@ -82,7 +82,7 @@ class SignApp extends Command {
 			$output->writeln('This command requires the --path, --privateKey and --certificate.');
 			$output->writeln('Example: ./occ integrity:sign-app --path="/Users/lukasreschke/Programming/myapp/" --privateKey="/Users/lukasreschke/private/myapp.key" --certificate="/Users/lukasreschke/public/mycert.crt"');
 			$output->writeln('For more information please consult the documentation: '. $documentationUrl);
-			return null;
+			return 1;
 		}
 
 		$privateKey = $this->fileAccessHelper->file_get_contents($privateKeyPath);
@@ -90,12 +90,12 @@ class SignApp extends Command {
 
 		if ($privateKey === false) {
 			$output->writeln(sprintf('Private key "%s" does not exists.', $privateKeyPath));
-			return null;
+			return 1;
 		}
 
 		if ($keyBundle === false) {
 			$output->writeln(sprintf('Certificate "%s" does not exists.', $keyBundlePath));
-			return null;
+			return 1;
 		}
 
 		$rsa = new RSA();

--- a/core/Command/Integrity/SignCore.php
+++ b/core/Command/Integrity/SignCore.php
@@ -67,13 +67,13 @@ class SignCore extends Command {
 	/**
 	 * {@inheritdoc }
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$privateKeyPath = $input->getOption('privateKey');
 		$keyBundlePath = $input->getOption('certificate');
 		$path = $input->getOption('path');
 		if (is_null($privateKeyPath) || is_null($keyBundlePath) || is_null($path)) {
 			$output->writeln('--privateKey, --certificate and --path are required.');
-			return null;
+			return 1;
 		}
 
 		$privateKey = $this->fileAccessHelper->file_get_contents($privateKeyPath);
@@ -81,12 +81,12 @@ class SignCore extends Command {
 
 		if ($privateKey === false) {
 			$output->writeln(sprintf('Private key "%s" does not exists.', $privateKeyPath));
-			return null;
+			return 1;
 		}
 
 		if ($keyBundle === false) {
 			$output->writeln(sprintf('Certificate "%s" does not exists.', $keyBundlePath));
-			return null;
+			return 1;
 		}
 
 		$rsa = new RSA();

--- a/core/Command/L10n/CreateJs.php
+++ b/core/Command/L10n/CreateJs.php
@@ -52,14 +52,14 @@ class CreateJs extends Command implements CompletionAwareInterface {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$app = $input->getArgument('app');
 		$lang = $input->getArgument('lang');
 
 		$path = \OC_App::getAppPath($app);
 		if ($path === false) {
 			$output->writeln("The app <$app> is unknown.");
-			return;
+			return 1;
 		}
 		$languages = $lang;
 		if (empty($lang)) {
@@ -69,6 +69,7 @@ class CreateJs extends Command implements CompletionAwareInterface {
 		foreach ($languages as $lang) {
 			$this->writeFiles($app, $path, $lang, $output);
 		}
+		return 0;
 	}
 
 	private function getAllLanguages($path) {

--- a/core/Command/Log/File.php
+++ b/core/Command/Log/File.php
@@ -72,7 +72,7 @@ class File extends Command implements Completion\CompletionAwareInterface {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$toBeSet = [];
 
 		if ($input->getOption('enable')) {
@@ -115,6 +115,7 @@ class File extends Command implements Completion\CompletionAwareInterface {
 			$rotateString = 'disabled';
 		}
 		$output->writeln('Rotate at: '.$rotateString);
+		return 0;
 	}
 
 	/**

--- a/core/Command/Log/Manage.php
+++ b/core/Command/Log/Manage.php
@@ -73,7 +73,7 @@ class Manage extends Command implements CompletionAwareInterface {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		// collate config setting to the end, to avoid partial configuration
 		$toBeSet = [];
 
@@ -114,6 +114,7 @@ class Manage extends Command implements CompletionAwareInterface {
 
 		$timezone = $this->config->getSystemValue('logtimezone', self::DEFAULT_TIMEZONE);
 		$output->writeln('Log timezone: '.$timezone);
+		return 0;
 	}
 
 	/**

--- a/core/Command/Maintenance/DataFingerprint.php
+++ b/core/Command/Maintenance/DataFingerprint.php
@@ -48,7 +48,8 @@ class DataFingerprint extends Command {
 			->setDescription('update the systems data-fingerprint after a backup is restored');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$this->config->setSystemValue('data-fingerprint', md5($this->timeFactory->getTime()));
+		return 0;
 	}
 }

--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -73,7 +73,7 @@ class Install extends Command {
 			->addOption('data-dir', null, InputOption::VALUE_REQUIRED, 'Path to data directory', \OC::$SERVERROOT."/data");
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 
 		// validate the environment
 		$server = \OC::$server;

--- a/core/Command/Maintenance/Mimetype/UpdateDB.php
+++ b/core/Command/Maintenance/Mimetype/UpdateDB.php
@@ -63,7 +63,7 @@ class UpdateDB extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$mappings = $this->mimetypeDetector->getAllMappings();
 
 		$totalFilecacheUpdates = 0;
@@ -95,5 +95,6 @@ class UpdateDB extends Command {
 
 		$output->writeln('Added '.$totalNewMimetypes.' new mimetypes');
 		$output->writeln('Updated '.$totalFilecacheUpdates.' filecache rows');
+		return 0;
 	}
 }

--- a/core/Command/Maintenance/Mimetype/UpdateJS.php
+++ b/core/Command/Maintenance/Mimetype/UpdateJS.php
@@ -48,7 +48,7 @@ class UpdateJS extends Command {
 			->setDescription('Update mimetypelist.js');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		// Fetch all the aliases
 		$aliases = $this->mimetypeDetector->getAllAliases();
 
@@ -57,5 +57,6 @@ class UpdateJS extends Command {
 		file_put_contents(\OC::$SERVERROOT.'/core/js/mimetypelist.js', $generatedMimetypeFile->generateFile($aliases));
 
 		$output->writeln('<info>mimetypelist.js is updated');
+		return 0;
 	}
 }

--- a/core/Command/Maintenance/Mode.php
+++ b/core/Command/Maintenance/Mode.php
@@ -61,7 +61,7 @@ class Mode extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$maintenanceMode = $this->config->getSystemValueBool('maintenance');
 		if ($input->getOption('on')) {
 			if ($maintenanceMode === false) {
@@ -84,5 +84,6 @@ class Mode extends Command {
 				$output->writeln('Maintenance mode is currently disabled');
 			}
 		}
+		return 0;
 	}
 }

--- a/core/Command/Maintenance/Repair.php
+++ b/core/Command/Maintenance/Repair.php
@@ -79,7 +79,7 @@ class Repair extends Command {
 				'Use this option when you want to include resource and load expensive tasks');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$repairSteps = $this->repair::getRepairSteps();
 
 		if ($input->getOption('include-expensive')) {
@@ -126,6 +126,7 @@ class Repair extends Command {
 		$this->repair->run();
 
 		$this->config->setSystemValue('maintenance', $maintenanceMode);
+		return 0;
 	}
 
 	public function handleRepairFeedBack($event) {

--- a/core/Command/Maintenance/UpdateHtaccess.php
+++ b/core/Command/Maintenance/UpdateHtaccess.php
@@ -36,7 +36,7 @@ class UpdateHtaccess extends Command {
 			->setDescription('Updates the .htaccess file');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if (\OC\Setup::updateHtaccess()) {
 			$output->writeln('.htaccess has been updated');
 			return 0;

--- a/core/Command/Maintenance/UpdateTheme.php
+++ b/core/Command/Maintenance/UpdateTheme.php
@@ -54,7 +54,7 @@ class UpdateTheme extends UpdateJS {
 			->setDescription('Apply custom theme changes');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		// run mimetypelist.js update since themes might change mimetype icons
 		parent::execute($input, $output);
 
@@ -62,5 +62,6 @@ class UpdateTheme extends UpdateJS {
 		$c = $this->cacheFactory->createDistributed('imagePath');
 		$c->clear('');
 		$output->writeln('<info>Image cache cleared</info>');
+		return 0;
 	}
 }

--- a/core/Command/Security/ImportCertificate.php
+++ b/core/Command/Security/ImportCertificate.php
@@ -49,17 +49,18 @@ class ImportCertificate extends Base {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$path = $input->getArgument('path');
 
 		if (!file_exists($path)) {
 			$output->writeln('<error>certificate not found</error>');
-			return;
+			return 1;
 		}
 
 		$certData = file_get_contents($path);
 		$name = basename($path);
 
 		$this->certificateManager->addCertificate($certData, $name);
+		return 0;
 	}
 }

--- a/core/Command/Security/ListCertificates.php
+++ b/core/Command/Security/ListCertificates.php
@@ -50,7 +50,7 @@ class ListCertificates extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$outputType = $input->getOption('output');
 		if ($outputType === self::OUTPUT_FORMAT_JSON || $outputType === self::OUTPUT_FORMAT_JSON_PRETTY) {
 			$certificates = array_map(function (ICertificate $certificate) {
@@ -91,5 +91,6 @@ class ListCertificates extends Base {
 			$table->setRows($rows);
 			$table->render();
 		}
+		return 0;
 	}
 }

--- a/core/Command/Security/RemoveCertificate.php
+++ b/core/Command/Security/RemoveCertificate.php
@@ -50,9 +50,10 @@ class RemoveCertificate extends Base {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$name = $input->getArgument('name');
 
 		$this->certificateManager->removeCertificate($name);
+		return 0;
 	}
 }

--- a/core/Command/Security/ResetBruteforceAttempts.php
+++ b/core/Command/Security/ResetBruteforceAttempts.php
@@ -49,7 +49,7 @@ class ResetBruteforceAttempts extends Base {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$ip = $input->getArgument('ipaddress');
 
 		if (!filter_var($ip, FILTER_VALIDATE_IP)) {
@@ -58,5 +58,6 @@ class ResetBruteforceAttempts extends Base {
 		}
 
 		$this->throttler->resetDelayForIP($ip);
+		return 0;
 	}
 }

--- a/core/Command/Status.php
+++ b/core/Command/Status.php
@@ -38,7 +38,7 @@ class Status extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$values = [
 			'installed' => (bool) \OC::$server->getConfig()->getSystemValue('installed', false),
 			'version' => implode('.', \OCP\Util::getVersion()),
@@ -47,5 +47,6 @@ class Status extends Base {
 		];
 
 		$this->writeArrayInOutputFormat($input, $output, $values);
+		return 0;
 	}
 }

--- a/core/Command/TwoFactorAuth/Cleanup.php
+++ b/core/Command/TwoFactorAuth/Cleanup.php
@@ -50,11 +50,12 @@ class Cleanup extends Base {
 		$this->addArgument('provider-id', InputArgument::REQUIRED);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$providerId = $input->getArgument('provider-id');
 
 		$this->registry->cleanUp($providerId);
 
 		$output->writeln("<info>All user-provider associations for provider <options=bold>$providerId</> have been removed.</info>");
+		return 0;
 	}
 }

--- a/core/Command/TwoFactorAuth/Disable.php
+++ b/core/Command/TwoFactorAuth/Disable.php
@@ -52,7 +52,7 @@ class Disable extends Base {
 		$this->addArgument('provider_id', InputArgument::REQUIRED);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$uid = $input->getArgument('uid');
 		$providerId = $input->getArgument('provider_id');
 		$user = $this->userManager->get($uid);

--- a/core/Command/TwoFactorAuth/Enable.php
+++ b/core/Command/TwoFactorAuth/Enable.php
@@ -52,7 +52,7 @@ class Enable extends Base {
 		$this->addArgument('provider_id', InputArgument::REQUIRED);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$uid = $input->getArgument('uid');
 		$providerId = $input->getArgument('provider_id');
 		$user = $this->userManager->get($uid);

--- a/core/Command/TwoFactorAuth/Enforce.php
+++ b/core/Command/TwoFactorAuth/Enforce.php
@@ -74,7 +74,7 @@ class Enforce extends Command {
 		);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if ($input->getOption('on')) {
 			$enforcedGroups = $input->getOption('group');
 			$excludedGroups = $input->getOption('exclude');
@@ -89,6 +89,7 @@ class Enforce extends Command {
 		} else {
 			$this->writeNotEnforced($output);
 		}
+		return 0;
 	}
 
 	/**

--- a/core/Command/TwoFactorAuth/State.php
+++ b/core/Command/TwoFactorAuth/State.php
@@ -52,7 +52,7 @@ class State extends Base {
 		$this->addArgument('uid', InputArgument::REQUIRED);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$uid = $input->getArgument('uid');
 		$user = $this->userManager->get($uid);
 		if (is_null($user)) {

--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -83,7 +83,7 @@ class Upgrade extends Command {
 	 * @param InputInterface $input input interface
 	 * @param OutputInterface $output output interface
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if (Util::needUpgrade()) {
 			if (OutputInterface::VERBOSITY_NORMAL < $output->getVerbosity()) {
 				// Prepend each line with a little timestamp

--- a/core/Command/User/Add.php
+++ b/core/Command/User/Add.php
@@ -85,7 +85,7 @@ class Add extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$uid = $input->getArgument('uid');
 		if ($this->userManager->userExists($uid)) {
 			$output->writeln('<error>The user "' . $uid . '" already exists.</error>');
@@ -164,5 +164,6 @@ class Add extends Command {
 				$output->writeln('User "' . $user->getUID() . '" added to group "' . $group->getGID() . '"');
 			}
 		}
+		return 0;
 	}
 }

--- a/core/Command/User/Delete.php
+++ b/core/Command/User/Delete.php
@@ -55,18 +55,19 @@ class Delete extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $this->userManager->get($input->getArgument('uid'));
 		if (is_null($user)) {
 			$output->writeln('<error>User does not exist</error>');
-			return;
+			return 0;
 		}
 
 		if ($user->delete()) {
 			$output->writeln('<info>The specified user was deleted</info>');
-			return;
+			return 0;
 		}
 
 		$output->writeln('<error>The specified user could not be deleted. Please check the logs.</error>');
+		return 1;
 	}
 }

--- a/core/Command/User/Disable.php
+++ b/core/Command/User/Disable.php
@@ -52,14 +52,15 @@ class Disable extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $this->userManager->get($input->getArgument('uid'));
 		if (is_null($user)) {
 			$output->writeln('<error>User does not exist</error>');
-			return;
+			return 1;
 		}
 
 		$user->setEnabled(false);
 		$output->writeln('<info>The specified user is disabled</info>');
+		return 0;
 	}
 }

--- a/core/Command/User/Enable.php
+++ b/core/Command/User/Enable.php
@@ -52,14 +52,15 @@ class Enable extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $this->userManager->get($input->getArgument('uid'));
 		if (is_null($user)) {
 			$output->writeln('<error>User does not exist</error>');
-			return;
+			return 1;
 		}
 
 		$user->setEnabled(true);
 		$output->writeln('<info>The specified user is enabled</info>');
+		return 0;
 	}
 }

--- a/core/Command/User/Info.php
+++ b/core/Command/User/Info.php
@@ -65,7 +65,7 @@ class Info extends Base {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $this->userManager->get($input->getArgument('user'));
 		if (is_null($user)) {
 			$output->writeln('<error>user not found</error>');
@@ -85,5 +85,6 @@ class Info extends Base {
 			'backend' => $user->getBackendClassName()
 		];
 		$this->writeArrayInOutputFormat($input, $output, $data);
+		return 0;
 	}
 }

--- a/core/Command/User/LastSeen.php
+++ b/core/Command/User/LastSeen.php
@@ -56,11 +56,11 @@ class LastSeen extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $this->userManager->get($input->getArgument('uid'));
 		if (is_null($user)) {
 			$output->writeln('<error>User does not exist</error>');
-			return;
+			return 1;
 		}
 
 		$lastLogin = $user->getLastLogin();
@@ -73,5 +73,6 @@ class LastSeen extends Command {
 			$output->writeln($user->getUID() .
 				'`s last login: ' . $date->format('d.m.Y H:i'));
 		}
+		return 0;
 	}
 }

--- a/core/Command/User/ListCommand.php
+++ b/core/Command/User/ListCommand.php
@@ -81,10 +81,11 @@ class ListCommand extends Base {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$users = $this->userManager->search('', (int) $input->getOption('limit'), (int) $input->getOption('offset'));
 
 		$this->writeArrayInOutputFormat($input, $output, $this->formatUsers($users, (bool)$input->getOption('info')));
+		return 0;
 	}
 
 	/**
@@ -96,7 +97,7 @@ class ListCommand extends Base {
 		$keys = array_map(function (IUser $user) {
 			return $user->getUID();
 		}, $users);
-	
+
 		$values = array_map(function (IUser $user) use ($detailed) {
 			if ($detailed) {
 				$groups = $this->groupManager->getUserGroupIds($user);

--- a/core/Command/User/Report.php
+++ b/core/Command/User/Report.php
@@ -51,7 +51,7 @@ class Report extends Command {
 			->setDescription('shows how many users have access');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$table = new Table($output);
 		$table->setHeaders(['User Report', '']);
 		$userCountArray = $this->countUsers();
@@ -75,6 +75,7 @@ class Report extends Command {
 
 		$table->setRows($rows);
 		$table->render();
+		return 0;
 	}
 
 	private function countUsers() {

--- a/core/Command/User/ResetPassword.php
+++ b/core/Command/User/ResetPassword.php
@@ -67,7 +67,7 @@ class ResetPassword extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$username = $input->getArgument('user');
 
 		/** @var $user \OCP\IUser */
@@ -134,5 +134,6 @@ class ResetPassword extends Command {
 			$output->writeln("<error>Error while resetting password!</error>");
 			return 1;
 		}
+		return 0;
 	}
 }

--- a/core/Command/User/Setting.php
+++ b/core/Command/User/Setting.php
@@ -158,7 +158,7 @@ class Setting extends Base {
 		}
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		try {
 			$this->checkInput($input);
 		} catch (\InvalidArgumentException $e) {

--- a/tests/lib/Command/Integrity/SignAppTest.php
+++ b/tests/lib/Command/Integrity/SignAppTest.php
@@ -76,7 +76,7 @@ class SignAppTest extends TestCase {
 			->method('writeln')
 			->with('This command requires the --path, --privateKey and --certificate.');
 
-		$this->assertNull(self::invokePrivate($this->signApp, 'execute', [$inputInterface, $outputInterface]));
+		$this->assertSame(1, self::invokePrivate($this->signApp, 'execute', [$inputInterface, $outputInterface]));
 	}
 
 	public function testExecuteWithMissingPrivateKey() {
@@ -104,7 +104,7 @@ class SignAppTest extends TestCase {
 				->method('writeln')
 				->with('This command requires the --path, --privateKey and --certificate.');
 
-		$this->assertNull(self::invokePrivate($this->signApp, 'execute', [$inputInterface, $outputInterface]));
+		$this->assertSame(1, self::invokePrivate($this->signApp, 'execute', [$inputInterface, $outputInterface]));
 	}
 
 	public function testExecuteWithMissingCertificate() {
@@ -132,7 +132,7 @@ class SignAppTest extends TestCase {
 			->method('writeln')
 			->with('This command requires the --path, --privateKey and --certificate.');
 
-		$this->assertNull(self::invokePrivate($this->signApp, 'execute', [$inputInterface, $outputInterface]));
+		$this->assertSame(1, self::invokePrivate($this->signApp, 'execute', [$inputInterface, $outputInterface]));
 	}
 
 	public function testExecuteWithNotExistingPrivateKey() {
@@ -166,7 +166,7 @@ class SignAppTest extends TestCase {
 			->method('writeln')
 			->with('Private key "privateKey" does not exists.');
 
-		$this->assertNull(self::invokePrivate($this->signApp, 'execute', [$inputInterface, $outputInterface]));
+		$this->assertSame(1, self::invokePrivate($this->signApp, 'execute', [$inputInterface, $outputInterface]));
 	}
 
 	public function testExecuteWithNotExistingCertificate() {
@@ -205,7 +205,7 @@ class SignAppTest extends TestCase {
 			->method('writeln')
 			->with('Certificate "certificate" does not exists.');
 
-		$this->assertNull(self::invokePrivate($this->signApp, 'execute', [$inputInterface, $outputInterface]));
+		$this->assertSame(1, self::invokePrivate($this->signApp, 'execute', [$inputInterface, $outputInterface]));
 	}
 
 	public function testExecuteWithException() {

--- a/tests/lib/Command/Integrity/SignCoreTest.php
+++ b/tests/lib/Command/Integrity/SignCoreTest.php
@@ -66,7 +66,7 @@ class SignCoreTest extends TestCase {
 			->method('writeln')
 			->with('--privateKey, --certificate and --path are required.');
 
-		$this->assertNull(self::invokePrivate($this->signCore, 'execute', [$inputInterface, $outputInterface]));
+		$this->assertSame(1, self::invokePrivate($this->signCore, 'execute', [$inputInterface, $outputInterface]));
 	}
 
 	public function testExecuteWithMissingCertificate() {
@@ -89,7 +89,7 @@ class SignCoreTest extends TestCase {
 			->method('writeln')
 			->with('--privateKey, --certificate and --path are required.');
 
-		$this->assertNull(self::invokePrivate($this->signCore, 'execute', [$inputInterface, $outputInterface]));
+		$this->assertSame(1, self::invokePrivate($this->signCore, 'execute', [$inputInterface, $outputInterface]));
 	}
 
 	public function testExecuteWithNotExistingPrivateKey() {
@@ -123,7 +123,7 @@ class SignCoreTest extends TestCase {
 			->method('writeln')
 			->with('Private key "privateKey" does not exists.');
 
-		$this->assertNull(self::invokePrivate($this->signCore, 'execute', [$inputInterface, $outputInterface]));
+		$this->assertSame(1, self::invokePrivate($this->signCore, 'execute', [$inputInterface, $outputInterface]));
 	}
 
 	public function testExecuteWithNotExistingCertificate() {
@@ -162,7 +162,7 @@ class SignCoreTest extends TestCase {
 			->method('writeln')
 			->with('Certificate "certificate" does not exists.');
 
-		$this->assertNull(self::invokePrivate($this->signCore, 'execute', [$inputInterface, $outputInterface]));
+		$this->assertSame(1, self::invokePrivate($this->signCore, 'execute', [$inputInterface, $outputInterface]));
 	}
 
 	public function testExecuteWithException() {


### PR DESCRIPTION
Reduces the debug spam:
```
Return value of \"OC\\Core\\Command\\Group\\AddUser::execute()\" should always be of the type int since Symfony 4.4, NULL returned.
```