### PR TITLE
reset the cookie internally in new API when abandoning paged results op

### DIFF
--- a/apps/user_ldap/lib/PagedResults/Php73.php
+++ b/apps/user_ldap/lib/PagedResults/Php73.php
@@ -82,6 +82,12 @@ class Php73 implements IAdapter {
 		return $this->linkData[$linkId]['serverControls'][LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'] ?? '';
 	}
 
+	private function resetCookie(int $linkId): void {
+		if (isset($this->linkData[$linkId]['serverControls'][LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'])) {
+			$this->linkData[$linkId]['serverControls'][LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'] = '';
+		}
+	}
+
 	public function getRequestCallFunc(): ?string {
 		return null;
 	}
@@ -94,6 +100,10 @@ class Php73 implements IAdapter {
 		$this->linkData[$linkId]['requestArgs'] = [];
 		$this->linkData[$linkId]['requestArgs']['pageSize'] = $pageSize;
 		$this->linkData[$linkId]['requestArgs']['isCritical'] = $isCritical;
+
+		if ($pageSize === 0) {
+			$this->resetCookie($linkId);
+		}
 	}
 
 	public function getRequestCallArgs($link): array {
@@ -153,7 +163,7 @@ class Php73 implements IAdapter {
 			'oid' => LDAP_CONTROL_PAGEDRESULTS,
 			'value' => [
 				'size' => $this->linkData[$linkId]['requestArgs']['pageSize'],
-				'cookie' => $this->linkData[$linkId]['serverControls'][LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'] ?? ''
+				'cookie' => $this->linkData[$linkId]['serverControls'][LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'] ?? '',
 			]
 		]];
 


### PR DESCRIPTION
Fixes #21892 

Reproduction steps:
1. Have Active Directory configured (not OpenLDAP, Samba4 or others), with a small Cache TTL
2. Have all LDAP users mapped
3. Delete a known user
4. run `php occ ldap:check-user USERID`

Before the fix, an LDAP Error ("LDAP error Critical extension is unavailable (12) after calling ldap_search" ) was logged.

(Note: there are other ways to get this error, the described steps are the easiest and most reliable way to trigger it).