### PR TITLE
Implement new user back end API

### DIFF
--- a/lib/private/User/Backend.php
+++ b/lib/private/User/Backend.php
@@ -29,6 +29,7 @@ use OCP\UserInterface;
 /**
  * Abstract base class for user management. Provides methods for querying backend
  * capabilities.
+ * @deprecated 21.0.0 use \OCP\Public\User\Backend\AbstractUserBackEnd instead
  */
 abstract class Backend implements UserInterface {
 	/**

--- a/lib/public/IUserBackend.php
+++ b/lib/public/IUserBackend.php
@@ -36,6 +36,7 @@ namespace OCP;
  * Interface IUserBackend
  *
  * @since 8.0.0
+ * @deprecated 21.0.0 use \OCP\Public\User\Backend\AbstractUserBackEnd instead
  */
 interface IUserBackend {
 
@@ -43,6 +44,7 @@ interface IUserBackend {
 	 * Backend name to be shown in user management
 	 * @return string the name of the backend to be shown
 	 * @since 8.0.0
+	 * @deprecated 21.0.0 use \OCP\Public\User\Backend\IUserBackEnd instead
 	 */
 	public function getBackendName();
 }

--- a/lib/public/User/Backend/ABackend.php
+++ b/lib/public/User/Backend/ABackend.php
@@ -33,6 +33,7 @@ use OCP\UserInterface;
 
 /**
  * @since 14.0.0
+ * @deprecated 21.0.0 use \OCP\Public\User\Backend\AbstractUserBackEnd instead
  */
 abstract class ABackend implements IUserBackend, UserInterface {
 

--- a/lib/public/User/Backend/AbstractUserBackend.php
+++ b/lib/public/User/Backend/AbstractUserBackend.php
@@ -3,9 +3,7 @@
 declare(strict_types=1);
 
 /**
- * @copyright Copyright (c) 2018 Roeland Jago Douma <roeland@famdouma.nl>
- *
- * @author Roeland Jago Douma <roeland@famdouma.nl>
+ * @copyright Copyright (c) 2020, Alexey Abel <dev@abelonline.de>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -20,24 +18,29 @@ declare(strict_types=1);
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
 
 namespace OCP\User\Backend;
 
 /**
- * @since 14.0.0
- * @deprecated  21.0.0
+ * Class AbstractUserBackend should be used as a base for all user back ends, e.g. implemented by apps.
+ * Additionally implement any number of interfaces in OCP\User\Backend\Action.
+ *
+ * @package OCP\User\Backend
+ * @since 21.0.0
  */
-interface IGetHomeBackend {
+class AbstractUserBackend {
 
-	/**
-	 * @since 14.0.0
-	 * @deprecated 21.0.0
-	 *
-	 * @param string $uid the username
-	 * @return string|bool Datadir on success false on failure
-	 */
-	public function getHome(string $uid);
+	/** @var string */
+	private $backEndName;
+
+	public function __construct(string $backEndName) {
+		$this->backEndName = $backEndName;
+	}
+
+	public function getName(): string {
+		return $this->backEndName;
+	}
 }

--- a/lib/public/User/Backend/Action/ICheckPassword.php
+++ b/lib/public/User/Backend/Action/ICheckPassword.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Alexey Abel <dev@abelonline.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend\Action;
+
+use OCP\User\Backend\Exception\ActionNotAvailableException;
+use OCP\User\Backend\Exception\UserDoesNotExistInBackEndException;
+
+
+/**
+ * @since 21.0.0
+ */
+interface ICheckPassword {
+	/**
+	 * @return bool whether the implementing user back end has the ability to check a password at this time
+	 * or with the current configuration
+	 */
+	public function canCheckPassword() : bool;
+
+	/**
+	 * Returns whether the supplied password is correct for the supplied user.
+	 *
+	 * Before using this method, you must call `can...Currently()` of this interface to ensure that the user
+	 * backend can perform this action at his time or with the current configuration, since this can change
+	 * during runtime. The implementing user back end will throw an ActionNotAvailableException if it doesn't.
+	 *
+	 * @param string $username the username of the checked user
+	 * @param string $password the password of the user to check
+	 * @return bool true if password is correct, false otherwise
+	 * @throws ActionNotAvailableException if this action is not supported at this time
+	 * @throws UserDoesNotExistInBackEndException if specified username doesn't exist in the user back end
+	 */
+	public function checkPassword(string $username, string $password): bool;
+}

--- a/lib/public/User/Backend/Action/ICountUsers.php
+++ b/lib/public/User/Backend/Action/ICountUsers.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Alexey Abel <dev@abelonline.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend\Action;
+
+use OCP\User\Backend\Exception\ActionNotAvailableException;
+
+
+/**
+ * @since 21.0.0
+ */
+interface ICountUsers {
+	/**
+	 * @return bool whether the implementing user back end has the ability to count users at this time
+	 * or with the current configuration
+	 */
+	public function canCountUsers() : bool;
+
+	/**
+	 * Returns the number of users present in this user backend.
+	 *
+	 * Before using this method, you must call `can...Currently()` of this interface to ensure that the user
+	 * backend can perform this action at his time or with the current configuration, since this can change
+	 * during runtime. The implementing user back end will throw an ActionNotAvailableException if it doesn't.
+	 *
+	 * @return int the number of users present in this user backend
+	 * @throws ActionNotAvailableException if this action is not supported at this time
+	 */
+	public function countUsers(): int;
+}

--- a/lib/public/User/Backend/Action/ICreateUser.php
+++ b/lib/public/User/Backend/Action/ICreateUser.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Alexey Abel <dev@abelonline.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend\Action;
+
+use OCP\User\Backend\Exception\ActionNotAvailableException;
+use OCP\User\Backend\Exception\UserAlreadyExistsException;
+
+
+/**
+ * @since 21.0.0
+ */
+interface ICreateUser {
+	/**
+	 * @return bool whether the implementing user back end has the ability to create a user at this time
+	 * or with the current configuration
+	 */
+	public function canCreateUser(): bool;
+
+	/**
+	 * Creates a new user.
+	 *
+	 * Before using this method, you must call `can...Currently()` of this interface to ensure that the user
+	 * backend can perform this action at his time or with the current configuration, since this can change
+	 * during runtime. The implementing user back end will throw an ActionNotAvailableException if it doesn't.
+	 *
+	 * @param string $username the username of the new user
+	 * @param string $password the password of the new user
+	 * @throws ActionNotAvailableException if this action is not supported at this time
+	 * @throws UserAlreadyExistsException if a user with provided username already exists
+	 */
+	public function createUser(string $username, string $password): void;
+}

--- a/lib/public/User/Backend/Action/IDeleteUser.php
+++ b/lib/public/User/Backend/Action/IDeleteUser.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Alexey Abel <dev@abelonline.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend\Action;
+
+use OCP\User\Backend\Exception\ActionNotAvailableException;
+use OCP\User\Backend\Exception\UserDoesNotExistInBackEndException;
+
+
+/**
+ * @since 21.0.0
+ */
+interface IDeleteUser {
+	/**
+	 * @return bool whether the implementing user back end has the ability to create a user at this time
+	 * or with the current configuration
+	 */
+	public function canDeleteUser() : bool;
+
+	/**
+	 * Deletes a user.
+	 *
+	 * Before using this method, you must call `can...Currently()` of this interface to ensure that the user
+	 * backend can perform this action at his time or with the current configuration, since this can change
+	 * during runtime. The implementing user back end will throw an ActionNotAvailableException if it doesn't.
+	 *
+	 * @param string $username the username of the user to be deleted
+	 * @throws ActionNotAvailableException if this action is not supported at this time
+	 * @throws UserDoesNotExistInBackEndException if specified username doesn't exist in the user back end
+	 */
+	public function deleteUser(string $username): void;
+}

--- a/lib/public/User/Backend/Action/IFindUsersByDisplayName.php
+++ b/lib/public/User/Backend/Action/IFindUsersByDisplayName.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Alexey Abel <dev@abelonline.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend\Action;
+
+use OCP\User\Backend\Exception\ActionNotAvailableException;
+
+
+/**
+ * @since 21.0.0
+ */
+interface IFindUsersByDisplayName {
+	/**
+	 * @return bool whether the implementing user back end has the ability to search users at this time
+	 * or with the current configuration
+	 */
+	public function canFindUsersByDisplayName() : bool;
+
+	/**
+	 * Finds users by display name and returns a list of matched users.
+	 *
+	 * Before using this method, you must call `can...Currently()` of this interface to ensure that the user
+	 * backend can perform this action at his time or with the current configuration, since this can change
+	 * during runtime. The implementing user back end will throw an ActionNotAvailableException if it doesn't.
+	 *
+	 * @param string $pattern the search pattern
+	 * @param int $limit limit the returned users to only this many
+	 * @param int $offset start the returned users at this position, 0-based
+	 * @return iterable list of users that matched the pattern or empty iterable if none matched
+	 * @throws ActionNotAvailableException if this action is not supported at this time
+	 */
+	public function findUsersByDisplayName(string $pattern, ?int $limit, ?int $offset): iterable;
+}

--- a/lib/public/User/Backend/Action/IFindUsersByUsername.php
+++ b/lib/public/User/Backend/Action/IFindUsersByUsername.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Alexey Abel <dev@abelonline.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend\Action;
+
+use OCP\User\Backend\Exception\ActionNotAvailableException;
+
+
+/**
+ * @since 21.0.0
+ */
+interface IFindUsersByUsername {
+	/**
+	 * @return bool whether the implementing user back end has the ability to search users at this time
+	 * or with the current configuration
+	 */
+	public function canFindUsersByUsername() : bool;
+
+	/**
+	 * Finds users by username and returns a list of matched users.
+	 *
+	 * Before using this method, you must call `can...Currently()` of this interface to ensure that the user
+	 * backend can perform this action at his time or with the current configuration, since this can change
+	 * during runtime. The implementing user back end will throw an ActionNotAvailableException if it doesn't.
+	 *
+	 * @param string $pattern the search pattern
+	 * @param int $limit limit the returned users to only this many
+	 * @param int $offset start the returned users at this position, 0-based
+	 * @return iterable list of users that matched the pattern or empty iterable if none matched
+	 * @throws ActionNotAvailableException if this action is not supported at this time
+	 */
+	public function findUsersByUsername(string $pattern, ?int $limit, ?int $offset): iterable;
+}

--- a/lib/public/User/Backend/Action/IGetDisplayName.php
+++ b/lib/public/User/Backend/Action/IGetDisplayName.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Alexey Abel <dev@abelonline.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend\Action;
+
+use OCP\User\Backend\Exception\ActionNotAvailableException;
+use OCP\User\Backend\Exception\UserDoesNotExistInBackEndException;
+
+
+/**
+ * @since 21.0.0
+ */
+interface IGetDisplayName {
+	/**
+	 * @return bool whether the implementing user back end has the ability to get a display name at this time
+	 * or with the current configuration
+	 */
+	public function canGetDisplayName() : bool;
+
+	/**
+	 * Gets the display name for a user.
+	 *
+	 * Before using this method, you must call `can...Currently()` of this interface to ensure that the user
+	 * backend can perform this action at his time or with the current configuration, since this can change
+	 * during runtime. The implementing user back end will throw an ActionNotAvailableException if it doesn't.
+	 *
+	 * @param string $username the username to get the display name for
+	 * @return string the display name of the user
+	 * @throws ActionNotAvailableException if this action is not supported at this time
+	 * @throws UserDoesNotExistInBackEndException if specified username doesn't exist in the user back end
+	 */
+	public function getDisplayName(string $username): string;
+}

--- a/lib/public/User/Backend/Action/IGetEMail.php
+++ b/lib/public/User/Backend/Action/IGetEMail.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Alexey Abel <dev@abelonline.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend\Action;
+
+use OCP\User\Backend\Exception\ActionNotAvailableException;
+use OCP\User\Backend\Exception\UserDoesNotExistInBackEndException;
+
+
+/**
+ * @since 21.0.0
+ */
+interface IGetEMail {
+	/**
+	 * @return bool whether the implementing user back end has the ability to get a e-mail at this time
+	 * or with the current configuration
+	 */
+	public function canGetEMail() : bool;
+
+	/**
+	 * Gets the e-mail address for a user.
+	 *
+	 * Before using this method, you must call `can...Currently()` of this interface to ensure that the user
+	 * backend can perform this action at his time or with the current configuration, since this can change
+	 * during runtime. The implementing user back end will throw an ActionNotAvailableException if it doesn't.
+	 *
+	 * @param string $username the username to get the e-mail for
+	 * @return string the e-mail of the user
+	 * @throws ActionNotAvailableException if this action is not supported at this time
+	 * @throws UserDoesNotExistInBackEndException if specified username doesn't exist in the user back end
+	 */
+	public function getEMail(string $username): string;
+}

--- a/lib/public/User/Backend/Action/IGetHome.php
+++ b/lib/public/User/Backend/Action/IGetHome.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Alexey Abel <dev@abelonline.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend\Action;
+
+use OCP\User\Backend\Exception\ActionNotAvailableException;
+use OCP\User\Backend\Exception\UserDoesNotExistInBackEndException;
+
+
+/**
+ * @since 21.0.0
+ */
+interface IGetHome {
+	/**
+	 * @return bool whether the implementing user back end has the ability to get a home folder at this time
+	 * or with the current configuration
+	 */
+	public function canGetHome() : bool;
+
+	/**
+	  * Gets the home folder for a user.
+	 *
+	 * Before using this method, you must call `can...Currently()` of this interface to ensure that the user
+	 * backend can perform this action at his time or with the current configuration, since this can change
+	 * during runtime. The implementing user back end will throw an ActionNotAvailableException if it doesn't.
+	 *
+	 * @param string $username the username to get the home folder for
+	 * @return string the home folder of the user
+	 * @throws ActionNotAvailableException if this action is not supported at this time
+	 * @throws UserDoesNotExistInBackEndException if specified username doesn't exist in the user back end
+	 */
+	public function getHome(string $username): string;
+}

--- a/lib/public/User/Backend/Action/IGetQuota.php
+++ b/lib/public/User/Backend/Action/IGetQuota.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Alexey Abel <dev@abelonline.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend\Action;
+
+use OCP\User\Backend\Exception\ActionNotAvailableException;
+use OCP\User\Backend\Exception\UserDoesNotExistInBackEndException;
+
+
+/**
+ * @since 21.0.0
+ */
+interface IGetQuota {
+	/**
+	 * @return bool whether the implementing user back end has the ability to get a quota at this time
+	 * or with the current configuration
+	 */
+	public function canGetQuota() : bool;
+
+	/**
+	 * Gets the quota for a user.
+	 *
+	 * Before using this method, you must call `can...Currently()` of this interface to ensure that the user
+	 * backend can perform this action at his time or with the current configuration, since this can change
+	 * during runtime. The implementing user back end will throw an ActionNotAvailableException if it doesn't.
+	 *
+	 * @param string $username the username to get the quota for
+	 * @return string the quota of the user
+	 * @throws ActionNotAvailableException if this action is not supported at this time
+	 * @throws UserDoesNotExistInBackEndException if specified username doesn't exist in the user back end
+	 */
+	public function getQuota(string $username): string;
+}

--- a/lib/public/User/Backend/Action/IGetRealUid.php
+++ b/lib/public/User/Backend/Action/IGetRealUid.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Alexey Abel <dev@abelonline.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend\Action;
+
+use OCP\User\Backend\Exception\ActionNotAvailableException;
+use OCP\User\Backend\Exception\UserDoesNotExistInBackEndException;
+
+
+/**
+ * @since 21.0.0
+ */
+interface IGetRealUid {
+	/**
+	 * @return bool whether the implementing user back end has the ability to get the real uid at this time
+	 * or with the current configuration
+	 */
+	public function canGetRealUid() : bool;
+
+	/**
+	 * Some back ends accept different UIDs than what is the internal UID to be used.
+	 * For example the database backend accepts different cased UIDs in all the functions
+	 * but the internal UID that is to be used should be correctly cased.
+	 *
+	 * Before using this method, you must call `can...Currently()` of this interface to ensure that the user
+	 * backend can perform this action at his time or with the current configuration, since this can change
+	 * during runtime. The implementing user back end will throw an ActionNotAvailableException if it doesn't.
+	 *
+	 * @param string $username the username to get the real UID for
+	 * @return string the real UID of the user
+	 * @throws ActionNotAvailableException if this action is not supported at this time
+	 * @throws UserDoesNotExistInBackEndException if specified username doesn't exist in the user back end
+	 */
+	public function getRealUid(string $username): string;
+}

--- a/lib/public/User/Backend/Action/IHasUser.php
+++ b/lib/public/User/Backend/Action/IHasUser.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Alexey Abel <dev@abelonline.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend\Action;
+
+use OCP\User\Backend\Exception\ActionNotAvailableException;
+
+
+/**
+ * @since 21.0.0
+ */
+interface IHasUser {
+	/**
+	 * @return bool whether the implementing user back end has the ability to check whether a user exsits at
+	 * this time or with the current configuration
+	 */
+	public function canHasUser() : bool;
+
+	/**
+	 * Checks whether a user exists in this user back end.
+	 *
+	 * Before using this method, you must call `can...Currently()` of this interface to ensure that the user
+	 * backend can perform this action at his time or with the current configuration, since this can change
+	 * during runtime. The implementing user back end will throw an ActionNotAvailableException if it doesn't.
+	 *
+	 * @param string $username the username whose existence is checked
+	 * @return bool whether the user exists in this user back end
+	 * @throws ActionNotAvailableException if this action is not supported at this time
+	 */
+	public function hasUser(string $username): bool;
+}

--- a/lib/public/User/Backend/Action/ISetDisplayName.php
+++ b/lib/public/User/Backend/Action/ISetDisplayName.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Alexey Abel <dev@abelonline.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend\Action;
+
+use OCP\User\Backend\Exception\ActionNotAvailableException;
+use OCP\User\Backend\Exception\UserDoesNotExistInBackEndException;
+
+
+/**
+ * @since 21.0.0
+ */
+interface ISetDisplayName {
+	/**
+	 * @return bool whether the implementing user back end has the ability to set a display name at this time
+	 * or with the current configuration
+	 */
+	public function canSetDisplayName() : bool;
+
+	/**
+	 * Sets a new display name for a user.
+	 *
+	 * Before using this method, you must call `can...Currently()` of this interface to ensure that the user
+	 * backend can perform this action at his time or with the current configuration, since this can change
+	 * during runtime. The implementing user back end will throw an ActionNotAvailableException if it doesn't.
+	 *
+	 * @param string $username the username to set the display name for
+	 * @param string $newDisplayName the new display name of the user
+	 * @throws ActionNotAvailableException if this action is not supported at this time
+	 * @throws UserDoesNotExistInBackEndException if specified username doesn't exist in the user back end
+	 */
+	public function setDisplayName(string $username, string $newDisplayName): void;
+}

--- a/lib/public/User/Backend/Action/ISetEMail.php
+++ b/lib/public/User/Backend/Action/ISetEMail.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Alexey Abel <dev@abelonline.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend\Action;
+
+use OCP\User\Backend\Exception\ActionNotAvailableException;
+use OCP\User\Backend\Exception\UserDoesNotExistInBackEndException;
+
+
+/**
+ * @since 21.0.0
+ */
+interface ISetEMail {
+	/**
+	 * @return bool whether the implementing user back end has the ability to set a e-mail at this time
+	 * or with the current configuration
+	 */
+	public function canSetEMail() : bool;
+
+	/**
+	 * Sets a new e-mail for a user.
+	 *
+	 * Before using this method, you must call `can...Currently()` of this interface to ensure that the user
+	 * backend can perform this action at his time or with the current configuration, since this can change
+	 * during runtime. The implementing user back end will throw an ActionNotAvailableException if it doesn't.
+	 *
+	 * @param string $username the username to set the e-mail for
+	 * @param string $newEMail the new e-mail of the user
+	 * @throws ActionNotAvailableException if this action is not supported at this time
+	 * @throws UserDoesNotExistInBackEndException if specified username doesn't exist in the user back end
+	 */
+	public function setEMail(string $username, string $newEMail): void;
+}

--- a/lib/public/User/Backend/Action/ISetHome.php
+++ b/lib/public/User/Backend/Action/ISetHome.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Alexey Abel <dev@abelonline.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend\Action;
+
+use OCP\User\Backend\Exception\ActionNotAvailableException;
+use OCP\User\Backend\Exception\UserDoesNotExistInBackEndException;
+
+
+/**
+ * @since 21.0.0
+ */
+interface ISetHome {
+	/**
+	 * @return bool whether the implementing user back end has the ability to set a home folder at this time
+	 * or with the current configuration
+	 */
+	public function canSetHome() : bool;
+
+	/**
+	 * Sets a new home folder for a user.
+	 *
+	 * Before using this method, you must call `can...Currently()` of this interface to ensure that the user
+	 * backend can perform this action at his time or with the current configuration, since this can change
+	 * during runtime. The implementing user back end will throw an ActionNotAvailableException if it doesn't.
+	 *
+	 * @param string $username the username to set the home folder for
+	 * @param string $newHome the new home folder of the user
+	 * @throws ActionNotAvailableException if this action is not supported at this time
+	 * @throws UserDoesNotExistInBackEndException if specified username doesn't exist in the user back end
+	 */
+	public function setHome(string $username, string $newHome): void;
+}

--- a/lib/public/User/Backend/Action/ISetPassword.php
+++ b/lib/public/User/Backend/Action/ISetPassword.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Alexey Abel <dev@abelonline.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend\Action;
+
+use OCP\User\Backend\Exception\ActionNotAvailableException;
+use OCP\User\Backend\Exception\UserDoesNotExistInBackEndException;
+
+
+/**
+ * @since 21.0.0
+ */
+interface ISetPassword {
+	/**
+	 * @return bool whether the implementing user back end has the ability to set a password at this time
+	 * or with the current configuration
+	 */
+	public function canSetPassword() : bool;
+
+	/**
+	 * Sets a new password for a user.
+	 *
+	 * Before using this method, you must call `can...Currently()` of this interface to ensure that the user
+	 * backend can perform this action at his time or with the current configuration, since this can change
+	 * during runtime. The implementing user back end will throw an ActionNotAvailableException if it doesn't.
+	 *
+	 * @param string $username the username to set the password for
+	 * @param string $newPassword the new password of the user
+	 * @throws ActionNotAvailableException if this action is not supported at this time
+	 * @throws UserDoesNotExistInBackEndException if specified username doesn't exist in the user back end
+	 */
+	public function setPassword(string $username, string $newPassword): void;
+}

--- a/lib/public/User/Backend/Action/ISetQuota.php
+++ b/lib/public/User/Backend/Action/ISetQuota.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Alexey Abel <dev@abelonline.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\User\Backend\Action;
+
+use OCP\User\Backend\Exception\ActionNotAvailableException;
+use OCP\User\Backend\Exception\UserDoesNotExistInBackEndException;
+
+
+/**
+ * @since 21.0.0
+ */
+interface ISetQuota {
+	/**
+	 * @return bool whether the implementing user back end has the ability to set a quota at this time
+	 * or with the current configuration
+	 */
+	public function canSetQuota() : bool;
+
+	/**
+	 * Sets a new quota for a user.
+	 *
+	 * Before using this method, you must call `can...Currently()` of this interface to ensure that the user
+	 * backend can perform this action at his time or with the current configuration, since this can change
+	 * during runtime. The implementing user back end will throw an ActionNotAvailableException if it doesn't.
+	 *
+	 * @param string $username the username to set the quota for
+	 * @param string $newQuota the new quota value
+	 * @throws ActionNotAvailableException if this action is not supported at this time
+	 * @throws UserDoesNotExistInBackEndException if specified username doesn't exist in the user back end
+	 */
+	public function setQuota(string $username, string $newQuota): void;
+}

--- a/lib/public/User/Backend/Exception/ActionNotAvailableException.php
+++ b/lib/public/User/Backend/Exception/ActionNotAvailableException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace OCP\User\Backend\Exception;
+
+use RuntimeException;
+
+class ActionNotAvailableException extends RuntimeException {
+
+}

--- a/lib/public/User/Backend/Exception/UserAlreadyExistsException.php
+++ b/lib/public/User/Backend/Exception/UserAlreadyExistsException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace OCP\User\Backend\Exception;
+
+use RuntimeException;
+
+class UserAlreadyExistsException extends RuntimeException {
+
+}

--- a/lib/public/User/Backend/Exception/UserDoesNotExistInBackEndException.php
+++ b/lib/public/User/Backend/Exception/UserDoesNotExistInBackEndException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace OCP\User\Backend\Exception;
+
+use RuntimeException;
+
+class UserDoesNotExistInBackEndException extends RuntimeException {
+
+}

--- a/lib/public/User/Backend/ICheckPasswordBackend.php
+++ b/lib/public/User/Backend/ICheckPasswordBackend.php
@@ -29,10 +29,12 @@ namespace OCP\User\Backend;
 
 /**
  * @since 14.0.0
+ * @deprecated 21.0.0
  */
 interface ICheckPasswordBackend {
 	/**
 	 * @since 14.0.0
+	 * @deprecated 21.0.0
 	 *
 	 * @param string $loginName The loginname
 	 * @param string $password The password

--- a/lib/public/User/Backend/ICountUsersBackend.php
+++ b/lib/public/User/Backend/ICountUsersBackend.php
@@ -28,11 +28,13 @@ namespace OCP\User\Backend;
 
 /**
  * @since 14.0.0
+ * @deprecated 21.0.0
  */
 interface ICountUsersBackend {
 
 	/**
 	 * @since 14.0.0
+	 * @deprecated 21.0.0
 	 *
 	 * @return int|bool The number of users on success false on failure
 	 */

--- a/lib/public/User/Backend/ICreateUserBackend.php
+++ b/lib/public/User/Backend/ICreateUserBackend.php
@@ -28,11 +28,13 @@ namespace OCP\User\Backend;
 
 /**
  * @since 14.0.0
+ * @deprecated 21.0.0
  */
 interface ICreateUserBackend {
 
 	/**
 	 * @since 14.0.0
+	 * @deprecated 21.0.0
 	 *
 	 * @param string $uid The username of the user to create
 	 * @param string $password The password of the new user

--- a/lib/public/User/Backend/IGetDisplayNameBackend.php
+++ b/lib/public/User/Backend/IGetDisplayNameBackend.php
@@ -28,11 +28,13 @@ namespace OCP\User\Backend;
 
 /**
  * @since 14.0.0
+ * @deprecated 21.0.0
  */
 interface IGetDisplayNameBackend {
 
 	/**
 	 * @since 14.0.0
+	 * @deprecated 21.0.0
 	 *
 	 * @param string $uid user ID of the user
 	 * @return string display name

--- a/lib/public/User/Backend/IGetRealUIDBackend.php
+++ b/lib/public/User/Backend/IGetRealUIDBackend.php
@@ -28,6 +28,7 @@ namespace OCP\User\Backend;
 
 /**
  * @since 17.0.0
+ * @deprecated 21.0.0
  */
 interface IGetRealUIDBackend {
 
@@ -39,6 +40,7 @@ interface IGetRealUIDBackend {
 	 * This little function makes sure that the used UID will be correct hen using the user object
 	 *
 	 * @since 17.0.0
+	 * @deprecated 21.0.0
 	 * @param string $uid
 	 * @return string
 	 */

--- a/lib/public/User/Backend/IPasswordConfirmationBackend.php
+++ b/lib/public/User/Backend/IPasswordConfirmationBackend.php
@@ -28,11 +28,14 @@ namespace OCP\User\Backend;
 
 /**
  * @since 15.0.0
+ * @deprecated 21.0.0
  */
 interface IPasswordConfirmationBackend {
 
 	/**
 	 * @since 15.0.0
+	 * @deprecated 21.0.0 Use @see \OCP\User\Backend\Action\ICheckPassword::canCheckPasswordCurrently()
+	 * instead.
 	 */
 	public function canConfirmPassword(string $uid): bool;
 }

--- a/lib/public/User/Backend/ISetDisplayNameBackend.php
+++ b/lib/public/User/Backend/ISetDisplayNameBackend.php
@@ -28,11 +28,13 @@ namespace OCP\User\Backend;
 
 /**
  * @since 14.0.0
+ * @deprecated 21.0.0
  */
 interface ISetDisplayNameBackend {
 
 	/**
 	 * @since 14.0.0
+	 * @deprecated 21.0.0
 	 *
 	 * @param string $uid The username
 	 * @param string $displayName The new display name

--- a/lib/public/User/Backend/ISetPasswordBackend.php
+++ b/lib/public/User/Backend/ISetPasswordBackend.php
@@ -28,11 +28,13 @@ namespace OCP\User\Backend;
 
 /**
  * @since 14.0.0
+ * @deprecated 21.0.0 Use \OCP\User\Backend\Action\ISetPassword instead
  */
 interface ISetPasswordBackend {
 
 	/**
 	 * @since 14.0.0
+	 * @deprecated 21.0.0 Use \OCP\User\Backend\Action\ISetPassword::setPassword() instead
 	 *
 	 * @param string $uid The username
 	 * @param string $password The new password

--- a/lib/public/UserInterface.php
+++ b/lib/public/UserInterface.php
@@ -38,6 +38,7 @@ namespace OCP;
  * TODO actually this is a IUserBackend
  *
  * @since 4.5.0
+ * @deprecated 21.0.0 use \OCP\User\Backend\AbstractUserBackEnd instead
  */
 interface UserInterface {
 
@@ -49,7 +50,7 @@ interface UserInterface {
 	 * Returns the supported actions as int to be
 	 * compared with \OC\User\Backend::CREATE_USER etc.
 	 * @since 4.5.0
-	 * @deprecated 14.0.0 Switch to the interfaces from OCP\User\Backend
+	 * @deprecated 21.0.0 implement interfaces from \OCP\User\Backend\Action instead
 	 */
 	public function implementsActions($actions);
 
@@ -58,6 +59,7 @@ interface UserInterface {
 	 * @param string $uid The username of the user to delete
 	 * @return bool
 	 * @since 4.5.0
+	 * @deprecated 21.0.0 implement interfaces from \OCP\User\Backend\Action instead
 	 */
 	public function deleteUser($uid);
 
@@ -69,6 +71,7 @@ interface UserInterface {
 	 * @param null|int $offset
 	 * @return string[] an array of all uids
 	 * @since 4.5.0
+	 * @deprecated 21.0.0 implement interfaces from \OCP\User\Backend\Action instead
 	 */
 	public function getUsers($search = '', $limit = null, $offset = null);
 
@@ -77,6 +80,7 @@ interface UserInterface {
 	 * @param string $uid the username
 	 * @return boolean
 	 * @since 4.5.0
+	 * @deprecated 21.0.0 implement interfaces from \OCP\User\Backend\Action instead
 	 */
 	public function userExists($uid);
 
@@ -85,6 +89,7 @@ interface UserInterface {
 	 * @param string $uid user ID of the user
 	 * @return string display name
 	 * @since 4.5.0
+	 * @deprecated 21.0.0 implement interfaces from \OCP\User\Backend\Action instead
 	 */
 	public function getDisplayName($uid);
 
@@ -96,6 +101,7 @@ interface UserInterface {
 	 * @param string|null $offset
 	 * @return array an array of all displayNames (value) and the corresponding uids (key)
 	 * @since 4.5.0
+	 * @deprecated 21.0.0 implement interfaces from \OCP\User\Backend\Action instead
 	 */
 	public function getDisplayNames($search = '', $limit = null, $offset = null);
 
@@ -103,6 +109,7 @@ interface UserInterface {
 	 * Check if a user list is available or not
 	 * @return boolean if users can be listed or not
 	 * @since 4.5.0
+	 * @deprecated 21.0.0 implement interfaces from \OCP\User\Backend\Action instead
 	 */
 	public function hasUserListings();
 }


### PR DESCRIPTION
This user back end API proposal uses single-method interfaces, an abstract base class for user
back ends and exceptions.

# Abstract User Back End Class
Instead of the old `OCP\IUserBackend` interface the new core entity is `AbstractUserBackend`. An abstract class is IMHO better than an interface because:
* it hints that this is an entity and not merely a contract. It communicates (better than an interface) that this should be the starting point for a user back end.
* an abstract class can contain all methods/attributes that are mandatory and have sensible default implementations like returning the back end name.
* PHP does not support multiple inheritance therefore it becomes clear that there can not be other language objects that are needed for a minimal user back end (you don't need to implement 3 interfaces from all over the code to get the basics).
* **TO DISCUSS**: what should be the minimal required methods/attributes for a user back end?

# Action Interfaces
An *action* is a single operations that a user back end can perform, e.g check password, read user email, set display name etc.

There are now 17 single action interfaces in the `OCP\User\Backend\Action` namespace. A user back end can implement any number of them, like so:

```php
use OCP\User\Backend\AbstractUserBackend;
use OCP\User\Backend\Action\ICheckPassword;
use OCP\User\Backend\Action\ICreateUser;
use OCP\User\Backend\Action\IUserExists;

class MyUserBackend extends AbstractUserBackend implements ICheckPassword, ICreateUser, IUserExists {
...
}
```
Since action interfaces have *Backend* in their namespace, the names themselves do not contain the word *Backend*, since it is implied.

## can...()-methods
In addition to the interfaces we also need the `can...()` methods to let the user back end communicate which actions are supported with the current cofniguration. Implementing interfaces is a compile time decision. 

The problem that this solves is that when you write your user back end, you can support all the actions (implementing the action interfaces), but then when your user back end app is deployed, the admin might not allow to change your e-mail for example and then the user back end must be able to communicate to Nextcloud which actions it can perform with the current configuration. This was done by the old `implementsActions()` method. So the interfaces give as an upper bound of actions implemented and method signature contracts but only `can..()` enables us to communicate this at runtime. If you can come up with a better solution, I would gladly adopt it.

So, the Nextcloud API (or whoever uses a user back end implementation) is expected to call e.g. `canCheckPasswordCurrently()` before using the actual method (`checkPasword()`). User back ends can throw  `ActionNotAvailableException` to signal that they are being used "wrongly" and do not implement that action at that time or with the current configuration.


# Exceptions
Action methods do not use return type `null` or `false` but are expected to throw exceptions.

Some of the reasons why exceptions are better than return values:
* return types do not communicate **what** failed only **that** it did, exceptions do.
* they are not propagated and must be forwarded each step in the call stack
* can create complicated if/then structures
* [more reasons](https://stackoverflow.com/questions/99683/which-and-why-do-you-prefer-exceptions-or-return-codes/46982339#46982339)

In case you wondering why there are `can...()` methods then that do return booleans: This is because here we are actually asking for that information and not doing an operation that wouuld not return a boolean naturally.

* exceptions can also be used for methods where a useable value, e.g. display name is returned. Here you can't use a `false` to signal failure.
* new Exception `ActionNotAvailableException` can be used by implementing user back ends to signal to the Nextcloud API that they do not support an action at that time (or with the current configuration).
    * it extends `RuntimeException` because this is a runtime issue
    
# Miscellaneous
* the `@since 21.0.0` is only a suggestion and I simply adopted it from Christoph's pull request. I think a new user back end API should be thoroughly tested and discussed, so maybe Nextcloud 22 is more appropriate. We should really try to avoid having yet another API for Nextcloud 25 :)
* `getUsers()` split into to `findUsersByName()` and `findUsersByDisplayName()`. The current implementation AFAIK only searches usernames and display names. In case more attributes are searched in the future this method should not "block" the generic name but use a name that matches its capabilities. But we could merge *name* and *display name* in case they are needed both.

## Things I Would Prefer To Do (but didn't do because of existing implicit code conventions in Nextcloud)
* Remove the `Exception` suffix to exception names.
* Remove the `I` from interface names.


# Questions / Discussion Points
1. Is there an advantage to password check functions returing the username on success and not simpy `true` (like I did)?
2. Can we name the "real UID" "normalized UID"? This is what it seems to do and Christoph's pr also does this.
3. What is the purpose of `IProvideAvatarBackend`? Should there be action interfaces to set and get an avatar?
4. `hasUserListings()` is found in some user back end implementations but no documentation exists for its actual purpose. many back ends just return `true`. Is this still needed or can we delete it?
5. What is the minimal user back end that should be required by `AbstractUserBackEnd`?