### PR TITLE
Discourage webauthn user interaction

### DIFF
--- a/lib/private/Authentication/WebAuthn/Manager.php
+++ b/lib/private/Authentication/WebAuthn/Manager.php
@@ -107,7 +107,11 @@ class Manager {
 		$excludedPublicKeyDescriptors = [
 		];
 
-		$authenticatorSelectionCriteria = new AuthenticatorSelectionCriteria();
+		$authenticatorSelectionCriteria = new AuthenticatorSelectionCriteria(
+			null,
+			false,
+			AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_DISCOURAGED
+		);
 
 		return new PublicKeyCredentialCreationOptions(
 			$rpEntity,
@@ -186,7 +190,8 @@ class Manager {
 			random_bytes(32),                                                    // Challenge
 			60000,                                                              // Timeout
 			$this->stripPort($serverHost),                                                                  // Relying Party ID
-			$registeredPublicKeyCredentialDescriptors                                  // Registered PublicKeyCredentialDescriptor classes
+			$registeredPublicKeyCredentialDescriptors,                                  // Registered PublicKeyCredentialDescriptor classes
+			AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_DISCOURAGED
 		);
 	}
 


### PR DESCRIPTION
Else people might have the feeling this is also doing 2FA. And since it
is only prefered it can be ignored and hacked around.

Once we have proper 2FA with webauthn in one go this probably needs to
be revisted.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>