### PR TITLE
DirectController: Let users choose the link expiration time

### DIFF
--- a/apps/dav/lib/Controller/DirectController.php
+++ b/apps/dav/lib/Controller/DirectController.php
@@ -81,7 +81,7 @@ class DirectController extends OCSController {
 	/**
 	 * @NoAdminRequired
 	 */
-	public function getUrl(int $fileId): DataResponse {
+	public function getUrl(int $fileId, int $expirationTime = 60 * 60 * 8): DataResponse {
 		$userFolder = $this->rootFolder->getUserFolder($this->userId);
 
 		$files = $userFolder->getById($fileId);
@@ -102,7 +102,7 @@ class DirectController extends OCSController {
 
 		$token = $this->random->generate(60, ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
 		$direct->setToken($token);
-		$direct->setExpiration($this->timeFactory->getTime() + 60 * 60 * 8);
+		$direct->setExpiration($this->timeFactory->getTime() + $expirationTime);
 
 		$this->mapper->insert($direct);
 

--- a/apps/dav/lib/Controller/DirectController.php
+++ b/apps/dav/lib/Controller/DirectController.php
@@ -90,6 +90,10 @@ class DirectController extends OCSController {
 			throw new OCSNotFoundException();
 		}
 
+		if ($expirationTime <= 0 || $expirationTime > (60 * 60 * 24)) {
+			throw new OCSBadRequestException('Expiration time should be greater than 0 and less than or equal to ' . (60 * 60 * 24));
+		}
+
 		$file = array_shift($files);
 		if (!($file instanceof File)) {
 			throw new OCSBadRequestException('Direct download only works for files');


### PR DESCRIPTION
Previously the expiration time for direct download links was hardcoded to 8 hours (although on the documentation 24 hours is stated).

Right now, a new optional body parameter can be added, "expirationTime". In case it is set, then that value will be used as the duration (in seconds) of the direct download link, else he default value of 8 hours is used.