### PR TITLE
Fix installing on Oracle

### DIFF
--- a/core/Migrations/Version18000Date20190920085628.php
+++ b/core/Migrations/Version18000Date20190920085628.php
@@ -60,7 +60,9 @@ class Version18000Date20190920085628 extends SimpleMigrationStep {
 			$table->addColumn('displayname', Types::STRING, [
 				'notnull' => true,
 				'length' => 255,
-				'default' => '',
+				// Will be overwritten in postSchemaChange, but Oracle can not save
+				// empty strings in notnull columns
+				'default' => 'name',
 			]);
 		}
 

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -513,6 +513,11 @@ class MigrationService {
 				if ((!$sourceTable instanceof Table || !$sourceTable->hasColumn($thing->getName())) && \strlen($thing->getName()) > 30) {
 					throw new \InvalidArgumentException('Column name "'  . $table->getName() . '"."' . $thing->getName() . '" is too long.');
 				}
+
+				if ($thing->getNotnull() && $thing->getDefault() === ''
+					&& $sourceTable instanceof Table && !$sourceTable->hasColumn($thing->getName())) {
+					throw new \InvalidArgumentException('Column name "'  . $table->getName() . '"."' . $thing->getName() . '" is NotNull, but has empty string or null as default.');
+				}
 			}
 
 			foreach ($table->getIndexes() as $thing) {


### PR DESCRIPTION
Empty strings are stored as null in Oracle,
so a column with NotNull can not have an empty string as default

Signed-off-by: Joas Schilling <coding@schilljs.com>