### PR TITLE
Fix numeric folders throwing on markDirty

### DIFF
--- a/apps/dav/lib/Connector/Sabre/CachingTree.php
+++ b/apps/dav/lib/Connector/Sabre/CachingTree.php
@@ -38,4 +38,16 @@ class CachingTree extends Tree {
 		}
 		$this->cache[trim($path, '/')] = $node;
 	}
+
+	public function markDirty($path) {
+		// We don't care enough about sub-paths
+		// flushing the entire cache
+		$path = trim($path, '/');
+		foreach ($this->cache as $nodePath => $node) {
+			$nodePath = (string) $nodePath;
+			if ('' === $path || $nodePath == $path || 0 === strpos($nodePath, $path.'/')) {
+				unset($this->cache[$nodePath]);
+			}
+		}
+	}
 }


### PR DESCRIPTION
TypeError: strpos() expects parameter 1 to be string, int given

The problem is that in cacheNode() we strip of any slashes, so
a folder `0/` will be trimmed to `'0'` and be used as an array key.
Since PHP automatically casts numeric array keys to integers,
you afterwards get $nodePath as int(0). Since it's now a number,
the strpos() function does not accept it anymore. Simply casting
$nodePath to a string again in the foreach solves the issue