### PR TITLE
Avoid SCSS compilation if not needed

### DIFF
--- a/tests/lib/Template/SCSSCacherTest.php
+++ b/tests/lib/Template/SCSSCacherTest.php
@@ -81,6 +81,11 @@ class SCSSCacherTest extends \Test\TestCase {
 			->willReturn('http://localhost/nextcloud');
 
 		$this->config = $this->createMock(IConfig::class);
+		$this->config->expects($this->any())
+			->method('getAppValue')
+			->will($this->returnCallback(function ($appId, $configKey, $defaultValue) {
+				return $defaultValue;
+			}));
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
 		$this->depsCache = $this->createMock(ICache::class);
 		$this->cacheFactory->expects($this->at(0))


### PR DESCRIPTION
Now we do on each template load a compile with the SCSS variables to see
if they changed or not. However there is no real reason for this if the
variables didn't change.

Shaves off around 10-15ms on our company instance per template render.