### PR TITLE
Simplify the check if admin can change password based on encryption status

### DIFF
--- a/apps/settings/lib/Controller/UsersController.php
+++ b/apps/settings/lib/Controller/UsersController.php
@@ -318,10 +318,8 @@ class UsersController extends Controller {
 			$noUserSpecificEncryptionKeys = true;
 			$isEncryptionModuleLoaded = false;
 		}
-
-		$canChangePassword = ($isEncryptionEnabled && $isEncryptionModuleLoaded && $noUserSpecificEncryptionKeys)
-			|| (!$isEncryptionEnabled && !$isEncryptionModuleLoaded)
-			|| (!$isEncryptionEnabled && $isEncryptionModuleLoaded && $noUserSpecificEncryptionKeys);
+		$canChangePassword = ($isEncryptionModuleLoaded && $noUserSpecificEncryptionKeys)
+			|| (!$isEncryptionModuleLoaded && !$isEncryptionEnabled);
 
 		return $canChangePassword;
 	}


### PR DESCRIPTION
Simplify the check if admin can change password based on encryption status
    
Found by Psalm:
```
/home/runner/work/server/server/apps/settings/lib/Controller/UsersController.php:324:8:error - RedundantCondition: Type true for $isEncryptionModuleLoaded is never falsy
```

<details>

<summary>Old and wrong initial comment</summary>

Was initially added in #23857 by @schiessle 

Found by Psalm:
```
/home/runner/work/server/server/apps/settings/lib/Controller/UsersController.php:324:8:error - RedundantCondition: Type true for $isEncryptionModuleLoaded is never falsy
```

This is basically a simplification of the logical statement there. The PHPDoc comment "encryption is enabled, encryption module is loaded and it uses per-user keys" was code-wise not true and therefore is removed here.

This may needs a verification by @schiessle because comment and code were not aligned.

Let me explain some simplifications:

If you look at the old code:

```php
$canChangePassword = ($isEncryptionEnabled && $isEncryptionModuleLoaded && $noUserSpecificEncryptionKeys)
			|| (!$isEncryptionEnabled && !$isEncryptionModuleLoaded)
			|| (!$isEncryptionEnabled && $isEncryptionModuleLoaded && $noUserSpecificEncryptionKeys);
```

If you check the first and the last line you notice that it's exactly the same except that `$isEncryptionEnabled` is negated. Therefore they can be combined into `$isEncryptionModuleLoaded && $noUserSpecificEncryptionKeys`.

```php
try {
	$noUserSpecificEncryptionKeys = !$this->encryptionManager->getEncryptionModule()->needDetailedAccessList();
	$isEncryptionModuleLoaded = true;
} catch (ModuleDoesNotExistsException $e) {
	$noUserSpecificEncryptionKeys = true;
	$isEncryptionModuleLoaded = false;
}

$canChangePassword = ($isEncryptionModuleLoaded && $noUserSpecificEncryptionKeys)
			|| (!$isEncryptionEnabled && !$isEncryptionModuleLoaded);
```

For the try block the first part would depend on `$noUserSpecificEncryptionKeys` and the second part would be `false`.

And for the catch block the first part of the statement would be `false` and the second part only depends on the `!$isEncryptionEnabled`.

This then would lead to:

```php

$canChangePassword = $noUserSpecificEncryptionKeys
			|| !$isEncryptionEnabled;
```

And that latter part is what Psalm found out. 🤯 🤯 🤯 🤯 🤯 🤯 

```
RedundantCondition: Type true for $isEncryptionModuleLoaded is never falsy
```

All in all it boils down to be able to allow password changes when encryption is not enabled or check for user specific encryption keys and if they are not available or the exception is thrown the password can be changed as well.

This is what this quite complex change here does.

I will dedicate this PR description to @danxuliu and @PVince81 because they write quite often those exhaustive descriptions for their PRs. 🙏

</details>