### PR TITLE
show better quota warning for group folders and external storage

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -33,6 +33,7 @@ use OC\Files\FileInfo;
 use OC\Files\Storage\Wrapper\Quota;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCP\Files\ForbiddenException;
+use OCP\Files\Mount\IMountPoint;
 
 class TestViewDirectory extends \OC\Files\View {
 	private $updatables;
@@ -270,9 +271,12 @@ class DirectoryTest extends \Test\TestCase {
 	}
 
 	public function testGetQuotaInfoUnlimited() {
+		$mountPoint = $this->createMock(IMountPoint::class);
 		$storage = $this->getMockBuilder(Quota::class)
 			->disableOriginalConstructor()
 			->getMock();
+		$mountPoint->method('getStorage')
+			->willReturn($storage);
 
 		$storage->expects($this->any())
 			->method('instanceOfStorage')
@@ -293,8 +297,8 @@ class DirectoryTest extends \Test\TestCase {
 			->willReturn(200);
 
 		$this->info->expects($this->once())
-			->method('getStorage')
-			->willReturn($storage);
+			->method('getMountPoint')
+			->willReturn($mountPoint);
 
 		$this->view->expects($this->once())
 			->method('getFileInfo')
@@ -305,9 +309,12 @@ class DirectoryTest extends \Test\TestCase {
 	}
 
 	public function testGetQuotaInfoSpecific() {
+		$mountPoint = $this->createMock(IMountPoint::class);
 		$storage = $this->getMockBuilder(Quota::class)
 			->disableOriginalConstructor()
 			->getMock();
+		$mountPoint->method('getStorage')
+			->willReturn($storage);
 
 		$storage->expects($this->any())
 			->method('instanceOfStorage')
@@ -329,8 +336,8 @@ class DirectoryTest extends \Test\TestCase {
 			->willReturn(200);
 
 		$this->info->expects($this->once())
-			->method('getStorage')
-			->willReturn($storage);
+			->method('getMountPoint')
+			->willReturn($mountPoint);
 
 		$this->view->expects($this->once())
 			->method('getFileInfo')

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -72,6 +72,7 @@
 				$('#free_space').val(response.data.freeSpace);
 				$('#upload.button').attr('data-original-title', response.data.maxHumanFilesize);
 				$('#usedSpacePercent').val(response.data.usedSpacePercent);
+				$('#usedSpacePercent').data('mount-type', response.data.mountType);
 				$('#owner').val(response.data.owner);
 				$('#ownerDisplayName').val(response.data.ownerDisplayName);
 				Files.displayStorageWarnings();
@@ -155,21 +156,30 @@
 
 			var usedSpacePercent = $('#usedSpacePercent').val(),
 				owner = $('#owner').val(),
-				ownerDisplayName = $('#ownerDisplayName').val();
+				ownerDisplayName = $('#ownerDisplayName').val(),
+				mountType = $('#usedSpacePercent').data('mount-type');
 			if (usedSpacePercent > 98) {
 				if (owner !== OC.getCurrentUser().uid) {
 					OC.Notification.show(t('files', 'Storage of {owner} is full, files can not be updated or synced anymore!',
 						{owner: ownerDisplayName}), {type: 'error'}
 					);
-					return;
+				} else if (mountType === 'group') {
+					OC.Notification.show(t('files',
+						'This group folder is full, files can not be updated or synced anymore!'),
+						{type: 'error'}
+					);
+				} else if (mountType === 'external') {
+					OC.Notification.show(t('files',
+						'This external storage is full, files can not be updated or synced anymore!'),
+						{type : 'error'}
+					);
+				} else {
+					OC.Notification.show(t('files',
+						'Your storage is full, files can not be updated or synced anymore!'),
+						{type: 'error'}
+					);
 				}
-				OC.Notification.show(t('files',
-					'Your storage is full, files can not be updated or synced anymore!'),
-					{type : 'error'}
-				);
-				return;
-			}
-			if (usedSpacePercent > 90) {
+			} else if (usedSpacePercent > 90) {
 				if (owner !== OC.getCurrentUser().uid) {
 					OC.Notification.show(t('files', 'Storage of {owner} is almost full ({usedSpacePercent}%)',
 						{
@@ -180,12 +190,24 @@
 							type: 'error'
 						}
 					);
-					return;
+				} else if (mountType === 'group') {
+					OC.Notification.show(t('files',
+						'This group folder is almost full ({usedSpacePercent}%)',
+						{usedSpacePercent: usedSpacePercent}),
+						{type : 'error'}
+					);
+				} else if (mountType === 'external') {
+					OC.Notification.show(t('files',
+						'This external storage is almost full ({usedSpacePercent}%)',
+						{usedSpacePercent: usedSpacePercent}),
+						{type : 'error'}
+					);
+				} else {
+					OC.Notification.show(t('files', 'Your storage is almost full ({usedSpacePercent}%)',
+						{usedSpacePercent: usedSpacePercent}),
+						{type : 'error'}
+					);
 				}
-				OC.Notification.show(t('files', 'Your storage is almost full ({usedSpacePercent}%)',
-					{usedSpacePercent: usedSpacePercent}),
-					{type : 'error'}
-				);
 			}
 		},
 

--- a/apps/files/lib/Helper.php
+++ b/apps/files/lib/Helper.php
@@ -63,6 +63,7 @@ class Helper {
 			'usedSpacePercent'  => (int)$storageInfo['relative'],
 			'owner' => $storageInfo['owner'],
 			'ownerDisplayName' => $storageInfo['ownerDisplayName'],
+			'mountType' => $storageInfo['mountType'],
 		];
 	}
 

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -495,7 +495,8 @@ class OC_Helper {
 			$used = 0;
 		}
 		$quota = \OCP\Files\FileInfo::SPACE_UNLIMITED;
-		$storage = $rootInfo->getStorage();
+		$mount = $rootInfo->getMountPoint();
+		$storage = $mount->getStorage();
 		$sourceStorage = $storage;
 		if ($storage->instanceOfStorage('\OCA\Files_Sharing\SharedStorage')) {
 			$includeExtStorage = false;
@@ -553,6 +554,7 @@ class OC_Helper {
 			'relative' => $relative,
 			'owner' => $ownerId,
 			'ownerDisplayName' => $ownerDisplayName,
+			'mountType' => $mount->getMountType()
 		];
 	}
 


### PR DESCRIPTION
instead of showing the generic 'Your storage is full' message, better explain that it's the group folder/external storage that is full

Before:
![image](https://user-images.githubusercontent.com/1283854/91184411-210e4b80-e6dc-11ea-86bd-836e7e74197d.png)


After: 
![image](https://user-images.githubusercontent.com/1283854/91184358-118f0280-e6dc-11ea-9577-d0e05421c9fb.png)
