### PR TITLE
17.0.10 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(17, 0, 9, 2);
+$OC_Version = array(17, 0, 10, 0);
 
 // The human readable string
-$OC_VersionString = '17.0.9';
+$OC_VersionString = '17.0.10RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #22046 Bump elliptic from 6.5.0 to 6.5.3
* #22513 Show disabled user count in occ user:report
* #22523 Fix S3 error handling
* #22539 Only disable zip64 if the size is known
* #22566 Bump node-sass from 4.12.0 to 4.13.1
* #22571 Bump dompurify from 1.0.11 to 2.0.7
* #22610 Bump http-proxy from 1.17.0 to 1.18.1 in /build
* #22842 Mitigate encoding issue with user principal uri
* #22895 Revoke secsignid
* #22901 Fix: file quota was not applied in all cases
* [firstrunwizard#402](https://github.com/nextcloud/firstrunwizard/pull/402) Bump node-sass from 4.11.0 to 4.13.1
* [notifications#646](https://github.com/nextcloud/notifications/pull/646) Bump handlebars from 4.3.0 to 4.6.0
* [notifications#730](https://github.com/nextcloud/notifications/pull/730) Bump node-sass from 4.12.0 to 4.13.1
* [recommendations#280](https://github.com/nextcloud/recommendations/pull/280) Bump node-sass from 4.12.0 to 4.13.1
