### PR TITLE
Also check the path based mimetype for flow rule checks

### DIFF
--- a/apps/workflowengine/lib/Check/FileMimeType.php
+++ b/apps/workflowengine/lib/Check/FileMimeType.php
@@ -94,6 +94,19 @@ class FileMimeType extends AbstractStringCheck implements IFileCheck {
 	}
 
 	/**
+	 * Make sure that even though the content based check returns an application/octet-stream can still be checked based on mimetypemappings of their extension
+	 *
+	 * @param string $operator
+	 * @param string $value
+	 * @return bool
+	 */
+	public function executeCheck($operator, $value) {
+		$actualValue = $this->getActualValue();
+		return $this->executeStringCheck($operator, $value, $actualValue) ||
+			$this->executeStringCheck($operator, $value, $this->mimeTypeDetector->detectPath($this->path));
+	}
+
+	/**
 	 * @return string
 	 */
 	protected function getActualValue() {


### PR DESCRIPTION
Before this PR it is not possible to match workflow rules against application/javascript or application/x-ms-dos-executable since they are not part of the mimetypemappings and the detectContents always uses the secure fallback, so checking for those file types for example always fails:

| file | detectContent | detectPath | 
|---|---|---|
| .exe | application/octet-stream | application/x-ms-dos-executable |
| .js | text/plain | application/javascript |

This PR makes sure that when checking for a workflow rule both the detected type on the content and path are checked. 


