### PR TITLE
filter files containing a hash in the path for ftp storages

### DIFF
--- a/apps/files_external/lib/Lib/Storage/FTP.php
+++ b/apps/files_external/lib/Lib/Storage/FTP.php
@@ -35,6 +35,7 @@
 namespace OCA\Files_External\Lib\Storage;
 
 use Icewind\Streams\CallbackWrapper;
+use Icewind\Streams\IteratorDirectory;
 use Icewind\Streams\RetryWrapper;
 
 class FTP extends StreamWrapper {
@@ -135,6 +136,22 @@ class FTP extends StreamWrapper {
 		}
 		return false;
 	}
+
+	public function opendir($path) {
+		$dh = parent::opendir($path);
+		if (is_resource($dh)) {
+			$files = [];
+			while (($file = readdir($dh)) !== false) {
+				if ($file != '.' && $file != '..' && strpos($file, '#') === false) {
+					$files[] = $file;
+				}
+			}
+			return IteratorDirectory::wrap($files);
+		} else {
+			return false;
+		}
+	}
+
 
 	public function writeBack($tmpFile, $path) {
 		$this->uploadFile($tmpFile, $path);

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -876,7 +876,10 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 			while (($file = readdir($dh)) !== false) {
 				if (!Filesystem::isIgnoredDir($file) && !Filesystem::isFileBlacklisted($file)) {
 					$childPath = $basePath . '/' . trim($file, '/');
-					yield $this->getMetaData($childPath);
+					$metadata = $this->getMetaData($childPath);
+					if ($metadata !== null) {
+						yield $metadata;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
the php ftp streamwrapper doesn't handle hashes correctly and will break when it tries to enter a path containing a hash.

By filtering out paths containing a hash we can at least stop the external storage from breaking completely

Signed-off-by: Robin Appelman <robin@icewind.nl>