### PR TITLE
Fetch the logger and system config once for all query builder instances

### DIFF
--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -42,20 +42,24 @@ use Doctrine\DBAL\Exception\ConstraintViolationException;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use OC\DB\QueryBuilder\QueryBuilder;
+use OC\SystemConfig;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
+use OCP\ILogger;
 use OCP\PreConditionNotMetException;
 
 class Connection extends ReconnectWrapper implements IDBConnection {
-	/**
-	 * @var string $tablePrefix
-	 */
+	/** @var string */
 	protected $tablePrefix;
 
-	/**
-	 * @var \OC\DB\Adapter $adapter
-	 */
+	/** @var \OC\DB\Adapter $adapter */
 	protected $adapter;
+
+	/** @var SystemConfig */
+	private $systemConfig;
+
+	/** @var ILogger */
+	private $logger;
 
 	protected $lockedTable = null;
 
@@ -90,8 +94,8 @@ class Connection extends ReconnectWrapper implements IDBConnection {
 		$this->queriesBuilt++;
 		return new QueryBuilder(
 			$this,
-			\OC::$server->getSystemConfig(),
-			\OC::$server->getLogger()
+			$this->systemConfig,
+			$this->logger
 		);
 	}
 
@@ -165,6 +169,9 @@ class Connection extends ReconnectWrapper implements IDBConnection {
 		parent::__construct($params, $driver, $config, $eventManager);
 		$this->adapter = new $params['adapter']($this);
 		$this->tablePrefix = $params['tablePrefix'];
+
+		$this->systemConfig = \OC::$server->getSystemConfig();
+		$this->logger = \OC::$server->getLogger();
 	}
 
 	/**


### PR DESCRIPTION
Found while profiling a DB heavy request. 

When a lot of query builders are used then often the logger is requested from the DI container and has quite some overhead due to the nested method calls.