### PR TITLE
Make the subscription registry lazy

### DIFF
--- a/lib/public/Support/Subscription/IRegistry.php
+++ b/lib/public/Support/Subscription/IRegistry.php
@@ -35,15 +35,27 @@ use OCP\Support\Subscription\Exception\AlreadyRegisteredException;
 interface IRegistry {
 
 	/**
-	 * Register a subscription instance. In case it is called multiple times the
-	 * first one is used.
+	 * Register a subscription instance. In case it is called multiple times an
+	 * exception is thrown
 	 *
 	 * @param ISubscription $subscription
 	 * @throws AlreadyRegisteredException
 	 *
 	 * @since 17.0.0
+	 * @deprecated 20.0.0 use registerService
 	 */
 	public function register(ISubscription $subscription): void;
+
+	/**
+	 * Register a subscription handler. The service has to implement the ISubscription interface.
+	 * In case this is called multiple times an exception is thrown.
+	 *
+	 * @param string $subscriptionService
+	 * @throws AlreadyRegisteredException
+	 *
+	 * @since 20.0.0
+	 */
+	public function registerService(string $subscriptionService): void;
 
 	/**
 	 * Fetches the list of app IDs that are supported by the subscription

--- a/tests/lib/Support/Subscription/DummySubscription.php
+++ b/tests/lib/Support/Subscription/DummySubscription.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Test\Support\Subscription;
+
+class DummySubscription implements \OCP\Support\Subscription\ISubscription {
+
+	/** @var bool */
+	private $hasValidSubscription;
+	/** @var bool */
+	private $hasExtendedSupport;
+
+	/**
+	 * DummySubscription constructor.
+	 *
+	 * @param bool $hasValidSubscription
+	 * @param bool $hasExtendedSupport
+	 */
+	public function __construct(bool $hasValidSubscription, bool $hasExtendedSupport) {
+		$this->hasValidSubscription = $hasValidSubscription;
+		$this->hasExtendedSupport = $hasExtendedSupport;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function hasValidSubscription(): bool {
+		return $this->hasValidSubscription;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function hasExtendedSupport(): bool {
+		return $this->hasExtendedSupport;
+	}
+}

--- a/tests/lib/Support/Subscription/RegistryTest.php
+++ b/tests/lib/Support/Subscription/RegistryTest.php
@@ -24,6 +24,7 @@ namespace Test\Support\Subscription;
 
 use OC\Support\Subscription\Registry;
 use OCP\IConfig;
+use OCP\IServerContainer;
 use OCP\Support\Subscription\ISubscription;
 use OCP\Support\Subscription\ISupportedApps;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -37,11 +38,15 @@ class RegistryTest extends TestCase {
 	/** @var MockObject|IConfig */
 	private $config;
 
+	/** @var MockObject|IServerContainer */
+	private $serverContainer;
+
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->config = $this->createMock(IConfig::class);
-		$this->registry = new Registry($this->config);
+		$this->serverContainer = $this->createMock(IServerContainer::class);
+		$this->registry = new Registry($this->config, $this->serverContainer);
 	}
 
 	/**
@@ -52,7 +57,7 @@ class RegistryTest extends TestCase {
 		$this->addToAssertionCount(1);
 	}
 
-	
+
 	public function testDoubleRegistration() {
 		$this->expectException(\OCP\Support\Subscription\Exception\AlreadyRegisteredException::class);
 

--- a/tests/lib/Support/Subscription/RegistryTest.php
+++ b/tests/lib/Support/Subscription/RegistryTest.php
@@ -117,4 +117,14 @@ class RegistryTest extends TestCase {
 
 		$this->assertSame(['abc'], $this->registry->delegateGetSupportedApps());
 	}
+
+	public function testSubscriptionService() {
+		$this->serverContainer->method('query')
+			->with(DummySubscription::class)
+			->willReturn(new DummySubscription(true, false));
+		$this->registry->registerService(DummySubscription::class);
+
+		$this->assertTrue($this->registry->delegateHasValidSubscription());
+		$this->assertFalse($this->registry->delegateHasExtendedSupport());
+	}
 }


### PR DESCRIPTION
This will allow to do lazy registration here which should allow for
loading less (or at least only when needed!).

Todo:
- [ ] Extend tests

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>