### PR TITLE
Do not exit if available space cannot be determined on file transfer

### DIFF
--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -194,7 +194,7 @@ class OwnershipTransferService {
 		$output->writeln('Validating quota');
 		$size = $view->getFileInfo($sourcePath, false)->getSize(false);
 		$freeSpace = $view->free_space($destinationUid . '/files/');
-		if ($size > $freeSpace) {
+		if ($size > $freeSpace && $freeSpace !== -2) {
 			$output->writeln('<error>Target user does not have enough free space available.</error>');
 			throw new \Exception('Execution terminated.');
 		}

--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -194,7 +194,7 @@ class OwnershipTransferService {
 		$output->writeln('Validating quota');
 		$size = $view->getFileInfo($sourcePath, false)->getSize(false);
 		$freeSpace = $view->free_space($destinationUid . '/files/');
-		if ($size > $freeSpace && $freeSpace !== -2) {
+		if ($size > $freeSpace && $freeSpace !== FileInfo::SPACE_UNKNOWN) {
 			$output->writeln('<error>Target user does not have enough free space available.</error>');
 			throw new \Exception('Execution terminated.');
 		}


### PR DESCRIPTION
Otherwise transfering files on primary object storage fails as the free space cannot be determined. I'm not fully sure if there are other cases where a -2 might happen for the free_space call and where we should then block file transfer but I think it makes sense to just allow it in such cases.