### PR TITLE
19.0.5 RC2

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [19, 0, 5, 0];
+$OC_Version = [19, 0, 5, 1];
 
 // The human readable string
-$OC_VersionString = '19.0.5 RC1';
+$OC_VersionString = '19.0.5 RC2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #24076 Unlock when promoting to exclusive lock fails
* #24080 Fix default internal expiration date enforce
* #24111 Fix password visibility toggles
* #24115 Convert the card resource to a string if necessary
* #24148 Don't throw on SHOW VERSION query
* #24155 Bump dompurify to 2.2.2
* #24160 Fix default internal expiration date
* [text#1167](https://github.com/nextcloud/text/pull/1167) Validate link before opening
