### PR TITLE
18.0.11 RC2

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(18, 0, 11, 0);
+$OC_Version = array(18, 0, 11, 1);
 
 // The human readable string
-$OC_VersionString = '18.0.11 RC1';
+$OC_VersionString = '18.0.11 RC2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #24077 Unlock when promoting to exclusive lock fails
* #24082 Fix default internal expiration date enforce
* #24149 Don't throw on SHOW VERSION query
* #24154 Bump dompurify to 2.2.2
* #24161 Fix default internal expiration date
* [text#1168](https://github.com/nextcloud/text/pull/1168) Validate link on click


Pending PRs:

* [x] #24078 Add mount point to quota warning message @MorrisJobke
