### PR TITLE
Adjust scroll container height to make it a proper boundary element for actions

### DIFF
--- a/apps/settings/css/settings.scss
+++ b/apps/settings/css/settings.scss
@@ -1443,6 +1443,8 @@ doesnotexist:-o-prefocus, .strengthify-wrapper {
 	$grid-row-height: 60px;
 	$grid-col-min-width: 160px;
 	overflow-x: scroll;
+	min-height: 100%;
+	height: auto;
 
 	#app-content.user-list-grid {
 		display: grid;


### PR DESCRIPTION
More general approach to replace #22998 

- Open the security settings on mobile
- scroll down to the token list
- Tap the 3-dots menu

Before:
See no menu (since it has boundaries to the body element which is out of the visible area)

After:
See the menu

See https://github.com/nextcloud/nextcloud-vue/issues/1384 for the background of this issue.