### PR TITLE
18.0.9 final

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(18, 0, 9, 0);
+$OC_Version = array(18, 0, 9, 1);
 
 // The human readable string
-$OC_VersionString = '18.0.9 RC1';
+$OC_VersionString = '18.0.9';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #22411 Fix possible leaking scope in Flow
* #22415 Fix event icon sizes and text alignment
* #22428 Combine body-login rules in theming and fix twofactor and guest styling on bright colors
* #22449 Add php docs build script
* #22504 Fix clicks on actions menu of non opaque file rows in acceptance tests
* #22518 Set the mount id before calling storage wrapper
* #22522 Fix S3 error handling
* #22538 Only disable zip64 if the size is known
* #22554 Change free space calculation
* #22561 Do not keep the part file if the forbidden exception has no retry set
* #22570 Fix app password updating out of bounds
* #22572 Bump node-sass from 4.13.0 to 4.13.1 in /build
* #22582 Upgrade icewind/smb to 3.2.7
* #22585 Use the correct root to determinate the webroot for the resource
* #22595 Bump node-sass from 4.13.0 to 4.13.1
* #22602 Bump http-proxy from 1.17.0 to 1.18.1 in /build
* [firstrunwizard#398](https://github.com/nextcloud/firstrunwizard/pull/398) Bump node-sass from 4.13.0 to 4.13.1
* [notifications#731](https://github.com/nextcloud/notifications/pull/731) Bump node-sass from 4.13.0 to 4.13.1
* [recommendations#279](https://github.com/nextcloud/recommendations/pull/279) Bump node-sass from 4.13.0 to 4.13.1
* [text#1002](https://github.com/nextcloud/text/pull/1002) Catch StorageNotAvailable exceptions
* [text#1018](https://github.com/nextcloud/text/pull/1018) Harden read only check on public endpoints
* [text#1030](https://github.com/nextcloud/text/pull/1030) Sessionid is an int
* [text#991](https://github.com/nextcloud/text/pull/991) Only overwrite Ctrl-f when text is focussed
* [viewer#586](https://github.com/nextcloud/viewer/pull/586) Set the X-Requested-With header on dav requests
