### PR TITLE
Use PSR container interface and deprecate our own abstraction

### DIFF
--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -30,20 +30,37 @@
 
 namespace OC\AppFramework\Utility;
 
+use ArrayAccess;
 use Closure;
 use OCP\AppFramework\QueryException;
 use OCP\IContainer;
 use Pimple\Container;
+use Psr\Container\ContainerInterface;
 use ReflectionClass;
 use ReflectionException;
+use ReflectionParameter;
+use function class_exists;
 
 /**
- * Class SimpleContainer
- *
- * SimpleContainer is a simple implementation of IContainer on basis of Pimple
+ * SimpleContainer is a simple implementation of a container on basis of Pimple
  */
-class SimpleContainer extends Container implements IContainer {
+class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 
+	/** @var Container */
+	private $container;
+
+	public function __construct() {
+		$this->container = new Container();
+	}
+
+	public function get($id) {
+		return $this->query($id);
+	}
+
+	public function has($id): bool {
+		// If a service is no registered but is an existing class, we can probably load it
+		return isset($this->container[$id]) || class_exists($id);
+	}
 
 	/**
 	 * @param ReflectionClass $class the class to instantiate
@@ -54,45 +71,37 @@ class SimpleContainer extends Container implements IContainer {
 		$constructor = $class->getConstructor();
 		if ($constructor === null) {
 			return $class->newInstance();
-		} else {
-			$parameters = [];
-			foreach ($constructor->getParameters() as $parameter) {
-				$parameterClass = $parameter->getClass();
-
-				// try to find out if it is a class or a simple parameter
-				if ($parameterClass === null) {
-					$resolveName = $parameter->getName();
-				} else {
-					$resolveName = $parameterClass->name;
-				}
-
-				try {
-					$builtIn = $parameter->hasType() && $parameter->getType()->isBuiltin();
-					$parameters[] = $this->query($resolveName, !$builtIn);
-				} catch (QueryException $e) {
-					// Service not found, use the default value when available
-					if ($parameter->isDefaultValueAvailable()) {
-						$parameters[] = $parameter->getDefaultValue();
-					} elseif ($parameterClass !== null) {
-						$resolveName = $parameter->getName();
-						$parameters[] = $this->query($resolveName);
-					} else {
-						throw $e;
-					}
-				}
-			}
-			return $class->newInstanceArgs($parameters);
 		}
+
+		return $class->newInstanceArgs(array_map(function (ReflectionParameter $parameter) {
+			$parameterClass = $parameter->getClass();
+
+			// try to find out if it is a class or a simple parameter
+			if ($parameterClass === null) {
+				$resolveName = $parameter->getName();
+			} else {
+				$resolveName = $parameterClass->name;
+			}
+
+			try {
+				$builtIn = $parameter->hasType() && $parameter->getType()->isBuiltin();
+				return $this->query($resolveName, !$builtIn);
+			} catch (QueryException $e) {
+				// Service not found, use the default value when available
+				if ($parameter->isDefaultValueAvailable()) {
+					return $parameter->getDefaultValue();
+				}
+
+				if ($parameterClass !== null) {
+					$resolveName = $parameter->getName();
+					return $this->query($resolveName);
+				}
+
+				throw $e;
+			}
+		}, $constructor->getParameters()));
 	}
 
-
-	/**
-	 * If a parameter is not registered in the container try to instantiate it
-	 * by using reflection to find out how to build the class
-	 * @param string $name the class name to resolve
-	 * @return \stdClass
-	 * @throws QueryException if the class could not be found or instantiated
-	 */
 	public function resolve($name) {
 		$baseMsg = 'Could not resolve ' . $name . '!';
 		try {
@@ -110,15 +119,18 @@ class SimpleContainer extends Container implements IContainer {
 
 	public function query(string $name, bool $autoload = true) {
 		$name = $this->sanitizeName($name);
-		if ($this->offsetExists($name)) {
-			return $this->offsetGet($name);
-		} elseif ($autoload) {
+		if (isset($this->container[$name])) {
+			return $this->container[$name];
+		}
+
+		if ($autoload) {
 			$object = $this->resolve($name);
 			$this->registerService($name, function () use ($object) {
 				return $object;
 			});
 			return $object;
 		}
+
 		throw new QueryException('Could not resolve ' . $name . '!');
 	}
 
@@ -140,14 +152,17 @@ class SimpleContainer extends Container implements IContainer {
 	 * @param bool $shared
 	 */
 	public function registerService($name, Closure $closure, $shared = true) {
+		$wrapped = function () use ($closure) {
+			return $closure($this);
+		};
 		$name = $this->sanitizeName($name);
 		if (isset($this[$name])) {
 			unset($this[$name]);
 		}
 		if ($shared) {
-			$this[$name] = $closure;
+			$this[$name] = $wrapped;
 		} else {
-			$this[$name] = parent::factory($closure);
+			$this[$name] = $this->container->factory($wrapped);
 		}
 	}
 
@@ -159,8 +174,8 @@ class SimpleContainer extends Container implements IContainer {
 	 * @param string $target the target that should be resolved instead
 	 */
 	public function registerAlias($alias, $target) {
-		$this->registerService($alias, function (IContainer $container) use ($target) {
-			return $container->query($target);
+		$this->registerService($alias, function (ContainerInterface $container) use ($target) {
+			return $container->get($target);
 		}, false);
 	}
 
@@ -173,5 +188,33 @@ class SimpleContainer extends Container implements IContainer {
 			return ltrim($name, '\\');
 		}
 		return $name;
+	}
+
+	/**
+	 * @deprecated 20.0.0 use \Psr\Container\ContainerInterface::has
+	 */
+	public function offsetExists($id) {
+		return $this->container->offsetExists($id);
+	}
+
+	/**
+	 * @deprecated 20.0.0 use \Psr\Container\ContainerInterface::get
+	 */
+	public function offsetGet($id) {
+		return $this->container->offsetGet($id);
+	}
+
+	/**
+	 * @deprecated 20.0.0 use \OCP\IContainer::registerService
+	 */
+	public function offsetSet($id, $service) {
+		$this->container->offsetSet($id, $service);
+	}
+
+	/**
+	 * @deprecated 20.0.0
+	 */
+	public function offsetUnset($offset) {
+		$this->container->offsetUnset($offset);
 	}
 }

--- a/lib/public/AppFramework/Bootstrap/IBootContext.php
+++ b/lib/public/AppFramework/Bootstrap/IBootContext.php
@@ -26,8 +26,9 @@ declare(strict_types=1);
 namespace OCP\AppFramework\Bootstrap;
 
 use OCP\AppFramework\IAppContainer;
-use OCP\AppFramework\QueryException;
 use OCP\IServerContainer;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
 use Throwable;
 
 /**
@@ -40,7 +41,7 @@ interface IBootContext {
 	 *
 	 * Useful to register and query app-specific services
 	 *
-	 * @return IAppContainer
+	 * @return IAppContainer|ContainerInterface
 	 * @since 20.0.0
 	 */
 	public function getAppContainer(): IAppContainer;
@@ -68,7 +69,7 @@ interface IBootContext {
 	 * Note: the app container will be queried
 	 *
 	 * @param callable $fn
-	 * @throws QueryException if at least one of the parameter can't be resolved
+	 * @throws ContainerExceptionInterface if at least one of the parameter can't be resolved
 	 * @throws Throwable any error the function invocation might cause
 	 * @return mixed|null the return value of the invoked function, if any
 	 * @since 20.0.0

--- a/lib/public/AppFramework/IAppContainer.php
+++ b/lib/public/AppFramework/IAppContainer.php
@@ -34,6 +34,7 @@ use OCP\IContainer;
  *
  * This container interface provides short cuts for app developers to access predefined app service.
  * @since 6.0.0
+ * @deprecated 20.0.0 use \Psr\Container\ContainerInterface
  */
 interface IAppContainer extends IContainer {
 
@@ -41,12 +42,14 @@ interface IAppContainer extends IContainer {
 	 * used to return the appname of the set application
 	 * @return string the name of your application
 	 * @since 6.0.0
+	 * @deprecated 20.0.0
 	 */
 	public function getAppName();
 
 	/**
 	 * @return \OCP\IServerContainer
 	 * @since 6.0.0
+	 * @deprecated 20.0.0
 	 */
 	public function getServer();
 
@@ -54,6 +57,7 @@ interface IAppContainer extends IContainer {
 	 * @param string $middleWare
 	 * @return boolean
 	 * @since 6.0.0
+	 * @deprecated 20.0.0 use \OCP\AppFramework\Bootstrap\IRegistrationContext::registerMiddleware
 	 */
 	public function registerMiddleWare($middleWare);
 
@@ -62,6 +66,7 @@ interface IAppContainer extends IContainer {
 	 *
 	 * @param string $serviceName e.g. 'OCA\Files\Capabilities'
 	 * @since 8.2.0
+	 * @deprecated 20.0.0 use \OCP\AppFramework\Bootstrap\IRegistrationContext::registerCapability
 	 */
 	public function registerCapability($serviceName);
 }

--- a/lib/public/AppFramework/QueryException.php
+++ b/lib/public/AppFramework/QueryException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -25,12 +28,16 @@
 namespace OCP\AppFramework;
 
 use Exception;
+use Psr\Container\ContainerExceptionInterface;
 
 /**
  * Class QueryException
  *
+ * The class extends `NotFoundExceptionInterface` since 20.0.0
+ *
  * @package OCP\AppFramework
  * @since 8.1.0
+ * @deprecated 20.0.0 catch \Psr\Container\ContainerExceptionInterface
  */
-class QueryException extends Exception {
+class QueryException extends Exception implements ContainerExceptionInterface {
 }

--- a/lib/public/IContainer.php
+++ b/lib/public/IContainer.php
@@ -37,6 +37,8 @@ namespace OCP;
 
 use Closure;
 use OCP\AppFramework\QueryException;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Class IContainer
@@ -45,8 +47,9 @@ use OCP\AppFramework\QueryException;
  *
  * @package OCP
  * @since 6.0.0
+ * @deprecated 20.0.0 use \Psr\Container\ContainerInterface
  */
-interface IContainer {
+interface IContainer extends ContainerInterface {
 
 	/**
 	 * If a parameter is not registered in the container try to instantiate it
@@ -54,6 +57,8 @@ interface IContainer {
 	 * @param string $name the class name to resolve
 	 * @return \stdClass
 	 * @since 8.2.0
+	 * @deprecated 20.0.0 use \Psr\Container\ContainerInterface::get
+	 * @throws ContainerExceptionInterface if the class could not be found or instantiated
 	 * @throws QueryException if the class could not be found or instantiated
 	 */
 	public function resolve($name);
@@ -64,8 +69,10 @@ interface IContainer {
 	 * @param string $name
 	 * @param bool $autoload Should we try to autoload the service. If we are trying to resolve built in types this makes no sense for example
 	 * @return mixed
+	 * @throws ContainerExceptionInterface if the query could not be resolved
 	 * @throws QueryException if the query could not be resolved
 	 * @since 6.0.0
+	 * @deprecated 20.0.0 use \Psr\Container\ContainerInterface::get
 	 */
 	public function query(string $name, bool $autoload = true);
 
@@ -76,6 +83,7 @@ interface IContainer {
 	 * @param mixed $value
 	 * @return void
 	 * @since 6.0.0
+	 * @deprecated 20.0.0 use \OCP\AppFramework\Bootstrap\IRegistrationContext::registerParameter
 	 */
 	public function registerParameter($name, $value);
 
@@ -91,6 +99,7 @@ interface IContainer {
 	 * @param bool $shared
 	 * @return void
 	 * @since 6.0.0
+	 * @deprecated 20.0.0 use \OCP\AppFramework\Bootstrap\IRegistrationContext::registerService
 	 */
 	public function registerService($name, Closure $closure, $shared = true);
 
@@ -101,6 +110,7 @@ interface IContainer {
 	 * @param string $alias the alias that should be registered
 	 * @param string $target the target that should be resolved instead
 	 * @since 8.2.0
+	 * @deprecated 20.0.0 use \OCP\AppFramework\Bootstrap\IRegistrationContext::registerServiceAlias
 	 */
 	public function registerAlias($alias, $target);
 }

--- a/lib/public/IServerContainer.php
+++ b/lib/public/IServerContainer.php
@@ -60,6 +60,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  *
  * This container holds all ownCloud services
  * @since 6.0.0
+ * @deprecated 20.0.0 use \Psr\Container\ContainerInterface
  */
 interface IServerContainer extends IContainer {
 


### PR DESCRIPTION
For https://help.nextcloud.com/t/do-we-still-need-ocp-icontainer/86139

* Add the PSR-11 container interface as a replacement for `IContainer`
* Deprecate our `IContainer` and friends
* Make the new interface base of our abstraction to ease the migration
* Use composition instead of inheritance for SimpleContainer -> Pimple as that makes the abstraction leaner and will help with the migration later on.

- [x] Requires https://github.com/nextcloud/3rdparty/pull/475 (though the interface was already there)

Docs are at https://github.com/nextcloud/documentation/pull/2202