### PR TITLE
Use ShareManager to determine shares of unlocatable LDAP users and fix an issue in a condition

### DIFF
--- a/apps/user_ldap/ajax/wizard.php
+++ b/apps/user_ldap/ajax/wizard.php
@@ -61,9 +61,10 @@ $userManager = new \OCA\User_LDAP\User\Manager(
 	new \OCA\User_LDAP\LogWrapper(),
 	\OC::$server->getAvatarManager(),
 	new \OCP\Image(),
-	\OC::$server->getDatabaseConnection(),
 	\OC::$server->getUserManager(),
-	\OC::$server->getNotificationManager());
+	\OC::$server->getNotificationManager(),
+	\OC::$server->get(\OCP\Share\IManager::class)
+);
 
 $access = new \OCA\User_LDAP\Access(
 	$con,

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -52,6 +52,7 @@ use OC\Hooks\PublicEmitter;
 use OC\ServerNotAvailableException;
 use OCA\User_LDAP\Exceptions\ConstraintViolationException;
 use OCA\User_LDAP\Mapping\AbstractMapping;
+use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User\Manager;
 use OCA\User_LDAP\User\OfflineUser;
 use OCP\IConfig;
@@ -74,9 +75,7 @@ class Access extends LDAPUtility {
 	protected $pagedSearchedSuccessful;
 
 	/**
-	 * protected $cookies = [];
-	 *
-	 * @var AbstractMapping $userMapper
+	 * @var UserMapping $userMapper
 	 */
 	protected $userMapper;
 
@@ -123,12 +122,9 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * returns the User Mapper
-	 *
-	 * @return AbstractMapping
 	 * @throws \Exception
 	 */
-	public function getUserMapper() {
+	public function getUserMapper(): UserMapping {
 		if (is_null($this->userMapper)) {
 			throw new \Exception('UserMapper was not assigned to this Access instance.');
 		}

--- a/apps/user_ldap/lib/Jobs/CleanUp.php
+++ b/apps/user_ldap/lib/Jobs/CleanUp.php
@@ -30,7 +30,6 @@ namespace OCA\User_LDAP\Jobs;
 
 use OC\BackgroundJob\TimedJob;
 use OCA\User_LDAP\Helper;
-use OCA\User_LDAP\LDAP;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCA\User_LDAP\User_LDAP;
@@ -68,11 +67,12 @@ class CleanUp extends TimedJob {
 	/** @var DeletedUsersIndex */
 	protected $dui;
 
-	public function __construct(User_Proxy $userBackend) {
+	public function __construct(User_Proxy $userBackend, DeletedUsersIndex $dui) {
 		$minutes = \OC::$server->getConfig()->getSystemValue(
 			'ldapUserCleanupInterval', (string)$this->defaultIntervalMin);
 		$this->setInterval((int)$minutes * 60);
 		$this->userBackend = $userBackend;
+		$this->dui = $dui;
 	}
 
 	/**
@@ -115,9 +115,6 @@ class CleanUp extends TimedJob {
 
 		if (isset($arguments['deletedUsersIndex'])) {
 			$this->dui = $arguments['deletedUsersIndex'];
-		} else {
-			$this->dui = new DeletedUsersIndex(
-				$this->ocConfig, $this->db, $this->mapping);
 		}
 	}
 

--- a/apps/user_ldap/lib/Jobs/Sync.php
+++ b/apps/user_ldap/lib/Jobs/Sync.php
@@ -29,16 +29,13 @@ use OC\ServerNotAvailableException;
 use OCA\User_LDAP\AccessFactory;
 use OCA\User_LDAP\Configuration;
 use OCA\User_LDAP\ConnectionFactory;
-use OCA\User_LDAP\FilesystemHelper;
 use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\LDAP;
-use OCA\User_LDAP\LogWrapper;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User\Manager;
 use OCP\IAvatarManager;
 use OCP\IConfig;
 use OCP\IDBConnection;
-use OCP\Image;
 use OCP\IUserManager;
 use OCP\Notification\IManager;
 
@@ -68,7 +65,8 @@ class Sync extends TimedJob {
 	/** @var AccessFactory */
 	protected $accessFactory;
 
-	public function __construct() {
+	public function __construct(Manager  $userManager) {
+		$this->userManager = $userManager;
 		$this->setInterval(
 			\OC::$server->getConfig()->getAppValue(
 				'user_ldap',
@@ -345,17 +343,6 @@ class Sync extends TimedJob {
 
 		if (isset($argument['userManager'])) {
 			$this->userManager = $argument['userManager'];
-		} else {
-			$this->userManager = new Manager(
-				$this->config,
-				new FilesystemHelper(),
-				new LogWrapper(),
-				$this->avatarManager,
-				new Image(),
-				$this->dbc,
-				$this->ncUserManager,
-				$this->notificationManager
-			);
 		}
 
 		if (isset($argument['mapper'])) {
@@ -363,7 +350,7 @@ class Sync extends TimedJob {
 		} else {
 			$this->mapper = new UserMapping($this->dbc);
 		}
-		
+
 		if (isset($argument['connectionFactory'])) {
 			$this->connectionFactory = $argument['connectionFactory'];
 		} else {

--- a/apps/user_ldap/lib/LDAPProviderFactory.php
+++ b/apps/user_ldap/lib/LDAPProviderFactory.php
@@ -26,38 +26,19 @@
 
 namespace OCA\User_LDAP;
 
-use OCA\User_LDAP\Mapping\UserMapping;
-use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCP\IServerContainer;
+use OCP\LDAP\ILDAPProvider;
 use OCP\LDAP\ILDAPProviderFactory;
 
 class LDAPProviderFactory implements ILDAPProviderFactory {
-	/**
-	 * Server container
-	 *
-	 * @var IServerContainer
-	 */
+	/** * @var IServerContainer */
 	private $serverContainer;
-	
-	/**
-	 * Constructor for the LDAP provider factory
-	 *
-	 * @param IServerContainer $serverContainer server container
-	 */
+
 	public function __construct(IServerContainer $serverContainer) {
 		$this->serverContainer = $serverContainer;
 	}
-	
-	/**
-	 * creates and returns an instance of the ILDAPProvider
-	 *
-	 * @return OCP\LDAP\ILDAPProvider
-	 */
-	public function getLDAPProvider() {
-		$dbConnection = $this->serverContainer->getDatabaseConnection();
-		$userMapping = new UserMapping($dbConnection);
-		return new LDAPProvider($this->serverContainer, new Helper($this->serverContainer->getConfig()),
-					new DeletedUsersIndex($this->serverContainer->getConfig(),
-					$dbConnection, $userMapping));
+
+	public function getLDAPProvider(): ILDAPProvider {
+		return $this->serverContainer->get(LDAPProvider::class);
 	}
 }

--- a/apps/user_ldap/lib/Proxy.php
+++ b/apps/user_ldap/lib/Proxy.php
@@ -36,6 +36,7 @@ namespace OCA\User_LDAP;
 use OCA\User_LDAP\Mapping\GroupMapping;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User\Manager;
+use OCP\Share\IManager;
 
 abstract class Proxy {
 	private static $accesses = [];
@@ -67,7 +68,7 @@ abstract class Proxy {
 		static $avatarM;
 		static $userMap;
 		static $groupMap;
-		static $db;
+		static $shareManager;
 		static $coreUserManager;
 		static $coreNotificationManager;
 		if ($fs === null) {
@@ -80,10 +81,11 @@ abstract class Proxy {
 			$groupMap = new GroupMapping($db);
 			$coreUserManager = \OC::$server->getUserManager();
 			$coreNotificationManager = \OC::$server->getNotificationManager();
+			$shareManager = \OC::$server->get(IManager::class);
 		}
 		$userManager =
-			new Manager($ocConfig, $fs, $log, $avatarM, new \OCP\Image(), $db,
-				$coreUserManager, $coreNotificationManager);
+			new Manager($ocConfig, $fs, $log, $avatarM, new \OCP\Image(),
+				$coreUserManager, $coreNotificationManager, $shareManager);
 		$connector = new Connection($this->ldap, $configPrefix);
 		$access = new Access($connector, $this->ldap, $userManager, new Helper($ocConfig), $ocConfig, $coreUserManager);
 		$access->setUserMapper($userMap);

--- a/apps/user_ldap/lib/User/DeletedUsersIndex.php
+++ b/apps/user_ldap/lib/User/DeletedUsersIndex.php
@@ -26,6 +26,7 @@
 namespace OCA\User_LDAP\User;
 
 use OCA\User_LDAP\Mapping\UserMapping;
+use OCP\Share\IManager;
 
 /**
  * Class DeletedUsersIndex
@@ -38,11 +39,6 @@ class DeletedUsersIndex {
 	protected $config;
 
 	/**
-	 * @var \OCP\IDBConnection $db
-	 */
-	protected $db;
-
-	/**
 	 * @var \OCA\User_LDAP\Mapping\UserMapping $mapping
 	 */
 	protected $mapping;
@@ -51,16 +47,13 @@ class DeletedUsersIndex {
 	 * @var array $deletedUsers
 	 */
 	protected $deletedUsers;
+	/** @var IManager */
+	private $shareManager;
 
-	/**
-	 * @param \OCP\IConfig $config
-	 * @param \OCP\IDBConnection $db
-	 * @param \OCA\User_LDAP\Mapping\UserMapping $mapping
-	 */
-	public function __construct(\OCP\IConfig $config, \OCP\IDBConnection $db, UserMapping $mapping) {
+	public function __construct(\OCP\IConfig $config, UserMapping $mapping, IManager $shareManager) {
 		$this->config = $config;
-		$this->db = $db;
 		$this->mapping = $mapping;
+		$this->shareManager = $shareManager;
 	}
 
 	/**
@@ -73,7 +66,7 @@ class DeletedUsersIndex {
 
 		$userObjects = [];
 		foreach ($deletedUsers as $user) {
-			$userObjects[] = new OfflineUser($user, $this->config, $this->db, $this->mapping);
+			$userObjects[] = new OfflineUser($user, $this->config, $this->mapping, $this->shareManager);
 		}
 		$this->deletedUsers = $userObjects;
 

--- a/apps/user_ldap/lib/User/Manager.php
+++ b/apps/user_ldap/lib/User/Manager.php
@@ -39,6 +39,7 @@ use OCP\IDBConnection;
 use OCP\Image;
 use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
+use OCP\Share\IManager;
 
 /**
  * Manager
@@ -82,32 +83,29 @@ class Manager {
 	 * @var CappedMemoryCache $usersByUid
 	 */
 	protected $usersByUid;
+	/** @var IManager */
+	private $shareManager;
 
-	/**
-	 * @param IConfig $ocConfig
-	 * @param \OCA\User_LDAP\FilesystemHelper $ocFilesystem object that
-	 * gives access to necessary functions from the OC filesystem
-	 * @param  \OCA\User_LDAP\LogWrapper $ocLog
-	 * @param IAvatarManager $avatarManager
-	 * @param Image $image an empty image instance
-	 * @param IDBConnection $db
-	 * @throws \Exception when the methods mentioned above do not exist
-	 */
-	public function __construct(IConfig $ocConfig,
-								FilesystemHelper $ocFilesystem, LogWrapper $ocLog,
-								IAvatarManager $avatarManager, Image $image,
-								IDBConnection $db, IUserManager $userManager,
-								INotificationManager $notificationManager) {
+	public function __construct(
+		IConfig $ocConfig,
+		FilesystemHelper $ocFilesystem,
+		LogWrapper $ocLog,
+		IAvatarManager $avatarManager,
+		Image $image,
+		IUserManager $userManager,
+		INotificationManager $notificationManager,
+		IManager $shareManager
+	) {
 		$this->ocConfig = $ocConfig;
 		$this->ocFilesystem = $ocFilesystem;
 		$this->ocLog = $ocLog;
 		$this->avatarManager = $avatarManager;
 		$this->image = $image;
-		$this->db = $db;
 		$this->userManager = $userManager;
 		$this->notificationManager = $notificationManager;
 		$this->usersByDN = new CappedMemoryCache();
 		$this->usersByUid = new CappedMemoryCache();
+		$this->shareManager = $shareManager;
 	}
 
 	/**
@@ -229,8 +227,9 @@ class Manager {
 		return new OfflineUser(
 			$id,
 			$this->ocConfig,
-			$this->db,
-			$this->access->getUserMapper());
+			$this->access->getUserMapper(),
+			$this->shareManager
+		);
 	}
 
 	/**

--- a/apps/user_ldap/lib/User/OfflineUser.php
+++ b/apps/user_ldap/lib/User/OfflineUser.php
@@ -90,7 +90,6 @@ class OfflineUser {
 		$this->config = $config;
 		$this->db = $db;
 		$this->mapping = $mapping;
-		$this->fetchDetails();
 	}
 
 	/**
@@ -132,6 +131,9 @@ class OfflineUser {
 	 * @return string
 	 */
 	public function getUID() {
+		if (!isset($this->uid)) {
+			$this->fetchDetails();
+		}
 		return $this->uid;
 	}
 
@@ -140,6 +142,9 @@ class OfflineUser {
 	 * @return string
 	 */
 	public function getDN() {
+		if (!isset($this->dn)) {
+			$this->fetchDetails();
+		}
 		return $this->dn;
 	}
 
@@ -148,6 +153,9 @@ class OfflineUser {
 	 * @return string
 	 */
 	public function getDisplayName() {
+		if (!isset($this->displayName)) {
+			$this->fetchDetails();
+		}
 		return $this->displayName;
 	}
 
@@ -156,6 +164,9 @@ class OfflineUser {
 	 * @return string
 	 */
 	public function getEmail() {
+		if (!isset($this->email)) {
+			$this->fetchDetails();
+		}
 		return $this->email;
 	}
 
@@ -164,6 +175,9 @@ class OfflineUser {
 	 * @return string
 	 */
 	public function getHomePath() {
+		if (!isset($this->homePath)) {
+			$this->fetchDetails();
+		}
 		return $this->homePath;
 	}
 
@@ -172,6 +186,9 @@ class OfflineUser {
 	 * @return int
 	 */
 	public function getLastLogin() {
+		if (!isset($this->lastLogin)) {
+			$this->fetchDetails();
+		}
 		return (int)$this->lastLogin;
 	}
 
@@ -180,6 +197,9 @@ class OfflineUser {
 	 * @return int
 	 */
 	public function getDetectedOn() {
+		if (!isset($this->foundDeleted)) {
+			$this->fetchDetails();
+		}
 		return (int)$this->foundDeleted;
 	}
 
@@ -188,6 +208,9 @@ class OfflineUser {
 	 * @return bool
 	 */
 	public function getHasActiveShares() {
+		if (!isset($this->hasActiveShares)) {
+			$this->fetchDetails();
+		}
 		return $this->hasActiveShares;
 	}
 

--- a/apps/user_ldap/lib/User/OfflineUser.php
+++ b/apps/user_ldap/lib/User/OfflineUser.php
@@ -243,29 +243,22 @@ class OfflineUser {
 	 */
 	protected function determineShares() {
 		$query = $this->db->prepare('
-			SELECT COUNT(`uid_owner`)
+			SELECT `uid_owner`
 			FROM `*PREFIX*share`
 			WHERE `uid_owner` = ?
 		', 1);
 		$query->execute([$this->ocName]);
-		$sResult = $query->fetchColumn(0);
-		if ((int)$sResult === 1) {
+		if ($query->rowCount() > 0) {
 			$this->hasActiveShares = true;
 			return;
 		}
 
 		$query = $this->db->prepare('
-			SELECT COUNT(`owner`)
+			SELECT `owner`
 			FROM `*PREFIX*share_external`
 			WHERE `owner` = ?
 		', 1);
 		$query->execute([$this->ocName]);
-		$sResult = $query->fetchColumn(0);
-		if ((int)$sResult === 1) {
-			$this->hasActiveShares = true;
-			return;
-		}
-
-		$this->hasActiveShares = false;
+		$this->hasActiveShares = $query->rowCount() > 0;
 	}
 }

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -48,10 +48,10 @@ use OCA\User_LDAP\User\OfflineUser;
 use OCA\User_LDAP\User\User;
 use OCP\IAvatarManager;
 use OCP\IConfig;
-use OCP\IDBConnection;
 use OCP\Image;
 use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
+use OCP\Share\IManager;
 use Test\TestCase;
 
 /**
@@ -64,6 +64,8 @@ use Test\TestCase;
 class AccessTest extends TestCase {
 	/** @var UserMapping|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userMapper;
+	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
+	protected $shareManager;
 	/** @var Connection|\PHPUnit\Framework\MockObject\MockObject */
 	private $connection;
 	/** @var LDAP|\PHPUnit\Framework\MockObject\MockObject */
@@ -87,6 +89,7 @@ class AccessTest extends TestCase {
 		$this->config = $this->createMock(IConfig::class);
 		$this->userMapper = $this->createMock(UserMapping::class);
 		$this->ncUserManager = $this->createMock(IUserManager::class);
+		$this->shareManager = $this->createMock(IManager::class);
 
 		$this->access = new Access(
 			$this->connection,
@@ -111,9 +114,9 @@ class AccessTest extends TestCase {
 				$this->createMock(LogWrapper::class),
 				$this->createMock(IAvatarManager::class),
 				$this->createMock(Image::class),
-				$this->createMock(IDBConnection::class),
 				$this->createMock(IUserManager::class),
-				$this->createMock(INotificationManager::class)])
+				$this->createMock(INotificationManager::class),
+				$this->shareManager])
 			->getMock();
 		$helper = new Helper(\OC::$server->getConfig());
 

--- a/apps/user_ldap/tests/Integration/AbstractIntegrationTest.php
+++ b/apps/user_ldap/tests/Integration/AbstractIntegrationTest.php
@@ -37,6 +37,7 @@ use OCA\User_LDAP\LDAP;
 use OCA\User_LDAP\LogWrapper;
 use OCA\User_LDAP\User\Manager;
 use OCA\User_LDAP\UserPluginManager;
+use OCP\Share\IManager;
 
 abstract class AbstractIntegrationTest {
 	/** @var  LDAP */
@@ -126,9 +127,9 @@ abstract class AbstractIntegrationTest {
 			new LogWrapper(),
 			\OC::$server->getAvatarManager(),
 			new \OCP\Image(),
-			\OC::$server->getDatabaseConnection(),
 			\OC::$server->getUserManager(),
-			\OC::$server->getNotificationManager()
+			\OC::$server->getNotificationManager(),
+			\OC::$server->get(IManager::class)
 		);
 	}
 

--- a/apps/user_ldap/tests/Jobs/CleanUpTest.php
+++ b/apps/user_ldap/tests/Jobs/CleanUpTest.php
@@ -44,7 +44,7 @@ class CleanUpTest extends TestCase {
 
 	public function setUp(): void {
 		$this->createMocks();
-		$this->bgJob = new CleanUp($this->mocks['userBackend']);
+		$this->bgJob = new CleanUp($this->mocks['userBackend'], $this->mocks['deletedUsersIndex']);
 		$this->bgJob->setArguments($this->mocks);
 	}
 

--- a/apps/user_ldap/tests/Jobs/SyncTest.php
+++ b/apps/user_ldap/tests/Jobs/SyncTest.php
@@ -89,7 +89,6 @@ class SyncTest extends TestCase {
 		$this->arguments = [
 			'helper' => $this->helper,
 			'ldapWrapper' => $this->ldapWrapper,
-			'userManager' => $this->userManager,
 			'mapper' => $this->mapper,
 			'config' => $this->config,
 			'avatarManager' => $this->avatarManager,
@@ -100,7 +99,7 @@ class SyncTest extends TestCase {
 			'accessFactory' => $this->accessFactory,
 		];
 
-		$this->sync = new Sync();
+		$this->sync = new Sync($this->userManager);
 	}
 
 	public function intervalDataProvider() {

--- a/apps/user_ldap/tests/User/DeletedUsersIndexTest.php
+++ b/apps/user_ldap/tests/User/DeletedUsersIndexTest.php
@@ -30,6 +30,7 @@ use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\Share\IManager;
 
 /**
  * Class DeletedUsersIndexTest
@@ -50,6 +51,8 @@ class DeletedUsersIndexTest extends \Test\TestCase {
 
 	/** @var UserMapping|\PHPUnit\Framework\MockObject\MockObject */
 	protected $mapping;
+	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
+	protected $shareManager;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -62,8 +65,9 @@ class DeletedUsersIndexTest extends \Test\TestCase {
 		$this->config->deleteAppFromAllUsers('user_ldap');
 
 		$this->mapping = $this->createMock(UserMapping::class);
+		$this->shareManager = $this->createMock(IManager::class);
 
-		$this->dui = new DeletedUsersIndex($this->config, $this->db, $this->mapping);
+		$this->dui = new DeletedUsersIndex($this->config, $this->mapping, $this->shareManager);
 	}
 
 	protected function tearDown(): void {

--- a/apps/user_ldap/tests/User/ManagerTest.php
+++ b/apps/user_ldap/tests/User/ManagerTest.php
@@ -42,6 +42,7 @@ use OCP\IDBConnection;
 use OCP\Image;
 use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
+use OCP\Share\IManager;
 
 /**
  * Class Test_User_Manager
@@ -86,6 +87,8 @@ class ManagerTest extends \Test\TestCase {
 
 	/** @var Manager */
 	protected $manager;
+	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
+	protected $shareManager;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -96,11 +99,11 @@ class ManagerTest extends \Test\TestCase {
 		$this->log = $this->createMock(LogWrapper::class);
 		$this->avatarManager = $this->createMock(IAvatarManager::class);
 		$this->image = $this->createMock(Image::class);
-		$this->dbc = $this->createMock(IDBConnection::class);
 		$this->ncUserManager = $this->createMock(IUserManager::class);
 		$this->notificationManager = $this->createMock(INotificationManager::class);
-
 		$this->ldapWrapper = $this->createMock(ILDAPWrapper::class);
+		$this->shareManager = $this->createMock(IManager::class);
+
 		$this->connection = new Connection($this->ldapWrapper, '', null);
 
 		$this->access->expects($this->any())
@@ -114,9 +117,9 @@ class ManagerTest extends \Test\TestCase {
 			$this->log,
 			$this->avatarManager,
 			$this->image,
-			$this->dbc,
 			$this->ncUserManager,
-			$this->notificationManager
+			$this->notificationManager,
+			$this->shareManager
 		);
 
 		$this->manager->setLdapAccess($this->access);

--- a/apps/user_ldap/tests/User/OfflineUserTest.php
+++ b/apps/user_ldap/tests/User/OfflineUserTest.php
@@ -78,10 +78,12 @@ class OfflineUserTest extends TestCase {
 	public function testHasActiveShares(int $internalOwnerships, int $externalOwnerships, bool $expected) {
 		$queryMock = $this->createMock(Statement::class);
 		$queryMock->expects($this->atLeastOnce())
-			->method('fetchColumn')
+			->method('execute');
+		$queryMock->expects($this->atLeastOnce())
+			->method('rowCount')
 			->willReturnOnConsecutiveCalls(
-				(string)$internalOwnerships,
-				(string)$externalOwnerships
+				$internalOwnerships > 0 ? 1 : 0,
+				$externalOwnerships > 0 ? 1 : 0
 			);
 
 		$this->dbc->expects($this->atLeastOnce())

--- a/apps/user_ldap/tests/User/OfflineUserTest.php
+++ b/apps/user_ldap/tests/User/OfflineUserTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_LDAP\Tests\User;
+
+use Doctrine\DBAL\Driver\Statement;
+use OCA\User_LDAP\Mapping\UserMapping;
+use OCA\User_LDAP\User\OfflineUser;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use Test\TestCase;
+
+class OfflineUserTest extends TestCase {
+
+	/** @var OfflineUser */
+	protected $offlineUser;
+	/** @var UserMapping|\PHPUnit\Framework\MockObject\MockObject */
+	protected $mapping;
+	/** @var string */
+	protected $uid;
+	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
+	protected $config;
+	/** @var IDBConnection|\PHPUnit\Framework\MockObject\MockObject */
+	protected $dbc;
+
+	public function setUp(): void {
+		$this->uid = 'deborah';
+		$this->config = $this->createMock(IConfig::class);
+		$this->dbc = $this->createMock(IDBConnection::class);
+		$this->mapping = $this->createMock(UserMapping::class);
+
+		$this->offlineUser = new OfflineUser(
+			$this->uid,
+			$this->config,
+			$this->dbc,
+			$this->mapping
+		);
+	}
+
+	public function shareOwnerProvider(): array {
+		// tests for none, one, many
+		return [
+			[ 0, 0, false],
+			[ 1, 0, true],
+			[ 0, 1, true],
+			[ 1, 1, true],
+			[ 2, 0, true],
+			[ 0, 2, true],
+			[ 2, 2, true],
+		];
+	}
+
+	/**
+	 * @dataProvider shareOwnerProvider
+	 */
+	public function testHasActiveShares(int $internalOwnerships, int $externalOwnerships, bool $expected) {
+		$queryMock = $this->createMock(Statement::class);
+		$queryMock->expects($this->atLeastOnce())
+			->method('fetchColumn')
+			->willReturnOnConsecutiveCalls(
+				(string)$internalOwnerships,
+				(string)$externalOwnerships
+			);
+
+		$this->dbc->expects($this->atLeastOnce())
+			->method('prepare')
+			->willReturn($queryMock);
+
+		$this->assertSame($expected, $this->offlineUser->getHasActiveShares());
+	}
+}

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -1410,7 +1410,7 @@ class User_LDAPTest extends TestCase {
 			->with($this->isInstanceOf(AbstractMapping::class), $this->anything(), $uid, $uuid, true);
 		$this->access->expects($this->any())
 			->method('getUserMapper')
-			->willReturn($this->createMock(AbstractMapping::class));
+			->willReturn($this->createMock(UserMapping::class));
 
 		$this->assertEquals($this->backend->createUser($uid, $pwd),true);
 	}


### PR DESCRIPTION
When LDAP users are found as deleted in occ ldap:show-remnants it is displayed whether a listed user was also a sharer. A Y(es) or N(o) is shown in that column. Example:

```
+--------------------------------------+------------------------+----------+---------------------------------------------+------------------+------------------+-----+--------+
| Nextcloud name                       | Display Name           | LDAP UID | LDAP DN                                     | Last Login       | Detected on      | Dir | Sharer |
+--------------------------------------+------------------------+----------+---------------------------------------------+------------------+------------------+-----+--------+
| folk_31                              | Teresa, John (folk_31) | folk_31  | uid=folk_31,ou=users,ou=small,dc=nc,dc=zara | October 26, 2020 | October 26, 2020 |     | Y      |
| 567DE9DC-D733-4FD5-8F85-EA637640A43A | Anna Mang (amang)      | amang    | cn=anna mang,cn=users,dc=nxtcld,dc=internal | -                | July 30, 2020    |     | N      |
+--------------------------------------+------------------------+----------+---------------------------------------------+------------------+------------------+-----+--------+
```

I was made aware that a condition failed to show it properly, if a user had more than one share :see_no_evil: In the old code (mostly unchanged since 2014) also the relevant share tables were queried directly, as the share manager was not  in place. This is updated in this PR as well.

Some refactorings are necessary, for instance moving logic from the OfflineUsers constructor. This allows for unit tests, but makes the instance also more lazy in gathering info on that user. Some further code cleanup was while some class signatures needed change. Leaving changed and added tests aside, about 20 LoC are saved.

The first three commits are essentially the base of the fix for NC 20 and below (PR coming in a bit).