### PR TITLE
Make 'Reasons to use Nextcloud' button translatable, fix #22977

### DIFF
--- a/apps/settings/templates/settings/personal/development.notice.php
+++ b/apps/settings/templates/settings/personal/development.notice.php
@@ -1,6 +1,6 @@
 <div class="section development-notice">
 	<p>
-		<a href="<?php p($_['reasons-use-nextcloud-pdf-link']); ?>" id="open-reasons-use-nextcloud-pdf" class="link-button icon-file" target="_blank">Reasons to use Nextcloud in your organization</a>
+		<a href="<?php p($_['reasons-use-nextcloud-pdf-link']); ?>" id="open-reasons-use-nextcloud-pdf" class="link-button icon-file" target="_blank"><?php p($l->t('Reasons to use Nextcloud in your organization'));?></a>
 	</p>
 	<p>
 		<?php print_unescaped(str_replace(


### PR DESCRIPTION
Please review @Valdnet @kesselb @rullzer @MorrisJobke especially if it’s the right syntax – aint no PHP dev. :) 

Fix https://github.com/nextcloud/server/issues/22977