### PR TITLE
Delegate bootstrap registration lazily

### DIFF
--- a/lib/private/AppFramework/Bootstrap/RegistrationContext.php
+++ b/lib/private/AppFramework/Bootstrap/RegistrationContext.php
@@ -26,7 +26,6 @@ declare(strict_types=1);
 namespace OC\AppFramework\Bootstrap;
 
 use Closure;
-use OC\Search\SearchComposer;
 use OC\Support\CrashReport\Registry;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
@@ -347,19 +346,9 @@ class RegistrationContext {
 	}
 
 	/**
-	 * @param App[] $apps
+	 * @return array[]
 	 */
-	public function delegateSearchProviderRegistration(array $apps, SearchComposer $searchComposer): void {
-		foreach ($this->searchProviders as $registration) {
-			try {
-				$searchComposer->registerProvider($registration['class']);
-			} catch (Throwable $e) {
-				$appId = $registration['appId'];
-				$this->logger->logException($e, [
-					'message' => "Error during search provider registration of $appId: " . $e->getMessage(),
-					'level' => ILogger::ERROR,
-				]);
-			}
-		}
+	public function getSearchProviders(): array {
+		return $this->searchProviders;
 	}
 }

--- a/tests/lib/AppFramework/Bootstrap/CoordinatorTest.php
+++ b/tests/lib/AppFramework/Bootstrap/CoordinatorTest.php
@@ -26,7 +26,6 @@ declare(strict_types=1);
 namespace lib\AppFramework\Bootstrap;
 
 use OC\AppFramework\Bootstrap\Coordinator;
-use OC\Search\SearchComposer;
 use OC\Support\CrashReport\Registry;
 use OCP\App\IAppManager;
 use OCP\AppFramework\App;
@@ -54,9 +53,6 @@ class CoordinatorTest extends TestCase {
 	/** @var IEventDispatcher|MockObject */
 	private $eventDispatcher;
 
-	/** @var SearchComposer|MockObject */
-	private $searchComposer;
-
 	/** @var ILogger|MockObject */
 	private $logger;
 
@@ -70,14 +66,12 @@ class CoordinatorTest extends TestCase {
 		$this->serverContainer = $this->createMock(IServerContainer::class);
 		$this->crashReporterRegistry = $this->createMock(Registry::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
-		$this->searchComposer = $this->createMock(SearchComposer::class);
 		$this->logger = $this->createMock(ILogger::class);
 
 		$this->coordinator = new Coordinator(
 			$this->serverContainer,
 			$this->crashReporterRegistry,
 			$this->eventDispatcher,
-			$this->searchComposer,
 			$this->logger
 		);
 	}


### PR DESCRIPTION
* Keep the registration context
* Expose the context object for other components
* Ensure registration is only run once

Search providers are migrated for demonstration.

@rullzer I think that is somewhat the idea you had IIRC. Things like event listeners make little sense to make more lazy because they are quite likely to be used in 90% of our requests, but other stuff if too specific and shouldn't consume too much CPU power not used in most cases, like in https://github.com/nextcloud/server/pull/21826.