### PR TITLE
provide event class and typed event to LDAP loaded event; also fixing a logged deprecation message

### DIFF
--- a/apps/user_ldap/composer/composer/autoload_classmap.php
+++ b/apps/user_ldap/composer/composer/autoload_classmap.php
@@ -23,6 +23,8 @@ return array(
     'OCA\\User_LDAP\\ConnectionFactory' => $baseDir . '/../lib/ConnectionFactory.php',
     'OCA\\User_LDAP\\Controller\\ConfigAPIController' => $baseDir . '/../lib/Controller/ConfigAPIController.php',
     'OCA\\User_LDAP\\Controller\\RenewPasswordController' => $baseDir . '/../lib/Controller/RenewPasswordController.php',
+    'OCA\\User_LDAP\\Events\\GroupBackendRegistered' => $baseDir . '/../lib/Events/GroupBackendRegistered.php',
+    'OCA\\User_LDAP\\Events\\UserBackendRegistered' => $baseDir . '/../lib/Events/UserBackendRegistered.php',
     'OCA\\User_LDAP\\Exceptions\\AttributeNotSet' => $baseDir . '/../lib/Exceptions/AttributeNotSet.php',
     'OCA\\User_LDAP\\Exceptions\\ConstraintViolationException' => $baseDir . '/../lib/Exceptions/ConstraintViolationException.php',
     'OCA\\User_LDAP\\Exceptions\\NotOnLDAP' => $baseDir . '/../lib/Exceptions/NotOnLDAP.php',

--- a/apps/user_ldap/composer/composer/autoload_static.php
+++ b/apps/user_ldap/composer/composer/autoload_static.php
@@ -38,6 +38,8 @@ class ComposerStaticInitUser_LDAP
         'OCA\\User_LDAP\\ConnectionFactory' => __DIR__ . '/..' . '/../lib/ConnectionFactory.php',
         'OCA\\User_LDAP\\Controller\\ConfigAPIController' => __DIR__ . '/..' . '/../lib/Controller/ConfigAPIController.php',
         'OCA\\User_LDAP\\Controller\\RenewPasswordController' => __DIR__ . '/..' . '/../lib/Controller/RenewPasswordController.php',
+        'OCA\\User_LDAP\\Events\\GroupBackendRegistered' => __DIR__ . '/..' . '/../lib/Events/GroupBackendRegistered.php',
+        'OCA\\User_LDAP\\Events\\UserBackendRegistered' => __DIR__ . '/..' . '/../lib/Events/UserBackendRegistered.php',
         'OCA\\User_LDAP\\Exceptions\\AttributeNotSet' => __DIR__ . '/..' . '/../lib/Exceptions/AttributeNotSet.php',
         'OCA\\User_LDAP\\Exceptions\\ConstraintViolationException' => __DIR__ . '/..' . '/../lib/Exceptions/ConstraintViolationException.php',
         'OCA\\User_LDAP\\Exceptions\\NotOnLDAP' => __DIR__ . '/..' . '/../lib/Exceptions/NotOnLDAP.php',

--- a/apps/user_ldap/lib/Events/GroupBackendRegistered.php
+++ b/apps/user_ldap/lib/Events/GroupBackendRegistered.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_LDAP\Events;
+
+use OCA\User_LDAP\GroupPluginManager;
+use OCA\User_LDAP\IGroupLDAP;
+use OCP\EventDispatcher\Event;
+
+class GroupBackendRegistered extends Event {
+
+	/** @var GroupPluginManager */
+	private $pluginManager;
+	/** @var IGroupLDAP */
+	private $backend;
+
+	public function __construct(IGroupLDAP $backend, GroupPluginManager $pluginManager) {
+		$this->pluginManager = $pluginManager;
+		$this->backend = $backend;
+	}
+
+	public function getBackend(): IGroupLDAP {
+		return $this->backend;
+	}
+
+	public function getPluginManager(): GroupPluginManager {
+		return $this->pluginManager;
+	}
+}

--- a/apps/user_ldap/lib/Events/UserBackendRegistered.php
+++ b/apps/user_ldap/lib/Events/UserBackendRegistered.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_LDAP\Events;
+
+use OCA\User_LDAP\IUserLDAP;
+use OCA\User_LDAP\UserPluginManager;
+use OCP\EventDispatcher\Event;
+
+class UserBackendRegistered extends Event {
+
+	/** @var IUserLDAP */
+	private $backend;
+	/** @var UserPluginManager */
+	private $pluginManager;
+
+	public function __construct(IUserLDAP $backend, UserPluginManager $pluginManager) {
+		$this->backend = $backend;
+		$this->pluginManager = $pluginManager;
+	}
+
+	public function getBackend(): IUserLDAP {
+		return $this->backend;
+	}
+
+	public function getPluginManager(): UserPluginManager {
+		return $this->pluginManager;
+	}
+}


### PR DESCRIPTION
fixes #19097 

I am not  aware of any current consumers. The event is not very usable as it is fired before most apps are loaded. To keep things stable and avoid surprises nevertheless, this is the safe, backportable approach (code diverted a bit, but no biggy). With 20 and the `IBootstrap` bits from @ChristophWurst it should be a viable approach to subscribe to the typed event.