### PR TITLE
Avoid substr() error when strpos returns false

### DIFF
--- a/lib/private/Files/Type/Detection.php
+++ b/lib/private/Files/Type/Detection.php
@@ -374,7 +374,7 @@ class Detection implements IMimeTypeDetector {
 
 		// Try only the first part of the filetype
 
-		if(strpos($icon, '-')) {
+		if (strpos($icon, '-')) {
 			$mimePart = substr($icon, 0, strpos($icon, '-'));
 			try {
 				$this->mimetypeIcons[$mimetype] = $this->urlGenerator->imagePath('core', 'filetypes/' . $mimePart . '.svg');

--- a/lib/private/Files/Type/Detection.php
+++ b/lib/private/Files/Type/Detection.php
@@ -373,12 +373,15 @@ class Detection implements IMimeTypeDetector {
 		}
 
 		// Try only the first part of the filetype
-		$mimePart = substr($icon, 0, strpos($icon, '-'));
-		try {
-			$this->mimetypeIcons[$mimetype] = $this->urlGenerator->imagePath('core', 'filetypes/' . $mimePart . '.svg');
-			return $this->mimetypeIcons[$mimetype];
-		} catch (\RuntimeException $e) {
-			// Image for the first part of the mimetype not found
+
+		if(strpos($icon, '-')) {
+			$mimePart = substr($icon, 0, strpos($icon, '-'));
+			try {
+				$this->mimetypeIcons[$mimetype] = $this->urlGenerator->imagePath('core', 'filetypes/' . $mimePart . '.svg');
+				return $this->mimetypeIcons[$mimetype];
+			} catch (\RuntimeException $e) {
+				// Image for the first part of the mimetype not found
+			}
 		}
 
 		$this->mimetypeIcons[$mimetype] = $this->urlGenerator->imagePath('core', 'filetypes/file.svg');


### PR DESCRIPTION
"Exception: substr() expects parameter 3 to be int, bool given" can occur on Line 378 $mimePart = substr($icon, 0, strpos($icon, '-'));
This happens, when '-' is not found and strpos returns false instead of an int.
When this occurs, e.g., Activity hangs.

Signed-off-by: Lukas Iffländer lukas.ifflaender@uni-wuerzburg.de