### PR TITLE
LDAP: when nesting is not enabled, the group filter can be applied right away

### DIFF
--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -145,11 +145,7 @@ class Connection extends LDAPUtility {
 		$this->dontDestruct = true;
 	}
 
-	/**
-	 * @param string $name
-	 * @return bool|mixed
-	 */
-	public function __get($name) {
+	public function __get(string $name) {
 		if (!$this->configured) {
 			$this->readConfiguration();
 		}

--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -344,7 +344,7 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 		}
 
 		$seen = [];
-		while ($record = array_pop($list)) {
+		while ($record = array_shift($list)) {
 			$recordDN = $recordMode ? $record['dn'][0] : $record;
 			if ($recordDN === $dn || array_key_exists($recordDN, $seen)) {
 				// Prevent loops
@@ -820,6 +820,11 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 		if ($this->ldapGroupMemberAssocAttr === 'zimbramailforwardingaddress') {
 			//in this case the member entries are email addresses
 			$filter .= '@*';
+		}
+
+		$nesting = (int)$this->access->connection->ldapNestedGroups;
+		if ($nesting === 0) {
+			$filter = $this->access->combineFilterWithAnd([$filter, $this->access->connection->ldapGroupFilter]);
 		}
 
 		$groups = $this->access->fetchListOfGroups($filter,


### PR DESCRIPTION
When fetcher user groups, we may take groups into account that do not match the filter. This is necessary when using nesting and have intermediate groups, which members still ought to be pulled in. When nesting is not enabled, though, we can save the overhead.

- helps performance, but skipping unnecessary entries
- reduces reoccuring info-level log output against groups that do not
  qualify ("no or empty name")

