### PR TITLE
inform the user when flow config data exceeds thresholds

### DIFF
--- a/apps/workflowengine/lib/Manager.php
+++ b/apps/workflowengine/lib/Manager.php
@@ -492,6 +492,11 @@ class Manager implements IManager {
 		if (count($checks) === 0) {
 			throw new \UnexpectedValueException($this->l->t('At least one check needs to be provided'));
 		}
+
+		if (strlen((string)$operation) > IManager::MAX_OPERATION_VALUE_BYTES) {
+			throw new \UnexpectedValueException($this->l->t('The provided operation data is too long'));
+		}
+
 		$instance->validateOperation($name, $checks, $operation);
 
 		foreach ($checks as $check) {
@@ -514,6 +519,10 @@ class Manager implements IManager {
 				&& !in_array($entity, $instance->supportedEntities())
 			) {
 				throw new \UnexpectedValueException($this->l->t('Check %s is not allowed with this entity', [$class]));
+			}
+
+			if (strlen((string)$check['value']) > IManager::MAX_CHECK_VALUE_BYTES) {
+				throw new \UnexpectedValueException($this->l->t('The provided check value is too long'));
 			}
 
 			$instance->validateCheck($check['operator'], $check['value']);

--- a/lib/public/WorkflowEngine/IManager.php
+++ b/lib/public/WorkflowEngine/IManager.php
@@ -36,6 +36,16 @@ interface IManager {
 	public const SCOPE_USER = 1;
 
 	/**
+	 * @since 21.0.0
+	 */
+	public const MAX_CHECK_VALUE_BYTES = 2048;
+
+	/**
+	 * @since 21.0.0
+	 */
+	public const MAX_OPERATION_VALUE_BYTES = 4096;
+
+	/**
 	 * @depreacted Will be removed in NC19. Use the dedicated events in OCP\WorkflowEngine\Events
 	 */
 	public const EVENT_NAME_REG_OPERATION = 'OCP\WorkflowEngine::registerOperations';


### PR DESCRIPTION
When providing check values or operation data (the stuff for action), you'll be informed when sending too much. The limits are now 2 and 4kB respectively, which should be sufficient for any flow configuration. Um, … ever ;)

![Screenshot_20201028_140922](https://user-images.githubusercontent.com/2184312/97440880-59264a80-1928-11eb-8a7d-cf0520f7ba5c.png)

