### PR TITLE
Call openssl_pkey_export with $config and log errors.

### DIFF
--- a/core/Service/LoginFlowV2Service.php
+++ b/core/Service/LoginFlowV2Service.php
@@ -225,7 +225,10 @@ class LoginFlowV2Service {
 			throw new \RuntimeException('Could not initialize keys');
 		}
 
-		openssl_pkey_export($res, $privateKey);
+		if (openssl_pkey_export($res, $privateKey, null, $config) === false) {
+			$this->logOpensslError();
+			throw new \RuntimeException('OpenSSL reported a problem');
+		}
 
 		// Extract the public key from $res to $pubKey
 		$publicKey = openssl_pkey_get_details($res);


### PR DESCRIPTION
Reported at: https://github.com/nextcloud/desktop/issues/2191

Similar to: https://github.com/nextcloud/server/pull/16495

I'm not able to verify but should do the trick. 