### PR TITLE
Support architecture limitations for apps and allow richdocumentscode_arm64 though htaccess

### DIFF
--- a/lib/private/App/AppStore/Bundles/HubBundle.php
+++ b/lib/private/App/AppStore/Bundles/HubBundle.php
@@ -33,13 +33,19 @@ class HubBundle extends Bundle {
 	}
 
 	public function getAppIdentifiers() {
-		return [
+		$hubApps = [
 			'spreed',
 			'contacts',
 			'calendar',
 			'mail',
-			'richdocumentscode',
-			'richdocuments',
 		];
+
+		$architecture = php_uname('m');
+		if (PHP_OS_FAMILY === 'Linux' && in_array($architecture, ['x86_64', 'aarch64'])) {
+			$hubApps[] = 'richdocuments';
+			$hubApps[] = 'richdocumentscode' . ($architecture === 'aarch64' ? '_arm64' : '');
+		}
+
+		return $hubApps;
 	}
 }

--- a/lib/private/App/DependencyAnalyzer.php
+++ b/lib/private/App/DependencyAnalyzer.php
@@ -64,6 +64,7 @@ class DependencyAnalyzer {
 		}
 
 		return array_merge(
+			$this->analyzeArchitecture($dependencies),
 			$this->analyzePhpVersion($dependencies),
 			$this->analyzeDatabases($dependencies),
 			$this->analyzeCommands($dependencies),
@@ -170,6 +171,29 @@ class DependencyAnalyzer {
 			if ($intSize > $this->platform->getIntSize()*8) {
 				$missing[] = (string)$this->l->t('%sbit or higher PHP required.', [$intSize]);
 			}
+		}
+		return $missing;
+	}
+
+	private function analyzeArchitecture(array $dependencies) {
+		$missing = [];
+		if (!isset($dependencies['architecture'])) {
+			return $missing;
+		}
+
+		$supportedArchitectures = $dependencies['architecture'];
+		if (empty($supportedArchitectures)) {
+			return $missing;
+		}
+		if (!is_array($supportedArchitectures)) {
+			$supportedArchitectures = [$supportedArchitectures];
+		}
+		$supportedArchitectures = array_map(function ($architecture) {
+			return $this->getValue($architecture);
+		}, $supportedArchitectures);
+		$currentArchitecture = $this->platform->getArchitecture();
+		if (!in_array($currentArchitecture, $supportedArchitectures, true)) {
+			$missing[] = (string)$this->l->t('The following architectures are supported: %s', [implode(', ', $supportedArchitectures)]);
 		}
 		return $missing;
 	}

--- a/lib/private/App/Platform.php
+++ b/lib/private/App/Platform.php
@@ -97,4 +97,8 @@ class Platform {
 		$repo = new PlatformRepository();
 		return $repo->findLibrary($name);
 	}
+
+	public function getArchitecture(): string {
+		return php_uname('m');
+	}
 }

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -544,7 +544,7 @@ class Setup {
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/ocs-provider/";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/ocm-provider/";
 			$content .= "\n  RewriteCond %{REQUEST_URI} !^/\\.well-known/(acme-challenge|pki-validation)/.*";
-			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/richdocumentscode/proxy.php$";
+			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/richdocumentscode(_arm64)?/proxy.php$";
 			$content .= "\n  RewriteRule . index.php [PT,E=PATH_INFO:$1]";
 			$content .= "\n  RewriteBase " . $rewriteBase;
 			$content .= "\n  <IfModule mod_env.c>";

--- a/resources/app-info.xsd
+++ b/resources/app-info.xsd
@@ -97,6 +97,10 @@
             <xs:selector xpath="dependencies/database"/>
             <xs:field xpath="."/>
         </xs:unique>
+        <xs:unique name="uniqueArchitecture">
+            <xs:selector xpath="dependencies/architecture"/>
+            <xs:field xpath="."/>
+        </xs:unique>
         <xs:unique name="uniqueLib">
             <xs:selector xpath="dependencies/lib"/>
             <xs:field xpath="."/>
@@ -552,6 +556,8 @@
                         maxOccurs="1"/>
             <xs:element name="nextcloud" type="nextcloud" minOccurs="1"
                         maxOccurs="1"/>
+            <xs:element name="architecture" type="architecture" minOccurs="0"
+                        maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -610,6 +616,15 @@
         <xs:restriction base="xs:int">
             <xs:enumeration value="32"/>
             <xs:enumeration value="64"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="architecture">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="x86"/>
+            <xs:enumeration value="x86_64"/>
+            <xs:enumeration value="aarch"/>
+            <xs:enumeration value="aarch64"/>
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
- Install richdocumentscode depending on the architecture as recommended app on first install or though hub bundle
- Add htaccess exception for richdocumentscode_arm64
- Allow to specify supported architectures in appinfo.xml

ToDo:
- [x] Requires an update to the appstore xsd files as well https://github.com/nextcloud/appstore/pull/752