### PR TITLE
Extend integration tests for "files:transfer-ownership" command

### DIFF
--- a/build/integration/features/transfer-ownership.feature
+++ b/build/integration/features/transfer-ownership.feature
@@ -44,6 +44,13 @@ Feature: transfer-ownership
 		And as "user0" the file "/somefile.txt" does not exist
 		And using received transfer folder of "user1" as dav path
 		And as "user1" the file "/somefile.txt" exists
+		And As an "user1"
+		And Getting info of last share
+		And the OCS status code should be "100"
+		And Share fields of last share match with
+			| uid_owner | user1 |
+			| uid_file_owner | user1 |
+			| share_with | user2 |
 
 	Scenario: transferring ownership of folder shared with third user
 		Given user "user0" exists
@@ -61,6 +68,13 @@ Feature: transfer-ownership
 		And as "user0" the folder "/test" does not exist
 		And using received transfer folder of "user1" as dav path
 		And as "user1" the folder "/test" exists
+		And As an "user1"
+		And Getting info of last share
+		And the OCS status code should be "100"
+		And Share fields of last share match with
+			| uid_owner | user1 |
+			| uid_file_owner | user1 |
+			| share_with | user2 |
 
 	Scenario: transferring ownership of folder shared with transfer recipient
 		Given user "user0" exists
@@ -79,6 +93,8 @@ Feature: transfer-ownership
 		And as "user0" the folder "/test" does not exist
 		And using received transfer folder of "user1" as dav path
 		And as "user1" the folder "/test" exists
+		And Getting info of last share
+		And the OCS status code should be "404"
 
 	Scenario: transferring ownership of folder doubly shared with third user
 		Given group "group1" exists
@@ -100,6 +116,13 @@ Feature: transfer-ownership
 		And as "user0" the folder "/test" does not exist
 		And using received transfer folder of "user1" as dav path
 		And as "user1" the folder "/test" exists
+		And As an "user1"
+		And Getting info of last share
+		And the OCS status code should be "100"
+		And Share fields of last share match with
+			| uid_owner | user1 |
+			| uid_file_owner | user1 |
+			| share_with | user2 |
 
 	Scenario: transferring ownership of file shares to user with the same id as the group
 		Given user "user0" exists
@@ -118,6 +141,13 @@ Feature: transfer-ownership
 		And as "user0" the file "/somefile.txt" does not exist
 		And using received transfer folder of "user1" as dav path
 		And as "test" the file "/somefile.txt" exists
+		And As an "test"
+		And Getting info of last share
+		And the OCS status code should be "100"
+		And Share fields of last share match with
+			| uid_owner | test |
+			| uid_file_owner | test |
+			| share_with | test |
 
 	Scenario: transferring ownership does not transfer received shares
 		Given user "user0" exists
@@ -133,6 +163,13 @@ Feature: transfer-ownership
 		Then as "user1" the folder "/test" does not exist
 		And using old dav path
 		And as "user0" the folder "/test" exists
+		And As an "user2"
+		And Getting info of last share
+		And the OCS status code should be "100"
+		And Share fields of last share match with
+			| uid_owner | user2 |
+			| uid_file_owner | user2 |
+			| share_with | user0 |
 
 	@local_storage
 	Scenario: transferring ownership does not transfer external storage
@@ -199,6 +236,13 @@ Feature: transfer-ownership
 		And as "user0" the folder "/test" does not exist
 		And using received transfer folder of "user1" as dav path
 		And as "user1" the folder "/test" exists
+		And As an "user1"
+		And Getting info of last share
+		And the OCS status code should be "100"
+		And Share fields of last share match with
+			| uid_owner | user1 |
+			| uid_file_owner | user1 |
+			| share_with | user2 |
 
 	Scenario: transferring ownership of folder shared with third user
 		Given user "user0" exists
@@ -216,6 +260,13 @@ Feature: transfer-ownership
 		And as "user0" the folder "/test" does not exist
 		And using received transfer folder of "user1" as dav path
 		And as "user1" the folder "/test" exists
+		And As an "user1"
+		And Getting info of last share
+		And the OCS status code should be "100"
+		And Share fields of last share match with
+			| uid_owner | user1 |
+			| uid_file_owner | user1 |
+			| share_with | user2 |
 
 	Scenario: transferring ownership of folder shared with transfer recipient
 		Given user "user0" exists
@@ -234,6 +285,8 @@ Feature: transfer-ownership
 		And as "user0" the folder "/test" does not exist
 		And using received transfer folder of "user1" as dav path
 		And as "user1" the folder "/test" exists
+		And Getting info of last share
+		And the OCS status code should be "404"
 
 	Scenario: transferring ownership of folder doubly shared with third user
 		Given group "group1" exists
@@ -255,6 +308,13 @@ Feature: transfer-ownership
 		And as "user0" the folder "/test" does not exist
 		And using received transfer folder of "user1" as dav path
 		And as "user1" the folder "/test" exists
+		And As an "user1"
+		And Getting info of last share
+		And the OCS status code should be "100"
+		And Share fields of last share match with
+			| uid_owner | user1 |
+			| uid_file_owner | user1 |
+			| share_with | user2 |
 
 	Scenario: transferring ownership does not transfer received shares
 		Given user "user0" exists
@@ -273,6 +333,8 @@ Feature: transfer-ownership
 		And as "user1" the folder "/sub/test" does not exist
 		And using old dav path
 		And as "user0" the folder "/sub" does not exist
+		And Getting info of last share
+		And the OCS status code should be "404"
 
 	Scenario: transferring ownership does not transfer external storage
 		Given user "user0" exists

--- a/build/integration/features/transfer-ownership.feature
+++ b/build/integration/features/transfer-ownership.feature
@@ -149,6 +149,91 @@ Feature: transfer-ownership
 			| uid_file_owner | test |
 			| share_with | test |
 
+	Scenario: transferring ownership of folder reshared with another user
+		Given user "user0" exists
+		And user "user1" exists
+		And user "user2" exists
+		And user "user3" exists
+		And User "user3" created a folder "/test"
+		And User "user3" uploads file "data/textfile.txt" to "/test/somefile.txt"
+		And folder "/test" of user "user3" is shared with user "user0" with permissions 31
+		And user "user0" accepts last share
+		And folder "/test" of user "user0" is shared with user "user2" with permissions 31
+		And user "user2" accepts last share
+		When transferring ownership from "user0" to "user1"
+		And the command was successful
+		And As an "user2"
+		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the folder "/test" exists
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the folder "/test" does not exist
+		And As an "user0"
+		And Getting info of last share
+		And the OCS status code should be "100"
+		And Share fields of last share match with
+			| uid_owner | user0 |
+			| uid_file_owner | user3 |
+			| share_with | user2 |
+
+	Scenario: transferring ownership of folder reshared with group to a user in the group
+		Given user "user0" exists
+		And user "user1" exists
+		And user "user2" exists
+		And user "user3" exists
+		And group "group1" exists
+		And user "user1" belongs to group "group1"
+		And User "user3" created a folder "/test"
+		And User "user3" uploads file "data/textfile.txt" to "/test/somefile.txt"
+		And folder "/test" of user "user3" is shared with user "user0" with permissions 31
+		And user "user0" accepts last share
+		And folder "/test" of user "user0" is shared with group "group1" with permissions 31
+		And user "user1" accepts last share
+		When transferring ownership from "user0" to "user1"
+		And the command was successful
+		And As an "user1"
+		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the folder "/test" exists
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the folder "/test" does not exist
+		And As an "user1"
+		And Getting info of last share
+		And the OCS status code should be "100"
+		And Share fields of last share match with
+			| uid_owner | user1 |
+			| uid_file_owner | user3 |
+			| share_with | group1 |
+
+	Scenario: transferring ownership of folder reshared with group to a user not in the group
+		Given user "user0" exists
+		And user "user1" exists
+		And user "user2" exists
+		And user "user3" exists
+		And group "group1" exists
+		And user "user2" belongs to group "group1"
+		And User "user3" created a folder "/test"
+		And User "user3" uploads file "data/textfile.txt" to "/test/somefile.txt"
+		And folder "/test" of user "user3" is shared with user "user0" with permissions 31
+		And user "user0" accepts last share
+		And folder "/test" of user "user0" is shared with group "group1" with permissions 31
+		And user "user2" accepts last share
+		When transferring ownership from "user0" to "user1"
+		And the command was successful
+		And As an "user2"
+		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the folder "/test" exists
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the folder "/test" does not exist
+		And As an "user0"
+		And Getting info of last share
+		And the OCS status code should be "100"
+		And Share fields of last share match with
+			| uid_owner | user0 |
+			| uid_file_owner | user3 |
+			| share_with | group1 |
+
 	Scenario: transferring ownership does not transfer received shares
 		Given user "user0" exists
 		And user "user1" exists
@@ -315,6 +400,21 @@ Feature: transfer-ownership
 			| uid_owner | user1 |
 			| uid_file_owner | user1 |
 			| share_with | user2 |
+
+	Scenario: transferring ownership of path fails for reshares
+		Given user "user0" exists
+		And user "user1" exists
+		And user "user2" exists
+		And user "user3" exists
+		And User "user3" created a folder "/test"
+		And User "user3" uploads file "data/textfile.txt" to "/test/somefile.txt"
+		And folder "/test" of user "user3" is shared with user "user0" with permissions 31
+		And user "user0" accepts last share
+		And folder "/test" of user "user0" is shared with user "user2" with permissions 31
+		And user "user2" accepts last share
+		When transferring ownership of path "test" from "user0" to "user1"
+		Then the command failed with exit code 1
+		And the command error output contains the text "Could not transfer files."
 
 	Scenario: transferring ownership does not transfer received shares
 		Given user "user0" exists

--- a/build/integration/features/transfer-ownership.feature
+++ b/build/integration/features/transfer-ownership.feature
@@ -9,6 +9,10 @@ Feature: transfer-ownership
 		And As an "user1"
 		And using received transfer folder of "user1" as dav path
 		Then Downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the file "/somefile.txt" does not exist
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the file "/somefile.txt" exists
 
 	Scenario: transferring ownership of a folder
 		Given user "user0" exists
@@ -20,6 +24,10 @@ Feature: transfer-ownership
 		And As an "user1"
 		And using received transfer folder of "user1" as dav path
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the folder "/test" does not exist
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the folder "/test" exists
 
 	Scenario: transferring ownership of file shares
 		Given user "user0" exists
@@ -32,6 +40,10 @@ Feature: transfer-ownership
 		And the command was successful
 		And As an "user2"
 		Then Downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the file "/somefile.txt" does not exist
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the file "/somefile.txt" exists
 
 	Scenario: transferring ownership of folder shared with third user
 		Given user "user0" exists
@@ -45,6 +57,10 @@ Feature: transfer-ownership
 		And the command was successful
 		And As an "user2"
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the folder "/test" does not exist
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the folder "/test" exists
 
 	Scenario: transferring ownership of folder shared with transfer recipient
 		Given user "user0" exists
@@ -59,6 +75,10 @@ Feature: transfer-ownership
 		Then as "user1" the folder "/test" does not exist
 		And using received transfer folder of "user1" as dav path
 		And Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the folder "/test" does not exist
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the folder "/test" exists
 
 	Scenario: transferring ownership of folder doubly shared with third user
 		Given group "group1" exists
@@ -76,6 +96,10 @@ Feature: transfer-ownership
 		And the command was successful
 		And As an "user2"
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the folder "/test" does not exist
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the folder "/test" exists
 
 	Scenario: transferring ownership of file shares to user with the same id as the group
 		Given user "user0" exists
@@ -90,6 +114,10 @@ Feature: transfer-ownership
 		And the command was successful
 		And As an "user2"
 		Then Downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the file "/somefile.txt" does not exist
+		And using received transfer folder of "user1" as dav path
+		And as "test" the file "/somefile.txt" exists
 
 	Scenario: transferring ownership does not transfer received shares
 		Given user "user0" exists
@@ -103,6 +131,8 @@ Feature: transfer-ownership
 		And As an "user1"
 		And using received transfer folder of "user1" as dav path
 		Then as "user1" the folder "/test" does not exist
+		And using old dav path
+		And as "user0" the folder "/test" exists
 
 	@local_storage
 	Scenario: transferring ownership does not transfer external storage
@@ -148,6 +178,10 @@ Feature: transfer-ownership
 		And As an "user1"
 		And using received transfer folder of "user1" as dav path
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the folder "/test" does not exist
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the folder "/test" exists
 
 	Scenario: transferring ownership of file shares
 		Given user "user0" exists
@@ -161,6 +195,10 @@ Feature: transfer-ownership
 		And the command was successful
 		And As an "user2"
 		Then Downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the folder "/test" does not exist
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the folder "/test" exists
 
 	Scenario: transferring ownership of folder shared with third user
 		Given user "user0" exists
@@ -174,6 +212,10 @@ Feature: transfer-ownership
 		And the command was successful
 		And As an "user2"
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the folder "/test" does not exist
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the folder "/test" exists
 
 	Scenario: transferring ownership of folder shared with transfer recipient
 		Given user "user0" exists
@@ -188,6 +230,10 @@ Feature: transfer-ownership
 		Then as "user1" the folder "/test" does not exist
 		And using received transfer folder of "user1" as dav path
 		And Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the folder "/test" does not exist
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the folder "/test" exists
 
 	Scenario: transferring ownership of folder doubly shared with third user
 		Given group "group1" exists
@@ -205,6 +251,10 @@ Feature: transfer-ownership
 		And the command was successful
 		And As an "user2"
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the folder "/test" does not exist
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the folder "/test" exists
 
 	Scenario: transferring ownership does not transfer received shares
 		Given user "user0" exists
@@ -219,7 +269,10 @@ Feature: transfer-ownership
 		And the command was successful
 		And As an "user1"
 		And using received transfer folder of "user1" as dav path
-		Then as "user1" the folder "/sub/test" does not exist
+		Then as "user1" the folder "/sub" exists
+		And as "user1" the folder "/sub/test" does not exist
+		And using old dav path
+		And as "user0" the folder "/sub" does not exist
 
 	Scenario: transferring ownership does not transfer external storage
 		Given user "user0" exists


### PR DESCRIPTION
This pull request extends the integration tests for the `file:transfer-ownership` command to also check that the files and shares were actually transferred between users (until now they only checked that the files could be downloaded after being transferred).

Besides that some extra scenarios were added to check reshares. While doing that I have noticed that currently it is only possible to transfer ownership of a reshare if it is a reshare with a group (or room) and the reshare is transferred to a user in the group (or [room](https://github.com/nextcloud/spreed/blob/6089fa5ec7577685214e91e4d61626173bfe74a0/tests/integration/features/sharing/transfer-ownership.feature#L51)).

When transferring ownership of a reshare with another user or with a group to a user not in the group restoring the share fails (but the command succeeds, it only fails for the specific files that are reshares).
    
When transferring ownership of a path that is a reshare the command fails (as when a specific path is provided [the path tries to move the file](https://github.com/nextcloud/server/blob/f0b46ea605548d9feb4af115a3d05cf2cff24bda/apps/files/lib/Service/OwnershipTransferService.php#L306), it does not take into account reshares).

Note that the above is not related to https://github.com/nextcloud/server/pull/22648 (that pull request fixed the _transferring ownership of folder reshared with group to a user in the group_ scenario). The failure when restoring a reshare is caused by [`getMountPoint()` being called on a null object](https://github.com/nextcloud/server/blob/2a054e6c04e0a40421510eb889cbf59f153c5177/lib/private/Share20/Manager.php#L304). However, even before https://github.com/nextcloud/server/pull/21489 it was failing too (in that case it complained that it could not increase permissions).

@rullzer @juliushaertl Feel free to either work on the issues or change the pull request state to _To review_ if not being able to transfer reshares is not an issue (or if you prefer to merge this now and work on them later ;-) ).
