### PR TITLE
Deprecate ILogger in favor of the PSR-3 logger

### DIFF
--- a/apps/contactsinteraction/lib/Listeners/ContactInteractionListener.php
+++ b/apps/contactsinteraction/lib/Listeners/ContactInteractionListener.php
@@ -33,8 +33,8 @@ use OCP\Contacts\Events\ContactInteractedWithEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
 use Sabre\VObject\Component\VCard;
 use Sabre\VObject\Reader;
 use Sabre\VObject\UUIDUtil;
@@ -57,7 +57,7 @@ class ContactInteractionListener implements IEventListener {
 	/** @var IL10N */
 	private $l10n;
 
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	private $logger;
 
 	public function __construct(RecentContactMapper $mapper,
@@ -65,7 +65,7 @@ class ContactInteractionListener implements IEventListener {
 								IUserManager $userManager,
 								ITimeFactory $timeFactory,
 								IL10N $l10nFactory,
-								ILogger $logger) {
+								LoggerInterface $logger) {
 		$this->mapper = $mapper;
 		$this->cardSearchDao = $cardSearchDao;
 		$this->userManager = $userManager;
@@ -125,10 +125,11 @@ class ContactInteractionListener implements IEventListener {
 				$parsed->CATEGORIES = $this->l10n->t('Recently contacted');
 				$contact->setCard($parsed->serialize());
 			} catch (Throwable $e) {
-				$this->logger->logException($e, [
-					'message' => 'Could not parse card to add recent category: ' . $e->getMessage(),
-					'level' => ILogger::WARN,
-				]);
+				$this->logger->warning(
+					'Could not parse card to add recent category: ' . $e->getMessage(),
+					[
+						'exception' => $e,
+					]);
 				$contact->setCard($copy);
 			}
 		} else {

--- a/lib/private/AppFramework/Logger.php
+++ b/lib/private/AppFramework/Logger.php
@@ -28,6 +28,9 @@ namespace OC\AppFramework;
 
 use OCP\ILogger;
 
+/**
+ * @deprecated
+ */
 class Logger implements ILogger {
 
 	/** @var ILogger */
@@ -36,6 +39,9 @@ class Logger implements ILogger {
 	/** @var string */
 	private $appName;
 
+	/**
+	 * @deprecated
+	 */
 	public function __construct(ILogger $logger, string $appName) {
 		$this->logger = $logger;
 		$this->appName = $appName;
@@ -49,42 +55,72 @@ class Logger implements ILogger {
 		return $context;
 	}
 
+	/**
+	 * @deprecated
+	 */
 	public function emergency(string $message, array $context = []) {
 		$this->logger->emergency($message, $this->extendContext($context));
 	}
 
+	/**
+	 * @deprecated
+	 */
 	public function alert(string $message, array $context = []) {
 		$this->logger->alert($message, $this->extendContext($context));
 	}
 
+	/**
+	 * @deprecated
+	 */
 	public function critical(string $message, array $context = []) {
 		$this->logger->critical($message, $this->extendContext($context));
 	}
 
+	/**
+	 * @deprecated
+	 */
 	public function error(string $message, array $context = []) {
 		$this->logger->emergency($message, $this->extendContext($context));
 	}
 
+	/**
+	 * @deprecated
+	 */
 	public function warning(string $message, array $context = []) {
 		$this->logger->warning($message, $this->extendContext($context));
 	}
 
+	/**
+	 * @deprecated
+	 */
 	public function notice(string $message, array $context = []) {
 		$this->logger->notice($message, $this->extendContext($context));
 	}
 
+	/**
+	 * @deprecated
+	 */
 	public function info(string $message, array $context = []) {
 		$this->logger->info($message, $this->extendContext($context));
 	}
 
+	/**
+	 * @deprecated
+	 */
 	public function debug(string $message, array $context = []) {
 		$this->logger->debug($message, $this->extendContext($context));
 	}
 
+	/**
+	 * @deprecated
+	 */
 	public function log(int $level, string $message, array $context = []) {
 		$this->logger->log($level, $message, $this->extendContext($context));
 	}
 
+	/**
+	 * @deprecated
+	 */
 	public function logException(\Throwable $exception, array $context = []) {
 		$this->logger->logException($exception, $this->extendContext($context));
 	}

--- a/lib/public/ILogger.php
+++ b/lib/public/ILogger.php
@@ -39,26 +39,32 @@ namespace OCP;
  *
  * This logger interface follows the design guidelines of PSR-3
  * https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md#3-psrlogloggerinterface
+ * @deprecated 20.0.0 use the PSR-3 logger \Psr\Log\LoggerInterface
  */
 interface ILogger {
 	/**
 	 * @since 14.0.0
+	 * @deprecated 20.0.0
 	 */
 	public const DEBUG=0;
 	/**
 	 * @since 14.0.0
+	 * @deprecated 20.0.0
 	 */
 	public const INFO=1;
 	/**
 	 * @since 14.0.0
+	 * @deprecated 20.0.0
 	 */
 	public const WARN=2;
 	/**
 	 * @since 14.0.0
+	 * @deprecated 20.0.0
 	 */
 	public const ERROR=3;
 	/**
 	 * @since 14.0.0
+	 * @deprecated 20.0.0
 	 */
 	public const FATAL=4;
 
@@ -69,6 +75,7 @@ interface ILogger {
 	 * @param array $context
 	 * @return null
 	 * @since 7.0.0
+	 * @deprecated 20.0.0 use \Psr\Log\LoggerInterface::emergency
 	 */
 	public function emergency(string $message, array $context = []);
 
@@ -79,6 +86,7 @@ interface ILogger {
 	 * @param array $context
 	 * @return null
 	 * @since 7.0.0
+	 * @deprecated 20.0.0 use \Psr\Log\LoggerInterface::alert
 	 */
 	public function alert(string $message, array $context = []);
 
@@ -89,6 +97,7 @@ interface ILogger {
 	 * @param array $context
 	 * @return null
 	 * @since 7.0.0
+	 * @deprecated 20.0.0 use \Psr\Log\LoggerInterface::critical
 	 */
 	public function critical(string $message, array $context = []);
 
@@ -100,6 +109,7 @@ interface ILogger {
 	 * @param array $context
 	 * @return null
 	 * @since 7.0.0
+	 * @deprecated 20.0.0 use \Psr\Log\LoggerInterface::error
 	 */
 	public function error(string $message, array $context = []);
 
@@ -110,6 +120,7 @@ interface ILogger {
 	 * @param array $context
 	 * @return null
 	 * @since 7.0.0
+	 * @deprecated 20.0.0 use \Psr\Log\LoggerInterface::warning
 	 */
 	public function warning(string $message, array $context = []);
 
@@ -120,6 +131,7 @@ interface ILogger {
 	 * @param array $context
 	 * @return null
 	 * @since 7.0.0
+	 * @deprecated 20.0.0 use \Psr\Log\LoggerInterface::notice
 	 */
 	public function notice(string $message, array $context = []);
 
@@ -130,6 +142,7 @@ interface ILogger {
 	 * @param array $context
 	 * @return null
 	 * @since 7.0.0
+	 * @deprecated 20.0.0 use \Psr\Log\LoggerInterface::info
 	 */
 	public function info(string $message, array $context = []);
 
@@ -140,6 +153,7 @@ interface ILogger {
 	 * @param array $context
 	 * @return null
 	 * @since 7.0.0
+	 * @deprecated 20.0.0 use \Psr\Log\LoggerInterface::debug
 	 */
 	public function debug(string $message, array $context = []);
 
@@ -151,6 +165,7 @@ interface ILogger {
 	 * @param array $context
 	 * @return mixed
 	 * @since 7.0.0
+	 * @deprecated 20.0.0 use \Psr\Log\LoggerInterface::log
 	 */
 	public function log(int $level, string $message, array $context = []);
 
@@ -169,6 +184,7 @@ interface ILogger {
 	 * @param array $context
 	 * @return void
 	 * @since 8.2.0
+	 * @deprecated 20.0.0 use the `exception` entry in the context of any method in \Psr\Log\LoggerInterface
 	 */
 	public function logException(\Throwable $exception, array $context = []);
 }


### PR DESCRIPTION
The logger service was always intended to follow the PSR-3 interface.
It's time to embrace this and switch over to the "official" API,
hence this custom interface can be slowly phased out.

With Nextcloud 20 the logger also got support for
* App id filled out automatically https://github.com/nextcloud/server/pull/21874
* Exceptions handling (as replacement for logException) https://github.com/nextcloud/server/pull/21827

So there are no more excuses not to use this :wink: 