### PR TITLE
Prefer typed event over string based ones

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -278,9 +278,8 @@ class ViewController extends Controller {
 		}
 
 		$event = new LoadAdditionalScriptsEvent();
-		$this->eventDispatcher->dispatch(LoadAdditionalScriptsEvent::class, $event);
-
-		$this->eventDispatcher->dispatch(LoadSidebar::class, new LoadSidebar());
+		$this->eventDispatcher->dispatchTyped($event);
+		$this->eventDispatcher->dispatchTyped(new LoadSidebar());
 		// Load Viewer scripts
 		if (class_exists(LoadViewer::class)) {
 			$this->eventDispatcher->dispatchTyped(new LoadViewer());

--- a/apps/workflowengine/lib/AppInfo/Application.php
+++ b/apps/workflowengine/lib/AppInfo/Application.php
@@ -36,6 +36,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ILogger;
 use OCP\IServerContainer;
+use OCP\WorkflowEngine\Events\LoadSettingsScriptsEvent;
 use OCP\WorkflowEngine\IEntity;
 use OCP\WorkflowEngine\IEntityCompat;
 use OCP\WorkflowEngine\IOperation;
@@ -51,7 +52,7 @@ class Application extends App implements IBootstrap {
 	public function register(IRegistrationContext $context): void {
 		$context->registerServiceAlias('RequestTimeController', RequestTime::class);
 		$context->registerEventListener(
-			'OCP\WorkflowEngine::loadAdditionalSettingScripts',
+			LoadSettingsScriptsEvent::class,
 			LoadAdditionalSettingsScriptsListener::class,
 			-100
 		);

--- a/apps/workflowengine/lib/Settings/ASettings.php
+++ b/apps/workflowengine/lib/Settings/ASettings.php
@@ -82,10 +82,12 @@ abstract class ASettings implements ISettings {
 	 * @return TemplateResponse
 	 */
 	public function getForm() {
+		// @deprecated in 20.0.0: retire this one in favor of the typed event
 		$this->eventDispatcher->dispatch(
 			'OCP\WorkflowEngine::loadAdditionalSettingScripts',
 			new LoadSettingsScriptsEvent()
 		);
+		$this->eventDispatcher->dispatchTyped(new LoadSettingsScriptsEvent());
 
 		$entities = $this->manager->getEntitiesList();
 		$this->initialStateService->provideInitialState(

--- a/lib/private/Security/CSP/ContentSecurityPolicyManager.php
+++ b/lib/private/Security/CSP/ContentSecurityPolicyManager.php
@@ -57,7 +57,7 @@ class ContentSecurityPolicyManager implements IContentSecurityPolicyManager {
 	 */
 	public function getDefaultPolicy(): ContentSecurityPolicy {
 		$event = new AddContentSecurityPolicyEvent($this);
-		$this->dispatcher->dispatch(AddContentSecurityPolicyEvent::class, $event);
+		$this->dispatcher->dispatchTyped($event);
 
 		$defaultPolicy = new \OC\Security\CSP\ContentSecurityPolicy();
 		foreach ($this->policies as $policy) {

--- a/lib/private/Security/FeaturePolicy/FeaturePolicyManager.php
+++ b/lib/private/Security/FeaturePolicy/FeaturePolicyManager.php
@@ -47,7 +47,7 @@ class FeaturePolicyManager {
 
 	public function getDefaultPolicy(): FeaturePolicy {
 		$event = new AddFeaturePolicyEvent($this);
-		$this->dispatcher->dispatch(AddFeaturePolicyEvent::class, $event);
+		$this->dispatcher->dispatchTyped($event);
 
 		$defaultPolicy = new FeaturePolicy();
 		foreach ($this->policies as $policy) {


### PR DESCRIPTION
* Already documented in https://github.com/nextcloud/documentation/pull/2842 (because the behavior doesn't change - only the used methods)
* [x] add deprecation noticed for `OCP\WorkflowEngine::loadAdditionalSettingScripts` to #20953 