### PR TITLE
Properly handle folder deletion on external s3 storage

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -318,6 +318,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 				}
 				// we reached the end when the list is no longer truncated
 			} while ($objects['IsTruncated']);
+			$this->deleteObject($path);
 		} catch (S3Exception $e) {
 			\OC::$server->getLogger()->logException($e, ['app' => 'files_external']);
 			return false;

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -612,6 +612,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 			$dh = $sourceStorage->opendir($sourceInternalPath);
 			$result = $this->mkdir($targetInternalPath);
 			if (is_resource($dh)) {
+				$result = true;
 				while ($result and ($file = readdir($dh)) !== false) {
 					if (!Filesystem::isIgnoredDir($file)) {
 						$result &= $this->copyFromStorage($sourceStorage, $sourceInternalPath . '/' . $file, $targetInternalPath . '/' . $file);


### PR DESCRIPTION
Steps to reproduce:

- On external s3 storage (minio in my test setup)
- Create an empty folder
- Delete the folder

Fixed by 7129f2c since otherwise the copyFromStorage would return false which is wrong for an empty directory

- On external s3 storage (minio in my test setup)
- Create a folder and add a single file to it
- Delete the folder

Fixed by 62c0009 which makes sure that any leftover of the path is removed from the bucket.

I remember also seeing an issue for that but I cannot find it anymore. 

