### PR TITLE
Less psalm warnings

### DIFF
--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php
@@ -327,7 +327,7 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 * Creates a IN () comparison expression with the given arguments.
 	 *
 	 * @param ILiteral|IParameter|IQueryFunction|string $x The field in string format to be inspected by IN() comparison.
-	 * @param string|array $y The placeholder or the array of values to be used by IN() comparison.
+	 * @param ILiteral|IParameter|IQueryFunction|string|array $y The placeholder or the array of values to be used by IN() comparison.
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
@@ -343,7 +343,7 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 * Creates a NOT IN () comparison expression with the given arguments.
 	 *
 	 * @param ILiteral|IParameter|IQueryFunction|string $x The field in string format to be inspected by NOT IN() comparison.
-	 * @param string|array $y The placeholder or the array of values to be used by NOT IN() comparison.
+	 * @param ILiteral|IParameter|IQueryFunction|string|array $y The placeholder or the array of values to be used by NOT IN() comparison.
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php
@@ -33,6 +33,7 @@ use OC\DB\QueryBuilder\QueryFunction;
 use OC\DB\QueryBuilder\QuoteHelper;
 use OCP\DB\QueryBuilder\IExpressionBuilder;
 use OCP\DB\QueryBuilder\ILiteral;
+use OCP\DB\QueryBuilder\IParameter;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\DB\QueryBuilder\IQueryFunction;
 use OCP\IDBConnection;
@@ -278,7 +279,7 @@ class ExpressionBuilder implements IExpressionBuilder {
 	/**
 	 * Creates a LIKE() comparison expression with the given arguments.
 	 *
-	 * @param string $x Field in string format to be inspected by LIKE() comparison.
+	 * @param ILiteral|IParameter|IQueryFunction|string $x Field in string format to be inspected by LIKE() comparison.
 	 * @param mixed $y Argument to be used in LIKE() comparison.
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
@@ -309,7 +310,7 @@ class ExpressionBuilder implements IExpressionBuilder {
 	/**
 	 * Creates a NOT LIKE() comparison expression with the given arguments.
 	 *
-	 * @param string $x Field in string format to be inspected by NOT LIKE() comparison.
+	 * @param ILiteral|IParameter|IQueryFunction|string $x Field in string format to be inspected by NOT LIKE() comparison.
 	 * @param mixed $y Argument to be used in NOT LIKE() comparison.
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
@@ -325,7 +326,7 @@ class ExpressionBuilder implements IExpressionBuilder {
 	/**
 	 * Creates a IN () comparison expression with the given arguments.
 	 *
-	 * @param string $x The field in string format to be inspected by IN() comparison.
+	 * @param ILiteral|IParameter|IQueryFunction|string $x The field in string format to be inspected by IN() comparison.
 	 * @param string|array $y The placeholder or the array of values to be used by IN() comparison.
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
@@ -341,7 +342,7 @@ class ExpressionBuilder implements IExpressionBuilder {
 	/**
 	 * Creates a NOT IN () comparison expression with the given arguments.
 	 *
-	 * @param string $x The field in string format to be inspected by NOT IN() comparison.
+	 * @param ILiteral|IParameter|IQueryFunction|string $x The field in string format to be inspected by NOT IN() comparison.
 	 * @param string|array $y The placeholder or the array of values to be used by NOT IN() comparison.
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -869,14 +869,14 @@ class QueryBuilder implements IQueryBuilder {
 	 * </code>
 	 *
 	 * @param string $column The column into which the value should be inserted.
-	 * @param string $value The value that should be inserted into the column.
+	 * @param IParameter|string $value The value that should be inserted into the column.
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function setValue($column, $value) {
 		$this->queryBuilder->setValue(
 			$this->helper->quoteColumnName($column),
-			$value
+			(string) $value
 		);
 
 		return $this;

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -42,6 +42,7 @@ use OC\DB\QueryBuilder\FunctionBuilder\OCIFunctionBuilder;
 use OC\DB\QueryBuilder\FunctionBuilder\PgSqlFunctionBuilder;
 use OC\DB\QueryBuilder\FunctionBuilder\SqliteFunctionBuilder;
 use OC\SystemConfig;
+use OCP\DB\QueryBuilder\ILiteral;
 use OCP\DB\QueryBuilder\IParameter;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\DB\QueryBuilder\IQueryFunction;
@@ -695,7 +696,7 @@ class QueryBuilder implements IQueryBuilder {
 	 * </code>
 	 *
 	 * @param string $key The column to set.
-	 * @param IParameter|string $value The value, expression, placeholder, etc.
+	 * @param ILiteral|IParameter|IQueryFunction|string $value The value, expression, placeholder, etc.
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */

--- a/lib/public/DB/QueryBuilder/IExpressionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IExpressionBuilder.php
@@ -284,7 +284,7 @@ interface IExpressionBuilder {
 	 * Creates a IN () comparison expression with the given arguments.
 	 *
 	 * @param ILiteral|IParameter|IQueryFunction|string $x The field in string format to be inspected by IN() comparison.
-	 * @param string|array $y The placeholder or the array of values to be used by IN() comparison.
+	 * @param ILiteral|IParameter|IQueryFunction|string|array $y The placeholder or the array of values to be used by IN() comparison.
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
@@ -297,7 +297,7 @@ interface IExpressionBuilder {
 	 * Creates a NOT IN () comparison expression with the given arguments.
 	 *
 	 * @param ILiteral|IParameter|IQueryFunction|string $x The field in string format to be inspected by NOT IN() comparison.
-	 * @param string|array $y The placeholder or the array of values to be used by NOT IN() comparison.
+	 * @param ILiteral|IParameter|IQueryFunction|string|array $y The placeholder or the array of values to be used by NOT IN() comparison.
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *

--- a/lib/public/DB/QueryBuilder/IExpressionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IExpressionBuilder.php
@@ -244,7 +244,7 @@ interface IExpressionBuilder {
 	/**
 	 * Creates a LIKE() comparison expression with the given arguments.
 	 *
-	 * @param string $x Field in string format to be inspected by LIKE() comparison.
+	 * @param ILiteral|IParameter|IQueryFunction|string $x Field in string format to be inspected by LIKE() comparison.
 	 * @param mixed $y Argument to be used in LIKE() comparison.
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
@@ -257,7 +257,7 @@ interface IExpressionBuilder {
 	/**
 	 * Creates a NOT LIKE() comparison expression with the given arguments.
 	 *
-	 * @param string $x Field in string format to be inspected by NOT LIKE() comparison.
+	 * @param ILiteral|IParameter|IQueryFunction|string $x Field in string format to be inspected by NOT LIKE() comparison.
 	 * @param mixed $y Argument to be used in NOT LIKE() comparison.
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
@@ -283,7 +283,7 @@ interface IExpressionBuilder {
 	/**
 	 * Creates a IN () comparison expression with the given arguments.
 	 *
-	 * @param string $x The field in string format to be inspected by IN() comparison.
+	 * @param ILiteral|IParameter|IQueryFunction|string $x The field in string format to be inspected by IN() comparison.
 	 * @param string|array $y The placeholder or the array of values to be used by IN() comparison.
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
@@ -296,7 +296,7 @@ interface IExpressionBuilder {
 	/**
 	 * Creates a NOT IN () comparison expression with the given arguments.
 	 *
-	 * @param string $x The field in string format to be inspected by NOT IN() comparison.
+	 * @param ILiteral|IParameter|IQueryFunction|string $x The field in string format to be inspected by NOT IN() comparison.
 	 * @param string|array $y The placeholder or the array of values to be used by NOT IN() comparison.
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -651,7 +651,7 @@ interface IQueryBuilder {
 	 * </code>
 	 *
 	 * @param string $column The column into which the value should be inserted.
-	 * @param string $value The value that should be inserted into the column.
+	 * @param IParameter|string $value The value that should be inserted into the column.
 	 *
 	 * @return $this This QueryBuilder instance.
 	 * @since 8.2.0

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -522,7 +522,7 @@ interface IQueryBuilder {
 	 * </code>
 	 *
 	 * @param string $key The column to set.
-	 * @param IParameter|string $value The value, expression, placeholder, etc.
+	 * @param ILiteral|IParameter|IQueryFunction|string $value The value, expression, placeholder, etc.
 	 *
 	 * @return $this This QueryBuilder instance.
 	 * @since 8.2.0


### PR DESCRIPTION
- Update signature for like/notLike/in/notIn: **$x** is always passed to quoteColumnName hence ILiteral|IParameter|IQueryFunction are supported.
- Update signature for in/notIn: **$y** is always passed to quoteColumnName hence ILiteral|IParameter|IQueryFunction are supported.
- Update signature for set: also ILiteral and IQueryFunction are valid values.
- Update signature for setValue: also IParameter is supported.

:warning: Functional change: setValue now casts $value to string. This was done before much later by doctrine.
