### PR TITLE
Clear cached app config while waiting for the SCSSCache lock to return

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -344,4 +344,14 @@ class AppConfig implements IAppConfig {
 
 		$this->configLoaded = true;
 	}
+
+	/**
+	 * Clear all the cached app config values
+	 *
+	 * WARNING: do not use this - this is only for usage with the SCSSCacher to
+	 * clear the memory cache of the app config
+	 */
+	public function clearCachedConfig() {
+		$this->configLoaded = false;
+	}
 }

--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -30,6 +30,7 @@
 
 namespace OC\Template;
 
+use OC\AppConfig;
 use OC\Files\AppData\Factory;
 use OC\Memcache\NullCache;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -89,6 +90,8 @@ class SCSSCacher {
 
 	/** @var IMemcache */
 	private $lockingCache;
+	/** @var AppConfig */
+	private $appConfig;
 
 	/**
 	 * @param ILogger $logger
@@ -109,7 +112,8 @@ class SCSSCacher {
 								$serverRoot,
 								ICacheFactory $cacheFactory,
 								IconsCacher $iconsCacher,
-								ITimeFactory $timeFactory) {
+								ITimeFactory $timeFactory,
+								AppConfig $appConfig) {
 		$this->logger = $logger;
 		$this->appData = $appDataFactory->get('css');
 		$this->urlGenerator = $urlGenerator;
@@ -126,6 +130,7 @@ class SCSSCacher {
 		$this->lockingCache = $lockingCache;
 		$this->iconsCacher = $iconsCacher;
 		$this->timeFactory = $timeFactory;
+		$this->appConfig = $appConfig;
 	}
 
 	/**
@@ -166,6 +171,7 @@ class SCSSCacher {
 			$retry = 0;
 			sleep(1);
 			while ($retry < 10) {
+				$this->appConfig->clearCachedConfig();
 				$this->logger->debug('SCSSCacher::process check in while loop follows', ['app' => 'scss_cacher']);
 				if (!$this->variablesChanged() && $this->isCached($fileNameCSS, $app)) {
 					// Inject icons vars css if any

--- a/tests/lib/Template/CSSResourceLocatorTest.php
+++ b/tests/lib/Template/CSSResourceLocatorTest.php
@@ -23,6 +23,7 @@
 
 namespace Test\Template;
 
+use OC\AppConfig;
 use OC\Files\AppData\AppData;
 use OC\Files\AppData\Factory;
 use OC\Template\CSSResourceLocator;
@@ -53,6 +54,8 @@ class CSSResourceLocatorTest extends \Test\TestCase {
 	protected $iconsCacher;
 	/** @var ITimeFactory|\PHPUnit\Framework\MockObject\MockObject */
 	private $timeFactory;
+	/** @var AppConfig|\PHPUnit\Framework\MockObject\MockObject */
+	private $appConfig;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -65,6 +68,7 @@ class CSSResourceLocatorTest extends \Test\TestCase {
 		$this->themingDefaults = $this->createMock(ThemingDefaults::class);
 		$this->iconsCacher = $this->createMock(IconsCacher::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->appConfig = $this->createMock(AppConfig::class);
 	}
 
 	private function cssResourceLocator() {
@@ -80,7 +84,8 @@ class CSSResourceLocatorTest extends \Test\TestCase {
 			\OC::$SERVERROOT,
 			$this->cacheFactory,
 			$this->iconsCacher,
-			$this->timeFactory
+			$this->timeFactory,
+			$this->appConfig
 		);
 		return new CSSResourceLocator(
 			$this->logger,

--- a/tests/lib/Template/SCSSCacherTest.php
+++ b/tests/lib/Template/SCSSCacherTest.php
@@ -23,6 +23,7 @@
 
 namespace Test\Template;
 
+use OC\AppConfig;
 use OC\Files\AppData\AppData;
 use OC\Files\AppData\Factory;
 use OC\Template\IconsCacher;
@@ -60,6 +61,8 @@ class SCSSCacherTest extends \Test\TestCase {
 	protected $iconsCacher;
 	/** @var ITimeFactory|\PHPUnit\Framework\MockObject\MockObject */
 	protected $timeFactory;
+	/** @var AppConfig|\PHPUnit\Framework\MockObject\MockObject */
+	protected $appConfig;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -92,6 +95,8 @@ class SCSSCacherTest extends \Test\TestCase {
 			->method('getCachedCSS')
 			->willReturn($iconsFile);
 
+		$this->appConfig = $this->createMock(AppConfig::class);
+
 		$this->scssCacher = new SCSSCacher(
 			$this->logger,
 			$factory,
@@ -101,7 +106,8 @@ class SCSSCacherTest extends \Test\TestCase {
 			\OC::$SERVERROOT,
 			$this->cacheFactory,
 			$this->iconsCacher,
-			$this->timeFactory
+			$this->timeFactory,
+			$this->appConfig
 		);
 	}
 


### PR DESCRIPTION
This should fix the issue described in https://github.com/nextcloud/server/pull/15794#issuecomment-631573831 and shown by @kesselb in https://github.com/nextcloud/server/pull/21059#issuecomment-633231413

If this is not cleared then the while loop in https://github.com/nextcloud/server/blob/4fd9fa0258b36bbf47b50c3c600a0c9fef7412bf/lib/private/Template/SCSSCacher.php#L167 will never evaluate to true and thus is the same as before the lock got released.

Part of the series around the SCSSCache: #23488 #23490