### PR TITLE
Reverted commit 54a5f938f99 because of Bug #23174

### DIFF
--- a/apps/workflowengine/lib/Migration/Version2000Date20190808074233.php
+++ b/apps/workflowengine/lib/Migration/Version2000Date20190808074233.php
@@ -114,7 +114,7 @@ class Version2000Date20190808074233 extends SimpleMigrationStep {
 	protected function ensureEntityColumns(Table $table) {
 		if(!$table->hasColumn('entity')) {
 			$table->addColumn('entity', Type::STRING, [
-				'notnull' => true,
+				'notnull' => false,
 				'length' => 256,
 				'default' => '',
 			]);


### PR DESCRIPTION
Reverted commit 54a5f938f99 from @nickvergessen to fix bug #23174 which breaks upgrades to 18.0.10.

Maybe it would be better to fix the migration of oc_flow_operations instead, but I'm not familiar with this part of the code.

fix https://github.com/nextcloud/server/issues/23174