### PR TITLE
Remove posix_getpwuid and compare only userid

### DIFF
--- a/apps/settings/lib/Settings/Admin/Server.php
+++ b/apps/settings/lib/Settings/Admin/Server.php
@@ -58,8 +58,7 @@ class Server implements ISettings {
 			'lastcron' => $this->config->getAppValue('core', 'lastcron', false),
 			'cronMaxAge' => $this->cronMaxAge(),
 			'cronErrors' => $this->config->getAppValue('core', 'cronErrors'),
-			'cli_based_cron_possible' => function_exists('posix_getpwuid'),
-			'cli_based_cron_user' => function_exists('posix_getpwuid') ? posix_getpwuid(fileowner(\OC::$configDir . 'config.php'))['name'] : '',
+			'cli_based_cron_user' => fileowner(\OC::$configDir . 'config.php'),
 		];
 
 		return new TemplateResponse('settings', 'settings/admin/server', $parameters, '');

--- a/apps/settings/templates/settings/admin/server.php
+++ b/apps/settings/templates/settings/admin/server.php
@@ -92,22 +92,10 @@
 				<input type="radio" name="mode" value="cron" class="radio"
 					   id="backgroundjobs_cron" <?php if ($_['backgroundjobs_mode'] === "cron") {
 			print_unescaped('checked="checked"');
-		}
-				if (!$_['cli_based_cron_possible']) {
-					print_unescaped('disabled');
-				}?>>
+		} ?>>
 				<label for="backgroundjobs_cron">Cron</label><br/>
 				<em><?php p($l->t("Use system cron service to call the cron.php file every 5 minutes.")); ?>
-					<?php if ($_['cli_based_cron_possible']) {
-					p($l->t('The cron.php needs to be executed by the system user "%s".', [$_['cli_based_cron_user']]));
-				} else {
-					print_unescaped(str_replace(
-							['{linkstart}', '{linkend}'],
-							['<a href="http://php.net/manual/en/book.posix.php">', ' ↗</a>'],
-							$l->t('To run this you need the PHP POSIX extension. See {linkstart}PHP documentation{linkend} for more details.')
-						));
-				} ?></em>
-
+					<?php p($l->t('The cron.php needs to be executed by the user id "%s".', [$_['cli_based_cron_user']])); ?></em>
 			</p>
 		</fieldset>
 	</form>

--- a/apps/settings/tests/Settings/Admin/ServerTest.php
+++ b/apps/settings/tests/Settings/Admin/ServerTest.php
@@ -96,8 +96,7 @@ class ServerTest extends TestCase {
 				'lastcron' => false,
 				'cronErrors' => '',
 				'cronMaxAge' => 1337,
-				'cli_based_cron_possible' => true,
-				'cli_based_cron_user' => function_exists('posix_getpwuid') ? posix_getpwuid(fileowner(\OC::$configDir . 'config.php'))['name'] : '', // to not explode here because of posix extension not being disabled - which is already checked in the line above
+				'cli_based_cron_user' => fileowner(\OC::$configDir . 'config.php'),
 			],
 			''
 		);

--- a/console.php
+++ b/console.php
@@ -64,14 +64,14 @@ try {
 		echo "The posix extensions are required - see http://php.net/manual/en/book.posix.php" . PHP_EOL;
 		exit(1);
 	}
-	$user = posix_getpwuid(posix_getuid());
-	$configUser = posix_getpwuid(fileowner(OC::$configDir . 'config.php'));
-	if ($user['name'] !== $configUser['name']) {
+	$user = posix_getuid();
+	$configUser = fileowner(OC::$configDir . 'config.php');
+	if ($user !== $configUser) {
 		echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
-		echo "Current user: " . $user['name'] . PHP_EOL;
-		echo "Owner of config.php: " . $configUser['name'] . PHP_EOL;
-		echo "Try adding 'sudo -u " . $configUser['name'] . " ' to the beginning of the command (without the single quotes)" . PHP_EOL;
-		echo "If running with 'docker exec' try adding the option '-u " . $configUser['name'] . "' to the docker command (without the single quotes)" . PHP_EOL;
+		echo "Current user id: " . $user . PHP_EOL;
+		echo "Owner id of config.php: " . $configUser . PHP_EOL;
+		echo "Try adding 'sudo -u " . $configUser . " ' to the beginning of the command (without the single quotes)" . PHP_EOL;
+		echo "If running with 'docker exec' try adding the option '-u " . $configUser . "' to the docker command (without the single quotes)" . PHP_EOL;
 		exit(1);
 	}
 

--- a/console.php
+++ b/console.php
@@ -70,7 +70,7 @@ try {
 		echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
 		echo "Current user id: " . $user . PHP_EOL;
 		echo "Owner id of config.php: " . $configUser . PHP_EOL;
-		echo "Try adding 'sudo -u " . $configUser . " ' to the beginning of the command (without the single quotes)" . PHP_EOL;
+		echo "Try adding 'sudo -u #" . $configUser . "' to the beginning of the command (without the single quotes)" . PHP_EOL;
 		echo "If running with 'docker exec' try adding the option '-u " . $configUser . "' to the docker command (without the single quotes)" . PHP_EOL;
 		exit(1);
 	}

--- a/cron.php
+++ b/cron.php
@@ -94,14 +94,15 @@ try {
 			exit(1);
 		}
 
-		$user = posix_getpwuid(posix_getuid());
-		$configUser = posix_getpwuid(fileowner(OC::$configDir . 'config.php'));
-		if ($user['name'] !== $configUser['name']) {
+		$user = posix_getuid();
+		$configUser = fileowner(OC::$configDir . 'config.php');
+		if ($user !== $configUser) {
 			echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
-			echo "Current user: " . $user['name'] . PHP_EOL;
-			echo "Owner of config.php: " . $configUser['name'] . PHP_EOL;
+			echo "Current user id: " . $user . PHP_EOL;
+			echo "Owner id of config.php: " . $configUser . PHP_EOL;
 			exit(1);
 		}
+
 
 		// We call Nextcloud from the CLI (aka cron)
 		if ($appMode !== 'cron') {


### PR DESCRIPTION
I had some trouble with the command `occ` and the cron job freezing and causing a thread to load 100% infinitely. 
This patch fixed it for me.

`posix_getpwuid` returns an array with information about user/group/etc. for current user. These information is not available when /etc/passwd is not readable (see https://secure.php.net/manual/en/function.posix-getpwuid.php#45994).

Calling posix_getpwuid() twice should not result in something different for the same input, and if it is not the same input, the result is also never the same. So comparing only the user id should be fine. 

Same as #11091 for `console.php` and `cron.php`.