### PR TITLE
Migrate OC_Group post_removeFromGroup hook to actual event object

### DIFF
--- a/apps/user_ldap/lib/Jobs/UpdateGroups.php
+++ b/apps/user_ldap/lib/Jobs/UpdateGroups.php
@@ -44,6 +44,8 @@ use OCA\User_LDAP\LogWrapper;
 use OCA\User_LDAP\Mapping\GroupMapping;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User\Manager;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Group\Events\UserRemovedEvent;
 use OCP\ILogger;
 
 class UpdateGroups extends \OC\BackgroundJob\TimedJob {
@@ -94,6 +96,10 @@ class UpdateGroups extends \OC\BackgroundJob\TimedJob {
 	 * @param string[] $groups
 	 */
 	private static function handleKnownGroups($groups) {
+		$dispatcher = \OC::$server->query(IEventDispatcher::class);
+		$groupManager = \OC::$server->getGroupManager();
+		$userManager = \OC::$server->getUserManager();
+
 		\OCP\Util::writeLog('user_ldap', 'bgJ "updateGroups" – Dealing with known Groups.', ILogger::DEBUG);
 		$query = \OC_DB::prepare('
 			UPDATE `*PREFIX*ldap_group_members`
@@ -105,8 +111,11 @@ class UpdateGroups extends \OC\BackgroundJob\TimedJob {
 			$knownUsers = unserialize(self::$groupsFromDB[$group]['owncloudusers']);
 			$actualUsers = self::getGroupBE()->usersInGroup($group);
 			$hasChanged = false;
+
+			$groupObject = $groupManager->get($group);
 			foreach (array_diff($knownUsers, $actualUsers) as $removedUser) {
-				\OCP\Util::emitHook('OC_User', 'post_removeFromGroup', ['uid' => $removedUser, 'gid' => $group]);
+				$userObject = $userManager->get($removedUser);
+				$dispatcher->dispatchTyped(new UserRemovedEvent($groupObject, $userObject));
 				\OCP\Util::writeLog('user_ldap',
 				'bgJ "updateGroups" – "'.$removedUser.'" removed from "'.$group.'".',
 					ILogger::INFO);

--- a/lib/base.php
+++ b/lib/base.php
@@ -61,6 +61,7 @@
  *
  */
 
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Group\Events\UserRemovedEvent;
 use OCP\ILogger;
 use OCP\Share;
@@ -898,11 +899,10 @@ class OC {
 	public static function registerShareHooks() {
 		if (\OC::$server->getSystemConfig()->getValue('installed')) {
 			OC_Hook::connect('OC_User', 'post_deleteUser', Hooks::class, 'post_deleteUser');
-			OC_Hook::connect('OC_User', 'post_removeFromGroup', Hooks::class, 'post_removeFromGroupLDAP');
 			OC_Hook::connect('OC_User', 'post_deleteGroup', Hooks::class, 'post_deleteGroup');
 
-			/** @var \OCP\EventDispatcher\IEventDispatcher $dispatcher */
-			$dispatcher = \OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class);
+			/** @var IEventDispatcher $dispatcher */
+			$dispatcher = \OC::$server->get(IEventDispatcher::class);
 			$dispatcher->addServiceListener(UserRemovedEvent::class, \OC\Share20\UserRemovedListener::class);
 		}
 	}

--- a/lib/private/Share20/Hooks.php
+++ b/lib/private/Share20/Hooks.php
@@ -30,8 +30,4 @@ class Hooks {
 	public static function post_deleteGroup($arguments) {
 		\OC::$server->getShareManager()->groupDeleted($arguments['gid']);
 	}
-
-	public static function post_removeFromGroupLDAP($arguments) {
-		\OC::$server->getShareManager()->userDeletedFromGroup($arguments['uid'], $arguments['gid']);
-	}
 }

--- a/lib/public/Group/Events/BeforeUserRemovedEvent.php
+++ b/lib/public/Group/Events/BeforeUserRemovedEvent.php
@@ -32,6 +32,7 @@ use OCP\IUser;
 
 /**
  * @since 18.0.0
+ * @deprecated 20.0.0
  */
 class BeforeUserRemovedEvent extends Event {
 
@@ -43,6 +44,7 @@ class BeforeUserRemovedEvent extends Event {
 
 	/**
 	 * @since 18.0.0
+	 * @deprecated 20.0.0
 	 */
 	public function __construct(IGroup $group, IUser $user) {
 		parent::__construct();
@@ -53,6 +55,7 @@ class BeforeUserRemovedEvent extends Event {
 	/**
 	 * @return IGroup
 	 * @since 18.0.0
+	 * @deprecated 20.0.0
 	 */
 	public function getGroup(): IGroup {
 		return $this->group;
@@ -61,6 +64,7 @@ class BeforeUserRemovedEvent extends Event {
 	/**
 	 * @return IUser
 	 * @since 18.0.0
+	 * @deprecated 20.0.0
 	 */
 	public function getUser(): IUser {
 		return $this->user;

--- a/lib/public/Group/Events/BeforeUserRemovedEvent.php
+++ b/lib/public/Group/Events/BeforeUserRemovedEvent.php
@@ -32,7 +32,10 @@ use OCP\IUser;
 
 /**
  * @since 18.0.0
- * @deprecated 20.0.0
+ * @deprecated 20.0.0 - it can't be guaranteed that this event is triggered in
+ * all case (e.g. for LDAP users this isn't possible) - if there is a valid use
+ * case please reach out in the issue tracker at
+ * https://github.com/nextcloud/server/issues
  */
 class BeforeUserRemovedEvent extends Event {
 


### PR DESCRIPTION
Ref #14552

~~This adds a BeforeUserRemovedEvent to the LDAP backend because it was missing. It's not really before, but we don't have the before state.~~


~~Problem with this code:~~

~~The setup fails with this exception and I don't really know why:~~
<details>
<summary>logs</summary>

```json
{
    "reqId": "eHbh95rpFH5mtg7wBVQI",
    "level": 3,
    "time": "2020-07-07T19:31:40+00:00",
    "remoteAddr": "127.0.0.1",
    "user": "--",
    "app": "index",
    "method": "POST",
    "url": "/index.php",
    "message": {
        "Exception": "Error",
        "Message": "Call to a member function getUID() on null",
        "Code": 0,
        "Trace": [
            {
                "file": "/Users/morris/Projects/nextcloud/server/core/Controller/SetupController.php",
                "line": 75,
                "function": "install",
                "class": "OC\\Setup",
                "type": "->",
                "args": [
                    "*** sensitive parameters replaced ***"
                ]
            },
            {
                "file": "/Users/morris/Projects/nextcloud/server/lib/base.php",
                "line": 955,
                "function": "run",
                "class": "OC\\Core\\Controller\\SetupController",
                "type": "->",
                "args": [
                    "*** sensitive parameters replaced ***"
                ]
            },
            {
                "file": "/Users/morris/Projects/nextcloud/server/index.php",
                "line": 37,
                "function": "handleRequest",
                "class": "OC",
                "type": "::",
                "args": []
            }
        ],
        "File": "/Users/morris/Projects/nextcloud/server/lib/private/Setup.php",
        "Line": 436,
        "CustomMessage": "--"
    },
    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Safari/605.1.15",
    "version": "20.0.0.0"
}
```
</details>