### PR TITLE
SCSSCacher - Lock should not be removed

### DIFF
--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -169,7 +169,6 @@ class SCSSCacher {
 				$this->logger->debug('SCSSCacher::process check in while loop follows', ['app' => 'scss_cacher']);
 				if (!$this->variablesChanged() && $this->isCached($fileNameCSS, $app)) {
 					// Inject icons vars css if any
-					$this->lockingCache->remove($lockKey);
 					$this->logger->debug("SCSSCacher::process cached file for app '$app' and file '$fileNameCSS' is now available after $retry s. Moving on...", ['app' => 'scss_cacher']);
 					return $this->injectCssVariablesIfAny();
 				}


### PR DESCRIPTION
This is within the failed lock acquiring branch. So the lock is free by another process and should not be removed because the cached file (that was created by the process having the lock) appeared on the filesystem.



This is part of multiple PRs. I just split them into their smallest independent parts. Other parts: #23478 #23490
