### PR TITLE
Add optional size field for the file obj

### DIFF
--- a/lib/public/RichObjectStrings/Definitions.php
+++ b/lib/public/RichObjectStrings/Definitions.php
@@ -254,6 +254,12 @@ class Definitions {
 					'description' => 'The file name which should be used in the visual representation',
 					'example' => 'file.txt',
 				],
+				'size' => [
+					'since' => '21.0.0',
+					'required' => false,
+					'description' => 'The file size in bytes',
+					'example' => '3145728',
+				],
 				'path' => [
 					'since' => '11.0.0',
 					'required' => true,


### PR DESCRIPTION
Add optional size field for the file rich object definition.

For https://github.com/nextcloud/spreed/pull/4472 but could be useful later also.