### PR TITLE
Fix AppFramework services

### DIFF
--- a/apps/settings/lib/Settings/Personal/Security/Authtokens.php
+++ b/apps/settings/lib/Settings/Personal/Security/Authtokens.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 
 namespace OCA\Settings\Settings\Personal\Security;
 
+use OCP\AppFramework\Services\IInitialState;
 use OCP\IUserSession;
 use function array_map;
 use OC\Authentication\Exceptions\InvalidTokenException;
@@ -33,7 +34,6 @@ use OC\Authentication\Token\INamedToken;
 use OC\Authentication\Token\IProvider as IAuthTokenProvider;
 use OC\Authentication\Token\IToken;
 use OCP\AppFramework\Http\TemplateResponse;
-use OCP\IInitialStateService;
 use OCP\ISession;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 use OCP\Settings\ISettings;
@@ -46,8 +46,8 @@ class Authtokens implements ISettings {
 	/** @var ISession */
 	private $session;
 
-	/** @var IInitialStateService */
-	private $initialStateService;
+	/** @var IInitialState */
+	private $initialState;
 
 	/** @var string|null */
 	private $uid;
@@ -58,24 +58,22 @@ class Authtokens implements ISettings {
 	public function __construct(IAuthTokenProvider $tokenProvider,
 								ISession $session,
 								IUserSession $userSession,
-								IInitialStateService $initialStateService,
+								IInitialState $initialState,
 								?string $UserId) {
 		$this->tokenProvider = $tokenProvider;
 		$this->session = $session;
-		$this->initialStateService = $initialStateService;
+		$this->initialState = $initialState;
 		$this->uid = $UserId;
 		$this->userSession = $userSession;
 	}
 
 	public function getForm(): TemplateResponse {
-		$this->initialStateService->provideInitialState(
-			'settings',
+		$this->initialState->provideInitialState(
 			'app_tokens',
 			$this->getAppTokens()
 		);
 
-		$this->initialStateService->provideInitialState(
-			'settings',
+		$this->initialState->provideInitialState(
 			'can_create_app_token',
 			$this->userSession->getImpersonatingUserID() === null
 		);

--- a/apps/settings/tests/Settings/Personal/Security/AuthtokensTest.php
+++ b/apps/settings/tests/Settings/Personal/Security/AuthtokensTest.php
@@ -30,7 +30,7 @@ use OC\Authentication\Token\DefaultToken;
 use OC\Authentication\Token\IProvider as IAuthTokenProvider;
 use OCA\Settings\Settings\Personal\Security\Authtokens;
 use OCP\AppFramework\Http\TemplateResponse;
-use OCP\IInitialStateService;
+use OCP\AppFramework\Services\IInitialState;
 use OCP\ISession;
 use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -47,8 +47,8 @@ class AuthtokensTest extends TestCase {
 	/** @var IUserSession|MockObject */
 	private $userSession;
 
-	/** @var IInitialStateService|MockObject */
-	private $initialStateService;
+	/** @var IInitialState|MockObject */
+	private $initialState;
 
 	/** @var string */
 	private $uid;
@@ -62,14 +62,14 @@ class AuthtokensTest extends TestCase {
 		$this->authTokenProvider = $this->createMock(IAuthTokenProvider::class);
 		$this->session = $this->createMock(ISession::class);
 		$this->userSession = $this->createMock(IUserSession::class);
-		$this->initialStateService = $this->createMock(IInitialStateService::class);
+		$this->initialState = $this->createMock(IInitialState::class);
 		$this->uid = 'test123';
 
 		$this->section = new Authtokens(
 			$this->authTokenProvider,
 			$this->session,
 			$this->userSession,
-			$this->initialStateService,
+			$this->initialState,
 			$this->uid
 		);
 	}
@@ -97,9 +97,9 @@ class AuthtokensTest extends TestCase {
 			->method('getToken')
 			->with('session123')
 			->willReturn($sessionToken);
-		$this->initialStateService->expects($this->at(0))
+		$this->initialState->expects($this->at(0))
 			->method('provideInitialState')
-			->with('settings', 'app_tokens', [
+			->with('app_tokens', [
 				[
 					'id' => 100,
 					'name' => null,
@@ -121,9 +121,9 @@ class AuthtokensTest extends TestCase {
 				],
 			]);
 
-		$this->initialStateService->expects($this->at(1))
+		$this->initialState->expects($this->at(1))
 			->method('provideInitialState')
-			->with('settings', 'can_create_app_token', true);
+			->with('can_create_app_token', true);
 
 		$form = $this->section->getForm();
 

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -59,6 +59,8 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\Folder;
 use OCP\Files\IAppData;
 use OCP\Group\ISubAdmin;
+use OCP\IConfig;
+use OCP\IInitialStateService;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\INavigationManager;
@@ -295,8 +297,18 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return $dispatcher;
 		});
 
-		$this->registerAlias(IAppConfig::class, OC\AppFramework\Services\AppConfig::class);
-		$this->registerAlias(IInitialState::class, OC\AppFramework\Services\InitialState::class);
+		$this->registerService(IAppConfig::class, function (SimpleContainer $c) {
+			return new OC\AppFramework\Services\AppConfig(
+				$c->query(IConfig::class),
+				$c->query('AppName')
+			);
+		});
+		$this->registerService(IInitialState::class, function (SimpleContainer $c) {
+			return new OC\AppFramework\Services\InitialState(
+				$c->query(IInitialStateService::class),
+				$c->query('AppName')
+			);
+		});
 	}
 
 	/**


### PR DESCRIPTION
* We can't just register an alias as the services need the appId to be
  injected. if we just register an alias this blows up since the main
  container doesn't have the appId.
* Moved the Authtokens over to show the PoC works

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>