### PR TITLE
Add a scoped PSR logger for apps

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -592,6 +592,7 @@ return array(
     'OC\\AppFramework\\OCS\\V2Response' => $baseDir . '/lib/private/AppFramework/OCS/V2Response.php',
     'OC\\AppFramework\\Routing\\RouteActionHandler' => $baseDir . '/lib/private/AppFramework/Routing/RouteActionHandler.php',
     'OC\\AppFramework\\Routing\\RouteConfig' => $baseDir . '/lib/private/AppFramework/Routing/RouteConfig.php',
+    'OC\\AppFramework\\ScopedPsrLogger' => $baseDir . '/lib/private/AppFramework/ScopedPsrLogger.php',
     'OC\\AppFramework\\Services\\AppConfig' => $baseDir . '/lib/private/AppFramework/Services/AppConfig.php',
     'OC\\AppFramework\\Services\\InitialState' => $baseDir . '/lib/private/AppFramework/Services/InitialState.php',
     'OC\\AppFramework\\Utility\\ControllerMethodReflector' => $baseDir . '/lib/private/AppFramework/Utility/ControllerMethodReflector.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -621,6 +621,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\AppFramework\\OCS\\V2Response' => __DIR__ . '/../../..' . '/lib/private/AppFramework/OCS/V2Response.php',
         'OC\\AppFramework\\Routing\\RouteActionHandler' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Routing/RouteActionHandler.php',
         'OC\\AppFramework\\Routing\\RouteConfig' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Routing/RouteConfig.php',
+        'OC\\AppFramework\\ScopedPsrLogger' => __DIR__ . '/../../..' . '/lib/private/AppFramework/ScopedPsrLogger.php',
         'OC\\AppFramework\\Services\\AppConfig' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Services/AppConfig.php',
         'OC\\AppFramework\\Services\\InitialState' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Services/InitialState.php',
         'OC\\AppFramework\\Utility\\ControllerMethodReflector' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Utility/ControllerMethodReflector.php',

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -45,8 +45,10 @@ use OC\AppFramework\Middleware\Security\CORSMiddleware;
 use OC\AppFramework\Middleware\Security\RateLimitingMiddleware;
 use OC\AppFramework\Middleware\Security\SecurityMiddleware;
 use OC\AppFramework\Middleware\SessionMiddleware;
+use OC\AppFramework\ScopedPsrLogger;
 use OC\AppFramework\Utility\SimpleContainer;
 use OC\Core\Middleware\TwoFactorMiddleware;
+use OC\Log\PsrLoggerAdapter;
 use OC\ServerContainer;
 use OCA\WorkflowEngine\Manager;
 use OCP\AppFramework\Http\IOutput;
@@ -70,6 +72,7 @@ use OCP\ISession;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * @deprecated 20.0.0
@@ -128,7 +131,13 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return $this->getServer()->getL10N($c->get('AppName'));
 		});
 
-		// Log wrapper
+		// Log wrappers
+		$this->registerService(LoggerInterface::class, function (ContainerInterface $c) {
+			return new ScopedPsrLogger(
+				$c->get(PsrLoggerAdapter::class),
+				$c->get('AppName')
+			);
+		});
 		$this->registerService(ILogger::class, function (ContainerInterface $c) {
 			return new OC\AppFramework\Logger($this->server->query(ILogger::class), $c->get('AppName'));
 		});

--- a/lib/private/AppFramework/ScopedPsrLogger.php
+++ b/lib/private/AppFramework/ScopedPsrLogger.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OC\AppFramework;
+
+use Psr\Log\LoggerInterface;
+use function array_merge;
+
+class ScopedPsrLogger implements LoggerInterface {
+
+	/** @var LoggerInterface */
+	private $inner;
+
+	/** @var string */
+	private $appId;
+
+	public function __construct(LoggerInterface $inner,
+								string $appId) {
+		$this->inner = $inner;
+		$this->appId = $appId;
+	}
+
+	public function emergency($message, array $context = []) {
+		$this->inner->emergency(
+			$message,
+			array_merge(
+				[
+					'app' => $this->appId,
+				],
+				$context
+			)
+		);
+	}
+
+	public function alert($message, array $context = []) {
+		$this->inner->alert(
+			$message,
+			array_merge(
+				[
+					'app' => $this->appId,
+				],
+				$context
+			)
+		);
+	}
+
+	public function critical($message, array $context = []) {
+		$this->inner->critical(
+			$message,
+			array_merge(
+				[
+					'app' => $this->appId,
+				],
+				$context
+			)
+		);
+	}
+
+	public function error($message, array $context = []) {
+		$this->inner->error(
+			$message,
+			array_merge(
+				[
+					'app' => $this->appId,
+				],
+				$context
+			)
+		);
+	}
+
+	public function warning($message, array $context = []) {
+		$this->inner->warning(
+			$message,
+			array_merge(
+				[
+					'app' => $this->appId,
+				],
+				$context
+			)
+		);
+	}
+
+	public function notice($message, array $context = []) {
+		$this->inner->notice(
+			$message,
+			array_merge(
+				[
+					'app' => $this->appId,
+				],
+				$context
+			)
+		);
+	}
+
+	public function info($message, array $context = []) {
+		$this->inner->info(
+			$message,
+			array_merge(
+				[
+					'app' => $this->appId,
+				],
+				$context
+			)
+		);
+	}
+
+	public function debug($message, array $context = []) {
+		$this->inner->debug(
+			$message,
+			array_merge(
+				[
+					'app' => $this->appId,
+				],
+				$context
+			)
+		);
+	}
+
+	public function log($level, $message, array $context = []) {
+		$this->inner->log(
+			$message,
+			array_merge(
+				[
+					'app' => $this->appId,
+				],
+				$context
+			)
+		);
+	}
+}


### PR DESCRIPTION
Just like for ILogger we should have a version that has the app ID
pre-set for the context (unless overwritten) so that each log entry can
be traced back to the app that produced it.

This adds a decorator that does just this.

Next step will be to deprecate ILogger :smiling_imp: :fire: :bomb: 