### PR TITLE
Object store trashbin fixes

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -44,6 +44,7 @@
 namespace OCA\Files_Trashbin;
 
 use OC\Files\Filesystem;
+use OC\Files\ObjectStore\ObjectStoreStorage;
 use OC\Files\View;
 use OCA\Files_Trashbin\AppInfo\Application;
 use OCA\Files_Trashbin\Command\Expire;
@@ -278,16 +279,22 @@ class Trashbin {
 		/** @var \OC\Files\Storage\Storage $sourceStorage */
 		[$sourceStorage, $sourceInternalPath] = $ownerView->resolvePath('/files/' . $ownerPath);
 
+
+		if ($trashStorage->file_exists($trashInternalPath)) {
+			$trashStorage->unlink($trashInternalPath);
+		}
+
 		$connection = \OC::$server->getDatabaseConnection();
 		$connection->beginTransaction();
 		$trashStorage->getUpdater()->renameFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
 
 		try {
 			$moveSuccessful = true;
-			if ($trashStorage->file_exists($trashInternalPath)) {
-				$trashStorage->unlink($trashInternalPath);
+
+			// when moving within the same object store, the cache update done above is enough to move the file
+			if (!($trashStorage->instanceOfStorage(ObjectStoreStorage::class) && $trashStorage->getId() === $sourceStorage->getId())) {
+				$trashStorage->moveFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
 			}
-			$trashStorage->moveFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
 		} catch (\OCA\Files_Trashbin\Exceptions\CopyRecursiveException $e) {
 			$moveSuccessful = false;
 			if ($trashStorage->file_exists($trashInternalPath)) {

--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -201,7 +201,11 @@ class Updater implements IUpdater {
 				$this->cache->moveFromCache($sourceCache, $source, $target);
 			}
 
-			if (pathinfo($source, PATHINFO_EXTENSION) !== pathinfo($target, PATHINFO_EXTENSION) && $sourceInfo->getMimeType() !== FileInfo::MIMETYPE_FOLDER) {
+			$sourceExtension = pathinfo($source, PATHINFO_EXTENSION);
+			$targetExtension = pathinfo($target, PATHINFO_EXTENSION);
+			$targetIsTrash = preg_match("/d\d+/", $targetExtension);
+
+			if ($sourceExtension !== $targetExtension && $sourceInfo->getMimeType() !== FileInfo::MIMETYPE_FOLDER && !$targetIsTrash) {
 				// handle mime type change
 				$mimeType = $this->storage->getMimeType($target);
 				$fileId = $this->cache->getId($target);


### PR DESCRIPTION
object stores are "special" given how they interact with the cache on their own

I'm not very happy about adding special cases like this but it's the best I can come up with