### PR TITLE
20 RC1

### DIFF
--- a/lib/public/User/GetQuotaEvent.php
+++ b/lib/public/User/GetQuotaEvent.php
@@ -28,6 +28,8 @@ use OCP\IUser;
 
 /**
  * Event to allow apps to
+ *
+ * @since 20.0.0
  */
 class GetQuotaEvent extends Event {
 	/** @var IUser */
@@ -35,11 +37,17 @@ class GetQuotaEvent extends Event {
 	/** @var string|null */
 	private $quota = null;
 
+	/**
+	 * @since 20.0.0
+	 */
 	public function __construct(IUser $user) {
 		parent::__construct();
 		$this->user = $user;
 	}
 
+	/**
+	 * @since 20.0.0
+	 */
 	public function getUser(): IUser {
 		return $this->user;
 	}
@@ -47,7 +55,7 @@ class GetQuotaEvent extends Event {
 	/**
 	 * Get the set quota as human readable string, or null if no overwrite is set
 	 *
-	 * @return string|null
+	 * @since 20.0.0
 	 */
 	public function getQuota(): ?string {
 		return $this->quota;
@@ -56,7 +64,7 @@ class GetQuotaEvent extends Event {
 	/**
 	 * Set the quota overwrite as human readable string
 	 *
-	 * @param string $quota
+	 * @since 20.0.0
 	 */
 	public function setQuota(string $quota): void {
 		$this->quota = $quota;

--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [20, 0, 0, 6];
+$OC_Version = [20, 0, 0, 7];
 
 // The human readable string
-$OC_VersionString = '20.0.0 Beta 4';
+$OC_VersionString = '20.0.0 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #22395 Fix settings chunk loading
* #22626 Bump dompurify from 2.0.14 to 2.0.15
* #22761 Extend integration tests for "files:transfer-ownership" command
* #22770 Mitigate encoding issue with user principal uri
* #22791 Announce added user and group backend later as there might be interdeps
* #22797 Fix files search provider
* #22799 Don't log Microsoft WebDAV client trying to tag things
* #22800 Add users and apps inner search and add HeaderMenu cancel
* #22801 Emit event on status-change
* #22806 Fix serializing indexed unified search array as object
* #22808 Dashboard: Add photo credits and background picture requirements to Readme
* #22809 Remove unneeded isset check
* #22820 Bump @nextcloud/vue from 2.6.4 to 2.6.5
* #22821 Bump webpack-merge from 5.1.3 to 5.1.4
* #22822 Bump @nextcloud/vue-dashboard from 0.1.8 to 1.0.0
* #22844 Support architecture limitations for apps and allow richdocumentscode_arm64 though htaccess
* #22852 Mention in the settings the side effect of outgoing federated shares
* #22854 Bugfix/noid/unified search
* #22857 It is very highly recommended to set an object for better filtering
* #22858 Ignore bundled assets in l10n
* #22859 Fix duplicate sentence in 'Reasons to use Nextcloud.pdf'
* #22860 Update .l10nignore for apps to exclude bundled JS files
* #22865 Dashboard design detail fixing
* #22866 Fix recommendation design details
* #22867 Shared storage optimizations
* #22870 Bump psalm/phar from 3.15 to 3.16
* #22874 L10n: Add parentheses
* #22880 Revoke secsignid
* #22883 Remove phan config - was replaced by Psalm
* #22884 Specific version for @deprecated PHPDoc
* #22885 Show group display name in workflows
* #22888 Remove not needed semicolon and PHPDoc hint
* #22890 Help static code analysis to understand code
* #22898 Fix variable name and add spaces around path in info log line
* #22902 Create proper target path for shared storage fopen event
* #22903 Do not fetch the normalized full path again if it is already available
* #22910 Add event to allow apps to overwrite user quota
* #22917 L10n: Add parentheses for unification
* #22920 L10n: Add a dot
* [activity#490](https://github.com/nextcloud/activity/pull/490) Fix new event documentation
* [activity#493](https://github.com/nextcloud/activity/pull/493) Only respect the favorite setting for users that favorited
* [example-files#11](https://github.com/nextcloud/example-files/pull/11) Fix duplicate sentence in 'Reasons to use Nextcloud.pdf'
* [files_pdfviewer#228](https://github.com/nextcloud/files_pdfviewer/pull/228) Bump stylelint from 13.7.0 to 13.7.1
* [files_videoplayer#185](https://github.com/nextcloud/files_videoplayer/pull/185) Fix removed global function call to escapeHTML
* [firstrunwizard#408](https://github.com/nextcloud/firstrunwizard/pull/408) Bump stylelint from 13.7.0 to 13.7.1
* [notifications#749](https://github.com/nextcloud/notifications/pull/749) Bump stylelint from 13.7.0 to 13.7.1
* [notifications#751](https://github.com/nextcloud/notifications/pull/751) Share notification data across tabs
* [photos#318](https://github.com/nextcloud/photos/pull/318) Allow heic images in the photos overview
* [photos#446](https://github.com/nextcloud/photos/pull/446) Bump @nextcloud/vue from 2.6.4 to 2.6.5
* [photos#447](https://github.com/nextcloud/photos/pull/447) Bump stylelint from 13.7.0 to 13.7.1
* [photos#448](https://github.com/nextcloud/photos/pull/448) Bump @vue/test-utils from 1.0.5 to 1.1.0
* [photos#449](https://github.com/nextcloud/photos/pull/449) Bump @nextcloud/l10n from 1.4.0 to 1.4.1
* [photos#450](https://github.com/nextcloud/photos/pull/450) Bump webpack-merge from 5.1.3 to 5.1.4
* [photos#451](https://github.com/nextcloud/photos/pull/451) Bump postcss-loader from 3.0.0 to 4.0.1
* [photos#453](https://github.com/nextcloud/photos/pull/453) Use correct NodeJS version in Github workflow
* [privacy#516](https://github.com/nextcloud/privacy/pull/516) Bump @nextcloud/vue from 2.6.4 to 2.6.5
* [privacy#517](https://github.com/nextcloud/privacy/pull/517) Bump stylelint from 13.7.0 to 13.7.1
* [recommendations#298](https://github.com/nextcloud/recommendations/pull/298) Use correct NodeJS version in Github workflow
* [text#1040](https://github.com/nextcloud/text/pull/1040) Bump @babel/preset-env from 7.11.0 to 7.11.5
* [updater#299](https://github.com/nextcloud/updater/pull/299) Add timestamp to backup directory
* [updater#306](https://github.com/nextcloud/updater/pull/306) Properly check only for downloaded archive
* [updater#307](https://github.com/nextcloud/updater/pull/307) Improve the error display on the web based updater
* [updater#308](https://github.com/nextcloud/updater/pull/308) Do not depend on the order of files in a folder
* [viewer#577](https://github.com/nextcloud/viewer/pull/577) Add heic image support
* [viewer#606](https://github.com/nextcloud/viewer/pull/606) Bump @nextcloud/vue from 2.6.4 to 2.6.5
* [viewer#607](https://github.com/nextcloud/viewer/pull/607) Bump stylelint from 13.7.0 to 13.7.1
* [viewer#608](https://github.com/nextcloud/viewer/pull/608) Bump webpack-merge from 5.1.3 to 5.1.4
* [viewer#610](https://github.com/nextcloud/viewer/pull/610) Update .l10nignore to exclude bundled JS files


Pending PRs:

* [ ] #22868 Fix/unified search papercuts @skjnldsv
* [ ] #22911 Allow to run occ preview:repair in parallel @MorrisJobke
* [ ] #22913 Add mount point to quota warning message @icewind1991
* [ ] #22915 Improve handling of out of space errors for smb @icewind1991
* [x] [serverinfo#235](https://github.com/nextcloud/serverinfo/pull/235) Update calculation for used and available disk space in gigabyte. @kesselb