### PR TITLE
20.0.2

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [20, 0, 2, 1];
+$OC_Version = [20, 0, 2, 2];
 
 // The human readable string
-$OC_VersionString = '20.0.2 RC2';
+$OC_VersionString = '20.0.2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* [text#1125](https://github.com/nextcloud/text/pull/1125) Bump eslint-plugin-standard from 4.0.1 to 4.0.2
* [text#1134](https://github.com/nextcloud/text/pull/1134) Bump sass-loader from 10.0.1 to 10.0.5
* [text#1140](https://github.com/nextcloud/text/pull/1140) Bump webpack from 4.44.1 to 4.44.2
* [text#1179](https://github.com/nextcloud/text/pull/1179) Bump cypress from 4.12.1 to 5.1.0
