### PR TITLE
Reset the user status when clearing the custom message

### DIFF
--- a/apps/user_status/lib/Controller/UserStatusController.php
+++ b/apps/user_status/lib/Controller/UserStatusController.php
@@ -138,7 +138,12 @@ class UserStatusController extends OCSController {
 									 string $message,
 									 ?int $clearAt): DataResponse {
 		try {
-			$status = $this->service->setCustomMessage($this->userId, $statusIcon, $message, $clearAt);
+			if ($message !== '') {
+				$status = $this->service->setCustomMessage($this->userId, $statusIcon, $message, $clearAt);
+			} else {
+				$this->service->clearMessage($this->userId);
+				$status = $this->service->findByUserId($this->userId);
+			}
 			return new DataResponse($this->formatStatus($status));
 		} catch (InvalidClearAtException $ex) {
 			$this->logger->debug('New user-status for "' . $this->userId . '" was rejected due to an invalid clearAt value "' . $clearAt . '"');


### PR DESCRIPTION
### Steps

1. Set a custom status message
2. Remove the message string from the input and press "Set status" instead of "Clear custom status"
3. Check status as another user, e.g. in the dashboard:
![201-66-max](https://user-images.githubusercontent.com/213943/94683707-3c95f300-0327-11eb-8a8b-a795753ed80b.png)
