### PR TITLE
Remove deprecated and unused method calls

### DIFF
--- a/apps/files_external/lib/Lib/FrontendDefinitionTrait.php
+++ b/apps/files_external/lib/Lib/FrontendDefinitionTrait.php
@@ -107,16 +107,6 @@ trait FrontendDefinitionTrait {
 	}
 
 	/**
-	 * @param string $custom
-	 * @return self
-	 * @deprecated 9.1.0, use addCustomJs() instead
-	 */
-	public function setCustomJs($custom) {
-		$this->customJs = [$custom];
-		return $this;
-	}
-
-	/**
 	 * Serialize into JSON for client-side JS
 	 *
 	 * @return array

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -311,18 +311,6 @@ class JobList implements IJobList {
 	}
 
 	/**
-	 * get the id of the last ran job
-	 *
-	 * @return int
-	 * @deprecated 9.1.0 - The functionality behind the value is deprecated, it
-	 *    only tells you which job finished last, but since we now allow multiple
-	 *    executors to run in parallel, it's not used to calculate the next job.
-	 */
-	public function getLastJob() {
-		return (int) $this->config->getAppValue('backgroundjob', 'lastjob', 0);
-	}
-
-	/**
 	 * set the lastRun of $job to now
 	 *
 	 * @param IJob $job

--- a/lib/public/BackgroundJob/IJobList.php
+++ b/lib/public/BackgroundJob/IJobList.php
@@ -116,17 +116,6 @@ interface IJobList {
 	public function unlockJob(IJob $job);
 
 	/**
-	 * get the id of the last ran job
-	 *
-	 * @return int
-	 * @since 7.0.0
-	 * @deprecated 9.1.0 - The functionality behind the value is deprecated, it
-	 *    only tells you which job finished last, but since we now allow multiple
-	 *    executors to run in parallel, it's not used to calculate the next job.
-	 */
-	public function getLastJob();
-
-	/**
 	 * set the lastRun of $job to now
 	 *
 	 * @param IJob $job

--- a/tests/lib/BackgroundJob/DummyJobList.php
+++ b/tests/lib/BackgroundJob/DummyJobList.php
@@ -118,15 +118,6 @@ class DummyJobList extends \OC\BackgroundJob\JobList {
 	}
 
 	/**
-	 * get the id of the last ran job
-	 *
-	 * @return int
-	 */
-	public function getLastJob() {
-		return $this->last;
-	}
-
-	/**
 	 * set the lastRun of $job to now
 	 *
 	 * @param IJob $job

--- a/tests/lib/BackgroundJob/JobListTest.php
+++ b/tests/lib/BackgroundJob/JobListTest.php
@@ -146,15 +146,6 @@ class JobListTest extends TestCase {
 		$this->assertFalse($this->instance->has($job, 10));
 	}
 
-	public function testGetLastJob() {
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->with('backgroundjob', 'lastjob', 0)
-			->willReturn(15);
-
-		$this->assertEquals(15, $this->instance->getLastJob());
-	}
-
 	protected function createTempJob($class, $argument, $reservedTime = 0, $lastChecked = 0) {
 		if ($lastChecked === 0) {
 			$lastChecked = time();


### PR DESCRIPTION
Both are deprecated over 3 years ago and aren't used in our app ecosystem.