### PR TITLE
Load accessibilityoca script

### DIFF
--- a/apps/accessibility/lib/AppInfo/Application.php
+++ b/apps/accessibility/lib/AppInfo/Application.php
@@ -73,6 +73,7 @@ class Application extends App implements IBootstrap {
 				$linkToCSS = $urlGenerator->linkToRoute(self::APP_ID . '.accessibility.getCss', ['md5' => $hash]);
 				\OCP\Util::addHeader('link', ['rel' => 'stylesheet', 'href' => $linkToCSS]);
 			}
+			\OCP\Util::addScript('accessibility', 'accessibilityoca');
 		} else {
 			$userValues = ['dark'];
 


### PR DESCRIPTION
Fixes a regression by https://github.com/nextcloud/server/pull/21442 where the newly introduced accessibilityoca script was not loaded anywhere and therefore `OCA.Accessibility` and the class on the body element was not available.