### PR TITLE
19.0.2 RC2

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [19, 0, 2, 0];
+$OC_Version = [19, 0, 2, 1];
 
 // The human readable string
-$OC_VersionString = '19.0.2 RC1';
+$OC_VersionString = '19.0.2 RC2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #22333 CalDAV: Add ability to limit sharing to owner
* #22337 Only copy the link when updating a share or no password was forced
* #22341 Remove encryption option for nextcloud external storage
* #22348 L10n:Correct appid for WebAuthn
* #22355 Properly search for users when limittogroups is enabled
* #22381 SSE: make legacy format opt in
* #22387 Update the CRL
* #22400 Fix missing FN from federated contact
