### PR TITLE
Fix iLike() falsely turning escaped % and _ into wildcards

### DIFF
--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/OCIExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/OCIExpressionBuilder.php
@@ -189,8 +189,6 @@ class OCIExpressionBuilder extends ExpressionBuilder {
 	 * @inheritdoc
 	 */
 	public function iLike($x, $y, $type = null) {
-		$x = $this->helper->quoteColumnName($x);
-		$y = $this->helper->quoteColumnName($y);
-		return new QueryFunction('REGEXP_LIKE(' . $x . ', \'^\' || REPLACE(REPLACE(' . $y . ', \'%\', \'.*\'), \'_\', \'.\') || \'$\', \'i\')');
+		return $this->like($this->functionBuilder->lower($x), $this->functionBuilder->lower($y));
 	}
 }


### PR DESCRIPTION
Otherwise Oracle fails:
https://github.com/nextcloud/server/blob/d9015a8c94bfd71fe484618a06d276701d3bf9ff/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php#L769

As the `_` is not escaped anymore