### PR TITLE
Fix adminpass strengthify margin

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -394,7 +394,6 @@ input[type='checkbox'].checkbox--white:checked + label:before {
 .strengthify-wrapper {
 	display: inline-block;
 	position: relative;
-	left: 5px;
 	top: -20px;
 	width: 269px;
 	border-radius: 0 0 3px 3px;


### PR DESCRIPTION
Removes obsolete left margin from the strength indicator of the adminpass field in the installation view.

Before:
![strengthify-bug-before](https://user-images.githubusercontent.com/1479486/95457066-a12cff80-0970-11eb-9786-ab7ae6b4f47f.png)

After:
![strengthify-bug-after](https://user-images.githubusercontent.com/1479486/95457064-a0946900-0970-11eb-9ec5-4c58dd560934.png)

