### PR TITLE
dont use `false` as cache key for non utf8 path in normalizePath

### DIFF
--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -813,7 +813,7 @@ class Filesystem {
 
 		$cacheKey = json_encode([$path, $stripTrailingSlash, $isAbsolutePath, $keepUnicode]);
 
-		if (isset(self::$normalizedPathCache[$cacheKey])) {
+		if ($cacheKey && isset(self::$normalizedPathCache[$cacheKey])) {
 			return self::$normalizedPathCache[$cacheKey];
 		}
 


### PR DESCRIPTION
since `json_encode` returns `false` if it's input isn't utf8, all non utf8 paths passed to normalizePath will currently return the same cached result.

Fixing this makes working with non utf8 storages a *little* bit more possible for apps

Signed-off-by: Robin Appelman <robin@icewind.nl>