### PR TITLE
Fix PHPUnit deprecation warnings

### DIFF
--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -279,7 +279,7 @@ EOD;
 		$this->assertCount(0, $calendarObjects);
 	}
 
-	
+
 	public function testMultipleCalendarObjectsWithSameUID() {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 		$this->expectExceptionMessage('Calendar object with uid already exists in this calendar collection.');
@@ -441,7 +441,7 @@ EOD;
 		$expectedEventsInResult = array_map(function ($index) use ($events) {
 			return $events[$index];
 		}, $expectedEventsInResult);
-		$this->assertEquals($expectedEventsInResult, $result, '', 0.0, 10, true);
+		$this->assertEqualsCanonicalizing($expectedEventsInResult, $result);
 	}
 
 	public function testGetCalendarObjectByUID() {

--- a/apps/dav/tests/unit/Command/ListCalendarsTest.php
+++ b/apps/dav/tests/unit/Command/ListCalendarsTest.php
@@ -63,7 +63,6 @@ class ListCalendarsTest extends TestCase {
 		);
 	}
 
-	
 	public function testWithBadUser() {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -76,7 +75,7 @@ class ListCalendarsTest extends TestCase {
 		$commandTester->execute([
 			'uid' => self::USERNAME,
 		]);
-		$this->assertContains("User <" . self::USERNAME . "> in unknown", $commandTester->getDisplay());
+		$this->assertStringContainsString("User <" . self::USERNAME . "> in unknown", $commandTester->getDisplay());
 	}
 
 	public function testWithCorrectUserWithNoCalendars() {
@@ -94,7 +93,7 @@ class ListCalendarsTest extends TestCase {
 		$commandTester->execute([
 			'uid' => self::USERNAME,
 		]);
-		$this->assertContains("User <" . self::USERNAME . "> has no calendars\n", $commandTester->getDisplay());
+		$this->assertStringContainsString("User <" . self::USERNAME . "> has no calendars\n", $commandTester->getDisplay());
 	}
 
 	public function dataExecute() {
@@ -133,7 +132,7 @@ class ListCalendarsTest extends TestCase {
 		$commandTester->execute([
 			'uid' => self::USERNAME,
 		]);
-		$this->assertContains($output, $commandTester->getDisplay());
-		$this->assertNotContains(BirthdayService::BIRTHDAY_CALENDAR_URI, $commandTester->getDisplay());
+		$this->assertStringContainsString($output, $commandTester->getDisplay());
+		$this->assertStringNotContainsString(BirthdayService::BIRTHDAY_CALENDAR_URI, $commandTester->getDisplay());
 	}
 }

--- a/apps/dav/tests/unit/Command/MoveCalendarTest.php
+++ b/apps/dav/tests/unit/Command/MoveCalendarTest.php
@@ -121,7 +121,7 @@ class MoveCalendarTest extends TestCase {
 		]);
 	}
 
-	
+
 	public function testMoveWithInexistantCalendar() {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('User <user> has no calendar named <personal>. You can run occ dav:list-calendars to list calendars URIs for this user.');
@@ -148,7 +148,7 @@ class MoveCalendarTest extends TestCase {
 		]);
 	}
 
-	
+
 	public function testMoveWithExistingDestinationCalendar() {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('User <user2> already has a calendar named <personal>.');
@@ -313,7 +313,7 @@ class MoveCalendarTest extends TestCase {
 			'destinationuid' => 'user2',
 		]);
 
-		$this->assertContains("[OK] Calendar <personal> was moved from user <user> to <user2>", $commandTester->getDisplay());
+		$this->assertStringContainsString("[OK] Calendar <personal> was moved from user <user> to <user2>", $commandTester->getDisplay());
 	}
 
 	public function testMoveWithDestinationNotPartOfGroupAndForce() {
@@ -360,7 +360,7 @@ class MoveCalendarTest extends TestCase {
 			'--force' => true
 		]);
 
-		$this->assertContains("[OK] Calendar <personal> was moved from user <user> to <user2>", $commandTester->getDisplay());
+		$this->assertStringContainsString("[OK] Calendar <personal> was moved from user <user> to <user2>", $commandTester->getDisplay());
 	}
 
 	public function dataTestMoveWithCalendarAlreadySharedToDestination(): array {

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -198,7 +198,9 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			'accepted' => 0,
 			'token' => 'token',
 		];
-		$this->assertArraySubset($expected, $data);
+		foreach (array_keys($expected) as $key) {
+			$this->assertEquals($expected[$key], $data[$key], "Assert that value for key '$key' is the same");
+		}
 
 		$this->assertEquals($data['id'], $share->getId());
 		$this->assertEquals(IShare::TYPE_REMOTE, $share->getShareType());

--- a/tests/Core/Command/TwoFactorAuth/CleanupTest.php
+++ b/tests/Core/Command/TwoFactorAuth/CleanupTest.php
@@ -60,6 +60,6 @@ class CleanupTest extends TestCase {
 
 		$this->assertEquals(0, $rc);
 		$output = $this->cmd->getDisplay();
-		$this->assertContains("All user-provider associations for provider u2f have been removed", $output);
+		$this->assertStringContainsString("All user-provider associations for provider u2f have been removed", $output);
 	}
 }

--- a/tests/Core/Command/TwoFactorAuth/DisableTest.php
+++ b/tests/Core/Command/TwoFactorAuth/DisableTest.php
@@ -67,7 +67,7 @@ class DisableTest extends TestCase {
 		]);
 
 		$this->assertEquals(1, $rc);
-		$this->assertContains("Invalid UID", $this->command->getDisplay());
+		$this->assertStringContainsString("Invalid UID", $this->command->getDisplay());
 	}
 
 	public function testEnableNotSupported() {
@@ -87,7 +87,7 @@ class DisableTest extends TestCase {
 		]);
 
 		$this->assertEquals(2, $rc);
-		$this->assertContains("The provider does not support this operation", $this->command->getDisplay());
+		$this->assertStringContainsString("The provider does not support this operation", $this->command->getDisplay());
 	}
 
 	public function testEnabled() {
@@ -107,6 +107,6 @@ class DisableTest extends TestCase {
 		]);
 
 		$this->assertEquals(0, $rc);
-		$this->assertContains("Two-factor provider totp disabled for user ricky", $this->command->getDisplay());
+		$this->assertStringContainsString("Two-factor provider totp disabled for user ricky", $this->command->getDisplay());
 	}
 }

--- a/tests/Core/Command/TwoFactorAuth/EnableTest.php
+++ b/tests/Core/Command/TwoFactorAuth/EnableTest.php
@@ -67,7 +67,7 @@ class EnableTest extends TestCase {
 		]);
 
 		$this->assertEquals(1, $rc);
-		$this->assertContains("Invalid UID", $this->command->getDisplay());
+		$this->assertStringContainsString("Invalid UID", $this->command->getDisplay());
 	}
 
 	public function testEnableNotSupported() {
@@ -87,7 +87,7 @@ class EnableTest extends TestCase {
 		]);
 
 		$this->assertEquals(2, $rc);
-		$this->assertContains("The provider does not support this operation", $this->command->getDisplay());
+		$this->assertStringContainsString("The provider does not support this operation", $this->command->getDisplay());
 	}
 
 	public function testEnabled() {
@@ -107,6 +107,6 @@ class EnableTest extends TestCase {
 		]);
 
 		$this->assertEquals(0, $rc);
-		$this->assertContains("Two-factor provider totp enabled for user belle", $this->command->getDisplay());
+		$this->assertStringContainsString("Two-factor provider totp enabled for user belle", $this->command->getDisplay());
 	}
 }

--- a/tests/Core/Command/TwoFactorAuth/EnforceTest.php
+++ b/tests/Core/Command/TwoFactorAuth/EnforceTest.php
@@ -64,7 +64,7 @@ class EnforceTest extends TestCase {
 
 		$this->assertEquals(0, $rc);
 		$display = $this->command->getDisplay();
-		$this->assertContains("Two-factor authentication is enforced for all users", $display);
+		$this->assertStringContainsString("Two-factor authentication is enforced for all users", $display);
 	}
 
 	public function testEnforceForOneGroup() {
@@ -82,7 +82,7 @@ class EnforceTest extends TestCase {
 
 		$this->assertEquals(0, $rc);
 		$display = $this->command->getDisplay();
-		$this->assertContains("Two-factor authentication is enforced for members of the group(s) twofactorers", $display);
+		$this->assertStringContainsString("Two-factor authentication is enforced for members of the group(s) twofactorers", $display);
 	}
 
 	public function testEnforceForAllExceptOneGroup() {
@@ -100,7 +100,7 @@ class EnforceTest extends TestCase {
 
 		$this->assertEquals(0, $rc);
 		$display = $this->command->getDisplay();
-		$this->assertContains("Two-factor authentication is enforced for all users, except members of yoloers", $display);
+		$this->assertStringContainsString("Two-factor authentication is enforced for all users, except members of yoloers", $display);
 	}
 
 	public function testDisableEnforced() {
@@ -117,7 +117,7 @@ class EnforceTest extends TestCase {
 
 		$this->assertEquals(0, $rc);
 		$display = $this->command->getDisplay();
-		$this->assertContains("Two-factor authentication is not enforced", $display);
+		$this->assertStringContainsString("Two-factor authentication is not enforced", $display);
 	}
 
 	public function testCurrentStateEnabled() {
@@ -129,7 +129,7 @@ class EnforceTest extends TestCase {
 
 		$this->assertEquals(0, $rc);
 		$display = $this->command->getDisplay();
-		$this->assertContains("Two-factor authentication is enforced for all users", $display);
+		$this->assertStringContainsString("Two-factor authentication is enforced for all users", $display);
 	}
 
 	public function testCurrentStateDisabled() {
@@ -141,6 +141,6 @@ class EnforceTest extends TestCase {
 
 		$this->assertEquals(0, $rc);
 		$display = $this->command->getDisplay();
-		$this->assertContains("Two-factor authentication is not enforced", $display);
+		$this->assertStringContainsString("Two-factor authentication is not enforced", $display);
 	}
 }

--- a/tests/Core/Command/TwoFactorAuth/StateTest.php
+++ b/tests/Core/Command/TwoFactorAuth/StateTest.php
@@ -61,7 +61,7 @@ class StateTest extends TestCase {
 		]);
 
 		$output = $this->cmd->getDisplay();
-		$this->assertContains("Invalid UID", $output);
+		$this->assertStringContainsString("Invalid UID", $output);
 	}
 
 	public function testStateNoProvidersActive() {
@@ -84,7 +84,7 @@ class StateTest extends TestCase {
 		]);
 
 		$output = $this->cmd->getDisplay();
-		$this->assertContains("Two-factor authentication is not enabled for user eldora", $output);
+		$this->assertStringContainsString("Two-factor authentication is not enabled for user eldora", $output);
 	}
 
 	public function testStateOneProviderActive() {
@@ -107,6 +107,6 @@ class StateTest extends TestCase {
 		]);
 
 		$output = $this->cmd->getDisplay();
-		$this->assertContains("Two-factor authentication is enabled for user mohamed", $output);
+		$this->assertStringContainsString("Two-factor authentication is enabled for user mohamed", $output);
 	}
 }

--- a/tests/lib/AppFramework/Http/DownloadResponseTest.php
+++ b/tests/lib/AppFramework/Http/DownloadResponseTest.php
@@ -45,7 +45,7 @@ class DownloadResponseTest extends \Test\TestCase {
 	public function testHeaders() {
 		$headers = $this->response->getHeaders();
 
-		$this->assertContains('attachment; filename="file"', $headers['Content-Disposition']);
-		$this->assertContains('content', $headers['Content-Type']);
+		$this->assertStringContainsString('attachment; filename="file"', $headers['Content-Disposition']);
+		$this->assertStringContainsString('content', $headers['Content-Type']);
 	}
 }

--- a/tests/lib/ConfigTest.php
+++ b/tests/lib/ConfigTest.php
@@ -71,9 +71,7 @@ class ConfigTest extends TestCase {
 
 	public function testSetValue() {
 		$this->config->setValue('foo', 'moo');
-		$expectedConfig = $this->initialConfig;
-		$expectedConfig['foo'] = 'moo';
-		$this->assertAttributeEquals($expectedConfig, 'cache', $this->config);
+		$this->assertSame('moo', $this->config->getValue('foo'));
 
 		$content = file_get_contents($this->configFile);
 		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
@@ -82,9 +80,8 @@ class ConfigTest extends TestCase {
 
 		$this->config->setValue('bar', 'red');
 		$this->config->setValue('apps', ['files', 'gallery']);
-		$expectedConfig['bar'] = 'red';
-		$expectedConfig['apps'] = ['files', 'gallery'];
-		$this->assertAttributeEquals($expectedConfig, 'cache', $this->config);
+		$this->assertSame('red', $this->config->getValue('bar'));
+		$this->assertSame(['files', 'gallery'], $this->config->getValue('apps'));
 
 		$content = file_get_contents($this->configFile);
 
@@ -105,7 +102,8 @@ class ConfigTest extends TestCase {
 			'not_exists'	=> null,
 		]);
 
-		$this->assertAttributeEquals($this->initialConfig, 'cache', $this->config);
+		$this->assertSame('bar', $this->config->getValue('foo'));
+		$this->assertSame(null, $this->config->getValue('not_exists'));
 		$content = file_get_contents($this->configFile);
 		$this->assertEquals(self::TESTCONTENT, $content);
 
@@ -113,10 +111,8 @@ class ConfigTest extends TestCase {
 			'foo'			=> 'moo',
 			'alcohol_free'	=> null,
 		]);
-		$expectedConfig = $this->initialConfig;
-		$expectedConfig['foo'] = 'moo';
-		unset($expectedConfig['alcohol_free']);
-		$this->assertAttributeEquals($expectedConfig, 'cache', $this->config);
+		$this->assertSame('moo', $this->config->getValue('foo'));
+		$this->assertSame(null, $this->config->getValue('not_exists'));
 
 		$content = file_get_contents($this->configFile);
 		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
@@ -126,9 +122,7 @@ class ConfigTest extends TestCase {
 
 	public function testDeleteKey() {
 		$this->config->deleteKey('foo');
-		$expectedConfig = $this->initialConfig;
-		unset($expectedConfig['foo']);
-		$this->assertAttributeEquals($expectedConfig, 'cache', $this->config);
+		$this->assertSame('this_was_clearly_not_set_before', $this->config->getValue('foo', 'this_was_clearly_not_set_before'));
 		$content = file_get_contents($this->configFile);
 
 		$expected = "<?php\n\$CONFIG = array (\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .

--- a/tests/lib/DB/DBSchemaTest.php
+++ b/tests/lib/DB/DBSchemaTest.php
@@ -83,8 +83,8 @@ class DBSchemaTest extends TestCase {
 		$outfile = $this->tempManager->getTemporaryFile();
 		OC_DB::getDbStructure($outfile);
 		$content = file_get_contents($outfile);
-		$this->assertContains($this->table1, $content);
-		$this->assertContains($this->table2, $content);
+		$this->assertStringContainsString($this->table1, $content);
+		$this->assertStringContainsString($this->table2, $content);
 	}
 
 	public function doTestSchemaRemoving() {

--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -329,7 +329,7 @@ class FactoryTest extends TestCase {
 			->with($app)
 			->willReturn(\OC::$SERVERROOT . '/tests/data/l10n/');
 
-		$this->assertEquals(['cs', 'de', 'en', 'ru'], $factory->findAvailableLanguages($app), '', 0.0, 10, true);
+		$this->assertEqualsCanonicalizing(['cs', 'de', 'en', 'ru'], $factory->findAvailableLanguages($app));
 	}
 
 	public function dataLanguageExists() {
@@ -360,7 +360,7 @@ class FactoryTest extends TestCase {
 			->with('theme')
 			->willReturn('abc');
 
-		$this->assertEquals(['en', 'zz'], $factory->findAvailableLanguages($app), '', 0.0, 10, true);
+		$this->assertEqualsCanonicalizing(['en', 'zz'], $factory->findAvailableLanguages($app));
 	}
 
 	/**

--- a/tests/lib/Template/CSSResourceLocatorTest.php
+++ b/tests/lib/Template/CSSResourceLocatorTest.php
@@ -107,16 +107,6 @@ class CSSResourceLocatorTest extends \Test\TestCase {
 		return sha1(uniqid(mt_rand(), true));
 	}
 
-	public function testConstructor() {
-		$locator = $this->cssResourceLocator();
-		$this->assertAttributeEquals('theme', 'theme', $locator);
-		$this->assertAttributeEquals('core', 'serverroot', $locator);
-		$this->assertAttributeEquals(['core'=>'map','3rd'=>'party'], 'mapping', $locator);
-		$this->assertAttributeEquals('3rd', 'thirdpartyroot', $locator);
-		$this->assertAttributeEquals('map', 'webroot', $locator);
-		$this->assertAttributeEquals([], 'resources', $locator);
-	}
-
 	public function testFindWithAppPathSymlink() {
 		// First create new apps path, and a symlink to it
 		$apps_dirname = $this->randomString();

--- a/tests/lib/Template/JSResourceLocatorTest.php
+++ b/tests/lib/Template/JSResourceLocatorTest.php
@@ -86,17 +86,6 @@ class JSResourceLocatorTest extends \Test\TestCase {
 		return sha1(uniqid(mt_rand(), true));
 	}
 
-
-	public function testConstructor() {
-		$locator = $this->jsResourceLocator();
-		$this->assertAttributeEquals('theme', 'theme', $locator);
-		$this->assertAttributeEquals('core', 'serverroot', $locator);
-		$this->assertAttributeEquals(['core'=>'map','3rd'=>'party'], 'mapping', $locator);
-		$this->assertAttributeEquals('3rd', 'thirdpartyroot', $locator);
-		$this->assertAttributeEquals('map', 'webroot', $locator);
-		$this->assertAttributeEquals([], 'resources', $locator);
-	}
-
 	public function testFindWithAppPathSymlink() {
 		// First create new apps path, and a symlink to it
 		$apps_dirname = $this->randomString();

--- a/tests/lib/Template/ResourceLocatorTest.php
+++ b/tests/lib/Template/ResourceLocatorTest.php
@@ -33,17 +33,6 @@ class ResourceLocatorTest extends \Test\TestCase {
 			'', true, true, true, []);
 	}
 
-	public function testConstructor() {
-		$locator = $this->getResourceLocator('theme',
-			['core'=>'map'], ['3rd'=>'party'], ['foo'=>'bar']);
-		$this->assertAttributeEquals('theme', 'theme', $locator);
-		$this->assertAttributeEquals('core', 'serverroot', $locator);
-		$this->assertAttributeEquals(['core'=>'map','3rd'=>'party'], 'mapping', $locator);
-		$this->assertAttributeEquals('3rd', 'thirdpartyroot', $locator);
-		$this->assertAttributeEquals('map', 'webroot', $locator);
-		$this->assertAttributeEquals([], 'resources', $locator);
-	}
-
 	public function testFind() {
 		$locator = $this->getResourceLocator('theme',
 			['core' => 'map'], ['3rd' => 'party'], ['foo' => 'bar']);


### PR DESCRIPTION
* nodb had 60 warnings and sqlite had 8 warnings before this PR
* avoids to need to work on them when we want to upgrade to PHPUnit 9 in the future