### PR TITLE
broaden exception handling on webcal refresh

### DIFF
--- a/apps/dav/lib/CalDAV/WebcalCaching/RefreshWebcalService.php
+++ b/apps/dav/lib/CalDAV/WebcalCaching/RefreshWebcalService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2020, Thomas Citharel <nextcloud@tcit.fr>
+ * @copyright Copyright (c) 2020, leith abdulla (<online-nextcloud@eleith.com>)
  *
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  * @author Georg Ehrke <oc.list@georgehrke.com>
@@ -45,6 +46,7 @@ use Sabre\DAV\Xml\Property\Href;
 use Sabre\VObject\Component;
 use Sabre\VObject\DateTimeParser;
 use Sabre\VObject\InvalidDataException;
+use Sabre\VObject\Recur\NoInstancesException;
 use Sabre\VObject\ParseException;
 use Sabre\VObject\Reader;
 use Sabre\VObject\Splitter\ICalendar;
@@ -140,7 +142,7 @@ class RefreshWebcalService {
 				$calendarData = $vObject->serialize();
 				try {
 					$this->calDavBackend->createCalendarObject($subscription['id'], $uri, $calendarData, CalDavBackend::CALENDAR_TYPE_SUBSCRIPTION);
-				} catch (BadRequest $ex) {
+				} catch (NoInstancesException | BadRequest $ex) {
 					$this->logger->logException($ex);
 				}
 			}


### PR DESCRIPTION
when iterating through a calendar, recurrance events can throw an
exception if no instances of the recurrance are found.

this exception is of class `Exception` but the try/catch clause in the
webcal refresh loop only catches `BadRequest` exception.

this leads to the exception bubbling up and thus other calendar events
do not get processed by the event iterator.

this PR broadens the exception so that the full webcal can be processed

Resolves: https://github.com/nextcloud/calendar/issues/2269