### PR TITLE
Move to automated dependabot merging

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,92 @@
+version: 2
+updates:
+# Linting and coding style
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "03:00"
+    timezone: Europe/Paris
+  open-pull-requests-limit: 10
+  labels:
+  - 3. to review
+  - "feature: dependencies"
+
+# Main master npm
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "03:00"
+    timezone: Europe/Paris
+  open-pull-requests-limit: 10
+  labels:
+  - 3. to review
+  - "feature: dependencies"
+
+# Testing master npm
+- package-ecosystem: npm
+  directory: "/build"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "03:00"
+    timezone: Europe/Paris
+  open-pull-requests-limit: 10
+  labels:
+  - 3. to review
+  - "feature: dependencies"
+
+# Testing master composer
+- package-ecosystem: composer
+  directory: "/build/integration"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "03:00"
+    timezone: Europe/Paris
+  open-pull-requests-limit: 10
+  labels:
+  - 3. to review
+  - "feature: dependencies"
+
+
+# Main stableXX npm
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "03:00"
+    timezone: Europe/Paris
+  open-pull-requests-limit: 10
+  # Only allow updates to the lockfile
+  versioning-strategy: lockfile-only
+  target-branch:
+  - stable19
+  - stable18
+  - stable17
+  labels:
+  - 3. to review
+  - "feature: dependencies"
+
+# Testing StableXX composer
+- package-ecosystem: composer
+  directory: "/build/integration"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "03:00"
+    timezone: Europe/Paris
+  open-pull-requests-limit: 10
+  # Only allow updates to the lockfile
+  versioning-strategy: lockfile-only
+  target-branch:
+  - stable19
+  - stable18
+  - stable17
+  labels:
+  - 3. to review
+  - "feature: dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,10 +64,35 @@ updates:
   open-pull-requests-limit: 10
   # Only allow updates to the lockfile
   versioning-strategy: lockfile-only
-  target-branch:
-  - stable19
-  - stable18
-  - stable17
+  target-branch: stable19
+  labels:
+  - 3. to review
+  - "feature: dependencies"
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "03:00"
+    timezone: Europe/Paris
+  open-pull-requests-limit: 10
+  # Only allow updates to the lockfile
+  versioning-strategy: lockfile-only
+  target-branch: stable18
+  labels:
+  - 3. to review
+  - "feature: dependencies"
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "03:00"
+    timezone: Europe/Paris
+  open-pull-requests-limit: 10
+  # Only allow updates to the lockfile
+  versioning-strategy: lockfile-only
+  target-branch: stable17
   labels:
   - 3. to review
   - "feature: dependencies"
@@ -83,10 +108,35 @@ updates:
   open-pull-requests-limit: 10
   # Only allow updates to the lockfile
   versioning-strategy: lockfile-only
-  target-branch:
-  - stable19
-  - stable18
-  - stable17
+  target-branch: stable19
+  labels:
+  - 3. to review
+  - "feature: dependencies"
+- package-ecosystem: composer
+  directory: "/build/integration"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "03:00"
+    timezone: Europe/Paris
+  open-pull-requests-limit: 10
+  # Only allow updates to the lockfile
+  versioning-strategy: lockfile-only
+  target-branch: stable18
+  labels:
+  - 3. to review
+  - "feature: dependencies"
+- package-ecosystem: composer
+  directory: "/build/integration"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "03:00"
+    timezone: Europe/Paris
+  open-pull-requests-limit: 10
+  # Only allow updates to the lockfile
+  versioning-strategy: lockfile-only
+  target-branch: stable17
   labels:
   - 3. to review
   - "feature: dependencies"

--- a/.github/workflows/dependabot-approve-merge.yml
+++ b/.github/workflows/dependabot-approve-merge.yml
@@ -1,0 +1,19 @@
+name: Dependabot
+on: pull_request
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      # Default github action approve
+      - uses: hmarr/auto-approve-action@v2.0.0
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Nextcloud bot approve and merge request
+      - uses: ahmadnassri/action-dependabot-auto-merge@v1
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+        with:
+          target: patch
+          github-token: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}


### PR DESCRIPTION
Currently this auto merge patch releases.

While I think it's fine to auto-merge minor on other apps.
I'd be more cautious on server

cc @nextcloud/javascript 