### PR TITLE
Remove unneeded isset check

### DIFF
--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -317,7 +317,7 @@ class AllConfig implements \OCP\IConfig {
 	 */
 	public function getUserValue($userId, $appName, $key, $default = '') {
 		$data = $this->getUserValues($userId);
-		if (isset($data[$appName]) and isset($data[$appName][$key])) {
+		if (isset($data[$appName][$key])) {
 			return $data[$appName][$key];
 		} else {
 			return $default;
@@ -355,7 +355,7 @@ class AllConfig implements \OCP\IConfig {
 				'WHERE `userid` = ? AND `appid` = ? AND `configkey` = ?';
 		$this->connection->executeUpdate($sql, [$userId, $appName, $key]);
 
-		if (isset($this->userCache[$userId]) and isset($this->userCache[$userId][$appName])) {
+		if (isset($this->userCache[$userId][$appName])) {
 			unset($this->userCache[$userId][$appName][$key]);
 		}
 	}


### PR DESCRIPTION
Due to the `and` the later part was checked anyway, but isset also works if a parent key does not exist, so removing it 