### PR TITLE
Use dispatchTyped instead of dispatch on the new event dispatcher

### DIFF
--- a/apps/files_sharing/list.php
+++ b/apps/files_sharing/list.php
@@ -30,7 +30,9 @@ use OCP\EventDispatcher\GenericEvent;
 OCP\User::checkLoggedIn();
 $config = \OC::$server->getConfig();
 $userSession = \OC::$server->getUserSession();
-$eventDispatcher = \OC::$server->getEventDispatcher();
+$legacyEventDispatcher = \OC::$server->getEventDispatcher();
+/** @var \OCP\EventDispatcher\IEventDispatcher $eventDispatcher */
+$eventDispatcher = \OC::$server->get(OCP\EventDispatcher\IEventDispatcher::class);
 
 $showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
 $isIE = \OCP\Util::isIE();
@@ -41,13 +43,13 @@ $tmpl = new OCP\Template('files_sharing', 'list', '');
 $tmpl->assign('showgridview', $showgridview && !$isIE);
 
 // fire script events
-$eventDispatcher->dispatch('\OCP\Collaboration\Resources::loadAdditionalScripts', new GenericEvent());
-$eventDispatcher->dispatch(LoadAdditionalScriptsEvent::class, new LoadAdditionalScriptsEvent());
-$eventDispatcher->dispatch(LoadSidebar::class, new LoadSidebar());
+$legacyEventDispatcher->dispatch('\OCP\Collaboration\Resources::loadAdditionalScripts', new GenericEvent());
+$eventDispatcher->dispatchTyped(new LoadAdditionalScriptsEvent());
+$eventDispatcher->dispatchTyped(new LoadSidebar());
 
 // Load Viewer scripts
 if (class_exists(LoadViewer::class)) {
-	$eventDispatcher->dispatch(LoadViewer::class, new LoadViewer());
+	$eventDispatcher->dispatchTyped(new LoadViewer());
 }
 
 $tmpl->printPage();

--- a/apps/twofactor_backupcodes/lib/Service/BackupCodeStorage.php
+++ b/apps/twofactor_backupcodes/lib/Service/BackupCodeStorage.php
@@ -81,7 +81,7 @@ class BackupCodeStorage {
 			$result[] = $code;
 		}
 
-		$this->eventDispatcher->dispatch(CodesGenerated::class, new CodesGenerated($user));
+		$this->eventDispatcher->dispatchTyped(new CodesGenerated($user));
 
 		return $result;
 	}

--- a/apps/twofactor_backupcodes/tests/Unit/Service/BackupCodeStorageTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Service/BackupCodeStorageTest.php
@@ -82,9 +82,8 @@ class BackupCodeStorageTest extends TestCase {
 			->method('insert')
 			->with($this->equalTo($row));
 		$this->eventDispatcher->expects($this->once())
-			->method('dispatch')
+			->method('dispatchTyped')
 			->with(
-				$this->equalTo(CodesGenerated::class),
 				$this->equalTo(new CodesGenerated($user))
 			);
 

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1947,13 +1947,10 @@
     </UndefinedMethod>
   </file>
   <file src="apps/files_sharing/list.php">
-    <InvalidArgument occurrences="4">
+    <InvalidArgument occurrences="1">
       <code>'\OCP\Collaboration\Resources::loadAdditionalScripts'</code>
-      <code>LoadAdditionalScriptsEvent::class</code>
-      <code>LoadSidebar::class</code>
-      <code>LoadViewer::class</code>
     </InvalidArgument>
-    <TooManyArguments occurrences="4">
+    <TooManyArguments occurrences="1">
       <code>dispatch</code>
       <code>dispatch</code>
       <code>dispatch</code>


### PR DESCRIPTION
This does not change any behavior. It just uses the non-deprecated method and does still the same thing.