### PR TITLE
Move NotFoundResponse to a proper TemplateResponse

### DIFF
--- a/lib/private/AppFramework/Middleware/AdditionalScriptsMiddleware.php
+++ b/lib/private/AppFramework/Middleware/AdditionalScriptsMiddleware.php
@@ -53,16 +53,15 @@ class AdditionalScriptsMiddleware extends Middleware {
 	}
 
 	public function afterController($controller, $methodName, Response $response): Response {
-		/*
-		 * There is no need to emit these signals on a public share page
-		 * There is a separate event for that already
-		 */
-		if ($controller instanceof PublicShareController) {
-			return $response;
-		}
-
 		if ($response instanceof TemplateResponse) {
-			$this->legacyDispatcher->dispatch(TemplateResponse::EVENT_LOAD_ADDITIONAL_SCRIPTS, new GenericEvent());
+			if (!$controller instanceof PublicShareController) {
+				/*
+				 * The old event was not dispatched on the public share controller as there was
+				 * OCA\Files_Sharing::loadAdditionalScripts for that. This is kept for compatibility reasons
+				 * only for the old event as this is now also included in BeforeTemplateRenderedEvent
+				 */
+				$this->legacyDispatcher->dispatch(TemplateResponse::EVENT_LOAD_ADDITIONAL_SCRIPTS, new GenericEvent());
+			}
 
 			if (!($response instanceof StandaloneTemplateResponse) && $this->userSession->isLoggedIn()) {
 				$this->legacyDispatcher->dispatch(TemplateResponse::EVENT_LOAD_ADDITIONAL_SCRIPTS_LOGGEDIN, new GenericEvent());

--- a/lib/public/AppFramework/Http/NotFoundResponse.php
+++ b/lib/public/AppFramework/Http/NotFoundResponse.php
@@ -24,30 +24,19 @@
 
 namespace OCP\AppFramework\Http;
 
-use OCP\Template;
-
 /**
  * A generic 404 response showing an 404 error page as well to the end-user
  * @since 8.1.0
  */
-class NotFoundResponse extends Response {
+class NotFoundResponse extends TemplateResponse {
 
 	/**
 	 * @since 8.1.0
 	 */
 	public function __construct() {
-		parent::__construct();
+		parent::__construct('core', '404', [], 'guest');
 
 		$this->setContentSecurityPolicy(new ContentSecurityPolicy());
 		$this->setStatus(404);
-	}
-
-	/**
-	 * @return string
-	 * @since 8.1.0
-	 */
-	public function render() {
-		$template = new Template('core', '404', 'guest');
-		return $template->fetchPage();
 	}
 }


### PR DESCRIPTION
Make sure that BeforeTemplateRenderedEvent is properly emitted on NotFoundResponses.

For https://github.com/nextcloud/server/pull/21818