### PR TITLE
Use correct year for generated birthdays events

### DIFF
--- a/apps/dav/lib/CalDAV/BirthdayService.php
+++ b/apps/dav/lib/CalDAV/BirthdayService.php
@@ -235,7 +235,12 @@ class BirthdayService {
 				}
 			} else {
 				$originalYear = (int)$dateParts['year'];
-
+				// 'X-APPLE-OMIT-YEAR' is not always present, at least iOS 12.4 uses the hard coded date of 1604 (the start of the gregorian calendar) when the year is unknown
+				if ($originalYear == 1604) {
+					$originalYear = null;
+					$unknownYear = true;
+					$birthday = '1970-' . $dateParts['month'] . '-' . $dateParts['date'];
+				}
 				if ($originalYear < 1970) {
 					$birthday = '1970-' . $dateParts['month'] . '-' . $dateParts['date'];
 				}


### PR DESCRIPTION
'X-APPLE-OMIT-YEAR' is not always present, at least iOS 12.4 uses the hard coded date of 1604 when the year is unknown.

Without this PR people are shown as born in 1604 if not year is entered.

cf. https://forums.bitfire.at/topic/2050/bday-without-year-for-vcard-3-0-if-server-drops-property-x-apple-omit-year and https://gitlab.com/CardBook/CardBook/-/issues/586

Also needed for older Nextcloud versions such as 19