### PR TITLE
Delete files that exceed trashbin size immediately

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -285,6 +285,14 @@ class Trashbin {
 			$trashStorage->unlink($trashInternalPath);
 		}
 
+		$config = \OC::$server->getConfig();
+		$systemTrashbinSize = (int)$config->getAppValue('files_trashbin', 'trashbin_size', '-1');
+		$userTrashbinSize = (int)$config->getUserValue($owner, 'files_trashbin', 'trashbin_size', '-1');
+		$configuredTrashbinSize = ($userTrashbinSize < 0) ? $systemTrashbinSize : $userTrashbinSize;
+		if ($configuredTrashbinSize >= 0 && $sourceStorage->filesize($sourceInternalPath) >= $configuredTrashbinSize) {
+			return false;
+		}
+
 		$connection = \OC::$server->getDatabaseConnection();
 		$connection->beginTransaction();
 		$trashStorage->getUpdater()->renameFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);


### PR DESCRIPTION
This extends https://github.com/nextcloud/server/pull/21658 so that files that exceed a configured trash bin size by itself will never be moved to the trash but just deleted right away. Otherwise they sill take up space until the trash bin items get expired again.