### PR TITLE
Do not create a RouteActionHandler object for each route

### DIFF
--- a/lib/private/AppFramework/Routing/RouteConfig.php
+++ b/lib/private/AppFramework/Routing/RouteConfig.php
@@ -140,12 +140,9 @@ class RouteConfig {
 
 		$routeName = $routeNamePrefix . $this->appName . '.' . $controller . '.' . $action . $postfix;
 
-		// register the route
-		$handler = new RouteActionHandler($this->container, $controllerName, $actionName);
-
 		$router = $this->router->create($routeName, $url)
 			->method($verb)
-			->action($handler);
+			->setDefault('caller', [$this->appName, $controllerName, $actionName]);
 
 		// optionally register requirements for route. This is used to
 		// tell the route parser how url parameters should be matched
@@ -233,9 +230,9 @@ class RouteConfig {
 
 				$routeName = $routeNamePrefix . $this->appName . '.' . strtolower($resource) . '.' . strtolower($method);
 
-				$this->router->create($routeName, $url)->method($verb)->action(
-					new RouteActionHandler($this->container, $controllerName, $actionName)
-				);
+				$this->router->create($routeName, $url)
+					->method($verb)
+					->setDefault('caller', [$this->appName, $controllerName, $actionName]);
 			}
 		}
 	}

--- a/tests/lib/AppFramework/Routing/RoutingTest.php
+++ b/tests/lib/AppFramework/Routing/RoutingTest.php
@@ -3,7 +3,6 @@
 namespace Test\AppFramework\Routing;
 
 use OC\AppFramework\DependencyInjection\DIContainer;
-use OC\AppFramework\Routing\RouteActionHandler;
 use OC\AppFramework\Routing\RouteConfig;
 use OC\Route\Route;
 use OC\Route\Router;
@@ -420,7 +419,7 @@ class RoutingTest extends \Test\TestCase {
 		array $defaults=[]
 	) {
 		$route = $this->getMockBuilder(Route::class)
-			->onlyMethods(['method', 'action', 'requirements', 'defaults'])
+			->onlyMethods(['method', 'setDefault', 'requirements', 'defaults'])
 			->disableOriginalConstructor()
 			->getMock();
 		$route
@@ -431,8 +430,8 @@ class RoutingTest extends \Test\TestCase {
 
 		$route
 			->expects($this->once())
-			->method('action')
-			->with($this->equalTo(new RouteActionHandler($container, $controllerName, $actionName)))
+			->method('setDefault')
+			->with('caller', ['app1', $controllerName, $actionName])
 			->willReturn($route);
 
 		if (count($requirements) > 0) {


### PR DESCRIPTION
This is not required and doesn't allow us to be properly lazy. On top of
it this doesnt allow us to cache the routes (since closures/objects
can't be cached).

This is the first small step into cleaning up the routing we have

Todo:
- [ ] Fix test
- [x] Fix CS