### PR TITLE
Only check path for being accessible when the storage is a object home

### DIFF
--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -824,7 +824,7 @@ class DefaultShareProvider implements IShareProvider {
 		$pathSections = explode('/', $data['path'], 2);
 		// FIXME: would not detect rare md5'd home storage case properly
 		if ($pathSections[0] !== 'files'
-				&& in_array(explode(':', $data['storage_string_id'], 2)[0], ['home', 'object'])) {
+			&& (strpos($data['storage_string_id'], 'home::') === 0 || strpos($data['storage_string_id'], 'object::user') === 0)) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
This fixes an issue where shares originating from groupfolders were not showing up at the recipient due to the check for a valid "files" path being applied to all object storages instead of just the user ones.

For groupfolders the storage would be something like `object::store:amazon::nc-65a6889e4cd6` where the previous check caused a false positive.