### PR TITLE
Fix the user email issue while creating a user

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -337,19 +337,21 @@ class UsersController extends AUserData {
 			}
 
 			// Send new user mail only if a mail is set
-			if ($email !== '' && $this->config->getAppValue('core', 'newUser.sendEmail', 'yes') === 'yes') {
+			if ($email !== '') {
 				$newUser->setEMailAddress($email);
-				try {
-					$emailTemplate = $this->newUserMailHelper->generateTemplate($newUser, $generatePasswordResetToken);
-					$this->newUserMailHelper->sendMail($newUser, $emailTemplate);
-				} catch (\Exception $e) {
-					// Mail could be failing hard or just be plain not configured
-					// Logging error as it is the hardest of the two
-					$this->logger->logException($e, [
-						'message' => "Unable to send the invitation mail to $email",
-						'level' => ILogger::ERROR,
-						'app' => 'ocs_api',
-					]);
+				if ($this->config->getAppValue('core', 'newUser.sendEmail', 'yes') === 'yes') {
+					try {
+						$emailTemplate = $this->newUserMailHelper->generateTemplate($newUser, $generatePasswordResetToken);
+						$this->newUserMailHelper->sendMail($newUser, $emailTemplate);
+					} catch (\Exception $e) {
+						// Mail could be failing hard or just be plain not configured
+						// Logging error as it is the hardest of the two
+						$this->logger->logException($e, [
+							'message' => "Unable to send the invitation mail to $email",
+							'level' => ILogger::ERROR,
+							'app' => 'ocs_api',
+						]);
+					}
 				}
 			}
 

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -500,9 +500,13 @@ class UsersControllerTest extends TestCase {
 			->method('userExists')
 			->with('NewUser')
 			->willReturn(false);
+		$newUser = $this->createMock(IUser::class);
+		$newUser->expects($this->once())
+			->method('setEMailAddress');
 		$this->userManager
 			->expects($this->once())
-			->method('createUser');
+			->method('createUser')
+			->willReturn($newUser);
 		$this->logger
 			->expects($this->once())
 			->method('info')


### PR DESCRIPTION
When the user is created, the provisioning api
was not adding the email address of the user
when provided if the `send email to new user`
is not set.

Signed-off-by: Sujith Haridasan <sujith.h@gmail.com>