### PR TITLE
[stable19] Properly fetch translation for remote wipe confirmation dialog

### DIFF
--- a/apps/settings/src/components/AuthTokenSection.vue
+++ b/apps/settings/src/components/AuthTokenSection.vue
@@ -44,8 +44,8 @@ import AuthTokenSetupDialogue from './AuthTokenSetupDialogue'
 const confirm = () => {
 	return new Promise(resolve => {
 		OC.dialogs.confirm(
-			t('core', 'Do you really want to wipe your data from this device?'),
-			t('core', 'Confirm wipe'),
+			t('settings', 'Do you really want to wipe your data from this device?'),
+			t('settings', 'Confirm wipe'),
 			resolve,
 			true
 		)


### PR DESCRIPTION
Backport of https://github.com/nextcloud/server/pull/21950