### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+FROM nextcloud
+ENTRYPOINT ["docker-php-entrypoint"]
+CMD ["apache2-foreground"]
+
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+    echo '[client]\nhost = mysql\nuser = nextcloud\npassword = nextcloud\ndatabase = nextcloud' > /var/www/.my.cnf && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nano git openssh-client default-mysql-client nodejs && \
+    curl -L https://phar.phpunit.de/phpunit-8.phar > /usr/local/bin/phpunit && chmod +x /usr/local/bin/phpunit
+
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupmod --gid $USER_GID www-data && \
+    usermod --uid $USER_UID --gid $USER_GID www-data && \
+    chown -R $USER_UID:$USER_GID /var/www

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,12 +18,23 @@
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"sqltools.connections": [{
+			"name": "mysql",
+			"driver": "MySQL",
+			"server": "mysql",
+			"port": 3306,
+			"username": "nextcloud",
+			"password": "nextcloud",
+			"database": "nextcloud"
+		}]
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"felixfbecker.php-intellisense",
+		"mtxr.sqltools",
+		"mtxr.sqltools-driver-mysql",
 		"octref.vetur"
 	],
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/docker-existing-docker-compose
+// If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
+{
+	"name": "Nextcloud",
+
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"dockerComposeFile": ["../docker-compose.yaml"],
+
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "nextcloud",
+
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	"workspaceFolder": "/var/www/html",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"felixfbecker.php-intellisense",
+		"octref.vetur"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// "shutdownAction": "none",
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "www-data"
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,26 @@
+version: "3.8"
+
+services:
+  mysql:
+    image: mysql:5.7
+    volumes:
+    - mysql_data:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: nextcloud
+      MYSQL_USER: nextcloud
+      MYSQL_PASSWORD: nextcloud
+      MYSQL_DATABASE: nextcloud
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
+
+  nextcloud:
+    build: 
+      context: .devcontainer
+      args:
+        USER_UID: ${UID-1000}
+    volumes:
+    - .:/var/www/html
+    ports:
+    - 8080:80
+
+volumes:
+  mysql_data:


### PR DESCRIPTION
This PR simplifies developer environment setup by adding docker-compose and [devcontainer](https://code.visualstudio.com/docs/remote/containers) configuration. It is based on official `nextcloud` image and includes `nano`, `git`, `ssh`, `node`, `phpunit`, preconfigured `mysql` and vscode extensions for [php](https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-intellisense), [mysql](https://marketplace.visualstudio.com/items?itemName=mtxr.sqltools) and [vue](https://marketplace.visualstudio.com/items?itemName=octref.vetur). Developers can open `nextcloud/server` in vscode, click on "Reopen in container" prompt and start hacking. Other editors users can run `docker-compose up` and use `docker-compose exec nextcloud bash` for `occ` or running tests.