### PR TITLE
fix possible leaking scope in Flow

### DIFF
--- a/apps/workflowengine/lib/AppInfo/Application.php
+++ b/apps/workflowengine/lib/AppInfo/Application.php
@@ -65,6 +65,7 @@ class Application extends App implements IBootstrap {
 	private function registerRuleListeners(IEventDispatcher $dispatcher,
 										   IServerContainer $container,
 										   ILogger $logger): void {
+		/** @var Manager $manager */
 		$manager = $container->query(Manager::class);
 		$configuredEvents = $manager->getAllConfiguredEvents();
 
@@ -81,6 +82,7 @@ class Application extends App implements IBootstrap {
 								/** @var IOperation $operation */
 								$operation = $container->query($operationClass);
 
+								$ruleMatcher->setEventName($eventName);
 								$ruleMatcher->setEntity($entity);
 								$ruleMatcher->setOperation($operation);
 

--- a/apps/workflowengine/lib/Service/RuleMatcher.php
+++ b/apps/workflowengine/lib/Service/RuleMatcher.php
@@ -62,6 +62,8 @@ class RuleMatcher implements IRuleMatcher {
 	protected $entity;
 	/** @var Logger */
 	protected $logger;
+	/** @var string */
+	protected $eventName;
 
 	public function __construct(
 		IUserSession $session,
@@ -99,6 +101,13 @@ class RuleMatcher implements IRuleMatcher {
 			throw new RuntimeException('This method must not be called more than once');
 		}
 		$this->entity = $entity;
+	}
+
+	public function setEventName(string $eventName): void {
+		if ($this->eventName !== null) {
+			throw new RuntimeException('This method must not be called more than once');
+		}
+		$this->eventName = $eventName;
 	}
 
 	public function getEntity(): IEntity {
@@ -155,6 +164,11 @@ class RuleMatcher implements IRuleMatcher {
 
 		$matches = [];
 		foreach ($operations as $operation) {
+			$configuredEvents = json_decode($operation['events'], true);
+			if ($this->eventName !== null && !in_array($this->eventName, $configuredEvents)) {
+				continue;
+			}
+
 			$checkIds = json_decode($operation['checks'], true);
 			$checks = $this->manager->getChecks($checkIds);
 

--- a/lib/public/WorkflowEngine/IRuleMatcher.php
+++ b/lib/public/WorkflowEngine/IRuleMatcher.php
@@ -78,4 +78,14 @@ interface IRuleMatcher extends IFileCheck {
 	 * @since 18.0.0
 	 */
 	public function getEntity(): IEntity;
+
+	/**
+	 * this method can be called once to set the event name that is currently
+	 * being processed. The workflow engine takes care of this usually, only an
+	 * IComplexOperation might want to make use of it.
+	 *
+	 * @throws RuntimeException
+	 * @since 20.0.0
+	 */
+	public function setEventName(string $eventName): void;
 }


### PR DESCRIPTION
How to reproduce:

1. have two Notification operations set with two different entities: e.g. file change and webhook (https://github.com/nextcloud/flow_webhooks)
2. trigger a webook (`curl -i -X POST -H "Content-Type: application/json" -d '{"foo": "bar"}'  https://my.nc.srv/ocs/v2.php/apps/flow_webhooks/api/v1/hook/1234567890`, see personal config)
3. realize a runtime exception was thrown, because file info was not set

The reason is that the `getFlows()` method does not take the event into account that is being currently processed.

This draft implements an API extension to `IRuleMatcher` to fix this, and also to backport it. Since it is not a component that is  implemented by third parties, but initialized by ourselves. Existing methods are not touched. Thus it is safe to backport. Usual operation implementation do not need to worry about this as it dealt with in the Manager code.  `IComplexOperations` might need to use that method, if it possible to react and configure different events. However, they are picked up by themselves (and they do event listening themselves), so even in these cases it is extremely unlikely that this needs to be used.