### PR TITLE
saving checksum to oc_filecache , upload checksum and picture metadata

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -339,8 +339,10 @@ class File extends Node implements IFile {
 				$this->fileView->putFileInfo($this->path, ['checksum' => $checksum]);
 				$this->refreshInfo();
 			} elseif ($this->getChecksum() !== null && $this->getChecksum() !== '') {
-				$this->fileView->putFileInfo($this->path, ['checksum' => '']);
-				$this->refreshInfo();
+				if (!$this->fileView->getMount($partFilePath)->getStorage()->instanceOfStorage('OCA\Files_External\Lib\Storage\AmazonS3')) {
+					$this->fileView->putFileInfo($this->path, ['checksum' => '']);
+					$this->refreshInfo();
+				}
 			}
 		} catch (StorageNotAvailableException $e) {
 			throw new ServiceUnavailable("Failed to check file size: " . $e->getMessage(), 0, $e);

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -68,6 +68,9 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 	/** @var CappedMemoryCache|array */
 	private $filesCache;
 
+	/** @var String */
+	private $checksum;
+
 	public function __construct($parameters) {
 		parent::__construct($parameters);
 		$this->parseParams($parameters);
@@ -673,6 +676,11 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			$source = fopen($tmpFile, 'r');
 			$this->writeObject($path, $source);
 			$this->invalidateCache($path);
+	  
+			$cache = $this->getCache();
+			$this->getUpdater()->update($path);
+			$cache->put($path,["checksum" => $this->checksum]);
+
 
 			unlink($tmpFile);
 			return true;


### PR DESCRIPTION
continue with #22495

using S3 storage backend as a single point of checksum control,

we need to save the checksum in the database, as we can't generate them on the fly 

also save the checksum and picture metadata as S3 metadata, in case we need them later:  to restore data or to format photos timeline 
