### PR TITLE
#3903 add Background job for cleanup of unneeded remote storages

### DIFF
--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -9,7 +9,7 @@
 Turning the feature off removes shared files and folders on the server for all share recipients, and also on the sync clients and mobile apps. More information is available in the Nextcloud Documentation.
 
 	</description>
-	<version>1.18.0</version>
+	<version>1.18.1</version>
 	<licence>agpl</licence>
 	<author>Michael Gapczynski</author>
 	<author>Bjoern Schiessle</author>
@@ -29,6 +29,7 @@ Turning the feature off removes shared files and folders on the server for all s
 		<job>OCA\Files_Sharing\DeleteOrphanedSharesJob</job>
 		<job>OCA\Files_Sharing\ExpireSharesJob</job>
 		<job>OCA\Files_Sharing\BackgroundJob\FederatedSharesDiscoverJob</job>
+		<job>OCA\Files_Sharing\BackgroundJob\CleanupRemoteStoragesJob</job>
 	</background-jobs>
 
 	<repair-steps>

--- a/apps/files_sharing/composer/composer/autoload_classmap.php
+++ b/apps/files_sharing/composer/composer/autoload_classmap.php
@@ -20,6 +20,7 @@ return array(
     'OCA\\Files_Sharing\\Activity\\Settings\\Shared' => $baseDir . '/../lib/Activity/Settings/Shared.php',
     'OCA\\Files_Sharing\\AppInfo\\Application' => $baseDir . '/../lib/AppInfo/Application.php',
     'OCA\\Files_Sharing\\BackgroundJob\\FederatedSharesDiscoverJob' => $baseDir . '/../lib/BackgroundJob/FederatedSharesDiscoverJob.php',
+    'OCA\\Files_Sharing\\BackgroundJob\\CleanupRemoteStoragesJob' => $baseDir . '/../lib/BackgroundJob/CleanupRemoteStoragesJob.php',
     'OCA\\Files_Sharing\\Cache' => $baseDir . '/../lib/Cache.php',
     'OCA\\Files_Sharing\\Capabilities' => $baseDir . '/../lib/Capabilities.php',
     'OCA\\Files_Sharing\\Collaboration\\ShareRecipientSorter' => $baseDir . '/../lib/Collaboration/ShareRecipientSorter.php',

--- a/apps/files_sharing/composer/composer/autoload_static.php
+++ b/apps/files_sharing/composer/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInitFiles_Sharing
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OCA\\Files_Sharing\\' => 18,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'OCA\\Files_Sharing\\' => 
+        'OCA\\Files_Sharing\\' =>
         array (
             0 => __DIR__ . '/..' . '/../lib',
         ),
@@ -35,6 +35,7 @@ class ComposerStaticInitFiles_Sharing
         'OCA\\Files_Sharing\\Activity\\Settings\\Shared' => __DIR__ . '/..' . '/../lib/Activity/Settings/Shared.php',
         'OCA\\Files_Sharing\\AppInfo\\Application' => __DIR__ . '/..' . '/../lib/AppInfo/Application.php',
         'OCA\\Files_Sharing\\BackgroundJob\\FederatedSharesDiscoverJob' => __DIR__ . '/..' . '/../lib/BackgroundJob/FederatedSharesDiscoverJob.php',
+        'OCA\\Files_Sharing\\BackgroundJob\\CleanupRemoteStoragesJob' => __DIR__ . '/..' . '/../lib/BackgroundJob/CleanupRemoteStoragesJob.php',
         'OCA\\Files_Sharing\\Cache' => __DIR__ . '/..' . '/../lib/Cache.php',
         'OCA\\Files_Sharing\\Capabilities' => __DIR__ . '/..' . '/../lib/Capabilities.php',
         'OCA\\Files_Sharing\\Collaboration\\ShareRecipientSorter' => __DIR__ . '/..' . '/../lib/Collaboration/ShareRecipientSorter.php',

--- a/apps/files_sharing/lib/BackgroundJob/CleanupRemoteStoragesJob.php
+++ b/apps/files_sharing/lib/BackgroundJob/CleanupRemoteStoragesJob.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright (c) 2020, Nils Werner <sammellog@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_Sharing\BackgroundJob;
+
+use OCA\Files_Sharing\Command\CleanupRemoteStorages;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+/**
+ * Background job for the Command CleanupRemoteStorages
+ */
+class CleanupRemoteStoragesJob extends TimedJob {
+	/**
+	 * @var CleanupRemoteStorages
+	 */
+	private $remoteStorages;
+
+	/**
+	 * CleanupRemoteStoragesJob constructor.
+	 * @param ITimeFactory $time
+	 * @param CleanupRemoteStorages $remoteStorages
+	 */
+	private function __construct(ITimeFactory $time, CleanupRemoteStorages $remoteStorages) {
+		parent::__construct($time);
+		$this->remoteStorages = $remoteStorages;
+
+		// Only once a week
+		parent::setInterval(604800);
+	}
+
+	/**
+	 * @param $argument
+	 * @return void
+	 */
+	protected function run($argument) {
+		$input = new ArrayInput(array(
+			'command' => 'sharing:cleanup-remote-storages',
+			'--dry-run' => ""
+		));
+		$output = new NullOutput();
+		$this->remoteStorages->execute($input, $output);
+	}
+}


### PR DESCRIPTION
Signed-off-by: Nils Werner <sammellog@gmail.com>

This change add a new background job to execute the command CleanupRemoteStorages

See #3903 for more details.

Fixes #3903