### PR TITLE
Add empty renderAs template

### DIFF
--- a/lib/public/AppFramework/Http/TemplateResponse.php
+++ b/lib/public/AppFramework/Http/TemplateResponse.php
@@ -49,6 +49,10 @@ class TemplateResponse extends Response {
 	/**
 	 * @since 20.0.0
 	 */
+	public const RENDER_AS_BASE = 'base';
+	/**
+	 * @since 20.0.0
+	 */
 	public const RENDER_AS_USER = 'user';
 	/**
 	 * @since 20.0.0
@@ -188,6 +192,7 @@ class TemplateResponse extends Response {
 		} elseif (in_array($this->renderAs, [
 			self::RENDER_AS_GUEST,
 			self::RENDER_AS_BLANK,
+			self::RENDER_AS_BASE,
 			self::RENDER_AS_ERROR,
 			self::RENDER_AS_PUBLIC,
 			self::RENDER_AS_USER], true)) {


### PR DESCRIPTION
Follow up to https://github.com/nextcloud/server/pull/21869

Before #21869 every renderAs parameter that was not known fell back to `layout.base.php` However with the [in_array check](https://github.com/nextcloud/server/pull/21869/files#diff-72ba5b73b640fa871221e8f9117388c6R188-R195) there is no way to get a empty template with the basic HTML structure now. Therefore this PR adds RENDER_AS_EMPTY which then is catched in https://github.com/nextcloud/server/blob/49970639faecbf5acd24b2b84e5df1a8fa9c746a/lib/private/TemplateLayout.php#L152-L154

The main purpose of this is to get a basic HTML template without the Nextcloud header which in contrast to `blank` still comes with the core scripts. This is for example used in Collabora https://github.com/nextcloud/richdocuments/blob/a73848938ee7d7282b00caf39802a01026b6e1e7/lib/Controller/DocumentController.php#L387