### PR TITLE
[stable20] Fix running video verification integration tests in Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1350,7 +1350,7 @@ steps:
   commands:
     # JavaScript files are not used in integration tests so it is not needed to
     # build them.
-    - git clone --depth 1 https://github.com/nextcloud/spreed apps/spreed
+    - git clone --branch stable20 --depth 1 https://github.com/nextcloud/spreed apps/spreed
 - name: integration-sharing-v1-video-verification
   image: nextcloudci/integration-php7.3:integration-php7.3-2
   commands:


### PR DESCRIPTION
In order to run the video verification integration tests the Talk app needs to be cloned in a branch compatible with the server.
