### PR TITLE
Small fix for .htaccess so that Apache will be aware of the ...

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -65,7 +65,13 @@
   RewriteRule ^\.well-known/host-meta\.json /public.php?service=host-meta-json [QSA,L]
   RewriteRule ^\.well-known/webfinger /public.php?service=webfinger [QSA,L]
   RewriteRule ^\.well-known/nodeinfo /public.php?service=nodeinfo [QSA,L]
+  # If request is forwarded from a reverse proxy.
+  RewriteCond %{HTTP:X-Forwarded-Proto} https
+  RewriteRule ^\.well-known/carddav https://%{HTTP_HOST}/remote.php/dav/ [R=301,L]
   RewriteRule ^\.well-known/carddav /remote.php/dav/ [R=301,L]
+  # If request is forwarded from a reverse proxy.
+  RewriteCond %{HTTP:X-Forwarded-Proto} https
+  RewriteRule ^\.well-known/caldav https://%{HTTP_HOST}/remote.php/dav/ [R=301,L]
   RewriteRule ^\.well-known/caldav /remote.php/dav/ [R=301,L]
   RewriteRule ^remote/(.*) remote.php [QSA,L]
   RewriteRule ^(?:build|tests|config|lib|3rdparty|templates)/.* - [R=404,L]


### PR DESCRIPTION
X-Forwarded-Proto header, and redirect reverse proxied https requets to corresponding https
destinations.

As written right now, if a user uses their own reverse proxy to terminate and forward https requests and goes to settings->overview page, the 2 async https calls to .well-known/ URLs will get redirected to http://.../remote.php/dav.

And that is a security violation in Chrome, and the redirections will get blocked.
As a result, there will be 2 warning messages about these .well-known URLs not being properly forwarded, which are actually false positive.