### PR TITLE
Make BeforeTemplateRenderedEvent aware of the actual response

### DIFF
--- a/apps/user_status/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/apps/user_status/lib/Listener/BeforeTemplateRenderedListener.php
@@ -28,6 +28,7 @@ namespace OCA\UserStatus\Listener;
 use OCA\UserStatus\AppInfo\Application;
 use OCA\UserStatus\Service\JSDataService;
 use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
+use OCP\AppFramework\Http\TemplateResponse;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IInitialStateService;
@@ -61,7 +62,7 @@ class BeforeTemplateRenderedListener implements IEventListener {
 			return;
 		}
 
-		if (!$event->isLoggedIn()) {
+		if (!$event->isLoggedIn() || $event->getResponse()->getRenderAs() !== TemplateResponse::RENDER_AS_USER) {
 			return;
 		}
 

--- a/lib/private/AppFramework/Middleware/AdditionalScriptsMiddleware.php
+++ b/lib/private/AppFramework/Middleware/AdditionalScriptsMiddleware.php
@@ -71,7 +71,7 @@ class AdditionalScriptsMiddleware extends Middleware {
 				$isLoggedIn = false;
 			}
 
-			$this->dispatcher->dispatchTyped(new BeforeTemplateRenderedEvent($isLoggedIn));
+			$this->dispatcher->dispatchTyped(new BeforeTemplateRenderedEvent($isLoggedIn, $response));
 		}
 
 		return $response;

--- a/lib/public/AppFramework/Http/Events/BeforeTemplateRenderedEvent.php
+++ b/lib/public/AppFramework/Http/Events/BeforeTemplateRenderedEvent.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace OCP\AppFramework\Http\Events;
 
+use OCP\AppFramework\Http\TemplateResponse;
 use OCP\EventDispatcher\Event;
 
 /**
@@ -38,14 +39,17 @@ use OCP\EventDispatcher\Event;
 class BeforeTemplateRenderedEvent extends Event {
 	/** @var bool */
 	private $loggedIn;
+	/** @var TemplateResponse */
+	private $response;
 
 	/**
 	 * @since 20.0.0
 	 */
-	public function __construct(bool $loggedIn) {
+	public function __construct(bool $loggedIn, TemplateResponse $response) {
 		parent::__construct();
 
 		$this->loggedIn = $loggedIn;
+		$this->response = $response;
 	}
 
 	/**
@@ -53,5 +57,12 @@ class BeforeTemplateRenderedEvent extends Event {
 	 */
 	public function isLoggedIn(): bool {
 		return $this->loggedIn;
+	}
+
+	/**
+	 * @since 20.0.0
+	 */
+	public function getResponse(): TemplateResponse {
+		return $this->response;
 	}
 }


### PR DESCRIPTION
With this listeners can make there rendering dependent on the actual TemplateResponse. As an example the user_status app can only register the menu if a template with the user base template is returned.

Not sure if backporting to 20 would still be fine, though it might be nice to save some additional processing time on requests that use a blank template response like Collabora/ONLYOFFICE.

As a separate note, the user_status script has a special performance impact due to the emoji picker being loaded immediately, which is quite expensive, so this would be something where we also can improve the loading time for the user template, but I'd tackle that in a separate PR once i found a good solution.

![image](https://user-images.githubusercontent.com/3404133/93977639-14345480-fd7b-11ea-95ce-994dafa8802c.png)
