### PR TITLE
Mention in the settings the side effect of outgoing federated shares

### DIFF
--- a/apps/federatedfilesharing/templates/settings-admin.php
+++ b/apps/federatedfilesharing/templates/settings-admin.php
@@ -23,7 +23,7 @@ style('federatedfilesharing', 'settings-admin');
 	print_unescaped('checked="checked"');
 } ?> />
 		<label for="outgoingServer2serverShareEnabled">
-			<?php p($l->t('Allow users on this server to send shares to other servers'));?>
+			<?php p($l->t('Allow users on this server to send shares to other servers. This option also allows WebDAV access to public shares'));?>
 		</label>
 	</p>
 	<p>


### PR DESCRIPTION
Until #20132 is fixed* the checkbox should explicitly mention its unexpected side effect.

*Note that the steps to reproduce mention using the viewer; the viewer case was fixed in https://github.com/nextcloud/viewer/pull/581, but the issue of not being able to access public shares using WebDAV when outgoing federated shares are disabled is still valid

The wording of the option is just a suggestion; feel free to improve it :-)

When/If this is merged [the user manual](https://github.com/nextcloud/documentation/blob/bb74601aeb37d811b5fbff76b23cc6ecc255654b/user_manual/files/access_webdav.rst#accessing-public-shares-over-webdav) should be updated to reflect the new text in the settings.

Should this be backported to _stable19_ and _stable18_?
