### PR TITLE
Do not use custom DI object names for user_ldap

### DIFF
--- a/apps/user_ldap/appinfo/app.php
+++ b/apps/user_ldap/appinfo/app.php
@@ -27,13 +27,6 @@
  *
  */
 
-\OC::$server->registerService('LDAPUserPluginManager', function () {
-	return new OCA\User_LDAP\UserPluginManager();
-});
-\OC::$server->registerService('LDAPGroupPluginManager', function () {
-	return new OCA\User_LDAP\GroupPluginManager();
-});
-
 $app = \OC::$server->query(\OCA\User_LDAP\AppInfo\Application::class);
 
 $helper = new \OCA\User_LDAP\Helper(\OC::$server->getConfig());
@@ -45,8 +38,8 @@ if (count($configPrefixes) > 0) {
 	$notificationManager->registerNotifierService(\OCA\User_LDAP\Notification\Notifier::class);
 	$userSession = \OC::$server->getUserSession();
 
-	$userPluginManager = \OC::$server->query('LDAPUserPluginManager');
-	$groupPluginManager = \OC::$server->query('LDAPGroupPluginManager');
+	$userPluginManager = \OC::$server->query(\OCA\User_LDAP\UserPluginManager::class);
+	$groupPluginManager = \OC::$server->query(\OCA\User_LDAP\GroupPluginManager::class);
 
 	$userBackend  = new OCA\User_LDAP\User_Proxy(
 		$configPrefixes, $ldapWrapper, $ocConfig, $notificationManager, $userSession, $userPluginManager

--- a/apps/user_ldap/appinfo/register_command.php
+++ b/apps/user_ldap/appinfo/register_command.php
@@ -41,7 +41,7 @@ $uBackend = new User_Proxy(
 	$ocConfig,
 	\OC::$server->getNotificationManager(),
 	\OC::$server->getUserSession(),
-	\OC::$server->query('LDAPUserPluginManager')
+	\OC::$server->query(\OCA\User_LDAP\UserPluginManager::class)
 );
 $deletedUsersIndex = new DeletedUsersIndex(
 	$ocConfig, $dbConnection, $userMapping

--- a/apps/user_ldap/lib/Command/Search.php
+++ b/apps/user_ldap/lib/Command/Search.php
@@ -29,9 +29,11 @@
 namespace OCA\User_LDAP\Command;
 
 use OCA\User_LDAP\Group_Proxy;
+use OCA\User_LDAP\GroupPluginManager;
 use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\LDAP;
 use OCA\User_LDAP\User_Proxy;
+use OCA\User_LDAP\UserPluginManager;
 use OCP\IConfig;
 
 use Symfony\Component\Console\Command\Command;
@@ -115,7 +117,7 @@ class Search extends Command {
 		$this->validateOffsetAndLimit($offset, $limit);
 
 		if ($input->getOption('group')) {
-			$proxy = new Group_Proxy($configPrefixes, $ldapWrapper, \OC::$server->query('LDAPGroupPluginManager'));
+			$proxy = new Group_Proxy($configPrefixes, $ldapWrapper, \OC::$server->query(GroupPluginManager::class));
 			$getMethod = 'getGroups';
 			$printID = false;
 			// convert the limit of groups to null. This will show all the groups available instead of
@@ -130,7 +132,7 @@ class Search extends Command {
 				$this->ocConfig,
 				\OC::$server->getNotificationManager(),
 				\OC::$server->getUserSession(),
-				\OC::$server->query('LDAPUserPluginManager')
+				\OC::$server->query(UserPluginManager::class)
 			);
 			$getMethod = 'getDisplayNames';
 			$printID = true;

--- a/apps/user_ldap/lib/Helper.php
+++ b/apps/user_ldap/lib/Helper.php
@@ -321,7 +321,7 @@ class Helper {
 		$notificationManager = \OC::$server->getNotificationManager();
 
 		$userSession = \OC::$server->getUserSession();
-		$userPluginManager = \OC::$server->query('LDAPUserPluginManager');
+		$userPluginManager = \OC::$server->query(UserPluginManager::class);
 
 		$userBackend = new User_Proxy(
 			$configPrefixes, $ldapWrapper, $ocConfig, $notificationManager, $userSession, $userPluginManager

--- a/apps/user_ldap/lib/Jobs/CleanUp.php
+++ b/apps/user_ldap/lib/Jobs/CleanUp.php
@@ -35,6 +35,7 @@ use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCA\User_LDAP\User_LDAP;
 use OCA\User_LDAP\User_Proxy;
+use OCA\User_LDAP\UserPluginManager;
 
 /**
  * Class CleanUp
@@ -105,7 +106,7 @@ class CleanUp extends TimedJob {
 				$this->ocConfig,
 				\OC::$server->getNotificationManager(),
 				\OC::$server->getUserSession(),
-				\OC::$server->query('LDAPUserPluginManager')
+				\OC::$server->query(UserPluginManager::class)
 			);
 		}
 

--- a/apps/user_ldap/lib/Jobs/UpdateGroups.php
+++ b/apps/user_ldap/lib/Jobs/UpdateGroups.php
@@ -37,6 +37,7 @@ namespace OCA\User_LDAP\Jobs;
 use OCA\User_LDAP\Access;
 use OCA\User_LDAP\Connection;
 use OCA\User_LDAP\FilesystemHelper;
+use OCA\User_LDAP\GroupPluginManager;
 use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\LDAP;
 use OCA\User_LDAP\LogWrapper;
@@ -198,9 +199,9 @@ class UpdateGroups extends \OC\BackgroundJob\TimedJob {
 			$userMapper  = new UserMapping($dbc);
 			$ldapAccess->setGroupMapper($groupMapper);
 			$ldapAccess->setUserMapper($userMapper);
-			self::$groupBE = new \OCA\User_LDAP\Group_LDAP($ldapAccess, \OC::$server->query('LDAPGroupPluginManager'));
+			self::$groupBE = new \OCA\User_LDAP\Group_LDAP($ldapAccess, \OC::$server->query(GroupPluginManager::class));
 		} else {
-			self::$groupBE = new \OCA\User_LDAP\Group_Proxy($configPrefixes, $ldapWrapper, \OC::$server->query('LDAPGroupPluginManager'));
+			self::$groupBE = new \OCA\User_LDAP\Group_Proxy($configPrefixes, $ldapWrapper, \OC::$server->query(GroupPluginManager::class));
 		}
 
 		return self::$groupBE;

--- a/apps/user_ldap/lib/Migration/UUIDFixGroup.php
+++ b/apps/user_ldap/lib/Migration/UUIDFixGroup.php
@@ -29,6 +29,7 @@ use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\LDAP;
 use OCA\User_LDAP\Mapping\GroupMapping;
 use OCA\User_LDAP\User_Proxy;
+use OCA\User_LDAP\UserPluginManager;
 use OCP\IConfig;
 
 class UUIDFixGroup extends UUIDFix {
@@ -36,6 +37,6 @@ class UUIDFixGroup extends UUIDFix {
 		$this->mapper = $mapper;
 		$this->proxy = new User_Proxy($helper->getServerConfigurationPrefixes(true), $ldap, $config,
 			\OC::$server->getNotificationManager(), \OC::$server->getUserSession(),
-			\OC::$server->query('LDAPUserPluginManager'));
+			\OC::$server->query(UserPluginManager::class));
 	}
 }

--- a/apps/user_ldap/lib/Migration/UUIDFixUser.php
+++ b/apps/user_ldap/lib/Migration/UUIDFixUser.php
@@ -26,6 +26,7 @@
 namespace OCA\User_LDAP\Migration;
 
 use OCA\User_LDAP\Group_Proxy;
+use OCA\User_LDAP\GroupPluginManager;
 use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\LDAP;
 use OCA\User_LDAP\Mapping\UserMapping;
@@ -34,7 +35,7 @@ use OCP\IConfig;
 class UUIDFixUser extends UUIDFix {
 	public function __construct(UserMapping $mapper, LDAP $ldap, IConfig $config, Helper $helper) {
 		$this->mapper = $mapper;
-		$groupPluginManager = \OC::$server->query('LDAPGroupPluginManager');
+		$groupPluginManager = \OC::$server->query(GroupPluginManager::class);
 		$this->proxy = new Group_Proxy($helper->getServerConfigurationPrefixes(true), $ldap, $groupPluginManager);
 	}
 }

--- a/apps/user_ldap/tests/Integration/AbstractIntegrationTest.php
+++ b/apps/user_ldap/tests/Integration/AbstractIntegrationTest.php
@@ -30,10 +30,12 @@ namespace OCA\User_LDAP\Tests\Integration;
 use OCA\User_LDAP\Access;
 use OCA\User_LDAP\Connection;
 use OCA\User_LDAP\FilesystemHelper;
+use OCA\User_LDAP\GroupPluginManager;
 use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\LDAP;
 use OCA\User_LDAP\LogWrapper;
 use OCA\User_LDAP\User\Manager;
+use OCA\User_LDAP\UserPluginManager;
 
 abstract class AbstractIntegrationTest {
 	/** @var  LDAP */
@@ -47,7 +49,7 @@ abstract class AbstractIntegrationTest {
 
 	/** @var Manager */
 	protected $userManager;
-	
+
 	/** @var Helper */
 	protected $helper;
 
@@ -72,10 +74,10 @@ abstract class AbstractIntegrationTest {
 	 * the LDAP backend.
 	 */
 	public function init() {
-		\OC::$server->registerService('LDAPUserPluginManager', function () {
+		\OC::$server->registerService(UserPluginManager::class, function () {
 			return new \OCA\User_LDAP\UserPluginManager();
 		});
-		\OC::$server->registerService('LDAPGroupPluginManager', function () {
+		\OC::$server->registerService(GroupPluginManager::class, function () {
 			return new \OCA\User_LDAP\GroupPluginManager();
 		});
 
@@ -128,7 +130,7 @@ abstract class AbstractIntegrationTest {
 			\OC::$server->getNotificationManager()
 		);
 	}
-	
+
 	/**
 	 * initializes the test Helper
 	 */

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestAttributeDetection.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestAttributeDetection.php
@@ -25,10 +25,12 @@
 namespace OCA\user_ldap\tests\Integration\Lib;
 
 use OCA\User_LDAP\Group_LDAP;
+use OCA\User_LDAP\GroupPluginManager;
 use OCA\User_LDAP\Mapping\GroupMapping;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\Tests\Integration\AbstractIntegrationTest;
 use OCA\User_LDAP\User_LDAP;
+use OCA\User_LDAP\UserPluginManager;
 
 require_once __DIR__ . '/../Bootstrap.php';
 
@@ -50,12 +52,12 @@ class IntegrationTestAttributeDetection extends AbstractIntegrationTest {
 		$groupMapper->clear();
 		$this->access->setGroupMapper($groupMapper);
 
-		$userBackend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager(), \OC::$server->getUserSession(), \OC::$server->query('LDAPUserPluginManager'));
+		$userBackend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager(), \OC::$server->getUserSession(), \OC::$server->query(UserPluginManager::class));
 		$userManager = \OC::$server->getUserManager();
 		$userManager->clearBackends();
 		$userManager->registerBackend($userBackend);
 
-		$groupBackend = new Group_LDAP($this->access, \OC::$server->query('LDAPGroupPluginManager'));
+		$groupBackend = new Group_LDAP($this->access, \OC::$server->query(GroupPluginManager::class));
 		$groupManger = \OC::$server->getGroupManager();
 		$groupManger->clearBackends();
 		$groupManger->addBackend($groupBackend);

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestFetchUsersByLoginName.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestFetchUsersByLoginName.php
@@ -28,6 +28,7 @@ namespace OCA\User_LDAP\Tests\Integration\Lib;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\Tests\Integration\AbstractIntegrationTest;
 use OCA\User_LDAP\User_LDAP;
+use OCA\User_LDAP\UserPluginManager;
 
 require_once __DIR__ . '/../Bootstrap.php';
 
@@ -49,7 +50,7 @@ class IntegrationTestFetchUsersByLoginName extends AbstractIntegrationTest {
 		$this->mapping = new UserMapping(\OC::$server->getDatabaseConnection());
 		$this->mapping->clear();
 		$this->access->setUserMapper($this->mapping);
-		$this->backend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager(), \OC::$server->getUserSession(), \OC::$server->query('LDAPUserPluginManager'));
+		$this->backend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager(), \OC::$server->getUserSession(), \OC::$server->query(UserPluginManager::class));
 	}
 
 	/**

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestPaging.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestPaging.php
@@ -29,6 +29,7 @@ namespace OCA\User_LDAP\Tests\Integration\Lib;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\Tests\Integration\AbstractIntegrationTest;
 use OCA\User_LDAP\User_LDAP;
+use OCA\User_LDAP\UserPluginManager;
 
 require_once __DIR__ . '/../Bootstrap.php';
 
@@ -50,7 +51,7 @@ class IntegrationTestPaging extends AbstractIntegrationTest {
 		require(__DIR__ . '/../setup-scripts/createExplicitUsers.php');
 		parent::init();
 
-		$this->backend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager(), \OC::$server->getUserSession(), \OC::$server->query('LDAPUserPluginManager'));
+		$this->backend = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager(), \OC::$server->getUserSession(), \OC::$server->query(UserPluginManager::class));
 	}
 
 	public function initConnection() {

--- a/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserAvatar.php
+++ b/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserAvatar.php
@@ -36,6 +36,7 @@ use OCA\User_LDAP\Tests\Integration\AbstractIntegrationTest;
 use OCA\User_LDAP\User\Manager;
 use OCA\User_LDAP\User\User;
 use OCA\User_LDAP\User_LDAP;
+use OCA\User_LDAP\UserPluginManager;
 use OCP\Image;
 
 require_once __DIR__ . '/../../Bootstrap.php';
@@ -54,7 +55,7 @@ class IntegrationTestUserAvatar extends AbstractIntegrationTest {
 		$this->mapping = new UserMapping(\OC::$server->getDatabaseConnection());
 		$this->mapping->clear();
 		$this->access->setUserMapper($this->mapping);
-		$userBackend  = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager(), \OC::$server->getUserSession(), \OC::$server->query('LDAPUserPluginManager'));
+		$userBackend  = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager(), \OC::$server->getUserSession(), \OC::$server->query(UserPluginManager::class));
 		\OC_User::useBackend($userBackend);
 	}
 

--- a/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserCleanUp.php
+++ b/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserCleanUp.php
@@ -28,6 +28,7 @@ use OCA\User_LDAP\Jobs\CleanUp;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\Tests\Integration\AbstractIntegrationTest;
 use OCA\User_LDAP\User_LDAP;
+use OCA\User_LDAP\UserPluginManager;
 
 require_once __DIR__ . '/../../Bootstrap.php';
 
@@ -46,7 +47,7 @@ class IntegrationTestUserCleanUp extends AbstractIntegrationTest {
 		$this->mapping->clear();
 		$this->access->setUserMapper($this->mapping);
 
-		$userBackend  = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager(), \OC::$server->getUserSession(), \OC::$server->query('LDAPUserPluginManager'));
+		$userBackend  = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager(), \OC::$server->getUserSession(), \OC::$server->query(UserPluginManager::class));
 		\OC_User::useBackend($userBackend);
 	}
 

--- a/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserDisplayName.php
+++ b/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserDisplayName.php
@@ -27,6 +27,7 @@ namespace OCA\User_LDAP\Tests\Integration\Lib\User;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\Tests\Integration\AbstractIntegrationTest;
 use OCA\User_LDAP\User_LDAP;
+use OCA\User_LDAP\UserPluginManager;
 
 require_once __DIR__ . '/../../Bootstrap.php';
 
@@ -44,7 +45,7 @@ class IntegrationTestUserDisplayName extends AbstractIntegrationTest {
 		$this->mapping = new UserMapping(\OC::$server->getDatabaseConnection());
 		$this->mapping->clear();
 		$this->access->setUserMapper($this->mapping);
-		$userBackend  = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager(), \OC::$server->getUserSession(), \OC::$server->query('LDAPUserPluginManager'));
+		$userBackend  = new User_LDAP($this->access, \OC::$server->getConfig(), \OC::$server->getNotificationManager(), \OC::$server->getUserSession(), \OC::$server->query(UserPluginManager::class));
 		\OC_User::useBackend($userBackend);
 	}
 


### PR DESCRIPTION
This is the first PR towards an app.php free user_ldap app. This removes the custom mapping of a string to a class name.