### PR TITLE
Increase scrollbar sizes

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -151,8 +151,8 @@ body {
 /* SCROLLING */
 
 ::-webkit-scrollbar {
-	width: 6px;
-	height: 5px;
+	width: 12px;
+	height: 12px
 }
 
 ::-webkit-scrollbar-track-piece {
@@ -161,7 +161,9 @@ body {
 
 ::-webkit-scrollbar-thumb {
 	background: var(--color-border-dark);
-	border-radius: var(--border-radius);
+	border-radius: var(--border-radius-large);
+	border: 2px solid transparent;
+	background-clip: content-box;
 }
 
 


### PR DESCRIPTION
I am tired of clicking next to it.
With our recent work towards more accessible UI, I think it is best to enlarge it a bit.


| Webkit Before | After |
|:---------:|:------:|
|![dev skjnldsv com_apps_files__dir=_ (1)](https://user-images.githubusercontent.com/14975046/95674940-e12ff480-0bb3-11eb-933c-a2b6ae5a04c7.png)|![dev skjnldsv com_apps_files__dir=_](https://user-images.githubusercontent.com/14975046/95674938-e0975e00-0bb3-11eb-87a5-7b738da04184.png)|
| Firefox Before | After |
|![Capture d’écran_2020-10-11_11-17-12](https://user-images.githubusercontent.com/14975046/95674896-8f876a00-0bb3-11eb-88bb-598f4b124621.png)|![Capture d’écran_2020-10-11_11-16-14](https://user-images.githubusercontent.com/14975046/95674898-944c1e00-0bb3-11eb-8b74-31d3e2c080c0.png)|