### PR TITLE
20 beta 4

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [20, 0, 0, 5];
+$OC_Version = [20, 0, 0, 6];
 
 // The human readable string
-$OC_VersionString = '20.0.0 Beta 3';
+$OC_VersionString = '20.0.0 Beta 4';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #17456 IMIP email improvements (take 2)
* #21082 Show changelog in apps management
* #21945 Changed Content-Disposition header to download Contact Photo with correct extension
* #22136 Add 'Reasons to use Nextcloud in your organization' call to action in settings
* #22469 Don't use SELECT DISTINCT when to_char() is used in a WHERE statement
* #22520 Dont use `false` as cache key for non utf8 path in normalizePath
* #22524 Fix app password updating out of bounds
* #22531 Fix dashboard statuses toggling
* #22540 Adapt status menu styles to nc/vue 2.6
* #22543 Don't keep menu open for next user after deleting one
* #22548 Improved status cleanup
* #22550 Use the correct root to determinate the webroot for the resource
* #22552 Add opendocument templates to mimetype mappings
* #22564 The privacy setting is only about syncing to other servers
* #22573 Remove tooltip on customize button in dashboard
* #22577 Better error message when blocked by access control
* #22578 Upgrade icewind/smb to 3.2.7
* #22583 LDAP: remove unused methods and DB values
* #22587 Check if var debugMode exists
* #22589 Allow additional personal settings via normal registration
* #22596 Build weather-status to solve design issues
* #22597 Add missing alias for OCP\Settings\IManager and deprecate the old one
* #22600 Bump http-proxy from 1.17.0 to 1.18.1 in /build
* #22605 [Automated] Update psalm-baseline.xml
* #22614 Increase html body height to full content height
* #22615 Change status popover container
* #22617 Bump @babel/core from 7.11.4 to 7.11.6
* #22622 Bump sass-loader from 9.0.3 to 10.0.2
* #22634 [Automated] Update psalm-baseline.xml
* #22636 Make sure that getConfig is still called for browsers that do not support CSPv3
* #22637 Fix weather status icon selector with nextcloud/vue update
* #22638 Add icon for dashboard app store category
* #22639 Move unified search to OCS api
* #22641 Fix undefined class property access after upgrade from 19 to 20
* #22642 Move to automated dependabot merging
* #22643 Fix installing on Oracle
* #22644 Update license headers for Nextcloud 20 (again)
* #22646 Fix detecting text/x-php mimetype and secure mimetype mapping
* #22647 Fix use of removed escapeHTML in settings.js
* #22648 Transfer shares if no path provided
* #22649 Emit typed event for user management
* #22650 Only load viewer in settings if the viewer app is enabled
* #22651 Fix reading empty files from objectstorage
* #22657 Check if quota should be applied to path when creating directories
* #22660 Bump psalm/phar from 3.12.2 to 3.15
* #22663 Bump karma-viewport from 1.0.6 to 1.0.7 in /build
* #22665 Update behat/behat requirement from ~3.6.1 to ~3.7.0 in /build/integration
* #22672 Bump v-click-outside from 3.1.0 to 3.1.1
* #22687 Bump query-string from 5.1.1 to 6.13.1
* #22700 Bump blueimp-md5 from 2.17.0 to 2.18.0
* #22712 Delete dependabot.yml
* #22729 Run stat less often for objectstorages
* #22739 Don't fail if copying a file of 0 byte size
* #22744 Only get the permissions from the share source if it's not already cached
* #22747 Fix s3 doesDirectoryExist check for empty directories
* #22762 Don't create a deprecation log in base.php
* #22765 Allow to get activities for files by email again
* #22766 Clarify PHP warning in admin settings
* #22768 Change 0 to null to properly encode image to BMP if the first pixel is black
* #22773 Revert "Increase html body height to full content height"
* [activity#488](https://github.com/nextcloud/activity/pull/488) Fix digest activity count not limiting to own activity correctly.
* [activity#489](https://github.com/nextcloud/activity/pull/489) Bump node-sass from 4.1.1 to 4.14.1 in /tests/js
* [activity#491](https://github.com/nextcloud/activity/pull/491) Fix activity tab in the files sidebar
* [activity#492](https://github.com/nextcloud/activity/pull/492) Bugfix/noid/email and notifications fixes
* [files_pdfviewer#210](https://github.com/nextcloud/files_pdfviewer/pull/210) Bump pdf.js to 2.5.207
* [files_pdfviewer#212](https://github.com/nextcloud/files_pdfviewer/pull/212) Bump stylelint from 13.6.1 to 13.7.0
* [files_pdfviewer#213](https://github.com/nextcloud/files_pdfviewer/pull/213) Bump @nextcloud/webpack-vue-config from 1.1.0 to 1.2.0
* [files_pdfviewer#215](https://github.com/nextcloud/files_pdfviewer/pull/215) Bump file-loader from 6.0.0 to 6.1.0
* [files_pdfviewer#217](https://github.com/nextcloud/files_pdfviewer/pull/217) Bump webpack-merge from 5.1.1 to 5.1.3
* [files_pdfviewer#218](https://github.com/nextcloud/files_pdfviewer/pull/218) Bump copy-webpack-plugin from 6.0.3 to 6.1.0
* [files_pdfviewer#219](https://github.com/nextcloud/files_pdfviewer/pull/219) Bump vue and vue-template-compiler
* [files_pdfviewer#221](https://github.com/nextcloud/files_pdfviewer/pull/221) Bump @babel/preset-env from 7.11.0 to 7.11.5
* [files_pdfviewer#222](https://github.com/nextcloud/files_pdfviewer/pull/222) Bump @nextcloud/router from 1.1.0 to 1.2.0
* [files_pdfviewer#223](https://github.com/nextcloud/files_pdfviewer/pull/223) Bump @babel/core from 7.11.1 to 7.11.6
* [files_pdfviewer#224](https://github.com/nextcloud/files_pdfviewer/pull/224) Revert "Bump pdf.js to 2.5.207"
* [files_pdfviewer#226](https://github.com/nextcloud/files_pdfviewer/pull/226) Bump phpunit/phpunit from 7.5.20 to 8.5.8
* [firstrunwizard#399](https://github.com/nextcloud/firstrunwizard/pull/399) Bump @nextcloud/vue from 2.6.1 to 2.6.4
* [firstrunwizard#400](https://github.com/nextcloud/firstrunwizard/pull/400) Bump @nextcloud/router from 1.0.0 to 1.2.0
* [firstrunwizard#403](https://github.com/nextcloud/firstrunwizard/pull/403) Bump @nextcloud/axios from 1.3.1 to 1.4.0
* [firstrunwizard#404](https://github.com/nextcloud/firstrunwizard/pull/404) Bump @babel/core from 7.11.1 to 7.11.6
* [firstrunwizard#405](https://github.com/nextcloud/firstrunwizard/pull/405) Bump acorn from 7.4.0 to 8.0.1
* [firstrunwizard#406](https://github.com/nextcloud/firstrunwizard/pull/406) Bump @nextcloud/l10n from 1.4.0 to 1.4.1
* [logreader#369](https://github.com/nextcloud/logreader/pull/369) Bump elliptic from 6.5.1 to 6.5.3
* [notifications#733](https://github.com/nextcloud/notifications/pull/733) Bump @babel/preset-env from 7.11.0 to 7.11.5
* [notifications#735](https://github.com/nextcloud/notifications/pull/735) Bump @nextcloud/vue from 2.6.3 to 2.6.4
* [notifications#736](https://github.com/nextcloud/notifications/pull/736) Bump webpack-merge from 5.1.2 to 5.1.3
* [notifications#737](https://github.com/nextcloud/notifications/pull/737) Bump @babel/core from 7.11.4 to 7.11.6
* [notifications#738](https://github.com/nextcloud/notifications/pull/738) Bump @nextcloud/router from 1.1.0 to 1.2.0
* [notifications#739](https://github.com/nextcloud/notifications/pull/739) Bump @nextcloud/axios from 1.3.3 to 1.4.0
* [notifications#740](https://github.com/nextcloud/notifications/pull/740) Bump sass-loader from 10.0.1 to 10.0.2
* [notifications#742](https://github.com/nextcloud/notifications/pull/742) Register via injectFn()
* [notifications#743](https://github.com/nextcloud/notifications/pull/743) Keep plaintext fallback when no RichText is given
* [notifications#744](https://github.com/nextcloud/notifications/pull/744) "App tutorial"ize this app
* [notifications#745](https://github.com/nextcloud/notifications/pull/745) Bump phpunit/phpunit from 7.5.20 to 8.5.8
* [notifications#746](https://github.com/nextcloud/notifications/pull/746) Bump @nextcloud/eslint-config from 2.0.0 to 2.2.0
* [notifications#748](https://github.com/nextcloud/notifications/pull/748) Reflect updated JS assets
* [photos#436](https://github.com/nextcloud/photos/pull/436) Bump @nextcloud/router from 1.1.0 to 1.2.0
* [photos#437](https://github.com/nextcloud/photos/pull/437) Bump @babel/core from 7.11.4 to 7.11.6
* [photos#438](https://github.com/nextcloud/photos/pull/438) Bump @babel/preset-env from 7.11.0 to 7.11.5
* [photos#439](https://github.com/nextcloud/photos/pull/439) Bump @nextcloud/vue from 2.6.1 to 2.6.4
* [photos#440](https://github.com/nextcloud/photos/pull/440) Bump @nextcloud/axios from 1.3.3 to 1.4.0
* [photos#441](https://github.com/nextcloud/photos/pull/441) Bump @nextcloud/l10n from 1.3.0 to 1.4.0
* [photos#442](https://github.com/nextcloud/photos/pull/442) Bump webpack-merge from 5.1.2 to 5.1.3
* [photos#443](https://github.com/nextcloud/photos/pull/443) Bump stylelint from 13.6.1 to 13.7.0
* [photos#444](https://github.com/nextcloud/photos/pull/444) Bump @vue/test-utils from 1.0.4 to 1.0.5
* [privacy#506](https://github.com/nextcloud/privacy/pull/506) Bump @nextcloud/axios from 1.3.3 to 1.4.0
* [privacy#508](https://github.com/nextcloud/privacy/pull/508) Bump @nextcloud/vue from 2.6.3 to 2.6.4
* [privacy#509](https://github.com/nextcloud/privacy/pull/509) Bump @babel/core from 7.11.5 to 7.11.6
* [privacy#510](https://github.com/nextcloud/privacy/pull/510) Automerge patch updates of dependencies
* [privacy#511](https://github.com/nextcloud/privacy/pull/511) Remove myself as reviewer
* [privacy#512](https://github.com/nextcloud/privacy/pull/512) Bump @nextcloud/l10n from 1.4.0 to 1.4.1
* [privacy#514](https://github.com/nextcloud/privacy/pull/514) Bump webpack-merge from 5.1.3 to 5.1.4
* [recommendations#281](https://github.com/nextcloud/recommendations/pull/281) Remove duplicate hidden overflow causing safari issues
* [recommendations#284](https://github.com/nextcloud/recommendations/pull/284) Bump @nextcloud/axios from 1.3.3 to 1.4.0
* [recommendations#285](https://github.com/nextcloud/recommendations/pull/285) Bump webpack-merge from 5.1.2 to 5.1.3
* [recommendations#286](https://github.com/nextcloud/recommendations/pull/286) Bump stylelint from 13.6.1 to 13.7.0
* [recommendations#287](https://github.com/nextcloud/recommendations/pull/287) Bump @nextcloud/router from 1.1.0 to 1.2.0
* [recommendations#288](https://github.com/nextcloud/recommendations/pull/288) Bump @babel/preset-env from 7.11.0 to 7.11.5
* [recommendations#290](https://github.com/nextcloud/recommendations/pull/290) Bump @babel/core from 7.11.4 to 7.11.6
* [recommendations#292](https://github.com/nextcloud/recommendations/pull/292) Check for mimetypes and files app before trying to navigate
* [serverinfo#231](https://github.com/nextcloud/serverinfo/pull/231) Normalize memory and disk values to MB
* [text#1004](https://github.com/nextcloud/text/pull/1004) Use proper event for loading scripts on public share links
* [text#1007](https://github.com/nextcloud/text/pull/1007) Move to automated dependabot merging
* [text#1008](https://github.com/nextcloud/text/pull/1008) Bump @babel/core from 7.11.4 to 7.11.6
* [text#1009](https://github.com/nextcloud/text/pull/1009) Bump @nextcloud/vue from 2.3.0 to 2.6.4
* [text#1012](https://github.com/nextcloud/text/pull/1012) Bump @vue/test-utils from 1.0.3 to 1.0.5
* [text#1014](https://github.com/nextcloud/text/pull/1014) Harden check when using token from memcache
* [text#1016](https://github.com/nextcloud/text/pull/1016) Harden read only check on public endpoints
* [text#1021](https://github.com/nextcloud/text/pull/1021) Bump christophwurst/nextcloud from 16.0.0 to 19.0.0
* [text#1022](https://github.com/nextcloud/text/pull/1022) Bump file-loader from 6.0.0 to 6.1.0
* [text#1024](https://github.com/nextcloud/text/pull/1024) Bump @babel/plugin-transform-runtime from 7.11.0 to 7.11.5
* [text#1025](https://github.com/nextcloud/text/pull/1025) Sessionid is an int
* [text#1026](https://github.com/nextcloud/text/pull/1026) Refresh lastContact only once every 30 seconds
* [text#1032](https://github.com/nextcloud/text/pull/1032) Yet another IE11 fixing round
* [text#983](https://github.com/nextcloud/text/pull/983) Bump vue and vue-template-compiler
* [text#986](https://github.com/nextcloud/text/pull/986) Bump webpack-merge from 4.2.2 to 5.1.2
* [text#999](https://github.com/nextcloud/text/pull/999) Bump sass-loader from 9.0.3 to 10.0.1
* [viewer#591](https://github.com/nextcloud/viewer/pull/591) Create Dependabot config file
* [viewer#593](https://github.com/nextcloud/viewer/pull/593) Bump @nextcloud/vue from 2.6.1 to 2.6.4
* [viewer#594](https://github.com/nextcloud/viewer/pull/594) Bump @nextcloud/router from 1.1.0 to 1.2.0
* [viewer#595](https://github.com/nextcloud/viewer/pull/595) Bump @babel/core from 7.11.4 to 7.11.6
* [viewer#596](https://github.com/nextcloud/viewer/pull/596) Bump webpack-merge from 5.1.2 to 5.1.3
* [viewer#597](https://github.com/nextcloud/viewer/pull/597) Bump cypress from 5.0.0 to 5.1.0
* [viewer#598](https://github.com/nextcloud/viewer/pull/598) Bump stylelint from 13.6.1 to 13.7.0
* [viewer#599](https://github.com/nextcloud/viewer/pull/599) Bump @babel/preset-env from 7.11.0 to 7.11.5
* [viewer#600](https://github.com/nextcloud/viewer/pull/600) AUto merge and add compsoer
* [viewer#601](https://github.com/nextcloud/viewer/pull/601) Bump @nextcloud/axios from 1.3.3 to 1.4.0
* [viewer#602](https://github.com/nextcloud/viewer/pull/602) Bump file-loader from 6.0.0 to 6.1.0
* [viewer#603](https://github.com/nextcloud/viewer/pull/603) Bump @nextcloud/dialogs from 2.0.0 to 2.0.1
* [viewer#604](https://github.com/nextcloud/viewer/pull/604) Dependabot-automerge  token
* [viewer#605](https://github.com/nextcloud/viewer/pull/605) Expose mimetypes so apps can check upfront if a file can be opened


Pending PRs:

* [ ] #16696 Fixed moving of master key encrypted and versioned files between shared folders @yahesh
* [ ] #22234 Use user mount with matching shared storage only @juliushaertl
* [ ] #22294 SFTP-Storage: Correctly Sync mtime @msander
* [ ] #22395 Fix settings chunk loading @skjnldsv
* [ ] #22563 Re-fix transaction isolation level @nickvergessen
* [ ] #22626 Bump dompurify from 2.0.14 to 2.0.15 
* [x] #22635 Bump @nextcloud/l10n from 1.4.0 to 1.4.1 
* [x] #22661 Bump karma-coverage from 2.0.1 to 2.0.3 in /build 
* [ ] #22761 Extend integration tests for "files:transfer-ownership" command @danxuliu
* [ ] #22770 Mitigate encoding issue with user principal uri @georgehrke
* [x] #22771 Switch to typed event for LDAPs user added to group case @blizzz
* [x] #22774 Don't break when the IP is empty @nickvergessen
* [ ] [files_pdfviewer#202](https://github.com/nextcloud/files_pdfviewer/pull/202) Fix styling and move towards standard TemplateResponse @skjnldsv
