### PR TITLE
18.0.11 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(18, 0, 10, 2);
+$OC_Version = array(18, 0, 11, 0);
 
 // The human readable string
-$OC_VersionString = '18.0.10';
+$OC_VersionString = '18.0.11 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #23204 Fix the user email issue while creating a user
* #23386 Fix adminpass strengthify margin
* #23393 Fix the user remove from group in UI
* #23405 VersioningTest.php:729 is unreliable and should be disabled
* #23423 Contactsmanager shall limit number of results early
* #23437 Use paginated search for contacts + fixes
* #23500 SharedMountTest.php:367 is unreliable
* #23506 Provide log statements for SCSS cache
* #23512 SCSSCacher - Lock should not be removed
* #23516 Clear cached app config while waiting for the SCSSCache lock to return
* #23549 Fix display of remote users in incoming share notifications
* #23557 Update CA bundle to october version
* #23565 CalDavBackend: check if timerange is array before accessing
* #23567 Dont hold a transaction during the move to trash
* #23584 Also expire share type email
* #23625 Disable unreliable app-files.feature:108
* #23626 Disable unreliable app-files-sharing.feature:108
* #23635 Only retry fetching app store data once every 5 minutes in case it fails
* #23638 Bring back the restore share button
* #23643 Fix updates of NULL appconfig values
* #23648 Fix sharing input placeholder for emails
* #23692 Use bigint for fileid in filecache_extended
* #23706 Enable theming background transparency
* #23709 Fix sharer flag on ldap:show-remnants when user owned more than a single share
* #23715 Check if array elements exist before using them
* #23729 Use lib instead if core as l10n module in OC_Files
* #23735 Save email as lower case
* #23756 Harden SSE key generation
* #23761 Inform the user when flow config data exceeds thresholds
* #23796 Only run phpunit when "php" changed
* #23803 Bump lodash from 4.17.15 to 4.17.20
* #23848 No need to check if there is an avatar available, because it is gener…
* #23861 Inidicate preview availability in share api responses
* #23876 Fix grid view toggle in tags view
* #23886 Restrict query when searching for versions of trashbin files
* #23896 Fix potentially passing null to events where IUser is expected
* #23926 Bearer must be in the start of the auth header
* #24006 Remove old legacy scripts references
* #24020 Fix js search in undefined ocs response
* #24046 Fix sharing tab state not matching resharing admin settings
* #24047 Fix iLike() falsely turning escaped % and _ into wildcards
* #24051 Use png icons in caldav reminder emails
* [firstrunwizard#435](https://github.com/nextcloud/firstrunwizard/pull/435) Bump lodash from 4.17.14 to 4.17.20
* [firstrunwizard#440](https://github.com/nextcloud/firstrunwizard/pull/440) Add dependabot-approve-merge
* [photos#512](https://github.com/nextcloud/photos/pull/512) Pass preview availability too
* [recommendations#321](https://github.com/nextcloud/recommendations/pull/321) Bump lodash from 4.17.14 to 4.17.20
* [text#1161](https://github.com/nextcloud/text/pull/1161) Bump dependencies to version in range


Pending PRs:

* [ ] #23169 Add mount point to quota warning message 
* [x] #23953 Improve query type detection 
