### PR TITLE
Remove old legacy scripts references

### DIFF
--- a/core/js/core.json
+++ b/core/js/core.json
@@ -13,7 +13,6 @@
 		"sharedialogshareelistview.js",
 		"public/publicpage.js",
 		"setupchecks.js",
-		"../search/js/search.js",
 		"mimetype.js",
 		"mimetypelist.js"
 	]

--- a/lib/base.php
+++ b/lib/base.php
@@ -371,7 +371,6 @@ class OC {
 
 		$oldTheme = $systemConfig->getValue('theme');
 		$systemConfig->setValue('theme', '');
-		OC_Util::addScript('config'); // needed for web root
 		OC_Util::addScript('update');
 
 		/** @var \OC\App\AppManager $appManager */


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/21235

Bug present since stable16 apparently :shrug: 
Was removed by https://github.com/nextcloud/server/commit/8e9d259074619de0f137d749fc94dd4e580d2ec9 @ChristophWurst 