### PR TITLE
Properly put hidden-visually off-screen

### DIFF
--- a/core/css/global.scss
+++ b/core/css/global.scss
@@ -30,8 +30,8 @@
 
 .hidden-visually {
 	position: absolute;
-	left:-10000px;
-	top: auto;
+	left: -10000px;
+	top: -10000px;
 	width: 1px;
 	height: 1px;
 	overflow: hidden;

--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -909,8 +909,8 @@ footer .info .entity-name {
 label.infield,
 .hidden-visually {
 	position: absolute;
-	left:-10000px;
-	top: auto;
+	left: -10000px;
+	top: -10000px;
 	width: 1px;
 	height: 1px;
 	overflow: hidden;

--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -948,8 +948,8 @@ progress {
 // Same as .hidden-visually
 label.infield {
 	position: absolute;
-	left:-10000px;
-	top: auto;
+	left: -10000px;
+	top: -10000px;
 	width: 1px;
 	height: 1px;
 	overflow: hidden;


### PR DESCRIPTION
In some situations the element is still affecting the layout, especially
when a sticky is nearby.

This fix moves it properly off-screen.


There is a risk that this might break existing layouts that were relying on this, if any.