### PR TITLE
Use matching parameter names form interfaces and implementations

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -19,7 +19,7 @@ jobs:
             - name: Psalm
               uses: docker://jakzal/phpqa:php7.4-alpine
               with:
-                args: psalm --monochrome --no-progress --output-format=text --update-baseline
+                args: psalm --monochrome --no-progress --output-format=text --update-baseline || ( git diff && exit 1 )
             - name: Check for changes in Psalm baseline
               run: |
-                bash -c "[[ ! \"`git status --porcelain build/psalm-baseline.xml`\" ]] || ( echo 'Uncommited changes in Psalm baseline' && git status && git diff && exit 1 )"
+                bash -c "[[ ! \"`git status --porcelain build/psalm-baseline.xml`\" ]] || ( echo 'Uncommited changes in Psalm baseline' && git status && git diff build/psalm-baseline.xml && exit 1 )"

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -905,15 +905,15 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 * used/fetched to determine these numbers. If both are specified the
 	 * amount of times this is needed is reduced by a great degree.
 	 *
-	 * @param mixed $id
+	 * @param mixed $calendarId
 	 * @param int $calendarType
 	 * @return array
 	 */
-	public function getCalendarObjects($id, $calendarType=self::CALENDAR_TYPE_CALENDAR):array {
+	public function getCalendarObjects($calendarId, $calendarType=self::CALENDAR_TYPE_CALENDAR):array {
 		$query = $this->db->getQueryBuilder();
 		$query->select(['id', 'uri', 'lastmodified', 'etag', 'calendarid', 'size', 'componenttype', 'classification'])
 			->from('calendarobjects')
-			->where($query->expr()->eq('calendarid', $query->createNamedParameter($id)))
+			->where($query->expr()->eq('calendarid', $query->createNamedParameter($calendarId)))
 			->andWhere($query->expr()->eq('calendartype', $query->createNamedParameter($calendarType)));
 		$stmt = $query->execute();
 
@@ -946,16 +946,16 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 *
 	 * This method must return null if the object did not exist.
 	 *
-	 * @param mixed $id
+	 * @param mixed $calendarId
 	 * @param string $objectUri
 	 * @param int $calendarType
 	 * @return array|null
 	 */
-	public function getCalendarObject($id, $objectUri, $calendarType=self::CALENDAR_TYPE_CALENDAR) {
+	public function getCalendarObject($calendarId, $objectUri, $calendarType=self::CALENDAR_TYPE_CALENDAR) {
 		$query = $this->db->getQueryBuilder();
 		$query->select(['id', 'uri', 'lastmodified', 'etag', 'calendarid', 'size', 'calendardata', 'componenttype', 'classification'])
 			->from('calendarobjects')
-			->where($query->expr()->eq('calendarid', $query->createNamedParameter($id)))
+			->where($query->expr()->eq('calendarid', $query->createNamedParameter($calendarId)))
 			->andWhere($query->expr()->eq('uri', $query->createNamedParameter($objectUri)))
 			->andWhere($query->expr()->eq('calendartype', $query->createNamedParameter($calendarType)));
 		$stmt = $query->execute();
@@ -991,7 +991,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 * @param int $calendarType
 	 * @return array
 	 */
-	public function getMultipleCalendarObjects($id, array $uris, $calendarType=self::CALENDAR_TYPE_CALENDAR):array {
+	public function getMultipleCalendarObjects($calendarId, array $uris, $calendarType=self::CALENDAR_TYPE_CALENDAR):array {
 		if (empty($uris)) {
 			return [];
 		}
@@ -1002,7 +1002,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$query = $this->db->getQueryBuilder();
 		$query->select(['id', 'uri', 'lastmodified', 'etag', 'calendarid', 'size', 'calendardata', 'componenttype', 'classification'])
 			->from('calendarobjects')
-			->where($query->expr()->eq('calendarid', $query->createNamedParameter($id)))
+			->where($query->expr()->eq('calendarid', $query->createNamedParameter($calendarId)))
 			->andWhere($query->expr()->in('uri', $query->createParameter('uri')))
 			->andWhere($query->expr()->eq('calendartype', $query->createNamedParameter($calendarType)));
 
@@ -1288,12 +1288,12 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 * as possible, so it gives you a good idea on what type of stuff you need
 	 * to think of.
 	 *
-	 * @param mixed $id
+	 * @param mixed $calendarId
 	 * @param array $filters
 	 * @param int $calendarType
 	 * @return array
 	 */
-	public function calendarQuery($id, array $filters, $calendarType=self::CALENDAR_TYPE_CALENDAR):array {
+	public function calendarQuery($calendarId, array $filters, $calendarType=self::CALENDAR_TYPE_CALENDAR):array {
 		$componentType = null;
 		$requirePostFilter = true;
 		$timeRange = null;
@@ -1329,7 +1329,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$query = $this->db->getQueryBuilder();
 		$query->select($columns)
 			->from('calendarobjects')
-			->where($query->expr()->eq('calendarid', $query->createNamedParameter($id)))
+			->where($query->expr()->eq('calendarid', $query->createNamedParameter($calendarId)))
 			->andWhere($query->expr()->eq('calendartype', $query->createNamedParameter($calendarType)));
 
 		if ($componentType) {
@@ -1355,13 +1355,13 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 				} catch (ParseException $ex) {
 					$this->logger->logException($ex, [
 						'app' => 'dav',
-						'message' => 'Caught parsing exception for calendar data. This usually indicates invalid calendar data. calendar-id:'.$id.' uri:'.$row['uri']
+						'message' => 'Caught parsing exception for calendar data. This usually indicates invalid calendar data. calendar-id:'.$calendarId.' uri:'.$row['uri']
 					]);
 					continue;
 				} catch (InvalidDataException $ex) {
 					$this->logger->logException($ex, [
 						'app' => 'dav',
-						'message' => 'Caught invalid data exception for calendar data. This usually indicates invalid calendar data. calendar-id:'.$id.' uri:'.$row['uri']
+						'message' => 'Caught invalid data exception for calendar data. This usually indicates invalid calendar data. calendar-id:'.$calendarId.' uri:'.$row['uri']
 					]);
 					continue;
 				}

--- a/apps/dav/lib/Connector/Sabre/ObjectTree.php
+++ b/apps/dav/lib/Connector/Sabre/ObjectTree.php
@@ -189,8 +189,8 @@ class ObjectTree extends CachingTree {
 	 * This method must work recursively and delete the destination
 	 * if it exists
 	 *
-	 * @param string $source
-	 * @param string $destination
+	 * @param string $sourcePath
+	 * @param string $destinationPath
 	 * @throws FileLocked
 	 * @throws Forbidden
 	 * @throws InvalidPath
@@ -201,14 +201,14 @@ class ObjectTree extends CachingTree {
 	 * @throws \Sabre\DAV\Exception\ServiceUnavailable
 	 * @return void
 	 */
-	public function copy($source, $destination) {
+	public function copy($sourcePath, $destinationPath) {
 		if (!$this->fileView) {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable('filesystem not setup');
 		}
 
 
-		$info = $this->fileView->getFileInfo(dirname($destination));
-		if ($this->fileView->file_exists($destination)) {
+		$info = $this->fileView->getFileInfo(dirname($destinationPath));
+		if ($this->fileView->file_exists($destinationPath)) {
 			$destinationPermission = $info && $info->isUpdateable();
 		} else {
 			$destinationPermission = $info && $info->isCreatable();
@@ -218,9 +218,9 @@ class ObjectTree extends CachingTree {
 		}
 
 		// this will trigger existence check
-		$this->getNodeForPath($source);
+		$this->getNodeForPath($sourcePath);
 
-		list($destinationDir, $destinationName) = \Sabre\Uri\split($destination);
+		list($destinationDir, $destinationName) = \Sabre\Uri\split($destinationPath);
 		try {
 			$this->fileView->verifyPath($destinationDir, $destinationName);
 		} catch (\OCP\Files\InvalidPathException $ex) {
@@ -228,7 +228,7 @@ class ObjectTree extends CachingTree {
 		}
 
 		try {
-			$this->fileView->copy($source, $destination);
+			$this->fileView->copy($sourcePath, $destinationPath);
 		} catch (StorageNotAvailableException $e) {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
 		} catch (ForbiddenException $ex) {
@@ -237,7 +237,7 @@ class ObjectTree extends CachingTree {
 			throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 		}
 
-		list($destinationDir,) = \Sabre\Uri\split($destination);
+		list($destinationDir,) = \Sabre\Uri\split($destinationPath);
 		$this->markDirty($destinationDir);
 	}
 }

--- a/apps/dav/lib/SystemTag/SystemTagsObjectMappingCollection.php
+++ b/apps/dav/lib/SystemTag/SystemTagsObjectMappingCollection.php
@@ -93,7 +93,8 @@ class SystemTagsObjectMappingCollection implements ICollection {
 		$this->user = $user;
 	}
 
-	public function createFile($tagId, $data = null) {
+	public function createFile($name, $data = null) {
+		$tagId = $name;
 		try {
 			$tags = $this->tagManager->getTagsByIds([$tagId]);
 			$tag = current($tags);

--- a/apps/files_external/lib/Lib/Auth/Password/UserProvided.php
+++ b/apps/files_external/lib/Lib/Auth/Password/UserProvided.php
@@ -64,8 +64,8 @@ class UserProvided extends AuthMechanism implements IUserProvided {
 		return self::CREDENTIALS_IDENTIFIER_PREFIX . $storageId;
 	}
 
-	public function saveBackendOptions(IUser $user, $id, array $options) {
-		$this->credentialsManager->store($user->getUID(), $this->getCredentialsIdentifier($id), [
+	public function saveBackendOptions(IUser $user, $mountId, array $options) {
+		$this->credentialsManager->store($user->getUID(), $this->getCredentialsIdentifier($mountId), [
 			'user' => $options['user'], // explicitly copy the fields we want instead of just passing the entire $options array
 			'password' => $options['password'] // this way we prevent users from being able to modify any other field
 		]);

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -530,7 +530,7 @@ class SMB extends Common implements INotifyStorage {
 		}
 	}
 
-	public function touch($path, $time = null) {
+	public function touch($path, $mtime = null) {
 		try {
 			if (!$this->file_exists($path)) {
 				$fh = $this->share->write($this->buildPath($path));

--- a/apps/files_external/lib/Migration/DummyUserSession.php
+++ b/apps/files_external/lib/Migration/DummyUserSession.php
@@ -34,7 +34,7 @@ class DummyUserSession implements IUserSession {
 	 */
 	private $user;
 
-	public function login($user, $password) {
+	public function login($uid, $password) {
 	}
 
 	public function logout() {

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -71,10 +71,10 @@ class MountProvider implements IMountProvider {
 	 * Get all mountpoints applicable for the user and check for shares where we need to update the etags
 	 *
 	 * @param \OCP\IUser $user
-	 * @param \OCP\Files\Storage\IStorageFactory $storageFactory
+	 * @param \OCP\Files\Storage\IStorageFactory $loader
 	 * @return \OCP\Files\Mount\IMountPoint[]
 	 */
-	public function getMountsForUser(IUser $user, IStorageFactory $storageFactory) {
+	public function getMountsForUser(IUser $user, IStorageFactory $loader) {
 		$shares = $this->shareManager->getSharedWith($user->getUID(), IShare::TYPE_USER, null, -1);
 		$shares = array_merge($shares, $this->shareManager->getSharedWith($user->getUID(), IShare::TYPE_GROUP, null, -1));
 		$shares = array_merge($shares, $this->shareManager->getSharedWith($user->getUID(), IShare::TYPE_CIRCLE, null, -1));
@@ -120,7 +120,7 @@ class MountProvider implements IMountProvider {
 						'ownerView' => $ownerViews[$owner],
 						'sharingDisabledForUser' => $sharingDisabledForUser
 					],
-					$storageFactory,
+					$loader,
 					$view,
 					$foldersExistCache
 				);

--- a/apps/files_sharing/lib/ShareBackend/File.php
+++ b/apps/files_sharing/lib/ShareBackend/File.php
@@ -89,14 +89,15 @@ class File implements \OCP\Share_Backend_File_Dependent {
 
 	/**
 	 * create unique target
-	 * @param string $filePath
+	 *
+	 * @param string $itemSource
 	 * @param string $shareWith
 	 * @param array $exclude (optional)
 	 * @return string
 	 */
-	public function generateTarget($filePath, $shareWith, $exclude = null) {
+	public function generateTarget($itemSource, $shareWith, $exclude = null) {
 		$shareFolder = \OCA\Files_Sharing\Helper::getShareFolder();
-		$target = \OC\Files\Filesystem::normalizePath($shareFolder . '/' . basename($filePath));
+		$target = \OC\Files\Filesystem::normalizePath($shareFolder . '/' . basename($itemSource));
 
 		// for group shares we return the target right away
 		if ($shareWith === false) {

--- a/apps/user_ldap/lib/Group_Proxy.php
+++ b/apps/user_ldap/lib/Group_Proxy.php
@@ -53,12 +53,13 @@ class Group_Proxy extends Proxy implements \OCP\GroupInterface, IGroupLDAP, IGet
 	/**
 	 * Tries the backends one after the other until a positive result is returned from the specified method
 	 *
-	 * @param string $gid the gid connected to the request
+	 * @param string $id the gid connected to the request
 	 * @param string $method the method of the group backend that shall be called
 	 * @param array $parameters an array of parameters to be passed
-	 * @return mixed, the result of the method or false
+	 * @return mixed the result of the method or false
 	 */
-	protected function walkBackends($gid, $method, $parameters) {
+	protected function walkBackends($id, $method, $parameters) {
+		$gid = $id;
 		$cacheKey = $this->getGroupCacheKey($gid);
 		foreach ($this->backends as $configPrefix => $backend) {
 			if ($result = call_user_func_array([$backend, $method], $parameters)) {
@@ -74,13 +75,14 @@ class Group_Proxy extends Proxy implements \OCP\GroupInterface, IGroupLDAP, IGet
 	/**
 	 * Asks the backend connected to the server that supposely takes care of the gid from the request.
 	 *
-	 * @param string $gid the gid connected to the request
+	 * @param string $id the gid connected to the request
 	 * @param string $method the method of the group backend that shall be called
 	 * @param array $parameters an array of parameters to be passed
 	 * @param mixed $passOnWhen the result matches this variable
-	 * @return mixed, the result of the method or false
+	 * @return mixed the result of the method or false
 	 */
-	protected function callOnLastSeenOn($gid, $method, $parameters, $passOnWhen) {
+	protected function callOnLastSeenOn($id, $method, $parameters, $passOnWhen) {
+		$gid = $id;
 		$cacheKey = $this->getGroupCacheKey($gid);
 		$prefix = $this->getFromCache($cacheKey);
 		//in case the uid has been found in the past, try this stored connection first

--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -73,12 +73,13 @@ class User_Proxy extends Proxy implements \OCP\IUserBackend, \OCP\UserInterface,
 	/**
 	 * Tries the backends one after the other until a positive result is returned from the specified method
 	 *
-	 * @param string $uid the uid connected to the request
+	 * @param string $id the uid connected to the request
 	 * @param string $method the method of the user backend that shall be called
 	 * @param array $parameters an array of parameters to be passed
 	 * @return mixed the result of the method or false
 	 */
-	protected function walkBackends($uid, $method, $parameters) {
+	protected function walkBackends($id, $method, $parameters) {
+		$uid = $id;
 		$cacheKey = $this->getUserCacheKey($uid);
 		foreach ($this->backends as $configPrefix => $backend) {
 			$instance = $backend;
@@ -99,13 +100,14 @@ class User_Proxy extends Proxy implements \OCP\IUserBackend, \OCP\UserInterface,
 	/**
 	 * Asks the backend connected to the server that supposely takes care of the uid from the request.
 	 *
-	 * @param string $uid the uid connected to the request
+	 * @param string $id the uid connected to the request
 	 * @param string $method the method of the user backend that shall be called
 	 * @param array $parameters an array of parameters to be passed
 	 * @param mixed $passOnWhen the result matches this variable
 	 * @return mixed the result of the method or false
 	 */
-	protected function callOnLastSeenOn($uid, $method, $parameters, $passOnWhen) {
+	protected function callOnLastSeenOn($id, $method, $parameters, $passOnWhen) {
+		$uid = $id;
 		$cacheKey = $this->getUserCacheKey($uid);
 		$prefix = $this->getFromCache($cacheKey);
 		//in case the uid has been found in the past, try this stored connection first

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.13.1@afd8874a9e4562eac42a02de90e42e430c3a1db1">
+<files psalm-version="3.14.1@9822043ca46d6682b76097bfa97d7c450eef9e90">
   <file src="3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Connection.php">
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>string|null</code>
@@ -196,6 +196,9 @@
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$calendarData</code>
     </MoreSpecificImplementedParamType>
+    <ParamNameMismatch occurrences="1">
+      <code>$calendarData</code>
+    </ParamNameMismatch>
   </file>
   <file src="apps/dav/lib/CalDAV/CachedSubscriptionObject.php">
     <ImplementedReturnTypeMismatch occurrences="1">
@@ -677,6 +680,9 @@
       <code>null</code>
       <code>null</code>
     </NullArgument>
+    <ParamNameMismatch occurrences="1">
+      <code>$fullSourcePath</code>
+    </ParamNameMismatch>
     <UndefinedFunction occurrences="1">
       <code>\Sabre\Uri\split($sourceNode-&gt;getPath())</code>
     </UndefinedFunction>
@@ -749,8 +755,8 @@
   <file src="apps/dav/lib/Connector/Sabre/ObjectTree.php">
     <UndefinedFunction occurrences="3">
       <code>\Sabre\Uri\split($path)</code>
-      <code>\Sabre\Uri\split($destination)</code>
-      <code>\Sabre\Uri\split($destination)</code>
+      <code>\Sabre\Uri\split($destinationPath)</code>
+      <code>\Sabre\Uri\split($destinationPath)</code>
     </UndefinedFunction>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/Principal.php">
@@ -1537,6 +1543,10 @@
     <InternalMethod occurrences="1">
       <code>put</code>
     </InternalMethod>
+    <ParamNameMismatch occurrences="2">
+      <code>$source</code>
+      <code>$target</code>
+    </ParamNameMismatch>
   </file>
   <file src="apps/files_external/lib/Lib/Storage/SFTPReadStream.php">
     <FalsableReturnStatement occurrences="2">
@@ -1611,6 +1621,10 @@
     <NullableReturnStatement occurrences="1">
       <code>null</code>
     </NullableReturnStatement>
+    <ParamNameMismatch occurrences="2">
+      <code>$source</code>
+      <code>$target</code>
+    </ParamNameMismatch>
     <TooManyArguments occurrences="2">
       <code>rename</code>
       <code>rename</code>
@@ -1848,9 +1862,6 @@
     <InvalidReturnType occurrences="1">
       <code>isSharable</code>
     </InvalidReturnType>
-    <NullArgument occurrences="1">
-      <code>$response['{http://open-collaboration-services.org/ns}share-permissions']</code>
-    </NullArgument>
   </file>
   <file src="apps/files_sharing/lib/Listener/LegacyBeforeTemplateRenderedListener.php">
     <InvalidArgument occurrences="1">
@@ -2561,12 +2572,6 @@
     <TypeDoesNotContainType occurrences="1">
       <code>is_array($members)</code>
     </TypeDoesNotContainType>
-  </file>
-  <file src="apps/user_ldap/lib/Group_Proxy.php">
-    <InvalidDocblock occurrences="2">
-      <code>protected function walkBackends($gid, $method, $parameters) {</code>
-      <code>protected function callOnLastSeenOn($gid, $method, $parameters, $passOnWhen) {</code>
-    </InvalidDocblock>
   </file>
   <file src="apps/user_ldap/lib/Helper.php">
     <InvalidScalarArgument occurrences="1">
@@ -3777,6 +3782,9 @@
     <InvalidScalarArgument occurrences="1">
       <code>$e-&gt;getCode()</code>
     </InvalidScalarArgument>
+    <ParamNameMismatch occurrences="1">
+      <code>$statement</code>
+    </ParamNameMismatch>
   </file>
   <file src="lib/private/DB/ConnectionFactory.php">
     <InternalClass occurrences="1">
@@ -3968,6 +3976,9 @@
     <InvalidArgument occurrences="1">
       <code>$eventName</code>
     </InvalidArgument>
+    <ParamNameMismatch occurrences="1">
+      <code>$eventName</code>
+    </ParamNameMismatch>
     <TooManyArguments occurrences="1">
       <code>dispatch</code>
     </TooManyArguments>
@@ -4410,14 +4421,15 @@
     </ImplementedReturnTypeMismatch>
   </file>
   <file src="lib/private/Files/ObjectStore/NoopScanner.php">
-    <ImplementedParamTypeMismatch occurrences="1">
-      <code>$folderData</code>
-    </ImplementedParamTypeMismatch>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$cacheData</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="lib/private/Files/ObjectStore/ObjectStoreStorage.php">
+    <ParamNameMismatch occurrences="2">
+      <code>$source</code>
+      <code>$target</code>
+    </ParamNameMismatch>
     <UndefinedInterfaceMethod occurrences="4">
       <code>$child</code>
       <code>$child</code>
@@ -4590,6 +4602,12 @@
     <InvalidReturnType occurrences="1">
       <code>filemtime</code>
     </InvalidReturnType>
+    <ParamNameMismatch occurrences="4">
+      <code>$source</code>
+      <code>$target</code>
+      <code>$source</code>
+      <code>$target</code>
+    </ParamNameMismatch>
   </file>
   <file src="lib/private/Files/Storage/Local.php">
     <ImplicitToStringCast occurrences="1">
@@ -4794,6 +4812,10 @@
     <InvalidScalarArgument occurrences="1">
       <code>'ext'</code>
     </InvalidScalarArgument>
+    <ParamNameMismatch occurrences="2">
+      <code>$source</code>
+      <code>$target</code>
+    </ParamNameMismatch>
     <UndefinedInterfaceMethod occurrences="1">
       <code>$data</code>
     </UndefinedInterfaceMethod>
@@ -5980,6 +6002,7 @@
     </UndefinedDocblockClass>
   </file>
   <file src="lib/private/legacy/OC_Files.php">
+    <EmptyArrayAccess occurrences="2"/>
     <InvalidArgument occurrences="3">
       <code>$fileInfos</code>
       <code>[$fileInfo]</code>

--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -123,10 +123,10 @@ class ListApps extends Base {
 
 	/**
 	 * @param string $optionName
-	 * @param CompletionContext $completionContext
+	 * @param CompletionContext $context
 	 * @return array
 	 */
-	public function completeOptionValues($optionName, CompletionContext $completionContext) {
+	public function completeOptionValues($optionName, CompletionContext $context) {
 		if ($optionName === 'shipped') {
 			return ['true', 'false'];
 		}

--- a/lib/private/Authentication/Token/IProvider.php
+++ b/lib/private/Authentication/Token/IProvider.php
@@ -140,13 +140,13 @@ interface IProvider {
 	/**
 	 * Get the (unencrypted) password of the given token
 	 *
-	 * @param IToken $token
+	 * @param IToken $savedToken
 	 * @param string $tokenId
 	 * @throws InvalidTokenException
 	 * @throws PasswordlessTokenException
 	 * @return string
 	 */
-	public function getPassword(IToken $token, string $tokenId): string;
+	public function getPassword(IToken $savedToken, string $tokenId): string;
 
 	/**
 	 * Encrypt and set the password of the given token

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -227,20 +227,20 @@ class PublicKeyTokenProvider implements IProvider {
 		return $this->mapper->getTokenByUser($uid);
 	}
 
-	public function getPassword(IToken $token, string $tokenId): string {
-		if (!($token instanceof PublicKeyToken)) {
+	public function getPassword(IToken $savedToken, string $tokenId): string {
+		if (!($savedToken instanceof PublicKeyToken)) {
 			throw new InvalidTokenException("Invalid token type");
 		}
 
-		if ($token->getPassword() === null) {
+		if ($savedToken->getPassword() === null) {
 			throw new PasswordlessTokenException();
 		}
 
 		// Decrypt private key with tokenId
-		$privateKey = $this->decrypt($token->getPrivateKey(), $tokenId);
+		$privateKey = $this->decrypt($savedToken->getPrivateKey(), $tokenId);
 
 		// Decrypt password with private key
-		return $this->decryptPassword($token->getPassword(), $privateKey);
+		return $this->decryptPassword($savedToken->getPassword(), $privateKey);
 	}
 
 	public function setPassword(IToken $token, string $tokenId, string $password) {

--- a/lib/private/ContactsManager.php
+++ b/lib/private/ContactsManager.php
@@ -69,11 +69,11 @@ class ContactsManager implements IManager {
 	 * This function can be used to delete the contact identified by the given id
 	 *
 	 * @param object $id the unique identifier to a contact
-	 * @param string $addressBookKey identifier of the address book in which the contact shall be deleted
+	 * @param string $address_book_key identifier of the address book in which the contact shall be deleted
 	 * @return bool successful or not
 	 */
-	public function delete($id, $addressBookKey) {
-		$addressBook = $this->getAddressBook($addressBookKey);
+	public function delete($id, $address_book_key) {
+		$addressBook = $this->getAddressBook($address_book_key);
 		if (!$addressBook) {
 			return null;
 		}
@@ -90,11 +90,11 @@ class ContactsManager implements IManager {
 	 * Otherwise the contact will be updated by replacing the entire data set.
 	 *
 	 * @param array $properties this array if key-value-pairs defines a contact
-	 * @param string $addressBookKey identifier of the address book in which the contact shall be created or updated
+	 * @param string $address_book_key identifier of the address book in which the contact shall be created or updated
 	 * @return array representing the contact just created or updated
 	 */
-	public function createOrUpdate($properties, $addressBookKey) {
-		$addressBook = $this->getAddressBook($addressBookKey);
+	public function createOrUpdate($properties, $address_book_key) {
+		$addressBook = $this->getAddressBook($address_book_key);
 		if (!$addressBook) {
 			return null;
 		}

--- a/lib/private/DB/OracleConnection.php
+++ b/lib/private/DB/OracleConnection.php
@@ -47,24 +47,24 @@ class OracleConnection extends Connection {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function insert($tableName, array $data, array $types = []) {
-		if ($tableName[0] !== $this->getDatabasePlatform()->getIdentifierQuoteCharacter()) {
-			$tableName = $this->quoteIdentifier($tableName);
+	public function insert($tableExpression, array $data, array $types = []) {
+		if ($tableExpression[0] !== $this->getDatabasePlatform()->getIdentifierQuoteCharacter()) {
+			$tableExpression = $this->quoteIdentifier($tableExpression);
 		}
 		$data = $this->quoteKeys($data);
-		return parent::insert($tableName, $data, $types);
+		return parent::insert($tableExpression, $data, $types);
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function update($tableName, array $data, array $identifier, array $types = []) {
-		if ($tableName[0] !== $this->getDatabasePlatform()->getIdentifierQuoteCharacter()) {
-			$tableName = $this->quoteIdentifier($tableName);
+	public function update($tableExpression, array $data, array $identifier, array $types = []) {
+		if ($tableExpression[0] !== $this->getDatabasePlatform()->getIdentifierQuoteCharacter()) {
+			$tableExpression = $this->quoteIdentifier($tableExpression);
 		}
 		$data = $this->quoteKeys($data);
 		$identifier = $this->quoteKeys($identifier);
-		return parent::update($tableName, $data, $identifier, $types);
+		return parent::update($tableExpression, $data, $identifier, $types);
 	}
 
 	/**

--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -254,9 +254,9 @@ class CacheJail extends CacheWrapper {
 	 * @param string|boolean $path
 	 * @param array $data (optional) meta data of the folder
 	 */
-	public function correctFolderSize($path, $data = null, $isBackgroundSize = false) {
+	public function correctFolderSize($path, $data = null, $isBackgroundScan = false) {
 		if ($this->getCache() instanceof Cache) {
-			$this->getCache()->correctFolderSize($this->getSourcePath($path), $data, $isBackgroundSize);
+			$this->getCache()->correctFolderSize($this->getSourcePath($path), $data, $isBackgroundScan);
 		}
 	}
 

--- a/lib/private/Files/ObjectStore/NoopScanner.php
+++ b/lib/private/Files/ObjectStore/NoopScanner.php
@@ -69,7 +69,7 @@ class NoopScanner extends Scanner {
 	 * @param array $folderData existing cache data for the folder to be scanned
 	 * @return int the size of the scanned folder or -1 if the size is unknown at this stage
 	 */
-	protected function scanChildren($path, $recursive = self::SCAN_RECURSIVE, $reuse = -1, $folderData = null, $lock = true) {
+	protected function scanChildren($path, $recursive = self::SCAN_RECURSIVE, $reuse = -1, $folderId = null, $lock = true) {
 		return 0;
 	}
 

--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -230,7 +230,7 @@ class SystemTagManager implements ISystemTagManager {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function updateTag(string $tagId, string $tagName, bool $userVisible, bool $userAssignable) {
+	public function updateTag(string $tagId, string $newName, bool $userVisible, bool $userAssignable) {
 		try {
 			$tags = $this->getTagsByIds($tagId);
 		} catch (TagNotFoundException $e) {
@@ -242,7 +242,7 @@ class SystemTagManager implements ISystemTagManager {
 		$beforeUpdate = array_shift($tags);
 		$afterUpdate = new SystemTag(
 			$tagId,
-			$tagName,
+			$newName,
 			$userVisible,
 			$userAssignable
 		);
@@ -253,7 +253,7 @@ class SystemTagManager implements ISystemTagManager {
 			->set('visibility', $query->createParameter('visibility'))
 			->set('editable', $query->createParameter('editable'))
 			->where($query->expr()->eq('id', $query->createParameter('tagid')))
-			->setParameter('name', $tagName)
+			->setParameter('name', $newName)
 			->setParameter('visibility', $userVisible ? 1 : 0)
 			->setParameter('editable', $userAssignable ? 1 : 0)
 			->setParameter('tagid', $tagId);
@@ -266,7 +266,7 @@ class SystemTagManager implements ISystemTagManager {
 			}
 		} catch (UniqueConstraintViolationException $e) {
 			throw new TagAlreadyExistsException(
-				'Tag ("' . $tagName . '", '. $userVisible . ', ' . $userAssignable . ') already exists',
+				'Tag ("' . $newName . '", '. $userVisible . ', ' . $userAssignable . ') already exists',
 				0,
 				$e
 			);

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -72,15 +72,16 @@ class URLGenerator implements IURLGenerator {
 
 	/**
 	 * Creates an url using a defined route
-	 * @param string $route
-	 * @param array $parameters args with param=>value, will be appended to the returned url
+	 *
+	 * @param string $routeName
+	 * @param array $arguments args with param=>value, will be appended to the returned url
 	 * @return string the url
 	 *
 	 * Returns a url to the given route.
 	 */
-	public function linkToRoute(string $route, array $parameters = []): string {
+	public function linkToRoute(string $routeName, array $arguments = []): string {
 		// TODO: mock router
-		return \OC::$server->getRouter()->generate($route, $parameters);
+		return \OC::$server->getRouter()->generate($routeName, $arguments);
 	}
 
 	/**
@@ -111,7 +112,8 @@ class URLGenerator implements IURLGenerator {
 
 	/**
 	 * Creates an url
-	 * @param string $app app
+	 *
+	 * @param string $appName app
 	 * @param string $file file
 	 * @param array $args array with param=>value, will be appended to the returned url
 	 *    The value of $args will be urlencoded
@@ -119,24 +121,24 @@ class URLGenerator implements IURLGenerator {
 	 *
 	 * Returns a url to the given app and file.
 	 */
-	public function linkTo(string $app, string $file, array $args = []): string {
+	public function linkTo(string $appName, string $file, array $args = []): string {
 		$frontControllerActive = ($this->config->getSystemValue('htaccess.IgnoreFrontController', false) === true || getenv('front_controller_active') === 'true');
 
-		if ($app !== '') {
-			$app_path = \OC_App::getAppPath($app);
+		if ($appName !== '') {
+			$app_path = \OC_App::getAppPath($appName);
 			// Check if the app is in the app folder
 			if ($app_path && file_exists($app_path . '/' . $file)) {
 				if (substr($file, -3) === 'php') {
-					$urlLinkTo = \OC::$WEBROOT . '/index.php/apps/' . $app;
+					$urlLinkTo = \OC::$WEBROOT . '/index.php/apps/' . $appName;
 					if ($frontControllerActive) {
-						$urlLinkTo = \OC::$WEBROOT . '/apps/' . $app;
+						$urlLinkTo = \OC::$WEBROOT . '/apps/' . $appName;
 					}
 					$urlLinkTo .= ($file !== 'index.php') ? '/' . $file : '';
 				} else {
-					$urlLinkTo = \OC_App::getAppWebPath($app) . '/' . $file;
+					$urlLinkTo = \OC_App::getAppWebPath($appName) . '/' . $file;
 				}
 			} else {
-				$urlLinkTo = \OC::$WEBROOT . '/' . $app . '/' . $file;
+				$urlLinkTo = \OC::$WEBROOT . '/' . $appName . '/' . $file;
 			}
 		} else {
 			if (file_exists(\OC::$SERVERROOT . '/core/' . $file)) {
@@ -159,16 +161,17 @@ class URLGenerator implements IURLGenerator {
 
 	/**
 	 * Creates path to an image
-	 * @param string $app app
-	 * @param string $image image name
+	 *
+	 * @param string $appName app
+	 * @param string $file image name
 	 * @throws \RuntimeException If the image does not exist
 	 * @return string the url
 	 *
 	 * Returns the path to the image.
 	 */
-	public function imagePath(string $app, string $image): string {
+	public function imagePath(string $appName, string $file): string {
 		$cache = $this->cacheFactory->createDistributed('imagePath-'.md5($this->getBaseUrl()).'-');
-		$cacheKey = $app.'-'.$image;
+		$cacheKey = $appName.'-'.$file;
 		if ($key = $cache->get($cacheKey)) {
 			return $key;
 		}
@@ -177,9 +180,9 @@ class URLGenerator implements IURLGenerator {
 		$theme = \OC_Util::getTheme();
 
 		//if a theme has a png but not an svg always use the png
-		$basename = substr(basename($image),0,-4);
+		$basename = substr(basename($file),0,-4);
 
-		$appPath = \OC_App::getAppPath($app);
+		$appPath = \OC_App::getAppPath($appName);
 
 		// Check if the app is in the app folder
 		$path = '';
@@ -188,39 +191,39 @@ class URLGenerator implements IURLGenerator {
 		if ($themingEnabled) {
 			$themingDefaults = \OC::$server->getThemingDefaults();
 			if ($themingDefaults instanceof ThemingDefaults) {
-				$themingImagePath = $themingDefaults->replaceImagePath($app, $image);
+				$themingImagePath = $themingDefaults->replaceImagePath($appName, $file);
 			}
 		}
 
-		if (file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$image")) {
-			$path = \OC::$WEBROOT . "/themes/$theme/apps/$app/img/$image";
-		} elseif (!file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$basename.svg")
-			&& file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$basename.png")) {
-			$path =  \OC::$WEBROOT . "/themes/$theme/apps/$app/img/$basename.png";
-		} elseif (!empty($app) and file_exists(\OC::$SERVERROOT . "/themes/$theme/$app/img/$image")) {
-			$path =  \OC::$WEBROOT . "/themes/$theme/$app/img/$image";
-		} elseif (!empty($app) and (!file_exists(\OC::$SERVERROOT . "/themes/$theme/$app/img/$basename.svg")
-			&& file_exists(\OC::$SERVERROOT . "/themes/$theme/$app/img/$basename.png"))) {
-			$path =  \OC::$WEBROOT . "/themes/$theme/$app/img/$basename.png";
-		} elseif (file_exists(\OC::$SERVERROOT . "/themes/$theme/core/img/$image")) {
-			$path =  \OC::$WEBROOT . "/themes/$theme/core/img/$image";
+		if (file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$appName/img/$file")) {
+			$path = \OC::$WEBROOT . "/themes/$theme/apps/$appName/img/$file";
+		} elseif (!file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$appName/img/$basename.svg")
+			&& file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$appName/img/$basename.png")) {
+			$path =  \OC::$WEBROOT . "/themes/$theme/apps/$appName/img/$basename.png";
+		} elseif (!empty($appName) and file_exists(\OC::$SERVERROOT . "/themes/$theme/$appName/img/$file")) {
+			$path =  \OC::$WEBROOT . "/themes/$theme/$appName/img/$file";
+		} elseif (!empty($appName) and (!file_exists(\OC::$SERVERROOT . "/themes/$theme/$appName/img/$basename.svg")
+			&& file_exists(\OC::$SERVERROOT . "/themes/$theme/$appName/img/$basename.png"))) {
+			$path =  \OC::$WEBROOT . "/themes/$theme/$appName/img/$basename.png";
+		} elseif (file_exists(\OC::$SERVERROOT . "/themes/$theme/core/img/$file")) {
+			$path =  \OC::$WEBROOT . "/themes/$theme/core/img/$file";
 		} elseif (!file_exists(\OC::$SERVERROOT . "/themes/$theme/core/img/$basename.svg")
 			&& file_exists(\OC::$SERVERROOT . "/themes/$theme/core/img/$basename.png")) {
 			$path =  \OC::$WEBROOT . "/themes/$theme/core/img/$basename.png";
 		} elseif ($themingEnabled && $themingImagePath) {
 			$path = $themingImagePath;
-		} elseif ($appPath && file_exists($appPath . "/img/$image")) {
-			$path =  \OC_App::getAppWebPath($app) . "/img/$image";
+		} elseif ($appPath && file_exists($appPath . "/img/$file")) {
+			$path =  \OC_App::getAppWebPath($appName) . "/img/$file";
 		} elseif ($appPath && !file_exists($appPath . "/img/$basename.svg")
 			&& file_exists($appPath . "/img/$basename.png")) {
-			$path =  \OC_App::getAppWebPath($app) . "/img/$basename.png";
-		} elseif (!empty($app) and file_exists(\OC::$SERVERROOT . "/$app/img/$image")) {
-			$path =  \OC::$WEBROOT . "/$app/img/$image";
-		} elseif (!empty($app) and (!file_exists(\OC::$SERVERROOT . "/$app/img/$basename.svg")
-				&& file_exists(\OC::$SERVERROOT . "/$app/img/$basename.png"))) {
-			$path =  \OC::$WEBROOT . "/$app/img/$basename.png";
-		} elseif (file_exists(\OC::$SERVERROOT . "/core/img/$image")) {
-			$path =  \OC::$WEBROOT . "/core/img/$image";
+			$path =  \OC_App::getAppWebPath($appName) . "/img/$basename.png";
+		} elseif (!empty($appName) and file_exists(\OC::$SERVERROOT . "/$appName/img/$file")) {
+			$path =  \OC::$WEBROOT . "/$appName/img/$file";
+		} elseif (!empty($appName) and (!file_exists(\OC::$SERVERROOT . "/$appName/img/$basename.svg")
+				&& file_exists(\OC::$SERVERROOT . "/$appName/img/$basename.png"))) {
+			$path =  \OC::$WEBROOT . "/$appName/img/$basename.png";
+		} elseif (file_exists(\OC::$SERVERROOT . "/core/img/$file")) {
+			$path =  \OC::$WEBROOT . "/core/img/$file";
 		} elseif (!file_exists(\OC::$SERVERROOT . "/core/img/$basename.svg")
 			&& file_exists(\OC::$SERVERROOT . "/core/img/$basename.png")) {
 			$path =  \OC::$WEBROOT . "/themes/$theme/core/img/$basename.png";
@@ -231,7 +234,7 @@ class URLGenerator implements IURLGenerator {
 			return $path;
 		}
 
-		throw new RuntimeException('image not found: image:' . $image . ' webroot:' . \OC::$WEBROOT . ' serverroot:' . \OC::$SERVERROOT);
+		throw new RuntimeException('image not found: image:' . $file . ' webroot:' . \OC::$WEBROOT . ' serverroot:' . \OC::$SERVERROOT);
 	}
 
 

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -293,14 +293,14 @@ class Database extends ABackend implements
 	/**
 	 * Check if the password is correct
 	 *
-	 * @param string $uid The username
+	 * @param string $loginName The loginname
 	 * @param string $password The password
 	 * @return string
 	 *
 	 * Check if the password is correct without logging in the user
 	 * returns the user id or false
 	 */
-	public function checkPassword(string $uid, string $password) {
+	public function checkPassword(string $loginName, string $password) {
 		$this->fixDI();
 
 		$qb = $this->dbConn->getQueryBuilder();
@@ -308,7 +308,7 @@ class Database extends ABackend implements
 			->from($this->table)
 			->where(
 				$qb->expr()->eq(
-					'uid_lower', $qb->createNamedParameter(mb_strtolower($uid))
+					'uid_lower', $qb->createNamedParameter(mb_strtolower($loginName))
 				)
 			);
 		$result = $qb->execute();
@@ -320,7 +320,7 @@ class Database extends ABackend implements
 			$newHash = '';
 			if (\OC::$server->getHasher()->verify($password, $storedHash, $newHash)) {
 				if (!empty($newHash)) {
-					$this->updatePassword($uid, $newHash);
+					$this->updatePassword($loginName, $newHash);
 				}
 				return (string)$row['uid'];
 			}

--- a/lib/public/IUserSession.php
+++ b/lib/public/IUserSession.php
@@ -46,12 +46,12 @@ interface IUserSession {
 	/**
 	 * Do a user login
 	 *
-	 * @param string $user the username
+	 * @param string $uid the username
 	 * @param string $password the password
 	 * @return bool true if successful
 	 * @since 6.0.0
 	 */
-	public function login($user, $password);
+	public function login($uid, $password);
 
 	/**
 	 * Logs the user out including all the session data

--- a/lib/public/User/Backend/ICheckPasswordBackend.php
+++ b/lib/public/User/Backend/ICheckPasswordBackend.php
@@ -33,7 +33,7 @@ interface ICheckPasswordBackend {
 	/**
 	 * @since 14.0.0
 	 *
-	 * @param string $uid The username
+	 * @param string $loginName The loginname
 	 * @param string $password The password
 	 * @return string|bool The uid on success false on failure
 	 */


### PR DESCRIPTION
Found by Psalm 3.14.1

That's the new feature of Psalm 3.14 vs 3.13 @nickvergessen ;) Thus it popped up in your PR.

It basically just renames parameters to match the ones of the interface and fixes two wrong PHPDoc blocks that contained a comma right behind the return value.