### PR TITLE
Fix null displayname crash as described in #21885

### DIFF
--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -458,11 +458,11 @@ class Database extends ABackend implements
 
 	public function getDisplayName(string $gid): string {
 		if (isset($this->groupCache[$gid])) {
-                        $displayName = $this->groupCache[$gid]['displayname'];
+			$displayName = $this->groupCache[$gid]['displayname'];
 
-                        if (isset($displayName) && trim($displayName) !== '') {
-                                return $displayName;
-                        }
+			if (isset($displayName) && trim($displayName) !== '') {
+				return $displayName;
+			}
 		}
 
 		$this->fixDI();

--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -458,7 +458,11 @@ class Database extends ABackend implements
 
 	public function getDisplayName(string $gid): string {
 		if (isset($this->groupCache[$gid])) {
-			return $this->groupCache[$gid]['displayname'];
+                        $displayName = $this->groupCache[$gid]['displayname'];
+
+                        if (isset($displayName) && trim($displayName) !== '') {
+                                return $displayName;
+                        }
 		}
 
 		$this->fixDI();


### PR DESCRIPTION
As discussed in #21885, `displayname` is sometimes Null when updating from older versions. This pull requests adds the code suggested in that issue by @dh-connect with modifications suggested by @kbzowski 