### PR TITLE
fix: add missing config value for PHP 'output_buffering'

### DIFF
--- a/apps/settings/lib/SetupChecks/PhpOutputBuffering.php
+++ b/apps/settings/lib/SetupChecks/PhpOutputBuffering.php
@@ -37,6 +37,6 @@ class PhpOutputBuffering {
 
 	public function run(): bool {
 		$value = trim(ini_get('output_buffering'));
-		return $value === '' || $value === '0';
+		return $value === '' || $value === '0' || $value === 'Off' || $value === 'off';
 	}
 }


### PR DESCRIPTION
Both `Off` and `off` are valid values for a PHP configuration. Therefore, the Nextcloud setup check should also accept these values. Otherwise, Nextcloud will falsely report a wrong/missing PHP config directive.

See also https://github.com/nextcloud/documentation/issues/478