### PR TITLE
Remove unused method uploadFile

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -430,15 +430,6 @@ class SFTP extends \OC\Files\Storage\Common {
 	}
 
 	/**
-	 * @param string $path
-	 * @param string $target
-	 * @throws \Exception
-	 */
-	public function uploadFile($path, $target) {
-		$this->getConnection()->put($target, $path, NET_SFTP_LOCAL_FILE);
-	}
-
-	/**
 	 * {@inheritdoc}
 	 */
 	public function rename($source, $target) {


### PR DESCRIPTION
Method is unused according to PHPStorm.

`apps/files_external/lib/Lib/Storage/SFTP.php:438:47:error - UndefinedConstant: Const NET_SFTP_LOCAL_FILE is not defined`

Also NET_SFTP_LOCAL_FILE has been renamed to `phpseclib\Net\SFTP::SOURCE_LOCAL_FILE` a while ago (phpseclib 1.x to 2.x). 