### PR TITLE
Fix typo 'shared'

### DIFF
--- a/lib/private/AppFramework/Bootstrap/RegistrationContext.php
+++ b/lib/private/AppFramework/Bootstrap/RegistrationContext.php
@@ -203,7 +203,7 @@ class RegistrationContext {
 			"appId" => $appId,
 			"name" => $name,
 			"factory" => $factory,
-			"sharred" => $shared,
+			"shared" => $shared,
 		];
 	}
 

--- a/tests/lib/AppFramework/Bootstrap/RegistrationContextTest.php
+++ b/tests/lib/AppFramework/Bootstrap/RegistrationContextTest.php
@@ -83,7 +83,10 @@ class RegistrationContextTest extends TestCase {
 		$this->context->delegateEventListenerRegistrations($dispatcher);
 	}
 
-	public function testRegisterService(): void {
+	/**
+	 * @dataProvider dataProvider_TrueFalse
+	 */
+	public function testRegisterService(bool $shared): void {
 		$app = $this->createMock(App::class);
 		$service = 'abc';
 		$factory = function () {
@@ -94,11 +97,11 @@ class RegistrationContextTest extends TestCase {
 			->willReturn($container);
 		$container->expects($this->once())
 			->method('registerService')
-			->with($service, $factory, true);
+			->with($service, $factory, $shared);
 		$this->logger->expects($this->never())
 			->method('logException');
 
-		$this->context->for('myapp')->registerService($service, $factory);
+		$this->context->for('myapp')->registerService($service, $factory, $shared);
 		$this->context->delegateContainerRegistrations([
 			'myapp' => $app,
 		]);
@@ -158,5 +161,12 @@ class RegistrationContextTest extends TestCase {
 		$this->context->delegateMiddlewareRegistrations([
 			'myapp' => $app,
 		]);
+	}
+
+	public function dataProvider_TrueFalse(){
+		return[
+			[true],
+			[false]
+		];
 	}
 }

--- a/tests/lib/AppFramework/Bootstrap/RegistrationContextTest.php
+++ b/tests/lib/AppFramework/Bootstrap/RegistrationContextTest.php
@@ -163,7 +163,7 @@ class RegistrationContextTest extends TestCase {
 		]);
 	}
 
-	public function dataProvider_TrueFalse(){
+	public function dataProvider_TrueFalse() {
 		return[
 			[true],
 			[false]


### PR DESCRIPTION
The current implementation of `RegistrationContext.registerService` does not recognize the `$shared`-parameter correctly because of a typo.
![image](https://user-images.githubusercontent.com/19730957/95746371-f6ca1a80-0c96-11eb-836f-c09720efa2e8.png)
