### PR TITLE
SSE: make legacy format opt in

### DIFF
--- a/apps/encryption/appinfo/info.xml
+++ b/apps/encryption/appinfo/info.xml
@@ -14,7 +14,7 @@
 		Please read the documentation to know all implications before you decide
 		to enable server-side encryption.
 	</description>
-	<version>2.8.0</version>
+	<version>2.8.1</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>
 	<author>Clark Tomlinson</author>
@@ -44,6 +44,7 @@
 		<command>OCA\Encryption\Command\EnableMasterKey</command>
 		<command>OCA\Encryption\Command\DisableMasterKey</command>
 		<command>OCA\Encryption\Command\RecoverUser</command>
+		<command>OCA\Encryption\Command\ScanLegacyFormat</command>
 	</commands>
 
 	<settings>

--- a/apps/encryption/composer/composer/autoload_classmap.php
+++ b/apps/encryption/composer/composer/autoload_classmap.php
@@ -10,6 +10,7 @@ return array(
     'OCA\\Encryption\\Command\\DisableMasterKey' => $baseDir . '/../lib/Command/DisableMasterKey.php',
     'OCA\\Encryption\\Command\\EnableMasterKey' => $baseDir . '/../lib/Command/EnableMasterKey.php',
     'OCA\\Encryption\\Command\\RecoverUser' => $baseDir . '/../lib/Command/RecoverUser.php',
+    'OCA\\Encryption\\Command\\ScanLegacyFormat' => $baseDir . '/../lib/Command/ScanLegacyFormat.php',
     'OCA\\Encryption\\Controller\\RecoveryController' => $baseDir . '/../lib/Controller/RecoveryController.php',
     'OCA\\Encryption\\Controller\\SettingsController' => $baseDir . '/../lib/Controller/SettingsController.php',
     'OCA\\Encryption\\Controller\\StatusController' => $baseDir . '/../lib/Controller/StatusController.php',

--- a/apps/encryption/composer/composer/autoload_static.php
+++ b/apps/encryption/composer/composer/autoload_static.php
@@ -25,6 +25,7 @@ class ComposerStaticInitEncryption
         'OCA\\Encryption\\Command\\DisableMasterKey' => __DIR__ . '/..' . '/../lib/Command/DisableMasterKey.php',
         'OCA\\Encryption\\Command\\EnableMasterKey' => __DIR__ . '/..' . '/../lib/Command/EnableMasterKey.php',
         'OCA\\Encryption\\Command\\RecoverUser' => __DIR__ . '/..' . '/../lib/Command/RecoverUser.php',
+        'OCA\\Encryption\\Command\\ScanLegacyFormat' => __DIR__ . '/..' . '/../lib/Command/ScanLegacyFormat.php',
         'OCA\\Encryption\\Controller\\RecoveryController' => __DIR__ . '/..' . '/../lib/Controller/RecoveryController.php',
         'OCA\\Encryption\\Controller\\SettingsController' => __DIR__ . '/..' . '/../lib/Controller/SettingsController.php',
         'OCA\\Encryption\\Controller\\StatusController' => __DIR__ . '/..' . '/../lib/Controller/StatusController.php',

--- a/apps/encryption/lib/Command/ScanLegacyFormat.php
+++ b/apps/encryption/lib/Command/ScanLegacyFormat.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Encryption\Command;
+
+use OC\Files\View;
+use OCA\Encryption\Util;
+use OCP\IConfig;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ScanLegacyFormat extends Command {
+
+	/** @var Util */
+	protected $util;
+
+	/** @var IConfig */
+	protected $config;
+
+	/** @var  QuestionHelper */
+	protected $questionHelper;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var View */
+	private $rootView;
+
+	/**
+	 * @param Util $util
+	 * @param IConfig $config
+	 * @param QuestionHelper $questionHelper
+	 */
+	public function __construct(Util $util,
+								IConfig $config,
+								QuestionHelper $questionHelper,
+								IUserManager $userManager) {
+		parent::__construct();
+
+		$this->util = $util;
+		$this->config = $config;
+		$this->questionHelper = $questionHelper;
+		$this->userManager = $userManager;
+		$this->rootView = new View();
+	}
+
+	protected function configure() {
+		$this
+			->setName('encryption:scan:legacy-format')
+			->setDescription('Scan the files for the legacy format');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$result = true;
+
+		$output->writeln('Scanning all files for legacy encryption');
+
+		foreach ($this->userManager->getBackends() as $backend) {
+			$limit = 500;
+			$offset = 0;
+			do {
+				$users = $backend->getUsers('', $limit, $offset);
+				foreach ($users as $user) {
+					$output->writeln('Scanning all files for ' . $user);
+					$this->setupUserFS($user);
+					$result &= $this->scanFolder($output, '/' . $user);
+				}
+				$offset += $limit;
+			} while (count($users) >= $limit);
+		}
+
+		if ($result) {
+			$output->writeln('All scanned files are propperly encrypted. You can disable the legacy compatibility mode.');
+			return 0;
+		}
+
+		return 1;
+	}
+
+	private function scanFolder(OutputInterface $output, string $folder): bool {
+		$clean = true;
+
+		foreach ($this->rootView->getDirectoryContent($folder) as $item) {
+			$path = $folder . '/' . $item['name'];
+			if ($this->rootView->is_dir($path)) {
+				if ($this->scanFolder($output, $path) === false) {
+					$clean = false;
+				}
+			} else {
+				if (!$item->isEncrypted()) {
+					// ignore
+					continue;
+				}
+
+				$stats = $this->rootView->stat($path);
+				if (!isset($stats['hasHeader']) || $stats['hasHeader'] === false) {
+					$clean = false;
+					$output->writeln($path . ' does not have a proper header');
+				}
+			}
+		}
+
+		return $clean;
+	}
+
+	/**
+	 * setup user file system
+	 *
+	 * @param string $uid
+	 */
+	protected function setupUserFS($uid) {
+		\OC_Util::tearDownFS();
+		\OC_Util::setupFS($uid);
+	}
+}

--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -32,6 +32,7 @@ namespace OCA\Encryption\Crypto;
 
 use OC\Encryption\Exceptions\DecryptionFailedException;
 use OC\Encryption\Exceptions\EncryptionFailedException;
+use OC\ServerNotAvailableException;
 use OCA\Encryption\Exceptions\MultiKeyDecryptException;
 use OCA\Encryption\Exceptions\MultiKeyEncryptException;
 use OCP\Encryption\Exceptions\GenericEncryptionException;
@@ -89,6 +90,9 @@ class Crypt {
 		'AES-128-CFB' => 16,
 	];
 
+	/** @var bool */
+	private $supportLegacy;
+
 	/**
 	 * @param ILogger $logger
 	 * @param IUserSession $userSession
@@ -101,6 +105,8 @@ class Crypt {
 		$this->config = $config;
 		$this->l = $l;
 		$this->supportedKeyFormats = ['hash', 'password'];
+
+		$this->supportLegacy = $this->config->getSystemValueBool('encryption.legacy_format_support', false);
 	}
 
 	/**
@@ -299,6 +305,10 @@ class Crypt {
 	 * @return string
 	 */
 	public function getLegacyCipher() {
+		if (!$this->supportLegacy) {
+			throw new ServerNotAvailableException('Legacy cipher is no longer supported!');
+		}
+
 		return self::LEGACY_CIPHER;
 	}
 
@@ -391,7 +401,7 @@ class Crypt {
 		if (isset($header['cipher'])) {
 			$cipher = $header['cipher'];
 		} else {
-			$cipher = self::LEGACY_CIPHER;
+			$cipher = $this->getLegacyCipher();
 		}
 
 		if (isset($header['keyFormat'])) {
@@ -569,6 +579,11 @@ class Crypt {
 
 		$meta = substr($catFile, -93);
 		$signaturePosition = strpos($meta, '00sig00');
+
+		// If we no longer support the legacy format then everything needs a signature
+		if (!$skipSignatureCheck && !$this->supportLegacy && $signaturePosition === false) {
+			throw new GenericEncryptionException('Missing Signature', $this->l->t('Missing Signature'));
+		}
 
 		// enforce signature for the new 'CTR' ciphers
 		if (!$skipSignatureCheck && $signaturePosition === false && stripos($cipher, 'ctr') !== false) {

--- a/apps/encryption/tests/Crypto/CryptTest.php
+++ b/apps/encryption/tests/Crypto/CryptTest.php
@@ -209,6 +209,9 @@ class CryptTest extends TestCase {
 	 * @dataProvider dataTestSplitMetaData
 	 */
 	public function testSplitMetaData($data, $expected) {
+		$this->config->method('getSystemValue')
+			->with('encryption_skip_signature_check', false)
+			->willReturn(true);
 		$result = self::invokePrivate($this->crypt, 'splitMetaData', [$data, 'AES-256-CFB']);
 		$this->assertTrue(is_array($result));
 		$this->assertSame(3, count($result));
@@ -233,6 +236,9 @@ class CryptTest extends TestCase {
 	 * @dataProvider dataTestHasSignature
 	 */
 	public function testHasSignature($data, $expected) {
+		$this->config->method('getSystemValue')
+			->with('encryption_skip_signature_check', false)
+			->willReturn(true);
 		$this->assertSame($expected,
 			$this->invokePrivate($this->crypt, 'hasSignature', [$data, 'AES-256-CFB'])
 		);
@@ -385,6 +391,10 @@ class CryptTest extends TestCase {
 	 * @dataProvider dataTestDecryptPrivateKey
 	 */
 	public function testDecryptPrivateKey($header, $privateKey, $expectedCipher, $isValidKey, $expected) {
+		$this->config->method('getSystemValueBool')
+			->with('encryption.legacy_format_support', false)
+			->willReturn(true);
+
 		/** @var \OCA\Encryption\Crypto\Crypt | \PHPUnit\Framework\MockObject\MockObject $crypt */
 		$crypt = $this->getMockBuilder(Crypt::class)
 			->setConstructorArgs(

--- a/apps/encryption/tests/Settings/AdminTest.php
+++ b/apps/encryption/tests/Settings/AdminTest.php
@@ -74,20 +74,21 @@ class AdminTest extends TestCase {
 
 	public function testGetForm() {
 		$this->config
-			->expects($this->at(0))
 			->method('getAppValue')
-			->with('encryption', 'recoveryAdminEnabled', '0')
-			->willReturn(1);
-		$this->config
-			->expects($this->at(1))
-			->method('getAppValue')
-			->with('encryption', 'encryptHomeStorage', '1')
-			->willReturn(1);
+			->will($this->returnCallback(function ($app, $key, $default) {
+				if ($app === 'encryption' && $key === 'recoveryAdminEnabled' && $default === '0') {
+					return '1';
+				}
+				if ($app === 'encryption' && $key === 'encryptHomeStorage' && $default === '1') {
+					return '1';
+				}
+				return $default;
+			}));
 		$params = [
-			'recoveryEnabled' => 1,
+			'recoveryEnabled' => '1',
 			'initStatus' => '0',
-			'encryptHomeStorage' => false,
-			'masterKeyEnabled' => false
+			'encryptHomeStorage' => true,
+			'masterKeyEnabled' => true
 		];
 		$expected = new TemplateResponse('encryption', 'settings-admin', $params, '');
 		$this->assertEquals($expected, $this->admin->getForm());

--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -54,6 +54,7 @@ return array(
     'OCA\\Settings\\Settings\\Personal\\Security\\TwoFactor' => $baseDir . '/../lib/Settings/Personal/Security/TwoFactor.php',
     'OCA\\Settings\\Settings\\Personal\\Security\\WebAuthn' => $baseDir . '/../lib/Settings/Personal/Security/WebAuthn.php',
     'OCA\\Settings\\Settings\\Personal\\ServerDevNotice' => $baseDir . '/../lib/Settings/Personal/ServerDevNotice.php',
+    'OCA\\Settings\\SetupChecks\\LegacySSEKeyFormat' => $baseDir . '/../lib/SetupChecks/LegacySSEKeyFormat.php',
     'OCA\\Settings\\SetupChecks\\PhpDefaultCharset' => $baseDir . '/../lib/SetupChecks/PhpDefaultCharset.php',
     'OCA\\Settings\\SetupChecks\\PhpOutputBuffering' => $baseDir . '/../lib/SetupChecks/PhpOutputBuffering.php',
 );

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -69,6 +69,7 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\Settings\\Personal\\Security\\TwoFactor' => __DIR__ . '/..' . '/../lib/Settings/Personal/Security/TwoFactor.php',
         'OCA\\Settings\\Settings\\Personal\\Security\\WebAuthn' => __DIR__ . '/..' . '/../lib/Settings/Personal/Security/WebAuthn.php',
         'OCA\\Settings\\Settings\\Personal\\ServerDevNotice' => __DIR__ . '/..' . '/../lib/Settings/Personal/ServerDevNotice.php',
+        'OCA\\Settings\\SetupChecks\\LegacySSEKeyFormat' => __DIR__ . '/..' . '/../lib/SetupChecks/LegacySSEKeyFormat.php',
         'OCA\\Settings\\SetupChecks\\PhpDefaultCharset' => __DIR__ . '/..' . '/../lib/SetupChecks/PhpDefaultCharset.php',
         'OCA\\Settings\\SetupChecks\\PhpOutputBuffering' => __DIR__ . '/..' . '/../lib/SetupChecks/PhpOutputBuffering.php',
     );

--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -53,6 +53,7 @@ use OC\DB\SchemaWrapper;
 use OC\IntegrityCheck\Checker;
 use OC\Lock\NoopLockingProvider;
 use OC\MemoryInfo;
+use OCA\Settings\SetupChecks\LegacySSEKeyFormat;
 use OCA\Settings\SetupChecks\PhpDefaultCharset;
 use OCA\Settings\SetupChecks\PhpOutputBuffering;
 use OCP\AppFramework\Controller;
@@ -687,6 +688,7 @@ Raw output
 	public function check() {
 		$phpDefaultCharset = new PhpDefaultCharset();
 		$phpOutputBuffering = new PhpOutputBuffering();
+		$legacySSEKeyFormat = new LegacySSEKeyFormat($this->l10n, $this->config, $this->urlGenerator);
 		return new DataResponse(
 			[
 				'isGetenvServerWorking' => !empty(getenv('PATH')),
@@ -729,6 +731,7 @@ Raw output
 				'reverseProxyGeneratedURL' => $this->urlGenerator->getAbsoluteURL('index.php'),
 				PhpDefaultCharset::class => ['pass' => $phpDefaultCharset->run(), 'description' => $phpDefaultCharset->description(), 'severity' => $phpDefaultCharset->severity()],
 				PhpOutputBuffering::class => ['pass' => $phpOutputBuffering->run(), 'description' => $phpOutputBuffering->description(), 'severity' => $phpOutputBuffering->severity()],
+				LegacySSEKeyFormat::class => ['pass' => $legacySSEKeyFormat->run(), 'description' => $legacySSEKeyFormat->description(), 'severity' => $legacySSEKeyFormat->severity(), 'linkToDocumentation' => $legacySSEKeyFormat->linkToDocumentation()],
 			]
 		);
 	}

--- a/apps/settings/lib/SetupChecks/LegacySSEKeyFormat.php
+++ b/apps/settings/lib/SetupChecks/LegacySSEKeyFormat.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020 Morris Jobke <hey@morrisjobke.de>
+ *
+ * @author DMorris Jobke <hey@morrisjobke.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Settings\SetupChecks;
+
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+
+class LegacySSEKeyFormat {
+	/** @var IL10N */
+	private $l10n;
+	/** @var IConfig */
+	private $config;
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
+	public function __construct(IL10N $l10n, IConfig $config, IURLGenerator $urlGenerator) {
+		$this->l10n = $l10n;
+		$this->config = $config;
+		$this->urlGenerator = $urlGenerator;
+	}
+
+	public function description(): string {
+		return $this->l10n->t('The old server-side-encryption format is enabled. We recommend disabling this.');
+	}
+
+	public function severity(): string {
+		return 'warning';
+	}
+
+	public function run(): bool {
+		return $this->config->getSystemValueBool('encryption.legacy_format_support', false) === false;
+	}
+
+	public function linkToDocumentation(): string {
+		return $this->urlGenerator->linkToDocs('admin-sse-legacy-format');
+	}
+}

--- a/apps/settings/tests/Controller/CheckSetupControllerTest.php
+++ b/apps/settings/tests/Controller/CheckSetupControllerTest.php
@@ -595,6 +595,7 @@ class CheckSetupControllerTest extends TestCase {
 				'reverseProxyGeneratedURL' => 'https://server/index.php',
 				'OCA\Settings\SetupChecks\PhpDefaultCharset' => ['pass' => true, 'description' => 'PHP configuration option default_charset should be UTF-8', 'severity' => 'warning'],
 				'OCA\Settings\SetupChecks\PhpOutputBuffering' => ['pass' => true, 'description' => 'PHP configuration option output_buffering must be disabled', 'severity' => 'error'],
+				'OCA\Settings\SetupChecks\LegacySSEKeyFormat' => ['pass' => true, 'description' => 'The old server-side-encryption format is enabled. We recommend disabling this.', 'severity' => 'warning', 'linkToDocumentation' => ''],
 			]
 		);
 		$this->assertEquals($expected, $this->checkSetupController->check());

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -490,6 +490,7 @@
 
 					OC.SetupChecks.addGenericSetupCheck(data, 'OCA\\Settings\\SetupChecks\\PhpDefaultCharset', messages)
 					OC.SetupChecks.addGenericSetupCheck(data, 'OCA\\Settings\\SetupChecks\\PhpOutputBuffering', messages)
+					OC.SetupChecks.addGenericSetupCheck(data, 'OCA\\Settings\\SetupChecks\\LegacySSEKeyFormat', messages)
 
 				} else {
 					messages.push({
@@ -509,7 +510,7 @@
 		},
 
 		addGenericSetupCheck: function(data, check, messages) {
-			var setupCheck = data[check] || { pass: true, description: '', severity: 'info'}
+			var setupCheck = data[check] || { pass: true, description: '', severity: 'info', linkToDocumentation: null}
 
 			var type = OC.SetupChecks.MESSAGE_TYPE_INFO
 			if (setupCheck.severity === 'warning') {
@@ -518,9 +519,14 @@
 				type = OC.SetupChecks.MESSAGE_TYPE_ERROR
 			}
 
+			var message = setupCheck.description;
+			if (setupCheck.linkToDocumentation) {
+				message += ' ' + t('core', 'For more details see the <a target="_blank" rel="noreferrer noopener" href="{docLink}">documentation</a>.', {docLink: setupCheck.linkToDocumentation});
+			}
+
 			if (!setupCheck.pass) {
 				messages.push({
-					msg: setupCheck.description,
+					msg: message,
 					type: type,
 				})
 			}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1245,6 +1245,7 @@ return array(
     'OC\\Repair\\NC16\\CleanupCardDAVPhotoCache' => $baseDir . '/lib/private/Repair/NC16/CleanupCardDAVPhotoCache.php',
     'OC\\Repair\\NC16\\ClearCollectionsAccessCache' => $baseDir . '/lib/private/Repair/NC16/ClearCollectionsAccessCache.php',
     'OC\\Repair\\NC18\\ResetGeneratedAvatarFlag' => $baseDir . '/lib/private/Repair/NC18/ResetGeneratedAvatarFlag.php',
+    'OC\\Repair\\NC20\\EncryptionLegacyCipher' => $baseDir . '/lib/private/Repair/NC20/EncryptionLegacyCipher.php',
     'OC\\Repair\\OldGroupMembershipShares' => $baseDir . '/lib/private/Repair/OldGroupMembershipShares.php',
     'OC\\Repair\\Owncloud\\DropAccountTermsTable' => $baseDir . '/lib/private/Repair/Owncloud/DropAccountTermsTable.php',
     'OC\\Repair\\Owncloud\\SaveAccountsTableData' => $baseDir . '/lib/private/Repair/Owncloud/SaveAccountsTableData.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1274,6 +1274,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Repair\\NC16\\CleanupCardDAVPhotoCache' => __DIR__ . '/../../..' . '/lib/private/Repair/NC16/CleanupCardDAVPhotoCache.php',
         'OC\\Repair\\NC16\\ClearCollectionsAccessCache' => __DIR__ . '/../../..' . '/lib/private/Repair/NC16/ClearCollectionsAccessCache.php',
         'OC\\Repair\\NC18\\ResetGeneratedAvatarFlag' => __DIR__ . '/../../..' . '/lib/private/Repair/NC18/ResetGeneratedAvatarFlag.php',
+        'OC\\Repair\\NC20\\EncryptionLegacyCipher' => __DIR__ . '/../../..' . '/lib/private/Repair/NC20/EncryptionLegacyCipher.php',
         'OC\\Repair\\OldGroupMembershipShares' => __DIR__ . '/../../..' . '/lib/private/Repair/OldGroupMembershipShares.php',
         'OC\\Repair\\Owncloud\\DropAccountTermsTable' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/DropAccountTermsTable.php',
         'OC\\Repair\\Owncloud\\SaveAccountsTableData' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/SaveAccountsTableData.php',

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -818,6 +818,7 @@ class Encryption extends Wrapper {
 		$fileSize = $this->filesize($path);
 		$stat['size'] = $fileSize;
 		$stat[7] = $fileSize;
+		$stat['hasHeader'] = $this->getHeaderSize($path) > 0;
 		return $stat;
 	}
 

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -48,6 +48,7 @@ use OC\Repair\NC16\AddClenupLoginFlowV2BackgroundJob;
 use OC\Repair\NC16\CleanupCardDAVPhotoCache;
 use OC\Repair\NC16\ClearCollectionsAccessCache;
 use OC\Repair\NC18\ResetGeneratedAvatarFlag;
+use OC\Repair\NC20\EncryptionLegacyCipher;
 use OC\Repair\OldGroupMembershipShares;
 use OC\Repair\Owncloud\DropAccountTermsTable;
 use OC\Repair\Owncloud\SaveAccountsTableData;
@@ -156,6 +157,7 @@ class Repair implements IOutput {
 			new RemoveLinkShares(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig(), \OC::$server->getGroupManager(), \OC::$server->getNotificationManager(), \OC::$server->query(ITimeFactory::class)),
 			new ClearCollectionsAccessCache(\OC::$server->getConfig(), \OC::$server->query(IManager::class)),
 			\OC::$server->query(ResetGeneratedAvatarFlag::class),
+			\OC::$server->query(EncryptionLegacyCipher::class),
 		];
 	}
 

--- a/lib/private/Repair/NC20/EncryptionLegacyCipher.php
+++ b/lib/private/Repair/NC20/EncryptionLegacyCipher.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Repair\NC20;
+
+use OCP\Encryption\IManager;
+use OCP\IConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class EncryptionLegacyCipher implements IRepairStep {
+
+	/** @var IConfig */
+	private $config;
+	/** @var IManager */
+	private $manager;
+
+	public function __construct(IConfig $config,
+								IManager $manager) {
+		$this->config = $config;
+		$this->manager = $manager;
+	}
+
+	public function getName(): string {
+		return 'Keep legacy encryption enabled';
+	}
+
+	private function shouldRun(): bool {
+		$versionFromBeforeUpdate = $this->config->getSystemValue('version', '0.0.0.0');
+		return version_compare($versionFromBeforeUpdate, '20.0.0.0', '<=');
+	}
+
+	public function run(IOutput $output): void {
+		if ($this->manager->isEnabled()) {
+			if ($this->config->getSystemValue('encryption.legacy_format_support', '') === '') {
+				$this->config->setSystemValue('encryption.legacy_format_support', true);
+			}
+		}
+	}
+}

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [20, 0, 0, 0];
+$OC_Version = [20, 0, 0, 1];
 
 // The human readable string
 $OC_VersionString = '20.0.0 alpha';


### PR DESCRIPTION
Basically a switch (off by default for new installations) to support the legacy format or not.
This should hopefully allow us to kill the old ways at some point.

Future work:
- [ ] Write docs
- [x] Setupcheck that checks for the config.php flag and links to the docs where we explain this a77c891e92
- [x] occ command to scan the files to see if there are any files that use the old format