### PR TITLE
19.0.1 RC1

### DIFF
--- a/resources/config/ca-bundle.crt
+++ b/resources/config/ca-bundle.crt
@@ -1,7 +1,7 @@
 ##
 ## Bundle of CA Root Certificates
 ##
-## Certificate data from Mozilla as of: Wed Jan  1 04:12:10 2020 GMT
+## Certificate data from Mozilla as of: Wed Jun 24 03:12:10 2020 GMT
 ##
 ## This is a bundle of X.509 certificates of public Certificate Authorities
 ## (CA). These were automatically extracted from Mozilla's root certificates
@@ -13,8 +13,8 @@
 ## an Apache+mod_ssl webserver for SSL client authentication.
 ## Just configure this file as the SSLCACertificateFile.
 ##
-## Conversion done with mk-ca-bundle.pl version 1.27.
-## SHA256: f3bdcd74612952da8476a9d4147f50b29ad0710b7dd95b4c8690500209986d70
+## Conversion done with mk-ca-bundle.pl version 1.28.
+## SHA256: 5796295533cad5a648a20a115b0894dc9b318c41501796e7158e824c323f11c3
 ##
 
 

--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [19, 0, 0, 12];
+$OC_Version = [19, 0, 1, 0];
 
 // The human readable string
-$OC_VersionString = '19.0.0';
+$OC_VersionString = '19.0.1 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #21068 Improve group queries
* #21095 Do not read certificate bundle from data dir by default
* #21111 Fixes infinitely repeating LDPA search results with PHP <= 7.2
* #21114 Use the loginname to verify the old password in user password changes
* #21126 Make the translation sanitization optional
* #21128 Simplify getGroups, fixing wrong chunking logic
* #21131 Move the password confirmation form template to post
* #21135 Clear the statscache before fetching the metadata
* #21148 Fix reference to wrong class name
* #21151 Fix password changes in link and mail shares
* #21200 Do not only catch Exceptions but any Throwable during rmt share delete
* #21203 Normalize sftp path in read and write stream
* #21210 Fix the Talk verification
* #21226 Prevent harder to share your root
* #21242 Use \OC::$CLI instead of PHP_SAPI
* #21247 Fix empty event UUID reminder notifications
* #21287 Enable passwordless for everyone not only admins.
* #21308 Only use background fade if nextcloud blue is set
* #21333 Clear LDAP cache after user deletion
* #21342 Update icewind/smb to 3.2.5
* #21352 Always sort shares in a reliable way
* #21354 Pass the proper share permissions to the create share call
* #21356 Reflect unreadable state in the UI
* #21387 Increase timeout of the appstore requests
* #21405 Fix pagination of contacts search
* #21409 Upload part size as S3 parameter instead of constant value
* #21419 Avoid duplicate matches in wide and exact results
* #21427 Clean up auth tokens when user is deleted
* #21441 Fix invalid usage of \Exception::getResult
* #21447 Disable Client-Side Monitoring on AWS storage
* #21485 Don't log Keys
* #21491 GetXbyY can still return false, e.g. when using ldap write support
* #21493 Acceptence tests shall specify which branch to pick when cloning apps
* #21495 Give up after 10 seconds in SCSS timeout
* #21521 Clarify that the email is always shared within the instance
* #21526 Allow to specify the cookie type for appframework responses
* #21538 Fix autocomplete for LDAP with `shareapi_only_share_with_group_members` on
* #21541 Fix modal support for vue apps and dark theme
* #21550 Fix language in share notes email for users
* #21568 Fix obsolete usage of OCdialogs
* #21571 Comment was wrong, block is needed nevertheless
* #21573 Relax permissions mask check for detecting part file rename
* #21574 Fix share permission checkboxes enabled when permissions can not be set
* #21583 Fix strings being passed where arrays where expected
* #21584 Remove rescanDelay from directory mtime
* #21622 Precalculate the primary element color for dark mode too
* #21638 Update presign method to match with interface again.
* #21652 Log deprecated events as debug
* #21655 Fix IPv6 remote addresses from X_FORWARDED_FOR headers before validating
* #21660 Check if debugMode is defined before using it
* #21663 Fix static method call for s3 bucket compat check
* #21664 Add missing TarHeader.php
* #21671 Revert "Do not read certificate bundle from data dir by default"
* #21687 Change OAuth2 redirect link to relative link
* #21703 Changes the Birthday calendar color to slightly brighter one
* #21710 Fix releasing a shared lock multiple times
* #21726 Fix main bundle on IE11
* #21751 Add a clear message why you could end up there
* #21770 Fix placeholder issues with multiplace spaces in the name
* #21772 Use the correct mountpoint to calculate
* #21779 Fix #21285 as oneliner
* [3rdparty#466](https://github.com/nextcloud/3rdparty/pull/466) Add missing TarHeader.php
* [files_pdfviewer#187](https://github.com/nextcloud/files_pdfviewer/pull/187) Allow downloads in sandboxed iframe
* [firstrunwizard#351](https://github.com/nextcloud/firstrunwizard/pull/351) Do not keep loading the slide list on every reopen
* [notifications#651](https://github.com/nextcloud/notifications/pull/651) Allow to group push notifications via an event
* [notifications#666](https://github.com/nextcloud/notifications/pull/666) Don't shutdown the notifications when it freezes by browser shutdown
* [notifications#667](https://github.com/nextcloud/notifications/pull/667) Ignore old push devices
* [notifications#672](https://github.com/nextcloud/notifications/pull/672) More buffer to the key size
* [notifications#676](https://github.com/nextcloud/notifications/pull/676) Delete duplicates of the same push token hash
* [notifications#686](https://github.com/nextcloud/notifications/pull/686) Fix wordwrap issue regression from #540, fix #679
* [serverinfo#221](https://github.com/nextcloud/serverinfo/pull/221) Correct format for uptime is used
* [text#856](https://github.com/nextcloud/text/pull/856) Also translate 'Add notes, ...' inside Editor
* [text#872](https://github.com/nextcloud/text/pull/872) Add proxy-polyfill to make tiptap work with IE11
* [text#875](https://github.com/nextcloud/text/pull/875) Perform file conflict check earlier so that it also triggers when not saving
* [text#880](https://github.com/nextcloud/text/pull/880) Don’t show empty workspace container if files are not creatable
* [text#898](https://github.com/nextcloud/text/pull/898) Show tooltip on link hover
* [text#914](https://github.com/nextcloud/text/pull/914) Log the exceptions as INFO


Pending PRs:

* [x] #21780 Set the moment locale even earlier 
* [ ] [3rdparty#457](https://github.com/nextcloud/3rdparty/pull/457) Bump stecman/symfony-console-completion from 0.8.0 to 0.11.0 @nickvergessen
* [x] [text#923](https://github.com/nextcloud/text/pull/923) Check if a file was created manually before creating a new workspace 
