### PR TITLE
Shortcut to avoid file system setup when generating the logo URL

### DIFF
--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -225,11 +225,20 @@ class ThemingDefaults extends \OC_Defaults {
 	public function getLogo($useSvg = true): string {
 		$logo = $this->config->getAppValue('theming', 'logoMime', false);
 
-		$logoExists = true;
-		try {
-			$this->imageManager->getImage('logo', $useSvg);
-		} catch (\Exception $e) {
-			$logoExists = false;
+		// short cut to avoid setting up the filesystem just to check if the logo is there
+		//
+		// explanation: if an SVG is requested and the app config value for logoMime is set then the logo is there.
+		// otherwise we need to check it and maybe also generate a PNG from the SVG (that's done in getImage() which
+		// needs to be called then)
+		if ($useSvg === true && $logo !== false) {
+			$logoExists = true;
+		} else {
+			try {
+				$this->imageManager->getImage('logo', $useSvg);
+				$logoExists = true;
+			} catch (\Exception $e) {
+				$logoExists = false;
+			}
 		}
 
 		$cacheBusterCounter = $this->config->getAppValue('theming', 'cachebuster', '0');

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -40,7 +40,6 @@ use OCA\Theming\Util;
 use OCP\App\IAppManager;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
-use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -617,11 +616,6 @@ class ThemingDefaultsTest extends TestCase {
 	}
 
 	public function testGetLogoCustom() {
-		$file = $this->createMock(ISimpleFile::class);
-		$this->imageManager->expects($this->once())
-			->method('getImage')
-			->with('logo')
-			->willReturn($file);
 		$this->config
 			->expects($this->at(0))
 			->method('getAppValue')


### PR DESCRIPTION
If an SVG is requested and the app config value for logoMime is set then the logo is there. Otherwise we need to check it and maybe also generate a PNG from the SVG (that's done in getImage() which needs to be called then).


