### PR TITLE
fix: file quota was not applied in all cases

### DIFF
--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -437,12 +437,12 @@ class Filesystem {
 
 			// home mounts are handled seperate since we need to ensure this is mounted before we call the other mount providers
 			$homeMount = $mountConfigManager->getHomeMountForUser($userObject);
+			self::getMountManager()->addMount($homeMount);
+
 			if ($homeMount->getStorageRootId() === -1) {
 				$homeMount->getStorage()->mkdir('');
 				$homeMount->getStorage()->getScanner()->scan('');
 			}
-
-			self::getMountManager()->addMount($homeMount);
 
 			\OC\Files\Filesystem::getStorage($user);
 


### PR DESCRIPTION
Since https://github.com/nextcloud/server/commit/70906a359f9f2dc326b299144b9f432ac4dc979c, the file quota was not applied in all cases (see discussion with @nickvergessen on Talk). You can see the problem in the test case for the notes app's API tests: https://github.com/nextcloud/notes/runs/881221664

It looks like the problem is that by calling `$homeMount->getStorageRootId()`, the storage cache is created before the mount was actually added. Moving `self::getMountManager()->addMount($homeMount)` before that call fixes this issue. However, I don't know if this has any side-effects.

/cc @icewind1991 @rullzer

Since the original PR https://github.com/nextcloud/server/pull/21489 was backported to stable19, stable18 and stable17, this PR should also be backported to those branches.