### PR TITLE
Don't search on storages multiple times

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1644,6 +1644,7 @@ class View {
 		$storage = $mount->getStorage();
 		if ($storage) {
 			$cache = $storage->getCache('');
+			$storagesDone = [$mount->getNumericStorageId()];
 
 			$results = call_user_func_array([$cache, $method], $args);
 			foreach ($results as $result) {
@@ -1658,6 +1659,11 @@ class View {
 
 			$mounts = Filesystem::getMountManager()->findIn($this->fakeRoot);
 			foreach ($mounts as $mount) {
+			    if (in_array($mount->getNumericStorageId(), $storagesDone)) {
+			        continue;
+			    }
+			    $storagesDone[] = $mount->getNumericStorageId();
+			    
 				$mountPoint = $mount->getMountPoint();
 				$storage = $mount->getStorage();
 				if ($storage) {


### PR DESCRIPTION
OC\Files\View::searchCommon will scan all storages the user has (partial) access to. The storages are derived from the mounts, and since there may be multiple mounts originating from the same storage, those storages are scanned multiple times. If this is performed on large storages, the performance impact may be enormous.

This patch will remember storages which are already scanned, and skip execution if a duplicate is detected.

Signed-off-by: Andreas Pflug <dev@admin4.org>