### PR TITLE
Expose session based authentication through mount point type

### DIFF
--- a/apps/files_external/lib/Config/ConfigAdapter.php
+++ b/apps/files_external/lib/Config/ConfigAdapter.php
@@ -161,6 +161,7 @@ class ConfigAdapter implements IMountProvider {
 			if ($storageConfig->getType() === StorageConfig::MOUNT_TYPE_PERSONAl) {
 				return new PersonalMount(
 					$this->userStoragesService,
+					$storageConfig,
 					$storageConfig->getId(),
 					$storage,
 					'/' . $user->getUID() . '/files' . $storageConfig->getMountPoint(),
@@ -171,6 +172,7 @@ class ConfigAdapter implements IMountProvider {
 				);
 			} else {
 				return new ExternalMountPoint(
+					$storageConfig,
 					$storage,
 					'/' . $user->getUID() . '/files' . $storageConfig->getMountPoint(),
 					null,

--- a/apps/files_external/lib/Config/ExternalMountPoint.php
+++ b/apps/files_external/lib/Config/ExternalMountPoint.php
@@ -24,9 +24,20 @@
 namespace OCA\Files_External\Config;
 
 use OC\Files\Mount\MountPoint;
+use OCA\Files_External\Lib\StorageConfig;
+use OCA\Files_External\Lib\Auth\Password\SessionCredentials;
 
 class ExternalMountPoint extends MountPoint {
+
+	/** @var StorageConfig */
+	protected $storageConfig;
+
+	public function __construct(StorageConfig $storageConfig, $storage, $mountpoint, $arguments = null, $loader = null, $mountOptions = null, $mountId = null) {
+		$this->storageConfig = $storageConfig;
+		parent::__construct($storage, $mountpoint, $arguments, $loader, $mountOptions, $mountId);
+	}
+
 	public function getMountType() {
-		return 'external';
+		return ($this->storageConfig->getAuthMechanism() instanceof SessionCredentials) ? 'external-session' : 'external';
 	}
 }

--- a/apps/files_external/lib/Lib/PersonalMount.php
+++ b/apps/files_external/lib/Lib/PersonalMount.php
@@ -28,6 +28,7 @@ namespace OCA\Files_External\Lib;
 use OC\Files\Mount\MoveableMount;
 use OCA\Files_External\Config\ExternalMountPoint;
 use OCA\Files_External\Service\UserStoragesService;
+use OCP\Files\Storage\IStorage;
 
 /**
  * Person mount points can be moved by the user
@@ -42,7 +43,7 @@ class PersonalMount extends ExternalMountPoint implements MoveableMount {
 	/**
 	 * @param UserStoragesService $storagesService
 	 * @param int $storageId
-	 * @param \OCP\Files\Storage $storage
+	 * @param IStorage $storage
 	 * @param string $mountpoint
 	 * @param array $arguments (optional) configuration for the storage backend
 	 * @param \OCP\Files\Storage\IStorageFactory $loader
@@ -50,6 +51,7 @@ class PersonalMount extends ExternalMountPoint implements MoveableMount {
 	 */
 	public function __construct(
 		UserStoragesService $storagesService,
+		StorageConfig $storageConfig,
 		$storageId,
 		$storage,
 		$mountpoint,
@@ -58,7 +60,7 @@ class PersonalMount extends ExternalMountPoint implements MoveableMount {
 		$mountOptions = null,
 		$mountId = null
 	) {
-		parent::__construct($storage, $mountpoint, $arguments, $loader, $mountOptions, $mountId);
+		parent::__construct($storageConfig, $storage, $mountpoint, $arguments, $loader, $mountOptions, $mountId);
 		$this->storagesService = $storagesService;
 		$this->numericStorageId = $storageId;
 	}

--- a/apps/files_external/tests/PersonalMountTest.php
+++ b/apps/files_external/tests/PersonalMountTest.php
@@ -26,10 +26,12 @@ namespace OCA\Files_External\Tests;
 
 use OC\Files\Mount\Manager;
 use OCA\Files_External\Lib\PersonalMount;
+use OCA\Files_External\Lib\StorageConfig;
 use Test\TestCase;
 
 class PersonalMountTest extends TestCase {
 	public function testFindByStorageId() {
+		$storageConfig = $this->createMock(StorageConfig::class);
 		/** @var \OCA\Files_External\Service\UserStoragesService $storageService */
 		$storageService = $this->getMockBuilder('\OCA\Files_External\Service\UserStoragesService')
 			->disableOriginalConstructor()
@@ -43,7 +45,7 @@ class PersonalMountTest extends TestCase {
 			->method('getId')
 			->willReturn('dummy');
 
-		$mount = new PersonalMount($storageService, 10, $storage, '/foo');
+		$mount = new PersonalMount($storageService, $storageConfig, 10, $storage, '/foo');
 
 		$mountManager = new Manager();
 		$mountManager->addMount($mount);


### PR DESCRIPTION
With this apps can check whether an external storage mountpoint uses credentials stored in the session and can act upon that. An example scenario would be Collabora/ONLYOFFICE or the direct editing endpoint on mobile/desktop clients that cannot be used with session based auth since the session is not available in the unauthenticated requests.

Reference implementation for Collabora https://github.com/nextcloud/richdocuments/pull/1178