### PR TITLE
Fix public calendars shared to circles

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -178,11 +178,7 @@ class Principal implements BackendInterface {
 				return $this->userToPrincipal($user);
 			}
 		} elseif ($prefix === 'principals/circles') {
-			try {
-				return $this->circleToPrincipal($name);
-			} catch (QueryException $e) {
-				return null;
-			}
+			return $this->circleToPrincipal($name);
 		}
 		return null;
 	}
@@ -471,9 +467,6 @@ class Principal implements BackendInterface {
 	/**
 	 * @param string $circleUniqueId
 	 * @return array|null
-	 * @throws \OCP\AppFramework\QueryException
-	 * @suppress PhanUndeclaredClassMethod
-	 * @suppress PhanUndeclaredClassCatch
 	 */
 	protected function circleToPrincipal($circleUniqueId) {
 		if (!$this->appManager->isEnabledForUser('circles') || !class_exists('\OCA\Circles\Api\v1\Circles')) {

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -178,7 +178,9 @@ class Principal implements BackendInterface {
 				return $this->userToPrincipal($user);
 			}
 		} elseif ($prefix === 'principals/circles') {
-			return $this->circleToPrincipal($name);
+			if ($this->userSession->getUser() !== null) {
+				return $this->circleToPrincipal($name);
+			}
 		}
 		return null;
 	}


### PR DESCRIPTION
Fix https://github.com/nextcloud/circles/issues/508

`TypeError: Argument 2 passed to OCA\Circles\Db\CirclesRequest::getCircle() must be of the type string, null given, called in /var/www/html/apps/circles/lib/Service/CirclesService.php on line 271`

It's not possible to fetch the principal from the circles app without a valid user session. 

https://github.com/nextcloud/server/pull/23652/commits/ca279f36900e6c0f9f7ffbab17c20967b29df97d Update outdated phpdoc
https://github.com/nextcloud/server/pull/23652/commits/ac8939a1a81c9d427ee5fe2f50517324e76a726f Fix

**How to test:**

1. Create a calendar
2. Create a link share for calendar 
3. Share calendar to a circle
4. Open calendar link
5. :boom: 