### PR TITLE
(Better) Fix for #19010

### DIFF
--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -298,7 +298,7 @@ class Node implements \OCP\Files\Node {
 	 * @param string $path
 	 * @return string
 	 */
-	protected function normalizePath(string $path) {
+	protected function normalizePath(string $path): string {
 		if ($path === '' or $path === '/') {
 			return '/';
 		}
@@ -324,7 +324,7 @@ class Node implements \OCP\Files\Node {
 	 * @param string $path
 	 * @return bool
 	 */
-	public function isValidPath(string $path) {
+	public function isValidPath(string $path): bool {
 		if (!$path || $path[0] !== '/') {
 			$path = '/' . $path;
 		}

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -38,6 +38,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Lock\LockedException;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Exception;
 
 // FIXME: this class really should be abstract
 class Node implements \OCP\Files\Node {

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -301,13 +301,12 @@ class Node implements \OCP\Files\Node {
 	 */
 	protected function normalizePath($path): string {
 		// temporary solution for #19010 and related. To be strictly typed!
-		if(is_string($path) === false)
-		{
+		if (is_string($path) === false) {
 			try {
 				$path = (string) $path;
 			} catch (Exception $e) {
 				\OC::$server->getLogger()->logException($e);
-				return null;
+				return '/';
 			}
 		}
 		
@@ -338,8 +337,7 @@ class Node implements \OCP\Files\Node {
 	 */
 	public function isValidPath($path): bool {
 		// temporary solution for #19010 and related. To be strictly typed!
-		if(is_string($path) === false)
-		{
+		if (is_string($path) === false) {
 			try {
 				$path = (string) $path;
 			} catch (Exception $e) {

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -306,7 +306,7 @@ class Node implements \OCP\Files\Node {
 				$path = (string) $path;
 			} catch (Exception $e) {
 				\OC::$server->getLogger()->logException($e);
-				return NULL;
+				return null;
 			}
 		}
 		

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -298,7 +298,18 @@ class Node implements \OCP\Files\Node {
 	 * @param string $path
 	 * @return string
 	 */
-	protected function normalizePath(string $path): string {
+	protected function normalizePath($path): string {
+		// temporary solution for #19010 and related. To be strictly typed!
+		if(is_string($path) === false)
+		{
+			try {
+				$path = (string) $path;
+			} catch (Exception $e) {
+				\OC::$server->getLogger()->logException($e);
+				return NULL;
+			}
+		}
+		
 		if ($path === '' or $path === '/') {
 			return '/';
 		}
@@ -324,7 +335,18 @@ class Node implements \OCP\Files\Node {
 	 * @param string $path
 	 * @return bool
 	 */
-	public function isValidPath(string $path): bool {
+	public function isValidPath($path): bool {
+		// temporary solution for #19010 and related. To be strictly typed!
+		if(is_string($path) === false)
+		{
+			try {
+				$path = (string) $path;
+			} catch (Exception $e) {
+				\OC::$server->getLogger()->logException($e);
+				return false;
+			}
+		}
+		
 		if (!$path || $path[0] !== '/') {
 			$path = '/' . $path;
 		}

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -298,7 +298,7 @@ class Node implements \OCP\Files\Node {
 	 * @param string $path
 	 * @return string
 	 */
-	protected function normalizePath($path) {
+	protected function normalizePath(string $path) {
 		if ($path === '' or $path === '/') {
 			return '/';
 		}
@@ -324,7 +324,7 @@ class Node implements \OCP\Files\Node {
 	 * @param string $path
 	 * @return bool
 	 */
-	public function isValidPath($path) {
+	public function isValidPath(string $path) {
 		if (!$path || $path[0] !== '/') {
 			$path = '/' . $path;
 		}


### PR DESCRIPTION
Applies the documented type of the argument in `normalizePath` and `isValidPath` to actually refer to `string`. Solves several issues, even in some extensions like groupfolders.

Fixes #19010
Fixes #21236
Fixes #21928
Fixes nextcloud/groupfolders#1023
