### PR TITLE
Move Cantarell before Ubuntu in font stack to fix GNOME + Ubuntu setups

### DIFF
--- a/core/css/variables.scss
+++ b/core/css/variables.scss
@@ -83,7 +83,7 @@ $border-radius-large: 10px !default;
 // Pill-style button, value is large so big buttons also have correct roundness
 $border-radius-pill: 100px !default;
 
-$font-face: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol' !default;
+$font-face: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol' !default;
 
 $animation-quick: 100ms;
 $animation-slow: 300ms;


### PR DESCRIPTION
GNOME being installed on top of Ubuntu still resulted in the Ubuntu font to be used by default, which looks off:

Before: different fonts in OS and Nextcloud | After: same font
-|-
![different fonts](https://user-images.githubusercontent.com/925062/88066560-3092f580-cb6e-11ea-9cac-1c5955a87714.png) | ![same fonts](https://user-images.githubusercontent.com/925062/88066556-2f61c880-cb6e-11ea-8479-4278886c1ad5.png)
