### PR TITLE
Use bigint for fileid in filecache_extended

### DIFF
--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -614,6 +614,7 @@ Raw output
 			'authtoken' => ['id'],
 			'bruteforce_attempts' => ['id'],
 			'filecache' => ['fileid', 'storage', 'parent', 'mimetype', 'mimepart', 'mtime', 'storage_mtime'],
+			'filecache_extended' => ['fileid'],
 			'file_locks' => ['id'],
 			'jobs' => ['id'],
 			'mimetypes' => ['id'],

--- a/core/Command/Db/ConvertFilecacheBigInt.php
+++ b/core/Command/Db/ConvertFilecacheBigInt.php
@@ -65,6 +65,7 @@ class ConvertFilecacheBigInt extends Command {
 			'authtoken' => ['id'],
 			'bruteforce_attempts' => ['id'],
 			'filecache' => ['fileid', 'storage', 'parent', 'mimetype', 'mimepart', 'mtime', 'storage_mtime'],
+			'filecache_extended' => ['fileid'],
 			'file_locks' => ['id'],
 			'jobs' => ['id'],
 			'mimetypes' => ['id'],


### PR DESCRIPTION
Users get error 
```
An exception occurred while executing 'INSERT INTO `xx_filecache_extended` (`fileid`, `upload_time`) VALUES(?, ?)' with params [4XY6418251, 160369XYZ0]:\\n\\nSQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'fileid' at row 1\"?
```