### PR TITLE
Fix array to string conversion on event search

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -1780,7 +1780,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		foreach ($searchParameters as $property => $parameter) {
 			$parameterAnd = $calendarObjectIdQuery->expr()->andX();
 			$parameterAnd->add($calendarObjectIdQuery->expr()->eq('cob.name', $calendarObjectIdQuery->createNamedParameter($property, IQueryBuilder::PARAM_STR)));
-			$parameterAnd->add($calendarObjectIdQuery->expr()->eq('cob.parameter', $calendarObjectIdQuery->createNamedParameter($parameter, IQueryBuilder::PARAM_STR)));
+			$parameterAnd->add($calendarObjectIdQuery->expr()->eq('cob.parameter', $calendarObjectIdQuery->createNamedParameter($parameter, IQueryBuilder::PARAM_STR_ARRAY)));
 
 			$searchOr->add($parameterAnd);
 		}


### PR DESCRIPTION
```json
{
  "reqId": "nieyd2kcbYk5PfY5JctS",
  "level": 3,
  "time": "2020-09-24T10:48:21+00:00",
  "remoteAddr": "85.195.247.3",
  "user": "…",
  "app": "PHP",
  "method": "GET",
  "url": "/ocs/v2.php/search/providers/calendar/search?term=gal&from=…",
  "message": "Array to string conversion at /var/www/html/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php#81",
  "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:80.0) Gecko/20100101 Firefox/80.0",
  "version": "20.0.0.7"
}
```

Values come from:
https://github.com/nextcloud/server/blob/2a054e6c04e0a40421510eb889cbf59f153c5177/apps/dav/lib/Search/EventsSearchProvider.php#L61-L64
Go in here:
https://github.com/nextcloud/server/blob/2a054e6c04e0a40421510eb889cbf59f153c5177/apps/dav/lib/Search/EventsSearchProvider.php#L113
And end up as a "Str" parameter instead of array:
https://github.com/nextcloud/server/blob/7d0602792280f88af6867db0131d1bf8984b2c2c/apps/dav/lib/CalDAV/CalDavBackend.php#L1780-L1786