### PR TITLE
Fix the escapeHTML issue with files_external app

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -8,6 +8,14 @@
  *
  */
 
+function escapeHTML(text) {
+        return text.toString()
+                .split('&').join('&amp;')
+                .split('<').join('&lt;')
+                .split('>').join('&gt;')
+                .split('"').join('&quot;')
+                .split('\'').join('&#039;')
+}
 (function(){
 
 /**


### PR DESCRIPTION
The files_external app uses escapeHTML. This change
helps fix the UI of the external storage.

Signed-off-by: Sujith Haridasan <sujith.h@gmail.com>