### PR TITLE
lower minimum search length to 2 characters

### DIFF
--- a/apps/files/js/search.js
+++ b/apps/files/js/search.js
@@ -146,7 +146,7 @@
 			search.setFilter('files', function (query) {
 				if (self.fileAppLoaded()) {
 					self.fileList.setFilter(query);
-					if (query.length > 2) {
+					if (query.length > 1) {
 						//search is not started until 500msec have passed
 						window.setTimeout(function() {
 							$('.nofilterresults').addClass('hidden');

--- a/core/search/js/searchprovider.js
+++ b/core/search/js/searchprovider.js
@@ -385,7 +385,7 @@
 				function(query) {
 					if (lastQuery !== query) {
 						currentResult = -1;
-						if (query.length > 2) {
+						if (query.length > 1) {
 							self.search(query);
 						} else {
 							self.hideResults();


### PR DESCRIPTION
The main use case is asian languages that have a much higher "density" per character and words often have fewer characters.

An alternative to simply lowering the limit is to change the limit only for multi-byte characters