### PR TITLE
also load app autoloader when located in /vendor

### DIFF
--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -266,6 +266,8 @@ class OC_App {
 
 		if (file_exists($path . '/composer/autoload.php')) {
 			require_once $path . '/composer/autoload.php';
+		} elseif (file_exists($path . '/vendor/autoload.php')) {
+			require_once $path . '/vendor/autoload.php';
 		} else {
 			\OC::$composerAutoloader->addPsr4($appNamespace . '\\', $path . '/lib/', true);
 			// Register on legacy autoloader


### PR DESCRIPTION
with the phasing out of `app.php` apps can no longer load the autoloader from there themselves

See https://github.com/nextcloud/server/pull/21812