### PR TITLE
Implemented parsing the X-WebDAV HTTP header

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -974,6 +974,15 @@ class Server extends ServerContainer implements IServerContainer {
 				$stream = 'php://input';
 			}
 
+			if(isset($_SERVER) && isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === "POST") {
+				foreach($_SERVER as $item => $value) {
+					if($item === "HTTP_X_WEBDAV") {
+						$_SERVER["REQUEST_METHOD"]=$value;
+						break;
+					}
+				};
+			}
+
 			return new Request(
 				[
 					'get' => $_GET,


### PR DESCRIPTION
This PR works in tandem with one I just submitted for the desktop client. It allows parsing an X-WebDAV HTTP header. This header supposedly contains the actual request method, which needs to be masked for some service providers that disallow the less common methods like PROPFIND and MOVE.
This PR reads the header and replaces the request method, after which everything proceeds as normal. Anyone with powers to submit an HTTP request to the server can also adjust both request method and headers, so this should not have any security implications.

I had a brief look at the test directory, but could not find clear instructions on how to run this. If you can give me some pointers on how to most easily set this up properly, I might be able to add test cases for this PR.

Pull request for desktop client: https://github.com/nextcloud/desktop/pull/2214
