### PR TITLE
Fix serializing indexed unified search array as object

### DIFF
--- a/lib/public/Search/SearchResult.php
+++ b/lib/public/Search/SearchResult.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace OCP\Search;
 
 use JsonSerializable;
+use function array_values;
 
 /**
  * @since 20.0.0
@@ -107,7 +108,7 @@ final class SearchResult implements JsonSerializable {
 		return [
 			'name' => $this->name,
 			'isPaginated' => $this->isPaginated,
-			'entries' => $this->entries,
+			'entries' => array_values($this->entries),
 			'cursor' => $this->cursor,
 		];
 	}


### PR DESCRIPTION
We expect an array of results from the search provider. If the search
provider returns an array with indexes, php will serialize it as object,
not as array (to preserve the keys). The client doesn't need this info,
so we should just discard it and take the values only to always render a
JSON array.