### PR TITLE
Show the full trace of an exception

### DIFF
--- a/core/templates/exception.php
+++ b/core/templates/exception.php
@@ -1,8 +1,24 @@
 <?php
-	/** @var array $_ */
-	/** @var \OCP\IL10N $l */
+/** @var array $_ */
+/** @var \OCP\IL10N $l */
 
 style('core', ['styles', 'header']);
+
+function print_exception(Throwable $e, \OCP\IL10N $l): void {
+	print_unescaped('<pre>');
+	p($e->getTraceAsString());
+	print_unescaped('</pre>');
+
+	if ($e->getPrevious() !== null) {
+		print_unescaped('<br />');
+		print_unescaped('<h4>');
+		p($l->t('Previous'));
+		print_unescaped('</h4>');
+
+		print_exception($e->getPrevious(), $l);
+	}
+}
+
 ?>
 <div class="error error-wide">
 	<h2><?php p($l->t('Internal Server Error')) ?></h2>
@@ -26,6 +42,6 @@ style('core', ['styles', 'header']);
 	<?php if (isset($_['debugMode']) && $_['debugMode'] === true): ?>
 		<br />
 		<h3><?php p($l->t('Trace')) ?></h3>
-		<pre><?php p($_['trace']) ?></pre>
+		<?php print_exception($_['exception'], $l); ?>
 	<?php endif; ?>
 </div>

--- a/lib/private/Template/Base.php
+++ b/lib/private/Template/Base.php
@@ -31,6 +31,7 @@
 namespace OC\Template;
 
 use OCP\Defaults;
+use Throwable;
 
 class Base {
 	private $template; // The template
@@ -92,7 +93,7 @@ class Base {
 	/**
 	 * Assign variables
 	 * @param string $key key
-	 * @param array|bool|integer|string $value value
+	 * @param array|bool|integer|string|Throwable $value value
 	 * @return bool
 	 *
 	 * This function assigns a variable. It can be accessed via $_[$key] in

--- a/lib/private/legacy/OC_Template.php
+++ b/lib/private/legacy/OC_Template.php
@@ -325,7 +325,7 @@ class OC_Template extends \OC\Template\Base {
 			$content->assign('errorCode', $exception->getCode());
 			$content->assign('file', $exception->getFile());
 			$content->assign('line', $exception->getLine());
-			$content->assign('trace', $exception->getTraceAsString());
+			$content->assign('exception', $exception);
 			$content->assign('debugMode', \OC::$server->getSystemConfig()->getValue('debug', false));
 			$content->assign('remoteAddr', $request->getRemoteAddress());
 			$content->assign('requestID', $request->getId());


### PR DESCRIPTION
Because often we catch the exception at some point and then the trace is
misleading. What's really interesting is the trace of the *previous*
exception.

### Before 

![Screenshot_2020-11-10 Nextcloud(1)](https://user-images.githubusercontent.com/1374172/98654165-422b2380-233e-11eb-8589-ca92576b61ac.png)

### After

![Screenshot_2020-11-10 Nextcloud](https://user-images.githubusercontent.com/1374172/98654188-49523180-233e-11eb-8def-5faa9b0b7ebc.png)
