### PR TITLE
Show federation and email results also with exact user match unless c…

### DIFF
--- a/lib/private/Collaboration/Collaborators/Search.php
+++ b/lib/private/Collaboration/Collaborators/Search.php
@@ -91,9 +91,10 @@ class Search implements ISearch {
 			$searchResult->unsetResult($emailType);
 		}
 
-		// if we have an exact local user match, there is no need to show the remote and email matches
+		// if we have an exact local user match with an email-a-like query,
+		// there is no need to show the remote and email matches.
 		$userType = new SearchResultType('users');
-		if ($searchResult->hasExactIdMatch($userType)) {
+		if (strpos($search, '@') !== false && $searchResult->hasExactIdMatch($userType)) {
 			$searchResult->unsetResult($remoteType);
 			$searchResult->unsetResult($emailType);
 		}


### PR DESCRIPTION
…ontaining @

Before when you have a user "smith" and a federated user "smith@example.com"
you could see the federation result with "smit" but not with "smith" anymore.
With most LDAP configurations and local backend setups this is disturbing and
causes issues.
The idea of not showing the email and federation on a matching user was with:
Local user registered with "smith@example.com" user id and having that same
email / cloud id in your contacts addressbook. So we now only hide those
"side results" when the search does contain an @
