### PR TITLE
fix use of removed escapeHTML in settings.js

### DIFF
--- a/apps/settings/js/settings.js
+++ b/apps/settings/js/settings.js
@@ -8,6 +8,15 @@ OC.Settings = _.extend(OC.Settings, {
 
 	_cachedGroups: null,
 
+	escapeHTML: function (text) {
+		return text.toString()
+			.split('&').join('&amp;')
+			.split('<').join('&lt;')
+			.split('>').join('&gt;')
+			.split('"').join('&quot;')
+			.split('\'').join('&#039;');
+	},
+
 	/**
      * Setup selection box for group selection.
      *
@@ -75,10 +84,10 @@ OC.Settings = _.extend(OC.Settings, {
 								callback(selection);
 							},
 							formatResult: function(element) {
-								return escapeHTML(element.displayname);
+								return self.escapeHTML(element.displayname);
 							},
 							formatSelection: function(element) {
-								return escapeHTML(element.displayname);
+								return self.escapeHTML(element.displayname);
 							},
 							escapeMarkup: function(m) {
 								// prevent double markup escape


### PR DESCRIPTION
First, this is not a compiled, but a static file.

Second, this is a very pragmatic approach. If someone prefers to wrap it in Webpack/Vue/$other magic, please close and take over, but ensure this is solved within Beta.

To reproduce:
1. Enable an app that registers settings in 'additional' section, like impersonate
2. Visit the settings
3. Try to set something there – JS will error out, because escapeHTML function was removed

Apart of adding a custom escapeHTML function~~, the eslint warnings were fixed, too~~.