### PR TITLE
Do not load app.php if Application implements IBootstrap

### DIFF
--- a/lib/private/AppFramework/Bootstrap/Coordinator.php
+++ b/lib/private/AppFramework/Bootstrap/Coordinator.php
@@ -147,12 +147,18 @@ class Coordinator {
 			$this->logger->logException($e, [
 				'message' => "Could not boot $appId" . $e->getMessage(),
 			]);
-			return;
 		} catch (Throwable $e) {
 			$this->logger->logException($e, [
 				'message' => "Could not boot $appId" . $e->getMessage(),
 				'level' => ILogger::FATAL,
 			]);
 		}
+	}
+
+	public function isBootable(string $appId) {
+		$appNameSpace = App::buildAppNamespace($appId);
+		$applicationClassName = $appNameSpace . '\\AppInfo\\Application';
+		return class_exists($applicationClassName) &&
+			in_array(IBootstrap::class, class_implements($applicationClassName), true);
 	}
 }


### PR DESCRIPTION
The problem with this is that it changes the load order also for apps without the IBootstrap. Another approach would be a big warning if the app is then one with `IBootstrap` but still has an app.php.

#20573 and #20865 