### PR TITLE
Don't fail if copying a file of 0 byte size

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -52,6 +52,7 @@ use OCP\Encryption\Exceptions\GenericEncryptionException;
 use OCP\Files\EntityTooLargeException;
 use OCP\Files\FileInfo;
 use OCP\Files\ForbiddenException;
+use OCP\Files\GenericFileException;
 use OCP\Files\InvalidContentException;
 use OCP\Files\InvalidPathException;
 use OCP\Files\LockNotAcquiredException;
@@ -200,8 +201,14 @@ class File extends Node implements IFile {
 					$isEOF = feof($stream);
 				});
 
-				$count = $partStorage->writeStream($internalPartPath, $wrappedData);
-				$result = $count > 0;
+				$result = true;
+				$count = -1;
+				try {
+					$count = $partStorage->writeStream($internalPartPath, $wrappedData);
+				} catch (GenericFileException $e) {
+					$result = false;
+				}
+
 
 				if ($result === false) {
 					$result = $isEOF;

--- a/lib/public/Files/Storage/IWriteStreamStorage.php
+++ b/lib/public/Files/Storage/IWriteStreamStorage.php
@@ -26,6 +26,8 @@ declare(strict_types=1);
 
 namespace OCP\Files\Storage;
 
+use OCP\Files\GenericFileException;
+
 /**
  * Interface that adds the ability to write a stream directly to file
  *
@@ -39,6 +41,7 @@ interface IWriteStreamStorage extends IStorage {
 	 * @param resource $stream
 	 * @param int|null $size the size of the stream if known in advance
 	 * @return int the number of bytes written
+	 * @throws GenericFileException
 	 * @since 15.0.0
 	 */
 	public function writeStream(string $path, $stream, int $size = null): int;


### PR DESCRIPTION
Steps to reproduce:
- Local primary storage
- Upload an empty file
- Try to copy the file to a different directory

Fixes #16989

Requires https://github.com/nextcloud/server/commit/ad7798f9c9066b1eee6ad91526ffab34186f4a7b so backporting will work to 18 and 19