### PR TITLE
Deprecate the query mothod on the server container

### DIFF
--- a/lib/private/ServerContainer.php
+++ b/lib/private/ServerContainer.php
@@ -127,6 +127,9 @@ class ServerContainer extends SimpleContainer {
 		return parent::has($id);
 	}
 
+	/**
+	 * @deprecated 20.0.0 use \Psr\Container\ContainerInterface::get
+	 */
 	public function query(string $name, bool $autoload = true) {
 		$name = $this->sanitizeName($name);
 


### PR DESCRIPTION
The interface method has already been deprecated, but if some code uses
the concrete type instead, the deprecation is not shown (by phpstorm),
so I think it's better to have this method tagged as well.

The "fix" for this deprecation is to simply use `get` instead of
`query`. Right now this will work 100% the same, but the goal is to slim
down the interface and only use what PSR-11 offers.

Instead of ``\OC::$server->query`` you should use ``\OC::$server->get``.