### PR TITLE
Mitigate encoding issue with user principal uri

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -168,7 +168,11 @@ class Principal implements BackendInterface {
 		}
 
 		if ($prefix === $this->principalPrefix) {
-			$user = $this->userManager->get($name);
+			// Depending on where it is called, it may happen that this function
+			// is called either with a urlencoded version of the name or with a non-urlencoded one.
+			// The urldecode function replaces %## and +, both of which are forbidden in usernames.
+			// Hence there can be no ambiguity here and it is safe to call urldecode on all usernames
+			$user = $this->userManager->get(urldecode($name));
 
 			if ($user !== null) {
 				return $this->userToPrincipal($user);


### PR DESCRIPTION
To test this:
- Create a user with a space in the username
- Invite that user to an event in the calendar app

Master:
- It fails with a 404, because it could not resolve the principal uri

This branch:
- Inviting the user succeeds

Disclaimer:
The problem is bigger than this and requires a better fix in the long run. It is necessary, to have consistent, url-encoded principal uris everywhere.