### PR TITLE
Revert "Log usages of the deprecated app.php file"

### DIFF
--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -150,9 +150,6 @@ class OC_App {
 		self::registerAutoloading($app, $appPath);
 
 		if (is_file($appPath . '/appinfo/app.php')) {
-			\OC::$server->getLogger()->debug('/appinfo/app.php is deprecated, use \OCP\AppFramework\Bootstrap\IBootstrap on the application class instead.', [
-				'app' => $app,
-			]);
 			\OC::$server->getEventLogger()->start('load_app_' . $app, 'Load app: ' . $app);
 			try {
 				self::requireAppFile($app);


### PR DESCRIPTION
Reverts nextcloud/server#21632 because of https://github.com/nextcloud/server/pull/21632#issuecomment-651958280

I only opened the PR now so I don't forget. But I don't want to annoy people yet with 20.