### PR TITLE
[stable18] fixing a logged deprecation message

### DIFF
--- a/apps/user_ldap/appinfo/app.php
+++ b/apps/user_ldap/appinfo/app.php
@@ -56,7 +56,7 @@ if(count($configPrefixes) > 0) {
 	OC_User::useBackend($userBackend);
 
 	// Hook to allow plugins to work on registered backends
-	OC::$server->getEventDispatcher()->dispatch('OCA\\User_LDAP\\User\\User::postLDAPBackendAdded');
+	OC::$server->getEventDispatcher()->dispatch('OCA\\User_LDAP\\User\\User::postLDAPBackendAdded', new \OCP\EventDispatcher\Event());
 
 	\OC::$server->getGroupManager()->addBackend($groupBackend);
 


### PR DESCRIPTION
simplified backport of #22221, only adjusting the legacy call, not bringing back the new events.

obsoletes #22255