### PR TITLE
Replace prefix in executeUpdate

### DIFF
--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -219,6 +219,9 @@ class Connection extends ReconnectWrapper implements IDBConnection {
 	}
 
 	public function executeUpdate($sql, array $params = [], array $types = []) {
+		$sql = $this->replaceTablePrefix($sql);
+		$sql = $this->adapter->fixupStatement($sql);
+		$this->queriesExecuted++;
 		return parent::executeUpdate($sql, $params, $types);
 	}
 


### PR DESCRIPTION
Follow up to https://github.com/nextcloud/server/pull/23764

Otherwise the prefix will not be replaced when executeUpdate is called, causing the following exception when doing a fresh installation (with sqlite):

```
Error while trying to initialise the database: An exception occurred while executing 'INSERT INTO `*PREFIX*migrations` (`app`,`version`) SELECT ?,? WHERE NOT EXISTS (SELECT 1 FROM `*PREFIX*migrations` WHERE `app` = ? AND `version` = ?)' with params ["core", "13000Date20170705121758", "core", "13000Date20170705121758"]: SQLSTATE[HY000]: General error: 1 no such table: *PREFIX*migrations 
```