### PR TITLE
Changed Content-Disposition header to download Contact Photo with correct extension

### DIFF
--- a/apps/dav/lib/CardDAV/ImageExportPlugin.php
+++ b/apps/dav/lib/CardDAV/ImageExportPlugin.php
@@ -103,7 +103,8 @@ class ImageExportPlugin extends ServerPlugin {
 		try {
 			$file = $this->cache->get($addressbook->getResourceId(), $node->getName(), $size, $node);
 			$response->setHeader('Content-Type', $file->getMimeType());
-			$response->setHeader('Content-Disposition', 'attachment');
+			$fileName = $node->getName() . '.' . PhotoCache::ALLOWED_CONTENT_TYPES[$file->getMimeType()];
+			$response->setHeader('Content-Disposition', "attachment; filename=$fileName");
 			$response->setStatus(200);
 
 			$response->setBody($file->getContent());

--- a/apps/dav/lib/CardDAV/PhotoCache.php
+++ b/apps/dav/lib/CardDAV/PhotoCache.php
@@ -43,7 +43,7 @@ use Sabre\VObject\Reader;
 class PhotoCache {
 
 	/** @var array  */
-	protected const ALLOWED_CONTENT_TYPES = [
+	public const ALLOWED_CONTENT_TYPES = [
 		'image/png' => 'png',
 		'image/jpeg' => 'jpg',
 		'image/gif' => 'gif',

--- a/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
@@ -166,7 +166,7 @@ class ImageExportPluginTest extends TestCase {
 		if ($photo) {
 			$file = $this->createMock(ISimpleFile::class);
 			$file->method('getMimeType')
-				->willReturn('imgtype');
+				->willReturn('image/jpeg');
 			$file->method('getContent')
 				->willReturn('imgdata');
 
@@ -176,10 +176,10 @@ class ImageExportPluginTest extends TestCase {
 
 			$this->response->expects($this->at(3))
 				->method('setHeader')
-				->with('Content-Type', 'imgtype');
+				->with('Content-Type', 'image/jpeg');
 			$this->response->expects($this->at(4))
 				->method('setHeader')
-				->with('Content-Disposition', 'attachment');
+				->with('Content-Disposition', 'attachment; filename=card.jpg');
 
 			$this->response->expects($this->once())
 				->method('setStatus')

--- a/build/integration/features/carddav.feature
+++ b/build/integration/features/carddav.feature
@@ -55,7 +55,7 @@ Feature: carddav
     Given "admin" uploads the contact "bjoern.vcf" to the addressbook "MyAddressbook"
     When Exporting the picture of contact "bjoern.vcf" from addressbook "MyAddressbook" as user "admin"
     Then The following HTTP headers should be set
-      |Content-Disposition|attachment|
+      |Content-Disposition|attachment; filename=bjoern.vcf.jpg|
       |Content-Type|image/jpeg|
       |Content-Security-Policy|default-src 'none';|
       |X-Content-Type-Options |nosniff|


### PR DESCRIPTION
Now prompts to download as ContactPhoto.png cross-browser

Signed-off-by: Jacob Neplokh <me@jacobneplokh.com>

--
Fixes #20143 
@jancborchardt @skjnldsv 

The `Content-Disposition` header now also has the file name (set to `ContactPhoto.png` — if this needs to be changed, let me know) to make sure it is downloaded with the correct file extension, and across browsers. 

