### PR TITLE
Bring back the restore share button

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -539,6 +539,23 @@ table td.selection {
 	cursor: default !important;
 }
 
+/*
+ * Make the disabled link look not like a link in file list rows
+ */
+#fileList a.name.disabled {
+	* {
+		cursor: default;
+	}
+
+	a, a * {
+		cursor: pointer;
+	}
+
+	&:focus {
+		background: none;
+	}
+}
+
 a.action > img {
 	height: 16px;
 	width: 16px;

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1561,9 +1561,7 @@
 				"href": linkUrl
 			});
 			if (this._defaultFileActionsDisabled) {
-				linkElem = $('<p></p>').attr({
-					"class": "name"
-				})
+				linkElem.addClass('disabled');
 			}
 
 			linkElem.append('<div class="thumbnail-wrapper"><div class="thumbnail" style="background-image:url(' + icon + ');"></div></div>');


### PR DESCRIPTION
Fix disabled default file action to still use an anchor element, as this
is used in many other places (and potentially apps).

Adjusted anchor style to not look like it's clickable and added extras
to make sure everything inside still looks clickable as before.

Fixes https://github.com/nextcloud/server/issues/23240

Note: I was not able to remove the unrelated hand icon from the avatar. This would need another more complex fix related to "when no sidebar, don't display hand on action-share".