### PR TITLE
19.0.4 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [19, 0, 3, 1];
+$OC_Version = [19, 0, 4, 0];
 
 // The human readable string
-$OC_VersionString = '19.0.3';
+$OC_VersionString = '19.0.4RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #22591 Better error message when blocked by access control
* #22630 LDAP: remove unused methods and DB values
* #22652 Fix installing on Oracle
* #22713 Do not fail if share for mountpoint is no longer available
* #22720 Don't use SELECT DISTINCT when to_char() is used in a WHERE statement
* #22742 Allow additional personal settings via normal registration
* #22745 Fix detecting text/x-php mimetype and secure mimetype mapping
* #22752 Check if var debugMode exists
* #22753 Fix reading empty files from objectstorage
* #22769 Clarify PHP warning in admin settings
* #22775 Makes LDAP's group updater dispatch type events
* #22776 Fix s3 doesDirectoryExist check for empty directories
* #22778 Don't fail if copying a file of 0 byte size
* #22784 Use user mount with matching shared storage only
* #22804 Fix share transfer of single files and on the transfered node
* #22840 Mitigate encoding issue with user principal uri
* #22892 Only get the permissions from the share source if it's not already cached
* #22893 Revoke secsignid
* #22899 Fix: file quota was not applied in all cases
* #22904 Make sure that getConfig is still called for browsers that do not support CSPv3
* #22926 Improve handling of out of space errors for smb
* #22941 Fix settings chunk loading
* #22988 Flow: do not hide "matches" and "does not match" checkers
* #23002 Never copy the share link when the password is forced
* #23049 Fix numeric folders throwing on markDirty
* #23086 Sync all users to the system addresssbook
* #23087 Show federation and email results also with exact user match unless c…
* #23090 Do not match sharees on an empty email address
* #23093 Generate exception to log on php errors
* [logreader#389](https://github.com/nextcloud/logreader/pull/389) Bugfix): Protect LogIterator.php from empty array indices
* [notifications#760](https://github.com/nextcloud/notifications/pull/760) Also check responses of 400 errors and so delete unknown devices
* [text#1003](https://github.com/nextcloud/text/pull/1003) Only return rich workspace when depth is 1 or greater
* [text#1036](https://github.com/nextcloud/text/pull/1036) IE11 madness
* [text#1054](https://github.com/nextcloud/text/pull/1054) Check if error is ocs response on workspace request
* [viewer#613](https://github.com/nextcloud/viewer/pull/613) Update .l10nignore to exclude bundled JS files
