### PR TITLE
only filter submounts for fileinfo on demand

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1400,12 +1400,9 @@ class View {
 			if ($data and isset($data['fileid'])) {
 				if ($includeMountPoints and $data['mimetype'] === 'httpd/unix-directory') {
 					//add the sizes of other mount points to the folder
-					$extOnly = ($includeMountPoints === 'ext');
+					$info->setIncludeShareSubMounts($includeMountPoints !== 'ext');
 					$mounts = Filesystem::getMountManager()->findIn($path);
-					$info->setSubMounts(array_filter($mounts, function (IMountPoint $mount) use ($extOnly) {
-						$subStorage = $mount->getStorage();
-						return !($extOnly && $subStorage instanceof \OCA\Files_Sharing\SharedStorage);
-					}));
+					$info->setSubMounts($mounts);
 				}
 			}
 


### PR DESCRIPTION
this removes the need to always setup all the sub storages when getting a folder info

Signed-off-by: Robin Appelman <robin@icewind.nl>