### PR TITLE
Added media-src to csp of remote.php

### DIFF
--- a/remote.php
+++ b/remote.php
@@ -116,8 +116,9 @@ try {
 
 	// All resources served via the DAV endpoint should have the strictest possible
 	// policy. Exempted from this is the SabreDAV browser plugin which overwrites
-	// this policy with a softer one if debug mode is enabled.
-	header("Content-Security-Policy: default-src 'none';");
+	// this policy with a softer one if debug mode is enabled. Media-src is set to
+	// 'self' to allow to play video and audio files directly in the browser.
+	header("Content-Security-Policy: default-src 'none'; media-src 'self'");
 
 	if (\OCP\Util::needUpgrade()) {
 		// since the behavior of apps or remotes are unpredictable during


### PR DESCRIPTION
This allows me again to download eg a mp4 video file. Without this patch when i click download on the video it redirects me to https://mydomain/cloud/remote.php/webdav/Folder/Video.mp4?downloadStartSecret=xyz where the video does not because of the csp policy of remote.php

Signed-off-by: Patrick Bender <patrick@bender-it-services.de>