### PR TITLE
generate preview when uploading to external storage S3

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -440,6 +440,31 @@ class Generator {
 
 		return $file;
 	}
+  
+	/**
+	 * Returns the max  preview of a external file
+	 *
+	 * @param File $file
+	 * @param int fileId
+	 * @throws NotFoundException
+	 * @throws \InvalidArgumentException if the preview would be invalid (in case the original image is invalid)
+	 * @since 20.0.0
+	 */
+	public function generateExternalMaxPreview($file,$fileId) {
+		try {
+			$previewFolder = $this->appData->getFolder($fileId);
+		} catch (NotFoundException $e) {
+			$previewFolder = $this->appData->newFolder($fileId);
+		}
+		
+		if ($mimeType === null) {
+			$mimeType = $file->getMimeType();
+		}
+	
+		if (in_array($mimeType, ['image/jpeg', 'video/mp4', 'video/quicktime'])) {
+			$this->getMaxPreview($previewFolder, $file, $mimeType, "");
+		}
+	}
 
 	/**
 	 * @param ISimpleFolder $previewFolder

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -191,6 +191,19 @@ class PreviewManager implements IPreview {
 	}
 
 	/**
+	 * Returns the max  preview of a external file
+	 *
+	 * @param File $file
+	 * @param int fileId
+	 * @throws NotFoundException
+	 * @throws \InvalidArgumentException if the preview would be invalid (in case the original image is invalid)
+	 * @since 20.0.0
+	 */
+	public function generateExternalMaxPreview(File $file, $fileId) {
+		return $this->getGenerator()->generateExternalMaxPreview($file,$fileId);
+	}
+
+	/**
 	 * Generates previews of a file
 	 *
 	 * @param File $file


### PR DESCRIPTION
after uploaded  photo to external storage S3, the preview request will download it again to generate the preview

here we generate the MAX preview so all later previews can be based on this, reduce the bandwidth between nextcloud server and S3(this usually cost money )