### PR TITLE
fix: php output_buffering setup check allowed values

### DIFF
--- a/apps/settings/lib/SetupChecks/PhpOutputBuffering.php
+++ b/apps/settings/lib/SetupChecks/PhpOutputBuffering.php
@@ -36,7 +36,7 @@ class PhpOutputBuffering {
 	}
 
 	public function run(): bool {
-		$value = trim(ini_get('output_buffering'));
-		return $value === '' || $value === '0' || $value === 'Off' || $value === 'off';
+		$value = strtolower(trim(ini_get('output_buffering')));
+		return in_array($value, array('', '0', 'off', 'false', 'no', 'none'));
 	}
 }

--- a/apps/settings/lib/SetupChecks/PhpOutputBuffering.php
+++ b/apps/settings/lib/SetupChecks/PhpOutputBuffering.php
@@ -37,6 +37,6 @@ class PhpOutputBuffering {
 
 	public function run(): bool {
 		$value = trim(ini_get('output_buffering'));
-		return $value === '' || $value === '0';
+		return $value === '' || $value === '0' || $value === 'Off' || $value === 'off';
 	}
 }

--- a/apps/settings/lib/SetupChecks/PhpOutputBuffering.php
+++ b/apps/settings/lib/SetupChecks/PhpOutputBuffering.php
@@ -37,6 +37,6 @@ class PhpOutputBuffering {
 
 	public function run(): bool {
 		$value = strtolower(trim(ini_get('output_buffering')));
-		return in_array($value, array('', '0', 'off', 'false', 'no', 'none'));
+		return in_array($value, ['', '0', 'off', 'false', 'no', 'none']);
 	}
 }


### PR DESCRIPTION
Both `Off` and `off` are valid values for a PHP configuration. Therefore, the Nextcloud setup check should also accept these values. Otherwise, Nextcloud will falsely report a wrong/missing PHP config directive.

See also https://github.com/nextcloud/documentation/issues/478