### PR TITLE
Added config setting to allow newly created users to be private. 

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -352,6 +352,15 @@ class UsersController extends AUserData {
 				}
 			}
 
+			if ($this->config->getSystemValue('users_private_by_default', false)) {
+				$targetUser = $this->userManager->get($userid);
+				$userAccount = $this->accountManager->getUser($targetUser);
+				$userAccount[AccountManager::PROPERTY_DISPLAYNAME]['scope'] = AccountManager::VISIBILITY_PRIVATE;
+				$userAccount[AccountManager::PROPERTY_EMAIL]['scope'] = AccountManager::VISIBILITY_PRIVATE;
+				$userAccount[AccountManager::PROPERTY_AVATAR]['scope'] = AccountManager::VISIBILITY_PRIVATE;
+				$this->accountManager->updateUser($targetUser, $userAccount);
+			}
+
 			return new DataResponse(['id' => $userid]);
 		} catch (HintException $e) {
 			$this->logger->logException($e, [

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1835,4 +1835,14 @@ $CONFIG = [
  */
 
 'login_form_autocomplete' => true,
+
+/**
+ * By default users' profiles are set to public and can be seen by other contacts.
+ * If you require new users that you create to not be visible to other, you can
+ * set this property to "true"
+ *
+ */
+
+'users_private_by_default' => false,
+
 ];


### PR DESCRIPTION
Hello,

Fixes issue: #14358 

This is my first real commit to any project so all feedback welcome.

I added a new setting to the sample config file `users_private_by_default` such that a newly created user has all their setting scopes to private.

I did not see any existing function that changes the `scope` setting and the `editUser` seemed hardcoded to change the `value` so I added the logic to an if statement on the `addUser` method.