### PR TITLE
First query the server container

### DIFF
--- a/lib/private/ServerContainer.php
+++ b/lib/private/ServerContainer.php
@@ -133,6 +133,12 @@ class ServerContainer extends SimpleContainer {
 	public function query(string $name, bool $autoload = true) {
 		$name = $this->sanitizeName($name);
 
+		try {
+			return parent::query($name, false);
+		} catch (QueryException $e) {
+			// Continue with general autoloading then
+		}
+
 		// In case the service starts with OCA\ we try to find the service in
 		// the apps container first.
 		if (($appContainer = $this->getAppContainerForService($name)) !== null) {


### PR DESCRIPTION
When the servercontainer wants to obtain something changes are very high
this is something from the server container. Esp on setups with a lot of
shares this can change quite a bit as it avoid a needless check on the
strpos OCA\\ etc.

Comparrison obtaining a collabora document info (witrh about 300 incomming shares)
https://blackfire.io/profiles/compare/8d44ae46-82c9-496a-8b9e-be286c68a7ae/graph