### PR TITLE
Fix detecting text/x-php mimetype and secure mimetype mapping

### DIFF
--- a/lib/private/Files/Type/Detection.php
+++ b/lib/private/Files/Type/Detection.php
@@ -122,8 +122,14 @@ class Detection implements IMimeTypeDetector {
 		$this->mimetypes = array_merge($this->mimetypes, $types);
 
 		// Update the alternative mimetypes to avoid having to look them up each time.
-		foreach ($this->mimetypes as $mimeType) {
+		foreach ($this->mimetypes as $extension => $mimeType) {
+			if (strpos($extension, '_comment') === 0) {
+				continue;
+			}
 			$this->secureMimeTypes[$mimeType[0]] = $mimeType[1] ?? $mimeType[0];
+			if (isset($mimeType[1])) {
+				$this->secureMimeTypes[$mimeType[1]] = $mimeType[1];
+			}
 		}
 	}
 

--- a/resources/config/mimetypemapping.dist.json
+++ b/resources/config/mimetypemapping.dist.json
@@ -134,7 +134,7 @@
 	"pdf": ["application/pdf"],
 	"pfb": ["application/x-font"],
 	"pef": ["image/x-dcraw"],
-	"php": ["application/x-php"],
+	"php": ["application/x-php", "text/x-php"],
 	"pl": ["application/x-perl"],
 	"pls": ["audio/x-scpls"],
 	"png": ["image/png"],


### PR DESCRIPTION
## Steps to reproduce 

- Have a server that returns `text/x-php` instead of `application/x-php` as a mimetype for php files

```
file --mime-type version.php 
version.php: text/x-php
```

- Try to block access control by mimetype

## Before:
The mimetype was always detected as application/octet-stream as `text/x-php` was never part of the secure mime type list.

## After:
`text/x-php` is a valid mimetype to be returned by `detectContent`. Now this PR is however kind of a hack since we abuse the secure mime fallback to actually also detect changes there. Ideally this would be an individual entry in https://github.com/nextcloud/server/blob/16b981735895424dd2d59707af87716c0e04d363/resources/config/mimetypemapping.dist.json but there is no way to extend the json without breaking changes since it still uses the file extension as a key for the entries. Also having both the secure and insecure mapping to the secure mimetype seems to be more sane than just the insecure mapping.

## Proposal

For a breaking change we could pull out the insecure->secure mimetype mapping to a separate file and just use mimetypemapping.dist.json for a list of all trusted mimetypes. mimetypealiases.json will not fit for this since it is only for mapping to simplified filetypes which are used for icons, so all code files e.g. will be "text/code"