### PR TITLE
Do not try to load non-existing icon

### DIFF
--- a/apps/user_status/appinfo/info.xml
+++ b/apps/user_status/appinfo/info.xml
@@ -18,7 +18,6 @@
             <name>User status</name>
             <route />
             <order>1</order>
-            <icon>info.svg</icon>
             <type>settings</type>
         </navigation>
     </navigations>


### PR DESCRIPTION
Otherwise it always does a request to index.php since the info.svg icon is not available:

> {"GET":{"scheme":"https","host":"nextcloud.local","filename":"/index.php/apps/dashboard/info.svg","query":{"v":"e3cd2014"},"remote":{"Address":"127.0.0.1:443"}}}