### PR TITLE
allow authenticating using urlencoded passwords

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -5171,7 +5171,8 @@
       <code>$this-&gt;createUserFromBackend($uid, $password, $backend)</code>
       <code>$this-&gt;createUserFromBackend($uid, $password, $backend)</code>
     </NullableReturnStatement>
-    <UndefinedInterfaceMethod occurrences="4">
+    <UndefinedInterfaceMethod occurrences="5">
+      <code>checkPassword</code>
       <code>checkPassword</code>
       <code>countUsers</code>
       <code>createUser</code>

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -231,6 +231,20 @@ class Manager extends PublicEmitter implements IUserManager {
 			}
 		}
 
+		// since http basic auth doesn't provide a standard way of handling non ascii password we allow password to be urlencoded
+		// we only do this decoding after using the plain password fails to maintain compatibility with any password that happens
+		// to contains urlencoded patterns by "accident".
+		$password = urldecode($password);
+
+		foreach ($this->backends as $backend) {
+			if ($backend->implementsActions(Backend::CHECK_PASSWORD)) {
+				$uid = $backend->checkPassword($loginName, $password);
+				if ($uid !== false) {
+					return $this->getUserObject($uid, $backend);
+				}
+			}
+		}
+
 		return false;
 	}
 


### PR DESCRIPTION
this allows authenticating with passwords that contain non ascii-characters in contexts that otherwise do not allow it (http basic)

Signed-off-by: Robin Appelman <robin@icewind.nl>