### PR TITLE
Expose CLOUD federation for local users in the recent addressbook

### DIFF
--- a/apps/contactsinteraction/lib/Listeners/ContactInteractionListener.php
+++ b/apps/contactsinteraction/lib/Listeners/ContactInteractionListener.php
@@ -156,9 +156,6 @@ class ContactInteractionListener implements IEventListener {
 			'CATEGORIES' => $this->l10n->t('Recently contacted'),
 		];
 
-		if ($contact->getUid() !== null) {
-			$props['X-NEXTCLOUD-UID'] = $contact->getUid();
-		}
 		if ($contact->getEmail() !== null) {
 			$props['EMAIL'] = $contact->getEmail();
 		}

--- a/apps/contactsinteraction/tests/Db/RecentContactMapperTest.php
+++ b/apps/contactsinteraction/tests/Db/RecentContactMapperTest.php
@@ -110,7 +110,6 @@ class RecentContactMapperTest extends TestCase {
 			'URI' => UUIDUtil::getUUID(),
 			'FN' => 'Foo Bar',
 			'CATEGORIES' => 'Recently contacted',
-			'X-NEXTCLOUD-UID' => 'foobar',
 		];
 
 		$time = $this->time->getDateTime();

--- a/apps/files_sharing/lib/Listener/ShareInteractionListener.php
+++ b/apps/files_sharing/lib/Listener/ShareInteractionListener.php
@@ -72,6 +72,7 @@ class ShareInteractionListener implements IEventListener {
 			return;
 		}
 		$actor = $this->userManager->get($share->getSharedBy());
+		$sharedWith = $this->userManager->get($share->getSharedWith());
 		if ($actor === null) {
 			$this->logger->warning('Share was not created by a user, can\'t emit interaction event');
 			return;
@@ -80,6 +81,9 @@ class ShareInteractionListener implements IEventListener {
 		switch ($share->getShareType()) {
 			case IShare::TYPE_USER:
 				$interactionEvent->setUid($share->getSharedWith());
+				if ($sharedWith !== null) {
+					$interactionEvent->setFederatedCloudId($sharedWith->getCloudId());
+				}
 				break;
 			case IShare::TYPE_EMAIL:
 				$interactionEvent->setEmail($share->getSharedWith());


### PR DESCRIPTION
If we want to show the users as local users on contacts we need to be able to match them.
I'll use the official CLOUD property like https://github.com/nextcloud/server/pull/23199 will implement too


Recents stays recent for 7 days, after they get destroyed. I'm fine with that, no need for a migration. The data will get update over time