### PR TITLE
Check if quota should be applied to path when creating directories

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Quota.php
+++ b/lib/private/Files/Storage/Wrapper/Quota.php
@@ -161,7 +161,7 @@ class Quota extends Wrapper {
 			$free = $this->free_space($path);
 			if ($source && $free >= 0 && $mode !== 'r' && $mode !== 'rb') {
 				// only apply quota for files, not metadata, trash or others
-				if (strpos(ltrim($path, '/'), 'files/') === 0) {
+				if ($this->shouldApplyQuota($path)) {
 					return \OC\Files\Stream\Quota::wrap($source, $free);
 				}
 			}
@@ -180,6 +180,13 @@ class Quota extends Wrapper {
 		$extension = pathinfo($path, PATHINFO_EXTENSION);
 
 		return ($extension === 'part');
+	}
+
+	/**
+	 * Only apply quota for files, not metadata, trash or others
+	 */
+	private function shouldApplyQuota(string $path): bool {
+		return strpos(ltrim($path, '/'), 'files/') === 0;
 	}
 
 	/**
@@ -214,7 +221,7 @@ class Quota extends Wrapper {
 
 	public function mkdir($path) {
 		$free = $this->free_space($path);
-		if ($free === 0.0) {
+		if ($this->shouldApplyQuota($path) && $free === 0.0) {
 			return false;
 		}
 

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -211,7 +211,17 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 
 	public function testNoMkdirQuotaZero() {
 		$instance = $this->getLimitedStorage(0.0);
-		$this->assertFalse($instance->mkdir('foobar'));
+		$this->assertFalse($instance->mkdir('files'));
+		$this->assertFalse($instance->mkdir('files/foobar'));
+	}
+
+	public function testMkdirQuotaZeroTrashbin() {
+		$instance = $this->getLimitedStorage(0.0);
+		$this->assertTrue($instance->mkdir('files_trashbin'));
+		$this->assertTrue($instance->mkdir('files_trashbin/files'));
+		$this->assertTrue($instance->mkdir('files_versions'));
+		$this->assertTrue($instance->mkdir('cache'));
+
 	}
 
 	public function testNoTouchQuotaZero() {

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -221,7 +221,6 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 		$this->assertTrue($instance->mkdir('files_trashbin/files'));
 		$this->assertTrue($instance->mkdir('files_versions'));
 		$this->assertTrue($instance->mkdir('cache'));
-
 	}
 
 	public function testNoTouchQuotaZero() {


### PR DESCRIPTION
This fixes an issue where the files_trashbin hierarchy of a user could not been created as the [mkdir operations](https://github.com/nextcloud/server/blob/2513b64602b291253813f6b83c6c52b2f50f2d0a/apps/files_trashbin/lib/Trashbin.php#L161-L173) were blocked by the quota storage wrapper. Even with 0 quota, users should be able to have a trashbin for external storages.

Steps to reproduce:
- Having LDAP setup (with object storage, but shouldn't matter much)
- occ config:app:set user_ldap s01ldap_quota_def --value="0"
- Mount an external storage to all users
- Login as a new user
- Try to delete a file

Before:
:boom: The file gets deleted but with a parent id of -1 in the filecache

After:
:heavy_check_mark: The files_trashbin/files/ hierarchy gets added to the filecache and the file is properly visible in the trashbin

