### PR TITLE
Log deprecated events as debug

### DIFF
--- a/lib/private/EventDispatcher/SymfonyAdapter.php
+++ b/lib/private/EventDispatcher/SymfonyAdapter.php
@@ -63,7 +63,7 @@ class SymfonyAdapter implements EventDispatcherInterface {
 			$this->eventDispatcher->dispatch($eventName, $event);
 		} else {
 			// Legacy event
-			$this->logger->info(
+			$this->logger->debug(
 				'Deprecated event type for {name}: {class}',
 				[ 'name' => $eventName, 'class' => is_object($event) ? get_class($event) : 'null' ]
 			);


### PR DESCRIPTION
Since this can spam the log quite agressively we should log it as debug
and not info.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>