### PR TITLE
Clarify import cert command

### DIFF
--- a/core/Command/Security/ImportCertificate.php
+++ b/core/Command/Security/ImportCertificate.php
@@ -42,11 +42,11 @@ class ImportCertificate extends Base {
 	protected function configure() {
 		$this
 			->setName('security:certificates:import')
-			->setDescription('import trusted certificate')
+			->setDescription('import trusted certificate in PEM format')
 			->addArgument(
 				'path',
 				InputArgument::REQUIRED,
-				'path to the certificate to import'
+				'path to the PEM certificate to import'
 			);
 	}
 
@@ -54,7 +54,7 @@ class ImportCertificate extends Base {
 		$path = $input->getArgument('path');
 
 		if (!file_exists($path)) {
-			$output->writeln('<error>certificate not found</error>');
+			$output->writeln('<error>Certificate not found, please provide a path accessible by the web server user</error>');
 			return 1;
 		}
 


### PR DESCRIPTION
Add hint that the certificate to be imported must be in PEM format (CRT did not parse for me).

Improved error message to mention that the given path must be accessible
by the web server user.

