### PR TITLE
[stable20] fix sharer flag on ldap:show-remnants when user owned more than a single share

### DIFF
--- a/apps/user_ldap/lib/User/OfflineUser.php
+++ b/apps/user_ldap/lib/User/OfflineUser.php
@@ -90,7 +90,6 @@ class OfflineUser {
 		$this->config = $config;
 		$this->db = $db;
 		$this->mapping = $mapping;
-		$this->fetchDetails();
 	}
 
 	/**
@@ -132,6 +131,9 @@ class OfflineUser {
 	 * @return string
 	 */
 	public function getUID() {
+		if (!isset($this->uid)) {
+			$this->fetchDetails();
+		}
 		return $this->uid;
 	}
 
@@ -140,6 +142,9 @@ class OfflineUser {
 	 * @return string
 	 */
 	public function getDN() {
+		if (!isset($this->dn)) {
+			$this->fetchDetails();
+		}
 		return $this->dn;
 	}
 
@@ -148,6 +153,9 @@ class OfflineUser {
 	 * @return string
 	 */
 	public function getDisplayName() {
+		if (!isset($this->displayName)) {
+			$this->fetchDetails();
+		}
 		return $this->displayName;
 	}
 
@@ -156,6 +164,9 @@ class OfflineUser {
 	 * @return string
 	 */
 	public function getEmail() {
+		if (!isset($this->email)) {
+			$this->fetchDetails();
+		}
 		return $this->email;
 	}
 
@@ -164,6 +175,9 @@ class OfflineUser {
 	 * @return string
 	 */
 	public function getHomePath() {
+		if (!isset($this->homePath)) {
+			$this->fetchDetails();
+		}
 		return $this->homePath;
 	}
 
@@ -172,6 +186,9 @@ class OfflineUser {
 	 * @return int
 	 */
 	public function getLastLogin() {
+		if (!isset($this->lastLogin)) {
+			$this->fetchDetails();
+		}
 		return (int)$this->lastLogin;
 	}
 
@@ -180,6 +197,9 @@ class OfflineUser {
 	 * @return int
 	 */
 	public function getDetectedOn() {
+		if (!isset($this->foundDeleted)) {
+			$this->fetchDetails();
+		}
 		return (int)$this->foundDeleted;
 	}
 
@@ -188,6 +208,9 @@ class OfflineUser {
 	 * @return bool
 	 */
 	public function getHasActiveShares() {
+		if (!isset($this->hasActiveShares)) {
+			$this->fetchDetails();
+		}
 		return $this->hasActiveShares;
 	}
 

--- a/apps/user_ldap/lib/User/OfflineUser.php
+++ b/apps/user_ldap/lib/User/OfflineUser.php
@@ -243,29 +243,22 @@ class OfflineUser {
 	 */
 	protected function determineShares() {
 		$query = $this->db->prepare('
-			SELECT COUNT(`uid_owner`)
+			SELECT `uid_owner`
 			FROM `*PREFIX*share`
 			WHERE `uid_owner` = ?
 		', 1);
 		$query->execute([$this->ocName]);
-		$sResult = $query->fetchColumn(0);
-		if ((int)$sResult === 1) {
+		if ($query->rowCount() > 0) {
 			$this->hasActiveShares = true;
 			return;
 		}
 
 		$query = $this->db->prepare('
-			SELECT COUNT(`owner`)
+			SELECT `owner`
 			FROM `*PREFIX*share_external`
 			WHERE `owner` = ?
 		', 1);
 		$query->execute([$this->ocName]);
-		$sResult = $query->fetchColumn(0);
-		if ((int)$sResult === 1) {
-			$this->hasActiveShares = true;
-			return;
-		}
-
-		$this->hasActiveShares = false;
+		$this->hasActiveShares = $query->rowCount() > 0;
 	}
 }

--- a/apps/user_ldap/tests/User/OfflineUserTest.php
+++ b/apps/user_ldap/tests/User/OfflineUserTest.php
@@ -78,10 +78,12 @@ class OfflineUserTest extends TestCase {
 	public function testHasActiveShares(int $internalOwnerships, int $externalOwnerships, bool $expected) {
 		$queryMock = $this->createMock(Statement::class);
 		$queryMock->expects($this->atLeastOnce())
-			->method('fetchColumn')
+			->method('execute');
+		$queryMock->expects($this->atLeastOnce())
+			->method('rowCount')
 			->willReturnOnConsecutiveCalls(
-				(string)$internalOwnerships,
-				(string)$externalOwnerships
+				$internalOwnerships > 0 ? 1 : 0,
+				$externalOwnerships > 0 ? 1 : 0
 			);
 
 		$this->dbc->expects($this->atLeastOnce())

--- a/apps/user_ldap/tests/User/OfflineUserTest.php
+++ b/apps/user_ldap/tests/User/OfflineUserTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\User_LDAP\Tests\User;
+
+use Doctrine\DBAL\Driver\Statement;
+use OCA\User_LDAP\Mapping\UserMapping;
+use OCA\User_LDAP\User\OfflineUser;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use Test\TestCase;
+
+class OfflineUserTest extends TestCase {
+
+	/** @var OfflineUser */
+	protected $offlineUser;
+	/** @var UserMapping|\PHPUnit\Framework\MockObject\MockObject */
+	protected $mapping;
+	/** @var string */
+	protected $uid;
+	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
+	protected $config;
+	/** @var IDBConnection|\PHPUnit\Framework\MockObject\MockObject */
+	protected $dbc;
+
+	public function setUp(): void {
+		$this->uid = 'deborah';
+		$this->config = $this->createMock(IConfig::class);
+		$this->dbc = $this->createMock(IDBConnection::class);
+		$this->mapping = $this->createMock(UserMapping::class);
+
+		$this->offlineUser = new OfflineUser(
+			$this->uid,
+			$this->config,
+			$this->dbc,
+			$this->mapping
+		);
+	}
+
+	public function shareOwnerProvider(): array {
+		// tests for none, one, many
+		return [
+			[ 0, 0, false],
+			[ 1, 0, true],
+			[ 0, 1, true],
+			[ 1, 1, true],
+			[ 2, 0, true],
+			[ 0, 2, true],
+			[ 2, 2, true],
+		];
+	}
+
+	/**
+	 * @dataProvider shareOwnerProvider
+	 */
+	public function testHasActiveShares(int $internalOwnerships, int $externalOwnerships, bool $expected) {
+		$queryMock = $this->createMock(Statement::class);
+		$queryMock->expects($this->atLeastOnce())
+			->method('fetchColumn')
+			->willReturnOnConsecutiveCalls(
+				(string)$internalOwnerships,
+				(string)$externalOwnerships
+			);
+
+		$this->dbc->expects($this->atLeastOnce())
+			->method('prepare')
+			->willReturn($queryMock);
+
+		$this->assertSame($expected, $this->offlineUser->getHasActiveShares());
+	}
+}


### PR DESCRIPTION
Little sibling of #23700 for Nextcloud 20 and below.

Fixes the condition and stupid DB query. But also adds a unit tests which requires the business logic being drawn out of OfflineUser's constructor, which was bad style anyhow.

Previously, if you had a gone LDAP user owning two or more shares, the "Sharer" flag in the table output would say N(o) instead of Y(es). Unit test added.