### PR TITLE
Cast float to int to avoid invalid scalar argument warning

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -4836,11 +4836,6 @@
     </InvalidReturnType>
   </file>
   <file src="lib/private/Files/Stream/Encryption.php">
-    <InvalidScalarArgument occurrences="3">
-      <code>$newFilePosition</code>
-      <code>$newFilePosition</code>
-      <code>$position</code>
-    </InvalidScalarArgument>
     <UndefinedInterfaceMethod occurrences="1">
       <code>$cacheEntry</code>
     </UndefinedInterfaceMethod>

--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -416,7 +416,7 @@ class Encryption extends Wrapper {
 			return $return;
 		}
 
-		$newFilePosition = floor($newPosition / $this->unencryptedBlockSize)
+		$newFilePosition = (int)floor($newPosition / $this->unencryptedBlockSize)
 			* $this->util->getBlockSize() + $this->headerSize;
 
 		$oldFilePosition = parent::stream_tell();


### PR DESCRIPTION
Found by Psalm and makes sense to just cast it explicitly.