### PR TITLE
VersioningTest.php:729 is unreliable and should be disabled

### DIFF
--- a/apps/files_versions/tests/VersioningTest.php
+++ b/apps/files_versions/tests/VersioningTest.php
@@ -688,6 +688,7 @@ class VersioningTest extends \Test\TestCase {
 	}
 
 	public function testRestoreMovedShare() {
+		$this->markTestSkipped('Unreliable test');
 		$this->loginAsUser(self::TEST_VERSIONS_USER);
 
 		$userHome = \OC::$server->getUserFolder(self::TEST_VERSIONS_USER);


### PR DESCRIPTION
One from #22305 

This happens sometimes:

```
1) OCA\Files_Versions\Tests\VersioningTest::testRestoreMovedShare
File content has not changed
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'version 2'
+'version 1'

/drone/src/apps/files_versions/tests/VersioningTest.php:729
```