### PR TITLE
Add option to set weather forecast offset

### DIFF
--- a/apps/weather_status/appinfo/routes.php
+++ b/apps/weather_status/appinfo/routes.php
@@ -30,7 +30,7 @@ return [
 		['name' => 'WeatherStatus#getLocation', 'url' => '/api/v1/location', 'verb' => 'GET'],
 		['name' => 'WeatherStatus#setLocation', 'url' => '/api/v1/location', 'verb' => 'PUT'],
 		['name' => 'WeatherStatus#getForecast', 'url' => '/api/v1/forecast', 'verb' => 'GET'],
-		['name' => 'WeatherStatus#getFavorites', 'url' => '/api/v1/favorites', 'verb' => 'GET'],
-		['name' => 'WeatherStatus#setFavorites', 'url' => '/api/v1/favorites', 'verb' => 'PUT'],
+		['name' => 'WeatherStatus#getOptions', 'url' => '/api/v1/options', 'verb' => 'GET'],
+		['name' => 'WeatherStatus#setOptions', 'url' => '/api/v1/options', 'verb' => 'PUT'],
 	],
 ];

--- a/apps/weather_status/lib/Controller/WeatherStatusController.php
+++ b/apps/weather_status/lib/Controller/WeatherStatusController.php
@@ -125,23 +125,24 @@ class WeatherStatusController extends OCSController {
 	/**
 	 * @NoAdminRequired
 	 *
-	 * Get favorites list
+	 * Get option values
 	 *
-	 * @return DataResponse which contains the favorite list
+	 * @return DataResponse
 	 */
-	public function getFavorites(): DataResponse {
-		return new DataResponse($this->service->getFavorites());
+	public function getOptions(): DataResponse {
+		return new DataResponse($this->service->getOptions());
 	}
 
 	/**
 	 * @NoAdminRequired
 	 *
-	 * Set favorites list
+	 * Set option values
 	 *
-	 * @param array $favorites
+	 * @param ?array $favorites
+	 * @param ?int $forecastOffset
 	 * @return DataResponse success state
 	 */
-	public function setFavorites(array $favorites): DataResponse {
-		return new DataResponse($this->service->setFavorites($favorites));
+	public function setOptions(?array $favorites = null, ?int $forecastOffset = null): DataResponse {
+		return new DataResponse($this->service->setOptions($favorites, $forecastOffset));
 	}
 }

--- a/apps/weather_status/lib/Service/WeatherStatusService.php
+++ b/apps/weather_status/lib/Service/WeatherStatusService.php
@@ -134,22 +134,31 @@ class WeatherStatusService {
 	}
 
 	/**
-	 * Get favorites list
-	 * @param array $favorites
-	 * @return array success state
+	 * Get option values
+	 * @return array the values
 	 */
-	public function getFavorites(): array {
+	public function getOptions(): array {
 		$favoritesJson = $this->config->getUserValue($this->userId, Application::APP_ID, 'favorites', '');
-		return json_decode($favoritesJson, true) ?: [];
+		$forecastOffset = $this->config->getUserValue($this->userId, Application::APP_ID, 'forecastOffset', '5');
+		return [
+			'favorites' => json_decode($favoritesJson, true) ?: [],
+			'forecastOffset' => $forecastOffset,
+		];
 	}
 
 	/**
-	 * Set favorites list
-	 * @param array $favorites
+	 * Set option values
+	 * @param ?array $favorites
+	 * @param ?int $forecastOffset
 	 * @return array success state
 	 */
-	public function setFavorites(array $favorites): array {
-		$this->config->setUserValue($this->userId, Application::APP_ID, 'favorites', json_encode($favorites));
+	public function setOptions(?array $favorites, ?int $forecastOffset): array {
+		if (!is_null($favorites)) {
+			$this->config->setUserValue($this->userId, Application::APP_ID, 'favorites', json_encode($favorites));
+		}
+		if (!is_null($forecastOffset)) {
+			$this->config->setUserValue($this->userId, Application::APP_ID, 'forecastOffset', $forecastOffset);
+		}
 		return ['success' => true];
 	}
 

--- a/apps/weather_status/lib/Service/WeatherStatusService.php
+++ b/apps/weather_status/lib/Service/WeatherStatusService.php
@@ -157,7 +157,7 @@ class WeatherStatusService {
 			$this->config->setUserValue($this->userId, Application::APP_ID, 'favorites', json_encode($favorites));
 		}
 		if (!is_null($forecastOffset)) {
-			$this->config->setUserValue($this->userId, Application::APP_ID, 'forecastOffset', $forecastOffset);
+			$this->config->setUserValue($this->userId, Application::APP_ID, 'forecastOffset', strval($forecastOffset));
 		}
 		return ['success' => true];
 	}

--- a/apps/weather_status/src/services/weatherStatusService.js
+++ b/apps/weather_status/src/services/weatherStatusService.js
@@ -107,27 +107,27 @@ const fetchForecast = async() => {
 }
 
 /**
- * Fetches the location favorites
+ * Fetches option values like favorites and weather offset
  *
- * @param {String} address The location
  * @returns {Promise<Object>}
  */
-const getFavorites = async() => {
-	const url = generateOcsUrl('apps/weather_status/api/v1', 2) + 'favorites'
+const getOptionValues = async() => {
+	const url = generateOcsUrl('apps/weather_status/api/v1', 2) + 'options'
 	const response = await HttpClient.get(url)
 
 	return response.data.ocs.data
 }
 
 /**
+ * Saves multiple option values
  *
- * @param {Array} favorites List of favorite addresses
+ * @param {Object} optionValues key/val option values
  * @returns {Promise<Object>}
  */
-const saveFavorites = async(favorites) => {
-	const url = generateOcsUrl('apps/weather_status/api/v1', 2) + 'favorites'
+const saveOptionValues = async(optionValues) => {
+	const url = generateOcsUrl('apps/weather_status/api/v1', 2) + 'options'
 	const response = await HttpClient.put(url, {
-		favorites,
+		...optionValues,
 	})
 
 	return response.data.ocs.data
@@ -140,6 +140,6 @@ export {
 	setLocation,
 	setAddress,
 	fetchForecast,
-	getFavorites,
-	saveFavorites,
+	getOptionValues,
+	saveOptionValues,
 }


### PR DESCRIPTION
refs #23399 
How about letting users set the forecast offset?

This adds a setting in the weather widget action menu to tell how many hours in advance we want to see the weather forecast. It has to be between 0 (now) and 9 hours ahead.

![offset](https://user-images.githubusercontent.com/11291457/99425693-7a64d000-2903-11eb-9e70-ffb0826a228b.gif)

As we get 10 hours weather range on each forecast request, no query is needed when changing the offset, it has an immediate effect on the widget.

The "play-next" icon might not be very explicit.

Do we want this?
If yes, how do we make it more explicit?