### PR TITLE
17.0.8 RC1

### DIFF
--- a/apps/accessibility/composer/composer/autoload_real.php
+++ b/apps/accessibility/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitAccessibility
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/admin_audit/composer/composer/autoload_real.php
+++ b/apps/admin_audit/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitAdminAudit
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/cloud_federation_api/composer/composer/autoload_real.php
+++ b/apps/cloud_federation_api/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitCloudFederationAPI
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/comments/composer/composer/autoload_real.php
+++ b/apps/comments/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitComments
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/dav/composer/composer/autoload_real.php
+++ b/apps/dav/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitDAV
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/encryption/composer/composer/autoload_real.php
+++ b/apps/encryption/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitEncryption
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/federatedfilesharing/composer/composer/autoload_real.php
+++ b/apps/federatedfilesharing/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitFederatedFileSharing
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/federation/composer/composer/autoload_real.php
+++ b/apps/federation/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitFederation
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/files/composer/composer/autoload_real.php
+++ b/apps/files/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitFiles
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/files_sharing/composer/composer/autoload_real.php
+++ b/apps/files_sharing/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitFiles_Sharing
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/files_trashbin/composer/composer/autoload_real.php
+++ b/apps/files_trashbin/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitFiles_Trashbin
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/files_versions/composer/composer/autoload_real.php
+++ b/apps/files_versions/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitFiles_Versions
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/lookup_server_connector/composer/composer/autoload_real.php
+++ b/apps/lookup_server_connector/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitLookupServerConnector
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/oauth2/composer/composer/autoload_real.php
+++ b/apps/oauth2/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitOAuth2
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/provisioning_api/composer/composer/autoload_real.php
+++ b/apps/provisioning_api/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitProvisioning_API
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/sharebymail/composer/composer/autoload_real.php
+++ b/apps/sharebymail/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitShareByMail
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/systemtags/composer/composer/autoload_real.php
+++ b/apps/systemtags/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitSystemTags
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/testing/composer/composer/autoload_real.php
+++ b/apps/testing/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitTesting
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/twofactor_backupcodes/composer/composer/autoload_real.php
+++ b/apps/twofactor_backupcodes/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitTwoFactorBackupCodes
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/updatenotification/composer/composer/autoload_real.php
+++ b/apps/updatenotification/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitUpdateNotification
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/user_ldap/composer/composer/autoload_real.php
+++ b/apps/user_ldap/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitUser_LDAP
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/apps/workflowengine/composer/composer/autoload_real.php
+++ b/apps/workflowengine/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInitWorkflowEngine
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/lib/composer/composer/autoload_real.php
+++ b/lib/composer/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInit53792487c5a8370acc0b06b1a864ff4c
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {

--- a/resources/config/ca-bundle.crt
+++ b/resources/config/ca-bundle.crt
@@ -1,7 +1,7 @@
 ##
 ## Bundle of CA Root Certificates
 ##
-## Certificate data from Mozilla as of: Wed Jan  1 04:12:10 2020 GMT
+## Certificate data from Mozilla as of: Wed Jun 24 03:12:10 2020 GMT
 ##
 ## This is a bundle of X.509 certificates of public Certificate Authorities
 ## (CA). These were automatically extracted from Mozilla's root certificates
@@ -13,8 +13,8 @@
 ## an Apache+mod_ssl webserver for SSL client authentication.
 ## Just configure this file as the SSLCACertificateFile.
 ##
-## Conversion done with mk-ca-bundle.pl version 1.27.
-## SHA256: f3bdcd74612952da8476a9d4147f50b29ad0710b7dd95b4c8690500209986d70
+## Conversion done with mk-ca-bundle.pl version 1.28.
+## SHA256: 5796295533cad5a648a20a115b0894dc9b318c41501796e7158e824c323f11c3
 ##
 
 

--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(17, 0, 7, 1);
+$OC_Version = array(17, 0, 8, 0);
 
 // The human readable string
-$OC_VersionString = '17.0.7';
+$OC_VersionString = '17.0.8 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #20803 Exclude groups from sharing: Skip delete groups
* #21130 Simplify getGroups, fixing wrong chunking logic
* #21158 Fix password changes in link and mail shares
* #21202 Do not only catch Exceptions but any Throwable during rmt share delete
* #21228 Prevent harder to share your root
* #21231 Fix password reset saying Admin changed my password when reset from login page
* #21249 Fix empty event UUID reminder notifications
* #21335 Clear LDAP cache after user deletion
* #21389 Increase timeout of the appstore requests
* #21487 Don't log Keys
* #21498 Fix #21285 as oneliner
* #21523 Clarify that the email is always shared within the instance
* #21552 Fix language in share notes email for users
* #21570 Fix obsolete usage of OCdialogs
* #21587 Fix federated link sharing permissions
* #21656 Fix IPv6 remote addresses from X_FORWARDED_FOR headers before validating
* #21669 Revert "Do not read certificate bundle from data dir by de…
* #21753 Add a clear message why you could end up there
* [files_pdfviewer#189](https://github.com/nextcloud/files_pdfviewer/pull/189) Allow downloads in sandboxed iframe
* [notifications#674](https://github.com/nextcloud/notifications/pull/674) More buffer to the key size
* [notifications#678](https://github.com/nextcloud/notifications/pull/678) Delete duplicates of the same push token hash


Pending PRs:

* [x] #21774 Use the correct mountpoint to calculate 
