### PR TITLE
[stable18] Use the correct root to determinate the webroot for the resource

### DIFF
--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -109,7 +109,7 @@ class CSSResourceLocator extends ResourceLocator {
 			if($this->scssCacher !== null) {
 				if($this->scssCacher->process($root, $file, $app)) {
 
-					$this->append($root, $this->scssCacher->getCachedSCSS($app, $file), \OC::$WEBROOT, true, true);
+					$this->append($this->serverroot, $this->scssCacher->getCachedSCSS($app, $file), \OC::$WEBROOT, true, true);
 					return true;
 				} else {
 					$this->logger->warning('Failed to compile and/or save '.$root.'/'.$file, ['app' => 'core']);
@@ -145,7 +145,7 @@ class CSSResourceLocator extends ResourceLocator {
 				}
 			}
 
-			$this->resources[] = array($webRoot? : \OC::$WEBROOT, $webRoot, $file);
+			$this->resources[] = array($webRoot ?: \OC::$WEBROOT, $webRoot, $file);
 		}
 	}
 }


### PR DESCRIPTION
Since all the compiled routes are based on the server webroot,
we have to use this, independent from which app this belongs to.
Backport of #22550