### PR TITLE
Remove hook for initSession

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -419,14 +419,8 @@ class OC {
 		$sessionName = OC_Util::getInstanceId();
 
 		try {
-			// Allow session apps to create a custom session object
-			$useCustomSession = false;
-			$session = self::$server->getSession();
-			OC_Hook::emit('OC', 'initSession', ['session' => &$session, 'sessionName' => &$sessionName, 'useCustomSession' => &$useCustomSession]);
-			if (!$useCustomSession) {
-				// set the session name to the instance id - which is unique
-				$session = new \OC\Session\Internal($sessionName);
-			}
+			// set the session name to the instance id - which is unique
+			$session = new \OC\Session\Internal($sessionName);
 
 			$cryptoWrapper = \OC::$server->getSessionCryptoWrapper();
 			$session = $cryptoWrapper->wrapSession($session);


### PR DESCRIPTION
It's not used anyways and allowed to manipulate the state of the session. Also removed the code handling this.

