### PR TITLE
Exclude apps/*/tests for coverage calculation

### DIFF
--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -8,7 +8,6 @@
 >
 	<testsuite name='ownCloud'>
 		<directory suffix='.php'>lib/</directory>
-		<directory suffix='.php'>Settings/</directory>
 		<directory suffix='.php'>Core/</directory>
 		<directory suffix='.php'>ocs-provider/</directory>
 		<file>apps.php</file>
@@ -20,29 +19,11 @@
 			<directory suffix=".php">..</directory>
 			<exclude>
 				<directory suffix=".php">../3rdparty</directory>
-				<directory suffix=".php">../apps/admin_audit/tests</directory>
-				<directory suffix=".php">../apps/dav/tests</directory>
-				<directory suffix=".php">../apps/encryption/tests</directory>
-				<directory suffix=".php">../apps/federatedfilesharing/tests</directory>
-				<directory suffix=".php">../apps/federation/tests</directory>
-				<directory suffix=".php">../apps/files/tests</directory>
-				<directory suffix=".php">../apps/files_external</directory>
-				<directory suffix=".php">../apps/files_sharing/tests</directory>
-				<directory suffix=".php">../apps/files_trashbin/tests</directory>
-				<directory suffix=".php">../apps/files_versions/tests</directory>
-				<directory suffix=".php">../apps/oauth2/tests</directory>
-				<directory suffix=".php">../apps/provisioning_api/tests</directory>
-				<directory suffix=".php">../apps/systemtags/tests</directory>
-				<directory suffix=".php">../apps/theming/tests</directory>
-				<directory suffix=".php">../apps/settings/tests</directory>
-				<directory suffix=".php">../apps/twofactor_backupcodes/tests</directory>
-				<directory suffix=".php">../apps/updatenotification/tests</directory>
-				<directory suffix=".php">../apps/user_ldap/tests</directory>
-				<directory suffix=".php">../apps/workflowengine/tests</directory>
-				<directory suffix=".php">../tests</directory>
+				<directory suffix=".php">../apps/*/composer</directory>
+				<directory suffix=".php">../apps/*/tests</directory>
 				<directory suffix=".php">../build</directory>
 				<directory suffix=".php">../lib/composer</directory>
-				<directory suffix=".php">../apps/*/composer</directory>
+				<directory suffix=".php">../tests</directory>
 			</exclude>
 		</whitelist>
 	</filter>

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -8,7 +8,7 @@
 >
 	<testsuite name='ownCloud'>
 		<directory suffix='.php'>lib/</directory>
-		<directory suffix='.php'>Core/</directory>
+		<directory suffix='.php'>core/</directory>
 		<directory suffix='.php'>ocs-provider/</directory>
 		<file>apps.php</file>
 	</testsuite>

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -21,6 +21,7 @@
 				<directory suffix=".php">../3rdparty</directory>
 				<directory suffix=".php">../apps/*/composer</directory>
 				<directory suffix=".php">../apps/*/tests</directory>
+				<directory suffix=".php">../apps/files_external/3rdparty</directory>
 				<directory suffix=".php">../build</directory>
 				<directory suffix=".php">../lib/composer</directory>
 				<directory suffix=".php">../tests</directory>


### PR DESCRIPTION
For some apps the coverage of the tests is calculated.

![image](https://user-images.githubusercontent.com/3902676/89779348-6f81ee80-db0f-11ea-87b7-7c4ac3d57334.png)

This PR excludes every tests folder in apps/appId/.