### PR TITLE
Fix file size computation on 32bit platforms

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -146,8 +146,8 @@ class Local extends \OC\Files\Storage\Common {
 	public function stat($path) {
 		$fullPath = $this->getSourcePath($path);
 		clearstatcache(true, $fullPath);
-		$statResult = stat($fullPath);
-		if (PHP_INT_SIZE === 4 && !$this->is_dir($path)) {
+		$statResult = @stat($fullPath);
+		if (PHP_INT_SIZE === 4 && $statResult && !$this->is_dir($path)) {
 			$filesize = $this->filesize($path);
 			$statResult['size'] = $filesize;
 			$statResult[7] = $filesize;
@@ -159,9 +159,7 @@ class Local extends \OC\Files\Storage\Common {
 	 * @inheritdoc
 	 */
 	public function getMetaData($path) {
-		$fullPath = $this->getSourcePath($path);
-		clearstatcache(true, $fullPath);
-		$stat = @stat($fullPath);
+		$stat = $this->stat($path);
 		if (!$stat) {
 			return null;
 		}
@@ -180,6 +178,7 @@ class Local extends \OC\Files\Storage\Common {
 		}
 
 		if (!($path === '' || $path === '/')) { // deletable depends on the parents unix permissions
+			$fullPath = $this->getSourcePath($path);
 			$parent = dirname($fullPath);
 			if (is_writable($parent)) {
 				$permissions += Constants::PERMISSION_DELETE;


### PR DESCRIPTION
This fixes #5031 (or at least, the comments referring to versions >= 19.0.0RC1)

### Steps to reproduce

Run `./occ files:scan --all` on a server running on a 32bit platform (in my case, a Raspberry Pi 4 with 32bit Raspberry Pi OS)

### Expected behavior

The size of files bigger than 4GB, displayed in the UI and saved in the DB, should correspond to the actual file size.

### Actual behaviour

the size of files bigger than 4GB gets replaced with an apparently random value, making impossible to download the file correctly.

### Reason

This is caused by a recent [optimization](https://github.com/nextcloud/server/commit/5439469b687478eb5626f69adce3e38060fcd99e), included in all releases starting from v19.0.0RC1, that reintroduced the native PHP function`stat()` for computing file metadatas. The `filesize` component of the array returned by`stat()` is broken on 32bit platforms, like the Raspberry Pi, and contains a wrong value. This behavior is well known and was already addressed in the past, with the introduction of a dedicated [method](https://github.com/nextcloud/server/blob/master/lib/private/Files/Storage/Local.php#L146) that fixes the output of `stat()`.

### Fix

This patch replace `stat()` with the already-developed `stat()` workaround, restoring the correct behavior.
