### PR TITLE
Check if debugMode is defined before using it

### DIFF
--- a/core/templates/exception.php
+++ b/core/templates/exception.php
@@ -14,7 +14,7 @@ style('core', ['styles', 'header']);
 	<ul>
 		<li><?php p($l->t('Remote Address: %s', [$_['remoteAddr']])) ?></li>
 		<li><?php p($l->t('Request ID: %s', [$_['requestID']])) ?></li>
-		<?php if ($_['debugMode']): ?>
+		<?php if (isset($_['debugMode']) && $_['debugMode'] === true): ?>
 			<li><?php p($l->t('Type: %s', [$_['errorClass']])) ?></li>
 			<li><?php p($l->t('Code: %s', [$_['errorCode']])) ?></li>
 			<li><?php p($l->t('Message: %s', [$_['errorMsg']])) ?></li>


### PR DESCRIPTION
Fix #21150 

Else the sabre error page (where the var is not defined) will throw
warnings all the time.


Was reported in sentry.
https://sentry.io/share/issue/bd815c63035749edba6754887b0602c2/