### PR TITLE
Ensured large image is unloaded from memory when generating previews

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -194,7 +194,7 @@ class Generator {
 
 		// Free memory being used by the embedded image resource.  Without this the image is kept in memory indefinitely.
 		// Garbage Collection does NOT free this memory.  We have to do it ourselves.
-		if ($maxPreviewImage instanceof IImage) {
+		if ($maxPreviewImage instanceof \OC_Image) {
 			$maxPreviewImage->destroy();
 		}
 

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -192,6 +192,12 @@ class Generator {
 			}
 		}
 
+		// Free memory being used by the embedded image resource.  Without this the image is kept in memory indefinitely.
+		// Garbage Collection does NOT free this memory.  We have to do it ourselves.
+		if ($maxPreviewImage instanceof IImage) {
+			$maxPreviewImage->destroy();
+		}
+
 		return $preview;
 	}
 

--- a/tests/lib/Preview/GeneratorTest.php
+++ b/tests/lib/Preview/GeneratorTest.php
@@ -31,7 +31,6 @@ use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\IConfig;
-use OCP\IImage;
 use OCP\IPreview;
 use OCP\Preview\IProviderV2;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -183,7 +182,7 @@ class GeneratorTest extends \Test\TestCase {
 				$this->fail('Unexpected provider requested');
 			});
 
-		$image = $this->createMock(IImage::class);
+		$image = $this->createMock(\OC_Image::class);
 		$image->method('width')->willReturn(2048);
 		$image->method('height')->willReturn(2048);
 		$image->method('valid')->willReturn(true);
@@ -318,7 +317,7 @@ class GeneratorTest extends \Test\TestCase {
 	}
 
 	private function getMockImage($width, $height, $data = null) {
-		$image = $this->createMock(IImage::class);
+		$image = $this->createMock(\OC_Image::class);
 		$image->method('height')->willReturn($width);
 		$image->method('width')->willReturn($height);
 		$image->method('valid')->willReturn(true);


### PR DESCRIPTION
PR to resolve #21995 
likely also resolves   https://github.com/rullzer/previewgenerator/issues/108
incorporates suggestion by @kesselb to use the destroy method of IImage instead of destroying the resource directly.

This change should be very low risk as it's destroying an image object that is only sometimes created.  It's created if there isn't a cached version of the preview and it is independent of the newly generated preview image.

It has been tested on 19.0.1

