### PR TITLE
Use autowiring where possible in server container

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -344,7 +344,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 			return new Encryption\Keys\Storage($view, $util);
 		});
-		$this->registerAlias('TagMapper', TagMapper::class);
+		$this->registerDeprecatedAlias('TagMapper', TagMapper::class);
 
 		$this->registerAlias(\OCP\ITagManager::class, TagManager::class);
 		$this->registerDeprecatedAlias('TagManager', \OCP\ITagManager::class);
@@ -871,7 +871,7 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 		$this->registerDeprecatedAlias('MountConfigManager', IMountProviderCollection::class);
 
-		$this->registerAlias('IniWrapper', IniGetWrapper::class);
+		$this->registerDeprecatedAlias('IniWrapper', IniGetWrapper::class);
 		$this->registerService('AsyncCommandBus', function (Server $c) {
 			$busClass = $c->getConfig()->getSystemValue('commandbus');
 			if ($busClass) {
@@ -888,7 +888,7 @@ class Server extends ServerContainer implements IServerContainer {
 			}
 		});
 		$this->registerAlias(IBus::class, 'AsyncCommandBus');
-		$this->registerAlias('TrustedDomainHelper', TrustedDomainHelper::class);
+		$this->registerDeprecatedAlias('TrustedDomainHelper', TrustedDomainHelper::class);
 		$this->registerDeprecatedAlias('Throttler', Throttler::class);
 		$this->registerService('IntegrityCodeChecker', function (Server $c) {
 			// IConfig and IAppManager requires a working database. This code

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -266,15 +266,19 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 
 		$this->registerAlias(\OCP\Calendar\IManager::class, \OC\Calendar\Manager::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('CalendarManager', \OC\Calendar\Manager::class);
 
 		$this->registerAlias(\OCP\Calendar\Resource\IManager::class, \OC\Calendar\Resource\Manager::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('CalendarResourceBackendManager', \OC\Calendar\Resource\Manager::class);
 
 		$this->registerAlias(\OCP\Calendar\Room\IManager::class, \OC\Calendar\Room\Manager::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('CalendarRoomBackendManager', \OC\Calendar\Room\Manager::class);
 
 		$this->registerAlias(\OCP\Contacts\IManager::class, \OC\ContactsManager::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('ContactsManager', \OCP\Contacts\IManager::class);
 
 		$this->registerAlias(\OCP\DirectEditing\IManager::class, \OC\DirectEditing\Manager::class);
@@ -292,6 +296,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getSession()->get('user_id')
 			);
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('PreviewManager', IPreview::class);
 
 		$this->registerService(\OC\Preview\Watcher::class, function (Server $c) {
@@ -317,6 +322,7 @@ class Server extends ServerContainer implements IServerContainer {
 				new ArrayCache()
 			);
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('EncryptionManager', \OCP\Encryption\IManager::class);
 
 		$this->registerService('EncryptionFileHelper', function (Server $c) {
@@ -344,9 +350,11 @@ class Server extends ServerContainer implements IServerContainer {
 
 			return new Encryption\Keys\Storage($view, $util);
 		});
+		/** @deprecated 20.0.0 */
 		$this->registerDeprecatedAlias('TagMapper', TagMapper::class);
 
 		$this->registerAlias(\OCP\ITagManager::class, TagManager::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('TagManager', \OCP\ITagManager::class);
 
 		$this->registerService('SystemTagManagerFactory', function (Server $c) {
@@ -357,6 +365,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService(ISystemTagManager::class, function (Server $c) {
 			return $c->query('SystemTagManagerFactory')->getManager();
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('SystemTagManager', ISystemTagManager::class);
 
 		$this->registerService(ISystemTagObjectMapper::class, function (Server $c) {
@@ -388,6 +397,7 @@ class Server extends ServerContainer implements IServerContainer {
 			);
 		});
 
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('SystemTagObjectMapper', ISystemTagObjectMapper::class);
 
 		$this->registerService(IRootFolder::class, function (Server $c) {
@@ -395,8 +405,10 @@ class Server extends ServerContainer implements IServerContainer {
 				return $c->query('RootFolder');
 			});
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('LazyRootFolder', IRootFolder::class);
 
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('UserManager', \OC\User\Manager::class);
 		$this->registerAlias(\OCP\IUserManager::class, \OC\User\Manager::class);
 
@@ -458,6 +470,7 @@ class Server extends ServerContainer implements IServerContainer {
 			});
 			return $groupManager;
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('GroupManager', \OCP\IGroupManager::class);
 
 		$this->registerService(Store::class, function (Server $c) {
@@ -597,21 +610,26 @@ class Server extends ServerContainer implements IServerContainer {
 			return $userSession;
 		});
 		$this->registerAlias(\OCP\IUserSession::class, \OC\User\Session::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('UserSession', \OC\User\Session::class);
 
 		$this->registerAlias(\OCP\Authentication\TwoFactorAuth\IRegistry::class, \OC\Authentication\TwoFactorAuth\Registry::class);
 
 		$this->registerAlias(INavigationManager::class, \OC\NavigationManager::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('NavigationManager', INavigationManager::class);
 
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('AllConfig', \OC\AllConfig::class);
 		$this->registerAlias(\OCP\IConfig::class, \OC\AllConfig::class);
 
 		$this->registerService(\OC\SystemConfig::class, function ($c) use ($config) {
 			return new \OC\SystemConfig($config);
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('SystemConfig', \OC\SystemConfig::class);
 
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('AppConfig', \OC\AppConfig::class);
 		$this->registerAlias(IAppConfig::class, \OC\AppConfig::class);
 
@@ -623,6 +641,7 @@ class Server extends ServerContainer implements IServerContainer {
 				\OC::$SERVERROOT
 			);
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('L10NFactory', IFactory::class);
 
 		$this->registerService(IURLGenerator::class, function (Server $c) {
@@ -635,14 +654,18 @@ class Server extends ServerContainer implements IServerContainer {
 				$request
 			);
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('URLGenerator', IURLGenerator::class);
 
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('AppFetcher', AppFetcher::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('CategoryFetcher', CategoryFetcher::class);
 
 		$this->registerService(ICache::class, function ($c) {
 			return new Cache\File();
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('UserCache', ICache::class);
 
 		$this->registerService(Factory::class, function (Server $c) {
@@ -668,6 +691,7 @@ class Server extends ServerContainer implements IServerContainer {
 			}
 			return $arrayCacheFactory;
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('MemCacheFactory', Factory::class);
 		$this->registerAlias(ICacheFactory::class, Factory::class);
 
@@ -686,6 +710,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$l10n
 			);
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('ActivityManager', \OCP\Activity\IManager::class);
 
 		$this->registerService(\OCP\Activity\IEventMerger::class, function (Server $c) {
@@ -705,6 +730,7 @@ class Server extends ServerContainer implements IServerContainer {
 			);
 		});
 		$this->registerAlias(IAvatarManager::class, AvatarManager::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('AvatarManager', AvatarManager::class);
 
 		$this->registerAlias(\OCP\Support\CrashReport\IRegistry::class, \OC\Support\CrashReport\Registry::class);
@@ -719,6 +745,7 @@ class Server extends ServerContainer implements IServerContainer {
 			return new Log($logger, $this->getSystemConfig(), null, $registry);
 		});
 		$this->registerAlias(ILogger::class, \OC\Log::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('Logger', \OC\Log::class);
 		// PSR-3 logger
 		$this->registerAlias(LoggerInterface::class, PsrLoggerAdapter::class);
@@ -728,6 +755,7 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 
 		$this->registerAlias(IJobList::class, \OC\BackgroundJob\JobList::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('JobList', IJobList::class);
 
 		$this->registerService(IRouter::class, function (Server $c) {
@@ -740,9 +768,11 @@ class Server extends ServerContainer implements IServerContainer {
 			}
 			return $router;
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('Router', IRouter::class);
 
 		$this->registerAlias(ISearch::class, Search::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('Search', ISearch::class);
 
 		$this->registerService(\OC\Security\RateLimiting\Backend\IBackend::class, function ($c) {
@@ -753,15 +783,19 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 
 		$this->registerAlias(\OCP\Security\ISecureRandom::class, SecureRandom::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('SecureRandom', \OCP\Security\ISecureRandom::class);
 
 		$this->registerAlias(ICrypto::class, Crypto::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('Crypto', ICrypto::class);
 
 		$this->registerAlias(IHasher::class, Hasher::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('Hasher', IHasher::class);
 
 		$this->registerAlias(ICredentialsManager::class, CredentialsManager::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('CredentialsManager', ICredentialsManager::class);
 
 		$this->registerService(IDBConnection::class, function (Server $c) {
@@ -776,6 +810,7 @@ class Server extends ServerContainer implements IServerContainer {
 			$connection->getConfiguration()->setSQLLogger($c->getQueryLogger());
 			return $connection;
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('DatabaseConnection', IDBConnection::class);
 
 
@@ -794,6 +829,7 @@ class Server extends ServerContainer implements IServerContainer {
 				)
 			);
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('HttpClientService', IClientService::class);
 		$this->registerService(IEventLogger::class, function (Server $c) {
 			$eventLogger = new EventLogger();
@@ -803,6 +839,7 @@ class Server extends ServerContainer implements IServerContainer {
 			}
 			return $eventLogger;
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('EventLogger', IEventLogger::class);
 
 		$this->registerService(IQueryLogger::class, function (Server $c) {
@@ -813,8 +850,10 @@ class Server extends ServerContainer implements IServerContainer {
 			}
 			return $queryLogger;
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('QueryLogger', IQueryLogger::class);
 
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('TempManager', TempManager::class);
 		$this->registerAlias(ITempManager::class, TempManager::class);
 
@@ -829,10 +868,12 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getLogger()
 			);
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('AppManager', AppManager::class);
 		$this->registerAlias(IAppManager::class, AppManager::class);
 
 		$this->registerAlias(IDateTimeZone::class, DateTimeZone::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('DateTimeZone', IDateTimeZone::class);
 
 		$this->registerService(IDateTimeFormatter::class, function (Server $c) {
@@ -843,6 +884,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getL10N('lib', $language)
 			);
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('DateTimeFormatter', IDateTimeFormatter::class);
 
 		$this->registerService(IUserMountCache::class, function (Server $c) {
@@ -851,6 +893,7 @@ class Server extends ServerContainer implements IServerContainer {
 			$listener->listen($c->getUserManager());
 			return $mountCache;
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('UserMountCache', IUserMountCache::class);
 
 		$this->registerService(IMountProviderCollection::class, function (Server $c) {
@@ -869,8 +912,10 @@ class Server extends ServerContainer implements IServerContainer {
 
 			return $manager;
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('MountConfigManager', IMountProviderCollection::class);
 
+		/** @deprecated 20.0.0 */
 		$this->registerDeprecatedAlias('IniWrapper', IniGetWrapper::class);
 		$this->registerService('AsyncCommandBus', function (Server $c) {
 			$busClass = $c->getConfig()->getSystemValue('commandbus');
@@ -888,7 +933,9 @@ class Server extends ServerContainer implements IServerContainer {
 			}
 		});
 		$this->registerAlias(IBus::class, 'AsyncCommandBus');
+		/** @deprecated 20.0.0 */
 		$this->registerDeprecatedAlias('TrustedDomainHelper', TrustedDomainHelper::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('Throttler', Throttler::class);
 		$this->registerService('IntegrityCodeChecker', function (Server $c) {
 			// IConfig and IAppManager requires a working database. This code
@@ -946,6 +993,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$stream
 			);
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('Request', \OCP\IRequest::class);
 
 		$this->registerService(IMailer::class, function (Server $c) {
@@ -959,6 +1007,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getL10NFactory()
 			);
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('Mailer', IMailer::class);
 
 		$this->registerService('LDAPProvider', function (Server $c) {
@@ -992,9 +1041,11 @@ class Server extends ServerContainer implements IServerContainer {
 			}
 			return new NoopLockingProvider();
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('LockingProvider', ILockingProvider::class);
 
 		$this->registerAlias(IMountManager::class, \OC\Files\Mount\Manager::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('MountManager', IMountManager::class);
 
 		$this->registerService(IMimeTypeDetector::class, function (Server $c) {
@@ -1005,14 +1056,17 @@ class Server extends ServerContainer implements IServerContainer {
 				\OC::$SERVERROOT . '/resources/config/'
 			);
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('MimeTypeDetector', IMimeTypeDetector::class);
 
 		$this->registerAlias(IMimeTypeLoader::class, Loader::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('MimeTypeLoader', IMimeTypeLoader::class);
 		$this->registerService(BundleFetcher::class, function () {
 			return new BundleFetcher($this->getL10N('lib'));
 		});
 		$this->registerAlias(\OCP\Notification\IManager::class, Manager::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('NotificationManager', \OCP\Notification\IManager::class);
 
 		$this->registerService(CapabilitiesManager::class, function (Server $c) {
@@ -1025,6 +1079,7 @@ class Server extends ServerContainer implements IServerContainer {
 			});
 			return $manager;
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('CapabilitiesManager', CapabilitiesManager::class);
 
 		$this->registerService(ICommentsManager::class, function (Server $c) {
@@ -1048,6 +1103,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 			return $manager;
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('CommentsManager', ICommentsManager::class);
 
 		$this->registerAlias(\OC_Defaults::class, 'ThemingDefaults');
@@ -1089,6 +1145,7 @@ class Server extends ServerContainer implements IServerContainer {
 			);
 		});
 		$this->registerAlias(\OCP\EventDispatcher\IEventDispatcher::class, \OC\EventDispatcher\EventDispatcher::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('EventDispatcher', \OC\EventDispatcher\SymfonyAdapter::class);
 		$this->registerAlias(EventDispatcherInterface::class, \OC\EventDispatcher\SymfonyAdapter::class);
 
@@ -1117,11 +1174,13 @@ class Server extends ServerContainer implements IServerContainer {
 				$request
 			);
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('CsrfTokenManager', CsrfTokenManager::class);
 		$this->registerService(SessionStorage::class, function (Server $c) {
 			return new SessionStorage($c->getSession());
 		});
 		$this->registerAlias(\OCP\Security\IContentSecurityPolicyManager::class, ContentSecurityPolicyManager::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('ContentSecurityPolicyManager', ContentSecurityPolicyManager::class);
 
 		$this->registerService(\OCP\Share\IManager::class, function (Server $c) {
@@ -1151,6 +1210,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 			return $manager;
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('ShareManager', \OCP\Share\IManager::class);
 
 		$this->registerService(\OCP\Collaboration\Collaborators\ISearch::class, function (Server $c) {
@@ -1165,6 +1225,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 			return $instance;
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('CollaboratorSearch', \OCP\Collaboration\Collaborators\ISearch::class);
 		$this->registerAlias(\OCP\Collaboration\Collaborators\ISearchResult::class, \OC\Collaboration\Collaborators\SearchResult::class);
 
@@ -1214,9 +1275,11 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 
 		$this->registerAlias(\OCP\AppFramework\Utility\IControllerMethodReflector::class, \OC\AppFramework\Utility\ControllerMethodReflector::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('ControllerMethodReflector', \OCP\AppFramework\Utility\IControllerMethodReflector::class);
 
 		$this->registerAlias(\OCP\AppFramework\Utility\ITimeFactory::class, \OC\AppFramework\Utility\TimeFactory::class);
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('TimeFactory', \OCP\AppFramework\Utility\ITimeFactory::class);
 
 		$this->registerService(Defaults::class, function (Server $c) {
@@ -1224,6 +1287,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getThemingDefaults()
 			);
 		});
+		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('Defaults', \OCP\Defaults::class);
 
 		$this->registerService(\OCP\ISession::class, function (SimpleContainer $c) {


### PR DESCRIPTION
Basically removes the implicit wiring of dependencies where the automatic DI would also just work. The only real addition is the `serverRoot` alias that maps to `OC::$SERVERROOT`.