### PR TITLE
Don't use SELECT DISTINCT when to_char() is used in a WHERE statement

### DIFF
--- a/apps/workflowengine/lib/Manager.php
+++ b/apps/workflowengine/lib/Manager.php
@@ -147,10 +147,10 @@ class Manager implements IManager {
 	public function getAllConfiguredEvents() {
 		$query = $this->connection->getQueryBuilder();
 
-		$query->selectDistinct('class')
-			->addSelect('entity', 'events')
+		$query->select('class', 'entity', $query->expr()->castColumn('events', IQueryBuilder::PARAM_STR))
 			->from('flow_operations')
-			->where($query->expr()->neq('events', $query->createNamedParameter('[]'), IQueryBuilder::PARAM_STR));
+			->where($query->expr()->neq('events', $query->createNamedParameter('[]'), IQueryBuilder::PARAM_STR))
+			->groupBy('class', 'entity', $query->expr()->castColumn('events', IQueryBuilder::PARAM_STR));
 
 		$result = $query->execute();
 		$operations = [];


### PR DESCRIPTION
Nice bug in Oracle

Found while debugging why Oracle tests failed installation in Notifications app:
https://github.com/nextcloud/notifications/pull/700

![oracle-sucks](https://user-images.githubusercontent.com/213943/91531287-d7587780-e90c-11ea-8584-06783ef30a00.jpg)

### Before

```json
{"reqId":"5Fq3jvkXoLzWz3iNLnWE","level":4,"time":"2020-08-27T14:52:00+00:00","remoteAddr":"","user":"admin","app":"no app in context","method":"","url":"--","message":{"Exception":"Doctrine\\DBAL\\Exception\\DriverException","Message":"An exception occurred while executing 'SELECT DISTINCT \"class\", \"entity\", \"events\" FROM \"oc_flow_operations\" WHERE to_char(\"events\") <> ?' with params [\"[]\"]:\n\nORA-00932: inconsistent datatypes: expected - got CLOB","Code":0,"Trace":[{"file":"/home/travis/build/nextcloud/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php","line":169,"function":"convertException","class":"Doctrine\\DBAL\\Driver\\AbstractOracleDriver","type":"->","args":["An exception occurred while executing 'SELECT DISTINCT \"class\", \"entity\", \"events\" FROM \"oc_flow_operations\" WHERE to_char(\"events\") <> ?' with params [\"[]\"]:\n\nORA-00932: inconsistent datatypes: expected - got CLOB",{"xdebug_message":"\nDoctrine\\DBAL\\Driver\\OCI8\\OCI8Exception: ORA-00932: inconsistent datatypes: expected - got CLOB in /home/travis/build/nextcloud/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Driver/OCI8/OCI8Exception.php on line 23\n\nCall Stack:\n    0.0001     426200   1. {main}() /home/travis/build/nextcloud/server/index.php:0\n    0.0503    8208160   2. OC::handleRequest() /home/travis/build/nextcloud/server/index.php:37\n    0.0510    8230992   3. OC\\Core\\Controller\\SetupController->run() /home/travis/build/nextcloud/server/lib/base.php:953\n    0.0516    8234096   4. OC\\Setup->install() /home/travis/build/nextcloud/server/core/Controller/SetupController.php:83\n  550.2345   15267344   5. OC\\User\\Session->login() /home/travis/build/nextcloud/server/lib/private/Setup.php:454\n  550.3492   15367016   6. OC\\User\\Session->loginWithPassword() /home/travis/build/nextcloud/server/lib/private/User/Session.php:366\n  550.5346   15367392   7. OC\\User\\Session->completeLogin() /home/travis/build/nextcloud/server/lib/private/User/Session.php:621\n  550.5861   15441880   8. OC\\User\\Session->prepareUserLogin() /home/travis/build/nextcloud/server/lib/private/User/Session.php:412\n  550.5861   15441880   9. OC_Util::setupFS() /home/travis/build/nextcloud/server/lib/private/User/Session.php:551\n  550.5861   15441880  10. OC_App::loadApps() /home/travis/build/nextcloud/server/lib/private/legacy/OC_Util.php:201\n  550.6290   19108376  11. OC_App::loadApp() /home/travis/build/nextcloud/server/lib/private/legacy/OC_App.php:131\n  550.6290   19108776  12. OC\\AppFramework\\Bootstrap\\Coordinator->bootApp() /home/travis/build/nextcloud/server/lib/private/legacy/OC_App.php:191\n  550.6290   19109264  13. OCA\\WorkflowEngine\\AppInfo\\Application->boot() /home/travis/build/nextcloud/server/lib/private/AppFramework/Bootstrap/Coordinator.php:168\n  550.6290   19109648  14. OC\\AppFramework\\Bootstrap\\BootContext->injectFn() /home/travis/build/nextcloud/server/apps/workflowengine/lib/AppInfo/Application.php:62\n  550.6290   19109704  15. OC\\AppFramework\\Bootstrap\\FunctionInjector->injectFn() /home/travis/build/nextcloud/server/lib/private/AppFramework/Bootstrap/BootContext.php:52\n  550.6293   19110648  16. OCA\\WorkflowEngine\\AppInfo\\Application->registerRuleListeners() /home/travis/build/nextcloud/server/lib/private/AppFramework/Bootstrap/FunctionInjector.php:68\n  550.6309   19257320  17. OCA\\WorkflowEngine\\Manager->getAllConfiguredEvents() /home/travis/build/nextcloud/server/apps/workflowengine/lib/AppInfo/Application.php:70\n  550.6311   19261056  18. OC\\DB\\QueryBuilder\\QueryBuilder->execute() /home/travis/build/nextcloud/server/apps/workflowengine/lib/Manager.php:155\n  550.6311   19261056  19. Doctrine\\DBAL\\Query\\QueryBuilder->execute() /home/travis/build/nextcloud/server/lib/private/DB/QueryBuilder/QueryBuilder.php:217\n  550.6312   19261216  20. OC\\DB\\OracleConnection->executeQuery() /home/travis/build/nextcloud/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Query/QueryBuilder.php:206\n  550.6312   19261376  21. OC\\DB\\OracleConnection->executeQuery() /home/travis/build/nextcloud/server/lib/private/DB/Connection.php:194\n  550.6314   19264328  22. Doctrine\\DBAL\\Driver\\OCI8\\OCI8Statement->execute() /home/travis/build/nextcloud/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:906\n","__class__":"Doctrine\\DBAL\\Driver\\OCI8\\OCI8Exception"}]},{"file":"/home/travis/build/nextcloud/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php","line":149,"function":"wrapException","class":"Doctrine\\DBAL\\DBALException","type":"::","args":[{"__class__":"Doctrine\\DBAL\\Driver\\OCI8\\Driver"},{"xdebug_message":"\nDoctrine\\DBAL\\Driver\\OCI8\\OCI8Exception: ORA-00932: inconsistent datatypes: expected - got CLOB in /home/travis/build/nextcloud/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Driver/OCI8/OCI8Exception.php on line 23\n\nCall Stack:\n    0.0001     426200   1. {main}() /home/travis/build/nextcloud/server/index.php:0\n    0.0503    8208160   2. OC::handleRequest() /home/travis/build/nextcloud/server/index.php:37\n    0.0510    8230992   3. OC\\Core\\Controller\\SetupController->run() /home/travis/build/nextcloud/server/lib/base.php:953\n    0.0516    8234096   4. OC\\Setup->install() /home/travis/build/nextcloud/server/core/Controller/SetupController.php:83\n  550.2345   15267344   5. OC\\User\\Session->login() /home/travis/build/nextcloud/server/lib/private/Setup.php:454\n  550.3492   15367016   6. OC\\User\\Session->loginWithPassword() /home/travis/build/nextcloud/server/lib/private/User/Session.php:366\n  550.5346   15367392   7. OC\\User\\Session->completeLogin() /home/travis/build/nextcloud/server/lib/private/User/Session.php:621\n  550.5861   15441880   8. OC\\User\\Session->prepareUserLogin() /home/travis/build/nextcloud/server/lib/private/User/Session.php:412\n  550.5861   15441880   9. OC_Util::setupFS() /home/travis/build/nextcloud/server/lib/private/User/Session.php:551\n  550.5861   15441880  10. OC_App::loadApps() /home/travis/build/nextcloud/server/lib/private/legacy/OC_Util.php:201\n  550.6290   19108376  11. OC_App::loadApp() /home/travis/build/nextcloud/server/lib/private/legacy/OC_App.php:131\n  550.6290   19108776  12. OC\\AppFramework\\Bootstrap\\Coordinator->bootApp() /home/travis/build/nextcloud/server/lib/private/legacy/OC_App.php:191\n  550.6290   19109264  13. OCA\\WorkflowEngine\\AppInfo\\Application->boot() /home/travis/build/nextcloud/server/lib/private/AppFramework/Bootstrap/Coordinator.php:168\n  550.6290   19109648  14. OC\\AppFramework\\Bootstrap\\BootContext->injectFn() /home/travis/build/nextcloud/server/apps/workflowengine/lib/AppInfo/Application.php:62\n  550.6290   19109704  15. OC\\AppFramework\\Bootstrap\\FunctionInjector->injectFn() /home/travis/build/nextcloud/server/lib/private/AppFramework/Bootstrap/BootContext.php:52\n  550.6293   19110648  16. OCA\\WorkflowEngine\\AppInfo\\Application->registerRuleListeners() /home/travis/build/nextcloud/server/lib/private/AppFramework/Bootstrap/FunctionInjector.php:68\n  550.6309   19257320  17. OCA\\WorkflowEngine\\Manager->getAllConfiguredEvents() /home/travis/build/nextcloud/server/apps/workflowengine/lib/AppInfo/Application.php:70\n  550.6311   19261056  18. OC\\DB\\QueryBuilder\\QueryBuilder->execute() /home/travis/build/nextcloud/server/apps/workflowengine/lib/Manager.php:155\n  550.6311   19261056  19. Doctrine\\DBAL\\Query\\QueryBuilder->execute() /home/travis/build/nextcloud/server/lib/private/DB/QueryBuilder/QueryBuilder.php:217\n  550.6312   19261216  20. OC\\DB\\OracleConnection->executeQuery() /home/travis/build/nextcloud/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Query/QueryBuilder.php:206\n  550.6312   19261376  21. OC\\DB\\OracleConnection->executeQuery() /home/travis/build/nextcloud/server/lib/private/DB/Connection.php:194\n  550.6314   19264328  22. Doctrine\\DBAL\\Driver\\OCI8\\OCI8Statement->execute() /home/travis/build/nextcloud/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:906\n","__class__":"Doctrine\\DBAL\\Driver\\OCI8\\OCI8Exception"},"An exception occurred while executing 'SELECT DISTINCT \"class\", \"entity\", \"events\" FROM \"oc_flow_operations\" WHERE to_char(\"events\") <> ?' with params [\"[]\"]:\n\nORA-00932: inconsistent datatypes: expected - got CLOB"]},{"file":"/home/travis/build/nextcloud/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Connection.php","line":914,"function":"driverExceptionDuringQuery","class":"Doctrine\\DBAL\\DBALException","type":"::","args":[{"__class__":"Doctrine\\DBAL\\Driver\\OCI8\\Driver"},{"xdebug_message":"\nDoctrine\\DBAL\\Driver\\OCI8\\OCI8Exception: ORA-00932: inconsistent datatypes: expected - got CLOB in /home/travis/build/nextcloud/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Driver/OCI8/OCI8Exception.php on line 23\n\nCall Stack:\n    0.0001     426200   1. {main}() /home/travis/build/nextcloud/server/index.php:0\n    0.0503    8208160   2. OC::handleRequest() /home/travis/build/nextcloud/server/index.php:37\n    0.0510    8230992   3. OC\\Core\\Controller\\SetupController->run() /home/travis/build/nextcloud/server/lib/base.php:953\n    0.0516    8234096   4. OC\\Setup->install() /home/travis/build/nextcloud/server/core/Controller/SetupController.php:83\n  550.2345   15267344   5. OC\\User\\Session->login() /home/travis/build/nextcloud/server/lib/private/Setup.php:454\n  550.3492   15367016   6. OC\\User\\Session->loginWithPassword() /home/travis/build/nextcloud/server/lib/private/User/Session.php:366\n  550.5346   15367392   7. OC\\User\\Session->completeLogin() /home/travis/build/nextcloud/server/lib/private/User/Session.php:621\n  550.5861   15441880   8. OC\\User\\Session->prepareUserLogin() /home/travis/build/nextcloud/server/lib/private/User/Session.php:412\n  550.5861   15441880   9. OC_Util::setupFS() /home/travis/build/nextcloud/server/lib/private/User/Session.php:551\n  550.5861   15441880  10. OC_App::loadApps() /home/travis/build/nextcloud/server/lib/private/legacy/OC_Util.php:201\n  550.6290   19108376  11. OC_App::loadApp() /home/travis/build/nextcloud/server/lib/private/legacy/OC_App.php:131\n  550.6290   19108776  12. OC\\AppFramework\\Bootstrap\\Coordinator->bootApp() /home/travis/build/nextcloud/server/lib/private/legacy/OC_App.php:191\n  550.6290   19109264  13. OCA\\WorkflowEngine\\AppInfo\\Application->boot() /home/travis/build/nextcloud/server/lib/private/AppFramework/Bootstrap/Coordinator.php:168\n  550.6290   19109648  14. OC\\AppFramework\\Bootstrap\\BootContext->injectFn() /home/travis/build/nextcloud/server/apps/workflowengine/lib/AppInfo/Application.php:62\n  550.6290   19109704  15. OC\\AppFramework\\Bootstrap\\FunctionInjector->injectFn() /home/travis/build/nextcloud/server/lib/private/AppFramework/Bootstrap/BootContext.php:52\n  550.6293   19110648  16. OCA\\WorkflowEngine\\AppInfo\\Application->registerRuleListeners() /home/travis/build/nextcloud/server/lib/private/AppFramework/Bootstrap/FunctionInjector.php:68\n  550.6309   19257320  17. OCA\\WorkflowEngine\\Manager->getAllConfiguredEvents() /home/travis/build/nextcloud/server/apps/workflowengine/lib/AppInfo/Application.php:70\n  550.6311   19261056  18. OC\\DB\\QueryBuilder\\QueryBuilder->execute() /home/travis/build/nextcloud/server/apps/workflowengine/lib/Manager.php:155\n  550.6311   19261056  19. Doctrine\\DBAL\\Query\\QueryBuilder->execute() /home/travis/build/nextcloud/server/lib/private/DB/QueryBuilder/QueryBuilder.php:217\n  550.6312   19261216  20. OC\\DB\\OracleConnection->executeQuery() /home/travis/build/nextcloud/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Query/QueryBuilder.php:206\n  550.6312   19261376  21. OC\\DB\\OracleConnection->executeQuery() /home/travis/build/nextcloud/server/lib/private/DB/Connection.php:194\n  550.6314   19264328  22. Doctrine\\DBAL\\Driver\\OCI8\\OCI8Statement->execute() /home/travis/build/nextcloud/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:906\n","__class__":"Doctrine\\DBAL\\Driver\\OCI8\\OCI8Exception"},"SELECT DISTINCT \"class\", \"entity\", \"events\" FROM \"oc_flow_operations\" WHERE to_char(\"events\") <> ?",{"1":"[]"}]},{"file":"/home/travis/build/nextcloud/server/lib/private/DB/Connection.php","line":194,"function":"executeQuery","class":"Doctrine\\DBAL\\Connection","type":"->","args":["SELECT DISTINCT \"class\", \"entity\", \"events\" FROM \"oc_flow_operations\" WHERE to_char(\"events\") <> ?",["[]"],[2],null]},{"file":"/home/travis/build/nextcloud/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Query/QueryBuilder.php","line":206,"function":"executeQuery","class":"OC\\DB\\Connection","type":"->","args":["SELECT DISTINCT \"class\", \"entity\", \"events\" FROM \"oc_flow_operations\" WHERE to_char(\"events\") <> :dcValue1",{"dcValue1":"[]"},{"dcValue1":2}]},{"file":"/home/travis/build/nextcloud/server/lib/private/DB/QueryBuilder/QueryBuilder.php","line":217,"function":"execute","class":"Doctrine\\DBAL\\Query\\QueryBuilder","type":"->","args":[]},{"file":"/home/travis/build/nextcloud/server/apps/workflowengine/lib/Manager.php","line":155,"function":"execute","class":"OC\\DB\\QueryBuilder\\QueryBuilder","type":"->","args":[]},{"file":"/home/travis/build/nextcloud/server/apps/workflowengine/lib/AppInfo/Application.php","line":70,"function":"getAllConfiguredEvents","class":"OCA\\WorkflowEngine\\Manager","type":"->","args":[]},{"file":"/home/travis/build/nextcloud/server/lib/private/AppFramework/Bootstrap/FunctionInjector.php","line":68,"function":"registerRuleListeners","class":"OCA\\WorkflowEngine\\AppInfo\\Application","type":"->","args":[{"__class__":"OC\\EventDispatcher\\EventDispatcher"},{"__class__":"OC\\Server"},{"__class__":"OC\\AppFramework\\Logger"}]},{"file":"/home/travis/build/nextcloud/server/lib/private/AppFramework/Bootstrap/BootContext.php","line":52,"function":"injectFn","class":"OC\\AppFramework\\Bootstrap\\FunctionInjector","type":"->","args":[{"__class__":"Closure"}]},{"file":"/home/travis/build/nextcloud/server/apps/workflowengine/lib/AppInfo/Application.php","line":62,"function":"injectFn","class":"OC\\AppFramework\\Bootstrap\\BootContext","type":"->","args":[{"__class__":"Closure"}]},{"file":"/home/travis/build/nextcloud/server/lib/private/AppFramework/Bootstrap/Coordinator.php","line":168,"function":"boot","class":"OCA\\WorkflowEngine\\AppInfo\\Application","type":"->","args":[{"__class__":"OC\\AppFramework\\Bootstrap\\BootContext"}]},{"file":"/home/travis/build/nextcloud/server/lib/private/legacy/OC_App.php","line":191,"function":"bootApp","class":"OC\\AppFramework\\Bootstrap\\Coordinator","type":"->","args":["workflowengine"]},{"file":"/home/travis/build/nextcloud/server/lib/private/legacy/OC_App.php","line":131,"function":"loadApp","class":"OC_App","type":"::","args":["workflowengine"]},{"file":"/home/travis/build/nextcloud/server/lib/private/legacy/OC_Util.php","line":201,"function":"loadApps","class":"OC_App","type":"::","args":[["filesystem"]]},{"file":"/home/travis/build/nextcloud/server/lib/private/User/Session.php","line":551,"function":"setupFS","class":"OC_Util","type":"::","args":["*** sensitive parameter replaced ***"]},{"file":"/home/travis/build/nextcloud/server/lib/private/User/Session.php","line":412,"function":"prepareUserLogin","class":"OC\\User\\Session","type":"->","args":[true,"*** sensitive parameter replaced ***"]},{"file":"/home/travis/build/nextcloud/server/lib/private/User/Session.php","line":621,"function":"completeLogin","class":"OC\\User\\Session","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"/home/travis/build/nextcloud/server/lib/private/User/Session.php","line":366,"function":"loginWithPassword","class":"OC\\User\\Session","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"/home/travis/build/nextcloud/server/lib/private/Setup.php","line":454,"function":"login","class":"OC\\User\\Session","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"/home/travis/build/nextcloud/server/core/Controller/SetupController.php","line":83,"function":"install","class":"OC\\Setup","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"/home/travis/build/nextcloud/server/lib/base.php","line":953,"function":"run","class":"OC\\Core\\Controller\\SetupController","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"/home/travis/build/nextcloud/server/index.php","line":37,"function":"handleRequest","class":"OC","type":"::","args":[]}],"File":"/home/travis/build/nextcloud/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php","Line":57,"Previous":{"Exception":"Doctrine\\DBAL\\Driver\\OCI8\\OCI8Exception","Message":"ORA-00932: inconsistent datatypes: expected - got CLOB","Code":0,"Trace":[{"file":"/home/travis/build/nextcloud/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php","line":399,"function":"fromErrorInfo","class":"Doctrine\\DBAL\\Driver\\OCI8\\OCI8Exception","type":"::","args":[{"code":932,"message":"ORA-00932: inconsistent datatypes: expected - got CLOB","offset":35,"sqltext":"SELECT DISTINCT \"class\", \"entity\", \"events\" FROM \"oc_flow_operations\" WHERE to_char(\"events\") <> :param1"}]},{"file":"/home/travis/build/nextcloud/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Connection.php","line":906,"function":"execute","class":"Doctrine\\DBAL\\Driver\\OCI8\\OCI8Statement","type":"->","args":[]},{"file":"/home/travis/build/nextcloud/server/lib/private/DB/Connection.php","line":194,"function":"executeQuery","class":"Doctrine\\DBAL\\Connection","type":"->","args":["SELECT DISTINCT \"class\", \"entity\", \"events\" FROM \"oc_flow_operations\" WHERE to_char(\"events\") <> ?",["[]"],[2],null]},{"file":"/home/travis/build/nextcloud/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Query/QueryBuilder.php","line":206,"function":"executeQuery","class":"OC\\DB\\Connection","type":"->","args":["SELECT DISTINCT \"class\", \"entity\", \"events\" FROM \"oc_flow_operations\" WHERE to_char(\"events\") <> :dcValue1",{"dcValue1":"[]"},{"dcValue1":2}]},{"file":"/home/travis/build/nextcloud/server/lib/private/DB/QueryBuilder/QueryBuilder.php","line":217,"function":"execute","class":"Doctrine\\DBAL\\Query\\QueryBuilder","type":"->","args":[]},{"file":"/home/travis/build/nextcloud/server/apps/workflowengine/lib/Manager.php","line":155,"function":"execute","class":"OC\\DB\\QueryBuilder\\QueryBuilder","type":"->","args":[]},{"file":"/home/travis/build/nextcloud/server/apps/workflowengine/lib/AppInfo/Application.php","line":70,"function":"getAllConfiguredEvents","class":"OCA\\WorkflowEngine\\Manager","type":"->","args":[]},{"file":"/home/travis/build/nextcloud/server/lib/private/AppFramework/Bootstrap/FunctionInjector.php","line":68,"function":"registerRuleListeners","class":"OCA\\WorkflowEngine\\AppInfo\\Application","type":"->","args":[{"__class__":"OC\\EventDispatcher\\EventDispatcher"},{"__class__":"OC\\Server"},{"__class__":"OC\\AppFramework\\Logger"}]},{"file":"/home/travis/build/nextcloud/server/lib/private/AppFramework/Bootstrap/BootContext.php","line":52,"function":"injectFn","class":"OC\\AppFramework\\Bootstrap\\FunctionInjector","type":"->","args":[{"__class__":"Closure"}]},{"file":"/home/travis/build/nextcloud/server/apps/workflowengine/lib/AppInfo/Application.php","line":62,"function":"injectFn","class":"OC\\AppFramework\\Bootstrap\\BootContext","type":"->","args":[{"__class__":"Closure"}]},{"file":"/home/travis/build/nextcloud/server/lib/private/AppFramework/Bootstrap/Coordinator.php","line":168,"function":"boot","class":"OCA\\WorkflowEngine\\AppInfo\\Application","type":"->","args":[{"__class__":"OC\\AppFramework\\Bootstrap\\BootContext"}]},{"file":"/home/travis/build/nextcloud/server/lib/private/legacy/OC_App.php","line":191,"function":"bootApp","class":"OC\\AppFramework\\Bootstrap\\Coordinator","type":"->","args":["workflowengine"]},{"file":"/home/travis/build/nextcloud/server/lib/private/legacy/OC_App.php","line":131,"function":"loadApp","class":"OC_App","type":"::","args":["workflowengine"]},{"file":"/home/travis/build/nextcloud/server/lib/private/legacy/OC_Util.php","line":201,"function":"loadApps","class":"OC_App","type":"::","args":[["filesystem"]]},{"file":"/home/travis/build/nextcloud/server/lib/private/User/Session.php","line":551,"function":"setupFS","class":"OC_Util","type":"::","args":["*** sensitive parameter replaced ***"]},{"file":"/home/travis/build/nextcloud/server/lib/private/User/Session.php","line":412,"function":"prepareUserLogin","class":"OC\\User\\Session","type":"->","args":[true,"*** sensitive parameter replaced ***"]},{"file":"/home/travis/build/nextcloud/server/lib/private/User/Session.php","line":621,"function":"completeLogin","class":"OC\\User\\Session","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"/home/travis/build/nextcloud/server/lib/private/User/Session.php","line":366,"function":"loginWithPassword","class":"OC\\User\\Session","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"/home/travis/build/nextcloud/server/lib/private/Setup.php","line":454,"function":"login","class":"OC\\User\\Session","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"/home/travis/build/nextcloud/server/core/Controller/SetupController.php","line":83,"function":"install","class":"OC\\Setup","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"/home/travis/build/nextcloud/server/lib/base.php","line":953,"function":"run","class":"OC\\Core\\Controller\\SetupController","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"/home/travis/build/nextcloud/server/index.php","line":37,"function":"handleRequest","class":"OC","type":"::","args":[]}],"File":"/home/travis/build/nextcloud/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Driver/OCI8/OCI8Exception.php","Line":23},"CustomMessage":"Could not boot workflowengineAn exception occurred while executing 'SELECT DISTINCT \"class\", \"entity\", \"events\" FROM \"oc_flow_operations\" WHERE to_char(\"events\") <> ?' with params [\"[]\"]:\n\nORA-00932: inconsistent datatypes: expected - got CLOB"},"userAgent":"--","version":"20.0.0.3"}
```
