### PR TITLE
Support REDIRECT_URI: By adding a generic local PHP request initialisation option

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -553,14 +553,6 @@ class OC {
 	}
 
 	public static function init() {
-        // If a REDIRECT_URI is provided respect that.
-        // Apache and Nginx URL rewrites alter REQUEST_URI
-        // lighttpd rewrites leaves REQUEST_URI and add REDIRECT_URI
-		if (isset($_SERVER['REDIRECT_URI'])) {
-	        $_SERVER['REQUEST_URI'] = $_SERVER['REDIRECT_URI'];
-	        unset($_SERVER['REDIRECT_URI']);
-	    }
-
 		// calculate the root directories
 		OC::$SERVERROOT = str_replace("\\", '/', substr(__DIR__, 0, -4));
 
@@ -583,6 +575,13 @@ class OC {
 
 		try {
 			self::initPaths();
+
+			// Load an init file if configured
+			$init_file = self::$configDir . 'init.php';
+			if (file_exists($init_file) && is_readable($init_file)) {
+				require_once $init_file;
+			}
+
 			// setup 3rdparty autoloader
 			$vendorAutoLoad = OC::$SERVERROOT. '/3rdparty/autoload.php';
 			if (!file_exists($vendorAutoLoad)) {

--- a/lib/base.php
+++ b/lib/base.php
@@ -553,6 +553,14 @@ class OC {
 	}
 
 	public static function init() {
+        // If a REDIRECT_URI is provided respect that.
+        // Apache and Nginx URL rewrites alter REQUEST_URI
+        // lighttpd rewrites leaves REQUEST_URI and add REDIRECT_URI
+		if (isset($_SERVER['REDIRECT_URI'])) {
+	        $_SERVER['REQUEST_URI'] = $_SERVER['REDIRECT_URI'];
+	        unset($_SERVER['REDIRECT_URI']);
+	    }
+
 		// calculate the root directories
 		OC::$SERVERROOT = str_replace("\\", '/', substr(__DIR__, 0, -4));
 


### PR DESCRIPTION
Lighttpd's url.rewrite does not alter the REQUEST_URI server variable but instead adds a REDIRECT_URI server variable and expects the client to honour it. 

https://redmine.lighttpd.net/projects/lighttpd/repository/14/revisions/9af58a9716b120209c4011b265657b32a414dff9

This small change respect REDIRECT_URI when it is present thus empower lighty's ur.rewrite.

The issue came to light when installing the PicoCMS app, which documents URL shortening methods in Admin settings, for Apache and Nginx. Analogous rewrite works fine in lighttpd but is delivered with this nuancal difference to the PHP environment.

If there is any risk of this misfunctioning (Apache or Nginx delivering REDIRECT_URI with some other meaning) it could be isolated and enabled with a config.php setting like "redirect_uri_enabled".

Of course, open to feedback, this is just a conversation starter if need be. It's a local patch I implemented so I can shorten PicoCMS URLs under lighttpd, and to put it into context:

1) lighttpd is not officially supported.
2) REQUEST_URI is allegedly not a CGI standard, but a PHP standard
3) REDIRECT_URI is a standard nowhere I can see bar lighttpd.
4) My local patch is not upgrade-proof, I'll lose it with upgrades so want to pursue whatever path I can to see some facility to respect REDIRECT_URI implemented in the main branch that sees it both endure here across upgrades and benefit other lightttpd users.
5) While lighttpd is not officially supported I use it to run Nextcloud and am happy to field support. It's the server of choice for embedded systems, used on OpenWRT and one reason NextcloudPi possible runs so sluggishly I had to abandon it is that it implements Apache (and every time I run htop on th Pi when it's not responding, Apache is churning - if the NextCloudPi team when lighttpd NextcloudPi might work ;-)