### PR TITLE
add option to disable notify self check

### DIFF
--- a/apps/files_external/lib/Command/Notify.php
+++ b/apps/files_external/lib/Command/Notify.php
@@ -85,6 +85,11 @@ class Notify extends Base {
 				InputOption::VALUE_REQUIRED,
 				'The directory in the storage to listen for updates in',
 				'/'
+			)->addOption(
+				'no-self-check',
+				'',
+				InputOption::VALUE_NONE,
+				'Disable self check on startup'
 			);
 		parent::configure();
 	}
@@ -138,7 +143,11 @@ class Notify extends Base {
 
 		$path = trim($input->getOption('path'), '/');
 		$notifyHandler = $storage->notify($path);
-		$this->selfTest($storage, $notifyHandler, $verbose, $output);
+
+		if (!$input->getOption('no-self-check')) {
+			$this->selfTest($storage, $notifyHandler, $verbose, $output);
+		}
+
 		$notifyHandler->listen(function (IChange $change) use ($mount, $verbose, $output) {
 			if ($verbose) {
 				$this->logUpdate($change, $output);


### PR DESCRIPTION
Running the self check can cause errors in some cases

Signed-off-by: Robin Appelman <robin@icewind.nl>