### PR TITLE
Do not expose direct editing if no master key is available

### DIFF
--- a/apps/files/lib/Controller/DirectEditingController.php
+++ b/apps/files/lib/Controller/DirectEditingController.php
@@ -76,6 +76,9 @@ class DirectEditingController extends OCSController {
 	 * @NoAdminRequired
 	 */
 	public function create(string $path, string $editorId, string $creatorId, string $templateId = null): DataResponse {
+		if (!$this->directEditingManager->isEnabled()) {
+			return new DataResponse(['message' => 'Direct editing is not enabled'], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
 		$this->eventDispatcher->dispatchTyped(new RegisterDirectEditorEvent($this->directEditingManager));
 
 		try {
@@ -85,7 +88,7 @@ class DirectEditingController extends OCSController {
 			]);
 		} catch (Exception $e) {
 			$this->logger->logException($e, ['message' => 'Exception when creating a new file through direct editing']);
-			return new DataResponse('Failed to create file: ' . $e->getMessage(), Http::STATUS_FORBIDDEN);
+			return new DataResponse(['message' => 'Failed to create file: ' . $e->getMessage()], Http::STATUS_FORBIDDEN);
 		}
 	}
 
@@ -93,6 +96,9 @@ class DirectEditingController extends OCSController {
 	 * @NoAdminRequired
 	 */
 	public function open(string $path, string $editorId = null): DataResponse {
+		if (!$this->directEditingManager->isEnabled()) {
+			return new DataResponse(['message' => 'Direct editing is not enabled'], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
 		$this->eventDispatcher->dispatchTyped(new RegisterDirectEditorEvent($this->directEditingManager));
 
 		try {
@@ -102,7 +108,7 @@ class DirectEditingController extends OCSController {
 			]);
 		} catch (Exception $e) {
 			$this->logger->logException($e, ['message' => 'Exception when opening a file through direct editing']);
-			return new DataResponse('Failed to open file: ' . $e->getMessage(), Http::STATUS_FORBIDDEN);
+			return new DataResponse(['message' => 'Failed to open file: ' . $e->getMessage()], Http::STATUS_FORBIDDEN);
 		}
 	}
 
@@ -112,13 +118,16 @@ class DirectEditingController extends OCSController {
 	 * @NoAdminRequired
 	 */
 	public function templates(string $editorId, string $creatorId): DataResponse {
+		if (!$this->directEditingManager->isEnabled()) {
+			return new DataResponse(['message' => 'Direct editing is not enabled'], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
 		$this->eventDispatcher->dispatchTyped(new RegisterDirectEditorEvent($this->directEditingManager));
 
 		try {
 			return new DataResponse($this->directEditingManager->getTemplates($editorId, $creatorId));
 		} catch (Exception $e) {
 			$this->logger->logException($e);
-			return new DataResponse('Failed to obtain template list: ' . $e->getMessage(), Http::STATUS_INTERNAL_SERVER_ERROR);
+			return new DataResponse(['message' => 'Failed to obtain template list: ' . $e->getMessage()], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 	}
 }

--- a/apps/files/lib/Service/DirectEditingService.php
+++ b/apps/files/lib/Service/DirectEditingService.php
@@ -55,6 +55,10 @@ class DirectEditingService {
 			'creators' => []
 		];
 
+		if (!$this->directEditingManager->isEnabled()) {
+			return $capabilities;
+		}
+
 		/**
 		 * @var string $id
 		 * @var IEditor $editor

--- a/lib/public/DirectEditing/IManager.php
+++ b/lib/public/DirectEditing/IManager.php
@@ -84,4 +84,12 @@ interface IManager {
 	 * @return int number of deleted tokens
 	 */
 	public function cleanup(): int;
+
+	/**
+	 * Check if direct editing is enabled
+	 *
+	 * @since 20.0.0
+	 * @return bool
+	 */
+	public function isEnabled(): bool;
 }

--- a/tests/lib/DirectEditing/ManagerTest.php
+++ b/tests/lib/DirectEditing/ManagerTest.php
@@ -10,6 +10,7 @@ use OCP\AppFramework\Http\Response;
 use OCP\DirectEditing\ACreateEmpty;
 use OCP\DirectEditing\IEditor;
 use OCP\DirectEditing\IToken;
+use OCP\Encryption\IManager;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\IDBConnection;
@@ -104,6 +105,10 @@ class ManagerTest extends TestCase {
 	 * @var MockObject|Folder
 	 */
 	private $userFolder;
+	/**
+	 * @var MockObject|IManager
+	 */
+	private $encryptionManager;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -116,6 +121,7 @@ class ManagerTest extends TestCase {
 		$this->rootFolder = $this->createMock(IRootFolder::class);
 		$this->userFolder = $this->createMock(Folder::class);
 		$this->l10n = $this->createMock(IL10N::class);
+		$this->encryptionManager = $this->createMock(IManager::class);
 
 		$l10nFactory = $this->createMock(IFactory::class);
 		$l10nFactory->expects($this->once())
@@ -128,7 +134,7 @@ class ManagerTest extends TestCase {
 			->willReturn($this->userFolder);
 
 		$this->manager = new Manager(
-			$this->random, $this->connection, $this->userSession, $this->rootFolder, $l10nFactory
+			$this->random, $this->connection, $this->userSession, $this->rootFolder, $l10nFactory, $this->encryptionManager
 		);
 
 		$this->manager->registerDirectEditor($this->editor);


### PR DESCRIPTION
This will make sure that direct editing is only exposed to mobile clients then a master key is available in case server side encryption is used.

I would propose to backport this even though the public interface is extended, but it is only used by the files app.


cc @camilasan @tobiasKaminsky @marinofaggiana for the clients:
I would expect there should be no changes required from the client side since it would just return an empty list of direct editors then.

Fixes https://github.com/nextcloud/ios/issues/1340

