### PR TITLE
Fix undefined class property access after upgrade from 19 to 20

### DIFF
--- a/lib/private/Authentication/LoginCredentials/Store.php
+++ b/lib/private/Authentication/LoginCredentials/Store.php
@@ -111,8 +111,13 @@ class Store implements IStore {
 		}
 
 		if ($trySession && $this->session->exists('login_credentials')) {
-			$creds = json_decode($this->session->get('login_credentials'));
-			return new Credentials($creds->uid, $creds->loginName, $creds->password);
+			/** @var array $creds */
+			$creds = json_decode($this->session->get('login_credentials'), true);
+			return new Credentials(
+				$creds['uid'],
+				$creds['loginName'] ?? $this->session->get('loginname') ?? $creds['uid'], // Pre 20 didn't have a loginName property, hence fall back to the session value and then to the UID
+				$creds['password']
+			);
 		}
 
 		// If we reach this line, an exception was thrown.


### PR DESCRIPTION
The serialized data in 19 has one property less and this was not
considered in the code. Hence adding a fallback. Moreover I'm changing
the deserialization into an array instead of object, as that is the
safer option.

Fixes 
![Bildschirmfoto von 2020-09-07 11-21-07](https://user-images.githubusercontent.com/1374172/92371866-785ce480-f0fc-11ea-935d-eb865f4d42fb.png)

Ref https://github.com/nextcloud/server/pull/21288