### PR TITLE
Password policy validation fail for new users

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -315,9 +315,8 @@ class UsersController extends AUserData {
  			$passwordEvent = new GenerateSecurePasswordEvent();
 			$this->eventDispatcher->dispatchTyped($passwordEvent);
 			$passwordEvent->getPassword();
-			if(isset($passwordEvent)){
-				$password .= $passwordEvent->getPassword();
-			} else {
+			$password = $passwordEvent->getPassword();
+			if($password === null){
 				// Fallback: ensure to pass password_policy in any case
 				$password = $this->secureRandom->generate(10);
 				$password .= $this->secureRandom->generate(1, ISecureRandom::CHAR_UPPER);


### PR DESCRIPTION
Password policy validation fail for new users #22014

1. Create a new GenerateSecurePasswordEvent
2. Dispatch the event
3. If the passwordEvent is null use fallback

Other option for fallback:
`/apps/provisioning_api/lib/Controller/UsersController.php` (around line324)
```
...
$passwordEvent = new GenerateSecurePasswordEvent();
$this->eventDispatcher->dispatchTyped($passwordEvent);
$password .= $passwordEvent->getPassword() ?? $this->secureRandom->generate(21);
...
```
