### PR TITLE
18.0.11

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(18, 0, 11, 1);
+$OC_Version = array(18, 0, 11, 2);
 
 // The human readable string
-$OC_VersionString = '18.0.11 RC2';
+$OC_VersionString = '18.0.11';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* [text#1173](https://github.com/nextcloud/text/pull/1173) Bump eslint-plugin-standard from 4.0.2 to 4.1.0
* [text#1174](https://github.com/nextcloud/text/pull/1174) Bump babel-loader from 8.1.0 to 8.2.1
