### PR TITLE
contactsmanager shall limit number of results early

### DIFF
--- a/lib/private/Contacts/ContactsMenu/ContactsStore.php
+++ b/lib/private/Contacts/ContactsMenu/ContactsStore.php
@@ -73,11 +73,23 @@ class ContactsStore implements IContactsStore {
 	 * @param string|null $filter
 	 * @return IEntry[]
 	 */
-	public function getContacts(IUser $user, $filter) {
-		$allContacts = $this->contactsManager->search($filter ?: '', [
-			'FN',
-			'EMAIL'
-		]);
+	public function getContacts(IUser $user, $filter, ?int $limit = null, ?int $offset = null) {
+		$options = [];
+		if ($limit !== null) {
+			$options['limit'] = $limit;
+		}
+		if ($offset !== null) {
+			$options['offset'] = $offset;
+		}
+
+		$allContacts = $this->contactsManager->search(
+			$filter ?: '',
+			[
+				'FN',
+				'EMAIL'
+			],
+			$options
+		);
 
 		$entries = array_map(function (array $contact) {
 			return $this->contactArrayToEntry($contact);
@@ -122,7 +134,7 @@ class ContactsStore implements IContactsStore {
 		if ($excludedGroups) {
 			$excludedGroups = $this->config->getAppValue('core', 'shareapi_exclude_groups_list', '');
 			$decodedExcludeGroups = json_decode($excludedGroups, true);
-			$excludeGroupsList = ($decodedExcludeGroups !== null) ? $decodedExcludeGroups :  [];
+			$excludeGroupsList = ($decodedExcludeGroups !== null) ? $decodedExcludeGroups : [];
 
 			if (count(array_intersect($excludeGroupsList, $selfGroups)) !== 0) {
 				// a group of the current user is excluded -> filter all local users

--- a/lib/private/Contacts/ContactsMenu/Manager.php
+++ b/lib/private/Contacts/ContactsMenu/Manager.php
@@ -66,7 +66,7 @@ class Manager {
 		$minSearchStringLength = $this->config->getSystemValueInt('sharing.minSearchStringLength', 0);
 		$topEntries = [];
 		if (strlen($filter) >= $minSearchStringLength) {
-			$entries = $this->store->getContacts($user, $filter);
+			$entries = $this->store->getContacts($user, $filter, $maxAutocompleteResults);
 
 			$sortedEntries = $this->sortEntries($entries);
 			$topEntries = array_slice($sortedEntries, 0, $maxAutocompleteResults);

--- a/lib/public/Contacts/ContactsMenu/IContactsStore.php
+++ b/lib/public/Contacts/ContactsMenu/IContactsStore.php
@@ -33,11 +33,13 @@ interface IContactsStore {
 
 	/**
 	 * @param IUser $user
-	 * @param $filter
+	 * @param string $filter
+	 * @param int $limit added 19.0.2
+	 * @param int $offset added 19.0.2
 	 * @return IEntry[]
 	 * @since 13.0.0
 	 */
-	public function getContacts(IUser $user, $filter);
+	public function getContacts(IUser $user, $filter, ?int $limit = null, ?int $offset = null);
 
 	/**
 	 * @brief finds a contact by specifying the property to search on ($shareType) and the value ($shareWith)


### PR DESCRIPTION
fixes #20009 cf. https://github.com/nextcloud/server/issues/20009#issuecomment-664643922

Optional arguments are added to the ContactsStore API, so it should be okay to backport it to 19. Support for limiting results is implemented down the stack already. Since the contactsmenu reduces results according to `sharing.maxAutocompleteResults` and the search filter is passed to the backend, limiting the possible results up front does not sacrifice anything, but improves performance.