### PR TITLE
allow admin to configure the max trashbin size

### DIFF
--- a/apps/files_trashbin/appinfo/info.xml
+++ b/apps/files_trashbin/appinfo/info.xml
@@ -34,6 +34,7 @@ To prevent a user from running out of disk space, the Deleted files app will not
 	<commands>
 		<command>OCA\Files_Trashbin\Command\CleanUp</command>
 		<command>OCA\Files_Trashbin\Command\ExpireTrash</command>
+		<command>OCA\Files_Trashbin\Command\Size</command>
 	</commands>
 
 	<sabre>

--- a/apps/files_trashbin/composer/composer/autoload_classmap.php
+++ b/apps/files_trashbin/composer/composer/autoload_classmap.php
@@ -12,6 +12,7 @@ return array(
     'OCA\\Files_Trashbin\\Command\\CleanUp' => $baseDir . '/../lib/Command/CleanUp.php',
     'OCA\\Files_Trashbin\\Command\\Expire' => $baseDir . '/../lib/Command/Expire.php',
     'OCA\\Files_Trashbin\\Command\\ExpireTrash' => $baseDir . '/../lib/Command/ExpireTrash.php',
+    'OCA\\Files_Trashbin\\Command\\Size' => $baseDir . '/../lib/Command/Size.php',
     'OCA\\Files_Trashbin\\Controller\\PreviewController' => $baseDir . '/../lib/Controller/PreviewController.php',
     'OCA\\Files_Trashbin\\Events\\MoveToTrashEvent' => $baseDir . '/../lib/Events/MoveToTrashEvent.php',
     'OCA\\Files_Trashbin\\Exceptions\\CopyRecursiveException' => $baseDir . '/../lib/Exceptions/CopyRecursiveException.php',

--- a/apps/files_trashbin/composer/composer/autoload_static.php
+++ b/apps/files_trashbin/composer/composer/autoload_static.php
@@ -27,6 +27,7 @@ class ComposerStaticInitFiles_Trashbin
         'OCA\\Files_Trashbin\\Command\\CleanUp' => __DIR__ . '/..' . '/../lib/Command/CleanUp.php',
         'OCA\\Files_Trashbin\\Command\\Expire' => __DIR__ . '/..' . '/../lib/Command/Expire.php',
         'OCA\\Files_Trashbin\\Command\\ExpireTrash' => __DIR__ . '/..' . '/../lib/Command/ExpireTrash.php',
+        'OCA\\Files_Trashbin\\Command\\Size' => __DIR__ . '/..' . '/../lib/Command/Size.php',
         'OCA\\Files_Trashbin\\Controller\\PreviewController' => __DIR__ . '/..' . '/../lib/Controller/PreviewController.php',
         'OCA\\Files_Trashbin\\Events\\MoveToTrashEvent' => __DIR__ . '/..' . '/../lib/Events/MoveToTrashEvent.php',
         'OCA\\Files_Trashbin\\Exceptions\\CopyRecursiveException' => __DIR__ . '/..' . '/../lib/Exceptions/CopyRecursiveException.php',

--- a/apps/files_trashbin/lib/Command/Size.php
+++ b/apps/files_trashbin/lib/Command/Size.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_Trashbin\Command;
+
+use OC\Core\Command\Base;
+use OCP\Command\IBus;
+use OCP\IConfig;
+use OCP\IUser;
+use OCP\IUserManager;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Size extends Base {
+	private $config;
+	private $userManager;
+	private $commandBus;
+
+	public function __construct(
+		IConfig $config,
+		IUserManager $userManager,
+		IBus $commandBus
+	) {
+		parent::__construct();
+
+		$this->config = $config;
+		$this->userManager = $userManager;
+		$this->commandBus = $commandBus;
+	}
+
+	protected function configure() {
+		parent::configure();
+		$this
+			->setName('trashbin:size')
+			->setDescription('Configure the target trashbin size')
+			->addOption('user', 'u', InputOption::VALUE_REQUIRED, 'configure the target size for the provided user, if no user is given the default size is configured')
+			->addArgument(
+				'size',
+				InputArgument::OPTIONAL,
+				'the target size for the trashbin, if not provided the current trashbin size will be returned'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$user = $input->getOption('user');
+		$size = $input->getArgument('size');
+
+		if ($size) {
+			$parsedSize = \OC_Helper::computerFileSize($size);
+			if ($parsedSize === false) {
+				$output->writeln("<error>Failed to parse input size</error>");
+				return -1;
+			}
+			if ($user) {
+				$this->config->setUserValue($user, 'files_trashbin', 'trashbin_size', (string)$parsedSize);
+				$this->commandBus->push(new Expire($user));
+			} else {
+				$this->config->setAppValue('files_trashbin', 'trashbin_size', (string)$parsedSize);
+				$output->writeln("<info>Warning: changing the default trashbin size will automatically trigger cleanup of existing trashbins,</info>");
+				$output->writeln("<info>a users trashbin can exceed the configured size until they move a new file to the trashbin.</info>");
+			}
+		} else {
+			$this->printTrashbinSize($input, $output, $user);
+		}
+
+		return 0;
+	}
+
+	private function printTrashbinSize(InputInterface $input, OutputInterface $output, ?string $user) {
+		$globalSize = (int)$this->config->getAppValue('files_trashbin', 'trashbin_size', '-1');
+		if ($globalSize < 0) {
+			$globalHumanSize = "default (50% of available space)";
+		} else {
+			$globalHumanSize = \OC_Helper::humanFileSize($globalSize);
+		}
+
+		if ($user) {
+			$userSize = (int)$this->config->getUserValue($user, 'files_trashbin', 'trashbin_size', '-1');
+
+			if ($userSize < 0) {
+				$userHumanSize = ($globalSize < 0) ? $globalHumanSize : "default($globalHumanSize)";
+			} else {
+				$userHumanSize = \OC_Helper::humanFileSize($userSize);
+			}
+
+			if ($input->getOption('output') == self::OUTPUT_FORMAT_PLAIN) {
+				$output->writeln($userHumanSize);
+			} else {
+				$userValue = ($userSize < 0) ? 'default' : $userSize;
+				$globalValue = ($globalSize < 0) ? 'default' : $globalSize;
+				$this->writeArrayInOutputFormat($input, $output, [
+					'user_size' => $userValue,
+					'global_size' => $globalValue,
+					'effective_size' => ($userSize < 0) ? $globalValue : $userValue,
+				]);
+			}
+		} else {
+			$users = [];
+			$this->userManager->callForSeenUsers(function (IUser $user) use (&$users) {
+				$users[] = $user->getUID();
+			});
+			$userValues = $this->config->getUserValueForUsers('files_trashbin', 'trashbin_size', $users);
+
+			if ($input->getOption('output') == self::OUTPUT_FORMAT_PLAIN) {
+				$output->writeln("Default size: $globalHumanSize");
+				$output->writeln("");
+				if (count($userValues)) {
+					$output->writeln("Per-user sizes:");
+					$this->writeArrayInOutputFormat($input, $output, array_map(function ($size) {
+						return \OC_Helper::humanFileSize($size);
+					}, $userValues));
+				} else {
+					$output->writeln("No per-user sizes configured");
+				}
+			} else {
+				$globalValue = ($globalSize < 0) ? 'default' : $globalSize;
+				$this->writeArrayInOutputFormat($input, $output, [
+					'global_size' => $globalValue,
+					'user_sizes' => $userValues,
+				]);
+			}
+		}
+	}
+}

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -569,6 +569,7 @@ class Trashbin {
 
 	/**
 	 * wrapper function to emit the 'preDelete' hook of \OCP\Trashbin before a file is deleted
+	 *
 	 * @param string $path
 	 */
 	protected static function emitTrashbinPreDelete($path) {
@@ -577,6 +578,7 @@ class Trashbin {
 
 	/**
 	 * wrapper function to emit the 'delete' hook of \OCP\Trashbin after a file has been deleted
+	 *
 	 * @param string $path
 	 */
 	protected static function emitTrashbinPostDelete($path) {
@@ -693,6 +695,14 @@ class Trashbin {
 	 * @return int available free space for trash bin
 	 */
 	private static function calculateFreeSpace($trashbinSize, $user) {
+		$config = \OC::$server->getConfig();
+		$systemTrashbinSize = (int)$config->getAppValue('files_trashbin', 'trashbin_size', '-1');
+		$userTrashbinSize = (int)$config->getUserValue($user, 'files_trashbin', 'trashbin_size', '-1');
+		$configuredTrashbinSize = ($userTrashbinSize < 0) ? $systemTrashbinSize : $userTrashbinSize;
+		if ($configuredTrashbinSize) {
+			return $configuredTrashbinSize - $trashbinSize;
+		}
+
 		$softQuota = true;
 		$userObject = \OC::$server->getUserManager()->get($user);
 		if (is_null($userObject)) {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -143,6 +143,7 @@ use OCP\AppFramework\QueryException;
 use OCP\Authentication\LoginCredentials\IStore;
 use OCP\BackgroundJob\IJobList;
 use OCP\Collaboration\AutoComplete\IManager;
+use OCP\Command\IBus;
 use OCP\Comments\ICommentsManager;
 use OCP\Contacts\ContactsMenu\IActionFactory;
 use OCP\Contacts\ContactsMenu\IContactsStore;
@@ -913,7 +914,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('AsyncCommandBus', function (Server $c) {
 			$busClass = $c->getConfig()->getSystemValue('commandbus');
 			if ($busClass) {
-				list($app, $class) = explode('::', $busClass, 2);
+				[$app, $class] = explode('::', $busClass, 2);
 				if ($c->getAppManager()->isInstalled($app)) {
 					\OC_App::loadApp($app);
 					return $c->query($class);
@@ -925,6 +926,7 @@ class Server extends ServerContainer implements IServerContainer {
 				return new CronBus($jobList);
 			}
 		});
+		$this->registerAlias(IBus::class, 'AsyncCommandBus');
 		$this->registerService('TrustedDomainHelper', function ($c) {
 			return new TrustedDomainHelper($this->getConfig());
 		});


### PR DESCRIPTION
this allows an admin to configure the max trashbin size instead of always relying on the users quota.

The trashbin size can be configured using the `occ trash:size` command and can be set both globally and per-user

Signed-off-by: Robin Appelman <robin@icewind.nl>