### PR TITLE
The encryption decrypt position can be int or string

### DIFF
--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -459,7 +459,7 @@ class Crypt {
 	 * @param string $passPhrase
 	 * @param string $cipher
 	 * @param int $version
-	 * @param int $position
+	 * @param int|string $position
 	 * @return string
 	 * @throws DecryptionFailedException
 	 */

--- a/apps/encryption/lib/Crypto/Encryption.php
+++ b/apps/encryption/lib/Crypto/Encryption.php
@@ -360,7 +360,7 @@ class Encryption implements IEncryptionModule {
 	 * decrypt data
 	 *
 	 * @param string $data you want to decrypt
-	 * @param int $position
+	 * @param int|string $position
 	 * @return string decrypted data
 	 * @throws DecryptionFailedException
 	 */

--- a/lib/public/Encryption/IEncryptionModule.php
+++ b/lib/public/Encryption/IEncryptionModule.php
@@ -102,7 +102,7 @@ interface IEncryptionModule {
 	 * decrypt data
 	 *
 	 * @param string $data you want to decrypt
-	 * @param string $position position of the block we want to decrypt
+	 * @param int|string $position position of the block we want to decrypt
 	 *
 	 * @return mixed decrypted data
 	 *


### PR DESCRIPTION
The public API said string, internally we treated it as int. In reality
both are used. Let's reflect that in the documented argument type.

Found in https://github.com/nextcloud/server/pull/23401/checks?check_run_id=1246541334