### PR TITLE
manifest to report correct favicon size

### DIFF
--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -383,7 +383,7 @@ class ThemingController extends Controller {
 						'src' => $this->urlGenerator->linkToRoute('theming.Icon.getTouchIcon',
 								['app' => $app]) . '?v=' . $cacheBusterValue,
 						'type' => 'image/png',
-						'sizes' => '128x128'
+						'sizes' => '512x512'
 					],
 					[
 						'src' => $this->urlGenerator->linkToRoute('theming.Icon.getFavicon',


### PR DESCRIPTION
In the environment where php-imagick with SVG support is correctly installed, this endpoint returns 512x512 image.
https://github.com/nextcloud/server/blob/d9015a8c94bfd71fe484618a06d276701d3bf9ff/apps/theming/lib/Controller/IconController.php#L146

Another problem here is in the environment without php-imagick or without SVG support, this will fall back to original, whose default is 128x128; but I thought this is a separate problem. (For this, default image may be enlarged. Should I create another issue if this is important one?)