### PR TITLE
Deprecate \OCP\EventDispatcher\IEventDispatcher::dispatch

### DIFF
--- a/lib/public/EventDispatcher/IEventDispatcher.php
+++ b/lib/public/EventDispatcher/IEventDispatcher.php
@@ -75,6 +75,7 @@ interface IEventDispatcher {
 	 * @psalm-param T $event
 	 *
 	 * @since 17.0.0
+	 * @deprecated 21.0.0 use \OCP\EventDispatcher\IEventDispatcher::dispatchTyped
 	 */
 	public function dispatch(string $eventName, Event $event): void;
 


### PR DESCRIPTION
As discussed in https://help.nextcloud.com/t/deprecation-of-ieventdispatcher-dispatch/95381