### PR TITLE
20 Beta3

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [20, 0, 0, 4];
+$OC_Version = [20, 0, 0, 5];
 
 // The human readable string
-$OC_VersionString = '20.0.0 Beta 2';
+$OC_VersionString = '20.0.0 Beta 3';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #16632 Set proper root path for single file shares originating from other storages
* #21288 Return correct loginname in credentials
* #22111 Allow unified search filtering and bump @nextcloud/vue
* #22116 Fix share transfer of single files and on the transfered node
* #22362 Bump nextcloud-vue-collections from 0.7.2 to 0.8.1
* #22423 Do not expose direct editing if no master key is available
* #22424 User Status: Display hint that DND mutes all notifications
* #22447 Use proper branch name in phpdoc builds
* #22450 UserStatus: Fix app icon visibility in apps management
* #22454 Fix double escape of user-status in Dashboard widget
* #22458 Hide error if a background request fails during navigation
* #22459 Bump @nextcloud/dialogs from 1.4.0 to 2.0.1
* #22463 L10n: Add a period at the end of the sentence
* #22472 Fix writing BLOBs to postgres with recent contacts interaction
* #22476 Ignore duplicate setting sections
* #22481 Fix clicks on actions menu of non opaque file rows in acceptance tests
* #22490 Bump webpack-node-externals from 2.5.1 to 2.5.2
* #22491 Bump dompurify from 2.0.12 to 2.0.14
* #22494 Bump underscore from 1.10.2 to 1.11.0
* #22502 Pimp Oauth2 table
* #22511 Declare OCA.Search  directly, not via a monkey patch
* #22514 Fix S3 error handling
* #22517 Set the mount id before calling storage wrapper
* #22526 Emit unified search query
* #22528 Change free space calculation
* #22533 Flow: do not hide "matches" and "does not match" checkers
* #22535 Only disable zip64 if the size is known
* #22545 [Automated] Update psalm-baseline.xml
* #22556 Do not keep the part file if the forbidden exception has no retry set
* #22557 Do not fail if share for mountpoint is no longer available
* [files_pdfviewer#209](https://github.com/nextcloud/files_pdfviewer/pull/209) Add missing build files
* [firstrunwizard#392](https://github.com/nextcloud/firstrunwizard/pull/392) Bump @nextcloud/vue from 2.5.0 to 2.6.1
* [firstrunwizard#393](https://github.com/nextcloud/firstrunwizard/pull/393) Bump file-loader from 6.0.0 to 6.1.0
* [firstrunwizard#395](https://github.com/nextcloud/firstrunwizard/pull/395) Bump @babel/preset-env from 7.11.0 to 7.11.5
* [firstrunwizard#396](https://github.com/nextcloud/firstrunwizard/pull/396) Bump @nextcloud/l10n from 1.3.0 to 1.4.0
* [firstrunwizard#397](https://github.com/nextcloud/firstrunwizard/pull/397) Bump stylelint from 13.6.1 to 13.7.0
* [logreader#381](https://github.com/nextcloud/logreader/pull/381) Use variables to fix style and dark theme issue, fix #380
* [notifications#725](https://github.com/nextcloud/notifications/pull/725) Bump sass-loader from 9.0.3 to 10.0.1
* [notifications#727](https://github.com/nextcloud/notifications/pull/727) Use vue-richtext instead of handlebars
* [privacy#493](https://github.com/nextcloud/privacy/pull/493) Bump @nextcloud/dialogs from 2.0.0 to 2.0.1
* [privacy#495](https://github.com/nextcloud/privacy/pull/495) Bump webpack-merge from 5.1.2 to 5.1.3
* [privacy#496](https://github.com/nextcloud/privacy/pull/496) Bump @vue/test-utils from 1.0.4 to 1.0.5
* [privacy#497](https://github.com/nextcloud/privacy/pull/497) Bump @nextcloud/vue from 2.6.0 to 2.6.3
* [privacy#498](https://github.com/nextcloud/privacy/pull/498) Bump @babel/core from 7.11.4 to 7.11.5
* [privacy#499](https://github.com/nextcloud/privacy/pull/499) Bump @nextcloud/axios from 1.3.3 to 1.4.0
* [privacy#500](https://github.com/nextcloud/privacy/pull/500) Bump @nextcloud/l10n from 1.3.0 to 1.4.0
* [privacy#501](https://github.com/nextcloud/privacy/pull/501) Bump @babel/preset-env from 7.11.0 to 7.11.5
* [privacy#502](https://github.com/nextcloud/privacy/pull/502) Bump stylelint from 13.6.1 to 13.7.0
* [privacy#503](https://github.com/nextcloud/privacy/pull/503) Bump @babel/polyfill from 7.10.4 to 7.11.5
* [privacy#504](https://github.com/nextcloud/privacy/pull/504) Bump @nextcloud/router from 1.1.0 to 1.2.0
* [privacy#505](https://github.com/nextcloud/privacy/pull/505) Create Dependabot config file
* [recommendations#278](https://github.com/nextcloud/recommendations/pull/278) Bump @nextcloud/vue from 2.5.0 to 2.6.1
* [serverinfo#224](https://github.com/nextcloud/serverinfo/pull/224) Add disk object
* [text#993](https://github.com/nextcloud/text/pull/993) Catch StorageNotAvailable exceptions
* [text#994](https://github.com/nextcloud/text/pull/994) Only return rich workspace when depth is 1 or greater
* [viewer#570](https://github.com/nextcloud/viewer/pull/570) Show proper error if the file doesn't have a handler
* [viewer#581](https://github.com/nextcloud/viewer/pull/581) Set the X-Requested-With header on dav requests
* [viewer#583](https://github.com/nextcloud/viewer/pull/583) Bump @nextcloud/vue from 2.6.0 to 2.6.1
* [viewer#584](https://github.com/nextcloud/viewer/pull/584) Bump @nextcloud/webpack-vue-config from 1.1.0 to 1.2.0
* [viewer#587](https://github.com/nextcloud/viewer/pull/587) Fix cypress config
* [viewer#588](https://github.com/nextcloud/viewer/pull/588) Use nextcloudci/server, cleanup github actions cypress process


Pending PRs:

* [ ] #16696 Fixed moving of master key encrypted and versioned files between shared folders @yahesh
* [ ] #17456 IMIP email improvements (take 2) @brad2014
* [ ] #21082 Show changelog in apps management @juliushaertl
* [ ] #22136 Add 'Reasons to use Nextcloud in your organization' call to action in settings @jancborchardt
* [ ] #22144 Add personal addtional settign section @dassio
* [ ] #22234 Use user mount with matching shared storage only @juliushaertl
* [ ] #22294 SFTP-Storage: Correctly Sync mtime @msander
* [ ] #22395 Fix settings chunk loading @skjnldsv
* [ ] #22469 Don't use SELECT DISTINCT when to_char() is used in a WHERE statement @nickvergessen
* [ ] #22493 Bump sass-loader from 9.0.3 to 10.0.1 @dependabot-preview
* [ ] #22520 Dont use `false` as cache key for non utf8 path in normalizePath @icewind1991
* [ ] #22524 Fix app password updating out of bounds @rullzer
* [ ] #22531 Fix dashboard statuses toggling @eneiluj
* [ ] #22540 Adapt status menu styles to nc/vue 2.6 @georgehrke
* [ ] #22543 Don't keep menu open for next user after deleting one @nickvergessen
* [ ] #22548 Improved status cleanup @georgehrke
* [ ] #22550 Use the correct root to determinate the webroot for the resource @nickvergessen
* [ ] #22552 Add opendocument templates to mimetype mappings @juliushaertl
* [ ] [activity#488](https://github.com/nextcloud/activity/pull/488) Fix digest activity count not limiting to own activity correctly. @icewind1991
* [ ] [files_pdfviewer#202](https://github.com/nextcloud/files_pdfviewer/pull/202) Fix styling and move towards standard TemplateResponse @skjnldsv
* [ ] [notifications#728](https://github.com/nextcloud/notifications/pull/728) Trigger a proper event-bus event @nickvergessen
