### PR TITLE
Remove bold font-weight and lower font-size for empty search box

### DIFF
--- a/core/src/views/UnifiedSearch.vue
+++ b/core/src/views/UnifiedSearch.vue
@@ -743,6 +743,8 @@ $input-padding: 6px;
 		margin: 10vh 0;
 
 		::v-deep .empty-content__title {
+			font-weight: normal;
+            font-size: 14px;
 			padding: 0 15px;
 			text-align: center;
 		}


### PR DESCRIPTION
Fixes #22987 
--
Simple changes to the `h2` part. Let me know if there is anything wrong, of course :)

Signed-off-by: Jacob Neplokh <me@jacobneplokh.com>