### PR TITLE
Revert "Increase html body height to full content height"

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -29,7 +29,7 @@ html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pr
 }
 
 html, body {
-	min-height: 100%;
+	height: 100%;
 }
 
 article, aside, dialog, figure, footer, header, hgroup, nav, section {


### PR DESCRIPTION
Reverts nextcloud/server#22614

Since quite some apps are published already, I think it's too late in the cycle for a breaking change like this

Dashboard | Talk
---|---
Background not stretched | Input missing and scrollbar of chat is outside
![Bildschirmfoto von 2020-09-10 13-18-22](https://user-images.githubusercontent.com/213943/92724144-71d3a480-f36a-11ea-9937-ba71a6bfc473.png) | ![Bildschirmfoto von 2020-09-10 13-30-32](https://user-images.githubusercontent.com/213943/92724148-7304d180-f36a-11ea-8188-ff6a54615d6d.png)
