### PR TITLE
18.0.7 RC1

### DIFF
--- a/resources/config/ca-bundle.crt
+++ b/resources/config/ca-bundle.crt
@@ -1,7 +1,7 @@
 ##
 ## Bundle of CA Root Certificates
 ##
-## Certificate data from Mozilla as of: Wed Jan  1 04:12:10 2020 GMT
+## Certificate data from Mozilla as of: Wed Jun 24 03:12:10 2020 GMT
 ##
 ## This is a bundle of X.509 certificates of public Certificate Authorities
 ## (CA). These were automatically extracted from Mozilla's root certificates
@@ -13,8 +13,8 @@
 ## an Apache+mod_ssl webserver for SSL client authentication.
 ## Just configure this file as the SSLCACertificateFile.
 ##
-## Conversion done with mk-ca-bundle.pl version 1.27.
-## SHA256: f3bdcd74612952da8476a9d4147f50b29ad0710b7dd95b4c8690500209986d70
+## Conversion done with mk-ca-bundle.pl version 1.28.
+## SHA256: 5796295533cad5a648a20a115b0894dc9b318c41501796e7158e824c323f11c3
 ##
 
 

--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(18, 0, 6, 0);
+$OC_Version = array(18, 0, 7, 0);
 
 // The human readable string
-$OC_VersionString = '18.0.6';
+$OC_VersionString = '18.0.7 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #21309 Only use background fade if nextcloud blue is set
* #21334 Clear LDAP cache after user deletion
* #21343 Update icewind/smb to 3.2.5
* #21355 Pass the proper share permissions to the create share call
* #21381 Increase max-height on button in welcome email template
* #21388 Increase timeout of the appstore requests
* #21448 Disable Client-Side Monitoring on AWS storage
* #21471 Clean up auth tokens when user is deleted
* #21486 Don't log Keys
* #21494 Acceptence tests shall specify which branch to pick when cloning apps
* #21496 Give up after 10 seconds in SCSS timeout
* #21499 Fix #21285 as oneliner
* #21522 Clarify that the email is always shared within the instance
* #21539 Fix autocomplete for LDAP with `shareapi_only_share_with_group_members` on
* #21543 Fix modal support for vue apps and dark theme
* #21551 Fix language in share notes email for users
* #21569 Fix obsolete usage of OCdialogs
* #21572 Relax permissions mask check for detecting part file rename
* #21575 Fix share permission checkboxes enabled when permissions can not be set
* #21585 Remove rescanDelay from directory mtime
* #21654 Fix IPv6 remote addresses from X_FORWARDED_FOR headers before validating
* #21661 Manual backport of "Check if debugMode is defined before using it" #21657
* #21670 Revert "Do not read certificate bundle from data dir by default"
* #21702 Changes the Birthday calendar color to slightly brighter one
* #21752 Add a clear message why you could end up there
* [firstrunwizard#352](https://github.com/nextcloud/firstrunwizard/pull/352) Do not keep loading the slide list on every reopen
* [notifications#673](https://github.com/nextcloud/notifications/pull/673) More buffer to the key size
* [notifications#677](https://github.com/nextcloud/notifications/pull/677) Delete duplicates of the same push token hash
* [notifications#685](https://github.com/nextcloud/notifications/pull/685) Fix wordwrap issue regression from #540, fix #679
* [password_policy#107](https://github.com/nextcloud/password_policy/pull/107) Fix NC18 deprecation
* [text#774](https://github.com/nextcloud/text/pull/774) Use horiziontal scrolling instead of wrapping in code block
* [text#782](https://github.com/nextcloud/text/pull/782) Fix broken syntax highlight with highlight.js > 9.16
* [text#784](https://github.com/nextcloud/text/pull/784) Remove unused preview plugin
* [text#842](https://github.com/nextcloud/text/pull/842) Same size for checkboxes
* [text#857](https://github.com/nextcloud/text/pull/857) Also translate 'Add notes, ...' inside Editor
* [text#873](https://github.com/nextcloud/text/pull/873) Add proxy-polyfill to make tiptap work with IE11
* [text#876](https://github.com/nextcloud/text/pull/876) Perform file conflict check earlier so that it also triggers when not saving
* [text#881](https://github.com/nextcloud/text/pull/881) Don’t show empty workspace container if files are not creatable
* [text#899](https://github.com/nextcloud/text/pull/899) Show tooltip on link hover


Pending PRs:

* [ ] #20842 Do not filter id matching userId on non-user-share shares 
* [x] #21773 Use the correct mountpoint to calculate 
* [x] #21781 Set the moment locale even earlier 
* [ ] [3rdparty#442](https://github.com/nextcloud/3rdparty/pull/442) Fix Trying to access array offset on value of type null notice 
* [x] [text#922](https://github.com/nextcloud/text/pull/922) Check if a file was created manually before creating a new workspace 
