### PR TITLE
ignore duplicate setting sections

### DIFF
--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -106,7 +106,7 @@ class Manager implements IManager {
 			return $this->sections[$type];
 		}
 
-		foreach ($this->sectionClasses[$type] as $index => $class) {
+		foreach (array_unique($this->sectionClasses[$type]) as $index => $class) {
 			try {
 				/** @var ISection $section */
 				$section = \OC::$server->query($class);
@@ -123,7 +123,7 @@ class Manager implements IManager {
 			$sectionID = $section->getID();
 
 			if (isset($this->sections[$type][$sectionID])) {
-				$this->log->logException(new \InvalidArgumentException('Section with the same ID already registered'), ['level' => ILogger::INFO]);
+				$this->log->logException(new \InvalidArgumentException('Section with the same ID already registered: ' . $sectionID . ', class: ' . $class), ['level' => ILogger::INFO]);
 				continue;
 			}
 


### PR DESCRIPTION
this prevents some 'Section with the same ID already registered' errors in the log

also includes an improvement of the error message to make other cases easier to find

Signed-off-by: Robin Appelman <robin@icewind.nl>