### PR TITLE
improve handling of files we can't access in the scanner

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -194,13 +194,15 @@ class SMB extends Common implements INotifyStorage {
 			}
 		} catch (ConnectException $e) {
 			$this->throwUnavailable($e);
+		} catch (NotFoundException $e) {
+			throw new \OCP\Files\NotFoundException($e->getMessage(), 0, $e);
 		} catch (ForbiddenException $e) {
 			// with php-smbclient, this exception is thrown when the provided password is invalid.
 			// Possible is also ForbiddenException with a different error code, so we check it.
 			if ($e->getCode() === 1) {
 				$this->throwUnavailable($e);
 			}
-			throw $e;
+			throw new \OCP\Files\ForbiddenException($e->getMessage(), false, $e);
 		}
 	}
 
@@ -283,6 +285,8 @@ class SMB extends Common implements INotifyStorage {
 		} catch (ConnectException $e) {
 			$this->logger->logException($e, ['message' => 'Error while getting folder content']);
 			throw new StorageNotAvailableException($e->getMessage(), (int)$e->getCode(), $e);
+		} catch (NotFoundException $e) {
+			throw new \OCP\Files\NotFoundException($e->getMessage(), 0, $e);
 		}
 	}
 
@@ -348,7 +352,7 @@ class SMB extends Common implements INotifyStorage {
 			$result = $this->formatInfo($this->getFileInfo($path));
 		} catch (ForbiddenException $e) {
 			return false;
-		} catch (NotFoundException $e) {
+		} catch (\OCP\Files\NotFoundException $e) {
 			return false;
 		} catch (TimedOutException $e) {
 			if ($retry) {
@@ -565,7 +569,7 @@ class SMB extends Common implements INotifyStorage {
 	public function getMetaData($path) {
 		try {
 			$fileInfo = $this->getFileInfo($path);
-		} catch (NotFoundException $e) {
+		} catch (\OCP\Files\NotFoundException $e) {
 			return null;
 		} catch (ForbiddenException $e) {
 			return null;
@@ -641,7 +645,7 @@ class SMB extends Common implements INotifyStorage {
 	public function filetype($path) {
 		try {
 			return $this->getFileInfo($path)->isDirectory() ? 'dir' : 'file';
-		} catch (NotFoundException $e) {
+		} catch (\OCP\Files\NotFoundException $e) {
 			return false;
 		} catch (ForbiddenException $e) {
 			return false;
@@ -665,7 +669,7 @@ class SMB extends Common implements INotifyStorage {
 		try {
 			$this->getFileInfo($path);
 			return true;
-		} catch (NotFoundException $e) {
+		} catch (\OCP\Files\NotFoundException $e) {
 			return false;
 		} catch (ForbiddenException $e) {
 			return false;
@@ -678,7 +682,7 @@ class SMB extends Common implements INotifyStorage {
 		try {
 			$info = $this->getFileInfo($path);
 			return $this->showHidden || !$info->isHidden();
-		} catch (NotFoundException $e) {
+		} catch (\OCP\Files\NotFoundException $e) {
 			return false;
 		} catch (ForbiddenException $e) {
 			return false;
@@ -691,7 +695,7 @@ class SMB extends Common implements INotifyStorage {
 			// following windows behaviour for read-only folders: they can be written into
 			// (https://support.microsoft.com/en-us/kb/326549 - "cause" section)
 			return ($this->showHidden || !$info->isHidden()) && (!$info->isReadOnly() || $info->isDirectory());
-		} catch (NotFoundException $e) {
+		} catch (\OCP\Files\NotFoundException $e) {
 			return false;
 		} catch (ForbiddenException $e) {
 			return false;
@@ -702,7 +706,7 @@ class SMB extends Common implements INotifyStorage {
 		try {
 			$info = $this->getFileInfo($path);
 			return ($this->showHidden || !$info->isHidden()) && !$info->isReadOnly();
-		} catch (NotFoundException $e) {
+		} catch (\OCP\Files\NotFoundException $e) {
 			return false;
 		} catch (ForbiddenException $e) {
 			return false;
@@ -727,6 +731,10 @@ class SMB extends Common implements INotifyStorage {
 	public function test() {
 		try {
 			return parent::test();
+		} catch (StorageAuthException $e) {
+			return false;
+		} catch (ForbiddenException $e) {
+			return false;
 		} catch (Exception $e) {
 			$this->logger->logException($e);
 			return false;

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -38,6 +38,7 @@ namespace OC\Files\Cache;
 use Doctrine\DBAL\Exception;
 use OCP\Files\Cache\IScanner;
 use OCP\Files\ForbiddenException;
+use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IReliableEtagStorage;
 use OCP\Lock\ILockingProvider;
 use OC\Files\Storage\Wrapper\Encoding;
@@ -219,7 +220,7 @@ class Scanner extends BasicEmitter implements IScanner {
 						$newData['parent'] = $parentId;
 						$data['fileid'] = $this->addToCache($file, $newData, $fileId);
 					}
-					
+
 					$data['oldSize'] = ($cacheData && isset($cacheData['size'])) ? $cacheData['size'] : 0;
 
 					if ($cacheData && isset($cacheData['encrypted'])) {
@@ -328,10 +329,15 @@ class Scanner extends BasicEmitter implements IScanner {
 			}
 		}
 		try {
-			$data = $this->scanFile($path, $reuse, -1, null, $lock);
-			if ($data && $data['mimetype'] === 'httpd/unix-directory') {
-				$size = $this->scanChildren($path, $recursive, $reuse, $data['fileid'], $lock, $data);
-				$data['size'] = $size;
+			try {
+				$data = $this->scanFile($path, $reuse, -1, null, $lock);
+				if ($data && $data['mimetype'] === 'httpd/unix-directory') {
+					$size = $this->scanChildren($path, $recursive, $reuse, $data['fileid'], $lock, $data);
+					$data['size'] = $size;
+				}
+			} catch (NotFoundException $e) {
+				$this->removeFromCache($path);
+				return null;
 			}
 		} finally {
 			if ($lock) {


### PR DESCRIPTION
instead of erroring, remove the items from the cache.

this situation can be triggered if a user has access to a file but looses it afterwards

Signed-off-by: Robin Appelman <robin@icewind.nl>