### PR TITLE
Anonymous options are fine

### DIFF
--- a/apps/dav/lib/Connector/Sabre/AnonymousOptionsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/AnonymousOptionsPlugin.php
@@ -67,7 +67,7 @@ class AnonymousOptionsPlugin extends ServerPlugin {
 		$emptyAuth = $request->getHeader('Authorization') === null
 			|| $request->getHeader('Authorization') === ''
 			|| trim($request->getHeader('Authorization')) === 'Bearer';
-		$isAnonymousOfficeOption = $request->getMethod() === 'OPTIONS' && $isOffice && $emptyAuth;
+		$isAnonymousOfficeOption = $request->getMethod() === 'OPTIONS' && $emptyAuth;
 		$isOfficeHead = $request->getMethod() === 'HEAD' && $isOffice && $emptyAuth;
 		if ($isAnonymousOfficeOption || $isOfficeHead) {
 			/** @var CorePlugin $corePlugin */


### PR DESCRIPTION
There is no reason to block those anonymous options requests. Right now they don't return anything. But they could at some point of course :wink: 