### PR TITLE
Update documentation for QueryBuilder::set

### DIFF
--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -694,7 +694,7 @@ class QueryBuilder implements IQueryBuilder {
 	 * </code>
 	 *
 	 * @param string $key The column to set.
-	 * @param string $value The value, expression, placeholder, etc.
+	 * @param IParameter|string $value The value, expression, placeholder, etc.
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -521,7 +521,7 @@ interface IQueryBuilder {
 	 * </code>
 	 *
 	 * @param string $key The column to set.
-	 * @param string $value The value, expression, placeholder, etc.
+	 * @param IParameter|string $value The value, expression, placeholder, etc.
 	 *
 	 * @return $this This QueryBuilder instance.
 	 * @since 8.2.0


### PR DESCRIPTION
Found by Psalm (https://github.com/nextcloud/server/pull/21787)

`Argument 2 of OCP\DB\QueryBuilder\IQueryBuilder::set expects string, OCP\DB\QueryBuilder\IParameter provided with a __toString method`

`quoteColumnName` casts every instance of IParameter to string and almost every time `set` is used together with `createNamedParameter` like `->set('email', $query->createNamedParameter($remote->getEMail()))`.

This basically updates the documentation with the reality ;)