### PR TITLE
Add confirm button in new link share pending expire/password menu

### DIFF
--- a/apps/files_sharing/src/components/SharingEntryLink.vue
+++ b/apps/files_sharing/src/components/SharingEntryLink.vue
@@ -113,6 +113,9 @@
 				{{ t('files_sharing', 'Enter a date') }}
 			</ActionInput>
 
+			<ActionButton icon="icon-checkmark" @click.prevent.stop="onNewLinkShare">
+				{{ t('files_sharing', 'Create share') }}
+			</ActionButton>
 			<ActionButton icon="icon-close" @click.prevent.stop="onCancel">
 				{{ t('files_sharing', 'Cancel') }}
 			</ActionButton>


### PR DESCRIPTION
Fixes #19526

![share-confirm-button](https://user-images.githubusercontent.com/1479486/95677131-af268e80-0bc3-11eb-87f1-9b5edcb58306.png)