### PR TITLE
Correctly remove usergroup shares on removing group members

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -61,6 +61,7 @@
  *
  */
 
+use OCP\Group\Events\UserRemovedEvent;
 use OCP\ILogger;
 use OCP\Share;
 use OC\Encryption\HookManager;
@@ -897,8 +898,12 @@ class OC {
 	public static function registerShareHooks() {
 		if (\OC::$server->getSystemConfig()->getValue('installed')) {
 			OC_Hook::connect('OC_User', 'post_deleteUser', Hooks::class, 'post_deleteUser');
-			OC_Hook::connect('OC_User', 'post_removeFromGroup', Hooks::class, 'post_removeFromGroup');
+			OC_Hook::connect('OC_User', 'post_removeFromGroup', Hooks::class, 'post_removeFromGroupLDAP');
 			OC_Hook::connect('OC_User', 'post_deleteGroup', Hooks::class, 'post_deleteGroup');
+
+			/** @var \OCP\EventDispatcher\IEventDispatcher $dispatcher */
+			$dispatcher = \OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class);
+			$dispatcher->addServiceListener(UserRemovedEvent::class, \OC\Share20\UserRemovedListener::class);
 		}
 	}
 

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1307,6 +1307,7 @@ return array(
     'OC\\Share20\\ProviderFactory' => $baseDir . '/lib/private/Share20/ProviderFactory.php',
     'OC\\Share20\\Share' => $baseDir . '/lib/private/Share20/Share.php',
     'OC\\Share20\\ShareHelper' => $baseDir . '/lib/private/Share20/ShareHelper.php',
+    'OC\\Share20\\UserRemovedListener' => $baseDir . '/lib/private/Share20/UserRemovedListener.php',
     'OC\\Share\\Constants' => $baseDir . '/lib/private/Share/Constants.php',
     'OC\\Share\\Helper' => $baseDir . '/lib/private/Share/Helper.php',
     'OC\\Share\\SearchResultSorter' => $baseDir . '/lib/private/Share/SearchResultSorter.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1336,6 +1336,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Share20\\ProviderFactory' => __DIR__ . '/../../..' . '/lib/private/Share20/ProviderFactory.php',
         'OC\\Share20\\Share' => __DIR__ . '/../../..' . '/lib/private/Share20/Share.php',
         'OC\\Share20\\ShareHelper' => __DIR__ . '/../../..' . '/lib/private/Share20/ShareHelper.php',
+        'OC\\Share20\\UserRemovedListener' => __DIR__ . '/../../..' . '/lib/private/Share20/UserRemovedListener.php',
         'OC\\Share\\Constants' => __DIR__ . '/../../..' . '/lib/private/Share/Constants.php',
         'OC\\Share\\Helper' => __DIR__ . '/../../..' . '/lib/private/Share/Helper.php',
         'OC\\Share\\SearchResultSorter' => __DIR__ . '/../../..' . '/lib/private/Share/SearchResultSorter.php',

--- a/lib/private/Share20/Hooks.php
+++ b/lib/private/Share20/Hooks.php
@@ -31,7 +31,7 @@ class Hooks {
 		\OC::$server->getShareManager()->groupDeleted($arguments['gid']);
 	}
 
-	public static function post_removeFromGroup($arguments) {
+	public static function post_removeFromGroupLDAP($arguments) {
 		\OC::$server->getShareManager()->userDeletedFromGroup($arguments['uid'], $arguments['gid']);
 	}
 }

--- a/lib/private/Share20/UserRemovedListener.php
+++ b/lib/private/Share20/UserRemovedListener.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Share20;
+
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Group\Events\UserRemovedEvent;
+use OCP\Share\IManager;
+
+class UserRemovedListener implements IEventListener {
+
+	/** @var IManager */
+	protected $shareManager;
+
+	public function __construct(IManager $shareManager) {
+		$this->shareManager = $shareManager;
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof UserRemovedEvent) {
+			return;
+		}
+
+		$this->shareManager->userDeletedFromGroup($event->getUser()->getUID(), $event->getGroup()->getGID());
+	}
+}


### PR DESCRIPTION
### Steps

1. As admin create a group and assign userA to the group
2. Share a file to the group
3. As userA edit the file
4. As admin remove userA from the group
5. Check share table (there is still a usergroup share entry for userA before this PR)
6. As admin modify the file
7. As userA check your activity (there is a new entry before this PR)

There seems to be inconsistency for LDAP and other group backends. The listened old hook `'OC_User', 'post_removeFromGroup'` is not emitted in the normal user/group backend since 16 at least?