### PR TITLE
Fix #17302: Add param to use grid view as default for share

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -399,7 +399,7 @@ class ShareController extends AuthPublicShareController {
 			$folder->assign('hideFileList', $hideFileList);
 			$folder->assign('publicUploadEnabled', 'no');
 			// default to list view
-			$folder->assign('showgridview', false);
+			$folder->assign('showgridview', ((bool) $_GET['show_grid']));
 			$folder->assign('uploadMaxFilesize', $maxUploadFilesize);
 			$folder->assign('uploadMaxHumanFilesize', \OCP\Util::humanFileSize($maxUploadFilesize));
 			$folder->assign('freeSpace', $freeSpace);


### PR DESCRIPTION
To allow sharing image galleries via links and restore at least a minimal set of the features that the gallery app used to have, this allows to set the default view to grid on a shared link.

Just append `?show_grid=1` to the URL and the grid view will be used by default.

This will only work for shared links.