### PR TITLE
Unlock when promoting to exclusive lock fails

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -665,7 +665,13 @@ class View {
 					return false;
 				}
 
-				$this->changeLock($path, ILockingProvider::LOCK_EXCLUSIVE);
+				try {
+					$this->changeLock($path, ILockingProvider::LOCK_EXCLUSIVE);
+				} catch (\Exception $e) {
+					// Release the shared lock before throwing.
+					$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
+					throw $e;
+				}
 
 				/** @var \OC\Files\Storage\Storage $storage */
 				[$storage, $internalPath] = $this->resolvePath($path);


### PR DESCRIPTION
In certain cases changeLock to EXCLUSIVE fails
and throws LockedException. This leaves the
file locked as SHARED in file_put_contents,
which prevents retrying (because on second
call file_put_contents takes another SHARED
lock on the same file, and changeLock doesn't
allow more than a single SHARED lock to promote
to EXCLUSIVE).

To avoid this case, we catch the LockedException
and unlock before re-throwing.

Resolves #23740