### PR TITLE
Move help to separate stylesheet

### DIFF
--- a/apps/settings/css/help.css
+++ b/apps/settings/css/help.css
@@ -1,0 +1,12 @@
+.help-includes {
+	overflow: hidden !important;
+}
+
+.help-iframe {
+	width: 100%;
+	height: 100%;
+	margin: 0;
+	padding: 0;
+	border: 0;
+	overflow: auto;
+}

--- a/apps/settings/css/settings.scss
+++ b/apps/settings/css/settings.scss
@@ -1353,20 +1353,6 @@ doesnotexist:-o-prefocus, .strengthify-wrapper {
 	font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 }
 
-/* HELP */
-.help-includes {
-	overflow: hidden !important;
-}
-
-.help-iframe {
-	width: 100%;
-	height: 100%;
-	margin: 0;
-	padding: 0;
-	border: 0;
-	overflow: auto;
-}
-
 #postsetupchecks {
 	ul {
 		margin-left: 44px;

--- a/apps/settings/templates/help.php
+++ b/apps/settings/templates/help.php
@@ -1,5 +1,5 @@
 <?php
-\OC_Util::addStyle('settings', "settings");
+\OC_Util::addStyle('settings', 'help');
 ?>
 <div id="app-navigation">
 	<ul>


### PR DESCRIPTION
settings.scss is a beast so this pr moves the help styling out to a small dedicated stylesheet in order to fix #23236 so we have a clean set of styles that are actually relevant here and we can reuse our default body styling. Otherwise we cannot apply the global settings fallback applied with https://github.com/nextcloud/server/pull/22999 to work around https://github.com/nextcloud/nextcloud-vue/issues/1384#issuecomment-690892427

Fixes #23236