### PR TITLE
Cast float/char to int to avoid invalid scalar argument warning

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -6045,9 +6045,7 @@
     <InvalidReturnType occurrences="1">
       <code>bool</code>
     </InvalidReturnType>
-    <InvalidScalarArgument occurrences="19">
-      <code>$bits</code>
-      <code>$lastIndex</code>
+    <InvalidScalarArgument occurrences="17">
       <code>$this-&gt;bitDepth</code>
       <code>90</code>
       <code>$imagePath</code>

--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -1175,7 +1175,7 @@ if (!function_exists('imagebmp')) {
 		} elseif ($bit == 32) {
 			$bit = 24;
 		}
-		$bits = pow(2, $bit);
+		$bits = (int)pow(2, $bit);
 		imagetruecolortopalette($im, true, $bits);
 		$width = imagesx($im);
 		$height = imagesy($im);
@@ -1211,7 +1211,7 @@ if (!function_exists('imagebmp')) {
 			} // RLE8
 			elseif ($compression == 1 && $bit == 8) {
 				for ($j = $height - 1; $j >= 0; $j--) {
-					$lastIndex = "\0";
+					$lastIndex = 0;
 					$sameNum = 0;
 					for ($i = 0; $i <= $width; $i++) {
 						$index = imagecolorat($im, $i, $j);


### PR DESCRIPTION
Found by Psalm.

The `$lastIndex` one is basically the same before and in this way even makes more sense. Other approach would be to wrap the `"\0"` into an `ord()` to get the `0` from that.


```
PHP Warning:  chr() expects parameter 1 to be int, string given in php shell code on line 1
```