### PR TITLE
Bootstrap: add initial state registration

### DIFF
--- a/apps/accessibility/lib/AppInfo/Application.php
+++ b/apps/accessibility/lib/AppInfo/Application.php
@@ -36,9 +36,7 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
-use OCP\AppFramework\IAppContainer;
 use OCP\IConfig;
-use OCP\IInitialStateService;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
 use function count;
@@ -55,11 +53,11 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function register(IRegistrationContext $context): void {
+		$context->registerInitialStateProvider(JSDataService::class);
 	}
 
 	public function boot(IBootContext $context): void {
 		$context->injectFn([$this, 'injectCss']);
-		$context->injectFn([$this, 'registerInitialState']);
 	}
 
 	public function injectCss(IUserSession $userSession,
@@ -83,14 +81,5 @@ class Application extends App implements IBootstrap {
 			$linkToCSS = $urlGenerator->linkToRoute(self::APP_ID . '.accessibility.getCss', ['md5' => $hash]);
 			\OCP\Util::addHeader('link', ['rel' => 'stylesheet', 'media' => '(prefers-color-scheme: dark)', 'href' => $linkToCSS]);
 		}
-	}
-
-	public function registerInitialState(IInitialStateService $initialState,
-										  IAppContainer $container) {
-		$initialState->provideLazyInitialState(self::APP_ID, 'data', function () use ($container) {
-			/** @var JSDataService $data */
-			$data = $container->query(JSDataService::class);
-			return $data;
-		});
 	}
 }

--- a/apps/accessibility/lib/Service/JSDataService.php
+++ b/apps/accessibility/lib/Service/JSDataService.php
@@ -27,10 +27,11 @@ declare(strict_types=1);
 namespace OCA\Accessibility\Service;
 
 use OCA\Accessibility\AppInfo\Application;
+use OCP\AppFramework\Services\InitialStateProvider;
 use OCP\IConfig;
 use OCP\IUserSession;
 
-class JSDataService implements \JsonSerializable {
+class JSDataService extends InitialStateProvider {
 	/** @var IUserSession */
 	private $userSession;
 	/** @var IConfig */
@@ -44,7 +45,11 @@ class JSDataService implements \JsonSerializable {
 		$this->config = $config;
 	}
 
-	public function jsonSerialize() {
+	public function getKey(): string {
+		return 'data';
+	}
+
+	public function getData() {
 		$user = $this->userSession->getUser();
 
 		if ($user === null) {

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -77,6 +77,7 @@ return array(
     'OCP\\AppFramework\\QueryException' => $baseDir . '/lib/public/AppFramework/QueryException.php',
     'OCP\\AppFramework\\Services\\IAppConfig' => $baseDir . '/lib/public/AppFramework/Services/IAppConfig.php',
     'OCP\\AppFramework\\Services\\IInitialState' => $baseDir . '/lib/public/AppFramework/Services/IInitialState.php',
+    'OCP\\AppFramework\\Services\\InitialStateProvider' => $baseDir . '/lib/public/AppFramework/Services/InitialStateProvider.php',
     'OCP\\AppFramework\\Utility\\IControllerMethodReflector' => $baseDir . '/lib/public/AppFramework/Utility/IControllerMethodReflector.php',
     'OCP\\AppFramework\\Utility\\ITimeFactory' => $baseDir . '/lib/public/AppFramework/Utility/ITimeFactory.php',
     'OCP\\App\\AppPathNotFoundException' => $baseDir . '/lib/public/App/AppPathNotFoundException.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -106,6 +106,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\AppFramework\\QueryException' => __DIR__ . '/../../..' . '/lib/public/AppFramework/QueryException.php',
         'OCP\\AppFramework\\Services\\IAppConfig' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Services/IAppConfig.php',
         'OCP\\AppFramework\\Services\\IInitialState' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Services/IInitialState.php',
+        'OCP\\AppFramework\\Services\\InitialStateProvider' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Services/InitialStateProvider.php',
         'OCP\\AppFramework\\Utility\\IControllerMethodReflector' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Utility/IControllerMethodReflector.php',
         'OCP\\AppFramework\\Utility\\ITimeFactory' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Utility/ITimeFactory.php',
         'OCP\\App\\AppPathNotFoundException' => __DIR__ . '/../../..' . '/lib/public/App/AppPathNotFoundException.php',

--- a/lib/private/AppFramework/Bootstrap/RegistrationContext.php
+++ b/lib/private/AppFramework/Bootstrap/RegistrationContext.php
@@ -69,6 +69,9 @@ class RegistrationContext {
 	/** @var array[] */
 	private $alternativeLogins = [];
 
+	/** @var array[] */
+	private $initialStates = [];
+
 	/** @var ILogger */
 	private $logger;
 
@@ -164,6 +167,13 @@ class RegistrationContext {
 					$class
 				);
 			}
+
+			public function registerInitialStateProvider(string $class): void {
+				$this->context->registerInitialState(
+					$this->appId,
+					$class
+				);
+			}
 		};
 	}
 
@@ -238,6 +248,13 @@ class RegistrationContext {
 
 	public function registerAlternativeLogin(string $appId, string $class): void {
 		$this->alternativeLogins[] = [
+			'appId' => $appId,
+			'class' => $class,
+		];
+	}
+
+	public function registerInitialState(string $appId, string $class): void {
+		$this->initialStates[] = [
 			'appId' => $appId,
 			'class' => $class,
 		];
@@ -412,5 +429,12 @@ class RegistrationContext {
 	 */
 	public function getAlternativeLogins(): array {
 		return $this->alternativeLogins;
+	}
+
+	/**
+	 * @erturn array[]
+	 */
+	public function getInitialStates(): array {
+		return $this->initialStates;
 	}
 }

--- a/lib/public/AppFramework/Bootstrap/IRegistrationContext.php
+++ b/lib/public/AppFramework/Bootstrap/IRegistrationContext.php
@@ -155,4 +155,17 @@ interface IRegistrationContext {
 	 * @since 20.0.0
 	 */
 	public function registerAlternativeLogin(string $class): void;
+
+	/**
+	 * Register an initialstate provider
+	 *
+	 * It is allowed to register more than one provider per app.
+	 *
+	 * @param string $class
+	 *
+	 * @return void
+	 *
+	 * @since 21.0.0
+	 */
+	public function registerInitialStateProvider(string $class): void;
 }

--- a/lib/public/AppFramework/Services/InitialStateProvider.php
+++ b/lib/public/AppFramework/Services/InitialStateProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\AppFramework\Services;
+
+/**
+ * @since 21.0.0
+ */
+abstract class InitialStateProvider implements \JsonSerializable {
+
+	/**
+	 * @since 21.0.0
+	 */
+	abstract public function getKey(): string;
+
+	/**
+	 * @since 21.0.0
+	 */
+	abstract public function getData();
+
+	/**
+	 * @since 21.0.0
+	 */
+	final public function jsonSerialize() {
+		return $this->getData();
+	}
+}

--- a/lib/public/IInitialStateService.php
+++ b/lib/public/IInitialStateService.php
@@ -43,6 +43,8 @@ interface IInitialStateService {
 	 * @param string $appName
 	 * @param string $key
 	 * @param bool|int|float|string|array|\JsonSerializable $data
+	 *
+	 * @deprecated 21 Use OCP\AppFramework\Services\IInitialState or OCP\AppFramework\Services\InitialStateProvider
 	 */
 	public function provideInitialState(string $appName, string $key, $data): void;
 
@@ -58,6 +60,8 @@ interface IInitialStateService {
 	 * @param string $appName
 	 * @param string $key
 	 * @param Closure $closure returns a primitive or an object that implements JsonSerializable
+	 *
+	 * @deprecated 21 Use OCP\AppFramework\Services\IInitialState or OCP\AppFramework\Services\InitialStateProvider
 	 */
 	public function provideLazyInitialState(string $appName, string $key, Closure $closure): void;
 }

--- a/tests/lib/InitialStateServiceTest.php
+++ b/tests/lib/InitialStateServiceTest.php
@@ -25,6 +25,8 @@ declare(strict_types=1);
 
 namespace Test;
 
+use OC\AppFramework\Bootstrap\Coordinator;
+use OCP\IServerContainer;
 use function json_encode;
 use JsonSerializable;
 use OC\InitialStateService;
@@ -40,7 +42,9 @@ class InitialStateServiceTest extends TestCase {
 		parent::setUp();
 
 		$this->service = new InitialStateService(
-			$this->createMock(ILogger::class)
+			$this->createMock(ILogger::class),
+			$this->createMock(Coordinator::class),
+			$this->createMock(IServerContainer::class)
 		);
 	}
 


### PR DESCRIPTION
Covers basically

* Allow registering 'global' initial states in the registration step
* Deprecate the old way
* Move accessibility over as a PoC

I'm not 100% happy with the location of the base class. But I could not come up with a better name just now.