### PR TITLE
Improve user share suggestions

### DIFF
--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -265,7 +265,7 @@ class Database extends ABackend implements
 
 		$query = $this->dbConn->getQueryBuilder();
 
-		$displayNameParameter = '%' . str_replace(' ', '% ', $this->dbConn->escapeLikeParameter($search)) . '%';
+		$displayNameParameter = '%' . implode('% %', array_map([$this->dbConn, 'escapeLikeParameter'], explode(' ', $search))) . '%';
 		$query->select('uid', 'displayname')
 			->from($this->table, 'u')
 			->leftJoin('u', 'preferences', 'p', $query->expr()->andX(

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -265,6 +265,7 @@ class Database extends ABackend implements
 
 		$query = $this->dbConn->getQueryBuilder();
 
+		$nameSearch = '%' . str_replace(' ', '% ', $this->dbConn->escapeLikeParameter($search)) . '%';
 		$query->select('uid', 'displayname')
 			->from($this->table, 'u')
 			->leftJoin('u', 'preferences', 'p', $query->expr()->andX(
@@ -273,8 +274,8 @@ class Database extends ABackend implements
 				$query->expr()->eq('configkey', $query->expr()->literal('email')))
 			)
 			// sqlite doesn't like re-using a single named parameter here
-			->where($query->expr()->iLike('uid', $query->createPositionalParameter('%' . $this->dbConn->escapeLikeParameter($search) . '%')))
-			->orWhere($query->expr()->iLike('displayname', $query->createPositionalParameter('%' . $this->dbConn->escapeLikeParameter($search) . '%')))
+			->where($query->expr()->iLike('uid', $query->createPositionalParameter($nameSearch)))
+			->orWhere($query->expr()->iLike('displayname', $query->createPositionalParameter($nameSearch)))
 			->orWhere($query->expr()->iLike('configvalue', $query->createPositionalParameter('%' . $this->dbConn->escapeLikeParameter($search) . '%')))
 			->orderBy($query->func()->lower('displayname'), 'ASC')
 			->orderBy('uid_lower', 'ASC')

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -265,7 +265,7 @@ class Database extends ABackend implements
 
 		$query = $this->dbConn->getQueryBuilder();
 
-		$nameSearch = '%' . str_replace(' ', '% ', $this->dbConn->escapeLikeParameter($search)) . '%';
+		$displayNameParameter = '%' . str_replace(' ', '% ', $this->dbConn->escapeLikeParameter($search)) . '%';
 		$query->select('uid', 'displayname')
 			->from($this->table, 'u')
 			->leftJoin('u', 'preferences', 'p', $query->expr()->andX(
@@ -274,10 +274,21 @@ class Database extends ABackend implements
 				$query->expr()->eq('configkey', $query->expr()->literal('email')))
 			)
 			// sqlite doesn't like re-using a single named parameter here
-			->where($query->expr()->iLike('uid', $query->createPositionalParameter($nameSearch)))
-			->orWhere($query->expr()->iLike('displayname', $query->createPositionalParameter($nameSearch)))
-			->orWhere($query->expr()->iLike('configvalue', $query->createPositionalParameter('%' . $this->dbConn->escapeLikeParameter($search) . '%')))
-			->orderBy($query->func()->lower('displayname'), 'ASC')
+			->where($query->expr()->iLike('uid', $query->createPositionalParameter('%' . $this->dbConn->escapeLikeParameter($search) . '%')))
+			->orWhere($query->expr()->iLike('displayname', $query->createPositionalParameter($displayNameParameter)))
+			->orWhere($query->expr()->iLike('configvalue', $query->createPositionalParameter('%' . $this->dbConn->escapeLikeParameter($search) . '%')));
+
+		$serverAbsolutePath = \OC::$server->getURLGenerator()->getAbsoluteURL('/');
+		$serverFederationPath = rtrim(\OC\Share\Share::removeProtocolFromUrl($serverAbsolutePath), '/');
+
+		/*
+		 * the given search looks like a local federation.
+		 */
+		if (mb_strpos($search, '@'.$serverFederationPath) !== false) {
+			$query->orWhere($query->expr()->eq('uid', $query->createPositionalParameter(explode('@', $search)[0])));
+		}
+
+		$query->orderBy($query->func()->lower('displayname'), 'ASC')
 			->orderBy('uid_lower', 'ASC')
 			->setMaxResults($limit)
 			->setFirstResult($offset);

--- a/tests/lib/User/DatabaseTest.php
+++ b/tests/lib/User/DatabaseTest.php
@@ -140,6 +140,12 @@ class DatabaseTest extends Backend {
 		$result = $this->backend->getDisplayNames('display');
 		$this->assertCount(1, $result);
 
+		$result = $this->backend->getDisplayNames('Use Dis');
+		$this->assertCount(1, $result);
+
+		$result = $this->backend->getDisplayNames($user1Obj->getCloudId());
+		$this->assertCount(1, $result);
+
 		$result = $this->backend->getDisplayNames(strtoupper($user1));
 		$this->assertCount(1, $result);
 


### PR DESCRIPTION
Fixes #1963

@jancborchardt wrote the best way to start is to pick a issues with label "good first issue".
that´s why i just choosed this issue here from the list. :pick:  

- with this change you find user "Dominik Meyer" also when you search for "Dom Me" in the share dialog
- with this change you find user "Dominik Meyer" also when you enter his local share "uid@domain:port"

this is my first contribution so be friendly :smiley_cat: 

PS next to my code contribution is saw this code-comment:

> // sqlite doesn't like re-using a single named parameter here

i not understand this comment exactly, what is not possible with sqlite?
my change works in sqlite even tho i reuse the same column (uid), but i guess this comment means something else.

PPS i personally would love :smiling_face_with_three_hearts:  to find the user if you start with typing the lastname like "Meyer Dominik". but this is out of scope here i guess.