### PR TITLE
Silence duplicate session warnings

### DIFF
--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -104,7 +104,7 @@ class Internal extends Session {
 	public function clear() {
 		$this->invoke('session_unset');
 		$this->regenerateId();
-		$this->startSession();
+		$this->startSession(true);
 		$_SESSION = [];
 	}
 
@@ -213,11 +213,11 @@ class Internal extends Session {
 		}
 	}
 
-	private function startSession() {
+	private function startSession(bool $silence = false) {
 		if (PHP_VERSION_ID < 70300) {
-			$this->invoke('session_start');
+			$this->invoke('session_start', [], $silence);
 		} else {
-			$this->invoke('session_start', [['cookie_samesite' => 'Lax']]);
+			$this->invoke('session_start', [['cookie_samesite' => 'Lax']], $silence);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #20490
Repalces https://github.com/nextcloud/server/pull/21468

Basically restoring the old behavior.

