### PR TITLE
Fix symlink issues when scanning for files

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -465,7 +465,7 @@ class Local extends \OC\Files\Storage\Common {
 		if ($realPath) {
 			$realPath = $realPath . '/';
 		}
-		if ($fileExists && substr($fullPath, 0, strlen($realPath)) === $realPath) {
+		if ($fileExists && rtrim($fullPath, '/.') === $fullPath && substr($fullPath, 0, strlen($realPath)) === $realPath) {
 			\OCP\Util::writeLog('core', "Cyclic symlinks are not allowed ('$fullPath' -> '$realPath')", ILogger::ERROR);
 		} elseif (substr($realPath, 0, $this->dataDirLength) === $this->realDataDir) {
 			return $fullPath;

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -453,7 +453,9 @@ class Local extends \OC\Files\Storage\Common {
 		}
 		$pathToResolve = $fullPath;
 		$realPath = realpath($pathToResolve);
+		$fileExists = true;
 		while ($realPath === false) { // for non existing files check the parent directory
+			$fileExists = false;
 			$currentPath = dirname($currentPath);
 			if ($currentPath === '' || $currentPath === '.') {
 				return $fullPath;
@@ -463,11 +465,14 @@ class Local extends \OC\Files\Storage\Common {
 		if ($realPath) {
 			$realPath = $realPath . '/';
 		}
-		if (substr($realPath, 0, $this->dataDirLength) === $this->realDataDir) {
+		if ($fileExists && substr($fullPath, 0, strlen($realPath)) === $realPath) {
+			\OCP\Util::writeLog('core', "Cyclic symlinks are not allowed ('$fullPath' -> '$realPath')", ILogger::ERROR);
+		} elseif (substr($realPath, 0, $this->dataDirLength) === $this->realDataDir) {
 			return $fullPath;
+		} else {
+			\OCP\Util::writeLog('core', "Following symlinks is not allowed ('$fullPath' -> '$realPath' not inside '{$this->realDataDir}')", ILogger::ERROR);
 		}
 
-		\OCP\Util::writeLog('core', "Following symlinks is not allowed ('$fullPath' -> '$realPath' not inside '{$this->realDataDir}')", ILogger::ERROR);
 		throw new ForbiddenException('Following symlinks is not allowed', false);
 	}
 

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -160,7 +160,14 @@ class Local extends \OC\Files\Storage\Common {
 	 * @inheritdoc
 	 */
 	public function getMetaData($path) {
-		$stat = $this->stat($path);
+		$stat = null;
+
+		try {
+			$stat = $this->stat($path);
+		} catch (ForbiddenException $e) {
+			$stat = false;
+		}
+
 		if (!$stat) {
 			return null;
 		}


### PR DESCRIPTION
## Description

Hi, there are issues with the file scanner and symlinks.
This PR fixes the ones that are crashing the `files:scan` command for local storage:

1. Inexisting symlink targets
2. Symlinks pointing outside the data directory

I am using Nextcloud more like a GUI to browse files online and do the sync or copy by other means.
Hence, some of the symlinks are not valid anymore when copied to the storage folder.

With the fixes applied, I was finally able to run a full scan of all files:

Folders: 46353
Files: 433857
Elapsed time: 00:20:28

The commits may not pass all checks when submitting.
I will try to update the code and force-push the branch with improvements.
Let me know about other adjustments so that the code is ready for merging.

## Case 1

The scanner uses `OC\Files\Storage\Storage::getDirectoryContent()` which calls `OC\Files\Storage\Local::getMetaData()` for local storage to populate the array of children.
Because invalid symlinks are not readable, the array can contain `null` which is not expected by `OC\Files\Cache\Scanner::handleChildren()`

The PR fixes this by ignoring unreadable entries.

## Case 2

`OC\Files\Storage\Local::getMetaData()` uses `OC\Files\Storage\Local::getSourcePath()` to resolve the filename.
The method can throw a `ForbiddenException` if the path is outside the data directory which is not handled gracefully.
Since `null` is returned, if the file is not readable, it is consistent to return `null` in that case as well.
