### PR TITLE
Only translate if we need the string

### DIFF
--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -851,7 +851,6 @@ class OC_Util {
 		];
 		$missingDependencies = [];
 		$invalidIniSettings = [];
-		$moduleHint = $l->t('Please ask your server administrator to install the module.');
 
 		$iniWrapper = \OC::$server->getIniWrapper();
 		foreach ($dependencies['classes'] as $class => $module) {
@@ -890,7 +889,7 @@ class OC_Util {
 		foreach ($missingDependencies as $missingDependency) {
 			$errors[] = [
 				'error' => $l->t('PHP module %s not installed.', [$missingDependency]),
-				'hint' => $moduleHint
+				'hint' => $l->t('Please ask your server administrator to install the module.'),
 			];
 			$webServerRestart = true;
 		}


### PR DESCRIPTION
This translation was done in each call. Over and over and over again.
All while it was probably not used in 99.99999% of the cases. A small
gain. But still.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>