### PR TITLE
Callable parameter injection

### DIFF
--- a/apps/accessibility/lib/AppInfo/Application.php
+++ b/apps/accessibility/lib/AppInfo/Application.php
@@ -56,16 +56,11 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function boot(IBootContext $context): void {
-		$this->injectCss(
-			$context->getAppContainer()->query(IUserSession::class),
-			$context->getAppContainer()->query(IConfig::class),
-			$context->getAppContainer()->query(IURLGenerator::class)
-		);
-
-		$this->registerInitialState($context->getAppContainer());
+		$context->injectFn([$this, 'injectCss']);
+		$context->injectFn([$this, 'registerInitialState']);
 	}
 
-	private function injectCss(IUserSession $userSession,
+	public function injectCss(IUserSession $userSession,
 							   IConfig $config,
 							   IURLGenerator $urlGenerator) {
 		// Inject the fake css on all pages if enabled and user is logged
@@ -87,10 +82,8 @@ class Application extends App implements IBootstrap {
 		}
 	}
 
-	private function registerInitialState(IAppContainer $container) {
-		/** @var IInitialStateService $initialState */
-		$initialState = $container->query(IInitialStateService::class);
-
+	public function registerInitialState(IInitialStateService $initialState,
+										  IAppContainer $container) {
 		$initialState->provideLazyInitialState(self::APP_ID, 'data', function () use ($container) {
 			/** @var JSDataService $data */
 			$data = $container->query(JSDataService::class);

--- a/apps/admin_audit/lib/AppInfo/Application.php
+++ b/apps/admin_audit/lib/AppInfo/Application.php
@@ -33,6 +33,7 @@ declare(strict_types=1);
 
 namespace OCA\AdminAudit\AppInfo;
 
+use Closure;
 use OC\Files\Filesystem;
 use OC\Files\Node\File;
 use OC\Group\Manager;
@@ -78,10 +79,9 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function boot(IBootContext $context): void {
-		$logger = $this->getLogger(
-			$context->getAppContainer()->query(IConfig::class),
-			$context->getAppContainer()->query(ILogger::class),
-			$context->getAppContainer()->query(ILogFactory::class)
+		/** @var ILogger $logger */
+		$logger = $context->injectFn(
+			Closure::fromCallable([$this, 'getLogger'])
 		);
 
 		/*

--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -105,30 +105,14 @@ class Application extends App implements IBootstrap {
 		// Load all dav apps
 		\OC_App::loadApps(['dav']);
 
-		$this->registerHooks(
-			$context->getAppContainer()->query(HookManager::class),
-			$context->getServerContainer()->getEventDispatcher(),
-			$context->getAppContainer(),
-			$context->getServerContainer()
-		);
-		$this->registerContactsManager(
-			$context->getAppContainer()->query(IContactsManager::class),
-			$context->getAppContainer()
-		);
-		$this->registerCalendarManager(
-			$context->getAppContainer()->query(ICalendarManager::class),
-			$context->getAppContainer()
-		);
-		$this->registerNotifier(
-			$context->getServerContainer()->getNotificationManager()
-		);
-		$this->registerCalendarReminders(
-			$context->getAppContainer()->query(NotificationProviderManager::class),
-			$context->getAppContainer()->query(ILogger::class)
-		);
+		$context->injectFn([$this, 'registerHooks']);
+		$context->injectFn([$this, 'registerContactsManager']);
+		$context->injectFn([$this, 'registerCalendarManager']);
+		$context->injectFn([$this, 'registerNotifier']);
+		$context->injectFn([$this, 'registerCalendarReminders']);
 	}
 
-	private function registerHooks(HookManager $hm,
+	public function registerHooks(HookManager $hm,
 								   EventDispatcherInterface $dispatcher,
 								   IAppContainer $container,
 								   IServerContainer $serverContainer) {
@@ -349,7 +333,7 @@ class Application extends App implements IBootstrap {
 		$dispatcher->addListener('\OCP\Calendar\Room\ForceRefreshEvent', $eventHandler);
 	}
 
-	private function registerContactsManager(IContactsManager $cm, IAppContainer $container): void {
+	public function registerContactsManager(IContactsManager $cm, IAppContainer $container): void {
 		$cm->register(function () use ($container, $cm): void {
 			$user = \OC::$server->getUserSession()->getUser();
 			if (!is_null($user)) {
@@ -377,7 +361,7 @@ class Application extends App implements IBootstrap {
 		$cm->setupSystemContactsProvider($contactsManager, $urlGenerator);
 	}
 
-	private function registerCalendarManager(ICalendarManager $calendarManager,
+	public function registerCalendarManager(ICalendarManager $calendarManager,
 											 IAppContainer $container): void {
 		$calendarManager->register(function () use ($container, $calendarManager) {
 			$user = \OC::$server->getUserSession()->getUser();
@@ -394,11 +378,11 @@ class Application extends App implements IBootstrap {
 		$cm->setupCalendarProvider($calendarManager, $userId);
 	}
 
-	private function registerNotifier(INotificationManager $manager): void {
+	public function registerNotifier(INotificationManager $manager): void {
 		$manager->registerNotifierService(Notifier::class);
 	}
 
-	private function registerCalendarReminders(NotificationProviderManager $manager,
+	public function registerCalendarReminders(NotificationProviderManager $manager,
 											   ILogger $logger): void {
 		try {
 			$manager->registerProvider(AudioProvider::class);

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -548,6 +548,7 @@ return array(
     'OC\\AppFramework\\App' => $baseDir . '/lib/private/AppFramework/App.php',
     'OC\\AppFramework\\Bootstrap\\BootContext' => $baseDir . '/lib/private/AppFramework/Bootstrap/BootContext.php',
     'OC\\AppFramework\\Bootstrap\\Coordinator' => $baseDir . '/lib/private/AppFramework/Bootstrap/Coordinator.php',
+    'OC\\AppFramework\\Bootstrap\\FunctionInjector' => $baseDir . '/lib/private/AppFramework/Bootstrap/FunctionInjector.php',
     'OC\\AppFramework\\Bootstrap\\RegistrationContext' => $baseDir . '/lib/private/AppFramework/Bootstrap/RegistrationContext.php',
     'OC\\AppFramework\\DependencyInjection\\DIContainer' => $baseDir . '/lib/private/AppFramework/DependencyInjection/DIContainer.php',
     'OC\\AppFramework\\Http' => $baseDir . '/lib/private/AppFramework/Http.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -577,6 +577,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\AppFramework\\App' => __DIR__ . '/../../..' . '/lib/private/AppFramework/App.php',
         'OC\\AppFramework\\Bootstrap\\BootContext' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Bootstrap/BootContext.php',
         'OC\\AppFramework\\Bootstrap\\Coordinator' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Bootstrap/Coordinator.php',
+        'OC\\AppFramework\\Bootstrap\\FunctionInjector' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Bootstrap/FunctionInjector.php',
         'OC\\AppFramework\\Bootstrap\\RegistrationContext' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Bootstrap/RegistrationContext.php',
         'OC\\AppFramework\\DependencyInjection\\DIContainer' => __DIR__ . '/../../..' . '/lib/private/AppFramework/DependencyInjection/DIContainer.php',
         'OC\\AppFramework\\Http' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Http.php',

--- a/lib/private/AppFramework/Bootstrap/BootContext.php
+++ b/lib/private/AppFramework/Bootstrap/BootContext.php
@@ -45,4 +45,8 @@ class BootContext implements IBootContext {
 	public function getServerContainer(): IServerContainer {
 		return $this->appContainer->getServer();
 	}
+
+	public function injectFn(callable $fn) {
+		return (new FunctionInjector($this->appContainer))->injectFn($fn);
+	}
 }

--- a/lib/private/AppFramework/Bootstrap/FunctionInjector.php
+++ b/lib/private/AppFramework/Bootstrap/FunctionInjector.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OC\AppFramework\Bootstrap;
+
+use Closure;
+use OCP\AppFramework\QueryException;
+use OCP\IContainer;
+use ReflectionFunction;
+use ReflectionParameter;
+use function array_map;
+
+class FunctionInjector {
+
+	/** @var IContainer */
+	private $container;
+
+	public function __construct(IContainer $container) {
+		$this->container = $container;
+	}
+
+	public function injectFn(callable $fn) {
+		$reflected = new ReflectionFunction(Closure::fromCallable($fn));
+		return $fn(...array_map(function (ReflectionParameter $param) {
+			// First we try by type (more likely these days)
+			if (($type = $param->getType()) !== null) {
+				try {
+					return $this->container->query($type->getName());
+				} catch (QueryException $ex) {
+					// Ignore and try name as well
+				}
+			}
+			// Second we try by name (mostly for primitives)
+			try {
+				return $this->container->query($param->getName());
+			} catch (QueryException $ex) {
+				// As a last resort we pass `null` if allowed
+				if ($type !== null && $type->allowsNull()) {
+					return null;
+				}
+
+				// Nothing worked, time to bail out
+				throw $ex;
+			}
+		}, $reflected->getParameters()));
+	}
+}

--- a/lib/public/AppFramework/Bootstrap/IBootContext.php
+++ b/lib/public/AppFramework/Bootstrap/IBootContext.php
@@ -26,7 +26,9 @@ declare(strict_types=1);
 namespace OCP\AppFramework\Bootstrap;
 
 use OCP\AppFramework\IAppContainer;
+use OCP\AppFramework\QueryException;
 use OCP\IServerContainer;
+use Throwable;
 
 /**
  * @since 20.0.0
@@ -52,4 +54,24 @@ interface IBootContext {
 	 * @since 20.0.0
 	 */
 	public function getServerContainer(): IServerContainer;
+
+	/**
+	 * Invoke the given callable and inject all parameters based on their types
+	 * and names
+	 *
+	 * Note: when used with methods, make sure they are public or use \Closure::fromCallable
+	 * to wrap the private method call, e.g.
+	 *  * `$context->injectFn([$obj, 'publicMethod'])`
+	 *  * `$context->injectFn([$this, 'publicMethod'])`
+	 *  * `$context->injectFn(\Closure::fromCallable([$this, 'privateMethod']))`
+	 *
+	 * Note: the app container will be queried
+	 *
+	 * @param callable $fn
+	 * @throws QueryException if at least one of the parameter can't be resolved
+	 * @throws Throwable any error the function invocation might cause
+	 * @return mixed|null the return value of the invoked function, if any
+	 * @since 20.0.0
+	 */
+	public function injectFn(callable $fn);
 }

--- a/tests/lib/AppFramework/Bootstrap/FunctionInjectorTest.php
+++ b/tests/lib/AppFramework/Bootstrap/FunctionInjectorTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace lib\AppFramework\Bootstrap;
+
+use OC\AppFramework\Bootstrap\FunctionInjector;
+use OC\AppFramework\Utility\SimpleContainer;
+use Test\TestCase;
+
+interface Foo {
+}
+
+class FunctionInjectorTest extends TestCase {
+
+	/** @var SimpleContainer */
+	private $container;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->container = new SimpleContainer();
+	}
+
+	public function testInjectFnNotRegistered(): void {
+		$this->expectException(\OCP\AppFramework\QueryException::class);
+
+		(new FunctionInjector($this->container))->injectFn(static function (Foo $p1): void {
+		});
+	}
+
+	public function testInjectFnNotRegisteredButNullable(): void {
+		(new FunctionInjector($this->container))->injectFn(static function (?Foo $p1): void {
+		});
+
+		// Nothing to assert. No errors means everything is fine.
+		$this->addToAssertionCount(1);
+	}
+
+	public function testInjectFnByType(): void {
+		$this->container->registerService(Foo::class, function () {
+			$this->addToAssertionCount(1);
+			return new class implements Foo {
+			};
+		});
+
+		(new FunctionInjector($this->container))->injectFn(static function (Foo $p1): void {
+		});
+
+		// Nothing to assert. No errors means everything is fine.
+		$this->addToAssertionCount(1);
+	}
+
+	public function testInjectFnByName(): void {
+		$this->container->registerParameter('test', 'abc');
+
+		(new FunctionInjector($this->container))->injectFn(static function ($test): void {
+		});
+
+		// Nothing to assert. No errors means everything is fine.
+		$this->addToAssertionCount(1);
+	}
+}

--- a/tests/lib/AppFramework/Utility/SimpleContainerTest.php
+++ b/tests/lib/AppFramework/Utility/SimpleContainerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * ownCloud - App Framework
  *
@@ -67,13 +69,14 @@ class SimpleContainerTest extends \Test\TestCase {
 	}
 
 
+
 	public function testRegister() {
 		$this->container->registerParameter('test', 'abc');
 		$this->assertEquals('abc', $this->container->query('test'));
 	}
 
 
-	
+
 	public function testNothingRegistered() {
 		$this->expectException(\OCP\AppFramework\QueryException::class);
 
@@ -81,7 +84,7 @@ class SimpleContainerTest extends \Test\TestCase {
 	}
 
 
-	
+
 	public function testNotAClass() {
 		$this->expectException(\OCP\AppFramework\QueryException::class);
 
@@ -190,7 +193,7 @@ class SimpleContainerTest extends \Test\TestCase {
 		$this->assertEquals('abc', $this->container->query($query));
 	}
 
-	
+
 	public function testConstructorComplexNoTestParameterFound() {
 		$this->expectException(\OCP\AppFramework\QueryException::class);
 


### PR DESCRIPTION



This is like what we have to DI and classes, but for callables.

Alternative description: invoke a callable as if it didn't have any parameters, but have the DI container resolve all parameters automagically.

---

The motivating factor is to get rid of *service locators* in the `boot`
method of apps as a new pattern is about to emerge where we have lots of
`query` calls on the app or server container in order to fetch some
services.

From https://stackoverflow.com/a/16132414/2239067

> When you use service locator, your code is calling locator for services everywhere. When you use inversion of control, there is only one place (composition root), where you call container. The rest of your app should not be container aware.

With this little helper it's possible to call another (public) method
and magically have everything injected.

---

I've changed three app's `boot` method to demonstrate the usefulness of this helper.

Ref https://josephsilber.com/posts/2016/07/13/closure-from-callable-in-php-7-1 for the trick with invoking private methods.