### PR TITLE
FeaturePolicy => PermissionPolicy

### DIFF
--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -268,7 +268,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				)
 			);
 			$dispatcher->registerMiddleware(
-				$server->query(OC\AppFramework\Middleware\Security\FeaturePolicyMiddleware::class)
+				$server->query(OC\AppFramework\Middleware\Security\PermissionPolicyMiddleware::class)
 			);
 			$dispatcher->registerMiddleware(
 				new OC\AppFramework\Middleware\Security\PasswordConfirmationMiddleware(

--- a/lib/private/AppFramework/Middleware/Security/PermissionPolicyMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/PermissionPolicyMiddleware.php
@@ -59,15 +59,15 @@ class PermissionPolicyMiddleware extends Middleware {
 	 * @return Response
 	 */
 	public function afterController($controller, $methodName, Response $response): Response {
-		$featurePolicy = !is_null($response->getFeaturePolicy()) ? $response->getFeaturePolicy() : new FeaturePolicy();
-		if (get_class($featurePolicy) !== EmptyFeaturePolicy::class) {
+		$featurePolicy = $response->getFeaturePolicy() ?? new FeaturePolicy();
+		if ($featurePolicy::class !== EmptyFeaturePolicy::class) {
 			$defaultPolicy = $this->featurePolicyManager->getDefaultPolicy();
 			$defaultPolicy = $this->featurePolicyManager->mergePolicies($defaultPolicy, $featurePolicy);
 			$response->setFeaturePolicy($defaultPolicy);
 		}
 
-		$permissionPolicy = !is_null($response->getPermissionPolicy()) ? $response->getPermissionPolicy() : new PermissionPolicy();
-		if (get_class($permissionPolicy) !== EmptyPermissionPolicy::class) {
+		$permissionPolicy = $response->getPermissionPolicy() ?? new PermissionPolicy();
+		if ($permissionPolicy::class !== EmptyPermissionPolicy::class) {
 			$defaultPolicy = $this->permissionPolicyManager->getDefaultPolicy();
 			$defaultPolicy = $this->permissionPolicyManager->mergePolicies($defaultPolicy, $permissionPolicy);
 			$defaultPolicy = $this->permissionPolicyManager->mergeFeaturePolicy($defaultPolicy, $response->getFeaturePolicy());

--- a/lib/private/Security/PermissionPolicy/PermissionPolicy.php
+++ b/lib/private/Security/PermissionPolicy/PermissionPolicy.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Security\PermissionPolicy;
+
+class PermissionPolicy extends \OCP\AppFramework\Http\PermissionPolicy {
+	public function getAutoplayDomains(): array {
+		return $this->autoplayDomains;
+	}
+
+	public function setAutoplayDomains(array $autoplayDomains): void {
+		$this->autoplayDomains = $autoplayDomains;
+	}
+
+	public function getCameraDomains(): array {
+		return $this->cameraDomains;
+	}
+
+	public function setCameraDomains(array $cameraDomains): void {
+		$this->cameraDomains = $cameraDomains;
+	}
+
+	public function getFullscreenDomains(): array {
+		return $this->fullscreenDomains;
+	}
+
+	public function setFullscreenDomains(array $fullscreenDomains): void {
+		$this->fullscreenDomains = $fullscreenDomains;
+	}
+
+	public function getGeolocationDomains(): array {
+		return $this->geolocationDomains;
+	}
+
+	public function setGeolocationDomains(array $geolocationDomains): void {
+		$this->geolocationDomains = $geolocationDomains;
+	}
+
+	public function getMicrophoneDomains(): array {
+		return $this->microphoneDomains;
+	}
+
+	public function setMicrophoneDomains(array $microphoneDomains): void {
+		$this->microphoneDomains = $microphoneDomains;
+	}
+
+	public function getPaymentDomains(): array {
+		return $this->paymentDomains;
+	}
+
+	public function setPaymentDomains(array $paymentDomains): void {
+		$this->paymentDomains = $paymentDomains;
+	}
+}

--- a/lib/private/Security/PermissionPolicy/PermissionPolicyManager.php
+++ b/lib/private/Security/PermissionPolicy/PermissionPolicyManager.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OC\Security\PermissionPolicy;
+
+use OCP\AppFramework\Http\EmptyFeaturePolicy;
+use OCP\AppFramework\Http\EmptyPermissionPolicy;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Security\PermissionPolicy\AddPermissionsPolicyEvent;
+
+class PermissionPolicyManager {
+	/** @var EmptyPermissionPolicy[] */
+	private $policies = [];
+
+	/** @var IEventDispatcher */
+	private $dispatcher;
+
+	public function __construct(IEventDispatcher $dispatcher) {
+		$this->dispatcher = $dispatcher;
+	}
+
+	public function addDefaultPolicy(EmptyPermissionPolicy $policy): void {
+		$this->policies[] = $policy;
+	}
+
+	public function getDefaultPolicy(): PermissionPolicy {
+		$event = new AddPermissionsPolicyEvent($this);
+		$this->dispatcher->dispatchTyped($event);
+
+		$defaultPolicy = new PermissionPolicy();
+		foreach ($this->policies as $policy) {
+			$defaultPolicy = $this->mergePolicies($defaultPolicy, $policy);
+		}
+		return $defaultPolicy;
+	}
+
+	/**
+	 * Merges the first given policy with the second one
+	 *
+	 */
+	public function mergePolicies(PermissionPolicy $defaultPolicy,
+								  EmptyPermissionPolicy $originalPolicy): PermissionPolicy {
+		foreach ((object)(array)$originalPolicy as $name => $value) {
+			$setter = 'set' . ucfirst($name);
+			if (\is_array($value)) {
+				$getter = 'get' . ucfirst($name);
+				$currentValues = \is_array($defaultPolicy->$getter()) ? $defaultPolicy->$getter() : [];
+				$defaultPolicy->$setter(\array_values(\array_unique(\array_merge($currentValues, $value))));
+			} elseif (\is_bool($value)) {
+				$defaultPolicy->$setter($value);
+			}
+		}
+
+		return $defaultPolicy;
+	}
+
+	public function mergeFeaturePolicy(PermissionPolicy $defaultPolicy, EmptyFeaturePolicy  $featurePolicy): PermissionPolicy {
+		foreach ((object)(array)$featurePolicy as $name => $value) {
+			$setter = 'set' . ucfirst($name);
+			if (\is_array($value)) {
+				$getter = 'get' . ucfirst($name);
+				$currentValues = \is_array($defaultPolicy->$getter()) ? $defaultPolicy->$getter() : [];
+				$defaultPolicy->$setter(\array_values(\array_unique(\array_merge($currentValues, $value))));
+			} elseif (\is_bool($value)) {
+				$defaultPolicy->$setter($value);
+			}
+		}
+
+		return $defaultPolicy;
+	}
+}

--- a/lib/public/AppFramework/Http/EmptyFeaturePolicy.php
+++ b/lib/public/AppFramework/Http/EmptyFeaturePolicy.php
@@ -34,7 +34,7 @@ namespace OCP\AppFramework\Http;
  *
  * @see \OCP\AppFramework\Http\FeaturePolicy
  * @since 17.0.0
- * @depreacted 21.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
+ * @deprecated 28.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
  */
 class EmptyFeaturePolicy {
 	/** @var string[] of allowed domains to autoplay media */
@@ -61,7 +61,7 @@ class EmptyFeaturePolicy {
 	 * @param string $domain Domain to whitelist. Any passed value needs to be properly sanitized.
 	 * @return $this
 	 * @since 17.0.0
-	 * @depreacted 21.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
+	 * @deprecated 28.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
 	 */
 	public function addAllowedAutoplayDomain(string $domain): self {
 		$this->autoplayDomains[] = $domain;
@@ -74,7 +74,7 @@ class EmptyFeaturePolicy {
 	 * @param string $domain Domain to whitelist. Any passed value needs to be properly sanitized.
 	 * @return $this
 	 * @since 17.0.0
-	 * @depreacted 21.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
+	 * @deprecated 28.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
 	 */
 	public function addAllowedCameraDomain(string $domain): self {
 		$this->cameraDomains[] = $domain;
@@ -87,7 +87,7 @@ class EmptyFeaturePolicy {
 	 * @param string $domain Domain to whitelist. Any passed value needs to be properly sanitized.
 	 * @return $this
 	 * @since 17.0.0
-	 * @depreacted 21.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
+	 * @deprecated 28.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
 	 */
 	public function addAllowedFullScreenDomain(string $domain): self {
 		$this->fullscreenDomains[] = $domain;
@@ -100,7 +100,7 @@ class EmptyFeaturePolicy {
 	 * @param string $domain Domain to whitelist. Any passed value needs to be properly sanitized.
 	 * @return $this
 	 * @since 17.0.0
-	 * @depreacted 21.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
+	 * @deprecated 28.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
 	 */
 	public function addAllowedGeoLocationDomain(string $domain): self {
 		$this->geolocationDomains[] = $domain;
@@ -113,7 +113,7 @@ class EmptyFeaturePolicy {
 	 * @param string $domain Domain to whitelist. Any passed value needs to be properly sanitized.
 	 * @return $this
 	 * @since 17.0.0
-	 * @depreacted 21.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
+	 * @deprecated 28.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
 	 */
 	public function addAllowedMicrophoneDomain(string $domain): self {
 		$this->microphoneDomains[] = $domain;
@@ -126,7 +126,7 @@ class EmptyFeaturePolicy {
 	 * @param string $domain Domain to whitelist. Any passed value needs to be properly sanitized.
 	 * @return $this
 	 * @since 17.0.0
-	 * @depreacted 21.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
+	 * @deprecated 28.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
 	 */
 	public function addAllowedPaymentDomain(string $domain): self {
 		$this->paymentDomains[] = $domain;
@@ -138,7 +138,7 @@ class EmptyFeaturePolicy {
 	 *
 	 * @return string
 	 * @since 17.0.0
-	 * @depreacted 21.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
+	 * @deprecated 28.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
 	 */
 	public function buildPolicy(): string {
 		$policy = '';

--- a/lib/public/AppFramework/Http/EmptyPermissionPolicy.php
+++ b/lib/public/AppFramework/Http/EmptyPermissionPolicy.php
@@ -1,9 +1,8 @@
 <?php
 
 declare(strict_types=1);
-
 /**
- * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ * @copyright Copyright (c) 2020, Roeland Jago Douma <roeland@famdouma.nl>
  *
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  *
@@ -16,27 +15,28 @@ declare(strict_types=1);
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 namespace OCP\AppFramework\Http;
 
 /**
- * Class EmptyFeaturePolicy is a simple helper which allows applications
- * to modify the FeaturePolicy sent by Nextcloud. Per default the policy
+ * Class EmptyPermissionsPolicy is a simple helper which allows applications
+ * to modify the PermissionPolicy sent by Nextcloud. Per default the policy
  * is forbidding everything.
  *
- * As alternative with sane exemptions look at FeaturePolicy
+ * As alternative with sane exemptions look at PermissionPolicy
  *
  * @see \OCP\AppFramework\Http\FeaturePolicy
- * @since 17.0.0
- * @depreacted 21.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
+ * @since 21.0.0
  */
-class EmptyFeaturePolicy {
+class EmptyPermissionPolicy {
+
 	/** @var string[] of allowed domains to autoplay media */
 	protected $autoplayDomains = null;
 
@@ -60,8 +60,7 @@ class EmptyFeaturePolicy {
 	 *
 	 * @param string $domain Domain to whitelist. Any passed value needs to be properly sanitized.
 	 * @return $this
-	 * @since 17.0.0
-	 * @depreacted 21.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
+	 * @since 21.0.0
 	 */
 	public function addAllowedAutoplayDomain(string $domain): self {
 		$this->autoplayDomains[] = $domain;
@@ -73,8 +72,7 @@ class EmptyFeaturePolicy {
 	 *
 	 * @param string $domain Domain to whitelist. Any passed value needs to be properly sanitized.
 	 * @return $this
-	 * @since 17.0.0
-	 * @depreacted 21.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
+	 * @since 21.0.0
 	 */
 	public function addAllowedCameraDomain(string $domain): self {
 		$this->cameraDomains[] = $domain;
@@ -86,8 +84,7 @@ class EmptyFeaturePolicy {
 	 *
 	 * @param string $domain Domain to whitelist. Any passed value needs to be properly sanitized.
 	 * @return $this
-	 * @since 17.0.0
-	 * @depreacted 21.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
+	 * @since 21.0.0
 	 */
 	public function addAllowedFullScreenDomain(string $domain): self {
 		$this->fullscreenDomains[] = $domain;
@@ -99,8 +96,7 @@ class EmptyFeaturePolicy {
 	 *
 	 * @param string $domain Domain to whitelist. Any passed value needs to be properly sanitized.
 	 * @return $this
-	 * @since 17.0.0
-	 * @depreacted 21.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
+	 * @since 21.0.0
 	 */
 	public function addAllowedGeoLocationDomain(string $domain): self {
 		$this->geolocationDomains[] = $domain;
@@ -112,8 +108,7 @@ class EmptyFeaturePolicy {
 	 *
 	 * @param string $domain Domain to whitelist. Any passed value needs to be properly sanitized.
 	 * @return $this
-	 * @since 17.0.0
-	 * @depreacted 21.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
+	 * @since 21.0.0
 	 */
 	public function addAllowedMicrophoneDomain(string $domain): self {
 		$this->microphoneDomains[] = $domain;
@@ -125,8 +120,7 @@ class EmptyFeaturePolicy {
 	 *
 	 * @param string $domain Domain to whitelist. Any passed value needs to be properly sanitized.
 	 * @return $this
-	 * @since 17.0.0
-	 * @depreacted 21.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
+	 * @since 21.0.0
 	 */
 	public function addAllowedPaymentDomain(string $domain): self {
 		$this->paymentDomains[] = $domain;
@@ -137,54 +131,43 @@ class EmptyFeaturePolicy {
 	 * Get the generated Feature-Policy as a string
 	 *
 	 * @return string
-	 * @since 17.0.0
-	 * @depreacted 21.0.0 Use \OCP\AppFramework\Http\EmptyPermissionPolicy
+	 * @since 21.0.0
 	 */
 	public function buildPolicy(): string {
 		$policy = '';
 
-		if (empty($this->autoplayDomains)) {
-			$policy .= "autoplay 'none';";
-		} else {
-			$policy .= 'autoplay ' . implode(' ', $this->autoplayDomains);
-			$policy .= ';';
+		$policy .= 'autoplay=(' . implode(' ', $this->formatDomainList($this->autoplayDomains)) . ') ';
+		$policy .= 'camera=(' . implode(' ', $this->formatDomainList($this->cameraDomains)) . ') ';
+		$policy .= 'fullscreen=(' . implode(' ', $this->formatDomainList($this->fullscreenDomains)) . ') ';
+		$policy .= 'geolocation=(' . implode(' ', $this->formatDomainList($this->geolocationDomains)) . ') ';
+		$policy .= 'microphone=(' . implode(' ', $this->formatDomainList($this->microphoneDomains)) . ') ';
+		$policy .= 'payment=(' . implode(' ', $this->formatDomainList($this->paymentDomains)) . ') ';
+
+		return rtrim($policy, ' ');
+	}
+
+	private function formatDomainList(?array $domains): array {
+		if ($domains === null) {
+			return [];
 		}
 
-		if (empty($this->cameraDomains)) {
-			$policy .= "camera 'none';";
-		} else {
-			$policy .= 'camera ' . implode(' ', $this->cameraDomains);
-			$policy .= ';';
+		$result = [];
+
+		foreach ($domains as $domain) {
+			if (!is_string($domain)) {
+				// Ignore wrong entries
+				continue;
+			}
+
+			if ($domain === '\'self\'') {
+				$domain = 'self';
+			}
+
+			$result[] = $domain;
 		}
 
-		if (empty($this->fullscreenDomains)) {
-			$policy .= "fullscreen 'none';";
-		} else {
-			$policy .= 'fullscreen ' . implode(' ', $this->fullscreenDomains);
-			$policy .= ';';
-		}
+		$result = array_unique($result);
 
-		if (empty($this->geolocationDomains)) {
-			$policy .= "geolocation 'none';";
-		} else {
-			$policy .= 'geolocation ' . implode(' ', $this->geolocationDomains);
-			$policy .= ';';
-		}
-
-		if (empty($this->microphoneDomains)) {
-			$policy .= "microphone 'none';";
-		} else {
-			$policy .= 'microphone ' . implode(' ', $this->microphoneDomains);
-			$policy .= ';';
-		}
-
-		if (empty($this->paymentDomains)) {
-			$policy .= "payment 'none';";
-		} else {
-			$policy .= 'payment ' . implode(' ', $this->paymentDomains);
-			$policy .= ';';
-		}
-
-		return rtrim($policy, ';');
+		return $result;
 	}
 }

--- a/lib/public/AppFramework/Http/PermissionPolicy.php
+++ b/lib/public/AppFramework/Http/PermissionPolicy.php
@@ -1,9 +1,8 @@
 <?php
 
 declare(strict_types=1);
-
 /**
- * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ * @copyright Copyright (c) 2020, Roeland Jago Douma <roeland@famdouma.nl>
  *
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  *
@@ -16,37 +15,37 @@ declare(strict_types=1);
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 namespace OCP\AppFramework\Http;
 
 /**
- * Class FeaturePolicy is a simple helper which allows applications to
- * modify the Feature-Policy sent by Nextcloud. Per default only autoplay is allowed
+ * Class PermissionPolicy is a simple helper which allows applications to
+ * modify the Permission-Policy sent by Nextcloud. Per default only autoplay is allowed
  * from the same domain and full screen as well from the same domain.
  *
  * Even if a value gets modified above defaults will still get appended. Please
  * notice that Nextcloud ships already with sensible defaults and those policies
  * should require no modification at all for most use-cases.
  *
- * @since 17.0.0
- * @depreacted 21.0.0 use \OCP\AppFramework\Http\PermissionPolicy
+ * @since 21.0.0
  */
-class FeaturePolicy extends EmptyFeaturePolicy {
+class PermissionPolicy extends EmptyPermissionPolicy {
 	protected $autoplayDomains = [
-		'\'self\'',
+		'self',
 	];
 
 	/** @var string[] of allowed domains that can access the camera */
 	protected $cameraDomains = [];
 
 	protected $fullscreenDomains = [
-		'\'self\'',
+		'self',
 	];
 
 	/** @var string[] of allowed domains that can use the geolocation of the device */

--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -85,6 +85,9 @@ class Response {
 	/** @var FeaturePolicy */
 	private $featurePolicy;
 
+	/** @var PermissionPolicy */
+	private $permissionPolicy;
+
 	/** @var bool */
 	private $throttled = false;
 	/** @var array */
@@ -257,6 +260,7 @@ class Response {
 
 		$this->headers['Content-Security-Policy'] = $this->getContentSecurityPolicy()->buildPolicy();
 		$this->headers['Feature-Policy'] = $this->getFeaturePolicy()->buildPolicy();
+		$this->headers['Permissions-Policy'] = $this->getPermissionPolicy()->buildPolicy();
 		$this->headers['X-Robots-Tag'] = 'noindex, nofollow';
 
 		if ($this->ETag) {
@@ -316,6 +320,7 @@ class Response {
 
 	/**
 	 * @since 17.0.0
+	 * @depreacted 28.0.0 Use getPermissionPolicy
 	 */
 	public function getFeaturePolicy(): EmptyFeaturePolicy {
 		if ($this->featurePolicy === null) {
@@ -326,9 +331,30 @@ class Response {
 
 	/**
 	 * @since 17.0.0
+	 * @depreacted 28.0.0 Use setPermissionPolicy
 	 */
 	public function setFeaturePolicy(EmptyFeaturePolicy $featurePolicy): self {
 		$this->featurePolicy = $featurePolicy;
+
+		return $this;
+	}
+
+	/**
+	 * @since 28.0.0
+	 */
+	public function getPermissionPolicy(): EmptyPermissionPolicy {
+		if ($this->permissionPolicy === null) {
+			$this->setPermissionPolicy(new EmptyPermissionPolicy());
+		}
+		return $this->permissionPolicy;
+	}
+
+	/**
+	 * @since 17.0.0
+	 * @depreacted 28.0.0 Use setPermissionPolicy
+	 */
+	public function setPermissionPolicy(EmptyPermissionPolicy $permissionPolicy): self {
+		$this->permissionPolicy = $permissionPolicy;
 
 		return $this;
 	}

--- a/lib/public/AppFramework/Http/TemplateResponse.php
+++ b/lib/public/AppFramework/Http/TemplateResponse.php
@@ -111,6 +111,7 @@ class TemplateResponse extends Response {
 
 		$this->setContentSecurityPolicy(new ContentSecurityPolicy());
 		$this->setFeaturePolicy(new FeaturePolicy());
+		$this->setPermissionPolicy(new PermissionPolicy());
 	}
 
 

--- a/lib/public/Security/FeaturePolicy/AddFeaturePolicyEvent.php
+++ b/lib/public/Security/FeaturePolicy/AddFeaturePolicyEvent.php
@@ -35,7 +35,7 @@ use OCP\EventDispatcher\Event;
  * Event that allows to register a feature policy header to a request.
  *
  * @since 17.0.0
- * @depreacted 21.0.0 use AddPermissionPolicyEvent
+ * @deprecated  28.0.0 use AddPermissionPolicyEvent
  */
 class AddFeaturePolicyEvent extends Event {
 	/** @var FeaturePolicyManager */
@@ -43,7 +43,7 @@ class AddFeaturePolicyEvent extends Event {
 
 	/**
 	 * @since 17.0.0
-	 * @depreacted 21.0.0 use AddPermissionPolicyEvent
+	 * @deprecated 28.0.0 use AddPermissionPolicyEvent
 	 */
 	public function __construct(FeaturePolicyManager $policyManager) {
 		parent::__construct();

--- a/lib/public/Security/PermissionsPolicy/AddPermissionsPolicyEvent.php
+++ b/lib/public/Security/PermissionsPolicy/AddPermissionsPolicyEvent.php
@@ -32,7 +32,7 @@ use OCP\EventDispatcher\Event;
 /**
  * Event that allows to register a feature policy header to a request.
  *
- * @since 21.0.0
+ * @since 28.0.0
  */
 class AddPermissionsPolicyEvent extends Event {
 
@@ -40,7 +40,7 @@ class AddPermissionsPolicyEvent extends Event {
 	private $policyManager;
 
 	/**
-	 * @since 21.0.0
+	 * @since 28.0.0
 	 */
 	public function __construct(PermissionPolicyManager $policyManager) {
 		parent::__construct();
@@ -48,7 +48,7 @@ class AddPermissionsPolicyEvent extends Event {
 	}
 
 	/**
-	 * @since 21.0.0
+	 * @since 28.0.0
 	 */
 	public function addPolicy(EmptyPermissionPolicy $policy) {
 		$this->policyManager->addDefaultPolicy($policy);

--- a/lib/public/Security/PermissionsPolicy/AddPermissionsPolicyEvent.php
+++ b/lib/public/Security/PermissionsPolicy/AddPermissionsPolicyEvent.php
@@ -1,12 +1,9 @@
 <?php
 
 declare(strict_types=1);
-
 /**
- * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ * @copyright Copyright (c) 2020, Roeland Jago Douma <roeland@famdouma.nl>
  *
- * @author Christoph Wurst <christoph@winzerhof-wurst.at>
- * @author Morris Jobke <hey@morrisjobke.de>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  *
  * @license GNU AGPL version 3 or any later version
@@ -18,43 +15,42 @@ declare(strict_types=1);
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-namespace OCP\Security\FeaturePolicy;
 
-use OC\Security\FeaturePolicy\FeaturePolicyManager;
-use OCP\AppFramework\Http\EmptyFeaturePolicy;
+namespace OCP\Security\PermissionPolicy;
+
+use OC\Security\PermissionPolicy\PermissionPolicyManager;
+use OCP\AppFramework\Http\EmptyPermissionPolicy;
 use OCP\EventDispatcher\Event;
 
 /**
  * Event that allows to register a feature policy header to a request.
  *
- * @since 17.0.0
- * @depreacted 21.0.0 use AddPermissionPolicyEvent
+ * @since 21.0.0
  */
-class AddFeaturePolicyEvent extends Event {
-	/** @var FeaturePolicyManager */
+class AddPermissionsPolicyEvent extends Event {
+
+	/** @var PermissionPolicyManager */
 	private $policyManager;
 
 	/**
-	 * @since 17.0.0
-	 * @depreacted 21.0.0 use AddPermissionPolicyEvent
+	 * @since 21.0.0
 	 */
-	public function __construct(FeaturePolicyManager $policyManager) {
+	public function __construct(PermissionPolicyManager $policyManager) {
 		parent::__construct();
 		$this->policyManager = $policyManager;
 	}
 
 	/**
-	 * @since 17.0.0
-	 * @depreacted 21.0.0 use AddPermissionPolicyEvent
+	 * @since 21.0.0
 	 */
-	public function addPolicy(EmptyFeaturePolicy $policy) {
+	public function addPolicy(EmptyPermissionPolicy $policy) {
 		$this->policyManager->addDefaultPolicy($policy);
 	}
 }


### PR DESCRIPTION
We already had the FeaturePolicy header. However this call got renamed
to PermisionPolicy. Here we move this over. The old mechanism stays
there it just won't get extended. So apps that use the FeaturePolicy
will not stop to work.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>

Fixes #22792