### PR TITLE
Use proper branch name in phpdoc builds

### DIFF
--- a/build/phpDocumentor.sh
+++ b/build/phpDocumentor.sh
@@ -8,4 +8,4 @@ wget https://bitgrid.net/~jus/phpDocumentor.phar
 
 mkdir -p api/
 
-php7.4 phpDocumentor.phar -t "./api" -d "./lib/public" --title="Nextcloud PHP API (`git rev-parse --abbrev-ref HEAD`)"
+php7.4 phpDocumentor.phar -t "./api" -d "./lib/public" --title="Nextcloud PHP API ($BRANCH)"


### PR DESCRIPTION
Follow up to to #22432 since the git rev-parse was also not working with netlify on the master branch

Branch preview: https://5f4756efe3af100007180d3e--nextcloud-server.netlify.app/