### PR TITLE
20 Beta 2

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [20, 0, 0, 3];
+$OC_Version = [20, 0, 0, 4];
 
 // The human readable string
-$OC_VersionString = '20.0.0 Beta 1';
+$OC_VersionString = '20.0.0 Beta 2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #17536 Expose currently active file list though OCA.Files.App
* #20772 Properly search for users when limittogroups is enabled
* #21894 Fix: file quota was not applied in all cases
* #22134 Merge activity settings for calendars, events and todos
* #22317 Change color of displayname and ellipsis status message
* #22319 Add attributions for weather status in modal
* #22354 Fix dark-theme selector
* #22357 Ability to toggle statuses in dashboard
* #22358 Fix event icon sizes and text alignment
* #22359 Fix possible leaking scope in Flow
* #22360 Bump @babel/core from 7.11.1 to 7.11.4
* #22361 Bump vue-material-design-icons from 4.8.0 to 4.9.0
* #22363 Bump p-queue from 6.6.0 to 6.6.1
* #22364 Bump vuedraggable from 2.24.0 to 2.24.1
* #22365 Bump webpack-merge from 5.1.1 to 5.1.2
* #22369 Bump vue and vue-template-compiler
* #22376 Files app menu design and wording fixes
* #22382 Add repair step to remove old dashboard app config
* #22385 Update the CRL
* #22392 Dashboard polishing
* #22393 Update the license headers for Nextcloud 20
* #22394 Fix missing FN from federated contact
* #22420 Make ellipsized unified search results visible on hover
* #22421 Show better quota warning for group folders and external storage
* #22422 Add the missing cursor parameter to unified search requests
* #22425 User-status: Fix icon coloring
* #22431 [Automated] Update psalm-baseline.xml
* #22432 Add php docs build script
* #22440 Bump @nextcloud/vue-dashboard from 0.1.3 to 0.1.8
* [activity#483](https://github.com/nextcloud/activity/pull/483) Add daily activity digest option
* [activity#484](https://github.com/nextcloud/activity/pull/484) Fix grouped settings
* [firstrunwizard#372](https://github.com/nextcloud/firstrunwizard/pull/372) Bump webpack from 4.43.0 to 4.44.1
* [firstrunwizard#390](https://github.com/nextcloud/firstrunwizard/pull/390) Bump @nextcloud/webpack-vue-config from 1.1.0 to 1.2.0
* [logreader#375](https://github.com/nextcloud/logreader/pull/375) (bugfix): Protect LogIterator.php from empty array indices
* [notifications#721](https://github.com/nextcloud/notifications/pull/721) Bump vue and vue-template-compiler
* [notifications#722](https://github.com/nextcloud/notifications/pull/722) Bump webpack-merge from 5.1.1 to 5.1.2
* [notifications#723](https://github.com/nextcloud/notifications/pull/723) Bump @babel/core from 7.11.1 to 7.11.4
* [notifications#724](https://github.com/nextcloud/notifications/pull/724) Status support - No Push and browser notifications when in DND
* [privacy#478](https://github.com/nextcloud/privacy/pull/478) Bump @nextcloud/dialogs from 1.4.0 to 2.0.0
* [privacy#479](https://github.com/nextcloud/privacy/pull/479) Bump @vue/test-utils from 1.0.3 to 1.0.4
* [privacy#480](https://github.com/nextcloud/privacy/pull/480) Bump webpack-merge from 5.1.1 to 5.1.2
* [privacy#482](https://github.com/nextcloud/privacy/pull/482) Bump vue and vue-template-compiler
* [privacy#483](https://github.com/nextcloud/privacy/pull/483) Bump @babel/core from 7.11.1 to 7.11.4
* [privacy#484](https://github.com/nextcloud/privacy/pull/484) Bump @nextcloud/vue from 2.3.0 to 2.6.0
* [privacy#485](https://github.com/nextcloud/privacy/pull/485) Fix usage of webpack-merge
* [privacy#486](https://github.com/nextcloud/privacy/pull/486) Do not show user-status in privacy
* [privacy#487](https://github.com/nextcloud/privacy/pull/487) Cleanup: Remove unnecessary console statements
* [privacy#488](https://github.com/nextcloud/privacy/pull/488) Fixes regression that prevented you from toggling the encryption flag
* [privacy#491](https://github.com/nextcloud/privacy/pull/491) Bump css-loader from 4.2.1 to 4.2.2
* [recommendations#268](https://github.com/nextcloud/recommendations/pull/268) Filter out entries that fail due to StorageNotAvailableException
* [recommendations#269](https://github.com/nextcloud/recommendations/pull/269) Dyslexia font fix
* [recommendations#270](https://github.com/nextcloud/recommendations/pull/270) Empty content view
* [recommendations#271](https://github.com/nextcloud/recommendations/pull/271) Bump webpack-merge from 5.1.1 to 5.1.2
* [recommendations#272](https://github.com/nextcloud/recommendations/pull/272) Bump vue and vue-template-compiler
* [recommendations#274](https://github.com/nextcloud/recommendations/pull/274) Bump @babel/core from 7.11.1 to 7.11.4
* [recommendations#275](https://github.com/nextcloud/recommendations/pull/275) Bump @nextcloud/vue-dashboard from 0.1.6 to 0.1.8
* [serverinfo#228](https://github.com/nextcloud/serverinfo/pull/228) Match any non-whitespace character in filesystem pattern
* [text#984](https://github.com/nextcloud/text/pull/984) Bump @babel/core from 7.11.1 to 7.11.4
* [text#985](https://github.com/nextcloud/text/pull/985) Bump tiptap-commands from 1.14.4 to 1.14.6
* [text#988](https://github.com/nextcloud/text/pull/988) Only overwrite Ctrl-f when text is focussed
* [viewer#571](https://github.com/nextcloud/viewer/pull/571) Bump vue and vue-template-compiler
* [viewer#572](https://github.com/nextcloud/viewer/pull/572) Bump @babel/core from 7.11.1 to 7.11.4
* [viewer#573](https://github.com/nextcloud/viewer/pull/573) Bump webpack-merge from 5.1.1 to 5.1.2
* [viewer#574](https://github.com/nextcloud/viewer/pull/574) Bump @nextcloud/vue from 2.3.0 to 2.6.0
* [viewer#575](https://github.com/nextcloud/viewer/pull/575) Bump vue-async-computed from 3.8.3 to 3.9.0
* [viewer#576](https://github.com/nextcloud/viewer/pull/576) Bump cypress to 5.0.0


Pending PRs:

* [ ] #16632 Set proper root path for single file shares originating from other storages @juliushaertl
* [ ] #16696 Fixed moving of master key encrypted and versioned files between shared folders @yahesh
* [ ] #17456 IMIP email improvements (take 2) @brad2014
* [ ] #21082 Show changelog in apps management @juliushaertl
* [ ] #21288 Return correct loginname in credentials @lmamane
* [ ] #22111 Allow unified search filtering and bump @nextcloud/vue @skjnldsv
* [ ] #22116 Fix share transfer of single files and on the transfered node @juliushaertl
* [ ] #22136 Add 'Reasons to use Nextcloud in your organization' call to action in settings @jancborchardt
* [ ] #22144 Add personal addtional settign section @dassio
* [ ] #22234 Use user mount with matching shared storage only @juliushaertl
* [ ] #22294 SFTP-Storage: Correctly Sync mtime @msander
* [ ] #22362 Bump nextcloud-vue-collections from 0.7.2 to 0.8.1 @dependabot-preview
* [ ] #22367 Bump @nextcloud/dialogs from 1.4.0 to 2.0.0 @dependabot-preview
* [ ] #22395 Fix settings chunk loading @skjnldsv
* [ ] #22423 Do not expose direct editing if no master key is available @juliushaertl
* [ ] #22450 UserStatus: Fix app icon visibility in apps management @georgehrke
* [ ] [files_pdfviewer#202](https://github.com/nextcloud/files_pdfviewer/pull/202) Fix styling and move towards standard TemplateResponse @skjnldsv
* [ ] [serverinfo#224](https://github.com/nextcloud/serverinfo/pull/224) Add disk object @kesselb
* [ ] [viewer#570](https://github.com/nextcloud/viewer/pull/570) Show proper error if the file doesn't have a handler @skjnldsv
