### PR TITLE
Add more details if extract fails

### DIFF
--- a/lib/private/Archive/TAR.php
+++ b/lib/private/Archive/TAR.php
@@ -381,4 +381,14 @@ class TAR extends Archive {
 		$types = [null, 'gz', 'bz'];
 		$this->tar = new \Archive_Tar($this->path, $types[self::getTarType($this->path)]);
 	}
+
+	/**
+	 * Get error object from archive_tar.
+	 */
+	public function getError(): ?\PEAR_Error {
+		if ($this->tar instanceof \Archive_Tar && $this->tar->error_object instanceof \PEAR_Error) {
+			return $this->tar->error_object;
+		}
+		return null;
+	}
 }

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -294,12 +294,14 @@ class Installer {
 
 					if ($archive) {
 						if (!$archive->extract($extractDir)) {
-							throw new \Exception(
-								sprintf(
-									'Could not extract app %s',
-									$appId
-								)
-							);
+							$errorMessage = 'Could not extract app ' . $appId;
+
+							$archiveError = $archive->getError();
+							if ($archiveError instanceof \PEAR_Error) {
+								$errorMessage .= ': ' . $archiveError->getMessage();
+							}
+
+							throw new \Exception($errorMessage);
 						}
 						$allFiles = scandir($extractDir);
 						$folders = array_diff($allFiles, ['.', '..']);


### PR DESCRIPTION
Fix #23482
Fix #19674 (it will not fix the actual issue but give people more information why it fails)

![image](https://user-images.githubusercontent.com/3902676/96741052-b7e84300-13c1-11eb-9a00-ee238e9a6fc0.png)


**How to test:**

You may set a quota for /tmp to 100mb and try to install documentserver_community. Or if you are lazy (like me):

- Open https://github.com/nextcloud/3rdparty/blob/7be056265cb5298857adada1f7b6430e7d273efc/pear/archive_tar/Archive/Tar.php#L1956 and insert `$p_mode = 'no' (that set's an invalid mode and extract fails) 
- Go to apps management
- Install an app

**Note:**

I had in mind to add this feature for install and update app: https://github.com/nextcloud/server/pull/23608/commits/521c12db2c9409b816677e20b6bedfd145509046

But the `updateAppstoreApp` method eats the exception. The update routine needs an update to work without the try-catch but is out of scope for this PR. On update the exception is still logged so the information is at least in the logs.

