### PR TITLE
Move localecache to array

### DIFF
--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -37,7 +37,6 @@
 
 namespace OC\L10N;
 
-use Ds\Set;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IUser;
@@ -65,9 +64,9 @@ class Factory implements IFactory {
 	protected $availableLanguages = [];
 
 	/**
-	 * @var Set
+	 * @var array
 	 */
-	protected $localeCache;
+	protected $localeCache = [];
 
 	/**
 	 * @var array
@@ -110,7 +109,6 @@ class Factory implements IFactory {
 		$this->request = $request;
 		$this->userSession = $userSession;
 		$this->serverRoot = $serverRoot;
-		$this->localeCache = new Set();
 	}
 
 	/**
@@ -398,14 +396,14 @@ class Factory implements IFactory {
 			return true;
 		}
 
-		if ($this->localeCache->isEmpty()) {
+		if ($this->localeCache === []) {
 			$locales = $this->findAvailableLocales();
 			foreach ($locales as $l) {
-				$this->localeCache->add($l['code']);
+				$this->localeCache[$l['code']] = true;
 			}
 		}
 
-		return $this->localeCache->contains($locale);
+		return isset($this->localeCache[$locale]);
 	}
 
 	/**


### PR DESCRIPTION
It seems the DS Set in the polyfill implementation is a lot less
efficient than normal arrays. (A LOT!).
So for now use a stupid normal array.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>