### PR TITLE
set the mount id before calling storage wrapper

### DIFF
--- a/lib/private/Files/Mount/MountPoint.php
+++ b/lib/private/Files/Mount/MountPoint.php
@@ -102,6 +102,7 @@ class MountPoint implements IMountPoint {
 
 		$mountpoint = $this->formatPath($mountpoint);
 		$this->mountPoint = $mountpoint;
+		$this->mountId = $mountId;
 		if ($storage instanceof Storage) {
 			$this->class = get_class($storage);
 			$this->storage = $this->loader->wrap($this, $storage);
@@ -113,7 +114,6 @@ class MountPoint implements IMountPoint {
 			$this->class = $storage;
 			$this->arguments = $arguments;
 		}
-		$this->mountId = $mountId;
 	}
 
 	/**


### PR DESCRIPTION
this allows the storage wrapper to use the mount id for it's own logic

Signed-off-by: Robin Appelman <robin@icewind.nl>