### PR TITLE
Allow Flow entity state to be recreated

### DIFF
--- a/apps/workflowengine/tests/ManagerTest.php
+++ b/apps/workflowengine/tests/ManagerTest.php
@@ -33,6 +33,7 @@ use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IServerContainer;
 use OCP\IURLGenerator;
+use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\SystemTag\ISystemTagManager;
 use OCP\WorkflowEngine\ICheck;
@@ -295,7 +296,8 @@ class ManagerTest extends TestCase {
 							$this->createMock(ILogger::class),
 							$this->createMock(\OCP\Share\IManager::class),
 							$this->createMock(IUserSession::class),
-							$this->createMock(ISystemTagManager::class)
+							$this->createMock(ISystemTagManager::class),
+							$this->createMock(IUserManager::class),
 						])
 						->setMethodsExcept(['getEvents'])
 						->getMock();

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -524,6 +524,7 @@ return array(
     'OCP\\User\\Events\\UserLoggedInWithCookieEvent' => $baseDir . '/lib/public/User/Events/UserLoggedInWithCookieEvent.php',
     'OCP\\User\\Events\\UserLoggedOutEvent' => $baseDir . '/lib/public/User/Events/UserLoggedOutEvent.php',
     'OCP\\Util' => $baseDir . '/lib/public/Util.php',
+    'OCP\\WorkflowEngine\\EntityContext\\IContextPortation' => $baseDir . '/lib/public/WorkflowEngine/EntityContext/IContextPortation.php',
     'OCP\\WorkflowEngine\\EntityContext\\IDisplayName' => $baseDir . '/lib/public/WorkflowEngine/EntityContext/IDisplayName.php',
     'OCP\\WorkflowEngine\\EntityContext\\IDisplayText' => $baseDir . '/lib/public/WorkflowEngine/EntityContext/IDisplayText.php',
     'OCP\\WorkflowEngine\\EntityContext\\IIcon' => $baseDir . '/lib/public/WorkflowEngine/EntityContext/IIcon.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -553,6 +553,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\User\\Events\\UserLoggedInWithCookieEvent' => __DIR__ . '/../../..' . '/lib/public/User/Events/UserLoggedInWithCookieEvent.php',
         'OCP\\User\\Events\\UserLoggedOutEvent' => __DIR__ . '/../../..' . '/lib/public/User/Events/UserLoggedOutEvent.php',
         'OCP\\Util' => __DIR__ . '/../../..' . '/lib/public/Util.php',
+        'OCP\\WorkflowEngine\\EntityContext\\IContextPortation' => __DIR__ . '/../../..' . '/lib/public/WorkflowEngine/EntityContext/IContextPortation.php',
         'OCP\\WorkflowEngine\\EntityContext\\IDisplayName' => __DIR__ . '/../../..' . '/lib/public/WorkflowEngine/EntityContext/IDisplayName.php',
         'OCP\\WorkflowEngine\\EntityContext\\IDisplayText' => __DIR__ . '/../../..' . '/lib/public/WorkflowEngine/EntityContext/IDisplayText.php',
         'OCP\\WorkflowEngine\\EntityContext\\IIcon' => __DIR__ . '/../../..' . '/lib/public/WorkflowEngine/EntityContext/IIcon.php',

--- a/lib/public/WorkflowEngine/EntityContext/IContextPortation.php
+++ b/lib/public/WorkflowEngine/EntityContext/IContextPortation.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it w	ill be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\WorkflowEngine\EntityContext;
+
+/**
+ * Interface IContextPortation
+ *
+ * Occasionally an IEntity needs to be reused not in the same, but a new
+ * request. As IEntities receive custom context information during a flow
+ * cycle, sometimes it might be necessary to export context identifiers to
+ * be able to recreate the state at a later point. For example: handling
+ * translations in a notification INotifier.
+ *
+ * @package OCP\WorkflowEngine\EntityContext
+ *
+ * @since 20.0.0
+ */
+interface IContextPortation {
+
+	/**
+	 * All relevant context identifiers that are needed to restore the state
+	 * of an entity shall be returned with this method. The resulting array
+	 * must be JSON-serializable.
+	 *
+	 * @since 20.0.0
+	 */
+	public function exportContextIDs(): array;
+
+	/**
+	 * This method receives the array as returned by `exportContextIDs()` in
+	 * order to restore the state of the IEntity if necessary.
+	 *
+	 * @since 20.0.0
+	 */
+	public function importContextIDs(array $contextIDs): void;
+}


### PR DESCRIPTION
An interface is added that allows entities to ex- and import their state identifiers, so usages in future requests is possible. The use case is notification handling: needed to solve https://github.com/nextcloud/flow_notifications/issues/1

