### PR TITLE
add proper paths to locking exceptions

### DIFF
--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -747,7 +747,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 			);
 		}
 		try {
-			$provider->acquireLock('files/' . md5($this->getId() . '::' . trim($path, '/')), $type);
+			$provider->acquireLock('files/' . md5($this->getId() . '::' . trim($path, '/')), $type, $this->getId() . '::' . $path);
 		} catch (LockedException $e) {
 			if ($logger) {
 				$logger->logException($e, ['level' => ILogger::INFO]);

--- a/lib/private/Lock/DBLockingProvider.php
+++ b/lib/private/Lock/DBLockingProvider.php
@@ -180,7 +180,7 @@ class DBLockingProvider extends AbstractLockingProvider {
 	 * @param int $type self::LOCK_SHARED or self::LOCK_EXCLUSIVE
 	 * @throws \OCP\Lock\LockedException
 	 */
-	public function acquireLock(string $path, int $type) {
+	public function acquireLock(string $path, int $type, string $readablePath = null) {
 		$expire = $this->getExpireTime();
 		if ($type === self::LOCK_SHARED) {
 			if (!$this->isLocallyLocked($path)) {
@@ -208,7 +208,7 @@ class DBLockingProvider extends AbstractLockingProvider {
 			}
 		}
 		if ($result !== 1) {
-			throw new LockedException($path);
+			throw new LockedException($path, null, null, $readablePath);
 		}
 		$this->markAcquire($path, $type);
 	}

--- a/lib/private/Lock/MemcacheLockingProvider.php
+++ b/lib/private/Lock/MemcacheLockingProvider.php
@@ -71,17 +71,18 @@ class MemcacheLockingProvider extends AbstractLockingProvider {
 	/**
 	 * @param string $path
 	 * @param int $type self::LOCK_SHARED or self::LOCK_EXCLUSIVE
+	 * @param string $readablePath human readable path to use in error messages
 	 * @throws \OCP\Lock\LockedException
 	 */
-	public function acquireLock(string $path, int $type) {
+	public function acquireLock(string $path, int $type, string $readablePath = null) {
 		if ($type === self::LOCK_SHARED) {
 			if (!$this->memcache->inc($path)) {
-				throw new LockedException($path, null, $this->getExistingLockForException($path));
+				throw new LockedException($path, null, $this->getExistingLockForException($path), $readablePath);
 			}
 		} else {
 			$this->memcache->add($path, 0);
 			if (!$this->memcache->cas($path, 0, 'exclusive')) {
-				throw new LockedException($path, null, $this->getExistingLockForException($path));
+				throw new LockedException($path, null, $this->getExistingLockForException($path), $readablePath);
 			}
 		}
 		$this->setTTL($path);

--- a/lib/private/Lock/NoopLockingProvider.php
+++ b/lib/private/Lock/NoopLockingProvider.php
@@ -46,7 +46,7 @@ class NoopLockingProvider implements ILockingProvider {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function acquireLock(string $path, int $type) {
+	public function acquireLock(string $path, int $type, string $readablePath = null) {
 		// do nothing
 	}
 

--- a/lib/public/Lock/ILockingProvider.php
+++ b/lib/public/Lock/ILockingProvider.php
@@ -55,10 +55,11 @@ interface ILockingProvider {
 	/**
 	 * @param string $path
 	 * @param int $type self::LOCK_SHARED or self::LOCK_EXCLUSIVE
+	 * @param string $readablePath human readable path to use in error messages, since 20.0.0
 	 * @throws \OCP\Lock\LockedException
 	 * @since 8.1.0
 	 */
-	public function acquireLock(string $path, int $type);
+	public function acquireLock(string $path, int $type, string $readablePath = null);
 
 	/**
 	 * @param string $path

--- a/lib/public/Lock/LockedException.php
+++ b/lib/public/Lock/LockedException.php
@@ -53,10 +53,15 @@ class LockedException extends \Exception {
 	 * @param string $path locked path
 	 * @param \Exception|null $previous previous exception for cascading
 	 * @param string $existingLock since 14.0.0
+	 * @param string $readablePath since 20.0.0
 	 * @since 8.1.0
 	 */
-	public function __construct(string $path, \Exception $previous = null, string $existingLock = null) {
-		$message = '"' . $path . '" is locked';
+	public function __construct(string $path, \Exception $previous = null, string $existingLock = null, string $readablePath = null) {
+		if ($readablePath) {
+			$message = "\"$path\"(\"$readablePath\") is locked";
+		} else {
+			$message = '"' . $path . '" is locked';
+		}
 		$this->existingLock = $existingLock;
 		if ($existingLock) {
 			$message .= ', existing lock on file: ' . $existingLock;


### PR DESCRIPTION
while some code paths do wrap the "raw" locking exception into one with a proper path, not all of them do
by adding the proper path to the original exception we ensure that we always have the usefull information in out logs

Signed-off-by: Robin Appelman <robin@icewind.nl>