### PR TITLE
Convert the card resource to a string if necessary

### DIFF
--- a/apps/contactsinteraction/lib/Db/CardSearchDao.php
+++ b/apps/contactsinteraction/lib/Db/CardSearchDao.php
@@ -28,6 +28,8 @@ namespace OCA\ContactsInteraction\Db;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\IUser;
+use function is_resource;
+use function stream_get_contents;
 
 class CardSearchDao {
 
@@ -79,11 +81,14 @@ class CardSearchDao {
 			->andWhere($cardQuery->expr()->in('addressbookid', $cardQuery->createFunction($addressbooksQuery->getSQL()), IQueryBuilder::PARAM_INT_ARRAY))
 			->setMaxResults(1);
 		$result = $cardQuery->execute();
-		/** @var string|false $card */
+		/** @var string|resource|false $card */
 		$card = $result->fetchColumn(0);
 
 		if ($card === false) {
 			return null;
+		}
+		if (is_resource($card)) {
+			return stream_get_contents($card);
 		}
 
 		return $card;


### PR DESCRIPTION
Apparently the fetched column can be a string or resource. Hence we have
to catch the resource type and convert it to a string.

Fixes https://github.com/nextcloud/server/issues/23979

I couldn't test because for me it's always a string. @medcloud please test :v: