### PR TITLE
Bearer must be in the start of the auth header

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -814,15 +814,15 @@ class Session implements IUserSession, Emitter {
 	 */
 	public function tryTokenLogin(IRequest $request) {
 		$authHeader = $request->getHeader('Authorization');
-		if (strpos($authHeader, 'Bearer ') === false) {
+		if (strpos($authHeader, 'Bearer ') === 0) {
+			$token = substr($authHeader, 7);
+		} else {
 			// No auth header, let's try session id
 			try {
 				$token = $this->session->getId();
 			} catch (SessionNotAvailableException $ex) {
 				return false;
 			}
-		} else {
-			$token = substr($authHeader, 7);
 		}
 
 		if (!$this->loginWithToken($token)) {


### PR DESCRIPTION
Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>