### PR TITLE
Fix share transfer of single files and on the transfered node

### DIFF
--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -37,6 +37,7 @@ use OC\Files\Filesystem;
 use OC\Files\View;
 use OCA\Files\Exception\TransferOwnershipException;
 use OCP\Encryption\IManager as IEncryptionManager;
+use OCP\Files\Config\IUserMountCache;
 use OCP\Files\FileInfo;
 use OCP\Files\IHomeStorage;
 use OCP\Files\InvalidPathException;
@@ -65,12 +66,17 @@ class OwnershipTransferService {
 	/** @var IMountManager */
 	private $mountManager;
 
+	/** @var IUserMountCache */
+	private $userMountCache;
+
 	public function __construct(IEncryptionManager $manager,
 								IShareManager $shareManager,
-								IMountManager $mountManager) {
+								IMountManager $mountManager,
+								IUserMountCache $userMountCache) {
 		$this->encryptionManager = $manager;
 		$this->shareManager = $shareManager;
 		$this->mountManager = $mountManager;
+		$this->userMountCache = $userMountCache;
 	}
 
 	/**
@@ -151,7 +157,9 @@ class OwnershipTransferService {
 		// collect all the shares
 		$shares = $this->collectUsersShares(
 			$sourceUid,
-			$output
+			$output,
+			$view,
+			$sourcePath
 		);
 
 		// transfer the files
@@ -236,7 +244,9 @@ class OwnershipTransferService {
 	}
 
 	private function collectUsersShares(string $sourceUid,
-										OutputInterface $output): array {
+										OutputInterface $output,
+										View $view,
+										?string $path = null): array {
 		$output->writeln("Collecting all share information for files and folders of $sourceUid ...");
 
 		$shares = [];
@@ -248,6 +258,23 @@ class OwnershipTransferService {
 				$progress->advance(count($sharePage));
 				if (empty($sharePage)) {
 					break;
+				}
+				if ($path !== null) {
+					$sharePage = array_filter($sharePage, function (IShare $share) use ($view, $path) {
+						try {
+							$relativePath = $view->getPath($share->getNodeId());
+							$singleFileTranfer = $view->is_file($path);
+							if ($singleFileTranfer) {
+								return Filesystem::normalizePath($relativePath) === Filesystem::normalizePath($path);
+							}
+
+							return mb_strpos(
+								Filesystem::normalizePath($relativePath . '/', false),
+								Filesystem::normalizePath($path . '/', false)) === 0;
+						} catch (\Exception $e) {
+							return false;
+						}
+					});
 				}
 				$shares = array_merge($shares, $sharePage);
 				$offset += 50;
@@ -308,6 +335,12 @@ class OwnershipTransferService {
 					if ($share->getSharedBy() === $sourceUid) {
 						$share->setSharedBy($destinationUid);
 					}
+
+
+					// trigger refetching of the node so that the new owner and mountpoint are taken into account
+					// otherwise the checks on the share update will fail due to the original node not being available in the new user scope
+					$this->userMountCache->clear();
+					$share->setNodeId($share->getNode()->getId());
 
 					$this->shareManager->updateShare($share);
 				}

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -409,4 +409,9 @@ class UserMountCache implements IUserMountCache {
 		$result->closeCursor();
 		return $results;
 	}
+
+	public function clear(): void {
+		$this->cacheInfoCache = new CappedMemoryCache();
+		$this->mountsForUsers = new CappedMemoryCache();
+	}
 }

--- a/lib/public/Files/Config/IUserMountCache.php
+++ b/lib/public/Files/Config/IUserMountCache.php
@@ -117,4 +117,11 @@ interface IUserMountCache {
 	 * @since 13.0.0
 	 */
 	public function getUsedSpaceForUsers(array $users);
+
+	/**
+	 * Clear all entries from the in-memory cache
+	 *
+	 * @since 20.0.0
+	 */
+	public function clear(): void;
 }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/21625

This fixes an issue where shares on single file transfers or on the root folder that is being transfered could not me moved over.

There were two issues here with the current implementation:
- When doing partial transfers with a path the shares to transfer were not filtered out so the transfer command attempted to migrate all shares to the new user
- The UserMountCache and Share object still had the old node information in their caches, so the share ownership checks had unexpected input data in https://github.com/nextcloud/server/blob/43efac345ec2850ea42629431d8a8beb353e0b77/lib/private/Share20/Manager.php#L302-L305

Steps to reproduce:
- Share a file f100.txt as admin with user1
- Transfer the file to user2 `occ files:transfer-ownership --path=f100.txt admin user2`