### PR TITLE
Fix updates of NULL appconfig values

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -202,12 +202,9 @@ class AppConfig implements IAppConfig {
 
 		$sql = $this->conn->getQueryBuilder();
 		$sql->update('appconfig')
-			->set('configvalue', $sql->createParameter('configvalue'))
-			->where($sql->expr()->eq('appid', $sql->createParameter('app')))
-			->andWhere($sql->expr()->eq('configkey', $sql->createParameter('configkey')))
-			->setParameter('configvalue', $value)
-			->setParameter('app', $app)
-			->setParameter('configkey', $key);
+			->set('configvalue', $sql->createNamedParameter($value))
+			->where($sql->expr()->eq('appid', $sql->createNamedParameter($app)))
+			->andWhere($sql->expr()->eq('configkey', $sql->createNamedParameter($key)));
 
 		/*
 		 * Only limit to the existing value for non-Oracle DBs:
@@ -215,9 +212,25 @@ class AppConfig implements IAppConfig {
 		 * > Large objects (LOBs) are not supported in comparison conditions.
 		 */
 		if (!($this->conn instanceof OracleConnection)) {
-			// Only update the value when it is not the same
-			$sql->andWhere($sql->expr()->neq('configvalue', $sql->createParameter('configvalue')))
-				->setParameter('configvalue', $value);
+
+			/*
+			 * Only update the value when it is not the same
+			 * Note that NULL requires some special handling. Since comparing
+			 * against null can have special results.
+			 */
+
+			if ($value === null) {
+				$sql->andWhere(
+					$sql->expr()->isNotNull('configvalue')
+				);
+			} else {
+				$sql->andWhere(
+					$sql->expr()->orX(
+						$sql->expr()->isNull('configvalue'),
+						$sql->expr()->neq('configvalue', $sql->createNamedParameter($value))
+					)
+				);
+			}
 		}
 
 		$changedRow = (bool) $sql->execute();


### PR DESCRIPTION
The comparisson of NULL is a bit special.
So we need to handle this a tad beter else it might not replace NULL
values. or allow you to set NULL values on updates.



To test:

1. php occ config:app:set dav calendarSubscriptionRefreshRate

Sets it properly to NULL

2. php occ config:app:set --value='foo' dav calendarSubscriptionRefreshRate

Before: still NULL
After: 'foo'