### PR TITLE
Encryption is ready if master key is enabled

### DIFF
--- a/apps/encryption/lib/Crypto/Encryption.php
+++ b/apps/encryption/lib/Crypto/Encryption.php
@@ -580,6 +580,9 @@ class Encryption implements IEncryptionModule {
 	 * @since 9.1.0
 	 */
 	public function isReadyForUser($user) {
+		if ($this->util->isMasterKeyEnabled()) {
+			return true;
+		}
 		return $this->keyManager->userHasKeys($user);
 	}
 


### PR DESCRIPTION
Make sure that encryption is taken as ready when a master key is used. Otherwise transfering files will always fail because there are no user keys generated by default:

https://github.com/nextcloud/server/blob/89ed2c37bf656ceb772bb6759c8977a7dc78b3fb/apps/files/lib/Service/OwnershipTransferService.php#L96

Steps to reproduce:
- Enable SSE with master key and home storage encryption
- Login as admin
- Login as user1
- `occ files:transfer-ownership admin user1`

Before:
The target user is not ready to accept files. The user has at least to have logged in once.

After:
Ownership transfer succeeds

Fixes https://github.com/nextcloud/server/issues/9601