### PR TITLE
Allow user to run console if he can write config via group membership

### DIFF
--- a/console.php
+++ b/console.php
@@ -65,15 +65,15 @@ try {
 		exit(1);
 	}
 	$user = posix_getpwuid(posix_getuid());
-	$configUser = posix_getpwuid(fileowner(OC::$configDir . 'config.php'));
-	$configGroup = posix_getgrgid(filegroup(OC::$configDir . 'config.php'));
-	$perms = fileperms(OC::$configDir . 'config.php');
+	$configUser = posix_getpwuid(fileowner(OC::$configDir.'config.php'));
+	$configGroup = posix_getgrgid(filegroup(OC::$configDir.'config.php'));
+	$perms = fileperms(OC::$configDir.'config.php');
 	/*
-	 * Ok to run if either:
+	 * Ok to run console if either:
 	 *      - the user owns the config file
 	 *      - the main user group or one of his groups is the group of the file AND the file is group writable
 	 */
-	if ( ($user['name'] !== $configUser['name']) && ( !((in_array($user['name'],$configGroup['members']) || $user['gid'] == $configGroup['gid']) && ($perms & 0x0010)) )  ) { 
+	if (($user['name'] !== $configUser['name']) && (!((in_array($user['name'],$configGroup['members']) || $user['gid'] == $configGroup['gid']) && ($perms & 0x0010)))) {
 		echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
 		echo "or who can write it via group membership." . PHP_EOL;
 		echo "Current user id: " . $user . PHP_EOL;

--- a/console.php
+++ b/console.php
@@ -64,10 +64,18 @@ try {
 		echo "The posix extensions are required - see http://php.net/manual/en/book.posix.php" . PHP_EOL;
 		exit(1);
 	}
-	$user = posix_getuid();
-	$configUser = fileowner(OC::$configDir . 'config.php');
-	if ($user !== $configUser) {
+	$user = posix_getpwuid(posix_getuid());
+	$configUser = posix_getpwuid(fileowner(OC::$configDir . 'config.php'));
+	$configGroup = posix_getgrgid(filegroup(OC::$configDir . 'config.php'));
+	$perms = fileperms(OC::$configDir . 'config.php');
+	/*
+	 * Ok to run if either:
+	 *      - the user owns the config file
+	 *      - the main user group or one of his groups is the group of the file AND the file is group writable
+	 */
+	if ( ($user['name'] !== $configUser['name']) && ( !((in_array($user['name'],$configGroup['members']) || $user['gid'] == $configGroup['gid']) && ($perms & 0x0010)) )  ) { 
 		echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
+		echo "or who can write it via group membership." . PHP_EOL;
 		echo "Current user id: " . $user . PHP_EOL;
 		echo "Owner id of config.php: " . $configUser . PHP_EOL;
 		echo "Try adding 'sudo -u #" . $configUser . "' to the beginning of the command (without the single quotes)" . PHP_EOL;


### PR DESCRIPTION
Hello,

If the web server is set up to tighten security with a different user for web server process and ssh user activities either the web server will have access to the config file through group membership or (reverse case) the logged user will have access to the config file through group membership.

This PR deals with the case of www-data owning the file and the logged-in user being able to read/write it through group membership.

Kind regards,
PVI