### PR TITLE
Fix name of app config option to properly reflect what it does

### DIFF
--- a/apps/settings/lib/Hooks.php
+++ b/apps/settings/lib/Hooks.php
@@ -182,7 +182,7 @@ class Hooks {
 			$event->setAuthor($actor->getUID())
 				->setSubject($subject);
 		} else {
-			if ($this->config->getAppValue('settings', 'disable_email.email_address_changed_by_admin', 'no') === 'yes') {
+			if ($this->config->getAppValue('settings', 'disable_activity.email_address_changed_by_admin', 'no') === 'yes') {
 				return;
 			}
 			$text = $l->t('Your email address on %s was changed by an administrator.', [$instanceUrl]);


### PR DESCRIPTION
Ref #22217 - it does not only stop the email but the email and the activity entry.

Already present in the backport #22233 and #22232 