### PR TITLE
Add more integration tests for "files:transfer-ownership" command

### DIFF
--- a/build/integration/features/bootstrap/CommandLineContext.php
+++ b/build/integration/features/bootstrap/CommandLineContext.php
@@ -27,6 +27,7 @@
 require __DIR__ . '/../../vendor/autoload.php';
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use PHPUnit\Framework\Assert;
 
 class CommandLineContext implements \Behat\Behat\Context\Context {
 	use CommandLine;
@@ -128,5 +129,12 @@ class CommandLineContext implements \Behat\Behat\Context\Context {
 		$davPath = $this->featureContext->getDavFilesPath($user);
 		$davPath = rtrim($davPath, '/') . $this->lastTransferPath;
 		$this->featureContext->usingDavPath($davPath);
+	}
+
+	/**
+	 * @Then /^transfer folder name contains "([^"]+)"$/
+	 */
+	public function transferFolderNameContains($text) {
+		Assert::assertContains($text, $this->lastTransferPath);
 	}
 }

--- a/build/integration/features/bootstrap/Provisioning.php
+++ b/build/integration/features/bootstrap/Provisioning.php
@@ -70,7 +70,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" with displayname "([^"]*)" exists$/
+	 * @Given /^user "([^"]*)" with displayname "((?:[^"]|\\")*)" exists$/
 	 * @param string $user
 	 */
 	public function assureUserWithDisplaynameExists($user, $displayname) {

--- a/build/integration/features/transfer-ownership.feature
+++ b/build/integration/features/transfer-ownership.feature
@@ -29,6 +29,22 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		And as "user1" the folder "/test" exists
 
+	Scenario: transferring ownership from user with risky display name
+		Given user "user0" with displayname "user0 \"risky\"? ヂspḷay 'na|\/|e':.#" exists
+		And user "user1" exists
+		And User "user0" created a folder "/test"
+		And User "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
+		When transferring ownership from "user0" to "user1"
+		And the command was successful
+		And As an "user1"
+		And using received transfer folder of "user1" as dav path
+		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And transfer folder name contains "transferred from user0 -risky- ヂspḷay -na|-|e- on"
+		And using old dav path
+		And as "user0" the folder "/test" does not exist
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the folder "/test" exists
+
 	Scenario: transferring ownership of file shares
 		Given user "user0" exists
 		And user "user1" exists
@@ -314,6 +330,22 @@ Feature: transfer-ownership
 		And As an "user1"
 		And using received transfer folder of "user1" as dav path
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the folder "/test" does not exist
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the folder "/test" exists
+
+	Scenario: transferring ownership from user with risky display name
+		Given user "user0" with displayname "user0 \"risky\"? ヂspḷay 'na|\/|e':.#" exists
+		And user "user1" exists
+		And User "user0" created a folder "/test"
+		And User "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
+		When transferring ownership of path "test" from "user0" to "user1"
+		And the command was successful
+		And As an "user1"
+		And using received transfer folder of "user1" as dav path
+		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And transfer folder name contains "transferred from user0 -risky- ヂspḷay -na|-|e- on"
 		And using old dav path
 		And as "user0" the folder "/test" does not exist
 		And using received transfer folder of "user1" as dav path

--- a/build/integration/features/transfer-ownership.feature
+++ b/build/integration/features/transfer-ownership.feature
@@ -351,6 +351,57 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		And as "user1" the folder "/test" exists
 
+	Scenario: transferring ownership of path does not affect other files
+		Given user "user0" exists
+		And user "user1" exists
+		And User "user0" created a folder "/test"
+		And User "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
+		And User "user0" created a folder "/test2"
+		And User "user0" uploads file "data/textfile.txt" to "/test2/somefile.txt"
+		When transferring ownership of path "test" from "user0" to "user1"
+		And the command was successful
+		And As an "user1"
+		And using received transfer folder of "user1" as dav path
+		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the folder "/test" does not exist
+		And as "user0" the folder "/test2" exists
+		And as "user0" the file "/test2/somefile.txt" exists
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the folder "/test" exists
+		And as "user1" the folder "/test2" does not exist
+
+	Scenario: transferring ownership of path does not affect other shares
+		Given user "user0" exists
+		And user "user1" exists
+		And User "user0" created a folder "/test"
+		And User "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
+		And User "user0" created a folder "/test2"
+		And User "user0" uploads file "data/textfile.txt" to "/test2/sharedfile.txt"
+		And file "/test2/sharedfile.txt" of user "user0" is shared with user "user1" with permissions 19
+		And user "user1" accepts last share
+		When transferring ownership of path "test" from "user0" to "user1"
+		And the command was successful
+		And As an "user1"
+		And using received transfer folder of "user1" as dav path
+		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the folder "/test" does not exist
+		And as "user0" the folder "/test2" exists
+		And as "user0" the file "/test2/sharedfile.txt" exists
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the folder "/test" exists
+		And as "user1" the folder "/test2" does not exist
+		And using old dav path
+		And as "user1" the file "/sharedfile.txt" exists
+		And As an "user1"
+		And Getting info of last share
+		And the OCS status code should be "100"
+		And Share fields of last share match with
+			| uid_owner | user0 |
+			| uid_file_owner | user0 |
+			| share_with | user1 |
+
 	Scenario: transferring ownership of file shares
 		Given user "user0" exists
 		And user "user1" exists

--- a/build/integration/features/transfer-ownership.feature
+++ b/build/integration/features/transfer-ownership.feature
@@ -290,6 +290,20 @@ Feature: transfer-ownership
 		Then the command error output contains the text "Unknown target user"
 		And the command failed with exit code 1
 
+	Scenario: transferring ownership of a file
+		Given user "user0" exists
+		And user "user1" exists
+		And User "user0" uploads file "data/textfile.txt" to "/somefile.txt"
+		When transferring ownership of path "somefile.txt" from "user0" to "user1"
+		And the command was successful
+		And As an "user1"
+		And using received transfer folder of "user1" as dav path
+		Then Downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
+		And using old dav path
+		And as "user0" the file "/somefile.txt" does not exist
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the file "/somefile.txt" exists
+
 	Scenario: transferring ownership of a folder
 		Given user "user0" exists
 		And user "user1" exists


### PR DESCRIPTION
Follow up to #22761

This pull request adds a test for a scenario fixed in #22116 (transferring ownership of a path caused shares with the target user to be removed). Unfortunately I have not been able to reproduce the other issues in d0a7f83^, so I did not add tests for them :shrug:

Nevertheless I added other tests that were missing and I thought that it was good to have ;-)

The backports to stable18 and stable19 will be pushed to #22802 and #22804.
