### PR TITLE
Enable theming background transparency

### DIFF
--- a/apps/theming/lib/ImageManager.php
+++ b/apps/theming/lib/ImageManager.php
@@ -228,13 +228,17 @@ class ImageManager {
 			// either to big or are not progressive rendering.
 			$newImage = @imagecreatefromstring(file_get_contents($tmpFile));
 
+			// Preserve transparency
+			imagesavealpha($newImage, true);
+			imagealphablending($newImage, true);
+
 			$tmpFile = $this->tempManager->getTemporaryFile();
 			$newWidth = (int)(imagesx($newImage) < 4096 ? imagesx($newImage) : 4096);
 			$newHeight = (int)(imagesy($newImage) / (imagesx($newImage) / $newWidth));
 			$outputImage = imagescale($newImage, $newWidth, $newHeight);
 
 			imageinterlace($outputImage, 1);
-			imagejpeg($outputImage, $tmpFile, 75);
+			imagepng($outputImage, $tmpFile, 8);
 			imagedestroy($outputImage);
 
 			$target->putContent(file_get_contents($tmpFile));


### PR DESCRIPTION
Fix #23649 

Example with colour `#9F40C9`
| Before | After |
|:---------:|:------:|
|![dev skjnldsv com_settings_admin_theming (1)](https://user-images.githubusercontent.com/14975046/97115468-352ff280-16f7-11eb-93cf-16284c0da412.png)|![dev skjnldsv com_settings_admin_theming](https://user-images.githubusercontent.com/14975046/97115466-34975c00-16f7-11eb-9b18-301450bf6640.png)|