### PR TITLE
Only parse the locales ones

### DIFF
--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -37,6 +37,7 @@
 
 namespace OC\L10N;
 
+use Ds\Set;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IUser;
@@ -62,6 +63,11 @@ class Factory implements IFactory {
 	 * @var array Structure: App => string[]
 	 */
 	protected $availableLanguages = [];
+
+	/**
+	 * @var Set
+	 */
+	protected $localeCache;
 
 	/**
 	 * @var array
@@ -104,6 +110,7 @@ class Factory implements IFactory {
 		$this->request = $request;
 		$this->userSession = $userSession;
 		$this->serverRoot = $serverRoot;
+		$this->localeCache = new Set();
 	}
 
 	/**
@@ -391,12 +398,14 @@ class Factory implements IFactory {
 			return true;
 		}
 
-		$locales = $this->findAvailableLocales();
-		$userLocale = array_filter($locales, function ($value) use ($locale) {
-			return $locale === $value['code'];
-		});
+		if ($this->localeCache->isEmpty()) {
+			$locales = $this->findAvailableLocales();
+			foreach ($locales as $l) {
+				$this->localeCache->add($l['code']);
+			}
+		}
 
-		return !empty($userLocale);
+		return $this->localeCache->contains($locale);
 	}
 
 	/**


### PR DESCRIPTION
Before we'd go over the entire list for each translation (so each app)
we'd use translation for. This means we'd also go over thise locale list
(currently containing 750 entries) * apps so often this added up to ~20k
calls.

now we just dump the locales in a set once and then check if the entry
is there.


for reference: https://blackfire.io/profiles/90959ea7-755e-4da5-af6f-1a0b5527c3bd/graph