### PR TITLE
When no user is logged in null is used

### DIFF
--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -52,7 +52,7 @@ use OCP\Share\IShare;
 class Manager {
 	public const STORAGE = '\OCA\Files_Sharing\External\Storage';
 
-	/** @var string */
+	/** @var string|null */
 	private $uid;
 
 	/** @var IDBConnection */
@@ -98,7 +98,7 @@ class Manager {
 								ICloudFederationFactory $cloudFederationFactory,
 								IGroupManager $groupManager,
 								IUserManager $userManager,
-								string $uid,
+								?string $uid,
 								IEventDispatcher $eventDispatcher) {
 		$this->connection = $connection;
 		$this->mountManager = $mountManager;


### PR DESCRIPTION
Regression from https://github.com/nextcloud/server/commit/0763a173321488acaadceb1eb0ecf1ec8691bf21#diff-77be6012596d2dbe01c8a4147c5949b5L123

https://github.com/nextcloud/server/blob/0763a173321488acaadceb1eb0ecf1ec8691bf21/apps/files_sharing/lib/AppInfo/Application.php#L85 clearly inserts null in case of no user, so string only doesnt work.