### PR TITLE
Reduce the getAppPath and autoloader calls

### DIFF
--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -118,9 +118,12 @@ class OC_App {
 
 		// Add each apps' folder as allowed class path
 		foreach ($apps as $app) {
-			$path = self::getAppPath($app);
-			if ($path !== false) {
-				self::registerAutoloading($app, $path);
+			// If the app is already loaded then autoloading it makes no sense
+			if (!isset(self::$loadedApps[$app])) {
+				$path = self::getAppPath($app);
+				if ($path !== false) {
+					self::registerAutoloading($app, $path);
+				}
 			}
 		}
 


### PR DESCRIPTION
The getAppPath will always return the same data for the same appId. It
is actually already cached. However we do some cleanup of the appId
(again). Same for the autoloading it is actually already checked.

This just removes the unneeded calls. Which can add up if you have a lot
of incomming shares.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>