### PR TITLE
Use user mount with matching path only

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -43,6 +43,7 @@ use OC\Cache\CappedMemoryCache;
 use OC\Files\Mount\MoveableMount;
 use OC\HintException;
 use OC\Share20\Exception\ProviderException;
+use OCA\Files_Sharing\ISharedStorage;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\File;
 use OCP\Files\Folder;
@@ -299,7 +300,9 @@ class Manager implements IManager {
 		$isFederatedShare = $share->getNode()->getStorage()->instanceOfStorage('\OCA\Files_Sharing\External\Storage');
 		$permissions = 0;
 
-		$userMounts = $userFolder->getById($share->getNode()->getId());
+		$userMounts = array_filter($userFolder->getById($share->getNode()->getId()), function($mount) use ($share) {
+			return $mount->getPath() === $share->getNode()->getPath();
+		});
 		$userMount = array_shift($userMounts);
 		$mount = $userMount->getMountPoint();
 		if (!$isFederatedShare && $share->getNode()->getOwner() && $share->getNode()->getOwner()->getUID() !== $share->getSharedBy()) {


### PR DESCRIPTION
Otherwise there might be cases with the user also having access to a file with external storage mounted and the parent shares are not fetched properly since the array_shift will pick the wrong mount.