### PR TITLE
Allow admin to decide whether to use multipart or not.

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -55,6 +55,9 @@ trait S3ConnectionTrait {
 	/** @var int */
 	protected $timeout;
 
+	/** @var string */
+	protected $uploaderType;
+
 	/** @var int */
 	protected $uploadPartSize;
 
@@ -70,6 +73,7 @@ trait S3ConnectionTrait {
 		$this->test = isset($params['test']);
 		$this->bucket = $params['bucket'];
 		$this->timeout = !isset($params['timeout']) ? 15 : $params['timeout'];
+		$this->uploaderType = $params['uploaderType'];
 		$this->uploadPartSize = !isset($params['uploadPartSize']) ? 524288000 : $params['uploadPartSize'];
 		$params['region'] = empty($params['region']) ? 'eu-west-1' : $params['region'];
 		$params['hostname'] = empty($params['hostname']) ? 's3.' . $params['region'] . '.amazonaws.com' : $params['hostname'];


### PR DESCRIPTION
Some of the S3 implementations, e.g. GCS, does not implement the
MultipartUploadere the same way that ASW S3 does and it is not 100%
compatible. To overcome this we allow the admin to give the possibility
to use a simple uploader.

The uploader for an empty file should not be an exception.