### PR TITLE
Fix risky test in twofactor_backupcodes

### DIFF
--- a/apps/twofactor_backupcodes/tests/Db/BackupCodeMapperTest.php
+++ b/apps/twofactor_backupcodes/tests/Db/BackupCodeMapperTest.php
@@ -117,7 +117,12 @@ class BackupCodeMapperTest extends TestCase {
 		$code->setUserId($this->testUID);
 		$code->setCode('2|$argon2i$v=19$m=1024,t=2,p=2$MjJWUjRFWndtMm5BWGxOag$BusVxLeFyiLLWtaVvX/JRFBiPdZcjRrzpQ/rAhn6vqY');
 		$code->setUsed(1);
+		$user = $this->getMockBuilder(IUser::class)->getMock();
+		$user->expects($this->any())
+			->method('getUID')
+			->willReturn($this->testUID);
 
 		$this->mapper->insert($code);
+		$this->assertCount(1, $this->mapper->getBackupCodes($user));
 	}
 }


### PR DESCRIPTION
Before it said:

```
There was 1 risky test:

1) OCA\TwoFactorBackupCodes\Tests\Db\BackupCodeMapperTest::testInsertArgonEncryptedCodes
This test did not perform any assertions

/drone/src/apps/twofactor_backupcodes/tests/Db/BackupCodeMapperTest.php:115
```