### PR TITLE
20.0.2 RC2

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [20, 0, 2, 0];
+$OC_Version = [20, 0, 2, 1];
 
 // The human readable string
-$OC_VersionString = '20.0.2 RC1';
+$OC_VersionString = '20.0.2 RC2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #24079 Make is_user_defined nullable so we can store false on oracle
* #24081 Fix default internal expiration date enforce
* #24106 Register new command db:add-missing-primary-keys
* #24114 Convert the card resource to a string if necessary
* #24147 Don't throw on SHOW VERSION query
* #24153 Bump dompurify to 2.2.2
* #24156 Set up FS before querying storage info in settings
* #24159 Fix default internal expiration date


Pending PRs:

* [ ] [photos#550](https://github.com/nextcloud/photos/pull/550) Feat/virtual grid @skjnldsv
