### PR TITLE
Do clearstatcache() on rmdir

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -108,6 +108,7 @@ class Local extends \OC\Files\Storage\Common {
 				 * @var \SplFileInfo $file
 				 */
 				$file = $it->current();
+				clearstatcache(true, $this->getSourcePath($file));
 				if (in_array($file->getBasename(), ['.', '..'])) {
 					$it->next();
 					continue;
@@ -118,6 +119,7 @@ class Local extends \OC\Files\Storage\Common {
 				}
 				$it->next();
 			}
+			clearstatcache(true, $this->getSourcePath($path));
 			return rmdir($this->getSourcePath($path));
 		} catch (\UnexpectedValueException $e) {
 			return false;

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -142,8 +142,8 @@ class Local extends \OC\Files\Storage\Common {
 	}
 
 	public function stat($path) {
-		clearstatcache();
 		$fullPath = $this->getSourcePath($path);
+		clearstatcache(true, $fullPath);
 		$statResult = stat($fullPath);
 		if (PHP_INT_SIZE === 4 && !$this->is_dir($path)) {
 			$filesize = $this->filesize($path);
@@ -158,7 +158,7 @@ class Local extends \OC\Files\Storage\Common {
 	 */
 	public function getMetaData($path) {
 		$fullPath = $this->getSourcePath($path);
-		clearstatcache();
+		clearstatcache(true, $fullPath);
 		$stat = @stat($fullPath);
 		if (!$stat) {
 			return null;


### PR DESCRIPTION
I'm trying to fix a bunch of errors that look like:
```
rmdir(): No such file or directory at /var/www/html/lib/private/Files/Storage/Local.php#114
unlink(): No such file or directory at /var/www/html/lib/private/Files/Storage/Local.php#116
```
