### PR TITLE
Do not fail if share for mountpoint is no longer available

### DIFF
--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -511,7 +511,7 @@ class Manager {
 			WHERE `id` = ?
 			');
 			$result = (bool)$query->execute([(int)$share['id']]);
-		} elseif ($result && (int)$share['share_type'] === IShare::TYPE_GROUP) {
+		} elseif ($result && $share !== false && (int)$share['share_type'] === IShare::TYPE_GROUP) {
 			$query = $this->connection->prepare('
 				UPDATE `*PREFIX*share_external`
 				SET `accepted` = ?


### PR DESCRIPTION
If the share for a mountpoint cannot be found in the oc_share_external table anymore, the elseif would still pass and then try to access `$share` even though it is false:

```
Exception during scan: Trying to access array offset on value of type bool
#0 /var/www/nextcloud/apps/files_sharing/lib/External/Manager.php(533): OCA\Files\Command\Scan->exceptionErrorHandler()
#1 /var/www/nextcloud/apps/files_sharing/lib/External/Storage.php(219): OCA\Files_Sharing\External\Manager->removeShare()
#2 [internal function]: OCA\Files_Sharing\External\Storage->checkStorageAvailability()
#3 /var/www/nextcloud/lib/private/Files/Storage/Wrapper/Wrapper.php(507): call_user_func_array()
#4 [internal function]: OC\Files\Storage\Wrapper\Wrapper->__call()
#5 /var/www/nextcloud/lib/private/Files/Storage/Wrapper/Wrapper.php(507): call_user_func_array()
#6 /var/www/nextcloud/apps/files_sharing/lib/External/Scanner.php(90): OC\Files\Storage\Wrapper\Wrapper->__call()
#7 /var/www/nextcloud/apps/files_sharing/lib/External/Scanner.php(45): OCA\Files_Sharing\External\Scanner->scanAll()
#8 /var/www/nextcloud/lib/private/Files/Utils/Scanner.php(260): OCA\Files_Sharing\External\Scanner->scan()
#9 /var/www/nextcloud/apps/files/lib/Command/Scan.php(151): OC\Files\Utils\Scanner->scan()
#10 /var/www/nextcloud/apps/files/lib/Command/Scan.php(207): OCA\Files\Command\Scan->scanFiles()
#11 /var/www/nextcloud/3rdparty/symfony/console/Command/Command.php(255): OCA\Files\Command\Scan->execute()
#12 /var/www/nextcloud/core/Command/Base.php(169): Symfony\Component\Console\Command\Command->run()
#13 /var/www/nextcloud/3rdparty/symfony/console/Application.php(1012): OC\Core\Command\Base->run()
#14 /var/www/nextcloud/3rdparty/symfony/console/Application.php(272): Symfony\Component\Console\Application->doRunCommand()
#15 /var/www/nextcloud/3rdparty/symfony/console/Application.php(148): Symfony\Component\Console\Application->doRun()
#16 /var/www/nextcloud/lib/private/Console/Application.php(215): Symfony\Component\Console\Application->run()
#17 /var/www/nextcloud/console.php(100): OC\Console\Application->run()
#18 /var/www/nextcloud/occ(11): require_once('/var/www/nextcl...')
#19 {main}
```