### PR TITLE
Added check of the $app_dir length in getAppTemplateDirs() to avoid successful result of file_exists()

### DIFF
--- a/lib/private/Template/Base.php
+++ b/lib/private/Template/Base.php
@@ -65,7 +65,7 @@ class Base {
 	 */
 	protected function getAppTemplateDirs($theme, $app, $serverRoot, $app_dir) {
 		// Check if the app is in the app folder or in the root
-		if (file_exists($app_dir.'/templates/')) {
+		if (!empty($app_dir) && file_exists($app_dir.'/templates/')) {
 			return [
 				$serverRoot.'/themes/'.$theme.'/apps/'.$app.'/templates/',
 				$app_dir.'/templates/',


### PR DESCRIPTION
Over every major update starting from NC 14, I was struggling with Internal Errors due to the incorrect paths of the template directories. As a result, the fix checks $app_dir length in the getAppTemplateDirs() calls of the Base.php to avoid successful calls of file_exists() due to (hypothetical?) existing of an /templates/ dir in the root.
I've created an [issue](https://github.com/nextcloud/server/issues/14115) over a year ago that was connected to a similar case of [owncloud](https://github.com/owncloud/core/issues/8071) many years ago with the same idea. I believe the PR resolves #14115.
Probably, the problem is related to some of the apps even though I've tested with disabling all of them, the problem is still persists. So, I was thinking, that an additional check of the $app_dir length anyway does make sense due to the check of the full /templates path, even though I still do not see any /templates/ in the root. However, I'm definitely far from a knowledgeable person in the code base, so I may missing something. Please, let me know if does make sense.