### PR TITLE
Do not emit UserCreatedEvent twice

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -540,10 +540,6 @@ class Server extends ServerContainer implements IServerContainer {
 			$userSession->listen('\OC\User', 'postCreateUser', function ($user, $password) {
 				/** @var \OC\User\User $user */
 				\OC_Hook::emit('OC_User', 'post_createUser', ['uid' => $user->getUID(), 'password' => $password]);
-
-				/** @var IEventDispatcher $dispatcher */
-				$dispatcher = $this->get(IEventDispatcher::class);
-				$dispatcher->dispatchTyped(new UserCreatedEvent($user, $password));
 			});
 			$userSession->listen('\OC\User', 'preDelete', function ($user) use ($legacyDispatcher) {
 				/** @var \OC\User\User $user */

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -223,7 +223,6 @@ use OCP\User\Events\BeforeUserLoggedOutEvent;
 use OCP\User\Events\PasswordUpdatedEvent;
 use OCP\User\Events\PostLoginEvent;
 use OCP\User\Events\UserChangedEvent;
-use OCP\User\Events\UserCreatedEvent;
 use OCP\User\Events\UserDeletedEvent;
 use OCP\User\Events\UserLoggedInEvent;
 use OCP\User\Events\UserLoggedInWithCookieEvent;


### PR DESCRIPTION
no more translation from postCreateUser hook to UserCreatedEvent anymore, as event is already emitted in user manager

Fixes https://github.com/nextcloud/server/issues/23797