### PR TITLE
dont apply encryption wrapper for root mount

### DIFF
--- a/lib/private/Encryption/EncryptionWrapper.php
+++ b/lib/private/Encryption/EncryptionWrapper.php
@@ -81,7 +81,7 @@ class EncryptionWrapper {
 			'mount' => $mount
 		];
 
-		if (!$storage->instanceOfStorage(Storage\IDisableEncryptionStorage::class)) {
+		if (!$storage->instanceOfStorage(Storage\IDisableEncryptionStorage::class) && $mountPoint !== '/') {
 			$user = \OC::$server->getUserSession()->getUser();
 			$mountManager = Filesystem::getMountManager();
 			$uid = $user ? $user->getUID() : null;


### PR DESCRIPTION
the `shouldEncrypt` already disables encryption for anything thats not in the users data folder,
however the encryption wrapper being applied anyway on the root folder breaks groupfolders

Fixes https://github.com/nextcloud/server/issues/14988