### PR TITLE
Menu overscroll

### DIFF
--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -124,7 +124,7 @@ kbd {
 		width: inherit;
 		overflow-x: hidden;
 		overflow-y: auto;
-		overscroll-behavior: contain;
+		overscroll-behavior: auto contain;
 		box-sizing: border-box;
 		display: flex;
 		flex-direction: column;

--- a/core/css/apps.scss
+++ b/core/css/apps.scss
@@ -124,6 +124,7 @@ kbd {
 		width: inherit;
 		overflow-x: hidden;
 		overflow-y: auto;
+		overscroll-behavior: contain;
 		box-sizing: border-box;
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
Just a small tweak I thought was worth adding, if you disagree feel free to reject/close :)

When scrolling to the bottom (or top) of the sidebar menu (eg on the settings page) the scroll then cascades to the body and causes the main content on the right to scroll.
This change prevents that and contains the vertical scroll to the menu sidebar.

Signed-off-by: Ben Court <git@bencourt.co.uk>