### PR TITLE
Fix default internal expiration date

### DIFF
--- a/build/integration/features/bootstrap/AppConfiguration.php
+++ b/build/integration/features/bootstrap/AppConfiguration.php
@@ -72,6 +72,19 @@ trait AppConfiguration {
 		}
 	}
 
+	/**
+	 * @param string $app
+	 * @param string $parameter
+	 * @param string $value
+	 */
+	protected function deleteServerConfig($app, $parameter) {
+		$this->sendingTo('DELETE', "/apps/testing/api/v1/app/{$app}/{$parameter}");
+		$this->theHTTPStatusCodeShouldBe('200');
+		if ($this->apiVersion === 1) {
+			$this->theOCSStatusCodeShouldBe('100');
+		}
+	}
+
 	protected function setStatusTestingApp($enabled) {
 		$this->sendingTo(($enabled ? 'post' : 'delete'), '/cloud/apps/testing');
 		$this->theHTTPStatusCodeShouldBe('200');

--- a/build/integration/features/bootstrap/CapabilitiesContext.php
+++ b/build/integration/features/bootstrap/CapabilitiesContext.php
@@ -61,16 +61,16 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 	}
 
 	protected function resetAppConfigs() {
-		$this->modifyServerConfig('core', 'shareapi_enabled', 'yes');
-		$this->modifyServerConfig('core', 'shareapi_allow_links', 'yes');
-		$this->modifyServerConfig('core', 'shareapi_allow_public_upload', 'yes');
-		$this->modifyServerConfig('core', 'shareapi_allow_resharing', 'yes');
-		$this->modifyServerConfig('files_sharing', 'outgoing_server2server_share_enabled', 'yes');
-		$this->modifyServerConfig('files_sharing', 'incoming_server2server_share_enabled', 'yes');
-		$this->modifyServerConfig('core', 'shareapi_enforce_links_password', 'no');
-		$this->modifyServerConfig('core', 'shareapi_allow_public_notification', 'no');
-		$this->modifyServerConfig('core', 'shareapi_default_expire_date', 'no');
-		$this->modifyServerConfig('core', 'shareapi_enforce_expire_date', 'no');
-		$this->modifyServerConfig('core', 'shareapi_allow_group_sharing', 'yes');
+		$this->deleteServerConfig('core', 'shareapi_enabled');
+		$this->deleteServerConfig('core', 'shareapi_allow_links');
+		$this->deleteServerConfig('core', 'shareapi_allow_public_upload');
+		$this->deleteServerConfig('core', 'shareapi_allow_resharing');
+		$this->deleteServerConfig('files_sharing', 'outgoing_server2server_share_enabled');
+		$this->deleteServerConfig('files_sharing', 'incoming_server2server_share_enabled');
+		$this->deleteServerConfig('core', 'shareapi_enforce_links_password');
+		$this->deleteServerConfig('core', 'shareapi_allow_public_notification');
+		$this->deleteServerConfig('core', 'shareapi_default_expire_date');
+		$this->deleteServerConfig('core', 'shareapi_enforce_expire_date');
+		$this->deleteServerConfig('core', 'shareapi_allow_group_sharing');
 	}
 }

--- a/build/integration/features/bootstrap/FederationContext.php
+++ b/build/integration/features/bootstrap/FederationContext.php
@@ -97,7 +97,7 @@ class FederationContext implements Context, SnippetAcceptingContext {
 	}
 
 	protected function resetAppConfigs() {
-		$this->modifyServerConfig('files_sharing', 'incoming_server2server_group_share_enabled', 'no');
-		$this->modifyServerConfig('files_sharing', 'outgoing_server2server_group_share_enabled', 'no');
+		$this->deleteServerConfig('files_sharing', 'incoming_server2server_group_share_enabled');
+		$this->deleteServerConfig('files_sharing', 'outgoing_server2server_group_share_enabled');
 	}
 }

--- a/build/integration/features/bootstrap/ShareesContext.php
+++ b/build/integration/features/bootstrap/ShareesContext.php
@@ -36,8 +36,8 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 	use AppConfiguration;
 
 	protected function resetAppConfigs() {
-		$this->modifyServerConfig('core', 'shareapi_only_share_with_group_members', 'no');
-		$this->modifyServerConfig('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes');
-		$this->modifyServerConfig('core', 'shareapi_allow_group_sharing', 'yes');
+		$this->deleteServerConfig('core', 'shareapi_only_share_with_group_members');
+		$this->deleteServerConfig('core', 'shareapi_allow_share_dialog_user_enumeration');
+		$this->deleteServerConfig('core', 'shareapi_allow_group_sharing');
 	}
 }

--- a/build/integration/features/bootstrap/SharingContext.php
+++ b/build/integration/features/bootstrap/SharingContext.php
@@ -38,6 +38,12 @@ class SharingContext implements Context, SnippetAcceptingContext {
 
 	protected function resetAppConfigs() {
 		$this->deleteServerConfig('core', 'shareapi_default_permissions');
+		$this->deleteServerConfig('core', 'shareapi_default_internal_expire_date');
+		$this->deleteServerConfig('core', 'shareapi_internal_expire_after_n_days');
+		$this->deleteServerConfig('core', 'internal_defaultExpDays');
+		$this->deleteServerConfig('core', 'shareapi_default_expire_date');
+		$this->deleteServerConfig('core', 'shareapi_expire_after_n_days');
+		$this->deleteServerConfig('core', 'link_defaultExpDays');
 		$this->deleteServerConfig('sharebymail', 'enforcePasswordProtection');
 	}
 }

--- a/build/integration/features/bootstrap/SharingContext.php
+++ b/build/integration/features/bootstrap/SharingContext.php
@@ -37,7 +37,7 @@ class SharingContext implements Context, SnippetAcceptingContext {
 	use CommandLine;
 
 	protected function resetAppConfigs() {
-		$this->modifyServerConfig('core', 'shareapi_default_permissions', '31');
-		$this->modifyServerConfig('sharebymail', 'enforcePasswordProtection', 'no');
+		$this->deleteServerConfig('core', 'shareapi_default_permissions');
+		$this->deleteServerConfig('sharebymail', 'enforcePasswordProtection');
 	}
 }

--- a/build/integration/sharing_features/sharing-v1.feature
+++ b/build/integration/sharing_features/sharing-v1.feature
@@ -391,6 +391,112 @@ Feature: sharing
     And Share fields of last share match with
       | permissions | 7 |
 
+  Scenario: Creating a new internal share with default expiration date
+    Given user "user0" exists
+    And user "user1" exists
+    And As an "user0"
+    And parameter "shareapi_default_internal_expire_date" of app "core" is set to "yes"
+    And parameter "shareapi_internal_expire_after_n_days" of app "core" is set to "3"
+    When creating a share with
+      | path | welcome.txt |
+      | shareWith | user1 |
+      | shareType | 0 |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And Getting info of last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And Share fields of last share match with
+      | expiration | +3 days |
+
+  Scenario: Creating a new internal share with relaxed default expiration date
+    Given user "user0" exists
+    And user "user1" exists
+    And As an "user0"
+    And parameter "shareapi_default_internal_expire_date" of app "core" is set to "yes"
+    And parameter "shareapi_internal_expire_after_n_days" of app "core" is set to "3"
+    And parameter "internal_defaultExpDays" of app "core" is set to "1"
+    When creating a share with
+      | path | welcome.txt |
+      | shareWith | user1 |
+      | shareType | 0 |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And Getting info of last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And Share fields of last share match with
+      | expiration | +1 days |
+
+  Scenario: Creating a new internal share with relaxed default expiration date too large
+    Given user "user0" exists
+    And user "user1" exists
+    And As an "user0"
+    And parameter "shareapi_default_internal_expire_date" of app "core" is set to "yes"
+    And parameter "shareapi_internal_expire_after_n_days" of app "core" is set to "3"
+    And parameter "internal_defaultExpDays" of app "core" is set to "10"
+    When creating a share with
+      | path | welcome.txt |
+      | shareWith | user1 |
+      | shareType | 0 |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And Getting info of last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And Share fields of last share match with
+      | expiration | +3 days |
+
+  Scenario: Creating a new link share with default expiration date
+    Given user "user0" exists
+    And As an "user0"
+    And parameter "shareapi_default_expire_date" of app "core" is set to "yes"
+    And parameter "shareapi_expire_after_n_days" of app "core" is set to "3"
+    When creating a share with
+      | path | welcome.txt |
+      | shareType | 3 |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And Getting info of last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And Share fields of last share match with
+      | expiration | +3 days |
+
+  Scenario: Creating a new link share with relaxed default expiration date
+    Given user "user0" exists
+    And As an "user0"
+    And parameter "shareapi_default_expire_date" of app "core" is set to "yes"
+    And parameter "shareapi_expire_after_n_days" of app "core" is set to "3"
+    And parameter "link_defaultExpDays" of app "core" is set to "1"
+    When creating a share with
+      | path | welcome.txt |
+      | shareType | 3 |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And Getting info of last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And Share fields of last share match with
+      | expiration | +1 days |
+
+  Scenario: Creating a new link share with relaxed default expiration date too large
+    Given user "user0" exists
+    And As an "user0"
+    And parameter "shareapi_default_expire_date" of app "core" is set to "yes"
+    And parameter "shareapi_expire_after_n_days" of app "core" is set to "3"
+    And parameter "link_defaultExpDays" of app "core" is set to "10"
+    When creating a share with
+      | path | welcome.txt |
+      | shareType | 3 |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And Getting info of last share
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And Share fields of last share match with
+      | expiration | +3 days |
+
   Scenario: getting all shares of a user using that user
     Given user "user0" exists
     And user "user1" exists

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -408,9 +408,9 @@ class Manager implements IManager {
 			$expirationDate = new \DateTime();
 			$expirationDate->setTime(0,0,0);
 
-			$days = (int)$this->config->getAppValue('core', 'internal_defaultExpDays', $this->shareApiLinkDefaultExpireDays());
-			if ($days > $this->shareApiLinkDefaultExpireDays()) {
-				$days = $this->shareApiLinkDefaultExpireDays();
+			$days = (int)$this->config->getAppValue('core', 'internal_defaultExpDays', (string)$this->shareApiInternalDefaultExpireDays());
+			if ($days > $this->shareApiInternalDefaultExpireDays()) {
+				$days = $this->shareApiInternalDefaultExpireDays();
 			}
 			$expirationDate->add(new \DateInterval('P'.$days.'D'));
 		}

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -833,6 +833,27 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertEquals($expected, $share->getExpirationDate());
 	}
 
+	public function testValidateExpirationDateEnforceRelaxedDefaultButNotSetNewShare() {
+		$share = $this->manager->newShare();
+
+		$this->config->method('getAppValue')
+			->willReturnMap([
+				['core', 'shareapi_enforce_expire_date', 'no', 'yes'],
+				['core', 'shareapi_expire_after_n_days', '7', '3'],
+				['core', 'shareapi_default_expire_date', 'no', 'yes'],
+				['core', 'link_defaultExpDays', 3, '1'],
+			]);
+
+		$expected = new \DateTime();
+		$expected->setTime(0,0,0);
+		$expected->add(new \DateInterval('P1D'));
+
+		self::invokePrivate($this->manager, 'validateExpirationDate', [$share]);
+
+		$this->assertNotNull($share->getExpirationDate());
+		$this->assertEquals($expected, $share->getExpirationDate());
+	}
+
 	public function testValidateExpirationDateEnforceTooFarIntoFuture() {
 		$future = new \DateTime();
 		$future->add(new \DateInterval('P7D'));

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -834,7 +834,6 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	public function testValidateExpirationDateEnforceTooFarIntoFuture() {
-		// Expire date in the past
 		$future = new \DateTime();
 		$future->add(new \DateInterval('P7D'));
 
@@ -858,7 +857,6 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	public function testValidateExpirationDateEnforceValid() {
-		// Expire date in the past
 		$future = new \DateTime();
 		$future->add(new \DateInterval('P2D'));
 		$future->setTime(0,0,0);

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -768,7 +768,7 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 
-	public function testvalidateExpirationDateInPast() {
+	public function testValidateExpirationDateInPast() {
 		$this->expectException(\OCP\Share\Exceptions\GenericShareException::class);
 		$this->expectExceptionMessage('Expiration date is in the past');
 
@@ -784,7 +784,7 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 
-	public function testvalidateExpirationDateEnforceButNotSet() {
+	public function testValidateExpirationDateEnforceButNotSet() {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Expiration date is enforced');
 
@@ -800,7 +800,7 @@ class ManagerTest extends \Test\TestCase {
 		self::invokePrivate($this->manager, 'validateExpirationDate', [$share]);
 	}
 
-	public function testvalidateExpirationDateEnforceButNotEnabledAndNotSet() {
+	public function testValidateExpirationDateEnforceButNotEnabledAndNotSet() {
 		$share = $this->manager->newShare();
 		$share->setProviderId('foo')->setId('bar');
 
@@ -814,7 +814,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertNull($share->getExpirationDate());
 	}
 
-	public function testvalidateExpirationDateEnforceButNotSetNewShare() {
+	public function testValidateExpirationDateEnforceButNotSetNewShare() {
 		$share = $this->manager->newShare();
 
 		$this->config->method('getAppValue')
@@ -835,7 +835,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertEquals($expected, $share->getExpirationDate());
 	}
 
-	public function testvalidateExpirationDateEnforceToFarIntoFuture() {
+	public function testValidateExpirationDateEnforceTooFarIntoFuture() {
 		// Expire date in the past
 		$future = new \DateTime();
 		$future->add(new \DateInterval('P7D'));
@@ -859,7 +859,7 @@ class ManagerTest extends \Test\TestCase {
 		}
 	}
 
-	public function testvalidateExpirationDateEnforceValid() {
+	public function testValidateExpirationDateEnforceValid() {
 		// Expire date in the past
 		$future = new \DateTime();
 		$future->add(new \DateInterval('P2D'));
@@ -888,7 +888,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertEquals($expected, $share->getExpirationDate());
 	}
 
-	public function testvalidateExpirationDateNoDateNoDefaultNull() {
+	public function testValidateExpirationDateNoDateNoDefaultNull() {
 		$date = new \DateTime();
 		$date->add(new \DateInterval('P5D'));
 
@@ -909,7 +909,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertEquals($expected, $share->getExpirationDate());
 	}
 
-	public function testvalidateExpirationDateNoDateNoDefault() {
+	public function testValidateExpirationDateNoDateNoDefault() {
 		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
 		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListner, 'listener');
 		$hookListner->expects($this->once())->method('listener')->with($this->callback(function ($data) {
@@ -924,7 +924,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertNull($share->getExpirationDate());
 	}
 
-	public function testvalidateExpirationDateNoDateDefault() {
+	public function testValidateExpirationDateNoDateDefault() {
 		$future = new \DateTime();
 		$future->add(new \DateInterval('P3D'));
 		$future->setTime(0,0,0);

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -877,10 +877,10 @@ class ManagerTest extends \Test\TestCase {
 	public function testValidateExpirationDateEnforceValid() {
 		$future = new \DateTime();
 		$future->add(new \DateInterval('P2D'));
-		$future->setTime(0,0,0);
+		$future->setTime(1,2,3);
 
 		$expected = clone $future;
-		$future->setTime(1,2,3);
+		$expected->setTime(0,0,0);
 
 		$share = $this->manager->newShare();
 		$share->setExpirationDate($future);
@@ -906,6 +906,7 @@ class ManagerTest extends \Test\TestCase {
 	public function testValidateExpirationDateNoDefault() {
 		$date = new \DateTime();
 		$date->add(new \DateInterval('P5D'));
+		$date->setTime(1,2,3);
 
 		$expected = clone $date;
 		$expected->setTime(0,0,0);
@@ -967,9 +968,10 @@ class ManagerTest extends \Test\TestCase {
 	public function testValidateExpirationDateDefault() {
 		$future = new \DateTime();
 		$future->add(new \DateInterval('P5D'));
-		$future->setTime(0,0,0);
+		$future->setTime(1,2,3);
 
 		$expected = clone $future;
+		$expected->setTime(0,0,0);
 
 		$share = $this->manager->newShare();
 		$share->setExpirationDate($future);

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -903,7 +903,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertEquals($expected, $share->getExpirationDate());
 	}
 
-	public function testValidateExpirationDateNoDateNoDefaultNull() {
+	public function testValidateExpirationDateNoDefault() {
 		$date = new \DateTime();
 		$date->add(new \DateInterval('P5D'));
 

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -889,6 +889,7 @@ class ManagerTest extends \Test\TestCase {
 			->willReturnMap([
 				['core', 'shareapi_enforce_expire_date', 'no', 'yes'],
 				['core', 'shareapi_expire_after_n_days', '7', '3'],
+				['core', 'shareapi_default_expire_date', 'no', 'yes'],
 			]);
 
 		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -940,19 +940,17 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	public function testValidateExpirationDateNoDateDefault() {
-		$future = new \DateTime();
-		$future->add(new \DateInterval('P3D'));
-		$future->setTime(0,0,0);
-
-		$expected = clone $future;
-
 		$share = $this->manager->newShare();
-		$share->setExpirationDate($future);
+
+		$expected = new \DateTime();
+		$expected->add(new \DateInterval('P3D'));
+		$expected->setTime(0,0,0);
 
 		$this->config->method('getAppValue')
 			->willReturnMap([
 				['core', 'shareapi_default_expire_date', 'no', 'yes'],
 				['core', 'shareapi_expire_after_n_days', '7', '3'],
+				['core', 'link_defaultExpDays', 3, '3'],
 			]);
 
 		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -964,6 +964,34 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertEquals($expected, $share->getExpirationDate());
 	}
 
+	public function testValidateExpirationDateDefault() {
+		$future = new \DateTime();
+		$future->add(new \DateInterval('P5D'));
+		$future->setTime(0,0,0);
+
+		$expected = clone $future;
+
+		$share = $this->manager->newShare();
+		$share->setExpirationDate($future);
+
+		$this->config->method('getAppValue')
+			->willReturnMap([
+				['core', 'shareapi_default_expire_date', 'no', 'yes'],
+				['core', 'shareapi_expire_after_n_days', '7', '3'],
+				['core', 'link_defaultExpDays', 3, '1'],
+			]);
+
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
+		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate', $hookListener, 'listener');
+		$hookListener->expects($this->once())->method('listener')->with($this->callback(function ($data) use ($expected) {
+			return $data['expirationDate'] == $expected;
+		}));
+
+		self::invokePrivate($this->manager, 'validateExpirationDate', [$share]);
+
+		$this->assertEquals($expected, $share->getExpirationDate());
+	}
+
 	public function testValidateExpirationDateHookModification() {
 		$nextWeek = new \DateTime();
 		$nextWeek->add(new \DateInterval('P7D'));

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -855,6 +855,9 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	public function testValidateExpirationDateEnforceTooFarIntoFuture() {
+		$this->expectException(\OCP\Share\Exceptions\GenericShareException::class);
+		$this->expectExceptionMessage('Can’t set expiration date more than 3 days in the future');
+
 		$future = new \DateTime();
 		$future->add(new \DateInterval('P7D'));
 
@@ -865,16 +868,10 @@ class ManagerTest extends \Test\TestCase {
 			->willReturnMap([
 				['core', 'shareapi_enforce_expire_date', 'no', 'yes'],
 				['core', 'shareapi_expire_after_n_days', '7', '3'],
+				['core', 'shareapi_default_expire_date', 'no', 'yes'],
 			]);
 
-		try {
-			self::invokePrivate($this->manager, 'validateExpirationDate', [$share]);
-			$this->addToAssertionCount(1);
-		} catch (\OCP\Share\Exceptions\GenericShareException $e) {
-			$this->assertEquals('Cannot set expiration date more than 3 days in the future', $e->getMessage());
-			$this->assertEquals('Cannot set expiration date more than 3 days in the future', $e->getHint());
-			$this->assertEquals(404, $e->getCode());
-		}
+		self::invokePrivate($this->manager, 'validateExpirationDate', [$share]);
 	}
 
 	public function testValidateExpirationDateEnforceValid() {

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -772,7 +772,6 @@ class ManagerTest extends \Test\TestCase {
 		$this->expectException(\OCP\Share\Exceptions\GenericShareException::class);
 		$this->expectExceptionMessage('Expiration date is in the past');
 
-
 		// Expire date in the past
 		$past = new \DateTime();
 		$past->sub(new \DateInterval('P1D'));
@@ -782,7 +781,6 @@ class ManagerTest extends \Test\TestCase {
 
 		self::invokePrivate($this->manager, 'validateExpirationDate', [$share]);
 	}
-
 
 	public function testValidateExpirationDateEnforceButNotSet() {
 		$this->expectException(\InvalidArgumentException::class);
@@ -878,7 +876,7 @@ class ManagerTest extends \Test\TestCase {
 			]);
 
 		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
-		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListener, 'listener');
+		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate', $hookListener, 'listener');
 		$hookListener->expects($this->once())->method('listener')->with($this->callback(function ($data) use ($future) {
 			return $data['expirationDate'] == $future;
 		}));
@@ -899,7 +897,7 @@ class ManagerTest extends \Test\TestCase {
 		$share->setExpirationDate($date);
 
 		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
-		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListener, 'listener');
+		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate', $hookListener, 'listener');
 		$hookListener->expects($this->once())->method('listener')->with($this->callback(function ($data) use ($expected) {
 			return $data['expirationDate'] == $expected && $data['passwordSet'] === false;
 		}));
@@ -911,7 +909,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testValidateExpirationDateNoDateNoDefault() {
 		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
-		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListener, 'listener');
+		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate', $hookListener, 'listener');
 		$hookListener->expects($this->once())->method('listener')->with($this->callback(function ($data) {
 			return $data['expirationDate'] === null && $data['passwordSet'] === true;
 		}));
@@ -941,7 +939,7 @@ class ManagerTest extends \Test\TestCase {
 			]);
 
 		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
-		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListener, 'listener');
+		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate', $hookListener, 'listener');
 		$hookListener->expects($this->once())->method('listener')->with($this->callback(function ($data) use ($expected) {
 			return $data['expirationDate'] == $expected;
 		}));
@@ -959,7 +957,7 @@ class ManagerTest extends \Test\TestCase {
 		$save = clone $nextWeek;
 
 		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
-		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListener, 'listener');
+		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate', $hookListener, 'listener');
 		$hookListener->expects($this->once())->method('listener')->willReturnCallback(function ($data) {
 			$data['expirationDate']->sub(new \DateInterval('P2D'));
 		});
@@ -973,7 +971,6 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertEquals($save, $share->getExpirationDate());
 	}
 
-
 	public function testValidateExpirationDateHookException() {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('Invalid date!');
@@ -986,7 +983,7 @@ class ManagerTest extends \Test\TestCase {
 		$share->setExpirationDate($nextWeek);
 
 		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
-		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListener, 'listener');
+		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate', $hookListener, 'listener');
 		$hookListener->expects($this->once())->method('listener')->willReturnCallback(function ($data) {
 			$data['accepted'] = false;
 			$data['message'] = 'Invalid date!';
@@ -1010,7 +1007,6 @@ class ManagerTest extends \Test\TestCase {
 
 		$this->assertEquals(null, $share->getExpirationDate());
 	}
-
 
 	public function testUserCreateChecksShareWithGroupMembersOnlyDifferentGroups() {
 		$this->expectException(\Exception::class);

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -877,9 +877,9 @@ class ManagerTest extends \Test\TestCase {
 				['core', 'shareapi_expire_after_n_days', '7', '3'],
 			]);
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
-		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListner, 'listener');
-		$hookListner->expects($this->once())->method('listener')->with($this->callback(function ($data) use ($future) {
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
+		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListener, 'listener');
+		$hookListener->expects($this->once())->method('listener')->with($this->callback(function ($data) use ($future) {
 			return $data['expirationDate'] == $future;
 		}));
 
@@ -898,9 +898,9 @@ class ManagerTest extends \Test\TestCase {
 		$share = $this->manager->newShare();
 		$share->setExpirationDate($date);
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
-		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListner, 'listener');
-		$hookListner->expects($this->once())->method('listener')->with($this->callback(function ($data) use ($expected) {
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
+		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListener, 'listener');
+		$hookListener->expects($this->once())->method('listener')->with($this->callback(function ($data) use ($expected) {
 			return $data['expirationDate'] == $expected && $data['passwordSet'] === false;
 		}));
 
@@ -910,9 +910,9 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	public function testValidateExpirationDateNoDateNoDefault() {
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
-		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListner, 'listener');
-		$hookListner->expects($this->once())->method('listener')->with($this->callback(function ($data) {
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
+		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListener, 'listener');
+		$hookListener->expects($this->once())->method('listener')->with($this->callback(function ($data) {
 			return $data['expirationDate'] === null && $data['passwordSet'] === true;
 		}));
 
@@ -940,9 +940,9 @@ class ManagerTest extends \Test\TestCase {
 				['core', 'shareapi_expire_after_n_days', '7', '3'],
 			]);
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
-		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListner, 'listener');
-		$hookListner->expects($this->once())->method('listener')->with($this->callback(function ($data) use ($expected) {
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
+		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListener, 'listener');
+		$hookListener->expects($this->once())->method('listener')->with($this->callback(function ($data) use ($expected) {
 			return $data['expirationDate'] == $expected;
 		}));
 
@@ -958,9 +958,9 @@ class ManagerTest extends \Test\TestCase {
 
 		$save = clone $nextWeek;
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
-		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListner, 'listener');
-		$hookListner->expects($this->once())->method('listener')->willReturnCallback(function ($data) {
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
+		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListener, 'listener');
+		$hookListener->expects($this->once())->method('listener')->willReturnCallback(function ($data) {
 			$data['expirationDate']->sub(new \DateInterval('P2D'));
 		});
 
@@ -985,9 +985,9 @@ class ManagerTest extends \Test\TestCase {
 		$share = $this->manager->newShare();
 		$share->setExpirationDate($nextWeek);
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
-		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListner, 'listener');
-		$hookListner->expects($this->once())->method('listener')->willReturnCallback(function ($data) {
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
+		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate',  $hookListener, 'listener');
+		$hookListener->expects($this->once())->method('listener')->willReturnCallback(function ($data) {
 			$data['accepted'] = false;
 			$data['message'] = 'Invalid date!';
 		});
@@ -2609,16 +2609,16 @@ class ManagerTest extends \Test\TestCase {
 			->with($share)
 			->willReturn($share);
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListner, 'post');
-		$hookListner->expects($this->never())->method('post');
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListener, 'post');
+		$hookListener->expects($this->never())->method('post');
 
 		$this->rootFolder->method('getUserFolder')->with('newUser')->willReturnSelf();
 		$this->rootFolder->method('getRelativePath')->with('/newUser/files/myPath')->willReturn('/myPath');
 
-		$hookListner2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListner2, 'post');
-		$hookListner2->expects($this->once())->method('post')->with([
+		$hookListener2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListener2, 'post');
+		$hookListener2->expects($this->once())->method('post')->with([
 			'itemType' => 'file',
 			'itemSource' => 100,
 			'shareType' => IShare::TYPE_USER,
@@ -2666,13 +2666,13 @@ class ManagerTest extends \Test\TestCase {
 			->with($share)
 			->willReturn($share);
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListner, 'post');
-		$hookListner->expects($this->never())->method('post');
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListener, 'post');
+		$hookListener->expects($this->never())->method('post');
 
-		$hookListner2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListner2, 'post');
-		$hookListner2->expects($this->never())->method('post');
+		$hookListener2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListener2, 'post');
+		$hookListener2->expects($this->never())->method('post');
 
 		$manager->updateShare($share);
 	}
@@ -2728,18 +2728,18 @@ class ManagerTest extends \Test\TestCase {
 			->with($share)
 			->willReturn($share);
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListner, 'post');
-		$hookListner->expects($this->once())->method('post')->with([
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListener, 'post');
+		$hookListener->expects($this->once())->method('post')->with([
 			'itemType' => 'file',
 			'itemSource' => 100,
 			'date' => $tomorrow,
 			'uidOwner' => 'owner',
 		]);
 
-		$hookListner2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListner2, 'post');
-		$hookListner2->expects($this->once())->method('post')->with([
+		$hookListener2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListener2, 'post');
+		$hookListener2->expects($this->once())->method('post')->with([
 			'itemType' => 'file',
 			'itemSource' => 100,
 			'uidOwner' => 'owner',
@@ -2747,9 +2747,9 @@ class ManagerTest extends \Test\TestCase {
 			'disabled' => false,
 		]);
 
-		$hookListner3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListner3, 'post');
-		$hookListner3->expects($this->never())->method('post');
+		$hookListener3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListener3, 'post');
+		$hookListener3->expects($this->never())->method('post');
 
 
 		$manager->updateShare($share);
@@ -2809,17 +2809,17 @@ class ManagerTest extends \Test\TestCase {
 		$this->defaultProvider->expects($this->never())
 			->method('update');
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListner, 'post');
-		$hookListner->expects($this->never())->method('post');
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListener, 'post');
+		$hookListener->expects($this->never())->method('post');
 
-		$hookListner2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListner2, 'post');
-		$hookListner2->expects($this->never())->method('post');
+		$hookListener2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListener2, 'post');
+		$hookListener2->expects($this->never())->method('post');
 
-		$hookListner3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListner3, 'post');
-		$hookListner3->expects($this->never())->method('post');
+		$hookListener3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListener3, 'post');
+		$hookListener3->expects($this->never())->method('post');
 
 		$manager->updateShare($share);
 	}
@@ -2878,13 +2878,13 @@ class ManagerTest extends \Test\TestCase {
 			->with($share, 'password')
 			->willReturn($share);
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListner, 'post');
-		$hookListner->expects($this->never())->method('post');
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListener, 'post');
+		$hookListener->expects($this->never())->method('post');
 
-		$hookListner2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListner2, 'post');
-		$hookListner2->expects($this->once())->method('post')->with([
+		$hookListener2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListener2, 'post');
+		$hookListener2->expects($this->once())->method('post')->with([
 			'itemType' => 'file',
 			'itemSource' => 100,
 			'uidOwner' => 'owner',
@@ -2892,9 +2892,9 @@ class ManagerTest extends \Test\TestCase {
 			'disabled' => false,
 		]);
 
-		$hookListner3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListner3, 'post');
-		$hookListner3->expects($this->never())->method('post');
+		$hookListener3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListener3, 'post');
+		$hookListener3->expects($this->never())->method('post');
 
 		$manager->updateShare($share);
 	}
@@ -2956,13 +2956,13 @@ class ManagerTest extends \Test\TestCase {
 			->with($share, 'password')
 			->willReturn($share);
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListner, 'post');
-		$hookListner->expects($this->never())->method('post');
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListener, 'post');
+		$hookListener->expects($this->never())->method('post');
 
-		$hookListner2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListner2, 'post');
-		$hookListner2->expects($this->once())->method('post')->with([
+		$hookListener2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListener2, 'post');
+		$hookListener2->expects($this->once())->method('post')->with([
 			'itemType' => 'file',
 			'itemSource' => 100,
 			'uidOwner' => 'owner',
@@ -2970,9 +2970,9 @@ class ManagerTest extends \Test\TestCase {
 			'disabled' => false,
 		]);
 
-		$hookListner3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListner3, 'post');
-		$hookListner3->expects($this->never())->method('post');
+		$hookListener3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListener3, 'post');
+		$hookListener3->expects($this->never())->method('post');
 
 		$manager->updateShare($share);
 	}
@@ -3039,13 +3039,13 @@ class ManagerTest extends \Test\TestCase {
 			->with($share, 'password')
 			->willReturn($share);
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListner, 'post');
-		$hookListner->expects($this->never())->method('post');
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListener, 'post');
+		$hookListener->expects($this->never())->method('post');
 
-		$hookListner2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListner2, 'post');
-		$hookListner2->expects($this->once())->method('post')->with([
+		$hookListener2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListener2, 'post');
+		$hookListener2->expects($this->once())->method('post')->with([
 			'itemType' => 'file',
 			'itemSource' => 100,
 			'uidOwner' => 'owner',
@@ -3053,9 +3053,9 @@ class ManagerTest extends \Test\TestCase {
 			'disabled' => false,
 		]);
 
-		$hookListner3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListner3, 'post');
-		$hookListner3->expects($this->never())->method('post');
+		$hookListener3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListener3, 'post');
+		$hookListener3->expects($this->never())->method('post');
 
 		$manager->updateShare($share);
 	}
@@ -3116,17 +3116,17 @@ class ManagerTest extends \Test\TestCase {
 		$this->defaultProvider->expects($this->never())
 			->method('update');
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListner, 'post');
-		$hookListner->expects($this->never())->method('post');
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListener, 'post');
+		$hookListener->expects($this->never())->method('post');
 
-		$hookListner2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListner2, 'post');
-		$hookListner2->expects($this->never())->method('post');
+		$hookListener2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListener2, 'post');
+		$hookListener2->expects($this->never())->method('post');
 
-		$hookListner3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListner3, 'post');
-		$hookListner3->expects($this->never())->method('post');
+		$hookListener3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListener3, 'post');
+		$hookListener3->expects($this->never())->method('post');
 
 		$manager->updateShare($share);
 	}
@@ -3188,17 +3188,17 @@ class ManagerTest extends \Test\TestCase {
 		$this->defaultProvider->expects($this->never())
 			->method('update');
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListner, 'post');
-		$hookListner->expects($this->never())->method('post');
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListener, 'post');
+		$hookListener->expects($this->never())->method('post');
 
-		$hookListner2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListner2, 'post');
-		$hookListner2->expects($this->never())->method('post');
+		$hookListener2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListener2, 'post');
+		$hookListener2->expects($this->never())->method('post');
 
-		$hookListner3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListner3, 'post');
-		$hookListner3->expects($this->never())->method('post');
+		$hookListener3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListener3, 'post');
+		$hookListener3->expects($this->never())->method('post');
 
 		$manager->updateShare($share);
 	}
@@ -3260,17 +3260,17 @@ class ManagerTest extends \Test\TestCase {
 		$this->defaultProvider->expects($this->never())
 			->method('update');
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListner, 'post');
-		$hookListner->expects($this->never())->method('post');
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListener, 'post');
+		$hookListener->expects($this->never())->method('post');
 
-		$hookListner2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListner2, 'post');
-		$hookListner2->expects($this->never())->method('post');
+		$hookListener2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListener2, 'post');
+		$hookListener2->expects($this->never())->method('post');
 
-		$hookListner3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListner3, 'post');
-		$hookListner3->expects($this->never())->method('post');
+		$hookListener3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListener3, 'post');
+		$hookListener3->expects($this->never())->method('post');
 
 		$manager->updateShare($share);
 	}
@@ -3337,17 +3337,17 @@ class ManagerTest extends \Test\TestCase {
 		$this->defaultProvider->expects($this->never())
 			->method('update');
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListner, 'post');
-		$hookListner->expects($this->never())->method('post');
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListener, 'post');
+		$hookListener->expects($this->never())->method('post');
 
-		$hookListner2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListner2, 'post');
-		$hookListner2->expects($this->never())->method('post');
+		$hookListener2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListener2, 'post');
+		$hookListener2->expects($this->never())->method('post');
 
-		$hookListner3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListner3, 'post');
-		$hookListner3->expects($this->never())->method('post');
+		$hookListener3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListener3, 'post');
+		$hookListener3->expects($this->never())->method('post');
 
 		$manager->updateShare($share);
 	}
@@ -3413,17 +3413,17 @@ class ManagerTest extends \Test\TestCase {
 		$this->defaultProvider->expects($this->never())
 			->method('update');
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListner, 'post');
-		$hookListner->expects($this->never())->method('post');
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListener, 'post');
+		$hookListener->expects($this->never())->method('post');
 
-		$hookListner2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListner2, 'post');
-		$hookListner2->expects($this->never())->method('post');
+		$hookListener2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListener2, 'post');
+		$hookListener2->expects($this->never())->method('post');
 
-		$hookListner3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListner3, 'post');
-		$hookListner3->expects($this->never())->method('post');
+		$hookListener3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListener3, 'post');
+		$hookListener3->expects($this->never())->method('post');
 
 		$manager->updateShare($share);
 	}
@@ -3487,17 +3487,17 @@ class ManagerTest extends \Test\TestCase {
 		$this->defaultProvider->expects($this->never())
 			->method('update');
 
-		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListner, 'post');
-		$hookListner->expects($this->never())->method('post');
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_set_expiration_date', $hookListener, 'post');
+		$hookListener->expects($this->never())->method('post');
 
-		$hookListner2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListner2, 'post');
-		$hookListner2->expects($this->never())->method('post');
+		$hookListener2 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_password', $hookListener2, 'post');
+		$hookListener2->expects($this->never())->method('post');
 
-		$hookListner3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
-		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListner3, 'post');
-		$hookListner3->expects($this->never())->method('post');
+		$hookListener3 = $this->getMockBuilder('Dummy')->setMethods(['post'])->getMock();
+		\OCP\Util::connectHook('OCP\Share', 'post_update_permissions', $hookListener3, 'post');
+		$hookListener3->expects($this->never())->method('post');
 
 		$manager->updateShare($share);
 	}


### PR DESCRIPTION
Follow up to #17725

The default expiration date for internal shares was set from the default link expiration date instead of the internal one.

The fix itself is in the fourth to last commit. The commits before that are fixes to the unit tests of `validateExpirationDate`, and the commits after that are unit and integration tests for the internal expiration date.

## How to test

- Open the settings
- Open the "Sharing" section in "Administration"
- Enable "Set default expiration date for shares" and set "Expire after" to 4
- Open the Files app
- Open the sidebar for a file
- Open the "Sharing" tab
- Share the file with another user
- Open the menu for the share

### Result with this pull request

The expiration date is set in four days.

### Result without this pull request

The expiration date is set in seven days.
