### PR TITLE
Set frame-ancestors to none if none are filled

### DIFF
--- a/build/integration/sharing_features/sharing-v1.feature
+++ b/build/integration/sharing_features/sharing-v1.feature
@@ -14,7 +14,7 @@ Feature: sharing
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And The following headers should be set
-      | Content-Security-Policy | default-src 'none';base-uri 'none';manifest-src 'self' |
+      | Content-Security-Policy | default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none' |
 
   Scenario: Creating a share with a group
     Given user "user0" exists

--- a/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
@@ -509,6 +509,8 @@ class EmptyContentSecurityPolicy {
 		if (!empty($this->allowedFrameAncestors)) {
 			$policy .= 'frame-ancestors ' . implode(' ', $this->allowedFrameAncestors);
 			$policy .= ';';
+		} else {
+			$policy .= 'frame-ancestors \'none\';';
 		}
 
 		if (!empty($this->allowedWorkerSrcDomains)) {

--- a/tests/lib/AppFramework/Controller/ControllerTest.php
+++ b/tests/lib/AppFramework/Controller/ControllerTest.php
@@ -112,7 +112,7 @@ class ControllerTest extends \Test\TestCase {
 			'test' => 'something',
 			'Cache-Control' => 'no-cache, no-store, must-revalidate',
 			'Content-Type' => 'application/json; charset=utf-8',
-			'Content-Security-Policy' => "default-src 'none';base-uri 'none';manifest-src 'self'",
+			'Content-Security-Policy' => "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'",
 			'Feature-Policy' => "autoplay 'none';camera 'none';fullscreen 'none';geolocation 'none';microphone 'none';payment 'none'",
 			'X-Robots-Tag' => 'none',
 		];

--- a/tests/lib/AppFramework/Http/DataResponseTest.php
+++ b/tests/lib/AppFramework/Http/DataResponseTest.php
@@ -65,7 +65,7 @@ class DataResponseTest extends \Test\TestCase {
 
 		$expectedHeaders = [
 			'Cache-Control' => 'no-cache, no-store, must-revalidate',
-			'Content-Security-Policy' => "default-src 'none';base-uri 'none';manifest-src 'self'",
+			'Content-Security-Policy' => "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'",
 			'Feature-Policy' => "autoplay 'none';camera 'none';fullscreen 'none';geolocation 'none';microphone 'none';payment 'none'",
 			'X-Robots-Tag' => 'none',
 		];

--- a/tests/lib/AppFramework/Http/EmptyContentSecurityPolicyTest.php
+++ b/tests/lib/AppFramework/Http/EmptyContentSecurityPolicyTest.php
@@ -26,19 +26,19 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDefault() {
-		$defaultPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$defaultPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 		$this->assertSame($defaultPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyScriptDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyScriptDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.org');
@@ -46,7 +46,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowScriptDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.com');
@@ -54,7 +54,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowScriptDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.org');
@@ -62,7 +62,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowScriptDomainMultipleStacked() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.org')->disallowScriptDomain('www.owncloud.com');
@@ -70,14 +70,14 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyScriptAllowInline() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src  'unsafe-inline'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src  'unsafe-inline';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->allowInlineScript(true);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyScriptAllowInlineWithDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src www.owncloud.com 'unsafe-inline'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src www.owncloud.com 'unsafe-inline';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->allowInlineScript(true);
@@ -85,7 +85,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyScriptAllowInlineAndEval() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src  'unsafe-inline' 'unsafe-eval'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src  'unsafe-inline' 'unsafe-eval';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->allowInlineScript(true);
 		$this->contentSecurityPolicy->allowEvalScript(true);
@@ -93,14 +93,14 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyStyleDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyStyleDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.org');
@@ -108,7 +108,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowStyleDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.com');
@@ -116,7 +116,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowStyleDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.org');
@@ -124,7 +124,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowStyleDomainMultipleStacked() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.org')->disallowStyleDomain('www.owncloud.com');
@@ -132,14 +132,14 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyStyleAllowInline() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src  'unsafe-inline'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src  'unsafe-inline';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->allowInlineStyle(true);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyStyleAllowInlineWithDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.owncloud.com 'unsafe-inline'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.owncloud.com 'unsafe-inline';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->allowInlineStyle(true);
@@ -147,21 +147,21 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyStyleDisallowInline() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->allowInlineStyle(false);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyImageDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';img-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';img-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyImageDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';img-src www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';img-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.org');
@@ -169,7 +169,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowImageDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.com');
@@ -177,7 +177,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowImageDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';img-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';img-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.org');
@@ -185,7 +185,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowImageDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.org')->disallowImageDomain('www.owncloud.com');
@@ -193,14 +193,14 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyFontDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';font-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';font-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyFontDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';font-src www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';font-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.org');
@@ -208,7 +208,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFontDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.com');
@@ -216,7 +216,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFontDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';font-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';font-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.org');
@@ -224,7 +224,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFontDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.org')->disallowFontDomain('www.owncloud.com');
@@ -232,14 +232,14 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyConnectDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';connect-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';connect-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyConnectDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';connect-src www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';connect-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.org');
@@ -247,7 +247,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowConnectDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.com');
@@ -255,7 +255,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowConnectDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';connect-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';connect-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.org');
@@ -263,7 +263,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowConnectDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.org')->disallowConnectDomain('www.owncloud.com');
@@ -271,14 +271,14 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyMediaDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';media-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';media-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyMediaDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';media-src www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';media-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.org');
@@ -286,7 +286,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowMediaDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.com');
@@ -294,7 +294,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowMediaDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';media-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';media-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.org');
@@ -302,7 +302,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowMediaDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.org')->disallowMediaDomain('www.owncloud.com');
@@ -310,14 +310,14 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyObjectDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';object-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';object-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyObjectDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';object-src www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';object-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.org');
@@ -325,7 +325,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowObjectDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.com');
@@ -333,7 +333,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowObjectDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';object-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';object-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.org');
@@ -341,7 +341,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowObjectDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.org')->disallowObjectDomain('www.owncloud.com');
@@ -349,14 +349,14 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetAllowedFrameDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyFrameDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-src www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.org');
@@ -364,7 +364,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFrameDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.com');
@@ -372,7 +372,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFrameDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.org');
@@ -380,7 +380,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFrameDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.org')->disallowFrameDomain('www.owncloud.com');
@@ -388,14 +388,14 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetAllowedChildSrcDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';child-src child.owncloud.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';child-src child.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyChildSrcValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';child-src child.owncloud.com child.owncloud.org";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';child-src child.owncloud.com child.owncloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.org');
@@ -403,7 +403,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowChildSrcDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.com');
@@ -411,7 +411,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowChildSrcDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';child-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';child-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org');
@@ -419,7 +419,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowChildSrcDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org')->disallowChildSrcDomain('www.owncloud.com');
@@ -427,7 +427,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyWithJsNonceAndScriptDomains() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-TXlKc05vbmNl' www.nextcloud.com www.nextcloud.org";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-TXlKc05vbmNl' www.nextcloud.com www.nextcloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.com');
 		$this->contentSecurityPolicy->useJsNonce('MyJsNonce');
@@ -436,7 +436,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyWithJsNonceAndSelfScriptDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-TXlKc05vbmNl'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-TXlKc05vbmNl';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->useJsNonce('MyJsNonce');
 		$this->contentSecurityPolicy->addAllowedScriptDomain("'self'");
@@ -444,21 +444,21 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyWithoutJsNonceAndSelfScriptDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain("'self'");
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyWithReportUri() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';report-uri https://my-report-uri.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none';report-uri https://my-report-uri.com";
 
 		$this->contentSecurityPolicy->addReportTo("https://my-report-uri.com");
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyWithMultipleReportUri() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';report-uri https://my-report-uri.com https://my-other-report-uri.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none';report-uri https://my-report-uri.com https://my-other-report-uri.com";
 
 		$this->contentSecurityPolicy->addReportTo("https://my-report-uri.com");
 		$this->contentSecurityPolicy->addReportTo("https://my-other-report-uri.com");

--- a/tests/lib/AppFramework/Http/ResponseTest.php
+++ b/tests/lib/AppFramework/Http/ResponseTest.php
@@ -57,7 +57,7 @@ class ResponseTest extends \Test\TestCase {
 
 		$this->childResponse->setHeaders($expected);
 		$headers = $this->childResponse->getHeaders();
-		$expected['Content-Security-Policy'] = "default-src 'none';base-uri 'none';manifest-src 'self'";
+		$expected['Content-Security-Policy'] = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 		$expected['Feature-Policy'] = "autoplay 'none';camera 'none';fullscreen 'none';geolocation 'none';microphone 'none';payment 'none'";
 
 		$this->assertEquals($expected, $headers);


### PR DESCRIPTION
frame-ancestors doesn't fall back to default-src. So when we apply a
very restricted CSP we should make sure to set it to 'none' and not
leave it empty.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>