### PR TITLE
20.0.2 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [20, 0, 1, 6];
+$OC_Version = [20, 0, 2, 0];
 
 // The human readable string
-$OC_VersionString = '20.0.1';
+$OC_VersionString = '20.0.2 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #23419 Inidicate preview availability in share api responses
* #23563 CalDavBackend: check if timerange is array before accessing
* #23575 Some emojis are in CHAR_CATEGORY_GENERAL_OTHER_TYPES
* #23583 Also expire share type email
* #23611 Only use index of mount point when it is there
* #23633 Only retry fetching app store data once every 5 minutes in case it fails
* #23636 Bring back the restore share button
* #23641 Fix updates of NULL appconfig values
* #23646 Fix sharing input placeholder for emails
* #23690 Use bigint for fileid in filecache_extended
* #23699 Enable theming background transparency
* #23702 Fix sharer flag on ldap:show-remnants when user owned more than a single share
* #23710 Make sure the function signatures of the backgroundjob match
* #23713 Check if array elements exist before using them
* #23726 Fix default quota display value in user row
* #23727 Use lib instead if core as l10n module in OC_Files
* #23732 Specify accept argument to avatar upload input field
* #23733 Save email as lower case
* #23736 Reset avatar cropper before showing
* #23745 Also run the SabreAuthInitEvent for the main server
* #23749 Type the \OCP\IUserManager::callForAllUsers closure with Psalm
* #23751 Type the \OCP\AppFramework\Services\IInitialState::provideLazyInitial…
* #23753 Don't overwrite the event if we use it later
* #23759 Inform the user when flow config data exceeds thresholds
* #23763 Type the \OCP\IUserManager::callForSeenUsers closure with Psalm
* #23774 Catch errors when closing file conflict dialog
* #23779 Document the backend registered events of LDAP
* #23787 Fetch the logger and system config once for all query builder instances
* #23789 Type the event dispatcher listener callables with Psalm
* #23794 Only run phpunit when "php" changed
* #23829 Remove bold font-weight and lower font-size for empty search box
* #23846 No need to check if there is an avatar available, because it is gener…
* #23850 Ensure filepicker list is empty before populating
* #23858 UserStatus: clear status message if message is null
* #23874 Fix grid view toggle in tags view
* #23884 Restrict query when searching for versions of trashbin files
* #23894 Fix potentially passing null to events where IUser is expected
* #23899 Make user status styles scoped
* #23900 Move help to separate stylesheet
* #23902 Add default font size
* #23917 Do not emit UserCreatedEvent twice
* #23924 Bearer must be in the start of the auth header
* #23935 Fix casting of integer and boolean on Oracle
* #23948 Skip already loaded apps in loadApps
* #23950 Fix repair mimetype step to not leave stray cursors
* #23951 Improve query type detection
* #23954 Fix iLike() falsely turning escaped % and _ into wildcards
* #23955 Replace some usages of OC_DB in OC\Share\* with query builder
* #23971 Use query builder instead of OC_DB in trashbin
* #23975 Fix greatest/least order for oracle
* #23992 Fix link share label placeholder not showing
* #23995 Unlock when promoting to exclusive lock fails
* #23996 Make sure root storage is valid before checking its size
* #23998 Use query builder instead of OC_DB in OC\Files\*
* #24001 Shortcut to avoid file system setup when generating the logo URL
* #24004 Remove old legacy scripts references
* #24012 Fix js search in undefined ocs response
* #24033 Don't leave cursors open
* #24044 Fix sharing tab state not matching resharing admin settings
* #24049 Run unit tests against oracle
* #24050 Use png icons in caldav reminder emails
* #24058 Manually iterate over calendardata when oracle is used
* [activity#523](https://github.com/nextcloud/activity/pull/523) Fix activity spinner on empty activity
* [activity#528](https://github.com/nextcloud/activity/pull/528) Add OCI github action
* [files_pdfviewer#257](https://github.com/nextcloud/files_pdfviewer/pull/257) Disable download button by default
* [firstrunwizard#442](https://github.com/nextcloud/firstrunwizard/pull/442) Feat/dependabot ga/stable20
* [notifications#796](https://github.com/nextcloud/notifications/pull/796) Fix loading notifications without a message on oracle
* [text#1105](https://github.com/nextcloud/text/pull/1105) Do not setup appdata in constructor to avoid errors causing the whole instance to stop working
* [text#1164](https://github.com/nextcloud/text/pull/1164) Bump dependencies to version in range
* [text#1166](https://github.com/nextcloud/text/pull/1166) Validate link on click
* [viewer#681](https://github.com/nextcloud/viewer/pull/681) Fix URL escaping of shared files
* [viewer#684](https://github.com/nextcloud/viewer/pull/684) Fix component click outside and cleanup structure