### PR TITLE
switch to typed event for LDAPs user added to group case

### DIFF
--- a/apps/user_ldap/lib/Jobs/UpdateGroups.php
+++ b/apps/user_ldap/lib/Jobs/UpdateGroups.php
@@ -44,6 +44,7 @@ use OCA\User_LDAP\Mapping\GroupMapping;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User\Manager;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Group\Events\UserAddedEvent;
 use OCP\Group\Events\UserRemovedEvent;
 use OCP\ILogger;
 
@@ -95,6 +96,7 @@ class UpdateGroups extends \OC\BackgroundJob\TimedJob {
 	 * @param string[] $groups
 	 */
 	private static function handleKnownGroups($groups) {
+		/** @var IEventDispatcher $dispatcher */
 		$dispatcher = \OC::$server->query(IEventDispatcher::class);
 		$groupManager = \OC::$server->getGroupManager();
 		$userManager = \OC::$server->getUserManager();
@@ -121,7 +123,8 @@ class UpdateGroups extends \OC\BackgroundJob\TimedJob {
 				$hasChanged = true;
 			}
 			foreach (array_diff($actualUsers, $knownUsers) as $addedUser) {
-				\OCP\Util::emitHook('OC_User', 'post_addToGroup', ['uid' => $addedUser, 'gid' => $group]);
+				$userObject = $userManager->get($addedUser);
+				$dispatcher->dispatchTyped(new UserAddedEvent($groupObject, $userObject));
 				\OCP\Util::writeLog('user_ldap',
 				'bgJ "updateGroups" – "'.$addedUser.'" added to "'.$group.'".',
 					ILogger::INFO);


### PR DESCRIPTION
1. have an ldap group
2. create a share to the group
3. add a new user to the group
4. let the background group updater job run
5. log in as affected user

You'd expect to see the share, but it was not updated, because the old hook was not listened to anymore.