### PR TITLE
Add psalm types for the migration schema closure

### DIFF
--- a/lib/public/Migration/IMigrationStep.php
+++ b/lib/public/Migration/IMigrationStep.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2017 Joas Schilling <coding@schilljs.com>
  *
@@ -49,6 +52,7 @@ interface IMigrationStep {
 	/**
 	 * @param IOutput $output
 	 * @param \Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @psalm-param Closure():ISchemaWrapper $schemaClosure
 	 * @param array $options
 	 * @since 13.0.0
 	 */
@@ -57,6 +61,7 @@ interface IMigrationStep {
 	/**
 	 * @param IOutput $output
 	 * @param \Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @psalm-param Closure():ISchemaWrapper $schemaClosure
 	 * @param array $options
 	 * @return null|ISchemaWrapper
 	 * @since 13.0.0
@@ -66,6 +71,7 @@ interface IMigrationStep {
 	/**
 	 * @param IOutput $output
 	 * @param \Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @psalm-param Closure():ISchemaWrapper $schemaClosure
 	 * @param array $options
 	 * @since 13.0.0
 	 */

--- a/lib/public/Migration/SimpleMigrationStep.php
+++ b/lib/public/Migration/SimpleMigrationStep.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2017 Joas Schilling <coding@schilljs.com>
  *
@@ -25,8 +28,6 @@
 
 namespace OCP\Migration;
 
-use OCP\DB\ISchemaWrapper;
-
 /**
  * @since 13.0.0
  */
@@ -52,19 +53,16 @@ abstract class SimpleMigrationStep implements IMigrationStep {
 	}
 
 	/**
-	 * @param IOutput $output
-	 * @param \Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
-	 * @param array $options
+	 * {@inheritDoc}
+	 *
 	 * @since 13.0.0
 	 */
 	public function preSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 	}
 
 	/**
-	 * @param IOutput $output
-	 * @param \Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
-	 * @param array $options
-	 * @return null|ISchemaWrapper
+	 * {@inheritDoc}
+	 *
 	 * @since 13.0.0
 	 */
 	public function changeSchema(IOutput $output, \Closure $schemaClosure, array $options) {
@@ -72,9 +70,8 @@ abstract class SimpleMigrationStep implements IMigrationStep {
 	}
 
 	/**
-	 * @param IOutput $output
-	 * @param \Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
-	 * @param array $options
+	 * {@inheritDoc}
+	 *
 	 * @since 13.0.0
 	 */
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {


### PR DESCRIPTION
This means at least for static analysis we won't need the manual doc comment anymore. Phpstorm does not read psalm annotations yet but as far as I'm concerned this is coming soonish.