### PR TITLE
Add to README about compiling JS production assets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Then inside the root folder of your local Nextcloud development installation, ru
 ./build/compile-handlebars-templates.sh
 ```
 
+Before checking in JS changes, make sure to also build for production:
+```
+make build-js-production
+```
+Then add the compiled files for committing.
+
+Please note that if you used `make build-js` or `make watch-js` before almost all files changed, so might need to clear the workspace first.
 
 ### Tools we use 🛠
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,12 @@ make build-js-production
 ```
 Then add the compiled files for committing.
 
-Please note that if you used `make build-js` or `make watch-js` before almost all files changed, so might need to clear the workspace first.
+To save some time, to only rebuild for a specific app, use the following and replace the module with the app name:
+```
+MODULE=user_status make build-js-production
+```
+
+Please note that if you used `make build-js` or `make watch-js` before, you'll notice that a lot of files were marked as changed, so might need to clear the workspace first.
 
 ### Tools we use 🛠
 


### PR DESCRIPTION
Add note in README about the need to checkin also compiled JS assets
after running `make build-js-production`.

I hope this is correct... I interpreted this by looking at other PRs containing JS assets.