### PR TITLE
Allow config to specify the bucket exists

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -76,6 +76,7 @@ trait S3ConnectionTrait {
 		if (!isset($params['port']) || $params['port'] === '') {
 			$params['port'] = (isset($params['use_ssl']) && $params['use_ssl'] === false) ? 80 : 443;
 		}
+		$params['verify_bucket_exists'] = empty($params['verify_bucket_exists']) ? true : $params['verify_bucket_exists'];
 		$this->params = $params;
 	}
 
@@ -130,7 +131,7 @@ trait S3ConnectionTrait {
 					 ['app' => 'objectstore']);
 		}
 
-		if (!$this->connection->doesBucketExist($this->bucket)) {
+		if ($this->params['verify_bucket_exists'] && !$this->connection->doesBucketExist($this->bucket)) {
 			$logger = \OC::$server->getLogger();
 			try {
 				$logger->info('Bucket "' . $this->bucket . '" does not exist - creating it.', ['app' => 'objectstore']);


### PR DESCRIPTION
In the 99% case the bucket is just always there. And if it is not the
read/write will fail hard anyways. Esp on big instances the Objectstore
is not always fast and this can save a few hundered ms of each request
that acess the objectstore.

In short it is adding

'verify_bucket_exists' => false

To the S3 config part

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>