### PR TITLE
Fix app text going too far down on hover/focus

### DIFF
--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -477,7 +477,6 @@ nav[role='navigation'] {
 			overflow: hidden;
 			padding: 0 5px;
 			z-index: 2;
-			margin-bottom: -1px; // for vertical alignment
 		}
 
 		/* hidden apps menu */


### PR DESCRIPTION
Fixing this detail as talked about @karlitschek 

Follow-up to "App name text display improvements" #22845