### PR TITLE
add personal addtional setting section

### DIFF
--- a/apps/settings/appinfo/info.xml
+++ b/apps/settings/appinfo/info.xml
@@ -36,6 +36,7 @@
 		<personal>OCA\Settings\Settings\Personal\Security\Password</personal>
 		<personal>OCA\Settings\Settings\Personal\Security\TwoFactor</personal>
 		<personal>OCA\Settings\Settings\Personal\Security\WebAuthn</personal>
+		<personal-section>OCA\Settings\Sections\Personal\Additional</personal-section>
 		<personal-section>OCA\Settings\Sections\Personal\PersonalInfo</personal-section>
 		<personal-section>OCA\Settings\Sections\Personal\Security</personal-section>
 		<personal-section>OCA\Settings\Sections\Personal\SyncClients</personal-section>

--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -39,6 +39,7 @@ return array(
     'OCA\\Settings\\Sections\\Admin\\Security' => $baseDir . '/../lib/Sections/Admin/Security.php',
     'OCA\\Settings\\Sections\\Admin\\Server' => $baseDir . '/../lib/Sections/Admin/Server.php',
     'OCA\\Settings\\Sections\\Admin\\Sharing' => $baseDir . '/../lib/Sections/Admin/Sharing.php',
+    'OCA\\Settings\\Sections\\Personal\\Additional' => $baseDir . '/../lib/Sections/Personal/Additional.php',
     'OCA\\Settings\\Sections\\Personal\\PersonalInfo' => $baseDir . '/../lib/Sections/Personal/PersonalInfo.php',
     'OCA\\Settings\\Sections\\Personal\\Security' => $baseDir . '/../lib/Sections/Personal/Security.php',
     'OCA\\Settings\\Sections\\Personal\\SyncClients' => $baseDir . '/../lib/Sections/Personal/SyncClients.php',

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -54,6 +54,7 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\Sections\\Admin\\Security' => __DIR__ . '/..' . '/../lib/Sections/Admin/Security.php',
         'OCA\\Settings\\Sections\\Admin\\Server' => __DIR__ . '/..' . '/../lib/Sections/Admin/Server.php',
         'OCA\\Settings\\Sections\\Admin\\Sharing' => __DIR__ . '/..' . '/../lib/Sections/Admin/Sharing.php',
+        'OCA\\Settings\\Sections\\Personal\\Additional' => __DIR__ . '/..' . '/../lib/Sections/Personal/Additional.php',
         'OCA\\Settings\\Sections\\Personal\\PersonalInfo' => __DIR__ . '/..' . '/../lib/Sections/Personal/PersonalInfo.php',
         'OCA\\Settings\\Sections\\Personal\\Security' => __DIR__ . '/..' . '/../lib/Sections/Personal/Security.php',
         'OCA\\Settings\\Sections\\Personal\\SyncClients' => __DIR__ . '/..' . '/../lib/Sections/Personal/SyncClients.php',

--- a/apps/settings/lib/Sections/Personal/Additional.php
+++ b/apps/settings/lib/Sections/Personal/Additional.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Settings\Sections\Personal;
+
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\Settings\IIconSection;
+
+class Additional implements IIconSection {
+
+	/** @var IL10N */
+	private $l;
+
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
+	public function __construct(IL10N $l, IURLGenerator $urlGenerator) {
+		$this->l = $l;
+		$this->urlGenerator = $urlGenerator;
+	}
+
+	public function getIcon(): string {
+		return $this->urlGenerator->imagePath('core', 'actions/settings-dark.svg');
+	}
+
+	public function getID(): string {
+		return 'additional';
+	}
+
+	public function getName(): string {
+		return $this->l->t('Additional settings');
+	}
+
+	public function getPriority(): int {
+		return 98;
+	}
+}

--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -260,11 +260,6 @@ class Manager implements IManager {
 
 		$sections = [];
 
-		$legacyForms = \OC_App::getForms('personal');
-		if (!empty($legacyForms) && $this->hasLegacyPersonalSettingsToRender($legacyForms)) {
-			$sections[98] = [new Section('additional', $this->l->t('Additional settings'), 0, $this->url->imagePath('core', 'actions/settings-dark.svg'))];
-		}
-
 		$appSections = $this->getSections('personal');
 
 		foreach ($appSections as $section) {
@@ -275,7 +270,10 @@ class Manager implements IManager {
 
 			$sections[$section->getPriority()][] = $section;
 		}
-
+		$legacyForms = \OC_App::getForms('personal');
+		if (!empty($legacyForms) && $this->hasLegacyPersonalSettingsToRender($legacyForms) && !array_key_exists(98,$sections)) {
+			$sections[98] = [new Section('additional', $this->l->t('Additional settings'), 0, $this->url->imagePath('core', 'actions/settings-dark.svg'))];
+		}
 		ksort($sections);
 
 		return $sections;
@@ -301,14 +299,22 @@ class Manager implements IManager {
 	public function getPersonalSettings($section): array {
 		$settings = [];
 		$appSettings = $this->getSettings('personal', $section);
-
+	
+		if (count($appSettings) == 1 && strcmp($section,'additional') === 0) {
+			// only empty addtional settings returned
+			$legacyForms = \OC_App::getForms('personal');
+			if (empty($legacyForms) || !$this->hasLegacyPersonalSettingsToRender($legacyForms)) {
+				// remove empty addtional setting
+				return [];
+			}
+		}
+	
 		foreach ($appSettings as $setting) {
 			if (!isset($settings[$setting->getPriority()])) {
 				$settings[$setting->getPriority()] = [];
 			}
 			$settings[$setting->getPriority()][] = $setting;
 		}
-
 		ksort($settings);
 		return $settings;
 	}


### PR DESCRIPTION
in the [developer manual settings section](https://docs.nextcloud.com/server/stable/developer_manual/app/settings.html?highlight=settings),  there is a mentioning of `additional` default section, but it only appears on the admin part, not on the person part. resulting in apps that are meant for non-admin users can not use the default additional section, this pull request is to add the personal default `Additional settings` 