### PR TITLE
Fix undefined index and consequential damages in versions code

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -496,7 +496,7 @@ class Storage {
 		$expiration = self::getExpiration();
 		$threshold = $expiration->getMaxAgeAsTimestamp();
 		$versions = self::getAllVersions($uid);
-		if (!$threshold || !array_key_exists('all', $versions)) {
+		if (!$threshold || empty($versions['all'])) {
 			return;
 		}
 
@@ -578,7 +578,10 @@ class Storage {
 		// newest version first
 		krsort($versions);
 
-		$result = [];
+		$result = [
+			'all' => [],
+			'by_file' => [],
+		];
 
 		foreach ($versions as $key => $value) {
 			$size = $view->filesize(self::VERSIONS_ROOT.'/'.$value['path'].'.v'.$value['timestamp']);
@@ -775,8 +778,8 @@ class Storage {
 
 			// if still not enough free space we rearrange the versions from all files
 			if ($availableSpace <= 0) {
-				$result = Storage::getAllVersions($uid);
-				$allVersions = $result['all'] ?? [];
+				$result = self::getAllVersions($uid);
+				$allVersions = $result['all'];
 
 				foreach ($result['by_file'] as $versions) {
 					list($toDeleteNew, $size) = self::getExpireList($time, $versions, $availableSpace <= 0);

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -776,7 +776,7 @@ class Storage {
 			// if still not enough free space we rearrange the versions from all files
 			if ($availableSpace <= 0) {
 				$result = Storage::getAllVersions($uid);
-				$allVersions = $result['all'];
+				$allVersions = $result['all'] ?? [];
 
 				foreach ($result['by_file'] as $versions) {
 					list($toDeleteNew, $size) = self::getExpireList($time, $versions, $availableSpace <= 0);


### PR DESCRIPTION
If the user has no space and there are no versions, there won't be an
`all` index in the versions entry. Hence this triggers a warning and
becomes `null`, afterwards `count`, `foreach` and friends will happily
throw even more warnings and errors because they don't want to play with
`null`. Thus adding a fallback to an empty array.