### PR TITLE
Add psalm types for the event dispatcher

### DIFF
--- a/lib/private/Authentication/Listeners/LoginFailedListener.php
+++ b/lib/private/Authentication/Listeners/LoginFailedListener.php
@@ -35,6 +35,9 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\IUserManager;
 use OCP\Util;
 
+/**
+ * @template-implements IEventListener<\OC\Authentication\Events\LoginFailed>
+ */
 class LoginFailedListener implements IEventListener {
 
 	/** @var IEventDispatcher */

--- a/lib/private/Authentication/Listeners/RemoteWipeActivityListener.php
+++ b/lib/private/Authentication/Listeners/RemoteWipeActivityListener.php
@@ -35,6 +35,9 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @template-implements IEventListener<\OC\Authentication\Events\ARemoteWipeEvent>
+ */
 class RemoteWipeActivityListener implements IEventListener {
 
 	/** @var IActvityManager */

--- a/lib/private/Authentication/Listeners/RemoteWipeEmailListener.php
+++ b/lib/private/Authentication/Listeners/RemoteWipeEmailListener.php
@@ -40,6 +40,9 @@ use OCP\Mail\IMessage;
 use Psr\Log\LoggerInterface;
 use function substr;
 
+/**
+ * @template-implements IEventListener<\OC\Authentication\Events\ARemoteWipeEvent>
+ */
 class RemoteWipeEmailListener implements IEventListener {
 
 	/** @var IMailer */

--- a/lib/private/Authentication/Listeners/RemoteWipeNotificationsListener.php
+++ b/lib/private/Authentication/Listeners/RemoteWipeNotificationsListener.php
@@ -35,6 +35,9 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Notification\IManager as INotificationManager;
 
+/**
+ * @template-implements IEventListener<\OC\Authentication\Events\ARemoteWipeEvent>
+ */
 class RemoteWipeNotificationsListener implements IEventListener {
 
 	/** @var INotificationManager */

--- a/lib/private/Authentication/Listeners/UserDeletedStoreCleanupListener.php
+++ b/lib/private/Authentication/Listeners/UserDeletedStoreCleanupListener.php
@@ -31,6 +31,9 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\User\Events\UserDeletedEvent;
 
+/**
+ * @template-implements IEventListener<\OCP\User\Events\UserDeletedEvent>
+ */
 class UserDeletedStoreCleanupListener implements IEventListener {
 
 	/** @var Registry */

--- a/lib/private/Authentication/Listeners/UserDeletedTokenCleanupListener.php
+++ b/lib/private/Authentication/Listeners/UserDeletedTokenCleanupListener.php
@@ -33,6 +33,9 @@ use OCP\User\Events\UserDeletedEvent;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
+/**
+ * @template-implements IEventListener<\OCP\User\Events\UserDeletedEvent>
+ */
 class UserDeletedTokenCleanupListener implements IEventListener {
 
 	/** @var Manager */

--- a/lib/private/Authentication/Listeners/UserLoggedInListener.php
+++ b/lib/private/Authentication/Listeners/UserLoggedInListener.php
@@ -31,6 +31,9 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\User\Events\PostLoginEvent;
 
+/**
+ * @template-implements IEventListener<\OCP\User\Events\PostLoginEvent>
+ */
 class UserLoggedInListener implements IEventListener {
 
 	/** @var Manager */

--- a/lib/public/AppFramework/Bootstrap/IRegistrationContext.php
+++ b/lib/public/AppFramework/Bootstrap/IRegistrationContext.php
@@ -113,10 +113,11 @@ interface IRegistrationContext {
 	 *
 	 * This is equivalent to calling IEventDispatcher::addServiceListener
 	 *
+	 * @template T of \OCP\EventDispatcher\Event
 	 * @param string $event preferably the fully-qualified class name of the Event sub class to listen for
-	 * @psalm-param string|class-string<\OCP\EventDispatcher\Event> $event preferably the fully-qualified class name of the Event sub class to listen for
+	 * @psalm-param string|class-string<T> $event preferably the fully-qualified class name of the Event sub class to listen for
 	 * @param string $listener fully qualified class name (or ::class notation) of a \OCP\EventDispatcher\IEventListener that can be built by the DI container
-	 * @psalm-param class-string<\OCP\EventDispatcher\IEventListener> $listener fully qualified class name that can be built by the DI container
+	 * @psalm-param class-string<\OCP\EventDispatcher\IEventListener<T>> $listener fully qualified class name that can be built by the DI container
 	 * @param int $priority
 	 *
 	 * @see IEventDispatcher::addServiceListener()

--- a/lib/public/EventDispatcher/IEventDispatcher.php
+++ b/lib/public/EventDispatcher/IEventDispatcher.php
@@ -35,7 +35,9 @@ namespace OCP\EventDispatcher;
 interface IEventDispatcher {
 
 	/**
+	 * @template T of \OCP\EventDispatcher\Event
 	 * @param string $eventName preferably the fully-qualified class name of the Event sub class
+	 * @psalm-param string|class-string<T> $eventName preferably the fully-qualified class name of the Event sub class
 	 * @param callable $listener the object that is invoked when a matching event is dispatched
 	 * @param int $priority
 	 *
@@ -44,7 +46,9 @@ interface IEventDispatcher {
 	public function addListener(string $eventName, callable $listener, int $priority = 0): void;
 
 	/**
+	 * @template T of \OCP\EventDispatcher\Event
 	 * @param string $eventName preferably the fully-qualified class name of the Event sub class
+	 * @psalm-param string|class-string<T> $eventName preferably the fully-qualified class name of the Event sub class
 	 * @param callable $listener the object that is invoked when a matching event is dispatched
 	 *
 	 * @since 19.0.0
@@ -52,8 +56,11 @@ interface IEventDispatcher {
 	public function removeListener(string $eventName, callable $listener): void;
 
 	/**
+	 * @template T of \OCP\EventDispatcher\Event
 	 * @param string $eventName preferably the fully-qualified class name of the Event sub class to listen for
+	 * @psalm-param string|class-string<T> $eventName preferably the fully-qualified class name of the Event sub class to listen for
 	 * @param string $className fully qualified class name (or ::class notation) of a \OCP\EventDispatcher\IEventListener that can be built by the DI container
+	 * @psalm-param class-string<\OCP\EventDispatcher\IEventListener<T>> $className fully qualified class name that can be built by the DI container
 	 * @param int $priority
 	 *
 	 * @since 17.0.0
@@ -61,8 +68,11 @@ interface IEventDispatcher {
 	public function addServiceListener(string $eventName, string $className, int $priority = 0): void;
 
 	/**
+	 * @template T of \OCP\EventDispatcher\Event
 	 * @param string $eventName
+	 * @psalm-param string|class-string<T> $eventName
 	 * @param Event $event
+	 * @psalm-param T $event
 	 *
 	 * @since 17.0.0
 	 */

--- a/lib/public/EventDispatcher/IEventListener.php
+++ b/lib/public/EventDispatcher/IEventListener.php
@@ -28,11 +28,14 @@ namespace OCP\EventDispatcher;
 
 /**
  * @since 17.0.0
+ *
+ * @template T of Event
  */
 interface IEventListener {
 
 	/**
 	 * @param Event $event
+	 * @psalm-param T $event
 	 *
 	 * @since 17.0.0
 	 */


### PR DESCRIPTION
This is almost perfect. This should detect a lot of things

* Registering events that don't exist
* Registering listeners that don't exist
* Listeners of the wrong event (if template param is specific on the class)

What it doesn't check right now is if the correct event is wired to a listener. Psalm doesn't enforce this right now, but I reported it upstream: https://github.com/vimeo/psalm/issues/4339.

Tested with Mail and that worked nicely. Let's see how CI does here :bomb:.