### PR TITLE
Improve security & performance of Encrypt then MAC scheme.

### DIFF
--- a/lib/private/Security/Crypto.php
+++ b/lib/private/Security/Crypto.php
@@ -32,7 +32,6 @@ namespace OC\Security;
 use OCP\IConfig;
 use OCP\Security\ICrypto;
 use phpseclib\Crypt\AES;
-use phpseclib\Crypt\Hash;
 
 /**
  * Class Crypto provides a high-level encryption layer using AES-CBC. If no key has been provided
@@ -70,9 +69,7 @@ class Crypto implements ICrypto {
 			$password = $this->config->getSystemValue('secret');
 		}
 
-		$hash = new Hash('sha512');
-		$hash->setKey($password);
-		return $hash->hash($message);
+		return hash_hmac('sha512', $message, $password, true);
 	}
 
 	/**

--- a/lib/private/Security/Crypto.php
+++ b/lib/private/Security/Crypto.php
@@ -70,9 +70,6 @@ class Crypto implements ICrypto {
 			$password = $this->config->getSystemValue('secret');
 		}
 
-		// Append an "a" behind the password and hash it to prevent reusing the same password as for encryption
-		$password = hash('sha512', $password . 'a');
-
 		$hash = new Hash('sha512');
 		$hash->setKey($password);
 		return $hash->hash($message);

--- a/lib/private/Security/Crypto.php
+++ b/lib/private/Security/Crypto.php
@@ -31,7 +31,6 @@ namespace OC\Security;
 
 use OCP\IConfig;
 use OCP\Security\ICrypto;
-use OCP\Security\ISecureRandom;
 use phpseclib\Crypt\AES;
 use phpseclib\Crypt\Hash;
 
@@ -55,7 +54,6 @@ class Crypto implements ICrypto {
 
 	/**
 	 * @param IConfig $config
-	 * @param ISecureRandom $random
 	 */
 	public function __construct(IConfig $config) {
 		$this->cipher = new AES();

--- a/lib/private/Security/Crypto.php
+++ b/lib/private/Security/Crypto.php
@@ -102,7 +102,7 @@ class Crypto implements ICrypto {
 		$iv = bin2hex($iv);
 		$hmac = bin2hex($this->calculateHMAC($ciphertext.$iv, substr($keyMaterial, 32)));
 
-		return $ciphertext.'|'.$iv.'|'.$hmac.'|2';
+		return $ciphertext.'|'.$iv.'|'.$hmac.'|3';
 	}
 
 	/**
@@ -131,7 +131,7 @@ class Crypto implements ICrypto {
 
 		if ($partCount === 4) {
 			$version = $parts[3];
-			if ($version === '2') {
+			if ($version >= '2') {
 				$iv = hex2bin($iv);
 			}
 		}

--- a/lib/private/Security/Crypto.php
+++ b/lib/private/Security/Crypto.php
@@ -90,14 +90,17 @@ class Crypto implements ICrypto {
 		if ($password === '') {
 			$password = $this->config->getSystemValue('secret');
 		}
-		$this->cipher->setPassword($password);
+		
+		$keyMaterial = hash_hkdf('sha512', $password);
+		
+		$this->cipher->setPassword(substr($keyMaterial, 0, 32));
 
 		$iv = \random_bytes($this->ivLength);
 		$this->cipher->setIV($iv);
 
 		$ciphertext = bin2hex($this->cipher->encrypt($plaintext));
 		$iv = bin2hex($iv);
-		$hmac = bin2hex($this->calculateHMAC($ciphertext.$iv, $password));
+		$hmac = bin2hex($this->calculateHMAC($ciphertext.$iv, substr($keyMaterial, 32)));
 
 		return $ciphertext.'|'.$iv.'|'.$hmac.'|2';
 	}


### PR DESCRIPTION
First off, this will properly split a single symmetric key into multiple, to increase the complexity of the relationship between the encryption & MAC key.

I removed unnecessary code (resulting in less dependencies, increasing simplicity), and documentation.

This Pull request is not ready to be merged, due to the fact I have not implemented unit tests nor I have I signed my work. I'm requesting review of this draft, prior to submitting the PR that should be accepted.

With that said, how should we go about the unit tests?