### PR TITLE
announce added user and group backend later as there might be interdeps

### DIFF
--- a/apps/user_ldap/lib/AppInfo/Application.php
+++ b/apps/user_ldap/lib/AppInfo/Application.php
@@ -109,11 +109,11 @@ class Application extends App implements IBootstrap {
 				$groupBackend = new Group_Proxy($configPrefixes, $ldapWrapper, $groupPluginManager);
 
 				\OC_User::useBackend($userBackend);
-				$userBackendRegisteredEvent = new UserBackendRegistered($userBackend, $userPluginManager);
-				$dispatcher->dispatchTyped($userBackendRegisteredEvent);
-				$legacyDispatcher->dispatch('OCA\\User_LDAP\\User\\User::postLDAPBackendAdded', $userBackendRegisteredEvent);
-
 				$groupManager->addBackend($groupBackend);
+
+				$userBackendRegisteredEvent = new UserBackendRegistered($userBackend, $userPluginManager);
+				$legacyDispatcher->dispatch('OCA\\User_LDAP\\User\\User::postLDAPBackendAdded', $userBackendRegisteredEvent);
+				$dispatcher->dispatchTyped($userBackendRegisteredEvent);
 				$groupBackendRegisteredEvent = new GroupBackendRegistered($groupBackend, $groupPluginManager);
 				$dispatcher->dispatchTyped($groupBackendRegisteredEvent);
 			}


### PR DESCRIPTION
add user and group backend first, before announcing them. User and group may have close relationships with each other, so announce one to early might be too early. For instance, the own LDAPProvider, which is accessible as a service from the server container. That's not the best solution, but the quickest for now.