### PR TITLE
Log usages of the deprecated app.php file

### DIFF
--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -150,6 +150,9 @@ class OC_App {
 		self::registerAutoloading($app, $appPath);
 
 		if (is_file($appPath . '/appinfo/app.php')) {
+			\OC::$server->getLogger()->debug('/appinfo/app.php is deprecated, use \OCP\AppFramework\Bootstrap\IBootstrap on the application class instead.', [
+				'app' => $app,
+			]);
 			\OC::$server->getEventLogger()->start('load_app_' . $app, 'Load app: ' . $app);
 			try {
 				self::requireAppFile($app);


### PR DESCRIPTION
This is a follow-up to https://github.com/nextcloud/server/pull/20865.

This will hopefully get more dev's attention on the deprecation if they don't read the upgrade docs.

I suggest to only add this for 21 so 20 can still handle the old apps and the warning starts later. We can even raise the log level to *warn* in 22.