### PR TITLE
Transfer shares if no path provided

### DIFF
--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -246,7 +246,7 @@ class OwnershipTransferService {
 	private function collectUsersShares(string $sourceUid,
 										OutputInterface $output,
 										View $view,
-										?string $path = null): array {
+										string $path): array {
 		$output->writeln("Collecting all share information for files and folders of $sourceUid ...");
 
 		$shares = [];
@@ -259,7 +259,7 @@ class OwnershipTransferService {
 				if (empty($sharePage)) {
 					break;
 				}
-				if ($path !== null) {
+				if ($path !== "$sourceUid/files") {
 					$sharePage = array_filter($sharePage, function (IShare $share) use ($view, $path) {
 						try {
 							$relativePath = $view->getPath($share->getNodeId());


### PR DESCRIPTION
Path is actually relative to the view and not to the user directory, so checking for null doesn't make any sense.

Fixes a regression by https://github.com/nextcloud/server/pull/22116#issuecomment-688327163 which got catched in talk integration tests for shares of transferred files.

Talk tests run fine locally with this.