### PR TITLE
Support /.well-known/change-password URL

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -67,7 +67,7 @@
   RewriteRule ^\.well-known/nodeinfo /public.php?service=nodeinfo [QSA,L]
   RewriteRule ^\.well-known/carddav /remote.php/dav/ [R=301,L]
   RewriteRule ^\.well-known/caldav /remote.php/dav/ [R=301,L]
-  RewriteRule ^\.well-known/change-password /settings/user/security [R=301]
+  RewriteRule ^\.well-known/change-password /index.php/settings/user/security [R=301,L]
   RewriteRule ^remote/(.*) remote.php [QSA,L]
   RewriteRule ^(?:build|tests|config|lib|3rdparty|templates)/.* - [R=404,L]
   RewriteCond %{REQUEST_URI} !^/\.well-known/(acme-challenge|pki-validation)/.*

--- a/.htaccess
+++ b/.htaccess
@@ -67,6 +67,7 @@
   RewriteRule ^\.well-known/nodeinfo /public.php?service=nodeinfo [QSA,L]
   RewriteRule ^\.well-known/carddav /remote.php/dav/ [R=301,L]
   RewriteRule ^\.well-known/caldav /remote.php/dav/ [R=301,L]
+  RewriteRule ^\.well-known/change-password /settings/user/security [R=301]
   RewriteRule ^remote/(.*) remote.php [QSA,L]
   RewriteRule ^(?:build|tests|config|lib|3rdparty|templates)/.* - [R=404,L]
   RewriteCond %{REQUEST_URI} !^/\.well-known/(acme-challenge|pki-validation)/.*


### PR DESCRIPTION
[Google Chrome (since v86)](https://www.bleepingcomputer.com/news/google/google-chrome-is-making-it-easier-to-reset-compromised-passwords/) as well as safari and the iCloud keychain support the [.well-known/change-password URL](https://wicg.github.io/change-password-url/).

This PR adds support for that to nextcloud by modifying the default `.htaccess` file.

This is my first PR to nextcloud, so feedback is appreciated