### PR TITLE
19.0.3 final

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [19, 0, 3, 0];
+$OC_Version = [19, 0, 3, 1];
 
 // The human readable string
-$OC_VersionString = '19.0.3 RC1';
+$OC_VersionString = '19.0.3';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #22410 Fix possible leaking scope in Flow
* #22427 Combine body-login rules in theming and fix twofactor and guest styling on bright colors
* #22442 Show better quota warning for group folders and external storage
* #22448 Add php docs build script
* #22503 Fix clicks on actions menu of non opaque file rows in acceptance tests
* #22515 Fix writing BLOBs to postgres with recent contacts interaction
* #22519 Set the mount id before calling storage wrapper
* #22521 Fix S3 error handling
* #22537 Only disable zip64 if the size is known
* #22553 Change free space calculation
* #22560 Do not keep the part file if the forbidden exception has no retry set
* #22569 Fix app password updating out of bounds
* #22579 Use the correct root to determinate the webroot for the resource
* #22581 Upgrade icewind/smb to 3.2.7
* [notifications#732](https://github.com/nextcloud/notifications/pull/732) Bump elliptic from 6.4.1 to 6.5.3
* [privacy#489](https://github.com/nextcloud/privacy/pull/489) Fixes regression that prevented you from toggling the encryption flag
* [serverinfo#229](https://github.com/nextcloud/serverinfo/pull/229) Match any non-whitespace character in filesystem pattern
* [text#1001](https://github.com/nextcloud/text/pull/1001) Catch StorageNotAvailable exceptions
* [text#1017](https://github.com/nextcloud/text/pull/1017) Harden read only check on public endpoints
* [text#1020](https://github.com/nextcloud/text/pull/1020) Harden check when using token from memcache
* [text#1029](https://github.com/nextcloud/text/pull/1029) Sessionid is an int
* [text#990](https://github.com/nextcloud/text/pull/990) Only overwrite Ctrl-f when text is focussed
* [viewer#582](https://github.com/nextcloud/viewer/pull/582) Set the X-Requested-With header on dav requests
