### PR TITLE
Check if var debugMode exists

### DIFF
--- a/core/templates/exception.php
+++ b/core/templates/exception.php
@@ -23,7 +23,7 @@ style('core', ['styles', 'header']);
 		<?php endif; ?>
 	</ul>
 
-	<?php if ($_['debugMode']): ?>
+	<?php if (isset($_['debugMode']) && $_['debugMode'] === true): ?>
 		<br />
 		<h3><?php p($l->t('Trace')) ?></h3>
 		<pre><?php p($_['trace']) ?></pre>


### PR DESCRIPTION
Closes #21150 a second time.
2nd appearance of debugMode may not seen in first fix.

Please also backport this PR to supported versions.