### PR TITLE
Files app menu design and wording fixes

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -701,7 +701,7 @@
 					if (mountType === 'external-root') {
 						deleteTitle = t('files', 'Disconnect storage');
 					} else if (mountType === 'shared-root') {
-						deleteTitle = t('files', 'Unshare');
+						deleteTitle = t('files', 'Leave this share');
 					}
 					return deleteTitle;
 				},

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -467,7 +467,9 @@ tr .action:not(.permanent), .selectedActions a {
 }
 
 tr {
-	&:hover .action, &:focus .action, .action.permanent {
+	&:hover .action:not(.menuitem),
+	&:focus .action:not(.menuitem),
+	.action.permanent:not(.menuitem) {
 		opacity: .5;
 	}
 }


### PR DESCRIPTION
Before: low text contrast and unclear wording for "Unshare" | After: proper contrast and fixed wording, fix #18622 
-|- 
![menu before](https://user-images.githubusercontent.com/925062/90989799-c6baa100-e59c-11ea-91f3-05e0a092cb8e.png) | ![menu after](https://user-images.githubusercontent.com/925062/90989804-c7533780-e59c-11ea-8ce4-d2a24f412ac2.png)
