### PR TITLE
Fix greatest/least order for oracle

### DIFF
--- a/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
@@ -27,6 +27,9 @@ namespace OC\DB\QueryBuilder\FunctionBuilder;
 use OC\DB\QueryBuilder\QueryFunction;
 use OC\DB\QueryBuilder\QuoteHelper;
 use OCP\DB\QueryBuilder\IFunctionBuilder;
+use OCP\DB\QueryBuilder\ILiteral;
+use OCP\DB\QueryBuilder\IParameter;
+use OCP\DB\QueryBuilder\IQueryFunction;
 
 class FunctionBuilder implements IFunctionBuilder {
 	/** @var QuoteHelper */
@@ -87,10 +90,20 @@ class FunctionBuilder implements IFunctionBuilder {
 		return new QueryFunction('MIN(' . $this->helper->quoteColumnName($field) . ')');
 	}
 
+	/**
+	 * @param string|ILiteral|IParameter|IQueryFunction $x
+	 * @param string|ILiteral|IParameter|IQueryFunction $y
+	 * @return IQueryFunction
+	 */
 	public function greatest($x, $y) {
 		return new QueryFunction('GREATEST(' . $this->helper->quoteColumnName($x) . ', ' . $this->helper->quoteColumnName($y) . ')');
 	}
 
+	/**
+	 * @param string|ILiteral|IParameter|IQueryFunction $x
+	 * @param string|ILiteral|IParameter|IQueryFunction $y
+	 * @return IQueryFunction
+	 */
 	public function least($x, $y) {
 		return new QueryFunction('LEAST(' . $this->helper->quoteColumnName($x) . ', ' . $this->helper->quoteColumnName($y) . ')');
 	}

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
@@ -24,9 +24,52 @@
 namespace OC\DB\QueryBuilder\FunctionBuilder;
 
 use OC\DB\QueryBuilder\QueryFunction;
+use OCP\DB\QueryBuilder\ILiteral;
+use OCP\DB\QueryBuilder\IParameter;
+use OCP\DB\QueryBuilder\IQueryFunction;
 
 class OCIFunctionBuilder extends FunctionBuilder {
 	public function md5($input) {
 		return new QueryFunction('LOWER(DBMS_OBFUSCATION_TOOLKIT.md5 (input => UTL_RAW.cast_to_raw(' . $this->helper->quoteColumnName($input) .')))');
+	}
+
+	/**
+	 * As per https://docs.oracle.com/cd/B19306_01/server.102/b14200/functions060.htm
+	 * Oracle uses the first value to cast the rest or the values. So when the
+	 * first value is a literal, plain value or column, instead of doing the
+	 * math, it will cast the expression to int and continue with a "0". So when
+	 * the second parameter is a function or column, we have to put that as
+	 * first parameter.
+	 *
+	 * @param string|ILiteral|IParameter|IQueryFunction $x
+	 * @param string|ILiteral|IParameter|IQueryFunction $y
+	 * @return QueryFunction
+	 */
+	public function greatest($x, $y) {
+		if (is_string($y) || $y instanceof IQueryFunction) {
+			return parent::greatest($y, $x);
+		}
+
+		return parent::greatest($x, $y);
+	}
+
+	/**
+	 * As per https://docs.oracle.com/cd/B19306_01/server.102/b14200/functions060.htm
+	 * Oracle uses the first value to cast the rest or the values. So when the
+	 * first value is a literal, plain value or column, instead of doing the
+	 * math, it will cast the expression to int and continue with a "0". So when
+	 * the second parameter is a function or column, we have to put that as
+	 * first parameter.
+	 *
+	 * @param string|ILiteral|IParameter|IQueryFunction $x
+	 * @param string|ILiteral|IParameter|IQueryFunction $y
+	 * @return QueryFunction
+	 */
+	public function least($x, $y) {
+		if (is_string($y) || $y instanceof IQueryFunction) {
+			return parent::least($y, $x);
+		}
+
+		return parent::least($x, $y);
 	}
 }

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
@@ -43,7 +43,7 @@ class OCIFunctionBuilder extends FunctionBuilder {
 	 *
 	 * @param string|ILiteral|IParameter|IQueryFunction $x
 	 * @param string|ILiteral|IParameter|IQueryFunction $y
-	 * @return QueryFunction
+	 * @return IQueryFunction
 	 */
 	public function greatest($x, $y) {
 		if (is_string($y) || $y instanceof IQueryFunction) {
@@ -63,7 +63,7 @@ class OCIFunctionBuilder extends FunctionBuilder {
 	 *
 	 * @param string|ILiteral|IParameter|IQueryFunction $x
 	 * @param string|ILiteral|IParameter|IQueryFunction $y
-	 * @return QueryFunction
+	 * @return IQueryFunction
 	 */
 	public function least($x, $y) {
 		if (is_string($y) || $y instanceof IQueryFunction) {

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/SqliteFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/SqliteFunctionBuilder.php
@@ -25,16 +25,29 @@
 namespace OC\DB\QueryBuilder\FunctionBuilder;
 
 use OC\DB\QueryBuilder\QueryFunction;
+use OCP\DB\QueryBuilder\ILiteral;
+use OCP\DB\QueryBuilder\IParameter;
+use OCP\DB\QueryBuilder\IQueryFunction;
 
 class SqliteFunctionBuilder extends FunctionBuilder {
 	public function concat($x, $y) {
 		return new QueryFunction('(' . $this->helper->quoteColumnName($x) . ' || ' . $this->helper->quoteColumnName($y) . ')');
 	}
 
+	/**
+	 * @param string|ILiteral|IParameter|IQueryFunction $x
+	 * @param string|ILiteral|IParameter|IQueryFunction $y
+	 * @return IQueryFunction
+	 */
 	public function greatest($x, $y) {
 		return new QueryFunction('MAX(' . $this->helper->quoteColumnName($x) . ', ' . $this->helper->quoteColumnName($y) . ')');
 	}
 
+	/**
+	 * @param string|ILiteral|IParameter|IQueryFunction $x
+	 * @param string|ILiteral|IParameter|IQueryFunction $y
+	 * @return IQueryFunction
+	 */
 	public function least($x, $y) {
 		return new QueryFunction('MIN(' . $this->helper->quoteColumnName($x) . ', ' . $this->helper->quoteColumnName($y) . ')');
 	}

--- a/lib/private/Files/Cache/Propagator.php
+++ b/lib/private/Files/Cache/Propagator.php
@@ -104,9 +104,9 @@ class Propagator implements IPropagator {
 			$builder = $this->connection->getQueryBuilder();
 			$builder->update('filecache')
 				->set('size', $builder->func()->greatest(
-					$builder->createNamedParameter(-1, IQueryBuilder::PARAM_INT),
-					$builder->func()->add('size', $builder->createNamedParameter($sizeDifference)))
-				)
+					$builder->func()->add('size', $builder->createNamedParameter($sizeDifference)),
+					$builder->createNamedParameter(-1, IQueryBuilder::PARAM_INT)
+				))
 				->where($builder->expr()->eq('storage', $builder->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
 				->andWhere($builder->expr()->in('path_hash', $hashParams))
 				->andWhere($builder->expr()->gt('size', $builder->expr()->literal(-1, IQueryBuilder::PARAM_INT)));

--- a/lib/private/Files/Cache/Propagator.php
+++ b/lib/private/Files/Cache/Propagator.php
@@ -168,7 +168,7 @@ class Propagator implements IPropagator {
 		$storageId = (int)$this->storage->getStorageCache()->getNumericId();
 
 		$query->update('filecache')
-			->set('mtime', $query->createFunction('GREATEST(' . $query->getColumnName('mtime') . ', ' . $query->createParameter('time') . ')'))
+			->set('mtime', $query->func()->greatest('mtime', $query->createParameter('time')))
 			->set('etag', $query->expr()->literal(uniqid()))
 			->where($query->expr()->eq('storage', $query->expr()->literal($storageId, IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->eq('path_hash', $query->createParameter('hash')));

--- a/lib/public/DB/QueryBuilder/IFunctionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IFunctionBuilder.php
@@ -137,9 +137,8 @@ interface IFunctionBuilder {
 	 *
 	 * If you want to get the maximum value of all rows in a column, use `max` instead
 	 *
-	 * @param mixed $x the first input field or number
-	 * @param mixed $y the first input field or number
-	 *
+	 * @param string|ILiteral|IParameter|IQueryFunction $x
+	 * @param string|ILiteral|IParameter|IQueryFunction $y
 	 * @return IQueryFunction
 	 * @since 18.0.0
 	 */
@@ -150,9 +149,8 @@ interface IFunctionBuilder {
 	 *
 	 * If you want to get the minimum value of all rows in a column, use `min` instead
 	 *
-	 * @param mixed $x the first input field or number
-	 * @param mixed $y the first input field or number
-	 *
+	 * @param string|ILiteral|IParameter|IQueryFunction $x
+	 * @param string|ILiteral|IParameter|IQueryFunction $y
 	 * @return IQueryFunction
 	 * @since 18.0.0
 	 */


### PR DESCRIPTION
As per https://docs.oracle.com/cd/B19306_01/server.102/b14200/functions060.htm
Oracle uses the first value to cast the rest or the values. So when the
first value is a literal, plain value or column, instead of doing the
math, it will cast the expression to int and continue with a "0". So when
the second parameter is a function or column, we have to put that as
first parameter.