### PR TITLE
Add setup checks for php default charset and output buffering.

### DIFF
--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -52,4 +52,6 @@ return array(
     'OCA\\Settings\\Settings\\Personal\\Security\\TwoFactor' => $baseDir . '/../lib/Settings/Personal/Security/TwoFactor.php',
     'OCA\\Settings\\Settings\\Personal\\Security\\WebAuthn' => $baseDir . '/../lib/Settings/Personal/Security/WebAuthn.php',
     'OCA\\Settings\\Settings\\Personal\\ServerDevNotice' => $baseDir . '/../lib/Settings/Personal/ServerDevNotice.php',
+    'OCA\\Settings\\SetupChecks\\PhpDefaultCharset' => $baseDir . '/../lib/SetupChecks/PhpDefaultCharset.php',
+    'OCA\\Settings\\SetupChecks\\PhpOutputBuffering' => $baseDir . '/../lib/SetupChecks/PhpOutputBuffering.php',
 );

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -67,6 +67,8 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\Settings\\Personal\\Security\\TwoFactor' => __DIR__ . '/..' . '/../lib/Settings/Personal/Security/TwoFactor.php',
         'OCA\\Settings\\Settings\\Personal\\Security\\WebAuthn' => __DIR__ . '/..' . '/../lib/Settings/Personal/Security/WebAuthn.php',
         'OCA\\Settings\\Settings\\Personal\\ServerDevNotice' => __DIR__ . '/..' . '/../lib/Settings/Personal/ServerDevNotice.php',
+        'OCA\\Settings\\SetupChecks\\PhpDefaultCharset' => __DIR__ . '/..' . '/../lib/SetupChecks/PhpDefaultCharset.php',
+        'OCA\\Settings\\SetupChecks\\PhpOutputBuffering' => __DIR__ . '/..' . '/../lib/SetupChecks/PhpOutputBuffering.php',
     );
 
     public static function getInitializer(ClassLoader $loader)

--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -53,6 +53,8 @@ use OC\DB\SchemaWrapper;
 use OC\IntegrityCheck\Checker;
 use OC\Lock\NoopLockingProvider;
 use OC\MemoryInfo;
+use OCA\Settings\SetupChecks\PhpDefaultCharset;
+use OCA\Settings\SetupChecks\PhpOutputBuffering;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\DataResponse;
@@ -683,6 +685,8 @@ Raw output
 	 * @return DataResponse
 	 */
 	public function check() {
+		$phpDefaultCharset = new PhpDefaultCharset();
+		$phpOutputBuffering = new PhpOutputBuffering();
 		return new DataResponse(
 			[
 				'isGetenvServerWorking' => !empty(getenv('PATH')),
@@ -723,6 +727,8 @@ Raw output
 				'isMysqlUsedWithoutUTF8MB4' => $this->isMysqlUsedWithoutUTF8MB4(),
 				'isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed' => $this->isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed(),
 				'reverseProxyGeneratedURL' => $this->urlGenerator->getAbsoluteURL('index.php'),
+				PhpDefaultCharset::class => ['pass' => $phpDefaultCharset->run(), 'description' => $phpDefaultCharset->description(), 'severity' => $phpDefaultCharset->severity()],
+				PhpOutputBuffering::class => ['pass' => $phpOutputBuffering->run(), 'description' => $phpOutputBuffering->description(), 'severity' => $phpOutputBuffering->severity()],
 			]
 		);
 	}

--- a/apps/settings/lib/SetupChecks/PhpDefaultCharset.php
+++ b/apps/settings/lib/SetupChecks/PhpDefaultCharset.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @author Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Settings\SetupChecks;
+
+class PhpDefaultCharset {
+	public function description(): string {
+		return 'PHP configuration option default_charset should be UTF-8';
+	}
+
+	public function severity(): string {
+		return 'warning';
+	}
+
+	public function run(): bool {
+		return strtoupper(trim(ini_get('default_charset'))) === 'UTF-8';
+	}
+}

--- a/apps/settings/lib/SetupChecks/PhpOutputBuffering.php
+++ b/apps/settings/lib/SetupChecks/PhpOutputBuffering.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @author Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Settings\SetupChecks;
+
+class PhpOutputBuffering {
+	public function description(): string {
+		return 'PHP configuration option output_buffering must be disabled';
+	}
+
+	public function severity(): string {
+		return 'error';
+	}
+
+	public function run(): bool {
+		$value = trim(ini_get('output_buffering'));
+		return $value === '' || $value === '0';
+	}
+}

--- a/apps/settings/tests/Controller/CheckSetupControllerTest.php
+++ b/apps/settings/tests/Controller/CheckSetupControllerTest.php
@@ -593,6 +593,8 @@ class CheckSetupControllerTest extends TestCase {
 				'isMysqlUsedWithoutUTF8MB4' => false,
 				'isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed' => true,
 				'reverseProxyGeneratedURL' => 'https://server/index.php',
+				'OCA\Settings\SetupChecks\PhpDefaultCharset' => ['pass' => true, 'description' => 'PHP configuration option default_charset should be UTF-8', 'severity' => 'warning'],
+				'OCA\Settings\SetupChecks\PhpOutputBuffering' => ['pass' => true, 'description' => 'PHP configuration option output_buffering must be disabled', 'severity' => 'error'],
 			]
 		);
 		$this->assertEquals($expected, $this->checkSetupController->check());

--- a/apps/settings/tests/SetupChecks/PhpDefaultCharsetTest.php
+++ b/apps/settings/tests/SetupChecks/PhpDefaultCharsetTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @author Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Settings\Tests;
+
+use OCA\Settings\SetupChecks\PhpDefaultCharset;
+use Test\TestCase;
+
+class PhpDefaultCharsetTest extends TestCase {
+	public function testPass(): void {
+		$check = new PhpDefaultCharset();
+		$this->assertTrue($check->run());
+	}
+
+	public function testFail(): void {
+		ini_set('default_charset', 'ISO-8859-15');
+
+		$check = new PhpDefaultCharset();
+		$this->assertFalse($check->run());
+
+		ini_restore('default_charset');
+	}
+}

--- a/apps/settings/tests/SetupChecks/PhpOutputBufferingTest.php
+++ b/apps/settings/tests/SetupChecks/PhpOutputBufferingTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @author Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Settings\Tests;
+
+use OCA\Settings\SetupChecks\PhpOutputBuffering;
+use Test\TestCase;
+
+class PhpOutputBufferingTest extends TestCase {
+	/*
+	 * output_buffer is PHP_INI_PERDIR and cannot changed at runtime.
+	 * Run this test with -d output_buffering=1 to validate the fail case.
+	 */
+
+	public function testPass(): void {
+		$check = new PhpOutputBuffering();
+		$this->assertTrue($check->run());
+	}
+}

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -488,6 +488,9 @@
 						})
 					}
 
+					OC.SetupChecks.addGenericSetupCheck(data, 'OCA\\Settings\\SetupChecks\\PhpDefaultCharset', messages)
+					OC.SetupChecks.addGenericSetupCheck(data, 'OCA\\Settings\\SetupChecks\\PhpOutputBuffering', messages)
+
 				} else {
 					messages.push({
 						msg: t('core', 'Error occurred while checking server setup'),
@@ -503,6 +506,24 @@
 				allowAuthErrors: true
 			}).then(afterCall, afterCall);
 			return deferred.promise();
+		},
+
+		addGenericSetupCheck: function(data, check, messages) {
+			const setupCheck = data[check] || { pass: true, description: '', severity: 'info'}
+
+			let type = OC.SetupChecks.MESSAGE_TYPE_INFO
+			if (setupCheck.severity === 'warning') {
+				type = OC.SetupChecks.MESSAGE_TYPE_WARNING
+			} else if (setupCheck.severity === 'error') {
+				type = OC.SetupChecks.MESSAGE_TYPE_ERROR
+			}
+
+			if (!setupCheck.pass) {
+				messages.push({
+					msg: setupCheck.description,
+					type: type,
+				})
+			}
 		},
 
 		/**

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -509,9 +509,9 @@
 		},
 
 		addGenericSetupCheck: function(data, check, messages) {
-			const setupCheck = data[check] || { pass: true, description: '', severity: 'info'}
+			var setupCheck = data[check] || { pass: true, description: '', severity: 'info'}
 
-			let type = OC.SetupChecks.MESSAGE_TYPE_INFO
+			var type = OC.SetupChecks.MESSAGE_TYPE_INFO
 			if (setupCheck.severity === 'warning') {
 				type = OC.SetupChecks.MESSAGE_TYPE_WARNING
 			} else if (setupCheck.severity === 'error') {


### PR DESCRIPTION
To remove `.user.ini` we need a setup check to inform the user about a broken configuration. Especially output buffering is critical as it might break downloading of files and cannot be changed with `ini_set`. 
