### PR TITLE
Fix chmod on file descriptor

### DIFF
--- a/lib/private/Log/File.php
+++ b/lib/private/Log/File.php
@@ -82,7 +82,7 @@ class File extends LogDetails implements IWriter, IFileBased {
 	public function write(string $app, $message, int $level) {
 		$entry = $this->logDetailsAsJSON($app, $message, $level);
 		$handle = @fopen($this->logFile, 'a');
-		if ($this->logFileMode > 0 && (fileperms($this->logFile) & 0777) != $this->logFileMode) {
+		if ($this->logFileMode > 0 && is_file($this->logFile) && (fileperms($this->logFile) & 0777) != $this->logFileMode) {
 			@chmod($this->logFile, $this->logFileMode);
 		}
 		if ($handle) {


### PR DESCRIPTION
This fixes an error when a file descriptor or unix device file is used as log file.
`chmod(): Operation not permitted at /var/www/html/lib/private/Log/File.php`