### PR TITLE
Properly add new methods to interface and document in PHPDoc for getR…

### DIFF
--- a/lib/private/Files/Config/MountProviderCollection.php
+++ b/lib/private/Files/Config/MountProviderCollection.php
@@ -207,6 +207,12 @@ class MountProviderCollection implements IMountProviderCollection, Emitter {
 		$this->rootProviders[] = $provider;
 	}
 
+	/**
+	 * Get all root mountpoints
+	 *
+	 * @return \OCP\Files\Mount\IMountPoint[]
+	 * @since 20.0.0
+	 */
 	public function getRootMounts(): array {
 		$loader = $this->loader;
 		$mounts = array_map(function (IRootMountProvider $provider) use ($loader) {

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -299,7 +299,6 @@ class OC_Util {
 
 		/** @var \OCP\Files\Config\IMountProviderCollection $mountProviderCollection */
 		$mountProviderCollection = \OC::$server->query(\OCP\Files\Config\IMountProviderCollection::class);
-		/** @var \OCP\Files\Mount\IMountPoint[] $rootMountProviders */
 		$rootMountProviders = $mountProviderCollection->getRootMounts();
 
 		/** @var \OC\Files\Mount\Manager $mountManager */

--- a/lib/public/Files/Config/IMountProviderCollection.php
+++ b/lib/public/Files/Config/IMountProviderCollection.php
@@ -79,4 +79,12 @@ interface IMountProviderCollection {
 	 * @since 9.0.0
 	 */
 	public function getMountCache();
+
+	/**
+	 * Get all root mountpoints
+	 *
+	 * @return \OCP\Files\Mount\IMountPoint[]
+	 * @since 20.0.0
+	 */
+	public function getRootMounts(): array;
 }

--- a/lib/public/Files/Config/IRootMountProvider.php
+++ b/lib/public/Files/Config/IRootMountProvider.php
@@ -32,7 +32,7 @@ use OCP\Files\Storage\IStorageFactory;
  */
 interface IRootMountProvider {
 	/**
-	 * Get all root mountpoints
+	 * Get all root mountpoints of this provider
 	 *
 	 * @return \OCP\Files\Mount\IMountPoint[]
 	 * @since 20.0.0


### PR DESCRIPTION
…ootMounts()

Introduced in #22063 and was just forgotten.

Found by Psalm in #21578 and avoids to add the typehint in the calling place \o/
