### PR TITLE
Run stat less often for objectstorages

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -227,6 +227,16 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 		}
 	}
 
+	public function getPermissions($path) {
+		$stat = $this->stat($path);
+
+		if (is_array($stat) && isset($stat['permissions'])) {
+			return $stat['permissions'];
+		}
+
+		return parent::getPermissions($path);
+	}
+
 	/**
 	 * Override this method if you need a different unique resource identifier for your object storage implementation.
 	 * The default implementations just appends the fileId to 'urn:oid:'. Make sure the URN is unique over all users.


### PR DESCRIPTION
When we want to get the permissions we now do stat at least 5 times for
each entry. Which is a bit much. Especially since the permssions are all
just in the database already.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>