### PR TITLE
Delete chunks if the move on an upload failed

### DIFF
--- a/apps/dav/lib/Upload/ChunkingPlugin.php
+++ b/apps/dav/lib/Upload/ChunkingPlugin.php
@@ -26,6 +26,7 @@
 namespace OCA\DAV\Upload;
 
 use OCA\DAV\Connector\Sabre\Directory;
+use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use Sabre\DAV\Exception\BadRequest;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\INode;
@@ -87,13 +88,16 @@ class ChunkingPlugin extends ServerPlugin {
 	 * @return bool|void false to stop handling, void to skip this handler
 	 */
 	public function performMove($path, $destination) {
-		if (!$this->server->tree->nodeExists($destination)) {
-			// skip and let the default handler do its work
-			return;
-		}
-
 		// do a move manually, skipping Sabre's default "delete" for existing nodes
-		$this->server->tree->move($path, $destination);
+		try {
+			$this->server->tree->move($path, $destination);
+		} catch (Forbidden $e) {
+			$sourceNode = $this->server->tree->getNodeForPath($path);
+			if ($sourceNode instanceof FutureFile) {
+				$sourceNode->delete();
+			}
+			throw $e;
+		}
 
 		// trigger all default events (copied from CorePlugin::move)
 		$this->server->emit('afterMove', [$path, $destination]);

--- a/apps/dav/lib/Upload/ChunkingPlugin.php
+++ b/apps/dav/lib/Upload/ChunkingPlugin.php
@@ -88,6 +88,7 @@ class ChunkingPlugin extends ServerPlugin {
 	 * @return bool|void false to stop handling, void to skip this handler
 	 */
 	public function performMove($path, $destination) {
+		$fileExists = $this->server->tree->nodeExists($destination);
 		// do a move manually, skipping Sabre's default "delete" for existing nodes
 		try {
 			$this->server->tree->move($path, $destination);
@@ -106,7 +107,7 @@ class ChunkingPlugin extends ServerPlugin {
 
 		$response = $this->server->httpResponse;
 		$response->setHeader('Content-Length', '0');
-		$response->setStatus(204);
+		$response->setStatus($fileExists ? 204 : 201);
 
 		return false;
 	}

--- a/apps/dav/tests/unit/Upload/ChunkingPluginTest.php
+++ b/apps/dav/tests/unit/Upload/ChunkingPluginTest.php
@@ -128,14 +128,18 @@ class ChunkingPluginTest extends TestCase {
 			->method('nodeExists')
 			->with('target')
 			->willReturn(false);
-		$this->response->expects($this->never())
-			->method('setStatus');
+		$this->response->expects($this->once())
+			->method('setHeader')
+			->with('Content-Length', '0');
+		$this->response->expects($this->once())
+			->method('setStatus')
+			->with(204);
 		$this->request->expects($this->once())
 			->method('getHeader')
 			->with('OC-Total-Length')
 			->willReturn(4);
 
-		$this->assertNull($this->plugin->beforeMove('source', 'target'));
+		$this->assertFalse($this->plugin->beforeMove('source', 'target'));
 	}
 
 	public function testBeforeMoveFutureFileMoveIt() {

--- a/apps/dav/tests/unit/Upload/ChunkingPluginTest.php
+++ b/apps/dav/tests/unit/Upload/ChunkingPluginTest.php
@@ -133,7 +133,7 @@ class ChunkingPluginTest extends TestCase {
 			->with('Content-Length', '0');
 		$this->response->expects($this->once())
 			->method('setStatus')
-			->with(204);
+			->with(201);
 		$this->request->expects($this->once())
 			->method('getHeader')
 			->with('OC-Total-Length')


### PR DESCRIPTION
This should fix https://github.com/nextcloud/server/issues/16517 where chunks don't get cleaned up if the move operation after a chunked upload fails for some reason, e.g. because the file is  blocked by files_accesscontrol.

Steps to reproduce:
- Setup a files_accesscontrol rule for test.iso
- Upload a file called test.iso (needs to be big enough to trigger chunking)
- Observe the data/admin/uploads directory