### PR TITLE
Change 0 to null to properly encode image to BMP if the first pixel is black

### DIFF
--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -1211,7 +1211,7 @@ if (!function_exists('imagebmp')) {
 			} // RLE8
 			elseif ($compression == 1 && $bit == 8) {
 				for ($j = $height - 1; $j >= 0; $j--) {
-					$lastIndex = 0;
+					$lastIndex = null;
 					$sameNum = 0;
 					for ($i = 0; $i <= $width; $i++) {
 						$index = imagecolorat($im, $i, $j);


### PR DESCRIPTION
Regression from #22288