### PR TITLE
Expose system address book

### DIFF
--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>WebDAV</name>
 	<summary>WebDAV endpoint</summary>
 	<description>WebDAV endpoint</description>
-	<version>1.17.0</version>
+	<version>1.18.0</version>
 	<licence>agpl</licence>
 	<author>owncloud.org</author>
 	<namespace>DAV</namespace>
@@ -55,6 +55,7 @@
 
 	<settings>
 		<admin>OCA\DAV\Settings\CalDAVSettings</admin>
+		<admin>OCA\DAV\Settings\CardDAVSettings</admin>
 	</settings>
 
 	<activity>

--- a/apps/dav/appinfo/v1/carddav.php
+++ b/apps/dav/appinfo/v1/carddav.php
@@ -57,7 +57,7 @@ $principalBackend = new Principal(
 	'principals/'
 );
 $db = \OC::$server->getDatabaseConnection();
-$cardDavBackend = new CardDavBackend($db, $principalBackend, \OC::$server->getUserManager(), \OC::$server->getGroupManager(), \OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class), \OC::$server->getEventDispatcher());
+$cardDavBackend = new CardDavBackend($db, $principalBackend, \OC::$server->getUserManager(), \OC::$server->getGroupManager(), \OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class), \OC::$server->getEventDispatcher(), \OC::$server->getConfig());
 
 $debugging = \OC::$server->getConfig()->getSystemValue('debug', false);
 

--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -239,6 +239,7 @@ return array(
     'OCA\\DAV\\Search\\TasksSearchProvider' => $baseDir . '/../lib/Search/TasksSearchProvider.php',
     'OCA\\DAV\\Server' => $baseDir . '/../lib/Server.php',
     'OCA\\DAV\\Settings\\CalDAVSettings' => $baseDir . '/../lib/Settings/CalDAVSettings.php',
+    'OCA\\DAV\\Settings\\CardDAVSettings' => $baseDir . '/../lib/Settings/CardDAVSettings.php',
     'OCA\\DAV\\Storage\\PublicOwnerWrapper' => $baseDir . '/../lib/Storage/PublicOwnerWrapper.php',
     'OCA\\DAV\\SystemTag\\SystemTagMappingNode' => $baseDir . '/../lib/SystemTag/SystemTagMappingNode.php',
     'OCA\\DAV\\SystemTag\\SystemTagNode' => $baseDir . '/../lib/SystemTag/SystemTagNode.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -254,6 +254,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Search\\TasksSearchProvider' => __DIR__ . '/..' . '/../lib/Search/TasksSearchProvider.php',
         'OCA\\DAV\\Server' => __DIR__ . '/..' . '/../lib/Server.php',
         'OCA\\DAV\\Settings\\CalDAVSettings' => __DIR__ . '/..' . '/../lib/Settings/CalDAVSettings.php',
+        'OCA\\DAV\\Settings\\CardDAVSettings' => __DIR__ . '/..' . '/../lib/Settings/CardDAVSettings.php',
         'OCA\\DAV\\Storage\\PublicOwnerWrapper' => __DIR__ . '/..' . '/../lib/Storage/PublicOwnerWrapper.php',
         'OCA\\DAV\\SystemTag\\SystemTagMappingNode' => __DIR__ . '/..' . '/../lib/SystemTag/SystemTagMappingNode.php',
         'OCA\\DAV\\SystemTag\\SystemTagNode' => __DIR__ . '/..' . '/../lib/SystemTag/SystemTagNode.php',

--- a/apps/dav/js/settings-admin-carddav.js
+++ b/apps/dav/js/settings-admin-carddav.js
@@ -21,8 +21,6 @@
  */
 "use strict";
 
-$('#carddavExposeSystemAddressBook').change(function() {
-	var val = $(this)[0].checked;
-
-	OCP.AppConfig.setValue('dav', 'exposeSystemAddressBook', val ? 'yes' : 'no');
-});
+document.getElementById('carddavExposeSystemAddressBook').onclick = function() {
+	OCP.AppConfig.setValue('dav', 'exposeSystemAddressBook', this.checked ? 'yes' : 'no');
+};

--- a/apps/dav/js/settings-admin-carddav.js
+++ b/apps/dav/js/settings-admin-carddav.js
@@ -21,6 +21,6 @@
  */
 "use strict";
 
-document.getElementById('carddavExposeSystemAddressBook').onclick = function() {
-	OCP.AppConfig.setValue('dav', 'exposeSystemAddressBook', this.checked ? 'yes' : 'no');
-};
+document.getElementById('carddavExposeSystemAddressBook').addEventListener('change', function(e) {
+	OCP.AppConfig.setValue('dav', 'exposeSystemAddressBook', e.target.checked ? 'yes' : 'no');
+});

--- a/apps/dav/js/settings-admin-carddav.js
+++ b/apps/dav/js/settings-admin-carddav.js
@@ -1,0 +1,28 @@
+/**
+ * @copyright 2017, Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @author Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+"use strict";
+
+$('#carddavExposeSystemAddressBook').change(function() {
+	var val = $(this)[0].checked;
+
+	OCP.AppConfig.setValue('dav', 'exposeSystemAddressBook', val ? 'yes' : 'no');
+});

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -47,6 +47,7 @@ use OCA\DAV\Events\CardDeletedEvent;
 use OCA\DAV\Events\CardUpdatedEvent;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IUser;
@@ -96,6 +97,9 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	/** @var IEventDispatcher */
 	private $dispatcher;
 
+	/** @var IConfig */
+	private $config;
+
 	/** @var EventDispatcherInterface */
 	private $legacyDispatcher;
 
@@ -110,18 +114,21 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	 * @param IGroupManager $groupManager
 	 * @param IEventDispatcher $dispatcher
 	 * @param EventDispatcherInterface $legacyDispatcher
+	 * @param IConfig $config
 	 */
 	public function __construct(IDBConnection $db,
 								Principal $principalBackend,
 								IUserManager $userManager,
 								IGroupManager $groupManager,
 								IEventDispatcher $dispatcher,
-								EventDispatcherInterface $legacyDispatcher) {
+								EventDispatcherInterface $legacyDispatcher,
+								IConfig $config) {
 		$this->db = $db;
 		$this->principalBackend = $principalBackend;
 		$this->userManager = $userManager;
 		$this->dispatcher = $dispatcher;
 		$this->legacyDispatcher = $legacyDispatcher;
+		$this->config = $config;
 		$this->sharingBackend = new Backend($this->db, $this->userManager, $groupManager, $principalBackend, 'addressbook');
 	}
 
@@ -243,29 +250,32 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		$result->closeCursor();
 
 		// query for system addressbooks
-		$principalUri="principals/system/system";
-		$query = $this->db->getQueryBuilder();
-		$query->select(['id', 'uri', 'displayname', 'principaluri', 'description', 'synctoken'])
-			->from('addressbooks')
-			->where($query->expr()->eq('principaluri', $query->createNamedParameter($principalUri)));
-		$result = $query->execute();
+		$includeSystemAddressBook = $this->config->getAppValue('dav', 'exposeSystemAddressBook', 'no') === 'yes';
+		if ($includeSystemAddressBook) {
+			$principalUri="principals/system/system";
+			$query = $this->db->getQueryBuilder();
+			$query->select(['id', 'uri', 'displayname', 'principaluri', 'description', 'synctoken'])
+				->from('addressbooks')
+				->where($query->expr()->eq('principaluri', $query->createNamedParameter($principalUri)));
+			$result = $query->execute();
 
-		while ($row = $result->fetch()) {
-			$addressBooks[$row['id']] = [
-				'id' => $row['id'],
-				'uri' => "system-address-book",
-				'principaluri' => $principalUriOriginal,
-				'{DAV:}displayname' => "System address book",
-				'{' . Plugin::NS_CARDDAV . '}addressbook-description' => $row['description'],
-				'{http://calendarserver.org/ns/}getctag' => $row['synctoken'],
-				'{http://sabredav.org/ns}sync-token' => $row['synctoken'] ?: '0',
-				'{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}owner-principal' => $row['principaluri'],
-				$readOnlyPropertyName => true,
-			];
+			while ($row = $result->fetch()) {
+				$addressBooks[$row['id']] = [
+					'id' => $row['id'],
+					'uri' => "system-address-book",
+					'principaluri' => $principalUriOriginal,
+					'{DAV:}displayname' => "System address book",
+					'{' . Plugin::NS_CARDDAV . '}addressbook-description' => $row['description'],
+					'{http://calendarserver.org/ns/}getctag' => $row['synctoken'],
+					'{http://sabredav.org/ns}sync-token' => $row['synctoken'] ?: '0',
+					'{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}owner-principal' => $row['principaluri'],
+					$readOnlyPropertyName => true,
+				];
 
-			$this->addOwnerPrincipal($addressBooks[$row['id']]);
+				$this->addOwnerPrincipal($addressBooks[$row['id']]);
+			}
+			$result->closeCursor();
 		}
-		$result->closeCursor();
 
 		return array_values($addressBooks);
 	}

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -128,11 +128,11 @@ class RootCollection extends SimpleCollection {
 		);
 
 		$pluginManager = new PluginManager(\OC::$server, \OC::$server->query(IAppManager::class));
-		$usersCardDavBackend = new CardDavBackend($db, $userPrincipalBackend, $userManager, $groupManager, $dispatcher, $legacyDispatcher);
+		$usersCardDavBackend = new CardDavBackend($db, $userPrincipalBackend, $userManager, $groupManager, $dispatcher, $legacyDispatcher, \OC::$server->getConfig());
 		$usersAddressBookRoot = new AddressBookRoot($userPrincipalBackend, $usersCardDavBackend, $pluginManager, 'principals/users');
 		$usersAddressBookRoot->disableListing = $disableListing;
 
-		$systemCardDavBackend = new CardDavBackend($db, $userPrincipalBackend, $userManager, $groupManager, $dispatcher, $legacyDispatcher);
+		$systemCardDavBackend = new CardDavBackend($db, $userPrincipalBackend, $userManager, $groupManager, $dispatcher, $legacyDispatcher,  \OC::$server->getConfig());
 		$systemAddressBookRoot = new AddressBookRoot(new SystemPrincipalBackend(), $systemCardDavBackend, $pluginManager, 'principals/system');
 		$systemAddressBookRoot->disableListing = $disableListing;
 

--- a/apps/dav/lib/Settings/CardDAVSettings.php
+++ b/apps/dav/lib/Settings/CardDAVSettings.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @copyright 2020, Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @author Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DAV\Settings;
+
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IConfig;
+use OCP\Settings\ISettings;
+
+class CardDAVSettings implements ISettings {
+
+	/** @var IConfig */
+	private $config;
+
+	/**
+	 * CalDAVSettings constructor.
+	 *
+	 * @param IConfig $config
+	 */
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	/**
+	 * @return TemplateResponse
+	 */
+	public function getForm() {
+		$parameters = [
+			'expose_system_address_book' => $this->config->getAppValue('dav', 'exposeSystemAddressBook', 'no'),
+		];
+
+		return new TemplateResponse('dav', 'settings-admin-carddav', $parameters);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getSection() {
+		return 'groupware';
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getPriority() {
+		return 10;
+	}
+}

--- a/apps/dav/templates/settings-admin-carddav.php
+++ b/apps/dav/templates/settings-admin-carddav.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @copyright 2020, Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @author Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+script('dav', [
+	'settings-admin-carddav'
+]);
+
+/** @var \OCP\IL10N $l */
+/** @var array $_ */
+?>
+<form id="CardDAV" class="section">
+	<h2><?php p($l->t('Addressbook server')); ?></h2>
+	<p>
+		<input type="checkbox" name="carddav_expose_system-address-book" id="carddavExposeSystemAddressBook" class="checkbox"
+			<?php ($_['expose_system_address_book'] === 'yes') ? print_unescaped('checked="checked"') : null ?>/>
+		<label for="carddavExposeSystemAddressBook"><?php p($l->t('Expose system address book')); ?></label>
+		<br>
+		<em>
+			<?php print_unescaped($l->t('Only information set to "Public" or "Trusted" in the user\'s personal settings will be exposed.')); ?>
+		</em>
+	</p>
+</form>

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -82,6 +82,9 @@ class CardDavBackendTest extends TestCase {
 	/** @var IEventDispatcher|\PHPUnit\Framework\MockObject\MockObject */
 	private $dispatcher;
 
+	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
+	private $config;
+
 	/** @var  IDBConnection */
 	private $db;
 
@@ -129,6 +132,9 @@ class CardDavBackendTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
+		$this->config = $this->createMock(IConfig::class);
+		$this->config->expects($this->any())->method('getAppValue')
+			->with('dav', 'exposeSystemAddressBook', 'no')->willReturn('no');
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->principal = $this->getMockBuilder(Principal::class)
@@ -156,7 +162,7 @@ class CardDavBackendTest extends TestCase {
 
 		$this->db = \OC::$server->getDatabaseConnection();
 
-		$this->backend = new CardDavBackend($this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher, $this->legacyDispatcher);
+		$this->backend = new CardDavBackend($this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher, $this->legacyDispatcher, $this->config);
 		// start every test with a empty cards_properties and cards table
 		$query = $this->db->getQueryBuilder();
 		$query->delete('cards_properties')->execute();
@@ -246,7 +252,7 @@ class CardDavBackendTest extends TestCase {
 
 		/** @var CardDavBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
 		$backend = $this->getMockBuilder(CardDavBackend::class)
-				->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher, $this->legacyDispatcher])
+				->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher, $this->legacyDispatcher, $this->config])
 				->setMethods(['updateProperties', 'purgeProperties'])->getMock();
 
 		// create a new address book
@@ -318,7 +324,7 @@ class CardDavBackendTest extends TestCase {
 
 	public function testMultiCard() {
 		$this->backend = $this->getMockBuilder(CardDavBackend::class)
-			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher, $this->legacyDispatcher])
+			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher, $this->legacyDispatcher, $this->config])
 			->setMethods(['updateProperties'])->getMock();
 
 		// create a new address book
@@ -371,7 +377,7 @@ class CardDavBackendTest extends TestCase {
 
 	public function testMultipleUIDOnDifferentAddressbooks() {
 		$this->backend = $this->getMockBuilder(CardDavBackend::class)
-			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher, $this->legacyDispatcher])
+			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher, $this->legacyDispatcher, $this->config])
 			->setMethods(['updateProperties'])->getMock();
 
 		// create 2 new address books
@@ -393,7 +399,7 @@ class CardDavBackendTest extends TestCase {
 
 	public function testMultipleUIDDenied() {
 		$this->backend = $this->getMockBuilder(CardDavBackend::class)
-			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher, $this->legacyDispatcher])
+			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher, $this->legacyDispatcher, $this->config])
 			->setMethods(['updateProperties'])->getMock();
 
 		// create a new address book
@@ -414,7 +420,7 @@ class CardDavBackendTest extends TestCase {
 
 	public function testNoValidUID() {
 		$this->backend = $this->getMockBuilder(CardDavBackend::class)
-			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher, $this->legacyDispatcher])
+			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher, $this->legacyDispatcher, $this->config])
 			->setMethods(['updateProperties'])->getMock();
 
 		// create a new address book
@@ -431,7 +437,7 @@ class CardDavBackendTest extends TestCase {
 
 	public function testDeleteWithoutCard() {
 		$this->backend = $this->getMockBuilder(CardDavBackend::class)
-			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher, $this->legacyDispatcher])
+			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher, $this->legacyDispatcher, $this->config])
 			->setMethods([
 				'getCardId',
 				'addChange',
@@ -471,7 +477,7 @@ class CardDavBackendTest extends TestCase {
 
 	public function testSyncSupport() {
 		$this->backend = $this->getMockBuilder(CardDavBackend::class)
-			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher, $this->legacyDispatcher])
+			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher, $this->legacyDispatcher, $this->config])
 			->setMethods(['updateProperties'])->getMock();
 
 		// create a new address book
@@ -537,7 +543,7 @@ class CardDavBackendTest extends TestCase {
 		$cardId = 2;
 
 		$backend = $this->getMockBuilder(CardDavBackend::class)
-			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher, $this->legacyDispatcher])
+			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher, $this->legacyDispatcher, $this->config])
 			->setMethods(['getCardId'])->getMock();
 
 		$backend->expects($this->any())->method('getCardId')->willReturn($cardId);


### PR DESCRIPTION
This was motivated by how we manage our address book at c.nc.com with all the shortcomings. As you know it happens regularly that users delete/edit contacts by accident or add contacts to the address book which doesn't belong there. Also from a user perspective it is highly irritating that you have to keep your contact information up-to-date twice, in your personal settings and in the company address book. All information are available through the personal profile and we store it already as a address book because we use it for example to sync the user directories between trusted servers for federated sharing.

This PR makes this address book available in the contacts app and for other carddav clients, read-only. Following constraints apply to the address book and its visibility.

1. It is a opt-in admin settings. By default the system address book will not be visible. I implemented the setting and the default to tackle privacy issues, especially for long term users who doesn't expect a accessible system address book after the next update. I also hope that this addresses some concerns, mentioned here https://github.com/nextcloud/server/issues/19575. The setting is in the admin "Groupware" section:

![image](https://user-images.githubusercontent.com/1589737/95104608-4dcf6d00-0736-11eb-96fc-93cb12024edd.png)

2. The system address book only contains information set to "public" or "trusted" by the user in their personal settings

4. All users are already searchable through the "people menu" which exposes additional information as well, like their email address, so there shouldn't be any privacy issue. Especially as the feature is opt-in and even than each user can tweak their privacy settings on the personal page.

fix https://github.com/nextcloud/server/issues/19575

PS: Please be nice to me, it is my first PR since almost two years :wink: 