### PR TITLE
20 RC2

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [20, 0, 0, 7];
+$OC_Version = [20, 0, 0, 8];
 
 // The human readable string
-$OC_VersionString = '20.0.0 RC1';
+$OC_VersionString = '20.0.0 RC2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #22928 Improve handling of out of space errors for smb
* #22932 Dashboard: Fix accessibility skip links
* #22935 Fix/unified search papercuts
* #22938 Allow to run occ preview:repair in parallel
* #22946 Make sure most app names don’t ellipsize, fix #22845, fix #22219
* #22950 Add transifex config for all new apps
* #23001 Never copy the share link when the password is forced
* #23009 Add padding to the empty content and center it
* #23018 Don't log a known shared section
* #23026 Make 'Reasons to use Nextcloud' button translatable, fix #22977
* [activity#495](https://github.com/nextcloud/activity/pull/495) Update stable20 target versions
* [files_pdfviewer#230](https://github.com/nextcloud/files_pdfviewer/pull/230) Update stable20 target versions
* [firstrunwizard#409](https://github.com/nextcloud/firstrunwizard/pull/409) Update stable20 target versions
* [logreader#388](https://github.com/nextcloud/logreader/pull/388) Update stable20 target versions
* [nextcloud_announcements#70](https://github.com/nextcloud/nextcloud_announcements/pull/70) Update stable20 target versions
* [notifications#753](https://github.com/nextcloud/notifications/pull/753) Update stable20 target versions
* [password_policy#110](https://github.com/nextcloud/password_policy/pull/110) Update stable20 target versions
* [recommendations#299](https://github.com/nextcloud/recommendations/pull/299) Update stable20 target versions
* [serverinfo#236](https://github.com/nextcloud/serverinfo/pull/236) Update stable20 target versions
* [serverinfo#239](https://github.com/nextcloud/serverinfo/pull/239) Various design and typography improvements
* [survey_client#111](https://github.com/nextcloud/survey_client/pull/111) Update stable20 target versions
* [text#1046](https://github.com/nextcloud/text/pull/1046) Update stable20 target versions
* [text#1055](https://github.com/nextcloud/text/pull/1055) Check if error is ocs response on workspace request
