### PR TITLE
Increase html body height to full content height

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -29,7 +29,7 @@ html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pr
 }
 
 html, body {
-	height: 100%;
+	min-height: 100%;
 }
 
 article, aside, dialog, figure, footer, header, hgroup, nav, section {


### PR DESCRIPTION
This PR increases the html `body` height to match the full content height. Fixes #22606 and https://github.com/nextcloud/nextcloud-vue/issues/1384.

This change is necessary, so that the popover boundaries are calculated correctly. Otherwise the every popover scrolls out of the viewport because `body` is to small.

Before:
![92301581-3baab500-ef65-11ea-9a26-d9822ed4f9c5](https://user-images.githubusercontent.com/2496460/92311626-e6988e80-efb8-11ea-9d4c-9ef10a35fe61.gif)

After:
![after](https://user-images.githubusercontent.com/2496460/92311629-eb5d4280-efb8-11ea-910b-32347c603854.gif)

Although code-wise this is a small change, I am a bit afraid of breaking anything, since this affects more or less the root element of the website. I did some testing and didn't find anything which is broken by this change. However, this really needs a good test.

The fluttering of the status popover is due to the container being the `body` element. This can be fixed by choosing e.g. the `header` once https://github.com/nextcloud/nextcloud-vue/pull/1389 is merged. I will do so in a follow up PR.

Also see https://github.com/nextcloud/nextcloud-vue/issues/1384 for details.