### PR TITLE
Improve recent file fetching

### DIFF
--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -505,4 +505,9 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 	public function setMountOptions(array $options) {
 		$this->mountOptions = $options;
 	}
+
+	public function getUnjailedPath($path) {
+		$this->init();
+		return parent::getUnjailedPath($path);
+	}
 }


### PR DESCRIPTION
Fixes #16876

Before we'd just fetch everything from all storages we'd have access to.
Then we'd sort. And filter in php. Now this of course is tricky if a
user shared just a file with you and then has a ton of activity.

Now we try to contruct the prefix path. So that the filtering can happen
right away in the databae.

Now this will make the DB more busy. But it should help overall as in
most cases less queries are needed then etc.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>