### PR TITLE
Add typed events for adding and removing a subadmin

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -347,6 +347,8 @@ return array(
     'OCP\\Group\\Events\\BeforeUserRemovedEvent' => $baseDir . '/lib/public/Group/Events/BeforeUserRemovedEvent.php',
     'OCP\\Group\\Events\\GroupCreatedEvent' => $baseDir . '/lib/public/Group/Events/GroupCreatedEvent.php',
     'OCP\\Group\\Events\\GroupDeletedEvent' => $baseDir . '/lib/public/Group/Events/GroupDeletedEvent.php',
+    'OCP\\Group\\Events\\SubAdminAddedEvent' => $baseDir . '/lib/public/Group/Events/SubAdminAddedEvent.php',
+    'OCP\\Group\\Events\\SubAdminRemovedEvent' => $baseDir . '/lib/public/Group/Events/SubAdminRemovedEvent.php',
     'OCP\\Group\\Events\\UserAddedEvent' => $baseDir . '/lib/public/Group/Events/UserAddedEvent.php',
     'OCP\\Group\\Events\\UserRemovedEvent' => $baseDir . '/lib/public/Group/Events/UserRemovedEvent.php',
     'OCP\\Group\\ISubAdmin' => $baseDir . '/lib/public/Group/ISubAdmin.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -376,6 +376,8 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Group\\Events\\BeforeUserRemovedEvent' => __DIR__ . '/../../..' . '/lib/public/Group/Events/BeforeUserRemovedEvent.php',
         'OCP\\Group\\Events\\GroupCreatedEvent' => __DIR__ . '/../../..' . '/lib/public/Group/Events/GroupCreatedEvent.php',
         'OCP\\Group\\Events\\GroupDeletedEvent' => __DIR__ . '/../../..' . '/lib/public/Group/Events/GroupDeletedEvent.php',
+        'OCP\\Group\\Events\\SubAdminAddedEvent' => __DIR__ . '/../../..' . '/lib/public/Group/Events/SubAdminAddedEvent.php',
+        'OCP\\Group\\Events\\SubAdminRemovedEvent' => __DIR__ . '/../../..' . '/lib/public/Group/Events/SubAdminRemovedEvent.php',
         'OCP\\Group\\Events\\UserAddedEvent' => __DIR__ . '/../../..' . '/lib/public/Group/Events/UserAddedEvent.php',
         'OCP\\Group\\Events\\UserRemovedEvent' => __DIR__ . '/../../..' . '/lib/public/Group/Events/UserRemovedEvent.php',
         'OCP\\Group\\ISubAdmin' => __DIR__ . '/../../..' . '/lib/public/Group/ISubAdmin.php',

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -41,6 +41,7 @@
 namespace OC\Group;
 
 use OC\Hooks\PublicEmitter;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\GroupInterface;
 use OCP\IGroup;
 use OCP\IGroupManager;
@@ -416,7 +417,8 @@ class Manager extends PublicEmitter implements IGroupManager {
 			$this->subAdmin = new \OC\SubAdmin(
 				$this->userManager,
 				$this,
-				\OC::$server->getDatabaseConnection()
+				\OC::$server->getDatabaseConnection(),
+				\OC::$server->get(IEventDispatcher::class)
 			);
 		}
 

--- a/lib/public/Group/Events/SubAdminAddedEvent.php
+++ b/lib/public/Group/Events/SubAdminAddedEvent.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author Morris Jobke <hey@morrisjobke.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Group\Events;
+
+use OCP\EventDispatcher\Event;
+use OCP\IGroup;
+use OCP\IUser;
+
+/**
+ * @since 21.0.0
+ */
+class SubAdminAddedEvent extends Event {
+
+	/** @var IGroup */
+	private $group;
+
+	/*** @var IUser */
+	private $user;
+
+	/**
+	 * @since 21.0.0
+	 */
+	public function __construct(IGroup $group, IUser $user) {
+		parent::__construct();
+		$this->group = $group;
+		$this->user = $user;
+	}
+
+	/**
+	 * @since 21.0.0
+	 */
+	public function getGroup(): IGroup {
+		return $this->group;
+	}
+
+	/**
+	 * @since 21.0.0
+	 */
+	public function getUser(): IUser {
+		return $this->user;
+	}
+}

--- a/lib/public/Group/Events/SubAdminRemovedEvent.php
+++ b/lib/public/Group/Events/SubAdminRemovedEvent.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author Morris Jobke <hey@morrisjobke.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Group\Events;
+
+use OCP\EventDispatcher\Event;
+use OCP\IGroup;
+use OCP\IUser;
+
+/**
+ * @since 21.0.0
+ */
+class SubAdminRemovedEvent extends Event {
+
+	/** @var IGroup */
+	private $group;
+
+	/*** @var IUser */
+	private $user;
+
+	/**
+	 * @since 21.0.0
+	 */
+	public function __construct(IGroup $group, IUser $user) {
+		parent::__construct();
+		$this->group = $group;
+		$this->user = $user;
+	}
+
+	/**
+	 * @since 21.0.0
+	 */
+	public function getGroup(): IGroup {
+		return $this->group;
+	}
+
+	/**
+	 * @since 21.0.0
+	 */
+	public function getUser(): IUser {
+		return $this->user;
+	}
+}

--- a/tests/lib/SubAdminTest.php
+++ b/tests/lib/SubAdminTest.php
@@ -22,6 +22,8 @@
 namespace Test;
 
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Group\Events\SubAdminAddedEvent;
+use OCP\Group\Events\SubAdminRemovedEvent;
 
 /**
  * @group DB
@@ -282,15 +284,15 @@ class SubAdminTest extends \Test\TestCase {
 		$g = $this->groups[0];
 		$count = 0;
 
-		$subAdmin->listen('\OC\SubAdmin', 'postCreateSubAdmin', function ($user, $group) use ($test, $u, $g, &$count) {
-			$test->assertEquals($u->getUID(), $user->getUID());
-			$test->assertEquals($g->getGID(), $group->getGID());
+		$this->eventDispatcher->addListener(SubAdminAddedEvent::class, function (SubAdminAddedEvent $event) use ($test, $u, $g, &$count) {
+			$test->assertEquals($u->getUID(), $event->getUser()->getUID());
+			$test->assertEquals($g->getGID(), $event->getGroup()->getGID());
 			$count++;
 		});
 
-		$subAdmin->listen('\OC\SubAdmin', 'postDeleteSubAdmin', function ($user, $group) use ($test, $u, $g, &$count) {
-			$test->assertEquals($u->getUID(), $user->getUID());
-			$test->assertEquals($g->getGID(), $group->getGID());
+		$this->eventDispatcher->addListener(SubAdminRemovedEvent::class, function ($event) use ($test, $u, $g, &$count) {
+			$test->assertEquals($u->getUID(), $event->getUser()->getUID());
+			$test->assertEquals($g->getGID(), $event->getGroup()->getGID());
 			$count++;
 		});
 


### PR DESCRIPTION
Also added in a separate commit the change of the event listener in the tests.

Continuation of the PRs I send already for 20 and to get closer to our goal of #14552

* [x] after merge: document in https://docs.nextcloud.com/server/20/developer_manual/basics/events.html