### PR TITLE
Make sure that getConfig is still called for browsers that do not support CSPv3

### DIFF
--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -194,21 +194,22 @@ class TemplateLayout extends \OC_Template {
 		$jsFiles = self::findJavascriptFiles(\OC_Util::$scripts);
 		$this->assign('jsfiles', []);
 		if ($this->config->getSystemValue('installed', false) && $renderAs != TemplateResponse::RENDER_AS_ERROR) {
+			$jsConfigHelper = new JSConfigHelper(
+				\OC::$server->getL10N('lib'),
+				\OC::$server->query(Defaults::class),
+				\OC::$server->getAppManager(),
+				\OC::$server->getSession(),
+				\OC::$server->getUserSession()->getUser(),
+				$this->config,
+				\OC::$server->getGroupManager(),
+				\OC::$server->get(IniGetWrapper::class),
+				\OC::$server->getURLGenerator(),
+				\OC::$server->getCapabilitiesManager(),
+				\OC::$server->query(IInitialStateService::class)
+			);
+			$config = $jsConfigHelper->getConfig();
 			if (\OC::$server->getContentSecurityPolicyNonceManager()->browserSupportsCspV3()) {
-				$jsConfigHelper = new JSConfigHelper(
-					\OC::$server->getL10N('lib'),
-					\OC::$server->query(Defaults::class),
-					\OC::$server->getAppManager(),
-					\OC::$server->getSession(),
-					\OC::$server->getUserSession()->getUser(),
-					$this->config,
-					\OC::$server->getGroupManager(),
-					\OC::$server->get(IniGetWrapper::class),
-					\OC::$server->getURLGenerator(),
-					\OC::$server->getCapabilitiesManager(),
-					\OC::$server->query(IInitialStateService::class)
-				);
-				$this->assign('inline_ocjs', $jsConfigHelper->getConfig());
+				$this->assign('inline_ocjs', $config);
 			} else {
 				$this->append('jsfiles', \OC::$server->getURLGenerator()->linkToRoute('core.OCJS.getConfig', ['v' => self::$versionHash]));
 			}


### PR DESCRIPTION
Fixes a regression from https://github.com/nextcloud/server/pull/20298/commits/cbd20867b59779d7aff5a024e4287206e3c028e0 where browsers that do not support CSP v3 would not have initial state for config and capabilities provided. They are set in https://github.com/nextcloud/server/blob/02095326385303b1febc74049579df6dc3700f23/lib/private/Template/JSConfigHelper.php#L306-L307 which never got called for those browsers.