### PR TITLE
Fix static method call for s3 bucket compat check

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -110,7 +110,7 @@ trait S3ConnectionTrait {
 		}
 		$this->connection = new S3Client($options);
 
-		if (!$this->connection->isBucketDnsCompatible($this->bucket)) {
+		if (!$this->connection::isBucketDnsCompatible($this->bucket)) {
 			$logger = \OC::$server->getLogger();
 			$logger->debug('Bucket "' . $this->bucket . '" This bucket name is not dns compatible, it may contain invalid characters.',
 					 ['app' => 'objectstore']);
@@ -120,7 +120,7 @@ trait S3ConnectionTrait {
 			$logger = \OC::$server->getLogger();
 			try {
 				$logger->info('Bucket "' . $this->bucket . '" does not exist - creating it.', ['app' => 'objectstore']);
-				if (!$this->connection->isBucketDnsCompatible($this->bucket)) {
+				if (!$this->connection::isBucketDnsCompatible($this->bucket)) {
 					throw new \Exception("The bucket will not be created because the name is not dns compatible, please correct it: " . $this->bucket);
 				}
 				$this->connection->createBucket(['Bucket' => $this->bucket]);


### PR DESCRIPTION
This is a static method, it should be called with `::`.