### PR TITLE
Fix boundaries of app token actions menu

### DIFF
--- a/apps/settings/src/components/AuthToken.vue
+++ b/apps/settings/src/components/AuthToken.vue
@@ -45,6 +45,7 @@
 					content: t('settings', 'Device settings'),
 					container: 'body'
 				}"
+				:boundaries-element="container"
 				:open.sync="actionOpen">
 				<ActionCheckbox v-if="token.type === 1"
 					:checked="token.scope.filesystem"
@@ -170,6 +171,7 @@ export default {
 			renaming: false,
 			newName: '',
 			actionOpen: false,
+			container: document.getElementById('content'),
 		}
 	},
 	computed: {


### PR DESCRIPTION
- Open the security settings on mobile
- scroll down to the token list
- Tap the 3-dots menu

Before:
See no menu (since it has boundaries to the body element which is out of the visible area)

After:
See the menu

See https://github.com/nextcloud/nextcloud-vue/issues/1384 for the background of this issue, though I cannot see any easy solution for this now to fix this in the vue lib.