### PR TITLE
Only load viewer in settings if the viewer app is enabled

### DIFF
--- a/apps/settings/lib/Settings/Personal/ServerDevNotice.php
+++ b/apps/settings/lib/Settings/Personal/ServerDevNotice.php
@@ -77,6 +77,9 @@ class ServerDevNotice implements ISettings {
 
 		$hasInitialState = false;
 
+		// viewer is default enabled and this makes a zero-cost assertion for Psalm
+		assert(class_exists(LoadViewer::class));
+
 		// If the Reasons to use Nextcloud.pdf file is here, let's init Viewer
 		if ($userFolder->nodeExists('Reasons to use Nextcloud.pdf')) {
 			$this->eventDispatcher->dispatch(LoadViewer::class, new LoadViewer());


### PR DESCRIPTION
Found by Psalm:

```
2 errors fixed
/github/workspace/apps/settings/lib/Settings/Personal/ServerDevNotice.php:83:37:error - UndefinedClass: Class or interface OCA\Viewer\Event\LoadViewer does not exist
/github/workspace/apps/settings/lib/Settings/Personal/ServerDevNotice.php:83:60:error - UndefinedClass: Class or interface OCA\Viewer\Event\LoadViewer does not exist
```