### PR TITLE
Create proper target path for shared storage fopen event

### DIFF
--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -286,7 +286,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 				}
 		}
 		$info = [
-			'target' => $this->getMountPoint() . $path,
+			'target' => $this->getMountPoint() . '/' . $path,
 			'source' => $source,
 			'mode' => $mode,
 		];


### PR DESCRIPTION
Extracted from #16696 by @yahesh 

This event isn't used anywhere, but better provide correct information.

Before:
![Bildschirmfoto 2020-09-17 um 09 51 33](https://user-images.githubusercontent.com/245432/93436876-a47e1f80-f8cb-11ea-9fe9-9d5f14487bdf.png)


After:
![Bildschirmfoto 2020-09-17 um 09 49 12](https://user-images.githubusercontent.com/245432/93436866-a2b45c00-f8cb-11ea-82d4-9ce0f336e929.png)
