### PR TITLE
circleId too short in some request

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -1648,10 +1648,11 @@ class ShareAPIController extends OCSController {
 			$hasCircleId = (substr($share->getSharedWith(), -1) === ']');
 			$shareWithStart = ($hasCircleId ? strrpos($share->getSharedWith(), '[') + 1 : 0);
 			$shareWithLength = ($hasCircleId ? -1 : strpos($share->getSharedWith(), ' '));
-			if (is_bool($shareWithLength)) {
-				$shareWithLength = -1;
+			if ($shareWithLength === false) {
+				$sharedWith = substr($share->getSharedWith(), $shareWithStart);
+			} else {
+				$sharedWith = substr($share->getSharedWith(), $shareWithStart, $shareWithLength);
 			}
-			$sharedWith = substr($share->getSharedWith(), $shareWithStart, $shareWithLength);
 			try {
 				$member = \OCA\Circles\Api\v1\Circles::getMember($sharedWith, $userId, 1);
 				if ($member->getLevel() >= 4) {


### PR DESCRIPTION
Sometimes, the getShareWith() will only contains the CircleUniqueId and not a complex string. In that case, the CircleId should not be cropped that much.