### PR TITLE
Allow additional personal settings via normal registration

### DIFF
--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -261,7 +261,8 @@ class Manager implements IManager {
 		$sections = [];
 
 		$legacyForms = \OC_App::getForms('personal');
-		if (!empty($legacyForms) && $this->hasLegacyPersonalSettingsToRender($legacyForms)) {
+		if ((!empty($legacyForms) && $this->hasLegacyPersonalSettingsToRender($legacyForms))
+			|| count($this->getPersonalSettings('additional')) > 1) {
 			$sections[98] = [new Section('additional', $this->l->t('Additional settings'), 0, $this->url->imagePath('core', 'actions/settings-dark.svg'))];
 		}
 


### PR DESCRIPTION
Currently the `Additional settings` for personal settings only shows when there are legacy panel registered via `\OCP\App::registerPersonal('ransomware_protection', 'personal');`
When this is transformed into a "normal" setting, it works and shows up in the additional section, as long as there is one "old" setting registered, otherwise the menu entry will not show up (but the page will work and show the setting).

So we now check if there is a legacy setting or any other setting registered for additional to determine whether the panel should display, or was this a conscious decision to get rid of the `additional` section for personal settings but keep it in administration settings?