### PR TITLE
Fix height to big for iPhone when using many apps

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -78,7 +78,7 @@
 
 @mixin header-menu-height() {
 	min-height: calc(44px * 1.5); // show at least 1.5 entries
-	max-height: calc(100vh - #{$header-height} * 2);
+	max-height: calc(100vh - #{$header-height} * 4);
 }
 
 #header {


### PR DESCRIPTION
Same story as https://github.com/nextcloud/server/pull/10276
I'm testing on iPhone without home button. These devices now have an even higher bottom bar.