### PR TITLE
Be sure to differentiate between user and server certificates

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -104,11 +104,18 @@ class Client implements IClient {
 			return \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';
 		}
 
-		if ($this->certificateManager->listCertificates() === []) {
-			return \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';
+		// If the user has personal certificates use those
+		if ($this->certificateManager->listCertificates() !== []) {
+			return $this->certificateManager->getAbsoluteBundlePath();
 		}
 
-		return $this->certificateManager->getAbsoluteBundlePath();
+		// If there are server wide customer certifcates use those
+		if ($this->certificateManager->listCertificates(null) !== []) {
+			return $this->certificateManager->getAbsoluteBundlePath(null);
+		}
+
+		// Else just use the default bundle
+		return \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';
 	}
 
 	/**

--- a/lib/private/Security/CertificateManager.php
+++ b/lib/private/Security/CertificateManager.php
@@ -86,12 +86,12 @@ class CertificateManager implements ICertificateManager {
 	 *
 	 * @return \OCP\ICertificate[]
 	 */
-	public function listCertificates() {
+	public function listCertificates($uid = '') {
 		if (!$this->config->getSystemValue('installed', false)) {
 			return [];
 		}
 
-		$path = $this->getPathToCertificates() . 'uploads/';
+		$path = $this->getPathToCertificates($uid) . 'uploads/';
 		if (!$this->view->is_dir($path)) {
 			return [];
 		}

--- a/lib/public/ICertificateManager.php
+++ b/lib/public/ICertificateManager.php
@@ -35,7 +35,7 @@ interface ICertificateManager {
 	 * @return \OCP\ICertificate[]
 	 * @since 8.0.0
 	 */
-	public function listCertificates();
+	public function listCertificates($uid = '');
 
 	/**
 	 * @param string $certificate the certificate data


### PR DESCRIPTION
If we try to list the certificates there is a difference between a user
and the system. If the user does not have customer certificates but the
server does. Then we should still fetch the customer server bundle

This slightly extends the ICertificateManager. But since it fixes a
perforamnce issue I'm kind of fine with it.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>