### PR TITLE
Update system addressbook card only when there was a change based on a cached etag

### DIFF
--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -253,7 +253,7 @@ class CardDavBackendTest extends TestCase {
 		$uri = $this->getUniqueID('card');
 		// updateProperties is expected twice, once for createCard and once for updateCard
 		$backend->expects($this->at(0))->method('updateProperties')->with($bookId, $uri, $this->vcardTest0);
-		$backend->expects($this->at(1))->method('updateProperties')->with($bookId, $uri, $this->vcardTest0);
+		$backend->expects($this->at(1))->method('updateProperties')->with($bookId, $uri, $this->vcardTest1);
 
 		// Expect event
 		$this->dispatcher->expects($this->at(0))
@@ -288,13 +288,13 @@ class CardDavBackendTest extends TestCase {
 			->with('\OCA\DAV\CardDAV\CardDavBackend::updateCard', $this->callback(function (GenericEvent $e) use ($bookId, $uri) {
 				return $e->getArgument('addressBookId') === $bookId &&
 					$e->getArgument('cardUri') === $uri &&
-					$e->getArgument('cardData') === $this->vcardTest0;
+					$e->getArgument('cardData') === $this->vcardTest1;
 			}));
 
 		// update the card
-		$backend->updateCard($bookId, $uri, $this->vcardTest0);
+		$backend->updateCard($bookId, $uri, $this->vcardTest1);
 		$card = $backend->getCard($bookId, $uri);
-		$this->assertEquals($this->vcardTest0, $card['carddata']);
+		$this->assertEquals($this->vcardTest1, $card['carddata']);
 
 		// Expect event
 		$this->dispatcher->expects($this->at(0))


### PR DESCRIPTION
Due to our old and new hook system the card dav backend listens to old and new hooks. This triggers this code multiple times and always causes an update. With this change we cache the etag during a request and only trigger the update if the etag has changed. This does not catches all not needed updates, but it does not need another round trip to the database and still covers most cases where multiple attributes are updated during one single request.


Other approach to #21732 

I would favor this one here as it does not add new queries and should catch most cases. This reduces the amount of updates during a user creation from 5 to 2 (one for the user creation and one for setting the display name as we don't have an API to create user and set the display name is the same call).

