### PR TITLE
Generate exception to log on php errors

### DIFF
--- a/lib/private/Log/ErrorHandler.php
+++ b/lib/private/Log/ErrorHandler.php
@@ -88,12 +88,14 @@ class ErrorHandler {
 			return;
 		}
 		$msg = $message . ' at ' . $file . '#' . $line;
-		self::$logger->error(self::removePassword($msg), ['app' => 'PHP']);
+		$e = new \Error(self::removePassword($msg));
+		self::$logger->logException($e, ['app' => 'PHP']);
 	}
 
 	//Recoverable handler which catch all errors, warnings and notices
 	public static function onAll($number, $message, $file, $line) {
 		$msg = $message . ' at ' . $file . '#' . $line;
-		self::$logger->debug(self::removePassword($msg), ['app' => 'PHP']);
+		$e = new \Error(self::removePassword($msg));
+		self::$logger->logException($e, ['app' => 'PHP', 'level' => 0]);
 	}
 }


### PR DESCRIPTION
This will make sure we get some more useful error log messages that contain a trace to the actual place in code that caused the issue when a PHP error is catched, e.g. for a "Trying to access array offset on value of type null" error.

Example output:
```
{
  "reqId": "SDrgQ5mzjHWyKLd9bP3u",
  "level": 0,
  "time": "2020-09-29T06:53:42+00:00",
  "remoteAddr": "192.168.21.9",
  "user": "admin",
  "app": "PHP",
  "method": "GET",
  "url": "/test.php",
  "message": {
    "Exception": "Error",
    "Message": "Trying to access array offset on value of type null at /var/www/html/test.php#15",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/html/test.php",
        "line": 15,
        "function": "onAll",
        "class": "OC\\Log\\ErrorHandler",
        "type": "::",
        "args": [
          8,
          "Trying to access array offset on value of type null",
          "/var/www/html/test.php",
          15,
          {
            "foo": null,
            "bar": null
          }
        ]
      },
      {
        "file": "/var/www/html/test.php",
        "line": 18,
        "function": "bar",
        "args": []
      },
      {
        "file": "/var/www/html/test.php",
        "line": 30,
        "function": "foo",
        "args": []
      }
    ],
    "File": "/var/www/html/lib/private/Log/ErrorHandler.php",
    "Line": 98,
    "CustomMessage": "--"
  },
  "userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:81.0) Gecko/20100101 Firefox/81.0",
  "version": "21.0.0.0"
}
```