### PR TITLE
Deprecate the internal Symfony dispatcher adapter

### DIFF
--- a/lib/private/EventDispatcher/EventDispatcher.php
+++ b/lib/private/EventDispatcher/EventDispatcher.php
@@ -100,6 +100,7 @@ class EventDispatcher implements IEventDispatcher {
 
 	/**
 	 * @return SymfonyDispatcher
+	 * @deprecated 20.0.0
 	 */
 	public function getSymfonyDispatcher(): SymfonyDispatcher {
 		return $this->dispatcher;

--- a/lib/private/EventDispatcher/SymfonyAdapter.php
+++ b/lib/private/EventDispatcher/SymfonyAdapter.php
@@ -35,6 +35,9 @@ use OCP\ILogger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
+/**
+ * @deprecated 20.0.0 use \OCP\EventDispatcher\IEventDispatcher
+ */
 class SymfonyAdapter implements EventDispatcherInterface {
 
 	/** @var EventDispatcher */
@@ -42,6 +45,9 @@ class SymfonyAdapter implements EventDispatcherInterface {
 	/** @var ILogger */
 	private $logger;
 
+	/**
+	 * @deprecated 20.0.0
+	 */
 	public function __construct(EventDispatcher $eventDispatcher, ILogger $logger) {
 		$this->eventDispatcher = $eventDispatcher;
 		$this->logger = $logger;
@@ -57,6 +63,7 @@ class SymfonyAdapter implements EventDispatcherInterface {
 	 *                              If not supplied, an empty Event instance is created
 	 *
 	 * @return void
+	 * @deprecated 20.0.0
 	 */
 	public function dispatch($eventName, $event = null) {
 		// type hinting is not possible, due to usage of GenericEvent
@@ -85,6 +92,7 @@ class SymfonyAdapter implements EventDispatcherInterface {
 	 * @param callable $listener The listener
 	 * @param int $priority The higher this value, the earlier an event
 	 *                            listener will be triggered in the chain (defaults to 0)
+	 * @deprecated 20.0.0
 	 */
 	public function addListener($eventName, $listener, $priority = 0) {
 		if (is_callable($listener)) {
@@ -100,6 +108,7 @@ class SymfonyAdapter implements EventDispatcherInterface {
 	 *
 	 * The subscriber is asked for all the events it is
 	 * interested in and added as a listener for these events.
+	 * @deprecated 20.0.0
 	 */
 	public function addSubscriber(EventSubscriberInterface $subscriber) {
 		$this->eventDispatcher->getSymfonyDispatcher()->addSubscriber($subscriber);
@@ -110,11 +119,15 @@ class SymfonyAdapter implements EventDispatcherInterface {
 	 *
 	 * @param string $eventName The event to remove a listener from
 	 * @param callable $listener The listener to remove
+	 * @deprecated 20.0.0
 	 */
 	public function removeListener($eventName, $listener) {
 		$this->eventDispatcher->getSymfonyDispatcher()->removeListener($eventName, $listener);
 	}
 
+	/**
+	 * @deprecated 20.0.0
+	 */
 	public function removeSubscriber(EventSubscriberInterface $subscriber) {
 		$this->eventDispatcher->getSymfonyDispatcher()->removeSubscriber($subscriber);
 	}
@@ -125,6 +138,7 @@ class SymfonyAdapter implements EventDispatcherInterface {
 	 * @param string|null $eventName The name of the event
 	 *
 	 * @return array The event listeners for the specified event, or all event listeners by event name
+	 * @deprecated 20.0.0
 	 */
 	public function getListeners($eventName = null) {
 		return $this->eventDispatcher->getSymfonyDispatcher()->getListeners($eventName);
@@ -139,6 +153,7 @@ class SymfonyAdapter implements EventDispatcherInterface {
 	 * @param callable $listener The listener
 	 *
 	 * @return int|null The event listener priority
+	 * @deprecated 20.0.0
 	 */
 	public function getListenerPriority($eventName, $listener) {
 		return $this->eventDispatcher->getSymfonyDispatcher()->getListenerPriority($eventName, $listener);
@@ -150,6 +165,7 @@ class SymfonyAdapter implements EventDispatcherInterface {
 	 * @param string|null $eventName The name of the event
 	 *
 	 * @return bool true if the specified event has any listeners, false otherwise
+	 * @deprecated 20.0.0
 	 */
 	public function hasListeners($eventName = null) {
 		return $this->eventDispatcher->getSymfonyDispatcher()->hasListeners($eventName);


### PR DESCRIPTION
This type is not known on the public API, yet we should make sure that
any usage of this class is noticed and migrated as soon as possible.

IMO deprecation makes sense for internals as well as phpstorm and other decent IDEs show deprecated API usages in a distinctive styling.

Related to https://github.com/nextcloud/server/pull/21322, the change of the public API.