### PR TITLE
fixes potential passing of null to getUserGroupIds

### DIFF
--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -881,7 +881,7 @@ class DefaultShareProvider implements IShareProvider {
 			$cursor->closeCursor();
 		} elseif ($shareType === IShare::TYPE_GROUP) {
 			$user = $this->userManager->get($userId);
-			$allGroups = $this->groupManager->getUserGroupIds($user);
+			$allGroups = ($user instanceof IUser) ? $this->groupManager->getUserGroupIds($user) : [];
 
 			/** @var Share[] $shares2 */
 			$shares2 = [];


### PR DESCRIPTION
fixes #23355

the issue was introduced with https://github.com/nextcloud/server/commit/756fe45493fd3b82284abcedc51528542edc43bf. The method of the group manager previously used was able to deal with a passed null, but `getUserGroupIds` asks for IUser specifically.