### PR TITLE
Add deprecated tag also to methods of deprecated classes - OC\\Hooks\\Emitter namespace

### DIFF
--- a/lib/private/Hooks/Emitter.php
+++ b/lib/private/Hooks/Emitter.php
@@ -39,6 +39,7 @@ interface Emitter {
 	 * @param string $method
 	 * @param callable $callback
 	 * @return void
+	 * @deprecated 18.0.0 use \OCP\EventDispatcher\IEventDispatcher::addListener
 	 */
 	public function listen($scope, $method, callable $callback);
 
@@ -47,6 +48,7 @@ interface Emitter {
 	 * @param string $method optional
 	 * @param callable $callback optional
 	 * @return void
+	 * @deprecated 18.0.0 use \OCP\EventDispatcher\IEventDispatcher::removeListener
 	 */
 	public function removeListener($scope = null, $method = null, callable $callback = null);
 }

--- a/lib/private/Hooks/EmitterTrait.php
+++ b/lib/private/Hooks/EmitterTrait.php
@@ -24,6 +24,9 @@
 
 namespace OC\Hooks;
 
+/**
+ * @deprecated 18.0.0 use events and the \OCP\EventDispatcher\IEventDispatcher service
+ */
 trait EmitterTrait {
 
 	/**
@@ -35,6 +38,7 @@ trait EmitterTrait {
 	 * @param string $scope
 	 * @param string $method
 	 * @param callable $callback
+	 * @deprecated 18.0.0 use \OCP\EventDispatcher\IEventDispatcher::addListener
 	 */
 	public function listen($scope, $method, callable $callback) {
 		$eventName = $scope . '::' . $method;
@@ -50,6 +54,7 @@ trait EmitterTrait {
 	 * @param string $scope optional
 	 * @param string $method optional
 	 * @param callable $callback optional
+	 * @deprecated 18.0.0 use \OCP\EventDispatcher\IEventDispatcher::removeListener
 	 */
 	public function removeListener($scope = null, $method = null, callable $callback = null) {
 		$names = [];
@@ -93,6 +98,7 @@ trait EmitterTrait {
 	 * @param string $scope
 	 * @param string $method
 	 * @param array $arguments optional
+	 * @deprecated 18.0.0 use \OCP\EventDispatcher\IEventDispatcher::dispatchTyped
 	 */
 	protected function emit($scope, $method, array $arguments = []) {
 		$eventName = $scope . '::' . $method;

--- a/lib/private/Hooks/PublicEmitter.php
+++ b/lib/private/Hooks/PublicEmitter.php
@@ -33,6 +33,7 @@ class PublicEmitter extends BasicEmitter {
 	 * @param string $scope
 	 * @param string $method
 	 * @param array $arguments optional
+	 * @deprecated 18.0.0 use \OCP\EventDispatcher\IEventDispatcher::dispatchTyped
 	 *
 	 * @suppress PhanAccessMethodProtected
 	 */


### PR DESCRIPTION
Was there before in https://github.com/nextcloud/server/blob/ef382f541c42f719b8dd30a4e0e248ef1bc39c84/lib/private/Hooks/Emitter.php#L34 and I just tagged all methods so that the IDE properly highlights this inline.


Ref #14552