### PR TITLE
Use object uploader

### DIFF
--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -27,7 +27,6 @@
 namespace OC\Files\ObjectStore;
 
 use Aws\S3\Exception\S3MultipartUploadException;
-use Aws\S3\MultipartUploader;
 use Aws\S3\ObjectUploader;
 use Aws\S3\S3Client;
 use Icewind\Streams\CallbackWrapper;
@@ -86,11 +85,14 @@ trait S3ObjectTrait {
 			$count += $read;
 		});
 
-		$uploader = new MultipartUploader($this->getConnection(), $countStream, [
-			'bucket' => $this->bucket,
-			'key' => $urn,
-			'part_size' => $this->uploadPartSize,
-		]);
+		$uploader = new ObjectUploader(
+			$this->getConnection(),
+			$this->getBucket(),
+			$urn,
+			$countStream,
+			'private',
+			['part_size' => $this->uploadPartSize]
+		);
 
 		try {
 			$uploader->upload();


### PR DESCRIPTION
I wrote this patch a while ago: https://github.com/nextcloud/server/issues/288#issuecomment-533892009. It seems to work but I stopped using S3 hence it's not well tested. 

Some people connect Nextcloud to B2 via Minio. Nextcloud uploads all files as multipart by default. That confuses B2 because they expect at least two parts if multipart is used. 

This patch uses the ObjectUploader (a wrapper provided by aws sdk) to upload objects. ObjectUploader either uses PutObject for objects < 16 MB and MultipartUploader otherwise. 

I think it's reasonable to let the aws sdk decide if PutObject or MultipartUploader should be used hence I opened a pull request (and to cleanup my stash :grinning:). 

**Update A**: The initial patch at https://github.com/nextcloud/server/issues/288#issuecomment-533892009 does not set the uploadPartSize. I think that is the actual fix for the multipart request with only one part problem. If we use a part size like 50 MB and upload a file with 25 MB it's still one part and B2 might complain :confused: 

