### PR TITLE
Undeprecate IAppContainer and IServerContainer

### DIFF
--- a/lib/public/AppFramework/IAppContainer.php
+++ b/lib/public/AppFramework/IAppContainer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -27,16 +30,18 @@
 namespace OCP\AppFramework;
 
 use OCP\IContainer;
+use Psr\Container\ContainerInterface;
 
 /**
- * Class IAppContainer
- * @package OCP\AppFramework
+ * This is a tagging interface for a container that belongs to an app
  *
- * This container interface provides short cuts for app developers to access predefined app service.
+ * The interface currently extends IContainer, but this interface is deprecated as of Nextcloud 20,
+ * thus this interface won't extend it anymore once that was removed. So migrate to the ContainerInterface
+ * only.
+ *
  * @since 6.0.0
- * @deprecated 20.0.0 use \Psr\Container\ContainerInterface
  */
-interface IAppContainer extends IContainer {
+interface IAppContainer extends ContainerInterface, IContainer {
 
 	/**
 	 * used to return the appname of the set application

--- a/lib/public/IServerContainer.php
+++ b/lib/public/IServerContainer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -37,32 +40,25 @@
  *
  */
 
-/**
- * Public interface of ownCloud for apps to use.
- * Server container interface
- *
- */
-
-// use OCP namespace for all classes that are considered public.
-// This means that they should be used by apps instead of the internal ownCloud classes
-
 namespace OCP;
 
 use OCP\Federation\ICloudFederationFactory;
 use OCP\Federation\ICloudFederationProviderManager;
 use OCP\Log\ILogFactory;
 use OCP\Security\IContentSecurityPolicyManager;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
- * Class IServerContainer
- * @package OCP
+ * This is a tagging interface for the server container
  *
- * This container holds all ownCloud services
+ * The interface currently extends IContainer, but this interface is deprecated as of Nextcloud 20,
+ * thus this interface won't extend it anymore once that was removed. So migrate to the ContainerInterface
+ * only.
+ *
  * @since 6.0.0
- * @deprecated 20.0.0 use \Psr\Container\ContainerInterface
  */
-interface IServerContainer extends IContainer {
+interface IServerContainer extends ContainerInterface, IContainer {
 
 	/**
 	 * The calendar manager will act as a broker between consumers for calendar information and


### PR DESCRIPTION
With 4152216bd8cf9d49e6749d26bb8b491dd49b089b these two interfaces got
deprecated with the reasoning that we only need the base PSR interface.
However, there are cases where in Nextcloud you still want to have a
specific container (the one for the app vs the one for the server) when
you either have a container injected or query one from a container.

With a single interface that would not be possible. So it's probably
better if we leave the two interfaces, but only have them extend the PSR
interface. IContainer – with the custom methods – shall still be phased
out, but the two other sub interfaces can stay for tagging purposes.
Tagging means that no methods shall be added.

Sorry for the back and forth, but I think now it's a more solid API design :)

Ref my pitch
![Bildschirmfoto von 2020-07-17 10-20-50](https://user-images.githubusercontent.com/1374172/87764788-39569500-c817-11ea-8912-64ce0a026007.png)
