### PR TITLE
Remove deprecated INotifyStorage::listen

### DIFF
--- a/lib/public/Files/Storage/INotifyStorage.php
+++ b/lib/public/Files/Storage/INotifyStorage.php
@@ -38,24 +38,6 @@ interface INotifyStorage {
 	public const NOTIFY_RENAMED = 4;
 
 	/**
-	 * Start listening for update notifications
-	 *
-	 * The provided callback will be called for every incoming notification with the following parameters
-	 *  - int $type the type of update, one of the INotifyStorage::NOTIFY_* constants
-	 *  - string $path the path of the update
-	 *  - string $renameTarget the target of the rename operation, only provided for rename updates
-	 *
-	 * Note that this call is blocking and will not exit on it's own, to stop listening for notifications return `false` from the callback
-	 *
-	 * @param string $path
-	 * @param callable $callback
-	 *
-	 * @since 9.1.0
-	 * @deprecated 12.0.0 use INotifyStorage::notify()->listen() instead
-	 */
-	public function listen($path, callable $callback);
-
-	/**
 	 * Start the notification handler for this storage
 	 *
 	 * @param $path


### PR DESCRIPTION
NC 12 was released in May 2017 and therefore we remove this API. I couldn't find any usages.


* [x] add to #23210