### PR TITLE
Also consider Noto Color Emoji font

### DIFF
--- a/apps/accessibility/css/fontdyslexic.scss
+++ b/apps/accessibility/css/fontdyslexic.scss
@@ -12,4 +12,4 @@
 	src: url('../fonts/OpenDyslexic-Bold.woff') format('woff');
 }
 
-$font-face: OpenDyslexic, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+$font-face: OpenDyslexic, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', Arial, 'Noto Color Emoji', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';

--- a/core/css/variables.scss
+++ b/core/css/variables.scss
@@ -83,7 +83,7 @@ $border-radius-large: 10px !default;
 // Pill-style button, value is large so big buttons also have correct roundness
 $border-radius-pill: 100px !default;
 
-$font-face: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol' !default;
+$font-face: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', Arial, 'Noto Color Emoji', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol' !default;
 
 $animation-quick: 100ms;
 $animation-slow: 300ms;


### PR DESCRIPTION
Ref https://www.google.com/get/noto/help/emoji/

I guess it's currently the most advertised Emoji font. However once installed, the browser tab and so on will show the emoji, but inside Nextcloud it is not being used

Before | After
---|---
![Bildschirmfoto von 2020-07-31 17-12-39](https://user-images.githubusercontent.com/213943/89050797-942dd780-d353-11ea-83ca-94fcc21fb875.png) | ![Bildschirmfoto von 2020-07-31 17-12-20](https://user-images.githubusercontent.com/213943/89050802-95f79b00-d353-11ea-98f2-ca385106186d.png)

Or is something wrong with Ubuntu 20.04s default font configuration. Because this worked out of the box super easy in Ubuntu 19.10 and before, but since 20.04 I see black/white outlined emojis only :(
