### PR TITLE
External storage encryption delete error 

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -515,7 +515,8 @@ class Cache implements ICache {
 	 */
 	public function remove($file) {
 		$entry = $this->get($file);
-
+		// when deleting the entry, encrypted is not save in database, so we ignore it
+		unset($entry['encrypted']);
 		if ($entry) {
 			$query = $this->getQueryBuilder();
 			$query->delete('filecache')


### PR DESCRIPTION
fix issue caused by https://github.com/nextcloud/server/commit/d3b6dbc0bc1aa2c81ca5e526d597ddbfca762cdf
# Error Message:
```
<?xml version="1.0" encoding="utf-8"?>
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
  <s:exception>Error</s:exception>
  <s:message>Call to a member function getId() on array</s:message>
</d:error>
```
# Analysis 
## File Upload
the metadata `encrypted` is not saved 

```
[0] OC\Files\Cache\Cache->insert @ /var/www/html/lib/private/Files/Cache/Cache.php:262
[1] OC\Files\Cache\Wrapper\CachePermissionsMask->insert @ /var/www/html/lib/private/Files/Cache/Wrapper/CacheWrapper.php:131
[2] OC\Files\Cache\Scanner->addToCache @ /var/www/html/lib/private/Files/Cache/Scanner.php:294
[3] OC\Files\Cache\Scanner->scanFile @ /var/www/html/lib/private/Files/Cache/Scanner.php:224
[4] OC\Files\Cache\Scanner->scan @ /var/www/html/lib/private/Files/Cache/Scanner.php:338
[5] OC\Files\Cache\Updater->update @ /var/www/html/lib/private/Files/Cache/Updater.php:126
[6] OCA\DAV\Connector\Sabre\File->put @ /var/www/html/apps/dav/lib/Connector/Sabre/File.php:299
[7] OCA\DAV\Connector\Sabre\Directory->createFile @ /var/www/html/apps/dav/lib/Connector/Sabre/Directory.php:155
[8] OCA\DAV\Connector\Sabre\Server->createFile @ /var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php:1104
[9] Sabre\DAV\CorePlugin->httpPut @ /var/www/html/3rdparty/sabre/dav/lib/DAV/CorePlugin.php:527
[10] OCA\DAV\Connector\Sabre\Server->emit @ /var/www/html/3rdparty/sabre/event/lib/WildcardEmitterTrait.php:89
[11] OCA\DAV\Connector\Sabre\Server->invokeMethod @ /var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php:474
[12] OCA\DAV\Connector\Sabre\Server->start @ /var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php:251
[13] OCA\DAV\Connector\Sabre\Server->exec @ /var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php:319
[14] require_once @ /var/www/html/apps/dav/appinfo/v1/webdav.php:84
[15] {main} @ /var/www/html/remote.php:167

 _ $builder = (uninitialized)
 _ $column = (uninitialized)
 _ $data = (array [10])
   _ $data["mimetype"] = (string [10]) `image/jpeg`
   _ $data["mtime"] = (int) 1599234758
   _ $data["size"] = (int) 267298
   _ $data["etag"] = (string [13]) `5f5262c877be5`
   _ $data["storage_mtime"] = (int) 1599234758
   _ $data["permissions"] = (int) 27
   _ $data["name"] = (string [12]) `IMG_2080.JPG`
   _ $data["scan_permissions"] = (int) 27
   _ $data["parent"] = (int) 12674
   _ $data["checksum"] = (string [0]) ``
 _ $e = (uninitialized)
 _ $extensionValues = (uninitialized)
 _ $field = (uninitialized)
 _ $file = (string [21]) `app-test/IMG_2080.JPG`
 _ $fileId = (uninitialized)
 _ $id = (uninitialized)
 _ $query = (uninitialized)
 _ $requiredFields = (uninitialized)
 _ $value = (uninitialized)
 _ $values = (uninitialized)
 _ $this = (OC\Files\Cache\Cache [8])
   _ $this->partial = (array)
   _ $this->storageId = (string [15]) `amazon::app-dev`
   _ $this->storage = (OCA\Files_Trashbin\Storage [12])
   _ $this->storageCache = (OC\Files\Cache\Storage [3])
   _ $this->mimetypeLoader = (OC\Files\Type\Loader [3])
   _ $this->connection = (OC\DB\Connection [19])
   _ $this->eventDispatcher = (OC\EventDispatcher\SymfonyAdapter [2])
   _ $this->querySearchHelper = (OC\Files\Cache\QuerySearchHelper [3])

```

## File Delete 
when deleting file, 'encrypted' is added, so it pass  condition check `if ($entry) {`,  result in the error 
```
[0] OC\Files\Cache\Cache->insert @ /var/www/html/lib/private/Files/Cache/Cache.php:262
[1] OC\Files\Cache\Wrapper\CachePermissionsMask->insert @ /var/www/html/lib/private/Files/Cache/Wrapper/CacheWrapper.php:131
[2] OC\Files\Cache\Wrapper\CachePermissionsMask->put @ /var/www/html/lib/private/Files/Cache/Wrapper/CacheWrapper.php:117
[3] OC\Files\Storage\Wrapper\Encryption->updateEncryptedVersion @ /var/www/html/lib/private/Files/Storage/Wrapper/Encryption.php:688
[4] OC\Files\Storage\Wrapper\Encryption->copyBetweenStorage @ /var/www/html/lib/private/Files/Storage/Wrapper/Encryption.php:769
[5] OC\Files\Storage\Wrapper\Encryption->moveFromStorage @ /var/www/html/lib/private/Files/Storage/Wrapper/Encryption.php:625
[6] OCA\Files_Trashbin\Storage->moveFromStorage @ /var/www/html/lib/private/Files/Storage/Wrapper/Wrapper.php:575
[7] OCA\Files_Trashbin\Trashbin::move2trash @ /var/www/html/apps/files_trashbin/lib/Trashbin.php:296
[8] OCA\Files_Trashbin\Trash\LegacyTrashBackend->moveToTrash @ /var/www/html/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php:108
[9] OCA\Files_Trashbin\Trash\TrashManager->moveToTrash @ /var/www/html/apps/files_trashbin/lib/Trash/TrashManager.php:103
[10] OCA\Files_Trashbin\Storage->doDelete @ /var/www/html/apps/files_trashbin/lib/Storage.php:192
[11] OCA\Files_Trashbin\Storage->unlink @ /var/www/html/apps/files_trashbin/lib/Storage.php:99
[12] OC\Files\View->basicOperation @ /var/www/html/lib/private/Files/View.php:1161
[13] OC\Files\View->unlink @ /var/www/html/lib/private/Files/View.php:718
[14] OCA\DAV\Connector\Sabre\File->delete @ /var/www/html/apps/dav/lib/Connector/Sabre/File.php:455
[15] OCA\DAV\Connector\Sabre\CachingTree->delete @ /var/www/html/3rdparty/sabre/dav/lib/DAV/Tree.php:183
[16] Sabre\DAV\CorePlugin->httpDelete @ /var/www/html/3rdparty/sabre/dav/lib/DAV/CorePlugin.php:295
[17] OCA\DAV\Connector\Sabre\Server->emit @ /var/www/html/3rdparty/sabre/event/lib/WildcardEmitterTrait.php:89
[18] OCA\DAV\Connector\Sabre\Server->invokeMethod @ /var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php:474
[19] OCA\DAV\Connector\Sabre\Server->start @ /var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php:251
[20] OCA\DAV\Connector\Sabre\Server->exec @ /var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php:319
[21] OCA\DAV\Server->exec @ /var/www/html/apps/dav/lib/Server.php:325
[22] require_once @ /var/www/html/apps/dav/appinfo/v2/remote.php:35
[23] {main} @ /var/www/html/remote.php:167

 _ $builder = (uninitialized)
 _ $column = (uninitialized)
 _ $data = (array [1])
   _ $data["encrypted"] = (bool) 0
 _ $e = (uninitialized)
 _ $extensionValues = (uninitialized)
 _ $field = (uninitialized)
 _ $file = (string [21]) `app-test/IMG_2192.PNG`
 _ $fileId = (uninitialized)
 _ $id = (uninitialized)
 _ $query = (uninitialized)
 _ $requiredFields = (uninitialized)
 _ $value = (uninitialized)
 _ $values = (uninitialized)
 _ $this = (OC\Files\Cache\Cache [8])
   _ $this->partial = (array)
   _ $this->storageId = (string [15]) `amazon::app-dev`
   _ $this->storage = (OCA\Files_Trashbin\Storage [12])
   _ $this->storageCache = (OC\Files\Cache\Storage [3])
   _ $this->mimetypeLoader = (OC\Files\Type\Loader [3])
   _ $this->connection = (OC\DB\Connection [19])
   _ $this->eventDispatcher = (OC\EventDispatcher\SymfonyAdapter [2])
   _ $this->querySearchHelper = (OC\Files\Cache\QuerySearchHelper [3])
```
