### PR TITLE
parse_url returns null in case a parameter is not found

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -158,7 +158,7 @@ class Client implements IClient {
 		}
 
 		$host = parse_url($uri, PHP_URL_HOST);
-		if ($host === false) {
+		if ($host === false || $host === null) {
 			$this->logger->warning("Could not detect any host in $uri");
 			throw new LocalServerException('Could not detect any host');
 		}


### PR DESCRIPTION
Signed-off-by: Joas Schilling <coding@schilljs.com>