### PR TITLE
Allow writing empty content to new file

### DIFF
--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -188,7 +188,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 			} else {
 				$result = $this->view->touch($fullPath);
 			}
-			if (!$result) {
+			if ($result === false) {
 				throw new NotPermittedException('Could not create path');
 			}
 			$node = new File($this->root, $this->view, $fullPath);


### PR DESCRIPTION
`ISimpleFolder::newFile('file.txt', '')` will fail on master, because `file_put_contents` returns the amount of bytes written, which for `''` is 0. Hence we need a strict false check.

https://github.com/nextcloud/server/blob/ee23906c3c1a283e0fc47627f90f772ef48fb5e7/lib/private/Files/Node/Folder.php#L187