### PR TITLE
Set up FS before querying storage info in settings

### DIFF
--- a/apps/settings/lib/Settings/Personal/PersonalInfo.php
+++ b/apps/settings/lib/Settings/Personal/PersonalInfo.php
@@ -105,6 +105,9 @@ class PersonalInfo implements ISettings {
 		$user = $this->userManager->get($uid);
 		$userData = $this->accountManager->getUser($user);
 
+		// make sure FS is setup before querying storage related stuff...
+		\OC_Util::setupFS($user->getUID());
+
 		$storageInfo = \OC_Helper::getStorageInfo('/');
 		if ($storageInfo['quota'] === FileInfo::SPACE_UNLIMITED) {
 			$totalSpace = $this->l->t('Unlimited');

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -475,6 +475,9 @@ class OC_Helper {
 	/**
 	 * Calculate the disc space for the given path
 	 *
+	 * BEWARE: this requires that Util::setupFS() was called
+	 * already !
+	 *
 	 * @param string $path
 	 * @param \OCP\Files\FileInfo $rootInfo (optional)
 	 * @return array


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/24099

The personal info section of the personal settings is querying the
storage quota information. For this it requires the FS to be setup which
is not always guaranteed.

This fixes an issue where refreshing the settings page would cause it to
fail after Redis caches are full. It is likely that when Redis cache is
populated, some code path is initializing the FS, so it works so far.
But when the cache is populated, that code path is skipped so the FS is
not guaranteed to be setup...

- [x] check if this happens on stable20